### PR TITLE
fix(services): read an input box whose top border carries the session title

### DIFF
--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -571,6 +571,17 @@ struct KernelFinalizationWiring {
           if config?.smartInsertion != true { return "setting_off" }
           if context.targetElement == nil { return "no_target" }
           if let terminalRefusal { return terminalRefusal.rawValue }
+          // #1932. A titled box is named separately so the field can see that
+          // path working. The parser's own refusal names never get here —
+          // `TerminalContextResolver` collapses all ten into
+          // `terminal_screen_refused` on purpose, because that enum's raw values
+          // are a shipped closed set — so a titled path that silently stopped
+          // matching would be invisible without this. That is the six-week blind
+          // spot #1926 sat in, and it is why declining this field on the
+          // grounds that "the refusal side already shows it" was wrong.
+          if caretContext?.terminalEvidence?.located.boxOpeningKind == .titled {
+            return "terminal_read_titled_box"
+          }
           if caretContext?.isScreenDerived == true { return "terminal_read" }
           return caretContext == nil ? "unreadable" : "read_selected"
         }()

--- a/Sources/EnviousWisprServices/TerminalScreenParser.swift
+++ b/Sources/EnviousWisprServices/TerminalScreenParser.swift
@@ -33,10 +33,25 @@ package enum TerminalScreenParser {
     /// DELETES a dictated word.
     package let leftWasCut: Bool
 
-    package init(cli: SupportedTerminalCLI, inputLine: String, leftWasCut: Bool = false) {
+    /// How the box's opening rule was drawn, or nil for a CLI that draws no box.
+    ///
+    /// Carried so a titled read is visible in the FIELD. The parser's own
+    /// refusal names never leave the log: `TerminalContextResolver` collapses
+    /// every one of them into `terminal_screen_refused` before telemetry,
+    /// deliberately, because that enum's raw values are a shipped closed set. So
+    /// "the titled path silently stopped matching" cannot be seen from the
+    /// refusal side, which is what an earlier version of this change wrongly
+    /// assumed when it declined to carry this.
+    package let boxOpeningKind: BoxOpeningKind?
+
+    package init(
+      cli: SupportedTerminalCLI, inputLine: String, leftWasCut: Bool = false,
+      boxOpeningKind: BoxOpeningKind? = nil
+    ) {
       self.cli = cli
       self.inputLine = inputLine
       self.leftWasCut = leftWasCut
+      self.boxOpeningKind = boxOpeningKind
     }
   }
 
@@ -68,22 +83,150 @@ package enum TerminalScreenParser {
 
   // MARK: - Row helpers
 
-  /// Whether a row is one repeated box glyph — the rule above or below an input
-  /// box. Requires four to avoid matching a short `---` in prose.
-  static func boundaryClass(of row: Substring) -> BoundaryClass? {
-    let trimmed = row.trimmingCharacters(in: .whitespaces)
-    // ONE repeated glyph, which is what the rule always claimed and did not
-    // enforce: a mixture such as `─━═─` was accepted, so ASCII art or another
-    // tool's output could be misread as a box.
-    guard
-      trimmed.count >= 4,
-      let glyph = trimmed.first,
-      trimmed.dropFirst().allSatisfy({ $0 == glyph })
+  /// Any Box Drawing (U+2500–U+257F) or Block Element (U+2580–U+259F) codepoint.
+  ///
+  /// The two six-character sets above are the glyphs a rule is DRAWN with; this
+  /// is the whole range a divider might use. They are different questions, and
+  /// answering the second with the first let `──── a ├ b ──` pass as a titled
+  /// border, because `├` is a box-drawing character that neither set contains.
+  /// A title never legitimately contains one of these.
+  static func isBoxDrawingGlyph(_ character: Character) -> Bool {
+    character.unicodeScalars.contains { (0x2500...0x259F).contains($0.value) }
+  }
+
+  /// Which end of the box a row is being tested for.
+  ///
+  /// The two ends have DIFFERENT rules, so the mode is explicit rather than
+  /// implied by which function was called. Only the opening may carry a title.
+  enum BoundaryUse {
+    case opening
+    case closing
+  }
+
+  /// How the opening rule was drawn. Carried so the field can tell a titled
+  /// read from an ordinary one; the title's text is never recorded.
+  package enum BoxOpeningKind: String, Equatable, Sendable {
+    case plain
+    case titled
+  }
+
+  package struct BoundaryMatch: Equatable, Sendable {
+    package let boxClass: BoundaryClass
+    package let openingKind: BoxOpeningKind
+  }
+
+  /// Whether a row is the rule above or below an input box.
+  ///
+  /// ONE authority for both ends, taking the end as a parameter. This replaces
+  /// `boundaryClass(of:)`, which no longer exists under that name: the first cut
+  /// of #1932 kept it and added a second function beside it that re-derived the
+  /// glyph set and the class, which grounded review correctly called two border
+  /// authorities under a plan claiming one.
+  ///
+  /// A plain rule is one repeated glyph, at least four of them — the mixture
+  /// `─━═─` is refused so ASCII art cannot be misread as a box.
+  ///
+  /// An OPENING rule may also carry Claude Code's session title:
+  ///
+  ///     ──────────────────────────────────── ollama-build-order-decision ──
+  ///     ❯ commit it and keep going
+  ///     ───────────────────────────────────────────────────────────────────
+  ///
+  /// Requiring one repeated glyph meant that row was not a boundary, so
+  /// `locateBoxed` found fewer than two and continuation casing silently did
+  /// nothing. MEASURED over 4,397 accessibility frames captured from the
+  /// founder's own window: 15 refused this way, against 43 that located.
+  ///
+  /// The trailing run must be EXACTLY two, which is the only invariant the
+  /// capture actually shows — both measured rows are 36/2 and 20/2. An earlier
+  /// draft used the ratio `trailing * 4 <= leading` to mean "right-aligned",
+  /// reasoning that a fixed suffix would break the day Claude Code changed its
+  /// margin. Grounded review killed it with a counterexample that was then
+  /// reproduced against the real parser: an ordinary rule of 24 glyphs, a title,
+  /// and 6 glyphs satisfies the ratio exactly, so any right-heavy program output
+  /// with a `❯` line under it was located and its rendered text returned as the
+  /// user's own sentence. The two failure directions are not symmetric — a
+  /// margin change under the fixed suffix refuses, which is merely today's
+  /// behaviour, while the ratio accepts and PERMITS A REPAIR on text nobody
+  /// typed. Widen this only when a different geometry is actually observed.
+  ///
+  /// The title is Claude Code's own AI-generated session name, so nothing is
+  /// assumed about its language, characters or length — it is never read.
+  static func boundary(of row: Substring, for use: BoundaryUse) -> BoundaryMatch? {
+    let trimmed = Substring(row.trimmingCharacters(in: .whitespaces))
+    guard trimmed.count >= 4, let glyph = trimmed.first else { return nil }
+
+    let boxClass: BoundaryClass
+    if lightBoxGlyphs.contains(glyph) {
+      boxClass = .light
+    } else if blockBoxGlyphs.contains(glyph) {
+      boxClass = .block
+    } else {
+      return nil
+    }
+
+    if trimmed.dropFirst().allSatisfy({ $0 == glyph }) {
+      return BoundaryMatch(boxClass: boxClass, openingKind: .plain)
+    }
+
+    // Titled openings are LIGHT-RULE ONLY, which is the only class the capture
+    // ever showed one on. Cloud review caught the first cut extending it to
+    // Gemini's block rules, and that combined the looser border rule with the
+    // WEAKER marker: `>` is ordinary in quoted mail, diffs and redirects, which
+    // is exactly why this file refuses to search by it. Claude Code's `❯` is
+    // rare enough to carry the weight; `>` is not, so a titled block border
+    // would widen the false-accept surface where it is already thinnest — and
+    // on no evidence, since no Gemini session appears in the capture at all.
+    //
+    // Gemini therefore keeps today's strict behaviour exactly. Widen this when
+    // a real titled Gemini layout is observed, not before: an accepted screen
+    // permits a repair on text nobody typed, and a refusal costs a capital.
+    guard use == .opening, boxClass == .light, trimmed.last == glyph else { return nil }
+
+    let leading = trimmed.prefix(while: { $0 == glyph }).count
+    let trailing = trimmed.reversed().prefix(while: { $0 == glyph }).count
+    guard leading >= 4, trailing == 2, leading + trailing < trimmed.count else { return nil }
+
+    let middle = trimmed.dropFirst(leading).dropLast(trailing)
+
+    // The rest of the row is checked against the MEASURED STRUCTURE rather than
+    // against the findings so far, because enumerating from findings is what
+    // kept missing cases. Both captured rows are exactly:
+    //
+    //     <run of light glyph><space><title text><space><run of light glyph>
+    //
+    // so every part of that gets a guard: glyph CLASS and the two run LENGTHS
+    // above, then PADDING on both sides of the title, no box glyph of any class
+    // inside it, and at least one real character in it.
+    //
+    // An earlier revision listed "four ways this span can over-accept" and
+    // called the class closed. It was not: that list covered what may be INSIDE
+    // the middle and never its BOUNDARIES, so `────────────────────Section──`
+    // still passed and a program-rendered divider above a `❯` line was read as
+    // the live input. Deriving the guards from the row's shape closes the set
+    // by construction, which enumerating symptoms did not.
+    // A plain space or the non-breaking space a box pads with, and nothing else.
+    // `isWhitespace` also admits tabs and the exotic Unicode spaces, which no
+    // measured row uses — and program output that happens to use one would then
+    // pass as a border.
+    guard let opensPadding = middle.first, let closesPadding = middle.last,
+      opensPadding == " " || opensPadding == "\u{00A0}",
+      closesPadding == " " || closesPadding == "\u{00A0}"
     else { return nil }
 
-    if lightBoxGlyphs.contains(glyph) { return .light }
-    if blockBoxGlyphs.contains(glyph) { return .block }
-    return nil
+    // No box glyph of ANY class, not merely the leading one: a plain rule
+    // refuses the mixture `─━═─` deliberately, so admitting that same mixture
+    // through the title span contradicted the boundary contract, and
+    // `──── a ━━ b ──` was located with its rendered text returned as the
+    // user's sentence. This also rejects `──── a ──── b ────`, which is
+    // decoration rather than a border.
+    guard !middle.contains(where: isBoxDrawingGlyph) else { return nil }
+
+    // A title is text. Without this, `──── ────` — a rule broken by spaces —
+    // would read as a titled border.
+    guard middle.contains(where: { !$0.isWhitespace && $0 != "\u{00A0}" }) else { return nil }
+
+    return BoundaryMatch(boxClass: boxClass, openingKind: .titled)
   }
 
   package enum BoundaryClass: Equatable, Sendable {
@@ -419,15 +562,39 @@ package enum TerminalScreenParser {
 
   /// Claude Code and Gemini both draw a box; the RULE GLYPH tells them apart.
   static func locateBoxed(_ rows: [Substring]) -> BoxedLocateResult {
-    let boundaries = rows.indices.compactMap { index -> (Int, BoundaryClass)? in
-      boundaryClass(of: rows[index]).map { (index, $0) }
-    }
-    guard boundaries.count >= 2 else { return .refused(.fewerThanTwoBoundaries) }
+    // Only the opening border is permitted to carry a title. No titled closing
+    // border appeared in 4,397 captured frames. Keeping the closing strict is an
+    // explicit fail-closed POLICY, not a claim that titled closers never occur —
+    // and it is what stops a decorative row being taken for the bottom of a box.
+    guard
+      let closing = rows.indices.reversed().lazy
+        .compactMap({ index in boundary(of: rows[index], for: .closing).map { (index, $0) } })
+        .first
+    else { return .refused(.fewerThanTwoBoundaries) }
 
-    let closing = boundaries[boundaries.count - 1]
-    let opening = boundaries[boundaries.count - 2]
+    guard
+      let opening = rows[..<closing.0].indices.reversed().lazy
+        .compactMap({ index in boundary(of: rows[index], for: .opening).map { (index, $0) } })
+        .first
+    else { return .refused(.fewerThanTwoBoundaries) }
     // Both rules must be the same kind of box.
-    guard opening.1 == closing.1, closing.0 > opening.0 + 1 else {
+    //
+    // NOT the same WIDTH, though a revision of this change briefly required it.
+    // The idea was sound — two sides of one rectangle — and it measured clean on
+    // all 4,397 captured frames. It is still wrong, because `String.count` is
+    // not terminal columns: a CJK or emoji title occupies two cells per
+    // character, so a box that renders perfectly square has an opening whose
+    // count is SHORTER than its closing rule, and the check would refuse it.
+    // That silently disables terminal repair for anyone whose session title is
+    // not Latin, which is a far worse trade than the P3 it was added for — a
+    // divider pasted into the user's own input, which the marker check on the
+    // first body row already refuses.
+    //
+    // Doing it properly needs a terminal-cell-width helper validated against
+    // real captures, and no capture here contains a non-Latin title, so there is
+    // nothing to validate one against. Measuring in the wrong unit is not a
+    // smaller version of measuring correctly.
+    guard opening.1.boxClass == closing.1.boxClass, closing.0 > opening.0 + 1 else {
       return .refused(.incompatibleBoundaries)
     }
 
@@ -442,8 +609,8 @@ package enum TerminalScreenParser {
 
     guard !aLivePromptSits(below: closing.0, in: rows) else { return .refused(.livePromptBelow) }
 
-    let cli: SupportedTerminalCLI = closing.1 == .block ? .geminiCLI : .claudeCode
-    let marker = closing.1 == .block ? geminiMarker : claudeMarker
+    let cli: SupportedTerminalCLI = closing.1.boxClass == .block ? .geminiCLI : .claudeCode
+    let marker = closing.1.boxClass == .block ? geminiMarker : claudeMarker
     // The marker sits on the FIRST populated row. A wrapped continuation row
     // never carries one, so this is checked where the marker actually is rather
     // than on whichever row is read.
@@ -490,7 +657,10 @@ package enum TerminalScreenParser {
       ? stripLeadingMarker(body[last], marker)
       : stripContinuationGutter(body[last])
     guard !line.trimmingCharacters(in: .whitespaces).isEmpty else { return .refused(.emptyInput) }
-    return .located(Located(cli: cli, inputLine: line, leftWasCut: last != first))
+    return .located(
+      Located(
+        cli: cli, inputLine: line, leftWasCut: last != first,
+        boxOpeningKind: opening.1.openingKind))
   }
 
   enum BoxedLocateResult {

--- a/Tests/EnviousWisprTests/Services/TerminalScreenParserTests.swift
+++ b/Tests/EnviousWisprTests/Services/TerminalScreenParserTests.swift
@@ -24,6 +24,60 @@ struct TerminalScreenParserTests {
     """
   }
 
+  /// Claude Code with its session title drawn INTO the top rule.
+  ///
+  /// The default title row is the real one, copied byte-for-byte from frame
+  /// 2419 of the 2026-08-04 capture of the founder's own 67-column window: a
+  /// 36-glyph leading run, the space-padded title, then exactly 2 glyphs. The
+  /// closing rule stays plain, which is what the same capture shows — opening
+  /// titled 15 frames, closing titled 0.
+  ///
+  /// The closing rule is derived from the title row's width rather than
+  /// hard-coded, because the first draft drew a 67-wide top over an 8-wide
+  /// bottom and no real box looks like that — measured across all 4,397 frames
+  /// the two rules match in 4,397 and differ in 0. The PARSER does not require
+  /// it (a width check was tried and removed: `String.count` is not terminal
+  /// columns, so it refused a square box with a CJK title). The fixture stays
+  /// faithful anyway, because a fixture looser than production hides exactly the
+  /// defect it exists to catch.
+  private static func claudeTitledBox(
+    _ input: String,
+    title: String = "\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}"
+      + "\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}"
+      + "\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}"
+      + "\u{2500}\u{2500}\u{2500}\u{2500}\u{2500} ollama-build-order-decision \u{2500}\u{2500}",
+    footer: String = "  ? for shortcuts"
+  ) -> String {
+    """
+    some earlier output
+    \(title)
+    \u{276F} \(input)
+    \(String(repeating: "\u{2500}", count: title.count))
+    \(footer)
+    """
+  }
+
+  /// A screen whose opening row is `opening` and whose CLOSING rule is the same
+  /// width, so the only thing a test varies is the opening's own shape.
+  ///
+  /// Every negative below needs this. While a width invariant was briefly in the
+  /// parser, a fixture with a 34-wide opening over a 40-wide closing refused for
+  /// the WIDTH — not for the centred title, the mixed glyph, or whatever the
+  /// test was named after — and would have gone on passing while testing
+  /// nothing. The invariant is gone, but the lesson is not: an acceptance check
+  /// must be able to reach its own subject, so widths stay matched here.
+  private static func boxWithOpening(
+    _ opening: String, input: String = "rendered output", marker: Character = "\u{276F}",
+    closingGlyph: Character = "\u{2500}"
+  ) -> String {
+    """
+    earlier output
+    \(opening)
+    \(marker) \(input)
+    \(String(repeating: String(closingGlyph), count: opening.count))
+    """
+  }
+
   /// Gemini: half-block rules with a plain `>` inside.
   private static func geminiBox(_ input: String) -> String {
     """
@@ -495,6 +549,365 @@ struct TerminalScreenParserTests {
   func unrecognisedScreenRefuses() {
     #expect(TerminalScreenParser.locate(inScreenTail: "") == nil)
     #expect(TerminalScreenParser.locate(inScreenTail: "just some output\nand more") == nil)
+  }
+
+  // MARK: - #1932: a top rule carrying the session title
+  //
+  // Claude Code draws the session name into the OPENING rule. `boundaryClass`
+  // wanted one repeated glyph, so the row was not a boundary and the whole box
+  // was refused as `fewer_than_two_boundaries` — measured at 15 of 4,397 frames
+  // captured from the founder's own window, against 43 that located.
+
+  @Test("#1932: a titled top rule is still the top of the box")
+  func titledOpeningRuleIsFound() throws {
+    let located = try #require(
+      TerminalScreenParser.locate(inScreenTail: Self.claudeTitledBox("Hey, so we")))
+    #expect(located.cli == .claudeCode)
+    #expect(located.inputLine == "Hey, so we")
+    #expect(located.leftWasCut == false)
+  }
+
+  @Test("#1932: the title's own content is never read, whatever it contains")
+  func titledRuleContentIsIrrelevant() throws {
+    // The title is Claude Code's AI-generated session name, so it can be any
+    // language and any length. Hold the GEOMETRY fixed at the measured
+    // right-aligned shape and vary only the text, or the test stops being about
+    // content — the first draft varied both and failed on its own short leading
+    // runs rather than on anything to do with the characters.
+    let lead = String(repeating: "\u{2500}", count: 20)
+    let trail = String(repeating: "\u{2500}", count: 2)
+    for text in [
+      "\u{6E2C}\u{8A66}\u{30BB}\u{30C3}\u{30B7}\u{30E7}\u{30F3}",
+      "a",
+      "1.2.3 (draft)",
+      "\u{0440}\u{0435}\u{0444}\u{0430}\u{043A}\u{0442}\u{043E}\u{0440}\u{0438}\u{043D}\u{0433}",
+      "fix: don't drop the user's text",
+    ] {
+      // Closing rule sized in terminal COLUMNS, not `String.count` — a CJK
+      // character occupies two cells. Building it from `title.count` is what
+      // hid the width-invariant defect: the fixture reproduced the same wrong
+      // count and passed while a real box would have been refused.
+      let columns =
+        lead.count + trail.count + 2
+        + text.unicodeScalars.reduce(0) { $0 + (($1.value >= 0x1100) ? 2 : 1) }
+      let screen = """
+        some earlier output
+        \(lead) \(text) \(trail)
+        \u{276F} carry on
+        \(String(repeating: "\u{2500}", count: columns))
+          ? for shortcuts
+        """
+      let located = try #require(
+        TerminalScreenParser.locate(inScreenTail: screen), "title \(text) should still locate")
+      #expect(located.inputLine == "carry on")
+    }
+  }
+
+  @Test("#1932: a titled rule composes with a WRAPPED input, still reading the tail")
+  func titledRuleAroundWrappedInput() throws {
+    let titled =
+      String(repeating: "\u{2500}", count: 20) + " ollama-build-order-decision "
+      + String(repeating: "\u{2500}", count: 2)
+    // Same width as the opening, because that is what a box is.
+    let rule = String(repeating: "\u{2500}", count: titled.count)
+    let screen = """
+      earlier output
+      \(titled)
+      \u{276F}\u{00A0}the first row of what was typed
+      \u{00A0}\u{00A0}and the tail after it wrapped
+      \(rule)
+      """
+    let located = try #require(TerminalScreenParser.locate(inScreenTail: screen))
+    #expect(located.inputLine == "and the tail after it wrapped")
+    #expect(located.leftWasCut, "a wrapped titled box must still report the cut")
+  }
+
+  // The adversarial negatives. Each is a DIFFERENT way the shape could
+  // over-match, not three phrasings of one way.
+
+  @Test("#1932: the CLOSING rule may not be titled")
+  func titledClosingRuleRefuses() {
+    let titled =
+      String(repeating: "\u{2500}", count: 20) + " not a bottom border "
+      + String(repeating: "\u{2500}", count: 2)
+    let screen = """
+      \(String(repeating: "\u{2500}", count: 8))
+      \u{276F} some text
+      \(titled)
+      """
+    #expect(TerminalScreenParser.locate(inScreenTail: screen) == nil)
+  }
+
+  @Test("#1932: a rule broken by text TWICE is decoration, not a border")
+  func glyphReappearingInTheMiddleRefuses() {
+    // `──── a ──── b ────` is a divider row some tools print. The middle
+    // containing the glyph is exactly what separates it from a titled border.
+    let decoration =
+      String(repeating: "\u{2500}", count: 6) + " a " + String(repeating: "\u{2500}", count: 6)
+      + " b " + String(repeating: "\u{2500}", count: 6)
+    #expect(
+      TerminalScreenParser.locate(
+        inScreenTail: Self.boxWithOpening(decoration, input: "some text")) == nil)
+  }
+
+  @Test("#1932: an ASCII markdown rule with a title is not a box rule")
+  func asciiRuleWithTitleRefuses() {
+    let screen = """
+      --- Chapter One ---
+      \u{276F} some text
+      \(String(repeating: "\u{2500}", count: 8))
+      """
+    #expect(TerminalScreenParser.locate(inScreenTail: screen) == nil)
+  }
+
+  @Test("#1932: a titled rule whose glyph CLASS differs from the closing refuses")
+  func titledOpeningOfTheWrongClassRefuses() {
+    let titled =
+      String(repeating: "\u{2500}", count: 20) + " light on top "
+      + String(repeating: "\u{2500}", count: 2)
+    #expect(
+      TerminalScreenParser.locate(
+        inScreenTail: Self.boxWithOpening(titled, input: "some text", closingGlyph: "\u{2580}"))
+        == nil)
+  }
+
+  @Test("#1932: a titled rule cannot rescue a box whose marker is missing")
+  func titledRuleStillRequiresTheMarker() {
+    // The measured spoof — a file of box-drawing rows shown in vim or less —
+    // carries no marker, and a title must not become a way around that.
+    let titled =
+      String(repeating: "\u{2500}", count: 20) + " some-file.txt "
+      + String(repeating: "\u{2500}", count: 2)
+    let screen = """
+      \(titled)
+      just an ordinary line of a file
+      \(String(repeating: "\u{2500}", count: 8))
+      """
+    #expect(TerminalScreenParser.locate(inScreenTail: screen) == nil)
+  }
+
+  @Test("#1932: a titled box left in scrollback still refuses under a live prompt")
+  func titledBoxInScrollbackRefuses() {
+    let titled =
+      String(repeating: "\u{2500}", count: 20) + " old-session "
+      + String(repeating: "\u{2500}", count: 2)
+    let screen = """
+      \(titled)
+      \u{276F} something typed a while ago
+      \(String(repeating: "\u{2500}", count: 8))
+      \u{276F} \u{00A0}
+      """
+    #expect(TerminalScreenParser.locate(inScreenTail: screen) == nil)
+  }
+
+  @Test("#1932: glyph runs separated only by SPACES are not a title")
+  func glyphRunsSplitBySpacesRefuse() {
+    // `──── ────` has no text between the runs, so it is a broken rule rather
+    // than a titled one. Without this the middle-has-no-glyph test alone would
+    // accept it.
+    let screen = """
+      \(String(repeating: "\u{2500}", count: 6))   \(String(repeating: "\u{2500}", count: 6))
+      \u{276F} some text
+      \(String(repeating: "\u{2500}", count: 8))
+      """
+    #expect(TerminalScreenParser.locate(inScreenTail: screen) == nil)
+  }
+
+  @Test("#1932: a tree-drawing row is not a border even with a box glyph in it")
+  func treeRowIsNotABorder() {
+    let screen = """
+      \u{251C}\u{2500}\u{2500} Sources
+      \u{276F} some text
+      \(String(repeating: "\u{2500}", count: 8))
+      """
+    #expect(TerminalScreenParser.locate(inScreenTail: screen) == nil)
+  }
+
+  @Test("#1932: a CENTRED titled rule is another tool's output, not our box")
+  func centredTitledRuleRefuses() {
+    // Python Rich's `Console.rule("Chapter 2")` centres its title, and a program
+    // printing a line that happens to open with `❯` between two rules then looks
+    // exactly like an input box. Found by coverage review and CONFIRMED by
+    // replaying the real parser, which located it and returned the program's
+    // output as the user's sentence. Right-alignment is what separates ours.
+    let centred =
+      String(repeating: "\u{2500}", count: 20) + " Chapter 2 "
+      + String(repeating: "\u{2500}", count: 20)
+    #expect(
+      TerminalScreenParser.locate(
+        inScreenTail: Self.boxWithOpening(centred, input: "this is rendered output")) == nil)
+  }
+
+  @Test("#1932: a LEFT-aligned titled rule refuses too")
+  func leftAlignedTitledRuleRefuses() {
+    let leftAligned =
+      String(repeating: "\u{2500}", count: 2) + " Chapter 2 "
+      + String(repeating: "\u{2500}", count: 30)
+    #expect(
+      TerminalScreenParser.locate(
+        inScreenTail: Self.boxWithOpening(leftAligned, input: "this is rendered output")) == nil)
+  }
+
+  @Test("#1932: a titled GEMINI block border refuses — untested is not supported")
+  func titledGeminiOpeningRefuses() {
+    // Titled openings are light-rule only. Cloud review caught the first cut
+    // extending them to Gemini's block rules, which combines the looser border
+    // rule with the WEAKER marker — `>` is ordinary in quoted mail, diffs and
+    // redirects, which is why this parser refuses to search by it. And there is
+    // no evidence for it either way: no Gemini session appears in the 4,397-frame
+    // capture. Refusing keeps Gemini exactly as it is today.
+    let titled =
+      String(repeating: "\u{2584}", count: 20) + " Gemini session "
+      + String(repeating: "\u{2584}", count: 2)
+    let screen = """
+      earlier output
+      \(titled)
+      > explain this result
+      \(String(repeating: "\u{2580}", count: 36))
+      """
+    #expect(TerminalScreenParser.locate(inScreenTail: screen) == nil)
+  }
+
+  @Test("#1932: an ordinary PLAIN Gemini box is untouched by any of this")
+  func plainGeminiBoxStillWorks() throws {
+    // The two-way control for the refusal above: Gemini must still work exactly
+    // as before, or "restrict to light rules" would have broken it outright.
+    let located = try #require(
+      TerminalScreenParser.locate(inScreenTail: Self.geminiBox("explain this to me")))
+    #expect(located.cli == .geminiCLI)
+    #expect(located.inputLine == "explain this to me")
+    #expect(located.boxOpeningKind == .plain)
+  }
+
+  @Test("#1932: a right-heavy rule outside the measured suffix refuses")
+  func rightHeavyRuleRefuses() {
+    // Grounded review's counterexample, reproduced against the real parser
+    // before it was accepted: 24 glyphs, a title, 6 glyphs satisfies a
+    // `trailing * 4 <= leading` ratio EXACTLY. Ordinary program output can
+    // reproduce any ratio, so the matcher takes only the measured suffix of two.
+    let opening =
+      String(repeating: "\u{2500}", count: 24) + " report "
+      + String(repeating: "\u{2500}", count: 6)
+    #expect(
+      TerminalScreenParser.locate(
+        inScreenTail: Self.boxWithOpening(opening, input: "rendered output")) == nil)
+  }
+
+  @Test("#1932: a divider pasted INSIDE the box cannot shadow the real top rule")
+  func titledDividerInsideTheBodyRefuses() {
+    // Cloud review's finding: a titled row is now a legal opening, so a divider
+    // pasted into the user's OWN input was picked ahead of the real top rule.
+    // It refuses because the first body row after that divider carries no
+    // marker, which is the guard this file already leans on hardest. A width
+    // invariant was tried here and REMOVED: `String.count` is not terminal
+    // columns, so it rejected a perfectly square box with a CJK title.
+    let rule = String(repeating: "\u{2500}", count: 40)
+    let screen = """
+      earlier output
+      \(rule)
+      \u{276F} first line the user typed
+        \(String(repeating: "\u{2500}", count: 8)) Section \(String(repeating: "\u{2500}", count: 2))
+        more typed text
+      \(rule)
+      """
+    #expect(TerminalScreenParser.locate(inScreenTail: screen) == nil)
+  }
+
+  @Test("#1932: an UNPADDED title is a program divider, not our border")
+  func unpaddedTitleRefuses() {
+    // Both measured rows pad the title with a space on each side. A divider
+    // printed as `────────Section──` does not, and cloud review caught it being
+    // accepted — a program-rendered rule above a `❯` output line then read as
+    // the live input. Every side of the padding is covered, not just the one
+    // reported, because the previous "enumerated the class" claim missed the
+    // middle's BOUNDARIES while covering its contents.
+    let cases = [
+      String(repeating: "\u{2500}", count: 20) + "Section"
+        + String(repeating: "\u{2500}", count: 2),
+      String(repeating: "\u{2500}", count: 20) + "Section "
+        + String(repeating: "\u{2500}", count: 2),
+      String(repeating: "\u{2500}", count: 20) + " Section"
+        + String(repeating: "\u{2500}", count: 2),
+    ]
+    for opening in cases {
+      #expect(
+        TerminalScreenParser.locate(inScreenTail: Self.boxWithOpening(opening)) == nil,
+        "unpadded title must refuse: \(opening)")
+    }
+  }
+
+  @Test("#1932: any box-drawing character in the title makes it a divider")
+  func boxDrawingCharacterInTitleRefuses() {
+    // The six glyphs a rule is DRAWN with are not the range a divider may USE.
+    // Answering the second question with the first let `──── a ├ b ──` pass,
+    // because `├` is box-drawing and in neither set. Local review caught it.
+    for interloper in ["\u{251C}", "\u{253C}", "\u{2502}", "\u{2554}", "\u{2591}"] {
+      let opening =
+        String(repeating: "\u{2500}", count: 24) + " a \(interloper) b "
+        + String(repeating: "\u{2500}", count: 2)
+      #expect(
+        TerminalScreenParser.locate(inScreenTail: Self.boxWithOpening(opening)) == nil,
+        "box-drawing \(interloper) in a title must refuse")
+    }
+  }
+
+  @Test("#1932: the title's padding must be a real space, not any whitespace")
+  func exoticWhitespacePaddingRefuses() {
+    // Every measured row pads with U+0020. `isWhitespace` also admits tabs and
+    // the Unicode spaces, which program output can produce and no Claude Code
+    // border does.
+    for pad in ["\t", "\u{2003}", "\u{2009}"] {
+      let opening =
+        String(repeating: "\u{2500}", count: 24) + "\(pad)Section\(pad)"
+        + String(repeating: "\u{2500}", count: 2)
+      #expect(
+        TerminalScreenParser.locate(inScreenTail: Self.boxWithOpening(opening)) == nil,
+        "padding \(pad.debugDescription) must refuse")
+    }
+  }
+
+  @Test("#1932: a titled rule mixing box glyphs is a divider, not a border")
+  func mixedGlyphTitledRuleRefuses() {
+    // Cloud review's finding, reproduced against the real parser: the middle
+    // check was scoped to the LEADING glyph, so a different box glyph inside the
+    // title span slipped through and a mixed divider under a `❯` line returned
+    // its rendered text as the user's sentence. A plain rule already refuses the
+    // mixture `─━═─` deliberately, so admitting it through the title span
+    // contradicted the boundary contract.
+    //
+    // The whole class, not just the reported instance: every box glyph of every
+    // class, in either box family, and in either run's neighbourhood.
+    let cases = [
+      String(repeating: "\u{2500}", count: 24) + " a \u{2501}\u{2501} b "
+        + String(repeating: "\u{2500}", count: 2),
+      String(repeating: "\u{2500}", count: 24) + " a \u{2550} b "
+        + String(repeating: "\u{2500}", count: 2),
+      String(repeating: "\u{2500}", count: 24) + " a \u{2584} b "
+        + String(repeating: "\u{2500}", count: 2),
+      String(repeating: "\u{2584}", count: 24) + " a \u{2580} b "
+        + String(repeating: "\u{2584}", count: 2),
+    ]
+    for opening in cases {
+      #expect(
+        TerminalScreenParser.locate(inScreenTail: Self.boxWithOpening(opening)) == nil,
+        "mixed-glyph divider must refuse: \(opening)")
+    }
+  }
+
+  @Test("#1932: the opening kind is recorded, so the field can see this path")
+  func openingKindIsRecorded() throws {
+    let titled = try #require(
+      TerminalScreenParser.locate(inScreenTail: Self.claudeTitledBox("Hey, so we")))
+    #expect(titled.boxOpeningKind == .titled)
+
+    let plain = try #require(
+      TerminalScreenParser.locate(inScreenTail: Self.claudeBox("Hey, so we")))
+    #expect(plain.boxOpeningKind == .plain)
+
+    // Codex draws no box at all, so it has no opening kind to report.
+    let codex = try #require(
+      TerminalScreenParser.locate(inScreenTail: Self.codexScreen("Hey, so we")))
+    #expect(codex.boxOpeningKind == nil)
   }
 
   // MARK: - The two live spoofs


