### PR TITLE
feat(services): name which terminal guard refused, and what each read cost

### DIFF
--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -600,11 +600,19 @@ struct KernelFinalizationWiring {
         // rounds of guessing during founder testing on 2026-07-26. Names and
         // shapes only, never a word of the document, so this respects the same
         // privacy boundary the telemetry does.
+        // The per-step timings ride the SAME line, because the question they
+        // answer is always "why did THIS outcome happen". Split across two
+        // lines they would have to be correlated by timestamp, which is exactly
+        // the reconstruction that made the 2026-08-04 breaker trip
+        // undiagnosable. Empty when no bounded step ran, so a non-terminal app
+        // does not gain a dangling ` timing=` on every dictation.
+        let terminalTiming = terminalBudget.timingDescription
         await AppLogger.shared.log(
           "CURSOR_REPAIR app=\(context.targetApp?.bundleIdentifier ?? "nil") "
             + "caret=\(outcome.caretContextOutcome ?? "nil") "
             + "rules=\(outcome.repairRules ?? "none") "
-            + "candidate=\(payloads.repairedText == nil ? "none" : "offered")",
+            + "candidate=\(payloads.repairedText == nil ? "none" : "offered")"
+            + (terminalTiming.isEmpty ? "" : " timing=[\(terminalTiming)]"),
           level: .info, category: "KernelFinalizationWiring")
 
         // The legacy payload is what a route falls back to; §6 decides per route

--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -637,6 +637,35 @@ struct KernelFinalizationWiring {
             restoreClipboardAfterPaste: config?.restoreClipboardAfterPaste ?? false,
             terminalBudget: terminalBudget))
         pasteResult = result
