### PR TITLE
fix(#1923,#1925): stop overwriting the mic advisory; route a zero-buffer session to it too

### DIFF
--- a/Sources/EnviousWisprAppKit/App/DictationNarrator.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationNarrator.swift
@@ -128,7 +128,7 @@ enum DictationNarrator {
   /// substantiate (#1876 product decision 1).
   static func copy(for reason: TerminalAdvisoryReason) -> String {
     switch reason {
-    case .zeroSignal, .vadGateNoSpeech:
+    case .zeroSignal, .vadGateNoSpeech, .noTransport:
       return
         "Audio isn't capturing. Your lid may be closed, your headset muted, or there may be a hardware issue. Please check your microphone settings."
     }

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingStarter.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingStarter.swift
@@ -422,28 +422,22 @@ final class RecordingStarter {
       return .noRecording
     }
     let totalMs = Self.elapsedMs(since: pttStart)
-    let pipelineActive: Bool
-    let pipelineInError: Bool
-    if isWhisperKit {
-      pipelineActive = whisperKitKernelDriver.state.isActive
-      if case .error = whisperKitKernelDriver.state {
-        pipelineInError = true
-      } else {
-        pipelineInError = false
-      }
-    } else {
-      pipelineActive = kernelDriver.state.isActive
-      if case .error = kernelDriver.state {
-        pipelineInError = true
-      } else {
-        pipelineInError = false
-      }
-    }
+    let pipelineActive = active.state.isActive
+    // #1925: was `pipelineInError`, matching only `.error`. A concluded
+    // `.advisory` (and any other quietly-concluded outcome) is just as much
+    // "something happened" as an error is, and the old check treated it like
+    // silence — letting this postcondition stamp a wedge over an already-
+    // correct message. `hasTerminalResult` answers the real question
+    // directly instead of enumerating recognized cases.
+    let pipelineConcluded = active.hasTerminalResult
     let userStoppedDuringStart: Bool = {
       guard let lastStop = lastUserStopAccess.read() else { return false }
       return lastStop > pttStart
     }()
-    if !pipelineActive && !pipelineInError && !userStoppedDuringStart {
+    if Self.shouldStampPostConditionWedge(
+      pipelineActive: pipelineActive, hasTerminalResult: pipelineConcluded,
+      userStoppedDuringStart: userStoppedDuringStart)
+    {
       SentryBreadcrumb.captureError(
         ModelLoadWatchdog.WedgeError(stage: "post_condition"),
         category: .pipelinePostConditionFailed, stage: "recording",
@@ -454,7 +448,7 @@ final class RecordingStarter {
       active.setTerminalReason(.modelWedged)
       return .noRecording
     }
-    if !pipelineActive && !pipelineInError && userStoppedDuringStart {
+    if !pipelineActive && !pipelineConcluded && userStoppedDuringStart {
       recordingOverlay.show(intent: .hidden)
       recordingLockedAccess.set(false)
       return .noRecording
@@ -462,7 +456,7 @@ final class RecordingStarter {
     // GitHub cloud review, PR #1732: consume the pending blocked-press info
     // (and emit `recovery.press_unblocked`) only NOW, after both post-
     // condition early-returns above have been survived — a genuine session
-    // (active or a real pipeline error, not a silent wedge or a user-stop-
+    // (active or a real pipeline result, not a silent wedge or a user-stop-
     // during-arm no-op) actually started. Firing this before `handle(event:)`
     // let a throw or an unactivated session get counted as "unblocked".
     consumePendingBlockedPressIfAny()
@@ -473,13 +467,27 @@ final class RecordingStarter {
       )
     }
     // #1631: report what the hotkey needs — a session that is genuinely
-    // continuing, and its id. `pipelineInError` is deliberately NOT treated as a
-    // session here: `PipelineState.error` is excluded from `isActive`, so an
-    // errored pipeline is not a live recording and must not keep hands-free
+    // continuing, and its id. `pipelineConcluded` is deliberately NOT treated
+    // as a session here: a concluded pipeline (error, advisory, or any other
+    // real ending) is not a live recording and must not keep hands-free
     // bookkeeping alive. The id also comes back nil when an exit is already
     // latched, which `state` alone cannot express.
     return RecordingStartOutcome.make(
       pipelineActive: pipelineActive, continuingSessionID: active.continuingSessionID)
+  }
+
+  /// #1925: the postcondition's actual decision, extracted as a pure function
+  /// so it is directly testable without constructing a live driver/kernel.
+  /// `pipelineActive` and `hasTerminalResult` are independent facts (a
+  /// session can be neither, briefly, between conclusion and reset) —
+  /// stamping a wedge is correct only when NEITHER holds AND the user did not
+  /// stop it themselves.
+  nonisolated static func shouldStampPostConditionWedge(
+    pipelineActive: Bool,
+    hasTerminalResult: Bool,
+    userStoppedDuringStart: Bool
+  ) -> Bool {
+    !pipelineActive && !hasTerminalResult && !userStoppedDuringStart
   }
 
   /// UI/menu toggle path (no prewarm). Mirrors the former root-state file

--- a/Sources/EnviousWisprCore/TerminalNoticeReason.swift
+++ b/Sources/EnviousWisprCore/TerminalNoticeReason.swift
@@ -67,23 +67,25 @@ public enum TerminalNoticeReason: String, Equatable, Sendable, CaseIterable {
 /// text through no fault of the pipeline.
 ///
 /// Deliberately a SEPARATE type from `TerminalNoticeReason`, not another case
-/// on it. `TerminalNoticeReason` means "a terminal notice whose raw value is
-/// the PostHog `pipeline.failed.error_code`", and both halves are wrong here:
-/// only one of these two reasons emits `pipeline.failed` at all, and the
-/// founder's model (#1876, 2026-07-31) splits capture endings into exactly two
-/// customer buckets — OUR SOFTWARE ("[X] error. Try again.") and YOUR SETUP.
+/// on it. `TerminalNoticeReason` couples each case directly to a raw PostHog
+/// `pipeline.failed.error_code`. This type cannot make that promise because its
+/// three producers have different telemetry obligations, described below.
+///
+/// The founder's model (#1876, 2026-07-31) splits capture endings into exactly
+/// two customer buckets: OUR SOFTWARE ("[X] error. Try again.") and YOUR SETUP.
 /// This type is the second bucket.
 ///
-/// Two cases rather than one because the two producers have different
-/// telemetry obligations even though they share a sentence: `.zeroSignal`
+/// Three cases rather than one because the producers have different telemetry
+/// obligations even though they share one customer sentence. `.zeroSignal`
 /// continues the existing `pipeline.failed` `zero_signal` series (340 events /
-/// 50 users per 30d — the baseline the Phase 2 analysis rests on), while
+/// 50 users per 30d — the baseline the Phase 2 analysis rests on). `.noTransport`
+/// continues the existing `pipeline.failed` `no_audio_captured` series.
 /// `.vadGateNoSpeech` is already counted by `audio.vad_gate_no_speech` (#1845)
 /// and must NOT manufacture a second, overlapping failure record.
 ///
-/// Both narrate identically. Do not add a per-case sentence without a founder
-/// decision: #1558 locked the customer copy set, and #1891 added exactly one
-/// seventh sentence to it.
+/// All three narrate identically. Do not add a per-case sentence without a
+/// founder decision: #1558 locked the customer copy set, and #1891 added
+/// exactly one seventh sentence to it.
 public enum TerminalAdvisoryReason: Equatable, Sendable, CaseIterable {
   /// The capture buffer was digitally silent — a closed lid in clamshell,
   /// vendor firmware mute, or a dead channel. Reaches here from
@@ -101,4 +103,11 @@ public enum TerminalAdvisoryReason: Equatable, Sendable, CaseIterable {
   /// `.asrEmptyNoSpeech`, which stays silent because the microphone was
   /// working and the user already knows they did not speak.
   case vadGateNoSpeech
+
+  /// #1923/#1925: no audio transport ever arrived for the whole session — the
+  /// no-buffer watchdog fired with zero buffers delivered. Reaches here from
+  /// `RecordingOutcome.noTransport`; keeps emitting `pipeline.failed` with the
+  /// unchanged `no_audio_captured` code (the LOCKED projection this outcome
+  /// has always carried, `KernelTerminalProjections.swift`).
+  case noTransport
 }

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -1217,6 +1217,18 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
     fireStateChangeIfNeeded()
   }
 
+  /// #1925: whether the current start produced any terminal result, by
+  /// either mechanism (`lastTerminalReason`, set directly by driver-level
+  /// fallback paths, or a concluded `kernel.recordingOutcome`, set by the FSM
+  /// itself). The single source of truth for "did something happen," so a
+  /// start-path postcondition can tell a genuine wedge from any real
+  /// conclusion without re-deriving it from `state` case by case — a check
+  /// that enumerated cases (`.error`, `.advisory`, ...) would need to grow
+  /// every time a new terminal shape is added; this does not.
+  package var hasTerminalResult: Bool {
+    lastTerminalReason != nil || kernel.recordingOutcome != nil
+  }
+
   // MARK: HeartPathTelemetryTarget — forwards to the observer (PR-4 §3.9)
 
   public func handleCaptureStall(_ ctx: CaptureStallContext) {
@@ -1626,7 +1638,7 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   /// them inherit it without a decision is not.
   ///
   /// Founder model (#1876, 2026-07-31): capture endings get exactly two
-  /// customer buckets, OUR SOFTWARE and YOUR SETUP. Only the two cases below
+  /// customer buckets, OUR SOFTWARE and YOUR SETUP. Only the three cases below
   /// are the second bucket. `.captureStalled` (a mid-take death) deliberately
   /// stays our-software until #1578 telemetry explains it — calling it the
   /// user's setup would be a guess.
@@ -1655,12 +1667,18 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
       case .asrEmptyNoSpeech, .emptyAfterProcessing:
         return nil
       }
+    // #1923/#1925: zero audio buffers ever arrived — the same "nothing to
+    // transcribe" shape as `.zeroSignal`/`.vadGate` above, not a transcription
+    // failure. Own advisory case (not reusing `.zeroSignal`) to keep its
+    // `no_audio_captured` telemetry identity separate from `zero_signal`'s.
+    case .noTransport:
+      return .noTransport
     // #1920: `.asrEmptyDespiteAudio` gets NO advisory. Audio was arriving above
     // every dead-air floor, so there is nothing to tell the user to check — the
-    // genuinely-absent-audio cases above (`.zeroSignal`, `.vadGate`) keep the
-    // advisory, and they are the ones that should speak.
+    // genuinely-absent-audio cases above (`.zeroSignal`, `.vadGate`, `.noTransport`)
+    // keep the advisory, and they are the ones that should speak.
     case .completed, .cancelled, .discarded, .audioInterrupted,
-      .asrInterrupted, .noTransport, .asrEmptyDespiteAudio:
+      .asrInterrupted, .asrEmptyDespiteAudio:
       return nil
     }
   }

--- a/Sources/EnviousWisprPipeline/PipelineStateChangePlanner.swift
+++ b/Sources/EnviousWisprPipeline/PipelineStateChangePlanner.swift
@@ -200,20 +200,31 @@ enum PipelineStateChangePlanner {
     if case .error(let reason) = newState.activity {
       effects.append(.reportPipelineFailed(errorCode: reason.rawValue))
     }
-    // #1891: `.zeroSignal` moved from `.error` to `.advisory` for PRESENTATION
-    // only. Its telemetry must not move with it — `zero_signal` is an existing
-    // series (340 events / 50 users per 30d) and the baseline the whole Phase 2
-    // analysis rests on, so it keeps emitting under its unchanged code.
-    // Splitting or renaming it would be the #1813 retired-vocabulary trap,
-    // self-inflicted.
+    // #1891/#1923/#1925: `.zeroSignal` and `.noTransport` moved from `.error`
+    // to `.advisory` for PRESENTATION only. Their telemetry must not move
+    // with them — `zero_signal` and `no_audio_captured` are existing series
+    // (`zero_signal`: 340 events / 50 users per 30d, the baseline the whole
+    // Phase 2 analysis rests on) that keep emitting under their unchanged
+    // codes. Splitting or renaming either would be the #1813 retired-
+    // vocabulary trap, self-inflicted. An exhaustive switch (not a second
+    // freestanding `if case`) so a FUTURE fourth advisory case is a compile
+    // error here, not a silently skipped telemetry record.
     //
     // `.vadGateNoSpeech` emits NOTHING here on purpose: it is already counted
     // by `audio.vad_gate_no_speech` (#1845), and a second record would both
     // double-count that population and inflate total `pipeline.failed` volume
     // with takes that were never a pipeline failure.
-    if case .advisory(.zeroSignal) = newState.activity {
-      effects.append(
-        .reportPipelineFailed(errorCode: TerminalNoticeReason.zeroSignal.rawValue))
+    if case .advisory(let reason) = newState.activity {
+      switch reason {
+      case .zeroSignal:
+        effects.append(
+          .reportPipelineFailed(errorCode: TerminalNoticeReason.zeroSignal.rawValue))
+      case .noTransport:
+        effects.append(
+          .reportPipelineFailed(errorCode: TerminalNoticeReason.noAudioCaptured.rawValue))
+      case .vadGateNoSpeech:
+        break
+      }
     }
 
     return PipelineStateChangePlan(effects: effects)

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -102,8 +102,9 @@ enum RecordingOutcome: Equatable, Sendable {
   /// distinction — true when the session was `.live` at interruption.
   case asrInterrupted(wasRecording: Bool)
   /// #1548: no audio ever arrived — the 800 ms no-buffer watchdog fired with
-  /// `bufferCountThisSession == 0` (a dead mic). Projects to the existing
-  /// `.failed(.noAudioCaptured)` telemetry + "No audio captured" copy.
+  /// `bufferCountThisSession == 0`. Retains the existing
+  /// `.failed(.noAudioCaptured)` telemetry identity and presents through
+  /// `.advisory(.noTransport)` (#1923/#1925), not a hardware verdict.
   case noTransport
   /// #1920: audio was arriving ABOVE every dead-air floor, the engine ran
   /// without error, and it produced no words.
@@ -3063,8 +3064,8 @@ final class RecordingSessionKernel {
   /// capture session via its own `isCurrentSession(ctx.sessionID)` check.
   ///
   /// #1317 §3.2 / #1548 D2: routes by `ctx.failureMode` AND lifecycle state.
-  /// - `.noBuffers` + no buffer ever (`bufferCountThisSession == 0`) → dead mic:
-  ///   `finishTerminal(.noTransport)` ("No audio captured"; #1755 disposition: best-effort deletion).
+  /// - `.noBuffers` + no buffer ever (`bufferCountThisSession == 0`) → transport absence:
+  ///   `finishTerminal(.noTransport)` (microphone advisory; #1755 disposition: best-effort deletion).
   /// - `.noBuffers` after a buffer arrived → `.captureStall` (routed via the
   ///   pending slot from `.arming`, `deliverRecordingExitIfCurrent` from `.live`).
   /// - `.allZeroFromStart` / `.becameZeroMidCapture` → the dedicated `.zeroSignal`

--- a/Tests/EnviousWisprTests/App/RecordingStarterStartPathTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingStarterStartPathTests.swift
@@ -516,6 +516,34 @@ import Testing
       RecordingStartOutcome.make(pipelineActive: false, continuingSessionID: nil) == .noRecording)
   }
 
+  // MARK: - #1925 postcondition decision
+
+  /// Extracted as a pure function so this is tested directly rather than by
+  /// racing a live driver into each of the four states. Only ONE combination
+  /// stamps a wedge: nothing active, no terminal result reached by any
+  /// mechanism, and the user did not stop it themselves.
+  @Test("the wedge postcondition fires only when truly nothing happened")
+  func postConditionWedgeClosedSet() {
+    // Active: never a wedge, regardless of the other two inputs.
+    #expect(
+      !RecordingStarter.shouldStampPostConditionWedge(
+        pipelineActive: true, hasTerminalResult: false, userStoppedDuringStart: false))
+    // Concluded by any mechanism (error, advisory, or any other real ending):
+    // not a wedge. This is the #1925 fix — the old check only recognized
+    // `.error` here.
+    #expect(
+      !RecordingStarter.shouldStampPostConditionWedge(
+        pipelineActive: false, hasTerminalResult: true, userStoppedDuringStart: false))
+    // The user stopped it themselves during start: not a wedge, a real no-op.
+    #expect(
+      !RecordingStarter.shouldStampPostConditionWedge(
+        pipelineActive: false, hasTerminalResult: false, userStoppedDuringStart: true))
+    // Nothing active, nothing concluded, no user stop: the one true wedge.
+    #expect(
+      RecordingStarter.shouldStampPostConditionWedge(
+        pipelineActive: false, hasTerminalResult: false, userStoppedDuringStart: false))
+  }
+
   #if DEBUG
 
     /// The helper test above proves the mapping. These prove the two PRODUCTION

--- a/Tests/EnviousWisprTests/Architecture/RecordingStarterCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RecordingStarterCeilingsTests.swift
@@ -34,11 +34,16 @@ import Testing
       named: "RecordingStarter", at: Self.sourcePath)
     let count = RouterCeilingParser.nonPrivateMethodCount(in: body)
     #expect(
-      count <= 2,
+      count <= 3,
       """
-      RecordingStarter non-private method ceiling exceeded: \(count) > 2 \
+      RecordingStarter non-private method ceiling exceeded: \(count) > 3 \
       non-private `func` declarations. PR10 baseline: start, toggle. \
-      `isProcessing` is a `var` (computed) and is not counted.
+      #1925 added `shouldStampPostConditionWedge` — the postcondition's actual \
+      decision, extracted as a pure `nonisolated static func` so the four-case \
+      wedge-detection truth table is directly testable rather than requiring a \
+      live driver/kernel; it must stay reachable from the test target, so it \
+      cannot be `private`. `isProcessing` is a `var` (computed) and is not \
+      counted.
       """)
   }
 
@@ -168,10 +173,17 @@ import Testing
     // in flight, so the pre-rebase local number was against a stale base and CI —
     // which tests the MERGE — was the first thing able to see the real total.
     // Deterministic rule: actual 646 + 4 → round up to nearest 5 = 650.
+    // #1925: raised 650 → 660. The postcondition's `pipelineInError` computation
+    // (duplicated across the `kernelDriver`/`whisperKitKernelDriver` branches)
+    // collapsed to a single `active.hasTerminalResult` read, and the new
+    // `shouldStampPostConditionWedge` pure function plus its doc comment were
+    // added — a net addition once the deleted branching is subtracted. No new
+    // collaborator (count stays ≤ 7). Deterministic rule: actual 654 + 6 → round
+    // up to nearest 5 = 660.
     #expect(
-      count <= 650,
+      count <= 660,
       """
-      RecordingStarter line count exceeded: \(count) > 650. \
+      RecordingStarter line count exceeded: \(count) > 660. \
       Raise via Bible §30 only.
       """)
   }

