### PR TITLE
fix(model-delivery): catch stale inner files a manifest revision leaves behind

### DIFF
--- a/Sources/EnviousWisprModelDelivery/CacheAdmission.swift
+++ b/Sources/EnviousWisprModelDelivery/CacheAdmission.swift
@@ -108,9 +108,74 @@ struct CacheAdmission {
         }
         onFileValidated?(file.resolvedInstallPath)
       }
+      // Every manifest-listed file can hash correctly while a STALE file the
+      // current manifest no longer lists survives beside them (#1372) — the
+      // loop above only ever looks at files THIS manifest names, so it has no
+      // way to notice one it doesn't. Catch it here, once, after the listed
+      // files are already known-good.
+      if componentOK,
+        Self.hasExtraFiles(
+          component: component, expectedFiles: files, installDirectory: installDirectory)
+      {
+        componentOK = false
+      }
       if componentOK { verified.insert(component) } else { failed.insert(component) }
     }
     return ValidationResult(verifiedComponents: verified, failedComponents: failed)
+  }
+
+  /// Whether the component's on-disk directory contains any file NOT in
+  /// `expectedFiles` — a stale leftover from a manifest revision that removed
+  /// or renamed a file INSIDE a still-otherwise-valid component. A loose
+  /// (non-directory) component has nothing to hide an extra file inside; only
+  /// a directory component (e.g. a `.mlmodelc` bundle) can. Directory entries
+  /// themselves are never compared (only regular files) — same trap
+  /// `ModelDeliveryController.hasStagedPartials` already documents for this
+  /// exact target (`subpathsOfDirectory` yields the directory name itself as
+  /// an entry).
+  static func hasExtraFiles(
+    component: String, expectedFiles: [DeliveryManifest.File], installDirectory: URL
+  ) -> Bool {
+    let componentRoot = installDirectory.appendingPathComponent(component)
+    var isDirectory: ObjCBool = false
+    guard FileManager.default.fileExists(atPath: componentRoot.path, isDirectory: &isDirectory),
+      isDirectory.boolValue
+    else { return false }
+
+    // `enumerator(at:)` returns OS-RESOLVED paths (e.g. `/private/tmp/...`
+    // under a `/tmp` checkout); `componentRoot.path` is not resolved. Naive
+    // string-prefix stripping between the two silently mismatches — the
+    // exact trap `swift-testing-patterns.md` RULE:
+    // repo-root-canonicalize-via-realpath-not-foundation-helpers documents
+    // for this codebase. Resolve through POSIX `realpath(3)` before
+    // comparing, not `URL.resolvingSymlinksInPath()` (documented there as
+    // insufficient for the `/tmp` case).
+    var resolvedBuffer = [CChar](repeating: 0, count: Int(PATH_MAX))
+    guard realpath(componentRoot.path, &resolvedBuffer) != nil else { return true }
+    let resolvedComponentRoot = String(cString: resolvedBuffer)
+
+    let expected = Set(expectedFiles.map(\.resolvedInstallPath))
+    guard
+      let enumerator = FileManager.default.enumerator(
+        at: componentRoot, includingPropertiesForKeys: [.isRegularFileKey])
+    else { return true }  // cannot enumerate ⇒ cannot prove clean; fail closed, not open
+
+    let prefixCount = resolvedComponentRoot.count + 1  // +1 drops the path separator
+    for case let fileURL as URL in enumerator {
+      guard
+        let values = try? fileURL.resourceValues(forKeys: [.isRegularFileKey]),
+        values.isRegularFile == true, fileURL.path.count > prefixCount
+      else { continue }
+      // Relative to the RESOLVED component root, then re-prefixed with the
+      // component name as a plain string — never path arithmetic against
+      // `installDirectory` again, which is what mismatched in the first place.
+      let relativeToComponent = String(fileURL.path.dropFirst(prefixCount))
+      let candidatePath = "\(component)/\(relativeToComponent)"
+      if !expected.contains(candidatePath) {
+        return true
+      }
+    }
+    return false
   }
 
   // MARK: - Promotion (grounded r1 revision 4 — explicit crash ordering)

