### PR TITLE
fix(pipeline): gate continuation casing on confidence, not input length (Closes #1921)

### DIFF
--- a/Sources/EnviousWisprCore/Transcript.swift
+++ b/Sources/EnviousWisprCore/Transcript.swift
@@ -7,9 +7,9 @@ public struct ExecutionMetrics: Codable, Sendable {
   public var llmLatencySeconds: Double?
   public var pasteTier: String?
   public var pasteLatencyMs: Int?
-  /// Cursor-aware insertion (#1785). All four are optional and additive, so a
-  /// transcript written before this feature decodes with them nil rather than
-  /// failing. Shapes and closed-set names only — a wrong-case report carries no
+  /// Cursor-aware insertion (#1785, extended by #1921). All six are optional and
+  /// additive, so a transcript written before either feature decodes with them
+  /// nil rather than failing. Shapes and closed-set names only — a wrong-case report carries no
   /// text, and these are what make it answerable:
   ///
   /// - `smartInsertionEnabled`: the setting as frozen for that recording,
@@ -21,10 +21,24 @@ public struct ExecutionMetrics: Codable, Sendable {
   ///   without the word it applied to.
   /// - `pastePayloadKind`: `legacy` / `repaired`, or nil when no route reached a
   ///   write. What was SUBMITTED, never proof of what landed.
+  /// - `languageResolutionSource` / `languageConfidenceBucket` (#1921): WHY the
+  ///   language question got the answer it did — `locked` / `engine` /
+  ///   `dictation` / `document` / `none`, and a confidence band. Without them
+  ///   `case_skipped:language_not_supported` looks identical whether the user
+  ///   locked a language, the engine reported one, or the recogniser was unsure.
+  ///
+  ///   Both stay OPTIONAL, and nil is not the same as `"none"`: `"none"` means
+  ///   the app measured and found nothing, nil means the fact was never
+  ///   recorded — which is every transcript written before #1921.
+  ///
+  ///   `public` is required, not preferred: `ExecutionMetrics` is the existing
+  ///   public carrier across Core -> Pipeline and Core -> Services.
   public var smartInsertionEnabled: Bool?
   public var caretContextOutcome: String?
   public var repairRules: String?
   public var pastePayloadKind: String?
+  public var languageResolutionSource: String?
+  public var languageConfidenceBucket: String?
   public var targetApp: String?
   public var coldStart: Bool
   public var streamingMode: Bool
@@ -131,6 +145,8 @@ public struct ExecutionMetrics: Codable, Sendable {
     caretContextOutcome: String? = nil,
     repairRules: String? = nil,
     pastePayloadKind: String? = nil,
+    languageResolutionSource: String? = nil,
+    languageConfidenceBucket: String? = nil,
     targetApp: String? = nil,
     coldStart: Bool = false,
     streamingMode: Bool = false,
@@ -183,6 +199,8 @@ public struct ExecutionMetrics: Codable, Sendable {
     self.caretContextOutcome = caretContextOutcome
     self.repairRules = repairRules
     self.pastePayloadKind = pastePayloadKind
+    self.languageResolutionSource = languageResolutionSource
+    self.languageConfidenceBucket = languageConfidenceBucket
     self.targetApp = targetApp
     self.coldStart = coldStart
     self.streamingMode = streamingMode

--- a/Sources/EnviousWisprPipeline/DictationLanguageResolver.swift
+++ b/Sources/EnviousWisprPipeline/DictationLanguageResolver.swift
@@ -3,7 +3,7 @@ import Foundation
 import NaturalLanguage
 
 /// Decides what language a finished dictation is in, for consumers that must not
-/// act on a guess (#1785).
+/// act on a guess (#1785, #1921).
 ///
 /// The cursor-insertion repair only recases text in a language whose rules it
 /// knows, so a WRONG language is worse than no language: it lowercases a
@@ -15,79 +15,160 @@ import NaturalLanguage
 /// "Parakeet's 25 European languages, not just English" — and Parakeet is the
 /// default engine. Reading that field directly meant a German dictation on the
 /// default path was recased with English rules (cloud review, PR #1802).
-enum DictationLanguageResolver {
+///
+/// #1921 replaced a LENGTH floor with a CONFIDENCE floor. The old rule demanded
+/// 24 alphabetic scalars before it would look at the recogniser's answer at all,
+/// which refused **29.9% of 12,150 real continuations** — the short mid-sentence
+/// insertions this feature exists for. The recogniser can identify far shorter
+/// text than that; it was simply never asked how sure it was. Measured:
+/// `Rat war gut.` (9 scalars) is German at 1.000, `On my way.` (7) is English at
+/// 0.966, and across 33 deliberately adversarial non-English negatives the
+/// highest ENGLISH score was 0.204. Receipts:
+/// `docs/feature-requests/issue-1921-artifacts/`.
+package enum DictationLanguageResolver {
 
-  /// Minimum alphabetic scalars before `NLLanguageRecognizer` is trusted.
-  /// Matches the existing precedent in the polish output validator: below this
-  /// the recognizer's answer is noise, and a wrong answer here recases text.
-  static let minAlphabeticScalars = 24
+  /// How sure the recogniser must be before its answer is used.
+  ///
+  /// 0.90 rather than a value closer to the observed noise floor, deliberately.
+  /// These are not demonstrated calibrated probabilities, and the adversarial
+  /// corpus was written by the same person choosing this number, so "headroom
+  /// over my own worst case" is close to circular reasoning. 0.90 costs 3.8
+  /// points of acceptance against 0.80 and still moves the feature from 70.0% to
+  /// 87.6% of real continuations. Lower it only against an independently sourced
+  /// multilingual corpus.
+  package static let minConfidence = 0.90
 
-  /// The dictation's language, or nil when nothing can positively establish it.
+  /// What the resolver decided, and on what evidence.
+  ///
+  /// `language` alone cannot say whether it came from the user's setting, the
+  /// engine, the text, or nothing — so a field regression would be invisible.
+  /// `Sendable` because this value is carried across the repair deadline's
+  /// isolation boundary.
+  package struct Resolution: Sendable {
+
+    /// Which rung of the precedence ladder answered.
+    package enum Source: String, Sendable {
+      case locked, engine, dictation, document, none
+    }
+
+    /// Bucketed confidence. Buckets, never the raw score: the operational
+    /// question is "did the gate start resolving", and a raw float per dictation
+    /// is more precision than that needs.
+    package enum Bucket: String, Sendable {
+      case none, lt50, f50to70, f70to90, ge90
+
+      init(_ confidence: Double) {
+        // A non-finite score falls to `none` rather than through the range
+        // ladder. NaN compares false against every bound, so it would otherwise
+        // reach `default` and be reported as the HIGHEST bucket — a telemetry
+        // value that says "very confident" about an answer the gate refused,
+        // since NaN also fails `>= minConfidence`.
+        guard confidence.isFinite else {
+          self = .none
+          return
+        }
+        switch confidence {
+        case ..<0.50: self = .lt50
+        case ..<0.70: self = .f50to70
+        case ..<0.90: self = .f70to90
+        default: self = .ge90
+        }
+      }
+    }
+
+    let language: String?
+    let source: Source
+    let confidenceBucket: Bucket
+  }
+
+  /// What the recogniser thinks, and how sure it is. No policy.
+  ///
+  /// Deliberately sets NO `languageConstraints`. Constraining to the default
+  /// engine's own language list looks obviously right and is not: every
+  /// non-Latin script then returns nil, which collapses Japanese, Chinese and
+  /// Thai to `LanguageRules.unknown`, whose `usesWordSpacing` is true — so the
+  /// repair would ADD spaces those languages must not have, on BOTH sides:
+  /// rule 1 (`CursorInsertionRepair.swift:392`) adds the leading one and rule 3
+  /// (`:487`) the trailing one, and both read that same field. Measured both
+  /// ways; unconstrained also decouples this from which engine ran.
+  package static func identify(_ text: String) -> (language: String, confidence: Double)? {
+    guard !text.isEmpty else { return nil }
+    let recognizer = NLLanguageRecognizer()
+    recognizer.processString(text)
+    guard
+      let top = recognizer.languageHypotheses(withMaximum: 3)
+        .max(by: { $0.value < $1.value }),
+      let base = LanguageNormalizer.baseCode(top.key.rawValue)
+    else { return nil }
+    return (base, top.value)
+  }
+
+  /// The dictation's language, or an unresolved answer when nothing establishes it.
   ///
   /// Precedence, strongest evidence first:
-  /// 1. **The user told us.** A locked language setting is a statement of intent
-  ///    and outranks anything inferred.
-  /// 2. **An engine that actually detects.** Only meaningful when the engine
-  ///    reports `supportsLanguageDetection`; an engine that hard-codes a
-  ///    language is not reporting a detection, it is reporting a constant.
-  /// 3. **The text itself.** Apple's recognizer, above a length floor, for
-  ///    everything else — which is the default engine's normal path.
+  /// 1. **The user told us.** A locked language outranks anything inferred.
+  /// 2. **An engine that actually detects.** Only when the engine reports
+  ///    `supportsLanguageDetection`; an engine that hard-codes a language is
+  ///    reporting a constant, not a detection.
+  /// 3. **The text itself**, at or above `minConfidence`. This is the default
+  ///    engine's normal path.
+  /// 4. **The surrounding document, as a VETO only.**
   ///
-  /// Returns nil rather than a default. Callers must treat nil as "unknown" and
-  /// do the conservative thing, not fall back to English.
-  /// - Parameter surroundingText: the document text either side of the caret,
-  ///   already read for the repair. Used ONLY when the dictation alone is too
-  ///   short to identify, which is the common case for a mid-sentence
-  ///   continuation: "Store is closed today" is 18 alphabetic scalars, under the
-  ///   floor, so on the default engine the feature would never fire for exactly
-  ///   the short insertions it was built for (cloud review, PR #1802).
-  ///
-  ///   Reading the surrounding document is safe in the direction that matters. A
-  ///   German document with a German insertion identifies as German — correct. An
-  ///   English document with an English insertion identifies as English —
-  ///   correct. The mixed cases (dictating English into a German document, or
-  ///   the reverse) identify as the document's language, so casing is SKIPPED,
-  ///   which is today's behaviour rather than a wrong recasing.
-  static func resolve(
+  /// - Parameter identify: seam. Real recogniser output cannot reproducibly hit
+  ///   0.899 / 0.900 / 0.901 across OS versions, so the boundary is tested
+  ///   through this rather than by hunting for input that happens to land there.
+  package static func resolve(
     lockedLanguage: String?,
     engineDetectsLanguage: Bool,
     engineReportedLanguage: String?,
     text: String,
-    surroundingText: String = ""
-  ) -> String? {
-    if let lockedLanguage, !lockedLanguage.isEmpty { return lockedLanguage }
-    if engineDetectsLanguage, let engineReportedLanguage, !engineReportedLanguage.isEmpty {
-      return engineReportedLanguage
+    surroundingText: String = "",
+    identify: (String) -> (language: String, confidence: Double)? = Self.identify
+  ) -> Resolution {
+    if let lockedLanguage, !lockedLanguage.isEmpty {
+      return Resolution(language: lockedLanguage, source: .locked, confidenceBucket: .none)
     }
-    if let fromDictation = dominantLanguage(of: text) { return fromDictation }
+    if engineDetectsLanguage, let engineReportedLanguage, !engineReportedLanguage.isEmpty {
+      return Resolution(language: engineReportedLanguage, source: .engine, confidenceBucket: .none)
+    }
+
+    // `isFinite` at every acceptance gate, not only in the bucket. Infinity
+    // satisfies `>= minConfidence` while bucketing to `none`, which would resolve
+    // a language while reporting no confidence — a contradiction the field could
+    // never explain. Hypothetical from the real recogniser, reachable through the
+    // seam, and silent if wrong, which is the shape worth guarding.
+    let fromDictation = identify(text).flatMap { $0.confidence.isFinite ? $0 : nil }
+    let dictationBucket = fromDictation.map { Resolution.Bucket($0.confidence) } ?? .none
+    if let fromDictation, fromDictation.confidence >= minConfidence {
+      return Resolution(
+        language: fromDictation.language, source: .dictation, confidenceBucket: dictationBucket)
+    }
+
     // The surrounding document may VETO, never authorise.
     //
-    // My first version let the document decide outright, under a comment
-    // claiming both mixed cases were safe. That was false in one direction and I
-    // did not check it: an English document with a short GERMAN insertion
-    // resolves to English, and English casing then lowercases a German noun —
-    // the precise defect this whole path exists to prevent (cloud review, PR
-    // #1802, second time tonight a confident comment covered an unchecked claim).
+    // An earlier version let the document decide outright, under a comment
+    // claiming both mixed cases were safe. That was false in one direction: an
+    // English document with a short GERMAN insertion resolves to English, and
+    // English casing then lowercases a German noun — the precise defect this
+    // path exists to prevent (cloud review, PR #1802). Re-measured for #1921:
+    // 17 of 24 German nouns that are also English words would have been
+    // wrongly lowered, and the word-level oracle stops only 7 of them.
     //
     // So the document can only ever make us MORE conservative. If it reads as a
     // language we do not case, we take that and skip casing. If it reads as
     // English we still abstain, because the insertion itself was never
     // identified and English is the one answer that lets recasing proceed.
     guard !surroundingText.isEmpty,
-      let fromDocument = dominantLanguage(of: surroundingText + " " + text),
-      fromDocument != "en"
-    else { return nil }
-    return fromDocument
-  }
-
-  /// Apple's on-device recognizer, or nil when the text is too short to trust or
-  /// the recognizer will not commit.
-  static func dominantLanguage(of text: String) -> String? {
-    let letters = text.unicodeScalars.filter(\.properties.isAlphabetic).count
-    guard letters >= minAlphabeticScalars else { return nil }
-    let recognizer = NLLanguageRecognizer()
-    recognizer.processString(text)
-    guard let dominant = recognizer.dominantLanguage?.rawValue else { return nil }
-    return LanguageNormalizer.baseCode(dominant)
+      let fromDocument = identify(surroundingText + " " + text),
+      fromDocument.confidence.isFinite,
+      fromDocument.confidence >= minConfidence,
+      fromDocument.language != "en"
+    else {
+      return Resolution(language: nil, source: .none, confidenceBucket: dictationBucket)
+    }
+    return Resolution(
+      language: fromDocument.language,
+      source: .document,
+      confidenceBucket: Resolution.Bucket(fromDocument.confidence))
   }
 }

--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -4,6 +4,7 @@ import EnviousWisprLLM
 import EnviousWisprPostProcessing
 import EnviousWisprServices
 import Foundation
+import os
 
 // MARK: - KernelFinalizationWiring (epic #827, PR-4 §3.3, §3.6)
 //
@@ -80,6 +81,16 @@ final class KernelFinalizationOutcome {
   var smartInsertionEnabled: Bool?
   var caretContextOutcome: String?
   var repairRules: String?
+  /// #1921. `repairRules` says WHAT the repair decided; these say why the
+  /// language question got the answer it did. Without them a fielded regression
+  /// in the confidence gate is invisible: `case_skipped:language_not_supported`
+  /// looks identical whether the user locked a language, the engine reported
+  /// one, the recogniser was unsure, or the document vetoed.
+  ///
+  /// Closed-set category names only, never a language code, so this says how the
+  /// gate behaved without shipping what language each user speaks.
+  var languageResolutionSource: String?
+  var languageConfidenceBucket: String?
   /// #1167: whether the durable history save succeeded. `false` ⟺ the save
   /// threw but delivery still proceeded (best-effort save). Default `true` (the
   /// happy path); the `store` closure sets it explicitly on each save attempt,
@@ -183,6 +194,24 @@ struct KernelFinalizationWiring {
     // suites that legitimately do (local diff review, P2).
     englishWordOracle: @escaping @MainActor () -> EnglishWordOracle = {
       EnglishWordOracleRuntime.snapshot()
+    },
+    // #1921 language-resolver seam. `@Sendable`, not `@MainActor`, because
+    // resolution now runs INSIDE the `@Sendable` deadline operation. Defaults to
+    // the real resolver, so production behaviour is identical.
+    //
+    // A test injects a blocking resolver to drive the REAL deadline into its two
+    // reachable timeout orders. Without this the only way to reach them would be
+    // to time work against the 100 ms boundary, which is a clock race.
+    resolveLanguage: @escaping @Sendable (
+      _ lockedLanguage: String?,
+      _ engineDetectsLanguage: Bool,
+      _ engineReportedLanguage: String?,
+      _ text: String,
+      _ surroundingText: String
+    ) -> DictationLanguageResolver.Resolution = {
+      DictationLanguageResolver.resolve(
+        lockedLanguage: $0, engineDetectsLanguage: $1, engineReportedLanguage: $2,
+        text: $3, surroundingText: $4)
     },
     pasteCompletionRegistry: PasteCompletionRegistry?,
     // #900 clock seam — defaults to today's live expression, so production
@@ -378,6 +407,21 @@ struct KernelFinalizationWiring {
       let config = context.config
       var pasteResult: PasteDeliveryResult?
       let deliveryOutcome: KernelDeliveryOutcome
+      // #1921: cleared BEFORE the auto-paste branch below, because `outcome` is
+      // shared and reused across sessions. Everything that describes the
+      // insertion repair is written inside that branch, so a clipboard-only
+      // delivery would otherwise report the PREVIOUS dictation's language
+      // decision as if it were this one's — a stale reading that looks exactly
+      // like a real one in the field.
+      //
+      // Cleared to NIL, not to `"none"`. My first version wrote `"none"` here
+      // and that broke the contract these fields exist to express: `"none"`
+      // means the app measured and found no answer, nil means no measurement was
+      // ever attempted. A clipboard-only session never reaches the resolver at
+      // all, so `"none"` would have reported a measurement that did not happen
+      // (integration review).
+      outcome.languageResolutionSource = nil
+      outcome.languageConfidenceBucket = nil
       if config?.autoPasteToActiveApp == true {
         // ONE cumulative terminal-resolution budget for this whole delivery,
         // created here and reused by every commit-boundary revalidation. A fresh
@@ -438,36 +482,89 @@ struct KernelFinalizationWiring {
         // the DEFAULT engine, a German dictation on the default path was being
         // recased with English rules — the exact defect the language gate was
         // built to prevent (cloud review, PR #1802).
-        let resolvedLanguage = DictationLanguageResolver.resolve(
-          lockedLanguage: {
-            if case .locked(let code) = context.config?.languageMode { return code }
-            return nil
-          }(),
-          engineDetectsLanguage: adapter.capabilities.supportsLanguageDetection,
-          engineReportedLanguage: adapter.lastResult?.language,
-          text: text,
-          // The caret windows we already read. A short mid-sentence
-          // continuation cannot be identified on its own, and that is exactly
-          // the insertion this feature exists for.
-          surroundingText: caretContext.map { $0.leftWindow + " " + $0.rightWindow } ?? "")
-
+        // Every `@MainActor` input, snapshotted BEFORE the `@Sendable` deadline
+        // operation, which cannot reach a `@MainActor` seam.
+        let lockedLanguageCode: String? = {
+          if case .locked(let code) = context.config?.languageMode { return code }
+          return nil
+        }()
+        let engineDetectsLanguage = adapter.capabilities.supportsLanguageDetection
+        let engineReportedLanguage = adapter.lastResult?.language
+        // The caret windows we already read. A short mid-sentence continuation
+        // cannot always be identified on its own, and that is exactly the
+        // insertion this feature exists for.
+        let surroundingText = caretContext.map { $0.leftWindow + " " + $0.rightWindow } ?? ""
         let protectedSpellings = context.protectedSpellings
-        // Taken on the main actor BEFORE the deadline closure, which is
-        // `@Sendable` and cannot call a `@MainActor` seam.
         let oracleSnapshot = englishWordOracle()
+
+        // #1921: language resolution now runs INSIDE this deadline. It used to
+        // run above it, unbounded, on the paste path — a claim an earlier
+        // revision of the plan asserted was already true and was not.
+        //
+        // One gate arbitrates both stages, because "which stage timed out" now
+        // decides whether `EnglishWordOracleRuntime` may be disabled, and a
+        // plain flag cannot answer it safely: cancellation here is best-effort
+        // and cannot preempt a running operation, so the timeout can look, see
+        // the language stage, decline to disable, and the un-preempted operation
+        // can then enter the oracle anyway.
+        let gate = LanguageRepairDeadlineGate()
+        // The timeout path's resolution. It cannot ride the operation's return
+        // value, because on timeout the operation's value is discarded; and
+        // `onTimeout` is `@Sendable`, so it cannot write to a captured `var`.
+        let timedOutResolution = OSAllocatedUnfairLock<DictationLanguageResolver.Resolution?>(
+          initialState: nil)
+
+        let deadlineResult = await withOrderedDeadline(
+          seconds: 0.100,
+          operation: {
+            let resolution = resolveLanguage(
+              lockedLanguageCode, engineDetectsLanguage, engineReportedLanguage,
+              text, surroundingText)
+            guard gate.beginRepair(resolution) else {
+              // The deadline already claimed the phase, so repair must not
+              // start. This return value is discarded by the deadline's own
+              // single-claim rule; it exists to leave the closure, not to be read.
+              return (
+                CursorInsertionRepair.legacyOnly(text: text, reason: .oracleTimedOut), resolution
+              )
+            }
+            // The oracle asks the gate before every consultation, which both
+            // tells the timeout a genuinely stuck oracle from repair stalling
+            // before it ever got there, and refuses the call outright once the
+            // deadline has fired. `repair` has early exits and does spacing work
+            // first, so "repair started" is not "the oracle is running"
+            // (integration review); and cancellation cannot preempt a blocked
+            // thread, so without the refusal an un-preempted repair would still
+            // enter the real oracle after the timeout gave up (integration
+            // review round 2). Every refusal keeps the capital.
+            // `CursorInsertionRepair` stays unaware of the deadline: it remains
+            // a pure function of the oracle it is handed.
+            let gatedOracle = oracleSnapshot.authorized { gate.authorizeOracleUse() }
+            let repaired = CursorInsertionRepair.repair(
+              text: text,
+              context: repairContext,
+              protectedWords: protectedSpellings,
+              language: resolution.language,
+              oracle: gatedOracle)
+            // Immediately after repair returns and before this closure does, so
+            // the window in which a FINISHED oracle still looks stuck is as
+            // small as the runtime allows.
+            gate.completeRepair()
+            return (repaired, resolution)
+          },
+          onTimeout: {
+            let timeout = gate.timeOut()
+            timedOutResolution.withLock { $0 = timeout.resolution }
+            // Only a genuinely RUNNING oracle. A language-stage stall must not
+            // disable an unrelated healthy component for the rest of the
+            // process, and neither must one that had already succeeded.
+            if timeout.shouldDisableOracle { EnglishWordOracleRuntime.disableAfterTimeout() }
+          }
+        )
+
         let payloads =
-          await withOrderedDeadline(
-            seconds: 0.100,
-            operation: {
-              CursorInsertionRepair.repair(
-                text: text,
-                context: repairContext,
-                protectedWords: protectedSpellings,
-                language: resolvedLanguage,
-                oracle: oracleSnapshot)
-            },
-            onTimeout: { EnglishWordOracleRuntime.disableAfterTimeout() }
-          ) ?? CursorInsertionRepair.legacyOnly(text: text, reason: .oracleTimedOut)
+          deadlineResult?.0 ?? CursorInsertionRepair.legacyOnly(text: text, reason: .oracleTimedOut)
+        let resolution = deadlineResult?.1 ?? timedOutResolution.withLock { $0 }
 
         // Why this dictation was or was not repaired, recorded before delivery
         // so it survives every route outcome. Names and shapes only (#1785 §8).
@@ -482,6 +579,21 @@ struct KernelFinalizationWiring {
         outcome.repairRules =
           payloads.candidateRules.isEmpty
           ? nil : payloads.candidateRules.map(\.telemetryName).joined(separator: ",")
+        // #1921. An auto-paste attempt records the resolver outcome here,
+        // overwriting the nil defaulted at the top of `deliver`. A
+        // language-stage timeout records `none` because it genuinely produced
+        // no answer before the deadline. Clipboard-only delivery never reaches
+        // this block at all and so stays nil, because it never attempts
+        // resolution — that is the whole distinction the two values carry.
+        //
+        // Two earlier versions of this comment were wrong, in opposite
+        // directions. The first claimed the fields were "written on EVERY path";
+        // they were not, because this block sits inside the auto-paste branch.
+        // The second still said the default above was `none` after it had been
+        // changed to nil. A comment asserting a property the code does not have
+        // is worse than none, because it stops the next reader checking.
+        outcome.languageResolutionSource = (resolution?.source ?? .none).rawValue
+        outcome.languageConfidenceBucket = (resolution?.confidenceBucket ?? .none).rawValue
 
         // #1803: the repair decision has only ever gone to telemetry, so a
         // wrong-case report could not be diagnosed locally — which cost three
@@ -658,6 +770,12 @@ struct KernelFinalizationWiring {
       caretContextOutcome: outcome.caretContextOutcome,
       repairRules: outcome.repairRules,
       pastePayloadKind: outcome.pasteResult?.submittedPayload?.rawValue,
+      // #1921: carried through unchanged. Each hop transports exactly what the
+      // previous one produced — no normalising, no substituting a default —
+      // because a value that is quietly rewritten in transit is worse than one
+      // that is dropped: the dropped one is visibly absent.
+      languageResolutionSource: outcome.languageResolutionSource,
+      languageConfidenceBucket: outcome.languageConfidenceBucket,
       targetApp: context.targetApp?.bundleIdentifier,
       coldStart: false,
       streamingMode: outcome.streamingMode,

--- a/Sources/EnviousWisprPipeline/LanguageRepairDeadlineGate.swift
+++ b/Sources/EnviousWisprPipeline/LanguageRepairDeadlineGate.swift
@@ -1,0 +1,137 @@
+import Foundation
+import os
+
+/// Arbitrates the single 100 ms deadline that now covers BOTH language
+/// resolution and cursor-insertion repair (#1921).
+///
+/// Before #1921 only repair sat inside `withOrderedDeadline`; language
+/// resolution ran ahead of it, unbounded, on the paste path. Moving resolution
+/// inside the same deadline creates a question the old code never had to answer:
+/// **which stage timed out?** It matters because the existing `onTimeout`
+/// permanently disables `EnglishWordOracleRuntime`, and doing that because the
+/// LANGUAGE stage stalled would kill an unrelated, healthy component for the
+/// rest of the process.
+///
+/// A plain "did the repair stage begin" flag is not enough, and this is the
+/// whole reason a lock exists here. `withOrderedDeadline` cancels
+/// best-effort — its own comment says cancellation "cannot preempt a blocked
+/// thread" (`TaskTimeout.swift:129`) — and `onTimeout()` runs synchronously
+/// before the nil resume. So with a flag, the timeout can observe "still
+/// resolving", decline to disable, and the un-preempted operation can then walk
+/// straight into the oracle anyway.
+///
+/// Four states rather than three, which grounded review r3 found: `TaskTimeout`
+/// runs `await operation()` and its `claim()` as separate steps
+/// (`TaskTimeout.swift:123-125`), so repair can FINISH and the timeout can still
+/// win `claim()` in the gap. A three-state gate reads that as still-running,
+/// concludes the oracle is stuck, and disables a component that had just
+/// succeeded. `completed` is that gap.
+///
+/// **One lock, not two (integration review round 2).** An earlier version of
+/// this type kept `oracleTouched` in a SECOND `OSAllocatedUnfairLock`, read just
+/// before the phase lock was claimed. That is check-then-act: between the read
+/// and the claim, repair can consult the oracle and block, and the timeout then
+/// claims with a stale `false` and leaves a genuinely stuck oracle enabled.
+/// Merging the flag into the phase makes the two facts one atomic transition,
+/// and it is simpler than what it replaced. Every mutation below is exactly one
+/// `withLock`, so neither side can lose a window.
+package final class LanguageRepairDeadlineGate: Sendable {
+
+  private enum Phase: Sendable {
+    /// Resolution in flight. Repair has not been authorised.
+    case resolvingLanguage
+    /// Repair genuinely running, carrying whether the word oracle has actually
+    /// been consulted yet. This is the only phase that may disable the oracle,
+    /// and only with `oracleTouched` true.
+    case repair(DictationLanguageResolver.Resolution, oracleTouched: Bool)
+    /// Repair returned; the operation has not claimed its result yet.
+    case completed(DictationLanguageResolver.Resolution)
+    /// Terminal.
+    case timedOut
+  }
+
+  private let phase = OSAllocatedUnfairLock(initialState: Phase.resolvingLanguage)
+
+  package init() {}
+
+  /// Authorises repair, carrying the resolution the timeout would otherwise lose.
+  ///
+  /// Returns `false` when the deadline already claimed the phase, which is the
+  /// signal for the operation to return the legacy payload WITHOUT calling
+  /// repair. That is the guarantee a cancellation flag cannot give, because the
+  /// operation may not have been preempted at all.
+  package func beginRepair(_ resolution: DictationLanguageResolver.Resolution) -> Bool {
+    phase.withLock {
+      guard case .resolvingLanguage = $0 else { return false }
+      $0 = .repair(resolution, oracleTouched: false)
+      return true
+    }
+  }
+
+  /// May the word oracle be consulted right now, and record that it was.
+  ///
+  /// Called from the oracle's own closures on EVERY consultation, not merely the
+  /// first — which is what makes it a guard rather than a notification. Two
+  /// jobs, and they must be one transition:
+  ///
+  /// 1. **Record** that the oracle was genuinely reached. `beginRepair` runs
+  ///    before `CursorInsertionRepair.repair`, but repair has early exits and
+  ///    does all its spacing work before it ever consults word knowledge. Arming
+  ///    on "repair began" lets a timeout in that window permanently disable an
+  ///    oracle that was never touched — the exact harm this gate exists to
+  ///    prevent, moved one step later rather than removed.
+  /// 2. **Refuse** once the deadline has fired. Cancellation cannot preempt a
+  ///    blocked thread, so without this an un-preempted repair walks into the
+  ///    real oracle AFTER the timeout already gave up — the unbounded blocking
+  ///    call the deadline exists to bound. The wrapper's refusal keeps the
+  ///    capital, so a late refusal can only be safe.
+  ///
+  /// Idempotent; the cost is one uncontended lock per word decision.
+  package func authorizeOracleUse() -> Bool {
+    phase.withLock {
+      guard case .repair(let resolution, _) = $0 else { return false }
+      $0 = .repair(resolution, oracleTouched: true)
+      return true
+    }
+  }
+
+  /// Marks repair finished. Must be called immediately after repair returns and
+  /// before the deadline operation's closure returns, so the window in which a
+  /// healthy oracle looks stuck is as small as the runtime allows.
+  ///
+  /// Inert from any other phase: a `completeRepair` that never began must not
+  /// promote `resolvingLanguage` into a completed run.
+  package func completeRepair() {
+    phase.withLock {
+      guard case .repair(let resolution, _) = $0 else { return }
+      $0 = .completed(resolution)
+    }
+  }
+
+  /// Claims the phase for the deadline and reports what the caller may do.
+  ///
+  /// - Returns: the resolution when one was reached, so an oracle-stage or
+  ///   post-repair timeout still reports its real source and confidence rather
+  ///   than `none` / `none`; and whether the oracle runtime may be disabled,
+  ///   which is true ONLY for an oracle that was genuinely consulted.
+  package func timeOut()
+    -> (resolution: DictationLanguageResolver.Resolution?, shouldDisableOracle: Bool)
+  {
+    phase.withLock {
+      let result: (DictationLanguageResolver.Resolution?, Bool) =
+        switch $0 {
+        // Nothing ran. Nothing to report, nothing to punish.
+        case .resolvingLanguage: (nil, false)
+        // Repair is still running. Disable ONLY if the oracle was genuinely
+        // consulted — repair may have stalled in its own spacing work, or have
+        // taken an early exit, without ever reaching it.
+        case .repair(let resolution, let oracleTouched): (resolution, oracleTouched)
+        // Repair already returned, so whatever it consulted answered in time.
+        case .completed(let resolution): (resolution, false)
+        case .timedOut: (nil, false)
+        }
+      $0 = .timedOut
+      return result
+    }
+  }
+}

--- a/Sources/EnviousWisprPostProcessing/EnglishWordOracle.swift
+++ b/Sources/EnviousWisprPostProcessing/EnglishWordOracle.swift
@@ -52,6 +52,62 @@ package struct EnglishWordOracle: Sendable {
 
   package var isAvailable: Bool { unavailableReason == nil }
 
+  /// The same oracle, but asking permission before every consultation.
+  ///
+  /// `authorize` answers two things at once for a caller holding a deadline
+  /// (#1921), and both need to be one atomic answer rather than a notification:
+  ///
+  /// - **It records that the oracle was genuinely reached.**
+  ///   `CursorInsertionRepair.repair` has early exits and does its spacing work
+  ///   before ever consulting word knowledge, so the moment repair STARTS is not
+  ///   the moment the oracle is involved — and a deadline that conflates the two
+  ///   permanently disables a component that was never touched.
+  /// - **It refuses once the deadline has fired.** Cancellation cannot preempt a
+  ///   blocked thread, so an un-preempted repair would otherwise walk into the
+  ///   real oracle after the timeout gave up, making exactly the unbounded call
+  ///   the deadline exists to bound (integration review round 2).
+  ///
+  /// Each refusal is conservative in that closure's OWN vocabulary — dictionary
+  /// unavailable, learned word, recognised name — so every one of them prevents
+  /// lowering. That is what makes a late refusal safe by construction: the worst
+  /// it can do is decline to improve text, which is what the app did before this
+  /// feature existed.
+  ///
+  /// `isLearnedWord` deliberately returns `true` here while `unavailable(_:)`
+  /// returns `false` there, and the difference is not an inconsistency. That
+  /// factory sets a non-nil `unavailableReason`, which short-circuits `mayLower`
+  /// at its first line, so none of its closures is ever consulted and their
+  /// values are inert. This wrapper passes the wrapped oracle's own
+  /// `unavailableReason` through, so on a healthy oracle the closures ARE
+  /// consulted and each value has to refuse on its own.
+  ///
+  /// I described these as "copied verbatim" from that factory when handing this
+  /// to review. They are not, and the reviewer checked. The values are right;
+  /// the reason I gave for them was not.
+  ///
+  /// Built here rather than at the call site because the memberwise initialiser
+  /// is internal to this module, and because a type that can be wrapped should
+  /// own how it is wrapped. `repair` stays unaware of any of this: it remains a
+  /// pure function of the oracle it is handed.
+  package func authorized(
+    by authorize: @escaping @Sendable () -> Bool
+  ) -> EnglishWordOracle {
+    EnglishWordOracle(
+      unavailableReason: unavailableReason,
+      dictionaryVerdict: { word in
+        guard authorize() else { return .unavailable(.oracleTimedOut) }
+        return dictionaryVerdict(word)
+      },
+      isLearnedWord: { word in
+        guard authorize() else { return true }
+        return isLearnedWord(word)
+      },
+      isRecognizedName: { left, payload in
+        guard authorize() else { return true }
+        return isRecognizedName(left, payload)
+      })
+  }
+
   package static func unavailable(
     _ reason: CursorInsertionRepair.CaseSkipReason
   ) -> EnglishWordOracle {

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -233,7 +233,9 @@ public final class TelemetryService {
           smartInsertionEnabled: m?.smartInsertionEnabled,
           caretContextOutcome: m?.caretContextOutcome,
           repairRules: m?.repairRules,
-          payloadKind: m?.pastePayloadKind),
+          payloadKind: m?.pastePayloadKind,
+          languageResolutionSource: m?.languageResolutionSource,
+          languageConfidenceBucket: m?.languageConfidenceBucket),
         takeID: takeID)
     }
   }
@@ -1709,12 +1711,13 @@ public final class TelemetryService {
     PostHogSDK.shared.capture("paste.completed", properties: props)
   }
 
-  /// Cursor-aware insertion fields for `paste.completed` (#1785).
+  /// Cursor-aware insertion fields for `paste.completed` (#1785, extended #1921).
   ///
-  /// A separate value rather than four more parameters so the projection has one
+  /// A separate value rather than six more parameters so the projection has one
   /// owner and one test surface: `paste.completed` is emitted from a metrics
-  /// projection, and four loose optionals threaded through it is how one of them
-  /// eventually gets dropped without any test noticing.
+  /// projection, and six loose optionals threaded through it is how one of them
+  /// eventually gets dropped without any test noticing. #1921 added two of them,
+  /// which is exactly the growth this shape was chosen to absorb.
   ///
   /// Every field is a shape or a closed-set name. `repairRules` carries reasons
   /// (`case_skipped:protected_word`) and never the word a reason applied to,
@@ -1725,17 +1728,27 @@ public final class TelemetryService {
     public let caretContextOutcome: String?
     public let repairRules: String?
     public let payloadKind: String?
+    /// #1921. Why the language question got its answer, and how confident. A
+    /// closed category and a band, never a language code or a raw score — this
+    /// says how the gate behaved without shipping what language each user
+    /// speaks.
+    public let languageResolutionSource: String?
+    public let languageConfidenceBucket: String?
 
     public init(
       smartInsertionEnabled: Bool? = nil,
       caretContextOutcome: String? = nil,
       repairRules: String? = nil,
-      payloadKind: String? = nil
+      payloadKind: String? = nil,
+      languageResolutionSource: String? = nil,
+      languageConfidenceBucket: String? = nil
     ) {
       self.smartInsertionEnabled = smartInsertionEnabled
       self.caretContextOutcome = caretContextOutcome
       self.repairRules = repairRules
       self.payloadKind = payloadKind
+      self.languageResolutionSource = languageResolutionSource
+      self.languageConfidenceBucket = languageConfidenceBucket
     }
 
     /// Absent facts are OMITTED rather than sent as a placeholder, so a
@@ -1747,6 +1760,12 @@ public final class TelemetryService {
       if let caretContextOutcome { out["caret_context"] = caretContextOutcome }
       if let repairRules { out["repair_rules"] = repairRules }
       if let payloadKind { out["payload_kind"] = payloadKind }
+      if let languageResolutionSource {
+        out["language_resolution_source"] = languageResolutionSource
+      }
+      if let languageConfidenceBucket {
+        out["language_confidence_bucket"] = languageConfidenceBucket
+      }
       return out
     }
   }

--- a/Tests/EnviousWisprTests/Pipeline/DictationLanguageResolverTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/DictationLanguageResolverTests.swift
@@ -2,18 +2,39 @@ import Testing
 
 @testable import EnviousWisprPipeline
 
-// What language a finished dictation is in (#1785, cloud review on PR #1802).
+// What language a finished dictation is in (#1785, cloud review on PR #1802, #1921).
 //
 // The repair only recases languages whose rules it knows, so a WRONG answer here
 // lowercases a correctly capitalised German noun. Everything below exists to
 // pin one property: the resolver answers from positive evidence and abstains
 // when it has none.
+//
+// #1921 changed WHICH evidence. The old rule refused to look at the recogniser
+// until the text reached 24 alphabetic scalars, which refused 29.9% of real
+// continuations. It now asks how CONFIDENT the recogniser is instead.
 @Suite("DictationLanguageResolver")
 struct DictationLanguageResolverTests {
 
-  /// Long enough to clear the recognizer's length floor, and unambiguous.
+  /// Long enough to be unambiguous under any rule.
   static let germanText = "Ich gehe heute Abend zum See und danach in die Stadt zurück."
   static let englishText = "I went to the store this afternoon and then walked back home again."
+
+  /// The rule #1921 deleted, as a seam, so the fix can be shown to be the cause.
+  static func lengthFlooredIdentify(_ text: String) -> (language: String, confidence: Double)? {
+    let letters = text.unicodeScalars.filter(\.properties.isAlphabetic).count
+    guard letters >= 24 else { return nil }
+    return DictationLanguageResolver.identify(text)
+  }
+
+  /// A seam that answers with a fixed language and confidence, for the cases real
+  /// recogniser output cannot reproducibly produce.
+  static func fixed(_ language: String, _ confidence: Double)
+    -> (String) -> (language: String, confidence: Double)?
+  {
+    { _ in (language, confidence) }
+  }
+
+  // MARK: - Precedence, unchanged by #1921
 
   @Test("An engine that hard-codes a language is not evidence")
   func hardCodedEngineLanguageIsIgnored() {
@@ -25,7 +46,8 @@ struct DictationLanguageResolverTests {
       engineDetectsLanguage: false,
       engineReportedLanguage: "en",
       text: Self.germanText)
-    #expect(resolved == "de", "the text itself settles it, not the engine's constant")
+    #expect(resolved.language == "de", "the text itself settles it, not the engine's constant")
+    #expect(resolved.source == .dictation)
   }
 
   @Test("An engine that really detects is believed")
@@ -35,91 +57,22 @@ struct DictationLanguageResolverTests {
       engineDetectsLanguage: true,
       engineReportedLanguage: "fr",
       text: Self.englishText)
-    #expect(resolved == "fr", "a detected language outranks anything inferred from the text")
+    #expect(resolved.language == "fr", "a detected language outranks anything inferred")
+    #expect(resolved.source == .engine)
+    #expect(resolved.confidenceBucket == .none, "an engine answer carries no recogniser confidence")
   }
 
   @Test("A locked language outranks every inference")
   func lockedLanguageWins() {
+    // Obligation 5: this is the documented workaround for the bug #1921 fixes,
+    // so it must keep working after the fix removes the need for it.
     let resolved = DictationLanguageResolver.resolve(
       lockedLanguage: "de",
       engineDetectsLanguage: true,
       engineReportedLanguage: "en",
       text: Self.englishText)
-    #expect(resolved == "de", "the user told us; that is not ours to second-guess")
-  }
-
-  @Test("English on a hard-coding engine still resolves to English")
-  func englishStillWorksOnTheDefaultEngine() {
-    // The fix must not cost the majority case its feature.
-    let resolved = DictationLanguageResolver.resolve(
-      lockedLanguage: nil,
-      engineDetectsLanguage: false,
-      engineReportedLanguage: "en",
-      text: Self.englishText)
-    #expect(resolved == "en")
-  }
-
-  @Test(
-    "Text too short to identify, with nothing around it, returns nothing",
-    arguments: ["Store today.", "Yes.", "Okay then", ""])
-  func shortTextAloneAbstains(_ text: String) {
-    let resolved = DictationLanguageResolver.resolve(
-      lockedLanguage: nil,
-      engineDetectsLanguage: false,
-      engineReportedLanguage: "en",
-      text: text)
-    #expect(resolved == nil, "\(text.debugDescription)")
-  }
-
-  @Test("An English document cannot authorise recasing an unidentified insertion")
-  func englishSurroundingsDoNotAuthorise() {
-    // The document VETOES, it never authorises. Letting English surroundings
-    // decide meant a short GERMAN insertion into an English document resolved to
-    // English, and English casing then lowercased a German noun — the exact
-    // defect this path exists to prevent (cloud review, PR #1802).
-    let resolved = DictationLanguageResolver.resolve(
-      lockedLanguage: nil,
-      engineDetectsLanguage: false,
-      engineReportedLanguage: "en",
-      text: "Store is closed today",
-      surroundingText: "I went to the shop this morning and then walked back")
-    #expect(resolved == nil, "unidentified stays unidentified; casing is skipped")
-  }
-
-  @Test("A short insertion into a German document is not called English")
-  func shortTextInAGermanDocumentIsGerman() {
-    // The case that matters: the dictation is too short to identify, the
-    // document says German, so casing is skipped rather than applied wrongly.
-    let resolved = DictationLanguageResolver.resolve(
-      lockedLanguage: nil,
-      engineDetectsLanguage: false,
-      engineReportedLanguage: "en",
-      text: "Start ist heute",
-      surroundingText: "Ich gehe heute Abend zum See und danach in die Stadt")
-    #expect(resolved == "de")
-  }
-
-  @Test("An unidentifiable dictation in an unidentifiable document still abstains")
-  func shortTextWithShortSurroundingsAbstains() {
-    let resolved = DictationLanguageResolver.resolve(
-      lockedLanguage: nil,
-      engineDetectsLanguage: false,
-      engineReportedLanguage: "en",
-      text: "Yes.",
-      surroundingText: "Ok, ")
-    #expect(resolved == nil)
-  }
-
-  @Test("A detecting engine that reported nothing falls through to the text")
-  func detectingEngineWithNoAnswerFallsThrough() {
-    // WhisperKit streaming with language on auto reports no language at all.
-    // Previously that meant "unknown" and no casing; now the text is asked.
-    let resolved = DictationLanguageResolver.resolve(
-      lockedLanguage: nil,
-      engineDetectsLanguage: true,
-      engineReportedLanguage: nil,
-      text: Self.englishText)
-    #expect(resolved == "en")
+    #expect(resolved.language == "de", "the user told us; that is not ours to second-guess")
+    #expect(resolved.source == .locked)
   }
 
   @Test("An empty locked code is not a lock")
@@ -129,6 +82,337 @@ struct DictationLanguageResolverTests {
       engineDetectsLanguage: false,
       engineReportedLanguage: "en",
       text: Self.germanText)
-    #expect(resolved == "de")
+    #expect(resolved.language == "de")
+    #expect(resolved.source == .dictation)
+  }
+
+  @Test("A detecting engine that reported nothing falls through to the text")
+  func detectingEngineWithNoAnswerFallsThrough() {
+    // WhisperKit streaming with language on auto reports no language at all.
+    let resolved = DictationLanguageResolver.resolve(
+      lockedLanguage: nil,
+      engineDetectsLanguage: true,
+      engineReportedLanguage: nil,
+      text: Self.englishText)
+    #expect(resolved.language == "en")
+    #expect(resolved.source == .dictation)
+  }
+
+  @Test("English on a hard-coding engine still resolves to English")
+  func englishStillWorksOnTheDefaultEngine() {
+    let resolved = DictationLanguageResolver.resolve(
+      lockedLanguage: nil,
+      engineDetectsLanguage: false,
+      engineReportedLanguage: "en",
+      text: Self.englishText)
+    #expect(resolved.language == "en")
+  }
+
+  // MARK: - Obligation 1: the reported defect, two-way
+
+  // Founder-reported 2026-08-03: typed "I can't wait till the weather is " then
+  // dictated "warmer and summer starts."; the capital survived because the
+  // insertion is 21 alphabetic scalars, under the floor, and the document may
+  // only veto.
+  @Test(
+    "#1921 A short English continuation into English text resolves English",
+    .bug("https://github.com/saurabhav88/EnviousWispr/issues/1921", "short English continuation"))
+  func shortEnglishContinuationResolvesEnglish() {
+    let resolved = DictationLanguageResolver.resolve(
+      lockedLanguage: nil,
+      engineDetectsLanguage: false,
+      engineReportedLanguage: "en",
+      text: "Warmer and summer starts.",
+      surroundingText: "I can't wait till the weather is ")
+    #expect(resolved.language == "en", "21 alphabetic scalars is plainly English")
+    #expect(resolved.source == .dictation, "the insertion identifies itself; no document needed")
+  }
+
+  @Test("#1921 The SAME input still refuses under the deleted length floor")
+  func shortEnglishContinuationRefusedByTheOldRule() {
+    // The other half of the two-way. Without this the test above would pass on a
+    // build where the floor was never removed, as long as something else
+    // happened to answer — it would prove the framework, not the fix.
+    let resolved = DictationLanguageResolver.resolve(
+      lockedLanguage: nil,
+      engineDetectsLanguage: false,
+      engineReportedLanguage: "en",
+      text: "Warmer and summer starts.",
+      surroundingText: "I can't wait till the weather is ",
+      identify: Self.lengthFlooredIdentify)
+    #expect(resolved.language == nil, "the length floor is what refused it, and it is now gone")
+  }
+
+  // MARK: - Obligation 2: German safety
+
+  @Test(
+    "A short German insertion into an English document is never called English",
+    arguments: [
+      "Gift ist gefährlich.",
+      "Hand tut weh.",
+      "Rat war gut.",
+      "Bank ist hier.",
+      "Der Server ist down.",
+      "Anna kommt später.",
+      "Ihr Team ist gut.",
+    ])
+  func germanInsertionIntoEnglishDocumentIsNotEnglish(_ insertion: String) {
+    // This is the invariant `englishSurroundingsDoNotAuthorise` used to protect.
+    // The document is overwhelmingly English and outvotes the insertion, so the
+    // protection has to come from the insertion identifying itself as German.
+    //
+    // The set is chosen adversarially: every leading word is also an English
+    // dictionary word (so the word-level oracle would permit lowering it), plus
+    // one with English loanwords and one starting with a person's name.
+    let resolved = DictationLanguageResolver.resolve(
+      lockedLanguage: nil,
+      engineDetectsLanguage: false,
+      engineReportedLanguage: "en",
+      text: insertion,
+      surroundingText:
+        "I have been writing this email in English all morning and I wanted to add that the ")
+    #expect(resolved.language != "en", "\(insertion.debugDescription) resolved English")
+  }
+
+  // MARK: - Obligation 3: the confidence floor, two-way
+
+  @Test(
+    "One-word homographs are refused BY THE CONFIDENCE GATE, nothing else",
+    arguments: ["Bad.", "Rock.", "Note."])
+  func homographRefusalIsCausedByConfidence(_ text: String) throws {
+    // Measured: these are the only three of 33 adversarial negatives that read as
+    // English at all, at 0.191, 0.111 and 0.204.
+    //
+    // Written as ONE controlled experiment rather than two tests, because two
+    // tests could both pass for the wrong reason: a recogniser that returned nil
+    // for every homograph would satisfy a bare "is refused" assertion, and a
+    // second test injecting a fixed `("en", 0.95)` replaces the LANGUAGE as well
+    // as the confidence, so it proves nothing about what the recogniser said.
+    // Here the only thing that changes between the two arms is the number.
+    let real = try #require(
+      DictationLanguageResolver.identify(text), "\(text.debugDescription) is identifiable at all")
+    #expect(real.language == "en", "the recogniser really does read it as English")
+    #expect(
+      real.confidence < DictationLanguageResolver.minConfidence,
+      "and really is below the bar, at \(real.confidence)")
+
+    let refused = DictationLanguageResolver.resolve(
+      lockedLanguage: nil, engineDetectsLanguage: false, engineReportedLanguage: "en", text: text,
+      identify: { _ in real })
+    #expect(refused.language == nil, "the real low-confidence answer is refused")
+
+    // Same language, same input, ONLY the confidence raised.
+    let accepted = DictationLanguageResolver.resolve(
+      lockedLanguage: nil, engineDetectsLanguage: false, engineReportedLanguage: "en", text: text,
+      identify: { _ in (real.language, 0.95) })
+    #expect(accepted.language == "en", "so confidence is what caused the refusal")
+  }
+
+  // MARK: - Obligation 4: the boundary, deterministically
+
+  @Test(
+    "The threshold is exact at its boundary",
+    arguments: [
+      (0.899, false),
+      (0.900, true),
+      (0.901, true),
+    ])
+  func thresholdBoundaryIsExact(_ confidence: Double, _ shouldResolve: Bool) {
+    // Real recogniser output cannot reproducibly hit these values across OS
+    // versions — the closest real input we found sits at 0.901, one thousandth
+    // above the line, which would be a flake waiting for an Apple update. The
+    // seam is how the boundary gets tested at all.
+    let resolved = DictationLanguageResolver.resolve(
+      lockedLanguage: nil, engineDetectsLanguage: false, engineReportedLanguage: nil,
+      text: "any text at all",
+      identify: Self.fixed("en", confidence))
+    #expect((resolved.language == "en") == shouldResolve, "at \(confidence)")
+  }
+
+  // MARK: - Obligation 6: unsegmented scripts keep their language
+
+  @Test(
+    "An unsegmented-script insertion resolves its own language, not nothing",
+    arguments: [
+      ("これは日本語のテストです。", "ja"),
+      ("这是一个中文测试。", "zh"),
+      ("นี่คือการทดสอบภาษาไทย", "th"),
+    ])
+  func unsegmentedScriptsResolveTheirLanguage(_ text: String, _ expected: String) {
+    // Load-bearing. `LanguageRules.unknown` has `usesWordSpacing == true`, so a
+    // nil here would make the repair ADD spaces these languages must not have,
+    // on BOTH sides: rule 1 supplies the leading one and rule 3 the trailing
+    // one, and both read that field. An earlier revision constrained the
+    // recogniser to the default
+    // engine's language list, which nil'd exactly these and would have shipped
+    // that regression.
+    let resolved = DictationLanguageResolver.resolve(
+      lockedLanguage: nil, engineDetectsLanguage: false, engineReportedLanguage: "en", text: text)
+    #expect(resolved.language == expected, "\(text.debugDescription)")
+  }
+
+  // MARK: - Obligation 7: the threshold is the value the plan claims
+
+  @Test("minConfidence is 0.90")
+  func thresholdIsTheDocumentedValue() {
+    // A silent change to this number changes user-visible behaviour in a way no
+    // other test would name. Chosen for headroom over a hand-authored corpus, so
+    // moving it needs an independently sourced one.
+    #expect(DictationLanguageResolver.minConfidence == 0.90)
+  }
+
+  // MARK: - Obligation 9: spaced text must not become an unsegmented language
+
+  @Test(
+    "Spaced-language text is never resolved to an unsegmented language",
+    arguments: [
+      "Warmer and summer starts.", "Store is closed today.", "Der Server ist down.",
+      "Gift ist gefährlich.", "Merci beaucoup.", "Muchas gracias.", "Tot straks.",
+    ])
+  func spacedTextIsNeverUnsegmented(_ text: String) {
+    // The new failure mode introduced by returning a confident language: an
+    // unsegmented verdict suppresses spacing at every rule, so a spaced-language
+    // insertion misread as Japanese would lose its spaces.
+    let unsegmented: Set<String> = ["ja", "zh", "th", "lo", "my", "km"]
+    let resolved = DictationLanguageResolver.resolve(
+      lockedLanguage: nil, engineDetectsLanguage: false, engineReportedLanguage: "en", text: text)
+    #expect(
+      resolved.language.map { unsegmented.contains($0) } != true,
+      "\(text.debugDescription) resolved to \(resolved.language ?? "nil")")
+  }
+
+  // MARK: - Abstention, now about confidence rather than length
+
+  @Test(
+    "Text the recogniser is not confident about, with nothing around it, returns nothing",
+    arguments: ["Store today.", ""])
+  func lowConfidenceTextAloneAbstains(_ text: String) {
+    // `"Store today."` reads as English at 0.757, under the floor. `""` cannot be
+    // identified at all. `"Yes."` was deliberately REMOVED from this set: it
+    // scores 0.901, one thousandth above the threshold, so an assertion on it
+    // would be a boundary flake rather than a statement about abstention.
+    let resolved = DictationLanguageResolver.resolve(
+      lockedLanguage: nil,
+      engineDetectsLanguage: false,
+      engineReportedLanguage: "en",
+      text: text)
+    #expect(resolved.language == nil, "\(text.debugDescription)")
+  }
+
+  @Test("An English document still cannot authorise an unidentified insertion")
+  func englishSurroundingsDoNotAuthorise() {
+    // The document VETOES, it never authorises, and #1921 did not change that.
+    // The insertion here is forced to be unidentifiable through the seam, which
+    // is the only way to test the document branch now that real short English
+    // text identifies itself.
+    let resolved = DictationLanguageResolver.resolve(
+      lockedLanguage: nil,
+      engineDetectsLanguage: false,
+      engineReportedLanguage: "en",
+      text: "Store is closed today",
+      surroundingText: "I went to the shop this morning and then walked back",
+      identify: { text in
+        text == "Store is closed today" ? nil : DictationLanguageResolver.identify(text)
+      })
+    #expect(resolved.language == nil, "unidentified stays unidentified; casing is skipped")
+    #expect(resolved.source == .none)
+  }
+
+  @Test("A short insertion into a German document is not called English")
+  func shortTextInAGermanDocumentIsGerman() {
+    let resolved = DictationLanguageResolver.resolve(
+      lockedLanguage: nil,
+      engineDetectsLanguage: false,
+      engineReportedLanguage: "en",
+      text: "Start ist heute",
+      surroundingText: "Ich gehe heute Abend zum See und danach in die Stadt")
+    #expect(resolved.language == "de")
+  }
+
+  @Test("An unidentifiable dictation in an unidentifiable document still abstains")
+  func shortTextWithShortSurroundingsAbstains() {
+    // Driven through the seam rather than through short real strings. Any real
+    // input here is an OS-dependent recogniser score, so the case would silently
+    // change meaning when Apple updates the model — the same hazard that made
+    // `"Yes."` unusable at 0.901.
+    let resolved = DictationLanguageResolver.resolve(
+      lockedLanguage: nil,
+      engineDetectsLanguage: false,
+      engineReportedLanguage: "en",
+      text: "Ok",
+      surroundingText: "Hm, ",
+      identify: { _ in nil })
+    #expect(resolved.language == nil)
+    #expect(resolved.source == .none)
+    #expect(resolved.confidenceBucket == .none, "nothing was measured, so nothing to report")
+  }
+
+  @Test(
+    "A non-finite confidence never resolves a language",
+    arguments: [Double.nan, .infinity, -.infinity])
+  func nonFiniteConfidenceNeverResolves(_ confidence: Double) {
+    // Infinity satisfies `>= minConfidence` while bucketing to `none`, so without
+    // an explicit finiteness gate the resolver would return a language while
+    // reporting no confidence for it. Not reachable from the real recogniser;
+    // reachable through the seam, trivial to close, and silent if left open.
+    let resolved = DictationLanguageResolver.resolve(
+      lockedLanguage: nil, engineDetectsLanguage: false, engineReportedLanguage: nil,
+      text: "any text at all",
+      identify: Self.fixed("en", confidence))
+    #expect(resolved.language == nil, "confidence \(confidence)")
+    #expect(resolved.confidenceBucket == .none)
+  }
+
+  @Test(
+    "A non-finite DOCUMENT confidence never resolves a language either",
+    arguments: [Double.nan, .infinity, -.infinity])
+  func nonFiniteDocumentConfidenceNeverResolves(_ confidence: Double) {
+    // The dictation gate and the document gate are separate `isFinite` checks.
+    // The test above only reaches the first, so without this one the second is a
+    // guard nothing arms. Dictation identification returns nil here, which is
+    // what forces execution down to the document branch.
+    let resolved = DictationLanguageResolver.resolve(
+      lockedLanguage: nil, engineDetectsLanguage: false, engineReportedLanguage: nil,
+      text: "x",
+      surroundingText: "y",
+      identify: { probe in probe == "x" ? nil : ("de", confidence) })
+    #expect(resolved.language == nil, "document confidence \(confidence)")
+    #expect(resolved.source == .none)
+    #expect(resolved.confidenceBucket == .none)
+  }
+
+  // MARK: - The resolution contract itself
+
+  @Test(
+    "Confidence buckets partition the range",
+    arguments: [
+      (0.0, DictationLanguageResolver.Resolution.Bucket.lt50),
+      (0.499, .lt50),
+      (0.50, .f50to70),
+      (0.699, .f50to70),
+      (0.70, .f70to90),
+      (0.899, .f70to90),
+      (0.90, .ge90),
+      (1.0, .ge90),
+      (Double.nan, .none),
+      (Double.infinity, .none),
+    ])
+  func bucketsPartitionTheRange(
+    _ confidence: Double, _ expected: DictationLanguageResolver.Resolution.Bucket
+  ) {
+    #expect(DictationLanguageResolver.Resolution.Bucket(confidence) == expected)
+  }
+
+  @Test("An abstention still reports what the dictation scored")
+  func abstentionCarriesTheDictationBucket() {
+    // Otherwise the field cannot distinguish "the recogniser was unsure" from
+    // "nothing was asked", which is the whole reason the bucket exists.
+    let resolved = DictationLanguageResolver.resolve(
+      lockedLanguage: nil, engineDetectsLanguage: false, engineReportedLanguage: "en",
+      text: "anything",
+      identify: Self.fixed("en", 0.62))
+    #expect(resolved.language == nil)
+    #expect(resolved.source == .none)
+    #expect(resolved.confidenceBucket == .f50to70)
   }
 }

--- a/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
@@ -4,10 +4,10 @@ import EnviousWisprLLM
 import EnviousWisprServices
 import Foundation
 import Testing
-
-@testable import EnviousWisprPostProcessing
+import os
 
 @testable import EnviousWisprPipeline
+@testable import EnviousWisprPostProcessing
 
 // MARK: - KernelFinalizationWiringTests (epic #827, PR-4 §11.4)
 //
@@ -32,7 +32,9 @@ import Testing
   /// gating CI on those would be flaky by construction (#1803 plan §11.2).
   static let testOracle = EnglishWordOracle(
     unavailableReason: nil,
-    dictionaryVerdict: { ["review", "the", "store", "testing"].contains($0) ? .ordinary : .notOrdinary },
+    dictionaryVerdict: {
+      ["review", "the", "store", "testing"].contains($0) ? .ordinary : .notOrdinary
+    },
     isLearnedWord: { _ in false },
     isRecognizedName: { _, _ in false })
 
@@ -340,6 +342,36 @@ import Testing
     let wiring = makeWiring(context: context, deliverPaste: { _ in Self.deliveredResult })
     let outcome = await wiring.deliver("hello")
     #expect(outcome == .clipboardOnly, "no auto-paste => never .pasted")
+  }
+
+  @Test("#1921 A clipboard-only delivery cannot inherit the previous session's language fields")
+  func clipboardOnlyDeliveryClearsStaleLanguageFields() async {
+    // `outcome` is SHARED and reused across sessions, and everything describing
+    // the insertion repair is written inside the auto-paste branch. So a
+    // clipboard-only delivery skips those assignments entirely.
+    //
+    // Without a default written at the top of `deliver`, this session would
+    // report the PREVIOUS dictation's language decision as if it were its own —
+    // stale telemetry that is indistinguishable from a real reading in the
+    // field, which is the worst kind. Found by chunk review; the first version
+    // of the production comment claimed these were "written on EVERY path".
+    let outcome = KernelFinalizationOutcome()
+    outcome.languageResolutionSource = "dictation"
+    outcome.languageConfidenceBucket = "ge90"
+
+    let context = KernelSessionContext()
+    context.config = .testDefault(autoCopyToClipboard: true, autoPasteToActiveApp: false)
+    let wiring = makeWiring(
+      outcome: outcome, context: context, deliverPaste: { _ in Self.deliveredResult })
+
+    _ = await wiring.deliver("hello")
+
+    #expect(
+      outcome.languageResolutionSource == nil,
+      "a clipboard-only session never reaches the resolver, so nothing was MEASURED")
+    #expect(
+      outcome.languageConfidenceBucket == nil,
+      "nil means no attempt; \"none\" would claim an attempt that produced no answer")
   }
 
   // MARK: - Contracts migrated to the live finalization wiring
@@ -1210,7 +1242,9 @@ import Testing
     currentTime: @escaping @MainActor () -> TimeInterval = { ProcessInfo.processInfo.systemUptime },
     // Defaults to UNREADABLE, so every pre-existing test in this suite keeps
     // exactly today's behaviour and only tests that opt in see a candidate.
-    readCaretContext: @escaping @MainActor (AXUIElement, TerminalResolutionBudget, ((TerminalContextRefusal) -> Void)?) -> PasteService.CaretContext? = { _, _, _ in
+    readCaretContext: @escaping @MainActor (
+      AXUIElement, TerminalResolutionBudget, ((TerminalContextRefusal) -> Void)?
+    ) -> PasteService.CaretContext? = { _, _, _ in
       nil
     },
     // Delivery only ever runs after a transcription produced the text being
@@ -1219,7 +1253,14 @@ import Testing
     adapter: (any ASREngineAdapter)? = nil,
     // Injected, never installed into the process-global runtime: mutating that
     // would race `EnglishWordOracleTests` under concurrent suite execution.
-    englishWordOracle: @escaping @MainActor () -> EnglishWordOracle = { Self.testOracle }
+    englishWordOracle: @escaping @MainActor () -> EnglishWordOracle = { Self.testOracle },
+    // #1921 language-resolver seam. Defaults to the real resolver so every
+    // pre-existing case keeps today's behaviour; the two deadline tests inject a
+    // blocking one to drive the REAL 100 ms deadline into its timeout paths.
+    resolveLanguage: (
+      @Sendable (String?, Bool, String?, String, String) ->
+        DictationLanguageResolver.Resolution
+    )? = nil
   ) -> KernelFinalizationWiring {
     KernelFinalizationWiring(
       outcome: outcome,
@@ -1239,6 +1280,12 @@ import Testing
       deliverPaste: deliverPaste,
       readCaretContext: readCaretContext,
       englishWordOracle: englishWordOracle,
+      resolveLanguage: resolveLanguage
+        ?? {
+          DictationLanguageResolver.resolve(
+            lockedLanguage: $0, engineDetectsLanguage: $1, engineReportedLanguage: $2,
+            text: $3, surroundingText: $4)
+        },
       pasteCompletionRegistry: registry,
       currentTime: currentTime,
       telemetryState: telemetryState)
@@ -1325,6 +1372,307 @@ import Testing
     #expect(metrics.polishFellBackToRaw == false)
     #expect(metrics.polishFallbackReason == nil)
   }
+
+  // MARK: - #1921 Chunk 2: the language/repair deadline handoff
+
+  /// A resolution to hand the gate, distinct enough that its survival is visible.
+  static let gateResolution = DictationLanguageResolver.Resolution(
+    language: "en", source: .dictation, confidenceBucket: .ge90)
+
+  @Test("#1921 The deadline gate's four phases, including the completed distinction")
+  func deadlineGateFourPhaseMatrix() {
+    // Obligation 10's third race order lives inside `withOrderedDeadline`, in the
+    // gap between `await operation()` returning and `claim()` (`TaskTimeout.swift:123-125`).
+    // No injected seam reaches it, and timing against the 100 ms boundary would be
+    // a clock race. So that ordering is proven HERE, on the state machine itself,
+    // and the production call site is verified structurally in the receipt.
+    //
+    // The `repair` versus `completed` distinction is the entire reason this gate
+    // has four states rather than three: a three-state gate permanently disables a
+    // word oracle that had already finished successfully.
+
+    // Timeout while still resolving: nothing to report, nothing to disable.
+    let resolving = LanguageRepairDeadlineGate()
+    let fromResolving = resolving.timeOut()
+    #expect(fromResolving.resolution == nil)
+    #expect(fromResolving.shouldDisableOracle == false, "the oracle never ran")
+
+    // Timeout while repair is running AND the oracle was genuinely consulted:
+    // keep the resolution, disable.
+    let running = LanguageRepairDeadlineGate()
+    #expect(running.beginRepair(Self.gateResolution))
+    #expect(running.authorizeOracleUse(), "an authorised repair may consult the oracle")
+    let fromOracle = running.timeOut()
+    #expect(fromOracle.resolution?.language == "en")
+    #expect(fromOracle.resolution?.confidenceBucket == .ge90)
+    #expect(fromOracle.shouldDisableOracle, "a genuinely stuck oracle must be disabled")
+
+    // Timeout while repair is running but the oracle was NEVER touched.
+    //
+    // Integration review found this: `beginRepair` runs before
+    // `CursorInsertionRepair.repair`, and repair has early exits and does its
+    // spacing work before it ever consults the oracle. Arming on "repair began"
+    // would permanently disable a healthy oracle that was never involved — the
+    // exact harm this gate exists to prevent, moved one step later.
+    //
+    // Not reachable through the real wiring: the window is inside repair, and
+    // forcing it would need either a production seam in `CursorInsertionRepair`
+    // or a clock race. Proven here, on the state machine, like the completed
+    // ordering above.
+    let authorizedButUntouched = LanguageRepairDeadlineGate()
+    #expect(authorizedButUntouched.beginRepair(Self.gateResolution))
+    let fromUntouched = authorizedButUntouched.timeOut()
+    #expect(
+      fromUntouched.resolution?.language == "en",
+      "the resolution still survives; only the disable decision differs")
+    #expect(
+      fromUntouched.shouldDisableOracle == false,
+      "an oracle that was never consulted must not be punished for repair stalling")
+
+    // Timeout after repair already returned: keep the resolution, do NOT disable.
+    let completed = LanguageRepairDeadlineGate()
+    #expect(completed.beginRepair(Self.gateResolution))
+    #expect(completed.authorizeOracleUse())
+    completed.completeRepair()
+    let fromCompleted = completed.timeOut()
+    #expect(fromCompleted.resolution?.language == "en", "a finished run keeps its answer")
+    #expect(
+      fromCompleted.shouldDisableOracle == false,
+      "a healthy oracle that already finished must NOT be disabled")
+
+    // A second timeout is inert.
+    let repeated = completed.timeOut()
+    #expect(repeated.resolution == nil)
+    #expect(repeated.shouldDisableOracle == false)
+
+    // Repair can never start once the timeout owns the phase.
+    let lateStart = LanguageRepairDeadlineGate()
+    _ = lateStart.timeOut()
+    #expect(
+      lateStart.beginRepair(Self.gateResolution) == false,
+      "a resolver the deadline could not preempt must not enter repair")
+
+    // And an un-preempted repair ALREADY INSIDE the deadline must not reach the
+    // oracle once the timeout has claimed the phase.
+    //
+    // Integration review round 2 found this. Cancellation "cannot preempt a
+    // blocked thread" (`TaskTimeout.swift:129`), so a repair authorised before
+    // the deadline keeps running after it. Without this refusal it walks into
+    // the real word oracle after the timeout gave up, making exactly the
+    // unbounded blocking call the deadline exists to bound.
+    let lateOracle = LanguageRepairDeadlineGate()
+    #expect(lateOracle.beginRepair(Self.gateResolution))
+    let lateTimeout = lateOracle.timeOut()
+    #expect(
+      lateTimeout.shouldDisableOracle == false,
+      "it had not been consulted at the moment the deadline fired")
+    #expect(
+      lateOracle.authorizeOracleUse() == false,
+      "and it must be refused entry afterwards, not merely recorded")
+
+    // `completeRepair` from a phase that never began is inert, not a promotion.
+    let neverBegan = LanguageRepairDeadlineGate()
+    neverBegan.completeRepair()
+    let afterInertComplete = neverBegan.timeOut()
+    #expect(afterInertComplete.resolution == nil)
+    #expect(afterInertComplete.shouldDisableOracle == false)
+  }
+
+  @Test("#1921 The language resolution reaches the real transcript metrics")
+  func languageResolutionReachesTranscriptMetrics() async throws {
+    // The first hop of the telemetry chain, exercised through the REAL
+    // `updateTranscriptMetrics` rather than by constructing an `ExecutionMetrics`
+    // in the test — which would prove only that I can copy two strings.
+    //
+    // `document` / `f70to90` are deliberately distinctive: neither is a default,
+    // and neither is what any other path would produce, so a hop that silently
+    // dropped the value could not pass by coincidence.
+    let outcome = KernelFinalizationOutcome()
+    let context = KernelSessionContext()
+    context.config = .testDefault(autoPasteToActiveApp: true, smartInsertion: true)
+    context.targetElement = Self.stubCaretElement()
+
+    let wiring = makeWiring(
+      outcome: outcome,
+      context: context,
+      readCaretContext: { _, _, _ in Self.midSentenceCaret },
+      resolveLanguage: { _, _, _, _, _ in
+        DictationLanguageResolver.Resolution(
+          language: "de", source: .document, confidenceBucket: .f70to90)
+      })
+
+    let processed = try await wiring.processText("Review this before the meeting") {}
+    try await wiring.store(processed, UUID())
+    let delivery = await wiring.deliver(processed)
+
+    #expect(delivery == .pasted, "the normal non-timeout route must still deliver")
+    #expect(outcome.languageResolutionSource == "document")
+    #expect(outcome.languageConfidenceBucket == "f70to90")
+
+    let metrics = try #require(outcome.transcript?.metrics, "delivery must produce metrics")
+    #expect(
+      metrics.languageResolutionSource == "document",
+      "the value must survive the outcome -> ExecutionMetrics hop unchanged")
+    #expect(metrics.languageConfidenceBucket == "f70to90")
+  }
+
+  @Test("#1921 A stalled LANGUAGE stage times out without disabling the word oracle")
+  func languageStageTimeoutLeavesOracleEnabled() async throws {
+    // Race order one, through the REAL deadline. Before #1921 language
+    // resolution ran outside it entirely, so this stall had no bound at all.
+    //
+    // A language stall must not latch an unrelated, healthy component off for
+    // the rest of the process. A naive "did the oracle begin" flag gets this
+    // right only by luck, because cancellation here cannot preempt the blocked
+    // call.
+    try await withEnglishWordOracleExclusion {
+      EnglishWordOracleRuntime.resetForTesting()
+      EnglishWordOracleRuntime.installForTesting(Self.testOracle)
+      #expect(
+        EnglishWordOracleRuntime.snapshot().isAvailable,
+        "precondition: the oracle starts enabled, or this test cannot fail")
+
+      let entered = DispatchSemaphore(value: 0)
+      let release = DispatchSemaphore(value: 0)
+      let exited = DispatchSemaphore(value: 0)
+      // Records WHY the blocking wait ended. Without it, `exited` fires whether
+      // the test released the blocker or the five-second fail-safe expired, so
+      // the fallback could silently become the normal path.
+      let releaseOutcome = OSAllocatedUnfairLock<DispatchTimeoutResult?>(initialState: nil)
+      let outcome = KernelFinalizationOutcome()
+      let context = KernelSessionContext()
+      context.config = .testDefault(autoPasteToActiveApp: true, smartInsertion: true)
+      context.targetElement = Self.stubCaretElement()
+      let captured = CapturedRequest()
+
+      let wiring = makeWiring(
+        outcome: outcome,
+        context: context,
+        deliverPaste: { request in
+          captured.request = request
+          return Self.deliveredResult
+        },
+        readCaretContext: { _, _, _ in Self.midSentenceCaret },
+        resolveLanguage: { _, _, _, _, _ in
+          entered.signal()
+          // deadline-fallback: `release` is the signal; this bound only stops a defect hanging the suite
+          let waited = release.wait(timeout: .now() + 5)
+          releaseOutcome.withLock { $0 = waited }
+          exited.signal()
+          return DictationLanguageResolver.Resolution(
+            language: "en", source: .dictation, confidenceBucket: .ge90)
+        })
+
+      let delivery = Task { await wiring.deliver("Warmer and summer starts.") }
+
+      // Prove the ordering this test is NAMED for. Without it the case passes
+      // even if the resolver is never reached at all.
+      #expect(await awaitSignal(entered), "the resolver must have been entered before the deadline")
+
+      _ = await delivery.value
+
+      // Cleanup BEFORE any throwing assertion, so a failure below cannot strand
+      // a blocked thread for the rest of the suite.
+      release.signal()
+      #expect(await awaitSignal(exited), "the blocked resolver must have exited")
+      #expect(
+        releaseOutcome.withLock { $0 } == .success,
+        "it must have exited because we released it, not because the fail-safe expired")
+
+      let request = try #require(captured.request, "the paste route must have been reached")
+      #expect(
+        request.repairedText == nil,
+        "a timed-out repair must offer no candidate, only today's payload")
+      #expect(
+        request.legacyText == "Warmer and summer starts. ",
+        "and that payload must be exactly today's, trailing space included")
+      #expect(
+        outcome.languageResolutionSource == "none",
+        "nothing was resolved in time, and the field must say so rather than guess")
+      #expect(outcome.languageConfidenceBucket == "none")
+      #expect(
+        EnglishWordOracleRuntime.snapshot().isAvailable,
+        "the oracle never ran, so the language stall must NOT have latched it off")
+    }
+  }
+
+  @Test("#1921 A stalled ORACLE still latches, and the language answer survives")
+  func oracleStageTimeoutLatchesAndKeepsResolution() async throws {
+    // Race order two. Repair genuinely entered the oracle, so today's latching
+    // must be preserved exactly — and the resolution the language stage already
+    // produced must survive into telemetry rather than being reported as `none`,
+    // which is what a gate without a payload would do.
+    try await withEnglishWordOracleExclusion {
+      EnglishWordOracleRuntime.resetForTesting()
+      EnglishWordOracleRuntime.installForTesting(Self.testOracle)
+      #expect(EnglishWordOracleRuntime.snapshot().isAvailable, "precondition")
+
+      let entered = DispatchSemaphore(value: 0)
+      let release = DispatchSemaphore(value: 0)
+      let exited = DispatchSemaphore(value: 0)
+      let releaseOutcome = OSAllocatedUnfairLock<DispatchTimeoutResult?>(initialState: nil)
+      let blockingOracle = EnglishWordOracle(
+        unavailableReason: nil,
+        dictionaryVerdict: { _ in
+          entered.signal()
+          // deadline-fallback: `release` is the signal; this bound only stops a defect hanging the suite
+          let waited = release.wait(timeout: .now() + 5)
+          releaseOutcome.withLock { $0 = waited }
+          exited.signal()
+          return .ordinary
+        },
+        isLearnedWord: { _ in false },
+        isRecognizedName: { _, _ in false })
+
+      let outcome = KernelFinalizationOutcome()
+      let context = KernelSessionContext()
+      context.config = .testDefault(autoPasteToActiveApp: true, smartInsertion: true)
+      context.targetElement = Self.stubCaretElement()
+      let captured = CapturedRequest()
+
+      let wiring = makeWiring(
+        outcome: outcome,
+        context: context,
+        deliverPaste: { request in
+          captured.request = request
+          return Self.deliveredResult
+        },
+        readCaretContext: { _, _, _ in Self.midSentenceCaret },
+        englishWordOracle: { blockingOracle },
+        resolveLanguage: { _, _, _, _, _ in
+          DictationLanguageResolver.Resolution(
+            language: "en", source: .dictation, confidenceBucket: .ge90)
+        })
+
+      let delivery = Task { await wiring.deliver("Review this before the meeting") }
+
+      #expect(
+        await awaitSignal(entered),
+        "repair must have genuinely reached the oracle, not merely timed out near it")
+
+      _ = await delivery.value
+
+      release.signal()
+      #expect(await awaitSignal(exited), "the blocked oracle must have exited")
+      #expect(
+        releaseOutcome.withLock { $0 } == .success,
+        "it must have exited because we released it, not because the fail-safe expired")
+
+      let request = try #require(captured.request, "the paste route must have been reached")
+      #expect(request.repairedText == nil, "a timed-out repair offers no candidate")
+      #expect(
+        request.legacyText == "Review this before the meeting ",
+        "and the delivered payload must be exactly today's")
+      #expect(
+        EnglishWordOracleRuntime.snapshot().unavailableReason == .oracleTimedOut,
+        "a genuinely stuck oracle must still be latched off, exactly as before #1921")
+      #expect(
+        outcome.languageResolutionSource == "dictation",
+        "the language stage had already answered; the timeout must not erase it")
+      #expect(outcome.languageConfidenceBucket == "ge90")
+    }
+  }
+
 }
 
 /// Hand-advanced logical clock for the tick-rate test. Local `@MainActor` copy:
