### PR TITLE
fix(llm): Ollama model picker no longer shows two models as one name

### DIFF
--- a/Sources/EnviousWisprLLM/OllamaSetupService.swift
+++ b/Sources/EnviousWisprLLM/OllamaSetupService.swift
@@ -1076,6 +1076,12 @@ public final class OllamaSetupService {
   nonisolated static func parseDownloadedModels(
     fromTagsModels models: [[String: Any]]
   ) -> [OllamaDownloadedModel] {
+    disambiguateLocalCollisions(parseDownloadedModelsWithoutDisambiguation(fromTagsModels: models))
+  }
+
+  nonisolated private static func parseDownloadedModelsWithoutDisambiguation(
+    fromTagsModels models: [[String: Any]]
+  ) -> [OllamaDownloadedModel] {
     models.compactMap { model -> OllamaDownloadedModel? in
       guard let name = model["name"] as? String else { return nil }
       let canonical = canonicalModelName(name)
@@ -1114,6 +1120,68 @@ public final class OllamaSetupService {
         fileSizeBytes: fileSizeBytes,
         displayName: displayName,
         facts: facts
+      )
+    }
+  }
+
+  /// #1947: the LOCAL half of the same defect #1956 fixed for hosted rows.
+  /// `inferDisplayName` drops everything after the colon, so two locally
+  /// installed sizes of one family (`llama3.2:1b` and `llama3.2:3b`, say)
+  /// both prettify to "Llama 3.2" — hosted rows dodge this by showing the
+  /// exact name verbatim (`hostedDisplayName`), but doing the same for every
+  /// local row would blank the prettification that already works for the
+  /// overwhelmingly common non-colliding case. Instead, only names that
+  /// ACTUALLY collide within this response get a disambiguating suffix.
+  ///
+  /// Two passes, because one suffix source is not always enough: pass 1
+  /// appends the parsed parameter size (the same "(SIZE)" convention the
+  /// curated static catalog already uses, e.g. `"Llama 3.2 (1B)"`), which
+  /// resolves the common case (two different sizes of one family) without
+  /// losing prettification. But two variants can share a size too (e.g. two
+  /// quantizations of the same 3B checkpoint), so pass 2 re-checks for a
+  /// SURVIVING collision after pass 1 and falls back to the exact tag for
+  /// just those — `exactName` is unique by construction (Ollama will not
+  /// list the same tag twice), so pass 2 cannot fail to resolve it.
+  nonisolated private static func disambiguateLocalCollisions(
+    _ models: [OllamaDownloadedModel]
+  ) -> [OllamaDownloadedModel] {
+    let localDisplayNames = models.filter { !$0.facts.isRemote }.map(\.displayName)
+    guard localDisplayNames.count != Set(localDisplayNames).count else { return models }
+
+    let sizeDisambiguated = renamingCollisions(in: models) { model in
+      let suffix = model.parameterSize.map { " (\($0.uppercased()))" } ?? " (\(model.exactName))"
+      return model.displayName + suffix
+    }
+    // Full replacement, not another suffix — appending the exact tag onto an
+    // already-suffixed name (e.g. "Llama3 2 (3B)") would still not be unique
+    // if two entries shared that same suffixed form, and reads worse besides.
+    return renamingCollisions(in: sizeDisambiguated) { model in model.exactName }
+  }
+
+  /// Shared collision pass: among LOCAL rows only, find every `displayName`
+  /// shared by more than one model and replace each with `rename(model)`.
+  /// Idempotent when nothing collides (returns `models` unchanged).
+  nonisolated private static func renamingCollisions(
+    in models: [OllamaDownloadedModel],
+    rename: (OllamaDownloadedModel) -> String
+  ) -> [OllamaDownloadedModel] {
+    var counts: [String: Int] = [:]
+    for model in models where !model.facts.isRemote {
+      counts[model.displayName, default: 0] += 1
+    }
+    let colliding = Set(counts.filter { $0.value > 1 }.keys)
+    guard !colliding.isEmpty else { return models }
+
+    return models.map { model in
+      guard !model.facts.isRemote, colliding.contains(model.displayName) else { return model }
+      return OllamaDownloadedModel(
+        exactName: model.exactName,
+        canonicalName: model.canonicalName,
+        parameterSize: model.parameterSize,
+        parameterBillions: model.parameterBillions,
+        fileSizeBytes: model.fileSizeBytes,
+        displayName: rename(model),
+        facts: model.facts
       )
     }
   }

--- a/Tests/EnviousWisprTests/LLM/LLMModelDiscoveryTests.swift
+++ b/Tests/EnviousWisprTests/LLM/LLMModelDiscoveryTests.swift
@@ -85,25 +85,100 @@ struct LLMModelDiscoveryTests {
     #expect(candidates.first(where: { $0.id == "gpt-oss:120b-cloud" })?.isRemote == true)
   }
 
-  /// #1947 verification (closed, already fixed by #1956/PR #1973): the
-  /// picker's own data source, not `dynamicCatalog`'s (Manage Models' path,
-  /// covered by `OllamaManageModelsPresentationTests`). `parseDownloadedModels`
-  /// (`OllamaSetupService.swift:~1105`) is the shared construction site both
-  /// paths draw from, and its own comment names this exact case ("left the
-  /// picker listing... 'Gpt Oss' twice, which is what the founder
-  /// screenshotted") — this test pins that fix at the layer #1947 actually
-  /// complained about, since `ollamaCandidates` re-exercising it is what a
-  /// `dynamicCatalog`-only test cannot prove.
-  @Test("two hosted models differing only by tag render distinct picker labels")
+  /// #1947, hosted half: the picker's own data source, not `dynamicCatalog`'s
+  /// (Manage Models' path, covered by `OllamaManageModelsPresentationTests`).
+  /// `parseDownloadedModels` (`OllamaSetupService.swift:~1105`) is the shared
+  /// construction site both paths draw from, and its own comment names this
+  /// exact case ("left the picker listing... 'Gpt Oss' twice, which is what
+  /// the founder screenshotted") — this test pins the fix at the layer #1947
+  /// actually complained about AND through to `LLMModelInfo`, the row the
+  /// picker actually renders (`Text(model.displayName)`,
+  /// `AIPolishSettingsView.swift:977`) — a `DiscoveryCandidate`-only
+  /// assertion stops one hop short of what the picker consumes. Uses the
+  /// daemon's real `remote_host` shape (`"https://ollama.com"`, not a bare
+  /// hostname) per whole-diff review r1.
+  @Test(
+    "two hosted models differing only by tag produce distinct picker labels",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/1947",
+      "Ollama model picker shows identical rows")
+  )
   func hostedCandidatesDifferingOnlyByTagStayDistinct() {
     let candidates = LLMModelDiscovery.ollamaCandidates(fromTagsModels: [
-      ["name": "gpt-oss:20b-cloud", "remote_host": "ollama.com"],
-      ["name": "gpt-oss:120b-cloud", "remote_host": "ollama.com"],
+      ["name": "gpt-oss:20b-cloud", "remote_host": "https://ollama.com"],
+      ["name": "gpt-oss:120b-cloud", "remote_host": "https://ollama.com"],
     ])
+    let models = candidates.map {
+      LLMModelDiscovery.modelInfo(from: $0, provider: .ollama, isAvailable: true)
+    }
 
-    #expect(candidates.count == 2)
+    #expect(models.map(\.id) == ["gpt-oss:20b-cloud", "gpt-oss:120b-cloud"])
+    #expect(models.map(\.displayName) == ["gpt-oss:20b-cloud", "gpt-oss:120b-cloud"])
+  }
+
+  /// #1947, local half: whole-diff review r1 found the fix above only covered
+  /// HOSTED rows — `parseDownloadedModels` still sent local models through
+  /// `inferDisplayName`, which drops everything after the colon, so two
+  /// installed sizes of one LOCAL family (`llama3.2:1b` / `llama3.2:3b`)
+  /// still both prettified to "Llama 3.2". #1947's own text named this: "Any
+  /// two variants of one family collide. This is not specific to hosted
+  /// models." Fixed by `disambiguateLocalCollisions` appending the parsed
+  /// size, matching this catalog's own "(SIZE)" convention.
+  @Test(
+    "two local models differing only by size get a disambiguating suffix",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/1947",
+      "Ollama model picker shows identical rows")
+  )
+  func localCandidatesDifferingBySizeStayDistinct() {
+    let candidates = LLMModelDiscovery.ollamaCandidates(fromTagsModels: [
+      ["name": "llama3.2:1b", "details": ["parameter_size": "1B"]],
+      ["name": "llama3.2:3b", "details": ["parameter_size": "3B"]],
+    ])
     let names = candidates.map(\.displayName)
+    // The base is the shared parser's own prettified form, not the CURATED
+    // static-catalog string ("Llama 3.2") — that override belongs to
+    // `dynamicCatalog`'s Manage Models path only, per
+    // `candidateCarriesExactNameAndInferredLabel` above; the picker's own
+    // path never applies it.
+    let base = OllamaSetupService.inferDisplayName(from: "llama3.2")
+
     #expect(Set(names).count == 2, "collided: \(names)")
+    #expect(names.contains("\(base) (1B)"), "\(names)")
+    #expect(names.contains("\(base) (3B)"), "\(names)")
+  }
+
+  /// Second-pass fallback: two local variants can share a parsed size too
+  /// (two quantizations of the same checkpoint), so the size suffix alone
+  /// would still collide. The exact tag is unique by construction, so the
+  /// fallback pass always resolves it.
+  @Test("two local models sharing both family AND size fall back to the exact tag")
+  func localCandidatesSharingSizeFallBackToExactTag() {
+    let candidates = LLMModelDiscovery.ollamaCandidates(fromTagsModels: [
+      ["name": "llama3.2:3b-instruct-q4_K_M", "details": ["parameter_size": "3B"]],
+      ["name": "llama3.2:3b-instruct-q8_0", "details": ["parameter_size": "3B"]],
+    ])
+    let names = candidates.map(\.displayName)
+
+    #expect(Set(names).count == 2, "collided: \(names)")
+    #expect(names.contains("llama3.2:3b-instruct-q4_K_M"), "\(names)")
+    #expect(names.contains("llama3.2:3b-instruct-q8_0"), "\(names)")
+  }
+
+  /// Two-way control: a local model with no sibling of the same family keeps
+  /// its plain prettified name — the fix must not suffix everything.
+  @Test("a local model with no colliding sibling keeps its plain prettified name")
+  func localCandidateWithNoSiblingStaysPlain() {
+    let candidates = LLMModelDiscovery.ollamaCandidates(fromTagsModels: [
+      ["name": "llama3.2:1b", "details": ["parameter_size": "1B"]],
+      ["name": "mistral:7b", "details": ["parameter_size": "7B"]],
+    ])
+    let expected = [
+      OllamaSetupService.inferDisplayName(from: "llama3.2"),
+      OllamaSetupService.inferDisplayName(from: "mistral"),
+    ].sorted()
+
+    #expect(candidates.map(\.displayName).sorted() == expected)
   }
 
   /// Identity is the EXACT name, not the canonical one. The picker tags rows by