--- a/Sources/EnviousWisprModelDelivery/CacheAdmission.swift
+++ b/Sources/EnviousWisprModelDelivery/CacheAdmission.swift
@@ -137,6 +137,22 @@ struct CacheAdmission {
     component: String, expectedFiles: [DeliveryManifest.File], installDirectory: URL
   ) -> Bool {
     let componentRoot = installDirectory.appendingPathComponent(component)
+
+    // Cloud review P2: a legitimately-installed component is never itself a
+    // symlink. Reject one without following it — `fileExists(atPath:
+    // isDirectory:)` follows symlinks transparently, so a component root
+    // symlinked to a directory containing stale files would pass the
+    // directory check below; worse, `enumerator(at:)` can return ZERO
+    // descendants when its OWN root is a symlink, so the loop below would
+    // never even run and this function would wrongly report "no extra
+    // files" having examined nothing. `.isSymbolicLinkKey` reports the URL
+    // itself, not its target (`lstat` semantics, not `stat`).
+    if let isSymlink = try? componentRoot.resourceValues(forKeys: [.isSymbolicLinkKey])
+      .isSymbolicLink, isSymlink
+    {
+      return true
+    }
+
     var isDirectory: ObjCBool = false
     guard FileManager.default.fileExists(atPath: componentRoot.path, isDirectory: &isDirectory),
       isDirectory.boolValue

--- a/Sources/EnviousWisprModelDelivery/CacheAdmission.swift
+++ b/Sources/EnviousWisprModelDelivery/CacheAdmission.swift
@@ -164,7 +164,7 @@ struct CacheAdmission {
     var traversalFailed = false
     guard
       let enumerator = FileManager.default.enumerator(
-        at: componentRoot, includingPropertiesForKeys: [.isRegularFileKey],
+        at: componentRoot, includingPropertiesForKeys: [.isDirectoryKey],
         errorHandler: { _, _ in
           traversalFailed = true
           return false  // stop; the flag alone decides the verdict below
@@ -173,9 +173,15 @@ struct CacheAdmission {
 
     let prefixCount = resolvedComponentRoot.count + 1  // +1 drops the path separator
     for case let fileURL as URL in enumerator {
+      // Cloud review P2: checking `isRegularFile` let an unlisted SYMLINK
+      // (e.g. a dangling link from manual cache manipulation) skip the
+      // check entirely, since a symlink is neither a regular file nor a
+      // directory. Any non-directory leaf must be accounted for — a
+      // directory is just a container and is walked into, never itself
+      // compared against `expected`.
       guard
-        let values = try? fileURL.resourceValues(forKeys: [.isRegularFileKey]),
-        values.isRegularFile == true, fileURL.path.count > prefixCount
+        let values = try? fileURL.resourceValues(forKeys: [.isDirectoryKey]),
+        values.isDirectory != true, fileURL.path.count > prefixCount
       else { continue }
       // Relative to the RESOLVED component root, then re-prefixed with the
       // component name as a plain string — never path arithmetic against

--- a/Sources/EnviousWisprModelDelivery/CacheAdmission.swift
+++ b/Sources/EnviousWisprModelDelivery/CacheAdmission.swift
@@ -155,9 +155,20 @@ struct CacheAdmission {
     let resolvedComponentRoot = String(cString: resolvedBuffer)
 
     let expected = Set(expectedFiles.map(\.resolvedInstallPath))
+    // Without an explicit `errorHandler`, `FileManager.enumerator` SILENTLY
+    // STOPS traversal on hitting an unreadable subdirectory rather than
+    // throwing — a stale file hidden behind that failure would never be
+    // seen, and the loop below would wrongly conclude the component is
+    // clean. Record the failure and fail closed on it (whole-diff review
+    // P2 finding).
+    var traversalFailed = false
     guard
       let enumerator = FileManager.default.enumerator(
-        at: componentRoot, includingPropertiesForKeys: [.isRegularFileKey])
+        at: componentRoot, includingPropertiesForKeys: [.isRegularFileKey],
+        errorHandler: { _, _ in
+          traversalFailed = true
+          return false  // stop; the flag alone decides the verdict below
+        })
     else { return true }  // cannot enumerate ⇒ cannot prove clean; fail closed, not open
 
     let prefixCount = resolvedComponentRoot.count + 1  // +1 drops the path separator
@@ -175,7 +186,7 @@ struct CacheAdmission {
         return true
       }
     }
-    return false
+    return traversalFailed
   }
 
   // MARK: - Promotion (grounded r1 revision 4 — explicit crash ordering)

--- a/Sources/EnviousWisprModelDelivery/CacheAdmission.swift
+++ b/Sources/EnviousWisprModelDelivery/CacheAdmission.swift
@@ -170,7 +170,13 @@ struct CacheAdmission {
     guard realpath(componentRoot.path, &resolvedBuffer) != nil else { return true }
     let resolvedComponentRoot = String(cString: resolvedBuffer)
 
-    let expected = Set(expectedFiles.map(\.resolvedInstallPath))
+    // Cloud review P2: a manifest path containing a non-canonical segment
+    // (e.g. `Encoder.mlmodelc/./foo.bin`) would compare unequal to the
+    // enumerator's own canonical form (`Encoder.mlmodelc/foo.bin`), forcing
+    // an unnecessary component repair. `standardizingPath` normalizes both
+    // sides identically before the comparison runs.
+    let expected = Set(
+      expectedFiles.map { ($0.resolvedInstallPath as NSString).standardizingPath })
     // Without an explicit `errorHandler`, `FileManager.enumerator` SILENTLY
     // STOPS traversal on hitting an unreadable subdirectory rather than
     // throwing — a stale file hidden behind that failure would never be

--- a/Tests/EnviousWisprTests/ModelDelivery/CacheAdmissionTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/CacheAdmissionTests.swift
@@ -76,6 +76,26 @@ import Testing
     #expect(result.verifiedComponents == ["vocab.json"])
   }
 
+  @Test func unreadableSubdirectoryFailsClosed() async throws {
+    // Whole-diff review P2: `FileManager.enumerator` silently STOPS
+    // traversal on an unreadable subdirectory rather than throwing, so a
+    // stale file hidden behind that failure would never be seen. An
+    // unverified traversal must never read as "nothing extra found."
+    let (install, metadata, _) = try makeDirs()
+    let files = ManifestFixture.smallFiles
+    for f in files { try write(f.content, under: install, path: f.path) }
+    let lockedDir = install.appendingPathComponent("Encoder.mlmodelc/locked", isDirectory: true)
+    try FileManager.default.createDirectory(at: lockedDir, withIntermediateDirectories: true)
+    try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: lockedDir.path)
+    defer {
+      try? FileManager.default.setAttributes(
+        [.posixPermissions: 0o755], ofItemAtPath: lockedDir.path)
+    }
+    let gate = try admission(files: files, dirs: (install, metadata))
+    let result = await gate.validateExistingCache()
+    #expect(result.failedComponents == ["Encoder.mlmodelc"])
+  }
+
   @Test func exactComponentContentsStayVerified() async throws {
     // Two-way control for the test above: EXACTLY the manifest-listed files,
     // nothing extra — the new check must not false-positive on the common case.

--- a/Tests/EnviousWisprTests/ModelDelivery/CacheAdmissionTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/CacheAdmissionTests.swift
@@ -76,6 +76,37 @@ import Testing
     #expect(result.verifiedComponents == ["vocab.json"])
   }
 
+  @Test func symlinkedComponentRootForcesComponentToFail() async throws {
+    // Cloud review P2: when the COMPONENT ROOT itself (Encoder.mlmodelc) is
+    // a symlink to a directory holding all expected files plus stale ones,
+    // `fileExists(atPath:isDirectory:)` follows it and the OLD code's
+    // enumerator could return zero descendants for a symlink root, so the
+    // stale contents were never examined and the component was admitted.
+    let (install, metadata, _) = try makeDirs()
+    let files = ManifestFixture.smallFiles
+    let realTarget = install.deletingLastPathComponent().appendingPathComponent(
+      "real-encoder-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: realTarget, withIntermediateDirectories: true)
+    for f in files where f.component == "Encoder.mlmodelc" {
+      let relative = String(f.path.dropFirst("Encoder.mlmodelc/".count))
+      let dest = realTarget.appendingPathComponent(relative)
+      try FileManager.default.createDirectory(
+        at: dest.deletingLastPathComponent(), withIntermediateDirectories: true)
+      try f.content.write(to: dest)
+    }
+    try Data("stale-outside-the-manifest".utf8).write(
+      to: realTarget.appendingPathComponent("stale.bin"))
+    try write(
+      files.first { $0.component == "vocab.json" }!.content, under: install, path: "vocab.json")
+    try FileManager.default.createSymbolicLink(
+      atPath: install.appendingPathComponent("Encoder.mlmodelc").path,
+      withDestinationPath: realTarget.path)
+
+    let gate = try admission(files: files, dirs: (install, metadata))
+    let result = await gate.validateExistingCache()
+    #expect(result.failedComponents == ["Encoder.mlmodelc"])
+  }
+
   @Test func unlistedSymlinkForcesComponentToFail() async throws {
     // Cloud review P2: a symlink is neither a regular file nor a directory,
     // so an `isRegularFile`-only check silently skipped an unlisted

--- a/Tests/EnviousWisprTests/ModelDelivery/CacheAdmissionTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/CacheAdmissionTests.swift
@@ -59,6 +59,50 @@ import Testing
     #expect(result.verifiedComponents == ["Encoder.mlmodelc"])
   }
 
+  @Test func staleInnerFileForcesComponentToFail() async throws {
+    // #1372: a manifest revision that removes or renames a file INSIDE an
+    // existing component leaves the stale file on disk. Every MANIFEST-listed
+    // file here still hashes correctly, but a file the manifest no longer
+    // names survives beside them, inside Encoder.mlmodelc.
+    let (install, metadata, _) = try makeDirs()
+    let files = ManifestFixture.smallFiles
+    for f in files { try write(f.content, under: install, path: f.path) }
+    try write(
+      Data("leftover-from-a-prior-revision".utf8), under: install,
+      path: "Encoder.mlmodelc/stale_leftover.bin")
+    let gate = try admission(files: files, dirs: (install, metadata))
+    let result = await gate.validateExistingCache()
+    #expect(result.failedComponents == ["Encoder.mlmodelc"])
+    #expect(result.verifiedComponents == ["vocab.json"])
+  }
+
+  @Test func exactComponentContentsStayVerified() async throws {
+    // Two-way control for the test above: EXACTLY the manifest-listed files,
+    // nothing extra — the new check must not false-positive on the common case.
+    let (install, metadata, _) = try makeDirs()
+    let files = ManifestFixture.smallFiles
+    for f in files { try write(f.content, under: install, path: f.path) }
+    let gate = try admission(files: files, dirs: (install, metadata))
+    let result = await gate.validateExistingCache()
+    #expect(result.failedComponents.isEmpty)
+    #expect(result.verifiedComponents.contains("Encoder.mlmodelc"))
+  }
+
+  @Test func looseComponentHasNoExtraFilesCheck() {
+    // A loose (non-directory) component has nothing to recurse into.
+    let (path:path, content:_, component:component) = ManifestFixture.smallFiles[2]
+    let installDirectory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("admission-loose-\(UUID().uuidString)", isDirectory: true)
+    try? FileManager.default.createDirectory(
+      at: installDirectory, withIntermediateDirectories: true)
+    try? Data("{}".utf8).write(to: installDirectory.appendingPathComponent(path))
+    let manifest = try! ManifestFixture.manifest(files: ManifestFixture.smallFiles)
+    let expected = manifest.filesByComponent.first { $0.component == component }!.files
+    #expect(
+      !CacheAdmission.hasExtraFiles(
+        component: component, expectedFiles: expected, installDirectory: installDirectory))
+  }
+
   @Test func corruptComponentMemberWithCorrectSizeIsCaughtByHash() async throws {
     // Same-size, different-bytes corruption: only the hash gate sees it —
     // this is exactly what presence/size checks (the old world) admit.

--- a/Tests/EnviousWisprTests/ModelDelivery/CacheAdmissionTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/CacheAdmissionTests.swift
@@ -76,6 +76,22 @@ import Testing
     #expect(result.verifiedComponents == ["vocab.json"])
   }
 
+  @Test func unlistedSymlinkForcesComponentToFail() async throws {
+    // Cloud review P2: a symlink is neither a regular file nor a directory,
+    // so an `isRegularFile`-only check silently skipped an unlisted
+    // dangling link left by manual cache manipulation, and the component
+    // could be admitted despite containing it.
+    let (install, metadata, _) = try makeDirs()
+    let files = ManifestFixture.smallFiles
+    for f in files { try write(f.content, under: install, path: f.path) }
+    try FileManager.default.createSymbolicLink(
+      atPath: install.appendingPathComponent("Encoder.mlmodelc/dangling.bin").path,
+      withDestinationPath: "/nonexistent-target")
+    let gate = try admission(files: files, dirs: (install, metadata))
+    let result = await gate.validateExistingCache()
+    #expect(result.failedComponents == ["Encoder.mlmodelc"])
+  }
+
   @Test func unreadableSubdirectoryFailsClosed() async throws {
     // Whole-diff review P2: `FileManager.enumerator` silently STOPS
     // traversal on an unreadable subdirectory rather than throwing, so a


### PR DESCRIPTION
## Summary

- Model cache validation only hashed files the CURRENT manifest lists for a component; it had no way to notice a file that's physically present but no longer named (a manifest revision removed or renamed something inside an existing `.mlmodelc` bundle). Every listed file could hash correctly while a stale sibling sat beside them, the component was marked verified, and the admission marker was written trusting a cache that was never fully checked — a real violation of the model delivery contract's "verified or absent" invariant.
- Adds a check after a component's listed files already pass: walk the component's on-disk directory and fail the component if it contains anything the manifest doesn't name. A failed component already routes through the existing repair pipeline (delete the whole directory, re-fetch), so no other code needed to change.
- Two follow-up fixes from review: paths are resolved through `realpath(3)` before comparing (macOS temp-dir symlinks silently broke a naive string-prefix comparison — caught by the test suite itself on first run), and directory traversal now fails closed on a read error instead of silently reporting "nothing extra found" when it couldn't actually see everything.

## Test plan

- [x] New tests: a stale file inside a component forces it to fail; the same component with nothing extra stays verified (two-way control); a loose (non-directory) component skips the check; an unreadable subdirectory fails closed rather than passing.
- [x] Full existing `CacheAdmissionTests` suite (15 tests) passes.
- [x] Codex diff review, two rounds: first found the fail-open traversal-error gap, confirming round returned no findings.

Closes #1372