@@ -1337,6 +1685,34 @@ private final class ManualClock {
 }
 
 private enum WiringTestError: Error { case storage }
+
+/// Awaits a `DispatchSemaphore` WITHOUT occupying the caller's actor.
+///
+/// The blocking side of these tests is a synchronous production closure, so a
+/// semaphore is the only thing it can signal. But `DispatchSemaphore.wait` is
+/// unavailable from an async context, and waiting on the `@MainActor` test body
+/// would block the very actor `deliver` needs to make progress — a guaranteed
+/// deadlock rather than a slow test.
+///
+/// So the wait happens on a global queue and the result comes back through a
+/// continuation. The SIGNAL is the semaphore; the bound is a fail-safe so a
+/// defect fails one case instead of hanging the suite.
+private func awaitSignal(_ semaphore: DispatchSemaphore) async -> Bool {
+  await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+    DispatchQueue.global().async {
+      // deadline-fallback: the semaphore is the signal; this bound is the fail-safe
+      continuation.resume(returning: semaphore.wait(timeout: .now() + 5) == .success)
+    }
+  }
+}
+
+/// Captures the real delivery request so a timeout test can assert on the
+/// payload that ACTUALLY reached the paste route, rather than on the outcome
+/// fields alone. `@MainActor` because `deliverPaste` is.
+@MainActor
+private final class CapturedRequest {
+  var request: PasteDeliveryRequest?
+}
 
 /// Deterministic polisher for the #1022 short-dictation test: enables the
 /// polish step (provider set, connector mocked) so the persisted nil can only

