### PR TITLE
fix(build): pin nanoid to patched 3.3.17+ (Dependabot #64)

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -3659,9 +3659,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/website/package.json
+++ b/website/package.json
@@ -17,7 +17,8 @@
     "devalue": ">=5.8.1",
     "undici": ">=7.24.0",
     "esbuild": ">=0.28.1",
-    "sharp": ">=0.35.0"
+    "sharp": ">=0.35.0",
+    "nanoid": "^3.3.17"
   },
   "dependencies": {
     "@astrojs/rss": "^4.0.19",


### PR DESCRIPTION
## Summary
- Closes Dependabot alert #64 (GHSA-2v37-7h3g-55p8 / CVE-2026-67213, high severity): `nanoid` < 3.3.17 hangs on an infinite loop when `customAlphabet`/`customRandom` receive size 0.
- `nanoid` was a transitive dep of `postcss` (build-time CSS tooling only, never shipped to the browser or given attacker-controlled input) — low real-world risk, fixed anyway since a clean fix was available.
- Added an npm `overrides` pin: `"nanoid": "^3.3.17"`, resolving to patched 3.3.18 while staying on the same major/CJS API postcss expects (an open-ended `>=3.3.17` pulled in nanoid 6, which is ESM-only and needs a newer Node floor than postcss supports — verified and avoided).
- Verified `npm run build` still produces all 122 pages cleanly with the pinned version.

## Test plan
- [x] `npm run build` in `website/` succeeds (122 pages built, 0 errors)
- [x] Confirmed `nanoid` resolves to `3.3.18` (patched) under `postcss`'s `node_modules` in the lockfile
- [x] `council-skip: zero-blast-radius (single-value config pin)` — single-file, single-value dependency override, no code/behavior change