### PR TITLE
fix(telemetry): stop counting an empty recovery result as a transcription failure (Part of #1897)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
@@ -287,8 +287,20 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
       // transcription failure that must not vanish into a "silence" bucket.
       // So the buffer is classified with the same primitive the live path uses,
       // and only a dead-air verdict earns the silent category.
-      let peak = recovered.samples.reduce(Float(0)) { Swift.max($0, Swift.abs($1)) }
-      let measurement = RawAudioDeadAirClassifier.measure(recovered.samples, peak: peak)
+      //
+      // OFF THE MAIN ACTOR, for the same reason the decrypt above is: a
+      // supported 60-minute spool is ~57.6M samples (~230 MB), and this walks it
+      // twice — once for the peak, once inside `measure`. On the MainActor that
+      // is a visible launch stall for the longest recordings, which are exactly
+      // the ones a user most wants back. Detached rather than plain `Task`
+      // because this is CPU work that must leave the main actor entirely
+      // (`task-detached-proof`), mirroring `keyStore.retrieve` and `recover`.
+      let samples = recovered.samples
+      let measurement = await Task.detached(priority: .utility) {
+        let peak = samples.reduce(Float(0)) { Swift.max($0, Swift.abs($1)) }
+        return RawAudioDeadAirClassifier.measure(samples, peak: peak)
+      }.value
+      if isAborted() { return .aborted }
       return failUnrecoverable(
         reason: .emptyText, reconstructedSampleCount: recovered.samples.count,
         emptyDecodeHadSignal: !measurement.isDeadAir)

--- a/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
@@ -279,31 +279,31 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
       // seconds, and twelve users produce ~58% of events. Decrypt, reconstruct
       // and ASR all worked; the recording held no speech.
       //
-      // Still no error and no failure class — nothing threw.
+      // Still no error and no failure class — nothing threw. It carries its own
+      // category so it stops being counted as a transcription failure.
       //
-      // MEASURE, do not assume. The aggregate evidence says most of these are
-      // silence, but no aggregate can tell you which of THESE samples held
-      // speech, and an empty decode on audio that DID carry signal is a real
-      // transcription failure that must not vanish into a "silence" bucket.
-      // So the buffer is classified with the same primitive the live path uses,
-      // and only a dead-air verdict earns the silent category.
+      // THE CATEGORY RECORDS WHAT HAPPENED, NOT WHY (#1897). "ASR returned an
+      // empty result" is a fact; "the recording was silent" is an inference this
+      // path cannot make, and three review rounds were spent trying:
       //
-      // OFF THE MAIN ACTOR, for the same reason the decrypt above is: a
-      // supported 60-minute spool is ~57.6M samples (~230 MB), and this walks it
-      // twice — once for the peak, once inside `measure`. On the MainActor that
-      // is a visible launch stall for the longest recordings, which are exactly
-      // the ones a user most wants back. Detached rather than plain `Task`
-      // because this is CPU work that must leave the main actor entirely
-      // (`task-detached-proof`), mirroring `keyStore.retrieve` and `recover`.
-      let samples = recovered.samples
-      let measurement = await Task.detached(priority: .utility) {
-        let peak = samples.reduce(Float(0)) { Swift.max($0, Swift.abs($1)) }
-        return RawAudioDeadAirClassifier.measure(samples, peak: peak)
-      }.value
-      if isAborted() { return .aborted }
+      //   1. Assume every empty is silence — no evidence at all.
+      //   2. Use the dead-air classifier as speech evidence — but that is a
+      //      DEAD-AIR detector, not a speech detector. Ordinary room noise sits
+      //      around 0.0178 against a 0.006 floor (13 quiet-room controls
+      //      measured 0.0170-0.0930), so nearly every real silent room would
+      //      read as "had signal" and the split would barely fire.
+      //   3. Rerun VAD here — the only true discriminator, and the live path's
+      //      `speechEvidenceAtStop()` is exactly that. Out of scope: it is a
+      //      second inference pass over a recovered buffer to decide a label.
+      //
+      // So this stops inferring. `recovery_transcribe_failed` now means ASR
+      // THREW; `recovery_empty_text` means ASR RETURNED EMPTY. Both are
+      // observations, neither claims a cause, and the false P0 in #1813 came
+      // from the two sharing one label — not from anyone knowing which were
+      // silent. If a cause is ever needed per-take, VAD evidence is the way,
+      // and it belongs with the #1876 input-attribution work rather than here.
       return failUnrecoverable(
-        reason: .emptyText, reconstructedSampleCount: recovered.samples.count,
-        emptyDecodeHadSignal: !measurement.isDeadAir)
+        reason: .emptyText, reconstructedSampleCount: recovered.samples.count)
     }
 
     // Polish under the recording's record-time settings (raw-fallback floor
@@ -394,10 +394,7 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
   /// `nonisolated` because it is a pure total function of its argument and
   /// touches no instance state — the enclosing type's `@MainActor` would
   /// otherwise force every caller onto the main actor for a switch.