--- a/Tests/EnviousWisprTests/Pipeline/PasteExecutionMetricsTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PasteExecutionMetricsTests.swift
@@ -22,13 +22,19 @@ struct PasteExecutionMetricsTests {
       smartInsertionEnabled: true,
       caretContextOutcome: "read",
       repairRules: "leading_space,lowercased_first",
-      pastePayloadKind: "repaired")
+      pastePayloadKind: "repaired",
+      languageResolutionSource: "document",
+      languageConfidenceBucket: "f70to90")
     let decoded = try JSONDecoder().decode(
       ExecutionMetrics.self, from: JSONEncoder().encode(metrics))
     #expect(decoded.smartInsertionEnabled == true)
     #expect(decoded.caretContextOutcome == "read")
     #expect(decoded.repairRules == "leading_space,lowercased_first")
     #expect(decoded.pastePayloadKind == "repaired")
+    // #1921. Distinctive values, not defaults, so a hop that silently dropped
+    // them could not pass by coincidence.
+    #expect(decoded.languageResolutionSource == "document")
+    #expect(decoded.languageConfidenceBucket == "f70to90")
   }
 
   @Test("A transcript stored before this feature still decodes")
@@ -45,6 +51,12 @@ struct PasteExecutionMetricsTests {
     #expect(decoded.caretContextOutcome == nil)
     #expect(decoded.repairRules == nil)
     #expect(decoded.pastePayloadKind == nil)
+    // #1921. The literal JSON above is deliberately UNCHANGED — it is the real
+    // pre-field shape, not something today's encoder produced. Generating it
+    // with the current encoder would only prove the new code agrees with
+    // itself, which is exactly the failure this case exists to prevent.
+    #expect(decoded.languageResolutionSource == nil)
+    #expect(decoded.languageConfidenceBucket == nil)
   }
 
   @Test("Absent facts are omitted, never sent as a placeholder")
