### PR TITLE
feat(pipeline): record what happened to every dictation (Part of #1884, #1890)

### DIFF
--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -1664,26 +1664,22 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   /// neutral `TerminalNoticeReason`. PURE — no telemetry side effect (this map
   /// is read from BOTH the state and overlay projections, so emitting here
   /// would double-fire; the raw error is already captured at its producer's
-  /// Sentry site). Total over all 12 cases (no `default`), so a new
-  /// `RecordingFailureReason` reds the build until it is assigned a reason.
+  /// Sentry site).
+  ///
+  /// #1884: the switch itself moved to `RecordingFailureReason.terminalNoticeReason`
+  /// (`KernelTerminalProjections.swift`) because terminal telemetry needs the SAME
+  /// answer, and two copies of a 13-arm mapping disagree silently — both values
+  /// look plausible in a dashboard. This stays as the driver's named entry point
+  /// so its call sites read unchanged.
+  ///
+  /// The old comment here said "all 12 cases"; the switch had 13 arms and has
+  /// since it was written. A count in a comment that nobody re-derives is how a
+  /// wrong enumeration survives — the shared projection is exhaustive with no
+  /// `default`, so the compiler holds the invariant the comment was claiming.
   nonisolated static func terminalNoticeReason(for reason: RecordingFailureReason)
     -> TerminalNoticeReason
   {
-    switch reason {
-    case .prepareFailed: return .prepareFailed
-    case .permissionDenied: return .permissionDenied
-    case .modelWedged: return .modelWedged
-    case .modelLoadFailed: return .modelLoadFailed
-    case .captureStartFailed: return .captureStartFailed
-    case .noMicrophoneFound: return .noMicrophoneFound
-    case .noAudioCaptured: return .noAudioCaptured
-    case .asrEmpty: return .asrEmptyWithSpeech
-    case .asrFailed: return .asrFailed
-    case .asrWedged: return .asrWedged
-    case .emptyAfterProcessing: return .emptyAfterProcessing
-    case .captureStalled: return .captureStalled
-    case .zeroSignal: return .zeroSignal
-    }
+    reason.terminalNoticeReason
   }
 
   /// #1558: map a stamped `EngineInterruptionCause` (optional) to the typed

--- a/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
@@ -228,12 +228,21 @@ public enum KernelDictationDriverFactory {
     /// then called synchronously from `start(config:)` on every accepted session.
     var sessionAccepted: (@MainActor (String) -> Void)?
 
+    /// #1884: set after the lifecycle sink exists, for the same construction-order
+    /// reason as `sessionAccepted` above. Called from `finishTerminal`'s `defer`
+    /// with an immutable snapshot, exactly once per accepted terminal.
+    var sessionTerminal: (@MainActor (KernelTerminalTelemetrySnapshot) -> Void)?
+
     func emitRecordingStopped(sampleCount: Int) {
       recordingStopped?(sampleCount)
     }
 
     func establishTakeID(_ takeID: String) {
       sessionAccepted?(takeID)
+    }
+
+    func deliverSessionTerminal(_ snapshot: KernelTerminalTelemetrySnapshot) {
+      sessionTerminal?(snapshot)
     }
 
     func modelLoadWedgeTelemetry() -> KernelModelLoadWedgeTelemetry? {
@@ -504,6 +513,11 @@ public enum KernelDictationDriverFactory {
       sessionAcceptedTelemetry: { takeID in
         telemetryRelay.establishTakeID(takeID)
       },
+      // #1884: same relay, same reason — the kernel is constructed before the
+      // lifecycle sink, so the terminal callback cannot reference it directly.
+      sessionTerminalTelemetry: { snapshot in
+        telemetryRelay.deliverSessionTerminal(snapshot)
+      },
       markPipelineTimingStart: {
         outcome.pipelineStartedAtSeconds = CFAbsoluteTimeGetCurrent()
       },
@@ -572,8 +586,14 @@ public enum KernelDictationDriverFactory {
     }
     // #1846: the sink stays the SINGLE writer of `dictation.take_id`; this only
     // gives the kernel a synchronous way to reach it at session acceptance.
+    // #1884: acceptance now activates BOTH effects through one sink method — the
+    // Sentry take tag (unchanged single writer) and the `dictation.started`
+    // denominator. One identity, no second callback.
     telemetryRelay.sessionAccepted = { [lifecycleSink] takeID in
-      lifecycleSink.establishTakeID(takeID)
+      lifecycleSink.acceptSession(takeID: takeID)
+    }
+    telemetryRelay.sessionTerminal = { [lifecycleSink] snapshot in
+      lifecycleSink.emitTerminal(snapshot)
     }
 
     // 9. Observer (constructed AFTER kernel — needs the kernel ref). The

--- a/Sources/EnviousWisprPipeline/KernelHeartPathTelemetryObserver.swift
+++ b/Sources/EnviousWisprPipeline/KernelHeartPathTelemetryObserver.swift
@@ -280,43 +280,15 @@ final class KernelHeartPathTelemetryObserver {
       events.append(.asrCompleted)
     }
 
-    if prevOutcome == nil, let outcome,
-      let event = terminalEvent(for: outcome, isStreaming: isStreaming)
-    {
+    if prevOutcome == nil, let outcome {
       // Conclusion — the ending event (the paired `→ .idle` has none).
-      events.append(event)
+      // Shared projection: `KernelTerminalProjections.swift`. The terminal
+      // telemetry path renders the SAME value from its frozen snapshot, so the
+      // two vendors cannot disagree about what ended a dictation (#1884).
+      events.append(outcome.lifecycleEvent)
     }
 
     return events
   }
 
-  /// Map a concluded session's `RecordingOutcome` to its terminal lifecycle
-  /// event (#1548 D1). `.noTransport` projects to the existing
-  /// `.failed(.noAudioCaptured)` telemetry (locked projection, plan §4 / §7) —
-  /// no new Sentry/PostHog identity.
-  static func terminalEvent(
-    for outcome: RecordingOutcome,
-    isStreaming: Bool
-  ) -> KernelLifecycleEvent? {
-    switch outcome {
-    case .completed:
-      return .pipelineCompleted
-    case .failed(let reason):
-      return .failed(reason)
-    case .cancelled:
-      return .cancelled
-    case .discarded(let reason):
-      return .discarded(reason)
-    case .noSpeech(let source):
-      return .noSpeech(source)
-    case .audioInterrupted(let cause):
-      // Default defensively to `.engineLost` if the cause was not stamped — a
-      // lost recording with no cause is still an unowned loss (#1174 A3).
-      return .audioInterrupted(cause: cause ?? .engineLost)
-    case .asrInterrupted(let wasRecording):
-      return .asrInterrupted(wasRecording: wasRecording)
-    case .noTransport:
-      return .failed(.noAudioCaptured)
-    }
-  }
 }

--- a/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
@@ -523,7 +523,13 @@ final class KernelLifecycleTelemetrySink {
 
   /// The terminal each lifecycle event represents, or `nil` for a non-terminal
   /// event. Exhaustive on purpose.
-  private static func terminalStateLabel(for event: KernelLifecycleEvent) -> String? {
+  /// `package` rather than `private` since #1884: the terminal telemetry path
+  /// renders this same label from a frozen snapshot, and tests assert that every
+  /// `RecordingOutcome` projection lands on a terminal. `package` is the seam
+  /// visibility — tests live in a separate module, so `internal` would work only
+  /// through `@testable` and couple the seam to a compilation mode
+  /// (swift-patterns.md RULE: package-visibility-avoids-cross-module-unknown-default).
+  package static func terminalStateLabel(for event: KernelLifecycleEvent) -> String? {
     switch event {
     case .pipelineCompleted: "completed"
     case .failed: "failed"

--- a/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
@@ -523,13 +523,11 @@ final class KernelLifecycleTelemetrySink {
 
   /// The terminal each lifecycle event represents, or `nil` for a non-terminal
   /// event. Exhaustive on purpose.
-  /// `package` rather than `private` since #1884: the terminal telemetry path
-  /// renders this same label from a frozen snapshot, and tests assert that every
-  /// `RecordingOutcome` projection lands on a terminal. `package` is the seam
-  /// visibility — tests live in a separate module, so `internal` would work only
-  /// through `@testable` and couple the seam to a compilation mode
-  /// (swift-patterns.md RULE: package-visibility-avoids-cross-module-unknown-default).
-  package static func terminalStateLabel(for event: KernelLifecycleEvent) -> String? {
+  /// Internal since #1884 so the projection tests can verify that every
+  /// `RecordingOutcome` maps to a terminal label. The enclosing type is already
+  /// `internal` and the tests already use `@testable`, so `package` would widen
+  /// access without buying anything — `internal` is the narrowest that works.
+  static func terminalStateLabel(for event: KernelLifecycleEvent) -> String? {
     switch event {
     case .pipelineCompleted: "completed"
     case .failed: "failed"

--- a/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
@@ -331,8 +331,13 @@ final class KernelLifecycleTelemetrySink {
       // which would be an unqueryable row that still counts in the denominator.
       return
     }
+    // Read from the PROJECTED event, never from the raw outcome. `.noTransport`
+    // projects to `.failed(.noAudioCaptured)`, so an outcome-side match labels the
+    // row `failed` with no reason at all — a failure invisible to every
+    // reason-keyed count (whole-diff review 2026-07-31). One projection decides
+    // both fields, so they cannot disagree.
     let reason: String? =
-      if case .failed(let failureReason) = snapshot.outcome {
+      if case .failed(let failureReason) = event {
         failureReason.terminalNoticeReason.rawValue
       } else {
         nil

--- a/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
@@ -63,6 +63,24 @@ final class KernelLifecycleTelemetrySink {
     _ takeID: String?
   ) -> Void
 
+  /// #1884 `dictation.started` — the denominator. Deliberately minimal: this
+  /// event exists to be counted, and every fact worth knowing about a take is
+  /// already on its terminal row.
+  typealias DictationStartedSink = @MainActor (
+    _ takeID: String, _ backend: String
+  ) -> Void
+
+  /// #1884 `dictation.terminal`. `result` is one of the seven terminal labels;
+  /// `reason` is a `TerminalNoticeReason.rawValue` and is nil unless the terminal
+  /// is `.failed`. The attribution block is nil unless the take was signal-free.
+  typealias DictationTerminalSink = @MainActor (
+    _ takeID: String, _ backend: String, _ result: String, _ reason: String?,
+    _ inputDeviceKind: String?, _ effectiveTransport: String?, _ selectedTransport: String?,
+    _ inputSelectionMode: String?, _ wholeBufferRMS: Float?, _ maxWindowRMS: Float?,
+    _ peakAudioLevel: Float?, _ durationMs: Int?, _ captureNativeRateHz: Double?,
+    _ captureNativeChannelCount: Int?
+  ) -> Void
+
   typealias CaptureErrorSink = @MainActor (
     _ error: any Error & StableSentryErrorIdentity,
     _ category: SentryBreadcrumb.ErrorCategory,
@@ -112,6 +130,14 @@ final class KernelLifecycleTelemetrySink {
   private let dictationInvoked: DictationInvokedSink
   private let modelLoadWedged: ModelLoadWedgedSink
   private let vadGateNoSpeech: VADGateNoSpeechSink
+
+  /// #1884 `dictation.started`. Primitives rather than the snapshot type because
+  /// `TelemetryService` lives in Services and cannot see Pipeline types — the
+  /// dependency runs one way only.
+  private let dictationStarted: DictationStartedSink
+
+  /// #1884 `dictation.terminal`. Destructured for the same reason.
+  private let dictationTerminal: DictationTerminalSink
   private let captureError: CaptureErrorSink
   private let captureErrorWithSnapshot: SnapshotCaptureErrorSink
   /// Optional. When wired (factory path), the sink routes
@@ -194,6 +220,22 @@ final class KernelLifecycleTelemetrySink {
         captureNativeRateHz: captureNativeRateHz,
         captureNativeChannelCount: captureNativeChannelCount, takeID: takeID)
     },
+    dictationStarted: @escaping DictationStartedSink = { takeID, backend in
+      TelemetryService.shared.dictationStarted(takeID: takeID, backend: backend)
+    },
+    dictationTerminal: @escaping DictationTerminalSink = {
+      takeID, backend, result, reason, inputDeviceKind, effectiveTransport, selectedTransport,
+      inputSelectionMode, wholeBufferRMS, maxWindowRMS, peakAudioLevel, durationMs,
+      captureNativeRateHz, captureNativeChannelCount in
+      TelemetryService.shared.dictationTerminal(
+        takeID: takeID, backend: backend, result: result, reason: reason,
+        inputDeviceKind: inputDeviceKind, effectiveTransport: effectiveTransport,
+        selectedTransport: selectedTransport, inputSelectionMode: inputSelectionMode,
+        wholeBufferRMS: wholeBufferRMS, maxWindowRMS: maxWindowRMS,
+        peakAudioLevel: peakAudioLevel, durationMs: durationMs,
+        captureNativeRateHz: captureNativeRateHz,
+        captureNativeChannelCount: captureNativeChannelCount)
+    },
     captureError: @escaping CaptureErrorSink = { error, category, stage, extra in
       SentryBreadcrumb.captureError(error, category: category, stage: stage, extra: extra)
     },
@@ -226,6 +268,8 @@ final class KernelLifecycleTelemetrySink {
     self.dictationInvoked = dictationInvoked
     self.modelLoadWedged = modelLoadWedged
     self.vadGateNoSpeech = vadGateNoSpeech
+    self.dictationStarted = dictationStarted
+    self.dictationTerminal = dictationTerminal
     self.captureError = captureError
     self.captureErrorWithSnapshot = captureErrorWithSnapshot
     self.noAudioCapturedRich = noAudioCapturedRich
@@ -255,6 +299,52 @@ final class KernelLifecycleTelemetrySink {
   /// scope tag.
   func establishTakeID(_ takeID: String) {
     updateTakeID(takeID)
+  }
+
+  /// #1884: BOTH acceptance effects, through one method and one identity.
+  ///
+  /// The Sentry take tag first (unchanged, same single writer), then exactly one
+  /// `dictation.started`. They share the `takeID` the kernel just minted — no
+  /// second callback, no second identity.
+  ///
+  /// This is the denominator. A take that never reaches a terminal is only
+  /// visible as the difference between this event and `dictation.terminal`, so
+  /// an accepted session that emits nothing here is invisible rather than
+  /// merely uncounted.
+  func acceptSession(takeID: String) {
+    updateTakeID(takeID)
+    dictationStarted(takeID, backend.rawValue)
+  }
+
+  /// #1884: exactly one row per ACCEPTED terminal, rendered from the immutable
+  /// snapshot and nothing else.
+  ///
+  /// Reads no live state on purpose. By the time this runs, `finishTerminal`'s
+  /// cleanup has torn down callbacks, tasks, the adapter and capture state, and
+  /// the next take may already be running — so anything consulted here could
+  /// describe a different dictation than the one being reported.
+  func emitTerminal(_ snapshot: KernelTerminalTelemetrySnapshot) {
+    let event = snapshot.outcome.lifecycleEvent
+    guard let result = Self.terminalStateLabel(for: event) else {
+      // Unreachable: every `RecordingOutcome` projects to a terminal, and a
+      // projection test freezes that. Refusing beats emitting `result: nil`,
+      // which would be an unqueryable row that still counts in the denominator.
+      return
+    }
+    let reason: String? =
+      if case .failed(let failureReason) = snapshot.outcome {
+        failureReason.terminalNoticeReason.rawValue
+      } else {
+        nil
+      }
+    let attribution = snapshot.signalAttribution
+    dictationTerminal(
+      snapshot.takeID, snapshot.backend, result, reason,
+      attribution?.inputDeviceKind, attribution?.effectiveTransport,
+      attribution?.selectedTransport, attribution?.inputSelectionMode,
+      attribution?.wholeBufferRMS, attribution?.maxWindowRMS,
+      attribution?.peakAudioLevel, attribution?.durationMs,
+      attribution?.captureNativeRateHz, attribution?.captureNativeChannelCount)
   }
 
   func emit(_ event: KernelLifecycleEvent) {

--- a/Sources/EnviousWisprPipeline/KernelTelemetryState.swift
+++ b/Sources/EnviousWisprPipeline/KernelTelemetryState.swift
@@ -108,6 +108,22 @@ final class KernelTelemetryState {
   /// disclosure for `becameZeroMidCapture` (§3.5).
   var zeroSignalFailureMode: CaptureStallFailureMode?
 
+  /// #1890: hardware and signal facts for a take that captured nothing usable,
+  /// or `nil` when this take is not one of those.
+  ///
+  /// **Written ONLY at the two producer sites** — immediately before the eligible
+  /// `.failed(.zeroSignal)` terminal, and on the final `asr_empty_with_speech`
+  /// path after salvage has failed. `finishTerminal` only COPIES it into the
+  /// terminal snapshot.
+  ///
+  /// That direction is the whole point. Measuring or re-reading the bind at the
+  /// terminal would be innocent in intent and indistinguishable in effect from
+  /// the defect `gotchas-audio.md`
+  /// RULE: read-the-bind-prepare-returned-never-re-derive-it exists to prevent:
+  /// the bind read ORDER is a tested #1844/#1578 contract. Freezing at the
+  /// producer makes that invariant true by construction, not by discipline.
+  var signalAttribution: KernelSignalAttributionTelemetry?
+
   /// #1707: this session's ASR-interruption salvage outcome, or `nil` if no
   /// salvage was attempted. See `ASRSalvageOutcome` for the value taxonomy.
   var asrSalvageOutcome: ASRSalvageOutcome?
@@ -132,6 +148,7 @@ final class KernelTelemetryState {
     captureHealth = nil
     interruptedSalvageSource = nil
     zeroSignalFailureMode = nil
+    signalAttribution = nil
     asrSalvageOutcome = nil
     asrRetryOutcome = nil
   }

--- a/Sources/EnviousWisprPipeline/KernelTerminalProjections.swift
+++ b/Sources/EnviousWisprPipeline/KernelTerminalProjections.swift
@@ -1,0 +1,83 @@
+import EnviousWisprCore
+import Foundation
+
+// The two pure projections a concluded take needs, in one place because two
+// different consumers need the same answer and a second copy would drift.
+//
+// `KernelHeartPathTelemetryObserver` reaches a terminal ASYNCHRONOUSLY, through
+// observation that is explicitly not a lossless queue. The terminal telemetry
+// path reaches the same terminal SYNCHRONOUSLY, from an immutable snapshot
+// frozen inside `finishTerminal`. Both must classify an ending identically or
+// the two vendors disagree about what happened to one dictation (#1884).
+
+extension RecordingOutcome {
+
+  /// The terminal lifecycle event this ending represents (#1548 D1).
+  ///
+  /// Total and non-optional: every `RecordingOutcome` is an ending, so there is
+  /// no "not a terminal" answer to return. The observer's earlier form was
+  /// `-> KernelLifecycleEvent?` with an unused `isStreaming:` parameter; neither
+  /// carried information (no arm returned nil, no arm read the flag), and both
+  /// were dropped when this moved here.
+  ///
+  /// `.noTransport` projects to `.failed(.noAudioCaptured)` — a LOCKED
+  /// projection. It deliberately reuses the existing telemetry identity rather
+  /// than minting a new one, so a transport-less take is counted with the
+  /// captured-nothing family it belongs to.
+  var lifecycleEvent: KernelLifecycleEvent {
+    switch self {
+    case .completed:
+      .pipelineCompleted
+    case .failed(let reason):
+      .failed(reason)
+    case .cancelled:
+      .cancelled
+    case .discarded(let reason):
+      .discarded(reason)
+    case .noSpeech(let source):
+      .noSpeech(source)
+    case .audioInterrupted(let cause):
+      // Default defensively to `.engineLost` when the cause was not stamped: a
+      // lost recording with no cause is still an unowned loss (#1174 A3).
+      .audioInterrupted(cause: cause ?? .engineLost)
+    case .asrInterrupted(let wasRecording):
+      .asrInterrupted(wasRecording: wasRecording)
+    case .noTransport:
+      .failed(.noAudioCaptured)
+    }
+  }
+}
+
+extension RecordingFailureReason {
+
+  /// The stable, presentation-neutral reason code for this failure.
+  ///
+  /// `TerminalNoticeReason.rawValue` is the SHIPPED PostHog vocabulary — it is
+  /// what `pipeline.failed.error_code` already carries — so terminal telemetry
+  /// reuses it rather than emitting raw Swift case names. Snake_case, stable,
+  /// and already what our queries and the daily report are written against.
+  ///
+  /// Exhaustive with no `default`, so adding a `RecordingFailureReason` is a
+  /// compile error here rather than a silently unmapped value in the data.
+  ///
+  /// One non-identity mapping: `.asrEmpty → .asrEmptyWithSpeech`. That is the
+  /// name #1890 counts, and it is more precise than the case name — the ASR ran
+  /// and returned nothing while the gate had accepted speech.
+  var terminalNoticeReason: TerminalNoticeReason {
+    switch self {
+    case .prepareFailed: .prepareFailed
+    case .permissionDenied: .permissionDenied
+    case .modelWedged: .modelWedged
+    case .modelLoadFailed: .modelLoadFailed
+    case .captureStartFailed: .captureStartFailed
+    case .noMicrophoneFound: .noMicrophoneFound
+    case .noAudioCaptured: .noAudioCaptured
+    case .asrEmpty: .asrEmptyWithSpeech
+    case .asrFailed: .asrFailed
+    case .asrWedged: .asrWedged
+    case .emptyAfterProcessing: .emptyAfterProcessing
+    case .captureStalled: .captureStalled
+    case .zeroSignal: .zeroSignal
+    }
+  }
+}

--- a/Sources/EnviousWisprPipeline/KernelTerminalProjections.swift
+++ b/Sources/EnviousWisprPipeline/KernelTerminalProjections.swift
@@ -52,10 +52,9 @@ extension RecordingFailureReason {
 
   /// The stable, presentation-neutral reason code for this failure.
   ///
-  /// `TerminalNoticeReason.rawValue` is the SHIPPED PostHog vocabulary — it is
-  /// what `pipeline.failed.error_code` already carries — so terminal telemetry
-  /// reuses it rather than emitting raw Swift case names. Snake_case, stable,
-  /// and already what our queries and the daily report are written against.
+  /// `TerminalNoticeReason.rawValue` is the SHIPPED PostHog vocabulary. It is
+  /// what `pipeline.failed.error_code` already carries, so terminal telemetry
+  /// reuses it rather than emitting raw Swift case names.
   ///
   /// Exhaustive with no `default`, so adding a `RecordingFailureReason` is a
   /// compile error here rather than a silently unmapped value in the data.

--- a/Sources/EnviousWisprPipeline/KernelTerminalTelemetrySnapshot.swift
+++ b/Sources/EnviousWisprPipeline/KernelTerminalTelemetrySnapshot.swift
@@ -1,0 +1,65 @@
+import EnviousWisprCore
+import Foundation
+
+/// Hardware and signal facts for a take that captured nothing usable (#1890).
+///
+/// **Every field is frozen at its PRODUCER, never re-read at the terminal.**
+/// That is structural, not stylistic. `gotchas-audio.md`
+/// RULE: read-the-bind-prepare-returned-never-re-derive-it establishes that the
+/// bind read ORDER is load-bearing; a telemetry read at terminal time is
+/// innocent in intent and indistinguishable in effect from the bug that rule
+/// exists to prevent. Freezing at the producer makes the invariant true by
+/// construction instead of by discipline.
+///
+/// Content-free by construction: counts, magnitudes, durations, and
+/// closed-vocabulary transport/device-class strings. Never a raw device UID
+/// (its USB form embeds the unit serial, its Bluetooth form is the peer MAC),
+/// never a device name or model, never audio, never transcript.
+///
+/// **Every optional omits rather than defaulting.** `peakAudioLevel` is optional
+/// for exactly that reason: an exact zero is the signature of a digitally dead
+/// channel (#1809), so defaulting a missing reading to `0` would manufacture the
+/// most diagnostically loaded value in the dataset and make absent data
+/// indistinguishable from the finding this record exists to detect.
+struct KernelSignalAttributionTelemetry: Sendable, Equatable {
+  /// Which physical input class produced the capture, from the bind-frozen
+  /// value — one of the four closed classes, never a device identifier.
+  let inputDeviceKind: String?
+  let effectiveTransport: String?
+  let selectedTransport: String?
+  let inputSelectionMode: String?
+
+  /// Signal magnitudes measured ONCE, at the producer, over the already-captured
+  /// buffer. Nil means not computed, never "silent".
+  let wholeBufferRMS: Float?
+  let maxWindowRMS: Float?
+  let peakAudioLevel: Float?
+
+  let durationMs: Int?
+  let captureNativeRateHz: Double?
+  let captureNativeChannelCount: Int?
+}
+
+/// Everything the terminal telemetry path needs, frozen at the moment the take
+/// ended and valid forever after.
+///
+/// Constructed inside `RecordingSessionKernel.finishTerminal` once the set-once
+/// guard has accepted an outcome, while `sid` still unambiguously identifies the
+/// concluded session. Delivered by a single `defer` so an accepted terminal
+/// cannot lose its event at a later cleanup return.
+///
+/// **The consumer must render this and nothing else.** It may not read
+/// `KernelTelemetryState`, `KernelSessionContext`, `AudioCaptureInterface`,
+/// captured samples, or any other live session state. The whole point is that
+/// take B can start immediately and change all of those without altering what
+/// take A reported — the identity race that made the observer path unusable for
+/// this (#1884, grounded review r1).
+///
+/// Vendor-neutral on purpose: no PostHog event names, no property keys. The
+/// kernel decides WHAT happened; the sink decides how to say it.
+struct KernelTerminalTelemetrySnapshot: Sendable {
+  let takeID: String
+  let backend: String
+  let outcome: RecordingOutcome
+  let signalAttribution: KernelSignalAttributionTelemetry?
+}

--- a/Sources/EnviousWisprPipeline/KernelTerminalTelemetrySnapshot.swift
+++ b/Sources/EnviousWisprPipeline/KernelTerminalTelemetrySnapshot.swift
@@ -22,8 +22,9 @@ import Foundation
 /// most diagnostically loaded value in the dataset and make absent data
 /// indistinguishable from the finding this record exists to detect.
 struct KernelSignalAttributionTelemetry: Sendable, Equatable {
-  /// Which physical input class produced the capture, from the bind-frozen
-  /// value — one of the four closed classes, never a device identifier.
+  /// Built-in-family input detail frozen at bind time: `built_in_mic` or
+  /// `jack_input`. Nil for USB, Bluetooth, and every other transport — those are
+  /// distinguished by `effectiveTransport`, not here. Never a device identifier.
   let inputDeviceKind: String?
   let effectiveTransport: String?
   let selectedTransport: String?

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -1749,10 +1749,8 @@ final class RecordingSessionKernel {
 
     if zeroSignalRecoveryMode == .allZeroFromStart {
       // #1890 producer 1 of 2. Frozen HERE, where the route snapshot and the bind
-      // label still describe this take. No measurement: an all-zero-from-start
-      // capture has no RMS worth reporting, and the peak is the diagnostic value.
-      freezeSignalAttribution(
-        samples: captureResult.samples, peak: rawPeakAudioLevel, measurement: nil)
+      // label still describe this take.
+      freezeSignalAttribution(samples: captureResult.samples, peak: rawPeakAudioLevel)
       finishTerminal(.failed(.zeroSignal), sid: sid)
       return
     }
@@ -2397,10 +2395,7 @@ final class RecordingSessionKernel {
         // half #1890 counts; the `.noSpeech(.asrEmptyNoSpeech)` half already has
         // its own richer event from #1888, and giving the terminal row the same
         // frozen facts costs nothing and keeps the two joinable on `take_id`.
-        freezeSignalAttribution(
-          samples: captureResult.samples,
-          peak: rawPeakAudioLevel,
-          measurement: nil)
+        freezeSignalAttribution(samples: captureResult.samples, peak: rawPeakAudioLevel)
         finishTerminal(
           effectiveSpeechEvidence ? .failed(.asrEmpty) : .noSpeech(.asrEmptyNoSpeech),
           sid: sid)
@@ -3634,23 +3629,34 @@ final class RecordingSessionKernel {
   /// there breaks the #1844/#1578 read-order contract that
   /// `KernelFrozenBindGuardTests` locks.
   ///
-  /// Measures the buffer ONCE. A second `RawAudioDeadAirClassifier.measure` call
-  /// would be a second measurement of the same samples, which is the
-  /// re-implementation this project forbids by name.
-  private func freezeSignalAttribution(
-    samples: [Float],
-    peak: Float?,
-    measurement: RawAudioDeadAirClassifier.DeadAirMeasurement?
-  ) {
+  /// Measures the buffer HERE rather than accepting a measurement argument. Both
+  /// producers are mutually exclusive terminals, so this runs at most once per
+  /// take — and an argument is a thing a caller can forget, which is exactly
+  /// what happened: both call sites passed `nil` and every `asr_empty_with_speech`
+  /// row shipped without its two energy values (whole-diff review 2026-07-31).
+  ///
+  /// `measure` SHORT-CIRCUITS, so both RMS values come back nil whenever the peak
+  /// already clears the dead-air floor. That is the #1845 contract — nil means NOT
+  /// COMPUTED, never "computed as zero" — and it is the honest answer here,
+  /// because a peak above the floor has already established the channel carried
+  /// audio. The two RMS values exist to characterise the QUIET case, which is the
+  /// only case in which the classifier computes them.
+  ///
+  /// That short-circuit is also the cost story: a below-floor peak buys two O(n)
+  /// passes over the buffer, bounded by the 60-minute cap (#1060), and every other
+  /// take returns at the peak guard without touching a sample. It runs once, on a
+  /// terminal the user is already being told about.
+  private func freezeSignalAttribution(samples: [Float], peak: Float) {
     let takeRoute = lastResolvedRoute
     let health = telemetryState.captureHealth
+    let measurement = RawAudioDeadAirClassifier.measure(samples, peak: peak)
     telemetryState.signalAttribution = KernelSignalAttributionTelemetry(
       inputDeviceKind: audioCapture.boundInputDeviceKind,
       effectiveTransport: takeRoute?.effective,
       selectedTransport: takeRoute?.selected,
       inputSelectionMode: takeRoute?.inputSelectionMode,
-      wholeBufferRMS: measurement?.wholeBufferRMS,
-      maxWindowRMS: measurement?.maxWindowRMS,
+      wholeBufferRMS: measurement.wholeBufferRMS,
+      maxWindowRMS: measurement.maxWindowRMS,
       // Stays optional all the way to PostHog. An exact zero is the signature of
       // a digitally dead channel (#1809), so a manufactured 0 for "not measured"
       // would be indistinguishable from the finding this data exists to detect.

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -318,6 +318,22 @@ final class RecordingSessionKernel {
   /// model-load or capture-start failure could be raised before the tag existed.
   /// Defaulted to a no-op: only the production composition root wires it.
   private let sessionAcceptedTelemetry: @MainActor (_ takeID: String) -> Void
+
+  /// #1884: called exactly once per ACCEPTED terminal, with an immutable snapshot
+  /// frozen at the moment the take ended.
+  ///
+  /// Deliberately NOT routed through `KernelHeartPathTelemetryObserver`, which is
+  /// how every other terminal signal reaches telemetry. That path observes
+  /// asynchronously through a `Task`, and its own source documents the mechanism
+  /// as not a lossless queue — so take B can start and replace
+  /// `telemetryState.takeID` before take A is rendered, and take A's row would
+  /// carry take B's identity. Nothing about that failure is visible in the data:
+  /// both ids are real, both rows look correct.
+  ///
+  /// Defaulted to a no-op: only the production composition root wires it, through
+  /// the relay (the kernel is constructed before the lifecycle sink exists).
+  private let sessionTerminalTelemetry: @MainActor (KernelTerminalTelemetrySnapshot) -> Void
+
   private let markPipelineTimingStart: @MainActor () -> Void
   private let markASRTimingStart: @MainActor (_ streaming: Bool) -> Void
   private let markASRTimingEnd: @MainActor () -> Void
@@ -818,6 +834,9 @@ final class RecordingSessionKernel {
     zeroSignalRefusalSink: @escaping @MainActor ([ZeroSignalRefusalContext]) -> Void = { _ in },
     recordingStoppedTelemetry: @escaping @MainActor (_ sampleCount: Int) -> Void = { _ in },
     sessionAcceptedTelemetry: @escaping @MainActor (_ takeID: String) -> Void = { _ in },
+    sessionTerminalTelemetry: @escaping @MainActor (KernelTerminalTelemetrySnapshot) -> Void = {
+      _ in
+    },
     markPipelineTimingStart: @escaping @MainActor () -> Void = {},
     markASRTimingStart: @escaping @MainActor (_ streaming: Bool) -> Void = { _ in },
     markASRTimingEnd: @escaping @MainActor () -> Void = {},
@@ -885,6 +904,7 @@ final class RecordingSessionKernel {
     self.zeroSignalRefusalSink = zeroSignalRefusalSink
     self.recordingStoppedTelemetry = recordingStoppedTelemetry
     self.sessionAcceptedTelemetry = sessionAcceptedTelemetry
+    self.sessionTerminalTelemetry = sessionTerminalTelemetry
     self.markPipelineTimingStart = markPipelineTimingStart
     self.markASRTimingStart = markASRTimingStart
     self.markASRTimingEnd = markASRTimingEnd
@@ -1728,6 +1748,11 @@ final class RecordingSessionKernel {
     // that correctly discard as `.tooShort` today.
 
     if zeroSignalRecoveryMode == .allZeroFromStart {
+      // #1890 producer 1 of 2. Frozen HERE, where the route snapshot and the bind
+      // label still describe this take. No measurement: an all-zero-from-start
+      // capture has no RMS worth reporting, and the peak is the diagnostic value.
+      freezeSignalAttribution(
+        samples: captureResult.samples, peak: rawPeakAudioLevel, measurement: nil)
       finishTerminal(.failed(.zeroSignal), sid: sid)
       return
     }
@@ -2364,6 +2389,18 @@ final class RecordingSessionKernel {
             )
           }
         }
+        // #1890 producer 2 of 2. Reached only after salvage has already failed
+        // (`!salvageDelivered` above), so this IS the final answer for the take
+        // — freezing earlier would attribute a take that later recovered.
+        //
+        // Both branches freeze. `.failed(.asrEmpty)` is the `asr_empty_with_speech`
+        // half #1890 counts; the `.noSpeech(.asrEmptyNoSpeech)` half already has
+        // its own richer event from #1888, and giving the terminal row the same
+        // frozen facts costs nothing and keeps the two joinable on `take_id`.
+        freezeSignalAttribution(
+          samples: captureResult.samples,
+          peak: rawPeakAudioLevel,
+          measurement: nil)
         finishTerminal(
           effectiveSpeechEvidence ? .failed(.asrEmpty) : .noSpeech(.asrEmptyNoSpeech),
           sid: sid)
@@ -3582,6 +3619,48 @@ final class RecordingSessionKernel {
   /// Fixed order (§5.3 r4, #1578): validate the floor and legal conclusion →
   /// set `recordingOutcome` → stamp `lastTakeID` (#1846) → drain pending
   /// zero-signal refusals → transition to `.idle` → drain the task bag.
+
+  /// #1890: freeze this take's hardware and signal facts, at the producer, for a
+  /// terminal that captured nothing usable.
+  ///
+  /// Called immediately before the two eligible terminals — `.failed(.zeroSignal)`
+  /// and the speech-evidence `.failed(.asrEmpty)`. `finishTerminal` only COPIES
+  /// what this leaves behind; it never measures and never re-reads the bind.
+  ///
+  /// Why here and not there: `lastResolvedRoute` is THIS take's frozen snapshot,
+  /// and `boundInputDeviceKind` is the label the bind returned. A live read at
+  /// terminal time can name a NEWER source in the fenced `.staleSession` /
+  /// `.sourceReplaced` races, and consulting `zeroSignalDiscriminatorDevice`
+  /// there breaks the #1844/#1578 read-order contract that
+  /// `KernelFrozenBindGuardTests` locks.
+  ///
+  /// Measures the buffer ONCE. A second `RawAudioDeadAirClassifier.measure` call
+  /// would be a second measurement of the same samples, which is the
+  /// re-implementation this project forbids by name.
+  private func freezeSignalAttribution(
+    samples: [Float],
+    peak: Float?,
+    measurement: RawAudioDeadAirClassifier.DeadAirMeasurement?
+  ) {
+    let takeRoute = lastResolvedRoute
+    let health = telemetryState.captureHealth
+    telemetryState.signalAttribution = KernelSignalAttributionTelemetry(
+      inputDeviceKind: audioCapture.boundInputDeviceKind,
+      effectiveTransport: takeRoute?.effective,
+      selectedTransport: takeRoute?.selected,
+      inputSelectionMode: takeRoute?.inputSelectionMode,
+      wholeBufferRMS: measurement?.wholeBufferRMS,
+      maxWindowRMS: measurement?.maxWindowRMS,
+      // Stays optional all the way to PostHog. An exact zero is the signature of
+      // a digitally dead channel (#1809), so a manufactured 0 for "not measured"
+      // would be indistinguishable from the finding this data exists to detect.
+      peakAudioLevel: peak,
+      durationMs: telemetryState.recordingSnapshot?.durationMs,
+      captureNativeRateHz: health?.stopMetadata?.nativeRateHz,
+      captureNativeChannelCount: health?.stopMetadata?.nativeChannelCount
+    )
+  }
+
   private func finishTerminal(_ rawOutcome: RecordingOutcome, sid: SessionID) {
     // Set-once barrier: `isCurrent` fences stale sessions; `recordingOutcome ==
     // nil` prevents a double conclusion.
@@ -3601,6 +3680,36 @@ final class RecordingSessionKernel {
     // `isCurrent(sid)` guard above already proved they match, and `sid` is
     // unambiguously the session being concluded.
     lastTakeID = sid.raw.uuidString
+
+    // #1884: freeze this take's outcome NOW, inside the set-once barrier, and
+    // register delivery with `defer`.
+    //
+    // Position is load-bearing in both directions. AFTER the guards and the
+    // outcome write, so a stale, illegal, or losing terminal returns before ever
+    // registering — one accepted terminal, one event, no duplicates. BEFORE
+    // `drainPendingZeroSignalRefusals()` and every later cleanup return, so an
+    // accepted terminal cannot lose its event to an early exit further down.
+    //
+    // `defer` rather than a direct call so delivery runs after this function's
+    // own cleanup, while still being unreachable from the rejecting paths above.
+    // `finishTerminal` is synchronous and MainActor-isolated with no suspension
+    // point, so the deferred call runs before control returns to the main actor:
+    // no new session can start, and the lifecycle observer's queued `Task` cannot
+    // run, in between.
+    //
+    // The snapshot is COMPLETE here. The consumer must render it and read nothing
+    // else — cleanup below tears down callbacks, tasks, the adapter and capture
+    // state, and take B may be running by the time anyone looks.
+    let terminalSnapshot = KernelTerminalTelemetrySnapshot(
+      takeID: sid.raw.uuidString,
+      backend: adapter.engineIdentity.backendType.rawValue,
+      outcome: outcome,
+      // COPIED, never measured here. Populated at its producer (§G5); nil for
+      // every take that is not signal-free.
+      signalAttribution: telemetryState.signalAttribution
+    )
+    defer { sessionTerminalTelemetry(terminalSnapshot) }
+
     // #1578 drain ownership point 2 of 2 — cancellation, non-recoverable
     // interruption, and every other direct terminal. Placed AFTER the set-once
     // outcome write so a stale or losing terminal (both bail on the guard above)

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -745,6 +745,15 @@ public final class TelemetryService {
       testEventHook?(
         CapturedTelemetryEvent(
           name: event, stringProps: ["take_id": takeID, "backend": backend]))
+      // Logged for the same reason the terminal is: without it, Live UAT can see
+      // endings but not beginnings, and the one number this event exists to
+      // produce — started takes that never reported an ending — is unverifiable
+      // outside PostHog.
+      Task {
+        await AppLogger.shared.log(
+          "dictation_started take=\(takeID) backend=\(backend)",
+          level: .info, category: "Telemetry")
+      }
     #endif
     PostHogSDK.shared.capture(event, properties: props)
   }

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -724,6 +724,125 @@ public final class TelemetryService {
     PostHogSDK.shared.capture(event, properties: props)
   }
 
+  // MARK: - #1884 outcome distribution
+
+  /// A dictation was ACCEPTED and a session minted. The denominator.
+  ///
+  /// Deliberately minimal — this event exists to be counted. Every fact worth
+  /// knowing about a take is on its `dictation.terminal` row, and duplicating
+  /// them here would create two places to keep in step.
+  ///
+  /// Its whole value is subtraction: a take with a `dictation.started` and no
+  /// `dictation.terminal` crashed, hung, was force-quit, or lost its telemetry.
+  /// That population is invisible in every other event we emit, and it is the
+  /// honest limit on any reliability number built from terminals alone.
+  ///
+  /// Content-free: an opaque take key and a closed-vocabulary backend name.
+  public func dictationStarted(takeID: String, backend: String) {
+    let event = "dictation.started"
+    let props: [String: Any] = ["take_id": takeID, "backend": backend]
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: event, stringProps: ["take_id": takeID, "backend": backend]))
+    #endif
+    PostHogSDK.shared.capture(event, properties: props)
+  }
+
+  /// A dictation ENDED, and this is what happened to it.
+  ///
+  /// `result` is one of the seven terminal labels the app already uses
+  /// internally; `reason` is a `TerminalNoticeReason` raw value, present only
+  /// when `result` is `failed`. Neither vocabulary is invented here — both ship
+  /// today, which is the whole point (founder 2026-07-31: "the backend system
+  /// just needs to match our existing reporting system").
+  ///
+  /// **`result: "failed"` is NOT "ASR failed".** It spans permission, microphone,
+  /// capture, processing and ASR causes, and it EXCLUDES `asr_interrupted`,
+  /// which is its own terminal. Anyone deriving an ASR-impact rate must select
+  /// reasons explicitly rather than counting this label.
+  ///
+  /// **Count DISTINCT `take_id`, never rows.** A healthy take also emits an
+  /// `asr.completed` stage row; adding event counts double-counts it.
+  ///
+  /// The attribution block is present only for `zero_signal` and
+  /// `asr_empty_with_speech` — the two terminals #1890 is about. Every one of
+  /// those fields omits when nil and NEVER defaults: an exact zero is the
+  /// signature of a digitally dead channel (#1809), so a manufactured `0` would
+  /// be indistinguishable from the finding this data exists to detect.
+  ///
+  /// Content-free: labels, counts, magnitudes, durations, and closed-vocabulary
+  /// transport / device-class strings. Never a device UID, name, or model; never
+  /// audio; never transcript.
+  public func dictationTerminal(
+    takeID: String,
+    backend: String,
+    result: String,
+    reason: String?,
+    inputDeviceKind: String? = nil,
+    effectiveTransport: String? = nil,
+    selectedTransport: String? = nil,
+    inputSelectionMode: String? = nil,
+    wholeBufferRMS: Float? = nil,
+    maxWindowRMS: Float? = nil,
+    peakAudioLevel: Float? = nil,
+    durationMs: Int? = nil,
+    captureNativeRateHz: Double? = nil,
+    captureNativeChannelCount: Int? = nil
+  ) {
+    let event = "dictation.terminal"
+    var props: [String: Any] = [
+      "take_id": takeID,
+      "backend": backend,
+      "result": result,
+    ]
+    if let reason { props["reason"] = reason }
+    if let inputDeviceKind { props["input_device_kind"] = inputDeviceKind }
+    if let effectiveTransport { props["effective_transport"] = effectiveTransport }
+    if let selectedTransport { props["selected_transport"] = selectedTransport }
+    if let inputSelectionMode { props["input_selection_mode"] = inputSelectionMode }
+    // Float -> Double at the boundary: PostHog carries numbers as Double.
+    if let wholeBufferRMS { props["whole_buffer_rms"] = Double(wholeBufferRMS) }
+    if let maxWindowRMS { props["max_window_rms"] = Double(maxWindowRMS) }
+    if let peakAudioLevel { props["peak_audio_level"] = Double(peakAudioLevel) }
+    if let durationMs { props["duration_ms"] = durationMs }
+    if let captureNativeRateHz { props["capture_native_rate_hz"] = captureNativeRateHz }
+    if let captureNativeChannelCount {
+      props["capture_native_channel_count"] = captureNativeChannelCount
+    }
+    #if DEBUG
+      var stringProps: [String: String] = [
+        "take_id": takeID, "backend": backend, "result": result,
+      ]
+      if let reason { stringProps["reason"] = reason }
+      for key in [
+        "input_device_kind", "effective_transport", "selected_transport", "input_selection_mode",
+      ] {
+        if let value = props[key] as? String { stringProps[key] = value }
+      }
+      var intProps: [String: Int] = [:]
+      for key in ["duration_ms", "capture_native_channel_count"] {
+        if let value = props[key] as? Int { intProps[key] = value }
+      }
+      var doubleProps: [String: Double] = [:]
+      for key in [
+        "whole_buffer_rms", "max_window_rms", "peak_audio_level", "capture_native_rate_hz",
+      ] {
+        if let value = props[key] as? Double { doubleProps[key] = value }
+      }
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: event, stringProps: stringProps, intProps: intProps, doubleProps: doubleProps))
+      Task {
+        await AppLogger.shared.log(
+          "dictation_terminal result=\(result) reason=\(reason ?? "nil") "
+            + "take=\(takeID) backend=\(backend)",
+          level: .info, category: "Telemetry")
+      }
+    #endif
+    PostHogSDK.shared.capture(event, properties: props)
+  }
+
   /// Heartpath 5b (#1520): a completed take came back zero-signal, so the fenced
   /// retire primitive was invoked. `retireAction` records whether teardown
   /// actually ran (`retired`) or was a fenced no-op. Content-free by

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -842,10 +842,24 @@ public final class TelemetryService {
       testEventHook?(
         CapturedTelemetryEvent(
           name: event, stringProps: stringProps, intProps: intProps, doubleProps: doubleProps))
+      // The attribution fields are logged as ABSENT-or-value rather than
+      // omitted, because their absence is the thing worth reading: a signal-free
+      // terminal that logs `peak=absent` is a wiring defect, and a terminal that
+      // logs `peak=0.0` is the #1809 dead-channel finding. Rendered from
+      // `doubleProps`, so a value dropped at the vendor boundary is dropped here
+      // too and Live UAT sees the same payload PostHog will.
+      let energy: String =
+        ["peak_audio_level", "whole_buffer_rms", "max_window_rms"]
+        .map { (key: String) -> String in
+          let value = doubleProps[key].map { String($0) } ?? "absent"
+          return "\(key)=\(value)"
+        }
+        .joined(separator: " ")
       Task {
         await AppLogger.shared.log(
           "dictation_terminal result=\(result) reason=\(reason ?? "nil") "
-            + "take=\(takeID) backend=\(backend)",
+            + "take=\(takeID) backend=\(backend) "
+            + "device=\(stringProps["input_device_kind"] ?? "absent") \(energy)",
           level: .info, category: "Telemetry")
       }
     #endif

--- a/Tests/EnviousWisprTests/Pipeline/DictationInvokedPipelineWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/DictationInvokedPipelineWiringTests.swift
@@ -249,19 +249,40 @@ struct DictationInvokedPipelineWiringTests {
     // The sink remains the single writer of the scope tag.
     let sinkSource = try Self.read(
       "Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift")
-    #expect(sinkSource.contains("func establishTakeID(_ takeID: String) {"))
-    let establish = try Self.slice(
-      sinkSource, from: "func establishTakeID(_ takeID: String) {", to: "\n  }")
+    // #1884: acceptance now activates BOTH effects through one method. The tag
+    // write is asserted here; the `dictation.started` emission below.
+    #expect(sinkSource.contains("func acceptSession(takeID: String) {"))
+    let acceptBody = try Self.slice(
+      sinkSource, from: "func acceptSession(takeID: String) {", to: "\n  }")
     #expect(
-      establish.contains("updateTakeID(takeID)"),
+      acceptBody.contains("updateTakeID(takeID)"),
       "must route through the same writer as the per-event refresh and terminal clear"
+    )
+    #expect(
+      acceptBody.contains("dictationStarted("),
+      "#1884: acceptance must also emit the denominator — removing it must fail this"
     )
 
     // And production actually wires it — an unwired hook is a dead guard.
     let factorySource = try Self.read(
       "Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift")
     #expect(factorySource.contains("telemetryRelay.establishTakeID(takeID)"))
-    #expect(factorySource.contains("lifecycleSink.establishTakeID(takeID)"))
+    #expect(factorySource.contains("lifecycleSink.acceptSession(takeID: takeID)"))
+
+    // #1884 terminal path: kernel -> relay -> sink, all three links. The kernel
+    // and sink defaults are INERT, so unit tests alone can pass with nothing
+    // wired in production (validation-discipline
+    // RULE: a-guard-nothing-arms-is-not-a-guard applied to an emitter).
+    #expect(factorySource.contains("telemetryRelay.deliverSessionTerminal(snapshot)"))
+    #expect(factorySource.contains("telemetryRelay.sessionTerminal = "))
+    #expect(factorySource.contains("lifecycleSink.emitTerminal(snapshot)"))
+
+    let terminalKernelSource = try Self.read(
+      "Sources/EnviousWisprPipeline/RecordingSessionKernel.swift")
+    #expect(
+      terminalKernelSource.contains("defer { sessionTerminalTelemetry(terminalSnapshot) }"),
+      "#1884: delivery must be deferred so a later cleanup return cannot lose it"
+    )
   }
 
   private static func read(_ relativePath: String) throws -> String {

--- a/Tests/EnviousWisprTests/Pipeline/DictationInvokedPipelineWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/DictationInvokedPipelineWiringTests.swift
@@ -283,6 +283,23 @@ struct DictationInvokedPipelineWiringTests {
       terminalKernelSource.contains("defer { sessionTerminalTelemetry(terminalSnapshot) }"),
       "#1884: delivery must be deferred so a later cleanup return cannot lose it"
     )
+
+    // #1890 attribution: the freeze MEASURES. Both producers previously handed it
+    // `measurement: nil`, so every signal-free row shipped without the two energy
+    // values it exists to carry, and the comment above the function claimed the
+    // measurement happened. Owning the measurement removes the argument a caller
+    // can forget; this fails if it is ever handed back out.
+    let freeze = try Self.slice(
+      terminalKernelSource,
+      from: "private func freezeSignalAttribution(", to: "\n  }")
+    #expect(
+      freeze.contains("RawAudioDeadAirClassifier.measure(samples, peak: peak)"),
+      "#1890: the freeze must measure the buffer itself"
+    )
+    #expect(
+      terminalKernelSource.contains("measurement: nil") == false,
+      "#1890: no producer may hand the freeze a measurement, least of all an absent one"
+    )
   }
 
   private static func read(_ relativePath: String) throws -> String {

--- a/Tests/EnviousWisprTests/Pipeline/DictationTerminalTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/DictationTerminalTelemetryTests.swift
@@ -1,0 +1,185 @@
+import EnviousWisprAudio
+import EnviousWisprCore
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+/// #1884 chunk 2. The two events, their contracts, and the invariants that make
+/// the frozen-snapshot design real rather than aspirational.
+@MainActor
+@Suite("Dictation terminal telemetry (#1884)")
+struct DictationTerminalTelemetryTests {
+
+  /// Captures what `emitTerminal` hands the vendor boundary.
+  private final class Recorder {
+    var terminals: [(takeID: String, backend: String, result: String, reason: String?)] = []
+    var attributions: [(kind: String?, peak: Float?, transport: String?)] = []
+    var starts: [(takeID: String, backend: String)] = []
+  }
+
+  private func makeSink(_ recorder: Recorder) -> KernelLifecycleTelemetrySink {
+    KernelLifecycleTelemetrySink(
+      backend: .parakeet,
+      audioCapture: FakeAudioCapture(),
+      context: KernelSessionContext(),
+      captureTelemetry: CaptureTelemetryState(),
+      telemetryState: KernelTelemetryState(),
+      dictationStarted: { takeID, backend in
+        recorder.starts.append((takeID, backend))
+      },
+      dictationTerminal: {
+        takeID, backend, result, reason, kind, effectiveTransport, _, _, _, _, peak, _, _, _ in
+        recorder.terminals.append((takeID, backend, result, reason))
+        recorder.attributions.append((kind, peak, effectiveTransport))
+      }
+    )
+  }
+
+  private func snapshot(
+    _ outcome: RecordingOutcome,
+    attribution: KernelSignalAttributionTelemetry? = nil
+  ) -> KernelTerminalTelemetrySnapshot {
+    KernelTerminalTelemetrySnapshot(
+      takeID: "TAKE-A", backend: "parakeet", outcome: outcome, signalAttribution: attribution)
+  }
+
+  // MARK: - The seven terminals
+
+  @Test("every terminal emits exactly one row with its expected label")
+  func everyTerminalEmitsItsLabel() {
+    let cases: [(RecordingOutcome, String)] = [
+      (.completed, "completed"),
+      (.failed(.asrFailed), "failed"),
+      (.cancelled, "cancelled"),
+      (.discarded(.tooShort), "discarded"),
+      (.noSpeech(.vadGate), "no_speech"),
+      (.audioInterrupted(.deviceRemoved), "audio_interrupted"),
+      (.asrInterrupted(wasRecording: true), "asr_interrupted"),
+    ]
+    for (outcome, expected) in cases {
+      let recorder = Recorder()
+      makeSink(recorder).emitTerminal(snapshot(outcome))
+      #expect(recorder.terminals.count == 1, "\(outcome) must emit exactly one row")
+      #expect(recorder.terminals.first?.result == expected)
+    }
+  }
+
+  /// `reason` exists only on `failed`. A reason on `cancelled` would invite a
+  /// query that reads user intent as a fault.
+  @Test("reason is present only for failed terminals")
+  func reasonOnlyOnFailure() {
+    let recorder = Recorder()
+    let sink = makeSink(recorder)
+    sink.emitTerminal(snapshot(.failed(.zeroSignal)))
+    sink.emitTerminal(snapshot(.cancelled))
+    sink.emitTerminal(snapshot(.noSpeech(.vadGate)))
+    #expect(recorder.terminals[0].reason == "zero_signal")
+    #expect(recorder.terminals[1].reason == nil)
+    #expect(recorder.terminals[2].reason == nil)
+  }
+
+  /// The two reasons #1890 counts, in the exact spelling its queries use.
+  @Test("the two signal-free reasons emit their #1890 spellings")
+  func signalFreeReasonSpellings() {
+    let recorder = Recorder()
+    let sink = makeSink(recorder)
+    sink.emitTerminal(snapshot(.failed(.zeroSignal)))
+    sink.emitTerminal(snapshot(.failed(.asrEmpty)))
+    #expect(recorder.terminals.map(\.reason) == ["zero_signal", "asr_empty_with_speech"])
+  }
+
+  // MARK: - Attribution, and the zero that must never be manufactured
+
+  @Test("attribution rides along when present")
+  func attributionIsCarried() {
+    let recorder = Recorder()
+    makeSink(recorder).emitTerminal(
+      snapshot(
+        .failed(.zeroSignal),
+        attribution: KernelSignalAttributionTelemetry(
+          inputDeviceKind: "built_in_mic", effectiveTransport: "builtin",
+          selectedTransport: nil, inputSelectionMode: "auto",
+          wholeBufferRMS: 0.0001, maxWindowRMS: 0.0002, peakAudioLevel: 0.0007,
+          durationMs: 3200, captureNativeRateHz: 48000, captureNativeChannelCount: 1)))
+    #expect(recorder.attributions.first?.kind == "built_in_mic")
+    #expect(recorder.attributions.first?.peak == 0.0007)
+    #expect(recorder.attributions.first?.transport == "builtin")
+  }
+
+  /// A take that is not signal-free carries no attribution at all — absent, not
+  /// zeroed. This is the two-way control for the invariant below.
+  @Test("a healthy terminal carries no attribution fields")
+  func healthyTerminalHasNoAttribution() {
+    let recorder = Recorder()
+    makeSink(recorder).emitTerminal(snapshot(.completed))
+    #expect(recorder.attributions.first?.kind == nil)
+    #expect(recorder.attributions.first?.peak == nil)
+  }
+
+  /// The invariant #1809 bought with real pain: a MISSING peak must stay
+  /// missing, because an exact zero is the signature of a digitally dead
+  /// channel. Both directions asserted — absent stays absent, and a genuine 0.0
+  /// still travels, because that reading IS the finding.
+  @Test("a missing peak omits; a measured exact zero is preserved")
+  func peakNeverManufacturesAZero() {
+    let missing = Recorder()
+    makeSink(missing).emitTerminal(
+      snapshot(
+        .failed(.zeroSignal),
+        attribution: KernelSignalAttributionTelemetry(
+          inputDeviceKind: nil, effectiveTransport: nil, selectedTransport: nil,
+          inputSelectionMode: nil, wholeBufferRMS: nil, maxWindowRMS: nil,
+          peakAudioLevel: nil, durationMs: nil, captureNativeRateHz: nil,
+          captureNativeChannelCount: nil)))
+    #expect(missing.attributions.first?.peak == nil, "a missing reading must never become 0")
+
+    let measuredZero = Recorder()
+    makeSink(measuredZero).emitTerminal(
+      snapshot(
+        .failed(.zeroSignal),
+        attribution: KernelSignalAttributionTelemetry(
+          inputDeviceKind: nil, effectiveTransport: nil, selectedTransport: nil,
+          inputSelectionMode: nil, wholeBufferRMS: nil, maxWindowRMS: nil,
+          peakAudioLevel: 0.0, durationMs: nil, captureNativeRateHz: nil,
+          captureNativeChannelCount: nil)))
+    #expect(
+      measuredZero.attributions.first?.peak == 0.0,
+      "a MEASURED zero is the diagnostic finding and must survive")
+  }
+
+  // MARK: - The identity race this design exists to remove
+
+  /// Take B may already be running by the time take A's row is rendered. The
+  /// snapshot must therefore be sufficient on its own: rendering reads it and
+  /// nothing else, so nothing take B does can change what take A reported.
+  @Test("a snapshot renders identically regardless of later state")
+  func snapshotIsSelfSufficient() {
+    let recorder = Recorder()
+    let sink = makeSink(recorder)
+    let takeA = snapshot(.failed(.zeroSignal))
+    // Emit twice with an unrelated terminal in between, standing in for take B
+    // having moved the world on.
+    sink.emitTerminal(takeA)
+    sink.emitTerminal(snapshot(.completed))
+    sink.emitTerminal(takeA)
+    #expect(recorder.terminals[0].takeID == "TAKE-A")
+    #expect(recorder.terminals[0].result == "failed")
+    #expect(
+      recorder.terminals[2].takeID == recorder.terminals[0].takeID,
+      "the same snapshot must render the same row, whatever happened in between")
+    #expect(recorder.terminals[2].result == recorder.terminals[0].result)
+  }
+
+  // MARK: - The denominator
+
+  @Test("acceptance emits exactly one started row carrying the same identity")
+  func acceptanceEmitsTheDenominator() {
+    let recorder = Recorder()
+    makeSink(recorder).acceptSession(takeID: "TAKE-A")
+    #expect(recorder.starts.count == 1)
+    #expect(recorder.starts.first?.takeID == "TAKE-A")
+    #expect(recorder.starts.first?.backend == "parakeet")
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/DictationTerminalTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/DictationTerminalTelemetryTests.swift
@@ -66,6 +66,36 @@ struct DictationTerminalTelemetryTests {
     }
   }
 
+  /// Every outcome, with the reason each one owes. `result` and `reason` are both
+  /// read from the SAME projection, so a `failed` row without a reason is a
+  /// contradiction rather than a gap — which is what `.noTransport` shipped as
+  /// until the whole-diff review caught it: it projects to
+  /// `.failed(.noAudioCaptured)`, so an outcome-side match labelled it `failed`
+  /// and then found no reason to attach, hiding it from every reason-keyed count.
+  @Test("a failed row always carries a reason, and only failed rows do")
+  func failedAlwaysCarriesItsReason() {
+    let cases: [(RecordingOutcome, String, String?)] = [
+      (.completed, "completed", nil),
+      (.failed(.asrFailed), "failed", "asr_failed"),
+      (.cancelled, "cancelled", nil),
+      (.discarded(.tooShort), "discarded", nil),
+      (.noSpeech(.vadGate), "no_speech", nil),
+      (.audioInterrupted(.deviceRemoved), "audio_interrupted", nil),
+      (.asrInterrupted(wasRecording: true), "asr_interrupted", nil),
+      (.noTransport, "failed", "no_audio_captured"),
+    ]
+    for (outcome, expectedResult, expectedReason) in cases {
+      let recorder = Recorder()
+      makeSink(recorder).emitTerminal(snapshot(outcome))
+      #expect(recorder.terminals.first?.result == expectedResult, "\(outcome) result")
+      #expect(recorder.terminals.first?.reason == expectedReason, "\(outcome) reason")
+      #expect(
+        (recorder.terminals.first?.result == "failed")
+          == (recorder.terminals.first?.reason != nil),
+        "\(outcome): a failed row without a reason is unqueryable")
+    }
+  }
+
   /// `reason` exists only on `failed`. A reason on `cancelled` would invite a
   /// query that reads user intent as a fault.
   @Test("reason is present only for failed terminals")

--- a/Tests/EnviousWisprTests/Pipeline/KernelHeartPathTelemetryObserverTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelHeartPathTelemetryObserverTests.swift
@@ -273,7 +273,11 @@ import Testing
       _ outcome: RecordingOutcome,
       isStreaming: Bool = false
     ) -> KernelLifecycleEvent? {
-      KernelHeartPathTelemetryObserver.terminalEvent(for: outcome, isStreaming: isStreaming)
+      // #1884: the switch moved to the shared `RecordingOutcome.lifecycleEvent`
+      // projection so terminal telemetry renders the identical value. This
+      // helper keeps returning an optional so every existing expectation below
+      // reads unchanged; the projection itself is total.
+      outcome.lifecycleEvent
     }
 
     /// The pure in-flight tuple-delta → lifecycle-events map (#1548 D1). Every

--- a/Tests/EnviousWisprTests/Pipeline/KernelLifecycleRecordingScopeBaselineTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelLifecycleRecordingScopeBaselineTests.swift
@@ -156,8 +156,9 @@ import Testing
       // hand-picking an event, so the test cannot drift from what the observer
       // would really emit.
       let outcome = try #require(kernel.recordingOutcome)
-      let event = try #require(
-        KernelHeartPathTelemetryObserver.terminalEvent(for: outcome, isStreaming: false))
+      // #1884: `lifecycleEvent` is total, so no `#require` — every outcome IS an
+      // ending and there is no "not a terminal" answer to unwrap.
+      let event = outcome.lifecycleEvent
 
       let recorder = RecordingStateRecorder()
       let sink = makeSink(recorder: recorder)

--- a/Tests/EnviousWisprTests/Pipeline/KernelTerminalProjectionsTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelTerminalProjectionsTests.swift
@@ -1,0 +1,123 @@
+import Testing
+
+@testable import EnviousWisprCore
+@testable import EnviousWisprPipeline
+
+/// #1884 chunk 1. The two shared projections a concluded take is classified by.
+///
+/// These are the vocabulary authority for `dictation.terminal`. A wrong value
+/// here is not a crash, it is a silently mislabelled dictation that looks
+/// exactly like a correctly labelled one in every dashboard — so the mapping is
+/// asserted exhaustively rather than sampled.
+@Suite("Kernel terminal projections (#1884)")
+struct KernelTerminalProjectionsTests {
+
+  // MARK: - RecordingFailureReason → TerminalNoticeReason
+
+  /// Exact and exhaustive: all 13 reasons, named individually.
+  ///
+  /// Deliberately NOT a loop over `CaseIterable` comparing to itself — that
+  /// would assert the mapping equals the mapping. Each expected raw value is
+  /// written out so a wrong-but-plausible edit has to be typed by hand.
+  @Test("every failure reason maps to its shipped snake_case code")
+  func reasonMappingIsExhaustiveAndExact() {
+    let expected: [(RecordingFailureReason, String)] = [
+      (.prepareFailed, "prepare_failed"),
+      (.permissionDenied, "permission_denied"),
+      (.modelWedged, "model_wedged"),
+      (.modelLoadFailed, "model_load_failed"),
+      (.captureStartFailed, "capture_start_failed"),
+      (.noMicrophoneFound, "no_microphone_found"),
+      (.noAudioCaptured, "no_audio_captured"),
+      (.asrEmpty, "asr_empty_with_speech"),
+      (.asrFailed, "asr_failed"),
+      (.asrWedged, "asr_wedged"),
+      (.emptyAfterProcessing, "empty_after_processing"),
+      (.captureStalled, "capture_stalled"),
+      (.zeroSignal, "zero_signal"),
+    ]
+
+    #expect(expected.count == 13, "13 RecordingFailureReason cases exist; update this table")
+
+    for (reason, code) in expected {
+      #expect(
+        reason.terminalNoticeReason.rawValue == code,
+        "\(reason) must emit \(code)")
+    }
+  }
+
+  /// The one non-identity mapping, called out because it is the name #1890
+  /// counts and an "obvious" correction to `asr_empty` would silently break
+  /// that issue's queries.
+  @Test("asrEmpty maps to asr_empty_with_speech, not asr_empty")
+  func asrEmptyKeepsItsMoreSpecificName() {
+    #expect(RecordingFailureReason.asrEmpty.terminalNoticeReason == .asrEmptyWithSpeech)
+    #expect(
+      RecordingFailureReason.asrEmpty.terminalNoticeReason.rawValue == "asr_empty_with_speech")
+  }
+
+  /// Cheap diagnostic, NOT the vocabulary authority — a wrong snake_case value
+  /// passes this. The exhaustive table above is what actually pins the codes.
+  @Test("no emitted reason code contains an uppercase letter")
+  func reasonCodesAreSnakeCase() {
+    for reason in TerminalNoticeReason.allCases {
+      #expect(
+        reason.rawValue == reason.rawValue.lowercased(),
+        "\(reason.rawValue) is not snake_case — raw Swift case names must never be emitted")
+    }
+  }
+
+  // MARK: - RecordingOutcome → KernelLifecycleEvent
+
+  @Test("every outcome projects to its terminal lifecycle event")
+  func outcomeProjectionCoversEveryEnding() {
+    #expect(RecordingOutcome.completed.lifecycleEvent == .pipelineCompleted)
+    #expect(RecordingOutcome.cancelled.lifecycleEvent == .cancelled)
+    #expect(RecordingOutcome.failed(.asrFailed).lifecycleEvent == .failed(.asrFailed))
+    #expect(RecordingOutcome.noSpeech(.vadGate).lifecycleEvent == .noSpeech(.vadGate))
+    #expect(RecordingOutcome.discarded(.tooShort).lifecycleEvent == .discarded(.tooShort))
+    #expect(
+      RecordingOutcome.asrInterrupted(wasRecording: true).lifecycleEvent
+        == .asrInterrupted(wasRecording: true))
+  }
+
+  /// LOCKED projection. `.noTransport` reuses an existing telemetry identity
+  /// rather than minting a new one, so a transport-less take is counted with the
+  /// captured-nothing family. Changing this splits a population across two names
+  /// with no migration.
+  @Test("noTransport projects to the existing noAudioCaptured identity")
+  func noTransportKeepsItsLockedProjection() {
+    #expect(RecordingOutcome.noTransport.lifecycleEvent == .failed(.noAudioCaptured))
+  }
+
+  /// An interrupted take with no stamped cause is still an unowned loss (#1174
+  /// A3), so it defaults to `.engineLost` rather than being dropped.
+  @Test("audioInterrupted with no cause defaults to engineLost")
+  func interruptedWithoutCauseStillCounts() {
+    #expect(
+      RecordingOutcome.audioInterrupted(nil).lifecycleEvent
+        == .audioInterrupted(cause: .engineLost))
+    #expect(
+      RecordingOutcome.audioInterrupted(.deviceRemoved).lifecycleEvent
+        == .audioInterrupted(cause: .deviceRemoved))
+  }
+
+  /// Every projected event must be a TERMINAL one. A projection landing on a
+  /// non-terminal would emit `result: nil` and produce an unqueryable row.
+  /// `@MainActor` because `KernelLifecycleTelemetrySink` is main-actor isolated;
+  /// the projections themselves are pure and need no isolation.
+  @MainActor
+  @Test("every projected event is a terminal, never a mid-flight event")
+  func everyProjectionIsTerminal() {
+    let endings: [RecordingOutcome] = [
+      .completed, .cancelled, .noTransport,
+      .failed(.zeroSignal), .noSpeech(.vadGate), .discarded(.tooShort),
+      .audioInterrupted(nil), .asrInterrupted(wasRecording: false),
+    ]
+    for outcome in endings {
+      #expect(
+        KernelLifecycleTelemetrySink.terminalStateLabel(for: outcome.lifecycleEvent) != nil,
+        "\(outcome) projected to a non-terminal event")
+    }
+  }
+}

--- a/Tests/RuntimeUAT/wispr_eyes.py
+++ b/Tests/RuntimeUAT/wispr_eyes.py
@@ -1230,11 +1230,44 @@ def switch_backend(name, wait=3.0):
             raise RuntimeError("Could not tap 'Transcription' in the Settings sidebar")
     time.sleep(0.3)
     label = _BACKEND_LABELS[name]
-    if not tap(label):
-        raise RuntimeError(f"Could not tap '{label}' button in Settings -> Transcription")
+    # These two engine buttons carry their label in AXDescription with an EMPTY
+    # AXTitle, which `tap()` does not search — so `tap("Fast")` reported
+    # 'Fast' not found while `see()` printed the button one line above
+    # (#1884 Live UAT, 2026-07-31). A missing control and an unsearched attribute
+    # look identical from the caller, which is why this resolves the element
+    # itself rather than retrying a tap that can never match.
+    button = _engine_button(label)
+    if button is None:
+        raise RuntimeError(
+            f"Could not find the '{label}' engine button in Settings -> Transcription")
+    if not perform_action(button, "AXPress"):
+        raise RuntimeError(f"Could not press the '{label}' engine button")
+    # Prove the switch LANDED, by waiting on the button's own selection state.
+    # Pressing and assuming is the precondition-never-checked shape: every later
+    # assertion would then describe whichever engine was already selected.
+    deadline = time.time() + 5.0
+    while time.time() < deadline:
+        if str(get_attr(_engine_button(label), "AXValue") or "") == "Selected":
+            break
+        time.sleep(0.25)  # settle: poll interval around the AXValue signal wait above, not a fixed delay
+    else:
+        raise RuntimeError(f"Pressed '{label}' but it never reported itself selected")
     print(f"Switched backend to {name} ({label}); waiting {wait:.0f}s for model load...")
     time.sleep(wait)
     return True
+
+
+def _engine_button(label):
+    """The Transcription-pane engine button whose AXDescription is *label*.
+
+    Separate from `tap()` on purpose: `tap()` matches AXTitle/AXValue across the
+    whole app, and matching a description app-wide would make every caller's
+    taps fuzzier. Returns None when absent.
+    """
+    for el in find_all_elements(_app, role="AXButton"):
+        if (get_attr(el, "AXDescription") or "") == label:
+            return el
+    return None
 
 
 def test_recording(audio=None, sentence=None, hold=3.0, expect=None, timeout=30.0):

--- a/scripts/telemetry-join.py
+++ b/scripts/telemetry-join.py
@@ -79,7 +79,7 @@ LEGACY_IDENTITY_LABEL = "legacy Sentry identity"
 TAKE_TAG = "dictation.take_id"
 TAKE_PROPERTY = "take_id"
 
-# The 13 events Phase 2 routes the take key to. MEASURED from the emitter, not
+# The events Phase 2 routes the take key to. MEASURED from the emitter, not
 # remembered: every name here has a `["take_id"] = takeID` assignment in
 # `TelemetryService.swift`. Match the FIELD, not a `props`/`properties` variable
 # name — a pattern pinned to `props[...]` structurally cannot match the
@@ -94,6 +94,11 @@ TAKE_KEYED_EVENTS = (
     "dictation.first_vad_chunk_completed",
     "dictation.first_vad_chunk_started",
     "dictation.invoked",
+    # #1884: the outcome distribution. `dictation.started` is the denominator
+    # (an accepted take with no terminal crashed, hung, or was force-quit);
+    # `dictation.terminal` classifies every observed ending.
+    "dictation.started",
+    "dictation.terminal",
     "dictation.vad_preparation_completed",
     "llm.polish_completed",
     "llm.polish_failed",
@@ -1668,7 +1673,7 @@ def fetch_take_rates(
     # denominator drawn from its own numerator. The first version of the
     # arithmetic case froze that as `1/1`.
     # ELIGIBLE, not SUCCESSFUL. Plan section 5 defines the affected-user rate over
-    # "installs with >=1 ELIGIBLE take" — any of the 13 keyed events — while the
+    # "installs with >=1 ELIGIBLE take" — any registered keyed event — while the
     # TAKE-level rate above deliberately uses successful `dictation.completed`
     # takes. One filter served both and quietly narrowed this denominator: an
     # install with keyed VAD, invocation or failure events but no successful
@@ -3351,7 +3356,10 @@ def run_self_test() -> int:
     ]
     assert queried == list(TAKE_KEYED_EVENTS), queried
     assert len(coverage_transport.seen) == len(TAKE_KEYED_EVENTS), len(coverage_transport.seen)
-    passed("take coverage queries every one of the 13 events, one bounded query each")
+    passed(
+        f"take coverage queries every one of {len(TAKE_KEYED_EVENTS)} events, "
+        "one bounded query each"
+    )
 
     # TRUNCATION. Measured 2026-07-30: PostHog caps a HogQL result at 100 rows and
     # sets `hasMore: true`. Every query in this file is an aggregate or a bounded


### PR DESCRIPTION
Part of #1884, Part of #1890

## What this answers

Today we can count dictations. We cannot say which ones worked.

`transcription_failed` in the daily report is a ratio of two unrelated numerators, and no event in the app says what happened to a given dictation. So "our total dictations are X" comes with no way to split it into succeeded, failed, and normal-but-not-a-bug — which is the exact gap the founder named.

Two events close it, and neither invents a vocabulary:

- `dictation.started` — emitted synchronously at the acceptance seam. The denominator, and the only way a take that crashed, hung, or was force-quit is visible at all: a started row with no terminal.
- `dictation.terminal` — one row per accepted terminal. `result` is one of the seven labels the app already uses internally. `reason` is a `TerminalNoticeReason` raw value, present only on `failed` — the same string the user was shown. A signal-free terminal also carries the hardware and energy facts #1890 asked for.

Both carry `take_id`, so both join to Sentry and to the rest of the take-keyed events.

## Why it is one PR

#1890 wanted `zero_signal` and `asr_empty_with_speech` counted with signal-level attribution. Both are already `TerminalNoticeReason` raw values, so they are the same emit moment, the same event, and the same vocabulary as #1884. Two PRs would have been one mechanism built twice.

## Shape

- One projection decides how a dictation ended, replacing two switches that could disagree. `result` and `reason` are both read from it.
- The terminal snapshot is frozen synchronously inside the set-once barrier and delivered by `defer`, so a take cannot be reported under the next take's identity — every other terminal signal reaches telemetry through an observer that documents itself as not a lossless queue.
- Signal attribution is frozen at its producer, never re-read at the terminal, where a live read can name a newer source.

## Review

Whole-diff review found two real defects, both verified against the code before being adopted:

- `.noTransport` projects to a failure but its reason was matched against the raw outcome, so those takes said `failed` with no reason and vanished from every reason-keyed count while still counting in the total.
- The attribution freeze took a measurement argument that both producers passed as nil, so the two energy values were absent from exactly the rows #1890 exists to characterise. The comment above it said it measured.

Rounds 2 and 3 found nothing.

## Live UAT

Six legs, both engines, on a binary verified to be this worktree's build. Verdicts read from the app log past a recorded baseline, exact counts asserted.

| Leg | Parakeet | WhisperKit |
|---|---|---|
| healthy control -> `completed`, no reason, no attribution | PASS | PASS |
| forced decode failure -> `failed` / `asr_failed` | PASS | PASS |
| signal-free capture -> `failed` / `zero_signal` + attribution | PASS | PASS |

Every leg also asserts exactly one started row, exactly one terminal row, and the same take id on both.

The signal-free legs report `peak=0.0 whole_buffer_rms=0.0 max_window_rms=0.0 device=built_in_mic`. A measured zero surviving the whole path is the point: an exact zero is the signature of a digitally dead channel, so a manufactured zero would be indistinguishable from the finding. The healthy legs assert the opposite direction — no attribution at all.

## Also here

- The debug log line now renders the attribution fields, without which the #1890 half was verifiable only in unit tests.
- Engine switching in the UAT harness could not find the two engine buttons (their label lives in an attribute the generic tap does not read) and never checked that a switch landed. Both fixed, verified live.

## Receipts

- `scripts/xcode-test.sh` -> `** TEST SUCCEEDED **`, `==> Debug lane executed 4701 tests`
- `python3 scripts/telemetry-join.py --self-test` -> `Self-test: 60 cases passed, 0 failed`
