### PR TITLE
fix(pipeline): retry the focus capture once at delivery so smart insertion survives a slow-to-warm target

### DIFF
--- a/Sources/EnviousWisprCore/Transcript.swift
+++ b/Sources/EnviousWisprCore/Transcript.swift
@@ -7,9 +7,9 @@ public struct ExecutionMetrics: Codable, Sendable {
   public var llmLatencySeconds: Double?
   public var pasteTier: String?
   public var pasteLatencyMs: Int?
-  /// Cursor-aware insertion (#1785, extended by #1921). All six are optional and
-  /// additive, so a transcript written before either feature decodes with them
-  /// nil rather than failing. Shapes and closed-set names only — a wrong-case report carries no
+  /// Cursor-aware insertion (#1785, extended by #1921 and #1980). All eight are
+  /// optional and additive, so a transcript written before any of these features
+  /// decodes with them nil rather than failing. Shapes and closed-set names only — a wrong-case report carries no
   /// text, and these are what make it answerable:
   ///
   /// - `smartInsertionEnabled`: the setting as frozen for that recording,
@@ -35,6 +35,15 @@ public struct ExecutionMetrics: Codable, Sendable {
   ///   public carrier across Core -> Pipeline and Core -> Services.
   public var smartInsertionEnabled: Bool?
   public var caretContextOutcome: String?
+  /// #1980. `caretCaptureRetried` is `nil` when this delivery never recorded
+  /// the fact (an older transcript, or auto-paste never entered), `false`
+  /// when it recorded that no delivery-time retry was needed or possible, and
+  /// `true` when a retry was ATTEMPTED — independent of whether it recovered
+  /// an element. Combine with `caretContextOutcome` to distinguish "retried
+  /// and still nothing" from "retried and recovered". `caretCaptureRetryMs`
+  /// is present only when `caretCaptureRetried == true`.
+  public var caretCaptureRetried: Bool?
+  public var caretCaptureRetryMs: Double?
   public var repairRules: String?
   public var pastePayloadKind: String?
   public var languageResolutionSource: String?
@@ -154,6 +163,8 @@ public struct ExecutionMetrics: Codable, Sendable {
     pasteLatencyMs: Int? = nil,
     smartInsertionEnabled: Bool? = nil,
     caretContextOutcome: String? = nil,
+    caretCaptureRetried: Bool? = nil,
+    caretCaptureRetryMs: Double? = nil,
     repairRules: String? = nil,
     pastePayloadKind: String? = nil,
     languageResolutionSource: String? = nil,
@@ -209,6 +220,8 @@ public struct ExecutionMetrics: Codable, Sendable {
     self.pasteLatencyMs = pasteLatencyMs
     self.smartInsertionEnabled = smartInsertionEnabled
     self.caretContextOutcome = caretContextOutcome
+    self.caretCaptureRetried = caretCaptureRetried
+    self.caretCaptureRetryMs = caretCaptureRetryMs
     self.repairRules = repairRules
     self.pastePayloadKind = pastePayloadKind
     self.languageResolutionSource = languageResolutionSource

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -1139,6 +1139,8 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
         outcome.smartInsertionEnabled = nil
         outcome.caretContextOutcome = nil
         outcome.repairRules = nil
+        outcome.caretCaptureRetried = nil
+        outcome.caretCaptureRetryMs = nil
         // #1167: a fresh session starts assuming the save will succeed; the
         // best-effort `store` closure flips these only on a real save throw.
         outcome.historySaved = true

--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -85,6 +85,13 @@ final class KernelFinalizationOutcome {
   var smartInsertionEnabled: Bool?
   var caretContextOutcome: String?
   var repairRules: String?
+  /// #1980. Whether the delivery-time retry (record-start capture came back
+  /// nil) was ATTEMPTED, independent of whether it recovered an element —
+  /// combine with `caretContextOutcome` to distinguish "retried and still
+  /// nothing" from "retried and recovered". `caretCaptureRetryMs` is set only
+  /// when `caretCaptureRetried == true`.
+  var caretCaptureRetried: Bool?
+  var caretCaptureRetryMs: Double?
   /// #1921. `repairRules` says WHAT the repair decided; these say why the
   /// language question got the answer it did. Without them a fielded regression
   /// in the confidence gate is invisible: `case_skipped:language_not_supported`
@@ -122,7 +129,12 @@ final class KernelSessionContext {
   var config: DictationSessionConfig?
   /// The frontmost app captured at recording start, re-activated before paste.
   var targetApp: NSRunningApplication?
-  /// The focused text element captured at recording start.
+  /// The focused text element captured at recording start, or — if that
+  /// capture failed — a delivery-time retry scoped to the same app (see
+  /// `deliver`'s caret-context computation). Nil if both attempts failed or
+  /// the app has no confirmed focused element. A retry-sourced value proves
+  /// same APP only, never same window/tab — commit-time safety is carried
+  /// separately via `PasteDeliveryRequest.targetElementIsRetried`.
   var targetElement: AXUIElement?
   /// Canonical protected spellings, snapshotted at `processText` entry.
   ///
@@ -191,6 +203,22 @@ struct KernelFinalizationWiring {
       AXUIElement, TerminalResolutionBudget, ((TerminalContextRefusal) -> Void)?
     ) -> PasteService.CaretContext? = {
       PasteService.readCaretContext(element: $0, terminalBudget: $1, onTerminalRefusal: $2)
+    },
+    // #1980 delivery-time retry seam. Production queries the target app's OWN
+    // focused element directly, scoped to its pid by construction, so it can
+    // never resolve to a different app than the one the user was dictating
+    // into. Tests inject a stub so the retry's occurrence, PID routing, and
+    // outcome are provable without depending on real AX focus state.
+    focusedElementInTargetApp: @escaping @MainActor (pid_t) -> AXUIElement? = {
+      PasteService.focusedElement(inAppWithPID: $0)
+    },
+    // #1980 whole-diff review (P1). Whether a retry-recovered element is a
+    // usable insertion target, gating whether it is adopted at all (see the
+    // `deliver` closure). Production reads the live AX role; tests inject a
+    // fixed answer so both directions of this gate are provable without a
+    // real focused text field in the test process.
+    isRetryTargetUsable: @escaping @MainActor (AXUIElement) -> Bool = {
+      PasteService.isTextFieldRole($0)
     },
     // Word-oracle seam. Production takes the live runtime snapshot; tests inject
     // a fixed oracle so a case never depends on the machine's dictionaries — and
@@ -461,12 +489,64 @@ struct KernelFinalizationWiring {
         // The specific terminal refusal, so a wrong-case report can be diagnosed
         // from the log instead of guessed at. Names and shapes only.
         var terminalRefusal: TerminalContextRefusal?
+        // #1980: if the record-start capture failed, retry once here, scoped
+        // directly to the app the user was dictating into (`context.targetApp`'s
+        // pid) — never the earlier system-wide query, which can answer for a
+        // different app. Mutates `context.targetElement` in place so the paste
+        // request built below (and `caretContextOutcome`'s `no_target` check)
+        // both observe the recovered element too, not just this read.
+        //
+        // No `terminalBudget` here: that budget's own design deliberately
+        // exempts non-terminal apps from a tighter cap, and reusing it for the
+        // retry would silently reintroduce exactly that squeeze. The retry
+        // keeps the standard `PasteService.axMessagingTimeoutSeconds` bound.
+        var caretCaptureRetried = false
+        var caretCaptureRetryMs: Double?
         let caretContext: PasteService.CaretContext? = {
-          guard config?.smartInsertion == true, let element = context.targetElement else {
-            return nil
+          guard config?.smartInsertion == true else { return nil }
+          // Whole-diff review (P2): `isTerminated` is checked before reading the
+          // pid, not after. If the target app quit between record-start and
+          // delivery, its pid can be reclaimed by an unrelated new process —
+          // querying a dead app's OWN stored pid at that point would resolve to
+          // whatever now holds it, and a coincidentally text-field-shaped
+          // element there could receive the user's dictated text. A terminated
+          // app can never be the one the user is dictating into.
+          if context.targetElement == nil, let app = context.targetApp, !app.isTerminated {
+            let pid = app.processIdentifier
+            caretCaptureRetried = true
+            let started = currentTime()
+            let recovered = focusedElementInTargetApp(pid)
+            caretCaptureRetryMs = (currentTime() - started) * 1000
+            // Whole-diff review (P1): adopt the recovered element ONLY when it
+            // is a usable text-insertion target. `context.targetElement == nil`
+            // classifies as `.missing` at the paste layer, which STILL attempts
+            // Tier 2 blind Cmd+V (#277's Chromium lazy-AX fallback — the reason
+            // pasting itself already works today even when caret repair
+            // silently no-ops). A recovered element that is NOT a text field
+            // (e.g. Chrome reporting a container/AXWebArea mid-warm-up)
+            // classifies as `.nonText` instead, which skips Tier 2 entirely and
+            // falls to clipboard-only — turning a today-working automatic paste
+            // into one requiring a manual Cmd+V. Keeping a non-text recovery
+            // discarded (not adopted) preserves that existing fallback exactly.
+            // Whole-diff review round 5 (P2): re-checked AFTER the query, not
+            // only before it. `app.isTerminated` is bound to this specific
+            // process instance (not merely a pid number), so if the app died
+            // WHILE `focusedElementInTargetApp` was blocked and its pid was
+            // immediately reclaimed, the pre-query check above cannot see
+            // that — the query can return a real, plausible text field
+            // belonging to the REPLACEMENT process. This narrows that window
+            // to the query's own duration; it does not claim to close it
+            // completely, matching this plan's disclosed same-app-not-same-
+            // window residual-risk posture elsewhere (§2.2, §7).
+            if let recovered, !app.isTerminated, isRetryTargetUsable(recovered) {
+              context.targetElement = recovered
+            }
           }
+          guard let element = context.targetElement else { return nil }
           return readCaretContext(element, terminalBudget, { terminalRefusal = $0 })
         }()
+        outcome.caretCaptureRetried = caretCaptureRetried
+        outcome.caretCaptureRetryMs = caretCaptureRetryMs
 
         // ONE call to the repair, which is the sole owner of the trailing-space
         // rule. Even with no context it returns today's payload, so Pipeline
@@ -663,7 +743,13 @@ struct KernelFinalizationWiring {
             + "caret=\(outcome.caretContextOutcome ?? "nil") "
             + "rules=\(outcome.repairRules ?? "none") "
             + "candidate=\(payloads.repairedText == nil ? "none" : "offered")"
-            + (terminalTiming.isEmpty ? "" : " timing=[\(terminalTiming)]"),
+            + (terminalTiming.isEmpty ? "" : " timing=[\(terminalTiming)]")
+            // #1980: local diagnostic only — production recovery-rate/latency
+            // authority is the `caret_capture_retried`/`caret_capture_retry_ms`
+            // telemetry (Chunk 3), which survives past this DEBUG-only log.
+            + (caretCaptureRetried
+              ? " retry_ms=\(String(format: "%.1f", caretCaptureRetryMs ?? 0))"
+              : ""),
           level: .info, category: "KernelFinalizationWiring")
 
         // The legacy payload is what a route falls back to; §6 decides per route
@@ -685,6 +771,10 @@ struct KernelFinalizationWiring {
             },
             targetApp: context.targetApp,
             targetElement: context.targetElement,
+            // Same local boolean the outcome fields above were stamped from —
+            // not re-derived from `targetElement` presence, which cannot tell
+            // "retried and recovered" apart from "captured at record-start".
+            targetElementIsRetried: caretCaptureRetried,
             restoreClipboardAfterPaste: config?.restoreClipboardAfterPaste ?? false,
             terminalBudget: terminalBudget))
         pasteResult = result
@@ -868,6 +958,8 @@ struct KernelFinalizationWiring {
       // reached a write at all, which is distinct from submitting the legacy one.
       smartInsertionEnabled: outcome.smartInsertionEnabled,
       caretContextOutcome: outcome.caretContextOutcome,
+      caretCaptureRetried: outcome.caretCaptureRetried,
+      caretCaptureRetryMs: outcome.caretCaptureRetryMs,
       repairRules: outcome.repairRules,
       pastePayloadKind: outcome.pasteResult?.submittedPayload?.rawValue,
       // #1921: carried through unchanged. Each hop transports exactly what the

--- a/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
+++ b/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
@@ -33,6 +33,11 @@ internal struct PasteDeliveryRequest {
   let candidateDeletesDictatedText: Bool
   let targetApp: NSRunningApplication?
   let targetElement: AXUIElement?
+  /// True when the delivery-time retry was attempted. If it recovered
+  /// `targetElement`, that element proves same-APP only, never same-window/tab,
+  /// so every commit boundary must re-verify the field before submitting a
+  /// repaired candidate.
+  let targetElementIsRetried: Bool
   let restoreClipboardAfterPaste: Bool
   /// The SAME cumulative terminal-resolution budget the caret read used.
   ///
@@ -332,7 +337,8 @@ internal final class PasteCascadeExecutor {
         legacy: request.legacyText,
         repaired: request.repairedText,
         context: request.caretContext,
-        element: element)
+        element: element,
+        requireFocusedElementMatch: request.targetElementIsRetried)
       let disposition = dispositionForAXDirect(insert.outcome)
       submittedKind = insert.submitted
       axAllowsRetry = disposition.allowsAutomaticRetry
@@ -372,6 +378,7 @@ internal final class PasteCascadeExecutor {
           context: request.caretContext,
           element: request.targetElement,
           candidateDeletesDictatedText: request.candidateDeletesDictatedText,
+          requireCaretUnchanged: request.targetElementIsRetried,
           terminalBudget: request.terminalBudget)
         // Snapshot AFTER that revalidation, immediately before the write. The
         // re-check makes accessibility calls, and anything copied while they run
@@ -422,6 +429,7 @@ internal final class PasteCascadeExecutor {
           context: request.caretContext,
           element: request.targetElement,
           candidateDeletesDictatedText: request.candidateDeletesDictatedText,
+          requireCaretUnchanged: request.targetElementIsRetried,
           terminalBudget: request.terminalBudget)
         // Same ordering as Tier 2: snapshot after the re-check, before the write.
         let snapshot: ClipboardSnapshot? =
@@ -474,6 +482,7 @@ internal final class PasteCascadeExecutor {
           context: request.caretContext,
           element: request.targetElement,
           candidateDeletesDictatedText: request.candidateDeletesDictatedText,
+          requireCaretUnchanged: request.targetElementIsRetried,
           terminalBudget: request.terminalBudget)
         submittedKind = payload.kind
         let changeCount = PasteService.copyToClipboardReturningChangeCount(payload.text)

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -401,17 +401,36 @@ public enum PasteService {
   ///
   /// Nothing here decides WHERE the paste lands. The write goes to whatever is
   /// focused either way; this only chooses between two strings.
+  ///
+  /// `requireCaretUnchanged` is a SEPARATE trigger for the same re-check,
+  /// independent of `candidateDeletesDictatedText`. That existing gate was
+  /// calibrated for "the caret shifted slightly within the same field" (worst
+  /// case: one wrong capital) and a trailing-space/seam-casing candidate never
+  /// sets it — so without this parameter, a retry-sourced element (which
+  /// carries only a same-APP guarantee, never same-window/tab) would commit
+  /// with no live re-check at all. Default `false` is byte-identical to
+  /// today's behavior for every existing caller.
   package static func payloadAtCommitBoundary(
     legacy: String,
     repaired: String?,
     context: CaretContext?,
     element: AXUIElement?,
     candidateDeletesDictatedText: Bool,
-    terminalBudget: TerminalResolutionBudget? = nil
+    requireCaretUnchanged: Bool = false,
+    terminalBudget: TerminalResolutionBudget? = nil,
+    // Injected seam, defaulting to the real check. Deleting-candidate cases
+    // can force the "changed" direction deterministically with a real-but-
+    // mismatched AX element; the "unchanged" direction this parameter adds
+    // has no such trick from a test process, so it needs a seam to be
+    // testable at all.
+    caretUnchangedCheck: (AXUIElement, CaretContext, TerminalResolutionBudget?) -> Bool =
+      caretUnchanged
   ) -> (text: String, kind: PastePayloadKind) {
     guard let repaired, let context, let element else { return (legacy, .legacy) }
-    guard candidateDeletesDictatedText else { return (repaired, .repaired) }
-    guard caretUnchanged(element: element, since: context, terminalBudget: terminalBudget)
+    guard candidateDeletesDictatedText || requireCaretUnchanged else {
+      return (repaired, .repaired)
+    }
+    guard caretUnchangedCheck(element, context, terminalBudget)
     else { return (legacy, .legacy) }
     return (repaired, .repaired)
   }
@@ -587,6 +606,42 @@ public enum PasteService {
       leftReachesDocumentStart: leftStart == 0)
   }
 
+  /// The app-scoped `kAXFocusedUIElementAttribute` query shared by every
+  /// caller that wants "what is focused in THIS process right now" — never a
+  /// system-wide query, which can answer for a different app.
+  ///
+  /// Owns every defensive check around that one AX round-trip: process trust,
+  /// a usable pid, the messaging timeout bound, CF type validation before the
+  /// cast, and confirming the returned element actually belongs to the
+  /// process that was asked, not one AX resolved to on its own.
+  private static func focusedElementQuery(
+    pid: pid_t,
+    messagingTimeout: Double
+  ) -> AXUIElement? {
+    guard AXIsProcessTrusted(), pid > 0 else { return nil }
+
+    let application = AXUIElementCreateApplication(pid)
+    // Bound every subsequent read. A wedged destination must not hang the
+    // dictation path; this is a failure bound, not a latency target.
+    AXUIElementSetMessagingTimeout(application, Float(messagingTimeout))
+
+    var focusedRef: CFTypeRef?
+    guard
+      AXUIElementCopyAttributeValue(
+        application, kAXFocusedUIElementAttribute as CFString, &focusedRef) == .success,
+      let focusedValue = focusedRef,
+      CFGetTypeID(focusedValue) == AXUIElementGetTypeID()
+    else { return nil }
+    // swift-format-ignore: NeverForceUnwrap — guarded by the CFGetTypeID check.
+    let focused = focusedValue as! AXUIElement
+
+    var focusedPID: pid_t = 0
+    guard AXUIElementGetPid(focused, &focusedPID) == .success, focusedPID == pid else {
+      return nil
+    }
+    return focused
+  }
+
   /// Read the text either side of the caret in the app that owns `element`.
   ///
   /// Synchronous, non-throwing, and fail-open: ANY unavailable, malformed,
@@ -610,35 +665,36 @@ public enum PasteService {
     matching element: AXUIElement,
     messagingTimeout: Double = axMessagingTimeoutSeconds
   ) -> AXUIElement? {
-    guard AXIsProcessTrusted() else { return nil }
-
     // Resolve the owning process from the captured element itself — never from
     // `NSWorkspace.frontmostApplication`, which is stale without a run loop,
     // and never from a system-wide element, which can answer for another app.
     var pid: pid_t = 0
     guard AXUIElementGetPid(element, &pid) == .success, pid > 0 else { return nil }
 
-    let application = AXUIElementCreateApplication(pid)
-    // Bound every subsequent read. A wedged destination must not hang the
-    // dictation path; this is a failure bound, not a latency target.
-    AXUIElementSetMessagingTimeout(application, Float(messagingTimeout))
-
-    var focusedRef: CFTypeRef?
-    guard
-      AXUIElementCopyAttributeValue(
-        application, kAXFocusedUIElementAttribute as CFString, &focusedRef) == .success,
-      let focusedValue = focusedRef,
-      CFGetTypeID(focusedValue) == AXUIElementGetTypeID()
-    else { return nil }
-    // swift-format-ignore: NeverForceUnwrap — guarded by the CFGetTypeID check.
-    let fresh = focusedValue as! AXUIElement
+    guard let fresh = focusedElementQuery(pid: pid, messagingTimeout: messagingTimeout) else {
+      return nil
+    }
 
     // The user may have moved on since capture. Repairing against a different
     // field would edit text they never dictated into.
     guard CFEqual(fresh, element) else { return nil }
-    var freshPid: pid_t = 0
-    guard AXUIElementGetPid(fresh, &freshPid) == .success, freshPid == pid else { return nil }
     return fresh
+  }
+
+  /// The currently focused element of a KNOWN app process, used when there is
+  /// no prior captured element to match against — e.g. the record-start
+  /// capture failed and this is a delivery-time retry. `pid` scopes the query
+  /// by construction, so this can never target an app the caller did not ask
+  /// for.
+  ///
+  /// This proves same-APP only, never same-window/tab within that app —
+  /// callers that need the stronger guarantee re-verify at commit time via
+  /// `payloadAtCommitBoundary`'s `requireCaretUnchanged`.
+  package static func focusedElement(
+    inAppWithPID pid: pid_t,
+    messagingTimeout: Double = axMessagingTimeoutSeconds
+  ) -> AXUIElement? {
+    focusedElementQuery(pid: pid, messagingTimeout: messagingTimeout)
   }
 
   /// Whether the field is still EXACTLY as it was when a contextual candidate
@@ -1022,6 +1078,21 @@ public enum PasteService {
     return resultRef as? String
   }
 
+  /// Whether a Tier 1 write may proceed given the focus-match requirement.
+  ///
+  /// Extracted as a pure function so this ONE new decision (#1980, whole-diff
+  /// review P1) is testable without live AX state. `insertViaAccessibility`
+  /// itself cannot be driven deterministically end to end — its role,
+  /// settable, range, and field reads are all live AX calls — but the rule
+  /// this guard adds can be, matching the existing precedent of
+  /// `classifyInsertOutcome` / `dispositionForAXDirect` / `classifyPasteFocus`.
+  package static func mayCommitAccessibilityWrite(
+    requireFocusedElementMatch: Bool,
+    isFocused: Bool
+  ) -> Bool {
+    !requireFocusedElementMatch || isFocused
+  }
+
   /// Insert text directly into an AX element at the cursor position.
   /// Uses kAXSelectedTextAttribute which inserts at cursor / replaces selection.
   ///
@@ -1033,13 +1104,24 @@ public enum PasteService {
   /// it submitted. The choice belongs here because this function already reads
   /// the selected range in the same breath as the write (#1785, plan §6): a
   /// caller-side check would be check-then-write with an AX round trip in the
-  /// gap. Element identity needs no separate check — the write targets the very
-  /// handle the candidate was computed against.
+  /// gap. For a RECORD-START-captured handle, element identity needs no
+  /// separate check — the write targets the very handle the candidate was
+  /// computed against, and its content/selection re-check (`accessibilityWritePayload`)
+  /// already catches any change.
+  ///
+  /// That is NOT sufficient for a retry-sourced handle (#1980, whole-diff
+  /// review): the content/selection check proves the FIELD hasn't changed,
+  /// never that the user is still FOCUSED on it. A background browser tab's
+  /// field can report byte-identical content long after the user switched
+  /// away, which is exactly how a retry-recovered element (same-APP, never
+  /// same-window/tab) can end up stale. `requireFocusedElementMatch` closes
+  /// that gap with a live focus re-check immediately before the write.
   package static func insertViaAccessibility(
     legacy: String,
     repaired: String? = nil,
     context: CaretContext? = nil,
-    element: AXUIElement
+    element: AXUIElement,
+    requireFocusedElementMatch: Bool = false
   ) -> (outcome: AXInsertOutcome, submitted: PastePayloadKind?) {
     // Verify the element is a text field or text area.
     var roleRef: CFTypeRef?
@@ -1143,6 +1225,32 @@ public enum PasteService {
       fieldBefore: fieldBefore)
     let text = payload.text
     let insertedLength = text.utf16.count
+
+    // #1980 whole-diff review (P1): the field-content re-check above cannot
+    // prove the user is still FOCUSED on this element — only that its content
+    // hasn't changed. For a retry-sourced handle that is not enough (see the
+    // doc comment above), so require a live focus re-check immediately before
+    // the write, narrowing the TOCTOU window to the smallest this function can
+    // offer. Nothing has been mutated yet, so `.noMutation` is correct: Tier 2
+    // remains free to try.
+    //
+    // #1980 whole-diff review round 2 (P2): `isFocused` MUST be computed only
+    // when `requireFocusedElementMatch` is true. Function arguments are not
+    // lazy in Swift, so passing `freshFocusedElement(matching:) != nil`
+    // directly as an argument evaluates it unconditionally — an extra AX
+    // round-trip (up to the full messaging timeout against a slow/wedged app)
+    // on EVERY Tier 1 write, including the common, unaffected, non-retried
+    // path this plan's own goals require to stay byte-identical. The `if`
+    // below is what makes the skip real.
+    if requireFocusedElementMatch {
+      guard
+        mayCommitAccessibilityWrite(
+          requireFocusedElementMatch: true,
+          isFocused: freshFocusedElement(matching: element) != nil)
+      else {
+        return (.noMutation, nil)
+      }
+    }
 
     // Insert at cursor via kAXSelectedTextAttribute.
     let err = AXUIElementSetAttributeValue(

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -233,6 +233,8 @@ public final class TelemetryService {
         insertion: PasteInsertionTelemetry(
           smartInsertionEnabled: m?.smartInsertionEnabled,
           caretContextOutcome: m?.caretContextOutcome,
+          caretCaptureRetried: m?.caretCaptureRetried,
+          caretCaptureRetryMs: m?.caretCaptureRetryMs,
           repairRules: m?.repairRules,
           payloadKind: m?.pastePayloadKind,
           languageResolutionSource: m?.languageResolutionSource,
@@ -1726,13 +1728,15 @@ public final class TelemetryService {
     PostHogSDK.shared.capture("paste.completed", properties: props)
   }
 
-  /// Cursor-aware insertion fields for `paste.completed` (#1785, extended #1921).
+  /// Cursor-aware insertion fields for `paste.completed` (#1785, extended #1921,
+  /// #1980).
   ///
-  /// A separate value rather than six more parameters so the projection has one
-  /// owner and one test surface: `paste.completed` is emitted from a metrics
-  /// projection, and six loose optionals threaded through it is how one of them
-  /// eventually gets dropped without any test noticing. #1921 added two of them,
-  /// which is exactly the growth this shape was chosen to absorb.
+  /// A separate value rather than eight more parameters so the projection has
+  /// one owner and one test surface: `paste.completed` is emitted from a
+  /// metrics projection, and eight loose optionals threaded through it is how
+  /// one of them eventually gets dropped without any test noticing. #1921 and
+  /// #1980 each added two of them, which is exactly the growth this shape was
+  /// chosen to absorb.
   ///
   /// Every field is a shape or a closed-set name. `repairRules` carries reasons
   /// (`case_skipped:protected_word`) and never the word a reason applied to,
@@ -1741,6 +1745,12 @@ public final class TelemetryService {
   public struct PasteInsertionTelemetry: Sendable {
     public let smartInsertionEnabled: Bool?
     public let caretContextOutcome: String?
+    /// #1980. `caretCaptureRetried` true means the delivery-time retry was
+    /// ATTEMPTED, independent of success — combine with `caretContextOutcome`
+    /// to distinguish "retried and still nothing" from "retried and
+    /// recovered". `caretCaptureRetryMs` is present only when a retry ran.
+    public let caretCaptureRetried: Bool?
+    public let caretCaptureRetryMs: Double?
     public let repairRules: String?
     public let payloadKind: String?
     /// #1921. Why the language question got its answer, and how confident. A
@@ -1753,6 +1763,8 @@ public final class TelemetryService {
     public init(
       smartInsertionEnabled: Bool? = nil,
       caretContextOutcome: String? = nil,
+      caretCaptureRetried: Bool? = nil,
+      caretCaptureRetryMs: Double? = nil,
       repairRules: String? = nil,
       payloadKind: String? = nil,
       languageResolutionSource: String? = nil,
@@ -1760,6 +1772,8 @@ public final class TelemetryService {
     ) {
       self.smartInsertionEnabled = smartInsertionEnabled
       self.caretContextOutcome = caretContextOutcome
+      self.caretCaptureRetried = caretCaptureRetried
+      self.caretCaptureRetryMs = caretCaptureRetryMs
       self.repairRules = repairRules
       self.payloadKind = payloadKind
       self.languageResolutionSource = languageResolutionSource
@@ -1773,6 +1787,8 @@ public final class TelemetryService {
       var out: [String: Any] = [:]
       if let smartInsertionEnabled { out["smart_insertion"] = smartInsertionEnabled }
       if let caretContextOutcome { out["caret_context"] = caretContextOutcome }
+      if let caretCaptureRetried { out["caret_capture_retried"] = caretCaptureRetried }
+      if let caretCaptureRetryMs { out["caret_capture_retry_ms"] = caretCaptureRetryMs }
       if let repairRules { out["repair_rules"] = repairRules }
       if let payloadKind { out["payload_kind"] = payloadKind }
       if let languageResolutionSource {

--- a/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverTests.swift
@@ -206,12 +206,19 @@ import Testing
     h.outcome.smartInsertionEnabled = true
     h.outcome.caretContextOutcome = "read"
     h.outcome.repairRules = "leading_space,lowercased_first"
+    // #1980: the delivery-time retry's two fields are written on the same
+    // branch and same schedule as the three above, so they carry the same
+    // stale-session risk.
+    h.outcome.caretCaptureRetried = true
+    h.outcome.caretCaptureRetryMs = 42
 
     try await startDriverToLive(h)
 
     #expect(h.outcome.smartInsertionEnabled == nil)
     #expect(h.outcome.caretContextOutcome == nil)
     #expect(h.outcome.repairRules == nil)
+    #expect(h.outcome.caretCaptureRetried == nil)
+    #expect(h.outcome.caretCaptureRetryMs == nil)
   }
 
   @Test("handle(.reset) clears currentTranscript (event entry — parity with TP:1081-1102)")
@@ -239,7 +246,8 @@ import Testing
       #expect(h.driver.overlayIntent == .error(reason: .modelLoadFailed))
     }
 
-    @Test("hasTerminalResult recognizes every terminal mechanism, including a silent outcome (#1925)")
+    @Test(
+      "hasTerminalResult recognizes every terminal mechanism, including a silent outcome (#1925)")
     func hasTerminalResultRecognizesEveryTerminalMechanism() {
       // Fresh driver, nothing has happened yet.
       let fresh = makeDriver()

--- a/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
@@ -920,6 +920,29 @@ import os
     AXUIElementCreateApplication(ProcessInfo.processInfo.processIdentifier)
   }
 
+  /// A real, LIVE `NSRunningApplication` — genuinely running and not
+  /// terminated, which the #1980 P2 retry-liveness guard now depends on.
+  ///
+  /// Two things that look right and are not, verified empirically (`swift`
+  /// one-liner) before writing this: `NSRunningApplication(processIdentifier:
+  /// ProcessInfo.processInfo.processIdentifier)` returns nil for a bare
+  /// xctest process (not a registered `.app` bundle — the earlier crash this
+  /// comment used to warn about). `.current` does NOT crash, but is a
+  /// DEGENERATE stand-in under xctest: `pid == -1`, `isTerminated == true`,
+  /// `bundleIdentifier == nil` — silently wrong for any test that reads
+  /// those properties rather than merely checking `!= nil` (the existing
+  /// `KernelDictationDriverTests.swift` precedent only ever does the latter).
+  ///
+  /// `NSWorkspace.shared.runningApplications` is the real system list and is
+  /// non-empty and genuinely live on any macOS capable of running this AX
+  /// test suite at all (loginwindow/Dock/Finder-class processes are always
+  /// present) — confirmed 100 entries, `.first` live and not terminated.
+  private static func stubTargetApp() -> NSRunningApplication {
+    // swift-format-ignore: NeverForceUnwrap — the system's own running-app
+    // list cannot be empty on a machine capable of running this suite.
+    NSWorkspace.shared.runningApplications.first!
+  }
+
   /// An engine that has already transcribed, which is the only state delivery
   /// runs in: the text being delivered exists BECAUSE a result was produced.
   /// A pre-finalize adapter reports no language, and the repair reads a missing
@@ -1194,6 +1217,252 @@ import os
       "today's payload is delivered unchanged in every cell")
   }
 
+  // MARK: - Delivery-time retry (#1980)
+  //
+  // The record-start focus capture is a single AX read that can transiently
+  // fail (Chromium/Electron lazy-AX warm-up, #277's own documented class).
+  // When it does, `context.targetElement` stays nil for the whole session and
+  // smart insertion silently never fires. These four cases prove the retry:
+  // succeeds, fails, is correctly never armed with no app to retry against,
+  // and stays correctly OFF when the record-start capture already succeeded.
+
+  @Test("a failed record-start capture is retried once, scoped to the target app's pid")
+  func retrySucceedsAndRecoversTheCaretRead() async throws {
+    let captured = DeliveryRequestBox()
+    let reads = SaveCountBox()
+    let retrySeam = RetrySeamBox()
+    let outcome = KernelFinalizationOutcome()
+    let context = KernelSessionContext()
+    context.config = .testDefault(autoPasteToActiveApp: true, smartInsertion: true)
+    context.targetApp = Self.stubTargetApp()
+    context.targetElement = nil
+    let recovered = Self.stubCaretElement()
+    let wiring = makeWiring(
+      outcome: outcome,
+      context: context,
+      deliverPaste: { request in
+        captured.requests.append(request)
+        return Self.deliveredResult
+      },
+      currentTime: { retrySeam.tick() },
+      readCaretContext: { element, _, _ in
+        reads.count += 1
+        #expect(element == recovered, "the caret read must use the RECOVERED element")
+        return Self.midSentenceCaret
+      },
+      focusedElementInTargetApp: { pid in
+        retrySeam.callCount += 1
+        retrySeam.lastPID = pid
+        return recovered
+      })
+
+    _ = await wiring.deliver("Review this before the meeting")
+
+    #expect(retrySeam.callCount == 1, "the retry fires exactly once")
+    #expect(retrySeam.lastPID == context.targetApp?.processIdentifier)
+    #expect(reads.count == 1, "the caret read runs against the recovered element")
+    #expect(context.targetElement == recovered, "the retry mutates the shared context in place")
+
+    let request = try #require(captured.requests.first)
+    #expect(request.targetElement == recovered)
+    #expect(request.repairedText != nil)
+    #expect(request.targetElementIsRetried == true)
+    #expect(outcome.caretContextOutcome != "no_target")
+    #expect(outcome.caretCaptureRetried == true)
+    let retryMs = try #require(outcome.caretCaptureRetryMs)
+    #expect(retryMs == 1_000, "matches the deterministic fake clock's one-tick advance")
+  }
+
+  @Test("a retry that also fails leaves today's no_target behavior exactly as it was")
+  func retryAttemptedButAlsoFails() async throws {
+    let captured = DeliveryRequestBox()
+    let reads = SaveCountBox()
+    let retrySeam = RetrySeamBox()
+    let outcome = KernelFinalizationOutcome()
+    let context = KernelSessionContext()
+    context.config = .testDefault(autoPasteToActiveApp: true, smartInsertion: true)
+    context.targetApp = Self.stubTargetApp()
+    context.targetElement = nil
+    let wiring = makeWiring(
+      outcome: outcome,
+      context: context,
+      deliverPaste: { request in
+        captured.requests.append(request)
+        return Self.deliveredResult
+      },
+      currentTime: { retrySeam.tick() },
+      readCaretContext: { _, _, _ in
+        reads.count += 1
+        return Self.midSentenceCaret
+      },
+      focusedElementInTargetApp: { pid in
+        retrySeam.callCount += 1
+        retrySeam.lastPID = pid
+        return nil
+      })
+
+    _ = await wiring.deliver("Review this before the meeting")
+
+    #expect(retrySeam.callCount == 1, "the retry still fires exactly once, even though it fails")
+    #expect(retrySeam.lastPID == context.targetApp?.processIdentifier)
+    #expect(reads.count == 0, "no caret read without a recovered element")
+    #expect(context.targetElement == nil)
+
+    let request = try #require(captured.requests.first)
+    #expect(request.targetElement == nil)
+    #expect(request.repairedText == nil)
+    #expect(request.caretContext == nil)
+    #expect(request.targetElementIsRetried == true, "attempted, though it did not recover")
+    #expect(outcome.caretContextOutcome == "no_target")
+    #expect(
+      outcome.caretCaptureRetried == true, "attempted is recorded whether or not it recovers"
+    )
+    let retryMs = try #require(outcome.caretCaptureRetryMs)
+    #expect(retryMs == 1_000, "matches the deterministic fake clock's one-tick advance")
+  }
+
+  @Test(
+    "a retry that recovers a NON-text element is discarded, preserving the missing-target fallback")
+  func retryRecoversAnUnusableElementAndIsDiscarded() async throws {
+    // Whole-diff review (P1): a recovered element that is present but not a
+    // text field must NOT be adopted. `context.targetElement == nil`
+    // classifies at the paste layer as `.missing`, which still attempts Tier 2
+    // blind Cmd+V (#277's Chromium lazy-AX fallback — why paste itself already
+    // works today even when caret repair no-ops). Adopting a non-text element
+    // instead reclassifies as `.nonText`, which skips Tier 2 and falls to
+    // clipboard-only — silently downgrading a today-working automatic paste.
+    let captured = DeliveryRequestBox()
+    let reads = SaveCountBox()
+    let retrySeam = RetrySeamBox()
+    let outcome = KernelFinalizationOutcome()
+    let context = KernelSessionContext()
+    context.config = .testDefault(autoPasteToActiveApp: true, smartInsertion: true)
+    context.targetApp = Self.stubTargetApp()
+    context.targetElement = nil
+    let unusable = Self.stubCaretElement()
+    let wiring = makeWiring(
+      outcome: outcome,
+      context: context,
+      deliverPaste: { request in
+        captured.requests.append(request)
+        return Self.deliveredResult
+      },
+      currentTime: { retrySeam.tick() },
+      readCaretContext: { _, _, _ in
+        reads.count += 1
+        return Self.midSentenceCaret
+      },
+      focusedElementInTargetApp: { pid in
+        retrySeam.callCount += 1
+        retrySeam.lastPID = pid
+        return unusable
+      },
+      isRetryTargetUsable: { element in
+        #expect(element == unusable, "the usability check must see exactly the recovered element")
+        return false
+      })
+
+    _ = await wiring.deliver("Review this before the meeting")
+
+    #expect(retrySeam.callCount == 1, "the retry still fires and recovers SOMETHING")
+    #expect(reads.count == 0, "an unusable element must never reach the caret read")
+    #expect(context.targetElement == nil, "the unusable element must not be adopted")
+
+    let request = try #require(captured.requests.first)
+    #expect(
+      request.targetElement == nil,
+      "nil, not the unusable element — preserves .missing classification")
+    #expect(request.repairedText == nil)
+    #expect(request.targetElementIsRetried == true, "the retry WAS attempted")
+    #expect(outcome.caretContextOutcome == "no_target")
+    #expect(outcome.caretCaptureRetried == true)
+  }
+
+  @Test("no target app means the retry is not attempted at all — never a failed retry")
+  func noTargetAppMeansNoRetryAttempt() async throws {
+    let captured = DeliveryRequestBox()
+    let reads = SaveCountBox()
+    let retrySeam = RetrySeamBox()
+    let outcome = KernelFinalizationOutcome()
+    let context = KernelSessionContext()
+    context.config = .testDefault(autoPasteToActiveApp: true, smartInsertion: true)
+    context.targetApp = nil
+    context.targetElement = nil
+    let wiring = makeWiring(
+      outcome: outcome,
+      context: context,
+      deliverPaste: { request in
+        captured.requests.append(request)
+        return Self.deliveredResult
+      },
+      readCaretContext: { _, _, _ in
+        reads.count += 1
+        return Self.midSentenceCaret
+      },
+      focusedElementInTargetApp: { pid in
+        retrySeam.callCount += 1
+        retrySeam.lastPID = pid
+        return nil
+      })
+
+    _ = await wiring.deliver("Review this before the meeting")
+
+    #expect(retrySeam.callCount == 0, "no pid to query with — the retry seam must never be called")
+    #expect(reads.count == 0, "no element to read against without a target app")
+    let request = try #require(captured.requests.first)
+    #expect(request.targetElement == nil)
+    #expect(request.repairedText == nil)
+    #expect(request.targetElementIsRetried == false)
+    #expect(outcome.caretContextOutcome == "no_target")
+    #expect(outcome.caretCaptureRetried == false, "unattempted, not a failed attempt")
+    #expect(outcome.caretCaptureRetryMs == nil)
+  }
+
+  @Test("a record-start capture that already succeeded is never retried")
+  func existingTargetElementIsNeverRetried() async throws {
+    let captured = DeliveryRequestBox()
+    let reads = SaveCountBox()
+    let retrySeam = RetrySeamBox()
+    let outcome = KernelFinalizationOutcome()
+    let context = KernelSessionContext()
+    context.config = .testDefault(autoPasteToActiveApp: true, smartInsertion: true)
+    context.targetApp = Self.stubTargetApp()
+    let original = Self.stubCaretElement()
+    context.targetElement = original
+    let wiring = makeWiring(
+      outcome: outcome,
+      context: context,
+      deliverPaste: { request in
+        captured.requests.append(request)
+        return Self.deliveredResult
+      },
+      readCaretContext: { element, _, _ in
+        reads.count += 1
+        #expect(element == original)
+        return Self.midSentenceCaret
+      },
+      focusedElementInTargetApp: { pid in
+        retrySeam.callCount += 1
+        retrySeam.lastPID = pid
+        return Self.stubCaretElement()
+      })
+
+    _ = await wiring.deliver("Review this before the meeting")
+
+    #expect(retrySeam.callCount == 0, "the record-start capture already succeeded — no retry")
+    #expect(reads.count == 1)
+    #expect(
+      context.targetElement == original, "the retry must not overwrite an already-present element")
+
+    let request = try #require(captured.requests.first)
+    #expect(request.targetElement == original)
+    #expect(request.repairedText != nil)
+    #expect(request.targetElementIsRetried == false)
+    #expect(outcome.caretContextOutcome == "read_selected")
+    #expect(outcome.caretCaptureRetried == false)
+    #expect(outcome.caretCaptureRetryMs == nil)
+  }
+
   @Test("an unreadable field yields no candidate, and today's payload still ships")
   func unreadableFieldFallsBackToTodaysPayload() async {
     // The accessibility read fails open. The distinction that matters is that it
@@ -1405,6 +1674,15 @@ import os
     ) -> PasteService.CaretContext? = { _, _, _ in
       nil
     },
+    // #1980 delivery-time retry seam. Defaults to "never recovers", so every
+    // pre-existing test in this suite keeps exactly today's behaviour and
+    // only a test that opts in observes a retry.
+    focusedElementInTargetApp: @escaping @MainActor (pid_t) -> AXUIElement? = { _ in nil },
+    // #1980 whole-diff review (P1) gate. Defaults to "usable", so every
+    // existing retry-success test in this suite keeps treating its recovered
+    // stub as adoptable; the dedicated non-text-recovery test opts into
+    // `{ _ in false }` to prove the OTHER direction.
+    isRetryTargetUsable: @escaping @MainActor (AXUIElement) -> Bool = { _ in true },
     // Delivery only ever runs after a transcription produced the text being
     // delivered, so the adapter it reads has a result by then. The default
     // stands in for exactly that state; language tests vary the code.
@@ -1444,6 +1722,8 @@ import os
       save: save,
       deliverPaste: deliverPaste,
       readCaretContext: readCaretContext,
+      focusedElementInTargetApp: focusedElementInTargetApp,
+      isRetryTargetUsable: isRetryTargetUsable,
       seamCasingOracle: seamCasingOracle,
       releaseOracleLease: releaseOracleLease,
       resolveLanguage: resolveLanguage
@@ -1905,6 +2185,20 @@ private final class SignalFlag {
 private final class SaveCountBox {
   var count = 0
   var last: Transcript?
+}
+
+/// Captures how the #1980 delivery-time retry seam was called, plus a
+/// deterministic fake clock so `caretCaptureRetryMs` is a real, nonzero,
+/// non-flaky advance rather than a real wall-clock read.
+@MainActor
+private final class RetrySeamBox {
+  var callCount = 0
+  var lastPID: pid_t?
+  private var clock: TimeInterval = 0
+  func tick() -> TimeInterval {
+    clock += 1
+    return clock
+  }
 }
 
 @MainActor

--- a/Tests/EnviousWisprTests/Pipeline/PasteExecutionMetricsTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PasteExecutionMetricsTests.swift
@@ -21,6 +21,10 @@ struct PasteExecutionMetricsTests {
       pasteLatencyMs: 5,
       smartInsertionEnabled: true,
       caretContextOutcome: "read",
+      // #1980. Distinctive, non-default values, matching the #1921 pattern
+      // below: `true`/`137.5` cannot pass by coincidence with an un-set field.
+      caretCaptureRetried: true,
+      caretCaptureRetryMs: 137.5,
       repairRules: "leading_space,lowercased_first",
       pastePayloadKind: "repaired",
       languageResolutionSource: "document",
@@ -29,6 +33,8 @@ struct PasteExecutionMetricsTests {
       ExecutionMetrics.self, from: JSONEncoder().encode(metrics))
     #expect(decoded.smartInsertionEnabled == true)
     #expect(decoded.caretContextOutcome == "read")
+    #expect(decoded.caretCaptureRetried == true)
+    #expect(decoded.caretCaptureRetryMs == 137.5)
     #expect(decoded.repairRules == "leading_space,lowercased_first")
     #expect(decoded.pastePayloadKind == "repaired")
     // #1921. Distinctive values, not defaults, so a hop that silently dropped
@@ -49,6 +55,8 @@ struct PasteExecutionMetricsTests {
     #expect(decoded.pasteTier == "cgevent")
     #expect(decoded.smartInsertionEnabled == nil)
     #expect(decoded.caretContextOutcome == nil)
+    #expect(decoded.caretCaptureRetried == nil)
+    #expect(decoded.caretCaptureRetryMs == nil)
     #expect(decoded.repairRules == nil)
     #expect(decoded.pastePayloadKind == nil)
     // #1921. The literal JSON above is deliberately UNCHANGED — it is the real
@@ -70,6 +78,12 @@ struct PasteExecutionMetricsTests {
     #expect(partial.properties["caret_context"] as? String == "setting_off")
     #expect(partial.properties["repair_rules"] == nil)
     #expect(partial.properties["payload_kind"] == nil)
+    // #1980. Absent, not present-as-nil/false/zero — same discipline as every
+    // other optional field on this type.
+    #expect(empty.properties["caret_capture_retried"] == nil)
+    #expect(empty.properties["caret_capture_retry_ms"] == nil)
+    #expect(partial.properties["caret_capture_retried"] == nil)
+    #expect(partial.properties["caret_capture_retry_ms"] == nil)
     // #1921. Nil must stay ABSENT rather than becoming "none". "none" is a real
     // upstream category meaning "we measured and found nothing"; absent means
     // the fact was never recorded, which is what an old stored transcript has.
@@ -88,6 +102,14 @@ struct PasteExecutionMetricsTests {
       languageResolutionSource: "none", languageConfidenceBucket: "none")
     #expect(measuredNothing.properties["language_resolution_source"] as? String == "none")
     #expect(measuredNothing.properties["language_confidence_bucket"] as? String == "none")
+
+    // #1980. The emission direction for the retry fields — proves the two
+    // properties actually appear, typed, when set, not merely that they
+    // disappear when nil.
+    let retried = TelemetryService.PasteInsertionTelemetry(
+      caretCaptureRetried: true, caretCaptureRetryMs: 137.5)
+    #expect(retried.properties["caret_capture_retried"] as? Bool == true)
+    #expect(retried.properties["caret_capture_retry_ms"] as? Double == 137.5)
   }
 
   @Test("Every rule name is a closed reason, never the word it applied to")

--- a/Tests/EnviousWisprTests/Services/PasteAccessibilityInsertionTests.swift
+++ b/Tests/EnviousWisprTests/Services/PasteAccessibilityInsertionTests.swift
@@ -253,3 +253,39 @@ struct PasteAccessibilityInsertionTests {
     #expect(outcome == .unverifiable)
   }
 }
+
+// #1980 whole-diff review (P1): the field-content re-check
+// (`accessibilityWritePayload`) proves the FIELD hasn't changed, never that
+// the user is still FOCUSED on it — a background browser tab's field can
+// report byte-identical content long after the user switched away, which is
+// exactly how a retry-recovered element (same-APP, never same-window/tab) can
+// end up stale. This suite pins the ONE new decision that closes that gap,
+// same precedent as `PasteAccessibilityInsertionTests` above: the live AX
+// focus re-check itself is Live-UAT-only, but the rule it feeds is pure.
+@Suite("PasteService.mayCommitAccessibilityWrite")
+struct PasteAccessibilityFocusMatchTests {
+
+  @Test("The unaffected default: no requirement, write proceeds whatever the focus state")
+  func noRequirementAlwaysProceeds() {
+    #expect(
+      PasteService.mayCommitAccessibilityWrite(
+        requireFocusedElementMatch: false, isFocused: false))
+    #expect(
+      PasteService.mayCommitAccessibilityWrite(
+        requireFocusedElementMatch: false, isFocused: true))
+  }
+
+  @Test("A retry-sourced element that is STILL focused may commit")
+  func requiredAndStillFocusedProceeds() {
+    #expect(
+      PasteService.mayCommitAccessibilityWrite(
+        requireFocusedElementMatch: true, isFocused: true))
+  }
+
+  @Test("A retry-sourced element the user has moved on from is refused — the defect this fixes")
+  func requiredAndNoLongerFocusedRefuses() {
+    #expect(
+      !PasteService.mayCommitAccessibilityWrite(
+        requireFocusedElementMatch: true, isFocused: false))
+  }
+}

--- a/Tests/EnviousWisprTests/Services/PasteServiceFocusedElementTests.swift
+++ b/Tests/EnviousWisprTests/Services/PasteServiceFocusedElementTests.swift
@@ -1,0 +1,22 @@
+import ApplicationServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprServices
+
+/// `PasteService.focusedElement(inAppWithPID:)` (#1980) — the app-scoped
+/// focused-element query used by the delivery-time retry.
+///
+/// Only the deterministic, environment-independent case is asserted here.
+/// CI's Debug lane has no guaranteed focused-element state, so a real-AX
+/// success case is not reliable on a headless runner; the live app-scoped
+/// round-trip is proven via Live UAT instead (plan §10/§11.1).
+@Suite("PasteService focused element (retry query)")
+struct PasteServiceFocusedElementTests {
+
+  @Test("An invalid pid is refused before any AX query")
+  func invalidPidReturnsNil() {
+    #expect(PasteService.focusedElement(inAppWithPID: 0) == nil)
+  }
+
+}

--- a/Tests/EnviousWisprTests/Services/TerminalInsertionPolicyTests.swift
+++ b/Tests/EnviousWisprTests/Services/TerminalInsertionPolicyTests.swift
@@ -400,4 +400,65 @@ struct TerminalInsertionPolicyTests {
     }
   }
 
+  // MARK: - `requireCaretUnchanged` (#1980) — the retry-sourced-element gate
+
+  @Test("A retried element that has since changed falls back to legacy")
+  func requireCaretUnchangedRefusesOnAChangedField() {
+    // The "changed" direction: `caretUnchangedCheck` is the injected seam,
+    // proving the new trigger reaches the SAME re-verification the deletion
+    // path already uses, independent of `candidateDeletesDictatedText`.
+    let payload = PasteService.payloadAtCommitBoundary(
+      legacy: "Fix the handler ",
+      repaired: "fix the handler ",
+      context: terminalContext(line: "I can't wait till the weather is"),
+      element: AXUIElementCreateSystemWide(),
+      candidateDeletesDictatedText: false,
+      requireCaretUnchanged: true,
+      caretUnchangedCheck: { _, _, _ in false })
+
+    #expect(payload.kind == .legacy, "a retry-sourced element must be re-verified before commit")
+    #expect(payload.text == "Fix the handler ")
+  }
+
+  @Test("A retried element that is confirmed unchanged commits the repair")
+  func requireCaretUnchangedCommitsOnAConfirmedField() {
+    // The "unchanged" direction: no real AX trick from a test process can
+    // force `caretUnchanged` to return true, so this seam is the only way to
+    // prove this half of the gate at all (grounded review round 2).
+    let payload = PasteService.payloadAtCommitBoundary(
+      legacy: "Fix the handler ",
+      repaired: "fix the handler ",
+      context: terminalContext(line: "I can't wait till the weather is"),
+      element: AXUIElementCreateSystemWide(),
+      candidateDeletesDictatedText: false,
+      requireCaretUnchanged: true,
+      caretUnchangedCheck: { _, _, _ in true })
+
+    #expect(payload.kind == .repaired)
+    #expect(payload.text == "fix the handler ")
+  }
+
+  @Test("The default requireCaretUnchanged never invokes the seam for a non-deleting candidate")
+  func requireCaretUnchangedDefaultsToTodaysBehavior() {
+    // Regression guard: today's unaffected (record-start-succeeded) path must
+    // stay byte-identical. A seam that returns false here would flip this
+    // test's outcome to `.legacy`, so an unexpected invocation is caught, not
+    // merely an unread flag.
+    var seamCalled = false
+    let payload = PasteService.payloadAtCommitBoundary(
+      legacy: "Fix the handler ",
+      repaired: "fix the handler ",
+      context: terminalContext(line: "I can't wait till the weather is"),
+      element: AXUIElementCreateSystemWide(),
+      candidateDeletesDictatedText: false,
+      caretUnchangedCheck: { _, _, _ in
+        seamCalled = true
+        return false
+      })
+
+    #expect(payload.kind == .repaired)
+    #expect(payload.text == "fix the handler ")
+    #expect(!seamCalled, "requireCaretUnchanged defaults to false and must not invoke the seam")
+  }
+
 }


### PR DESCRIPTION
## Summary

- Retries the record-start focus capture once at delivery time, scoped to the target app's own PID, so a transient AX warm-up race (Chrome/Electron lazy-AX tree) no longer permanently disables smart insertion (trailing space + seam casing) for the whole dictation.
- Closes a real gap the whole-diff review found: a retried element now requires a live re-check (`requireCaretUnchanged` / `requireFocusedElementMatch`) at every commit route — Tier 1 AX-direct write included — before a repaired candidate may land, narrowing exposure to the short gap between retry and commit.
- A non-text recovered element (e.g. a container reported mid-warm-up) is discarded rather than adopted, preserving the existing missing-target blind-paste fallback (#277) instead of silently downgrading it to clipboard-only.
- Adds `caret_capture_retried` / `caret_capture_retry_ms` to `paste.completed` telemetry so real-world recovery rate is measurable from data.

Full design: `docs/feature-requests/issue-1980-2026-08-07-smart-insertion-caret-retry.md` (approved after 5 grounded-review rounds).

Closes #1980.

## Disclosed, founder-approved residual risk

This fix proves the retried element belongs to the same **app** the user was dictating into (PID-scoped by construction) — it cannot prove same **window/tab**. If the user switches windows within the target app during the retry-to-commit gap, the commit-time re-check catches most of that window, but a user who is *still* in the wrong window at the exact instant of commit is not caught. Closing that fully would require walking the AX tree for a global focus signal, which the plan explicitly scoped out as materially bigger than this fix calls for. Disclosed to the founder at Gate 2; he chose to proceed with this narrowed, not eliminated, risk.

## Test plan

- [x] `scripts/xcode-test.sh` — full Debug suite, 5,131 tests, green
- [x] `scripts/xcode-test.sh --release` — Release suite, 4,715 tests, green
- [x] Standalone `apple_runner` / `alias_runner` SwiftPM packages build clean against the `Transcript.swift` (Core) signature change
- [x] 7 rounds of independent whole-diff `codex review`, reaching an explicit all-clear ("No actionable correctness issues found") after fixing 3 real defects (a paste-tier downgrade on non-text recovery, a stale-handle Tier 1 write, and pre/post-query process-liveness checks)
- [x] Live UAT: real Chrome/Gmail dictation confirmed the retry fires end-to-end — `retry_ms=` in the local log and `caret_capture_retried: true` in dev-build PostHog, both present; Chrome's own focus desync did not clear in this specific repro, reported honestly rather than claimed fixed