### PR DESCRIPTION
Claude Code draws the session name **into the top rule** of its input box:

```
──────────────────────────────────── ollama-build-order-decision ──
❯ commit it and keep going
───────────────────────────────────────────────────────────────────
```

`boundaryClass` wants one repeated glyph, so that row was not a boundary, `locateBoxed` found fewer than two, and continuation casing silently did nothing. The user gets a stray capital and nothing explains why.

Found while validating #1926, and it is a **separate guard that predates it** — the refusal is in the original feature commit, not in the wrap work.

## Measured, with the shipped parser

`TerminalScreenParser.swift` imports only `Foundation` and needs one type from elsewhere in its module, so the real source compiles standalone against a driver. Run unmodified over **4,397 accessibility frames captured from the founder's own 67-column window** on 2026-08-04:

| Outcome | Frames |
|---|---|
| `LOCATED claude_code` | 43 |
| **`refused fewer_than_two_boundaries`** | **15** |
| `refused ambiguous_trailing_blank_row` | 1 |
| `refused empty_input` | 4,338 |

Every one of the 15 is a titled border. Against 43 located frames, not a corner case.

## Two ends, one matcher

One `boundary(of:for:)` takes the end as a parameter. The closing rule stays **strict**; the opening may carry a title. Across the same capture the opening was titled 15 times and the closing **zero** — which is absence of a positive example rather than proof a titled closer cannot exist, so the strict closer is an explicit fail-closed **policy**, not an inference. It is also what stops a decorative row being taken for the bottom of a box.

