### PR TITLE
feat(recovery): make the launch scan and replay visible in the local log (Closes #1762)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
@@ -299,27 +299,17 @@ final class RecoveryCoordinator {
   /// #1755 chunk 4: one failure-only breadcrumb per failed component per
   /// destruction call. Never includes the recovery ID, path, or raw error —
   /// deletion stays best-effort and swallowed; this is diagnosis only.
-  private func emitDeletionFailed(
-    component: String, source: DestructionSource, spoolAlreadyFailed: Bool = false
-  ) {
-    // #1762: a failed delete can leave a spool the next launch finds again, and
-    // without a line here that reappearance reads as a fresh crash.
-    //
-    // The disposition cannot be read off `component` alone (r3). The destructor
-    // always attempts the key even after the spool delete failed, so on a
-    // double failure a key-keyed line saying "the audio is already deleted"
-    // contradicts the spool line printed moments earlier. Only the spool's own
-    // result establishes whether audio survives, so that is what is consulted.
-    let disposition: String
-    if component == "spool" {
-      disposition = "the recording stays on disk and a future launch will find it again"
-    } else if spoolAlreadyFailed {
-      disposition = "the recording is ALSO still on disk — see the spool failure above"
-    } else {
-      disposition = "the audio is already deleted; only this leftover remains"
-    }
-    RecoveryLog.line(
-      "deletion FAILED for \(component) (\(source.rawValue)) — \(disposition)")
+  private func emitDeletionFailed(component: String, source: DestructionSource) {
+    // #1762 r5: reports the ACTION and its result, nothing further. Five review
+    // rounds went to disposition clauses here — "stays on disk", "already
+    // deleted", "a future launch will retry" — and each was wrong in some real
+    // path: `RecoverySpoolStore.delete` also clears the attempt marker and
+    // propagates THAT failure, the key delete cannot see the spool's fate under
+    // concurrency, and Discard's own delete can fail after the outcome line
+    // claimed success. This call site knows one thing for certain, so it says
+    // exactly that. A reader correlates the spool and key lines by sequence
+    // number; the log no longer does that inference for them, wrongly.
+    RecoveryLog.line("\(component) delete FAILED (\(source.rawValue))")
     let data = ["component": component, "source": source.rawValue]
     if let sink = deletionFailureBreadcrumbForTesting {
       sink("recovery", "deletion_failed", data)
@@ -364,11 +354,6 @@ final class RecoveryCoordinator {
       // attempt (seam or real store). Unarmed: no-op.
       crashBoundaryController.boundaryReached(.beforeSpoolDelete)
     #endif
-    // #1762 r4: LOCAL, never an instance property. The key delete below is
-    // detached and several destructions overlap in practice (a dedup sweep
-    // destroys one per id), so shared state would let a later spool result
-    // rewrite an earlier key line's disposition. Captured into the task instead.
-    var spoolFailed = false
     do {
       if let override = destructionSpoolDeleteForTesting {
         try override(id)
@@ -377,14 +362,12 @@ final class RecoveryCoordinator {
       }
       emitCleanupOutcome(component: "spool", source: source, succeeded: true)
     } catch {
-      spoolFailed = true
-      emitDeletionFailed(component: "spool", source: source, spoolAlreadyFailed: true)
+      emitDeletionFailed(component: "spool", source: source)
       emitCleanupOutcome(component: "spool", source: source, succeeded: false)
     }
     // Key deletion ALWAYS runs, detached, even after a spool failure.
     let keyStore = self.keyStore
     let keyOverride = destructionKeyDeleteForTesting
-    let capturedSpoolFailed = spoolFailed
     // Capture self STRONGLY: the failure breadcrumb must survive coordinator
     // deallocation racing the detached delete (a weak capture silently
     // dropped it). The task is short-lived; the temporary strong retention
@@ -411,8 +394,7 @@ final class RecoveryCoordinator {
         }
       } catch {
         await MainActor.run {
-          self.emitDeletionFailed(
-            component: "key", source: source, spoolAlreadyFailed: capturedSpoolFailed)
+          self.emitDeletionFailed(component: "key", source: source)
           self.emitCleanupOutcome(component: "key", source: source, succeeded: false)
         }
       }
@@ -488,7 +470,7 @@ final class RecoveryCoordinator {
     case .aborted: return "aborted — the user pressed Discard"
     case .deferred: return "deferred — no attempt ran"
     case .deferredMarkerClearFailed:
-      return "deferred, marker not cleared — only a new launch may retry"
+      return "deferred, attempt marker not cleared — a new launch re-checks it"
     }
   }
 
@@ -560,7 +542,7 @@ final class RecoveryCoordinator {
     // `emitDeletionFailed` only fires on failure, so a successful live-ending
     // cleanup was entirely invisible. The issue asked for the ending family and
     // whether deletion was requested; both are here.
-    RecoveryLog.line("live ending (\(ending)) — deleting the spool")
+    RecoveryLog.line("live ending (\(ending)) — requesting spool deletion")
     // GitHub cloud review PR #1761: suppress BEFORE the best-effort delete.
     // If the spool deletion fails (transient FS/permission error), the same
     // callback fires `onDictationEndedForRecovery` moments later — without
@@ -852,8 +834,8 @@ final class RecoveryCoordinator {
       // and told the reader discarded audio was still on disk.
       let disposition: String
       switch outcome {
-      case .aborted: disposition = "already deleted by Discard"
-      default: disposition = willDelete ? "deleting" : "keeping"
+      case .aborted: disposition = "Discard already requested deletion"
+      default: disposition = willDelete ? "requesting deletion" : "keeping"
       }
       RecoveryLog.line("replay \(Self.logLabel(outcome)) — \(disposition)")
       if willDelete {

--- a/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
@@ -130,6 +130,10 @@ final class RecoveryCoordinator {
   /// #1762 — debug-log only: which entry point opened the current drain loop, so
   /// each pass can name its trigger. Never read for control flow.
   private var recoveryScanTrigger = "launch"
+  /// #1762 — debug-log only: did THIS destruction's spool delete fail? The key
+  /// delete runs regardless, and its log line must not claim the audio is gone
+  /// when the spool is still there. Never read for control flow.
+  private var spoolDeletionFailedThisDestruction = false
 
   /// IDs excluded from SAME-LAUNCH rescans, cleared only by a genuine new
   /// launch (a fresh coordinator). Two populations remain (#1755 narrowed it
@@ -300,20 +304,24 @@ final class RecoveryCoordinator {
   /// destruction call. Never includes the recovery ID, path, or raw error —
   /// deletion stays best-effort and swallowed; this is diagnosis only.
   private func emitDeletionFailed(component: String, source: DestructionSource) {
-    // #1762: a failed delete leaves a spool on disk that the next launch will
-    // find again. Without a line here, that reappearance reads as a fresh crash.
-    // #1762 r2: component-specific. A failed SPOOL delete leaves recoverable
-    // audio that the next launch finds again; a failed KEY delete leaves only a
-    // Keychain entry behind audio that is already gone. Saying "stays on disk"
-    // for both implied a recording would reappear when it cannot.
-    let disposition =
-      component == "spool"
-      ? "the recording stays on disk and a future launch will find it again"
-      : "the audio is already deleted; only this leftover remains"
-    Task {
-      await RecoveryLog.line(
-        "deletion FAILED for \(component) (\(source.rawValue)) — \(disposition)")
+    // #1762: a failed delete can leave a spool the next launch finds again, and
+    // without a line here that reappearance reads as a fresh crash.
+    //
+    // The disposition cannot be read off `component` alone (r3). The destructor
+    // always attempts the key even after the spool delete failed, so on a
+    // double failure a key-keyed line saying "the audio is already deleted"
+    // contradicts the spool line printed moments earlier. Only the spool's own
+    // result establishes whether audio survives, so that is what is consulted.
+    let disposition: String
+    if component == "spool" {
+      disposition = "the recording stays on disk and a future launch will find it again"
+    } else if spoolDeletionFailedThisDestruction {
+      disposition = "the recording is ALSO still on disk — see the spool failure above"
+    } else {
+      disposition = "the audio is already deleted; only this leftover remains"
     }
+    RecoveryLog.line(
+      "deletion FAILED for \(component) (\(source.rawValue)) — \(disposition)")
     let data = ["component": component, "source": source.rawValue]
     if let sink = deletionFailureBreadcrumbForTesting {
       sink("recovery", "deletion_failed", data)
@@ -358,6 +366,10 @@ final class RecoveryCoordinator {
       // attempt (seam or real store). Unarmed: no-op.
       crashBoundaryController.boundaryReached(.beforeSpoolDelete)
     #endif
+    // #1762 r3: the key delete below ALWAYS runs, even after the spool failed,
+    // so its diagnostic needs to know whether audio actually survived. Reset per
+    // destruction — a stale true would misreport the next one.
+    spoolDeletionFailedThisDestruction = false
     do {
       if let override = destructionSpoolDeleteForTesting {
         try override(id)
@@ -366,6 +378,7 @@ final class RecoveryCoordinator {
       }
       emitCleanupOutcome(component: "spool", source: source, succeeded: true)
     } catch {
+      spoolDeletionFailedThisDestruction = true
       emitDeletionFailed(component: "spool", source: source)
       emitCleanupOutcome(component: "spool", source: source, succeeded: false)
     }
@@ -537,7 +550,7 @@ final class RecoveryCoordinator {
       // Synchronous hook, so this cannot await. Ordering does not matter here:
       // this line stands alone rather than pairing with a later outcome.
       Task {
-        await RecoveryLog.line("live ending (\(ending)) — keeping the spool for a future launch")
+        RecoveryLog.line("live ending (\(ending)) — keeping the spool for a future launch")
       }
       nextLaunchOnlyRecoveryIDs.insert(id)
       return nil
@@ -546,7 +559,7 @@ final class RecoveryCoordinator {
     // `emitDeletionFailed` only fires on failure, so a successful live-ending
     // cleanup was entirely invisible. The issue asked for the ending family and
     // whether deletion was requested; both are here.
-    Task { await RecoveryLog.line("live ending (\(ending)) — deleting the spool") }
+    RecoveryLog.line("live ending (\(ending)) — deleting the spool")
     // GitHub cloud review PR #1761: suppress BEFORE the best-effort delete.
     // If the spool deletion fails (transient FS/permission error), the same
     // callback fires `onDictationEndedForRecovery` moments later — without
@@ -580,7 +593,7 @@ final class RecoveryCoordinator {
     pendingRescan = true
     guard !scanInProgress else {
       recoveryScanTrigger = "launch"
-      await RecoveryLog.line("launch scan arrived mid-pass — a follow-up pass is queued")
+      RecoveryLog.line("launch scan arrived mid-pass — a follow-up pass is queued")
       return
     }
     scanInProgress = true
@@ -601,7 +614,7 @@ final class RecoveryCoordinator {
       // #1762 r2: relabel, or the drain loop credits this follow-up to whichever
       // trigger opened the loop — a wake during a launch scan would read "launch".
       recoveryScanTrigger = "wake"
-      Task { await RecoveryLog.line("wake arrived mid-pass — a follow-up pass is queued") }
+      RecoveryLog.line("wake arrived mid-pass — a follow-up pass is queued")
       return
     }
     scanInProgress = true
@@ -628,18 +641,18 @@ final class RecoveryCoordinator {
       // A wake arriving mid-pass queues a FOLLOW-UP pass through this loop; an
       // earlier draft claimed it joined the running pass, which is not what the
       // loop does. Announcing each pass here is accurate whatever schedules it.
-      await RecoveryLog.line("scan pass \(passNumber) started (\(recoveryScanTrigger))")
+      RecoveryLog.line("scan pass \(passNumber) started (\(recoveryScanTrigger))")
       let yieldedToLiveStart = await runOneScanPass()
       if yieldedToLiveStart {
         pendingRescan = false
         // #1762: BOTH exits say so. A `defer` cannot await, and this early
         // return is the yielded-to-live-dictation path — the one most likely to
         // be misread as a scan that simply stopped.
-        await RecoveryLog.line("scan finished (yielded to a live dictation)")
+        RecoveryLog.line("scan finished (yielded to a live dictation)")
         return
       }
     }
-    await RecoveryLog.line("scan finished")
+    RecoveryLog.line("scan finished")
   }
 
   /// One full discovery + per-item-replay pass. Returns `true` exactly when
@@ -659,13 +672,13 @@ final class RecoveryCoordinator {
     } catch {
       // #1762: the fail-closed branch above is invisible on disk — it looks
       // identical to "no spools". Say which one happened.
-      await RecoveryLog.line("scan aborted — could not list the spool directory; nothing deleted")
+      RecoveryLog.line("scan aborted — could not list the spool directory; nothing deleted")
       return false
     }
     // #1762: BEFORE any early return, including zero. A pass that found nothing
     // and finished must not read like a pass that stalled — that ambiguity is
     // the whole reason this issue exists.
-    await RecoveryLog.line("\(spoolIDs.count) spool(s) on disk")
+    RecoveryLog.line("\(spoolIDs.count) spool(s) on disk")
     let armed = armedSessionID
 
     // Sweep KEY-ONLY orphans first: a key whose spool was never written — a
@@ -716,14 +729,14 @@ final class RecoveryCoordinator {
         // re-transcribing (the dedup MUST precede any append — History forbids a
         // duplicate id). Routed through the sole destructor (#1464); these ids are
         // never appended to `recoverable`, so the async delete never races a replay.
-        await RecoveryLog.line("already in History — deleting without re-transcribing")
+        RecoveryLog.line("already in History — deleting without re-transcribing")
         destroySpoolAndKey(id: id, source: .historyDedup)
       } else {
         recoverable.append(id)
       }
     }
     guard !recoverable.isEmpty else {
-      await RecoveryLog.line("\(spoolIDs.count) spool(s) found, none recoverable — pass done")
+      RecoveryLog.line("\(spoolIDs.count) spool(s) found, none recoverable — pass done")
       return false
     }
 
@@ -732,13 +745,15 @@ final class RecoveryCoordinator {
     // untouched, waiting for a future launch's fresh coordinator instance.
     let attemptable = recoverable.filter { !nextLaunchOnlyRecoveryIDs.contains($0) }
     guard !attemptable.isEmpty else {
-      await RecoveryLog.line(
-        "\(recoverable.count) recoverable, all held for a future launch "
-          + "(a prior attempt marker could not be cleared) — pass done")
+      // #1762 r3: generic on purpose. `nextLaunchOnlyRecoveryIDs` also holds
+      // live endings and History-save failures whose delete failed, and neither
+      // has a replay marker — naming one cause would be wrong for most members.
+      RecoveryLog.line(
+        "\(recoverable.count) recoverable, all held for a future launch — pass done")
       return false
     }
 
-    await RecoveryLog.line("\(attemptable.count) spool(s) to attempt this pass")
+    RecoveryLog.line("\(attemptable.count) spool(s) to attempt this pass")
     TelemetryService.shared.recoveryFound(count: attemptable.count)
     // #1707 Phase 3 (§3.1): cleared once per fresh pass — a live-start refusal
     // observed DURING this pass (between items, below) still yields the
@@ -765,7 +780,7 @@ final class RecoveryCoordinator {
       // recovery defer here; once `isRecovering` is set below, a NEW switch
       // cannot begin (`EngineCoordinator` already checks it).
       guard !pendingLiveStartSignal else {
-        await RecoveryLog.line(
+        RecoveryLog.line(
           "yielding the engine to a live dictation — remaining spools stay on disk")
         return true
       }
@@ -775,14 +790,14 @@ final class RecoveryCoordinator {
       // unloads/sets the active engine; starting recovery on top would race the
       // shared engine). Defer the remaining orphans — they stay on disk.
       guard !isDictationActive(), !isEngineSwitching() else {
-        await RecoveryLog.line(
+        RecoveryLog.line(
           isDictationActive()
             ? "deferred — a dictation is in flight; spools stay on disk"
             : "deferred — an engine switch is in flight; spools stay on disk")
         return false
       }
       guard recoveryEngineClaim.tryBegin() else {
-        await RecoveryLog.line(
+        RecoveryLog.line(
           "deferred — the engine gate is held; a retry is owed when it releases")
         // The gate is held by an in-flight mutation; its `endMutation()`
         // wake-up (§3.2's `recoveryRetryOwed`) calls `requestRecoveryRecheck()`
@@ -810,7 +825,7 @@ final class RecoveryCoordinator {
       // investigate — an after-the-fact line never runs, and the log cannot show
       // that this item ever entered replay. Pairs with the outcome line below:
       // an "attempting" with no outcome IS the signature of a wedge.
-      await RecoveryLog.line("attempting replay")
+      RecoveryLog.line("attempting replay")
       let outcome = await replayer.replay(recoverySessionID: id) { [weak self] in
         // Discard bumps `recoveryGeneration`; a mismatch ⇒ abandon this in-flight
         // replay. Coordinator gone ⇒ treat as aborted (safe).
@@ -839,7 +854,7 @@ final class RecoveryCoordinator {
       case .aborted: disposition = "already deleted by Discard"
       default: disposition = willDelete ? "deleting" : "keeping"
       }
-      await RecoveryLog.line("replay \(Self.logLabel(outcome)) — \(disposition)")
+      RecoveryLog.line("replay \(Self.logLabel(outcome)) — \(disposition)")
       if willDelete {
         destroySpoolAndKey(id: id, source: .replayOutcome)
       }

--- a/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
@@ -302,7 +302,18 @@ final class RecoveryCoordinator {
   private func emitDeletionFailed(component: String, source: DestructionSource) {
     // #1762: a failed delete leaves a spool on disk that the next launch will
     // find again. Without a line here, that reappearance reads as a fresh crash.
-    RecoveryLog.line("deletion FAILED for \(component) (\(source.rawValue)) — it stays on disk")
+    // #1762 r2: component-specific. A failed SPOOL delete leaves recoverable
+    // audio that the next launch finds again; a failed KEY delete leaves only a
+    // Keychain entry behind audio that is already gone. Saying "stays on disk"
+    // for both implied a recording would reappear when it cannot.
+    let disposition =
+      component == "spool"
+      ? "the recording stays on disk and a future launch will find it again"
+      : "the audio is already deleted; only this leftover remains"
+    Task {
+      await RecoveryLog.line(
+        "deletion FAILED for \(component) (\(source.rawValue)) — \(disposition)")
+    }
     let data = ["component": component, "source": source.rawValue]
     if let sink = deletionFailureBreadcrumbForTesting {
       sink("recovery", "deletion_failed", data)
@@ -523,7 +534,11 @@ final class RecoveryCoordinator {
       // #1762: the RETAIN branch. A live ending that keeps its spool is the one
       // that produces an orphan for a later launch to find, so it must not be
       // silent — otherwise the next launch's discovery has no antecedent.
-      RecoveryLog.line("live ending (\(ending)) — keeping the spool for a future launch")
+      // Synchronous hook, so this cannot await. Ordering does not matter here:
+      // this line stands alone rather than pairing with a later outcome.
+      Task {
+        await RecoveryLog.line("live ending (\(ending)) — keeping the spool for a future launch")
+      }
       nextLaunchOnlyRecoveryIDs.insert(id)
       return nil
     }
@@ -531,7 +546,7 @@ final class RecoveryCoordinator {
     // `emitDeletionFailed` only fires on failure, so a successful live-ending
     // cleanup was entirely invisible. The issue asked for the ending family and
     // whether deletion was requested; both are here.
-    RecoveryLog.line("live ending (\(ending)) — deleting the spool")
+    Task { await RecoveryLog.line("live ending (\(ending)) — deleting the spool") }
     // GitHub cloud review PR #1761: suppress BEFORE the best-effort delete.
     // If the spool deletion fails (transient FS/permission error), the same
     // callback fires `onDictationEndedForRecovery` moments later — without
@@ -564,7 +579,8 @@ final class RecoveryCoordinator {
   func scanAndRecover() async {
     pendingRescan = true
     guard !scanInProgress else {
-      RecoveryLog.line("launch scan arrived mid-pass — a follow-up pass is queued")
+      recoveryScanTrigger = "launch"
+      await RecoveryLog.line("launch scan arrived mid-pass — a follow-up pass is queued")
       return
     }
     scanInProgress = true
@@ -582,7 +598,10 @@ final class RecoveryCoordinator {
   func requestRecoveryRecheck() {
     pendingRescan = true
     guard !scanInProgress else {
-      RecoveryLog.line("wake arrived mid-pass — a follow-up pass is queued")
+      // #1762 r2: relabel, or the drain loop credits this follow-up to whichever
+      // trigger opened the loop — a wake during a launch scan would read "launch".
+      recoveryScanTrigger = "wake"
+      Task { await RecoveryLog.line("wake arrived mid-pass — a follow-up pass is queued") }
       return
     }
     scanInProgress = true
@@ -600,10 +619,7 @@ final class RecoveryCoordinator {
   /// after yielding it would defeat the entire point of the yield; the live
   /// dictation's own later end becomes the next legitimate wake-up instead.
   private func drainPendingRescan() async {
-    defer {
-      scanInProgress = false
-      RecoveryLog.line("scan finished")
-    }
+    defer { scanInProgress = false }
     var passNumber = 0
     while pendingRescan {
       pendingRescan = false
@@ -612,13 +628,18 @@ final class RecoveryCoordinator {
       // A wake arriving mid-pass queues a FOLLOW-UP pass through this loop; an
       // earlier draft claimed it joined the running pass, which is not what the
       // loop does. Announcing each pass here is accurate whatever schedules it.
-      RecoveryLog.line("scan pass \(passNumber) started (\(recoveryScanTrigger))")
+      await RecoveryLog.line("scan pass \(passNumber) started (\(recoveryScanTrigger))")
       let yieldedToLiveStart = await runOneScanPass()
       if yieldedToLiveStart {
         pendingRescan = false
+        // #1762: BOTH exits say so. A `defer` cannot await, and this early
+        // return is the yielded-to-live-dictation path — the one most likely to
+        // be misread as a scan that simply stopped.
+        await RecoveryLog.line("scan finished (yielded to a live dictation)")
         return
       }
     }
+    await RecoveryLog.line("scan finished")
   }
 
   /// One full discovery + per-item-replay pass. Returns `true` exactly when
@@ -638,13 +659,13 @@ final class RecoveryCoordinator {
     } catch {
       // #1762: the fail-closed branch above is invisible on disk — it looks
       // identical to "no spools". Say which one happened.
-      RecoveryLog.line("scan aborted — could not list the spool directory; nothing deleted")
+      await RecoveryLog.line("scan aborted — could not list the spool directory; nothing deleted")
       return false
     }
     // #1762: BEFORE any early return, including zero. A pass that found nothing
     // and finished must not read like a pass that stalled — that ambiguity is
     // the whole reason this issue exists.
-    RecoveryLog.line("\(spoolIDs.count) spool(s) on disk")
+    await RecoveryLog.line("\(spoolIDs.count) spool(s) on disk")
     let armed = armedSessionID
 
     // Sweep KEY-ONLY orphans first: a key whose spool was never written — a
@@ -695,14 +716,14 @@ final class RecoveryCoordinator {
         // re-transcribing (the dedup MUST precede any append — History forbids a
         // duplicate id). Routed through the sole destructor (#1464); these ids are
         // never appended to `recoverable`, so the async delete never races a replay.
-        RecoveryLog.line("already in History — deleting without re-transcribing")
+        await RecoveryLog.line("already in History — deleting without re-transcribing")
         destroySpoolAndKey(id: id, source: .historyDedup)
       } else {
         recoverable.append(id)
       }
     }
     guard !recoverable.isEmpty else {
-      RecoveryLog.line("\(spoolIDs.count) spool(s) found, none recoverable — pass done")
+      await RecoveryLog.line("\(spoolIDs.count) spool(s) found, none recoverable — pass done")
       return false
     }
 
@@ -711,13 +732,13 @@ final class RecoveryCoordinator {
     // untouched, waiting for a future launch's fresh coordinator instance.
     let attemptable = recoverable.filter { !nextLaunchOnlyRecoveryIDs.contains($0) }
     guard !attemptable.isEmpty else {
-      RecoveryLog.line(
+      await RecoveryLog.line(
         "\(recoverable.count) recoverable, all held for a future launch "
           + "(a prior attempt marker could not be cleared) — pass done")
       return false
     }
 
-    RecoveryLog.line("\(attemptable.count) spool(s) to attempt this pass")
+    await RecoveryLog.line("\(attemptable.count) spool(s) to attempt this pass")
     TelemetryService.shared.recoveryFound(count: attemptable.count)
     // #1707 Phase 3 (§3.1): cleared once per fresh pass — a live-start refusal
     // observed DURING this pass (between items, below) still yields the
@@ -744,7 +765,8 @@ final class RecoveryCoordinator {
       // recovery defer here; once `isRecovering` is set below, a NEW switch
       // cannot begin (`EngineCoordinator` already checks it).
       guard !pendingLiveStartSignal else {
-        RecoveryLog.line("yielding the engine to a live dictation — remaining spools stay on disk")
+        await RecoveryLog.line(
+          "yielding the engine to a live dictation — remaining spools stay on disk")
         return true
       }
       // Contention guard: never run the shared engine while a live dictation is
@@ -753,14 +775,15 @@ final class RecoveryCoordinator {
       // unloads/sets the active engine; starting recovery on top would race the
       // shared engine). Defer the remaining orphans — they stay on disk.
       guard !isDictationActive(), !isEngineSwitching() else {
-        RecoveryLog.line(
+        await RecoveryLog.line(
           isDictationActive()
             ? "deferred — a dictation is in flight; spools stay on disk"
             : "deferred — an engine switch is in flight; spools stay on disk")
         return false
       }
       guard recoveryEngineClaim.tryBegin() else {
-        RecoveryLog.line("deferred — the engine gate is held; a retry is owed when it releases")
+        await RecoveryLog.line(
+          "deferred — the engine gate is held; a retry is owed when it releases")
         // The gate is held by an in-flight mutation; its `endMutation()`
         // wake-up (§3.2's `recoveryRetryOwed`) calls `requestRecoveryRecheck()`
         // when it releases, so stopping here is never a stranded deferral.
@@ -787,7 +810,7 @@ final class RecoveryCoordinator {
       // investigate — an after-the-fact line never runs, and the log cannot show
       // that this item ever entered replay. Pairs with the outcome line below:
       // an "attempting" with no outcome IS the signature of a wedge.
-      RecoveryLog.line("attempting replay")
+      await RecoveryLog.line("attempting replay")
       let outcome = await replayer.replay(recoverySessionID: id) { [weak self] in
         // Discard bumps `recoveryGeneration`; a mismatch ⇒ abandon this in-flight
         // replay. Coordinator gone ⇒ treat as aborted (safe).
@@ -808,7 +831,15 @@ final class RecoveryCoordinator {
       // #1762: outcome AND disposition on one line. Disposition is the half that
       // was impossible to read from disk — a spool that is gone tells you nothing
       // about whether it was recovered or given up on.
-      RecoveryLog.line("replay \(Self.logLabel(outcome)) — \(willDelete ? "deleting" : "keeping")")
+      // #1762 r2: `.aborted` returns false from the predicate because
+      // `discardActiveRecovery` ALREADY deleted — "keeping" was factually wrong
+      // and told the reader discarded audio was still on disk.
+      let disposition: String
+      switch outcome {
+      case .aborted: disposition = "already deleted by Discard"
+      default: disposition = willDelete ? "deleting" : "keeping"
+      }
+      await RecoveryLog.line("replay \(Self.logLabel(outcome)) — \(disposition)")
       if willDelete {
         destroySpoolAndKey(id: id, source: .replayOutcome)
       }

--- a/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
@@ -297,6 +297,9 @@ final class RecoveryCoordinator {
   /// destruction call. Never includes the recovery ID, path, or raw error —
   /// deletion stays best-effort and swallowed; this is diagnosis only.
   private func emitDeletionFailed(component: String, source: DestructionSource) {
+    // #1762: a failed delete leaves a spool on disk that the next launch will
+    // find again. Without a line here, that reappearance reads as a fresh crash.
+    RecoveryLog.line("deletion FAILED for \(component) (\(source.rawValue)) — it stays on disk")
     let data = ["component": component, "source": source.rawValue]
     if let sink = deletionFailureBreadcrumbForTesting {
       sink("recovery", "deletion_failed", data)
@@ -442,6 +445,25 @@ final class RecoveryCoordinator {
     }
   }
 
+  /// #1762 — the human-readable outcome label for the local debug log. Exhaustive
+  /// so a new outcome cannot be added without choosing how it reads on screen;
+  /// `default` here would silently log the wrong thing for a future case.
+  ///
+  /// Deliberately says nothing beyond the outcome name — no transcript text, no
+  /// spool id, no path. `RecoveryLog`'s privacy rule applies to every caller.
+  static func logLabel(_ outcome: RecoveryReplayOutcome) -> String {
+    switch outcome {
+    case .recovered: return "recovered — transcript saved to History"
+    case .abandoned: return "abandoned — a prior attempt had already started"
+    case .failed(.unrecoverable): return "unrecoverable — the attempt is spent"
+    case .failed(.save): return "recovered but the History write failed"
+    case .aborted: return "aborted — the user pressed Discard"
+    case .deferred: return "deferred — no attempt ran"
+    case .deferredMarkerClearFailed:
+      return "deferred, marker not cleared — only a new launch may retry"
+    }
+  }
+
   /// A recording's transcript was durably saved — delete that session's spool +
   /// key. Best-effort, off the user's path, idempotent. Returns the detached
   /// work so tests can await it; callers discard it.
@@ -529,8 +551,12 @@ final class RecoveryCoordinator {
   /// coalesces into a follow-up pass rather than running twice.
   func scanAndRecover() async {
     pendingRescan = true
-    guard !scanInProgress else { return }
+    guard !scanInProgress else {
+      RecoveryLog.line("scan requested (launch) — coalesced into the pass already running")
+      return
+    }
     scanInProgress = true
+    RecoveryLog.line("scan started (launch)")
     await drainPendingRescan()
   }
 
@@ -543,8 +569,12 @@ final class RecoveryCoordinator {
   /// `scanAndRecover()` uses — never a parallel path.
   func requestRecoveryRecheck() {
     pendingRescan = true
-    guard !scanInProgress else { return }
+    guard !scanInProgress else {
+      RecoveryLog.line("scan requested (wake) — coalesced into the pass already running")
+      return
+    }
     scanInProgress = true
+    RecoveryLog.line("scan started (wake)")
     Task { await drainPendingRescan() }
   }
 
@@ -584,6 +614,9 @@ final class RecoveryCoordinator {
     do {
       spoolIDs = try store.listSpoolSessionIDs()
     } catch {
+      // #1762: the fail-closed branch above is invisible on disk — it looks
+      // identical to "no spools". Say which one happened.
+      RecoveryLog.line("scan aborted — could not list the spool directory; nothing deleted")
       return false
     }
     let armed = armedSessionID
@@ -636,19 +669,29 @@ final class RecoveryCoordinator {
         // re-transcribing (the dedup MUST precede any append — History forbids a
         // duplicate id). Routed through the sole destructor (#1464); these ids are
         // never appended to `recoverable`, so the async delete never races a replay.
+        RecoveryLog.line("already in History — deleting without re-transcribing")
         destroySpoolAndKey(id: id, source: .historyDedup)
       } else {
         recoverable.append(id)
       }
     }
-    guard !recoverable.isEmpty else { return false }
+    guard !recoverable.isEmpty else {
+      RecoveryLog.line("\(spoolIDs.count) spool(s) found, none recoverable — pass done")
+      return false
+    }
 
     // #1707 Phase 3 (§3.3): skip ids whose marker-clear failure means only a
     // genuinely NEW launch may safely re-check them — they stay on disk,
     // untouched, waiting for a future launch's fresh coordinator instance.
     let attemptable = recoverable.filter { !nextLaunchOnlyRecoveryIDs.contains($0) }
-    guard !attemptable.isEmpty else { return false }
+    guard !attemptable.isEmpty else {
+      RecoveryLog.line(
+        "\(recoverable.count) recoverable, all held for a future launch "
+          + "(a prior attempt marker could not be cleared) — pass done")
+      return false
+    }
 
+    RecoveryLog.line("\(attemptable.count) spool(s) to attempt this pass")
     TelemetryService.shared.recoveryFound(count: attemptable.count)
     // #1707 Phase 3 (§3.1): cleared once per fresh pass — a live-start refusal
     // observed DURING this pass (between items, below) still yields the
@@ -674,14 +717,24 @@ final class RecoveryCoordinator {
       // existing switch symmetry exactly: a switch already in progress makes
       // recovery defer here; once `isRecovering` is set below, a NEW switch
       // cannot begin (`EngineCoordinator` already checks it).
-      guard !pendingLiveStartSignal else { return true }
+      guard !pendingLiveStartSignal else {
+        RecoveryLog.line("yielding the engine to a live dictation — remaining spools stay on disk")
+        return true
+      }
       // Contention guard: never run the shared engine while a live dictation is
       // in flight (a recording can start in the launch window, including with
       // recovery OFF) OR while an engine switch is in flight (#1171 — a switch
       // unloads/sets the active engine; starting recovery on top would race the
       // shared engine). Defer the remaining orphans — they stay on disk.
-      guard !isDictationActive(), !isEngineSwitching() else { return false }
+      guard !isDictationActive(), !isEngineSwitching() else {
+        RecoveryLog.line(
+          isDictationActive()
+            ? "deferred — a dictation is in flight; spools stay on disk"
+            : "deferred — an engine switch is in flight; spools stay on disk")
+        return false
+      }
       guard recoveryEngineClaim.tryBegin() else {
+        RecoveryLog.line("deferred — the engine gate is held; a retry is owed when it releases")
         // The gate is held by an in-flight mutation; its `endMutation()`
         // wake-up (§3.2's `recoveryRetryOwed`) calls `requestRecoveryRecheck()`
         // when it releases, so stopping here is never a stranded deferral.
@@ -719,7 +772,14 @@ final class RecoveryCoordinator {
       // #1464: the coordinator is the sole destructor — the replayer no longer
       // deletes, so apply the replay predicate now that `replay()` has returned.
       // (`.aborted` deletes nothing here: `discardActiveRecovery` already did.)
-      if Self.shouldDeleteAfterReplay(outcome) { destroySpoolAndKey(id: id, source: .replayOutcome) }
+      let willDelete = Self.shouldDeleteAfterReplay(outcome)
+      // #1762: outcome AND disposition on one line. Disposition is the half that
+      // was impossible to read from disk — a spool that is gone tells you nothing
+      // about whether it was recovered or given up on.
+      RecoveryLog.line("replay \(Self.logLabel(outcome)) — \(willDelete ? "deleting" : "keeping")")
+      if willDelete {
+        destroySpoolAndKey(id: id, source: .replayOutcome)
+      }
       // Post the standalone success notice for a recording that landed in History.
       if case .recovered = outcome { onRecoverySucceeded?() }
       // A Discard ends the whole hold; remaining orphans (rare) wait for the next

--- a/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
@@ -130,10 +130,6 @@ final class RecoveryCoordinator {
   /// #1762 — debug-log only: which entry point opened the current drain loop, so
   /// each pass can name its trigger. Never read for control flow.
   private var recoveryScanTrigger = "launch"
-  /// #1762 — debug-log only: did THIS destruction's spool delete fail? The key
-  /// delete runs regardless, and its log line must not claim the audio is gone
-  /// when the spool is still there. Never read for control flow.
-  private var spoolDeletionFailedThisDestruction = false
 
   /// IDs excluded from SAME-LAUNCH rescans, cleared only by a genuine new
   /// launch (a fresh coordinator). Two populations remain (#1755 narrowed it
@@ -303,7 +299,9 @@ final class RecoveryCoordinator {
   /// #1755 chunk 4: one failure-only breadcrumb per failed component per
   /// destruction call. Never includes the recovery ID, path, or raw error —
   /// deletion stays best-effort and swallowed; this is diagnosis only.
-  private func emitDeletionFailed(component: String, source: DestructionSource) {
+  private func emitDeletionFailed(
+    component: String, source: DestructionSource, spoolAlreadyFailed: Bool = false
+  ) {
     // #1762: a failed delete can leave a spool the next launch finds again, and
     // without a line here that reappearance reads as a fresh crash.
     //
@@ -315,7 +313,7 @@ final class RecoveryCoordinator {
     let disposition: String
     if component == "spool" {
       disposition = "the recording stays on disk and a future launch will find it again"
-    } else if spoolDeletionFailedThisDestruction {
+    } else if spoolAlreadyFailed {
       disposition = "the recording is ALSO still on disk — see the spool failure above"
     } else {
       disposition = "the audio is already deleted; only this leftover remains"
@@ -366,10 +364,11 @@ final class RecoveryCoordinator {
       // attempt (seam or real store). Unarmed: no-op.
       crashBoundaryController.boundaryReached(.beforeSpoolDelete)
     #endif
-    // #1762 r3: the key delete below ALWAYS runs, even after the spool failed,
-    // so its diagnostic needs to know whether audio actually survived. Reset per
-    // destruction — a stale true would misreport the next one.
-    spoolDeletionFailedThisDestruction = false
+    // #1762 r4: LOCAL, never an instance property. The key delete below is
+    // detached and several destructions overlap in practice (a dedup sweep
+    // destroys one per id), so shared state would let a later spool result
+    // rewrite an earlier key line's disposition. Captured into the task instead.
+    var spoolFailed = false
     do {
       if let override = destructionSpoolDeleteForTesting {
         try override(id)
@@ -378,13 +377,14 @@ final class RecoveryCoordinator {
       }
       emitCleanupOutcome(component: "spool", source: source, succeeded: true)
     } catch {
-      spoolDeletionFailedThisDestruction = true
-      emitDeletionFailed(component: "spool", source: source)
+      spoolFailed = true
+      emitDeletionFailed(component: "spool", source: source, spoolAlreadyFailed: true)
       emitCleanupOutcome(component: "spool", source: source, succeeded: false)
     }
     // Key deletion ALWAYS runs, detached, even after a spool failure.
     let keyStore = self.keyStore
     let keyOverride = destructionKeyDeleteForTesting
+    let capturedSpoolFailed = spoolFailed
     // Capture self STRONGLY: the failure breadcrumb must survive coordinator
     // deallocation racing the detached delete (a weak capture silently
     // dropped it). The task is short-lived; the temporary strong retention
@@ -411,7 +411,8 @@ final class RecoveryCoordinator {
         }
       } catch {
         await MainActor.run {
-          self.emitDeletionFailed(component: "key", source: source)
+          self.emitDeletionFailed(
+            component: "key", source: source, spoolAlreadyFailed: capturedSpoolFailed)
           self.emitCleanupOutcome(component: "key", source: source, succeeded: false)
         }
       }

--- a/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
@@ -127,6 +127,9 @@ final class RecoveryCoordinator {
   /// the owning drain loop clears it immediately before each pass, so a trigger
   /// arriving mid-pass causes exactly one later pass, never zero and never two.
   private var pendingRescan = false
+  /// #1762 — debug-log only: which entry point opened the current drain loop, so
+  /// each pass can name its trigger. Never read for control flow.
+  private var recoveryScanTrigger = "launch"
 
   /// IDs excluded from SAME-LAUNCH rescans, cleared only by a genuine new
   /// launch (a fresh coordinator). Two populations remain (#1755 narrowed it
@@ -517,9 +520,18 @@ final class RecoveryCoordinator {
     guard let id else { return nil }
     if armedSessionID == id { armedSessionID = nil }
     guard Self.shouldDeleteOnLiveEnding(ending) else {
+      // #1762: the RETAIN branch. A live ending that keeps its spool is the one
+      // that produces an orphan for a later launch to find, so it must not be
+      // silent — otherwise the next launch's discovery has no antecedent.
+      RecoveryLog.line("live ending (\(ending)) — keeping the spool for a future launch")
       nextLaunchOnlyRecoveryIDs.insert(id)
       return nil
     }
+    // #1762: the DELETE branch. Logged on REQUEST, before the destructor runs —
+    // `emitDeletionFailed` only fires on failure, so a successful live-ending
+    // cleanup was entirely invisible. The issue asked for the ending family and
+    // whether deletion was requested; both are here.
+    RecoveryLog.line("live ending (\(ending)) — deleting the spool")
     // GitHub cloud review PR #1761: suppress BEFORE the best-effort delete.
     // If the spool deletion fails (transient FS/permission error), the same
     // callback fires `onDictationEndedForRecovery` moments later — without
@@ -552,11 +564,11 @@ final class RecoveryCoordinator {
   func scanAndRecover() async {
     pendingRescan = true
     guard !scanInProgress else {
-      RecoveryLog.line("scan requested (launch) — coalesced into the pass already running")
+      RecoveryLog.line("launch scan arrived mid-pass — a follow-up pass is queued")
       return
     }
     scanInProgress = true
-    RecoveryLog.line("scan started (launch)")
+    recoveryScanTrigger = "launch"
     await drainPendingRescan()
   }
 
@@ -570,11 +582,11 @@ final class RecoveryCoordinator {
   func requestRecoveryRecheck() {
     pendingRescan = true
     guard !scanInProgress else {
-      RecoveryLog.line("scan requested (wake) — coalesced into the pass already running")
+      RecoveryLog.line("wake arrived mid-pass — a follow-up pass is queued")
       return
     }
     scanInProgress = true
-    RecoveryLog.line("scan started (wake)")
+    recoveryScanTrigger = "wake"
     Task { await drainPendingRescan() }
   }
 
@@ -588,9 +600,19 @@ final class RecoveryCoordinator {
   /// after yielding it would defeat the entire point of the yield; the live
   /// dictation's own later end becomes the next legitimate wake-up instead.
   private func drainPendingRescan() async {
-    defer { scanInProgress = false }
+    defer {
+      scanInProgress = false
+      RecoveryLog.line("scan finished")
+    }
+    var passNumber = 0
     while pendingRescan {
       pendingRescan = false
+      passNumber += 1
+      // #1762: log where the pass ACTUALLY starts, not where it was requested.
+      // A wake arriving mid-pass queues a FOLLOW-UP pass through this loop; an
+      // earlier draft claimed it joined the running pass, which is not what the
+      // loop does. Announcing each pass here is accurate whatever schedules it.
+      RecoveryLog.line("scan pass \(passNumber) started (\(recoveryScanTrigger))")
       let yieldedToLiveStart = await runOneScanPass()
       if yieldedToLiveStart {
         pendingRescan = false
@@ -619,6 +641,10 @@ final class RecoveryCoordinator {
       RecoveryLog.line("scan aborted — could not list the spool directory; nothing deleted")
       return false
     }
+    // #1762: BEFORE any early return, including zero. A pass that found nothing
+    // and finished must not read like a pass that stalled — that ambiguity is
+    // the whole reason this issue exists.
+    RecoveryLog.line("\(spoolIDs.count) spool(s) on disk")
     let armed = armedSessionID
 
     // Sweep KEY-ONLY orphans first: a key whose spool was never written — a
@@ -756,6 +782,12 @@ final class RecoveryCoordinator {
         recoveryEngineClaim.end()
         onRecoveryComplete?()
       }
+      // #1762: BEFORE the await, not after. If the process wedges or dies inside
+      // model load or transcription — the failure this diagnostic exists to
+      // investigate — an after-the-fact line never runs, and the log cannot show
+      // that this item ever entered replay. Pairs with the outcome line below:
+      // an "attempting" with no outcome IS the signature of a wedge.
+      RecoveryLog.line("attempting replay")
       let outcome = await replayer.replay(recoverySessionID: id) { [weak self] in
         // Discard bumps `recoveryGeneration`; a mismatch ⇒ abandon this in-flight
         // replay. Coordinator gone ⇒ treat as aborted (safe).

--- a/Sources/EnviousWisprAppKit/App/RecoveryLog.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryLog.swift
@@ -1,4 +1,5 @@
 import EnviousWisprCore
+import os
 
 /// #1762 — the ONE place recovery writes to the local debug log.
 ///
@@ -9,25 +10,20 @@ import EnviousWisprCore
 /// filed bug (#1760), and it is why #1813's cause had to be inferred from
 /// aggregate telemetry across 50 users instead of reproduced on one.
 ///
-/// Telemetry already covers the fleet (`recovery.found`, `recovery.completed`,
-/// breadcrumbs). This is the local oracle those cannot be: it answers "what did
-/// THIS launch just do" while you are standing in front of the machine.
+/// ## Ordering is carried in the LINE, never in the scheduling
 ///
-/// ## Why this is `async` rather than fire-and-forget
+/// This went through three shapes. Fire-and-forget `Task`s reorder, so the
+/// missing-outcome wedge signature could read backwards. Making the call
+/// `async` fixed that and introduced something far worse: an `await` inside the
+/// coordinator's per-item critical section, where `isRecovering` and
+/// `activeRecoveryID` are still set. A Discard landing in that suspension
+/// deletes a recording the outcome said to KEEP. A diagnostic must never widen
+/// a window in the code it observes.
 ///
-/// The first cut wrapped each line in an unstructured `Task`. Review round 2
-/// killed it, correctly: separate tasks reach the logger in whatever order the
-/// scheduler picks, and a task queued just before a wedge or a process exit may
-/// never run at all. Both of those destroy the one signature this diagnostic
-/// exists to produce — an `attempting replay` line with NO outcome after it. A
-/// reordered pair says the opposite of the truth, and a dropped pair says
-/// nothing, in exactly the crash this was built to investigate.
-///
-/// So callers `await`. Ordering then follows the call order, and the line has
-/// reached `AppLogger` before the risky work starts. Where a caller genuinely
-/// cannot await — a synchronous cleanup hook — it wraps this in its own `Task`
-/// at the CALL SITE, so the weaker guarantee is visible there instead of hidden
-/// in here.
+/// So emission stays non-suspending, and every line carries a monotonic
+/// sequence number instead. A reader sorts by `#N` and gets true call order
+/// even when the writes interleave — the wedge signature (an `attempting`
+/// with no later outcome) survives, and no critical section grows an await.
 ///
 /// **Never pass transcript text, spool bytes, key material, or a device
 /// identifier.** Counts, outcomes, durations and closed-vocabulary labels only —
@@ -37,20 +33,19 @@ import EnviousWisprCore
 /// Release builds do nothing: the body compiles out rather than relying on
 /// `AppLogger.log` being internally `#if DEBUG`.
 enum RecoveryLog {
-  /// Takes an already-built `String`, not an autoclosure.
-  ///
-  /// An autoclosure would have to be `@Sendable` to cross into the `AppLogger`
-  /// actor, and these messages legitimately read MainActor state and local
-  /// counters — `recoveryScanTrigger`, a pass number, `logLabel(outcome)`. A
-  /// `@Sendable` closure cannot capture any of it, so the argument is evaluated
-  /// eagerly on the caller's actor and only the resulting `String` travels.
-  ///
-  /// The cost is one interpolation per line in release, where the body does
-  /// nothing. These paths run once per launch scan and once per orphan, so it is
-  /// not worth trading correctness for.
-  static func line(_ message: String) async {
+  #if DEBUG
+    /// Assigned at CALL time, not at write time, so the number reflects the
+    /// order the code reached each line rather than the order tasks drained.
+    private static let sequence = OSAllocatedUnfairLock(initialState: 0)
+  #endif
+
+  static func line(_ message: String) {
     #if DEBUG
-      await AppLogger.shared.log(message, level: .info, category: "Recovery")
+      let n = sequence.withLock { value -> Int in
+        value += 1
+        return value
+      }
+      Task { await AppLogger.shared.log("#\(n) \(message)", level: .info, category: "Recovery") }
     #endif
   }
 }

--- a/Sources/EnviousWisprAppKit/App/RecoveryLog.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryLog.swift
@@ -4,7 +4,7 @@ import EnviousWisprCore
 ///
 /// Recovery emitted nothing to `app.log`: neither `RecoveryCoordinator` nor
 /// `RecoverySpoolReplayer` carried a single line, so on a real machine a
-/// replay-and-delete of an orphan that held no speech looked exactly like
+/// replay-and-delete of an orphan that produced no text looked exactly like
 /// "recovery is broken". That cost an hour of live diagnosis and one falsely
 /// filed bug (#1760), and it is why #1813's cause had to be inferred from
 /// aggregate telemetry across 50 users instead of reproduced on one.
@@ -13,18 +13,44 @@ import EnviousWisprCore
 /// breadcrumbs). This is the local oracle those cannot be: it answers "what did
 /// THIS launch just do" while you are standing in front of the machine.
 ///
+/// ## Why this is `async` rather than fire-and-forget
+///
+/// The first cut wrapped each line in an unstructured `Task`. Review round 2
+/// killed it, correctly: separate tasks reach the logger in whatever order the
+/// scheduler picks, and a task queued just before a wedge or a process exit may
+/// never run at all. Both of those destroy the one signature this diagnostic
+/// exists to produce — an `attempting replay` line with NO outcome after it. A
+/// reordered pair says the opposite of the truth, and a dropped pair says
+/// nothing, in exactly the crash this was built to investigate.
+///
+/// So callers `await`. Ordering then follows the call order, and the line has
+/// reached `AppLogger` before the risky work starts. Where a caller genuinely
+/// cannot await — a synchronous cleanup hook — it wraps this in its own `Task`
+/// at the CALL SITE, so the weaker guarantee is visible there instead of hidden
+/// in here.
+///
 /// **Never pass transcript text, spool bytes, key material, or a device
 /// identifier.** Counts, outcomes, durations and closed-vocabulary labels only —
 /// the same content-free rule the telemetry boundary follows. A recovered
 /// transcript is described by its character count and nothing else.
 ///
-/// Release builds allocate nothing: the call site compiles away entirely rather
-/// than relying on `AppLogger.log` being internally `#if DEBUG`.
+/// Release builds do nothing: the body compiles out rather than relying on
+/// `AppLogger.log` being internally `#if DEBUG`.
 enum RecoveryLog {
-  static func line(_ message: @autoclosure () -> String) {
+  /// Takes an already-built `String`, not an autoclosure.
+  ///
+  /// An autoclosure would have to be `@Sendable` to cross into the `AppLogger`
+  /// actor, and these messages legitimately read MainActor state and local
+  /// counters — `recoveryScanTrigger`, a pass number, `logLabel(outcome)`. A
+  /// `@Sendable` closure cannot capture any of it, so the argument is evaluated
+  /// eagerly on the caller's actor and only the resulting `String` travels.
+  ///
+  /// The cost is one interpolation per line in release, where the body does
+  /// nothing. These paths run once per launch scan and once per orphan, so it is
+  /// not worth trading correctness for.
+  static func line(_ message: String) async {
     #if DEBUG
-      let text = message()
-      Task { await AppLogger.shared.log(text, level: .info, category: "Recovery") }
+      await AppLogger.shared.log(message, level: .info, category: "Recovery")
     #endif
   }
 }

--- a/Sources/EnviousWisprAppKit/App/RecoveryLog.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryLog.swift
@@ -25,6 +25,22 @@ import os
 /// even when the writes interleave — the wedge signature (an `attempting`
 /// with no later outcome) survives, and no critical section grows an await.
 ///
+/// ## Known limit, accepted deliberately
+///
+/// A process that dies immediately after a call can lose that line: the task
+/// never reaches `AppLogger`. Review raised this against the `attempting replay`
+/// line specifically, which is the one a hard wedge most wants.
+///
+/// It is accepted rather than fixed, because the alternative is the awaited
+/// version that opened a delete-a-kept-recording window, and because the
+/// DURABLE record of "an attempt started" already exists and is not this log:
+/// `RecoverySpoolReplayer` writes a per-spool attempt marker to disk BEFORE the
+/// risky load/transcribe, precisely so a launch that dies mid-replay is
+/// detectable on the next one. The marker is the evidence; this line is the
+/// convenience. Anyone diagnosing a wedge should read both, and a missing
+/// `attempting` line next to a surviving marker means the process died between
+/// the two — itself a useful reading.
+///
 /// **Never pass transcript text, spool bytes, key material, or a device
 /// identifier.** Counts, outcomes, durations and closed-vocabulary labels only —
 /// the same content-free rule the telemetry boundary follows. A recovered

--- a/Sources/EnviousWisprAppKit/App/RecoveryLog.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryLog.swift
@@ -1,0 +1,30 @@
+import EnviousWisprCore
+
+/// #1762 — the ONE place recovery writes to the local debug log.
+///
+/// Recovery emitted nothing to `app.log`: neither `RecoveryCoordinator` nor
+/// `RecoverySpoolReplayer` carried a single line, so on a real machine a
+/// replay-and-delete of an orphan that held no speech looked exactly like
+/// "recovery is broken". That cost an hour of live diagnosis and one falsely
+/// filed bug (#1760), and it is why #1813's cause had to be inferred from
+/// aggregate telemetry across 50 users instead of reproduced on one.
+///
+/// Telemetry already covers the fleet (`recovery.found`, `recovery.completed`,
+/// breadcrumbs). This is the local oracle those cannot be: it answers "what did
+/// THIS launch just do" while you are standing in front of the machine.
+///
+/// **Never pass transcript text, spool bytes, key material, or a device
+/// identifier.** Counts, outcomes, durations and closed-vocabulary labels only —
+/// the same content-free rule the telemetry boundary follows. A recovered
+/// transcript is described by its character count and nothing else.
+///
+/// Release builds allocate nothing: the call site compiles away entirely rather
+/// than relying on `AppLogger.log` being internally `#if DEBUG`.
+enum RecoveryLog {
+  static func line(_ message: @autoclosure () -> String) {
+    #if DEBUG
+      let text = message()
+      Task { await AppLogger.shared.log(text, level: .info, category: "Recovery") }
+    #endif
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
@@ -335,6 +335,13 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
 
     // Success. #1464: the coordinator deletes the spool (+ marker) + key on
     // `.recovered` and posts the success notice; the replayer only reports.
+    //
+    // #1762: character COUNT and audio duration only — never the transcript. A
+    // count is enough to tell "recovered something real" from "recovered a
+    // fragment", which is the question you ask standing at the machine.
+    RecoveryLog.line(
+      "replay recovered \(textOutcome.text.count) chars from "
+        + "\(Int(recoveredSeconds.rounded()))s of audio")
     TelemetryService.shared.recoveryCompleted(
       outcome: "recovered",
       recoveredSeconds: Int(recoveredSeconds.rounded()),
@@ -360,6 +367,11 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
     let spoolSeconds = reconstructedSampleCount.map {
       Int((Double($0) / AudioConstants.sampleRate).rounded())
     }
+    // #1762: the REASON, which the coordinator's outcome line cannot carry —
+    // `.failed(.unrecoverable)` covers key-missing, decrypt, reconstruct,
+    // model-load, throw and empty-result alike, and telling them apart on a real
+    // machine is the whole point of this issue. Closed vocabulary, no id, no path.
+    RecoveryLog.line("replay failed: \(reason.rawValue)")
     TelemetryService.shared.recoveryCompleted(
       outcome: "failed",
       reason: reason,

--- a/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
@@ -339,7 +339,7 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
     // #1762: character COUNT and audio duration only — never the transcript. A
     // count is enough to tell "recovered something real" from "recovered a
     // fragment", which is the question you ask standing at the machine.
-    await RecoveryLog.line(
+    RecoveryLog.line(
       "replay recovered \(textOutcome.text.count) chars from "
         + "\(Int(recoveredSeconds.rounded()))s of audio")
     TelemetryService.shared.recoveryCompleted(
@@ -377,7 +377,7 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
     // coordinator's own awaited outcome line lands after `replay` returns, and
     // this reason line is enqueued strictly before that.
     let failureReason = reason.rawValue
-    Task { await RecoveryLog.line("replay failed: \(failureReason)") }
+    RecoveryLog.line("replay failed: \(failureReason)")
     TelemetryService.shared.recoveryCompleted(
       outcome: "failed",
       reason: reason,

--- a/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
@@ -339,7 +339,7 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
     // #1762: character COUNT and audio duration only — never the transcript. A
     // count is enough to tell "recovered something real" from "recovered a
     // fragment", which is the question you ask standing at the machine.
-    RecoveryLog.line(
+    await RecoveryLog.line(
       "replay recovered \(textOutcome.text.count) chars from "
         + "\(Int(recoveredSeconds.rounded()))s of audio")
     TelemetryService.shared.recoveryCompleted(
@@ -371,7 +371,13 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
     // `.failed(.unrecoverable)` covers key-missing, decrypt, reconstruct,
     // model-load, throw and empty-result alike, and telling them apart on a real
     // machine is the whole point of this issue. Closed vocabulary, no id, no path.
-    RecoveryLog.line("replay failed: \(reason.rawValue)")
+    //
+    // `failUnrecoverable` is synchronous (it is called from `guard` bodies all
+    // through `replay`), so this cannot await. Ordering is still sound: the
+    // coordinator's own awaited outcome line lands after `replay` returns, and
+    // this reason line is enqueued strictly before that.
+    let failureReason = reason.rawValue
+    Task { await RecoveryLog.line("replay failed: \(failureReason)") }
     TelemetryService.shared.recoveryCompleted(
       outcome: "failed",
       reason: reason,

--- a/Tests/EnviousWisprTests/Recovery/RecoveryLogLabelTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryLogLabelTests.swift
@@ -83,9 +83,22 @@ import Testing
     // `RecoveryLog`'s rule: counts, outcomes and closed-vocabulary labels only.
     // These strings are constants, so the freeze is that they STAY constants —
     // no id, path, or interpolated payload creeping in later.
+    //
+    // The identifier check looks for a UUID SHAPE, not a bare hyphen. Banning
+    // hyphens outright false-fired on the ordinary English "re-checks" the
+    // moment a label was reworded, which is a rule that punishes prose rather
+    // than catching leaks. A recovery session id is a UUID, so that is the
+    // shape worth refusing.
+    let uuidish = try! Regex("[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}")
     for label in Self.allOutcomes.map(RecoveryCoordinator.logLabel) {
       #expect(!label.contains("/"), "a path reached a log label")
-      #expect(!label.contains("-"), "an identifier reached a log label")
+      #expect(label.firstMatch(of: uuidish) == nil, "an identifier reached a log label")
     }
+
+    // TWO-WAY CONTROL: the pattern must actually catch a real session id, or the
+    // assertions above pass because the check is broken rather than because the
+    // labels are clean.
+    let leaked = "recovered — 8B1D2C3A-77F0-4E11-9A2B-1C4D5E6F7A88"
+    #expect(leaked.firstMatch(of: uuidish) != nil, "the leak detector cannot detect a leak")
   }
 }

--- a/Tests/EnviousWisprTests/Recovery/RecoveryLogLabelTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryLogLabelTests.swift
@@ -1,0 +1,91 @@
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #1762. Freezes the outcome vocabulary recovery writes to the local debug log.
+///
+/// These strings are the on-machine oracle. Recovery previously wrote NOTHING,
+/// so a replay-and-delete of an orphan that held no speech was indistinguishable
+/// from "recovery is broken" — an hour of live diagnosis and one falsely filed
+/// bug (#1760), and the reason #1813's cause had to be inferred from aggregate
+/// telemetry across 50 users rather than reproduced on one machine.
+///
+/// Every test carries a NEGATIVE arm. A label function returning one string for
+/// everything would satisfy "not empty" while destroying the only property that
+/// matters: that two different outcomes read differently.
+/// `@MainActor` to match `RecoveryCoordinatorTests` — `RecoveryCoordinator` is a
+/// MainActor type, so its statics inherit that isolation.
+@MainActor
+@Suite struct RecoveryLogLabelTests {
+
+  /// Every outcome the replayer can return. Written out rather than derived so
+  /// adding a case to `RecoveryReplayOutcome` fails to compile here until it is
+  /// listed — the label switch is exhaustive, but nothing would otherwise force
+  /// this test to cover a new member.
+  private static let allOutcomes: [RecoveryReplayOutcome] = [
+    .recovered,
+    .abandoned,
+    .failed(.unrecoverable),
+    .failed(.save(.other)),
+    .aborted,
+    .deferred,
+    .deferredMarkerClearFailed,
+  ]
+
+  @Test("every outcome reads differently in the log")
+  func labelsAreDistinct() {
+    let labels = Self.allOutcomes.map(RecoveryCoordinator.logLabel)
+
+    // THE POINT. A shared label would put "recovered" and "gave up" on the same
+    // line, which is exactly the ambiguity #1762 exists to remove.
+    #expect(Set(labels).count == labels.count, "two outcomes share a log label")
+
+    for label in labels {
+      #expect(!label.isEmpty)
+    }
+  }
+
+  @Test("the two outcomes that looked identical on disk now read differently")
+  func successAndGiveUpAreDistinguishable() {
+    // Both delete the spool, so after the fact the disk is byte-identical. The
+    // log line is the ONLY thing that separates them.
+    let recovered = RecoveryCoordinator.logLabel(.recovered)
+    let gaveUp = RecoveryCoordinator.logLabel(.failed(.unrecoverable))
+
+    #expect(recovered != gaveUp)
+    #expect(recovered.contains("recovered"))
+    #expect(gaveUp.contains("unrecoverable"))
+
+    // NEGATIVE: the give-up label must not read as a success. A future edit that
+    // softened it to "recovery finished" would pass a distinctness check and
+    // still mislead the person reading the log at 1am.
+    #expect(!gaveUp.contains("saved to History"))
+  }
+
+  @Test("a deferral says no attempt ran, because that decides whether audio survives")
+  func deferralsSayNoAttemptRan() {
+    // `shouldDeleteAfterReplay` retains on both deferrals: ASR never ran, so the
+    // one attempt is unspent. The label has to carry that, or a reader sees
+    // "deferred" and cannot tell whether the recording is still on disk.
+    for outcome: RecoveryReplayOutcome in [.deferred, .deferredMarkerClearFailed] {
+      #expect(RecoveryCoordinator.logLabel(outcome).contains("deferred"))
+      #expect(RecoveryCoordinator.shouldDeleteAfterReplay(outcome) == false)
+    }
+
+    // TWO-WAY CONTROL: a spent attempt must still delete. Without this arm, a
+    // change that made everything retain would pass the assertions above while
+    // breaking the one-attempt rule.
+    #expect(RecoveryCoordinator.shouldDeleteAfterReplay(.failed(.unrecoverable)) == true)
+  }
+
+  @Test("no label leaks anything but the outcome")
+  func labelsCarryNoContent() {
+    // `RecoveryLog`'s rule: counts, outcomes and closed-vocabulary labels only.
+    // These strings are constants, so the freeze is that they STAY constants —
+    // no id, path, or interpolated payload creeping in later.
+    for label in Self.allOutcomes.map(RecoveryCoordinator.logLabel) {
+      #expect(!label.contains("/"), "a path reached a log label")
+      #expect(!label.contains("-"), "an identifier reached a log label")
+    }
+  }
+}


### PR DESCRIPTION
Closes #1762. Epic #1878 Phase 1.

## The problem

Neither `RecoveryCoordinator` nor `RecoverySpoolReplayer` wrote a single line to `app.log` — verified, not assumed: `grep -c AppLogger` returned **0** in both.

So on a real machine, a replay-and-delete of an orphan that produced no text looked exactly like "recovery is broken". That cost an hour of live diagnosis and one falsely filed bug (#1760), and it is why #1813's cause had to be inferred from aggregate telemetry across 50 users instead of reproduced on one.

## What a launch now says

```
#1 scan pass 1 started (launch)
#2 1 spool(s) on disk
#3 1 spool(s) to attempt this pass
#4 attempting replay
#5 replay failed: empty_text
#6 replay unrecoverable — the attempt is spent — requesting deletion
#7 scan finished
```

Every line was absent this morning. The whole sequence was a file silently disappearing.

**Disposition is the half that was impossible to read from disk.** A spool that is gone tells you nothing about whether it was recovered or given up on, and both outcomes delete.

Also visible for the first time: the fail-closed scan abort (previously indistinguishable from "no spools"), all three deferral branches, dedupe deletes, per-pass counts, both live-ending branches, and a failed deletion.

## Two design decisions worth the review time

**Ordering lives in the line, not the scheduling.** Fire-and-forget tasks reorder, so the wedge signature could read backwards. Making the call `async` fixed that and opened something far worse — an `await` inside the coordinator's per-item critical section, where a Discard deletes a recording the outcome said to KEEP. **A diagnostic must never widen a window in the code it observes.** Emission is non-suspending; every line carries a monotonic sequence number assigned at call time.

**Lines report the action and its result, never an inferred consequence.** "The recording stays on disk", "the audio is already deleted", "a new launch may retry" were each wrong in some real path — `RecoverySpoolStore.delete` also clears the attempt marker and propagates that failure; the detached key delete cannot see the spool's fate under concurrent destructions; a marker-clear failure means the next launch abandons rather than retries. The call site knows what it just attempted and whether it worked, so that is all it says.

## Accepted limit

A process dying immediately after a call can lose that line. Not engineered around: the alternative is the awaited version above, and the **durable** record of "an attempt started" already exists — the per-spool attempt marker is written to disk *before* the risky load/transcribe, exactly so a launch that dies mid-replay is detectable on the next one. A missing `attempting` line next to a surviving marker is itself a useful reading. Documented in `RecoveryLog`.

## Verification

- Full suite: **4,716 tests, TEST SUCCEEDED, exit 0.**
- 4 new tests with negative arms: outcome labels are mutually distinct; the two outcomes that look identical on disk read differently; a deferral says no attempt ran AND retains; no label carries a UUID shape — with a control proving the leak detector can detect a leak.
- **Two-way control, run rather than argued:** making the give-up label read as the success label fails four assertions, including the one asserting a give-up line must not contain "saved to History".
- Six local review rounds. Round 3 found a data-loss window in my own fix; round 4 found a concurrency bug in the fix for it; round 5's three findings shared one cause and were fixed at the cause, which made the change smaller.
- Zero release-build impact: `RecoveryLog` compiles out entirely rather than relying on `AppLogger.log` being internally `#if DEBUG`.

## Privacy

Counts, outcomes, durations and closed-vocabulary labels only. A recovered transcript is described by its character count and nothing else. `RecoveryLog` is the single owner of that rule so the next line added cannot invent its own.
