### PR TITLE
feat(asr): catch the FluidAudio fork up to upstream 00a9aa7 — seam fixes in, recovery patch retired

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "128828a61b47ef123f86378ec9597524df246a35c1816b3723f061057695421a",
+  "originHash" : "5c9e6cf3e8d5681449539d5bbf499b433c34cc0d4e4b02d62d7b20b9a4ae1690",
   "pins" : [
     {
       "identity" : "argmax-oss-swift",
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/saurabhav88/FluidAudio.git",
       "state" : {
-        "revision" : "afb9aab1efdad979bca22ca887a936ff2c1cd8ea"
+        "revision" : "a1767d862dd1ba221593af4b92c81d004c2cc86b"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
     .package(url: "https://github.com/argmaxinc/argmax-oss-swift", from: "1.0.0"),
     .package(
       url: "https://github.com/saurabhav88/FluidAudio.git",
-      revision: "afb9aab1efdad979bca22ca887a936ff2c1cd8ea"),
+      revision: "a1767d862dd1ba221593af4b92c81d004c2cc86b"),
     .package(url: "https://github.com/sparkle-project/Sparkle.git", from: "2.6.0"),
     .package(url: "https://github.com/PostHog/posthog-ios.git", from: "3.0.0"),
     .package(url: "https://github.com/getsentry/sentry-cocoa.git", from: "9.8.0"),

--- a/Sources/EnviousWispr/Resources/parakeet-delivery-manifest.json
+++ b/Sources/EnviousWispr/Resources/parakeet-delivery-manifest.json
@@ -5,7 +5,7 @@
     "name": "parakeet-tdt-0.6b-v3-coreml",
     "revision": "aed02740059203c4a87495924f685de3722ae9ce",
     "variant": "int8",
-    "runtimeABI": "fluidAudio-afb9aab1"
+    "runtimeABI": "fluidAudio-a1767d86"
   },
   "runtimeCompatibility": {
     "minAppVersion": "2.4.0"
@@ -172,5 +172,5 @@
     "diskHeadroomFactor": "2.2",
     "evictPreviousRevisions": false
   },
-  "manifestDigest": "db47ee6d8eb3bff63a46619ef626bd28618b165e1a48d56ae799871cd31f9232"
+  "manifestDigest": "2fe5bab08d88b3d0f32c3ab0bce126855c600f3a0cab382953d7a25b56249657"
 }

