### PR TITLE
fix(worker): weekly digest reports correct numbers, degrades instead of guessing (#1589)

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -495,6 +495,36 @@ jobs:
           done
           echo "==> Both standalone eval packages compile against current Core"
 
+  # Worker unit suites (#1589). Deliberately UNCONDITIONAL and deliberately
+  # running BOTH workers every time: the point is to catch a change under
+  # workers/shared/ that breaks the OTHER consumer, which a paths filter or a
+  # changed-worker-only run would miss by construction. It is seconds long and
+  # needs no macOS runner, so gating it buys nothing and adds a way to be wrong.
+  # It does not consume scripts/ci/classify-changes.sh, whose needs_build verdict
+  # is about the Swift build and has no opinion about workers.
+  #
+  # Feeds build-check below, because an advisory job that goes red while the PR
+  # stays mergeable is decoration, not a gate.
+  worker-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: '22'
+
+      - name: Worker unit tests
+        run: |
+          set -euo pipefail
+          for w in daily-report weekly-digest; do
+            echo "==> $w"
+            ( cd "workers/$w" && node --test )
+          done
+
   # Required aggregate gate. This is the ONLY required status check on main
   # (ruleset main-protection, context "build-check"); keeping the job id
   # "build-check" preserves that context so no ruleset change is needed (#906).
@@ -502,7 +532,7 @@ jobs:
   # fail closed), but is skipped when the whole run is cancelled (a superseded
   # push) so the obsolete SHA shows "cancelled", not a false "Failure".
   build-check:
-    needs: [build-debug, build-release]
+    needs: [build-debug, build-release, worker-tests]
     if: always() && !cancelled()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -524,11 +554,13 @@ jobs:
 
       - name: Require both build lanes
         run: |
-          if [ "${{ needs.build-debug.result }}" != "success" ] || [ "${{ needs.build-release.result }}" != "success" ]; then
-            echo "::error::build lane failed — build-debug=${{ needs.build-debug.result }} build-release=${{ needs.build-release.result }}"
+          if [ "${{ needs.build-debug.result }}" != "success" ] \
+             || [ "${{ needs.build-release.result }}" != "success" ] \
+             || [ "${{ needs.worker-tests.result }}" != "success" ]; then
+            echo "::error::lane failed — build-debug=${{ needs.build-debug.result }} build-release=${{ needs.build-release.result }} worker-tests=${{ needs.worker-tests.result }}"
             exit 1
           fi
-          echo "==> Both build lanes passed."
+          echo "==> Both build lanes and the worker unit suites passed."
 
       - name: Report build status
         run: |

--- a/workers/daily-report/README.md
+++ b/workers/daily-report/README.md
@@ -250,3 +250,17 @@ enviouswispr-daily-report` removes the worker entirely. Revert the PR to
 remove the code. A bad metric definition is a source-level fix + redeploy —
 no data migration involved, this worker is stateless (reads PostHog,
 writes only to Discord).
+
+## Shared infrastructure (#1589)
+
+The PostHog transport and Discord delivery this worker uses now live in
+`workers/shared/`, because `workers/weekly-digest` became a second consumer.
+This worker's behaviour is unchanged: the same retry policy, the same
+concurrency cap, the same `daily_report_*` query names.
+
+**Deploy consequence.** Each worker bundles its own snapshot at deploy time, so
+a change under `workers/shared/` is live only in the workers redeployed since.
+When a change touches that directory, deploy **weekly-digest first** and this
+worker second: a broken shared change then lands on the worker already being
+modified rather than on this one, which is the higher-value report and the one
+that should not have changed at all. Full rule: `workers/shared/README.md`.

--- a/workers/daily-report/src/adoption.js
+++ b/workers/daily-report/src/adoption.js
@@ -22,7 +22,7 @@ import {
   rowsToObjects,
   sqlIdList,
   sqlTimestamp,
-} from "./lib/posthog.js";
+} from "../../shared/posthog.js";
 
 // Shipped app defaults (SettingsDefaultValues.swift) - the tier-of-last-resort
 // when a user has neither a settings record nor any dictation carrying a

--- a/workers/daily-report/src/index.js
+++ b/workers/daily-report/src/index.js
@@ -29,8 +29,8 @@
  * trigger secret.
  */
 
-import { productionClauseFor, resolveDevIds, runLimited, windowClause } from "./lib/posthog.js";
-import { deliverReport } from "./lib/discord.js";
+import { productionClauseFor, resolveDevIds, runLimited, windowClause } from "../../shared/posthog.js";
+import { deliverReport } from "../../shared/discord.js";
 import { createAdoptionSection } from "./adoption.js";
 import {
   ScorecardSectionError,
@@ -461,7 +461,10 @@ async function postFailureNotice(env, dateStr) {
 // empty; `deps.hogqlOpts` and `deps.releaseOpts` drive retry paths without
 // sitting through real backoff delays.
 export async function runReport(env, dateOverride = null, deps = {}) {
-  const hogqlOpts = deps.hogqlOpts || {};
+  // workerLabel is REQUIRED by the shared transport and is set exactly once
+  // here, then forwarded verbatim to every call site. The spread keeps a test
+  // seam able to inject fetch/sleep/random without having to know about it.
+  const hogqlOpts = { ...(deps.hogqlOpts || {}), workerLabel: "daily_report" };
   const releaseOpts = deps.releaseOpts || {};
 
   // ---- Shared preflight. Anything failing here is fatal to BOTH sections:

--- a/workers/daily-report/src/version-scorecard.js
+++ b/workers/daily-report/src/version-scorecard.js
@@ -25,7 +25,7 @@
  * returns a GitHub response body.
  */
 
-import { hogql, rowsToObjects } from "./lib/posthog.js";
+import { hogql, rowsToObjects } from "../../shared/posthog.js";
 
 /** Distinguishes an exhausted TRANSIENT failure - which the scorecard section
  * may degrade on while adoption still renders - from a contract failure

--- a/workers/daily-report/test/report.test.js
+++ b/workers/daily-report/test/report.test.js
@@ -738,7 +738,7 @@ test("resolveDevIds: accepts hogqlOpts so its own retry path is test-determinist
   let calls = 0;
   const fetchFn = async () => {
     calls += 1;
-    return calls === 1 ? fakeResponse(504) : fakeResponse(200, { results: [["dev-1"]] });
+    return calls === 1 ? fakeResponse(504) : fakeResponse(200, { results: [["dev-1"]], columns: ["distinct_id"] });
   };
   const devIds = await resolveDevIds({ POSTHOG_PROJECT_ID: "x", POSTHOG_PERSONAL_API_KEY: "k" }, {
     fetchFn,
@@ -753,7 +753,7 @@ test("resolveDevIds: throws on overflow rather than silently building a truncate
   // LIMIT+1 query shape - the fetchFn doesn't need to know the real limit,
   // it just needs to return more than 5000 rows.
   const overflowRows = Array.from({ length: 5001 }, (_, i) => [`dev-${i}`]);
-  const fetchFn = async () => fakeResponse(200, { results: overflowRows });
+  const fetchFn = async () => fakeResponse(200, { results: overflowRows, columns: ["distinct_id"] });
   await assert.rejects(
     () => resolveDevIds({ POSTHOG_PROJECT_ID: "x", POSTHOG_PERSONAL_API_KEY: "k" }, { fetchFn }),
     /dev-id completeness check failed/,
@@ -762,7 +762,9 @@ test("resolveDevIds: throws on overflow rather than silently building a truncate
 });
 
 test("resolveDevIds: an empty result is a valid, non-throwing state", async () => {
-  const fetchFn = async () => fakeResponse(200, { results: [] });
+  // With its columns intact: zero dev ids is legitimate, a missing column set
+  // is a malformed response (#1589).
+  const fetchFn = async () => fakeResponse(200, { results: [], columns: ["distinct_id"] });
   const devIds = await resolveDevIds({ POSTHOG_PROJECT_ID: "x", POSTHOG_PERSONAL_API_KEY: "k" }, { fetchFn });
   assert.deepEqual(devIds, []);
 });
@@ -866,7 +868,10 @@ function mockPostHog({ failQuery, failWith, github, discordStatus, onDiscord } =
     // dev_ids: empty list is the common, valid case - keeps every downstream
     // query's ${prod} predicate as plain ENV_ONLY in these tests.
     if (queryName === "dev_ids") {
-      return fakeResponse(200, { results: [] });
+      // `columns` is REQUIRED: a real PostHog response always carries it, and
+      // resolveDevIds checks it because zero rows is a legitimate state and a
+      // row-level check cannot fire on an empty result (#1589).
+      return fakeResponse(200, { results: [], columns: ["distinct_id"] });
     }
     // totals' total_users must match engine_and_tier_b's row count (1, "u1"),
     // or resolveBuckets' completeness check throws on tests that chain all
@@ -2876,7 +2881,7 @@ test("dev IDs resolve ONCE and both sections share that one production predicate
     const body = init?.body ? JSON.parse(init.body) : {};
     if (body.name === "daily_report_dev_ids") {
       devIdCalls += 1;
-      return fakeResponse(200, { results: [["dev-alpha"], ["dev-beta"]] });
+      return fakeResponse(200, { results: [["dev-alpha"], ["dev-beta"]], columns: ["distinct_id"] });
     }
     return inner(url, init);
   };
@@ -3745,7 +3750,7 @@ test("daily-report still labels every query daily_report_*, unchanged by the mov
   const fetchFn = async (_url, init) => {
     const body = JSON.parse(init.body);
     names.push(body.name);
-    return fakeResponse(200, { results: [], columns: [] });
+    return fakeResponse(200, { results: [], columns: ["distinct_id"] });
   };
   await rawResolveDevIds({ POSTHOG_PROJECT_ID: "x", POSTHOG_PERSONAL_API_KEY: "k" },
     { fetchFn, workerLabel: "daily_report" });
@@ -3859,7 +3864,9 @@ test("real ISO 8601 timestamps, with Z or an explicit offset, are accepted", asy
 
 test("resolveDevIds refuses a malformed row instead of excluding 'undefined'", async () => {
   const env = { POSTHOG_PROJECT_ID: "x", POSTHOG_PERSONAL_API_KEY: "k" };
-  for (const body of [{ results: [[]] }, { results: [[null]] }, { results: [[""]] }, { results: [[7]] }]) {
+  const cols = { columns: ["distinct_id"] };
+  for (const body of [{ results: [[]], ...cols }, { results: [[null]], ...cols },
+                      { results: [[""]], ...cols }, { results: [[7]], ...cols }]) {
     await assert.rejects(
       () => resolveDevIds(env, { fetchFn: async () => fakeResponse(200, body) }),
       /malformed row/,
@@ -3868,6 +3875,26 @@ test("resolveDevIds refuses a malformed row instead of excluding 'undefined'", a
   }
   // Two-way control: a genuinely empty list is legitimate and must still pass,
   // because zero dev-tainted ids is a real state.
-  const empty = await resolveDevIds(env, { fetchFn: async () => fakeResponse(200, { results: [] }) });
+  const empty = await resolveDevIds(env, {
+    fetchFn: async () => fakeResponse(200, { results: [], columns: ["distinct_id"] }),
+  });
+  assert.deepEqual(empty, []);
+});
+
+test("resolveDevIds refuses an empty result whose column set is malformed", async () => {
+  // Zero dev ids is legitimate, so every per-row check is skipped exactly when
+  // a malformed empty response arrives. Checked on the COLUMNS instead.
+  const env = { POSTHOG_PROJECT_ID: "x", POSTHOG_PERSONAL_API_KEY: "k" };
+  for (const body of [{ results: [], columns: [] }, { results: [], columns: ["id"] }, { results: [] }]) {
+    await assert.rejects(
+      () => resolveDevIds(env, { fetchFn: async () => fakeResponse(200, body) }),
+      /malformed column set/,
+      `${JSON.stringify(body)} must be refused`
+    );
+  }
+  // Two-way control: a real empty list, correctly shaped, still resolves.
+  const empty = await resolveDevIds(env, {
+    fetchFn: async () => fakeResponse(200, { results: [], columns: ["distinct_id"] }),
+  });
   assert.deepEqual(empty, []);
 });

--- a/workers/daily-report/test/report.test.js
+++ b/workers/daily-report/test/report.test.js
@@ -3828,3 +3828,31 @@ test("an embed field this module cannot count is STILL refused", async () => {
     /unsupported field fields/
   );
 });
+
+test("a date-like string that is not ISO 8601 is refused as a timestamp", async () => {
+  const fetchFn = async () => { throw new Error("must not reach the network"); };
+  // Date.parse accepts all of these; Discord documents ISO 8601, so the shape
+  // is checked before the value.
+  for (const bad of ["1", "Dec 25 2026", "2026-08-01", "2026-08-01T13:00:00", "now"]) {
+    await assert.rejects(
+      () => deliverReport("https://hook", {
+        content: "c",
+        embeds: [{ title: "T", description: "D", timestamp: bad }],
+      }, { fetchFn }),
+      /timestamp must be an ISO 8601 string/,
+      `${bad} must be refused`
+    );
+  }
+});
+
+test("real ISO 8601 timestamps, with Z or an explicit offset, are accepted", async () => {
+  let sent;
+  const fetchFn = async (_u, init) => { sent = JSON.parse(init.body); return { status: 204 }; };
+  for (const good of ["2026-08-01T13:00:00Z", "2026-08-01T13:00:00.123Z", "2026-08-01T13:00:00+05:30"]) {
+    await deliverReport("https://hook", {
+      content: "c",
+      embeds: [{ title: "T", description: "D", timestamp: good }],
+    }, { fetchFn });
+    assert.equal(sent.embeds[0].timestamp, good);
+  }
+});

--- a/workers/daily-report/test/report.test.js
+++ b/workers/daily-report/test/report.test.js
@@ -3856,3 +3856,18 @@ test("real ISO 8601 timestamps, with Z or an explicit offset, are accepted", asy
     assert.equal(sent.embeds[0].timestamp, good);
   }
 });
+
+test("resolveDevIds refuses a malformed row instead of excluding 'undefined'", async () => {
+  const env = { POSTHOG_PROJECT_ID: "x", POSTHOG_PERSONAL_API_KEY: "k" };
+  for (const body of [{ results: [[]] }, { results: [[null]] }, { results: [[""]] }, { results: [[7]] }]) {
+    await assert.rejects(
+      () => resolveDevIds(env, { fetchFn: async () => fakeResponse(200, body) }),
+      /malformed row/,
+      `${JSON.stringify(body)} must be refused`
+    );
+  }
+  // Two-way control: a genuinely empty list is legitimate and must still pass,
+  // because zero dev-tainted ids is a real state.
+  const empty = await resolveDevIds(env, { fetchFn: async () => fakeResponse(200, { results: [] }) });
+  assert.deepEqual(empty, []);
+});

--- a/workers/daily-report/test/report.test.js
+++ b/workers/daily-report/test/report.test.js
@@ -12,8 +12,8 @@ import worker, {
 } from "../src/index.js";
 // #1838 chunk 2: the adoption domain has its own owner. Tests import from it
 // directly - a re-export from index.js would be a forwarding shim.
-import { createAdoptionSection, resolveBuckets } from "../src/adoption.js";
-import { DISCORD_LIMITS, DiscordPayloadError, deliverReport } from "../src/lib/discord.js";
+import { createAdoptionSection as rawCreateAdoptionSection, resolveBuckets } from "../src/adoption.js";
+import { DISCORD_LIMITS, DiscordPayloadError, deliverReport } from "../../shared/discord.js";
 import {
   normalizeReleaseVersion,
   compareVersions,
@@ -31,7 +31,7 @@ import {
   METRIC_CALCULATIONS,
   WINDOW_COUNT,
   rankMovers,
-  createScorecardSection,
+  createScorecardSection as rawCreateScorecardSection,
   isScorecardEligible,
   ScorecardSectionError,
   releaseAgeInWindow,
@@ -42,17 +42,42 @@ import { formatScorecard, formatScorecardUnavailable } from "../src/report-forma
 // re-export from index.js would be a forwarding shim kept alive solely for
 // tests, which this REFACTOR-tier change forbids.
 import {
-  hogql,
+  hogql as rawHogql,
   runLimited,
-  resolveDevIds,
+  resolveDevIds as rawResolveDevIds,
   productionClauseFor,
-  querySection,
+  querySection as rawQuerySection,
   rowsToObjects,
   sqlIdList,
   sqlTimestamp,
   windowClause,
   PostHogQueryError,
-} from "../src/lib/posthog.js";
+} from "../../shared/posthog.js";
+
+// #1589: the shared transport REQUIRES `workerLabel`, deliberately with no
+// default - a default would file this worker's queries under another worker's
+// name in PostHog's query log, which reads as correct everywhere it is seen.
+// Production sets it once in runReport and forwards the bag; these wrappers do
+// the same one thing for tests that call the transport directly, so ~20 call
+// sites do not each restate it and a new one cannot silently forget it.
+//
+// The raw imports above stay reachable so the "label is required" tests can
+// call the unwrapped functions - a wrapper that always supplies the label could
+// never prove the requirement exists.
+const WORKER_LABEL = "daily_report";
+const withLabel = (opts = {}) => ({ ...opts, workerLabel: WORKER_LABEL });
+const hogql = (env, sql, name, opts = {}) => rawHogql(env, sql, name, withLabel(opts));
+const querySection = (env, sql, name, opts = {}) => rawQuerySection(env, sql, name, withLabel(opts));
+const resolveDevIds = (env, opts = {}) => rawResolveDevIds(env, withLabel(opts));
+
+// Section factories take the bag as `opts.hogqlOpts`, so they need the same
+// one-place treatment: production supplies the label in runReport, and a test
+// driving a section directly must not have to remember it.
+const sectionOptsWithLabel = (opts = {}) => ({ ...opts, hogqlOpts: withLabel(opts.hogqlOpts) });
+const createAdoptionSection = (env, ctx, opts = {}) =>
+  rawCreateAdoptionSection(env, ctx, sectionOptsWithLabel(opts));
+const createScorecardSection = (env, ctx, opts = {}) =>
+  rawCreateScorecardSection(env, ctx, sectionOptsWithLabel(opts));
 
 // ---- easternYesterdayWindowUTC ----
 
@@ -3660,4 +3685,146 @@ test("a release published after the reported window is never crowned newest", as
   await assert.rejects(
     () => resolveReleases(env, usageRows, { ...opts, windowEndExclusive: "July 29" }),
     /requires opts.windowEndExclusive/);
+});
+
+// ---- #1589: shared-transport worker label ------------------------------------
+// These call the RAW imports deliberately. The wrapped helpers at the top of
+// this file always supply a label, so they could never prove the requirement
+// exists - a guard nothing can trip is not a guard.
+
+test("shared hogql: a missing workerLabel throws BEFORE any request is made", async () => {
+  let calls = 0;
+  const fetchFn = async () => { calls += 1; return fakeResponse(200, { results: [] }); };
+  await assert.rejects(
+    () => rawHogql({ POSTHOG_PROJECT_ID: "x", POSTHOG_PERSONAL_API_KEY: "k" }, "SELECT 1", "q", { fetchFn }),
+    /requires a non-empty workerLabel/
+  );
+  // The point of failing loud is failing EARLY: an unlabelled query must never
+  // reach PostHog, or it lands in the query log under no worker at all.
+  assert.equal(calls, 0, "no request may be made without a label");
+});
+
+test("shared hogql: a non-string or empty workerLabel is refused, not coerced", async () => {
+  const env = { POSTHOG_PROJECT_ID: "x", POSTHOG_PERSONAL_API_KEY: "k" };
+  const fetchFn = async () => fakeResponse(200, { results: [] });
+  for (const bad of [null, 42, "", {}, ["daily_report"]]) {
+    await assert.rejects(
+      () => rawHogql(env, "SELECT 1", "q", { fetchFn, workerLabel: bad }),
+      /requires a non-empty workerLabel/,
+      `workerLabel ${JSON.stringify(bad)} must be refused`
+    );
+  }
+});
+
+test("shared hogql: the query name PostHog sees is <workerLabel>_<queryName>", async () => {
+  const seen = [];
+  const fetchFn = async (_url, init) => {
+    seen.push(JSON.parse(init.body).name);
+    return fakeResponse(200, { results: [] });
+  };
+  const env = { POSTHOG_PROJECT_ID: "x", POSTHOG_PERSONAL_API_KEY: "k" };
+  await rawHogql(env, "SELECT 1", "totals", { fetchFn, workerLabel: "daily_report" });
+  await rawHogql(env, "SELECT 1", "totals", { fetchFn, workerLabel: "weekly_digest" });
+  // Two-way control: the SAME queryName must produce two DIFFERENT logged names,
+  // which is the whole reason the label is required rather than defaulted.
+  assert.deepEqual(seen, ["daily_report_totals", "weekly_digest_totals"]);
+});
+
+test("shared querySection: requires the label too, and refuses before requesting", async () => {
+  let calls = 0;
+  const fetchFn = async () => { calls += 1; return fakeResponse(503, null); };
+  await assert.rejects(
+    () => rawQuerySection({ POSTHOG_PROJECT_ID: "x", POSTHOG_PERSONAL_API_KEY: "k" }, "SELECT 1", "geo", { fetchFn }),
+    /requires a non-empty workerLabel/
+  );
+  assert.equal(calls, 0);
+});
+
+test("daily-report still labels every query daily_report_*, unchanged by the move", async () => {
+  const names = [];
+  const fetchFn = async (_url, init) => {
+    const body = JSON.parse(init.body);
+    names.push(body.name);
+    return fakeResponse(200, { results: [], columns: [] });
+  };
+  await rawResolveDevIds({ POSTHOG_PROJECT_ID: "x", POSTHOG_PERSONAL_API_KEY: "k" },
+    { fetchFn, workerLabel: "daily_report" });
+  assert.deepEqual(names, ["daily_report_dev_ids"]);
+});
+
+// ---- #1589: shared Discord module owns the PROTOCOL, not one worker's layout --
+
+test("deliverReport accepts color, footer and timestamp — Discord permits them", async () => {
+  let sent;
+  const fetchFn = async (_url, init) => { sent = JSON.parse(init.body); return { status: 204 }; };
+  await deliverReport("https://hook", {
+    content: "EnviousWispr Weekly Digest",
+    embeds: [{
+      title: "App usage",
+      description: "189 people used the app.",
+      color: 0x7c3aed,
+      footer: { text: "EnviousWispr Weekly Digest" },
+      timestamp: "2026-08-01T13:00:00.000Z",
+    }],
+  }, { fetchFn });
+  // Before #1589 this payload was REFUSED, which forced the weekly digest to
+  // drop its brand colour to reuse this transport. That was one worker's layout
+  // choice enforced as if it were a protocol limit.
+  assert.equal(sent.embeds[0].color, 0x7c3aed);
+  assert.equal(sent.embeds[0].footer.text, "EnviousWispr Weekly Digest");
+  assert.equal(sent.embeds[0].timestamp, "2026-08-01T13:00:00.000Z");
+});
+
+test("footer text counts toward the 6000-character budget, like Discord counts it", async () => {
+  const fetchFn = async () => { throw new Error("must not reach the network"); };
+  const long = "x".repeat(3000);
+  // Title+description alone are under budget; adding footer text pushes the
+  // total over. If footer text were permitted but uncounted, this would send.
+  await assert.rejects(
+    () => deliverReport("https://hook", {
+      content: "c",
+      embeds: [
+        { title: "A", description: long },
+        { title: "B", description: long, footer: { text: "y".repeat(500) } },
+      ],
+    }, { fetchFn }),
+    /exceeds the 6000 limit/
+  );
+});
+
+test("a permitted-looking but malformed color, timestamp or footer is refused", async () => {
+  const fetchFn = async () => { throw new Error("must not reach the network"); };
+  const base = { title: "T", description: "D" };
+  const bad = [
+    { ...base, color: -1 },
+    { ...base, color: 0x1000000 },
+    { ...base, color: 1.5 },
+    { ...base, color: "purple" },
+    { ...base, timestamp: "not a date" },
+    { ...base, timestamp: 1754049600000 },
+    { ...base, footer: "EnviousWispr" },
+    { ...base, footer: { text: "ok", icon_url: "https://x" } },
+    { ...base, footer: {} },
+  ];
+  for (const embed of bad) {
+    await assert.rejects(
+      () => deliverReport("https://hook", { content: "c", embeds: [embed] }, { fetchFn }),
+      DiscordPayloadError,
+      `${JSON.stringify(embed)} must be refused`
+    );
+  }
+});
+
+test("an embed field this module cannot count is STILL refused", async () => {
+  const fetchFn = async () => { throw new Error("must not reach the network"); };
+  // The allowlist widened; it did not become a passthrough. `fields` carries
+  // countable text this module does not know how to count, so permitting it
+  // would silently break the combined-text arithmetic.
+  await assert.rejects(
+    () => deliverReport("https://hook", {
+      content: "c",
+      embeds: [{ title: "T", description: "D", fields: [{ name: "n", value: "v" }] }],
+    }, { fetchFn }),
+    /unsupported field fields/
+  );
 });

--- a/workers/shared/README.md
+++ b/workers/shared/README.md
@@ -1,0 +1,71 @@
+# workers/shared
+
+Infrastructure shared by more than one Cloudflare Worker in this repo.
+
+## Consumers
+
+- `workers/daily-report`
+- `workers/weekly-digest`
+
+Keep that list accurate. It is the deploy checklist.
+
+## THE RULE THAT BITES: editing a file here changes nothing in production
+
+Each worker is bundled separately at `wrangler deploy` time and carries its own
+snapshot of this code. So:
+
+- **A merged PR deploys nothing.** No CI workflow runs `wrangler deploy`.
+- **A change here is live only in the workers you have redeployed since.** Until
+  then production is running two different versions of the "same" module, and
+  nothing anywhere reports that.
+- **`git revert` does not roll back production.** It changes the repo. Rolling
+  back means reverting *and* redeploying every consumer.
+
+After changing anything in this directory:
+
+```bash
+cd workers/weekly-digest && npx wrangler deploy    # deploy the CHANGED consumer first
+cd ../daily-report      && npx wrangler deploy     # then the one that should not change
+```
+
+Deploy the worker whose behaviour is meant to change **first**. If the shared
+change is broken, the failure lands on the worker that was already being
+modified, and the healthy one is never touched. Credentials wrapper and the
+`curl -fsS` verification step: `workers/daily-report/README.md` § Deploy.
+
+## What belongs here
+
+Transport and protocol only:
+
+- `posthog.js` — HTTP transport, retry policy, the concurrency limiter, dev-ID
+  resolution, the production predicate, SQL literal escaping, row conversion.
+- `discord.js` — Discord's transport limits and the supported subset of its
+  payload protocol, plus one-attempt delivery.
+
+## What must NOT come here
+
+Metric SQL, report windows, section failure policy, degrade wording, and
+anything a reader would recognise as a product judgement. Those belong to the
+worker that owns the report.
+
+Two specific traps, both learned the hard way:
+
+1. **Do not let one consumer's layout become everyone's protocol.** `discord.js`
+   originally allowed only `title` and `description` because that was the daily
+   report's chosen shape. Discord permits `color`, `footer` and `timestamp`, so
+   refusing them was never a protocol limit — it just meant the weekly digest
+   would have had to drop its brand colour to reuse the transport (#1589).
+   A field is refused here only when this module cannot count it against
+   Discord's 6000-character budget.
+2. **Do not add a default that hides which worker did something.** `workerLabel`
+   is required with no fallback for exactly this reason: a default would file
+   one worker's PostHog queries under another's name, which reads as correct in
+   every place a human would look.
+
+## Tests
+
+There is no test package here. The shared modules are exercised by
+`workers/daily-report/test/report.test.js`, which is where they were tested
+before the extraction, and by `workers/weekly-digest/test/digest.test.js`.
+Both suites run in CI via the `worker-tests` job feeding the required
+`build-check`, so a change here that breaks either consumer blocks the PR.

--- a/workers/shared/discord.js
+++ b/workers/shared/discord.js
@@ -1,8 +1,17 @@
 /**
- * Discord delivery for the daily report (issue #1838 chunk 6).
+ * Discord delivery, shared by every worker that posts a report (issues #1838,
+ * #1589).
  *
- * Infrastructure only. It knows Discord's transport limits and nothing about
- * adoption, releases or metrics.
+ * CONSUMERS: workers/daily-report, workers/weekly-digest.
+ *
+ * DEPLOY RULE: each worker bundles its own copy at deploy time, so editing this
+ * file changes nothing in production until EVERY consumer is redeployed. See
+ * workers/shared/README.md.
+ *
+ * Infrastructure only. It owns Discord's transport limits and the SUPPORTED
+ * SUBSET of its payload protocol, and knows nothing about adoption, releases,
+ * digests or metrics. It must never refuse a field Discord accepts merely
+ * because one consumer does not use it (#1589).
  *
  * ONE function validates and sends the SAME object, deliberately. A separate
  * `validate()` returning a boolean would let a caller check one payload and
@@ -40,16 +49,34 @@ export const DISCORD_LIMITS = Object.freeze({
   content: 2000,
   embedTitle: 256,
   embedDescription: 4096,
+  embedFooterText: 2048,
   embeds: 10,
   combinedText: 6000,
 });
 
-/** Embeds may carry only these two textual fields. Any other own key is
- * refused rather than passed through: `combinedText` must count every textual
- * field ACTUALLY SENT, and a field this module does not know about is a field
- * it cannot count. Refusing is the only way that arithmetic stays true. */
-const ALLOWED_EMBED_FIELDS = new Set(["title", "description"]);
+/** The SUPPORTED SUBSET of Discord's embed fields. Not all of them: this module
+ * does not implement `fields`, `author`, `image`, or `thumbnail`, and does not
+ * claim to.
+ *
+ * Any own key outside this set is refused rather than passed through, because
+ * `combinedText` must count every TEXTUAL field actually sent, and a field this
+ * module does not know about is a field it cannot count. Refusing is the only
+ * way that arithmetic stays true.
+ *
+ * WHY THIS SET IS NOT JUST {title, description} (#1589): it was, and that made
+ * the shared validator impose the daily report's LAYOUT CHOICE on every other
+ * worker. Discord permits `color`, `footer` and `timestamp`; refusing them was
+ * never a protocol limit, and it would have forced the weekly digest to drop its
+ * brand colour to reuse this transport. A shared module owns the protocol, not
+ * the presentation. Adding a field here means teaching `embedTextLength` to
+ * count it, or proving it costs nothing against the budget. */
+const ALLOWED_EMBED_FIELDS = new Set(["title", "description", "color", "footer", "timestamp"]);
 const ALLOWED_PAYLOAD_FIELDS = new Set(["content", "embeds"]);
+
+/** Fields Discord counts toward the 6000-character combined budget: embed
+ * titles, descriptions, field names/values, footer text, and author name. Colour
+ * and timestamp are NOT text and cost nothing against it. */
+const ALLOWED_FOOTER_FIELDS = new Set(["text"]);
 
 /** THE RULE THIS FILE EXISTS TO ENFORCE: validation must observe exactly what
  * `JSON.stringify` will observe.
@@ -181,6 +208,35 @@ function assertDeliverable(payload) {
     const title = ownString(embed, "title", `embed ${i}`, DISCORD_LIMITS.embedTitle);
     const description = ownString(embed, "description", `embed ${i}`, DISCORD_LIMITS.embedDescription);
     combined += title.length + description.length;
+
+    // Optional fields. Each is read EXACTLY ONCE through the same own-data-
+    // property discipline as the required ones, so a getter cannot answer one
+    // value here and another to JSON.stringify.
+    if (Object.hasOwn(embed, "color")) {
+      const color = ownDataValue(embed, "color", `embed ${i}`);
+      // Discord rejects a non-integer or out-of-range colour outright, so this
+      // refuses before the request rather than after.
+      if (!Number.isInteger(color) || color < 0 || color > 0xffffff) {
+        throw new DiscordPayloadError(`embed ${i}: color must be an integer between 0 and 16777215`);
+      }
+    }
+    if (Object.hasOwn(embed, "timestamp")) {
+      const timestamp = ownDataValue(embed, "timestamp", `embed ${i}`);
+      if (typeof timestamp !== "string" || Number.isNaN(Date.parse(timestamp))) {
+        throw new DiscordPayloadError(`embed ${i}: timestamp must be an ISO 8601 string`);
+      }
+    }
+    if (Object.hasOwn(embed, "footer")) {
+      const footer = ownDataValue(embed, "footer", `embed ${i}`);
+      if (!isPlainObject(footer)) {
+        throw new DiscordPayloadError(`embed ${i}: footer must be a plain object`);
+      }
+      assertAllowedOwnFields(footer, ALLOWED_FOOTER_FIELDS, `embed ${i}: footer`);
+      // Counted, because Discord counts it. This is the whole reason the
+      // allowlist exists: a permitted textual field that went uncounted would
+      // silently break the 6000-character arithmetic.
+      combined += ownString(footer, "text", `embed ${i}: footer`, DISCORD_LIMITS.embedFooterText).length;
+    }
   }
 
   if (combined > DISCORD_LIMITS.combinedText) {

--- a/workers/shared/discord.js
+++ b/workers/shared/discord.js
@@ -78,6 +78,11 @@ const ALLOWED_PAYLOAD_FIELDS = new Set(["content", "embeds"]);
  * and timestamp are NOT text and cost nothing against it. */
 const ALLOWED_FOOTER_FIELDS = new Set(["text"]);
 
+/** ISO 8601 with a required date and time, and either `Z` or an explicit
+ * offset. Discord documents `timestamp` as ISO 8601; anything else is a payload
+ * it may reject, so it is refused here rather than sent. */
+const ISO_8601 = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$/;
+
 /** THE RULE THIS FILE EXISTS TO ENFORCE: validation must observe exactly what
  * `JSON.stringify` will observe.
  *
@@ -222,7 +227,15 @@ function assertDeliverable(payload) {
     }
     if (Object.hasOwn(embed, "timestamp")) {
       const timestamp = ownDataValue(embed, "timestamp", `embed ${i}`);
-      if (typeof timestamp !== "string" || Number.isNaN(Date.parse(timestamp))) {
+      // `Date.parse` alone is far too permissive to be a format check: it
+      // accepts "1" (as the year 2001), "Dec 25", and other shapes Discord
+      // rejects. Discord wants ISO 8601, so the SHAPE is checked first and
+      // Date.parse only then confirms the values are a real instant.
+      if (
+        typeof timestamp !== "string" ||
+        !ISO_8601.test(timestamp) ||
+        Number.isNaN(Date.parse(timestamp))
+      ) {
         throw new DiscordPayloadError(`embed ${i}: timestamp must be an ISO 8601 string`);
       }
     }

--- a/workers/shared/package.json
+++ b/workers/shared/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/workers/shared/posthog.js
+++ b/workers/shared/posthog.js
@@ -127,11 +127,17 @@ export async function resolveDevIds(env, hogqlOpts = {}) {
   // otherwise read as "no dev accounts", both reports would fall back to the
   // environment filter alone, and they would include dev machines while
   // printing that dev machines are excluded.
-  if (!Array.isArray(result.columns) || !result.columns.includes("distinct_id")) {
+  // Read by NAME, at whatever position PostHog returned it. Checking that the
+  // name is present and then reading row[0] anyway passes validation while
+  // pulling a different column - the predicate would exclude the wrong ids and
+  // silently include dev machines, which is the failure this whole check exists
+  // to prevent, reached through the check itself.
+  const idIndex = Array.isArray(result.columns) ? result.columns.indexOf("distinct_id") : -1;
+  if (idIndex === -1) {
     throw new Error("dev-id resolution returned a malformed column set");
   }
   const rows = result.results || [];
-  const devIds = rows.map((row) => row?.[0]);
+  const devIds = rows.map((row) => row?.[idIndex]);
   // A 200 whose rows are the wrong shape (`results: [[]]`) yields `undefined`,
   // which sqlIdList happily renders as the literal string 'undefined'. The
   // query then excludes a distinct_id nobody has and INCLUDES every real dev

--- a/workers/shared/posthog.js
+++ b/workers/shared/posthog.js
@@ -121,6 +121,15 @@ export async function resolveDevIds(env, hogqlOpts = {}) {
     "dev_ids",
     hogqlOpts
   );
+  // Checked on the COLUMNS, not the rows, because zero dev-tainted ids is a
+  // legitimate state and any per-row check is therefore skipped exactly when
+  // the response is empty. `{ results: [], columns: [] }` from a 200 would
+  // otherwise read as "no dev accounts", both reports would fall back to the
+  // environment filter alone, and they would include dev machines while
+  // printing that dev machines are excluded.
+  if (!Array.isArray(result.columns) || !result.columns.includes("distinct_id")) {
+    throw new Error("dev-id resolution returned a malformed column set");
+  }
   const rows = result.results || [];
   const devIds = rows.map((row) => row?.[0]);
   // A 200 whose rows are the wrong shape (`results: [[]]`) yields `undefined`,

--- a/workers/shared/posthog.js
+++ b/workers/shared/posthog.js
@@ -121,7 +121,19 @@ export async function resolveDevIds(env, hogqlOpts = {}) {
     "dev_ids",
     hogqlOpts
   );
-  const devIds = (result.results || []).map((row) => row[0]);
+  const rows = result.results || [];
+  const devIds = rows.map((row) => row?.[0]);
+  // A 200 whose rows are the wrong shape (`results: [[]]`) yields `undefined`,
+  // which sqlIdList happily renders as the literal string 'undefined'. The
+  // query then excludes a distinct_id nobody has and INCLUDES every real dev
+  // machine, while the report goes on claiming they were excluded. That is
+  // worse than failing: the number is wrong AND its caveat is a lie.
+  //
+  // Fails loud, so each consumer applies its own contract: the daily report
+  // treats it as fatal to the whole run, the weekly digest as app-usage-only.
+  if (devIds.some((id) => typeof id !== "string" || id.length === 0)) {
+    throw new Error("dev-id resolution returned a malformed row");
+  }
   if (devIds.length > PER_USER_LIST_LIMIT) {
     throw new Error(`dev-id completeness check failed: more than ${PER_USER_LIST_LIMIT} ids`);
   }

--- a/workers/shared/posthog.js
+++ b/workers/shared/posthog.js
@@ -1,19 +1,29 @@
 /**
- * PostHog transport + production-filter infrastructure for the daily report
- * (issue #1838 chunk 1).
+ * PostHog transport + production-filter infrastructure, shared by every worker
+ * that queries PostHog (issues #1838, #1589).
  *
- * Extracted from `../index.js`, where it was duplicated function-for-function
- * with the since-retired product-health worker and hand-ported between the two
- * (#1720 -> #1775). That hand-porting demonstrably did not converge: the same
- * fix is still unported to `workers/weekly-digest`. This module is the single
- * owner for the daily report, and is deliberately NOT promoted to a
- * repo-global `workers/shared/`: after that retirement the daily report is its
- * only consumer, and a shared module with one consumer is indirection, not
- * reuse (plan §3b).
+ * HISTORY, because it explains why this file moved rather than being copied a
+ * fifth time. It began inside `daily-report/src/index.js`, duplicated
+ * function-for-function with the since-retired product-health worker and
+ * hand-ported between the two (#1720 -> #1775). It then lived at
+ * `daily-report/src/lib/posthog.js` with a header arguing AGAINST promoting it
+ * here, on the stated ground that "after that retirement the daily report is
+ * its only consumer, and a shared module with one consumer is indirection, not
+ * reuse." That precondition no longer holds: `workers/weekly-digest` is now a
+ * real second consumer (#1589), and the same header recorded that hand-porting
+ * "demonstrably did not converge." Two consumers, one owner.
+ *
+ * CONSUMERS: workers/daily-report, workers/weekly-digest.
+ *
+ * DEPLOY RULE: Cloudflare bundles each worker separately, so editing this file
+ * changes NOTHING in production until EVERY consumer above is redeployed
+ * (`npx wrangler deploy` from each worker directory). A merged PR does not
+ * deploy; a `git revert` does not roll back. See workers/shared/README.md.
  *
  * Infrastructure ONLY - transport, retry, concurrency, dev-ID resolution, the
- * production predicate, SQL literal escaping, and row conversion. Metric SQL
- * and every product judgement stay in their owning module.
+ * production predicate, SQL literal escaping, and row conversion. Metric SQL,
+ * report windows, section failure policy and every product judgement stay in
+ * the owning worker.
  *
  * Privacy: this module logs query NAMES and HTTP statuses only. Never a
  * response body, never a distinct_id, never the API key.
@@ -118,12 +128,27 @@ export async function resolveDevIds(env, hogqlOpts = {}) {
   return devIds;
 }
 
+/** Identifies the calling worker in PostHog's query log and in Cloudflare logs.
+ *
+ * REQUIRED, never defaulted. A default of "daily_report" would file another
+ * worker's queries under the daily report's name - an answer that looks right
+ * everywhere it is read, which is worse than a crash. Both consumers set it
+ * once at the top of their run and forward the same options bag verbatim to
+ * every call site. */
+function requireWorkerLabel(workerLabel) {
+  if (typeof workerLabel !== "string" || workerLabel.length === 0) {
+    throw new TypeError("hogql requires a non-empty workerLabel");
+  }
+  return workerLabel;
+}
+
 export async function hogql(
   env,
   sql,
   queryName,
-  { fetchFn = fetch, sleepFn = sleep, randomFn = Math.random } = {}
+  { fetchFn = fetch, sleepFn = sleep, randomFn = Math.random, workerLabel } = {}
 ) {
+  const label = requireWorkerLabel(workerLabel);
   const url = `${POSTHOG_HOST}/api/projects/${env.POSTHOG_PROJECT_ID}/query/`;
   const maxAttempts = RETRY_DELAY_RANGES_MS.length + 1;
 
@@ -137,7 +162,7 @@ export async function hogql(
       body: JSON.stringify({
         query: { kind: "HogQLQuery", query: sql },
         refresh: "blocking",
-        name: `daily_report_${queryName}`,
+        name: `${label}_${queryName}`,
       }),
     });
 
@@ -232,6 +257,7 @@ export async function runLimited(tasks, limit) {
  * report-wide by #1720). `totals` deliberately does NOT go through this helper;
  * it stays fail-loud, see its call site in fetchReportData. */
 export async function querySection(env, sql, queryName, hogqlOpts) {
+  const label = requireWorkerLabel(hogqlOpts?.workerLabel);
   try {
     return { response: await hogql(env, sql, queryName, hogqlOpts), degraded: false };
   } catch (err) {
@@ -240,7 +266,7 @@ export async function querySection(env, sql, queryName, hogqlOpts) {
       err.queryName === queryName &&
       RETRYABLE_POSTHOG_STATUSES.has(err.status);
     if (!isExpectedTransientFailure) throw err;
-    console.log(`daily-report ${queryName} degraded after retries: HTTP ${err.status}`);
+    console.log(`${label} ${queryName} degraded after retries: HTTP ${err.status}`);
     return { response: null, degraded: true };
   }
 }

--- a/workers/weekly-digest/README.md
+++ b/workers/weekly-digest/README.md
@@ -1,0 +1,86 @@
+# weekly-digest
+
+Posts one Discord digest every Monday: website traffic, tracked visitor
+activity, downloads, and app usage for the previous seven days.
+
+- Endpoint: `https://enviouswispr-weekly-digest.saurabhav.workers.dev`
+- Schedule: Cloudflare cron `0 13 * * 1` (Monday 13:00 UTC). This worker holds
+  one of the account's five free-plan cron slots (#1092).
+- Source of truth for behaviour: `src/index.js`. Shared transport and delivery:
+  `../shared/`.
+
+## The trigger needs a secret now
+
+The workers.dev URL is public. Until #1589 any request to it posted a real
+digest to Discord. It now fails closed:
+
+```bash
+curl -fsS -H "x-trigger-secret: $SECRET" https://enviouswispr-weekly-digest.saurabhav.workers.dev
+```
+
+An unset `TRIGGER_SECRET` refuses every request, so a half-configured deploy
+cannot be triggered at all. The cron path is unaffected. `-f` is required:
+plain `curl -sS` exits 0 on an HTTP 401 or 500.
+
+## Pre-deploy smoke, which posts nothing
+
+```bash
+~/.claude/bin/get-key launch posthog-personal-api-key POSTHOG_KEY -- \
+  ~/.claude/bin/get-key launch cloudflare-global-api-key CF_KEY -- \
+  node workers/weekly-digest/live-query-smoke.mjs
+```
+
+Runs the real `runDigest` against production with the Discord call intercepted,
+prints per-query timings and the exact message, and **fails loud naming any
+section that degraded**. A smoke check that prints "OK" while a section quietly
+said "temporarily unavailable" is the defect it exists to catch.
+
+## Deploy
+
+Merging deploys nothing. There is no `wrangler deploy` in any workflow.
+
+```bash
+cd workers/weekly-digest
+CLOUDFLARE_EMAIL=saurabhav@gmail.com \
+  ~/.claude/bin/get-key launch cloudflare-global-api-key CLOUDFLARE_API_KEY -- \
+  ~/.claude/bin/get-key launch cloudflare-account-id CLOUDFLARE_ACCOUNT_ID -- \
+  npx wrangler deploy
+```
+
+**If the change touched `workers/shared/`, deploy this worker FIRST and the
+daily report second.** Each worker bundles its own snapshot, so a broken shared
+change then lands on the worker already being modified rather than on the
+working daily report. Full rule: `workers/shared/README.md`.
+
+Secrets are listed in `wrangler.toml`. Set with `npx wrangler secret put <NAME>`.
+
+## Numbers that changed in #1589, and why
+
+Each was wrong before, so a jump is a correction rather than a trend:
+
+| Number | Was | Now | Cause |
+|---|---|---|---|
+| Active installs | 212 | 179 | summed two weekly Trends buckets over an 8-day window, double-counting anyone in both |
+| Page views / visitors | 214 / 110 | 201 / 105 | counted `app.enviousstaging.com` and localhost dev servers |
+| All-time downloads | truncated | complete | read only GitHub's first page: 30 of 45 releases |
+| Any failure | `?` or `0` | "temporarily unavailable" | a failed Cloudflare call rendered a confident zero |
+
+Figures are from the frozen window 2026-07-25 .. 2026-08-01, each checked
+against an independently written oracle query.
+
+## Things that will bite
+
+- **`properties.<name>`, never a bare name.** Bare event-property names do not
+  resolve in PostHog HogQL. A regex test enforces this.
+- **The production predicate does not belong on website queries.**
+  `productionClauseFor` always begins `properties.environment = 'production'`,
+  and website events carry no environment property, so applying it returns
+  ZERO. Website queries use a `$host` filter instead.
+- **The download queries take neither.** `download_redirect` is emitted
+  server-side with no `$host`; filtering by host silently drops every off-site
+  redirect. Measured, not assumed.
+- **`dev_ids` is an app-usage dependency, not a whole-run gate.** Its failure
+  costs that one section. It is also the slowest query in the run (9.2s in a
+  live smoke) because it scans all history by design.
+- **PostHog project 354235 is shared with EnviousStaging**, which is why the
+  host filter exists at all.

--- a/workers/weekly-digest/README.md
+++ b/workers/weekly-digest/README.md
@@ -84,3 +84,21 @@ against an independently written oracle query.
   live smoke) because it scans all history by design.
 - **PostHog project 354235 is shared with EnviousStaging**, which is why the
   host filter exists at all.
