### PR TITLE
fix(pipeline): proactively prime a target app's accessibility tree on app-switch

### DIFF
--- a/Sources/EnviousWisprAppKit/App/AccessibilityWarmupObserver.swift
+++ b/Sources/EnviousWisprAppKit/App/AccessibilityWarmupObserver.swift
@@ -1,0 +1,139 @@
+import AppKit
+import EnviousWisprCore
+import EnviousWisprServices
+import Foundation
+
+/// Proactively nudges a newly-frontmost app's own on-demand accessibility
+/// activation (Chrome/Chromium apps only turn this on the first time
+/// something asks) to start as early as possible, instead of only when a
+/// dictation's own caret capture asks at record-start or commit time (#1980).
+/// The result of the priming query is always discarded — this exists purely
+/// to trigger the target app's own activation earlier, never to read it.
+///
+/// #1986, live-diagnosed 2026-08-08: a cold Chrome silently degraded smart
+/// insertion (trailing space / seam casing) to a plain paste for minutes on
+/// the founder's own machine.
+@MainActor
+final class AccessibilityWarmupObserver {
+  private var token: NSObjectProtocol?
+  private var primedAtByPID: [pid_t: TimeInterval] = [:]
+  private let currentTime: @MainActor () -> TimeInterval
+  private let currentApplication: @MainActor () -> NSRunningApplication?
+  private let cooldown: TimeInterval
+
+  init(
+    currentTime: @escaping @MainActor () -> TimeInterval = {
+      ProcessInfo.processInfo.systemUptime
+    },
+    currentApplication: @escaping @MainActor () -> NSRunningApplication? = {
+      NSWorkspace.shared.frontmostApplication
+    },
+    cooldown: TimeInterval = 10.0
+  ) {
+    self.currentTime = currentTime
+    self.currentApplication = currentApplication
+    self.cooldown = cooldown
+  }
+
+  /// Begin observing app activation. Idempotent.
+  func start() {
+    guard token == nil else { return }
+
+    token = NSWorkspace.shared.notificationCenter.addObserver(
+      forName: NSWorkspace.didActivateApplicationNotification,
+      object: nil,
+      queue: .main
+    ) { [weak self] note in
+      // Extract the notification's payload BEFORE entering
+      // `MainActor.assumeIsolated`: reading `note`'s properties from inside
+      // that block trips "sending 'note' risks causing data races" under
+      // Swift 6 strict concurrency, because `note` is captured by the
+      // closure the compiler treats as task-isolated. Only the extracted
+      // value crosses into the MainActor-asserted block.
+      let app = note.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication
+      MainActor.assumeIsolated {
+        guard let self, let app else { return }
+        self.handleActivation(of: app)
+      }
+    }
+
+    // The app already frontmost when EnviousWispr launches (the common case
+    // after every rebuild/relaunch) will not itself emit a NEW activation
+    // notification — prime it explicitly once on start.
+    if let app = currentApplication() {
+      handleActivation(of: app)
+    }
+  }
+
+  /// Tear down. Idempotent.
+  func stop() {
+    if let token {
+      NSWorkspace.shared.notificationCenter.removeObserver(token)
+    }
+    token = nil
+    primedAtByPID.removeAll()
+  }
+
+  private func handleActivation(of app: NSRunningApplication) {
+    let pid = app.processIdentifier
+    let now = currentTime()
+
+    guard
+      Self.registerPrimeIfAllowed(
+        activatedPID: pid,
+        ownPID: ProcessInfo.processInfo.processIdentifier,
+        isRegularActivationPolicy: app.activationPolicy == .regular,
+        primedAtByPID: &primedAtByPID,
+        now: now, cooldown: cooldown
+      )
+    else { return }
+
+    Task(priority: .utility) { await Self.primeAccessibility(pid: pid) }
+  }
+
+  /// Deterministic, unit-testable against a plain `[pid_t: TimeInterval]` (no
+  /// NSWorkspace/Date needed). Mutates `primedAtByPID` in place — prunes
+  /// expired entries so a long-running session's dictionary stays bounded by
+  /// "apps activated within the last `cooldown` seconds," then decides and
+  /// records the new entry atomically, so a test exercises the SAME
+  /// dictionary state production does rather than a hand-supplied timestamp.
+  /// Per-PID cooldown (not "most recently primed pid") so `A → B → A` inside
+  /// the cooldown window still refuses to re-prime A.
+  nonisolated static func registerPrimeIfAllowed(
+    activatedPID: pid_t, ownPID: pid_t, isRegularActivationPolicy: Bool,
+    primedAtByPID: inout [pid_t: TimeInterval], now: TimeInterval, cooldown: TimeInterval
+  ) -> Bool {
+    primedAtByPID = primedAtByPID.filter { now - $0.value < cooldown }
+
+    guard isRegularActivationPolicy, activatedPID > 0, activatedPID != ownPID else { return false }
+    if let lastPrimedAt = primedAtByPID[activatedPID], now - lastPrimedAt < cooldown {
+      return false
+    }
+
+    primedAtByPID[activatedPID] = now
+    return true
+  }
+
+  // `@concurrent` is load-bearing, not decoration, matching the established
+  // precedent at `KernelDictationDriverFactory.swift:365`
+  // (`Task { await SeamCasingOracleRuntime.prewarm() }`, prewarm itself
+  // `@concurrent` at `SeamCasingOracleRuntime.swift:137`) rather than
+  // `Task.detached`: entering the `@concurrent` function switches the
+  // synchronous AX call to the generic executor even though the enclosing
+  // `Task` inherits MainActor at creation (SE-0461). Result intentionally
+  // discarded. Reuses the shared AX round-trip bound
+  // (`PasteService.axMessagingTimeoutSeconds`) rather than a second magic
+  // number.
+  @concurrent
+  private static func primeAccessibility(pid: pid_t) async {
+    let found =
+      PasteService.focusedElement(
+        inAppWithPID: pid, messagingTimeout: PasteService.axMessagingTimeoutSeconds
+      ) != nil
+    // .info, not .debug: AppLogger filters by `level <= logLevel`, default
+    // `.info` — a `.debug`-level line is invisible under the standard
+    // Debug-Mode-on / default-verbosity UAT setup this project requires.
+    await AppLogger.shared.log(
+      "AXWarmup prime pid=\(pid) found=\(found)", level: .info, category: "AccessibilityWarmup")
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift
@@ -31,6 +31,8 @@ final class AppLifecycleCoordinator {
   private var audioEnvironmentSnapshotter: AudioEnvironmentSnapshotter?
   // periphery:ignore - retain anchor: owns audio-system observer lifetime
   private var audioSystemEventReporter: AudioSystemEventReporter?
+  // periphery:ignore - retain anchor: owns app-activation observer lifetime
+  private var accessibilityWarmupObserver: AccessibilityWarmupObserver?
 
   #if DEBUG
     /// V2 fault-injection control surface (issue #291). Started only when
@@ -341,6 +343,14 @@ final class AppLifecycleCoordinator {
         self?.bluetoothAwarenessPresenter.reconcile(trigger: .deviceChanged)
       }
     )
+
+    // #1986: nudge a newly-frontmost app's own on-demand accessibility
+    // activation to start as early as possible, so slow-to-warm apps
+    // (Chrome/Chromium) get the whole time the user spends in that app to
+    // wake up, instead of only the retry #1980 fires at commit time.
+    let warmupObserver = AccessibilityWarmupObserver()
+    warmupObserver.start()
+    accessibilityWarmupObserver = warmupObserver
   }
 
   func runDidBecomeActive() {
@@ -385,5 +395,8 @@ final class AppLifecycleCoordinator {
     audioSystemEventReporter = nil
     SentryBreadcrumb.audioEnvironmentProvider = nil
     audioEnvironmentSnapshotter = nil
+
+    accessibilityWarmupObserver?.stop()
+    accessibilityWarmupObserver = nil
   }
 }

--- a/Tests/EnviousWisprTests/App/AccessibilityWarmupObserverTests.swift
+++ b/Tests/EnviousWisprTests/App/AccessibilityWarmupObserverTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+
+@Suite("AccessibilityWarmupObserver.registerPrimeIfAllowed")
+struct AccessibilityWarmupObserverTests {
+  @Test("Own pid is excluded")
+  func excludesOwnPID() {
+    var primedAtByPID: [pid_t: TimeInterval] = [:]
+    #expect(
+      AccessibilityWarmupObserver.registerPrimeIfAllowed(
+        activatedPID: 999, ownPID: 999, isRegularActivationPolicy: true,
+        primedAtByPID: &primedAtByPID, now: 0, cooldown: 10) == false)
+  }
+
+  @Test("Non-regular activation policy is excluded")
+  func excludesNonRegularActivationPolicy() {
+    var primedAtByPID: [pid_t: TimeInterval] = [:]
+    #expect(
+      AccessibilityWarmupObserver.registerPrimeIfAllowed(
+        activatedPID: 100, ownPID: 999, isRegularActivationPolicy: false,
+        primedAtByPID: &primedAtByPID, now: 0, cooldown: 10) == false)
+  }
+
+  @Test("First activation of a new pid is allowed")
+  func allowsFirstActivation() {
+    var primedAtByPID: [pid_t: TimeInterval] = [:]
+    #expect(
+      AccessibilityWarmupObserver.registerPrimeIfAllowed(
+        activatedPID: 100, ownPID: 999, isRegularActivationPolicy: true,
+        primedAtByPID: &primedAtByPID, now: 0, cooldown: 10))
+    #expect(primedAtByPID[100] == 0)
+  }
+
+  @Test("Re-activation of same pid within cooldown is blocked")
+  func blocksReactivationWithinCooldown() {
+    var primedAtByPID: [pid_t: TimeInterval] = [100: 0]
+    #expect(
+      AccessibilityWarmupObserver.registerPrimeIfAllowed(
+        activatedPID: 100, ownPID: 999, isRegularActivationPolicy: true,
+        primedAtByPID: &primedAtByPID, now: 5, cooldown: 10) == false)
+  }
+
+  @Test("Re-activation of same pid after cooldown is allowed")
+  func allowsReactivationAfterCooldown() {
+    var primedAtByPID: [pid_t: TimeInterval] = [100: 0]
+    #expect(
+      AccessibilityWarmupObserver.registerPrimeIfAllowed(
+        activatedPID: 100, ownPID: 999, isRegularActivationPolicy: true,
+        primedAtByPID: &primedAtByPID, now: 10, cooldown: 10))
+    #expect(primedAtByPID[100] == 10)
+  }
+
+  @Test("A to B to A does not bypass A's cooldown")
+  func interleavedActivationKeepsPerPIDCooldown() {
+    var primedAtByPID: [pid_t: TimeInterval] = [:]
+
+    #expect(
+      AccessibilityWarmupObserver.registerPrimeIfAllowed(
+        activatedPID: 100, ownPID: 999, isRegularActivationPolicy: true,
+        primedAtByPID: &primedAtByPID, now: 5, cooldown: 10))
+
+    #expect(
+      AccessibilityWarmupObserver.registerPrimeIfAllowed(
+        activatedPID: 200, ownPID: 999, isRegularActivationPolicy: true,
+        primedAtByPID: &primedAtByPID, now: 7, cooldown: 10))
+
+    #expect(
+      AccessibilityWarmupObserver.registerPrimeIfAllowed(
+        activatedPID: 100, ownPID: 999, isRegularActivationPolicy: true,
+        primedAtByPID: &primedAtByPID, now: 9, cooldown: 10) == false)
+  }
+}