@@ -58,6 +70,24 @@ struct PasteExecutionMetricsTests {
     #expect(partial.properties["caret_context"] as? String == "setting_off")
     #expect(partial.properties["repair_rules"] == nil)
     #expect(partial.properties["payload_kind"] == nil)
+    // #1921. Nil must stay ABSENT rather than becoming "none". "none" is a real
+    // upstream category meaning "we measured and found nothing"; absent means
+    // the fact was never recorded, which is what an old stored transcript has.
+    // Collapsing the two would make a pre-#1921 history entry indistinguishable
+    // from a genuine language-stage timeout.
+    #expect(empty.properties["language_resolution_source"] == nil)
+    #expect(empty.properties["language_confidence_bucket"] == nil)
+    #expect(partial.properties["language_resolution_source"] == nil)
+    #expect(partial.properties["language_confidence_bucket"] == nil)
+
+    // #1921. The other half, which the omission assertions alone do NOT prove: a
+    // REAL "none" must actually be emitted. Without this the suite shows only
+    // that nil disappears, and the distinction between "we measured and found
+    // nothing" and "nobody ever looked" would be asserted in prose and untested.
+    let measuredNothing = TelemetryService.PasteInsertionTelemetry(
+      languageResolutionSource: "none", languageConfidenceBucket: "none")
+    #expect(measuredNothing.properties["language_resolution_source"] as? String == "none")
+    #expect(measuredNothing.properties["language_confidence_bucket"] as? String == "none")
   }
 
   @Test("Every rule name is a closed reason, never the word it applied to")