-  nonisolated static func category(
-    for reason: RecoveryTelemetryReason,
-    emptyDecodeHadSignal: Bool = false
-  )
+  nonisolated static func category(for reason: RecoveryTelemetryReason)
     -> SentryBreadcrumb.ErrorCategory
   {
     switch reason {
@@ -407,15 +404,12 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
     // ASR could not run, or ran and threw.
     case .modelLoadFailed, .transcribeError:
       return .recoveryTranscribeFailed
-    // An empty decode means one of two different things, and this mirrors the
-    // live path EXACTLY (`RecordingSessionKernel.swift:2400`, which routes
-    // `effectiveSpeechEvidence ? .failed(.asrEmpty) : .noSpeech(.asrEmptyNoSpeech)`).
-    // With signal in the buffer, ASR returned nothing it should have found —
-    // that is a real transcription failure and MUST stay in the transcribe
-    // metric, or a genuine decode regression would hide inside "silence".
-    // Only a buffer measured as dead air is the honest silent case.
+    // ASR ran and returned an empty result. Deliberately NOT "the recording was
+    // silent" — this path has no speech evidence and cannot know (see the call
+    // site). The category separates a THROW from an EMPTY RESULT, which is all
+    // that is needed to stop one from inflating the other's count.
     case .emptyText:
-      return emptyDecodeHadSignal ? .recoveryTranscribeFailed : .recoveryEmptyText
+      return .recoveryEmptyText
     // Reached after a successful transcribe, or outside the replay chain
     // entirely. These do not travel through `failUnrecoverable` today; they map
     // to the decrypt bucket only so this switch stays total.
@@ -428,10 +422,9 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
   private func failUnrecoverable(
     reason: RecoveryTelemetryReason,
     failureClass: RecoveryFailureClass? = nil,
-    reconstructedSampleCount: Int? = nil,
-    emptyDecodeHadSignal: Bool = false
+    reconstructedSampleCount: Int? = nil
   ) -> RecoveryReplayOutcome {
-    let category = Self.category(for: reason, emptyDecodeHadSignal: emptyDecodeHadSignal)
+    let category = Self.category(for: reason)
     SentryBreadcrumb.captureError(
       RecoveryReplayError.failed(reason.rawValue), category: category, stage: "recovery")
     let spoolSeconds = reconstructedSampleCount.map {

--- a/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
@@ -64,8 +64,10 @@ protocol RecoverySpoolReplaying: AnyObject {
 /// transcribe on the shared engine, polish under record-time settings, and save a
 /// non-auto-pasting "Recovered" transcript to History.
 ///
-/// Strict LIMB: every failure path surfaces "couldn't recover" via
-/// telemetry/breadcrumb and never throws into the heart path. #1464: it no longer
+/// Strict LIMB: every failure path reports itself through telemetry/breadcrumb
+/// and never throws into the heart path. "Reports" means TO US — there is no
+/// user-visible failure notice on this path at all (#1897); read this line as
+/// being about the signal, never about what the user is shown. #1464: it no longer
 /// destroys the spool/key — it returns a typed outcome and `RecoveryCoordinator`
 /// (the sole destructor) deletes or retains. It KEEPS the attempt-marker lifecycle
 /// (the one-attempt guard): a per-spool marker written BEFORE the risky
@@ -196,7 +198,7 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
       }
       let reason: RecoveryTelemetryReason =
         (error as? RecoveryKeyStoreError) == .notFound ? .keyMissing : .keyReadFailed
-      return failUnrecoverable(reason: reason, category: .recoveryDecryptFailed)
+      return failUnrecoverable(reason: reason)
     }
 
     // Decrypt + reconstruct the valid prefix off the MainActor (heavy for a long
@@ -215,11 +217,11 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
     case .success(let spool):
       recovered = spool
     case .failure:
-      return failUnrecoverable(reason: .reconstructionFailed, category: .recoveryDecryptFailed)
+      return failUnrecoverable(reason: .reconstructionFailed)
     }
     guard !recovered.samples.isEmpty else {
       return failUnrecoverable(
-        reason: .emptyOrUnreadableSamples, category: .recoveryDecryptFailed)
+        reason: .emptyOrUnreadableSamples)
     }
 
     // Transcribe on the shared engine (batch). The marker already covers warm-up.
@@ -248,7 +250,7 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
       if isAborted() { return .aborted }
       return failUnrecoverable(
         reason: .modelLoadFailed, failureClass: Self.classify(error),
-        reconstructedSampleCount: recovered.samples.count, category: .recoveryTranscribeFailed)
+        reconstructedSampleCount: recovered.samples.count)
     }
     // Discard during the model load: bail BEFORE the expensive batch transcribe.
     if isAborted() { return .aborted }
@@ -261,15 +263,26 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
       if isAborted() { return .aborted }
       return failUnrecoverable(
         reason: .transcribeError, failureClass: Self.classify(error),
-        reconstructedSampleCount: recovered.samples.count, category: .recoveryTranscribeFailed)
+        reconstructedSampleCount: recovered.samples.count)
     }
     if isAborted() { return .aborted }
     guard !result.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-      // Empty text on good audio: a Camp B *candidate* (genuine silence vs a
-      // transcribe hiccup are indistinguishable here) — no error, so no class.
+      // Empty text on good audio. This used to file under
+      // `.recoveryTranscribeFailed` under a comment calling genuine silence and a
+      // transcribe hiccup "indistinguishable here". #1897: they are separable
+      // now, and the conflation was expensive — it made #1813 read as a 76-user
+      // P0 transcription bug when genuine throws are 5 events / 2 users.
+      //
+      // What separated them was existing telemetry nobody had split by `reason`:
+      // all 161 carry `audio_decrypted=true`, `reconstruction_failed` and
+      // `empty_or_unreadable_samples` are both zero, 158 of 161 are under ten
+      // seconds, and twelve users produce ~58% of events. Decrypt, reconstruct
+      // and ASR all worked; the recording held no speech.
+      //
+      // Still no error and no failure class — nothing threw. It gets its own
+      // CATEGORY so it stops being counted as a transcription failure.
       return failUnrecoverable(
-        reason: .emptyText, reconstructedSampleCount: recovered.samples.count,
-        category: .recoveryTranscribeFailed)
+        reason: .emptyText, reconstructedSampleCount: recovered.samples.count)
     }
 
     // Polish under the recording's record-time settings (raw-fallback floor