--- a/Tests/EnviousWisprTests/LLM/LLMModelDiscoveryTests.swift
+++ b/Tests/EnviousWisprTests/LLM/LLMModelDiscoveryTests.swift
@@ -85,6 +85,27 @@ struct LLMModelDiscoveryTests {
     #expect(candidates.first(where: { $0.id == "gpt-oss:120b-cloud" })?.isRemote == true)
   }
 
+  /// #1947 verification (closed, already fixed by #1956/PR #1973): the
+  /// picker's own data source, not `dynamicCatalog`'s (Manage Models' path,
+  /// covered by `OllamaManageModelsPresentationTests`). `parseDownloadedModels`
+  /// (`OllamaSetupService.swift:~1105`) is the shared construction site both
+  /// paths draw from, and its own comment names this exact case ("left the
+  /// picker listing... 'Gpt Oss' twice, which is what the founder
+  /// screenshotted") — this test pins that fix at the layer #1947 actually
+  /// complained about, since `ollamaCandidates` re-exercising it is what a
+  /// `dynamicCatalog`-only test cannot prove.
+  @Test("two hosted models differing only by tag render distinct picker labels")
+  func hostedCandidatesDifferingOnlyByTagStayDistinct() {
+    let candidates = LLMModelDiscovery.ollamaCandidates(fromTagsModels: [
+      ["name": "gpt-oss:20b-cloud", "remote_host": "ollama.com"],
+      ["name": "gpt-oss:120b-cloud", "remote_host": "ollama.com"],
+    ])
+
+    #expect(candidates.count == 2)
+    let names = candidates.map(\.displayName)
+    #expect(Set(names).count == 2, "collided: \(names)")
+  }
+
   /// Identity is the EXACT name, not the canonical one. The picker tags rows by
   /// this value and the runtime arms it, so dropping the `:latest` here would
   /// arm a name the daemon may not answer to.