--- a/Tests/EnviousWisprTests/PostProcessing/CursorInsertionRepairLanguagePairingTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CursorInsertionRepairLanguagePairingTests.swift
@@ -1,0 +1,207 @@
+import Testing
+
+@testable import EnviousWisprPostProcessing
+
+// #1921 obligation 8: the paired replay.
+//
+// Every other measurement for #1921 stops at the resolver — it asks whether a
+// usable language came back, never what the repair then DID with it. A defect
+// created after the language reaches the consumer is invisible to all of them.
+//
+// #1921 changes the resolver so it answers where it used to abstain. The safety
+// argument for that is a closed-set claim about `LanguageRules`: it has exactly
+// two policy fields; `knowsCasing` differs from `.unknown` only for English, and
+// `usesWordSpacing` differs only for the six effective unsegmented values
+// (`yue` normalises to `zh`). This suite is that claim executed against the real
+// `CursorInsertionRepair.repair` rather than asserted in a document.
+//
+// The oracle is injected and fixed, so these cases never touch the system
+// dictionary and stay deterministic on every machine and CI image — the same
+// discipline `CursorInsertionRepairTests` uses.
+@Suite("CursorInsertionRepair language pairing")
+struct CursorInsertionRepairLanguagePairingTests {
+
+  /// Permits lowering any word it knows, so the casing rule is free to fire.
+  /// A refusing oracle would make every case identical and the suite vacuous.
+  static let oracle = EnglishWordOracle(
+    unavailableReason: nil,
+    dictionaryVerdict: { _ in .ordinary },
+    isLearnedWord: { _ in false },
+    isRecognizedName: { _, _ in false })
+
+  static let protectedWords: Set<String> = []
+
+  static func caret(left: String, right: String) -> CursorInsertionRepair.CaretText {
+    CursorInsertionRepair.CaretText(
+      left: left, right: right, leftReachesDocumentStart: true, isScreenDerived: false)
+  }
+
+  static func repaired(_ text: String, _ language: String?, left: String, right: String)
+    -> CursorInsertionRepair.PreparedPayloads
+  {
+    CursorInsertionRepair.repair(
+      text: text,
+      context: caret(left: left, right: right),
+      protectedWords: protectedWords,
+      language: language,
+      oracle: oracle)
+  }
+
+  // MARK: - Segmented non-English: resolving must change NOTHING
+
+  @Test(
+    "A segmented non-English language is byte-identical to no language at all",
+    arguments: [
+      ("Gift ist gefährlich.", "de", "Ich sagte dass das "),
+      ("Merci beaucoup vraiment.", "fr", "Je voulais dire que "),
+      ("Muchas gracias de verdad.", "es", "Queria decir que "),
+      ("Tot straks dan maar.", "nl", "Ik wilde zeggen dat "),
+      ("Dziekuje bardzo za to.", "pl", "Chcialem powiedziec ze "),
+      ("Grazie mille davvero.", "it", "Volevo dire che "),
+    ])
+  func segmentedNonEnglishIsIdenticalToNil(_ payload: String, _ language: String, _ left: String) {
+    // This is the load-bearing half of the closed-set proof. Before #1921 these
+    // insertions resolved to nil; after it they resolve to their own language.
+    // If ANY field differs, returning a confident language is not the no-op the
+    // plan claims and the change is unsafe.
+    let withNil = Self.repaired(payload, nil, left: left, right: "")
+    let withLanguage = Self.repaired(payload, language, left: left, right: "")
+
+    #expect(withNil.legacyText == withLanguage.legacyText, "\(language): legacy payload")
+    #expect(withNil.repairedText == withLanguage.repairedText, "\(language): candidate")
+    #expect(
+      withNil.candidateRules.map(\.telemetryName)
+        == withLanguage.candidateRules.map(\.telemetryName),
+      "\(language): applied rules")
+  }
+
+  // MARK: - English: exactly one axis may change
+
+  @Test(
+    "English differs from nil ONLY by the casing rule",
+    arguments: [
+      ("Warmer and summer starts.", "I can't wait till the weather is "),
+      ("Store is closed today.", "I went past and the "),
+      ("Coming back tomorrow.", "He said he was "),
+    ])
+  func englishDiffersOnlyByCasing(_ payload: String, _ left: String) {
+    let withNil = Self.repaired(payload, nil, left: left, right: "")
+    let withEnglish = Self.repaired(payload, "en", left: left, right: "")
+
+    // The legacy payload is what ships when no candidate is offered, and this
+    // change must never touch it.
+    #expect(withNil.legacyText == withEnglish.legacyText, "legacy payload must not move")
+
+    // EXACT payloads, not "different" plus a `contains`. Integration review was
+    // right that the loose form passes alongside unrelated text damage: any
+    // change anywhere in the string satisfies `!=`, and `contains` of a single
+    // lowercase letter is satisfied by most of the sentence.
+    //
+    // Derived from the rules rather than copied from a run: `left` already ends
+    // in a space so rule 1 adds none, rule 2 lowercases the first character, and
+    // rule 3 appends the trailing space.
+    let expectedLowered = payload.prefix(1).lowercased() + payload.dropFirst() + " "
+    #expect(
+      withEnglish.repairedText == expectedLowered,
+      "English must produce exactly the lowercased payload plus today's trailing space")
+    #expect(
+      withNil.repairedText == payload + " ",
+      "and the nil arm must produce exactly the payload unchanged plus that space")
+
+    // Every rule other than the casing decision must be identical. This is the
+    // assertion that would catch a spacing or duplicate-word change sneaking in
+    // alongside the intended one.
+    let casingRules: Set<String> = ["lowercased_first", "case_skipped:language_not_supported"]
+    let nilOther = withNil.candidateRules.map(\.telemetryName).filter { !casingRules.contains($0) }
+    let enOther = withEnglish.candidateRules.map(\.telemetryName).filter {
+      !casingRules.contains($0)
+    }
+    #expect(nilOther == enOther, "only the casing rule may differ, got \(nilOther) vs \(enOther)")
+  }
+
+  // MARK: - Unsegmented: the one intended non-casing change, frozen
+
+  @Test(
+    "Every effective unsegmented language suppresses spacing where nil would add it",
+    arguments: [
+      ("これは日本語のテストです。", "ja", "昨日の会議について"),
+      ("这是一个中文测试。", "zh", "关于昨天的会议"),
+      ("นี่คือการทดสอบภาษาไทย", "th", "เกี่ยวกับการประชุมเมื่อวาน"),
+      ("ນີ້ແມ່ນການທົດສອບພາສາລາວ", "lo", "ກ່ຽວກັບກອງປະຊຸມມື້ວານນີ້"),
+      ("ဤသည်မြန်မာဘာသာစကားစမ်းသပ်မှုဖြစ်သည်", "my", "မနေ့ကအစည်းအဝေးအကြောင်း"),
+      ("នេះជាការសាកល្បងភាសាខ្មែរ", "km", "អំពីកិច្ចប្រជុំកាលពីម្សិលមិញ"),
+    ])
+  func unsegmentedSuppressesSpacing(_ payload: String, _ language: String, _ left: String) {
+    // All SIX effective unsegmented values, not a sample of three. `yue` is
+    // absent deliberately: `LanguageNormalizer.baseCode` maps it to `zh` before
+    // policy is evaluated, so it can never reach `LanguageRules` as itself.
+    //
+    // This is the reason the recogniser is NOT constrained to the default
+    // engine's language list. Constrained, these all came back nil, which is
+    // `LanguageRules.unknown`, whose `usesWordSpacing` is true — so the repair
+    // would have ADDED spaces they must not have, on BOTH sides, as the byte
+    // assertions below show. Frozen here so a future constraint cannot
+    // reintroduce that silently.
+    let withNil = Self.repaired(payload, nil, left: left, right: "")
+    let withLanguage = Self.repaired(payload, language, left: left, right: "")
+
+    let nilRules = withNil.candidateRules.map(\.telemetryName)
+    let languageRules = withLanguage.candidateRules.map(\.telemetryName)
+
+    #expect(
+      languageRules.contains("trailing_space_skipped:unsegmented_script"),
+      "\(language) must suppress the trailing space, got \(languageRules)")
+    #expect(
+      nilRules.contains("trailing_space_skipped:unsegmented_script") == false,
+      "and nil must NOT, or this case proves nothing (\(language))")
+
+    // Rule names alone would pass alongside unrelated damage to the text, so
+    // assert the BYTES.
+    //
+    // The delta is TWO spaces, not one, and I had this wrong until the assertion
+    // failed. Without a resolved language, `usesWordSpacing` is true, so rule 1
+    // adds a LEADING space at `:392` as well as rule 3 adding the trailing one.
+    // Unsegmented text therefore arrives wrapped in spaces on both sides. The
+    // plan's prose described only the trailing space; the five-site table was
+    // right and the sentence under it was not.
+    //
+    // This is why the expectation is derived from the rules rather than copied
+    // from a run: a copied value would have frozen the wrong description as if
+    // it were intended.
+    #expect(
+      withLanguage.repairedText == payload,
+      "\(language) must deliver the payload byte-identical, with no added spacing")
+    #expect(
+      withNil.repairedText == " " + payload + " ",
+      "and the nil arm wraps it in spaces on BOTH sides (\(language))")
+  }
+
+  // MARK: - Code-switching, which is the case the German set exists for
+
+  @Test("A German insertion in an English document is untouched when resolved German")
+  func germanInEnglishDocumentIsUntouched() {
+    // The document is overwhelmingly English. If the resolver had let the
+    // document authorise English — the design withdrawn in rev 2 after measuring
+    // 17 wrong lowerings of 24 — this is the payload that would have been
+    // damaged. Resolved German, the repair must leave the capital alone.
+    let payload = "Gift ist gefährlich."
+    let left = "I have been writing this email in English all morning and I wanted to add that the "
+
+    let asGerman = Self.repaired(payload, "de", left: left, right: "")
+    let asEnglish = Self.repaired(payload, "en", left: left, right: "")
+
+    // EXACT bytes, not `contains`. Integration review made this point about the
+    // English case and it applies identically here: `contains("Gift")` is
+    // satisfied by a payload that kept its capital and was damaged elsewhere.
+    //
+    // Derived from the rules: `left` already ends in a space so rule 1 adds
+    // none, German `knowsCasing` is false so rule 2 cannot fire, and rule 3
+    // appends the trailing space because German IS word-spaced.
+    #expect(
+      asGerman.repairedText == "Gift ist gefährlich. ",
+      "the German noun must keep its capital, and nothing else may move")
+    #expect(
+      asEnglish.repairedText == "gift ist gefährlich. ",
+      "and English rules WOULD have lowered it, which is what makes this test meaningful")
+  }
+}