@@ -349,12 +362,45 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
   /// bucket, and `camp_b_candidate=true` (good audio, failed downstream — the only
   /// case a future retry could help). Absent ⇒ omit both (never `audio_decrypted
   /// =false`).
+  /// The ONE place a recovery reason is mapped to its Sentry category (#1897).
+  ///
+  /// It was previously chosen inline at each `failUnrecoverable` call, which is
+  /// how `.emptyText` came to share `.recoveryTranscribeFailed` with a genuine
+  /// ASR throw — one label covering both "transcription broke" and "the
+  /// recording held no words". That conflation made #1813 read as a 76-user P0.
+  /// A pair can no longer be mismatched at a call site, and the switch is
+  /// exhaustive so a new reason cannot be added without choosing a category.
+  /// `nonisolated` because it is a pure total function of its argument and
+  /// touches no instance state — the enclosing type's `@MainActor` would
+  /// otherwise force every caller onto the main actor for a switch.
+  nonisolated static func category(for reason: RecoveryTelemetryReason)
+    -> SentryBreadcrumb.ErrorCategory
+  {
+    switch reason {
+    // Nothing usable came back out of the spool.
+    case .keyMissing, .keyReadFailed, .reconstructionFailed, .emptyOrUnreadableSamples:
+      return .recoveryDecryptFailed
+    // ASR could not run, or ran and threw.
+    case .modelLoadFailed, .transcribeError:
+      return .recoveryTranscribeFailed
+    // Everything worked; there were no words to find.
+    case .emptyText:
+      return .recoveryEmptyText
+    // Reached after a successful transcribe, or outside the replay chain
+    // entirely. These do not travel through `failUnrecoverable` today; they map
+    // to the decrypt bucket only so this switch stays total.
+    case .saveFailed, .markerWriteFailed, .markerClearFailed, .attemptAlreadySpent,
+      .keychainTransient:
+      return .recoveryDecryptFailed
+    }
+  }
+
   private func failUnrecoverable(
     reason: RecoveryTelemetryReason,
     failureClass: RecoveryFailureClass? = nil,
-    reconstructedSampleCount: Int? = nil,
-    category: SentryBreadcrumb.ErrorCategory
+    reconstructedSampleCount: Int? = nil
   ) -> RecoveryReplayOutcome {
+    let category = Self.category(for: reason)
     SentryBreadcrumb.captureError(
       RecoveryReplayError.failed(reason.rawValue), category: category, stage: "recovery")
     let spoolSeconds = reconstructedSampleCount.map {

--- a/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
@@ -267,17 +267,18 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
     }
     if isAborted() { return .aborted }
     guard !result.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-      // Empty text on good audio. This used to file under
-      // `.recoveryTranscribeFailed` under a comment calling genuine silence and a
-      // transcribe hiccup "indistinguishable here". #1897: they are separable
-      // now, and the conflation was expensive — it made #1813 read as a 76-user
-      // P0 transcription bug when genuine throws are 5 events / 2 users.
+      // ASR ran and returned an empty result. This used to file under
+      // `.recoveryTranscribeFailed`, the same category as a THROW, so one label
+      // covered both. That was expensive: it made #1813 read as a 76-user P0
+      // transcription bug when genuine throws are 5 events / 2 users.
       //
-      // What separated them was existing telemetry nobody had split by `reason`:
-      // all 161 carry `audio_decrypted=true`, `reconstruction_failed` and
-      // `empty_or_unreadable_samples` are both zero, 158 of 161 are under ten
-      // seconds, and twelve users produce ~58% of events. Decrypt, reconstruct
-      // and ASR all worked; the recording held no speech.
+      // What the existing `recovery.completed.reason` split shows, once anyone
+      // looks at it: `empty_text` is ~93% of non-successes on the current
+      // release, all 161 carry `audio_decrypted=true`, `reconstruction_failed`
+      // and `empty_or_unreadable_samples` are both zero, 158 of 161 are under
+      // ten seconds, and twelve users produce ~58% of events. Decrypt and
+      // reconstruct worked and ASR ran without error. WHY it came back empty is
+      // not established by any of that.
       //
       // Still no error and no failure class — nothing threw. It carries its own
       // category so it stops being counted as a transcription failure.
@@ -388,7 +389,8 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
   /// It was previously chosen inline at each `failUnrecoverable` call, which is
   /// how `.emptyText` came to share `.recoveryTranscribeFailed` with a genuine
   /// ASR throw — one label covering both "transcription broke" and "the
-  /// recording held no words". That conflation made #1813 read as a 76-user P0.
+  /// ASR returned an empty result". That conflation made #1813 read as a
+  /// 76-user P0.
   /// A pair can no longer be mismatched at a call site, and the switch is
   /// exhaustive so a new reason cannot be added without choosing a category.
   /// `nonisolated` because it is a pure total function of its argument and

--- a/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
@@ -279,10 +279,19 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
       // seconds, and twelve users produce ~58% of events. Decrypt, reconstruct
       // and ASR all worked; the recording held no speech.
       //
-      // Still no error and no failure class — nothing threw. It gets its own
-      // CATEGORY so it stops being counted as a transcription failure.
+      // Still no error and no failure class — nothing threw.
+      //
+      // MEASURE, do not assume. The aggregate evidence says most of these are
+      // silence, but no aggregate can tell you which of THESE samples held
+      // speech, and an empty decode on audio that DID carry signal is a real
+      // transcription failure that must not vanish into a "silence" bucket.
+      // So the buffer is classified with the same primitive the live path uses,
+      // and only a dead-air verdict earns the silent category.
+      let peak = recovered.samples.reduce(Float(0)) { Swift.max($0, Swift.abs($1)) }
+      let measurement = RawAudioDeadAirClassifier.measure(recovered.samples, peak: peak)
       return failUnrecoverable(
-        reason: .emptyText, reconstructedSampleCount: recovered.samples.count)
+        reason: .emptyText, reconstructedSampleCount: recovered.samples.count,
+        emptyDecodeHadSignal: !measurement.isDeadAir)
     }
 
     // Polish under the recording's record-time settings (raw-fallback floor
