### PR TITLE
fix(#1920): an empty decode with audio present is not our error

### DIFF
--- a/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
@@ -412,7 +412,11 @@ final class RecoveryCoordinator {
   /// cells are unit-tested directly (`matcher-set-adversarial-tests`).
   static func shouldDeleteOnLiveEnding(_ ending: RecordingRecoveryEnding) -> Bool {
     switch ending {
-    case .discarded, .noSpeech, .asrRetryExhausted:
+    // #1920: `.asrEmptyDespiteAudio` deletes like every other concluded live
+    // ending. The app was alive, the user witnessed the take end with no text,
+    // and re-pressing the key is the whole recovery — a surprise replay of a
+    // wordless recording at a later launch would be a bug in their eyes.
+    case .discarded, .noSpeech, .asrRetryExhausted, .asrEmptyDespiteAudio:
       return true
     case .failed, .audioInterrupted, .asrInterrupted, .noTransport:
       // #1755: flipped from retain — the in-session salvage/retry was the

--- a/Sources/EnviousWisprCore/TerminalNoticeReason.swift
+++ b/Sources/EnviousWisprCore/TerminalNoticeReason.swift
@@ -36,6 +36,11 @@ public enum TerminalNoticeReason: String, Equatable, Sendable, CaseIterable {
   case asrWedged = "asr_wedged"
   case asrInterrupted = "asr_interrupted"
   case noAudioCaptured = "no_audio_captured"
+  /// #1920: NO PRODUCTION PRODUCER — the empty-decode path now ends at
+  /// `asr_empty_despite_audio` and says nothing to the user. This raw value is
+  /// retained because historical PostHog rows carry it; expect the series to
+  /// drop to zero at that release boundary, and read that drop as the change,
+  /// not as a fix. Do not give it a producer again.
   case asrEmptyWithSpeech = "asr_empty_with_speech"
   case emptyAfterProcessing = "empty_after_processing"
 

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -1034,7 +1034,9 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
         return .advisory(reason: advisory)
       }
       switch outcome {
-      case .completed, .cancelled, .discarded, .noSpeech:
+      // #1920: `.asrEmptyDespiteAudio` is hidden. The engine ran and found no
+      // words while audio was arriving; that is not an event to announce.
+      case .completed, .cancelled, .discarded, .noSpeech, .asrEmptyDespiteAudio:
         return .hidden
       case .failed(let reason):
         // #1558: emit the TYPED reason; the raw detail stays owned by the
@@ -1428,6 +1430,11 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
       return .discarded
     case .noSpeech:
       return .noSpeech
+    // #1920: its OWN ending, not reused from `.noSpeech`. The two are different
+    // observations, and `shouldDeleteOnLiveEnding` must decide this one
+    // explicitly rather than inherit a no-speech decision.
+    case .asrEmptyDespiteAudio:
+      return .asrEmptyDespiteAudio
     case .failed:
       return retryOutcome == .retryExhausted ? .asrRetryExhausted : .failed
     case .audioInterrupted:
@@ -1648,8 +1655,12 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
       case .asrEmptyNoSpeech, .emptyAfterProcessing:
         return nil
       }
+    // #1920: `.asrEmptyDespiteAudio` gets NO advisory. Audio was arriving above
+    // every dead-air floor, so there is nothing to tell the user to check — the
+    // genuinely-absent-audio cases above (`.zeroSignal`, `.vadGate`) keep the
+    // advisory, and they are the ones that should speak.
     case .completed, .cancelled, .discarded, .audioInterrupted,
-      .asrInterrupted, .noTransport:
+      .asrInterrupted, .noTransport, .asrEmptyDespiteAudio:
       return nil
     }
   }
@@ -1676,7 +1687,8 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
       switch outcome {
       case .completed:
         return .complete
-      case .cancelled, .discarded, .noSpeech:
+      // #1920: back to idle with no error state published.
+      case .cancelled, .discarded, .noSpeech, .asrEmptyDespiteAudio:
         return .idle
       case .failed(let reason):
         return .error(terminalNoticeReason(for: reason))

--- a/Sources/EnviousWisprPipeline/KernelHeartPathTelemetryObserver.swift
+++ b/Sources/EnviousWisprPipeline/KernelHeartPathTelemetryObserver.swift
@@ -59,6 +59,11 @@ enum KernelLifecycleEvent: Equatable, Sendable {
   case noSpeech(NoSpeechSource)
   /// The session reached `cancelled` — a user-cancelled recording.
   case cancelled
+  /// #1920: the session reached `asrEmptyDespiteAudio` — audio was arriving, the
+  /// engine ran clean, and it produced no words. Kept as its own event rather
+  /// than folded into `.failed` or `.noSpeech`: it is neither a failure nor an
+  /// assertion that the recording was silent.
+  case asrEmptyDespiteAudio
 
   // MARK: PR-4b.2 r6 additions
 
@@ -81,7 +86,9 @@ enum KernelLifecycleEvent: Equatable, Sendable {
   /// "ASR completed" breadcrumb. NOT fired on the `.finalizing` path that came
   /// from a no-speech VAD gate or asrEmpty — those emit `.noSpeech(source:)` /
   /// `.failed(.asrEmpty)` instead, matching old code which never emits the
-  /// "ASR completed" breadcrumb on those paths.
+  /// "ASR completed" breadcrumb on those paths. #1920: the speech-evidence half
+  /// of that pair is now `.asrEmptyDespiteAudio`, and it emits no "ASR completed"
+  /// breadcrumb either.
   case asrCompleted
 
   /// The session entered `.preparing` — the first observable transition from

--- a/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
@@ -549,6 +549,19 @@ final class KernelLifecycleTelemetrySink {
           ["backend": backend.rawValue])
       }
 
+    case .asrEmptyDespiteAudio:
+      // #1920: context-only breadcrumb, mirroring the `.failed(.asrEmpty)` arm
+      // this replaces (#979 already downgraded that one from a Sentry error).
+      // NO Sentry event: nothing failed. The countable record is the
+      // `asr_empty_despite_audio` terminal result plus the dedicated
+      // `audio.asr_empty_despite_audio` event emitted from `emitTerminal`, which
+      // reads only the FROZEN snapshot — a breadcrumb here cannot carry the
+      // count because a no-error terminal fires no Sentry event for it to
+      // attach to (the #1845 lesson).
+      breadcrumb(
+        "asr", "ASR returned empty text while audio was arriving",
+        telemetryState.asrEmptyDiagnostics?.sentryExtra() ?? ["backend": backend.rawValue])
+
     case .cancelled:
       // r7 — NO breadcrumb. PR-1 §B.7.4 allows only ONE new event
       // (`discarded`); a `.cancelled` breadcrumb would be a second new event.
@@ -630,6 +643,12 @@ final class KernelLifecycleTelemetrySink {
     case .asrInterrupted: "asr_interrupted"
     case .discarded: "discarded"
     case .noSpeech: "no_speech"
+    // #1920: its OWN terminal result, an additive eighth value. NOT `failed`
+    // (nothing failed) and NOT `no_speech` (we cannot assert absence of speech,
+    // and `analytics-operations.md` documents `no_speech` as a quiet room).
+    // The `asr_empty_with_speech` series drops to zero at this release boundary;
+    // that drop IS this change, not a fix.
+    case .asrEmptyDespiteAudio: "asr_empty_despite_audio"
     case .cancelled: "cancelled"
     case .pipelineStartingUp, .modelLoading, .recordingCommitted, .recordingStopped,
       .transcriptionStarted, .asrCompleted:
@@ -914,6 +933,11 @@ final class KernelLifecycleTelemetrySink {
         .audioCaptureFailed, "recording",
         captureFailureExtra(error: error, failureMode: "no_microphone_found"))
     case .asrEmpty:
+      // #1920: UNREACHABLE — `RecordingFailureReason.asrEmpty` has no production
+      // producer since the empty-decode path was re-typed to
+      // `.asrEmptyDespiteAudio` (see that case's own arm above). Retained with
+      // the reason case itself; the notes below are the #979 provenance and
+      // describe the pre-#1920 shape.
       // #979: ASR-empty on non-speech (ambient noise trips VAD, engine
       // correctly returns empty) is an EXPECTED outcome, not an error.
       // Evidence: 7 organic capture pairs all ambient non-speech (energy-mod

--- a/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
@@ -553,11 +553,12 @@ final class KernelLifecycleTelemetrySink {
       // #1920: context-only breadcrumb, mirroring the `.failed(.asrEmpty)` arm
       // this replaces (#979 already downgraded that one from a Sentry error).
       // NO Sentry event: nothing failed. The countable record is the
-      // `asr_empty_despite_audio` terminal result plus the dedicated
-      // `audio.asr_empty_despite_audio` event emitted from `emitTerminal`, which
-      // reads only the FROZEN snapshot — a breadcrumb here cannot carry the
-      // count because a no-error terminal fires no Sentry event for it to
-      // attach to (the #1845 lesson).
+      // `asr_empty_despite_audio` value on the `dictation_terminal` row, which
+      // already carries `take_id`, device kind, both transports, the energy
+      // triple and duration — so no dedicated audio event was minted (a second
+      // record would overlap it, the #1845 lesson). A breadcrumb cannot carry
+      // the count either, because a no-error terminal fires no Sentry event for
+      // it to attach to.
       breadcrumb(
         "asr", "ASR returned empty text while audio was arriving",
         telemetryState.asrEmptyDiagnostics?.sentryExtra() ?? ["backend": backend.rawValue])

--- a/Sources/EnviousWisprPipeline/KernelTelemetryState.swift
+++ b/Sources/EnviousWisprPipeline/KernelTelemetryState.swift
@@ -112,8 +112,9 @@ final class KernelTelemetryState {
   /// or `nil` when this take is not one of those.
   ///
   /// **Written ONLY at the two producer sites** — immediately before the eligible
-  /// `.failed(.zeroSignal)` terminal, and on the final `asr_empty_with_speech`
-  /// path after salvage has failed. `finishTerminal` only COPIES it into the
+  /// `.failed(.zeroSignal)` terminal, and on the final empty-decode path after
+  /// salvage has failed (#1920 re-typed that terminal to
+  /// `.asrEmptyDespiteAudio`; it was `asr_empty_with_speech`). `finishTerminal` only COPIES it into the
   /// terminal snapshot.
   ///
   /// That direction is the whole point. Measuring or re-reading the bind at the
@@ -192,6 +193,9 @@ struct KernelNoSpeechTelemetry {
   /// `nil` means NOT COMPUTED, never "computed as zero". Populated only on the
   /// `.vadGate` route, which is the only one that runs the classifier — the
   /// `.asrEmptyNoSpeech` stamp leaves them nil and that is correct, not a gap.
+  /// #1920: `.asrEmptyDespiteAudio` likewise leaves them nil here — its energy
+  /// numbers reach telemetry through the frozen `signalAttribution` snapshot,
+  /// not these fields.
   var wholeBufferRMS: Float?
   var maxWindowRMS: Float?
   /// #1845 — THIS take's route, frozen from `lastResolvedRoute` at the

--- a/Sources/EnviousWisprPipeline/KernelTerminalProjections.swift
+++ b/Sources/EnviousWisprPipeline/KernelTerminalProjections.swift
@@ -36,6 +36,8 @@ extension RecordingOutcome {
       .discarded(reason)
     case .noSpeech(let source):
       .noSpeech(source)
+    case .asrEmptyDespiteAudio:
+      .asrEmptyDespiteAudio
     case .audioInterrupted(let cause):
       // Default defensively to `.engineLost` when the cause was not stamped: a
       // lost recording with no cause is still an unowned loss (#1174 A3).

--- a/Sources/EnviousWisprPipeline/PipelineVocabulary.swift
+++ b/Sources/EnviousWisprPipeline/PipelineVocabulary.swift
@@ -191,6 +191,12 @@ public enum RecordingRecoveryEnding: Equatable, Sendable {
   case asrInterrupted
   case noTransport
   case cancelled(RecordingCancelOrigin)
+  /// #1920: audio was arriving, the engine ran clean, and it produced no words.
+  /// Kept distinct from `.noSpeech` because it asserts nothing about whether
+  /// speech occurred. Deletes like every other concluded live ending (#1755) —
+  /// `RecoveryCoordinator.shouldDeleteOnLiveEnding` is exhaustive, so that
+  /// decision is made explicitly there rather than inherited.
+  case asrEmptyDespiteAudio
 }
 
 /// Issue #285 — heart-path telemetry callbacks that the former root state routes to

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -37,6 +37,16 @@ public enum RecordingFailureReason: Equatable, Sendable {
   /// same as the prewarm (PTT) path already does AppKit-side.
   case noMicrophoneFound
   case noAudioCaptured
+  /// #1920: NO PRODUCTION PRODUCER since the empty-decode path was re-typed to
+  /// `RecordingOutcome.asrEmptyDespiteAudio`. Kept, not deleted, for two reasons:
+  /// its projected `TerminalNoticeReason.asrEmptyWithSpeech` raw value is the
+  /// SHIPPED PostHog vocabulary that historical rows still carry, and the tests
+  /// guarding #979's Sentry downgrade document why that downgrade exists. Same
+  /// accepted pattern as `TerminalNoticeReason.unknown`.
+  ///
+  /// **DO NOT route an empty decode here again.** An empty result carries no
+  /// evidence that anything failed; that is the whole finding of #1920, and
+  /// `.failed(_)` renders "Transcription error. Try again."
   case asrEmpty
   case asrFailed
   case asrWedged
@@ -95,6 +105,29 @@ enum RecordingOutcome: Equatable, Sendable {
   /// `bufferCountThisSession == 0` (a dead mic). Projects to the existing
   /// `.failed(.noAudioCaptured)` telemetry + "No audio captured" copy.
   case noTransport
+  /// #1920: audio was arriving ABOVE every dead-air floor, the engine ran
+  /// without error, and it produced no words.
+  ///
+  /// THAT IS ALL THIS MEANS. It is deliberately NOT a claim that the recording
+  /// was silent, NOT a claim that anything failed, and NOT a claim about the
+  /// user. We hold no evidence for any of those: the empty decode itself is not
+  /// evidence, and neither energy nor duration can supply it — measured twice
+  /// independently (`pipeline-mechanics.md` FACT: no-speech-gate-and-soft-onset;
+  /// `SentryBreadcrumb.swift` `recoveryEmptyText` reached the same wall on the
+  /// recovery path).
+  ///
+  /// Replaces `.failed(.asrEmpty)` on this path. Founder rule 2026-08-04: "no
+  /// error if people are holding down the button and not speaking, as long as we
+  /// know we're capturing audio" — pressing the key while gathering thoughts is
+  /// ordinary use, and the engine doing its job and finding nothing is not an
+  /// event. Genuinely absent audio keeps its own advisory
+  /// (`.failed(.zeroSignal)` / `.noSpeech(.vadGate)`), which is the case that
+  /// SHOULD speak.
+  ///
+  /// Silent for the user by design. Carries its own `asr_empty_despite_audio`
+  /// terminal result rather than `failed` (it is not a failure) or `no_speech`
+  /// (we cannot assert absence of speech).
+  case asrEmptyDespiteAudio
 }
 
 /// The `delivering` sub-phase (#1548 D1). Nests the existing
@@ -525,6 +558,13 @@ final class RecordingSessionKernel {
       return .interruption
     case .asrInterrupted, .failed, .noTransport:
       return .recoverableError
+    // #1920: NAMED rather than left to the `default`. This projection is
+    // `default`-bearing, so the compiler does NOT force a decision here and a
+    // new terminal silently inherits `nil`. That happens to be correct for
+    // `.asrEmptyDespiteAudio` — nothing failed, so there is no error surface —
+    // but the correctness must be visible, not accidental.
+    case .asrEmptyDespiteAudio:
+      return nil
     default:
       return nil
     }
@@ -2391,13 +2431,24 @@ final class RecordingSessionKernel {
         // (`!salvageDelivered` above), so this IS the final answer for the take
         // — freezing earlier would attribute a take that later recovered.
         //
+        // Both branches freeze. #1920 re-typed the speech-evidence branch to
+        // `.asrEmptyDespiteAudio`, which now carries its own
+        // `asr_empty_despite_audio` terminal result; the line below describes the
+        // pre-#1920 shape and is kept for the #1890 provenance.
         // Both branches freeze. `.failed(.asrEmpty)` is the `asr_empty_with_speech`
         // half #1890 counts; the `.noSpeech(.asrEmptyNoSpeech)` half already has
         // its own richer event from #1888, and giving the terminal row the same
         // frozen facts costs nothing and keeps the two joinable on `take_id`.
         freezeSignalAttribution(samples: captureResult.samples, peak: rawPeakAudioLevel)
+        // #1920: an empty decode is NOT a failure. Audio was arriving above every
+        // dead-air floor and the engine ran clean, so there is no evidence that
+        // anything broke — the terminal is a neutral observation and the user is
+        // told nothing. Genuinely absent audio keeps its own advisory via
+        // `.failed(.zeroSignal)` / `.noSpeech(.vadGate)`, which never reach here.
+        // The trigger is UNCHANGED from the pre-#1920 line: same
+        // `effectiveSpeechEvidence`, same point, after the same salvage attempt.
         finishTerminal(
-          effectiveSpeechEvidence ? .failed(.asrEmpty) : .noSpeech(.asrEmptyNoSpeech),
+          effectiveSpeechEvidence ? .asrEmptyDespiteAudio : .noSpeech(.asrEmptyNoSpeech),
           sid: sid)
       }
     case .cancelled:
@@ -3367,7 +3418,10 @@ final class RecordingSessionKernel {
       switch outcome {
       case .failed, .discarded, .cancelled, .noTransport:
         return true
-      case .completed, .noSpeech, .audioInterrupted, .asrInterrupted:
+      // #1920: `.asrEmptyDespiteAudio` is produced ONLY by the post-decode empty
+      // branch, which runs at `.delivering/.transcribing`. Refusing it everywhere
+      // else makes the impossible state unreachable rather than handled.
+      case .completed, .noSpeech, .audioInterrupted, .asrInterrupted, .asrEmptyDespiteAudio:
         return false
       }
     case .live:
@@ -3381,7 +3435,7 @@ final class RecordingSessionKernel {
         return true
       case .asrInterrupted(wasRecording: true):
         return true
-      case .asrInterrupted(wasRecording: false), .completed, .noSpeech:
+      case .asrInterrupted(wasRecording: false), .completed, .noSpeech, .asrEmptyDespiteAudio:
         return false
       }
     case .stopping:
@@ -3398,7 +3452,9 @@ final class RecordingSessionKernel {
         // never for an ordinary caller forging the live-time payload from a
         // later phase.
         return telemetryState.interruptedSalvageSource == .asr
-      case .completed, .noTransport:
+      // #1920: illegal from `.stopping` — the empty-decode producer runs a phase
+      // later, at `.delivering/.transcribing`.
+      case .completed, .noTransport, .asrEmptyDespiteAudio:
         return false
       }
     case .delivering:
@@ -3411,6 +3467,10 @@ final class RecordingSessionKernel {
         // is #1707's salvage-recovery-failure floor target, typed-gated below.
         switch outcome {
         case .failed, .noSpeech, .cancelled, .audioInterrupted:
+          return true
+        // #1920: the ONLY phase that may conclude `.asrEmptyDespiteAudio`. Its
+        // sole producer is the post-decode empty branch, which runs here.
+        case .asrEmptyDespiteAudio:
           return true
         case .asrInterrupted(wasRecording: false):
           return true
@@ -3435,7 +3495,11 @@ final class RecordingSessionKernel {
           return true
         case .asrInterrupted(wasRecording: true):
           return telemetryState.interruptedSalvageSource == .asr
-        case .cancelled, .discarded, .asrInterrupted(wasRecording: false), .noTransport:
+        // #1920: `.finalizing` begins only once a NON-EMPTY transcript enters
+        // `runFinalizing`, so the empty-decode producer can never conclude from
+        // here. Refused rather than accepted-just-in-case.
+        case .cancelled, .discarded, .asrInterrupted(wasRecording: false), .noTransport,
+          .asrEmptyDespiteAudio:
           return false
         }
       }
@@ -3500,7 +3564,10 @@ final class RecordingSessionKernel {
       return outcome
     case .engine(let cause):
       switch outcome {
-      case .discarded, .noSpeech, .failed(.noAudioCaptured):
+      // #1920: `.asrEmptyDespiteAudio` joins the narrow set. An interrupted
+      // engine IS the honest account of why there is no text, and this is the
+      // same treatment its `.noSpeech` siblings already get.
+      case .discarded, .noSpeech, .failed(.noAudioCaptured), .asrEmptyDespiteAudio:
         return .audioInterrupted(cause)
       case .completed, .cancelled, .failed, .audioInterrupted, .asrInterrupted, .noTransport:
         return outcome
@@ -3533,7 +3600,11 @@ final class RecordingSessionKernel {
           stage: "recovery", message: "asr_salvage_cancelled",
           data: ["asr_salvage_outcome": "cancelled"])
         return outcome
-      case .discarded, .noSpeech, .failed, .audioInterrupted, .asrInterrupted, .noTransport:
+      // #1920: `.asrEmptyDespiteAudio` joins the WIDE-by-design set — the ASR
+      // salvage promises the same terminal every pre-salvage failure mode
+      // produced, and this is one of them.
+      case .discarded, .noSpeech, .failed, .audioInterrupted, .asrInterrupted, .noTransport,
+        .asrEmptyDespiteAudio:
         // #1707 Codex code-diff r2: only UPGRADE the telemetry signal — a
         // recovery that already failed/cancelled (stamped at the call site
         // before decode was ever attempted) must not be overwritten here;

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -778,8 +778,10 @@ public final class TelemetryService {
   /// **Count DISTINCT `take_id`, never rows.** A healthy take also emits an
   /// `asr.completed` stage row; adding event counts double-counts it.
   ///
-  /// The attribution block is present only for `zero_signal` and
-  /// `asr_empty_with_speech` — the two terminals #1890 is about. Every one of
+  /// The attribution block is present only for `zero_signal` and the
+  /// empty-decode terminal — the two terminals #1890 is about. #1920 renamed the
+  /// latter from `asr_empty_with_speech` to `asr_empty_despite_audio`, so a query
+  /// spanning that release boundary must accept BOTH tokens. Every one of
   /// those fields omits when nil and NEVER defaults: an exact zero is the
   /// signature of a digitally dead channel (#1809), so a manufactured `0` would
   /// be indistinguishable from the finding this data exists to detect.

--- a/Tests/EnviousWisprTests/Pipeline/DictationTerminalTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/DictationTerminalTelemetryTests.swift
@@ -57,6 +57,10 @@ struct DictationTerminalTelemetryTests {
       (.noSpeech(.vadGate), "no_speech"),
       (.audioInterrupted(.deviceRemoved), "audio_interrupted"),
       (.asrInterrupted(wasRecording: true), "asr_interrupted"),
+      // #1920: its own eighth value. Countability for this class lives HERE, on
+      // the terminal row that already carries device, transports, the energy
+      // triple, duration and take_id — no second overlapping event is minted.
+      (.asrEmptyDespiteAudio, "asr_empty_despite_audio"),
     ]
     for (outcome, expected) in cases {
       let recorder = Recorder()
@@ -83,6 +87,10 @@ struct DictationTerminalTelemetryTests {
       (.audioInterrupted(.deviceRemoved), "audio_interrupted", nil),
       (.asrInterrupted(wasRecording: true), "asr_interrupted", nil),
       (.noTransport, "failed", "no_audio_captured"),
+      // #1920: NOT a failure, so no reason — and the row is still countable by
+      // its own `result`. This is the assertion that keeps the "only failed rows
+      // carry a reason" contract true after adding the eighth value.
+      (.asrEmptyDespiteAudio, "asr_empty_despite_audio", nil),
     ]
     for (outcome, expectedResult, expectedReason) in cases {
       let recorder = Recorder()

--- a/Tests/EnviousWisprTests/Pipeline/Issue1358EmptyRecoveryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Issue1358EmptyRecoveryTests.swift
@@ -265,6 +265,23 @@ private final class SavedBox {
           == .noSpeech(.asrEmptyNoSpeech))
     }
 
+    /// #1920: the same two floor cells for the new speech-evidence terminal. It
+    /// is a TOP-LEVEL case, so unlike a `.noSpeech` sub-case it is not swept in
+    /// by `case .noSpeech` — both arms had to name it, and this freezes that.
+    @Test("asrEmptyDespiteAudio floors to audioInterrupted, and passes through clean")
+    func asrEmptyDespiteAudioFloorCells() {
+      let interrupted = freshKernelAtFinalizing()
+      interrupted.testSetInterruptionCause(.engineLost)
+      #expect(
+        interrupted.testInterruptedTerminalFloor(.asrEmptyDespiteAudio).kind
+          == .audioInterrupted)
+
+      let clean = freshKernelAtFinalizing()
+      clean.testSetInterruptionCause(nil)
+      #expect(
+        clean.testInterruptedTerminalFloor(.asrEmptyDespiteAudio) == .asrEmptyDespiteAudio)
+    }
+
     // MARK: Diagnostic-archive relabel (code-diff r2)
     // `relabeledArchiveOutcome` + the dictation-audio-archive feature are
     // `#if DEBUG`-only (diagnostic capture), so this test lives in the gated suite.

--- a/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverTests.swift
@@ -55,6 +55,8 @@ import Testing
     // (founder ruling, 2026-07-31). Without these two arms an advisory that
     // fired on every no-speech source would pass the assertion above.
     #expect(mappedOutcome(.noSpeech(.asrEmptyNoSpeech)) == .idle)
+    // #1920: silent terminal — back to idle, no error state published.
+    #expect(mappedOutcome(.asrEmptyDespiteAudio) == .idle)
     #expect(mappedOutcome(.noSpeech(.emptyAfterProcessing)) == .idle)
     // #1891: zero-signal moved out of the error surface for the same reason.
     #expect(mappedOutcome(.failed(.zeroSignal)) == .advisory(.zeroSignal))

--- a/Tests/EnviousWisprTests/Pipeline/KernelHeartPathTelemetryObserverTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelHeartPathTelemetryObserverTests.swift
@@ -81,6 +81,7 @@ import Testing
     func noSpeechCarriesSource() {
       #expect(terminalEvent(.noSpeech(.vadGate)) == .noSpeech(.vadGate))
       #expect(terminalEvent(.noSpeech(.asrEmptyNoSpeech)) == .noSpeech(.asrEmptyNoSpeech))
+      #expect(terminalEvent(.asrEmptyDespiteAudio) == .asrEmptyDespiteAudio)
     }
 
     // MARK: deltaEvents map — pure (in-flight tuple delta → lifecycle events)

--- a/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
@@ -1368,7 +1368,8 @@ import Testing
     .recordingStopped,
     .transcriptionStarted,
     .asrCompleted,
-    // Terminal — the seven `terminalStateLabel` recognises.
+    // Terminal — the eight `terminalStateLabel` recognises (#1920 added the
+    // eighth).
     .pipelineCompleted,
     .failed(.asrEmpty),
     .audioInterrupted(cause: .engineLost),
@@ -1376,6 +1377,7 @@ import Testing
     .discarded(.tooShort),
     .noSpeech(.vadGate),
     .cancelled,
+    .asrEmptyDespiteAudio,
   ]
 
   /// A deliberate COMPILE-TIME MIRROR of the production `terminalStateLabel`
@@ -1387,7 +1389,7 @@ import Testing
   private static func isTerminalMirror(_ event: KernelLifecycleEvent) -> Bool {
     switch event {
     case .pipelineCompleted, .failed, .audioInterrupted, .asrInterrupted,
-      .discarded, .noSpeech, .cancelled:
+      .discarded, .noSpeech, .cancelled, .asrEmptyDespiteAudio:
       true
     case .pipelineStartingUp, .modelLoading, .recordingCommitted, .recordingStopped,
       .transcriptionStarted, .asrCompleted:
@@ -1407,10 +1409,10 @@ import Testing
   @Test("every terminal removes the take key and clears recording state exactly once")
   func everyTerminalClearsTheTakeKeyExactlyOnce() {
     let events = Self.allEvents
-    #expect(events.count == 13, "one representative per KernelLifecycleEvent case")
+    #expect(events.count == 14, "one representative per KernelLifecycleEvent case")
 
     let terminals = events.filter { Self.isTerminalMirror($0) }
-    #expect(terminals.count == 7, "the closed terminal set `terminalStateLabel` recognises")
+    #expect(terminals.count == 8, "the closed terminal set `terminalStateLabel` recognises")
 
     for event in events {
       let recorder = Recorder()

--- a/Tests/EnviousWisprTests/Pipeline/KernelSalvageRetryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelSalvageRetryTests.swift
@@ -156,13 +156,13 @@ struct KernelSalvageRetryTests {
     #expect(ctx.wrapper.telemetryState.asrCompletedTelemetry?.mode == "batch")
   }
 
-  @Test("all retries empty → today's asrEmpty terminal, ladder bounded by the candidate count")
+  @Test("all retries empty → the empty terminal (#1920), ladder bounded by the candidate count")
   func allRetriesEmptyFallsThrough() async {
     let ctx = makeContext(behavior: .emptyThenScripted(text: "never", emptyCalls: 99))
     await runToTerminal(ctx)
     let kernel = ctx.wrapper.testKernel
 
-    #expect(kernel.recordingOutcome == .failed(.asrEmpty))
+    #expect(kernel.recordingOutcome == .asrEmptyDespiteAudio)
     #expect(kernel.deliveredTranscript == nil)
     #expect(kernel.pasteCount == 0)
     #expect(kernel.lastSalvagedLeadTrimMs == nil)
@@ -180,12 +180,12 @@ struct KernelSalvageRetryTests {
 
     // The primary decode classified the session as empty; a retry-path error
     // must not surface as `.asrFailed`.
-    #expect(kernel.recordingOutcome == .failed(.asrEmpty))
+    #expect(kernel.recordingOutcome == .asrEmptyDespiteAudio)
     #expect(ctx.engine.finalizeCallCount == 2)
     #expect(kernel.lastSalvagedLeadTrimMs == nil)
   }
 
-  @Test("no candidates (healthy-shaped capture) → no retry, terminal unchanged from A11")
+  @Test("no candidates (healthy-shaped capture) → no retry, terminal unchanged from A11 (#1920 renamed it)")
   func noCandidatesMeansNoRetry() async {
     let ctx = makeContext(behavior: .emptyThenScripted(text: "never", emptyCalls: 99))
     await ctx.wrapper.apply(.start)
@@ -200,7 +200,7 @@ struct KernelSalvageRetryTests {
     await ctx.wrapper.drainReadyWork()
     let kernel = ctx.wrapper.testKernel
 
-    #expect(kernel.recordingOutcome == .failed(.asrEmpty))
+    #expect(kernel.recordingOutcome == .asrEmptyDespiteAudio)
     // Exactly the primary decode — the ladder never dispatched.
     #expect(ctx.engine.finalizeCallCount == 1)
   }

--- a/Tests/EnviousWisprTests/Pipeline/KernelTerminalKindTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelTerminalKindTests.swift
@@ -161,6 +161,18 @@ struct EndingRetryOutcomeComposedMatrixTests {
     }
   }
 
+  /// #1920: the new terminal projects to its OWN ending and that ending deletes,
+  /// like every other concluded live ending (#1755). This is the audio-deletion
+  /// decision, so it gets its own cell rather than riding on a sibling's: the
+  /// compiler forces the `shouldDeleteOnLiveEnding` arm to exist, but only a test
+  /// proves it answers `true`.
+  @Test(".asrEmptyDespiteAudio: projects to its own ending and deletes")
+  func asrEmptyDespiteAudioProjectsAndDeletes() {
+    for retry in [nil, .attempted, .retrySucceeded, .retryExhausted] as [ASRRetryOutcome?] {
+      #expect(composedDelete(.asrEmptyDespiteAudio, retry) == (.asrEmptyDespiteAudio, true))
+    }
+  }
+
   @Test("characterization: .completed and static .cancelled stay outside the predicate")
   func completedAndStaticCancelledProjectNil() {
     #expect(KernelDictationDriver.recoveryEnding(for: .completed) == nil)

--- a/Tests/EnviousWisprTests/Pipeline/KernelTerminalProjectionsTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelTerminalProjectionsTests.swift
@@ -75,6 +75,7 @@ struct KernelTerminalProjectionsTests {
     #expect(RecordingOutcome.cancelled.lifecycleEvent == .cancelled)
     #expect(RecordingOutcome.failed(.asrFailed).lifecycleEvent == .failed(.asrFailed))
     #expect(RecordingOutcome.noSpeech(.vadGate).lifecycleEvent == .noSpeech(.vadGate))
+    #expect(RecordingOutcome.asrEmptyDespiteAudio.lifecycleEvent == .asrEmptyDespiteAudio)
     #expect(RecordingOutcome.discarded(.tooShort).lifecycleEvent == .discarded(.tooShort))
     #expect(
       RecordingOutcome.asrInterrupted(wasRecording: true).lifecycleEvent

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FSMState.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FSMState.swift
@@ -44,6 +44,8 @@ enum FSMState: Equatable, Sendable {
   case cancelled
   case discarded
   case noSpeech
+  /// #1920: audio arrived, the engine ran clean, no words. Silent terminal.
+  case asrEmptyDespiteAudio
   case audioInterrupted
   case asrInterrupted
 
@@ -51,7 +53,7 @@ enum FSMState: Equatable, Sendable {
   var isTerminal: Bool {
     switch self {
     case .completed, .failed, .cancelled, .discarded, .noSpeech,
-      .audioInterrupted, .asrInterrupted:
+      .audioInterrupted, .asrInterrupted, .asrEmptyDespiteAudio:
       return true
     case .idle, .preparing, .warmingUp, .recording, .stopping, .transcribing,
       .finalizing:

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
@@ -484,6 +484,7 @@ final class KernelRecordingSession: RecordingSessionDriving {
       case .cancelled: return .cancelled
       case .discarded: return .discarded
       case .noSpeech: return .noSpeech
+      case .asrEmptyDespiteAudio: return .asrEmptyDespiteAudio
       case .audioInterrupted: return .audioInterrupted
       case .asrInterrupted: return .asrInterrupted
       case .noTransport: return .failed(.noAudioCaptured)

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioInventory.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioInventory.swift
@@ -144,15 +144,20 @@ enum ScenarioInventory {
         terminalState: .completed, pasteCount: 1, pasteOutcome: .pasted,
         transcript: .nonEmpty)),
     Scenario(
-      id: "A11", name: "adapter empty result with speech evidence",
+      // #1920: audio was arriving above every dead-air floor and the engine ran
+      // clean — nothing failed, so the user is told NOTHING. Founder rule
+      // 2026-08-04: holding the key while gathering thoughts is ordinary use.
+      // `userVisibleError: nil` is the assertion that matters here; it was
+      // `.recoverableError` before this change.
+      id: "A11", name: "adapter empty result with speech evidence -> silent (#1920)",
       steps: [
         .engine(.setBehavior(.empty(hadSpeechEvidence: true))),
         .vad(.evidence(.voiced)),
         .trigger(.start), .capture(.deliverBuffer), .trigger(.stop),
       ],
       expected: ExpectedOutcome(
-        terminalState: .failed(.asrEmpty), pasteCount: 0, pasteOutcome: .none,
-        transcript: .none, userVisibleError: .recoverableError)),
+        terminalState: .asrEmptyDespiteAudio, pasteCount: 0, pasteOutcome: .none,
+        transcript: .none, userVisibleError: nil)),
     Scenario(
       id: "A12", name: "adapter empty result, no speech",
       steps: [

--- a/Tests/EnviousWisprTests/Pipeline/TerminalAdvisoryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TerminalAdvisoryTests.swift
@@ -26,6 +26,10 @@ import Testing
     // NEGATIVE — a working microphone and a user who said nothing. These stay
     // SILENT by founder ruling: they already know they did not speak.
     #expect(KernelDictationDriver.advisoryReason(for: .noSpeech(.asrEmptyNoSpeech)) == nil)
+    // #1920: audio WAS arriving above every dead-air floor and the engine ran
+    // clean, so there is nothing to tell the user to check. The two advisories
+    // above stay the only ones, and they are the genuinely-absent-audio cases.
+    #expect(KernelDictationDriver.advisoryReason(for: .asrEmptyDespiteAudio) == nil)
     #expect(KernelDictationDriver.advisoryReason(for: .noSpeech(.emptyAfterProcessing)) == nil)
 
     // NEGATIVE — genuinely our software. These keep "Audio capture error.

--- a/Tests/EnviousWisprTests/Pipeline/TestSupport/RecordingOutcomeAssertions.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TestSupport/RecordingOutcomeAssertions.swift
@@ -24,6 +24,8 @@ extension RecordingOutcome {
     case audioInterrupted
     case asrInterrupted
     case noTransport
+    /// #1920: audio arrived, engine ran clean, no words. Silent terminal.
+    case asrEmptyDespiteAudio
   }
 
   var kind: Kind {
@@ -36,6 +38,7 @@ extension RecordingOutcome {
     case .audioInterrupted: return .audioInterrupted
     case .asrInterrupted: return .asrInterrupted
     case .noTransport: return .noTransport
+    case .asrEmptyDespiteAudio: return .asrEmptyDespiteAudio
     }
   }
 }


### PR DESCRIPTION
Closes #1920.

## What changed

An empty transcription is no longer an error. When audio was arriving above every dead-air floor and the engine ran clean, the user is now told **nothing**.

`.failed(.asrEmpty)` became a new cause-neutral `RecordingOutcome.asrEmptyDespiteAudio` on the **identical trigger** — same `effectiveSpeechEvidence` condition, same point in `finishTerminal`, after the same #1434 salvage attempt. No threshold of any kind was added.

Founder rule (2026-08-04): *"no error if people are holding down the button and not speaking, as long as we know we're capturing audio."*

## Why this was the wrong bucket

`.failed(.asrEmpty)` is filed under "our software broke" while carrying no evidence that anything broke. A single false-positive VAD segment from fan noise was the entire difference between a silent non-event and an accusation:

- VAD returns `segments=0` → the empty decode maps to `.noSpeech(.asrEmptyNoSpeech)` → silent.
- VAD returns `segments=1` on the identical audio → `.failed(.asrEmpty)` → "Transcription error. Try again."

The founder's repro measured `peak=0.005744`, **below** our own 0.006 dead-air peak floor, and was still told transcription failed.

Genuinely absent audio keeps its existing "Audio isn't capturing" advisory. That is the case that *should* speak, and it is unchanged.

## No threshold, and three rejected ones

| Rejected | Killed by |
|---|---|
| Loudness / energy vs the dead-air floor | Measurement. The failing takes sit 2.3-2.6× above the floor, and a real "Mm-hmm." take sits *inside* the failing cluster. Third independent confirmation. |
| Envelope modulation | Same measurement. Both soft-vocalisation controls are *less* modulated than fan noise. |
| A 2.0s duration threshold | Founder. Brittle, and it puts whispering and one-word replies at risk for no gain. |
| Escalating after N consecutive empties | Founder. Press-let-go-press-let-go while gathering thoughts is the *common* case, so the counter fires on benign behaviour and lands exactly when the user finally speaks. |

All four failed for one shared reason: the benign case and the broken case are indistinguishable on that signal. Repeats are a telemetry query, never announced.

## Telemetry

`asr_empty_despite_audio` is an additive **eighth** `dictation_terminal` `result` value, carrying the existing attribution block (device, transports, energy triple, duration, `take_id`). `no_speech` keeps meaning "a quiet room". No new event was minted — consecutive-empty runs are a query over data we already have.

Registered in `analytics-operations.md` and `sentry-operations.md` (terminal count seven → eight), with the release-boundary trend traps documented: `asr_empty_with_speech` drops to zero, and that drop is the change, not a fix.

## Competitor grounding

Wispr Flow 1.6.326, SuperWhisper 2.17.0 and Handy were torn down before this design landed (`.claude/knowledge/competitor-error-taxonomies.md`, new file). None of the three uses an audio discriminator for this; all three solve it at the **notice** layer. Wispr Flow ships 86 notification types with a frequency-capped eligibility layer and keeps `transcription_empty` separate from `transcription_error`. Handy shows nothing at all on empty.

## Tests

- **Failing test first:** simulator scenario A11 flipped from `terminalState: .failed(.asrEmpty), userVisibleError: .recoverableError` to `terminalState: .asrEmptyDespiteAudio, userVisibleError: nil`.
- Full Debug lane green: **4,742 tests**.
- The compiler enumerated all 12 exhaustive-switch consumers and they matched the plan's matrix exactly — including `RecoveryCoordinator.shouldDeleteOnLiveEnding`, the audio-deletion decision, which was compiler-forced rather than remembered.

## Live UAT (three cases, dev app from this branch)

1. **The defect** — reached `terminal asrEmptyDespiteAudio` with the salvage ladder declining, the spool deleted, and `result=asr_empty_despite_audio` carrying the attribution block. The founder independently confirmed no pill appears; `app.log` has no overlay instrument, so its silence would not have been evidence either way. Reproducing the branch needed synthesized fan noise at one narrow level — a quiet room gives `segments=0`, and louder noise makes Parakeet hallucinate and complete.
2. **Normal dictation** — `result=completed`, transcribed and pasted.
3. **Muted mic still warns** — `terminal noSpeech(vadGate)` with all three dead-air floors crossed, the advisory's own terminal, unchanged.

## Accepted, flagged for review

`RecordingFailureReason.asrEmpty` and `TerminalNoticeReason.asrEmptyWithSpeech` now have **no production producer**. They are documented dead with do-not-reuse notes rather than deleted: removal touches 18 test files, several of which exist to document why #979's Sentry downgrade happened. Same accepted pattern as `TerminalNoticeReason.unknown`.

This is a deliberate deviation from "remove old code in the same change". The local whole-diff review grepped both symbols and returned clean without raising them. **If this review rejects it, say so and it gets removed rather than argued.**

## Routed out

**#1923** — a dead mic and an interrupted recording both say "Transcription error". Two pre-existing misfilings found while checking all 18 reasons against the positive-evidence test. Both reuse copy we already ship. Deliberately not folded in, so this change's UAT stays attributable.
