### PR TITLE
fix(settings): stop claiming Model Ready while the engine is still loading (Closes #1635)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/EngineCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/EngineCoordinator.swift
@@ -114,6 +114,17 @@ final class EngineCoordinator {
   /// the Task.
   @ObservationIgnored private var warmTask: Task<Void, Never>?
   @ObservationIgnored private var warmingBackend: ASRBackendType?
+  /// #1635. Identifies WHICH `startWarm` a completion belongs to, so a superseded warm's
+  /// cleanup cannot clear the REPLACEMENT's `warmingBackend`. Without it, `startWarm`
+  /// cancels the prior Task and immediately reassigns the field, while the old Task's
+  /// unconditional clear still runs when its awaited load finally returns — the row would
+  /// then lose "Getting the model ready" while the engine is still loading.
+  ///
+  /// The window is narrow: once readiness reports `.warming`, gate 4b defers and JOINS
+  /// rather than starting a second warm. It is the interval between the assignment and
+  /// that readiness transition. `&+=` because a wrapping counter cannot trap, and a
+  /// collision would need 2^64 warms while one Task is still in flight.
+  @ObservationIgnored private var warmGeneration: UInt64 = 0
   /// The engine whose in-flight load gate 4b is currently joining (so repeated
   /// gate-4b pokes don't spawn duplicate join tasks).
   @ObservationIgnored private var joiningBackend: ASRBackendType?
@@ -141,7 +152,7 @@ final class EngineCoordinator {
   init(dependencies: Dependencies) {
     self.deps = dependencies
     self.status = EngineCoordinator.snapshot(
-      deps: dependencies, switchPhase: .idle, blockedReason: nil)
+      deps: dependencies, switchPhase: .idle, blockedReason: nil, warmInFlight: nil)
     let (stream, continuation) = AsyncStream<PokeReason>.makeStream(
       bufferingPolicy: .bufferingNewest(1))
     self.pokeStream = stream
@@ -391,7 +402,15 @@ final class EngineCoordinator {
     if warmingBackend == backend, warmTask != nil { return }
 
     warmTask?.cancel()
+    // #1635: stamp this warm BEFORE the field is reassigned, so a superseded task's
+    // cleanup can recognise that the field no longer belongs to it.
+    warmGeneration &+= 1
+    let generation = warmGeneration
     warmingBackend = backend
+    // #1635: publish HERE. This is the only moment a Settings row can learn a warm has
+    // begun. The switch published immediately before this call, and the next publication is
+    // the `.warmCompleted` poke roughly 27 seconds later (WhisperKit engine-swap p50).
+    publishStatus()
     warmTask = Task(priority: .utility) { [weak self] in
       guard let self else { return }
       // #1707 Phase 3 (§3.2, row 4): hold a mutation claim for the FULL
@@ -403,7 +422,10 @@ final class EngineCoordinator {
       let claimOutcome = await self.deps.engineMutationScope.withClaim(site: "startWarm") {
         let start = ContinuousClock.now
         let outcome = await self.deps.warm(backend)
-        self.warmingBackend = nil
+        // #1635: clear only if this warm still owns the field. Guarding the ASSIGNMENT
+        // rather than returning early deliberately preserves the cancellation check and
+        // the outcome telemetry below, which an early return would skip.
+        if self.warmGeneration == generation { self.warmingBackend = nil }
         if Task.isCancelled { return }
         let ms = Self.elapsedMs(since: start)
         switch outcome {
@@ -435,7 +457,12 @@ final class EngineCoordinator {
         self.poke(.warmCompleted)
       }
       if case .refused = claimOutcome {
+        // #1635: a refusal has no `.warmCompleted` poke to publish for it, so it must
+        // publish its own clear — otherwise the row keeps showing "Getting the model
+        // ready" until some unrelated poke happens to republish.
+        guard self.warmGeneration == generation else { return }
         self.warmingBackend = nil
+        self.publishStatus()
       }
     }
   }
@@ -462,13 +489,15 @@ final class EngineCoordinator {
 
   private func publishStatus() {
     status = Self.snapshot(
-      deps: deps, switchPhase: currentSwitchPhase, blockedReason: currentBlockedReason)
+      deps: deps, switchPhase: currentSwitchPhase, blockedReason: currentBlockedReason,
+      warmInFlight: warmingBackend)
   }
 
   private static func snapshot(
     deps: Dependencies,
     switchPhase: EngineStatus.SwitchPhase,
-    blockedReason: EngineStatus.BlockedReason?
+    blockedReason: EngineStatus.BlockedReason?,
+    warmInFlight: ASRBackendType?
   ) -> EngineStatus {
     let sel = deps.selectedBackend()
     let act = deps.activeBackend()
@@ -481,7 +510,8 @@ final class EngineCoordinator {
       whisperKitActive: deps.isEngineActive(.whisperKit),
       switchPhase: switchPhase,
       selectedInstalled: deps.isInstalled(sel),
-      blockedReason: blockedReason)
+      blockedReason: blockedReason,
+      warmInFlight: warmInFlight)
   }
 
   /// Record a deferral, emit `change_blocked` once per reason per epoch, publish.

--- a/Sources/EnviousWisprAppKit/App/EngineStatus.swift
+++ b/Sources/EnviousWisprAppKit/App/EngineStatus.swift
@@ -44,6 +44,20 @@ struct EngineStatus: Sendable {
   /// WhisperKit is true only once downloaded).
   let selectedInstalled: Bool
   let blockedReason: BlockedReason?
+  /// The engine whose COORDINATOR-OWNED warm is in flight right now, else nil.
+  ///
+  /// #1635. This is coordinator INTENT, not adapter readiness, and the distinction is
+  /// load-bearing: `warmingBackend` is assigned synchronously before the warm Task is
+  /// spawned, whereas the adapter does not reach `.warming` until inside the awaited
+  /// load. A snapshot keyed on readiness at warm-start would still read `.notReady`,
+  /// which is how the previous attempt at this feature produced a label that could
+  /// never appear.
+  ///
+  /// Scope: coordinator-owned post-switch warms ONLY. The launch preload
+  /// (`SetupCoordinator`) and the cold-press warm (`ColdPressGuard`) call their drivers
+  /// directly and never touch `warmingBackend`, so this stays nil for them. Widening it
+  /// would mean owning every warm entry point, which is #1882's job, not this field's.
+  let warmInFlight: ASRBackendType?
 
   /// The selected engine differs from the active one — a switch is owed.
   var isDiverged: Bool { selected != active }

--- a/Sources/EnviousWisprAppKit/Views/Settings/ModelPreparingCopy.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/ModelPreparingCopy.swift
@@ -22,6 +22,36 @@ import Foundation
 /// for about a quarter of users. A progress percentage is impossible — WhisperKit exposes
 /// no load-progress stream (`whisperkit-research.md` FACT: cold-start-warmup-lifecycle).
 ///
+/// ## THE ROW STILL LIES ON A COLD PRESS. This is known, observed, and accepted.
+///
+/// **Do not read the scope note above as a theoretical edge.** On 2026-08-01 the founder
+/// reproduced it live: the warming pill reading "Getting dictation ready… WhisperKit is
+/// warming up after a restart" sat ON TOP of this row reading "Model Ready", both visible
+/// in one screenshot. His words: "the pill is more accurate than the settings page." The
+/// `app.log` line for that press is
+/// `press blocked — engine not ready (readinessAtPTT=warming) backend=whisperKit`, i.e. the
+/// `ColdPressGuard` path, which calls `ensureEngineWarm(reason: .coldPress)` directly and
+/// never touches `warmingBackend`.
+///
+/// **Founder ruling 2026-08-01: SHIP ANYWAY, and write down why.** The reasoning, so the
+/// next person can disagree with the actual argument rather than guess at it:
+/// - The originally filed bug (#1635, 2026-07-17) is the post-download / engine-swap
+///   moment, which this DOES fix. That is the path a user reaches by installing the
+///   optional engine, and it is the one with the 27.4s median.
+/// - The cold-press case is rarer than the reproduction suggests. The shipped default for
+///   "Unload model after" is `never` (`SettingsDefaultValues.swift:49`), so the engine stays
+///   resident; the founder had switched it to `immediately` specifically to make this
+///   testable. A genuinely cold press mostly means first launch or a post-OS-update cache
+///   wipe.
+/// - On a cold press the user gets the pill, which is honest and already correct. The row
+///   is then redundant rather than the only signal.
+/// - Fixing it properly means the coordinator learning about warms it does not own, which
+///   is #1882's engine load-state consolidation, not a label change. A shortcut here would
+///   be a fourth place guessing at readiness, which is the disease #1171 cured.
+///
+/// So: if you are here because someone reported "Model Ready while it says warming up",
+/// that is THIS, it is known, and the fix lives in #1882 — not in widening this file.
+///
 /// Copy frozen by the founder 2026-08-01, who explicitly declined further wordsmithing.
 /// `ModelPreparingCopyTests` pins both strings so a change is a conscious act.
 /// No em-dashes or en-dashes (brand rule).

--- a/Sources/EnviousWisprAppKit/Views/Settings/ModelPreparingCopy.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/ModelPreparingCopy.swift
@@ -1,0 +1,54 @@
+import EnviousWisprCore
+import Foundation
+
+/// #1635: canonical copy for the WhisperKit "Model Setup" row's two settled-ish states.
+///
+/// The row previously had ONE state and it lied. "Model Ready" is delivery truth — the
+/// model is admitted on disk — but the engine then loads into memory for a measured p50 of
+/// 27.4s on the engine-swap path (90d production `coldstart.warmup_completed`, WhisperKit,
+/// `reason = engine_swap`; p90 44.2s). A press inside that window is correctly refused with
+/// the warming pill, so the green tick contradicted the app for roughly half a minute on
+/// the exact path a user hits right after downloading.
+///
+/// **THE DURATION IS HONEST ONLY BECAUSE THE STATE IS NARROW, and that is not an accident.**
+/// `warmInFlight` is set solely by `EngineCoordinator.startWarm`, which is the
+/// post-switch warm — precisely the `engine_swap` population the 27.4s median describes.
+/// The launch preload and the cold-press warm call their drivers directly and never set it,
+/// and their medians are 10.1s and 9.0s. If this state is ever widened to cover those
+/// paths, "about 30 seconds" becomes wrong and must be re-derived from whatever population
+/// it then describes. Do not widen one without the other.
+///
+/// "usually" is load-bearing: p90 on this path is 44.2s, so a hard promise would be broken
+/// for about a quarter of users. A progress percentage is impossible — WhisperKit exposes
+/// no load-progress stream (`whisperkit-research.md` FACT: cold-start-warmup-lifecycle).
+///
+/// Copy frozen by the founder 2026-08-01, who explicitly declined further wordsmithing.
+/// `ModelPreparingCopyTests` pins both strings so a change is a conscious act.
+/// No em-dashes or en-dashes (brand rule).
+enum ModelPreparingCopy {
+  /// Shown while the coordinator-owned warm is in flight.
+  static let preparing = "Getting the model ready. This usually takes about 30 seconds."
+  /// The unchanged settled label.
+  static let ready = "Model Ready"
+
+  /// Whether the row should show the preparing state.
+  ///
+  /// Deliberately takes `warmInFlight` and NOTHING else. It never consults adapter
+  /// readiness: a snapshot keyed on readiness at warm-start still reads `.notReady`,
+  /// because the adapter does not reach `.warming` until inside the awaited load. That is
+  /// exactly how the previous attempt at this issue produced a label that could never
+  /// appear.
+  ///
+  /// `nil` covers both "nothing is warming" and "no coordinator in the environment"
+  /// (previews and tests). Both fail toward the copy we have shipped for months; a stale
+  /// "ready" is the status quo, whereas a stuck "preparing" would be a NEW lie with no way
+  /// out.
+  static func isPreparing(warmInFlight: ASRBackendType?) -> Bool {
+    warmInFlight == .whisperKit
+  }
+
+  /// The label for a given warm state. Convenience over `isPreparing` for the row.
+  static func label(warmInFlight: ASRBackendType?) -> String {
+    isPreparing(warmInFlight: warmInFlight) ? preparing : ready
+  }
+}

--- a/Sources/EnviousWisprAppKit/Views/Settings/SpeechEngineSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SpeechEngineSettingsView.swift
@@ -543,6 +543,15 @@ struct SpeechEngineSettingsView: View {
               .font(.stHelper)
               .foregroundStyle(.stTextSecondary)
             }
+            // #1635: on the SUBVIEW that renders the copy, so the event can only fire when
+            // the words genuinely entered the visible hierarchy. `reason` is the constant
+            // "engine_swap" because `warmInFlight` is set solely by the coordinator-owned
+            // post-switch warm; the view has no wider reason to report and must not invent
+            // one. Reappearance is another honest impression, so there is no dedup here.
+            .onAppear {
+              TelemetryService.shared.settingsModelPreparingImpression(
+                engine: "whisperKit", reason: "engine_swap")
+            }
           } else {
             Label(
               ModelPreparingCopy.label(

--- a/Sources/EnviousWisprAppKit/Views/Settings/SpeechEngineSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SpeechEngineSettingsView.swift
@@ -526,8 +526,31 @@ struct SpeechEngineSettingsView: View {
     case .ready:
       VStack(alignment: .leading, spacing: 6) {
         HStack {
-          Label("Model Ready", systemImage: "checkmark.circle.fill")
+          // #1635: delivery `.ready` means the model is on DISK. The engine then loads into
+          // memory for a measured p50 of 27.4s on this path, and a press during that window
+          // is correctly refused — so a green tick here contradicted the app for roughly
+          // half a minute. `warmInFlight` is coordinator intent, published synchronously at
+          // warm-start; do NOT swap it for adapter readiness, which is still `.notReady` at
+          // that moment and is why the previous attempt's label could never appear.
+          if ModelPreparingCopy.isPreparing(warmInFlight: engineCoordinator?.status.warmInFlight) {
+            HStack(spacing: 6) {
+              ProgressView()
+                .controlSize(.small)
+              Text(
+                ModelPreparingCopy.label(
+                  warmInFlight: engineCoordinator?.status.warmInFlight)
+              )
+              .font(.stHelper)
+              .foregroundStyle(.stTextSecondary)
+            }
+          } else {
+            Label(
+              ModelPreparingCopy.label(
+                warmInFlight: engineCoordinator?.status.warmInFlight),
+              systemImage: "checkmark.circle.fill"
+            )
             .foregroundStyle(.stSuccess)
+          }
           Spacer()
           // 2c: the way out. An app that installs 1.5 GB must offer deletion.
           // Removal does NOT switch the selected engine (founder ruling 2.5.5

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -1920,6 +1920,45 @@ public final class TelemetryService {
       ])
   }
 
+  /// #1635: the WhisperKit setup row's "getting the model ready" copy genuinely entered the
+  /// visible view hierarchy.
+  ///
+  /// WHY THIS EXISTS AT ALL. The previous attempt at #1635 shipped a label that could NEVER
+  /// appear, behind four passing tests, because nothing published the state it keyed on. No
+  /// existing telemetry could have caught that: `coldstart.warmup_*` measures how long the
+  /// engine took to load, never whether we told the user anything. This event answers the
+  /// one question those cannot — did the copy actually reach a screen.
+  ///
+  /// EMITTED BY THE VIEW, NEVER THE COORDINATOR. The event name claims a render, and only
+  /// the thing that renders can honestly claim it. Emitting from `EngineCoordinator` would
+  /// assert a render it never observes, which is the same false-claim shape as the label
+  /// this issue exists to fix.
+  ///
+  /// An impression, not a session: a SwiftUI subview can disappear and reappear during one
+  /// warm, so a reappearance is another honest impression. There is deliberately no
+  /// deduplication, no clear event, and no `elapsed_ms` — a view that can vanish mid-warm
+  /// cannot measure the warm, and `coldstart.warmup_*` already owns that duration.
+  ///
+  /// Privacy: two enum-shaped strings, no content
+  /// (`sentry-operations.md` RULE: telemetry-privacy-boundary).
+  public func settingsModelPreparingImpression(engine: String, reason: String) {
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "settings.model_preparing_impression",
+          stringProps: [
+            "engine": engine,
+            "reason": reason,
+          ]))
+    #endif
+    PostHogSDK.shared.capture(
+      "settings.model_preparing_impression",
+      properties: [
+        "engine": engine,
+        "reason": reason,
+      ])
+  }
+
   /// Telemetry Bible Phase 4 (#1173): an API key was saved or removed. `action`
   /// is `save` (code can't cheaply tell first-add from overwrite) or `remove`;
   /// `result` is `success` or `failure`. Key material is never logged.

--- a/Tests/EnviousWisprTests/App/EngineCoordinatorTestSupport.swift
+++ b/Tests/EnviousWisprTests/App/EngineCoordinatorTestSupport.swift
@@ -38,6 +38,29 @@ final class FakeEngineDeps {
   /// Optional hook awaited INSIDE `warm`, before it resolves.
   var onWarmAwait: (@MainActor () async -> Void)?
 
+  /// #1635: the mutation scope handed to the coordinator. Defaults to the existing
+  /// always-allowed test value so every prior test is byte-for-byte unchanged; a test that
+  /// needs the REFUSED branch (which clears and republishes `warmInFlight` without any
+  /// `.warmCompleted` poke to follow it) swaps in a refusing `.live`.
+  var mutationScope: EngineMutationScope = .alwaysAllowedForTesting
+
+  /// Records the site string of every refused claim, so a test can prove the refusal
+  /// actually happened rather than inferring it from an absence.
+  private(set) var refusedSites: [String] = []
+
+  /// Released from `onRefused`, so a test can await the refusal instead of polling.
+  var onRefusedSignal: (@MainActor () -> Void)?
+
+  /// A scope that refuses every claim, recording the site and firing the signal.
+  func makeRefusingScope() -> EngineMutationScope {
+    .live(
+      tryBegin: { false }, end: { false }, wake: {},
+      onRefused: { site in
+        self.refusedSites.append(site)
+        self.onRefusedSignal?()
+      })
+  }
+
   init(
     selected: ASRBackendType = .parakeet,
     active: ASRBackendType = .parakeet,
@@ -89,7 +112,7 @@ final class FakeEngineDeps {
         if case .ready = outcome { self.setReadiness(backend, .ready) }
         return outcome
       },
-      engineMutationScope: .alwaysAllowedForTesting)
+      engineMutationScope: mutationScope)
   }
 
   /// Build a started coordinator over this fake. `start()` fires the initial

--- a/Tests/EnviousWisprTests/App/EngineCoordinatorTestSupport.swift
+++ b/Tests/EnviousWisprTests/App/EngineCoordinatorTestSupport.swift
@@ -1,6 +1,7 @@
 import EnviousWisprCore
 import EnviousWisprPipeline
 import Foundation
+import Observation
 
 @testable import EnviousWisprASR
 @testable import EnviousWisprAppKit
@@ -21,7 +22,21 @@ final class FakeEngineDeps {
   var whisperKitActive = false
   var recovering = false
   var parakeetInstalled = true
-  var whisperKitInstalled = true
+
+  /// #1635: backed by an `@Observable` box so `EngineCoordinator.observeInstalledState()`
+  /// can genuinely track it.
+  ///
+  /// That method wraps `deps.isInstalled(.whisperKit)` in `withObservationTracking`, and
+  /// its own comment says "In unit tests the fake reader touches no `@Observable` source,
+  /// so this is inert." A plain stored property therefore made the real download-completion
+  /// trigger untestable, and a test could only fake it by calling
+  /// `poke(.setupStateChanged)` by hand — which exercises the EFFECT, not the trigger.
+  /// Reading through this box makes the observation fire for real.
+  var whisperKitInstalled: Bool {
+    get { whisperKitInstalledBox.value }
+    set { whisperKitInstalledBox.value = newValue }
+  }
+  private let whisperKitInstalledBox = ObservableInstallFlag(true)
 
   /// Switch bookkeeping.
   private(set) var switchCount = 0
@@ -150,3 +165,12 @@ func enginePoll(
 }
 
 enum FakeWarmError: Error { case failed }
+
+/// #1635: an `@Observable` cell so `FakeEngineDeps.whisperKitInstalled` participates in
+/// `withObservationTracking`. Without this, `EngineCoordinator.observeInstalledState()` is
+/// inert under test and the real download-completion trigger cannot be exercised.
+@Observable
+final class ObservableInstallFlag {
+  var value: Bool
+  init(_ value: Bool) { self.value = value }
+}

--- a/Tests/EnviousWisprTests/App/EngineCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/EngineCoordinatorTests.swift
@@ -561,6 +561,212 @@ struct EngineCoordinatorTests {
       #expect(warm.intProps["duration_ms"] != nil)
     }
   #endif
+
+  // MARK: - #1635 published warm-in-flight
+
+  /// THE test the parked attempt lacked. It must fail if `startWarm` stops publishing.
+  ///
+  /// Every assertion reads `c.status`, the PUBLISHED snapshot, never a hand-built
+  /// `EngineStatus` — four green copy-mapping tests over hand-supplied values are exactly
+  /// how #1635 previously shipped a label that could never appear.
+  ///
+  /// Note what the fake does NOT do: `warm` leaves readiness at `.notReady` until the
+  /// outcome resolves. So while the latch is held, adapter readiness is `.notReady`, and
+  /// `warmInFlight == .whisperKit` can ONLY come from the coordinator's own field. That is
+  /// the acceptance check "publication must work before adapter readiness becomes
+  /// `.warming`", proved by construction rather than asserted.
+  @Test("a coordinator-owned warm publishes warmInFlight while the load is still running")
+  func warmInFlightIsPublishedDuringTheWarm() async {
+    let fake = FakeEngineDeps(selected: .parakeet, active: .parakeet)
+    let latch = AsyncLatch()
+    fake.onWarmAwait = { await latch.wait() }
+    let c = fake.makeStartedCoordinator()
+    fake.selected = .whisperKit
+    c.poke(.settingsChanged)
+
+    // Signal, not a clock: resumes the instant the warm actually parks inside `deps.warm`.
+    await latch.waitUntilWaiting()
+    #expect(
+      c.status.warmInFlight == .whisperKit,
+      "the published snapshot must name the engine being warmed")
+    #expect(
+      c.status.activeReadiness != .warming,
+      "published BEFORE readiness reports .warming — the race that killed the last attempt")
+
+    // Completion signal from the SUBJECT, not from the stub: the coordinator fires this
+    // after a warm settles and republishes.
+    let warmCompleted = AsyncLatch()
+    c.onEngineStateChangedForRecovery = { warmCompleted.release() }
+    latch.release()
+    await warmCompleted.wait()
+    #expect(c.status.warmInFlight == nil, "a settled warm must clear the published field")
+  }
+
+  /// Two-way control: a healthy engine that never warms must never announce one.
+  /// Without this, a field stuck at non-nil would pass the test above.
+  @Test("a converged ready engine never publishes warmInFlight")
+  func warmInFlightStaysNilWhenNothingWarms() async {
+    let fake = FakeEngineDeps(
+      selected: .whisperKit, active: .whisperKit, whisperKitReadiness: .ready)
+    let c = fake.makeStartedCoordinator()
+    // Signal, not a window: this returns once the coordinator has fully converged, which is
+    // the exact point at which a spurious warm would already have announced itself.
+    await c.ensureSelectedReadyForPress()
+    #expect(c.status.warmInFlight == nil, "nothing is loading, so nothing may claim to be")
+    #expect(fake.warmCount == 0, "and no warm was started at all")
+  }
+
+  /// A FAILED warm must not strand the field. Round 2 of the parked review killed a design
+  /// that mapped every not-ready value to a progress label precisely because a failed warm
+  /// settles into `.notReady` and then idles forever.
+  @Test("a failed warm clears warmInFlight instead of stranding it")
+  func warmInFlightClearsAfterAFailedWarm() async {
+    let fake = FakeEngineDeps(selected: .parakeet, active: .parakeet)
+    fake.warmOutcome[.whisperKit] = .failed(FakeWarmError.failed)
+    let warm = AsyncLatch()
+    let completed = AsyncLatch()
+    fake.onWarmAwait = { await warm.wait() }
+    let c = fake.makeStartedCoordinator()
+
+    fake.selected = .whisperKit
+    c.poke(.settingsChanged)
+    await warm.waitUntilWaiting()
+    // Arm the completion signal only NOW. The recovery hook also fires when the SWITCH
+    // completes, which happens before the warm starts — arming earlier would resolve on
+    // that first fire and assert while the warm is still running.
+    c.onEngineStateChangedForRecovery = { completed.release() }
+    #expect(c.status.warmInFlight == .whisperKit, "the failing warm announces itself first")
+    warm.release()
+    await completed.wait()
+    #expect(fake.active == .whisperKit, "the user's choice is honored, not reverted")
+    #expect(
+      c.status.warmInFlight == nil,
+      "a failed warm must not leave a progress label on screen forever")
+  }
+
+  /// Third of the four warm outcomes. `.cancelled` is a deliberate user choice (#1388's
+  /// Cancel during an install), not a failure, and it must not strand the label either.
+  @Test("a cancelled warm clears warmInFlight")
+  func warmInFlightClearsAfterACancelledWarm() async {
+    let fake = FakeEngineDeps(selected: .parakeet, active: .parakeet)
+    fake.warmOutcome[.whisperKit] = .cancelled
+    let warm = AsyncLatch()
+    let completed = AsyncLatch()
+    fake.onWarmAwait = { await warm.wait() }
+    let c = fake.makeStartedCoordinator()
+
+    fake.selected = .whisperKit
+    c.poke(.settingsChanged)
+    await warm.waitUntilWaiting()
+    // Arm the completion signal only NOW. The recovery hook also fires when the SWITCH
+    // completes, which happens before the warm starts — arming earlier would resolve on
+    // that first fire and assert while the warm is still running.
+    c.onEngineStateChangedForRecovery = { completed.release() }
+    #expect(c.status.warmInFlight == .whisperKit, "the warm announces itself first")
+    warm.release()
+    await completed.wait()
+    #expect(
+      c.status.warmInFlight == nil,
+      "a cancelled warm must not leave a progress label on screen forever")
+  }
+
+  /// Fourth outcome, and the one with no `.warmCompleted` poke behind it. A refused
+  /// mutation claim (recovery holds the engine) returns without ever reaching the
+  /// completion path, so this branch must publish its OWN clear — otherwise the row keeps
+  /// showing "Getting the model ready" until some unrelated poke happens to republish.
+  @Test("a refused warm claim clears and republishes warmInFlight")
+  func warmInFlightClearsWhenTheClaimIsRefused() async {
+    let fake = FakeEngineDeps(selected: .parakeet, active: .parakeet)
+    fake.mutationScope = fake.makeRefusingScope()
+    let refused = AsyncLatch()
+    fake.onRefusedSignal = { refused.release() }
+    let c = fake.makeStartedCoordinator()
+    fake.selected = .whisperKit
+    c.poke(.settingsChanged)
+
+    // Signal from the subject's own refusal path, and the ORDERING IS SOUND rather than
+    // lucky: `onRefused` runs inside `withClaim`, and the coordinator's clear-and-publish
+    // runs immediately after `withClaim` returns, in the same MainActor turn. Resuming a
+    // continuation SCHEDULES the waiter, it does not preempt the running turn, so this test
+    // cannot resume until after the publish has landed.
+    await refused.wait()
+    #expect(fake.refusedSites == ["startWarm"], "the claim was actually refused")
+    #expect(fake.warmCount == 0, "a refused claim never runs the warm itself")
+    #expect(c.status.warmInFlight == nil, "the refusal branch must publish its own clear")
+  }
+
+  /// THE test the generation counter exists for. A superseded warm's cleanup must not clear
+  /// the REPLACEMENT's marker, which would blank "Getting the model ready" mid-load.
+  ///
+  /// Reachable here because the fake leaves readiness at `.notReady` for the duration of a
+  /// warm. In production, gate 4b (`readiness(actual) == .warming`) defers and JOINS
+  /// instead, so the real window is only between the assignment and that readiness
+  /// transition — narrow, but real.
+  ///
+  /// **ACCEPTED LIMIT, founder decision 2026-08-01 (#1635 chunk-1 review r2).** This test is
+  /// SCHEDULING-DEPENDENT and is not a deterministic proof. `staleResumed` fires inside the
+  /// fake's warm hook, one resumption before the coordinator's own generation check, so in
+  /// principle the test can poke and inspect before the stale cleanup has executed. Making
+  /// it deterministic would require a coordinator-owned signal fired after the generation
+  /// check — production code existing solely to be observed by a test — and the founder
+  /// declined that trade for a one-line guard against a narrow window.
+  ///
+  /// What it IS worth: run against the code with the generation check deleted, it fails
+  /// (`Expectation failed: (clobbered → true) == false`); restored, it passes. So it does
+  /// catch this defect, it simply cannot promise to catch it every time. Do not "fix" the
+  /// flake by weakening the assertion; if it ever fails, the guard is genuinely gone.
+  @Test("a superseded warm cannot clear the replacement warmInFlight")
+  func supersededWarmCannotClearTheReplacementMarker() async {
+    let fake = FakeEngineDeps(selected: .parakeet, active: .parakeet)
+    let firstWarm = AsyncLatch()
+    let secondWarm = AsyncLatch()
+    // Signals the moment the STALE warm has resumed, so the test can force a publication
+    // afterwards rather than guessing at a delay.
+    let staleResumed = AsyncLatch()
+    fake.onWarmAwait = {
+      await firstWarm.wait()
+      staleResumed.release()
+    }
+
+    let c = fake.makeStartedCoordinator()
+    fake.selected = .whisperKit
+    c.poke(.settingsChanged)
+    await firstWarm.waitUntilWaiting()
+    #expect(c.status.warmInFlight == .whisperKit, "generation 1 owns the marker")
+
+    // Supersede it: swap the hook, then switch back. This reaches `startWarm` again,
+    // bumping the generation and reassigning the marker while warm 1 is still parked.
+    fake.onWarmAwait = { await secondWarm.wait() }
+    fake.selected = .parakeet
+    c.poke(.settingsChanged)
+    await secondWarm.waitUntilWaiting()
+    #expect(c.status.warmInFlight == .parakeet, "generation 2 now owns the marker")
+
+    // Release the STALE warm. Its cleanup runs against a generation that has moved on.
+    firstWarm.release()
+    await staleResumed.wait()
+
+    // THE PUBLICATION IS WHAT MAKES THE DEFECT VISIBLE, and omitting it is why the first
+    // draft of this test passed with the guard REMOVED. A superseded task writes the
+    // private field and then returns at the `Task.isCancelled` check without publishing,
+    // so `status` still holds the pre-clobber value and asserting on it alone proves
+    // nothing. An unrelated poke forces a republication, which is exactly how a real user
+    // would see it: any settings or driver-state change during the warm re-reads the field
+    // and would render "Model Ready" over a still-loading engine.
+    c.poke(.driverStateChanged)
+    let clobbered = await enginePoll(.milliseconds(250)) { c.status.warmInFlight == nil }
+    #expect(
+      clobbered == false,
+      "the stale warm's cleanup must not clear generation 2's marker")
+
+    let settled = AsyncLatch()
+    c.onEngineStateChangedForRecovery = { settled.release() }
+    secondWarm.release()
+    await settled.wait()
+    #expect(
+      c.status.warmInFlight == nil,
+      "and the current generation still clears normally afterwards")
+  }
 }
 
 /// A one-shot MainActor latch so a test can hold a switch/warm `await` open and