--- a/Tests/EnviousWisprTests/PostProcessing/EnglishWordOracleTestExclusion.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/EnglishWordOracleTestExclusion.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+@testable import EnviousWisprPostProcessing
+
+/// Cross-SUITE exclusion for the process-wide `EnglishWordOracleRuntime`.
+///
+/// Modelled on `AppLoggerTestExclusion` (#1361), which exists for the identical
+/// problem: `.serialized` orders tests within ONE suite and nothing more, and
+/// Swift Testing runs suites concurrently, so two suites touching the same
+/// process global interleave at every `await`.
+///
+/// Until #1921 only `EnglishWordOracleTests` mutated this runtime, and its
+/// `.serialized` was sufficient BY ACCIDENT — it was the only participant.
+/// `KernelFinalizationWiringTests` deliberately injected a fake oracle instead,
+/// with a comment saying mutating the global "would race `EnglishWordOracleTests`".
+/// #1921's two deadline tests must assert what the timeout does to the real
+/// runtime, so they cannot avoid it, and the accident ends.
+///
+/// The latch is one-way and process-wide: `disableAfterTimeout()` permanently
+/// marks the runtime `.oracleTimedOut`. A suite observing "still enabled" while
+/// another suite's timeout test fires is not a flaky assertion, it is a wrong
+/// one — so this is a correctness fix, not tidiness.
+///
+/// Fair FIFO, so a suite cannot be starved by a busy neighbour.
+actor EnglishWordOracleTestExclusion {
+  static let shared = EnglishWordOracleTestExclusion()
+
+  private var held = false
+  private var waiters: [CheckedContinuation<Void, Never>] = []
+
+  private init() {}
+
+  func acquire() async {
+    if !held {
+      held = true
+      return
+    }
+    await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+      waiters.append(continuation)
+    }
+  }
+
+  func release() {
+    if waiters.isEmpty {
+      held = false
+    } else {
+      // Stays `held`; ownership passes straight to the next waiter.
+      waiters.removeFirst().resume()
+    }
+  }
+}
+
+/// Runs `body` with exclusive access to `EnglishWordOracleRuntime`, then resets
+/// it so the next holder starts from a known state.
+///
+/// Free function, NOT a method on the actor: as a method the caller's closure
+/// would be sent across the actor boundary, and a `@MainActor` test body is not
+/// `Sendable`. Keeping only `acquire`/`release` on the actor lets `body` run in
+/// whatever isolation the caller already has. `isolation: isolated (any Actor)?
+/// = #isolation` makes this INHERIT that isolation rather than hopping off it;
+/// without it a `@MainActor` suite cannot pass its body at all under Swift 6.
+///
+/// **Snapshots the prior runtime and RESTORES it before releasing**, on the
+/// throwing path too.
+///
+/// An earlier draft of this helper simply reset the runtime on the way out, on
+/// the reasoning that a one-way latch has no state worth preserving. That was
+/// wrong in one direction I did not check: a holder that arrives after a suite
+/// has legitimately prewarmed the runtime would have that prewarm destroyed, and
+/// every later reader would see `oracleWarming` instead of the real oracle.
+/// Borrowing shared state means giving it back as you found it.
+///
+/// Order matters and is the #1361 lesson: reset FIRST, then reinstall, because a
+/// teardown that resets after restoring undoes its own restore. A genuinely
+/// warming prior state needs no reinstall — the reset already reproduces it.
+///
+/// A leaked hold would deadlock every other participating suite for the rest of
+/// the run, so restoration and release happen on both exits.
+func withEnglishWordOracleExclusion<T>(
+  isolation: isolated (any Actor)? = #isolation,
+  _ body: () async throws -> T
+) async rethrows -> T {
+  await EnglishWordOracleTestExclusion.shared.acquire()
+
+  let prior = EnglishWordOracleRuntime.snapshot()
+
+  @Sendable func restoreAndRelease() async {
+    EnglishWordOracleRuntime.resetForTesting()
+    // `oracleWarming` IS what a reset produces, so reinstalling it would be a
+    // no-op at best. Any other prior state was a real oracle this holder must
+    // hand back.
+    if prior.unavailableReason != .oracleWarming {
+      EnglishWordOracleRuntime.installForTesting(prior)
+    }
+    await EnglishWordOracleTestExclusion.shared.release()
+  }
+
+  do {
+    let value = try await body()
+    await restoreAndRelease()
+    return value
+  } catch {
+    await restoreAndRelease()
+    throw error
+  }
+}