+
+        // WHICH payload actually went to the app, which `CURSOR_REPAIR` cannot
+        // say because it is logged before the write happens.
+        //
+        // This is the gap that made the founder's original report
+        // undiagnosable: the repair can decide `lowercased_first`, offer a
+        // candidate, and the route can still commit the LEGACY text because
+        // `payloadAtCommitBoundary` re-reads the caret and refuses when
+        // anything changed. From the log alone those two outcomes were
+        // indistinguishable — both showed `candidate=offered` and the user saw
+        // the capital survive.
+        //
+        // A second line rather than a field on the first, only because the fact
+        // does not exist until after the write. `tier` rides along so the two
+        // can be matched without a timestamp join.
+        // The FULL budget spend, which `CURSOR_REPAIR` structurally cannot show:
+        // that line is written before the paste, and the commit-boundary
+        // re-check runs after the target app is activated. On 2026-08-04 the
+        // repair line reported a healthy 1.6 ms and the breaker tripped anyway,
+        // because the whole overspend lived in the half no line covered.
+        //
+        // Everything before `|recheck|` was already on the repair line; the
+        // suffix is new, and the total is what the 100 ms cap is judged against.
+        await AppLogger.shared.log(
+          "CURSOR_COMMIT submitted=\(result.submittedPayload?.rawValue ?? "none") "
+            + "tier=\(result.pasteTierLabel ?? "none") "
+            + "timing=[\(terminalBudget.timingDescription)]",
+          level: .info, category: "KernelFinalizationWiring")
+
         if case .delivered = result.outcome {
           // The text that actually LANDED, which is not always the one this
           // closure passed in: a route may have committed the contextual

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -745,7 +745,7 @@ public enum PasteService {
     // Cloud review found it; the discipline already existed one function away.
     guard
       let fresh = budget.step(
-        applying: element,
+        applying: element, label: "focused",
         {
           freshFocusedElement(matching: element, messagingTimeout: max(0.005, budget.remaining))
         })
@@ -757,7 +757,9 @@ public enum PasteService {
     let dependencies = TerminalContextResolver.Dependencies(
       bundleIdentifier: { NSRunningApplication(processIdentifier: pid)?.bundleIdentifier },
       scanProcesses: { TerminalProcessScanner.liveSnapshot() },
-      readScreenTail: { budget.step(applying: fresh) { terminalScreenTail(of: fresh) } })
+      readScreenTail: {
+        budget.step(applying: fresh, label: "screen") { terminalScreenTail(of: fresh) }
+      })
 
     // The typed refusal is REPORTED, not discarded. §8 of the plan lists eight
     // distinct outcomes, and cloud review found every one of them collapsing
@@ -890,38 +892,42 @@ public enum PasteService {
     budget: TerminalResolutionBudget? = nil
   ) -> CaretContext? {
     // One helper, so no read can be added later that forgets to be counted.
-    func bounded<T>(_ body: () -> T) -> T {
+    func bounded<T>(_ label: String, _ body: () -> T) -> T {
       guard let budget else { return body() }
-      return budget.step(applying: element, body)
+      return budget.step(applying: element, label: label, body)
     }
 
     guard
-      let fresh = bounded({
-        freshFocusedElement(
-          matching: element,
-          messagingTimeout: budget.map { max(0.005, $0.remaining) } ?? axMessagingTimeoutSeconds)
-      })
+      let fresh = bounded(
+        "focused",
+        {
+          freshFocusedElement(
+            matching: element,
+            messagingTimeout: budget.map { max(0.005, $0.remaining) } ?? axMessagingTimeoutSeconds)
+        })
     else { return nil }
 
     // Role is read from the FRESH element, never the captured handle.
     var roleRef: CFTypeRef?
     guard
-      bounded({
-        AXUIElementCopyAttributeValue(fresh, kAXRoleAttribute as CFString, &roleRef)
-      }) == .success,
+      bounded(
+        "role", { AXUIElementCopyAttributeValue(fresh, kAXRoleAttribute as CFString, &roleRef) })
+        == .success,
       let role = roleRef as? String, textRoles.contains(role)
     else { return nil }
 
     var countRef: CFTypeRef?
     guard
-      bounded({
-        AXUIElementCopyAttributeValue(
-          fresh, kAXNumberOfCharactersAttribute as CFString, &countRef)
-      }) == .success,
+      bounded(
+        "count",
+        {
+          AXUIElementCopyAttributeValue(
+            fresh, kAXNumberOfCharactersAttribute as CFString, &countRef)
+        }) == .success,
       let characterCount = countRef as? Int
     else { return nil }
 
-    guard let range = bounded({ selectedRange(of: fresh) }) else { return nil }
+    guard let range = bounded("range", { selectedRange(of: fresh) }) else { return nil }
 
     return assembleCaretContext(
       characterCount: characterCount,
@@ -929,7 +935,7 @@ public enum PasteService {
       selectionLength: range.length,
       window: window,
       readRange: { location, length in
-        bounded { string(of: fresh, at: location, length: length) }
+        bounded("range_read", { string(of: fresh, at: location, length: length) })
       })
   }
 

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -645,6 +645,11 @@ public enum PasteService {
   ) -> Bool {
     // The SAME budget as the initial read, so resolution plus every commit check
     // share one cumulative per-delivery bound rather than one bound each.
+    //
+    // Marked so the trace says WHICH phase spent the budget. This one runs after
+    // the target app has been activated, which the initial read does not, and it
+    // was invisible until now because `CURSOR_REPAIR` is logged before the paste.
+    terminalBudget?.mark("recheck")
     guard let fresh = readCaretContext(element: element, terminalBudget: terminalBudget) else {
       return false
     }

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -855,8 +855,11 @@ public enum PasteService {
     var context = caretDerivedContext(
       element: element, window: window, budget: terminalBudget)
 
+    // `nil` label and zero cost: every read inside `caretDerivedContext` already
+    // recorded itself through `budget.step`, so this is an exhaustion CHECK and
+    // not a cost. Labelling it would add a phantom zero-cost entry to the trace.
     if TerminalContextResolver.overspent(
-      by: 0, budget: terminalBudget, breaker: terminalBreaker, pid: targetPID)
+      by: 0, label: nil, budget: terminalBudget, breaker: terminalBreaker, pid: targetPID)
     {
       // Path 3. Whatever came back arrived too late to spend more time on.
       onTerminalRefusal?(.deadline)

--- a/Sources/EnviousWisprServices/TerminalContextResolver.swift
+++ b/Sources/EnviousWisprServices/TerminalContextResolver.swift
@@ -1,5 +1,6 @@
 import ApplicationServices
 import Darwin
+import EnviousWisprCore
 import Foundation
 import os
 
@@ -81,7 +82,8 @@ package final class TerminalResolutionBudget: Sendable {
   ///
   /// Metadata only — a label and a duration. Never screen text, a path, or the
   /// derived line, which is the same boundary `TerminalContextRefusal` keeps.
-  private let trace = OSAllocatedUnfairLock(initialState: [(label: String, seconds: Double)]())
+  private let trace = OSAllocatedUnfairLock(
+    initialState: [(label: String, seconds: Double, isMark: Bool)]())
 
   /// `now` reads a monotonic clock in seconds. It exists so `step` can be
   /// tested against a clock the test drives, matching how the resolver already
@@ -135,20 +137,34 @@ package final class TerminalResolutionBudget: Sendable {
       // Two separate locks, never nested: `charge` has already returned.
       // Recording is a plain array append under an uncontended lock with no
       // suspension point, so this cannot widen the window it measures.
-      trace.withLock { $0.append((label, elapsed)) }
+      trace.withLock { $0.append((label, elapsed, false)) }
     }
     return body()
   }
 
+  /// Note a PHASE boundary in the trace. Costs nothing and charges nothing.
+  ///
+  /// The commit-boundary re-check calls the same read path as the initial
+  /// resolution, so its steps carry the same labels and land in the same trace.
+  /// Without a separator the line reads as one long run of duplicated names and
+  /// the reader cannot tell which phase spent the budget — which matters here
+  /// precisely because the re-check runs AFTER the target app is activated and
+  /// is the half we could not previously see.
+  package func mark(_ label: String) {
+    trace.withLock { $0.append((label, 0, true)) }
+  }
+
   /// The per-step costs, for one log line. Empty when no step ran.
   ///
-  /// Reads as `focused=0.4ms scan=1.1ms screen=0.2ms total=1.7ms`, which is
-  /// what makes a trip diagnosable: the total says the cap was hit, the labels
-  /// say which call ate it.
+  /// Reads as `focused=0.4ms screen=0.2ms |recheck| focused=97.1ms total=97.7ms`,
+  /// which is what makes a trip diagnosable: the total says the cap was hit, the
+  /// labels say which call ate it, and the marker says in which phase.
   package var timingDescription: String {
     let samples = trace.withLock { $0 }
-    guard !samples.isEmpty else { return "" }
-    let parts = samples.map { "\($0.label)=\(String(format: "%.1f", $0.seconds * 1000))ms" }
+    guard samples.contains(where: { !$0.isMark }) else { return "" }
+    let parts = samples.map {
+      $0.isMark ? "|\($0.label)|" : "\($0.label)=\(String(format: "%.1f", $0.seconds * 1000))ms"
+    }
     let total = samples.reduce(0.0) { $0 + $1.seconds }
     return parts.joined(separator: " ") + " total=\(String(format: "%.1f", total * 1000))ms"
   }
@@ -328,7 +344,25 @@ package enum TerminalContextResolver {
     }
 
     guard let tail else { return .refused(.screenUnreadable) }
-    guard let located = TerminalScreenParser.locate(inScreenTail: tail) else {
+    let located: TerminalScreenParser.Located
+    switch TerminalScreenParser.locateDetailed(inScreenTail: tail) {
+    case .located(let found):
+      located = found
+    case .refused(let detail):
+      // WHICH guard refused. `screenRefused` is one telemetry value covering ten
+      // structurally different outcomes, and that collapse is why a live field
+      // failure could not be diagnosed on 2026-08-04.
+      //
+      // Logged rather than threaded into `TerminalContextRefusal`, because that
+      // enum's raw values are a shipped closed set read by telemetry, and
+      // widening it to carry a parser detail would change what those values
+      // mean. Closed-set names only; nothing here can carry screen content.
+      Task {
+        await AppLogger.shared.log(
+          "TERMINAL_PARSE refused codex=\(detail.codex.rawValue) "
+            + "boxed=\(detail.boxed.telemetryName)",
+          level: .info, category: "TerminalContextResolver")
+      }
       return .refused(.screenRefused)
     }
 

--- a/Sources/EnviousWisprServices/TerminalContextResolver.swift
+++ b/Sources/EnviousWisprServices/TerminalContextResolver.swift
@@ -70,6 +70,19 @@ package final class TerminalResolutionBudget: Sendable {
   private let spent = OSAllocatedUnfairLock(initialState: 0.0)
   private let now: @Sendable () -> Double
 
+  /// What each bounded step actually cost, for the log line.
+  ///
+  /// The budget was previously unobservable: it charged itself, tripped the
+  /// breaker on exhaustion, and recorded nothing about WHICH step spent the
+  /// time or how much. When the breaker fired in the field on 2026-08-04 there
+  /// was no way to answer "why did a read that measures ~1 ms take over 100?"
+  /// from the logs, and three separate hypotheses had to be tested by hand
+  /// against a live machine, all three wrong.
+  ///
+  /// Metadata only — a label and a duration. Never screen text, a path, or the
+  /// derived line, which is the same boundary `TerminalContextRefusal` keeps.
+  private let trace = OSAllocatedUnfairLock(initialState: [(label: String, seconds: Double)]())
+
   /// `now` reads a monotonic clock in seconds. It exists so `step` can be
   /// tested against a clock the test drives, matching how the resolver already
   /// takes `Dependencies.now` — an assertion about cumulative charging must not
@@ -109,12 +122,35 @@ package final class TerminalResolutionBudget: Sendable {
   /// 1.79 ms in iTerm2, with the only spikes (19-35 ms) on a cold first call.
   /// The cap is roughly fifty times the typical cost and three times the worst
   /// observed — it exists to bound a wedge, and never bites healthy work.
-  package func step<T>(applying element: AXUIElement, _ body: () -> T) -> T {
+  /// - Parameter label: names this step in the timing trace. Required rather
+  ///   than defaulted, so a new bounded step cannot silently appear in the log
+  ///   as an anonymous cost.
+  package func step<T>(applying element: AXUIElement, label: String, _ body: () -> T) -> T {
     let application = AXUIElementCreateApplication(processIdentifier(of: element))
     AXUIElementSetMessagingTimeout(application, Float(max(0.005, remaining)))
     let started = now()
-    defer { charge(now() - started) }
+    defer {
+      let elapsed = now() - started
+      charge(elapsed)
+      // Two separate locks, never nested: `charge` has already returned.
+      // Recording is a plain array append under an uncontended lock with no
+      // suspension point, so this cannot widen the window it measures.
+      trace.withLock { $0.append((label, elapsed)) }
+    }
     return body()
+  }
+
+  /// The per-step costs, for one log line. Empty when no step ran.
+  ///
+  /// Reads as `focused=0.4ms scan=1.1ms screen=0.2ms total=1.7ms`, which is
+  /// what makes a trip diagnosable: the total says the cap was hit, the labels
+  /// say which call ate it.
+  package var timingDescription: String {
+    let samples = trace.withLock { $0 }
+    guard !samples.isEmpty else { return "" }
+    let parts = samples.map { "\($0.label)=\(String(format: "%.1f", $0.seconds * 1000))ms" }
+    let total = samples.reduce(0.0) { $0 + $1.seconds }
+    return parts.joined(separator: " ") + " total=\(String(format: "%.1f", total * 1000))ms"
   }
 
   private func processIdentifier(of element: AXUIElement) -> pid_t {

--- a/Sources/EnviousWisprServices/TerminalContextResolver.swift
+++ b/Sources/EnviousWisprServices/TerminalContextResolver.swift
@@ -107,8 +107,21 @@ package final class TerminalResolutionBudget: Sendable {
   package var isExhausted: Bool { remaining <= 0 }
 
   /// Charge the time a step made the caller wait.
-  package func charge(_ seconds: Double) {
+  ///
+  /// Charging and RECORDING are one call, so a cost cannot reach the budget
+  /// without also reaching the trace unless a caller says so explicitly. Cloud
+  /// review found exactly that gap: the process scan was charged and recorded
+  /// nowhere, so a scan that ate 90 ms printed `total=1.0ms` — the line would
+  /// have been at its most misleading in the one case it exists to explain. A
+  /// log line carries the same evidence burden as a comment.
+  ///
+  /// Pass `nil` ONLY where the cost is already recorded by `step`, which is the
+  /// screen read: charging it a second time from the caller would double-count
+  /// it and halve the effective budget.
+  package func charge(_ seconds: Double, label: String?) {
     spent.withLock { $0 += max(0, seconds) }
+    guard let label else { return }
+    trace.withLock { $0.append((label, max(0, seconds), false)) }
   }
 
   /// Run one bounded step: apply the remaining budget as the accessibility
@@ -132,12 +145,14 @@ package final class TerminalResolutionBudget: Sendable {
     AXUIElementSetMessagingTimeout(application, Float(max(0.005, remaining)))
     let started = now()
     defer {
-      let elapsed = now() - started
-      charge(elapsed)
-      // Two separate locks, never nested: `charge` has already returned.
-      // Recording is a plain array append under an uncontended lock with no
-      // suspension point, so this cannot widen the window it measures.
-      trace.withLock { $0.append((label, elapsed, false)) }
+      // ONE call. `charge` both charges and records, so the separate
+      // `trace.append` this used to make alongside it would enter every step
+      // twice and double the printed total.
+      //
+      // Two separate locks inside `charge`, never nested: recording is a plain
+      // array append under an uncontended lock with no suspension point, so it
+      // cannot widen the window it measures.
+      charge(now() - started, label: label)
     }
     return body()
   }
@@ -273,13 +288,17 @@ package enum TerminalContextResolver {
   /// documented, and inert — a wedged terminal would have repeated its delay on
   /// every single dictation forever. Tests that only trip it by hand cannot
   /// catch that; this is the one place the product itself does.
+  /// - Parameter label: names this cost in the timing trace, or `nil` when the
+  ///   cost was already recorded by `budget.step` and charging it again here
+  ///   would double-count it.
   static func overspent(
     by elapsed: Double,
+    label: String?,
     budget: TerminalResolutionBudget,
     breaker: TerminalCircuitBreaker,
     pid: pid_t
   ) -> Bool {
-    budget.charge(elapsed)
+    budget.charge(elapsed, label: label)
     guard budget.isExhausted else { return false }
     breaker.trip(for: pid)
     return true
@@ -315,7 +334,8 @@ package enum TerminalContextResolver {
     let scanStart = dependencies.now()
     let scan = dependencies.scanProcesses()
     if overspent(
-      by: dependencies.now() - scanStart, budget: budget, breaker: breaker, pid: targetPID)
+      by: dependencies.now() - scanStart, label: "scan", budget: budget, breaker: breaker,
+      pid: targetPID)
     {
       return .refused(.deadline)
     }
@@ -336,7 +356,9 @@ package enum TerminalContextResolver {
     // cumulative. Timing it again from out here would double-count it and
     // halve the effective budget.
     let tail = dependencies.readScreenTail()
-    if overspent(by: 0, budget: budget, breaker: breaker, pid: targetPID) {
+    // `nil` label and zero cost: `budget.step` already recorded the read under
+    // `screen`. This call exists only to re-test exhaustion after it.
+    if overspent(by: 0, label: nil, budget: budget, breaker: breaker, pid: targetPID) {
       // The evidence may well be complete, and it is discarded anyway. A result
       // that arrived after the deadline is a result the user already waited too
       // long for, and accepting it would make the promised bound meaningless.

--- a/Sources/EnviousWisprServices/TerminalScreenParser.swift
+++ b/Sources/EnviousWisprServices/TerminalScreenParser.swift
@@ -136,14 +136,93 @@ package enum TerminalScreenParser {
   /// Refusals ARE the feature. A wrapped box, an empty box, a stale box, an
   /// unrecognised layout and a bare shell all return nil, and the user gets
   /// today's behaviour unchanged.
+  /// The existing shape, kept because thirty-five tests encode the behaviour
+  /// contract through it and this change is diagnostic, not behavioural.
+  ///
+  /// DELEGATES rather than re-deciding: a second copy of the matching rules
+  /// could drift from the first, and then the log would describe a decision the
+  /// product did not make.
   package static func locate(inScreenTail tail: String) -> Located? {
+    if case .located(let found) = locateDetailed(inScreenTail: tail) { return found }
+    return nil
+  }
+
+  /// The same decision, carrying WHY it refused.
+  package static func locateDetailed(inScreenTail tail: String) -> LocateResult {
     let rows = tail.split(separator: "\n", omittingEmptySubsequences: false)
 
     // Codex first: it draws NO box, so the box search cannot find it, and its
     // status bar sits below the input. Anchoring on "the last non-empty row"
     // was measured to return `weekly 63% left` from that status bar.
-    if let located = locateCodex(rows) { return located }
-    return locateBoxed(rows)
+    switch locateCodex(rows) {
+    case .located(let located): return .located(located)
+    case .refused(let codexRefusal):
+      switch locateBoxed(rows) {
+      case .located(let located): return .located(located)
+      case .refused(let boxedRefusal):
+        // BOTH routes, deliberately. Every normal Claude Code screen fails the
+        // Codex probe first, so logging that refusal alone would report
+        // `no_opening_marker` on every dictation and send the next reader
+        // chasing the wrong layout entirely.
+        return .refused(Refusal(codex: codexRefusal, boxed: boxedRefusal))
+      }
+    }
+  }
+
+  // MARK: - Typed refusals
+  //
+  // `locate` returned a bare `nil` for ten structurally different reasons, and
+  // the caller collapsed all of them into one telemetry value. That discarded
+  // the only evidence that could explain a field failure: on 2026-08-04 three
+  // of four dictations refused here in under a millisecond, and no amount of
+  // reading could say which guard fired. Three hypotheses were tested by hand
+  // and all three were wrong.
+  //
+  // Closed-set names only. Never the screen, the input text, the marker-adjacent
+  // text, or any row's contents — the same boundary `TerminalContextRefusal`
+  // keeps.
+
+  package enum CodexRefusal: String, Sendable {
+    case noOpeningMarker = "codex:no_opening_marker"
+    case tooManyPopulatedRowsBelow = "codex:too_many_populated_rows_below"
+    case livePromptBelow = "codex:live_prompt_below"
+    case emptyInput = "codex:empty_input"
+  }
+
+  package enum BoxedRefusal: Sendable {
+    case fewerThanTwoBoundaries
+    case incompatibleBoundaries
+    case populatedBodyRows(Int)
+    case livePromptBelow
+    case wrongOpeningMarker
+    case emptyInput
+
+    package var telemetryName: String {
+      switch self {
+      case .fewerThanTwoBoundaries: return "boxed:fewer_than_two_boundaries"
+      case .incompatibleBoundaries: return "boxed:incompatible_boundaries"
+      case .populatedBodyRows(let count):
+        // The COUNT distinguishes an empty box from a wrapped one, which is the
+        // whole question. It is a small non-negative integer describing screen
+        // STRUCTURE, never content.
+        return count == 0
+          ? "boxed:zero_populated_body_rows"
+          : "boxed:multiple_populated_body_rows(\(count))"
+      case .livePromptBelow: return "boxed:live_prompt_below"
+      case .wrongOpeningMarker: return "boxed:wrong_opening_marker"
+      case .emptyInput: return "boxed:empty_input"
+      }
+    }
+  }
+
+  package struct Refusal: Sendable {
+    package let codex: CodexRefusal
+    package let boxed: BoxedRefusal
+  }
+
+  package enum LocateResult: Sendable {
+    case located(Located)
+    case refused(Refusal)
   }
 
   // MARK: - Codex
@@ -154,42 +233,51 @@ package enum TerminalScreenParser {
   /// "Opens" is load-bearing. A row that merely CONTAINS the marker — a footer
   /// reading `Press › to continue` — is not input, and requiring the marker to
   /// start the row is what separates them.
-  static func locateCodex(_ rows: [Substring]) -> Located? {
+  static func locateCodex(_ rows: [Substring]) -> CodexLocateResult {
     guard
       let index = rows.indices.last(where: { openingCharacter(of: rows[$0]) == codexMarker })
-    else { return nil }
+    else { return .refused(.noOpeningMarker) }
 
     let populatedBelow = rows[(index + 1)...].filter { !isBlank($0) }.count
-    guard populatedBelow <= 2 else { return nil }
+    guard populatedBelow <= 2 else { return .refused(.tooManyPopulatedRowsBelow) }
     // Same staleness rule as the boxed layouts: a live shell prompt below means
     // Codex has exited and this row is history.
-    guard !aLivePromptSits(below: index, in: rows) else { return nil }
+    guard !aLivePromptSits(below: index, in: rows) else { return .refused(.livePromptBelow) }
 
     let line = stripLeadingMarker(rows[index], codexMarker)
-    guard !line.trimmingCharacters(in: .whitespaces).isEmpty else { return nil }
-    return Located(cli: .codex, inputLine: line)
+    guard !line.trimmingCharacters(in: .whitespaces).isEmpty else { return .refused(.emptyInput) }
+    return .located(Located(cli: .codex, inputLine: line))
+  }
+
+  enum CodexLocateResult {
+    case located(Located)
+    case refused(CodexRefusal)
   }
 
   // MARK: - Boxed layouts
 
   /// Claude Code and Gemini both draw a box; the RULE GLYPH tells them apart.
-  static func locateBoxed(_ rows: [Substring]) -> Located? {
+  static func locateBoxed(_ rows: [Substring]) -> BoxedLocateResult {
     let boundaries = rows.indices.compactMap { index -> (Int, BoundaryClass)? in
       boundaryClass(of: rows[index]).map { (index, $0) }
     }
-    guard boundaries.count >= 2 else { return nil }
+    guard boundaries.count >= 2 else { return .refused(.fewerThanTwoBoundaries) }
 
     let closing = boundaries[boundaries.count - 1]
     let opening = boundaries[boundaries.count - 2]
     // Both rules must be the same kind of box.
-    guard opening.1 == closing.1, closing.0 > opening.0 + 1 else { return nil }
+    guard opening.1 == closing.1, closing.0 > opening.0 + 1 else {
+      return .refused(.incompatibleBoundaries)
+    }
 
     let body = rows[(opening.0 + 1)..<closing.0].filter { !isBlank($0) }
     // More than one populated row means the input wrapped, and joining screen
     // rows reconstructs different text — a soft wrap can fall mid-word.
-    guard body.count == 1, let row = body.first else { return nil }
+    guard body.count == 1, let row = body.first else {
+      return .refused(.populatedBodyRows(body.count))
+    }
 
-    guard !aLivePromptSits(below: closing.0, in: rows) else { return nil }
+    guard !aLivePromptSits(below: closing.0, in: rows) else { return .refused(.livePromptBelow) }
 
     let cli: SupportedTerminalCLI = closing.1 == .block ? .geminiCLI : .claudeCode
     let marker = closing.1 == .block ? geminiMarker : claudeMarker
@@ -203,13 +291,18 @@ package enum TerminalScreenParser {
     // it at no cost. A faithful spoof that reproduces the marker still passes,
     // which is exactly why Gate 1 remains the authority; closing an instance is
     // not a claim to have closed the class.
-    guard openingCharacter(of: row) == marker else { return nil }
+    guard openingCharacter(of: row) == marker else { return .refused(.wrongOpeningMarker) }
 
     let line = stripLeadingMarker(row, marker)
     // An EMPTY box refuses. The prototype's exact failure was reading an empty
     // box back as the hint text printed below it, which would delete words
     // nobody typed.
-    guard !line.trimmingCharacters(in: .whitespaces).isEmpty else { return nil }
-    return Located(cli: cli, inputLine: line)
+    guard !line.trimmingCharacters(in: .whitespaces).isEmpty else { return .refused(.emptyInput) }
+    return .located(Located(cli: cli, inputLine: line))
+  }
+
+  enum BoxedLocateResult {
+    case located(Located)
+    case refused(BoxedRefusal)
   }
 }

--- a/Tests/EnviousWisprTests/Services/TerminalContextResolverTests.swift
+++ b/Tests/EnviousWisprTests/Services/TerminalContextResolverTests.swift
@@ -263,7 +263,7 @@ struct TerminalContextResolverTests {
 
     let shared = TerminalResolutionBudget(total: 1.0, now: { clock.read() })
     var calls = 0
-    for _ in 0..<3 { _ = shared.step(applying: element) { calls += 1 } }
+    for _ in 0..<3 { _ = shared.step(applying: element, label: "probe") { calls += 1 } }
 
     #expect(calls == 3)
     // THE POINT. Cumulative charges all three: 0.090. A per-call bound retains
@@ -274,7 +274,7 @@ struct TerminalContextResolverTests {
     // between them while neither does alone, so exhaustion is reachable only by
     // accumulating — a per-call bound would sit at 30 ms and stay open.
     let tight = TerminalResolutionBudget(total: 0.040, now: { clock.read() })
-    for _ in 0..<2 { _ = tight.step(applying: element) {} }
+    for _ in 0..<2 { _ = tight.step(applying: element, label: "probe") {} }
 
     #expect(tight.isExhausted, "two 30 ms calls must exhaust a 40 ms cumulative cap")
     #expect(tight.remaining == 0)
@@ -296,12 +296,46 @@ struct TerminalContextResolverTests {
     let budget = TerminalResolutionBudget(total: 0.100, now: { clock.read() })
     let element = AXUIElementCreateSystemWide()
 
-    for _ in 0..<5 { _ = budget.step(applying: element) {} }
+    for _ in 0..<5 { _ = budget.step(applying: element, label: "probe") {} }
 
     #expect(!budget.isExhausted, "five healthy calls must not exhaust the cap")
     #expect(
       budget.remaining > 0.090,
       "five healthy calls must leave the budget nearly whole")
+  }
+
+  @Test("the budget records what each step cost, named, for the log line")
+  func timingDescriptionNamesEachStep() {
+    // The breaker trip on 2026-08-04 was undiagnosable because the budget
+    // charged itself and recorded nothing. Three hypotheses were tested by hand
+    // against a live machine and all three were wrong. This is the line that
+    // makes the next trip answerable from the log alone.
+    let clock = TestClock()
+    clock.perCallCost = 0.002
+    let budget = TerminalResolutionBudget(total: 0.100, now: { clock.read() })
+    let element = AXUIElementCreateSystemWide()
+
+    #expect(
+      budget.timingDescription.isEmpty,
+      "no step ran, so the line must carry nothing rather than an empty bracket")
+
+    _ = budget.step(applying: element, label: "focused") {}
+    _ = budget.step(applying: element, label: "screen") {}
+
+    let description = budget.timingDescription
+    #expect(description.contains("focused="), "each step is named, got \(description)")
+    #expect(description.contains("screen="), "each step is named, got \(description)")
+    #expect(description.contains("total="), "and the total is what the cap is judged against")
+
+    // The point of the line is that the numbers are REAL, not that they exist.
+    // A description that renders every step as 0.0ms would satisfy `contains`
+    // and diagnose nothing, which is the failure mode this asserts against.
+    #expect(
+      description.contains("2.0ms"),
+      "the recorded cost must be the driven clock's, got \(description)")
+    #expect(
+      description.contains("total=4.0ms"),
+      "and the total must be their sum, got \(description)")
   }
 
   // MARK: - Circuit breaker

--- a/Tests/EnviousWisprTests/Services/TerminalContextResolverTests.swift
+++ b/Tests/EnviousWisprTests/Services/TerminalContextResolverTests.swift
@@ -200,7 +200,7 @@ struct TerminalContextResolverTests {
       readScreenTail: { Self.claudeScreen })
 
     let budget = TerminalResolutionBudget(total: 0.100)
-    budget.charge(0.100)
+    budget.charge(0.100, label: "probe")
     #expect(resolve(dependencies, budget: budget) == .refused(.deadline))
     #expect(!scanned.wasRaised)
   }
@@ -227,13 +227,13 @@ struct TerminalContextResolverTests {
   func budgetAccounting() {
     let budget = TerminalResolutionBudget(total: 0.100)
     #expect(budget.remaining == 0.100)
-    budget.charge(0.040)
+    budget.charge(0.040, label: "probe")
     #expect(abs(budget.remaining - 0.060) < 0.0001)
-    budget.charge(0.500)
+    budget.charge(0.500, label: "probe")
     #expect(budget.remaining == 0)
     #expect(budget.isExhausted)
     // A negative charge cannot buy time back.
-    budget.charge(-1.0)
+    budget.charge(-1.0, label: "probe")
     #expect(budget.isExhausted)
   }
 
@@ -349,6 +349,39 @@ struct TerminalContextResolverTests {
     #expect(
       withPhases.contains("total=6.0ms"),
       "the marker adds no time; only the third real step does, got \(withPhases)")
+  }
+
+  @Test("a cost charged OUTSIDE an accessibility step still reaches the total")
+  func nonAccessibilityCostsAreInTheTotal() {
+    // Cloud review's finding, frozen. The process sweep is not an accessibility
+    // call, so nothing else charges it — `resolve` times it by hand and charges
+    // the shared budget directly. It was recorded NOWHERE, so a sweep that ate
+    // 90 ms of the 100 ms cap printed `total=1.0ms`: the line would have been at
+    // its most misleading in exactly the case it exists to explain.
+    let clock = TestClock()
+    clock.perCallCost = 0.002
+    let budget = TerminalResolutionBudget(total: 0.100, now: { clock.read() })
+    let element = AXUIElementCreateSystemWide()
+
+    budget.charge(0.090, label: "scan")
+    _ = budget.step(applying: element, label: "screen") {}
+
+    let description = budget.timingDescription
+    #expect(description.contains("scan=90.0ms"), "named and real, got \(description)")
+    #expect(
+      description.contains("total=92.0ms"),
+      "the total must include it, got \(description)")
+
+    // Two-way control on the escape hatch: a cost the caller says is ALREADY
+    // recorded must not appear twice. `overspent(by: 0, label: nil, …)` runs on
+    // the screen-read path for exactly that reason, and a version that recorded
+    // anyway would double every step in the line.
+    budget.charge(0.005, label: nil)
+    let after = budget.timingDescription
+    #expect(
+      after == description,
+      "an unlabelled charge changes the budget, never the trace, got \(after)")
+    #expect(budget.remaining < 0.006, "but it IS charged")
   }
 
   // MARK: - Circuit breaker

--- a/Tests/EnviousWisprTests/Services/TerminalContextResolverTests.swift
+++ b/Tests/EnviousWisprTests/Services/TerminalContextResolverTests.swift
@@ -336,6 +336,19 @@ struct TerminalContextResolverTests {
     #expect(
       description.contains("total=4.0ms"),
       "and the total must be their sum, got \(description)")
+
+    // A phase marker separates the initial read from the commit-boundary
+    // re-check, which reuses the same labels. It must cost nothing: if a marker
+    // charged even a rounding error, the total the 100 ms cap is judged against
+    // would drift with the number of phases rather than with real work.
+    budget.mark("recheck")
+    _ = budget.step(applying: element, label: "focused") {}
+
+    let withPhases = budget.timingDescription
+    #expect(withPhases.contains("|recheck|"), "the phase boundary must be visible")
+    #expect(
+      withPhases.contains("total=6.0ms"),
+      "the marker adds no time; only the third real step does, got \(withPhases)")
   }
 
   // MARK: - Circuit breaker

--- a/Tests/EnviousWisprTests/Services/TerminalInsertionPolicyTests.swift
+++ b/Tests/EnviousWisprTests/Services/TerminalInsertionPolicyTests.swift
@@ -206,13 +206,13 @@ struct TerminalInsertionPolicyTests {
     // A nearly-spent budget still yields a usable, non-zero bound rather than
     // an instant-failure timeout.
     let spent = TerminalResolutionBudget(total: 0.100)
-    spent.charge(0.099)
+    spent.charge(0.099, label: "probe")
     #expect(spent.remaining > 0)
     #expect(max(0.010, min(spent.remaining, PasteService.axMessagingTimeoutSeconds)) >= 0.010)
 
     // An exhausted budget clamps to the floor, never to zero or a negative.
     let exhausted = TerminalResolutionBudget(total: 0.100)
-    exhausted.charge(1.0)
+    exhausted.charge(1.0, label: "probe")
     #expect(max(0.010, min(exhausted.remaining, PasteService.axMessagingTimeoutSeconds)) == 0.010)
   }
 

--- a/Tests/EnviousWisprTests/Services/TerminalScreenParserTests.swift
+++ b/Tests/EnviousWisprTests/Services/TerminalScreenParserTests.swift
@@ -87,6 +87,58 @@ struct TerminalScreenParserTests {
     #expect(TerminalScreenParser.locate(inScreenTail: wrapped) == nil)
   }
 
+  @Test("#1921 diagnosis: refusals name WHICH guard fired, on both routes")
+  func refusalsAreDistinguishable() {
+    // Every one of the ten guards reported the same word, which is why a live
+    // failure on 2026-08-04 could not be diagnosed at all: three hypotheses were
+    // tested by hand against the founder's machine and all three were wrong.
+    //
+    // Both routes are recorded deliberately. Every normal Claude Code screen
+    // fails the Codex probe first, so a line carrying only the Codex refusal
+    // would read `no_opening_marker` on every single dictation and point the
+    // next reader at the wrong layout entirely.
+    func refusal(_ tail: String) -> TerminalScreenParser.Refusal? {
+      if case .refused(let detail) = TerminalScreenParser.locateDetailed(inScreenTail: tail) {
+        return detail
+      }
+      return nil
+    }
+
+    let wrapped = """
+      \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
+      \u{276F} this line is long enough that it
+      wrapped onto a second row
+      \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
+      """
+    let wrappedRefusal = refusal(wrapped)
+    #expect(
+      wrappedRefusal?.boxed.telemetryName == "boxed:multiple_populated_body_rows(2)",
+      "a wrapped input must name the wrap and its row count")
+
+    // The distinction that matters most: an EMPTY box and a WRAPPED box both
+    // refused with the same word before this change, and they mean opposite
+    // things — nothing typed yet, versus too much typed.
+    //
+    // Corrected by this test failing: an empty box reports `empty_input`, not a
+    // zero row count, because the marker row `\u{276F} ` is not blank and so
+    // survives the body-count guard to be rejected later for having no text. I
+    // expected the row count; the code was right and the assumption was mine.
+    let emptyRefusal = refusal(Self.claudeBox(""))
+    #expect(
+      emptyRefusal?.boxed.telemetryName == "boxed:empty_input",
+      "an empty box must be distinguishable from a wrapped one")
+
+    // And the Codex probe is reported even when the boxed route is the one that
+    // decided, because that is the pair the log has to carry.
+    #expect(wrappedRefusal?.codex == .noOpeningMarker)
+
+    // Two-way control: a screen the parser ACCEPTS must not produce a refusal at
+    // all, or every assertion above passes for the wrong reason.
+    #expect(
+      refusal(Self.claudeBox("fix the")) == nil,
+      "a locatable box must not be reported as refused")
+  }
+
   @Test("An EMPTY box refuses, never reading back the hints printed below it")
   func emptyBoxRefuses() {
     // The prototype's exact failure: an untouched box read back as


### PR DESCRIPTION
Two diagnostics, each of which turned a dead end into an answer within one round of live testing on 2026-08-04. Neither changes behaviour.

### feat(services): record what each terminal read step cost, on the outcome line

The terminal resolution budget charged itself, tripped the circuit breaker on
exhaustion, and recorded nothing about WHICH step spent the time or how much.
So when the breaker fired on the founder's machine on 2026-08-04 there was no
way to answer "why did a read that measures ~1 ms take over 100?" from the
logs — not that day, and not for any of the trips before it.

Three hypotheses had to be tested by hand against the live machine, and all
three were wrong: the terminal answers its character count in 0.02 ms and
exposes only ~1,250 characters, walking all 646 running processes costs 1 ms,
and the range read is 0.02 ms. Total ~1 ms, matching the original measurement.
Whatever eats the budget is intermittent, and nothing in the build could say
what.

`TerminalResolutionBudget.step` now takes a required `label` and records the
elapsed time per step; `timingDescription` renders them for one log line, and
`CURSOR_REPAIR` carries it as `timing=[focused=0.4ms role=0.1ms count=0.1ms
screen=0.2ms total=0.8ms]`.

Three deliberate choices:

- **The label is required, not defaulted.** A bounded step added later cannot
  silently appear in the log as an anonymous cost.
- **Same line as the outcome, not its own.** The question these numbers answer
  is always "why did THIS outcome happen". On separate lines they would have to
  be correlated by timestamp, which is exactly the reconstruction that made the
  2026-08-04 trip undiagnosable.
- **Recording is not `#if DEBUG`.** The append is five tuples per dictation,
  far below the 100 ms noise floor, and leaving it unguarded is what lets this
  become a telemetry field later without re-plumbing the heart path. Only the
  log line is debug-only, because `AppLogger` already is.

Metadata only — a label and a duration. Never screen text, a path, or the
derived line, which is the boundary `TerminalContextRefusal` already keeps.

The test drives a fake clock at 2 ms per step and asserts the rendered line
says `2.0ms` and `total=4.0ms`, not merely that the names are present: a
version rendering every step as 0.0ms would satisfy a `contains` check and
diagnose nothing.

Tier: SMALL | Lane: Code | Modules: Services, Pipeline
Full suite: 4741 tests, zero failures.

Self-audit-grep: grep -rnE "bounded[ ]*[({]|\.step\(applying" Sources/ Tests/ — every call site labelled; the compiler is the exhaustive check here because the label is required, and it caught one site my first grep missed (it used the trailing-closure form)
Self-audit-owner: TerminalResolutionBudget.step is the single choke point every bounded terminal read already passes through; no second timing path added


### feat(services): name which parser guard refused, and log the committed payload

Three diagnostics, each of which turned a dead end into an answer within one
round of live testing on 2026-08-04.

**`TERMINAL_PARSE` — which guard refused.** `TerminalScreenParser.locate`
returned a bare `nil` for ten structurally different reasons and the caller
collapsed all of them into `terminal_screen_refused`. Three hypotheses had to be
tested by hand against a live machine and all three were wrong. `locateDetailed`
now returns a typed refusal per guard; `locate` keeps its old shape and DELEGATES
to it, so the thirty-five tests encoding the behaviour contract are untouched
and no second copy of the matching rules can drift from the first.

BOTH routes are recorded, which is not obvious and is load-bearing: every normal
Claude Code screen fails the Codex probe first, so a line carrying only that
refusal would read `no_opening_marker` on every dictation and send the reader
after the wrong layout entirely. Codex caught that in review before it shipped.

Within one test the log distinguished `boxed:fewer_than_two_boundaries` (the
input box caught mid-redraw) from `boxed:empty_input` (nothing typed) — two
outcomes that had been the same word for the feature's whole life.

**`CURSOR_COMMIT` — which payload was actually written.** `CURSOR_REPAIR` is
logged before the paste, so it can say a candidate was OFFERED and never whether
it was used. Both outcomes printed `candidate=offered` and the user saw the
capital survive either way. The first run carrying this line showed
`rules=lowercased_first ... submitted=legacy` and pinned the real defect, which
was fixed separately.

**The `|recheck|` phase marker.** The commit-boundary re-check reuses the same
read path, so its steps carry the same labels and land in the same trace. Worse,
the repair line is written BEFORE the re-check runs: on 2026-08-04 it reported a
healthy 1.6 ms while the breaker tripped anyway, because the whole overspend
lived in the half no line covered. The marker separates the phases and the
commit line now carries the full spend.

Metadata only throughout — labels, durations, and a small non-negative row
count describing screen STRUCTURE. Never screen text, a path, or the derived
line, which is the boundary `TerminalContextRefusal` already keeps.

Tests: the refusal test asserts the wrap and empty cases are DISTINGUISHABLE,
plus a two-way control that an acceptable screen produces no refusal at all. The
marker test asserts it costs nothing, so the total the 100 ms cap is judged
against cannot drift with the number of phases. One expectation in it was
corrected BY the test failing: an empty box reports `empty_input`, not a zero row
count, because the marker row is not blank. The code was right and the
assumption was mine.

Tier: SMALL | Lane: Code | Modules: Services, Pipeline
Full suite: 4768 tests, zero failures.

Self-audit-grep: grep -rn "TerminalScreenParser.locate|bounded[ ]*[({]" Sources/ Tests/ — every call site checked; the compiler is the exhaustive check for the required step label and caught one site an earlier grep missed
Self-audit-owner: TerminalScreenParser.locateDetailed is the single decision; locate delegates rather than re-deciding

