### PR TITLE
feat(telemetry): report which Mac, not just which architecture (Part of #1572)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift
@@ -245,7 +245,8 @@ final class AppLifecycleCoordinator {
       let snap = AppleIntelligenceDiagnosticsService.launchSnapshot()
       await TelemetryService.shared.appLaunched(
         version: version, build: build, osVersion: osVersion,
-        hardware: snap.hardwareClass, isFreshInstall: isFreshInstall,
+        hardware: snap.hardwareClass, deviceModel: snap.deviceModel,
+        isFreshInstall: isFreshInstall,
         aiCapable: snap.isCapable, aiEnabled: snap.isEnabled)
     }
 

--- a/Sources/EnviousWisprCore/AppleIntelligenceDiagnostics.swift
+++ b/Sources/EnviousWisprCore/AppleIntelligenceDiagnostics.swift
@@ -117,7 +117,26 @@ public struct AIGateSet: Sendable, Codable {
 /// `AppleIntelligenceDiagnosticsService.launchSnapshot()`.
 public struct LaunchAvailabilitySnapshot: Sendable {
   /// `hw.machine` (e.g. "arm64"). Live sysctl, always real — never "unknown" via a missing cache.
+  ///
+  /// This is the ARCHITECTURE, and it is the same string for every Apple Silicon
+  /// Mac we ship to. It cannot answer "which Macs", only "is it ARM" — see
+  /// `deviceModel`.
   public let hardwareClass: String
+  /// `hw.model` (e.g. "Mac16,8"). The specific machine.
+  ///
+  /// Separate field rather than a redefinition of `hardwareClass`: that one is
+  /// already emitted and already charted, and silently changing what a shipped
+  /// property means corrupts its own history.
+  ///
+  /// Why it exists (#1572): Sentry records the exact model but only on failures,
+  /// so it has no denominator, and PostHog had the whole population reporting
+  /// `arm64`. Neither could answer "do M5 users get worse transcription than
+  /// everyone else", because one side had no population and the other had no
+  /// model. Founder-approved 2026-07-28.
+  ///
+  /// Metadata, not content: it describes the machine, never anything the user
+  /// said or typed, so it sits inside the privacy boundary (CLAUDE.md § Privacy).
+  public let deviceModel: String
   /// Framework compiled in AND macOS 26+ AND the device is hardware-eligible (NOT
   /// `.deviceNotEligible`): the device CAN run Apple Intelligence. The user may
   /// still have it switched off or the model may be downloading — see `isEnabled`.
@@ -125,8 +144,9 @@ public struct LaunchAvailabilitySnapshot: Sendable {
   /// `SystemLanguageModel.default.availability == .available`: eligible + enabled + model-ready right now.
   public let isEnabled: Bool
 
-  public init(hardwareClass: String, isCapable: Bool, isEnabled: Bool) {
+  public init(hardwareClass: String, deviceModel: String, isCapable: Bool, isEnabled: Bool) {
     self.hardwareClass = hardwareClass
+    self.deviceModel = deviceModel
     self.isCapable = isCapable
     self.isEnabled = isEnabled
   }

--- a/Sources/EnviousWisprLLM/AppleIntelligenceDiagnosticsService.swift
+++ b/Sources/EnviousWisprLLM/AppleIntelligenceDiagnosticsService.swift
@@ -134,7 +134,8 @@ public enum AppleIntelligenceDiagnosticsService {
     let isCapable = frameworkAndOS && !deviceIneligible
     let isEnabled = eligibility?.status == .passed
     return LaunchAvailabilitySnapshot(
-      hardwareClass: hardwareClass, isCapable: isCapable, isEnabled: isEnabled)
+      hardwareClass: hardwareClass, deviceModel: currentDeviceModel(),
+      isCapable: isCapable, isEnabled: isEnabled)
   }
 
   // MARK: - Timeout Helpers
@@ -358,12 +359,27 @@ public enum AppleIntelligenceDiagnosticsService {
     return "\(v.majorVersion).\(v.minorVersion).\(v.patchVersion)"
   }
 
-  private static func currentHardwareClass() -> String {
+  private static func currentHardwareClass() -> String { sysctlString("hw.machine") }
+
+  private static func currentDeviceModel() -> String { sysctlString("hw.model") }
+
+  /// One sysctl string reader for both hardware keys.
+  ///
+  /// Written as one function rather than two near-identical bodies: the
+  /// NUL-trimming and the sign-flip from `CChar` are the parts that are easy to
+  /// get subtly wrong, and a second copy is a second chance to get them wrong.
+  ///
+  /// Returns "unknown" rather than an empty string when the key is missing or the
+  /// read fails, so a failed read is distinguishable in the data from a machine
+  /// that genuinely reported nothing. An empty string would silently group with
+  /// every other empty value.
+  private static func sysctlString(_ key: String) -> String {
     var size: size_t = 0
-    sysctlbyname("hw.machine", nil, &size, nil, 0)
-    var machine = [CChar](repeating: 0, count: size)
-    sysctlbyname("hw.machine", &machine, &size, nil, 0)
-    return String(
-      decoding: machine.prefix(while: { $0 != 0 }).map { UInt8(bitPattern: $0) }, as: UTF8.self)
+    guard sysctlbyname(key, nil, &size, nil, 0) == 0, size > 0 else { return "unknown" }
+    var buffer = [CChar](repeating: 0, count: size)
+    guard sysctlbyname(key, &buffer, &size, nil, 0) == 0 else { return "unknown" }
+    let value = String(
+      decoding: buffer.prefix(while: { $0 != 0 }).map { UInt8(bitPattern: $0) }, as: UTF8.self)
+    return value.isEmpty ? "unknown" : value
   }
 }

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -241,7 +241,8 @@ public final class TelemetryService {
   // MARK: - App Lifecycle
 
   public func appLaunched(
-    version: String, build: String, osVersion: String, hardware: String, isFreshInstall: Bool,
+    version: String, build: String, osVersion: String, hardware: String,
+    deviceModel: String, isFreshInstall: Bool,
     aiCapable: Bool, aiEnabled: Bool
   ) {
     PostHogSDK.shared.capture(
@@ -251,6 +252,9 @@ public final class TelemetryService {
         "build": build,
         "os_version": osVersion,
         "hardware": hardware,
+        // #1572: the SPECIFIC machine, alongside the architecture. `hardware` keeps
+        // its meaning so its own history stays readable.
+        "device_model": deviceModel,
         "is_fresh_install": isFreshInstall,
         "ai_capable": aiCapable,
         "ai_enabled": aiEnabled,

--- a/Tests/EnviousWisprTests/LLM/LaunchAvailabilitySnapshotTests.swift
+++ b/Tests/EnviousWisprTests/LLM/LaunchAvailabilitySnapshotTests.swift
@@ -65,6 +65,32 @@ struct LaunchAvailabilitySnapshotTests {
     #expect(afterPoison.hardwareClass != "poisoned-fake-hw")
   }
 
+  /// #1572. The whole point of this field is that it is NOT the architecture:
+  /// `hardwareClass` reads `arm64` on every Mac we ship to, so it can never
+  /// answer "which Macs". Asserting only that the field is populated would pass
+  /// on a copy of `hardwareClass`, which is the mistake worth freezing against.
+  @Test("device model is the specific machine, not the architecture")
+  func deviceModelIsTheMachineNotTheArchitecture() {
+    let snap = AppleIntelligenceDiagnosticsService.launchSnapshot()
+    #expect(snap.deviceModel.isEmpty == false)
+    #expect(
+      snap.deviceModel != snap.hardwareClass,
+      "device_model must not be a second copy of the architecture")
+    // Stable across calls, same as the architecture read.
+    #expect(AppleIntelligenceDiagnosticsService.launchSnapshot().deviceModel == snap.deviceModel)
+  }
+
+  /// A failed read reports `unknown` rather than an empty string, so it groups
+  /// separately in the data instead of merging with every other empty value.
+  /// Real hardware answers `hw.model`, so on a healthy machine this is the
+  /// model — the assertion accepts either and rejects the empty string, which is
+  /// the only genuinely unusable answer.
+  @Test("a device model is either a real model string or the explicit unknown")
+  func deviceModelIsNeverEmpty() {
+    let value = AppleIntelligenceDiagnosticsService.launchSnapshot().deviceModel
+    #expect(value == "unknown" || value.contains(","), "saw \(value)")
+  }
+
   @Test("isEnabled implies isCapable")
   func isEnabledImpliesCapable() {
     let snap = AppleIntelligenceDiagnosticsService.launchSnapshot()


### PR DESCRIPTION
Part of #1572

## What was broken

`app.launched` reported `hardware`, read from `hw.machine`. That is the ARCHITECTURE, so all 620 users report `arm64` and the field can never answer "which Macs".

That is the whole blocker on #1572. Sentry knows the exact model but records only failures, so it has no denominator. PostHog has the entire population and no model. Neither side can answer whether one class of machine has a worse time than another — which is exactly what #1572 needs to know about M5 and the Neural-Engine-excluded compute path.

Founder-approved 2026-07-28. Never built.

## A new field, not a redefinition

`device_model` from `hw.model`, alongside `hardware` rather than replacing it. Silently changing what a shipped property means corrupts its own history — the same reasoning that pins Sentry descriptors forever.

## One reader for both keys

The two hardware reads now share `sysctlString(_:)`. The NUL-trimming and the sign-flip out of `CChar` are the parts that are easy to get subtly wrong, and a second copy is a second chance to get them wrong.

It also fails honestly. The old reader ignored both sysctl return values and would hand back an empty string on a failed read. This one returns the literal `unknown`, so a failed read groups separately in the data instead of merging with every other empty value.

## Tests

Two, and the first is the one that matters: `device_model` must NOT equal `hardwareClass`. Asserting only that the field is populated would pass on a copy of the architecture, which is precisely the bug being fixed.

## Verified on the dev build, not assumed

`observability-operations.md` RULE: verify-telemetry-on-the-dev-build-never-wait-for-production.

```
hardware=arm64 device_model=Mac16,8  2026-07-31T18:35:21
hardware=arm64 device_model=None     2026-07-31T18:24:54   (before this change)
```

The field arrives, carries the real machine, and the architecture field is untouched.

## Privacy

Metadata about the machine, never anything the user said or typed. Inside the boundary in CLAUDE.md § Privacy, and Sentry already collects it.

## Receipts

- `scripts/xcode-test.sh` → `** TEST SUCCEEDED **`, `==> Debug lane executed 4709 tests`
- Local diff review: clean, no findings
