### PR TITLE
feat(post-processing): continuation casing for eleven European languages (Part of #1922)

### DIFF
--- a/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
@@ -362,7 +362,7 @@ public enum KernelDictationDriverFactory {
     // `AppLifecycleCoordinator` have import ceilings that exclude
     // PostProcessing, and their doctrine is right — the layer that consumes the
     // oracle should be the layer that prepares it. Both ceilings caught this.
-    Task { await EnglishWordOracleRuntime.prewarm() }
+    Task { await SeamCasingOracleRuntime.prewarm() }
 
     // 1. LimbSteps — same instances driver + wiring hold by reference.
     // #832/#913 PR8: the live-dictation LLMPolishStep receives the app-owned

--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -195,8 +195,8 @@ struct KernelFinalizationWiring {
     // a fixed oracle so a case never depends on the machine's dictionaries — and
     // so no test has to MUTATE the process-global runtime, which would race the
     // suites that legitimately do (local diff review, P2).
-    englishWordOracle: @escaping @MainActor () -> EnglishWordOracle = {
-      EnglishWordOracleRuntime.snapshot()
+    englishWordOracle: @escaping @MainActor () -> SeamCasingOracle = {
+      SeamCasingOracleRuntime.snapshot()
     },
     // #1921 language-resolver seam. `@Sendable`, not `@MainActor`, because
     // resolution now runs INSIDE the `@Sendable` deadline operation. Defaults to
@@ -509,7 +509,7 @@ struct KernelFinalizationWiring {
         // revision of the plan asserted was already true and was not.
         //
         // One gate arbitrates both stages, because "which stage timed out" now
-        // decides whether `EnglishWordOracleRuntime` may be disabled, and a
+        // decides whether `SeamCasingOracleRuntime` may be disabled, and a
         // plain flag cannot answer it safely: cancellation here is best-effort
         // and cannot preempt a running operation, so the timeout can look, see
         // the language stage, decline to disable, and the un-preempted operation
@@ -565,7 +565,7 @@ struct KernelFinalizationWiring {
             // Only a genuinely RUNNING oracle. A language-stage stall must not
             // disable an unrelated healthy component for the rest of the
             // process, and neither must one that had already succeeded.
-            if timeout.shouldDisableOracle { EnglishWordOracleRuntime.disableAfterTimeout() }
+            if timeout.shouldDisableOracle { SeamCasingOracleRuntime.disableAfterTimeout() }
           }
         )
 

--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -195,8 +195,18 @@ struct KernelFinalizationWiring {
     // a fixed oracle so a case never depends on the machine's dictionaries — and
     // so no test has to MUTATE the process-global runtime, which would race the
     // suites that legitimately do (local diff review, P2).
-    englishWordOracle: @escaping @MainActor () -> SeamCasingOracle = {
-      SeamCasingOracleRuntime.snapshot()
+    // Takes the RESOLVED language, so it must be called after resolution, not
+    // before it (grounded review r1: the snapshot used to be taken above the
+    // deadline, where the language is not yet known).
+    seamCasingOracle: @escaping @MainActor (String?) -> SeamCasingOracle = {
+      SeamCasingOracleRuntime.snapshot(for: $0)
+    },
+    // Paired with the seam above. A READY snapshot holds a lease that stops the
+    // preparation drain entering the shared spell checker underneath a decision
+    // already in flight; releasing is mandatory and happens in a `defer`.
+    // Injected tests pass a no-op, because their oracle takes no lease.
+    releaseOracleLease: @escaping @MainActor () -> Void = {
+      SeamCasingOracleRuntime.releaseDecisionLease()
     },
     // #1921 language-resolver seam. `@Sendable`, not `@MainActor`, because
     // resolution now runs INSIDE the `@Sendable` deadline operation. Defaults to
@@ -502,7 +512,6 @@ struct KernelFinalizationWiring {
         // insertion this feature exists for.
         let surroundingText = caretContext.map { $0.leftWindow + " " + $0.rightWindow } ?? ""
         let protectedSpellings = context.protectedSpellings
-        let oracleSnapshot = englishWordOracle()
 
         // #1921: language resolution now runs INSIDE this deadline. It used to
         // run above it, unbounded, on the paste path — a claim an earlier
@@ -546,6 +555,13 @@ struct KernelFinalizationWiring {
             // review round 2). Every refusal keeps the capital.
             // `CursorInsertionRepair` stays unaware of the deadline: it remains
             // a pure function of the oracle it is handed.
+            // Taken HERE, below resolution, because the oracle is per-language
+            // now and the language is not known any earlier. A ready snapshot
+            // holds a lease; `defer` releases it on every exit including the
+            // discarded-on-timeout one, since the deadline cannot preempt this
+            // closure and it always runs to completion.
+            let oracleSnapshot = await MainActor.run { seamCasingOracle(resolution.language) }
+            defer { Task { @MainActor in releaseOracleLease() } }
             let gatedOracle = oracleSnapshot.authorized { gate.authorizeOracleUse() }
             let repaired = CursorInsertionRepair.repair(
               text: text,

--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -561,7 +561,17 @@ struct KernelFinalizationWiring {
             // discarded-on-timeout one, since the deadline cannot preempt this
             // closure and it always runs to completion.
             let oracleSnapshot = await MainActor.run { seamCasingOracle(resolution.language) }
-            defer { Task { @MainActor in releaseOracleLease() } }
+            // Release ONLY IF a lease was actually taken. `snapshot(for:)` leases
+            // on a ready answer and not on a refusal, so an unconditional release
+            // is not merely harmless bookkeeping: leases carry no identity, so an
+            // unmatched release decrements whichever decision currently holds the
+            // count, and the drain may then start preparing while that decision is
+            // still inside the shared spell checker — precisely the race the lease
+            // exists to close. Grounded review r3, MED.
+            let holdsOracleLease = oracleSnapshot.isAvailable
+            defer {
+              if holdsOracleLease { Task { @MainActor in releaseOracleLease() } }
+            }
             let gatedOracle = oracleSnapshot.authorized { gate.authorizeOracleUse() }
             let repaired = CursorInsertionRepair.repair(
               text: text,

--- a/Sources/EnviousWisprPipeline/LanguageRepairDeadlineGate.swift
+++ b/Sources/EnviousWisprPipeline/LanguageRepairDeadlineGate.swift
@@ -8,7 +8,7 @@ import os
 /// resolution ran ahead of it, unbounded, on the paste path. Moving resolution
 /// inside the same deadline creates a question the old code never had to answer:
 /// **which stage timed out?** It matters because the existing `onTimeout`
-/// permanently disables `EnglishWordOracleRuntime`, and doing that because the
+/// permanently disables `SeamCasingOracleRuntime`, and doing that because the
 /// LANGUAGE stage stalled would kill an unrelated, healthy component for the
 /// rest of the process.
 ///

--- a/Sources/EnviousWisprPostProcessing/CursorInsertionRepair.swift
+++ b/Sources/EnviousWisprPostProcessing/CursorInsertionRepair.swift
@@ -302,7 +302,7 @@ public enum CursorInsertionRepair {
     context: CaretText?,
     protectedWords: Set<String>,
     language: String? = "en",
-    oracle: EnglishWordOracle
+    oracle: SeamCasingOracle
   ) -> PreparedPayloads {
     let legacy = legacyPayload(text)
     guard let context else {
@@ -387,7 +387,7 @@ public enum CursorInsertionRepair {
     context: CaretText,
     protectedWords: Set<String>,
     language: LanguageRules,
-    oracle: EnglishWordOracle
+    oracle: SeamCasingOracle
   ) -> (String, [AppliedRule]) {
     var out = text
     var rules: [AppliedRule] = []
@@ -544,7 +544,7 @@ public enum CursorInsertionRepair {
     leftWindow: String,
     isScreenDerived: Bool,
     protectedWords: Set<String>,
-    oracle: EnglishWordOracle
+    oracle: SeamCasingOracle
   ) -> (String, AppliedRule) {
     let leadingWhitespace = text.prefix(while: \.isWhitespace)
     let stripped = text.dropFirst(leadingWhitespace.count)

--- a/Sources/EnviousWisprPostProcessing/CursorInsertionRepair.swift
+++ b/Sources/EnviousWisprPostProcessing/CursorInsertionRepair.swift
@@ -64,6 +64,12 @@ public enum CursorInsertionRepair {
     case alreadyLower = "already_lower"
     case protectedWord = "protected_word"
     case mixedCaseOrAcronym = "mixed_case_or_acronym"
+    /// German only: the word-class tagger called this a noun, and German
+    /// capitalises every noun. #1922.
+    case nounInNounCapitalisingLanguage = "noun_in_noun_capitalising_language"
+    /// A form whose capital marks polite address — German `Sie`, Swedish `Ni`.
+    /// The capital IS the meaning, so no dictionary can see it. #1922.
+    case politeForm = "polite_form"
     case containsDigit = "contains_digit"
     case pronounI = "pronoun_i"
     case alwaysCapitalized = "always_capitalized"
@@ -245,22 +251,110 @@ public enum CursorInsertionRepair {
   /// rule, and Russian spaces its words while using an alphabet our lexicon has
   /// never seen. Deciding them separately keeps every language in exactly one of
   /// four honest states rather than one all-or-nothing switch.
+  /// How a language wants its leading capital decided, when it wants one decided
+  /// at all. `nil` in `LanguageRules.casingPolicy` means abstain.
+  ///
+  /// Two knobs, because exactly two things vary across the eleven supported
+  /// languages and neither implies the other. German inverts the noun rule and
+  /// has polite forms; Swedish has polite forms and no noun rule; the other nine
+  /// have neither.
+  struct CasingPolicy: Equatable {
+    /// Keep the capital when the word-class tagger calls this word a noun.
+    ///
+    /// TRUE for German ONLY, and that is a measurement, not an oversight: German
+    /// capitalises every noun, so "lower a positively identified non-noun" is its
+    /// rule. French and Italian LOWERCASE their common nouns, so the same veto
+    /// there refuses correct lowerings — measured at a third of their recall for
+    /// one point of precision. Do not extend this on intuition.
+    let nounVeto: Bool
+
+    /// Forms that are always capitalised for politeness, lowercased for lookup.
+    ///
+    /// A closed grammatical inventory (German `Sie`/`Ihr`/`Ihnen` and their
+    /// declensions, Swedish `Ni`), NOT a vocabulary prediction — the distinction
+    /// `matcher-set-adversarial-tests`' generalisation gate turns on. The test is
+    /// whether the CAPITAL ITSELF carries the meaning: `Sie` capitalised is the
+    /// polite you, `sie` is "she". Italian and Russian polite lists were tried
+    /// and REVERTED because theirs failed that test — `la`, `le`, `suo`, `sua`,
+    /// `вы` are ordinary articles, possessives and pronouns, so protecting them
+    /// blocked correct lowerings and cost far more than it saved.
+    let politeForms: Set<String>
+
+    /// The English shape: dictionary and name detection decide, nothing else.
+    static let plain = CasingPolicy(nounVeto: false, politeForms: [])
+  }
+
+  /// What this repair may do in the language actually being dictated.
+  ///
+  /// Both answers are per-language and neither is a detail of the other: Japanese
+  /// has no casing AND no word spacing, German has both but inverts the noun
+  /// rule, and Russian spaces its words while using an alphabet our lexicon has
+  /// never seen. Deciding them separately keeps every language in exactly one of
+  /// four honest states rather than one all-or-nothing switch.
   struct LanguageRules: Equatable {
     /// Words are separated by spaces, so a seam may need one.
     let usesWordSpacing: Bool
-    /// We hold casing knowledge for this language. English only today.
-    let knowsCasing: Bool
+
+    /// How to decide the leading capital, or `nil` to leave it alone.
+    ///
+    /// Replaces the former `knowsCasing: Bool`, which could only say yes or no
+    /// and so could not express that German's rule is inverted. One authority for
+    /// "what may this repair do in this language", covering spacing and casing.
+    let casingPolicy: CasingPolicy?
+
+    /// The resolved two-letter code, or `nil` when the language is unknown.
+    ///
+    /// Carried because LOWERCASING IS LOCALE-DEPENDENT and the repair cannot
+    /// recover the language once `forLanguage` has mapped it. Turkish `I`
+    /// lowercases to `ı`, not `i`, and only a Turkish locale knows that; Dutch
+    /// needs its own digraph handling. Measured both ways in
+    /// `2026-08-05-lowering-locale-probe.swift`.
+    let baseCode: String?
 
     /// Unknown language: space, do not recase. Spacing is what all but six of
     /// Whisper's ninety-nine languages do, and a missing or extra space is a
     /// far smaller error than a wrongly lowercased proper noun.
-    static let unknown = LanguageRules(usesWordSpacing: true, knowsCasing: false)
+    static let unknown = LanguageRules(
+      usesWordSpacing: true, casingPolicy: nil, baseCode: nil)
+
+    /// The eleven languages measured as safe, and the two that need more than the
+    /// English shape.
+    ///
+    /// This is a POLICY table keyed by language code, and that is deliberate even
+    /// though `cursor-aware-insertion.md` RULE: never-extend-knowsCasing-by-adding-a-language-code
+    /// forbids code-gating. That rule governs AVAILABILITY — whether macOS can
+    /// actually serve a language — because Apple's facilities fail open and a
+    /// code-based gate would trust a service that is lying. Availability is still
+    /// probed at runtime by the oracle, unchanged. What lives here is the
+    /// LANGUAGE'S OWN GRAMMAR: German capitalises its nouns whether or not this
+    /// Mac has a German dictionary installed. There is no fail-open to detect.
+    ///
+    /// Every entry is measured on held-out published text; per-language numbers
+    /// and the floors they must clear are in the #1922 plan §13. A language absent
+    /// from this table abstains, which is what all 23 remaining European
+    /// languages do today and must keep doing.
+    static let casingPolicies: [String: CasingPolicy] = [
+      // Full toolkit, English shape.
+      "en": .plain, "fr": .plain, "it": .plain,
+      // Dictionary only, English shape. No name detection exists for these, so
+      // the dictionary alone carries the decision.
+      "ru": .plain, "nl": .plain, "es": .plain, "pt": .plain,
+      "da": .plain, "fi": .plain, "tr": .plain,
+      // German: the only language whose rule inverts.
+      "de": CasingPolicy(
+        nounVeto: true,
+        politeForms: ["sie", "ihr", "ihnen", "ihre", "ihrer", "ihres", "ihrem", "ihren"]),
+      // Swedish: polite forms without a noun rule. `.lexicalClass` is unavailable
+      // for Swedish, so a veto here would be inert even if the grammar wanted one.
+      "sv": CasingPolicy(nounVeto: false, politeForms: ["ni", "er", "ert", "era"]),
+    ]
 
     static func forLanguage(_ raw: String?) -> LanguageRules {
       guard let base = LanguageNormalizer.baseCode(raw) else { return .unknown }
       return LanguageRules(
         usesWordSpacing: !LanguageTypes.isUnsegmentedScript(base),
-        knowsCasing: base == "en")
+        casingPolicy: casingPolicies[base],
+        baseCode: base)
     }
   }
 
@@ -430,17 +524,18 @@ public enum CursorInsertionRepair {
         !left.atLineStart && (anchor.isLetter || anchor.isNumber || continuers.contains(anchor))
       } ?? false
 
-    if continuing, !language.knowsCasing {
+    if continuing, let policy = language.casingPolicy {
+      let (adjusted, caseRule) = applyLeadingCase(
+        to: out, leftWindow: context.left, isScreenDerived: context.isScreenDerived,
+        protectedWords: protectedWords, oracle: oracle,
+        policy: policy, languageCode: language.baseCode)
+      out = adjusted
+      rules.append(caseRule)
+    } else if continuing {
       // Positioned to lowercase, but not in a language whose casing we know.
       // Recorded as a skip rather than silently omitted so the field can tell
       // "we chose not to" from "the position did not call for it".
       rules.append(.caseSkipped(.languageNotSupported))
-    } else if continuing {
-      let (adjusted, caseRule) = applyLeadingCase(
-        to: out, leftWindow: context.left, isScreenDerived: context.isScreenDerived,
-        protectedWords: protectedWords, oracle: oracle)
-      out = adjusted
-      rules.append(caseRule)
     } else if left.character == nil {
       // Nothing real to the left: an empty window means nothing precedes the
       // caret at all, a non-empty one means we walked back to a line start.
@@ -544,7 +639,9 @@ public enum CursorInsertionRepair {
     leftWindow: String,
     isScreenDerived: Bool,
     protectedWords: Set<String>,
-    oracle: SeamCasingOracle
+    oracle: SeamCasingOracle,
+    policy: CasingPolicy,
+    languageCode: String?
   ) -> (String, AppliedRule) {
     let leadingWhitespace = text.prefix(while: \.isWhitespace)
     let stripped = text.dropFirst(leadingWhitespace.count)
@@ -564,17 +661,40 @@ public enum CursorInsertionRepair {
     if startsWithProtectedSpelling(stripped, protectedWords: protectedWords) {
       return (text, .caseSkipped(.protectedWord))
     }
-    if bare.dropFirst().contains(where: \.isUppercase) {
+    // Dutch `IJ` is ONE casing unit, so its second character is not evidence of
+    // an acronym. Without this exemption every `IJ`-initial Dutch word dies here,
+    // four guards before the lowering code ever runs — which made rev 2's
+    // "add a locale" fix completely inert (verified: `2026-08-05-dutch-guard-probe.swift`).
+    //
+    // Scoped as narrowly as it can be: Dutch only, exactly `I` then `J`, and only
+    // that one character is forgiven. `USA` still refuses in Dutch, because its
+    // `S` is not the exempted position. The single-character `Ĳ` ligature never
+    // reaches here — it has no second uppercase character.
+    if bare.dropFirst().contains(where: \.isUppercase), !isDutchIJDigraph(bare, languageCode) {
       return (text, .caseSkipped(.mixedCaseOrAcronym))
     }
     if bare.contains(where: \.isNumber) {
       return (text, .caseSkipped(.containsDigit))
     }
-    if isFirstPersonPronoun(bare) {
-      return (text, .caseSkipped(.pronounI))
+    // English-only by construction, and that is deliberate: `isFirstPersonPronoun`
+    // is `["I", "I'm", …]` and `alwaysCapitalized` is the English weekday/month
+    // set. Applying either to German or Turkish would be asserting an English
+    // fact about another language. Both were language-blind before this change,
+    // which was harmless only because English was the sole casing language.
+    if languageCode == "en" {
+      if isFirstPersonPronoun(bare) {
+        return (text, .caseSkipped(.pronounI))
+      }
+      if alwaysCapitalized.contains(bare) {
+        return (text, .caseSkipped(.alwaysCapitalized))
+      }
     }
-    if alwaysCapitalized.contains(bare) {
-      return (text, .caseSkipped(.alwaysCapitalized))
+    // A polite form is capitalised for its ROLE, so the capital carries the
+    // meaning and no dictionary can see it: German `Sie` is the polite you while
+    // `sie` is "she". Closed grammatical inventory, checked before the oracle
+    // because the oracle would happily call it an ordinary word.
+    if policy.politeForms.contains(bare.lowercased()) {
+      return (text, .caseSkipped(.politeForm))
     }
     // The tagger must see the seam AS IT WILL BE WRITTEN, separator included.
     //
@@ -624,8 +744,66 @@ public enum CursorInsertionRepair {
       }
     }
 
-    let lowered = String(firstCharacter).lowercased()
-    return (String(leadingWhitespace) + lowered + String(stripped.dropFirst()), .lowercasedFirst)
+    // German inverts the rule: every noun is capitalised, so a positively
+    // identified noun keeps its capital.
+    //
+    // A VETO, never a decider. Everything above has already decided to lower;
+    // this can only withdraw that. #1803's rejected design made word class the
+    // DECIDER plus a safe-tag allowlist, which lowered nominalised adverbs and
+    // pronouns. As a conjunction it cannot introduce a damage class the rule did
+    // not already have — measured 127 wrong to 22 on the tuned split, and 91 to 9
+    // on a clean holdout.
+    //
+    // The dictation ALONE, never the surrounding document: #1803 measured that
+    // adding the document flipped `Morgen` from adverb to noun. And the top tag,
+    // not `tagHypotheses` — that was #1803's prescribed fix and it is byte-
+    // identical here, because noun carries weight only when noun already wins.
+    if policy.nounVeto, oracle.isNoun(String(stripped)) {
+      return (text, .caseSkipped(.nounInNounCapitalisingLanguage))
+    }
+
+    return (loweringLeadingUnit(of: text, languageCode: languageCode), .lowercasedFirst)
+  }
+
+  /// Is `bare` a Dutch word opening with the `IJ` digraph?
+  ///
+  /// Deliberately ASCII `I`+`J` and Dutch only. Widening either axis breaks
+  /// acronym protection somewhere: any-language would forgive `IT`, and
+  /// any-second-capital would forgive `USA`.
+  static func isDutchIJDigraph(_ bare: String, _ languageCode: String?) -> Bool {
+    guard languageCode == "nl" else { return false }
+    var it = bare.makeIterator()
+    guard it.next() == "I", it.next() == "J" else { return false }
+    // Only the `J` is forgiven — anything uppercase after it is still an acronym.
+    return !bare.dropFirst(2).contains(where: \.isUppercase)
+  }
+
+  /// Lowercase the leading CASING UNIT, which is not always one character.
+  ///
+  /// Two things the old `String(firstCharacter).lowercased()` got wrong, both
+  /// latent until #1922 made Turkish and Dutch reachable, both measured in
+  /// `2026-08-05-lowering-locale-probe.swift`:
+  ///
+  /// - **Locale.** `lowercased()` uses the root locale, so Turkish `I` becomes
+  ///   `i` when it must become `ı`.
+  /// - **Unit length.** Dutch `IJ` is one casing unit spelled with two
+  ///   characters, so lowering only the first yields `iJs`. A locale argument
+  ///   does NOT fix this — measured, `lowercased(with: nl)` also returns `iJs`.
+  static func loweringLeadingUnit(of text: String, languageCode: String?) -> String {
+    let leadingWhitespace = text.prefix(while: \.isWhitespace)
+    let stripped = text.dropFirst(leadingWhitespace.count)
+    guard let firstCharacter = stripped.first else { return text }
+    let locale = languageCode.map { Locale(identifier: $0) } ?? Locale(identifier: "en")
+
+    // Dutch digraph: two characters in, two characters out.
+    if languageCode == "nl", stripped.count >= 2 {
+      let second = stripped[stripped.index(after: stripped.startIndex)]
+      if firstCharacter == "I", second == "J" {
+        return String(leadingWhitespace) + "ij" + String(stripped.dropFirst(2))
+      }
+    }
+    let lowered = String(firstCharacter).lowercased(with: locale)
+    return String(leadingWhitespace) + lowered + String(stripped.dropFirst())
   }
 
   // MARK: - Seam de-duplication (#1803)

--- a/Sources/EnviousWisprPostProcessing/CursorInsertionRepair.swift
+++ b/Sources/EnviousWisprPostProcessing/CursorInsertionRepair.swift
@@ -75,7 +75,10 @@ public enum CursorInsertionRepair {
     case alwaysCapitalized = "always_capitalized"
     /// The system dictionary does not recognise the lowercase form.
     case notOrdinaryWord = "not_ordinary_word"
-    /// No usable English dictionary on this machine.
+    /// No usable dictionary for THIS dictation's language on this machine.
+    /// Per-language since #1922: a missing Danish dictionary says nothing about
+    /// the English one, and demoting all of them would turn one language's
+    /// outage into a whole-feature outage.
     case dictionaryUnavailable = "dictionary_unavailable"
     /// Apple's recogniser read this word as a person, place or organisation in
     /// this sentence, so the capital is carrying meaning.
@@ -254,10 +257,10 @@ public enum CursorInsertionRepair {
   /// How a language wants its leading capital decided, when it wants one decided
   /// at all. `nil` in `LanguageRules.casingPolicy` means abstain.
   ///
-  /// Two knobs, because exactly two things vary across the eleven supported
-  /// languages and neither implies the other. German inverts the noun rule and
-  /// has polite forms; Swedish has polite forms and no noun rule; the other nine
-  /// have neither.
+  /// Two knobs, because exactly two things vary across the TWELVE languages that
+  /// have a policy — English plus the eleven #1922 added — and neither implies the
+  /// other. German inverts the noun rule and has polite forms; Swedish has polite
+  /// forms and no noun rule; the other ten have neither.
   struct CasingPolicy: Equatable {
     /// Keep the capital when the word-class tagger calls this word a noun.
     ///
@@ -751,8 +754,11 @@ public enum CursorInsertionRepair {
     // this can only withdraw that. #1803's rejected design made word class the
     // DECIDER plus a safe-tag allowlist, which lowered nominalised adverbs and
     // pronouns. As a conjunction it cannot introduce a damage class the rule did
-    // not already have — measured 127 wrong to 22 on the tuned split, and 91 to 9
-    // on a clean holdout.
+    // not already have. Measured 127 wrong to 22 on the tuned split; on the clean
+    // dev holdout the BUILT code lowers 1,547 German seams correctly and 7 wrongly
+    // (0.30%), taking German from 22.0% to 88.5% end-state accuracy. An earlier
+    // 91-to-9 figure here was the PROBE's, and the probe reimplemented part of the
+    // chain (issue-1922-artifacts/2026-08-05-shipfloor-dev.out).
     //
     // The dictation ALONE, never the surrounding document: #1803 measured that
     // adding the document flipped `Morgen` from adverb to noun. And the top tag,

--- a/Sources/EnviousWisprPostProcessing/CursorInsertionRepair.swift
+++ b/Sources/EnviousWisprPostProcessing/CursorInsertionRepair.swift
@@ -712,7 +712,9 @@ public enum CursorInsertionRepair {
     // already ended in a space, so none of them could exercise this. Caught by
     // local diff review r2 (P1).
     let taggerLeft = leftWindow + String(leadingWhitespace)
-    if let refusal = oracle.mayLower(word: bare, left: taggerLeft, payload: String(stripped)) {
+    if let refusal = oracle.mayLower(
+      word: bare, left: taggerLeft, payload: String(stripped), languageCode: languageCode)
+    {
       return (text, .caseSkipped(refusal))
     }
 
@@ -742,7 +744,9 @@ public enum CursorInsertionRepair {
     // its separator and the second reading would merely double it.
     if isScreenDerived, let lastLeft = taggerLeft.last, !lastLeft.isWhitespace {
       let separated = taggerLeft + " "
-      if let refusal = oracle.mayLower(word: bare, left: separated, payload: String(stripped)) {
+      if let refusal = oracle.mayLower(
+        word: bare, left: separated, payload: String(stripped), languageCode: languageCode)
+      {
         return (text, .caseSkipped(refusal))
       }
     }
@@ -795,11 +799,23 @@ public enum CursorInsertionRepair {
   /// - **Unit length.** Dutch `IJ` is one casing unit spelled with two
   ///   characters, so lowering only the first yields `iJs`. A locale argument
   ///   does NOT fix this — measured, `lowercased(with: nl)` also returns `iJs`.
+  /// The one locale authority for this file.
+  ///
+  /// Extracted because TWO places lowercase and both must agree: the text we
+  /// WRITE, and the word we ASK THE DICTIONARY ABOUT. Whole-diff review found
+  /// them disagreeing — the query used the root locale, so Turkish `Işık` was
+  /// looked up as `işık` instead of `ışık`, the Turkish dictionary rejected an
+  /// ordinary word, and the capital was kept. That fails safe and costs recall,
+  /// which is why no test caught it.
+  static func casingLocale(for languageCode: String?) -> Locale {
+    Locale(identifier: languageCode ?? "en")
+  }
+
   static func loweringLeadingUnit(of text: String, languageCode: String?) -> String {
     let leadingWhitespace = text.prefix(while: \.isWhitespace)
     let stripped = text.dropFirst(leadingWhitespace.count)
     guard let firstCharacter = stripped.first else { return text }
-    let locale = languageCode.map { Locale(identifier: $0) } ?? Locale(identifier: "en")
+    let locale = casingLocale(for: languageCode)
 
     // Dutch digraph: two characters in, two characters out.
     if languageCode == "nl", stripped.count >= 2 {

--- a/Sources/EnviousWisprPostProcessing/SeamCasingOracle.swift
+++ b/Sources/EnviousWisprPostProcessing/SeamCasingOracle.swift
@@ -4,14 +4,14 @@ import Foundation
 ///
 /// A VALUE, not a service: the four closures are the only contact with the
 /// operating system, so unit tests inject fixed answers and never touch a
-/// system facility. `EnglishWordOracleRuntime` is the only thing that builds a
+/// system facility. `SeamCasingOracleRuntime` is the only thing that builds a
 /// live one, which keeps `AppKit` and `NaturalLanguage` confined to that file.
 ///
 /// Replaces `OrdinaryLowercaseLexicon`, a hand-authored 799-word allowlist that
 /// could not contain the English language: `go`, `send`, `call`, `buy`, `email`
 /// and `learn` were all absent, so ordinary continuations kept a wrong capital.
 /// Issue #1803.
-package struct EnglishWordOracle: Sendable {
+package struct SeamCasingOracle: Sendable {
   /// Why this oracle cannot decide, or `nil` when it can.
   package let unavailableReason: CursorInsertionRepair.CaseSkipReason?
 
@@ -91,8 +91,8 @@ package struct EnglishWordOracle: Sendable {
   /// pure function of the oracle it is handed.
   package func authorized(
     by authorize: @escaping @Sendable () -> Bool
-  ) -> EnglishWordOracle {
-    EnglishWordOracle(
+  ) -> SeamCasingOracle {
+    SeamCasingOracle(
       unavailableReason: unavailableReason,
       dictionaryVerdict: { word in
         guard authorize() else { return .unavailable(.oracleTimedOut) }
@@ -110,8 +110,8 @@ package struct EnglishWordOracle: Sendable {
 
   package static func unavailable(
     _ reason: CursorInsertionRepair.CaseSkipReason
-  ) -> EnglishWordOracle {
-    EnglishWordOracle(
+  ) -> SeamCasingOracle {
+    SeamCasingOracle(
       unavailableReason: reason,
       dictionaryVerdict: { _ in .unavailable(reason) },
       isLearnedWord: { _ in false },

--- a/Sources/EnviousWisprPostProcessing/SeamCasingOracle.swift
+++ b/Sources/EnviousWisprPostProcessing/SeamCasingOracle.swift
@@ -1,10 +1,17 @@
 import Foundation
 
-/// Whether a capitalised English word may be lowered where it sits.
+/// Whether a capitalised word may be lowered where it sits, in any of the
+/// twelve languages that have a casing policy.
 ///
-/// A VALUE, not a service: the four closures are the only contact with the
+/// A VALUE, not a service: its four closures — `dictionaryVerdict`,
+/// `isLearnedWord`, `isRecognizedName`, `isNoun` — are the only contact with the
 /// operating system, so unit tests inject fixed answers and never touch a
-/// system facility. `SeamCasingOracleRuntime` is the only thing that builds a
+/// system facility.
+
+// Named `EnglishWordOracle` until #1922 (2026-08-05) made it serve twelve
+// languages. `mayLower` still asks the two questions below; the German noun VETO
+// that issue added lives OUTSIDE it, in `CursorInsertionRepair.applyLeadingCase`,
+// which is what keeps it structurally a veto rather than a decider. `SeamCasingOracleRuntime` is the only thing that builds a
 /// live one, which keeps `AppKit` and `NaturalLanguage` confined to that file.
 ///
 /// Replaces `OrdinaryLowercaseLexicon`, a hand-authored 799-word allowlist that

--- a/Sources/EnviousWisprPostProcessing/SeamCasingOracle.swift
+++ b/Sources/EnviousWisprPostProcessing/SeamCasingOracle.swift
@@ -50,6 +50,20 @@ package struct SeamCasingOracle: Sendable {
   /// the dictionary, which is why that second step exists.
   package let isRecognizedName: @Sendable (_ left: String, _ payload: String) -> Bool
 
+  /// Does the word-class tagger call the payload's first word a noun?
+  ///
+  /// Consulted ONLY where `CasingPolicy.nounVeto` is set, which today is German
+  /// alone — the one supported language that capitalises every noun. #1922.
+  ///
+  /// Takes the payload and not the joined seam on purpose: #1803 measured that
+  /// feeding the surrounding document made German WORSE, flipping `Morgen` from
+  /// adverb to noun. This is the opposite of `isRecognizedName`, which needs the
+  /// left context because a name is recognised from its neighbours.
+  ///
+  /// Answering `true` KEEPS the capital, so `true` is the conservative direction
+  /// and every refusal path returns it.
+  package let isNoun: @Sendable (_ payload: String) -> Bool
+
   package var isAvailable: Bool { unavailableReason == nil }
 
   /// The same oracle, but asking permission before every consultation.
@@ -105,6 +119,13 @@ package struct SeamCasingOracle: Sendable {
       isRecognizedName: { left, payload in
         guard authorize() else { return true }
         return isRecognizedName(left, payload)
+      },
+      // `true` on refusal, same as the others and for the same reason: a veto
+      // answering "noun" keeps the capital, which is what the app did before
+      // this feature existed.
+      isNoun: { payload in
+        guard authorize() else { return true }
+        return isNoun(payload)
       })
   }
 
@@ -115,7 +136,8 @@ package struct SeamCasingOracle: Sendable {
       unavailableReason: reason,
       dictionaryVerdict: { _ in .unavailable(reason) },
       isLearnedWord: { _ in false },
-      isRecognizedName: { _, _ in true })
+      isRecognizedName: { _, _ in true },
+      isNoun: { _ in true })
   }
 
   /// The decision, in one place.

--- a/Sources/EnviousWisprPostProcessing/SeamCasingOracle.swift
+++ b/Sources/EnviousWisprPostProcessing/SeamCasingOracle.swift
@@ -6,13 +6,14 @@ import Foundation
 /// A VALUE, not a service: its four closures — `dictionaryVerdict`,
 /// `isLearnedWord`, `isRecognizedName`, `isNoun` — are the only contact with the
 /// operating system, so unit tests inject fixed answers and never touch a
-/// system facility.
-
-// Named `EnglishWordOracle` until #1922 (2026-08-05) made it serve twelve
-// languages. `mayLower` still asks the two questions below; the German noun VETO
-// that issue added lives OUTSIDE it, in `CursorInsertionRepair.applyLeadingCase`,
-// which is what keeps it structurally a veto rather than a decider. `SeamCasingOracleRuntime` is the only thing that builds a
+/// system facility. `SeamCasingOracleRuntime` is the only thing that builds a
 /// live one, which keeps `AppKit` and `NaturalLanguage` confined to that file.
+///
+/// Named `EnglishWordOracle` until #1922 (2026-08-05) made it serve twelve
+/// languages. `mayLower` still asks the two questions below; the German noun
+/// VETO that issue added lives OUTSIDE it, in
+/// `CursorInsertionRepair.applyLeadingCase`, which is what keeps it structurally
+/// a veto rather than a decider.
 ///
 /// Replaces `OrdinaryLowercaseLexicon`, a hand-authored 799-word allowlist that
 /// could not contain the English language: `go`, `send`, `call`, `buy`, `email`
@@ -173,10 +174,18 @@ package struct SeamCasingOracle: Sendable {
   /// this feature existed, so no failure here can damage text that was already
   /// correct.
   package func mayLower(
-    word: String, left: String, payload: String
+    word: String, left: String, payload: String, languageCode: String? = nil
   ) -> CursorInsertionRepair.CaseSkipReason? {
     if let unavailableReason { return unavailableReason }
-    let lower = word.lowercased()
+    // LOCALE-AWARE, and it has to be: `lowercased()` uses the root locale, so a
+    // Turkish word opening with dotless `I` was queried as `işık` rather than
+    // `ışık` — the Turkish dictionary rejects that, so an ordinary word kept its
+    // capital. The defect fails SAFE, which is exactly why nothing caught it: it
+    // costs Turkish recall and never damages text. Whole-diff review, P2.
+    //
+    // Defaults to nil (root locale) so the many test call sites that pass no
+    // language keep their existing behaviour, which is correct for English.
+    let lower = word.lowercased(with: CursorInsertionRepair.casingLocale(for: languageCode))
     guard !isRecognizedName(left, payload) else { return .recognizedName }
     // Queried lowercased, and that is sufficient: `hasLearnedWord` folds case in
     // both directions. Measured with clean before-teaching controls — teach

--- a/Sources/EnviousWisprPostProcessing/SeamCasingOracleRuntime.swift
+++ b/Sources/EnviousWisprPostProcessing/SeamCasingOracleRuntime.swift
@@ -46,12 +46,66 @@ package enum SeamCasingOracleRuntime {
 
   private struct State: Sendable {
     var prewarmStarted = false
-    var phase: Phase = .warming
-    /// Bumped by every deliberate state change. A prewarm that started before a
-    /// change must not publish after it: `prewarmStarted` guards STARTING one,
-    /// not one already in flight, and a reset restores exactly the `.warming`
-    /// phase its publish step looks for (local diff review r3, residual).
+    /// One phase PER LANGUAGE. Absent means never requested.
+    ///
+    /// Keyed by the base code the repair resolved, never by the raw dictation
+    /// tag: `LanguageNormalizer.baseCode` has already folded `de-DE` and `de_AT`
+    /// together, so two spellings of one language cannot each build an oracle.
+    var phases: [String: Phase] = [:]
+    /// Bumped by every deliberate state change. A preparation that started
+    /// before a change must not publish after it: `prewarmStarted` guards
+    /// STARTING one, not one already in flight, and a reset restores exactly the
+    /// `.warming` phase its publish step looks for (local diff review r3).
     var epoch = 0
+
+    /// Languages requested but not yet prepared, in request order.
+    var pending: [String] = []
+    /// A preparation system call is running right now.
+    var preparing = false
+    /// How many decisions hold a lease and may still call into the checker.
+    ///
+    /// THE RACE THIS CLOSES, because refusing at snapshot time does not close it:
+    /// a snapshot taken microseconds BEFORE preparation begins is already out,
+    /// and its `NSSpellChecker` call would land inside the preparation window —
+    /// two callers in the one shared checker, which is precisely the invariant
+    /// the runtime's one-lock argument depends on. Refusing future snapshots is
+    /// necessary and not sufficient; the drain must also WAIT for in-flight
+    /// decisions. Grounded review r2, HIGH.
+    var decisionLeases = 0
+
+    /// A permanent latch stops everything, everywhere, forever.
+    var latched: CursorInsertionRepair.CaseSkipReason?
+  }
+
+  /// What a language needs from macOS before it may decide anything.
+  ///
+  /// Availability is PROFILE-SPECIFIC and getting this wrong is silent: the
+  /// shipped code required `.nameType` unconditionally, which exists for exactly
+  /// en/fr/de/it, so the eight dictionary-only languages would have resolved
+  /// unavailable and the release would have shipped four languages while
+  /// claiming twelve — with every test green, because refusing without name
+  /// detection is correct ENGLISH behaviour. #1922, found while writing this
+  /// file and independently by grounded review r2.
+  ///
+  /// The dictionary sentinel is required by EVERY profile and must never be
+  /// relaxed: it is what makes the 23 unsupported European languages refuse
+  /// safely. Only the tag-scheme requirements vary.
+  struct CapabilityProfile: Sendable {
+    let needsNameType: Bool
+    let needsLexicalClass: Bool
+
+    static func forLanguage(_ base: String) -> CapabilityProfile {
+      switch base {
+      // German's entire rule IS the noun veto, so a missing word-class scheme
+      // makes it unavailable rather than merely weaker.
+      case "de": return CapabilityProfile(needsNameType: true, needsLexicalClass: true)
+      case "en", "fr", "it": return CapabilityProfile(needsNameType: true, needsLexicalClass: false)
+      // Dictionary only, deliberately. Measured at 95.6-99.4% precision on
+      // held-out text with name detection absent; the residual risk is stated in
+      // the #1922 plan's second persona rather than engineered away.
+      default: return CapabilityProfile(needsNameType: false, needsLexicalClass: false)
+      }
+    }
   }
 
   private static let state = OSAllocatedUnfairLock(initialState: State())
@@ -67,43 +121,90 @@ package enum SeamCasingOracleRuntime {
   /// paste. Measured: unwarmed first paste 105.6 ms, warmed 0.5 ms.
   @concurrent
   package static func prewarm() async {
-    let startedEpoch = state.withLock { state -> Int? in
-      guard !state.prewarmStarted else { return nil }
+    let start = state.withLock { state -> Bool in
+      guard !state.prewarmStarted else { return false }
       state.prewarmStarted = true
-      return state.epoch
+      // English is warmed unconditionally at launch because it is by far the
+      // most common language and this is the one moment that is definitely off
+      // the paste path. Every other language is prepared on first request.
+      state.phases["en"] = .warming
+      state.pending.append("en")
+      return true
     }
-    guard let startedEpoch else { return }
+    guard start else { return }
+    await drain()
+  }
 
-    let prepared = prepare()
+  /// Prepare pending languages one at a time, never while a decision is in
+  /// flight, and never on the paste path.
+  ///
+  /// Serialization is not tidiness. The runtime's one-lock argument (see the
+  /// type doc) holds only because preparation and decisions never overlap in the
+  /// one shared `NSSpellChecker`. Independent per-language warmers would void
+  /// it, and so would draining while a decision holds a lease.
+  @concurrent
+  private static func drain() async {
+    while true {
+      let next: (String, Int)? = state.withLock { state in
+        guard state.latched == nil else { return nil }
+        // Wait for in-flight decisions. Their `NSSpellChecker` calls were
+        // authorised before we got here and must finish before we start ours.
+        guard state.decisionLeases == 0, !state.preparing else { return nil }
+        guard let base = state.pending.first else { return nil }
+        state.pending.removeFirst()
+        state.preparing = true
+        return (base, state.epoch)
+      }
+      guard let (base, startedEpoch) = next else {
+        // Either nothing to do, or a lease is out. A lease holder re-pokes the
+        // drain on release, so returning here cannot strand pending work.
+        return
+      }
 
-    state.withLock { state in
-      // Publish only if NOTHING has changed the state since this prewarm began.
-      // The phase check alone is insufficient: a reset restores `.warming`, so a
-      // stale prepare would satisfy it and overwrite the state a test just
-      // established.
-      guard state.epoch == startedEpoch, case .warming = state.phase else { return }
-      state.phase = prepared
+      let prepared = prepare(base: base)
+
+      state.withLock { state in
+        state.preparing = false
+        // Publish only if NOTHING has changed since this preparation began. The
+        // phase check alone is insufficient: a reset restores `.warming`, so a
+        // stale prepare would satisfy it and overwrite state a test just set.
+        guard state.epoch == startedEpoch, case .warming? = state.phases[base] else { return }
+        state.phases[base] = prepared
+      }
     }
+  }
+
+  /// Kick the drain from a non-async context, without ever blocking the caller.
+  private static func pokeDrain() {
+    Task.detached(priority: .utility) { await drain() }
   }
 
   /// Resolve the dictionary language and probe tagger availability.
   ///
   /// Both are one-time and both are expensive: 20.2 ms and 80.3 ms measured
   /// cold. Neither is ever repeated.
-  private static func prepare() -> Phase {
+  private static func prepare(base: String) -> Phase {
     // NEVER the raw dictation language, the checker's currently selected
     // language, or nil. Measured: `checkSpelling(language:)` with an
     // unrecognised identifier reports EVERY word correctly spelled — it fails
     // OPEN, which would lowercase names wholesale. Choosing from
     // `availableLanguages` makes that path unreachable rather than detected.
-    guard let english = resolveEnglishLanguage(from: NSSpellChecker.shared.availableLanguages)
+    guard let identifier = resolveLanguage(base, from: NSSpellChecker.shared.availableLanguages)
     else {
       return .unavailable(.dictionaryUnavailable)
     }
+    let profile = CapabilityProfile.forLanguage(base)
+    let nlLanguage = NLLanguage(base)
+    let schemes = NLTagger.availableTagSchemes(for: .word, language: nlLanguage)
+    let hasNameType = schemes.contains(.nameType)
     // A scheme/language pair may be unsupported, or its assets not loaded, on
     // this device. We never request a download; an absent model keeps capitals.
-    guard NLTagger.availableTagSchemes(for: .word, language: .english).contains(.nameType)
-    else {
+    // PROFILE-specific, not universal. Requiring `.nameType` everywhere is what
+    // would have silently reduced twelve languages to four.
+    if profile.needsNameType, !hasNameType {
+      return .unavailable(.wordClassUnavailable)
+    }
+    if profile.needsLexicalClass, !schemes.contains(.lexicalClass) {
       return .unavailable(.wordClassUnavailable)
     }
 
@@ -134,8 +235,8 @@ package enum SeamCasingOracleRuntime {
         // otherwise recreate the stale-identifier fail-open path. The dictation
         // that discovers it reports the outage itself rather than looking like
         // an ordinary miss.
-        guard checker.availableLanguages.contains(english) else {
-          markUnavailableIfReady(.dictionaryUnavailable)
+        guard checker.availableLanguages.contains(identifier) else {
+          markUnavailableIfReady(.dictionaryUnavailable, base: base)
           return .unavailable(.dictionaryUnavailable)
         }
         let ordinary = isOrdinary(
@@ -143,13 +244,13 @@ package enum SeamCasingOracleRuntime {
           sentinel: sentinel,
           spelledCorrectly: { candidate in
             checker.checkSpelling(
-              of: candidate, startingAt: 0, language: english, wrap: false,
+              of: candidate, startingAt: 0, language: identifier, wrap: false,
               inSpellDocumentWithTag: tag, wordCount: nil
             ).location == NSNotFound
           },
-          onServiceFailure: { markUnavailableIfReady(.dictionaryUnavailable) })
+          onServiceFailure: { markUnavailableIfReady(.dictionaryUnavailable, base: base) })
         // A yes-to-everything service is an outage too, not a plain refusal.
-        if !ordinary, case .unavailable(let reason)? = currentUnavailableReason() {
+        if !ordinary, case .unavailable(let reason)? = currentUnavailableReason(base) {
           return .unavailable(reason)
         }
         return ordinary ? .ordinary : .notOrdinary
@@ -174,6 +275,28 @@ package enum SeamCasingOracleRuntime {
           return false
         }
         return Self.nameTags.contains(name)
+      },
+      isNoun: { payload in
+        // The PAYLOAD alone, never the joined seam. #1803 measured that adding
+        // the surrounding document made German worse, flipping `Morgen` from
+        // adverb to noun. That is the opposite of `isRecognizedName` above,
+        // which needs the left context — the two questions want different
+        // inputs, so they are asked separately rather than sharing a string.
+        let tagger = NLTagger(tagSchemes: [.lexicalClass])
+        // Pinned, not sniffed. `NLTagger` guesses the language of a short
+        // fragment badly, and this closure is only ever built for a language
+        // whose `.lexicalClass` availability was already probed in `prepare`.
+        tagger.setLanguage(nlLanguage, range: payload.startIndex..<payload.endIndex)
+        tagger.string = payload
+        guard
+          let tag = tagger.tag(at: payload.startIndex, unit: .word, scheme: .lexicalClass).0
+        else {
+          // No tag is not an outage, and here it is also not a licence to lower:
+          // this is a VETO, so the safe answer is "treat it as a noun" and keep
+          // the capital.
+          return true
+        }
+        return tag == .noun
       })
     return .ready(oracle)
   }
@@ -203,9 +326,9 @@ package enum SeamCasingOracleRuntime {
   }
 
   /// The stored unavailable reason, if the runtime has latched one.
-  private static func currentUnavailableReason() -> Phase? {
+  private static func currentUnavailableReason(_ base: String) -> Phase? {
     state.withLock { state in
-      if case .unavailable = state.phase { return state.phase }
+      if case .unavailable? = state.phases[base] { return state.phases[base] }
       return nil
     }
   }
@@ -213,15 +336,26 @@ package enum SeamCasingOracleRuntime {
   /// What counts as a name. Anything else falls through to the dictionary.
   private static let nameTags: Set<NLTag> = [.personalName, .placeName, .organizationName]
 
-  /// Pick an installed English dictionary deterministically.
-  static func resolveEnglishLanguage(from availableLanguages: [String]) -> String? {
+  /// Pick an installed dictionary for `base` deterministically.
+  ///
+  /// Chosen from `availableLanguages` and never from the raw dictation tag,
+  /// because `checkSpelling(language:)` with an unrecognised identifier reports
+  /// EVERY word correctly spelled — it fails OPEN, which would lowercase names
+  /// wholesale. Selecting from the installed list makes that path unreachable
+  /// rather than merely detected.
+  ///
+  /// `.sorted().first` is arbitrary but deterministic, which matters more than
+  /// which regional variant wins: `en_GB` and `en_US` disagree about `colour`,
+  /// not about whether a word is ordinary, and a stable choice keeps one machine
+  /// answering the same way across launches.
+  static func resolveLanguage(_ base: String, from availableLanguages: [String]) -> String? {
     availableLanguages
       .filter { identifier in
         identifier
           .replacingOccurrences(of: "_", with: "-")
           .split(separator: "-", maxSplits: 1)
           .first?
-          .lowercased() == "en"
+          .lowercased() == base
       }
       .sorted()
       .first
@@ -229,15 +363,59 @@ package enum SeamCasingOracleRuntime {
 
   // MARK: - Decisions
 
-  /// The oracle as it stands right now. Never blocks.
-  package static func snapshot() -> SeamCasingOracle {
-    state.withLock { state in
-      switch state.phase {
-      case .warming: return .unavailable(.oracleWarming)
-      case .ready(let oracle): return oracle
-      case .unavailable(let reason): return .unavailable(reason)
+  /// The oracle for `base` as it stands right now. Never blocks.
+  ///
+  /// Requesting an unprepared language returns `.oracleWarming` and schedules
+  /// its preparation OFF the paste path. The first dictation in a new language
+  /// keeps its capital — today's behaviour — and every later one is served.
+  /// Preparation costs ~100 ms against a 100 ms wall-clock deadline whose
+  /// timeout latches casing off process-wide and permanently (#1946), so doing
+  /// it inline would mean one German dictation on a busy Mac disables casing in
+  /// every language until relaunch.
+  ///
+  /// Returns a LEASED oracle when ready. The caller MUST release it (see
+  /// `releaseDecisionLease`), which the repair does in `defer`. Without the
+  /// lease the drain could begin a preparation call while an already-issued
+  /// decision is still inside the shared checker — the race refusing-at-snapshot
+  /// does not close, because that snapshot escaped before preparation started.
+  package static func snapshot(for base: String?) -> SeamCasingOracle {
+    let (oracle, needsDrain) = state.withLock { state -> (SeamCasingOracle, Bool) in
+      if let latched = state.latched { return (.unavailable(latched), false) }
+      guard let base else { return (.unavailable(.languageNotSupported), false) }
+      // A preparation call is inside the checker right now: everyone refuses,
+      // including languages that are already built.
+      if state.preparing { return (.unavailable(.oracleWarming), false) }
+
+      switch state.phases[base] {
+      case .ready(let oracle):
+        state.decisionLeases += 1
+        return (oracle, false)
+      case .warming:
+        return (.unavailable(.oracleWarming), false)
+      case .unavailable(let reason):
+        return (.unavailable(reason), false)
+      case nil:
+        state.phases[base] = .warming
+        state.pending.append(base)
+        return (.unavailable(.oracleWarming), true)
       }
     }
+    if needsDrain { pokeDrain() }
+    return oracle
+  }
+
+  /// Release a lease taken by `snapshot(for:)`, and let preparation proceed.
+  ///
+  /// Must be called exactly once per READY snapshot, from a `defer` so an early
+  /// return or a thrown error cannot strand it. A stranded lease does not
+  /// corrupt anything, but it stops every future language from ever preparing.
+  package static func releaseDecisionLease() {
+    let resume = state.withLock { state -> Bool in
+      guard state.decisionLeases > 0 else { return false }
+      state.decisionLeases -= 1
+      return state.decisionLeases == 0 && !state.pending.isEmpty && !state.preparing
+    }
+    if resume { pokeDrain() }
   }
 
   /// Latch permanently after a live decision exceeded its deadline.
@@ -248,7 +426,11 @@ package enum SeamCasingOracleRuntime {
   package static func disableAfterTimeout() {
     state.withLock { state in
       state.epoch += 1
-      state.phase = .unavailable(.oracleTimedOut)
+      // PROCESS-WIDE and across every language, deliberately: a hung spell
+      // service is hung for all of them, and this is one shared checker. The
+      // latch is read first by `snapshot(for:)`, so no language can escape it.
+      state.latched = .oracleTimedOut
+      state.pending.removeAll()
     }
   }
 
@@ -259,11 +441,16 @@ package enum SeamCasingOracleRuntime {
   /// later found the identifier missing would write `.dictionaryUnavailable`
   /// over an already-installed `.oracleTimedOut` — it could not re-block paste,
   /// but it would violate the permanent-latch contract and mislabel telemetry.
-  private static func markUnavailableIfReady(_ reason: CursorInsertionRepair.CaseSkipReason) {
+  private static func markUnavailableIfReady(
+    _ reason: CursorInsertionRepair.CaseSkipReason, base: String
+  ) {
     state.withLock { state in
-      guard case .ready = state.phase else { return }
+      guard case .ready? = state.phases[base] else { return }
       state.epoch += 1
-      state.phase = .unavailable(reason)
+      // Scoped to the language that discovered it. A missing German dictionary
+      // says nothing about the English one, and demoting all of them would turn
+      // one language's outage into a whole-feature outage.
+      state.phases[base] = .unavailable(reason)
     }
   }
 
@@ -285,20 +472,35 @@ package enum SeamCasingOracleRuntime {
   /// order-dependent (local diff review r3).
   package static func resetForTesting() {
     state.withLock { state in
-      state = State(prewarmStarted: true, phase: .warming, epoch: state.epoch + 1)
+      state = State(prewarmStarted: true, epoch: state.epoch + 1)
     }
   }
 
-  /// Install a fixed phase without touching a system service.
-  package static func installForTesting(_ oracle: SeamCasingOracle) {
+  /// Install a fixed phase for one language without touching a system service.
+  ///
+  /// Defaults to English so the many existing suites that installed "the"
+  /// oracle keep meaning what they meant before this type became per-language.
+  /// A suite testing German must say so, which is the point: an oracle silently
+  /// installed under the wrong language would make a German test pass on an
+  /// English answer.
+  package static func installForTesting(_ oracle: SeamCasingOracle, for base: String = "en") {
     state.withLock { state in
       state.epoch += 1
       state.prewarmStarted = true
       if let reason = oracle.unavailableReason {
-        state.phase = .unavailable(reason)
+        state.phases[base] = .unavailable(reason)
       } else {
-        state.phase = .ready(oracle)
+        state.phases[base] = .ready(oracle)
       }
     }
+  }
+
+  /// Leases outstanding right now. Test-only.
+  ///
+  /// Exists so a test can PROVE the drain waits rather than asserting it in a
+  /// comment: take a lease, enqueue a second language, and show its preparation
+  /// cannot start until the lease is released.
+  package static func outstandingLeasesForTesting() -> Int {
+    state.withLock { $0.decisionLeases }
   }
 }

--- a/Sources/EnviousWisprPostProcessing/SeamCasingOracleRuntime.swift
+++ b/Sources/EnviousWisprPostProcessing/SeamCasingOracleRuntime.swift
@@ -142,8 +142,15 @@ package enum SeamCasingOracleRuntime {
       // English is warmed unconditionally at launch because it is by far the
       // most common language and this is the one moment that is definitely off
       // the paste path. Every other language is prepared on first request.
-      state.phases["en"] = .warming
-      state.pending.append("en")
+      //
+      // Through the SHARED enqueue, which is idempotent. `prewarm()` is launched
+      // asynchronously, so a dictation can request English first — and that
+      // request already marks English warming and queues it, while leaving
+      // `prewarmStarted` false. Appending unconditionally here queued English
+      // TWICE, so the drain built it twice, and during the pointless second build
+      // every ready language returned `oracleWarming`. Confirming whole-diff
+      // review r3, P2.
+      _ = enqueueLocked(&state, "en")
       return true
     }
     guard start else { return }
@@ -157,6 +164,24 @@ package enum SeamCasingOracleRuntime {
   /// type doc) holds only because preparation and decisions never overlap in the
   /// one shared `NSSpellChecker`. Independent per-language warmers would void
   /// it, and so would draining while a decision holds a lease.
+  /// Mark a language as requested, exactly once. Returns whether the drain needs
+  /// poking.
+  ///
+  /// ONE enqueue for both callers — `prewarm()` and `snapshot(for:)` — because
+  /// they had two, and the two disagreed. Guarding on "no phase yet" makes a
+  /// double request idempotent by construction rather than by both call sites
+  /// remembering to check.
+  ///
+  /// `prewarmStarted` is deliberately NOT touched here: it means "prewarm has
+  /// run", and a German dictation must not be able to suppress English's launch
+  /// warm-up by setting it.
+  private static func enqueueLocked(_ state: inout State, _ base: String) -> Bool {
+    guard state.phases[base] == nil else { return false }
+    state.phases[base] = .warming
+    state.pending.append(base)
+    return true
+  }
+
   @concurrent
   private static func drain() async {
     while true {
@@ -427,22 +452,34 @@ package enum SeamCasingOracleRuntime {
     }
     let (oracle, needsDrain) = state.withLock { state -> (SeamCasingOracle, Bool) in
       if let latched = state.latched { return (.unavailable(latched), false) }
+
+      // RECORD THE REQUEST FIRST, whatever we go on to answer. Enqueueing and
+      // answering are separate concerns, and collapsing them lost requests: the
+      // `preparing` early return below used to sit ABOVE the enqueue, so a German
+      // dictation arriving while English was still building was refused AND
+      // forgotten. The next German dictation only started German's preparation,
+      // so German casing could not work until the THIRD attempt — once at launch
+      // for every user whose second language is not English. Confirming
+      // whole-diff review r3, P2.
+      let queued = enqueueLocked(&state, base)
+
       // A preparation call is inside the checker right now: everyone refuses,
       // including languages that are already built.
-      if state.preparing { return (.unavailable(.oracleWarming), false) }
+      if state.preparing { return (.unavailable(.oracleWarming), queued) }
 
       switch state.phases[base] {
       case .ready(let oracle):
         state.decisionLeases += 1
-        return (oracle, false)
+        return (oracle, queued)
       case .warming:
-        return (.unavailable(.oracleWarming), false)
+        return (.unavailable(.oracleWarming), queued)
       case .unavailable(let reason):
-        return (.unavailable(reason), false)
+        return (.unavailable(reason), queued)
       case nil:
-        state.phases[base] = .warming
-        state.pending.append(base)
-        return (.unavailable(.oracleWarming), true)
+        // Unreachable: `enqueueLocked` above installs `.warming` for any language
+        // that had no phase. Kept for exhaustiveness, and answering `warming` is
+        // the correct conservative answer if it ever became reachable.
+        return (.unavailable(.oracleWarming), queued)
       }
     }
     if needsDrain { pokeDrain() }
@@ -515,13 +552,17 @@ package enum SeamCasingOracleRuntime {
   /// that concurrently — without this, a background prepare could publish
   /// `.ready` over a test's expected state and make full-suite results
   /// order-dependent (local diff review r3).
-  package static func resetForTesting() {
+  /// - Parameter prewarmStarted: defaults to `true`, which is what almost every
+  ///   case wants — it stops a REAL prewarm firing underneath the test. Pass
+  ///   `false` only to exercise `prewarm()` itself; without it that function
+  ///   returns at its first guard and a test aimed at its body reaches nothing.
+  package static func resetForTesting(prewarmStarted: Bool = true) {
     // Cleared here as well as by the setter, so a case that fails mid-way cannot
     // leave a blocking builder installed for every suite after it. The exclusion
     // helper resets on the way out, which makes this the backstop.
     preparationOverride.withLock { $0 = nil }
     state.withLock { state in
-      state = State(prewarmStarted: true, epoch: state.epoch + 1)
+      state = State(prewarmStarted: prewarmStarted, epoch: state.epoch + 1)
     }
   }
 

--- a/Sources/EnviousWisprPostProcessing/SeamCasingOracleRuntime.swift
+++ b/Sources/EnviousWisprPostProcessing/SeamCasingOracleRuntime.swift
@@ -100,8 +100,11 @@ package enum SeamCasingOracleRuntime {
   /// file and independently by grounded review r2.
   ///
   /// The dictionary sentinel is required by EVERY profile and must never be
-  /// relaxed: it is what makes the 23 unsupported European languages refuse
-  /// safely. Only the tag-scheme requirements vary.
+  /// relaxed. Be precise about what it does, because the two guards are easy to
+  /// conflate: the POLICY TABLE is what makes the 23 unsupported European
+  /// languages abstain — they never reach this type at all — while the sentinel
+  /// protects a SUPPORTED language against a dictionary that is listed but
+  /// answers yes to everything. Only the tag-scheme requirements vary.
   struct CapabilityProfile: Sendable {
     let needsNameType: Bool
     let needsLexicalClass: Bool

--- a/Sources/EnviousWisprPostProcessing/SeamCasingOracleRuntime.swift
+++ b/Sources/EnviousWisprPostProcessing/SeamCasingOracleRuntime.swift
@@ -404,10 +404,29 @@ package enum SeamCasingOracleRuntime {
   /// lease the drain could begin a preparation call while an already-issued
   /// decision is still inside the shared checker — the race refusing-at-snapshot
   /// does not close, because that snapshot escaped before preparation started.
-  package static func snapshot(for base: String?) -> SeamCasingOracle {
+  package static func snapshot(for rawLanguage: String?) -> SeamCasingOracle {
+    // ONE authority decides both the KEY and whether to do any work at all, and
+    // it is the same one `repair` consults. Whole-diff review found two P2s that
+    // are really one defect — the caller passed the RAW dictation tag while
+    // `repair` keyed off the NORMALISED base code:
+    //
+    // - A regional tag (`de-DE`) would key `phases["de-DE"]` and then ask
+    //   `resolveLanguage("de-DE", …)`, which compares against base codes, finds
+    //   nothing, and permanently marks that phantom key `.dictionaryUnavailable`.
+    //   Latent today — every producer emits a base code (the 100-entry lock
+    //   catalog and both engines) — but silent if one ever does not.
+    // - A language with NO casing policy (`ja`, `pl`) queued a real spell-checker
+    //   preparation it could never use, and WHILE that ran every ready language
+    //   refused with `oracleWarming`. That one is reachable today.
+    //
+    // Deriving both from `LanguageRules` makes the two key spaces identical by
+    // construction rather than by two call sites agreeing.
+    let rules = CursorInsertionRepair.LanguageRules.forLanguage(rawLanguage)
+    guard rules.casingPolicy != nil, let base = rules.baseCode else {
+      return .unavailable(.languageNotSupported)
+    }
     let (oracle, needsDrain) = state.withLock { state -> (SeamCasingOracle, Bool) in
       if let latched = state.latched { return (.unavailable(latched), false) }
-      guard let base else { return (.unavailable(.languageNotSupported), false) }
       // A preparation call is inside the checker right now: everyone refuses,
       // including languages that are already built.
       if state.preparing { return (.unavailable(.oracleWarming), false) }

--- a/Sources/EnviousWisprPostProcessing/SeamCasingOracleRuntime.swift
+++ b/Sources/EnviousWisprPostProcessing/SeamCasingOracleRuntime.swift
@@ -558,6 +558,28 @@ package enum SeamCasingOracleRuntime {
     }
   }
 
+  /// Read a language's prepared oracle WITHOUT requesting one. Test-only.
+  ///
+  /// `snapshot(for:)` is deliberately not read-only: an absent language is
+  /// enqueued and the drain is poked. That is right for a decision and wrong for
+  /// a helper whose only job is to save state so it can hand it back.
+  ///
+  /// Using `snapshot(for:)` for that started a REAL `NSSpellChecker` preparation
+  /// which `resetForTesting()` then could not cancel — it clears `preparing`
+  /// without stopping the builder — so the test's own preparation could overlap
+  /// the stray one. That is precisely the concurrent access these tests exist to
+  /// prove cannot happen, manufactured by the observation itself. Confirming
+  /// whole-diff review, P2.
+  ///
+  /// Returns nil when the language is absent, warming, or unavailable; all three
+  /// recompute safely on next request, so only a READY oracle is worth restoring.
+  package static func installedOracleForTesting(_ base: String = "en") -> SeamCasingOracle? {
+    state.withLock { state in
+      guard case .ready(let oracle)? = state.phases[base] else { return nil }
+      return oracle
+    }
+  }
+
   /// Leases outstanding right now. Test-only.
   ///
   /// Exists so a test can PROVE the drain waits rather than asserting it in a

--- a/Sources/EnviousWisprPostProcessing/SeamCasingOracleRuntime.swift
+++ b/Sources/EnviousWisprPostProcessing/SeamCasingOracleRuntime.swift
@@ -3,9 +3,9 @@ import Foundation
 import NaturalLanguage
 import os
 
-/// The single runtime owner of the English word oracle: readiness,
-/// availability, the permanent timeout latch, and the only contact with
-/// `NSSpellChecker` and `NLTagger` in the app.
+/// The single runtime owner of seam-casing word knowledge, one language at a
+/// time: readiness, availability, the permanent timeout latch, and the only
+/// contact with `NSSpellChecker` and `NLTagger` in the app.
 ///
 /// ## Why an owner at all
 ///
@@ -35,7 +35,19 @@ import os
 /// A stalled prewarm needs no deadline either: the state simply stays
 /// `.warming`, decisions refuse, and capitals are kept — today's behaviour.
 ///
-/// Issue #1803.
+/// ## What #1922 changed, and what it had to add
+///
+/// Going per-language is what put point 1 at risk. With one language, prewarm ran
+/// once at launch and nothing else ever prepared. With twelve, any dictation in a
+/// new language can start a preparation at any moment. Two guards restore the
+/// argument, and neither is sufficient alone:
+///
+/// - **One global drain**, so at most one builder is ever inside the checker.
+///   Independent per-language warmers would void the proof outright.
+/// - **A decision LEASE**, because refusing new snapshots does not stop one taken
+///   microseconds earlier from calling in during preparation.
+///
+/// Issues #1803, #1922.
 package enum SeamCasingOracleRuntime {
 
   private enum Phase: Sendable {
@@ -184,6 +196,17 @@ package enum SeamCasingOracleRuntime {
   /// Both are one-time and both are expensive: 20.2 ms and 80.3 ms measured
   /// cold. Neither is ever repeated.
   private static func prepare(base: String) -> Phase {
+    // The one seam in this function, and it exists because the serialization
+    // contract cannot be demonstrated any other way. `drain()` is the only code
+    // that can prove "one builder at a time, and never while a decision holds a
+    // lease", and the real body below calls `NSSpellChecker` and `NLTagger` — a
+    // test driving that would measure the machine, and could not hold a
+    // preparation open at a chosen instant, which IS the experiment.
+    if let build = preparationOverride.withLock({ $0 }) {
+      let oracle = build(base)
+      if let reason = oracle.unavailableReason { return .unavailable(reason) }
+      return .ready(oracle)
+    }
     // NEVER the raw dictation language, the checker's currently selected
     // language, or nil. Measured: `checkSpelling(language:)` with an
     // unrecognised identifier reports EVERY word correctly spelled — it fails
@@ -471,10 +494,28 @@ package enum SeamCasingOracleRuntime {
   /// `.ready` over a test's expected state and make full-suite results
   /// order-dependent (local diff review r3).
   package static func resetForTesting() {
+    // Cleared here as well as by the setter, so a case that fails mid-way cannot
+    // leave a blocking builder installed for every suite after it. The exclusion
+    // helper resets on the way out, which makes this the backstop.
+    preparationOverride.withLock { $0 = nil }
     state.withLock { state in
       state = State(prewarmStarted: true, epoch: state.epoch + 1)
     }
   }
+
+  /// Stand in for the system preparation of one language.
+  ///
+  /// Set AFTER `resetForTesting()`, which clears it. Returning an oracle with a
+  /// non-nil `unavailableReason` stands in for a preparation that found the
+  /// language unusable.
+  package static func setPreparationOverrideForTesting(
+    _ build: (@Sendable (String) -> SeamCasingOracle)?
+  ) {
+    preparationOverride.withLock { $0 = build }
+  }
+
+  private static let preparationOverride =
+    OSAllocatedUnfairLock<(@Sendable (String) -> SeamCasingOracle)?>(initialState: nil)
 
   /// Install a fixed phase for one language without touching a system service.
   ///

--- a/Sources/EnviousWisprPostProcessing/SeamCasingOracleRuntime.swift
+++ b/Sources/EnviousWisprPostProcessing/SeamCasingOracleRuntime.swift
@@ -36,11 +36,11 @@ import os
 /// `.warming`, decisions refuse, and capitals are kept — today's behaviour.
 ///
 /// Issue #1803.
-package enum EnglishWordOracleRuntime {
+package enum SeamCasingOracleRuntime {
 
   private enum Phase: Sendable {
     case warming
-    case ready(EnglishWordOracle)
+    case ready(SeamCasingOracle)
     case unavailable(CursorInsertionRepair.CaseSkipReason)
   }
 
@@ -126,7 +126,7 @@ package enum EnglishWordOracleRuntime {
     // advance.
     let sentinel = "zqx\(UInt32.random(in: 100_000...999_999))vkj"
 
-    let oracle = EnglishWordOracle(
+    let oracle = SeamCasingOracle(
       unavailableReason: nil,
       dictionaryVerdict: { word in
         let checker = NSSpellChecker.shared
@@ -230,7 +230,7 @@ package enum EnglishWordOracleRuntime {
   // MARK: - Decisions
 
   /// The oracle as it stands right now. Never blocks.
-  package static func snapshot() -> EnglishWordOracle {
+  package static func snapshot() -> SeamCasingOracle {
     state.withLock { state in
       switch state.phase {
       case .warming: return .unavailable(.oracleWarming)
@@ -290,7 +290,7 @@ package enum EnglishWordOracleRuntime {
   }
 
   /// Install a fixed phase without touching a system service.
-  package static func installForTesting(_ oracle: EnglishWordOracle) {
+  package static func installForTesting(_ oracle: SeamCasingOracle) {
     state.withLock { state in
       state.epoch += 1
       state.prewarmStarted = true

--- a/Sources/EnviousWisprPostProcessing/SeamCasingOracleRuntime.swift
+++ b/Sources/EnviousWisprPostProcessing/SeamCasingOracleRuntime.swift
@@ -337,8 +337,21 @@ package enum SeamCasingOracleRuntime {
         // Pinned, not sniffed. `NLTagger` guesses the language of a short
         // fragment badly, and this closure is only ever built for a language
         // whose `.lexicalClass` availability was already probed in `prepare`.
-        tagger.setLanguage(nlLanguage, range: payload.startIndex..<payload.endIndex)
+        //
+        // ORDER IS LOAD-BEARING: `string` FIRST, then `setLanguage`. Assigning
+        // the string RESETS the tagger, so pinning first threw the pin away and
+        // the comment above was describing something that was not happening.
+        //
+        // Measured, because the API contract alone understates it (cloud review,
+        // P2). On multi-word payloads the two orders agree — auto-detection gets
+        // German right — so a first probe of eight sentences found zero
+        // differences. On SINGLE-WORD payloads they diverge: `Hut`, `Bad` and
+        // `Boot` tag as `OtherWord` pinned-last and `Noun` pinned-correctly. The
+        // veto reads `tag == .noun`, so the wrong order LOWERCASED three ordinary
+        // German nouns — exactly the one-word dictation this feature is for.
+        // Probe: `issue-1922-artifacts/2026-08-05-tagger-order-probe.swift`.
         tagger.string = payload
+        tagger.setLanguage(nlLanguage, range: payload.startIndex..<payload.endIndex)
         guard
           let tag = tagger.tag(at: payload.startIndex, unit: .word, scheme: .lexicalClass).0
         else {

--- a/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
@@ -36,7 +36,31 @@ import os
       ["review", "the", "store", "testing"].contains($0) ? .ordinary : .notOrdinary
     },
     isLearnedWord: { _ in false },
-    isRecognizedName: { _, _ in false })
+    isRecognizedName: { _, _ in false },
+    // Never consulted on this suite's path: the veto runs only where
+    // `CasingPolicy.nounVeto` is set, and every case here resolves English.
+    // `false` rather than the conservative `true` so a future case that DOES
+    // reach it fails loudly instead of silently keeping every capital.
+    isNoun: { _ in false })
+
+  /// Availability without stranding a lease.
+  ///
+  /// `snapshot(for:)` takes a decision lease when it answers ready, and a lease
+  /// nobody releases stops every later language from ever preparing. An
+  /// assertion is not a decision, so it hands the lease straight back.
+  static func oracleIsAvailable(_ base: String = "en") -> Bool {
+    let oracle = SeamCasingOracleRuntime.snapshot(for: base)
+    if oracle.isAvailable { SeamCasingOracleRuntime.releaseDecisionLease() }
+    return oracle.isAvailable
+  }
+
+  static func oracleUnavailableReason(
+    _ base: String = "en"
+  ) -> CursorInsertionRepair.CaseSkipReason? {
+    let oracle = SeamCasingOracleRuntime.snapshot(for: base)
+    if oracle.isAvailable { SeamCasingOracleRuntime.releaseDecisionLease() }
+    return oracle.unavailableReason
+  }
 
   // MARK: Wedge tuning (PR-4 §3.6)
 
@@ -705,7 +729,7 @@ import os
       },
       registry: registry,
       readCaretContext: { _, _, _ in Self.midSentenceCaret },
-      englishWordOracle: { Self.testOracle })
+      seamCasingOracle: { _ in Self.testOracle })
 
     let processed = try await wiring.processText("Review this before the meeting") {}
     _ = await wiring.deliver(processed)
@@ -734,7 +758,7 @@ import os
       },
       registry: registry,
       readCaretContext: { _, _, _ in Self.midSentenceCaret },
-      englishWordOracle: { Self.testOracle })
+      seamCasingOracle: { _ in Self.testOracle })
 
     let processed = try await wiring.processText("Review this before the meeting") {}
     _ = await wiring.deliver(processed)
@@ -933,7 +957,7 @@ import os
         return Self.deliveredResult
       },
       readCaretContext: { _, _, _ in Self.midSentenceCaret },
-      englishWordOracle: { Self.testOracle })
+      seamCasingOracle: { _ in Self.testOracle })
 
     let processed = try await wiring.processText("Review this before the meeting") {}
     try await wiring.store(processed, UUID())
@@ -1214,7 +1238,7 @@ import os
         return Self.deliveredResult
       },
       readCaretContext: { _, _, _ in Self.midSentenceCaret },
-      englishWordOracle: { Self.testOracle })
+      seamCasingOracle: { _ in Self.testOracle })
 
     let first = try await wiring.processText("Review this before the meeting") {}
     _ = await wiring.deliver(first)
@@ -1277,7 +1301,7 @@ import os
         return Self.deliveredResult
       },
       readCaretContext: { _, _, _ in Self.midSentenceCaret },
-      englishWordOracle: { Self.testOracle })
+      seamCasingOracle: { _ in Self.testOracle })
 
     _ = await wiring.deliver("Review this before the meeting ")
 
@@ -1302,7 +1326,7 @@ import os
         return Self.deliveredResult
       },
       readCaretContext: { _, _, _ in Self.midSentenceCaret },
-      englishWordOracle: { Self.testOracle })
+      seamCasingOracle: { _ in Self.testOracle })
 
     // The vocabulary is EMPTY while this dictation is processed, so nothing
     // protects the leading word.
@@ -1340,7 +1364,7 @@ import os
         return Self.deliveredResult
       },
       readCaretContext: { _, _, _ in Self.midSentenceCaret },
-      englishWordOracle: { Self.testOracle })
+      seamCasingOracle: { _ in Self.testOracle })
 
     let secondProcessed = try await secondWiring.processText("Review this before the meeting") {}
     _ = await secondWiring.deliver(secondProcessed)
@@ -1387,7 +1411,14 @@ import os
     adapter: (any ASREngineAdapter)? = nil,
     // Injected, never installed into the process-global runtime: mutating that
     // would race `SeamCasingOracleTests` under concurrent suite execution.
-    englishWordOracle: @escaping @MainActor () -> SeamCasingOracle = { Self.testOracle },
+    //
+    // Takes the resolved language (#1922) and ignores it by default, so every
+    // pre-existing case keeps the one oracle it always had. A language-specific
+    // case passes its own closure and reads the argument.
+    seamCasingOracle: @escaping @MainActor (String?) -> SeamCasingOracle = { _ in
+      Self.testOracle
+    },
+    releaseOracleLease: @escaping @MainActor () -> Void = {},
     // #1921 language-resolver seam. Defaults to the real resolver so every
     // pre-existing case keeps today's behaviour; the two deadline tests inject a
     // blocking one to drive the REAL 100 ms deadline into its timeout paths.
@@ -1413,7 +1444,8 @@ import os
       save: save,
       deliverPaste: deliverPaste,
       readCaretContext: readCaretContext,
-      englishWordOracle: englishWordOracle,
+      seamCasingOracle: seamCasingOracle,
+      releaseOracleLease: releaseOracleLease,
       resolveLanguage: resolveLanguage
         ?? {
           DictationLanguageResolver.resolve(
@@ -1663,7 +1695,7 @@ import os
       SeamCasingOracleRuntime.resetForTesting()
       SeamCasingOracleRuntime.installForTesting(Self.testOracle)
       #expect(
-        SeamCasingOracleRuntime.snapshot().isAvailable,
+        Self.oracleIsAvailable(),
         "precondition: the oracle starts enabled, or this test cannot fail")
 
       let entered = DispatchSemaphore(value: 0)
@@ -1725,7 +1757,7 @@ import os
         "nothing was resolved in time, and the field must say so rather than guess")
       #expect(outcome.languageConfidenceBucket == "none")
       #expect(
-        SeamCasingOracleRuntime.snapshot().isAvailable,
+        Self.oracleIsAvailable(),
         "the oracle never ran, so the language stall must NOT have latched it off")
     }
   }
@@ -1739,7 +1771,7 @@ import os
     try await withSeamCasingOracleExclusion {
       SeamCasingOracleRuntime.resetForTesting()
       SeamCasingOracleRuntime.installForTesting(Self.testOracle)
-      #expect(SeamCasingOracleRuntime.snapshot().isAvailable, "precondition")
+      #expect(Self.oracleIsAvailable(), "precondition")
 
       let entered = DispatchSemaphore(value: 0)
       let release = DispatchSemaphore(value: 0)
@@ -1756,7 +1788,8 @@ import os
           return .ordinary
         },
         isLearnedWord: { _ in false },
-        isRecognizedName: { _, _ in false })
+        isRecognizedName: { _, _ in false },
+        isNoun: { _ in false })
 
       let outcome = KernelFinalizationOutcome()
       let context = KernelSessionContext()
@@ -1772,7 +1805,7 @@ import os
           return Self.deliveredResult
         },
         readCaretContext: { _, _, _ in Self.midSentenceCaret },
-        englishWordOracle: { blockingOracle },
+        seamCasingOracle: { _ in blockingOracle },
         resolveLanguage: { _, _, _, _, _ in
           DictationLanguageResolver.Resolution(
             language: "en", source: .dictation, confidenceBucket: .ge90)
@@ -1798,7 +1831,7 @@ import os
         request.legacyText == "Review this before the meeting ",
         "and the delivered payload must be exactly today's")
       #expect(
-        SeamCasingOracleRuntime.snapshot().unavailableReason == .oracleTimedOut,
+        Self.oracleUnavailableReason() == .oracleTimedOut,
         "a genuinely stuck oracle must still be latched off, exactly as before #1921")
       #expect(
         outcome.languageResolutionSource == "dictation",

--- a/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
@@ -22,15 +22,15 @@ import os
   ///
   /// Six cases here drive the real production repair, which needs word
   /// knowledge. This is INJECTED rather than installed into
-  /// `EnglishWordOracleRuntime`: mutating that process-global would race
-  /// `EnglishWordOracleTests`, which legitimately resets and latches it, and
+  /// `SeamCasingOracleRuntime`: mutating that process-global would race
+  /// `SeamCasingOracleTests`, which legitimately resets and latches it, and
   /// Swift Testing runs suites concurrently — a flake that passes until it does
   /// not (local diff review, P2).
   ///
   /// A FAKE rather than a real prewarm, because the live oracle reads the
   /// machine's dictionaries, part-of-speech assets and the user's learned words;
   /// gating CI on those would be flaky by construction (#1803 plan §11.2).
-  static let testOracle = EnglishWordOracle(
+  static let testOracle = SeamCasingOracle(
     unavailableReason: nil,
     dictionaryVerdict: {
       ["review", "the", "store", "testing"].contains($0) ? .ordinary : .notOrdinary
@@ -1386,8 +1386,8 @@ import os
     // stands in for exactly that state; language tests vary the code.
     adapter: (any ASREngineAdapter)? = nil,
     // Injected, never installed into the process-global runtime: mutating that
-    // would race `EnglishWordOracleTests` under concurrent suite execution.
-    englishWordOracle: @escaping @MainActor () -> EnglishWordOracle = { Self.testOracle },
+    // would race `SeamCasingOracleTests` under concurrent suite execution.
+    englishWordOracle: @escaping @MainActor () -> SeamCasingOracle = { Self.testOracle },
     // #1921 language-resolver seam. Defaults to the real resolver so every
     // pre-existing case keeps today's behaviour; the two deadline tests inject a
     // blocking one to drive the REAL 100 ms deadline into its timeout paths.
@@ -1659,11 +1659,11 @@ import os
     // the rest of the process. A naive "did the oracle begin" flag gets this
     // right only by luck, because cancellation here cannot preempt the blocked
     // call.
-    try await withEnglishWordOracleExclusion {
-      EnglishWordOracleRuntime.resetForTesting()
-      EnglishWordOracleRuntime.installForTesting(Self.testOracle)
+    try await withSeamCasingOracleExclusion {
+      SeamCasingOracleRuntime.resetForTesting()
+      SeamCasingOracleRuntime.installForTesting(Self.testOracle)
       #expect(
-        EnglishWordOracleRuntime.snapshot().isAvailable,
+        SeamCasingOracleRuntime.snapshot().isAvailable,
         "precondition: the oracle starts enabled, or this test cannot fail")
 
       let entered = DispatchSemaphore(value: 0)
@@ -1725,7 +1725,7 @@ import os
         "nothing was resolved in time, and the field must say so rather than guess")
       #expect(outcome.languageConfidenceBucket == "none")
       #expect(
-        EnglishWordOracleRuntime.snapshot().isAvailable,
+        SeamCasingOracleRuntime.snapshot().isAvailable,
         "the oracle never ran, so the language stall must NOT have latched it off")
     }
   }
@@ -1736,16 +1736,16 @@ import os
     // must be preserved exactly — and the resolution the language stage already
     // produced must survive into telemetry rather than being reported as `none`,
     // which is what a gate without a payload would do.
-    try await withEnglishWordOracleExclusion {
-      EnglishWordOracleRuntime.resetForTesting()
-      EnglishWordOracleRuntime.installForTesting(Self.testOracle)
-      #expect(EnglishWordOracleRuntime.snapshot().isAvailable, "precondition")
+    try await withSeamCasingOracleExclusion {
+      SeamCasingOracleRuntime.resetForTesting()
+      SeamCasingOracleRuntime.installForTesting(Self.testOracle)
+      #expect(SeamCasingOracleRuntime.snapshot().isAvailable, "precondition")
 
       let entered = DispatchSemaphore(value: 0)
       let release = DispatchSemaphore(value: 0)
       let exited = DispatchSemaphore(value: 0)
       let releaseOutcome = OSAllocatedUnfairLock<DispatchTimeoutResult?>(initialState: nil)
-      let blockingOracle = EnglishWordOracle(
+      let blockingOracle = SeamCasingOracle(
         unavailableReason: nil,
         dictionaryVerdict: { _ in
           entered.signal()
@@ -1798,7 +1798,7 @@ import os
         request.legacyText == "Review this before the meeting ",
         "and the delivered payload must be exactly today's")
       #expect(
-        EnglishWordOracleRuntime.snapshot().unavailableReason == .oracleTimedOut,
+        SeamCasingOracleRuntime.snapshot().unavailableReason == .oracleTimedOut,
         "a genuinely stuck oracle must still be latched off, exactly as before #1921")
       #expect(
         outcome.languageResolutionSource == "dictation",

--- a/Tests/EnviousWisprTests/PostProcessing/CursorInsertionRepairLanguagePairingTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CursorInsertionRepairLanguagePairingTests.swift
@@ -295,8 +295,9 @@ struct CursorInsertionRepairLanguagePairingTests {
     // The two-way control the case above cannot supply. A veto that answered
     // "noun" to everything would satisfy every German assertion in this suite
     // while disabling the feature for the whole language, and nothing would show
-    // it. Measured on held-out German: 22.0% correct before, 89.0% after — that
-    // gain is entirely made of continuations like this one.
+    // it. Measured on held-out German against the BUILT code: 22.0% correct
+    // before, 88.5% after — and that gain is entirely made of continuations like
+    // this one.
     let lowered = Self.repaired(
       "Und dann sagte er nichts.", "de",
       left: "Ich habe den ganzen Morgen an dieser Mail geschrieben ", right: "")

--- a/Tests/EnviousWisprTests/PostProcessing/CursorInsertionRepairLanguagePairingTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CursorInsertionRepairLanguagePairingTests.swift
@@ -23,7 +23,7 @@ struct CursorInsertionRepairLanguagePairingTests {
 
   /// Permits lowering any word it knows, so the casing rule is free to fire.
   /// A refusing oracle would make every case identical and the suite vacuous.
-  static let oracle = EnglishWordOracle(
+  static let oracle = SeamCasingOracle(
     unavailableReason: nil,
     dictionaryVerdict: { _ in .ordinary },
     isLearnedWord: { _ in false },

--- a/Tests/EnviousWisprTests/PostProcessing/CursorInsertionRepairLanguagePairingTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CursorInsertionRepairLanguagePairingTests.swift
@@ -9,11 +9,17 @@ import Testing
 // created after the language reaches the consumer is invisible to all of them.
 //
 // #1921 changes the resolver so it answers where it used to abstain. The safety
-// argument for that is a closed-set claim about `LanguageRules`: it has exactly
-// two policy fields; `knowsCasing` differs from `.unknown` only for English, and
-// `usesWordSpacing` differs only for the six effective unsegmented values
-// (`yue` normalises to `zh`). This suite is that claim executed against the real
-// `CursorInsertionRepair.repair` rather than asserted in a document.
+// argument for that is a closed-set claim about `LanguageRules`, executed here
+// against the real `CursorInsertionRepair.repair` rather than asserted in a
+// document.
+//
+// #1922 MOVED that claim, and this suite moved with it. `knowsCasing: Bool`
+// became `casingPolicy: CasingPolicy?`, and eleven more languages now have one,
+// so "every non-English language is byte-identical to nil" — what this suite
+// used to freeze — is no longer the contract and asserting it would freeze the
+// bug. The contract now has two halves and both are below: a language WITHOUT a
+// policy is still byte-identical to nil, and a language WITH one differs on the
+// casing axis and on nothing else.
 //
 // The oracle is injected and fixed, so these cases never touch the system
 // dictionary and stay deterministic on every machine and CI image — the same
@@ -23,11 +29,22 @@ struct CursorInsertionRepairLanguagePairingTests {
 
   /// Permits lowering any word it knows, so the casing rule is free to fire.
   /// A refusing oracle would make every case identical and the suite vacuous.
+  ///
+  /// `isNoun` mirrors what `NLTagger`'s `.lexicalClass` actually answers for the
+  /// German words this suite dictates, rather than a constant. A double thinner
+  /// than the guard it stands in for cannot demonstrate the guard: `false`
+  /// everywhere would make the German case fail for the right reason by the
+  /// wrong route, and `true` everywhere would make it pass without the veto
+  /// being what passed it.
   static let oracle = SeamCasingOracle(
     unavailableReason: nil,
     dictionaryVerdict: { _ in .ordinary },
     isLearnedWord: { _ in false },
-    isRecognizedName: { _, _ in false })
+    isRecognizedName: { _, _ in false },
+    isNoun: { payload in
+      let first = payload.split(separator: " ").first.map(String.init) ?? payload
+      return ["Gift", "Brot", "Haus"].contains(first)
+    })
 
   static let protectedWords: Set<String> = []
 
@@ -47,23 +64,30 @@ struct CursorInsertionRepairLanguagePairingTests {
       oracle: oracle)
   }
 
-  // MARK: - Segmented non-English: resolving must change NOTHING
+  // MARK: - A language WITHOUT a policy: resolving must still change NOTHING
 
   @Test(
-    "A segmented non-English language is byte-identical to no language at all",
+    "A segmented language with no casing policy is byte-identical to no language at all",
     arguments: [
-      ("Gift ist gefährlich.", "de", "Ich sagte dass das "),
-      ("Merci beaucoup vraiment.", "fr", "Je voulais dire que "),
-      ("Muchas gracias de verdad.", "es", "Queria decir que "),
-      ("Tot straks dan maar.", "nl", "Ik wilde zeggen dat "),
       ("Dziekuje bardzo za to.", "pl", "Chcialem powiedziec ze "),
-      ("Grazie mille davvero.", "it", "Volevo dire che "),
+      ("Dekuji moc za to.", "cs", "Chtel jsem rici ze "),
+      ("Nagyon szepen koszonom.", "hu", "Azt akartam mondani hogy "),
+      ("Multumesc mult pentru asta.", "ro", "Voiam sa spun ca "),
+      ("Efcharisto poly gia afto.", "el", "Ithela na po oti "),
+      ("Duzhe dyakuyu za tse.", "uk", "Ya khotiv skazaty shcho "),
     ])
-  func segmentedNonEnglishIsIdenticalToNil(_ payload: String, _ language: String, _ left: String) {
-    // This is the load-bearing half of the closed-set proof. Before #1921 these
-    // insertions resolved to nil; after it they resolve to their own language.
-    // If ANY field differs, returning a confident language is not the no-op the
-    // plan claims and the change is unsafe.
+  func unsupportedSegmentedLanguageIsIdenticalToNil(
+    _ payload: String, _ language: String, _ left: String
+  ) {
+    // The abstain half of the contract, and the control that makes the other
+    // half meaningful. #1922 gave eleven languages a policy; these six deliberately
+    // have none, so a confident resolution must still be a complete no-op for
+    // them. If any field moves here, the policy table is reaching languages it
+    // was never measured on.
+    //
+    // Six rather than one because "the table is keyed correctly" is a claim about
+    // absence, and one row cannot carry it — a prefix or fallback bug that
+    // admitted, say, every Slavic code would pass on Polish alone.
     let withNil = Self.repaired(payload, nil, left: left, right: "")
     let withLanguage = Self.repaired(payload, language, left: left, right: "")
 
@@ -73,6 +97,59 @@ struct CursorInsertionRepairLanguagePairingTests {
       withNil.candidateRules.map(\.telemetryName)
         == withLanguage.candidateRules.map(\.telemetryName),
       "\(language): applied rules")
+    #expect(
+      withLanguage.candidateRules.map(\.telemetryName)
+        .contains("case_skipped:language_not_supported"),
+      "\(language): and it must say WHY it abstained, not merely produce the same bytes")
+  }
+
+  // MARK: - A language WITH a policy: exactly one axis may change
+
+  @Test(
+    "A supported non-English language differs from nil ONLY by the casing rule",
+    arguments: [
+      ("Merci beaucoup vraiment.", "fr", "Je voulais dire que ", "merci beaucoup vraiment. "),
+      ("Muchas gracias de verdad.", "es", "Queria decir que ", "muchas gracias de verdad. "),
+      ("Tot straks dan maar.", "nl", "Ik wilde zeggen dat ", "tot straks dan maar. "),
+      ("Grazie mille davvero.", "it", "Volevo dire che ", "grazie mille davvero. "),
+      ("Tack sa mycket verkligen.", "sv", "Jag ville saga att ", "tack sa mycket verkligen. "),
+      ("Tusind tak for det.", "da", "Jeg ville sige at ", "tusind tak for det. "),
+      ("Kiitos oikein paljon.", "fi", "Halusin sanoa etta ", "kiitos oikein paljon. "),
+      ("Cok tesekkur ederim.", "tr", "Sunu soylemek istedim ", "cok tesekkur ederim. "),
+      ("Obrigado mesmo por isso.", "pt", "Eu queria dizer que ", "obrigado mesmo por isso. "),
+      ("Spasibo bolshoe za eto.", "ru", "Ya khotel skazat chto ", "spasibo bolshoe za eto. "),
+    ])
+  func supportedLanguageDiffersOnlyByCasing(
+    _ payload: String, _ language: String, _ left: String, _ expected: String
+  ) {
+    // The half #1922 adds. Before it, every one of these was byte-identical to
+    // nil and the seam kept a capital the user never asked for — wrong 92.9% of
+    // the time on held-out published text.
+    //
+    // EXACT bytes, never `!=` plus a `contains`. The loose form passes alongside
+    // unrelated text damage, which is precisely what "only one axis moved" is
+    // supposed to rule out.
+    let withNil = Self.repaired(payload, nil, left: left, right: "")
+    let withLanguage = Self.repaired(payload, language, left: left, right: "")
+
+    #expect(withNil.legacyText == withLanguage.legacyText, "\(language): legacy must not move")
+    #expect(
+      withLanguage.repairedText == expected,
+      "\(language): must produce exactly the lowered payload plus today's trailing space")
+    #expect(
+      withNil.repairedText == payload + " ",
+      "\(language): and the nil arm must produce exactly the payload unchanged")
+
+    // Every rule other than the casing decision must be identical. This is what
+    // would catch a spacing or duplicate-word change riding along.
+    let casingRules: Set<String> = ["lowercased_first", "case_skipped:language_not_supported"]
+    let nilOther = withNil.candidateRules.map(\.telemetryName).filter { !casingRules.contains($0) }
+    let langOther = withLanguage.candidateRules.map(\.telemetryName).filter {
+      !casingRules.contains($0)
+    }
+    #expect(
+      nilOther == langOther,
+      "\(language): only the casing rule may differ, got \(nilOther) vs \(langOther)")
   }
 
   // MARK: - English: exactly one axis may change
@@ -194,14 +271,41 @@ struct CursorInsertionRepairLanguagePairingTests {
     // English case and it applies identically here: `contains("Gift")` is
     // satisfied by a payload that kept its capital and was damaged elsewhere.
     //
-    // Derived from the rules: `left` already ends in a space so rule 1 adds
-    // none, German `knowsCasing` is false so rule 2 cannot fire, and rule 3
-    // appends the trailing space because German IS word-spaced.
+    // Derived from the rules, and the derivation CHANGED with #1922. It used to
+    // read "German `knowsCasing` is false so rule 2 cannot fire" — German now has
+    // a policy and rule 2 fires, reaches the oracle, is authorised to lower, and
+    // is then withdrawn by the noun veto. Same bytes out, entirely different
+    // route through, which is why the reason is asserted below: without it this
+    // case would keep passing if the veto were deleted and German were simply
+    // dropped from the table again.
     #expect(
       asGerman.repairedText == "Gift ist gefährlich. ",
       "the German noun must keep its capital, and nothing else may move")
     #expect(
+      asGerman.candidateRules.map(\.telemetryName)
+        .contains("case_skipped:noun_in_noun_capitalising_language"),
+      "and the VETO must be what kept it, not an abstention")
+    #expect(
       asEnglish.repairedText == "gift ist gefährlich. ",
       "and English rules WOULD have lowered it, which is what makes this test meaningful")
+  }
+
+  @Test("German lowers an ordinary non-noun continuation — the veto is not a blanket refusal")
+  func germanNonNounStillLowers() {
+    // The two-way control the case above cannot supply. A veto that answered
+    // "noun" to everything would satisfy every German assertion in this suite
+    // while disabling the feature for the whole language, and nothing would show
+    // it. Measured on held-out German: 22.0% correct before, 89.0% after — that
+    // gain is entirely made of continuations like this one.
+    let lowered = Self.repaired(
+      "Und dann sagte er nichts.", "de",
+      left: "Ich habe den ganzen Morgen an dieser Mail geschrieben ", right: "")
+
+    #expect(
+      lowered.repairedText == "und dann sagte er nichts. ",
+      "an ordinary German continuation must still lower")
+    #expect(
+      lowered.candidateRules.map(\.telemetryName).contains("lowercased_first"),
+      "and it must be the casing rule that did it")
   }
 }

--- a/Tests/EnviousWisprTests/PostProcessing/CursorInsertionRepairTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CursorInsertionRepairTests.swift
@@ -36,12 +36,19 @@ struct CursorInsertionRepairTests {
   /// exactly as they did against the old lexicon, which had no part-of-speech
   /// layer. The word-class filter has its own coverage in `SeamCasingOracleTests`;
   /// letting it fire here would silently change what these assertions mean.
+  ///
+  /// `isNoun` is unreachable from this suite — the veto runs only where
+  /// `CasingPolicy.nounVeto` is set, which is German alone, and every case here
+  /// is English. It answers `false` rather than the conservative `true` so that
+  /// a future case which DOES reach it fails visibly instead of quietly keeping
+  /// every capital and looking like a passing test of something else.
   static func oracle(_ words: Set<String>) -> SeamCasingOracle {
     SeamCasingOracle(
       unavailableReason: nil,
       dictionaryVerdict: { words.contains($0) ? .ordinary : .notOrdinary },
       isLearnedWord: { _ in false },
-      isRecognizedName: { _, _ in false })
+      isRecognizedName: { _, _ in false },
+      isNoun: { _ in false })
   }
 
   /// The prototype's representative word set. Proves the SHAPE of the rule
@@ -1294,11 +1301,27 @@ struct CursorInsertionRepairTests {
     "A word that is English-lowercase and a German noun is recased only in English",
     arguments: germanNounCollisions)
   func germanNounsKeepTheirCapital(_ word: String) {
-    // An oracle that AGREES these are ordinary English words, which is what the
-    // real dictionary says and what the deleted 799-word list said too. The
-    // contract under test is the LANGUAGE GATE, not dictionary membership: the
-    // English arm must lowercase, or the German arm proves nothing.
-    let agrees = Self.oracle(Set(Self.germanNounCollisions.map { $0.lowercased() }))
+    // The best case in this file, and #1922 changed only WHY it passes.
+    //
+    // It used to pass because German was not a casing language at all. German now
+    // is one, so the capital is kept by the noun VETO instead — which is a real
+    // improvement, because the old mechanism kept the capital on every German
+    // word and this one keeps it on the nouns.
+    //
+    // The oracle AGREES these are ordinary English words, which is what the real
+    // dictionary says and what the deleted 799-word list said too, and calls them
+    // nouns, which is what `NLTagger` answers in German. The contract under test
+    // is that the two languages disagree; the English arm must lowercase, or the
+    // German arm proves nothing.
+    let agrees = SeamCasingOracle(
+      unavailableReason: nil,
+      dictionaryVerdict: {
+        Set(Self.germanNounCollisions.map { $0.lowercased() }).contains($0)
+          ? .ordinary : .notOrdinary
+      },
+      isLearnedWord: { _ in false },
+      isRecognizedName: { _, _ in false },
+      isNoun: { _ in true })
 
     let english = CursorInsertionRepair.repair(
       text: "\(word) is fine.",
@@ -1313,20 +1336,47 @@ struct CursorInsertionRepairTests {
       context: CursorInsertionRepair.CaretText(left: "Ich gehe zum ", right: ""),
       protectedWords: [], language: "de", oracle: agrees)
     #expect(german.repairedText?.hasPrefix(word) == true, "\(word) must keep its capital")
-    #expect(german.candidateRules.contains(.caseSkipped(.languageNotSupported)))
+    #expect(german.candidateRules.contains(.caseSkipped(.nounInNounCapitalisingLanguage)))
     #expect(german.candidateRules.contains(.lowercasedFirst) == false)
   }
 
   @Test(
-    "Only English is recased; every other language keeps the capital it was given",
-    arguments: ["de", "fr", "es", "nl", "it", "pt", "ru", "sv", "tr", "ja", "zh"])
-  func nonEnglishIsNeverRecased(_ language: String) {
+    "A language with no casing policy keeps the capital it was given",
+    arguments: ["pl", "cs", "hu", "ro", "el", "uk", "ja", "zh"])
+  func unsupportedLanguageIsNeverRecased(_ language: String) {
+    // This case used to list de/fr/es/nl/it/pt/ru/sv/tr and assert that ALL of
+    // them kept the capital, under the title "Only English is recased". #1922 is
+    // precisely the change that gives those nine a rule of their own, so leaving
+    // the list alone would have frozen the defect. The eleven are covered by
+    // `CursorInsertionRepairLanguagePairingTests` and `SeamCasingPolicyTests`.
+    //
+    // What survives unchanged, and still matters, is the abstain half: a language
+    // we have not measured must keep doing exactly what the app did before this
+    // feature existed. `ja` and `zh` also stand for the unsegmented set, which
+    // has never had a casing rule to lose.
     let payloads = CursorInsertionRepair.repair(
       text: "Store today.",
       context: CursorInsertionRepair.CaretText(left: "I went to the ", right: ""),
       protectedWords: [], language: language, oracle: Self.prototypeOracle)
     #expect(payloads.candidateRules.contains(.caseSkipped(.languageNotSupported)))
     #expect(payloads.repairedText?.contains("Store") == true)
+  }
+
+  @Test(
+    "A language WITH a casing policy is recased, which is the other half of the same gate",
+    arguments: ["en", "de", "fr", "es", "nl", "it", "pt", "ru", "sv", "tr", "da", "fi"])
+  func supportedLanguageIsRecased(_ language: String) {
+    // The two-way control. Without it, the case above is satisfied by a build
+    // where NOTHING is ever recased — including English, which would be the
+    // largest regression this change could possibly ship.
+    let payloads = CursorInsertionRepair.repair(
+      text: "Store today.",
+      context: CursorInsertionRepair.CaretText(left: "I went to the ", right: ""),
+      protectedWords: [], language: language, oracle: Self.prototypeOracle)
+    #expect(
+      payloads.candidateRules.contains(.lowercasedFirst),
+      "\(language) has a policy, so it must act")
+    #expect(payloads.repairedText?.contains("store") == true)
   }
 
   @Test("Region variants resolve to their base language", arguments: ["en-US", "en_GB", "EN"])
@@ -1575,7 +1625,8 @@ struct CursorInsertionRepairTests {
     unavailableReason: nil,
     dictionaryVerdict: { ["mark", "with", "and", "now"].contains($0) ? .ordinary : .notOrdinary },
     isLearnedWord: { _ in false },
-    isRecognizedName: { left, _ in left.last?.isWhitespace == true })
+    isRecognizedName: { left, _ in left.last?.isWhitespace == true },
+    isNoun: { _ in false })
 
   @Test("A terminal seam asks the SEPARATED reading too, so a name keeps its capital")
   func screenDerivedSeamProtectsAName() {
@@ -1641,7 +1692,8 @@ struct CursorInsertionRepairTests {
         unavailableReason: nil,
         dictionaryVerdict: { ["and", "now"].contains($0) ? .ordinary : .notOrdinary },
         isLearnedWord: { _ in false },
-        isRecognizedName: { _, _ in false }))
+        isRecognizedName: { _, _ in false },
+        isNoun: { _ in false }))
     #expect(payloads.repairedText?.hasPrefix("and now") == true)
   }
 

--- a/Tests/EnviousWisprTests/PostProcessing/CursorInsertionRepairTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CursorInsertionRepairTests.swift
@@ -13,7 +13,7 @@ import Testing
 //
 // Repair MECHANICS are tested against an injected oracle with fixed answers,
 // so these cases never touch the system dictionary or the part-of-speech model
-// and stay deterministic on every machine and CI image. `EnglishWordOracleTests`
+// and stay deterministic on every machine and CI image. `SeamCasingOracleTests`
 // covers the live oracle's own behaviour (#1803).
 @Suite("CursorInsertionRepair")
 struct CursorInsertionRepairTests {
@@ -34,10 +34,10 @@ struct CursorInsertionRepairTests {
   ///
   /// `isRecognizedName` always returns false so these cases test repair MECHANICS
   /// exactly as they did against the old lexicon, which had no part-of-speech
-  /// layer. The word-class filter has its own coverage in `EnglishWordOracleTests`;
+  /// layer. The word-class filter has its own coverage in `SeamCasingOracleTests`;
   /// letting it fire here would silently change what these assertions mean.
-  static func oracle(_ words: Set<String>) -> EnglishWordOracle {
-    EnglishWordOracle(
+  static func oracle(_ words: Set<String>) -> SeamCasingOracle {
+    SeamCasingOracle(
       unavailableReason: nil,
       dictionaryVerdict: { words.contains($0) ? .ordinary : .notOrdinary },
       isLearnedWord: { _ in false },
@@ -1571,7 +1571,7 @@ struct CursorInsertionRepairTests {
   /// (`...with Mark said`) recognised 5. A terminal renders a row up to its last
   /// VISIBLE character, so the trailing space the user typed is not on screen
   /// and the fused reading is the one the repair would otherwise get.
-  private static let seamSensitiveOracle = EnglishWordOracle(
+  private static let seamSensitiveOracle = SeamCasingOracle(
     unavailableReason: nil,
     dictionaryVerdict: { ["mark", "with", "and", "now"].contains($0) ? .ordinary : .notOrdinary },
     isLearnedWord: { _ in false },
@@ -1637,7 +1637,7 @@ struct CursorInsertionRepairTests {
         left: "I want to test if this works", right: "",
         leftReachesDocumentStart: true, isScreenDerived: true),
       protectedWords: [],
-      oracle: EnglishWordOracle(
+      oracle: SeamCasingOracle(
         unavailableReason: nil,
         dictionaryVerdict: { ["and", "now"].contains($0) ? .ordinary : .notOrdinary },
         isLearnedWord: { _ in false },

--- a/Tests/EnviousWisprTests/PostProcessing/SeamCasingOracleTestExclusion.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SeamCasingOracleTestExclusion.swift
@@ -2,17 +2,17 @@ import Foundation
 
 @testable import EnviousWisprPostProcessing
 
-/// Cross-SUITE exclusion for the process-wide `EnglishWordOracleRuntime`.
+/// Cross-SUITE exclusion for the process-wide `SeamCasingOracleRuntime`.
 ///
 /// Modelled on `AppLoggerTestExclusion` (#1361), which exists for the identical
 /// problem: `.serialized` orders tests within ONE suite and nothing more, and
 /// Swift Testing runs suites concurrently, so two suites touching the same
 /// process global interleave at every `await`.
 ///
-/// Until #1921 only `EnglishWordOracleTests` mutated this runtime, and its
+/// Until #1921 only `SeamCasingOracleTests` mutated this runtime, and its
 /// `.serialized` was sufficient BY ACCIDENT — it was the only participant.
 /// `KernelFinalizationWiringTests` deliberately injected a fake oracle instead,
-/// with a comment saying mutating the global "would race `EnglishWordOracleTests`".
+/// with a comment saying mutating the global "would race `SeamCasingOracleTests`".
 /// #1921's two deadline tests must assert what the timeout does to the real
 /// runtime, so they cannot avoid it, and the accident ends.
 ///
@@ -22,8 +22,8 @@ import Foundation
 /// one — so this is a correctness fix, not tidiness.
 ///
 /// Fair FIFO, so a suite cannot be starved by a busy neighbour.
-actor EnglishWordOracleTestExclusion {
-  static let shared = EnglishWordOracleTestExclusion()
+actor SeamCasingOracleTestExclusion {
+  static let shared = SeamCasingOracleTestExclusion()
 
   private var held = false
   private var waiters: [CheckedContinuation<Void, Never>] = []
@@ -50,7 +50,7 @@ actor EnglishWordOracleTestExclusion {
   }
 }
 
-/// Runs `body` with exclusive access to `EnglishWordOracleRuntime`, then resets
+/// Runs `body` with exclusive access to `SeamCasingOracleRuntime`, then resets
 /// it so the next holder starts from a known state.
 ///
 /// Free function, NOT a method on the actor: as a method the caller's closure
@@ -76,23 +76,23 @@ actor EnglishWordOracleTestExclusion {
 ///
 /// A leaked hold would deadlock every other participating suite for the rest of
 /// the run, so restoration and release happen on both exits.
-func withEnglishWordOracleExclusion<T>(
+func withSeamCasingOracleExclusion<T>(
   isolation: isolated (any Actor)? = #isolation,
   _ body: () async throws -> T
 ) async rethrows -> T {
-  await EnglishWordOracleTestExclusion.shared.acquire()
+  await SeamCasingOracleTestExclusion.shared.acquire()
 
-  let prior = EnglishWordOracleRuntime.snapshot()
+  let prior = SeamCasingOracleRuntime.snapshot()
 
   @Sendable func restoreAndRelease() async {
-    EnglishWordOracleRuntime.resetForTesting()
+    SeamCasingOracleRuntime.resetForTesting()
     // `oracleWarming` IS what a reset produces, so reinstalling it would be a
     // no-op at best. Any other prior state was a real oracle this holder must
     // hand back.
     if prior.unavailableReason != .oracleWarming {
-      EnglishWordOracleRuntime.installForTesting(prior)
+      SeamCasingOracleRuntime.installForTesting(prior)
     }
-    await EnglishWordOracleTestExclusion.shared.release()
+    await SeamCasingOracleTestExclusion.shared.release()
   }
 
   do {

--- a/Tests/EnviousWisprTests/PostProcessing/SeamCasingOracleTestExclusion.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SeamCasingOracleTestExclusion.swift
@@ -82,7 +82,21 @@ func withSeamCasingOracleExclusion<T>(
 ) async rethrows -> T {
   await SeamCasingOracleTestExclusion.shared.acquire()
 
-  let prior = SeamCasingOracleRuntime.snapshot()
+  // ENGLISH only, and that is a deliberate limit rather than an oversight.
+  //
+  // The runtime holds one phase per language now (#1922), so "the prior state"
+  // is a dictionary. It cannot be read as one: probing a language that was never
+  // requested ENQUEUES it, so a save loop would itself mutate what it is trying
+  // to preserve, and the phase type is private besides. English is the only
+  // language the app prewarms at launch, so it is the only one a holder can
+  // realistically destroy. Every other language is left reset, which costs one
+  // re-preparation and can never produce a wrong answer.
+  //
+  // The lease goes back immediately: an assertion is not a decision, and a lease
+  // nobody releases would stop the drain preparing any language for the rest of
+  // the run.
+  let prior = SeamCasingOracleRuntime.snapshot(for: "en")
+  if prior.isAvailable { SeamCasingOracleRuntime.releaseDecisionLease() }
 
   @Sendable func restoreAndRelease() async {
     SeamCasingOracleRuntime.resetForTesting()
@@ -90,7 +104,7 @@ func withSeamCasingOracleExclusion<T>(
     // no-op at best. Any other prior state was a real oracle this holder must
     // hand back.
     if prior.unavailableReason != .oracleWarming {
-      SeamCasingOracleRuntime.installForTesting(prior)
+      SeamCasingOracleRuntime.installForTesting(prior, for: "en")
     }
     await SeamCasingOracleTestExclusion.shared.release()
   }

--- a/Tests/EnviousWisprTests/PostProcessing/SeamCasingOracleTestExclusion.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SeamCasingOracleTestExclusion.swift
@@ -82,30 +82,29 @@ func withSeamCasingOracleExclusion<T>(
 ) async rethrows -> T {
   await SeamCasingOracleTestExclusion.shared.acquire()
 
-  // ENGLISH only, and that is a deliberate limit rather than an oversight.
+  // READ-ONLY, and that is load-bearing rather than tidy.
   //
-  // The runtime holds one phase per language now (#1922), so "the prior state"
-  // is a dictionary. It cannot be read as one: probing a language that was never
-  // requested ENQUEUES it, so a save loop would itself mutate what it is trying
-  // to preserve, and the phase type is private besides. English is the only
-  // language the app prewarms at launch, so it is the only one a holder can
-  // realistically destroy. Every other language is left reset, which costs one
-  // re-preparation and can never produce a wrong answer.
+  // The obvious way to save prior state is `snapshot(for: "en")`. That is a
+  // decision-time call and is deliberately NOT read-only: an absent language is
+  // enqueued and a real `NSSpellChecker` preparation is started. The body then
+  // calls `resetForTesting()`, which clears `preparing` without being able to
+  // cancel a builder already running — so the test's own preparation could
+  // overlap the stray one and produce exactly the concurrent access these suites
+  // exist to prove cannot happen. Observation manufacturing the defect it
+  // observes. Confirming whole-diff review, P2.
   //
-  // The lease goes back immediately: an assertion is not a decision, and a lease
-  // nobody releases would stop the drain preparing any language for the rest of
-  // the run.
-  let prior = SeamCasingOracleRuntime.snapshot(for: "en")
-  if prior.isAvailable { SeamCasingOracleRuntime.releaseDecisionLease() }
+  // ENGLISH only, and that is a deliberate limit. The runtime holds one phase per
+  // language now (#1922), and there is no way to enumerate them without
+  // requesting them. English is the only language the app prewarms at launch, so
+  // it is the only one a holder can realistically destroy; every other language
+  // is left reset, which costs one re-preparation and can never produce a wrong
+  // answer. Warming and unavailable phases are not restored for the same reason —
+  // both recompute safely.
+  let prior = SeamCasingOracleRuntime.installedOracleForTesting("en")
 
   @Sendable func restoreAndRelease() async {
     SeamCasingOracleRuntime.resetForTesting()
-    // `oracleWarming` IS what a reset produces, so reinstalling it would be a
-    // no-op at best. Any other prior state was a real oracle this holder must
-    // hand back.
-    if prior.unavailableReason != .oracleWarming {
-      SeamCasingOracleRuntime.installForTesting(prior, for: "en")
-    }
+    if let prior { SeamCasingOracleRuntime.installForTesting(prior, for: "en") }
     await SeamCasingOracleTestExclusion.shared.release()
   }
 

--- a/Tests/EnviousWisprTests/PostProcessing/SeamCasingOracleTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SeamCasingOracleTests.swift
@@ -346,7 +346,11 @@ struct SeamCasingOracleTests {
       // this case stands in for the product call, so it should take the same
       // route through the runtime that the product call takes.
       let live = SeamCasingOracleRuntime.snapshot(for: "en")
-      defer { SeamCasingOracleRuntime.releaseDecisionLease() }
+      // Conditional, mirroring production. This case's snapshot is WARMING, so it
+      // takes no lease, and an unconditional release here would model the
+      // production bug rather than the production code.
+      let holdsLease = live.isAvailable
+      defer { if holdsLease { SeamCasingOracleRuntime.releaseDecisionLease() } }
       let payloads = CursorInsertionRepair.repair(
         text: "Go home.",
         context: CursorInsertionRepair.CaretText(left: "I can't wait to", right: ""),

--- a/Tests/EnviousWisprTests/PostProcessing/SeamCasingOracleTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SeamCasingOracleTests.swift
@@ -20,8 +20,8 @@ import os
 // this `warmingRefuses` can reset the phase while `timeoutLatchIsPermanent`
 // expects it still latched — an order-dependent flake that passes until it does
 // not (local diff review r3).
-@Suite("EnglishWordOracle", .serialized)
-struct EnglishWordOracleTests {
+@Suite("SeamCasingOracle", .serialized)
+struct SeamCasingOracleTests {
 
   /// An oracle with fixed answers. `isName` defaults to false so a case that is
   /// not about the name recogniser cannot fail because of it.
@@ -29,8 +29,8 @@ struct EnglishWordOracleTests {
     ordinary: Set<String> = [],
     learned: Set<String> = [],
     isName: Bool = false
-  ) -> EnglishWordOracle {
-    EnglishWordOracle(
+  ) -> SeamCasingOracle {
+    SeamCasingOracle(
       unavailableReason: nil,
       dictionaryVerdict: { ordinary.contains($0) ? .ordinary : .notOrdinary },
       isLearnedWord: { learned.contains($0) },
@@ -101,7 +101,7 @@ struct EnglishWordOracleTests {
     // Order is the design: a name is decided before the dictionary is asked, so
     // `mark` being a perfectly good English word is irrelevant.
     let probe = ConsultationSpy()
-    let oracle = EnglishWordOracle(
+    let oracle = SeamCasingOracle(
       unavailableReason: nil,
       dictionaryVerdict: { _ in
         probe.record()
@@ -168,7 +168,7 @@ struct EnglishWordOracleTests {
       .wordClassUnavailable, .oracleWarming, .oracleTimedOut,
     ])
   func unavailableOracleRefuses(_ reason: CursorInsertionRepair.CaseSkipReason) {
-    let decision = EnglishWordOracle.unavailable(reason)
+    let decision = SeamCasingOracle.unavailable(reason)
       .mayLower(word: "Go", left: "I want to ", payload: "Go home.")
     #expect(decision == reason)
   }
@@ -182,24 +182,24 @@ struct EnglishWordOracleTests {
     // word correctly spelled — it fails OPEN. Choosing from `availableLanguages`
     // makes that unreachable rather than merely detected.
     let installed = ["fr", "en_GB", "de", "en", "en_AU"]
-    #expect(EnglishWordOracleRuntime.resolveEnglishLanguage(from: installed) == "en")
+    #expect(SeamCasingOracleRuntime.resolveEnglishLanguage(from: installed) == "en")
   }
 
   @Test("A machine with no English dictionary yields no identifier")
   func noEnglishYieldsNil() {
-    #expect(EnglishWordOracleRuntime.resolveEnglishLanguage(from: ["fr", "de", "ja"]) == nil)
+    #expect(SeamCasingOracleRuntime.resolveEnglishLanguage(from: ["fr", "de", "ja"]) == nil)
   }
 
   @Test("A regional English is accepted when plain English is absent")
   func regionalEnglishAccepted() {
-    #expect(EnglishWordOracleRuntime.resolveEnglishLanguage(from: ["de", "en_GB"]) == "en_GB")
+    #expect(SeamCasingOracleRuntime.resolveEnglishLanguage(from: ["de", "en_GB"]) == "en_GB")
   }
 
   @Test("Language matching is on the base code, not a prefix of the string")
   func baseCodeNotPrefix() {
     // `eng` and `enm` start with "en" but are not English identifiers we want to
     // silently accept; matching must split on the separator.
-    #expect(EnglishWordOracleRuntime.resolveEnglishLanguage(from: ["eng", "enm"]) == nil)
+    #expect(SeamCasingOracleRuntime.resolveEnglishLanguage(from: ["eng", "enm"]) == nil)
   }
 
   // MARK: - The spell service failing OPEN
@@ -207,7 +207,7 @@ struct EnglishWordOracleTests {
   @Test("A healthy service: a valid word is ordinary and the sentinel is refused")
   func healthyServiceAcceptsWord() {
     var failed = false
-    let ordinary = EnglishWordOracleRuntime.isOrdinary(
+    let ordinary = SeamCasingOracleRuntime.isOrdinary(
       "go", sentinel: "zqx123456vkj",
       spelledCorrectly: { $0 == "go" },
       onServiceFailure: { failed = true })
@@ -221,7 +221,7 @@ struct EnglishWordOracleTests {
     // same NSNotFound. Without this guard every word would read as ordinary and
     // names would be lowercased wholesale — silent, and the worst direction.
     var failed = false
-    let ordinary = EnglishWordOracleRuntime.isOrdinary(
+    let ordinary = SeamCasingOracleRuntime.isOrdinary(
       "Rose", sentinel: "zqx123456vkj",
       spelledCorrectly: { _ in true },
       onServiceFailure: { failed = true })
@@ -234,7 +234,7 @@ struct EnglishWordOracleTests {
     // Refusing is the safe direction, so it needs no confirmation. This keeps
     // the second lookup off every decision that keeps its capital.
     var probed: [String] = []
-    let ordinary = EnglishWordOracleRuntime.isOrdinary(
+    let ordinary = SeamCasingOracleRuntime.isOrdinary(
       "Zorbitrax", sentinel: "zqx123456vkj",
       spelledCorrectly: {
         probed.append($0)
@@ -259,7 +259,7 @@ struct EnglishWordOracleTests {
     // design used left contexts already ending in a space, so none of them could
     // catch it (local diff review r2, P1).
     let seenLeft = LeftContextRecorder()
-    let recorder = EnglishWordOracle(
+    let recorder = SeamCasingOracle(
       unavailableReason: nil,
       dictionaryVerdict: { _ in .ordinary },
       isLearnedWord: { _ in false },
@@ -290,9 +290,9 @@ struct EnglishWordOracleTests {
     // Cross-suite exclusion: this test mutates the process-wide runtime,
     // and since #1921 a second suite does too. `.serialized` orders this
     // suite only; Swift Testing runs suites concurrently.
-    await withEnglishWordOracleExclusion {
-      EnglishWordOracleRuntime.resetForTesting()
-      let snapshot = EnglishWordOracleRuntime.snapshot()
+    await withSeamCasingOracleExclusion {
+      SeamCasingOracleRuntime.resetForTesting()
+      let snapshot = SeamCasingOracleRuntime.snapshot()
       #expect(snapshot.isAvailable == false)
       #expect(snapshot.unavailableReason == .oracleWarming)
     }
@@ -303,16 +303,16 @@ struct EnglishWordOracleTests {
     // Cross-suite exclusion: this test mutates the process-wide runtime,
     // and since #1921 a second suite does too. `.serialized` orders this
     // suite only; Swift Testing runs suites concurrently.
-    await withEnglishWordOracleExclusion {
+    await withSeamCasingOracleExclusion {
       // The product call: the first dictation after a cold launch keeps its
       // capital — today's behaviour — rather than paying the measured 105.6 ms of
       // one-time setup on the paste path.
-      EnglishWordOracleRuntime.resetForTesting()
+      SeamCasingOracleRuntime.resetForTesting()
       let payloads = CursorInsertionRepair.repair(
         text: "Go home.",
         context: CursorInsertionRepair.CaretText(left: "I can't wait to", right: ""),
         protectedWords: [],
-        oracle: EnglishWordOracleRuntime.snapshot())
+        oracle: SeamCasingOracleRuntime.snapshot())
 
       #expect(payloads.candidateRules.contains(.caseSkipped(.oracleWarming)))
       #expect(payloads.repairedText?.contains("Go home.") == true, "capital kept")
@@ -325,18 +325,18 @@ struct EnglishWordOracleTests {
     // Cross-suite exclusion: this test mutates the process-wide runtime,
     // and since #1921 a second suite does too. `.serialized` orders this
     // suite only; Swift Testing runs suites concurrently.
-    await withEnglishWordOracleExclusion {
+    await withSeamCasingOracleExclusion {
       // `withOrderedDeadline.claim()` discards a late decision but cannot roll
       // back side effects inside the abandoned operation. The latch must therefore
       // outlast anything that call does afterwards, or a stalled service could be
       // waited on twice.
-      EnglishWordOracleRuntime.resetForTesting()
-      EnglishWordOracleRuntime.installForTesting(Self.oracle(ordinary: ["go"]))
-      #expect(EnglishWordOracleRuntime.snapshot().isAvailable)
+      SeamCasingOracleRuntime.resetForTesting()
+      SeamCasingOracleRuntime.installForTesting(Self.oracle(ordinary: ["go"]))
+      #expect(SeamCasingOracleRuntime.snapshot().isAvailable)
 
-      EnglishWordOracleRuntime.disableAfterTimeout()
+      SeamCasingOracleRuntime.disableAfterTimeout()
 
-      let after = EnglishWordOracleRuntime.snapshot()
+      let after = SeamCasingOracleRuntime.snapshot()
       #expect(after.isAvailable == false)
       #expect(after.unavailableReason == .oracleTimedOut)
       #expect(
@@ -350,7 +350,7 @@ struct EnglishWordOracleTests {
     // Cross-suite exclusion: this test mutates the process-wide runtime,
     // and since #1921 a second suite does too. `.serialized` orders this
     // suite only; Swift Testing runs suites concurrently.
-    await withEnglishWordOracleExclusion {
+    await withSeamCasingOracleExclusion {
       // `prewarmStarted` guards STARTING a prewarm, not one already in flight. A
       // prepare launched by another suite's driver construction can finish after
       // `resetForTesting()` restores `.warming` — which is exactly the condition
@@ -358,13 +358,13 @@ struct EnglishWordOracleTests {
       //
       // The epoch closes it. Simulated here by latching, which bumps the epoch,
       // and then letting a prewarm attempt to publish.
-      EnglishWordOracleRuntime.resetForTesting()
-      EnglishWordOracleRuntime.disableAfterTimeout()
+      SeamCasingOracleRuntime.resetForTesting()
+      SeamCasingOracleRuntime.disableAfterTimeout()
 
-      await EnglishWordOracleRuntime.prewarm()
+      await SeamCasingOracleRuntime.prewarm()
 
       #expect(
-        EnglishWordOracleRuntime.snapshot().unavailableReason == .oracleTimedOut,
+        SeamCasingOracleRuntime.snapshot().unavailableReason == .oracleTimedOut,
         "a prewarm must never overwrite state established after it began")
     }
   }
@@ -374,16 +374,16 @@ struct EnglishWordOracleTests {
     // Cross-suite exclusion: this test mutates the process-wide runtime,
     // and since #1921 a second suite does too. `.serialized` orders this
     // suite only; Swift Testing runs suites concurrently.
-    await withEnglishWordOracleExclusion {
-      EnglishWordOracleRuntime.resetForTesting()
-      EnglishWordOracleRuntime.installForTesting(Self.oracle(ordinary: ["go"]))
-      EnglishWordOracleRuntime.disableAfterTimeout()
+    await withSeamCasingOracleExclusion {
+      SeamCasingOracleRuntime.resetForTesting()
+      SeamCasingOracleRuntime.installForTesting(Self.oracle(ordinary: ["go"]))
+      SeamCasingOracleRuntime.disableAfterTimeout()
 
       // `installForTesting` marks prewarm started, so this is the real
       // idempotence guard rather than an accident of ordering.
-      await EnglishWordOracleRuntime.prewarm()
+      await SeamCasingOracleRuntime.prewarm()
 
-      #expect(EnglishWordOracleRuntime.snapshot().unavailableReason == .oracleTimedOut)
+      #expect(SeamCasingOracleRuntime.snapshot().unavailableReason == .oracleTimedOut)
     }
   }
 
@@ -395,7 +395,7 @@ struct EnglishWordOracleTests {
     // first would silently weaken the contract shipped in PR #1804 — and the
     // dictionary would accept `olive` happily.
     let consulted = ConsultationSpy()
-    let spy = EnglishWordOracle(
+    let spy = SeamCasingOracle(
       unavailableReason: nil,
       dictionaryVerdict: { _ in
         consulted.record()
@@ -418,7 +418,7 @@ struct EnglishWordOracleTests {
   @Test("Non-English dictation never reaches the oracle at all")
   func nonEnglishNeverConsultsOracle() {
     let consulted = ConsultationSpy()
-    let spy = EnglishWordOracle(
+    let spy = SeamCasingOracle(
       unavailableReason: nil,
       dictionaryVerdict: { _ in
         consulted.record()
@@ -456,7 +456,7 @@ struct EnglishWordOracleTests {
   @Test("#1921 An authorized wrapper reaches the underlying oracle on every closure")
   func authorizedWrapperPassesThrough() {
     let calls = OSAllocatedUnfairLock(initialState: 0)
-    let underlying = EnglishWordOracle(
+    let underlying = SeamCasingOracle(
       unavailableReason: nil,
       dictionaryVerdict: { _ in
         calls.withLock { $0 += 1 }
@@ -491,7 +491,7 @@ struct EnglishWordOracleTests {
     // counting: a count can be asserted after the damage, this cannot pass at
     // all if the guard is missing.
     let calls = OSAllocatedUnfairLock(initialState: 0)
-    let underlying = EnglishWordOracle(
+    let underlying = SeamCasingOracle(
       unavailableReason: nil,
       dictionaryVerdict: { _ in
         calls.withLock { $0 += 1 }
@@ -522,7 +522,7 @@ struct EnglishWordOracleTests {
     // `mayLower` short-circuits at `isRecognizedName`, so the test above proves
     // only that ONE refusal is safe. If a later refactor reorders those checks,
     // the other two refusals become load-bearing. Assert each in isolation.
-    let permissive = EnglishWordOracle(
+    let permissive = SeamCasingOracle(
       unavailableReason: nil,
       dictionaryVerdict: { _ in .ordinary },
       isLearnedWord: { _ in false },

--- a/Tests/EnviousWisprTests/PostProcessing/SeamCasingOracleTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SeamCasingOracleTests.swift
@@ -25,16 +25,30 @@ struct SeamCasingOracleTests {
 
   /// An oracle with fixed answers. `isName` defaults to false so a case that is
   /// not about the name recogniser cannot fail because of it.
+  /// Read the runtime's state for an ASSERTION, without stranding a lease.
+  ///
+  /// `snapshot(for:)` leases when it answers ready, and the drain will not begin
+  /// preparing any language while a lease is outstanding. A test that asserts
+  /// availability and walks away would therefore wedge preparation for the rest
+  /// of the run — quietly, because every later language just reports warming.
+  static func probe(_ base: String = "en") -> SeamCasingOracle {
+    let oracle = SeamCasingOracleRuntime.snapshot(for: base)
+    if oracle.isAvailable { SeamCasingOracleRuntime.releaseDecisionLease() }
+    return oracle
+  }
+
   static func oracle(
     ordinary: Set<String> = [],
     learned: Set<String> = [],
-    isName: Bool = false
+    isName: Bool = false,
+    isNoun: Bool = false
   ) -> SeamCasingOracle {
     SeamCasingOracle(
       unavailableReason: nil,
       dictionaryVerdict: { ordinary.contains($0) ? .ordinary : .notOrdinary },
       isLearnedWord: { learned.contains($0) },
-      isRecognizedName: { _, _ in isName })
+      isRecognizedName: { _, _ in isName },
+      isNoun: { _ in isNoun })
   }
 
   /// A `@Sendable`-safe flag, because the oracle's closures are `@Sendable` and
@@ -108,7 +122,8 @@ struct SeamCasingOracleTests {
         return .ordinary
       },
       isLearnedWord: { _ in false },
-      isRecognizedName: { _, _ in true })
+      isRecognizedName: { _, _ in true },
+      isNoun: { _ in false })
 
     #expect(
       oracle.mayLower(word: "Mark", left: "speak with ", payload: "Mark today.") == .recognizedName)
@@ -173,33 +188,51 @@ struct SeamCasingOracleTests {
     #expect(decision == reason)
   }
 
-  // MARK: - English selection
+  // MARK: - Dictionary selection
 
-  @Test("English is chosen deterministically from what is actually installed")
-  func resolvesEnglishDeterministically() {
+  @Test("A language is chosen deterministically from what is actually installed")
+  func resolvesLanguageDeterministically() {
     // Never the raw dictation language, the checker's selected language, or nil.
     // Measured: an unrecognised identifier makes `checkSpelling` report EVERY
     // word correctly spelled — it fails OPEN. Choosing from `availableLanguages`
     // makes that unreachable rather than merely detected.
     let installed = ["fr", "en_GB", "de", "en", "en_AU"]
-    #expect(SeamCasingOracleRuntime.resolveEnglishLanguage(from: installed) == "en")
+    #expect(SeamCasingOracleRuntime.resolveLanguage("en", from: installed) == "en")
   }
 
-  @Test("A machine with no English dictionary yields no identifier")
-  func noEnglishYieldsNil() {
-    #expect(SeamCasingOracleRuntime.resolveEnglishLanguage(from: ["fr", "de", "ja"]) == nil)
+  @Test("A machine with no dictionary for the asked language yields no identifier")
+  func missingLanguageYieldsNil() {
+    #expect(SeamCasingOracleRuntime.resolveLanguage("en", from: ["fr", "de", "ja"]) == nil)
   }
 
-  @Test("A regional English is accepted when plain English is absent")
-  func regionalEnglishAccepted() {
-    #expect(SeamCasingOracleRuntime.resolveEnglishLanguage(from: ["de", "en_GB"]) == "en_GB")
+  @Test("A regional variant is accepted when the plain code is absent")
+  func regionalVariantAccepted() {
+    #expect(SeamCasingOracleRuntime.resolveLanguage("en", from: ["de", "en_GB"]) == "en_GB")
   }
 
   @Test("Language matching is on the base code, not a prefix of the string")
   func baseCodeNotPrefix() {
     // `eng` and `enm` start with "en" but are not English identifiers we want to
     // silently accept; matching must split on the separator.
-    #expect(SeamCasingOracleRuntime.resolveEnglishLanguage(from: ["eng", "enm"]) == nil)
+    #expect(SeamCasingOracleRuntime.resolveLanguage("en", from: ["eng", "enm"]) == nil)
+  }
+
+  @Test(
+    "#1922 Selection is per-language, so no language can be served another's dictionary",
+    arguments: [
+      // asked, installed, expected
+      ("de", ["en", "de_DE", "fr"], "de_DE"),
+      ("sv", ["en", "sv", "nb"], "sv"),
+      ("tr", ["en", "de", "fr"], String?.none),
+      ("nl", ["nl_BE"], "nl_BE"),
+      // The trap this exists for: asking for Danish must never be answered by
+      // German because both were once hard-coded to whatever "the" dictionary
+      // was. A wrong dictionary does not fail loudly — it silently calls the
+      // user's words unknown and keeps every capital.
+      ("da", ["de", "en"], String?.none),
+    ])
+  func selectionIsPerLanguage(_ asked: String, _ installed: [String], _ expected: String?) {
+    #expect(SeamCasingOracleRuntime.resolveLanguage(asked, from: installed) == expected)
   }
 
   // MARK: - The spell service failing OPEN
@@ -266,7 +299,8 @@ struct SeamCasingOracleTests {
       isRecognizedName: { left, _ in
         seenLeft.record(left)
         return false
-      })
+      },
+      isNoun: { _ in false })
 
     _ = CursorInsertionRepair.repair(
       text: "Mark said he would be late.",
@@ -292,7 +326,7 @@ struct SeamCasingOracleTests {
     // suite only; Swift Testing runs suites concurrently.
     await withSeamCasingOracleExclusion {
       SeamCasingOracleRuntime.resetForTesting()
-      let snapshot = SeamCasingOracleRuntime.snapshot()
+      let snapshot = Self.probe()
       #expect(snapshot.isAvailable == false)
       #expect(snapshot.unavailableReason == .oracleWarming)
     }
@@ -308,11 +342,16 @@ struct SeamCasingOracleTests {
       // capital — today's behaviour — rather than paying the measured 105.6 ms of
       // one-time setup on the paste path.
       SeamCasingOracleRuntime.resetForTesting()
+      // Leased and released exactly as the repair does it, rather than probed:
+      // this case stands in for the product call, so it should take the same
+      // route through the runtime that the product call takes.
+      let live = SeamCasingOracleRuntime.snapshot(for: "en")
+      defer { SeamCasingOracleRuntime.releaseDecisionLease() }
       let payloads = CursorInsertionRepair.repair(
         text: "Go home.",
         context: CursorInsertionRepair.CaretText(left: "I can't wait to", right: ""),
         protectedWords: [],
-        oracle: SeamCasingOracleRuntime.snapshot())
+        oracle: live)
 
       #expect(payloads.candidateRules.contains(.caseSkipped(.oracleWarming)))
       #expect(payloads.repairedText?.contains("Go home.") == true, "capital kept")
@@ -332,11 +371,11 @@ struct SeamCasingOracleTests {
       // waited on twice.
       SeamCasingOracleRuntime.resetForTesting()
       SeamCasingOracleRuntime.installForTesting(Self.oracle(ordinary: ["go"]))
-      #expect(SeamCasingOracleRuntime.snapshot().isAvailable)
+      #expect(Self.probe().isAvailable)
 
       SeamCasingOracleRuntime.disableAfterTimeout()
 
-      let after = SeamCasingOracleRuntime.snapshot()
+      let after = Self.probe()
       #expect(after.isAvailable == false)
       #expect(after.unavailableReason == .oracleTimedOut)
       #expect(
@@ -364,7 +403,7 @@ struct SeamCasingOracleTests {
       await SeamCasingOracleRuntime.prewarm()
 
       #expect(
-        SeamCasingOracleRuntime.snapshot().unavailableReason == .oracleTimedOut,
+        Self.probe().unavailableReason == .oracleTimedOut,
         "a prewarm must never overwrite state established after it began")
     }
   }
@@ -383,7 +422,7 @@ struct SeamCasingOracleTests {
       // idempotence guard rather than an accident of ordering.
       await SeamCasingOracleRuntime.prewarm()
 
-      #expect(SeamCasingOracleRuntime.snapshot().unavailableReason == .oracleTimedOut)
+      #expect(Self.probe().unavailableReason == .oracleTimedOut)
     }
   }
 
@@ -402,7 +441,8 @@ struct SeamCasingOracleTests {
         return .ordinary
       },
       isLearnedWord: { _ in false },
-      isRecognizedName: { _, _ in false })
+      isRecognizedName: { _, _ in false },
+      isNoun: { _ in false })
 
     let payloads = CursorInsertionRepair.repair(
       text: "Olive sent the files.",
@@ -415,8 +455,18 @@ struct SeamCasingOracleTests {
       consulted.wasConsulted == false, "the oracle must never be asked about a protected spelling")
   }
 
-  @Test("Non-English dictation never reaches the oracle at all")
-  func nonEnglishNeverConsultsOracle() {
+  @Test("A language with no casing policy never reaches the oracle at all")
+  func unsupportedLanguageNeverConsultsOracle() {
+    // Polish, not German. This case used to dictate German on the reasoning that
+    // "an English dictionary must never judge German" — but the dictionary was
+    // never English, it was whichever language the runtime prepared, and #1922
+    // gives German its own. Left as it was, the case would have frozen the exact
+    // behaviour the change removes.
+    //
+    // What it actually guards is unchanged and still worth guarding: a language
+    // absent from the policy table must not reach word knowledge at all, so the
+    // 23 unsupported European languages cannot be judged by a neighbour's
+    // dictionary.
     let consulted = ConsultationSpy()
     let spy = SeamCasingOracle(
       unavailableReason: nil,
@@ -425,15 +475,56 @@ struct SeamCasingOracleTests {
         return .ordinary
       },
       isLearnedWord: { _ in false },
-      isRecognizedName: { _, _ in false })
+      isRecognizedName: { _, _ in false },
+      isNoun: { _ in false })
 
     let payloads = CursorInsertionRepair.repair(
-      text: "Haus ist gross.",
-      context: CursorInsertionRepair.CaretText(left: "Ich gehe zum ", right: ""),
-      protectedWords: [], language: "de", oracle: spy)
+      text: "Dziekuje bardzo za to.",
+      context: CursorInsertionRepair.CaretText(left: "Chcialem powiedziec ze ", right: ""),
+      protectedWords: [], language: "pl", oracle: spy)
 
     #expect(payloads.candidateRules.contains(.caseSkipped(.languageNotSupported)))
-    #expect(consulted.wasConsulted == false, "an English dictionary must never judge German")
+    #expect(
+      consulted.wasConsulted == false,
+      "a language we did not measure must never be judged by another language's dictionary")
+  }
+
+  @Test("German DOES reach the oracle, and the noun veto is what decides")
+  func germanReachesOracleAndVetoDecides() {
+    // The positive control for the case above. Without it, deleting German from
+    // the policy table would leave every assertion in this suite green while
+    // silently reverting the language.
+    let consulted = ConsultationSpy()
+    let noun = SeamCasingOracle(
+      unavailableReason: nil,
+      dictionaryVerdict: { _ in
+        consulted.record()
+        return .ordinary
+      },
+      isLearnedWord: { _ in false },
+      isRecognizedName: { _, _ in false },
+      isNoun: { _ in true })
+
+    let kept = CursorInsertionRepair.repair(
+      text: "Haus ist gross.",
+      context: CursorInsertionRepair.CaretText(left: "Ich gehe zum ", right: ""),
+      protectedWords: [], language: "de", oracle: noun)
+
+    #expect(consulted.wasConsulted, "German must consult its own word knowledge")
+    #expect(
+      kept.candidateRules.contains(.caseSkipped(.nounInNounCapitalisingLanguage)),
+      "and a tagged noun must keep its capital by VETO")
+    #expect(kept.repairedText == "Haus ist gross. ")
+
+    // Same input, same policy, only the tagger's answer flipped. A veto that
+    // refused everything would pass the assertions above and disable the feature.
+    let lowered = CursorInsertionRepair.repair(
+      text: "Haus ist gross.",
+      context: CursorInsertionRepair.CaretText(left: "Ich gehe zum ", right: ""),
+      protectedWords: [], language: "de",
+      oracle: Self.oracle(ordinary: ["haus"], isNoun: false))
+
+    #expect(lowered.repairedText == "haus ist gross. ", "and a non-noun must lower")
   }
 
   @Test("The founder's reported case: a determiner continuation is lowered")
@@ -469,6 +560,10 @@ struct SeamCasingOracleTests {
       isRecognizedName: { _, _ in
         calls.withLock { $0 += 1 }
         return false
+      },
+      isNoun: { _ in
+        calls.withLock { $0 += 1 }
+        return false
       })
 
     let wrapped = underlying.authorized(by: { true })
@@ -478,6 +573,15 @@ struct SeamCasingOracleTests {
     #expect(
       calls.withLock { $0 } == 3,
       "and all three closures must reach it, or the wrapper is silently deciding")
+
+    // THREE, not four: `isNoun` is deliberately outside `mayLower` — it is a veto
+    // the repair applies after `mayLower` has already authorised lowering, so a
+    // count of four here would mean the veto had leaked into the decision. It
+    // still has to survive the wrapper, which the fourth call proves separately.
+    _ = wrapped.isNoun("Haus ist gross.")
+    #expect(
+      calls.withLock { $0 } == 4,
+      "and the veto must reach it too when asked directly")
   }
 
   @Test("#1921 A refused wrapper calls NOTHING underneath and keeps the capital")
@@ -504,10 +608,17 @@ struct SeamCasingOracleTests {
       isRecognizedName: { _, _ in
         calls.withLock { $0 += 1 }
         return false
+      },
+      isNoun: { _ in
+        calls.withLock { $0 += 1 }
+        return false
       })
 
     let wrapped = underlying.authorized(by: { false })
     let skip = wrapped.mayLower(word: "The", left: "I went to ", payload: "The museum.")
+    // The veto is asked separately by the repair, so a refusal that covered only
+    // `mayLower` would still let a post-deadline call reach the tagger.
+    let noun = wrapped.isNoun("Haus ist gross.")
 
     #expect(
       calls.withLock { $0 } == 0,
@@ -515,6 +626,9 @@ struct SeamCasingOracleTests {
     #expect(
       skip != nil,
       "and it must refuse to lower, because every refusal keeps the capital")
+    #expect(
+      noun,
+      "and a refused veto must read as NOUN, which is the direction that keeps the capital")
   }
 
   @Test("#1921 Refusal is safe on each closure independently, not just the first")
@@ -526,7 +640,8 @@ struct SeamCasingOracleTests {
       unavailableReason: nil,
       dictionaryVerdict: { _ in .ordinary },
       isLearnedWord: { _ in false },
-      isRecognizedName: { _, _ in false })
+      isRecognizedName: { _, _ in false },
+      isNoun: { _ in false })
     let refused = permissive.authorized(by: { false })
 
     #expect(
@@ -538,5 +653,8 @@ struct SeamCasingOracleTests {
     #expect(
       refused.dictionaryVerdict("the") == .unavailable(.oracleTimedOut),
       "and the dictionary must report the real cause, not a bland 'not ordinary'")
+    #expect(
+      refused.isNoun("Haus ist gross."),
+      "and refusing the veto must read as NOUN, which keeps the capital")
   }
 }

--- a/Tests/EnviousWisprTests/PostProcessing/SeamCasingPolicyTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SeamCasingPolicyTests.swift
@@ -1,0 +1,428 @@
+import Testing
+
+@testable import EnviousWisprPostProcessing
+
+// #1922: the eleven-language policy table, the German noun veto, the polite-form
+// guards, and locale-aware lowering.
+//
+// Everything here is a pure function of an injected oracle, so no case touches a
+// system dictionary or a part-of-speech tagger. What macOS can actually SERVE is
+// a separate question owned by `SeamCasingOracleTests` and the runtime's
+// capability profiles; conflating the two is how #1803's rejected design got its
+// availability answer from a language code.
+@Suite("Seam casing policy (#1922)")
+struct SeamCasingPolicyTests {
+
+  // MARK: - Fixtures
+
+  /// Permits lowering anything, so a kept capital is always attributable to a
+  /// policy rule rather than to the oracle declining.
+  static func permissive(isNoun: Bool = false) -> SeamCasingOracle {
+    SeamCasingOracle(
+      unavailableReason: nil,
+      dictionaryVerdict: { _ in .ordinary },
+      isLearnedWord: { _ in false },
+      isRecognizedName: { _, _ in false },
+      isNoun: { _ in isNoun })
+  }
+
+  static func caret(_ left: String) -> CursorInsertionRepair.CaretText {
+    CursorInsertionRepair.CaretText(
+      left: left, right: "", leftReachesDocumentStart: true, isScreenDerived: false)
+  }
+
+  static func repaired(
+    _ text: String,
+    language: String?,
+    left: String = "I was saying that ",
+    protectedWords: Set<String> = [],
+    oracle: SeamCasingOracle? = nil
+  ) -> CursorInsertionRepair.PreparedPayloads {
+    CursorInsertionRepair.repair(
+      text: text,
+      context: caret(left),
+      protectedWords: protectedWords,
+      language: language,
+      oracle: oracle ?? permissive())
+  }
+
+  static func reasons(_ payloads: CursorInsertionRepair.PreparedPayloads) -> [String] {
+    payloads.candidateRules.map(\.telemetryName)
+  }
+
+  // MARK: - The policy table
+
+  @Test(
+    "#1922 Every shipped policy resolves, and only the shipped ones do",
+    arguments: [
+      // The twelve that act. English was already here; the other eleven are the
+      // change. Each row states the SHAPE it must resolve to, so a copy-paste
+      // slip that gave, say, Turkish the German policy fails here rather than in
+      // a Live UAT case nobody ran.
+      ("en", true, false, 0),
+      ("fr", true, false, 0),
+      ("it", true, false, 0),
+      ("ru", true, false, 0),
+      ("nl", true, false, 0),
+      ("es", true, false, 0),
+      ("pt", true, false, 0),
+      ("da", true, false, 0),
+      ("fi", true, false, 0),
+      ("tr", true, false, 0),
+      ("de", true, true, 8),
+      ("sv", true, false, 4),
+      // The controls. Polish is the thirteenth European language by usage and is
+      // deliberately absent; the rest stand for the 23 that must keep abstaining.
+      ("pl", false, false, 0),
+      ("cs", false, false, 0),
+      ("hu", false, false, 0),
+      ("el", false, false, 0),
+      ("uk", false, false, 0),
+    ])
+  func policyTableResolves(
+    _ code: String, _ hasPolicy: Bool, _ nounVeto: Bool, _ politeCount: Int
+  ) {
+    let rules = CursorInsertionRepair.LanguageRules.forLanguage(code)
+    #expect(
+      (rules.casingPolicy != nil) == hasPolicy,
+      "\(code): policy presence")
+    #expect(rules.casingPolicy?.nounVeto == (hasPolicy ? nounVeto : nil), "\(code): noun veto")
+    #expect(
+      (rules.casingPolicy?.politeForms.count ?? 0) == politeCount,
+      "\(code): polite form count")
+    #expect(rules.baseCode == code, "\(code): base code must be carried for locale lowering")
+  }
+
+  @Test(
+    "#1922 A tag that normalises still reaches the right policy, and carries the NORMALISED base",
+    arguments: [
+      // `de_AT` and `de-DE` are the same grammar. Without normalisation each
+      // spelling would be its own miss, and the language would silently abstain
+      // on exactly the machines that set a region.
+      ("de", "de", true),
+      ("de-DE", "de", true),
+      ("de_AT", "de", true),
+      ("de-CH", "de", true),
+      ("nl_BE", "nl", true),
+      ("pt-BR", "pt", true),
+      // `nb` is the case that makes the SECOND assertion worth having: Norwegian
+      // Bokmål normalises to `no`, so `baseCode` is not simply the code passed
+      // in. It still has no policy, which is the answer either way — but the
+      // locale used for lowering is `no`, and a reader who assumed otherwise
+      // would be wrong about which locale a future Norwegian entry would get.
+      ("nb", "no", false),
+    ])
+  func normalisedTagsResolveToBasePolicy(
+    _ raw: String, _ expectedBase: String, _ hasPolicy: Bool
+  ) {
+    let rules = CursorInsertionRepair.LanguageRules.forLanguage(raw)
+    #expect(rules.baseCode == expectedBase, "\(raw) must normalise to \(expectedBase)")
+    #expect((rules.casingPolicy != nil) == hasPolicy, "\(raw): policy presence after normalising")
+  }
+
+  @Test("#1922 An unknown or absent language abstains rather than guessing")
+  func unknownLanguageAbstains() {
+    #expect(CursorInsertionRepair.LanguageRules.forLanguage(nil).casingPolicy == nil)
+    #expect(CursorInsertionRepair.LanguageRules.forLanguage(nil).baseCode == nil)
+    #expect(CursorInsertionRepair.LanguageRules.forLanguage("zz").casingPolicy == nil)
+  }
+
+  // MARK: - English is frozen
+
+  @Test(
+    "#1922 English output is byte-identical to the shipped behaviour",
+    arguments: [
+      // The cross-persona guarantee. English shipped this rule in #1803 and
+      // 100k users depend on it; the eleven new languages are worth nothing if
+      // they cost a regression here.
+      //
+      // Each row is payload / expected repaired text / expected reason, taken
+      // from the rules English already had, not from a run of the new code.
+      ("The museum tonight.", "the museum tonight. ", "lowercased_first"),
+      ("And then we left.", "and then we left. ", "lowercased_first"),
+      // English-only guards must still be English-only AND still fire here.
+      ("I went home.", "I went home. ", "case_skipped:pronoun_i"),
+      ("Monday works for me.", "Monday works for me. ", "case_skipped:always_capitalized"),
+      ("USA is far.", "USA is far. ", "case_skipped:mixed_case_or_acronym"),
+      ("X5 arrives today.", "X5 arrives today. ", "case_skipped:contains_digit"),
+    ])
+  func englishIsFrozen(_ payload: String, _ expected: String, _ reason: String) {
+    let out = Self.repaired(payload, language: "en")
+    #expect(out.repairedText == expected, "English output must not move")
+    #expect(Self.reasons(out).contains(reason), "and for the same stated reason")
+  }
+
+  @Test("#1922 The English-only guards do NOT leak into another language")
+  func englishGuardsDoNotLeak() {
+    // `isFirstPersonPronoun` is `["I", "I'm", …]` and `alwaysCapitalized` is the
+    // English weekday and month set. Both were language-blind before this change,
+    // which was harmless only while English was the only casing language.
+    //
+    // Dutch `Ik` is the first-person pronoun and is ordinarily LOWERCASE
+    // mid-sentence, so leaking the English rule would keep a capital Dutch never
+    // wanted. German `Mai` is a month and IS capitalised — but by the noun rule,
+    // which is German's own, not by an English table.
+    let dutch = Self.repaired("Ik ga naar huis.", language: "nl", left: "Ik zei dat ")
+    #expect(dutch.repairedText == "ik ga naar huis. ", "Dutch `Ik` is not the English `I`")
+    #expect(Self.reasons(dutch).contains("case_skipped:pronoun_i") == false)
+
+    let german = Self.repaired(
+      "Monday ist ein Tag.", language: "de", left: "Ich sagte dass ",
+      oracle: Self.permissive(isNoun: false))
+    #expect(
+      Self.reasons(german).contains("case_skipped:always_capitalized") == false,
+      "the English weekday table must not decide anything in German")
+  }
+
+  // MARK: - The German noun veto
+
+  @Test("#1922 A German noun keeps its capital by veto")
+  func germanNounIsVetoed() {
+    let out = Self.repaired(
+      "Brot ist teuer.", language: "de", left: "Ich sagte dass das ",
+      oracle: Self.permissive(isNoun: true))
+
+    #expect(out.repairedText == "Brot ist teuer. ")
+    #expect(Self.reasons(out).contains("case_skipped:noun_in_noun_capitalising_language"))
+  }
+
+  @Test("#1922 A German non-noun lowers — the veto is not a blanket refusal")
+  func germanNonNounLowers() {
+    // The two-way control. A veto answering "noun" to everything would satisfy
+    // every keep-the-capital assertion in this file while disabling German
+    // entirely, and no test above would notice.
+    let out = Self.repaired(
+      "Gestern war es besser.", language: "de", left: "Ich sagte dass ",
+      oracle: Self.permissive(isNoun: false))
+
+    #expect(out.repairedText == "gestern war es besser. ")
+    #expect(Self.reasons(out).contains("lowercased_first"))
+  }
+
+  @Test("#1922 The veto is absent in French and Italian even when the tagger says noun")
+  func vetoDoesNotLeakToRomanceLanguages() {
+    // Measured on held-out text: applying the veto to French and Italian costs a
+    // third of the recall for one point of precision, because those languages
+    // lowercase their common nouns. The tagger is deliberately not consulted, so
+    // an oracle screaming "noun" must change nothing.
+    for language in ["fr", "it", "es", "pt", "sv", "nl", "da", "fi", "tr", "ru", "en"] {
+      let out = Self.repaired(
+        "Merci beaucoup vraiment.", language: language, left: "Je voulais dire que ",
+        oracle: Self.permissive(isNoun: true))
+      #expect(
+        out.repairedText == "merci beaucoup vraiment. ",
+        "\(language) must lower regardless of the tagger")
+      #expect(
+        Self.reasons(out).contains("case_skipped:noun_in_noun_capitalising_language") == false,
+        "\(language) must never reach the veto at all")
+    }
+  }
+
+  // MARK: - Polite forms
+
+  @Test(
+    "#1922 A polite form keeps its capital, because the capital IS the meaning",
+    arguments: [
+      // German `Sie` is the polite you; `sie` is "she". No dictionary can see the
+      // difference, because both spellings are ordinary words — which is exactly
+      // why this guard runs before the oracle.
+      ("Sie haben recht.", "de", "Sie haben recht. "),
+      ("Ihnen gehört das.", "de", "Ihnen gehört das. "),
+      ("Ihre Nachricht kam an.", "de", "Ihre Nachricht kam an. "),
+      // Swedish `Ni`, the same shape without a noun rule.
+      ("Ni har rätt.", "sv", "Ni har rätt. "),
+      ("Er bok ligger där.", "sv", "Er bok ligger där. "),
+    ])
+  func politeFormsKeepTheirCapital(_ payload: String, _ language: String, _ expected: String) {
+    let out = Self.repaired(payload, language: language, left: "Ich sagte dass ")
+    #expect(out.repairedText == expected)
+    #expect(Self.reasons(out).contains("case_skipped:polite_form"))
+  }
+
+  @Test("#1922 A polite set belongs to ONE language and does not travel")
+  func politeSetsAreLanguageScoped() {
+    // Swedish `Er` is a polite possessive; German `er` is "he" and is ordinary.
+    // If the sets were merged, or if a lookup fell back to another language's,
+    // German would keep a capital on an everyday pronoun.
+    let german = Self.repaired(
+      "Er kommt später.", language: "de", left: "Ich sagte dass ",
+      oracle: Self.permissive(isNoun: false))
+    #expect(german.repairedText == "er kommt später. ", "German `er` is not Swedish `Er`")
+    #expect(Self.reasons(german).contains("case_skipped:polite_form") == false)
+
+    // And a language with no polite set at all must not acquire one.
+    let french = Self.repaired("Sie est un mot.", language: "fr", left: "Je disais que ")
+    #expect(Self.reasons(french).contains("case_skipped:polite_form") == false)
+  }
+
+  @Test("#1922 Italian and Russian have NO polite set, and that was measured")
+  func italianAndRussianHaveNoPoliteSet() {
+    // Both were tried and reverted: the candidate lists contained ordinary
+    // articles and possessives (`la`, `le`, `suo`, `sua`, `вы`), and each made
+    // its language measurably WORSE. Frozen so the idea is not re-added on the
+    // reasoning that "German and Swedish have one, so these should too".
+    #expect(CursorInsertionRepair.LanguageRules.forLanguage("it").casingPolicy?.politeForms == [])
+    #expect(CursorInsertionRepair.LanguageRules.forLanguage("ru").casingPolicy?.politeForms == [])
+  }
+
+  // MARK: - Locale-aware lowering
+
+  @Test(
+    "#1922 The leading unit lowers in the language's own locale",
+    arguments: [
+      // Turkish is the case that makes a locale mandatory rather than tidy:
+      // dotted and dotless `I` are DIFFERENT LETTERS, and an invariant lowercase
+      // maps both to `i`, silently misspelling one of them.
+      ("Istanbul dır.", "tr", "ıstanbul dır. "),
+      ("İyi günler.", "tr", "iyi günler. "),
+      // German `ß` has no uppercase form in the leading position we touch; the
+      // point is that lowering the first character must not disturb the rest.
+      ("Straße ist voll.", "de", "straße ist voll. "),
+      // And an ordinary Latin language must be unaffected by the locale work.
+      ("Merci beaucoup.", "fr", "merci beaucoup. "),
+    ])
+  func loweringUsesTheLanguageLocale(_ payload: String, _ language: String, _ expected: String) {
+    let out = Self.repaired(
+      payload, language: language, left: "Ben dedim ki ",
+      oracle: Self.permissive(isNoun: false))
+    #expect(out.repairedText == expected)
+  }
+
+  @Test("#1922 Turkish lowering is NOT the invariant lowering")
+  func turkishDiffersFromInvariant() {
+    // The control that makes the row above mean something: if the locale were
+    // ignored, `Istanbul` would come out `istanbul` and the assertion would still
+    // look plausible to a reader who does not speak Turkish.
+    #expect(
+      CursorInsertionRepair.loweringLeadingUnit(of: "Istanbul", languageCode: "tr") == "ıstanbul")
+    #expect(
+      CursorInsertionRepair.loweringLeadingUnit(of: "Istanbul", languageCode: "en") == "istanbul")
+    #expect(
+      CursorInsertionRepair.loweringLeadingUnit(of: "İyi", languageCode: "tr") == "iyi")
+  }
+
+  // MARK: - Dutch IJ: both halves, because either alone is inert
+
+  @Test("#1922 Dutch `IJ` is one casing unit and both characters lower together")
+  func dutchDigraphLowersBothCharacters() {
+    // TWO changes are required and each is inert without the other: the acronym
+    // guard refused every `IJ`-initial word four checks before the lowering code
+    // could run, so rev 2's "add a locale" fix would have done nothing at all.
+    // Verified against the shipped guard, not reasoned about
+    // (`2026-08-05-dutch-guard-probe.swift`).
+    let out = Self.repaired("IJs is lekker.", language: "nl", left: "Ik zei dat ")
+    #expect(out.repairedText == "ijs is lekker. ", "both characters, or the word is misspelled")
+    #expect(Self.reasons(out).contains("lowercased_first"))
+  }
+
+  @Test("#1922 An ordinary Dutch word is unaffected by the digraph exemption")
+  func dutchOrdinaryWordUnaffected() {
+    let out = Self.repaired("Ik ga nu weg.", language: "nl", left: "Ik zei dat ")
+    #expect(out.repairedText == "ik ga nu weg. ")
+  }
+
+  @Test("#1922 A Dutch acronym still refuses, and so does one that opens with IJ")
+  func dutchAcronymsStillRefuse() {
+    // `USA` proves ordinary acronym protection survives the exemption. It does
+    // NOT prove the exemption is narrow, because its second character is not the
+    // exempted position — so `IJUSA` is the case that carries that claim, and
+    // grounded review r2 was right that its absence left a hole.
+    let usa = Self.repaired("USA is ver weg.", language: "nl", left: "Ik zei dat ")
+    #expect(usa.repairedText == "USA is ver weg. ")
+    #expect(Self.reasons(usa).contains("case_skipped:mixed_case_or_acronym"))
+
+    let ijusa = Self.repaired("IJUSA is iets.", language: "nl", left: "Ik zei dat ")
+    #expect(ijusa.repairedText == "IJUSA is iets. ", "only the second J is forgiven")
+    #expect(Self.reasons(ijusa).contains("case_skipped:mixed_case_or_acronym"))
+  }
+
+  @Test("#1922 The digraph exemption is Dutch-only")
+  func digraphExemptionIsDutchOnly() {
+    // Widening it to every language would forgive English `IT`, `IP`, `ID`.
+    for language in ["en", "de", "fr", "sv"] {
+      let out = Self.repaired("IJssel is ver.", language: language, left: "I said that ")
+      #expect(
+        Self.reasons(out).contains("case_skipped:mixed_case_or_acronym"),
+        "\(language) must still read `IJ` as an acronym")
+    }
+    #expect(CursorInsertionRepair.isDutchIJDigraph("IJs", "nl"))
+    #expect(CursorInsertionRepair.isDutchIJDigraph("IJs", "en") == false)
+    #expect(CursorInsertionRepair.isDutchIJDigraph("IJUSA", "nl") == false)
+    #expect(CursorInsertionRepair.isDutchIJDigraph("Ik", "nl") == false)
+  }
+
+  // MARK: - Priority: the user's own signals outrank every new one
+
+  @Test("#1922 A protected word beats the new policies in every language")
+  func protectedWordOutranksPolicy() {
+    // Custom Words is the user's explicit instruction and the strongest signal
+    // there is. A new language must not quietly overrule it — and unlike the
+    // rules above, this one is per-user, so a regression here is invisible to
+    // every corpus measurement.
+    for language in ["en", "de", "sv", "nl", "tr", "fr"] {
+      let out = Self.repaired(
+        "Olive stuurde het bestand.", language: language, left: "Ik hoorde dat ",
+        protectedWords: ["Olive"])
+      #expect(
+        out.repairedText == "Olive stuurde het bestand. ",
+        "\(language): a protected spelling must survive")
+      #expect(
+        Self.reasons(out).contains("case_skipped:protected_word"),
+        "\(language): and for the protected-word reason specifically")
+    }
+  }
+
+  @Test("#1922 A learned word beats the new policies in every language")
+  func learnedWordOutranksPolicy() {
+    let learned = SeamCasingOracle(
+      unavailableReason: nil,
+      dictionaryVerdict: { _ in .ordinary },
+      isLearnedWord: { _ in true },
+      isRecognizedName: { _, _ in false },
+      isNoun: { _ in false })
+
+    for language in ["en", "de", "sv", "nl", "tr", "fr"] {
+      let out = Self.repaired(
+        "Vercel deployt nu.", language: language, left: "Ik zei dat ", oracle: learned)
+      #expect(
+        Self.reasons(out).contains("case_skipped:learned_word"),
+        "\(language): what the user taught macOS must outrank a language rule")
+    }
+  }
+
+  @Test("#1922 An unavailable oracle keeps the capital in every policy language")
+  func unavailableOracleKeepsCapitalEverywhere() {
+    // The safety floor for the whole change: if word knowledge is missing for a
+    // language, that language must behave exactly as the app did before this
+    // feature existed. A policy entry alone must never be able to lower anything.
+    for language in ["en", "de", "sv", "nl", "tr", "fr", "ru", "fi", "da", "es", "pt", "it"] {
+      let out = Self.repaired(
+        "Store is closed.", language: language, left: "I went past and the ",
+        oracle: .unavailable(.dictionaryUnavailable))
+      #expect(
+        out.repairedText == "Store is closed. ",
+        "\(language): no dictionary means no lowering")
+      #expect(Self.reasons(out).contains("case_skipped:dictionary_unavailable"))
+    }
+  }
+
+  // MARK: - The new reasons reach telemetry
+
+  @Test("#1922 Both new skip reasons carry a stable telemetry name")
+  func newReasonsHaveTelemetryNames() {
+    // These two VALUES are the whole of the change's telemetry: they ride the
+    // existing `paste.completed.repair_rules`, so no field or plumbing changes.
+    // A renamed value would silently break the version floor recorded at ship.
+    #expect(
+      CursorInsertionRepair.CaseSkipReason.nounInNounCapitalisingLanguage.rawValue
+        == "noun_in_noun_capitalising_language")
+    #expect(CursorInsertionRepair.CaseSkipReason.politeForm.rawValue == "polite_form")
+    #expect(
+      CursorInsertionRepair.AppliedRule
+        .caseSkipped(.nounInNounCapitalisingLanguage).telemetryName
+        == "case_skipped:noun_in_noun_capitalising_language")
+    #expect(
+      CursorInsertionRepair.AppliedRule.caseSkipped(.politeForm).telemetryName
+        == "case_skipped:polite_form")
+  }
+}

--- a/Tests/EnviousWisprTests/PostProcessing/SeamCasingPolicyTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SeamCasingPolicyTests.swift
@@ -2,8 +2,8 @@ import Testing
 
 @testable import EnviousWisprPostProcessing
 
-// #1922: the eleven-language policy table, the German noun veto, the polite-form
-// guards, and locale-aware lowering.
+// #1922: the TWELVE-language policy table — English plus the eleven this issue
+// added — the German noun veto, the polite-form guards, and locale-aware lowering.
 //
 // Everything here is a pure function of an injected oracle, so no case touches a
 // system dictionary or a part-of-speech tagger. What macOS can actually SERVE is
@@ -132,9 +132,9 @@ struct SeamCasingPolicyTests {
   @Test(
     "#1922 English output is byte-identical to the shipped behaviour",
     arguments: [
-      // The cross-persona guarantee. English shipped this rule in #1803 and
-      // 100k users depend on it; the eleven new languages are worth nothing if
-      // they cost a regression here.
+      // The cross-persona guarantee. English shipped this rule in #1803 and is
+      // the language most of our users dictate in; the eleven new languages are
+      // worth nothing if they cost a regression here.
       //
       // Each row is payload / expected repaired text / expected reason, taken
       // from the rules English already had, not from a run of the new code.

--- a/Tests/EnviousWisprTests/PostProcessing/SeamCasingPolicyTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SeamCasingPolicyTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import os
 
 @testable import EnviousWisprPostProcessing
 
@@ -286,6 +287,50 @@ struct SeamCasingPolicyTests {
       payload, language: language, left: "Ben dedim ki ",
       oracle: Self.permissive(isNoun: false))
     #expect(out.repairedText == expected)
+  }
+
+  @Test("#1922 The DICTIONARY is asked about the locale-correct lowercase form")
+  func dictionaryQueryUsesTheLanguageLocale() {
+    // Whole-diff review, P2. Two places lowercase and both must agree: the text
+    // we WRITE and the word we ASK ABOUT. The query used the root locale, so
+    // Turkish `Işık` was looked up as `işık` rather than `ışık` — the real
+    // Turkish dictionary rejects that, so an ordinary word kept its capital.
+    //
+    // It fails SAFE, which is precisely why nothing caught it: it costs recall
+    // and never damages text. This asserts the word the oracle actually received.
+    let asked = OSAllocatedUnfairLock(initialState: [String]())
+    let recorder = SeamCasingOracle(
+      unavailableReason: nil,
+      dictionaryVerdict: { word in
+        asked.withLock { $0.append(word) }
+        return .ordinary
+      },
+      isLearnedWord: { _ in false },
+      isRecognizedName: { _, _ in false },
+      isNoun: { _ in false })
+
+    _ = Self.repaired(
+      "Işık çok güzel.", language: "tr", left: "Ben dedim ki ", oracle: recorder)
+    #expect(
+      asked.withLock { $0 }.contains("ışık"),
+      "Turkish must be asked about `ışık`, got \(asked.withLock { $0 })")
+    #expect(
+      asked.withLock { $0 }.contains("işık") == false,
+      "and never about the root-locale form, which the Turkish dictionary rejects")
+
+    // Two-way control: English must be unaffected by the locale threading.
+    let englishAsked = OSAllocatedUnfairLock(initialState: [String]())
+    let englishRecorder = SeamCasingOracle(
+      unavailableReason: nil,
+      dictionaryVerdict: { word in
+        englishAsked.withLock { $0.append(word) }
+        return .ordinary
+      },
+      isLearnedWord: { _ in false },
+      isRecognizedName: { _, _ in false },
+      isNoun: { _ in false })
+    _ = Self.repaired("Ice is cold.", language: "en", left: "I said that ", oracle: englishRecorder)
+    #expect(englishAsked.withLock { $0 }.contains("ice"))
   }
 
   @Test("#1922 Turkish lowering is NOT the invariant lowering")

--- a/Tests/EnviousWisprTests/PostProcessing/SeamCasingRuntimeSerializationTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SeamCasingRuntimeSerializationTests.swift
@@ -1,0 +1,325 @@
+import Foundation
+import Testing
+import os
+
+@testable import EnviousWisprPostProcessing
+
+// #1922: the runtime became PER-LANGUAGE, and that is what put its concurrency
+// proof at risk.
+//
+// The type's one-lock argument holds only because preparation and decisions never
+// overlap in the single shared `NSSpellChecker`. With one language that was true
+// by construction — prewarm ran once at launch and nothing else prepared. With
+// twelve, any dictation in a new language can start a preparation at any moment,
+// and rev 2 of the plan did exactly that with independent per-language warmers,
+// which grounded review round 2 correctly killed.
+//
+// Two guards replaced it, and each closes a window the other does not:
+//
+//  1. A global drain: one builder at a time, never on the paste path.
+//  2. A decision LEASE: the drain also waits for decisions already in flight.
+//     Refusing new snapshots is necessary and NOT sufficient — a snapshot taken
+//     microseconds before preparation begins is already out, and its system call
+//     would land inside the preparation window.
+//
+// Both are asserted here against the real `drain()`, with the system preparation
+// replaced by a builder this suite can hold open. Every case runs under the
+// cross-suite exclusion because the runtime is process-global.
+@Suite("Seam casing runtime serialization (#1922)", .serialized)
+struct SeamCasingRuntimeSerializationTests {
+
+  static func ready(_ ordinary: Set<String>) -> SeamCasingOracle {
+    SeamCasingOracle(
+      unavailableReason: nil,
+      dictionaryVerdict: { ordinary.contains($0) ? .ordinary : .notOrdinary },
+      isLearnedWord: { _ in false },
+      isRecognizedName: { _, _ in false },
+      isNoun: { _ in false })
+  }
+
+  /// Availability without stranding a lease. See `SeamCasingOracleTests.probe`.
+  static func probe(_ base: String) -> SeamCasingOracle {
+    let oracle = SeamCasingOracleRuntime.snapshot(for: base)
+    if oracle.isAvailable { SeamCasingOracleRuntime.releaseDecisionLease() }
+    return oracle
+  }
+
+  /// Wait for a semaphore the runtime signals, without blocking the test's thread.
+  static func awaitSignal(_ semaphore: DispatchSemaphore) async -> Bool {
+    await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+      DispatchQueue.global().async {
+        // deadline-fallback: the semaphore is the signal; this bound is the fail-safe
+        continuation.resume(returning: semaphore.wait(timeout: .now() + 5) == .success)
+      }
+    }
+  }
+
+  /// Wait for an observable state change in the runtime.
+  ///
+  /// The drain publishes from a DETACHED task, so there is no handle to await and
+  /// no callback to hook — the published state IS the signal, and this reads it.
+  /// The interval below is how often that signal is sampled, not how long the
+  /// test waits for it; the deadline is a fail-safe against a hang and is never
+  /// the mechanism.
+  static func waitUntil(
+    timeout: Duration = .seconds(5),
+    _ condition: @Sendable () -> Bool
+  ) async -> Bool {
+    let deadline = ContinuousClock.now + timeout
+    while ContinuousClock.now < deadline {
+      if condition() { return true }
+      // settle: poll interval for the published-state signal, not a fixed wait
+      try? await Task.sleep(for: .milliseconds(2))
+    }
+    return condition()
+  }
+
+  // MARK: - One builder at a time
+
+  @Test("#1922 Two unbuilt languages prepare ONE AT A TIME, never concurrently")
+  func preparationIsSerialized() async throws {
+    try await withSeamCasingOracleExclusion {
+      SeamCasingOracleRuntime.resetForTesting()
+      // Installed BEFORE any preparation starts, deliberately. `installForTesting`
+      // bumps the epoch, and a preparation already in flight refuses to publish
+      // across an epoch change — so arranging this later would strand the very
+      // preparation the case is measuring.
+      SeamCasingOracleRuntime.installForTesting(Self.ready(["the"]), for: "en")
+
+      let inside = OSAllocatedUnfairLock(initialState: 0)
+      let peak = OSAllocatedUnfairLock(initialState: 0)
+      let entered = DispatchSemaphore(value: 0)
+      let release = DispatchSemaphore(value: 0)
+
+      SeamCasingOracleRuntime.setPreparationOverrideForTesting { _ in
+        let now = inside.withLock { value -> Int in
+          value += 1
+          return value
+        }
+        peak.withLock { $0 = max($0, now) }
+        entered.signal()
+        // deadline-fallback: `release` is the signal; this bound only stops a defect hanging the suite
+        _ = release.wait(timeout: .now() + 5)
+        inside.withLock { $0 -= 1 }
+        return Self.ready(["tack", "danke"])
+      }
+      defer { SeamCasingOracleRuntime.setPreparationOverrideForTesting(nil) }
+
+      // Two languages neither of which has ever been requested.
+      #expect(Self.probe("sv").unavailableReason == .oracleWarming, "first request warms")
+      #expect(Self.probe("da").unavailableReason == .oracleWarming, "second request warms too")
+
+      #expect(
+        await Self.awaitSignal(entered),
+        "the drain must have started a preparation off the paste path")
+
+      // While a builder is inside, an ALREADY-READY language must ALSO refuse.
+      // This is the invariant rev 2 broke: independent per-language warmers would
+      // have let English keep deciding while another language was inside the one
+      // shared checker, which is exactly what the one-lock proof forbids.
+      #expect(
+        Self.probe("en").unavailableReason == .oracleWarming,
+        "a ready language must also refuse while any preparation is running")
+
+      release.signal()
+      release.signal()
+
+      #expect(
+        await Self.waitUntil { Self.probe("sv").isAvailable && Self.probe("da").isAvailable },
+        "both languages must eventually publish")
+
+      let observed = peak.withLock { $0 }
+      #expect(
+        observed == 1,
+        "at most ONE builder may ever be inside the shared checker, saw \(observed)")
+    }
+  }
+
+  // MARK: - The lease
+
+  @Test("#1922 A decision lease blocks preparation until it is released")
+  func leaseBlocksPreparation() async throws {
+    try await withSeamCasingOracleExclusion {
+      SeamCasingOracleRuntime.resetForTesting()
+      SeamCasingOracleRuntime.installForTesting(Self.ready(["the"]), for: "en")
+
+      let builderRan = OSAllocatedUnfairLock(initialState: false)
+      SeamCasingOracleRuntime.setPreparationOverrideForTesting { _ in
+        builderRan.withLock { $0 = true }
+        return Self.ready(["gestern"])
+      }
+      defer { SeamCasingOracleRuntime.setPreparationOverrideForTesting(nil) }
+
+      // Take a decision lease, as the repair does, and DO NOT release it.
+      let leased = SeamCasingOracleRuntime.snapshot(for: "en")
+      #expect(leased.isAvailable, "precondition: English must be ready to lease")
+      #expect(SeamCasingOracleRuntime.outstandingLeasesForTesting() == 1)
+
+      // Request a language that has never been prepared. It must enqueue, and the
+      // drain must decline to start while the lease is out.
+      #expect(SeamCasingOracleRuntime.snapshot(for: "de").unavailableReason == .oracleWarming)
+
+      // Give the detached drain a real chance to misbehave. A negative assertion
+      // taken instantly would pass even if the gate were missing entirely.
+      let started = await Self.waitUntil(timeout: .milliseconds(300)) {
+        builderRan.withLock { $0 }
+      }
+      #expect(started == false, "no preparation may begin while a decision holds a lease")
+      #expect(SeamCasingOracleRuntime.outstandingLeasesForTesting() == 1)
+
+      // Releasing must re-poke the drain, or the queued language would stay
+      // warming forever — a stranded queue is the failure mode this design has to
+      // avoid, and it would be invisible in the field.
+      SeamCasingOracleRuntime.releaseDecisionLease()
+      #expect(SeamCasingOracleRuntime.outstandingLeasesForTesting() == 0)
+
+      #expect(
+        await Self.waitUntil { Self.probe("de").isAvailable },
+        "and release must let the queued language prepare")
+      #expect(builderRan.withLock { $0 })
+    }
+  }
+
+  @Test("#1922 A ready language DOES decide once preparation has published")
+  func readyLanguageActsAfterPublication() async throws {
+    // The two-way control for both cases above. Everything else here asserts a
+    // REFUSAL, and a runtime that refused permanently would satisfy all of it
+    // while shipping a dead feature.
+    try await withSeamCasingOracleExclusion {
+      SeamCasingOracleRuntime.resetForTesting()
+      SeamCasingOracleRuntime.setPreparationOverrideForTesting { _ in Self.ready(["gestern"]) }
+      defer { SeamCasingOracleRuntime.setPreparationOverrideForTesting(nil) }
+
+      #expect(Self.probe("de").unavailableReason == .oracleWarming, "first request warms")
+      #expect(
+        await Self.waitUntil { Self.probe("de").isAvailable }, "preparation must complete")
+
+      let oracle = SeamCasingOracleRuntime.snapshot(for: "de")
+      defer { SeamCasingOracleRuntime.releaseDecisionLease() }
+      let payloads = CursorInsertionRepair.repair(
+        text: "Gestern war es besser.",
+        context: CursorInsertionRepair.CaretText(left: "Ich sagte dass ", right: ""),
+        protectedWords: [], language: "de", oracle: oracle)
+
+      #expect(
+        payloads.repairedText == "gestern war es besser. ",
+        "a published language must actually act, or the whole feature is inert")
+    }
+  }
+
+  @Test("#1922 A lease is issued ONLY when a language is ready")
+  func leasesAreIssuedOnlyWhenReady() async throws {
+    // A lease taken on a refusal would never be released — the repair releases in
+    // `defer`, but only on the path that took one — and a stranded lease stops
+    // every future language preparing, silently and permanently.
+    try await withSeamCasingOracleExclusion {
+      SeamCasingOracleRuntime.resetForTesting()
+      SeamCasingOracleRuntime.setPreparationOverrideForTesting { _ in
+        .unavailable(.dictionaryUnavailable)
+      }
+      defer { SeamCasingOracleRuntime.setPreparationOverrideForTesting(nil) }
+
+      _ = SeamCasingOracleRuntime.snapshot(for: "fi")
+      #expect(SeamCasingOracleRuntime.outstandingLeasesForTesting() == 0, "warming must not lease")
+
+      #expect(
+        await Self.waitUntil {
+          SeamCasingOracleRuntime.snapshot(for: "fi").unavailableReason == .dictionaryUnavailable
+        })
+      #expect(
+        SeamCasingOracleRuntime.outstandingLeasesForTesting() == 0,
+        "an unavailable language must not lease either")
+
+      _ = SeamCasingOracleRuntime.snapshot(for: nil)
+      #expect(SeamCasingOracleRuntime.outstandingLeasesForTesting() == 0, "nil must not lease")
+
+      SeamCasingOracleRuntime.disableAfterTimeout()
+      _ = SeamCasingOracleRuntime.snapshot(for: "en")
+      #expect(SeamCasingOracleRuntime.outstandingLeasesForTesting() == 0, "latched must not lease")
+    }
+  }
+
+  // MARK: - The latch is still process-wide
+
+  @Test("#1922 One language's timeout latches EVERY language, not just its own")
+  func timeoutLatchIsStillProcessWide() async throws {
+    // A hung spell service is hung for all of them — it is one shared checker —
+    // so per-language state must not have quietly made the latch per-language.
+    try await withSeamCasingOracleExclusion {
+      SeamCasingOracleRuntime.resetForTesting()
+      SeamCasingOracleRuntime.installForTesting(Self.ready(["the"]), for: "en")
+      SeamCasingOracleRuntime.installForTesting(Self.ready(["gestern"]), for: "de")
+      #expect(Self.probe("en").isAvailable && Self.probe("de").isAvailable, "precondition")
+
+      SeamCasingOracleRuntime.disableAfterTimeout()
+
+      for base in ["en", "de", "sv", "tr", "fi"] {
+        #expect(
+          Self.probe(base).unavailableReason == .oracleTimedOut,
+          "\(base) must be latched off by another language's timeout")
+      }
+    }
+  }
+
+  @Test("#1922 A missing dictionary is scoped to ITS language and no other")
+  func unavailabilityIsPerLanguage() async throws {
+    // The opposite direction, and it must NOT be process-wide: a Mac with no
+    // Danish dictionary says nothing about its English one, and demoting all of
+    // them would turn one language's outage into a whole-feature outage.
+    try await withSeamCasingOracleExclusion {
+      SeamCasingOracleRuntime.resetForTesting()
+      SeamCasingOracleRuntime.installForTesting(Self.ready(["the"]), for: "en")
+      SeamCasingOracleRuntime.installForTesting(.unavailable(.dictionaryUnavailable), for: "da")
+
+      #expect(Self.probe("da").unavailableReason == .dictionaryUnavailable)
+      #expect(Self.probe("en").isAvailable, "one language's outage must not disable another")
+    }
+  }
+
+  // MARK: - Capability profiles
+
+  @Test(
+    "#1922 Each language asks macOS only for what its rule actually needs",
+    arguments: [
+      // Getting this wrong is SILENT. The shipped code required name detection
+      // unconditionally; it exists for exactly en/fr/de/it, so the eight
+      // dictionary-only languages would have resolved unavailable and the release
+      // would have shipped four languages while claiming twelve — with every test
+      // green, because refusing without name detection is correct ENGLISH
+      // behaviour. Found while writing the runtime and independently by grounded
+      // review round 2.
+      ("de", true, true),
+      ("en", true, false),
+      ("fr", true, false),
+      ("it", true, false),
+      ("sv", false, false),
+      ("nl", false, false),
+      ("es", false, false),
+      ("pt", false, false),
+      ("da", false, false),
+      ("fi", false, false),
+      ("tr", false, false),
+      ("ru", false, false),
+    ])
+  func capabilityProfilesMatchTheRule(
+    _ base: String, _ needsNameType: Bool, _ needsLexicalClass: Bool
+  ) {
+    let profile = SeamCasingOracleRuntime.CapabilityProfile.forLanguage(base)
+    #expect(profile.needsNameType == needsNameType, "\(base): name detection requirement")
+    #expect(profile.needsLexicalClass == needsLexicalClass, "\(base): word class requirement")
+  }
+
+  @Test("#1922 Only German requires the word-class scheme, because only German vetoes")
+  func onlyGermanNeedsWordClass() {
+    // A requirement and the rule that consumes it must agree. German's entire rule
+    // IS the noun veto, so a missing scheme makes it unavailable rather than
+    // merely weaker; any other language requiring it would be demanding something
+    // it never consults, and would go dark on machines for no reason.
+    for (code, policy) in CursorInsertionRepair.LanguageRules.casingPolicies {
+      let profile = SeamCasingOracleRuntime.CapabilityProfile.forLanguage(code)
+      #expect(
+        profile.needsLexicalClass == policy.nounVeto,
+        "\(code): the word-class requirement must match whether the veto is used")
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/PostProcessing/SeamCasingRuntimeSerializationTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SeamCasingRuntimeSerializationTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import NaturalLanguage
 import Testing
 import os
 
@@ -509,6 +510,102 @@ struct SeamCasingRuntimeSerializationTests {
 
       #expect(Self.probe("da").unavailableReason == .dictionaryUnavailable)
       #expect(Self.probe("en").isAvailable, "one language's outage must not disable another")
+    }
+  }
+
+  // MARK: - The tagger's ordering contract
+
+  /// Is German word-class tagging actually available here? CI's hosted runner
+  /// may not carry the assets, and a missing model must SKIP rather than fail.
+  static var germanWordClassAvailable: Bool {
+    NLTagger.availableTagSchemes(for: .word, language: .german).contains(.lexicalClass)
+  }
+
+  @Test(
+    "#1922 The tagger is pinned AFTER its string, or the pin is silently discarded",
+    .enabled(if: SeamCasingRuntimeSerializationTests.germanWordClassAvailable))
+  func taggerLanguagePinSurvivesTheStringAssignment() {
+    // Cloud review, P2. Assigning `NLTagger.string` RESETS the tagger, so calling
+    // `setLanguage` first threw the pin away — and the shipped comment claimed the
+    // pin was load-bearing, which made a false claim look deliberate.
+    //
+    // This asserts the API contract directly rather than through the runtime,
+    // because the runtime's closure only exists after a real `NSSpellChecker`
+    // preparation and this question is purely about `NLTagger`.
+    //
+    // SINGLE WORDS, deliberately. A first probe of eight multi-word German
+    // sentences found ZERO differences — auto-detection gets German right when it
+    // has a sentence to work with — so a test built from those would have frozen
+    // nothing. The divergence is on one-word payloads, which is exactly the
+    // dictation this feature serves.
+    func tag(_ payload: String, pinFirst: Bool) -> NLTag? {
+      let tagger = NLTagger(tagSchemes: [.lexicalClass])
+      if pinFirst {
+        tagger.setLanguage(.german, range: payload.startIndex..<payload.endIndex)
+        tagger.string = payload
+      } else {
+        tagger.string = payload
+        tagger.setLanguage(.german, range: payload.startIndex..<payload.endIndex)
+      }
+      return tagger.tag(at: payload.startIndex, unit: .word, scheme: .lexicalClass).0
+    }
+
+    // Ordinary German nouns. Each MUST tag as a noun so the veto keeps its
+    // capital; pinned-first they came back `OtherWord` and were lowercased.
+    for noun in ["Hut", "Bad", "Boot"] {
+      #expect(
+        tag(noun, pinFirst: false) == .noun,
+        "\(noun) must tag as a noun when the language is pinned AFTER the string")
+    }
+
+    // The two-way control. Without it this passes on a machine where BOTH orders
+    // happen to answer `.noun`, which would prove nothing about the ordering.
+    let divergent = ["Hut", "Bad", "Boot"].filter { tag($0, pinFirst: true) != .noun }
+    #expect(
+      divergent.isEmpty == false,
+      "at least one word must differ between the orderings, or this test cannot fail")
+  }
+
+  @Test(
+    "#1922 The SHIPPED German veto answers noun for a one-word noun",
+    .enabled(if: SeamCasingRuntimeSerializationTests.germanWordClassAvailable))
+  func shippedGermanVetoTagsAOneWordNoun() async throws {
+    // The case above freezes an `NLTagger` FACT and is therefore blind to the
+    // shipped call site — reverting the ordering in `prepare` left it green, which
+    // the mutation control exposed. This one drives the REAL closure the product
+    // uses, so it fails when that ordering regresses.
+    //
+    // No preparation override: the point is to exercise the real
+    // `NSSpellChecker` + `NLTagger` build. Gated on German word-class
+    // availability so a runner without the assets SKIPS rather than fails.
+    try await withSeamCasingOracleExclusion {
+      SeamCasingOracleRuntime.resetForTesting()
+
+      // The read-only seam, so waiting cannot itself re-request — and so the
+      // closure stays `@Sendable` without capturing a mutable local.
+      _ = await Self.waitUntil(timeout: .seconds(30)) {
+        SeamCasingOracleRuntime.installedOracleForTesting("de") != nil
+          || SeamCasingOracleRuntime.snapshot(for: "de").unavailableReason != .oracleWarming
+      }
+
+      guard let german = SeamCasingOracleRuntime.installedOracleForTesting("de") else {
+        // A machine without a usable German dictionary cannot answer this, and a
+        // fabricated pass would be worse than no coverage.
+        Issue.record(
+          "German did not become available; skipping is correct but the case ran anyway")
+        return
+      }
+
+      for noun in ["Hut", "Bad", "Boot"] {
+        #expect(
+          german.isNoun(noun),
+          "the shipped veto must read `\(noun)` as a noun, or German loses its capital")
+      }
+      // Two-way control: the veto must NOT answer noun to everything, or it would
+      // pass here while disabling German entirely.
+      #expect(
+        german.isNoun("gestern") == false,
+        "and it must still answer NOT-a-noun for an ordinary adverb")
     }
   }
 

--- a/Tests/EnviousWisprTests/PostProcessing/SeamCasingRuntimeSerializationTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SeamCasingRuntimeSerializationTests.swift
@@ -386,6 +386,95 @@ struct SeamCasingRuntimeSerializationTests {
     }
   }
 
+  @Test("#1922 A request made DURING another preparation is queued, not dropped")
+  func requestDuringPreparationIsQueued() async throws {
+    // Confirming whole-diff review r3, P2, and it is a real first-run cost: the
+    // `preparing` early return used to sit above the enqueue, so a German
+    // dictation arriving while English was still building was refused AND
+    // forgotten. German casing then could not work until the THIRD dictation —
+    // once at launch for every user whose second language is not English.
+    try await withSeamCasingOracleExclusion {
+      SeamCasingOracleRuntime.resetForTesting()
+
+      let entered = DispatchSemaphore(value: 0)
+      let release = DispatchSemaphore(value: 0)
+      let built = OSAllocatedUnfairLock(initialState: [String]())
+      SeamCasingOracleRuntime.setPreparationOverrideForTesting { base in
+        built.withLock { $0.append(base) }
+        entered.signal()
+        // deadline-fallback: `release` is the signal; this bound only stops a defect hanging the suite
+        _ = release.wait(timeout: .now() + 5)
+        return Self.ready(["the", "gestern"])
+      }
+      defer { SeamCasingOracleRuntime.setPreparationOverrideForTesting(nil) }
+
+      // English starts building and is held open.
+      #expect(Self.probe("en").unavailableReason == .oracleWarming)
+      #expect(await Self.awaitSignal(entered), "English must be inside the builder")
+
+      // German arrives DURING that build. It must refuse — one builder at a time —
+      // AND be remembered.
+      #expect(
+        SeamCasingOracleRuntime.snapshot(for: "de").unavailableReason == .oracleWarming,
+        "German must refuse while another language is inside the checker")
+
+      release.signal()
+      release.signal()
+
+      // READ-ONLY from here, and that is the whole point of the case.
+      //
+      // The first draft waited on `probe("de")`, which calls `snapshot(for:)` —
+      // so the wait itself re-requested German, queued it, and the language
+      // became ready no matter what. The test passed against the defect it was
+      // written to catch, and only the mutation control exposed it. An assertion
+      // must never be able to repair the state it is inspecting.
+      #expect(
+        await Self.waitUntil {
+          SeamCasingOracleRuntime.installedOracleForTesting("de") != nil
+        },
+        "German must prepare from the request made DURING English's build, with no second ask")
+      #expect(
+        built.withLock { $0 }.sorted() == ["de", "en"],
+        "both languages built exactly once, got \(built.withLock { $0 })")
+    }
+  }
+
+  @Test("#1922 An early English request and prewarm do not queue English twice")
+  func prewarmDoesNotDoubleQueueEnglish() async throws {
+    // Confirming whole-diff review r3, P2. `prewarm()` is launched
+    // asynchronously, so a dictation can request English first. That request
+    // marks English warming and queues it while leaving `prewarmStarted` false,
+    // so an unconditional append in `prewarm()` queued English a second time —
+    // and during the pointless second build every ready language refused.
+    try await withSeamCasingOracleExclusion {
+      // `prewarmStarted: false` is REQUIRED, not incidental. The default reset
+      // marks prewarm as already run — correct for every other case, because it
+      // stops a real prewarm racing the test — but it makes `prewarm()` return at
+      // its first guard, so a case aimed at its body reaches nothing and passes
+      // against any implementation. The first draft did exactly that and the
+      // mutation control caught it.
+      SeamCasingOracleRuntime.resetForTesting(prewarmStarted: false)
+
+      let builds = OSAllocatedUnfairLock(initialState: 0)
+      SeamCasingOracleRuntime.setPreparationOverrideForTesting { _ in
+        builds.withLock { $0 += 1 }
+        return Self.ready(["the"])
+      }
+      defer { SeamCasingOracleRuntime.setPreparationOverrideForTesting(nil) }
+
+      // The dictation wins the race to English.
+      #expect(SeamCasingOracleRuntime.snapshot(for: "en").unavailableReason == .oracleWarming)
+      // Then launch prewarm, exactly as `WisprBootstrapper` does.
+      await SeamCasingOracleRuntime.prewarm()
+
+      // Read-only, for the same reason as the case above: probing would re-request.
+      #expect(await Self.waitUntil { SeamCasingOracleRuntime.installedOracleForTesting() != nil })
+      #expect(
+        builds.withLock { $0 } == 1,
+        "English must be built ONCE, got \(builds.withLock { $0 })")
+    }
+  }
+
   // MARK: - The latch is still process-wide
 
   @Test("#1922 One language's timeout latches EVERY language, not just its own")

--- a/Tests/EnviousWisprTests/PostProcessing/SeamCasingRuntimeSerializationTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SeamCasingRuntimeSerializationTests.swift
@@ -282,6 +282,69 @@ struct SeamCasingRuntimeSerializationTests {
     }
   }
 
+  @Test("#1922 A regional tag reaches the SAME cache entry as its base code")
+  func regionalTagSharesTheBaseEntry() async throws {
+    // Whole-diff review, P2. The caller passes whatever the resolver produced;
+    // `repair` keys off the NORMALISED base code. If the runtime keyed off the
+    // raw tag instead, `de-DE` would build a phantom entry, ask the spell checker
+    // for a dictionary named `de-DE`, find none, and mark that key permanently
+    // unavailable — silently, and only for users whose language carries a region.
+    //
+    // Latent today (every producer emits a base code) and cheap to make
+    // impossible, which is the bar for fixing an unproven defect: trivial fix,
+    // silent failure.
+    try await withSeamCasingOracleExclusion {
+      SeamCasingOracleRuntime.resetForTesting()
+      SeamCasingOracleRuntime.installForTesting(Self.ready(["gestern"]), for: "de")
+
+      for raw in ["de", "de-DE", "de_AT", "de-CH"] {
+        let oracle = SeamCasingOracleRuntime.snapshot(for: raw)
+        #expect(oracle.isAvailable, "\(raw) must resolve to the prepared German entry")
+        if oracle.isAvailable { SeamCasingOracleRuntime.releaseDecisionLease() }
+      }
+    }
+  }
+
+  @Test("#1922 A language with no casing policy never enters the preparation drain")
+  func unsupportedLanguageNeverPrepares() async throws {
+    // Whole-diff review, P2, and this one is reachable today: dictating Japanese
+    // queued a real spell-checker preparation that `repair` could never use, and
+    // while it ran EVERY ready language refused with `oracleWarming`. Pure waste
+    // plus a self-inflicted global refusal window.
+    try await withSeamCasingOracleExclusion {
+      SeamCasingOracleRuntime.resetForTesting()
+      SeamCasingOracleRuntime.installForTesting(Self.ready(["the"]), for: "en")
+
+      let builderRan = OSAllocatedUnfairLock(initialState: false)
+      SeamCasingOracleRuntime.setPreparationOverrideForTesting { _ in
+        builderRan.withLock { $0 = true }
+        return Self.ready([])
+      }
+      defer { SeamCasingOracleRuntime.setPreparationOverrideForTesting(nil) }
+
+      for unsupported in ["ja", "zh", "pl", "cs", "hu", "th"] {
+        let oracle = SeamCasingOracleRuntime.snapshot(for: unsupported)
+        #expect(
+          oracle.unavailableReason == .languageNotSupported,
+          "\(unsupported) must refuse immediately, not warm")
+      }
+
+      // Give the drain a real chance to misbehave; an instant assertion would
+      // pass even with the guard missing.
+      let started = await Self.waitUntil(timeout: .milliseconds(300)) {
+        builderRan.withLock { $0 }
+      }
+      #expect(started == false, "no preparation may be queued for a language that will abstain")
+
+      // Two-way control: a SUPPORTED language must still prepare, or this test
+      // would also pass against a runtime that prepares nothing at all.
+      #expect(SeamCasingOracleRuntime.snapshot(for: "sv").unavailableReason == .oracleWarming)
+      #expect(
+        await Self.waitUntil { builderRan.withLock { $0 } },
+        "a supported language must still reach the builder")
+    }
+  }
+
   // MARK: - The latch is still process-wide
 
   @Test("#1922 One language's timeout latches EVERY language, not just its own")

--- a/Tests/EnviousWisprTests/PostProcessing/SeamCasingRuntimeSerializationTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SeamCasingRuntimeSerializationTests.swift
@@ -345,6 +345,47 @@ struct SeamCasingRuntimeSerializationTests {
     }
   }
 
+  @Test("#1922 Saving state for the exclusion helper must not START anything")
+  func stateCaptureIsReadOnly() async throws {
+    // Confirming whole-diff review, P2. `withSeamCasingOracleExclusion` saves the
+    // prior English oracle so it can hand it back. Doing that with
+    // `snapshot(for:)` enqueued English and started a real preparation, which
+    // `resetForTesting()` cannot cancel — so the helper could manufacture the
+    // very overlap the suites it guards exist to disprove.
+    //
+    // This asserts the read is inert on the hardest case: a runtime where English
+    // has NEVER been prepared, which is exactly when `snapshot` would enqueue.
+    try await withSeamCasingOracleExclusion {
+      SeamCasingOracleRuntime.resetForTesting()
+
+      let builderRan = OSAllocatedUnfairLock(initialState: false)
+      SeamCasingOracleRuntime.setPreparationOverrideForTesting { _ in
+        builderRan.withLock { $0 = true }
+        return Self.ready(["the"])
+      }
+      defer { SeamCasingOracleRuntime.setPreparationOverrideForTesting(nil) }
+
+      #expect(
+        SeamCasingOracleRuntime.installedOracleForTesting("en") == nil,
+        "nothing is prepared, so there is nothing to hand back")
+      #expect(
+        SeamCasingOracleRuntime.outstandingLeasesForTesting() == 0,
+        "and a read must not take a lease")
+
+      let started = await Self.waitUntil(timeout: .milliseconds(300)) {
+        builderRan.withLock { $0 }
+      }
+      #expect(started == false, "reading prior state must not queue a preparation")
+
+      // Two-way control: it must still SEE a prepared oracle, or the helper would
+      // silently stop restoring anything and this test would pass on a stub.
+      SeamCasingOracleRuntime.installForTesting(Self.ready(["the"]), for: "en")
+      #expect(
+        SeamCasingOracleRuntime.installedOracleForTesting("en") != nil,
+        "and it must return a READY oracle when one exists")
+    }
+  }
+
   // MARK: - The latch is still process-wide
 
   @Test("#1922 One language's timeout latches EVERY language, not just its own")

--- a/Tests/EnviousWisprTests/PostProcessing/SeamCasingRuntimeSerializationTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SeamCasingRuntimeSerializationTests.swift
@@ -239,6 +239,49 @@ struct SeamCasingRuntimeSerializationTests {
     }
   }
 
+  @Test("#1922 An unmatched release cannot steal a lease another decision holds")
+  func unmatchedReleaseCannotStealALease() async throws {
+    // Grounded review r3 (MED). Leases carry no identity, so `releaseDecisionLease()`
+    // called by a decision that never took one decrements whichever decision
+    // currently holds the count — and the drain then starts preparing while that
+    // decision is still inside the shared spell checker, which is exactly the race
+    // the lease exists to close.
+    //
+    // The production fix is at the CALL SITE: release only if the snapshot was
+    // ready. This freezes the property that makes the fix necessary — an extra
+    // release does real damage — so nobody restores the unconditional form
+    // believing it harmless.
+    try await withSeamCasingOracleExclusion {
+      SeamCasingOracleRuntime.resetForTesting()
+      SeamCasingOracleRuntime.installForTesting(Self.ready(["the"]), for: "en")
+
+      // Decision A: ready, so it leases.
+      let a = SeamCasingOracleRuntime.snapshot(for: "en")
+      #expect(a.isAvailable)
+      #expect(SeamCasingOracleRuntime.outstandingLeasesForTesting() == 1)
+
+      // Decision B: a language with no policy. It gets no lease — and if it
+      // releases anyway, it takes A's.
+      let b = SeamCasingOracleRuntime.snapshot(for: nil)
+      #expect(b.isAvailable == false, "an unsupported language must not be ready")
+      #expect(
+        SeamCasingOracleRuntime.outstandingLeasesForTesting() == 1,
+        "and it must not have taken a lease of its own")
+
+      // What the old unconditional `defer` did.
+      SeamCasingOracleRuntime.releaseDecisionLease()
+      #expect(
+        SeamCasingOracleRuntime.outstandingLeasesForTesting() == 0,
+        "THIS is the damage: A conceptually still holds its lease, the count says zero, and the drain is now free to prepare while A is inside the checker"
+      )
+
+      // Clean up A's real lease. The count is already zero, so this is a no-op —
+      // which is the other half of the same defect: the accounting cannot recover.
+      SeamCasingOracleRuntime.releaseDecisionLease()
+      #expect(SeamCasingOracleRuntime.outstandingLeasesForTesting() == 0)
+    }
+  }
+
   // MARK: - The latch is still process-wide
 
   @Test("#1922 One language's timeout latches EVERY language, not just its own")

--- a/Tests/EnviousWisprTests/Services/TerminalInsertionPolicyTests.swift
+++ b/Tests/EnviousWisprTests/Services/TerminalInsertionPolicyTests.swift
@@ -21,7 +21,8 @@ struct TerminalInsertionPolicyTests {
       ["fix", "first", "second", "a", "b"].contains($0) ? .ordinary : .notOrdinary
     },
     isLearnedWord: { _ in false },
-    isRecognizedName: { _, _ in false })
+    isRecognizedName: { _, _ in false },
+    isNoun: { _ in false })
 
   private func terminalContext(line: String) -> PasteService.CaretContext {
     PasteService.CaretContext(

--- a/Tests/EnviousWisprTests/Services/TerminalInsertionPolicyTests.swift
+++ b/Tests/EnviousWisprTests/Services/TerminalInsertionPolicyTests.swift
@@ -15,7 +15,7 @@ struct TerminalInsertionPolicyTests {
 
   /// Every word this suite dictates is an ordinary lowercase word, so the
   /// leading-case rule is exercised rather than skipped as a proper noun.
-  static let ordinaryWords = EnglishWordOracle(
+  static let ordinaryWords = SeamCasingOracle(
     unavailableReason: nil,
     dictionaryVerdict: {
       ["fix", "first", "second", "a", "b"].contains($0) ? .ordinary : .notOrdinary


### PR DESCRIPTION
Part of #1922.

Stops hard-coding the seam oracle to English. **Eleven more languages now get the capital right when you dictate into the middle of a sentence: German, French, Italian, Spanish, Portuguese, Dutch, Danish, Swedish, Finnish, Russian and Turkish.**

Measured on the BUILT code over **51,895 held-out seams** from real published text with gold labels: **7.1% correct → 94.4%**. Swedish 1.1% → 97.7%, German 22.0% → 88.5%.

Today's baseline is not "no errors". Polish returns a well-formed sentence, so the app capitalises **every** mid-sentence join, and that is wrong 92.9% of the time in these languages.

No bundled word list, no model, no new dependency, no telemetry plumbing. Both solution classes the founder banned stayed banned.

## Design

- **`LanguageRules.knowsCasing: Bool` → `casingPolicy: CasingPolicy?`.** A Bool could not express that German's rule INVERTS (it capitalises every noun), and `nil` now carries "abstain" explicitly rather than by omission.
- **German alone gets a `.lexicalClass` noun VETO.** It is a conjunction, so it can only WITHDRAW a lowering, never cause one — structurally unlike #1803's rejected design where word class was the decider. Not applied to French or Italian, which lowercase their common nouns: measured there it costs a third of the recall for one point of precision.
- **Closed polite-form guards** for German (`Sie`/`Ihr`/`Ihnen`) and Swedish (`Ni`), where the capital itself carries the meaning and no dictionary can see it. Italian and Russian lists were tried and reverted — theirs contained ordinary articles and possessives, and each made its language measurably worse.
- **Locale-aware lowercasing in BOTH directions** — the text we write and the word we ask the dictionary about. Turkish `I` → `ı` needs a locale; Dutch `IJ` → `ij` needs two characters AND an exemption in the acronym guard, which refused every `IJ` word four checks earlier. Either Dutch fix alone is inert; verified, not reasoned.
- **Capability profiles, not one precondition.** `.nameType` exists for four European languages only. Requiring it everywhere would have shipped four languages while claiming twelve, silently, with every test green.
- **Per-language oracle cache** with a globally serialized preparation drain and a decision LEASE. Preparation costs ~100 ms against a 100 ms wall-clock deadline whose timeout latches casing off process-wide (#1946), so it never runs on the paste path; and the drain waits for in-flight decisions, because refusing new snapshots does not stop one that escaped microseconds earlier.

**English is untouched by construction, with one stated exception**: while another language prepares, a ready English snapshot also refuses with `oracle_warming`. That window did not exist when English was the only prepared language. It is one-time per language per launch and fails safe.

## Review found seven real defects, all fixed with a mutation control each

Grounded review r3 plus four whole-diff rounds:

1. **Release was unconditional, acquisition was conditional.** Leases carry no identity, so an unmatched release decremented whichever decision held the count, freeing the drain to prepare while a real decision was inside the shared spell checker — the exact race the lease was added to close.
2. **The dictionary was queried with the root locale**, so Turkish `Işık` was looked up as `işık` rather than `ışık` and an ordinary word kept its capital. Fails safe, which is why nothing caught it.
3. **The runtime keyed off the RAW dictation tag** while `repair` keyed off the normalised base code, so a regional tag would have built a phantom cache entry and permanently marked it unavailable.
4. **A language with no policy queued a spell-checker preparation it could never use**, and every ready language refused while it ran.
5. **A request made DURING another preparation was refused AND forgotten**, so a second language could not work until its third dictation.
6. **English could be queued twice at startup**, and the pointless second build made every ready language refuse.
7. **The test exclusion helper started a real preparation while saving state** — observation manufacturing the defect it observed.

## The measurement is the other half of this PR

The floors driver compiles the three shipped source files **unmodified** and calls the real `repair` through the real runtime, so what is measured is what ships.

**It caught itself being wrong.** The first run failed Danish at 87.9%; re-run minutes later, same binary, same corpus, 94.8%. `NSSpellChecker` is a separate process and the oracle demotes a language when it stops answering, after which every later seam refuses — which reads as poor recall, not as a broken instrument. Each language is now scored twice back to back, re-probed for health, and reports INVALID rather than a number.

**And a correct fix made a number worse.** Correcting the Turkish dictionary locale dropped measured Turkish from 92.4% to 88.6%. A probe against the real dictionary settled it: on correctly spelled Turkish the locale query wins 5 of 8 words and never loses, but the corpus writes ASCII `I` where Turkish requires `İ` — 125 payloads to 4 — so the benchmark rewards the wrong query. Shipped the correct code, reported the worse number, wrote down why.

**Founder decision, recorded:** Spanish (4.07%) and Portuguese (4.38%) exceed the plan's 4% wrong-lowering ceiling while clearing accuracy and beating today's baseline by ~84 points. Asked with the full table and three options; chosen: ship all eleven.

## Validation

- **4,989 tests green.** Eight mutations, each caught by its own new test — including two first drafts that passed against the very defects they were written to catch, exposed only by the mutation control.
- **Live UAT: 11 of 12 rounds pass** on the shipped build, covering every policy class including the French-noun anti-leak case, the Dutch digraph, the Polish inert control and the negative control. Turkish is not live-verifiable on this machine because the speech engine does not transcribe Turkish audio as Turkish; every layer behaved correctly on the input it received.
- Grounded review to PROCEED, whole-diff review clean on its fourth round.

Plan: `docs/feature-requests/issue-1922-2026-08-05-european-continuation-casing.md` (rev 5).
