### PR TITLE
feat(settings): explain the real Live transcription trade with a per-engine help panel

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Settings/LiveTranscriptionCopy.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LiveTranscriptionCopy.swift
@@ -1,3 +1,4 @@
+import EnviousWisprCore
 import Foundation
 
 /// #1337: canonical copy for the "Live transcription" setting and its in-app help panel.
@@ -6,70 +7,49 @@ import Foundation
 /// user-facing string, with `LiveTranscriptionCopyTests` freezing them so a change is a
 /// conscious act rather than a drift.
 ///
-/// WHY THIS PANEL EXISTS. Streaming was measured against batch on the same audio and lost
-/// on every accuracy axis while saving no time a user can perceive below five minutes. The
-/// founder's decision (2026-07-31) was to KEEP the setting and make the trade explicit,
-/// rather than remove a control that users deliberately enabled. So this copy has one job:
-/// let someone who chose "faster" see what it actually costs and decide again.
+/// WHY THIS PANEL EXISTS. Streaming was measured against batch on the same audio and, on
+/// Parakeet, lost on every accuracy axis while saving no time a user can perceive below
+/// five minutes. The founder's decision (2026-07-31) was to KEEP the setting and make the
+/// trade explicit, rather than remove a control users deliberately enabled. So this copy
+/// has one job: let someone who chose "faster" see what it actually costs and decide again.
 ///
-/// EVERY NUMBER HERE IS MEASURED, NOT ESTIMATED. Sources, both recorded on #1337:
+/// **THE COPY IS SPLIT BY ENGINE, AND THAT IS LOAD-BEARING.** One toggle drives two
+/// completely different implementations, and the evidence points in OPPOSITE directions for
+/// them. Parakeet streams by sliding window and stitching text; WhisperKit uses
+/// `WhisperKitStreamingSession` (LocalAgreement-2 over one retained buffer, #1276 PR-2) and
+/// degrades to clean batch entirely when the language is Auto-detect. Showing Parakeet's
+/// 28-clip and 500-dictation figures to a WhisperKit user, and telling them to switch the
+/// setting off, would be materially wrong guidance. The first draft of this file did
+/// exactly that and the diff review caught it.
+///
+/// EVERY PARAKEET NUMBER IS MEASURED, NOT ESTIMATED. Sources, both recorded on #1337:
 ///   - Word errors, phantom words: 28-clip firehose bake-off, one pass per clip, pace
 ///     invariance proven separately by a real-time-vs-firehose canary.
 ///   - Lost endings: replay of 500 archived real dictations through both paths, scored
 ///     word-level against the batch transcript of the same audio.