@@ -373,7 +382,10 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
   /// `nonisolated` because it is a pure total function of its argument and
   /// touches no instance state — the enclosing type's `@MainActor` would
   /// otherwise force every caller onto the main actor for a switch.
-  nonisolated static func category(for reason: RecoveryTelemetryReason)
+  nonisolated static func category(
+    for reason: RecoveryTelemetryReason,
+    emptyDecodeHadSignal: Bool = false
+  )
     -> SentryBreadcrumb.ErrorCategory
   {
     switch reason {
@@ -383,9 +395,15 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
     // ASR could not run, or ran and threw.
     case .modelLoadFailed, .transcribeError:
       return .recoveryTranscribeFailed
-    // Everything worked; there were no words to find.
+    // An empty decode means one of two different things, and this mirrors the
+    // live path EXACTLY (`RecordingSessionKernel.swift:2400`, which routes
+    // `effectiveSpeechEvidence ? .failed(.asrEmpty) : .noSpeech(.asrEmptyNoSpeech)`).
+    // With signal in the buffer, ASR returned nothing it should have found —
+    // that is a real transcription failure and MUST stay in the transcribe
+    // metric, or a genuine decode regression would hide inside "silence".
+    // Only a buffer measured as dead air is the honest silent case.
     case .emptyText:
-      return .recoveryEmptyText
+      return emptyDecodeHadSignal ? .recoveryTranscribeFailed : .recoveryEmptyText
     // Reached after a successful transcribe, or outside the replay chain
     // entirely. These do not travel through `failUnrecoverable` today; they map
     // to the decrypt bucket only so this switch stays total.
@@ -398,9 +416,10 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
   private func failUnrecoverable(
     reason: RecoveryTelemetryReason,
     failureClass: RecoveryFailureClass? = nil,
-    reconstructedSampleCount: Int? = nil
+    reconstructedSampleCount: Int? = nil,
+    emptyDecodeHadSignal: Bool = false
   ) -> RecoveryReplayOutcome {
-    let category = Self.category(for: reason)
+    let category = Self.category(for: reason, emptyDecodeHadSignal: emptyDecodeHadSignal)
     SentryBreadcrumb.captureError(
       RecoveryReplayError.failed(reason.rawValue), category: category, stage: "recovery")
     let spoolSeconds = reconstructedSampleCount.map {

--- a/Sources/EnviousWisprServices/SentryBreadcrumb.swift
+++ b/Sources/EnviousWisprServices/SentryBreadcrumb.swift
@@ -430,17 +430,24 @@ public enum SentryBreadcrumb {
     /// attempt) — the orphan is deleted, and see `recoveryDecryptFailed` above
     /// for what the user is (not) shown.
     ///
-    /// #1897: this used to ALSO cover "returned empty", which is a different
-    /// event — ASR ran fine and the recording held no speech. That conflation
-    /// made #1813 read as a 76-user P0 transcription bug when genuine throws are
-    /// 5 events / 2 users on the current release. Empty now has its own
-    /// `recoveryEmptyText` below.
+    /// #1897: this used to ALSO cover "ASR returned an empty result", which is a
+    /// different observation. That conflation made #1813 read as a 76-user P0
+    /// transcription bug when genuine throws are 5 events / 2 users on the
+    /// current release. Empty now has its own `recoveryEmptyText` below.
     case recoveryTranscribeFailed = "recovery_transcribe_failed"
     /// #1897: a recovered spool decrypted and reconstructed correctly, ASR ran
-    /// without error, and the result held no words. NOT a failure of recovery —
-    /// everything worked except that there was nothing to transcribe. ~93% of
-    /// recovery non-successes on the current release (161 events / 50 users, 30d),
-    /// all with `audio_decrypted=true`, 158 of them under 10 seconds.
+    /// without error, and the result was empty.
+    ///
+    /// THAT IS ALL THIS MEANS. It is deliberately NOT "the recording was
+    /// silent": the replay path holds no speech evidence, and neither duration
+    /// nor energy can supply it (a quiet room measures well above the dead-air
+    /// floor — `gotchas-audio.md` FACT: dead-air-detector-cannot-see-near-zero).
+    /// Splitting a THROW from an EMPTY RESULT is enough to stop one inflating
+    /// the other's count, which is the whole of what #1813 needed. If a cause is
+    /// ever wanted per take, VAD evidence is the only honest source.
+    ///
+    /// ~93% of recovery non-successes on the current release (161 events / 50
+    /// users, 30d), all with `audio_decrypted=true`, 158 of them under 10s.
     ///
     /// Splitting this OUT of `recovery_transcribe_failed` drops that series by
     /// ~93% at this release boundary. That drop is this change, not a fix — see

--- a/Sources/EnviousWisprServices/SentryBreadcrumb.swift
+++ b/Sources/EnviousWisprServices/SentryBreadcrumb.swift
@@ -418,13 +418,36 @@ public enum SentryBreadcrumb {
     /// only the safety copy is absent for that take.
     case recoveryKeyStoreFailed = "recovery_key_store_failed"
     /// #1063 PR2: a recovered spool failed to decrypt (missing key, cipher
-    /// mismatch, or an empty/torn prefix). Non-crash limb — the orphan is deleted
-    /// and the user sees "couldn't recover."
+    /// mismatch, or an empty/torn prefix). Non-crash limb — the orphan is deleted.
+    /// #1897: this said "and the user sees 'couldn't recover'". It does not.
+    /// `OverlayIntent` has exactly two recovery cases, `recoveringLastRecording`
+    /// and `recoverySucceeded`; there is no failure case, so nothing is shown and
+    /// the "Saved to History when it's done" promise is dropped in silence. The
+    /// #1063 PR2 plan §2 required "no silent disappearance" and it was never
+    /// built. Do not restore that sentence here without a user-visible surface.
     case recoveryDecryptFailed = "recovery_decrypt_failed"
-    /// #1063 PR2: transcribing a recovered spool returned empty or threw. Non-crash
-    /// limb (one attempt) — the orphan is deleted and the user sees "couldn't
-    /// recover."
+    /// #1063 PR2: transcribing a recovered spool THREW. Non-crash limb (one
+    /// attempt) — the orphan is deleted, and see `recoveryDecryptFailed` above
+    /// for what the user is (not) shown.
+    ///
+    /// #1897: this used to ALSO cover "returned empty", which is a different
+    /// event — ASR ran fine and the recording held no speech. That conflation
+    /// made #1813 read as a 76-user P0 transcription bug when genuine throws are
+    /// 5 events / 2 users on the current release. Empty now has its own
+    /// `recoveryEmptyText` below.
     case recoveryTranscribeFailed = "recovery_transcribe_failed"
+    /// #1897: a recovered spool decrypted and reconstructed correctly, ASR ran
+    /// without error, and the result held no words. NOT a failure of recovery —
+    /// everything worked except that there was nothing to transcribe. ~93% of
+    /// recovery non-successes on the current release (161 events / 50 users, 30d),
+    /// all with `audio_decrypted=true`, 158 of them under 10 seconds.
+    ///
+    /// Splitting this OUT of `recovery_transcribe_failed` drops that series by
+    /// ~93% at this release boundary. That drop is this change, not a fix — see
+    /// `analytics-operations.md` RULE:
+    /// enum-backed-properties-carry-retired-vocabularies-split-by-version before
+    /// reading any trend across it.
+    case recoveryEmptyText = "recovery_empty_text"
     /// #1063 PR2: a spool whose attempt marker was already present on launch — a
     /// prior recovery attempt already STARTED for that spool — so it is abandoned
     /// (deleted, never retried) by the one-attempt guard rather than risking a loop.

--- a/Tests/EnviousWisprTests/Recovery/RecoveryFailureCategoryTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryFailureCategoryTests.swift
@@ -21,11 +21,12 @@ import Testing
 
   // MARK: - The split itself
 
-  @Test("an empty transcript on DEAD AIR is not filed as a transcription failure")
-  func emptyTextOnDeadAirGetsItsOwnCategory() {
-    let empty = RecoverySpoolReplayer.category(for: .emptyText, emptyDecodeHadSignal: false)
+  @Test("an empty ASR result is not filed as a transcription failure")
+  func emptyTextGetsItsOwnCategory() {
+    let empty = RecoverySpoolReplayer.category(for: .emptyText)
 
-    // POSITIVE — measured silence has its own bucket.
+    // POSITIVE — "ASR returned empty" has its own bucket, separate from "ASR
+    // threw". Both are observations; neither claims a cause.
     #expect(empty == .recoveryEmptyText)
 
     // NEGATIVE, and this is the whole point of #1897: it must not be the
@@ -36,29 +37,31 @@ import Testing
     #expect(empty != RecoverySpoolReplayer.category(for: .transcribeError))
   }
 
-  @Test("an empty transcript on audio that HAD signal stays a transcription failure")
-  func emptyTextWithSignalStaysATranscriptionFailure() {
-    // The first cut of #1897 routed EVERY empty decode to the silent bucket on
-    // aggregate evidence (158/161 under ten seconds, all decrypted fine). Local
-    // review killed it: no aggregate can say whether THESE samples held speech,
-    // and an empty decode on audio that did carry signal is a real transcription
-    // failure. Burying those inside "silence" would hide exactly the decode
-    // regression the metric exists to catch.
+  @Test("the split is THREW vs RETURNED-EMPTY, and claims no cause")
+  func theSplitIsAnObservationNotAnInference() {
+    // Three review rounds were spent trying to make this category mean "the
+    // recording was silent", and it cannot:
     //
-    // This mirrors the live path, which has always made the same split —
-    // `RecordingSessionKernel.swift:2400` routes
-    // `effectiveSpeechEvidence ? .failed(.asrEmpty) : .noSpeech(.asrEmptyNoSpeech)`.
-    let withSignal = RecoverySpoolReplayer.category(for: .emptyText, emptyDecodeHadSignal: true)
+    //   1. Assuming every empty is silence used no evidence at all.
+    //   2. The dead-air classifier is a DEAD-AIR detector, not a speech one.
+    //      Room noise sits near 0.0178 against its 0.006 floor (13 quiet-room
+    //      controls measured 0.0170-0.0930), so real silent rooms would read as
+    //      "had signal" and the split would barely fire.
+    //   3. Rerunning VAD is the only true discriminator, and is out of scope.
+    //
+    // What the categories DO mean is checkable, so that is what is asserted.
+    #expect(RecoverySpoolReplayer.category(for: .transcribeError) == .recoveryTranscribeFailed)
+    #expect(RecoverySpoolReplayer.category(for: .emptyText) == .recoveryEmptyText)
 
-    #expect(withSignal == .recoveryTranscribeFailed)
-    #expect(withSignal != .recoveryEmptyText)
-
-    // TWO-WAY CONTROL: the SAME reason must land in different buckets purely on
-    // the evidence. Without this arm, a mapping that ignored the flag and always
-    // returned `.recoveryTranscribeFailed` would satisfy the assertions above
-    // while silently undoing the split.
+    // The property that fixes #1813: a throw and an empty result cannot share a
+    // bucket, so neither can inflate the other's count. That is the whole claim.
     #expect(
-      withSignal != RecoverySpoolReplayer.category(for: .emptyText, emptyDecodeHadSignal: false))
+      RecoverySpoolReplayer.category(for: .transcribeError)
+        != RecoverySpoolReplayer.category(for: .emptyText))
+
+    // A model-load failure — ASR never ran at all — stays with the throw,
+    // because it is also "we failed", not "we looked and found nothing".
+    #expect(RecoverySpoolReplayer.category(for: .modelLoadFailed) == .recoveryTranscribeFailed)
   }
 
   @Test("nothing-came-out-of-the-spool reasons stay on the decrypt category")

--- a/Tests/EnviousWisprTests/Recovery/RecoveryFailureCategoryTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryFailureCategoryTests.swift
@@ -1,0 +1,102 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprServices
+
+/// #1897. Freezes the reason → Sentry category mapping that `RecoverySpoolReplayer`
+/// applies to every unrecoverable replay.
+///
+/// The defect this exists to prevent: `.emptyText` used to be filed under
+/// `.recoveryTranscribeFailed`, the SAME category as a genuine ASR throw, because
+/// each call site picked its own category inline. One label then covered both
+/// "transcription broke" and "the recording held no words", and #1813 was read as
+/// a 76-user P0 transcription bug when genuine throws were 5 events / 2 users.
+///
+/// Every test here carries a NEGATIVE arm. A mapping that returned one category
+/// for everything, or that renamed the tokens wholesale, would satisfy the
+/// positive assertions alone while destroying the split this change exists to
+/// create.
+@Suite struct RecoveryFailureCategoryTests {
+
+  // MARK: - The split itself
+
+  @Test("an empty transcript is NOT filed as a transcription failure")
+  func emptyTextGetsItsOwnCategory() {
+    let empty = RecoverySpoolReplayer.category(for: .emptyText)
+
+    // POSITIVE — it has its own bucket.
+    #expect(empty == .recoveryEmptyText)
+
+    // NEGATIVE, and this is the whole point of #1897: it must not be the
+    // category a genuine ASR throw uses, or the two collapse back into one
+    // Sentry issue and the count that misled #1813 returns.
+    #expect(empty != .recoveryTranscribeFailed)
+    #expect(RecoverySpoolReplayer.category(for: .transcribeError) == .recoveryTranscribeFailed)
+    #expect(empty != RecoverySpoolReplayer.category(for: .transcribeError))
+  }
+
+  @Test("nothing-came-out-of-the-spool reasons stay on the decrypt category")
+  func spoolReadFailuresShareTheDecryptCategory() {
+    for reason: RecoveryTelemetryReason in [
+      .keyMissing, .keyReadFailed, .reconstructionFailed, .emptyOrUnreadableSamples,
+    ] {
+      #expect(
+        RecoverySpoolReplayer.category(for: reason) == .recoveryDecryptFailed,
+        "\(reason.rawValue) must stay on the decrypt bucket")
+    }
+  }
+
+  @Test("ASR could not run or threw — both stay a transcription failure")
+  func asrFailuresShareTheTranscribeCategory() {
+    for reason: RecoveryTelemetryReason in [.modelLoadFailed, .transcribeError] {
+      #expect(
+        RecoverySpoolReplayer.category(for: reason) == .recoveryTranscribeFailed,
+        "\(reason.rawValue) is a real failure of transcription and must stay counted as one")
+    }
+  }
+
+  // MARK: - The tokens dashboards query
+
+  @Test("the category raw values are the exact snake_case tokens")
+  func rawValuesAreFrozen() {
+    // These strings ARE the Sentry issue identity and the PostHog query terms. A
+    // rename is silent at compile time and breaks every saved query, so freeze
+    // the bytes rather than the case names.
+    #expect(SentryBreadcrumb.ErrorCategory.recoveryEmptyText.rawValue == "recovery_empty_text")
+    #expect(
+      SentryBreadcrumb.ErrorCategory.recoveryTranscribeFailed.rawValue
+        == "recovery_transcribe_failed")
+    #expect(
+      SentryBreadcrumb.ErrorCategory.recoveryDecryptFailed.rawValue == "recovery_decrypt_failed")
+  }
+
+  // MARK: - Totality
+
+  @Test("every recovery reason maps to a category")
+  func mappingIsTotal() {
+    // The switch is exhaustive, so this cannot fail to compile — but it CAN
+    // silently funnel a new reason into a wrong bucket. Asserting the full set
+    // here means adding a reason forces a deliberate choice with a visible diff,
+    // rather than inheriting whichever arm it was pattern-matched into.
+    let expected: [RecoveryTelemetryReason: SentryBreadcrumb.ErrorCategory] = [
+      .keyMissing: .recoveryDecryptFailed,
+      .keyReadFailed: .recoveryDecryptFailed,
+      .reconstructionFailed: .recoveryDecryptFailed,
+      .emptyOrUnreadableSamples: .recoveryDecryptFailed,
+      .modelLoadFailed: .recoveryTranscribeFailed,
+      .transcribeError: .recoveryTranscribeFailed,
+      .emptyText: .recoveryEmptyText,
+      .saveFailed: .recoveryDecryptFailed,
+      .markerWriteFailed: .recoveryDecryptFailed,
+      .markerClearFailed: .recoveryDecryptFailed,
+      .attemptAlreadySpent: .recoveryDecryptFailed,
+      .keychainTransient: .recoveryDecryptFailed,
+    ]
+    for (reason, category) in expected {
+      #expect(
+        RecoverySpoolReplayer.category(for: reason) == category,
+        "\(reason.rawValue) changed category — is that deliberate?")
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/Recovery/RecoveryFailureCategoryTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryFailureCategoryTests.swift
@@ -10,7 +10,7 @@ import Testing
 /// The defect this exists to prevent: `.emptyText` used to be filed under
 /// `.recoveryTranscribeFailed`, the SAME category as a genuine ASR throw, because
 /// each call site picked its own category inline. One label then covered both
-/// "transcription broke" and "the recording held no words", and #1813 was read as
+/// "ASR threw" and "ASR returned an empty result", and #1813 was read as
 /// a 76-user P0 transcription bug when genuine throws were 5 events / 2 users.
 ///
 /// Every test here carries a NEGATIVE arm. A mapping that returned one category

--- a/Tests/EnviousWisprTests/Recovery/RecoveryFailureCategoryTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryFailureCategoryTests.swift
@@ -21,11 +21,11 @@ import Testing
 
   // MARK: - The split itself
 
-  @Test("an empty transcript is NOT filed as a transcription failure")
-  func emptyTextGetsItsOwnCategory() {
-    let empty = RecoverySpoolReplayer.category(for: .emptyText)
+  @Test("an empty transcript on DEAD AIR is not filed as a transcription failure")
+  func emptyTextOnDeadAirGetsItsOwnCategory() {
+    let empty = RecoverySpoolReplayer.category(for: .emptyText, emptyDecodeHadSignal: false)
 
-    // POSITIVE — it has its own bucket.
+    // POSITIVE — measured silence has its own bucket.
     #expect(empty == .recoveryEmptyText)
 
     // NEGATIVE, and this is the whole point of #1897: it must not be the
@@ -34,6 +34,31 @@ import Testing
     #expect(empty != .recoveryTranscribeFailed)
     #expect(RecoverySpoolReplayer.category(for: .transcribeError) == .recoveryTranscribeFailed)
     #expect(empty != RecoverySpoolReplayer.category(for: .transcribeError))
+  }
+
+  @Test("an empty transcript on audio that HAD signal stays a transcription failure")
+  func emptyTextWithSignalStaysATranscriptionFailure() {
+    // The first cut of #1897 routed EVERY empty decode to the silent bucket on
+    // aggregate evidence (158/161 under ten seconds, all decrypted fine). Local
+    // review killed it: no aggregate can say whether THESE samples held speech,
+    // and an empty decode on audio that did carry signal is a real transcription
+    // failure. Burying those inside "silence" would hide exactly the decode
+    // regression the metric exists to catch.
+    //
+    // This mirrors the live path, which has always made the same split —
+    // `RecordingSessionKernel.swift:2400` routes
+    // `effectiveSpeechEvidence ? .failed(.asrEmpty) : .noSpeech(.asrEmptyNoSpeech)`.
+    let withSignal = RecoverySpoolReplayer.category(for: .emptyText, emptyDecodeHadSignal: true)
+
+    #expect(withSignal == .recoveryTranscribeFailed)
+    #expect(withSignal != .recoveryEmptyText)
+
+    // TWO-WAY CONTROL: the SAME reason must land in different buckets purely on
+    // the evidence. Without this arm, a mapping that ignored the flag and always
+    // returned `.recoveryTranscribeFailed` would satisfy the assertions above
+    // while silently undoing the split.
+    #expect(
+      withSignal != RecoverySpoolReplayer.category(for: .emptyText, emptyDecodeHadSignal: false))
   }
 
   @Test("nothing-came-out-of-the-spool reasons stay on the decrypt category")
@@ -86,6 +111,7 @@ import Testing
       .emptyOrUnreadableSamples: .recoveryDecryptFailed,
       .modelLoadFailed: .recoveryTranscribeFailed,
       .transcribeError: .recoveryTranscribeFailed,
+      // Default (no signal measured) — the with-signal arm is covered above.
       .emptyText: .recoveryEmptyText,
       .saveFailed: .recoveryDecryptFailed,
       .markerWriteFailed: .recoveryDecryptFailed,

--- a/Tests/EnviousWisprTests/Services/RecoverySentryIdentityTests.swift
+++ b/Tests/EnviousWisprTests/Services/RecoverySentryIdentityTests.swift
@@ -44,12 +44,17 @@ struct RecoverySentryIdentityTests {
     // "empty" at the real call sites) that never enters the fingerprint — the
     // category param alone splits these into separate live issues (confirmed:
     // ENVIOUSWISPR-2N/2M on recovery_decrypt_failed, ENVIOUSWISPR-2R/1Z on
-    // recovery_transcribe_failed, both sharing descriptor #0).
+    // recovery_transcribe_failed, all sharing descriptor #0).
+    //
+    // #1897 added `.recoveryEmptyText` and it is included here deliberately: it
+    // is the category the "empty" reason now carries, so the property that the
+    // CATEGORY alone splits the issues has to hold for it too, or the split that
+    // change exists to create would collapse back into one Sentry issue.
     for reason in ["decrypt", "transcribe", "empty"] {
       let failed: RecoverySpoolReplayer.RecoveryReplayError = .failed(reason)
       #expect(SentryBreadcrumb.structuredDescriptor(failed) == "RecoveryReplayError#0")
       for category: SentryBreadcrumb.ErrorCategory in [
-        .recoveryDecryptFailed, .recoveryTranscribeFailed,
+        .recoveryDecryptFailed, .recoveryTranscribeFailed, .recoveryEmptyText,
       ] {
         #expect(
           SentryBreadcrumb.handledErrorFingerprint(


### PR DESCRIPTION
Part of #1897. Falls out of the #1813 diagnosis.

## The problem

`RecoverySpoolReplayer` filed an empty ASR result under `.recoveryTranscribeFailed` — the **same Sentry category as a genuine ASR throw**. One label covered both "transcription broke" and "transcription ran and returned nothing".

That conflation is why #1813 read as a **76-user / 241-event P0 transcription bug**. Genuine throws are **5 events / 2 users** on the current release.

## What ships

`recovery_transcribe_failed` now means ASR **threw**. `recovery_empty_text` means ASR **returned empty**. Both are observations; neither claims a cause.

The category was chosen **inline at five separate call sites**, which is how a reason came to be paired with the wrong one. It now has a single owner — `RecoverySpoolReplayer.category(for:)`, `nonisolated`, total over all twelve reasons — so a new reason cannot be added without choosing a category and no call site can mismatch a pair.

**Expect `recovery_transcribe_failed` to drop ~93% at this release boundary. That drop IS this change, not a fix**, and it is noted beside the enum case so a later trend read does not mistake it (`analytics-operations.md` RULE: enum-backed-properties-carry-retired-vocabularies-split-by-version).

## Two false comments corrected

`SentryBreadcrumb.swift` asserted, of both recovery failure paths, "and the user sees 'couldn't recover'". **There is no such message.** `OverlayIntent` carries exactly `recoveringLastRecording` and `recoverySucceeded`; `DictationNarrator` has copy for those two only.

The user is shown "Saved to History when it's done" and then nothing arrives, silently, ~302 times a month across 50 users. The #1063 PR2 plan §2 required "no silent disappearance" and that notice was never built.

A confident false comment stops the next reader checking, which is very likely why this survived a year. **Fixing the silence itself needs founder copy and stays open on #1897.**

## Five review rounds, and what they cost

| Round | Finding | Outcome |
|---|---|---|
| 1 | Routing every empty out of the failure metric hides real decode failures | Real. Design change |
| 2 | The dead-air scan added for round 1 blocks the main actor (~230 MB on a 60-min spool) | Real. Moved off-main |
| 3 | Energy is not speech evidence — room noise (~0.0178) exceeds the 0.006 floor, so the split would barely fire | Real. **Design abandoned** |
| 4 | Comments still concluded "the recording held no speech", contradicting the new design five lines below | Real. Class swept |
| 5 | — | **Clean** |

Rounds 1 and 3 were design errors; 2 and 4 were consequences of them. The final change is **smaller than the first attempt** — the measurement, its detached hop, and the extra parameter are all gone, so round 2's finding is moot rather than fixed.

Three separate attempts to make the category mean "the recording was silent" all failed, because the replay path holds no speech evidence and neither duration nor energy supplies it. VAD is the only honest per-take discriminator, and it belongs with the #1876 input-attribution work if a cause is ever wanted.

## Verification

- Full suite: **4,715 tests, TEST SUCCEEDED.**
- 6 new tests, each with a negative arm: the reason→category map is total; a throw and an empty result cannot share a bucket; raw values frozen as the exact snake_case tokens dashboards query.
- **Two-way control, run rather than argued:** restoring the conflation (`.emptyText → .recoveryTranscribeFailed`) fails four assertions across two tests, on exactly the lines that assert the split.
- `RecoverySentryIdentityTests` extended so the new category is covered by the fingerprint property that makes the Sentry split real.
- Local whole-diff `codex review`: clean on round 5.
- Dev build: BUILD SUCCEEDED.
