### PR TITLE
feat(audio): count takes that end at the VAD no-speech gate, with input-device attribution (Closes #1845)

### DIFF
--- a/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
@@ -94,6 +94,20 @@ public protocol AudioCaptureInterface: AnyObject {
   /// treat a `deviceID` match alone as identity — that is what `deviceUID` is for.
   var zeroSignalDiscriminatorDevice: BoundInputDevice? { get }
 
+  /// #1845: which BUILT-IN-family input the bind opened (`built_in_mic` /
+  /// `jack_input`), or nil for every other transport. DERIVED once at bind time
+  /// from the bound UID and stored, deliberately NOT computed by reading
+  /// `zeroSignalDiscriminatorDevice` at emit time.
+  ///
+  /// The separation is load-bearing, not stylistic. That accessor participates
+  /// in the #1844/#1578 zero-signal DECISION and its read ORDER is a tested
+  /// contract: a run already classified reactively must short-circuit before the
+  /// bind is consulted at all. Telemetry asking the same question later would
+  /// consult it on a path the guard forbids, which is exactly the regression
+  /// `KernelFrozenBindGuardTests` caught. A decision input and an observation
+  /// are different concerns even when they describe the same fact.
+  var boundInputDeviceKind: String? { get }
+
   /// #1317, superseded as a consumer surface by #1578: a COMPATIBILITY VIEW of
   /// whether the CURRENT trailing all-zero run has a categorical refusal reason.
   /// True once the reactive check refused a candidate buffer somewhere in that
@@ -209,6 +223,7 @@ extension AudioCaptureInterface {
   /// source-compatible. The real capture backend (`AudioCaptureManager`)
   /// overrides it with the bind its own `prepare()` returned (#1844).
   public var zeroSignalDiscriminatorDevice: BoundInputDevice? { nil }
+  public var boundInputDeviceKind: String? { nil }
 
   /// #1714: WHY the microphone this session is using was chosen —
   /// `pinned_uid`, `system_default` or `list_fallback`. Default `nil` so every

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -54,6 +54,11 @@ public final class AudioCaptureManager: AudioCaptureInterface {
 
   public var zeroSignalDiscriminatorDevice: BoundInputDevice? { effectiveDiscriminatorDevice }
 
+  /// #1845: derived once in `adoptBoundState`, alongside the route refresh, so
+  /// no consumer re-reads the bind to answer it. See the protocol requirement
+  /// for why this is not a computed projection of the property above.
+  public private(set) var boundInputDeviceKind: String?
+
   /// #1317 (ported in-process from the former app-side capture proxy at the C1
   /// collapse, #1543): WHY the CURRENT trailing all-zero run was refused by the
   /// device discriminator. The kernel's STOP-time backstop reads this guard-first
@@ -553,6 +558,7 @@ public final class AudioCaptureManager: AudioCaptureInterface {
   /// the source, so there is nothing to downcast and no way to read a stale bind.
   private func adoptBoundState(_ bound: BoundInputDevice) {
     effectiveDiscriminatorDevice = bound
+    boundInputDeviceKind = AudioDeviceEnumerator.builtInInputKind(forUID: bound.deviceUID)
     refreshResolvedRoute(actualBoundTransport: bound.transportLabel)
   }
 

--- a/Sources/EnviousWisprAudio/AudioDeviceManager.swift
+++ b/Sources/EnviousWisprAudio/AudioDeviceManager.swift
@@ -365,6 +365,51 @@ public enum AudioDeviceEnumerator {
     return transportLabel(for: id)
   }
 
+  /// #1845: which BUILT-IN-family input a UID names, or nil for anything else.
+  ///
+  /// `transportLabel` reports `built_in` for BOTH the internal microphone and a
+  /// microphone plugged into the 3.5 mm jack, because macOS routes the jack
+  /// through the same audio codec. Measured on the founder's Mac 2026-07-31:
+  ///
+  /// | Picker name | UID | transport |
+  /// |---|---|---|
+  /// | MacBook Pro Microphone | `BuiltInMicrophoneDevice` | `bltn` |
+  /// | External Microphone | `BuiltInHeadphoneInputDevice` | `bltn` |
+  ///
+  /// So transport alone cannot tell "the internal mic went quiet" from "a dead
+  /// headset is plugged into the jack" — and the second is the population #1845
+  /// exists to measure. The UID does distinguish them.
+  ///
+  /// **Returns a CLOSED VOCABULARY, never the UID itself.** That is a privacy
+  /// requirement, not a style choice: a USB UID embeds the device serial
+  /// (`AppleUSBAudioEngine:Plantronics:…:CBB85FCE…`) and a Bluetooth UID is the
+  /// peer MAC address, so emitting raw UIDs would ship hardware identifiers.
+  /// The two values below are Apple-fixed constants that name a PORT on every
+  /// Mac, identify nobody, and are already documented as the UID-shape
+  /// cross-check in `gotchas-audio.md`.
+  ///
+  /// Deliberately nil outside the built-in family: `usb`, `bluetooth` and
+  /// `virtual` are already unambiguous in the transport label, so a second
+  /// field there would be a duplicate authority for a fact that has one.
+  ///
+  /// **Device MODEL is deliberately not reported, and that was a considered
+  /// decision rather than an omission (founder, 2026-07-31).** `kAudioDevice`
+  /// `PropertyModelUID` is available and safe — measured `Blackwire 5220
+  /// Series:047F:C053` for USB and `4066 9e` for Bluetooth, neither carrying a
+  /// serial or the user's chosen device name. It was rejected on VALUE, not on
+  /// privacy: the question worth answering is which of four input CLASSES
+  /// failed, and a per-model breakdown does not change what we would do about
+  /// it. Do not add it back without a use that a class-level answer cannot
+  /// serve. The raw `deviceUID` remains permanently unemittable — the USB form
+  /// embeds the unit serial and the Bluetooth form is the peer MAC address.
+  public static func builtInInputKind(forUID uid: String?) -> String? {
+    switch uid {
+    case "BuiltInMicrophoneDevice": return "built_in_mic"
+    case "BuiltInHeadphoneInputDevice": return "jack_input"
+    default: return nil
+    }
+  }
+
   // MARK: - Private Helpers
 
   /// Raw CoreAudio transport-type constant, or nil if the property read fails.

--- a/Sources/EnviousWisprCore/RawAudioDeadAirClassifier.swift
+++ b/Sources/EnviousWisprCore/RawAudioDeadAirClassifier.swift
@@ -24,20 +24,48 @@ public enum RawAudioDeadAirClassifier {
     public static let windowSamples = 640
   }
 
-  /// True when a raw capture buffer is dead air (no recoverable speech) for
-  /// the #964 gate: when Silero reports zero segments the kernel skips ASR
-  /// ONLY if the raw audio is also below every `DeadAirFloor` threshold.
-  /// Otherwise it falls through and lets Parakeet decide. Pure + static so
-  /// the boundary cases (just-below / just-above each threshold) unit-test
-  /// without a kernel.
-  public static func isDeadAir<C: RandomAccessCollection>(_ samples: C, peak: Float) -> Bool
+  /// What `measure` observed while classifying a buffer (#1845).
+  ///
+  /// Both RMS values are OPTIONAL because the classification short-circuits:
+  /// an above-floor peak, an empty buffer, or an above-floor whole-buffer RMS
+  /// each return before the later work runs. `nil` therefore means "not
+  /// computed", never "computed as zero" — the same distinction #1845 enforces
+  /// on `peak_audio_level` at the telemetry layer, where a fabricated zero
+  /// would be indistinguishable from a digitally dead channel.
+  package struct DeadAirMeasurement: Sendable, Equatable {
+    package let wholeBufferRMS: Float?
+    package let maxWindowRMS: Float?
+    package let isDeadAir: Bool
+  }
+
+  /// The classification above, plus the intermediate energy values it computed.
+  ///
+  /// `isDeadAir` delegates here, so this is the single implementation of the
+  /// #964 gate rather than a parallel copy. #1845 needs the two RMS values as
+  /// telemetry: the classifier already computed them and threw them away, and
+  /// recomputing them at the call site would be a second implementation of the
+  /// thing being measured.
+  ///
+  /// Short-circuit ORDER and RESULTS are identical to the pre-#1845 code —
+  /// peak, then empty, then whole-buffer RMS, then the short-buffer reuse, then
+  /// the tiled window loop. Nothing added here may change what the gate decides.
+  package static func measure<C: RandomAccessCollection>(
+    _ samples: C,
+    peak: Float
+  ) -> DeadAirMeasurement
   where C.Element == Float, C.Index == Int {
-    guard peak < DeadAirFloor.peak else { return false }
-    guard !samples.isEmpty else { return true }
+    guard peak < DeadAirFloor.peak else {
+      return DeadAirMeasurement(wholeBufferRMS: nil, maxWindowRMS: nil, isDeadAir: false)
+    }
+    guard !samples.isEmpty else {
+      return DeadAirMeasurement(wholeBufferRMS: nil, maxWindowRMS: nil, isDeadAir: true)
+    }
     var sumSquares: Float = 0
     for s in samples { sumSquares += s * s }
     let rms = (sumSquares / Float(samples.count)).squareRoot()
-    guard rms < DeadAirFloor.rms else { return false }
+    guard rms < DeadAirFloor.rms else {
+      return DeadAirMeasurement(wholeBufferRMS: rms, maxWindowRMS: nil, isDeadAir: false)
+    }
     // Loudest non-overlapping 40 ms window. A faint word lifts a local
     // window's RMS even when most of the buffer is silence around it; tiled
     // windows keep this bounded at O(n). Indices are offset from
@@ -45,7 +73,13 @@ public enum RawAudioDeadAirClassifier {
     // a larger buffer, #1317 cloud review) does NOT start at index 0, so raw
     // `0..<window`-style indexing would read the wrong elements or trap.
     let window = DeadAirFloor.windowSamples
-    guard samples.count >= window else { return rms < DeadAirFloor.windowRms }
+    guard samples.count >= window else {
+      // A buffer shorter than one window has no tiled window to measure, so the
+      // whole-buffer RMS IS the loudest-window value. Reported rather than left
+      // nil: it was computed, and the gate compared it.
+      return DeadAirMeasurement(
+        wholeBufferRMS: rms, maxWindowRMS: rms, isDeadAir: rms < DeadAirFloor.windowRms)
+    }
     var maxWindowRms = rms
     var windowStart = samples.startIndex
     while windowStart + window <= samples.endIndex {
@@ -55,6 +89,22 @@ public enum RawAudioDeadAirClassifier {
       if wr > maxWindowRms { maxWindowRms = wr }
       windowStart += window
     }
-    return maxWindowRms < DeadAirFloor.windowRms
+    return DeadAirMeasurement(
+      wholeBufferRMS: rms, maxWindowRMS: maxWindowRms,
+      isDeadAir: maxWindowRms < DeadAirFloor.windowRms)
+  }
+
+  /// True when a raw capture buffer is dead air (no recoverable speech) for
+  /// the #964 gate: when Silero reports zero segments the kernel skips ASR
+  /// ONLY if the raw audio is also below every `DeadAirFloor` threshold.
+  /// Otherwise it falls through and lets Parakeet decide. Pure + static so
+  /// the boundary cases (just-below / just-above each threshold) unit-test
+  /// without a kernel.
+  ///
+  /// #1845: now a projection of `measure`, which owns the computation. Callers
+  /// that only need the verdict keep using this.
+  public static func isDeadAir<C: RandomAccessCollection>(_ samples: C, peak: Float) -> Bool
+  where C.Element == Float, C.Index == Int {
+    measure(samples, peak: peak).isDeadAir
   }
 }

--- a/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
@@ -52,6 +52,16 @@ final class KernelLifecycleTelemetrySink {
     _ backend: String, _ telemetry: KernelModelLoadWedgeTelemetry?
   ) -> Void
 
+  /// #1845. Every optional is omit-when-nil at the `TelemetryService` boundary;
+  /// `peakAudioLevel` is optional deliberately so a missing reading can never be
+  /// emitted as an exact zero.
+  typealias VADGateNoSpeechSink = @MainActor (
+    _ backend: String, _ mode: String, _ rawSampleCount: Int, _ peakAudioLevel: Float?,
+    _ wholeBufferRMS: Float?, _ maxWindowRMS: Float?, _ durationMs: Int?,
+    _ effectiveTransport: String?, _ selectedTransport: String?, _ inputSelectionMode: String?,
+    _ captureNativeRateHz: Double?, _ captureNativeChannelCount: Int?, _ takeID: String?
+  ) -> Void
+
   typealias CaptureErrorSink = @MainActor (
     _ error: any Error & StableSentryErrorIdentity,
     _ category: SentryBreadcrumb.ErrorCategory,
@@ -100,6 +110,7 @@ final class KernelLifecycleTelemetrySink {
   private let updateAudioRoute: AudioRouteSink
   private let dictationInvoked: DictationInvokedSink
   private let modelLoadWedged: ModelLoadWedgedSink
+  private let vadGateNoSpeech: VADGateNoSpeechSink
   private let captureError: CaptureErrorSink
   private let captureErrorWithSnapshot: SnapshotCaptureErrorSink
   /// Optional. When wired (factory path), the sink routes
@@ -169,6 +180,18 @@ final class KernelLifecycleTelemetrySink {
         firstSignalLatencyMs: telemetry?.firstSignalLatencyMs,
         totalAttemptDurationMs: telemetry?.totalAttemptDurationMs)
     },
+    vadGateNoSpeech: @escaping VADGateNoSpeechSink = {
+      backend, mode, rawSampleCount, peakAudioLevel, wholeBufferRMS, maxWindowRMS, durationMs,
+      effectiveTransport, selectedTransport, inputSelectionMode, captureNativeRateHz,
+      captureNativeChannelCount, takeID in
+      TelemetryService.shared.vadGateNoSpeech(
+        backend: backend, mode: mode, rawSampleCount: rawSampleCount,
+        peakAudioLevel: peakAudioLevel, wholeBufferRMS: wholeBufferRMS,
+        maxWindowRMS: maxWindowRMS, durationMs: durationMs,
+        effectiveTransport: effectiveTransport, selectedTransport: selectedTransport,
+        inputSelectionMode: inputSelectionMode, captureNativeRateHz: captureNativeRateHz,
+        captureNativeChannelCount: captureNativeChannelCount, takeID: takeID)
+    },
     captureError: @escaping CaptureErrorSink = { error, category, stage, extra in
       SentryBreadcrumb.captureError(error, category: category, stage: stage, extra: extra)
     },
@@ -200,6 +223,7 @@ final class KernelLifecycleTelemetrySink {
     self.updateAudioRoute = updateAudioRoute
     self.dictationInvoked = dictationInvoked
     self.modelLoadWedged = modelLoadWedged
+    self.vadGateNoSpeech = vadGateNoSpeech
     self.captureError = captureError
     self.captureErrorWithSnapshot = captureErrorWithSnapshot
     self.noAudioCapturedRich = noAudioCapturedRich
@@ -396,10 +420,20 @@ final class KernelLifecycleTelemetrySink {
       // name/string rule. VAD-gate path = TP:787; ASR-empty no-speech = TP:902.
       switch source {
       case .vadGate:
-        // TODO(test-fix): update no-speech payload expectations for round-2 fields.
+        // #1845: ONE computation, TWO records. The breadcrumb is unchanged in
+        // name and stage; the tally is new and is the only countable evidence
+        // this terminal has ever produced — a breadcrumb is attached to a later
+        // Sentry event, and a no-speech terminal fires none, so until now these
+        // takes were invisible.
+        let facts = vadGateNoSpeechFacts()
         breadcrumb(
           "asr", "VAD gate: no speech detected, skipping ASR",
-          noSpeechVADGatePayload())
+          noSpeechVADGatePayload(facts))
+        vadGateNoSpeech(
+          facts.backend, facts.mode, facts.rawSampleCount, facts.peakAudioLevel,
+          facts.wholeBufferRMS, facts.maxWindowRMS, facts.durationMs,
+          facts.effectiveTransport, facts.selectedTransport, facts.inputSelectionMode,
+          facts.captureNativeRateHz, facts.captureNativeChannelCount, facts.takeID)
       case .asrEmptyNoSpeech:
         breadcrumb(
           "asr", "ASR empty (no speech detected)",
@@ -609,15 +643,75 @@ final class KernelLifecycleTelemetrySink {
     return payload
   }
 
-  private func noSpeechVADGatePayload() -> [String: Any] {
-    [
-      "backend": backend.rawValue,
-      "mode": telemetryState.noSpeechTelemetry?.mode
-        ?? (outcome.streamingMode ? "streaming" : "batch"),
-      "raw_sample_count": telemetryState.noSpeechTelemetry?.rawSampleCount
-        ?? audioCapture.capturedSamples.count,
-      "peak_audio_level": telemetryState.noSpeechTelemetry?.peakAudioLevel ?? 0,
+  /// #1845: everything the `.vadGate` terminal reports, computed ONCE and fed to
+  /// BOTH the Sentry breadcrumb and the PostHog tally. Two independent reads
+  /// would let the two records describe the same take differently.
+  ///
+  /// Every route and format value here is frozen: route from
+  /// `noSpeechTelemetry` (stamped at the classifier site from this take's
+  /// `lastResolvedRoute`), format from `captureHealth.stopMetadata` (stamped
+  /// immediately post-stop, before every early terminal). Nothing reads
+  /// `audioCapture.currentResolvedRoute`, which is live and can describe a
+  /// later source by the time a terminal renders.
+  private struct VADGateNoSpeechFacts {
+    let backend: String
+    let mode: String
+    let rawSampleCount: Int
+    /// Optional and NEVER defaulted to `0`. An exact zero is the signature of a
+    /// digitally dead channel (#1809); manufacturing one from missing state
+    /// would make absent data look like the finding we are hunting.
+    let peakAudioLevel: Float?
+    let wholeBufferRMS: Float?
+    let maxWindowRMS: Float?
+    let durationMs: Int?
+    let effectiveTransport: String?
+    let selectedTransport: String?
+    let inputSelectionMode: String?
+    let captureNativeRateHz: Double?
+    let captureNativeChannelCount: Int?
+    let takeID: String?
+  }
+
+  private func vadGateNoSpeechFacts() -> VADGateNoSpeechFacts {
+    let noSpeech = telemetryState.noSpeechTelemetry
+    let health = telemetryState.captureHealth
+    return VADGateNoSpeechFacts(
+      backend: backend.rawValue,
+      mode: noSpeech?.mode ?? (outcome.streamingMode ? "streaming" : "batch"),
+      rawSampleCount: noSpeech?.rawSampleCount ?? audioCapture.capturedSamples.count,
+      peakAudioLevel: noSpeech?.peakAudioLevel,
+      wholeBufferRMS: noSpeech?.wholeBufferRMS,
+      maxWindowRMS: noSpeech?.maxWindowRMS,
+      durationMs: telemetryState.recordingSnapshot?.durationMs,
+      effectiveTransport: noSpeech?.effectiveTransport,
+      selectedTransport: noSpeech?.selectedTransport,
+      inputSelectionMode: noSpeech?.inputSelectionMode,
+      captureNativeRateHz: health?.stopMetadata?.nativeRateHz,
+      captureNativeChannelCount: health?.stopMetadata?.nativeChannelCount,
+      // Read BEFORE the generic terminal postamble clears the take key. The
+      // postamble deliberately runs after the event-specific arm for exactly
+      // this reason; if it is ever moved above the switch, the §11.2 take-key
+      // test fails rather than the property silently emptying.
+      takeID: telemetryState.takeID
+    )
+  }
+
+  private func noSpeechVADGatePayload(_ facts: VADGateNoSpeechFacts) -> [String: Any] {
+    var payload: [String: Any] = [
+      "backend": facts.backend,
+      "mode": facts.mode,
+      "raw_sample_count": facts.rawSampleCount,
     ]
+    if let v = facts.peakAudioLevel { payload["peak_audio_level"] = v }
+    if let v = facts.wholeBufferRMS { payload["whole_buffer_rms"] = v }
+    if let v = facts.maxWindowRMS { payload["max_window_rms"] = v }
+    if let v = facts.durationMs { payload["duration_ms"] = v }
+    if let v = facts.effectiveTransport { payload["effective_transport"] = v }
+    if let v = facts.selectedTransport { payload["selected_transport"] = v }
+    if let v = facts.inputSelectionMode { payload["input_selection_mode"] = v }
+    if let v = facts.captureNativeRateHz { payload["capture_native_rate_hz"] = v }
+    if let v = facts.captureNativeChannelCount { payload["capture_native_channel_count"] = v }
+    return payload
   }
 
   private func recordingSnapshot() -> SentryBreadcrumb.RecordingSnapshot? {

--- a/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
@@ -59,7 +59,8 @@ final class KernelLifecycleTelemetrySink {
     _ backend: String, _ mode: String, _ rawSampleCount: Int, _ peakAudioLevel: Float?,
     _ wholeBufferRMS: Float?, _ maxWindowRMS: Float?, _ durationMs: Int?,
     _ effectiveTransport: String?, _ selectedTransport: String?, _ inputSelectionMode: String?,
-    _ captureNativeRateHz: Double?, _ captureNativeChannelCount: Int?, _ takeID: String?
+    _ inputDeviceKind: String?, _ captureNativeRateHz: Double?, _ captureNativeChannelCount: Int?,
+    _ takeID: String?
   ) -> Void
 
   typealias CaptureErrorSink = @MainActor (
@@ -182,14 +183,15 @@ final class KernelLifecycleTelemetrySink {
     },
     vadGateNoSpeech: @escaping VADGateNoSpeechSink = {
       backend, mode, rawSampleCount, peakAudioLevel, wholeBufferRMS, maxWindowRMS, durationMs,
-      effectiveTransport, selectedTransport, inputSelectionMode, captureNativeRateHz,
-      captureNativeChannelCount, takeID in
+      effectiveTransport, selectedTransport, inputSelectionMode, inputDeviceKind,
+      captureNativeRateHz, captureNativeChannelCount, takeID in
       TelemetryService.shared.vadGateNoSpeech(
         backend: backend, mode: mode, rawSampleCount: rawSampleCount,
         peakAudioLevel: peakAudioLevel, wholeBufferRMS: wholeBufferRMS,
         maxWindowRMS: maxWindowRMS, durationMs: durationMs,
         effectiveTransport: effectiveTransport, selectedTransport: selectedTransport,
-        inputSelectionMode: inputSelectionMode, captureNativeRateHz: captureNativeRateHz,
+        inputSelectionMode: inputSelectionMode, inputDeviceKind: inputDeviceKind,
+        captureNativeRateHz: captureNativeRateHz,
         captureNativeChannelCount: captureNativeChannelCount, takeID: takeID)
     },
     captureError: @escaping CaptureErrorSink = { error, category, stage, extra in
@@ -433,7 +435,8 @@ final class KernelLifecycleTelemetrySink {
           facts.backend, facts.mode, facts.rawSampleCount, facts.peakAudioLevel,
           facts.wholeBufferRMS, facts.maxWindowRMS, facts.durationMs,
           facts.effectiveTransport, facts.selectedTransport, facts.inputSelectionMode,
-          facts.captureNativeRateHz, facts.captureNativeChannelCount, facts.takeID)
+          facts.inputDeviceKind, facts.captureNativeRateHz, facts.captureNativeChannelCount,
+          facts.takeID)
       case .asrEmptyNoSpeech:
         breadcrumb(
           "asr", "ASR empty (no speech detected)",
@@ -667,6 +670,9 @@ final class KernelLifecycleTelemetrySink {
     let effectiveTransport: String?
     let selectedTransport: String?
     let inputSelectionMode: String?
+    /// #1845: `built_in_mic` / `jack_input`, refining the ambiguous `built_in`
+    /// transport into the two physical inputs it covers. nil elsewhere.
+    let inputDeviceKind: String?
     let captureNativeRateHz: Double?
     let captureNativeChannelCount: Int?
     let takeID: String?
@@ -686,6 +692,7 @@ final class KernelLifecycleTelemetrySink {
       effectiveTransport: noSpeech?.effectiveTransport,
       selectedTransport: noSpeech?.selectedTransport,
       inputSelectionMode: noSpeech?.inputSelectionMode,
+      inputDeviceKind: noSpeech?.inputDeviceKind,
       captureNativeRateHz: health?.stopMetadata?.nativeRateHz,
       captureNativeChannelCount: health?.stopMetadata?.nativeChannelCount,
       // Read BEFORE the generic terminal postamble clears the take key. The
@@ -709,6 +716,7 @@ final class KernelLifecycleTelemetrySink {
     if let v = facts.effectiveTransport { payload["effective_transport"] = v }
     if let v = facts.selectedTransport { payload["selected_transport"] = v }
     if let v = facts.inputSelectionMode { payload["input_selection_mode"] = v }
+    if let v = facts.inputDeviceKind { payload["input_device_kind"] = v }
     if let v = facts.captureNativeRateHz { payload["capture_native_rate_hz"] = v }
     if let v = facts.captureNativeChannelCount { payload["capture_native_channel_count"] = v }
     return payload

--- a/Sources/EnviousWisprPipeline/KernelTelemetryState.swift
+++ b/Sources/EnviousWisprPipeline/KernelTelemetryState.swift
@@ -193,6 +193,16 @@ struct KernelNoSpeechTelemetry {
   var effectiveTransport: String?
   var selectedTransport: String?
   var inputSelectionMode: String?
+  /// #1845 — which BUILT-IN-family input this was, closed vocabulary
+  /// (`built_in_mic` / `jack_input`), nil for every other transport.
+  ///
+  /// `effectiveTransport` reports `built_in` for BOTH the internal microphone
+  /// and a microphone in the 3.5 mm jack, because macOS routes the jack through
+  /// the same codec. Without this field a quiet built-in mic and a dead headset
+  /// plugged into the jack are the same row — and the second is the population
+  /// #1845 exists to measure. Derived from the bound device's Apple-fixed UID
+  /// constant, never from the device name or the raw UID.
+  var inputDeviceKind: String?
 }
 
 struct KernelASRCompletedTelemetry {

--- a/Sources/EnviousWisprPipeline/KernelTelemetryState.swift
+++ b/Sources/EnviousWisprPipeline/KernelTelemetryState.swift
@@ -170,6 +170,29 @@ struct KernelNoSpeechTelemetry {
   let mode: String
   let rawSampleCount: Int
   let peakAudioLevel: Float
+  /// #1845 — the two energy values `RawAudioDeadAirClassifier.measure` compared
+  /// against their floors. Optional because the classification short-circuits;
+  /// `nil` means NOT COMPUTED, never "computed as zero". Populated only on the
+  /// `.vadGate` route, which is the only one that runs the classifier — the
+  /// `.asrEmptyNoSpeech` stamp leaves them nil and that is correct, not a gap.
+  var wholeBufferRMS: Float?
+  var maxWindowRMS: Float?
+  /// #1845 — THIS take's route, frozen from `lastResolvedRoute` at the
+  /// classifier site.
+  ///
+  /// These live here rather than being read at emit time because the sink's
+  /// only other handle is `audioCapture.currentResolvedRoute`, which is LIVE
+  /// state and can describe a later source by the time a terminal renders. The
+  /// dead-mic telemetry already refuses that live read for the same reason
+  /// (`RecordingSessionKernel.swift:1686-1690`).
+  ///
+  /// The native capture FORMAT fields are deliberately NOT duplicated here:
+  /// `telemetryState.captureHealth.stopMetadata` is already frozen before every
+  /// early terminal and already reachable from the sink, so a second copy would
+  /// be a second authority for one fact.
+  var effectiveTransport: String?
+  var selectedTransport: String?
+  var inputSelectionMode: String?
 }
 
 struct KernelASRCompletedTelemetry {

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -1800,7 +1800,15 @@ final class RecordingSessionKernel {
           maxWindowRMS: deadAirMeasurement.maxWindowRMS,
           effectiveTransport: takeRoute?.effective,
           selectedTransport: takeRoute?.selected,
-          inputSelectionMode: takeRoute?.inputSelectionMode
+          inputSelectionMode: takeRoute?.inputSelectionMode,
+          // #1845: read from the device HAL ACTUALLY OPENED (#1844's bound-device
+          // contract), not from a re-derived lookup — the whole point of that
+          // contract is that a re-read can name a different microphone.
+          // #1845: the label frozen at bind time. Deliberately NOT
+          // `zeroSignalDiscriminatorDevice?.deviceUID` — that accessor's read
+          // ORDER is a tested #1844/#1578 contract and consulting it here
+          // breaks it (caught by KernelFrozenBindGuardTests).
+          inputDeviceKind: audioCapture.boundInputDeviceKind
         )
         // #1317 N2: a classified zero-signal session emits ONLY the new
         // failure-mode event — never the legacy zombie telemetry too.

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -1781,11 +1781,26 @@ final class RecordingSessionKernel {
     // a quiet `.noSpeech` instead of a user-visible ASR failure (#964 R2).
     var attemptedFromEnergyDespiteNoSegments = false
     if speechEvidence == .confirmedNoSpeech {
-      if Self.rawAudioIsDeadAir(captureResult.samples, peak: rawPeakAudioLevel) {
+      // #1845: `measure` instead of `rawAudioIsDeadAir` — the identical verdict,
+      // plus the two energy values the classifier already computed. Read ONCE;
+      // a second call would be a second measurement of the same buffer.
+      let deadAirMeasurement = RawAudioDeadAirClassifier.measure(
+        captureResult.samples, peak: rawPeakAudioLevel)
+      if deadAirMeasurement.isDeadAir {
+        // #1845: route frozen from THIS take's snapshot, never from the live
+        // `audioCapture.currentResolvedRoute` — by terminal time that can
+        // describe a different source. Same reasoning as the dead-mic retire
+        // telemetry below (`:1686-1690`).
+        let takeRoute = lastResolvedRoute
         telemetryState.noSpeechTelemetry = KernelNoSpeechTelemetry(
           mode: isStreamingSession ? "streaming" : "batch",
           rawSampleCount: captureResult.samples.count,
-          peakAudioLevel: rawPeakAudioLevel
+          peakAudioLevel: rawPeakAudioLevel,
+          wholeBufferRMS: deadAirMeasurement.wholeBufferRMS,
+          maxWindowRMS: deadAirMeasurement.maxWindowRMS,
+          effectiveTransport: takeRoute?.effective,
+          selectedTransport: takeRoute?.selected,
+          inputSelectionMode: takeRoute?.inputSelectionMode
         )
         // #1317 N2: a classified zero-signal session emits ONLY the new
         // failure-mode event — never the legacy zombie telemetry too.

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -626,6 +626,98 @@ public final class TelemetryService {
     PostHogSDK.shared.capture(event, properties: props)
   }
 
+  /// #1845: one event per take that terminated at the VAD no-speech gate having
+  /// passed every dead-air threshold. Sizes a population that until now emitted
+  /// NOTHING countable — the existing Sentry breadcrumb is only visible when
+  /// some other event fires, and a no-speech terminal fires none.
+  ///
+  /// Named for the terminal it observes, NOT for a presumed cause. The app knows
+  /// the audio was below every energy floor; it does not know the microphone was
+  /// muted, dead, or simply pointed at a quiet room, and a physical mute switch
+  /// is frequently invisible to the host by design. Nothing here may be renamed
+  /// to imply otherwise.
+  ///
+  /// Content-free by construction: counts, durations, magnitudes, closed-vocabulary
+  /// transport strings, and the existing take key. Never transcript, audio,
+  /// device name, or UID.
+  ///
+  /// **Every optional omits when nil rather than emitting a sentinel, and
+  /// `peakAudioLevel` is optional for exactly that reason.** An exact zero is the
+  /// signature of a digitally dead channel (#1809), so defaulting a missing
+  /// reading to `0` would manufacture the most diagnostically loaded value in the
+  /// dataset and make absent data indistinguishable from the finding this event
+  /// exists to detect.
+  public func vadGateNoSpeech(
+    backend: String,
+    mode: String,
+    rawSampleCount: Int,
+    peakAudioLevel: Float?,
+    wholeBufferRMS: Float?,
+    maxWindowRMS: Float?,
+    durationMs: Int?,
+    effectiveTransport: String?,
+    selectedTransport: String?,
+    inputSelectionMode: String?,
+    captureNativeRateHz: Double?,
+    captureNativeChannelCount: Int?,
+    takeID: String?
+  ) {
+    let event = "audio.vad_gate_no_speech"
+    var props: [String: Any] = [
+      "backend": backend,
+      "mode": mode,
+      "raw_sample_count": rawSampleCount,
+    ]
+    // Float -> Double at the boundary: PostHog carries numbers as Double and the
+    // DEBUG hook has a Double bucket and no Float one.
+    if let peakAudioLevel { props["peak_audio_level"] = Double(peakAudioLevel) }
+    if let wholeBufferRMS { props["whole_buffer_rms"] = Double(wholeBufferRMS) }
+    if let maxWindowRMS { props["max_window_rms"] = Double(maxWindowRMS) }
+    if let durationMs { props["duration_ms"] = durationMs }
+    if let effectiveTransport { props["effective_transport"] = effectiveTransport }
+    if let selectedTransport { props["selected_transport"] = selectedTransport }
+    if let inputSelectionMode { props["input_selection_mode"] = inputSelectionMode }
+    if let captureNativeRateHz { props["capture_native_rate_hz"] = captureNativeRateHz }
+    if let captureNativeChannelCount {
+      props["capture_native_channel_count"] = captureNativeChannelCount
+    }
+    if let takeID { props["take_id"] = takeID }
+    #if DEBUG
+      // Read BACK OUT of the emitted payload so a test observes what PostHog
+      // receives rather than what the caller passed — the #1846 pattern.
+      var stringProps: [String: String] = ["backend": backend, "mode": mode]
+      for key in ["effective_transport", "selected_transport", "input_selection_mode", "take_id"] {
+        if let value = props[key] as? String { stringProps[key] = value }
+      }
+      var intProps: [String: Int] = ["raw_sample_count": rawSampleCount]
+      for key in ["duration_ms", "capture_native_channel_count"] {
+        if let value = props[key] as? Int { intProps[key] = value }
+      }
+      var doubleProps: [String: Double] = [:]
+      for key in [
+        "peak_audio_level", "whole_buffer_rms", "max_window_rms", "capture_native_rate_hz",
+      ] {
+        if let value = props[key] as? Double { doubleProps[key] = value }
+      }
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: event, stringProps: stringProps, intProps: intProps, doubleProps: doubleProps))
+      // Unlike `zeroSignalRefused`, this event DOES write a log line: #1845's Live
+      // UAT needs a local witness it can correlate to the PostHog row by take key,
+      // and verifying through PostHog alone is what made the sibling's UAT hard.
+      Task {
+        await AppLogger.shared.log(
+          "vad_gate_no_speech mode=\(mode) samples=\(rawSampleCount) "
+            + "peak=\(peakAudioLevel.map { "\($0)" } ?? "nil") "
+            + "wholeRms=\(wholeBufferRMS.map { "\($0)" } ?? "nil") "
+            + "maxWindowRms=\(maxWindowRMS.map { "\($0)" } ?? "nil") "
+            + "transport=\(effectiveTransport ?? "nil") take=\(takeID ?? "nil")",
+          level: .info, category: "Telemetry")
+      }
+    #endif
+    PostHogSDK.shared.capture(event, properties: props)
+  }
+
   /// Heartpath 5b (#1520): a completed take came back zero-signal, so the fenced
   /// retire primitive was invoked. `retireAction` records whether teardown
   /// actually ran (`retired`) or was a fenced no-op. Content-free by

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -658,6 +658,7 @@ public final class TelemetryService {
     effectiveTransport: String?,
     selectedTransport: String?,
     inputSelectionMode: String?,
+    inputDeviceKind: String?,
     captureNativeRateHz: Double?,
     captureNativeChannelCount: Int?,
     takeID: String?
@@ -677,6 +678,7 @@ public final class TelemetryService {
     if let effectiveTransport { props["effective_transport"] = effectiveTransport }
     if let selectedTransport { props["selected_transport"] = selectedTransport }
     if let inputSelectionMode { props["input_selection_mode"] = inputSelectionMode }
+    if let inputDeviceKind { props["input_device_kind"] = inputDeviceKind }
     if let captureNativeRateHz { props["capture_native_rate_hz"] = captureNativeRateHz }
     if let captureNativeChannelCount {
       props["capture_native_channel_count"] = captureNativeChannelCount
@@ -686,7 +688,10 @@ public final class TelemetryService {
       // Read BACK OUT of the emitted payload so a test observes what PostHog
       // receives rather than what the caller passed — the #1846 pattern.
       var stringProps: [String: String] = ["backend": backend, "mode": mode]
-      for key in ["effective_transport", "selected_transport", "input_selection_mode", "take_id"] {
+      for key in [
+        "effective_transport", "selected_transport", "input_selection_mode", "input_device_kind",
+        "take_id",
+      ] {
         if let value = props[key] as? String { stringProps[key] = value }
       }
       var intProps: [String: Int] = ["raw_sample_count": rawSampleCount]
@@ -711,7 +716,8 @@ public final class TelemetryService {
             + "peak=\(peakAudioLevel.map { "\($0)" } ?? "nil") "
             + "wholeRms=\(wholeBufferRMS.map { "\($0)" } ?? "nil") "
             + "maxWindowRms=\(maxWindowRMS.map { "\($0)" } ?? "nil") "
-            + "transport=\(effectiveTransport ?? "nil") take=\(takeID ?? "nil")",
+            + "transport=\(effectiveTransport ?? "nil") kind=\(inputDeviceKind ?? "nil") "
+            + "take=\(takeID ?? "nil")",
           level: .info, category: "Telemetry")
       }
     #endif

--- a/Tests/EnviousWisprTests/Audio/BuiltInInputKindTests.swift
+++ b/Tests/EnviousWisprTests/Audio/BuiltInInputKindTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprAudio
+
+// MARK: - BuiltInInputKindTests (#1845)
+//
+// `effectiveTransport` reports `built_in` for BOTH the internal microphone and
+// a microphone plugged into the 3.5 mm jack, because macOS routes the jack
+// through the same audio codec. Measured on the founder's Mac 2026-07-31:
+//
+//   MacBook Pro Microphone -> BuiltInMicrophoneDevice      -> bltn
+//   External Microphone    -> BuiltInHeadphoneInputDevice  -> bltn
+//
+// Without a discriminator those two collapse into one bucket, and the jack case
+// is the population #1845 exists to measure. These tests freeze the mapping and,
+// just as importantly, freeze what must NEVER be emitted.
+
+@Suite("AudioDeviceEnumerator.builtInInputKind (#1845)")
+struct BuiltInInputKindTests {
+
+  @Test("the two Apple built-in-family UIDs map to distinct kinds")
+  func mapsTheBuiltInFamily() {
+    #expect(
+      AudioDeviceEnumerator.builtInInputKind(forUID: "BuiltInMicrophoneDevice") == "built_in_mic")
+    #expect(
+      AudioDeviceEnumerator.builtInInputKind(forUID: "BuiltInHeadphoneInputDevice") == "jack_input")
+  }
+
+  /// The whole point: these two must not be the same value. A refactor that
+  /// collapsed them would silently restore the ambiguity this field removes,
+  /// and every assertion above would still pass if both returned the same
+  /// non-nil string.
+  @Test("the internal microphone and the jack input are never the same kind")
+  func internalAndJackAreDistinct() {
+    let internalKind = AudioDeviceEnumerator.builtInInputKind(forUID: "BuiltInMicrophoneDevice")
+    let jackKind = AudioDeviceEnumerator.builtInInputKind(forUID: "BuiltInHeadphoneInputDevice")
+
+    #expect(internalKind != nil)
+    #expect(jackKind != nil)
+    #expect(internalKind != jackKind)
+  }
+
+  /// Non-built-in transports return nil on purpose. `usb` and `bluetooth` are
+  /// already unambiguous in the transport label, so a value here would be a
+  /// second authority for a fact that already has one.
+  @Test(
+    "non-built-in and unknown UIDs return nil",
+    arguments: [
+      "AppleUSBAudioEngine:Plantronics:Plantronics Blackwire 5220 Series:CBB85FCE:1",
+      "BC-87-FA-9C-7E-71:input",
+      "BlackHole2ch_UID",
+      "MSLoopbackDriverDevice_UID",
+      "SomeFutureAppleInput",
+      "",
+    ]
+  )
+  func returnsNilOutsideTheBuiltInFamily(uid: String) {
+    #expect(AudioDeviceEnumerator.builtInInputKind(forUID: uid) == nil)
+  }
+
+  @Test("a nil UID returns nil rather than guessing")
+  func nilUIDReturnsNil() {
+    #expect(AudioDeviceEnumerator.builtInInputKind(forUID: nil) == nil)
+  }
+
+  /// PRIVACY FREEZE. The returned value must be one of exactly two closed
+  /// constants and must never echo any part of the input UID.
+  ///
+  /// This matters because the real UIDs we refuse are genuinely sensitive: the
+  /// USB form embeds the unit's SERIAL NUMBER and the Bluetooth form IS the peer
+  /// MAC address. A future "just pass the UID through" refactor would ship
+  /// hardware identifiers, and it would look harmless in review.
+  @Test(
+    "the output is a closed vocabulary and never echoes the UID",
+    arguments: [
+      "BuiltInMicrophoneDevice",
+      "BuiltInHeadphoneInputDevice",
+      "AppleUSBAudioEngine:Plantronics:Blackwire:CBB85FCE8061435CB8C2E9EC589C0931:1",
+      "BC-87-FA-9C-7E-71:input",
+    ]
+  )
+  func outputIsClosedVocabularyAndLeaksNothing(uid: String) {
+    let allowed: Set<String> = ["built_in_mic", "jack_input"]
+
+    guard let kind = AudioDeviceEnumerator.builtInInputKind(forUID: uid) else { return }
+
+    #expect(allowed.contains(kind), "unexpected value '\(kind)' escaped the closed vocabulary")
+    #expect(!kind.contains("CBB85FCE"), "a device serial reached the emitted value")
+    #expect(!kind.contains("BC-87-FA"), "a MAC address reached the emitted value")
+    #expect(kind != uid, "the raw UID was passed straight through")
+  }
+}

--- a/Tests/EnviousWisprTests/Core/RawAudioDeadAirMeasurementTests.swift
+++ b/Tests/EnviousWisprTests/Core/RawAudioDeadAirMeasurementTests.swift
@@ -1,0 +1,143 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprCore
+
+// MARK: - RawAudioDeadAirMeasurementTests (#1845)
+//
+// `measure` became the single implementation of the #964 gate and `isDeadAir`
+// became a projection of it. Two obligations follow, and they are different:
+//
+//  1. EQUIVALENCE. `measure(...).isDeadAir` must decide exactly what the
+//     pre-#1845 `isDeadAir` decided, on every shape the floor was tuned
+//     against. A verdict change here is a heart-path routing change wearing a
+//     telemetry PR's clothes.
+//  2. SHORT-CIRCUIT FIDELITY. A `nil` RMS must mean "not computed", never
+//     "computed as zero". #1845 exists because a fabricated zero is
+//     indistinguishable from a digitally dead channel, and that trap is one
+//     layer down here too.
+
+@Suite("RawAudioDeadAirClassifier.measure (#1845)")
+struct RawAudioDeadAirMeasurementTests {
+
+  private func peak(_ samples: [Float]) -> Float {
+    samples.reduce(Float(0)) { max($0, abs($1)) }
+  }
+
+  // MARK: Equivalence with the shipped verdict
+
+  /// The shapes the #964 floor was tuned against, each asserted to give the
+  /// SAME verdict through both entry points. Parameterized so a future shape is
+  /// one row rather than a copied test.
+  @Test(
+    "measure and isDeadAir agree on every tuned shape",
+    arguments: [
+      // (label, samples, expectedDeadAir)
+      ("uniform sub-floor", [Float](repeating: 0.001, count: 16_000), true),
+      ("just below whole-buffer RMS", [Float](repeating: 0.0011, count: 16_000), true),
+      ("just above whole-buffer RMS", [Float](repeating: 0.0013, count: 16_000), false),
+      ("short buffer sub-floor", [Float](repeating: 0.001, count: 320), true),
+      ("short buffer above window RMS", [Float](repeating: 0.0025, count: 320), false),
+      ("empty buffer", [Float](), true),
+    ] as [(String, [Float], Bool)]
+  )
+  func measureAgreesWithIsDeadAir(label: String, samples: [Float], expectedDeadAir: Bool) {
+    let p = peak(samples)
+    let measured = RawAudioDeadAirClassifier.measure(samples, peak: p)
+    let projected = RawAudioDeadAirClassifier.isDeadAir(samples, peak: p)
+
+    #expect(measured.isDeadAir == expectedDeadAir, "\(label): measure verdict")
+    #expect(projected == expectedDeadAir, "\(label): isDeadAir verdict")
+    #expect(measured.isDeadAir == projected, "\(label): the two entry points diverged")
+  }
+
+  /// A loud window buried in an otherwise silent buffer is the case the tiled
+  /// window loop exists for. Whole-buffer RMS stays under its floor while the
+  /// loudest window does not, so the verdict must be "not dead air" and the
+  /// reported `maxWindowRMS` must exceed the reported `wholeBufferRMS`.
+  @Test("a buried loud window is not dead air and reports the higher window value")
+  func buriedLoudWindowIsNotDeadAir() {
+    var samples = [Float](repeating: 0.0002, count: 16_000)
+    for i in 3_200..<3_840 { samples[i] = 0.004 }
+
+    let measured = RawAudioDeadAirClassifier.measure(samples, peak: peak(samples))
+
+    #expect(measured.isDeadAir == false)
+    #expect(RawAudioDeadAirClassifier.isDeadAir(samples, peak: peak(samples)) == false)
+    let whole = try! #require(measured.wholeBufferRMS)
+    let window = try! #require(measured.maxWindowRMS)
+    #expect(window > whole, "the tiled loop must find a window louder than the whole buffer")
+  }
+
+  /// An `ArraySlice` does not start at index 0. The window loop indexes from
+  /// `startIndex`, and #1317's cloud review caught this exact trap; `measure`
+  /// inherits the loop so it inherits the obligation.
+  @Test("measure agrees for an Array and a non-zero-offset slice of the same values")
+  func measureAgreesAcrossSliceOffset() {
+    var backing = [Float](repeating: 0.9, count: 1_000)
+    backing.append(contentsOf: [Float](repeating: 0.001, count: 16_000))
+    let slice = backing[1_000...]
+    let array = Array(slice)
+
+    let slicePeak = slice.reduce(Float(0)) { max($0, abs($1)) }
+    let arrayResult = RawAudioDeadAirClassifier.measure(array, peak: peak(array))
+    let sliceResult = RawAudioDeadAirClassifier.measure(slice, peak: slicePeak)
+
+    #expect(arrayResult == sliceResult, "slice offset changed the measurement")
+  }
+
+  // MARK: Short-circuit fidelity — nil means NOT COMPUTED
+
+  /// An above-floor peak returns before any RMS work. Both values must be nil.
+  /// If either came back `0`, a caller could not tell "we never looked" from
+  /// "we looked and the line is dead", which is the whole point of #1845.
+  @Test("an above-floor peak reports both RMS values as nil, never zero")
+  func abovePeakFloorReportsNilNotZero() {
+    let samples = [Float](repeating: 0.5, count: 16_000)
+
+    let measured = RawAudioDeadAirClassifier.measure(samples, peak: peak(samples))
+
+    #expect(measured.isDeadAir == false)
+    #expect(measured.wholeBufferRMS == nil, "not computed must not be reported as a value")
+    #expect(measured.maxWindowRMS == nil, "not computed must not be reported as a value")
+  }
+
+  /// An empty buffer is dead air by definition and computes no RMS at all.
+  @Test("an empty buffer is dead air with both RMS values nil")
+  func emptyBufferReportsNil() {
+    let measured = RawAudioDeadAirClassifier.measure([Float](), peak: 0)
+
+    #expect(measured.isDeadAir == true)
+    #expect(measured.wholeBufferRMS == nil)
+    #expect(measured.maxWindowRMS == nil)
+  }
+
+  /// Whole-buffer RMS above its floor returns before the window loop, so the
+  /// whole-buffer value IS known and the window value is not. This is the row
+  /// that proves the two optionals are independent rather than moving together.
+  @Test("an above-floor whole-buffer RMS reports that value but a nil window value")
+  func aboveWholeBufferRMSReportsPartialMeasurement() {
+    let samples = [Float](repeating: 0.0013, count: 16_000)
+
+    let measured = RawAudioDeadAirClassifier.measure(samples, peak: peak(samples))
+
+    #expect(measured.isDeadAir == false)
+    #expect(measured.wholeBufferRMS != nil, "it was computed, so it must be reported")
+    #expect(measured.maxWindowRMS == nil, "the window loop never ran")
+  }
+
+  /// A buffer shorter than one 40 ms window has no tiled window, so the
+  /// whole-buffer RMS is legitimately BOTH values. Distinct from the nil cases
+  /// above: here the window value is known, and happens to equal the other.
+  @Test("a sub-window buffer reports the whole-buffer RMS as both values")
+  func shortBufferReusesWholeBufferRMS() {
+    let samples = [Float](repeating: 0.001, count: 320)
+
+    let measured = RawAudioDeadAirClassifier.measure(samples, peak: peak(samples))
+
+    #expect(measured.isDeadAir == true)
+    let whole = try! #require(measured.wholeBufferRMS)
+    let window = try! #require(measured.maxWindowRMS)
+    #expect(whole == window, "a sub-window buffer's loudest window is the whole buffer")
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
@@ -77,6 +77,7 @@ import Testing
       let effectiveTransport: String?
       let selectedTransport: String?
       let inputSelectionMode: String?
+      let inputDeviceKind: String?
       let captureNativeRateHz: Double?
       let captureNativeChannelCount: Int?
       let takeID: String?
@@ -153,14 +154,15 @@ import Testing
       modelLoadWedged: { backend, _ in recorder.modelLoadWedgedBackends.append(backend) },
       vadGateNoSpeech: {
         backend, mode, rawSampleCount, peak, wholeRMS, maxWindowRMS, durationMs,
-        effectiveTransport, selectedTransport, inputSelectionMode, nativeRate, nativeChannels,
-        takeID in
+        effectiveTransport, selectedTransport, inputSelectionMode, deviceKind, nativeRate,
+        nativeChannels, takeID in
         recorder.vadGateNoSpeechCalls.append(
           Recorder.VADGateNoSpeechCall(
             backend: backend, mode: mode, rawSampleCount: rawSampleCount,
             peakAudioLevel: peak, wholeBufferRMS: wholeRMS, maxWindowRMS: maxWindowRMS,
             durationMs: durationMs, effectiveTransport: effectiveTransport,
             selectedTransport: selectedTransport, inputSelectionMode: inputSelectionMode,
+            inputDeviceKind: deviceKind,
             captureNativeRateHz: nativeRate, captureNativeChannelCount: nativeChannels,
             takeID: takeID))
         recorder.timeline.append("vadGateNoSpeech")
@@ -781,7 +783,8 @@ import Testing
       maxWindowRMS: 0.0009,
       effectiveTransport: "built_in",
       selectedTransport: "unknown",
-      inputSelectionMode: "auto"
+      inputSelectionMode: "auto",
+      inputDeviceKind: "jack_input"
     )
     let sink = makeSink(recorder: recorder, telemetryState: state)
 
@@ -797,6 +800,11 @@ import Testing
     #expect(call.effectiveTransport == "built_in")
     #expect(call.selectedTransport == "unknown")
     #expect(call.inputSelectionMode == "auto")
+    // #1845: the field that makes a jack-connected microphone distinguishable
+    // from the internal one. Both report transport `built_in`, so without this
+    // the two are the same row — and the jack case is the population the issue
+    // exists to measure.
+    #expect(call.inputDeviceKind == "jack_input")
     // The take key must survive to the tally. The generic terminal postamble
     // clears it, and only its placement AFTER the event-specific arm saves this.
     // If that postamble is ever hoisted above the switch, this assertion fails
@@ -881,14 +889,15 @@ import Testing
       updateTakeID: { _ in },
       vadGateNoSpeech: {
         backend, mode, rawSampleCount, peak, wholeRMS, maxWindowRMS, durationMs,
-        effectiveTransport, selectedTransport, inputSelectionMode, nativeRate, nativeChannels,
-        takeID in
+        effectiveTransport, selectedTransport, inputSelectionMode, deviceKind, nativeRate,
+        nativeChannels, takeID in
         recorder.vadGateNoSpeechCalls.append(
           Recorder.VADGateNoSpeechCall(
             backend: backend, mode: mode, rawSampleCount: rawSampleCount,
             peakAudioLevel: peak, wholeBufferRMS: wholeRMS, maxWindowRMS: maxWindowRMS,
             durationMs: durationMs, effectiveTransport: effectiveTransport,
             selectedTransport: selectedTransport, inputSelectionMode: inputSelectionMode,
+            inputDeviceKind: deviceKind,
             captureNativeRateHz: nativeRate, captureNativeChannelCount: nativeChannels,
             takeID: takeID))
       })

--- a/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
@@ -62,7 +62,28 @@ import Testing
       let takeID: String?
     }
 
+    /// #1845: the `audio.vad_gate_no_speech` tally. Optionals are kept optional
+    /// on purpose — the whole point of the event is that "we did not measure" and
+    /// "we measured exactly zero" must stay distinguishable, so a recorder that
+    /// collapsed nil to a default would hide the defect it exists to catch.
+    struct VADGateNoSpeechCall: Equatable {
+      let backend: String
+      let mode: String
+      let rawSampleCount: Int
+      let peakAudioLevel: Float?
+      let wholeBufferRMS: Float?
+      let maxWindowRMS: Float?
+      let durationMs: Int?
+      let effectiveTransport: String?
+      let selectedTransport: String?
+      let inputSelectionMode: String?
+      let captureNativeRateHz: Double?
+      let captureNativeChannelCount: Int?
+      let takeID: String?
+    }
+
     var breadcrumbs: [BreadcrumbCall] = []
+    var vadGateNoSpeechCalls: [VADGateNoSpeechCall] = []
     var recordingStates: [RecordingStateCall] = []
     var audioRoutes: [String] = []
     var dictationsInvoked: [DictationInvokedCall] = []
@@ -130,6 +151,20 @@ import Testing
             triggerSource: trigger, inputMode: mode, targetApp: target, takeID: takeID))
       },
       modelLoadWedged: { backend, _ in recorder.modelLoadWedgedBackends.append(backend) },
+      vadGateNoSpeech: {
+        backend, mode, rawSampleCount, peak, wholeRMS, maxWindowRMS, durationMs,
+        effectiveTransport, selectedTransport, inputSelectionMode, nativeRate, nativeChannels,
+        takeID in
+        recorder.vadGateNoSpeechCalls.append(
+          Recorder.VADGateNoSpeechCall(
+            backend: backend, mode: mode, rawSampleCount: rawSampleCount,
+            peakAudioLevel: peak, wholeBufferRMS: wholeRMS, maxWindowRMS: maxWindowRMS,
+            durationMs: durationMs, effectiveTransport: effectiveTransport,
+            selectedTransport: selectedTransport, inputSelectionMode: inputSelectionMode,
+            captureNativeRateHz: nativeRate, captureNativeChannelCount: nativeChannels,
+            takeID: takeID))
+        recorder.timeline.append("vadGateNoSpeech")
+      },
       captureError: { error, category, stage, extra in
         recorder.captureErrors.append(
           Recorder.CaptureErrorCall(
@@ -713,13 +748,157 @@ import Testing
     let sink = makeSink(recorder: recorder)
     sink.emit(.noSpeech(.vadGate))
     // Round 2 item #15 restored OLD-TP:787-804's `mode`, `peak_audio_level`,
-    // `raw_sample_count` fields. Sink now emits the full sorted key set.
+    // `raw_sample_count` fields.
+    //
+    // #1845 CHANGED THIS EXPECTATION DELIBERATELY: with no `noSpeechTelemetry`
+    // stamped, `peak_audio_level` is now ABSENT rather than `0`. It used to be
+    // defaulted, which meant a take with no measurement was reported as having
+    // measured exact zero — the signature of a digitally dead channel. This
+    // assertion is the regression test for that removal: if the default ever
+    // returns, `peak_audio_level` reappears here and this fails.
     #expect(
       recorder.breadcrumbs == [
         .init(
           stage: "asr", message: "VAD gate: no speech detected, skipping ASR",
-          dataKeys: ["backend", "mode", "peak_audio_level", "raw_sample_count"])
+          dataKeys: ["backend", "mode", "raw_sample_count"])
       ])
+  }
+
+  // MARK: - #1845 `audio.vad_gate_no_speech`
+
+  /// The sink must emit the tally alongside the breadcrumb, carrying every value
+  /// the classifier and the frozen take state supplied.
+  @Test("#1845: .vadGate emits the tally with the frozen measurement and route")
+  func vadGateNoSpeechEmitsTally() {
+    let recorder = Recorder()
+    let state = KernelTelemetryState()
+    state.takeID = "take-1845"
+    state.noSpeechTelemetry = KernelNoSpeechTelemetry(
+      mode: "batch",
+      rawSampleCount: 16_000,
+      peakAudioLevel: 0.0007,
+      wholeBufferRMS: 0.0004,
+      maxWindowRMS: 0.0009,
+      effectiveTransport: "built_in",
+      selectedTransport: "unknown",
+      inputSelectionMode: "auto"
+    )
+    let sink = makeSink(recorder: recorder, telemetryState: state)
+
+    sink.emit(.noSpeech(.vadGate))
+
+    #expect(recorder.vadGateNoSpeechCalls.count == 1)
+    let call = try! #require(recorder.vadGateNoSpeechCalls.first)
+    #expect(call.mode == "batch")
+    #expect(call.rawSampleCount == 16_000)
+    #expect(call.peakAudioLevel == 0.0007)
+    #expect(call.wholeBufferRMS == 0.0004)
+    #expect(call.maxWindowRMS == 0.0009)
+    #expect(call.effectiveTransport == "built_in")
+    #expect(call.selectedTransport == "unknown")
+    #expect(call.inputSelectionMode == "auto")
+    // The take key must survive to the tally. The generic terminal postamble
+    // clears it, and only its placement AFTER the event-specific arm saves this.
+    // If that postamble is ever hoisted above the switch, this assertion fails
+    // rather than the property silently emptying.
+    #expect(call.takeID == "take-1845")
+  }
+
+  /// A missing measurement must arrive as `nil`, never as `0`. This is the
+  /// event's core correctness property: an exact zero is a real and highly
+  /// meaningful hardware observation, so absent data must not impersonate it.
+  @Test("#1845: an unmeasured take reports nil energy values, never zero")
+  func vadGateNoSpeechReportsNilNotZero() {
+    let recorder = Recorder()
+    let sink = makeSink(recorder: recorder)
+
+    sink.emit(.noSpeech(.vadGate))
+
+    let call = try! #require(recorder.vadGateNoSpeechCalls.first)
+    #expect(call.peakAudioLevel == nil, "a missing reading must not be emitted as exact zero")
+    #expect(call.wholeBufferRMS == nil)
+    #expect(call.maxWindowRMS == nil)
+    #expect(call.effectiveTransport == nil)
+  }
+
+  /// Exhaustive negative control. Every OTHER lifecycle event must leave the
+  /// tally untouched — a per-terminal spot check would miss whichever arm nobody
+  /// thought of, which is the failure mode `classify-by-producer-not-by-name`
+  /// exists to prevent.
+  @Test(
+    "#1845: no other lifecycle event emits the tally",
+    arguments: [
+      KernelLifecycleEvent.noSpeech(.asrEmptyNoSpeech),
+      .noSpeech(.emptyAfterProcessing),
+      .pipelineStartingUp,
+      .recordingCommitted(isStreaming: false),
+      .recordingStopped,
+      .transcriptionStarted,
+      .discarded(.tooShort),
+      .cancelled,
+      .pipelineCompleted,
+    ] as [KernelLifecycleEvent]
+  )
+  func vadGateNoSpeechDoesNotFireOnOtherEvents(event: KernelLifecycleEvent) {
+    let recorder = Recorder()
+    let sink = makeSink(recorder: recorder)
+
+    sink.emit(event)
+
+    #expect(
+      recorder.vadGateNoSpeechCalls.isEmpty,
+      "\(event) must not emit audio.vad_gate_no_speech")
+  }
+
+  /// The sink must not re-derive the route from LIVE capture state. The fake
+  /// reports its own live route; the frozen take route says something different;
+  /// the frozen one must win. This fails if the sink is ever changed to read
+  /// `audioCapture.currentResolvedRoute`.
+  @Test("#1845: the tally uses the frozen take route, not live capture state")
+  func vadGateNoSpeechPrefersFrozenRoute() {
+    let recorder = Recorder()
+    let state = KernelTelemetryState()
+    state.noSpeechTelemetry = KernelNoSpeechTelemetry(
+      mode: "batch",
+      rawSampleCount: 16_000,
+      peakAudioLevel: 0.0007,
+      effectiveTransport: "usb",
+      selectedTransport: "usb",
+      inputSelectionMode: "explicit"
+    )
+    let capture = FakeAudioCapture()
+    capture.liveResolvedRoute = ResolvedRouteTransports(
+      selected: "bluetooth", effective: "bluetooth", routeReason: "test",
+      routeFallbackReason: nil, inputSelectionMode: "auto", outputTransport: "unknown",
+      routeResolutionSource: "app_derived")
+    let sink = KernelLifecycleTelemetrySink(
+      backend: .parakeet,
+      audioCapture: capture,
+      context: KernelSessionContext(),
+      captureTelemetry: CaptureTelemetryState(),
+      telemetryState: state,
+      breadcrumb: { _, _, _ in },
+      updateTakeID: { _ in },
+      vadGateNoSpeech: {
+        backend, mode, rawSampleCount, peak, wholeRMS, maxWindowRMS, durationMs,
+        effectiveTransport, selectedTransport, inputSelectionMode, nativeRate, nativeChannels,
+        takeID in
+        recorder.vadGateNoSpeechCalls.append(
+          Recorder.VADGateNoSpeechCall(
+            backend: backend, mode: mode, rawSampleCount: rawSampleCount,
+            peakAudioLevel: peak, wholeBufferRMS: wholeRMS, maxWindowRMS: maxWindowRMS,
+            durationMs: durationMs, effectiveTransport: effectiveTransport,
+            selectedTransport: selectedTransport, inputSelectionMode: inputSelectionMode,
+            captureNativeRateHz: nativeRate, captureNativeChannelCount: nativeChannels,
+            takeID: takeID))
+      })
+
+    sink.emit(.noSpeech(.vadGate))
+
+    let call = try! #require(recorder.vadGateNoSpeechCalls.first)
+    #expect(call.effectiveTransport == "usb", "live capture route leaked into the tally")
+    #expect(call.selectedTransport == "usb")
+    #expect(call.inputSelectionMode == "explicit")
   }
 
   @Test(".noSpeech(.asrEmptyNoSpeech) emits the TP:902 breadcrumb (r7)")

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
@@ -106,7 +106,12 @@ final class FakeAudioCapture: AudioCaptureInterface {
   /// route captured at monitor start, not a later value. Default unchanged.
   var routeOverride: String = "fake"
   var currentAudioRoute: String { routeOverride }
-  var currentResolvedRoute: ResolvedRouteTransports? { nil }
+  /// #1845: settable so a test can make the LIVE route disagree with the take's
+  /// frozen route. Telemetry that reads this instead of the frozen snapshot is a
+  /// real defect (the live value can describe a later source by terminal time),
+  /// and it is only detectable if the two can be made to differ.
+  var liveResolvedRoute: ResolvedRouteTransports?
+  var currentResolvedRoute: ResolvedRouteTransports? { liveResolvedRoute }
 
   // MARK: #1714 — scripted input-resolution attribution
   //

--- a/scripts/telemetry-join.py
+++ b/scripts/telemetry-join.py
@@ -89,6 +89,7 @@ TAKE_KEYED_EVENTS = (
     "asr.completed",
     "audio.capture_interrupted",
     "audio.dead_mic_retire_attempted",
+    "audio.vad_gate_no_speech",
     "dictation.completed",
     "dictation.first_vad_chunk_completed",
     "dictation.first_vad_chunk_started",


### PR DESCRIPTION
Closes #1845. Epic #1876 Phase 1.

## The problem

A microphone that delivers no usable signal but not exact zeros — an analog mute switch, a dead 3.5 mm line — falls through both exact-match detectors and terminates at the VAD no-speech gate. That terminal wrote a Sentry breadcrumb and nothing else, and a breadcrumb is only visible when some OTHER event fires. A no-speech terminal fires none, so these takes have never been countable.

Measured on real hardware: muted analog peaks 0.0005–0.0010, unmuted silent room 0.0170–0.0930, 23/23 separation.

## What ships

**`audio.vad_gate_no_speech`**, emitted from the existing `.vadGate` arm of `KernelLifecycleTelemetrySink` as a closure-injected sink sharing ONE computation with the breadcrumb already there. Two records, one set of values, so they cannot describe the same take differently.

Fourteen properties: backend, mode, raw_sample_count, peak_audio_level, whole_buffer_rms, max_window_rms, duration_ms, effective_transport, selected_transport, input_selection_mode, **input_device_kind**, capture_native_rate_hz, capture_native_channel_count, take_id.

## Three decisions worth reading

**Renamed from the issue's `audio.dead_air_no_speech`.** "Dead air" asserts a physical cause we cannot prove. The app knows the audio was below every energy floor, not that a microphone was muted or dead, and a hardware mute switch is frequently invisible to the host by design. A shipped event name is permanent in the analytics history.

**`peak_audio_level` is omit-when-nil and NEVER defaulted to 0.** An exact zero is the signature of a digitally dead channel (#1809), so defaulting a missing reading would manufacture the most diagnostically loaded value in the dataset and make absent data indistinguishable from the finding this event exists to detect. The pre-existing `?? 0` on the breadcrumb is removed for the same reason, and its test now asserts ABSENCE — that assertion is the regression test for the removal. Same principle one layer down: `RawAudioDeadAirClassifier.measure` returns `nil` for any RMS a short circuit skipped.

**`input_device_kind` exists because transport alone was not enough.** `effective_transport` reports `built_in` for BOTH the internal microphone and a microphone in the 3.5 mm jack, since macOS routes the jack through the same codec — and the jack case is exactly the population this issue targets. Measured live: `BuiltInMicrophoneDevice` vs `BuiltInHeadphoneInputDevice`, both Apple-fixed constants naming a port. Mapped to `built_in_mic` / `jack_input`, giving four distinct input classes.

The raw `deviceUID` stays permanently unemittable: the USB form embeds the unit serial, the Bluetooth form IS the peer MAC. `BuiltInInputKindTests` asserts the emitted value is one of exactly two constants and never echoes a serial or MAC from its input, so a future "pass the UID through" refactor fails loudly.

Device MODEL was considered and declined on VALUE, not privacy (founder, 2026-07-31).

## Scope limit, stated because the number will be quoted

**This counts ONE of three empty-take exits.** `noAudioCaptured` (`:1614`) and `zeroSignal` (`:1730`) leave earlier and are not included. Any "how often does a microphone deliver no usable signal" figure is the union of three, and defining it is Phase 2's first task. Epic #1876's definition of done says so.

Observed live during UAT: one muted headset produced `noSpeech(vadGate)` on one take and `zeroSignal` on four others, giving the user two different messages for one physical fault. That is the argument for Phase 2 shipping one family-wide sentence rather than a message per exit path.

## A test caught a real regression, and the fix went to the cause

The first implementation read `zeroSignalDiscriminatorDevice?.deviceUID` at the classifier site. `KernelFrozenBindGuardTests` failed: that accessor participates in the #1844/#1578 zero-signal decision and its read ORDER is a tested contract — a run already classified reactively must short-circuit BEFORE the bind is consulted, so a device whose live state has since recovered cannot flip an already-correct refusal. A telemetry read is innocent in intent and indistinguishable from a decision read in effect.

The label is now derived ONCE in `AudioCaptureManager.adoptBoundState`, the single place the manager adopts post-bind facts, and stored. Nothing re-reads the bind. Loosening the test would have removed a guard protecting a real invariant.

## Verification

- Full suite **4,676 tests**, TEST SUCCEEDED
- New: `RawAudioDeadAirMeasurementTests` (7), `BuiltInInputKindTests` (5); `KernelLifecycleTelemetrySinkTests` 68 including an exhaustive negative control across 9 lifecycle events
- Two-way control on the classifier: injecting `nil` → `0` on the above-peak short circuit made the named test fail, then reverted to green
- `EnviousWispr-Release` builds; both standalone eval packages build in Release against the root lockfile (#1836 CI mirror)
- Two local whole-diff Codex reviews, both clean
- **Live UAT on the dev build**: `audio.vad_gate_no_speech` reached PostHog under `environment=development` with all fourteen properties populated and values matching the app log exactly (peak `0.000243…`, transport `usb`, take key joined to `dictation.invoked`). Negative control: zero emissions on a normal dictation, with a positive control proving the instrument worked on the same log slice.

## Also in this PR

`scripts/telemetry-join.py` gains the event in `TAKE_KEYED_EVENTS` — it carries `take_id`, and that list is the authority the join instrument reads, so an unregistered event would be silently absent from every coverage report.
