### PR TITLE
docs(content): rewrite all 52 help articles in the documentation register

### DIFF
--- a/website/src/content/help/accessibility-permission-not-working.md
+++ b/website/src/content/help/accessibility-permission-not-working.md
@@ -6,17 +6,19 @@ section: "Permissions"
 order: 1
 keywords: ["accessibility not working", "permission wont stick", "toggle keeps turning off", "already allowed but still broken", "granted but not working", "reset permission"]
 related: ["granting-permissions-microphone-accessibility-and-automation", "paste-not-working"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS, and it uses the Accessibility permission to put your finished text into whatever app you are working in. Without that permission, your words are transcribed but nothing is pasted.
+EnviousWispr uses the Accessibility permission to put your finished text into whatever app you are working in. Without that permission, your words are transcribed but nothing is pasted.
 
 ### Grant it
+
+Granting Accessibility allows EnviousWispr to insert text into the app you are working in.
 
 1. Open **System Settings** \> **Privacy & Security** \> **Accessibility**.
 2. Click **+** and add EnviousWispr from your Applications folder.
 3. Make sure the switch beside it is on.
 
-You do not need to restart EnviousWispr. It notices within a few seconds. You will know it worked when your next dictation lands in the text box on its own.
+You do not need to restart EnviousWispr. The app notices within a few seconds. You will know it worked when your next dictation lands in the text box on its own.
 
 ### If it was working and then stopped
 
@@ -28,4 +30,4 @@ macOS occasionally holds on to a stale record of the app. Remove EnviousWispr fr
 
 ### Your dictation is not lost meanwhile
 
-When EnviousWispr cannot paste, it copies your text to the clipboard instead and tells you it has done so. Press Cmd+V to put it in yourself.
+When EnviousWispr cannot paste, it copies your text to the clipboard instead and tells you it has done so. Press Cmd+V to put the text into your document yourself.

--- a/website/src/content/help/adding-custom-words.md
+++ b/website/src/content/help/adding-custom-words.md
@@ -6,43 +6,51 @@ section: "Custom Words"
 order: 1
 keywords: ["custom words", "vocabulary", "add a word", "my name", "names", "jargon", "technical terms", "spells my name wrong", "dictionary", "teach it a word", "acronyms"]
 related: ["why-is-my-dictation-inaccurate", "how-custom-word-correction-works"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. When it keeps getting a name or a term wrong, you can teach it the spelling you want.
+When EnviousWispr repeatedly misspells a name or a specialised term, you can teach it the exact spelling you want to use.
 
-### Adding one
+### Adding a custom word
 
-1. Click the EnviousWispr icon in your menu bar, choose **Settings**, and go to **Your Words**.
-2. Add the spelling you want.
+Open settings to enter your preferred terms and override what the speech engine produces.
 
-From then on, when you say that word, you get your spelling. If EnviousWispr writes "Chat G P T", adding "ChatGPT" fixes it.
+1. **Open settings.** Click the EnviousWispr icon in your menu bar, choose **Settings**, and go to **Your Words**.
+2. **Add your term.** Type the exact spelling you want to appear.
 
-### Worth adding
+From then on, when you speak that word, EnviousWispr writes your chosen spelling. If it writes out "Chat G P T", adding "ChatGPT" to your words corrects that for every dictation from then on.
 
-- Names of people you write to.
-- Your company and product names.
-- Terms your field uses that nobody outside it does.
+### Words worth adding
 
-### Ready-made packs
+Building a reliable list saves you time editing afterwards. These are the categories that pay off most:
 
-The same page offers vocabulary packs you can switch on: Tech, Medical, Legal, Brands and Names. Turn on the ones that match your work rather than typing all those terms in yourself.
+- Names of people you write to regularly.
+- Your company name and your internal product names.
+- Technical terms, acronyms, and jargon from your field that a general dictionary misses.
+
+### Using ready-made vocabulary packs
+
+Vocabulary packs group common terms by industry, so you do not have to type every word in yourself.
+
+**Switch on a pack.** On the same **Your Words** page, turn on any of the packs: Tech, Medical, Legal, and Brands and Names. Turn on the ones that match your daily work to cover those terms straight away.
 
 ### Importing from Contacts
 
-You can pull names straight out of your Contacts, so the people you write to are spelled correctly from the start. macOS asks your permission the first time.
+You can pull names directly out of your macOS Contacts app, so the people you write to are spelled correctly from your very first dictation.
 
-Switch on **Keep in sync on launch** if you want EnviousWispr to check for new contacts each time it starts. That is off unless you turn it on.
+**Import your contacts.** Use the Contacts import on the **Your Words** page. macOS asks for your permission the first time you do this.
+
+**Keep it up to date.** Switch on **Keep in sync on launch** if you want EnviousWispr to check for new contacts each time it starts. This setting is off unless you turn it on.
 
 ### Letting your Mac guess the mishearings
 
-When you add a word, EnviousWispr can work out how it is likely to be misheard and watch for those versions too. Add "Kubernetes" and it might also watch for "Cooper net ease", so you do not have to think of the wrong versions yourself.
+When you add a word, EnviousWispr can work out how the speech engine is likely to mishear it and watch for those versions too. Adding "Kubernetes" prompts it to watch for versions like "Cooper net ease", which saves you thinking up the wrong spellings yourself.
 
-This needs macOS 26 or later with Apple Intelligence switched on, and it happens on your Mac. Without it, custom words still work exactly as they should.
+This needs macOS 26 or later with Apple Intelligence switched on, and it all happens on your Mac. Without Apple Intelligence, your custom words still work exactly as they should.
 
-### When your words are used
+### When your words are applied
 
-Your spellings are applied to your text before AI Polish runs, on every dictation, whether or not polish is switched on.
+Your custom spellings are applied to your transcribed text before AI Polish runs, on every dictation, whether or not polish is switched on.
 
-OpenAI, Gemini and Claude are also given your list, so their rewriting keeps your spellings. Whether Ollama is given the list depends on the model you picked. Apple Intelligence and EG-1 are not given it, because they do better with shorter instructions and your words have already been applied by then.
+OpenAI, Gemini, and Claude also receive your custom word list, so their rewrites keep your spellings. Whether Ollama receives the list depends on the model you selected. Apple Intelligence and EG-1 do not receive it, because they do better with shorter instructions, and your words have already been applied to the text by that stage.
 
-To move your words between Macs, or bring them in from another app, see [_Importing and Exporting Custom Words_](/help/importing-and-exporting-custom-words/).
+To move your words between Macs, or bring them in from another app, read [_Importing and Exporting Custom Words_](/help/importing-and-exporting-custom-words/).

--- a/website/src/content/help/ai-polish-and-cloud-data.md
+++ b/website/src/content/help/ai-polish-and-cloud-data.md
@@ -7,37 +7,39 @@ order: 3
 keywords: ["cloud", "does it send my text anywhere", "sent to openai", "sent to google", "leaves my mac", "third party", "who sees my text", "confidential", "work data", "hipaa"]
 related: ["privacy-overview", "choosing-an-ai-provider-none-apple-intelligence-ollama-openai-gemini"]
 seeAlso: "cloud-ai-polish-not-stored"
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. Whether any of your text leaves your Mac depends entirely on which AI Polish option you picked. Go to **Settings** \> **AI Polish** to see which one is yours.
+Whether any of your text leaves your Mac depends entirely on which AI Polish option you picked. Go to **Settings** \> **AI Polish** to check your current selection.
 
 ### Nothing leaves your Mac
 
-- **None.** No AI step at all.
-- **Apple Intelligence.** Apple's model, running on your Mac.
-- **EG-1.** The model EnviousWispr built, running on your Mac.
-- **Ollama, when you pick a model you downloaded.** Ollama also offers hosted models that run on its own servers, and those do send your transcribed text. EnviousWispr shows them under their own heading so you can tell which kind you are choosing.
+These options keep your transcription and the polish request entirely on your device.
+
+- **None.** No AI step runs at all.
+- **Apple Intelligence.** Apple's model, running directly on your Mac.
+- **EG-1.** The model built by Envious Labs, running directly on your Mac.
+- **Ollama, when you pick a model you downloaded.** Ollama also offers hosted models that run on its own servers, and those do send your transcribed text. EnviousWispr shows the hosted models under a separate heading so you can tell which kind you are choosing.
 
 ### Your text is sent
 
-OpenAI, Gemini, Claude and Ollama's hosted models all run on their own servers. Your account is with that company, on their terms. Envious Labs is not in the middle of it: everything goes straight from your Mac to them, so it is never seen here either.
+OpenAI, Gemini, Claude, and Ollama's hosted models all run on their own servers. Your account is with that company, on their terms. Envious Labs is not in the middle of it. Everything goes straight from your Mac to the provider, so Envious Labs never sees your text either.
 
 #### What is sent
 
-- The text to polish.
+- The text that needs polishing.
 - The instructions for cleaning it up, plus your custom words.
 - The name of the app you are dictating into.
-- Your API key, so the provider can confirm the request is yours. Ollama's hosted models use your Ollama sign-in instead of a key.
+- Your API key, so the provider can confirm the request belongs to you. Ollama's hosted models use your Ollama sign-in instead of an API key.
 
 #### What is never sent
 
-- Your audio. Ever, on any option.
+- Your audio. That holds on every single option without exception.
 - Your other transcripts, or your History.
 
 EnviousWispr adds nothing to the request that identifies you or your Mac. The provider still sees the ordinary details of any internet connection, such as your IP address.
 
-With OpenAI and Gemini, EnviousWispr also asks them not to keep a copy of that request. That is a request to them, not something EnviousWispr can enforce, and your text still has to reach them to be polished.
+With OpenAI and Gemini, EnviousWispr also asks them not to keep a copy of that request. That is a request to the provider, not something EnviousWispr can enforce, and your text still has to reach their servers to be polished.
 
 ### If polish fails
 
-You get the tidied-up version of your dictation from immediately before the AI step. A network problem, a slow provider, or a reply that arrives cut short costs you the polish, never your words.
+You still receive the tidied-up version of your dictation from immediately before the AI step. A network problem, a slow provider, or a reply that arrives cut short costs you the polish, never your words.

--- a/website/src/content/help/api-key-security.md
+++ b/website/src/content/help/api-key-security.md
@@ -6,15 +6,15 @@ section: "Privacy"
 order: 4
 keywords: ["api key", "where is my key stored", "keychain", "secret", "token", "is my key safe", "billing"]
 related: ["choosing-an-ai-provider-none-apple-intelligence-ollama-openai-gemini"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. If you use OpenAI, Gemini or Claude to polish your dictation, you bring your own API key. Here is where that key is kept and how to take it back out.
+If you use OpenAI, Gemini, or Claude to polish your dictation, you bring your own API key. Here is where that key is kept and how to take it back out.
 
 ### Stored in the macOS Keychain
 
-Your key goes into the macOS Keychain, the same place the system keeps your other passwords. It is protected by your login and encrypted at rest, and no other account on the Mac can read it.
+Your key goes into the macOS Keychain, the same place the system keeps your other passwords. It is protected by your login and encrypted at rest, and no other user account on the Mac can read it.
 
-If you used an early version of EnviousWispr, your key may have started out in an older file store. The app moves it into the Keychain the next time it is used, and clears the old file afterwards.
+If you used an early version of EnviousWispr, your key may have started out in an older file store. The app moves the key into the Keychain the next time it is used, and clears the old file afterwards.
 
 ### Where your key does and does not go
 
@@ -24,4 +24,6 @@ If you used an early version of EnviousWispr, your key may have started out in a
 
 ### Removing a key
 
-Clear the field in **Settings** \> **AI Polish** and the stored key goes with it. You can also revoke the key from your provider's own dashboard at any time, which takes effect immediately whatever EnviousWispr does.
+**Clear the field.** Open **Settings**, select **AI Polish**, and clear the key field. The stored key goes with it.
+
+You can also revoke the key from your provider's own dashboard at any time, which takes effect immediately regardless of what EnviousWispr does.

--- a/website/src/content/help/app-crashes-or-asr-engine-crashes.md
+++ b/website/src/content/help/app-crashes-or-asr-engine-crashes.md
@@ -5,22 +5,22 @@ category: "troubleshooting"
 section: "Recording Issues"
 order: 8
 keywords: ["crash", "crashes", "quits", "closes by itself", "keeps crashing", "stopped working", "disappeared", "not responding"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. The part of it that turns speech into text runs separately from the rest of the app, so the two can stop on their own without taking the other down.
+EnviousWispr keeps its transcription engine separate from the rest of the app, so a failure in one does not take the other down with it.
 
 ### If the speech engine stops
 
-EnviousWispr keeps running and starts the engine again on your next recording. There is nothing for you to do.
+The transcription engine runs in its own process. If that process hits an error and stops, the rest of EnviousWispr stays open. EnviousWispr starts the engine again when you press your hotkey for your next recording. There is nothing for you to do.
 
 ### If the app itself quits
 
-Open it again from your Applications folder. Your History is written to disk as you go, so past dictations are still there.
+**Open the app again.** Launch EnviousWispr from your Applications folder. Your past dictations are still there, because your history is written to disk as you go rather than held in memory.
 
-### The dictation you were in the middle of
+### Recovering an interrupted recording
 
-While you dictate, EnviousWispr keeps a protected copy of the recording and deletes it once your text is safely saved. If the app quits before that happens, EnviousWispr makes one attempt to recover those words the next time it starts.
+EnviousWispr keeps a protected copy of your audio while you speak, and deletes that copy once your text has been safely saved. If the app quits before that happens, EnviousWispr makes one attempt to recover those words the next time you open it.
 
 ### Crash reports
 
-Crashes are reported to Envious Labs automatically so they can be fixed. A report describes what the app was doing, never what you said. No audio and no transcripts are ever included.
+Crash reports are sent to Envious Labs automatically so the cause can be diagnosed and fixed. A crash report describes what the application code was doing at the moment of failure. It never includes what you said. Audio recordings and text transcripts are never part of a crash report.

--- a/website/src/content/help/apple-intelligence-not-available.md
+++ b/website/src/content/help/apple-intelligence-not-available.md
@@ -6,19 +6,21 @@ section: "AI Polish Issues"
 order: 6
 keywords: ["apple intelligence missing", "apple intelligence greyed out", "cant use apple intelligence", "not available", "unavailable", "why cant i pick apple"]
 related: ["apple-intelligence-setup", "system-requirements"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. Apple Intelligence is one of the options it can use to tidy up your dictation, and Apple only makes it available on some Macs.
+Apple Intelligence is one of the polish options EnviousWispr can use to tidy up your dictation, but Apple restricts the feature to specific hardware and software versions. Dictation itself keeps working normally even when Apple Intelligence is unavailable on your Mac.
 
-To see where you stand, open EnviousWispr's settings, go to **AI Polish**, and select Apple Intelligence. EnviousWispr names the exact requirement you are missing.
+To see which requirement is missing, open EnviousWispr settings, go to **AI Polish**, and select Apple Intelligence. EnviousWispr names the exact reason the option is unavailable on your system.
 
-### The usual reasons
+### Common reasons it is unavailable
 
-- **macOS is too old.** This needs macOS 26 or later. Check under the Apple menu \> About This Mac. It is not the same thing as the Apple Intelligence that arrived in macOS 15: other apps could not reach the model until macOS 26.
-- **Apple Intelligence is switched off.** Turn it on in **System Settings** \> **Apple Intelligence & Siri**.
-- **The model is still downloading.** macOS fetches it in the background after you switch it on, and that can take a while. Try again later.
-- **Your Mac does not support it.** Apple decides which Macs qualify, and there is no way around that from inside EnviousWispr.
+Work through this list to identify why Apple Intelligence is not active in EnviousWispr.
 
-### What to do instead
+- **macOS is too old.** This feature requires macOS 26 or later. Check your version under the Apple menu by selecting **About This Mac**. This requirement is separate from the Apple Intelligence features introduced in macOS 15, because other applications could not reach the system model until macOS 26.
+- **Apple Intelligence is switched off.** Open **System Settings**, go to **Apple Intelligence & Siri**, and turn the feature on.
+- **The model is still downloading.** macOS downloads the required model files in the background after you turn the feature on, and that can take a while. Try the option again later.
+- **Your Mac does not support the feature.** Apple decides which Macs qualify, and there is no way around that from inside EnviousWispr.
 
-Dictation itself works either way. Only the clean-up step is affected. If Apple Intelligence is out of reach, pick EG-1 or an Ollama model you have downloaded to keep everything on your Mac, or use your own key for OpenAI, Gemini or Claude.
+### Alternative polish options
+
+If Apple Intelligence is out of reach on your Mac, you can choose a different way to clean up your dictated text. Pick EG-1 or a downloaded Ollama model to keep everything on your Mac, or enter your own API key for OpenAI, Gemini, or Claude.

--- a/website/src/content/help/apple-intelligence-setup.md
+++ b/website/src/content/help/apple-intelligence-setup.md
@@ -6,26 +6,30 @@ section: "Polish"
 order: 5
 keywords: ["apple intelligence", "apple ai", "on device ai", "free ai", "macos 26", "set up apple intelligence", "enable apple intelligence"]
 related: ["apple-intelligence-not-available"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. Apple Intelligence is Apple's own AI, built into newer versions of macOS, and EnviousWispr can use it to tidy up your dictation. It is free, there is no key to enter, and your text never leaves the Mac.
+Apple Intelligence is Apple's built-in system for processing language on your Mac, and EnviousWispr can use it to tidy up your dictation by removing filler words and fixing punctuation. This option is free to use, requires no API key, and keeps your text on your Mac.
 
 ### What you need
 
-- macOS 26 or later.
-- A Mac that supports Apple Intelligence.
-- Apple Intelligence switched on in System Settings.
+Before you select Apple Intelligence in EnviousWispr, make sure your Mac meets these requirements:
+
+- **macOS version.** You need macOS 26 or later.
+- **Hardware.** You need a Mac that supports Apple Intelligence.
+- **System setting.** You need Apple Intelligence switched on in System Settings.
 
 ### Setting it up
 
-1. Open **System Settings** \> **Apple Intelligence & Siri** and switch it on.
-2. In EnviousWispr, go to **Settings** \> **AI Polish**.
-3. Choose **Apple Intelligence**.
+Follow these steps to turn on Apple Intelligence polish inside EnviousWispr:
 
-You will know it worked when your next dictation comes back with the filler words gone and the punctuation fixed.
+1. **Open System Settings.** Open **System Settings**, click **Apple Intelligence & Siri**, and switch it on.
+2. **Open EnviousWispr settings.** Open EnviousWispr, go to **Settings**, and click **AI Polish**.
+3. **Select Apple Intelligence.** Choose **Apple Intelligence** from the list of polish options.
+
+You will know the setup worked when your next dictation comes back with the filler words removed and the punctuation corrected.
 
 ### If it is not available
 
-EnviousWispr checks your Mac and names the missing requirement on that same **AI Polish** page. The usual reasons are an older version of macOS, Apple Intelligence not switched on yet, or the model still downloading in the background.
+EnviousWispr checks your Mac and names the missing requirement directly on the **AI Polish** page. The usual reasons are an older version of macOS, Apple Intelligence not switched on yet, or the model still downloading in the background.
 
-See [_Apple Intelligence Not Available_](/help/apple-intelligence-not-available/) if you get stuck.
+Read [_Apple Intelligence Not Available_](/help/apple-intelligence-not-available/) if you run into any of those.

--- a/website/src/content/help/auto-updates.md
+++ b/website/src/content/help/auto-updates.md
@@ -5,18 +5,22 @@ category: "updates-and-source"
 section: "Updates"
 order: 1
 keywords: ["update", "updates", "new version", "upgrade", "auto update", "check for updates", "latest version"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. It checks for updates by itself and tells you when one is ready. Click to install, and the app restarts into the new version.
+EnviousWispr checks for updates by itself and tells you when a new version is ready to install. When one arrives, you click to install it, and the app restarts into the updated version.
 
-### Checking now
+### Checking for updates manually
 
-Click the EnviousWispr icon in your menu bar, choose **Settings**, and go to **Check for Updates**.
+You can check for a new version at any time, without waiting for the background check to run.
+
+**Open settings.** Click the EnviousWispr icon in your menu bar and choose **Settings**.
+
+**Check for Updates.** Go to the **Check for Updates** section to start a manual search.
 
 ### Where updates come from
 
-Every update is downloaded from the official EnviousWispr release page, and its signature is checked before it installs. An update that fails that check is refused.
+Every update is downloaded from the official EnviousWispr release page. The app checks the cryptographic signature of every download before installation begins, and any update that fails that check is refused.
 
-### What is new
+### Reading the release notes
 
-After each update, the **What's New** page in the app lists what changed.
+After each update completes, the **What's New** page inside the app lists everything that changed in the version you have moved to.

--- a/website/src/content/help/bluetooth-and-airpods.md
+++ b/website/src/content/help/bluetooth-and-airpods.md
@@ -6,23 +6,25 @@ section: "Input Configuration"
 order: 2
 keywords: ["airpods", "air pods", "bluetooth", "wireless headphones", "headphones", "earbuds", "sounds muffled", "quality drops", "music stops", "beats", "headset"]
 related: ["choosing-your-microphone"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. AirPods and Bluetooth headsets work with it, and there are two things worth knowing before you rely on them.
+AirPods and Bluetooth headsets work with EnviousWispr, and there are two things worth knowing before you rely on them.
 
 ### Which microphone gets used
 
 On **Auto**, EnviousWispr records from whatever input your Mac is set to. If that is your AirPods, it records from your AirPods.
 
-To use your Mac's built-in microphone instead, either change the input in **System Settings** \> **Sound**, or name it directly under **Settings** \> **Microphone** in EnviousWispr.
+To use your Mac's built-in microphone instead, change the input in **System Settings** \> **Sound**, or name it directly under **Settings** \> **Microphone** in EnviousWispr.
 
 ### Why your music dips when you record
 
 A Bluetooth headset has a music mode and a microphone mode, and it cannot do both at once. The moment anything uses the microphone, the headset switches over, and audio quality drops for as long as the recording lasts.
 
-That switch also takes a moment, which is why a first word can go missing if you start talking instantly. Hold your hotkey for a beat before speaking on the first recording after connecting.
+That switch also takes a moment, which is why a first word can go missing if you start talking instantly.
 
-If that bothers you, record from your Mac's built-in microphone instead. Your headset then stays in music mode the whole time.
+**Wait a beat before speaking.** Hold your hotkey for a moment before you start talking on the first recording after connecting.
+
+If that drop in audio quality bothers you, record from your Mac's built-in microphone instead. Your headset then stays in music mode the whole time.
 
 ### If it disconnects mid-recording
 

--- a/website/src/content/help/canceling-a-recording.md
+++ b/website/src/content/help/canceling-a-recording.md
@@ -6,18 +6,22 @@ section: "Recording"
 order: 5
 keywords: ["cancel", "stop without pasting", "throw away", "discard", "escape", "abort", "undo", "didnt mean to record", "delete recording"]
 related: ["recording-won-t-stop-or-seems-stuck"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. If you misspeak, get interrupted, or start recording by accident, press **Escape**. The recording stops, the audio is thrown away, and nothing is typed. This works in every recording mode, at any point during a recording.
+If you misspeak, get interrupted, or start recording by accident, you can stop the recording without leaving any text behind. EnviousWispr ends the recording, discards the audio, and leaves your cursor untouched. This works in every recording mode and at any point during a recording.
 
-In push to talk, you can also triple-press your hotkey to cancel, so you do not need to reach for the Escape key.
+### How to cancel
 
-### In hands-free mode
+**Press Escape.** Press the Escape key on your keyboard while the recording is running.
 
-Press **Escape**. Do not press your recording hotkey again, because in hands-free mode that stops the recording and transcribes it instead of canceling.
+**Or press your hotkey three times.** In push-to-talk mode, a triple press of your recording hotkey cancels the session without reaching for the Escape key.
 
-### What happens
+### Canceling in hands-free mode
 
-Nothing is transcribed, nothing is pasted, and nothing is saved to your History. The bar disappears from the screen and EnviousWispr goes back to waiting, which is how you know it worked.
+In hands-free mode, pressing your recording hotkey stops the recording and sends the audio for transcription. To cancel instead, press **Escape**. Do not use your hotkey for this.
 
-You can change the cancel key under **Settings** \> **Shortcuts**, reached from the EnviousWispr icon in your menu bar.
+### What happens when you cancel
+
+EnviousWispr ends the session entirely. Nothing is transcribed, nothing is pasted into the app you were working in, and no entry is saved to your History. The recording bar disappears from the screen and EnviousWispr returns to waiting, which is how you know the cancellation worked.
+
+You can change the cancel key if you prefer a different shortcut. Click the EnviousWispr icon in your menu bar, choose **Settings**, and select **Shortcuts**.

--- a/website/src/content/help/choosing-a-speech-engine-parakeet-vs-whisperkit.md
+++ b/website/src/content/help/choosing-a-speech-engine-parakeet-vs-whisperkit.md
@@ -8,7 +8,7 @@ keywords: ["parakeet", "whisperkit", "whisper", "which engine", "engine", "speec
 related: ["multi-language-dictation", "why-is-my-dictation-inaccurate"]
 updated: 2026-08-06
 ---
-EnviousWispr turns your speech into text using one of two speech engines, Parakeet or WhisperKit. Both run entirely on your Mac. Neither sends your audio anywhere, and neither needs an internet connection once its model has been downloaded.
+You can choose between two speech engines for transcription, Parakeet or WhisperKit. Both run entirely on your Mac. Neither sends your audio anywhere, and neither needs an internet connection once its model has been downloaded.
 
 ### Comparison of the two engines
 
@@ -21,7 +21,7 @@ EnviousWispr turns your speech into text using one of two speech engines, Parake
 
 ### Choosing an engine
 
-Keep Parakeet. It is the engine you start with, it is the faster of the two, and it covers 25 European languages. Switch to WhisperKit only if you dictate in a language Parakeet does not cover.
+Keep Parakeet. It is the default engine, it is faster than WhisperKit, and it covers 25 European languages. Switch to WhisperKit only if you dictate in a language Parakeet does not cover.
 
 To change your engine, follow these steps.
 
@@ -35,14 +35,18 @@ The change applies to your next recording.
 
 ### What happens when you dictate
 
-Knowing the sequence helps you work out where a delay or an error came from. When you finish a recording, EnviousWispr does four things in order.
+Knowing the sequence helps you work out where a delay or an unexpected change came from. When you finish a recording, EnviousWispr does five things in order.
 
 **Trim the audio.** EnviousWispr takes the audio it recorded and trims the silence at the start and the end.
 
 **Transcribe the speech.** Your chosen engine reads the audio and writes out the text.
 
-**Polish the text.** Any AI polish you have switched on runs against that text.
+**Clean up the text.** Your custom words are applied, filler words are removed, spoken emoji are converted, and numbers, dates and times are written the way you would type them. This stage always runs, whatever you have AI Polish set to, and each part of it has its own setting.
+
+**Polish the text.** Any AI polish you have switched on runs against the cleaned-up text. This stage is optional, and setting AI Polish to None skips it entirely.
 
 **Paste the result.** The finished text is pasted into the text box you were working in.
 
-Transcription speed depends on your Mac, the engine you selected, and how long you spoke. If one engine feels slow or keeps missing your language, try the other. If speech recognition fails for any reason, EnviousWispr stays open. Start another recording and it sorts itself out.
+That split matters when you are troubleshooting. If your text came out different from what you said and AI Polish is switched off, the clean-up stage is what changed it.
+
+Transcription speed depends on your Mac, the engine you selected, and how long you spoke. If one engine feels slow or keeps missing your language, try the other. If speech recognition fails for any reason, EnviousWispr stays open. Start another recording and it recovers on its own.

--- a/website/src/content/help/choosing-a-speech-engine-parakeet-vs-whisperkit.md
+++ b/website/src/content/help/choosing-a-speech-engine-parakeet-vs-whisperkit.md
@@ -6,38 +6,43 @@ section: "Transcription"
 order: 1
 keywords: ["parakeet", "whisperkit", "whisper", "which engine", "engine", "speech engine", "model", "accuracy vs speed", "switch engine", "transcription engine", "which is better"]
 related: ["multi-language-dictation", "why-is-my-dictation-inaccurate"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS, and it can turn your speech into text using either of two engines, Parakeet or WhisperKit.
+EnviousWispr turns your speech into text using one of two speech engines, Parakeet or WhisperKit. Both run entirely on your Mac. Neither sends your audio anywhere, and neither needs an internet connection once its model has been downloaded.
 
-**Keep Parakeet.** It is what you start with, it is the faster of the two, and it covers 25 European languages. Switch to WhisperKit only if you dictate in a language Parakeet does not cover.
+### Comparison of the two engines
 
-Both engines run on your Mac. Neither sends your audio anywhere, and neither needs an internet connection once its model has been downloaded.
-
-### The difference
-
-|  | Parakeet | WhisperKit |
-|---|---|---|
+| Feature | Parakeet | WhisperKit |
+| --- | --- | --- |
 | Languages | 25 European | 99 |
 | Speed | Faster | Slower |
 | Setup | Downloaded for you during setup | You download it, about 1.5 GB |
 | Best for | Everyday dictation | Languages Parakeet does not cover |
 
-### Switching
+### Choosing an engine
 
-1. Click the EnviousWispr icon in your menu bar, choose **Settings**, and go to **Transcription**.
-2. Pick your engine.
-3. The first time you choose WhisperKit, click **Download WhisperKit Model**. It does not download on its own.
+Keep Parakeet. It is the engine you start with, it is the faster of the two, and it covers 25 European languages. Switch to WhisperKit only if you dictate in a language Parakeet does not cover.
+
+To change your engine, follow these steps.
+
+**Open settings.** Click the EnviousWispr icon in your menu bar, choose **Settings**, and go to **Transcription**.
+
+**Pick your engine.** Select either Parakeet or WhisperKit.
+
+**Download the model.** The first time you choose WhisperKit, click **Download WhisperKit Model**. The model does not download on its own, and it takes about 1.5 GB of storage.
 
 The change applies to your next recording.
 
 ### What happens when you dictate
 
-1. EnviousWispr takes the audio it recorded.
-2. It trims the silence at the start and the end.
-3. Your engine reads it and writes out the text.
-4. Any clean-up you have switched on runs, then the text is pasted.
+Knowing the sequence helps you work out where a delay or an error came from. When you finish a recording, EnviousWispr does four things in order.
 
-Speed depends on your Mac, your engine and how long you spoke. If one feels slow or keeps missing your language, try the other.
+**Trim the audio.** EnviousWispr takes the audio it recorded and trims the silence at the start and the end.
 
-If speech recognition fails, EnviousWispr stays open. Start another recording and it sorts itself out.
+**Transcribe the speech.** Your chosen engine reads the audio and writes out the text.
+
+**Polish the text.** Any AI polish you have switched on runs against that text.
+
+**Paste the result.** The finished text is pasted into the text box you were working in.
+
+Transcription speed depends on your Mac, the engine you selected, and how long you spoke. If one engine feels slow or keeps missing your language, try the other. If speech recognition fails for any reason, EnviousWispr stays open. Start another recording and it sorts itself out.

--- a/website/src/content/help/choosing-an-ai-provider-none-apple-intelligence-ollama-openai-gemini.md
+++ b/website/src/content/help/choosing-an-ai-provider-none-apple-intelligence-ollama-openai-gemini.md
@@ -6,15 +6,17 @@ section: "Polish"
 order: 2
 keywords: ["turn off ai", "turn ai off", "disable ai", "no ai", "provider", "openai", "chatgpt", "gemini", "claude", "apple intelligence", "ollama", "which ai", "api key", "change provider", "stop rewriting my words"]
 related: ["ai-polish-and-cloud-data", "api-key-security"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. AI Polish is the step that tidies up your dictation, and you choose which AI does it. Go to **Settings** \> **AI Polish** to make the choice. These are your options.
+AI Polish is the step that tidies up your dictation after transcription, and you choose which provider does the work. Your transcription audio stays on your Mac on every one of these options. Open **Settings**, then select **AI Polish** to make your choice.
 
 ### Stays on your Mac
 
-- **Apple Intelligence.** Free, with nothing to set up. Needs macOS 26 or later on a Mac that supports it. This is what you start with.
-- **EG-1.** The model EnviousWispr built for dictation. Free. Download it from the AI Polish page, about 2.9 GB once.
-- **None.** No AI step at all. You still get filler-word removal and your custom words.
+These options process your text entirely on your own machine.
+
+- **Apple Intelligence.** Free, with nothing to set up. It requires macOS 26 or later on a Mac that supports Apple Intelligence. This is the default when you install the app.
+- **EG-1.** The model Envious Labs built specifically for dictation. It is free. Download it from the AI Polish page, and it takes about 2.9 GB of storage once installed.
+- **None.** No AI polish step runs at all. You still get filler-word removal and the benefit of your custom words.
 
 ### Your own setup
 
@@ -22,13 +24,13 @@ EnviousWispr is a free dictation app for macOS. AI Polish is the step that tidie
 
 ### Uses a company's service
 
-These need an account and a key from that company, and you pay them directly for what you use. Your text goes to them. Your audio never does, on any option.
+These options require an account and an API key from that company, and you pay them directly for what you use. Your transcribed text goes to them.
 
 - **OpenAI**
 - **Gemini**
 - **Claude**
 
-With OpenAI and Gemini, EnviousWispr also asks them not to keep a copy of the request.
+With OpenAI and Gemini, EnviousWispr also asks them not to keep a copy of your request.
 
 ### Side by side
 
@@ -42,4 +44,4 @@ With OpenAI and Gemini, EnviousWispr also asks them not to keep a copy of the re
 | Gemini | To Google | You pay Google | An API key |
 | Claude | To Anthropic | You pay Anthropic | An API key |
 
-Not sure? Leave it on Apple Intelligence. If your Mac cannot run that, try EG-1.
+If you are not sure which to pick, leave the setting on Apple Intelligence. If your Mac cannot run Apple Intelligence, try EG-1.

--- a/website/src/content/help/choosing-your-microphone.md
+++ b/website/src/content/help/choosing-your-microphone.md
@@ -6,24 +6,32 @@ section: "Input Configuration"
 order: 1
 keywords: ["microphone", "mic", "input device", "which microphone", "headset", "usb mic", "external mic", "built in mic", "change microphone", "wrong microphone"]
 related: ["bluetooth-and-airpods", "empty-or-missing-transcription"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. It can follow whichever microphone your Mac is set to, or use one you name yourself. Both choices live under **Settings** \> **Microphone**.
+EnviousWispr can follow whichever microphone your Mac is set to, or use a specific device you name yourself. Both choices live under **Settings** \> **Microphone**.
 
 ### Auto
 
-EnviousWispr records from whatever input your Mac is currently set to, and follows it as devices come and go. This is what you start with, and it suits most setups.
+Auto records from whatever input your Mac is currently set to, and follows that input as devices come and go. This is the default, and it suits most setups.
 
 To change what Auto follows, set your input in **System Settings** \> **Sound**.
 
-### Choosing one yourself
+### Choosing a specific microphone
 
-Pick a device from the list and EnviousWispr always uses that one, whatever your Mac is set to. This is worth doing if you keep ending up on the wrong microphone. The picker shows the device name in place of Auto once you have chosen.
+Pick a device from the list and EnviousWispr always uses that one, whatever your Mac is set to. This is worth doing if you keep ending up on the wrong microphone. The picker then shows that device's name in place of Auto.
+
+To select a specific device:
+
+**Open settings.** Click the EnviousWispr icon in the menu bar and select **Settings**, or press Cmd+,.
+
+**Go to the Microphone tab.** Click **Microphone** in the settings sidebar.
+
+**Select your device.** Choose your microphone from the list.
 
 ### If your microphone is unplugged mid-recording
 
-EnviousWispr keeps what it recorded up to that point and transcribes it, rather than losing the whole thing.
+EnviousWispr keeps what it recorded up to that point and transcribes it, rather than losing the entire recording.
 
 ### A note on headsets
 
-If your AirPods are your Mac's input, EnviousWispr records from them, and your headset drops out of music mode while it does. See [_Bluetooth and AirPods_](/help/bluetooth-and-airpods/).
+If your AirPods are your Mac's input, EnviousWispr records from them, and your headset drops out of music mode while it does. Read [_Bluetooth and AirPods_](/help/bluetooth-and-airpods/) for what that changes.

--- a/website/src/content/help/clipboard-preservation.md
+++ b/website/src/content/help/clipboard-preservation.md
@@ -6,25 +6,29 @@ section: "Paste System"
 order: 2
 keywords: ["clipboard", "copied text", "lost what i copied", "overwrites clipboard", "restore clipboard", "cmd v", "pasteboard"]
 related: ["how-text-gets-pasted-into-your-app"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. Some of the ways it delivers your text have to use your clipboard, so it saves whatever was there first and puts it back afterwards.
+When you dictate, your text often has to travel through your clipboard to reach the app you are working in. EnviousWispr handles that by recording whatever is on your clipboard first, and putting it back immediately afterwards.
 
 ### How it works
 
-1. Your clipboard is saved, everything on it, not only plain text.
-2. Your dictation is pasted.
-3. Your original clipboard comes back.
+EnviousWispr runs the paste in three steps, which is what protects what you already had.
+
+- **Save your clipboard.** Everything currently on the clipboard is preserved, not only plain text.
+- **Paste your dictation.** Your newly transcribed text appears in the text box you were working in.
+- **Restore your original clipboard.** What you had copied goes back onto the clipboard, so you lose nothing.
 
 ### When it leaves your clipboard alone
 
-- If your text went straight into the box, the clipboard was never touched.
-- If another app, such as a clipboard manager, changed the clipboard in between, EnviousWispr does not overwrite it.
-- If pasting failed and your dictation ended up on the clipboard, it stays there so you can paste it yourself.
+In three situations that cycle changes, each one to avoid losing something.
+
+- **Direct text insertion.** If your dictation went straight into the text box without using the clipboard, EnviousWispr never touched your clipboard at all.
+- **Third-party clipboard managers.** If another application changes your clipboard while your dictation is in progress, EnviousWispr does not overwrite the new content.
+- **Failed paste attempts.** If pasting failed and your dictation ended up on the clipboard instead, EnviousWispr leaves it there so you can paste it yourself.
 
 ### The two settings
 
-Both live under **Settings** \> **Clipboard**, and both are on out of the box.
+You control this under **Settings** \> **Clipboard**. Both options are on by default.
 
-- **Restore clipboard after paste.** Puts back what you had copied. Switch it off if you would rather keep your dictation on the clipboard to paste again somewhere else.
-- **Auto-copy to clipboard.** Copies your dictation whenever EnviousWispr is not pasting it into an app for you.
+- **Restore clipboard after paste.** Puts what you had copied back onto the clipboard after your dictation lands. Switch this off if you would rather keep the dictation on your clipboard to paste again somewhere else.
+- **Auto-copy to clipboard.** Copies your dictation to the clipboard whenever EnviousWispr is not pasting it into an app for you.

--- a/website/src/content/help/customizing-your-hotkey.md
+++ b/website/src/content/help/customizing-your-hotkey.md
@@ -5,31 +5,35 @@ category: "recording-and-hotkeys"
 section: "Recording"
 order: 4
 keywords: ["hotkey", "shortcut", "keyboard shortcut", "change the key", "how do i change the key", "key combo", "keybinding", "remap", "different key", "fn key", "caps lock", "conflicts with another app"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. Your hotkey is the key you hold or press to record, and you can change it to whatever suits your hands. It arrives set to the right Option key.
+Your hotkey is the key you hold or press to record, and you can change it to whatever suits your hands. EnviousWispr arrives set to the right Option key.
 
 ### Changing it
 
-1. Click the EnviousWispr icon in your menu bar, choose **Settings**, and go to **Shortcuts**.
-2. Click the **Recording hotkey** box.
-3. Press the keys you want.
+You can assign any key combination to your recording hotkey in settings.
 
-The new combination is saved straight away and shown in the box. Try it in any text field to confirm.
+1. **Open settings.** Click the EnviousWispr icon in your menu bar, choose **Settings**, and go to **Shortcuts**.
+2. **Select the hotkey box.** Click the **Recording hotkey** box.
+3. **Press your new keys.** Press the keys you want to use.
 
-### What you can use
+The new combination saves immediately and appears in the box. Click into any text field and try it to confirm it works.
 
-- Any key, with or without Command, Option, Control or Shift.
-- A modifier key on its own, such as Option by itself or Control by itself. This is worth considering, because your hand never has to leave the keys it already rests on.
+### Available key combinations
+
+You can choose almost any combination that fits how you work.
+
+- **A key with modifiers.** Any key, with or without Command, Option, Control, or Shift.
+- **A modifier on its own.** A modifier key by itself, such as Option alone or Control alone. This is worth considering, because your hand never has to leave the keys it already rests on.
 
 ### One key for both modes
 
-The recording hotkey is the same whether you use push to talk or toggle mode. Switching mode changes what a press does, never which key you press.
+The recording hotkey stays the same whether you use push to talk or toggle mode. Switching between modes changes what a press does to your recording, but never which key you press.
 
 ### The cancel key
 
-Escape throws a recording away. You can change it on the same **Shortcuts** page.
+Pressing Escape throws the current recording away without transcribing it. You can change this cancel key on the same **Shortcuts** page if you prefer a different one.
 
 ### If your hotkey stops working
 
-Something else is probably using the same combination. macOS shortcuts and other apps take priority over EnviousWispr. Pick a different combination.
+Another application or system feature is usually using the same key combination. macOS system shortcuts and other running apps take priority over EnviousWispr. Pick a different combination in **Shortcuts** to resolve the conflict.

--- a/website/src/content/help/download-and-install.md
+++ b/website/src/content/help/download-and-install.md
@@ -7,26 +7,30 @@ order: 3
 keywords: ["install", "download", "setup", "get started", "dmg", "first time", "where do i get it", "installation"]
 related: ["system-requirements", "granting-permissions-microphone-accessibility-and-automation"]
 seeAlso: "getting-started-enviouswispr-under-2-minutes"
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. Installing it takes about two minutes, and there is nothing to sign up for.
+EnviousWispr is a free, open-source dictation app for macOS. Installing it takes about two minutes, and there is no account to create and no subscription to start.
 
 ### Install it
 
-1. Download EnviousWispr from [enviouswispr.com](https://enviouswispr.com). What arrives is a disk image file ending in .dmg.
-2. Open the downloaded file. A window appears with the EnviousWispr icon in it. Drag that icon onto the Applications folder shown beside it.
-3. Open EnviousWispr from your Applications folder.
+**Download the disk image.** Go to [enviouswispr.com](https://enviouswispr.com) and download the installer file, which ends in the extension .dmg.
+
+**Open the file.** Double-click the downloaded file to mount the disk image. A window appears showing the EnviousWispr icon alongside the Applications folder.
+
+**Move the application.** Drag the EnviousWispr icon directly onto the Applications folder icon shown beside it.
+
+**Open the app.** Open your Applications folder and double-click EnviousWispr to run it for the first time.
 
 ### The first time you open it
 
-macOS may ask you to confirm, because you downloaded the app from the internet. Click **Open**.
+macOS may show a security warning because you downloaded the application from the internet. Click **Open** to proceed.
 
-EnviousWispr then walks you through setup: choosing a speech engine, picking the hotkey you will hold down to dictate, and granting the macOS permissions it needs.
+EnviousWispr then walks you through setup. You will choose a speech engine, pick the hotkey you will hold down while dictating, and grant the macOS permissions it needs.
 
 ### How you know it worked
 
-Look at the top right of your screen. The EnviousWispr icon sits in your menu bar, and clicking it is how you reach settings and history from now on. There is no Dock icon and no window left open.
+Look at the top right of your screen in the menu bar. The EnviousWispr icon sits there quietly. Clicking that icon is how you open settings and history from now on. The application runs entirely from the menu bar, which means there is no Dock icon and no window left open on your desktop.
 
 ### Updates
 
-EnviousWispr checks for updates on its own and tells you when one is ready. You never need to download the app again by hand.
+EnviousWispr checks for updates automatically and tells you when a new version is ready to install. You never need to download the installer file again by hand.

--- a/website/src/content/help/empty-or-missing-transcription.md
+++ b/website/src/content/help/empty-or-missing-transcription.md
@@ -6,9 +6,9 @@ section: "Transcription Issues"
 order: 3
 keywords: ["nothing happens", "no text", "empty", "microphone not working", "mic not working", "not hearing me", "no output", "blank", "nothing appears", "not transcribing", "not working at all", "silent", "no sound"]
 related: ["choosing-your-microphone", "granting-permissions-microphone-accessibility-and-automation"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. When a recording finishes and no text appears, something between your microphone and the speech model did not deliver. Work through these in order.
+When a recording finishes and no text appears, something between your microphone and the speech model did not deliver. These checks run from the most common cause to the least, so work through them in order.
 
 ### 1. Is the app hearing you?
 
@@ -16,24 +16,24 @@ Watch the recording bar on screen while you talk. Its meter moves with your voic
 
 ### 2. Check the microphone permission
 
-Open **System Settings** \> **Privacy & Security** \> **Microphone**. EnviousWispr should be in the list with its switch on. If it is not in the list at all, it has never been asked. Record once and macOS will prompt you.
+macOS requires explicit permission for an app to use your microphone. Open **System Settings**, click **Privacy & Security**, and click **Microphone**. EnviousWispr should be in the list with its switch turned on. If the app is not in the list at all, macOS has never been asked for permission. Record once and macOS will prompt you to allow access.
 
 ### 3. Check for a hardware mute
 
-Check the microphone itself, the cable, and any switch on a desk stand. Many headsets have a mute switch on the earcup or a button partway down the cable. A muted microphone still records. It records silence.
+A physical mute switch stops your voice reaching the app even when everything else is set up correctly. Check the microphone itself, the cable, and any switch on a desk stand. Many headsets have a mute switch on the earcup or a button partway down the cable. A muted microphone still records, but it records only silence.
 
 ### 4. Check the right microphone is selected
 
-Open EnviousWispr's settings and go to **Microphone**. On Auto, EnviousWispr records from whatever input your Mac is set to, which may not be the one you are speaking into. Pick a device from the list to be sure.
+EnviousWispr needs to listen to the device you are actually speaking into. Open EnviousWispr settings and go to **Microphone**. When set to Auto, EnviousWispr records from whatever input your Mac is using, which may not be the device at your mouth. Pick a specific device from the list to remove the ambiguity.
 
 ### 5. Is the speech model ready?
 
-The first launch downloads it, and until that download finishes there is nothing to transcribe with. Progress is shown on screen.
+The app downloads its speech model on first launch. Until that download finishes, there is no model available to transcribe your voice. Progress is shown on screen.
 
 ### 6. Was the recording very short?
 
-A recording of well under a second may not give the model enough to work with. Hold the key a moment longer, and pause for a beat before you start speaking.
+Very brief audio does not give the speech model enough to work with. A recording of well under a second may come back empty. Hold the hotkey a moment longer, and pause for a beat before you start speaking.
 
 ### 7. Were you quiet, or far from the microphone?
 
-Speaking softly or from across the room is a common reason a recording comes back looking silent. Move closer, or use a headset microphone.
+Quiet audio can register with the speech model as background noise rather than speech. Speaking softly or sitting far from the microphone is a common reason a recording comes back looking silent. Move closer, or use a headset microphone.

--- a/website/src/content/help/empty-or-missing-transcription.md
+++ b/website/src/content/help/empty-or-missing-transcription.md
@@ -1,6 +1,6 @@
 ---
 title: "Empty or Missing Transcription"
-description: "What to check when a recording finishes but no text appears."
+description: "What to check when your microphone is not working and no text appears."
 category: "troubleshooting"
 section: "Transcription Issues"
 order: 3

--- a/website/src/content/help/extended-thinking-reasoning-mode.md
+++ b/website/src/content/help/extended-thinking-reasoning-mode.md
@@ -5,18 +5,33 @@ category: "ai-polish"
 section: "Polish"
 order: 4
 keywords: ["thinking", "reasoning", "extended thinking", "slow", "takes too long", "quality vs speed"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. Deep reasoning is a setting that gives the AI more time to work on your text before it rewrites it. That extra time can help when what you are asking for is complicated.
+Deep reasoning is a setting that gives the AI more time to work on your text before it rewrites it. That extra time can help when what you are asking for is complicated.
 
 ### Turning it on
 
-Go to **Settings** \> **AI Polish** and switch on **Deep reasoning**. The switch only appears when the option and model you have chosen support it, so if you cannot find it, that is why.
+Deep reasoning is off when you install EnviousWispr. Once you switch it on, it applies to every dictation you make, not only the ones you think are complicated.
+
+**Open settings.** Click the EnviousWispr icon in the menu bar and select **Settings**.
+
+**Go to AI Polish.** Click the **AI Polish** tab.
+
+**Switch on Deep reasoning.** Turn on **Deep reasoning**. The switch only appears when the option and model you have chosen support it, so if you cannot find it, that is why.
 
 ### Which options support it
 
-Some OpenAI and Gemini models. Apple Intelligence, EG-1, Ollama and Claude do not support it.
+Deep reasoning is available only on certain cloud models.
+
+| Provider or option | Supports deep reasoning |
+| :--- | :--- |
+| OpenAI | Yes, on supported models |
+| Gemini | Yes, on supported models |
+| Apple Intelligence | No |
+| EG-1 | No |
+| Ollama | No |
+| Claude | No |
 
 ### The trade-off
 
-It takes longer on every dictation, not only the complicated ones. Leave it off for ordinary use, and turn it on when a complicated request is not coming out right.
+Switching this on changes how long you wait for every dictation to finish, not only the complicated ones. Leave it off for ordinary use, and turn it on when a complicated request is not coming out right.

--- a/website/src/content/help/filler-word-removal.md
+++ b/website/src/content/help/filler-word-removal.md
@@ -5,22 +5,28 @@ category: "features"
 section: "Text Processing"
 order: 2
 keywords: ["um", "uh", "filler", "filler words", "remove um", "you know", "like", "stop words", "cleaner speech"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. It strips "um", "uh", "hmm", "er" and similar noises out of your text before you ever see them. This is on out of the box.
+EnviousWispr automatically removes spoken noises like "um", "uh", "hmm", and "er" from your dictated text before it reaches your app. This is on by default.
 
 ### Turning it off
 
-Go to **Settings** \> **Transcription** and switch off **Remove filler words**. Your next dictation will keep the noises in.
+You can switch this off if you would rather keep your spoken hesitations in the final text.
 
-### It does not need AI
+**Open settings.** Click the EnviousWispr menu bar icon and select **Settings**, or press Cmd+,.
 
-This runs on your Mac with no AI model involved. It works when AI Polish is switched off, and it works with no internet connection.
+**Go to Transcription.** Click the **Transcription** tab.
+
+**Switch off the setting.** Turn off **Remove filler words**. Your next dictation keeps every noise in the text.
+
+### How it runs without AI
+
+This runs on your Mac against a fixed list of noises, with no AI model involved. It works with no internet connection, and it works even when AI Polish is switched off.
 
 ### What it leaves alone
 
-It only removes those noises when they stand on their own as words. The "um" inside "umbrella" is safe.
+EnviousWispr only removes these noises when they stand on their own as separate words. The "um" inside the word "umbrella" is left alone.
 
 ### If you want more than this
 
-AI Polish also removes hesitations, false starts and repeated words, which a fixed list of noises cannot catch.
+A fixed list only catches those specific sounds. AI Polish, which is on by default, goes further and also removes false starts, repeated words, and general hesitations that no list can anticipate.

--- a/website/src/content/help/first-word-gets-cut-off.md
+++ b/website/src/content/help/first-word-gets-cut-off.md
@@ -5,30 +5,34 @@ category: "troubleshooting"
 section: "Transcription Issues"
 order: 4
 keywords: ["first word", "cut off", "clipped", "missing the beginning", "loses the start", "chops the first word", "beginning missing"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. When the start of your speech goes missing, it is because the microphone was still waking up as you began to talk.
+When the start of your speech goes missing, it is because the microphone was still waking up as you began to talk.
 
 While the microphone is still awake from a recent dictation, EnviousWispr keeps the half second of audio from immediately before you pressed the key, so an early start is captured anyway. On a cold start there is no earlier audio to keep, and the first word or two can be lost.
 
 ### Keep the microphone awake for longer
 
-Open EnviousWispr's settings, go to **Microphone**, and find **Microphone Readiness**:
+You can change how long the microphone stays active between dictations, which is what prevents a cold start. Open EnviousWispr settings, click **Microphone**, and find **Microphone Readiness**:
 
-- **Off.** The microphone shuts down straight away. Lowest power use, slowest start, and no earlier audio kept.
-- **10 sec, 30 sec, 60 sec.** Stays ready for that long after each dictation. It arrives set to 30 seconds.
-- **Always.** Keeps the microphone ready all the time. The macOS microphone indicator may stay visible, and power use may go up.
+- **Off.** The microphone shuts down straight away. This setting gives the lowest power use, the slowest start, and no earlier audio kept.
+- **10 sec, 30 sec, 60 sec.** The microphone stays ready for that long after each dictation. The app arrives set to 30 seconds.
+- **Always.** The microphone stays ready all the time. The macOS microphone indicator may stay visible in your menu bar, and power use may go up.
 
 ### When a word can still go missing
 
+Some situations need the microphone to wake from a completely inactive state, and those can still cost you a word:
+
 - Your first dictation after opening the app.
-- The first one after Microphone Readiness has run out.
-- The first one after connecting AirPods or another Bluetooth headset, which takes a moment to switch into microphone mode.
+- The first dictation after your Microphone Readiness timer has run out.
+- The first dictation after connecting AirPods or another Bluetooth headset, which takes a moment to switch into microphone mode.
 
 ### What to do
 
-- Pause for a beat after pressing the key, before you speak.
-- Set Microphone Readiness to **60 sec** or **Always**.
-- Use push-to-talk. Holding the key down starts waking the microphone while you are still drawing breath.
+If your speech keeps cutting off at the beginning, try these adjustments:
 
-You will know it is fixed when your next few dictations open with the word you meant to say.
+- **Pause briefly.** Pause for a beat after pressing your hotkey, before you begin to speak.
+- **Change your readiness time.** Set Microphone Readiness to **60 sec** or **Always**.
+- **Use push to talk.** Holding the key down starts waking the microphone while you are still drawing breath.
+
+You will know the problem is fixed when your next few dictations open with the exact word you meant to say.

--- a/website/src/content/help/granting-permissions-microphone-accessibility-and-automation.md
+++ b/website/src/content/help/granting-permissions-microphone-accessibility-and-automation.md
@@ -6,23 +6,23 @@ section: "Basics"
 order: 5
 keywords: ["permissions", "permission", "allow", "access", "microphone access", "accessibility", "privacy settings", "system settings", "grant", "it is asking for permission", "blocked", "denied"]
 related: ["accessibility-permission-not-working", "paste-not-working"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. Because it listens to your microphone and types into other apps, macOS makes you grant it permission first. Two permissions are needed, and a third only in rare cases. The **Permissions** page in EnviousWispr's settings always shows where each one stands.
+Because EnviousWispr listens to your microphone and types into other apps, macOS requires you to grant specific permissions first. Two permissions are always needed, and a third is required only in rare cases. The **Permissions** page in EnviousWispr settings always shows the current status of each one.
 
 ### Microphone
 
-This one lets EnviousWispr hear you while you dictate.
+This permission allows EnviousWispr to hear your voice while you dictate.
 
-macOS asks the first time you record. If you missed the prompt, open **System Settings** \> **Privacy & Security** \> **Microphone** and switch EnviousWispr on.
+**Grant permission.** macOS asks the first time you record. If you missed the prompt, open **System Settings**, select **Privacy & Security**, click **Microphone**, and switch EnviousWispr on.
 
 You will know it worked when you hold your hotkey and the meter on the recording bar moves as you speak.
 
 ### Accessibility
 
-This one lets EnviousWispr put the finished text into your app for you.
+This permission allows EnviousWispr to place the finished text directly into the app you are working in.
 
-Open **System Settings** \> **Privacy & Security** \> **Accessibility**, click **+**, and add EnviousWispr from your Applications folder.
+**Grant permission.** Open **System Settings**, select **Privacy & Security**, click **Accessibility**, click the plus button, and add EnviousWispr from your Applications folder.
 
 You will know it worked when your next dictation lands in the text box on its own.
 
@@ -30,12 +30,12 @@ Without this permission, dictation still works. EnviousWispr copies your text to
 
 ### Automation
 
-This one is a fallback, asked for only when the usual ways of pasting fail in a particular app.
+This permission is a fallback, requested only when the usual ways of pasting fail inside a particular application.
 
-macOS asks whether EnviousWispr can control "System Events". Click **OK**. To change your answer later, open **System Settings** \> **Privacy & Security** \> **Automation**.
+**Grant permission.** macOS asks whether EnviousWispr can control System Events. Click **OK**. To change your answer later, open **System Settings**, select **Privacy & Security**, and click **Automation**.
 
-Declining is fine. Most apps never need it.
+Declining this permission is fine, because most applications never require it.
 
 ### Your hotkey needs no permission
 
-The key you hold to record works everywhere on its own. These permissions are only about hearing you and delivering the text.
+The key you hold to record works everywhere on its own. These permissions are strictly about hearing your voice and delivering the text.

--- a/website/src/content/help/hallucination-protection.md
+++ b/website/src/content/help/hallucination-protection.md
@@ -6,22 +6,24 @@ section: "Polish"
 order: 7
 keywords: ["hallucination", "made up words", "invented text", "wrong words added", "ai changed my meaning", "extra text", "it added things i didnt say"]
 related: ["why-is-my-dictation-inaccurate"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. It can hand your dictation to an AI to tidy up, and AI models sometimes make things up. EnviousWispr checks the result before it reaches you and throws out the clear failures.
+EnviousWispr can hand your dictation to an AI model to tidy up, and AI models sometimes invent content you never spoke. EnviousWispr checks the result before it reaches your cursor and throws out the clear failures.
 
 ### What it checks
 
-- **Text that grew far beyond what you said.** Something was added.
-- **Text that lost most of what you said.** It was cut, not tidied.
-- **An answer instead of an edit.** Ask a question out loud and you get your question back, not a reply to it.
-- **Chatter.** Openers like "Certainly!" are stripped rather than pasted.
-- **Very short dictations.** These skip AI Polish entirely and keep the earlier clean-up result.
+EnviousWispr tests the polished text against a set of known failure patterns before pasting anything into your app.
 
-Apple Intelligence also checks longer results in other languages in case the AI switched language on you.
+- **Text that grew far beyond what you said.** The model added material that was not in your speech.
+- **Text that lost most of what you said.** The model cut your words instead of tidying them.
+- **An answer instead of an edit.** If you speak a question out loud, the polish step might return an answer to it rather than a tidied version of the words you spoke.
+- **Chatter.** Conversational openers such as "Certainly!" are stripped from the output rather than pasted into your document.
+- **Very short dictations.** These skip the AI polish step entirely and keep the earlier clean-up result.
+
+Apple Intelligence also checks longer results in other languages, in case the model switched language partway through.
 
 ### What you get when a check rejects the result
 
-The tidied-up version of your dictation from immediately before the AI step. You never lose what you said if the polish goes wrong.
+When a check rejects the polished text, EnviousWispr gives you the tidied-up version of your dictation from immediately before the AI step. You never lose what you said because the polish went wrong.
 
-These checks catch the obvious failures, not every bad edit. Read anything important before you send it.
+These checks catch the obvious failures rather than every bad edit. Read anything important before you send it.

--- a/website/src/content/help/hands-free-mode-long-dictation.md
+++ b/website/src/content/help/hands-free-mode-long-dictation.md
@@ -6,29 +6,36 @@ section: "Recording"
 order: 2
 keywords: ["hands free", "handsfree", "long dictation", "dont want to hold", "without holding", "let go", "keep recording", "long recording", "stop holding the key"]
 related: ["voice-activity-detection-and-auto-stop", "recording-won-t-stop-or-seems-stuck"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. Hands-free mode locks recording on, so you can keep talking without holding a key down. It is worth using for anything longer than a sentence or two: a blog post, a long email, notes after a meeting.
+Hands-free mode locks recording on so you can dictate without holding a key down. This mode suits any text longer than a sentence or two, such as a blog post, a long email, or meeting notes.
 
-### Turning it on
+### Turning on hands-free mode
 
-1. Tap your hotkey to start recording.
-2. Press it again within half a second.
-3. Let go. Recording keeps going.
+EnviousWispr relies on a double tap of your hotkey to lock the recording in place. This works whenever you have push to talk selected as your recording mode.
 
-The bar on screen grows to confirm that recording is locked on. If nothing locks, you were too slow. Tap and press again a little quicker.
+**Tap, then tap again.** Start your recording with a normal press of your hotkey, then press it a second time within half a second, before you let go.
 
-Hands-free works with push to talk, so you can use it whenever that recording mode is selected.
+The on-screen bar grows to confirm that recording is locked on. If the bar does not change, the second press came too late, and the recording ends as usual when you release the key. Try the double tap a little quicker.
 
-### Stopping
+### Stopping recording
 
-- **Press your hotkey once** to stop and get your text.
-- **Press Escape** to throw the recording away.
+You have two choices when you finish speaking, depending on whether you want to keep what you said.
 
-### How long you can talk
+**Press your hotkey once.** Stop recording and insert your text into the app you were working in.
 
-Up to an hour. You get a warning a minute before the limit, then EnviousWispr stops on its own and writes out what you said.
+**Press Escape.** Stop recording and discard the audio without producing any text.
 
-### Stopping automatically when you go quiet
+### Time limits
 
-You can have recording end by itself after a pause. Open EnviousWispr's settings, go to **Transcription**, and switch on **Stop recording on silence**. It is off unless you turn it on. The slider under it sets how long a pause has to be, from half a second to three seconds.
+A single hands-free session can last up to one hour. EnviousWispr shows a warning one minute before that limit, then stops on its own and writes out everything you said.
+
+### Stopping automatically on silence
+
+You can have EnviousWispr end a recording by itself after a pause in your speech.
+
+**Open settings.** Click the EnviousWispr icon in your menu bar, choose **Settings**, and go to the **Transcription** tab.
+
+**Switch on silence detection.** Turn on **Stop recording on silence**. This setting is off by default.
+
+**Set the pause length.** Use the slider beneath the switch to choose how long you have to pause before recording stops, anywhere from half a second to three seconds.

--- a/website/src/content/help/hands-free-mode-long-dictation.md
+++ b/website/src/content/help/hands-free-mode-long-dictation.md
@@ -1,6 +1,6 @@
 ---
 title: "Hands-Free Mode (Long Dictation)"
-description: "Lock recording on so you can keep talking without holding a key."
+description: "For when you do not want to hold the key down: lock recording on and keep talking."
 category: "recording-and-hotkeys"
 section: "Recording"
 order: 2
@@ -8,7 +8,7 @@ keywords: ["hands free", "handsfree", "long dictation", "dont want to hold", "wi
 related: ["voice-activity-detection-and-auto-stop", "recording-won-t-stop-or-seems-stuck"]
 updated: 2026-08-06
 ---
-Hands-free mode locks recording on so you can dictate without holding a key down. This mode suits any text longer than a sentence or two, such as a blog post, a long email, or meeting notes.
+Hands-free mode locks recording on, for when you do not want to hold the key down while you talk. This mode suits any text longer than a sentence or two, such as a blog post, a long email, or meeting notes.
 
 ### Turning on hands-free mode
 

--- a/website/src/content/help/how-custom-word-correction-works.md
+++ b/website/src/content/help/how-custom-word-correction-works.md
@@ -6,22 +6,26 @@ section: "Custom Words"
 order: 2
 keywords: ["how correction works", "why didnt my word work", "fuzzy match", "sounds like", "replacement rules"]
 related: ["adding-custom-words"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. When you teach it a custom word, you give it one spelling, and it then recognises the many ways that word can come out wrong and corrects them for you.
+When you teach EnviousWispr a custom word, you give it one correct spelling, and it then recognises the many ways that word can come out wrong during transcription and corrects them for you.
 
-### Three kinds of mistake it catches
+### The three kinds of mistake it catches
 
-- **Split apart.** "Chat G P T" and "Chat GPT" both become "ChatGPT".
-- **Sounds right, spelled wrong.** "Cue Bernetes" becomes "Kubernetes".
-- **Close but not exact.** "Kubernettes" becomes "Kubernetes".
+Transcription errors on an unfamiliar word fall into three groups, and custom word correction handles all three.
 
-### It happens first
+- **Split apart.** A single word that arrived in pieces is put back together. Both "Chat G P T" and "Chat GPT" become "ChatGPT".
+- **Sounds right, spelled wrong.** A word the engine heard correctly but wrote phonetically is corrected to your spelling. "Cue Bernetes" becomes "Kubernetes".
+- **Close but not exact.** Small spelling slips from the speech engine are fixed. "Kubernettes" becomes "Kubernetes".
 
-Your words are corrected before anything else touches the text, so they are already right by the time filler removal and AI Polish see them.
+### When custom word correction runs
+
+Custom word correction runs first, before anything else touches the text. Your words are therefore already right by the time filler removal and AI Polish see them.
 
 ### If a word is not being caught
 
-- Check that the spelling you saved is exactly what you want to see.
-- Say the word as you normally would, then look in **History** to see what EnviousWispr actually heard. That tells you which version to add.
-- Very short words are harder to match safely, because matching them would change words you did not mean.
+If one of your custom words keeps slipping through, work through these checks.
+
+- **Verify your spelling.** Check that the spelling you saved is exactly what you want to see in your text.
+- **Inspect your history.** Say the word as you normally would, then open **History** to see what EnviousWispr actually heard. That transcript tells you which wrong version to add.
+- **Consider the word's length.** Very short words are harder to match safely, because matching them broadly enough to catch would also change common words you did not mean to touch.

--- a/website/src/content/help/how-smart-polish-works-context-aware.md
+++ b/website/src/content/help/how-smart-polish-works-context-aware.md
@@ -5,27 +5,35 @@ category: "ai-polish"
 section: "Polish"
 order: 3
 keywords: ["smart polish", "context", "context aware", "knows what app", "different apps", "tone", "formal", "casual"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. When it hands your dictation to an AI to tidy up, it can pass along a few facts about that dictation, so the corrections are better than they would be from the words alone.
+When EnviousWispr sends your dictation to an AI for polishing, it includes a small set of background facts along with your words. That extra context helps the AI make better corrections than it could by reading the transcript alone.
 
-### What it can pass along
+### What context gets included
 
-- **That this is speech, not typing.** So the AI looks for words that sound alike but are wrong, such as "their" for "there".
-- **Which language you spoke.** So you get corrected, not translated.
-- **Which app you are dictating into.** A Slack message and a code comment should not be tidied up the same way.
-- **Your custom words.** So your spellings survive the rewrite.
+EnviousWispr can send several pieces of information to the AI alongside your text.
 
-Short dictations are sent with an instruction to leave well alone.
+- **That this is speech, not typing.** The AI knows to look for words that sound alike but are wrong, such as "their" for "there".
+- **Which language you spoke.** The AI knows which language you used, so it corrects your grammar instead of translating you.
+- **Which app you are dictating into.** A message in Slack and a comment in a code editor need different styles of tidying.
+- **Your custom words.** Your own vocabulary list goes along too, so your spellings survive the rewrite.
 
-### How much is sent depends on the option
+Short dictations carry an instruction to leave them alone, which stops the AI overworking a brief phrase.
 
-- **OpenAI, Gemini and Claude** get the app name and your custom words.
-- **Ollama** depends on the model you picked. Some get both, some get neither.
-- **Apple Intelligence and EG-1** get neither. Both are small on-device models that do better with short instructions, and EG-1 was trained without them.
+### How context varies by provider
+
+How much context is sent depends on the polish option you selected in settings.
+
+| Polish option | App name included | Custom words included |
+| :--- | :--- | :--- |
+| **OpenAI, Gemini, and Claude** | Yes | Yes |
+| **Ollama** | Varies | Varies |
+| **Apple Intelligence and EG-1** | No | No |
+
+What Ollama receives depends on the model you picked. Some Ollama models get both the app name and your custom words, and others get neither. Apple Intelligence and EG-1 get neither. Both are compact on-device models that do better with short instructions, and EG-1 was trained without those context fields.
 
 Your custom words are applied to your text before AI Polish runs anyway, as long as custom words are switched on under **Your Words**. Sending them to the AI as well is a second layer, not the only one.
 
 ### Your words are treated as words
 
-If you dictate something that sounds like an instruction, such as "ignore everything above", the AI tidies that sentence up instead of obeying it. Your dictation is always text to fix, never orders to follow.
+If you dictate a phrase that sounds like an instruction, such as "ignore everything above", the AI treats that sentence as text to tidy up rather than an order to follow. Your dictation is always handled as text to fix, never as a command to run.

--- a/website/src/content/help/how-text-gets-pasted-into-your-app.md
+++ b/website/src/content/help/how-text-gets-pasted-into-your-app.md
@@ -6,32 +6,32 @@ section: "Paste System"
 order: 1
 keywords: ["paste", "how does it type", "where does the text go", "delivery", "spacing", "capitals", "capitalisation", "capitalization", "stop capitalising", "stop capitalizing", "capital letters", "extra space", "no space", "jams words together", "smart insertion", "middle of a sentence", "cursor"]
 related: ["clipboard-preservation", "paste-not-working"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. It remembers the app and text field that were focused when you started recording, and delivers your text there. It works anywhere you can type: native Mac apps, browsers, and apps built on web technology such as VS Code, Slack, Discord and Notion.
+EnviousWispr remembers the app and text field that were focused when you started recording, and delivers your text there. It works anywhere you can type, including native Mac apps, web browsers, and apps built on web technology such as VS Code, Slack, Discord, and Notion.
 
-### It picks the destination at the start
+### The destination is locked in at the start
 
-Not at the end. AI Polish can take a few seconds, and by then you may have clicked elsewhere. Locking the destination in at the start means your words land where you were talking. Keep that field open until the text arrives.
+EnviousWispr captures your active text field when you begin recording rather than when you finish. AI polish can take a few seconds, and you might click into a different window while you wait. Locking the destination at the beginning is what makes sure your words land where you started talking. Keep that text field open until your text arrives.
 
-### It tries the cleanest method first
+### Three ways to deliver the text, tried in order
 
-The cleanest method is writing straight into the text box, without touching your clipboard. Some apps will not accept that, so EnviousWispr falls back to an ordinary paste, and then to the app's own Edit \> Paste menu.
+EnviousWispr first tries to write your text directly into the text box, without touching your clipboard. Some apps reject direct input, so it falls back to an ordinary paste command, and then to the app's own Edit \> Paste menu.
 
-If none of those work, your text goes to your clipboard and EnviousWispr tells you, so you can paste it yourself. You never lose a dictation to a failed paste.
+If all three fail, EnviousWispr copies your text to your clipboard and tells you, so you can paste it yourself. You never lose a dictation to a failed paste.
 
-### Spacing and capitals
+### Spacing and capitals are handled for you
 
-EnviousWispr looks at the text on either side of your cursor and matches it. Dictating into the middle of a sentence adds a space where one is needed and keeps the capital letter right, instead of jamming your words up against what is already there.
+EnviousWispr looks at the text on either side of your cursor and matches it. Dictating into the middle of a sentence adds a space where one is needed and gets the capital letter right, instead of jamming your new words against what is already there.
 
-Capitals are matched in English, German, French, Italian, Spanish, Portuguese, Dutch, Danish, Swedish, Finnish, Russian and Turkish. German is handled on its own terms, so nouns keep the capital they are supposed to have. In any other language EnviousWispr takes care of the spacing and leaves your capitals exactly as you said them.
+Capital matching works in English, German, French, Italian, Spanish, Portuguese, Dutch, Danish, Swedish, Finnish, Russian, and Turkish. German follows its own rules, so nouns keep the capital letters they are supposed to have. In every other language, EnviousWispr handles the spacing and leaves your capitals exactly as you spoke them.
 
-You can switch this off under **Settings** \> **Clipboard**, where it is called **Smart insertion**.
+You can turn this behaviour off under **Settings** \> **Clipboard**, where the setting is named **Smart insertion**.
 
-### Your clipboard
+### Your clipboard contents are preserved
 
-When **Restore clipboard after paste** is on, EnviousWispr saves what was on your clipboard and puts it back after pasting. It is on out of the box. See [_Clipboard Preservation_](/help/clipboard-preservation/).
+When **Restore clipboard after paste** is switched on, EnviousWispr saves whatever was on your clipboard before you dictated and puts it back immediately after pasting. This setting is on by default. See [_Clipboard Preservation_](/help/clipboard-preservation/) for the detail.
 
-### What this needs
+### The permission this needs
 
-Accessibility permission. Without it, EnviousWispr copies your text to the clipboard and tells you instead. Full-screen games and apps that block simulated typing are the other exceptions.
+EnviousWispr needs macOS Accessibility permission to insert text for you. Without it, the app copies your text to your clipboard and tells you instead. Full-screen games and applications that block simulated typing also prevent direct insertion.

--- a/website/src/content/help/importing-and-exporting-custom-words.md
+++ b/website/src/content/help/importing-and-exporting-custom-words.md
@@ -32,7 +32,7 @@ Exporting creates a file holding your whole custom word list, which you can keep
 
 If you want to clear out several terms together, you can select them as a group rather than deleting them one at a time.
 
-**Turn on selection.** Click **Select**, which sits just above your list of terms.
+**Turn on selection.** Click **Select**, which sits directly above your list of terms.
 
 **Choose the words.** Tick the box next to every word you want to remove.
 

--- a/website/src/content/help/importing-and-exporting-custom-words.md
+++ b/website/src/content/help/importing-and-exporting-custom-words.md
@@ -6,27 +6,34 @@ section: "Custom Words"
 order: 3
 keywords: ["import", "export", "backup my words", "csv", "move to a new mac", "transfer", "share my word list"]
 related: ["adding-custom-words"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. Your custom words are the names and terms you have taught it, and you can move them to another Mac or bring them in from another dictation app. Everything on this page lives under **Settings** \> **Your Words**.
+Your custom words are the names and specialised terms you have taught EnviousWispr to recognise. You can move them to another Mac or bring them in from another dictation app. Every control mentioned on this page lives under **Settings** \> **Your Words**.
 
-### Importing
+### Importing custom words
 
-1. Click **Import**.
-2. Choose to paste a list of words, open a file, or bring them in from another dictation app.
-3. Review what it found, then add them.
+Importing adds new terms to your list without changing the words you already have. You can bring in a plain text file, paste a list directly, or pull terms from another dictation app installed on your Mac.
 
-The file can be one you exported from EnviousWispr, or a plain text list with one word per line. If you have Wispr Flow, FluidVoice or Superwhisper installed, EnviousWispr can read your words straight out of them.
+**Open the import tool.** Click **Import** on the Your Words page.
 
-Importing only adds. Words you already have are left alone.
+**Choose your source.** Select whether you want to paste a list of words, open a saved file, or import from another dictation app. EnviousWispr can read your existing vocabulary straight out of Wispr Flow, FluidVoice, or Superwhisper if you have them installed. If you are importing from a file, that file can be a previous export from EnviousWispr or any plain text document with one word per line.
 
-### Exporting
+**Review and confirm.** Check the list of terms it found, then add them to your list.
 
-1. Click **Export your words**.
-2. Choose where to save the file.
+### Exporting your vocabulary
 
-Keep that file as a backup, or import it on another Mac.
+Exporting creates a file holding your whole custom word list, which you can keep as a backup or carry to another Mac.
 
-### Removing several at once
+**Start the export.** Click **Export your words**.
 
-Click **Select** above your list of terms, tick the ones you want gone, then click **Delete**.
+**Save the file.** Choose where on your Mac you want to store it, then confirm the location.
+
+### Removing several words at once
+
+If you want to clear out several terms together, you can select them as a group rather than deleting them one at a time.
+
+**Turn on selection.** Click **Select**, which sits just above your list of terms.
+
+**Choose the words.** Tick the box next to every word you want to remove.
+
+**Delete the selection.** Click **Delete** to remove all the ticked words at once.

--- a/website/src/content/help/is-enviouswispr-free.md
+++ b/website/src/content/help/is-enviouswispr-free.md
@@ -6,24 +6,26 @@ section: "Cost"
 order: 1
 keywords: ["free", "is this free", "price", "cost", "pricing", "subscription", "pay", "trial", "how much", "premium", "hidden costs", "catch"]
 related: ["source-code-and-contributing", "choosing-an-ai-provider-none-apple-intelligence-ollama-openai-gemini"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS, and free means all of it. There is no subscription, no trial period and no account to create.
+EnviousWispr is a free dictation app for macOS, and free means all of it. There is no subscription, no trial period, and no account to create.
 
 ### What you get
 
-- Both speech engines and every language they cover.
-- AI Polish, including options that run entirely on your Mac.
-- Every recording mode, and hotkeys you can set to anything.
-- Your own dictionary of custom words, plus ready-made vocabulary packs.
-- Unlimited dictation, and a History with no limit on how much it keeps.
+Every installation includes the complete feature set, with no hidden tiers and no paywalls.
+
+- **Speech engines.** Both speech engines, and every language they cover.
+- **AI polish.** AI Polish, including the options that run entirely on your Mac.
+- **Recording modes.** Every recording mode, and hotkeys you can set to anything.
+- **Custom vocabulary.** Your own dictionary of custom words, plus ready-made vocabulary packs.
+- **History with no ceiling.** Unlimited dictation, and a History with no limit on how much it keeps.
 
 ### The one thing that can cost money
 
-If you choose OpenAI, Gemini or Claude for AI Polish, you bring your own key and pay that company for what you use. EnviousWispr charges nothing either way.
+If you choose OpenAI, Gemini, or Claude for AI Polish, you bring your own API key and pay that company for what you use. EnviousWispr charges nothing either way.
 
-You never have to go that route. Apple Intelligence, EG-1, and Ollama models you download to your Mac all polish for free. Ollama's hosted models run on Ollama's servers, and some of those need a paid Ollama plan.
+You never have to go that route. Apple Intelligence, EG-1, and Ollama models you download to your Mac all polish for free. Ollama also has hosted models that run on its own servers, and some of those need a paid Ollama plan.
 
-### Why free
+### Why it is free
 
-We want EnviousWispr in as many hands as possible. It is also open source, so you can read it, build it, and keep using it whatever Envious Labs does later.
+The goal is to put EnviousWispr into as many hands as possible. The app is also open source under the GPLv3 license, so you can read the code, build it yourself, and keep using it whatever Envious Labs does later.

--- a/website/src/content/help/live-transcription-streaming-asr.md
+++ b/website/src/content/help/live-transcription-streaming-asr.md
@@ -6,9 +6,9 @@ section: "Transcription"
 order: 4
 keywords: ["live", "live text", "see words as i speak", "real time", "realtime", "streaming", "as you talk", "preview"]
 seeAlso: "live-transcription-that-keeps-up-with-you"
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. It normally writes your text once you stop talking. Live transcription writes it while you are still speaking, and it is off unless you turn it on.
+EnviousWispr normally writes your text once you stop talking. Live transcription writes it while you are still speaking, and it is off unless you turn it on.
 
 **Leave it off on Parakeet. On WhisperKit, turn it on if you have picked a language and you often dictate for more than a minute.**
 
@@ -16,7 +16,7 @@ EnviousWispr is a free dictation app for macOS. It normally writes your text onc
 
 Go to **Settings** \> **Transcription** and switch on **Live transcription**. The question mark beside it explains what changes for the engine you are on.
 
-### Why we say leave it off on Parakeet
+### Why you should leave it off on Parakeet
 
 Parakeet writes your speech in overlapping pieces and joins them together. The joins are where mistakes appear, and the longer you talk the more joins there are.
 

--- a/website/src/content/help/model-downloads-and-management.md
+++ b/website/src/content/help/model-downloads-and-management.md
@@ -6,15 +6,15 @@ section: "Transcription"
 order: 3
 keywords: ["download model", "model download", "stuck downloading", "how big", "disk space", "gb", "storage", "redownload", "model files", "where are the models"]
 related: ["uninstalling-enviouswispr"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. It turns your speech into text using a model kept on your own Mac rather than on a server, so there is a download the first time and some disk space to manage afterwards.
+EnviousWispr keeps its speech models on your own Mac rather than on a server, which is what lets your audio stay on the device. The trade for that is a download the first time and some disk space to manage afterwards.
 
 ### The two downloads
 
-Parakeet, the engine you start with, is downloaded for you during setup, and you watch the progress as it goes. It is about 480 MB.
+**Parakeet.** This engine is downloaded for you during setup, and you watch the progress as it goes. It is about 480 MB.
 
-WhisperKit is not downloaded for you. If you switch to it, go to **Settings** \> **Transcription** and click **Download WhisperKit Model**. It is about 1.5 GB.
+**WhisperKit.** This engine is not downloaded for you. If you switch to it, go to **Settings** \> **Transcription** and click **Download WhisperKit Model**. It is about 1.5 GB.
 
 Each download is checked before it is used, so a broken or half-finished file is never loaded.
 
@@ -26,14 +26,18 @@ EnviousWispr retries some temporary network problems by itself. Anything else st
 
 The model stays in your Mac's memory between dictations so there is nothing to load next time. If you would rather have the memory back, go to **Settings** \> **Transcription** and change **Unload model after**.
 
-It arrives set to **Never**, so the model stays loaded. The other choices unload it after 2, 5, 10, 15 or 60 minutes of not being used, or straight after every recording. Each one costs you a short wait next time you dictate.
+It arrives set to **Never**, so the model stays loaded. The other choices unload it after 2, 5, 10, 15 or 60 minutes of not being used, or straight after every recording. Each one costs you a short wait the next time you dictate.
 
 ### Freeing up disk space
 
-For WhisperKit, open **Transcription** and use **Remove Model**. For EG-1, the polish model EnviousWispr built, open **AI Polish** and use the remove button there. Ollama models are removed from that same AI Polish page.
+You can remove models you no longer need to recover storage, and you can download any of them again later.
 
-You can download any of them again later.
+**Remove a WhisperKit model.** Open **Transcription** and use **Remove Model**.
+
+**Remove EG-1.** EG-1 is the polish model EnviousWispr built. Open **AI Polish** and use the remove button there.
+
+**Remove Ollama models.** Ollama models are removed from that same **AI Polish** page.
 
 ### The other speed setting
 
-How quickly a dictation _starts_ is a different setting, under **Microphone**. See [_First Word Gets Cut Off_](/help/first-word-gets-cut-off/).
+How quickly a dictation starts is a different setting, under **Microphone**. See [_First Word Gets Cut Off_](/help/first-word-gets-cut-off/).

--- a/website/src/content/help/multi-language-dictation.md
+++ b/website/src/content/help/multi-language-dictation.md
@@ -6,20 +6,24 @@ section: "Transcription"
 order: 2
 keywords: ["language", "languages", "spanish", "french", "german", "hindi", "not english", "foreign language", "bilingual", "multilingual", "change language", "accent"]
 related: ["choosing-a-speech-engine-parakeet-vs-whisperkit"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS, and it is not English-only. Most people need to change nothing: Parakeet, the engine you start with, handles 25 European languages on its own, with no language to set.
+EnviousWispr handles dozens of languages without asking you to change a setting before every session. Parakeet, the transcription engine you start with, recognises 25 European languages on its own, with nothing to configure.
 
-### If your language is not one of those 25
+### Switching to WhisperKit for more languages
 
-1. Click the EnviousWispr icon in your menu bar, choose **Settings**, and go to **Transcription**.
-2. Choose **WhisperKit** and click **Download WhisperKit Model** if you have not already.
-3. Pick your language from the list, or leave it on auto-detect.
+If your spoken language is not among the 25 Parakeet covers, switch to the WhisperKit engine, which supports 99 languages.
 
-WhisperKit covers 99 languages. You will know it is working when your next dictation comes back in the language you spoke.
+**Open settings.** Click the EnviousWispr icon in your menu bar, choose **Settings**, and go to **Transcription**.
 
-### Tips
+**Select WhisperKit.** Choose **WhisperKit** from the transcription engine options. If you have not downloaded the engine yet, click **Download WhisperKit Model**.
 
-- On WhisperKit, naming your language is more accurate than leaving it on auto-detect.
-- Auto-detect copes with one language at a time. It struggles when you switch language mid-sentence.
-- AI Polish will not translate you. Dictate in French and you get French back.
+**Choose your language.** Pick your language from the list, or leave the setting on auto-detect.
+
+You will know the setup is working when your next dictation comes back in the language you spoke.
+
+### Tips for the best results
+
+- **Name your language rather than auto-detecting.** Choosing your language in settings gives higher accuracy than leaving it on auto-detect.
+- **Keep to one language per sentence.** Auto-detect handles one language at a time and struggles when you switch languages mid-sentence.
+- **Expect correction, not translation.** AI Polish cleans up grammar and filler words, but it does not translate. Dictating in French returns French text.

--- a/website/src/content/help/noise-suppression.md
+++ b/website/src/content/help/noise-suppression.md
@@ -5,14 +5,14 @@ category: "audio-and-microphone"
 section: "Audio Processing"
 order: 3
 keywords: ["noise", "background noise", "noisy room", "cafe", "fan", "noise cancelling", "suppression", "echo"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS, and it has no noise suppression setting. It records your microphone as it is and lets the speech model handle the audio.
+EnviousWispr has no noise suppression setting. It records your microphone as it is and lets the speech model handle the audio directly.
 
-### Why it went
+### Why noise suppression was removed
 
-Processing the audio first hurt transcription accuracy more than it helped, and it slowed every recording down. The setting was removed in version 2.0.2, and switched off for you when you updated.
+Running the audio through a suppression filter before transcription hurt accuracy more than it helped, and it added a noticeable delay to every recording. The setting was removed in version 2.0.2, and switched off automatically when you updated.
 
-### If background noise is hurting your accuracy
+### How to manage background noise
 
-Move closer to your microphone, or try a headset microphone. Dictate the same sentence both ways and compare the results in **History**.
+If sound around you is hurting your accuracy, change your physical setup rather than looking for a software filter. Move closer to your microphone, or switch to a headset microphone. You can test any change by dictating the same sentence both ways and comparing the results in **History**.

--- a/website/src/content/help/numbers-dates-and-times.md
+++ b/website/src/content/help/numbers-dates-and-times.md
@@ -7,11 +7,11 @@ order: 4
 keywords: ["numbers", "dates", "times", "money", "dollars", "percent", "phone number", "email address", "url", "formatting numbers", "writes out numbers", "spelled out"]
 related: ["spoken-punctuation-and-emoji"]
 seeAlso: "spoken-text-formatting-dates-numbers-emails"
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. It writes numbers, money, dates, times, phone numbers, email addresses and web addresses the way you would type them, not the way you said them. This is always on and there is nothing to set up.
+Numbers, dates, and times are converted automatically from spoken words into the standard written forms. EnviousWispr writes numbers, money, dates, times, phone numbers, email addresses, and web addresses the way you would type them, rather than spelling out every word you said. It is switched on when you install the app, and there is nothing to configure.
 
-### What you get
+### Examples of spoken input and written output
 
 | You say | You get |
 |---|---|
@@ -22,14 +22,14 @@ EnviousWispr is a free dictation app for macOS. It writes numbers, money, dates,
 
 ### Small numbers stay as words
 
-Numbers below ten are written out, and ten upwards use digits. That is standard style in most writing.
+Numbers below ten are written out as words, while numbers from ten upwards use digits. That follows the standard style used in most professional and general writing.
 
-### It happens before AI Polish
+### When the formatting happens
 
-So if polish is switched off or fails, this formatting is what gets pasted. A successful AI polish may still reword it.
+Formatting runs before any AI polish. If polish is switched off or hits an error, this formatted text is what gets pasted into your app. If a polish step runs successfully, the AI model may still reword it.
 
-### Where it stops
+### Ambiguous phrases
 
-Some phrases are genuinely ambiguous. "Meet at one twenty" is a time and "paid one twenty" is money, and only the surrounding words say which. EnviousWispr leaves those alone rather than guessing.
+Some phrases carry more than one meaning depending on the context. "Meet at one twenty" is a time, whereas "paid one twenty" is an amount of money. EnviousWispr leaves ambiguous phrases as you spoke them rather than guessing which you meant.
 
-This works on English dictation. Other languages are written as spoken.
+This conversion applies only to English dictation. Other languages are written out word for word, exactly as you spoke them.

--- a/website/src/content/help/ollama-polish-not-working.md
+++ b/website/src/content/help/ollama-polish-not-working.md
@@ -6,28 +6,38 @@ section: "AI Polish Issues"
 order: 5
 keywords: ["ollama not working", "ollama error", "cant connect to ollama", "ollama failed", "local ai broken"]
 related: ["using-ollama-for-fully-offline-ai-polish"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. Ollama is one of the AI options it can use to tidy up what you dictated. When that step fails, it is nearly always because Ollama itself is not running.
+When Ollama polish fails to tidy up your dictation, the cause is nearly always that Ollama itself is not running.
 
-### Work through these
+### Confirm Ollama is installed
 
-1. **Is Ollama installed?** Get it from [ollama.com](https://ollama.com).
-2. **Is it running?** Open the Ollama app, or run `ollama serve` in Terminal. It has to be running before you start recording.
-3. **Do you have a model?** Run `ollama list` in Terminal. If nothing comes back, run `ollama pull llama3.2`.
-4. **Is the right model selected?** Open EnviousWispr's settings, go to **AI Polish**, and check the model picker.
+Ollama must be installed on your Mac before EnviousWispr can send any text to it. Download the app from [ollama.com](https://ollama.com) if you have not installed it yet.
 
-### If you picked one of Ollama's hosted models
+### Start the application
 
-Ollama offers models that run on its own servers as well as models you download to your Mac. Hosted models still go through the Ollama app, so everything above still applies, and two more things matter:
+Ollama needs to be running before you start recording. Open your Applications folder and launch the Ollama app, or run `ollama serve` in Terminal.
 
-- **You have to be signed in to Ollama.** Run `ollama signin` in Terminal. If you are not signed in, EnviousWispr says so after the first failed dictation.
-- **Some hosted models are paid.** If the one you picked needs a subscription you do not have, Ollama refuses the request. Choose a free model instead, or subscribe.
+### Verify your model
 
-### If it is slow rather than broken
+EnviousWispr relies on a model you have downloaded to process your text. Run `ollama list` in Terminal to see which models are on your machine. If the list is empty, run `ollama pull llama3.2` to download a working one.
 
-A large model on a busy Mac can take longer than EnviousWispr waits, which is about fifteen seconds. Try a smaller model.
+### Match your settings
 
-### What happens meanwhile
+The model selected in EnviousWispr has to match one that is installed on your system. Open EnviousWispr settings, go to **AI Polish**, and check the model picker.
 
-You still get your dictation. It arrives without the AI clean-up, which is the only part that failed.
+### Sign in for hosted models
+
+Ollama offers both models you download to your Mac and models it hosts on its own servers. Hosted models still route through the Ollama app, so everything above still applies, and you also have to be signed in to your Ollama account. Run `ollama signin` in Terminal. EnviousWispr tells you after the first failed dictation if you are not signed in.
+
+### Check subscription status
+
+Some hosted models need a paid account with Ollama. If the model you selected requires a subscription you do not have, Ollama rejects the request. Choose a free model in your settings, or subscribe through Ollama.
+
+### Address slow processing times
+
+A large model running on a busy Mac can take longer than the fifteen seconds EnviousWispr waits. Switch to a smaller model if your dictations time out often.
+
+### You still get your dictation
+
+The polish step is the only part that failed. Your text still arrives, carrying the clean-up EnviousWispr does on your Mac, such as filler-word removal and your custom words. Only the AI rewrite is missing.

--- a/website/src/content/help/paste-not-working.md
+++ b/website/src/content/help/paste-not-working.md
@@ -6,28 +6,28 @@ section: "Paste System"
 order: 3
 keywords: ["paste not working", "wont paste", "nothing pastes", "text not appearing", "goes to the wrong app", "vs code", "slack", "discord", "notion", "no text in my app"]
 related: ["accessibility-permission-not-working", "how-text-gets-pasted-into-your-app"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. When your dictation does not appear in the app you were typing in, work through these in order.
+When your dictation does not appear in the app you were typing in, work through these steps in order.
 
 ### 1. Check Accessibility permission
 
-This is the cause most of the time. Open **System Settings** \> **Privacy & Security** \> **Accessibility**. EnviousWispr should be listed with its switch on. Without this permission, nothing can be typed into your apps.
+macOS requires explicit permission before any app can type text into other windows, and this is the cause of missing text most of the time. Open **System Settings**, click **Privacy & Security**, and select **Accessibility**. Find EnviousWispr in the list and make sure its switch is turned on. Without this permission, EnviousWispr cannot deliver your text.
 
-If the switch already looks on, remove EnviousWispr from the list with **-** and add it back with **+**.
+If the switch already looks on but nothing is typed, remove EnviousWispr from the list using the minus button, then add it back using the plus button.
 
 ### 2. Check your cursor was in a text box
 
-EnviousWispr sends the text to wherever your cursor was when you **started** recording. Click into the box first, then press your hotkey.
+EnviousWispr delivers text to whichever text field your cursor was in when you started recording. Click directly into your target text box first, then press your hotkey and begin speaking.
 
 ### 3. The text went to a different app
 
-Same reason. If you switched apps during the dictation, the text still goes to the one you started in. That is deliberate, so a slow AI polish cannot drop your words somewhere unexpected.
+If you switched windows while dictating, the text still goes to the app you were in when you started. That is deliberate. It makes sure a slow AI polish cannot drop your words into an unexpected window if you change tasks mid-sentence.
 
-### 4. VS Code, Slack, Discord and similar
+### 4. VS Code, Slack, Discord and similar apps
 
-These sometimes accept text and then quietly ignore it. EnviousWispr checks for that and delivers a different way, which handles most cases. If yours is not one of them, make sure the app is in front and your cursor is in the field before you record.
+Some apps built on web technology accept text input and then quietly drop it. EnviousWispr has fallback delivery methods that handle this for most of them. If your text still fails to appear, bring the target app to the front and make sure your cursor is inside the text field before you record.
 
 ### 5. You were told the text is on your clipboard
 
-That means every delivery method failed. Your dictation is safe. Press Cmd+V to paste it, then work through the checks above.
+If every delivery method fails, EnviousWispr copies your words to the clipboard and tells you. Your dictation is safe. Press Cmd+V to paste it yourself, then work through the checks above to get normal delivery back.

--- a/website/src/content/help/privacy-overview.md
+++ b/website/src/content/help/privacy-overview.md
@@ -7,20 +7,38 @@ order: 1
 keywords: ["privacy", "private", "is it private", "does it spy", "does it send my text anywhere", "data", "offline", "internet", "cloud", "tracking", "who can see my dictation"]
 related: ["what-data-is-collected", "ai-polish-and-cloud-data"]
 seeAlso: "on-device-vs-cloud-dictation-privacy"
-updated: 2026-08-05
+updated: 2026-08-06
 ---
 EnviousWispr is a free dictation app for macOS. Your voice becomes text on your own Mac, and the audio never leaves it. There is no account and nothing to sign up for.
 
 ### What stays on your Mac
 
-- Recording, transcribing and pasting need no internet connection. Both speech engines run on your Mac.
-- Your transcripts are saved in your user folder. Envious Labs, the company that makes EnviousWispr, never receives a copy.
-- You can read the code. EnviousWispr is open source, so every claim on this page can be checked.
+You can use the app without an internet connection at all, and your dictation stays on your own hardware.
+
+- **Offline operation.** Recording, transcribing, and pasting need no internet connection. Both speech engines run on your Mac.
+- **Local transcripts.** Your transcripts are saved in your user folder. Envious Labs, the company that makes EnviousWispr, never receives a copy.
+- **Open source verification.** You can read the code. EnviousWispr is open source, so every claim on this page can be checked against it.
 
 ### When EnviousWispr uses the network
 
+The app connects to the internet only for specific tasks that genuinely need it.
+
 - **Updates and downloads.** The app checks for new versions, and downloads the speech and AI models you choose.
-- **Anonymous usage and crash data.** On by default. It reports which app and macOS versions were involved in a problem, never what you said. See [_What Data Is Collected_](/help/what-data-is-collected/).
+- **Anonymous usage and crash data.** This is on by default. It reports which app and macOS versions were involved in a problem, and it never reports what you said. See [_What Data Is Collected_](/help/what-data-is-collected/).
 - **Cloud AI Polish, only if you choose it.** If you pick OpenAI, Gemini, Claude, or one of Ollama's hosted models, your text goes to that company under your own account with them. Your audio never does. See [_AI Polish and Cloud Data_](/help/ai-polish-and-cloud-data/).
 
-The short version of AI Polish: your text stays on your Mac with Apple Intelligence, EG-1, or an Ollama model you downloaded. Your text goes to that company's servers with OpenAI, Gemini, Claude, or one of Ollama's hosted models. Ollama appears on both sides of that line, so check which kind of model you picked.
+### Where your text goes with each polish option
+
+This depends entirely on the option you select in settings.
+
+| Polish option | Where your text goes |
+| :--- | :--- |
+| Apple Intelligence | Stays on your Mac |
+| EG-1 | Stays on your Mac |
+| An Ollama model you downloaded | Stays on your Mac |
+| An Ollama hosted model | To Ollama's servers |
+| OpenAI | To OpenAI |
+| Gemini | To Google |
+| Claude | To Anthropic |
+
+Ollama appears on both sides of that line, so check which kind of model you picked.

--- a/website/src/content/help/push-to-talk-mode.md
+++ b/website/src/content/help/push-to-talk-mode.md
@@ -5,27 +5,39 @@ category: "recording-and-hotkeys"
 section: "Recording"
 order: 1
 keywords: ["push to talk", "hold to talk", "hold the key", "ptt", "press and hold", "default mode", "recording mode"]
-related: ["customizing-your-hotkey"]
-updated: 2026-08-05
+related: ["customizing-your-hotkey", "first-word-gets-cut-off"]
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. Push to talk is its default recording mode. You hold your hotkey down for as long as you are speaking, and your words appear when you let go.
+Push-to-talk is the default recording mode. You hold your hotkey down for as long as you are speaking, and your transcribed words appear at your cursor the moment you let go.
 
-### Using it
+### Using push-to-talk
 
-1. Hold your hotkey down.
-2. Speak.
-3. Let go. Your text appears at the cursor.
+**Use any text box.** Click into any text box on your Mac, then use the hotkey you assigned during setup.
 
-Recording stops the moment you release the key, so a cough or a passing conversation afterwards never reaches the transcript.
+**Hold the hotkey.** Press and hold your designated hotkey, and begin speaking into your microphone.
 
-### For longer dictations
+**Release the hotkey.** Let go of the hotkey when you finish your sentence. Your text appears at the cursor.
 
-If you would rather not keep holding the key, tap it and press it again within half a second. Recording stays on after you let go. See [_Hands-Free Mode (Long Dictation)_](/help/hands-free-mode-long-dictation/).
+Recording stops the exact moment you release the key. Because of that, a cough, a deep breath, or a passing conversation after you finish speaking never reaches the transcript.
 
-### Choosing it
+### Dictating for longer periods
 
-Open EnviousWispr's settings, go to **Shortcuts**, and pick **Push to Talk** under **1. Choose recording mode**. The card you picked is marked as selected. You will know it took effect when holding the key starts a recording and releasing it ends one.
+If you would rather not hold the key down through a long block of speech, tap your hotkey and then press it again within half a second. Recording stays on after you let go. That is hands-free mode, and [_Hands-Free Mode (Long Dictation)_](/help/hands-free-mode-long-dictation/) covers it in full.
 
-### Why it feels instant
+### Configuring the mode
 
-The moment you press the key, EnviousWispr starts waking the microphone, before you have said anything. That head start is what stops a Bluetooth headset cutting off your first word.
+You can check or change your recording mode at any time in settings if you want to switch between dictation styles.
+
+**Open settings.** Click the EnviousWispr icon in your menu bar and choose **Settings**.
+
+**Go to Shortcuts.** Open the **Shortcuts** tab.
+
+**Select push to talk.** Pick **Push to Talk** under **1. Choose recording mode**.
+
+The card you choose highlights to show it is selected. You know the setting took effect when holding your hotkey starts a recording and releasing it ends the recording.
+
+### Why holding the key helps the first word
+
+The moment you press your hotkey, EnviousWispr starts waking the microphone, before you have said anything. That head start is what stops a Bluetooth headset cutting off the beginning of your sentence.
+
+It is a head start, not a guarantee. On your first dictation after opening the app there is no earlier audio to draw on, so pause for a beat after pressing the key before you speak. [_First Word Gets Cut Off_](/help/first-word-gets-cut-off/) explains when that happens and how to make it rarer.

--- a/website/src/content/help/push-to-talk-mode.md
+++ b/website/src/content/help/push-to-talk-mode.md
@@ -8,7 +8,7 @@ keywords: ["push to talk", "hold to talk", "hold the key", "ptt", "press and hol
 related: ["customizing-your-hotkey", "first-word-gets-cut-off"]
 updated: 2026-08-06
 ---
-Push-to-talk is the default recording mode. You hold your hotkey down for as long as you are speaking, and your transcribed words appear at your cursor the moment you let go.
+Push-to-talk is the default recording mode. You hold your hotkey down for as long as you are speaking. Letting go ends the recording, and your transcribed words appear at your cursor once EnviousWispr has worked out what you said.
 
 ### Using push-to-talk
 
@@ -16,7 +16,7 @@ Push-to-talk is the default recording mode. You hold your hotkey down for as lon
 
 **Press and hold.** Keep your designated hotkey pressed, and begin speaking into your microphone.
 
-**Release it.** Let go when you finish your sentence. Your text appears at the cursor.
+**Release it.** Let go when you finish your sentence. Your text appears at the cursor a moment later, once the audio has been transcribed.
 
 Recording stops the exact moment you release the key. Because of that, a cough, a deep breath, or a passing conversation after you finish speaking never reaches the transcript.
 

--- a/website/src/content/help/push-to-talk-mode.md
+++ b/website/src/content/help/push-to-talk-mode.md
@@ -14,15 +14,15 @@ Push-to-talk is the default recording mode. You hold your hotkey down for as lon
 
 **Use any text box.** Click into any text box on your Mac, then use the hotkey you assigned during setup.
 
-**Hold the hotkey.** Press and hold your designated hotkey, and begin speaking into your microphone.
+**Press and hold.** Keep your designated hotkey pressed, and begin speaking into your microphone.
 
-**Release the hotkey.** Let go of the hotkey when you finish your sentence. Your text appears at the cursor.
+**Release it.** Let go when you finish your sentence. Your text appears at the cursor.
 
 Recording stops the exact moment you release the key. Because of that, a cough, a deep breath, or a passing conversation after you finish speaking never reaches the transcript.
 
 ### Dictating for longer periods
 
-If you would rather not hold the key down through a long block of speech, tap your hotkey and then press it again within half a second. Recording stays on after you let go. That is hands-free mode, and [_Hands-Free Mode (Long Dictation)_](/help/hands-free-mode-long-dictation/) covers it in full.
+For a long block of speech there is a way to keep recording with your finger off the hotkey. Tap it, then press it again within half a second. Recording stays on after you let go. That is hands-free mode, and [_Hands-Free Mode (Long Dictation)_](/help/hands-free-mode-long-dictation/) covers it in full.
 
 ### Configuring the mode
 

--- a/website/src/content/help/recording-won-t-stop-or-seems-stuck.md
+++ b/website/src/content/help/recording-won-t-stop-or-seems-stuck.md
@@ -7,20 +7,22 @@ order: 7
 keywords: ["wont stop", "stuck", "keeps recording", "frozen", "hung", "still recording", "cant stop", "spinning"]
 related: ["canceling-a-recording"]
 seeAlso: "mac-dictation-keeps-stopping"
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. If a recording will not stop, press **Escape**. That ends any recording in progress and throws it away, in every recording mode. The bar on screen disappears, which is how you know it worked.
+If a recording will not stop, press **Escape**. This ends any recording in progress and discards the audio, in every recording mode. The on-screen bar disappears, which confirms it worked.
 
 ### Recording cannot run forever
 
-An hour is the limit. You get a warning a minute before, then EnviousWispr stops on its own and writes out what you said up to that point.
+EnviousWispr enforces a one-hour limit on a single recording. You get a warning one minute before the limit, and then EnviousWispr stops on its own and writes out the text up to that point.
 
 ### Stopping automatically when you pause
 
-You can have a recording end after a silence. Open EnviousWispr's settings, go to **Transcription**, and switch on **Stop recording on silence**. It is off unless you turn it on. The slider next to it sets how long a pause has to be, anywhere from half a second to three seconds.
+You can have EnviousWispr end a recording after a period of silence.
 
-A pause shorter than your setting is ignored. At the half-second setting, an ordinary pause for thought is enough to end the recording.
+To turn this on, open settings, select **Transcription**, and switch on **Stop recording on silence**. The setting is off by default. The slider next to the switch sets how long the pause has to be, anywhere from half a second to three seconds.
+
+A pause shorter than your chosen duration is ignored. At the half-second setting, an ordinary pause for thought is enough to end the recording.
 
 ### If it seems stuck after you stop talking
 
-Recording has already ended, and EnviousWispr is turning your speech into text and polishing it. That takes a moment, especially on the first dictation after opening the app. Escape only cancels a recording, so pressing it now does nothing. Wait for the attempt to finish, then record again.
+When the app appears unresponsive after you stop speaking, the recording has already ended. EnviousWispr is turning your speech into text and applying any polish you have chosen. That takes a moment, especially on the first dictation after opening the app. Because the Escape key only cancels a recording that is still running, pressing it now has no effect. Wait for the current dictation to finish before starting a new one.

--- a/website/src/content/help/sounds-and-appearance.md
+++ b/website/src/content/help/sounds-and-appearance.md
@@ -5,24 +5,24 @@ category: "features"
 section: "Appearance and Sounds"
 order: 5
 keywords: ["sound", "sounds", "beep", "chime", "mute the sound", "turn off sound", "appearance", "theme", "dark mode", "pill", "overlay", "bar position", "move the bar", "menu bar icon"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. A few of its settings change how it looks and sounds, and none of them affect what you dictate.
+Three settings change how EnviousWispr looks and sounds while you use it. None of them affects what you dictate or how accurately it is transcribed.
 
 ### Light or dark
 
-Go to **Settings** \> **Appearance**. EnviousWispr follows your macOS setting unless you pick Light or Dark yourself.
+EnviousWispr follows your macOS appearance setting by default, and you can override that if you prefer. Go to **Settings**, then select **Appearance**. Choose either Light or Dark to fix the theme regardless of what your system is set to.
 
 ### Where the recording bar appears
 
-On the same page, **Recording Indicator Position** puts the bar at the top or the bottom of your screen.
+The recording bar shows you when EnviousWispr is listening, and you can put it wherever suits your screen. Go to **Settings**, then select **Appearance**. Use **Recording Indicator Position** to place the bar at either the top or the bottom of your screen.
 
-You can also drag the bar somewhere else while it is on screen. That lasts for the current dictation only. The next one goes back to the position you chose in Settings.
+You can also move the bar during a dictation.
+
+**Drag the bar.** Click and drag the recording bar to any position on your screen while it is visible. That placement lasts for the current dictation only, and the next one returns to the position you chose in Settings.
 
 ### Recording sounds
 
-Go to **Settings** \> **Sounds** and switch on **Play recording sounds** to hear a short sound when recording starts and stops. It is off out of the box.
+A short sound confirms when EnviousWispr starts and stops listening, which helps if you dictate without looking at the screen or you are unsure whether it registered your hotkey. Go to **Settings**, then select **Sounds**, and switch on **Play recording sounds**. This setting is off by default.
 
-There are several sound pairings and a preview button, so you can hear each one before choosing.
-
-This is worth turning on if you dictate without looking at the screen, or if you are ever unsure whether EnviousWispr is listening.
+**Preview a sound.** Select any of the sound pairings on the **Sounds** page and click the preview button to hear each one before you settle on it.

--- a/website/src/content/help/source-code-and-contributing.md
+++ b/website/src/content/help/source-code-and-contributing.md
@@ -5,24 +5,26 @@ category: "updates-and-source"
 section: "Source Code"
 order: 2
 keywords: ["source code", "github", "open source", "license", "gpl", "contribute", "pull request", "build it myself", "repo"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS, and it is open source. The whole app is at [github.com/saurabhav88/EnviousWispr](https://github.com/saurabhav88/EnviousWispr), so every privacy claim on this site can be checked against the code that makes it.
+EnviousWispr is a free dictation app for macOS, and the entire application is open source under the GPLv3 license. You can inspect every part of the codebase at [github.com/saurabhav88/EnviousWispr](https://github.com/saurabhav88/EnviousWispr) and check every privacy claim on this site against the code that runs on your Mac.
 
 ### The license
 
-GNU General Public License v3. In short:
+EnviousWispr is distributed under the terms of the GNU General Public License v3. That license grants specific rights and sets clear boundaries for use and distribution.
 
-- Free to use, study, change and share, including commercially.
-- If you share a changed version, that version has to be open source too.
-- The EnviousWispr name and logo belong to Envious Labs LLC and are not covered by the license.
+- **Use freely.** You are free to use, study, change, and share the software, including for commercial purposes.
+- **Share modifications.** If you distribute a modified version of EnviousWispr, that version has to be open source under the same license terms.
+- **Trademarks are excluded.** The EnviousWispr name and logo belong to Envious Labs LLC and are not covered by the open source license.
 
 ### Helping out
 
-- Report a bug or ask for a feature on GitHub Issues.
-- Send a pull request.
-- Read the code and say so if something we claim does not match what it does.
+Contributions make the project more stable and easier to trust. There are three ways to take part.
+
+- **Report bugs and request features.** Open an issue on GitHub Issues to report unexpected behaviour or suggest something new.
+- **Submit code.** Send a pull request with a bug fix or an improvement.
+- **Audit the code.** Read the source and report any gap between what the documentation claims and what the app actually does.
 
 ### Building it yourself
 
-You need a Mac with Apple Silicon and Xcode. The current steps are in the repository README.
+You can compile the application from source on your own machine. Building EnviousWispr needs a Mac with Apple Silicon and Xcode installed. The current compilation steps are kept up to date in the repository README.

--- a/website/src/content/help/spoken-punctuation-and-emoji.md
+++ b/website/src/content/help/spoken-punctuation-and-emoji.md
@@ -7,21 +7,23 @@ order: 3
 keywords: ["punctuation", "say comma", "period", "full stop", "new line", "new paragraph", "emoji", "thumbs up", "smiley", "spoken commands"]
 related: ["numbers-dates-and-times"]
 seeAlso: "speak-emoji-dictation"
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. Two of its settings let you say something out loud and get a symbol instead of the words. Both live under **Settings** \> **Transcription**.
+Two transcription settings let you speak a phrase and get a symbol or a line break instead of the words you said. Both live under **Settings** \> **Transcription**.
 
-### Spoken emoji, on out of the box
+### Spoken emoji
 
-Say "thumbs up emoji" and you get 👍.
+EnviousWispr converts certain spoken phrases into emoji. This setting is on by default.
 
-It only fires when you say the word "emoji" straight after the name, so ordinary sentences are never changed. Talking about emoji is safe too: "the heart emoji category" stays as words.
+**Speak the trigger phrase.** Say the name of the emoji followed immediately by the word "emoji". Saying "thumbs up emoji" inserts 👍 into your text.
+
+Ordinary sentences are left alone, because the conversion only fires when you say the word "emoji" directly after the name. You can also talk about emoji without triggering one, so "the heart emoji category" stays as words.
 
 The setting is **Convert spoken emoji**.
 
-### Spoken punctuation, off out of the box
+### Spoken punctuation
 
-Say "comma" and you get a comma. This one is worth understanding before you switch it on.
+EnviousWispr can convert spoken words like "comma" into punctuation marks. This setting is off by default.
 
 | Say this | You get |
 |---|---|
@@ -36,6 +38,6 @@ Say "comma" and you get a comma. This one is worth understanding before you swit
 | new line | a line break |
 | new paragraph | a blank line |
 
-**Why it is off.** EnviousWispr already punctuates for you, so this competes with it. It also cannot tell when you meant the word: say "the grace period expires" and you get a full stop in the middle of your sentence.
+**Understand the trade-off before turning it on.** EnviousWispr already punctuates for you, so spoken punctuation competes with that. It also cannot tell when you meant the word itself: saying "the grace period expires" puts a full stop in the middle of your sentence.
 
-Turn it on if you need exact control over punctuation and do not mind fixing the occasional sentence. The setting is **Convert spoken punctuation**.
+Turn this on if you need exact control over your punctuation and do not mind fixing the occasional unintended symbol. The setting is **Convert spoken punctuation**.

--- a/website/src/content/help/system-requirements.md
+++ b/website/src/content/help/system-requirements.md
@@ -5,22 +5,22 @@ category: "getting-started"
 section: "Basics"
 order: 2
 keywords: ["requirements", "supported macs", "will it run", "intel", "apple silicon", "m1", "m2", "m3", "m4", "macos version", "sonoma", "sequoia", "compatible", "does it work on my mac", "old mac"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
 EnviousWispr is a free dictation app for macOS. It runs on any Mac with Apple Silicon (M1 or later) running macOS 14 Sonoma or later. Intel Macs are not supported.
 
 ### What you need
 
-- **A Mac with Apple Silicon.** M1, M2, M3, M4, or newer. To check yours, open the Apple menu and choose About This Mac. If the Chip line starts with "Apple", you are set.
-- **macOS 14 Sonoma or later.** The same About This Mac window shows your version.
-- **A microphone.** The one built into your Mac is fine. External mics, AirPods and Bluetooth headsets all work.
-- **A little disk space.** The app itself is small. It downloads a speech model the first time you run it.
+- **A Mac with Apple Silicon.** You need an M1, M2, M3, M4, or newer processor. To check your chip, open the Apple menu and choose About This Mac. If the chip line starts with Apple, your Mac meets this requirement.
+- **macOS 14 Sonoma or later.** The same About This Mac window displays your operating system version.
+- **A microphone.** The built-in microphone on your Mac works well. You can also use external microphones, AirPods, and Bluetooth headsets.
+- **Disk space for the speech model.** The application file is small, but it downloads a speech model the first time you run it.
 
 ### Extra requirements for AI polish
 
-AI polish is the optional step that cuts filler words and fixes your grammar. Dictation works without it, so none of the following is required. Each option asks for something different:
+AI polish is an optional feature that removes filler words and corrects grammar. Dictation works without it, so these requirements only apply if you choose to turn it on. Each polish option asks for something different:
 
-- **Apple Intelligence** needs macOS 26 or later, on a Mac that supports Apple Intelligence.
-- **EG-1**, the model EnviousWispr built, is a one-time 2.9 GB download and needs about 6 GB free while it installs.
-- **Ollama** running on your Mac needs enough free memory for the model you pick. Ollama also offers models it hosts itself, and those need an internet connection instead.
-- **OpenAI, Gemini or Claude** need an internet connection and your own API key from that company.
+- **Apple Intelligence** requires macOS 26 or later, running on a Mac model that supports Apple Intelligence.
+- **EG-1**, the model built by Envious Labs, requires a one-time 2.9 GB download and around 6 GB of free disk space while it installs.
+- **Ollama** running on your Mac requires enough free memory to load the model you choose. Ollama also offers models hosted on its own servers, which need an internet connection instead.
+- **OpenAI, Gemini, or Claude** require an internet connection and your own API key from that provider.

--- a/website/src/content/help/toggle-mode.md
+++ b/website/src/content/help/toggle-mode.md
@@ -6,25 +6,37 @@ section: "Recording"
 order: 3
 keywords: ["toggle", "press once", "click to start click to stop", "on off mode", "start stop"]
 related: ["customizing-your-hotkey"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS that turns what you say into typed text. Toggle is one of its two recording modes. You press your hotkey once to start recording and press it again to stop, instead of holding the key down the whole time.
+Toggle mode changes how you interact with your recording hotkey. Instead of holding the key down for every sentence, you press the hotkey once to start recording and press it again to stop.
 
-### Using it
+### Using toggle mode
 
-1. Press your hotkey. Recording starts and the bar appears on screen.
-2. Speak.
-3. Press it again. Your text appears at the cursor.
+When you want to capture speech without keeping a finger on a key, one press is enough to begin.
 
-### When to pick it
+**Press your hotkey.** Click into any text box and press your hotkey once. Recording starts and the audio bar appears on your screen.
 
-- You would rather not hold a key while you talk.
-- You know in advance when you want to stop.
+**Speak your thoughts.** Dictate at your normal pace while EnviousWispr captures your voice.
 
-### Choosing it
+**Press the hotkey again.** Stop the recording with a second press. The transcribed text appears at your cursor.
 
-Click the EnviousWispr icon in your menu bar, choose **Settings**, and go to **Shortcuts**. Under **1. Choose recording mode**, pick **Toggle**. You will know it took effect when a single press starts recording instead of needing to be held.
+### When to select toggle mode
 
-The recording hotkey itself is the same in both modes, so nothing else about your setup changes. Escape still throws a recording away.
+This mode suits some working styles better than the default push-to-talk behaviour.
 
-The double-press lock from push to talk does not apply here. In toggle mode your hands are already free.
+- You would rather not hold a key down while you talk.
+- You know in advance exactly when you want to stop recording.
+
+### Configuring toggle mode
+
+You can switch to this mode in settings.
+
+**Open settings.** Click the EnviousWispr icon in your menu bar and choose **Settings**.
+
+**Go to Shortcuts.** Open the **Shortcuts** tab.
+
+**Select Toggle.** Under **1. Choose recording mode**, pick **Toggle**.
+
+You will know the setting took effect when a single press starts recording instead of requiring a constant hold. The recording hotkey stays the same in both modes, so the rest of your setup remains unchanged. Pressing the Escape key still cancels and discards a recording.
+
+The double-press lock from push to talk does not apply in toggle mode. There is nothing to lock on, because your hands are already free.

--- a/website/src/content/help/transcript-history.md
+++ b/website/src/content/help/transcript-history.md
@@ -6,23 +6,27 @@ section: "Transcript History"
 order: 1
 keywords: ["history", "past dictations", "previous", "find an old dictation", "where did my text go", "recover", "lost text", "copy again", "log"]
 related: ["clipboard-preservation"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. It saves each finished dictation so you can find it again later. Click the EnviousWispr icon in your menu bar, choose **Settings**, and go to **History**.
+EnviousWispr saves each finished dictation so you can find it again later. To see your past dictations, click the EnviousWispr icon in your menu bar, choose **Settings**, and go to **History**.
 
 Recordings you cancelled, and recordings where no speech was found, are not saved. If saving fails for a storage reason, EnviousWispr tells you.
 
 ### What you can do
 
-- Search your past dictations.
-- Copy one back to your clipboard, or paste it straight into the app you are in.
-- Delete a single dictation, or delete them all.
+History gives you several ways to work with past recordings.
+
+- **Search your past dictations.** Find text from an earlier session inside the history window.
+- **Copy or paste.** Copy a past dictation back to your clipboard, or paste it straight into the app you are in.
+- **Delete records.** Remove a single dictation you no longer need, or delete all of them at once.
 
 ### Where it is kept
 
-On your Mac, in your user folder. It survives quitting, updating and restarting. Envious Labs never receives a copy, and there is no limit on how many dictations are kept.
+Your past dictations are stored on your Mac, inside your user folder. They survive quitting the app, updating it, and restarting your computer. Envious Labs never receives a copy of your history, and there is no limit on how many dictations are kept.
 
 ### If History looks empty
 
-- Finish at least one dictation first.
-- If dictations you had are missing, check whether `~/Library/Application Support/EnviousWispr` was moved or deleted. Every copy of the app on your Mac reads that same folder.
+If the history view shows nothing, check these two things.
+
+- **Complete a dictation.** Finish at least one dictation, so there is something to display.
+- **Check the storage folder.** If dictations you know you recorded are missing, check whether `~/Library/Application Support/EnviousWispr` was moved or deleted. Every copy of the app on your Mac reads that same folder.

--- a/website/src/content/help/uninstalling-enviouswispr.md
+++ b/website/src/content/help/uninstalling-enviouswispr.md
@@ -6,41 +6,50 @@ section: "Basics"
 order: 6
 keywords: ["uninstall", "remove", "delete", "get rid of it", "clean up", "free up space", "leftover files", "models taking up space"]
 related: ["model-downloads-and-management"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. Removing it has two parts: deleting the app, and deleting the files it saved on your Mac.
+Removing the app involves two parts: deleting the application itself, and deleting the support files it saved on your Mac.
 
 ### Remove the app
 
-1. Click the EnviousWispr icon in your menu bar and choose **Quit**.
-2. Open your Applications folder and drag EnviousWispr to the Trash.
+Quit the application first, so macOS is not holding the program files open when you send them to the Trash.
 
-The app is now gone. Your history, custom words and downloaded speech models are still on the Mac.
+**Quit the application.** Click the EnviousWispr icon in your menu bar and choose **Quit**.
+
+**Move it to the Trash.** Open your Applications folder in Finder and drag EnviousWispr to the Trash.
+
+The application is now gone, but your dictation history, custom words, and downloaded speech models remain on the Mac.
 
 ### Remove your data and settings
 
-Those files can add up to a few gigabytes.
+Those remaining files can add up to a few gigabytes of storage. Follow these steps to clear them.
 
-1. In Finder, press **Shift+Cmd+G** to open the Go to Folder box.
-2. Go to `~/Library/Application Support/EnviousWispr` and move that folder to the Trash. It holds your dictation history, your custom words, and the WhisperKit and EG-1 models.
-3. Go to `~/Library/Preferences` and move `com.enviouswispr.app.plist` to the Trash. That file is your settings.
+**Open the Go to Folder box.** In Finder, press **Shift+Cmd+G** on your keyboard.
 
-### The Parakeet model sits somewhere else
+**Delete the application support folder.** Paste `~/Library/Application Support/EnviousWispr` into the box, press Enter, and move that folder to the Trash. It holds your dictation history, your custom words, and the WhisperKit and EG-1 models.
 
-Parakeet is one of the two speech engines. It lives in a folder shared with other apps, so the step above does not remove it. Go to `~/Library/Application Support/FluidAudio/Models` and move `parakeet-tdt-0.6b-v3` to the Trash.
+**Delete the preferences file.** Press **Shift+Cmd+G** again, paste `~/Library/Preferences`, press Enter, and move `com.enviouswispr.app.plist` to the Trash. That file stores your settings.
 
-Move only that one folder. Anything else in there may belong to a different app, which would then have to download it again.
+### Remove the Parakeet model
 
-If you installed Ollama, its models belong to Ollama and are removed from there.
+Parakeet is one of the two speech engines the app can use. It lives in a folder shared with other applications, so the steps above do not remove it.
 
-### Your API key
+**Open the shared model folder.** Press **Shift+Cmd+G** in Finder and go to `~/Library/Application Support/FluidAudio/Models`.
 
-If you added a key for OpenAI, Gemini or Claude, it lives in your macOS Keychain rather than in any of the folders above. Clearing the field in EnviousWispr's settings before you uninstall removes it. If the app is already gone, open Keychain Access, search for EnviousWispr, and delete every entry you find. There can be one for each provider.
+**Delete the Parakeet folder.** Move only the `parakeet-tdt-0.6b-v3` folder to the Trash. Anything else in that folder may belong to a different application, which would then have to download its files again.
+
+If you installed Ollama for text polish, those models belong to Ollama and are removed from there.
+
+### Remove your API key
+
+If you added a personal key for OpenAI, Gemini, or Claude, it lives in your macOS Keychain rather than in the support folders above.
+
+If you cleared the field in EnviousWispr settings before uninstalling, the key is already gone. If the app is already deleted, open the macOS Keychain Access application, search for EnviousWispr, and delete every entry you find. There can be one entry for each provider.
 
 Revoking the key in that company's own dashboard is worth doing either way.
 
 ### If you come back
 
-Leave those files in place and reinstalling brings your History, custom words, models and settings back. Delete them first and you start fresh.
+If you plan to reinstall later, leave those support files in place. Reinstalling brings your history, custom words, models, and settings back on its own. Delete them first if you want to start fresh.
 
-Once you delete them they are gone. Envious Labs cannot restore them, because we never had a copy.
+Once you move those files to the Trash and empty it, they are gone for good. Envious Labs cannot restore them, because we never had a copy.

--- a/website/src/content/help/using-ollama-for-fully-offline-ai-polish.md
+++ b/website/src/content/help/using-ollama-for-fully-offline-ai-polish.md
@@ -6,32 +6,36 @@ section: "Polish"
 order: 6
 keywords: ["ollama", "offline ai", "local ai", "local model", "llama", "run ai locally", "no internet ai", "free local"]
 related: ["ollama-polish-not-working"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. Ollama is a separate free app that runs language models on your own Mac, and EnviousWispr can hand your dictation to one of them for tidying up. Once it is set up there is no key, no account, and none of your dictation goes to the internet.
+Ollama is a separate free application that runs language models directly on your Mac, and EnviousWispr can hand your dictation to one of those models for tidying up. Once you have completed the setup, you do not need an API key or an account, and your transcribed text stays on your Mac.
 
-This page is about those on-Mac models. Ollama also offers hosted models that run on its own servers, and those do send your transcribed text off your Mac. EnviousWispr lists them under their own heading in the model list and never selects one for you, so if you want everything to stay local, pick a model that is not in that group.
+Ollama offers both models that download to run on your machine and models that run on Ollama's own servers. The hosted models send your transcribed text over the internet. EnviousWispr lists them under their own heading in the model list and never selects one automatically, so if you want your text to stay local, choose a model that is not in that group.
 
-### Setting it up
+### Setting up Ollama
 
-1. Install Ollama from [ollama.com](https://ollama.com).
-2. Open it, so the Ollama app is running.
-3. Download a model. In Terminal that is `ollama pull llama3.2`, or you can do it from the Ollama app.
-4. In EnviousWispr, go to **Settings** \> **AI Polish**.
-5. Choose **Ollama**, then pick your model from the list.
+You need an internet connection to install Ollama and download a model, but polish works offline after that. Follow these steps to connect EnviousWispr to Ollama.
 
-Installing Ollama and downloading a model need an internet connection. Polishing after that does not.
+**Install Ollama.** Download and install the application from [ollama.com](https://ollama.com).
 
-EnviousWispr finds your installed models on its own, so they appear in that list without you telling it where they are. You can also download and remove models from the same page.
+**Open Ollama.** Launch the application so it runs in the background.
+
+**Download a model.** Open Terminal and run `ollama pull llama3.2`, or use the model download tools inside the Ollama application.
+
+**Open AI Polish settings.** Open EnviousWispr, go to **Settings**, and select **AI Polish**.
+
+**Select your model.** Choose **Ollama** as your provider, then pick your downloaded model from the list.
+
+EnviousWispr finds your installed models on its own, so they appear in that list without any configuration. You can also download and remove models from the same settings page.
 
 ### Picking a model
 
-Start with llama3.2, the one EnviousWispr suggests. If polish feels slow, try a smaller model. Larger models use more memory and take longer, and they do not automatically write better.
+Start with `llama3.2`, the model EnviousWispr suggests. If polish feels too slow, switch to a smaller model. Larger models use more memory and take longer, and they do not automatically produce better text.
 
 ### If Ollama is not running
 
-Polish is skipped and you get your text anyway, without the AI clean-up. Ollama has to be running by the time AI Polish starts, which is a moment after your speech is transcribed.
+If Ollama is not running when you dictate, the polish step is skipped. You still get your text, without the AI clean-up. Ollama has to be running by the time AI polish starts, which is a moment after your speech finishes transcribing.
 
-### A simpler local option
+### An option with nothing to install
 
-If you want AI Polish on your Mac with nothing separate to install, try EG-1, the model EnviousWispr built. It downloads from inside Settings and needs no other app.
+If you want AI polish on your Mac without installing a separate application, try EG-1, the model Envious Labs built for this. It downloads from inside the EnviousWispr settings and needs no other software.

--- a/website/src/content/help/voice-activity-detection-and-auto-stop.md
+++ b/website/src/content/help/voice-activity-detection-and-auto-stop.md
@@ -6,28 +6,34 @@ section: "Audio Processing"
 order: 4
 keywords: ["auto stop", "stops on silence", "stops too early", "cuts me off", "pause", "silence", "vad", "keeps going after i stop", "waits too long"]
 related: ["hands-free-mode-long-dictation", "first-word-gets-cut-off"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. It can end a recording by itself once you stop talking, so you do not have to reach for the key again. This is off unless you turn it on.
+EnviousWispr can end a recording by itself once you stop talking, so you do not have to reach for your hotkey again. This is off by default and has to be switched on before it does anything.
 
-### Turning it on
+### Turning on auto-stop
+
+Switch the feature on in settings to let EnviousWispr work out when you have finished speaking.
 
 1. Go to **Settings** \> **Transcription**.
 2. Switch on **Stop recording on silence**.
-3. Use the slider to set how long a pause has to be, anywhere from half a second to three seconds. It arrives set to one and a half.
+3. Use the slider to set how long a pause has to be, anywhere from half a second to three seconds. It arrives set to one and a half seconds.
 
-A pause shorter than your setting is ignored. A longer silence ends the recording. At the half-second setting, an ordinary pause for thought is enough to stop it.
+A pause shorter than your setting is ignored, while a longer silence ends the recording. At the half-second setting, an ordinary pause for thought is often enough to stop it.
 
 ### Choosing a pause length
 
-- **Half a second.** Ends quickly, and will cut you off mid-thought.
-- **One and a half seconds.** A good starting point for normal speech.
-- **Up to three seconds.** Best if you pause a lot mid-sentence.
+Different pause lengths suit different speaking habits.
 
-### It also trims your recording
+| Setting | What it does |
+| :--- | :--- |
+| **Half a second** | Ends recordings quickly, but risks cutting you off mid-thought. |
+| **One and a half seconds** | A reliable starting point for normal speech. |
+| **Up to three seconds** | Suits speakers who pause often in the middle of a sentence. |
 
-Silence at the start and the end is removed before your speech is transcribed, whether or not you have auto-stop switched on. That happens on your Mac and needs no setting.
+### Automatic trimming
 
-### If it stops too early or too late
+Silence at the beginning and the end of your recording is removed before your speech is transcribed. That trimming happens whether or not you have auto-stop switched on, runs entirely on your Mac, and needs no configuration.
 
-Move the slider. If it keeps stopping while you are still thinking, try three seconds, or switch it off and end recordings yourself.
+### If it stops at the wrong time
+
+Move the slider. If EnviousWispr keeps ending the recording while you are still thinking, raise the setting to three seconds, or switch the feature off and end every recording yourself.

--- a/website/src/content/help/what-data-is-collected.md
+++ b/website/src/content/help/what-data-is-collected.md
@@ -6,17 +6,17 @@ section: "Privacy"
 order: 2
 keywords: ["what data", "analytics", "telemetry", "collected", "do you see my text", "do you store", "opt out", "tracking", "crash reports"]
 related: ["privacy-overview"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. Nothing you say ever reaches Envious Labs, the company that makes it. Not your audio, not your transcripts, not a word of it.
+EnviousWispr collects anonymous usage data and crash reports. Nothing you say is part of that. Your audio and your transcripts never reach Envious Labs, the company that makes the app.
 
 ### What stays on your Mac
 
 Your transcripts are saved to your History so you can find them later. They sit in your user folder, and Envious Labs never receives a copy.
 
-While you dictate, the app keeps an encrypted backup of the recording. Once your text is safely saved, the app requests deletion of that backup. If the app quits first, EnviousWispr makes one recovery attempt the next time it runs, then requests deletion whether recovery succeeded or failed.
+While you dictate, the app keeps an encrypted backup of the recording. Once your text is safely saved, the app requests deletion of that backup. If the app quits first, EnviousWispr makes one recovery attempt the next time it runs, then requests deletion whether that recovery succeeded or failed.
 
-Your custom words, settings and API keys live here too. They stay here unless you turn on cloud polish, which is covered below.
+Your custom words, settings, and API keys live here too. They stay on your Mac unless you turn on cloud polish, which is covered below.
 
 ### What Envious Labs never receives
 
@@ -29,16 +29,16 @@ Your custom words, settings and API keys live here too. They stay here unless yo
 
 ### What the app does collect
 
-Anonymous usage and crash data. It shows that a release broke dictation on a particular macOS version, or that nobody has ever opened a setting that took a month to build. It is on by default and cannot be turned off.
+The app collects anonymous usage and crash data. That data shows whether a release broke dictation on a particular macOS version, or whether anyone ever opens a setting that took a month to build. It is on by default and cannot be turned off.
 
-It records how the app is used, never what you said. There is no account and nothing in it names you, though each install gets a random ID so one Mac counts as one user. The privacy policy has the full detail.
+The app records how you use it, never what you said. There is no account, and nothing in the data names you, although each installation gets a random ID so that one Mac counts as one user. The privacy policy has the full detail.
 
-If you would rather run without it, EnviousWispr is open source. Build it yourself and dictation works exactly the same.
+If you would rather run without it, EnviousWispr is open source under the GPLv3 license. You can build the app yourself, and dictation works in exactly the same way.
 
-### If you use cloud AI polish
+### Where your text goes if you use cloud AI polish
 
-Polish runs on your Mac by default. Choose OpenAI, Gemini or Claude instead and you add your own API key, and your transcript is sent to them, along with your custom words and the name of the app you are dictating into, so the model gets your spellings and tone right. Audio is never sent. The app tells you this when you set it up. That is your account with that company, on their terms.
+Polish runs on your Mac by default. If you choose OpenAI, Gemini, or Claude instead, you add your own API key. Your transcript is then sent to that provider, along with your custom words and the name of the app you are dictating into, so the model gets your spellings and tone right. Audio is never sent. The app tells you this when you set it up. That connection is your account with that company, governed by their terms.
 
-Ollama works in two ways, and only one of them keeps your transcript on your Mac. A model you have downloaded runs on your Mac and sends nothing. A hosted model runs on Ollama's servers, so your transcript goes to Ollama the same way it would go to any other cloud provider. EnviousWispr lists the two kinds under separate headings so you can tell which you are picking.
+Ollama works in two ways, and only one of them keeps your transcript on your Mac. A model you download runs on your Mac and sends nothing anywhere. A hosted model runs on Ollama's servers, so your transcript goes to Ollama in the same way it would go to any other cloud provider. EnviousWispr lists the two kinds under separate headings so you can tell which you are picking.
 
-Envious Labs is not in the middle of any of this. Everything goes straight from your Mac to the provider, so it is never seen here either way.
+Envious Labs is not in the middle of any of these requests. Everything goes straight from your Mac to the provider, so Envious Labs never sees it either way.

--- a/website/src/content/help/what-is-ai-polish.md
+++ b/website/src/content/help/what-is-ai-polish.md
@@ -6,25 +6,27 @@ section: "Polish"
 order: 1
 keywords: ["polish", "ai polish", "cleanup", "clean up my text", "grammar", "punctuation", "tidy", "what does ai do", "editing"]
 related: ["choosing-an-ai-provider-none-apple-intelligence-ollama-openai-gemini"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. AI Polish is the optional step it runs after transcribing you, to tidy up what you said. It fixes grammar and punctuation, cuts filler words, and is instructed to keep your meaning and your language.
+AI Polish is the optional step EnviousWispr runs after transcribing your speech, to tidy up what you said. It fixes grammar and punctuation, cuts filler words, and is instructed to keep your exact meaning and your language.
 
-### What it is designed not to do
+### What the AI is designed not to do
 
-- Add ideas of its own.
-- Answer a question instead of tidying it up.
-- Translate you. Dictate in French and you get French.
-- Touch a very short dictation. Those skip the AI step, though your other clean-up settings still apply.
+The polish step has strict limits, which exist to protect what you actually said.
 
-AI can still get things wrong. EnviousWispr checks the result and rejects the obvious failures (see [_Hallucination Protection_](/help/hallucination-protection/)), but read anything important before you send it.
+- **Add ideas.** The model is not allowed to introduce new thoughts or expand on your points.
+- **Answer questions.** If you dictate a question, the model tidies the wording rather than replying to it.
+- **Translate text.** If you dictate in French, you get French back.
+- **Touch very short dictations.** These skip the AI step entirely, though your other clean-up settings still apply.
 
-### It cannot lose your words
+AI can still make mistakes. EnviousWispr checks the result and rejects the obvious failures (read [_Hallucination Protection_](/help/hallucination-protection/) for details), but read anything important before you send it.
 
-If polish is unavailable, too slow, or gives back something unusable, EnviousWispr pastes the tidied-up text it already had before the AI step. You still get your dictation. How long the app waits before giving up depends on which option you chose.
+### How the fallback prevents lost words
 
-### What it starts as
+If polish is unavailable, runs too slowly, or returns something unusable, EnviousWispr pastes the version of your dictation from immediately before the AI step. That version is not raw: your custom words, filler-word removal, and number and date formatting have already been applied to it. You never lose your dictation. How long the app waits before giving up depends on which polish option you chose.
 
-Apple Intelligence is the option you begin with, and it needs macOS 26 or later. On a Mac that cannot run it, the AI step is quietly skipped and you get your text without it.
+### The default, and how to change it
 
-There is one polish style, tuned for dictation. To change the option or switch polish off, go to **Settings** \> **AI Polish**.
+Apple Intelligence is the option you begin with, and it requires macOS 26 or later. On a Mac that cannot run macOS 26, the AI step is quietly skipped and you receive that same pre-polish version of your text.
+
+EnviousWispr uses a single polish style, tuned for dictation. To change your polish option or switch polish off entirely, open **Settings** and select **AI Polish**.

--- a/website/src/content/help/what-is-enviouswispr.md
+++ b/website/src/content/help/what-is-enviouswispr.md
@@ -6,20 +6,24 @@ section: "Basics"
 order: 1
 keywords: ["what is it", "overview", "how does it work", "dictation app", "voice to text", "speech to text", "talk to type"]
 related: ["is-enviouswispr-free", "privacy-overview"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. You hold a hotkey, speak, and your words appear as text in whatever app you are already working in.
+EnviousWispr is a free, open-source dictation application for macOS. You hold a hotkey, speak into your microphone, and your spoken words appear as written text in whatever application you are currently using.
 
 ### How you use it
 
-1. Click where you want the text to go.
-2. Hold your hotkey and talk.
-3. Let go. The text appears at your cursor.
+You dictate by holding a hotkey while your cursor rests in a text field.
+
+- **Click into a text field.** Click inside any window or document where you want your words to appear.
+- **Hold your hotkey and talk.** Press and hold the hotkey down, then speak your thoughts out loud.
+- **Release the hotkey.** Let go of the key when you finish speaking. The transcribed text appears at your cursor.
 
 ### What you get
 
-- **It costs nothing.** No subscription, no account, no trial period. The code is open source under the GPLv3 license.
-- **Your voice stays on your Mac.** Your speech is turned into text on the device itself. The audio is never sent anywhere.
-- **It works anywhere you can type.** Slack, Mail, Notion, VS Code, Google Docs, Terminal, or any other text field on your Mac.
-- **It lives in your menu bar.** There is no Dock icon and no window to keep open.
-- **AI can tidy up what you said.** It cuts filler words like "um" and fixes grammar and punctuation. This is switched on when you install, and you can change which AI does the tidying or turn it off.
+EnviousWispr gives you a full dictation setup on macOS without asking for payment or an account.
+
+- **It costs nothing.** There is no subscription fee, no user account requirement, and no trial period. The entire application code is open source and licensed under the GPLv3.
+- **Your voice stays on your Mac.** Your speech is transcribed into text entirely on your own device. The audio recording never leaves your Mac.
+- **It works anywhere you can type.** You can dictate into Slack, Mail, Notion, VS Code, Google Docs, Terminal, or any other text field on your Mac.
+- **It lives in your menu bar.** The application runs quietly from your menu bar. There is no Dock icon and no separate window to keep open on your desktop.
+- **AI can tidy up what you said.** An optional polish step cuts filler words like "um" and fixes grammar and punctuation. This is enabled by default when you install the app, and you can switch which AI performs the polish or turn the feature off entirely.

--- a/website/src/content/help/what-is-enviouswispr.md
+++ b/website/src/content/help/what-is-enviouswispr.md
@@ -16,7 +16,7 @@ You dictate by holding a hotkey while your cursor rests in a text field.
 
 - **Click into a text field.** Click inside any window or document where you want your words to appear.
 - **Hold your hotkey and talk.** Press and hold the hotkey down, then speak your thoughts out loud.
-- **Release the hotkey.** Let go of the key when you finish speaking. The transcribed text appears at your cursor.
+- **Release the hotkey.** Let go of the key when you finish speaking. The transcribed text appears at your cursor a moment later.
 
 ### What you get
 

--- a/website/src/content/help/why-is-my-dictation-inaccurate.md
+++ b/website/src/content/help/why-is-my-dictation-inaccurate.md
@@ -6,37 +6,39 @@ section: "Transcription Issues"
 order: 2
 keywords: ["inaccurate", "wrong words", "typos", "bad accuracy", "not accurate", "gets my words wrong", "misheard", "poor quality", "garbled", "names spelled wrong", "improve accuracy"]
 related: ["adding-custom-words", "choosing-your-microphone"]
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. When it gets your words wrong, the cause is nearly always weak audio, the wrong microphone, a language it is not set to, or a word it has never met. Work through these in order.
+Dictation accuracy drops when the audio is weak, the input microphone is the wrong one, the language setting does not match your speech, or the engine meets an unfamiliar word. Work through these steps in order to improve accuracy.
 
 ### 1. Get closer to the microphone
 
-Try a headset microphone, or move nearer to your Mac. Dictate the same sentence both ways and compare the results in **History**.
+Audio quality directly affects transcription accuracy. Try a headset microphone, or move nearer to your Mac. Dictate the same sentence both ways and compare the results in **History**.
 
 ### 2. Check which microphone is being used
 
-Open EnviousWispr's settings and go to **Microphone**. On Auto, EnviousWispr records from whatever input your Mac is set to, which may not be the one you are speaking into. Pick a device from the list to be sure. The picker then shows that device's name in place of Auto.
+**Select your input device.** Open EnviousWispr settings and go to **Microphone**. On Auto, EnviousWispr records from whatever input your Mac is set to, which may not be the one you are speaking into. Pick a device from the list to be sure. The picker then shows that device's name in place of Auto.
 
 ### 3. Teach it the words it keeps missing
 
-Names, companies and terms from your field are not in a general speech model. Open settings, go to **Your Words**, and add them. Each word appears in the list once you have added it. Switch on the vocabulary packs that match your work. This is the fix for "it always spells my colleague's name wrong".
+Names, companies, and terms from your field are not in a general speech model.
+
+**Add the missing terms.** Open settings, go to **Your Words**, and add them. Each word appears in the list once you have added it. Switch on the vocabulary packs that match your work. This is the fix for a colleague's name that comes out spelled wrong every single time.
 
 ### 4. Check your language
 
-Parakeet, the engine you start with, covers 25 European languages. For anything outside that, switch to WhisperKit under **Transcription** and pick your language. On WhisperKit, naming your language is more accurate than leaving it on auto-detect.
+Parakeet, the transcription engine you start with, covers 25 European languages. For anything outside that, switch to WhisperKit under **Transcription** and pick your language. On WhisperKit, naming your language is more accurate than leaving it on auto-detect.
 
 ### 5. Turn Live transcription off
 
-If you switched it on, switch it back off under **Transcription**. On Parakeet it measurably increases mistakes.
+If you switched Live transcription on, switch it back off under **Transcription**. On Parakeet, Live transcription measurably increases mistakes.
 
 ### 6. Work out which half went wrong
 
-Open **History** and read the dictation back.
+**Review your history.** Open **History** and read the dictation back to work out where the error came from.
 
-- **The words themselves are wrong.** That is the audio or the speech engine. Go back to steps 1 to 5.
-- **The words are right but the phrasing changed.** That is AI Polish rewriting you. Set it to None under **AI Polish** and dictate again to confirm.
+- **The words themselves are wrong.** That points at the audio or the speech engine. Go back to steps 1 to 5.
+- **The words are right but the phrasing changed.** That means AI Polish rewrote your text. Set it to None under **AI Polish** and dictate again to confirm.
 
-### One more thing
+### Speak naturally
 
-Speak naturally, at your normal pace. Slowing down or over-enunciating makes recognition worse, not better.
+Speak at your normal pace. Slowing down or over-enunciating makes recognition worse, not better.

--- a/website/src/content/help/your-first-dictation.md
+++ b/website/src/content/help/your-first-dictation.md
@@ -7,27 +7,32 @@ order: 4
 keywords: ["first dictation", "how to use", "getting started", "try it", "how do i dictate", "speak", "record", "start"]
 related: ["push-to-talk-mode", "how-text-gets-pasted-into-your-app"]
 seeAlso: "getting-started-enviouswispr-under-2-minutes"
-updated: 2026-08-05
+updated: 2026-08-06
 ---
-EnviousWispr is a free dictation app for macOS. You dictate by holding a key, speaking, and letting go. Your first try takes about ten seconds.
+You dictate by holding a key, speaking, and letting go. Your first attempt takes about ten seconds, and you can do it in whatever app you already have open.
 
 ### Try it now
 
-1. Open any app you type in, such as Notes or Mail, and click into a text box so the cursor is blinking.
-2. Hold down your hotkey, the key you chose during setup.
-3. Speak normally.
-4. Let go of the key.
+**Open a text box.** Open any app you type in, such as Notes or Mail, and click into a text box so the cursor is blinking.
 
-Your words appear at the cursor a moment later.
+**Press and hold.** Hold down your hotkey, which is the key you chose during setup.
+
+**Speak.** Talk at your normal pace, as you would to a person.
+
+**Release.** Let go of the key. Your words appear at the cursor a moment later.
 
 ### What you will see
 
-- A small bar appears while you are recording, with a meter that moves as you talk. It does not take focus away from the app you were typing in.
-- The menu bar icon goes from grey to colour while you record, then turns into a spinning wheel while EnviousWispr works out what you said.
-- The text is pasted for you. Whatever was on your clipboard beforehand is put back afterwards.
+Three things happen while EnviousWispr works, and knowing them saves you wondering whether anything is happening at all.
+
+**A recording bar appears.** A small bar shows up while you are recording, with a meter that moves as you talk. It does not take focus away from the app you were typing in.
+
+**The menu bar icon changes.** The icon goes from grey to colour while you record, then turns into a spinning wheel while EnviousWispr works out what you said.
+
+**The text is pasted for you.** Whatever was on your clipboard beforehand is put back afterwards, so you do not lose what you had copied.
 
 ### Tips for a good first result
 
-- Speak at your normal speed. Slowing down does not help.
+- Speak at your normal speed. Slowing down or over-enunciating does not help.
 - On your first dictation after opening the app, pause for a beat after pressing the key. Once the microphone has been used recently, EnviousWispr also captures the half second before you press, so later dictations do not need that pause.
-- Finished dictations are saved under **History**, which you reach from the menu bar icon, so you can go back and find one. If saving fails, EnviousWispr tells you.
+- Finished dictations are saved under **History**, which you reach from the menu bar icon, so you can go back and find one later. If saving fails, EnviousWispr tells you.


### PR DESCRIPTION
## Why

PR #1961 fixed the wrong thing. The founder had said Gemini's rewrite of the help centre read better than ours, and I concluded the problem was a missing definition sentence, so I stamped "EnviousWispr is a free dictation app for macOS" onto all 52 pages. His reaction: *"we don't need to re-explain enviouswispr on every single page. I was just explaining how the writing was better. You latched onto 1 example and treated it as gospel."*

Asked directly, he named three things that were actually better about Gemini's writing, and the definition sentence was not one of them:

1. **Full explanatory sentences** rather than clipped notes that assume context.
2. **Scannable structure**: headings, bold labels, tables.
3. **A professional documentation register**, not terse working notes.

He then picked the target from three sample treatments of one real page, and chose the one closest to Gemini's own style.

## What changed

All 52 articles rewritten again, to that target:

- Sections **explain, then instruct**. A section says what the thing is and when it matters before giving the steps.
- Steps carry **bold labels**: `**Press and hold.** Keep your designated hotkey pressed, and begin speaking.`
- **Tables** wherever options are being compared. Seven pages gained one.
- Sentences carry their own meaning, so a reader can enter mid-page.
- The definition sentence now appears on **6 pages of 52**, the ones a stranger can land on cold: what it is, what it costs, system requirements, install, privacy, source code.

## How it was written

The founder's instruction was explicit: *"fix 1 page at a time, Gemini is the proof reader, the best at copywriting. listen to it's feedback. It writes better copy than you do."*

So the split is: **Gemini writes the copy, I override only when it changes a product fact.** Two prompts, one to draft and one to sign off, sharing a single register definition so they cannot drift. 52 pages, 52 explicit all-clears.

Every writing call went Gemini's way, including several I would not have made. Its structural instincts were consistently better than mine: the comparison tables, the bold-label pattern, and cutting the definition from interior pages were all its calls.

## Factual overrides, which is where I earned my keep

Fifteen, every one a product fact rather than a writing choice:

| Page | What Gemini wrote | Why it was wrong |
|---|---|---|
| push-to-talk-mode | the app "eliminates" first-word clipping | We ship a whole article about that happening |
| toggle-mode | the Shortcuts tab sits "at the top of the window" | The sidebar runs down the left |
| download-and-install | install to Applications "so the background helper can start at boot" | Invented mechanism |
| what-is-ai-polish | fallback pastes the "raw transcription", twice | Custom words, filler removal and number formatting have already run; only the empty-output floor is raw |
| ollama-polish-not-working | "you still receive your raw transcription" | Same |
| apple-intelligence-not-available | "Apple Intelligence and Siri" | The pane is "Apple Intelligence & Siri" |
| app-crashes | audio backup deleted "after the text is pasted" | The condition is saved, not pasted |
| app-crashes | app quits attributed to "an unexpected system error" | We do not claim a cause |
| numbers-dates-and-times | named the feature "smart formatting" | No such feature name |
| how-smart-polish-works | "EG-1 was trained without context awareness" | Broader than "without those context fields" |
| clipboard-preservation | clipboard save covers "images and files" | Unverified specifics |
| ai-polish-and-cloud-data | "never seen by Envious Wispr" | Wrong entity |
| choosing-your-microphone, filler-word-removal | "Command and Comma" / "Command-V" | House form is Cmd+, and Cmd+V |
| adding-custom-words | adding a word "corrects the output permanently" | Overclaim |
| various | kept the definition on interior pages after being told not to | Founder's correction |

I also caught two banned "just" instances that Gemini's own proofread passed, and cut one paragraph that restated its own first sentence, which its own rules forbid.

## Verification

| Check | Result |
|---|---|
| Files changed | 52 |
| Banned words (`simply`/`just`/`easily` + buzzword list) | 0 |
| Em and en dashes | 0 |
| Pages naming the category in sentence 1 | 6, and they are the intended 6 |
| Settings names vs `SettingsSection.swift` | 15 distinct bolded targets, 0 unrecognised |
| `npm ci` then `npm run build` **in this worktree** | 122 pages, Complete |
| `check-help-content` | 52 articles, 0 errors |
| `check-help-routes` | expected 65, built 65, sitemap 65, 8727 internal links, 0 dead |
| `check-help-search` | 37 passed, 0 failed |

**The search check caught two real regressions** and neither assertion was relaxed to make them pass. The fuller register repeated "hold" and "hotkey" enough on push-to-talk that it stole `dont want to hold the key` from hands-free; the permissions page gained enough microphone prose to steal `microphone not working` from the empty-transcription page. Both fixed by moving the wording to the page that should own it, then re-running.

Part of #1944. Supersedes the opener approach in #1961.