--- a/Sources/EnviousWisprASR/ParakeetBackend.swift
+++ b/Sources/EnviousWisprASR/ParakeetBackend.swift
@@ -44,24 +44,28 @@ public actor ParakeetBackend: ASRBackend {
   /// #1348 Phase 2: whether this process may let FluidAudio touch the
   /// network. Cache-only is the delivery-managed invariant — the host admits
   /// verified bytes into FluidAudio's default cache and the service ONLY
-  /// loads them; a cache miss must throw typed (`OfflineError.modelMissing`
-  /// for model dirs, `AsrModelsError` for the vocab), never silently re-enter
-  /// the borrowed downloader. Deterministic last-writer per prepare (the XPC
-  /// handler serializes loads and unloads the previous backend first), so
-  /// flipping the delivery flag works without a service restart.
-  /// `internal` for the legacy-after-cache-only unit test.
+  /// loads them; a cache miss must throw typed (`DownloadError.modelMissing`
+  /// for model dirs, `AsrModelsError.modelNotFound` for the vocab), never
+  /// silently re-enter the borrowed downloader. With offline armed, ModelHub
+  /// throws before its purge/re-download recovery branch, so a corrupt cache
+  /// can never trigger a network repair from this process (#1981). Deterministic
+  /// last-writer per prepare (the XPC handler serializes loads and unloads the
+  /// previous backend first), so flipping the delivery flag works without a
+  /// service restart. `internal` for the legacy-after-cache-only unit test.
   static func configureOfflineMode(cacheOnly: Bool) {
-    DownloadUtils.enforceOffline = cacheOnly
+    ModelHub.offlineMode = cacheOnly
   }
 
   /// Prepare with optional progress reporting.
   /// The callback is called from FluidAudio's download thread — caller must marshal to MainActor.
   ///
-  /// FluidAudio's progress system:
-  /// - `downloadRepo()` downloads ALL model files in one pass with byte-weighted progress.
-  /// - `fractionCompleted` range: [0.0, 0.5] = download, [0.5, 1.0] = CoreML compilation.
-  /// - `downloadRepo()` only fires on the first `loadModels()` call — subsequent calls find
-  ///   files cached and skip. We map directly from FluidAudio's fraction.
+  /// FluidAudio's progress system (ModelHub/ProgressReporter):
+  /// - Repo loads declare a 0.5 download-phase weight, so `fractionCompleted`
+  ///   range is [0.0, 0.5] = download (byte-weighted), [0.5, 1.0] = CoreML
+  ///   compilation; the cached fast path emits 0.5 with `.downloading(0, 0)`
+  ///   and completion emits 1.0 with `.compiling(modelName: "")`.
+  /// - Downloads only happen on the legacy path's first load — cached files
+  ///   skip straight to compilation. We map directly from FluidAudio's fraction.
   ///
   /// Stall detection is host-side (#1339): the kernel's session detector and
   /// the sessionless warm-up guard watch the shared progress file this
@@ -72,8 +76,48 @@ public actor ParakeetBackend: ASRBackend {
   /// The legacy path (`cacheOnly: false`) stays byte-identical for the
   /// staged-rollout window (D5 §5), minus the deleted inert checksum no-op.
   public func prepare(cacheOnly: Bool, progressCallback: ProgressCallback?) async throws {
-    let handler: DownloadUtils.ProgressHandler? = progressCallback.map {
-      callback -> DownloadUtils.ProgressHandler in
+    let handler = Self.makeLoadProgressHandler(progressCallback)
+
+    Self.configureOfflineMode(cacheOnly: cacheOnly)
+    do {
+      let loadedModels: AsrModels
+      if cacheOnly {
+        // Delivery-managed: the default cache was admitted by the host's hash
+        // gate before this call; offlineMode (armed above) turns any gap
+        // into a typed throw the host maps to its repair path.
+        loadedModels = try await AsrModels.loadFromCache(version: .v3, progressHandler: handler)
+      } else {
+        loadedModels = try await AsrModels.downloadAndLoad(version: .v3, progressHandler: handler)
+      }
+      self.fluidModels = loadedModels
+
+      let manager = AsrManager(config: .default)
+      // Vendor API: models load via loadModels(_:) after construction.
+      try await manager.loadModels(loadedModels)
+      self.fluidAsrManager = manager
+    } catch is CancellationError {
+      throw CancellationError()
+    } catch {
+      // #1525 PR I-B: unlike `transcribe`'s catch below, a non-recognized error
+      // here does NOT stay raw — model loading's own genuinely-non-vendor
+      // errors (a plain CocoaError/CoreML error from inside AsrModels'
+      // own loading calls) are still model-load failures, not a different
+      // physical class, so they normalize to `.unknownLoadFailure` too.
+      throw ParakeetModelLoadSentryError(normalizingLoadError: error)
+    }
+
+    isReady = true
+  }
+
+  /// The production vendor-progress → app-callback mapping, extracted from
+  /// `prepare` unchanged so the mapping itself is directly testable — one
+  /// owner, identical control flow (#1981 chunk 2; the test feeds real
+  /// `DownloadProgress` values through THIS function, not a copy).
+  static func makeLoadProgressHandler(
+    _ progressCallback: ProgressCallback?
+  ) -> ProgressHandler? {
+    progressCallback.map {
+      callback -> ProgressHandler in
       { progress in
         let phase: String
         let detail: String
@@ -104,36 +148,6 @@ public actor ParakeetBackend: ASRBackend {
         callback(progress.fractionCompleted, phase, detail)
       }
     }
-
-    Self.configureOfflineMode(cacheOnly: cacheOnly)
-    do {
-      let loadedModels: AsrModels
-      if cacheOnly {
-        // Delivery-managed: the default cache was admitted by the host's hash
-        // gate before this call; enforceOffline (armed above) turns any gap
-        // into a typed throw the host maps to its repair path.
-        loadedModels = try await AsrModels.loadFromCache(version: .v3, progressHandler: handler)
-      } else {
-        loadedModels = try await AsrModels.downloadAndLoad(version: .v3, progressHandler: handler)
-      }
-      self.fluidModels = loadedModels
-
-      let manager = AsrManager(config: .default)
-      // v0.15.4 API: initialize(models:) became loadModels(_:).
-      try await manager.loadModels(loadedModels)
-      self.fluidAsrManager = manager
-    } catch is CancellationError {
-      throw CancellationError()
-    } catch {
-      // #1525 PR I-B: unlike `transcribe`'s catch below, a non-recognized error
-      // here does NOT stay raw — model loading's own genuinely-non-vendor
-      // errors (a plain CocoaError/CoreML error from inside AsrModels'
-      // own loading calls) are still model-load failures, not a different
-      // physical class, so they normalize to `.unknownLoadFailure` too.
-      throw ParakeetModelLoadSentryError(normalizingLoadError: error)
-    }
-
-    isReady = true
   }
 
   public func transcribe(audioSamples: [Float], options: TranscriptionOptions) async throws
@@ -142,10 +156,11 @@ public actor ParakeetBackend: ASRBackend {
     guard isReady, let manager = fluidAsrManager else { throw ASRError.notReady }
 
     let startTime = CFAbsoluteTimeGetCurrent()
-    // v0.15.4 API: the caller owns decoder state (fresh per one-shot batch decode;
-    // upstream's ChunkProcessor also makes fresh state per chunk internally) and the
-    // `source:` parameter is gone. Language hint intentionally NOT passed in PR-2
-    // (parity with the d5fcca4 behavior); G7 language propagation ships in PR-4.
+    // Vendor API: the caller owns decoder state (fresh per one-shot batch decode;
+    // upstream's ChunkProcessor also makes fresh state per chunk internally); there
+    // is no `source:` parameter. Language hint deliberately NOT passed — parked
+    // with #1678 (the fork's decode-time language machinery ships a French-tuned
+    // blocklist that measurably corrupts other languages; FluidInference#840).
     var decoderState = TdtDecoderState.make(decoderLayers: await manager.decoderLayerCount)
     #if DEBUG
       // #1707 Phase 2: the real shared-engine call boundary for the overlap
@@ -207,7 +222,7 @@ public actor ParakeetBackend: ASRBackend {
 
     let config = SlidingWindowAsrConfig.streaming
     let manager = SlidingWindowAsrManager(config: config)
-    // v0.15.4 API: start(models:source:) split into loadModels(_:) + startStreaming(source:).
+    // Vendor API: streaming starts via loadModels(_:) then startStreaming(source:).
     try await manager.loadModels(models)
     try await manager.startStreaming(source: .microphone)
     self.streamingManager = manager

--- a/Sources/EnviousWisprASR/ParakeetModelLoadSentryError.swift
+++ b/Sources/EnviousWisprASR/ParakeetModelLoadSentryError.swift
@@ -18,6 +18,8 @@ enum ParakeetModelLoadSentryError: Error, LocalizedError, CustomNSError, Sendabl
   case hfDownloadFailed(String)
   case hfModelNotFound(String)
   case hfHtmlErrorResponse(String)
+  case downloadInvalidArtifact(String)
+  case downloadStalled(String)
   case unknownLoadFailure(String)
 
   static let errorDomain = "EnviousWisprASR.ParakeetModelLoadSentryError"
@@ -36,6 +38,10 @@ enum ParakeetModelLoadSentryError: Error, LocalizedError, CustomNSError, Sendabl
     case .hfModelNotFound: return 9
     case .hfHtmlErrorResponse: return 10
     case .unknownLoadFailure: return 11
+    // #1981: appended for the unified DownloadError's two new cases — codes
+    // 0-11 are a frozen XPC/Sentry contract and never renumber.
+    case .downloadInvalidArtifact: return 12
+    case .downloadStalled: return 13
     }
   }
 
@@ -44,7 +50,8 @@ enum ParakeetModelLoadSentryError: Error, LocalizedError, CustomNSError, Sendabl
     case .modelsModelNotFound(let d), .modelsDownloadFailed(let d), .modelsLoadingFailed(let d),
       .modelsCompilationFailed(let d), .offlineNetworkDisabled(let d), .offlineModelMissing(let d),
       .hfInvalidResponse(let d), .hfRateLimited(let d), .hfDownloadFailed(let d),
-      .hfModelNotFound(let d), .hfHtmlErrorResponse(let d), .unknownLoadFailure(let d):
+      .hfModelNotFound(let d), .hfHtmlErrorResponse(let d), .downloadInvalidArtifact(let d),
+      .downloadStalled(let d), .unknownLoadFailure(let d):
       return d
     }
   }
@@ -74,6 +81,8 @@ enum ParakeetModelLoadSentryError: Error, LocalizedError, CustomNSError, Sendabl
     case .hfDownloadFailed(let d): self = .hfDownloadFailed(d)
     case .hfModelNotFound(let d): self = .hfModelNotFound(d)
     case .hfHtmlErrorResponse(let d): self = .hfHtmlErrorResponse(d)
+    case .downloadInvalidArtifact(let d): self = .downloadInvalidArtifact(d)
+    case .downloadStalled(let d): self = .downloadStalled(d)
     case .unknownLoadFailure(let d): self = .unknownLoadFailure(d)
     }
   }
@@ -108,6 +117,8 @@ enum ParakeetModelLoadSentryError: Error, LocalizedError, CustomNSError, Sendabl
     case 9: self = .hfModelNotFound(d)
     case 10: self = .hfHtmlErrorResponse(d)
     case 11: self = .unknownLoadFailure(d)
+    case 12: self = .downloadInvalidArtifact(d)
+    case 13: self = .downloadStalled(d)
     default: return nil
     }
   }
@@ -130,6 +141,11 @@ extension ParakeetModelLoadSentryError: StableSentryErrorIdentity {
     case .hfDownloadFailed: return "FluidAudio.DownloadUtils.HuggingFaceDownloadError#2"
     case .hfModelNotFound: return "FluidAudio.DownloadUtils.HuggingFaceDownloadError#3"
     case .hfHtmlErrorResponse: return "FluidAudio.DownloadUtils.HuggingFaceDownloadError#4"
+    // #1981: new unified-DownloadError cases get NEW literals under the new type
+    // name; the seven literals above are FROZEN historical identities (Sentry
+    // issue continuity) and deliberately keep the deleted type's name.
+    case .downloadInvalidArtifact: return "FluidAudio.DownloadError.invalidArtifact"
+    case .downloadStalled: return "FluidAudio.DownloadError.stalled"
     case .unknownLoadFailure:
       return "EnviousWisprASR.ParakeetModelLoadSentryError.unknownLoadFailure"
     }
