### PR TITLE
fix(test): stop the UAT typer latching shift after the first capital

### DIFF
--- a/Tests/RuntimeUAT/simulate_input.py
+++ b/Tests/RuntimeUAT/simulate_input.py
@@ -172,16 +172,16 @@ def press_key(key_name, cmd=False, shift=False, alt=False, ctrl=False):
     if ctrl:
         flags |= kCGEventFlagMaskControl
 
-    # Key down.
+    # Key down. Flags are set unconditionally, including to 0 — see the note in
+    # `type_text`: a new event inherits ambient modifier state, so a conditional
+    # set latches a modifier into every later event.
     down_event = CGEventCreateKeyboardEvent(None, keycode, True)
-    if flags:
-        CGEventSetFlags(down_event, flags)
+    CGEventSetFlags(down_event, flags)
     CGEventPost(kCGHIDEventTap, down_event)
 
     # Key up.
     up_event = CGEventCreateKeyboardEvent(None, keycode, False)
-    if flags:
-        CGEventSetFlags(up_event, flags)
+    CGEventSetFlags(up_event, flags)
     CGEventPost(kCGHIDEventTap, up_event)
 
     time.sleep(DEFAULT_DELAY)
@@ -222,9 +222,19 @@ def type_text(text, delay=None):
 
         down = CGEventCreateKeyboardEvent(None, keycode, True)
         up = CGEventCreateKeyboardEvent(None, keycode, False)
-        if flags:
-            CGEventSetFlags(down, flags)
-            CGEventSetFlags(up, flags)
+        # ALWAYS set flags, including to 0. A freshly created keyboard event
+        # inherits the ambient modifier state, so skipping this call when
+        # `flags` is 0 leaves shift latched from the previous character:
+        # `hello then Hello then world` typed as `hello then HELLO THEN WORLD`
+        # (2026-08-04). The first capital turns shift on and nothing turns it
+        # off again.
+        #
+        # It fails silently and in the worst possible place. Any UAT that types
+        # mixed-case context is then testing ALL-CAPS input, and for the
+        # continuation-casing feature that is a different question entirely —
+        # the run looks healthy and proves nothing.
+        CGEventSetFlags(down, flags)
+        CGEventSetFlags(up, flags)
 
         CGEventPost(kCGHIDEventTap, down)
         CGEventPost(kCGHIDEventTap, up)
@@ -329,18 +339,16 @@ def hold_key(key_name, duration=2.0, cmd=False, shift=False, alt=False, ctrl=Fal
     if ctrl:
         flags |= kCGEventFlagMaskControl
 
-    # Key down
+    # Key down. Unconditional flags, same reason as `type_text`.
     down_event = CGEventCreateKeyboardEvent(None, keycode, True)
-    if flags:
-        CGEventSetFlags(down_event, flags)
+    CGEventSetFlags(down_event, flags)
     CGEventPost(kCGHIDEventTap, down_event)
 
     time.sleep(duration)
 
     # Key up
     up_event = CGEventCreateKeyboardEvent(None, keycode, False)
-    if flags:
-        CGEventSetFlags(up_event, flags)
+    CGEventSetFlags(up_event, flags)
     CGEventPost(kCGHIDEventTap, up_event)
     time.sleep(DEFAULT_DELAY)
 


### PR DESCRIPTION
`simulate_input.type_text` latched the shift modifier the moment it typed its first capital, so everything after it came out shifted. `hello then Hello then world` typed as `hello then HELLO THEN WORLD`.

A new `CGEvent` inherits the ambient modifier state, and the old code only ever SET flags — it never cleared them — so once shift went on for one character it stayed on for the rest of the string.

Every event-creating site now calls `CGEventSetFlags` unconditionally, including with `0`.

**This is a test-harness bug with a product-sized blast radius.** Any UAT that types a capital was measuring a sentence nobody wrote, and nothing in the output says so — the run completes, the pipeline reports OK, and the verdict is about the wrong input. It was caught by the founder noticing the screen, not by any assertion.

It cost this session one wasted UAT setup before it was noticed a second time: the #1926 wrapped-terminal harness typed `I WANT TO TEST IF THIS WORKS...` on its first run.

Tier: SMALL | Lane: Code | Modules: RuntimeUAT