--- a/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverTests.swift
@@ -60,10 +60,12 @@ import Testing
     #expect(mappedOutcome(.noSpeech(.emptyAfterProcessing)) == .idle)
     // #1891: zero-signal moved out of the error surface for the same reason.
     #expect(mappedOutcome(.failed(.zeroSignal)) == .advisory(.zeroSignal))
+    // #1923/#1925: zero buffers for the whole session is the same "nothing to
+    // transcribe" shape, own advisory case to keep its own telemetry identity.
+    #expect(mappedOutcome(.noTransport) == .advisory(.noTransport))
     // Error-surface endings.
     for o: RecordingOutcome in [
       .failed(.asrEmpty), .audioInterrupted(nil), .asrInterrupted(wasRecording: true),
-      .noTransport,
     ] {
       if case .error = mappedOutcome(o) {
       } else {
@@ -96,10 +98,6 @@ import Testing
       KernelDictationDriver.pipelineState(
         for: .idle, outcome: .failed(.modelLoadFailed), externalReason: nil)
         == .error(.modelLoadFailed))
-    #expect(
-      KernelDictationDriver.pipelineState(
-        for: .idle, outcome: .noTransport, externalReason: nil)
-        == .error(.noAudioCaptured))
   }
 
   // MARK: handle(event:) -> kernel triggers
