### PR TITLE
fix(services): read a wrapped terminal input from its last row instead of refusing

### DIFF
--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -457,14 +457,12 @@ struct KernelFinalizationWiring {
         let repairContext: CursorInsertionRepair.CaretText? = caretContext.map {
           CursorInsertionRepair.CaretText(
             left: $0.leftWindow, right: $0.rightWindow,
-            // The left window is cut to `caretContextWindow` units, and the
-            // string cannot say whether it was cut or simply began at the
-            // document's start. `assembleCaretContext` reads from
-            // `max(0, selectionLocation - window)`, so the window reached
-            // offset zero exactly when it is as long as the caret's offset.
-            // Without this the seam de-duplication refused every short field
-            // (#1803, local diff review).
-            leftReachesDocumentStart: $0.leftWindow.utf16.count == $0.selectionLocation,
+            // Read, not derived. This was `leftWindow.utf16.count ==
+            // selectionLocation`, which is exact for a real caret and vacuous
+            // for a terminal — both values come from the same string there, so
+            // EVERY screen-derived context claimed to reach the start, wrapped
+            // ones included. Each source now states the fact it alone knows.
+            leftReachesDocumentStart: $0.leftReachesDocumentStart,
             // The narrow policy fact the repair needs. A screen-derived line is
             // ONE rendered row, so a payload carrying a line break is refused
             // rather than reasoned about — in a terminal a newline can submit

--- a/Sources/EnviousWisprPostProcessing/CursorInsertionRepair.swift
+++ b/Sources/EnviousWisprPostProcessing/CursorInsertionRepair.swift
@@ -437,7 +437,8 @@ public enum CursorInsertionRepair {
       rules.append(.caseSkipped(.languageNotSupported))
     } else if continuing {
       let (adjusted, caseRule) = applyLeadingCase(
-        to: out, leftWindow: context.left, protectedWords: protectedWords, oracle: oracle)
+        to: out, leftWindow: context.left, isScreenDerived: context.isScreenDerived,
+        protectedWords: protectedWords, oracle: oracle)
       out = adjusted
       rules.append(caseRule)
     } else if left.character == nil {
@@ -541,6 +542,7 @@ public enum CursorInsertionRepair {
   private static func applyLeadingCase(
     to text: String,
     leftWindow: String,
+    isScreenDerived: Bool,
     protectedWords: Set<String>,
     oracle: EnglishWordOracle
   ) -> (String, AppliedRule) {
@@ -589,6 +591,37 @@ public enum CursorInsertionRepair {
     let taggerLeft = leftWindow + String(leadingWhitespace)
     if let refusal = oracle.mayLower(word: bare, left: taggerLeft, payload: String(stripped)) {
       return (text, .caseSkipped(refusal))
+    }
+
+    // A TERMINAL hides the trailing space, so the seam above may be a lie.
+    //
+    // A rendered row ends at its last VISIBLE character, which is why `fix the`
+    // and `fix the ` are byte-identical on screen and why Rule 1 is disabled
+    // here. So `taggerLeft` fuses the left text onto the payload — `with` +
+    // `Mark` reads as `withMark`, which the tagger calls a verb, which is a safe
+    // class, which lowercases somebody's name. The same defect Rule 1's space
+    // fixes everywhere else, arriving through the one door Rule 1 does not
+    // cover.
+    //
+    // MEASURED on six names whose caret sits after a word: FUSED recognised 1
+    // of 6, SEPARATED recognised 5. So the separated reading is asked as well,
+    // and either one calling it a name keeps the capital.
+    //
+    // This can only ever DECLINE to lower. Every oracle refusal preserves the
+    // capital, which is what the app did before this feature existed, so a
+    // wrong answer here cannot damage text that was already correct.
+    //
+    // Asked only when the seam is actually FUSED. Trailing whitespace in a
+    // terminal is unrecoverable in BOTH directions — a read can show cell
+    // padding the user never typed, or hide a space they did — so the test is
+    // what `taggerLeft` actually ends with rather than an assumption about
+    // which. Whitespace already there, from either side, means the tagger has
+    // its separator and the second reading would merely double it.
+    if isScreenDerived, let lastLeft = taggerLeft.last, !lastLeft.isWhitespace {
+      let separated = taggerLeft + " "
+      if let refusal = oracle.mayLower(word: bare, left: separated, payload: String(stripped)) {
+        return (text, .caseSkipped(refusal))
+      }
     }
 
     let lowered = String(firstCharacter).lowercased()

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -472,17 +472,31 @@ public enum PasteService {
     /// context has no selection offsets to compare, so this IS its identity.
     package let terminalEvidence: TerminalEvidence?
 
+    /// Whether `leftWindow` begins at the very start of what the user can edit,
+    /// so its first token has no hidden prefix.
+    ///
+    /// STORED, not inferred. Pipeline used to derive it as
+    /// `leftWindow.utf16.count == selectionLocation`, which is exact for a real
+    /// caret and meaningless for a terminal: both values come from the same
+    /// string there, so a screen-derived context ALWAYS claimed to reach the
+    /// start — including when the row read was the tail of a wrapped line with
+    /// text hidden above it. That claim lets `completeLeftToken` treat a wrap
+    /// fragment as a complete word, which authorises the one repair rule that
+    /// DELETES a dictated word.
+    package let leftReachesDocumentStart: Bool
+
     /// Whether this context was derived from a terminal screen.
     package var isScreenDerived: Bool { terminalEvidence != nil }
 
     package init(
       leftWindow: String, rightWindow: String, selectionLocation: Int, selectionLength: Int,
-      terminalEvidence: TerminalEvidence? = nil
+      leftReachesDocumentStart: Bool, terminalEvidence: TerminalEvidence? = nil
     ) {
       self.leftWindow = leftWindow
       self.rightWindow = rightWindow
       self.selectionLocation = selectionLocation
       self.selectionLength = selectionLength
+      self.leftReachesDocumentStart = leftReachesDocumentStart
       self.terminalEvidence = terminalEvidence
     }
   }
@@ -566,7 +580,11 @@ public enum PasteService {
       leftWindow: leftWindow,
       rightWindow: rightWindow,
       selectionLocation: selectionLocation,
-      selectionLength: selectionLength)
+      selectionLength: selectionLength,
+      // The window reached offset zero exactly when it is as long as the
+      // caret's offset — the same test Pipeline used to make, moved to the one
+      // place that actually knows the geometry.
+      leftReachesDocumentStart: leftStart == 0)
   }
 
   /// Read the text either side of the caret in the app that owns `element`.
@@ -785,6 +803,11 @@ public enum PasteService {
       rightWindow: "",
       selectionLocation: evidence.located.inputLine.utf16.count,
       selectionLength: 0,
+      // A wrapped line's tail has text hidden above it, so its first token may
+      // be a fragment. The parser is the only thing that knows a row was
+      // dropped, so it says so rather than leaving it to be inferred from
+      // offsets that cannot express it.
+      leftReachesDocumentStart: !evidence.located.leftWasCut,
       terminalEvidence: evidence)
   }
 

--- a/Sources/EnviousWisprServices/TerminalScreenParser.swift
+++ b/Sources/EnviousWisprServices/TerminalScreenParser.swift
@@ -21,10 +21,22 @@ package enum TerminalScreenParser {
   package struct Located: Equatable, Sendable {
     package let cli: SupportedTerminalCLI
     package let inputLine: String
+    /// True when the line WRAPPED and a populated row above this one was
+    /// dropped, so `inputLine` is the tail of what the user typed rather than
+    /// all of it.
+    ///
+    /// Carried rather than inferred. The downstream document-start test was
+    /// `leftWindow.utf16.count == selectionLocation`, which a terminal always
+    /// satisfies because both come from the same string — so a cut tail claimed
+    /// to reach the start of the input, and `completeLeftToken` would treat a
+    /// wrap fragment as a complete word. That authorises the one rule that
+    /// DELETES a dictated word.
+    package let leftWasCut: Bool
 
-    package init(cli: SupportedTerminalCLI, inputLine: String) {
+    package init(cli: SupportedTerminalCLI, inputLine: String, leftWasCut: Bool = false) {
       self.cli = cli
       self.inputLine = inputLine
+      self.leftWasCut = leftWasCut
     }
   }
 
@@ -110,6 +122,60 @@ package enum TerminalScreenParser {
     return String(body).replacingOccurrences(of: "\u{00A0}", with: " ")
   }
 
+  /// Strip a CONTINUATION row's gutter — the blank cells a wrapped row is
+  /// indented by, which are as wide as the marker prefix above it.
+  ///
+  /// Dropping all leading whitespace is equivalent to deriving that width, and
+  /// needs no width to derive: a wrap can never put whitespace at the START of a
+  /// row, because the spaces at a wrap boundary are consumed. MEASURED against a
+  /// live Claude Code at 67 columns — `"A"x62 + "  next"` renders its
+  /// continuation row as `next`, with BOTH spaces gone.
+  static func stripContinuationGutter(_ row: Substring) -> String {
+    String(row.drop(while: { $0.isWhitespace || $0 == "\u{00A0}" }))
+      .replacingOccurrences(of: "\u{00A0}", with: " ")
+  }
+
+  /// The column a row's first non-whitespace character sits at, or nil when the
+  /// row is blank.
+  static func indentWidth(of row: Substring) -> Int? {
+    let leading = row.prefix(while: { $0.isWhitespace || $0 == "\u{00A0}" }).count
+    return leading == row.count ? nil : leading
+  }
+
+  /// Whether `row` can be part of the input block below a marker row.
+  ///
+  /// AT LEAST the gutter, never exactly it: a wrap continuation sits exactly at
+  /// the gutter, but a hard-newline row the user indented themselves sits past
+  /// it, and requiring equality ended the block early and read the row above
+  /// the caret (whole-diff review r2, P1). A blank row qualifies because a user
+  /// may leave one inside their own prompt.
+  ///
+  /// Without a readable gutter nothing can be judged part of the block, so the
+  /// block collapses to the marker row — the conservative direction.
+  static func continuesInput(_ row: Substring, gutter: Int?) -> Bool {
+    if isBlank(row) { return true }
+    guard let gutter, let indent = indentWidth(of: row) else { return false }
+    return indent >= gutter
+  }
+
+  /// The column the user's text starts at on a MARKER row: past any leading
+  /// blank cells, the marker itself, and the single space after it.
+  ///
+  /// This is the gutter every continuation row beneath it is indented by, so it
+  /// is measured from the screen rather than hardcoded — Claude Code's is 2
+  /// cells and Gemini's is 3, because their markers are different widths.
+  static func markerTextColumn(of row: Substring, marker: Character) -> Int? {
+    guard let indent = indentWidth(of: row) else { return nil }
+    var index = row.index(row.startIndex, offsetBy: indent)
+    guard index < row.endIndex, row[index] == marker else { return nil }
+    var column = indent + 1
+    index = row.index(after: index)
+    if index < row.endIndex, row[index] == " " || row[index] == "\u{00A0}" {
+      column += 1
+    }
+    return column
+  }
+
   /// Whether a LIVE shell prompt sits below `index`, which proves the match was
   /// scrollback: the user ran a full-screen tool, quit it, and is now at a shell.
   ///
@@ -133,11 +199,18 @@ package enum TerminalScreenParser {
 
   /// Locate the input line, or nil to refuse.
   ///
-  /// Refusals ARE the feature. A wrapped box, an empty box, a stale box, an
-  /// unrecognised layout and a bare shell all return nil, and the user gets
-  /// today's behaviour unchanged.
-  /// The existing shape, kept because thirty-five tests encode the behaviour
-  /// contract through it and this change is diagnostic, not behavioural.
+  /// Refusals ARE the feature. An empty box, a stale box, an unrecognised
+  /// layout and a bare shell all return nil, and the user gets today's
+  /// behaviour unchanged.
+  ///
+  /// A WRAPPED box used to refuse too, and no longer does (#1926) — that
+  /// refusal made the feature unavailable for most real dictations, because a
+  /// 67-column terminal wraps at 63 characters and two sentences do not fit. It
+  /// returns the LAST row instead. Rejoining rows is still impossible and still
+  /// not attempted; the last row alone is exact.
+  ///
+  /// This shape is kept because the suite encodes its behaviour contract
+  /// through it.
   ///
   /// DELEGATES rather than re-deciding: a second copy of the matching rules
   /// could drift from the first, and then the log would describe a decision the
@@ -187,6 +260,9 @@ package enum TerminalScreenParser {
     case tooManyPopulatedRowsBelow = "codex:too_many_populated_rows_below"
     case livePromptBelow = "codex:live_prompt_below"
     case emptyInput = "codex:empty_input"
+    /// The caret is on a new empty line of the user's own input, not on the
+    /// last populated row.
+    case ambiguousTrailingBlankRow = "codex:ambiguous_trailing_blank_row"
   }
 
   package enum BoxedRefusal: Sendable {
@@ -196,21 +272,25 @@ package enum TerminalScreenParser {
     case livePromptBelow
     case wrongOpeningMarker
     case emptyInput
+    /// The last body row is blank while an earlier one is populated, which two
+    /// different inputs produce and which want opposite answers.
+    case ambiguousTrailingBlankRow
 
     package var telemetryName: String {
       switch self {
       case .fewerThanTwoBoundaries: return "boxed:fewer_than_two_boundaries"
       case .incompatibleBoundaries: return "boxed:incompatible_boundaries"
       case .populatedBodyRows(let count):
-        // The COUNT distinguishes an empty box from a wrapped one, which is the
-        // whole question. It is a small non-negative integer describing screen
-        // STRUCTURE, never content.
+        // Retained for the ALL-BLANK body only, now that a wrapped box is read
+        // rather than refused. It is a small non-negative integer describing
+        // screen STRUCTURE, never content.
         return count == 0
           ? "boxed:zero_populated_body_rows"
           : "boxed:multiple_populated_body_rows(\(count))"
       case .livePromptBelow: return "boxed:live_prompt_below"
       case .wrongOpeningMarker: return "boxed:wrong_opening_marker"
       case .emptyInput: return "boxed:empty_input"
+      case .ambiguousTrailingBlankRow: return "boxed:ambiguous_trailing_blank_row"
       }
     }
   }
@@ -238,15 +318,96 @@ package enum TerminalScreenParser {
       let index = rows.indices.last(where: { openingCharacter(of: rows[$0]) == codexMarker })
     else { return .refused(.noOpeningMarker) }
 
-    let populatedBelow = rows[(index + 1)...].filter { !isBlank($0) }.count
+    // The input BLOCK: the marker row plus every following row indented to
+    // exactly the gutter, stopping at the first blank row.
+    //
+    // Codex draws no box, so nothing else delimits its input, and the flat
+    // "at most two populated rows below the marker" rule counted a WRAPPED
+    // line's own continuation rows against its status-bar allowance. Worse, a
+    // ONE-row wrap plus a one-row status bar is exactly two, so it passed and
+    // returned the MARKER row — the text from before the wrap. That is a silent
+    // wrong answer rather than a refusal, and it ships today.
+    //
+    // MEASURED at 67 columns: continuation rows carry the 2-cell gutter, then
+    // ONE blank row, then the status bar.
+    //
+    // FOUND BY WALKING UP FROM THE BOTTOM, not down from the marker. Two review
+    // rounds found the same class scanning downward — first the status bar
+    // absorbed as continuation text, then a user-indented row ending the block
+    // early — so the class is enumerated here rather than patched again.
+    //
+    // Every row that is the user's INPUT: the marker row; a wrap continuation
+    // (indent == gutter); a hard-newline row the user indented further
+    // (indent > gutter); a blank line inside their own prompt; and the caret's
+    // own trailing blank line. Every row that is NOT: the single blank
+    // separator, the 1-2 status rows below it — which carry the SAME gutter as
+    // a continuation row and so cannot be told apart by indent — and any
+    // trailing blanks below those.
+    //
+    // Downward scanning cannot separate those sets. Upward can, because the
+    // separator is the FIRST blank row met walking up from the last populated
+    // row on screen, and everything past it is by definition the status bar.
+    let gutter = markerTextColumn(of: rows[index], marker: codexMarker)
+    var separator: Int? = nil
+    var statusRows = 0
+    if let lastPopulated = rows.indices.last(where: { !isBlank(rows[$0]) }), lastPopulated > index {
+      var probe = lastPopulated
+      while probe > index {
+        if isBlank(rows[probe]) {
+          separator = probe
+          break
+        }
+        statusRows += 1
+        probe -= 1
+      }
+    }
+
+    // Rows between the marker and the separator are the input, and every one of
+    // them must be blank or indented to AT LEAST the gutter. A row that is not
+    // was never part of this input, so the block collapses to the marker row
+    // and the original limit judges everything below it — which is what keeps a
+    // marker left in scrollback refused.
+    var blockEnd = index
+    if let separator, statusRows <= 2 {
+      let inputRows = (index + 1)..<separator
+      if inputRows.allSatisfy({ continuesInput(rows[$0], gutter: gutter) }) {
+        // The caret sits on its own blank line, so the last populated row is
+        // NOT where the next word goes and lowering against it would continue a
+        // sentence the user deliberately ended. The boxed path already refuses
+        // this; MEASURED at 67 columns, a caret at the end of the input leaves
+        // no blank row here and a newline (Ctrl+J) leaves one.
+        if let last = inputRows.last, isBlank(rows[last]) {
+          return .refused(.ambiguousTrailingBlankRow)
+        }
+        blockEnd = inputRows.last ?? index
+      }
+    }
+
+    // The ORIGINAL staleness limit, moved past the block rather than removed.
+    // Ordinary output is not indented to the gutter, so it never joins the
+    // block and still counts here — which is what keeps a marker row left in
+    // scrollback refused.
+    //
+    // Codex's consult also proposed requiring every pre-wrap row to reach the
+    // screen's content edge. REFUTED by measurement: in the real wrapped frame
+    // the pre-wrap rows are 62 and 60 cells wide on a 67-column screen, because
+    // a word wrap moves a whole word down. That rule would refuse almost every
+    // real wrap.
+    let populatedBelow = rows[(blockEnd + 1)...].filter { !isBlank($0) }.count
     guard populatedBelow <= 2 else { return .refused(.tooManyPopulatedRowsBelow) }
     // Same staleness rule as the boxed layouts: a live shell prompt below means
-    // Codex has exited and this row is history.
-    guard !aLivePromptSits(below: index, in: rows) else { return .refused(.livePromptBelow) }
+    // Codex has exited and this row is history. Scanned from the END of the
+    // block, never from the marker row: a wrapped line whose own continuation
+    // happens to start with `$`, `%`, `#` or `❯` would otherwise read as a live
+    // shell prompt and refuse.
+    guard !aLivePromptSits(below: blockEnd, in: rows) else { return .refused(.livePromptBelow) }
 
-    let line = stripLeadingMarker(rows[index], codexMarker)
+    let line =
+      blockEnd == index
+      ? stripLeadingMarker(rows[index], codexMarker)
+      : stripContinuationGutter(rows[blockEnd])
     guard !line.trimmingCharacters(in: .whitespaces).isEmpty else { return .refused(.emptyInput) }
-    return .located(Located(cli: .codex, inputLine: line))
+    return .located(Located(cli: .codex, inputLine: line, leftWasCut: blockEnd != index))
   }
 
   enum CodexLocateResult {
@@ -270,18 +431,22 @@ package enum TerminalScreenParser {
       return .refused(.incompatibleBoundaries)
     }
 
-    let body = rows[(opening.0 + 1)..<closing.0].filter { !isBlank($0) }
-    // More than one populated row means the input wrapped, and joining screen
-    // rows reconstructs different text — a soft wrap can fall mid-word.
-    guard body.count == 1, let row = body.first else {
-      return .refused(.populatedBodyRows(body.count))
+    // UNFILTERED, deliberately. The old slice dropped blank rows before
+    // counting, and the blank-row question cannot be asked once they are gone —
+    // a blank row sitting AFTER the text is the one shape that has to refuse.
+    let body = Array(rows[(opening.0 + 1)..<closing.0])
+    let populated = body.indices.filter { !isBlank(body[$0]) }
+    guard let first = populated.first, let last = populated.last else {
+      return .refused(.populatedBodyRows(0))
     }
 
     guard !aLivePromptSits(below: closing.0, in: rows) else { return .refused(.livePromptBelow) }
 
     let cli: SupportedTerminalCLI = closing.1 == .block ? .geminiCLI : .claudeCode
     let marker = closing.1 == .block ? geminiMarker : claudeMarker
-    // The row must carry its tool's marker.
+    // The marker sits on the FIRST populated row. A wrapped continuation row
+    // never carries one, so this is checked where the marker actually is rather
+    // than on whichever row is read.
     //
     // Grounded review caught a real error here, and the error was in my
     // reasoning rather than the code: because screen matching is spoofable AS A
@@ -291,14 +456,41 @@ package enum TerminalScreenParser {
     // it at no cost. A faithful spoof that reproduces the marker still passes,
     // which is exactly why Gate 1 remains the authority; closing an instance is
     // not a claim to have closed the class.
-    guard openingCharacter(of: row) == marker else { return .refused(.wrongOpeningMarker) }
+    guard openingCharacter(of: body[first]) == marker else {
+      return .refused(.wrongOpeningMarker)
+    }
 
-    let line = stripLeadingMarker(row, marker)
-    // An EMPTY box refuses. The prototype's exact failure was reading an empty
-    // box back as the hint text printed below it, which would delete words
-    // nobody typed.
+    // An UNTOUCHED box refuses, and is tested BEFORE the trailing-blank rule so
+    // that a box drawn with spare height still reports "nothing typed" rather
+    // than "ambiguous". The prototype's exact failure was reading an empty box
+    // back as the hint text printed below it, which would delete words nobody
+    // typed.
+    if populated.count == 1,
+      stripLeadingMarker(body[first], marker).trimmingCharacters(in: .whitespaces).isEmpty
+    {
+      return .refused(.emptyInput)
+    }
+
+    // A blank row BELOW the text is the one wrap shape that cannot be read.
+    // MEASURED: `"A"x63 + " "` (ended exactly at the wrap) and
+    // `"first line of text" + backslash + Enter` (a deliberate new line) render
+    // the SAME two rows, and want opposite answers — continue-and-lowercase
+    // versus new-line-and-capitalise. Refusing keeps today's behaviour instead
+    // of inventing a new wrong one.
+    guard last == body.count - 1 else { return .refused(.ambiguousTrailingBlankRow) }
+
+    // The LAST populated row, not the first. Rejoining rows is impossible —
+    // `"A"x63 + " next word"` and `"A"x64 + " next word"` render byte-identical
+    // screens — but the last row is ALWAYS the verbatim tail of what was typed,
+    // measured at every length from 40 to 260 characters on all three CLIs. And
+    // the tail is all the repair needs: it walks backward to the first
+    // non-whitespace character.
+    let line =
+      last == first
+      ? stripLeadingMarker(body[last], marker)
+      : stripContinuationGutter(body[last])
     guard !line.trimmingCharacters(in: .whitespaces).isEmpty else { return .refused(.emptyInput) }
-    return .located(Located(cli: cli, inputLine: line))
+    return .located(Located(cli: cli, inputLine: line, leftWasCut: last != first))
   }
 
   enum BoxedLocateResult {

--- a/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
@@ -783,7 +783,10 @@ import os
     leftWindow: "I went to the ",
     rightWindow: "",
     selectionLocation: 14,
-    selectionLength: 0)
+    selectionLength: 0,
+    // The window is as long as the caret's offset, so it began at the field's
+    // own start — the value Pipeline used to derive from exactly that test.
+    leftReachesDocumentStart: true)
 
   @Test(
     "delivery carries today's payload, the contextual candidate, and the caret evidence")
@@ -843,7 +846,8 @@ import os
       },
       readCaretContext: { _, _, _ in
         PasteService.CaretContext(
-          leftWindow: "Ich gehe zum ", rightWindow: "", selectionLocation: 13, selectionLength: 0)
+          leftWindow: "Ich gehe zum ", rightWindow: "", selectionLocation: 13,
+          selectionLength: 0, leftReachesDocumentStart: true)
       },
       adapter: Self.transcribedEngine(language: "en"))
 
@@ -884,7 +888,7 @@ import os
       readCaretContext: { _, _, _ in
         PasteService.CaretContext(
           leftWindow: "I want to go to the ", rightWindow: "", selectionLocation: 20,
-          selectionLength: 0)
+          selectionLength: 0, leftReachesDocumentStart: true)
       },
       adapter: Self.transcribedEngine(language: "en"))
 
@@ -920,7 +924,7 @@ import os
       readCaretContext: { _, _, _ in
         PasteService.CaretContext(
           leftWindow: "\u{4ECA}\u{65E5}", rightWindow: "", selectionLocation: 2,
-          selectionLength: 0)
+          selectionLength: 0, leftReachesDocumentStart: true)
       },
       adapter: Self.transcribedEngine(language: "ja"))
 
@@ -1109,7 +1113,8 @@ import os
       leftWindow: "sto",
       rightWindow: "re",
       selectionLocation: 3,
-      selectionLength: 0)
+      selectionLength: 0,
+      leftReachesDocumentStart: true)
 
     let wiring = makeWiring(
       context: context,

--- a/Tests/EnviousWisprTests/PostProcessing/CursorInsertionRepairTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CursorInsertionRepairTests.swift
@@ -1560,4 +1560,114 @@ struct CursorInsertionRepairTests {
     #expect(payloads.candidateRules.contains(.droppedDuplicateWord))
     #expect(payloads.repairedText == " Bahnhof. ")
   }
+
+  // MARK: - The seam a terminal hides (#1926)
+
+  /// An oracle that recognises a name ONLY when the left context ends with a
+  /// separator, which is how the real one behaves.
+  ///
+  /// MEASURED on `NLTagger` over six names whose caret sits directly after a
+  /// word: FUSED (`...withMark said`) recognised 1 of 6, SEPARATED
+  /// (`...with Mark said`) recognised 5. A terminal renders a row up to its last
+  /// VISIBLE character, so the trailing space the user typed is not on screen
+  /// and the fused reading is the one the repair would otherwise get.
+  private static let seamSensitiveOracle = EnglishWordOracle(
+    unavailableReason: nil,
+    dictionaryVerdict: { ["mark", "with", "and", "now"].contains($0) ? .ordinary : .notOrdinary },
+    isLearnedWord: { _ in false },
+    isRecognizedName: { left, _ in left.last?.isWhitespace == true })
+
+  @Test("A terminal seam asks the SEPARATED reading too, so a name keeps its capital")
+  func screenDerivedSeamProtectsAName() {
+    let payloads = CursorInsertionRepair.repair(
+      text: "Mark said he would help ",
+      context: CursorInsertionRepair.CaretText(
+        left: "I had a long conversation with", right: "",
+        leftReachesDocumentStart: true, isScreenDerived: true),
+      protectedWords: [], oracle: Self.seamSensitiveOracle)
+    // Asserted on the RULE as well as the text. In a terminal Rule 1 is
+    // disabled, so a kept capital leaves the payload byte-identical — and an
+    // assertion of the form `repairedText?.hasPrefix("Mark") ?? true` would
+    // then pass whether the name check ran or not.
+    #expect(
+      payloads.candidateRules.contains(.caseSkipped(.recognizedName)),
+      "the separated reading must be what refuses, by name")
+    #expect(payloads.repairedText == "Mark said he would help ", "and the capital survives")
+  }
+
+  @Test("Control: the FUSED reading alone would have lowered that name")
+  func fusedReadingAloneWouldLowerTheName() {
+    // Without this, the test above passes for a repair that never lowers
+    // anything. Asking the oracle the way the code asked it BEFORE this change
+    // — one question, fused — permits the lowering, so the capital that
+    // survives above can only have come from the second reading.
+    #expect(
+      Self.seamSensitiveOracle.mayLower(
+        word: "Mark", left: "I had a long conversation with",
+        payload: "Mark said he would help") == nil,
+      "the fused seam reads as an ordinary word, which is the whole defect")
+    #expect(
+      Self.seamSensitiveOracle.mayLower(
+        word: "Mark", left: "I had a long conversation with ",
+        payload: "Mark said he would help") != nil,
+      "and the separated seam recognises the name")
+  }
+
+  @Test("An ordinary field never needed this, because Rule 1 already separates")
+  func caretDerivedSeamIsAlreadySeparated() {
+    // Why the defect is terminal-only. Everywhere else Rule 1 prepends the
+    // seam space, so the FIRST reading is already the separated one — and the
+    // second question is not asked at all.
+    let payloads = CursorInsertionRepair.repair(
+      text: "Mark said he would help ",
+      context: CursorInsertionRepair.CaretText(
+        left: "I had a long conversation with", right: "",
+        leftReachesDocumentStart: true, isScreenDerived: false),
+      protectedWords: [], oracle: Self.seamSensitiveOracle)
+    #expect(payloads.repairedText == " Mark said he would help ")
+  }
+
+  @Test("An ordinary continuation in a terminal still lowers — the point of the feature")
+  func screenDerivedOrdinaryWordStillLowers() {
+    // The founder's actual traffic. If the extra reading refused these too, the
+    // change would have bought a name at the cost of the whole feature.
+    let payloads = CursorInsertionRepair.repair(
+      text: "And now I dictate the rest ",
+      context: CursorInsertionRepair.CaretText(
+        left: "I want to test if this works", right: "",
+        leftReachesDocumentStart: true, isScreenDerived: true),
+      protectedWords: [],
+      oracle: EnglishWordOracle(
+        unavailableReason: nil,
+        dictionaryVerdict: { ["and", "now"].contains($0) ? .ordinary : .notOrdinary },
+        isLearnedWord: { _ in false },
+        isRecognizedName: { _, _ in false }))
+    #expect(payloads.repairedText?.hasPrefix("and now") == true)
+  }
+
+  @Test("A wrapped tail cannot authorise deleting a dictated word")
+  func cutLeftWindowRefusesTheSeamDelete() {
+    // A wrapped row's first token may be the tail of a word split at the wrap,
+    // so it is not a complete token and cannot match the payload's first word.
+    // The terminal path used to claim every line reached the document start,
+    // because `leftWindow.utf16.count == selectionLocation` is trivially true
+    // when both come from the same string.
+    let cut = Self.seamCut(left: "the", payload: "The store is closed today.", reaches: false)
+    #expect(!cut.candidateRules.contains(.droppedDuplicateWord))
+
+    let whole = Self.seamCut(left: "the", payload: "The store is closed today.", reaches: true)
+    #expect(
+      whole.candidateRules.contains(.droppedDuplicateWord),
+      "two-way control: a window known to reach the start still de-duplicates")
+  }
+
+  private static func seamCut(
+    left: String, payload: String, reaches: Bool
+  ) -> CursorInsertionRepair.PreparedPayloads {
+    CursorInsertionRepair.repair(
+      text: payload,
+      context: CursorInsertionRepair.CaretText(
+        left: left, right: "", leftReachesDocumentStart: reaches, isScreenDerived: true),
+      protectedWords: [], language: "en", oracle: Self.prototypeOracle)
+  }
 }

