### PR TITLE
feat(ui): tell users to check the microphone instead of retrying (Closes #1891)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/BackendMetadata.swift
+++ b/Sources/EnviousWisprAppKit/App/BackendMetadata.swift
@@ -68,6 +68,9 @@ final class BackendMetadata {
       case .transcribing: return DictationNarrator.shortCopy(for: .transcribing)
       case .polishing: return DictationNarrator.shortCopy(for: .polishing)
       case .error: return DictationNarrator.errorStatus
+      // #1891: `.advisory` deliberately falls through to the engine-health
+      // label ("Loaded" / "Unloaded") rather than showing "Error" in the
+      // sidebar. The microphone sent nothing; the engine is fine.
       default: break
       }
     } else {

--- a/Sources/EnviousWisprAppKit/App/DictationNarrator.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationNarrator.swift
@@ -108,6 +108,32 @@ enum DictationNarrator {
     }
   }
 
+  /// #1891 (epic #1876 Phase 2b) — THE SEVENTH SENTENCE, founder-approved
+  /// verbatim 2026-07-31. Do not reword without a founder decision: #1558
+  /// locked the six, and this adds exactly one.
+  ///
+  /// It is a PLAIN SENTENCE, not `[Category] error. Try again.`, and that is
+  /// the whole point. Under the design rule at the top of this file the error
+  /// form means "our bug, just retry" — which is false here and, worse,
+  /// sends the user to do the one thing that cannot help. Capture worked. It
+  /// recorded exactly what the microphone sent, which was nothing usable.
+  ///
+  /// Both reasons share one sentence deliberately: the user cannot act on the
+  /// difference between a digitally silent channel and a signal floor below
+  /// every dead-air threshold, and the founder's model gives capture endings
+  /// exactly two customer buckets rather than one per cause.
+  ///
+  /// The three causes are offered with "may" because we genuinely cannot tell
+  /// them apart from the samples, and the app never claims a mute it cannot
+  /// substantiate (#1876 product decision 1).
+  static func copy(for reason: TerminalAdvisoryReason) -> String {
+    switch reason {
+    case .zeroSignal, .vadGateNoSpeech:
+      return
+        "Audio isn't capturing. Your lid may be closed, your headset muted, or there may be a hardware issue. Please check your microphone settings."
+    }
+  }
+
   // MARK: - Post-completion + advisory warnings (E3, #1567)
 
   /// Founder-LOCKED 2026-07-15. Unchanged from today EXCEPT two approved