### PR DESCRIPTION
## Summary

- The AI Polish model picker showed two different Ollama models as identical rows (e.g. `gpt-oss:20b-cloud` and `gpt-oss:120b-cloud` both rendered as "Gpt Oss") because the shared name-prettifying helper drops everything after the colon.
- Investigating, the HOSTED half of this was already fixed by a prior PR (#1973, closing #1956), but its own test coverage only exercised the Manage Models catalog, not the picker's actual data source — so this PR first adds a direct regression test at the layer #1947 complained about, proving the hosted fix reaches the picker.
- That review then found the LOCAL half of the same defect was still live: two locally installed sizes of one family (e.g. two `llama3.2` variants) still collide, exactly as #1947's own text predicted ("not specific to hosted models"). Fixed with a two-pass disambiguation: append the parsed model size to any colliding name (matching this catalog's own existing naming convention), then fall back to the exact tag for the rare case where two variants also share a size.

## Test plan

- [x] New unit tests: hosted collision (through to the `LLMModelInfo` row the picker renders), local size-collision, local same-size fallback, and a two-way control proving non-colliding names are untouched.
- [x] Existing `OllamaManageModelsPresentationTests` (47 tests) and `LLMModelDiscoveryTests` (14 tests) pass unmodified — confirms the Manage Models catalog path is unaffected.
- [x] Codex whole-diff review: no blocking findings.

Closes #1947
