### PR TITLE
docs(content): rewrite all 52 help articles in the documentation voice

### DIFF
--- a/website/src/content/help/accessibility-permission-not-working.md
+++ b/website/src/content/help/accessibility-permission-not-working.md
@@ -8,24 +8,24 @@ keywords: ["accessibility not working", "permission wont stick", "toggle keeps t
 related: ["granting-permissions-microphone-accessibility-and-automation", "paste-not-working"]
 updated: 2026-08-05
 ---
-EnviousWispr needs Accessibility permission to put text into your apps. Without it, nothing gets pasted.
+EnviousWispr is a free dictation app for macOS, and it uses the Accessibility permission to put your finished text into whatever app you are working in. Without that permission, your words are transcribed but nothing is pasted.
 
-### Granting it
+### Grant it
 
 1. Open **System Settings** \> **Privacy & Security** \> **Accessibility**.
 2. Click **+** and add EnviousWispr from your Applications folder.
-3. Make sure its switch is on.
+3. Make sure the switch beside it is on.
 
-You do not need to restart the app. It notices within a few seconds.
+You do not need to restart EnviousWispr. It notices within a few seconds. You will know it worked when your next dictation lands in the text box on its own.
 
-### If it was working and stopped
+### If it was working and then stopped
 
-macOS lets permission be turned off while an app is running, and a system update can do it. EnviousWispr shows a warning when that happens. Switch it back on in the same place.
+macOS can turn a permission off while an app is running, and a system update sometimes does exactly that. EnviousWispr shows a warning when it happens. Switch the permission back on in the same place.
 
 ### If the switch looks on but nothing pastes
 
-Remove EnviousWispr from the Accessibility list with the **-** button, then add it back and switch it on.
+macOS occasionally holds on to a stale record of the app. Remove EnviousWispr from the Accessibility list with the **-** button, then add it back with **+** and switch it on again.
 
-### Meanwhile
+### Your dictation is not lost meanwhile
 
-Your dictation is not lost. EnviousWispr copies it to the clipboard instead and tells you. Paste it with Cmd+V.
+When EnviousWispr cannot paste, it copies your text to the clipboard instead and tells you it has done so. Press Cmd+V to put it in yourself.

--- a/website/src/content/help/adding-custom-words.md
+++ b/website/src/content/help/adding-custom-words.md
@@ -8,24 +8,24 @@ keywords: ["custom words", "vocabulary", "add a word", "my name", "names", "jarg
 related: ["why-is-my-dictation-inaccurate", "how-custom-word-correction-works"]
 updated: 2026-08-05
 ---
-If the app keeps getting a name or a term wrong, teach it. Open Settings and go to **Your Words**.
+EnviousWispr is a free dictation app for macOS. When it keeps getting a name or a term wrong, you can teach it the spelling you want.
 
 ### Adding one
 
-1. Open Settings and go to **Your Words**.
+1. Click the EnviousWispr icon in your menu bar, choose **Settings**, and go to **Your Words**.
 2. Add the spelling you want.
 
-From then on, when you say it, you get your spelling. If the app writes "Chat G P T", adding "ChatGPT" fixes it.
+From then on, when you say that word, you get your spelling. If EnviousWispr writes "Chat G P T", adding "ChatGPT" fixes it.
 
 ### Worth adding
 
 - Names of people you write to.
 - Your company and product names.
-- Terms your field uses that nobody else does.
+- Terms your field uses that nobody outside it does.
 
 ### Ready-made packs
 
-The same page offers vocabulary packs you can switch on: Tech, Medical, Legal, Brands and Names. Turn on the ones that match your work rather than typing those terms in yourself.
+The same page offers vocabulary packs you can switch on: Tech, Medical, Legal, Brands and Names. Turn on the ones that match your work rather than typing all those terms in yourself.
 
 ### Importing from Contacts
 
@@ -41,8 +41,8 @@ This needs macOS 26 or later with Apple Intelligence switched on, and it happens
 
 ### When your words are used
 
-Your spellings are applied to your text before AI Polish runs, on every dictation, whether or not polish is on.
+Your spellings are applied to your text before AI Polish runs, on every dictation, whether or not polish is switched on.
 
-OpenAI, Gemini and Claude are also given your list, so their rewriting keeps your spellings. Whether Ollama is depends on the model you picked. Apple Intelligence and EG-1 are not, because they do better with shorter instructions and your words have already been applied by then.
+OpenAI, Gemini and Claude are also given your list, so their rewriting keeps your spellings. Whether Ollama is given the list depends on the model you picked. Apple Intelligence and EG-1 are not given it, because they do better with shorter instructions and your words have already been applied by then.
 
 To move your words between Macs, or bring them in from another app, see [_Importing and Exporting Custom Words_](/help/importing-and-exporting-custom-words/).

--- a/website/src/content/help/ai-polish-and-cloud-data.md
+++ b/website/src/content/help/ai-polish-and-cloud-data.md
@@ -9,35 +9,35 @@ related: ["privacy-overview", "choosing-an-ai-provider-none-apple-intelligence-o
 seeAlso: "cloud-ai-polish-not-stored"
 updated: 2026-08-05
 ---
-Whether anything leaves your Mac depends entirely on which AI Polish option you picked. Open Settings and go to **AI Polish** to see yours.
+EnviousWispr is a free dictation app for macOS. Whether any of your text leaves your Mac depends entirely on which AI Polish option you picked. Go to **Settings** \> **AI Polish** to see which one is yours.
 
 ### Nothing leaves your Mac
 
 - **None.** No AI step at all.
 - **Apple Intelligence.** Apple's model, running on your Mac.
-- **EG-1.** Our own model, running on your Mac.
-- **Ollama, when you pick a model that runs on your Mac.** Ollama also offers hosted models that run on its servers; those send your transcribed text, and EnviousWispr shows them under their own heading so you can tell which is which.
+- **EG-1.** The model EnviousWispr built, running on your Mac.
+- **Ollama, when you pick a model you downloaded.** Ollama also offers hosted models that run on its own servers, and those do send your transcribed text. EnviousWispr shows them under their own heading so you can tell which kind you are choosing.
 
 ### Your text is sent
 
-OpenAI, Gemini and Claude run on their own servers. You bring your own key, and your account is with them, on their terms. We are not in the middle of it: everything goes straight from your Mac to them, so we never see it either.
+OpenAI, Gemini, Claude and Ollama's hosted models all run on their own servers. Your account is with that company, on their terms. Envious Labs is not in the middle of it: everything goes straight from your Mac to them, so it is never seen here either.
 
 #### What is sent
 
 - The text to polish.
 - The instructions for cleaning it up, plus your custom words.
 - The name of the app you are dictating into.
-- Your API key, so the provider can authenticate the request.
+- Your API key, so the provider can confirm the request is yours. Ollama's hosted models use your Ollama sign-in instead of a key.
 
 #### What is never sent
 
 - Your audio. Ever, on any option.
 - Your other transcripts, or your History.
 
-EnviousWispr does not add anything identifying you or your Mac to the request. The provider still sees the ordinary details of any internet connection, such as your IP address.
+EnviousWispr adds nothing to the request that identifies you or your Mac. The provider still sees the ordinary details of any internet connection, such as your IP address.
 
-With OpenAI and Gemini, EnviousWispr also asks them not to keep a copy of that request. That is a request to them, not something we can enforce, and your text still has to reach them to be polished.
+With OpenAI and Gemini, EnviousWispr also asks them not to keep a copy of that request. That is a request to them, not something EnviousWispr can enforce, and your text still has to reach them to be polished.
 
 ### If polish fails
 
-You get the tidied-up version of your dictation from just before the AI step. A network problem, a slow provider, or a reply that arrives cut short costs you the polish, never your words.
+You get the tidied-up version of your dictation from immediately before the AI step. A network problem, a slow provider, or a reply that arrives cut short costs you the polish, never your words.

--- a/website/src/content/help/api-key-security.md
+++ b/website/src/content/help/api-key-security.md
@@ -8,13 +8,13 @@ keywords: ["api key", "where is my key stored", "keychain", "secret", "token", "
 related: ["choosing-an-ai-provider-none-apple-intelligence-ollama-openai-gemini"]
 updated: 2026-08-05
 ---
-If you use OpenAI, Gemini or Claude for AI Polish, you bring your own key. Here is how it is looked after.
+EnviousWispr is a free dictation app for macOS. If you use OpenAI, Gemini or Claude to polish your dictation, you bring your own API key. Here is where that key is kept and how to take it back out.
 
 ### Stored in the macOS Keychain
 
 Your key goes into the macOS Keychain, the same place the system keeps your other passwords. It is protected by your login and encrypted at rest, and no other account on the Mac can read it.
 
-If you used an early version of EnviousWispr, your key may have started out in an older file store. The app moves it into the Keychain the next time it is used, and tidies up the old file afterwards.
+If you used an early version of EnviousWispr, your key may have started out in an older file store. The app moves it into the Keychain the next time it is used, and clears the old file afterwards.
 
 ### Where your key does and does not go
 
@@ -24,4 +24,4 @@ If you used an early version of EnviousWispr, your key may have started out in a
 
 ### Removing a key
 
-Clear the field in Settings and the stored key goes with it. You can also revoke the key from your provider's dashboard at any time, which takes effect immediately whatever EnviousWispr does.
+Clear the field in **Settings** \> **AI Polish** and the stored key goes with it. You can also revoke the key from your provider's own dashboard at any time, which takes effect immediately whatever EnviousWispr does.

--- a/website/src/content/help/app-crashes-or-asr-engine-crashes.md
+++ b/website/src/content/help/app-crashes-or-asr-engine-crashes.md
@@ -7,16 +7,20 @@ order: 8
 keywords: ["crash", "crashes", "quits", "closes by itself", "keeps crashing", "stopped working", "disappeared", "not responding"]
 updated: 2026-08-05
 ---
-Speech recognition runs separately from the app. If it fails, EnviousWispr keeps running and starts it again on your next recording. There is nothing for you to do.
+EnviousWispr is a free dictation app for macOS. The part of it that turns speech into text runs separately from the rest of the app, so the two can stop on their own without taking the other down.
+
+### If the speech engine stops
+
+EnviousWispr keeps running and starts the engine again on your next recording. There is nothing for you to do.
 
 ### If the app itself quits
 
-Open it again from Applications. Your History is saved to disk, so past dictations are still there.
+Open it again from your Applications folder. Your History is written to disk as you go, so past dictations are still there.
 
 ### The dictation you were in the middle of
 
-While you dictate, the app keeps a protected copy of the recording, and deletes it once your text is safely saved. If the app quits before that, EnviousWispr makes one attempt to recover those words the next time it starts.
+While you dictate, EnviousWispr keeps a protected copy of the recording and deletes it once your text is safely saved. If the app quits before that happens, EnviousWispr makes one attempt to recover those words the next time it starts.
 
 ### Crash reports
 
-Crashes are reported automatically so we can fix them. Reports describe what the app was doing, never what you said. No audio and no transcripts are ever included.
+Crashes are reported to Envious Labs automatically so they can be fixed. A report describes what the app was doing, never what you said. No audio and no transcripts are ever included.

--- a/website/src/content/help/apple-intelligence-not-available.md
+++ b/website/src/content/help/apple-intelligence-not-available.md
@@ -8,15 +8,17 @@ keywords: ["apple intelligence missing", "apple intelligence greyed out", "cant 
 related: ["apple-intelligence-setup", "system-requirements"]
 updated: 2026-08-05
 ---
-Open Settings and go to **AI Polish**. With Apple Intelligence selected, EnviousWispr shows you exactly which requirement is missing.
+EnviousWispr is a free dictation app for macOS. Apple Intelligence is one of the options it can use to tidy up your dictation, and Apple only makes it available on some Macs.
+
+To see where you stand, open EnviousWispr's settings, go to **AI Polish**, and select Apple Intelligence. EnviousWispr names the exact requirement you are missing.
 
 ### The usual reasons
 
-- **macOS is too old.** This needs macOS 26 or later. Check under the Apple menu \> About This Mac. It is not the same as the Apple Intelligence that arrived in macOS 15: apps could not use the model until macOS 26.
+- **macOS is too old.** This needs macOS 26 or later. Check under the Apple menu \> About This Mac. It is not the same thing as the Apple Intelligence that arrived in macOS 15: other apps could not reach the model until macOS 26.
 - **Apple Intelligence is switched off.** Turn it on in **System Settings** \> **Apple Intelligence & Siri**.
 - **The model is still downloading.** macOS fetches it in the background after you switch it on, and that can take a while. Try again later.
-- **Your Mac does not support it.** Apple sets the requirements.
+- **Your Mac does not support it.** Apple decides which Macs qualify, and there is no way around that from inside EnviousWispr.
 
 ### What to do instead
 
-Dictation works regardless. Only the AI clean-up is affected. If Apple Intelligence is not available to you, pick EG-1 or Ollama to stay on your Mac, or bring your own key for OpenAI, Gemini or Claude.
+Dictation itself works either way. Only the clean-up step is affected. If Apple Intelligence is out of reach, pick EG-1 or an Ollama model you have downloaded to keep everything on your Mac, or use your own key for OpenAI, Gemini or Claude.

--- a/website/src/content/help/apple-intelligence-setup.md
+++ b/website/src/content/help/apple-intelligence-setup.md
@@ -8,7 +8,7 @@ keywords: ["apple intelligence", "apple ai", "on device ai", "free ai", "macos 2
 related: ["apple-intelligence-not-available"]
 updated: 2026-08-05
 ---
-Apple Intelligence tidies up your text on your Mac. It is free, there is no key to enter, and nothing leaves the machine.
+EnviousWispr is a free dictation app for macOS. Apple Intelligence is Apple's own AI, built into newer versions of macOS, and EnviousWispr can use it to tidy up your dictation. It is free, there is no key to enter, and your text never leaves the Mac.
 
 ### What you need
 
@@ -19,11 +19,13 @@ Apple Intelligence tidies up your text on your Mac. It is free, there is no key 
 ### Setting it up
 
 1. Open **System Settings** \> **Apple Intelligence & Siri** and switch it on.
-2. In EnviousWispr, open Settings and go to **AI Polish**.
+2. In EnviousWispr, go to **Settings** \> **AI Polish**.
 3. Choose **Apple Intelligence**.
+
+You will know it worked when your next dictation comes back with the filler words gone and the punctuation fixed.
 
 ### If it is not available
 
-EnviousWispr checks and tells you which requirement is missing, on that same page. The usual reasons are an older macOS, Apple Intelligence not switched on yet, or the model still downloading in the background.
+EnviousWispr checks your Mac and names the missing requirement on that same **AI Polish** page. The usual reasons are an older version of macOS, Apple Intelligence not switched on yet, or the model still downloading in the background.
 
 See [_Apple Intelligence Not Available_](/help/apple-intelligence-not-available/) if you get stuck.

--- a/website/src/content/help/auto-updates.md
+++ b/website/src/content/help/auto-updates.md
@@ -7,15 +7,15 @@ order: 1
 keywords: ["update", "updates", "new version", "upgrade", "auto update", "check for updates", "latest version"]
 updated: 2026-08-05
 ---
-EnviousWispr checks for updates by itself and tells you when one is ready. Click to install, and the app restarts into the new version.
+EnviousWispr is a free dictation app for macOS. It checks for updates by itself and tells you when one is ready. Click to install, and the app restarts into the new version.
 
 ### Checking now
 
-Open the EnviousWispr window and click **Check for Updates**.
+Click the EnviousWispr icon in your menu bar, choose **Settings**, and go to **Check for Updates**.
 
 ### Where updates come from
 
-Every update is downloaded from our official release page, and its signature is checked before it installs. An update that fails that check is refused.
+Every update is downloaded from the official EnviousWispr release page, and its signature is checked before it installs. An update that fails that check is refused.
 
 ### What is new
 

--- a/website/src/content/help/bluetooth-and-airpods.md
+++ b/website/src/content/help/bluetooth-and-airpods.md
@@ -8,17 +8,17 @@ keywords: ["airpods", "air pods", "bluetooth", "wireless headphones", "headphone
 related: ["choosing-your-microphone"]
 updated: 2026-08-05
 ---
-They work. There are two things worth knowing.
+EnviousWispr is a free dictation app for macOS. AirPods and Bluetooth headsets work with it, and there are two things worth knowing before you rely on them.
 
 ### Which microphone gets used
 
 On **Auto**, EnviousWispr records from whatever input your Mac is set to. If that is your AirPods, it records from your AirPods.
 
-To use your Mac's built-in microphone instead, either change the input in **System Settings** \> **Sound**, or pick it directly under **Microphone** in EnviousWispr.
+To use your Mac's built-in microphone instead, either change the input in **System Settings** \> **Sound**, or name it directly under **Settings** \> **Microphone** in EnviousWispr.
 
 ### Why your music dips when you record
 
-A Bluetooth headset has a music mode and a microphone mode, and it cannot do both at once. The moment anything uses the microphone, the headset switches, and audio quality drops for as long as it is recording.
+A Bluetooth headset has a music mode and a microphone mode, and it cannot do both at once. The moment anything uses the microphone, the headset switches over, and audio quality drops for as long as the recording lasts.
 
 That switch also takes a moment, which is why a first word can go missing if you start talking instantly. Hold your hotkey for a beat before speaking on the first recording after connecting.
 

--- a/website/src/content/help/canceling-a-recording.md
+++ b/website/src/content/help/canceling-a-recording.md
@@ -8,14 +8,16 @@ keywords: ["cancel", "stop without pasting", "throw away", "discard", "escape", 
 related: ["recording-won-t-stop-or-seems-stuck"]
 updated: 2026-08-05
 ---
-Press **Escape**. The recording stops, the audio is thrown away, and nothing is typed. This works in every mode, at any point during a recording.
+EnviousWispr is a free dictation app for macOS. If you misspeak, get interrupted, or start recording by accident, press **Escape**. The recording stops, the audio is thrown away, and nothing is typed. This works in every recording mode, at any point during a recording.
+
+In push to talk, you can also triple-press your hotkey to cancel, so you do not need to reach for the Escape key.
 
 ### In hands-free mode
 
-Use Escape. Pressing your recording hotkey stops the recording and transcribes it, which is not what you want if you are trying to discard it.
+Press **Escape**. Do not press your recording hotkey again, because in hands-free mode that stops the recording and transcribes it instead of canceling.
 
 ### What happens
 
-Nothing is transcribed, nothing is pasted, and nothing is saved to your History. The app goes back to waiting.
+Nothing is transcribed, nothing is pasted, and nothing is saved to your History. The bar disappears from the screen and EnviousWispr goes back to waiting, which is how you know it worked.
 
-You can change the cancel key under **Shortcuts** in Settings.
+You can change the cancel key under **Settings** \> **Shortcuts**, reached from the EnviousWispr icon in your menu bar.

--- a/website/src/content/help/choosing-a-speech-engine-parakeet-vs-whisperkit.md
+++ b/website/src/content/help/choosing-a-speech-engine-parakeet-vs-whisperkit.md
@@ -8,22 +8,24 @@ keywords: ["parakeet", "whisperkit", "whisper", "which engine", "engine", "speec
 related: ["multi-language-dictation", "why-is-my-dictation-inaccurate"]
 updated: 2026-08-05
 ---
-**Keep Parakeet.** It is what you start with, it is the faster of the two, and it covers 25 European languages. Switch to WhisperKit only if you dictate in a language it does not cover.
+EnviousWispr is a free dictation app for macOS, and it can turn your speech into text using either of two engines, Parakeet or WhisperKit.
 
-Both run on your Mac. Neither sends your audio anywhere, and neither needs an internet connection once its model is downloaded.
+**Keep Parakeet.** It is what you start with, it is the faster of the two, and it covers 25 European languages. Switch to WhisperKit only if you dictate in a language Parakeet does not cover.
+
+Both engines run on your Mac. Neither sends your audio anywhere, and neither needs an internet connection once its model has been downloaded.
 
 ### The difference
 
 |  | Parakeet | WhisperKit |
 |---|---|---|
-| Languages | 25 European | Over 90 |
+| Languages | 25 European | 99 |
 | Speed | Faster | Slower |
 | Setup | Downloaded for you during setup | You download it, about 1.5 GB |
 | Best for | Everyday dictation | Languages Parakeet does not cover |
 
 ### Switching
 
-1. Open Settings and go to **Transcription**.
+1. Click the EnviousWispr icon in your menu bar, choose **Settings**, and go to **Transcription**.
 2. Pick your engine.
 3. The first time you choose WhisperKit, click **Download WhisperKit Model**. It does not download on its own.
 
@@ -31,8 +33,8 @@ The change applies to your next recording.
 
 ### What happens when you dictate
 
-1. The app takes the audio it recorded.
-2. It trims the silence at the start and end.
+1. EnviousWispr takes the audio it recorded.
+2. It trims the silence at the start and the end.
 3. Your engine reads it and writes out the text.
 4. Any clean-up you have switched on runs, then the text is pasted.
 

--- a/website/src/content/help/choosing-an-ai-provider-none-apple-intelligence-ollama-openai-gemini.md
+++ b/website/src/content/help/choosing-an-ai-provider-none-apple-intelligence-ollama-openai-gemini.md
@@ -1,5 +1,5 @@
 ---
-title: "Choosing an AI Provider (None, Apple Intelligence, Ollama, OpenAI, Gemini)"
+title: "Choosing an AI Provider"
 description: "The AI Polish options, what each one costs, and which ones keep your text on your Mac."
 category: "ai-polish"
 section: "Polish"
@@ -8,17 +8,17 @@ keywords: ["turn off ai", "turn ai off", "disable ai", "no ai", "provider", "ope
 related: ["ai-polish-and-cloud-data", "api-key-security"]
 updated: 2026-08-05
 ---
-Open Settings and go to **AI Polish**. These are your choices.
+EnviousWispr is a free dictation app for macOS. AI Polish is the step that tidies up your dictation, and you choose which AI does it. Go to **Settings** \> **AI Polish** to make the choice. These are your options.
 
 ### Stays on your Mac
 
-- **Apple Intelligence.** Free, nothing to set up. Needs macOS 26 or later on a Mac that supports it. This is what you start with.
-- **EG-1.** Our own model, built for dictation. Free. Download it from the AI Polish page, about 2.9 GB once.
-- **None.** No AI step. You still get filler-word removal and your custom words.
+- **Apple Intelligence.** Free, with nothing to set up. Needs macOS 26 or later on a Mac that supports it. This is what you start with.
+- **EG-1.** The model EnviousWispr built for dictation. Free. Download it from the AI Polish page, about 2.9 GB once.
+- **None.** No AI step at all. You still get filler-word removal and your custom words.
 
 ### Your own setup
 
-- **Ollama.** Runs a model you choose. Free for models on your Mac. You install Ollama yourself. Ollama offers models that run on your Mac and models that run on Ollama's servers. EnviousWispr lists the hosted ones separately and never picks one for you.
+- **Ollama.** Runs a model you choose, and you install Ollama yourself. Models you download to your Mac are free and keep your text on the machine. Ollama also offers models that run on its own servers, which EnviousWispr lists separately and never picks for you.
 
 ### Uses a company's service
 
@@ -42,4 +42,4 @@ With OpenAI and Gemini, EnviousWispr also asks them not to keep a copy of the re
 | Gemini | To Google | You pay Google | An API key |
 | Claude | To Anthropic | You pay Anthropic | An API key |
 
-Not sure? Leave it on Apple Intelligence. If your Mac cannot run it, try EG-1.
+Not sure? Leave it on Apple Intelligence. If your Mac cannot run that, try EG-1.

--- a/website/src/content/help/choosing-your-microphone.md
+++ b/website/src/content/help/choosing-your-microphone.md
@@ -8,17 +8,17 @@ keywords: ["microphone", "mic", "input device", "which microphone", "headset", "
 related: ["bluetooth-and-airpods", "empty-or-missing-transcription"]
 updated: 2026-08-05
 ---
-Open Settings and go to **Microphone**.
+EnviousWispr is a free dictation app for macOS. It can follow whichever microphone your Mac is set to, or use one you name yourself. Both choices live under **Settings** \> **Microphone**.
 
 ### Auto
 
-EnviousWispr records from whatever input your Mac is currently set to, and follows it when devices come and go. This is what you start with and it suits most setups.
+EnviousWispr records from whatever input your Mac is currently set to, and follows it as devices come and go. This is what you start with, and it suits most setups.
 
 To change what Auto follows, set your input in **System Settings** \> **Sound**.
 
 ### Choosing one yourself
 
-Pick a device from the list and EnviousWispr always uses it, whatever your Mac is set to. Worth doing if you keep ending up on the wrong microphone.
+Pick a device from the list and EnviousWispr always uses that one, whatever your Mac is set to. This is worth doing if you keep ending up on the wrong microphone. The picker shows the device name in place of Auto once you have chosen.
 
 ### If your microphone is unplugged mid-recording
 

--- a/website/src/content/help/clipboard-preservation.md
+++ b/website/src/content/help/clipboard-preservation.md
@@ -8,11 +8,11 @@ keywords: ["clipboard", "copied text", "lost what i copied", "overwrites clipboa
 related: ["how-text-gets-pasted-into-your-app"]
 updated: 2026-08-05
 ---
-Some ways of pasting have to use your clipboard. EnviousWispr saves what was there first and puts it back afterwards.
+EnviousWispr is a free dictation app for macOS. Some of the ways it delivers your text have to use your clipboard, so it saves whatever was there first and puts it back afterwards.
 
 ### How it works
 
-1. Your clipboard is saved, everything on it, not just plain text.
+1. Your clipboard is saved, everything on it, not only plain text.
 2. Your dictation is pasted.
 3. Your original clipboard comes back.
 
@@ -20,11 +20,11 @@ Some ways of pasting have to use your clipboard. EnviousWispr saves what was the
 
 - If your text went straight into the box, the clipboard was never touched.
 - If another app, such as a clipboard manager, changed the clipboard in between, EnviousWispr does not overwrite it.
-- If pasting failed and your dictation ended up on the clipboard, it stays there so you can paste it.
+- If pasting failed and your dictation ended up on the clipboard, it stays there so you can paste it yourself.
 
 ### The two settings
 
-Both are under **Clipboard** in Settings, and both are on out of the box.
+Both live under **Settings** \> **Clipboard**, and both are on out of the box.
 
 - **Restore clipboard after paste.** Puts back what you had copied. Switch it off if you would rather keep your dictation on the clipboard to paste again somewhere else.
-- **Auto-copy to clipboard.** Copies your dictation when EnviousWispr is not pasting it into an app for you.
+- **Auto-copy to clipboard.** Copies your dictation whenever EnviousWispr is not pasting it into an app for you.

--- a/website/src/content/help/customizing-your-hotkey.md
+++ b/website/src/content/help/customizing-your-hotkey.md
@@ -7,25 +7,29 @@ order: 4
 keywords: ["hotkey", "shortcut", "keyboard shortcut", "change the key", "how do i change the key", "key combo", "keybinding", "remap", "different key", "fn key", "caps lock", "conflicts with another app"]
 updated: 2026-08-05
 ---
-1. Open Settings and go to **Shortcuts**.
+EnviousWispr is a free dictation app for macOS. Your hotkey is the key you hold or press to record, and you can change it to whatever suits your hands. It arrives set to the right Option key.
+
+### Changing it
+
+1. Click the EnviousWispr icon in your menu bar, choose **Settings**, and go to **Shortcuts**.
 2. Click the **Recording hotkey** box.
 3. Press the keys you want.
 
-It saves straight away.
+The new combination is saved straight away and shown in the box. Try it in any text field to confirm.
 
 ### What you can use
 
 - Any key, with or without Command, Option, Control or Shift.
-- A modifier key on its own, such as just Option or just Control. Handy, because you never have to reach for it.
+- A modifier key on its own, such as Option by itself or Control by itself. This is worth considering, because your hand never has to leave the keys it already rests on.
 
 ### One key for both modes
 
-The recording hotkey is the same whether you use push-to-talk or toggle mode. Switching mode changes what a press does, never which key to press.
+The recording hotkey is the same whether you use push to talk or toggle mode. Switching mode changes what a press does, never which key you press.
 
 ### The cancel key
 
-Escape discards a recording. You can change it on the same page.
+Escape throws a recording away. You can change it on the same **Shortcuts** page.
 
 ### If your hotkey stops working
 
-Something else is probably using the same combination. macOS shortcuts and other apps take priority. Pick a different one.
+Something else is probably using the same combination. macOS shortcuts and other apps take priority over EnviousWispr. Pick a different combination.

--- a/website/src/content/help/download-and-install.md
+++ b/website/src/content/help/download-and-install.md
@@ -9,20 +9,24 @@ related: ["system-requirements", "granting-permissions-microphone-accessibility-
 seeAlso: "getting-started-enviouswispr-under-2-minutes"
 updated: 2026-08-05
 ---
-1. Download EnviousWispr from [enviouswispr.com](https://enviouswispr.com).
-2. Open the downloaded file and drag EnviousWispr into your Applications folder.
-3. Open it from Applications.
+EnviousWispr is a free dictation app for macOS. Installing it takes about two minutes, and there is nothing to sign up for.
+
+### Install it
+
+1. Download EnviousWispr from [enviouswispr.com](https://enviouswispr.com). What arrives is a disk image file ending in .dmg.
+2. Open the downloaded file. A window appears with the EnviousWispr icon in it. Drag that icon onto the Applications folder shown beside it.
+3. Open EnviousWispr from your Applications folder.
 
 ### The first time you open it
 
 macOS may ask you to confirm, because you downloaded the app from the internet. Click **Open**.
 
-EnviousWispr then walks you through setup: choosing a speech engine, setting your hotkey, and granting permissions.
+EnviousWispr then walks you through setup: choosing a speech engine, picking the hotkey you will hold down to dictate, and granting the macOS permissions it needs.
 
-### Where to find it afterwards
+### How you know it worked
 
-Look for the icon in your menu bar, at the top of the screen. There is no Dock icon.
+Look at the top right of your screen. The EnviousWispr icon sits in your menu bar, and clicking it is how you reach settings and history from now on. There is no Dock icon and no window left open.
 
 ### Updates
 
-EnviousWispr checks for updates on its own and tells you when one is ready.
+EnviousWispr checks for updates on its own and tells you when one is ready. You never need to download the app again by hand.

--- a/website/src/content/help/empty-or-missing-transcription.md
+++ b/website/src/content/help/empty-or-missing-transcription.md
@@ -8,27 +8,27 @@ keywords: ["nothing happens", "no text", "empty", "microphone not working", "mic
 related: ["choosing-your-microphone", "granting-permissions-microphone-accessibility-and-automation"]
 updated: 2026-08-05
 ---
-Work through these in order.
+EnviousWispr is a free dictation app for macOS. When a recording finishes and no text appears, something between your microphone and the speech model did not deliver. Work through these in order.
 
 ### 1. Is the app hearing you?
 
-Watch the recording bar on screen while you talk. Its meter moves with your voice. If it stays flat while you speak, the microphone is not reaching the app, and steps 2 to 4 are where to look.
+Watch the recording bar on screen while you talk. Its meter moves with your voice. If the meter stays flat while you speak, your microphone is not reaching the app, and steps 2 to 4 are where to look.
 
 ### 2. Check the microphone permission
 
-**System Settings** \> **Privacy & Security** \> **Microphone**. EnviousWispr should be listed and switched on.
+Open **System Settings** \> **Privacy & Security** \> **Microphone**. EnviousWispr should be in the list with its switch on. If it is not in the list at all, it has never been asked. Record once and macOS will prompt you.
 
 ### 3. Check for a hardware mute
 
-Many headsets have a mute switch or a mute button on the cable. A muted microphone still records, just silence.
+Check the microphone itself, the cable, and any switch on a desk stand. Many headsets have a mute switch on the earcup or a button partway down the cable. A muted microphone still records. It records silence.
 
 ### 4. Check the right microphone is selected
 
-Open Settings and go to **Microphone**. On Auto, EnviousWispr records from whatever input your Mac is set to, which may not be the one you are speaking into. Pick a device from the list to be sure.
+Open EnviousWispr's settings and go to **Microphone**. On Auto, EnviousWispr records from whatever input your Mac is set to, which may not be the one you are speaking into. Pick a device from the list to be sure.
 
 ### 5. Is the speech model ready?
 
-The first launch downloads it. Until that finishes there is nothing to transcribe. Progress is shown on screen.
+The first launch downloads it, and until that download finishes there is nothing to transcribe with. Progress is shown on screen.
 
 ### 6. Was the recording very short?
 
@@ -36,4 +36,4 @@ A recording of well under a second may not give the model enough to work with. H
 
 ### 7. Were you quiet, or far from the microphone?
 
-Speaking softly or across the room is a common cause of a silent-looking recording. Move closer, or use a headset microphone.
+Speaking softly or from across the room is a common reason a recording comes back looking silent. Move closer, or use a headset microphone.

--- a/website/src/content/help/extended-thinking-reasoning-mode.md
+++ b/website/src/content/help/extended-thinking-reasoning-mode.md
@@ -7,16 +7,16 @@ order: 4
 keywords: ["thinking", "reasoning", "extended thinking", "slow", "takes too long", "quality vs speed"]
 updated: 2026-08-05
 ---
-Deep reasoning lets the AI spend longer on your text before rewriting it. It can help when your instructions are complicated.
+EnviousWispr is a free dictation app for macOS. Deep reasoning is a setting that gives the AI more time to work on your text before it rewrites it. That extra time can help when what you are asking for is complicated.
 
 ### Turning it on
 
-Open Settings, go to **AI Polish**, and switch on **Deep reasoning**. The switch only appears when the option and model you have chosen support it.
+Go to **Settings** \> **AI Polish** and switch on **Deep reasoning**. The switch only appears when the option and model you have chosen support it, so if you cannot find it, that is why.
 
 ### Which options support it
 
-Some OpenAI and Gemini models. Apple Intelligence, EG-1, Ollama and Claude do not.
+Some OpenAI and Gemini models. Apple Intelligence, EG-1, Ollama and Claude do not support it.
 
 ### The trade-off
 
-It takes longer, on every dictation. Leave it off for ordinary use and try it when a complicated request is not coming out right.
+It takes longer on every dictation, not only the complicated ones. Leave it off for ordinary use, and turn it on when a complicated request is not coming out right.

--- a/website/src/content/help/filler-word-removal.md
+++ b/website/src/content/help/filler-word-removal.md
@@ -7,15 +7,15 @@ order: 2
 keywords: ["um", "uh", "filler", "filler words", "remove um", "you know", "like", "stop words", "cleaner speech"]
 updated: 2026-08-05
 ---
-EnviousWispr strips "um", "uh", "hmm", "er" and similar noises out of your text. It is on out of the box.
+EnviousWispr is a free dictation app for macOS. It strips "um", "uh", "hmm", "er" and similar noises out of your text before you ever see them. This is on out of the box.
 
 ### Turning it off
 
-Open Settings, go to **Transcription**, and switch off **Remove filler words**.
+Go to **Settings** \> **Transcription** and switch off **Remove filler words**. Your next dictation will keep the noises in.
 
 ### It does not need AI
 
-This runs on your Mac with no model involved, so it works with AI Polish switched off and with no internet connection.
+This runs on your Mac with no AI model involved. It works when AI Polish is switched off, and it works with no internet connection.
 
 ### What it leaves alone
 
@@ -23,4 +23,4 @@ It only removes those noises when they stand on their own as words. The "um" ins
 
 ### If you want more than this
 
-AI Polish also removes hesitations, false starts and repeated words, which a simple list cannot catch.
+AI Polish also removes hesitations, false starts and repeated words, which a fixed list of noises cannot catch.

--- a/website/src/content/help/first-word-gets-cut-off.md
+++ b/website/src/content/help/first-word-gets-cut-off.md
@@ -9,7 +9,7 @@ updated: 2026-08-05
 ---
 EnviousWispr is a free dictation app for macOS. When the start of your speech goes missing, it is because the microphone was still waking up as you began to talk.
 
-While the microphone is still awake from a recent dictation, EnviousWispr keeps the half second of audio from just before you pressed the key, so an early start is captured anyway. On a cold start there is no earlier audio to keep, and the first word or two can be lost.
+While the microphone is still awake from a recent dictation, EnviousWispr keeps the half second of audio from immediately before you pressed the key, so an early start is captured anyway. On a cold start there is no earlier audio to keep, and the first word or two can be lost.
 
 ### Keep the microphone awake for longer
 

--- a/website/src/content/help/first-word-gets-cut-off.md
+++ b/website/src/content/help/first-word-gets-cut-off.md
@@ -7,15 +7,17 @@ order: 4
 keywords: ["first word", "cut off", "clipped", "missing the beginning", "loses the start", "chops the first word", "beginning missing"]
 updated: 2026-08-05
 ---
-While the microphone is still awake from a recent dictation, EnviousWispr keeps the half second of audio before you press the key, so the start of your speech is captured even if you begin talking early. On a cold start there is no earlier audio to keep.
+EnviousWispr is a free dictation app for macOS. When the start of your speech goes missing, it is because the microphone was still waking up as you began to talk.
 
-### Keeping the microphone awake for longer
+While the microphone is still awake from a recent dictation, EnviousWispr keeps the half second of audio from just before you pressed the key, so an early start is captured anyway. On a cold start there is no earlier audio to keep, and the first word or two can be lost.
 
-Open Settings, go to **Microphone**, and look at **Microphone Readiness**:
+### Keep the microphone awake for longer
+
+Open EnviousWispr's settings, go to **Microphone**, and find **Microphone Readiness**:
 
 - **Off.** The microphone shuts down straight away. Lowest power use, slowest start, and no earlier audio kept.
-- **10 sec, 30 sec, 60 sec.** Stays ready for that long. It starts at 30 seconds.
-- **Always.** Keeps the microphone ready. The macOS microphone indicator may stay visible, and power use may increase.
+- **10 sec, 30 sec, 60 sec.** Stays ready for that long after each dictation. It arrives set to 30 seconds.
+- **Always.** Keeps the microphone ready all the time. The macOS microphone indicator may stay visible, and power use may go up.
 
 ### When a word can still go missing
 
@@ -27,4 +29,6 @@ Open Settings, go to **Microphone**, and look at **Microphone Readiness**:
 
 - Pause for a beat after pressing the key, before you speak.
 - Set Microphone Readiness to **60 sec** or **Always**.
-- Use push-to-talk. Holding the key starts waking the microphone before you speak.
+- Use push-to-talk. Holding the key down starts waking the microphone while you are still drawing breath.
+
+You will know it is fixed when your next few dictations open with the word you meant to say.

--- a/website/src/content/help/granting-permissions-microphone-accessibility-and-automation.md
+++ b/website/src/content/help/granting-permissions-microphone-accessibility-and-automation.md
@@ -8,30 +8,34 @@ keywords: ["permissions", "permission", "allow", "access", "microphone access", 
 related: ["accessibility-permission-not-working", "paste-not-working"]
 updated: 2026-08-05
 ---
-EnviousWispr needs two permissions, and a third only in rare cases. The **Permissions** page in Settings always shows where you stand.
+EnviousWispr is a free dictation app for macOS. Because it listens to your microphone and types into other apps, macOS makes you grant it permission first. Two permissions are needed, and a third only in rare cases. The **Permissions** page in EnviousWispr's settings always shows where each one stands.
 
 ### Microphone
 
-Needed to hear you. macOS asks the first time you record.
+This one lets EnviousWispr hear you while you dictate.
 
-If you missed the prompt, open **System Settings** \> **Privacy & Security** \> **Microphone** and switch EnviousWispr on.
+macOS asks the first time you record. If you missed the prompt, open **System Settings** \> **Privacy & Security** \> **Microphone** and switch EnviousWispr on.
+
+You will know it worked when you hold your hotkey and the meter on the recording bar moves as you speak.
 
 ### Accessibility
 
-Needed to put the text into your app for you.
+This one lets EnviousWispr put the finished text into your app for you.
 
 Open **System Settings** \> **Privacy & Security** \> **Accessibility**, click **+**, and add EnviousWispr from your Applications folder.
 
-Without it, dictation still works. EnviousWispr copies your text to the clipboard instead and tells you, so you can paste it with Cmd+V.
+You will know it worked when your next dictation lands in the text box on its own.
+
+Without this permission, dictation still works. EnviousWispr copies your text to the clipboard instead and tells you it has done so, and you paste it yourself with Cmd+V.
 
 ### Automation
 
-Asked for only if the usual ways of pasting do not work in a particular app. macOS asks whether EnviousWispr can control "System Events". Click **OK**.
+This one is a fallback, asked for only when the usual ways of pasting fail in a particular app.
 
-To change it later, open **System Settings** \> **Privacy & Security** \> **Automation**.
+macOS asks whether EnviousWispr can control "System Events". Click **OK**. To change your answer later, open **System Settings** \> **Privacy & Security** \> **Automation**.
 
 Declining is fine. Most apps never need it.
 
 ### Your hotkey needs no permission
 
-The recording hotkey works everywhere on its own. These permissions are only about hearing you and delivering the text.
+The key you hold to record works everywhere on its own. These permissions are only about hearing you and delivering the text.

--- a/website/src/content/help/hallucination-protection.md
+++ b/website/src/content/help/hallucination-protection.md
@@ -8,7 +8,7 @@ keywords: ["hallucination", "made up words", "invented text", "wrong words added
 related: ["why-is-my-dictation-inaccurate"]
 updated: 2026-08-05
 ---
-AI models sometimes make things up. EnviousWispr checks the result before it reaches you and rejects the clear failures.
+EnviousWispr is a free dictation app for macOS. It can hand your dictation to an AI to tidy up, and AI models sometimes make things up. EnviousWispr checks the result before it reaches you and throws out the clear failures.
 
 ### What it checks
 
@@ -18,10 +18,10 @@ AI models sometimes make things up. EnviousWispr checks the result before it rea
 - **Chatter.** Openers like "Certainly!" are stripped rather than pasted.
 - **Very short dictations.** These skip AI Polish entirely and keep the earlier clean-up result.
 
-Apple Intelligence also checks longer non-English results for a switch of language.
+Apple Intelligence also checks longer results in other languages in case the AI switched language on you.
 
 ### What you get when a check rejects the result
 
-The tidied-up version of your dictation from just before the AI step. You never lose what you said because polish went wrong.
+The tidied-up version of your dictation from immediately before the AI step. You never lose what you said if the polish goes wrong.
 
 These checks catch the obvious failures, not every bad edit. Read anything important before you send it.

--- a/website/src/content/help/hands-free-mode-long-dictation.md
+++ b/website/src/content/help/hands-free-mode-long-dictation.md
@@ -8,7 +8,7 @@ keywords: ["hands free", "handsfree", "long dictation", "dont want to hold", "wi
 related: ["voice-activity-detection-and-auto-stop", "recording-won-t-stop-or-seems-stuck"]
 updated: 2026-08-05
 ---
-Hands-free lets you keep talking without holding the key down. Use it for anything longer than a sentence or two.
+EnviousWispr is a free dictation app for macOS. Hands-free mode locks recording on, so you can keep talking without holding a key down. It is worth using for anything longer than a sentence or two: a blog post, a long email, notes after a meeting.
 
 ### Turning it on
 
@@ -16,7 +16,9 @@ Hands-free lets you keep talking without holding the key down. Use it for anythi
 2. Press it again within half a second.
 3. Let go. Recording keeps going.
 
-The bar on screen grows to confirm recording is locked on. If nothing locks, you were too slow; tap and press again a little quicker.
+The bar on screen grows to confirm that recording is locked on. If nothing locks, you were too slow. Tap and press again a little quicker.
+
+Hands-free works with push to talk, so you can use it whenever that recording mode is selected.
 
 ### Stopping
 
@@ -25,8 +27,8 @@ The bar on screen grows to confirm recording is locked on. If nothing locks, you
 
 ### How long you can talk
 
-Up to an hour. You get a warning a minute before, then the app stops on its own and writes out what you said.
+Up to an hour. You get a warning a minute before the limit, then EnviousWispr stops on its own and writes out what you said.
 
 ### Stopping automatically when you go quiet
 
-You can have recording end by itself after a pause. Open Settings, go to **Transcription**, and switch on **Stop recording on silence**. It is off unless you turn it on. The slider under it sets how long a pause has to be.
+You can have recording end by itself after a pause. Open EnviousWispr's settings, go to **Transcription**, and switch on **Stop recording on silence**. It is off unless you turn it on. The slider under it sets how long a pause has to be, from half a second to three seconds.

--- a/website/src/content/help/how-custom-word-correction-works.md
+++ b/website/src/content/help/how-custom-word-correction-works.md
@@ -8,7 +8,7 @@ keywords: ["how correction works", "why didnt my word work", "fuzzy match", "sou
 related: ["adding-custom-words"]
 updated: 2026-08-05
 ---
-You add the spelling you want. EnviousWispr then recognises the many ways it can come out wrong, and fixes them.
+EnviousWispr is a free dictation app for macOS. When you teach it a custom word, you give it one spelling, and it then recognises the many ways that word can come out wrong and corrects them for you.
 
 ### Three kinds of mistake it catches
 
@@ -18,10 +18,10 @@ You add the spelling you want. EnviousWispr then recognises the many ways it can
 
 ### It happens first
 
-Your words are corrected before anything else touches the text, so they are already right by the time filler removal and AI Polish see it.
+Your words are corrected before anything else touches the text, so they are already right by the time filler removal and AI Polish see them.
 
 ### If a word is not being caught
 
-- Check the spelling you saved is exactly what you want to see.
-- Say it as you normally would, then look in **History** to see what the app actually heard. That tells you what to add.
-- Very short words are harder to match safely, because doing so would change words you did not mean.
+- Check that the spelling you saved is exactly what you want to see.
+- Say the word as you normally would, then look in **History** to see what EnviousWispr actually heard. That tells you which version to add.
+- Very short words are harder to match safely, because matching them would change words you did not mean.

--- a/website/src/content/help/how-smart-polish-works-context-aware.md
+++ b/website/src/content/help/how-smart-polish-works-context-aware.md
@@ -7,16 +7,16 @@ order: 3
 keywords: ["smart polish", "context", "context aware", "knows what app", "different apps", "tone", "formal", "casual"]
 updated: 2026-08-05
 ---
-EnviousWispr can tell the AI a few things about your dictation, so it makes better corrections than it could from the words alone.
+EnviousWispr is a free dictation app for macOS. When it hands your dictation to an AI to tidy up, it can pass along a few facts about that dictation, so the corrections are better than they would be from the words alone.
 
 ### What it can pass along
 
-- **That this is speech, not typing.** So it looks for words that sound alike but are wrong, such as "their" for "there".
+- **That this is speech, not typing.** So the AI looks for words that sound alike but are wrong, such as "their" for "there".
 - **Which language you spoke.** So you get corrected, not translated.
 - **Which app you are dictating into.** A Slack message and a code comment should not be tidied up the same way.
 - **Your custom words.** So your spellings survive the rewrite.
 
-Short dictations come with an instruction to leave well alone.
+Short dictations are sent with an instruction to leave well alone.
 
 ### How much is sent depends on the option
 

--- a/website/src/content/help/how-text-gets-pasted-into-your-app.md
+++ b/website/src/content/help/how-text-gets-pasted-into-your-app.md
@@ -8,25 +8,25 @@ keywords: ["paste", "how does it type", "where does the text go", "delivery", "s
 related: ["clipboard-preservation", "paste-not-working"]
 updated: 2026-08-05
 ---
-EnviousWispr remembers the app and text field that were focused when you started recording, and delivers your text there. It works anywhere you can type: native Mac apps, browsers, and apps built on web technology such as VS Code, Slack, Discord and Notion.
+EnviousWispr is a free dictation app for macOS. It remembers the app and text field that were focused when you started recording, and delivers your text there. It works anywhere you can type: native Mac apps, browsers, and apps built on web technology such as VS Code, Slack, Discord and Notion.
 
 ### It picks the destination at the start
 
-Not at the end. AI Polish can take a few seconds, and you may have clicked elsewhere. Locking it in at the start means your words land where you were talking. Keep that field open until the text arrives.
+Not at the end. AI Polish can take a few seconds, and by then you may have clicked elsewhere. Locking the destination in at the start means your words land where you were talking. Keep that field open until the text arrives.
 
 ### It tries the cleanest method first
 
-Writing straight into the text box, without touching your clipboard. Some apps will not accept that, so EnviousWispr falls back to a normal paste, and then to the app's own Edit \> Paste menu.
+The cleanest method is writing straight into the text box, without touching your clipboard. Some apps will not accept that, so EnviousWispr falls back to an ordinary paste, and then to the app's own Edit \> Paste menu.
 
-If none of that works, your text goes to your clipboard and you are told, so you can paste it yourself. You never lose a dictation to a failed paste.
+If none of those work, your text goes to your clipboard and EnviousWispr tells you, so you can paste it yourself. You never lose a dictation to a failed paste.
 
 ### Spacing and capitals
 
-EnviousWispr looks at the text either side of your cursor and matches it. Dictating into the middle of a sentence adds a space where one is needed and keeps the capital letter right, instead of jamming your words against what is already there.
+EnviousWispr looks at the text on either side of your cursor and matches it. Dictating into the middle of a sentence adds a space where one is needed and keeps the capital letter right, instead of jamming your words up against what is already there.
 
 Capitals are matched in English, German, French, Italian, Spanish, Portuguese, Dutch, Danish, Swedish, Finnish, Russian and Turkish. German is handled on its own terms, so nouns keep the capital they are supposed to have. In any other language EnviousWispr takes care of the spacing and leaves your capitals exactly as you said them.
 
-You can switch this off under **Clipboard** in Settings, where it is called **Smart insertion**.
+You can switch this off under **Settings** \> **Clipboard**, where it is called **Smart insertion**.
 
 ### Your clipboard
 

--- a/website/src/content/help/importing-and-exporting-custom-words.md
+++ b/website/src/content/help/importing-and-exporting-custom-words.md
@@ -8,7 +8,7 @@ keywords: ["import", "export", "backup my words", "csv", "move to a new mac", "t
 related: ["adding-custom-words"]
 updated: 2026-08-05
 ---
-Open Settings and go to **Your Words**.
+EnviousWispr is a free dictation app for macOS. Your custom words are the names and terms you have taught it, and you can move them to another Mac or bring them in from another dictation app. Everything on this page lives under **Settings** \> **Your Words**.
 
 ### Importing
 
@@ -16,7 +16,7 @@ Open Settings and go to **Your Words**.
 2. Choose to paste a list of words, open a file, or bring them in from another dictation app.
 3. Review what it found, then add them.
 
-A file can be one you exported from EnviousWispr, or a plain text list with one word per line. If you have Wispr Flow, FluidVoice or Superwhisper installed, EnviousWispr can read your words straight out of them.
+The file can be one you exported from EnviousWispr, or a plain text list with one word per line. If you have Wispr Flow, FluidVoice or Superwhisper installed, EnviousWispr can read your words straight out of them.
 
 Importing only adds. Words you already have are left alone.
 
@@ -25,7 +25,7 @@ Importing only adds. Words you already have are left alone.
 1. Click **Export your words**.
 2. Choose where to save the file.
 
-Keep the file as a backup, or import it on another Mac.
+Keep that file as a backup, or import it on another Mac.
 
 ### Removing several at once
 

--- a/website/src/content/help/is-enviouswispr-free.md
+++ b/website/src/content/help/is-enviouswispr-free.md
@@ -8,7 +8,7 @@ keywords: ["free", "is this free", "price", "cost", "pricing", "subscription", "
 related: ["source-code-and-contributing", "choosing-an-ai-provider-none-apple-intelligence-ollama-openai-gemini"]
 updated: 2026-08-05
 ---
-Yes. Everything, with no subscription, no trial and no account.
+EnviousWispr is a free dictation app for macOS, and free means all of it. There is no subscription, no trial period and no account to create.
 
 ### What you get
 
@@ -16,14 +16,14 @@ Yes. Everything, with no subscription, no trial and no account.
 - AI Polish, including options that run entirely on your Mac.
 - Every recording mode, and hotkeys you can set to anything.
 - Your own dictionary of custom words, plus ready-made vocabulary packs.
-- Unlimited dictation, and History with no limit.
+- Unlimited dictation, and a History with no limit on how much it keeps.
 
 ### The one thing that can cost money
 
 If you choose OpenAI, Gemini or Claude for AI Polish, you bring your own key and pay that company for what you use. EnviousWispr charges nothing either way.
 
-You never have to. Apple Intelligence, EG-1, and Ollama models on your Mac all polish for free. Ollama's hosted models run on Ollama's servers and some of them need a paid Ollama plan.
+You never have to go that route. Apple Intelligence, EG-1, and Ollama models you download to your Mac all polish for free. Ollama's hosted models run on Ollama's servers, and some of those need a paid Ollama plan.
 
 ### Why free
 
-We want EnviousWispr in as many hands as possible. It is also open source, so you can read it, build it, and keep using it whatever we do later.
+We want EnviousWispr in as many hands as possible. It is also open source, so you can read it, build it, and keep using it whatever Envious Labs does later.

--- a/website/src/content/help/live-transcription-streaming-asr.md
+++ b/website/src/content/help/live-transcription-streaming-asr.md
@@ -8,13 +8,13 @@ keywords: ["live", "live text", "see words as i speak", "real time", "realtime",
 seeAlso: "live-transcription-that-keeps-up-with-you"
 updated: 2026-08-05
 ---
-Normally EnviousWispr writes your text once you stop talking. Live transcription writes it while you are still speaking. It is off unless you turn it on.
+EnviousWispr is a free dictation app for macOS. It normally writes your text once you stop talking. Live transcription writes it while you are still speaking, and it is off unless you turn it on.
 
-**Leave it off on Parakeet. On WhisperKit, turn it on if you have picked a language and often dictate for more than a minute.**
+**Leave it off on Parakeet. On WhisperKit, turn it on if you have picked a language and you often dictate for more than a minute.**
 
 ### Turning it on
 
-Open Settings, go to **Transcription**, and switch on **Live transcription**. The question mark beside it shows what changes for the engine you are on.
+Go to **Settings** \> **Transcription** and switch on **Live transcription**. The question mark beside it explains what changes for the engine you are on.
 
 ### Why we say leave it off on Parakeet
 
@@ -26,7 +26,7 @@ Measured on 28 test recordings and a replay of 500 real dictations, against the 
 - Repeated or invented words went from 17 to 51.
 - About 1 dictation in 24 lost its final words.
 
-It also saves no time you would notice under a minute. It only gets ahead at around five minutes, which is where it makes the most mistakes.
+It also saves no time you would notice under a minute. It only gets ahead at around five minutes, which is exactly where it makes the most mistakes.
 
 ### Why WhisperKit is different
 

--- a/website/src/content/help/model-downloads-and-management.md
+++ b/website/src/content/help/model-downloads-and-management.md
@@ -8,25 +8,29 @@ keywords: ["download model", "model download", "stuck downloading", "how big", "
 related: ["uninstalling-enviouswispr"]
 updated: 2026-08-05
 ---
-Parakeet, the engine you start with, is downloaded for you during setup. You see the progress. It is about 480 MB.
+EnviousWispr is a free dictation app for macOS. It turns your speech into text using a model kept on your own Mac rather than on a server, so there is a download the first time and some disk space to manage afterwards.
 
-WhisperKit is not downloaded for you. If you switch to it, open Settings, go to **Transcription**, and click **Download WhisperKit Model**. It is about 1.5 GB.
+### The two downloads
+
+Parakeet, the engine you start with, is downloaded for you during setup, and you watch the progress as it goes. It is about 480 MB.
+
+WhisperKit is not downloaded for you. If you switch to it, go to **Settings** \> **Transcription** and click **Download WhisperKit Model**. It is about 1.5 GB.
 
 Each download is checked before it is used, so a broken or half-finished file is never loaded.
 
 ### If a download fails
 
-EnviousWispr retries some temporary network problems by itself. Anything else stops and offers you a button to try again.
+EnviousWispr retries some temporary network problems by itself. Anything else stops and gives you a button to try again.
 
 ### Freeing up memory
 
-The model stays in memory between dictations, so there is nothing to load next time. If you would rather have the memory back, open Settings, go to **Transcription**, and change **Unload model after**.
+The model stays in your Mac's memory between dictations so there is nothing to load next time. If you would rather have the memory back, go to **Settings** \> **Transcription** and change **Unload model after**.
 
-It starts on **Never**, so the model stays loaded. The other choices unload it after 2, 5, 10, 15 or 60 minutes of not being used, or right after every recording. Each one costs you a short wait next time.
+It arrives set to **Never**, so the model stays loaded. The other choices unload it after 2, 5, 10, 15 or 60 minutes of not being used, or straight after every recording. Each one costs you a short wait next time you dictate.
 
 ### Freeing up disk space
 
-For WhisperKit, open **Transcription** and use **Remove Model**. For EG-1, open **AI Polish** and use the remove button there. Ollama models are removed from the same AI Polish page.
+For WhisperKit, open **Transcription** and use **Remove Model**. For EG-1, the polish model EnviousWispr built, open **AI Polish** and use the remove button there. Ollama models are removed from that same AI Polish page.
 
 You can download any of them again later.
 

--- a/website/src/content/help/multi-language-dictation.md
+++ b/website/src/content/help/multi-language-dictation.md
@@ -8,18 +8,18 @@ keywords: ["language", "languages", "spanish", "french", "german", "hindi", "not
 related: ["choosing-a-speech-engine-parakeet-vs-whisperkit"]
 updated: 2026-08-05
 ---
-Most people need to do nothing. Parakeet, the engine you start with, handles 25 European languages automatically. There is no language to set.
+EnviousWispr is a free dictation app for macOS, and it is not English-only. Most people need to change nothing: Parakeet, the engine you start with, handles 25 European languages on its own, with no language to set.
 
 ### If your language is not one of those 25
 
-1. Open Settings and go to **Transcription**.
-2. Choose **WhisperKit**.
+1. Click the EnviousWispr icon in your menu bar, choose **Settings**, and go to **Transcription**.
+2. Choose **WhisperKit** and click **Download WhisperKit Model** if you have not already.
 3. Pick your language from the list, or leave it on auto-detect.
 
-WhisperKit covers over 90 languages.
+WhisperKit covers 99 languages. You will know it is working when your next dictation comes back in the language you spoke.
 
 ### Tips
 
-- On WhisperKit, picking your language is more accurate than leaving it on auto-detect.
-- Auto-detect is fine for one language at a time. It struggles when you switch language mid-sentence.
+- On WhisperKit, naming your language is more accurate than leaving it on auto-detect.
+- Auto-detect copes with one language at a time. It struggles when you switch language mid-sentence.
 - AI Polish will not translate you. Dictate in French and you get French back.

--- a/website/src/content/help/noise-suppression.md
+++ b/website/src/content/help/noise-suppression.md
@@ -7,7 +7,7 @@ order: 3
 keywords: ["noise", "background noise", "noisy room", "cafe", "fan", "noise cancelling", "suppression", "echo"]
 updated: 2026-08-05
 ---
-There is no noise suppression setting. EnviousWispr records your microphone as it is and lets the speech model deal with the audio.
+EnviousWispr is a free dictation app for macOS, and it has no noise suppression setting. It records your microphone as it is and lets the speech model handle the audio.
 
 ### Why it went
 
@@ -15,4 +15,4 @@ Processing the audio first hurt transcription accuracy more than it helped, and 
 
 ### If background noise is hurting your accuracy
 
-Move closer to your microphone, or try a headset microphone, and compare the two in **History**.
+Move closer to your microphone, or try a headset microphone. Dictate the same sentence both ways and compare the results in **History**.

--- a/website/src/content/help/numbers-dates-and-times.md
+++ b/website/src/content/help/numbers-dates-and-times.md
@@ -9,7 +9,7 @@ related: ["spoken-punctuation-and-emoji"]
 seeAlso: "spoken-text-formatting-dates-numbers-emails"
 updated: 2026-08-05
 ---
-EnviousWispr writes numbers, money, dates, times, phone numbers, email addresses and web addresses the way you would type them, not the way you said them. This is always on and there is nothing to set up.
+EnviousWispr is a free dictation app for macOS. It writes numbers, money, dates, times, phone numbers, email addresses and web addresses the way you would type them, not the way you said them. This is always on and there is nothing to set up.
 
 ### What you get
 
@@ -22,14 +22,14 @@ EnviousWispr writes numbers, money, dates, times, phone numbers, email addresses
 
 ### Small numbers stay as words
 
-Numbers below ten are written out and ten upwards use digits, which is standard style in most writing.
+Numbers below ten are written out, and ten upwards use digits. That is standard style in most writing.
 
 ### It happens before AI Polish
 
-So if polish is off or fails, your formatting is what gets pasted. A successful AI polish may still reword it.
+So if polish is switched off or fails, this formatting is what gets pasted. A successful AI polish may still reword it.
 
 ### Where it stops
 
-Some phrases are genuinely ambiguous. "Meet at one twenty" is a time and "paid one twenty" is money, and only the surrounding words say which. Those are left alone rather than guessed at.
+Some phrases are genuinely ambiguous. "Meet at one twenty" is a time and "paid one twenty" is money, and only the surrounding words say which. EnviousWispr leaves those alone rather than guessing.
 
-This works on English dictation. Other languages are left as spoken.
+This works on English dictation. Other languages are written as spoken.

--- a/website/src/content/help/ollama-polish-not-working.md
+++ b/website/src/content/help/ollama-polish-not-working.md
@@ -8,19 +8,26 @@ keywords: ["ollama not working", "ollama error", "cant connect to ollama", "olla
 related: ["using-ollama-for-fully-offline-ai-polish"]
 updated: 2026-08-05
 ---
-Almost always, Ollama is not running.
+EnviousWispr is a free dictation app for macOS. Ollama is one of the AI options it can use to tidy up what you dictated. When that step fails, it is nearly always because Ollama itself is not running.
 
 ### Work through these
 
 1. **Is Ollama installed?** Get it from [ollama.com](https://ollama.com).
 2. **Is it running?** Open the Ollama app, or run `ollama serve` in Terminal. It has to be running before you start recording.
-3. **Do you have a model?** Run `ollama list` in Terminal. If it is empty, run `ollama pull llama3.2`.
-4. **Is the right model selected?** Open Settings, go to **AI Polish**, and check the model picker.
+3. **Do you have a model?** Run `ollama list` in Terminal. If nothing comes back, run `ollama pull llama3.2`.
+4. **Is the right model selected?** Open EnviousWispr's settings, go to **AI Polish**, and check the model picker.
+
+### If you picked one of Ollama's hosted models
+
+Ollama offers models that run on its own servers as well as models you download to your Mac. Hosted models still go through the Ollama app, so everything above still applies, and two more things matter:
+
+- **You have to be signed in to Ollama.** Run `ollama signin` in Terminal. If you are not signed in, EnviousWispr says so after the first failed dictation.
+- **Some hosted models are paid.** If the one you picked needs a subscription you do not have, Ollama refuses the request. Choose a free model instead, or subscribe.
 
 ### If it is slow rather than broken
 
-A big model on a busy Mac can take longer than EnviousWispr waits, which is about fifteen seconds for a local model. Try a smaller one.
+A large model on a busy Mac can take longer than EnviousWispr waits, which is about fifteen seconds. Try a smaller model.
 
 ### What happens meanwhile
 
-You still get your dictation. It just arrives without the AI clean-up.
+You still get your dictation. It arrives without the AI clean-up, which is the only part that failed.

--- a/website/src/content/help/paste-not-working.md
+++ b/website/src/content/help/paste-not-working.md
@@ -8,26 +8,26 @@ keywords: ["paste not working", "wont paste", "nothing pastes", "text not appear
 related: ["accessibility-permission-not-working", "how-text-gets-pasted-into-your-app"]
 updated: 2026-08-05
 ---
-Work through these in order.
+EnviousWispr is a free dictation app for macOS. When your dictation does not appear in the app you were typing in, work through these in order.
 
 ### 1. Check Accessibility permission
 
-This is the cause most of the time. Open **System Settings** \> **Privacy & Security** \> **Accessibility**. EnviousWispr should be listed and switched on. Without it, nothing can be typed into your apps.
+This is the cause most of the time. Open **System Settings** \> **Privacy & Security** \> **Accessibility**. EnviousWispr should be listed with its switch on. Without this permission, nothing can be typed into your apps.
 
-If the switch already looks on, remove EnviousWispr with **-** and add it back.
+If the switch already looks on, remove EnviousWispr from the list with **-** and add it back with **+**.
 
 ### 2. Check your cursor was in a text box
 
-EnviousWispr sends the text where your cursor was when you **started** recording. Click into the box first, then press the hotkey.
+EnviousWispr sends the text to wherever your cursor was when you **started** recording. Click into the box first, then press your hotkey.
 
 ### 3. The text went to a different app
 
-Same reason. If you switched apps during the dictation, the text still goes to the one you started in. That is on purpose.
+Same reason. If you switched apps during the dictation, the text still goes to the one you started in. That is deliberate, so a slow AI polish cannot drop your words somewhere unexpected.
 
 ### 4. VS Code, Slack, Discord and similar
 
-These sometimes accept text and quietly ignore it. EnviousWispr checks for that and pastes a different way, so it should just work. If it does not, make sure the app is in front and your cursor is in the field before you record.
+These sometimes accept text and then quietly ignore it. EnviousWispr checks for that and delivers a different way, which handles most cases. If yours is not one of them, make sure the app is in front and your cursor is in the field before you record.
 
 ### 5. You were told the text is on your clipboard
 
-Every delivery method failed. Your dictation is safe. Press Cmd+V to paste it, then work through the checks above.
+That means every delivery method failed. Your dictation is safe. Press Cmd+V to paste it, then work through the checks above.

--- a/website/src/content/help/privacy-overview.md
+++ b/website/src/content/help/privacy-overview.md
@@ -9,18 +9,18 @@ related: ["what-data-is-collected", "ai-polish-and-cloud-data"]
 seeAlso: "on-device-vs-cloud-dictation-privacy"
 updated: 2026-08-05
 ---
-Your voice becomes text on your Mac. The audio never leaves it. There is no account and nothing to sign up for.
+EnviousWispr is a free dictation app for macOS. Your voice becomes text on your own Mac, and the audio never leaves it. There is no account and nothing to sign up for.
 
 ### What stays on your Mac
 
 - Recording, transcribing and pasting need no internet connection. Both speech engines run on your Mac.
-- Your transcripts are saved in your user folder. We never receive a copy.
-- You can read the code. EnviousWispr is open source, so every claim here can be checked.
+- Your transcripts are saved in your user folder. Envious Labs, the company that makes EnviousWispr, never receives a copy.
+- You can read the code. EnviousWispr is open source, so every claim on this page can be checked.
 
 ### When EnviousWispr uses the network
 
 - **Updates and downloads.** The app checks for new versions, and downloads the speech and AI models you choose.
-- **Anonymous usage and crash data.** On by default. It tells us which app and macOS versions were involved in a problem, never what you said. See [_What Data Is Collected_](/help/what-data-is-collected/).
-- **Cloud AI Polish, only if you choose it.** If you pick OpenAI, Gemini or Claude, your text goes to that company under your own key. Your audio never does. See [_AI Polish and Cloud Data_](/help/ai-polish-and-cloud-data/).
+- **Anonymous usage and crash data.** On by default. It reports which app and macOS versions were involved in a problem, never what you said. See [_What Data Is Collected_](/help/what-data-is-collected/).
+- **Cloud AI Polish, only if you choose it.** If you pick OpenAI, Gemini, Claude, or one of Ollama's hosted models, your text goes to that company under your own account with them. Your audio never does. See [_AI Polish and Cloud Data_](/help/ai-polish-and-cloud-data/).
 
-AI Polish sends none of your dictation anywhere when it runs on your Mac: Apple Intelligence, EG-1, or an Ollama model you have downloaded. Ollama's hosted models are the exception, because they run on Ollama's servers.
+The short version of AI Polish: your text stays on your Mac with Apple Intelligence, EG-1, or an Ollama model you downloaded. Your text goes to that company's servers with OpenAI, Gemini, Claude, or one of Ollama's hosted models. Ollama appears on both sides of that line, so check which kind of model you picked.

--- a/website/src/content/help/push-to-talk-mode.md
+++ b/website/src/content/help/push-to-talk-mode.md
@@ -8,22 +8,24 @@ keywords: ["push to talk", "hold to talk", "hold the key", "ptt", "press and hol
 related: ["customizing-your-hotkey"]
 updated: 2026-08-05
 ---
-Hold your hotkey, talk, let go. That is push to talk, and it is how EnviousWispr works out of the box.
+EnviousWispr is a free dictation app for macOS. Push to talk is its default recording mode. You hold your hotkey down for as long as you are speaking, and your words appear when you let go.
 
 ### Using it
 
-1. Hold your hotkey.
+1. Hold your hotkey down.
 2. Speak.
-3. Let go. Your text appears.
+3. Let go. Your text appears at the cursor.
+
+Recording stops the moment you release the key, so a cough or a passing conversation afterwards never reaches the transcript.
 
 ### For longer dictations
 
-If you do not want to keep holding the key, tap it quickly and then press it again within half a second. Recording stays on after you let go. See [_Hands-Free Mode (Long Dictation)_](/help/hands-free-mode-long-dictation/).
+If you would rather not keep holding the key, tap it and press it again within half a second. Recording stays on after you let go. See [_Hands-Free Mode (Long Dictation)_](/help/hands-free-mode-long-dictation/).
 
 ### Choosing it
 
-Open Settings, go to **Shortcuts**, and pick **Push-to-Talk**.
+Open EnviousWispr's settings, go to **Shortcuts**, and pick **Push to Talk** under **1. Choose recording mode**. The card you picked is marked as selected. You will know it took effect when holding the key starts a recording and releasing it ends one.
 
 ### Why it feels instant
 
-The moment you press the key, the app starts waking the microphone, before you speak. On Bluetooth headsets that is what stops the first word being lost.
+The moment you press the key, EnviousWispr starts waking the microphone, before you have said anything. That head start is what stops a Bluetooth headset cutting off your first word.

--- a/website/src/content/help/recording-won-t-stop-or-seems-stuck.md
+++ b/website/src/content/help/recording-won-t-stop-or-seems-stuck.md
@@ -9,18 +9,18 @@ related: ["canceling-a-recording"]
 seeAlso: "mac-dictation-keeps-stopping"
 updated: 2026-08-05
 ---
-Press **Escape**. That stops any recording in progress and throws it away, in every mode.
+EnviousWispr is a free dictation app for macOS. If a recording will not stop, press **Escape**. That ends any recording in progress and throws it away, in every recording mode. The bar on screen disappears, which is how you know it worked.
 
 ### Recording cannot run forever
 
-An hour is the limit. You get a warning a minute before, then the app stops on its own and writes out what you said.
+An hour is the limit. You get a warning a minute before, then EnviousWispr stops on its own and writes out what you said up to that point.
 
 ### Stopping automatically when you pause
 
-You can have recording end after a silence. Open Settings, go to **Transcription**, and switch on **Stop recording on silence**. It is off unless you turn it on. The slider sets how long a pause has to be, between half a second and three seconds.
+You can have a recording end after a silence. Open EnviousWispr's settings, go to **Transcription**, and switch on **Stop recording on silence**. It is off unless you turn it on. The slider next to it sets how long a pause has to be, anywhere from half a second to three seconds.
 
-A pause shorter than your setting is ignored. At the half-second setting, an ordinary pause for thought is enough to stop the recording.
+A pause shorter than your setting is ignored. At the half-second setting, an ordinary pause for thought is enough to end the recording.
 
 ### If it seems stuck after you stop talking
 
-It is transcribing and polishing, which takes a moment, especially on the first dictation after launching. Escape only cancels a recording, so it does nothing at this stage. Wait for the attempt to finish, then record again.
+Recording has already ended, and EnviousWispr is turning your speech into text and polishing it. That takes a moment, especially on the first dictation after opening the app. Escape only cancels a recording, so pressing it now does nothing. Wait for the attempt to finish, then record again.

--- a/website/src/content/help/sounds-and-appearance.md
+++ b/website/src/content/help/sounds-and-appearance.md
@@ -7,22 +7,22 @@ order: 5
 keywords: ["sound", "sounds", "beep", "chime", "mute the sound", "turn off sound", "appearance", "theme", "dark mode", "pill", "overlay", "bar position", "move the bar", "menu bar icon"]
 updated: 2026-08-05
 ---
-A few settings change how EnviousWispr looks and sounds. None of them affect what you dictate.
+EnviousWispr is a free dictation app for macOS. A few of its settings change how it looks and sounds, and none of them affect what you dictate.
 
 ### Light or dark
 
-Open Settings and go to **Appearance**. EnviousWispr follows your macOS setting unless you pick Light or Dark yourself.
+Go to **Settings** \> **Appearance**. EnviousWispr follows your macOS setting unless you pick Light or Dark yourself.
 
 ### Where the recording bar appears
 
 On the same page, **Recording Indicator Position** puts the bar at the top or the bottom of your screen.
 
-You can also drag the bar somewhere else while it is on screen. That lasts for the current dictation; the next one goes back to the position you chose in Settings.
+You can also drag the bar somewhere else while it is on screen. That lasts for the current dictation only. The next one goes back to the position you chose in Settings.
 
 ### Recording sounds
 
-Open Settings and go to **Sounds**, then switch on **Play recording sounds** to hear a short sound when recording starts and stops. It is off out of the box.
+Go to **Settings** \> **Sounds** and switch on **Play recording sounds** to hear a short sound when recording starts and stops. It is off out of the box.
 
 There are several sound pairings and a preview button, so you can hear each one before choosing.
 
-Worth turning on if you dictate without looking at the screen, or if you are ever unsure whether the app is listening.
+This is worth turning on if you dictate without looking at the screen, or if you are ever unsure whether EnviousWispr is listening.

--- a/website/src/content/help/source-code-and-contributing.md
+++ b/website/src/content/help/source-code-and-contributing.md
@@ -7,7 +7,7 @@ order: 2
 keywords: ["source code", "github", "open source", "license", "gpl", "contribute", "pull request", "build it myself", "repo"]
 updated: 2026-08-05
 ---
-EnviousWispr is open source. The whole app is at [github.com/saurabhav88/EnviousWispr](https://github.com/saurabhav88/EnviousWispr), so every privacy claim we make can be checked against the code.
+EnviousWispr is a free dictation app for macOS, and it is open source. The whole app is at [github.com/saurabhav88/EnviousWispr](https://github.com/saurabhav88/EnviousWispr), so every privacy claim on this site can be checked against the code that makes it.
 
 ### The license
 
@@ -21,7 +21,7 @@ GNU General Public License v3. In short:
 
 - Report a bug or ask for a feature on GitHub Issues.
 - Send a pull request.
-- Read the code and tell us if we have got something wrong.
+- Read the code and say so if something we claim does not match what it does.
 
 ### Building it yourself
 

--- a/website/src/content/help/spoken-punctuation-and-emoji.md
+++ b/website/src/content/help/spoken-punctuation-and-emoji.md
@@ -9,7 +9,7 @@ related: ["numbers-dates-and-times"]
 seeAlso: "speak-emoji-dictation"
 updated: 2026-08-05
 ---
-Two settings let you say something out loud and get a symbol. Both are under **Transcription** in Settings.
+EnviousWispr is a free dictation app for macOS. Two of its settings let you say something out loud and get a symbol instead of the words. Both live under **Settings** \> **Transcription**.
 
 ### Spoken emoji, on out of the box
 
@@ -21,7 +21,7 @@ The setting is **Convert spoken emoji**.
 
 ### Spoken punctuation, off out of the box
 
-Say "comma" and you get a comma. Worth understanding before you switch it on.
+Say "comma" and you get a comma. This one is worth understanding before you switch it on.
 
 | Say this | You get |
 |---|---|
@@ -38,4 +38,4 @@ Say "comma" and you get a comma. Worth understanding before you switch it on.
 
 **Why it is off.** EnviousWispr already punctuates for you, so this competes with it. It also cannot tell when you meant the word: say "the grace period expires" and you get a full stop in the middle of your sentence.
 
-Turn it on if you need exact control of punctuation and do not mind fixing the occasional sentence. The setting is **Convert spoken punctuation**.
+Turn it on if you need exact control over punctuation and do not mind fixing the occasional sentence. The setting is **Convert spoken punctuation**.

--- a/website/src/content/help/system-requirements.md
+++ b/website/src/content/help/system-requirements.md
@@ -7,17 +7,20 @@ order: 2
 keywords: ["requirements", "supported macs", "will it run", "intel", "apple silicon", "m1", "m2", "m3", "m4", "macos version", "sonoma", "sequoia", "compatible", "does it work on my mac", "old mac"]
 updated: 2026-08-05
 ---
-A Mac with Apple Silicon (M1 or later) running macOS 14 Sonoma or later. Intel Macs are not supported.
+EnviousWispr is a free dictation app for macOS. It runs on any Mac with Apple Silicon (M1 or later) running macOS 14 Sonoma or later. Intel Macs are not supported.
 
-### Also worth knowing
+### What you need
 
-- **Microphone.** The built-in one is fine. External mics, AirPods and Bluetooth headsets all work.
-- **Disk space.** The app is small. It downloads a speech model the first time you run it.
+- **A Mac with Apple Silicon.** M1, M2, M3, M4, or newer. To check yours, open the Apple menu and choose About This Mac. If the Chip line starts with "Apple", you are set.
+- **macOS 14 Sonoma or later.** The same About This Mac window shows your version.
+- **A microphone.** The one built into your Mac is fine. External mics, AirPods and Bluetooth headsets all work.
+- **A little disk space.** The app itself is small. It downloads a speech model the first time you run it.
 
-### Only needed for some options
+### Extra requirements for AI polish
 
-- **Apple Intelligence polish** needs macOS 26 or later, on a Mac that supports Apple Intelligence.
-- **EG-1 polish** is a one-time 2.9 GB download and needs about 6 GB free while it installs.
-- **Ollama polish** needs enough free memory for the model you pick.
+AI polish is the optional step that cuts filler words and fixes your grammar. Dictation works without it, so none of the following is required. Each option asks for something different:
 
-Dictation itself works on every supported Mac. None of those three is required.
+- **Apple Intelligence** needs macOS 26 or later, on a Mac that supports Apple Intelligence.
+- **EG-1**, the model EnviousWispr built, is a one-time 2.9 GB download and needs about 6 GB free while it installs.
+- **Ollama** running on your Mac needs enough free memory for the model you pick. Ollama also offers models it hosts itself, and those need an internet connection instead.
+- **OpenAI, Gemini or Claude** need an internet connection and your own API key from that company.

--- a/website/src/content/help/toggle-mode.md
+++ b/website/src/content/help/toggle-mode.md
@@ -8,23 +8,23 @@ keywords: ["toggle", "press once", "click to start click to stop", "on off mode"
 related: ["customizing-your-hotkey"]
 updated: 2026-08-05
 ---
-Toggle mode means press once to start and press again to stop. Nothing to hold.
+EnviousWispr is a free dictation app for macOS that turns what you say into typed text. Toggle is one of its two recording modes. You press your hotkey once to start recording and press it again to stop, instead of holding the key down the whole time.
 
 ### Using it
 
-1. Press your hotkey. Recording starts.
+1. Press your hotkey. Recording starts and the bar appears on screen.
 2. Speak.
-3. Press it again. Your text appears.
+3. Press it again. Your text appears at the cursor.
 
 ### When to pick it
 
-- You would rather not hold a key while talking.
-- You know when you want to stop.
+- You would rather not hold a key while you talk.
+- You know in advance when you want to stop.
 
 ### Choosing it
 
-Open Settings, go to **Shortcuts**, and pick **Toggle**.
+Click the EnviousWispr icon in your menu bar, choose **Settings**, and go to **Shortcuts**. Under **1. Choose recording mode**, pick **Toggle**. You will know it took effect when a single press starts recording instead of needing to be held.
 
-The recording hotkey is the same in both modes, so nothing else changes. Escape still discards a recording.
+The recording hotkey itself is the same in both modes, so nothing else about your setup changes. Escape still throws a recording away.
 
 The double-press lock from push to talk does not apply here. In toggle mode your hands are already free.

--- a/website/src/content/help/transcript-history.md
+++ b/website/src/content/help/transcript-history.md
@@ -8,7 +8,7 @@ keywords: ["history", "past dictations", "previous", "find an old dictation", "w
 related: ["clipboard-preservation"]
 updated: 2026-08-05
 ---
-Finished dictations are normally saved automatically. Open the EnviousWispr window and go to **History**.
+EnviousWispr is a free dictation app for macOS. It saves each finished dictation so you can find it again later. Click the EnviousWispr icon in your menu bar, choose **Settings**, and go to **History**.
 
 Recordings you cancelled, and recordings where no speech was found, are not saved. If saving fails for a storage reason, EnviousWispr tells you.
 
@@ -20,7 +20,7 @@ Recordings you cancelled, and recordings where no speech was found, are not save
 
 ### Where it is kept
 
-On your Mac, in your user folder. It survives quitting, updating and restarting. We never receive a copy, and there is no limit on how many are kept.
+On your Mac, in your user folder. It survives quitting, updating and restarting. Envious Labs never receives a copy, and there is no limit on how many dictations are kept.
 
 ### If History looks empty
 

--- a/website/src/content/help/uninstalling-enviouswispr.md
+++ b/website/src/content/help/uninstalling-enviouswispr.md
@@ -8,32 +8,39 @@ keywords: ["uninstall", "remove", "delete", "get rid of it", "clean up", "free u
 related: ["model-downloads-and-management"]
 updated: 2026-08-05
 ---
-Quit EnviousWispr from the menu bar, then drag it from your Applications folder to the Trash. That removes the app.
+EnviousWispr is a free dictation app for macOS. Removing it has two parts: deleting the app, and deleting the files it saved on your Mac.
 
-### Removing your data and settings
+### Remove the app
 
-Your dictation history, custom words and downloaded models stay behind unless you remove them. Together they can be a few gigabytes.
+1. Click the EnviousWispr icon in your menu bar and choose **Quit**.
+2. Open your Applications folder and drag EnviousWispr to the Trash.
 
-1. In Finder, press **Shift+Cmd+G**.
-2. Go to `~/Library/Application Support/EnviousWispr` and move that folder to the Trash. That is your History, your custom words, and the WhisperKit and EG-1 models.
-3. Go to `~/Library/Preferences` and move `com.enviouswispr.app.plist` to the Trash. That is your settings.
+The app is now gone. Your history, custom words and downloaded speech models are still on the Mac.
 
-### The Parakeet model is kept somewhere else
+### Remove your data and settings
 
-It sits in a shared folder, so the step above does not remove it. Go to `~/Library/Application Support/FluidAudio/Models` and move `parakeet-tdt-0.6b-v3` to the Trash.
+Those files can add up to a few gigabytes.
 
-Move only that one folder. Anything else in there may belong to another app, which would have to download it again.
+1. In Finder, press **Shift+Cmd+G** to open the Go to Folder box.
+2. Go to `~/Library/Application Support/EnviousWispr` and move that folder to the Trash. It holds your dictation history, your custom words, and the WhisperKit and EG-1 models.
+3. Go to `~/Library/Preferences` and move `com.enviouswispr.app.plist` to the Trash. That file is your settings.
+
+### The Parakeet model sits somewhere else
+
+Parakeet is one of the two speech engines. It lives in a folder shared with other apps, so the step above does not remove it. Go to `~/Library/Application Support/FluidAudio/Models` and move `parakeet-tdt-0.6b-v3` to the Trash.
+
+Move only that one folder. Anything else in there may belong to a different app, which would then have to download it again.
 
 If you installed Ollama, its models belong to Ollama and are removed from there.
 
 ### Your API key
 
-If you added a key for OpenAI, Gemini or Claude, it lives in your macOS Keychain. Clearing the field in Settings before you uninstall removes it. If the app is already gone, open Keychain Access, search for EnviousWispr, and delete every entry you find. There can be one per provider.
+If you added a key for OpenAI, Gemini or Claude, it lives in your macOS Keychain rather than in any of the folders above. Clearing the field in EnviousWispr's settings before you uninstall removes it. If the app is already gone, open Keychain Access, search for EnviousWispr, and delete every entry you find. There can be one for each provider.
 
-Revoking the key in that company's dashboard is worth doing either way.
+Revoking the key in that company's own dashboard is worth doing either way.
 
 ### If you come back
 
 Leave those files in place and reinstalling brings your History, custom words, models and settings back. Delete them first and you start fresh.
 
-Once you delete them they are gone. We cannot restore them, because we never had a copy.
+Once you delete them they are gone. Envious Labs cannot restore them, because we never had a copy.

--- a/website/src/content/help/using-ollama-for-fully-offline-ai-polish.md
+++ b/website/src/content/help/using-ollama-for-fully-offline-ai-polish.md
@@ -8,21 +8,21 @@ keywords: ["ollama", "offline ai", "local ai", "local model", "llama", "run ai l
 related: ["ollama-polish-not-working"]
 updated: 2026-08-05
 ---
-Ollama can run a language model on your own Mac. Once it is set up, polishing needs no key, no account, and sends none of your dictation to the internet.
+EnviousWispr is a free dictation app for macOS. Ollama is a separate free app that runs language models on your own Mac, and EnviousWispr can hand your dictation to one of them for tidying up. Once it is set up there is no key, no account, and none of your dictation goes to the internet.
 
-This page is about those on-Mac models. Ollama also offers hosted models that run on Ollama's servers, which do send your transcribed text off your Mac. EnviousWispr lists them under their own heading in the model list and never selects one for you, so if you want everything to stay local, pick a model that is not in that group.
+This page is about those on-Mac models. Ollama also offers hosted models that run on its own servers, and those do send your transcribed text off your Mac. EnviousWispr lists them under their own heading in the model list and never selects one for you, so if you want everything to stay local, pick a model that is not in that group.
 
 ### Setting it up
 
 1. Install Ollama from [ollama.com](https://ollama.com).
 2. Open it, so the Ollama app is running.
-3. Download a model. In Terminal that is `ollama pull llama3.2`, or use the Ollama app.
-4. In EnviousWispr, open Settings and go to **AI Polish**.
-5. Choose **Ollama**, then pick your model.
+3. Download a model. In Terminal that is `ollama pull llama3.2`, or you can do it from the Ollama app.
+4. In EnviousWispr, go to **Settings** \> **AI Polish**.
+5. Choose **Ollama**, then pick your model from the list.
 
 Installing Ollama and downloading a model need an internet connection. Polishing after that does not.
 
-EnviousWispr finds your installed models on its own. You can also download and remove models from that page.
+EnviousWispr finds your installed models on its own, so they appear in that list without you telling it where they are. You can also download and remove models from the same page.
 
 ### Picking a model
 
@@ -30,8 +30,8 @@ Start with llama3.2, the one EnviousWispr suggests. If polish feels slow, try a 
 
 ### If Ollama is not running
 
-Polish is skipped and you get your text anyway, without the AI clean-up. Ollama has to be running by the time AI Polish starts, which is just after your speech is transcribed.
+Polish is skipped and you get your text anyway, without the AI clean-up. Ollama has to be running by the time AI Polish starts, which is a moment after your speech is transcribed.
 
 ### A simpler local option
 
-If you want AI Polish on your Mac with nothing to install, try EG-1. It downloads from inside Settings and needs no separate app.
+If you want AI Polish on your Mac with nothing separate to install, try EG-1, the model EnviousWispr built. It downloads from inside Settings and needs no other app.

--- a/website/src/content/help/voice-activity-detection-and-auto-stop.md
+++ b/website/src/content/help/voice-activity-detection-and-auto-stop.md
@@ -8,13 +8,13 @@ keywords: ["auto stop", "stops on silence", "stops too early", "cuts me off", "p
 related: ["hands-free-mode-long-dictation", "first-word-gets-cut-off"]
 updated: 2026-08-05
 ---
-EnviousWispr can end a recording by itself once you stop talking. It is off unless you turn it on.
+EnviousWispr is a free dictation app for macOS. It can end a recording by itself once you stop talking, so you do not have to reach for the key again. This is off unless you turn it on.
 
 ### Turning it on
 
-1. Open Settings and go to **Transcription**.
+1. Go to **Settings** \> **Transcription**.
 2. Switch on **Stop recording on silence**.
-3. Use the slider to set how long a pause has to be, between half a second and three seconds. It starts at one and a half.
+3. Use the slider to set how long a pause has to be, anywhere from half a second to three seconds. It arrives set to one and a half.
 
 A pause shorter than your setting is ignored. A longer silence ends the recording. At the half-second setting, an ordinary pause for thought is enough to stop it.
 
@@ -26,8 +26,8 @@ A pause shorter than your setting is ignored. A longer silence ends the recordin
 
 ### It also trims your recording
 
-Silence at the start and end is removed before your speech is transcribed, whether or not you have auto-stop on. That happens on your Mac and needs no setting.
+Silence at the start and the end is removed before your speech is transcribed, whether or not you have auto-stop switched on. That happens on your Mac and needs no setting.
 
 ### If it stops too early or too late
 
-Move the slider. If it keeps stopping while you think, try three seconds, or switch it off and stop recordings yourself.
+Move the slider. If it keeps stopping while you are still thinking, try three seconds, or switch it off and end recordings yourself.

--- a/website/src/content/help/what-data-is-collected.md
+++ b/website/src/content/help/what-data-is-collected.md
@@ -8,17 +8,17 @@ keywords: ["what data", "analytics", "telemetry", "collected", "do you see my te
 related: ["privacy-overview"]
 updated: 2026-08-05
 ---
-Nothing you say ever reaches us. Not your audio, not your transcripts, not a word of it.
+EnviousWispr is a free dictation app for macOS. Nothing you say ever reaches Envious Labs, the company that makes it. Not your audio, not your transcripts, not a word of it.
 
 ### What stays on your Mac
 
-Your transcripts are saved to your History so you can find them later. They sit in your user folder, and we never receive a copy.
+Your transcripts are saved to your History so you can find them later. They sit in your user folder, and Envious Labs never receives a copy.
 
-While you dictate, the app keeps an encrypted backup of the recording. Once your text is safely saved, the app requests deletion of that backup. If the app quits first, EnviousWispr makes one recovery attempt the next time it runs, then requests deletion whether recovery succeeds or fails.
+While you dictate, the app keeps an encrypted backup of the recording. Once your text is safely saved, the app requests deletion of that backup. If the app quits first, EnviousWispr makes one recovery attempt the next time it runs, then requests deletion whether recovery succeeded or failed.
 
 Your custom words, settings and API keys live here too. They stay here unless you turn on cloud polish, which is covered below.
 
-### What we never receive
+### What Envious Labs never receives
 
 - Your audio
 - Your transcripts, before or after polish
@@ -27,11 +27,11 @@ Your custom words, settings and API keys live here too. They stay here unless yo
 - Your API keys
 - Your name or email address
 
-### What we do collect
+### What the app does collect
 
-Anonymous usage and crash data. It tells us that a release broke dictation on a particular macOS version, or that nobody has ever opened a setting we spent a month on. It is on by default and cannot be turned off.
+Anonymous usage and crash data. It shows that a release broke dictation on a particular macOS version, or that nobody has ever opened a setting that took a month to build. It is on by default and cannot be turned off.
 
-It records how the app is used, never what you said. There is no account and nothing in it names you, though each install gets a random ID so we can count one Mac as one user. Our privacy policy has the full detail.
+It records how the app is used, never what you said. There is no account and nothing in it names you, though each install gets a random ID so one Mac counts as one user. The privacy policy has the full detail.
 
 If you would rather run without it, EnviousWispr is open source. Build it yourself and dictation works exactly the same.
 
@@ -39,6 +39,6 @@ If you would rather run without it, EnviousWispr is open source. Build it yourse
 
 Polish runs on your Mac by default. Choose OpenAI, Gemini or Claude instead and you add your own API key, and your transcript is sent to them, along with your custom words and the name of the app you are dictating into, so the model gets your spellings and tone right. Audio is never sent. The app tells you this when you set it up. That is your account with that company, on their terms.
 
-Ollama is worth reading twice, because it can be either. A model you have downloaded runs on your Mac and sends nothing. A hosted one runs on Ollama's servers, so your transcript goes there just as it would to any other cloud provider. EnviousWispr lists the two under separate headings so you can tell which you are picking.
+Ollama works in two ways, and only one of them keeps your transcript on your Mac. A model you have downloaded runs on your Mac and sends nothing. A hosted model runs on Ollama's servers, so your transcript goes to Ollama the same way it would go to any other cloud provider. EnviousWispr lists the two kinds under separate headings so you can tell which you are picking.
 
-We are not in the middle of it. Everything goes straight from your Mac to them, so we never see it either way.
+Envious Labs is not in the middle of any of this. Everything goes straight from your Mac to the provider, so it is never seen here either way.

--- a/website/src/content/help/what-is-ai-polish.md
+++ b/website/src/content/help/what-is-ai-polish.md
@@ -8,7 +8,7 @@ keywords: ["polish", "ai polish", "cleanup", "clean up my text", "grammar", "pun
 related: ["choosing-an-ai-provider-none-apple-intelligence-ollama-openai-gemini"]
 updated: 2026-08-05
 ---
-AI Polish tidies up what you said. It fixes grammar and punctuation, cuts filler words, and is instructed to keep your meaning and your language.
+EnviousWispr is a free dictation app for macOS. AI Polish is the optional step it runs after transcribing you, to tidy up what you said. It fixes grammar and punctuation, cuts filler words, and is instructed to keep your meaning and your language.
 
 ### What it is designed not to do
 
@@ -21,10 +21,10 @@ AI can still get things wrong. EnviousWispr checks the result and rejects the ob
 
 ### It cannot lose your words
 
-If polish is unavailable, too slow, or gives back something unusable, EnviousWispr pastes the tidied-up text it already had before the AI step. You still get your dictation. How long the app waits depends on which option you chose.
+If polish is unavailable, too slow, or gives back something unusable, EnviousWispr pastes the tidied-up text it already had before the AI step. You still get your dictation. How long the app waits before giving up depends on which option you chose.
 
 ### What it starts as
 
-Apple Intelligence is the option you begin with. On a Mac that cannot run it, the AI step is quietly skipped and you get your text without it.
+Apple Intelligence is the option you begin with, and it needs macOS 26 or later. On a Mac that cannot run it, the AI step is quietly skipped and you get your text without it.
 
-There is one polish style, tuned for dictation. To change the option or switch polish off, open Settings and go to **AI Polish**.
+There is one polish style, tuned for dictation. To change the option or switch polish off, go to **Settings** \> **AI Polish**.

--- a/website/src/content/help/what-is-enviouswispr.md
+++ b/website/src/content/help/what-is-enviouswispr.md
@@ -8,18 +8,18 @@ keywords: ["what is it", "overview", "how does it work", "dictation app", "voice
 related: ["is-enviouswispr-free", "privacy-overview"]
 updated: 2026-08-05
 ---
-EnviousWispr types for you. Hold a key, speak, and your words appear in whatever app you are already in.
+EnviousWispr is a free dictation app for macOS. You hold a hotkey, speak, and your words appear as text in whatever app you are already working in.
 
 ### How you use it
 
-1. Click where you want the text.
+1. Click where you want the text to go.
 2. Hold your hotkey and talk.
-3. Let go. The text appears.
+3. Let go. The text appears at your cursor.
 
-### What you should know
+### What you get
 
-- It is free. No subscription, no account.
-- Your voice becomes text on your Mac. The audio never leaves it.
-- It works anywhere you can type: Slack, Mail, Notion, VS Code, Google Docs, Terminal.
-- It lives in your menu bar. No Dock icon, no window to keep open.
-- AI can tidy up grammar and cut filler words. That is on to start with, and you can change it or switch it off.
+- **It costs nothing.** No subscription, no account, no trial period. The code is open source under the GPLv3 license.
+- **Your voice stays on your Mac.** Your speech is turned into text on the device itself. The audio is never sent anywhere.
+- **It works anywhere you can type.** Slack, Mail, Notion, VS Code, Google Docs, Terminal, or any other text field on your Mac.
+- **It lives in your menu bar.** There is no Dock icon and no window to keep open.
+- **AI can tidy up what you said.** It cuts filler words like "um" and fixes grammar and punctuation. This is switched on when you install, and you can change which AI does the tidying or turn it off.

--- a/website/src/content/help/why-is-my-dictation-inaccurate.md
+++ b/website/src/content/help/why-is-my-dictation-inaccurate.md
@@ -8,35 +8,35 @@ keywords: ["inaccurate", "wrong words", "typos", "bad accuracy", "not accurate",
 related: ["adding-custom-words", "choosing-your-microphone"]
 updated: 2026-08-05
 ---
-Poor audio, the wrong microphone, an unsupported language and unfamiliar words all reduce accuracy. Work through these in order.
+EnviousWispr is a free dictation app for macOS. When it gets your words wrong, the cause is nearly always weak audio, the wrong microphone, a language it is not set to, or a word it has never met. Work through these in order.
 
 ### 1. Get closer to the microphone
 
-Try a headset microphone, or move nearer to your Mac, then compare the two in **History**.
+Try a headset microphone, or move nearer to your Mac. Dictate the same sentence both ways and compare the results in **History**.
 
 ### 2. Check which microphone is being used
 
-Open Settings and go to **Microphone**. On Auto, EnviousWispr records from whatever input your Mac is set to, which may not be the one you are speaking into. Pick a device from the list to be sure.
+Open EnviousWispr's settings and go to **Microphone**. On Auto, EnviousWispr records from whatever input your Mac is set to, which may not be the one you are speaking into. Pick a device from the list to be sure. The picker then shows that device's name in place of Auto.
 
 ### 3. Teach it the words it keeps missing
 
-Names, companies and terms from your field are not in a general speech model. Open Settings, go to **Your Words**, and add them. Switch on the vocabulary packs that match your work. This is the fix for "it always spells my colleague's name wrong".
+Names, companies and terms from your field are not in a general speech model. Open settings, go to **Your Words**, and add them. Each word appears in the list once you have added it. Switch on the vocabulary packs that match your work. This is the fix for "it always spells my colleague's name wrong".
 
 ### 4. Check your language
 
-Parakeet, the engine you start with, covers 25 European languages. For anything else, switch to WhisperKit under **Transcription** and pick your language. On WhisperKit, choosing your language is more accurate than leaving it on auto-detect.
+Parakeet, the engine you start with, covers 25 European languages. For anything outside that, switch to WhisperKit under **Transcription** and pick your language. On WhisperKit, naming your language is more accurate than leaving it on auto-detect.
 
 ### 5. Turn Live transcription off
 
-If you switched it on, switch it back off. On Parakeet it measurably increases mistakes. It is under **Transcription**.
+If you switched it on, switch it back off under **Transcription**. On Parakeet it measurably increases mistakes.
 
 ### 6. Work out which half went wrong
 
-Open **History** and read the dictation.
+Open **History** and read the dictation back.
 
 - **The words themselves are wrong.** That is the audio or the speech engine. Go back to steps 1 to 5.
-- **The words are right but the wording changed.** That is AI Polish. Set it to None under **AI Polish** to confirm.
+- **The words are right but the phrasing changed.** That is AI Polish rewriting you. Set it to None under **AI Polish** and dictate again to confirm.
 
 ### One more thing
 
-Speak naturally, at your normal pace.
+Speak naturally, at your normal pace. Slowing down or over-enunciating makes recognition worse, not better.

--- a/website/src/content/help/your-first-dictation.md
+++ b/website/src/content/help/your-first-dictation.md
@@ -9,23 +9,25 @@ related: ["push-to-talk-mode", "how-text-gets-pasted-into-your-app"]
 seeAlso: "getting-started-enviouswispr-under-2-minutes"
 updated: 2026-08-05
 ---
+EnviousWispr is a free dictation app for macOS. You dictate by holding a key, speaking, and letting go. Your first try takes about ten seconds.
+
 ### Try it now
 
-1. Open any app you type in and click into a text box.
-2. Hold your hotkey.
+1. Open any app you type in, such as Notes or Mail, and click into a text box so the cursor is blinking.
+2. Hold down your hotkey, the key you chose during setup.
 3. Speak normally.
-4. Let go.
+4. Let go of the key.
 
-Your words appear in the text box a moment later.
+Your words appear at the cursor a moment later.
 
 ### What you will see
 
-- A small bar appears while you are recording, with a meter that moves as you talk. It does not take focus away from your app.
-- The menu bar icon turns colour while recording, then becomes a spinning wheel while the app works.
-- The text is pasted for you. Whatever was on your clipboard is put back afterwards.
+- A small bar appears while you are recording, with a meter that moves as you talk. It does not take focus away from the app you were typing in.
+- The menu bar icon goes from grey to colour while you record, then turns into a spinning wheel while EnviousWispr works out what you said.
+- The text is pasted for you. Whatever was on your clipboard beforehand is put back afterwards.
 
-### Tips
+### Tips for a good first result
 
 - Speak at your normal speed. Slowing down does not help.
-- On your first dictation after opening the app, pause for a beat after pressing the key. Once the microphone has been used recently it also captures the half second before you press, so later dictations do not need the pause.
-- Finished dictations are normally saved under **History** so you can find them again. If saving fails, EnviousWispr tells you.
+- On your first dictation after opening the app, pause for a beat after pressing the key. Once the microphone has been used recently, EnviousWispr also captures the half second before you press, so later dictations do not need that pause.
+- Finished dictations are saved under **History**, which you reach from the menu bar icon, so you can go back and find one. If saving fails, EnviousWispr tells you.


### PR DESCRIPTION
## Why

The founder read the shipped help centre next to a Gemini rewrite of the same pages and preferred Gemini's. The reason was concrete: our opener was "EnviousWispr types for you", which means nothing to someone who has never seen the product, while Gemini's said what the product is.

The rules were fixed first, in the EnviousMarketing engine: documentation is Mode E, not Mode D, and Mode E leads with the definition. This PR applies those rules to all 52 articles.

## What changed

Every article now:

- opens with a sentence naming the category a stranger could repeat back, before answering the page's question
- names the exact on-screen control, using the labels that are actually in the app
- says how the reader knows the thing worked

Nothing was deleted for brevity. Mode E's rule is "cut words, never steps."

## Accuracy fixes found while rewriting

Restyling inherited copy re-asserts every claim in it, so each was checked against the shipped code rather than carried over.

- **Settings tab labels.** Gemini's draft invented "Speech Engine", "Audio", "Text Polish", "Hotkeys" and a "Models" tab that does not exist. The real labels are Transcription, Microphone, AI Polish, Shortcuts, Your Words (`SettingsSection.swift:38-57`). Every section name used across the 52 articles was audited against that enum.
- **Recording-mode cards** read "Push to Talk" and "Toggle" (`ShortcutsSettingsView.swift:31,39`), not "Push-to-Talk".
- **Hosted Ollama** needs `ollama signin`, not an API key, and some hosted models need a paid plan. Neither was documented anywhere, and the Ollama troubleshooting article now covers both.
- **`privacy-overview` omitted hosted Ollama from its cloud-polish list.** Same class as the #1944 defect: a claim that names some members of a set and silently drops a new one. An entity sweep cannot find this, because the omission contains no instance of the entity.
- **`ai-polish-and-cloud-data`:** broadening the "your text is sent" heading to include hosted Ollama made the bullet under it wrong, since that bullet says an API key is sent. Corrected in the same edit rather than left for review to catch.
- **WhisperKit's language count** is 99 in the app's own settings copy; two articles said "over 90".
- **Apple Intelligence needs macOS 26**, not 15.1 as Gemini's draft claimed in three places.
- **Retitled** the provider article to "Choosing an AI Provider". Its old title listed five options and the product has six, so it went stale the day Claude shipped. The filename, and therefore the public URL, is untouched.
- **Noise suppression's "removed in v2.0.2"** was an unsourced number, so it was checked: `git describe --tags --contains d3962ae5` returns `v2.0.2~3`. Correct.

## How each article was reviewed

One at a time, on the founder's instruction: write it, send it to Gemini 3.5 flash lite as a copywriter and proofreader, iterate to an explicit ALL CLEAR, then move to the next. 52 all-clears.

Its findings were adjudicated, not pasted. It repeatedly reported banned-word hits for words that are not banned ("available", "saves", "simple", "out"), twice proposed UI details it had invented ("the card turns blue"), and once wanted the opening sentence replaced with a stiffer one that no longer defined the product. Its genuine catches were real, including one banned "just" my own draft had introduced, which then turned out to be a class of six across the tree.

## Verification

Two-way, because a check that has never failed proves nothing.

| Check | Result |
|---|---|
| All 52 openings name the category | 52/52 pass |
| Same check against `origin/main` | 52/52 **fail**, so it is not vacuous |
| Banned words (`simply`/`just`/`easily` and the buzzword list) | 0 |
| Em and en dashes | 0 |
| Settings-section names vs `SettingsSection.swift` | all 9 referenced names valid |
| `npm ci` then `npm run build` **in this worktree** | 122 pages, Complete |
| `check-help-content` | 52 articles, 0 errors |
| `check-help-routes` | expected 65, built 65, in sitemap 65, 0 dead links |
| `check-help-search` | 37 passed, 0 failed |
| New opening present in built HTML | 52/52 `dist/help/*/index.html` |
| Old "types for you" opening in built HTML | 0 |

The build was run after `npm ci` in the worktree, not in the main checkout, because a worktree has no `node_modules` and a build there would otherwise not be a build of these changes.

Part of #1944.