@@ -148,6 +164,8 @@ extension ParakeetModelLoadSentryError: StableSentryErrorIdentity {
     case .hfDownloadFailed: return "parakeet_load.hf_download_failed"
     case .hfModelNotFound: return "parakeet_load.hf_model_not_found"
     case .hfHtmlErrorResponse: return "parakeet_load.hf_html_error_response"
+    case .downloadInvalidArtifact: return "parakeet_load.download_invalid_artifact"
+    case .downloadStalled: return "parakeet_load.download_stalled"
     case .unknownLoadFailure: return "parakeet_load.unknown_load_failure"
     }
   }

--- a/Sources/EnviousWisprAppKit/Resources/THIRD-PARTY-NOTICES.txt
+++ b/Sources/EnviousWisprAppKit/Resources/THIRD-PARTY-NOTICES.txt
@@ -257,7 +257,7 @@ The full text of the Apache License, Version 2.0 follows.
 
 --------------------------------------------------------------------------------
 FluidAudio
-  Version: afb9aab1 (fork saurabhav88/FluidAudio)
+  Version: a1767d86 (fork saurabhav88/FluidAudio)
   License: Apache-2.0
   Source:  https://github.com/saurabhav88/FluidAudio
 --------------------------------------------------------------------------------

--- a/Sources/EnviousWisprAppKit/Resources/THIRD-PARTY-NOTICES.txt
+++ b/Sources/EnviousWisprAppKit/Resources/THIRD-PARTY-NOTICES.txt
@@ -1366,6 +1366,63 @@ limitations under the License.
 
 
 --------------------------------------------------------------------------------