--- a/Tests/EnviousWisprTests/Services/PasteCaretContextTests.swift
+++ b/Tests/EnviousWisprTests/Services/PasteCaretContextTests.swift
@@ -300,7 +300,8 @@ struct PasteCaretContextTests {
   @Test("identical surroundings at the same offsets still match")
   func windowsMatchWhenNothingChanged() {
     let context = PasteService.CaretContext(
-      leftWindow: "I went to the ", rightWindow: "", selectionLocation: 14, selectionLength: 0)
+      leftWindow: "I went to the ", rightWindow: "", selectionLocation: 14,
+      selectionLength: 0, leftReachesDocumentStart: true)
     #expect(
       PasteService.contextWindowsStillMatch(context, inFieldBefore: "I went to the "))
   }
@@ -310,7 +311,8 @@ struct PasteCaretContextTests {
     // The reviewer's case: `, ` became `. `, every offset identical, but the
     // repair's whole decision — lowercase or keep the capital — inverts.
     let context = PasteService.CaretContext(
-      leftWindow: "I went home, ", rightWindow: "", selectionLocation: 13, selectionLength: 0)
+      leftWindow: "I went home, ", rightWindow: "", selectionLocation: 13,
+      selectionLength: 0, leftReachesDocumentStart: true)
     #expect(
       PasteService.contextWindowsStillMatch(context, inFieldBefore: "I went home. ") == false)
   }
