### PR TITLE
feat(reporting): Sentry error section in both digests, and a rate alert that says something (Part of #1965)

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -520,7 +520,12 @@ jobs:
       - name: Worker unit tests
         run: |
           set -euo pipefail
-          for w in daily-report weekly-digest; do
+          # sentry-triage joined this list in #1965. Its 60 tests had existed
+          # since #1586 and had never run in CI, which nobody noticed because a
+          # test that is never executed reports nothing at all. #1965 added 26
+          # more, so the silence would have covered the whole spike-card path.
+          # It has no package.json and needs none; `node --test` finds test/.
+          for w in daily-report weekly-digest sentry-triage; do
             echo "==> $w"
             ( cd "workers/$w" && node --test )
           done

--- a/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
@@ -452,9 +452,16 @@ final class KernelLifecycleTelemetrySink {
       // (`.maxDurationReached` was deleted by #1408 A3 — the cap is a normal
       // auto-stop and no longer stamps a cause at all. `.captureSessionLost`
       // was deleted by #1524; the XPC-connection cause by #1543 with the audio
-      // boundary.) Category is `.audioCaptureFailed`, never `.xpcServiceError` —
-      // a benign device disconnect must not page the "XPC Service Crash >1/hr"
-      // alert.
+      // boundary.) Category is `.audioCaptureFailed`, never `.xpcServiceError`,
+      // because a device disconnect is an audio failure and not an XPC one.
+      //
+      // The old justification here claimed the category choice kept a benign
+      // disconnect from paging the "XPC Service Crash >1/hr" alert. That was
+      // FALSE and is deleted rather than reworded: the rate rules were plain
+      // `count()` over `is:unresolved` and filtered by no category at all, so
+      // both categories fed the same counter and the choice changed nothing
+      // about what fired (#1965, verified against the live rule definitions).
+      // The category is still right; only the stated reason was wrong.
       //
       // NOTE: reaching this terminal at all now means salvage did not produce a
       // transcript. A salvaged dictation ends `.completed` and never lands here,

--- a/workers/daily-report/README.md
+++ b/workers/daily-report/README.md
@@ -53,13 +53,19 @@ node --test                     # pure query-shape/bucketing/formatting logic, n
 ```
 
 Pre-deploy live-query smoke (runs the real HogQL against production
-PostHog, asserts the completeness check passes, prints the would-be
-message, posts nothing):
+PostHog **and the real Sentry queries**, asserts the completeness check
+passes, prints the would-be message, posts nothing):
 
 ```bash
 ~/.claude/bin/get-key launch posthog-personal-api-key POSTHOG_KEY -- \
+  ~/.claude/bin/get-key launch sentry-master-key SENTRY_KEY -- \
   node workers/daily-report/live-query-smoke.mjs [YYYY-MM-DD]
 ```
+
+`SENTRY_KEY` uses the existing admin read credential **for this local smoke
+only**, because no worker-grade credential can reach the Discover endpoint the
+Sentry section needs (measured 2026-08-06: both worker tokens 403). Never
+install `sentry-master-key` as a Cloudflare Worker secret.
 
 The optional date argument overrides "yesterday" — useful for testing
 against a known day, and mirrors the deployed worker's `?date=` recovery

--- a/workers/daily-report/README.md
+++ b/workers/daily-report/README.md
@@ -134,6 +134,16 @@ security find-generic-password -w -a m4pro_sv -s enviouswispr.discord-webhook-se
 # not exist on the machine (verified 2026-07-18, #1655).
 ~/.claude/bin/get-key launch daily-report-trigger-secret V -- sh -c 'printf "%s" "$V" | npx wrangler secret put TRIGGER_SECRET'
 
+# SENTRY_AUTH_TOKEN goes on ALL THREE Sentry workers, not just this one (#1965).
+# sentry-triage needs it for the rate-alert breakdown; its older token reads
+# per-issue events fine but 403s on the aggregate endpoint, so leaving that one
+# in place degrades every spike card while the error path keeps working and
+# hides the gap.
+for w in daily-report weekly-digest sentry-triage; do
+  (cd "../$w" && ~/.claude/bin/get-key launch sentry-workers-readonly-token V -- \
+     sh -c 'printf "%s" "$V" | npx wrangler secret put SENTRY_AUTH_TOKEN')
+done
+
 # verify (posts a REAL report to EnviousNotes) - needs the token:
 curl -fsS "https://enviouswispr-daily-report.saurabhav.workers.dev/?token=<TRIGGER_SECRET>"
 ```

--- a/workers/daily-report/README.md
+++ b/workers/daily-report/README.md
@@ -58,14 +58,19 @@ passes, prints the would-be message, posts nothing):
 
 ```bash
 ~/.claude/bin/get-key launch posthog-personal-api-key POSTHOG_KEY -- \
-  ~/.claude/bin/get-key launch sentry-master-key SENTRY_KEY -- \
+  ~/.claude/bin/get-key launch sentry-workers-readonly-token SENTRY_KEY -- \
   node workers/daily-report/live-query-smoke.mjs [YYYY-MM-DD]
 ```
 
-`SENTRY_KEY` uses the existing admin read credential **for this local smoke
-only**, because no worker-grade credential can reach the Discover endpoint the
-Sentry section needs (measured 2026-08-06: both worker tokens 403). Never
-install `sentry-master-key` as a Cloudflare Worker secret.
+`SENTRY_KEY` is the same least-privilege token the deployed Worker holds
+(`event:read` + `org:read`), so the smoke exercises exactly the access
+production has. An earlier version of this file used `sentry-master-key` and
+justified it with "no worker-grade credential can reach the Discover endpoint" —
+true when written, false since `sentry-workers-readonly-token` was minted on
+2026-08-06. Do not reintroduce the admin key here: it grants far more than a
+smoke needs, and running the smoke under wider access than production has can
+pass a query the deployed Worker would be refused. Never install
+`sentry-master-key` as a Cloudflare Worker secret either.
 
 The optional date argument overrides "yesterday" — useful for testing
 against a known day, and mirrors the deployed worker's `?date=` recovery

--- a/workers/daily-report/live-query-smoke.mjs
+++ b/workers/daily-report/live-query-smoke.mjs
@@ -26,9 +26,21 @@ const env = {
   POSTHOG_PERSONAL_API_KEY: process.env.POSTHOG_KEY,
   GITHUB_REPO: "saurabhav88/EnviousWispr",
   DISCORD_WEBHOOK_URL: CAPTURED_WEBHOOK,
+  SENTRY_ORG: "envious-labs-llc",
+  SENTRY_PROJECT_ID: "4511097112428544",
+  SENTRY_PROJECT_SLUG: "enviouswispr",
+  SENTRY_AUTH_TOKEN: process.env.SENTRY_KEY,
 };
 if (!env.POSTHOG_PERSONAL_API_KEY) {
   console.error("POSTHOG_KEY not set - run via get-key launch posthog-personal-api-key POSTHOG_KEY -- ...");
+  process.exit(1);
+}
+// Sentry is REQUIRED here, not optional. The whole point of a pre-deploy
+// smoke is to prove the section answers against live Sentry before the
+// worker is deployed; skipping it on a missing key would print "Smoke OK"
+// for a run that never exercised the new section at all.
+if (!env.SENTRY_AUTH_TOKEN) {
+  console.error("SENTRY_KEY not set - the Sentry section would not be exercised, so this smoke proves nothing about it");
   process.exit(1);
 }
 
@@ -43,7 +55,9 @@ globalThis.fetch = async (url, init) => {
       ? `posthog:${JSON.parse(init.body).name}`
       : target.startsWith("https://api.github.com")
         ? "github:releases"
-        : target
+        : target.startsWith("https://us.sentry.io")
+          ? `sentry:${new URL(target).pathname}`
+          : target
   );
   if (target === CAPTURED_WEBHOOK) {
     captured = JSON.parse(init.body);

--- a/workers/daily-report/src/index.js
+++ b/workers/daily-report/src/index.js
@@ -479,14 +479,19 @@ const SENTRY_TITLE = "Sentry, yesterday";
  * five calls is how a report ends up comparing windows that do not abut. */
 export function sentryWindowFor(context) {
   const naiveISO = (date) => date.toISOString().slice(0, 19);
-  const priorStart = new Date(context.startUTC.getTime() - (context.endUTC - context.startUTC));
+  // The prior window is the PREVIOUS EASTERN CALENDAR DAY, resolved through the
+  // same midnight machinery as the reported one. Subtracting the reported day's
+  // DURATION instead looks equivalent and is wrong twice a year: on 2026-11-01
+  // the reported day is 25 hours long, so a duration subtraction would compare
+  // it against a 25-hour "yesterday" that reaches an hour back into Oct 30; on
+  // 2026-03-08 the day is 23 hours and the comparison would MISS an hour of
+  // Mar 7. Either way the founder reads "1 fewer than yesterday" against a
+  // window that is not yesterday, and nothing in the output would say so.
+  const priorStart = findUTCForEasternMidnight(shiftDateString(context.dateStr, -1));
   return {
     startISO: naiveISO(context.startUTC),
     endISO: naiveISO(context.endUTC),
     priorStartISO: naiveISO(priorStart),
-    // Matches the report window. The daily report badges an issue as new only
-    // when its FIRST-EVER event is inside the day being reported.
-    firstSeenPeriod: "24h",
   };
 }
 

--- a/workers/daily-report/src/index.js
+++ b/workers/daily-report/src/index.js
@@ -11,6 +11,10 @@
  *   Version scorecard - the last complete Eastern week, per release, with the
  *                       two largest ranked changes against each measure's own
  *                       normal week-to-week movement (#1838).
+ *   Sentry            - yesterday's errors on the current release line, split
+ *                       into dictations LOST and dictations that still worked
+ *                       but worse, with the change in affected people against
+ *                       the day before (#1965).
  *
  * Gates nothing and alerts on nothing. Defect detection belongs to the Sentry
  * triage routines; this is a digest, and the threshold-alarm shape it replaced
@@ -43,6 +47,11 @@ import {
   formatScorecard,
   formatScorecardUnavailable,
 } from "./report-format.js";
+import {
+  fetchSentrySection,
+  formatSentrySection,
+  formatSentryUnavailable,
+} from "../../reporting/sentry-section.js";
 
 export default {
   async fetch(request, env) {
@@ -455,6 +464,54 @@ async function postFailureNotice(env, dateStr) {
   }
 }
 
+/** Just "Sentry, yesterday": the day is on the message's content line, and this
+ * section always reports the day the rest of the report is about. */
+const SENTRY_TITLE = "Sentry, yesterday";
+
+/** Sentry's window, derived from the ONE resolved report context and nothing
+ * else - this file's orchestration rule, applied to a third vendor. Sentry's
+ * `start`/`end` are naive ISO instants interpreted as UTC, so the Eastern day
+ * boundary already computed in `context` converts directly with no second
+ * timezone calculation.
+ *
+ * `statsPeriod` is deliberately NOT used. It cannot express "the day before
+ * yesterday", which the people delta needs, and mixing the two forms across
+ * five calls is how a report ends up comparing windows that do not abut. */
+export function sentryWindowFor(context) {
+  const naiveISO = (date) => date.toISOString().slice(0, 19);
+  const priorStart = new Date(context.startUTC.getTime() - (context.endUTC - context.startUTC));
+  return {
+    startISO: naiveISO(context.startUTC),
+    endISO: naiveISO(context.endUTC),
+    priorStartISO: naiveISO(priorStart),
+    // Matches the report window. The daily report badges an issue as new only
+    // when its FIRST-EVER event is inside the day being reported.
+    firstSeenPeriod: "24h",
+  };
+}
+
+/** Runs the Sentry section and converts every failure into a settled record.
+ *
+ * NEVER whole-run fatal, deliberately. A Sentry outage must not cost the
+ * founder the adoption numbers, which are measured from an entirely different
+ * vendor and are perfectly good. The trigger still fails afterwards, so a
+ * section that quietly stopped working cannot look healthy forever.
+ */
+async function settleSentrySection(env, context, deps) {
+  try {
+    const opts = { ...(deps.sentryOpts || {}), workerLabel: "daily_report" };
+    const data = await fetchSentrySection(env, sentryWindowFor(context), opts);
+    // Rendering AND its shape check both sit inside the settled outcome, for
+    // the same reason driveSections puts them there: a section that computes
+    // cleanly and renders badly is an unavailable section, and validating it
+    // later at delivery would fail the whole payload and cost the OTHER
+    // sections their place in the report.
+    return { status: "fulfilled", value: toEmbed(formatSentrySection(data, { title: SENTRY_TITLE })) };
+  } catch (reason) {
+    return { status: "rejected", reason: asError(reason, "sentry section") };
+  }
+}
+
 // `deps` is a test-only injection seam (production passes nothing, every
 // default applies): `deps.resolveBuckets` lets a degraded-engine test prove
 // resolveBuckets was never CALLED rather than that its output merely looks
@@ -500,7 +557,15 @@ export async function runReport(env, dateOverride = null, deps = {}) {
     },
   ];
 
-  const outcomes = await driveSections(sections, CONCURRENCY_LIMIT);
+  // Sentry runs ALONGSIDE the PostHog work, not inside its limiter. The limiter
+  // exists for PostHog's 3-query project ceiling; Sentry is a different vendor
+  // with its own limits (30 per window, 15 concurrent), so a Sentry read that
+  // waited for a PostHog slot would block a PostHog query for ~1.8s while doing
+  // no PostHog work at all.
+  const [outcomes, sentryOutcome] = await Promise.all([
+    driveSections(sections, CONCURRENCY_LIMIT),
+    settleSentrySection(env, context, deps),
+  ]);
 
   // A release-resolution CONTRACT failure - misconfiguration, a malformed
   // response, no eligible release - means we cannot know which releases this
@@ -525,9 +590,14 @@ export async function runReport(env, dateOverride = null, deps = {}) {
     content: reportHeader(context.dateStr),
     // A fulfilled outcome is ALREADY an embed, validated inside its own
     // section. Only the fixed unavailable copy is rendered here.
-    embeds: sections.map((s, i) =>
-      outcomes[i].status === "fulfilled" ? outcomes[i].value : toEmbed(s.unavailable())
-    ),
+    embeds: [
+      ...sections.map((s, i) =>
+        outcomes[i].status === "fulfilled" ? outcomes[i].value : toEmbed(s.unavailable())
+      ),
+      sentryOutcome.status === "fulfilled"
+        ? sentryOutcome.value
+        : toEmbed(formatSentryUnavailable(SENTRY_TITLE)),
+    ],
   };
 
   // Validated and sent as ONE object inside deliverReport. An over-budget
@@ -536,8 +606,11 @@ export async function runReport(env, dateOverride = null, deps = {}) {
   await deliverReport(env.DISCORD_WEBHOOK_URL, payload);
 
   // The founder has the report; the trigger still has to fail, or a section
-  // that silently stopped working would look like a healthy run forever.
-  const failed = outcomes.find((o) => o.status === "rejected");
+  // that silently stopped working would look like a healthy run forever. The
+  // Sentry outcome is checked with the others, not separately: it is exactly as
+  // capable of failing quietly, and a missing Sentry section for months is the
+  // shape this whole issue exists to prevent.
+  const failed = [...outcomes, sentryOutcome].find((o) => o.status === "rejected");
   if (failed) throw failed.reason;
   return payload.content;
 }

--- a/workers/daily-report/test/report.test.js
+++ b/workers/daily-report/test/report.test.js
@@ -38,6 +38,8 @@ import {
 } from "../src/version-scorecard.js";
 import { formatScorecard, formatScorecardUnavailable } from "../src/report-format.js";
 import { SENTRY_CALLS_PER_DIGEST } from "../../reporting/sentry-section.js";
+import { SENTRY_MAX_ATTEMPTS } from "../../shared/sentry.js";
+import { sentryWindowFor } from "../src/index.js";
 // #1838 chunk 1: the PostHog transport/concurrency/production-filter
 // infrastructure now has ONE owner. Tests import it from there directly - a
 // re-export from index.js would be a forwarding shim kept alive solely for
@@ -1348,11 +1350,14 @@ test("worst-case explicit fetch count stays under Cloudflare's 50-subrequest cap
   // No Sentry path fans out per issue, so this does not move with error volume.
   const SENTRY_REQUESTS = SENTRY_CALLS_PER_DIGEST;
   const MAX_ATTEMPTS_PER_REQUEST = 3;
-  // Sentry retries TWICE, not three times, precisely so this arithmetic keeps
-  // headroom under the 50 cap. At three it lands on 49, and the next query
-  // added anywhere in this worker would take the WHOLE report over the cap
-  // rather than just the Sentry section. See workers/shared/sentry.js.
-  const SENTRY_ATTEMPTS = 2;
+  // READ FROM THE TRANSPORT, never restated. A literal 2 here would keep this
+  // assertion green while the real retry budget changed underneath it, which is
+  // precisely the drift that makes a subrequest-cap check worthless.
+  // Sentry retries twice, not three times, so this arithmetic keeps headroom
+  // under the 50 cap: at three it lands on 49, and the next query added
+  // anywhere in this worker would take the WHOLE report over.
+  const SENTRY_ATTEMPTS = SENTRY_MAX_ATTEMPTS;
+  assert.equal(SENTRY_ATTEMPTS, 2, "the Sentry retry budget changed; re-check the 50-subrequest cap");
   const DISCORD_POSTS = 1; // one atomic payload, one attempt, never a retry
 
   assert.equal(SENTRY_REQUESTS, 5, "the Sentry call budget is five fixed requests");
@@ -4067,4 +4072,34 @@ test("installs counts BEGAN-ONBOARDING, not the launch-time fresh-install state"
   assert.ok(weeklyQuery, "expected weekly appUsageSql");
   assert.match(weeklyQuery, /uniqExactIf\(distinct_id, event = 'onboarding\.started'\) AS fresh/);
   assert.doesNotMatch(weeklyQuery, /is_fresh_install/);
+});
+
+test("the Sentry prior window is the previous EASTERN day, not a duration subtraction", () => {
+  // Subtracting the reported day's own duration looks equivalent and is wrong
+  // twice a year. On 2026-11-01 the reported day is 25 hours long, so a
+  // duration subtraction reaches an hour back into Oct 30; on 2026-03-08 the
+  // day is 23 hours and it MISSES an hour of Mar 7. Either way the founder
+  // reads "1 fewer than yesterday" against a window that is not yesterday.
+  const cases = [
+    // [reported day, prior start, window start, window end]
+    ["2026-07-17", "2026-07-16T04:00:00", "2026-07-17T04:00:00", "2026-07-18T04:00:00"],
+    ["2026-11-01", "2026-10-31T04:00:00", "2026-11-01T04:00:00", "2026-11-02T05:00:00"], // fall back, 25h day
+    ["2026-03-08", "2026-03-07T05:00:00", "2026-03-08T05:00:00", "2026-03-09T04:00:00"], // spring forward, 23h day
+  ];
+  for (const [day, priorStartISO, startISO, endISO] of cases) {
+    const w = sentryWindowFor(resolveReportWindow(new Date("2026-12-01T12:00:00Z"), day));
+    assert.equal(w.startISO, startISO, `${day} start`);
+    assert.equal(w.endISO, endISO, `${day} end`);
+    assert.equal(w.priorStartISO, priorStartISO, `${day} prior start`);
+  }
+});
+
+test("the prior window abuts the reported one exactly, with no gap and no overlap", () => {
+  for (const day of ["2026-07-17", "2026-11-01", "2026-03-08"]) {
+    const w = sentryWindowFor(resolveReportWindow(new Date("2026-12-01T12:00:00Z"), day));
+    const priorEnd = w.startISO;
+    assert.ok(w.priorStartISO < priorEnd, `${day}: prior window must have positive length`);
+    // The prior window ends exactly where the reported one starts.
+    assert.equal(priorEnd, w.startISO, `${day}: contiguous`);
+  }
 });

--- a/workers/daily-report/test/report.test.js
+++ b/workers/daily-report/test/report.test.js
@@ -37,6 +37,7 @@ import {
   releaseAgeInWindow,
 } from "../src/version-scorecard.js";
 import { formatScorecard, formatScorecardUnavailable } from "../src/report-format.js";
+import { SENTRY_CALLS_PER_DIGEST } from "../../reporting/sentry-section.js";
 // #1838 chunk 1: the PostHog transport/concurrency/production-filter
 // infrastructure now has ONE owner. Tests import it from there directly - a
 // re-export from index.js would be a forwarding shim kept alive solely for
@@ -805,6 +806,64 @@ const PUBLISHED_RELEASES = [
 ];
 
 const GITHUB_HOST = "https://api.github.com";
+const SENTRY_HOST = "https://us.sentry.io";
+
+/** Answers the five Sentry calls the digest section makes (#1965).
+ *
+ * The aggregate bodies carry `meta.fields`, because the REAL endpoint returns
+ * it on an EMPTY response too - a double thinner than production would slip
+ * straight past the shape check that exists to stop a malformed empty body
+ * reading as "no errors today". Measured against live Sentry 2026-08-06.
+ *
+ * The release rows are the real 2026-08-05 production split, so the resolved
+ * release line in these tests is the one the rule actually produces rather than
+ * a shape invented to match it. */
+const SENTRY_RELEASE_ROWS = [
+  { release: "com.enviouswispr.app@2.4.3", "count_unique(user)": 8, "count()": 19 },
+  { release: "com.enviouswispr.app@2.4.1", "count_unique(user)": 3, "count()": 12 },
+  { release: "com.enviouswispr.app@2.3.1", "count_unique(user)": 2, "count()": 5 },
+];
+const SENTRY_PROBLEM_ROWS = [
+  {
+    issue: "ENVIOUSWISPR-2C", "issue.id": 1, title: "audio_capture_stalled: HeartPathError#0",
+    "error.category": "audio_capture_stalled", level: "error",
+    "count_unique(user)": 7, "count()": 19,
+  },
+  {
+    issue: "ENVIOUSWISPR-24", "issue.id": 2, title: "paste_failed: HeartPathError#3",
+    "error.category": "paste_failed", level: "error",
+    "count_unique(user)": 1, "count()": 1,
+  },
+];
+
+function sentryMeta(names) {
+  return { fields: Object.fromEntries(names.map((n) => [n, "integer"])) };
+}
+
+function sentryAnswer(target) {
+  if (target.includes("/issues/")) {
+    return fakeResponse(200, [{ shortId: "ENVIOUSWISPR-4P", firstSeen: "2026-07-17T12:00:00Z" }]);
+  }
+  if (target.includes("field=release")) {
+    return fakeResponse(200, {
+      data: SENTRY_RELEASE_ROWS,
+      meta: sentryMeta(["release", "count_unique(user)", "count()"]),
+    });
+  }
+  if (target.includes("field=issue")) {
+    return fakeResponse(200, {
+      data: SENTRY_PROBLEM_ROWS,
+      meta: sentryMeta(["title", "issue.id", "error.category", "level", "count_unique(user)", "count()"]),
+    });
+  }
+  // The two headline aggregates differ only by window; the prior one starts a
+  // day earlier than the reported day.
+  const isPrior = target.includes(encodeURIComponent("2026-07-16T04:00:00"));
+  return fakeResponse(200, {
+    data: [{ "count_unique(user)": isPrior ? 6 : 8, "count()": 20 }],
+    meta: sentryMeta(["count_unique(user)", "count()"]),
+  });
+}
 
 function githubResponse(status, body) {
   return {
@@ -820,7 +879,7 @@ function githubResponse(status, body) {
  * post) succeed, and lets the caller redirect any one of them. `seen` records
  * every PostHog query name in order; `requests` records every outbound call so
  * a test can count what actually left the worker. Returns a restore fn. */
-function mockPostHog({ failQuery, failWith, github, discordStatus, onDiscord } = {}) {
+function mockPostHog({ failQuery, failWith, github, discordStatus, onDiscord, sentry } = {}) {
   const realFetch = globalThis.fetch;
   const seen = [];
   const requests = [];
@@ -830,17 +889,32 @@ function mockPostHog({ failQuery, failWith, github, discordStatus, onDiscord } =
   // before answering, so two tasks genuinely coexist and a raised ceiling shows
   // up here instead of being invisible to an instantly-resolving mock.
   let inFlight = 0;
-  const state = { maxInFlight: 0 };
+  // Counted PER VENDOR since #1965. The ceiling this worker is scarce against
+  // is PostHog's 3-concurrent PROJECT limit, and Sentry deliberately runs
+  // OUTSIDE that limiter because it is a different vendor with its own limits.
+  // A single combined counter would measure a ceiling nobody ever promised, and
+  // "fix" it by relaxing the one real invariant this test exists to hold.
+  let posthogInFlight = 0;
+  let sentryInFlight = 0;
+  const state = { maxInFlight: 0, maxPostHogInFlight: 0, maxSentryInFlight: 0 };
   globalThis.fetch = async (url, init) => {
     const target = String(url);
     requests.push(target);
+    const isPostHog = target.includes("posthog.com");
+    const isSentry = target.startsWith(SENTRY_HOST);
     inFlight += 1;
+    if (isPostHog) posthogInFlight += 1;
+    if (isSentry) sentryInFlight += 1;
     state.maxInFlight = Math.max(state.maxInFlight, inFlight);
+    state.maxPostHogInFlight = Math.max(state.maxPostHogInFlight, posthogInFlight);
+    state.maxSentryInFlight = Math.max(state.maxSentryInFlight, sentryInFlight);
     try {
       await new Promise((resolve) => setTimeout(resolve, 0));
       return await answer(target, init);
     } finally {
       inFlight -= 1;
+      if (isPostHog) posthogInFlight -= 1;
+      if (isSentry) sentryInFlight -= 1;
     }
   };
 
@@ -849,6 +923,11 @@ function mockPostHog({ failQuery, failWith, github, discordStatus, onDiscord } =
       if (github instanceof Error) throw github;
       if (typeof github === "number") return githubResponse(github, null);
       return githubResponse(200, github ?? PUBLISHED_RELEASES);
+    }
+    if (target.startsWith(SENTRY_HOST)) {
+      if (sentry instanceof Error) throw sentry;
+      if (typeof sentry === "number") return fakeResponse(sentry, {});
+      return sentryAnswer(target);
     }
 
     const body = init?.body ? JSON.parse(init.body) : {};
@@ -907,6 +986,13 @@ const TEST_ENV = {
   POSTHOG_PERSONAL_API_KEY: "k",
   GITHUB_REPO: "saurabhav88/EnviousWispr",
   DISCORD_WEBHOOK_URL: "https://discord.example/webhook",
+  // #1965. Present in the base env so a "clean run" test exercises the Sentry
+  // section for real. An env WITHOUT these is a legitimate deployment state
+  // (the secret has not been installed yet) and is covered by its own test.
+  SENTRY_ORG: "envious-labs-llc",
+  SENTRY_PROJECT_ID: "4511097112428544",
+  SENTRY_PROJECT_SLUG: "enviouswispr",
+  SENTRY_AUTH_TOKEN: "sentry-test-token",
 };
 const TEST_WIN = "timestamp >= '2026-07-17 04:00:00' AND timestamp < '2026-07-18 04:00:00'";
 const TEST_END = new Date("2026-07-18T04:00:00Z");
@@ -1257,15 +1343,28 @@ test("worst-case explicit fetch count stays under Cloudflare's 50-subrequest cap
   const ADOPTION_QUERIES = 7; // installs, onboard_activate, totals, engine_and_tier_b, geo, top5, tier_a
   const SCORECARD_QUERIES = 2; // additive (day grain) + non-additive (window grain)
   const GITHUB_REQUESTS = 1; // the published release list
+  // #1965. FIVE fixed Sentry calls, and the number that matters is that it is
+  // FIXED: releases, problems, the new-issue set, and two headline aggregates.
+  // No Sentry path fans out per issue, so this does not move with error volume.
+  const SENTRY_REQUESTS = SENTRY_CALLS_PER_DIGEST;
   const MAX_ATTEMPTS_PER_REQUEST = 3;
+  // Sentry retries TWICE, not three times, precisely so this arithmetic keeps
+  // headroom under the 50 cap. At three it lands on 49, and the next query
+  // added anywhere in this worker would take the WHOLE report over the cap
+  // rather than just the Sentry section. See workers/shared/sentry.js.
+  const SENTRY_ATTEMPTS = 2;
   const DISCORD_POSTS = 1; // one atomic payload, one attempt, never a retry
+
+  assert.equal(SENTRY_REQUESTS, 5, "the Sentry call budget is five fixed requests");
 
   const worstCase =
     (PREFLIGHT_QUERIES + ADOPTION_QUERIES + SCORECARD_QUERIES + GITHUB_REQUESTS) *
       MAX_ATTEMPTS_PER_REQUEST +
+    SENTRY_REQUESTS * SENTRY_ATTEMPTS +
     DISCORD_POSTS;
 
-  assert.equal(worstCase, 34, "the designed worst case is exactly 34 outbound requests");
+  assert.equal(worstCase, 44, "the designed worst case is exactly 44 outbound requests");
+  assert.ok(worstCase <= 50 - 5, "keep at least one section's worth of headroom under the cap");
   assert.ok(worstCase < 50, "worst-case fetch count must stay under Cloudflare's 50-subrequest-per-request cap");
 
   // And the CLEAN case, measured against the real worker rather than restated:
@@ -1273,7 +1372,7 @@ test("worst-case explicit fetch count stays under Cloudflare's 50-subrequest cap
   const mock = mockPostHog({});
   try {
     await runReport(TEST_ENV, "2026-07-17", { hogqlOpts: { sleepFn: async () => {} } });
-    assert.equal(mock.requests.length, 12, `expected 12 clean-run requests, got ${mock.requests.length}`);
+    assert.equal(mock.requests.length, 17, `expected 17 clean-run requests, got ${mock.requests.length}`);
     assert.deepEqual(
       [...mock.seen].sort(),
       ["dev_ids", "engine_and_tier_b", "geo", "installs", "onboard_activate",
@@ -2792,7 +2891,7 @@ test("ranked-change formatting freezes normalized raw-fallback and unavailable c
 // limiter, one payload, one request. Every test below exists because the
 // alternative is a report that looks entirely reasonable and is not.
 
-test("a clean run resolves ONE context and posts ONE payload carrying both sections", async () => {
+test("a clean run resolves ONE context and posts ONE payload carrying all three sections", async () => {
   const mock = mockPostHog({});
   try {
     const content = await runReport(TEST_ENV, "2026-07-17", { hogqlOpts: { sleepFn: async () => {} } });
@@ -2801,15 +2900,24 @@ test("a clean run resolves ONE context and posts ONE payload carrying both secti
     const payload = mock.discordPayloads[0];
     assert.equal(payload.content, content);
     assert.equal(payload.content, reportHeader("2026-07-17"));
-    assert.equal(payload.embeds.length, 2, "exactly two embeds");
+    assert.equal(payload.embeds.length, 3, "exactly three embeds");
     assert.equal(payload.embeds[0].title, "Adoption");
     assert.match(payload.embeds[1].title, /^Version scorecard/);
+    assert.equal(payload.embeds[2].title, "Sentry, yesterday");
     // Real sections, not the unavailable copy.
     assert.match(payload.embeds[0].description, /Total users: 1 people used the app that day\./);
     assert.match(payload.embeds[1].description, /2\.4\.1: 7\/7 days publicly available/);
     assert.match(payload.embeds[1].description, /2\.4\.0: 7\/7 days publicly available/);
-    assert.doesNotMatch(payload.embeds[0].description, /unavailable today/);
-    assert.doesNotMatch(payload.embeds[1].description, /unavailable today/);
+    // The Sentry section is REAL here, not the unavailable copy: the release
+    // line resolves to 2.4.0 from the fixture's own per-release split, and both
+    // groups render.
+    assert.match(payload.embeds[2].description, /on 2\.4\.0 and newer/);
+    assert.match(payload.embeds[2].description, /LOST THE DICTATION/);
+    assert.match(payload.embeds[2].description, /7 people {3}microphone capture stalled/);
+    assert.match(payload.embeds[2].description, /STILL WORKED, JUST WORSE/);
+    for (const embed of payload.embeds) {
+      assert.doesNotMatch(embed.description, /unavailable today/);
+    }
     for (const embed of payload.embeds) {
       assert.ok(embed.description.length > 0, "an embed description is never empty");
       assert.doesNotMatch(embed.description, /[–—]/, "no en-dashes or em-dashes");
@@ -2819,19 +2927,21 @@ test("a clean run resolves ONE context and posts ONE payload carrying both secti
   }
 });
 
-test("a clean run's twelve requests go to the expected queries, repository and webhook", async () => {
+test("a clean run's seventeen requests go to the expected queries, repository, Sentry and webhook", async () => {
   const mock = mockPostHog({});
   try {
     await runReport(TEST_ENV, "2026-07-17", { hogqlOpts: { sleepFn: async () => {} } });
 
-    assert.equal(mock.requests.length, 12);
+    assert.equal(mock.requests.length, 17);
     const posthog = mock.requests.filter((u) => u.includes("posthog.com"));
     const github = mock.requests.filter((u) => u.startsWith(GITHUB_HOST));
+    const sentry = mock.requests.filter((u) => u.startsWith(SENTRY_HOST));
     const discord = mock.requests.filter((u) => u === TEST_ENV.DISCORD_WEBHOOK_URL);
     assert.equal(posthog.length, 10, "1 dev-ID + 7 adoption + 2 scorecard");
     assert.equal(github.length, 1, "the release list is fetched exactly once");
+    assert.equal(sentry.length, SENTRY_CALLS_PER_DIGEST, "the fixed Sentry budget, never a per-issue fan-out");
     assert.equal(discord.length, 1, "one delivery");
-    assert.equal(posthog.length + github.length + discord.length, mock.requests.length,
+    assert.equal(posthog.length + github.length + sentry.length + discord.length, mock.requests.length,
       "no unaccounted outbound request");
     // GITHUB_REPO is OBSERVED, not assumed: a hard-coded repository would still
     // pass a count check while reading somebody else's release history.
@@ -2906,12 +3016,33 @@ test("dev IDs resolve ONCE and both sections share that one production predicate
   }
 });
 
-test("concurrency never exceeds two ACROSS both sections, not two per section", async () => {
+test("PostHog concurrency never exceeds two ACROSS both sections, not two per section", async () => {
   const mock = mockPostHog({});
   try {
     await runReport(TEST_ENV, "2026-07-17", { hogqlOpts: { sleepFn: async () => {} } });
-    assert.equal(mock.state.maxInFlight, 2,
-      `PostHog allows three concurrent project queries; observed ${mock.state.maxInFlight}`);
+    assert.equal(mock.state.maxPostHogInFlight, 2,
+      `PostHog allows three concurrent project queries; observed ${mock.state.maxPostHogInFlight}`);
+    // The cap is REACHED, not merely respected. A serialised run would satisfy
+    // any ceiling and would tell us nothing.
+    assert.ok(mock.state.maxPostHogInFlight >= 2, "the limiter must actually reach its ceiling");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("Sentry runs alongside PostHog, not inside its limiter, and stays well under its own ceiling", async () => {
+  // The point of running outside: a Sentry read must never occupy a PostHog
+  // slot. The evidence is that the two overlap - total in-flight exceeds
+  // PostHog's own ceiling - while Sentry stays far below its 15-concurrent
+  // limit. Both directions matter: if these were serialised, the Sentry section
+  // would add its full latency to every report.
+  const mock = mockPostHog({});
+  try {
+    await runReport(TEST_ENV, "2026-07-17", { hogqlOpts: { sleepFn: async () => {} } });
+    assert.ok(mock.state.maxSentryInFlight >= 2, "the Sentry stages must run concurrently");
+    assert.ok(mock.state.maxSentryInFlight <= 3, "no Sentry stage exceeds three in flight");
+    assert.ok(mock.state.maxInFlight > mock.state.maxPostHogInFlight,
+      "Sentry must overlap PostHog rather than queue behind it");
   } finally {
     mock.restore();
   }
@@ -2964,7 +3095,7 @@ test("a scorecard-only failure posts the real adoption beside an unavailable sco
   }
 });
 
-test("both sections failing still posts exactly one message, with both marked unavailable", async () => {
+test("every section failing still posts exactly one message, with each marked unavailable", async () => {
   const mock = mockPostHog({});
   const realFetch = globalThis.fetch;
   globalThis.fetch = async (url, init) => {
@@ -2978,12 +3109,23 @@ test("both sections failing still posts exactly one message, with both marked un
     const res = await trigger("&date=2026-07-17");
     assert.equal(res.status, 500);
     assert.equal(mock.discordPayloads.length, 1, "one message, never one per failure");
-    const [adoption, scorecard] = mock.discordPayloads[0].embeds;
+    const [adoption, scorecard, sentry] = mock.discordPayloads[0].embeds;
     assert.match(adoption.title, /unavailable today/);
     assert.match(scorecard.title, /unavailable today/);
-    // Still a report, still two embeds: the founder learns that nothing was
+    // Sentry is unaffected by a PostHog 401 and must still render for real.
+    // A section that failed BECAUSE a different vendor failed would be a
+    // coupling this design does not have.
+    assert.equal(sentry.title, "Sentry, yesterday");
+    // Checked against the unavailable COPY, not the word "unavailable": a
+    // healthy section deliberately contains the sentence "Impact rate
+    // unavailable", so a bare word match would confuse a working section with
+    // a broken one.
+    assert.doesNotMatch(sentry.title, /unavailable today/);
+    assert.doesNotMatch(sentry.description, /could not be measured/);
+    assert.match(sentry.description, /on 2\.4\.0 and newer/);
+    // Still a report, still three embeds: the founder learns that nothing was
     // measured, which is not the same as learning that everything was zero.
-    assert.equal(mock.discordPayloads[0].embeds.length, 2);
+    assert.equal(mock.discordPayloads[0].embeds.length, 3);
     // Neither half may reassure the founder about the other. Both failed, so a
     // cross-reference would print two calm, mutually contradicting sentences.
     assert.doesNotMatch(adoption.description, /unaffected/);

--- a/workers/daily-report/test/report.test.js
+++ b/workers/daily-report/test/report.test.js
@@ -4094,12 +4094,8 @@ test("the Sentry prior window is the previous EASTERN day, not a duration subtra
   }
 });
 
-test("the prior window abuts the reported one exactly, with no gap and no overlap", () => {
-  for (const day of ["2026-07-17", "2026-11-01", "2026-03-08"]) {
-    const w = sentryWindowFor(resolveReportWindow(new Date("2026-12-01T12:00:00Z"), day));
-    const priorEnd = w.startISO;
-    assert.ok(w.priorStartISO < priorEnd, `${day}: prior window must have positive length`);
-    // The prior window ends exactly where the reported one starts.
-    assert.equal(priorEnd, w.startISO, `${day}: contiguous`);
-  }
-});
+// The "abuts" assertion that used to sit here was TAUTOLOGICAL: it assigned
+// `priorEnd = w.startISO` and then asserted they were equal, so it could not
+// fail for any input. Contiguity is now asserted against the REAL prior request
+// in workers/daily-report/test/sentry-section.test.js, where the query the
+// section actually issues is observable.

--- a/workers/daily-report/test/sentry-section.test.js
+++ b/workers/daily-report/test/sentry-section.test.js
@@ -151,11 +151,23 @@ test("every ErrorCategory in the Swift enum is classified", () => {
   assert.ok(start !== -1, "ErrorCategory declaration not found - this test's parse is broken, not the map");
   const end = source.indexOf("\n  }", start);
   assert.ok(end !== -1, "ErrorCategory declaration has no closing brace - parse is broken");
-  // `[^"]+`, not `[a-z_]+`: a raw value containing a hyphen or a digit would
-  // not match the narrower class, so the new case would be invisible here AND
-  // the 27 lower bound would still pass. The regex has to be able to see
-  // everything the enum can express.
-  const raws = [...source.slice(start, end).matchAll(/case\s+\w+\s*=\s*"([^"]+)"/g)].map((m) => m[1]);
+  // Parses BOTH forms Swift allows, and proves it saw every one.
+  //
+  // Two rounds of review went into this line. `[a-z_]+` could not match a raw
+  // value containing a hyphen or a digit. Widening to `[^"]+` fixed that and
+  // still missed a case with an IMPLICIT raw value - `case newCategory`, whose
+  // raw value is its own name - which is legal Swift and would have been
+  // invisible while the 27 lower bound still passed.
+  //
+  // The count check is what makes this non-vacuous: it compares what the
+  // detailed pattern matched against a plain count of `case` lines, so a third
+  // unparsed form fails loudly instead of silently shrinking the enum.
+  const enumBody = source.slice(start, end);
+  const declarations = [...enumBody.matchAll(/^\s*case\s+(\w+)(?:\s*=\s*"([^"]+)")?\s*$/gm)];
+  const caseLines = enumBody.match(/^\s*case\b/gm) || [];
+  assert.equal(declarations.length, caseLines.length,
+    "an ErrorCategory declaration was not parsed - the parser is incomplete, not the enum");
+  const raws = declarations.map(([, name, explicitRaw]) => explicitRaw ?? name);
 
   // POSITIVE CONTROL. A regex that silently matches nothing would make this
   // whole test vacuous and it would pass forever. 27 is the measured count on
@@ -860,11 +872,20 @@ test("an untruncated section still says the totals include the omitted rows", as
 test("the section's Discord cap matches the transport's own limit", () => {
   // The cap is duplicated as a number rather than imported across the
   // policy/transport boundary, so this is what stops the two drifting apart.
-  const data = { empty: true, reason: "no-errors" };
+  // The empty-section render that used to sit here was vacuous: its output is a
+  // fixed two lines, so it fits any cap. The 300-row test below is the real one.
   assert.equal(DISCORD_LIMITS.embedDescription, 4096);
-  // A caller asking for more than Discord accepts is capped, not obeyed.
-  const lines = formatSentrySection(data, { title: "Sentry", budget: 99999 });
-  assert.ok(lines.slice(1).join("\n").length <= DISCORD_LIMITS.embedDescription);
+});
+
+test("a budget that is not a positive safe integer is refused, never obeyed", async () => {
+  // NaN makes every `> budget` comparison FALSE, so it disabled every check
+  // silently: review rendered a 21,824-character description that way.
+  const { fetchFn } = digestFetch({ problems: [problemRow("EW-1", "paste_failed", 1, 1)] });
+  const data = await fetchSentrySection(ENV, WINDOW, { ...OPTS, fetchFn });
+  for (const bad of [Number.NaN, Infinity, -1, 0, 1.5, "1200", null]) {
+    assert.throws(() => formatSentrySection(data, { title: "Sentry", budget: bad }), TypeError,
+      `budget ${String(bad)} must be refused`);
+  }
 });
 
 // ── Gaps a mutation sweep found, each with the mutation it now kills ────────
@@ -908,4 +929,106 @@ test("a generous caller cannot push the description past Discord's own limit", a
   assert.ok(description.length > DEFAULT_SECTION_BUDGET, "the fixture must actually exceed the default budget");
   assert.ok(description.length <= DISCORD_LIMITS.embedDescription,
     `description ${description.length} exceeds Discord's ${DISCORD_LIMITS.embedDescription} limit`);
+});
+
+test("the prior aggregate ends exactly where the reported window begins", () => {
+  // Asserted against the REAL request rather than by restating the window
+  // object back to itself. The version this replaces assigned the value it then
+  // compared, so it could not fail for any input.
+  return (async () => {
+    const { fetchFn, urls } = digestFetch({ problems: [problemRow("EW-1", "paste_failed", 1, 1)] });
+    await fetchSentrySection(ENV, WINDOW, { ...OPTS, fetchFn });
+    const parsed = urls.map((u) => new URL(u));
+    const prior = parsed.find((u) => u.searchParams.get("start") === WINDOW.priorStartISO);
+    assert.ok(prior, "no request was made over the prior window");
+    assert.equal(prior.searchParams.get("end"), WINDOW.startISO,
+      "the prior window must end where the reported one starts");
+    // And the reported window is the one everything else measures.
+    const current = parsed.filter((u) => u.searchParams.get("start") === WINDOW.startISO);
+    assert.ok(current.length >= 2, "the reported window is used by more than one call");
+    for (const u of current) assert.equal(u.searchParams.get("end"), WINDOW.endISO);
+  })();
+});
+
+test("an incomplete badge set is disclosed rather than left silent", async () => {
+  // A full page of genuinely-new issues means some NEW marks are missing, and
+  // an absent badge is indistinguishable from a problem that is not new.
+  // Disclosed rather than thrown: reaching 100 new issues in one window means a
+  // catastrophic release, which is exactly when the ranked list is most worth
+  // reading.
+  const newIssues = Array.from({ length: 100 }, (_, i) => ({
+    shortId: `EW-${i}`, firstSeen: "2026-08-05T12:00:00Z",
+  }));
+  const { lines } = await render({ problems: [problemRow("EW-1", "paste_failed", 1, 1)], newIssues });
+  assert.match(lines.join("\n"), /the NEW marks below are not complete/);
+});
+
+test("a normal badge set says nothing about completeness", async () => {
+  // Two-way control: the disclosure must appear ONLY when the page was full.
+  const { lines } = await render({
+    problems: [problemRow("EW-1", "paste_failed", 1, 1)],
+    newIssues: [{ shortId: "EW-1", firstSeen: "2026-08-05T12:00:00Z" }],
+  });
+  assert.doesNotMatch(lines.join("\n"), /not complete/);
+});
+
+test("a generated ordinal never collides with a label that already exists", () => {
+  // The exact shape review proved: counting duplicates first and numbering them
+  // produces `same (1)` twice when a row is ALREADY called `same (1)`.
+  const row = (shortId, label) =>
+    ({ shortId, people: 1, events: 1, group: LOST, label, deliveryProven: true, isNew: false });
+  // TWO shapes, because they defeat different wrong implementations and the
+  // first alone left a mutation alive:
+  //   a) three identical labels - a single bump produces `same (1)` twice,
+  //      since it cannot advance past an ordinal it has already used;
+  //   b) a duplicate plus a row already NAMED `same (1)` - a count-then-number
+  //      pass collides with the pre-existing label.
+  for (const labels of [
+    ["same", "same", "same"],
+    ["same", "same", "same (1)"],
+    ["same", "same", "same", "same (1)", "same (2)"],
+  ]) {
+    const data = {
+      empty: false, floor: "2.4.0", tailPeople: 0,
+      people: labels.length, priorPeople: labels.length, events: labels.length, truncated: false,
+      rows: labels.map((label) => row(null, label)),
+    };
+    const rendered = formatSentrySection(data, { title: "Sentry" }).filter((l) => l.startsWith("  1 person"));
+    assert.equal(rendered.length, labels.length, `all rows render for ${JSON.stringify(labels)}`);
+    assert.equal(new Set(rendered).size, labels.length,
+      `rows must render distinctly for ${JSON.stringify(labels)}, got ${JSON.stringify(rendered)}`);
+  }
+});
+
+test("even the fixed empty-section copy is checked against the budget", () => {
+  // The two empty paths return short fixed text, which is exactly why it was
+  // tempting to let them skip the final check. A guard with exceptions is not a
+  // guard, and a budget small enough proves the check is actually applied.
+  for (const data of [{ empty: true, reason: "no-errors" }, { empty: true, reason: "no-release-line" }]) {
+    assert.throws(() => formatSentrySection(data, { title: "Sentry", budget: 10 }), RangeError,
+      `${data.reason} must be budget-checked too`);
+    // Two-way: it renders normally at a sane budget.
+    assert.ok(formatSentrySection(data, { title: "Sentry" }).length === 2);
+  }
+});
+
+test("a people total too large to be exact is refused, never published", () => {
+  // Each addend is a validated safe integer; their SUM need not be. An earlier
+  // version returned a fabricated ZERO here, which reads as "nobody is on an
+  // old build" - the one answer this line must never give.
+  const huge = Number.MAX_SAFE_INTEGER;
+  assert.throws(() => resolveReleaseLine([
+    // All three tie on people, so the NEWEST wins and the floor is 2.4.0.
+    { release: "com.enviouswispr.app@2.4.3", "count_unique(user)": huge },
+    { release: "com.enviouswispr.app@2.3.1", "count_unique(user)": huge },
+    { release: "com.enviouswispr.app@2.2.0", "count_unique(user)": huge },
+  ]), TypeError);
+});
+
+test("an event total too large to be exact is refused, never published", async () => {
+  const huge = Number.MAX_SAFE_INTEGER;
+  const { fetchFn } = digestFetch({
+    problems: [problemRow("EW-1", "asr_failed", 1, huge), problemRow("EW-2", "paste_failed", 1, huge)],
+  });
+  await assert.rejects(() => fetchSentrySection(ENV, WINDOW, { ...OPTS, fetchFn }), TypeError);
 });

--- a/workers/daily-report/test/sentry-section.test.js
+++ b/workers/daily-report/test/sentry-section.test.js
@@ -560,7 +560,12 @@ test("an over-budget section discloses what it omitted instead of truncating sil
   const { lines } = await render({ problems: many });
   const text = lines.join("\n");
   assert.match(text, /more problems are not listed here\. The totals above include them\./);
-  assert.ok(text.length <= DEFAULT_SECTION_BUDGET + 200, `description ${text.length} should stay near its budget`);
+  // STRICT. A "near its budget" tolerance is what let a real 24-character
+  // overrun pass: the disclosure line was appended after the budget was already
+  // spent. The budget governs the DESCRIPTION, so the title is excluded.
+  const description = lines.slice(1).join("\n");
+  assert.ok(description.length <= DEFAULT_SECTION_BUDGET,
+    `description ${description.length} exceeds the ${DEFAULT_SECTION_BUDGET} budget`);
 });
 
 test("a full page of problems is disclosed as a limited breakdown", async () => {
@@ -593,7 +598,7 @@ test("the worst realistic section still fits Discord's per-embed limits", async 
   assert.ok(body.join("\n").length <= DISCORD_LIMITS.embedDescription);
   // And well inside the shared 6000 budget, so it cannot crowd out the other
   // sections and take the whole report down with it.
-  assert.ok(body.join("\n").length <= DEFAULT_SECTION_BUDGET + 200);
+  assert.ok(body.join("\n").length <= DEFAULT_SECTION_BUDGET);
 });
 
 test("a crash label carries the exception type and never the message", () => {
@@ -651,4 +656,60 @@ test("a collision straddling the two groups is still disambiguated", () => {
   const text = formatSentrySection(data, { title: "Sentry" }).join("\n");
   assert.match(text, /same thing EW-A/);
   assert.match(text, /same thing EW-B/);
+});
+
+test("the description never exceeds its budget, at any problem count", async () => {
+  // Swept rather than spot-checked: the overrun appeared only at counts where
+  // the rows filled the budget exactly and the disclosure line then pushed past
+  // it, which a single fixture size can miss entirely.
+  for (const n of [1, 2, 3, 5, 8, 13, 21, 34, 40, 45, 50, 55, 60, 80, 100]) {
+    const problems = Array.from({ length: n }, (_, i) =>
+      problemRow(`EW-${i}`, i % 3 === 0 ? "audio_capture_stalled" : "paste_failed", 2, 2));
+    const { lines } = await render({ problems });
+    const description = lines.slice(1).join("\n");
+    assert.ok(description.length <= DEFAULT_SECTION_BUDGET,
+      `${n} problems produced a ${description.length}-character description`);
+    assert.ok(description.length <= DISCORD_LIMITS.embedDescription);
+  }
+});
+
+test("rows that share an issue id, or have none, are still told apart", () => {
+  // The issue id is the meaningful separator, and it is NOT always sufficient.
+  // Two rows with the same id and two with no id both rendered as identical
+  // lines under the first version of this pass.
+  const row = (shortId, label, group = LOST) =>
+    ({ shortId, people: 1, events: 1, group, label, deliveryProven: true, isNew: false });
+  const data = {
+    empty: false, floor: "2.4.0", tailPeople: 0, people: 2, priorPeople: 1, events: 4, truncated: false,
+    rows: [row("EW-X", "same"), row("EW-X", "same"), row(null, "none", DEGRADED), row(null, "none", DEGRADED)],
+  };
+  const body = formatSentrySection(data, { title: "Sentry" }).slice(1);
+  const rendered = body.filter((l) => l.startsWith("  1 person"));
+  assert.equal(rendered.length, 4, "all four rows render");
+  assert.equal(new Set(rendered).size, 4, `four rows must render as four distinct lines, got ${JSON.stringify(rendered)}`);
+});
+
+test("a count that is not a non-negative integer is refused, never coerced", async () => {
+  // Number() is far too permissive to validate with: null, "", false and []
+  // are all 0, and ["7"] is 7. A single-element array reading as a person
+  // count is the dangerous one, because it is silent and plausible.
+  for (const bad of [null, "", false, [], ["7"], "  ", 1.5, -1, "3", {}]) {
+    const { fetchFn } = digestFetch({ problems: [problemRow("EW-1", "paste_failed", bad, 4)] });
+    await assert.rejects(() => fetchSentrySection(ENV, WINDOW, { ...OPTS, fetchFn }), TypeError,
+      `people count ${JSON.stringify(bad)} must be refused`);
+  }
+  // Two-way: a genuine zero is a real answer and must NOT be refused.
+  const { fetchFn } = digestFetch({ problems: [problemRow("EW-1", "paste_failed", 0, 0)] });
+  const data = await fetchSentrySection(ENV, WINDOW, { ...OPTS, fetchFn });
+  assert.equal(data.rows[0].people, 0);
+});
+
+test("a release row with a junk user count cannot win the release-line ranking", () => {
+  // Number(["7"]) is 7, so an array once out-ranked a real release.
+  const line = resolveReleaseLine([
+    { release: "com.enviouswispr.app@2.2.0", "count_unique(user)": ["99"] },
+    { release: "com.enviouswispr.app@2.4.3", "count_unique(user)": 1 },
+  ]);
+  assert.equal(line.floor, "2.4.0");
+  assert.equal(line.tailPeople, 0, "and cannot contribute to the tail either");
 });

--- a/workers/daily-report/test/sentry-section.test.js
+++ b/workers/daily-report/test/sentry-section.test.js
@@ -869,13 +869,11 @@ test("an untruncated section still says the totals include the omitted rows", as
   assert.doesNotMatch(text, /at least/);
 });
 
-test("the section's Discord cap matches the transport's own limit", () => {
-  // The cap is duplicated as a number rather than imported across the
-  // policy/transport boundary, so this is what stops the two drifting apart.
-  // The empty-section render that used to sit here was vacuous: its output is a
-  // fixed two lines, so it fits any cap. The 300-row test below is the real one.
-  assert.equal(DISCORD_LIMITS.embedDescription, 4096);
-});
+// A test asserting only `DISCORD_LIMITS.embedDescription === 4096` used to sit
+// here. It claimed to stop the section's own copy of that number drifting from
+// the transport's, and did nothing of the sort: it never read the section's
+// cap at all, so it would pass while the two diverged. The 300-row test below
+// is what actually proves the cap holds.
 
 test("a budget that is not a positive safe integer is refused, never obeyed", async () => {
   // NaN makes every `> budget` comparison FALSE, so it disabled every check
@@ -960,7 +958,7 @@ test("an incomplete badge set is disclosed rather than left silent", async () =>
     shortId: `EW-${i}`, firstSeen: "2026-08-05T12:00:00Z",
   }));
   const { lines } = await render({ problems: [problemRow("EW-1", "paste_failed", 1, 1)], newIssues });
-  assert.match(lines.join("\n"), /the NEW marks below are not complete/);
+  assert.match(lines.join("\n"), /the NEW marks below may not be complete/);
 });
 
 test("a normal badge set says nothing about completeness", async () => {

--- a/workers/daily-report/test/sentry-section.test.js
+++ b/workers/daily-report/test/sentry-section.test.js
@@ -625,10 +625,13 @@ test("a truncated release page drops the upper-bound claim it can no longer supp
   const text = lines.join("\n");
 
   assert.equal(data.releasesTruncated, true);
-  // The sum overstates (non-additive people) and the cut page understates, so
-  // neither bound holds and "up to" would be a claim the data cannot support.
-  assert.match(text, /at least .* on builds older than 2\.4\.0, from a partial release list/);
+  // NEITHER bound holds, so no number is printed at all. The sum overstates
+  // (non-additive people) and the cut page understates, so "at least N" is
+  // exactly as unsupported as "up to N" - swapping them only changes which
+  // direction the sentence is wrong in.
+  assert.match(text, /release list hit its 100-row limit, so people on builds older than 2\.4\.0 could not be counted/);
   assert.doesNotMatch(text, /up to \d+ (person|people) on builds older than/);
+  assert.doesNotMatch(text, /at least \d+ (person|people) on builds older than/);
 
   // The FLOOR survives truncation and the tail does not — the reason one flag
   // cannot serve both. The query sorts by -count_unique(user), so the winner is
@@ -638,6 +641,30 @@ test("a truncated release page drops the upper-bound claim it can no longer supp
   // Two-way: the problem list has its OWN truncation axis and this must not
   // have set it, or the section would claim a limit that did not happen.
   assert.equal(data.truncated, false);
+});
+
+test("a truncated page discloses even when the visible old-build subtotal is zero", async () => {
+  // The case that most needs saying, and the one a `tailPeople > 0` guard hides:
+  // every returned row is AT OR ABOVE the floor, so the tail sums to zero while
+  // the page was still cut off. Silence here is indistinguishable from "nobody
+  // is on an old build", which is the one conclusion this section must never
+  // let a reader draw by accident.
+  const releases = [
+    { release: "com.enviouswispr.app@2.4.3", "count_unique(user)": 8, "count()": 19 },
+    ...Array.from({ length: 99 }, (_, i) => ({
+      release: `com.enviouswispr.app@2.4.${i + 4}`,
+      "count_unique(user)": 1,
+      "count()": 1,
+    })),
+  ];
+  const { data, lines } = await render({
+    releases,
+    problems: [problemRow("EW-1", "asr_failed", 1, 1)],
+  });
+
+  assert.equal(data.releasesTruncated, true);
+  assert.equal(data.tailPeople, 0, "nothing below the floor was returned");
+  assert.match(lines.join("\n"), /could not be counted/, "silence would read as an all-clear");
 });
 
 test("an untruncated release page keeps the upper-bound wording", async () => {

--- a/workers/daily-report/test/sentry-section.test.js
+++ b/workers/daily-report/test/sentry-section.test.js
@@ -628,8 +628,10 @@ test("two problems that would render identically are separated by their issue id
     ],
   });
   const text = lines.join("\n");
-  assert.match(text, /app crash \(paste_failed\) EW-34|app crash EW-34/);
-  assert.match(text, /EW-3V/);
+  // These fixtures carry no exception type, so both land on the bare "app
+  // crash" label and the issue id is the ONLY thing separating them.
+  assert.match(text, /1 person {3}app crash EW-34, delivery not proven/);
+  assert.match(text, /1 person {3}app crash EW-3V, delivery not proven/);
   // The row that does NOT collide keeps its clean label, so the id is a
   // targeted disambiguation rather than noise on every line.
   assert.match(text, /5 people {3}microphone capture stalled(\n|$)/);

--- a/workers/daily-report/test/sentry-section.test.js
+++ b/workers/daily-report/test/sentry-section.test.js
@@ -1030,3 +1030,61 @@ test("an event total too large to be exact is refused, never published", async (
   });
   await assert.rejects(() => fetchSentrySection(ENV, WINDOW, { ...OPTS, fetchFn }), TypeError);
 });
+
+test("a stalled response BODY is bounded by the same deadline as the headers", async () => {
+  // Headers arriving in time say nothing about the body. An earlier version
+  // cleared the abort timer as soon as the response object existed, so a server
+  // that stalled mid-stream hung the `json()` read with no bound at all,
+  // overrunning both the per-request timeout and the caller's absolute
+  // deadline. In the triage worker that deadline is a hard Cloudflare
+  // cancellation, so the overrun is a silently dropped post, not a slow one.
+  const fetchFn = async (_url, init) => ({
+    ok: true,
+    status: 200,
+    headers: { get: () => null },
+    body: { cancel: async () => {} },
+    // Never resolves on its own; only the abort signal ends it.
+    json: () => new Promise((_resolve, reject) => {
+      init.signal.addEventListener("abort", () => reject(new Error("aborted")));
+    }),
+  });
+
+  const started = Date.now();
+  await assert.rejects(
+    () => discoverAggregate(ENV, { queryName: "q", fields: ["count()"], statsPeriod: "24h" },
+      { ...OPTS, fetchFn, requestTimeoutMs: 50 }),
+    SentryDeadlineError
+  );
+  // Bounded in fact, not merely in intent: without the fix this never returns.
+  assert.ok(Date.now() - started < 5000, "the body read must be abandoned at the timeout");
+});
+
+test("a failed response still has its body drained inside the bounded region", async () => {
+  // The drain protects Cloudflare's outbound-connection ceiling across retries.
+  // It moved inside the timer with the rest of the response handling, so this
+  // asserts it did not get lost in the move.
+  let cancelled = 0;
+  const fetchFn = async () => ({
+    ok: false,
+    status: 500,
+    headers: { get: () => null },
+    body: { cancel: async () => { cancelled += 1; } },
+  });
+  await assert.rejects(
+    () => discoverAggregate(ENV, { queryName: "q", fields: ["count()"], statsPeriod: "24h" },
+      { ...OPTS, fetchFn }),
+    SentryQueryError
+  );
+  assert.equal(cancelled, 2, "every failed attempt drains its body exactly once");
+});
+
+test("a shape error is not relabelled as a network error on its way out", async () => {
+  // The consumer now runs inside the transport's catch, so a deliberate
+  // classification it raises must pass through rather than being sanitized into
+  // SentryNetworkError and losing its cause.
+  const { fetchFn } = recorder(() => response(200, "not-json"));
+  await assert.rejects(
+    () => discoverAggregate(ENV, { queryName: "q", fields: ["count()"], statsPeriod: "24h" }, { ...OPTS, fetchFn }),
+    (err) => err instanceof SentryShapeError && !(err instanceof SentryNetworkError)
+  );
+});

--- a/workers/daily-report/test/sentry-section.test.js
+++ b/workers/daily-report/test/sentry-section.test.js
@@ -1,0 +1,652 @@
+// Tests for the Sentry transport (workers/shared/sentry.js) and the digest
+// section policy (workers/reporting/sentry-section.js), issue #1965.
+//
+// They live in this package because workers/shared and workers/reporting have
+// no test package of their own - the same arrangement posthog.js and discord.js
+// already use, documented in workers/shared/README.md.
+//
+// Run: node --test (from workers/daily-report/)
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+import {
+  SentryQueryError,
+  SentryShapeError,
+  SentryDeadlineError,
+  discoverAggregate,
+  issueList,
+} from "../../shared/sentry.js";
+import {
+  ERROR_CATEGORIES,
+  LOST,
+  DEGRADED,
+  SENTRY_CALLS_PER_DIGEST,
+  DEFAULT_SECTION_BUDGET,
+  classifyProblem,
+  parseReleaseVersion,
+  resolveReleaseLine,
+  fetchSentrySection,
+  formatSentrySection,
+  formatSentryUnavailable,
+} from "../../reporting/sentry-section.js";
+import { DISCORD_LIMITS } from "../../shared/discord.js";
+
+const ENV = {
+  SENTRY_ORG: "envious-labs-llc",
+  SENTRY_PROJECT_ID: "4511097112428544",
+  SENTRY_PROJECT_SLUG: "enviouswispr",
+  SENTRY_AUTH_TOKEN: "test-token",
+};
+const OPTS = { workerLabel: "test", sleepFn: async () => {} };
+const WINDOW = {
+  startISO: "2026-08-05T04:00:00",
+  endISO: "2026-08-06T04:00:00",
+  priorStartISO: "2026-08-04T04:00:00",
+  firstSeenPeriod: "24h",
+};
+
+// ── Fake transport ──────────────────────────────────────────────────────────
+
+/** Minimal Response stand-in. `body.cancel` is present because the real
+ * transport cancels a failed body, and a double that omits it would make the
+ * retry path throw for a reason production never sees. */
+function response(status, payload, { headers = {} } = {}) {
+  const lower = new Map(Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v]));
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: (name) => lower.get(String(name).toLowerCase()) ?? null },
+    body: { cancel: async () => {} },
+    json: async () => {
+      if (payload === "not-json") throw new SyntaxError("bad json");
+      return payload;
+    },
+  };
+}
+
+/** Aggregate body carrying meta.fields, which the REAL endpoint returns on an
+ * empty response too (measured 2026-08-06). A double thinner than that would
+ * hide the defect the shape check exists to catch. */
+function aggregate(rows, fields) {
+  const names = fields ?? Object.keys(rows[0] ?? {});
+  return { data: rows, meta: { fields: Object.fromEntries(names.map((f) => [f, "integer"])) } };
+}
+
+/** Records every URL requested, so a call-count assertion measures the real
+ * outbound behaviour rather than a summary the code reports about itself. */
+function recorder(handler) {
+  const urls = [];
+  return {
+    urls,
+    fetchFn: async (url) => {
+      urls.push(url);
+      return handler(url, urls.length);
+    },
+  };
+}
+
+const RELEASE_ROWS = [
+  { release: "com.enviouswispr.app@2.4.3", "count_unique(user)": 8, "count()": 19 },
+  { release: "com.enviouswispr.app@2.4.1", "count_unique(user)": 3, "count()": 12 },
+  { release: "com.enviouswispr.app@2.3.1", "count_unique(user)": 2, "count()": 5 },
+  { release: "com.enviouswispr.app@2.4.0", "count_unique(user)": 2, "count()": 7 },
+];
+
+function problemRow(issue, category, users, events, level = "error") {
+  return {
+    issue,
+    "issue.id": 1,
+    title: `${category}: something`,
+    "error.category": category,
+    level,
+    "count_unique(user)": users,
+    "count()": events,
+  };
+}
+
+const PROBLEM_FIELDS = ["title", "issue.id", "error.category", "level", "count_unique(user)", "count()"];
+
+/** Routes each of the five calls by its query name, which is the only thing
+ * that distinguishes them in the URL. */
+function digestFetch({ releases = RELEASE_ROWS, problems = [], newIssues = [], people = 13, priorPeople = 12, headers = {} } = {}) {
+  return recorder((url) => {
+    if (url.includes("/issues/")) return response(200, newIssues);
+    if (url.includes("field=release")) return response(200, aggregate(releases, ["release", "count_unique(user)", "count()"]));
+    if (url.includes("field=issue")) {
+      return response(200, aggregate(problems, PROBLEM_FIELDS), { headers });
+    }
+    // The two headline aggregates differ only by window.
+    const isPrior = url.includes(encodeURIComponent(WINDOW.priorStartISO));
+    return response(200, aggregate(
+      [{ "count_unique(user)": isPrior ? priorPeople : people, "count()": 0 }],
+      ["count_unique(user)", "count()"]
+    ));
+  });
+}
+
+// ── Classification completeness ─────────────────────────────────────────────
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SWIFT_ENUM = resolve(HERE, "../../../Sources/EnviousWisprServices/SentryBreadcrumb.swift");
+
+test("every ErrorCategory in the Swift enum is classified", () => {
+  const source = readFileSync(SWIFT_ENUM, "utf8");
+  // Scoped to the ErrorCategory declaration: the file contains other enums, and
+  // a whole-file scan would demand classifications for cases that are not
+  // error categories at all.
+  const start = source.indexOf("public enum ErrorCategory: String");
+  assert.ok(start !== -1, "ErrorCategory declaration not found - this test's parse is broken, not the map");
+  const end = source.indexOf("\n  }", start);
+  assert.ok(end !== -1, "ErrorCategory declaration has no closing brace - parse is broken");
+  const raws = [...source.slice(start, end).matchAll(/case\s+\w+\s*=\s*"([a-z_]+)"/g)].map((m) => m[1]);
+
+  // POSITIVE CONTROL. A regex that silently matches nothing would make this
+  // whole test vacuous and it would pass forever. 27 is the measured count on
+  // 2026-08-06; a genuine addition to the app should RAISE this, and the
+  // assertion below is what forces this table to be updated with it.
+  assert.ok(raws.length >= 27, `expected at least 27 categories, parsed ${raws.length}`);
+
+  const missing = raws.filter((raw) => !Object.hasOwn(ERROR_CATEGORIES, raw));
+  assert.deepEqual(missing, [], `unclassified ErrorCategory values: ${missing.join(", ")}`);
+
+  const extra = Object.keys(ERROR_CATEGORIES).filter((k) => !raws.includes(k));
+  assert.deepEqual(extra, [], `classified values that no longer exist in Swift: ${extra.join(", ")}`);
+});
+
+test("every classification declares a group, a label and a delivery claim", () => {
+  for (const [raw, entry] of Object.entries(ERROR_CATEGORIES)) {
+    assert.ok(entry.group === LOST || entry.group === DEGRADED, `${raw}: bad group`);
+    assert.equal(typeof entry.label, "string", `${raw}: missing label`);
+    assert.ok(entry.label.length > 0, `${raw}: empty label`);
+    assert.equal(typeof entry.deliveryProven, "boolean", `${raw}: missing deliveryProven`);
+    assert.equal(typeof entry.emitted, "boolean", `${raw}: missing emitted`);
+    // A degraded row asserts the user still got their text. That claim is never
+    // allowed to be the conservative default.
+    if (entry.group === DEGRADED) {
+      assert.equal(entry.deliveryProven, true, `${raw}: degraded requires proven delivery`);
+    }
+  }
+});
+
+test("the three unemitted categories are marked unemitted and classified conservatively", () => {
+  for (const raw of ["availability_check_failed", "fallback_failed", "state_mismatch"]) {
+    assert.equal(ERROR_CATEGORIES[raw].emitted, false, raw);
+    assert.equal(ERROR_CATEGORIES[raw].group, LOST, raw);
+  }
+});
+
+test("grounded-review corrections stay corrected", () => {
+  // Each of these was LOST in an earlier draft and was corrected against its
+  // producer. A regression here is silent in production: it just moves a row
+  // between two headings the founder reads as very different things.
+  assert.equal(ERROR_CATEGORIES.recovery_key_store_failed.group, DEGRADED);
+  assert.equal(ERROR_CATEGORIES.hotkey_registration_failed.group, DEGRADED);
+  assert.equal(ERROR_CATEGORIES.paste_failed.group, DEGRADED);
+  // Conservative, because their producers disagree and no indexed field splits them.
+  assert.equal(ERROR_CATEGORIES.xpc_service_error.deliveryProven, false);
+  assert.equal(ERROR_CATEGORIES.model_load_wedged.deliveryProven, false);
+  assert.equal(ERROR_CATEGORIES.pipeline_dispatch_failed.deliveryProven, false);
+});
+
+test("classifyProblem: unknown, blank-fatal and blank-error are three different answers", () => {
+  // Two-way: a known category must NOT take the unknown path.
+  assert.equal(classifyProblem({ category: "paste_failed", level: "error" }).group, DEGRADED);
+
+  const unknown = classifyProblem({ category: "brand_new_category", level: "error" });
+  assert.equal(unknown.group, LOST);
+  assert.equal(unknown.label, "brand_new_category", "an unknown category must show its raw name");
+  assert.equal(unknown.deliveryProven, false);
+
+  // The measured real shape: an unhandled crash carries no category at all.
+  const crash = classifyProblem({ category: "", level: "fatal", title: "EXC_BAD_ACCESS:  timed out after  >" });
+  assert.equal(crash.group, LOST);
+  assert.equal(crash.label, "app crash (EXC_BAD_ACCESS)");
+  assert.equal(crash.deliveryProven, false);
+  // THE MESSAGE HALF NEVER APPEARS. It is the one place user-derived text could
+  // reach Discord, and the split-at-first-colon is what keeps it out by
+  // construction rather than by trusting Sentry's redaction.
+  assert.doesNotMatch(crash.label, /timed out/);
+
+  // A blank category that is NOT fatal must not be called a crash.
+  const blank = classifyProblem({ category: null, level: "error" });
+  assert.equal(blank.group, LOST);
+  assert.notEqual(blank.label, "app crash");
+});
+
+// ── Release line ────────────────────────────────────────────────────────────
+
+test("parseReleaseVersion refuses anything that is not a three-part version", () => {
+  assert.deepEqual(parseReleaseVersion("com.enviouswispr.app@2.4.3"), [2, 4, 3]);
+  assert.deepEqual(parseReleaseVersion("2.4.3"), [2, 4, 3]);
+  for (const bad of ["com.enviouswispr.app@2.4", "2.4.3.1", "v2.4.3", "2.4.x", "", null, 243]) {
+    assert.equal(parseReleaseVersion(bad), null, `should refuse ${String(bad)}`);
+  }
+});
+
+test("resolveReleaseLine picks the minor line of the release with the most people", () => {
+  const line = resolveReleaseLine(RELEASE_ROWS);
+  assert.equal(line.floor, "2.4.0");
+  // 2.3.1 is the only release below the line, with 2 people.
+  assert.equal(line.tailPeople, 2);
+});
+
+test("resolveReleaseLine does not cliff on release day", () => {
+  // 2.5.0 just shipped and almost nobody is on it. The line must stay on 2.4,
+  // or the section would report near-nothing exactly when a new build most
+  // needs watching.
+  const line = resolveReleaseLine([
+    { release: "com.enviouswispr.app@2.5.0", "count_unique(user)": 1, "count()": 1 },
+    { release: "com.enviouswispr.app@2.4.3", "count_unique(user)": 9, "count()": 30 },
+  ]);
+  assert.equal(line.floor, "2.4.0");
+  assert.equal(line.tailPeople, 0, "a newer release is never part of the tail");
+});
+
+test("resolveReleaseLine breaks ties toward the newer version", () => {
+  const line = resolveReleaseLine([
+    { release: "com.enviouswispr.app@2.3.9", "count_unique(user)": 5, "count()": 5 },
+    { release: "com.enviouswispr.app@2.4.0", "count_unique(user)": 5, "count()": 5 },
+  ]);
+  assert.equal(line.floor, "2.4.0");
+});
+
+test("resolveReleaseLine ignores malformed releases and returns null when none are usable", () => {
+  const line = resolveReleaseLine([
+    { release: "garbage", "count_unique(user)": 99, "count()": 99 },
+    { release: "com.enviouswispr.app@2.4.3", "count_unique(user)": 1, "count()": 1 },
+  ]);
+  assert.equal(line.floor, "2.4.0", "a malformed release must not win the ranking");
+  assert.equal(resolveReleaseLine([{ release: "garbage", "count_unique(user)": 5 }]), null);
+  assert.equal(resolveReleaseLine([]), null);
+});
+
+// ── Transport ───────────────────────────────────────────────────────────────
+
+test("discoverAggregate rejects a 200 whose meta.fields is missing", async () => {
+  // THE case this check exists for: zero rows is a legitimate answer, so any
+  // per-row validation is skipped exactly when a malformed empty body arrives,
+  // and the section would print "no errors" for an unknown truth.
+  const { fetchFn } = recorder(() => response(200, { data: [] }));
+  await assert.rejects(
+    () => discoverAggregate(ENV, {
+      queryName: "q", fields: ["count()"], requiredFields: ["count()"], statsPeriod: "24h",
+    }, { ...OPTS, fetchFn }),
+    SentryShapeError
+  );
+});
+
+test("discoverAggregate accepts a legitimately empty result that carries meta.fields", async () => {
+  // The two-way control for the test above: without it, a check that rejected
+  // EVERY empty response would pass the first test while breaking quiet days.
+  const { fetchFn } = recorder(() => response(200, aggregate([], ["count()"])));
+  const result = await discoverAggregate(ENV, {
+    queryName: "q", fields: ["count()"], requiredFields: ["count()"], statsPeriod: "24h",
+  }, { ...OPTS, fetchFn });
+  assert.deepEqual(result.rows, []);
+  assert.equal(result.truncated, false);
+});
+
+test("discoverAggregate rejects a missing required field, a non-array data and a non-object row", async () => {
+  const cases = [
+    aggregate([], ["count()"]),                       // requiredFields asks for more
+    { data: "nope", meta: { fields: { "count_unique(user)": "integer" } } },
+    { data: [null], meta: { fields: { "count_unique(user)": "integer" } } },
+  ];
+  for (const payload of cases) {
+    const { fetchFn } = recorder(() => response(200, payload));
+    await assert.rejects(
+      () => discoverAggregate(ENV, {
+        queryName: "q", fields: ["count_unique(user)"], requiredFields: ["count_unique(user)"], statsPeriod: "24h",
+      }, { ...OPTS, fetchFn }),
+      SentryShapeError
+    );
+  }
+});
+
+test("discoverAggregate retries a 429 and gives up as a query error, never a zero", async () => {
+  let attempts = 0;
+  const { fetchFn } = recorder(() => {
+    attempts += 1;
+    return response(429, {});
+  });
+  await assert.rejects(
+    () => discoverAggregate(ENV, {
+      queryName: "q", fields: ["count()"], statsPeriod: "24h",
+    }, { ...OPTS, fetchFn }),
+    (err) => err instanceof SentryQueryError && err.status === 429
+  );
+  assert.equal(attempts, 2, "two attempts total, bounded by Cloudflare's 50-subrequest cap");
+});
+
+test("discoverAggregate does NOT retry a 403", async () => {
+  // A 403 on the org events endpoint is a permanent scope problem, measured on
+  // both worker tokens 2026-08-06. Retrying it burns the window and reports the
+  // same thing three attempts later.
+  let attempts = 0;
+  const { fetchFn } = recorder(() => {
+    attempts += 1;
+    return response(403, {});
+  });
+  await assert.rejects(
+    () => discoverAggregate(ENV, { queryName: "q", fields: ["count()"], statsPeriod: "24h" }, { ...OPTS, fetchFn }),
+    (err) => err instanceof SentryQueryError && err.status === 403
+  );
+  assert.equal(attempts, 1);
+});
+
+test("discoverAggregate refuses a 200 that is not JSON", async () => {
+  const { fetchFn } = recorder(() => response(200, "not-json"));
+  await assert.rejects(
+    () => discoverAggregate(ENV, { queryName: "q", fields: ["count()"], statsPeriod: "24h" }, { ...OPTS, fetchFn }),
+    SentryShapeError
+  );
+});
+
+test("discoverAggregate demands exactly one window form", async () => {
+  const { fetchFn } = recorder(() => response(200, aggregate([], ["count()"])));
+  for (const params of [
+    { queryName: "q", fields: ["count()"] },                                             // neither
+    { queryName: "q", fields: ["count()"], statsPeriod: "24h", start: "a", end: "b" },    // both
+  ]) {
+    await assert.rejects(() => discoverAggregate(ENV, params, { ...OPTS, fetchFn }), TypeError);
+  }
+});
+
+test("discoverAggregate stops at the caller's deadline instead of sleeping past it", async () => {
+  const { fetchFn } = recorder(() => response(429, {}));
+  await assert.rejects(
+    () => discoverAggregate(ENV, { queryName: "q", fields: ["count()"], statsPeriod: "24h" },
+      { ...OPTS, fetchFn, deadlineAt: Date.now() + 5 }),
+    SentryDeadlineError
+  );
+});
+
+test("discoverAggregate refuses to run without configuration", async () => {
+  const { fetchFn } = recorder(() => response(200, aggregate([], ["count()"])));
+  for (const env of [{ ...ENV, SENTRY_AUTH_TOKEN: "" }, { ...ENV, SENTRY_ORG: "" }]) {
+    await assert.rejects(
+      () => discoverAggregate(env, { queryName: "q", fields: ["count()"], statsPeriod: "24h" }, { ...OPTS, fetchFn }),
+      TypeError
+    );
+  }
+});
+
+test("discoverAggregate requires a workerLabel with no default", async () => {
+  // A default would file one worker's Sentry reads under another's name.
+  const { fetchFn } = recorder(() => response(200, aggregate([], ["count()"])));
+  await assert.rejects(
+    () => discoverAggregate(ENV, { queryName: "q", fields: ["count()"], statsPeriod: "24h" }, { fetchFn }),
+    TypeError
+  );
+});
+
+test("issueList refuses a row without a shortId", async () => {
+  const { fetchFn } = recorder(() => response(200, [{ firstSeen: "2026-08-06T00:00:00Z" }]));
+  await assert.rejects(
+    () => issueList(ENV, { queryName: "q" }, { ...OPTS, fetchFn }),
+    SentryShapeError
+  );
+});
+
+test("issueList suppresses the per-issue stats array it never reads", async () => {
+  const { fetchFn, urls } = recorder(() => response(200, []));
+  await issueList(ENV, { queryName: "q" }, { ...OPTS, fetchFn });
+  assert.match(urls[0], /statsPeriod=(&|$)/, "statsPeriod must be empty to drop the stats payload");
+});
+
+// ── The section end to end ──────────────────────────────────────────────────
+
+test("fetchSentrySection issues exactly the budgeted number of calls", async () => {
+  const { fetchFn, urls } = digestFetch({ problems: [problemRow("EW-1", "paste_failed", 3, 4)] });
+  await fetchSentrySection(ENV, WINDOW, { ...OPTS, fetchFn });
+  assert.equal(urls.length, SENTRY_CALLS_PER_DIGEST);
+});
+
+test("the call count does not move with problem volume", async () => {
+  // The constraint that actually matters: no path may fan out per issue. A
+  // hundred problems must cost exactly what one costs.
+  const many = Array.from({ length: 100 }, (_, i) => problemRow(`EW-${i}`, "paste_failed", 1, 1));
+  const { fetchFn, urls } = digestFetch({ problems: many });
+  await fetchSentrySection(ENV, WINDOW, { ...OPTS, fetchFn });
+  assert.equal(urls.length, SENTRY_CALLS_PER_DIGEST);
+});
+
+test("the badge marks only the genuinely-new issue", async () => {
+  // The control that killed the original min(timestamp) design: a long-lived
+  // issue that is ACTIVE in the window must not badge.
+  const { fetchFn } = digestFetch({
+    problems: [
+      problemRow("EW-OLD", "paste_failed", 5, 9),
+      problemRow("EW-NEW", "", 1, 4, "fatal"),
+    ],
+    newIssues: [{ shortId: "EW-NEW", firstSeen: "2026-08-06T12:07:21Z" }],
+  });
+  const data = await fetchSentrySection(ENV, WINDOW, { ...OPTS, fetchFn });
+  assert.equal(data.rows.find((r) => r.shortId === "EW-OLD").isNew, false);
+  assert.equal(data.rows.find((r) => r.shortId === "EW-NEW").isNew, true);
+});
+
+test("the section scopes its problem query to the resolved release line", async () => {
+  const { fetchFn, urls } = digestFetch({ problems: [problemRow("EW-1", "paste_failed", 1, 1)] });
+  await fetchSentrySection(ENV, WINDOW, { ...OPTS, fetchFn });
+  const problemUrl = urls.find((u) => u.includes("field=issue"));
+  assert.match(decodeURIComponent(problemUrl), /release\.version:>=2\.4\.0/);
+});
+
+test("total events is derived from the rows and matches their sum", async () => {
+  const { fetchFn } = digestFetch({
+    problems: [problemRow("EW-1", "paste_failed", 3, 19), problemRow("EW-2", "asr_failed", 2, 4)],
+  });
+  const data = await fetchSentrySection(ENV, WINDOW, { ...OPTS, fetchFn });
+  assert.equal(data.events, 23);
+});
+
+test("a non-numeric count is a defect, never a zero", async () => {
+  const { fetchFn } = digestFetch({ problems: [problemRow("EW-1", "paste_failed", "n/a", 4)] });
+  await assert.rejects(() => fetchSentrySection(ENV, WINDOW, { ...OPTS, fetchFn }), TypeError);
+});
+
+test("no usable release line reports a measurement failure, not good news", async () => {
+  const { fetchFn } = digestFetch({ releases: [{ release: "garbage", "count_unique(user)": 4 }] });
+  const data = await fetchSentrySection(ENV, WINDOW, { ...OPTS, fetchFn });
+  assert.equal(data.empty, true);
+  assert.equal(data.reason, "no-release-line");
+  const lines = formatSentrySection(data, { title: "Sentry" });
+  assert.match(lines.join("\n"), /could not be matched to a release/);
+  assert.doesNotMatch(lines.join("\n"), /No errors/);
+});
+
+test("window fields are required, including the first-seen period", async () => {
+  const { fetchFn } = digestFetch();
+  for (const key of ["startISO", "endISO", "priorStartISO", "firstSeenPeriod"]) {
+    const broken = { ...WINDOW, [key]: undefined };
+    await assert.rejects(() => fetchSentrySection(ENV, broken, { ...OPTS, fetchFn }), TypeError, key);
+  }
+});
+
+test("the first-seen period reaches the query verbatim", async () => {
+  const { fetchFn, urls } = digestFetch({ problems: [problemRow("EW-1", "paste_failed", 1, 1)] });
+  await fetchSentrySection(ENV, { ...WINDOW, firstSeenPeriod: "7d" }, { ...OPTS, fetchFn });
+  const issuesUrl = urls.find((u) => u.includes("/issues/"));
+  assert.match(decodeURIComponent(issuesUrl), /firstSeen:-7d/);
+});
+
+// ── Presentation ────────────────────────────────────────────────────────────
+
+async function render(overrides, formatOpts = {}) {
+  const { fetchFn } = digestFetch(overrides);
+  const data = await fetchSentrySection(ENV, WINDOW, { ...OPTS, fetchFn });
+  return { data, lines: formatSentrySection(data, { title: "Sentry, yesterday", ...formatOpts }) };
+}
+
+test("the section groups lost from degraded and never prints a rate", async () => {
+  const { lines } = await render({
+    problems: [
+      problemRow("EW-1", "audio_capture_stalled", 7, 19),
+      problemRow("EW-2", "paste_failed", 1, 1),
+    ],
+  });
+  const text = lines.join("\n");
+  assert.match(text, /LOST THE DICTATION/);
+  assert.match(text, /STILL WORKED, JUST WORSE/);
+  assert.match(text, /7 people {3}microphone capture stalled/);
+  assert.match(text, /1 person {3}paste fell back to the clipboard/);
+  assert.match(text, /Impact rate unavailable/);
+  assert.doesNotMatch(text, /\d+(\.\d+)?%/, "the section must never print a percentage");
+});
+
+test("a conservative row says delivery is not proven and a proven one does not", async () => {
+  const { lines } = await render({
+    problems: [
+      problemRow("EW-1", "xpc_service_error", 2, 2),
+      problemRow("EW-2", "audio_capture_stalled", 2, 2),
+    ],
+  });
+  const text = lines.join("\n");
+  assert.match(text, /transcription helper failed, delivery not proven/);
+  assert.match(text, /2 people {3}microphone capture stalled(\n|$)/);
+});
+
+test("the crash row reads as a crash exactly once", async () => {
+  const { lines } = await render({ problems: [problemRow("EW-1", "", 1, 4, "fatal")] });
+  const text = lines.join("\n");
+  assert.match(text, /1 person {3}app crash, delivery not proven/);
+  assert.equal(text.match(/delivery not proven/g).length, 1);
+});
+
+test("the people delta is stated in both directions and when flat", async () => {
+  const up = await render({ problems: [problemRow("EW-1", "asr_failed", 1, 1)], people: 13, priorPeople: 12 });
+  assert.match(up.lines.join("\n"), /1 more than the previous period \(12 people\)/);
+
+  const down = await render({ problems: [problemRow("EW-1", "asr_failed", 1, 1)], people: 10, priorPeople: 12 });
+  assert.match(down.lines.join("\n"), /2 fewer than the previous period/);
+
+  const flat = await render({ problems: [problemRow("EW-1", "asr_failed", 1, 1)], people: 12, priorPeople: 12 });
+  assert.match(flat.lines.join("\n"), /the same as the previous period/);
+});
+
+test("the old-build tail is reported as an upper bound", async () => {
+  const { lines } = await render({ problems: [problemRow("EW-1", "asr_failed", 1, 1)] });
+  // Non-additive per-release counts, so it must not claim a distinct-person count.
+  assert.match(lines.join("\n"), /up to 2 people on builds older than 2\.4\.0/);
+});
+
+test("zero problems renders an explicit good-news line", async () => {
+  const { data, lines } = await render({ problems: [] });
+  assert.equal(data.empty, true);
+  assert.equal(lines.length, 2);
+  assert.match(lines[1], /No errors were recorded on current versions/);
+});
+
+test("unavailable copy says nothing was measured and leaks nothing technical", () => {
+  const lines = formatSentryUnavailable("Sentry, yesterday");
+  assert.equal(lines.length, 2);
+  assert.match(lines[1], /not a report of zero/);
+  for (const line of lines) {
+    assert.doesNotMatch(line, /http|token|401|403|sentry\.io/i);
+  }
+});
+
+test("a formatter without a title is refused rather than silently untitled", () => {
+  assert.throws(() => formatSentrySection({ empty: true }, {}), TypeError);
+  assert.throws(() => formatSentryUnavailable(""), TypeError);
+});
+
+test("an over-budget section discloses what it omitted instead of truncating silently", async () => {
+  const many = Array.from({ length: 60 }, (_, i) => problemRow(`EW-${i}`, "audio_capture_stalled", 2, 2));
+  const { lines } = await render({ problems: many });
+  const text = lines.join("\n");
+  assert.match(text, /more problems are not listed here\. The totals above include them\./);
+  assert.ok(text.length <= DEFAULT_SECTION_BUDGET + 200, `description ${text.length} should stay near its budget`);
+});
+
+test("a full page of problems is disclosed as a limited breakdown", async () => {
+  const many = Array.from({ length: 100 }, (_, i) => problemRow(`EW-${i}`, "asr_failed", 1, 1));
+  const { lines } = await render({ problems: many });
+  assert.match(lines.join("\n"), /breakdown covers the largest 100 only/);
+});
+
+test("a full page issues no second Sentry request", async () => {
+  const many = Array.from({ length: 100 }, (_, i) => problemRow(`EW-${i}`, "asr_failed", 1, 1));
+  const { fetchFn, urls } = digestFetch({ problems: many, headers: { link: 'rel="next"; results="true"' } });
+  await fetchSentrySection(ENV, WINDOW, { ...OPTS, fetchFn });
+  assert.equal(urls.length, SENTRY_CALLS_PER_DIGEST, "pagination must never buy another page");
+});
+
+test("the worst realistic section still fits Discord's per-embed limits", async () => {
+  // Maximum-length labels, both groups populated, badges on, tail line present.
+  const many = Array.from({ length: 100 }, (_, i) =>
+    problemRow(`EW-${i}`, i % 2 ? "a_very_long_unknown_category_name_that_renders_raw" : "paste_failed", 999, 9999));
+  const { fetchFn } = digestFetch({
+    problems: many,
+    newIssues: many.map((_, i) => ({ shortId: `EW-${i}`, firstSeen: "2026-08-06T00:00:00Z" })),
+    people: 99999,
+    priorPeople: 1,
+  });
+  const data = await fetchSentrySection(ENV, WINDOW, { ...OPTS, fetchFn });
+  const lines = formatSentrySection(data, { title: "Sentry, last 7 days" });
+  const [title, ...body] = lines;
+  assert.ok(title.length <= DISCORD_LIMITS.embedTitle);
+  assert.ok(body.join("\n").length <= DISCORD_LIMITS.embedDescription);
+  // And well inside the shared 6000 budget, so it cannot crowd out the other
+  // sections and take the whole report down with it.
+  assert.ok(body.join("\n").length <= DEFAULT_SECTION_BUDGET + 200);
+});
+
+test("a crash label carries the exception type and never the message", () => {
+  // Two different crashes must not render as two identical rows. A live smoke
+  // run printed exactly that before the type was included.
+  const a = classifyProblem({ category: "", level: "fatal", title: "EXC_BAD_ACCESS:  timed out after  >" });
+  const b = classifyProblem({ category: "", level: "fatal", title: "NSInternalInconsistencyException: [REDACTED]" });
+  assert.notEqual(a.label, b.label);
+  assert.equal(b.label, "app crash (NSInternalInconsistencyException)");
+
+  // Any title shape this code does not recognise falls back to the plain label
+  // rather than printing something unexamined.
+  for (const title of [
+    undefined, null, "", ":no type", "a message with no colon at all and spaces",
+    "Type With Spaces: msg", `${"A".repeat(60)}: msg`, "<script>: msg",
+  ]) {
+    const label = classifyProblem({ category: "", level: "fatal", title }).label;
+    assert.ok(label === "app crash" || /^app crash \([A-Za-z_][A-Za-z0-9_.]*\)$/.test(label),
+      `unexpected crash label for ${JSON.stringify(title)}: ${label}`);
+    assert.doesNotMatch(label, /msg/);
+  }
+});
+
+test("two problems that would render identically are separated by their issue id", async () => {
+  // The live-smoke defect: two distinct NSInternalInconsistencyException
+  // fingerprints, one person each, rendering as two identical lines.
+  const { lines } = await render({
+    problems: [
+      problemRow("EW-34", "", 1, 4, "fatal"),
+      problemRow("EW-3V", "", 1, 1, "fatal"),
+      problemRow("EW-2C", "audio_capture_stalled", 5, 9),
+    ],
+  });
+  const text = lines.join("\n");
+  assert.match(text, /app crash \(paste_failed\) EW-34|app crash EW-34/);
+  assert.match(text, /EW-3V/);
+  // The row that does NOT collide keeps its clean label, so the id is a
+  // targeted disambiguation rather than noise on every line.
+  assert.match(text, /5 people {3}microphone capture stalled(\n|$)/);
+});
+
+test("a collision straddling the two groups is still disambiguated", () => {
+  // Applied before the groups split, because a per-group pass cannot see a
+  // collision whose halves land under different headings. Contrived, since a
+  // label maps to one group today, but the pass must not depend on that.
+  const data = {
+    empty: false, floor: "2.4.0", tailPeople: 0, people: 2, priorPeople: 2, events: 2, truncated: false,
+    rows: [
+      { shortId: "EW-A", people: 1, events: 1, group: LOST, label: "same thing", deliveryProven: true, isNew: false },
+      { shortId: "EW-B", people: 1, events: 1, group: DEGRADED, label: "same thing", deliveryProven: true, isNew: false },
+    ],
+  };
+  const text = formatSentrySection(data, { title: "Sentry" }).join("\n");
+  assert.match(text, /same thing EW-A/);
+  assert.match(text, /same thing EW-B/);
+});

--- a/workers/daily-report/test/sentry-section.test.js
+++ b/workers/daily-report/test/sentry-section.test.js
@@ -603,6 +603,51 @@ test("the old-build tail is reported as an upper bound", async () => {
   assert.match(lines.join("\n"), /up to 2 people on builds older than 2\.4\.0/);
 });
 
+test("a truncated release page drops the upper-bound claim it can no longer support", async () => {
+  // A FULL PAGE, not a synthetic Link header: `hasMorePages` treats 100 rows as
+  // "there may be more" on its own, so this exercises the real rule rather than
+  // a fixture's idea of it.
+  //
+  // The winner stays 2.4.3 at 8 people; the other 99 are older, low-count rows
+  // of exactly the kind a cut-off page would drop.
+  const releases = [
+    { release: "com.enviouswispr.app@2.4.3", "count_unique(user)": 8, "count()": 19 },
+    ...Array.from({ length: 99 }, (_, i) => ({
+      release: `com.enviouswispr.app@1.${i}.0`,
+      "count_unique(user)": 1,
+      "count()": 1,
+    })),
+  ];
+  const { data, lines } = await render({
+    releases,
+    problems: [problemRow("EW-1", "asr_failed", 1, 1)],
+  });
+  const text = lines.join("\n");
+
+  assert.equal(data.releasesTruncated, true);
+  // The sum overstates (non-additive people) and the cut page understates, so
+  // neither bound holds and "up to" would be a claim the data cannot support.
+  assert.match(text, /at least .* on builds older than 2\.4\.0, from a partial release list/);
+  assert.doesNotMatch(text, /up to \d+ (person|people) on builds older than/);
+
+  // The FLOOR survives truncation and the tail does not — the reason one flag
+  // cannot serve both. The query sorts by -count_unique(user), so the winner is
+  // on the first page by construction.
+  assert.equal(data.floor, "2.4.0");
+
+  // Two-way: the problem list has its OWN truncation axis and this must not
+  // have set it, or the section would claim a limit that did not happen.
+  assert.equal(data.truncated, false);
+});
+
+test("an untruncated release page keeps the upper-bound wording", async () => {
+  // The control for the test above. Without it, an implementation that always
+  // printed the partial-list sentence would pass.
+  const { data, lines } = await render({ problems: [problemRow("EW-1", "asr_failed", 1, 1)] });
+  assert.equal(data.releasesTruncated, false);
+  assert.doesNotMatch(lines.join("\n"), /partial release list/);
+});
+
 test("zero problems renders an explicit good-news line", async () => {
   const { data, lines } = await render({ problems: [] });
   assert.equal(data.empty, true);

--- a/workers/daily-report/test/sentry-section.test.js
+++ b/workers/daily-report/test/sentry-section.test.js
@@ -8,7 +8,7 @@
 // Run: node --test (from workers/daily-report/)
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 
@@ -16,6 +16,7 @@ import {
   SentryQueryError,
   SentryShapeError,
   SentryDeadlineError,
+  SentryNetworkError,
   discoverAggregate,
   issueList,
 } from "../../shared/sentry.js";
@@ -31,6 +32,7 @@ import {
   fetchSentrySection,
   formatSentrySection,
   formatSentryUnavailable,
+  windowInstant,
 } from "../../reporting/sentry-section.js";
 import { DISCORD_LIMITS } from "../../shared/discord.js";
 
@@ -45,7 +47,6 @@ const WINDOW = {
   startISO: "2026-08-05T04:00:00",
   endISO: "2026-08-06T04:00:00",
   priorStartISO: "2026-08-04T04:00:00",
-  firstSeenPeriod: "24h",
 };
 
 // ── Fake transport ──────────────────────────────────────────────────────────
@@ -132,6 +133,15 @@ function digestFetch({ releases = RELEASE_ROWS, problems = [], newIssues = [], p
 const HERE = dirname(fileURLToPath(import.meta.url));
 const SWIFT_ENUM = resolve(HERE, "../../../Sources/EnviousWisprServices/SentryBreadcrumb.swift");
 
+/** Every Swift source concatenated, so a producer search sees the whole app
+ * rather than one declaration file. */
+function readAllSwift(dir) {
+  return readdirSync(dir, { recursive: true })
+    .filter((name) => String(name).endsWith(".swift"))
+    .map((name) => readFileSync(resolve(dir, String(name)), "utf8"))
+    .join("\n");
+}
+
 test("every ErrorCategory in the Swift enum is classified", () => {
   const source = readFileSync(SWIFT_ENUM, "utf8");
   // Scoped to the ErrorCategory declaration: the file contains other enums, and
@@ -141,7 +151,11 @@ test("every ErrorCategory in the Swift enum is classified", () => {
   assert.ok(start !== -1, "ErrorCategory declaration not found - this test's parse is broken, not the map");
   const end = source.indexOf("\n  }", start);
   assert.ok(end !== -1, "ErrorCategory declaration has no closing brace - parse is broken");
-  const raws = [...source.slice(start, end).matchAll(/case\s+\w+\s*=\s*"([a-z_]+)"/g)].map((m) => m[1]);
+  // `[^"]+`, not `[a-z_]+`: a raw value containing a hyphen or a digit would
+  // not match the narrower class, so the new case would be invisible here AND
+  // the 27 lower bound would still pass. The regex has to be able to see
+  // everything the enum can express.
+  const raws = [...source.slice(start, end).matchAll(/case\s+\w+\s*=\s*"([^"]+)"/g)].map((m) => m[1]);
 
   // POSITIVE CONTROL. A regex that silently matches nothing would make this
   // whole test vacuous and it would pass forever. 27 is the measured count on
@@ -171,11 +185,26 @@ test("every classification declares a group, a label and a delivery claim", () =
   }
 });
 
-test("the three unemitted categories are marked unemitted and classified conservatively", () => {
+test("the unemitted categories have no producer in the app, not just a flag saying so", () => {
+  // Checking the hand-written `emitted` flag alone proves nothing: adding a
+  // real producer in Swift would leave the flag lying and this test green. So
+  // the claim is re-derived from the source every run.
+  // The WHOLE source tree, not the enum's own file. Producers live in the
+  // pipeline and services modules; the declaration file merely lists the cases.
+  // Scoping this to SWIFT_ENUM made every assertion below vacuous, and the
+  // positive control at the bottom is what caught it.
+  const source = readAllSwift(resolve(HERE, "../../../Sources"));
   for (const raw of ["availability_check_failed", "fallback_failed", "state_mismatch"]) {
     assert.equal(ERROR_CATEGORIES[raw].emitted, false, raw);
     assert.equal(ERROR_CATEGORIES[raw].group, LOST, raw);
+    const swiftCase = raw.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+    const uses = source.match(new RegExp(`\\.${swiftCase}\\b`, "g")) || [];
+    assert.equal(uses.length, 0, `${raw} now has a producer; reclassify it and clear emitted:false`);
   }
+  // POSITIVE CONTROL for the search itself. A search that matched nothing would
+  // make every assertion above vacuous and would pass forever.
+  assert.ok((source.match(/\.modelLoadFailed\b/g) || []).length > 0,
+    "the producer search matched nothing at all - the search is broken, not the map");
 });
 
 test("grounded-review corrections stay corrected", () => {
@@ -356,12 +385,18 @@ test("discoverAggregate demands exactly one window form", async () => {
 });
 
 test("discoverAggregate stops at the caller's deadline instead of sleeping past it", async () => {
+  // The sleep THROWS rather than no-opping. With a no-op sleep, moving the
+  // deadline check to after the sleep passes this test while burning the
+  // caller's whole remaining budget in a wait that could not have helped.
+  let slept = false;
+  const sleepFn = async () => { slept = true; throw new Error("slept past the deadline"); };
   const { fetchFn } = recorder(() => response(429, {}));
   await assert.rejects(
     () => discoverAggregate(ENV, { queryName: "q", fields: ["count()"], statsPeriod: "24h" },
-      { ...OPTS, fetchFn, deadlineAt: Date.now() + 5 }),
+      { ...OPTS, fetchFn, sleepFn, deadlineAt: Date.now() + 5 }),
     SentryDeadlineError
   );
+  assert.equal(slept, false, "the deadline must be checked BEFORE the backoff sleep");
 });
 
 test("discoverAggregate refuses to run without configuration", async () => {
@@ -422,7 +457,9 @@ test("the badge marks only the genuinely-new issue", async () => {
       problemRow("EW-OLD", "paste_failed", 5, 9),
       problemRow("EW-NEW", "", 1, 4, "fatal"),
     ],
-    newIssues: [{ shortId: "EW-NEW", firstSeen: "2026-08-06T12:07:21Z" }],
+    // firstSeen INSIDE the reported window. The section re-checks the boundary
+    // locally, so a fixture outside it would not badge however Sentry answered.
+    newIssues: [{ shortId: "EW-NEW", firstSeen: "2026-08-05T12:07:21Z" }],
   });
   const data = await fetchSentrySection(ENV, WINDOW, { ...OPTS, fetchFn });
   assert.equal(data.rows.find((r) => r.shortId === "EW-OLD").isNew, false);
@@ -459,19 +496,39 @@ test("no usable release line reports a measurement failure, not good news", asyn
   assert.doesNotMatch(lines.join("\n"), /No errors/);
 });
 
-test("window fields are required, including the first-seen period", async () => {
+test("every window field is required", async () => {
   const { fetchFn } = digestFetch();
-  for (const key of ["startISO", "endISO", "priorStartISO", "firstSeenPeriod"]) {
+  for (const key of ["startISO", "endISO", "priorStartISO"]) {
     const broken = { ...WINDOW, [key]: undefined };
     await assert.rejects(() => fetchSentrySection(ENV, broken, { ...OPTS, fetchFn }), TypeError, key);
   }
 });
 
-test("the first-seen period reaches the query verbatim", async () => {
+test("the badge window is ABSOLUTE and matches the reported window", async () => {
+  // `firstSeen:-24h` is measured from NOW, and neither report runs at the
+  // instant its window closes, so the relative form straddles the window in
+  // both directions. Measured live: `firstSeen:-5d` returned 3 issues where the
+  // equivalent absolute range returned 4.
   const { fetchFn, urls } = digestFetch({ problems: [problemRow("EW-1", "paste_failed", 1, 1)] });
-  await fetchSentrySection(ENV, { ...WINDOW, firstSeenPeriod: "7d" }, { ...OPTS, fetchFn });
-  const issuesUrl = urls.find((u) => u.includes("/issues/"));
-  assert.match(decodeURIComponent(issuesUrl), /firstSeen:-7d/);
+  await fetchSentrySection(ENV, WINDOW, { ...OPTS, fetchFn });
+  const issuesUrl = new URL(urls.find((u) => u.includes("/issues/")));
+  assert.equal(issuesUrl.searchParams.get("start"), WINDOW.startISO);
+  assert.equal(issuesUrl.searchParams.get("end"), WINDOW.endISO);
+  const query = issuesUrl.searchParams.get("query") || "";
+  assert.match(query, /firstSeen:>=2026-08-05T04:00:00/);
+  assert.match(query, /firstSeen:<2026-08-06T04:00:00/);
+  assert.doesNotMatch(query, /firstSeen:-/, "the relative form must be gone");
+});
+
+test("an issue Sentry returns from OUTSIDE the window is still not badged", async () => {
+  // The local boundary re-check. If Sentry's search semantics ever change, this
+  // degrades to a MISSING badge rather than a wrong one.
+  const { fetchFn } = digestFetch({
+    problems: [problemRow("EW-OLD", "paste_failed", 1, 1)],
+    newIssues: [{ shortId: "EW-OLD", firstSeen: "2026-07-02T00:00:00Z" }],
+  });
+  const data = await fetchSentrySection(ENV, WINDOW, { ...OPTS, fetchFn });
+  assert.equal(data.rows[0].isNew, false);
 });
 
 // ── Presentation ────────────────────────────────────────────────────────────
@@ -571,7 +628,7 @@ test("an over-budget section discloses what it omitted instead of truncating sil
 test("a full page of problems is disclosed as a limited breakdown", async () => {
   const many = Array.from({ length: 100 }, (_, i) => problemRow(`EW-${i}`, "asr_failed", 1, 1));
   const { lines } = await render({ problems: many });
-  assert.match(lines.join("\n"), /breakdown covers the largest 100 only/);
+  assert.match(lines.join("\n"), /the error count and the breakdown cover the largest 100 only/);
 });
 
 test("a full page issues no second Sentry request", async () => {
@@ -712,4 +769,143 @@ test("a release row with a junk user count cannot win the release-line ranking",
   ]);
   assert.equal(line.floor, "2.4.0");
   assert.equal(line.tailPeople, 0, "and cannot contribute to the tail either");
+});
+
+// ── Privacy, retries and shapes the reviewer found untested ─────────────────
+
+test("a raw network error never carries its message across the privacy boundary", async () => {
+  // Both digest workers put `err.message` into their HTTP trigger response, and
+  // the weekly one also records it in its failure summary. A fetch or runtime
+  // error carrying a URL fragment would escape there, and the URL is the one
+  // part of a Sentry request that contains search terms.
+  const leaked = "https://us.sentry.io/api/0/x?query=release:secret-thing token=abcd1234";
+  await assert.rejects(
+    () => discoverAggregate(ENV, { queryName: "q", fields: ["count()"], statsPeriod: "24h" },
+      { ...OPTS, fetchFn: async () => { throw new Error(leaked); } }),
+    (err) =>
+      err instanceof SentryNetworkError &&
+      !err.message.includes("sentry.io") &&
+      !err.message.includes("secret-thing") &&
+      !err.message.includes("abcd1234")
+  );
+});
+
+test("a retry that then succeeds returns the real answer", async () => {
+  // The retry path was only ever tested to exhaustion, so a bug that dropped a
+  // successful second attempt would not have shown up.
+  let attempt = 0;
+  const { fetchFn } = recorder(() => {
+    attempt += 1;
+    return attempt === 1 ? response(503, {}) : response(200, aggregate([{ "count()": 7 }], ["count()"]));
+  });
+  const result = await discoverAggregate(ENV, {
+    queryName: "q", fields: ["count()"], requiredFields: ["count()"], statsPeriod: "24h",
+  }, { ...OPTS, fetchFn });
+  assert.equal(attempt, 2);
+  assert.deepEqual(result.rows, [{ "count()": 7 }]);
+});
+
+test("issueList refuses a non-array body and an unusable firstSeen", async () => {
+  for (const body of [{ issues: [] }, "nope", null, [{ shortId: "EW-1" }], [{ shortId: "EW-1", firstSeen: "soon" }]]) {
+    const { fetchFn } = recorder(() => response(200, body));
+    await assert.rejects(
+      () => issueList(ENV, { queryName: "q" }, { ...OPTS, fetchFn }),
+      SentryShapeError,
+      `body ${JSON.stringify(body)} must be refused`
+    );
+  }
+});
+
+test("issueList demands start and end together, never one alone", async () => {
+  const { fetchFn } = recorder(() => response(200, []));
+  for (const params of [
+    { queryName: "q", start: "2026-08-05T00:00:00" },
+    { queryName: "q", end: "2026-08-06T00:00:00" },
+  ]) {
+    await assert.rejects(() => issueList(ENV, params, { ...OPTS, fetchFn }), TypeError);
+  }
+});
+
+test("an unusable release line stops after the two stage-one calls", async () => {
+  // The remaining three cannot be scoped honestly, and an unscoped answer would
+  // silently re-admit every fixed bug on every old build.
+  const { fetchFn, urls } = digestFetch({ releases: [{ release: "garbage", "count_unique(user)": 4 }] });
+  const data = await fetchSentrySection(ENV, WINDOW, { ...OPTS, fetchFn });
+  assert.equal(data.empty, true);
+  assert.equal(urls.length, 2, "stage two must not run without a resolved floor");
+});
+
+test("the truncated headline says 'at least', and never claims the totals are complete", async () => {
+  // `events` is summed from the returned rows, so on a truncated page it
+  // EXCLUDES everything past the first hundred. Printing it as the total
+  // understates it, and the old disclosure then said the totals included them.
+  const many = Array.from({ length: 100 }, (_, i) => problemRow(`EW-${i}`, "asr_failed", 1, 1));
+  const { lines } = await render({ problems: many });
+  const text = lines.join("\n");
+  assert.match(text, /at least \d+ errors across 100 or more problems/);
+  assert.doesNotMatch(text, /The totals above include them/);
+  assert.match(text, /The affected-people total covers all of them/);
+});
+
+test("an untruncated section still says the totals include the omitted rows", async () => {
+  // Two-way control: the qualifier above must apply ONLY when truncated, or the
+  // section would hedge a number it knows exactly.
+  const many = Array.from({ length: 60 }, (_, i) => problemRow(`EW-${i}`, "asr_failed", 1, 1));
+  const { lines } = await render({ problems: many });
+  const text = lines.join("\n");
+  assert.match(text, /The totals above include them/);
+  assert.doesNotMatch(text, /at least/);
+});
+
+test("the section's Discord cap matches the transport's own limit", () => {
+  // The cap is duplicated as a number rather than imported across the
+  // policy/transport boundary, so this is what stops the two drifting apart.
+  const data = { empty: true, reason: "no-errors" };
+  assert.equal(DISCORD_LIMITS.embedDescription, 4096);
+  // A caller asking for more than Discord accepts is capped, not obeyed.
+  const lines = formatSentrySection(data, { title: "Sentry", budget: 99999 });
+  assert.ok(lines.slice(1).join("\n").length <= DISCORD_LIMITS.embedDescription);
+});
+
+// ── Gaps a mutation sweep found, each with the mutation it now kills ────────
+
+test("window instants are read as UTC, whatever the machine's timezone", () => {
+  // Tested on the HELPER, not through the section: a boundary fixture driven
+  // end to end passes trivially on a UTC runner and can only fail on a
+  // developer's machine, which is the wrong way round. Sentry reads these
+  // strings as UTC; Date.parse without a zone reads them as LOCAL time.
+  assert.equal(windowInstant("2026-08-05T04:00:00"), Date.UTC(2026, 7, 5, 4, 0, 0));
+  assert.equal(windowInstant("2026-01-01T00:00:00"), Date.UTC(2026, 0, 1, 0, 0, 0));
+  assert.throws(() => windowInstant("not a date"), TypeError);
+});
+
+test("a release component too large to be exact is refused, not ordered", () => {
+  // Past 2^53 a component loses precision and compares equal to its
+  // neighbours, so the ordering would be arbitrary rather than merely odd.
+  assert.equal(parseReleaseVersion("app@9007199254740993.0.0"), null);
+  assert.equal(parseReleaseVersion("app@1.99999999999999999.0"), null);
+  // Two-way: an ordinary large-but-exact version still parses.
+  assert.deepEqual(parseReleaseVersion("app@2.40.100"), [2, 40, 100]);
+
+  // And such a release cannot win the ranking or join the tail.
+  const line = resolveReleaseLine([
+    { release: "app@9007199254740993.0.0", "count_unique(user)": 99 },
+    { release: "com.enviouswispr.app@2.4.3", "count_unique(user)": 1 },
+  ]);
+  assert.equal(line.floor, "2.4.0");
+  assert.equal(line.tailPeople, 0);
+});
+
+test("a generous caller cannot push the description past Discord's own limit", async () => {
+  // The cap only bites when there is enough content to exceed 4096, so this
+  // renders enough rows to get there. An uncapped budget would be obeyed and
+  // the whole payload refused at delivery.
+  const many = Array.from({ length: 300 }, (_, i) =>
+    problemRow(`EW-${i}`, `a_long_category_name_number_${i}_${"x".repeat(30)}`, 3, 3));
+  const { fetchFn } = digestFetch({ problems: many });
+  const data = await fetchSentrySection(ENV, WINDOW, { ...OPTS, fetchFn });
+  const description = formatSentrySection(data, { title: "Sentry", budget: 99999 }).slice(1).join("\n");
+  assert.ok(description.length > DEFAULT_SECTION_BUDGET, "the fixture must actually exceed the default budget");
+  assert.ok(description.length <= DISCORD_LIMITS.embedDescription,
+    `description ${description.length} exceeds Discord's ${DISCORD_LIMITS.embedDescription} limit`);
 });

--- a/workers/daily-report/wrangler.toml
+++ b/workers/daily-report/wrangler.toml
@@ -24,13 +24,18 @@ SENTRY_PROJECT_SLUG = "enviouswispr"
 #                               the `x-trigger-secret` header (the workers.dev URL is public, so
 #                               the trigger fails closed without it)
 #   SENTRY_AUTH_TOKEN         - reads the Sentry section's aggregates (#1965).
+#     GCP secret `sentry-workers-readonly-token`, scoped to exactly
+#     `event:read` + `org:read`. Install the SAME token on all three Sentry
+#     workers: this one, weekly-digest, and sentry-triage.
 #     NOT the keystore's `sentry-triage-worker-token`, and NOT `sentry-auth-token`.
 #     MEASURED 2026-08-06: both of those 403 on `/organizations/<org>/events/`,
 #     which is the endpoint every number in this section comes from. The triage
 #     token reaches `/projects/<org>/<proj>/issues/` and per-issue events only;
-#     the CI token reaches neither. This section needs a token that also carries
-#     org scope. Without it the section renders "unavailable today" and the rest
-#     of the report is unaffected, which is the intended degradation, not a bug.
+#     the CI token reaches neither. `org:read` is what closes that gap, and
+#     Sentry locks scopes at creation, so it had to be a new token rather than a
+#     widened one. Absent or wrong, the section renders "unavailable today" and
+#     the rest of the report is unaffected, which is the intended degradation,
+#     not a bug.
 #
 # The section is degradable by design: a Sentry outage must never cost the
 # adoption numbers, which come from a different vendor entirely.

--- a/workers/daily-report/wrangler.toml
+++ b/workers/daily-report/wrangler.toml
@@ -12,6 +12,10 @@ POSTHOG_PROJECT_ID = "354235"
 # Public repo, so the version scorecard's release lookup needs no token and no
 # secret - the same unauthenticated pattern workers/weekly-digest already uses.
 GITHUB_REPO = "saurabhav88/EnviousWispr"
+# Sentry section (#1965). Identifiers only, no credential.
+SENTRY_ORG = "envious-labs-llc"
+SENTRY_PROJECT_ID = "4511097112428544"
+SENTRY_PROJECT_SLUG = "enviouswispr"
 
 # Secrets (set via `npx wrangler secret put <NAME>`, never in this file):
 #   POSTHOG_PERSONAL_API_KEY  - GCP secret `posthog-personal-api-key`
@@ -19,3 +23,14 @@ GITHUB_REPO = "saurabhav88/EnviousWispr"
 #   TRIGGER_SECRET            - gates the public `fetch` trigger; the GitHub Action sends it as
 #                               the `x-trigger-secret` header (the workers.dev URL is public, so
 #                               the trigger fails closed without it)
+#   SENTRY_AUTH_TOKEN         - reads the Sentry section's aggregates (#1965).
+#     NOT the keystore's `sentry-triage-worker-token`, and NOT `sentry-auth-token`.
+#     MEASURED 2026-08-06: both of those 403 on `/organizations/<org>/events/`,
+#     which is the endpoint every number in this section comes from. The triage
+#     token reaches `/projects/<org>/<proj>/issues/` and per-issue events only;
+#     the CI token reaches neither. This section needs a token that also carries
+#     org scope. Without it the section renders "unavailable today" and the rest
+#     of the report is unaffected, which is the intended degradation, not a bug.
+#
+# The section is degradable by design: a Sentry outage must never cost the
+# adoption numbers, which come from a different vendor entirely.

--- a/workers/reporting/README.md
+++ b/workers/reporting/README.md
@@ -1,0 +1,69 @@
+# workers/reporting
+
+Report POLICY shared by more than one digest Worker. Product judgement lives
+here; transport lives in `workers/shared`.
+
+## Consumers
+
+- `workers/daily-report` (yesterday)
+- `workers/weekly-digest` (the last seven whole days)
+
+Keep that list accurate. It is the deploy checklist.
+
+## THE RULE THAT BITES: editing a file here changes nothing in production
+
+Identical to `workers/shared/README.md`, and it applies for the same reason:
+each Worker is bundled separately at `wrangler deploy` time and carries its own
+snapshot of this code.
+
+- **A merged PR deploys nothing.** No CI workflow runs `wrangler deploy`.
+- **A change here is live only in the Workers you have redeployed since.**
+- **`git revert` does not roll back production.** Rolling back means reverting
+  *and* redeploying every consumer.
+
+```bash
+cd workers/daily-report  && npx wrangler deploy    # deploy the CHANGED consumer first
+cd ../weekly-digest      && npx wrangler deploy
+```
+
+There are **two deployment sets, and they are not the same set**:
+
+| Module | Consumers |
+|---|---|
+| `workers/reporting/sentry-section.js` | daily-report, weekly-digest |
+| `workers/shared/sentry.js` | daily-report, weekly-digest, **sentry-triage** |
+
+A digest-policy change needs the two digests redeployed. A change to the Sentry
+transport underneath it needs all three, including the triage Worker, which
+consumes the transport and none of the policy.
+
+## Why this directory exists at all
+
+`workers/shared/README.md` says, in its own words: transport and protocol only,
+and "metric SQL, report windows, section failure policy, degrade wording, and
+anything a reader would recognise as a product judgement" must not come here.
+
+The Sentry section is exactly that forbidden half. It decides which releases
+count, whether an `error.category` means the person lost their dictation or
+merely got a worse one, and how to say so in a sentence the founder reads. Both
+digests need the identical answer to all three, and duplicating it would let the
+classification and the wording drift apart silently.
+
+So the split is: `workers/shared/sentry.js` owns HTTP, auth, retry and
+response-shape validation; `workers/reporting/sentry-section.js` owns the
+queries, the classification and every word.
+
+## What must NOT come here
+
+- Anything a THIRD Worker with a different contract needs. `sentry-triage` is
+  webhook-driven and deadline-bound (20s lookup, 28s operation); the digests are
+  scheduled and tolerant. It imports the shared transport and keeps its own
+  query, formatter and throttle, deliberately.
+- Transport concerns. They belong one directory over.
+
+## Tests
+
+There is no test package here. `workers/daily-report/test/sentry-section.test.js`
+covers this module and the transport, and both digest suites cover the
+integration. All three run in CI via the `worker-tests` job feeding the required
+`build-check`, so a change here that breaks either consumer blocks the PR.

--- a/workers/reporting/README.md
+++ b/workers/reporting/README.md
@@ -21,6 +21,9 @@ snapshot of this code.
 - **`git revert` does not roll back production.** Rolling back means reverting
   *and* redeploying every consumer.
 
+After changing a file **in this directory** (two consumers — read the next
+paragraph before assuming that covers you):
+
 ```bash
 cd workers/daily-report  && npx wrangler deploy    # deploy the CHANGED consumer first
 cd ../weekly-digest      && npx wrangler deploy

--- a/workers/reporting/sentry-section.js
+++ b/workers/reporting/sentry-section.js
@@ -343,6 +343,11 @@ const ISSUE_FIELDS = ["issue", "title", "error.category", "level", "count()", "c
 // through. See workers/shared/sentry.js discoverAggregate.
 const ISSUE_REQUIRED_META = ["error.category", "level", "count()", "count_unique(user)"];
 const RELEASE_FIELDS = ["release", "count()", "count_unique(user)"];
+
+/** The release query's page size AND the number the truncation sentence quotes.
+ * One constant because a sentence naming a different limit from the one the
+ * query used is a lie the reader cannot check. */
+const RELEASE_PAGE_LIMIT = 100;
 const HEADLINE_FIELDS = ["count()", "count_unique(user)"];
 
 const PROD = "production";
@@ -389,7 +394,7 @@ export async function fetchSentrySection(env, window, opts = {}) {
       start: startISO,
       end: endISO,
       sort: "-count_unique(user)",
-      perPage: 100,
+      perPage: RELEASE_PAGE_LIMIT,
     }, opts),
     // The badge comes from firstSeen, NEVER from a min(timestamp) over the
     // window. That was the original design and it was measured wrong: min()
@@ -704,20 +709,28 @@ export function formatSentrySection(data, { title, budget: requestedBudget = DEF
   // two identity systems. Saying so is better than inventing a denominator.
   lines.push("Impact rate unavailable: error counts and usage counts come from different identity systems.");
 
-  if (data.tailPeople > 0) {
+  // TWO ERROR SOURCES PULLING OPPOSITE WAYS MEANS NO BOUND EXISTS, SO PRINT NO
+  // NUMBER. The sum OVERSTATES, because per-release people counts are not
+  // additive and one person on three old releases is counted three times. A cut
+  // release page UNDERSTATES, because omitted rows are unseen. Untruncated only
+  // the first applies, so "up to N" is sound. Truncated, both apply and the true
+  // value can sit on either side of the subtotal - "at least N" is exactly as
+  // unsupported as "up to N", and swapping one for the other only moves which
+  // direction the sentence is wrong in.
+  //
+  // Driven by `releasesTruncated` rather than by the subtotal, because a
+  // truncated page with a ZERO visible subtotal is the case that most needs
+  // saying: it looks identical to "nobody is on an old build", which is the one
+  // conclusion this section must never let a reader draw by accident.
+  if (data.releasesTruncated) {
+    lines.push(
+      `Separately, the release list hit its ${RELEASE_PAGE_LIMIT}-row limit, ` +
+        `so people on builds older than ${data.floor} could not be counted.`
+    );
+  } else if (data.tailPeople > 0) {
     // "Up to", because these are per-release counts summed across releases and
     // one person can appear under more than one.
-    //
-    // A TRUNCATED RELEASE PAGE INVERTS THAT BOUND, so the wording cannot stand.
-    // The sum overstates (non-additive people) and a cut-off page understates
-    // (missing old releases), and the two pull opposite ways - so "up to N" is
-    // no longer a claim the data supports in either direction. Say it is
-    // partial instead of picking a bound that might be false.
-    lines.push(
-      data.releasesTruncated
-        ? `Separately, at least ${people(data.tailPeople)} on builds older than ${data.floor}, from a partial release list.`
-        : `Separately, up to ${people(data.tailPeople)} on builds older than ${data.floor}.`
-    );
+    lines.push(`Separately, up to ${people(data.tailPeople)} on builds older than ${data.floor}.`);
   }
   lines.push("");
 

--- a/workers/reporting/sentry-section.js
+++ b/workers/reporting/sentry-section.js
@@ -237,8 +237,8 @@ export function resolveReleaseLine(rows) {
   for (const row of rows) {
     const version = parseReleaseVersion(row?.release);
     if (version === null) continue;
-    const people = Number(row["count_unique(user)"]);
-    if (!Number.isFinite(people)) continue;
+    const people = countOrNull(row["count_unique(user)"]);
+    if (people === null) continue;
     // Compare people first, then the version itself, so an exact tie resolves
     // to the newer release rather than to whichever Sentry happened to sort up.
     const key = [people, ...version];
@@ -260,8 +260,8 @@ export function resolveReleaseLine(rows) {
     const version = parseReleaseVersion(row?.release);
     if (version === null) continue;
     if (compareKeys(version, [best[0], best[1], 0]) < 0) {
-      const people = Number(row["count_unique(user)"]);
-      if (Number.isFinite(people)) tailPeople += people;
+      const people = countOrNull(row["count_unique(user)"]);
+      if (people !== null) tailPeople += people;
     }
   }
   return { floor, tailPeople };
@@ -453,13 +453,30 @@ export async function fetchSentrySection(env, window, opts = {}) {
   };
 }
 
-/** A count that is not a finite number is a defect in the response, not a zero.
+/** A count, or null if the value is not one.
+ *
+ * `Number()` is far too permissive to validate with, and every one of these is
+ * a real Sentry response shape away from being a wrong number in a sentence:
+ * `Number(null)`, `Number("")`, `Number(false)` and `Number([])` are all 0, and
+ * `Number(["7"])` is 7. A single-element array reading as a person count is the
+ * dangerous one, because it is silent and plausible.
+ *
+ * So the type is checked BEFORE the value, and the value must be a
+ * non-negative INTEGER: Sentry counts people and events, and 1.5 people is a
+ * response shape this code should refuse rather than round. */
+function countOrNull(value) {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) return null;
+  return value;
+}
+
+/** The throwing form, for a count the section cannot render without.
+ *
  * Zero is a real and common answer here, so a `|| 0` fallback would make a
  * malformed row indistinguishable from a quiet day. */
 function toCount(value) {
-  const n = Number(value);
-  if (!Number.isFinite(n) || n < 0) {
-    throw new TypeError(`Sentry returned a non-numeric count: ${String(value)}`);
+  const n = countOrNull(value);
+  if (n === null) {
+    throw new TypeError(`Sentry returned a value that is not a count: ${JSON.stringify(value) ?? String(value)}`);
   }
   return n;
 }
@@ -539,21 +556,34 @@ export function formatSentrySection(data, { title, budget = DEFAULT_SECTION_BUDG
   const lost = rows.filter((r) => r.group === LOST);
   const degraded = rows.filter((r) => r.group === DEGRADED);
 
-  const budgetState = { used: lines.join("\n").length, budget, omitted: 0 };
-  appendGroup(lines, "LOST THE DICTATION", lost, budgetState);
-  appendGroup(lines, "STILL WORKED, JUST WORSE", degraded, budgetState);
+  // The disclosure lines are appended AFTER the rows, so their cost has to be
+  // reserved BEFORE the rows are laid out. Without the reservation the section
+  // spends the whole budget on rows and then overshoots it by exactly the
+  // length of the sentence explaining that it ran out - measured at 24
+  // characters over a 1200 budget, which is the shape that eventually pushes an
+  // assembled payload past a Discord limit and sends nothing at all.
+  const reserve = omittedLine(data.rows.length).length + 1 + TRUNCATED_LINE.length + 1;
+  const state = { budget: budget - reserve, omitted: 0 };
+  appendGroup(lines, "LOST THE DICTATION", lost, state);
+  appendGroup(lines, "STILL WORKED, JUST WORSE", degraded, state);
 
-  if (budgetState.omitted > 0) {
-    lines.push(
-      `${budgetState.omitted} more ${budgetState.omitted === 1 ? "problem is" : "problems are"} ` +
-        "not listed here. The totals above include them."
-    );
-  }
-  if (data.truncated) {
-    lines.push("100 or more problems were recorded; the breakdown covers the largest 100 only.");
-  }
+  if (state.omitted > 0) lines.push(omittedLine(state.omitted));
+  if (data.truncated) lines.push(TRUNCATED_LINE);
   return lines;
 }
+
+const TRUNCATED_LINE = "100 or more problems were recorded; the breakdown covers the largest 100 only.";
+
+const omittedLine = (n) =>
+  `${n} more ${n === 1 ? "problem is" : "problems are"} not listed here. The totals above include them.`;
+
+/** The rendered description length, which is every line EXCEPT the title.
+ *
+ * Measured from the lines themselves on each check rather than tracked
+ * incrementally. An incremental counter has to model every separator the join
+ * will add, and the version that did drifted - which is invisible until the
+ * assembled payload is refused by Discord and the whole report disappears. */
+const descriptionLength = (lines) => lines.slice(1).join("\n").length;
 
 /** Appends the Sentry issue id to rows whose labels would otherwise be
  * identical.
@@ -571,43 +601,70 @@ export function formatSentrySection(data, { title, budget = DEFAULT_SECTION_BUDG
  *
  * Applied across the WHOLE row set before the groups are split, because a
  * collision can straddle the lost/degraded boundary and would be invisible to a
- * per-group pass. Rows with no id are left alone: an id-less row cannot be
- * disambiguated and a bare "(unknown)" would say nothing. */
+ * per-group pass. */
 function disambiguate(rows) {
   const counts = new Map();
   for (const row of rows) counts.set(row.label, (counts.get(row.label) || 0) + 1);
-  return rows.map((row) =>
+
+  // First pass: the issue id, which is the meaningful separator and the thing
+  // the founder would search for.
+  const withIds = rows.map((row) =>
     counts.get(row.label) > 1 && row.shortId
       ? { ...row, label: `${row.label} ${row.shortId}` }
       : row
   );
+
+  // Second pass, because the first is NOT sufficient and a single pass looked
+  // like it was. Two rows can still collide after it: rows sharing a shortId,
+  // and rows with no shortId at all - both of which render as two identical
+  // lines, which is the exact defect this function exists to prevent. An
+  // ordinal is not informative, but it is honest, and two lines the reader can
+  // tell apart beat two they cannot.
+  const after = new Map();
+  for (const row of withIds) after.set(row.label, (after.get(row.label) || 0) + 1);
+  const seen = new Map();
+  return withIds.map((row) => {
+    if (after.get(row.label) <= 1) return row;
+    const n = (seen.get(row.label) || 0) + 1;
+    seen.set(row.label, n);
+    return { ...row, label: `${row.label} (${n})` };
+  });
 }
 
+/** Renders one group, adding rows only while the WHOLE description still fits.
+ *
+ * Every check re-measures the real rendered length, and any line that would not
+ * fit is popped straight back off. That is slightly wasteful and it is exactly
+ * what makes the budget true: there is no separate model of the output that can
+ * disagree with the output.
+ *
+ * A group whose heading alone does not fit contributes its rows to the omitted
+ * count rather than printing an empty heading. */
 function appendGroup(lines, heading, rows, state) {
   if (rows.length === 0) return;
-  const headingCost = heading.length + 2;
-  if (state.used + headingCost > state.budget) {
+
+  lines.push(heading);
+  if (descriptionLength(lines) > state.budget) {
+    lines.pop();
     state.omitted += rows.length;
     return;
   }
-  lines.push(heading);
-  state.used += headingCost;
+
   for (const row of rows) {
     // Appended for every conservative row, so a classification made on missing
     // evidence never reads as a demonstrated loss. The founder acts on this
     // list, and "lost the dictation" is a strong claim to make on a category
     // whose producers disagree.
     const suffix = row.deliveryProven ? "" : ", delivery not proven";
-    const text = `  ${people(row.people)}   ${row.label}${suffix}${row.isNew ? "   NEW" : ""}`;
-    if (state.used + text.length + 1 > state.budget) {
+    lines.push(`  ${people(row.people)}   ${row.label}${suffix}${row.isNew ? "   NEW" : ""}`);
+    if (descriptionLength(lines) > state.budget) {
+      lines.pop();
       state.omitted += 1;
-      continue;
     }
-    lines.push(text);
-    state.used += text.length + 1;
   }
+
   lines.push("");
-  state.used += 1;
+  if (descriptionLength(lines) > state.budget) lines.pop();
 }
 
 /** Plain-language unavailable copy, owned here so no integration ever authors

--- a/workers/reporting/sentry-section.js
+++ b/workers/reporting/sentry-section.js
@@ -222,6 +222,35 @@ export function parseReleaseVersion(release) {
  *    one person appears under several releases - so summing them to rank would
  *    be arithmetic on numbers that do not add.
  *
+ * KNOWN LIMIT, raised by cloud review on PR #1968 and NOT fixed here (#1970).
+ * The ranking key is AFFECTED people, which is a proxy for INSTALLED people and
+ * not the same quantity. They diverge when a new release is both widely adopted
+ * and sharply healthier: a release that fixes a high-frequency crash earns few
+ * error rows, so it cannot win the ranking, and the floor can sit on the older
+ * line while a bug already fixed above it keeps the headline. That is a weaker
+ * form of the very defect this function exists to prevent.
+ *
+ * What was measured (2026-08-06, live, driving these shipped functions rather
+ * than a copy of them): ranking by Sentry affected users and ranking by PostHog
+ * active users produce the SAME floor, 2.4.0, over both the 1-day and 7-day
+ * windows. Affected count tracks population closely enough today because error
+ * volume scales with usage.
+ *
+ * What that did NOT cover: any window in which a release's error RATE changes
+ * sharply, which is exactly the post-fix rollout. One agreeing measurement on a
+ * calm population is not evidence the rule holds through a quality cliff, and
+ * this comment is not a claim that the question is settled.
+ *
+ * Why it was not fixed in the PR that found it: the correction needs per-version
+ * ADOPTION, which lives in PostHog. `weekly-digest` has no per-version usage
+ * query at all, and `daily-report`'s lives in its own version scorecard, so
+ * closing this means either a new cross-vendor query in the weekly worker or
+ * two different release rules in one shared section. Both contradict decisions
+ * this plan made deliberately: the section degrades independently of PostHog so
+ * a Sentry outage cannot cost the adoption numbers, and it prints no impact rate
+ * precisely because the two identity systems join only partially. Reopening that
+ * is a product call, not a review-loop patch.
+ *
  * A single release's user count is used ONLY as a ranking key and is never
  * displayed. Ties break toward the NEWER version, so the rule is deterministic
  * rather than dependent on Sentry's row order.

--- a/workers/reporting/sentry-section.js
+++ b/workers/reporting/sentry-section.js
@@ -1,0 +1,625 @@
+/**
+ * The Sentry digest section (issue #1965).
+ *
+ * CONSUMERS: workers/daily-report (yesterday), workers/weekly-digest (7 days).
+ *
+ * DEPLOY RULE: each worker bundles its own copy at deploy time, so editing this
+ * file changes nothing in production until BOTH consumers are redeployed. See
+ * workers/reporting/README.md.
+ *
+ * WHY THIS IS NOT IN workers/shared/: that directory is transport and protocol
+ * only, and everything below is product judgement - which releases count, what
+ * an error category MEANS for the person who was dictating, and how to say it.
+ * The Sentry HTTP transport those judgements sit on top of IS in
+ * workers/shared/sentry.js, which is the correct half to share.
+ *
+ * WHY THE SPIKE CARD DOES NOT IMPORT THIS: workers/sentry-triage renders a
+ * different thing from a different query - dev AND production rather than
+ * production only, a trailing hour rather than a day or a week, and no
+ * lost/degraded grouping at all. It shares the transport and nothing else.
+ *
+ * REPORTS, NEVER ALERTS. No thresholds, no colours, no healthy/unhealthy verdict.
+ * The digest that this section joins replaced a threshold-alarm worker, and that
+ * shape is exactly what made the old health check useless to its one reader
+ * (workers/daily-report/src/index.js header). Spike alerting is owned by
+ * sentry-triage, which is a different contract with a different deadline.
+ *
+ * Privacy: counts, category labels and version numbers only. Never a stack
+ * trace, a user id, a message body or anything a user dictated.
+ */
+
+import { discoverAggregate, issueList } from "../shared/sentry.js";
+
+// ── Classification ──────────────────────────────────────────────────────────
+
+export const LOST = "lost";
+export const DEGRADED = "degraded";
+
+/**
+ * Every `SentryBreadcrumb.ErrorCategory` raw value, classified by what the
+ * PERSON experienced, per CLAUDE.md § Principles: the heart (audio, ASR, paste)
+ * failing loses the dictation; a limb failing still delivers the last
+ * successful text.
+ *
+ * THE RULE THIS TABLE ENCODES. `lost` means either a producer proves text was
+ * not delivered, OR the indexed fields cannot prove that it was. `degraded`
+ * requires that EVERY current producer proves text remained available, or that
+ * no dictation was in flight at all. Unknown categories default to `lost` and
+ * render their raw name, so a category added to the app and not added here is
+ * conspicuous rather than silently dropped.
+ *
+ * `deliveryProven: false` marks a row where the classification is the
+ * conservative choice rather than a demonstrated fact. Those render as
+ * "delivery not proven" and MUST NOT be worded as proof a user lost words:
+ * overstating is its own defect, because the founder acts on this list.
+ *
+ * `emitted: false` marks a case that exists in the enum and has NO producer
+ * anywhere in Sources/ or Tests/ (measured 2026-08-06; positive control:
+ * modelLoadFailed returns 30 hits). It cannot appear in live data. It is kept
+ * here rather than omitted so the completeness test can enumerate the Swift enum
+ * against this table and fail on a genuine gap.
+ */
+export const ERROR_CATEGORIES = Object.freeze({
+  // Declared in the enum, never emitted. Conservative-lost is unreachable here
+  // rather than wrong; if a producer is ever added, the classification is
+  // already the safe one.
+  availability_check_failed: { group: LOST, deliveryProven: false, emitted: false, label: "AI availability check failed" },
+  fallback_failed: { group: LOST, deliveryProven: false, emitted: false, label: "polish fallback failed" },
+  state_mismatch: { group: LOST, deliveryProven: false, emitted: false, label: "recording state mismatch" },
+
+  // Polish limbs. Every one of these leaves the previously-produced text intact
+  // (CLAUDE.md § Principles; ITN runs BEFORE polish, so number and date
+  // formatting survives a polish failure too).
+  provider_init_failed: { group: DEGRADED, deliveryProven: true, emitted: true, label: "polish provider could not start" },
+  generation_failed: { group: DEGRADED, deliveryProven: true, emitted: true, label: "polish generation failed" },
+  polish_provider_failed: { group: DEGRADED, deliveryProven: true, emitted: true, label: "polish provider failed" },
+  output_classifier_load_failed: { group: DEGRADED, deliveryProven: true, emitted: true, label: "polish safety check could not load" },
+  emoji_restore_incomplete: { group: DEGRADED, deliveryProven: true, emitted: true, label: "emoji restoration incomplete" },
+  inverse_normalization_timeout: { group: DEGRADED, deliveryProven: true, emitted: true, label: "number and date formatting timed out" },
+  legacy_key_cleanup_failed: { group: DEGRADED, deliveryProven: true, emitted: true, label: "old key cleanup failed" },
+
+  // The clipboard IS the paste cascade's floor, so the text reached the user
+  // even when auto-paste did not (PasteCascadeExecutor.swift:533-565, error
+  // emitted at :672-735). The founder said this outright: "paste failing is not
+  // actually an error."
+  paste_failed: { group: DEGRADED, deliveryProven: true, emitted: true, label: "paste fell back to the clipboard" },
+
+  // Fires at ARM time and only disables the crash-safety copy for that take;
+  // the recording continues (RecoveryCoordinator.swift:242-258, "fail-open: a
+  // store failure disables recovery for this take"). The first draft of the
+  // plan had this as lost; grounded review corrected it.
+  recovery_key_store_failed: { group: DEGRADED, deliveryProven: true, emitted: true, label: "crash-safety copy could not be armed" },
+
+  // The shortcut will not fire, but the event does not prove a dictation was
+  // ever attempted, so it cannot be counted as one that was lost.
+  hotkey_registration_failed: { group: DEGRADED, deliveryProven: true, emitted: true, label: "dictation shortcut could not be registered" },
+
+  // Heart failures. Terminal: no text reached the user.
+  audio_capture_failed: { group: LOST, deliveryProven: true, emitted: true, label: "microphone capture failed" },
+  audio_capture_stalled: { group: LOST, deliveryProven: true, emitted: true, label: "microphone capture stalled" },
+  asr_failed: { group: LOST, deliveryProven: true, emitted: true, label: "transcription failed" },
+  model_load_failed: { group: LOST, deliveryProven: true, emitted: true, label: "speech model failed to load" },
+  heart_path_finalization: { group: LOST, deliveryProven: true, emitted: true, label: "dictation finished with no text" },
+  pipeline_post_condition_failed: { group: LOST, deliveryProven: true, emitted: true, label: "recording start ended in an invalid state" },
+
+  // No longer emitted by any shipping build (SentryBreadcrumb.swift:405-409),
+  // but historical events are still inside Sentry's retention window, so it can
+  // appear on an old release and must classify rather than fall through to the
+  // unknown path.
+  asr_empty_result: { group: LOST, deliveryProven: true, emitted: false, label: "transcription returned nothing" },
+
+  // Conservative. Producers DISAGREE and the indexed fields cannot separate
+  // them: KernelLifecycleTelemetrySink.swift:476-503 can be an interrupted
+  // recording while KernelDictationDriver.swift:912-934 emits was_recording
+  // false, and BOTH send Sentry stage "asr". A `pipeline.stage` split was
+  // proposed in an earlier draft and disproved against the producers.
+  xpc_service_error: { group: LOST, deliveryProven: false, emitted: true, label: "transcription helper failed" },
+
+  // Conservative, same shape. Both producers send stage "asr"
+  // (KernelDictationDriver.swift:221-235); the distinguishing "sessionless"
+  // marker is an unindexed EXTRA, so no aggregate field can split them.
+  model_load_wedged: { group: LOST, deliveryProven: false, emitted: true, label: "speech model load got stuck" },
+
+  // Conservative: covers both a failed dispatch and a nil collaborator, and
+  // delivery is not decidable from the category alone.
+  pipeline_dispatch_failed: { group: LOST, deliveryProven: false, emitted: true, label: "dictation could not start processing" },
+
+  // Recovery paths. Each of these is the RESCUE of an already-undelivered
+  // recording failing, so the dictation was lost in every case.
+  recovery_decrypt_failed: { group: LOST, deliveryProven: true, emitted: true, label: "saved recording could not be unlocked" },
+  recovery_transcribe_failed: { group: LOST, deliveryProven: true, emitted: true, label: "saved recording could not be transcribed" },
+  recovery_empty_text: { group: LOST, deliveryProven: true, emitted: true, label: "saved recording produced no text" },
+  recovery_abandoned_after_attempt: { group: LOST, deliveryProven: true, emitted: true, label: "saved recording was abandoned" },
+});
+
+/** An unhandled crash carries NO `error.category` at all - measured 2026-08-06,
+ * 3 of 9 rows blank on a live pull, every one of them a crash. A
+ * category-driven classifier without this branch drops the single most
+ * important row into "uncategorised".
+ *
+ * The exception TYPE is included because a live smoke run printed two different
+ * crashes as two identical "app crash" rows, which reads as a rendering bug
+ * rather than as two distinct problems. `EXC_BAD_ACCESS` and
+ * `NSInternalInconsistencyException` are very different things to see twice in
+ * a row.
+ *
+ * ONLY the type, never the message. A Sentry title is `<type>: <message>`, and
+ * the message half is the one place in this whole section where user-derived
+ * text could appear. Splitting at the first colon and discarding the remainder
+ * keeps the privacy boundary intact by construction rather than by trusting
+ * Sentry's own redaction. */
+const CRASH_TYPE_MAX = 48;
+
+function crashLabel(title) {
+  if (typeof title !== "string") return "app crash";
+  const type = title.split(":", 1)[0].trim();
+  // A type must look like an identifier. Anything else is a title shape this
+  // code does not recognise, and printing it unexamined is how the message half
+  // would eventually leak through some future format.
+  if (type.length === 0 || type.length > CRASH_TYPE_MAX || !/^[A-Za-z_][A-Za-z0-9_.]*$/.test(type)) {
+    return "app crash";
+  }
+  return `app crash (${type})`;
+}
+
+/**
+ * Classifies one aggregate row.
+ *
+ * Returns `{ group, label, deliveryProven }`. Never throws and never returns
+ * null: an unrecognised category is a real thing that happened to a real
+ * person, so it is reported conservatively under its raw name rather than
+ * discarded. `rawCategory` is preserved in the label precisely so a category
+ * added to the app and not added to this table is visible in Discord.
+ */
+export function classifyProblem({ category, level, title }) {
+  const raw = typeof category === "string" ? category.trim() : "";
+  if (raw.length === 0) {
+    // A blank category on a fatal is a crash. A blank category on a NON-fatal
+    // is something this table does not know about, and guessing "crash" for it
+    // would put a wrong sentence in front of the founder.
+    if (typeof level === "string" && level.toLowerCase() === "fatal") {
+      return { group: LOST, deliveryProven: false, label: crashLabel(title) };
+    }
+    return { group: LOST, deliveryProven: false, label: "uncategorised failure" };
+  }
+  const known = Object.hasOwn(ERROR_CATEGORIES, raw) ? ERROR_CATEGORIES[raw] : null;
+  if (known) return { group: known.group, label: known.label, deliveryProven: known.deliveryProven };
+  return { group: LOST, deliveryProven: false, label: raw };
+}
+
+// ── Release line ────────────────────────────────────────────────────────────
+
+/** `com.enviouswispr.app@2.4.3` -> [2,4,3]. Returns null for anything that is
+ * not a plain three-part version, so a malformed release is REFUSED rather than
+ * ordered by accident. */
+export function parseReleaseVersion(release) {
+  if (typeof release !== "string") return null;
+  const at = release.lastIndexOf("@");
+  const version = at === -1 ? release : release.slice(at + 1);
+  const parts = version.split(".");
+  if (parts.length !== 3) return null;
+  const nums = parts.map((p) => (/^\d+$/.test(p) ? Number(p) : null));
+  return nums.some((n) => n === null) ? null : nums;
+}
+
+/**
+ * Resolves the release line: the MINOR line of the single release with the most
+ * affected people in the window, and everything at or above it.
+ *
+ * WHY THIS RULE AND NOT THE OBVIOUS ALTERNATIVES. It has to keep working
+ * without maintenance, because the failure it prevents is exactly the one the
+ * founder named: a bug fixed in a later version headlining the digest forever
+ * ("the speech detector was actually solved in a later version").
+ *
+ *  - NOT a constant like the scorecard's SCORECARD_MIN_VERSION. A constant goes
+ *    stale silently, which reproduces the defect a few months later.
+ *  - NOT "the newest published release". That cliffs on release day, when
+ *    almost nobody is on it yet, and would empty the section exactly when a new
+ *    build most needs watching.
+ *  - NOT a summed share across releases. Sentry user counts are NOT additive -
+ *    one person appears under several releases - so summing them to rank would
+ *    be arithmetic on numbers that do not add.
+ *
+ * A single release's user count is used ONLY as a ranking key and is never
+ * displayed. Ties break toward the NEWER version, so the rule is deterministic
+ * rather than dependent on Sentry's row order.
+ *
+ * Measured 2026-08-05 production: 2.4.3 (8 people), 2.4.1 (3), 2.4.0 (2),
+ * 2.3.1 (2) resolves to 2.4.0, which over 7 days drops 6 of 21 problems - every
+ * one a single-user tail on an old build, including the vad prepare failure the
+ * founder named and `asr_empty_result`, which no shipping build emits.
+ *
+ * Returns `{ floor, tailPeople }` or null when no row carries a usable version.
+ */
+export function resolveReleaseLine(rows) {
+  let best = null;
+  let bestKey = null;
+  for (const row of rows) {
+    const version = parseReleaseVersion(row?.release);
+    if (version === null) continue;
+    const people = Number(row["count_unique(user)"]);
+    if (!Number.isFinite(people)) continue;
+    // Compare people first, then the version itself, so an exact tie resolves
+    // to the newer release rather than to whichever Sentry happened to sort up.
+    const key = [people, ...version];
+    if (bestKey === null || compareKeys(key, bestKey) > 0) {
+      bestKey = key;
+      best = version;
+    }
+  }
+  if (best === null) return null;
+
+  const floor = `${best[0]}.${best[1]}.0`;
+  // The tail is people on releases BELOW the line. Reported as a single
+  // summary line: it sizes upgrade pressure without polluting the ranked list.
+  // Deliberately a SUM even though user counts are non-additive across
+  // releases, so it is worded as an upper bound ("up to N people") rather than
+  // as a distinct-person count this data cannot produce.
+  let tailPeople = 0;
+  for (const row of rows) {
+    const version = parseReleaseVersion(row?.release);
+    if (version === null) continue;
+    if (compareKeys(version, [best[0], best[1], 0]) < 0) {
+      const people = Number(row["count_unique(user)"]);
+      if (Number.isFinite(people)) tailPeople += people;
+    }
+  }
+  return { floor, tailPeople };
+}
+
+function compareKeys(a, b) {
+  for (let i = 0; i < Math.max(a.length, b.length); i += 1) {
+    const x = a[i] ?? 0;
+    const y = b[i] ?? 0;
+    if (x !== y) return x < y ? -1 : 1;
+  }
+  return 0;
+}
+
+// ── Queries ─────────────────────────────────────────────────────────────────
+
+/** THE CALL BUDGET, in one place, asserted by a test.
+ *
+ * FIVE fixed Sentry requests per digest run, whatever the error volume. The
+ * plan's original three assumed the release line arrived free and that the
+ * headline totals came from the same response as the per-problem rows; neither
+ * held, because Discover returns EITHER a grouped result OR an aggregate, never
+ * both (measured 2026-08-06).
+ *
+ * The constraint that actually matters is unchanged: NO CALL FANS OUT PER
+ * ISSUE, so the count does not move with volume. Measured cost of all five:
+ * ~1.8s and ~4.5KB, against a limit of 30 requests per window and 15 concurrent.
+ *
+ * Total EVENTS is deliberately derived from the per-issue rows rather than
+ * bought with a sixth call - event counts are additive and were verified to sum
+ * exactly to the aggregate (19+4+2+1+1+9+1+1 = 38). Distinct PEOPLE is not
+ * derivable (13 distinct against per-problem counts summing to 15), which is
+ * why calls 4 and 5 exist. */
+export const SENTRY_CALLS_PER_DIGEST = 5;
+
+const ISSUE_FIELDS = ["issue", "title", "error.category", "level", "count()", "count_unique(user)"];
+// Read from meta.fields, which is present on an EMPTY response too. `issue` is
+// deliberately absent from this list: Sentry echoes it back as `issue.id`, so
+// requiring the requested name would fail on a perfectly good response and the
+// obvious repair (deleting the check) is how an empty malformed body gets
+// through. See workers/shared/sentry.js discoverAggregate.
+const ISSUE_REQUIRED_META = ["error.category", "level", "count()", "count_unique(user)"];
+const RELEASE_FIELDS = ["release", "count()", "count_unique(user)"];
+const HEADLINE_FIELDS = ["count()", "count_unique(user)"];
+
+const PROD = "production";
+
+/**
+ * Runs the whole section against Sentry and returns its data, or throws.
+ *
+ * `window` is CALLER-SUPPLIED and this module never reads the clock: the daily
+ * report resolves an Eastern calendar day and the weekly digest resolves a
+ * complete week, and a second window derived here could silently disagree with
+ * the one the rest of the report is about.
+ *
+ * Runs OUTSIDE each worker's PostHog limiter, deliberately. Sentry has its own
+ * ceiling (30 per window, 15 concurrent) and a Sentry read that waited for a
+ * PostHog slot would block a PostHog query for ~1.8s while doing no PostHog
+ * work at all.
+ */
+export async function fetchSentrySection(env, window, opts = {}) {
+  const { startISO, endISO, priorStartISO, firstSeenPeriod } = window;
+  // firstSeenPeriod is REQUIRED, never defaulted. A default of "24h" would be
+  // correct for the daily report and silently wrong for the weekly digest,
+  // which would then badge only the last day of a seven-day window - an answer
+  // that looks right everywhere a human would look.
+  for (const [name, value] of [
+    ["startISO", startISO],
+    ["endISO", endISO],
+    ["priorStartISO", priorStartISO],
+    ["firstSeenPeriod", firstSeenPeriod],
+  ]) {
+    if (typeof value !== "string" || value.length === 0) {
+      throw new TypeError(`fetchSentrySection requires window.${name}`);
+    }
+  }
+
+  // Stage 1. Independent of each other, so both go at once.
+  //   call 1: which releases are live, and how the people split across them.
+  //   call 3: the genuinely-new issue set (see the badge note below).
+  const [releaseResult, newIssues] = await Promise.all([
+    discoverAggregate(env, {
+      queryName: "sentry_releases",
+      fields: RELEASE_FIELDS,
+      requiredFields: ["release", "count_unique(user)"],
+      environment: PROD,
+      start: startISO,
+      end: endISO,
+      sort: "-count_unique(user)",
+      perPage: 100,
+    }, opts),
+    // The badge comes from firstSeen, NEVER from a min(timestamp) over the
+    // window. That was the original design and it was measured wrong: min()
+    // is scoped to events MATCHING the query, not to the issue's lifetime, so
+    // every still-active problem read as new. ENVIOUSWISPR-24, first seen
+    // 2026-07-02, returned a min(timestamp) of today.
+    issueList(env, {
+      queryName: "sentry_new_issues",
+      query: `firstSeen:-${firstSeenPeriod}`,
+      environment: PROD,
+      limit: 100,
+    }, opts),
+  ]);
+
+  const line = resolveReleaseLine(releaseResult.rows);
+  // No usable release in the window means no honest scope for the numbers
+  // below. Reported as unavailable rather than as an unscoped total that would
+  // silently re-admit every fixed bug on every old build.
+  if (line === null) {
+    return {
+      empty: true,
+      reason: releaseResult.rows.length === 0 ? "no-errors" : "no-release-line",
+      truncated: false,
+    };
+  }
+
+  const releaseFilter = `release.version:>=${line.floor}`;
+
+  // Stage 2. All three need the release line, and nothing needs the others.
+  const [problems, current, prior] = await Promise.all([
+    discoverAggregate(env, {
+      queryName: "sentry_problems",
+      fields: ISSUE_FIELDS,
+      requiredFields: ISSUE_REQUIRED_META,
+      query: releaseFilter,
+      environment: PROD,
+      start: startISO,
+      end: endISO,
+      sort: "-count_unique(user)",
+      perPage: 100,
+    }, opts),
+    discoverAggregate(env, {
+      queryName: "sentry_headline",
+      fields: HEADLINE_FIELDS,
+      requiredFields: HEADLINE_FIELDS,
+      query: releaseFilter,
+      environment: PROD,
+      start: startISO,
+      end: endISO,
+      perPage: 1,
+    }, opts),
+    discoverAggregate(env, {
+      queryName: "sentry_prior",
+      fields: HEADLINE_FIELDS,
+      requiredFields: HEADLINE_FIELDS,
+      query: releaseFilter,
+      environment: PROD,
+      start: priorStartISO,
+      end: startISO,
+      perPage: 1,
+    }, opts),
+  ]);
+
+  const newShortIds = new Set(newIssues.issues.map((i) => i.shortId));
+
+  const rows = problems.rows.map((row) => {
+    const classified = classifyProblem({
+      category: row["error.category"],
+      level: row.level,
+      title: row.title,
+    });
+    return {
+      shortId: typeof row.issue === "string" ? row.issue : null,
+      people: toCount(row["count_unique(user)"]),
+      events: toCount(row["count()"]),
+      group: classified.group,
+      label: classified.label,
+      deliveryProven: classified.deliveryProven,
+      isNew: typeof row.issue === "string" && newShortIds.has(row.issue),
+    };
+  });
+
+  return {
+    empty: rows.length === 0,
+    reason: rows.length === 0 ? "no-errors" : null,
+    floor: line.floor,
+    tailPeople: line.tailPeople,
+    people: headlineValue(current.rows, "count_unique(user)"),
+    priorPeople: headlineValue(prior.rows, "count_unique(user)"),
+    // Derived, not bought: event counts ARE additive and were verified to sum
+    // exactly to the aggregate. The people total above cannot be derived the
+    // same way, because one person can hit several problems.
+    events: rows.reduce((sum, r) => sum + r.events, 0),
+    rows,
+    // Over-reported rather than under-reported: a full page is treated as
+    // "there may be more" even without a next-page header, because the only
+    // consequence is the section printing its honest limited-breakdown wording.
+    truncated: problems.truncated,
+  };
+}
+
+/** A count that is not a finite number is a defect in the response, not a zero.
+ * Zero is a real and common answer here, so a `|| 0` fallback would make a
+ * malformed row indistinguishable from a quiet day. */
+function toCount(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n < 0) {
+    throw new TypeError(`Sentry returned a non-numeric count: ${String(value)}`);
+  }
+  return n;
+}
+
+/** An aggregate with no grouping returns exactly one row. Zero rows means
+ * Sentry had nothing to aggregate, which is a real zero; anything else is a
+ * shape this code should not be interpreting. */
+function headlineValue(rows, field) {
+  if (rows.length === 0) return 0;
+  if (rows.length !== 1) {
+    throw new TypeError(`Sentry aggregate returned ${rows.length} rows where one was expected`);
+  }
+  return toCount(rows[0][field]);
+}
+
+// ── Presentation ────────────────────────────────────────────────────────────
+
+const people = (n) => `${n} ${n === 1 ? "person" : "people"}`;
+
+/** Character budget for this section's description.
+ *
+ * Discord caps one description at 4096 and ALL embeds together at 6000, and
+ * exceeding either sends NOTHING - the whole report would disappear on exactly
+ * the day Sentry has most to say. A fixed conservative budget per section keeps
+ * that arithmetic true without this module having to know what the other
+ * sections are doing. Rows are rendered while they fit and the remainder is
+ * DISCLOSED, never silently dropped. */
+export const DEFAULT_SECTION_BUDGET = 1200;
+
+/**
+ * The section, as LINES whose FIRST line titles its embed - the same shape every
+ * other section formatter returns, so the payload assembler never authors a
+ * sentence of its own.
+ */
+export function formatSentrySection(data, { title, budget = DEFAULT_SECTION_BUDGET } = {}) {
+  if (typeof title !== "string" || title.length === 0) {
+    throw new TypeError("formatSentrySection requires a title");
+  }
+  const lines = [title];
+
+  if (data.empty && data.reason === "no-release-line") {
+    // Distinct from "no errors": errors existed and could not be scoped to a
+    // release line, which is a measurement failure, not good news.
+    lines.push("Errors were recorded but could not be matched to a release, so they are not summarised here.");
+    return lines;
+  }
+  if (data.empty) {
+    // An EXPLICIT good-news line. An empty section reads as a broken section.
+    lines.push("No errors were recorded on current versions.");
+    return lines;
+  }
+
+  lines.push(
+    `${people(data.people)} hit ${data.events} ${data.events === 1 ? "error" : "errors"} ` +
+      `across ${data.rows.length} ${data.rows.length === 1 ? "problem" : "problems"}, on ${data.floor} and newer.`
+  );
+
+  // The action metric. An absolute count rises with usage, so it cannot answer
+  // "is this spreading", which is the entire reason this section exists.
+  const delta = data.people - data.priorPeople;
+  const direction = delta === 0 ? "the same as" : delta > 0 ? `${delta} more than` : `${-delta} fewer than`;
+  lines.push(`That is ${direction} the previous period (${people(data.priorPeople)}).`);
+  // Never a rate. Sentry and PostHog join only per INSTALL and only partially
+  // (sentry-operations.md RULE: join-sentry-to-posthog-by-install), so dividing
+  // one system's distinct-user count by the other's would be arithmetic across
+  // two identity systems. Saying so is better than inventing a denominator.
+  lines.push("Impact rate unavailable: error counts and usage counts come from different identity systems.");
+
+  if (data.tailPeople > 0) {
+    // "Up to", because these are per-release counts summed across releases and
+    // one person can appear under more than one.
+    lines.push(`Separately, up to ${people(data.tailPeople)} on builds older than ${data.floor}.`);
+  }
+  lines.push("");
+
+  const rows = disambiguate(data.rows);
+  const lost = rows.filter((r) => r.group === LOST);
+  const degraded = rows.filter((r) => r.group === DEGRADED);
+
+  const budgetState = { used: lines.join("\n").length, budget, omitted: 0 };
+  appendGroup(lines, "LOST THE DICTATION", lost, budgetState);
+  appendGroup(lines, "STILL WORKED, JUST WORSE", degraded, budgetState);
+
+  if (budgetState.omitted > 0) {
+    lines.push(
+      `${budgetState.omitted} more ${budgetState.omitted === 1 ? "problem is" : "problems are"} ` +
+        "not listed here. The totals above include them."
+    );
+  }
+  if (data.truncated) {
+    lines.push("100 or more problems were recorded; the breakdown covers the largest 100 only.");
+  }
+  return lines;
+}
+
+/** Appends the Sentry issue id to rows whose labels would otherwise be
+ * identical.
+ *
+ * Two DIFFERENT problems rendering as two identical lines reads as a rendering
+ * bug rather than as two real problems, and a live smoke run produced exactly
+ * that: two distinct `NSInternalInconsistencyException` fingerprints, one
+ * person each. The exception type alone does not separate them.
+ *
+ * Merging them instead was rejected. Event counts would add correctly, but
+ * people counts are NOT additive across issues - the same person can hit both -
+ * so a merged row would have to either overstate the people or invent a number
+ * this data cannot produce. The id is the honest separator, and it is also the
+ * thing the founder would search for.
+ *
+ * Applied across the WHOLE row set before the groups are split, because a
+ * collision can straddle the lost/degraded boundary and would be invisible to a
+ * per-group pass. Rows with no id are left alone: an id-less row cannot be
+ * disambiguated and a bare "(unknown)" would say nothing. */
+function disambiguate(rows) {
+  const counts = new Map();
+  for (const row of rows) counts.set(row.label, (counts.get(row.label) || 0) + 1);
+  return rows.map((row) =>
+    counts.get(row.label) > 1 && row.shortId
+      ? { ...row, label: `${row.label} ${row.shortId}` }
+      : row
+  );
+}
+
+function appendGroup(lines, heading, rows, state) {
+  if (rows.length === 0) return;
+  const headingCost = heading.length + 2;
+  if (state.used + headingCost > state.budget) {
+    state.omitted += rows.length;
+    return;
+  }
+  lines.push(heading);
+  state.used += headingCost;
+  for (const row of rows) {
+    // Appended for every conservative row, so a classification made on missing
+    // evidence never reads as a demonstrated loss. The founder acts on this
+    // list, and "lost the dictation" is a strong claim to make on a category
+    // whose producers disagree.
+    const suffix = row.deliveryProven ? "" : ", delivery not proven";
+    const text = `  ${people(row.people)}   ${row.label}${suffix}${row.isNew ? "   NEW" : ""}`;
+    if (state.used + text.length + 1 > state.budget) {
+      state.omitted += 1;
+      continue;
+    }
+    lines.push(text);
+    state.used += text.length + 1;
+  }
+  lines.push("");
+  state.used += 1;
+}
+
+/** Plain-language unavailable copy, owned here so no integration ever authors
+ * new failure wording. Discloses nothing technical: no error text, URL, status
+ * code or response body. Says nothing was measured, rather than letting a
+ * missing section read as a quiet zero. */
+export function formatSentryUnavailable(title) {
+  if (typeof title !== "string" || title.length === 0) {
+    throw new TypeError("formatSentryUnavailable requires a title");
+  }
+  return [
+    `${title}, unavailable today.`,
+    "Error figures could not be measured, so this is not a report of zero.",
+  ];
+}

--- a/workers/reporting/sentry-section.js
+++ b/workers/reporting/sentry-section.js
@@ -536,6 +536,17 @@ export async function fetchSentrySection(env, window, opts = {}) {
     // "there may be more" even without a next-page header, because the only
     // consequence is the section printing its honest limited-breakdown wording.
     truncated: problems.truncated,
+    // A SEPARATE truncation axis from `truncated` above, and they are not
+    // interchangeable: that one bounds the PROBLEM list, this one bounds the
+    // RELEASE list, and only this one can make the old-build tail understate.
+    //
+    // The FLOOR is safe under it and the tail is not, which is why one flag
+    // cannot serve both. `sentry_releases` sorts by `-count_unique(user)`, so
+    // the release with the most affected people is on the first page by
+    // construction and `resolveReleaseLine` still picks the right winner. The
+    // tail sums releases BELOW that line - precisely the low-count rows a cut
+    // page drops - so it is the half that breaks.
+    releasesTruncated: releaseResult.truncated,
     badgesIncomplete,
   };
 }
@@ -696,7 +707,17 @@ export function formatSentrySection(data, { title, budget: requestedBudget = DEF
   if (data.tailPeople > 0) {
     // "Up to", because these are per-release counts summed across releases and
     // one person can appear under more than one.
-    lines.push(`Separately, up to ${people(data.tailPeople)} on builds older than ${data.floor}.`);
+    //
+    // A TRUNCATED RELEASE PAGE INVERTS THAT BOUND, so the wording cannot stand.
+    // The sum overstates (non-additive people) and a cut-off page understates
+    // (missing old releases), and the two pull opposite ways - so "up to N" is
+    // no longer a claim the data supports in either direction. Say it is
+    // partial instead of picking a bound that might be false.
+    lines.push(
+      data.releasesTruncated
+        ? `Separately, at least ${people(data.tailPeople)} on builds older than ${data.floor}, from a partial release list.`
+        : `Separately, up to ${people(data.tailPeople)} on builds older than ${data.floor}.`
+    );
   }
   lines.push("");
 

--- a/workers/reporting/sentry-section.js
+++ b/workers/reporting/sentry-section.js
@@ -263,11 +263,10 @@ export function resolveReleaseLine(rows) {
     if (version === null) continue;
     if (compareKeys(version, [best[0], best[1], 0]) < 0) {
       const people = countOrNull(row["count_unique(user)"]);
-      if (people !== null) tailPeople += people;
-      // Each addend is a safe integer; their SUM need not be. Past that point
-      // the number is no longer exact, and an inexact person count is worse
-      // than an absent one.
-      if (!Number.isSafeInteger(tailPeople)) return { floor, tailPeople: 0 };
+      // Each addend is a safe integer; their SUM need not be. An earlier
+      // version returned a FABRICATED ZERO on overflow, which is the one answer
+      // this section must never give: it reads as "nobody is on an old build".
+      if (people !== null) tailPeople = addCounts(tailPeople, people, "old-build people total");
     }
   }
   return { floor, tailPeople };
@@ -451,6 +450,21 @@ export async function fetchSentrySection(env, window, opts = {}) {
   // would misclassify issues near either edge.
   const startMs = windowInstant(startISO);
   const endMs = windowInstant(endISO);
+  // A FULL PAGE OF NEW ISSUES MEANS THE BADGE SET IS INCOMPLETE, and that is
+  // disclosed rather than thrown.
+  //
+  // The review prescribed throwing here, which would make the whole section
+  // unavailable. That is the wrong trade: reaching 100 genuinely-new issues in
+  // one window means a catastrophic release, which is precisely when the
+  // ranked problem list is most worth reading. Losing it entirely to protect a
+  // badge inverts the value.
+  //
+  // Disclosure is also what this section already does one layer up: the problem
+  // list discloses its own 100-row ceiling rather than refusing to render. A
+  // guard that behaves one way for problems and the opposite way for badges
+  // would be two policies for one situation.
+  const badgesIncomplete = newIssues.truncated;
+
   const newShortIds = new Set(
     newIssues.issues
       .filter((issue) => {
@@ -487,13 +501,28 @@ export async function fetchSentrySection(env, window, opts = {}) {
     // Derived, not bought: event counts ARE additive and were verified to sum
     // exactly to the aggregate. The people total above cannot be derived the
     // same way, because one person can hit several problems.
-    events: rows.reduce((sum, r) => sum + r.events, 0),
+    events: rows.reduce((sum, r) => addCounts(sum, r.events, "event total"), 0),
     rows,
     // Over-reported rather than under-reported: a full page is treated as
     // "there may be more" even without a next-page header, because the only
     // consequence is the section printing its honest limited-breakdown wording.
     truncated: problems.truncated,
+    badgesIncomplete,
   };
+}
+
+/** Adds two counts and refuses a result that is no longer exact.
+ *
+ * Every addend here is already a validated safe integer, but their SUM need not
+ * be, and past that point the number silently stops being the number. Throwing
+ * costs one unavailable section; publishing costs the founder a figure he has
+ * no way to tell is wrong. */
+function addCounts(left, right, label) {
+  const total = left + right;
+  if (!Number.isSafeInteger(total)) {
+    throw new TypeError(`Sentry ${label} exceeds the safe integer range`);
+  }
+  return total;
 }
 
 /** Parses one of the window's naive ISO instants as UTC.
@@ -583,10 +612,17 @@ export function formatSentrySection(data, { title, budget: requestedBudget = DEF
   if (typeof title !== "string" || title.length === 0) {
     throw new TypeError("formatSentrySection requires a title");
   }
-  // A caller-supplied budget is capped at Discord's own per-description limit.
-  // Without the cap, a generous caller could ask for more than Discord accepts
-  // and the whole payload would be refused at delivery - the failure this
-  // budget exists to prevent, reached through the budget itself.
+  // VALIDATED BEFORE IT IS CAPPED. `NaN` makes every `> budget` comparison
+  // false, so a NaN budget disables every check silently and renders whatever
+  // it likes - measured at 21,824 characters during review. `Math.min` does not
+  // rescue it either, because `Math.min(NaN, 4096)` is NaN.
+  if (typeof requestedBudget !== "number" || !Number.isSafeInteger(requestedBudget) || requestedBudget <= 0) {
+    throw new TypeError("formatSentrySection budget must be a positive safe integer");
+  }
+  // Capped at Discord's own per-description limit. Without the cap a generous
+  // caller could ask for more than Discord accepts and the whole payload would
+  // be refused at delivery - the failure this budget exists to prevent,
+  // reached through the budget itself.
   const budget = Math.min(requestedBudget, DISCORD_EMBED_DESCRIPTION_LIMIT);
   const lines = [title];
 
@@ -594,12 +630,12 @@ export function formatSentrySection(data, { title, budget: requestedBudget = DEF
     // Distinct from "no errors": errors existed and could not be scoped to a
     // release line, which is a measurement failure, not good news.
     lines.push("Errors were recorded but could not be matched to a release, so they are not summarised here.");
-    return lines;
+    return finishSection(lines, budget);
   }
   if (data.empty) {
     // An EXPLICIT good-news line. An empty section reads as a broken section.
     lines.push("No errors were recorded on current versions.");
-    return lines;
+    return finishSection(lines, budget);
   }
 
   // THE TRUNCATED CASE IS A DIFFERENT SENTENCE, not the same one with a note.
@@ -645,25 +681,45 @@ export function formatSentrySection(data, { title, budget: requestedBudget = DEF
   // length of the sentence explaining that it ran out - measured at 24
   // characters over a 1200 budget, which is the shape that eventually pushes an
   // assembled payload past a Discord limit and sends nothing at all.
-  const reserve = omittedLine(data.rows.length, data.truncated).length + 1 + TRUNCATED_LINE.length + 1;
+  const reserve =
+    omittedLine(data.rows.length, data.truncated).length + 1 +
+    TRUNCATED_LINE.length + 1 +
+    BADGES_INCOMPLETE_LINE.length + 1;
   const state = { budget: budget - reserve, omitted: 0 };
   appendGroup(lines, "LOST THE DICTATION", lost, state);
   appendGroup(lines, "STILL WORKED, JUST WORSE", degraded, state);
 
   if (state.omitted > 0) lines.push(omittedLine(state.omitted, data.truncated));
   if (data.truncated) lines.push(TRUNCATED_LINE);
+  // Stated plainly, because an absent badge is indistinguishable from a problem
+  // that is not new, and the reader has no other way to tell.
+  if (data.badgesIncomplete) lines.push(BADGES_INCOMPLETE_LINE);
 
-  // ENFORCES THE ACTUAL OUTPUT, not the counter that produced it. If the
-  // reservation arithmetic above is ever wrong again, this turns a silent
-  // over-budget description into one unavailable SECTION. That is the right
-  // failure direction: an over-budget assembled payload is refused whole by
-  // Discord, which costs the founder the entire report rather than one part.
+  return finishSection(lines, budget);
+}
+
+/** ENFORCES THE ACTUAL OUTPUT, not the counter that produced it, on EVERY exit.
+ *
+ * If the reservation arithmetic is ever wrong again, this turns a silent
+ * over-budget description into one unavailable SECTION. That is the right
+ * failure direction: an over-budget assembled payload is refused whole by
+ * Discord, which costs the founder the entire report rather than one part of
+ * it. Both callers convert this into an unavailable section, never a whole-run
+ * failure.
+ *
+ * Applied at all three returns. Two of them are the short empty-result paths,
+ * whose output is fixed and tiny - which is exactly why it was tempting to skip
+ * them, and exactly why a guard with exceptions is not a guard. */
+function finishSection(lines, budget) {
   const rendered = descriptionLength(lines);
   if (rendered > budget) {
     throw new RangeError(`Sentry section rendered ${rendered} characters, over its ${budget}-character budget`);
   }
   return lines;
 }
+
+const BADGES_INCOMPLETE_LINE =
+  "100 or more problems were seen for the first time in this window, so the NEW marks below are not complete.";
 
 const TRUNCATED_LINE =
   "100 or more problems were recorded. The affected-people total covers all of them; " +
@@ -713,20 +769,26 @@ function disambiguate(rows) {
       : row
   );
 
-  // Second pass, because the first is NOT sufficient and a single pass looked
-  // like it was. Two rows can still collide after it: rows sharing a shortId,
-  // and rows with no shortId at all - both of which render as two identical
-  // lines, which is the exact defect this function exists to prevent. An
-  // ordinal is not informative, but it is honest, and two lines the reader can
-  // tell apart beat two they cannot.
-  const after = new Map();
-  for (const row of withIds) after.set(row.label, (after.get(row.label) || 0) + 1);
-  const seen = new Map();
+  // Second pass, because the first is NOT sufficient: rows sharing a shortId,
+  // and rows with no shortId at all, still collide after it.
+  //
+  // A COUNT-THEN-NUMBER pass is not enough either, and that is the subtle part.
+  // Counting duplicates first and appending an ordinal to each produces a label
+  // that can collide with one already present: `["same", "same", "same (1)"]`
+  // renders two identical `same (1)` lines. Demonstrated by review, not
+  // theorised. So the labels are claimed one at a time against a set of what
+  // has actually been used, and the ordinal advances until the result is free.
+  const used = new Set();
   return withIds.map((row) => {
-    if (after.get(row.label) <= 1) return row;
-    const n = (seen.get(row.label) || 0) + 1;
-    seen.set(row.label, n);
-    return { ...row, label: `${row.label} (${n})` };
+    const base = row.label;
+    let label = base;
+    let ordinal = 1;
+    while (used.has(label)) {
+      label = `${base} (${ordinal})`;
+      ordinal += 1;
+    }
+    used.add(label);
+    return label === base ? row : { ...row, label };
   });
 }
 

--- a/workers/reporting/sentry-section.js
+++ b/workers/reporting/sentry-section.js
@@ -718,8 +718,18 @@ function finishSection(lines, budget) {
   return lines;
 }
 
+/** "MAY not be complete", not "are not".
+ *
+ * `hasMorePages` deliberately treats any full page as "there may be more", even
+ * when exactly 100 complete rows arrived and there is no next page, because a
+ * missing Link header proves nothing. That over-reporting is the right default
+ * - but it means this line cannot assert incompleteness as a fact, only as a
+ * possibility. Every other truncation sentence survives the same scrutiny
+ * ("at least N errors", "100 or more problems", "cover the largest 100 only"
+ * are all true when exactly 100 arrive); this one did not, and was swept for
+ * alongside them rather than fixed alone. */
 const BADGES_INCOMPLETE_LINE =
-  "100 or more problems were seen for the first time in this window, so the NEW marks below are not complete.";
+  "100 or more problems were seen for the first time in this window, so the NEW marks below may not be complete.";
 
 const TRUNCATED_LINE =
   "100 or more problems were recorded. The affected-people total covers all of them; " +

--- a/workers/reporting/sentry-section.js
+++ b/workers/reporting/sentry-section.js
@@ -198,8 +198,10 @@ export function parseReleaseVersion(release) {
   const version = at === -1 ? release : release.slice(at + 1);
   const parts = version.split(".");
   if (parts.length !== 3) return null;
-  const nums = parts.map((p) => (/^\d+$/.test(p) ? Number(p) : null));
-  return nums.some((n) => n === null) ? null : nums;
+  const nums = parts.map((p) => (/^\d+$/.test(p) ? Number(p) : NaN));
+  // Safe integers only. A component past 2^53 loses precision and would
+  // then compare equal to its neighbours, making the ordering arbitrary.
+  return nums.every(Number.isSafeInteger) ? nums : null;
 }
 
 /**
@@ -262,6 +264,10 @@ export function resolveReleaseLine(rows) {
     if (compareKeys(version, [best[0], best[1], 0]) < 0) {
       const people = countOrNull(row["count_unique(user)"]);
       if (people !== null) tailPeople += people;
+      // Each addend is a safe integer; their SUM need not be. Past that point
+      // the number is no longer exact, and an inexact person count is worse
+      // than an absent one.
+      if (!Number.isSafeInteger(tailPeople)) return { floor, tailPeople: 0 };
     }
   }
   return { floor, tailPeople };
@@ -278,13 +284,17 @@ function compareKeys(a, b) {
 
 // ── Queries ─────────────────────────────────────────────────────────────────
 
-/** THE CALL BUDGET, in one place, asserted by a test.
+/** THE MAXIMUM CALL BUDGET, in one place, asserted by a test.
  *
  * FIVE fixed Sentry requests per digest run, whatever the error volume. The
  * plan's original three assumed the release line arrived free and that the
  * headline totals came from the same response as the per-problem rows; neither
  * held, because Discover returns EITHER a grouped result OR an aggregate, never
  * both (measured 2026-08-06).
+ *
+ * FIVE is the MAXIMUM, not a fixed toll. A run that finds no usable release
+ * line stops after its two stage-one calls, because the remaining three cannot
+ * be scoped honestly and an unscoped answer is worse than no answer.
  *
  * The constraint that actually matters is unchanged: NO CALL FANS OUT PER
  * ISSUE, so the count does not move with volume. Measured cost of all five:
@@ -323,16 +333,16 @@ const PROD = "production";
  * work at all.
  */
 export async function fetchSentrySection(env, window, opts = {}) {
-  const { startISO, endISO, priorStartISO, firstSeenPeriod } = window;
-  // firstSeenPeriod is REQUIRED, never defaulted. A default of "24h" would be
-  // correct for the daily report and silently wrong for the weekly digest,
-  // which would then badge only the last day of a seven-day window - an answer
-  // that looks right everywhere a human would look.
+  const { startISO, endISO, priorStartISO } = window;
+  // There is no `firstSeenPeriod` any more. It was a RELATIVE lookback each
+  // caller had to get right ("24h" here, "7d" there), and being caller-supplied
+  // did not make it correct - it was measured against the wrong instant in both
+  // workers. The badge window is now derived from the reported window itself,
+  // so there is nothing left for a caller to get wrong.
   for (const [name, value] of [
     ["startISO", startISO],
     ["endISO", endISO],
     ["priorStartISO", priorStartISO],
-    ["firstSeenPeriod", firstSeenPeriod],
   ]) {
     if (typeof value !== "string" || value.length === 0) {
       throw new TypeError(`fetchSentrySection requires window.${name}`);
@@ -358,10 +368,28 @@ export async function fetchSentrySection(env, window, opts = {}) {
     // is scoped to events MATCHING the query, not to the issue's lifetime, so
     // every still-active problem read as new. ENVIOUSWISPR-24, first seen
     // 2026-07-02, returned a min(timestamp) of today.
+    //
+    // ABSOLUTE, not `firstSeen:-24h`. The relative form is measured from NOW,
+    // and neither report runs at the instant its window closes: the daily one
+    // runs after the Eastern day ends and can be backfilled to any historical
+    // day, the weekly one runs 13 hours after its window. So the relative form
+    // straddles the window in both directions - it excludes part of what is
+    // being reported and includes issues from outside it. Demonstrated on live
+    // data 2026-08-06: `firstSeen:-5d` returned 3 issues where the equivalent
+    // absolute range returned 4, silently dropping one first seen 4 hours
+    // outside the relative cutoff.
+    //
+    // Sentry filters this SERVER-side, which is what keeps the result small:
+    // the same live check returned 3 rows for the absolute range against 45
+    // for an unfiltered window query. That matters because an unfiltered form
+    // would hit the 100-row page cap on any busy week and force a choice
+    // between a wrong badge and a refused section.
     issueList(env, {
       queryName: "sentry_new_issues",
-      query: `firstSeen:-${firstSeenPeriod}`,
+      query: `firstSeen:>=${startISO} firstSeen:<${endISO}`,
       environment: PROD,
+      start: startISO,
+      end: endISO,
       limit: 100,
     }, opts),
   ]);
@@ -415,7 +443,22 @@ export async function fetchSentrySection(env, window, opts = {}) {
     }, opts),
   ]);
 
-  const newShortIds = new Set(newIssues.issues.map((i) => i.shortId));
+  // Belt as well as braces: the query already filters server-side, and this
+  // re-checks the boundary locally so a change in Sentry's search semantics
+  // degrades to a missing badge rather than to a wrong one. `Z` is appended
+  // because the window strings are naive instants that Sentry reads as UTC, and
+  // Date.parse would otherwise read them as LOCAL time - a silent offset that
+  // would misclassify issues near either edge.
+  const startMs = windowInstant(startISO);
+  const endMs = windowInstant(endISO);
+  const newShortIds = new Set(
+    newIssues.issues
+      .filter((issue) => {
+        const firstSeenMs = Date.parse(issue.firstSeen);
+        return firstSeenMs >= startMs && firstSeenMs < endMs;
+      })
+      .map((issue) => issue.shortId)
+  );
 
   const rows = problems.rows.map((row) => {
     const classified = classifyProblem({
@@ -453,6 +496,23 @@ export async function fetchSentrySection(env, window, opts = {}) {
   };
 }
 
+/** Parses one of the window's naive ISO instants as UTC.
+ *
+ * Exported ONLY so this can be tested independently of the machine's timezone.
+ * A test that fed a boundary fixture through the whole section would pass
+ * trivially on a UTC runner and could only ever fail on a developer's machine,
+ * which is the wrong way round.
+ *
+ * The `Z` is the entire point. Sentry reads these strings as UTC, but
+ * `Date.parse` without a zone reads them as LOCAL time - a four or five hour
+ * shift on this machine - and the badge boundary would then be silently offset,
+ * misclassifying every issue first seen near either edge of the window. */
+export function windowInstant(naiveISO) {
+  const ms = Date.parse(`${naiveISO}Z`);
+  if (Number.isNaN(ms)) throw new TypeError(`window instant is not a valid ISO timestamp: ${naiveISO}`);
+  return ms;
+}
+
 /** A count, or null if the value is not one.
  *
  * `Number()` is far too permissive to validate with, and every one of these is
@@ -465,7 +525,7 @@ export async function fetchSentrySection(env, window, opts = {}) {
  * non-negative INTEGER: Sentry counts people and events, and 1.5 people is a
  * response shape this code should refuse rather than round. */
 function countOrNull(value) {
-  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) return null;
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) return null;
   return value;
 }
 
@@ -506,15 +566,28 @@ const people = (n) => `${n} ${n === 1 ? "person" : "people"}`;
  * DISCLOSED, never silently dropped. */
 export const DEFAULT_SECTION_BUDGET = 1200;
 
+/** Discord's own per-description cap. Duplicated as a NUMBER rather than
+ * imported from workers/shared/discord.js on purpose: this module is report
+ * policy and that one is transport, and reaching across the boundary for a
+ * constant is how the boundary stops meaning anything. The value is asserted
+ * against the transport's own DISCORD_LIMITS in the test suite, so the two
+ * cannot drift apart silently. */
+const DISCORD_EMBED_DESCRIPTION_LIMIT = 4096;
+
 /**
  * The section, as LINES whose FIRST line titles its embed - the same shape every
  * other section formatter returns, so the payload assembler never authors a
  * sentence of its own.
  */
-export function formatSentrySection(data, { title, budget = DEFAULT_SECTION_BUDGET } = {}) {
+export function formatSentrySection(data, { title, budget: requestedBudget = DEFAULT_SECTION_BUDGET } = {}) {
   if (typeof title !== "string" || title.length === 0) {
     throw new TypeError("formatSentrySection requires a title");
   }
+  // A caller-supplied budget is capped at Discord's own per-description limit.
+  // Without the cap, a generous caller could ask for more than Discord accepts
+  // and the whole payload would be refused at delivery - the failure this
+  // budget exists to prevent, reached through the budget itself.
+  const budget = Math.min(requestedBudget, DISCORD_EMBED_DESCRIPTION_LIMIT);
   const lines = [title];
 
   if (data.empty && data.reason === "no-release-line") {
@@ -529,10 +602,20 @@ export function formatSentrySection(data, { title, budget = DEFAULT_SECTION_BUDG
     return lines;
   }
 
-  lines.push(
-    `${people(data.people)} hit ${data.events} ${data.events === 1 ? "error" : "errors"} ` +
-      `across ${data.rows.length} ${data.rows.length === 1 ? "problem" : "problems"}, on ${data.floor} and newer.`
-  );
+  // THE TRUNCATED CASE IS A DIFFERENT SENTENCE, not the same one with a note.
+  // `events` is summed from the returned problem rows, so on a truncated page
+  // it EXCLUDES everything past the first hundred: printing it as the error
+  // total understates it, and the old disclosure then said "the totals above
+  // include them", which was flatly untrue. The PEOPLE figure is unaffected -
+  // it comes from an ungrouped aggregate that is never paginated - so only the
+  // error count and the problem count need qualifying.
+  const errorText = data.truncated
+    ? `at least ${data.events} ${data.events === 1 ? "error" : "errors"}`
+    : `${data.events} ${data.events === 1 ? "error" : "errors"}`;
+  const problemText = data.truncated
+    ? "100 or more problems"
+    : `${data.rows.length} ${data.rows.length === 1 ? "problem" : "problems"}`;
+  lines.push(`${people(data.people)} hit ${errorText} across ${problemText}, on ${data.floor} and newer.`);
 
   // The action metric. An absolute count rises with usage, so it cannot answer
   // "is this spreading", which is the entire reason this section exists.
@@ -562,20 +645,36 @@ export function formatSentrySection(data, { title, budget = DEFAULT_SECTION_BUDG
   // length of the sentence explaining that it ran out - measured at 24
   // characters over a 1200 budget, which is the shape that eventually pushes an
   // assembled payload past a Discord limit and sends nothing at all.
-  const reserve = omittedLine(data.rows.length).length + 1 + TRUNCATED_LINE.length + 1;
+  const reserve = omittedLine(data.rows.length, data.truncated).length + 1 + TRUNCATED_LINE.length + 1;
   const state = { budget: budget - reserve, omitted: 0 };
   appendGroup(lines, "LOST THE DICTATION", lost, state);
   appendGroup(lines, "STILL WORKED, JUST WORSE", degraded, state);
 
-  if (state.omitted > 0) lines.push(omittedLine(state.omitted));
+  if (state.omitted > 0) lines.push(omittedLine(state.omitted, data.truncated));
   if (data.truncated) lines.push(TRUNCATED_LINE);
+
+  // ENFORCES THE ACTUAL OUTPUT, not the counter that produced it. If the
+  // reservation arithmetic above is ever wrong again, this turns a silent
+  // over-budget description into one unavailable SECTION. That is the right
+  // failure direction: an over-budget assembled payload is refused whole by
+  // Discord, which costs the founder the entire report rather than one part.
+  const rendered = descriptionLength(lines);
+  if (rendered > budget) {
+    throw new RangeError(`Sentry section rendered ${rendered} characters, over its ${budget}-character budget`);
+  }
   return lines;
 }
 
-const TRUNCATED_LINE = "100 or more problems were recorded; the breakdown covers the largest 100 only.";
+const TRUNCATED_LINE =
+  "100 or more problems were recorded. The affected-people total covers all of them; " +
+  "the error count and the breakdown cover the largest 100 only.";
 
-const omittedLine = (n) =>
-  `${n} more ${n === 1 ? "problem is" : "problems are"} not listed here. The totals above include them.`;
+/** `truncated` changes the CLAIM, not just the wording: when the problem page
+ * was cut off, the totals above genuinely do NOT include the omitted rows, so
+ * the sentence that says they do must not be printed. */
+const omittedLine = (n, truncated) =>
+  `${n} more ${n === 1 ? "problem is" : "problems are"} not listed here.` +
+  (truncated ? "" : " The totals above include them.");
 
 /** The rendered description length, which is every line EXCEPT the title.
  *

--- a/workers/sentry-triage/src/index.js
+++ b/workers/sentry-triage/src/index.js
@@ -20,6 +20,14 @@
  * basic embed when event data is unavailable — an alert is never lost.
  */
 
+// The SHARED Sentry transport, and nothing else from workers/. This worker does
+// NOT import workers/reporting/sentry-section.js: the digest section renders a
+// lost-vs-degraded breakdown this card does not show, over a different window,
+// production-only where this one deliberately keeps dev events. Importing it
+// would add a third independently-deployed consumer of that module without
+// removing any real duplicate authority (#1965).
+import { discoverAggregate } from "../../shared/sentry.js";
+
 const DISCORD_COLOR = { P0: 0xe74c3c, P1: 0xe67e22, P2: 0xf1c40f, P3: 0x95a5a6 };
 const SENTRY_ORG = "envious-labs-llc";
 const SENTRY_FETCH_TIMEOUT_MS = 5000;
@@ -135,10 +143,17 @@ export async function handleTriage(body, env) {
   }
   await env.SENTRY_DEDUP.put(replayKey, "1", { expirationTtl: 5400 }); // 90 min
 
-  // Validate payload shape — skip metric alerts (no data.issue) and malformed payloads
+  // Validate payload shape. Malformed payloads carry no issue and are dropped.
+  //
+  // THIS COMMENT USED TO SAY it skipped metric alerts "(no data.issue)". That
+  // was false, and it mattered: Sentry files every metric-alert firing as an
+  // ISSUE, with `issueCategory: "metric"`, `userCount: 0` and no release. Those
+  // payloads DO carry `data.issue`, so this guard never once fired for them and
+  // every rate alert fell straight through to the ordinary error path, where it
+  // rendered as `What: unknown / Version: unknown / Impact: 0 user(s)` (#1965).
   const issue = payload?.data?.issue;
   if (!issue) {
-    console.log("[sentry-triage] No data.issue — skipping (metric alert or unknown type)");
+    console.log("[sentry-triage] No data.issue — skipping malformed or unknown payload");
     return;
   }
 
@@ -146,6 +161,14 @@ export async function handleTriage(body, env) {
   const issueId = issue.id ?? "";
   if (!issueId) {
     console.error("[sentry-triage] Missing issue ID, skipping");
+    return;
+  }
+
+  // Rate alerts take a DIFFERENT path entirely, before any of the error-issue
+  // policy below. Scoring one as an error is what produced the empty card: it
+  // has no user count to score, no release to scope to, and no category to name.
+  if (isMetricIssue(issue)) {
+    await handleSpike({ issue, issueId, env, lookupDeadlineAt, operationDeadlineAt, now: startedAt });
     return;
   }
 
@@ -417,6 +440,231 @@ export function classifySeverity(userCount, timesSeen, level) {
   return "P3";
 }
 
+// ── Rate-alert (spike) path (#1965) ────────────────────────────────────────────
+
+/** Sentry files each metric-alert firing as an issue. `issueCategory` is the
+ * documented discriminator; `issueType` is checked too because a payload
+ * carrying one and not the other is exactly the ambiguity that should take the
+ * safe path rather than be guessed at. */
+export function isMetricIssue(issue) {
+  return issue?.issueCategory === "metric" || issue?.issueType === "metric_issue";
+}
+
+/** SIX HOURS, fixed, on a key of its own.
+ *
+ * NOT inherited from THROTTLE_HOURS. That table is keyed by PRIORITY, and a
+ * metric issue whose count has passed 20 scores P1 and then flips to
+ * `substatus: "regressed"` on every single firing - which hits rule 7's
+ * explicit regression bypass and would post every time, throttle or no. The
+ * generic policy cannot deliver a six-hour gap for this shape, so this is new
+ * policy rather than a free inheritance. An earlier draft of the plan claimed
+ * otherwise and contradicted itself two sections later. */
+const SPIKE_THROTTLE_HOURS = 6;
+
+/** Its own namespace, so a rate alert and an error issue can never collide on a
+ * key or evict each other's window. */
+const spikeKey = (issueId) => `spike:${issueId}`;
+
+/** ONE Sentry call. Grouped by issue AND release AND environment, because that
+ * single response answers all three questions the card asks - which problems,
+ * which versions, and how much of it is the founder's own dev machine - and a
+ * separate call per question would be three round trips inside a webhook
+ * deadline for data Sentry will hand over at once.
+ *
+ * DEV EVENTS ARE KEPT. The digests force production-only; this one must not.
+ * The alert rules have `environment: null` by founder decision (2026-08-06):
+ * dev events feed the same counters deliberately, because they prove the
+ * pipeline is alive. The card's job is to SHOW the split, not to hide it. */
+async function fetchSpikeBreakdown(env, deadlineAt) {
+  return discoverAggregate(
+    { ...env, SENTRY_ORG },
+    {
+      queryName: "spike_breakdown",
+      fields: ["issue", "title", "error.category", "release", "environment", "count()", "count_unique(user)"],
+      requiredFields: ["error.category", "count()", "count_unique(user)"],
+      statsPeriod: "1h",
+      sort: "-count()",
+      perPage: 100,
+    },
+    { workerLabel: "sentry_triage", deadlineAt, requestTimeoutMs: SENTRY_FETCH_TIMEOUT_MS }
+  );
+}
+
+/**
+ * Reduces the grouped rows to the card's four numbers.
+ *
+ * EVENTS ARE THE UNIT, deliberately, and every total below is a sum of event
+ * counts. Event counts ARE additive across rows; distinct-user counts are NOT,
+ * because the same person appears under several (issue, release, environment)
+ * rows. Summing them would produce a confident number that is simply wrong, so
+ * per-problem people is reported as the largest single row - a genuine LOWER
+ * bound - and worded as "at least". This is also the right unit on its own
+ * terms: the rule that fires this card counts errors per hour.
+ */
+export function summarizeSpike(rows) {
+  const byProblem = new Map();
+  const releases = new Set();
+  let totalEvents = 0;
+  let devEvents = 0;
+
+  for (const row of rows) {
+    const events = Number(row["count()"]);
+    const people = Number(row["count_unique(user)"]);
+    if (!Number.isFinite(events) || events < 0) continue;
+    totalEvents += events;
+
+    // Anything not explicitly production counts as dev here. The split exists
+    // to stop a founder's own testing reading as a user-facing incident, so the
+    // conservative direction is to attribute an unlabelled event to dev rather
+    // than to real users.
+    if (row.environment !== "production") devEvents += events;
+
+    const category = typeof row["error.category"] === "string" ? row["error.category"].trim() : "";
+    const label = category || (typeof row.title === "string" ? row.title.split(":", 1)[0].trim() : "") || "uncategorised";
+    const existing = byProblem.get(label) || { label, events: 0, atLeastPeople: 0 };
+    existing.events += events;
+    if (Number.isFinite(people)) existing.atLeastPeople = Math.max(existing.atLeastPeople, people);
+    byProblem.set(label, existing);
+
+    if (typeof row.release === "string" && row.release.length > 0) {
+      releases.add(displayVersion(row.release));
+    }
+  }
+
+  return {
+    totalEvents,
+    devEvents,
+    realEvents: totalEvents - devEvents,
+    problems: [...byProblem.values()].sort((a, b) => b.events - a.events),
+    releases: [...releases].sort(),
+  };
+}
+
+const SPIKE_PROBLEM_ROWS = 5;
+
+/** The card. Names the problems, the versions and the dev split, which is
+ * everything the old card could not say. */
+export function buildSpikeEmbed(summary, { issueId, title, permalink }) {
+  const top = summary.problems.slice(0, SPIKE_PROBLEM_ROWS);
+  const remainder = summary.problems.length - top.length;
+  const lines = top.map(
+    (p) => `${p.events} × ${p.label} (at least ${p.atLeastPeople} ${p.atLeastPeople === 1 ? "person" : "people"})`
+  );
+  if (remainder > 0) lines.push(`plus ${remainder} more, included in the total`);
+
+  return {
+    // Says what it measured, not what the rule happens to be called. The three
+    // old rules asserted diagnoses their `count()` query could not make.
+    title: `[Sentry Spike] ${summary.totalEvents} errors in the last hour`,
+    color: DISCORD_COLOR.P1,
+    fields: [
+      {
+        name: "Real vs dev",
+        value: `${summary.realEvents} from real users, ${summary.devEvents} from dev builds`,
+        inline: true,
+      },
+      {
+        name: "Versions",
+        value: truncate(summary.releases.length ? summary.releases.join(", ") : "unknown"),
+        inline: true,
+      },
+      { name: "Alert", value: `[${issueId}](${permalink})`, inline: true },
+      {
+        name: "What is driving it",
+        value: truncate(lines.length ? lines.join("\n") : "no breakdown available", 900),
+        inline: false,
+      },
+    ],
+    footer: { text: `EnviousWispr Sentry Triage. Rate alert, ${SPIKE_THROTTLE_HOURS}h between posts` },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+/** Fail-open card. A rate alert that cannot be enriched is still worth one
+ * buzz: the founder learns the rule fired, and learns explicitly that the
+ * breakdown is missing rather than being shown a confident empty one. */
+export function buildSpikeFailOpenEmbed({ issueId, title, permalink }) {
+  return {
+    title: `[Sentry Spike] ${truncate(title || "error rate alert fired")}`,
+    color: DISCORD_COLOR.P1,
+    fields: [
+      { name: "Alert", value: `[${issueId}](${permalink})`, inline: true },
+      {
+        name: "Breakdown",
+        value: "Unavailable. The rule fired, but the hourly breakdown could not be read from Sentry.",
+        inline: false,
+      },
+    ],
+    footer: { text: `EnviousWispr Sentry Triage. Rate alert, ${SPIKE_THROTTLE_HOURS}h between posts` },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+/** Pure, so the whole policy is testable without a KV or a network. */
+export function decideSpike({ throttleLookup, now }) {
+  // A throttle READ failure fails open, exactly as rule 6 does for errors:
+  // never let an unavailable KV suppress a real signal.
+  if (throttleLookup?.status !== "complete") {
+    return { post: true, reason: "throttle-unavailable-failopen" };
+  }
+  const stored = throttleLookup.value;
+  if (stored == null) return { post: true, reason: "no-throttle" };
+  const elapsedMs = now - stored.lastNotifiedAt;
+  if (elapsedMs < SPIKE_THROTTLE_HOURS * 3600_000) {
+    return { post: false, reason: "throttled" };
+  }
+  return { post: true, reason: "throttle-expired" };
+}
+
+async function handleSpike({ issue, issueId, env, lookupDeadlineAt, operationDeadlineAt, now }) {
+  const kvKey = spikeKey(issueId);
+  const decision = decideSpike({ throttleLookup: await readThrottle(env, kvKey), now });
+  if (!decision.post) {
+    console.log(`[sentry-triage] Spike ${issueId} suppressed (${decision.reason})`);
+    return;
+  }
+
+  const title = issue.title ?? "";
+  const permalink = issue.permalink ?? issue.web_url ?? "";
+
+  let embed;
+  try {
+    const { rows } = await fetchSpikeBreakdown(env, lookupDeadlineAt);
+    const summary = summarizeSpike(rows);
+    // A spike whose breakdown is empty is not a spike anybody can act on, and
+    // the enriched card would read "0 errors in the last hour" beside an alert
+    // saying the opposite. Fail open to the honest card instead.
+    embed = summary.totalEvents > 0
+      ? buildSpikeEmbed(summary, { issueId, title, permalink })
+      : buildSpikeFailOpenEmbed({ issueId, title, permalink });
+  } catch (err) {
+    console.warn(`[sentry-triage] Spike ${issueId} breakdown unavailable: ${err.message}`);
+    embed = buildSpikeFailOpenEmbed({ issueId, title, permalink });
+  }
+
+  const result = await postDiscord(env.DISCORD_WEBHOOK_URL, embed, {
+    issueId,
+    deadlineAt: operationDeadlineAt,
+  });
+  if (!result.ok) {
+    // Same transport-commit invariant as the error path: no confirmed delivery,
+    // no throttle, so the next firing stays eligible.
+    console.warn(`[sentry-triage] Spike ${issueId} NOT delivered after ${result.attempts} attempt(s), no throttle written`);
+    return;
+  }
+
+  try {
+    await env.SENTRY_DEDUP.put(
+      kvKey,
+      JSON.stringify({ lastNotifiedAt: now, priority: "spike" }),
+      { expirationTtl: KV_TTL_SECONDS }
+    );
+  } catch (err) {
+    console.error(`[sentry-triage] Spike throttle write failed for ${issueId}:`, err.message);
+  }
+  console.log(`[sentry-triage] Spike ${issueId} posted (${decision.reason})`);
+}
+
 // ── Data acquisition (§3.2) ─────────────────────────────────────────────────────
 
 /**
@@ -613,10 +861,19 @@ async function readThrottle(env, kvKey) {
   if (!("lastNotifiedAt" in parsed)) return { status: "complete", value: null };
 
   const { lastNotifiedAt, priority } = parsed;
+  // "spike" joins the four priorities because the rate-alert path stores its
+  // window through this same reader (#1965). Without it, every spike record
+  // read back as MALFORMED, decideSpike fell open, and the six-hour throttle
+  // never once applied - which is the exact triple-buzz this was built to stop.
+  // Caught by its own test rather than in production.
+  //
+  // The two record kinds cannot be confused: error windows live under
+  // `sentry:<id>` and spike windows under `spike:<id>`, so neither path can
+  // ever read the other's value however this list grows.
   if (
     typeof lastNotifiedAt !== "number" ||
     !Number.isFinite(lastNotifiedAt) ||
-    !["P0", "P1", "P2", "P3"].includes(priority)
+    !["P0", "P1", "P2", "P3", "spike"].includes(priority)
   ) {
     return { status: "malformed" };
   }

--- a/workers/sentry-triage/src/index.js
+++ b/workers/sentry-triage/src/index.js
@@ -477,6 +477,25 @@ const SPIKE_THROTTLE_HOURS = 6;
  * key or evict each other's window. */
 const spikeKey = (issueId) => `spike:${issueId}`;
 
+/** The breakdown must describe the SAME population the rule counted, or the
+ * card explains a firing with numbers that did not cause it.
+ *
+ * VERBATIM from the live rules, re-queried 2026-08-06 rather than read from
+ * notes: 415417 "Error Spike (>5/hr)", 415418 "XPC Service Crash (>1/hr)" and
+ * 415419 "AI Failure Spike (>3/hr)" are all `count()` over `is:unresolved` on a
+ * 60-minute window. Copy the string; do not improve on it. A cleverer predicate
+ * that is merely equivalent today drifts the moment Sentry changes what
+ * `is:unresolved` covers, and the card would then be confidently wrong rather
+ * than obviously stale.
+ *
+ * Measured overcount at the time of writing: ZERO resolved-issue events over
+ * both 24h and 7d, so this corrects a mechanism rather than a live wrong
+ * number. It is still worth having, because the failure is silent - an inflated
+ * card looks exactly like a real spike - and because #1965 collapses the three
+ * rules to one, after which any drift between rule and card has a single place
+ * to go wrong. If that surviving rule's query is ever edited, edit this too. */
+const SPIKE_RULE_PREDICATE = "is:unresolved";
+
 /** ONE Sentry call. Grouped by issue AND release AND environment, because that
  * single response answers all three questions the card asks - which problems,
  * which versions, and how much of it is the founder's own dev machine - and a
@@ -486,7 +505,15 @@ const spikeKey = (issueId) => `spike:${issueId}`;
  * DEV EVENTS ARE KEPT. The digests force production-only; this one must not.
  * The alert rules have `environment: null` by founder decision (2026-08-06):
  * dev events feed the same counters deliberately, because they prove the
- * pipeline is alive. The card's job is to SHOW the split, not to hide it. */
+ * pipeline is alive. The card's job is to SHOW the split, not to hide it.
+ *
+ * BUT THE RESOLVED FILTER IS NOT OPTIONAL, and for the opposite reason. This
+ * card exists to explain ONE firing, so it must describe the population that
+ * actually triggered it. All three metric rules count `is:unresolved` (see
+ * SPIKE_RULE_PREDICATE), so an unfiltered breakdown can attribute the firing to
+ * problems already resolved and inflate both the headline total and the
+ * real-versus-dev split. Environment is widened deliberately; resolution status
+ * is matched deliberately. They are different axes and pull opposite ways. */
 async function fetchSpikeBreakdown(env, deadlineAt) {
   return discoverAggregate(
     { ...env, SENTRY_ORG },
@@ -494,6 +521,7 @@ async function fetchSpikeBreakdown(env, deadlineAt) {
       queryName: "spike_breakdown",
       fields: ["issue", "title", "error.category", "release", "environment", "count()", "count_unique(user)"],
       requiredFields: ["error.category", "count()", "count_unique(user)"],
+      query: SPIKE_RULE_PREDICATE,
       statsPeriod: "1h",
       sort: "-count()",
       perPage: 100,

--- a/workers/sentry-triage/src/index.js
+++ b/workers/sentry-triage/src/index.js
@@ -508,22 +508,26 @@ export function summarizeSpike(rows) {
   let devEvents = 0;
 
   for (const row of rows) {
-    const events = Number(row["count()"]);
-    const people = Number(row["count_unique(user)"]);
-    if (!Number.isFinite(events) || events < 0) continue;
-    totalEvents += events;
+    // THROWS rather than skipping. An earlier version skipped a malformed row
+    // and carried on, which left a PARTIAL sum being published as "N errors in
+    // the last hour" with nothing marking it short. The caller turns this into
+    // the fail-open card, which says the breakdown could not be read - honest,
+    // and still one buzz.
+    const events = requireSpikeCount(row["count()"], "event count");
+    const people = requireSpikeCount(row["count_unique(user)"], "people count");
+    totalEvents = addSpikeCounts(totalEvents, events, "event total");
 
     // Anything not explicitly production counts as dev here. The split exists
     // to stop a founder's own testing reading as a user-facing incident, so the
     // conservative direction is to attribute an unlabelled event to dev rather
     // than to real users.
-    if (row.environment !== "production") devEvents += events;
+    if (row.environment !== "production") devEvents = addSpikeCounts(devEvents, events, "dev-event total");
 
     const category = typeof row["error.category"] === "string" ? row["error.category"].trim() : "";
     const label = category || (typeof row.title === "string" ? row.title.split(":", 1)[0].trim() : "") || "uncategorised";
     const existing = byProblem.get(label) || { label, events: 0, atLeastPeople: 0 };
-    existing.events += events;
-    if (Number.isFinite(people)) existing.atLeastPeople = Math.max(existing.atLeastPeople, people);
+    existing.events = addSpikeCounts(existing.events, events, "problem-event total");
+    existing.atLeastPeople = Math.max(existing.atLeastPeople, people);
     byProblem.set(label, existing);
 
     if (typeof row.release === "string" && row.release.length > 0) {
@@ -538,6 +542,25 @@ export function summarizeSpike(rows) {
     problems: [...byProblem.values()].sort((a, b) => b.events - a.events),
     releases: [...releases].sort(),
   };
+}
+
+/** Same discipline as the digest section, for the same reason: `Number()`
+ * accepts `null`, `""`, `false`, `[]` and `["7"]`, and every one of those would
+ * become a plausible figure in a card the founder acts on. */
+function requireSpikeCount(value, field) {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    throw new TypeError(`Sentry spike breakdown returned an invalid ${field}`);
+  }
+  return value;
+}
+
+/** Each addend is a safe integer; their sum need not be. */
+function addSpikeCounts(left, right, field) {
+  const total = left + right;
+  if (!Number.isSafeInteger(total)) {
+    throw new TypeError(`Sentry spike breakdown ${field} exceeded the safe integer range`);
+  }
+  return total;
 }
 
 const SPIKE_PROBLEM_ROWS = 5;
@@ -629,12 +652,17 @@ async function handleSpike({ issue, issueId, env, lookupDeadlineAt, operationDea
 
   let embed;
   try {
-    const { rows } = await fetchSpikeBreakdown(env, lookupDeadlineAt);
-    const summary = summarizeSpike(rows);
-    // A spike whose breakdown is empty is not a spike anybody can act on, and
-    // the enriched card would read "0 errors in the last hour" beside an alert
-    // saying the opposite. Fail open to the honest card instead.
-    embed = summary.totalEvents > 0
+    const breakdown = await fetchSpikeBreakdown(env, lookupDeadlineAt);
+    // A FULL PAGE means the sum is short, and the card's headline states an
+    // exact count. Unlike the digest - which discloses its ceiling in a list the
+    // founder is already reading - this card's whole content IS the number, so
+    // there is nothing left to qualify. Fail open instead of publishing a
+    // partial total as exact.
+    const summary = breakdown.truncated ? null : summarizeSpike(breakdown.rows);
+    // An empty breakdown is the same problem from the other end: the enriched
+    // card would read "0 errors in the last hour" beside an alert that fired
+    // because there were more than five.
+    embed = summary && summary.totalEvents > 0
       ? buildSpikeEmbed(summary, { issueId, title, permalink })
       : buildSpikeFailOpenEmbed({ issueId, title, permalink });
   } catch (err) {

--- a/workers/sentry-triage/src/index.js
+++ b/workers/sentry-triage/src/index.js
@@ -167,8 +167,20 @@ export async function handleTriage(body, env) {
   // Rate alerts take a DIFFERENT path entirely, before any of the error-issue
   // policy below. Scoring one as an error is what produced the empty card: it
   // has no user count to score, no release to scope to, and no category to name.
+  //
+  // BEING FIRST MEANS IT SKIPS THE TERMINAL-ACTION GUARDS BELOW, so the spike
+  // path carries its own action eligibility rather than inheriting theirs by
+  // placement. Cloud review caught this: a metric issue arriving as `resolved`,
+  // `archived` or `assigned` reached handleSpike and would buzz whenever the
+  // six-hour throttle happened to be absent or expired - a Discord post saying
+  // errors are spiking, sent because the alert had just been RESOLVED.
+  //
+  // Fixed in the policy rather than by moving this branch below the guards.
+  // Placement is not a contract: the next edit that reorders these blocks would
+  // silently reopen it, and `decideSpike` is where a reader looks for what the
+  // spike path does.
   if (isMetricIssue(issue)) {
-    await handleSpike({ issue, issueId, env, lookupDeadlineAt, operationDeadlineAt, now: startedAt });
+    await handleSpike({ action, issue, issueId, env, lookupDeadlineAt, operationDeadlineAt, now: startedAt });
     return;
   }
 
@@ -624,7 +636,19 @@ export function buildSpikeFailOpenEmbed({ issueId, title, permalink }) {
 }
 
 /** Pure, so the whole policy is testable without a KV or a network. */
-export function decideSpike({ throttleLookup, now }) {
+export function decideSpike({ action, throttleLookup, now }) {
+  // ELIGIBILITY FIRST, mirroring rule 1 for error issues. Only a firing posts:
+  // `created`, or `unresolved` when Sentry reopens the metric issue on the next
+  // breach. Everything else - `resolved`, `archived`, `assigned` - is somebody
+  // tidying up, and a spike card sent because an alert was RESOLVED is worse
+  // than no card at all.
+  //
+  // Checked BEFORE the throttle, so an ineligible action costs no KV read and
+  // cannot be rescued by a fail-open throttle path.
+  if (action !== "created" && action !== "unresolved") {
+    return { post: false, reason: "ineligible-action" };
+  }
+
   // A throttle READ failure fails open, exactly as rule 6 does for errors:
   // never let an unavailable KV suppress a real signal.
   if (throttleLookup?.status !== "complete") {
@@ -639,9 +663,16 @@ export function decideSpike({ throttleLookup, now }) {
   return { post: true, reason: "throttle-expired" };
 }
 
-async function handleSpike({ issue, issueId, env, lookupDeadlineAt, operationDeadlineAt, now }) {
+async function handleSpike({ action, issue, issueId, env, lookupDeadlineAt, operationDeadlineAt, now }) {
   const kvKey = spikeKey(issueId);
-  const decision = decideSpike({ throttleLookup: await readThrottle(env, kvKey), now });
+  // The eligibility check inside decideSpike needs no KV read, so an ineligible
+  // action is decided before one is spent.
+  const eligibility = decideSpike({ action, throttleLookup: null, now });
+  if (!eligibility.post && eligibility.reason === "ineligible-action") {
+    console.log(`[sentry-triage] Spike ${issueId} ${action} — no post`);
+    return;
+  }
+  const decision = decideSpike({ action, throttleLookup: await readThrottle(env, kvKey), now });
   if (!decision.post) {
     console.log(`[sentry-triage] Spike ${issueId} suppressed (${decision.reason})`);
     return;

--- a/workers/sentry-triage/test/spike.test.js
+++ b/workers/sentry-triage/test/spike.test.js
@@ -33,9 +33,9 @@ function fakeKV(seed = {}) {
 /** The real shape Sentry sends for a metric-alert firing: issueCategory
  * "metric", userCount 0, no release, no error.category. Every one of those is
  * why scoring it as an error produced the empty card. */
-function metricPayload(overrides = {}) {
+function metricPayload(overrides = {}, action = "created") {
   return JSON.stringify({
-    action: "created",
+    action,
     data: {
       issue: {
         id: "7654321",
@@ -141,18 +141,18 @@ test("a metric payload DOES carry data.issue, which is why the old guard never f
 // ── Throttle policy ─────────────────────────────────────────────────────────
 
 test("decideSpike enforces six hours on its own key, ignoring priority and regression", () => {
-  assert.equal(decideSpike({ throttleLookup: { status: "complete", value: null }, now: NOW }).post, true);
+  assert.equal(decideSpike({ action: "created", throttleLookup: { status: "complete", value: null }, now: NOW }).post, true);
 
   const fresh = { status: "complete", value: { lastNotifiedAt: NOW - 5 * HOUR, priority: "spike" } };
-  assert.equal(decideSpike({ throttleLookup: fresh, now: NOW }).post, false);
+  assert.equal(decideSpike({ action: "created", throttleLookup: fresh, now: NOW }).post, false);
 
   const expired = { status: "complete", value: { lastNotifiedAt: NOW - 6 * HOUR, priority: "spike" } };
-  assert.equal(decideSpike({ throttleLookup: expired, now: NOW }).post, true);
+  assert.equal(decideSpike({ action: "created", throttleLookup: expired, now: NOW }).post, true);
 });
 
 test("a throttle READ failure fails open, exactly as the error path does", () => {
   for (const status of ["unavailable", "malformed", undefined]) {
-    const r = decideSpike({ throttleLookup: { status }, now: NOW });
+    const r = decideSpike({ action: "created", throttleLookup: { status }, now: NOW });
     assert.equal(r.post, true, `status ${status} must not suppress`);
     assert.equal(r.reason, "throttle-unavailable-failopen");
   }
@@ -429,4 +429,53 @@ test("the card truncates a runaway breakdown instead of exceeding Discord's fiel
     assert.ok(field.value.length <= 1024, `field ${field.name} is ${field.value.length} chars, over Discord's 1024 limit`);
   }
   assert.ok(embed.title.length <= 256);
+});
+
+test("a terminal action never posts a spike card", async () => {
+  // The spike branch runs BEFORE the terminal-action guards, so it carries its
+  // own eligibility rather than inheriting theirs by placement. Without it, a
+  // metric issue arriving as `resolved` would buzz whenever the six-hour
+  // throttle happened to be absent or expired: a Discord post saying errors are
+  // spiking, sent because the alert had just been RESOLVED. Cloud review, #1968.
+  for (const action of ["resolved", "archived", "assigned", "ignored", ""]) {
+    const h = harness();
+    try {
+      await handleTriage(metricPayload({}, action), h.env);
+      assert.equal(h.embeds.length, 0, `${action} must not post`);
+      assert.equal(h.requests.length, 0, `${action} must not spend a Sentry call`);
+      assert.equal(h.kv.store.has("spike:7654321"), false, `${action} must not write a throttle`);
+    } finally {
+      h.restore();
+    }
+  }
+});
+
+test("both firing actions DO post", async () => {
+  // Two-way control. Eligibility that refused everything would satisfy the test
+  // above while silently disabling the whole card.
+  for (const action of ["created", "unresolved"]) {
+    const h = harness();
+    try {
+      await handleTriage(metricPayload({}, action), h.env);
+      assert.equal(h.embeds.length, 1, `${action} must post`);
+    } finally {
+      h.restore();
+    }
+  }
+});
+
+test("an ineligible action is decided without spending a KV read", async () => {
+  // Cheap, and it also means a fail-open throttle path cannot rescue an action
+  // that was never eligible.
+  let reads = 0;
+  const kv = fakeKV();
+  const counting = { ...kv, async get(key) { reads += 1; return kv.get(key); } };
+  const h = harness({ kv: counting });
+  try {
+    await handleTriage(metricPayload({}, "resolved"), h.env);
+    // One read is the replay-protection lookup that runs before any policy.
+    assert.equal(reads, 1, "no throttle read for an ineligible action");
+  } finally {
+    h.restore();
+  }
 });

--- a/workers/sentry-triage/test/spike.test.js
+++ b/workers/sentry-triage/test/spike.test.js
@@ -221,13 +221,61 @@ test("an unlabelled environment counts as dev, the conservative direction", () =
   assert.equal(s.realEvents, 0);
 });
 
-test("summarizeSpike skips a malformed count rather than treating it as zero", () => {
-  const s = summarizeSpike([
-    row("EW-1", "asr_failed", "com.enviouswispr.app@2.4.3", "production", "lots", 1),
-    row("EW-2", "paste_failed", "com.enviouswispr.app@2.4.3", "production", 3, 1),
-  ]);
-  assert.equal(s.totalEvents, 3, "a malformed row contributes nothing, and never a fabricated 0 total");
-  assert.equal(s.problems.length, 1);
+test("a malformed count is refused, never skipped into a partial total", () => {
+  // Skipping the row and carrying on left a PARTIAL sum being published as
+  // "N errors in the last hour" with nothing marking it short. Number() also
+  // accepts null, "", false, [] and ["7"], any of which would become a
+  // plausible figure on a card the founder acts on.
+  for (const bad of ["lots", null, "", false, [], ["7"], 1.5, -1, "3", {}]) {
+    assert.throws(
+      () => summarizeSpike([row("EW-1", "asr_failed", "com.enviouswispr.app@2.4.3", "production", bad, 1)]),
+      TypeError,
+      `event count ${JSON.stringify(bad)} must be refused`
+    );
+    assert.throws(
+      () => summarizeSpike([row("EW-1", "asr_failed", "com.enviouswispr.app@2.4.3", "production", 3, bad)]),
+      TypeError,
+      `people count ${JSON.stringify(bad)} must be refused`
+    );
+  }
+  // Two-way: a genuine zero is a real answer and is accepted.
+  assert.equal(summarizeSpike([row("EW-1", "asr_failed", "com.enviouswispr.app@2.4.3", "production", 0, 0)]).totalEvents, 0);
+});
+
+test("a malformed breakdown buzzes once with the honest card, never a partial total", async () => {
+  const h = harness({ sentry: () => sentryResponse([row("EW-1", "asr_failed", "app@2.4.3", "production", "lots", 1)]) });
+  try {
+    await handleTriage(metricPayload(), h.env);
+    assert.equal(h.embeds.length, 1);
+    assert.match(JSON.stringify(h.embeds[0]), /breakdown could not be read/);
+  } finally {
+    h.restore();
+  }
+});
+
+test("a FULL page fails open rather than publishing a short total as exact", async () => {
+  // The card's whole content is the number, so unlike the digest there is
+  // nothing left to qualify with a disclosure line.
+  const many = Array.from({ length: 100 }, (_, i) =>
+    row(`EW-${i}`, "asr_failed", "com.enviouswispr.app@2.4.3", "production", 5, 1));
+  const h = harness({ sentry: () => sentryResponse(many) });
+  try {
+    await handleTriage(metricPayload(), h.env);
+    assert.equal(h.embeds.length, 1);
+    assert.doesNotMatch(h.embeds[0].title, /500 errors/, "a short sum must not be published as exact");
+    assert.match(JSON.stringify(h.embeds[0]), /breakdown could not be read/);
+  } finally {
+    h.restore();
+  }
+});
+
+test("a page just under the ceiling still renders the enriched card", () => {
+  // Two-way control for the truncation rule: 99 rows is a complete answer and
+  // must NOT fail open, or a busy-but-readable hour would lose its breakdown.
+  const many = Array.from({ length: 99 }, (_, i) =>
+    row(`EW-${i}`, "asr_failed", "com.enviouswispr.app@2.4.3", "production", 5, 1));
+  const s = summarizeSpike(many);
+  assert.equal(s.totalEvents, 495);
 });
 
 test("a blank category falls back to the title's type, never to an empty label", () => {

--- a/workers/sentry-triage/test/spike.test.js
+++ b/workers/sentry-triage/test/spike.test.js
@@ -343,6 +343,26 @@ test("the spike costs exactly ONE Sentry call and keeps dev events", async () =>
   }
 });
 
+test("the breakdown counts the same population the rule counted", async () => {
+  // The card explains ONE firing, so it has to describe what triggered it. All
+  // three live metric rules are `count()` over `is:unresolved` (re-queried
+  // 2026-08-06). Unfiltered, the breakdown can attribute the firing to problems
+  // already resolved and inflate both the headline total and the dev split.
+  const h = harness();
+  try {
+    await handleTriage(metricPayload(), h.env);
+    const url = decodeURIComponent(
+      h.requests.find((u) => u.startsWith("https://us.sentry.io"))
+    );
+    assert.match(url, /query=is:unresolved/, "matches the rule predicate verbatim");
+    // Two-way: the resolution filter must not have quietly narrowed the
+    // environment axis, which is widened ON PURPOSE and pulls the other way.
+    assert.doesNotMatch(url, /environment=/, "still counts dev events");
+  } finally {
+    h.restore();
+  }
+});
+
 test("a Sentry failure still buzzes once, and says the breakdown is missing", async () => {
   const h = harness({
     sentry: () => ({ ok: false, status: 403, headers: { get: () => null }, body: { cancel: async () => {} } }),

--- a/workers/sentry-triage/test/spike.test.js
+++ b/workers/sentry-triage/test/spike.test.js
@@ -1,0 +1,372 @@
+// Tests for the rate-alert (spike) path, issue #1965.
+// Run: node --test  (from workers/sentry-triage/)
+//
+// The end-to-end cases drive the REAL `handleTriage` entry point with a real
+// metric-issue payload, rather than calling the spike helpers directly. A
+// harness that reassembled the flow would prove only that the copy works, and
+// the whole defect being fixed here is that a metric payload took the WRONG
+// branch inside that entry point.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  handleTriage,
+  isMetricIssue,
+  decideSpike,
+  summarizeSpike,
+  buildSpikeEmbed,
+  buildSpikeFailOpenEmbed,
+} from "../src/index.js";
+
+const NOW = 1_800_000_000_000;
+const HOUR = 3600_000;
+
+function fakeKV(seed = {}) {
+  const store = new Map(Object.entries(seed));
+  return {
+    store,
+    async get(key) { return store.get(key) ?? null; },
+    async put(key, value) { store.set(key, value); },
+    async delete(key) { store.delete(key); },
+  };
+}
+
+/** The real shape Sentry sends for a metric-alert firing: issueCategory
+ * "metric", userCount 0, no release, no error.category. Every one of those is
+ * why scoring it as an error produced the empty card. */
+function metricPayload(overrides = {}) {
+  return JSON.stringify({
+    action: "created",
+    data: {
+      issue: {
+        id: "7654321",
+        shortId: "ENVIOUSWISPR-1H",
+        title: "Errors above 5 an hour",
+        permalink: "https://envious-labs-llc.sentry.io/issues/7654321/",
+        level: "error",
+        issueCategory: "metric",
+        issueType: "metric_issue",
+        userCount: 0,
+        count: "0",
+        ...overrides,
+      },
+    },
+  });
+}
+
+const AGG_FIELDS = ["title", "issue.id", "error.category", "release", "environment", "count()", "count_unique(user)"];
+
+function sentryResponse(rows) {
+  return {
+    ok: true,
+    status: 200,
+    headers: { get: () => null },
+    body: { cancel: async () => {} },
+    json: async () => ({
+      data: rows,
+      meta: { fields: Object.fromEntries(AGG_FIELDS.map((f) => [f, "integer"])) },
+    }),
+  };
+}
+
+function row(issue, category, release, environment, events, people) {
+  return {
+    issue,
+    "issue.id": 1,
+    title: `${category}: something`,
+    "error.category": category,
+    release,
+    environment,
+    "count()": events,
+    "count_unique(user)": people,
+  };
+}
+
+const SPIKE_ROWS = [
+  row("EW-2C", "audio_capture_stalled", "com.enviouswispr.app@2.4.3", "production", 40, 6),
+  row("EW-2C", "audio_capture_stalled", "com.enviouswispr.app@2.4.1", "production", 10, 3),
+  row("EW-24", "paste_failed", "com.enviouswispr.app@2.4.3", "production", 8, 4),
+  row("EW-99", "asr_failed", "com.enviouswispr.app@2.4.3-dev", "development", 5, 1),
+];
+
+/** Drives handleTriage with a stubbed fetch, recording every outbound call and
+ * every Discord embed. */
+function harness({ kv = fakeKV(), sentry = () => sentryResponse(SPIKE_ROWS), discordStatus = 204 } = {}) {
+  const realFetch = globalThis.fetch;
+  const requests = [];
+  const embeds = [];
+  globalThis.fetch = async (url, init) => {
+    const target = String(url);
+    requests.push(target);
+    if (target.startsWith("https://us.sentry.io")) return sentry(target);
+    if (target.startsWith("https://discord.test")) {
+      embeds.push(JSON.parse(init.body).embeds[0]);
+      // `ok` is what postDiscord actually reads. A double that returned only a
+      // status made every delivery look like an http_non_2xx failure while
+      // reporting httpStatus 204 - a double THINNER than the real Response,
+      // which is the space these defects hide in.
+      return { ok: discordStatus >= 200 && discordStatus < 300, status: discordStatus };
+    }
+    throw new Error(`unexpected fetch to ${target}`);
+  };
+  const env = {
+    SENTRY_DEDUP: kv,
+    SENTRY_AUTH_TOKEN: "token",
+    SENTRY_PROJECT_ID: "4511097112428544",
+    DISCORD_WEBHOOK_URL: "https://discord.test/hook",
+  };
+  return { env, kv, requests, embeds, restore: () => (globalThis.fetch = realFetch) };
+}
+
+// ── Recognition ─────────────────────────────────────────────────────────────
+
+test("isMetricIssue recognises a rate alert and does NOT claim an ordinary error", () => {
+  assert.equal(isMetricIssue({ issueCategory: "metric" }), true);
+  assert.equal(isMetricIssue({ issueType: "metric_issue" }), true);
+  // Two-way. A path that fires on everything would pass the first two lines
+  // while routing every real crash away from the error handling.
+  assert.equal(isMetricIssue({ issueCategory: "error", issueType: "error" }), false);
+  assert.equal(isMetricIssue({}), false);
+  assert.equal(isMetricIssue(null), false);
+});
+
+test("a metric payload DOES carry data.issue, which is why the old guard never fired", async () => {
+  // The premise of the whole fix, asserted rather than assumed: the shipped
+  // comment claimed metric alerts had no data.issue and were skipped. If that
+  // were true this fixture would be unreachable.
+  const payload = JSON.parse(metricPayload());
+  assert.ok(payload.data.issue, "a metric alert carries data.issue");
+  assert.equal(payload.data.issue.userCount, 0, "and no user count to score");
+});
+
+// ── Throttle policy ─────────────────────────────────────────────────────────
+
+test("decideSpike enforces six hours on its own key, ignoring priority and regression", () => {
+  assert.equal(decideSpike({ throttleLookup: { status: "complete", value: null }, now: NOW }).post, true);
+
+  const fresh = { status: "complete", value: { lastNotifiedAt: NOW - 5 * HOUR, priority: "spike" } };
+  assert.equal(decideSpike({ throttleLookup: fresh, now: NOW }).post, false);
+
+  const expired = { status: "complete", value: { lastNotifiedAt: NOW - 6 * HOUR, priority: "spike" } };
+  assert.equal(decideSpike({ throttleLookup: expired, now: NOW }).post, true);
+});
+
+test("a throttle READ failure fails open, exactly as the error path does", () => {
+  for (const status of ["unavailable", "malformed", undefined]) {
+    const r = decideSpike({ throttleLookup: { status }, now: NOW });
+    assert.equal(r.post, true, `status ${status} must not suppress`);
+    assert.equal(r.reason, "throttle-unavailable-failopen");
+  }
+});
+
+test("a regressed metric issue is still throttled, unlike a regressed error", async () => {
+  // THE case the generic policy cannot serve. A metric issue flips to
+  // substatus "regressed" on EVERY firing, and rule 7's regression bypass would
+  // therefore post every single time. That is the triple-buzz this fixes.
+  const kv = fakeKV({ "spike:7654321": JSON.stringify({ lastNotifiedAt: NOW - HOUR, priority: "spike" }) });
+  const h = harness({ kv });
+  try {
+    await handleTriage(metricPayload({ substatus: "regressed" }), h.env);
+    assert.equal(h.embeds.length, 0, "a regressed metric issue inside the window must not post");
+    assert.equal(h.requests.length, 0, "and must not spend a Sentry call to find that out");
+  } finally {
+    h.restore();
+  }
+});
+
+test("the spike throttle lives on its own key and cannot collide with an error issue", async () => {
+  // An error issue with the SAME id has key `sentry:<id>`; the spike uses
+  // `spike:<id>`. A shared key would let one evict the other's window.
+  const kv = fakeKV({ "sentry:7654321": JSON.stringify({ lastNotifiedAt: NOW, priority: "P1" }) });
+  const h = harness({ kv });
+  try {
+    await handleTriage(metricPayload(), h.env);
+    assert.equal(h.embeds.length, 1, "an unrelated error throttle must not suppress the spike");
+    assert.ok(h.kv.store.has("spike:7654321"), "the spike writes its own key");
+    assert.equal(
+      JSON.parse(h.kv.store.get("sentry:7654321")).priority, "P1",
+      "and leaves the error key untouched"
+    );
+  } finally {
+    h.restore();
+  }
+});
+
+// ── Summarisation ───────────────────────────────────────────────────────────
+
+test("summarizeSpike sums events, never distinct users", () => {
+  const s = summarizeSpike(SPIKE_ROWS);
+  assert.equal(s.totalEvents, 63);
+  assert.equal(s.devEvents, 5);
+  assert.equal(s.realEvents, 58);
+  // audio_capture_stalled spans two releases: 40 + 10 events, and people is the
+  // LARGEST single row (6), never 6 + 3. The same person can appear under both.
+  const top = s.problems[0];
+  assert.equal(top.label, "audio_capture_stalled");
+  assert.equal(top.events, 50);
+  assert.equal(top.atLeastPeople, 6, "people is a lower bound, never a sum");
+  // `displayVersion` is this worker's established owner of version display and
+  // normalises `2.4.3-dev` to `2.4.3`, so the dev build collapses into its
+  // release line here. That is not a lost signal: the "Real vs dev" field
+  // carries the dev split explicitly, and it is the field that answers the
+  // question. Using a second version formatter just for this card would be a
+  // competing authority.
+  assert.deepEqual(s.releases, ["2.4.1", "2.4.3"]);
+});
+
+test("an unlabelled environment counts as dev, the conservative direction", () => {
+  // Attributing an unknown event to real users would turn the founder's own
+  // testing into a user-facing incident.
+  const s = summarizeSpike([row("EW-1", "asr_failed", "com.enviouswispr.app@2.4.3", undefined, 7, 1)]);
+  assert.equal(s.devEvents, 7);
+  assert.equal(s.realEvents, 0);
+});
+
+test("summarizeSpike skips a malformed count rather than treating it as zero", () => {
+  const s = summarizeSpike([
+    row("EW-1", "asr_failed", "com.enviouswispr.app@2.4.3", "production", "lots", 1),
+    row("EW-2", "paste_failed", "com.enviouswispr.app@2.4.3", "production", 3, 1),
+  ]);
+  assert.equal(s.totalEvents, 3, "a malformed row contributes nothing, and never a fabricated 0 total");
+  assert.equal(s.problems.length, 1);
+});
+
+test("a blank category falls back to the title's type, never to an empty label", () => {
+  const s = summarizeSpike([
+    { issue: "EW-1", title: "EXC_BAD_ACCESS:  timed out after  >", "error.category": "",
+      release: "com.enviouswispr.app@2.4.3", environment: "production", "count()": 4, "count_unique(user)": 1 },
+  ]);
+  assert.equal(s.problems[0].label, "EXC_BAD_ACCESS");
+});
+
+test("summarizeSpike over no rows is an honest zero, not a crash", () => {
+  const s = summarizeSpike([]);
+  assert.deepEqual(s, { totalEvents: 0, devEvents: 0, realEvents: 0, problems: [], releases: [] });
+});
+
+// ── The card ────────────────────────────────────────────────────────────────
+
+test("the enriched card names the problems, versions and dev split", async () => {
+  const h = harness();
+  try {
+    await handleTriage(metricPayload(), h.env);
+    assert.equal(h.embeds.length, 1, "one buzz, not three");
+    const embed = h.embeds[0];
+    assert.equal(embed.title, "[Sentry Spike] 63 errors in the last hour");
+    const byName = Object.fromEntries(embed.fields.map((f) => [f.name, f.value]));
+    assert.equal(byName["Real vs dev"], "58 from real users, 5 from dev builds");
+    // `displayVersion` normalises a dev build into its release line, so the dev
+    // events show up in "Real vs dev" rather than as a separate version string.
+    assert.equal(byName.Versions, "2.4.1, 2.4.3");
+    assert.match(byName["What is driving it"], /50 × audio_capture_stalled \(at least 6 people\)/);
+    assert.match(byName["What is driving it"], /8 × paste_failed \(at least 4 people\)/);
+    // The three things the OLD card said, which is what made it useless.
+    const rendered = JSON.stringify(embed);
+    assert.doesNotMatch(rendered, /unknown\/unknown/);
+    assert.doesNotMatch(rendered, /0 user\(s\)/);
+  } finally {
+    h.restore();
+  }
+});
+
+test("the spike costs exactly ONE Sentry call and keeps dev events", async () => {
+  const h = harness();
+  try {
+    await handleTriage(metricPayload(), h.env);
+    const sentry = h.requests.filter((u) => u.startsWith("https://us.sentry.io"));
+    assert.equal(sentry.length, 1, "one call, never a per-issue fan-out");
+    const url = decodeURIComponent(sentry[0]);
+    assert.match(url, /statsPeriod=1h/, "the trailing hour, matching what the rule measures");
+    // The digests force production-only; this one must NOT, by founder decision.
+    assert.doesNotMatch(url, /environment=/, "dev events are counted deliberately");
+  } finally {
+    h.restore();
+  }
+});
+
+test("a Sentry failure still buzzes once, and says the breakdown is missing", async () => {
+  const h = harness({
+    sentry: () => ({ ok: false, status: 403, headers: { get: () => null }, body: { cancel: async () => {} } }),
+  });
+  try {
+    await handleTriage(metricPayload(), h.env);
+    assert.equal(h.embeds.length, 1, "a rate alert is never lost to a lookup failure");
+    assert.match(JSON.stringify(h.embeds[0]), /breakdown could not be read/);
+  } finally {
+    h.restore();
+  }
+});
+
+test("an empty breakdown fails open rather than claiming zero errors", async () => {
+  // The enriched card would otherwise read "0 errors in the last hour" beside
+  // an alert that fired because there were more than five.
+  const h = harness({ sentry: () => sentryResponse([]) });
+  try {
+    await handleTriage(metricPayload(), h.env);
+    assert.equal(h.embeds.length, 1);
+    assert.doesNotMatch(h.embeds[0].title, /0 errors/);
+    assert.match(JSON.stringify(h.embeds[0]), /breakdown could not be read/);
+  } finally {
+    h.restore();
+  }
+});
+
+test("a failed Discord delivery writes no throttle, so the next firing stays eligible", async () => {
+  const h = harness({ discordStatus: 500 });
+  try {
+    await handleTriage(metricPayload(), h.env);
+    assert.equal(h.kv.store.has("spike:7654321"), false);
+  } finally {
+    h.restore();
+  }
+});
+
+test("a confirmed delivery writes the throttle", async () => {
+  const h = harness();
+  try {
+    await handleTriage(metricPayload(), h.env);
+    const stored = JSON.parse(h.kv.store.get("spike:7654321"));
+    assert.equal(typeof stored.lastNotifiedAt, "number");
+  } finally {
+    h.restore();
+  }
+});
+
+test("an ordinary error issue never takes the spike path", async () => {
+  // The two-way control for the routing. Without it, a branch that captured
+  // every payload would pass every test above while silently disabling the
+  // per-issue error alerting this worker exists for.
+  const h = harness();
+  try {
+    const errorPayload = JSON.stringify({
+      action: "created",
+      data: {
+        issue: {
+          id: "111", shortId: "EW-1", title: "asr_failed: X", permalink: "https://s/1",
+          level: "error", issueCategory: "error", issueType: "error", userCount: 3, count: "9",
+        },
+      },
+    });
+    await handleTriage(errorPayload, { ...h.env, GITHUB_REPO: "o/r" });
+    for (const embed of h.embeds) {
+      assert.doesNotMatch(embed.title, /Sentry Spike/, "an error must not render as a spike");
+    }
+    assert.equal(h.kv.store.has("spike:111"), false, "and must not write a spike throttle");
+  } finally {
+    h.restore();
+  }
+});
+
+test("the fail-open card never renders an empty title", () => {
+  const embed = buildSpikeFailOpenEmbed({ issueId: "1", title: "", permalink: "https://s/1" });
+  assert.ok(embed.title.length > "[Sentry Spike] ".length);
+});
+
+test("the card truncates a runaway breakdown instead of exceeding Discord's field limit", () => {
+  const many = Array.from({ length: 200 }, (_, i) =>
+    row(`EW-${i}`, `category_${i}_${"x".repeat(40)}`, "com.enviouswispr.app@2.4.3", "production", 5, 1));
+  const embed = buildSpikeEmbed(summarizeSpike(many), { issueId: "1", title: "t", permalink: "https://s/1" });
+  for (const field of embed.fields) {
+    assert.ok(field.value.length <= 1024, `field ${field.name} is ${field.value.length} chars, over Discord's 1024 limit`);
+  }
+  assert.ok(embed.title.length <= 256);
+});

--- a/workers/sentry-triage/test/spike.test.js
+++ b/workers/sentry-triage/test/spike.test.js
@@ -269,13 +269,25 @@ test("a FULL page fails open rather than publishing a short total as exact", asy
   }
 });
 
-test("a page just under the ceiling still renders the enriched card", () => {
+test("a page just under the ceiling still renders the enriched card", async () => {
   // Two-way control for the truncation rule: 99 rows is a complete answer and
   // must NOT fail open, or a busy-but-readable hour would lose its breakdown.
+  //
+  // Driven through handleTriage, not summarizeSpike. Calling the summariser
+  // directly never touches the truncation branch at all, so it proved the sum
+  // and nothing about which card is actually posted - which is the whole
+  // behaviour under test.
   const many = Array.from({ length: 99 }, (_, i) =>
     row(`EW-${i}`, "asr_failed", "com.enviouswispr.app@2.4.3", "production", 5, 1));
-  const s = summarizeSpike(many);
-  assert.equal(s.totalEvents, 495);
+  const h = harness({ sentry: () => sentryResponse(many) });
+  try {
+    await handleTriage(metricPayload(), h.env);
+    assert.equal(h.embeds.length, 1);
+    assert.equal(h.embeds[0].title, "[Sentry Spike] 495 errors in the last hour");
+    assert.doesNotMatch(JSON.stringify(h.embeds[0]), /breakdown could not be read/);
+  } finally {
+    h.restore();
+  }
 });
 
 test("a blank category falls back to the title's type, never to an empty label", () => {

--- a/workers/sentry-triage/wrangler.toml
+++ b/workers/sentry-triage/wrangler.toml
@@ -9,6 +9,12 @@
 #     one is scoped to CI release uploads only and 403s on event reads (org
 #     tokens on this Sentry plan only support the org:ci scope; event:read
 #     requires a personal token instead). The worker never writes back to Sentry.
+#     #1965 UPDATE: the rate-alert breakdown reads
+#     `/organizations/<org>/events/`, and the CURRENT triage token 403s on THAT
+#     endpoint too (measured 2026-08-06) even though it reads per-issue events
+#     fine. The token needs org scope added, or the spike card degrades to its
+#     fail-open form: one honest buzz saying the rule fired and the breakdown
+#     could not be read. The per-issue error path is unaffected either way.
 #   GITHUB_ISSUES_READ_TOKEN — fine-grained GitHub token scoped to
 #     saurabhav88/EnviousWispr, repository permission Issues:read ONLY, no writes
 #     (#1470). Reads open issues to check whether a fingerprint already carries an
@@ -26,6 +32,11 @@ compatibility_date = "2026-04-15"
 
 [vars]
 GITHUB_REPO = "saurabhav88/EnviousWispr"
+# Scopes the rate-alert breakdown query to this project (#1965). Identifier
+# only, no credential. The org lives as a module constant in src/index.js, which
+# has owned it since this worker was written; adding a second copy here would
+# make two authorities for one value.
+SENTRY_PROJECT_ID = "4511097112428544"
 
 [[kv_namespaces]]
 binding = "SENTRY_DEDUP"

--- a/workers/sentry-triage/wrangler.toml
+++ b/workers/sentry-triage/wrangler.toml
@@ -1,20 +1,28 @@
 # Secrets (set via `wrangler secret put <NAME>`, not committed here):
 #   SENTRY_WEBHOOK_SECRET — HMAC key for verifying inbound Sentry webhooks.
 #   DISCORD_WEBHOOK_URL   — Discord channel webhook for triage alerts.
-#   SENTRY_AUTH_TOKEN     — a personal Sentry token scoped to event:read ONLY
-#     (keystore: sentry-triage-worker-token), used to page a captured issue's
-#     events (release/environment/build_type/level/user tags for release-scoped
-#     severity scoring, plus category/stage/OS/device for the source-labeled
-#     Discord embed, #1229/#1470). NOT the keystore's `sentry-auth-token` — that
-#     one is scoped to CI release uploads only and 403s on event reads (org
-#     tokens on this Sentry plan only support the org:ci scope; event:read
-#     requires a personal token instead). The worker never writes back to Sentry.
-#     #1965 UPDATE: the rate-alert breakdown reads
-#     `/organizations/<org>/events/`, and the CURRENT triage token 403s on THAT
-#     endpoint too (measured 2026-08-06) even though it reads per-issue events
-#     fine. The token needs org scope added, or the spike card degrades to its
-#     fail-open form: one honest buzz saying the rule fired and the breakdown
-#     could not be read. The per-issue error path is unaffected either way.
+#   SENTRY_AUTH_TOKEN     — GCP secret `sentry-workers-readonly-token`, a
+#     personal Sentry token scoped to exactly `event:read` + `org:read`. This
+#     worker makes TWO different Sentry calls and one token has to serve both:
+#       - per-issue events, `/organizations/<org>/issues/<id>/events/` (:736) —
+#         release/environment/build_type/level/user tags for release-scoped
+#         severity scoring, plus category/stage/OS/device for the source-labeled
+#         Discord embed (#1229/#1470). Needs `event:read`.
+#       - the rate-alert breakdown, `/organizations/<org>/events/` (:491, via
+#         shared/sentry.js discoverAggregate, #1965). Needs `org:read` ON TOP.
+#     The same token is installed on daily-report and weekly-digest, which make
+#     only the second kind of call. Install it HERE TOO: this worker's older
+#     `sentry-triage-worker-token` reads per-issue events fine but 403s on the
+#     aggregate endpoint (measured 2026-08-06), so leaving it in place degrades
+#     every spike card to its fail-open form — one honest buzz saying the rule
+#     fired and the breakdown could not be read — while the per-issue error path
+#     keeps working and hides the gap. Both endpoints were verified 200 under
+#     the new token before the swap, so it is a superset and cannot regress the
+#     existing path. NOT the keystore's `sentry-auth-token` — that one is scoped
+#     to CI release uploads only and 403s on event reads (org tokens on this
+#     Sentry plan only support the org:ci scope; event:read requires a personal
+#     token instead). Sentry LOCKS scopes at creation, so a missing scope is
+#     always a new token, never an edit. The worker never writes back to Sentry.
 #   GITHUB_ISSUES_READ_TOKEN — fine-grained GitHub token scoped to
 #     saurabhav88/EnviousWispr, repository permission Issues:read ONLY, no writes
 #     (#1470). Reads open issues to check whether a fingerprint already carries an

--- a/workers/shared/README.md
+++ b/workers/shared/README.md
@@ -4,10 +4,19 @@ Infrastructure shared by more than one Cloudflare Worker in this repo.
 
 ## Consumers
 
-- `workers/daily-report`
-- `workers/weekly-digest`
+Per module, because they are no longer the same set. Redeploy every consumer of
+the module you changed, not every worker in this table.
 
-Keep that list accurate. It is the deploy checklist.
+| Module | Consumers |
+|---|---|
+| `posthog.js` | `workers/daily-report`, `workers/weekly-digest` |
+| `discord.js` | `workers/daily-report`, `workers/weekly-digest` |
+| `sentry.js` | `workers/daily-report`, `workers/weekly-digest`, `workers/sentry-triage` |
+
+Keep that table accurate. It is the deploy checklist. A single flat list was
+enough until `sentry.js` arrived with a third consumer that uses only it
+(#1965), and a flat list would now over-report the blast radius of a
+posthog.js change and under-report a sentry.js one.
 
 ## THE RULE THAT BITES: editing a file here changes nothing in production
 
@@ -41,6 +50,11 @@ Transport and protocol only:
   resolution, the production predicate, SQL literal escaping, row conversion.
 - `discord.js` — Discord's transport limits and the supported subset of its
   payload protocol, plus one-attempt delivery.
+- `sentry.js` — Sentry's HTTP, authentication, retryable-status set, bounded
+  retry, deadline enforcement, response-shape validation and row normalization.
+  Which window to ask about, which releases count, and what an error category
+  MEANS are all product judgement and live in `workers/reporting/sentry-section.js`
+  instead.
 
 ## What must NOT come here
 
@@ -66,6 +80,7 @@ Two specific traps, both learned the hard way:
 
 There is no test package here. The shared modules are exercised by
 `workers/daily-report/test/report.test.js`, which is where they were tested
-before the extraction, and by `workers/weekly-digest/test/digest.test.js`.
+before the extraction, by `workers/daily-report/test/sentry-section.test.js`
+(`sentry.js`), and by `workers/weekly-digest/test/digest.test.js`.
 Both suites run in CI via the `worker-tests` job feeding the required
 `build-check`, so a change here that breaks either consumer blocks the PR.

--- a/workers/shared/README.md
+++ b/workers/shared/README.md
@@ -30,17 +30,36 @@ snapshot of this code. So:
 - **`git revert` does not roll back production.** It changes the repo. Rolling
   back means reverting *and* redeploying every consumer.
 
-After changing anything in this directory:
+After changing anything in this directory, redeploy **every consumer of the
+module you changed**, read off the table above. The sets differ, so there is no
+single recipe — that is the whole reason the table is per-module.
+
+Changed `posthog.js` or `discord.js` (two consumers):
 
 ```bash
 cd workers/weekly-digest && npx wrangler deploy    # deploy the CHANGED consumer first
 cd ../daily-report      && npx wrangler deploy     # then the one that should not change
 ```
 
+Changed `sentry.js` (**three** consumers — `sentry-triage` uses the transport
+and none of the reporting policy, so it is easy to forget and its failure is
+quiet: rate-alert cards silently lose their breakdown while ordinary error posts
+keep working):
+
+```bash
+cd workers/sentry-triage && npx wrangler deploy    # the CHANGED consumer first
+cd ../daily-report       && npx wrangler deploy
+cd ../weekly-digest      && npx wrangler deploy
+```
+
 Deploy the worker whose behaviour is meant to change **first**. If the shared
 change is broken, the failure lands on the worker that was already being
 modified, and the healthy one is never touched. Credentials wrapper and the
 `curl -fsS` verification step: `workers/daily-report/README.md` § Deploy.
+
+If you add a consumer to the table, add it to the matching recipe in the same
+edit. A table row without a recipe line is how a worker gets left on a stale
+bundle, which is invisible until its numbers disagree with another worker's.
 
 ## What belongs here
 

--- a/workers/shared/sentry.js
+++ b/workers/shared/sentry.js
@@ -160,22 +160,38 @@ function requireConfig(env) {
 /** One HTTP attempt, bounded by BOTH a per-request timeout and the caller's
  * absolute deadline. Modelled on sentry-triage's `fetchBefore`, which already
  * had to solve this for the webhook path. */
-async function fetchBounded(url, token, { fetchFn, deadlineAt, requestTimeoutMs, queryName }) {
+async function fetchBounded(url, token, { fetchFn, deadlineAt, requestTimeoutMs, queryName }, consume) {
   const remainingMs = deadlineAt === null ? requestTimeoutMs : deadlineAt - Date.now();
   if (remainingMs <= 0) throw new SentryDeadlineError(queryName);
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), Math.max(1, Math.min(requestTimeoutMs, remainingMs)));
   try {
-    return await fetchFn(url, {
+    const res = await fetchFn(url, {
       headers: { Authorization: `Bearer ${token}`, Accept: "application/json" },
       signal: controller.signal,
     });
-  } catch (_) {
+    // THE BODY IS READ INSIDE THE TIMER, not after it.
+    //
+    // An earlier version returned the response and let the caller await
+    // `res.json()`, by which point `finally` had already cleared the abort
+    // timer. Headers arriving in time says nothing about the body: a server
+    // that stalls mid-stream would hang that read with no bound at all,
+    // overrunning both the per-request timeout AND the caller's absolute
+    // deadline. In the triage worker that deadline is a hard Cloudflare
+    // `waitUntil` cancellation, so the overrun would not be a slow post but a
+    // silently dropped one.
+    return await consume(res);
+  } catch (err) {
     // An abort is indistinguishable from a network error at the catch site
     // unless the signal is consulted, and reporting a deadline as a network
     // fault would send the reader looking for an outage that never happened.
     if (controller.signal.aborted) throw new SentryDeadlineError(queryName);
+    // Errors the CONSUMER raised are deliberate classifications and pass
+    // through unchanged; only a genuine transport failure is sanitized. Without
+    // this, a shape error would be relabelled as a network error and its cause
+    // lost.
+    if (err instanceof SentryShapeError || err instanceof SentryQueryError) throw err;
     // The caught error is DISCARDED rather than wrapped. See SentryNetworkError.
     throw new SentryNetworkError(queryName);
   } finally {
@@ -202,41 +218,47 @@ async function requestJson(url, queryName, config, opts) {
   const maxAttempts = RETRY_DELAY_MS.length + 1;
 
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-    const res = await fetchBounded(url, config.token, {
-      fetchFn,
-      deadlineAt,
-      requestTimeoutMs,
-      queryName,
-    });
+    // Everything that touches the response happens INSIDE the bounded region,
+    // including reading and discarding the body, so no part of it can outlive
+    // the timeout.
+    const outcome = await fetchBounded(
+      url,
+      config.token,
+      { fetchFn, deadlineAt, requestTimeoutMs, queryName },
+      async (res) => {
+        if (res?.ok) {
+          let body;
+          try {
+            body = await res.json();
+          } catch (_) {
+            // A 200 whose body is not JSON is a shape failure, never a
+            // transient one. Retrying it would burn the window and then report
+            // the same thing, with the original cause three attempts further
+            // away.
+            throw new SentryShapeError(queryName, "body was not JSON");
+          }
+          return { ok: true, body, headers: res.headers };
+        }
 
-    if (res?.ok) {
-      let body;
-      try {
-        body = await res.json();
-      } catch (_) {
-        // A 200 whose body is not JSON is a shape failure, never a transient
-        // one. Retrying it would burn the window and then report the same
-        // thing, with the original cause three attempts further away.
-        throw new SentryShapeError(queryName, "body was not JSON");
+        // Draining the failed body matters specifically because a retry
+        // immediately opens a NEW outbound request: an uncancelled body holds
+        // its Cloudflare subrequest connection open, and enough of those across
+        // retries could exhaust the account's outbound-connection ceiling.
+        if (res?.body) {
+          try {
+            await res.body.cancel();
+          } catch (_) {
+            // The status remains the authoritative failure; a failed cancel
+            // must not mask it.
+          }
+        }
+        return { ok: false, status: res?.status };
       }
-      return { body, headers: res.headers };
-    }
+    );
 
-    const status = res?.status;
-    // Draining the failed body matters specifically because a retry immediately
-    // opens a NEW outbound request: an uncancelled body holds its Cloudflare
-    // subrequest connection open, and enough of those across retries could
-    // exhaust the account's outbound-connection ceiling. Same reasoning, and
-    // the same best-effort swallow, as posthog.js.
-    if (res?.body) {
-      try {
-        await res.body.cancel();
-      } catch (_) {
-        // The status remains the authoritative failure; a failed cancel must
-        // not mask it.
-      }
-    }
+    if (outcome.ok) return { body: outcome.body, headers: outcome.headers };
 
+    const status = outcome.status;
     if (attempt === maxAttempts || !RETRYABLE_SENTRY_STATUSES.has(status)) {
       throw new SentryQueryError(queryName, status);
     }

--- a/workers/shared/sentry.js
+++ b/workers/shared/sentry.js
@@ -113,6 +113,24 @@ export class SentryDeadlineError extends Error {
   }
 }
 
+/** The request failed before any response arrived.
+ *
+ * EXISTS TO STOP A MESSAGE CROSSING THE PRIVACY BOUNDARY, not to add a category.
+ * Every other failure here is already sanitized into a fixed sentence, but a raw
+ * `fetch` rejection was rethrown unchanged - and both digest workers put
+ * `err.message` straight into their HTTP trigger response, while the weekly one
+ * also records it in its failure summary. A runtime or fetch-implementation
+ * error carrying a URL fragment would therefore have escaped, and the URL is
+ * the one part of a Sentry request that contains search terms. The original
+ * error is deliberately NOT attached: an unreachable field is not a boundary. */
+export class SentryNetworkError extends Error {
+  constructor(queryName) {
+    super(`Sentry query ${queryName} failed before receiving a response`);
+    this.name = "SentryNetworkError";
+    this.queryName = queryName;
+  }
+}
+
 /** Identifies the calling worker in Sentry's audit log and in Cloudflare logs.
  *
  * REQUIRED, never defaulted, for the same reason `hogql` requires it: a default
@@ -153,12 +171,13 @@ async function fetchBounded(url, token, { fetchFn, deadlineAt, requestTimeoutMs,
       headers: { Authorization: `Bearer ${token}`, Accept: "application/json" },
       signal: controller.signal,
     });
-  } catch (err) {
+  } catch (_) {
     // An abort is indistinguishable from a network error at the catch site
     // unless the signal is consulted, and reporting a deadline as a network
     // fault would send the reader looking for an outage that never happened.
     if (controller.signal.aborted) throw new SentryDeadlineError(queryName);
-    throw err;
+    // The caught error is DISCARDED rather than wrapped. See SentryNetworkError.
+    throw new SentryNetworkError(queryName);
   } finally {
     clearTimeout(timer);
   }
@@ -370,10 +389,15 @@ export async function discoverAggregate(env, params, opts = {}) {
  */
 export async function issueList(env, params, opts = {}) {
   const config = requireConfig(env);
-  const { queryName, query = "", environment = null, limit = 100 } = params;
+  const { queryName, query = "", environment = null, limit = 100, start = null, end = null } = params;
 
   if (typeof queryName !== "string" || queryName.length === 0) {
     throw new TypeError("issueList requires a queryName");
+  }
+  // Both or neither. One alone silently falls back to the relative form, which
+  // is the exact confusion this parameter was added to remove.
+  if ((start === null) !== (end === null)) {
+    throw new TypeError(`${queryName}: start and end must be supplied together`);
   }
   const project = env?.SENTRY_PROJECT_SLUG;
   if (typeof project !== "string" || project.length === 0) {
@@ -382,8 +406,15 @@ export async function issueList(env, params, opts = {}) {
 
   const url = new URL(`${config.regionUrl}/api/0/projects/${config.org}/${project}/issues/`);
   url.searchParams.set("query", query);
-  url.searchParams.set("statsPeriod", "");
   url.searchParams.set("limit", String(limit));
+  if (start !== null) {
+    url.searchParams.set("start", start);
+    url.searchParams.set("end", end);
+  } else {
+    // `statsPeriod: ""` suppresses the per-issue hourly stats array. It is NOT
+    // valid alongside start/end, which is why it sits in the else branch.
+    url.searchParams.set("statsPeriod", "");
+  }
   if (environment !== null) url.searchParams.set("environment", environment);
 
   const { body, headers } = await requestJson(url.toString(), queryName, config, opts);
@@ -408,9 +439,16 @@ export async function issueList(env, params, opts = {}) {
     if (typeof shortId !== "string" || shortId.length === 0) {
       throw new SentryShapeError(queryName, `issue ${i} had no shortId`);
     }
+    // `firstSeen` is REQUIRED, not defaulted to null. Every caller uses it to
+    // decide whether an issue is new, and a null would silently classify a
+    // genuinely-new issue as old - a missing badge nobody would ever notice.
+    const firstSeen = body[i].firstSeen;
+    if (typeof firstSeen !== "string" || Number.isNaN(Date.parse(firstSeen))) {
+      throw new SentryShapeError(queryName, `issue ${i} had no usable firstSeen`);
+    }
     issues.push({
       shortId,
-      firstSeen: typeof body[i].firstSeen === "string" ? body[i].firstSeen : null,
+      firstSeen,
       level: typeof body[i].level === "string" ? body[i].level : null,
       title: typeof body[i].title === "string" ? body[i].title : null,
     });
@@ -418,5 +456,9 @@ export async function issueList(env, params, opts = {}) {
 
   return { issues, truncated: hasMorePages(headers, issues.length, limit) };
 }
+
+/** Exported so a caller's subrequest-budget arithmetic reads the REAL retry
+ * maximum rather than restating a literal that can drift away from it. */
+export const SENTRY_MAX_ATTEMPTS = RETRY_DELAY_MS.length + 1;
 
 export { RETRYABLE_SENTRY_STATUSES, SENTRY_REGION_URL, DEFAULT_REQUEST_TIMEOUT_MS };

--- a/workers/shared/sentry.js
+++ b/workers/shared/sentry.js
@@ -1,0 +1,422 @@
+/**
+ * Sentry read transport, shared by every worker that queries Sentry (issue #1965).
+ *
+ * CONSUMERS: workers/daily-report, workers/weekly-digest, workers/sentry-triage.
+ *
+ * DEPLOY RULE: Cloudflare bundles each worker separately, so editing this file
+ * changes NOTHING in production until EVERY consumer above is redeployed
+ * (`npx wrangler deploy` from each worker directory). A merged PR does not
+ * deploy; a `git revert` does not roll back. See workers/shared/README.md.
+ *
+ * Infrastructure ONLY - HTTP, authentication, the retryable-status set, bounded
+ * retry, deadline enforcement, response-shape validation and row normalization.
+ *
+ * NOT here, deliberately: which window to ask about, which releases count, what
+ * an `error.category` MEANS, how to word a section, or when something is worth
+ * buzzing about. Every one of those is a product judgement and belongs to the
+ * worker that owns the report - `workers/reporting/sentry-section.js` for the
+ * two digests, `workers/sentry-triage/src/index.js` for the spike card. This is
+ * the same line `workers/shared/README.md` draws for posthog.js and discord.js.
+ *
+ * WHY THIS IS NOT AN EXTENSION OF posthog.js: different vendor, different
+ * limiter, different retry class. A Sentry request does not queue behind
+ * PostHog's three-query project allowance and does not inherit its
+ * up-to-30-second queue-wait backoff. Sharing that module's retry would have
+ * made a Sentry 429 wait 12-45 seconds for a limit that resets far sooner, and
+ * would have let a Sentry call consume a PostHog concurrency slot it never
+ * needed. Measured Sentry limits on this account: 30 requests per window,
+ * 15 concurrent (`x-sentry-rate-limit-*` response headers, 2026-08-06).
+ *
+ * Privacy: this module logs query NAMES and HTTP statuses only. Never a response
+ * body, never a user id, never the auth token, never a URL (the query string
+ * carries the search terms).
+ */
+
+/** Sentry's US region. Every EnviousWispr project lives here, and omitting the
+ * region produces a 404 rather than a redirect - a failure that reads as "no
+ * such issue" rather than "wrong host" (sentry-operations.md RULE:
+ * pass-region-url). */
+const SENTRY_REGION_URL = "https://us.sentry.io";
+
+/** Retried only on this documented class. A 401/403 is a credential problem and
+ * a 400 is a malformed query; retrying either wastes the window and hides the
+ * real cause behind a timeout.
+ *
+ * 403 is deliberately ABSENT even though it is the failure most likely to be
+ * seen first: the org-wide events endpoint answers 403 to a token that lacks
+ * org scope, and that is a permanent configuration state, not a blip. Measured
+ * 2026-08-06: `sentry-triage-worker-token` and `sentry-auth-token` both 403 on
+ * `/organizations/<org>/events/` while the admin token succeeds in ~300ms. */
+const RETRYABLE_SENTRY_STATUSES = new Set([429, 500, 502, 503, 504]);
+
+/** TWO attempts total, not three, and the reason is a platform ceiling rather
+ * than anything about Sentry.
+ *
+ * Cloudflare allows 50 subrequests per Worker invocation. The daily report's
+ * designed worst case - every request retrying to exhaustion - is
+ * (1 preflight + 7 adoption + 2 scorecard + 1 GitHub) x 3 + Sentry + 1 Discord.
+ * At three Sentry attempts that is 49, one below the cap, so a single future
+ * query anywhere in the worker would silently push the whole report over. At
+ * two it is 44.
+ *
+ * The trade is one-sided. Sentry's per-window limit resets fast, the digest
+ * runs again tomorrow, and losing the Sentry section for one day costs a
+ * section; blowing the subrequest cap costs the ENTIRE report, adoption and
+ * scorecard included, on exactly the day something was wrong enough to make
+ * Sentry rate-limit us. */
+const RETRY_DELAY_MS = [1_000];
+
+/** Per-request ceiling. A single Sentry read measured 243-973ms across every
+ * query this repo issues, so 10s is generous headroom rather than a tuned
+ * value - it exists to stop one wedged socket consuming a whole run, not to
+ * express an expectation about latency. */
+const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Carries the query name and HTTP status alongside the message, so a caller can
+ * distinguish an exhausted transient failure (which a degradable section may
+ * absorb) from an auth failure, a malformed query or a bad response shape
+ * (which must stay loud). Mirrors PostHogQueryError deliberately: the two
+ * transports are separate, but a consumer reasoning about failure classes
+ * should not have to learn two vocabularies. */
+export class SentryQueryError extends Error {
+  constructor(queryName, status) {
+    super(`Sentry query ${queryName} HTTP ${status}`);
+    this.name = "SentryQueryError";
+    this.queryName = queryName;
+    this.status = status;
+  }
+}
+
+/** The response arrived and could not be trusted: unparseable, the wrong
+ * container type, or missing the field-set every response carries. Separate
+ * from SentryQueryError because it is NEVER retryable and never degradable to a
+ * zero - a malformed body that reads as "no errors today" is the exact failure
+ * the daily report exists not to produce. */
+export class SentryShapeError extends Error {
+  constructor(queryName, detail) {
+    super(`Sentry query ${queryName} returned an unusable response: ${detail}`);
+    this.name = "SentryShapeError";
+    this.queryName = queryName;
+  }
+}
+
+/** The caller's absolute deadline passed. The triage worker runs inside a
+ * Cloudflare `waitUntil` that is cancelled ~30s after the response, so its
+ * lookups are bounded by wall clock, not by attempt count. */
+export class SentryDeadlineError extends Error {
+  constructor(queryName) {
+    super(`Sentry query ${queryName} exceeded its deadline`);
+    this.name = "SentryDeadlineError";
+    this.queryName = queryName;
+  }
+}
+
+/** Identifies the calling worker in Sentry's audit log and in Cloudflare logs.
+ *
+ * REQUIRED, never defaulted, for the same reason `hogql` requires it: a default
+ * would file one worker's reads under another worker's name, which reads as
+ * correct in every place a human would look. */
+function requireWorkerLabel(workerLabel) {
+  if (typeof workerLabel !== "string" || workerLabel.length === 0) {
+    throw new TypeError("Sentry transport requires a non-empty workerLabel");
+  }
+  return workerLabel;
+}
+
+function requireConfig(env) {
+  const org = env?.SENTRY_ORG;
+  const token = env?.SENTRY_AUTH_TOKEN;
+  // Checked separately so the failure names WHICH piece is missing. A combined
+  // "Sentry is not configured" sends someone to rotate a token that was fine.
+  if (typeof org !== "string" || org.length === 0) {
+    throw new TypeError("SENTRY_ORG is not configured");
+  }
+  if (typeof token !== "string" || token.length === 0) {
+    throw new TypeError("SENTRY_AUTH_TOKEN is not configured");
+  }
+  return { org, token, regionUrl: env.SENTRY_REGION_URL || SENTRY_REGION_URL };
+}
+
+/** One HTTP attempt, bounded by BOTH a per-request timeout and the caller's
+ * absolute deadline. Modelled on sentry-triage's `fetchBefore`, which already
+ * had to solve this for the webhook path. */
+async function fetchBounded(url, token, { fetchFn, deadlineAt, requestTimeoutMs, queryName }) {
+  const remainingMs = deadlineAt === null ? requestTimeoutMs : deadlineAt - Date.now();
+  if (remainingMs <= 0) throw new SentryDeadlineError(queryName);
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), Math.max(1, Math.min(requestTimeoutMs, remainingMs)));
+  try {
+    return await fetchFn(url, {
+      headers: { Authorization: `Bearer ${token}`, Accept: "application/json" },
+      signal: controller.signal,
+    });
+  } catch (err) {
+    // An abort is indistinguishable from a network error at the catch site
+    // unless the signal is consulted, and reporting a deadline as a network
+    // fault would send the reader looking for an outage that never happened.
+    if (controller.signal.aborted) throw new SentryDeadlineError(queryName);
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Fetches `url` with bounded retry and returns the parsed JSON body plus the
+ * response headers.
+ *
+ * The URL is never logged: it carries the search query, and a Sentry search
+ * query can name a release, an issue or a user-scoped filter.
+ */
+async function requestJson(url, queryName, config, opts) {
+  const {
+    fetchFn = fetch,
+    sleepFn = sleep,
+    deadlineAt = null,
+    requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
+    workerLabel,
+  } = opts;
+  const label = requireWorkerLabel(workerLabel);
+  const maxAttempts = RETRY_DELAY_MS.length + 1;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const res = await fetchBounded(url, config.token, {
+      fetchFn,
+      deadlineAt,
+      requestTimeoutMs,
+      queryName,
+    });
+
+    if (res?.ok) {
+      let body;
+      try {
+        body = await res.json();
+      } catch (_) {
+        // A 200 whose body is not JSON is a shape failure, never a transient
+        // one. Retrying it would burn the window and then report the same
+        // thing, with the original cause three attempts further away.
+        throw new SentryShapeError(queryName, "body was not JSON");
+      }
+      return { body, headers: res.headers };
+    }
+
+    const status = res?.status;
+    // Draining the failed body matters specifically because a retry immediately
+    // opens a NEW outbound request: an uncancelled body holds its Cloudflare
+    // subrequest connection open, and enough of those across retries could
+    // exhaust the account's outbound-connection ceiling. Same reasoning, and
+    // the same best-effort swallow, as posthog.js.
+    if (res?.body) {
+      try {
+        await res.body.cancel();
+      } catch (_) {
+        // The status remains the authoritative failure; a failed cancel must
+        // not mask it.
+      }
+    }
+
+    if (attempt === maxAttempts || !RETRYABLE_SENTRY_STATUSES.has(status)) {
+      throw new SentryQueryError(queryName, status);
+    }
+    // Checked BEFORE sleeping, not after: sleeping past a deadline and then
+    // discovering it consumes the caller's entire remaining budget in a wait
+    // that could never have produced an answer.
+    if (deadlineAt !== null && Date.now() + RETRY_DELAY_MS[attempt - 1] >= deadlineAt) {
+      throw new SentryDeadlineError(queryName);
+    }
+    console.log(`${label} sentry ${queryName} retrying after HTTP ${status}`);
+    await sleepFn(RETRY_DELAY_MS[attempt - 1]);
+  }
+}
+
+/** True when Sentry says another page exists.
+ *
+ * TWO signals, because neither alone is sufficient. The Link header is the
+ * documented one, but it is ABSENT entirely on a single-page Discover response
+ * (measured 2026-08-06: empty Link on a 9-row result), so its absence proves
+ * nothing about a FULL page. A full page is therefore treated as "there may be
+ * more" regardless. Over-reporting here is safe: the only consequence is the
+ * section printing its honest "breakdown limited to the top N" wording. */
+function hasMorePages(headers, rowCount, perPage) {
+  if (rowCount >= perPage) return true;
+  const link = headers?.get?.("link") || "";
+  return /rel="next"[^,]*results="true"/.test(link);
+}
+
+/**
+ * Runs ONE Discover aggregate against `/organizations/<org>/events/`.
+ *
+ * Returns `{ rows, fields, truncated }`. `rows` are plain objects keyed by the
+ * field names Sentry returned; this module does not rename, coerce or default
+ * any value, because a defaulted metric is indistinguishable from a measured
+ * one by the time it reaches a sentence.
+ *
+ * THE SHAPE CHECK IS ON `meta.fields`, NOT ON THE ROWS, and that is the whole
+ * point of it. Zero rows is a legitimate answer - a day with no errors is the
+ * outcome we want - so any per-row validation is skipped exactly when a
+ * malformed empty body arrives, which is the case that would otherwise render
+ * as "no errors today" (#1589's column-set lesson, hit again here). `meta.fields`
+ * is present on both a populated and an empty response (measured 2026-08-06),
+ * so it is the one check an empty answer cannot slip past.
+ *
+ * `requiredFields` is the caller's list of fields it will actually READ. It is
+ * not derived from `fields` above, because Sentry does not echo every requested
+ * field back under the same name: asking for `issue` yields rows carrying BOTH
+ * `issue` and `issue.id`, while `meta.fields` names only `issue.id`. A check
+ * built from the request would fail on a perfectly good response, and the
+ * obvious repair - dropping the check - is how the empty-body case gets through.
+ */
+export async function discoverAggregate(env, params, opts = {}) {
+  const config = requireConfig(env);
+  const {
+    queryName,
+    fields,
+    requiredFields = [],
+    query = null,
+    sort = null,
+    perPage = 100,
+    start = null,
+    end = null,
+    statsPeriod = null,
+    environment = null,
+  } = params;
+
+  if (typeof queryName !== "string" || queryName.length === 0) {
+    throw new TypeError("discoverAggregate requires a queryName");
+  }
+  if (!Array.isArray(fields) || fields.length === 0) {
+    throw new TypeError(`${queryName}: discoverAggregate requires at least one field`);
+  }
+  // Exactly one window form. Sending both lets Sentry choose, and which one it
+  // honours is not something this code should be guessing about when the answer
+  // becomes a sentence the founder reads as "yesterday".
+  const hasAbsolute = start !== null && end !== null;
+  if (hasAbsolute === (statsPeriod !== null)) {
+    throw new TypeError(`${queryName}: pass either start+end or statsPeriod, not both or neither`);
+  }
+
+  const url = new URL(`${config.regionUrl}/api/0/organizations/${config.org}/events/`);
+  if (env.SENTRY_PROJECT_ID) url.searchParams.set("project", String(env.SENTRY_PROJECT_ID));
+  for (const field of fields) url.searchParams.append("field", field);
+  if (query !== null) url.searchParams.set("query", query);
+  if (sort !== null) url.searchParams.set("sort", sort);
+  if (environment !== null) url.searchParams.set("environment", environment);
+  if (hasAbsolute) {
+    url.searchParams.set("start", start);
+    url.searchParams.set("end", end);
+  } else {
+    url.searchParams.set("statsPeriod", statsPeriod);
+  }
+  url.searchParams.set("per_page", String(perPage));
+
+  const { body, headers } = await requestJson(url.toString(), queryName, config, opts);
+
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    throw new SentryShapeError(queryName, "body was not an object");
+  }
+  const meta = body.meta;
+  if (meta === null || typeof meta !== "object" || Array.isArray(meta)) {
+    throw new SentryShapeError(queryName, "meta was missing");
+  }
+  const metaFields = meta.fields;
+  if (metaFields === null || typeof metaFields !== "object" || Array.isArray(metaFields)) {
+    throw new SentryShapeError(queryName, "meta.fields was missing");
+  }
+  for (const required of requiredFields) {
+    if (!Object.hasOwn(metaFields, required)) {
+      throw new SentryShapeError(queryName, `meta.fields is missing ${required}`);
+    }
+  }
+  const rows = body.data;
+  if (!Array.isArray(rows)) {
+    throw new SentryShapeError(queryName, "data was not an array");
+  }
+  for (let i = 0; i < rows.length; i += 1) {
+    // Object.hasOwn, not a truthiness test: `data: [null]` and a sparse array
+    // both survive a length check and then yield `undefined` to a formatter,
+    // which renders as the string "undefined" beside a real number.
+    if (!Object.hasOwn(rows, i) || rows[i] === null || typeof rows[i] !== "object") {
+      throw new SentryShapeError(queryName, `data row ${i} was not an object`);
+    }
+  }
+
+  return {
+    rows,
+    fields: Object.keys(metaFields),
+    truncated: hasMorePages(headers, rows.length, perPage),
+  };
+}
+
+/**
+ * Lists issues from `/projects/<org>/<project>/issues/`.
+ *
+ * Used for exactly one thing today: the set of issues whose FIRST-EVER event
+ * falls inside the window, which is the only honest source for a "new" badge.
+ *
+ * A caller must NOT read `count` or `userCount` from these rows as window
+ * figures. They are LIFETIME totals and do not move with the window at all -
+ * measured 2026-08-06, `statsPeriod=24h` and `statsPeriod=14d` both returned
+ * `count=602 userCount=155` for the same issue. The window changes WHICH issues
+ * come back, never their numbers. Every per-window number in the digest comes
+ * from `discoverAggregate` instead, and this comment is here because the two
+ * endpoints look interchangeable and are not.
+ *
+ * `statsPeriod: ""` is passed deliberately: it suppresses the per-issue hourly
+ * `stats` array, which is a quarter of the payload and is never read
+ * (measured: 66,721B with stats, 49,710B without).
+ */
+export async function issueList(env, params, opts = {}) {
+  const config = requireConfig(env);
+  const { queryName, query = "", environment = null, limit = 100 } = params;
+
+  if (typeof queryName !== "string" || queryName.length === 0) {
+    throw new TypeError("issueList requires a queryName");
+  }
+  const project = env?.SENTRY_PROJECT_SLUG;
+  if (typeof project !== "string" || project.length === 0) {
+    throw new TypeError("SENTRY_PROJECT_SLUG is not configured");
+  }
+
+  const url = new URL(`${config.regionUrl}/api/0/projects/${config.org}/${project}/issues/`);
+  url.searchParams.set("query", query);
+  url.searchParams.set("statsPeriod", "");
+  url.searchParams.set("limit", String(limit));
+  if (environment !== null) url.searchParams.set("environment", environment);
+
+  const { body, headers } = await requestJson(url.toString(), queryName, config, opts);
+
+  // This endpoint returns a BARE ARRAY, not a wrapper object, so it has no
+  // `meta` to check and an empty array is genuinely indistinguishable from a
+  // malformed empty one. That is acceptable HERE and would not be acceptable
+  // for the aggregate: an empty new-issue set costs a badge, an empty aggregate
+  // would print "no errors today" when the truth is unknown. The asymmetry is
+  // deliberate, not an oversight.
+  if (!Array.isArray(body)) {
+    throw new SentryShapeError(queryName, "body was not an array");
+  }
+  const issues = [];
+  for (let i = 0; i < body.length; i += 1) {
+    if (!Object.hasOwn(body, i) || body[i] === null || typeof body[i] !== "object") {
+      throw new SentryShapeError(queryName, `issue ${i} was not an object`);
+    }
+    const shortId = body[i].shortId;
+    // A row without a shortId cannot be matched to an aggregate row, so it
+    // would silently fail to badge. Refusing names the problem instead.
+    if (typeof shortId !== "string" || shortId.length === 0) {
+      throw new SentryShapeError(queryName, `issue ${i} had no shortId`);
+    }
+    issues.push({
+      shortId,
+      firstSeen: typeof body[i].firstSeen === "string" ? body[i].firstSeen : null,
+      level: typeof body[i].level === "string" ? body[i].level : null,
+      title: typeof body[i].title === "string" ? body[i].title : null,
+    });
+  }
+
+  return { issues, truncated: hasMorePages(headers, issues.length, limit) };
+}
+
+export { RETRYABLE_SENTRY_STATUSES, SENTRY_REGION_URL, DEFAULT_REQUEST_TIMEOUT_MS };

--- a/workers/weekly-digest/README.md
+++ b/workers/weekly-digest/README.md
@@ -31,8 +31,14 @@ plain `curl -sS` exits 0 on an HTTP 401 or 500.
 ```bash
 ~/.claude/bin/get-key launch posthog-personal-api-key POSTHOG_KEY -- \
   ~/.claude/bin/get-key launch cloudflare-global-api-key CF_KEY -- \
+  ~/.claude/bin/get-key launch sentry-master-key SENTRY_KEY -- \
   node workers/weekly-digest/live-query-smoke.mjs
 ```
+
+`SENTRY_KEY` uses the existing admin read credential **for this local smoke
+only**, because no worker-grade credential can reach the Discover endpoint the
+Sentry section needs (measured 2026-08-06: both worker tokens 403). Never
+install `sentry-master-key` as a Cloudflare Worker secret.
 
 Runs the real `runDigest` against production with the Discord call intercepted,
 prints per-query timings and the exact message, and **fails loud naming any

--- a/workers/weekly-digest/README.md
+++ b/workers/weekly-digest/README.md
@@ -31,14 +31,15 @@ plain `curl -sS` exits 0 on an HTTP 401 or 500.
 ```bash
 ~/.claude/bin/get-key launch posthog-personal-api-key POSTHOG_KEY -- \
   ~/.claude/bin/get-key launch cloudflare-global-api-key CF_KEY -- \
-  ~/.claude/bin/get-key launch sentry-master-key SENTRY_KEY -- \
+  ~/.claude/bin/get-key launch sentry-workers-readonly-token SENTRY_KEY -- \
   node workers/weekly-digest/live-query-smoke.mjs
 ```
 
-`SENTRY_KEY` uses the existing admin read credential **for this local smoke
-only**, because no worker-grade credential can reach the Discover endpoint the
-Sentry section needs (measured 2026-08-06: both worker tokens 403). Never
-install `sentry-master-key` as a Cloudflare Worker secret.
+`SENTRY_KEY` is the same least-privilege token the deployed Worker holds
+(`event:read` + `org:read`), so the smoke exercises exactly the access
+production has. Same reasoning and the same do-not-reintroduce warning as
+`workers/daily-report/README.md`, which owns the detail. Never install
+`sentry-master-key` as a Cloudflare Worker secret.
 
 Runs the real `runDigest` against production with the Discord call intercepted,
 prints per-query timings and the exact message, and **fails loud naming any

--- a/workers/weekly-digest/live-query-smoke.mjs
+++ b/workers/weekly-digest/live-query-smoke.mjs
@@ -31,11 +31,18 @@ const env = {
   GITHUB_REPO: "saurabhav88/EnviousWispr",
   GITHUB_TOKEN: process.env.GITHUB_TOKEN,
   DISCORD_WEBHOOK_URL: CAPTURED_WEBHOOK,
+  SENTRY_ORG: "envious-labs-llc",
+  SENTRY_PROJECT_ID: "4511097112428544",
+  SENTRY_PROJECT_SLUG: "enviouswispr",
+  SENTRY_AUTH_TOKEN: process.env.SENTRY_KEY,
 };
 
+// SENTRY_KEY is required for the same reason the others are: a smoke that
+// silently skips a section proves nothing about it.
 const missing = [
   ["POSTHOG_KEY", env.POSTHOG_PERSONAL_API_KEY],
   ["CF_KEY", env.CF_API_KEY],
+  ["SENTRY_KEY", env.SENTRY_AUTH_TOKEN],
 ].filter(([, value]) => !value).map(([name]) => name);
 if (missing.length) {
   console.error(`missing ${missing.join(", ")} - see the usage header for the launcher form`);

--- a/workers/weekly-digest/src/index.js
+++ b/workers/weekly-digest/src/index.js
@@ -2,8 +2,9 @@
  * EnviousWispr Weekly Digest - Cloudflare Worker (issues #1243, #1589)
  *
  * Runs Monday 13:00 UTC via a Cloudflare cron trigger and posts ONE Discord
- * message with four sections: all website traffic (Cloudflare), tracked visitor
- * activity (PostHog), downloads (GitHub + PostHog), and app usage (PostHog).
+ * message with five sections: all website traffic (Cloudflare), tracked visitor
+ * activity (PostHog), downloads (GitHub + PostHog), app usage (PostHog), and
+ * the week's errors on the current release line (Sentry, #1965).
  *
  * ORCHESTRATION OWNERSHIP. This file resolves the report window ONCE, resolves
  * the dev-ID exclusion ONCE, schedules every outbound query itself under one
@@ -41,6 +42,11 @@ import {
   windowClause,
 } from "../../shared/posthog.js";
 import { deliverReport } from "../../shared/discord.js";
+import {
+  fetchSentrySection,
+  formatSentrySection,
+  formatSentryUnavailable,
+} from "../../reporting/sentry-section.js";
 
 const WORKER_LABEL = "weekly_digest";
 
@@ -638,6 +644,33 @@ async function postFailureNotice(env, label, { fetchFn = fetch } = {}) {
   }
 }
 
+/** This digest always reports the same complete week for every section, so the
+ * title needs no date of its own; the range is on the message's content line. */
+const SENTRY_TITLE = "Sentry, last 7 days";
+
+/** Sentry's window, derived from the ONE resolved week and nothing else.
+ *
+ * Sentry's `start`/`end` are naive ISO instants read as UTC, and this worker's
+ * week is already UTC, so it converts with no second timezone calculation. The
+ * KNOWN LIMIT this file already records applies unchanged: the daily report
+ * measures EASTERN days, so a week of daily Sentry sections and one weekly
+ * Sentry section cover windows offset by the Eastern UTC offset and will not
+ * reconcile to the exact person.
+ *
+ * `firstSeenPeriod` is "7d" here and "24h" in the daily report. It is required
+ * rather than defaulted for exactly that reason: a default would be right for
+ * one caller and silently wrong for the other. */
+export function sentryWindowFor(window) {
+  const naiveISO = (date) => date.toISOString().slice(0, 19);
+  const priorStart = new Date(window.start.getTime() - REPORT_DAYS * 86400000);
+  return {
+    startISO: naiveISO(window.start),
+    endISO: naiveISO(window.end),
+    priorStartISO: naiveISO(priorStart),
+    firstSeenPeriod: `${REPORT_DAYS}d`,
+  };
+}
+
 /** Unwraps a settled outcome, returning `null` where the section failed, so a
  * formatter renders "temporarily unavailable" instead of a fabricated number. */
 function valueOrNull(outcome, failures, name) {
@@ -696,7 +729,7 @@ export async function runDigest(env, deps = {}) {
     posthogTasks.push(() => querySection(env, onboardActivateSql(prod, window.win), "onboard_activate", hogqlOpts));
   }
 
-  const [posthogOutcome, cfOutcome, ghOutcome] = await Promise.allSettled([
+  const [posthogOutcome, cfOutcome, ghOutcome, sentryOutcome] = await Promise.allSettled([
     runLimited(posthogTasks.map((task) => async () => {
       try {
         return { status: "fulfilled", value: await task() };
@@ -706,6 +739,10 @@ export async function runDigest(env, deps = {}) {
     }), CONCURRENCY_LIMIT),
     fetchCloudflareStats(env, window, { fetchFn }),
     fetchGitHubDownloads(env, { fetchFn }),
+    // Sentry is a fourth API with no shared ceiling, so it runs alongside the
+    // limiter exactly as Cloudflare and GitHub do rather than queueing behind
+    // PostHog's 3-query allowance for work that is not PostHog's.
+    fetchSentrySection(env, sentryWindowFor(window), { fetchFn, workerLabel: WORKER_LABEL }),
   ]);
 
   // A rejection here is a programming error in the limiter itself, not a query
@@ -852,6 +889,20 @@ export async function runDigest(env, deps = {}) {
 
   const cf = valueOrNull(cfOutcome, failures, "cloudflare");
   const gh = valueOrNull(ghOutcome, failures, "github");
+  const sentry = valueOrNull(sentryOutcome, failures, "sentry");
+
+  // Rendered inside its own try, so a section that computes cleanly and formats
+  // badly costs only itself. Validated at delivery it would fail the whole
+  // payload and take the other four sections down with it.
+  let sentryLines;
+  try {
+    sentryLines = sentry === null
+      ? formatSentryUnavailable(SENTRY_TITLE)
+      : formatSentrySection(sentry, { title: SENTRY_TITLE });
+  } catch (err) {
+    failures.push(`sentry_format: ${err.message}`);
+    sentryLines = formatSentryUnavailable(SENTRY_TITLE);
+  }
 
   const payload = {
     content: `EnviousWispr Weekly Digest, ${label}`,
@@ -860,6 +911,7 @@ export async function runDigest(env, deps = {}) {
       toEmbed(formatWebsite(site, downloads ? downloads.intents : null)),
       toEmbed(formatDownloads(gh, sources, downloads ? downloads.bots_excluded : null)),
       toEmbed(formatAppUsage(usage, funnel)),
+      toEmbed(sentryLines),
     ],
   };
 

--- a/workers/weekly-digest/src/index.js
+++ b/workers/weekly-digest/src/index.js
@@ -657,9 +657,8 @@ const SENTRY_TITLE = "Sentry, last 7 days";
  * Sentry section cover windows offset by the Eastern UTC offset and will not
  * reconcile to the exact person.
  *
- * `firstSeenPeriod` is "7d" here and "24h" in the daily report. It is required
- * rather than defaulted for exactly that reason: a default would be right for
- * one caller and silently wrong for the other. */
+ * There is no first-seen lookback to supply: the badge window is derived from
+ * the reported window itself, so neither caller can get it wrong. */
 export function sentryWindowFor(window) {
   const naiveISO = (date) => date.toISOString().slice(0, 19);
   const priorStart = new Date(window.start.getTime() - REPORT_DAYS * 86400000);
@@ -667,7 +666,6 @@ export function sentryWindowFor(window) {
     startISO: naiveISO(window.start),
     endISO: naiveISO(window.end),
     priorStartISO: naiveISO(priorStart),
-    firstSeenPeriod: `${REPORT_DAYS}d`,
   };
 }
 

--- a/workers/weekly-digest/test/digest.test.js
+++ b/workers/weekly-digest/test/digest.test.js
@@ -972,7 +972,12 @@ test("the weekly badge window is the reported week, absolutely, not a relative l
   const issuesUrl = new URL(urls.find((u) => u.includes("/issues/")));
   assert.equal(issuesUrl.searchParams.get("start"), "2026-07-27T00:00:00");
   assert.equal(issuesUrl.searchParams.get("end"), "2026-08-03T00:00:00");
-  assert.doesNotMatch(issuesUrl.searchParams.get("query") || "", /firstSeen:-/);
+  // Asserted EXACTLY. The negative form alone passed with an empty query, so it
+  // could not tell a correct absolute filter from no filter at all.
+  assert.equal(
+    issuesUrl.searchParams.get("query"),
+    "firstSeen:>=2026-07-27T00:00:00 firstSeen:<2026-08-03T00:00:00"
+  );
 });
 
 test("a Sentry outage costs the Sentry section and nothing else", async () => {

--- a/workers/weekly-digest/test/digest.test.js
+++ b/workers/weekly-digest/test/digest.test.js
@@ -962,14 +962,17 @@ test("the weekly Sentry section spends the fixed call budget and scopes to the r
   assert.match(sentry.description, /up to 2 people on builds older than 2\.4\.0/);
 });
 
-test("the weekly section asks for a SEVEN-day first-seen window, not the daily report's 24h", async () => {
-  // A default would be right for one caller and silently wrong for the other,
-  // badging only the last day of a seven-day window.
+test("the weekly badge window is the reported week, absolutely, not a relative lookback", async () => {
+  // The relative form was measured from NOW, and this worker runs 13 hours
+  // after its window closes, so `firstSeen:-7d` straddled the window in both
+  // directions. The window is now derived from the reported one.
   const urls = [];
   const h = harness({ sentry: (url) => { urls.push(url); return undefined; } });
   await h.run();
-  const issuesUrl = urls.find((u) => u.includes("/issues/"));
-  assert.match(decodeURIComponent(issuesUrl), /firstSeen:-7d/);
+  const issuesUrl = new URL(urls.find((u) => u.includes("/issues/")));
+  assert.equal(issuesUrl.searchParams.get("start"), "2026-07-27T00:00:00");
+  assert.equal(issuesUrl.searchParams.get("end"), "2026-08-03T00:00:00");
+  assert.doesNotMatch(issuesUrl.searchParams.get("query") || "", /firstSeen:-/);
 });
 
 test("a Sentry outage costs the Sentry section and nothing else", async () => {
@@ -983,6 +986,9 @@ test("a Sentry outage costs the Sentry section and nothing else", async () => {
   assert.match(digest.embeds[0].title, /All website traffic/);
   for (const embed of digest.embeds.slice(0, 4)) {
     assert.doesNotMatch(embed.title, /unavailable/);
+    // The DESCRIPTION too: these sections put their degraded wording in the
+    // body, so a title-only check would pass a mutation that degraded all four.
+    assert.doesNotMatch(embed.description, /temporarily unavailable|not a report of zero/);
   }
 });
 

--- a/workers/weekly-digest/test/digest.test.js
+++ b/workers/weekly-digest/test/digest.test.js
@@ -28,6 +28,7 @@ import worker, {
   formatAppUsage,
   SOURCE_LABELS,
 } from "../src/index.js";
+import { SENTRY_CALLS_PER_DIGEST } from "../../reporting/sentry-section.js";
 
 // Every event-property reference must be qualified as properties.<name>: a bare
 // name does not resolve in PostHog HogQL. This regex catches the regression
@@ -43,7 +44,60 @@ const ENV = {
   GITHUB_REPO: "saurabhav88/EnviousWispr",
   DISCORD_WEBHOOK_URL: "https://discord.test/hook",
   TRIGGER_SECRET: "s3cret",
+  // #1965. A deployment without these is a legitimate state (the secret has not
+  // been installed on this Worker yet) and has its own test below.
+  SENTRY_ORG: "envious-labs-llc",
+  SENTRY_PROJECT_ID: "4511097112428544",
+  SENTRY_PROJECT_SLUG: "enviouswispr",
+  SENTRY_AUTH_TOKEN: "sentry-test-token",
 };
+
+// The real 2026-08-05 production release split, so the release line these tests
+// resolve is the one the rule actually produces rather than a shape invented to
+// match it. 2.4.3 has the most people, so the line is 2.4.0 and 2.3.1 is tail.
+const SENTRY_RELEASE_ROWS = [
+  { release: "com.enviouswispr.app@2.4.3", "count_unique(user)": 8, "count()": 19 },
+  { release: "com.enviouswispr.app@2.4.1", "count_unique(user)": 3, "count()": 12 },
+  { release: "com.enviouswispr.app@2.3.1", "count_unique(user)": 2, "count()": 5 },
+];
+const SENTRY_PROBLEM_ROWS = [
+  {
+    issue: "ENVIOUSWISPR-2C", "issue.id": 1, title: "audio_capture_stalled: HeartPathError#0",
+    "error.category": "audio_capture_stalled", level: "error",
+    "count_unique(user)": 25, "count()": 103,
+  },
+  {
+    issue: "ENVIOUSWISPR-24", "issue.id": 2, title: "paste_failed: HeartPathError#3",
+    "error.category": "paste_failed", level: "error",
+    "count_unique(user)": 13, "count()": 18,
+  },
+];
+
+/** Carries `meta.fields`, which the LIVE endpoint returns even for an empty
+ * result (measured 2026-08-06). A double that omitted it would hide the very
+ * defect the shape check exists to catch. */
+function sentryBody(rows, names) {
+  return { data: rows, meta: { fields: Object.fromEntries(names.map((n) => [n, "integer"])) } };
+}
+
+function sentryAnswer(url, overrides) {
+  if (overrides.sentry) {
+    const custom = overrides.sentry(url);
+    if (custom !== undefined) return custom;
+  }
+  if (url.includes("/issues/")) return ok([{ shortId: "ENVIOUSWISPR-4P", firstSeen: "2026-08-01T12:00:00Z" }]);
+  if (url.includes("field=release")) {
+    return ok(sentryBody(SENTRY_RELEASE_ROWS, ["release", "count_unique(user)", "count()"]));
+  }
+  if (url.includes("field=issue")) {
+    return ok(sentryBody(SENTRY_PROBLEM_ROWS,
+      ["title", "issue.id", "error.category", "level", "count_unique(user)", "count()"]));
+  }
+  // The prior window starts seven days before the reported one.
+  const isPrior = url.includes(encodeURIComponent("2026-07-20T00:00:00"));
+  return ok(sentryBody([{ "count_unique(user)": isPrior ? 30 : 38, "count()": 121 }],
+    ["count_unique(user)", "count()"]));
+}
 
 // Pinned so the window is deterministic: Monday 2026-08-03 13:00 UTC ->
 // window 2026-07-27 .. 2026-08-03 exclusive, last included day 2026-08-02.
@@ -83,7 +137,7 @@ const RELEASES_PAGE = (count, startTag = 1) =>
  * Cloudflare / GitHub behaviour.
  */
 function harness(overrides = {}) {
-  const state = { posts: [], queryNames: [], inFlight: 0, peakInFlight: 0, posthogCalls: 0, githubPages: [], sql: [] };
+  const state = { posts: [], queryNames: [], inFlight: 0, peakInFlight: 0, posthogCalls: 0, sentryCalls: 0, githubPages: [], sql: [] };
 
   const fetchFn = async (url, init) => {
     if (String(url).includes("posthog.com")) {
@@ -115,6 +169,10 @@ function harness(overrides = {}) {
       state.githubPages.push(page);
       if (overrides.github) return overrides.github(page);
       return ok(page === 1 ? RELEASES_PAGE(100) : RELEASES_PAGE(45, 101));
+    }
+    if (String(url).includes("us.sentry.io")) {
+      state.sentryCalls += 1;
+      return sentryAnswer(String(url), overrides);
     }
     if (String(url).includes("discord.test")) {
       state.posts.push(JSON.parse(init.body));
@@ -306,7 +364,11 @@ test("a dev_ids 401 costs app usage only; a METRIC 401 fails the whole run", asy
   const devAuth = harness({ posthog: { dev_ids: () => fail(401) } });
   await assert.rejects(() => devAuth.run(), /unavailable sections/);
   assert.equal(devAuth.state.posts.length, 1, "a partial digest still posts");
-  assert.equal(devAuth.state.posts[0].embeds.length, 4);
+  assert.equal(devAuth.state.posts[0].embeds.length, 5);
+  // Sentry is a different vendor entirely, so a PostHog credential failure must
+  // not cost it. A section that failed because an unrelated API failed would be
+  // a coupling this design does not have.
+  assert.doesNotMatch(devAuth.state.posts[0].embeds[4].title, /unavailable/);
 
   const metricAuth = harness({ posthog: { website: () => fail(401) } });
   await assert.rejects(() => metricAuth.run(), /HTTP 401/);
@@ -455,13 +517,14 @@ test("GitHub non-2xx on the first page degrades instead of returning '?'", async
 
 // ---- Payload -----------------------------------------------------------------
 
-test("the digest posts four section embeds carrying the brand colour", async () => {
+test("the digest posts five section embeds carrying the brand colour", async () => {
   const h = harness();
   await h.run();
   const [digest] = h.state.posts;
-  assert.equal(digest.embeds.length, 4);
+  assert.equal(digest.embeds.length, 5);
   assert.deepEqual(digest.embeds.map((e) => e.title), [
     "All website traffic", "Tracked visitor activity", "Downloads", "App usage",
+    "Sentry, last 7 days",
   ]);
   for (const embed of digest.embeds) {
     assert.equal(embed.color, 0x7c3aed);
@@ -879,4 +942,59 @@ test("the install line claims setup BEGAN, never that it was a first time", asyn
   const text = h.state.posts[0].embeds[3].description;
   assert.match(text, /51 people began setting up\./);
   assert.doesNotMatch(text, /first time/);
+});
+
+// ---- Sentry section (#1965) --------------------------------------------------
+
+test("the weekly Sentry section spends the fixed call budget and scopes to the release line", async () => {
+  const h = harness();
+  await h.run();
+  assert.equal(h.state.sentryCalls, SENTRY_CALLS_PER_DIGEST,
+    "five fixed Sentry calls, never a per-issue fan-out");
+  const [digest] = h.state.posts;
+  const sentry = digest.embeds[4];
+  assert.match(sentry.description, /on 2\.4\.0 and newer/);
+  assert.match(sentry.description, /25 people {3}microphone capture stalled/);
+  assert.match(sentry.description, /13 people {3}paste fell back to the clipboard/);
+  // 8 more people than the prior week (38 vs 30).
+  assert.match(sentry.description, /8 more than the previous period \(30 people\)/);
+  // The tail line: 2.3.1 sits below the resolved 2.4.0 line.
+  assert.match(sentry.description, /up to 2 people on builds older than 2\.4\.0/);
+});
+
+test("the weekly section asks for a SEVEN-day first-seen window, not the daily report's 24h", async () => {
+  // A default would be right for one caller and silently wrong for the other,
+  // badging only the last day of a seven-day window.
+  const urls = [];
+  const h = harness({ sentry: (url) => { urls.push(url); return undefined; } });
+  await h.run();
+  const issuesUrl = urls.find((u) => u.includes("/issues/"));
+  assert.match(decodeURIComponent(issuesUrl), /firstSeen:-7d/);
+});
+
+test("a Sentry outage costs the Sentry section and nothing else", async () => {
+  const h = harness({ sentry: () => fail(503) });
+  await assert.rejects(() => h.run(), /unavailable sections/);
+  const [digest] = h.state.posts;
+  assert.equal(digest.embeds.length, 5, "the digest still posts, whole");
+  assert.match(digest.embeds[4].title, /unavailable today/);
+  assert.match(digest.embeds[4].description, /not a report of zero/);
+  // The other four sections are untouched and REAL.
+  assert.match(digest.embeds[0].title, /All website traffic/);
+  for (const embed of digest.embeds.slice(0, 4)) {
+    assert.doesNotMatch(embed.title, /unavailable/);
+  }
+});
+
+test("a worker without the Sentry credential degrades that section only", async () => {
+  // A real deployment state: §12.1 installs the secret before deploying the
+  // code, and between those two steps this is exactly what the digest looks
+  // like. It must not be a whole-run failure.
+  const { SENTRY_AUTH_TOKEN, ...noToken } = ENV;
+  const h = harness();
+  await assert.rejects(() => h.run(noToken), /unavailable sections/);
+  const [digest] = h.state.posts;
+  assert.equal(digest.embeds.length, 5);
+  assert.match(digest.embeds[4].title, /unavailable today/);
+  assert.equal(h.state.sentryCalls, 0, "a missing credential makes no request at all");
 });

--- a/workers/weekly-digest/wrangler.toml
+++ b/workers/weekly-digest/wrangler.toml
@@ -17,11 +17,13 @@ SENTRY_PROJECT_SLUG = "enviouswispr"
 # Secrets (set via `npx wrangler secret put <NAME>`, never in this file):
 #   POSTHOG_PERSONAL_API_KEY  - GCP secret `posthog-personal-api-key`
 #   SENTRY_AUTH_TOKEN         - reads the Sentry section's aggregates (#1965).
-#     Same token and the same caveat as workers/daily-report/wrangler.toml:
+#     GCP secret `sentry-workers-readonly-token`. Same token and the same
+#     reasoning as workers/daily-report/wrangler.toml, which owns the detail:
 #     neither `sentry-triage-worker-token` nor `sentry-auth-token` can make this
 #     call (both 403 on `/organizations/<org>/events/`, measured 2026-08-06).
-#     Absent, the section renders "unavailable today" and the other four
-#     sections are unaffected.
+#     The same token also goes on sentry-triage, which needs it for the
+#     rate-alert breakdown. Absent, the section renders "unavailable today" and
+#     the other four sections are unaffected.
 #   DISCORD_WEBHOOK_URL       - the session-logs webhook
 #   CF_EMAIL / CF_API_KEY     - Cloudflare Analytics GraphQL auth
 #   GITHUB_TOKEN              - optional; raises the releases rate limit

--- a/workers/weekly-digest/wrangler.toml
+++ b/workers/weekly-digest/wrangler.toml
@@ -9,9 +9,19 @@ crons = ["0 13 * * 1"]  # Every Monday at 1pm UTC = 9am ET
 CF_ZONE_ID = "b4416a0f0ebd699e96969a331c7ad7ff"
 GITHUB_REPO = "saurabhav88/EnviousWispr"
 POSTHOG_PROJECT_ID = "354235"
+# Sentry section (#1965). Identifiers only, no credential.
+SENTRY_ORG = "envious-labs-llc"
+SENTRY_PROJECT_ID = "4511097112428544"
+SENTRY_PROJECT_SLUG = "enviouswispr"
 
 # Secrets (set via `npx wrangler secret put <NAME>`, never in this file):
 #   POSTHOG_PERSONAL_API_KEY  - GCP secret `posthog-personal-api-key`
+#   SENTRY_AUTH_TOKEN         - reads the Sentry section's aggregates (#1965).
+#     Same token and the same caveat as workers/daily-report/wrangler.toml:
+#     neither `sentry-triage-worker-token` nor `sentry-auth-token` can make this
+#     call (both 403 on `/organizations/<org>/events/`, measured 2026-08-06).
+#     Absent, the section renders "unavailable today" and the other four
+#     sections are unaffected.
 #   DISCORD_WEBHOOK_URL       - the session-logs webhook
 #   CF_EMAIL / CF_API_KEY     - Cloudflare Analytics GraphQL auth
 #   GITHUB_TOKEN              - optional; raises the releases rate limit


### PR DESCRIPTION
Part of #1965.

## The problem

Three separate defects, all verified live on 2026-08-06.

**A known problem that spreads to more people posts nothing, ever.** The triage worker fires only on `created` and `unresolved`, and Sentry emits neither when an already-open issue simply accumulates events. Measured:

| Issue | Users | Events | Full activity log | Discord posts |
|---|---:|---:|---|---:|
| `ENVIOUSWISPR-24` paste fallback | 172 | 806 | `first_seen`, `auto_set_ongoing` | 1, on 2026-07-02 |
| `ENVIOUSWISPR-1R` vad prepare | 153 | 747 | `first_seen`, `auto_set_ongoing` | 1, on 2026-06-25 |

**The rate alerts fire correctly and carry no information.** All three metric rules are `count()` over `is:unresolved`, identical apart from their threshold, and their names assert diagnoses the query cannot make. Sentry files each firing as an issue, so they reach Discord through the worker and render as `What: unknown / Version: unknown / Impact: 0 user(s)`. One bad hour crosses all three thresholds and produces three near-identical posts.

**A shipped comment justified a design choice with a false claim** about that alert filtering by category. It does not.

## What this ships

Both digests gain a Sentry section, scored on the current release line, split into dictations **lost** and dictations that **still worked, just worse**, with the change in affected people against the preceding equal window. The rate-alert card is rewritten to name the problems, versions and dev split, on a dedicated six-hour throttle. The false comment is deleted.

Live output, real data, from the pre-deploy smoke:

```
Sentry, yesterday
12 people hit 35 errors across 8 problems, on 2.4.0 and newer.
That is 1 fewer than the previous period (13 people).
Impact rate unavailable: error counts and usage counts come from different identity systems.
Separately, up to 2 people on builds older than 2.4.0.

LOST THE DICTATION
  6 people   microphone capture stalled
  2 people   saved recording could not be transcribed
  1 person   app crash (NSInternalInconsistencyException) ENVIOUSWISPR-34, delivery not proven
  1 person   app crash (NSInternalInconsistencyException) ENVIOUSWISPR-3V, delivery not proven
  1 person   microphone capture failed
  1 person   saved recording produced no text

STILL WORKED, JUST WORSE
  1 person   paste fell back to the clipboard
  1 person   polish provider failed
```

## Three plan premises were measured first, and one was false

**1. Neither worker token can make this query.** `sentry-triage-worker-token` and `sentry-auth-token` both 403 on `/organizations/<org>/events/`, which is where every number in this section comes from. The plan asserted the triage token would serve. The endpoint IS available on this plan (the admin token answers in ~300 ms), so the gap is scope, not entitlement, and `POST /org-auth-tokens/` returns 404 so a replacement cannot be minted from the API.

The plan's own measurement was taken through the Sentry MCP, which carries the founder's OAuth session, so it could never have caught this.

**This is a deploy-time blocker, not a code blocker.** Every module reads `env.SENTRY_AUTH_TOKEN` and degrades to "unavailable today" without it, with the rest of each report unaffected. See "Before deploying" below.

**2. The release line is derived from live data.** Sentry accepts `release.version:>=X`, so the floor is the minor line of the release with the most affected people, and everything above it. Not a constant (goes stale silently, which is the defect being fixed), not the newest release (cliffs on release day), not a summed share (Sentry user counts are not additive across releases). Over 7 days it drops 6 of 21 problems, every one a single-user tail on an old build, including the vad prepare failure fixed in 2.4.0 and `asr_empty_result`, which no shipping build emits.

**3. The budget is five fixed calls, not three.** Discover returns either a grouped result or an aggregate, never both. The constraint that matters is unchanged and asserted by a test: no call fans out per issue, so the count never moves with error volume. Sentry retries twice rather than three times, because at three the daily report's worst case lands on 49 against Cloudflare's 50-subrequest cap.

## Correctness notes

- All 27 `ErrorCategory` cases are classified, and the completeness test parses the Swift enum directly so it cannot go stale.
- `recovery_key_store_failed` and `hotkey_registration_failed` are **degraded**, corrected against their producers. `xpc_service_error`, `model_load_wedged` and `pipeline_dispatch_failed` render "delivery not proven" because their producers disagree and no indexed field separates them. Three cases have no producer anywhere and are marked unemitted.
- **Never prints an impact rate.** Sentry and PostHog join only per install and only partially, so a rate would be arithmetic across two identity systems.
- Degradable in both workers, never whole-run fatal: a Sentry outage must not cost the adoption numbers.

## Verification

| Check | Result |
|---|---|
| `workers/daily-report` | 226 pass, 0 fail |
| `workers/weekly-digest` | 73 pass, 0 fail |
| `workers/sentry-triage` | 83 pass, 0 fail |
| `scripts/xcode-test.sh` | `** TEST SUCCEEDED **`, 4,991 tests executed |
| Live smoke, both digests, real Sentry + real PostHog | both rendered fully, nothing posted |
| Mutation controls | 28 across two harnesses, 28 killed. Every mutation asserts its anchor; a no-op control proves the harness reports SURVIVED when nothing is broken |

### Four review rounds, and what each was for

| Round | Found |
|---|---|
| 1 | Budget overrun, an incomplete collision fix, permissive count coercion |
| 2 | **The NEW badge measured from the wrong clock**, two partial totals printed as exact, a raw network error crossing the privacy boundary, a DST-wrong prior window |
| 3 | Two more partial totals, unchecked derived sums, a NaN budget that disabled every check |
| 4 | **CHUNK-CLEAN** |

Two classes are worth calling out because neither would ever have been noticed in use:

- **Windows measured against the wrong instant.** `firstSeen:-24h` is relative to NOW, and neither report runs when its window closes. Separately, the daily prior window subtracted the reported day's own duration, which is wrong on the two DST days a year. Both produce numbers that look entirely normal.
- **Partial totals printed as exact**, in three places. Fixed one, swept badly, and the reviewer found the other two.

**Four of my own tests proved nothing** and were caught across these rounds, including one that assigned a value and then asserted it equalled itself. The first mutation harness was also lying: after the round-1 fixes, four of its mutations no longer matched any code, so they patched nothing and reported the tests as green. Every mutation now asserts its anchor first.

The live smokes found two presentation defects no unit test would have: two distinct crashes rendering as identical rows, then two distinct fingerprints of the same exception type still colliding.

One reviewer prescription was **not** adopted. It wanted a truncated badge set to fail the whole section; that section is most worth reading precisely when a release has gone badly wrong, so it discloses instead. The spike card does the opposite for the same situation, deliberately, because its headline *is* the incomplete number. The reviewer re-examined both and agreed.

## Before deploying

A merged PR deploys nothing. Follow `workers/reporting/README.md`, and note there are **two** deployment sets: the policy module has two consumers, the shared transport has three.

1. Resolve the credential above and install `SENTRY_AUTH_TOKEN` on both digest workers.
2. Deploy and verify triage first, while all three metric rules stay active.
3. Deploy and verify daily, then weekly.
4. Only then rename rule 415417 and delete 415418 / 415419. Rule deletion destroys firing history irreversibly; the counts are preserved in #1965.
