### PR TITLE
docs(1780): point the VAD harness reference at its archive tag

### DIFF
--- a/docs/feature-requests/issue-1780-2026-07-24-record-start-observability.md
+++ b/docs/feature-requests/issue-1780-2026-07-24-record-start-observability.md
@@ -134,7 +134,7 @@ Issue #1780 classified the investigation as LARGE. This reduced plan is **MEDIUM
 
 The compute-unit pin does not ship in this PR. Before it may be proposed again:
 
-1. Bring the exact VAD benchmark into a reviewable branch, or name a committed immutable artifact and command both configurations run unchanged. The `Tests/RuntimeUAT/repro-1780` harness currently lives only on the `investigate/1780-vad-repro` branch and is NOT in this worktree; the measurement may not depend on an investigation-branch artifact.
+1. Bring the exact VAD benchmark into a reviewable branch, or name a committed immutable artifact and command both configurations run unchanged. The `Tests/RuntimeUAT/repro-1780` harness lives only in the annotated tag `parked/1780-vad-repro-2026-08-01` (branch `investigate/1780-vad-repro` archived into it and deleted 2026-08-01) and is NOT in this worktree; the measurement may not depend on an investigation-branch artifact. Restore with `git checkout parked/1780-vad-repro-2026-08-01 -- Tests/RuntimeUAT/repro-1780`.
 2. Run the unchanged harness against current `.all` and proposed `.cpuAndNeuralEngine` before any implementation approval.
 3. Record cold preparation, first prediction, sustained prediction, CPU time, and energy, broken out by tested hardware and macOS version.
 4. Obtain explicit founder approval for changing compute scheduling for all users.

--- a/docs/feature-requests/issue-1780-2026-07-24-record-start-observability.md
+++ b/docs/feature-requests/issue-1780-2026-07-24-record-start-observability.md
@@ -134,7 +134,7 @@ Issue #1780 classified the investigation as LARGE. This reduced plan is **MEDIUM
 
 The compute-unit pin does not ship in this PR. Before it may be proposed again:
 
-1. Bring the exact VAD benchmark into a reviewable branch, or name a committed immutable artifact and command both configurations run unchanged. The `Tests/RuntimeUAT/repro-1780` harness lives only in the annotated tag `parked/1780-vad-repro-2026-08-01` (branch `investigate/1780-vad-repro` archived into it and deleted 2026-08-01) and is NOT in this worktree; the measurement may not depend on an investigation-branch artifact. Restore with `git checkout parked/1780-vad-repro-2026-08-01 -- Tests/RuntimeUAT/repro-1780`.
+1. Bring the exact VAD benchmark into a reviewable branch, or name a committed immutable artifact and command both configurations run unchanged. The `Tests/RuntimeUAT/repro-1780` harness lives only in the annotated tag `parked/1780-vad-repro-2026-08-01` (branch `investigate/1780-vad-repro` archived into it and deleted 2026-08-01) and is NOT in this worktree; the measurement may not depend on an investigation-branch artifact. Restore with `git checkout parked/1780-vad-repro-2026-08-01 -- Tests/RuntimeUAT/repro-1780 .github/workflows/repro-1780-vad.yml` — both paths, since the probe is only runnable through that workflow's macos-14 matrix.
 2. Run the unchanged harness against current `.all` and proposed `.cpuAndNeuralEngine` before any implementation approval.
 3. Record cold preparation, first prediction, sustained prediction, CPU time, and energy, broken out by tested hardware and macOS version.
 4. Obtain explicit founder approval for changing compute scheduling for all users.


### PR DESCRIPTION
## What

`investigate/1780-vad-repro` was archived into the annotated tag `parked/1780-vad-repro-2026-08-01` and deleted (local + remote). This plan's §12 was the **only tracked reference** to the old branch name, so it would have dangled. It now names the tag and carries the restore command.

## Why the branch became a tag

github.md RULE: park-deferred-work-as-an-annotated-tag — a retained branch sits in the branch list asking to be judged stale on every audit, which is the exact ambiguity that cost a full session on 2026-07-28. A tag cannot be advanced, half-merged, or mistaken for live work, and the state travels in the tag message rather than drifting from the code.

The harness itself is unchanged and still worth keeping: it is the only way we have run the real bundled Silero VAD model on a Sonoma runner, and it encodes two things that would otherwise be re-learned from scratch (the macos-14 runner ships Swift 5.10 against FluidAudio's swift-tools 6.0 requirement, and dev on macOS 26 cannot execute the BNNS path in the crash stack).

**Verified before deleting anything:** the tag holds all six files — `Tests/RuntimeUAT/repro-1780/{.gitignore,Package.swift,guard.swift,sonoma-probe.swift,Sources/vadrepro/main.swift}` plus `.github/workflows/repro-1780-vad.yml`.

## Lane

`Docs/dev-tooling`. Prose only, one line, no logic. #1780 stays closed; this changes no plan decision.

Part of #1780