@@ -318,7 +320,8 @@ struct PasteCaretContextTests {
   @Test("text after the selection is compared too")
   func windowsCompareTheRightSide() {
     let context = PasteService.CaretContext(
-      leftWindow: "the ", rightWindow: "yesterday", selectionLocation: 4, selectionLength: 0)
+      leftWindow: "the ", rightWindow: "yesterday", selectionLocation: 4,
+      selectionLength: 0, leftReachesDocumentStart: true)
     #expect(PasteService.contextWindowsStillMatch(context, inFieldBefore: "the yesterday"))
     #expect(
       PasteService.contextWindowsStillMatch(context, inFieldBefore: "the tomorrow ") == false)
@@ -327,7 +330,8 @@ struct PasteCaretContextTests {
   @Test("a field that shrank below the recorded selection fails closed")
   func windowsFailClosedOnAShrunkField() {
     let context = PasteService.CaretContext(
-      leftWindow: "I went to the ", rightWindow: "", selectionLocation: 14, selectionLength: 0)
+      leftWindow: "I went to the ", rightWindow: "", selectionLocation: 14,
+      selectionLength: 0, leftReachesDocumentStart: true)
     #expect(PasteService.contextWindowsStillMatch(context, inFieldBefore: "I went") == false)
   }
 
@@ -336,7 +340,8 @@ struct PasteCaretContextTests {
     // "🚀" is two UTF-16 units and one Character; slicing in Characters would
     // land mid-surrogate and compare the wrong text.
     let context = PasteService.CaretContext(
-      leftWindow: "a🚀", rightWindow: "b", selectionLocation: 3, selectionLength: 0)
+      leftWindow: "a🚀", rightWindow: "b", selectionLocation: 3,
+      selectionLength: 0, leftReachesDocumentStart: true)
     #expect(PasteService.contextWindowsStillMatch(context, inFieldBefore: "a🚀b"))
   }
 