## The trailing run must be EXACTLY two

`leading >= 4`, `trailing == 2`. This took two review rounds, and both are worth recording because the first fix was wrong for a reason that sounded right.

**Coverage review** found the rule as first written accepts Python Rich's `Console.rule("Chapter 2")`, which centres its title — replaying the real parser confirmed it, returning a program's rendered output as the user's own sentence. I fixed it with the ratio `trailing * 4 <= leading` ("the title must be right-aligned") and argued against the reviewer's proposed literal `trailing == 2`, on the grounds that a fixed suffix would break the day Claude Code changed its margin.

**Grounded review killed that**, with a counterexample I then reproduced against the real parser: an ordinary rule of **24 glyphs, a title, 6 glyphs** satisfies `trailing * 4 <= leading` exactly, so any right-heavy program output with a `❯` line under it was located. Right-alignment is not an identity — general terminal output reproduces any ratio. And the ratio bought nothing it was meant to: Rich's *right-aligned* rule ends with the title text rather than a glyph, so `trimmed.last == glyph` had already excluded it.

**The two failure directions are not symmetric, and that settles it.** Under the fixed suffix a future margin change REFUSES — merely today's behaviour, the bug this fixes, not a new harm. Under the ratio it ACCEPTS and permits a repair on text nobody typed.

