### PR TITLE
test(audio): teach the capture fake the production session fence (Part of #1854)

### DIFF
--- a/Tests/EnviousWisprTests/Pipeline/CaptureSessionFenceTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/CaptureSessionFenceTests.swift
@@ -87,13 +87,35 @@ struct CaptureSessionFenceTests {
     try await capture.startEnginePhase()
     #expect(capture.currentCaptureSessionID == 0)
 
-    // Its cleanup MUST be permitted or the engine leaks. This is why the fence
-    // treats 0 as valid, and why the fix cannot simply refuse id 0 — the first
-    // attempt in #1854 refused `.notStarted` and stranded a live engine.
+    // Its cleanup MUST be permitted or the engine leaks — not by a special case
+    // for `0`, but because the counter is also `0`, so the equality holds. The
+    // fix cannot simply refuse id 0: attempt 1 in #1854 refused `.notStarted`
+    // and stranded a live engine.
     _ = await capture.stopCapture(sessionID: 0)
 
     #expect(
       capture.stopCaptureRefusedCallCount == 0,
       "refusing an unarmed cleanup leaks the engine — the round-1 failure mode")
+  }
+
+  @Test("a stale ZERO id is refused once the counter has moved on")
+  func staleZeroIDIsRefusedAfterArming() async throws {
+    let capture = FakeAudioCapture()
+
+    // A session arms, so the counter is no longer 0.
+    try await capture.startEnginePhase()
+    _ = try await capture.beginCapturePhase(recoveryPayload: nil)
+    #expect(capture.currentCaptureSessionID != 0)
+
+    // A leftover unarmed-cleanup carrying `0` arrives late. Production's guard
+    // is strict equality, so this is REFUSED — `0` is not a skeleton key.
+    _ = await capture.stopCapture(sessionID: 0)
+
+    // This test exists because the first draft of the fence wrote
+    // `|| sessionID == 0` and would have torn down the live capture here. A fake
+    // that is more permissive than production makes a Phase 2 race test report a
+    // failure that cannot occur, which is worse than no fake fidelity at all.
+    #expect(capture.stopCaptureRefusedCallCount == 1)
+    #expect(capture.isCapturing, "a stale zero-id stop must not stop a live capture")
   }
 }

