### PR TITLE
feat(eval): corpus-fidelity, Codex judging and competitor-benchmark harness (Part of #1272)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,6 +196,8 @@ scripts/eval/apple_runner/Package.resolved
 !scripts/eval/run_cloud_type_b.py
 !scripts/eval/tts_corpus.py
 !scripts/eval/build_parakeet_corpus.py
+!scripts/eval/build_refreshed_corpus.py
+!scripts/eval/wispr_flow_bench.py
 !scripts/eval/parakeet_runner/
 !scripts/eval/parakeet_runner/**
 scripts/eval/parakeet_runner/.build/

--- a/.gitignore
+++ b/.gitignore
@@ -187,6 +187,19 @@ scripts/eval/corpus/*
 !scripts/eval/tests/**
 scripts/eval/apple_runner/.build/
 scripts/eval/apple_runner/Package.resolved
+# Corpus-fidelity + judging harness (#1272, 2026-08-01) — PUBLIC tracked files.
+# These are tracked deliberately: the one-off generator behind the #1199 cloud
+# numbers was gitignored, got deleted, and cost a session rediscovering that
+# those scores had been measured through the wrong prompt. Tooling that produces
+# a number we later cite must survive in git.
+!scripts/eval/classify_redundant.py
+!scripts/eval/run_cloud_type_b.py
+!scripts/eval/tts_corpus.py
+!scripts/eval/build_parakeet_corpus.py
+!scripts/eval/parakeet_runner/
+!scripts/eval/parakeet_runner/**
+scripts/eval/parakeet_runner/.build/
+scripts/eval/parakeet_runner/Package.resolved
 # Alias suggestion eval harness (#637) — PUBLIC tracked files
 !scripts/eval/alias_runner/
 !scripts/eval/alias_runner/**

--- a/Tests/RuntimeUAT/simulate_input.py
+++ b/Tests/RuntimeUAT/simulate_input.py
@@ -47,6 +47,7 @@ from Quartz import (
     kCGEventFlagMaskShift,
     kCGEventFlagMaskAlternate,
     kCGEventFlagMaskControl,
+    kCGEventFlagMaskSecondaryFn,
     kCGKeyboardEventKeycode,
     kCGMouseEventClickState,
 )
@@ -240,13 +241,22 @@ _MODIFIER_FLAGS = {
     60: kCGEventFlagMaskShift,     # Right Shift
     59: kCGEventFlagMaskControl,   # Left Control
     62: kCGEventFlagMaskControl,   # Right Control
+    63: kCGEventFlagMaskSecondaryFn,  # Fn, hardware key, flagsChanged only
 }
 
 # Friendly names for modifier keys
 MODIFIER_KEYS = {
     "rcmd": 54, "lcmd": 55, "lopt": 58, "ropt": 61,
     "lshift": 56, "rshift": 60, "lctrl": 59, "rctrl": 62,
+    "fn": 63,
 }
+
+# Fn caveat (2026-08-02, #1272). Fn is not in KEY_CODES on purpose: it has no
+# keyDown form, so it only works through modifier_down/up and hold_key('fn').
+# After holding it, a plain press_key() inherits the ambient modifier state, so
+# a lingering Fn turns Return into Fn+Return — macOS beeps and inserts nothing,
+# which reads as "the app ignored me" rather than "my event was malformed".
+# Release Fn and let the system settle before posting ordinary keystrokes.
 
 
 def modifier_down(keycode):

--- a/scripts/eval/build_parakeet_corpus.py
+++ b/scripts/eval/build_parakeet_corpus.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Regenerate corpus `asr_input` as REAL Parakeet output via a TTS round-trip.
+
+Why: measured 2026-08-01, 0/1890 Type B corpus inputs are both capitalized and
+terminally punctuated, while 32/32 real dictations in the founder's app log are
+(100% terminal punctuation, 94% both; backend=parakeet). Every cloud polish
+score we hold was therefore measured on an input form the shipped ASR does not
+produce. This rebuilds the inputs through the ASR we actually ship.
+
+Engine fidelity: drives `fluidaudiocli tts-asr-verify` from the PINNED FluidAudio
+checkout (`.build/checkouts/FluidAudio`, revision afb9aab1 per Package.resolved),
+NOT `~/Developer/EnviousLabs/FluidAudio*`, whose HEADs are different commits and
+would measure a different engine.
+
+Two hard limitations, both stated in the report rather than hidden:
+
+1. A TTS voice is not a person. This fixes the punctuation/casing mismatch we
+   proved; it does NOT make the corpus real human dictation (no noise, no
+   accent, no hesitation timing).
+2. The round-trip mangles proper nouns. "loop in jamal actually priya wait no
+   loop in alina" came back "Loop in JAML, actually pre-await no loop and a
+   lina". A case whose words changed no longer matches its `expected_output`,
+   so it is BROKEN, not improved. Cases above --max-wer are REJECTED and keep
+   their original input; the report names every one.
+
+The upstream tool aborts the whole run and writes NO json if any single phrase
+fails TTS (seen on the 814-char cases: Kokoro `postAlbert` shape-deduction
+crash). So batches are isolated here, and a failed batch is retried per-line to
+salvage everything except the genuinely bad phrase.
+
+Usage:
+  python3 scripts/eval/build_parakeet_corpus.py \
+    --corpus scripts/eval/corpus/type_b_approved_1890.jsonl \
+    --out-dir scripts/eval/corpus/parakeet-roundtrip
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+CLI = ROOT / ".build/checkouts/FluidAudio/.build/arm64-apple-macosx/release/fluidaudiocli"
+PIN = "afb9aab1efdad979bca22ca887a936ff2c1cd8ea"
+
+
+def check_engine() -> None:
+    if not CLI.exists():
+        sys.exit(
+            f"fluidaudiocli not built at {CLI}\n"
+            f"Build it:  cd {CLI.parents[3]} && swift build -c release --product fluidaudiocli"
+        )
+    rev = subprocess.run(
+        ["git", "-C", str(CLI.parents[3]), "rev-parse", "HEAD"],
+        capture_output=True, text=True,
+    ).stdout.strip()
+    if rev != PIN:
+        sys.exit(
+            f"checkout is {rev}, expected pinned {PIN}. Refusing to measure a "
+            "different engine than the app ships."
+        )
+    print(f"engine   : pinned FluidAudio {PIN[:8]} (matches Package.resolved)", file=sys.stderr)
+
+
+def wer(ref: str, hyp: str) -> float:
+    """Word error rate, the same metric the CLI reports. Case/punctuation are
+    NORMALISED AWAY here on purpose: adding capitals and periods is the whole
+    point of this exercise, so counting them as errors would reject every case."""
+    import re
+
+    def norm(s: str) -> list[str]:
+        return re.sub(r"[^\w\s']", " ", s.lower()).split()
+
+    r, h = norm(ref), norm(hyp)
+    if not r:
+        return 0.0 if not h else 1.0
+    d = [[0] * (len(h) + 1) for _ in range(len(r) + 1)]
+    for i in range(len(r) + 1):
+        d[i][0] = i
+    for j in range(len(h) + 1):
+        d[0][j] = j
+    for i in range(1, len(r) + 1):
+        for j in range(1, len(h) + 1):
+            cost = 0 if r[i - 1] == h[j - 1] else 1
+            d[i][j] = min(d[i - 1][j] + 1, d[i][j - 1] + 1, d[i - 1][j - 1] + cost)
+    return d[len(r)][len(h)] / len(r)
+
+
+def run_batch(texts: list[str], voice: str) -> list[str] | None:
+    """Synthesize+transcribe a batch. Returns hypotheses in order, or None if
+    the batch aborted (caller then retries line by line)."""
+    with tempfile.TemporaryDirectory() as td:
+        tf = Path(td) / "phrases.txt"
+        of = Path(td) / "out.json"
+        # '#' starts a comment in the tool's phrases file; no corpus line begins
+        # with one (checked at load), so nothing is silently dropped.
+        tf.write_text("\n".join(texts) + "\n")
+        proc = subprocess.run(
+            [str(CLI), "tts-asr-verify", "--texts-file", str(tf),
+             "--voice", voice, "--output-json", str(of)],
+            capture_output=True, text=True,
+        )
+        if proc.returncode != 0 or not of.exists():
+            return None
+        data = json.loads(of.read_text())
+        phrases = sorted(data["phrases"], key=lambda p: p["index"])
+        if len(phrases) != len(texts):
+            return None
+        return [p["hypothesis"].strip() for p in phrases]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--corpus", required=True, type=Path)
+    ap.add_argument("--out-dir", required=True, type=Path)
+    ap.add_argument("--voice", default="af_heart")
+    ap.add_argument("--batch-size", type=int, default=40)
+    ap.add_argument("--max-wer", type=float, default=0.0,
+                    help="keep the round-trip input only when word error is at "
+                         "or below this (default 0.0: the words must be "
+                         "IDENTICAL, only casing/punctuation may differ)")
+    ap.add_argument("--limit", type=int, default=0)
+    args = ap.parse_args()
+
+    check_engine()
+    cases = []
+    for line in open(args.corpus):
+        line = line.strip()
+        if not line:
+            continue
+        d = json.loads(line)
+        key = "asr_input" if "asr_input" in d else "input"
+        text = d[key].replace("\n", " ").replace("\r", " ").strip()
+        if text.startswith("#"):
+            sys.exit(f"case {d['id']} starts with '#', which the TTS tool treats as a comment")
+        cases.append((d, key, text))
+    if args.limit:
+        cases = cases[: args.limit]
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    print(f"corpus   : {args.corpus.name} ({len(cases)} cases), voice={args.voice}", file=sys.stderr)
+
+    hyps: dict[str, str | None] = {}
+    for start in range(0, len(cases), args.batch_size):
+        chunk = cases[start : start + args.batch_size]
+        got = run_batch([t for _, _, t in chunk], args.voice)
+        if got is None:
+            # Isolate: one bad phrase must not cost us the other 39.
+            print(f"  batch @{start} aborted, retrying per-line", file=sys.stderr)
+            got = []
+            for d, _, t in chunk:
+                one = run_batch([t], args.voice)
+                if one is None:
+                    print(f"    TTS FAILED {d['id']} (len={len(t)})", file=sys.stderr)
+                    got.append(None)
+                else:
+                    got.append(one[0])
+        for (d, _, _), h in zip(chunk, got):
+            hyps[d["id"]] = h
+        print(f"  {min(start + args.batch_size, len(cases))}/{len(cases)}", file=sys.stderr)
+
+    kept, rejected, failed = [], [], []
+    out_path = args.out_dir / args.corpus.name
+    with open(out_path, "w") as out:
+        for d, key, text in cases:
+            h = hyps.get(d["id"])
+            if h is None:
+                failed.append((d["id"], text, ""))
+                out.write(json.dumps(d) + "\n")
+                continue
+            w = wer(text, h)
+            if w <= args.max_wer:
+                nd = dict(d)
+                nd[key] = h
+                nd["asr_roundtrip"] = {"source": "parakeet-tts-roundtrip",
+                                       "engine_pin": PIN, "voice": args.voice, "wer": round(w, 4)}
+                out.write(json.dumps(nd) + "\n")
+                kept.append((d["id"], text, h))
+            else:
+                rejected.append((d["id"], text, h, round(w, 4)))
+                out.write(json.dumps(d) + "\n")
+
+    report = {
+        "engine_pin": PIN, "voice": args.voice, "max_wer": args.max_wer,
+        "total": len(cases), "kept": len(kept),
+        "rejected_wer": len(rejected), "tts_failed": len(failed),
+        "rejected": [{"id": i, "orig": o, "parakeet": h, "wer": w} for i, o, h, w in rejected],
+        "tts_failed_ids": [i for i, _, _ in failed],
+    }
+    (args.out_dir / "roundtrip_report.json").write_text(json.dumps(report, indent=2))
+
+    n = len(cases)
+    print(f"\nkept (words identical)  : {len(kept)}/{n} ({100*len(kept)/n:.1f}%)", file=sys.stderr)
+    print(f"rejected (words changed): {len(rejected)}/{n} ({100*len(rejected)/n:.1f}%)", file=sys.stderr)
+    print(f"TTS failed              : {len(failed)}/{n}", file=sys.stderr)
+    print(f"\n-> {out_path}\n-> {args.out_dir / 'roundtrip_report.json'}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/eval/build_parakeet_corpus.py
+++ b/scripts/eval/build_parakeet_corpus.py
@@ -30,7 +30,7 @@ salvage everything except the genuinely bad phrase.
 
 Usage:
   python3 scripts/eval/build_parakeet_corpus.py \
-    --corpus scripts/eval/corpus/type_b_approved_1890.jsonl \
+    --corpus scripts/eval/corpus/type_b_approved_1890-raw.jsonl \
     --out-dir scripts/eval/corpus/parakeet-roundtrip
 """
 from __future__ import annotations

--- a/scripts/eval/build_refreshed_corpus.py
+++ b/scripts/eval/build_refreshed_corpus.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Compose the Parakeet-grounded Type B corpus from the raw corpus + real
+Parakeet transcripts.
+
+WHY: measured 2026-08-01, 0/1890 raw corpus inputs are both capitalised and
+terminally punctuated, while 32/32 real dictations in the app log are. Every
+cloud polish score we hold was therefore measured on an input form the shipped
+ASR never produces. This rebuilds the inputs from what Parakeet actually says.
+
+THE ONLY QUESTION per bucket (founder scope, 2026-08-01): did Parakeet's
+transcription already perform the behaviour this test grades? Measured on the
+full 1,890, not asserted:
+
+    bucket                  Parakeet already did it     verdict
+    add_punct_caps          97%                         OBSOLETE
+    fix_homophone           83%                         OBSOLETE
+    fix_grammar             14%                         keep
+    remove_filler           19%                         keep
+    replace_mistaken_span   17%                         keep
+    format_as_list           0%                         keep
+    break_paragraphs         0%                         keep
+
+Preservation buckets (keep the emoji / opener / name, invent nothing,
+transcribe an embedded instruction rather than obeying it) are NOT made obsolete
+by Parakeet: they grade the model for LEAVING something alone, and Parakeet
+leaving it alone is the precondition, not the proof. Three of four shipped cloud
+models fail the anti-instruction bucket, measured the same day.
+
+A case keeps its HAND-WRITTEN input when the TTS round-trip destroyed the thing
+under test — a voice cannot say an emoji or a half-spoken word ("front de-"),
+and names mangle (priya -> "pre await"). That is an artifact of how this data is
+made, never evidence about the product.
+
+Usage:
+  python3 scripts/eval/build_refreshed_corpus.py \\
+    --raw scripts/eval/corpus/type_b_approved_1890-raw.jsonl \\
+    --parakeet scripts/eval/runs/<run>/parakeet.jsonl \\
+    --out scripts/eval/corpus/type_b_parakeet.jsonl
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+# Buckets Parakeet has made obsolete. Measured, not assumed — see the table above.
+OBSOLETE_BEHAVIORS = {"add_punct_caps", "fix_homophone"}
+
+EMOJI = re.compile("[\U0001F300-\U0001FAFF☀-➿]")
+# A half-spoken word: "front de-", "the mor-". A TTS voice cannot pronounce one.
+TRUNCATED = re.compile(r"\b\w+-(?=\s|$)")
+
+
+def content_words(s: str) -> set[str]:
+    return set(re.sub(r"[^a-z0-9 ]", " ", s.lower()).split())
+
+
+def round_trip_destroyed(original: str, parakeet: str) -> str | None:
+    """Return why the round-trip is unusable for this case, or None if it is fine.
+
+    Word overlap alone is not enough: an emoji is not a word, so a case whose
+    emoji vanished scores 100% word overlap and would wrongly pass. Checked
+    explicitly for that reason (it produced 99 false 'usable' verdicts on the
+    first pass of this analysis)."""
+    if EMOJI.search(original) and not EMOJI.search(parakeet):
+        return "emoji lost (a voice cannot speak one)"
+    if TRUNCATED.search(original) and not TRUNCATED.search(parakeet):
+        return "half-spoken word lost (a voice cannot pronounce one)"
+    orig = content_words(original)
+    if orig and len(orig & content_words(parakeet)) / len(orig) < 0.9:
+        return "words mangled (usually a name)"
+    return None
+
+
+def load_jsonl(path: Path) -> dict:
+    out = {}
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                d = json.loads(line)
+                out[d["id"]] = d
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--raw", required=True, type=Path)
+    ap.add_argument("--parakeet", required=True, type=Path)
+    ap.add_argument("--out", required=True, type=Path)
+    args = ap.parse_args()
+
+    raw = load_jsonl(args.raw)
+    parakeet = load_jsonl(args.parakeet)
+    missing = [cid for cid in raw if cid not in parakeet or not parakeet[cid].get("text")]
+    if missing:
+        # Fail closed: a partial transcript set would silently produce a corpus
+        # that is part-real, part-synthetic with no way to tell which is which.
+        print(f"{len(missing)} cases have no Parakeet transcript, e.g. {missing[:5]}", file=sys.stderr)
+        return 2
+
+    kept, decisions = [], Counter()
+    per_bucket = defaultdict(Counter)
+    reasons = Counter()
+
+    for cid, case in raw.items():
+        behavior = case.get("gold_behavior") or "mixed"
+        key = "asr_input" if "asr_input" in case else "input"
+        original = case[key]
+
+        if behavior in OBSOLETE_BEHAVIORS:
+            decisions["dropped"] += 1
+            per_bucket[behavior]["dropped"] += 1
+            continue
+
+        out_case = dict(case)
+        why = round_trip_destroyed(original, parakeet[cid]["text"])
+        if why:
+            out_case["input_source"] = {"source": "hand-written", "reason": why}
+            decisions["hand-written"] += 1
+            per_bucket[behavior]["hand-written"] += 1
+            reasons[why] += 1
+        else:
+            out_case[key] = parakeet[cid]["text"]
+            out_case["input_source"] = {"source": "parakeet", "original_input": original}
+            decisions["parakeet"] += 1
+            per_bucket[behavior]["parakeet"] += 1
+        kept.append(out_case)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with open(args.out, "w") as f:
+        for case in kept:
+            f.write(json.dumps(case) + "\n")
+
+    total = sum(decisions.values())
+    print(f"raw corpus        : {len(raw)} cases", file=sys.stderr)
+    print(f"refreshed corpus  : {len(kept)} cases -> {args.out}", file=sys.stderr)
+    for k in ("parakeet", "hand-written", "dropped"):
+        print(f"  {k:<14}{decisions[k]:>5}  {100*decisions[k]/total:>5.1f}%", file=sys.stderr)
+    print("\nhand-written inputs retained because:", file=sys.stderr)
+    for why, n in reasons.most_common():
+        print(f"  {n:>4}  {why}", file=sys.stderr)
+    print(f"\n{'bucket':<24}{'parakeet':>10}{'hand-w':>8}{'dropped':>9}", file=sys.stderr)
+    for b in sorted(per_bucket):
+        c = per_bucket[b]
+        print(f"{b:<24}{c['parakeet']:>10}{c['hand-written']:>8}{c['dropped']:>9}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/eval/build_refreshed_corpus.py
+++ b/scripts/eval/build_refreshed_corpus.py
@@ -69,9 +69,15 @@ def round_trip_destroyed(original: str, parakeet: str) -> str | None:
         return "emoji lost (a voice cannot speak one)"
     if TRUNCATED.search(original) and not TRUNCATED.search(parakeet):
         return "half-spoken word lost (a voice cannot pronounce one)"
-    orig = content_words(original)
-    if orig and len(orig & content_words(parakeet)) / len(orig) < 0.9:
-        return "words mangled (usually a name)"
+    # Any lost word disqualifies the case, not a ratio of them. A 0.9 threshold
+    # lets an input with ten or more unique words lose one silently, and the one
+    # it loses is typically a name; the case then keeps an `expected_output` that
+    # still refers to a word no longer in the input, so the model is graded on
+    # producing something it was never given. Measured on the 2026-08-01 build:
+    # 206 of 1458 adopted cases (14.1%) had lost at least one word this way.
+    missing = content_words(original) - content_words(parakeet)
+    if missing:
+        return f"words mangled (usually a name): lost {sorted(missing)[:5]}"
     return None
 
 

--- a/scripts/eval/build_refreshed_corpus.py
+++ b/scripts/eval/build_refreshed_corpus.py
@@ -55,7 +55,16 @@ TRUNCATED = re.compile(r"\b\w+-(?=\s|$)")
 
 
 def content_words(s: str) -> set[str]:
-    return set(re.sub(r"[^a-z0-9 ]", " ", s.lower()).split())
+    """Tokenize for the fidelity check. `\\w` is Unicode-aware for str patterns.
+
+    An ASCII-only class here (`[^a-z0-9 ]`) deleted every word of a non-Latin
+    script, so the check below saw an empty set, found nothing missing, and
+    adopted a transcript unrelated to the case. That is the fail-open shape
+    workflow-process.md RULE: parse-structured-input-dont-regex-and-iterate
+    warns about: ask of any character class in a guard what input makes it match
+    NOTHING, and whether the guard then allows or refuses.
+    """
+    return set(re.findall(r"\w+", s.lower()))
 
 
 def round_trip_destroyed(original: str, parakeet: str) -> str | None:
@@ -75,7 +84,12 @@ def round_trip_destroyed(original: str, parakeet: str) -> str | None:
     # still refers to a word no longer in the input, so the model is graded on
     # producing something it was never given. Measured on the 2026-08-01 build:
     # 206 of 1458 adopted cases (14.1%) had lost at least one word this way.
-    missing = content_words(original) - content_words(parakeet)
+    orig = content_words(original)
+    if original.strip() and not orig:
+        # Fail closed. A tokenizer that returns nothing cannot testify that
+        # nothing was lost, so refuse rather than adopt on an empty comparison.
+        return "input did not tokenize into any word (unsupported script?)"
+    missing = orig - content_words(parakeet)
     if missing:
         return f"words mangled (usually a name): lost {sorted(missing)[:5]}"
     return None

--- a/scripts/eval/build_refreshed_corpus.py
+++ b/scripts/eval/build_refreshed_corpus.py
@@ -43,6 +43,7 @@ import argparse
 import json
 import re
 import sys
+import unicodedata
 from collections import Counter, defaultdict
 from pathlib import Path
 
@@ -60,15 +61,29 @@ def word_counts(s: str) -> Counter:
     Multiplicity matters: 'very very important' losing one 'very' changes the
     emphasis, and a set cannot see that.
 
-    `\\w` is Unicode-aware for str patterns. An ASCII-only class here
-    (`[^a-z0-9 ]`) deleted every word of a non-Latin script, so the check below
-    saw nothing missing and adopted a transcript unrelated to the case. That is
-    the fail-open shape workflow-process.md RULE:
-    parse-structured-input-dont-regex-and-iterate warns about: ask of any
-    character class in a guard what input makes it match NOTHING, and whether
-    the guard then allows or refuses.
+    Tokenized by Unicode CATEGORY rather than by a character class, because two
+    successive review rounds found a class that silently dropped a script.
+    `[^a-z0-9 ]` deleted every non-Latin word outright; `\\w` then looked correct
+    but excludes combining marks, so Indic vowel signs vanished and "कि" and
+    "कु" compared equal. Both failed OPEN, and only in languages nobody
+    spot-checks, which is the shape workflow-process.md RULE:
+    parse-structured-input-dont-regex-and-iterate warns about. Letters, marks
+    and numbers are kept and everything else separates words, so the rule is
+    "what a script considers part of a word" instead of a hand-drawn set.
+
+    The product ships 25 languages, so this harness cannot assume English.
     """
-    return Counter(re.findall(r"\w+", s.lower()))
+    text = unicodedata.normalize("NFC", s.casefold())
+    words, buf = [], []
+    for ch in text:
+        if unicodedata.category(ch)[0] in ("L", "M", "N"):
+            buf.append(ch)
+        elif buf:
+            words.append("".join(buf))
+            buf = []
+    if buf:
+        words.append("".join(buf))
+    return Counter(words)
 
 
 def round_trip_destroyed(original: str, parakeet: str) -> str | None:
@@ -87,7 +102,10 @@ def round_trip_destroyed(original: str, parakeet: str) -> str | None:
     # it loses is typically a name; the case then keeps an `expected_output` that
     # still refers to a word no longer in the input, so the model is graded on
     # producing something it was never given. Measured on the 2026-08-01 build:
-    # 206 of 1458 adopted cases (14.1%) had lost at least one word this way.
+    # Measured on the shipped 2026-08-01 build with this tokenizer and rule:
+    # of 1458 adopted cases, 221 lost a word, 42 more only GAINED words and were
+    # invisible to the old one-way check, 263 (18.0%) differ at all, and 161 have
+    # an expected_output still requiring a word now entirely absent from the input.
     orig, got = word_counts(original), word_counts(parakeet)
     if original.strip() and not orig:
         # Fail closed. A tokenizer that returns nothing cannot testify that

--- a/scripts/eval/build_refreshed_corpus.py
+++ b/scripts/eval/build_refreshed_corpus.py
@@ -54,17 +54,21 @@ EMOJI = re.compile("[\U0001F300-\U0001FAFF☀-➿]")
 TRUNCATED = re.compile(r"\b\w+-(?=\s|$)")
 
 
-def content_words(s: str) -> set[str]:
-    """Tokenize for the fidelity check. `\\w` is Unicode-aware for str patterns.
+def word_counts(s: str) -> Counter:
+    """Multiset of words for the fidelity check.
 
-    An ASCII-only class here (`[^a-z0-9 ]`) deleted every word of a non-Latin
-    script, so the check below saw an empty set, found nothing missing, and
-    adopted a transcript unrelated to the case. That is the fail-open shape
-    workflow-process.md RULE: parse-structured-input-dont-regex-and-iterate
-    warns about: ask of any character class in a guard what input makes it match
-    NOTHING, and whether the guard then allows or refuses.
+    Multiplicity matters: 'very very important' losing one 'very' changes the
+    emphasis, and a set cannot see that.
+
+    `\\w` is Unicode-aware for str patterns. An ASCII-only class here
+    (`[^a-z0-9 ]`) deleted every word of a non-Latin script, so the check below
+    saw nothing missing and adopted a transcript unrelated to the case. That is
+    the fail-open shape workflow-process.md RULE:
+    parse-structured-input-dont-regex-and-iterate warns about: ask of any
+    character class in a guard what input makes it match NOTHING, and whether
+    the guard then allows or refuses.
     """
-    return set(re.findall(r"\w+", s.lower()))
+    return Counter(re.findall(r"\w+", s.lower()))
 
 
 def round_trip_destroyed(original: str, parakeet: str) -> str | None:
@@ -84,14 +88,23 @@ def round_trip_destroyed(original: str, parakeet: str) -> str | None:
     # still refers to a word no longer in the input, so the model is graded on
     # producing something it was never given. Measured on the 2026-08-01 build:
     # 206 of 1458 adopted cases (14.1%) had lost at least one word this way.
-    orig = content_words(original)
+    orig, got = word_counts(original), word_counts(parakeet)
     if original.strip() and not orig:
         # Fail closed. A tokenizer that returns nothing cannot testify that
         # nothing was lost, so refuse rather than adopt on an empty comparison.
         return "input did not tokenize into any word (unsupported script?)"
-    missing = orig - content_words(parakeet)
-    if missing:
-        return f"words mangled (usually a name): lost {sorted(missing)[:5]}"
+    # Compared BOTH ways, as multisets. A one-way subtraction sees only removals,
+    # so `call priya` -> `call priya tomorrow` and `very very important` ->
+    # `very important` both read as unchanged, and the adopted input then says
+    # something the hand-written expected_output was never written against.
+    lost, gained = orig - got, got - orig
+    if lost or gained:
+        detail = []
+        if lost:
+            detail.append(f"lost {sorted(lost.elements())[:5]}")
+        if gained:
+            detail.append(f"gained {sorted(gained.elements())[:5]}")
+        return "words changed in the round trip: " + ", ".join(detail)
     return None
 
 

--- a/scripts/eval/classify_redundant.py
+++ b/scripts/eval/classify_redundant.py
@@ -212,7 +212,14 @@ def main() -> int:
         cases.append({
             "id": cid,
             "gold_behavior": d.get("gold_behavior"),
-            "original": (d.get("asr_input") or d.get("input") or "").replace("\n", " "),
+            # On a refreshed corpus build_refreshed_corpus.py has already replaced
+            # asr_input/input with the Parakeet transcript and preserved the real
+            # source under input_source.original_input. Reading the replaced field
+            # would compare the transcript against itself.
+            "original": (
+                (d.get("input_source") or {}).get("original_input")
+                or d.get("asr_input") or d.get("input") or ""
+            ).replace("\n", " "),
             "parakeet": pk["text"],
             "expected": (d.get("expected_output") or "").replace("\n", " "),
         })

--- a/scripts/eval/classify_redundant.py
+++ b/scripts/eval/classify_redundant.py
@@ -32,7 +32,7 @@ SERIAL by construction: `codex-cli.md` FACT: parallel-codex-execs-get-killed-und
 
 Usage:
   python3 scripts/eval/classify_redundant.py \\
-    --corpus scripts/eval/corpus/type_b_approved_1890.jsonl \\
+    --corpus scripts/eval/corpus/type_b_parakeet.jsonl \\
     --parakeet <run>/parakeet.jsonl --out <run>/classification.jsonl
 """
 from __future__ import annotations
@@ -48,6 +48,33 @@ BATCH = 30  # matches the proven chunk size in codex_fill_judge_gaps.py
 CODEX_RUN = Path.home() / ".claude/bin/codex-run"
 
 SYSTEM = """You audit a test corpus for a dictation app's AI text-polish feature.
+
+THE ONLY QUESTION: did the speech-to-text engine (Parakeet) ALREADY perform the
+specific behaviour this test grades? If yes, the test no longer exercises the
+polish model and is obsolete. If no, it still does its job.
+
+Judge ONLY the graded behaviour named in each case. Ignore every other
+difference — stray commas, sentence splits, capitalisation, anything not the
+behaviour under test. You are not scoring output quality and you are not asking
+whether any work remains in general.
+
+Two traps, both of which produced wrong verdicts on a previous pass:
+
+1. PRESERVATION tests (keep the emoji, keep the opener, invent nothing, leave
+   short text alone, transcribe an embedded instruction instead of obeying it,
+   preserve a name) grade the polish model for NOT changing something. Parakeet
+   leaving it unchanged is the test's PRECONDITION, never proof of obsolescence.
+   A model that meddles still fails these, and several shipped models do.
+   Such a test is obsolete ONLY if Parakeet destroyed the thing being preserved,
+   so there is nothing left to preserve.
+
+2. The PARAKEET text was produced by speaking the corpus input aloud with a
+   synthetic voice and transcribing it. That method cannot carry things a voice
+   cannot say — emoji, half-spoken words ("front de-"), a deliberately wrong
+   spelling of an identical-sounding word. When such a thing is missing from
+   PARAKEET, that is an artifact of HOW this data was made, not evidence about
+   the real product. Never call a test obsolete for that reason; call it
+   INCONCLUSIVE.
 
 Pipeline reality you must assume:
   speech -> Parakeet speech-to-text -> [deterministic steps] -> AI polish model -> paste

--- a/scripts/eval/classify_redundant.py
+++ b/scripts/eval/classify_redundant.py
@@ -166,7 +166,15 @@ def load_cached_batch(work: Path, n: int, batch: list[dict]) -> list[dict] | Non
         return None
     if not stamp.exists() or stamp.read_text().strip() != batch_fingerprint(batch):
         return None
-    return [json.loads(l) for l in cached.read_text().splitlines() if l.strip()]
+    rows = [json.loads(l) for l in cached.read_text().splitlines() if l.strip()]
+    # A parseable but PARTIAL Codex response is still written, and it carries a
+    # valid fingerprint because the fingerprint describes the request, not the
+    # answer. Without this the first run exits nonzero on MISSING and every
+    # rerun happily serves the same incomplete batch. Completeness is a property
+    # of the response, so it has to be checked separately from staleness.
+    if {r.get("id") for r in rows} != {c["id"] for c in batch}:
+        return None
+    return rows
 
 
 def codex_judge(system: str, user: str, outfile: Path) -> str:

--- a/scripts/eval/classify_redundant.py
+++ b/scripts/eval/classify_redundant.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Classify each Type B case as REDUNDANT or KEEP, given what Parakeet actually
+delivers to the polish model.
+
+The question per case is narrow and mechanical: **starting from the text
+Parakeet produces, is there still work for the polish model to do to reach the
+expected output?**
+
+  REDUNDANT — Parakeet's output already satisfies the expected output. Anything
+              still differing is cosmetic (spacing, a comma the expected answer
+              also permits) or is handled by a deterministic pipeline step that
+              runs before/after polish rather than by the model.
+  KEEP      — a real edit remains that only the polish model can make (resolve a
+              self-correction, drop a filler word Parakeet transcribed, reshape
+              into a list, break paragraphs, refuse an embedded instruction,
+              fix an audible grammar error).
+  BROKEN    — Parakeet mangled the words (usually a name), so the case no longer
+              matches its expected output and cannot be scored either way. These
+              are a TTS/ASR artifact, not a judgement about the test's value.
+
+Why an LLM and not string comparison: "already satisfies" is a semantic call.
+`Set aside six plates` vs `Set aside six plates.` is satisfied; `We need twelve`
+vs `We need 12` may or may not be, depending on what the case is testing.
+
+JUDGE = CODEX CLI, always (founder directive 2026-08-01: no cloud judges).
+Invoked through `~/.claude/bin/codex-run`, which is the mandatory path (founder
+2026-07-21) — a bare `codex exec` is denied by hook. `codex_fill_judge_gaps.py`
+predates that mandate and still shells the bare binary; do not copy it.
+
+SERIAL by construction: `codex-cli.md` FACT: parallel-codex-execs-get-killed-under-load
+— several concurrent execs get killed with zero output. One in flight, always.
+
+Usage:
+  python3 scripts/eval/classify_redundant.py \\
+    --corpus scripts/eval/corpus/type_b_approved_1890.jsonl \\
+    --parakeet <run>/parakeet.jsonl --out <run>/classification.jsonl
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+BATCH = 30  # matches the proven chunk size in codex_fill_judge_gaps.py
+CODEX_RUN = Path.home() / ".claude/bin/codex-run"
+
+SYSTEM = """You audit a test corpus for a dictation app's AI text-polish feature.
+
+Pipeline reality you must assume:
+  speech -> Parakeet speech-to-text -> [deterministic steps] -> AI polish model -> paste
+
+Parakeet ALREADY produces capitalisation, terminal punctuation, and commas, and
+it chooses between identical-sounding spellings (your/you're, their/there,
+hear/here, to/too) on its own. It does NOT fix audible grammar errors, and it
+does NOT remove filler words like "um", "you know" or "I mean".
+
+Deterministic app code (not the AI model) already handles: stripping the exact
+fillers um/uh/hmm/mm/mhm/ah/er, spoken-emoji conversion, restoring dropped
+emoji, number/date/money/email formatting, and custom-vocabulary spellings.
+
+For each case you are given:
+  ORIGINAL  - the hand-written test input (may be unrealistic)
+  PARAKEET  - what the real speech engine actually delivers to the polish model
+  EXPECTED  - the answer the test grades the polish model against
+
+Decide, starting from PARAKEET:
+
+REDUNDANT - PARAKEET already satisfies EXPECTED, or every remaining difference
+            is cosmetic or is handled by the deterministic steps listed above.
+            The AI polish model has nothing meaningful left to do.
+KEEP      - a real edit remains that only the AI polish model can make.
+BROKEN    - PARAKEET has different WORDS from ORIGINAL in a way that makes the
+            case no longer match EXPECTED (typically a mangled name or a
+            destroyed half-spoken word). Not scoreable either way.
+
+OUTPUT CONTRACT — obey exactly:
+Emit ONE single-line JSON object per case, in the order given, nothing else.
+No prose before or after. No markdown fence. No summary. No file reading.
+Shape:
+{"id":"<id>","verdict":"REDUNDANT|KEEP|BROKEN","work_left":"<remaining edit the AI must make, or none>","why":"<one short sentence>"}
+Emit exactly as many lines as there are cases, then stop."""
+
+
+def load_jsonl(path: Path) -> dict:
+    out = {}
+    for line in open(path):
+        line = line.strip()
+        if not line:
+            continue
+        d = json.loads(line)
+        out[d["id"]] = d
+    return out
+
+
+def build_prompt(batch: list[dict]) -> str:
+    parts = []
+    for c in batch:
+        parts.append(
+            f"CASE {c['id']} (tests: {c.get('gold_behavior', '?')})\n"
+            f"ORIGINAL: {c['original']}\n"
+            f"PARAKEET: {c['parakeet']}\n"
+            f"EXPECTED: {c['expected']}"
+        )
+    return "\n\n".join(parts)
+
+
+def codex_judge(system: str, user: str, outfile: Path) -> str:
+    """One `codex-run exec` over a batch. Returns the answer text.
+
+    `codex-run` writes the transcript to `outfile` and the proven answer to
+    `outfile.last`; exit 0 REQUIRES a non-empty answer file, so a wedged or
+    answerless run cannot masquerade as success (codex-cli.md
+    RULE: codex-exec-wedges-silently-use-codex-run). Exit 75 = wedged and killed,
+    76 = no answer; both are surfaced rather than swallowed.
+    """
+    outfile.parent.mkdir(parents=True, exist_ok=True)
+    proc = subprocess.run(
+        [str(CODEX_RUN), str(outfile), "exec", "--sandbox", "read-only",
+         "--skip-git-repo-check"],
+        input=f"{system}\n\n{user}\n",
+        capture_output=True, text=True,
+    )
+    answer = outfile.with_suffix(outfile.suffix + ".last")
+    if proc.returncode != 0:
+        detail = {75: "wedged and killed", 76: "exited with no answer"}.get(
+            proc.returncode, f"codex exit {proc.returncode}")
+        raise RuntimeError(f"{detail}: {proc.stderr[-300:]}")
+    if not answer.exists() or not answer.read_text().strip():
+        raise RuntimeError(f"empty answer file {answer}")
+    return answer.read_text()
+
+
+def parse_jsonl(text: str) -> list[dict]:
+    """Pull our verdict objects out of Codex output, ignoring any narration.
+
+    Mirrors `codex_fill_judge_gaps.extract_jsonl_from_codex_output`: match on
+    SHAPE (has id + verdict), never on position, so a stray prose line cannot
+    shift the parse. First occurrence of an id wins.
+    """
+    rows, seen = [], set()
+    for line in text.splitlines():
+        s = line.strip()
+        if not s.startswith("{") or not s.endswith("}"):
+            continue
+        try:
+            d = json.loads(s)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(d, dict) or "id" not in d or "verdict" not in d:
+            continue
+        if d["id"] in seen:
+            continue
+        seen.add(d["id"])
+        rows.append(d)
+    if not rows:
+        raise ValueError(f"no verdict objects in codex output: {text[:200]}")
+    return rows
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--corpus", required=True, type=Path)
+    ap.add_argument("--parakeet", required=True, type=Path)
+    ap.add_argument("--out", required=True, type=Path)
+    ap.add_argument("--work-dir", type=Path, default=None,
+                    help="where per-batch codex transcripts land (default <out>.codex)")
+    ap.add_argument("--limit", type=int, default=0)
+    args = ap.parse_args()
+
+    if not CODEX_RUN.exists():
+        print(f"codex-run not found at {CODEX_RUN}", file=sys.stderr)
+        return 2
+
+    corpus = load_jsonl(args.corpus)
+    parakeet = load_jsonl(args.parakeet)
+
+    cases = []
+    for cid, d in corpus.items():
+        pk = parakeet.get(cid)
+        if pk is None or pk.get("error") or not pk.get("text"):
+            continue
+        cases.append({
+            "id": cid,
+            "gold_behavior": d.get("gold_behavior"),
+            "original": (d.get("asr_input") or d.get("input") or "").replace("\n", " "),
+            "parakeet": pk["text"],
+            "expected": (d.get("expected_output") or "").replace("\n", " "),
+        })
+    if args.limit:
+        cases = cases[: args.limit]
+    batches = [cases[i : i + BATCH] for i in range(0, len(cases), BATCH)]
+
+    work = args.work_dir or Path(str(args.out) + ".codex")
+    work.mkdir(parents=True, exist_ok=True)
+    # Resume: a completed batch leaves a parseable verdicts file, so an
+    # interrupted run re-does only what it has to. 60+ serial codex calls is a
+    # long window and losing all of it to one bad batch is not acceptable.
+    verdicts: dict[str, dict] = {}
+    done_batches = 0
+    for n in range(len(batches)):
+        cached = work / f"batch-{n:03d}.verdicts.jsonl"
+        if cached.exists() and cached.read_text().strip():
+            for line in cached.read_text().splitlines():
+                if line.strip():
+                    row = json.loads(line)
+                    verdicts[row["id"]] = row
+            done_batches += 1
+
+    print(f"judge   : codex-run exec (serial, one in flight)", file=sys.stderr)
+    print(f"cases   : {len(cases)} in {len(batches)} batches of {BATCH}", file=sys.stderr)
+    print(f"resume  : {done_batches} batches already cached in {work}", file=sys.stderr)
+
+    failed = 0
+    t0 = time.monotonic()
+    for n, batch in enumerate(batches):
+        cached = work / f"batch-{n:03d}.verdicts.jsonl"
+        if cached.exists() and cached.read_text().strip():
+            continue
+        transcript = work / f"batch-{n:03d}.txt"
+        try:
+            # SERIAL, never parallel: concurrent execs get killed with zero
+            # output (codex-cli.md FACT: parallel-codex-execs-get-killed-under-load).
+            rows = parse_jsonl(codex_judge(SYSTEM, build_prompt(batch), transcript))
+        except Exception as e:  # noqa: BLE001
+            failed += 1
+            print(f"BATCH {n} FAILED ({batch[0]['id']}..{batch[-1]['id']}): {e}", file=sys.stderr)
+            continue
+        with open(cached, "w") as f:
+            for row in rows:
+                f.write(json.dumps(row) + "\n")
+                verdicts[row["id"]] = row
+        got = len({r["id"] for r in rows} & {c["id"] for c in batch})
+        elapsed = int(time.monotonic() - t0)
+        print(f"  batch {n+1}/{len(batches)}: {got}/{len(batch)} verdicts ({elapsed}s)",
+              file=sys.stderr)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    counts = {"REDUNDANT": 0, "KEEP": 0, "BROKEN": 0, "MISSING": 0}
+    with open(args.out, "w") as f:
+        for c in cases:
+            v = verdicts.get(c["id"])
+            if v is None:
+                counts["MISSING"] += 1
+                row = {**c, "verdict": "MISSING", "why": "judge returned no verdict"}
+            else:
+                verdict = str(v.get("verdict", "")).upper()
+                if verdict not in counts:
+                    verdict = "MISSING"
+                counts[verdict] += 1
+                row = {**c, "verdict": verdict,
+                       "work_left": v.get("work_left", ""), "why": v.get("why", "")}
+            f.write(json.dumps(row) + "\n")
+
+    total = len(cases)
+    if total == 0:
+        # Fail loud: an empty run printing a clean summary is the "green means
+        # nothing happened" shape (validation-discipline.md verify-the-feature-not-the-crash).
+        print("NO CASES SCORED — corpus/parakeet join produced nothing", file=sys.stderr)
+        return 2
+    print(f"\nfailed batches: {failed}", file=sys.stderr)
+    for k in ("KEEP", "REDUNDANT", "BROKEN", "MISSING"):
+        print(f"{k:<10} {counts[k]:>5}  {100*counts[k]/total:>5.1f}%", file=sys.stderr)
+    print(f"\n-> {args.out}", file=sys.stderr)
+    # A judge that silently dropped cases must not read as a clean run.
+    return 0 if counts["MISSING"] == 0 and failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/eval/classify_redundant.py
+++ b/scripts/eval/classify_redundant.py
@@ -38,6 +38,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import subprocess
 import sys
@@ -74,7 +75,8 @@ Two traps, both of which produced wrong verdicts on a previous pass:
    spelling of an identical-sounding word. When such a thing is missing from
    PARAKEET, that is an artifact of HOW this data was made, not evidence about
    the real product. Never call a test obsolete for that reason; call it
-   INCONCLUSIVE.
+   BROKEN, the verdict for "the round trip destroyed what this case was written
+   to test". Never emit a verdict outside the three defined below.
 
 Pipeline reality you must assume:
   speech -> Parakeet speech-to-text -> [deterministic steps] -> AI polish model -> paste
@@ -132,6 +134,39 @@ def build_prompt(batch: list[dict]) -> str:
             f"EXPECTED: {c['expected']}"
         )
     return "\n\n".join(parts)
+
+
+def batch_fingerprint(batch: list[dict]) -> str:
+    """Identity of everything that determines a batch's verdicts.
+
+    The cache is keyed by batch INDEX, so reusing --out/--work-dir after the
+    corpus, the transcripts or BATCH changed would serve verdicts computed for
+    a different set of cases under the same filename, and the run would look
+    clean. The rubric is folded in as well: editing SYSTEM changes the answers
+    just as surely as changing the inputs does.
+    """
+    h = hashlib.sha256()
+    h.update(SYSTEM.encode())
+    h.update(b"\x00")
+    h.update(build_prompt(batch).encode())
+    return h.hexdigest()
+
+
+def load_cached_batch(work: Path, n: int, batch: list[dict]) -> list[dict] | None:
+    """Cached rows for this batch, or None when absent or stale.
+
+    Single authority for the resume decision: the preload pass and the skip
+    check must agree, or one of them re-runs work the other believes is done.
+    A cache written before fingerprints existed has no sidecar and is treated
+    as stale, which costs one re-run and cannot serve a wrong verdict.
+    """
+    cached = work / f"batch-{n:03d}.verdicts.jsonl"
+    stamp = work / f"batch-{n:03d}.fingerprint"
+    if not (cached.exists() and cached.read_text().strip()):
+        return None
+    if not stamp.exists() or stamp.read_text().strip() != batch_fingerprint(batch):
+        return None
+    return [json.loads(l) for l in cached.read_text().splitlines() if l.strip()]
 
 
 def codex_judge(system: str, user: str, outfile: Path) -> str:
@@ -234,14 +269,13 @@ def main() -> int:
     # long window and losing all of it to one bad batch is not acceptable.
     verdicts: dict[str, dict] = {}
     done_batches = 0
-    for n in range(len(batches)):
-        cached = work / f"batch-{n:03d}.verdicts.jsonl"
-        if cached.exists() and cached.read_text().strip():
-            for line in cached.read_text().splitlines():
-                if line.strip():
-                    row = json.loads(line)
-                    verdicts[row["id"]] = row
-            done_batches += 1
+    for n, batch in enumerate(batches):
+        rows = load_cached_batch(work, n, batch)
+        if rows is None:
+            continue
+        for row in rows:
+            verdicts[row["id"]] = row
+        done_batches += 1
 
     print(f"judge   : codex-run exec (serial, one in flight)", file=sys.stderr)
     print(f"cases   : {len(cases)} in {len(batches)} batches of {BATCH}", file=sys.stderr)
@@ -250,9 +284,9 @@ def main() -> int:
     failed = 0
     t0 = time.monotonic()
     for n, batch in enumerate(batches):
-        cached = work / f"batch-{n:03d}.verdicts.jsonl"
-        if cached.exists() and cached.read_text().strip():
+        if load_cached_batch(work, n, batch) is not None:
             continue
+        cached = work / f"batch-{n:03d}.verdicts.jsonl"
         transcript = work / f"batch-{n:03d}.txt"
         try:
             # SERIAL, never parallel: concurrent execs get killed with zero
@@ -266,6 +300,9 @@ def main() -> int:
             for row in rows:
                 f.write(json.dumps(row) + "\n")
                 verdicts[row["id"]] = row
+        # Written only after the verdicts land, so an interrupted write leaves a
+        # batch with no fingerprint and it is recomputed rather than trusted.
+        (work / f"batch-{n:03d}.fingerprint").write_text(batch_fingerprint(batch) + "\n")
         got = len({r["id"] for r in rows} & {c["id"] for c in batch})
         elapsed = int(time.monotonic() - t0)
         print(f"  batch {n+1}/{len(batches)}: {got}/{len(batch)} verdicts ({elapsed}s)",

--- a/scripts/eval/parakeet_runner/Package.swift
+++ b/scripts/eval/parakeet_runner/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+// Standalone eval runner: loads Parakeet ONCE and transcribes a manifest of
+// audio files. `fluidaudiocli transcribe` takes a single file per invocation
+// and reloads the model each time, which is unusable for 1,890 cases.
+//
+// Depends on the SAME git URL + revision the app pins in the root Package.swift
+// (saurabhav88/FluidAudio @ afb9aab1) rather than a local path, so this provably
+// runs the engine we ship. Do not repoint at ~/Developer/EnviousLabs/FluidAudio*
+// — both of those checkouts are at different commits.
+let package = Package(
+  name: "ParakeetRunner",
+  platforms: [.macOS(.v14)],
+  dependencies: [
+    .package(
+      url: "https://github.com/saurabhav88/FluidAudio.git",
+      revision: "afb9aab1efdad979bca22ca887a936ff2c1cd8ea")
+  ],
+  targets: [
+    .executableTarget(name: "ParakeetRunner", dependencies: ["FluidAudio"])
+  ]
+)

--- a/scripts/eval/parakeet_runner/Sources/ParakeetRunner/main.swift
+++ b/scripts/eval/parakeet_runner/Sources/ParakeetRunner/main.swift
@@ -1,0 +1,121 @@
+import AVFoundation
+@preconcurrency import FluidAudio
+import Foundation
+
+/// Batch Parakeet transcription for eval corpora.
+///
+/// Mirrors `ParakeetBackend.swift` EXACTLY so the text this emits is the text
+/// the shipped app would produce for the same audio:
+///   - `AsrModels.loadFromCache(version: .v3)` (falls back to downloadAndLoad)
+///   - `AsrManager(config: .default)` + `loadModels(_:)`
+///   - a FRESH `TdtDecoderState` per file, sized by `manager.decoderLayerCount`
+///     (the app makes one per one-shot batch decode; reusing state across files
+///     would leak decoder context between unrelated utterances)
+///   - `manager.transcribe(samples, decoderState: &state)`
+///   - no language hint (parity with the shipped d5fcca4 behaviour)
+///
+/// Input:  a JSONL manifest, one {"id": "...", "wav": "/abs/path.wav"} per line.
+/// Output: JSONL, one {"id","text","ms"} or {"id","error"} per line.
+
+struct ManifestRow: Decodable {
+  let id: String
+  let wav: String
+}
+
+func fail(_ message: String) -> Never {
+  FileHandle.standardError.write(Data((message + "\n").utf8))
+  exit(1)
+}
+
+let args = CommandLine.arguments
+guard args.count >= 3 else {
+  fail("usage: ParakeetRunner <manifest.jsonl> <out.jsonl>")
+}
+let manifestURL = URL(fileURLWithPath: args[1])
+let outURL = URL(fileURLWithPath: args[2])
+
+guard let manifestData = try? Data(contentsOf: manifestURL) else {
+  fail("cannot read manifest at \(manifestURL.path)")
+}
+let decoder = JSONDecoder()
+var rows: [ManifestRow] = []
+for line in String(decoding: manifestData, as: UTF8.self).split(separator: "\n") {
+  let trimmed = line.trimmingCharacters(in: .whitespaces)
+  if trimmed.isEmpty { continue }
+  guard let row = try? decoder.decode(ManifestRow.self, from: Data(trimmed.utf8)) else {
+    fail("bad manifest line: \(trimmed.prefix(120))")
+  }
+  rows.append(row)
+}
+guard !rows.isEmpty else { fail("manifest is empty") }
+
+/// Read a WAV and return mono Float samples at the rate FluidAudio expects.
+/// `AudioConverter().resampleAudioFile` is the same helper the CLI's transcribe
+/// path uses, so resampling behaviour matches rather than being reimplemented.
+func samples(at path: String) throws -> [Float] {
+  try AudioConverter().resampleAudioFile(path: path)
+}
+
+let start = Date()
+FileHandle.standardError.write(Data("loading Parakeet v3...\n".utf8))
+
+let models: AsrModels
+do {
+  models = try await AsrModels.loadFromCache(version: .v3)
+} catch {
+  FileHandle.standardError.write(Data("cache miss (\(error)); downloading...\n".utf8))
+  models = try await AsrModels.downloadAndLoad(version: .v3)
+}
+let manager = AsrManager(config: .default)
+try await manager.loadModels(models)
+let layers = await manager.decoderLayerCount
+FileHandle.standardError.write(
+  Data("loaded in \(Int(Date().timeIntervalSince(start)))s, decoderLayers=\(layers)\n".utf8))
+
+FileManager.default.createFile(atPath: outURL.path, contents: nil)
+guard let out = FileHandle(forWritingAtPath: outURL.path) else {
+  fail("cannot open \(outURL.path) for writing")
+}
+defer { try? out.close() }
+
+var done = 0
+var errors = 0
+let runStart = Date()
+
+for row in rows {
+  var payload: [String: Any]
+  let caseStart = Date()
+  do {
+    let audio = try samples(at: row.wav)
+    // Fresh per file, exactly as the app does per batch decode.
+    var state = TdtDecoderState.make(decoderLayers: layers)
+    let result = try await manager.transcribe(audio, decoderState: &state)
+    payload = [
+      "id": row.id,
+      "text": result.text,
+      "ms": Int(Date().timeIntervalSince(caseStart) * 1000),
+    ]
+  } catch {
+    errors += 1
+    payload = ["id": row.id, "error": "\(error)"]
+    FileHandle.standardError.write(Data("ERROR \(row.id): \(error)\n".utf8))
+  }
+  let data = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
+  out.write(data)
+  out.write(Data("\n".utf8))
+  done += 1
+  if done % 100 == 0 {
+    let elapsed = Int(Date().timeIntervalSince(runStart))
+    FileHandle.standardError.write(
+      Data("  \(done)/\(rows.count) (\(errors) errors, \(elapsed)s)\n".utf8))
+  }
+}
+
+await manager.cleanup()
+let elapsedTotal = Int(Date().timeIntervalSince(runStart))
+// Build the summary as one String first: splitting a concatenation across the
+// `.utf8` call makes `+` apply to a String and a UTF8View, which does not compile.
+let summary =
+  "DONE \(done - errors)/\(rows.count) in \(elapsedTotal)s | errors=\(errors) -> \(outURL.path)\n"
+FileHandle.standardError.write(Data(summary.utf8))
+exit(errors == 0 ? 0 : 1)

--- a/scripts/eval/run_cloud_type_b.py
+++ b/scripts/eval/run_cloud_type_b.py
@@ -121,6 +121,10 @@ GEMINI_THINKING_FAST = {
     "gemini-3.1-pro-preview-customtools": ("thinkingLevel", "low"),
     "gemini-2.5-flash": ("thinkingBudget", 0),
     "gemini-2.5-flash-lite": ("thinkingBudget", 0),
+    # 2.5 Pro rejects budget 0 ("This model only works in thinking mode"); 128 is
+    # the documented minimum and is what production sends. Omitting it here would
+    # silently benchmark the model at Google's default dynamic thinking instead.
+    "gemini-2.5-pro": ("thinkingBudget", 128),
 }
 
 
@@ -279,7 +283,12 @@ def call_once(provider: str, model: str, api_key: str, system: str, user: str,
         if cand.get("finishReason") not in (None, "STOP"):
             raise RuntimeError(f"non-STOP finishReason={cand.get('finishReason')}")
         parts = (cand.get("content") or {}).get("parts") or []
-        text = "".join(p.get("text", "") for p in parts).strip()
+        # Drop internal-reasoning parts exactly as GeminiConnector.swift does
+        # (`.filter { $0["thought"] as? Bool != true }`). Without this a thinking
+        # -capable model's chain of thought is concatenated into the candidate and
+        # then scored as if the model had said it.
+        text = "".join(p.get("text", "") for p in parts
+                       if p.get("thought") is not True).strip()
         usage = data.get("usageMetadata", {}) or {}
         meta = {
             "inTok": usage.get("promptTokenCount"),

--- a/scripts/eval/run_cloud_type_b.py
+++ b/scripts/eval/run_cloud_type_b.py
@@ -44,12 +44,12 @@ Usage:
   ~/.claude/bin/get-key launch openai-api-key OPENAI_API_KEY -- \\
     python3 scripts/eval/run_cloud_type_b.py \\
       --provider openai --model gpt-5.6-luna \\
-      --corpus scripts/eval/corpus/type_b_approved_1890.jsonl \\
+      --corpus scripts/eval/corpus/type_b_parakeet.jsonl \\
       --out scripts/eval/runs/type-b-luna/candidates.jsonl
 
 Score the result with the SAME judge the baseline used:
   python3 scripts/eval/behavior_judge.py --system new --judge claude-sonnet-5 \\
-    --corpus scripts/eval/corpus/type_b_approved_1890.jsonl \\
+    --corpus scripts/eval/corpus/type_b_parakeet.jsonl \\
     --candidates <out> --out <run-dir>/scores
 """
 from __future__ import annotations
@@ -203,14 +203,30 @@ def _post(url: str, body: dict, headers: dict, timeout: int) -> dict:
         return json.loads(resp.read())
 
 
-def call_once(provider: str, model: str, api_key: str, system: str, user: str) -> tuple[str, dict]:
+def call_once(provider: str, model: str, api_key: str, system: str, user: str,
+              azure_endpoint: str = "") -> tuple[str, dict]:
     if provider == "openai":
-        data = _post(
-            OPENAI_URL,
-            openai_body(model, system, user),
-            {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
-            timeout=120,
-        )
+        # Azure hosts the same OpenAI models on Founders Hub credits. Same
+        # Chat Completions body; only the URL and the auth header differ, and
+        # `model` is a DEPLOYMENT name (hyphens: gpt-5-6-luna) not a model id.
+        # Fidelity caveat, stated once and accepted by the founder: our users
+        # call api.openai.com directly, so an Azure-hosted deployment is a
+        # different service instance of the same model.
+        if azure_endpoint:
+            data = _post(
+                f"{azure_endpoint.rstrip('/')}/openai/deployments/{model}"
+                "/chat/completions?api-version=2024-10-21",
+                openai_body(model, system, user),
+                {"api-key": api_key, "Content-Type": "application/json"},
+                timeout=180,
+            )
+        else:
+            data = _post(
+                OPENAI_URL,
+                openai_body(model, system, user),
+                {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+                timeout=120,
+            )
         choice = data["choices"][0]
         finish = choice.get("finish_reason")
         if finish == "length":
@@ -279,7 +295,8 @@ BARE_PROMPT = (ROOT / "scripts/eval/prompts/cloud-fixed-polish-prompt-v6.txt").r
 
 
 def polish_case(
-    provider: str, model: str, api_key: str, case: dict, prompt_mode: str = "production"
+    provider: str, model: str, api_key: str, case: dict,
+    prompt_mode: str = "production", azure_endpoint: str = ""
 ) -> dict:
     transcript = case["text"]
     word_count = len(transcript.split())
@@ -292,7 +309,7 @@ def polish_case(
     last_err = None
     for attempt in range(1, MAX_ATTEMPTS + 1):
         try:
-            raw, meta = call_once(provider, model, api_key, system, user)
+            raw, meta = call_once(provider, model, api_key, system, user, azure_endpoint)
             # Production strips the LLM preamble before pasting; judge the same
             # text the user would get. Cloud keeps literal <transcript> tags.
             candidate = _strip_llm_preamble_python(raw, strip_transcript_tags=False)
@@ -359,6 +376,12 @@ def main() -> int:
              "ONLY so a past bare-prompt number can be reproduced as a control; "
              "never report a bare-prompt score as the shipped product's quality.",
     )
+    ap.add_argument(
+        "--azure", action="store_true",
+        help="route --provider openai through the Azure deployment on Founders Hub "
+             "credits instead of the direct key. --model then takes the DEPLOYMENT "
+             "name (gpt-5-6-luna), not the model id (gpt-5.6-luna).",
+    )
     args = ap.parse_args()
 
     # Fail fast on prompt drift BEFORE spending anything.
@@ -368,13 +391,22 @@ def main() -> int:
         print(f"{args.model} is Responses-API-only; the shipped connector cannot call it", file=sys.stderr)
         return 2
 
-    api_key = _key(
-        {
-            "openai": "openai-api-key",
-            "gemini": "gemini-api-key",
-            "claude": "anthropic-api-key",
-        }[args.provider]
-    )
+    azure_endpoint = ""
+    if args.azure:
+        if args.provider != "openai":
+            print("--azure applies to --provider openai only", file=sys.stderr)
+            return 2
+        # Founders Hub credits instead of the direct key (founder 2026-08-01).
+        api_key = _key("azure-openai-key")
+        azure_endpoint = _key("azure-openai-endpoint")
+    else:
+        api_key = _key(
+            {
+                "openai": "openai-api-key",
+                "gemini": "gemini-api-key",
+                "claude": "anthropic-api-key",
+            }[args.provider]
+        )
 
     cases = load_corpus(args.corpus)
     if args.limit:
@@ -392,7 +424,8 @@ def main() -> int:
     t0 = time.monotonic()
     with ThreadPoolExecutor(max_workers=args.workers) as pool:
         futures = [
-            pool.submit(polish_case, args.provider, args.model, api_key, c, args.system_prompt)
+            pool.submit(polish_case, args.provider, args.model, api_key, c,
+                        args.system_prompt, azure_endpoint)
             for c in cases
         ]
         for fut in as_completed(futures):

--- a/scripts/eval/run_cloud_type_b.py
+++ b/scripts/eval/run_cloud_type_b.py
@@ -1,0 +1,435 @@
+#!/usr/bin/env python3
+"""Generate Type B candidates from OpenAI / Gemini using the EXACT shipped
+production request shape. Sibling of `run_claude_type_b.py` (Anthropic).
+
+Why this exists: `acceptance_gate.py`'s `call_openai`/`call_gemini` are the
+gpt-4o-mini-era shape — they send `temperature: 0` with no thinking field. That
+is NOT what production sends to a reasoning-shape OpenAI id (which omits
+temperature and carries `reasoning_effort`) nor to a Gemini 3.x id (which
+carries `thinkingLevel`). Scoring a model through the wrong shape measures a
+configuration we do not ship. The one-off generator that produced the #1199
+gemini35flash / gpt54mini runs was gitignored and is gone, so this is its
+faithful, auditable replacement.
+
+Mirrored authorities (verified 2026-08-01, cite before changing):
+  - System prompt composition ....... acceptance_gate.build_cloud_fixed_system
+                                      (itself the mirror of
+                                      CloudFixedPromptBuilder.build, with a
+                                      `--mode selftest` drift guard)
+  - User message ................... CloudFixedPromptBuilder.swift:66
+                                     "Transcript to clean:\\n\\n<transcript>"
+  - OpenAI body .................... OpenAIConnector.makeRequestBody
+                                     (model/messages/store:false;
+                                     max_completion_tokens omitted because
+                                     LLMPolishStep.outputTokenPolicy returns
+                                     .providerDefault for .openAI;
+                                     temperature omitted for reasoning ids;
+                                     reasoning_effort from thinkingControl)
+  - Gemini body .................... GeminiConnector.makeGenerationConfig +
+                                     makeRequestBody (systemInstruction /
+                                     contents without a role / temperature 0 /
+                                     thinkingConfig dialect per model)
+  - Capability resolution .......... LLMModelCapabilities.modelCapabilities
+                                     + geminiThinkingControl (EXACT ids, never
+                                     prefixes — an unlisted id sends NO
+                                     thinking field, same as Swift)
+  - Output post-processing ......... acceptance_gate._strip_llm_preamble_python
+                                     with strip_transcript_tags=False (cloud is
+                                     the no-sandwich fixed-prompt path)
+
+The resolved request shape is PRINTED as a receipt before any spend, so the
+configuration under test is auditable rather than assumed.
+
+Usage:
+  ~/.claude/bin/get-key launch openai-api-key OPENAI_API_KEY -- \\
+    python3 scripts/eval/run_cloud_type_b.py \\
+      --provider openai --model gpt-5.6-luna \\
+      --corpus scripts/eval/corpus/type_b_approved_1890.jsonl \\
+      --out scripts/eval/runs/type-b-luna/candidates.jsonl
+
+Score the result with the SAME judge the baseline used:
+  python3 scripts/eval/behavior_judge.py --system new --judge claude-sonnet-5 \\
+    --corpus scripts/eval/corpus/type_b_approved_1890.jsonl \\
+    --candidates <out> --out <run-dir>/scores
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts/eval"))
+
+from acceptance_gate import (  # noqa: E402
+    _key,
+    _selftest_mirrors,
+    _strip_llm_preamble_python,
+    build_cloud_fixed_system,
+)
+
+OPENAI_URL = "https://api.openai.com/v1/chat/completions"
+GEMINI_URL = "https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={key}"
+ANTHROPIC_URL = "https://api.anthropic.com/v1/messages"
+ANTHROPIC_VERSION = "2023-06-01"
+# Mirrors LLMConstants.claudeMaxOutputTokens (#1710): the Anthropic API
+# requires max_tokens, and the app sends this fixed generous value.
+CLAUDE_MAX_OUTPUT_TOKENS = 8192
+RETRYABLE = {408, 429, 500, 502, 503, 504, 529}
+MAX_ATTEMPTS = 4
+
+
+# --- Capability mirror (LLMModelCapabilities.swift) -------------------------
+
+def openai_capabilities(model: str) -> dict:
+    """Mirror of LLMProvider.openAI.modelCapabilities. Returns the two facts
+    that shape the body: whether temperature is sent, and the reasoning_effort
+    value for the Deep-reasoning toggle in its default OFF position."""
+    mid = model.lower()
+    is_chat_variant = "-chat" in mid
+    is_reasoning = (
+        mid.startswith("o1")
+        or mid.startswith("o3")
+        or mid.startswith("o4")
+        or (mid.startswith("gpt-5") and not is_chat_variant)
+    )
+    is_responses_only = "codex" in mid or "-pro" in mid
+    return {
+        # .effort(fast: "low", deep: "medium") — fast is the shipped default.
+        "reasoning_effort": "low" if is_reasoning else None,
+        "send_temperature": not is_reasoning,
+        "supports_chat_completions": not is_responses_only,
+    }
+
+
+# EXACT ids, never prefixes — mirrors geminiThinkingControl's deliberate design.
+# An id absent from this table sends NO thinking field, exactly as Swift does.
+GEMINI_THINKING_FAST = {
+    "gemini-3.6-flash": ("thinkingLevel", "minimal"),
+    "gemini-3.5-flash": ("thinkingLevel", "minimal"),
+    "gemini-3.5-flash-lite": ("thinkingLevel", "minimal"),
+    "gemini-3.1-flash-lite": ("thinkingLevel", "minimal"),
+    "gemini-3.1-flash-lite-preview": ("thinkingLevel", "minimal"),
+    "gemini-3-flash-preview": ("thinkingLevel", "minimal"),
+    "gemini-3.1-pro-preview": ("thinkingLevel", "low"),
+    "gemini-3.1-pro-preview-customtools": ("thinkingLevel", "low"),
+    "gemini-2.5-flash": ("thinkingBudget", 0),
+    "gemini-2.5-flash-lite": ("thinkingBudget", 0),
+}
+
+
+# --- Request construction ---------------------------------------------------
+
+def openai_body(model: str, system: str, user: str) -> dict:
+    caps = openai_capabilities(model)
+    body = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ],
+        "store": False,
+    }
+    # outputTokenPolicy -> .providerDefault for .openAI: no cap field at all.
+    if caps["send_temperature"]:
+        body["temperature"] = 0
+    if caps["reasoning_effort"] is not None:
+        body["reasoning_effort"] = caps["reasoning_effort"]
+    return body
+
+
+def gemini_body(model: str, system: str, user: str) -> dict:
+    generation_config: dict = {"temperature": 0}
+    thinking = GEMINI_THINKING_FAST.get(model.lower())
+    if thinking is not None:
+        generation_config["thinkingConfig"] = {thinking[0]: thinking[1]}
+    return {
+        "systemInstruction": {"parts": [{"text": system}]},
+        # Production sends no `role` on the content part (GeminiConnector).
+        "contents": [{"parts": [{"text": user}]}],
+        "generationConfig": generation_config,
+        "store": False,
+    }
+
+
+def claude_body(model: str, system: str, user: str) -> dict:
+    # Mirrors ClaudeConnector.makeRequestBody: fixed max_tokens, thinking
+    # disabled unconditionally, and NO temperature (temperaturePolicy .omit —
+    # post-Opus-4.6 generations reject even temperature 0).
+    return {
+        "model": model,
+        "max_tokens": CLAUDE_MAX_OUTPUT_TOKENS,
+        "messages": [{"role": "user", "content": user}],
+        "thinking": {"type": "disabled"},
+        "system": system,
+    }
+
+
+def describe_shape(provider: str, model: str) -> str:
+    if provider == "claude":
+        return (
+            f"messages | max_tokens={CLAUDE_MAX_OUTPUT_TOKENS} | temperature OMITTED "
+            "| thinking disabled"
+        )
+    if provider == "openai":
+        caps = openai_capabilities(model)
+        if not caps["supports_chat_completions"]:
+            return "UNSUPPORTED: Responses-API-only id; the shipped connector refuses it"
+        temp = "temperature=0" if caps["send_temperature"] else "temperature OMITTED"
+        eff = (
+            f"reasoning_effort={caps['reasoning_effort']!r}"
+            if caps["reasoning_effort"]
+            else "no reasoning_effort"
+        )
+        return f"chat/completions | store=false | {temp} | {eff} | no max_completion_tokens"
+    thinking = GEMINI_THINKING_FAST.get(model.lower())
+    tdesc = f"{thinking[0]}={thinking[1]!r}" if thinking else "NO thinking field (id not in table)"
+    return f"generateContent | temperature=0 | {tdesc} | no maxOutputTokens"
+
+
+# --- Transport --------------------------------------------------------------
+
+def _post(url: str, body: dict, headers: dict, timeout: int) -> dict:
+    req = urllib.request.Request(
+        url, data=json.dumps(body).encode(), headers=headers, method="POST"
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read())
+
+
+def call_once(provider: str, model: str, api_key: str, system: str, user: str) -> tuple[str, dict]:
+    if provider == "openai":
+        data = _post(
+            OPENAI_URL,
+            openai_body(model, system, user),
+            {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+            timeout=120,
+        )
+        choice = data["choices"][0]
+        finish = choice.get("finish_reason")
+        if finish == "length":
+            # Mirrors the shipped connector's truncation rejection (#1271 cloud
+            # review): a truncated polish must never be treated as an answer.
+            raise RuntimeError("truncated response rejected (finish_reason=length)")
+        text = (choice["message"].get("content") or "").strip()
+        usage = data.get("usage", {}) or {}
+        meta = {
+            "inTok": usage.get("prompt_tokens"),
+            "outTok": usage.get("completion_tokens"),
+            "reasoningTok": (usage.get("completion_tokens_details") or {}).get("reasoning_tokens"),
+        }
+    elif provider == "claude":
+        data = _post(
+            ANTHROPIC_URL,
+            claude_body(model, system, user),
+            {
+                "x-api-key": api_key,
+                "anthropic-version": ANTHROPIC_VERSION,
+                "content-type": "application/json",
+            },
+            timeout=120,
+        )
+        stop = data.get("stop_reason")
+        if stop == "refusal":
+            raise RuntimeError("model refused (stop_reason=refusal)")
+        blocks = [b.get("text", "") for b in data.get("content", []) if b.get("type") == "text"]
+        text = "".join(blocks).strip()
+        if stop == "max_tokens":
+            # Truncation classifies BEFORE emptiness, mirroring the connector.
+            raise RuntimeError("truncated response rejected (stop_reason=max_tokens)")
+        usage = data.get("usage", {}) or {}
+        meta = {
+            "inTok": usage.get("input_tokens"),
+            "outTok": usage.get("output_tokens"),
+            "reasoningTok": 0,
+        }
+    else:
+        data = _post(
+            GEMINI_URL.format(model=model, key=api_key),
+            gemini_body(model, system, user),
+            {"Content-Type": "application/json"},
+            timeout=120,
+        )
+        cands = data.get("candidates") or []
+        if not cands:
+            raise RuntimeError(f"no candidates (promptFeedback={data.get('promptFeedback')})")
+        cand = cands[0]
+        if cand.get("finishReason") not in (None, "STOP"):
+            raise RuntimeError(f"non-STOP finishReason={cand.get('finishReason')}")
+        parts = (cand.get("content") or {}).get("parts") or []
+        text = "".join(p.get("text", "") for p in parts).strip()
+        usage = data.get("usageMetadata", {}) or {}
+        meta = {
+            "inTok": usage.get("promptTokenCount"),
+            "outTok": usage.get("candidatesTokenCount"),
+            "reasoningTok": usage.get("thoughtsTokenCount"),
+        }
+    if not text:
+        raise RuntimeError("empty text in response")
+    return text, meta
+
+
+BARE_PROMPT = (ROOT / "scripts/eval/prompts/cloud-fixed-polish-prompt-v6.txt").read_text().strip()
+
+
+def polish_case(
+    provider: str, model: str, api_key: str, case: dict, prompt_mode: str = "production"
+) -> dict:
+    transcript = case["text"]
+    word_count = len(transcript.split())
+    system = (
+        BARE_PROMPT if prompt_mode == "bare" else build_cloud_fixed_system(word_count)
+    )
+    user = f"Transcript to clean:\n\n{transcript}"
+
+    start = time.monotonic()
+    last_err = None
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        try:
+            raw, meta = call_once(provider, model, api_key, system, user)
+            # Production strips the LLM preamble before pasting; judge the same
+            # text the user would get. Cloud keeps literal <transcript> tags.
+            candidate = _strip_llm_preamble_python(raw, strip_transcript_tags=False)
+            return {
+                "id": case["id"],
+                "candidate": candidate,
+                "latencyMs": int((time.monotonic() - start) * 1000),
+                "attempts": attempt,
+                **{k: v for k, v in meta.items() if v is not None},
+            }
+        except urllib.error.HTTPError as e:
+            detail = e.read().decode(errors="replace")[:300]
+            last_err = f"HTTP {e.code}: {detail}"
+            retryable = e.code in RETRYABLE
+        except urllib.error.URLError as e:
+            last_err = f"URLError: {e.reason}"
+            retryable = True
+        except (RuntimeError, KeyError, json.JSONDecodeError) as e:
+            last_err = str(e)
+            retryable = False
+        if attempt < MAX_ATTEMPTS and retryable:
+            time.sleep(min(2 ** attempt, 16))
+            continue
+        break
+    return {
+        "id": case["id"],
+        "candidate": "",
+        "error": last_err,
+        "latencyMs": int((time.monotonic() - start) * 1000),
+        "attempts": attempt,
+    }
+
+
+def load_corpus(path: Path) -> list[dict]:
+    cases = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            d = json.loads(line)
+            text = d.get("asr_input") or d.get("input")
+            if not text:
+                raise ValueError(f"case {d.get('id')} has no asr_input/input")
+            cases.append({"id": d["id"], "text": text})
+    if not cases:
+        raise ValueError(f"corpus {path} is empty")
+    return cases
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--provider", required=True, choices=["openai", "gemini", "claude"])
+    ap.add_argument("--model", required=True)
+    ap.add_argument("--corpus", required=True, type=Path)
+    ap.add_argument("--out", required=True, type=Path)
+    ap.add_argument("--workers", type=int, default=8)
+    ap.add_argument("--limit", type=int, default=0, help="first N cases only (smoke)")
+    ap.add_argument(
+        "--system-prompt", choices=["production", "bare"], default="production",
+        help="production = the full CloudFixedPromptBuilder composition the app "
+             "sends (default). bare = the v6 prompt file alone, which is what "
+             "run_claude_type_b.py and the retired #1199 generator used. Provided "
+             "ONLY so a past bare-prompt number can be reproduced as a control; "
+             "never report a bare-prompt score as the shipped product's quality.",
+    )
+    args = ap.parse_args()
+
+    # Fail fast on prompt drift BEFORE spending anything.
+    _selftest_mirrors()
+
+    if args.provider == "openai" and not openai_capabilities(args.model)["supports_chat_completions"]:
+        print(f"{args.model} is Responses-API-only; the shipped connector cannot call it", file=sys.stderr)
+        return 2
+
+    api_key = _key(
+        {
+            "openai": "openai-api-key",
+            "gemini": "gemini-api-key",
+            "claude": "anthropic-api-key",
+        }[args.provider]
+    )
+
+    cases = load_corpus(args.corpus)
+    if args.limit:
+        cases = cases[: args.limit]
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+
+    print(f"model    : {args.model} ({args.provider})", file=sys.stderr)
+    print(f"shape    : {describe_shape(args.provider, args.model)}", file=sys.stderr)
+    print(f"prompt   : {args.system_prompt}", file=sys.stderr)
+    print(f"corpus   : {args.corpus.name} ({len(cases)} cases, {args.workers} workers)", file=sys.stderr)
+
+    results: dict[str, dict] = {}
+    errors = 0
+    done = 0
+    t0 = time.monotonic()
+    with ThreadPoolExecutor(max_workers=args.workers) as pool:
+        futures = [
+            pool.submit(polish_case, args.provider, args.model, api_key, c, args.system_prompt)
+            for c in cases
+        ]
+        for fut in as_completed(futures):
+            row = fut.result()
+            results[row["id"]] = row
+            done += 1
+            if row.get("error"):
+                errors += 1
+                print(f"[{done}/{len(cases)}] ERROR {row['id']}: {row['error']}", file=sys.stderr)
+            elif done % 200 == 0:
+                el = int(time.monotonic() - t0)
+                print(f"[{done}/{len(cases)}] ok ({errors} errors, {el}s)", file=sys.stderr)
+
+    with open(args.out, "w") as f:
+        for case in cases:
+            f.write(json.dumps(results[case["id"]]) + "\n")
+
+    lat = sorted(r["latencyMs"] for r in results.values() if not r.get("error"))
+    in_tok = sum(r.get("inTok") or 0 for r in results.values())
+    out_tok = sum(r.get("outTok") or 0 for r in results.values())
+    reason_tok = sum(r.get("reasoningTok") or 0 for r in results.values())
+    if lat:
+        print(
+            f"latency ms: median={lat[len(lat)//2]} p90={lat[int(len(lat)*0.9)]} max={lat[-1]}",
+            file=sys.stderr,
+        )
+    print(
+        f"tokens: in={in_tok} out={out_tok} reasoning={reason_tok} "
+        f"(reasoning MUST be 0 for a thinking-off run)",
+        file=sys.stderr,
+    )
+    print(
+        f"DONE {len(cases) - errors}/{len(cases)} in {int(time.monotonic() - t0)}s | errors={errors} -> {args.out}",
+        file=sys.stderr,
+    )
+    return 0 if errors == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/eval/tts_corpus.py
+++ b/scripts/eval/tts_corpus.py
@@ -26,7 +26,7 @@ the unfinished cases.
 Usage:
   ~/.claude/bin/get-key launch openai-api-key OPENAI_API_KEY -- \\
     python3 scripts/eval/tts_corpus.py \\
-      --corpus scripts/eval/corpus/type_b_approved_1890.jsonl \\
+      --corpus scripts/eval/corpus/type_b_parakeet.jsonl \\
       --wav-dir scripts/eval/runs/<run>/wav \\
       --manifest scripts/eval/runs/<run>/manifest.jsonl
 """

--- a/scripts/eval/tts_corpus.py
+++ b/scripts/eval/tts_corpus.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Synthesize a corpus to per-case WAV files and emit a ParakeetRunner manifest.
+
+DEFAULT ENGINE = AZURE (founder decision 2026-08-01, after A/B listening across
+five voices): `en-US-AvaNeural` on the `envious-research-speech` F0 resource.
+Runs on Microsoft Founders Hub credits instead of the direct OpenAI key, and the
+F0 allowance (0.5M neural chars/month) covers a full 1,890-case corpus (~182K)
+at zero cost. The founder picked the STANDARD neural tier over Dragon HD on
+quality — the cheap tier won, so there is no cost/quality trade to make here.
+
+`--engine openai` keeps the previous path (`tts-1-hd`, voice `echo`, the default
+in `Tests/RuntimeUAT/wispr_eyes.py`, tools-and-apps.md RULE: tts-openai-echo-default)
+for comparability with pre-2026-08-01 audio. It bills the direct key; prefer
+Azure unless you are deliberately reproducing an older run.
+
+That UAT helper writes ONE fixed path per call and returns MP3; this is the
+batch form: per-case paths, WAV, concurrency, and resume.
+
+WAV (not MP3) because ParakeetRunner reads via `AudioConverter().resampleAudioFile`,
+the same helper the FluidAudio CLI uses; handing it lossy audio would add a
+compression artifact that is not part of what we are measuring.
+
+Resumable: an existing non-empty WAV is skipped, so a rate-limit abort costs only
+the unfinished cases.
+
+Usage:
+  ~/.claude/bin/get-key launch openai-api-key OPENAI_API_KEY -- \\
+    python3 scripts/eval/tts_corpus.py \\
+      --corpus scripts/eval/corpus/type_b_approved_1890.jsonl \\
+      --wav-dir scripts/eval/runs/<run>/wav \\
+      --manifest scripts/eval/runs/<run>/manifest.jsonl
+"""
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+OPENAI_URL = "https://api.openai.com/v1/audio/speech"
+RETRYABLE = {408, 429, 500, 502, 503, 504}
+MAX_ATTEMPTS = 5
+# List prices verified 2026-08-01, for a pre-spend estimate only, never a
+# billing record. Azure is the S0 neural rate (the resource was upgraded off F0
+# the day it was created, so the F0 free allowance no longer applies) and is
+# funded by Founders Hub credits, not a card.
+USD_PER_1M_CHARS = {"openai": 30.0, "azure": 15.0}
+
+
+def _openai_request(text: str, model: str, voice: str, api_key: str) -> urllib.request.Request:
+    body = {"model": model, "input": text, "voice": voice, "response_format": "wav"}
+    return urllib.request.Request(
+        OPENAI_URL,
+        data=json.dumps(body).encode(),
+        headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+        method="POST",
+    )
+
+
+def _azure_request(text: str, voice: str, api_key: str, region: str) -> urllib.request.Request:
+    # SSML, not JSON: Azure's TTS REST endpoint takes an SSML document. Escape
+    # the transcript — corpus text contains &, <, > and quotes, and an unescaped
+    # one makes the whole document invalid, which returns a 400 that reads like
+    # a voice-name problem.
+    ssml = (
+        f'<speak version="1.0" xmlns="http://www.w3.org/2001/10/synthesis" '
+        f'xml:lang="en-US"><voice name="{voice}">{html.escape(text)}</voice></speak>'
+    )
+    return urllib.request.Request(
+        f"https://{region}.tts.speech.microsoft.com/cognitiveservices/v1",
+        data=ssml.encode("utf-8"),
+        headers={
+            "Ocp-Apim-Subscription-Key": api_key,
+            "Content-Type": "application/ssml+xml",
+            # 16 kHz mono is what Parakeet consumes; asking for it here avoids a
+            # resample step and matches the eval pipeline's expected input.
+            "X-Microsoft-OutputFormat": "riff-16khz-16bit-mono-pcm",
+            "User-Agent": "EnviousWispr-eval",
+        },
+        method="POST",
+    )
+
+
+def synth(text: str, out: Path, engine: str, model: str, voice: str,
+          api_key: str, region: str) -> None:
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        req = (
+            _azure_request(text, voice, api_key, region) if engine == "azure"
+            else _openai_request(text, model, voice, api_key)
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=120) as resp:
+                data = resp.read()
+            if not data:
+                raise RuntimeError("empty audio body")
+            tmp = out.with_suffix(".part")
+            tmp.write_bytes(data)
+            tmp.replace(out)  # atomic: a killed run never leaves a half WAV
+            return
+        except urllib.error.HTTPError as e:
+            if e.code in RETRYABLE and attempt < MAX_ATTEMPTS:
+                time.sleep(min(2 ** attempt, 30))
+                continue
+            raise RuntimeError(f"HTTP {e.code}: {e.read().decode(errors='replace')[:200]}") from None
+        except urllib.error.URLError:
+            if attempt < MAX_ATTEMPTS:
+                time.sleep(min(2 ** attempt, 30))
+                continue
+            raise
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--corpus", required=True, type=Path)
+    ap.add_argument("--wav-dir", required=True, type=Path)
+    ap.add_argument("--manifest", required=True, type=Path)
+    ap.add_argument("--engine", choices=["azure", "openai"], default="azure")
+    ap.add_argument("--model", default="tts-1-hd", help="openai engine only")
+    ap.add_argument("--voice", default="", help="default: en-US-AvaNeural (azure) / echo (openai)")
+    ap.add_argument("--workers", type=int, default=0, help="default: 12 azure / 8 openai")
+    ap.add_argument("--limit", type=int, default=0)
+    ap.add_argument("--yes", action="store_true", help="skip the cost confirmation")
+    args = ap.parse_args()
+
+    voice = args.voice or ("en-US-AvaNeural" if args.engine == "azure" else "echo")
+    # S0 allows 30 transactions/sec (F0 allowed 20 per MINUTE, which is why this
+    # was 4 before the 2026-08-01 upgrade). 12 stays well inside the ceiling —
+    # Azure's own guidance is to ramp gradually rather than spike, since a sharp
+    # jump can draw 429s while their autoscaler catches up.
+    workers = args.workers or (12 if args.engine == "azure" else 8)
+    region = ""
+    if args.engine == "azure":
+        api_key = os.environ.get("AZURE_SPEECH_KEY", "").strip()
+        region = os.environ.get("AZURE_SPEECH_REGION", "").strip()
+        if not api_key or not region:
+            print("AZURE_SPEECH_KEY / AZURE_SPEECH_REGION not set — run via `get-key launch`",
+                  file=sys.stderr)
+            return 2
+    else:
+        api_key = os.environ.get("OPENAI_API_KEY", "").strip()
+        if not api_key:
+            print("OPENAI_API_KEY not set — run via `get-key launch`", file=sys.stderr)
+            return 2
+
+    cases = []
+    for line in open(args.corpus):
+        line = line.strip()
+        if not line:
+            continue
+        d = json.loads(line)
+        text = (d.get("asr_input") or d.get("input") or "").replace("\n", " ").strip()
+        if not text:
+            print(f"case {d.get('id')} has no input text", file=sys.stderr)
+            return 2
+        cases.append((d["id"], text))
+    if args.limit:
+        cases = cases[: args.limit]
+
+    args.wav_dir.mkdir(parents=True, exist_ok=True)
+    args.manifest.parent.mkdir(parents=True, exist_ok=True)
+
+    todo = []
+    for cid, text in cases:
+        p = args.wav_dir / f"{cid}.wav"
+        if p.exists() and p.stat().st_size > 0:
+            continue
+        todo.append((cid, text))
+
+    chars = sum(len(t) for _, t in todo)
+    est = chars / 1_000_000 * USD_PER_1M_CHARS[args.engine]
+    print(
+        f"corpus  : {len(cases)} cases, {len(todo)} to synthesize "
+        f"({len(cases) - len(todo)} already present)",
+        file=sys.stderr,
+    )
+    engine_desc = (
+        f"azure {voice}" if args.engine == "azure" else f"openai {args.model} voice={voice}"
+    )
+    print(f"engine  : {engine_desc} -> WAV, {workers} workers", file=sys.stderr)
+    print(f"estimate: {chars:,} chars ~= ${est:.2f} (credit-funded on azure)", file=sys.stderr)
+    if todo and not args.yes:
+        print("re-run with --yes to spend", file=sys.stderr)
+        return 3
+
+    errors = 0
+    done = 0
+    t0 = time.monotonic()
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futs = {
+            pool.submit(synth, text, args.wav_dir / f"{cid}.wav", args.engine,
+                        args.model, voice, api_key, region): cid
+            for cid, text in todo
+        }
+        for fut in as_completed(futs):
+            cid = futs[fut]
+            done += 1
+            try:
+                fut.result()
+            except Exception as e:  # noqa: BLE001 — report and continue; resume handles retries
+                errors += 1
+                print(f"ERROR {cid}: {e}", file=sys.stderr)
+            if done % 100 == 0:
+                print(f"  {done}/{len(todo)} ({errors} errors, {int(time.monotonic()-t0)}s)",
+                      file=sys.stderr)
+
+    # Manifest lists only cases whose audio actually exists, so a partial run
+    # produces a manifest ParakeetRunner can consume without phantom paths.
+    written = 0
+    missing = []
+    with open(args.manifest, "w") as m:
+        for cid, _ in cases:
+            p = args.wav_dir / f"{cid}.wav"
+            if p.exists() and p.stat().st_size > 0:
+                m.write(json.dumps({"id": cid, "wav": str(p.resolve())}) + "\n")
+                written += 1
+            else:
+                missing.append(cid)
+
+    print(f"\nsynth errors : {errors}", file=sys.stderr)
+    print(f"manifest     : {written}/{len(cases)} cases -> {args.manifest}", file=sys.stderr)
+    if missing:
+        print(f"MISSING audio: {len(missing)} -> {missing[:10]}{' ...' if len(missing) > 10 else ''}",
+              file=sys.stderr)
+    return 0 if not missing else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/eval/tts_corpus.py
+++ b/scripts/eval/tts_corpus.py
@@ -33,6 +33,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import html
 import json
 import os
@@ -165,10 +166,28 @@ def main() -> int:
     args.wav_dir.mkdir(parents=True, exist_ok=True)
     args.manifest.parent.mkdir(parents=True, exist_ok=True)
 
+    # Resume is keyed on WHAT PRODUCED the audio, not on the file existing. A
+    # refreshed corpus deliberately keeps case IDs while changing their text, so
+    # reusing a --wav-dir would silently serve the old sentence's audio under the
+    # new case and put it in the manifest as if it were current. Engine, model
+    # and voice are folded in for the same reason: they change the audio.
+    stamp_path = args.wav_dir / ".synthesis.json"
+    try:
+        stamps = json.loads(stamp_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        stamps = {}
+
+    def stamp_of(text: str) -> str:
+        h = hashlib.sha256()
+        for part in (text, args.engine, args.model, voice):
+            h.update(part.encode())
+            h.update(b"\x00")
+        return h.hexdigest()
+
     todo = []
     for cid, text in cases:
         p = args.wav_dir / f"{cid}.wav"
-        if p.exists() and p.stat().st_size > 0:
+        if p.exists() and p.stat().st_size > 0 and stamps.get(cid) == stamp_of(text):
             continue
         todo.append((cid, text))
 
@@ -197,11 +216,15 @@ def main() -> int:
                         args.model, voice, api_key, region): cid
             for cid, text in todo
         }
+        texts = dict(todo)
         for fut in as_completed(futs):
             cid = futs[fut]
             done += 1
             try:
                 fut.result()
+                # Stamped only on success, so a failed case is retried next run
+                # instead of being treated as current audio.
+                stamps[cid] = stamp_of(texts[cid])
             except Exception as e:  # noqa: BLE001 — report and continue; resume handles retries
                 errors += 1
                 print(f"ERROR {cid}: {e}", file=sys.stderr)
@@ -209,14 +232,17 @@ def main() -> int:
                 print(f"  {done}/{len(todo)} ({errors} errors, {int(time.monotonic()-t0)}s)",
                       file=sys.stderr)
 
-    # Manifest lists only cases whose audio actually exists, so a partial run
-    # produces a manifest ParakeetRunner can consume without phantom paths.
+    stamp_path.write_text(json.dumps(stamps, ensure_ascii=False, indent=0))
+
+    # Manifest lists only cases whose audio actually exists AND was produced from
+    # the current text, so a stale WAV left by an earlier corpus cannot enter the
+    # run under a reused case ID.
     written = 0
     missing = []
     with open(args.manifest, "w") as m:
-        for cid, _ in cases:
+        for cid, text in cases:
             p = args.wav_dir / f"{cid}.wav"
-            if p.exists() and p.stat().st_size > 0:
+            if p.exists() and p.stat().st_size > 0 and stamps.get(cid) == stamp_of(text):
                 m.write(json.dumps({"id": cid, "wav": str(p.resolve())}) + "\n")
                 written += 1
             else:

--- a/scripts/eval/wispr_flow_bench.py
+++ b/scripts/eval/wispr_flow_bench.py
@@ -140,6 +140,12 @@ def main():
             for l in f:
                 if l.strip():
                     r = json.loads(l)
+                    # A failed capture is not a result. The abort path appends
+                    # no_paste rows before stopping, so treating them as done
+                    # would make a resumed run skip precisely the cases that
+                    # failed and report a full sweep it never took.
+                    if r.get("no_paste") or not r.get("output"):
+                        continue
                     done[r["id"]] = r.get("wav_sha")
     # Skip only when the stored result came from THIS audio. A row written before
     # wav_sha existed has None and is redone, which costs one run and cannot

--- a/scripts/eval/wispr_flow_bench.py
+++ b/scripts/eval/wispr_flow_bench.py
@@ -33,7 +33,7 @@ Method notes that are load-bearing:
     is a harder input than the pristine WAV our own runs consume, so check the reported
     word-overlap before reading anything into a competitor's mistakes.
 """
-import argparse, json, os, subprocess, sys, threading, time
+import argparse, hashlib, json, os, subprocess, sys, threading, time
 
 REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, os.path.join(REPO, "Tests/RuntimeUAT"))
@@ -52,6 +52,16 @@ def duration(path):
         if "estimated duration" in line:
             return float(line.split(":")[1].strip().split()[0])
     raise RuntimeError(f"afinfo gave no duration for {path}")
+
+
+def wav_sha(path):
+    """Identity of the audio a result came from.
+
+    Resume matches on case ID, and a refreshed corpus reuses IDs while changing
+    the audio behind them, so an ID alone would keep a result produced from a
+    different recording.
+    """
+    return hashlib.sha256(open(path, "rb").read()).hexdigest()
 
 
 def _focused_element(app="TextEdit"):
@@ -107,7 +117,7 @@ def dictate(case_id, wav_dir, key="fn", app="TextEdit", settle=2.0, timeout=30.0
         elif last_change and time.time() - last_change > 1.5:
             break
     delta = text[len(before):] if text.startswith(before) else text
-    return {"id": case_id, "audio_s": round(dur, 2),
+    return {"id": case_id, "audio_s": round(dur, 2), "wav_sha": wav_sha(path),
             "output": delta.strip(), "no_paste": last_change is None}
 
 
@@ -124,11 +134,18 @@ def main():
     ids = sorted((f[:-4] for f in os.listdir(args.wav_dir)
                   if f.startswith(args.ids) and f.endswith(".wav")),
                  key=lambda x: (x.split("-")[0], int(x.split("-")[1])))
-    done = set()
+    done = {}
     if os.path.exists(args.out):
         with open(args.out) as f:
-            done = {json.loads(l)["id"] for l in f if l.strip()}
-    todo = [c for c in ids if c not in done]
+            for l in f:
+                if l.strip():
+                    r = json.loads(l)
+                    done[r["id"]] = r.get("wav_sha")
+    # Skip only when the stored result came from THIS audio. A row written before
+    # wav_sha existed has None and is redone, which costs one run and cannot
+    # report a result from a recording that no longer exists.
+    todo = [c for c in ids
+            if done.get(c) != wav_sha(os.path.join(args.wav_dir, f"{c}.wav"))]
     print(f"{len(done)} already done, {len(todo)} to run", flush=True)
 
     empties = 0

--- a/scripts/eval/wispr_flow_bench.py
+++ b/scripts/eval/wispr_flow_bench.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Play corpus WAVs aloud into a THIRD-PARTY dictation app and capture what it pastes.
+
+Why this exists (#1272, 2026-08-02). Our Type B buckets encode an opinion about what
+good polish looks like. When a bucket scores badly the question "is our model wrong, or
+is our rubric wrong?" cannot be answered from inside our own harness. Running the same
+audio through a shipping competitor answers it: if the market leader makes the same call
+we graded a failure, the rubric is the thing to fix.
+
+It is deliberately NOT a wispr_eyes.py addition. wispr_eyes drives EnviousWispr and reads
+verdicts from our app log (tools-and-apps.md RULE: uat-verdicts-from-app-log); this drives
+an app we do not own, which has no log we can read, so the capture path is different.
+Keystroke synthesis is reused from simulate_input.py rather than re-implemented.
+
+Usage:
+    # Wispr Flow open, its record key set to fn, a TextEdit window open and focused
+    python3 scripts/eval/wispr_flow_bench.py \
+        --wav-dir scripts/eval/runs/typeb-parakeet-2026-08-01/wav \
+        --ids LF- --out /tmp/wf_results.jsonl
+
+Method notes that are load-bearing:
+  * Capture is a direct accessibility read of the TextEdit buffer. Saving to disk was
+    tried first and failed: Sublime's unregistered-license modal fired on save and
+    silently swallowed every later keystroke, which looked exactly like the dictation
+    app refusing to transcribe.
+  * The buffer is cleared between cases via an accessibility write, not Cmd+A/Delete.
+    Dictation apps read the text around the cursor for context, so leaving earlier
+    outputs above would change what the app produces and invalidate the comparison.
+  * No synthetic keystrokes are sent apart from the record key. A posted key event
+    inherits ambient modifier state, so a lingering fn turns Return into fn+Return:
+    macOS beeps and inserts nothing.
+  * Audio reaches the app acoustically, through the speakers and the microphone. That
+    is a harder input than the pristine WAV our own runs consume, so check the reported
+    word-overlap before reading anything into a competitor's mistakes.
+"""
+import argparse, json, os, subprocess, sys, threading, time
+
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(REPO, "Tests/RuntimeUAT"))
+import simulate_input as si  # noqa: E402
+
+from ApplicationServices import (  # noqa: E402
+    AXUIElementCreateApplication, AXUIElementCopyAttributeValue,
+    AXUIElementSetAttributeValue, kAXFocusedUIElementAttribute, kAXValueAttribute)
+
+
+def duration(path):
+    """True duration via afinfo. WAV headers written by our TTS step carry bogus
+    frame counts, so the wave module reports ~89000 seconds for a 3 second clip."""
+    out = subprocess.run(["afinfo", path], capture_output=True, text=True).stdout
+    for line in out.splitlines():
+        if "estimated duration" in line:
+            return float(line.split(":")[1].strip().split()[0])
+    raise RuntimeError(f"afinfo gave no duration for {path}")
+
+
+def _focused_element(app="TextEdit"):
+    p = subprocess.run(["pgrep", "-n", "-x", app], capture_output=True, text=True)
+    pid = int(p.stdout.strip() or 0)
+    if not pid:
+        raise RuntimeError(f"{app} is not running")
+    err, foc = AXUIElementCopyAttributeValue(AXUIElementCreateApplication(pid),
+                                             kAXFocusedUIElementAttribute, None)
+    if err:
+        raise RuntimeError(f"no focused element in {app} (AX err {err})")
+    return foc
+
+
+def read_buffer(app="TextEdit"):
+    """Raises rather than returning '' when the editor is unreachable, so a broken
+    instrument can never be mistaken for the app declining to dictate."""
+    err, val = AXUIElementCopyAttributeValue(_focused_element(app), kAXValueAttribute, None)
+    if err:
+        raise RuntimeError(f"cannot read {app} value (AX err {err})")
+    return val or ""
+
+
+def clear_buffer(app="TextEdit"):
+    err = AXUIElementSetAttributeValue(_focused_element(app), kAXValueAttribute, "")
+    if err:
+        raise RuntimeError(f"cannot clear {app} buffer (AX err {err})")
+
+
+def dictate(case_id, wav_dir, key="fn", app="TextEdit", settle=2.0, timeout=30.0):
+    path = os.path.join(wav_dir, f"{case_id}.wav")
+    dur = duration(path)
+    subprocess.run(["osascript", "-e", f'tell application "{app}" to activate'],
+                   capture_output=True)
+    time.sleep(0.4)
+    clear_buffer(app)
+    time.sleep(0.2)
+    before = read_buffer(app)
+
+    player = threading.Thread(
+        target=lambda: (time.sleep(0.35), subprocess.run(["afplay", path], capture_output=True)))
+    player.start()
+    si.hold_key(key, duration=dur + settle)
+    player.join()
+
+    # Signal-based wait: poll until the buffer grows and then settles. Never a fixed sleep.
+    deadline, text, last_change = time.time() + timeout, before, None
+    while time.time() < deadline:
+        time.sleep(0.5)
+        now = read_buffer(app)
+        if now != text:
+            text, last_change = now, time.time()
+        elif last_change and time.time() - last_change > 1.5:
+            break
+    delta = text[len(before):] if text.startswith(before) else text
+    return {"id": case_id, "audio_s": round(dur, 2),
+            "output": delta.strip(), "no_paste": last_change is None}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--wav-dir", required=True)
+    ap.add_argument("--ids", required=True,
+                    help="id prefix to run, e.g. 'LF-' for the list_format bucket")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--key", default="fn", help="the competitor's record key")
+    ap.add_argument("--app", default="TextEdit", help="paste target, must be AX-readable")
+    args = ap.parse_args()
+
+    ids = sorted((f[:-4] for f in os.listdir(args.wav_dir)
+                  if f.startswith(args.ids) and f.endswith(".wav")),
+                 key=lambda x: (x.split("-")[0], int(x.split("-")[1])))
+    done = set()
+    if os.path.exists(args.out):
+        with open(args.out) as f:
+            done = {json.loads(l)["id"] for l in f if l.strip()}
+    todo = [c for c in ids if c not in done]
+    print(f"{len(done)} already done, {len(todo)} to run", flush=True)
+
+    empties = 0
+    with open(args.out, "a") as f:
+        for i, cid in enumerate(todo, 1):
+            r = dictate(cid, args.wav_dir, key=args.key, app=args.app)
+            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+            f.flush()
+            print(f"[{i}/{len(todo)}] {cid} -> {r['output'][:70]!r}", flush=True)
+            # Fail loud. A long run of empties means the instrument broke, not that the
+            # competitor declined to answer a hundred times in a row.
+            empties = empties + 1 if not r["output"] else 0
+            if empties >= 3:
+                print("ABORT: 3 consecutive empty results, instrument is broken", flush=True)
+                return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Tracks the corpus-fidelity, Codex-judging and competitor-benchmark harness behind the #1272 numbers, and adds the one keystroke primitive that harness needed.

## Why these are tracked and not gitignored

`scripts/eval/*` is broadly ignored. These files get explicit negations because the one-off generator behind the #1199 cloud numbers was gitignored, got deleted, and cost a session rediscovering that those scores had been measured through the wrong prompt. Tooling that produces a number we later cite has to survive in git.

## What is here

**`scripts/eval/wispr_flow_bench.py` (new).** Plays corpus WAVs aloud into a third-party dictation app and captures what it pastes. It exists because a badly scoring bucket raises a question our own harness cannot answer: is the model wrong, or is the rubric wrong. Running the same audio through a shipping competitor answers it.

First use settled `format_as_list`. Our rubric demands a bullet list on all 100 cases; Wispr Flow produced one on 48 and `gpt-5.6-luna` on 55, agreeing with each other on 67. Full analysis in the [issue comment](https://github.com/saurabhav88/EnviousWispr/issues/1272#issuecomment-5161110772).

It is deliberately not a `wispr_eyes.py` addition. `wispr_eyes` drives EnviousWispr and reads verdicts from our app log (tools-and-apps.md RULE: uat-verdicts-from-app-log). This drives an app we do not own, which has no log we can read, so the capture path differs. Keystroke synthesis is reused from `simulate_input.py` rather than re-implemented.

**`Tests/RuntimeUAT/simulate_input.py`.** Adds `fn` to `MODIFIER_KEYS` (keycode 63, `SecondaryFn`), routing through the existing `modifier_down`/`modifier_up` path. `fn` is deliberately absent from `KEY_CODES` because it has no keyDown form. Two lines plus a comment recording the trap that cost the most time: after holding `fn`, a plain `press_key` inherits the ambient modifier state, so Return arrives as `fn`+Return, macOS beeps and inserts nothing, and that reads as the target app ignoring you rather than as a malformed event.

**Four synced scripts.** `run_cloud_type_b.py`, `classify_redundant.py`, `tts_corpus.py`, `build_parakeet_corpus.py` had committed copies that went stale against the working tree (Azure routing, `type_b_parakeet` corpus paths). `build_refreshed_corpus.py` had no gitignore negation and was untracked.

## Method decisions recorded in the docstring

Two obvious approaches are wrong and both fail silently, so they are documented where the next reader will be:

- Capture is an accessibility read of the TextEdit buffer, not a file save. Saving trips Sublime's unregistered-license modal, which then swallows every later keystroke. Nine of ten cases returned empty and it looked exactly like the dictation app refusing to transcribe.
- The buffer is cleared between cases. Dictation apps read surrounding text for context, so leaving earlier outputs above the cursor changes what the app produces and quietly invalidates the comparison.

## Validation

- Lane: `Docs/dev-tooling` for the eval scripts; `Tests/RuntimeUAT/simulate_input.py` is a tracked ship path but is Python UAT tooling, not compiled into the app.
- `scripts/build-dev-app.sh` in this worktree: **BUILD SUCCEEDED**, required by the push gate because the diff touches `Tests/`.
- `wispr_flow_bench.py` run end to end against the live app for 9 cases through the newly committed `fn` path. All 9 captured, no empty results.
- `python3 -m py_compile` clean on both changed Python files.
- No product code, no user-facing surface, no secrets, no migration.

Part of #1272