Verified against the capture: the narrowing changes none of the 15 frames.

**Correction to the plan's own safety argument.** An earlier draft claimed a wrong match "fails toward no repair". False, and both reviewers rejected it: a wrong match returns `Located`, which permits a repair. Wrongly accepting a screen is the dangerous direction, which is why both narrowings are in this change rather than follow-ups.

## One border authority, not two

The first draft added `openingBoundaryClass` beside `boundaryClass`, delegating only the plain case and re-deriving the glyph set and class for titled rows — two authorities under a plan claiming one. Grounded review named it; it is now a single `boundary(of:for:)` taking the end as a parameter, so the two ends cannot drift apart.

## Differential replay

Both parsers compiled from source, all 4,397 frames, comparing outcome **and located payload**:

```
frames total            : 4397
allowlisted (titled)    : 15
  of those, changed     : 15
NON-allowlisted changed : 0
VERDICT: PASS — only allowlisted frames moved
```

Every one of the 15 moved from `boxed:fewer_than_two_boundaries`; eleven now locate and four correctly report an empty box.

The ship criterion originally only protected frames that already **located**, which a broken implementation could satisfy while newly locating all 4,338 empty ones. Coverage review caught that; the criterion is now the full differential above.

## Telemetry: a titled read is named in the field

Coverage review proposed carrying a `boxOpeningKind` and emitting `caret_context=terminal_read_titled_box`. **I declined it, and I was wrong.**