--- a/Tests/EnviousWisprTests/Services/TerminalInsertionPolicyTests.swift
+++ b/Tests/EnviousWisprTests/Services/TerminalInsertionPolicyTests.swift
@@ -29,6 +29,7 @@ struct TerminalInsertionPolicyTests {
       rightWindow: "",
       selectionLocation: line.utf16.count,
       selectionLength: 0,
+      leftReachesDocumentStart: true,
       terminalEvidence: TerminalEvidence(
         surface: .ghostty,
         runningCLIs: [.init(processIdentifier: 42, cli: .claudeCode)],
@@ -41,7 +42,8 @@ struct TerminalInsertionPolicyTests {
   @Test("A caret-derived context is not screen-derived, and a terminal one is")
   func provenanceIsTyped() {
     let caret = PasteService.CaretContext(
-      leftWindow: "abc", rightWindow: "", selectionLocation: 3, selectionLength: 0)
+      leftWindow: "abc", rightWindow: "", selectionLocation: 3, selectionLength: 0,
+      leftReachesDocumentStart: true)
     #expect(!caret.isScreenDerived)
     #expect(terminalContext(line: "abc").isScreenDerived)
   }
@@ -54,6 +56,7 @@ struct TerminalInsertionPolicyTests {
     let original = terminalContext(line: line)
     let scrolled = PasteService.CaretContext(
       leftWindow: line, rightWindow: "", selectionLocation: line.utf16.count, selectionLength: 0,
+      leftReachesDocumentStart: true,
       terminalEvidence: TerminalEvidence(
         surface: .ghostty,
         runningCLIs: [.init(processIdentifier: 42, cli: .claudeCode)],
@@ -236,7 +239,8 @@ struct TerminalInsertionPolicyTests {
     // And an ordinary app's context carries no terminal provenance, so neither
     // the multiline refusal nor the Tier 1 exclusion can reach it.
     let ordinary = PasteService.CaretContext(
-      leftWindow: "notes: ", rightWindow: "", selectionLocation: 7, selectionLength: 0)
+      leftWindow: "notes: ", rightWindow: "", selectionLocation: 7, selectionLength: 0,
+      leftReachesDocumentStart: true)
     #expect(!ordinary.isScreenDerived)
     let payload = PasteService.accessibilityWritePayload(
       legacy: "Fix it ", repaired: "fix it ", context: ordinary,
@@ -270,7 +274,8 @@ struct TerminalInsertionPolicyTests {
     // route refuses everything.
     let left = "git commit -m "
     let caret = PasteService.CaretContext(
-      leftWindow: left, rightWindow: "", selectionLocation: left.utf16.count, selectionLength: 0)
+      leftWindow: left, rightWindow: "", selectionLocation: left.utf16.count,
+      selectionLength: 0, leftReachesDocumentStart: true)
     let payload = PasteService.accessibilityWritePayload(
       legacy: "Fix the handler ",
       repaired: "fix the handler ",

--- a/Tests/EnviousWisprTests/Services/TerminalScreenParserTests.swift
+++ b/Tests/EnviousWisprTests/Services/TerminalScreenParserTests.swift
@@ -45,6 +45,48 @@ struct TerminalScreenParserTests {
     """
   }
 
+  // MARK: - Wrapped layouts, MEASURED rather than invented
+  //
+  // Captured from live CLIs in a 67-column terminal on 2026-08-04. The gutter is
+  // the width of the marker prefix and differs per tool — 2 cells for Claude
+  // Code's `❯` plus its non-breaking space, 3 for Gemini's leading space, `>`
+  // and space, 2 for Codex's `› `. The previous wrapped fixture used an
+  // UNINDENTED continuation row, which no real CLI draws, so it could not have
+  // caught a gutter mistake either way.
+
+  /// Claude Code with the input wrapped across `rows`, the first carrying the
+  /// marker and the rest the 2-cell gutter.
+  private static func claudeWrapped(_ rows: [String], trailingBlank: Bool = false) -> String {
+    let rule = String(repeating: "\u{2500}", count: 8)
+    var body = rows.enumerated().map { index, text in
+      index == 0 ? "\u{276F}\u{00A0}\(text)" : "  \(text)"
+    }
+    if trailingBlank { body.append("") }
+    return (["some earlier output", rule] + body + [rule, "  ? for shortcuts"])
+      .joined(separator: "\n")
+  }
+
+  /// Gemini with the input wrapped, whose gutter is 3 cells wide.
+  private static func geminiWrapped(_ rows: [String]) -> String {
+    let top = String(repeating: "\u{2584}", count: 8)
+    let bottom = String(repeating: "\u{2580}", count: 8)
+    let body = rows.enumerated().map { index, text in
+      index == 0 ? " > \(text)" : "   \(text)"
+    }
+    return (["earlier output", top] + body + [bottom]).joined(separator: "\n")
+  }
+
+  /// Codex with the input wrapped: marker row, gutter-indented continuation
+  /// rows, ONE blank row, then the status bar.
+  private static func codexWrapped(
+    _ rows: [String], status: [String] = ["  tab to queue message      100% context left"]
+  ) -> String {
+    let body = rows.enumerated().map { index, text in
+      index == 0 ? "\u{203A} \(text)" : "  \(text)"
+    }
+    return (["earlier output"] + body + [""] + status).joined(separator: "\n")
+  }
+
   // MARK: - The three tools
 
   @Test("Claude Code's boxed input line is found, and the footer below it is not")
@@ -74,17 +116,251 @@ struct TerminalScreenParserTests {
 
   // MARK: - Refusals that are the feature
 
-  @Test("A WRAPPED box refuses rather than joining rows")
-  func wrappedBoxRefuses() {
-    // Joining screen rows reconstructs different text, and a soft wrap can fall
-    // mid-word.
-    let wrapped = """
+  // MARK: - Wrapping
+
+  @Test("A WRAPPED box is read from its LAST row, never rejoined")
+  func wrappedBoxReadsItsLastRow() {
+    // This used to refuse, and that refusal made the feature unavailable for
+    // most real dictations: a 67-column terminal wraps at 63 characters, so two
+    // sentences do not fit. 8 of the 9 field refusals where the founder had
+    // actually typed something were this guard (#1926).
+    //
+    // Rejoining is still impossible and still not attempted. MEASURED:
+    // `"A"x63 + " next word"` and `"A"x64 + " next word"` render byte-identical
+    // screens, so no join rule can recover which was typed. The LAST row needs
+    // no join — it is the verbatim tail, confirmed at every typed length from
+    // 40 to 260 characters.
+    let located = TerminalScreenParser.locate(
+      inScreenTail: Self.claudeWrapped([
+        "I want to test if this works as intended and works properly.",
+        "Now I dictate",
+      ]))
+    #expect(located?.cli == .claudeCode)
+    #expect(located?.inputLine == "Now I dictate")
+    #expect(located?.leftWasCut == true, "a wrapped tail has text hidden above it")
+  }
+
+  @Test("An UNWRAPPED box still reads its only row, and reports nothing was cut")
+  func unwrappedBoxIsNotMarkedAsCut() {
+    // The two-way control. Without it the assertion above passes for a parser
+    // that marked EVERY line as cut, which would refuse seam de-duplication on
+    // every short field in every terminal.
+    let located = TerminalScreenParser.locate(inScreenTail: Self.claudeBox("git commit -m fix the"))
+    #expect(located?.inputLine == "git commit -m fix the")
+    #expect(located?.leftWasCut == false)
+  }
+
+  @Test("The gutter is the MARKER's width, so Gemini's 3-cell indent survives")
+  func geminiWrappedKeepsItsOwnGutter() {
+    // Claude Code indents continuation rows by 2 and Gemini by 3, because their
+    // markers are different widths. A hardcoded 2 would leave a stray space on
+    // every wrapped Gemini line.
+    let located = TerminalScreenParser.locate(
+      inScreenTail: Self.geminiWrapped(["explain this to me in a lot", "more detail please"]))
+    #expect(located?.cli == .geminiCLI)
+    #expect(located?.inputLine == "more detail please")
+    #expect(located?.leftWasCut == true)
+  }
+
+  @Test("A wrapped Codex input reads its last row, not the row before the wrap")
+  func codexWrappedReadsItsLastRow() {
+    // The Codex path did NOT refuse a one-row wrap: its status bar allowance is
+    // two populated rows, and one continuation plus one status row is exactly
+    // two. So it passed and returned the MARKER row — the text from BEFORE the
+    // wrap — and the repair acted on stale context with nothing logged. A
+    // silent wrong answer, worse than the boxed refusal it sat beside.
+    let located = TerminalScreenParser.locate(
+      inScreenTail: Self.codexWrapped([
+        "refactor the handler so it stops swallowing the error",
+        "and then run the tests",
+      ]))
+    #expect(located?.cli == .codex)
+    #expect(located?.inputLine == "and then run the tests")
+    #expect(located?.leftWasCut == true)
+  }
+
+  @Test("A three-row Codex wrap is read too, not refused for having rows below")
+  func codexDeepWrapIsRead() {
+    let located = TerminalScreenParser.locate(
+      inScreenTail: Self.codexWrapped(["first visual row", "second visual row", "third row"]))
+    #expect(located?.inputLine == "third row")
+  }
+
+  @Test("A Codex continuation row starting with a shell glyph is not a live prompt")
+  func codexWrapContainingAPromptGlyphIsStillInput() {
+    // The staleness scan used to start at the MARKER row, so any row of the
+    // user's own wrapped text beginning `$`, `%`, `#` or `❯` read as a live
+    // shell prompt and refused. It now starts after the input block.
+    let located = TerminalScreenParser.locate(
+      inScreenTail: Self.codexWrapped([
+        "run this for me and explain what it does:",
+        "$ git rebase --onto main feature",
+      ]))
+    #expect(located?.inputLine == "$ git rebase --onto main feature")
+  }
+
+  @Test("Codex refuses when the caret sits on a new empty line of its own")
+  func codexTrailingBlankRowRefuses() {
+    // MEASURED at 67 columns: caret at the END of the input draws ONE blank row
+    // before the status bar, wrapped or not; a newline (Ctrl+J) draws TWO. The
+    // second blank IS the caret's line, so the last populated row is not where
+    // the next word goes and lowering against it continues a sentence the user
+    // deliberately ended. Found by whole-diff review, which spotted that the
+    // boxed path already refused this and Codex read straight past it.
+    let wrappedThenNewline = """
+      earlier output
+      \u{203A} a short line and now a much longer continuation that certainly
+        wraps past the edge of this window
+
+
+        gpt-5.6-sol high \u{00B7} /tmp \u{00B7} Ready
+      """
+    #expect(TerminalScreenParser.locate(inScreenTail: wrappedThenNewline) == nil)
+    if case .refused(let detail) = TerminalScreenParser.locateDetailed(
+      inScreenTail: wrappedThenNewline)
+    {
+      #expect(detail.codex == .ambiguousTrailingBlankRow)
+    } else {
+      Issue.record("a caret on its own blank line must refuse")
+    }
+
+    // Two-way control, and it is the SAME screen with ONE blank row instead of
+    // two. Without it this passes for a parser that refuses every Codex wrap.
+    let wrappedCaretAtEnd = """
+      earlier output
+      \u{203A} a short line and now a much longer continuation that certainly
+        wraps past the edge of this window
+
+        gpt-5.6-sol high \u{00B7} /tmp \u{00B7} Ready
+      """
+    #expect(
+      TerminalScreenParser.locate(inScreenTail: wrappedCaretAtEnd)?.inputLine
+        == "wraps past the edge of this window")
+  }
+
+  @Test("Every shape a Codex input block can take is read from its LAST row")
+  func codexInputBlockShapes() {
+    // The CLASS, enumerated. Two review rounds found the same defect scanning
+    // DOWNWARD from the marker — first the status bar absorbed as continuation
+    // text, then a row the user had indented ending the block early — so every
+    // member is frozen here rather than the one that was reported.
+    func line(_ tail: String) -> String? {
+      TerminalScreenParser.locate(inScreenTail: tail)?.inputLine
+    }
+    let status = "  gpt-5.6-sol high \u{00B7} /tmp \u{00B7} Ready"
+
+    // A wrap continuation sits exactly at the gutter.
+    #expect(
+      line(
+        """
+        earlier output
+        \u{203A} first visual row of the prompt
+          second visual row
+
+        \(status)
+        """) == "second visual row")
+
+    // A hard-newline row the user indented FURTHER sits past the gutter. This
+    // is review r2's P1: requiring equality ended the block at the marker row,
+    // so the parser read the row ABOVE the caret and reported it as unwrapped —
+    // which also let the seam rule delete a dictated word.
+    #expect(
+      line(
+        """
+        earlier output
+        \u{203A} first line of my prompt
+              an indented second line
+
+        \(status)
+        """) == "an indented second line")
+
+    // A blank line inside the user's OWN prompt is not the separator.
+    #expect(
+      line(
+        """
+        earlier output
+        \u{203A} first line
+
+          third line after a blank one
+
+        \(status)
+        """) == "third line after a blank one")
+
+    // Trailing blank rows below the status bar do not move the separator.
+    #expect(
+      line(
+        """
+        earlier output
+        \u{203A} first visual row of the prompt
+          second visual row
+
+        \(status)
+
+
+        """) == "second visual row")
+
+    // Two status rows are still allowed, as they always were.
+    #expect(
+      line(
+        """
+        earlier output
+        \u{203A} first visual row of the prompt
+          second visual row
+
+        \(status)
+          tab to queue message
+        """) == "second visual row")
+  }
+
+  @Test("An UNWRAPPED Codex line with the caret on a new line refuses too")
+  func codexUnwrappedTrailingBlankRefuses() {
+    // The same shape without a wrap, which the shipped parser also read past —
+    // it counted one populated row below the marker, which is inside its limit.
+    let shortThenNewline = """
+      earlier output
+      \u{203A} short text
+
+
+        gpt-5.6-sol high \u{00B7} /tmp \u{00B7} Ready
+      """
+    #expect(TerminalScreenParser.locate(inScreenTail: shortThenNewline) == nil)
+  }
+
+  @Test("A blank row BELOW the text refuses — two inputs draw it and they disagree")
+  func trailingBlankRowRefuses() {
+    // MEASURED, and the reason this one case still refuses. `"A"x63 + " "`
+    // (text that ended exactly at the wrap) and `"first line" + backslash +
+    // Enter` (a deliberate new line) render the SAME two rows. The first wants
+    // the sentence continued in lower case; the second wants a capital. The
+    // screen cannot tell them apart, so the app declines rather than guessing.
+    #expect(
+      TerminalScreenParser.locate(
+        inScreenTail: Self.claudeWrapped(["first line of text"], trailingBlank: true)) == nil)
+
+    if case .refused(let detail) = TerminalScreenParser.locateDetailed(
+      inScreenTail: Self.claudeWrapped(["first line of text"], trailingBlank: true))
+    {
+      #expect(detail.boxed.telemetryName == "boxed:ambiguous_trailing_blank_row")
+    } else {
+      Issue.record("a trailing blank row must refuse")
+    }
+  }
+
+  @Test("An untouched box still says EMPTY even when the box is drawn taller")
+  func emptyBoxOutranksTheTrailingBlankRule() {
+    // Order matters: an empty box drawn with spare height has a blank row below
+    // its marker row too, and it means "nothing typed", not "ambiguous".
+    let taller = """
       \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
-      \u{276F} this line is long enough that it
-      wrapped onto a second row
+      \u{276F}\u{00A0}
+
       \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
       """
-    #expect(TerminalScreenParser.locate(inScreenTail: wrapped) == nil)
+    if case .refused(let detail) = TerminalScreenParser.locateDetailed(inScreenTail: taller) {
+      #expect(detail.boxed.telemetryName == "boxed:empty_input")
+    } else {
+      Issue.record("an untouched box must refuse as empty")
+    }
   }
 
   @Test("#1921 diagnosis: refusals name WHICH guard fired, on both routes")
@@ -104,20 +380,18 @@ struct TerminalScreenParserTests {
       return nil
     }
 
-    let wrapped = """
-      \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
-      \u{276F} this line is long enough that it
-      wrapped onto a second row
-      \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
-      """
-    let wrappedRefusal = refusal(wrapped)
+    // A trailing blank row is the one wrap shape that still refuses, and it must
+    // be nameable. The row-count refusal it replaced fired on ORDINARY wraps,
+    // which are now read (#1926).
+    let ambiguous = Self.claudeWrapped(["first line of text"], trailingBlank: true)
+    let ambiguousRefusal = refusal(ambiguous)
     #expect(
-      wrappedRefusal?.boxed.telemetryName == "boxed:multiple_populated_body_rows(2)",
-      "a wrapped input must name the wrap and its row count")
+      ambiguousRefusal?.boxed.telemetryName == "boxed:ambiguous_trailing_blank_row",
+      "the one unreadable wrap shape must name itself")
 
