### PR TITLE
fix(asr): stop dropping the last words of a live dictation (Closes #1308)

### DIFF
--- a/Sources/EnviousWisprASR/WhisperKitStreamingSession.swift
+++ b/Sources/EnviousWisprASR/WhisperKitStreamingSession.swift
@@ -152,13 +152,6 @@ package actor WhisperKitStreamingSession: WhisperKitIncrementalSession {
   private var lastConfirmedSec: Float = 0
   /// Sample count at the last decode, to gate the >= 1s-new-audio check.
   private var lastDecodeSampleCount: Int = 0
-
-  /// How far the decoded WORDS have reached, in samples (#1308). Distinct from
-  /// `lastDecodeSampleCount`, which records how much audio a decode was HANDED.
-  /// Finalize's caught-up check reads this one: a decode that produced words
-  /// covering 6s of an 11s buffer has not heard the last 5s, however much audio
-  /// it was given.
-  private var lastWordCoverageSampleCount: Int = 0
   private var decodeCount: Int = 0
   private var totalDecodeTimeMs: Int = 0
 
@@ -285,7 +278,6 @@ package actor WhisperKitStreamingSession: WhisperKitIncrementalSession {
     confirmedText = ""
     lastConfirmedSec = 0
     lastDecodeSampleCount = 0
-    lastWordCoverageSampleCount = 0
     decodeCount = 0
     totalDecodeTimeMs = 0
     retainedUnconfirmedSegments = []
@@ -434,12 +426,25 @@ package actor WhisperKitStreamingSession: WhisperKitIncrementalSession {
     // `streamingResult` trims the edges.
     let releaseText = confirmedText + retainedUnconfirmedSegments.map(\.text).joined()
 
-    // Exact bookkeeping: audio the decoded WORDS never reached (#1308). Reads
-    // `lastWordCoverageSampleCount`, NOT `lastDecodeSampleCount` — the latter is
-    // how much audio a decode was handed, and handing a decoder 11s of audio that
-    // yields 6s of words does not make the last 5s heard. Using it here released
-    // without the tail decode below and dropped the user's final words.
-    let unheardStart = max(0, min(count, lastWordCoverageSampleCount))
+    // Exact bookkeeping (#1308): audio that the text we are ABOUT TO RELEASE does
+    // not cover. Derived from `releaseText`'s own words — `lastConfirmedSec` for
+    // the committed prefix, the last retained segment for the held-back tail —
+    // never from `lastDecodeSampleCount`.
+    //
+    // That marker records how much audio a decode was HANDED, and handing a
+    // decoder 11s that yields 6s of words does not make the last 5s heard. Using
+    // it here skipped the tail decode below and dropped the user's final words.
+    //
+    // Deriving it here rather than caching it during the loop is deliberate, and
+    // whole-diff review is why. A cached high-water mark went wrong twice: it read
+    // UNFILTERED words, so a hallucinated timestamp in the 30s window's silence
+    // padding claimed full coverage even though `applyLocalAgreement` discarded
+    // that word; and being monotonic it held an older, farther endpoint after a
+    // later hypothesis retracted its final word, hiding real audio from the
+    // unheard slice. Both recreate the exact silent tail loss this fixes. The
+    // release hypothesis cannot disagree with itself.
+    let releasedEndSec = max(lastConfirmedSec, retainedUnconfirmedSegments.last?.end ?? 0)
+    let unheardStart = max(0, min(count, Int(releasedEndSec * 16_000)))
     let unheardSlice = unheardStart < count ? Array(samples[unheardStart..<count]) : []
     let unheardSec = Float(unheardSlice.count) / 16_000.0
     if unheardSec < minVoicedTailSec || rms(unheardSlice) <= tailEnergyFloor || samples.isEmpty {
@@ -627,15 +632,7 @@ package actor WhisperKitStreamingSession: WhisperKitIncrementalSession {
         // instant-release over voiced audio that never transcribed (its energy
         // gate routes genuine silence to release, fresh speech to the bounded
         // buffer decode).
-        //
-        // #1308: this marker answers "how much audio has a decode SEEN", which is
-        // the right question for the cadence gate above and the WRONG one for
-        // finalize's caught-up check. Both are recorded, separately.
-        if heard {
-          lastDecodeSampleCount = count
-          lastWordCoverageSampleCount = max(
-            lastWordCoverageSampleCount, wordCoverageSampleCount(from: results, cap: count))
-        }
+        if heard { lastDecodeSampleCount = count }
         decodeCount += 1
         let elapsedMs = Int((CFAbsoluteTimeGetCurrent() - decodeStart) * 1000)
         totalDecodeTimeMs += elapsedMs
@@ -648,30 +645,6 @@ package actor WhisperKitStreamingSession: WhisperKitIncrementalSession {
         }
       }
     }
-  }
-
-  /// How far this decode's WORDS actually reached, in samples (#1308).
-  ///
-  /// Deliberately NOT folded into `lastDecodeSampleCount`. That marker also gates
-  /// the live decode cadence at the top of the loop, so lagging it behind the fed
-  /// audio would make the loop re-decode unchanged audio on every cycle whenever
-  /// the words trail by a second. Two questions, two values: how much audio a
-  /// decode has SEEN drives cadence, how far the WORDS reached drives whether
-  /// finalize still owes a tail decode.
-  ///
-  /// `min(cap, …)` because a decoder can stamp a word past the buffer, into the
-  /// 30s window's silence padding — the same hallucination `applyLocalAgreement`
-  /// already clamps against. Monotonic at the call site, so a later cycle whose
-  /// words happen to end earlier cannot drag it back and make every finalize pay
-  /// a redundant tail decode.
-  ///
-  /// Buffer mode only; the segment path keeps reporting the full count, because
-  /// its own finalize does not consult this.
-  private func wordCoverageSampleCount(from results: [TranscriptionResult], cap: Int) -> Int {
-    guard localAgreement else { return cap }
-    let words = results.flatMap { $0.segments }.flatMap { $0.words ?? [] }
-    guard let lastEnd = words.last?.end else { return cap }
-    return max(0, min(cap, Int(lastEnd * 16_000)))
   }
 
   /// Freeze the confirmable prefix of this cycle's segments into `confirmedText`
@@ -818,10 +791,17 @@ package actor WhisperKitStreamingSession: WhisperKitIncrementalSession {
       }
     }
 
-    // Retain the uncommitted remainder for the benchmark's release-only arm
-    // (set before the commitCount>0 guard, mirroring the segment path).
-    // Retained text is the RAW token (self-spacing, see the commit loop) —
-    // the release path concatenates these without a separator.
+    // The held-back tail of the current hypothesis. Set before the commitCount>0
+    // guard (mirroring the segment path) so a cycle that commits nothing still
+    // records everything as retained. Retained text is the RAW token
+    // (self-spacing, see the commit loop) — the release path concatenates these
+    // without a separator.
+    //
+    // SHIPPED FINALIZE READS THIS. It builds `releaseText` from it (`:435`) and,
+    // since #1308, derives the release hypothesis's audio coverage from its last
+    // segment. An earlier comment here said "Shipped finalize never reads this",
+    // which was false and was quoted as evidence in the #1308 plan before the
+    // grep caught it.
     retainedUnconfirmedSegments = words[commitCount...].map {
       BenchmarkSegment(text: $0.word, start: $0.start, end: $0.end)
     }

--- a/Sources/EnviousWisprASR/WhisperKitStreamingSession.swift
+++ b/Sources/EnviousWisprASR/WhisperKitStreamingSession.swift
@@ -152,6 +152,13 @@ package actor WhisperKitStreamingSession: WhisperKitIncrementalSession {
   private var lastConfirmedSec: Float = 0
   /// Sample count at the last decode, to gate the >= 1s-new-audio check.
   private var lastDecodeSampleCount: Int = 0
+
+  /// How far the decoded WORDS have reached, in samples (#1308). Distinct from
+  /// `lastDecodeSampleCount`, which records how much audio a decode was HANDED.
+  /// Finalize's caught-up check reads this one: a decode that produced words
+  /// covering 6s of an 11s buffer has not heard the last 5s, however much audio
+  /// it was given.
+  private var lastWordCoverageSampleCount: Int = 0
   private var decodeCount: Int = 0
   private var totalDecodeTimeMs: Int = 0
 
@@ -278,6 +285,7 @@ package actor WhisperKitStreamingSession: WhisperKitIncrementalSession {
     confirmedText = ""
     lastConfirmedSec = 0
     lastDecodeSampleCount = 0
+    lastWordCoverageSampleCount = 0
     decodeCount = 0
     totalDecodeTimeMs = 0
     retainedUnconfirmedSegments = []
@@ -426,9 +434,12 @@ package actor WhisperKitStreamingSession: WhisperKitIncrementalSession {
     // `streamingResult` trims the edges.
     let releaseText = confirmedText + retainedUnconfirmedSegments.map(\.text).joined()
 
-    // Exact bookkeeping: audio that arrived after the last decode pulled the
-    // buffer. `lastDecodeSampleCount` is the sample count that decode saw.
-    let unheardStart = max(0, min(count, lastDecodeSampleCount))
+    // Exact bookkeeping: audio the decoded WORDS never reached (#1308). Reads
+    // `lastWordCoverageSampleCount`, NOT `lastDecodeSampleCount` — the latter is
+    // how much audio a decode was handed, and handing a decoder 11s of audio that
+    // yields 6s of words does not make the last 5s heard. Using it here released
+    // without the tail decode below and dropped the user's final words.
+    let unheardStart = max(0, min(count, lastWordCoverageSampleCount))
     let unheardSlice = unheardStart < count ? Array(samples[unheardStart..<count]) : []
     let unheardSec = Float(unheardSlice.count) / 16_000.0
     if unheardSec < minVoicedTailSec || rms(unheardSlice) <= tailEnergyFloor || samples.isEmpty {
@@ -616,7 +627,15 @@ package actor WhisperKitStreamingSession: WhisperKitIncrementalSession {
         // instant-release over voiced audio that never transcribed (its energy
         // gate routes genuine silence to release, fresh speech to the bounded
         // buffer decode).
-        if heard { lastDecodeSampleCount = count }
+        //
+        // #1308: this marker answers "how much audio has a decode SEEN", which is
+        // the right question for the cadence gate above and the WRONG one for
+        // finalize's caught-up check. Both are recorded, separately.
+        if heard {
+          lastDecodeSampleCount = count
+          lastWordCoverageSampleCount = max(
+            lastWordCoverageSampleCount, wordCoverageSampleCount(from: results, cap: count))
+        }
         decodeCount += 1
         let elapsedMs = Int((CFAbsoluteTimeGetCurrent() - decodeStart) * 1000)
         totalDecodeTimeMs += elapsedMs
@@ -629,6 +648,30 @@ package actor WhisperKitStreamingSession: WhisperKitIncrementalSession {
         }
       }
     }
+  }
+
+  /// How far this decode's WORDS actually reached, in samples (#1308).
+  ///
+  /// Deliberately NOT folded into `lastDecodeSampleCount`. That marker also gates
+  /// the live decode cadence at the top of the loop, so lagging it behind the fed
+  /// audio would make the loop re-decode unchanged audio on every cycle whenever
+  /// the words trail by a second. Two questions, two values: how much audio a
+  /// decode has SEEN drives cadence, how far the WORDS reached drives whether
+  /// finalize still owes a tail decode.
+  ///
+  /// `min(cap, …)` because a decoder can stamp a word past the buffer, into the
+  /// 30s window's silence padding — the same hallucination `applyLocalAgreement`
+  /// already clamps against. Monotonic at the call site, so a later cycle whose
+  /// words happen to end earlier cannot drag it back and make every finalize pay
+  /// a redundant tail decode.
+  ///
+  /// Buffer mode only; the segment path keeps reporting the full count, because
+  /// its own finalize does not consult this.
+  private func wordCoverageSampleCount(from results: [TranscriptionResult], cap: Int) -> Int {
+    guard localAgreement else { return cap }
+    let words = results.flatMap { $0.segments }.flatMap { $0.words ?? [] }
+    guard let lastEnd = words.last?.end else { return cap }
+    return max(0, min(cap, Int(lastEnd * 16_000)))
   }
 
   /// Freeze the confirmable prefix of this cycle's segments into `confirmedText`

--- a/Tests/EnviousWisprASRTests/WhisperKitStreamingSessionTests.swift
+++ b/Tests/EnviousWisprASRTests/WhisperKitStreamingSessionTests.swift
@@ -346,6 +346,55 @@ import Testing
     await s.cancel()
   }
 
+  /// Whole-diff review P1, frozen. A decoder stamps words into the 30s window's
+  /// silence PADDING — a word at 99s on an 11s clip. `applyLocalAgreement`
+  /// discards those (`start < realAudioEndSec`), so they never reach the
+  /// transcript. An earlier version of this fix read the UNFILTERED word list, so
+  /// the hallucination claimed coverage of the whole buffer and finalize skipped
+  /// the tail decode — recreating the exact silent loss this issue is about.
+  ///
+  /// Deriving coverage from the release hypothesis makes that unrepresentable:
+  /// a word the transcript does not contain cannot vouch for audio.
+  @Test("a hallucinated word past the buffer does not claim coverage of it")
+  func paddingHallucinationDoesNotClaimCoverage() async throws {
+    let liveCount = 176_000  // 11s
+    // Real words to 6s, plus a hallucination stamped at 40s in the silence pad.
+    let partial = result(
+      "the meeting went rather well today",
+      [
+        seg(0, 40, "the meeting went rather well today spurious").with(words: [
+          word(0, 1, "the"), word(1, 2, "meeting"), word(2, 3, "went"),
+          word(3, 4, "rather"), word(4, 5, "well"), word(5, 6, "today"),
+          word(39, 40, "spurious"),
+        ])
+      ])
+    let withTail = result(
+      "the meeting went rather well today everyone agreed",
+      [
+        seg(0, 11, "the meeting went rather well today everyone agreed").with(words: [
+          word(0, 1, "the"), word(1, 2, "meeting"), word(2, 3, "went"),
+          word(3, 4, "rather"), word(4, 5, "well"), word(5, 6, "today"),
+          word(6, 9, "everyone"), word(9, 11, "agreed"),
+        ])
+      ])
+
+    let fake = TailCoverageDecoder(
+      liveCount: liveCount, loopResult: [partial], tailResult: [withTail])
+    let s = WhisperKitStreamingSession(
+      whisperKit: fake, decodingOptions: DecodingOptions(),
+      requiredSegmentsForConfirmation: 2, cadence: .milliseconds(1),
+      localAgreement: true)
+    await s.start(audioSamplesProvider: fixedProvider([Float](repeating: 0.4, count: liveCount)))
+    await waitForDecode(1, s)
+
+    let r = await s.finalize(finalSamples: [], speechSegments: [])
+    #expect(
+      await fake.paddedCalls == 1,
+      "a discarded padding word must not vouch for the 5s it never covered")
+    #expect((r.text ?? "").contains("agreed"), "the real tail is recovered")
+    await s.cancel()
+  }
+
   /// The two-way control. A hypothesis that reaches the end of the buffer must
   /// still mark it heard, or every dictation pays a redundant tail decode and the
   /// streaming speed win is spent on nothing.

--- a/Tests/EnviousWisprASRTests/WhisperKitStreamingSessionTests.swift
+++ b/Tests/EnviousWisprASRTests/WhisperKitStreamingSessionTests.swift
@@ -256,6 +256,123 @@ import Testing
     #expect(r.text == "one two")
   }
 
+  // MARK: Tail coverage (#1308)
+
+  /// Returns the partial hypothesis for every LOOP decode and the fuller one for
+  /// the padded finalize decode. Keyed on input length rather than call index
+  /// because the number of loop cycles differs before and after the fix — with
+  /// the fix the marker stays behind, so the loop legitimately decodes again. A
+  /// call-index script would hand the tail result to a loop cycle and the test
+  /// would pass for the wrong reason.
+  private actor TailCoverageDecoder: WhisperKitTranscribing {
+    nonisolated func encodeText(_ text: String) -> [Int] { [] }
+    private let liveCount: Int
+    private let loopResult: [TranscriptionResult]
+    private let tailResult: [TranscriptionResult]
+    private(set) var loopCalls = 0
+    private(set) var paddedCalls = 0
+
+    init(liveCount: Int, loopResult: [TranscriptionResult], tailResult: [TranscriptionResult]) {
+      self.liveCount = liveCount
+      self.loopResult = loopResult
+      self.tailResult = tailResult
+    }
+
+    func transcribe(audioArray: [Float], decodeOptions: DecodingOptions?) async throws
+      -> [TranscriptionResult]
+    {
+      if audioArray.count > liveCount {
+        paddedCalls += 1
+        return tailResult
+      }
+      loopCalls += 1
+      return loopResult
+    }
+  }
+
+  /// **The #1308 defect, as a failing test.**
+  ///
+  /// A decode cycle that produces ANY words marks the ENTIRE captured buffer as
+  /// heard (`applyLocalAgreement` returns true whenever it saw words at all).
+  /// Finalize then computes an empty unheard slice, takes the caught-up fast
+  /// path, and releases WITHOUT the padded tail decode — so everything spoken
+  /// after the last decoded word is silently dropped.
+  ///
+  /// Distinct from the wordless-decode case PR #1313 fixed: that one returns
+  /// "not heard" and already holds the marker back. This decode DID produce
+  /// words, just not enough of them.
+  ///
+  /// 11s of continuously loud audio, a hypothesis reaching 6s. The 5s remainder
+  /// is far above the energy floor, so it is speech rather than trailing silence
+  /// and the tail decode must run.
+  @Test("a decode whose words cover only part of the buffer must not mark the tail heard")
+  func partialWordCoverageDoesNotMarkTailHeard() async throws {
+    let liveCount = 176_000  // 11s
+    let partial = result(
+      "the meeting went rather well today and",
+      [
+        seg(0, 6, "the meeting went rather well today and").with(words: [
+          word(0, 1, "the"), word(1, 2, "meeting"), word(2, 3, "went"),
+          word(3, 4, "rather"), word(4, 5, "well"), word(5, 6, "today"),
+        ])
+      ])
+    let withTail = result(
+      "the meeting went rather well today and everyone agreed",
+      [
+        seg(0, 11, "the meeting went rather well today and everyone agreed").with(words: [
+          word(0, 1, "the"), word(1, 2, "meeting"), word(2, 3, "went"),
+          word(3, 4, "rather"), word(4, 5, "well"), word(5, 6, "today"),
+          word(6, 9, "everyone"), word(9, 11, "agreed"),
+        ])
+      ])
+
+    let fake = TailCoverageDecoder(
+      liveCount: liveCount, loopResult: [partial], tailResult: [withTail])
+    let s = WhisperKitStreamingSession(
+      whisperKit: fake, decodingOptions: DecodingOptions(),
+      requiredSegmentsForConfirmation: 2, cadence: .milliseconds(1),
+      localAgreement: true)
+    await s.start(audioSamplesProvider: fixedProvider([Float](repeating: 0.4, count: liveCount)))
+    await waitForDecode(1, s)
+
+    let r = await s.finalize(finalSamples: [], speechSegments: [])
+
+    #expect(
+      await fake.paddedCalls == 1,
+      "5s of voiced audio past the last decoded word must trigger exactly one tail decode")
+    #expect(
+      (r.text ?? "").contains("agreed"),
+      "words after the hypothesis must reach the transcript, not be dropped")
+    await s.cancel()
+  }
+
+  /// The two-way control. A hypothesis that reaches the end of the buffer must
+  /// still mark it heard, or every dictation pays a redundant tail decode and the
+  /// streaming speed win is spent on nothing.
+  @Test("full word coverage still marks the buffer heard and skips the tail decode")
+  func fullWordCoverageSkipsTailDecode() async throws {
+    let liveCount = 96_000  // 6s, exactly what the words cover
+    let full = result(
+      "the meeting went rather well today",
+      [
+        seg(0, 6, "the meeting went rather well today").with(words: [
+          word(0, 1, "the"), word(1, 2, "meeting"), word(2, 3, "went"),
+          word(3, 4, "rather"), word(4, 5, "well"), word(5, 6, "today"),
+        ])
+      ])
+    let fake = TailCoverageDecoder(liveCount: liveCount, loopResult: [full], tailResult: [full])
+    let s = WhisperKitStreamingSession(
+      whisperKit: fake, decodingOptions: DecodingOptions(),
+      requiredSegmentsForConfirmation: 2, cadence: .milliseconds(1),
+      localAgreement: true)
+    await s.start(audioSamplesProvider: fixedProvider([Float](repeating: 0.4, count: liveCount)))
+    await waitForDecode(1, s)
+
+    _ = await s.finalize(finalSamples: [], speechSegments: [])
+    #expect(await fake.paddedCalls == 0, "a fully covered buffer needs no tail decode")
+    await s.cancel()
+  }
+
   // MARK: In-flight decode serialization (Codex r5 P2)
 
   /// Tracks concurrent `transcribe` calls and blocks the FIRST (loop) decode