My reasoning was that the regression is already visible on the refusal side, since `KernelFinalizationWiring` returns `terminalRefusal.rawValue` before the success branch. Grounded review checked it: `terminalRefusal` is a `TerminalContextRefusal`, and `TerminalContextResolver.swift:370-388` collapses all ten parser refusals into the single `terminal_screen_refused` before telemetry sees anything. The parser's own names go to `AppLogger` and nowhere else — deliberately, because that enum's raw values are a shipped closed set. The 8-of-9 statistic that started this investigation came from the founder's **local debug log**, not production, which is exactly consistent.

So the regression signal does not exist in the field, and declining was a factual error rather than a judgement call. **Accepted:** `Located` carries `boxOpeningKind`, and a successful titled read emits `caret_context=terminal_read_titled_box`. Never the title, the row, the input text, or any glyph count — a closed-set name only.

## Tests

Twenty-one, and the negatives are separate ways the shape can over-match rather than rephrasings of one: a centred titled rule, a left-aligned one, a titled **closing** rule, a glyph reappearing mid-row, an ASCII markdown rule, a mismatched glyph class, a titled rule with no marker, a titled box in scrollback under a live prompt, glyph runs split only by spaces, a tree-drawing row, a right-heavy rule outside the measured suffix, a titled BLOCK rule, and an unpadded title in each of its three forms.