@@ -569,7 +775,23 @@ struct EngineCoordinatorTests {
 final class AsyncLatch {
   private var cont: CheckedContinuation<Void, Never>?
   private var released = false
+  /// #1635: fires the moment the subject actually PARKS on this latch, so a test can assert
+  /// mid-flight state on a signal instead of polling a clock. Without it the key
+  /// publication test would poll, which is the "wait for a signal, not a clock" violation
+  /// the chunk-1 review flagged.
+  private var arrival: CheckedContinuation<Void, Never>?
+  private var hasArrived = false
+
+  /// Await the subject reaching `wait()`. Returns immediately if it already has.
+  func waitUntilWaiting() async {
+    if hasArrived { return }
+    await withCheckedContinuation { arrival = $0 }
+  }
+
   func wait() async {
+    hasArrived = true
+    arrival?.resume()
+    arrival = nil
     if released { return }
     await withCheckedContinuation { cont = $0 }
   }

--- a/Tests/EnviousWisprTests/Services/ModelPreparingImpressionTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/Services/ModelPreparingImpressionTelemetryTests.swift
@@ -1,0 +1,63 @@
+import EnviousWisprServices
+import Foundation
+import Testing
+
+#if DEBUG
+
+  /// #1635: the shape of the one event that can tell us whether the "getting the model
+  /// ready" copy ever reached a real screen.
+  ///
+  /// This event exists because the previous attempt at #1635 shipped a label that could
+  /// never appear, behind four passing tests. `coldstart.warmup_*` measures how long the
+  /// engine took, never whether we told anyone. So the payload is pinned here: a wrong
+  /// event name or a renamed property would silently restore that blind spot, and the
+  /// dashboard would show nothing while looking exactly like "the state never happened".
+  @Suite("Model preparing impression telemetry", .serialized)
+  struct ModelPreparingImpressionTelemetryTests {
+
+    final class EventBox: @unchecked Sendable {
+      private let lock = NSLock()
+      private var stored: CapturedTelemetryEvent?
+
+      func set(_ event: CapturedTelemetryEvent) {
+        lock.withLock { stored = event }
+      }
+
+      var value: CapturedTelemetryEvent? {
+        lock.withLock { stored }
+      }
+    }
+
+    @MainActor
+    @Test("the impression event carries exactly engine and reason, and nothing else")
+    func impressionPayloadIsExact() throws {
+      let box = EventBox()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        if event.name == "settings.model_preparing_impression" { box.set(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      TelemetryService.shared.settingsModelPreparingImpression(
+        engine: "whisperKit", reason: "engine_swap")
+
+      let event = try #require(
+        box.value,
+        "Expected settings.model_preparing_impression event")
+      #expect(event.name == "settings.model_preparing_impression")
+      #expect(event.stringProps["engine"] == "whisperKit")
+      #expect(event.stringProps["reason"] == "engine_swap")
+
+      // Exactly two properties. A third would mean someone added a field without deciding
+      // whether it crosses the privacy boundary.
+      #expect(event.stringProps.count == 2)
+
+      // No duration anywhere. A view that can disappear and reappear during one warm cannot
+      // honestly measure the warm; `coldstart.warmup_*` owns that number.
+      #expect(event.intProps.isEmpty)
+      #expect(event.doubleProps.isEmpty)
+      #expect(event.boolProps.isEmpty)
+      #expect(event.stringProps["elapsed_ms"] == nil)
+    }
+  }
+
+#endif

--- a/Tests/EnviousWisprTests/Settings/ModelPreparingCopyTests.swift
+++ b/Tests/EnviousWisprTests/Settings/ModelPreparingCopyTests.swift
@@ -1,0 +1,52 @@
+import EnviousWisprCore
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #1635: the WhisperKit setup row's copy contract.
+///
+/// These strings are founder-frozen (2026-08-01) and one of them states a DURATION derived
+/// from production telemetry. A silent edit to either would either break a promise made on
+/// screen or reintroduce the "Model Ready" lie this issue exists to fix, so both are pinned
+/// verbatim here and a change must be a conscious act.
+struct ModelPreparingCopyTests {
+
+  @Test("both user-facing strings are frozen verbatim")
+  func stringsAreFrozen() {
+    #expect(
+      ModelPreparingCopy.preparing
+        == "Getting the model ready. This usually takes about 30 seconds.")
+    #expect(ModelPreparingCopy.ready == "Model Ready")
+  }
+
+  /// The duration in the copy is only honest for the population `warmInFlight` describes
+  /// (coordinator-owned post-switch warms, p50 27.4s). If someone widens the state to cover
+  /// launch or cold-press warms, this mapping test cannot detect it. The canonical copy
+  /// comment records that population and copy must be reviewed together.
+  @Test("only WhisperKit's own warm shows the preparing copy")
+  func whisperKitWarmShowsPreparing() {
+    #expect(ModelPreparingCopy.isPreparing(warmInFlight: .whisperKit))
+    #expect(ModelPreparingCopy.label(warmInFlight: .whisperKit) == ModelPreparingCopy.preparing)
+  }
+
+  /// Two-way control. Without these the mapping could return preparing unconditionally and
+  /// the freeze test above would still pass, leaving a permanent spinner over a ready model.
+  @Test("no warm, or another engine's warm, leaves the settled label untouched")
+  func othersShowReady() {
+    #expect(ModelPreparingCopy.isPreparing(warmInFlight: nil) == false)
+    #expect(ModelPreparingCopy.label(warmInFlight: nil) == ModelPreparingCopy.ready)
+
+    // Parakeet warming must not relabel WhisperKit's row. `selectedReadiness` describes
+    // whichever engine the user picked, and this label lives in the WhisperKit section.
+    #expect(ModelPreparingCopy.isPreparing(warmInFlight: .parakeet) == false)
+    #expect(ModelPreparingCopy.label(warmInFlight: .parakeet) == ModelPreparingCopy.ready)
+  }
+
+  /// A missing coordinator (previews, tests without the environment) arrives as `nil` and
+  /// must fail toward the shipped copy. A stuck "preparing" would be a new lie with no exit.
+  @Test("a missing coordinator falls back to Model Ready")
+  func missingCoordinatorFallsBackToReady() {
+    let absent: ASRBackendType? = nil
+    #expect(ModelPreparingCopy.label(warmInFlight: absent) == "Model Ready")
+  }
+}

--- a/Tests/EnviousWisprTests/Settings/ModelPreparingRowIntegrationTests.swift
+++ b/Tests/EnviousWisprTests/Settings/ModelPreparingRowIntegrationTests.swift
@@ -28,32 +28,49 @@ struct ModelPreparingRowIntegrationTests {
 
   /// Drive: not installed → user picks WhisperKit → download admits → coordinator switches
   /// and warms. Returns the coordinator with its warm parked on `warm`.
+  ///
+  /// **The admission is NOT poked by hand.** Flipping `whisperKitInstalled` is the whole
+  /// trigger: the fake's flag is `@Observable`, so the coordinator's own
+  /// `observeInstalledState()` sees the change and fires `.setupStateChanged` itself. An
+  /// earlier draft called `poke(.setupStateChanged)` manually, which exercised the EFFECT
+  /// of the trigger rather than the trigger, and the audit caught it.
+  ///
+  /// **IF THIS HANGS, `FakeEngineDeps.whisperKitInstalled` HAS STOPPED BEING OBSERVABLE.**
+  /// The `#require` below does not catch that: losing observability still leaves the switch
+  /// correctly blocked, so the precondition passes and the hang lands later at
+  /// `waitUntilWaiting()`, waiting for a warm the coordinator was never told to start.
+  /// Do NOT "fix" it with a timeout — that puts a clock back into the one place this test
+  /// deliberately has none. Restore the `@Observable` box instead.
   private func driveToParkedWarm(
     _ fake: FakeEngineDeps, _ warm: AsyncLatch
-  ) async -> EngineCoordinator {
+  ) async throws -> EngineCoordinator {
     fake.whisperKitInstalled = false
     fake.onWarmAwait = { await warm.wait() }
     let c = fake.makeStartedCoordinator()
 
-    // The user picks the optional engine before it exists on disk. The switch is refused
-    // (gate 4, not installed) and Parakeet stays active — this is the real ordering, since
-    // the Download button only renders once WhisperKit is selected.
+    // The user picks the optional engine before it exists on disk. The switch must be
+    // refused (gate 4, not installed) with Parakeet still active — this is the real
+    // ordering, since the Download button only renders once WhisperKit is selected.
     fake.selected = .whisperKit
     c.poke(.settingsChanged)
+    let blocked = await enginePoll { c.status.blockedReason == .notInstalled }
+    try #require(blocked, "an uninstalled engine must block the switch, not warm")
+    #expect(fake.active == .parakeet, "and the old engine stays active meanwhile")
+    #expect(fake.warmCount == 0, "nothing may warm before the model exists")
+    #expect(renderedLabel(c) == ModelPreparingCopy.ready, "and the row is not preparing yet")
 
-    // Download completes. `observeInstalledState` fires exactly this poke on admission.
+    // Download completes. Nothing else: the observation does the rest.
     fake.whisperKitInstalled = true
-    c.poke(.setupStateChanged)
 
     await warm.waitUntilWaiting()
     return c
   }
 
   @Test("a completed download shows the preparing copy, then Model Ready")
-  func settledWarmRoundTrip() async {
+  func settledWarmRoundTrip() async throws {
     let fake = FakeEngineDeps(selected: .parakeet, active: .parakeet)
     let warm = AsyncLatch()
-    let c = await driveToParkedWarm(fake, warm)
+    let c = try await driveToParkedWarm(fake, warm)
 
     #expect(
       renderedLabel(c) == ModelPreparingCopy.preparing,
@@ -68,11 +85,11 @@ struct ModelPreparingRowIntegrationTests {
   }
 
   @Test("a failed warm returns the row to Model Ready, never a stuck spinner")
-  func failedWarmReturnsToReady() async {
+  func failedWarmReturnsToReady() async throws {
     let fake = FakeEngineDeps(selected: .parakeet, active: .parakeet)
     fake.warmOutcome[.whisperKit] = .failed(FakeWarmError.failed)
     let warm = AsyncLatch()
-    let c = await driveToParkedWarm(fake, warm)
+    let c = try await driveToParkedWarm(fake, warm)
 
     #expect(renderedLabel(c) == ModelPreparingCopy.preparing)
 
@@ -86,11 +103,11 @@ struct ModelPreparingRowIntegrationTests {
   }
 
   @Test("a cancelled warm returns the row to Model Ready")
-  func cancelledWarmReturnsToReady() async {
+  func cancelledWarmReturnsToReady() async throws {
     let fake = FakeEngineDeps(selected: .parakeet, active: .parakeet)
     fake.warmOutcome[.whisperKit] = .cancelled
     let warm = AsyncLatch()
-    let c = await driveToParkedWarm(fake, warm)
+    let c = try await driveToParkedWarm(fake, warm)
 
     #expect(renderedLabel(c) == ModelPreparingCopy.preparing)
 

--- a/Tests/EnviousWisprTests/Settings/ModelPreparingRowIntegrationTests.swift
+++ b/Tests/EnviousWisprTests/Settings/ModelPreparingRowIntegrationTests.swift
@@ -1,0 +1,103 @@
+import EnviousWisprCore
+import EnviousWisprPipeline
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #1635 §11.4: the JOIN between the two halves of this fix.
+///
+/// Chunk 1 proves the coordinator publishes `warmInFlight`. Chunk 2 proves the copy mapping
+/// turns `.whisperKit` into the preparing string. Neither proves the value the coordinator
+/// actually publishes is the value the production mapper actually receives — and that gap
+/// is precisely where the previous attempt at this issue died: every piece passed its own
+/// test while the label could never appear on screen.
+///
+/// So these tests drive the real download-completion trigger (`isInstalled` flipping true,
+/// then the `.setupStateChanged` poke that `observeInstalledState` fires on admission),
+/// take the coordinator's OWN published snapshot, and feed it to the production
+/// `ModelPreparingCopy.label` — the same call the row makes. No hand-supplied readiness, no
+/// hand-built `EngineStatus`, no sleeps.
+@MainActor
+@Suite("Model preparing row integration (#1635)", .serialized)
+struct ModelPreparingRowIntegrationTests {
+
+  /// What the row would render right now, through the production mapping.
+  private func renderedLabel(_ c: EngineCoordinator) -> String {
+    ModelPreparingCopy.label(warmInFlight: c.status.warmInFlight)
+  }
+
+  /// Drive: not installed → user picks WhisperKit → download admits → coordinator switches
+  /// and warms. Returns the coordinator with its warm parked on `warm`.
+  private func driveToParkedWarm(
+    _ fake: FakeEngineDeps, _ warm: AsyncLatch
+  ) async -> EngineCoordinator {
+    fake.whisperKitInstalled = false
+    fake.onWarmAwait = { await warm.wait() }
+    let c = fake.makeStartedCoordinator()
+
+    // The user picks the optional engine before it exists on disk. The switch is refused
+    // (gate 4, not installed) and Parakeet stays active — this is the real ordering, since
+    // the Download button only renders once WhisperKit is selected.
+    fake.selected = .whisperKit
+    c.poke(.settingsChanged)
+
+    // Download completes. `observeInstalledState` fires exactly this poke on admission.
+    fake.whisperKitInstalled = true
+    c.poke(.setupStateChanged)
+
+    await warm.waitUntilWaiting()
+    return c
+  }
+
+  @Test("a completed download shows the preparing copy, then Model Ready")
+  func settledWarmRoundTrip() async {
+    let fake = FakeEngineDeps(selected: .parakeet, active: .parakeet)
+    let warm = AsyncLatch()
+    let c = await driveToParkedWarm(fake, warm)
+
+    #expect(
+      renderedLabel(c) == ModelPreparingCopy.preparing,
+      "the row must render the preparing copy from the coordinator's own published value")
+    #expect(fake.active == .whisperKit, "and the engine really did switch")
+
+    let completed = AsyncLatch()
+    c.onEngineStateChangedForRecovery = { completed.release() }
+    warm.release()
+    await completed.wait()
+    #expect(renderedLabel(c) == ModelPreparingCopy.ready, "and settles back to Model Ready")
+  }
+
+  @Test("a failed warm returns the row to Model Ready, never a stuck spinner")
+  func failedWarmReturnsToReady() async {
+    let fake = FakeEngineDeps(selected: .parakeet, active: .parakeet)
+    fake.warmOutcome[.whisperKit] = .failed(FakeWarmError.failed)
+    let warm = AsyncLatch()
+    let c = await driveToParkedWarm(fake, warm)
+
+    #expect(renderedLabel(c) == ModelPreparingCopy.preparing)
+
+    let completed = AsyncLatch()
+    c.onEngineStateChangedForRecovery = { completed.release() }
+    warm.release()
+    await completed.wait()
+    #expect(
+      renderedLabel(c) == ModelPreparingCopy.ready,
+      "a failed load must not leave a progress label spinning forever")
+  }
+
+  @Test("a cancelled warm returns the row to Model Ready")
+  func cancelledWarmReturnsToReady() async {
+    let fake = FakeEngineDeps(selected: .parakeet, active: .parakeet)
+    fake.warmOutcome[.whisperKit] = .cancelled
+    let warm = AsyncLatch()
+    let c = await driveToParkedWarm(fake, warm)
+
+    #expect(renderedLabel(c) == ModelPreparingCopy.preparing)
+
+    let completed = AsyncLatch()
+    c.onEngineStateChangedForRecovery = { completed.release() }
+    warm.release()
+    await completed.wait()
+    #expect(renderedLabel(c) == ModelPreparingCopy.ready)
+  }
+}


### PR DESCRIPTION
Closes #1635.

## What the user sees

The WhisperKit "Model Setup" row claimed **"Model Ready"** the instant the model landed on disk. The engine then loaded into memory for a measured **p50 of 27.4s** on the path a user actually reaches, during which a press was correctly refused with the warming pill. A green tick contradicted the app for roughly half a minute.

The row now shows **"Getting the model ready. This usually takes about 30 seconds."** with a spinner while the engine loads, then reverts to the unchanged "Model Ready" once a press would really record.

## Why 30 seconds is not a guess

Production `coldstart.warmup_completed`, 90 days, real users only, WhisperKit:

| reason | n | p50 | p90 |
|---|---|---|---|
| `engine_swap` | 82 | 27,397 ms | 44,206 ms |
| `launch` | 140 | 10,081 ms | 25,203 ms |
| `cold_press` | 89 | 8,984 ms | 30,327 ms |

Only 11% of WhisperKit warms finish under 3s; 59% take over 10s. "usually" is load-bearing because p90 on this path is 44.2s.

## Why this shipped once already and did not work

A previous attempt (branch discarded, see #1635 comments) shipped a label that **could never appear**, behind four passing tests. `EngineCoordinator` publishes its snapshot at `:374` and starts the warm at `:380`; the next publication is the `.warmCompleted` poke ~27s later. Nothing published while readiness was `.warming`.

So `EngineStatus` gains `warmInFlight`, sourced from the coordinator's own `warmingBackend` — **coordinator intent, not adapter readiness**. That distinction is the fix: `warmingBackend` is assigned synchronously before the warm Task spawns, while the adapter does not reach `.warming` until inside the awaited load.

A generation counter stops a superseded warm's cleanup clearing the replacement's marker.

## Declared scope limit, verified live and accepted

`warmInFlight` covers **coordinator-owned post-switch warms only**. Launch and cold-press warms call their drivers directly and never set it, so the row still shows "Model Ready" during those.

This was reproduced live: the warming pill sat directly on top of the row reading "Model Ready", both on screen at once. The founder's verdict was *"the pill is more accurate than the settings page"*, and the ruling was to ship as is with the reasoning written down — the filed bug is the post-download moment and that IS fixed; the shipped unload default is `never` so a genuinely cold press is rare; the pill is honest in that moment; and covering it properly needs #1882's engine load-state consolidation rather than a fourth place guessing at readiness.

The full argument lives at the top of `ModelPreparingCopy.swift`, so anyone reporting this later finds it immediately.

## Verification

- **4,740 tests** pass.
- **Negative controls run in both directions**: removing the publish fails four tests; removing the generation guard fails the stale-cleanup test. An early draft of the stale test passed with the guard deleted and was rewritten.
- **Integration test** drives the real admission trigger — flipping `isInstalled` and letting the coordinator's own observation fire — then feeds the coordinator's published snapshot to the production copy mapper.
- **Live UAT PASSED**: preparing copy observed on screen at t+0.64s after an engine switch, settled at t+11.55s, 871 AX samples.
- One earlier live attempt reported "not seen" and was treated as **inconclusive, not a pass** — the engine was still resident so no warm ran and the instrument never reached the target.

## Telemetry

Adds view-owned `settings.model_preparing_impression` (`engine`, `reason`). No existing telemetry could tell us whether this copy ever reached a screen, which is exactly how the previous attempt shipped invisible. Two enum-shaped strings, no content.

## Known limits, recorded rather than hidden

- The stale-cleanup test is scheduling-dependent. Making it deterministic needs production code existing only to be observed by a test; the founder declined that trade. Recorded in the test.
- `reason` is the constant `"engine_swap"` because `warmInFlight` has one producer today. If that widens, the string silently becomes wrong.