@@ -239,6 +237,27 @@ import Testing
       // leak. Customer copy is proven in `DictationNarratorTests` (AppKit).
       #expect(h.driver.state == .error(.modelLoadFailed))
       #expect(h.driver.overlayIntent == .error(reason: .modelLoadFailed))
+    }
+
+    @Test("hasTerminalResult recognizes every terminal mechanism, including a silent outcome (#1925)")
+    func hasTerminalResultRecognizesEveryTerminalMechanism() {
+      // Fresh driver, nothing has happened yet.
+      let fresh = makeDriver()
+      #expect(fresh.driver.hasTerminalResult == false)
+
+      // A silent, non-error conclusion (the shape #1925's postcondition
+      // could not previously distinguish from a genuine wedge) still counts.
+      let silent = makeDriver()
+      #expect(silent.kernel.testForceTransition(to: .arming))
+      silent.kernel.testForceConclude(.asrEmptyDespiteAudio)
+      #expect(silent.driver.hasTerminalResult == true)
+
+      // The driver's OWN direct-set mechanism also counts, independent of the
+      // kernel-concluded path above.
+      let direct = makeDriver()
+      #expect(direct.driver.hasTerminalResult == false)
+      direct.driver.setTerminalReason(.modelWedged)
+      #expect(direct.driver.hasTerminalResult == true)
     }
 
     @Test(

--- a/Tests/EnviousWisprTests/Pipeline/PipelineStateChangePlannerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PipelineStateChangePlannerTests.swift
@@ -320,6 +320,73 @@ struct PipelineStateChangePlannerTests {
   // redundant now that both backends share `PipelineState.error(_)` (covered
   // by `errorStateEmitsReportPipelineFailed` above).
 
+  // MARK: - Advisory telemetry identity (#1923/#1925)
+  //
+  // The advisory bucket presents one shared sentence for three producers, but
+  // each keeps its OWN `pipeline.failed.error_code` so the three underlying
+  // series never merge. This is the regression guard for a defect caught
+  // before it shipped: an earlier draft would have routed `.noTransport`
+  // through the `.zeroSignal` code, silently corrupting the `zero_signal`
+  // baseline the whole Phase 2 analysis rests on.
+
+  @Test("advisory zeroSignal still reports the unchanged zero_signal code")
+  func advisoryZeroSignalReportsUnchangedCode() {
+    let plan = PipelineStateChangePlanner.plan(
+      to: PipelineState.advisory(.zeroSignal),
+      pipelineOverlayIntent: .advisory(reason: .zeroSignal),
+      isClipboardFallback: false,
+      isAccessibilityToast: false,
+      lastPolishError: nil,
+      hasCurrentTranscript: false,
+      historySaved: true,
+      historySaveReason: nil
+    )
+    #expect(
+      plan.effects.contains(
+        .reportPipelineFailed(errorCode: TerminalNoticeReason.zeroSignal.rawValue)))
+  }
+
+  @Test("advisory noTransport reports the pre-existing no_audio_captured code, not zero_signal")
+  func advisoryNoTransportReportsNoAudioCapturedCode() {
+    let plan = PipelineStateChangePlanner.plan(
+      to: PipelineState.advisory(.noTransport),
+      pipelineOverlayIntent: .advisory(reason: .noTransport),
+      isClipboardFallback: false,
+      isAccessibilityToast: false,
+      lastPolishError: nil,
+      hasCurrentTranscript: false,
+      historySaved: true,
+      historySaveReason: nil
+    )
+    #expect(
+      plan.effects.contains(
+        .reportPipelineFailed(errorCode: TerminalNoticeReason.noAudioCaptured.rawValue)))
+    // TWO-WAY CONTROL: the defect this test guards against would have this
+    // pass too, since both codes would be emitted under a merged series.
+    #expect(
+      !plan.effects.contains(
+        .reportPipelineFailed(errorCode: TerminalNoticeReason.zeroSignal.rawValue)))
+  }
+
+  @Test("advisory vadGateNoSpeech still emits nothing here, unchanged")
+  func advisoryVadGateStillEmitsNothing() {
+    let plan = PipelineStateChangePlanner.plan(
+      to: PipelineState.advisory(.vadGateNoSpeech),
+      pipelineOverlayIntent: .advisory(reason: .vadGateNoSpeech),
+      isClipboardFallback: false,
+      isAccessibilityToast: false,
+      lastPolishError: nil,
+      hasCurrentTranscript: false,
+      historySaved: true,
+      historySaveReason: nil
+    )
+    for effect in plan.effects {
+      if case .reportPipelineFailed = effect {
+        Issue.record("vadGateNoSpeech must not emit reportPipelineFailed (already counted by audio.vad_gate_no_speech)")
+      }
+    }
+  }
+
   // MARK: - Effect ordering guarantees
 
   @Test("complete success plan produces canonical effect order")

