### PR TITLE
fix(worker): count installs from began-onboarding, not a state that never clears (#1910)

### DIFF
--- a/workers/daily-report/README.md
+++ b/workers/daily-report/README.md
@@ -20,7 +20,7 @@ never a UTC-day approximation).
 
 | Line | Definition |
 |---|---|
-| New installs | Unique `distinct_id`s with `app.launched{is_fresh_install=true}` that day. |
+| People who began setting up | Unique `distinct_id`s with `onboarding.started` that day. NOT `app.launched{is_fresh_install}` — that is a STATE (`onboardingState != .completed`) that stays true until setup finishes, so it re-counted unfinished onboarding as a new install every day (#1910). Says setup BEGAN that day, not that it was a first time: Diagnostics can restart onboarding. |
 | People who finished setup | Unique `distinct_id`s with `onboarding.completed` that day. |
 | Of those, also dictated | Same-day activation: of the users who onboarded THAT day, how many ALSO had a successful dictation that same day. Deliberately same-day, not open-ended — a stated simplification, not an oversight. |
 | Total users | Unique `distinct_id`s with a **successful** `dictation.completed` that day. This deliberately EXCLUDES people who launched the app, or attempted a dictation that failed (ASR/paste failure). It is not "everyone who touched the app," it is "everyone who got a working dictation." Per-version failure rates live in the version scorecard section, not here. |

--- a/workers/daily-report/src/adoption.js
+++ b/workers/daily-report/src/adoption.js
@@ -104,10 +104,16 @@ export function createAdoptionSection(env, context, opts = {}) {
   const endTs = sqlTimestamp(context.endUTC);
   const activeUsers = activeUsersSubquery(win);
 
+  // "Began onboarding", from the EVENT fired once when the user taps "Get
+  // Started" (OnboardingV2View.swift:670) - not `app.launched` +
+  // `is_fresh_install`, which is a STATE (`onboardingState != .completed`) and
+  // stays true on every launch until setup finishes. That re-counted anyone who
+  // never finished as a new install EVERY DAY. Measured over 30 days: 21 ids
+  // re-counted under the flag, 2 under the event. Founder decision 2026-08-01;
+  // the weekly digest counts the same thing the same way.
   const installsSql = `
     SELECT uniqExact(distinct_id) FROM events
-    WHERE event = 'app.launched' AND properties.is_fresh_install = true
-      AND ${prod} AND ${win}`;
+    WHERE event = 'onboarding.started' AND ${prod} AND ${win}`;
 
   const onboardActivateSql = `
     SELECT

--- a/workers/daily-report/src/index.js
+++ b/workers/daily-report/src/index.js
@@ -224,7 +224,7 @@ export function reportHeader(dateStr) {
 // same booleans the adoption section returns. `totals` is deliberately absent -
 // it never degrades (#1720).
 const DEGRADED_SECTION_LABELS = [
-  ["installsDegraded", "new installs"],
+  ["installsDegraded", "people who began setting up"],
   ["onboardActivateDegraded", "onboarding/activation"],
   ["engineAndTierBDegraded", "transcription engine and AI-polish breakdown"],
   ["geoDegraded", "where they are"],
@@ -261,8 +261,8 @@ export function formatAdoption(data, buckets) {
   }
 
   const installsPart = data.installsDegraded
-    ? "New installs: temporarily unavailable."
-    : `New installs: ${data.freshInstalls}.`;
+    ? "People who began setting up: temporarily unavailable."
+    : `People who began setting up: ${data.freshInstalls}.`;
   const onboardPart = data.onboardActivateDegraded
     ? "Onboarding and activation: temporarily unavailable."
     : `People who finished setup that day: ${data.onboarded}. Of those, ${data.activated} also dictated that day.`;

--- a/workers/daily-report/test/report.test.js
+++ b/workers/daily-report/test/report.test.js
@@ -245,7 +245,7 @@ test("adoption section: golden fixture matches the founder-approved report shape
   assert.equal(reportHeader("2026-07-08"), "EnviousWispr Daily Report, Wednesday, July 8, 2026");
   assert.match(msg, /^Adoption\n/);
   assert.doesNotMatch(msg, /EnviousWispr Daily Report/);
-  assert.match(msg, /New installs: 90\. People who finished setup that day: 82\. Of those, 60 also dictated that day\./);
+  assert.match(msg, /People who began setting up: 90\. People who finished setup that day: 82\. Of those, 60 also dictated that day\./);
   assert.doesNotMatch(msg, /for the first time/);
   assert.doesNotMatch(msg, /out of 90/); // no funnel-bleed wording (r1 fix)
   assert.match(msg, /Total users: 110 people used the app that day\./);
@@ -288,15 +288,15 @@ test("adoption section: zero total_users omits the engine/polish section entirel
 
 test("adoption section: installsDegraded omits the freshInstalls number, keeps onboarding intact", () => {
   const msg = formatAdoption({ ...GOLDEN_DATA, installsDegraded: true }, GOLDEN_BUCKETS).join("\n");
-  assert.match(msg, /New installs: temporarily unavailable\./);
-  assert.doesNotMatch(msg, /New installs: 90/);
+  assert.match(msg, /People who began setting up: temporarily unavailable\./);
+  assert.doesNotMatch(msg, /began setting up: 90/);
   assert.match(msg, /People who finished setup that day: 82\. Of those, 60 also dictated that day\./);
-  assert.match(msg, /Note: .*new installs/);
+  assert.match(msg, /Note: .*people who began setting up/);
 });
 
 test("adoption section: onboardActivateDegraded omits onboarding, keeps installs intact", () => {
   const msg = formatAdoption({ ...GOLDEN_DATA, onboardActivateDegraded: true }, GOLDEN_BUCKETS).join("\n");
-  assert.match(msg, /New installs: 90\./);
+  assert.match(msg, /People who began setting up: 90\./);
   assert.match(msg, /Onboarding and activation: temporarily unavailable\./);
   assert.doesNotMatch(msg, /People who finished setup that day/);
   assert.match(msg, /Note: .*onboarding\/activation/);
@@ -330,7 +330,7 @@ test("adoption section: multiple degraded sections all appear in one combined no
   ).join("\n");
   const noteLine = msg.split("\n").find((l) => l.startsWith("Note:"));
   assert.ok(noteLine, "expected one combined Note line");
-  assert.match(noteLine, /new installs/);
+  assert.match(noteLine, /people who began setting up/);
   assert.match(noteLine, /where they are/);
 });
 
@@ -3897,4 +3897,32 @@ test("resolveDevIds refuses an empty result whose column set is malformed", asyn
     fetchFn: async () => fakeResponse(200, { results: [], columns: ["distinct_id"] }),
   });
   assert.deepEqual(empty, []);
+});
+
+test("installs counts BEGAN-ONBOARDING, not the launch-time fresh-install state", async () => {
+  // The existing source guardrail checks the ${prod} predicate and the absence
+  // of an inline dev-exclusion, so it could not see this change at all: the
+  // whole suite stayed green while the metric's MEANING moved. Locking the
+  // meaning, not just the plumbing.
+  //
+  // `is_fresh_install` is a STATE (`onboardingState != .completed`), true on
+  // every launch until setup finishes, so it re-counted anyone who never
+  // finished as a new install EVERY DAY. `onboarding.started` is an EVENT fired
+  // once on the "Get Started" tap. Measured over 30 days: 21 ids re-counted
+  // under the flag, 2 under the event. Founder decision 2026-08-01.
+  const fs = await import("node:fs");
+  const src = fs.readFileSync(new URL("../src/adoption.js", import.meta.url), "utf8");
+  const query = src.match(/const installsSql = `([\s\S]*?)`;/)?.[1];
+  assert.ok(query, "expected installsSql");
+  assert.match(query, /event = 'onboarding\.started'/);
+  assert.doesNotMatch(query, /is_fresh_install/);
+  // The weekly digest must count the same thing; they share the definition.
+  // Asserted on the QUERY BODY, not the file: the file also EXPLAINS why the
+  // old flag was wrong, and a whole-file match would fail on that prose - a
+  // check that forbids naming the thing it forbids using.
+  const weekly = fs.readFileSync(new URL("../../weekly-digest/src/index.js", import.meta.url), "utf8");
+  const weeklyQuery = weekly.match(/export function appUsageSql[\s\S]*?return `([\s\S]*?)`;/)?.[1];
+  assert.ok(weeklyQuery, "expected weekly appUsageSql");
+  assert.match(weeklyQuery, /uniqExactIf\(distinct_id, event = 'onboarding\.started'\) AS fresh/);
+  assert.doesNotMatch(weeklyQuery, /is_fresh_install/);
 });

--- a/workers/weekly-digest/README.md
+++ b/workers/weekly-digest/README.md
@@ -97,27 +97,27 @@ is what counts as really using the app. The section reports all three, matching
 the daily report's per-day shape:
 
 ```
-179 people used EnviousWispr this week.
-New installs: 46.
+160 people used EnviousWispr this week.
+43 people began setting up.
 40 people finished setting up. Of those, 35 also dictated.
 ```
 
-"Used" means **at least one successful dictation**, not a launch, matching the
-daily report's headline and the founder's definition. Someone who opens the app
-and never dictates is not counted as a user.
+"Used" means at least one successful dictation, not a launch. Someone who opens
+the app and never dictates is not counted as a user.
 
-`is_fresh_install` is `settings.onboardingState != .completed`
-(`Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift:221`), which is
-why "install" means begun-onboarding rather than first-ever-launch. Two
-consequences worth knowing before reading the number as first launches:
+"Began setting up" comes from the `onboarding.started` EVENT, fired on the
+"Get Started" tap (`OnboardingV2View.swift:670`). It says setup BEGAN in the
+window, not that it was a first time: Diagnostics has a "Restart Onboarding"
+action (`DiagnosticsSettingsView.swift:106`), so an existing user can emit it
+again. The wording stays at what the event proves.
 
-- It stays true on **every launch until setup finishes**, so someone who never
-  completes onboarding counts again in each week they open the app. Measured
-  2026-08-01: 21 ids carried the flag on more than one day across 30 days, and
-  the 2026-07-25..08-01 window showed 46 against 43 ids genuinely launching for
-  the first time.
-- The funnel is what makes that readable. A gap between installs and finished
-  setup is the interesting signal, not noise to be cleaned out of the top line.
+**It is NOT `is_fresh_install`, and that distinction is the whole point** (#1910).
+That property is a STATE, `onboardingState != .completed`, so it stayed true on
+every launch until setup finished and re-counted anyone who never finished as a
+new install every single week. Measured over 30 days: 21 ids re-counted under
+the flag, 2 under the event. The week 2026-07-25..08-01 reads 43 rather than 46,
+and 43 is exactly the number of ids whose first-ever launch fell in that window.
 
-The daily report counts the same property the same way, so both reports share
-this definition. Change them together or not at all.
+The daily report counts the same thing the same way. A source-guardrail test in
+`workers/daily-report/test/report.test.js` asserts BOTH files, so the two cannot
+drift apart silently.

--- a/workers/weekly-digest/src/index.js
+++ b/workers/weekly-digest/src/index.js
@@ -338,21 +338,32 @@ const hostFilter = `properties.$host IN (${SITE_HOSTS.map((h) => `'${h}'`).join(
  * the weekly headline a different metric from the daily report's, which has
  * always counted successful dictators.
  *
- * FRESH still comes from app.launched, because is_fresh_install rides on that
- * event. Both live in ONE query over the two event types rather than two round
- * trips; `WHERE event IN (...)` keeps it scoped.
+ * FRESH is `onboarding.started`, an EVENT fired once when the user taps "Get
+ * Started" (OnboardingV2View.swift:670). It replaced `is_fresh_install`, which
+ * is a STATE - `onboardingState != .completed` - and therefore stayed true on
+ * every launch until setup finished, re-counting anyone who never finished as a
+ * new install every single day and week. Measured over 30 days: 21 ids were
+ * re-counted under the flag, 2 under the event, and those 2 look like genuine
+ * re-onboards. For the 2026-07-25..08-01 week it reads 43 rather than 46, and
+ * 43 is exactly the number of ids whose first-ever launch fell in that window.
  *
- * New installs uses the app's own is_fresh_install rather than PostHog's
- * first_time_for_user (founder decision 2026-08-01): it is what the daily
- * report counts, and reproducing first_time_for_user in HogQL needs a
- * whole-history min(timestamp) per user, the unbounded-scan shape that caused
- * the #1655 and #1716 timeouts. */
+ * An install therefore means "began onboarding" (founder definition
+ * 2026-08-01), which is what the label now literally says - and no more than
+ * that. The line deliberately does NOT say "for the first time": Diagnostics
+ * has a "Restart Onboarding" action (DiagnosticsSettingsView.swift:106), so an
+ * existing user can emit this event again. It proves setup BEGAN in the window,
+ * not that it was ever a first time, and claiming otherwise would be the same
+ * overclaiming that made is_fresh_install misleading.
+ *
+ * Both numbers come from ONE query over the two event types rather than two
+ * round trips; `WHERE event IN (...)` keeps it scoped. app.launched is no
+ * longer read at all here. */
 export function appUsageSql(prod, win) {
   return `SELECT
       uniqExactIf(distinct_id, event = 'dictation.completed' AND properties.result = 'success') AS active,
-      uniqExactIf(distinct_id, event = 'app.launched' AND properties.is_fresh_install = true) AS fresh
+      uniqExactIf(distinct_id, event = 'onboarding.started') AS fresh
     FROM events
-    WHERE event IN ('dictation.completed', 'app.launched') AND ${prod} AND ${win}`;
+    WHERE event IN ('dictation.completed', 'onboarding.started') AND ${prod} AND ${win}`;
 }
 
 /** The week's active-user population (successful dictators), used ONCE as an
@@ -562,8 +573,8 @@ export function formatAppUsage(usage, funnel) {
     ? `${n(usage.active)} people used EnviousWispr this week.`
     : `The number of people who used the app was ${UNAVAILABLE}.`);
   lines.push(usage
-    ? `New installs: ${n(usage.fresh)}.`
-    : `New installs were ${UNAVAILABLE}.`);
+    ? `${n(usage.fresh)} people began setting up.`
+    : `The number of people who began setting up was ${UNAVAILABLE}.`);
   // The two steps after install, on the founder's definition (2026-08-01): an
   // install is someone who has begun onboarding, finishing setup is its own
   // step, and ONE successful dictation is what counts as really using it. Same

--- a/workers/weekly-digest/test/digest.test.js
+++ b/workers/weekly-digest/test/digest.test.js
@@ -32,7 +32,7 @@ import worker, {
 // Every event-property reference must be qualified as properties.<name>: a bare
 // name does not resolve in PostHog HogQL. This regex catches the regression
 // Codex flagged twice on the pre-#1589 builders.
-const BARE_PROP = /(?<!properties\.)\b(excluded_reason|source_bucket|is_fresh_install|app_version)\b/;
+const BARE_PROP = /(?<!properties\.)\b(excluded_reason|source_bucket|app_version)\b/;
 
 const ENV = {
   POSTHOG_PROJECT_ID: "354235",
@@ -201,7 +201,9 @@ test("the merged downloads query preserves both original predicates", () => {
 
 test("app usage counts fresh installs by the app's own flag, not PostHog first-seen", () => {
   const sql = appUsageSql("P", "W");
-  assert.match(sql, /uniqExactIf\(distinct_id, event = 'app\.launched' AND properties\.is_fresh_install = true\)/);
+  assert.match(sql, /uniqExactIf\(distinct_id, event = 'onboarding\.started'\) AS fresh/);
+  // The STATE flag re-counted anyone who never finished setup, every window.
+  assert.doesNotMatch(sql, /is_fresh_install/);
   // Single whole-window uniqExactIf counts, never per-bucket counts a caller
   // could sum into a double count.
   assert.doesNotMatch(sql, /interval/i);
@@ -325,7 +327,7 @@ test("a malformed metric response posts the failure notice and no digest", async
 test("zero dev ids is a legitimate state and must not produce NOT IN ()", async () => {
   const h = harness({ posthog: { dev_ids: () => ok({ results: [], columns: ["distinct_id"] }) } });
   await h.run();
-  const appUsage = h.state.sql.find((q) => q.includes("app.launched"));
+  const appUsage = h.state.sql.find((q) => q.includes("AS fresh"));
   assert.match(appUsage, /environment = 'production'/);
   assert.doesNotMatch(appUsage, /NOT IN \(\)/);
 });
@@ -333,7 +335,7 @@ test("zero dev ids is a legitimate state and must not produce NOT IN ()", async 
 test("resolved dev ids reach the app-usage query as a literal exclusion list", async () => {
   const h = harness();
   await h.run();
-  const appUsage = h.state.sql.find((q) => q.includes("app.launched"));
+  const appUsage = h.state.sql.find((q) => q.includes("AS fresh"));
   assert.match(appUsage, /distinct_id NOT IN \('dev-a', 'dev-b'\)/);
 });
 
@@ -760,7 +762,7 @@ test("the app-usage line does not claim first-time installs it cannot prove", as
   const h = harness();
   await h.run();
   const text = h.state.posts[0].embeds[3].description;
-  assert.match(text, /New installs: 51\./);
+  assert.match(text, /51 people began setting up\./);
   assert.match(text, /31 people finished setting up\. Of those, 24 also dictated\./);
   // The install number is launches-without-completed-onboarding, so it must not
   // claim first-time installs it cannot prove.
@@ -772,7 +774,7 @@ test("the onboarding funnel reads install, setup, then first dictation", async (
   await h.run();
   const text = h.state.posts[0].embeds[3].description;
   assert.match(text, /189 people used EnviousWispr this week\./);
-  assert.match(text, /New installs: 51\./);
+  assert.match(text, /51 people began setting up\./);
   assert.match(text, /31 people finished setting up\. Of those, 24 also dictated\./);
 });
 
@@ -809,7 +811,7 @@ test("a failed funnel query leaves the usage line intact, and vice versa", async
   await assert.rejects(() => usageDown.run(), /unavailable sections/);
   const b = usageDown.state.posts[0].embeds[3].description;
   assert.match(b, /31 people finished setting up/);
-  assert.match(b, /New installs were temporarily unavailable/);
+  assert.match(b, /The number of people who began setting up was temporarily unavailable/);
 });
 
 test("an EMPTY response with a malformed column set degrades, not 'none yet'", async () => {
@@ -848,12 +850,12 @@ test("a genuinely empty response WITH valid columns is still a real empty week",
 test("the usage headline counts successful DICTATORS, not launches", async () => {
   const h = harness();
   await h.run();
-  const sql = h.state.sql.find((q) => q.includes("is_fresh_install"));
+  const sql = h.state.sql.find((q) => q.includes("AS fresh"));
   // Founder definition: one successful dictation is what counts as using it.
   assert.match(sql, /uniqExactIf\(distinct_id, event = 'dictation\.completed' AND properties\.result = 'success'\) AS active/);
-  assert.match(sql, /uniqExactIf\(distinct_id, event = 'app\.launched' AND properties\.is_fresh_install = true\) AS fresh/);
+  assert.match(sql, /uniqExactIf\(distinct_id, event = 'onboarding\.started'\) AS fresh/);
   // One round trip over both event types, scoped so it does not scan everything.
-  assert.match(sql, /WHERE event IN \('dictation\.completed', 'app\.launched'\)/);
+  assert.match(sql, /WHERE event IN \('dictation\.completed', 'onboarding\.started'\)/);
 });
 
 test("dev ids are read by column NAME, not by position", async () => {
@@ -863,7 +865,18 @@ test("dev ids are read by column NAME, not by position", async () => {
     dev_ids: () => ok({ results: [["2026-08-01", "dev-a"]], columns: ["day", "distinct_id"] }),
   } });
   await h.run();
-  const sql = h.state.sql.find((q) => q.includes("is_fresh_install"));
+  const sql = h.state.sql.find((q) => q.includes("AS fresh"));
   assert.match(sql, /NOT IN \('dev-a'\)/);
   assert.doesNotMatch(sql, /2026-08-01/);
+});
+
+test("the install line claims setup BEGAN, never that it was a first time", async () => {
+  // Diagnostics has a "Restart Onboarding" action, so an existing user can emit
+  // onboarding.started again. Claiming "for the first time" would be the same
+  // overclaiming that made is_fresh_install misleading, in a new place.
+  const h = harness();
+  await h.run();
+  const text = h.state.posts[0].embeds[3].description;
+  assert.match(text, /51 people began setting up\./);
+  assert.doesNotMatch(text, /first time/);
 });


### PR DESCRIPTION
Closes #1910.

Both reports counted "new installs" from `properties.is_fresh_install` on `app.launched`. That is a **state**, not an event — `AppLifecycleCoordinator.swift:221` derives it as `settings.onboardingState != .completed` — so it stayed true on **every launch until setup finished**. Anyone who installed and never completed onboarding was counted as a new install again **every day** in the daily report, and again every week in the weekly digest.

`onboarding.started` already existed and is the right signal: fired on the "Get Started" tap (`OnboardingV2View.swift:670`).

## Measured before changing anything

Production only, 30 days:

| | Flag | Event |
|---|---|---|
| ids firing on more than one day | 21 | **2** |
| week 2026-07-25..08-01 | 46 | **43** |
| day 2026-07-31 ET | 10 | **9** |

**43 is exactly the number of ids whose first-ever launch fell in that week** — the independent cross-check that the new signal means what it claims. The remaining 2 look like genuine re-onboards after a reinstall, which should count twice.

## The wording says what the event proves, and no more

"began setting up", **not** "for the first time". Diagnostics has a "Restart Onboarding" action (`DiagnosticsSettingsView.swift:106`), so an existing user can emit the event again. It proves setup BEGAN in the window. Claiming a first time would be the same overclaiming that made `is_fresh_install` misleading, moved somewhere new — caught in review, now locked by a test.

```
Daily:  People who began setting up: 9. People who finished setup that day: 8. Of those, 7 also dictated that day.
Weekly: 43 people began setting up. 40 people finished setting up. Of those, 35 also dictated.
```

## Two process notes worth keeping

**A green suite hid this change entirely.** daily-report's source guardrail asserts each query references `${prod}` and embeds no raw dev-exclusion, so it passed unchanged while the metric's *meaning* moved underneath it. The new test locks the meaning in **both** files, verified with two-way controls: reverting either report's query fails it.

**My first grep said the event was never fired.** It found no callers of `onboardingStarted()` and I nearly concluded the event was dead. Live PostHog said 619 events across 608 people. The grep was wrong, not the data.

## Relabelled everywhere, after review caught a partial sweep

The first pass changed the weekly's positive line and left "New installs" on the daily report, on both workers' unavailable branches, in the daily degradation note and in both READMEs — so a restarting user was still reported as a new install. The sweep now covers every label site in both workers plus the knowledge file, whose row had ended up stating both definitions in one sentence.

## Validation

69 tests in weekly-digest, 155 in daily-report, both green. `wrangler deploy --dry-run` clean in both. Live smoke on both against production, nothing posted. Three whole-diff review rounds, last clean.

Deploy is manual: weekly first, then daily, per `workers/shared/README.md`.
