### PR TITLE
fix(ci): daily-report ping prints the failure reason instead of binning it (Closes #1969)

### DIFF
--- a/.github/workflows/daily-report-ping.yml
+++ b/.github/workflows/daily-report-ping.yml
@@ -68,7 +68,33 @@ jobs:
           # A single failed attempt already turns this job red (GitHub's own
           # failure-email signal); manual recovery is the documented ?date=
           # override (README § Failure visibility), not an automatic retry.
-          curl -fsS \
+          #
+          # --fail-with-body, NOT -f. Both turn a non-2xx into a nonzero exit, but
+          # plain -f SUPPRESSES the body, and the body is the only place the reason
+          # exists: the worker returns "daily report failed: " + err.message
+          # (src/index.js fetch catch), naming the failing query and its HTTP
+          # status. Under -f with -o /dev/null every failure was diagnostically
+          # empty, so #1969 had to argue about causes from job DURATIONS.
+          BODY_FILE="$(mktemp)"
+          RC=0
+          curl -sS --fail-with-body \
             -H "x-trigger-secret: ${TRIGGER_SECRET}" \
             "$URL" \
-            -o /dev/null -w "worker responded HTTP %{http_code}\n"
+            -o "$BODY_FILE" -w "worker responded HTTP %{http_code}\n" || RC=$?
+          if [ "$RC" -ne 0 ]; then
+            echo "--- worker response body (failure reason) ---"
+            # This repository is PUBLIC, so these logs are world-readable, and
+            # Actions can only mask secrets it holds ITSELF - DISCORD_WEBHOOK_URL
+            # is a CLOUDFLARE secret and is not maskable here. err.message is
+            # whatever was thrown: every shape this exists to capture carries no
+            # URL ("PostHog query <name> HTTP <status>", "Discord rejected the
+            # report: HTTP <status>"), but an unexpected native throw could - a
+            # malformed-URL TypeError out of deliverReport would quote the
+            # webhook. So cap, then mask any URL. Capping FIRST is deliberate: it
+            # keeps a long body from SIGPIPE-ing the masker under pipefail, and
+            # a URL starting inside the kept prefix is still matched at its scheme.
+            head -c 2000 "$BODY_FILE" \
+              | sed -E 's#[a-zA-Z][a-zA-Z0-9+.-]*://[^[:space:]]*#<redacted-url>#g'
+            echo
+            exit "$RC"
+          fi


### PR DESCRIPTION
Closes #1969.

The worker has always returned why it failed. The ping threw it away every time, so #1969 had to argue about causes from job **durations**.

## The cause was `-f`, not `-o /dev/null`

Both flags had to change. `-f` **suppresses the response body**, so redirecting to a file while keeping `-f` would still have captured nothing. `--fail-with-body` keeps the non-2xx exit *and* the body (curl 7.76+; `ubuntu-latest` ships 8.x). `|| RC=$?` is required because Actions runs the block under `-e`, where a bare `RC=$?` after a failing curl is never reached.

## Redacted and capped, because this repo is public

Workflow logs here are world-readable, and Actions masks only secrets it holds itself — `DISCORD_WEBHOOK_URL` is a **Cloudflare** secret and cannot be masked here. Every shape this exists to capture carries no URL (`PostHog query <name> HTTP <status>`; `Discord rejected the report: HTTP <status>` — checked every throw site in `workers/shared/discord.js` and `workers/shared/posthog.js`), but `err.message` is whatever was thrown and an unexpected native throw could: a malformed-URL `TypeError` out of `deliverReport` would quote the webhook.

Classified **hypothetical**, fixed anyway because the change is two lines and the failure would be silent and permanent once indexed.

Capping precedes masking on purpose: `head -c 2000 | sed` cannot SIGPIPE the masker under `pipefail`, whereas `sed | head -c` can on an over-length body, and a URL beginning inside the kept prefix is still matched at its scheme.

## Validation

Two-way control under GitHub's own interpreter flags (`bash --noprofile --norc -e -o pipefail`) against a stub `curl` reproducing `--fail-with-body`:

| Case | Result |
|---|---|
| 200 | exits 0, prints no body |
| 500 naming the query | prints it intact, exits 22 |
| 500 carrying a webhook URL | prints `<redacted-url>` |
| 3000-byte body | truncates, no `pipefail` crash |

**Baseline control on the same failing stub:** the pre-fix block prints `worker responded HTTP 500` and nothing else. So the check discriminates rather than passing by construction.

`shellcheck` clean, verified against a positive control first (it flags SC2034/SC2116 on a probe) so its silence is evidence rather than absence.

Local `codex review`: clean, no findings.

## The issue's headline rate is wrong, and this corrects it

Splitting the run history at the last reliability fix (`b81ac1d5`, #1720, 2026-07-20 17:26Z):

- **4 failures in the 12 runs before it**
- **12 consecutive clean runs**, Jul 21 – Aug 1
- **3 failures in the last 5**

The "24% of runs" headline averaged across the repair and hid that it worked. The recent cluster is a separate, still-unattributed regression: the Aug 1 change (`f5d24225`) made its query **lighter**, dropping an `app.launched` scan for `onboarding.started`, and the Jul 30 scorecard (`e4d053de`) ran clean for three days first. Guessing at it is exactly what this PR stops being necessary.

Today's failed run was also recovered manually while investigating — it returned a healthy report in 13.8s, so the missing August 6 report is posted.