--- a/Tests/EnviousWisprTests/Pipeline/TerminalAdvisoryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TerminalAdvisoryTests.swift
@@ -15,20 +15,24 @@ import Testing
 
   // MARK: - The classifier: one authority, both projections
 
-  @Test("only zeroSignal and vadGate no-speech are advisories")
+  @Test("only genuinely absent-audio outcomes are advisories")
   func classifierTruthTable() {
-    // POSITIVE — the two endings the founder decision covers.
+    // POSITIVE — the absent-audio endings the founder decision covers.
     #expect(
       KernelDictationDriver.advisoryReason(for: .failed(.zeroSignal)) == .zeroSignal)
     #expect(
       KernelDictationDriver.advisoryReason(for: .noSpeech(.vadGate)) == .vadGateNoSpeech)
+    // #1923/#1925: zero buffers for the whole session is the same shape, just
+    // a different producer — own case to preserve its own telemetry identity
+    // (§ PipelineStateChangePlanner), same shared sentence.
+    #expect(KernelDictationDriver.advisoryReason(for: .noTransport) == .noTransport)
 
     // NEGATIVE — a working microphone and a user who said nothing. These stay
     // SILENT by founder ruling: they already know they did not speak.
     #expect(KernelDictationDriver.advisoryReason(for: .noSpeech(.asrEmptyNoSpeech)) == nil)
     // #1920: audio WAS arriving above every dead-air floor and the engine ran