+NemoTextProcessing / text-processing-rs (bundled in FluidAudio)
+  Version: v0.3.0
+  License: Apache-2.0 (aggregating Apache-2.0/MIT components)
+  Source:  https://github.com/FluidInference/text-processing-rs
+--------------------------------------------------------------------------------
+
+# NemoTextProcessing (text-processing-rs)
+
+The `NemoTextProcessing` binary target is the prebuilt xcframework of
+[`text-processing-rs`](https://github.com/FluidInference/text-processing-rs)
+(v0.3.0), used by `NemoTextNormalizer` for byte-exact NeMo text normalization.
+
+- **Source:** https://github.com/FluidInference/text-processing-rs
+- **License:** Apache License, Version 2.0
+
+Built with the `fst-engine` feature, the xcframework includes and statically
+links the following third-party works. All are permissive (Apache-2.0 / MIT)
+and compatible.
+
+## NVIDIA NeMo Text Processing
+
+The compiled weighted-FST grammars and text-normalization fixtures are derived
+from / copied from NVIDIA NeMo Text Processing (pinned commit
+`1f1263579fe57ba7ed783cad3dddee710fcc5064`).
+
+- **Source:** https://github.com/NVIDIA/NeMo-text-processing
+- **License:** Apache License, Version 2.0
+- **Copyright:** Copyright (c) NVIDIA CORPORATION & AFFILIATES.
+
+## rustfst
+
+Loads and executes the compiled OpenFST grammars.
+
+- **Source:** https://github.com/Garvys/rustfst
+- **License:** MIT OR Apache-2.0
+- **Copyright:** Copyright (c) Alexandre Caulier and the rustfst contributors.
+
+## flate2
+
+Decompresses the bundled gzipped grammars at load time.
+
+- **Source:** https://github.com/rust-lang/flate2-rs
+- **License:** MIT OR Apache-2.0
+- **Copyright:** Copyright (c) Alex Crichton and the flate2 contributors.
+
+## Other Rust dependencies
+
+The xcframework transitively links additional permissive-licensed Rust crates
+(MIT and/or Apache-2.0) via `rustfst` and `flate2` — e.g. `nom`,
+`miniz_oxide`, `bitflags`, `anyhow`. See the crate's `THIRD-PARTY-LICENSES.md`
+for detail.
+
+Full texts: Apache-2.0 <https://www.apache.org/licenses/LICENSE-2.0>,
+MIT <https://opensource.org/license/mit>.
+
+
+--------------------------------------------------------------------------------
 PLCrashReporter + protobuf-c (bundled in PostHog)
   Version: n/a
   License: MIT / Apache-2.0 / BSD-2-Clause

--- a/Sources/EnviousWisprAudio/BundledVADModelLoader.swift
+++ b/Sources/EnviousWisprAudio/BundledVADModelLoader.swift
@@ -31,20 +31,22 @@ enum BundledVADModelLoader {
       throw LoadError.resourceNotFound
     }
     do {
-      // Match the pinned FluidAudio VAD loader (`DownloadUtils.swift:301-303`).
-      // Keep this heart-path policy explicit across dependency updates (#1784).
+      // Match the pinned FluidAudio loader's compute policy
+      // (`ModelHub.swift:356-369` at fork pin a1767d86; the authority re-homed
+      // there through upstream's download-stack unification, #1981). Keep this
+      // heart-path policy explicit across dependency updates (#1784).
       //
-      // Deliberately NOT copied from `DownloadUtils.loadModelsOnce` (#1784
-      // audit, 2026-07-30): its aggregate cache-presence check, its three
-      // per-model structural checks (path exists, path is a directory, contains
-      // `coremldata.bin`), and — in the `loadModels` wrapper around it — the
-      // delete-cache-then-redownload retry. The retry has no equivalent here
-      // because this path has no download source to re-fetch from. The three
-      // structural checks are REDUNDANT rather than unreachable: the `Bundle`
-      // lookup above already proves the named resource exists, and
-      // `MLModel(contentsOf:configuration:)` is the authority on whether the
-      // compiled model is loadable — a failure surfaces as `.loadFailed`
-      // carrying the real CoreML error instead of a synthesized one.
+      // Deliberately NOT copied from `ModelHub.loadModelsOnce` (#1784 audit,
+      // 2026-07-30; re-verified against the new owner, #1981): its per-model
+      // structural layout validation (`ModelCache.validateCompiledModelLayout`)
+      // and — in the `loadModels` wrapper around it — the purge-then-redownload
+      // recovery. The recovery has no equivalent here because this path has no
+      // download source to re-fetch from. The structural checks are REDUNDANT
+      // rather than unreachable: the `Bundle` lookup above already proves the
+      // named resource exists, and `MLModel(contentsOf:configuration:)` is the
+      // authority on whether the compiled model is loadable — a failure
+      // surfaces as `.loadFailed` carrying the real CoreML error instead of a
+      // synthesized one.
       //
       // Do not upgrade that to "corruption is impossible here." App-bundle
       // resources are covered by the code signature's resource seal, but a seal

--- a/Sources/EnviousWisprFluidAudioBridge/FluidAudioModelLoadErrorKind.swift
+++ b/Sources/EnviousWisprFluidAudioBridge/FluidAudioModelLoadErrorKind.swift
@@ -1,11 +1,14 @@
 @preconcurrency import FluidAudio
 
-/// #1525 PR I-B: classifies FluidAudio's raw model-load errors (`ParakeetBackend.prepare`,
-/// not the transcribe path — see `FluidAudioASRErrorKind`). Three separate, unrelated
-/// FluidAudio error enums can escape model loading; each needs its own `as?` probe.
-/// `AsrModelsError.modelNotFound`/`.downloadFailed` and
-/// `HuggingFaceDownloadError.modelNotFound`/`.downloadFailed` collide by case NAME
-/// across enums (different payloads), so every case below is prefixed by its source enum.
+/// #1525 PR I-B (types updated #1981): classifies FluidAudio's raw model-load errors
+/// (`ParakeetBackend.prepare`, not the transcribe path — see `FluidAudioASRErrorKind`).
+/// Two vendor error enums can escape model loading: `AsrModelsError` and the unified
+/// `DownloadError` (which absorbed the deleted `DownloadUtils.OfflineError` and
+/// `DownloadUtils.HuggingFaceDownloadError` with case names preserved, plus two new
+/// cases). `AsrModelsError.modelNotFound`/`.downloadFailed` and
+/// `DownloadError.modelNotFound`/`.downloadFailed` collide by case NAME across enums
+/// (different payloads), so every case below is prefixed by its historical source —
+/// the `offline*`/`hf*` names are FROZEN identities predating the vendor unification.
 package enum FluidAudioModelLoadErrorKind: Sendable, Equatable {
   case modelsModelNotFound(String)
   case modelsDownloadFailed(String)
@@ -18,6 +21,8 @@ package enum FluidAudioModelLoadErrorKind: Sendable, Equatable {
   case hfDownloadFailed(String)
   case hfModelNotFound(String)
   case hfHtmlErrorResponse(String)
+  case downloadInvalidArtifact(String)
+  case downloadStalled(String)
   case unknownLoadFailure(String)
 }
 
@@ -32,22 +37,21 @@ package func classifyFluidAudioModelLoadError(_ error: any Error) -> FluidAudioM
     @unknown default: return .unknownLoadFailure(description)
     }
   }
-  if let e = error as? DownloadUtils.OfflineError {
+  if let e = error as? DownloadError {
+    // Deliberately NO `default`/`@unknown default`: the fork compiles non-resilient,
+    // so a future vendor case is a COMPILE error here, never a silent fallthrough
+    // (#1981 chunk 2 invariant).
     switch e {
     case .networkDisabled: return .offlineNetworkDisabled(description)
     case .modelMissing: return .offlineModelMissing(description)
-    @unknown default: return .unknownLoadFailure(description)
-    }
-  }
-  if let e = error as? DownloadUtils.HuggingFaceDownloadError {
-    switch e {
     case .invalidResponse: return .hfInvalidResponse(description)
     case .rateLimited: return .hfRateLimited(description)
     case .downloadFailed: return .hfDownloadFailed(description)
     case .modelNotFound: return .hfModelNotFound(description)
     case .htmlErrorResponse: return .hfHtmlErrorResponse(description)
-    @unknown default: return .unknownLoadFailure(description)
+    case .invalidArtifact: return .downloadInvalidArtifact(description)
+    case .stalled: return .downloadStalled(description)
     }
   }
-  return nil  // none of the 3 named vendor types — caller maps this to .unknownLoadFailure too
+  return nil  // neither named vendor type — caller maps this to .unknownLoadFailure too
 }

--- a/Sources/EnviousWisprModelDelivery/ModelIdentity.swift
+++ b/Sources/EnviousWisprModelDelivery/ModelIdentity.swift
@@ -14,9 +14,10 @@ public enum ModelFamily: String, Codable, Sendable, CaseIterable {
 /// `revision` is the BYTE pin (upstream commit SHA / our version tag);
 /// `runtimeABI` is the CODE pin (the runtime build the bytes were validated
 /// against). They move independently — #1339's existence proof: the FluidAudio
-/// code pin and the HF model revision advanced separately. A `runtimeABI`
-/// change with identical bytes never touches delivery (invariant 9); it
-/// signals the backend adapter, not this layer.
+/// code pin and HF model revision advance independently. `runtimeABI` is part
+/// of the manifest's canonical JSON, so changing it changes `manifestDigest`.
+/// Existing bytes are revalidated once and re-admitted without re-download;
+/// the delivery layer still never loads or compiles the runtime (invariant 9).
 public struct ModelIdentity: Hashable, Codable, Sendable {
   public let family: ModelFamily
   public let name: String

--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -257,7 +257,7 @@ The full text of the Apache License, Version 2.0 follows.
 
 --------------------------------------------------------------------------------
 FluidAudio
-  Version: afb9aab1 (fork saurabhav88/FluidAudio)
+  Version: a1767d86 (fork saurabhav88/FluidAudio)
   License: Apache-2.0
   Source:  https://github.com/saurabhav88/FluidAudio
 --------------------------------------------------------------------------------

--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -1366,6 +1366,63 @@ limitations under the License.
 
 
 --------------------------------------------------------------------------------
+NemoTextProcessing / text-processing-rs (bundled in FluidAudio)
+  Version: v0.3.0
+  License: Apache-2.0 (aggregating Apache-2.0/MIT components)
+  Source:  https://github.com/FluidInference/text-processing-rs
+--------------------------------------------------------------------------------
+
+# NemoTextProcessing (text-processing-rs)
+
+The `NemoTextProcessing` binary target is the prebuilt xcframework of
+[`text-processing-rs`](https://github.com/FluidInference/text-processing-rs)
+(v0.3.0), used by `NemoTextNormalizer` for byte-exact NeMo text normalization.
+
+- **Source:** https://github.com/FluidInference/text-processing-rs
+- **License:** Apache License, Version 2.0
+
+Built with the `fst-engine` feature, the xcframework includes and statically
+links the following third-party works. All are permissive (Apache-2.0 / MIT)
+and compatible.
+
+## NVIDIA NeMo Text Processing
+
+The compiled weighted-FST grammars and text-normalization fixtures are derived
+from / copied from NVIDIA NeMo Text Processing (pinned commit
+`1f1263579fe57ba7ed783cad3dddee710fcc5064`).
+
+- **Source:** https://github.com/NVIDIA/NeMo-text-processing
+- **License:** Apache License, Version 2.0
+- **Copyright:** Copyright (c) NVIDIA CORPORATION & AFFILIATES.
+
+## rustfst
+
+Loads and executes the compiled OpenFST grammars.
+
+- **Source:** https://github.com/Garvys/rustfst
+- **License:** MIT OR Apache-2.0
+- **Copyright:** Copyright (c) Alexandre Caulier and the rustfst contributors.
+
+## flate2
+
+Decompresses the bundled gzipped grammars at load time.
+
+- **Source:** https://github.com/rust-lang/flate2-rs
+- **License:** MIT OR Apache-2.0
+- **Copyright:** Copyright (c) Alex Crichton and the flate2 contributors.
+
+## Other Rust dependencies
+
+The xcframework transitively links additional permissive-licensed Rust crates
+(MIT and/or Apache-2.0) via `rustfst` and `flate2` — e.g. `nom`,
+`miniz_oxide`, `bitflags`, `anyhow`. See the crate's `THIRD-PARTY-LICENSES.md`
+for detail.
+
+Full texts: Apache-2.0 <https://www.apache.org/licenses/LICENSE-2.0>,
+MIT <https://opensource.org/license/mit>.
+
+
+--------------------------------------------------------------------------------
 PLCrashReporter + protobuf-c (bundled in PostHog)
   Version: n/a
   License: MIT / Apache-2.0 / BSD-2-Clause

--- a/Tests/EnviousWisprASRTests/FluidAudioBridgeClassificationTests.swift
+++ b/Tests/EnviousWisprASRTests/FluidAudioBridgeClassificationTests.swift
@@ -5,13 +5,12 @@ import Testing
 
 @testable import EnviousWisprFluidAudioBridge
 
-/// #1525 PR I-B — classification-completeness tests for the bridge that isolates
-/// FluidAudio's raw error taxonomies (`ASRError`, `AsrModelsError`,
-/// `DownloadUtils.OfflineError`, `DownloadUtils.HuggingFaceDownloadError`) behind
-/// name-collision-free values. Lives in this CONSUMING test target, not inside the
-/// bridge target itself (Codex r9). Both types' `@unknown default`/catch-all
-/// branches are code-inspection-only guarantees — no real FluidAudio SDK value
-/// can exercise them with the currently pinned fork version.
+/// #1525 PR I-B (types updated #1981) — classification-completeness tests for the
+/// bridge that isolates FluidAudio's raw error taxonomies (`ASRError`,
+/// `AsrModelsError`, and the unified `DownloadError`) behind name-collision-free
+/// values. Lives in this CONSUMING test target, not inside the bridge target itself
+/// (Codex r9). The `DownloadError` switch is deliberately exhaustive with no
+/// default branch, so vendor growth is a compile error, never a silent miss.
 @Suite("FluidAudio error classification (#1525 PR I-B)")
 struct FluidAudioBridgeClassificationTests {
 
@@ -60,7 +59,7 @@ struct FluidAudioBridgeClassificationTests {
     #expect(classifyFluidAudioASRError(OtherError()) == nil)
   }
 
-  // MARK: - FluidAudioModelLoadErrorKind (model-load path, 11 real cases across 3 enums)
+  // MARK: - FluidAudioModelLoadErrorKind (model-load path, 13 real cases across 2 enums)
 
   @Test("classifyFluidAudioModelLoadError maps every real AsrModelsError case")
   func classifiesAllAsrModelsErrorCases() {
@@ -88,69 +87,60 @@ struct FluidAudioBridgeClassificationTests {
     }
   }
 
-  @Test("classifyFluidAudioModelLoadError maps every real DownloadUtils.OfflineError case")
-  func classifiesAllOfflineErrorCases() {
-    let cases: [(DownloadUtils.OfflineError, FluidAudioModelLoadErrorKind)] = [
+  @Test("classifyFluidAudioModelLoadError maps every real unified DownloadError case (all 9)")
+  func classifiesAllDownloadErrorCases() {
+    let cases: [(DownloadError, FluidAudioModelLoadErrorKind)] = [
       (
-        .networkDisabled(operation: "downloadRepo(x)"),
+        .networkDisabled(operation: "loadModels(x)"),
         .offlineNetworkDisabled(
-          DownloadUtils.OfflineError.networkDisabled(operation: "downloadRepo(x)")
-            .localizedDescription)
+          DownloadError.networkDisabled(operation: "loadModels(x)").localizedDescription)
       ),
       (
         .modelMissing(repo: "r", missing: ["a.mlmodel"]),
         .offlineModelMissing(
-          DownloadUtils.OfflineError.modelMissing(repo: "r", missing: ["a.mlmodel"])
-            .localizedDescription)
+          DownloadError.modelMissing(repo: "r", missing: ["a.mlmodel"]).localizedDescription)
       ),
-    ]
-    for (vendorError, expected) in cases {
-      #expect(classifyFluidAudioModelLoadError(vendorError) == expected)
-    }
-  }
-
-  @Test(
-    "classifyFluidAudioModelLoadError maps every real DownloadUtils.HuggingFaceDownloadError case"
-  )
-  func classifiesAllHuggingFaceDownloadErrorCases() {
-    let cases: [(DownloadUtils.HuggingFaceDownloadError, FluidAudioModelLoadErrorKind)] = [
       (
         .invalidResponse,
-        .hfInvalidResponse(
-          DownloadUtils.HuggingFaceDownloadError.invalidResponse.localizedDescription)
+        .hfInvalidResponse(DownloadError.invalidResponse.localizedDescription)
       ),
       (
         .rateLimited(statusCode: 429, message: "slow down"),
         .hfRateLimited(
-          DownloadUtils.HuggingFaceDownloadError.rateLimited(
-            statusCode: 429, message: "slow down"
-          ).localizedDescription)
+          DownloadError.rateLimited(statusCode: 429, message: "slow down").localizedDescription)
       ),
       (
         .downloadFailed(path: "p", underlying: NSError(domain: "fixture", code: 3)),
         .hfDownloadFailed(
-          DownloadUtils.HuggingFaceDownloadError.downloadFailed(
-            path: "p", underlying: NSError(domain: "fixture", code: 3)
-          ).localizedDescription)
+          DownloadError.downloadFailed(path: "p", underlying: NSError(domain: "fixture", code: 3))
+            .localizedDescription)
       ),
       (
         .modelNotFound(path: "p"),
-        .hfModelNotFound(
-          DownloadUtils.HuggingFaceDownloadError.modelNotFound(path: "p").localizedDescription)
+        .hfModelNotFound(DownloadError.modelNotFound(path: "p").localizedDescription)
       ),
       (
         .htmlErrorResponse(path: "p", snippet: "<html>"),
         .hfHtmlErrorResponse(
-          DownloadUtils.HuggingFaceDownloadError.htmlErrorResponse(path: "p", snippet: "<html>")
-            .localizedDescription)
+          DownloadError.htmlErrorResponse(path: "p", snippet: "<html>").localizedDescription)
+      ),
+      (
+        .invalidArtifact(path: "p", reason: "truncated"),
+        .downloadInvalidArtifact(
+          DownloadError.invalidArtifact(path: "p", reason: "truncated").localizedDescription)
+      ),
+      (
+        .stalled(path: "p", window: 60),
+        .downloadStalled(DownloadError.stalled(path: "p", window: 60).localizedDescription)
       ),
     ]
+    #expect(cases.count == 9, "the unified DownloadError has exactly 9 cases")
     for (vendorError, expected) in cases {
       #expect(classifyFluidAudioModelLoadError(vendorError) == expected)
     }
   }
 
-  @Test("classifyFluidAudioModelLoadError returns nil for none of the 3 named vendor types")
+  @Test("classifyFluidAudioModelLoadError returns nil for neither named vendor type")
   func returnsNilForNonVendorModelLoadError() {
     struct OtherError: Error {}
     #expect(classifyFluidAudioModelLoadError(OtherError()) == nil)

--- a/Tests/EnviousWisprASRTests/ParakeetDeliveryModeTests.swift
+++ b/Tests/EnviousWisprASRTests/ParakeetDeliveryModeTests.swift
@@ -1,3 +1,4 @@
+import EnviousWisprCore
 import FluidAudio
 import Foundation
 import Testing
@@ -8,19 +9,81 @@ import Testing
 /// helper recycle (grounded r2 blocker 1 / r3-precise test scope).
 @MainActor
 @Suite struct ParakeetDeliveryModeTests {
-  /// Cache-only arms FluidAudio's own offline switch; the legacy mode resets
-  /// it explicitly — flipping the delivery flag works without a service
-  /// restart (declared invariant, plan §3).
+  /// Cache-only arms FluidAudio's own offline switch (`ModelHub.offlineMode`
+  /// since #1981); the legacy mode resets it explicitly — flipping the
+  /// delivery flag works without a service restart (declared invariant, plan §3).
   @Test func offlineModeFollowsCacheOnlyDeterministically() {
-    let original = DownloadUtils.enforceOffline
-    defer { DownloadUtils.enforceOffline = original }
+    let original = ModelHub.offlineMode
+    defer { ModelHub.offlineMode = original }
 
     ParakeetBackend.configureOfflineMode(cacheOnly: true)
-    #expect(DownloadUtils.enforceOffline)
+    #expect(ModelHub.offlineMode)
 
     // Legacy-after-cache-only: the reset is explicit, not leftover state.
     ParakeetBackend.configureOfflineMode(cacheOnly: false)
-    #expect(!DownloadUtils.enforceOffline)
+    #expect(!ModelHub.offlineMode)
+  }
+
+  /// #1981 chunk 2: the vendor-progress → app-callback mapping, exercised
+  /// through the PRODUCTION-owned `makeLoadProgressHandler` (extracted from
+  /// `prepare` unchanged — one owner), across the four real emission shapes
+  /// FluidAudio's ProgressReporter produces for a repo load. No model bytes
+  /// or network involved: the handler is pure mapping.
+  @Test func progressMappingCoversAllVendorPhases() {
+    // The callback is @Sendable; collect on a lock-protected box confined to this test.
+    final class Box: @unchecked Sendable {
+      private var storage: [(Double, String, String)] = []
+      private let lock = NSLock()
+      func append(_ emission: (Double, String, String)) {
+        lock.lock()
+        storage.append(emission)
+        lock.unlock()
+      }
+      func snapshot() -> [(Double, String, String)] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+      }
+    }
+    let box = Box()
+    let handler = ParakeetBackend.makeLoadProgressHandler { fraction, phase, detail in
+      box.append((fraction, phase, detail))
+    }
+    guard let handler else {
+      Issue.record("non-nil callback must produce a non-nil handler")
+      return
+    }
+    // nil callback maps to nil handler (skip the closure allocation entirely).
+    #expect(ParakeetBackend.makeLoadProgressHandler(nil) == nil)
+
+    // The four real ProgressReporter shapes for a repo load (downloadPhaseWeight 0.5):
+    handler(DownloadProgress(fractionCompleted: 0.0, phase: .listing))
+    // cachedModelsAvailable(): download phase complete without network.
+    handler(
+      DownloadProgress(
+        fractionCompleted: 0.5, phase: .downloading(completedFiles: 0, totalFiles: 0)))
+    handler(DownloadProgress(fractionCompleted: 0.75, phase: .compiling(modelName: "Encoder")))
+    // finished(): fraction 1.0 with an empty compiling name.
+    handler(DownloadProgress(fractionCompleted: 1.0, phase: .compiling(modelName: "")))
+
+    let emissions = box.snapshot()
+    #expect(emissions.count == 4)
+    // 1) listing -> stall-policy listing token, empty detail.
+    #expect(emissions[0].0 == 0.0)
+    #expect(emissions[0].1 == ModelLoadStallPolicy.listingPhase)
+    #expect(emissions[0].2 == "")
+    // 2) downloading at 0.5 -> x2 fraction math against the 483 MB total.
+    #expect(emissions[1].0 == 0.5)
+    #expect(emissions[1].1 == "Downloading model files...")
+    #expect(emissions[1].2 == "483 MB of 483 MB (100%)")
+    // 3) compiling -> stall-policy install token with the model name.
+    #expect(emissions[2].0 == 0.75)
+    #expect(emissions[2].1 == ModelLoadStallPolicy.installPhase)
+    #expect(emissions[2].2 == "Encoder")
+    // 4) finished -> install token, empty detail, fraction passed through.
+    #expect(emissions[3].0 == 1.0)
+    #expect(emissions[3].1 == ModelLoadStallPolicy.installPhase)
+    #expect(emissions[3].2 == "")
   }
 
   /// The recycle path: a proxy-level error drops the connection and marks

--- a/Tests/EnviousWisprTests/ASR/ParakeetModelLoadSentryErrorTests.swift
+++ b/Tests/EnviousWisprTests/ASR/ParakeetModelLoadSentryErrorTests.swift
@@ -62,6 +62,14 @@ struct ParakeetModelLoadSentryErrorTests {
       "parakeet_load.hf_html_error_response"
     ),
     (
+      .downloadInvalidArtifact("x"), "FluidAudio.DownloadError.invalidArtifact",
+      "parakeet_load.download_invalid_artifact"
+    ),
+    (
+      .downloadStalled("x"), "FluidAudio.DownloadError.stalled",
+      "parakeet_load.download_stalled"
+    ),
+    (
       .unknownLoadFailure("x"), "EnviousWisprASR.ParakeetModelLoadSentryError.unknownLoadFailure",
       "parakeet_load.unknown_load_failure"
     ),
@@ -77,11 +85,16 @@ struct ParakeetModelLoadSentryErrorTests {
     }
   }
 
-  @Test("all 12 declared identities are unique")
+  @Test("all 14 declared identities are unique")
   func identitiesAreUnique() {
     let errors = Self.pins.map(\.0)
-    #expect(Set(errors.map(\.sentryFingerprintDescriptor)).count == 12)
-    #expect(Set(errors.map(\.sentrySemanticID)).count == 12)
+    #expect(Self.pins.count == 14, "every enum case must appear in the pin fixture")
+    #expect(Set(errors.map(\.sentryFingerprintDescriptor)).count == 14)
+    #expect(Set(errors.map(\.sentrySemanticID)).count == 14)
+    // #1981: appended codes only — the numeric contract 0-11 is frozen and the
+    // two new cases take exactly 12 and 13.
+    #expect(ParakeetModelLoadSentryError.downloadInvalidArtifact("x").errorCode == 12)
+    #expect(ParakeetModelLoadSentryError.downloadStalled("x").errorCode == 13)
   }
 
   // MARK: - B. Mapping completeness — built from FluidAudioModelLoadErrorKind
@@ -102,6 +115,8 @@ struct ParakeetModelLoadSentryErrorTests {
       (.hfDownloadFailed("i"), .hfDownloadFailed("i")),
       (.hfModelNotFound("j"), .hfModelNotFound("j")),
       (.hfHtmlErrorResponse("k"), .hfHtmlErrorResponse("k")),
+      (.downloadInvalidArtifact("m"), .downloadInvalidArtifact("m")),
+      (.downloadStalled("n"), .downloadStalled("n")),
       (.unknownLoadFailure("l"), .unknownLoadFailure("l")),
     ]
     for (kind, expected) in cases {
@@ -112,11 +127,11 @@ struct ParakeetModelLoadSentryErrorTests {
   // MARK: - C. Mapping completeness — the real production normalizer
 
   @Test(
-    "init(normalizingLoadError:) recognizes a real FluidAudio model-load vendor error"
+    "init(normalizingLoadError:) maps a genuinely non-vendor error to .unknownLoadFailure"
   )
-  func normalizingLoadErrorRecognizesVendorError() {
-    // classifyFluidAudioModelLoadError only recognizes AsrModelsError/OfflineError/
-    // HuggingFaceDownloadError — a genuinely non-vendor error normalizes to
+  func normalizingLoadErrorMapsNonVendorErrorToUnknown() {
+    // classifyFluidAudioModelLoadError recognizes AsrModelsError and the unified
+    // DownloadError; a genuinely non-vendor error normalizes to
     // .unknownLoadFailure, tested below.
     struct SyntheticNonVendorError: Error, LocalizedError {
       var errorDescription: String? { "a synthetic CoreML-shaped model-load failure" }
@@ -151,15 +166,20 @@ struct ParakeetModelLoadSentryErrorTests {
   /// process cast but NOT an actual XPC-style archive round-trip (confirmed via a
   /// direct `NSKeyedArchiver`/`NSKeyedUnarchiver` probe this session). Only
   /// `errorUserInfo` populating `NSLocalizedDescriptionKey` survives that.
-  @Test("localizedDescription survives an actual NSSecureCoding archive round-trip")
-  func localizedDescriptionSurvivesArchiveRoundTrip() throws {
-    let error = ParakeetModelLoadSentryError.hfRateLimited("a real vendor description")
-    let bridged = error as NSError
-    let data = try NSKeyedArchiver.archivedData(
-      withRootObject: bridged, requiringSecureCoding: true)
-    let decoded = try #require(
-      try NSKeyedUnarchiver.unarchivedObject(ofClass: NSError.self, from: data))
-    #expect(decoded.localizedDescription == "a real vendor description")
+  @Test("every case survives an actual NSSecureCoding archive round-trip")
+  func everyCaseSurvivesArchiveRoundTrip() throws {
+    for (error, _, _) in Self.pins {
+      let bridged = error as NSError
+      let data = try NSKeyedArchiver.archivedData(
+        withRootObject: bridged, requiringSecureCoding: true)
+      let decoded = try #require(
+        try NSKeyedUnarchiver.unarchivedObject(ofClass: NSError.self, from: data))
+
+      #expect(decoded.domain == ParakeetModelLoadSentryError.errorDomain)
+      #expect(decoded.code == error.errorCode)
+      #expect(decoded.localizedDescription == error.errorDescription)
+      #expect(ParakeetModelLoadSentryError(reconstructingFrom: decoded) == error)
+    }
   }
 
   // MARK: - E. Event-construction contract

--- a/Tests/EnviousWisprTests/ModelDelivery/DeliveryManifestTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/DeliveryManifestTests.swift
@@ -251,7 +251,12 @@ enum ManifestFixture {
   // carrying the finalization fix. `runtimeABI` participates in the canonical
   // JSON, so the digest moves with it — cloud review caught the stale value,
   // which would have made `loadBundled` reject the manifest on every launch.
-  static let goldenDigest = "db47ee6d8eb3bff63a46619ef626bd28618b165e1a48d56ae799871cd31f9232"
+  // Updated 2026-08-07 (#1981): `runtimeABI` advanced to fork pin a1767d86
+  // (upstream catch-up). Identical model bytes; the digest change deliberately
+  // invalidates the prior Parakeet admission marker, causing one full verification
+  // pass and re-admission with no re-download (CacheAdmission.isAdmitted
+  // digest equality; ModelIdentity invariant 9 keeps delivery runtime-agnostic).
+  static let goldenDigest = "2fe5bab08d88b3d0f32c3ab0bce126855c600f3a0cab382953d7a25b56249657"
 
   @Test func shippedManifestLoadsAndMatchesGoldenDigest() throws {
     let data = try Data(contentsOf: Self.shippedManifestURL)

--- a/scripts/ci/gen-third-party-notices.sh
+++ b/scripts/ci/gen-third-party-notices.sh
@@ -37,7 +37,7 @@ COMPONENTS=(
   # text too, not just Argmax's MIT LICENSE (Codex audit 2026-07-10). Empty
   # identity — it is vendored inside argmax-oss-swift, not its own SwiftPM pin.
   "swift-transformers (incorporated into Argmax OSS)|n/a|Apache-2.0|argmax-oss-swift/NOTICES|https://github.com/huggingface/swift-transformers|"
-  "FluidAudio|afb9aab1 (fork saurabhav88/FluidAudio)|Apache-2.0|FluidAudio/LICENSE|https://github.com/saurabhav88/FluidAudio|fluidaudio"
+  "FluidAudio|a1767d86 (fork saurabhav88/FluidAudio)|Apache-2.0|FluidAudio/LICENSE|https://github.com/saurabhav88/FluidAudio|fluidaudio"
   "PostHog iOS|3.68.2|MIT|posthog-ios/LICENSE|https://github.com/PostHog/posthog-ios|posthog-ios"
   "Sentry Cocoa|9.23.0|MIT|sentry-cocoa/LICENSE.md|https://github.com/getsentry/sentry-cocoa|sentry-cocoa"
   "Sparkle|2.9.4|MIT (with bundled BSD/MIT components)|Sparkle/LICENSE|https://github.com/sparkle-project/Sparkle|sparkle"

--- a/scripts/ci/gen-third-party-notices.sh
+++ b/scripts/ci/gen-third-party-notices.sh
@@ -50,6 +50,12 @@ COMPONENTS=(
   "swift-syntax|603.0.2|Apache-2.0|swift-syntax/LICENSE.txt|https://github.com/swiftlang/swift-syntax|swift-syntax"
   "fastcluster (bundled in FluidAudio)|n/a|BSD-2-Clause|FluidAudio/ThirdPartyLicenses/fastcluster-LICENSE.md|https://github.com/dmuellner/fastcluster|"
   "VBx (bundled in FluidAudio)|n/a|Apache-2.0|FluidAudio/ThirdPartyLicenses/vbx-LICENSE.md|https://github.com/BUTSpeechFIT/VBx|"
+  # #1981: at fork pin a1767d86, FluidAudio's target statically links the
+  # prebuilt NemoTextProcessing xcframework (text-processing-rs v0.3.0). Its
+  # aggregate license file carries the NVIDIA NeMo Text Processing, rustfst,
+  # and Rust-crate attributions the binary embeds. Empty identity — a binary
+  # target inside FluidAudio, not its own SwiftPM pin.
+  "NemoTextProcessing / text-processing-rs (bundled in FluidAudio)|v0.3.0|Apache-2.0 (aggregating Apache-2.0/MIT components)|FluidAudio/ThirdPartyLicenses/NemoTextProcessing-LICENSE.md|https://github.com/FluidInference/text-processing-rs|"
   "PLCrashReporter + protobuf-c (bundled in PostHog)|n/a|MIT / Apache-2.0 / BSD-2-Clause|posthog-ios/vendor/PHPLCrashReporter/LICENSE|https://github.com/microsoft/plcrashreporter|"
   "libwebp (bundled in PostHog)|n/a|BSD-3-Clause|posthog-ios/vendor/libwebp/COPYING|https://chromium.googlesource.com/webm/libwebp|"
   # llama.cpp is NOT a SwiftPM dep — the bundled llama-server binary is built

--- a/scripts/eval/build_parakeet_corpus.py
+++ b/scripts/eval/build_parakeet_corpus.py
@@ -8,9 +8,9 @@ score we hold was therefore measured on an input form the shipped ASR does not
 produce. This rebuilds the inputs through the ASR we actually ship.
 
 Engine fidelity: drives `fluidaudiocli tts-asr-verify` from the PINNED FluidAudio
-checkout (`.build/checkouts/FluidAudio`, revision afb9aab1 per Package.resolved),
-NOT `~/Developer/EnviousLabs/FluidAudio*`, whose HEADs are different commits and
-would measure a different engine.
+checkout (`.build/checkouts/FluidAudio`, revision a1767d86 per Package.resolved),
+NOT `~/Developer/EnviousLabs/FluidAudio*` — a local checkout's HEAD floats, so
+it can silently measure a different engine; the pinned checkout cannot.
 
 Two hard limitations, both stated in the report rather than hidden:
 
@@ -44,7 +44,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 CLI = ROOT / ".build/checkouts/FluidAudio/.build/arm64-apple-macosx/release/fluidaudiocli"
-PIN = "afb9aab1efdad979bca22ca887a936ff2c1cd8ea"
+PIN = "a1767d862dd1ba221593af4b92c81d004c2cc86b"
 
 
 def check_engine() -> None:

--- a/scripts/eval/parakeet_runner/Package.swift
+++ b/scripts/eval/parakeet_runner/Package.swift
@@ -5,17 +5,18 @@ import PackageDescription
 // audio files. `fluidaudiocli transcribe` takes a single file per invocation
 // and reloads the model each time, which is unusable for 1,890 cases.
 //
-// Depends on the SAME git URL + revision the app pins in the root Package.swift
-// (saurabhav88/FluidAudio @ afb9aab1) rather than a local path, so this provably
-// runs the engine we ship. Do not repoint at ~/Developer/EnviousLabs/FluidAudio*
-// — both of those checkouts are at different commits.
+// Depends on the SAME git URL + exact immutable revision the app pins in the
+// root Package.swift (saurabhav88/FluidAudio @ a1767d86) rather than a local
+// path, so this provably runs the same pinned engine the app resolves. Do not
+// repoint at a local checkout — a path dependency floats with whatever that
+// checkout happens to hold, while this remote revision cannot drift.
 let package = Package(
   name: "ParakeetRunner",
   platforms: [.macOS(.v14)],
   dependencies: [
     .package(
       url: "https://github.com/saurabhav88/FluidAudio.git",
-      revision: "afb9aab1efdad979bca22ca887a936ff2c1cd8ea")
+      revision: "a1767d862dd1ba221593af4b92c81d004c2cc86b")
   ],
   targets: [
     .executableTarget(name: "ParakeetRunner", dependencies: ["FluidAudio"])

--- a/scripts/eval/parakeet_runner/Sources/ParakeetRunner/main.swift
+++ b/scripts/eval/parakeet_runner/Sources/ParakeetRunner/main.swift
@@ -4,15 +4,18 @@ import Foundation
 
 /// Batch Parakeet transcription for eval corpora.
 ///
-/// Mirrors `ParakeetBackend.swift` EXACTLY so the text this emits is the text
-/// the shipped app would produce for the same audio:
-///   - `AsrModels.loadFromCache(version: .v3)` (falls back to downloadAndLoad)
+/// Matches the shipped one-shot decode mechanics after model setup, so the
+/// text this emits is the text the app would produce for the same audio:
+///   - a cache-only model load with FluidAudio's network switch armed off —
+///     the app's ModelDelivery path OWNS model setup and admission; this
+///     benchmark only consumes the cache it populated, and must never mutate
+///     the model bytes it measures (#1981)
 ///   - `AsrManager(config: .default)` + `loadModels(_:)`
 ///   - a FRESH `TdtDecoderState` per file, sized by `manager.decoderLayerCount`
 ///     (the app makes one per one-shot batch decode; reusing state across files
 ///     would leak decoder context between unrelated utterances)
 ///   - `manager.transcribe(samples, decoderState: &state)`
-///   - no language hint (parity with the shipped d5fcca4 behaviour)
+///   - no language hint (parity with the shipped behaviour)
 ///
 /// Input:  a JSONL manifest, one {"id": "...", "wav": "/abs/path.wav"} per line.
 /// Output: JSONL, one {"id","text","ms"} or {"id","error"} per line.
@@ -59,12 +62,14 @@ func samples(at path: String) throws -> [Float] {
 let start = Date()
 FileHandle.standardError.write(Data("loading Parakeet v3...\n".utf8))
 
+// Cache-only: the app owns model setup; a benchmark must never mutate the
+// model bytes it measures.
+ModelHub.offlineMode = true
 let models: AsrModels
 do {
   models = try await AsrModels.loadFromCache(version: .v3)
 } catch {
-  FileHandle.standardError.write(Data("cache miss (\(error)); downloading...\n".utf8))
-  models = try await AsrModels.downloadAndLoad(version: .v3)
+  fail("Open EnviousWispr and complete Parakeet model setup once, then rerun.")
 }
 let manager = AsrManager(config: .default)
 try await manager.loadModels(models)


### PR DESCRIPTION
Closes #1981

Catches the pinned FluidAudio fork up to upstream `FluidInference/FluidAudio` main `00a9aa7` (74 commits, incl. the chunk-seam content-drop fixes and upstream's own end-aligned-final-window fix for the empty-window family we reported as FluidInference#746). New pin: `a1767d862dd1ba221593af4b92c81d004c2cc86b` = upstream + 4 fork commits (3 carry picks + one docs/test extraction). Our 251-line #1237 empty-chunk recovery patch is **dropped as superseded** — proven on the archived repro, below.

Plan: `docs/feature-requests/issue-1981-2026-08-07-fluidaudio-catchup.md` (rev 7, PROCEED-AS-PLANNED after consult + coverage + 4 grounded rounds). Built via chunked orchestration (8 chunks, each CHUNK-CLEAN). Validation run dir: `.validation/runs/2026-08-08T12-50-14Z-540fcd3f`.

**Lane:** Code, `mixed_pr: true` (Eval-harness: `scripts/eval/parakeet_runner/**`, `scripts/eval/build_parakeet_corpus.py`; CI-adjacent tooling: `scripts/ci/gen-third-party-notices.sh` + both notices copies).

### What changed (18 tracked files)
- Pin bump + mechanical `DownloadUtils`→`ModelHub` migration (offline switch, progress-handler type, unified `DownloadError` with exhaustive 9-case switch and no default branch; two new error kinds appended as XPC/Sentry codes 12–13; the seven historical fingerprint literals byte-frozen).
- Delivery manifest `runtimeABI` → `fluidAudio-a1767d86`; `manifestDigest` recomputed via the canonical authoring validator (Python and shipped Swift canonicalization agree); golden-digest test updated. Existing installs revalidate the 483MB cache ONCE (local hash pass, no re-download) — designed path, #1792 precedent.
- Notices regenerated (16 components) — including the **NemoTextProcessing / text-processing-rs binary FluidAudio now bundles** (NVIDIA NeMo + rustfst attributions), caught by whole-diff review.
- `parakeet_runner` is now cache-only (`ModelHub.offlineMode = true`, download fallback removed): a benchmark must never mutate the model bytes it measures.
- VAD authority comment re-grounded; bundled Silero v6.0.0 and injection path untouched.

### Final-tip evidence (§11.3)
- Fork: full suite at the pin — **2,199 XCTest + 54 Swift Testing, 0 failures, exit 0**; remote tip == tested tip (`git ls-remote` equality). Receipt: `docs/audits/2026-08-07-1981-fork-suite-receipt.txt` (session-side).
- German stress (120 cases, both exact-SHA arms rebuilt + run adjacently, revision-bound result files): comparator **PASS** — all five category median WER deltas **0.0%**, 0 new script leaks, 0 new empty outputs, **0 worsened of 120**.
- Protected #1237 tail-clip repro: new engine keeps the full closing clause without our patch, cleaner output than the patch produced.
- 20 real-dictation no-op corpus: 16/23 byte-identical; 7 punctuation/casing-level diffs; **zero content loss**; one word substitution (`site`→`side`) adjudicated (bounded single-word miss, not the content-loss stop).
- App suite post-rebase: **5,135 tests, TEST SUCCEEDED**. All four standalone eval packages compile in Release with the root lockfile.
- Live UAT on the rebuilt dev app: short + long-with-trailing-clause dictations PASS (ASR 0.260s — sub-second transcription holds on the new engine); engine-toggle item skipped with justification (`skip-note.txt`: switch machinery byte-untouched + suite-covered; AX surface flaky).

### Adjudications
- Whole-diff review P1 (missing NeMo notices): **fixed** (`540fcd3f`).
- Whole-diff review P2 (+18MB from FluidAudio's unconditionally-linked, unused TTS payload; 158→176MB): **founder-adjudicated 2026-08-08 — accepted permanently, no slimming follow-up.**
- Coverage F5: no `--allow-download` escape in the benchmark runner (rejected as a second delivery path).
- WhatsNew v2.2.1 entry unchanged: the user promise ("closing words always land") is preserved by the new engine, proven by the protected repro gate.