Positives use the measured geometry, hold it fixed while varying only the title text (the first draft varied both and failed on its own short runs), compose with a **wrapped** input, and pair a titled-Gemini REFUSAL with a plain-Gemini positive, so restricting the class is shown not to have broken Gemini outright.

**Two-way control:** all three synthetic positives are refused by the pre-fix parser and located by this one, so the tests measure the change rather than restate it.

## Cloud review: a fourth way the title span was too permissive

`middle.contains(glyph)` rejected only the LEADING glyph reappearing, so a row mixing box glyphs — `──── a ━━ b ──` — was accepted. Reproduced against the real parser: located, and the program's rendered output returned as the user's sentence. It also contradicted the boundary contract, since a plain rule refuses the mixture `─━═─` deliberately.

Three review rounds had now each found this one span too generous, so it is **enumerated rather than patched a fourth time**. The ways a titled row can over-accept are: the run LENGTHS (`leading >= 4`, `trailing == 2`); the SAME glyph reappearing (decoration, `──── a ──── b ────`); a DIFFERENT box glyph (this finding); and a middle that is only padding (`──── ────`). The check is now against the box-glyph CLASSES, and the test covers all four box glyphs in both families rather than only the reported instance.

Real frames unaffected: the 15 still fix, nothing else moves.