-    // clean, so there is nothing to tell the user to check. The two advisories
-    // above stay the only ones, and they are the genuinely-absent-audio cases.
+    // clean, so there is nothing to tell the user to check. The three advisories
+    // above stay the only ones, and they are the genuinely absent-audio cases.
     #expect(KernelDictationDriver.advisoryReason(for: .asrEmptyDespiteAudio) == nil)
     #expect(KernelDictationDriver.advisoryReason(for: .noSpeech(.emptyAfterProcessing)) == nil)
 
@@ -50,12 +54,11 @@ import Testing
     #expect(KernelDictationDriver.advisoryReason(for: .cancelled) == nil)
     #expect(KernelDictationDriver.advisoryReason(for: .discarded(.tooShort)) == nil)
     #expect(KernelDictationDriver.advisoryReason(for: .discarded(.releasedBeforeRecording)) == nil)
-    #expect(KernelDictationDriver.advisoryReason(for: .noTransport) == nil)
   }
 
   // MARK: - The copy
 
-  @Test("the seventh sentence is byte-exact and shared by both reasons")
+  @Test("the seventh sentence is byte-exact and shared by all advisory reasons")
   func seventhSentenceIsFrozen() {
     let expected =
       "Audio isn't capturing. Your lid may be closed, your headset muted, or there may be a hardware issue. Please check your microphone settings."


### PR DESCRIPTION
## Summary

Two related bugs in the recording-failure messages.

- #1925: a start-path safety check could silently overwrite an already-correct "check your mic" message with a generic "Audio capture error." Fixed by making that check recognize any real recording outcome instead of only recognizing errors.
- #1923 (case 1 only): a session that received zero audio the whole time showed "Transcription error. Try again." instead of the existing "check your mic" message. Routed to that message now, via its own internal tracking code so it doesn't merge into an unrelated metric already being tracked.

#1923's other case (a crash mid-recording showing "Transcription error") was investigated and declined by founder decision — that message is correct as-is for that case.

Full plan, grounding, and four rounds of independent review: `docs/feature-requests/issue-1923-1925-2026-08-04-terminal-notice-misrouting.md` (local, not in this diff).

## Test plan
- [x] Full local suite: 4,747 tests, 0 failures
- [x] Independent code-diff review (codex-run exec, read-only) — clean after two documentation-accuracy fixes
- [x] Two architecture ceiling limits bumped with justification (RecordingStarter gained one small, directly-tested pure function)
- [ ] Cloud review gate (auto)
- [ ] Live UAT on the ASR-interruption case and the zero-signal regression check (unrelated case 2 declined, so no asrInterrupted UAT needed for THIS diff)