### PR TITLE
fix(services): raise the terminal resolution budget to 200ms (Part of #1941)

### DIFF
--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -668,7 +668,10 @@ struct KernelFinalizationWiring {
         // because the whole overspend lived in the half no line covered.
         //
         // Everything before `|recheck|` was already on the repair line; the
-        // suffix is new, and the total is what the 100 ms cap is judged against.
+        // suffix is new, and the total is what the cumulative cap is judged
+        // against. That cap is `TerminalResolutionBudget.defaultTotal`, which
+        // owns the current value — do not restate the number here, because a
+        // second copy is what goes stale (it read "100 ms" until 2026-08-05).
         await AppLogger.shared.log(
           "CURSOR_COMMIT submitted=\(result.submittedPayload?.rawValue ?? "none") "
             + "tier=\(result.pasteTierLabel ?? "none") "

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -914,7 +914,9 @@ public enum PasteService {
   ///
   /// When a `budget` is supplied, EVERY accessibility call inside is wrapped so
   /// the cap applies to all of them TOGETHER (founder 2026-07-28: "it has to be
-  /// a 100 ms cap for all the questions"). Passing no budget is today's path
+  /// a 100 ms cap for all the questions"; the cumulative rule stands, the value
+  /// is 200 ms since 2026-08-05 — `TerminalResolutionBudget.defaultTotal` owns
+  /// why). Passing no budget is today's path
   /// exactly, at the standard failure timeout — which is what every non-terminal
   /// app takes.
   static func caretDerivedContext(

--- a/Sources/EnviousWisprServices/TerminalContextResolver.swift
+++ b/Sources/EnviousWisprServices/TerminalContextResolver.swift
@@ -65,7 +65,30 @@ package enum TerminalContextResult: Equatable, Sendable {
 /// the user, on the heart path. A per-CALL limit would not bound that; only a
 /// cumulative one does. No call, route, retry or revalidation resets it.
 package final class TerminalResolutionBudget: Sendable {
-  package static let defaultTotal: Double = 0.100
+  /// 200 ms, raised from 100 ms (founder, 2026-08-05). INTERIM — the cost this
+  /// accommodates is a defect, tracked in #1943.
+  ///
+  /// The cap has always been cumulative, and that half of the original decision
+  /// is unchanged (founder 2026-07-28: "it has to be a 100 ms cap for all the
+  /// questions"). Only the number moved, and it moved because the number was
+  /// set against a cost that turned out to be wrong by an order of magnitude.
+  ///
+  /// What forced it: Gate 1's process scan is charged here, and it walks EVERY
+  /// pid on the machine at ~4 syscalls each. Measured on the real path across
+  /// one ordinary session — 36, 49, 54, 61, 77, 77 ms, then 114.7 ms, which
+  /// exhausted the old cap and tripped the breaker. `TerminalCircuitBreaker`
+  /// has no production reset, so that single moment turned terminal insertion
+  /// off for the rest of that terminal's life with nothing shown to the user
+  /// (#1941). A later clean session measured 60-65 ms per dictation: passing,
+  /// but spending two thirds of the old cap on one step with no headroom.
+  ///
+  /// Why raising it is the right INTERIM move and the wrong permanent one: the
+  /// worst case here is added latency before falling back to the payload we
+  /// would have pasted anyway, whereas exhausting it is a silent permanent
+  /// feature loss. Trading up to 100 ms of rare worst-case delay against that is
+  /// worth it today. It is not a fix — #1943 makes the scan cheap, and this
+  /// number should come back down once it lands, against a re-measured cost.
+  package static let defaultTotal: Double = 0.200
 
   private let total: Double
   private let spent = OSAllocatedUnfairLock(initialState: 0.0)
@@ -131,6 +154,11 @@ package final class TerminalResolutionBudget: Sendable {
   /// 2026-07-28: "it has to be a 100 ms cap for all the questions"). An earlier
   /// version applied the same bound to each of the five reads, so five could
   /// take five times the cap between them.
+  ///
+  /// The cumulative half of that decision stands. The VALUE is now 200 ms
+  /// (founder, 2026-08-05); `defaultTotal` owns the reason. Quoting the older
+  /// figure here as the live cap would make this comment the kind of confidently
+  /// stale citation that grounding-discipline.md warns about.
   ///
   /// Measured live the same day, which is why this is a FAILURE bound and not a
   /// latency target: all five reads together cost mean 0.78 ms in Ghostty and
@@ -330,7 +358,21 @@ package enum TerminalContextResolver {
     // result is what keeps them apart.
     //
     // Timed from out here because the process sweep is NOT an accessibility
-    // call, so nothing else charges it. Measured mean 3 ms / p95 7 ms.
+    // call, so nothing else charges it.
+    //
+    // COST, re-measured 2026-08-05 and corrected: this line previously read
+    // "Measured mean 3 ms / p95 7 ms", and that number is what the old 100 ms
+    // cap was sized against. On the real path it is 4x to 40x higher. The app's
+    // own trace across one ordinary session: 36, 49, 54, 61, 77, 77, then
+    // 114.7 ms — the last exhausted the whole cap here and tripped the breaker
+    // (#1941). A later clean session ran 60-65 ms per dictation. Standalone, the
+    // shipped scanner spans 13 ms to 862 ms depending on queue and machine load.
+    //
+    // This step is therefore the dominant consumer of the budget, not a rounding
+    // error, and #1943 exists to make it cheap. Do not restore the 3 ms figure,
+    // and do not size anything against it.
+    //
+    // Every other step in the same traces is under 0.5 ms.
     let scanStart = dependencies.now()
     let scan = dependencies.scanProcesses()
     if overspent(

--- a/Tests/EnviousWisprTests/Services/TerminalContextResolverTests.swift
+++ b/Tests/EnviousWisprTests/Services/TerminalContextResolverTests.swift
@@ -244,6 +244,11 @@ struct TerminalContextResolverTests {
     // five could take five times the cap between them and no single call ever
     // looked late.
     //
+    // The CUMULATIVE half of that decision is what this test freezes and it is
+    // unchanged. The VALUE is no longer 100 ms — it is
+    // `TerminalResolutionBudget.defaultTotal`, raised to 200 ms on 2026-08-05
+    // (#1941). This test passes its own total, so it does not depend on either.
+    //
     // NO ASSERTION HERE MAY DEPEND ON WALL TIME (#1893), which is the rule the
     // rest of this suite already follows through `TestClock`. Three review
     // rounds landed on this one test, each on a different face of the same
@@ -339,8 +344,8 @@ struct TerminalContextResolverTests {
 
     // A phase marker separates the initial read from the commit-boundary
     // re-check, which reuses the same labels. It must cost nothing: if a marker
-    // charged even a rounding error, the total the 100 ms cap is judged against
-    // would drift with the number of phases rather than with real work.
+    // charged even a rounding error, the total the cap is judged against would
+    // drift with the number of phases rather than with real work.
     budget.mark("recheck")
     _ = budget.step(applying: element, label: "focused") {}
 


### PR DESCRIPTION
Interim mitigation for #1941, founder-directed 2026-08-05. **One behavioural line**; everything else is the reasoning and two corrections to a measurement that was wrong.

```diff
-  package static let defaultTotal: Double = 0.100
+  package static let defaultTotal: Double = 0.200
```

## Why

Gate 1's process scan is charged to the cumulative terminal budget, and it walks **every pid on the machine** at ~4 syscalls each (~3,300 syscalls at 825 processes), uncached, per terminal dictation.

Measured on the real path from the app's own `timing=[...]` trace, one ordinary session in order:

| scan | of the old 100 ms budget |
|---:|---|
| 36.0 ms | 36% |
| 54.1 ms | 54% |
| 60.7 ms | 61% |
| 77.4 ms | 77% |
| 49.2 ms | 49% |
| 77.2 ms | 77% |
| **114.7 ms** | **exhausted, breaker tripped** |

`TerminalCircuitBreaker.resetAll()` has **no production caller**, so that one moment turned terminal insertion off for the rest of that terminal process's life, with nothing shown to the user. A later clean session ran 60-65 ms per dictation — passing, but two thirds of the old cap on one step with no headroom.

## Direction of failure

Exhausting the budget is a **silent, permanent feature loss**. Overrunning it costs added latency before falling back to the payload we would have pasted anyway. Trading up to 100 ms of rare worst-case delay against a silent permanent loss is worth it today.

## This is not the fix

**#1943** makes the scan cheap. This number should come back down against a re-measured cost once that lands. The comment on `defaultTotal` says so explicitly.

## Corrected premises

Two places asserted a cost that is wrong by 4x to 40x on the real path, and the old 100 ms cap was sized against it:

1. `TerminalContextResolver.swift` inline: *"Measured mean 3 ms / p95 7 ms"* → replaced with what was measured, plus an explicit instruction not to restore it.
2. `.claude/knowledge/accessibility-macos.md` (local-only, not in this diff) used the same figure to justify *"do NOT build a candidate pre-filter"* — i.e. it forbade the fix. Corrected there too, **preserving the half that still holds**: no hand-authored guesses at CLI launch shape (`workflow-process.md` RULE: matcher-set-adversarial-tests).

## Supersession, not overwrite

The founder's 2026-07-28 decision had two halves. **"Cumulative across all the questions" is unchanged** and still frozen by `budgetStepChargesEveryCall`. Only the value moved. Every site quoting the old figure is now either dated history or points at `defaultTotal`, which is the sole owner of the current value.

## Testing

- Full suite: **4818 passed**, `** TEST SUCCEEDED **`.
- `TerminalContextResolverTests`: **30 passed** as a positive control that the affected suite actually executes (a full run does not name suites, so a green summary alone would not prove it ran).
- **No test depends on the default** — all construct their own budget with an explicit total, so the change is behaviourally isolated.
- `boundIsDerivedFromTheBudget` asserts a fresh default budget stays under `PasteService.axMessagingTimeoutSeconds` (0.5 s). 200 ms clears it, and that test is the guard against raising it unsafely later.
- Dev app built and launched from this branch.

## Self-audit

Swept `defaultTotal`, `TerminalResolutionBudget(`, `100 ms cap`, `0.100` across `Sources/` and `Tests/` and classified every hit as live claim vs dated history. Fixed the two live ones (`KernelFinalizationWiring.swift:671`, `TerminalContextResolverTests.swift:342`), kept the historical ones deliberately, and confirmed `KernelFinalizationWiring.swift:516` is the unrelated language-resolution deadline.

`council-skip: zero-blast-radius (single-value constant)`

Part of #1941