-/// If those numbers are ever re-measured, change them HERE and in the test together.
+/// If those are ever re-measured, change them HERE and in the test together.
+///
+/// THE WHISPERKIT PANEL CARRIES NO FIGURES, DELIBERATELY. Its benchmark numbers are
+/// genuinely contested in our own records: `#1276`'s comment says 3/107 phantom endings
+/// while `whisperkit-research.md` FACT: ufal-streaming-architecture-shipped explicitly
+/// corrects that to "1/109 UFAL phantom endings versus 14/109 stitch, not 3/107", and the
+/// often-quoted 1.6s-vs-38.5s latency pair was measured on a PROTOTYPE harness before
+/// PR #1313 shipped a different architecture. Two sources disagreeing is precisely when a
+/// number must not be put in front of a user. The qualitative claims below are the ones
+/// both sources support.
 ///
 /// Brand rule: no em-dashes or en-dashes in user-facing copy.
 enum LiveTranscriptionCopy {
   static let toggleLabel = "Live transcription"
-
-  /// Replaces the pre-#1337 line "Transcribes while you speak for faster results. Turn off
-  /// for cleaner text on longer recordings." That claim was measurably wrong: there is no
-  /// perceptible speed gain below five minutes, so the description advertised a benefit the
-  /// data does not support.
-  static let toggleDescription =
-    "Transcribes while you speak instead of once when you stop. This does not save time "
-    + "you can notice on most dictations, and it can drop your last few words."
+  static let helpButtonAccessibilityLabel = "What does Live transcription change?"
 
   /// Shown under the toggle only when WhisperKit is selected AND the language is
   /// Auto-detect, because streaming must commit to one language up front and a bad early
-  /// guess poisons the whole dictation (#1276). Lives here rather than inline so all three
-  /// of this toggle's user-facing strings have one home; leaving one behind is how copy
-  /// drifts out of step with the other two.
+  /// guess poisons the whole dictation (#1276). Lives here rather than inline so all of
+  /// this toggle's user-facing strings have one home.
   static let autoLanguageFootnote =
     "Live transcription needs a selected language. With Auto-detect, EnviousWispr uses "
     + "clean batch transcription for accuracy."
-
-  static let helpButtonAccessibilityLabel = "What does Live transcription change?"
-  static let helpTitle = "What Live transcription changes"
-
-  /// Lead paragraph: the speed answer first, because speed is why people turn this on.
-  static let helpSpeedHeading = "Speed"
-  static let helpSpeedBody =
-    "On dictations under a minute, both settings finish at about the same moment. The "
-    + "difference is smaller than you can feel. It only pulls ahead on recordings of "
-    + "roughly five minutes or longer."
-
-  static let helpAccuracyHeading = "Accuracy, measured"
-  static let helpComparisonOffColumn = "Off"
-  static let helpComparisonOnColumn = "On"
-
-  static let helpWhyHeading = "Why this happens"
-  static let helpWhyBody =
-    "With this on, EnviousWispr transcribes overlapping chunks of audio while you talk and "
-    + "joins them together. When two chunks disagree about the same moment of speech, "
-    + "nothing can tell which reading was right. The longer you talk, the more joins there "
-    + "are, so the problem grows with length."
-
-  static let helpRecommendationHeading = "What we recommend"
-  static let helpRecommendationBody =
-    "Leave this off. If you regularly dictate for five minutes or more in one go, it may "
-    + "be worth the trade, and the risk of a lost ending is highest there too."
-
-  /// Footnote naming the evidence, so the numbers above are not bare assertions.
-  static let helpFootnote =
-    "Measured on 28 test recordings and a replay of 500 real dictations, comparing both "
-    + "settings on the same audio."
 
   /// One measured comparison row. `off` and `on` are display copy for the two settings.
   struct Comparison: Identifiable, Equatable {
@@ -79,22 +59,110 @@ enum LiveTranscriptionCopy {
     var id: String { metric }
   }
 
-  /// Order is the order shown. ONLY genuine two-arm measurements belong here.
-  ///
-  /// Lost endings is deliberately NOT a row. In the 500-dictation replay, the off setting
-  /// was the REFERENCE the on setting was scored against, so its "zero lost endings" is
-  /// true by construction rather than independently measured. Printing a measured-looking
-  /// `0` beside it would be a fabricated number in a panel whose entire purpose is honesty.
-  /// It gets its own correctly-framed line below instead.
-  static let comparisons: [Comparison] = [
-    Comparison(metric: "Word errors", off: "2.0%", on: "3.7%"),
-    Comparison(metric: "Repeated or invented words", off: "17", on: "51"),
-  ]
+  /// The content of one engine's help panel. Optional fields are genuinely absent for an
+  /// engine rather than empty: WhisperKit has no comparison table because it has no
+  /// figures we can defend, and rendering an empty table would read as a bug.
+  struct Panel {
+    let title: String
+    let speedHeading: String
+    let speedBody: String
+    let accuracyHeading: String
+    let comparisons: [Comparison]
+    let accuracyBody: String
+    let whyHeading: String
+    let whyBody: String
+    let recommendationHeading: String
+    let recommendationBody: String
+    let footnote: String
+  }
 
-  /// Stated as a comparison against the same audio rather than as a bare rate, because
-  /// that is what was actually measured: how often the on setting dropped words the off
-  /// setting captured.
-  static let helpLostEndings =
-    "About 1 in 24 dictations lost its final words with this on, compared with the same "
-    + "recording transcribed after stopping."
+  static func panel(for backend: ASRBackendType) -> Panel {
+    switch backend {
+    case .parakeet: return parakeet
+    case .whisperKit: return whisperKit
+    }
+  }
+
+  static func toggleDescription(for backend: ASRBackendType) -> String {
+    switch backend {
+    case .parakeet: return parakeetToggleDescription
+    case .whisperKit: return whisperKitToggleDescription
+    }
+  }
+
+  // MARK: - Parakeet
+
+  /// Replaces the pre-#1337 line "Transcribes while you speak for faster results. Turn off
+  /// for cleaner text on longer recordings." That claim was measurably wrong for Parakeet:
+  /// no perceptible gain below five minutes, so it advertised a benefit the data denies.
+  static let parakeetToggleDescription =
+    "Transcribes while you speak instead of once when you stop. This does not save time "
+    + "you can notice on most dictations, and it can drop your last few words."
+
+  static let parakeet = Panel(
+    title: "What Live transcription changes",
+    speedHeading: "Speed",
+    speedBody:
+      "On dictations under a minute, both settings finish at about the same moment. The "
+      + "difference is smaller than you can feel. It only pulls ahead on recordings of "
+      + "roughly five minutes or longer.",
+    accuracyHeading: "Accuracy, measured",
+    comparisons: [
+      Comparison(metric: "Word errors", off: "2.0%", on: "3.7%"),
+      Comparison(metric: "Repeated or invented words", off: "17", on: "51"),
+    ],
+    // Stated as a comparison against the same audio rather than a bare rate, because that
+    // is what was measured. NOT a table row: in the replay the off setting was the
+    // REFERENCE the on setting was scored against, so its "zero" is true by construction,
+    // and printing it beside genuinely measured columns would be a fabricated figure in
+    // the one panel whose whole purpose is to be trusted.
+    accuracyBody:
+      "About 1 in 24 dictations lost its final words with this on, compared with the same "
+      + "recording transcribed after stopping.",
+    whyHeading: "Why this happens",
+    whyBody:
+      "With this on, EnviousWispr transcribes overlapping chunks of audio while you talk "
+      + "and joins them together. When two chunks disagree about the same moment of "
+      + "speech, nothing can tell which reading was right. The longer you talk, the more "
+      + "joins there are, so the problem grows with length.",
+    recommendationHeading: "What we recommend",
+    recommendationBody:
+      "Leave this off. If you regularly dictate for five minutes or more in one go it may "
+      + "be worth the trade, and the risk of a lost ending is highest there too.",
+    footnote:
+      "Measured on 28 test recordings and a replay of 500 real dictations, comparing both "
+      + "settings on the same audio."
+  )
+
+  // MARK: - WhisperKit
+
+  static let whisperKitToggleDescription =
+    "Transcribes while you speak instead of once when you stop. This mainly helps on long "
+    + "recordings, and it needs a language selected."
+
+  static let whisperKit = Panel(
+    title: "What Live transcription changes",
+    speedHeading: "Speed",
+    speedBody:
+      "On short dictations you will not notice a difference. On long ones it helps clearly: "
+      + "transcribing after you stop gets slower the longer you spoke, while transcribing "
+      + "as you go stays about the same however long the recording is.",
+    accuracyHeading: "Accuracy",
+    comparisons: [],
+    accuracyBody:
+      "On this engine, transcribing as you go is about as accurate as waiting until you "
+      + "stop. It can still occasionally drop a final word or two, which we are working on.",
+    whyHeading: "One thing to know",
+    whyBody:
+      "This engine has to commit to a language before it can start. If your language is "
+      + "set to Auto-detect, EnviousWispr ignores this setting and transcribes after you "
+      + "stop instead, because guessing the language early gets it wrong too often.",
+    recommendationHeading: "What we recommend",
+    recommendationBody:
+      "If you pick a specific language and often dictate for more than a minute, turn this "
+      + "on. Otherwise it makes little difference either way.",
+    footnote:
+      "This engine transcribes differently from the Fast engine, so its behaviour and the "
+      + "advice here are not the same."
+  )
 }

--- a/Sources/EnviousWisprAppKit/Views/Settings/LiveTranscriptionCopy.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LiveTranscriptionCopy.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+/// #1337: canonical copy for the "Live transcription" setting and its in-app help panel.
+///
+/// Mirrors `SpokenPunctuationCopy` (#1794) in shape and intent: one place owning every
+/// user-facing string, with `LiveTranscriptionCopyTests` freezing them so a change is a
+/// conscious act rather than a drift.
+///
+/// WHY THIS PANEL EXISTS. Streaming was measured against batch on the same audio and lost
+/// on every accuracy axis while saving no time a user can perceive below five minutes. The
+/// founder's decision (2026-07-31) was to KEEP the setting and make the trade explicit,
+/// rather than remove a control that users deliberately enabled. So this copy has one job:
+/// let someone who chose "faster" see what it actually costs and decide again.
+///
+/// EVERY NUMBER HERE IS MEASURED, NOT ESTIMATED. Sources, both recorded on #1337:
+///   - Word errors, phantom words: 28-clip firehose bake-off, one pass per clip, pace
+///     invariance proven separately by a real-time-vs-firehose canary.
+///   - Lost endings: replay of 500 archived real dictations through both paths, scored
+///     word-level against the batch transcript of the same audio.
+/// If those numbers are ever re-measured, change them HERE and in the test together.
+///
+/// Brand rule: no em-dashes or en-dashes in user-facing copy.
+enum LiveTranscriptionCopy {
+  static let toggleLabel = "Live transcription"
+
+  /// Replaces the pre-#1337 line "Transcribes while you speak for faster results. Turn off
+  /// for cleaner text on longer recordings." That claim was measurably wrong: there is no
+  /// perceptible speed gain below five minutes, so the description advertised a benefit the
+  /// data does not support.
+  static let toggleDescription =
+    "Transcribes while you speak instead of once when you stop. This does not save time "
+    + "you can notice on most dictations, and it can drop your last few words."
+
+  /// Shown under the toggle only when WhisperKit is selected AND the language is
+  /// Auto-detect, because streaming must commit to one language up front and a bad early
+  /// guess poisons the whole dictation (#1276). Lives here rather than inline so all three
+  /// of this toggle's user-facing strings have one home; leaving one behind is how copy
+  /// drifts out of step with the other two.
+  static let autoLanguageFootnote =
+    "Live transcription needs a selected language. With Auto-detect, EnviousWispr uses "
+    + "clean batch transcription for accuracy."
+
+  static let helpButtonAccessibilityLabel = "What does Live transcription change?"
+  static let helpTitle = "What Live transcription changes"
+
+  /// Lead paragraph: the speed answer first, because speed is why people turn this on.
+  static let helpSpeedHeading = "Speed"
+  static let helpSpeedBody =
+    "On dictations under a minute, both settings finish at about the same moment. The "
+    + "difference is smaller than you can feel. It only pulls ahead on recordings of "
+    + "roughly five minutes or longer."
+
+  static let helpAccuracyHeading = "Accuracy, measured"
+  static let helpComparisonOffColumn = "Off"
+  static let helpComparisonOnColumn = "On"
+
+  static let helpWhyHeading = "Why this happens"
+  static let helpWhyBody =
+    "With this on, EnviousWispr transcribes overlapping chunks of audio while you talk and "
+    + "joins them together. When two chunks disagree about the same moment of speech, "
+    + "nothing can tell which reading was right. The longer you talk, the more joins there "
+    + "are, so the problem grows with length."
+
+  static let helpRecommendationHeading = "What we recommend"
+  static let helpRecommendationBody =
+    "Leave this off. If you regularly dictate for five minutes or more in one go, it may "
+    + "be worth the trade, and the risk of a lost ending is highest there too."
+
+  /// Footnote naming the evidence, so the numbers above are not bare assertions.
+  static let helpFootnote =
+    "Measured on 28 test recordings and a replay of 500 real dictations, comparing both "
+    + "settings on the same audio."
+
+  /// One measured comparison row. `off` and `on` are display copy for the two settings.
+  struct Comparison: Identifiable, Equatable {
+    let metric: String
+    let off: String
+    let on: String
+    var id: String { metric }
+  }
+
+  /// Order is the order shown. ONLY genuine two-arm measurements belong here.
+  ///
+  /// Lost endings is deliberately NOT a row. In the 500-dictation replay, the off setting
+  /// was the REFERENCE the on setting was scored against, so its "zero lost endings" is
+  /// true by construction rather than independently measured. Printing a measured-looking
+  /// `0` beside it would be a fabricated number in a panel whose entire purpose is honesty.
+  /// It gets its own correctly-framed line below instead.
+  static let comparisons: [Comparison] = [
+    Comparison(metric: "Word errors", off: "2.0%", on: "3.7%"),
+    Comparison(metric: "Repeated or invented words", off: "17", on: "51"),
+  ]
+
+  /// Stated as a comparison against the same audio rather than as a bare rate, because
+  /// that is what was actually measured: how often the on setting dropped words the off
+  /// setting captured.
+  static let helpLostEndings =
+    "About 1 in 24 dictations lost its final words with this on, compared with the same "
+    + "recording transcribed after stopping."
+}

--- a/Sources/EnviousWisprAppKit/Views/Settings/SpeechEngineSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SpeechEngineSettingsView.swift
@@ -289,7 +289,7 @@ struct SpeechEngineSettingsView: View {
                   .toggleStyle(BrandedToggleStyle())
                   liveTranscriptionHelpButton
                 }
-                Text(LiveTranscriptionCopy.toggleDescription)
+                Text(LiveTranscriptionCopy.toggleDescription(for: settings.selectedBackend))
                   .settingsReadingCopy()
                 if settings.selectedBackend == .whisperKit,
                   isAutoLanguage(settings.languageMode)
@@ -615,60 +615,75 @@ struct SpeechEngineSettingsView: View {
     }
   }
 
