### PR TITLE
fix(settings): Ollama status in Settings no longer goes stale

### DIFF
--- a/Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift
@@ -352,6 +352,8 @@ final class AppLifecycleCoordinator {
       model: settings.llmModel,
       keychainManager: keychainManager
     )
+
+    setup.applicationDidBecomeActive()
   }
 
   func runWillTerminate() {
@@ -368,7 +370,7 @@ final class AppLifecycleCoordinator {
     // PR-B.2 of #763: both window-close observers are torn down by the
     // coordinator now.
     appWindowCoordinator.tearDown()
-    setup.ollamaSetup.cleanup()
+    setup.cleanup()
     // PR10 of #763 — shared HotkeyService is owned by EnviousWisprApp as
     // `@State`; this coordinator holds an injected ref.
     hotkeyService.stop()

--- a/Sources/EnviousWisprAppKit/App/SetupCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/SetupCoordinator.swift
@@ -20,6 +20,16 @@ final class SetupCoordinator {
   @ObservationIgnored
   private var whisperKitPreloadTask: Task<Void, Never>?
 
+  @ObservationIgnored
+  private var whisperKitMigrationTask: Task<Void, Never>?
+
+  /// #1918: the settings-pane-scoped poll and the app-activation probe for
+  /// Ollama status. Both nil when no pane is watching.
+  @ObservationIgnored
+  private var ollamaStatusPollTask: Task<Void, Never>?
+  @ObservationIgnored
+  private var ollamaActivationProbeTask: Task<Void, Never>?
+
   private let asrManager: any ASRManagerInterface
   private let preloadAction: @MainActor () async -> Void
 
@@ -35,21 +45,35 @@ final class SetupCoordinator {
   /// the step that can raise a Files-and-Folders prompt. Defaults to a no-op.
   private let runDocumentsMigration: @MainActor () async -> Void
 
+  /// #1918 test seams. Default to the real Ollama probe and a real 15s delay,
+  /// so production behavior is unchanged; a unit test injects both to make
+  /// polling deterministic without real time or a real daemon.
+  private let ollamaStatusProbe: @MainActor (String) async -> Void
+  private let ollamaPollDelay: @MainActor () async throws -> Void
+
   init(
     asrManager: any ASRManagerInterface,
     whisperKitSetup: WhisperKitSetupService,
     setupStateReader: (@MainActor () -> WhisperKitSetupState)? = nil,
     runDocumentsMigration: @escaping @MainActor () async -> Void = {},
-    preloadAction: @escaping @MainActor () async -> Void
+    preloadAction: @escaping @MainActor () async -> Void,
+    ollamaStatusProbe: (@MainActor (String) async -> Void)? = nil,
+    ollamaPollDelay: @escaping @MainActor () async throws -> Void = {
+      try await Task.sleep(for: .seconds(15))
+    }
   ) {
     self.asrManager = asrManager
     self.whisperKitSetup = whisperKitSetup
     self.runDocumentsMigration = runDocumentsMigration
     self.preloadAction = preloadAction
-    // Bind the default reader inside init capturing the owned service as a local
-    // (a default parameter value cannot reference `self`).
+    self.ollamaPollDelay = ollamaPollDelay
+    // Bind the default readers inside init capturing the owned services as
+    // locals (a default parameter value cannot reference `self`).
     let service = whisperKitSetup
     self.setupStateReader = setupStateReader ?? { service.setupState }
+    let ollama = ollamaSetup
+    self.ollamaStatusProbe =
+      ollamaStatusProbe ?? { trigger in await ollama.detectState(trigger: trigger) }
   }
 
   /// #1386 PR-2: the post-UI launch step for the multilingual engine, in order —
@@ -58,12 +82,73 @@ final class SetupCoordinator {
   /// half-migrated state, and called from `runDidFinishLaunching` so the
   /// Documents read (and any permission prompt) happens with the app on screen.
   func startWhisperKitMigrationThenDetect() {
-    Task { [weak self] in
-      guard let self else { return }
+    whisperKitMigrationTask = Task { [weak self] in
+      // `Task.cancel()` only sets a flag; a closure cancelled before entry
+      // still runs until its first cancellation check. This is that check.
+      guard !Task.isCancelled, let self else { return }
       await self.runDocumentsMigration()
+      guard !Task.isCancelled else { return }
       await self.whisperKitSetup.detectState()
+      guard !Task.isCancelled else { return }
       self.startPreloadObservation()
     }
+  }
+
+  /// Start the settings-pane-scoped poll for Ollama status, called from
+  /// `AIPolishSettingsView.onAppear`/`.onChange(llmProvider)`. Idempotent:
+  /// cancels-before-restart, mirroring `startPreloadObservation()`'s own
+  /// precedent for the sibling WhisperKit observer.
+  func startOllamaStatusWatch() {
+    ollamaStatusPollTask?.cancel()
+    ollamaStatusPollTask = Task { [weak self] in
+      while !Task.isCancelled {
+        guard let self else { return }
+        try? await self.ollamaPollDelay()
+        guard !Task.isCancelled else { return }
+        if self.ollamaSetup.setupState.allowsSilentBackgroundRefresh {
+          await self.ollamaStatusProbe("visible_poll")
+        }
+      }
+    }
+  }
+
+  /// Stop the visible-pane poll AND the activation probe — closing/leaving
+  /// the pane must fully stop the watch, not just the poll half of it.
+  func stopOllamaStatusWatch() {
+    ollamaStatusPollTask?.cancel()
+    ollamaStatusPollTask = nil
+    ollamaActivationProbeTask?.cancel()
+    ollamaActivationProbeTask = nil
+  }
+
+  /// Called from `AppLifecycleCoordinator.runDidBecomeActive()`. Self-gated
+  /// no-op unless a pane is currently watching, so a background/foreground
+  /// cycle with no Settings pane open costs nothing.
+  func applicationDidBecomeActive() {
+    guard ollamaStatusPollTask != nil else { return }
+    ollamaActivationProbeTask?.cancel()
+    ollamaActivationProbeTask = Task { [weak self] in
+      // `Task.cancel()` only sets a flag; a closure cancelled before entry
+      // still runs until its first cancellation check. This is that check.
+      guard !Task.isCancelled, let self else { return }
+      guard self.ollamaSetup.setupState.allowsSilentBackgroundRefresh else { return }
+      await self.ollamaStatusProbe("app_active")
+    }
+  }
+
+  /// Cancel every task this coordinator owns: the Ollama poll, the Ollama
+  /// activation probe, the WhisperKit preload observer, and the WhisperKit
+  /// migration task.
+  func cleanup() {
+    ollamaStatusPollTask?.cancel()
+    ollamaStatusPollTask = nil
+    ollamaActivationProbeTask?.cancel()
+    ollamaActivationProbeTask = nil
+    whisperKitPreloadTask?.cancel()
+    whisperKitPreloadTask = nil
+    whisperKitMigrationTask?.cancel()
+    whisperKitMigrationTask = nil
+    ollamaSetup.cleanup()
   }
 
   /// Observe `whisperKitSetup.setupState` and invoke `preloadAction` when it becomes

--- a/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
@@ -660,8 +660,9 @@ struct AIPolishSettingsView: View {
       }
       if settings.llmProvider == .ollama {
         llmDiscovery.loadCachedModels(for: .ollama)
+        setup.startOllamaStatusWatch()
         Task {
-          await setup.ollamaSetup.detectState()
+          await setup.ollamaSetup.detectState(trigger: "settings_open")
           if case .ready = setup.ollamaSetup.setupState {
             await llmDiscovery.validateKeyAndDiscoverModels(
               provider: .ollama, settings: settings)
@@ -684,6 +685,9 @@ struct AIPolishSettingsView: View {
         llmDiscovery.loadCachedModels(for: settings.llmProvider)
       }
     }
+    .onDisappear {
+      setup.stopOllamaStatusWatch()
+    }
     .onChange(of: settings.llmProvider) { _, newProvider in
       llmDiscovery.reset()
       // Model canonicalization handled by SettingsManager.llmProvider didSet.
@@ -699,15 +703,17 @@ struct AIPolishSettingsView: View {
         // just left, and that late pull cancels whatever pull is current.
         setup.ollamaSetup.cancelHostedResolution()
         setup.ollamaSetup.resetWarmup()
+        setup.stopOllamaStatusWatch()
       }
 
       switch newProvider {
       case .none:
         break
       case .ollama:
+        setup.startOllamaStatusWatch()
         // detectState() will set setupState, which triggers the onChange handler
         // for discovery + warm-up. Don't duplicate that work here.
-        Task { await setup.ollamaSetup.detectState() }
+        Task { await setup.ollamaSetup.detectState(trigger: "provider_switch") }
         // #1956: the hosted catalog does not depend on the daemon at all, so it
         // must load on SELECTION rather than on readiness. A daemon running with
         // zero models settles in `.runningNoModels`, which Manage Models still
@@ -1357,7 +1363,7 @@ struct AIPolishSettingsView: View {
 
         Button("Try Again") {
           Task {
-            await setup.ollamaSetup.detectState()
+            await setup.ollamaSetup.detectState(trigger: "try_again")
             if case .ready = setup.ollamaSetup.setupState {
               await llmDiscovery.validateKeyAndDiscoverModels(
                 provider: .ollama, settings: settings)

--- a/Sources/EnviousWisprLLM/OllamaSetupService.swift
+++ b/Sources/EnviousWisprLLM/OllamaSetupService.swift
@@ -13,6 +13,28 @@ public enum OllamaSetupState: Equatable {
   case error(String)
 }
 
+extension OllamaSetupState {
+  /// #1918: whether a PASSIVE background refresh (`SetupCoordinator`'s poll
+  /// loop or `applicationDidBecomeActive()`) may silently re-probe this
+  /// state. `.error` IS eligible — a transient failure self-heals without
+  /// user action, and a persistent one keeps showing the same message (no
+  /// new copy, no flicker on re-write since content is identical).
+  /// `.detecting`/`.pullingModel` are excluded: re-probing mid-detection or
+  /// mid-pull would contend with work already in flight. `package`, not
+  /// `public`: consumed from `SetupCoordinator` in the separate
+  /// `EnviousWisprAppKit` module, a sibling target in the same Swift
+  /// package, matching this file's own precedent (`refreshCloudCatalog`,
+  /// `pullStepLabel`).
+  package var allowsSilentBackgroundRefresh: Bool {
+    switch self {
+    case .ready, .installedNotRunning, .runningNoModels, .notInstalled, .error:
+      return true
+    case .detecting, .pullingModel:
+      return false
+    }
+  }
+}
+
 /// Warm-up state for the currently selected Ollama model.
 public enum OllamaWarmupState: Equatable {
   case idle
@@ -186,11 +208,34 @@ public final class OllamaSetupService {
   private let cloudCatalogNow: @MainActor () -> Date
   private var cloudCatalogRefreshTask: Task<Void, Never>?
 
+  /// #1918 test seam: overrides `findOllamaBinary()` for `resolveState`'s full
+  /// detection path, so the two tests exercising it are deterministic on CI,
+  /// which has no guaranteed Ollama install.
+  private let findOllamaBinaryOverride: (@MainActor () -> String?)?
+
   // Per-pull generation token. Bumped on every pullModel/cancelPull call so stale
   // tasks can no-op their writes (Swift Task cancellation is cooperative; without
   // this, a late chunk or terminal-branch cleanup from an old task could clobber
   // the newer pull's state, most acutely on cancel-then-re-download-same-model).
   private var pullEpoch: UInt64 = 0
+
+  /// #1918: generation counter bumped by every direct writer of `setupState`/
+  /// `downloadedModels`/`lastKnownStateKey` OUTSIDE `detectState`'s own commit
+  /// (`deleteModel`, `isServerRunning`, `refreshDownloadedModels`, `startServer`),
+  /// PLUS by `detectState`'s own valid commit, so a background probe suspended
+  /// during any of them backs off instead of overwriting fresher data. Pull
+  /// writes are already covered by `pullEpoch`/`currentPullingModel` and are the
+  /// one exemption; `pullModel`/`cancelPull` still bump this too, since a
+  /// change of pull ownership is itself a competing mutation `startServer`
+  /// needs to see.
+  private var statusMutationEpoch: UInt64 = 0
+
+  /// #1918: single-flight guard for `startServer`. True for the duration of its
+  /// launch + startup poll; a second call while true is a no-op. Also makes
+  /// `detectState` skip PASSIVE (`visible_poll`/`app_active`) triggers while
+  /// true, so a slower background probe never competes with the startup poll's
+  /// own 500ms cadence — an explicit trigger is unaffected.
+  private var isStartingServer = false
 
   /// #1956: the same generation guard as `pullEpoch`, for the window `pullEpoch`
   /// cannot cover.
@@ -506,11 +551,13 @@ public final class OllamaSetupService {
   private init(
     cloudCatalogClient: OllamaCloudCatalogClient,
     now: @escaping @MainActor () -> Date,
-    downloadedModels: [OllamaDownloadedModel]
+    downloadedModels: [OllamaDownloadedModel],
+    findOllamaBinaryOverride: (@MainActor () -> String?)? = nil
   ) {
     self.cloudCatalogClient = cloudCatalogClient
     self.cloudCatalogNow = now
     self.downloadedModels = downloadedModels
+    self.findOllamaBinaryOverride = findOllamaBinaryOverride
   }
 
   public convenience init() {
@@ -529,9 +576,12 @@ public final class OllamaSetupService {
   /// (swift-patterns RULE: tests-no-real-time-scheduling-precision).
   package convenience init(
     cloudCatalogClient: OllamaCloudCatalogClient,
-    now: @escaping @MainActor () -> Date = Date.init
+    now: @escaping @MainActor () -> Date = Date.init,
+    findOllamaBinaryOverride: (@MainActor () -> String?)? = nil
   ) {
-    self.init(cloudCatalogClient: cloudCatalogClient, now: now, downloadedModels: [])
+    self.init(
+      cloudCatalogClient: cloudCatalogClient, now: now, downloadedModels: [],
+      findOllamaBinaryOverride: findOllamaBinaryOverride)
   }
 
   /// #1914 test seam, approved by the founder on 2026-08-04 (test seams are a
@@ -547,41 +597,196 @@ public final class OllamaSetupService {
       downloadedModels: downloadedModelsForTesting)
   }
 
-  /// Run the full detection pipeline: binary -> server -> models.
-  public func detectState() async {
-    setupState = .detecting
+  private static let backgroundTriggers: Set<String> = ["visible_poll", "app_active"]
+  private static let portConflictMessage =
+    "Another app is using Ollama's port (11434). Close it and try again."
 
+  private var detectionToken: UInt64 = 0
+
+  private enum ServerProbeResult: Equatable {
+    case running
+    case unavailable
+    case portConflict
+  }
+
+  /// The ONLY server-health probe used during detection AND the redesigned
+  /// startup poll; `fetchDownloadedModels()` separately fetches `/api/tags`.
+  /// Returns a value instead of writing `setupState` directly, so the caller's
+  /// single commit point is genuinely the only writer during its pass.
+  private func probeServer(
+    transport: (@Sendable (URLRequest) async throws -> (Data, URLResponse))? = nil
+  ) async -> ServerProbeResult {
+    guard let url = URL(string: Self.baseURL) else { return .unavailable }
+    var request = URLRequest(url: url)
+    request.httpMethod = "GET"
+    request.timeoutInterval = 3
+    let send = transport ?? { try await URLSession.shared.data(for: $0) }
+    do {
+      let (_, response) = try await send(request)
+      guard let http = response as? HTTPURLResponse else { return .unavailable }
+      return http.statusCode == 200 ? .running : .portConflict
+    } catch {
+      return .unavailable
+    }
+  }
+
+  /// Value-returning sibling of `refreshDownloadedModels()`. Nil on any
+  /// failure (network error, non-200, malformed JSON), so callers can retain
+  /// their pre-probe list on failure exactly as `refreshDownloadedModels()`
+  /// itself does by leaving `downloadedModels` untouched.
+  private func fetchDownloadedModels(
+    transport: (@Sendable (URLRequest) async throws -> (Data, URLResponse))? = nil
+  ) async -> [OllamaDownloadedModel]? {
+    guard let url = URL(string: "\(Self.baseURL)/api/tags") else { return nil }
+    var request = URLRequest(url: url)
+    request.httpMethod = "GET"
+    request.timeoutInterval = 5
+    let send = transport ?? { try await URLSession.shared.data(for: $0) }
+    do {
+      let (data, response) = try await send(request)
+      guard let http = response as? HTTPURLResponse, http.statusCode == 200 else { return nil }
+      guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+        let models = json["models"] as? [[String: Any]]
+      else { return nil }
+      return Self.parseDownloadedModels(fromTagsModels: models)
+    } catch {
+      return nil
+    }
+  }
+
+  /// The complete value-return contract for one detection pass. Not part of
+  /// any public API; exists so `resolveState` can make zero direct writes.
+  private struct DetectionResolution {
+    let state: OllamaSetupState
+    let downloadedModels: [OllamaDownloadedModel]?
+    let lastKnownReady: Bool?
+  }
+
+  /// #1918 test seam: resolves `findOllamaBinary()` through the override when
+  /// present, so `resolveState`'s full-detection branch is deterministic on CI.
+  private func findOllamaBinaryForDetection() -> String? {
+    if let findOllamaBinaryOverride {
+      return findOllamaBinaryOverride()
+    }
+    return findOllamaBinary()
+  }
+
+  /// Full detection pipeline, matching every original branch of
+  /// `detectState()`/`hasAnyModels()`: binary -> server -> models. Makes ZERO
+  /// direct writes — `detectState`'s single commit point applies the result.
+  private func resolveState(
+    transport: (@Sendable (URLRequest) async throws -> (Data, URLResponse))?,
+    startingDownloadedModels: [OllamaDownloadedModel]
+  ) async -> DetectionResolution {
     // Fast path: if the user previously reached .ready, try the server directly.
+    // Fast path: original never writes UserDefaults here (only full detection
+    // does), so both branches below return `lastKnownReady: nil`.
     if UserDefaults.standard.bool(forKey: Self.lastKnownStateKey) {
-      if await isServerRunning() {
-        if await hasAnyModels() {
-          setupState = .ready
-          return
-        }
-        setupState = .runningNoModels
-        return
+      if case .running = await probeServer(transport: transport) {
+        let fetched = await fetchDownloadedModels(transport: transport)
+        let effective = fetched ?? startingDownloadedModels
+        return DetectionResolution(
+          state: effective.isEmpty ? .runningNoModels : .ready,
+          downloadedModels: fetched, lastKnownReady: nil)
       }
+      // Fast-path probe failed (unavailable OR port conflict) — fall through
+      // to full detection, which re-checks with a second, fresher probe. A
+      // port conflict that resolves between the two probes correctly reports
+      // `.installedNotRunning` from the second, newer probe — a deliberate
+      // divergence from the original's stale shared-state readback, not an
+      // equivalence claim.
     }
 
     // Full detection
-    guard findOllamaBinary() != nil else {
-      setupState = .notInstalled
-      UserDefaults.standard.set(false, forKey: Self.lastKnownStateKey)
-      return
+    guard findOllamaBinaryForDetection() != nil else {
+      return DetectionResolution(state: .notInstalled, downloadedModels: nil, lastKnownReady: false)
     }
 
-    guard await isServerRunning() else {
-      // isServerRunning may have already set an .error state (port conflict)
-      if case .error = setupState { return }
-      setupState = .installedNotRunning
-      return
+    switch await probeServer(transport: transport) {
+    case .unavailable:
+      return DetectionResolution(
+        state: .installedNotRunning, downloadedModels: nil, lastKnownReady: nil)
+    case .portConflict:
+      return DetectionResolution(
+        state: .error(Self.portConflictMessage), downloadedModels: nil, lastKnownReady: nil)
+    case .running:
+      let fetched = await fetchDownloadedModels(transport: transport)
+      let effective = fetched ?? startingDownloadedModels
+      return DetectionResolution(
+        state: effective.isEmpty ? .runningNoModels : .ready,
+        downloadedModels: fetched, lastKnownReady: effective.isEmpty ? nil : true)
+    }
+  }
+
+  /// Run the full detection pipeline: binary -> server -> models.
+  ///
+  /// `trigger` is diagnostic provenance AND the sole determinant of silence —
+  /// a background trigger (`visible_poll`/`app_active`) bypasses the transient
+  /// `.detecting` UI state, since a passive refresh should not flash the
+  /// spinner over content the user is already looking at.
+  public func detectState(
+    trigger: String = "manual_refresh",
+    transport: (@Sendable (URLRequest) async throws -> (Data, URLResponse))? = nil
+  ) async {
+    guard currentPullingModel == nil else { return }  // a pull is already active — never contend with it
+
+    let silent = Self.backgroundTriggers.contains(trigger)
+    guard !(silent && isStartingServer) else { return }  // don't compete with the startup poll's own cadence
+
+    detectionToken &+= 1
+    let detectionEpoch = detectionToken
+    let startingPullEpoch = pullEpoch  // snapshot BEFORE the await — catches start-and-finish too
+    let startingStatusMutationEpoch = statusMutationEpoch
+
+    if !silent {
+      setupState = .detecting
     }
 
-    if await hasAnyModels() {
-      setupState = .ready
-      UserDefaults.standard.set(true, forKey: Self.lastKnownStateKey)
-    } else {
-      setupState = .runningNoModels
+    // Without this snapshot, a failed model-list fetch inside `resolveState`
+    // has no way to preserve the current behavior — `refreshDownloadedModels()`
+    // originally left `downloadedModels` UNTOUCHED on failure, and
+    // `hasAnyModels()` decided readiness from that retained list. Passed
+    // through so `resolveState` can reproduce the same fallback without
+    // reading instance state itself (still zero direct writes).
+    let startingDownloadedModels = downloadedModels
+
+    let resolution = await resolveState(
+      transport: transport, startingDownloadedModels: startingDownloadedModels)
+
+    guard !Task.isCancelled else { return }
+    guard detectionToken == detectionEpoch else { return }  // superseded by a newer detect
+    guard pullEpoch == startingPullEpoch, currentPullingModel == nil else { return }  // a pull started, ran, or finished during our probe
+    guard statusMutationEpoch == startingStatusMutationEpoch else { return }  // deleteModel/isServerRunning/refreshDownloadedModels/startServer wrote fresher state during our probe
+
+    let previous = setupState
+    let writesModels = resolution.downloadedModels != nil
+    let writesDefault = resolution.lastKnownReady != nil
+    let writesState = previous != resolution.state
+
+    guard writesModels || writesDefault || writesState else { return }  // genuine no-op: nothing to make visible
+
+    statusMutationEpoch &+= 1
+
+    // Applied even when `setupState` itself is unchanged below — a background
+    // refresh can legitimately discover a new model list while the visible
+    // state stays `.ready`. This can reassign `downloadedModels` to an equal
+    // array on a genuine no-op detect; `OllamaDownloadedModel` is not
+    // `Equatable` today, so this is real `@Observable` churn with no
+    // consequential `.onChange` consumer — accepted as low-impact.
+    if let models = resolution.downloadedModels {
+      downloadedModels = models
+    }
+    if let lastKnownReady = resolution.lastKnownReady {
+      UserDefaults.standard.set(lastKnownReady, forKey: Self.lastKnownStateKey)
+    }
+
+    guard writesState else { return }  // no `setupState` write, no log — model/default updates above still applied
+
+    setupState = resolution.state
+
+    if silent {
+      let message = "Ollama detect (\(trigger)): \(previous) -> \(resolution.state)"
+      Task { await AppLogger.shared.log(message, level: .debug, category: "LLM") }  // fired AFTER the commit, never between guard and write
     }
   }
 
@@ -627,28 +832,21 @@ public final class OllamaSetupService {
 
   // MARK: - Server Health
 
-  /// Check whether the Ollama server is reachable. Strict 3-second timeout.
-  public func isServerRunning() async -> Bool {
-    guard let url = URL(string: Self.baseURL) else { return false }
-
-    var request = URLRequest(url: url)
-    request.httpMethod = "GET"
-    request.timeoutInterval = 3
-
-    do {
-      let (_, response) = try await URLSession.shared.data(for: request)
-      guard let http = response as? HTTPURLResponse else { return false }
-
-      if http.statusCode == 200 {
-        return true
-      }
-
-      // Port is in use by something other than Ollama
-      setupState = .error(
-        "Another app is using Ollama's port (11434). Close it and try again."
-      )
-      return false
-    } catch {
+  /// Public compatibility wrapper — after #1918, detection and the startup poll
+  /// both use `probeServer` directly, so this has no internal caller; kept as
+  /// public API surface and for its own regression test. Still bumps
+  /// `statusMutationEpoch` before its direct write, so a background probe
+  /// cannot commit stale data over this call's result if a future caller
+  /// reappears.
+  public func isServerRunning(
+    transport: (@Sendable (URLRequest) async throws -> (Data, URLResponse))? = nil
+  ) async -> Bool {
+    switch await probeServer(transport: transport) {
+    case .running: return true
+    case .unavailable: return false
+    case .portConflict:
+      statusMutationEpoch &+= 1
+      setupState = .error(Self.portConflictMessage)
       return false
     }
   }
@@ -979,6 +1177,7 @@ public final class OllamaSetupService {
       guard let http = response as? HTTPURLResponse, http.statusCode == 200 else { return }
       let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
       guard let models = json?["models"] as? [[String: Any]] else { return }
+      statusMutationEpoch &+= 1
       downloadedModels = Self.parseDownloadedModels(fromTagsModels: models)
     } catch {
       // Silently ignore -- server may not be running
@@ -1211,6 +1410,7 @@ public final class OllamaSetupService {
     do {
       let (_, response) = try await send(request)
       if let http = response as? HTTPURLResponse, http.statusCode == 200 {
+        statusMutationEpoch &+= 1
         downloadedModels.removeAll(where: { $0.exactName == name })
         // Reset warm-up if the deleted model was warmed or warming
         let canonical = Self.canonicalModelName(name)
@@ -1234,60 +1434,155 @@ public final class OllamaSetupService {
 
   // MARK: - Server Lifecycle
 
+  private static let autoStartFailureMessage =
+    "Couldn't start Ollama automatically. Try running `ollama serve` in Terminal."
+
   /// Start the Ollama server, preferring the .app bundle, falling back to the CLI binary.
   public func startServer() {
+    startServer(launch: nil, pollDelay: nil, transport: nil)
+  }
+
+  /// Testing seam, mirrors `detectState`'s injected-transport pattern. Production
+  /// supplies the real app/process launch, the real 500ms delay, and the shared
+  /// URLSession transport; tests supply a no-op launch, a signal-controlled
+  /// delay, and canned responses. No test-only state setter is added — every
+  /// seeded state is reached through this same code path production uses.
+  package func startServer(
+    launch: (@MainActor () -> Bool)?,
+    pollDelay: (@MainActor () async -> Void)?,
+    transport: (@Sendable (URLRequest) async throws -> (Data, URLResponse))?
+  ) {
+    guard !isStartingServer else { return }  // single-flight: a second click while starting is a no-op
+    isStartingServer = true
+    statusMutationEpoch &+= 1
+
+    guard (launch ?? realLaunchOllama)() else {
+      // An INJECTED `launch` closure cannot itself write private `setupState`,
+      // so this overload — not the launch closure — owns this commit.
+      // `realLaunchOllama()` is pure: it only reports whether launch was
+      // attempted successfully.
+      statusMutationEpoch &+= 1
+      setupState = .error(Self.autoStartFailureMessage)
+      isStartingServer = false
+      return
+    }
+
+    // Bumping the epoch when startup BEGINS protects every OTHER writer from
+    // a stale startup result, but does not protect startup's OWN eventual
+    // commit from a pull, delete, or explicit detection that lands during
+    // its own two awaits below (the probe, then the fetch). Re-checked after
+    // each await; `expectedStatusMutationEpoch` is tracked forward past this
+    // call's own port-conflict self-bump so a self-caused change is not
+    // misread as someone else's.
+    let startingPullEpoch = pullEpoch
+    var expectedStatusMutationEpoch = statusMutationEpoch
+
+    Task { [weak self] in
+      let maxAttempts = 20
+      for _ in 0..<maxAttempts {
+        if let pollDelay {
+          await pollDelay()
+        } else {
+          try? await Task.sleep(nanoseconds: 500_000_000)  // 500ms
+        }
+        guard let self else { return }
+
+        let probeResult = await self.probeServer(transport: transport)
+        guard self.pullEpoch == startingPullEpoch, self.currentPullingModel == nil,
+          self.statusMutationEpoch == expectedStatusMutationEpoch
+        else {
+          // A pull, delete, or explicit detection landed fresher data during
+          // this probe's await — this startup attempt is now stale; back off
+          // without committing, exactly as `detectState` would.
+          self.isStartingServer = false
+          return
+        }
+
+        // Today's `isServerRunning()`-based poll writes the port-conflict
+        // error immediately on the first such probe while still polling —
+        // preserved here so a naive continue-on-any-non-running case cannot
+        // silently delay it until the timeout branch.
+        switch probeResult {
+        case .unavailable:
+          continue
+        case .portConflict:
+          self.statusMutationEpoch &+= 1
+          expectedStatusMutationEpoch = self.statusMutationEpoch
+          self.setupState = .error(Self.portConflictMessage)
+          continue
+        case .running:
+          break
+        }
+
+        // Value-returning probes only — NEVER the side-effecting
+        // isServerRunning()/hasAnyModels(), which would each need their own
+        // guard against this same Task racing a concurrent explicit
+        // detectState() commit.
+        let fetched = await self.fetchDownloadedModels(transport: transport)
+        guard self.pullEpoch == startingPullEpoch, self.currentPullingModel == nil,
+          self.statusMutationEpoch == expectedStatusMutationEpoch
+        else {
+          self.isStartingServer = false
+          return
+        }
+
+        // `fetched ?? self.downloadedModels` retains the existing model list
+        // on a transient `/api/tags` failure, matching
+        // `refreshDownloadedModels()`'s own no-op-on-failure contract — the
+        // same pattern `resolveState` uses via `startingDownloadedModels`.
+        let effective = fetched ?? self.downloadedModels
+        self.statusMutationEpoch &+= 1  // bump immediately before the one synchronous commit below
+        if let fetched {
+          self.downloadedModels = fetched
+        }
+        self.setupState = effective.isEmpty ? .runningNoModels : .ready
+        if !effective.isEmpty {
+          UserDefaults.standard.set(true, forKey: Self.lastKnownStateKey)
+        }
+        self.isStartingServer = false
+        return
+      }
+      self?.statusMutationEpoch &+= 1
+      self?.setupState = .error(Self.autoStartFailureMessage)
+      self?.isStartingServer = false
+    }
+  }
+
+  /// Carries today's app-bundle/binary/`Process.run()` decision tree but
+  /// writes no state. Returns `false` when no launch path exists or
+  /// `Process.run()` throws; the `startServer` overload above uniformly
+  /// commits `autoStartFailureMessage` for both production and injected
+  /// failures. Preserves today's exact behavior: the app-bundle path calls
+  /// `NSWorkspace.open`, whose `Bool` return today's code already ignores,
+  /// so returning `true` unconditionally changes nothing observable; the
+  /// binary path's `Process.run()` can still throw.
+  private func realLaunchOllama() -> Bool {
     let appPath = "/Applications/Ollama.app"
 
     if FileManager.default.fileExists(atPath: appPath) {
       NSWorkspace.shared.open(URL(fileURLWithPath: appPath))
-    } else if let binary = findOllamaBinary() {
-      let process = Process()
-      process.executableURL = URL(fileURLWithPath: binary)
-      process.arguments = ["serve"]
-      process.standardOutput = FileHandle.nullDevice
-      process.standardError = FileHandle.nullDevice
-      process.terminationHandler = { [weak self] _ in
-        Task { @MainActor in
-          self?.ollamaProcess = nil
-        }
-      }
-      do {
-        try process.run()
-        ollamaProcess = process
-      } catch {
-        setupState = .error(
-          "Couldn't start Ollama automatically. Try running `ollama serve` in Terminal."
-        )
-        return
-      }
-    } else {
-      setupState = .error(
-        "Couldn't start Ollama automatically. Try running `ollama serve` in Terminal."
-      )
-      return
+      return true
     }
 
-    // Poll until the server is up (up to 10 seconds)
-    Task { [weak self] in
-      let maxAttempts = 20
-      for _ in 0..<maxAttempts {
-        try? await Task.sleep(nanoseconds: 500_000_000)  // 500ms
-        guard let self else { return }
+    guard let binary = findOllamaBinary() else { return false }
 
-        if await self.isServerRunning() {
-          if await self.hasAnyModels() {
-            self.setupState = .ready
-            UserDefaults.standard.set(true, forKey: Self.lastKnownStateKey)
-          } else {
-            self.setupState = .runningNoModels
-          }
-          return
-        }
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: binary)
+    process.arguments = ["serve"]
+    process.standardOutput = FileHandle.nullDevice
+    process.standardError = FileHandle.nullDevice
+    process.terminationHandler = { [weak self] _ in
+      Task { @MainActor in
+        self?.ollamaProcess = nil
       }
+    }
 
-      self?.setupState = .error(
-        "Couldn't start Ollama automatically. Try running `ollama serve` in Terminal."
-      )
+    do {
+      try process.run()
+      ollamaProcess = process
+      return true
+    } catch {
+      return false
     }
   }
 
@@ -1308,6 +1603,7 @@ public final class OllamaSetupService {
     pullTask?.cancel()
     pullTask = nil
     pullEpoch &+= 1
+    statusMutationEpoch &+= 1
     let epoch = pullEpoch
 
     // Reset progress
@@ -1386,6 +1682,7 @@ public final class OllamaSetupService {
       pullTask?.cancel()
       pullTask = nil
       pullEpoch &+= 1
+      statusMutationEpoch &+= 1
       currentPullingModel = nil
       // Bug fix: don't force .runningNoModels if models exist
       if downloadedModels.isEmpty {
@@ -1412,6 +1709,7 @@ public final class OllamaSetupService {
       //      runs. Provider-switch path overwrites this moments later via
       //      detectState() on switch-back; same-pane Cancel just settles here.
       pullEpoch &+= 1
+      statusMutationEpoch &+= 1
       currentPullingModel = nil
       setupState = .ready
     }

--- a/Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift
@@ -89,6 +89,263 @@ struct SetupCoordinatorTests {
   private func drainMainActorTasks(_ iterations: Int = 20) async {
     for _ in 0..<iterations { await Task.yield() }
   }
+
+  // MARK: - #1918: Ollama status watch (poll + activation)
+
+  /// Default placeholder delay for tests that never let the poll tick on its
+  /// own (they assert on `startOllamaStatusWatch()`'s IMMEDIATE effects
+  /// only); any test that cares about a poll tick injects its own
+  /// signal-controlled `ollamaPollDelay` instead of relying on this firing.
+  private func neverFiringPollDelay() async throws {
+    try? await Task.sleep(for: .seconds(3600))  // settle: never-fires placeholder, real tests inject their own signal-controlled delay
+  }
+
+  private func makeCoordinator(
+    ollamaStatusProbe: (@MainActor (String) async -> Void)? = nil,
+    ollamaPollDelay: (@MainActor () async throws -> Void)? = nil
+  ) -> SetupCoordinator {
+    SetupCoordinator(
+      asrManager: FakeASRManager(backend: .parakeet),
+      whisperKitSetup: WhisperKitSetupService(engineMutationScope: .alwaysAllowedForTesting),
+      preloadAction: { @MainActor in },
+      ollamaStatusProbe: ollamaStatusProbe,
+      ollamaPollDelay: ollamaPollDelay ?? neverFiringPollDelay
+    )
+  }
+
+  @Test("applicationDidBecomeActive() probes only when a watch is active and the state is eligible")
+  func applicationDidBecomeActiveProbesOnlyWhenWatchActive() async {
+    let probeLog = ProbeLog()
+    let coord = makeCoordinator(
+      ollamaStatusProbe: { trigger in await probeLog.record(trigger) })
+
+    // `ollamaSetup.setupState` defaults to `.detecting`, which is NOT
+    // eligible for a silent background refresh — reach a real eligible
+    // state first, the same way production only ever reaches one: through
+    // a genuine call, never a direct assignment.
+    _ = await coord.ollamaSetup.isServerRunning(
+      transport: { request in
+        (
+          Data(),
+          HTTPURLResponse(
+            url: request.url!, statusCode: 503, httpVersion: nil, headerFields: nil)!
+        )
+      })
+    #expect(coord.ollamaSetup.setupState.allowsSilentBackgroundRefresh)
+
+    // Before startOllamaStatusWatch(): no-op.
+    coord.applicationDidBecomeActive()
+    await drainMainActorTasks()
+    #expect(await probeLog.triggers.isEmpty)
+
+    // After starting the watch: probes with "app_active".
+    coord.startOllamaStatusWatch()
+    coord.applicationDidBecomeActive()
+    for _ in 0..<200 where await probeLog.triggers.isEmpty { await Task.yield() }
+    #expect(await probeLog.triggers == ["app_active"])
+
+    coord.stopOllamaStatusWatch()
+  }
+
+  @Test(
+    "cleanup() cancels the Ollama watch tasks: the injected probe receives no further calls even after the delay would have fired again"
+  )
+  func cleanupCancelsOllamaStatusTasks() async {
+    let probeLog = ProbeLog()
+    let gate = ReleaseGate()
+    let started = AsyncStream.makeStream(of: Void.self)
+    let startedContinuation = started.continuation
+
+    let coord = makeCoordinator(
+      ollamaStatusProbe: { trigger in await probeLog.record(trigger) },
+      ollamaPollDelay: {
+        startedContinuation.yield(())
+        await gate.wait()
+      })
+
+    // Reach a real eligible state first — `.detecting` (the default) would
+    // make this test pass vacuously, since no probe would fire either way.
+    _ = await coord.ollamaSetup.isServerRunning(
+      transport: { request in
+        (
+          Data(),
+          HTTPURLResponse(
+            url: request.url!, statusCode: 503, httpVersion: nil, headerFields: nil)!
+        )
+      })
+    #expect(coord.ollamaSetup.setupState.allowsSilentBackgroundRefresh)
+
+    coord.startOllamaStatusWatch()
+
+    var iterator = started.stream.makeAsyncIterator()
+    _ = await iterator.next()  // poll task has entered its delay, about to probe once released
+
+    coord.cleanup()
+    await gate.release()
+    await drainMainActorTasks(200)
+
+    #expect(
+      await probeLog.triggers.isEmpty, "no probe should fire once cleanup() has cancelled the watch"
+    )
+  }
+
+  @Test("cleanup() also cancels migration/preload tasks")
+  func cleanupCancelsMigrationAndPreloadTasks() async {
+    let fakeASR = FakeASRManager(backend: .whisperKit)
+    let migrationLog = ProbeLog()
+    let migrationGate = ReleaseGate()
+    let migrationStarted = AsyncStream.makeStream(of: Void.self)
+    let migrationStartedContinuation = migrationStarted.continuation
+
+    let coord = SetupCoordinator(
+      asrManager: fakeASR,
+      whisperKitSetup: WhisperKitSetupService(engineMutationScope: .alwaysAllowedForTesting),
+      setupStateReader: { .ready },
+      runDocumentsMigration: {
+        migrationStartedContinuation.yield(())
+        migrationStartedContinuation.finish()
+        await migrationGate.wait()
+        await migrationLog.record("migration-completed")
+      },
+      preloadAction: { @MainActor in await migrationLog.record("preload-fired") }
+    )
+
+    coord.startWhisperKitMigrationThenDetect()
+
+    var iterator = migrationStarted.stream.makeAsyncIterator()
+    _ = await iterator.next()  // migration task is parked
+
+    coord.cleanup()
+    await migrationGate.release()
+    await drainMainActorTasks(200)
+
+    // `runDocumentsMigration()` was already in flight when `cleanup()` ran,
+    // so per Swift's cooperative cancellation it legitimately completes and
+    // records "migration-completed" — cancellation only takes effect at the
+    // NEXT check. What must NOT happen is anything AFTER it: the migration
+    // task's own `guard !Task.isCancelled else { return }` (checked right
+    // after this await) must stop it from calling `detectState()` and
+    // `startPreloadObservation()` — and since this test's fake backend is
+    // `.whisperKit` with `setupStateReader` fixed to `.ready`, preload would
+    // fire almost immediately if that guard were missing.
+    #expect(await migrationLog.triggers.contains("migration-completed"))
+    #expect(
+      !(await migrationLog.triggers.contains("preload-fired")),
+      "cleanup() must stop the migration chain before it reaches startPreloadObservation()/preloadAction"
+    )
+  }
+
+  @Test("stopOllamaStatusWatch actually cancels — no further probe calls after stop")
+  func stopOllamaStatusWatchActuallyCancels() async {
+    let probeLog = ProbeLog()
+    let gate = ReleaseGate()
+    let started = AsyncStream.makeStream(of: Void.self)
+    let startedContinuation = started.continuation
+
+    let coord = makeCoordinator(
+      ollamaStatusProbe: { trigger in await probeLog.record(trigger) },
+      ollamaPollDelay: {
+        startedContinuation.yield(())
+        await gate.wait()
+      })
+
+    // Reach a real eligible state first — `.detecting` (the default) would
+    // make this test pass vacuously, since no probe would fire either way.
+    _ = await coord.ollamaSetup.isServerRunning(
+      transport: { request in
+        (
+          Data(),
+          HTTPURLResponse(
+            url: request.url!, statusCode: 503, httpVersion: nil, headerFields: nil)!
+        )
+      })
+    #expect(coord.ollamaSetup.setupState.allowsSilentBackgroundRefresh)
+
+    coord.startOllamaStatusWatch()
+
+    var iterator = started.stream.makeAsyncIterator()
+    _ = await iterator.next()  // poll task has entered its delay, about to probe once released
+
+    coord.stopOllamaStatusWatch()
+    await gate.release()
+    await drainMainActorTasks(200)
+
+    #expect(
+      await probeLog.triggers.isEmpty,
+      "no probe should fire once stopOllamaStatusWatch() has cancelled the poll")
+  }
+
+  @Test(
+    "cleanup() cancelling whisperKitMigrationTask before it starts must stop it from ever entering runDocumentsMigration — Task.cancel() only sets a flag, so a closure cancelled before entry still runs unless its own first line checks Task.isCancelled"
+  )
+  func cleanupBeforeMigrationTaskStartsPreventsEntry() async {
+    let migrationLog = ProbeLog()
+    let coord = SetupCoordinator(
+      asrManager: FakeASRManager(backend: .whisperKit),
+      whisperKitSetup: WhisperKitSetupService(engineMutationScope: .alwaysAllowedForTesting),
+      setupStateReader: { .ready },
+      runDocumentsMigration: { await migrationLog.record("migration-entered") },
+      preloadAction: { @MainActor in }
+    )
+
+    coord.startWhisperKitMigrationThenDetect()
+    coord.cleanup()  // cancels the Task before it has necessarily been scheduled to run at all
+    await drainMainActorTasks(200)
+
+    #expect(
+      await migrationLog.triggers.isEmpty,
+      "a migration task cancelled before it starts must never enter runDocumentsMigration")
+  }
+
+  @Test(
+    "stopOllamaStatusWatch() cancelling the activation-probe task before it starts must stop it from ever probing — same Task.cancel()-only-sets-a-flag reasoning as the migration case"
+  )
+  func stopWatchBeforeActivationProbeStartsPreventsEntry() async {
+    let probeLog = ProbeLog()
+    let coord = makeCoordinator(ollamaStatusProbe: { trigger in await probeLog.record(trigger) })
+
+    _ = await coord.ollamaSetup.isServerRunning(
+      transport: { request in
+        (
+          Data(),
+          HTTPURLResponse(
+            url: request.url!, statusCode: 503, httpVersion: nil, headerFields: nil)!
+        )
+      })
+    #expect(coord.ollamaSetup.setupState.allowsSilentBackgroundRefresh)
+
+    coord.startOllamaStatusWatch()
+    coord.applicationDidBecomeActive()  // launches the activation-probe Task
+    coord.stopOllamaStatusWatch()  // cancels it before it has necessarily been scheduled to run at all
+    await drainMainActorTasks(200)
+
+    #expect(
+      await probeLog.triggers.isEmpty,
+      "an activation-probe task cancelled before it starts must never call ollamaStatusProbe")
+  }
+}
+
+/// Signal-based release for a parked async closure, matching
+/// `OllamaSetupServiceDetectStateTests.ReleaseGate`.
+private actor ReleaseGate {
+  private var released = false
+  private var waiter: CheckedContinuation<Void, Never>?
+  func release() {
+    released = true
+    waiter?.resume()
+    waiter = nil
+  }
+  func wait() async {
+    if released { return }
+    await withCheckedContinuation { waiter = $0 }
+  }
+}
+
+/// Thread-safe log of every trigger an injected probe/callback was invoked
+/// with, readable from a `@Sendable` closure under Swift 6 strict concurrency.
+private actor ProbeLog {
+  private(set) var triggers: [String] = []
+  func record(_ trigger: String) { triggers.append(trigger) }
 }
 
 @MainActor

--- a/Tests/EnviousWisprTests/LLM/OllamaSetupServiceDetectStateTests.swift
+++ b/Tests/EnviousWisprTests/LLM/OllamaSetupServiceDetectStateTests.swift
@@ -1,0 +1,1003 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprLLM
+
+/// #1918: Ollama status goes stale in Settings — the detection/startup
+/// concurrency guard (`statusMutationEpoch`, `pullEpoch`, `detectionToken`,
+/// `isStartingServer`) that makes every direct writer of `setupState`/
+/// `downloadedModels`/`lastKnownStateKey` safe against a background probe
+/// (or the startup poll) suspended mid-flight and later committing stale data.
+///
+/// This suite is a SERIALIZED suite because these cases share
+/// `UserDefaults.standard` key `OllamaSetupService.lastKnownReady`. Every test
+/// that changes the key saves its prior value and restores it with `defer`.
+@MainActor
+@Suite("OllamaSetupService detectState/startServer concurrency guard (#1918)", .serialized)
+struct OllamaSetupServiceDetectStateTests {
+
+  // MARK: - Shared test infrastructure
+
+  private static let lastKnownReadyKey = "OllamaSetupService.lastKnownReady"
+
+  /// Signal-based release for a parked async closure — mirrors
+  /// `OutputClassifierHolderStateTests.ReleaseGate` / `LLMPolishReentrancyTests.ReleaseGate`.
+  private actor ReleaseGate {
+    private var released = false
+    private var waiter: CheckedContinuation<Void, Never>?
+    func release() {
+      released = true
+      waiter?.resume()
+      waiter = nil
+    }
+    func wait() async {
+      if released { return }
+      await withCheckedContinuation { waiter = $0 }
+    }
+  }
+
+  private nonisolated static func healthResponse(status: Int) -> (Data, URLResponse) {
+    (
+      Data(),
+      HTTPURLResponse(
+        url: URL(string: "http://localhost:11434")!, statusCode: status, httpVersion: nil,
+        headerFields: nil)!
+    )
+  }
+
+  private nonisolated static func tagsResponse(modelNames: [String]) -> (Data, URLResponse) {
+    let json: [String: Any] = ["models": modelNames.map { ["name": $0] }]
+    let data = try! JSONSerialization.data(withJSONObject: json)
+    return (
+      data,
+      HTTPURLResponse(
+        url: URL(string: "http://localhost:11434/api/tags")!, statusCode: 200, httpVersion: nil,
+        headerFields: nil)!
+    )
+  }
+
+  private nonisolated static func tagsFailureResponse() -> (Data, URLResponse) {
+    (
+      Data(),
+      HTTPURLResponse(
+        url: URL(string: "http://localhost:11434/api/tags")!, statusCode: 500, httpVersion: nil,
+        headerFields: nil)!
+    )
+  }
+
+  /// A transport that routes by path: `/api/tags` gets `tags`, everything else
+  /// (the bare health-check root) gets `health`. Mirrors how `resolveState`
+  /// and the redesigned `startServer` poll both share one injected transport
+  /// across `probeServer`/`fetchDownloadedModels`.
+  private nonisolated static func routedTransport(
+    health: @escaping @Sendable (URLRequest) async throws -> (Data, URLResponse),
+    tags: @escaping @Sendable (URLRequest) async throws -> (Data, URLResponse)
+  ) -> @Sendable (URLRequest) async throws -> (Data, URLResponse) {
+    { request in
+      if request.url?.path == "/api/tags" {
+        return try await tags(request)
+      }
+      return try await health(request)
+    }
+  }
+
+  /// Thread-safe counter/flag for asserting invocation state from inside a
+  /// `@Sendable` transport closure, where a plain captured `var` is rejected
+  /// under Swift 6 strict concurrency.
+  private actor CallCounter {
+    private(set) var count = 0
+    func increment() { count += 1 }
+  }
+
+  private func setLastKnownReady(_ value: Bool) {
+    UserDefaults.standard.set(value, forKey: Self.lastKnownReadyKey)
+  }
+
+  private func withRestoredLastKnownReady(_ body: () async throws -> Void) async rethrows {
+    // Preserves true ABSENCE, not just the Bool default — a genuinely fresh
+    // machine has this key unset entirely, and restoring to `false` would
+    // silently create a persisted entry that was never there before.
+    let prior = UserDefaults.standard.object(forKey: Self.lastKnownReadyKey)
+    defer {
+      if let prior {
+        UserDefaults.standard.set(prior, forKey: Self.lastKnownReadyKey)
+      } else {
+        UserDefaults.standard.removeObject(forKey: Self.lastKnownReadyKey)
+      }
+    }
+    try await body()
+  }
+
+  // MARK: - Silent vs non-silent triggers
+
+  @Test("a background trigger never shows .detecting")
+  func silentTriggerNeverObservesDetecting() async {
+    let service = OllamaSetupService(
+      cloudCatalogClient: OllamaCloudCatalogClient(),
+      findOllamaBinaryOverride: { "/test/ollama" })
+
+    // First establish `.error` through the public wrapper with a canned
+    // non-200 response — a state `allowsSilentBackgroundRefresh`.
+    _ = await service.isServerRunning(transport: { _ in Self.healthResponse(status: 503) })
+    #expect(
+      service.setupState
+        == .error("Another app is using Ollama's port (11434). Close it and try again."))
+
+    // Start a silent detection with its first transport request parked;
+    // assert the state remains `.error`, not `.detecting`.
+    let gate = ReleaseGate()
+    let started = AsyncStream.makeStream(of: Void.self)
+    let startedContinuation = started.continuation
+
+    let task = Task { @MainActor in
+      await service.detectState(
+        trigger: "visible_poll",
+        transport: { request in
+          startedContinuation.yield(())
+          startedContinuation.finish()
+          await gate.wait()
+          return Self.healthResponse(status: 200)
+        })
+    }
+
+    var iterator = started.stream.makeAsyncIterator()
+    _ = await iterator.next()  // proves the transport was actually invoked
+
+    #expect(
+      service.setupState
+        == .error("Another app is using Ollama's port (11434). Close it and try again."))
+
+    await gate.release()
+    _ = await task.value
+  }
+
+  @Test("a non-background trigger still shows .detecting immediately")
+  func nonBackgroundTriggerStillShowsDetecting() async {
+    let service = OllamaSetupService(
+      cloudCatalogClient: OllamaCloudCatalogClient(),
+      findOllamaBinaryOverride: { "/test/ollama" })
+
+    // First establish a non-detecting state through a completed public call.
+    _ = await service.isServerRunning(transport: { _ in Self.healthResponse(status: 503) })
+    #expect(service.setupState != .detecting)
+
+    // Start the second, non-background detection with its transport parked;
+    // assert `.detecting` before releasing the response.
+    let gate = ReleaseGate()
+    let started = AsyncStream.makeStream(of: Void.self)
+    let startedContinuation = started.continuation
+
+    let task = Task { @MainActor in
+      await service.detectState(
+        trigger: "manual_refresh",
+        transport: { request in
+          startedContinuation.yield(())
+          startedContinuation.finish()
+          await gate.wait()
+          return Self.healthResponse(status: 200)
+        })
+    }
+
+    var iterator = started.stream.makeAsyncIterator()
+    _ = await iterator.next()
+
+    #expect(service.setupState == .detecting)
+
+    await gate.release()
+    _ = await task.value
+  }
+
+  // MARK: - Overlapping detections
+
+  @Test("overlapping calls: older starts first, resolves last -> newer result wins")
+  func newerCallWinsOverStaleSlowerCall() async {
+    let service = OllamaSetupService(
+      cloudCatalogClient: OllamaCloudCatalogClient(),
+      findOllamaBinaryOverride: { "/test/ollama" })
+
+    let olderGate = ReleaseGate()
+    let olderStarted = AsyncStream.makeStream(of: Void.self)
+    let olderStartedContinuation = olderStarted.continuation
+
+    let olderTask = Task { @MainActor in
+      await service.detectState(
+        trigger: "manual_refresh",
+        transport: { request in
+          olderStartedContinuation.yield(())
+          olderStartedContinuation.finish()
+          await olderGate.wait()
+          return Self.healthResponse(status: 503)  // would resolve to .installedNotRunning
+        })
+    }
+
+    var olderIterator = olderStarted.stream.makeAsyncIterator()
+    _ = await olderIterator.next()  // older call's probe is in flight
+
+    // Newer call resolves fully before the older one is released.
+    await service.detectState(
+      trigger: "manual_refresh",
+      transport: { _ in Self.healthResponse(status: 200) })
+
+    #expect(
+      service.setupState == .installedNotRunning || service.setupState == .runningNoModels
+        || service.setupState == .ready)
+    let afterNewer = service.setupState
+
+    await olderGate.release()
+    _ = await olderTask.value
+
+    // The older, now-stale call must not have overwritten the newer result.
+    #expect(service.setupState == afterNewer)
+  }
+
+  // MARK: - Pull contention
+
+  @Test("detectState refuses to even START while a pull is already active")
+  func detectStateNoOpsWhileAlreadyPulling() async {
+    let service = OllamaSetupService(
+      cloudCatalogClient: OllamaCloudCatalogClient(),
+      findOllamaBinaryOverride: { "/test/ollama" })
+    service.pullModel("llama3.2")
+    #expect(service.currentPullingModel == "llama3.2")
+
+    let counter = CallCounter()
+    await service.detectState(
+      trigger: "manual_refresh",
+      transport: { request in
+        await counter.increment()
+        return Self.healthResponse(status: 200)
+      })
+
+    #expect(await counter.count == 0)
+    service.cancelPull()
+  }
+
+  @Test(
+    "a pull starts WHILE a probe is in flight, and FINISHES before the probe resolves — the case rev 2's guard structurally could not catch"
+  )
+  func pullStartingAndFinishingMidProbeIsNeverClobbered() async {
+    let service = OllamaSetupService(
+      cloudCatalogClient: OllamaCloudCatalogClient(),
+      findOllamaBinaryOverride: { "/test/ollama" })
+
+    let gate = ReleaseGate()
+    let started = AsyncStream.makeStream(of: Void.self)
+    let startedContinuation = started.continuation
+
+    let task = Task { @MainActor in
+      await service.detectState(
+        trigger: "visible_poll",
+        transport: { request in
+          startedContinuation.yield(())
+          startedContinuation.finish()
+          await gate.wait()
+          return Self.healthResponse(status: 200)  // stale "ready"-ish response
+        })
+    }
+
+    var iterator = started.stream.makeAsyncIterator()
+    _ = await iterator.next()  // proves the probe is in flight
+
+    service.pullModel("llama3.2")
+    service.cancelPull()  // both starts AND finishes the pull before the probe resolves
+
+    let stateAfterPull = service.setupState
+
+    await gate.release()
+    _ = await task.value
+
+    // The discarded probe must not have overwritten the pull's outcome.
+    #expect(service.setupState == stateAfterPull)
+  }
+
+  // MARK: - Single-authority: isServerRunning's retained direct write
+
+  @Test(
+    "port-conflict .error surfaces through probeServer -> resolveState, with NO direct write outside detectState's commit"
+  )
+  func portConflictSurfacesAsErrorThroughSingleCommit() async {
+    let service = OllamaSetupService(
+      cloudCatalogClient: OllamaCloudCatalogClient(),
+      findOllamaBinaryOverride: { "/test/ollama" })
+
+    let gate = ReleaseGate()
+    let started = AsyncStream.makeStream(of: Void.self)
+    let startedContinuation = started.continuation
+
+    let task = Task { @MainActor in
+      await service.detectState(
+        trigger: "manual_refresh",
+        transport: { request in
+          startedContinuation.yield(())
+          startedContinuation.finish()
+          await gate.wait()
+          return Self.healthResponse(status: 503)  // port conflict
+        })
+    }
+
+    var iterator = started.stream.makeAsyncIterator()
+    _ = await iterator.next()
+
+    // While the probe is parked, `setupState` must still be `.detecting`
+    // (the entry write), not already `.error` — proving no direct write
+    // happened outside the eventual commit.
+    #expect(service.setupState == .detecting)
+
+    await gate.release()
+    _ = await task.value
+
+    #expect(
+      service.setupState
+        == .error("Another app is using Ollama's port (11434). Close it and try again."))
+  }
+
+  @Test(
+    "isServerRunning() (the public wrapper) still writes .error directly, for its ONE remaining caller, AND bumps statusMutationEpoch before that write"
+  )
+  func isServerRunningStillWritesErrorAndInvalidatesDetection() async {
+    let service = OllamaSetupService(
+      cloudCatalogClient: OllamaCloudCatalogClient(),
+      findOllamaBinaryOverride: { "/test/ollama" })
+
+    let running = await service.isServerRunning(
+      transport: { _ in Self.healthResponse(status: 503) })
+
+    #expect(!running)
+    #expect(
+      service.setupState
+        == .error("Another app is using Ollama's port (11434). Close it and try again."))
+
+    // A detection parked BEFORE this call must back off rather than
+    // overwrite it — proving the epoch bump actually took effect.
+    let gate = ReleaseGate()
+    let started = AsyncStream.makeStream(of: Void.self)
+    let startedContinuation = started.continuation
+
+    let task = Task { @MainActor in
+      await service.detectState(
+        trigger: "visible_poll",
+        transport: { request in
+          startedContinuation.yield(())
+          startedContinuation.finish()
+          await gate.wait()
+          return Self.healthResponse(status: 200)
+        })
+    }
+    var iterator = started.stream.makeAsyncIterator()
+    _ = await iterator.next()
+
+    // Land a second isServerRunning() error WHILE the detection is parked.
+    _ = await service.isServerRunning(transport: { _ in Self.healthResponse(status: 503) })
+
+    await gate.release()
+    _ = await task.value
+
+    // The parked detection's stale "running" result must not have won.
+    #expect(
+      service.setupState
+        == .error("Another app is using Ollama's port (11434). Close it and try again."))
+  }
+
+  // MARK: - deleteModel / startServer race coverage
+
+  @Test(
+    "a deleteModel() success lands entirely within a probe's network wait — a case pullEpoch cannot see at all"
+  )
+  func deleteModelDuringProbeIsNeverClobbered() async {
+    let service = OllamaSetupService(
+      cloudCatalogClient: OllamaCloudCatalogClient(),
+      findOllamaBinaryOverride: { "/test/ollama" })
+
+    let gate = ReleaseGate()
+    let started = AsyncStream.makeStream(of: Void.self)
+    let startedContinuation = started.continuation
+
+    let task = Task { @MainActor in
+      await service.detectState(
+        trigger: "visible_poll",
+        transport: { request in
+          startedContinuation.yield(())
+          startedContinuation.finish()
+          await gate.wait()
+          return Self.healthResponse(status: 503)  // stale "not running"
+        })
+    }
+
+    var iterator = started.stream.makeAsyncIterator()
+    _ = await iterator.next()
+
+    await service.deleteModel(
+      name: "llama3.2", transport: { _ in Self.healthResponse(status: 200) })
+    let stateAfterDelete = service.setupState
+
+    await gate.release()
+    _ = await task.value
+
+    #expect(service.setupState == stateAfterDelete)
+  }
+
+  @Test(
+    "a startServer() write lands entirely within a probe's network wait, same shape as the delete case"
+  )
+  func startServerDuringProbeIsNeverClobbered() async {
+    await withRestoredLastKnownReady {
+      let service = OllamaSetupService(
+        cloudCatalogClient: OllamaCloudCatalogClient(),
+        findOllamaBinaryOverride: { "/test/ollama" })
+
+      let gate = ReleaseGate()
+      let started = AsyncStream.makeStream(of: Void.self)
+      let startedContinuation = started.continuation
+
+      let task = Task { @MainActor in
+        await service.detectState(
+          trigger: "visible_poll",
+          transport: { request in
+            startedContinuation.yield(())
+            startedContinuation.finish()
+            await gate.wait()
+            return Self.healthResponse(status: 503)  // stale "not running"
+          })
+      }
+
+      var iterator = started.stream.makeAsyncIterator()
+      _ = await iterator.next()
+
+      service.startServer(
+        launch: { true },
+        pollDelay: {},
+        transport: Self.routedTransport(
+          health: { _ in Self.healthResponse(status: 200) },
+          tags: { _ in Self.tagsResponse(modelNames: ["llama3.2"]) }))
+
+      // Let the startup poll's own Task run to completion.
+      for _ in 0..<200 where service.setupState == .detecting {
+        await Task.yield()
+      }
+      let stateAfterStartup = service.setupState
+
+      await gate.release()
+      _ = await task.value
+
+      #expect(service.setupState == stateAfterStartup)
+    }
+  }
+
+  // MARK: - Resolution mutation guards (grounded review r3, required)
+
+  @Test(
+    "a rejected resolution (superseded, pull-invalidated, or cancelled) must not mutate downloadedModels or lastKnownStateKey"
+  )
+  func rejectedResolutionNeverMutatesModelsOrDefaults() async {
+    await withRestoredLastKnownReady {
+      let service = OllamaSetupService(
+        cloudCatalogClient: OllamaCloudCatalogClient(),
+        findOllamaBinaryOverride: { "/opt/homebrew/bin/ollama" })
+      setLastKnownReady(false)  // force FULL detection, not the fast path
+
+      let gate = ReleaseGate()
+      let started = AsyncStream.makeStream(of: Void.self)
+      let startedContinuation = started.continuation
+
+      let priorModels = service.downloadedModels
+      let priorDefault = UserDefaults.standard.bool(forKey: Self.lastKnownReadyKey)
+
+      let task = Task { @MainActor in
+        await service.detectState(
+          trigger: "manual_refresh",
+          transport: Self.routedTransport(
+            health: { request in
+              startedContinuation.yield(())
+              startedContinuation.finish()
+              await gate.wait()
+              return Self.healthResponse(status: 200)
+            },
+            tags: { _ in Self.tagsResponse(modelNames: ["new-model"]) }))
+      }
+
+      var iterator = started.stream.makeAsyncIterator()
+      _ = await iterator.next()
+
+      // Invalidate via a pull starting mid-probe.
+      service.pullModel("llama3.2")
+
+      await gate.release()
+      _ = await task.value
+
+      #expect(service.downloadedModels.count == priorModels.count)
+      #expect(UserDefaults.standard.bool(forKey: Self.lastKnownReadyKey) == priorDefault)
+
+      service.cancelPull()
+    }
+  }
+
+  @Test("a same-state valid resolution (setupState unchanged) still applies a changed model list")
+  func sameStateResolutionStillUpdatesModels() async {
+    await withRestoredLastKnownReady {
+      let service = OllamaSetupService(
+        cloudCatalogClient: OllamaCloudCatalogClient(),
+        findOllamaBinaryOverride: { "/opt/homebrew/bin/ollama" })
+      setLastKnownReady(false)
+
+      // Establish `.ready` through one completed public detection.
+      await service.detectState(
+        trigger: "manual_refresh",
+        transport: Self.routedTransport(
+          health: { _ in Self.healthResponse(status: 200) },
+          tags: { _ in Self.tagsResponse(modelNames: ["llama3.2"]) }))
+      #expect(service.setupState == .ready)
+
+      // Run a second detection returning a DIFFERENT model list while
+      // remaining `.ready`; assert the model list changes.
+      await service.detectState(
+        trigger: "manual_refresh",
+        transport: Self.routedTransport(
+          health: { _ in Self.healthResponse(status: 200) },
+          tags: { _ in Self.tagsResponse(modelNames: ["llama3.2", "mistral"]) }))
+
+      #expect(service.setupState == .ready)
+      #expect(service.downloadedModels.count == 2)
+    }
+  }
+
+  @Test(
+    "a failed model-list fetch retains the STARTING list for the state decision, matching refreshDownloadedModels's original no-op-on-failure"
+  )
+  func failedFetchRetainsStartingModelsForStateDecision() async {
+    await withRestoredLastKnownReady {
+      let service = OllamaSetupService(
+        cloudCatalogClient: OllamaCloudCatalogClient(),
+        findOllamaBinaryOverride: { "/test/ollama" })
+      setLastKnownReady(true)  // reach the fast path directly
+
+      // Seed a non-empty list via a successful detection first.
+      await service.detectState(
+        trigger: "manual_refresh",
+        transport: Self.routedTransport(
+          health: { _ in Self.healthResponse(status: 200) },
+          tags: { _ in Self.tagsResponse(modelNames: ["llama3.2"]) }))
+      #expect(service.setupState == .ready)
+      let seededCount = service.downloadedModels.count
+      #expect(seededCount > 0)
+
+      // Now a fetch that succeeds for the server probe but fails /api/tags.
+      await service.detectState(
+        trigger: "manual_refresh",
+        transport: Self.routedTransport(
+          health: { _ in Self.healthResponse(status: 200) },
+          tags: { _ in Self.tagsFailureResponse() }))
+
+      // Resulting state is `.ready` (not `.runningNoModels`), because the
+      // retained starting list was non-empty, and the committed
+      // downloadedModels is unchanged.
+      #expect(service.setupState == .ready)
+      #expect(service.downloadedModels.count == seededCount)
+    }
+  }
+
+  @Test(
+    "a fast-path port conflict followed by a second probe reporting .unavailable resolves to .installedNotRunning, a deliberate divergence from the original's stale-.error-retention readback"
+  )
+  func staleFastPathErrorClearsWhenSecondProbeRecovers() async {
+    await withRestoredLastKnownReady {
+      let service = OllamaSetupService(
+        cloudCatalogClient: OllamaCloudCatalogClient(),
+        findOllamaBinaryOverride: { "/opt/homebrew/bin/ollama" })
+      setLastKnownReady(true)  // reach the fast path
+
+      let counter = CallCounter()
+      await service.detectState(
+        trigger: "manual_refresh",
+        transport: Self.routedTransport(
+          health: { request in
+            await counter.increment()
+            if await counter.count == 1 {
+              return Self.healthResponse(status: 503)  // fast-path port-conflict-shaped failure
+            }
+            throw URLError(.cannotConnectToHost)  // full-detection probe: connection failure
+          },
+          tags: { _ in Self.tagsResponse(modelNames: []) }))
+
+      #expect(service.setupState == .installedNotRunning)
+    }
+  }
+
+  // MARK: - startServer
+
+  @Test(
+    "startServer is single-flight: a second call while starting is a no-op, not a second launch/poll"
+  )
+  func repeatedStartServerIsSingleFlight() async {
+    let service = OllamaSetupService(
+      cloudCatalogClient: OllamaCloudCatalogClient(),
+      findOllamaBinaryOverride: { "/test/ollama" })
+
+    let gate = ReleaseGate()
+    let started = AsyncStream.makeStream(of: Void.self)
+    let startedContinuation = started.continuation
+    var launchCount = 0
+
+    service.startServer(
+      launch: {
+        launchCount += 1
+        return true
+      },
+      pollDelay: {
+        startedContinuation.yield(())
+        await gate.wait()
+      },
+      transport: { _ in Self.healthResponse(status: 503) })
+
+    var iterator = started.stream.makeAsyncIterator()
+    _ = await iterator.next()  // first poll tick is parked
+
+    var secondLaunchCount = 0
+    service.startServer(
+      launch: {
+        secondLaunchCount += 1
+        return true
+      },
+      pollDelay: {},
+      transport: { _ in Self.healthResponse(status: 200) })
+
+    #expect(launchCount == 1)
+    #expect(secondLaunchCount == 0)
+    #expect(service.setupState != .ready)  // second call's transport never ran
+
+    await gate.release()
+    for _ in 0..<200 where service.setupState == .detecting {
+      await Task.yield()
+    }
+  }
+
+  @Test(
+    "startup reaches the server but /api/tags fails -- must retain the existing model list, matching refreshDownloadedModels's own no-op-on-failure contract, not erase it"
+  )
+  func startServerFailedFetchRetainsStartingModels() async {
+    await withRestoredLastKnownReady {
+      let service = OllamaSetupService(
+        cloudCatalogClient: OllamaCloudCatalogClient(),
+        findOllamaBinaryOverride: { "/test/ollama" })
+      setLastKnownReady(true)
+
+      // Seed a non-empty model list.
+      await service.detectState(
+        trigger: "manual_refresh",
+        transport: Self.routedTransport(
+          health: { _ in Self.healthResponse(status: 200) },
+          tags: { _ in Self.tagsResponse(modelNames: ["llama3.2"]) }))
+      let seededCount = service.downloadedModels.count
+      #expect(seededCount > 0)
+
+      service.startServer(
+        launch: { true },
+        pollDelay: {},
+        transport: Self.routedTransport(
+          health: { _ in Self.healthResponse(status: 200) },
+          tags: { _ in Self.tagsFailureResponse() }))
+
+      for _ in 0..<200 where service.setupState != .ready && service.setupState != .runningNoModels
+      {
+        await Task.yield()
+      }
+
+      #expect(service.setupState == .ready)
+      #expect(service.downloadedModels.count == seededCount)
+    }
+  }
+
+  @Test("injected launch failure commits the existing error and releases single-flight")
+  func startServerLaunchFailureCommitsErrorAndAllowsRetry() async {
+    let service = OllamaSetupService(
+      cloudCatalogClient: OllamaCloudCatalogClient(),
+      findOllamaBinaryOverride: { "/test/ollama" })
+
+    service.startServer(
+      launch: { false }, pollDelay: {}, transport: { _ in Self.healthResponse(status: 200) })
+
+    #expect(
+      service.setupState
+        == .error("Couldn't start Ollama automatically. Try running `ollama serve` in Terminal."))
+
+    var secondLaunchRan = false
+    service.startServer(
+      launch: {
+        secondLaunchRan = true
+        return false
+      }, pollDelay: {}, transport: { _ in Self.healthResponse(status: 200) })
+
+    #expect(secondLaunchRan)  // single-flight released after the first failure
+  }
+
+  @Test("twenty unsuccessful probes commit timeout and release single-flight")
+  func startServerTimeoutCommitsErrorAndAllowsRetry() async {
+    let service = OllamaSetupService(
+      cloudCatalogClient: OllamaCloudCatalogClient(),
+      findOllamaBinaryOverride: { "/test/ollama" })
+
+    service.startServer(
+      launch: { true },
+      pollDelay: {},
+      transport: { _ in Self.healthResponse(status: 503) })
+
+    for _ in 0..<500
+    where service.setupState
+      != .error("Couldn't start Ollama automatically. Try running `ollama serve` in Terminal.")
+    {
+      await Task.yield()
+    }
+
+    #expect(
+      service.setupState
+        == .error("Couldn't start Ollama automatically. Try running `ollama serve` in Terminal."))
+
+    var secondLaunchRan = false
+    service.startServer(
+      launch: {
+        secondLaunchRan = true
+        return true
+      }, pollDelay: {}, transport: { _ in Self.healthResponse(status: 200) })
+    #expect(secondLaunchRan)
+  }
+
+  @Test("a port-conflict probe surfaces its error right away but polling continues")
+  func startServerPortConflictSurfacesImmediatelyAndKeepsPolling() async {
+    await withRestoredLastKnownReady {
+      let service = OllamaSetupService(
+        cloudCatalogClient: OllamaCloudCatalogClient(),
+        findOllamaBinaryOverride: { "/test/ollama" })
+      setLastKnownReady(false)
+
+      // Deterministic ordering: park the SECOND health request behind a
+      // gate. Waiting for "second request started" proves the first
+      // conflict was already committed — a plain `Task.yield()` poll cannot
+      // guarantee interception of that transient `.error` state, since
+      // nothing forces the startup Task to yield between committing `.error`
+      // and immediately looping into its next (trivial, no real delay)
+      // attempt.
+      let counter = CallCounter()
+      let gate = ReleaseGate()
+      let secondRequestStarted = AsyncStream.makeStream(of: Void.self)
+      let secondRequestStartedContinuation = secondRequestStarted.continuation
+
+      service.startServer(
+        launch: { true },
+        pollDelay: {},
+        transport: Self.routedTransport(
+          health: { _ in
+            await counter.increment()
+            if await counter.count == 1 {
+              return Self.healthResponse(status: 503)
+            }
+            secondRequestStartedContinuation.yield(())
+            secondRequestStartedContinuation.finish()
+            await gate.wait()
+            return Self.healthResponse(status: 200)
+          },
+          tags: { _ in Self.tagsResponse(modelNames: ["llama3.2"]) }))
+
+      var iterator = secondRequestStarted.stream.makeAsyncIterator()
+      _ = await iterator.next()  // proves the first conflict was already committed
+
+      #expect(
+        service.setupState
+          == .error("Another app is using Ollama's port (11434). Close it and try again."))
+
+      await gate.release()
+      for _ in 0..<200 where service.setupState != .ready { await Task.yield() }
+      #expect(service.setupState == .ready)
+    }
+  }
+
+  @Test(
+    "a pull that starts during startup's probe or fetch await must not be clobbered by startup's later, now-stale commit"
+  )
+  func startServerDoesNotClobberPullStartedDuringPoll() async {
+    let service = OllamaSetupService(
+      cloudCatalogClient: OllamaCloudCatalogClient(),
+      findOllamaBinaryOverride: { "/test/ollama" })
+
+    let gate = ReleaseGate()
+    let started = AsyncStream.makeStream(of: Void.self)
+    let startedContinuation = started.continuation
+
+    service.startServer(
+      launch: { true },
+      pollDelay: {},
+      transport: Self.routedTransport(
+        health: { request in
+          startedContinuation.yield(())
+          startedContinuation.finish()
+          await gate.wait()
+          return Self.healthResponse(status: 200)
+        },
+        tags: { _ in Self.tagsResponse(modelNames: ["llama3.2"]) }))
+
+    var iterator = started.stream.makeAsyncIterator()
+    _ = await iterator.next()
+
+    service.pullModel("mistral")
+    let stateAfterPull = service.setupState
+
+    await gate.release()
+    for _ in 0..<200 { await Task.yield() }
+
+    #expect(service.setupState == stateAfterPull)
+    service.cancelPull()
+  }
+
+  @Test(
+    "the symmetric case: a delete that lands during startup's probe or fetch await must not be clobbered by startup's later, now-stale commit"
+  )
+  func startServerDoesNotClobberDeleteDuringPoll() async {
+    let service = OllamaSetupService(
+      cloudCatalogClient: OllamaCloudCatalogClient(),
+      findOllamaBinaryOverride: { "/test/ollama" })
+
+    let gate = ReleaseGate()
+    let started = AsyncStream.makeStream(of: Void.self)
+    let startedContinuation = started.continuation
+
+    service.startServer(
+      launch: { true },
+      pollDelay: {},
+      transport: Self.routedTransport(
+        health: { request in
+          startedContinuation.yield(())
+          startedContinuation.finish()
+          await gate.wait()
+          return Self.healthResponse(status: 200)
+        },
+        tags: { _ in Self.tagsResponse(modelNames: ["llama3.2"]) }))
+
+    var iterator = started.stream.makeAsyncIterator()
+    _ = await iterator.next()
+
+    await service.deleteModel(
+      name: "llama3.2", transport: { _ in Self.healthResponse(status: 200) })
+    let stateAfterDelete = service.setupState
+
+    await gate.release()
+    for _ in 0..<200 { await Task.yield() }
+
+    #expect(service.setupState == stateAfterDelete)
+  }
+
+  @Test(
+    "an explicit detection landing during startup's fetch await must not be clobbered by startup's later, now-stale commit"
+  )
+  func startServerDoesNotClobberExplicitDetectionDuringFetch() async {
+    await withRestoredLastKnownReady {
+      let service = OllamaSetupService(
+        cloudCatalogClient: OllamaCloudCatalogClient(),
+        findOllamaBinaryOverride: { "/opt/homebrew/bin/ollama" })
+      setLastKnownReady(false)
+
+      let gate = ReleaseGate()
+      let started = AsyncStream.makeStream(of: Void.self)
+      let startedContinuation = started.continuation
+
+      service.startServer(
+        launch: { true },
+        pollDelay: {},
+        transport: Self.routedTransport(
+          health: { _ in Self.healthResponse(status: 200) },
+          tags: { request in
+            startedContinuation.yield(())
+            startedContinuation.finish()
+            await gate.wait()
+            return Self.tagsFailureResponse()
+          }))
+
+      var iterator = started.stream.makeAsyncIterator()
+      _ = await iterator.next()  // startup's fetch is now in flight
+
+      // Explicit detection completes and commits `.installedNotRunning`.
+      // `probeServer` maps a THROWN transport error (connection refused) to
+      // `.unavailable` -> `.installedNotRunning`; a non-200 HTTP response
+      // maps to `.portConflict` instead, which is a different case.
+      await service.detectState(
+        trigger: "manual_refresh",
+        transport: Self.routedTransport(
+          health: { _ in throw URLError(.cannotConnectToHost) },
+          tags: { _ in Self.tagsFailureResponse() }))
+      #expect(service.setupState == .installedNotRunning)
+
+      await gate.release()
+      for _ in 0..<200 { await Task.yield() }
+
+      // Startup must have backed off, not overwritten the detection's result.
+      #expect(service.setupState == .installedNotRunning)
+    }
+  }
+
+  @Test(
+    "while isStartingServer is true, a passive trigger no-ops but an explicit trigger still runs, and cannot beat a startup terminal commit that lands after it"
+  )
+  func startingServerGateDistinguishesTriggers() async {
+    await withRestoredLastKnownReady {
+      let service = OllamaSetupService(
+        cloudCatalogClient: OllamaCloudCatalogClient(),
+        findOllamaBinaryOverride: { "/test/ollama" })
+
+      let gate = ReleaseGate()
+      let started = AsyncStream.makeStream(of: Void.self)
+      let startedContinuation = started.continuation
+
+      // Hold the startup overload inside its poll.
+      service.startServer(
+        launch: { true },
+        pollDelay: {
+          startedContinuation.yield(())
+          startedContinuation.finish()
+          await gate.wait()
+        },
+        transport: Self.routedTransport(
+          health: { _ in Self.healthResponse(status: 200) },
+          tags: { _ in Self.tagsResponse(modelNames: ["llama3.2"]) }))
+
+      var iterator = started.stream.makeAsyncIterator()
+      _ = await iterator.next()  // isStartingServer is now true
+
+      // Invoke visible_poll and assert its transport is untouched.
+      let passiveCounter = CallCounter()
+      await service.detectState(
+        trigger: "visible_poll",
+        transport: { _ in
+          await passiveCounter.increment()
+          return Self.healthResponse(status: 200)
+        })
+      #expect(await passiveCounter.count == 0)
+
+      // Invoke manual_refresh and assert its transport starts.
+      let explicitCounter = CallCounter()
+      let explicitGate = ReleaseGate()
+      let explicitStarted = AsyncStream.makeStream(of: Void.self)
+      let explicitStartedContinuation = explicitStarted.continuation
+
+      let explicitTask = Task { @MainActor in
+        await service.detectState(
+          trigger: "manual_refresh",
+          transport: { request in
+            await explicitCounter.increment()
+            explicitStartedContinuation.yield(())
+            explicitStartedContinuation.finish()
+            await explicitGate.wait()
+            return Self.healthResponse(status: 503)  // stale, would-be .installedNotRunning
+          })
+      }
+      var explicitIterator = explicitStarted.stream.makeAsyncIterator()
+      _ = await explicitIterator.next()
+      #expect(await explicitCounter.count > 0)
+
+      // Complete startup — its terminal commit lands while the explicit
+      // detection is still parked.
+      await gate.release()
+      for _ in 0..<200 where service.setupState != .ready { await Task.yield() }
+      #expect(service.setupState == .ready)
+
+      // Release the stale explicit detection; it must not overwrite startup's
+      // fresher, already-landed result.
+      await explicitGate.release()
+      _ = await explicitTask.value
+      #expect(service.setupState == .ready)
+    }
+  }
+}
+
+/// Exhaustive coverage of `OllamaSetupState.allowsSilentBackgroundRefresh`:
+/// `.error` IS eligible; `.detecting`/`.pullingModel` are NOT. A new
+/// `OllamaSetupState` case fails to compile here until classified.
+@Suite("OllamaSetupState background-refresh eligibility (#1918)")
+struct OllamaSetupStateBackgroundRefreshEligibilityTests {
+  @Test("every case's eligibility is exhaustively classified")
+  func exhaustiveEligibility() {
+    #expect(OllamaSetupState.ready.allowsSilentBackgroundRefresh)
+    #expect(OllamaSetupState.installedNotRunning.allowsSilentBackgroundRefresh)
+    #expect(OllamaSetupState.runningNoModels.allowsSilentBackgroundRefresh)
+    #expect(OllamaSetupState.notInstalled.allowsSilentBackgroundRefresh)
+    #expect(OllamaSetupState.error("x").allowsSilentBackgroundRefresh)
+    #expect(!OllamaSetupState.detecting.allowsSilentBackgroundRefresh)
+    #expect(!OllamaSetupState.pullingModel(progress: 0, status: "x").allowsSilentBackgroundRefresh)
+  }
+}

--- a/Tests/EnviousWisprTests/LLM/OllamaSetupServiceDetectStateTests.swift
+++ b/Tests/EnviousWisprTests/LLM/OllamaSetupServiceDetectStateTests.swift
@@ -816,14 +816,24 @@ struct OllamaSetupServiceDetectStateTests {
     var iterator = started.stream.makeAsyncIterator()
     _ = await iterator.next()
 
+    // `pullModel` has no transport seam and calls the real network for its
+    // own streaming pull, so leaving it active here would race the real
+    // connection outcome against this test's gated mock (fast-refuses in a
+    // sandboxed CI runner with no Ollama daemon, unlike a dev machine running
+    // one; CI failure on PR #1984, 2026-08-08). Cancelling immediately
+    // settles setupState synchronously and bumps pullEpoch, so the pull
+    // task's own eventual real-network completion is a guaranteed no-op
+    // regardless of how fast or slow it resolves -- matching
+    // `startServerDoesNotClobberDeleteDuringPoll`'s already-deterministic
+    // pattern of settling the competing write before capturing the snapshot.
     service.pullModel("mistral")
+    service.cancelPull()
     let stateAfterPull = service.setupState
 
     await gate.release()
     for _ in 0..<200 { await Task.yield() }
 
     #expect(service.setupState == stateAfterPull)
-    service.cancelPull()
   }
 
   @Test(


### PR DESCRIPTION
## Summary

The Ollama status shown in AI Polish settings could freeze on an outdated state: still showing "starting" after the daemon was already ready, or "ready" after the user quit Ollama outside the app. Competing async writers (manual refresh, model pull/cancel/delete, server start, and the periodic detection poll) could race and let a stale result overwrite a fresher one.

- Adds a monotonic mutation epoch (`statusMutationEpoch`) that every status-changing path bumps before it writes and re-checks after every suspension point, so only the freshest in-flight operation's result is ever committed.
- Adds a settings-pane-scoped background poll plus an app-activation probe (`SetupCoordinator.startOllamaStatusWatch()` / `applicationDidBecomeActive()`) so the status keeps itself current while the pane is open, without polling when nobody is looking at it.
- `startServer()` is redesigned as a single-flight operation with a value-returning `resolveState`/`probeServer`/`fetchDownloadedModels` shape, so a rejected detection corrupts nothing.

Full design history (7 rounds of "fresh eyes" grounded review, converged to PROCEED-AS-PLANNED): `docs/feature-requests/issue-1918-2026-08-07-ollama-status-staleness.md`.

Closes #1918

## Review

- Grounded review: converged to PROCEED-AS-PLANNED across many rounds against the plan.
- Codex diff review: two full-diff rounds via `codex exec` (round 1 found and fixed 3 issues: a cancellation-before-entry bug in two `SetupCoordinator` Task closures, a test hang risk on clean CI from missing binary-override seams, a port-conflict test race; round 2 confirmed all fixes and found nothing new) plus a fresh local `codex review --base origin/main` ("No actionable bugs were found in the changed code").
- Full local suite: 5152 tests passing (verified against a clean, uncorrupted log after an earlier concurrent-run corruption was traced and ruled out).
- 30 new/updated unit tests: 22 in `OllamaSetupServiceDetectStateTests` (new) covering the race/eligibility/resolution logic, 8 in `SetupCoordinatorTests` covering task cancellation and the watch lifecycle.

## Test plan

- [x] `scripts/xcode-test.sh` — full suite green (5152 tests)
- [x] Codex diff review clean (2 rounds `codex exec` + 1 `codex review`)
- [x] Live UAT — all 6 steps of the plan's §11.1 spec, against a real `ollama serve` daemon and the rebuilt dev app:
  - [x] Step 1: pane shows "Running" with Ollama up
  - [x] Step 2: stop Ollama with pane open, label flips to "Not running" within 40s with no click (observed at t+5s)
  - [x] Step 3: restart Ollama, label flips back to "Running" within 40s with no click (observed at t+5s)
  - [x] Step 4: background app + stop Ollama + foreground app, label flips within 12s (observed at t+3s) and `app.log` shows `Ollama detect (app_active): ready -> installedNotRunning`
  - [x] Step 5: pull-protection — uncached model download observed advancing continuously (16%→22%→29%→35% over 16s) with no interruption from the background poll, then Cancel settles the UI cleanly
  - [x] Step 6: close Settings, stop Ollama, wait 35s, reopen — fresh `settings_open` detection correctly shows "Not running"