## Cloud review, round 3: the title must be SPACE-PADDED

Round 2's fix came with a claim that the class was "now enumerated", listing four ways the middle span could over-accept. **It was not enumerated.** That list covered what may be INSIDE the middle and never its BOUNDARIES — both measured rows pad the title with a space on each side, and nothing checked it, so `────────────────────Section──` was still accepted and a program-rendered divider above a `❯` line read as the live input.

Enumerating symptoms kept missing cases, so the guards are now derived from the measured row instead:

```
<run of light glyph><space><title text><space><run of light glyph>
```

One guard per part: glyph class, both run lengths, padding on each side, no box glyph of any class inside, at least one real character inside. That closes the set by construction rather than by my having thought of enough cases.

## Cloud review, round 2: titled openings are LIGHT-RULE only

The first cut accepted a titled **block** rule too, extending titled support to Gemini on no evidence — the 4,397-frame capture contains no Gemini session at all. Worse, it combined the looser border rule with the **weaker marker**: Gemini's is `>`, which this file already refuses to *search* by because it is ordinary in quoted mail, diffs and redirects, while Claude Code's `❯` is rare enough to carry the weight. The one place the marker is thinnest was the one place the border got loosest.

Gemini now keeps today's behaviour exactly, with a two-way control proving an ordinary plain Gemini box still reads.

