### PR TITLE
fix(storage): make Custom Words saves crash-durable

### DIFF
--- a/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
@@ -1686,6 +1686,31 @@ public final class CustomWordsManager {
             NSFilePathErrorKey: fileURL.path,
           ])
       }
+
+      // Codex review: F_FULLFSYNC on the file makes the BYTES durable, but
+      // not the rename itself -- if the Mac loses power after rename()
+      // returns but before APFS commits the directory metadata, the new
+      // file's content is safe on disk while the rename that made it live
+      // can still be lost, reintroducing the exact race this fix exists to
+      // close. Sync the containing directory too.
+      let dirFD = Foundation.open(fileURL.deletingLastPathComponent().path, O_RDONLY)
+      guard dirFD >= 0 else {
+        throw NSError(
+          domain: NSPOSIXErrorDomain, code: Int(errno),
+          userInfo: [
+            NSLocalizedDescriptionKey: String(cString: strerror(errno)),
+            NSFilePathErrorKey: fileURL.deletingLastPathComponent().path,
+          ])
+      }
+      defer { close(dirFD) }
+      guard fcntl(dirFD, F_FULLFSYNC) != -1 else {
+        throw NSError(
+          domain: NSPOSIXErrorDomain, code: Int(errno),
+          userInfo: [
+            NSLocalizedDescriptionKey: String(cString: strerror(errno)),
+            NSFilePathErrorKey: fileURL.deletingLastPathComponent().path,
+          ])
+      }
     } catch {
       try? fm.removeItem(at: tmpURL)
       throw error

--- a/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
@@ -1687,29 +1687,22 @@ public final class CustomWordsManager {
           ])
       }
 
-      // Codex review: F_FULLFSYNC on the file makes the BYTES durable, but
-      // not the rename itself -- if the Mac loses power after rename()
-      // returns but before APFS commits the directory metadata, the new
-      // file's content is safe on disk while the rename that made it live
-      // can still be lost, reintroducing the exact race this fix exists to
-      // close. Sync the containing directory too.
+      // F_FULLFSYNC on the file makes the BYTES durable, but not the rename
+      // itself -- if the Mac loses power after rename() returns but before
+      // APFS commits the directory metadata, the new file's content is safe
+      // on disk while the rename that made it live can still be lost.
+      // Sync the containing directory too, BEST-EFFORT: by this point
+      // `rename()` has already succeeded, the new content is live, and the
+      // caller's in-memory state is about to be treated as consistent with
+      // disk. Throwing here (round 1 of this fix did) would make the caller
+      // believe the save failed and skip updating its own state while the
+      // file on disk had already changed -- correctness regression Codex
+      // review caught. A failure at this point only narrows the crash
+      // window this hardening closes; it does not undo the save.
       let dirFD = Foundation.open(fileURL.deletingLastPathComponent().path, O_RDONLY)
-      guard dirFD >= 0 else {
-        throw NSError(
-          domain: NSPOSIXErrorDomain, code: Int(errno),
-          userInfo: [
-            NSLocalizedDescriptionKey: String(cString: strerror(errno)),
-            NSFilePathErrorKey: fileURL.deletingLastPathComponent().path,
-          ])
-      }
-      defer { close(dirFD) }
-      guard fcntl(dirFD, F_FULLFSYNC) != -1 else {
-        throw NSError(
-          domain: NSPOSIXErrorDomain, code: Int(errno),
-          userInfo: [
-            NSLocalizedDescriptionKey: String(cString: strerror(errno)),
-            NSFilePathErrorKey: fileURL.deletingLastPathComponent().path,
-          ])
+      if dirFD >= 0 {
+        _ = fcntl(dirFD, F_FULLFSYNC)
+        close(dirFD)
       }
     } catch {
       try? fm.removeItem(at: tmpURL)

--- a/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
@@ -1660,6 +1660,20 @@ public final class CustomWordsManager {
       }
       let fh = FileHandle(fileDescriptor: fd, closeOnDealloc: true)
       try fh.write(contentsOf: data)
+      // #1744: atomic (via the rename below) is not durable on its own — force
+      // the just-written bytes off the drive's write cache before the rename
+      // makes them live, so a crash/power-loss immediately after this call
+      // returns cannot silently revert to the prior save. Mirrors the shipped
+      // pattern in RecoverySpoolStore.writeAttemptMarker (write, F_FULLFSYNC,
+      // then atomic rename) — same primitive, this call's own error shape.
+      guard fcntl(fd, F_FULLFSYNC) != -1 else {
+        throw NSError(
+          domain: NSPOSIXErrorDomain, code: Int(errno),
+          userInfo: [
+            NSLocalizedDescriptionKey: String(cString: strerror(errno)),
+            NSFilePathErrorKey: tmpURL.path,
+          ])
+      }
       try fh.close()
 
       // Same-directory temp file means same filesystem, which is what makes


### PR DESCRIPTION
## Summary

- Custom Words saves write to a temp file and atomically rename it into place -- safe against a torn/partial file, but not durable: nothing forced the just-written bytes off the drive's write cache before the app considered the save complete. A crash or power loss in that window could silently revert to the previous save with no error and no user-visible signal.
- Adds `F_FULLFSYNC` on the temp file before the rename, mirroring the exact shipped pattern already used for recovery-spool durability elsewhere in the app.
- Review found the file-level sync alone wasn't the whole story: the rename itself needs the containing directory synced too, or a crash right after a successful rename can still lose the rename's own metadata. That sync is best-effort (a rare sync hiccup narrows the durability window, it doesn't undo an already-successful save, so it must never make the caller think the save failed).
- Measured rather than assumed: the added sync costs about 6ms per save on a representative word-list-sized write, on a save path that runs far less often than dictation itself.

## Test plan

- [x] Existing `CustomWordsManagerDiskRoundTripTests` (9 tests) pass unmodified -- confirms the write/rename sequence still works with both sync calls inserted.
- [x] Codex diff review, three rounds: found the missing directory sync, then found my first fix threw on a rare sync failure (which would have falsely reported an already-successful save as failed); final round is clean.

Closes #1744