--- a/Tests/EnviousWisprTests/PostProcessing/EnglishWordOracleTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/EnglishWordOracleTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import os
 
 @testable import EnviousWisprPostProcessing
 
@@ -36,7 +37,6 @@ struct EnglishWordOracleTests {
       isRecognizedName: { _, _ in isName })
   }
 
-
   /// A `@Sendable`-safe flag, because the oracle's closures are `@Sendable` and
   /// a captured `var` cannot be mutated from one.
   final class ConsultationSpy: @unchecked Sendable {
@@ -53,7 +53,6 @@ struct EnglishWordOracleTests {
       lock.unlock()
     }
   }
-
 
   /// Records what the word-class closure was handed. `@Sendable`-safe for the
   /// same reason `ConsultationSpy` is.
@@ -111,7 +110,8 @@ struct EnglishWordOracleTests {
       isLearnedWord: { _ in false },
       isRecognizedName: { _, _ in true })
 
-    #expect(oracle.mayLower(word: "Mark", left: "speak with ", payload: "Mark today.") == .recognizedName)
+    #expect(
+      oracle.mayLower(word: "Mark", left: "speak with ", payload: "Mark today.") == .recognizedName)
     #expect(probe.wasConsulted == false, "the dictionary must not be asked about a recognised name")
   }
 
@@ -133,7 +133,8 @@ struct EnglishWordOracleTests {
     // and the recogniser does not call them names.
     for noun in ["today", "museum", "coffee", "everything"] {
       let decision = Self.oracle(ordinary: [noun])
-        .mayLower(word: noun.capitalized, left: "we went to ", payload: "\(noun.capitalized) later.")
+        .mayLower(
+          word: noun.capitalized, left: "we went to ", payload: "\(noun.capitalized) later.")
       #expect(decision == nil, "\(noun) must lowercase without needing an exception list")
     }
   }