**That is seven widenings beyond the measurement rejected in this one change** — centred rules, a right-heavy ratio, mixed glyphs, a glyph class, an unpadded title, an incomplete glyph range, and exotic padding — plus one narrowing that went too far the other way and had to come out. One lesson: widen only to what was actually observed, because an accepted screen permits a repair on text nobody typed while a refusal only costs a capital.

## Local review: a narrowing that went too far, and two that did not go far enough

**A width invariant was added and then REMOVED, and the removal is the most useful thing here.** Cloud review round 4 found a divider pasted into the user's own input could be picked as the opening ahead of the real top rule, so I required both rules to match in width — two sides of one rectangle, clean on 4,397 of 4,397 frames.

Local review showed it **rejects valid input.** `String.count` is not terminal columns: a CJK or emoji title occupies two cells per character, so a box that renders perfectly square has an opening whose count is SHORTER than its closing rule, and the check refuses it — silently disabling terminal repair for anyone whose session title is not Latin. Far worse than the P3 it was added for, which the marker check already refuses. Verified both ways: a CJK-titled box now locates, the pasted divider still refuses.

**My own multilingual test hid it**, because it built the closing rule from `title.count` — the same wrong unit — so the fixture reproduced the defect and passed. It now sizes the rule in columns. Doing this properly needs a cell-width helper validated against real captures, and no capture here has a non-Latin title, so there is nothing to validate one against.

The invariant left one real improvement behind: it failed four of this change's own tests, and there the FIXTURES were wrong — a 67-wide top over an 8-wide bottom, which no real box draws. Most negatives were mismatched too, so they had started refusing for the WIDTH rather than for the property they were named after. One helper now keeps them matched.

Two more unmeasured shapes closed: the six glyphs a rule is DRAWN with are not the range a divider may USE (`──── a ├ b ──` passed until the check became the whole U+2500–U+259F range), and padding was `isWhitespace`, which admits tabs and exotic Unicode spaces no measured row uses.

Confirming local round: all three fixes OK, no new issues.

## One defect this unmasks without creating

Filed as #1934. Claude Code renders `❯ Press up to edit queued messages` on the marker row while messages are queued, and the parser cannot tell a placeholder from typed text. Verified against the **baseline** parser that an untitled border with the same placeholder is located today, so the class is pre-existing; this change adds the titled variant of it. Two frames of 4,397, during compaction.

## Validation

- **4,818 tests, zero failures.**
- Differential replay above.
- Coverage review: 4 findings — 3 accepted, 1 declined.
- Grounded review: 4 findings, all accepted, including one that overturned my decline above and one that overturned my own fix for the coverage finding.
- **Live UAT in a real titled Claude Code: 8 of 10 rounds, zero wrong repairs.**

### The live run

Driven through a scratch Ghostty at 67 columns with a real Claude Code whose border WAS titled, so every round exercised this change and #1926 together. Verdicts read from `app.log`, not the clipboard.

Every one of the ten reads came back `caret=terminal_read_titled_box` — the new value, on the same screen shape that returned `boxed:fewer_than_two_boundaries` an hour earlier on the pre-fix build, where the identical fixtures scored **0 of 10**.

The discriminating pair both landed:

| round | decision | correct? |
|---|---|---|
| control: wrapped line ending in a full stop | `case_kept:after_terminator` | capital kept ✓ |
| continuations 1-3, cumulative 2-4 | `lowercased_first` | joined lowercase ✓ |
| seam: a real name after a wrapped line | `case_skipped:recognized_name` | name kept ✓ |

**The two failures are both #1926's designed behaviour, not defects here, and neither is a wrong repair:**

1. *wrapped continuation 4* — the decoder misheard the fixture: it was scripted `want to add one more clause` and ASR produced `Wanna add one more clause`. The name oracle judged that capitalised token a name and returned `case_skipped:recognized_name`. The rule can only ever DECLINE to lower, so it left a capital rather than damaging text.
2. *cumulative pass 1* — the typed chunk was 63 characters, exactly the row capacity, so its trailing space wrapped to a blank last row. That is precisely the shape #1926 refuses as `boxed:ambiguous_trailing_blank_row`, because a deliberate Enter draws identical rows and wants the opposite answer. Filed separately as #1935.

Zero wrong repairs in ten rounds: every failure is "did not fix it", never "made it worse".

Closes #1932.