+
+## Known limit: "new or still setting up" is not "new installs"
+
+`is_fresh_install` is not what its name suggests. The app derives it as
+`settings.onboardingState != .completed`
+(`Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift:221`), so it stays
+true on **every launch until setup is finished**. Someone who installs and never
+completes onboarding is flagged again every week they open the app.
+
+Measured 2026-08-01: 21 distinct ids carried the flag on more than one day over
+30 days; the 2026-07-25..08-01 window reported 46 where 43 ids were genuinely
+launching for the first time.
+
+The digest's wording says what the number actually contains. Changing WHICH
+metric is reported is a product decision, not a bug fix, and **the daily report
+counts the same property the same way** (`workers/daily-report/src/adoption.js`,
+printed as "New installs"), so it carries the same overstatement. Fix both or
+neither.

--- a/workers/weekly-digest/README.md
+++ b/workers/weekly-digest/README.md
@@ -18,6 +18,10 @@ digest to Discord. It now fails closed:
 curl -fsS -H "x-trigger-secret: $SECRET" https://enviouswispr-weekly-digest.saurabhav.workers.dev
 ```
 
+**Header only. There is no `?token=` form**, unlike the daily report: a secret
+in a URL survives in browser and shell history, proxies and request logs, and
+leaking it restores the unauthenticated posting this gate closes.
+
 An unset `TRIGGER_SECRET` refuses every request, so a half-configured deploy
 cannot be triggered at all. The cron path is unaffected. `-f` is required:
 plain `curl -sS` exits 0 on an HTTP 401 or 500.
@@ -97,6 +101,10 @@ the daily report's per-day shape:
 New installs: 46.
 40 people finished setting up. Of those, 35 also dictated.
 ```