@@ -609,11 +726,18 @@ import Testing
     // One decode heard ALL the audio; nothing commits (no previous hypothesis)
     // so both words are the retained hypothesis. Finalize must release
     // confirmed+retained with ZERO further inference.
+    //
+    // #1308: the words now reach 3.0s, matching the 3.0s buffer. They previously
+    // reached 2.0s over the same buffer, which this test called "heard ALL the
+    // audio" — it was not. That 1s of loud uncovered audio is exactly the dropped
+    // tail #1308 is about, and under the corrected definition of caught-up it
+    // earns a tail decode. The fixture changed, the intent did not: this still
+    // asserts that a genuinely caught-up stream releases with zero inference.
     let d1 = result(
       "the meeting",
       [
-        seg(0, 2, "the meeting").with(words: [
-          word(0, 1, "the"), word(1, 2, "meeting"),
+        seg(0, 3, "the meeting").with(words: [
+          word(0, 1.5, "the"), word(1.5, 3, "meeting"),
         ])
       ])
     let (s, fake) = laFinalizeSession([[d1]])


### PR DESCRIPTION
Closes #1308

## What the user gets

Live transcription stops eating the end of your sentence.

A decode cycle that produced words covering only PART of the captured audio marked ALL of it as heard. Finalize then believed it was caught up, skipped the padded tail decode that exists to recover exactly this, and released. Everything spoken after the last decoded word vanished, silently, with a transcript that looked complete.

## The fix

Finalize derives coverage from the hypothesis it is about to release — `lastConfirmedSec` for the committed prefix, the last retained segment for the held-back tail. Nothing cached, no new state.

`lastDecodeSampleCount` is untouched and keeps its one job, gating decode cadence.

## Two designs were rejected first, and both recreated the bug

**Advance `lastDecodeSampleCount` by word coverage.** Plan review caught that this marker also gates the live decode cadence, so lagging it makes the loop re-decode unchanged audio on every cycle whenever the words trail by a second.

**A separate cached marker, monotonic, from the decode's words.** Whole-diff review returned two P1s, both verified before adopting:

- It read the UNFILTERED word list. A decoder stamps words into the 30s window's silence padding — one at 40s on an 11s clip — and `applyLocalAgreement` discards those. The marker still used the hallucination's end and claimed full coverage, so finalize skipped the tail decode over audio the transcript never contained.
- Being monotonic, it held an older, farther endpoint after a later hypothesis RETRACTED its final word, so the unheard slice began past real speech the release text no longer covered.

One cause behind both: coverage was tracked SEPARATELY from the text being released, so the two could disagree. Deriving it from the release hypothesis makes disagreement unrepresentable.

## A correction I owe

Plan review proposed the final shape first. I rejected it, citing a code comment stating `retainedUnconfirmedSegments` is benchmark-only and that "Shipped finalize never reads this". The comment was false — `finalizeLocalAgreement:435` builds `releaseText` from that exact field. I quoted a stale comment as evidence and it cost two review rounds. The comment is corrected in place and now names what it misled. Its sibling on the segment path was checked and is accurate, so the two genuinely differ.

## Tests

Three, each freezing a way this went wrong rather than only the happy path:

- partial word coverage over a voiced tail triggers the tail decode
- a hallucinated word past the buffer does NOT vouch for audio it never covered
- full coverage still skips the tail decode, or every dictation pays for this

The decoder fake keys on input LENGTH rather than call index, because the number of loop cycles differs before and after the fix; a call-index script would hand the tail result to a loop cycle and pass for the wrong reason.

**My first failing test was wrong, and running it is what caught that.** It drove the segment path, which has its own finalize and never consults this marker — it PASSED against the bug while its control FAILED. Rewritten against the LocalAgreement path where the defect lives.

**An existing test asserted the buggy premise.** `laFinalizeCaughtUpReleases` fed 3s of loud audio with words ending at 2s and called that "heard ALL the audio". Its words now reach 3.0s. Flagged rather than quietly edited — the intent is unchanged and the fixture's old encoding of "caught up" was the defect. Review found this independently.

## Live UAT

WhisperKit, Live transcription ON, language locked to English. Preconditions read back from the AX layer rather than assumed, because a run that configures itself and does not check is measuring the default.

The app's own log proves the streaming path was exercised and the tail decode fired:

```
WhisperKit recording started (streaming, language: en)
Recording started. Backend: whisperKit, streaming=true
WhisperKit streaming flush complete: chars=123, decodes=5, tailDecodeMs=834
RAW ASR: The quarterly review covered hiring, runway, and the roadmap,
         and the team agreed to revisit pricing next Thursday morning.
```

The sentence ends on content words rather than trailing into silence, because the defect drops audio after the last DECODED word. Settings restored afterwards.

## Not delivered here

#1879 D4 wants streaming word-error at or below batch before Live transcription defaults ON. The benchmark runner paths are absent from the tree. This fixes the bookkeeping defect and proves it; that measurement is separate and is not unblocked by this.

## Receipts

- `scripts/xcode-test.sh` → `** TEST SUCCEEDED **`, `==> Debug lane executed 4712 tests`
- Baseline control: reverting the finalize read makes the defect test fail with 2 issues
- Local diff review: two P1s in round 1, clean on the confirming round