@@ -235,7 +236,10 @@ struct EnglishWordOracleTests {
     var probed: [String] = []
     let ordinary = EnglishWordOracleRuntime.isOrdinary(
       "Zorbitrax", sentinel: "zqx123456vkj",
-      spelledCorrectly: { probed.append($0); return false },
+      spelledCorrectly: {
+        probed.append($0)
+        return false
+      },
       onServiceFailure: {})
     #expect(ordinary == false)
     #expect(probed == ["Zorbitrax"], "the sentinel must not be probed on a refusal")
@@ -282,80 +286,105 @@ struct EnglishWordOracleTests {
   // MARK: - Runtime state machine
 
   @Test("Before prewarm the runtime refuses with oracle_warming")
-  func warmingRefuses() {
-    EnglishWordOracleRuntime.resetForTesting()
-    let snapshot = EnglishWordOracleRuntime.snapshot()
-    #expect(snapshot.isAvailable == false)
-    #expect(snapshot.unavailableReason == .oracleWarming)
+  func warmingRefuses() async {
+    // Cross-suite exclusion: this test mutates the process-wide runtime,
+    // and since #1921 a second suite does too. `.serialized` orders this
+    // suite only; Swift Testing runs suites concurrently.
+    await withEnglishWordOracleExclusion {
+      EnglishWordOracleRuntime.resetForTesting()
+      let snapshot = EnglishWordOracleRuntime.snapshot()
+      #expect(snapshot.isAvailable == false)
+      #expect(snapshot.unavailableReason == .oracleWarming)
+    }
   }
 
   @Test("A warming runtime keeps the capital while spacing still repairs")
-  func warmingKeepsCapitalButSpaces() {
-    // The product call: the first dictation after a cold launch keeps its
-    // capital — today's behaviour — rather than paying the measured 105.6 ms of
-    // one-time setup on the paste path.
-    EnglishWordOracleRuntime.resetForTesting()
-    let payloads = CursorInsertionRepair.repair(
-      text: "Go home.",
-      context: CursorInsertionRepair.CaretText(left: "I can't wait to", right: ""),
-      protectedWords: [],
-      oracle: EnglishWordOracleRuntime.snapshot())
+  func warmingKeepsCapitalButSpaces() async {
+    // Cross-suite exclusion: this test mutates the process-wide runtime,
+    // and since #1921 a second suite does too. `.serialized` orders this
+    // suite only; Swift Testing runs suites concurrently.
+    await withEnglishWordOracleExclusion {
+      // The product call: the first dictation after a cold launch keeps its
+      // capital — today's behaviour — rather than paying the measured 105.6 ms of
+      // one-time setup on the paste path.
+      EnglishWordOracleRuntime.resetForTesting()
+      let payloads = CursorInsertionRepair.repair(
+        text: "Go home.",
+        context: CursorInsertionRepair.CaretText(left: "I can't wait to", right: ""),
+        protectedWords: [],
+        oracle: EnglishWordOracleRuntime.snapshot())
 
-    #expect(payloads.candidateRules.contains(.caseSkipped(.oracleWarming)))
-    #expect(payloads.repairedText?.contains("Go home.") == true, "capital kept")
-    #expect(payloads.candidateRules.contains(.leadingSpace), "spacing is unaffected")
+      #expect(payloads.candidateRules.contains(.caseSkipped(.oracleWarming)))
+      #expect(payloads.repairedText?.contains("Go home.") == true, "capital kept")
+      #expect(payloads.candidateRules.contains(.leadingSpace), "spacing is unaffected")
+    }
   }
 
   @Test("The timeout latch is permanent and survives a later ready oracle")
-  func timeoutLatchIsPermanent() {
-    // `withOrderedDeadline.claim()` discards a late decision but cannot roll
-    // back side effects inside the abandoned operation. The latch must therefore
-    // outlast anything that call does afterwards, or a stalled service could be
-    // waited on twice.
-    EnglishWordOracleRuntime.resetForTesting()
-    EnglishWordOracleRuntime.installForTesting(Self.oracle(ordinary: ["go"]))
-    #expect(EnglishWordOracleRuntime.snapshot().isAvailable)
+  func timeoutLatchIsPermanent() async {
+    // Cross-suite exclusion: this test mutates the process-wide runtime,
+    // and since #1921 a second suite does too. `.serialized` orders this
+    // suite only; Swift Testing runs suites concurrently.
+    await withEnglishWordOracleExclusion {
+      // `withOrderedDeadline.claim()` discards a late decision but cannot roll
+      // back side effects inside the abandoned operation. The latch must therefore
+      // outlast anything that call does afterwards, or a stalled service could be
+      // waited on twice.
+      EnglishWordOracleRuntime.resetForTesting()
+      EnglishWordOracleRuntime.installForTesting(Self.oracle(ordinary: ["go"]))
+      #expect(EnglishWordOracleRuntime.snapshot().isAvailable)
 
-    EnglishWordOracleRuntime.disableAfterTimeout()
+      EnglishWordOracleRuntime.disableAfterTimeout()
 
-    let after = EnglishWordOracleRuntime.snapshot()
-    #expect(after.isAvailable == false)
-    #expect(after.unavailableReason == .oracleTimedOut)
-    #expect(
-      after.mayLower(word: "Go", left: "I want to ", payload: "Go home.") == .oracleTimedOut,
-      "no decision may reach a system service after the latch")
+      let after = EnglishWordOracleRuntime.snapshot()
+      #expect(after.isAvailable == false)
+      #expect(after.unavailableReason == .oracleTimedOut)
+      #expect(
+        after.mayLower(word: "Go", left: "I want to ", payload: "Go home.") == .oracleTimedOut,
+        "no decision may reach a system service after the latch")
+    }
   }
 
   @Test("A prewarm that started before a state change cannot publish after it")
   func stalePrewarmCannotPublish() async {
-    // `prewarmStarted` guards STARTING a prewarm, not one already in flight. A
-    // prepare launched by another suite's driver construction can finish after
-    // `resetForTesting()` restores `.warming` — which is exactly the condition
-    // its publish step checks — and land `.ready` on top of a test's state.
-    //
-    // The epoch closes it. Simulated here by latching, which bumps the epoch,
-    // and then letting a prewarm attempt to publish.
-    EnglishWordOracleRuntime.resetForTesting()
-    EnglishWordOracleRuntime.disableAfterTimeout()
+    // Cross-suite exclusion: this test mutates the process-wide runtime,
+    // and since #1921 a second suite does too. `.serialized` orders this
+    // suite only; Swift Testing runs suites concurrently.
+    await withEnglishWordOracleExclusion {
+      // `prewarmStarted` guards STARTING a prewarm, not one already in flight. A
+      // prepare launched by another suite's driver construction can finish after
+      // `resetForTesting()` restores `.warming` — which is exactly the condition
+      // its publish step checks — and land `.ready` on top of a test's state.
+      //
+      // The epoch closes it. Simulated here by latching, which bumps the epoch,
+      // and then letting a prewarm attempt to publish.
+      EnglishWordOracleRuntime.resetForTesting()
+      EnglishWordOracleRuntime.disableAfterTimeout()
 
-    await EnglishWordOracleRuntime.prewarm()
+      await EnglishWordOracleRuntime.prewarm()
 
-    #expect(
-      EnglishWordOracleRuntime.snapshot().unavailableReason == .oracleTimedOut,
-      "a prewarm must never overwrite state established after it began")
+      #expect(
+        EnglishWordOracleRuntime.snapshot().unavailableReason == .oracleTimedOut,
+        "a prewarm must never overwrite state established after it began")
+    }
   }
 
   @Test("Repeated prewarm after a latch cannot revive the runtime")
   func prewarmCannotRevive() async {
-    EnglishWordOracleRuntime.resetForTesting()
-    EnglishWordOracleRuntime.installForTesting(Self.oracle(ordinary: ["go"]))
-    EnglishWordOracleRuntime.disableAfterTimeout()
+    // Cross-suite exclusion: this test mutates the process-wide runtime,
+    // and since #1921 a second suite does too. `.serialized` orders this
+    // suite only; Swift Testing runs suites concurrently.
+    await withEnglishWordOracleExclusion {
+      EnglishWordOracleRuntime.resetForTesting()
+      EnglishWordOracleRuntime.installForTesting(Self.oracle(ordinary: ["go"]))
+      EnglishWordOracleRuntime.disableAfterTimeout()
 
-    // `installForTesting` marks prewarm started, so this is the real
-    // idempotence guard rather than an accident of ordering.
-    await EnglishWordOracleRuntime.prewarm()
+      // `installForTesting` marks prewarm started, so this is the real
+      // idempotence guard rather than an accident of ordering.
+      await EnglishWordOracleRuntime.prewarm()
 
-    #expect(EnglishWordOracleRuntime.snapshot().unavailableReason == .oracleTimedOut)
+      #expect(EnglishWordOracleRuntime.snapshot().unavailableReason == .oracleTimedOut)
+    }
   }
 
   // MARK: - Ordering against the guards that outrank the oracle
@@ -382,7 +411,8 @@ struct EnglishWordOracleTests {
       oracle: spy)
 
     #expect(payloads.candidateRules.contains(.caseSkipped(.protectedWord)))
-    #expect(consulted.wasConsulted == false, "the oracle must never be asked about a protected spelling")
+    #expect(
+      consulted.wasConsulted == false, "the oracle must never be asked about a protected spelling")
   }
 
   @Test("Non-English dictation never reaches the oracle at all")
@@ -419,5 +449,94 @@ struct EnglishWordOracleTests {
 
     #expect(payloads.candidateRules.contains(.lowercasedFirst))
     #expect(payloads.repairedText?.hasPrefix("the museum") == true)
+  }
+
+  // MARK: - #1921 `authorized(by:)`
+
+  @Test("#1921 An authorized wrapper reaches the underlying oracle on every closure")
+  func authorizedWrapperPassesThrough() {
+    let calls = OSAllocatedUnfairLock(initialState: 0)
+    let underlying = EnglishWordOracle(
+      unavailableReason: nil,
+      dictionaryVerdict: { _ in
+        calls.withLock { $0 += 1 }
+        return .ordinary
+      },
+      isLearnedWord: { _ in
+        calls.withLock { $0 += 1 }
+        return false
+      },
+      isRecognizedName: { _, _ in
+        calls.withLock { $0 += 1 }
+        return false
+      })
+
+    let wrapped = underlying.authorized(by: { true })
+    let skip = wrapped.mayLower(word: "The", left: "I went to ", payload: "The museum.")
+
+    #expect(skip == nil, "an authorized oracle decides exactly as the one it wraps")
+    #expect(
+      calls.withLock { $0 } == 3,
+      "and all three closures must reach it, or the wrapper is silently deciding")
+  }
+
+  @Test("#1921 A refused wrapper calls NOTHING underneath and keeps the capital")
+  func refusedWrapperNeverCallsUnderlying() {
+    // The control integration review round 2 asked for. A deadline that has
+    // already fired must stop the call, not merely record it: cancellation
+    // "cannot preempt a blocked thread", so an un-preempted repair would
+    // otherwise make exactly the unbounded call the deadline exists to bound.
+    //
+    // The underlying closures fail the test if reached, which is stronger than
+    // counting: a count can be asserted after the damage, this cannot pass at
+    // all if the guard is missing.
+    let calls = OSAllocatedUnfairLock(initialState: 0)
+    let underlying = EnglishWordOracle(
+      unavailableReason: nil,
+      dictionaryVerdict: { _ in
+        calls.withLock { $0 += 1 }
+        return .ordinary
+      },
+      isLearnedWord: { _ in
+        calls.withLock { $0 += 1 }
+        return false
+      },
+      isRecognizedName: { _, _ in
+        calls.withLock { $0 += 1 }
+        return false
+      })
+
+    let wrapped = underlying.authorized(by: { false })
+    let skip = wrapped.mayLower(word: "The", left: "I went to ", payload: "The museum.")
+
+    #expect(
+      calls.withLock { $0 } == 0,
+      "a refused wrapper must not enter the underlying oracle at all")
+    #expect(
+      skip != nil,
+      "and it must refuse to lower, because every refusal keeps the capital")
+  }
+
+  @Test("#1921 Refusal is safe on each closure independently, not just the first")
+  func refusalIsSafeOnEveryClosure() {
+    // `mayLower` short-circuits at `isRecognizedName`, so the test above proves
+    // only that ONE refusal is safe. If a later refactor reorders those checks,
+    // the other two refusals become load-bearing. Assert each in isolation.
+    let permissive = EnglishWordOracle(
+      unavailableReason: nil,
+      dictionaryVerdict: { _ in .ordinary },
+      isLearnedWord: { _ in false },
+      isRecognizedName: { _, _ in false })
+    let refused = permissive.authorized(by: { false })
+
+    #expect(
+      refused.isRecognizedName("I went to ", "The museum."),
+      "refusing the name check must read as A NAME, which keeps the capital")
+    #expect(
+      refused.isLearnedWord("the"),
+      "refusing the learned check must read as LEARNED, which keeps the capital")
+    #expect(
+      refused.dictionaryVerdict("the") == .unavailable(.oracleTimedOut),
+      "and the dictionary must report the real cause, not a bland 'not ordinary'")
   }
 }

--- a/Tests/EnviousWisprTests/Services/DictationCompletedRouteFieldsTests.swift
+++ b/Tests/EnviousWisprTests/Services/DictationCompletedRouteFieldsTests.swift
@@ -278,5 +278,73 @@ struct DictationCompletedRouteFieldsTests {
       #expect(box.event?.stringProps.keys.contains("input_resolution_source") == false)
     }
 
+    // MARK: - #1921 language-resolution telemetry, end to end
+
+    /// Collects EVERY event, not just the last. `paste.completed` and
+    /// `dictation.completed` both fire from one `reportDictationCompleted`, so a
+    /// last-write-wins box would assert against whichever happened to land
+    /// second — a test that reads a different event than it names.
+    private final class EventLog: @unchecked Sendable {
+      var events: [CapturedTelemetryEvent] = []
+    }
+
+    @Test("#1921 language resolution reaches the real paste.completed payload")
+    func languageResolutionReachesPasteCompleted() throws {
+      let log = EventLog()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        MainActor.assumeIsolated { log.events.append(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      // `pasteTier` and `pasteLatencyMs` are what open the real
+      // `paste.completed` gate; the two #1921 values ride the same metrics.
+      // Distinctive on purpose — `document` and `f70to90` are neither the
+      // default nor the value any other hop would produce by accident, so a
+      // dropped field cannot pass by coincidence.
+      var metrics = ExecutionMetrics(pasteTier: "cgevent", pasteLatencyMs: 12)
+      metrics.languageResolutionSource = "document"
+      metrics.languageConfidenceBucket = "f70to90"
+      var transcript = Transcript(text: "hello")
+      transcript.metrics = metrics
+
+      TelemetryService.shared.reportDictationCompleted(
+        transcript: transcript, inputMode: "ptt")
+
+      let pasteEvents = log.events.filter { $0.name == "paste.completed" }
+      #expect(pasteEvents.count == 1, "exactly one paste.completed, got \(pasteEvents.count)")
+      let props = try #require(pasteEvents.first).stringProps
+
+      #expect(props["language_resolution_source"] == "document")
+      #expect(props["language_confidence_bucket"] == "f70to90")
+      // Exact spelling. An alias would be silently unqueryable in PostHog.
+      #expect(props.keys.contains("language_source") == false)
+      #expect(props.keys.contains("confidence_bucket") == false)
+      #expect(props.keys.contains("resolution_source") == false)
+    }
+
+    @Test("#1921 a transcript without the fields omits both keys entirely")
+    func absentLanguageResolutionOmitsBothKeys() throws {
+      let log = EventLog()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        MainActor.assumeIsolated { log.events.append(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      // A transcript written before #1921 has neither field. It must not report
+      // `"none"`, which is a real category meaning the app looked and found
+      // nothing — otherwise the whole back catalogue reads as timed-out.
+      var transcript = Transcript(text: "hello")
+      transcript.metrics = ExecutionMetrics(pasteTier: "cgevent", pasteLatencyMs: 12)
+
+      TelemetryService.shared.reportDictationCompleted(
+        transcript: transcript, inputMode: "ptt")
+
+      let pasteEvents = log.events.filter { $0.name == "paste.completed" }
+      #expect(pasteEvents.count == 1)
+      let props = try #require(pasteEvents.first).stringProps
+      #expect(props.keys.contains("language_resolution_source") == false)
+      #expect(props.keys.contains("language_confidence_bucket") == false)
+    }
+
   #endif
 }


### PR DESCRIPTION
fix(pipeline): gate continuation casing on confidence, not input length (Closes #1921)

Continuation casing refused to act on 29.9% of real continuations because the
language resolver demanded 24 alphabetic characters before it would trust an
answer. "I can't wait till the weather is " + "warmer and summer starts." kept
its capital for exactly that reason.

Replace the length floor with a confidence floor on the same Apple recogniser:
read `languageHypotheses(withMaximum: 3)` and accept the top answer at or above
0.90. Measured on 12,150 real continuations rebuilt from stored transcripts:
acceptance 70.0% -> 87.6%, 0.80 ms per call against a 100 ms budget, and zero
leakage across 33 adversarial non-English negatives whose worst English score is
0.204.

Return the confident language WHATEVER it is, not English only. An English-only
return regresses unsegmented scripts: they resolve to nil, `LanguageRules.unknown`
has `usesWordSpacing == true`, and Japanese, Chinese and Thai insertions then gain
ASCII spaces on BOTH sides — rule 1 leading and rule 3 trailing. The safety
argument is a closed-set proof rather than a sample: `LanguageRules` has exactly
two policy fields, `knowsCasing` differs from `.unknown` only for English, and
`usesWordSpacing` differs only for the six effective unsegmented values.

The same reasoning is why the recogniser is deliberately NOT constrained to the
engine's own language list. Constrained, every non-Latin script returns nil,
which is the regression above.

Language resolution also moves inside the existing 100 ms deadline; it previously
ran ahead of it, unbounded, on the paste path. That creates a question the old
code never had to answer — which stage timed out — because the timeout path
permanently disables the word oracle. `LanguageRepairDeadlineGate` arbitrates it
through one lock-backed phase transition:

- a language-stage timeout returns the legacy payload and does NOT disable the
  oracle, since the oracle was never involved;
- a repair-stage timeout disables it only once the oracle has genuinely been
  consulted, because repair has early exits and does its spacing work first;
- a timeout landing after repair returned but before the operation claims its
  result keeps the resolution and does NOT disable a component that just
  succeeded;
- and once the timeout owns the phase, `EnglishWordOracle.authorized(by:)`
  REFUSES the late underlying call rather than merely recording it, because
  cancellation cannot preempt a blocked thread. Every refusal keeps the capital.

Two optional telemetry fields, `language_resolution_source` and
`language_confidence_bucket`, make the decision observable in the field.
`case_skipped:language_not_supported` previously looked identical whether the
user locked a language, the engine reported one, or the recogniser was unsure.
nil and "none" are deliberately different: "none" means the app measured and
found nothing, nil means the fact was never recorded — which is every transcript
written before this change, and every clipboard-only delivery, which never
attempts resolution.

Reproducible-vs-hypothetical triage on review findings: the two-lock race and the
late oracle call were both classified hypothetical (sub-millisecond, never
observed) but fixed anyway, because merging the flag into the phase is strictly
simpler than what it replaced and both failures are silent.

Tier: MEDIUM | Lane: Code | Modules: Pipeline, Core, PostProcessing, Services
Full suite: 4766 tests, zero failures.

