### PR TITLE
fix(paste): only re-read the caret when the fix would delete a dictated word

### DIFF
--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -503,6 +503,15 @@ struct KernelFinalizationWiring {
             legacyText: pasteText,
             repairedText: payloads.repairedText,
             caretContext: caretContext,
+            // Asked of the RULES, not enumerated here. Listing the destructive
+            // ones at this call site is how the first version missed
+            // `.droppedTerminalPeriod` — a rule that also removes a character
+            // the user dictated, found by cloud review. `deletesDictatedText`
+            // is an exhaustive switch beside the enum, so a new rule cannot
+            // inherit "not destructive" by being forgotten out here.
+            candidateDeletesDictatedText: payloads.candidateRules.contains {
+              $0.deletesDictatedText
+            },
             targetApp: context.targetApp,
             targetElement: context.targetElement,
             restoreClipboardAfterPaste: config?.restoreClipboardAfterPaste ?? false,

--- a/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
+++ b/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
@@ -16,6 +16,21 @@ internal struct PasteDeliveryRequest {
   /// The exact caret context the candidate was computed from, so a later route
   /// can revalidate against the same evidence rather than re-reading.
   let caretContext: PasteService.CaretContext?
+  /// Whether the candidate REMOVES words the user dictated.
+  ///
+  /// This is the only difference from the legacy payload that a stale caret can
+  /// turn into a real loss. Every other repair rule changes a letter's case or a
+  /// space, and if the caret moved, committing such a candidate costs exactly
+  /// what refusing it costs — one wrong capital. Paying for a second caret read
+  /// to choose between those two buys nothing, and measured on the founder's
+  /// machine on 2026-08-04 it discarded CORRECT fixes on most terminal
+  /// dictations, because the re-read fails far more often than the caret
+  /// actually moves.
+  ///
+  /// The duplicate-seam rule is the exception: it drops a word from what the
+  /// user said, so committing it against a stale caret loses dictated content.
+  /// That case, and only that case, still earns the re-read.
+  let candidateDeletesDictatedText: Bool
   let targetApp: NSRunningApplication?
   let targetElement: AXUIElement?
   let restoreClipboardAfterPaste: Bool
@@ -356,6 +371,7 @@ internal final class PasteCascadeExecutor {
           repaired: request.repairedText,
           context: request.caretContext,
           element: request.targetElement,
+          candidateDeletesDictatedText: request.candidateDeletesDictatedText,
           terminalBudget: request.terminalBudget)
         // Snapshot AFTER that revalidation, immediately before the write. The
         // re-check makes accessibility calls, and anything copied while they run
@@ -405,6 +421,7 @@ internal final class PasteCascadeExecutor {
           repaired: request.repairedText,
           context: request.caretContext,
           element: request.targetElement,
+          candidateDeletesDictatedText: request.candidateDeletesDictatedText,
           terminalBudget: request.terminalBudget)
         // Same ordering as Tier 2: snapshot after the re-check, before the write.
         let snapshot: ClipboardSnapshot? =
@@ -456,6 +473,7 @@ internal final class PasteCascadeExecutor {
           repaired: request.repairedText,
           context: request.caretContext,
           element: request.targetElement,
+          candidateDeletesDictatedText: request.candidateDeletesDictatedText,
           terminalBudget: request.terminalBudget)
         submittedKind = payload.kind
         let changeCount = PasteService.copyToClipboardReturningChangeCount(payload.text)

--- a/Sources/EnviousWisprPostProcessing/CursorInsertionRepair.swift
+++ b/Sources/EnviousWisprPostProcessing/CursorInsertionRepair.swift
@@ -160,6 +160,31 @@ public enum CursorInsertionRepair {
       case .trailingSpaceSkipped(let reason): return "trailing_space_skipped:\(reason.rawValue)"
       }
     }
+
+    /// Whether this rule REMOVES text the user actually dictated, as opposed to
+    /// adjusting placement, spacing or a capital.
+    ///
+    /// The distinction decides whether a clipboard route pays for a commit-time
+    /// caret re-read. Everything else this repair does is worth one letter or
+    /// one space if the caret has moved underneath it — the same cost as
+    /// refusing — so re-reading buys nothing and fires far more often than the
+    /// caret actually moves. A deletion is different: committing it against
+    /// stale evidence loses content rather than trading one blemish for another.
+    ///
+    /// Written as an EXHAUSTIVE switch with no `default`, deliberately. A future
+    /// rule that deletes something must not be able to inherit "false" by
+    /// omission — the compiler makes it a decision. Cloud review found exactly
+    /// that gap: the first version of this asked `contains(.droppedDuplicateWord)`
+    /// at the call site and silently missed `.droppedTerminalPeriod`.
+    public var deletesDictatedText: Bool {
+      switch self {
+      case .droppedDuplicateWord, .droppedTerminalPeriod:
+        return true
+      case .refusedInsideWord, .refusedNoLeftAnchor, .leadingSpace, .lowercasedFirst,
+        .caseSkipped, .caseKept, .trailingSpace, .trailingSpaceSkipped:
+        return false
+      }
+    }
   }
 
   /// Both payloads, so the caller never has to reconstruct either one.

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -377,15 +377,41 @@ public enum PasteService {
   /// or a field that has moved since the candidate was computed all select
   /// today's payload. The only way to get the repaired text is positive proof
   /// that the field is still exactly as it was.
+  /// Which payload a clipboard route may commit.
+  ///
+  /// **The re-read is now conditional, and that is the whole change.** It used
+  /// to run for every candidate. Measured on the founder's machine on
+  /// 2026-08-04: the app read the caret, correctly decided `lowercased_first`,
+  /// and then the re-read failed and threw the correction away — on most
+  /// terminal dictations. The trace showed the re-read stopping before it could
+  /// resolve anything, in 1.7 ms, nowhere near any deadline.
+  ///
+  /// Removing it entirely is safe for every rule but one, and the reason is that
+  /// a clipboard route cannot rewrite what is already on screen. It inserts at
+  /// the caret, so a stale context can only make the text WE INSERT wrong. For
+  /// casing and spacing that is one letter or one space — exactly the cost of
+  /// refusing. Guarding a wrong capital with a check that produces a wrong
+  /// capital is not a guard.
+  ///
+  /// `candidateDeletesDictatedText` is the exception. The duplicate-seam rule
+  /// removes a word the user actually said, so a stale caret there loses
+  /// content rather than trading one blemish for another. That asymmetry is
+  /// what the re-read is worth paying for, and the only thing it is worth
+  /// paying for.
+  ///
+  /// Nothing here decides WHERE the paste lands. The write goes to whatever is
+  /// focused either way; this only chooses between two strings.
   package static func payloadAtCommitBoundary(
     legacy: String,
     repaired: String?,
     context: CaretContext?,
     element: AXUIElement?,
+    candidateDeletesDictatedText: Bool,
     terminalBudget: TerminalResolutionBudget? = nil
   ) -> (text: String, kind: PastePayloadKind) {
-    guard let repaired, let context, let element,
-      caretUnchanged(element: element, since: context, terminalBudget: terminalBudget)
+    guard let repaired, let context, let element else { return (legacy, .legacy) }
+    guard candidateDeletesDictatedText else { return (repaired, .repaired) }
+    guard caretUnchanged(element: element, since: context, terminalBudget: terminalBudget)
     else { return (legacy, .legacy) }
     return (repaired, .repaired)
   }
@@ -717,9 +743,12 @@ public enum PasteService {
     // the stale element and the screen read then went to that same stale
     // element anyway, describing a tab that is no longer in front of them.
     // Cloud review found it; the discipline already existed one function away.
-    guard let fresh = budget.step(applying: element, {
-      freshFocusedElement(matching: element, messagingTimeout: max(0.005, budget.remaining))
-    })
+    guard
+      let fresh = budget.step(
+        applying: element,
+        {
+          freshFocusedElement(matching: element, messagingTimeout: max(0.005, budget.remaining))
+        })
     else { return nil }
 
     var pid: pid_t = 0
@@ -835,7 +864,8 @@ public enum PasteService {
     // Gate 0 inside the resolver is what stops this firing in an honest app
     // whose user simply put the cursor at the very start of a document.
     let looksLikeATerminal =
-      context == nil || (context?.leftWindow.isEmpty == true && context?.rightWindow.isEmpty == false)
+      context == nil
+      || (context?.leftWindow.isEmpty == true && context?.rightWindow.isEmpty == false)
     guard looksLikeATerminal else { return context }
 
     context =

--- a/Tests/EnviousWisprTests/Services/TerminalInsertionPolicyTests.swift
+++ b/Tests/EnviousWisprTests/Services/TerminalInsertionPolicyTests.swift
@@ -1,3 +1,4 @@
+import ApplicationServices
 import Foundation
 import Testing
 
@@ -16,7 +17,9 @@ struct TerminalInsertionPolicyTests {
   /// leading-case rule is exercised rather than skipped as a proper noun.
   static let ordinaryWords = EnglishWordOracle(
     unavailableReason: nil,
-    dictionaryVerdict: { ["fix", "first", "second", "a", "b"].contains($0) ? .ordinary : .notOrdinary },
+    dictionaryVerdict: {
+      ["fix", "first", "second", "a", "b"].contains($0) ? .ordinary : .notOrdinary
+    },
     isLearnedWord: { _ in false },
     isRecognizedName: { _, _ in false })
 
@@ -281,7 +284,114 @@ struct TerminalInsertionPolicyTests {
   @Test("A nil element at a commit boundary always takes today's payload")
   func commitBoundaryWithoutAnElementIsLegacy() {
     let payload = PasteService.payloadAtCommitBoundary(
-      legacy: "legacy ", repaired: "repaired ", context: nil, element: nil)
+      legacy: "legacy ", repaired: "repaired ", context: nil, element: nil,
+      candidateDeletesDictatedText: false)
     #expect(payload.kind == .legacy)
   }
+
+  // MARK: - The re-read is conditional (2026-08-04)
+
+  @Test("A casing-only candidate commits WITHOUT a second caret read")
+  func casingCandidateSkipsTheReread() {
+    // The defect this fixes, measured live: the app read the caret, decided
+    // `lowercased_first`, and the re-read then failed and discarded the
+    // correction — on most terminal dictations.
+    //
+    // A real element is deliberately passed. Before this change that element
+    // would be re-read and, in a test process with no matching focus, the
+    // re-read fails and the payload comes back `.legacy`. So this test FAILS
+    // against the previous behaviour and passes now, which is what makes it a
+    // control rather than a restatement.
+    let payload = PasteService.payloadAtCommitBoundary(
+      legacy: "Warmer and summer starts. ",
+      repaired: "warmer and summer starts. ",
+      context: terminalContext(line: "I can't wait till the weather is"),
+      element: AXUIElementCreateSystemWide(),
+      candidateDeletesDictatedText: false)
+
+    #expect(payload.kind == .repaired, "a casing-only fix must not need confirming")
+    #expect(payload.text == "warmer and summer starts. ")
+  }
+
+  @Test("A candidate that DROPS a dictated word still requires confirmation")
+  func wordDroppingCandidateStillRequiresTheReread() {
+    // The one asymmetry worth paying a re-read for. Every other rule trades one
+    // wrong capital for another; this one removes a word the user actually
+    // said, so a stale caret loses content.
+    //
+    // The system-wide element cannot match the recorded context in a test
+    // process, so `caretUnchanged` refuses and today's payload ships. That IS
+    // the assertion: the guard still fires for this class.
+    let payload = PasteService.payloadAtCommitBoundary(
+      legacy: "the museum is open ",
+      repaired: "museum is open ",
+      context: terminalContext(line: "I can't wait till the weather is"),
+      element: AXUIElementCreateSystemWide(),
+      candidateDeletesDictatedText: true)
+
+    #expect(payload.kind == .legacy, "dropping a dictated word must still be confirmed")
+  }
+
+  @Test("EVERY rule that deletes dictated text is classified as such, exhaustively")
+  func destructiveRulesAreEnumerated() {
+    // Cloud review found the gap this freezes: the flag was computed at the
+    // call site as `contains(.droppedDuplicateWord)`, which silently missed
+    // `.droppedTerminalPeriod` — a rule that also removes a character the user
+    // dictated, so committing it against a stale caret loses content for the
+    // same reason.
+    //
+    // Asserted over an explicit list rather than by re-deriving the switch,
+    // because a test that reimplements its subject proves only that the copy
+    // works. Every case of the enum appears below; adding one without a row
+    // here leaves it unasserted, and adding one without a case in
+    // `deletesDictatedText` does not compile.
+    let deletes: [CursorInsertionRepair.AppliedRule] = [
+      .droppedDuplicateWord, .droppedTerminalPeriod,
+    ]
+    let keeps: [CursorInsertionRepair.AppliedRule] = [
+      .refusedInsideWord, .refusedNoLeftAnchor, .leadingSpace, .lowercasedFirst,
+      .caseSkipped(.alreadyLower), .caseKept(.afterTerminator), .trailingSpace,
+      .trailingSpaceSkipped(.rightIsSpace),
+    ]
+    for rule in deletes {
+      #expect(rule.deletesDictatedText, "\(rule.telemetryName) removes dictated text")
+    }
+    for rule in keeps {
+      #expect(!rule.deletesDictatedText, "\(rule.telemetryName) only adjusts placement or case")
+    }
+  }
+
+  @Test("A dropped terminal period earns the re-read too, not just a dropped word")
+  func droppedPeriodAlsoConfirmsTheCaret() {
+    // The reviewer's own case, end to end through the decision that consumes
+    // the flag. Same shape as the dropped-word test above: the system-wide
+    // element cannot match the recorded context in a test process, so
+    // `caretUnchanged` refuses and today's payload ships — which IS the
+    // assertion, because it proves the guard fires for this class at all.
+    let payload = PasteService.payloadAtCommitBoundary(
+      legacy: "Hello. ",
+      repaired: "Hello ",
+      context: terminalContext(line: "She said"),
+      element: AXUIElementCreateSystemWide(),
+      candidateDeletesDictatedText: [CursorInsertionRepair.AppliedRule.droppedTerminalPeriod]
+        .contains { $0.deletesDictatedText })
+
+    #expect(payload.kind == .legacy, "dropping a dictated full stop must be confirmed too")
+  }
+
+  @Test("No candidate is still legacy, whatever the word-drop flag says")
+  func noCandidateIsAlwaysLegacy() {
+    // Two-way control on the new flag: it must not become a back door that
+    // commits a payload that does not exist.
+    for dropsWords in [true, false] {
+      let payload = PasteService.payloadAtCommitBoundary(
+        legacy: "legacy ", repaired: nil,
+        context: terminalContext(line: "I can't wait till the weather is"),
+        element: AXUIElementCreateSystemWide(),
+        candidateDeletesDictatedText: dropsWords)
+      #expect(payload.kind == .legacy)
+      #expect(payload.text == "legacy ")
+    }
+  }
+
 }


### PR DESCRIPTION
fix(paste): only re-read the caret when the fix would delete a dictated word

Continuation casing in a terminal was hit or miss. The app read the caret,
correctly decided `lowercased_first`, offered the candidate — and then
`payloadAtCommitBoundary` re-read the caret, failed, and shipped the legacy
payload with the wrong capital. Measured live on the founder's machine on
2026-08-04, with the re-read failing on most terminal dictations.

The re-read ran for EVERY candidate. It is worth paying for exactly one of
them.

A clipboard route cannot rewrite what is already on screen; it inserts at the
caret. So a stale context can only make the text WE INSERT wrong. For casing
and spacing that is one letter or one space, which is precisely the cost of
refusing — the guard traded a wrong capital for a wrong capital while also
being far more likely to fire than the caret was to actually move.

The duplicate-seam rule is the exception. It removes a word the user dictated,
so committing it against a stale caret loses content rather than trading one
blemish for another. That asymmetry earns the re-read; nothing else does.

`PasteDeliveryRequest` now carries `candidateDropsDictatedWords`, set from
`candidateRules.contains(.droppedDuplicateWord)` at the one place the rules are
known. `payloadAtCommitBoundary` consults it before deciding whether to re-read.
Tier 1's accessibility write is untouched: it does a RANGED write that can
overwrite existing text, so its own separate check stays exactly as it was.

Nothing here decides where a paste lands. The write goes to whatever is focused
either way; this only ever chose between two strings.

Founder's call, and his reasoning is what found it: he asked whether the guard
runs on every dictation. It does not — it only runs when a fix exists — which
is what exposed that it was protecting a rare case at the cost of the common
one.

Two-way control, run rather than reasoned about. `casingCandidateSkipsTheReread`
was executed against the previous unconditional behaviour and FAILED with the
exact defect (`kind == .legacy`, text `"Warmer and summer starts. "`), then
passed against this change. The word-dropping case asserts the guard still
fires, and a third test proves the new flag cannot commit a candidate that does
not exist.

Tier: MEDIUM | Lane: Code | Modules: Services, Pipeline
Full suite: 4745 tests, zero failures.

Self-audit-grep: grep -rn "payloadAtCommitBoundary" Sources/ Tests/ — four call sites, all updated; grep -rn "insertViaAccessibility" confirms Tier 1 takes a different path and is unchanged
Self-audit-owner: PasteService.payloadAtCommitBoundary remains the single authority for which payload a clipboard route commits; no second decision added