-  /// Ordered speed first, then the measured cost, then why, then the recommendation.
-  /// Speed leads because speed is why anyone turns this on, so the answer they came for
-  /// should not be buried under a caveat.
+  /// Ordered speed first, then accuracy, then why, then the recommendation. Speed leads
+  /// because speed is why anyone turns this on, so the answer they came for should not be
+  /// buried under a caveat.
+  ///
+  /// Content is per-engine. The two engines stream by different mechanisms and the evidence
+  /// points opposite ways, so a single panel would give one of them wrong advice
+  /// (diff review, 2026-07-31). The comparison table renders only when that engine actually
+  /// has defensible figures.
   private var liveTranscriptionHelpPanel: some View {
-    VStack(alignment: .leading, spacing: 12) {
-      Text(LiveTranscriptionCopy.helpTitle)
+    let panel = LiveTranscriptionCopy.panel(for: settings.selectedBackend)
+    return VStack(alignment: .leading, spacing: 12) {
+      Text(panel.title)
         .font(.stSectionHeader)
 
-      VStack(alignment: .leading, spacing: 4) {
-        Text(LiveTranscriptionCopy.helpSpeedHeading).font(.stHelper)
-          .foregroundStyle(Color.stTextSecondary)
-        Text(LiveTranscriptionCopy.helpSpeedBody).settingsReadingCopy()
+      helpSection(panel.speedHeading) {
+        Text(panel.speedBody).settingsReadingCopy()
       }
 
-      VStack(alignment: .leading, spacing: 6) {
-        Text(LiveTranscriptionCopy.helpAccuracyHeading).font(.stHelper)
-          .foregroundStyle(Color.stTextSecondary)
-        Grid(alignment: .leading, horizontalSpacing: 18, verticalSpacing: 6) {
-          GridRow {
-            Text("")
-            Text(LiveTranscriptionCopy.helpComparisonOffColumn)
-            Text(LiveTranscriptionCopy.helpComparisonOnColumn)
-          }
-          .font(.stHelper)
-          .foregroundStyle(Color.stTextSecondary)
-          ForEach(LiveTranscriptionCopy.comparisons) { row in
-            GridRow {
-              Text(row.metric)
-              Text(row.off)
-              Text(row.on)
+      helpSection(panel.accuracyHeading) {
+        VStack(alignment: .leading, spacing: 6) {
+          if panel.comparisons.isEmpty == false {
+            Grid(alignment: .leading, horizontalSpacing: 18, verticalSpacing: 6) {
+              GridRow {
+                Text("")
+                Text("Off")
+                Text("On")
+              }
+              .font(.stHelper)
+              .foregroundStyle(Color.stTextSecondary)
+              ForEach(panel.comparisons) { row in
+                GridRow {
+                  Text(row.metric)
+                  Text(row.off)
+                  Text(row.on)
+                }
+              }
             }
+            .font(.stBody)
           }
+          Text(panel.accuracyBody).settingsReadingCopy()
         }
-        .font(.stBody)
-        Text(LiveTranscriptionCopy.helpLostEndings).settingsReadingCopy()
       }
 
-      VStack(alignment: .leading, spacing: 4) {
-        Text(LiveTranscriptionCopy.helpWhyHeading).font(.stHelper)
-          .foregroundStyle(Color.stTextSecondary)
-        Text(LiveTranscriptionCopy.helpWhyBody).settingsReadingCopy()
+      helpSection(panel.whyHeading) {
+        Text(panel.whyBody).settingsReadingCopy()
       }
 
-      VStack(alignment: .leading, spacing: 4) {
-        Text(LiveTranscriptionCopy.helpRecommendationHeading).font(.stHelper)
-          .foregroundStyle(Color.stTextSecondary)
-        Text(LiveTranscriptionCopy.helpRecommendationBody).settingsReadingCopy()
+      helpSection(panel.recommendationHeading) {
+        Text(panel.recommendationBody).settingsReadingCopy()
       }
 
-      Text(LiveTranscriptionCopy.helpFootnote)
+      Text(panel.footnote)
         .settingsReadingCopy()
     }
     .frame(maxWidth: 340, alignment: .leading)
     .padding(16)
+  }
+
+  /// A labelled block inside the help panel. Extracted so the four sections cannot drift
+  /// apart in spacing or heading treatment.
+  private func helpSection<Content: View>(
+    _ heading: String, @ViewBuilder content: () -> Content
+  ) -> some View {
+    VStack(alignment: .leading, spacing: 4) {
+      Text(heading)
+        .font(.stHelper)
+        .foregroundStyle(Color.stTextSecondary)
+      content()
+    }
   }
 
   // MARK: - Spoken punctuation help (#1794)

--- a/Sources/EnviousWisprAppKit/Views/Settings/SpeechEngineSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SpeechEngineSettingsView.swift
@@ -18,6 +18,7 @@ struct SpeechEngineSettingsView: View {
 
   @State private var showLanguageLockSheet: Bool = false
   @State private var showSpokenPunctuationHelp: Bool = false
+  @State private var showLiveTranscriptionHelp: Bool = false
 
   /// #1171 — shown ONLY when the user's selected engine differs from the active
   /// one because a switch is deferred while a dictation/recovery is in flight.
@@ -281,21 +282,20 @@ struct SpeechEngineSettingsView: View {
             HStack(alignment: .top, spacing: 11) {
               SettingsRowIcon(systemName: "waveform")
               VStack(alignment: .leading, spacing: 4) {
-                Toggle(isOn: $settings.useStreamingASR) {
-                  Text("Live transcription").settingsRowLabel()
+                HStack(spacing: 6) {
+                  Toggle(isOn: $settings.useStreamingASR) {
+                    Text(LiveTranscriptionCopy.toggleLabel).settingsRowLabel()
+                  }
+                  .toggleStyle(BrandedToggleStyle())
+                  liveTranscriptionHelpButton
                 }
-                .toggleStyle(BrandedToggleStyle())
-                Text(
-                  "Transcribes while you speak for faster results. Turn off for cleaner text on longer recordings."
-                )
-                .settingsReadingCopy()
+                Text(LiveTranscriptionCopy.toggleDescription)
+                  .settingsReadingCopy()
                 if settings.selectedBackend == .whisperKit,
                   isAutoLanguage(settings.languageMode)
                 {
-                  Text(
-                    "Live transcription needs a selected language. With Auto-detect, EnviousWispr uses clean batch transcription for accuracy."
-                  )
-                  .settingsReadingCopy()
+                  Text(LiveTranscriptionCopy.autoLanguageFootnote)
+                    .settingsReadingCopy()
                 }
               }
             }
@@ -592,6 +592,83 @@ struct SpeechEngineSettingsView: View {
     .buttonStyle(.borderless)
     .help("Re-check model status")
     .accessibilityLabel("Re-check model status")
+  }
+
+  // MARK: - Live transcription help (#1337)
+
+  /// Same shape as `spokenPunctuationHelpButton` deliberately: a real `Button`, never a
+  /// hover-only reveal, so it is reachable by keyboard and VoiceOver. The two panels are
+  /// the same affordance and must read as one family.
+  private var liveTranscriptionHelpButton: some View {
+    Button {
+      showLiveTranscriptionHelp = true
+    } label: {
+      Image(systemName: "questionmark.circle")
+        .foregroundStyle(Color.stTextSecondary)
+        .font(.stHelper)
+    }
+    .buttonStyle(.borderless)
+    .help(LiveTranscriptionCopy.helpButtonAccessibilityLabel)
+    .accessibilityLabel(LiveTranscriptionCopy.helpButtonAccessibilityLabel)
+    .popover(isPresented: $showLiveTranscriptionHelp, arrowEdge: .bottom) {
+      liveTranscriptionHelpPanel
+    }
+  }
+
+  /// Ordered speed first, then the measured cost, then why, then the recommendation.
+  /// Speed leads because speed is why anyone turns this on, so the answer they came for
+  /// should not be buried under a caveat.
+  private var liveTranscriptionHelpPanel: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Text(LiveTranscriptionCopy.helpTitle)
+        .font(.stSectionHeader)
+
+      VStack(alignment: .leading, spacing: 4) {
+        Text(LiveTranscriptionCopy.helpSpeedHeading).font(.stHelper)
+          .foregroundStyle(Color.stTextSecondary)
+        Text(LiveTranscriptionCopy.helpSpeedBody).settingsReadingCopy()
+      }
+
+      VStack(alignment: .leading, spacing: 6) {
+        Text(LiveTranscriptionCopy.helpAccuracyHeading).font(.stHelper)
+          .foregroundStyle(Color.stTextSecondary)
+        Grid(alignment: .leading, horizontalSpacing: 18, verticalSpacing: 6) {
+          GridRow {
+            Text("")
+            Text(LiveTranscriptionCopy.helpComparisonOffColumn)
+            Text(LiveTranscriptionCopy.helpComparisonOnColumn)
+          }
+          .font(.stHelper)
+          .foregroundStyle(Color.stTextSecondary)
+          ForEach(LiveTranscriptionCopy.comparisons) { row in
+            GridRow {
+              Text(row.metric)
+              Text(row.off)
+              Text(row.on)
+            }
+          }
+        }
+        .font(.stBody)
+        Text(LiveTranscriptionCopy.helpLostEndings).settingsReadingCopy()
+      }
+
+      VStack(alignment: .leading, spacing: 4) {
+        Text(LiveTranscriptionCopy.helpWhyHeading).font(.stHelper)
+          .foregroundStyle(Color.stTextSecondary)
+        Text(LiveTranscriptionCopy.helpWhyBody).settingsReadingCopy()
+      }
+
+      VStack(alignment: .leading, spacing: 4) {
+        Text(LiveTranscriptionCopy.helpRecommendationHeading).font(.stHelper)
+          .foregroundStyle(Color.stTextSecondary)
+        Text(LiveTranscriptionCopy.helpRecommendationBody).settingsReadingCopy()
+      }
+
+      Text(LiveTranscriptionCopy.helpFootnote)
+        .settingsReadingCopy()
+    }
+    .frame(maxWidth: 340, alignment: .leading)
+    .padding(16)
   }
 
   // MARK: - Spoken punctuation help (#1794)

--- a/Tests/EnviousWisprTests/Settings/LiveTranscriptionCopyTests.swift
+++ b/Tests/EnviousWisprTests/Settings/LiveTranscriptionCopyTests.swift
@@ -1,120 +1,172 @@
+import EnviousWisprCore
 import Testing
 
 @testable import EnviousWisprAppKit
 
-/// #1337: the Live transcription help panel states MEASURED figures to a user who is
-/// deciding whether to keep a setting that costs them accuracy. Nothing derives these
-/// numbers from the benchmarks at runtime, so this freeze test is the guard: if a figure
-/// changes it must be a conscious act backed by a re-measurement, not a drift, and a panel
-/// whose whole purpose is honesty must never quietly start lying.
+/// #1337: the Live transcription help panel states MEASURED figures to a user deciding
+/// whether to keep a setting that costs them accuracy. Nothing derives these numbers from
+/// the benchmarks at runtime, so this freeze test is the guard: if a figure changes it must
+/// be a conscious act backed by a re-measurement, and a panel whose whole purpose is
+/// honesty must never quietly start lying.
 struct LiveTranscriptionCopyTests {
 
   /// Sources, both recorded on #1337: word errors and phantom words from the 28-clip
   /// firehose bake-off; the lost-endings figure from a replay of 500 archived real
   /// dictations. Change a number here only alongside a fresh measurement.
-  @Test("The measured comparison rows are frozen, verbatim and in order")
-  func comparisonsAreFrozen() {
+  @Test("Parakeet's measured comparison rows are frozen, verbatim and in order")
+  func parakeetComparisonsAreFrozen() {
     let expected: [(String, String, String)] = [
       ("Word errors", "2.0%", "3.7%"),
       ("Repeated or invented words", "17", "51"),
     ]
-    #expect(LiveTranscriptionCopy.comparisons.count == expected.count)
-    for (actual, want) in zip(LiveTranscriptionCopy.comparisons, expected) {
+    #expect(LiveTranscriptionCopy.parakeet.comparisons.count == expected.count)
+    for (actual, want) in zip(LiveTranscriptionCopy.parakeet.comparisons, expected) {
       #expect(actual.metric == want.0, "metric drifted: \(actual.metric) vs \(want.0)")
       #expect(actual.off == want.1, "OFF figure drifted for \(actual.metric)")
       #expect(actual.on == want.2, "ON figure drifted for \(actual.metric)")
     }
   }
 
+  /// THE DEFECT THIS SUITE EXISTS TO PREVENT, caught by diff review on 2026-07-31.
+  ///
+  /// One toggle drives two different implementations whose evidence points in OPPOSITE
+  /// directions. The first draft showed Parakeet's 28-clip and 500-dictation figures to
+  /// WhisperKit users and told them to switch the setting off, which is materially wrong
+  /// guidance for an engine where streaming is about as accurate as batch and clearly
+  /// faster on long recordings.
+  ///
+  /// WhisperKit carries NO figures on purpose: our own records disagree about them
+  /// (`#1276` says 3/107 phantom endings, `whisperkit-research.md` corrects it to 1/109),
+  /// and the quoted latency pair came from a prototype harness predating the shipped
+  /// architecture. Two sources disagreeing is exactly when a number must not reach a user.
+  @Test("Parakeet's measurements never appear in WhisperKit's panel")
+  func parakeetFiguresDoNotLeakIntoWhisperKit() {
+    let wk = LiveTranscriptionCopy.whisperKit
+    #expect(wk.comparisons.isEmpty, "WhisperKit has no defensible figures; it must show no table")
+
+    let allWhisperKitCopy = [
+      wk.title, wk.speedHeading, wk.speedBody, wk.accuracyHeading, wk.accuracyBody,
+      wk.whyHeading, wk.whyBody, wk.recommendationHeading, wk.recommendationBody, wk.footnote,
+      LiveTranscriptionCopy.whisperKitToggleDescription,
+    ].joined(separator: " ")
+
+    for parakeetFigure in ["2.0%", "3.7%", "1 in 24", "28 test recordings", "500 real dictations"] {
+      #expect(
+        allWhisperKitCopy.contains(parakeetFigure) == false,
+        "Parakeet figure leaked into WhisperKit copy: \(parakeetFigure)")
+    }
+  }
+
+  /// WhisperKit must not inherit Parakeet's "leave this off" advice. On that engine
+  /// streaming is roughly accuracy-neutral and genuinely faster on long recordings.
+  @Test("WhisperKit is not told to turn the setting off")
+  func whisperKitIsNotToldToDisable() {
+    let advice = LiveTranscriptionCopy.whisperKit.recommendationBody.lowercased()
+    #expect(
+      advice.contains("leave this off") == false,
+      "WhisperKit must not inherit Parakeet's disable recommendation")
+    #expect(
+      LiveTranscriptionCopy.parakeet.recommendationBody.lowercased().contains("leave this off"),
+      "Parakeet's recommendation must still say to leave it off")
+  }
+
+  /// Every engine resolves to its own panel, so adding a third engine forces a decision
+  /// here rather than silently reusing whichever branch the compiler picked.
+  @Test("Each backend resolves to its own panel and description")
+  func everyBackendHasItsOwnContent() {
+    #expect(
+      LiveTranscriptionCopy.panel(for: .parakeet).accuracyBody
+        == LiveTranscriptionCopy.parakeet.accuracyBody)
+    #expect(
+      LiveTranscriptionCopy.panel(for: .whisperKit).accuracyBody
+        == LiveTranscriptionCopy.whisperKit.accuracyBody)
+    #expect(
+      LiveTranscriptionCopy.toggleDescription(for: .parakeet)
+        != LiveTranscriptionCopy.toggleDescription(for: .whisperKit))
+  }
+
   /// The panel is keyed by `metric` through `Identifiable`, so a duplicate would silently
   /// collapse a row in the `ForEach` and hide a measurement from users.
   @Test("Metric names are unique so no row is dropped from the panel")
   func metricsAreUnique() {
-    let metrics = LiveTranscriptionCopy.comparisons.map(\.metric)
+    let metrics = LiveTranscriptionCopy.parakeet.comparisons.map(\.metric)
     #expect(Set(metrics).count == metrics.count, "duplicate metric would collapse a panel row")
   }
 
   /// GUARD FOR A SPECIFIC MISTAKE MADE AND CAUGHT WHILE WRITING THIS PANEL.
   ///
-  /// The first draft included a third row, "Dictations that lost their ending", with `off`
-  /// set to "none". That zero is true by CONSTRUCTION, not by measurement: in the
-  /// 500-dictation replay the off setting was the reference the on setting was scored
-  /// against, so it could not have shown a loss. Printing it beside a genuinely measured
-  /// column would have presented a fabricated figure as data, in the one panel that exists
-  /// to be trusted. It lives in `helpLostEndings` instead, phrased as the comparison that
-  /// was actually run.
-  ///
-  /// This test fails if anyone re-adds a comparison row for lost endings.
+  /// The first draft included a row "Dictations that lost their ending" with `off` set to
+  /// "none". That zero is true by CONSTRUCTION, not measurement: in the 500-dictation
+  /// replay the off setting was the reference the on setting was scored against, so it
+  /// could not have shown a loss. Printing it beside a genuinely measured column would
+  /// present a fabricated figure as data, in the one panel that exists to be trusted.
   @Test("Lost endings is NOT a two-arm row, because the off arm was the reference")
   func lostEndingsIsNotAComparisonRow() {
-    for row in LiveTranscriptionCopy.comparisons {
+    for row in LiveTranscriptionCopy.parakeet.comparisons {
       #expect(
         row.metric.lowercased().contains("ending") == false,
-        "lost endings must not be a comparison row: its OFF value is true by construction, not measured. Use helpLostEndings."
+        "lost endings must not be a comparison row: its OFF value is true by construction, not measured."
       )
     }
-    #expect(LiveTranscriptionCopy.helpLostEndings.contains("1 in 24"))
+    let body = LiveTranscriptionCopy.parakeet.accuracyBody
+    #expect(body.contains("1 in 24"))
     #expect(
-      LiveTranscriptionCopy.helpLostEndings.contains("compared with"),
+      body.contains("compared with"),
       "the lost-endings line must state what it was compared against, not a bare rate")
   }
 
   /// The pre-#1337 description claimed "faster results". Measurement says there is no
-  /// perceptible gain below five minutes, so that claim must not return.
-  @Test("The toggle description does not promise speed the measurements do not support")
-  func descriptionDoesNotPromiseSpeed() {
-    let d = LiveTranscriptionCopy.toggleDescription.lowercased()
+  /// perceptible gain below five minutes on Parakeet, so that claim must not return.
+  @Test("No toggle description promises speed the measurements do not support")
+  func descriptionsDoNotPromiseUnsupportedSpeed() {
+    for backend in [ASRBackendType.parakeet, .whisperKit] {
+      let d = LiveTranscriptionCopy.toggleDescription(for: backend).lowercased()
+      #expect(
+        d.contains("faster results") == false,
+        "description must not claim faster results: measured imperceptible below 5 min")
+    }
     #expect(
-      d.contains("faster results") == false,
-      "the description must not claim faster results: measured as imperceptible below 5 min")
-    #expect(d.contains("does not save time"), "the description must state the real speed answer")
+      LiveTranscriptionCopy.parakeetToggleDescription.lowercased()
+        .contains("does not save time"),
+      "Parakeet's description must state the real speed answer")
   }
 
   /// Brand rule: no em-dashes or en-dashes in user-facing copy.
   @Test("User-facing strings carry no em-dash or en-dash")
   func noDashes() {
-    let strings =
-      [
-        LiveTranscriptionCopy.toggleLabel,
-        LiveTranscriptionCopy.toggleDescription,
-        LiveTranscriptionCopy.autoLanguageFootnote,
-        LiveTranscriptionCopy.helpButtonAccessibilityLabel,
-        LiveTranscriptionCopy.helpTitle,
-        LiveTranscriptionCopy.helpSpeedHeading,
-        LiveTranscriptionCopy.helpSpeedBody,
-        LiveTranscriptionCopy.helpAccuracyHeading,
-        LiveTranscriptionCopy.helpComparisonOffColumn,
-        LiveTranscriptionCopy.helpComparisonOnColumn,
-        LiveTranscriptionCopy.helpLostEndings,
-        LiveTranscriptionCopy.helpWhyHeading,
-        LiveTranscriptionCopy.helpWhyBody,
-        LiveTranscriptionCopy.helpRecommendationHeading,
-        LiveTranscriptionCopy.helpRecommendationBody,
-        LiveTranscriptionCopy.helpFootnote,
-      ] + LiveTranscriptionCopy.comparisons.flatMap { [$0.metric, $0.off, $0.on] }
-    for s in strings {
+    for s in allUserFacingStrings {
       #expect(s.contains("\u{2014}") == false, "em-dash in user-facing copy: \(s)")
       #expect(s.contains("\u{2013}") == false, "en-dash in user-facing copy: \(s)")
     }
   }
 
-  /// Every string the panel renders must be non-empty. An empty one would render as a
-  /// blank gap that looks like a layout bug rather than a missing sentence.
+  /// An empty string renders as a blank gap that reads as a layout bug rather than a
+  /// missing sentence.
   @Test("No user-facing string is empty")
   func noEmptyStrings() {
-    let strings = [
-      LiveTranscriptionCopy.toggleLabel,
-      LiveTranscriptionCopy.toggleDescription,
-      LiveTranscriptionCopy.helpButtonAccessibilityLabel,
-      LiveTranscriptionCopy.helpTitle,
-      LiveTranscriptionCopy.helpSpeedBody,
-      LiveTranscriptionCopy.helpLostEndings,
-      LiveTranscriptionCopy.helpWhyBody,
-      LiveTranscriptionCopy.helpRecommendationBody,
-      LiveTranscriptionCopy.helpFootnote,
-    ]
-    for s in strings {
+    for s in allUserFacingStrings {
       #expect(s.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false)
     }
+  }
+
+  /// Every string either panel can render, both engines, in one place so a new field
+  /// cannot be added without the dash and empty checks covering it.
+  private var allUserFacingStrings: [String] {
+    var out = [
+      LiveTranscriptionCopy.toggleLabel,
+      LiveTranscriptionCopy.helpButtonAccessibilityLabel,
+      LiveTranscriptionCopy.autoLanguageFootnote,
+      LiveTranscriptionCopy.parakeetToggleDescription,
+      LiveTranscriptionCopy.whisperKitToggleDescription,
+    ]
+    for panel in [LiveTranscriptionCopy.parakeet, LiveTranscriptionCopy.whisperKit] {
+      out += [
+        panel.title, panel.speedHeading, panel.speedBody, panel.accuracyHeading,
+        panel.accuracyBody, panel.whyHeading, panel.whyBody, panel.recommendationHeading,
+        panel.recommendationBody, panel.footnote,
+      ]
+      out += panel.comparisons.flatMap { [$0.metric, $0.off, $0.on] }
+    }
+    return out
   }
 }

--- a/Tests/EnviousWisprTests/Settings/LiveTranscriptionCopyTests.swift
+++ b/Tests/EnviousWisprTests/Settings/LiveTranscriptionCopyTests.swift
@@ -1,0 +1,120 @@
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #1337: the Live transcription help panel states MEASURED figures to a user who is
+/// deciding whether to keep a setting that costs them accuracy. Nothing derives these
+/// numbers from the benchmarks at runtime, so this freeze test is the guard: if a figure
+/// changes it must be a conscious act backed by a re-measurement, not a drift, and a panel
+/// whose whole purpose is honesty must never quietly start lying.
+struct LiveTranscriptionCopyTests {
+
+  /// Sources, both recorded on #1337: word errors and phantom words from the 28-clip
+  /// firehose bake-off; the lost-endings figure from a replay of 500 archived real
+  /// dictations. Change a number here only alongside a fresh measurement.
+  @Test("The measured comparison rows are frozen, verbatim and in order")
+  func comparisonsAreFrozen() {
+    let expected: [(String, String, String)] = [
+      ("Word errors", "2.0%", "3.7%"),
+      ("Repeated or invented words", "17", "51"),
+    ]
+    #expect(LiveTranscriptionCopy.comparisons.count == expected.count)
+    for (actual, want) in zip(LiveTranscriptionCopy.comparisons, expected) {
+      #expect(actual.metric == want.0, "metric drifted: \(actual.metric) vs \(want.0)")
+      #expect(actual.off == want.1, "OFF figure drifted for \(actual.metric)")
+      #expect(actual.on == want.2, "ON figure drifted for \(actual.metric)")
+    }
+  }
+
+  /// The panel is keyed by `metric` through `Identifiable`, so a duplicate would silently
+  /// collapse a row in the `ForEach` and hide a measurement from users.
+  @Test("Metric names are unique so no row is dropped from the panel")
+  func metricsAreUnique() {
+    let metrics = LiveTranscriptionCopy.comparisons.map(\.metric)
+    #expect(Set(metrics).count == metrics.count, "duplicate metric would collapse a panel row")
+  }
+
+  /// GUARD FOR A SPECIFIC MISTAKE MADE AND CAUGHT WHILE WRITING THIS PANEL.
+  ///
+  /// The first draft included a third row, "Dictations that lost their ending", with `off`
+  /// set to "none". That zero is true by CONSTRUCTION, not by measurement: in the
+  /// 500-dictation replay the off setting was the reference the on setting was scored
+  /// against, so it could not have shown a loss. Printing it beside a genuinely measured
+  /// column would have presented a fabricated figure as data, in the one panel that exists
+  /// to be trusted. It lives in `helpLostEndings` instead, phrased as the comparison that
+  /// was actually run.
+  ///
+  /// This test fails if anyone re-adds a comparison row for lost endings.
+  @Test("Lost endings is NOT a two-arm row, because the off arm was the reference")
+  func lostEndingsIsNotAComparisonRow() {
+    for row in LiveTranscriptionCopy.comparisons {
+      #expect(
+        row.metric.lowercased().contains("ending") == false,
+        "lost endings must not be a comparison row: its OFF value is true by construction, not measured. Use helpLostEndings."
+      )
+    }
+    #expect(LiveTranscriptionCopy.helpLostEndings.contains("1 in 24"))
+    #expect(
+      LiveTranscriptionCopy.helpLostEndings.contains("compared with"),
+      "the lost-endings line must state what it was compared against, not a bare rate")
+  }
+
+  /// The pre-#1337 description claimed "faster results". Measurement says there is no
+  /// perceptible gain below five minutes, so that claim must not return.
+  @Test("The toggle description does not promise speed the measurements do not support")
+  func descriptionDoesNotPromiseSpeed() {
+    let d = LiveTranscriptionCopy.toggleDescription.lowercased()
+    #expect(
+      d.contains("faster results") == false,
+      "the description must not claim faster results: measured as imperceptible below 5 min")
+    #expect(d.contains("does not save time"), "the description must state the real speed answer")
+  }
+
+  /// Brand rule: no em-dashes or en-dashes in user-facing copy.
+  @Test("User-facing strings carry no em-dash or en-dash")
+  func noDashes() {
+    let strings =
+      [
+        LiveTranscriptionCopy.toggleLabel,
+        LiveTranscriptionCopy.toggleDescription,
+        LiveTranscriptionCopy.autoLanguageFootnote,
+        LiveTranscriptionCopy.helpButtonAccessibilityLabel,
+        LiveTranscriptionCopy.helpTitle,
+        LiveTranscriptionCopy.helpSpeedHeading,
+        LiveTranscriptionCopy.helpSpeedBody,
+        LiveTranscriptionCopy.helpAccuracyHeading,
+        LiveTranscriptionCopy.helpComparisonOffColumn,
+        LiveTranscriptionCopy.helpComparisonOnColumn,
+        LiveTranscriptionCopy.helpLostEndings,
+        LiveTranscriptionCopy.helpWhyHeading,
+        LiveTranscriptionCopy.helpWhyBody,
+        LiveTranscriptionCopy.helpRecommendationHeading,
+        LiveTranscriptionCopy.helpRecommendationBody,
+        LiveTranscriptionCopy.helpFootnote,
+      ] + LiveTranscriptionCopy.comparisons.flatMap { [$0.metric, $0.off, $0.on] }
+    for s in strings {
+      #expect(s.contains("\u{2014}") == false, "em-dash in user-facing copy: \(s)")
+      #expect(s.contains("\u{2013}") == false, "en-dash in user-facing copy: \(s)")
+    }
+  }
+
+  /// Every string the panel renders must be non-empty. An empty one would render as a
+  /// blank gap that looks like a layout bug rather than a missing sentence.
+  @Test("No user-facing string is empty")
+  func noEmptyStrings() {
+    let strings = [
+      LiveTranscriptionCopy.toggleLabel,
+      LiveTranscriptionCopy.toggleDescription,
+      LiveTranscriptionCopy.helpButtonAccessibilityLabel,
+      LiveTranscriptionCopy.helpTitle,
+      LiveTranscriptionCopy.helpSpeedBody,
+      LiveTranscriptionCopy.helpLostEndings,
+      LiveTranscriptionCopy.helpWhyBody,
+      LiveTranscriptionCopy.helpRecommendationBody,
+      LiveTranscriptionCopy.helpFootnote,
+    ]
+    for s in strings {
+      #expect(s.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false)
+    }
+  }
+}


### PR DESCRIPTION
Part of #1879. Updates #1337.

## What this does

Adds a `questionmark.circle` help panel beside the **Live transcription** toggle, mirroring the one shipped for Convert spoken punctuation (#1794), and rewrites the toggle's own description.

**The sunset was reversed.** #1337 originally planned to delete Parakeet streaming outright. The founder decided on 2026-07-31 to keep it: the users who enabled it are chasing speed, removing a control labelled "faster" reads as the app getting slower, and they made a deliberate choice we should not override. So instead of taking the choice away, this makes the trade explicit where the choice is made.

## Why the description changed too

The old line read *"Transcribes while you speak for faster results."* Measurement says there is no perceptible gain below five minutes on Parakeet, so it advertised a benefit the data denies. Leaving a false speed claim beside an honesty panel would have been self-defeating. A test blocks the phrase returning.

## The copy is split per engine, and that is the point

One toggle drives two different implementations whose evidence points in **opposite** directions.

| | Parakeet | WhisperKit |
|---|---|---|
| Mechanism | sliding window + text stitching | `WhisperKitStreamingSession`, LocalAgreement-2 over one retained buffer (#1276 PR-2) |
| Accuracy vs batch | **worse** (2.0% → 3.7% word errors) | roughly neutral |
| Long recordings | no benefit that matters | clearly faster |
| Auto-detect language | n/a | degrades to clean batch entirely |
| Panel says | measured table, "leave this off" | no table, "turn it on if you dictate long" |

The first commit showed Parakeet's numbers to both. **A WhisperKit user would have read error rates measured on a different engine and been told to disable a setting that helps them.** Caught by `codex review`, fixed in the second commit.

## WhisperKit deliberately carries no figures

Our own records disagree about them. #1276's comment says 3/107 phantom endings; `whisperkit-research.md` FACT: ufal-streaming-architecture-shipped explicitly corrects that to *"1/109 UFAL phantom endings versus 14/109 stitch, not 3/107"*. The widely-quoted 1.6s-vs-38.5s latency pair was measured on a prototype harness **before** PR #1313 shipped a different architecture.

Two sources disagreeing is exactly when a number must not reach a user, so that panel makes only the qualitative claims both sources support. The comparison table renders only for an engine that has defensible figures, rather than rendering empty.

## One deliberate omission

The Parakeet table has **no "lost endings" row**. In the 500-dictation replay the OFF setting was the *reference* the ON setting was scored against, so its zero is true by construction, not measured. Printing it beside genuinely measured columns would put a fabricated figure in the one panel whose purpose is to be trusted. It is stated separately as the comparison that was actually run, and a test fails if anyone re-adds it as a row.

## Usage that informed the decision (measured 2026-07-31)

- **28 of 163** weekly active dictating users have it on.
- They produce **35%** of all Parakeet dictation volume (3,498 of 9,848 in 7 days).
- They dictate **125 times a week each**, against 49 for everyone else.
- **81% of their dictations are under 30 seconds, and none exceed five minutes** — the only length where streaming helps. They carry the full accuracy cost for none of the benefit.

## Testing

- **9 copy-freeze tests**, three of them targeting the cross-engine defect class specifically: any Parakeet figure appearing in WhisperKit copy fails; WhisperKit inheriting the disable recommendation fails; every backend must resolve to its own panel, so a third engine forces a decision rather than silently reusing a branch.
- Full Debug lane: **4,669 tests passed**.
- **Live UAT:** dev build rebuilt, founder opened both panels and visually confirmed layout, table alignment and popover clipping. Automated tests prove the words; only a human eye can judge whether four sections plus a table read as cramped in a popover.

## Follow-up that must ship in the same release

**#1885** — the knowledge base currently calls Live transcription *"a Parakeet-exclusive feature"*, and separately carries three claims wrong since 2026-07-04: Parakeet described as "English only" (it does 25 languages), WhisperKit as "Streaming ASR: No" (it streams), and a description of an incremental worker deleted in PR #1316. The app and the help centre must not disagree on the same day.