--- a/Tests/EnviousWisprTests/Architecture/AppLifecycleCoordinatorCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/AppLifecycleCoordinatorCeilingsTests.swift
@@ -46,6 +46,12 @@ import Testing
 /// `var` + 20 injected `let`) — `batchDecodeFaultController`, a deliberate,
 /// explicit addition for the new DEBUG fault-injection oracle (§11.1/§3.2a-i),
 /// forwarded into `DebugFaultEndpoint`'s construction; not accretion.
+/// Bible §30 entry (#1986, 2026-08-08): `accessibilityWarmupObserver` added as
+/// one owned process-lifetime `var`. `AppLifecycleCoordinator` only starts,
+/// retains, and stops the narrow observer; activation filtering, cooldown
+/// state, and AX priming remain inside the delegated type. Allowlist 23 → 24
+/// (4 owned `var` + 20 injected `let`); non-private method count and imports
+/// unchanged.
 @Suite struct AppLifecycleCoordinatorCeilingsTests {
   private static let sourcePath =
     "Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift"
@@ -74,6 +80,7 @@ import Testing
     "applicationRelocationCoordinator",
     "bluetoothAwarenessPresenter",
     "batchDecodeFaultController",
+    "accessibilityWarmupObserver",
   ]
 
   @Test func storedPropertyNamesMatchAllowlist() throws {
@@ -86,7 +93,7 @@ import Testing
       extras.isEmpty && missing.isEmpty,
       """
       AppLifecycleCoordinator stored-property set drifted from the \
-      22-name allowlist. Unexpected: \(extras.sorted()). Missing: \
+      24-name allowlist. Unexpected: \(extras.sorted()). Missing: \
       \(missing.sorted()). Adding a stored property is god-object drift — \
       raising the allowlist requires a Bible §30 entry. Removing one means \
       this allowlist must shrink in the same PR.


### PR DESCRIPTION
## Summary

- Adds `AccessibilityWarmupObserver`: watches for any app becoming frontmost and fires one discarded, off-main accessibility query at it, purely to nudge slow-to-warm apps (Chrome/Chromium, whose native accessibility support only turns on "automatically on-demand") to start activating earlier than #1980's single commit-time retry can reach.
- Also primes the app already frontmost when EnviousWispr launches — the common case after every dev rebuild.
- Purely additive: reuses the existing `PasteService.focusedElement` primitive end to end (no new AX-calling code, only a new caller), touches nothing in the paste/dictation path, and leaves #1980's retry untouched.

Full design, grounding evidence, and the live diagnosis that produced this plan: `docs/feature-requests/issue-1986-2026-08-08-accessibility-warmup-priming.md` (3 rounds of Codex grounded review, PROCEED-AS-PLANNED).

Closes #1986.

## Disclosed limit

Not a guarantee: a target app that is still cold when the user starts dictating within under a second of switching to it gets no more runway than before this change. This shortens the typical case; it does not eliminate the tail. A bounded manual premise-check against a genuinely cold Chrome relaunch was inconclusive within the ~1-2 minute window a manual test allows (recorded in the plan) — effectiveness against real cold-Chrome usage is measured post-release from existing `paste.completed` telemetry fields (`target_app`, `smart_insertion`, `caret_context`, `caret_capture_retried`), not asserted from local testing.

## Test plan

- [x] `scripts/xcode-test.sh` — full Debug suite, 5,170 tests, green (including 6 new `AccessibilityWarmupObserverTests` and the updated `AppLifecycleCoordinatorCeilingsTests` architecture-ceiling gate)
- [x] `scripts/xcode-test.sh --release` — Release suite, 4,754 tests, green
- [x] Codex chunk review of the actual diff: one style fix adopted (negated `#expect` assertions → `== false`, per `swift-testing-no-negated-expect`)
- [x] Independent whole-diff `codex review`: clean, no actionable regressions or correctness defects found
- [x] Live UAT: both activation paths confirmed firing (`AXWarmup prime pid=... found=...` log line on ordinary app-switch AND on the already-frontmost-at-launch case), heart path confirmed unaffected via two real dictations into TextEdit/Chrome