--- a/Tests/EnviousWisprTests/Pipeline/CaptureSessionFenceTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/CaptureSessionFenceTests.swift
@@ -1,0 +1,99 @@
+import Testing
+
+@testable import EnviousWisprPipeline
+
+/// #1854 Phase 1. Pins what the capture-session identity fence does and does
+/// NOT protect, now that `FakeAudioCapture` models it faithfully.
+///
+/// The fence lives in `AudioCaptureManager.stopCapture(sessionID:)` and refuses
+/// a stop whose id is not the live one. Its own comment states the limit this
+/// issue exists to close:
+///
+/// > `0` stays valid: it is the id of a prepared-but-never-armed engine, whose
+/// > cleanup must be allowed through or the engine leaks. This guard cannot
+/// > identify that prepared interval; callers must separately gate it using
+/// > lifecycle ownership.
+///
+/// Until now the fake ignored `sessionID` entirely, so every stale stop landed
+/// and a test could not tell "production would have fenced this" from "this is
+/// the hole". Both showed up as the capture stopping. These tests separate them.
+@MainActor
+@Suite("Capture session fence (#1854 Phase 1)")
+struct CaptureSessionFenceTests {
+
+  @Test("a stale stop from a PREVIOUS armed session is refused")
+  func staleStopFromOlderSessionIsRefused() async throws {
+    let capture = FakeAudioCapture()
+
+    // Session 1 arms, then a successor arms. The counter is now 2.
+    try await capture.startEnginePhase()
+    _ = try await capture.beginCapturePhase(recoveryPayload: nil)
+    let firstSessionID = capture.currentCaptureSessionID
+    try await capture.startEnginePhase()
+    _ = try await capture.beginCapturePhase(recoveryPayload: nil)
+
+    #expect(capture.currentCaptureSessionID != firstSessionID)
+    #expect(capture.isCapturing)
+
+    // Session 1's cleanup arrives late, carrying its own id.
+    _ = await capture.stopCapture(sessionID: firstSessionID)
+
+    // THE FENCE WORKS HERE. This is the half production already closes, and it
+    // is why the fake had to learn it: a fix credited with closing this window
+    // would be taking credit for a guard that already exists.
+    #expect(capture.stopCaptureRefusedCallCount == 1)
+    #expect(capture.isCapturing, "the newer capture must survive a stale stop")
+  }
+
+  @Test("a stale stop DURING the successor's prepared interval is NOT refused")
+  func staleStopDuringPreparedIntervalIsNotRefused() async throws {
+    let capture = FakeAudioCapture()
+
+    // Predecessor arms. Counter is 1.
+    try await capture.startEnginePhase()
+    _ = try await capture.beginCapturePhase(recoveryPayload: nil)
+    let ownedSessionID = capture.currentCaptureSessionID
+
+    // The successor prepares the engine but has NOT armed yet — exactly the
+    // interval cloud review reached independently on PR #1855. `startEnginePhase`
+    // does not bump the counter, so it still reads the PREDECESSOR's id.
+    try await capture.startEnginePhase()
+    #expect(
+      capture.currentCaptureSessionID == ownedSessionID,
+      "preparing a successor must not bump the counter — that is the premise")
+
+    // The predecessor's detached cleanup lands now, carrying the id it
+    // snapshotted synchronously at terminal time (`RecordingSessionKernel`
+    // :3797). That id still matches, so the fence has nothing to catch it with.
+    _ = await capture.stopCapture(sessionID: ownedSessionID)
+
+    // THE HOLE, pinned. Not refused, and the engine the successor just prepared
+    // is now stopped. `AudioCaptureManager`'s own comment predicts exactly this:
+    // the guard cannot identify the prepared interval, so the caller must gate
+    // it by lifecycle ownership — which is Phase 2.
+    #expect(
+      capture.stopCaptureRefusedCallCount == 0,
+      "the identity fence cannot see this interval — that is the defect")
+    #expect(
+      !capture.isCapturing,
+      "the successor's prepared engine was stopped by its predecessor's cleanup")
+  }
+
+  @Test("a prepared-but-never-armed cleanup still gets through")
+  func unarmedCleanupIsPermitted() async throws {
+    let capture = FakeAudioCapture()
+
+    // Prepared, never armed: the counter is still 0.
+    try await capture.startEnginePhase()
+    #expect(capture.currentCaptureSessionID == 0)
+
+    // Its cleanup MUST be permitted or the engine leaks. This is why the fence
+    // treats 0 as valid, and why the fix cannot simply refuse id 0 — the first
+    // attempt in #1854 refused `.notStarted` and stranded a live engine.
+    _ = await capture.stopCapture(sessionID: 0)
+
+    #expect(
+      capture.stopCaptureRefusedCallCount == 0,
+      "refusing an unarmed cleanup leaks the engine — the round-1 failure mode")
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
@@ -44,6 +44,14 @@ final class FakeAudioCapture: AudioCaptureInterface {
   // MARK: Observed counters (for FakeAudioCaptureTests teardown assertion)
 
   private(set) var stopCaptureCallCount = 0
+  /// #1854 Phase 1 — how many of those calls the identity fence REFUSED.
+  ///
+  /// Separate from `stopCaptureCallCount` on purpose: a refused stop still
+  /// arrived, and a test proving the kernel gate works needs to distinguish
+  /// "the stale stop was fenced" from "the stale stop never happened". Without
+  /// this, both read as the engine surviving, and a fix that merely stopped
+  /// scheduling the cleanup would look identical to one that gated it.
+  private(set) var stopCaptureRefusedCallCount = 0
   private(set) var beginCapturePhaseCallCount = 0
   private(set) var preWarmCallCount = 0
   private(set) var abortPreWarmCallCount = 0
@@ -240,6 +248,25 @@ final class FakeAudioCapture: AudioCaptureInterface {
 
   func stopCapture(sessionID: UInt64) async -> CaptureResult {
     stopCaptureCallCount += 1
+    // #1854 Phase 1: model the PRODUCTION identity fence.
+    //
+    // `AudioCaptureManager.stopCapture(sessionID:)` refuses a stop whose id is
+    // not the live one and changes nothing. This fake ignored `sessionID`
+    // entirely, so every stale stop LANDED — which meant a test could not tell
+    // "production would have fenced this" from "this is the hole", and both
+    // showed up as `stopCaptureCallCount` rising with `isCapturing` going false.
+    //
+    // `0` stays valid deliberately, exactly as production does: it is the id of
+    // a prepared-but-never-armed engine whose cleanup must be allowed through or
+    // the engine leaks. That permitted `0` is precisely the interval #1854 is
+    // about — the manager's own comment says this guard cannot identify it and
+    // callers must gate it by lifecycle ownership. Modelling the fence here
+    // narrows the failing test to that interval instead of a broader window the
+    // real code already closes.
+    guard sessionID == currentCaptureSessionID || sessionID == 0 else {
+      stopCaptureRefusedCallCount += 1
+      return CaptureResult(samples: [])
+    }
     isCapturing = false
     bufferContinuation?.finish()
     bufferContinuation = nil

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
@@ -256,14 +256,17 @@ final class FakeAudioCapture: AudioCaptureInterface {
     // "production would have fenced this" from "this is the hole", and both
     // showed up as `stopCaptureCallCount` rising with `isCapturing` going false.
     //
-    // `0` stays valid deliberately, exactly as production does: it is the id of
-    // a prepared-but-never-armed engine whose cleanup must be allowed through or
-    // the engine leaks. That permitted `0` is precisely the interval #1854 is
-    // about — the manager's own comment says this guard cannot identify it and
-    // callers must gate it by lifecycle ownership. Modelling the fence here
-    // narrows the failing test to that interval instead of a broader window the
-    // real code already closes.
-    guard sessionID == currentCaptureSessionID || sessionID == 0 else {
+    // STRICT EQUALITY, with no special case for `0`. Production's guard is
+    // exactly `sessionID == captureSessionCounter`. A prepared-but-never-armed
+    // cleanup gets through there not by exception but because the counter is
+    // ALSO `0` at that moment, so the equality simply holds.
+    //
+    // An earlier draft here wrote `|| sessionID == 0`, which accepts a stale
+    // zero-id stop even when the counter has moved on — more permissive than
+    // production, in precisely the direction that makes a Phase 2 race test
+    // report a failure that cannot happen. Over-modelling the fence is the same
+    // class of error as not modelling it.
+    guard sessionID == currentCaptureSessionID else {
       stopCaptureRefusedCallCount += 1
       return CaptureResult(samples: [])
     }


### PR DESCRIPTION
Part of #1854. Epic #1877 Phase 1. **Test infrastructure only — no production line changes.**

## Why this lands alone

#1854 is a demonstrated lost dictation: a terminal capture cleanup can run after a newer session took over and stop it. Two fix attempts have failed review, both in the same direction — refusing a legitimate stop, which is worse than the bug — and three reviewers reached the window independently.

The demonstration used a fake that **ignored `sessionID` entirely**, so every stale stop landed. That fake could not distinguish:

- a stale stop with a mismatched id — **production already refuses this**; from
- a stale stop during the successor's PREPARED interval — **production permits it**.

Only the second is the defect. A Phase 2 fix closing only the first would have looked successful.

## What ships

`FakeAudioCapture.stopCapture(sessionID:)` now models the production fence — plain equality against the live counter, matching `AudioCaptureManager.stopCapture(sessionID:)` — and counts refusals separately from calls, so a test can tell "the stale stop was fenced" from "the stale stop never happened". Without that split, a fix that merely stopped *scheduling* the cleanup reads identically to one that gated it.

Four tests pin four distinct behaviours:

| Case | Result | Why it is pinned |
|---|---|---|
| Stale stop from a previous ARMED session | refused | Production already closes this; a fix must not take credit for it |
| Stale stop during the successor's PREPARED interval | **not refused** | **The defect.** `startEnginePhase` does not bump the counter, so it still reads the predecessor's id — exactly what the kernel snapshotted at `RecordingSessionKernel.swift:3797` |
| Prepared-but-never-armed cleanup | permitted | Must be, or the engine leaks. Attempt 1 broke this by refusing `.notStarted` |
| Stale ZERO id after a session armed | refused | Zero is not a skeleton key |

## The falsifier, answered

Posted on the issue before writing any code: *if the control stops reproducing entirely once the fake learns the fence, Phase 2's premise needs re-examining.*

**It still reproduces**, via the prepared interval only. The premise holds and the target is narrower than the original demonstration implied.

## Review round 1 caught the fake being wrong in a NEW direction

The first draft wrote `sessionID == current || sessionID == 0`, treating zero as a special case. Production has no such case — zero passes only because the counter is also zero, so the equality holds naturally.

That draft would accept a stale zero-id stop *after* the counter moved on, tearing down a live capture production protects. **A fake more permissive than production makes a Phase 2 race test report a failure that cannot happen** — the exact class of error this Phase exists to remove.

The fourth test above fails against that draft, so the fidelity claim is now tested rather than asserted in a comment.

## Verification

- Full suite: **4,726 tests, TEST SUCCEEDED, exit 0.** No existing test depended on the fake's old permissiveness.
- Local whole-diff `codex review`: clean on the confirming round.
- Dev build: BUILD SUCCEEDED.

## Not in this change

Phase 2 — the explicit handoff in the forward path. The epic records the principle (exactly one owner of the audio engine at any instant, ownership transfers explicitly, no third refusal condition) but does not pick the mechanism, and that choice is a module-boundary decision with a demonstrated cost of getting it wrong. Founder Gate 2.