-    // The distinction that matters most: an EMPTY box and a WRAPPED box both
-    // refused with the same word before this change, and they mean opposite
-    // things — nothing typed yet, versus too much typed.
+    // The distinction that matters most: an EMPTY box and an unreadable one
+    // meant the same word before the diagnostic existed, and they mean opposite
+    // things — nothing typed yet, versus typed but unreadable.
     //
     // Corrected by this test failing: an empty box reports `empty_input`, not a
     // zero row count, because the marker row `\u{276F} ` is not blank and so
@@ -126,11 +400,11 @@ struct TerminalScreenParserTests {
     let emptyRefusal = refusal(Self.claudeBox(""))
     #expect(
       emptyRefusal?.boxed.telemetryName == "boxed:empty_input",
-      "an empty box must be distinguishable from a wrapped one")
+      "an empty box must be distinguishable from an unreadable one")
 
     // And the Codex probe is reported even when the boxed route is the one that
     // decided, because that is the pair the log has to carry.
-    #expect(wrappedRefusal?.codex == .noOpeningMarker)
+    #expect(ambiguousRefusal?.codex == .noOpeningMarker)
 
     // Two-way control: a screen the parser ACCEPTS must not produce a refusal at
     // all, or every assertion above passes for the wrong reason.
@@ -338,15 +612,15 @@ struct TerminalScreenParserTests {
     let screen =
       kind == "boxed"
       ? """
-        \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
-        \u{276F} old boxed input
-        \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
-        $ ls -la
-        """
+      \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
+      \u{276F} old boxed input
+      \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
+      $ ls -la
+      """
       : """
-        \u{203A} old codex input
-        $ ls -la
-        """
+      \u{203A} old codex input
+      $ ls -la
+      """
     #expect(TerminalScreenParser.locate(inScreenTail: screen) == nil)
   }
 