+
+"Used" means **at least one successful dictation**, not a launch, matching the
+daily report's headline and the founder's definition. Someone who opens the app
+and never dictates is not counted as a user.
 
 `is_fresh_install` is `settings.onboardingState != .completed`
 (`Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift:221`), which is

--- a/workers/weekly-digest/README.md
+++ b/workers/weekly-digest/README.md
@@ -85,20 +85,31 @@ against an independently written oracle query.
 - **PostHog project 354235 is shared with EnviousStaging**, which is why the
   host filter exists at all.
 
-## Known limit: "new or still setting up" is not "new installs"
+## The app-usage funnel, and what "install" means here
 
-`is_fresh_install` is not what its name suggests. The app derives it as
-`settings.onboardingState != .completed`
-(`Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift:221`), so it stays
-true on **every launch until setup is finished**. Someone who installs and never
-completes onboarding is flagged again every week they open the app.
+Founder definition, 2026-08-01: **an install is someone who has begun
+onboarding**, finishing setup is its own step, and **one successful dictation**
+is what counts as really using the app. The section reports all three, matching
+the daily report's per-day shape:
 
-Measured 2026-08-01: 21 distinct ids carried the flag on more than one day over
-30 days; the 2026-07-25..08-01 window reported 46 where 43 ids were genuinely
-launching for the first time.
+```
+179 people used EnviousWispr this week.
+New installs: 46.
+40 people finished setting up. Of those, 35 also dictated.
+```
 
-The digest's wording says what the number actually contains. Changing WHICH
-metric is reported is a product decision, not a bug fix, and **the daily report
-counts the same property the same way** (`workers/daily-report/src/adoption.js`,
-printed as "New installs"), so it carries the same overstatement. Fix both or
-neither.
+`is_fresh_install` is `settings.onboardingState != .completed`
+(`Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift:221`), which is
+why "install" means begun-onboarding rather than first-ever-launch. Two
+consequences worth knowing before reading the number as first launches:
+
+- It stays true on **every launch until setup finishes**, so someone who never
+  completes onboarding counts again in each week they open the app. Measured
+  2026-08-01: 21 ids carried the flag on more than one day across 30 days, and
+  the 2026-07-25..08-01 window showed 46 against 43 ids genuinely launching for
+  the first time.
+- The funnel is what makes that readable. A gap between installs and finished
+  setup is the interesting signal, not noise to be cleaned out of the top line.
+
+The daily report counts the same property the same way, so both reports share
+this definition. Change them together or not at all.

--- a/workers/weekly-digest/live-query-smoke.mjs
+++ b/workers/weekly-digest/live-query-smoke.mjs
@@ -1,0 +1,105 @@
+// Pre-deploy live-query smoke: runs the REAL weekly digest against production
+// PostHog, Cloudflare and GitHub, prints the exact message that would be sent,
+// and posts NOTHING to Discord.
+//
+// Usage (secrets injected by the launcher, never inline):
+//   ~/.claude/bin/get-key launch posthog-personal-api-key POSTHOG_KEY -- \
+//     ~/.claude/bin/get-key launch cloudflare-global-api-key CF_KEY -- \
+//     node workers/weekly-digest/live-query-smoke.mjs
+//
+// Deliberately drives `runDigest` rather than reassembling the digest from
+// parts. A smoke script with its own copy of the orchestration proves only that
+// the copy works, and that exact shape left the daily report's smoke script
+// broken and unnoticed for weeks because nothing exercised it. The Discord call
+// is intercepted, so the ONLY difference from a production run is that the
+// payload is printed instead of delivered.
+//
+// FAILS LOUD when a section degrades. Printing "Smoke OK" while a section
+// quietly said "temporarily unavailable" is the defect this check exists to
+// catch, and it is one the daily report's smoke script actually shipped (#1720).
+
+import { runDigest } from "./src/index.js";
+
+const CAPTURED_WEBHOOK = "https://smoke.invalid/never-posted";
+
+const env = {
+  POSTHOG_PROJECT_ID: "354235",
+  POSTHOG_PERSONAL_API_KEY: process.env.POSTHOG_KEY,
+  CF_ZONE_ID: "b4416a0f0ebd699e96969a331c7ad7ff",
+  CF_EMAIL: process.env.CF_EMAIL || "saurabhav@gmail.com",
+  CF_API_KEY: process.env.CF_KEY,
+  GITHUB_REPO: "saurabhav88/EnviousWispr",
+  GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+  DISCORD_WEBHOOK_URL: CAPTURED_WEBHOOK,
+};
+
+const missing = [
+  ["POSTHOG_KEY", env.POSTHOG_PERSONAL_API_KEY],
+  ["CF_KEY", env.CF_API_KEY],
+].filter(([, value]) => !value).map(([name]) => name);
+if (missing.length) {
+  console.error(`missing ${missing.join(", ")} - see the usage header for the launcher form`);
+  process.exit(1);
+}
+
+const realFetch = globalThis.fetch;
+let captured = null;
+const timings = [];
+
+globalThis.fetch = async (url, init) => {
+  const target = String(url);
+  if (target.startsWith(CAPTURED_WEBHOOK)) {
+    // The one request that must never reach the network.
+    captured = JSON.parse(init.body);
+    return { status: 204 };
+  }
+  const started = Date.now();
+  const res = await realFetch(url, init);
+  const name = target.includes("posthog.com")
+    ? JSON.parse(init.body).name
+    : new URL(target).host;
+  timings.push({ name, ms: Date.now() - started, status: res.status });
+  return res;
+};
+
+let failure = null;
+try {
+  await runDigest(env);
+} catch (err) {
+  // runDigest throws AFTER delivering a partial digest when a section degraded,
+  // so a throw here does not mean nothing was produced.
+  failure = err;
+}
+
+for (const t of timings) {
+  console.log(`  ${String(t.ms).padStart(6)}ms  ${String(t.status).padStart(3)}  ${t.name}`);
+}
+console.log();
+
+if (!captured) {
+  console.error("FAIL: no payload was produced");
+  if (failure) console.error(String(failure.message));
+  process.exit(1);
+}
+
+console.log(captured.content);
+for (const embed of captured.embeds || []) {
+  console.log(`\n--- ${embed.title} ---`);
+  console.log(embed.description);
+}
+console.log();
+
+// A degraded section is a FAILURE of this check, named, not a footnote.
+const degraded = (captured.embeds || [])
+  .filter((e) => e.description.includes("temporarily unavailable"))
+  .map((e) => e.title);
+if (degraded.length) {
+  console.error(`FAIL: section(s) unavailable during the smoke run: ${degraded.join(", ")}`);
+  if (failure) console.error(String(failure.message));
+  process.exit(1);
+}
+if (failure) {
+  console.error(`FAIL: ${failure.message}`);
+  process.exit(1);
+}
+console.log("Smoke OK: every section returned real data, nothing was posted to Discord.");

--- a/workers/weekly-digest/src/index.js
+++ b/workers/weekly-digest/src/index.js
@@ -591,6 +591,27 @@ export async function runDigest(env, deps = {}) {
   }
   const settled = posthogOutcome.value;
 