@@ -165,6 +191,10 @@ enum DictationNarrator {
     case .accessibilityToast: return "Accessibility permission needed for auto-paste"
     case .warning(let reason): return "Warning: \(copy(for: reason))"
     case .error(let reason): return "Error: \(copy(for: reason))"
+    // #1891: NO "Error: " prefix. A screen-reader user would otherwise hear
+    // the exact opposite of what the sentence says. This arm is the reason the
+    // advisory is a separate intent rather than a suppression flag on `.error`.
+    case .advisory(let reason): return copy(for: reason)
     case .interruption(let reason): return "Interruption: \(copy(for: reason))"
     case .passiveChip(let payload): return "Detected \(payload.displayName)"
     case .cachingModel(engineLabel: _): return "Getting dictation ready, one moment"

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
@@ -264,7 +264,8 @@ final class DictationLifecycleCoordinator {
     case .loadingModel, .transcribing, .polishing:
       recordingLockedAccess.set(false)
       hotkeyService.unregisterCancelHotkey()
-    case .error, .idle, .complete:
+    // #1891: an advisory is a concluded terminal — same teardown as any ending.
+    case .error, .idle, .complete, .advisory:
       recordingLockedAccess.set(false)
       hotkeyService.unregisterCancelHotkey()
       // Session ended — retry any Ollama eviction deferred because the
@@ -344,7 +345,8 @@ final class DictationLifecycleCoordinator {
     case .loadingModel, .transcribing, .polishing:
       recordingLockedAccess.set(false)
       hotkeyService.unregisterCancelHotkey()
-    case .error, .idle, .complete:
+    // #1891: an advisory is a concluded terminal — same teardown as any ending.
+    case .error, .idle, .complete, .advisory:
       recordingLockedAccess.set(false)
       hotkeyService.unregisterCancelHotkey()
       settingsSync.retryDeferredOllamaEviction(settings: settings)
@@ -403,7 +405,10 @@ final class DictationLifecycleCoordinator {
       } else {
         languageSuggestionPresenter?.clearBuffer()
       }
-    case .error:
+    // #1891: an advisory is a terminal with no transcript, like `.error`, so it
+    // must clear a stale chip too. Found by sweeping `default` arms — the
+    // compiler could not flag this one.
+    case .error, .advisory:
       languageSuggestionPresenter?.clearCurrentChip()
       languageSuggestionPresenter?.clearBuffer()
     default:

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingSoundCue.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingSoundCue.swift
@@ -74,7 +74,10 @@ struct RecordingSoundCue {
       // code-diff review r3).
       guard playback(selectedPairing, .start) else { return }
       activePairingByBackend[backend] = selectedPairing
-    case .idle, .loadingModel, .transcribing, .polishing, .complete, .error:
+    // #1891: an advisory means the recording ended, so it plays the stop cue
+    // exactly like every other non-recording state.
+    case .idle, .loadingModel, .transcribing, .polishing, .complete, .error,
+      .advisory:
       guard let pairing = activePairingByBackend.removeValue(forKey: backend) else { return }
       _ = playback(pairing, .stop)
     }

--- a/Sources/EnviousWisprAppKit/App/DictationSessionConfigFactory.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationSessionConfigFactory.swift
@@ -26,10 +26,17 @@ enum DictationSessionConfigFactory {
     // (WhisperKit-only) maps to `.idle` in the kernel driver's state mapping.
     let active: KernelDictationDriver =
       asrManager.activeBackendType == .whisperKit ? whisperKitKernelDriver : kernelDriver
+    // #1891: EXHAUSTIVE on purpose — the previous `default: return false` made
+    // this the one consumer the compiler could not flag. Adding `.advisory`
+    // without this line would have silently disabled auto-paste on the NEXT
+    // take: the user fixes their muted microphone, dictates successfully, and
+    // the text never lands. That is a heart-path regression hiding behind a
+    // green build and a green test suite. A future state must fail to compile
+    // here rather than quietly opt out of pasting.
     let activePipelineIdle: Bool = {
       switch active.state {
-      case .idle, .complete, .error: return true
-      default: return false
+      case .idle, .complete, .error, .advisory: return true
+      case .loadingModel, .recording, .transcribing, .polishing: return false
       }
     }()
     // #500: drop the legacy `permissions.hasAccessibilityPermission` gate so the

--- a/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
@@ -407,6 +407,18 @@ final class RecordingOverlayPanel {
           .priority: NSAccessibilityPriorityLevel.high.rawValue as NSNumber,
         ])
       showError(message: message)
+    // #1891: a user-setup advisory, announced WITHOUT an "Error: " prefix (the
+    // narrator owns that) and rendered in the non-red multiline style.
+    case .advisory(let reason):
+      let message = DictationNarrator.copy(for: reason)
+      NSAccessibility.post(
+        element: NSApp.mainWindow as Any,
+        notification: .announcementRequested,
+        userInfo: [
+          .announcement: spokenAnnouncement,
+          .priority: NSAccessibilityPriorityLevel.high.rawValue as NSNumber,
+        ])
+      showAdvisory(message: message)
     case .interruption(let reason):
       let message = DictationNarrator.copy(for: reason)
       NSAccessibility.post(
@@ -812,6 +824,13 @@ final class RecordingOverlayPanel {
     showNotification(message: message, style: .error)
   }
 
+  /// #1891: show a user-setup advisory. Wider and taller than the other
+  /// notices because it carries a full sentence, and it dwells long enough to
+  /// read that sentence.
+  func showAdvisory(message: String) {
+    showNotification(message: message, style: .advisory)
+  }
+
   /// Unified handler for transient notification overlays (errors and warnings).
   private func showNotification(message: String, style: NotificationStyle) {
     guard panel == nil else {
@@ -827,16 +846,27 @@ final class RecordingOverlayPanel {
     let work = DispatchWorkItem { [weak self] in
       guard let self, self.generation == token else { return }
       self.pendingCreateWork = nil
-      self.showPanel(
-        content: NotificationOverlayView(message: message, style: style).frame(
-          width: 280, height: 44),
-        width: 280
-      )
+      // #1891: the advisory sizes to its content; every other notice keeps the
+      // fixed 280x44 box unchanged.
+      let width: CGFloat = style.isMultiline ? Self.advisoryWidth : 280
+      let content =
+        style.isMultiline
+        ? AnyView(
+          NotificationOverlayView(message: message, style: style)
+            .frame(width: width))
+        : AnyView(
+          NotificationOverlayView(message: message, style: style)
+            .frame(width: 280, height: 44))
+      self.showPanel(content: content, width: width, fitToContent: style.isMultiline)
       self.scheduleAutoDismiss(seconds: style.autoDismissSeconds)
     }
     pendingCreateWork = work
     DispatchQueue.main.async(execute: work)
   }
+
+  /// #1891: wider than the 280pt notice box so the advisory sentence wraps to a
+  /// readable number of lines instead of a narrow column.
+  static let advisoryWidth: CGFloat = 360
 
   /// Transition an existing panel to a notification display.
   private func transitionToNotification(message: String, style: NotificationStyle) {
@@ -857,12 +887,21 @@ final class RecordingOverlayPanel {
     let work = DispatchWorkItem { [weak self] in
       guard let self, self.generation == token else { return }
       self.pendingCreateWork = nil
+      // #1891: mirror the create path exactly. A notice inherited from a
+      // recording panel must not be silently clipped back to 280x44 — the twin
+      // site is where this class of defect hides
+      // (workflow-process.md RULE: port-proven-patterns-wholesale).
+      let width: CGFloat = style.isMultiline ? Self.advisoryWidth : 280
+      let content =
+        style.isMultiline
+        ? AnyView(
+          NotificationOverlayView(message: message, style: style).frame(width: width))
+        : AnyView(
+          NotificationOverlayView(message: message, style: style)
+            .frame(width: 280, height: 44))
       self.showPanel(
-        content: NotificationOverlayView(message: message, style: style).frame(
-          width: 280, height: 44),
-        width: 280,
-        inheritedFrame: inheritedFrame
-      )
+        content: content, width: width, inheritedFrame: inheritedFrame,
+        fitToContent: style.isMultiline)
     }
     pendingCreateWork = work
     DispatchQueue.main.async(execute: work)
@@ -1764,12 +1803,16 @@ enum NotificationStyle {
   case error
   case warning
   case interruption
+  /// #1891: a user-setup advisory. Not a failure of ours, so it does not
+  /// borrow the red failure treatment.
+  case advisory
 
   var iconName: String {
     switch self {
     case .error: "xmark.circle.fill"
     case .warning: "exclamationmark.triangle.fill"
     case .interruption: ""  // uses distress lips, not SF Symbol
+    case .advisory: "mic.slash.fill"
     }
   }
 
@@ -1778,6 +1821,10 @@ enum NotificationStyle {
     case .error: .red
     case .warning: .orange
     case .interruption: .red
+    // #1891: deliberately not red. The glyph carries the meaning, so the state
+    // is never signalled by colour alone (accessibility-macos.md
+    // RULE: accessibility-macos-baseline, accessibility-noncolor-motion).
+    case .advisory: .secondary
     }
   }
 
@@ -1786,7 +1833,17 @@ enum NotificationStyle {
     case .error: 3.0
     case .warning: 2.5
     case .interruption: 2.0
+    // #1891: the advisory sentence is ~23 words. At roughly 200 wpm that needs
+    // about 7 seconds to read, so the 3.0s error dwell would show a message
+    // the user physically cannot finish. 8s, confirmed by reading UAT.
+    case .advisory: 8.0
     }
+  }
+
+  /// #1891: only the advisory wraps and sizes to its content. Every other
+  /// notice is a short single line in a fixed 280x44 box and stays that way.
+  var isMultiline: Bool {
+    self == .advisory
   }
 
   var usesDistressLips: Bool {
@@ -1814,7 +1871,12 @@ struct NotificationOverlayView: View {
       Text(message)
         .font(.system(size: 13, weight: .medium))
         .foregroundStyle(style.usesDistressLips ? Color.orange : .white)
-        .lineLimit(1)
+        // #1891: `.lineLimit(1)` in a 280pt box truncates the advisory sentence
+        // to a fragment. Only the advisory wraps; every other notice keeps its
+        // single-line shape exactly as before.
+        .lineLimit(style.isMultiline ? nil : 1)
+        .fixedSize(horizontal: false, vertical: style.isMultiline)
+        .multilineTextAlignment(.leading)
     }
     .padding(.horizontal, 14)
     .padding(.vertical, 10)

--- a/Sources/EnviousWisprAppKit/Views/Main/MainWindowView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/MainWindowView.swift
@@ -180,6 +180,19 @@ struct StatusView: View {
             dictationRuntime.resetActivePipeline()
           }
         }
+
+      // #1891: deliberately NO "Try Again" button and NO "Error" heading.
+      // Retrying cannot change the outcome when the microphone sent nothing,
+      // and offering it is the specific defect this change exists to remove.
+      // A mic-slash glyph rather than the error triangle, so the state is not
+      // signalled by colour alone (accessibility-macos.md
+      // RULE: accessibility-macos-baseline, accessibility-noncolor-motion).
+      case .advisory(let reason):
+        ContentUnavailableView {
+          Label("No audio captured", systemImage: "mic.slash")
+        } description: {
+          Text(DictationNarrator.copy(for: reason))
+        }
       }
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -305,7 +318,10 @@ struct StatusBadge: View {
       case .polishing:
         progressLabel(DictationNarrator.statusBadgeCopy(for: .polishing))
 
-      case .idle, .complete, .error:
+      // #1891: advisory is a resting terminal like idle/complete/error, so the
+      // toolbar badge stays empty. The sentence is carried by the overlay and
+      // the main-window body, not duplicated in the toolbar.
+      case .idle, .complete, .error, .advisory:
         EmptyView()
       }
     }

--- a/Sources/EnviousWisprCore/AppSettings.swift
+++ b/Sources/EnviousWisprCore/AppSettings.swift
@@ -22,6 +22,11 @@ public enum PipelineState: Equatable, Sendable {
   case polishing
   case complete
   case error(TerminalNoticeReason)
+  /// #1891: a terminal the user can act on that is NOT our failure — the
+  /// microphone delivered nothing usable. Separate from `.error` because
+  /// `.error` drags a Try Again button, a red menu-bar state, a red sidebar
+  /// dot and a VoiceOver "Error: " prefix, all of which contradict the fact.
+  case advisory(TerminalAdvisoryReason)
 
   public var isActive: Bool {
     switch self {
@@ -45,6 +50,13 @@ public enum PipelineState: Equatable, Sendable {
     case .polishing: return "polishing"
     case .complete: return "complete"
     case .error: return "error"
+    // #1891: DELIBERATELY "error", not a new label. This feeds `app_phase` on
+    // `telemetry.flush_requested`; a new value would change that series'
+    // vocabulary at a version boundary, which is the exact trap #1813 hit
+    // (analytics-operations.md RULE: enum-backed-properties-carry-retired-
+    // vocabularies-split-by-version). The customer-facing split is a
+    // presentation decision and does not belong in a telemetry phase label.
+    case .advisory: return "error"
     }
   }
 

--- a/Sources/EnviousWisprCore/PipelineStateProtocol.swift
+++ b/Sources/EnviousWisprCore/PipelineStateProtocol.swift
@@ -13,6 +13,11 @@ public enum PipelineActivity: Equatable, Sendable {
   case processing
   case complete
   case error(TerminalNoticeReason)
+  /// #1891: a user-actionable terminal that is not our failure. Kept distinct
+  /// from `.error` so control-flow consumers can opt in explicitly rather than
+  /// inherit error treatment (a Try Again button, red menu bar, red sidebar
+  /// dot, VoiceOver "Error: " prefix).
+  case advisory(TerminalAdvisoryReason)
 }
 
 /// Narrow protocol the planner / handler consume. Backends' concrete enums
@@ -37,6 +42,7 @@ extension PipelineState: PipelineStateProtocol {
     case .transcribing, .polishing: return .processing
     case .complete: return .complete
     case .error(let reason): return .error(reason)
+    case .advisory(let reason): return .advisory(reason)
     }
   }
 }

--- a/Sources/EnviousWisprCore/TerminalNoticeReason.swift
+++ b/Sources/EnviousWisprCore/TerminalNoticeReason.swift
@@ -56,3 +56,44 @@ public enum TerminalNoticeReason: String, Equatable, Sendable, CaseIterable {
   /// enum case; any future explicit producer must own its own telemetry first.
   case unknown
 }
+
+/// #1891 (epic #1876 Phase 2b). A terminal fact that is NOT our software
+/// failing: the microphone delivered nothing usable, so the take ended with no
+/// text through no fault of the pipeline.
+///
+/// Deliberately a SEPARATE type from `TerminalNoticeReason`, not another case
+/// on it. `TerminalNoticeReason` means "a terminal notice whose raw value is
+/// the PostHog `pipeline.failed.error_code`", and both halves are wrong here:
+/// only one of these two reasons emits `pipeline.failed` at all, and the
+/// founder's model (#1876, 2026-07-31) splits capture endings into exactly two
+/// customer buckets — OUR SOFTWARE ("[X] error. Try again.") and YOUR SETUP.
+/// This type is the second bucket.
+///
+/// Two cases rather than one because the two producers have different
+/// telemetry obligations even though they share a sentence: `.zeroSignal`
+/// continues the existing `pipeline.failed` `zero_signal` series (340 events /
+/// 50 users per 30d — the baseline the Phase 2 analysis rests on), while
+/// `.vadGateNoSpeech` is already counted by `audio.vad_gate_no_speech` (#1845)
+/// and must NOT manufacture a second, overlapping failure record.
+///
+/// Both narrate identically. Do not add a per-case sentence without a founder
+/// decision: #1558 locked the customer copy set, and #1891 added exactly one
+/// seventh sentence to it.
+public enum TerminalAdvisoryReason: Equatable, Sendable, CaseIterable {
+  /// The capture buffer was digitally silent — a closed lid in clamshell,
+  /// vendor firmware mute, or a dead channel. Reaches here from
+  /// `RecordingOutcome.failed(.zeroSignal)`; keeps emitting `pipeline.failed`
+  /// with the unchanged `zero_signal` code.
+  case zeroSignal
+
+  /// The capture carried a signal floor but no speech evidence: every dead-air
+  /// threshold was crossed (raw peak `<0.006`, whole-buffer RMS `<0.00125`,
+  /// max 40 ms window RMS `<0.002`). An analog mute switch or a dead 3.5 mm
+  /// line looks like this — an ADC keeps converting a broken line, so it can
+  /// never read exact zero. Reaches here from `.noSpeech(.vadGate)`.
+  ///
+  /// NOT the same as a user who simply said nothing: that is
+  /// `.asrEmptyNoSpeech`, which stays silent because the microphone was
+  /// working and the user already knows they did not speak.
+  case vadGateNoSpeech
+}

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -1027,6 +1027,12 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
     // (state has returned to `.idle`, #1548 D1). The ending pill reads from the
     // outcome, not an FSM terminal state.
     if let outcome = kernel.recordingOutcome {
+      // #1891: same classifier as the `state` projection above. These are two
+      // INDEPENDENT projections — the original design changed only the other
+      // one and would have displayed nothing at all.
+      if let advisory = Self.advisoryReason(for: outcome) {
+        return .advisory(reason: advisory)
+      }
       switch outcome {
       case .completed, .cancelled, .discarded, .noSpeech:
         return .hidden
@@ -1601,6 +1607,53 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   // `RecordingOutcome` / `DeliveringPhase` types. No App-layer caller exists
   // (only same-module `state` getter + `@testable` tests); the App reads the
   // public `state` getter's `PipelineState` (#1548 D1, §2.5).
+  /// #1891 — the SINGLE authority deciding whether a concluded take is a
+  /// user-setup advisory rather than our failure. Called by BOTH the public
+  /// `state` projection and `overlayIntent`, which is the whole point: those
+  /// are independent projections, and an earlier design that changed only one
+  /// of them would have updated the state and displayed nothing.
+  ///
+  /// Exhaustive on purpose — no `default` anywhere. A future `RecordingOutcome`
+  /// or `RecordingFailureReason` case must fail the build and be classified
+  /// deliberately. Silence is the right ANSWER for unrelated outcomes; letting
+  /// them inherit it without a decision is not.
+  ///
+  /// Founder model (#1876, 2026-07-31): capture endings get exactly two
+  /// customer buckets, OUR SOFTWARE and YOUR SETUP. Only the two cases below
+  /// are the second bucket. `.captureStalled` (a mid-take death) deliberately
+  /// stays our-software until #1578 telemetry explains it — calling it the
+  /// user's setup would be a guess.
+  /// `nonisolated` because it is a pure function of the outcome value and
+  /// touches no driver state. Both projections call it, and keeping it off the
+  /// main actor means the truth table can be tested directly.
+  nonisolated static func advisoryReason(for outcome: RecordingOutcome)
+    -> TerminalAdvisoryReason?
+  {
+    switch outcome {
+    case .failed(let reason):
+      switch reason {
+      case .zeroSignal:
+        return .zeroSignal
+      case .prepareFailed, .permissionDenied, .modelWedged, .modelLoadFailed,
+        .captureStartFailed, .noMicrophoneFound, .noAudioCaptured, .asrEmpty,
+        .asrFailed, .asrWedged, .emptyAfterProcessing, .captureStalled:
+        return nil
+      }
+    case .noSpeech(let source):
+      switch source {
+      case .vadGate:
+        return .vadGateNoSpeech
+      // A working microphone and a user who said nothing. Stays SILENT — they
+      // already know they did not speak (founder, 2026-07-31).
+      case .asrEmptyNoSpeech, .emptyAfterProcessing:
+        return nil
+      }
+    case .completed, .cancelled, .discarded, .audioInterrupted,
+      .asrInterrupted, .noTransport:
+      return nil
+    }
+  }
+
   static func pipelineState(
     for state: RecordingSessionState,
     outcome: RecordingOutcome?,
@@ -1614,6 +1667,12 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
     // A concluded session's public state comes from `recordingOutcome` (state
     // has returned to `.idle`, #1548 D1).
     if let outcome {
+      // #1891: the advisory classification wins over the error mapping below,
+      // so `.failed(.zeroSignal)` and `.noSpeech(.vadGate)` present identically
+      // instead of one being an error and the other silent.
+      if let advisory = advisoryReason(for: outcome) {
+        return .advisory(advisory)
+      }
       switch outcome {
       case .completed:
         return .complete

--- a/Sources/EnviousWisprPipeline/PipelineStateChangePlanner.swift
+++ b/Sources/EnviousWisprPipeline/PipelineStateChangePlanner.swift
@@ -200,6 +200,21 @@ enum PipelineStateChangePlanner {
     if case .error(let reason) = newState.activity {
       effects.append(.reportPipelineFailed(errorCode: reason.rawValue))
     }
+    // #1891: `.zeroSignal` moved from `.error` to `.advisory` for PRESENTATION
+    // only. Its telemetry must not move with it — `zero_signal` is an existing
+    // series (340 events / 50 users per 30d) and the baseline the whole Phase 2
+    // analysis rests on, so it keeps emitting under its unchanged code.
+    // Splitting or renaming it would be the #1813 retired-vocabulary trap,
+    // self-inflicted.
+    //
+    // `.vadGateNoSpeech` emits NOTHING here on purpose: it is already counted
+    // by `audio.vad_gate_no_speech` (#1845), and a second record would both
+    // double-count that population and inflate total `pipeline.failed` volume
+    // with takes that were never a pipeline failure.
+    if case .advisory(.zeroSignal) = newState.activity {
+      effects.append(
+        .reportPipelineFailed(errorCode: TerminalNoticeReason.zeroSignal.rawValue))
+    }
 
     return PipelineStateChangePlan(effects: effects)
   }

--- a/Sources/EnviousWisprPipeline/PipelineVocabulary.swift
+++ b/Sources/EnviousWisprPipeline/PipelineVocabulary.swift
@@ -98,6 +98,16 @@ public enum OverlayIntent: Equatable, Sendable {
   /// #1558: carries a TYPED reason; `DictationNarrator` authors the
   /// sentence. Auto-dismissed by the overlay panel after 3 seconds.
   case error(reason: TerminalNoticeReason)
+  /// #1891 (epic #1876 Phase 2b). A user-setup advisory: the microphone
+  /// delivered nothing usable, so there is no text — and that is NOT our
+  /// software failing. Deliberately not `.error`, which carries a red
+  /// `xmark.circle.fill`, a 3-second dismissal too short to read this
+  /// sentence, a main-window "Error" heading with a Try Again button, a red
+  /// menu-bar state and a VoiceOver "Error: " prefix. Every one of those
+  /// contradicts the fact and sends the user to retry something that cannot
+  /// work. `DictationNarrator` authors the sentence; the panel renders it
+  /// multiline with a content-driven height and a dwell long enough to read.
+  case advisory(reason: TerminalAdvisoryReason)
   /// Transient interruption notice shown when the recording was cut short
   /// (device removed, or engine lost with the mic still attached). #1558:
   /// carries a TYPED reason. Distress lips (red pulse), auto-dismissed after 2 seconds.

--- a/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverTests.swift
@@ -46,7 +46,18 @@ import Testing
     #expect(mappedOutcome(.completed) == .complete)
     #expect(mappedOutcome(.cancelled) == .idle)
     #expect(mappedOutcome(.discarded(.tooShort)) == .idle)
-    #expect(mappedOutcome(.noSpeech(.vadGate)) == .idle)
+    // #1891: the VAD-gate no-speech ending NO LONGER collapses to idle. A
+    // microphone that delivered a dead signal floor now surfaces the seventh
+    // sentence as a user-setup advisory instead of vanishing silently.
+    #expect(mappedOutcome(.noSpeech(.vadGate)) == .advisory(.vadGateNoSpeech))
+    // The other two no-speech sources STAY silent — these are a working
+    // microphone and a user who said nothing, and they already know that
+    // (founder ruling, 2026-07-31). Without these two arms an advisory that
+    // fired on every no-speech source would pass the assertion above.
+    #expect(mappedOutcome(.noSpeech(.asrEmptyNoSpeech)) == .idle)
+    #expect(mappedOutcome(.noSpeech(.emptyAfterProcessing)) == .idle)
+    // #1891: zero-signal moved out of the error surface for the same reason.
+    #expect(mappedOutcome(.failed(.zeroSignal)) == .advisory(.zeroSignal))
     // Error-surface endings.
     for o: RecordingOutcome in [
       .failed(.asrEmpty), .audioInterrupted(nil), .asrInterrupted(wasRecording: true),

--- a/Tests/EnviousWisprTests/Pipeline/TerminalAdvisoryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TerminalAdvisoryTests.swift
@@ -1,0 +1,125 @@
+import EnviousWisprCore
+import Testing
+
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprPipeline
+
+/// #1891 (epic #1876 Phase 2b). Freezes the seventh sentence and the routing
+/// that reaches it.
+///
+/// Every test here has a NEGATIVE arm. A classifier that returned an advisory
+/// for everything, or a projection that fired on every no-speech source, would
+/// pass the positive assertions alone while silencing correct behaviour
+/// elsewhere — the exact shape `verify-the-feature-not-the-crash` warns about.
+@Suite struct TerminalAdvisoryTests {
+
+  // MARK: - The classifier: one authority, both projections
+
+  @Test("only zeroSignal and vadGate no-speech are advisories")
+  func classifierTruthTable() {
+    // POSITIVE — the two endings the founder decision covers.
+    #expect(
+      KernelDictationDriver.advisoryReason(for: .failed(.zeroSignal)) == .zeroSignal)
+    #expect(
+      KernelDictationDriver.advisoryReason(for: .noSpeech(.vadGate)) == .vadGateNoSpeech)
+
+    // NEGATIVE — a working microphone and a user who said nothing. These stay
+    // SILENT by founder ruling: they already know they did not speak.
+    #expect(KernelDictationDriver.advisoryReason(for: .noSpeech(.asrEmptyNoSpeech)) == nil)
+    #expect(KernelDictationDriver.advisoryReason(for: .noSpeech(.emptyAfterProcessing)) == nil)
+
+    // NEGATIVE — genuinely our software. These keep "Audio capture error.
+    // Try again." `.captureStalled` is here deliberately: the mid-take death
+    // stays our-fault until #1578 telemetry explains it.
+    for reason: RecordingFailureReason in [
+      .prepareFailed, .permissionDenied, .modelWedged, .modelLoadFailed,
+      .captureStartFailed, .noMicrophoneFound, .noAudioCaptured, .asrEmpty,
+      .asrFailed, .asrWedged, .emptyAfterProcessing, .captureStalled,
+    ] {
+      #expect(
+        KernelDictationDriver.advisoryReason(for: .failed(reason)) == nil,
+        "\(reason) must not become an advisory")
+    }
+
+    // NEGATIVE — non-failure terminals.
+    #expect(KernelDictationDriver.advisoryReason(for: .completed) == nil)
+    #expect(KernelDictationDriver.advisoryReason(for: .cancelled) == nil)
+    #expect(KernelDictationDriver.advisoryReason(for: .discarded(.tooShort)) == nil)
+    #expect(KernelDictationDriver.advisoryReason(for: .discarded(.releasedBeforeRecording)) == nil)
+    #expect(KernelDictationDriver.advisoryReason(for: .noTransport) == nil)
+  }
+
+  // MARK: - The copy
+
+  @Test("the seventh sentence is byte-exact and shared by both reasons")
+  func seventhSentenceIsFrozen() {
+    let expected =
+      "Audio isn't capturing. Your lid may be closed, your headset muted, or there may be a hardware issue. Please check your microphone settings."
+    for reason in TerminalAdvisoryReason.allCases {
+      #expect(DictationNarrator.copy(for: reason) == expected)
+    }
+  }
+
+  @Test("the advisory is a plain sentence, never the our-fault retry form")
+  func advisoryNeverClaimsOurBug() {
+    // The house rule (#1558): "[Category] error. Try again." means OUR bug.
+    // This sentence must never adopt that form — saying it would both blame
+    // ourselves falsely and send the user to do the one thing that cannot work.
+    for reason in TerminalAdvisoryReason.allCases {
+      let copy = DictationNarrator.copy(for: reason)
+      #expect(!copy.contains("Try again."))
+      #expect(!copy.contains("error."))
+      // Rule 6: no em-dashes or en-dashes in user-facing copy.
+      #expect(!copy.contains("\u{2014}"))
+      #expect(!copy.contains("\u{2013}"))
+    }
+  }
+
+  // MARK: - VoiceOver
+
+  @Test("VoiceOver announces the advisory with no Error prefix")
+  func advisoryHasNoErrorPrefix() {
+    let spoken = DictationNarrator.announcement(for: .advisory(reason: .vadGateNoSpeech))
+    #expect(spoken == DictationNarrator.copy(for: .vadGateNoSpeech))
+    #expect(!spoken.hasPrefix("Error:"))
+
+    // TWO-WAY CONTROL: a real error must STILL be prefixed. Without this arm a
+    // change that dropped the prefix everywhere would pass the assertion above.
+    let errorSpoken = DictationNarrator.announcement(for: .error(reason: .asrFailed))
+    #expect(errorSpoken.hasPrefix("Error:"))
+  }
+
+  // MARK: - The state contract
+
+  @Test("advisory is inactive and keeps the error telemetry phase label")
+  func advisoryStateContract() {
+    for reason in TerminalAdvisoryReason.allCases {
+      let state = PipelineState.advisory(reason)
+      // Recording controls must stay enabled — an advisory is a resting
+      // terminal, not work in progress.
+      #expect(state.isActive == false)
+      // DELIBERATELY "error": this feeds `app_phase` on
+      // `telemetry.flush_requested`, and a new value would change that series'
+      // vocabulary at a version boundary (#1813's trap).
+      #expect(state.telemetryLabel == "error")
+      #expect(state.activity == .advisory(reason))
+    }
+  }
+
+  // MARK: - The dead mapping, documented rather than left as a trap
+
+  @Test("no producer routes zeroSignal to the old error sentence any more")
+  func zeroSignalNoLongerNarratesAsCaptureError() {
+    // `TerminalNoticeReason.zeroSignal` still exists and its rawValue is still
+    // the LIVE PostHog `zero_signal` code — that series must not break. But
+    // after #1891 no code path produces `.error(.zeroSignal)`: the outcome now
+    // classifies as an advisory first, and every `setTerminalReason` caller
+    // passes permissionDenied / noMicrophoneFound / micWouldNotOpen /
+    // modelWedged / asrInterrupted or an interruption cause.
+    //
+    // So this asserts the ROUTING, not the dead table entry.
+    #expect(
+      KernelDictationDriver.advisoryReason(for: .failed(.zeroSignal)) == .zeroSignal)
+    #expect(TerminalNoticeReason.zeroSignal.rawValue == "zero_signal")
+  }
+}


### PR DESCRIPTION
Part of #1876 (Phase 2b). Closes #1891.

## The problem

340 times a month, across 50 users, a microphone sends us nothing and we answer **"Audio capture error. Try again."** — alongside a Try Again button, a red menu-bar state, a red sidebar dot and a VoiceOver "Error: " prefix. Capture did not error. It recorded exactly what the device sent.

A second population gets worse treatment: an analog mute switch or a dead 3.5 mm line ends at the VAD gate and we say **nothing at all**.

**14 users fail on more than half their takes behind this.**

## What ships

Both endings present one founder-approved sentence through a **new `.advisory` presentation channel that is not the error channel**:

> Audio isn't capturing. Your lid may be closed, your headset muted, or there may be a hardware issue. Please check your microphone settings.

A plain sentence, per the #1558 design rule: `[X] error. Try again.` means our bug, a plain sentence means a real event.

**One `nonisolated` classifier** in `KernelDictationDriver` is the single authority, called by **both** the `state` projection and `overlayIntent`. Those are independent projections — the first design in this plan changed only one of them and would have displayed nothing at all.

**Zero telemetry change.** `.advisory(.zeroSignal)` keeps emitting `pipeline.failed` under its unchanged `zero_signal` code, so the 340/30d series continues; `.vadGateNoSpeech` emits nothing because `audio.vad_gate_no_speech` (#1845, merged today) already counts it. `telemetryLabel` stays `"error"` so `app_phase` vocabulary is untouched.

## The defect that would have shipped silently

`DictationSessionConfigFactory` derived `autoPaste` through a `default: return false` arm. Adding a state without touching it would have **disabled auto-paste on the NEXT take** — the user fixes their microphone, dictates successfully, and the text never lands. Paste is heart path.

No compiler catches that. No existing test catches it. Made exhaustive, then swept every `switch` over a pipeline state carrying a `default` arm and found one more (a stale language chip surviving an advisory terminal).

## Scope, all founder rulings (#1876, 2026-07-31)

Out: `asrEmptyWithSpeech` ("transcription is a different session's job"), `captureStalled` (stays our-software until #1578 telemetry explains it), the two quiet no-speech sources (a working microphone and a user who said nothing needs no message), lid detection (#1853 stays parked), a "Select microphone" button.

## Verification

- **Full suite: 4,691 tests, TEST SUCCEEDED.**
- 6 new tests, every one with a negative arm: the classifier truth table across all 8 outcomes and all 13 failure reasons; byte-exact copy freeze; a guard that the sentence never adopts the our-fault retry form; VoiceOver prefix-free **with a two-way control that real errors are still prefixed**; the state contract (`isActive == false`, `telemetryLabel == "error"`).
- `KernelDictationDriverTests.stateMapIsTotal` updated: it correctly failed because it pinned the old silence. Now pins the new routing **plus** that the other two no-speech sources still collapse to `.idle`.
- **Live UAT on the dev build**, fault-injected `zero_from_start`: log confirms `terminal failed(zeroSignal)`, and the founder confirmed the message renders on screen.
- **Live negative control**: a normal dictation returned `terminal completed`, full transcript, `paste=0.331s` — on the take immediately following an advisory, which is the auto-paste regression above proven end to end.
- Local whole-diff `codex review`: **no actionable defects**.

## Review trail

One coverage round, five grounded rounds (PIVOT, PIVOT, then converging). The pivots were earned: round 1 found the design could not display anything, round 2 found the telemetry fork that would have broken the `zero_signal` series.

Five of my own load-bearing claims were false during planning, all checkable in one command. The worst was declaring a button absent from a `head -10`-truncated grep and writing that into the plan as a correction to a reviewer who was right. Both standing corrections are recorded in the plan header: **a search proving an absence is never piped through `head`**, and **a cited symbol is verified to exist before it is written down**.

## Line ceiling

`DictationLifecycleCoordinator` 499/500. My comments pushed it to 503; I trimmed the comments rather than raise the ceiling, then re-measured after `git rebase origin/main` because CI tests the merge, not the branch base (#1631).