### PR DESCRIPTION
Continuation casing in a terminal stopped working the moment the typed line wrapped onto a second screen row. The founder's terminal is 67 columns and a Claude Code row holds 63 characters, so one sentence fits and two do not — which is exactly how he described it: *"as long as it is on the first sentence it doesn't cause any problems, but if it's more than one sentence long it will not work as intended."*

Every `TERMINAL_PARSE` line his machine had recorded, 13 in total: **8 of the 9 refusals where he had actually typed something were this one guard.**

Not a regression. The refusal shipped in the original feature commit `51012c0d` (#1817), and #1803's plan chose it deliberately — *"A wrapped box is a REFUSAL, not something to compensate for"* — while that same plan's Live-UAT list records "long/wrapped input" as a receipt **still owed**. Designed in, never exercised.

## Rejoining rows really is impossible, and here is the proof it never had

Measured against a live Claude Code at 67 columns:

```
typed  "A"x63 + " next word"   renders   row0 = 63 A's,  row1 = "next word"
typed  "A"x64 + " next word"   renders   row0 = 63 A's,  row1 = "A next word"
```

Two different inputs, one byte-identical screen. In the first the separator space was swallowed at the wrap; in the second there is none. A mid-word wrap carries no separator at all, and two spaces at a boundary both vanish.

## But the feature never needed the whole line

`leftWindow` feeds three consumers and every one reads the tail: `leftAnchor` walks back to the first non-whitespace character, `completeLeftToken` wants the last word, and the name recogniser wants a little sentence context. Every other app in the product caps this at `caretContextWindow = 20` characters.

And the LAST row is the verbatim tail — verified at typed lengths 40 through 260, plus a 150-character unbroken word, on Claude Code, Gemini CLI and Codex.

**Our own knowledge base already said so.** `accessibility-macos.md`, written during #1803: *"The LAST CHARACTER survives all of that … the two jobs have different answers, so do not carry the refusal across"*, and *"Do not carry the whole-line wrap refusal onto the tail."* The shipped parser carried it across anyway, and that survived a coverage round, five grounded rounds and a cloud review.

## Codex was worse than the boxed path: it returned a wrong answer, silently

Its status-bar allowance is two populated rows, so a ONE-row wrap plus a one-row status bar passed the guard and returned the MARKER row — the text from before the wrap — and the repair acted on stale context with nothing logged.

## What changed

1. **A boxed layout reads its LAST populated body row.** The marker is validated on the FIRST row, where it actually is; a continuation row never carries one. The body slice is UNFILTERED, because the blank-row question cannot be asked after blank rows have been dropped.

2. **A blank row BELOW the text still refuses**, with its own name. Measured: `"A"x63 + " "` (text ending exactly at the wrap) and a deliberate new line draw the SAME two rows and want opposite answers.

3. **The Codex input block is found by walking UP from the last populated row.** Whole-diff review found the same class twice scanning downward — first the status bar absorbed as continuation text, then a user-indented hard-newline row ending the block early. Two rounds of one shape means the axis is wrong, so the class is enumerated: marker row, wrap continuation at the gutter, hard-newline row indented past it, a blank line inside the user's own prompt, and the caret's own trailing blank — versus the separator, the 1-2 status rows (same gutter!) and trailing blanks. Upward scanning separates them; downward cannot.

4. **`leftReachesDocumentStart` is carried, not inferred.** Pipeline derived it as `leftWindow.utf16.count == selectionLocation`, which is exact for a real caret and vacuous for a terminal — both values come from the same string there, so EVERY screen-derived context claimed to reach the start. A wrapped tail claiming that lets `completeLeftToken` treat a wrap fragment as a complete word, which authorises the one rule that DELETES a dictated word.

5. **One defect this change would otherwise have multiplied.** A terminal's trailing whitespace is unrecoverable in both directions, so the seam handed to the name recogniser may be fused: `with` + `Mark` reads as `withMark`, tags as a verb, and lowercases somebody's name. Rule 1's space prevents this everywhere else and Rule 1 is disabled in terminals. Measured over six names whose caret sits after a word: **fused recognised 1 of 6, separated recognised 5.** A screen-derived context now asks both readings and keeps the capital if either says name. It can only ever decline to lower.

## Validation

- **4,796 tests, zero failures**, run on this branch rebased onto `main` after #1931 merged.
- **4,397 real screen frames** captured over accessibility from the founder's own Ghostty while he worked, run through the real parser compiled from source: 43 located (5 genuinely wrapped, each reading the correct tail), 4,338 empty box, 15 `fewer_than_two_boundaries`, 1 `ambiguous_trailing_blank_row`, **zero wrap refusals**. Under the shipped code those 5 wrapped frames were `multiple_populated_body_rows(2)`.
- **Those 15 refusals are a different defect, filed as #1932 and not addressed here.** An earlier draft of this description called them "caught mid-redraw"; re-running the real parser over the frames shows every one is a Claude Code input box whose TOP border carries the session title (`──── ollama-build-order-decision ──`), which `boundaryClass` refuses because it is not one repeated glyph. All 15 had text already typed. It is a separate guard, it predates this change, and this change neither fixes nor worsens it.
- Design consulted with Codex BEFORE any code was written; it found five real problems, four fixed and the fifth (requiring every pre-wrap row to reach the screen's content edge) refuted by measurement and declined in a comment, because a word wrap leaves rows 62 and 60 cells wide on a 67-column screen.
- Three whole-diff review rounds to clean.
- Live UAT: back-to-back dictations into a wrapped Claude Code input, with a negative control that a wrapped line ending in a full stop keeps its capital.

Fixtures are the measured geometry captured from live CLIs. The previous wrapped fixture used an unindented continuation row, which no real CLI draws.

Closes #1926.