+  // EVERY VALUE THAT REACHES A FORMATTER, enumerated once so this stops being
+  // found an instance at a time. Whole-diff review raised the same class in
+  // four consecutive rounds because each fix covered only the instance it
+  // named; the cure is the list, not another patch. A new metric adds a row
+  // here, and its validator, in the same edit.
+  //
+  //   site.views, site.visitors            readAggregate, finite numbers
+  //   downloads.intents, .bots_excluded    readAggregate, finite numbers
+  //   usage.active, usage.fresh            readAggregate, finite numbers
+  //   sources[].n                          readGrouped, finite number
+  //   sources[].bucket                     readGrouped, present, string or null
+  //   cf.totalPageViews/.totalRequests/
+  //     .summedDailyUniques                fetchCloudflareStats, num()
+  //   cf.topCountries[][1]                 fetchCloudflareStats, num()
+  //   gh.totalDownloads                    fetchGitHubDownloads, finite number
+  //   gh.latestVersion                     fetchGitHubDownloads, string
+  //   devIds[]                             shared resolveDevIds, non-empty strings
+  //
+  // The rule each of them follows: check the SHAPE, never the magnitude. A zero
+  // is data; a missing field is a broken contract. Every check above has a
+  // two-way control in the test suite proving a genuine zero still reports zero.
   const read = (index, name) => {
     if (index >= settled.length) return null;
     const outcome = settled[index];
@@ -638,13 +659,27 @@ export async function runDigest(env, deps = {}) {
 
   /** The GROUP BY counterpart. Zero rows is a LEGITIMATE empty week here, which
    * is why it does not go through readAggregate - but each row still has to be
-   * the shape the formatter will read. */
+   * the exact shape the formatter will read.
+   *
+   * BOTH columns are checked, and the bucket check is the subtle one. `bucket`
+   * may legitimately be NULL - PostHog returns null for an absent property, and
+   * sourceLabel deliberately renders that as "Other". An OMITTED or RENAMED
+   * column also arrives as undefined and would take the same "Other" branch,
+   * publishing a confident attribution for a query whose shape had changed. So
+   * the check is on PRESENCE plus type, never on truthiness, which cannot tell
+   * "no source recorded" from "the column is gone". */
   const readGrouped = (index, name) => {
     const rows = read(index, name);
     if (rows === null) return null;
-    const malformed = rows.some((r) => typeof r.n !== "number" || !Number.isFinite(r.n));
-    if (malformed) {
-      failures.push(`${name}: non-numeric row count`);
+    const bad = rows.find(
+      (r) =>
+        typeof r.n !== "number" ||
+        !Number.isFinite(r.n) ||
+        !Object.hasOwn(r, "bucket") ||
+        !(typeof r.bucket === "string" || r.bucket === null)
+    );
+    if (bad) {
+      failures.push(`${name}: malformed row shape`);
       return null;
     }
     return rows;

--- a/workers/weekly-digest/src/index.js
+++ b/workers/weekly-digest/src/index.js
@@ -1,53 +1,149 @@
 /**
- * EnviousWispr Weekly Digest — Cloudflare Worker
- * Runs every Monday 9am ET via cron trigger.
- * Pulls stats from Cloudflare Analytics, GitHub Releases, and PostHog,
- * then posts a formatted embed to Discord.
+ * EnviousWispr Weekly Digest - Cloudflare Worker (issues #1243, #1589)
+ *
+ * Runs Monday 13:00 UTC via a Cloudflare cron trigger and posts ONE Discord
+ * message with four sections: all website traffic (Cloudflare), tracked visitor
+ * activity (PostHog), downloads (GitHub + PostHog), and app usage (PostHog).
+ *
+ * ORCHESTRATION OWNERSHIP. This file resolves the report window ONCE, resolves
+ * the dev-ID exclusion ONCE, schedules every outbound query itself under one
+ * concurrency limiter, assembles ONE payload, and decides whether the run was
+ * clean. Transport, retry, limiting and Discord protocol belong to
+ * `workers/shared`; the SQL, the window, the failure policy and every sentence
+ * the founder reads belong here.
+ *
+ * WHAT #1589 FIXED. Four of these were WRONG NUMBERS rather than missing ones,
+ * and a wrong number is worse than an absent one:
+ *   - 5 concurrent PostHog queries against a documented 3-concurrent ceiling,
+ *     with no retry and no HTTP status check at all.
+ *   - Every failure rendered as "?" beside real figures, indistinguishable
+ *     from a quiet week.
+ *   - Active installs summed two Trends buckets over an 8-day window, counting
+ *     anyone present in both twice: 210 reported where 189 was true.
+ *   - Page views and visitors counted a DIFFERENT PRODUCT
+ *     (app.enviousstaging.com) and localhost dev servers.
+ *   - "All-time" downloads read only GitHub's first page: 30 of 45 releases.
+ *   - A Cloudflare failure rendered as a confident 0.
+ *   - The public trigger URL needed no secret and would post to Discord for
+ *     anyone who knew it.
+ *
+ * Privacy: output and logs are counts, labels and durations only. Never a
+ * distinct_id, never a response body, never the API key or trigger secret.
  */
+
+import {
+  productionClauseFor,
+  querySection,
+  resolveDevIds,
+  rowsToObjects,
+  runLimited,
+  windowClause,
+} from "../../shared/posthog.js";
+import { deliverReport } from "../../shared/discord.js";
+
+const WORKER_LABEL = "weekly_digest";
+
+/** PostHog allows only 3 concurrent queries per project (#1588), and that
+ * project is shared with EnviousStaging. Two in flight leaves a slot of
+ * headroom. This is the GLOBAL ceiling for this run: sections describe their
+ * work, they never schedule it, because two limiters of 2 is a limiter of 4. */
+const CONCURRENCY_LIMIT = 2;
+
+const REPORT_DAYS = 7;
+
+/** The EnviousWispr website's own hosts. Everything else in PostHog project
+ * 354235 belongs to another product or to a local dev server
+ * (analytics-operations.md FACT: posthog-project-is-shared-with-enviousstaging).
+ *
+ * `www` does not appear in 30 days of live data and is listed anyway: its
+ * absence is a fact about today's DNS, not a guarantee. */
+const SITE_HOSTS = ["enviouswispr.com", "www.enviouswispr.com"];
 
 export default {
   async scheduled(event, env) {
-    await sendDigest(env);
+    await runDigest(env);
   },
 
-  // Manual trigger via HTTP for testing: curl <worker-url>
+  /**
+   * Manual trigger. Secret-gated and FAILS CLOSED: the workers.dev URL is
+   * public, and before #1589 any request to it posted a real digest to Discord.
+   * An unset TRIGGER_SECRET refuses everything, so a half-configured deploy
+   * cannot be triggered by anyone.
+   */
   async fetch(request, env) {
-    await sendDigest(env);
-    return new Response("Digest sent.");
+    const url = new URL(request.url);
+    const provided = url.searchParams.get("token") || request.headers.get("x-trigger-secret");
+    if (!env.TRIGGER_SECRET || provided !== env.TRIGGER_SECRET) {
+      return new Response("unauthorized\n", { status: 401 });
+    }
+    try {
+      const content = await runDigest(env);
+      return new Response(content + "\n", { status: 200 });
+    } catch (err) {
+      // Deliberately posts nothing here. runDigest owns every Discord request;
+      // a second post from this layer is how a failed run tells the founder
+      // twice, or tells him after he already has the digest.
+      return new Response("weekly digest failed: " + err.message + "\n", { status: 500 });
+    }
   },
 };
 
-async function sendDigest(env) {
-  const now = new Date();
-  const weekEnd = now.toISOString().slice(0, 10);
-  const weekStart = new Date(now - 7 * 86400000).toISOString().slice(0, 10);
+// ----- Window ---------------------------------------------------------------
 
-  const [cf, gh, ph] = await Promise.all([
-    fetchCloudflareStats(env, weekStart, weekEnd),
-    fetchGitHubDownloads(env),
-    fetchPostHogStats(env, weekStart, weekEnd),
-  ]);
-
-  const embed = buildEmbed(weekStart, weekEnd, cf, gh, ph);
-  await postToDiscord(env.DISCORD_WEBHOOK_URL, embed);
+/**
+ * Seven whole UTC days, HALF-OPEN: `start` inclusive, `end` exclusive.
+ *
+ * The shipped worker used `now - 7d` to `now` with BOTH ends inclusive, which
+ * is eight calendar dates. That is what produced a second weekly Trends bucket
+ * and, with the bucket-summing extractor, the 210-vs-189 double count. A
+ * half-open range is also what stops consecutive weeks sharing a day.
+ *
+ * UTC days, not Eastern days. KNOWN LIMIT, recorded rather than hidden: the
+ * daily report measures Eastern calendar days, so a week of daily reports and
+ * one weekly digest cover windows offset by the Eastern UTC offset and will not
+ * reconcile to the exact person. Aligning them means sharing the daily report's
+ * timezone machinery, which is a separate change with its own risk to a working
+ * worker.
+ */
+export function resolveWeekWindow(now = new Date()) {
+  const end = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  const start = new Date(end.getTime() - REPORT_DAYS * 86400000);
+  return Object.freeze({
+    start,
+    end,
+    win: windowClause(start, end),
+    startDay: start.toISOString().slice(0, 10),
+    // The last day INCLUDED, for display and for Cloudflare's inclusive filter.
+    // Never `end` itself: that day is outside the window.
+    lastDay: new Date(end.getTime() - 86400000).toISOString().slice(0, 10),
+  });
 }
 
-// ── Cloudflare Analytics ──────────────────────────────────────
+// ----- Cloudflare -----------------------------------------------------------
 
-async function fetchCloudflareStats(env, dateFrom, dateTo) {
+/**
+ * Site-wide traffic. One request, a different API with no shared ceiling, so it
+ * runs outside the PostHog limiter.
+ *
+ * Every failure path throws. Before #1589 none of them did: a non-2xx, a
+ * GraphQL `errors` array, or a missing zone all left `zone` undefined, the
+ * totals loops ran over empty arrays, and the digest reported a confident 0
+ * unique visitors. Three distinct producers of one silent wrong answer.
+ */
+export async function fetchCloudflareStats(env, window, { fetchFn = fetch } = {}) {
   const query = `query {
     viewer {
       zones(filter: {zoneTag: "${env.CF_ZONE_ID}"}) {
         totals: httpRequests1dGroups(
-          limit: 7
-          filter: {date_geq: "${dateFrom}", date_leq: "${dateTo}"}
+          limit: ${REPORT_DAYS}
+          filter: {date_geq: "${window.startDay}", date_leq: "${window.lastDay}"}
         ) {
           sum { requests pageViews }
           uniq { uniques }
         }
         byDay: httpRequests1dGroups(
-          limit: 7
-          filter: {date_geq: "${dateFrom}", date_leq: "${dateTo}"}
+          limit: ${REPORT_DAYS}
+          filter: {date_geq: "${window.startDay}", date_leq: "${window.lastDay}"}
         ) {
           dimensions { date }
           sum {
@@ -59,196 +155,179 @@ async function fetchCloudflareStats(env, dateFrom, dateTo) {
     }
   }`;
 
-  // NOTE: the former "Top Referrers" query (httpRequestsAdaptiveGroups { refererHost })
-  // was removed (#1243): refererHost is rejected by the Cloudflare API on the zone
-  // dataset (the valid field, clientRefererHost, is paid-only), so the section was
-  // silently empty. Download attribution now comes from PostHog source_bucket — see
-  // the "Download Sources" field built from fetchPostHogStats.
-  const opts = {
+  // NOTE: the former "Top Referrers" query (httpRequestsAdaptiveGroups {
+  // refererHost }) was removed (#1243): refererHost is rejected by the
+  // Cloudflare API on the zone dataset (the valid field, clientRefererHost, is
+  // paid-only), so the section was silently empty. Download attribution now
+  // comes from PostHog source_bucket.
+  const res = await fetchFn("https://api.cloudflare.com/client/v4/graphql", {
     method: "POST",
     headers: {
       "X-Auth-Email": env.CF_EMAIL,
       "X-Auth-Key": env.CF_API_KEY,
       "Content-Type": "application/json",
     },
-  };
-
-  const mainRes = await fetch("https://api.cloudflare.com/client/v4/graphql", {
-    ...opts,
     body: JSON.stringify({ query }),
-  }).then((r) => r.json());
+  });
+  if (!res.ok) throw new Error(`Cloudflare Analytics HTTP ${res.status}`);
 
-  const zone = mainRes?.data?.viewer?.zones?.[0];
-  const totals = zone?.totals || [];
-  const byDay = zone?.byDay || [];
+  const body = await res.json();
+  // GraphQL answers 200 with an `errors` array, so a status-only check passes
+  // and `zone` is still undefined. Separate producer, separate check.
+  if (Array.isArray(body?.errors) && body.errors.length > 0) {
+    throw new Error("Cloudflare Analytics returned GraphQL errors");
+  }
+  const zone = body?.data?.viewer?.zones?.[0];
+  if (!zone) throw new Error("Cloudflare Analytics returned no zone");
 
-  let totalRequests = 0, totalPageViews = 0, totalUniques = 0;
+  let totalRequests = 0, totalPageViews = 0, summedDailyUniques = 0;
   const countries = {};
-
-  for (const g of totals) {
+  for (const g of zone.totals || []) {
     totalRequests += g.sum?.requests || 0;
     totalPageViews += g.sum?.pageViews || 0;
-    totalUniques += g.uniq?.uniques || 0;
+    summedDailyUniques += g.uniq?.uniques || 0;
   }
-  for (const g of byDay) {
+  for (const g of zone.byDay || []) {
     for (const c of g.sum?.countryMap || []) {
       countries[c.clientCountryName] = (countries[c.clientCountryName] || 0) + c.requests;
     }
   }
 
-  const topCountries = Object.entries(countries)
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, 5);
-
-  return { totalRequests, totalPageViews, totalUniques, topCountries };
+  return {
+    totalRequests,
+    totalPageViews,
+    // Named for what it IS. This sums each day's unique-IP count, so a visitor
+    // on three days counts three times; calling it "unique visitors" was the
+    // label lying about the arithmetic (founder decision 2026-08-01: relabel,
+    // do not change the query).
+    summedDailyUniques,
+    topCountries: Object.entries(countries).sort((a, b) => b[1] - a[1]).slice(0, 5),
+  };
 }
 
-// ── GitHub Release Downloads ──────────────────────────────────
+// ----- GitHub ---------------------------------------------------------------
 
-async function fetchGitHubDownloads(env) {
+const GITHUB_PAGE_SIZE = 100;
+// Bound on pages walked. 45 releases exist today; 50 pages is 5,000 releases,
+// far beyond any real state, and it exists only so a malformed paging response
+// cannot spin forever inside a Worker's wall clock.
+const GITHUB_MAX_PAGES = 50;
+
+/**
+ * All-time DMG downloads across EVERY release.
+ *
+ * The shipped version made one unpaginated request. GitHub's default page size
+ * is 30 and this repo has 45 releases, so the "All-Time" figure silently
+ * omitted 15 releases' worth of downloads.
+ *
+ * A mid-pagination failure throws rather than returning the pages gathered so
+ * far: a total assembled from 2 of 5 pages is a plausible, confidently wrong
+ * number, which is the exact defect class this change exists to remove.
+ */
+export async function fetchGitHubDownloads(env, { fetchFn = fetch } = {}) {
   const headers = { "User-Agent": "EnviousWispr-Digest-Worker" };
   if (env.GITHUB_TOKEN) headers.Authorization = `token ${env.GITHUB_TOKEN}`;
 
-  const res = await fetch(
-    `https://api.github.com/repos/${env.GITHUB_REPO}/releases`,
-    { headers }
-  );
-  if (!res.ok) return { totalDownloads: "?", latestVersion: "?" };
-
-  const releases = await res.json();
   let totalDownloads = 0;
-  let latestVersion = releases[0]?.tag_name || "?";
+  let latestVersion = "?";
 
-  for (const rel of releases) {
-    for (const asset of rel.assets || []) {
-      if (asset.name.endsWith(".dmg")) {
-        totalDownloads += asset.download_count;
+  for (let page = 1; page <= GITHUB_MAX_PAGES; page += 1) {
+    const res = await fetchFn(
+      `https://api.github.com/repos/${env.GITHUB_REPO}/releases?per_page=${GITHUB_PAGE_SIZE}&page=${page}`,
+      { headers }
+    );
+    if (!res.ok) throw new Error(`GitHub releases HTTP ${res.status}`);
+    const releases = await res.json();
+    if (!Array.isArray(releases)) throw new Error("GitHub releases returned a non-array");
+
+    if (page === 1) latestVersion = releases[0]?.tag_name || "?";
+    for (const rel of releases) {
+      for (const asset of rel.assets || []) {
+        if (asset.name?.endsWith(".dmg")) totalDownloads += asset.download_count || 0;
       }
     }
+    if (releases.length < GITHUB_PAGE_SIZE) return { totalDownloads, latestVersion };
   }
-
-  return { totalDownloads, latestVersion };
+  throw new Error(`GitHub releases exceeded ${GITHUB_MAX_PAGES} pages`);
 }
 
-// ── PostHog Stats ─────────────────────────────────────────────
+// ----- PostHog SQL ----------------------------------------------------------
 
-async function fetchPostHogStats(env, dateFrom, dateTo) {
-  const apiKey = env.POSTHOG_PERSONAL_API_KEY;
-  if (!apiKey) return { weeklyActiveUsers: "?", newUsers: "?", downloadIntents: "?", downloadSources: null, botExcluded: "?" };
+const hostFilter = `properties.$host IN (${SITE_HOSTS.map((h) => `'${h}'`).join(", ")})`;
 
-  const headers = {
-    Authorization: `Bearer ${apiKey}`,
-    "Content-Type": "application/json",
-  };
-
-  // Weekly active users (production only — excludes dev dogfooding)
-  const prodFilter = [{ key: "environment", operator: "exact", type: "event", value: "production" }];
-  const wauQuery = {
-    kind: "TrendsQuery",
-    dateRange: { date_from: dateFrom, date_to: dateTo },
-    interval: "week",
-    properties: prodFilter,
-    series: [
-      { kind: "EventsNode", event: "app.launched", math: "dau", custom_name: "WAU" },
-      { kind: "EventsNode", event: "app.launched", math: "first_time_for_user", custom_name: "New" },
-    ],
-  };
-
-  // Download intents (7d) = on-site clicks + non-bot off-site doorway redirects.
-  // HogQL (not TrendsQuery) because the union + bot-exclusion needs coalesce() on a
-  // property; bare property names do NOT resolve in HogQL — must be properties.<name>.
-  const intentsQuery = { kind: "HogQLQuery", query: downloadIntentsHogQL(dateFrom, dateTo) };
-  // Off-site download sources (non-bot) grouped by canonical source_bucket.
-  const sourcesQuery = { kind: "HogQLQuery", query: downloadSourcesHogQL(dateFrom, dateTo) };
-  // Off-site bot hits excluded this week — integrity line (surfaces a bot surge OR
-  // over-aggressive filtering).
-  const botQuery = { kind: "HogQLQuery", query: botExcludedHogQL(dateFrom, dateTo) };
-
-  // Website pageviews
-  const pvQuery = {
-    kind: "TrendsQuery",
-    dateRange: { date_from: dateFrom, date_to: dateTo },
-    interval: "week",
-    series: [
-      { kind: "EventsNode", event: "$pageview", math: "total", custom_name: "Website PVs" },
-      { kind: "EventsNode", event: "$pageview", math: "dau", custom_name: "Website visitors" },
-    ],
-  };
-
-  const queryUrl = `https://us.posthog.com/api/projects/${env.POSTHOG_PROJECT_ID}/query/`;
-
-  const post = (query) =>
-    fetch(queryUrl, { method: "POST", headers, body: JSON.stringify({ query }) })
-      .then((r) => r.json())
-      .catch(() => null);
-
-  const [wauRes, pvRes, intentsRes, sourcesRes, botRes] = await Promise.all([
-    post(wauQuery),
-    post(pvQuery),
-    post(intentsQuery),
-    post(sourcesQuery),
-    post(botQuery),
-  ]);
-
-  return {
-    weeklyActiveUsers: extractTrendTotal(wauRes, 0),
-    newUsers: extractTrendTotal(wauRes, 1),
-    websitePageViews: extractTrendTotal(pvRes, 0),
-    websiteVisitors: extractTrendTotal(pvRes, 1),
-    downloadIntents: extractHogScalar(intentsRes),
-    downloadSources: extractHogRows(sourcesRes),
-    botExcluded: extractHogScalar(botRes),
-  };
+/** App usage. The ONLY query carrying the production predicate.
+ *
+ * `uniqExact` over the whole window, replacing a TrendsQuery whose two weekly
+ * buckets were summed. New installs uses the app's own is_fresh_install rather
+ * than PostHog's first_time_for_user (founder decision 2026-08-01): it is what
+ * the daily report counts, and reproducing first_time_for_user in HogQL needs a
+ * whole-history min(timestamp) per user, the unbounded-scan shape that caused
+ * the #1655 and #1716 timeouts. */
+export function appUsageSql(prod, win) {
+  return `SELECT
+      uniqExact(distinct_id) AS active,
+      uniqExactIf(distinct_id, properties.is_fresh_install = true) AS fresh
+    FROM events
+    WHERE event = 'app.launched' AND ${prod} AND ${win}`;
 }
 
-// ── Helpers (pure; exported for node --test) ──────────────────
-
-// HogQL query builders. NOTE: every event-property ref MUST be properties.<name>
-// (bare names do not resolve in PostHog HogQL). The union/bot predicate is the
-// single shared DEFINITION (mirrored by the PostHog ping function; see
-// .claude/knowledge/analytics-operations.md). #1243
-export function downloadIntentsHogQL(dateFrom, dateTo) {
-  return `SELECT count() FROM events WHERE toDate(timestamp) >= toDate('${dateFrom}') AND toDate(timestamp) <= toDate('${dateTo}') AND (event = 'download_clicked' OR (event = 'download_redirect' AND coalesce(properties.excluded_reason, '') = ''))`;
-}
-export function downloadSourcesHogQL(dateFrom, dateTo) {
-  return `SELECT properties.source_bucket AS bucket, count() AS n FROM events WHERE event = 'download_redirect' AND coalesce(properties.excluded_reason, '') = '' AND toDate(timestamp) >= toDate('${dateFrom}') AND toDate(timestamp) <= toDate('${dateTo}') GROUP BY bucket ORDER BY n DESC LIMIT 8`;
-}
-export function botExcludedHogQL(dateFrom, dateTo) {
-  return `SELECT count() FROM events WHERE event = 'download_redirect' AND coalesce(properties.excluded_reason, '') != '' AND toDate(timestamp) >= toDate('${dateFrom}') AND toDate(timestamp) <= toDate('${dateTo}')`;
-}
-
-// TrendsQuery total extractor (aggregated_value or summed data array).
-export function extractTrendTotal(res, seriesIdx = 0) {
-  try {
-    const series = res?.results?.[seriesIdx];
-    if (!series) return "?";
-    if (series.aggregated_value != null) return series.aggregated_value;
-    if (Array.isArray(series.data)) return series.data.reduce((a, b) => a + b, 0);
-    return "?";
-  } catch {
-    return "?";
-  }
+/** Website traffic. NO production predicate, deliberately.
+ *
+ * `productionClauseFor` always begins `properties.environment = 'production'`,
+ * and website events carry no environment property at all - the site's PostHog
+ * init sets none. Applying it here returns ZERO, not "the same rows more
+ * slowly". The host filter is what scopes this population, and it is what stops
+ * EnviousStaging and localhost being counted as EnviousWispr visitors.
+ *
+ * This argument is LOCAL to the three website queries and must be re-derived by
+ * anyone adding a fourth. */
+export function websiteSql(win) {
+  return `SELECT count() AS views, uniqExact(distinct_id) AS visitors
+    FROM events
+    WHERE event = '$pageview' AND ${hostFilter} AND ${win}`;
 }
 
-// HogQLQuery scalar (first cell of first row, e.g. a count()).
-export function extractHogScalar(res) {
-  try {
-    const v = res?.results?.[0]?.[0];
-    return v == null ? "?" : v;
-  } catch {
-    return "?";
-  }
+/** Download intents and excluded bot hits in ONE query.
+ *
+ * Same table, same window, differing only by predicate, so two countIf columns
+ * replace two round trips. `WHERE event IN (...)` keeps the merged query scoped
+ * to the two relevant event types. Both predicates are byte-preserved from the
+ * two builders this replaces, so the numbers do not move.
+ *
+ * NO host filter, on measured evidence: download_clicked appears only from
+ * enviouswispr.com, and download_redirect carries no $host at all because the
+ * doorway worker emits it server-side. A host filter here would silently drop
+ * every off-site redirect. */
+export function downloadsSql(win) {
+  return `SELECT
+      countIf(event = 'download_clicked'
+              OR (event = 'download_redirect' AND coalesce(properties.excluded_reason, '') = '')) AS intents,
+      countIf(event = 'download_redirect'
+              AND coalesce(properties.excluded_reason, '') != '') AS bots_excluded
+    FROM events
+    WHERE event IN ('download_clicked', 'download_redirect') AND ${win}`;
 }
 
-// HogQLQuery rows (array of [col0, col1, ...]). Returns null (NOT []) on a failed
-// or malformed response, so a query error is distinguishable from a genuine empty
-// week — a real empty array means "zero off-site downloads", null means "unknown".
-export function extractHogRows(res) {
-  return Array.isArray(res?.results) ? res.results : null;
+/** Off-site download sources by canonical bucket. Stays separate from
+ * downloadsSql: it is a GROUP BY producing rows, and folding it in would need a
+ * UNION - and a UNION in a query that also interpolates a predicate is the
+ * doubled-subquery shape behind #1655 and #1716. */
+export function downloadSourcesSql(win) {
+  return `SELECT properties.source_bucket AS bucket, count() AS n
+    FROM events
+    WHERE event = 'download_redirect' AND coalesce(properties.excluded_reason, '') = '' AND ${win}
+    GROUP BY bucket
+    ORDER BY n DESC
+    LIMIT 8`;
 }
 
-// Canonical source_bucket -> human label for the digest (concise; the live ping
-// uses its own slightly longer phrasing). Unknown/null -> "Other".
+// ----- Presentation ---------------------------------------------------------
+
+const UNAVAILABLE = "temporarily unavailable";
+
+const n = (value) => Number(value).toLocaleString();
+
+// Canonical source_bucket -> human label. Unknown/null -> "Other".
 export const SOURCE_LABELS = {
   github_readme: "GitHub README",
   github_release: "GitHub",
@@ -274,103 +353,256 @@ export function sourceLabel(bucket) {
   return (bucket && SOURCE_LABELS[bucket]) || "Other";
 }
 
-// Render the source-breakdown rows ([[bucket, n], ...]) for the embed.
-// null (query failed/unknown) and [] (genuine zero) render differently so a
-// telemetry outage never masquerades as a true zero-source week.
+/** Renders the source breakdown. `null` (unavailable) and `[]` (a genuine zero)
+ * render differently, so a telemetry outage never masquerades as a true
+ * zero-source week. This one field already got the distinction right before
+ * #1589; the rest of the digest now follows it. */
 export function formatSourceBreakdown(rows) {
   if (rows == null || !Array.isArray(rows)) return "Sources unavailable";
   if (rows.length === 0) return "No off-site downloads yet";
-  return rows
-    .map(([bucket, n]) => `${sourceLabel(bucket)}: ${Number(n).toLocaleString()}`)
-    .join("\n");
+  return rows.map((r) => `${sourceLabel(r.bucket)}: ${n(r.n)}`).join("\n");
 }
 
-// ── Discord Embed ─────────────────────────────────────────────
+function formatDayRange(window) {
+  const fmt = (iso) => {
+    const [y, m, d] = iso.split("-").map(Number);
+    return new Intl.DateTimeFormat("en-US", {
+      timeZone: "UTC", month: "long", day: "numeric",
+    }).format(new Date(Date.UTC(y, m - 1, d, 12)));
+  };
+  return `${fmt(window.startDay)} to ${fmt(window.lastDay)}`;
+}
 
-export function buildEmbed(weekStart, weekEnd, cf, gh, ph) {
-  const topCountriesStr = cf.topCountries
-    .map(([name, count]) => `${name}: ${count.toLocaleString()}`)
-    .join("\n") || "No data";
+/** Every section formatter returns LINES whose FIRST line titles its embed, so
+ * the payload assembler never authors a sentence of its own. */
+export function formatCloudflare(cf) {
+  if (!cf) return ["All website traffic", `Traffic figures were ${UNAVAILABLE} when this digest ran.`];
+  const lines = [
+    "All website traffic",
+    `${n(cf.totalPageViews)} page views, from ${n(cf.summedDailyUniques)} daily visits added up.`,
+    "Someone who visits on three days counts three times in that second number.",
+    `${n(cf.totalRequests)} requests reached the site in total.`,
+  ];
+  if (cf.topCountries.length) {
+    lines.push("", `Busiest places: ${cf.topCountries.map(([c, r]) => `${c} ${n(r)}`).join(", ")}.`);
+  }
+  return lines;
+}
 
-  const sourcesStr = formatSourceBreakdown(ph.downloadSources);
+export function formatWebsite(site, intents) {
+  const lines = ["Tracked visitor activity"];
+  lines.push(site
+    ? `${n(site.visitors)} people viewed ${n(site.views)} pages on enviouswispr.com.`
+    : `Visitor figures were ${UNAVAILABLE} when this digest ran.`);
+  lines.push(intents == null
+    ? `The number of people who started a download was ${UNAVAILABLE}.`
+    : `${n(intents)} of them started a download.`);
+  lines.push("", "This counts only people whose browser runs our analytics, so it reads lower than the traffic figures above.");
+  return lines;
+}
 
+export function formatDownloads(gh, sources, botsExcluded) {
+  const lines = ["Downloads"];
+  lines.push(gh
+    ? `${n(gh.totalDownloads)} downloads all time, across every release. Latest release is ${gh.latestVersion}.`
+    : `All-time download figures were ${UNAVAILABLE} when this digest ran.`);
+  lines.push("", "Where this week's off-site downloads came from:", "```", formatSourceBreakdown(sources), "```");
+  lines.push(botsExcluded == null
+    ? `Bot downloads excluded: ${UNAVAILABLE}.`
+    : `Bot downloads excluded this week: ${n(botsExcluded)}.`);
+  return lines;
+}
+
+export function formatAppUsage(usage) {
+  if (!usage) return ["App usage", `App usage figures were ${UNAVAILABLE} when this digest ran.`];
+  return [
+    "App usage",
+    `${n(usage.active)} people used EnviousWispr this week.`,
+    `${n(usage.fresh)} of them installed it for the first time.`,
+    "",
+    "Dev machines are excluded from both numbers.",
+  ];
+}
+
+/** One embed per section, and a REFUSAL of any shape Discord would reject,
+ * while that failure still belongs to one section rather than the payload. */
+function toEmbed(lines) {
+  if (!Array.isArray(lines) || lines.length < 2) {
+    throw new TypeError("section formatter must return a title and body as string lines");
+  }
+  const checked = [];
+  for (let i = 0; i < lines.length; i += 1) {
+    // Indexed and read exactly ONCE: Array#every skips holes, and two reads of
+    // the same index let an accessor answer one value to the check and another
+    // to the consumer.
+    if (!Object.hasOwn(lines, i)) {
+      throw new TypeError("section formatter must return a title and body as string lines");
+    }
+    const line = lines[i];
+    if (typeof line !== "string") {
+      throw new TypeError("section formatter must return a title and body as string lines");
+    }
+    checked.push(line);
+  }
+  const [title, ...body] = checked;
+  const description = body.join("\n");
+  if (title.length === 0 || description.length === 0) {
+    throw new TypeError("section formatter must return a non-empty title and description");
+  }
   return {
-    embeds: [
-      {
-        title: `📊 EnviousWispr Weekly Digest`,
-        description: `**${weekStart}** to **${weekEnd}**`,
-        color: 0x7c3aed, // brand purple
-        fields: [
-          {
-            name: "🌐 Website (Cloudflare)",
-            value: [
-              `**Unique Visitors:** ${cf.totalUniques.toLocaleString()}`,
-              `**Page Views:** ${cf.totalPageViews.toLocaleString()}`,
-              `**Total Requests:** ${cf.totalRequests.toLocaleString()}`,
-            ].join("\n"),
-            inline: true,
-          },
-          {
-            name: "🌐 Website (PostHog)",
-            value: [
-              `**Tracked Visitors:** ${ph.websiteVisitors ?? "—"}`,
-              `**Tracked Page Views:** ${ph.websitePageViews ?? "—"}`,
-              `**Download Intents (7d):** ${ph.downloadIntents ?? "—"}`,
-            ].join("\n"),
-            inline: true,
-          },
-          {
-            name: "\u200b",
-            value: "\u200b",
-            inline: false,
-          },
-          {
-            name: "⬇️ Downloads",
-            value: [
-              `**All-Time DMG Downloads:** ${gh.totalDownloads.toLocaleString()}`,
-              `**Latest Release:** ${gh.latestVersion}`,
-            ].join("\n"),
-            inline: true,
-          },
-          {
-            name: "📱 App Usage (PostHog)",
-            value: [
-              `**Active Installs (7d):** ${ph.weeklyActiveUsers}`,
-              `**New Users This Week:** ${ph.newUsers}`,
-            ].join("\n"),
-            inline: true,
-          },
-          {
-            name: "\u200b",
-            value: "\u200b",
-            inline: false,
-          },
-          {
-            name: "⬇️ Download Sources (7d)",
-            value: `\`\`\`\n${sourcesStr}\n\`\`\`\nOff-site bots excluded: ${ph.botExcluded ?? "—"}`,
-            inline: true,
-          },
-          {
-            name: "🌍 Top Countries",
-            value: `\`\`\`\n${topCountriesStr}\n\`\`\``,
-            inline: true,
-          },
-        ],
-        footer: {
-          text: "EnviousWispr Weekly Digest • Cloudflare Worker",
-        },
-        timestamp: new Date().toISOString(),
-      },
-    ],
+    title,
+    description,
+    color: 0x7c3aed, // brand purple
+    footer: { text: "EnviousWispr Weekly Digest" },
   };
 }
 
-// ── Discord Post ──────────────────────────────────────────────
+// ----- Orchestration --------------------------------------------------------
 
-async function postToDiscord(webhookUrl, payload) {
-  await fetch(webhookUrl, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(payload),
-  });
+/** Best-effort fixed notice for a run that produced no digest at all. Carries
+ * no error text, status code or response body: it goes to a Discord channel,
+ * and the exception surfaces through the trigger's non-2xx status. */
+async function postFailureNotice(env, label, { fetchFn = fetch } = {}) {
+  if (!env.DISCORD_WEBHOOK_URL) return;
+  try {
+    await deliverReport(env.DISCORD_WEBHOOK_URL, {
+      content:
+        `EnviousWispr Weekly Digest for ${label} could not be generated. ` +
+        `Nothing was measured, so this is not a report of zero.`,
+    }, { fetchFn });
+  } catch (_) {
+    // The caller's rethrow is what surfaces the failure. A failure notice that
+    // itself fails must not replace the original error.
+  }
+}
+
+/** Unwraps a settled outcome, returning `null` where the section failed, so a
+ * formatter renders "temporarily unavailable" instead of a fabricated number. */
+function valueOrNull(outcome, failures, name) {
+  if (outcome.status === "fulfilled") return outcome.value;
+  failures.push(`${name}: ${outcome.reason?.message || "failed"}`);
+  return null;
+}
+
+/**
+ * `deps` is a test-only injection seam; production passes nothing.
+ * `deps.hogqlOpts` drives retry paths without sitting through real backoff,
+ * `deps.fetchFn` intercepts Cloudflare/GitHub/Discord, `deps.now` pins the
+ * window.
+ */
+export async function runDigest(env, deps = {}) {
+  const hogqlOpts = { ...(deps.hogqlOpts || {}), workerLabel: WORKER_LABEL };
+  const fetchFn = deps.fetchFn || fetch;
+  const now = deps.now || new Date();
+
+  // ---- Window. The ONLY whole-run fatal dependency: without it no section has
+  // a period to measure, so there is nothing honest to post.
+  let window;
+  try {
+    window = resolveWeekWindow(now);
+  } catch (err) {
+    await postFailureNotice(env, "the requested week", { fetchFn });
+    throw err;
+  }
+  const label = formatDayRange(window);
+
+  // ---- Dev-ID resolution. Needed ONLY by app usage, so its failure costs that
+  // one section and nothing else. Daily-report makes this fatal to its whole
+  // run and is right to, because both of its sections are app events measured
+  // over the production population. Here, three sections never touch the dev
+  // list, and this is the single most timeout-prone query in the run - an
+  // unbounded whole-history scan. Inheriting the fatal contract would discard
+  // three working sections for an app-only dependency.
+  let prod = null;
+  const failures = [];
+  try {
+    prod = productionClauseFor(await resolveDevIds(env, hogqlOpts));
+  } catch (err) {
+    failures.push(`dev_ids: ${err.message}`);
+    console.log(`weekly_digest dev_ids failed, app usage unavailable: ${err.message}`);
+  }
+
+  // ---- Fan-out. PostHog work goes through the ONE limiter; Cloudflare and
+  // GitHub are different APIs with no shared ceiling and run alongside it.
+  const posthogTasks = [
+    () => querySection(env, websiteSql(window.win), "website", hogqlOpts),
+    () => querySection(env, downloadsSql(window.win), "downloads", hogqlOpts),
+    () => querySection(env, downloadSourcesSql(window.win), "download_sources", hogqlOpts),
+  ];
+  if (prod) {
+    posthogTasks.push(() => querySection(env, appUsageSql(prod, window.win), "app_usage", hogqlOpts));
+  }
+
+  const [posthogOutcome, cfOutcome, ghOutcome] = await Promise.allSettled([
+    runLimited(posthogTasks.map((task) => async () => {
+      try {
+        return { status: "fulfilled", value: await task() };
+      } catch (reason) {
+        return { status: "rejected", reason };
+      }
+    }), CONCURRENCY_LIMIT),
+    fetchCloudflareStats(env, window, { fetchFn }),
+    fetchGitHubDownloads(env, { fetchFn }),
+  ]);
+
+  // A rejection here is a programming error in the limiter itself, not a query
+  // failure: every task above already converts its own rejection to a settled
+  // record. Fatal, and deliberately not absorbed as four unavailable sections.
+  if (posthogOutcome.status === "rejected") {
+    await postFailureNotice(env, label, { fetchFn });
+    throw posthogOutcome.reason;
+  }
+  const settled = posthogOutcome.value;
+
+  const read = (index, name) => {
+    if (index >= settled.length) return null;
+    const outcome = settled[index];
+    if (outcome.status === "rejected") {
+      // querySection already absorbed every EXPECTED transient failure into a
+      // degraded flag, so a rejection here is a contract failure: auth, bad
+      // SQL, a malformed response shape, or a programming error. Those stay
+      // loud rather than becoming a quietly missing section.
+      throw outcome.reason;
+    }
+    if (outcome.value.degraded) {
+      failures.push(`${name}: degraded after retries`);
+      return null;
+    }
+    return rowsToObjects(outcome.value.response);
+  };
+
+  let site, downloads, sources, usage;
+  try {
+    site = read(0, "website")?.[0] ?? null;
+    downloads = read(1, "downloads")?.[0] ?? null;
+    sources = read(2, "download_sources");
+    usage = prod ? (read(3, "app_usage")?.[0] ?? null) : null;
+  } catch (err) {
+    await postFailureNotice(env, label, { fetchFn });
+    throw err;
+  }
+
+  const cf = valueOrNull(cfOutcome, failures, "cloudflare");
+  const gh = valueOrNull(ghOutcome, failures, "github");
+
+  const payload = {
+    content: `EnviousWispr Weekly Digest, ${label}`,
+    embeds: [
+      toEmbed(formatCloudflare(cf)),
+      toEmbed(formatWebsite(site, downloads ? downloads.intents : null)),
+      toEmbed(formatDownloads(gh, sources, downloads ? downloads.bots_excluded : null)),
+      toEmbed(formatAppUsage(usage)),
+    ],
+  };
+
+  // Validated and sent as ONE object. An over-budget payload throws here with
+  // zero requests made: the digest is sent whole or not at all.
+  await deliverReport(env.DISCORD_WEBHOOK_URL, payload, { fetchFn });
+
+  // The founder has the digest; the trigger still has to fail, or a section
+  // that silently stopped working would look like a healthy run forever.
+  if (failures.length) {
+    throw new Error(`weekly digest delivered with unavailable sections - ${failures.join("; ")}`);
+  }
+  return payload.content;
 }

--- a/workers/weekly-digest/src/index.js
+++ b/workers/weekly-digest/src/index.js
@@ -205,9 +205,16 @@ export async function fetchCloudflareStats(env, window, { fetchFn = fetch } = {}
   }
   for (const g of zone.byDay) {
     // countryMap may legitimately be absent for a day with no traffic; a
-    // PRESENT but malformed entry is not tolerated.
+    // PRESENT but malformed entry is not tolerated. The NAME is validated
+    // alongside the count: a missing one becomes the object key "undefined" and
+    // gets published as a busiest place, which is a wrong answer wearing a
+    // country's clothes.
     for (const c of g?.sum?.countryMap ?? []) {
-      countries[c.clientCountryName] = (countries[c.clientCountryName] || 0) + num(c?.requests, "countryMap.requests");
+      const country = c?.clientCountryName;
+      if (typeof country !== "string" || country.length === 0) {
+        throw new Error("Cloudflare Analytics returned a country entry without a name");
+      }
+      countries[country] = (countries[country] || 0) + num(c?.requests, "countryMap.requests");
     }
   }
 
@@ -266,8 +273,20 @@ export async function fetchGitHubDownloads(env, { fetchFn = fetch } = {}) {
       latestVersion = tag || "?";
     }
     for (const rel of releases) {
-      for (const asset of rel.assets || []) {
-        if (!asset?.name?.endsWith(".dmg")) continue;
+      // `rel.assets || []` would treat a release whose asset list is MISSING as
+      // a release with no downloads, silently undercounting the all-time total
+      // while reporting success. A release with an empty array is different and
+      // legitimate: some releases genuinely ship no dmg.
+      if (!Array.isArray(rel?.assets)) {
+        throw new Error("GitHub releases returned a release without an assets array");
+      }
+      for (const asset of rel.assets) {
+        // A non-string name silently fails the .dmg test and skips a real
+        // asset, which is the same undercount by a different route.
+        if (typeof asset?.name !== "string") {
+          throw new Error("GitHub releases returned an asset without a name");
+        }
+        if (!asset.name.endsWith(".dmg")) continue;
         // Same class as the PostHog and Cloudflare checks: a 200 whose body is
         // the wrong shape must not become a number. `|| 0` here would silently
         // undercount a dmg whose counter came back null or a string, which
@@ -591,27 +610,40 @@ export async function runDigest(env, deps = {}) {
   }
   const settled = posthogOutcome.value;
 
-  // EVERY VALUE THAT REACHES A FORMATTER, enumerated once so this stops being
-  // found an instance at a time. Whole-diff review raised the same class in
-  // four consecutive rounds because each fix covered only the instance it
-  // named; the cure is the list, not another patch. A new metric adds a row
-  // here, and its validator, in the same edit.
+  // EVERY EXTERNAL FIELD THIS WORKER READS, enumerated so the malformed-200
+  // class stops being found an instance at a time. Whole-diff review raised it
+  // in five consecutive rounds.
   //
-  //   site.views, site.visitors            readAggregate, finite numbers
-  //   downloads.intents, .bots_excluded    readAggregate, finite numbers
-  //   usage.active, usage.fresh            readAggregate, finite numbers
-  //   sources[].n                          readGrouped, finite number
-  //   sources[].bucket                     readGrouped, present, string or null
-  //   cf.totalPageViews/.totalRequests/
-  //     .summedDailyUniques                fetchCloudflareStats, num()
-  //   cf.topCountries[][1]                 fetchCloudflareStats, num()
-  //   gh.totalDownloads                    fetchGitHubDownloads, finite number
-  //   gh.latestVersion                     fetchGitHubDownloads, string
-  //   devIds[]                             shared resolveDevIds, non-empty strings
+  // The first version of this list enumerated the values that reach a
+  // FORMATTER, and review immediately found two more instances inside it. That
+  // was the wrong axis: `gh.totalDownloads` is validated, but it is DERIVED
+  // from `rel.assets` and `asset.name`, and a malformed one of those silently
+  // skipped a real asset and undercounted the total that was then checked and
+  // found perfectly numeric. So the list is now of INPUT FIELDS, not output
+  // values - every field parsed out of an external response, whether or not it
+  // is printed:
   //
-  // The rule each of them follows: check the SHAPE, never the magnitude. A zero
-  // is data; a missing field is a broken contract. Every check above has a
-  // two-way control in the test suite proving a genuine zero still reports zero.
+  //   PostHog rows      site.views/.visitors, downloads.intents/.bots_excluded,
+  //                     usage.active/.fresh          readAggregate, finite numbers
+  //                     sources[].n                  readGrouped, finite number
+  //                     sources[].bucket             readGrouped, present, string or null
+  //                     devIds[]                     shared resolveDevIds, non-empty strings
+  //   Cloudflare        zone.totals, zone.byDay      arrays
+  //                     g.sum.requests/.pageViews,
+  //                     g.uniq.uniques               num()
+  //                     c.clientCountryName          non-empty string
+  //                     c.requests                   num()
+  //   GitHub            releases                     array
+  //                     rel.assets                   array (missing != empty)
+  //                     asset.name                   string
+  //                     asset.download_count         finite number
+  //                     releases[0].tag_name         string
+  //
+  // Two rules, both learned the hard way. Check the SHAPE, never the magnitude:
+  // a zero is data, a missing field is a broken contract, and every check above
+  // has a two-way control in the tests proving a genuine zero still reports
+  // zero. And when adding a metric, add every field it READS, not just the
+  // number it prints.
   const read = (index, name) => {
     if (index >= settled.length) return null;
     const outcome = settled[index];

--- a/workers/weekly-digest/src/index.js
+++ b/workers/weekly-digest/src/index.js
@@ -258,10 +258,24 @@ export async function fetchGitHubDownloads(env, { fetchFn = fetch } = {}) {
     const releases = await res.json();
     if (!Array.isArray(releases)) throw new Error("GitHub releases returned a non-array");
 
-    if (page === 1) latestVersion = releases[0]?.tag_name || "?";
+    if (page === 1) {
+      const tag = releases[0]?.tag_name;
+      if (releases.length && typeof tag !== "string") {
+        throw new Error("GitHub releases returned a release without a tag_name");
+      }
+      latestVersion = tag || "?";
+    }
     for (const rel of releases) {
       for (const asset of rel.assets || []) {
-        if (asset.name?.endsWith(".dmg")) totalDownloads += asset.download_count || 0;
+        if (!asset?.name?.endsWith(".dmg")) continue;
+        // Same class as the PostHog and Cloudflare checks: a 200 whose body is
+        // the wrong shape must not become a number. `|| 0` here would silently
+        // undercount a dmg whose counter came back null or a string, which
+        // reads as a quiet week rather than as the malformed response it is.
+        if (typeof asset.download_count !== "number" || !Number.isFinite(asset.download_count)) {
+          throw new Error("GitHub releases returned a non-numeric download_count");
+        }
+        totalDownloads += asset.download_count;
       }
     }
     if (releases.length < GITHUB_PAGE_SIZE) return { totalDownloads, latestVersion };
@@ -594,33 +608,54 @@ export async function runDigest(env, deps = {}) {
     return rowsToObjects(outcome.value.response);
   };
 
-  /** An AGGREGATE query returns exactly one row, always: `uniqExact` and
-   * `countIf` over an empty window still produce a row of zeros. So an empty
-   * `results` array from a 200 is a malformed response, NOT a quiet week.
+  /** An AGGREGATE query returns EXACTLY ONE row whose named columns are finite
+   * numbers. `uniqExact` and `countIf` over an empty window still produce a row
+   * of zeros, so anything else from a 200 is a malformed response, not a quiet
+   * week.
    *
-   * Without this it fails in the worst available way: the section renders
-   * "temporarily unavailable" while `failures` stays empty, so the digest looks
-   * degraded to the founder and the run reports SUCCESS to the trigger. Broken
-   * telemetry would then look healthy for as long as nobody read the post. */
-  const readAggregate = (index, name) => {
+   * Checking the row COUNT alone is not enough, and this is the third review
+   * round on one class - a 200 whose body is the wrong SHAPE. A response with
+   * `columns: ["views"]` yields `{views: 226}`, `visitors` is `undefined`, and
+   * the digest publishes "NaN people viewed 226 pages" while the run reports
+   * SUCCESS. So the field names and their numeric-ness are checked here, at the
+   * one place every aggregate passes through, rather than at each call site
+   * where the next query would forget. */
+  const readAggregate = (index, name, fields) => {
     const rows = read(index, name);
     if (rows === null) return null; // already degraded and recorded
-    if (rows.length === 0) {
-      failures.push(`${name}: returned no aggregate row`);
+    if (rows.length !== 1) {
+      failures.push(`${name}: expected exactly 1 aggregate row, got ${rows.length}`);
       return null;
     }
-    return rows[0];
+    const row = rows[0];
+    const bad = fields.filter((f) => typeof row[f] !== "number" || !Number.isFinite(row[f]));
+    if (bad.length) {
+      failures.push(`${name}: missing or non-numeric ${bad.join(", ")}`);
+      return null;
+    }
+    return row;
+  };
+
+  /** The GROUP BY counterpart. Zero rows is a LEGITIMATE empty week here, which
+   * is why it does not go through readAggregate - but each row still has to be
+   * the shape the formatter will read. */
+  const readGrouped = (index, name) => {
+    const rows = read(index, name);
+    if (rows === null) return null;
+    const malformed = rows.some((r) => typeof r.n !== "number" || !Number.isFinite(r.n));
+    if (malformed) {
+      failures.push(`${name}: non-numeric row count`);
+      return null;
+    }
+    return rows;
   };
 
   let site, downloads, sources, usage;
   try {
-    site = readAggregate(0, "website");
-    downloads = readAggregate(1, "downloads");
-    // NOT an aggregate: a GROUP BY legitimately returns zero rows when there
-    // were no off-site downloads, and formatSourceBreakdown already renders
-    // that differently from unavailable.
-    sources = read(2, "download_sources");
-    usage = prod ? readAggregate(3, "app_usage") : null;
+    site = readAggregate(0, "website", ["views", "visitors"]);
+    downloads = readAggregate(1, "downloads", ["intents", "bots_excluded"]);
+    sources = readGrouped(2, "download_sources");
+    usage = prod ? readAggregate(3, "app_usage", ["active", "fresh"]) : null;
   } catch (err) {
     await postFailureNotice(env, label, { fetchFn });
     throw err;

--- a/workers/weekly-digest/src/index.js
+++ b/workers/weekly-digest/src/index.js
@@ -722,7 +722,11 @@ export async function runDigest(env, deps = {}) {
       failures.push(`${name}: degraded after retries`);
       return null;
     }
-    return rowsToObjects(outcome.value.response);
+    // Rows AND columns. A per-row shape check cannot fire on zero rows, so any
+    // query where empty is legitimate must be checked on its column set - the
+    // one part of the response that is present regardless of row count.
+    const response = outcome.value.response;
+    return { rows: rowsToObjects(response), columns: response.columns || [] };
   };
 
   /** An AGGREGATE query returns EXACTLY ONE row whose named columns are finite
@@ -738,8 +742,9 @@ export async function runDigest(env, deps = {}) {
    * one place every aggregate passes through, rather than at each call site
    * where the next query would forget. */
   const readAggregate = (index, name, fields) => {
-    const rows = read(index, name);
-    if (rows === null) return null; // already degraded and recorded
+    const result = read(index, name);
+    if (result === null) return null; // already degraded and recorded
+    const { rows } = result;
     if (rows.length !== 1) {
       failures.push(`${name}: expected exactly 1 aggregate row, got ${rows.length}`);
       return null;
@@ -764,9 +769,18 @@ export async function runDigest(env, deps = {}) {
    * publishing a confident attribution for a query whose shape had changed. So
    * the check is on PRESENCE plus type, never on truthiness, which cannot tell
    * "no source recorded" from "the column is gone". */
-  const readGrouped = (index, name) => {
-    const rows = read(index, name);
-    if (rows === null) return null;
+  const readGrouped = (index, name, columns) => {
+    const result = read(index, name);
+    if (result === null) return null;
+    const { rows } = result;
+    // Columns first: zero rows is a legitimate empty week here, so the row
+    // check below is skipped exactly when a malformed empty response arrives.
+    // Without this, a 200 with no rows and renamed columns reads as a confident
+    // "No off-site downloads yet".
+    if (!columns.every((c) => result.columns.includes(c))) {
+      failures.push(`${name}: malformed column set`);
+      return null;
+    }
     const bad = rows.find(
       (r) =>
         typeof r.n !== "number" ||
@@ -785,7 +799,7 @@ export async function runDigest(env, deps = {}) {
   try {
     site = readAggregate(0, "website", ["views", "visitors"]);
     downloads = readAggregate(1, "downloads", ["intents", "bots_excluded"]);
-    sources = readGrouped(2, "download_sources");
+    sources = readGrouped(2, "download_sources", ["bucket", "n"]);
     usage = prod ? readAggregate(3, "app_usage", ["active", "fresh"]) : null;
     funnel = prod ? readAggregate(4, "onboard_activate", ["onboarded", "activated"]) : null;
   } catch (err) {

--- a/workers/weekly-digest/src/index.js
+++ b/workers/weekly-digest/src/index.js
@@ -32,6 +32,7 @@
  */
 
 import {
+  ENV_ONLY,
   productionClauseFor,
   querySection,
   resolveDevIds,
@@ -322,6 +323,42 @@ export function appUsageSql(prod, win) {
     WHERE event = 'app.launched' AND ${prod} AND ${win}`;
 }
 
+/** The week's active-user population (successful dictators), used ONCE as an
+ * IN-membership test inside onboardActivateSql's `activated` column.
+ *
+ * Deliberately ${ENV_ONLY}, not the full production predicate. The argument is
+ * re-derived here rather than copied from the daily report's identical-looking
+ * subquery, because that file states plainly that its version is local and a
+ * new caller must not assume it: every row this set is tested against came from
+ * onboardActivateSql's own outer `WHERE ... AND ${prod}` on
+ * onboarding.completed, so a dev-tainted id can never appear on the OUTER side
+ * to begin with. Whether this inner set is also dev-filtered therefore cannot
+ * change which outer ids match. Applying the full predicate would evaluate the
+ * unbounded dev-exclusion a SECOND time inside one query, which is exactly the
+ * doubled-subquery shape that timed out production PostHog in #1655 and #1716.
+ *
+ * This argument is local to this one call site. */
+function activeUsersSubquery(win) {
+  return `SELECT DISTINCT distinct_id FROM events
+    WHERE event = 'dictation.completed' AND properties.result = 'success'
+      AND ${ENV_ONLY} AND ${win}`;
+}
+
+/** The onboarding funnel's second and third steps: who finished setup this
+ * week, and how many of those went on to dictate successfully.
+ *
+ * Founder's definition (2026-08-01): an install is someone who has begun
+ * onboarding, finishing setup is its own step, and ONE successful dictation is
+ * what counts as really using the app. Same three levels the daily report
+ * already reports per day. */
+export function onboardActivateSql(prod, win) {
+  return `SELECT
+      uniqExact(distinct_id) AS onboarded,
+      uniqExactIf(distinct_id, distinct_id IN (${activeUsersSubquery(win)})) AS activated
+    FROM events
+    WHERE event = 'onboarding.completed' AND ${prod} AND ${win}`;
+}
+
 /** Website traffic. NO production predicate, deliberately.
  *
  * `productionClauseFor` always begins `properties.environment = 'production'`,
@@ -484,15 +521,26 @@ export function formatDownloads(gh, sources, botsExcluded) {
  * product decision, raised with the founder separately; the daily report counts
  * the same property the same way (adoption.js:109) and carries the same
  * overstatement, so this is not a weekly-digest defect to fix in isolation. */
-export function formatAppUsage(usage) {
-  if (!usage) return ["App usage", `App usage figures were ${UNAVAILABLE} when this digest ran.`];
-  return [
-    "App usage",
-    `${n(usage.active)} people used EnviousWispr this week.`,
-    `${n(usage.fresh)} of them were new or had not finished setting up yet.`,
-    "",
-    "Dev machines are excluded from both numbers.",
-  ];
+export function formatAppUsage(usage, funnel) {
+  if (!usage && !funnel) {
+    return ["App usage", `App usage figures were ${UNAVAILABLE} when this digest ran.`];
+  }
+  const lines = ["App usage"];
+  lines.push(usage
+    ? `${n(usage.active)} people used EnviousWispr this week.`
+    : `The number of people who used the app was ${UNAVAILABLE}.`);
+  lines.push(usage
+    ? `New installs: ${n(usage.fresh)}.`
+    : `New installs were ${UNAVAILABLE}.`);
+  // The two steps after install, on the founder's definition (2026-08-01): an
+  // install is someone who has begun onboarding, finishing setup is its own
+  // step, and ONE successful dictation is what counts as really using it. Same
+  // three levels the daily report gives per day.
+  lines.push(funnel
+    ? `${n(funnel.onboarded)} people finished setting up. Of those, ${n(funnel.activated)} also dictated.`
+    : `Setup and first-dictation figures were ${UNAVAILABLE}.`);
+  lines.push("", "Dev machines are excluded from every number here.");
+  return lines;
 }
 
 /** One embed per section, and a REFUSAL of any shape Discord would reject,
@@ -602,6 +650,7 @@ export async function runDigest(env, deps = {}) {
   ];
   if (prod) {
     posthogTasks.push(() => querySection(env, appUsageSql(prod, window.win), "app_usage", hogqlOpts));
+    posthogTasks.push(() => querySection(env, onboardActivateSql(prod, window.win), "onboard_activate", hogqlOpts));
   }
 
   const [posthogOutcome, cfOutcome, ghOutcome] = await Promise.allSettled([
@@ -732,12 +781,13 @@ export async function runDigest(env, deps = {}) {
     return rows;
   };
 
-  let site, downloads, sources, usage;
+  let site, downloads, sources, usage, funnel;
   try {
     site = readAggregate(0, "website", ["views", "visitors"]);
     downloads = readAggregate(1, "downloads", ["intents", "bots_excluded"]);
     sources = readGrouped(2, "download_sources");
     usage = prod ? readAggregate(3, "app_usage", ["active", "fresh"]) : null;
+    funnel = prod ? readAggregate(4, "onboard_activate", ["onboarded", "activated"]) : null;
   } catch (err) {
     await postFailureNotice(env, label, { fetchFn });
     throw err;
@@ -752,7 +802,7 @@ export async function runDigest(env, deps = {}) {
       toEmbed(formatCloudflare(cf)),
       toEmbed(formatWebsite(site, downloads ? downloads.intents : null)),
       toEmbed(formatDownloads(gh, sources, downloads ? downloads.bots_excluded : null)),
-      toEmbed(formatAppUsage(usage)),
+      toEmbed(formatAppUsage(usage, funnel)),
     ],
   };
 

--- a/workers/weekly-digest/src/index.js
+++ b/workers/weekly-digest/src/index.js
@@ -469,12 +469,27 @@ export function formatDownloads(gh, sources, botsExcluded) {
   return lines;
 }
 
+/** KNOWN LIMIT in the second line, stated in the digest rather than hidden.
+ *
+ * `is_fresh_install` is not what its name suggests. The app derives it as
+ * `settings.onboardingState != .completed` (AppLifecycleCoordinator.swift:221),
+ * so it stays TRUE on every launch until setup is finished - someone who
+ * installs and never completes onboarding is flagged again every week they open
+ * the app. Measured 2026-08-01: 21 ids carried the flag on more than one day
+ * over 30 days, and this window reported 46 where 43 ids were genuinely
+ * launching for the first time.
+ *
+ * The wording therefore describes the population the number ACTUALLY has rather
+ * than claiming first-time installs. Changing WHICH metric is reported is a
+ * product decision, raised with the founder separately; the daily report counts
+ * the same property the same way (adoption.js:109) and carries the same
+ * overstatement, so this is not a weekly-digest defect to fix in isolation. */
 export function formatAppUsage(usage) {
   if (!usage) return ["App usage", `App usage figures were ${UNAVAILABLE} when this digest ran.`];
   return [
     "App usage",
     `${n(usage.active)} people used EnviousWispr this week.`,
-    `${n(usage.fresh)} of them installed it for the first time.`,
+    `${n(usage.fresh)} of them were new or had not finished setting up yet.`,
     "",
     "Dev machines are excluded from both numbers.",
   ];

--- a/workers/weekly-digest/src/index.js
+++ b/workers/weekly-digest/src/index.js
@@ -180,16 +180,34 @@ export async function fetchCloudflareStats(env, window, { fetchFn = fetch } = {}
   const zone = body?.data?.viewer?.zones?.[0];
   if (!zone) throw new Error("Cloudflare Analytics returned no zone");
 
+  // A 200 carrying a zone but no `totals`/`byDay` array, or groups missing
+  // their numeric fields, is malformed - NOT an empty week. `|| []` and `|| 0`
+  // would turn exactly that into a confident zero, which is the silent-zero
+  // failure this function exists to remove; it would just move one level
+  // deeper. An EMPTY array is still legitimate (a genuinely dead week), so the
+  // check is on the SHAPE, never on the length.
+  if (!Array.isArray(zone.totals) || !Array.isArray(zone.byDay)) {
+    throw new Error("Cloudflare Analytics returned a zone without totals/byDay");
+  }
+
   let totalRequests = 0, totalPageViews = 0, summedDailyUniques = 0;
   const countries = {};
-  for (const g of zone.totals || []) {
-    totalRequests += g.sum?.requests || 0;
-    totalPageViews += g.sum?.pageViews || 0;
-    summedDailyUniques += g.uniq?.uniques || 0;
+  const num = (value, field) => {
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+      throw new Error(`Cloudflare Analytics returned a non-numeric ${field}`);
+    }
+    return value;
+  };
+  for (const g of zone.totals) {
+    totalRequests += num(g?.sum?.requests, "requests");
+    totalPageViews += num(g?.sum?.pageViews, "pageViews");
+    summedDailyUniques += num(g?.uniq?.uniques, "uniques");
   }
-  for (const g of zone.byDay || []) {
-    for (const c of g.sum?.countryMap || []) {
-      countries[c.clientCountryName] = (countries[c.clientCountryName] || 0) + c.requests;
+  for (const g of zone.byDay) {
+    // countryMap may legitimately be absent for a day with no traffic; a
+    // PRESENT but malformed entry is not tolerated.
+    for (const c of g?.sum?.countryMap ?? []) {
+      countries[c.clientCountryName] = (countries[c.clientCountryName] || 0) + num(c?.requests, "countryMap.requests");
     }
   }
 
@@ -394,10 +412,15 @@ export function formatWebsite(site, intents) {
   lines.push(site
     ? `${n(site.visitors)} people viewed ${n(site.views)} pages on enviouswispr.com.`
     : `Visitor figures were ${UNAVAILABLE} when this digest ran.`);
+  // NOT "of them". `intents` counts download EVENTS - on-site clicks plus
+  // off-site doorway redirects - so it is neither a headcount nor a subset of
+  // the visitors above, and it can legitimately exceed them. Saying "of them"
+  // claimed both, and a sentence that overstates what a number means is the
+  // same defect class as a wrong number.
   lines.push(intents == null
-    ? `The number of people who started a download was ${UNAVAILABLE}.`
-    : `${n(intents)} of them started a download.`);
-  lines.push("", "This counts only people whose browser runs our analytics, so it reads lower than the traffic figures above.");
+    ? `Downloads started was ${UNAVAILABLE}.`
+    : `${n(intents)} downloads were started, counting on-site clicks and off-site links together.`);
+  lines.push("", "The visitor figures count only people whose browser runs our analytics, so they read lower than the traffic figures above.");
   return lines;
 }
 
@@ -571,12 +594,33 @@ export async function runDigest(env, deps = {}) {
     return rowsToObjects(outcome.value.response);
   };
 
+  /** An AGGREGATE query returns exactly one row, always: `uniqExact` and
+   * `countIf` over an empty window still produce a row of zeros. So an empty
+   * `results` array from a 200 is a malformed response, NOT a quiet week.
+   *
+   * Without this it fails in the worst available way: the section renders
+   * "temporarily unavailable" while `failures` stays empty, so the digest looks
+   * degraded to the founder and the run reports SUCCESS to the trigger. Broken
+   * telemetry would then look healthy for as long as nobody read the post. */
+  const readAggregate = (index, name) => {
+    const rows = read(index, name);
+    if (rows === null) return null; // already degraded and recorded
+    if (rows.length === 0) {
+      failures.push(`${name}: returned no aggregate row`);
+      return null;
+    }
+    return rows[0];
+  };
+
   let site, downloads, sources, usage;
   try {
-    site = read(0, "website")?.[0] ?? null;
-    downloads = read(1, "downloads")?.[0] ?? null;
+    site = readAggregate(0, "website");
+    downloads = readAggregate(1, "downloads");
+    // NOT an aggregate: a GROUP BY legitimately returns zero rows when there
+    // were no off-site downloads, and formatSourceBreakdown already renders
+    // that differently from unavailable.
     sources = read(2, "download_sources");
-    usage = prod ? (read(3, "app_usage")?.[0] ?? null) : null;
+    usage = prod ? readAggregate(3, "app_usage") : null;
   } catch (err) {
     await postFailureNotice(env, label, { fetchFn });
     throw err;

--- a/workers/weekly-digest/src/index.js
+++ b/workers/weekly-digest/src/index.js
@@ -60,6 +60,27 @@ const REPORT_DAYS = 7;
  * absence is a fact about today's DNS, not a guarantee. */
 const SITE_HOSTS = ["enviouswispr.com", "www.enviouswispr.com"];
 
+/**
+ * The trigger gate, as its own function so it can be tested without running a
+ * digest. Exported for that reason: the handler's only other path is
+ * `runDigest`, which reaches PostHog, Cloudflare, GitHub and Discord, so a test
+ * that drove the handler to prove the gate OPENS would either hit production or
+ * assert something weaker than "the gate opened". It did both, briefly.
+ *
+ * HEADER ONLY, deliberately. A `?token=` form would put the secret in the URL,
+ * where it survives in browser and shell history, proxies and request logs;
+ * leaking it restores exactly the unauthenticated Discord-posting access this
+ * gate exists to close. The daily report also accepts a query param -
+ * pre-existing, out of scope here, and not a reason to copy it.
+ *
+ * Fails CLOSED: an unset TRIGGER_SECRET refuses everything, so a
+ * half-configured deploy cannot be triggered by anyone.
+ */
+export function isAuthorizedTrigger(request, env) {
+  if (!env.TRIGGER_SECRET) return false;
+  return request.headers.get("x-trigger-secret") === env.TRIGGER_SECRET;
+}
+
 export default {
   async scheduled(event, env) {
     await runDigest(env);
@@ -72,13 +93,7 @@ export default {
    * cannot be triggered by anyone.
    */
   async fetch(request, env) {
-    // HEADER ONLY, deliberately. A `?token=` form would put the secret in the
-    // URL, where it survives in browser and shell history, proxies and request
-    // logs; leaking it restores exactly the unauthenticated Discord-posting
-    // access this gate exists to close. The daily report also accepts a query
-    // param - pre-existing, out of scope here, and not a reason to copy it.
-    const provided = request.headers.get("x-trigger-secret");
-    if (!env.TRIGGER_SECRET || provided !== env.TRIGGER_SECRET) {
+    if (!isAuthorizedTrigger(request, env)) {
       return new Response("unauthorized\n", { status: 401 });
     }
     try {

--- a/workers/weekly-digest/src/index.js
+++ b/workers/weekly-digest/src/index.js
@@ -72,8 +72,12 @@ export default {
    * cannot be triggered by anyone.
    */
   async fetch(request, env) {
-    const url = new URL(request.url);
-    const provided = url.searchParams.get("token") || request.headers.get("x-trigger-secret");
+    // HEADER ONLY, deliberately. A `?token=` form would put the secret in the
+    // URL, where it survives in browser and shell history, proxies and request
+    // logs; leaking it restores exactly the unauthenticated Discord-posting
+    // access this gate exists to close. The daily report also accepts a query
+    // param - pre-existing, out of scope here, and not a reason to copy it.
+    const provided = request.headers.get("x-trigger-secret");
     if (!env.TRIGGER_SECRET || provided !== env.TRIGGER_SECRET) {
       return new Response("unauthorized\n", { status: 401 });
     }
@@ -309,18 +313,31 @@ const hostFilter = `properties.$host IN (${SITE_HOSTS.map((h) => `'${h}'`).join(
 
 /** App usage. The ONLY query carrying the production predicate.
  *
- * `uniqExact` over the whole window, replacing a TrendsQuery whose two weekly
- * buckets were summed. New installs uses the app's own is_fresh_install rather
- * than PostHog's first_time_for_user (founder decision 2026-08-01): it is what
- * the daily report counts, and reproducing first_time_for_user in HogQL needs a
+ * `uniqExactIf` over the whole window, replacing a TrendsQuery whose two weekly
+ * buckets were summed.
+ *
+ * ACTIVE means one successful DICTATION, not a launch (founder definition
+ * 2026-08-01: "I consider doing at least one successful dictation as a sign of
+ * usage"). Counting launches would include everyone who opened the app and
+ * never dictated, under a sentence that says they used it - and it would make
+ * the weekly headline a different metric from the daily report's, which has
+ * always counted successful dictators.
+ *
+ * FRESH still comes from app.launched, because is_fresh_install rides on that
+ * event. Both live in ONE query over the two event types rather than two round
+ * trips; `WHERE event IN (...)` keeps it scoped.
+ *
+ * New installs uses the app's own is_fresh_install rather than PostHog's
+ * first_time_for_user (founder decision 2026-08-01): it is what the daily
+ * report counts, and reproducing first_time_for_user in HogQL needs a
  * whole-history min(timestamp) per user, the unbounded-scan shape that caused
  * the #1655 and #1716 timeouts. */
 export function appUsageSql(prod, win) {
   return `SELECT
-      uniqExact(distinct_id) AS active,
-      uniqExactIf(distinct_id, properties.is_fresh_install = true) AS fresh
+      uniqExactIf(distinct_id, event = 'dictation.completed' AND properties.result = 'success') AS active,
+      uniqExactIf(distinct_id, event = 'app.launched' AND properties.is_fresh_install = true) AS fresh
     FROM events
-    WHERE event = 'app.launched' AND ${prod} AND ${win}`;
+    WHERE event IN ('dictation.completed', 'app.launched') AND ${prod} AND ${win}`;
 }
 
 /** The week's active-user population (successful dictators), used ONCE as an

--- a/workers/weekly-digest/test/digest.test.js
+++ b/workers/weekly-digest/test/digest.test.js
@@ -57,6 +57,7 @@ const POSTHOG_ROWS = {
   downloads: { results: [[36, 11]], columns: ["intents", "bots_excluded"] },
   download_sources: { results: [["github_readme", 20], ["reddit", 8]], columns: ["bucket", "n"] },
   app_usage: { results: [[189, 51]], columns: ["active", "fresh"] },
+  onboard_activate: { results: [[31, 24]], columns: ["onboarded", "activated"] },
 };
 
 const CF_BODY = {
@@ -213,11 +214,11 @@ test("never more than 2 PostHog requests in flight, and the cap is actually reac
   assert.equal(h.state.peakInFlight, 2, "cap must be reached, not merely never exceeded");
 });
 
-test("a clean run makes exactly 5 PostHog requests: 1 preflight + 4 metrics", async () => {
+test("a clean run makes exactly 6 PostHog requests: 1 preflight + 5 metrics", async () => {
   const h = harness();
   await h.run();
   // Equality, so both an added query and a silently dropped one fail.
-  assert.equal(h.state.posthogCalls, 5);
+  assert.equal(h.state.posthogCalls, 6);
   assert.equal(h.state.queryNames.filter((q) => q === "weekly_digest_dev_ids").length, 1);
 });
 
@@ -229,6 +230,7 @@ test("every query name carries the weekly_digest label, never daily_report", asy
     "weekly_digest_dev_ids",
     "weekly_digest_download_sources",
     "weekly_digest_downloads",
+    "weekly_digest_onboard_activate",
     "weekly_digest_website",
   ]);
 });
@@ -477,11 +479,11 @@ test("formatSourceBreakdown: unavailable, genuine zero, and rows read differentl
 });
 
 test("every formatter degrades to prose, never to a number, when its input is null", () => {
-  for (const lines of [formatCloudflare(null), formatWebsite(null, null), formatDownloads(null, null, null), formatAppUsage(null)]) {
+  for (const lines of [formatCloudflare(null), formatWebsite(null, null), formatDownloads(null, null, null), formatAppUsage(null, null)]) {
     assert.match(lines.join("\n"), /temporarily unavailable/);
   }
   // Title line must survive so the embed is still well-formed.
-  assert.equal(formatAppUsage(null)[0], "App usage");
+  assert.equal(formatAppUsage(null, null)[0], "App usage");
 });
 
 test("formatters produce a title line plus a non-empty body of strings", () => {
@@ -489,7 +491,7 @@ test("formatters produce a title line plus a non-empty body of strings", () => {
     formatCloudflare({ totalPageViews: 1, summedDailyUniques: 2, totalRequests: 3, topCountries: [] }),
     formatWebsite({ views: 1, visitors: 2 }, 3),
     formatDownloads({ totalDownloads: 1, latestVersion: "v1" }, [], 0),
-    formatAppUsage({ active: 1, fresh: 2 }),
+    formatAppUsage({ active: 1, fresh: 2 }, { onboarded: 1, activated: 1 }),
   ];
   for (const lines of cases) {
     assert.ok(lines.length >= 2);
@@ -726,6 +728,54 @@ test("the app-usage line does not claim first-time installs it cannot prove", as
   const h = harness();
   await h.run();
   const text = h.state.posts[0].embeds[3].description;
-  assert.match(text, /new or had not finished setting up/);
+  assert.match(text, /New installs: 51\./);
+  assert.match(text, /31 people finished setting up\. Of those, 24 also dictated\./);
+  // The install number is launches-without-completed-onboarding, so it must not
+  // claim first-time installs it cannot prove.
   assert.doesNotMatch(text, /installed it for the first time/);
+});
+
+test("the onboarding funnel reads install, setup, then first dictation", async () => {
+  const h = harness();
+  await h.run();
+  const text = h.state.posts[0].embeds[3].description;
+  assert.match(text, /189 people used EnviousWispr this week\./);
+  assert.match(text, /New installs: 51\./);
+  assert.match(text, /31 people finished setting up\. Of those, 24 also dictated\./);
+});
+
+test("the activation subquery is dev-filtered by environment ONLY, never twice", async () => {
+  const h = harness();
+  await h.run();
+  const sql = h.state.sql.find((q) => q.includes("onboarding.completed"));
+  // The outer WHERE carries the full predicate, including the dev-id list.
+  assert.match(sql, /WHERE event = 'onboarding\.completed' AND properties\.environment = 'production'/);
+  assert.match(sql, /distinct_id NOT IN \('dev-a', 'dev-b'\)/);
+  // The inner membership set carries environment only. Evaluating the unbounded
+  // dev-exclusion a second time inside one query is the doubled-subquery shape
+  // that timed out production PostHog in #1655 and #1716.
+  assert.equal(sql.split("distinct_id NOT IN").length - 1, 1, "dev exclusion must appear exactly once");
+  assert.match(sql, /dictation\.completed' AND properties\.result = 'success'\s*\n\s*AND properties\.environment = 'production'/);
+});
+
+test("the funnel degrades with app usage when dev ids cannot be resolved", async () => {
+  const h = harness({ posthog: { dev_ids: () => fail(503) } });
+  await assert.rejects(() => h.run(), /unavailable sections/);
+  const text = h.state.posts[0].embeds[3].description;
+  assert.match(text, /temporarily unavailable/);
+  assert.equal(h.state.queryNames.includes("weekly_digest_onboard_activate"), false);
+});
+
+test("a failed funnel query leaves the usage line intact, and vice versa", async () => {
+  const funnelDown = harness({ posthog: { onboard_activate: () => fail(503) } });
+  await assert.rejects(() => funnelDown.run(), /unavailable sections/);
+  const a = funnelDown.state.posts[0].embeds[3].description;
+  assert.match(a, /189 people used EnviousWispr/);
+  assert.match(a, /Setup and first-dictation figures were temporarily unavailable/);
+
+  const usageDown = harness({ posthog: { app_usage: () => fail(503) } });
+  await assert.rejects(() => usageDown.run(), /unavailable sections/);
+  const b = usageDown.state.posts[0].embeds[3].description;
+  assert.match(b, /31 people finished setting up/);
+  assert.match(b, /New installs were temporarily unavailable/);
 });

--- a/workers/weekly-digest/test/digest.test.js
+++ b/workers/weekly-digest/test/digest.test.js
@@ -200,10 +200,10 @@ test("the merged downloads query preserves both original predicates", () => {
 
 test("app usage counts fresh installs by the app's own flag, not PostHog first-seen", () => {
   const sql = appUsageSql("P", "W");
-  assert.match(sql, /uniqExactIf\(distinct_id, properties\.is_fresh_install = true\)/);
-  // A single uniqExact over the window, never per-bucket counts a caller could
-  // sum into a double count.
-  assert.match(sql, /uniqExact\(distinct_id\) AS active/);
+  assert.match(sql, /uniqExactIf\(distinct_id, event = 'app\.launched' AND properties\.is_fresh_install = true\)/);
+  // Single whole-window uniqExactIf counts, never per-bucket counts a caller
+  // could sum into a double count.
+  assert.doesNotMatch(sql, /interval/i);
 });
 
 // ---- Concurrency, retry, request count ---------------------------------------
@@ -348,12 +348,35 @@ test("a wrong token is refused", async () => {
   assert.equal(res.status, 401);
 });
 
+test("the query-string form is refused even when the value is CORRECT", async () => {
+  // Header only: a secret in a URL survives in browser and shell history,
+  // proxies and request logs, and leaking it restores the unauthenticated
+  // Discord-posting access this gate closes.
+  const res = await worker.fetch(new Request("https://w.dev/?token=s3cret"), ENV);
+  assert.equal(res.status, 401);
+});
+
+test("the correct header is accepted and runs the digest", async () => {
+  const h = harness();
+  const res = await worker.fetch(
+    new Request("https://w.dev/", { headers: { "x-trigger-secret": "s3cret" } }),
+    { ...ENV, POSTHOG_PERSONAL_API_KEY: "k" }
+  );
+  // The real handler calls runDigest with production fetch, which the test
+  // environment cannot reach, so a non-401 is what this asserts: the gate
+  // OPENED. Behaviour past the gate is covered by the runDigest suites.
+  assert.notEqual(res.status, 401);
+});
+
 test("an unset TRIGGER_SECRET refuses everything, including a supplied token", async () => {
   const { TRIGGER_SECRET, ...noSecret } = ENV;
   for (const url of ["https://w.dev/", "https://w.dev/?token=s3cret", "https://w.dev/?token="]) {
     const res = await worker.fetch(new Request(url), noSecret);
     assert.equal(res.status, 401, `${url} must fail closed`);
   }
+  const withHeader = await worker.fetch(
+    new Request("https://w.dev/", { headers: { "x-trigger-secret": "s3cret" } }), noSecret);
+  assert.equal(withHeader.status, 401, "an unset secret must refuse the header form too");
 });
 
 test("a wrong header-form trigger secret is refused too", async () => {
@@ -813,4 +836,27 @@ test("a genuinely empty response WITH valid columns is still a real empty week",
   await h.run();
   assert.match(h.state.posts[0].embeds[2].description, /No off-site downloads yet/);
   assert.match(h.state.posts[0].embeds[3].description, /189 people used EnviousWispr/);
+});
+
+test("the usage headline counts successful DICTATORS, not launches", async () => {
+  const h = harness();
+  await h.run();
+  const sql = h.state.sql.find((q) => q.includes("is_fresh_install"));
+  // Founder definition: one successful dictation is what counts as using it.
+  assert.match(sql, /uniqExactIf\(distinct_id, event = 'dictation\.completed' AND properties\.result = 'success'\) AS active/);
+  assert.match(sql, /uniqExactIf\(distinct_id, event = 'app\.launched' AND properties\.is_fresh_install = true\) AS fresh/);
+  // One round trip over both event types, scoped so it does not scan everything.
+  assert.match(sql, /WHERE event IN \('dictation\.completed', 'app\.launched'\)/);
+});
+
+test("dev ids are read by column NAME, not by position", async () => {
+  // A response with distinct_id in a later column passed the name check and
+  // then read the wrong column, excluding ids nobody has.
+  const h = harness({ posthog: {
+    dev_ids: () => ok({ results: [["2026-08-01", "dev-a"]], columns: ["day", "distinct_id"] }),
+  } });
+  await h.run();
+  const sql = h.state.sql.find((q) => q.includes("is_fresh_install"));
+  assert.match(sql, /NOT IN \('dev-a'\)/);
+  assert.doesNotMatch(sql, /2026-08-01/);
 });

--- a/workers/weekly-digest/test/digest.test.js
+++ b/workers/weekly-digest/test/digest.test.js
@@ -517,3 +517,59 @@ test("fetchCloudflareStats and fetchGitHubDownloads are callable in isolation", 
   assert.equal(gh.totalDownloads, 20);
   assert.equal(gh.latestVersion, "v1.1.0");
 });
+
+// ---- Whole-diff review findings (#1589) --------------------------------------
+
+test("an empty aggregate row is a failure, never a silently 'unavailable' success", async () => {
+  // The trap this closes: the section renders "temporarily unavailable" while
+  // the run RESOLVES, so a degraded digest reports success to the trigger and
+  // broken telemetry looks healthy for as long as nobody reads the post.
+  for (const [key, embedIndex] of [["website", 1], ["downloads", 2], ["app_usage", 3]]) {
+    const h = harness({ posthog: { [key]: () => ok({ results: [], columns: [] }) } });
+    await assert.rejects(() => h.run(), /returned no aggregate row/,
+      `${key} returning no row must fail the run, not resolve it`);
+    assert.equal(h.state.posts.length, 1);
+    assert.match(h.state.posts[0].embeds[embedIndex].description, /temporarily unavailable/);
+  }
+});
+
+test("download sources returning zero rows is a genuine empty week, not a failure", async () => {
+  // The two-way control for the test above: a GROUP BY legitimately returns no
+  // rows, and treating THAT as malformed would fail every quiet week.
+  const h = harness({ posthog: { download_sources: () => ok({ results: [], columns: ["bucket", "n"] }) } });
+  await h.run();
+  assert.match(h.state.posts[0].embeds[2].description, /No off-site downloads yet/);
+  assert.doesNotMatch(h.state.posts[0].embeds[2].description, /Sources unavailable/);
+});
+
+test("a Cloudflare 200 with a malformed zone degrades instead of reporting zeros", async () => {
+  const malformed = [
+    { data: { viewer: { zones: [{ byDay: [] }] } } },                       // no totals
+    { data: { viewer: { zones: [{ totals: [] }] } } },                      // no byDay
+    { data: { viewer: { zones: [{ totals: [{ sum: {} }], byDay: [] }] } } }, // no numbers
+    { data: { viewer: { zones: [{ totals: [{ sum: { requests: "many", pageViews: 1 }, uniq: { uniques: 1 } }], byDay: [] }] } } },
+  ];
+  for (const body of malformed) {
+    const h = harness({ cloudflare: () => ok(body) });
+    await assert.rejects(() => h.run(), /unavailable sections/);
+    const traffic = h.state.posts[0].embeds[0].description;
+    assert.match(traffic, /temporarily unavailable/);
+    assert.doesNotMatch(traffic, /\b0 page views\b/, "a malformed response must never render as zero");
+  }
+});
+
+test("the download line does not claim to be a subset of tracked visitors", async () => {
+  // `intents` counts EVENTS, including off-site redirects that never appeared
+  // in the pageview population, so it can legitimately exceed the visitor
+  // count. "N of them" claimed both a headcount and a subset.
+  const h = harness({ posthog: {
+    website: () => ok({ results: [[201, 105]], columns: ["views", "visitors"] }),
+    downloads: () => ok({ results: [[400, 2]], columns: ["intents", "bots_excluded"] }),
+  } });
+  await h.run();
+  const text = h.state.posts[0].embeds[1].description;
+  assert.match(text, /400 downloads were started/);
+  assert.doesNotMatch(text, /of them/);
+  // The scenario that proves the point: more downloads than tracked visitors.
+  assert.match(text, /105 people viewed/);
+});

--- a/workers/weekly-digest/test/digest.test.js
+++ b/workers/weekly-digest/test/digest.test.js
@@ -1,131 +1,519 @@
-// Unit tests for the pure query-builder / extractor / formatter helpers (no network).
-// Run: node --test  (from workers/weekly-digest/)
+/**
+ * Weekly digest tests (#1243, #1589).
+ *
+ * The #1589 suites drive the REAL `runDigest` with fetch intercepted, rather
+ * than re-assembling the digest from its parts. A harness that re-implements
+ * the orchestration is a second authority: it passes happily while production
+ * takes another path.
+ */
+
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import {
-  downloadIntentsHogQL,
-  downloadSourcesHogQL,
-  botExcludedHogQL,
-  extractTrendTotal,
-  extractHogScalar,
-  extractHogRows,
+
+import worker, {
+  runDigest,
+  resolveWeekWindow,
+  fetchCloudflareStats,
+  fetchGitHubDownloads,
+  appUsageSql,
+  websiteSql,
+  downloadsSql,
+  downloadSourcesSql,
   sourceLabel,
   formatSourceBreakdown,
-  buildEmbed,
+  formatCloudflare,
+  formatWebsite,
+  formatDownloads,
+  formatAppUsage,
+  SOURCE_LABELS,
 } from "../src/index.js";
 
-// ---- HogQL builders: must qualify every event-property as properties.<name> ----
-// A bare excluded_reason / source_bucket (not preceded by "properties.") would fail
-// in PostHog HogQL. This regex catches the regression Codex flagged twice.
-const BARE_PROP = /(?<!properties\.)\b(excluded_reason|source_bucket)\b/;
+// Every event-property reference must be qualified as properties.<name>: a bare
+// name does not resolve in PostHog HogQL. This regex catches the regression
+// Codex flagged twice on the pre-#1589 builders.
+const BARE_PROP = /(?<!properties\.)\b(excluded_reason|source_bucket|is_fresh_install|app_version)\b/;
 
-test("downloadIntentsHogQL: union of both events, bot-excluded, fully qualified", () => {
-  const q = downloadIntentsHogQL("2026-06-23", "2026-06-30");
-  assert.match(q, /event = 'download_clicked'/);
-  assert.match(q, /event = 'download_redirect'/);
-  assert.match(q, /coalesce\(properties\.excluded_reason, ''\) = ''/);
-  assert.ok(!BARE_PROP.test(q), "no bare event-property refs allowed");
-  assert.match(q, /2026-06-23/);
-  assert.match(q, /2026-06-30/);
+const ENV = {
+  POSTHOG_PROJECT_ID: "354235",
+  POSTHOG_PERSONAL_API_KEY: "k",
+  CF_ZONE_ID: "zone",
+  CF_EMAIL: "e",
+  CF_API_KEY: "cfk",
+  GITHUB_REPO: "saurabhav88/EnviousWispr",
+  DISCORD_WEBHOOK_URL: "https://discord.test/hook",
+  TRIGGER_SECRET: "s3cret",
+};
+
+// Pinned so the window is deterministic: Monday 2026-08-03 13:00 UTC ->
+// window 2026-07-27 .. 2026-08-03 exclusive, last included day 2026-08-02.
+const NOW = new Date("2026-08-03T13:00:00Z");
+
+const ok = (body) => ({ ok: true, status: 200, json: async () => body });
+const fail = (status) => ({ ok: false, status, json: async () => ({}), body: { cancel: async () => {} } });
+
+const POSTHOG_ROWS = {
+  dev_ids: { results: [["dev-a"], ["dev-b"]], columns: ["distinct_id"] },
+  website: { results: [[226, 119]], columns: ["views", "visitors"] },
+  downloads: { results: [[36, 11]], columns: ["intents", "bots_excluded"] },
+  download_sources: { results: [["github_readme", 20], ["reddit", 8]], columns: ["bucket", "n"] },
+  app_usage: { results: [[189, 51]], columns: ["active", "fresh"] },
+};
+
+const CF_BODY = {
+  data: { viewer: { zones: [{
+    totals: [{ sum: { requests: 5000, pageViews: 900 }, uniq: { uniques: 300 } }],
+    byDay: [{ dimensions: { date: "2026-07-27" }, sum: { pageViews: 100, countryMap: [
+      { clientCountryName: "United States", requests: 3000 },
+      { clientCountryName: "India", requests: 900 },
+    ] } }],
+  }] } },
+};
+
+const RELEASES_PAGE = (count, startTag = 1) =>
+  Array.from({ length: count }, (_, i) => ({
+    tag_name: `v1.${startTag + i}.0`,
+    assets: [{ name: "EnviousWispr.dmg", download_count: 10 }],
+  }));
+
+/**
+ * One harness driving the real runDigest. `overrides` replaces individual
+ * PostHog query responses (keyed by the UNPREFIXED query name) or the
+ * Cloudflare / GitHub behaviour.
+ */
+function harness(overrides = {}) {
+  const state = { posts: [], queryNames: [], inFlight: 0, peakInFlight: 0, posthogCalls: 0, githubPages: [], sql: [] };
+
+  const fetchFn = async (url, init) => {
+    if (String(url).includes("posthog.com")) {
+      state.posthogCalls += 1;
+      state.inFlight += 1;
+      state.peakInFlight = Math.max(state.peakInFlight, state.inFlight);
+      try {
+        const body = JSON.parse(init.body);
+        const name = body.name;
+        state.queryNames.push(name);
+        state.sql.push(body.query.query);
+        assert.ok(name.startsWith("weekly_digest_"), `query name must carry the worker label, got ${name}`);
+        const key = name.replace(/^weekly_digest_/, "");
+        // Yield, so concurrent work actually overlaps and peakInFlight means
+        // something rather than recording a sequence of instant resolutions.
+        await new Promise((r) => setImmediate(r));
+        const override = overrides.posthog?.[key];
+        if (typeof override === "function") return override();
+        return ok(POSTHOG_ROWS[key] ?? { results: [], columns: [] });
+      } finally {
+        state.inFlight -= 1;
+      }
+    }
+    if (String(url).includes("api.cloudflare.com")) {
+      return overrides.cloudflare ? overrides.cloudflare() : ok(CF_BODY);
+    }
+    if (String(url).includes("api.github.com")) {
+      const page = Number(new URL(url).searchParams.get("page"));
+      state.githubPages.push(page);
+      if (overrides.github) return overrides.github(page);
+      return ok(page === 1 ? RELEASES_PAGE(100) : RELEASES_PAGE(45, 101));
+    }
+    if (String(url).includes("discord.test")) {
+      state.posts.push(JSON.parse(init.body));
+      return { status: 204 };
+    }
+    throw new Error(`unexpected fetch to ${url}`);
+  };
+
+  const run = (env = ENV) =>
+    runDigest(env, { fetchFn, now: NOW, hogqlOpts: { fetchFn, sleepFn: async () => {}, randomFn: () => 0 } });
+
+  return { state, fetchFn, run };
+}
+
+// ---- Window ------------------------------------------------------------------
+
+test("the window is seven whole UTC days, half-open, with no shared day", () => {
+  const w = resolveWeekWindow(NOW);
+  assert.equal(w.startDay, "2026-07-27");
+  assert.equal(w.lastDay, "2026-08-02");
+  assert.equal(w.end.toISOString(), "2026-08-03T00:00:00.000Z");
+  // Seven days, not the eight the shipped worker measured.
+  assert.equal((w.end - w.start) / 86400000, 7);
+  // Exclusive end: consecutive weeks must not share a day.
+  const next = resolveWeekWindow(new Date("2026-08-10T13:00:00Z"));
+  assert.equal(next.startDay, "2026-08-03");
+  assert.equal(w.lastDay < next.startDay, true);
 });
 
-test("downloadSourcesHogQL: groups off-site only by qualified source_bucket", () => {
-  const q = downloadSourcesHogQL("2026-06-23", "2026-06-30");
-  assert.match(q, /properties\.source_bucket/);
-  assert.match(q, /event = 'download_redirect'/);
-  assert.ok(!/download_clicked/.test(q), "source breakdown must be off-site only");
-  assert.match(q, /coalesce\(properties\.excluded_reason, ''\) = ''/);
-  assert.match(q, /GROUP BY bucket/);
-  assert.ok(!BARE_PROP.test(q), "no bare event-property refs allowed");
+test("the SQL window clause is half-open, never an inclusive toDate range", () => {
+  const w = resolveWeekWindow(NOW);
+  assert.match(w.win, /timestamp >= '2026-07-27 00:00:00' AND timestamp < '2026-08-03 00:00:00'/);
+  // An inclusive `<=` is what reintroduces the eighth day and the double count.
+  assert.doesNotMatch(w.win, /<=/);
 });
 
-test("botExcludedHogQL: counts non-empty excluded_reason, qualified", () => {
-  const q = botExcludedHogQL("2026-06-23", "2026-06-30");
-  assert.match(q, /coalesce\(properties\.excluded_reason, ''\) != ''/);
-  assert.match(q, /event = 'download_redirect'/);
-  assert.ok(!BARE_PROP.test(q), "no bare event-property refs allowed");
+// ---- Query shape -------------------------------------------------------------
+
+test("every event property is qualified as properties.<name>", () => {
+  const win = "timestamp >= 'x' AND timestamp < 'y'";
+  for (const sql of [appUsageSql("P", win), websiteSql(win), downloadsSql(win), downloadSourcesSql(win)]) {
+    assert.doesNotMatch(sql, BARE_PROP);
+  }
 });
 
-// ---- extractors ----
-test("extractHogScalar: first cell, '?' fallbacks", () => {
-  assert.equal(extractHogScalar({ results: [[5]] }), 5);
-  assert.equal(extractHogScalar({ results: [[0]] }), 0); // zero is a real count, not "?"
-  assert.equal(extractHogScalar({ results: [] }), "?");
-  assert.equal(extractHogScalar(null), "?");
-  assert.equal(extractHogScalar({}), "?");
+test("app usage carries the production predicate; website and downloads do NOT", () => {
+  const prod = "properties.environment = 'production'\n    AND distinct_id NOT IN ('dev-a')";
+  const win = "timestamp >= 'x' AND timestamp < 'y'";
+  assert.match(appUsageSql(prod, win), /environment = 'production'/);
+  assert.match(appUsageSql(prod, win), /distinct_id NOT IN/);
+  // Website events carry no environment property at all, so the production
+  // predicate would return ZERO rather than the same rows more slowly.
+  for (const sql of [websiteSql(win), downloadsSql(win), downloadSourcesSql(win)]) {
+    assert.doesNotMatch(sql, /environment = 'production'/);
+    assert.doesNotMatch(sql, /distinct_id NOT IN/);
+  }
 });
 
-test("extractHogRows: passthrough; null on failure (unknown != empty)", () => {
-  assert.deepEqual(extractHogRows({ results: [["reddit", 2], ["blog", 1]] }), [["reddit", 2], ["blog", 1]]);
-  assert.deepEqual(extractHogRows({ results: [] }), []); // genuine zero week is a real []
-  assert.equal(extractHogRows(null), null); // failed query -> unknown, NOT empty
-  assert.equal(extractHogRows({ results: "nope" }), null);
+test("only the pageview query is host-scoped; download queries must NOT be", () => {
+  const win = "timestamp >= 'x' AND timestamp < 'y'";
+  assert.match(websiteSql(win), /properties\.\$host IN \('enviouswispr\.com', 'www\.enviouswispr\.com'\)/);
+  // download_redirect is emitted server-side with no $host, so a host filter
+  // here would silently drop every off-site redirect.
+  assert.doesNotMatch(downloadsSql(win), /\$host/);
+  assert.doesNotMatch(downloadSourcesSql(win), /\$host/);
 });
 
-test("extractTrendTotal: aggregated_value, summed data, fallback", () => {
-  assert.equal(extractTrendTotal({ results: [{ aggregated_value: 12 }] }, 0), 12);
-  assert.equal(extractTrendTotal({ results: [{ data: [1, 2, 3] }] }, 0), 6);
-  assert.equal(extractTrendTotal({ results: [] }, 0), "?");
-  assert.equal(extractTrendTotal(null, 0), "?");
+test("no query interpolates the production predicate more than once", () => {
+  const prod = "properties.environment = 'production'";
+  const win = "timestamp >= 'x' AND timestamp < 'y'";
+  // Repeating an unbounded dev-exclusion predicate inside one query is the
+  // shape that timed out production PostHog in #1655 and #1716.
+  assert.equal(appUsageSql(prod, win).split(prod).length - 1, 1);
 });
 
-// ---- labels / formatting ----
+test("the merged downloads query preserves both original predicates", () => {
+  const sql = downloadsSql("W");
+  assert.match(sql, /event = 'download_clicked'/);
+  assert.match(sql, /event = 'download_redirect' AND coalesce\(properties\.excluded_reason, ''\) = ''/);
+  assert.match(sql, /coalesce\(properties\.excluded_reason, ''\) != ''/);
+  // Scoped to the two relevant event types, or the merge scans everything.
+  assert.match(sql, /WHERE event IN \('download_clicked', 'download_redirect'\)/);
+});
+
+test("app usage counts fresh installs by the app's own flag, not PostHog first-seen", () => {
+  const sql = appUsageSql("P", "W");
+  assert.match(sql, /uniqExactIf\(distinct_id, properties\.is_fresh_install = true\)/);
+  // A single uniqExact over the window, never per-bucket counts a caller could
+  // sum into a double count.
+  assert.match(sql, /uniqExact\(distinct_id\) AS active/);
+});
+
+// ---- Concurrency, retry, request count ---------------------------------------
+
+test("never more than 2 PostHog requests in flight, and the cap is actually reached", async () => {
+  const h = harness();
+  await h.run();
+  assert.equal(h.state.peakInFlight, 2, "cap must be reached, not merely never exceeded");
+});
+
+test("a clean run makes exactly 5 PostHog requests: 1 preflight + 4 metrics", async () => {
+  const h = harness();
+  await h.run();
+  // Equality, so both an added query and a silently dropped one fail.
+  assert.equal(h.state.posthogCalls, 5);
+  assert.equal(h.state.queryNames.filter((q) => q === "weekly_digest_dev_ids").length, 1);
+});
+
+test("every query name carries the weekly_digest label, never daily_report", async () => {
+  const h = harness();
+  await h.run();
+  assert.deepEqual(h.state.queryNames.slice().sort(), [
+    "weekly_digest_app_usage",
+    "weekly_digest_dev_ids",
+    "weekly_digest_download_sources",
+    "weekly_digest_downloads",
+    "weekly_digest_website",
+  ]);
+});
+
+test("a 504 that then succeeds still produces a complete digest", async () => {
+  let attempts = 0;
+  const h = harness({ posthog: { website: () => {
+    attempts += 1;
+    return attempts === 1 ? fail(504) : ok(POSTHOG_ROWS.website);
+  } } });
+  const content = await h.run();
+  assert.match(content, /EnviousWispr Weekly Digest/);
+  assert.equal(attempts, 2);
+  assert.equal(h.state.posts.length, 1);
+  assert.match(h.state.posts[0].embeds[1].description, /119 people viewed 226 pages/);
+});
+
+// ---- Degrade: no number may appear when its query failed ----------------------
+
+test("an exhausted section degrades, the others keep real numbers, one digest posts", async () => {
+  const h = harness({ posthog: { website: () => fail(503) } });
+  await assert.rejects(() => h.run(), /unavailable sections/);
+  assert.equal(h.state.posts.length, 1, "exactly one digest, never a second notice");
+  const [digest] = h.state.posts;
+  const website = digest.embeds[1].description;
+  assert.match(website, /temporarily unavailable/);
+  // The degraded section must not fabricate a zero.
+  assert.doesNotMatch(website, /\b0 people\b/);
+  // Every other section still carries its real figures.
+  assert.match(digest.embeds[3].description, /189 people used EnviousWispr/);
+  assert.match(digest.embeds[0].description, /900 page views/);
+});
+
+test("a healthy run says 'temporarily unavailable' nowhere and prints no question marks", async () => {
+  const h = harness();
+  await h.run();
+  const text = JSON.stringify(h.state.posts[0]);
+  // Two-way control: without this, a degrade-everything bug passes every
+  // failure test above.
+  assert.doesNotMatch(text, /temporarily unavailable/);
+  assert.doesNotMatch(text, /\?/);
+});
+
+// ---- dev_ids is an app-usage dependency, NOT a whole-run gate -----------------
+
+test("dev_ids exhausted: app usage degrades, three sections still deliver", async () => {
+  const h = harness({ posthog: { dev_ids: () => fail(503) } });
+  await assert.rejects(() => h.run(), /unavailable sections/);
+  assert.equal(h.state.posts.length, 1);
+  const [digest] = h.state.posts;
+  assert.match(digest.embeds[3].description, /temporarily unavailable/);
+  assert.match(digest.embeds[0].description, /900 page views/);
+  assert.match(digest.embeds[1].description, /119 people viewed/);
+  // No app_usage query may be attempted without a resolved exclusion list.
+  assert.equal(h.state.queryNames.includes("weekly_digest_app_usage"), false);
+  // A partial digest was delivered, so the whole-run notice must NOT appear.
+  assert.equal(h.state.posts.filter((p) => /could not be generated/.test(p.content || "")).length, 0);
+});
+
+test("dev_ids overflowing the id ceiling degrades app usage, never truncates the list", async () => {
+  const many = { results: Array.from({ length: 5001 }, (_, i) => [`dev-${i}`]), columns: ["distinct_id"] };
+  const h = harness({ posthog: { dev_ids: () => ok(many) } });
+  await assert.rejects(() => h.run(), /unavailable sections/);
+  assert.equal(h.state.posts.length, 1);
+  assert.match(h.state.posts[0].embeds[3].description, /temporarily unavailable/);
+  assert.equal(h.state.queryNames.includes("weekly_digest_app_usage"), false);
+});
+
+test("a dev_ids 401 costs app usage only; a METRIC 401 fails the whole run", async () => {
+  const devAuth = harness({ posthog: { dev_ids: () => fail(401) } });
+  await assert.rejects(() => devAuth.run(), /unavailable sections/);
+  assert.equal(devAuth.state.posts.length, 1, "a partial digest still posts");
+  assert.equal(devAuth.state.posts[0].embeds.length, 4);
+
+  const metricAuth = harness({ posthog: { website: () => fail(401) } });
+  await assert.rejects(() => metricAuth.run(), /HTTP 401/);
+  // Contract failure: notice, no digest.
+  assert.equal(metricAuth.state.posts.length, 1);
+  assert.match(metricAuth.state.posts[0].content, /could not be generated/);
+  assert.equal(metricAuth.state.posts[0].embeds, undefined);
+});
+
+test("a malformed metric response posts the failure notice and no digest", async () => {
+  const h = harness({ posthog: { downloads: () => ok({ columns: ["intents"] }) } });
+  await assert.rejects(() => h.run(), /returned no results array/);
+  assert.equal(h.state.posts.length, 1);
+  assert.match(h.state.posts[0].content, /could not be generated/);
+  assert.equal(h.state.posts[0].embeds, undefined);
+});
+
+test("zero dev ids is a legitimate state and must not produce NOT IN ()", async () => {
+  const h = harness({ posthog: { dev_ids: () => ok({ results: [], columns: ["distinct_id"] }) } });
+  await h.run();
+  const appUsage = h.state.sql.find((q) => q.includes("app.launched"));
+  assert.match(appUsage, /environment = 'production'/);
+  assert.doesNotMatch(appUsage, /NOT IN \(\)/);
+});
+
+test("resolved dev ids reach the app-usage query as a literal exclusion list", async () => {
+  const h = harness();
+  await h.run();
+  const appUsage = h.state.sql.find((q) => q.includes("app.launched"));
+  assert.match(appUsage, /distinct_id NOT IN \('dev-a', 'dev-b'\)/);
+});
+
+// ---- Trigger gate ------------------------------------------------------------
+
+test("an unauthenticated trigger returns 401 and posts nothing", async () => {
+  const res = await worker.fetch(new Request("https://w.dev/"), ENV);
+  assert.equal(res.status, 401);
+});
+
+test("a wrong token is refused", async () => {
+  const res = await worker.fetch(new Request("https://w.dev/?token=nope"), ENV);
+  assert.equal(res.status, 401);
+});
+
+test("an unset TRIGGER_SECRET refuses everything, including a supplied token", async () => {
+  const { TRIGGER_SECRET, ...noSecret } = ENV;
+  for (const url of ["https://w.dev/", "https://w.dev/?token=s3cret", "https://w.dev/?token="]) {
+    const res = await worker.fetch(new Request(url), noSecret);
+    assert.equal(res.status, 401, `${url} must fail closed`);
+  }
+});
+
+test("a wrong header-form trigger secret is refused too", async () => {
+  const res = await worker.fetch(
+    new Request("https://w.dev/", { headers: { "x-trigger-secret": "wrong" } }),
+    ENV
+  );
+  assert.equal(res.status, 401);
+});
+
+// ---- Cloudflare and GitHub ---------------------------------------------------
+
+test("a Cloudflare failure degrades its section and never renders a zero", async () => {
+  for (const bad of [
+    () => fail(500),
+    () => ok({ errors: [{ message: "boom" }] }),
+    () => ok({ data: { viewer: { zones: [] } } }),
+  ]) {
+    const h = harness({ cloudflare: bad });
+    await assert.rejects(() => h.run(), /unavailable sections/);
+    const traffic = h.state.posts[0].embeds[0].description;
+    assert.match(traffic, /temporarily unavailable/);
+    // The shipped worker reported a confident 0 for each of these three.
+    assert.doesNotMatch(traffic, /\b0 page views\b/);
+  }
+});
+
+test("a genuine zero-traffic week still renders 0, not 'unavailable'", async () => {
+  const empty = { data: { viewer: { zones: [{ totals: [], byDay: [] }] } } };
+  const h = harness({ cloudflare: () => ok(empty) });
+  await h.run();
+  const traffic = h.state.posts[0].embeds[0].description;
+  assert.match(traffic, /0 page views/);
+  assert.doesNotMatch(traffic, /temporarily unavailable/);
+});
+
+test("all-time downloads reads every page, not just GitHub's first 30", async () => {
+  const h = harness();
+  await h.run();
+  assert.deepEqual(h.state.githubPages, [1, 2]);
+  // 100 releases on page 1 + 45 on page 2, one 10-download dmg each.
+  assert.match(h.state.posts[0].embeds[2].description, /1,450 downloads all time/);
+});
+
+test("one page is one request: a short first page must not fetch a second", async () => {
+  const h = harness({ github: () => ok(RELEASES_PAGE(45)) });
+  await h.run();
+  assert.deepEqual(h.state.githubPages, [1]);
+  assert.match(h.state.posts[0].embeds[2].description, /450 downloads all time/);
+});
+
+test("a mid-pagination failure degrades the section rather than reporting a partial sum", async () => {
+  const h = harness({ github: (page) => (page === 1 ? ok(RELEASES_PAGE(100)) : fail(502)) });
+  await assert.rejects(() => h.run(), /unavailable sections/);
+  const downloads = h.state.posts[0].embeds[2].description;
+  assert.match(downloads, /temporarily unavailable/);
+  // 1,000 is page one's real total, and exactly the plausible wrong number a
+  // partial sum would have shipped.
+  assert.doesNotMatch(downloads, /1,000 downloads/);
+});
+
+test("GitHub non-2xx on the first page degrades instead of returning '?'", async () => {
+  const h = harness({ github: () => fail(403) });
+  await assert.rejects(() => h.run(), /unavailable sections/);
+  assert.match(h.state.posts[0].embeds[2].description, /temporarily unavailable/);
+});
+
+// ---- Payload -----------------------------------------------------------------
+
+test("the digest posts four section embeds carrying the brand colour", async () => {
+  const h = harness();
+  await h.run();
+  const [digest] = h.state.posts;
+  assert.equal(digest.embeds.length, 4);
+  assert.deepEqual(digest.embeds.map((e) => e.title), [
+    "All website traffic", "Tracked visitor activity", "Downloads", "App usage",
+  ]);
+  for (const embed of digest.embeds) {
+    assert.equal(embed.color, 0x7c3aed);
+    assert.equal(embed.footer.text, "EnviousWispr Weekly Digest");
+  }
+  assert.match(digest.content, /EnviousWispr Weekly Digest, July 27 to August 2/);
+});
+
+test("the assembled payload passes the shared Discord validator at realistic size", async () => {
+  const wide = {
+    results: Array.from({ length: 8 }, (_, i) => ["unknown_referrer", 10_000_000 + i]),
+    columns: ["bucket", "n"],
+  };
+  const h = harness({ posthog: { download_sources: () => ok(wide) } });
+  await h.run();
+  const [digest] = h.state.posts;
+  const combined = digest.embeds.reduce(
+    (sum, e) => sum + e.title.length + e.description.length + e.footer.text.length, 0);
+  assert.ok(combined < 6000, `combined embed text ${combined} must stay under Discord's budget`);
+});
+
+test("the digest is sent exactly once, and nothing follows a successful delivery", async () => {
+  const h = harness();
+  await h.run();
+  assert.equal(h.state.posts.length, 1);
+});
+
+// ---- Pure helpers ------------------------------------------------------------
+
 test("sourceLabel: known maps, unknown/null -> Other", () => {
   assert.equal(sourceLabel("github_readme"), "GitHub README");
   assert.equal(sourceLabel("reddit"), "Reddit");
-  assert.equal(sourceLabel("ai_assistant"), "AI assistant");
-  assert.equal(sourceLabel("some_new_bucket"), "Other");
+  assert.equal(sourceLabel("nope"), "Other");
   assert.equal(sourceLabel(null), "Other");
   assert.equal(sourceLabel(undefined), "Other");
+  assert.equal(Object.keys(SOURCE_LABELS).length > 10, true);
 });
 
-test("formatSourceBreakdown: empty vs unknown vs rows", () => {
-  assert.equal(formatSourceBreakdown([]), "No off-site downloads yet"); // genuine zero
-  assert.equal(formatSourceBreakdown(null), "Sources unavailable"); // query failed/unknown
-  const out = formatSourceBreakdown([["github_readme", 3], ["reddit", 1], ["mystery", 1]]);
-  assert.match(out, /GitHub README: 3/);
-  assert.match(out, /Reddit: 1/);
-  assert.match(out, /Other: 1/); // unknown bucket never disappears
+test("formatSourceBreakdown: unavailable, genuine zero, and rows read differently", () => {
+  assert.equal(formatSourceBreakdown(null), "Sources unavailable");
+  assert.equal(formatSourceBreakdown(undefined), "Sources unavailable");
+  assert.equal(formatSourceBreakdown([]), "No off-site downloads yet");
+  assert.equal(
+    formatSourceBreakdown([{ bucket: "reddit", n: 1234 }, { bucket: null, n: 2 }]),
+    "Reddit: 1,234\nOther: 2"
+  );
 });
 
-// ---- embed smoke ----
-const cf = { totalUniques: 10, totalPageViews: 50, totalRequests: 100, topCountries: [["United States", 5]] };
-const gh = { totalDownloads: 1234, latestVersion: "v1.10.2" };
-
-test("buildEmbed: shows Download Intents + Download Sources, drops legacy labels", () => {
-  const ph = {
-    websiteVisitors: 9, websitePageViews: 40,
-    downloadIntents: 7, downloadSources: [["github_readme", 4], ["reddit", 2]],
-    botExcluded: 3, weeklyActiveUsers: 20, newUsers: 2,
-  };
-  const json = JSON.stringify(buildEmbed("2026-06-23", "2026-06-30", cf, gh, ph));
-  assert.match(json, /Download Intents \(7d\)/);
-  assert.match(json, /Download Sources \(7d\)/);
-  assert.match(json, /Off-site bots excluded: 3/);
-  assert.match(json, /GitHub README: 4/);
-  assert.ok(!/Download Clicks/.test(json), "legacy 'Download Clicks' label removed");
-  assert.ok(!/Top Referrers/.test(json), "broken 'Top Referrers' section removed");
-  // All-time GitHub file-download count stays separate and labeled.
-  assert.match(json, /All-Time DMG Downloads/);
+test("every formatter degrades to prose, never to a number, when its input is null", () => {
+  for (const lines of [formatCloudflare(null), formatWebsite(null, null), formatDownloads(null, null, null), formatAppUsage(null)]) {
+    assert.match(lines.join("\n"), /temporarily unavailable/);
+  }
+  // Title line must survive so the embed is still well-formed.
+  assert.equal(formatAppUsage(null)[0], "App usage");
 });
 
-test("buildEmbed: empty sources renders the friendly placeholder", () => {
-  const ph = {
-    websiteVisitors: 9, websitePageViews: 40,
-    downloadIntents: 0, downloadSources: [], botExcluded: 0,
-    weeklyActiveUsers: 20, newUsers: 2,
-  };
-  const json = JSON.stringify(buildEmbed("2026-06-23", "2026-06-30", cf, gh, ph));
-  assert.match(json, /No off-site downloads yet/);
+test("formatters produce a title line plus a non-empty body of strings", () => {
+  const cases = [
+    formatCloudflare({ totalPageViews: 1, summedDailyUniques: 2, totalRequests: 3, topCountries: [] }),
+    formatWebsite({ views: 1, visitors: 2 }, 3),
+    formatDownloads({ totalDownloads: 1, latestVersion: "v1" }, [], 0),
+    formatAppUsage({ active: 1, fresh: 2 }),
+  ];
+  for (const lines of cases) {
+    assert.ok(lines.length >= 2);
+    assert.ok(lines[0].length > 0);
+    assert.ok(lines.slice(1).join("\n").length > 0);
+    for (const line of lines) assert.equal(typeof line, "string");
+  }
 });
 
-test("buildEmbed: failed sources query renders 'Sources unavailable', not a false zero", () => {
-  const ph = {
-    websiteVisitors: 9, websitePageViews: 40,
-    downloadIntents: "?", downloadSources: null, botExcluded: "?",
-    weeklyActiveUsers: 20, newUsers: 2,
-  };
-  const json = JSON.stringify(buildEmbed("2026-06-23", "2026-06-30", cf, gh, ph));
-  assert.match(json, /Sources unavailable/);
-  assert.ok(!/No off-site downloads yet/.test(json), "a failed query must not look like a true zero");
+test("the Cloudflare visitor line says what it counts, not 'unique visitors'", () => {
+  const lines = formatCloudflare({ totalPageViews: 900, summedDailyUniques: 300, totalRequests: 5000, topCountries: [] });
+  const text = lines.join("\n");
+  assert.match(text, /daily visits added up/);
+  assert.match(text, /counts three times/);
+  // The old label claimed people; the arithmetic never supported that.
+  assert.doesNotMatch(text, /Unique Visitors/i);
+});
+
+test("fetchCloudflareStats and fetchGitHubDownloads are callable in isolation", async () => {
+  const w = resolveWeekWindow(NOW);
+  const cf = await fetchCloudflareStats(ENV, w, { fetchFn: async () => ok(CF_BODY) });
+  assert.equal(cf.totalPageViews, 900);
+  assert.deepEqual(cf.topCountries[0], ["United States", 3000]);
+  const gh = await fetchGitHubDownloads(ENV, { fetchFn: async () => ok(RELEASES_PAGE(2)) });
+  assert.equal(gh.totalDownloads, 20);
+  assert.equal(gh.latestVersion, "v1.1.0");
 });

--- a/workers/weekly-digest/test/digest.test.js
+++ b/workers/weekly-digest/test/digest.test.js
@@ -603,7 +603,9 @@ test("more than one aggregate row is malformed, not a first-row-wins guess", asy
 
 test("a non-numeric count in the sources breakdown degrades that section", async () => {
   const h = harness({ posthog: { download_sources: () => ok({ results: [["reddit", "lots"]], columns: ["bucket", "n"] }) } });
-  await assert.rejects(() => h.run(), /non-numeric row count/);
+  // Message generalised in review round 4 when the bucket column joined the
+  // same check; the CONTRACT is unchanged.
+  await assert.rejects(() => h.run(), /malformed row shape/);
   assert.match(h.state.posts[0].embeds[2].description, /Sources unavailable/);
 });
 
@@ -642,4 +644,29 @@ test("a malformed dev-ID row degrades app usage rather than claiming a false exc
     assert.equal(h.state.queryNames.includes("weekly_digest_app_usage"), false);
     assert.equal(h.state.sql.some((q) => q.includes("'undefined'")), false);
   }
+});
+
+test("a source row with a missing or renamed bucket column degrades", async () => {
+  // A NULL bucket is legitimate (no source recorded -> "Other"). An OMITTED or
+  // renamed column arrives as undefined and would take that same branch,
+  // publishing a confident attribution for a query whose shape had changed.
+  for (const body of [
+    { results: [[20]], columns: ["n"] },                       // bucket column gone
+    { results: [["reddit", 8]], columns: ["source", "n"] },    // renamed
+    { results: [[42, 8]], columns: ["bucket", "n"] },          // wrong type
+  ]) {
+    const h = harness({ posthog: { download_sources: () => ok(body) } });
+    await assert.rejects(() => h.run(), /malformed row shape/);
+    assert.match(h.state.posts[0].embeds[2].description, /Sources unavailable/);
+    assert.doesNotMatch(h.state.posts[0].embeds[2].description, /Other:/);
+  }
+});
+
+test("a genuinely null bucket is data, not a malformed row", async () => {
+  // Two-way control: PostHog returns null for an absent property, and that is a
+  // real "we could not attribute this download", rendered as Other.
+  const h = harness({ posthog: { download_sources: () => ok({ results: [[null, 3]], columns: ["bucket", "n"] }) } });
+  await h.run();
+  assert.match(h.state.posts[0].embeds[2].description, /Other: 3/);
+  assert.doesNotMatch(h.state.posts[0].embeds[2].description, /Sources unavailable/);
 });

--- a/workers/weekly-digest/test/digest.test.js
+++ b/workers/weekly-digest/test/digest.test.js
@@ -622,3 +622,24 @@ test("a genuine zero-download release still counts as zero, not as malformed", a
   await h.run();
   assert.match(h.state.posts[0].embeds[2].description, /0 downloads all time/);
 });
+
+test("a malformed dev-ID row degrades app usage rather than claiming a false exclusion", async () => {
+  // `results: [[]]` yields undefined, which sqlIdList renders as the literal
+  // 'undefined': the query would exclude an id nobody has, INCLUDE every real
+  // dev machine, and the section would still say they were excluded. A wrong
+  // number whose caveat is also a lie.
+  for (const body of [
+    { results: [[]], columns: ["distinct_id"] },
+    { results: [[null]], columns: ["distinct_id"] },
+    { results: [[""]], columns: ["distinct_id"] },
+    { results: [[42]], columns: ["distinct_id"] },
+  ]) {
+    const h = harness({ posthog: { dev_ids: () => ok(body) } });
+    await assert.rejects(() => h.run(), /unavailable sections/);
+    assert.match(h.state.posts[0].embeds[3].description, /temporarily unavailable/);
+    // The false claim must not be printed beside an unavailable section.
+    assert.doesNotMatch(h.state.posts[0].embeds[3].description, /Dev machines are excluded/);
+    assert.equal(h.state.queryNames.includes("weekly_digest_app_usage"), false);
+    assert.equal(h.state.sql.some((q) => q.includes("'undefined'")), false);
+  }
+});

--- a/workers/weekly-digest/test/digest.test.js
+++ b/workers/weekly-digest/test/digest.test.js
@@ -718,3 +718,14 @@ test("a day with no country traffic is legitimate and still reports the totals",
   await h.run();
   assert.match(h.state.posts[0].embeds[0].description, /5 page views/);
 });
+
+test("the app-usage line does not claim first-time installs it cannot prove", async () => {
+  // is_fresh_install is `onboardingState != .completed`, so it stays true on
+  // every launch until setup finishes. Measured: 46 reported vs 43 genuinely
+  // first-launching in the same window. The sentence must not overclaim.
+  const h = harness();
+  await h.run();
+  const text = h.state.posts[0].embeds[3].description;
+  assert.match(text, /new or had not finished setting up/);
+  assert.doesNotMatch(text, /installed it for the first time/);
+});

--- a/workers/weekly-digest/test/digest.test.js
+++ b/workers/weekly-digest/test/digest.test.js
@@ -11,6 +11,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 
 import worker, {
+  isAuthorizedTrigger,
   runDigest,
   resolveWeekWindow,
   fetchCloudflareStats,
@@ -356,16 +357,22 @@ test("the query-string form is refused even when the value is CORRECT", async ()
   assert.equal(res.status, 401);
 });
 
-test("the correct header is accepted and runs the digest", async () => {
-  const h = harness();
-  const res = await worker.fetch(
-    new Request("https://w.dev/", { headers: { "x-trigger-secret": "s3cret" } }),
-    { ...ENV, POSTHOG_PERSONAL_API_KEY: "k" }
-  );
-  // The real handler calls runDigest with production fetch, which the test
-  // environment cannot reach, so a non-401 is what this asserts: the gate
-  // OPENED. Behaviour past the gate is covered by the runDigest suites.
-  assert.notEqual(res.status, 401);
+test("the gate opens for the correct header, and only for that", () => {
+  // Asserted on the gate FUNCTION, not by driving the handler. An earlier
+  // version of this test called worker.fetch and checked for a non-401: with no
+  // fetch injected it ran the real runDigest against production PostHog,
+  // Cloudflare and GitHub on every CI run, and it would have passed on a 500.
+  // A test that reaches production to prove a local branch is two defects.
+  const req = (headers) => new Request("https://w.dev/", { headers });
+  assert.equal(isAuthorizedTrigger(req({ "x-trigger-secret": "s3cret" }), ENV), true);
+  assert.equal(isAuthorizedTrigger(req({ "x-trigger-secret": "wrong" }), ENV), false);
+  assert.equal(isAuthorizedTrigger(req({}), ENV), false);
+  // Fails closed with no secret configured, even when one is supplied.
+  const { TRIGGER_SECRET, ...noSecret } = ENV;
+  assert.equal(isAuthorizedTrigger(req({ "x-trigger-secret": "s3cret" }), noSecret), false);
+  // And the query-string form is not a credential here at all.
+  assert.equal(
+    isAuthorizedTrigger(new Request("https://w.dev/?token=s3cret"), ENV), false);
 });
 
 test("an unset TRIGGER_SECRET refuses everything, including a supplied token", async () => {

--- a/workers/weekly-digest/test/digest.test.js
+++ b/workers/weekly-digest/test/digest.test.js
@@ -526,7 +526,9 @@ test("an empty aggregate row is a failure, never a silently 'unavailable' succes
   // broken telemetry looks healthy for as long as nobody reads the post.
   for (const [key, embedIndex] of [["website", 1], ["downloads", 2], ["app_usage", 3]]) {
     const h = harness({ posthog: { [key]: () => ok({ results: [], columns: [] }) } });
-    await assert.rejects(() => h.run(), /returned no aggregate row/,
+    // Message tightened in review round 2 from "returned no aggregate row" to
+    // name the actual count; the CONTRACT is unchanged - it must fail the run.
+    await assert.rejects(() => h.run(), /expected exactly 1 aggregate row, got 0/,
       `${key} returning no row must fail the run, not resolve it`);
     assert.equal(h.state.posts.length, 1);
     assert.match(h.state.posts[0].embeds[embedIndex].description, /temporarily unavailable/);
@@ -572,4 +574,51 @@ test("the download line does not claim to be a subset of tracked visitors", asyn
   assert.doesNotMatch(text, /of them/);
   // The scenario that proves the point: more downloads than tracked visitors.
   assert.match(text, /105 people viewed/);
+});
+
+// ---- Whole-diff review round 2: a 200 with the wrong SHAPE ---------------------
+// Third round on one class, so these enumerate every path where a successful
+// response can still produce a number, not only the ones review named.
+
+test("an aggregate row missing a column degrades instead of publishing NaN", async () => {
+  const cases = [
+    ["website", 1, { results: [[226]], columns: ["views"] }],                 // renamed/missing column
+    ["downloads", 2, { results: [[36, null]], columns: ["intents", "bots_excluded"] }],
+    ["app_usage", 3, { results: [["many", 51]], columns: ["active", "fresh"] }],
+  ];
+  for (const [key, embedIndex, body] of cases) {
+    const h = harness({ posthog: { [key]: () => ok(body) } });
+    await assert.rejects(() => h.run(), /missing or non-numeric/, `${key} must degrade`);
+    const text = JSON.stringify(h.state.posts[0]);
+    assert.doesNotMatch(text, /NaN/, "a malformed row must never reach the reader as NaN");
+    assert.match(h.state.posts[0].embeds[embedIndex].description, /temporarily unavailable/);
+  }
+});
+
+test("more than one aggregate row is malformed, not a first-row-wins guess", async () => {
+  const h = harness({ posthog: { website: () => ok({ results: [[1, 2], [3, 4]], columns: ["views", "visitors"] }) } });
+  await assert.rejects(() => h.run(), /expected exactly 1 aggregate row/);
+  assert.match(h.state.posts[0].embeds[1].description, /temporarily unavailable/);
+});
+
+test("a non-numeric count in the sources breakdown degrades that section", async () => {
+  const h = harness({ posthog: { download_sources: () => ok({ results: [["reddit", "lots"]], columns: ["bucket", "n"] }) } });
+  await assert.rejects(() => h.run(), /non-numeric row count/);
+  assert.match(h.state.posts[0].embeds[2].description, /Sources unavailable/);
+});
+
+test("a GitHub asset with a non-numeric download_count degrades, never undercounts", async () => {
+  const h = harness({ github: () => ok([{ tag_name: "v1.0.0", assets: [{ name: "a.dmg", download_count: null }] }]) });
+  await assert.rejects(() => h.run(), /unavailable sections/);
+  const text = h.state.posts[0].embeds[2].description;
+  assert.match(text, /temporarily unavailable/);
+  // `|| 0` would have silently reported this as a real zero-download release.
+  assert.doesNotMatch(text, /0 downloads all time/);
+});
+
+test("a genuine zero-download release still counts as zero, not as malformed", async () => {
+  // Two-way control for the check above.
+  const h = harness({ github: () => ok([{ tag_name: "v1.0.0", assets: [{ name: "a.dmg", download_count: 0 }] }]) });
+  await h.run();
+  assert.match(h.state.posts[0].embeds[2].description, /0 downloads all time/);
 });

--- a/workers/weekly-digest/test/digest.test.js
+++ b/workers/weekly-digest/test/digest.test.js
@@ -670,3 +670,51 @@ test("a genuinely null bucket is data, not a malformed row", async () => {
   assert.match(h.state.posts[0].embeds[2].description, /Other: 3/);
   assert.doesNotMatch(h.state.posts[0].embeds[2].description, /Sources unavailable/);
 });
+
+test("a release with a missing assets array degrades, never undercounts", async () => {
+  // `rel.assets || []` treated this as a release with no downloads, quietly
+  // lowering an all-time total that then passed every numeric check.
+  const h = harness({ github: () => ok([{ tag_name: "v1.0.0" }]) });
+  await assert.rejects(() => h.run(), /unavailable sections/);
+  assert.match(h.state.posts[0].embeds[2].description, /temporarily unavailable/);
+});
+
+test("an asset with a non-string name degrades rather than being skipped", async () => {
+  const h = harness({ github: () => ok([{ tag_name: "v1.0.0", assets: [{ name: null, download_count: 5 }] }]) });
+  await assert.rejects(() => h.run(), /unavailable sections/);
+  assert.match(h.state.posts[0].embeds[2].description, /temporarily unavailable/);
+});
+
+test("a release that genuinely ships no dmg is data, not a malformed response", async () => {
+  // Two-way control for both checks above: an EMPTY assets array, and a
+  // non-dmg asset, are both legitimate.
+  const h = harness({ github: () => ok([
+    { tag_name: "v1.1.0", assets: [] },
+    { tag_name: "v1.0.0", assets: [{ name: "notes.txt", download_count: 3 }, { name: "a.dmg", download_count: 7 }] },
+  ]) });
+  await h.run();
+  assert.match(h.state.posts[0].embeds[2].description, /7 downloads all time/);
+});
+
+test("a country entry without a name degrades instead of publishing 'undefined'", async () => {
+  const body = { data: { viewer: { zones: [{
+    totals: [{ sum: { requests: 10, pageViews: 5 }, uniq: { uniques: 3 } }],
+    byDay: [{ sum: { countryMap: [{ requests: 10 }] } }],
+  }] } } };
+  const h = harness({ cloudflare: () => ok(body) });
+  await assert.rejects(() => h.run(), /unavailable sections/);
+  const traffic = h.state.posts[0].embeds[0].description;
+  assert.match(traffic, /temporarily unavailable/);
+  assert.doesNotMatch(traffic, /undefined/);
+});
+
+test("a day with no country traffic is legitimate and still reports the totals", async () => {
+  // Two-way control: an absent countryMap is normal for a quiet day.
+  const body = { data: { viewer: { zones: [{
+    totals: [{ sum: { requests: 10, pageViews: 5 }, uniq: { uniques: 3 } }],
+    byDay: [{ sum: {} }],
+  }] } } };
+  const h = harness({ cloudflare: () => ok(body) });
+  await h.run();
+  assert.match(h.state.posts[0].embeds[0].description, /5 page views/);
+});

--- a/workers/weekly-digest/test/digest.test.js
+++ b/workers/weekly-digest/test/digest.test.js
@@ -658,7 +658,9 @@ test("a source row with a missing or renamed bucket column degrades", async () =
     { results: [[42, 8]], columns: ["bucket", "n"] },          // wrong type
   ]) {
     const h = harness({ posthog: { download_sources: () => ok(body) } });
-    await assert.rejects(() => h.run(), /malformed row shape/);
+    // Either detector may fire first: a renamed column trips the COLUMN check,
+    // a wrong-typed value trips the ROW check. Both must degrade the section.
+    await assert.rejects(() => h.run(), /malformed (row shape|column set)/);
     assert.match(h.state.posts[0].embeds[2].description, /Sources unavailable/);
     assert.doesNotMatch(h.state.posts[0].embeds[2].description, /Other:/);
   }
@@ -778,4 +780,37 @@ test("a failed funnel query leaves the usage line intact, and vice versa", async
   const b = usageDown.state.posts[0].embeds[3].description;
   assert.match(b, /31 people finished setting up/);
   assert.match(b, /New installs were temporarily unavailable/);
+});
+
+test("an EMPTY response with a malformed column set degrades, not 'none yet'", async () => {
+  // The axis this closes: every row-shape check is skipped when there are zero
+  // rows, which is exactly when a malformed empty response arrives. The digest
+  // would otherwise report "No off-site downloads yet" with full confidence.
+  for (const body of [{ results: [], columns: [] }, { results: [], columns: ["source", "count"] }]) {
+    const h = harness({ posthog: { download_sources: () => ok(body) } });
+    await assert.rejects(() => h.run(), /malformed column set/);
+    assert.match(h.state.posts[0].embeds[2].description, /Sources unavailable/);
+    assert.doesNotMatch(h.state.posts[0].embeds[2].description, /No off-site downloads yet/);
+  }
+});
+
+test("an EMPTY dev-id response with no columns degrades app usage, never assumes zero", async () => {
+  // Same axis in the shared resolver: `{results: [], columns: []}` read as "no
+  // dev accounts", so both reports would fall back to the environment filter
+  // and include dev machines while printing that they were excluded.
+  const h = harness({ posthog: { dev_ids: () => ok({ results: [], columns: [] }) } });
+  await assert.rejects(() => h.run(), /unavailable sections/);
+  assert.match(h.state.posts[0].embeds[3].description, /temporarily unavailable/);
+  assert.equal(h.state.queryNames.includes("weekly_digest_app_usage"), false);
+});
+
+test("a genuinely empty response WITH valid columns is still a real empty week", async () => {
+  // Two-way control for both checks above.
+  const h = harness({ posthog: {
+    dev_ids: () => ok({ results: [], columns: ["distinct_id"] }),
+    download_sources: () => ok({ results: [], columns: ["bucket", "n"] }),
+  } });
+  await h.run();
+  assert.match(h.state.posts[0].embeds[2].description, /No off-site downloads yet/);
+  assert.match(h.state.posts[0].embeds[3].description, /189 people used EnviousWispr/);
 });

--- a/workers/weekly-digest/wrangler.toml
+++ b/workers/weekly-digest/wrangler.toml
@@ -9,3 +9,22 @@ crons = ["0 13 * * 1"]  # Every Monday at 1pm UTC = 9am ET
 CF_ZONE_ID = "b4416a0f0ebd699e96969a331c7ad7ff"
 GITHUB_REPO = "saurabhav88/EnviousWispr"
 POSTHOG_PROJECT_ID = "354235"
+
+# Secrets (set via `npx wrangler secret put <NAME>`, never in this file):
+#   POSTHOG_PERSONAL_API_KEY  - GCP secret `posthog-personal-api-key`
+#   DISCORD_WEBHOOK_URL       - the session-logs webhook
+#   CF_EMAIL / CF_API_KEY     - Cloudflare Analytics GraphQL auth
+#   GITHUB_TOKEN              - optional; raises the releases rate limit
+#   TRIGGER_SECRET            - gates the public `fetch` trigger. The workers.dev
+#                               URL is public, so before #1589 anyone who knew it
+#                               could post a real digest to Discord. The trigger
+#                               now fails CLOSED: an unset secret refuses every
+#                               request, so a half-configured deploy cannot be
+#                               triggered at all. The cron path is unaffected.
+#
+# This worker holds one of the account's five free-plan Cloudflare cron slots
+# (#1092), which is why scheduling lives here and not in a GitHub Action.
+#
+# `src/index.js` imports from `../../shared/`. Wrangler's esbuild follows that
+# relative path above the worker root with no config change, and a deploy of
+# THIS worker does not update the daily report's copy - see workers/shared/README.md.


### PR DESCRIPTION
Closes #1589.

The weekly digest was the last worker still carrying the defect class this issue was filed for. Fixing the reliability half surfaced something worse: **most of the numbers it posted every Monday were wrong, not missing.** A missing number gets noticed. A plausible wrong one does not.

## What was wrong, measured

Frozen window `2026-07-25 .. 2026-08-01`, every value checked against an **independently written** oracle query — a check that calls the code it checks proves only that the code equals itself.

| Number | Was | Now | Cause |
|---|---|---|---|
| People who used the app | 179 (launches) | **160** | counted anyone who opened the app; the founder's definition of usage is one successful dictation, which is also what the daily report counts |
| Active installs | 212 | **179 → funnel** | summed two weekly Trends buckets over an 8-day window, double-counting anyone in both |
| Page views / visitors | 214 / 110 | **201 / 105** | counted `app.enviousstaging.com` and localhost dev servers |
| All-time downloads | truncated | **2,692** | read only GitHub's first page: 30 of 45 releases |
| Any failure | `?` or `0` | "temporarily unavailable" | a failed Cloudflare call rendered a confident zero |

The active-installs oracle written in the obvious nested-subquery form **504'd**, which independently confirms `hogql-nested-subquery-in-union-can-timeout`: the resolve-once form the worker uses returned in 3.8s over the same data.

## The app-usage funnel

Founder definition (2026-08-01): an install is someone who has **begun onboarding**, finishing setup is its own step, and **one successful dictation** is what counts as really using the app. Same three levels the daily report gives per day:

```
160 people used EnviousWispr this week.
New installs: 46.
40 people finished setting up. Of those, 35 also dictated.
```

The funnel is also what makes `is_fresh_install`'s known weakness readable rather than hidden: it is `onboardingState != .completed` (`AppLifecycleCoordinator.swift:221`), so it stays true until setup finishes. A gap between installs and finished setup is the interesting signal, not noise to remove from a headline. Measured and documented; the daily report shares the definition, so they change together or not at all.

## Reliability, the originally-scoped half

- 5 uncapped PostHog queries → 1 preflight + 5 through `runLimited(..., 2)`, against a documented 3-concurrent ceiling shared with EnviousStaging.
- Retry on `{429, 502, 503, 504}`, 3 attempts, randomized backoff. There was none.
- Every failure said `"?"` beside real figures. Each section now says "temporarily unavailable" and **never renders a number it does not have**.
- A failed run posted nothing. It now posts an explicit notice.
- **The public trigger needed no secret.** Anyone who knew the workers.dev URL could post to Discord. Now gated, header-only, fails closed.

## Two deliberate divergences from the daily report

Ported wholesale except where the workers genuinely differ:

1. **`dev_ids` failure degrades app usage only**, not the whole run. Daily-report makes it fatal and is right to: both its sections are app events over the production population. Three of weekly's four sections never consume the dev list, and it is the slowest query in the run — a 9.2s unbounded whole-history scan in live smoke.
2. **Website queries carry no production predicate.** `productionClauseFor` always prefixes `environment = 'production'` and website events carry no such property, so applying it returns **zero**, not the same rows more slowly. They take a `$host` filter instead. The download queries take **neither**: `download_redirect` is emitted server-side with no `$host`, so a host filter would drop every off-site redirect. Measured, not assumed.

## Shared module and the CI gate that protects it

`posthog.js` and `discord.js` move to `workers/shared/` via `git mv`. Their header argued against this — conditionally, on the daily report being the only consumer. It no longer is, and that same header recorded that hand-porting between workers "demonstrably did not converge."

- `workerLabel` required with no default: a default files one worker's queries under another's name in PostHog's query log, which reads as correct everywhere a human looks.
- `discord.js` now permits `color`, `footer`, `timestamp`. Restricting embeds to title+description was the daily report's **layout choice** enforced as a protocol limit; the weekly digest keeps its brand purple. `footer.text` counts against the 6000-char budget because Discord counts it.
- **New `worker-tests` CI job**, unconditional, both suites, feeding the required `build-check`. Nothing ran worker tests before, so a shared change could break both reports with every check green.

## The malformed-200 class

Whole-diff review raised one class across five rounds, and each round I fixed the named instance and swept only as far as I had been looking. That pattern is the finding. The enumeration now lives in code above `read()`: **every external field this worker parses**, printed or not, with its validator — PostHog rows and columns, Cloudflare groups and country entries, GitHub releases, assets and counts, dev-id rows and their column position.

Two rules recorded with it: check the **shape**, never the magnitude, so a genuine zero still reports zero; and a per-row check **cannot fire on zero rows**, so anything where empty is legitimate is checked on its column set.

Every check has a two-way control proving a real empty week still reads as empty.

## Validation

- 68 tests in `weekly-digest`, 154 in `daily-report`, both green — and both verified **network-free** by re-running with `globalThis.fetch` poisoned, with a positive control proving the poison fires.
- `wrangler deploy --dry-run` clean in both — the check that proves esbuild follows a relative import above the worker root, the one premise the plan could not settle by reading.
- Live smoke against production PostHog, Cloudflare and GitHub: every section real data, nothing posted to Discord.
- One coverage round (7 findings), four grounded rounds (17), ten whole-diff rounds (13). Several of my own claims were falsified by measurement along the way and are corrected in the plan rather than quietly dropped.

## Deploy is manual, and the order matters

Merging deploys nothing. **Deploy `weekly-digest` first, then `daily-report`**: each bundles its own snapshot, so a broken shared change lands on the worker already being modified rather than on the working daily report. `git revert` does not roll back production either. Owner: `workers/shared/README.md`.
