### PR TITLE
feat(hotkey): use the Globe (Fn) key as your dictation shortcut

### DIFF
--- a/Sources/EnviousWisprAppKit/App/SettingsChangeTelemetry.swift
+++ b/Sources/EnviousWisprAppKit/App/SettingsChangeTelemetry.swift
@@ -40,6 +40,10 @@ enum SettingsProjection {
     case appearance = "appearance"
     case overlayPillPosition = "overlay_pill_position"
     case toggleHotkeyShape = "toggle_hotkey_shape"
+    /// #1987 — WHICH key is configured, one level finer than shape. `key_shape`
+    /// reports `modifier_only` for both Globe and Right Option, so it cannot
+    /// answer whether the Globe key was adopted. Content-free class only.
+    case toggleHotkeyIdentity = "toggle_hotkey_identity"
     case pushToTalkHotkeyShape = "push_to_talk_hotkey_shape"
     case cancelHotkeyShape = "cancel_hotkey_shape"
     case playRecordingSounds = "play_recording_sounds"
@@ -50,46 +54,52 @@ enum SettingsProjection {
   /// debounce so a drag collapses to one bucketed delta.
   static let sliderLogicals: Set<Logical> = [.vadSilenceTimeout, .vadSensitivity]
 
-  /// Map a raw `SettingKey` to its logical setting; nil = not instrumented.
+  /// Map a raw `SettingKey` to its logical settings; empty = not instrumented.
   /// Each hotkey role groups its keyCode + modifiers keys into one shape logical
   /// (so a key+modifier reassignment is one delta, never two).
-  static func logical(for key: SettingsManager.SettingKey) -> Logical? {
+  ///
+  /// #1987: returns an ARRAY because the toggle hotkey now projects two logicals,
+  /// shape and identity. Every other key returns exactly the one it always did, or
+  /// none. The array is the whole fan-out contract: `handle(_:)` seeds or enqueues
+  /// each element independently, so shape and identity coalesce and suppress net
+  /// no-ops separately rather than as a pair.
+  static func logicals(for key: SettingsManager.SettingKey) -> [Logical] {
     switch key {
-    case .recordingMode: return .recordingMode
-    case .llmProvider: return .llmProvider
+    case .recordingMode: return [.recordingMode]
+    case .llmProvider: return [.llmProvider]
     // #1173: both the cloud `llmModel` and the local `ollamaModel` feed the one
     // `llm_model` logical — the projection reads the EFFECTIVE model
     // (`SettingsManager.effectiveLLMModel`, ollama→ollamaModel else llmModel), so
     // a mirror/discovery write to either field re-emits. Coalescing-by-logical
     // collapses a `.llmModel`+`.ollamaModel` pair (the Ollama mirror) into ONE
     // delta. (Codex r7 pivot.)
-    case .llmModel, .ollamaModel: return .llmModel
-    case .autoCopyToClipboard: return .autoCopy
-    case .hotkeyEnabled: return .hotkeyEnabled
-    case .vadAutoStop: return .vadAutoStop
-    case .vadSilenceTimeout: return .vadSilenceTimeout
-    case .vadSensitivity: return .vadSensitivity
-    case .vadEnergyGate: return .vadEnergyGate
-    case .modelUnloadPolicy: return .modelUnloadPolicy
-    case .restoreClipboardAfterPaste: return .restoreClipboard
-    case .smartInsertion: return .smartInsertion
-    case .wordCorrectionEnabled: return .wordCorrection
-    case .fillerRemovalEnabled: return .fillerRemoval
-    case .contactsSyncOnLaunchEnabled: return .contactsSync
-    case .emojiFormatterEnabled: return .emojiFormatter
-    case .spokenPunctuationEnabled: return .spokenPunctuation
-    case .crashRecoveryEnabled: return .crashRecovery
-    case .useExtendedThinking: return .useExtendedThinking
-    case .languageMode: return .languageMode
-    case .useStreamingASR: return .streamingASR
-    case .warmEnginePolicy: return .warmEnginePolicy
-    case .appearance: return .appearance
-    case .overlayPillPosition: return .overlayPillPosition
-    case .toggleKeyCode, .toggleModifiers: return .toggleHotkeyShape
-    case .pushToTalkKeyCode, .pushToTalkModifiers: return .pushToTalkHotkeyShape
-    case .cancelKeyCode, .cancelModifiers: return .cancelHotkeyShape
-    case .playRecordingSounds: return .playRecordingSounds
-    case .recordingSoundPairing: return .recordingSoundPairing
+    case .llmModel, .ollamaModel: return [.llmModel]
+    case .autoCopyToClipboard: return [.autoCopy]
+    case .hotkeyEnabled: return [.hotkeyEnabled]
+    case .vadAutoStop: return [.vadAutoStop]
+    case .vadSilenceTimeout: return [.vadSilenceTimeout]
+    case .vadSensitivity: return [.vadSensitivity]
+    case .vadEnergyGate: return [.vadEnergyGate]
+    case .modelUnloadPolicy: return [.modelUnloadPolicy]
+    case .restoreClipboardAfterPaste: return [.restoreClipboard]
+    case .smartInsertion: return [.smartInsertion]
+    case .wordCorrectionEnabled: return [.wordCorrection]
+    case .fillerRemovalEnabled: return [.fillerRemoval]
+    case .contactsSyncOnLaunchEnabled: return [.contactsSync]
+    case .emojiFormatterEnabled: return [.emojiFormatter]
+    case .spokenPunctuationEnabled: return [.spokenPunctuation]
+    case .crashRecoveryEnabled: return [.crashRecovery]
+    case .useExtendedThinking: return [.useExtendedThinking]
+    case .languageMode: return [.languageMode]
+    case .useStreamingASR: return [.streamingASR]
+    case .warmEnginePolicy: return [.warmEnginePolicy]
+    case .appearance: return [.appearance]
+    case .overlayPillPosition: return [.overlayPillPosition]
+    case .toggleKeyCode, .toggleModifiers: return [.toggleHotkeyShape, .toggleHotkeyIdentity]
+    case .pushToTalkKeyCode, .pushToTalkModifiers: return [.pushToTalkHotkeyShape]
+    case .cancelKeyCode, .cancelModifiers: return [.cancelHotkeyShape]
+    case .playRecordingSounds: return [.playRecordingSounds]
+    case .recordingSoundPairing: return [.recordingSoundPairing]
     // Not instrumented.
     case .selectedBackend, .onboardingState, .hasCompletedOnboarding,
       .isDebugModeEnabled, .isDictationAudioArchiveEnabled, .debugLogLevel, .whisperKitLanguage,
@@ -97,7 +107,7 @@ enum SettingsProjection {
       // #1480: the popover's own lifecycle telemetry (`bt_awareness.*`) owns this
       // signal, incl. `suppressed_by_setting`; no separate settings.changed delta.
       .showBluetoothTips:
-      return nil
+      return []
     }
   }
 
@@ -131,6 +141,11 @@ enum SettingsProjection {
     case .appearance: return settings.appearancePreference.rawValue
     case .overlayPillPosition: return settings.overlayPillPosition.rawValue
     case .toggleHotkeyShape: return hotkeyShape(settings.toggleKeyCode)
+    // #1987: same key, one level finer. Projected through the Services-owned
+    // classifier so the vocabulary has exactly one authority and no key code can
+    // reach telemetry from here.
+    case .toggleHotkeyIdentity:
+      return HotkeyKeyIdentity.classify(keyCode: settings.toggleKeyCode).rawValue
     case .pushToTalkHotkeyShape: return hotkeyShape(settings.pushToTalkKeyCode)
     case .cancelHotkeyShape: return hotkeyShape(settings.cancelKeyCode)
     case .playRecordingSounds: return onOff(settings.playRecordingSounds)
@@ -346,20 +361,33 @@ final class SettingsChangeTelemetry {
       }
       return
     }
-    guard let logical = SettingsProjection.logical(for: key) else { return }
+    let logicals = SettingsProjection.logicals(for: key)
+    // #1987: an uninstrumented key returns an empty array; the old shape returned
+    // nil. Same outcome, explicitly handled rather than falling out of a `guard`.
+    guard !logicals.isEmpty else { return }
 
     // Suppress onboarding-time writes (the onboarding-completion baseline
     // captures the final state); keep the committed baseline current so the
     // first real post-onboarding change has a truthful `from`.
     if settings.onboardingState != .completed {
-      committedBaseline[logical] = SettingsProjection.value(for: logical, settings: settings)
-      pendingOriginal[logical] = nil
-      pendingSource[logical] = nil
+      // #1987: advance the baseline for EVERY logical this key projects, not just
+      // the first. Missing one would leave a stale `from` and make the first real
+      // post-onboarding change look like a no-op.
+      for logical in logicals {
+        committedBaseline[logical] = SettingsProjection.value(for: logical, settings: settings)
+        pendingOriginal[logical] = nil
+        pendingSource[logical] = nil
+      }
       return
     }
 
     let source: Source = settings.isApplyingSystemWrite ? .system : .user
-    enqueue(logical, source: source)
+    // Each logical coalesces and suppresses net no-ops independently, so a
+    // key-code change that alters identity but not shape (Globe and Right Option
+    // are both modifier-only) emits one delta, not two.
+    for logical in logicals {
+      enqueue(logical, source: source)
+    }
     // `llm_model`'s projection also depends on `llmProvider` (cloud id vs Ollama
     // catalog vs `none`/`apple-intelligence`), so a provider change can alter the
     // projected model even with NO `llmModel` write — e.g. turning polish off →
@@ -368,9 +396,11 @@ final class SettingsChangeTelemetry {
     // keeping a cloud id). The provider switch is a user gesture, so this enqueues
     // `user`; if async discovery then corrects the model inside the same window,
     // last-writer-wins re-stamps it `system` (Codex r6).
-    if logical == .llmProvider {
+    if logicals.contains(.llmProvider) {
       enqueue(.llmModel, source: source)
     }
+    // Once per RAW change, never once per logical: a fan-out must not shorten or
+    // multiply the settle window.
     scheduleSettle()
   }
 

--- a/Sources/EnviousWisprAppKit/Views/Components/HotkeyRecorderView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Components/HotkeyRecorderView.swift
@@ -48,6 +48,44 @@ final class KeyCaptureNSView: NSView {
   }
 }
 
+// MARK: - HotkeyCapture
+
+/// #1987 — the single authority for what a captured key event MEANS.
+///
+/// Two surfaces record shortcuts: Settings, through `HotkeyRecorderView`, and
+/// onboarding, through `KeycapHotkeyView`. Both already shared `KeyCaptureNSView`
+/// for what they RECEIVE, but each carried its own copy of what to ACCEPT, so the
+/// same press could bind differently depending on where the user set it. That
+/// duplication became load-bearing when accepting a binding started deciding
+/// whether to present the Globe guidance, which must happen exactly once across
+/// both surfaces.
+///
+/// Free of `@Environment` and of any view state on purpose: the decision is a
+/// function of the event alone, so it is provable without a rendered hierarchy.
+enum HotkeyCapture {
+  /// True when the event cancels recording instead of binding: Escape pressed
+  /// alone. Restricted to real key presses, since a modifier change never cancels.
+  static func isCancel(_ event: NSEvent) -> Bool {
+    event.type != .flagsChanged
+      && event.keyCode == 53
+      && event.modifierFlags.intersection(.deviceIndependentFlagsMask).isEmpty
+  }
+
+  /// The shortcut a non-cancelling event binds to.
+  ///
+  /// A standalone modifier reports its OWN flag in `modifierFlags`, so storing
+  /// that flag would require the user to hold Globe while pressing Globe and the
+  /// shortcut could never fire. Those come back with empty modifiers; an ordinary
+  /// chord keeps its modifiers.
+  static func binding(for event: NSEvent) -> (keyCode: UInt16, modifiers: NSEvent.ModifierFlags) {
+    let keyCode = event.keyCode
+    if event.type == .flagsChanged && ModifierKeyCodes.isModifierOnly(keyCode) {
+      return (keyCode, [])
+    }
+    return (keyCode, event.modifierFlags.intersection(.deviceIndependentFlagsMask))
+  }
+}
+
 // MARK: - KeyCaptureView
 
 /// SwiftUI wrapper around `KeyCaptureNSView`. When `isRecording` is true the underlying
@@ -109,6 +147,11 @@ struct HotkeyRecorderView: View {
   let label: String
   var colors: HotkeyRecorderColors = .system
   var style: Style = .compact
+  /// #1987 — fires after a binding is ACCEPTED, so the owning surface can decide
+  /// whether to present the Globe-key guidance. Settings and onboarding have
+  /// separate completion handlers, so the decision cannot live in this view; it
+  /// belongs to `SettingsManager.claimGlobeKeyGuidancePresentation`.
+  var onBindingAccepted: (UInt16, NSEvent.ModifierFlags) -> Void = { _, _ in }
 
   // PR10 of #763: hotkey suspend/resume dispatch through DictationRuntime
   // façade; the shared HotkeyService is no longer accessible via the former root state.
@@ -260,39 +303,42 @@ struct HotkeyRecorderView: View {
     dictationRuntime.resumeHotkeys()
   }
 
+  /// Stays `private`: this method reads `dictationRuntime` from `@Environment` via
+  /// `stopRecording()`, so it traps outside a rendered hierarchy and no test can
+  /// drive it. The parts a test needs — what an event means, and what accepting it
+  /// does — live in `HotkeyCapture` and `acceptBinding(from:)`, neither of which
+  /// touches the environment.
   private func handleKeyEvent(_ event: NSEvent) {
-    // Escape with no modifiers cancels recording (only from keyDown / performKeyEquivalent)
-    if event.type != .flagsChanged
-      && event.keyCode == 53
-      && event.modifierFlags.intersection(.deviceIndependentFlagsMask).isEmpty
-    {
+    if HotkeyCapture.isCancel(event) {
       Task { @MainActor in
         stopRecording()
       }
       return
     }
-
-    let newKeyCode = event.keyCode
-
-    // Modifier-only hotkey: the keyCode IS the modifier key.
-    // Store the key code as-is and clear modifiers — the modifier IS the key,
-    // so there is no additional modifier to hold down.
-    if event.type == .flagsChanged && ModifierKeyCodes.isModifierOnly(newKeyCode) {
-      Task { @MainActor in
-        keyCode = newKeyCode
-        modifiers = []
-        stopRecording()
-      }
-      return
-    }
-
-    let newModifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
 
     Task { @MainActor in
-      keyCode = newKeyCode
-      modifiers = newModifiers
+      acceptBinding(from: event)
       stopRecording()
     }
+  }
+
+  /// #1987 — the acceptance EFFECT, extracted from `handleKeyEvent` so it is
+  /// reachable without a rendered view hierarchy. `internal` (not `package`) per
+  /// the chunk contract: the test target already uses
+  /// `@testable import EnviousWisprAppKit`, and an AppKit-local declaration must
+  /// not widen beyond that.
+  ///
+  /// Two things this shape buys beyond testability. The callback would otherwise
+  /// need one invocation per acceptance branch, so a later edit could update one
+  /// and miss the other; there is exactly one. And the bindings are written BEFORE
+  /// the owner is notified, which both surfaces depend on: `onBindingAccepted`
+  /// presents the Globe guidance, and the popover anchors on a control whose label
+  /// must already read the new key.
+  func acceptBinding(from event: NSEvent) {
+    let accepted = HotkeyCapture.binding(for: event)
+    keyCode = accepted.keyCode
+    modifiers = accepted.modifiers
+    onBindingAccepted(accepted.keyCode, accepted.modifiers)
   }
 
   private func resetToDefault() {

--- a/Sources/EnviousWisprAppKit/Views/Components/HotkeyRecorderView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Components/HotkeyRecorderView.swift
@@ -35,24 +35,15 @@ final class KeyCaptureNSView: NSView {
     // and the direction of the transition from the modifier flags themselves.
     let currentFlags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
 
-    // Map the physical key code to the modifier flag it represents.
-    let addedFlag = flagForModifierKeyCode(event.keyCode)
-    guard addedFlag != [] else { return }  // not a recognised modifier key
+    // Map the physical key code to the modifier flag it represents. One shared
+    // authority with the dispatch path (#1987): nil means "not a standalone
+    // modifier", which is distinguishable from a real flag in a way an empty
+    // OptionSet is not.
+    guard let addedFlag = ModifierKeyCodes.flag(for: event.keyCode) else { return }
 
     // Only forward the event when the modifier is being pressed (added), not released.
     if currentFlags.contains(addedFlag) {
       onKeyEvent?(event)
-    }
-  }
-
-  /// Returns the NSEvent.ModifierFlags bit that corresponds to the given modifier key code.
-  private func flagForModifierKeyCode(_ keyCode: UInt16) -> NSEvent.ModifierFlags {
-    switch keyCode {
-    case 55, 54: return .command
-    case 58, 61: return .option
-    case 59, 62: return .control
-    case 56, 60: return .shift
-    default: return []
     }
   }
 }
@@ -240,7 +231,10 @@ struct HotkeyRecorderView: View {
     KeyCaptureBehavior(
       isRecording: isRecording,
       label: label,
-      valueDescription: KeySymbols.format(keyCode: keyCode, modifiers: modifiers),
+      // Spoken projection, not the visible one (#1987): the visible label leads
+      // with an emoji for the Globe key. Visible text is unchanged.
+      valueDescription: KeySymbols.accessibilityDescription(
+        keyCode: keyCode, modifiers: modifiers),
       onKeyEvent: handleKeyEvent,
       onToggle: toggleRecording
     )

--- a/Sources/EnviousWisprAppKit/Views/Components/HotkeyRecorderView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Components/HotkeyRecorderView.swift
@@ -9,17 +9,59 @@ import SwiftUI
 final class KeyCaptureNSView: NSView {
   var onKeyEvent: ((NSEvent) -> Void)?
 
-  override var acceptsFirstResponder: Bool { true }
+  /// #1987 — whether the owner is actively recording a shortcut.
+  ///
+  /// All three handlers below and first-responder eligibility read this one flag,
+  /// but they did NOT share the same history, and the difference matters to anyone
+  /// tempted to relax one of them:
+  ///
+  /// - `keyDown` and `flagsChanged` relied on this hidden view never becoming first
+  ///   responder outside recording, because the only `makeFirstResponder` call sat
+  ///   in the recording branch. That is an absence of opportunity, not a guard.
+  ///   #1987 removed the absence by making the enclosing control `.focusable()` so
+  ///   the guidance popover could return focus to it, and the founder then hit the
+  ///   consequence in live UAT (2026-08-09): landing on the Shortcuts page and
+  ///   typing rebound the shortcut with no click and no "press a key" prompt.
+  /// - `performKeyEquivalent` was already unsafe before #1987 and for a different
+  ///   reason. See its own note below.
+  ///
+  /// Gated here rather than in each owner because this view is the event SOURCE and
+  /// both recording surfaces share it. A per-owner check would have to be repeated
+  /// and could be forgotten by the next surface.
+  var isRecording = false {
+    didSet {
+      // Stop holding focus the instant recording ends. `acceptsFirstResponder`
+      // going false does not resign an existing first-responder status, so without
+      // this the view keeps receiving keys until something else takes focus.
+      guard !isRecording, oldValue, let window, window.firstResponder === self else { return }
+      window.makeFirstResponder(nil)
+    }
+  }
+
+  override var acceptsFirstResponder: Bool { isRecording }
 
   /// Called BEFORE the system handles key equivalents (e.g. Command+Left, Option+Arrow).
   /// Returning true tells AppKit this view handled the event, preventing system consumption.
+  ///
+  /// AppKit can route a key equivalent through the view tree rather than to the
+  /// first responder, so this arm fires even when this view holds no focus at all.
+  /// That is why it needed the gate independently of the focus story above, and why
+  /// it was unsafe before #1987 rather than because of it. Returning `true`
+  /// unconditionally also told AppKit that every key equivalent REACHING this view
+  /// was handled, so an ordinary shortcut on the page could both rebind the hotkey
+  /// and fail to perform its own action.
   override func performKeyEquivalent(with event: NSEvent) -> Bool {
+    guard isRecording else { return super.performKeyEquivalent(with: event) }
     onKeyEvent?(event)
     return true
   }
 
   /// Called for regular key presses that are not key equivalents (plain letters, etc.).
   override func keyDown(with event: NSEvent) {
+    guard isRecording else {
+      super.keyDown(with: event)
+      return
+    }
     onKeyEvent?(event)
   }
 
@@ -29,6 +71,11 @@ final class KeyCaptureNSView: NSView {
   /// We only forward it when the modifier count goes UP (a new modifier is added)
   /// so that releasing the key does not trigger a second recording action.
   override func flagsChanged(with event: NSEvent) {
+    guard isRecording else {
+      super.flagsChanged(with: event)
+      return
+    }
+
     // Determine which device-independent modifier bits changed compared to the
     // previous event. NSEvent does not expose a "previous flags" property, so
     // we rely on the keyCode to identify the specific modifier key that changed
@@ -97,11 +144,16 @@ struct KeyCaptureView: NSViewRepresentable {
   func makeNSView(context: Context) -> KeyCaptureNSView {
     let view = KeyCaptureNSView()
     view.onKeyEvent = onKeyEvent
+    view.isRecording = isRecording
     return view
   }
 
   func updateNSView(_ nsView: KeyCaptureNSView, context: Context) {
     nsView.onKeyEvent = onKeyEvent
+    // Set BEFORE requesting first responder: `acceptsFirstResponder` reads this,
+    // so assigning it after would have AppKit refuse the very request below.
+    // Assigning it also resigns focus when recording ends (see its `didSet`).
+    nsView.isRecording = isRecording
     if isRecording {
       // Defer making first responder so the window is ready
       Task { @MainActor in

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
@@ -1294,6 +1294,16 @@ private struct PermissionRow: View {
 // MARK: - Screen 3: Ready
 
 private struct ReadyScreenV2: View {
+  @State private var showGlobeGuidance = false
+  @AccessibilityFocusState private var guidanceReturnFocus: Bool
+  @FocusState private var shortcutFocused: Bool
+
+  private func dismissGlobeGuidance() {
+    showGlobeGuidance = false
+    shortcutFocused = true
+    guidanceReturnFocus = true
+  }
+
   @Environment(SettingsManager.self) private var settings
   @Environment(PermissionsService.self) private var permissions
   let onComplete: () -> Void
@@ -1331,8 +1341,27 @@ private struct ReadyScreenV2: View {
       // Interactive keycap — tap to record, shows result inline
       KeycapHotkeyView(
         keyCode: $settings.toggleKeyCode,
-        modifiers: $settings.toggleModifiers
+        modifiers: $settings.toggleModifiers,
+        onBindingAccepted: { code, _ in
+          // One shared owner across both surfaces (#1987): whichever surface binds
+          // Globe FIRST shows the explanation, and the other never repeats it.
+          if settings.claimGlobeKeyGuidancePresentation(for: code) {
+            showGlobeGuidance = true
+          }
+        }
       )
+      // Same reason as the Settings recorder (#1987): the keycap is a tappable
+      // plain view, not a `Button`, so without `.focusable()` the focus binding
+      // below would succeed in state while keyboard focus went nowhere.
+      .focusable()
+      .focused($shortcutFocused)
+      .accessibilityFocused($guidanceReturnFocus)
+      .popover(isPresented: $showGlobeGuidance, arrowEdge: .bottom) {
+        GlobeGuidancePopover(onDismiss: dismissGlobeGuidance)
+          // Same single dismissal path as Settings (#1987): both surfaces must
+          // return focus, not just the one a reviewer happens to open.
+          .onExitCommand(perform: dismissGlobeGuidance)
+      }
       .padding(.bottom, 20)
 
       if !permissions.accessibilityGranted {
@@ -1404,6 +1433,11 @@ private struct ReadyScreenV2: View {
 private struct KeycapHotkeyView: View {
   @Binding var keyCode: UInt16
   @Binding var modifiers: NSEvent.ModifierFlags
+  /// #1987 — onboarding has its OWN bind-completion handler; it does not share
+  /// `HotkeyRecorderView`. Without this the Globe guidance would only ever appear
+  /// in Settings, and a user who binds Globe during first-run setup, which is the
+  /// likeliest moment, would be told nothing.
+  var onBindingAccepted: (UInt16, NSEvent.ModifierFlags) -> Void = { _, _ in }
 
   // PR10 of #763: hotkey suspend/resume dispatch through DictationRuntime
   // façade; the shared HotkeyService is no longer accessible via the former root state.
@@ -1634,33 +1668,29 @@ private struct KeycapHotkeyView: View {
     dictationRuntime.resumeHotkeys()
   }
 
+  /// #1987 — reads the same `HotkeyCapture` authority as the Settings recorder.
+  /// This method carried its own copy of the accept/cancel logic, so the same
+  /// press could bind differently depending on which surface the user set it in.
   private func handleKeyEvent(_ event: NSEvent) {
-    // Escape with no modifiers cancels
-    if event.type != .flagsChanged,
-      event.keyCode == 53,
-      event.modifierFlags.intersection(.deviceIndependentFlagsMask).isEmpty
-    {
+    if HotkeyCapture.isCancel(event) {
       Task { @MainActor in stopRecording() }
       return
     }
 
-    let newKeyCode = event.keyCode
-
-    // Modifier-only hotkey (e.g. bare Option)
-    if event.type == .flagsChanged, ModifierKeyCodes.isModifierOnly(newKeyCode) {
-      Task { @MainActor in
-        keyCode = newKeyCode
-        modifiers = []
-        stopRecording()
-      }
-      return
-    }
-
-    let newModifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
     Task { @MainActor in
-      keyCode = newKeyCode
-      modifiers = newModifiers
+      acceptBinding(from: event)
       stopRecording()
     }
+  }
+
+  /// The acceptance EFFECT, mirroring `HotkeyRecorderView.acceptBinding(from:)`:
+  /// one callback site rather than one per branch, and the bindings written before
+  /// the owner is notified so the guidance popover anchors on a keycap that already
+  /// reads the new key.
+  private func acceptBinding(from event: NSEvent) {
+    let accepted = HotkeyCapture.binding(for: event)
+    keyCode = accepted.keyCode
+    modifiers = accepted.modifiers
+    onBindingAccepted(accepted.keyCode, accepted.modifiers)
   }
 }

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
@@ -1463,7 +1463,9 @@ private struct KeycapHotkeyView: View {
           .accessibilityValue(
             isRecording
               ? "Recording, press a key combination"
-              : displayLabel
+              // Spoken projection, not the visible keycap text (#1987). Visible
+              // display is unchanged.
+              : KeySymbols.accessibilityDescription(keyCode: keyCode, modifiers: modifiers)
           )
           .accessibilityHint("Activates recording. Then press the key combination you want.")
           .accessibilityAction { toggleRecording() }

--- a/Sources/EnviousWisprAppKit/Views/Settings/GlobeKeyCopy.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/GlobeKeyCopy.swift
@@ -7,7 +7,18 @@ import Foundation
 /// conscious act rather than drift. Stateless. No persistence, no preference
 /// reads, no behaviour.
 ///
-/// **THE COPY IS FOUNDER-APPROVED VERBATIM (2026-08-08). DO NOT REWORD IT.**
+/// **THE COPY IS FOUNDER-APPROVED VERBATIM (2026-08-08, body amended 2026-08-09).
+/// DO NOT REWORD IT.**
+///
+/// The 2026-08-09 amendment added "or start its own dictation" to the body. The
+/// original named two of the three things the "Press 🌐 key to" menu can do and
+/// omitted Start Dictation, which is the worst case for us: Apple's dictation
+/// takes the microphone, so the user gets Apple's panel and nothing from us and
+/// reasonably concludes the app is broken. Someone with that setting read a list
+/// their situation was not in. Naming most of a set and dropping one member is an
+/// omission no search for the missing term can find, which is why it survived
+/// review; the founder supplied the missing member.
+///
 /// Three properties of it are load-bearing and a later edit must preserve them:
 ///
 /// 1. It does NOT assert a conflict exists. `#1987` deliberately reads no macOS
@@ -27,8 +38,9 @@ enum GlobeKeyCopy {
   static let title = "Free up the Globe key"
 
   static let body =
-    "macOS may already use the Globe key to switch keyboard languages or open the "
-    + "emoji picker. If that happens while you dictate, you can turn it off:"
+    "macOS may already use the Globe key to switch keyboard languages, open the "
+    + "emoji picker, or start its own dictation. If that happens while you dictate, "
+    + "you can turn it off:"
 
   static let steps = [
     "Open System Settings, then Keyboard",

--- a/Sources/EnviousWisprAppKit/Views/Settings/GlobeKeyCopy.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/GlobeKeyCopy.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// #1987 — every user-facing string for the Globe-key guidance popover.
+///
+/// Same shape as `LiveTranscriptionCopy` (#1337) and `SpokenPunctuationCopy`
+/// (#1794): one namespace owning the copy, frozen by tests so a change is a
+/// conscious act rather than drift. Stateless. No persistence, no preference
+/// reads, no behaviour.
+///
+/// **THE COPY IS FOUNDER-APPROVED VERBATIM (2026-08-08). DO NOT REWORD IT.**
+/// Three properties of it are load-bearing and a later edit must preserve them:
+///
+/// 1. It does NOT assert a conflict exists. `#1987` deliberately reads no macOS
+///    preference, so "may already use" is the only honest phrasing. Changing it to
+///    "is using" would be wrong for every user who already freed the key.
+/// 2. It reassures before it instructs. The closing line answers the question the
+///    popover itself provokes, which is "did my shortcut fail to save?".
+/// 3. It quotes macOS verbatim. "Press 🌐 key to" and "Do Nothing" are the exact
+///    on-screen labels, so the user does no translation.
+///
+/// The founder also explicitly DECLINED adding a Toggle-mode line here: the
+/// popover's single job is telling people they can disable the emoji or language
+/// shortcut. That pointer belongs in the help article, where length is free.
+///
+/// Brand rule: no em-dashes or en-dashes.
+enum GlobeKeyCopy {
+  static let title = "Free up the Globe key"
+
+  static let body =
+    "macOS may already use the Globe key to switch keyboard languages or open the "
+    + "emoji picker. If that happens while you dictate, you can turn it off:"
+
+  static let steps = [
+    "Open System Settings, then Keyboard",
+    "Click the \"Press 🌐 key to\" menu",
+    "Choose \"Do Nothing\"",
+  ]
+
+  static let reassurance =
+    "Your Globe key is set as your dictation shortcut either way. This only stops "
+    + "macOS doing its own thing at the same time."
+
+  static let dismissButton = "Got it"
+
+  /// Spoken container label. VoiceOver reads this before the body, so it must say
+  /// what the popover IS rather than repeat the title verbatim.
+  static let accessibilityLabel = "Free up the Globe key. Setup tip."
+}

--- a/Sources/EnviousWisprAppKit/Views/Settings/ShortcutsSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/ShortcutsSettingsView.swift
@@ -8,6 +8,18 @@ import SwiftUI
 /// selectors read as one family; the hotkeys render as big edit buttons.
 struct ShortcutsSettingsView: View {
   @Environment(SettingsManager.self) private var settings
+  @State private var showGlobeGuidance = false
+  /// Where keyboard and VoiceOver focus must return when the guidance closes.
+  @AccessibilityFocusState private var guidanceReturnFocus: Bool
+  @FocusState private var recordingShortcutFocused: Bool
+
+  /// Single dismissal path: closing the guidance ALWAYS returns focus to the
+  /// control the user was operating, whichever way it was closed.
+  private func dismissGlobeGuidance() {
+    showGlobeGuidance = false
+    recordingShortcutFocused = true
+    guidanceReturnFocus = true
+  }
 
   var body: some View {
     @Bindable var settings = settings
@@ -63,8 +75,34 @@ struct ShortcutsSettingsView: View {
             modifiers: $settings.toggleModifiers,
             defaultKeyCode: ModifierKeyCodes.rightOption,
             defaultModifiers: [],
-            accessibilityLabel: "Recording shortcut"
+            accessibilityLabel: "Recording shortcut",
+            onBindingAccepted: { code, _ in
+              // The claim is owned by SettingsManager, not by this view: onboarding
+              // has a separate completion handler and would otherwise show the same
+              // explanation a second time.
+              if settings.claimGlobeKeyGuidancePresentation(for: code) {
+                showGlobeGuidance = true
+              }
+            }
           )
+          // `.focusable()` is load-bearing, not belt-and-braces (#1987): the
+          // shortcut surface is a plain view with `onTapGesture`, deliberately not
+          // a `Button`, so that a Button does not swallow the key events being
+          // recorded. A non-focusable view accepts no keyboard focus, so binding
+          // `@FocusState` to it alone would set a flag nothing honours and leave a
+          // keyboard user stranded after the popover closed.
+          .focusable()
+          .focused($recordingShortcutFocused)
+          .accessibilityFocused($guidanceReturnFocus)
+          .popover(isPresented: $showGlobeGuidance, arrowEdge: .bottom) {
+            GlobeGuidancePopover(onDismiss: dismissGlobeGuidance)
+              // ONE dismissal path for both "Got it" and Escape (#1987). Relying on
+              // AppKit's implicit Escape handling left focus wherever the popover
+              // had taken it, which strands a keyboard or VoiceOver user: every
+              // unit test still passed while the RSI persona this feature exists
+              // for could be forced back to the pointer.
+              .onExitCommand(perform: dismissGlobeGuidance)
+          }
         }
         .padding(18)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -209,6 +247,9 @@ private struct ProminentHotkeyRow: View {
   let defaultKeyCode: UInt16
   let defaultModifiers: NSEvent.ModifierFlags
   let accessibilityLabel: String
+  /// #1987 — nil on rows that are not the recording shortcut, so only the toggle
+  /// row can ever present the Globe guidance.
+  var onBindingAccepted: ((UInt16, NSEvent.ModifierFlags) -> Void)?
 
   var body: some View {
     HStack(alignment: .center, spacing: 16) {
@@ -226,9 +267,66 @@ private struct ProminentHotkeyRow: View {
         defaultKeyCode: defaultKeyCode,
         defaultModifiers: defaultModifiers,
         label: accessibilityLabel,
-        style: .prominent
+        style: .prominent,
+        onBindingAccepted: { code, mods in onBindingAccepted?(code, mods) }
       )
       .frame(width: 260)
     }
+  }
+}
+
+// MARK: - Globe key guidance (#1987)
+
+/// The one-time "free up the Globe key" explanation, shared by Settings and
+/// onboarding so both surfaces render identical copy.
+///
+/// Accessibility is load-bearing here, not decoration: the persona this feature
+/// exists for is an RSI user whose card demands no modals. Shipping an
+/// ergonomics feature behind a pointer-only dialog would be self-defeating. So the
+/// dismiss control is a real focusable `Button`, the container carries one spoken
+/// label, and the decorative step numbers are hidden from VoiceOver so it reads
+/// the instructions rather than the bullets.
+///
+/// Escape is handled EXPLICITLY by each host through `.onExitCommand`, not by
+/// AppKit's default popover dismissal. The default closes the popover and leaves
+/// focus wherever it had taken it, so a keyboard user is dropped nowhere; the
+/// hosts route both Escape and the button through one dismissal that restores
+/// focus to the shortcut control.
+struct GlobeGuidancePopover: View {
+  let onDismiss: () -> Void
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Text(GlobeKeyCopy.title)
+        .font(.stRowTitle)
+        .foregroundStyle(.stTextPrimary)
+
+      Text(GlobeKeyCopy.body)
+        .settingsReadingCopy()
+
+      VStack(alignment: .leading, spacing: 6) {
+        ForEach(Array(GlobeKeyCopy.steps.enumerated()), id: \.offset) { index, step in
+          HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text("\(index + 1).")
+              .foregroundStyle(.stTextTertiary)
+              .accessibilityHidden(true)
+            Text(step).settingsReadingCopy()
+          }
+        }
+      }
+
+      Text(GlobeKeyCopy.reassurance)
+        .settingsReadingCopy()
+
+      HStack {
+        Spacer()
+        Button(GlobeKeyCopy.dismissButton, action: onDismiss)
+          .keyboardShortcut(.defaultAction)
+      }
+    }
+    .padding(18)
+    .frame(width: 340)
+    .accessibilityElement(children: .contain)
+    .accessibilityLabel(GlobeKeyCopy.accessibilityLabel)
   }
 }

--- a/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
@@ -34,7 +34,7 @@ enum WhatsNewContent {
       icon: "globe",
       title: "Use the Globe key as your dictation shortcut",
       description:
-        "You can now use the Globe (Fn) key as your dictation shortcut. Right Option stays exactly as it is unless you choose Globe. If macOS also opens emoji or switches your keyboard language when you press it, go to System Settings, then Keyboard, then Press Globe key to, and choose Do Nothing.",
+        "You can now use the Globe (Fn) key as your dictation shortcut. Right Option stays exactly as it is unless you choose Globe. If macOS also opens emoji, switches your keyboard language, or starts its own dictation when you press it, go to System Settings, then Keyboard, then Press Globe key to, and choose Do Nothing.",
       version: "2.5.0"
     ),
 

--- a/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
@@ -24,6 +24,15 @@ enum WhatsNewContent {
       version: "2.5.0"
     ),
 
+    Entry(
+      id: "globe-key-dictation-hotkey",
+      icon: "globe",
+      title: "Use the Globe key as your dictation shortcut",
+      description:
+        "You can now use the Globe (Fn) key as your dictation shortcut. Right Option stays exactly as it is unless you choose Globe. If macOS also opens emoji or switches your keyboard language when you press it, go to System Settings, then Keyboard, then Press Globe key to, and choose Do Nothing.",
+      version: "2.5.0"
+    ),
+
     // MARK: - v2.4.3
 
     Entry(

--- a/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
@@ -2,7 +2,12 @@ import EnviousWisprCore
 import Foundation
 
 /// Static "What's New" content, decoupled from the view layer.
-/// Update WhatsNewConstants.currentContentVersion in Core whenever entries change.
+///
+/// The invariant is that the newest group MATCHES `WhatsNewConstants.currentContentVersion`,
+/// not that the constant is bumped whenever entries change. Adding an entry to the
+/// already-open group needs no Core edit; bumping it there would invent a release.
+/// Bump only when starting a group for a version beyond the current one.
+/// `WhatsNewContentTests.newestGroupIsCurrentVersion` enforces the match.
 enum WhatsNewContent {
   struct Entry: Identifiable, Hashable {
     let id: String

--- a/Sources/EnviousWisprServices/HotkeyKeyIdentity.swift
+++ b/Sources/EnviousWisprServices/HotkeyKeyIdentity.swift
@@ -1,0 +1,33 @@
+import AppKit
+
+/// #1987 — which shortcut key a hotkey event belongs to, as a content-free class.
+///
+/// The existing `key_shape` property answers "modifier-only or chord", which puts
+/// the Globe key in the same bucket as Right Option and six other keys. That bucket
+/// cannot answer the only question worth asking after shipping a top-requested
+/// shortcut: did anyone actually choose it.
+///
+/// **Never emit a raw key code.** A key code is closer to keystroke content than
+/// anything belongs in telemetry, and these four classes answer every question we
+/// actually have. Privacy boundary per CLAUDE.md: this is shape, not content, and
+/// no dictated text, transcript, or surrounding document text is involved.
+///
+/// One authority for the vocabulary, so the four values are not re-derived at each
+/// emit site. Adding a ninth standalone key later without adding a case here lands
+/// it in `otherModifier`, which is the correct default and a conscious call rather
+/// than a silent one.
+package enum HotkeyKeyIdentity: String, Sendable {
+  case globe
+  case rightOption = "right_option"
+  case otherModifier = "other_modifier"
+  case chord
+
+  /// Order matters: the two keys we report on by name are checked first, then the
+  /// remaining standalone modifiers, then everything else.
+  package static func classify(keyCode: UInt16) -> Self {
+    if keyCode == ModifierKeyCodes.globe { return .globe }
+    if keyCode == ModifierKeyCodes.rightOption { return .rightOption }
+    if ModifierKeyCodes.isModifierOnly(keyCode) { return .otherModifier }
+    return .chord
+  }
+}

--- a/Sources/EnviousWisprServices/HotkeyKeyIdentity.swift
+++ b/Sources/EnviousWisprServices/HotkeyKeyIdentity.swift
@@ -3,7 +3,8 @@ import AppKit
 /// #1987 — which shortcut key a hotkey event belongs to, as a content-free class.
 ///
 /// The existing `key_shape` property answers "modifier-only or chord", which puts
-/// the Globe key in the same bucket as Right Option and six other keys. That bucket
+/// the Globe key in the same bucket as Right Option and seven other keys, nine
+/// standalone modifiers in all (`ModifierKeyCodes.all`). That bucket
 /// cannot answer the only question worth asking after shipping a top-requested
 /// shortcut: did anyone actually choose it.
 ///
@@ -13,9 +14,9 @@ import AppKit
 /// no dictated text, transcript, or surrounding document text is involved.
 ///
 /// One authority for the vocabulary, so the four values are not re-derived at each
-/// emit site. Adding a ninth standalone key later without adding a case here lands
-/// it in `otherModifier`, which is the correct default and a conscious call rather
-/// than a silent one.
+/// emit site. Globe is the ninth standalone key; adding a TENTH later without
+/// adding a case here lands it in `otherModifier`, which is the correct default
+/// and a conscious call rather than a silent one.
 package enum HotkeyKeyIdentity: String, Sendable {
   case globe
   case rightOption = "right_option"

--- a/Sources/EnviousWisprServices/HotkeyService.swift
+++ b/Sources/EnviousWisprServices/HotkeyService.swift
@@ -737,16 +737,19 @@ public final class HotkeyService {
   /// Processes modifier key changes from pre-extracted values.
   /// Used by the global monitor (which dispatches to main thread with raw values)
   /// and directly by the local monitor via handleFlagsChanged.
-  private func handleFlagsChangedValues(keyCode: UInt16, flags: NSEvent.ModifierFlags) {
+  /// Test seam (#1987): `package` rather than `private` so tests drive the REAL
+  /// modifier dispatch path on a plain import. `internal` would work only through
+  /// `@testable`, which couples the seam to a compilation mode.
+  package func handleFlagsChangedValues(keyCode: UInt16, flags: NSEvent.ModifierFlags) {
     guard !isSuspended else { return }
 
     let currentFlags = flags.intersection(.deviceIndependentFlagsMask)
 
-    // Only process known modifier key codes
-    guard ModifierKeyCodes.isModifierOnly(keyCode) else { return }
+    // Only known standalone modifier key codes; this also supplies the flag, so a
+    // member can never reach the press/release test without one (#1987).
+    guard let flag = ModifierKeyCodes.flag(for: keyCode) else { return }
 
     // Determine press vs. release by checking whether the flag is present
-    let flag = flagForKeyCode(keyCode)
     let isPress = currentFlags.contains(flag)
 
     // Unified shortcut — both modes use toggleKeyCode
@@ -764,16 +767,6 @@ public final class HotkeyService {
     } else {
       // Push-to-talk mode with hands-free support
       handleRecordAction(isPress: isPress)
-    }
-  }
-
-  private func flagForKeyCode(_ keyCode: UInt16) -> NSEvent.ModifierFlags {
-    switch keyCode {
-    case 55, 54: return .command
-    case 58, 61: return .option
-    case 59, 62: return .control
-    case 56, 60: return .shift
-    default: return []
     }
   }
 

--- a/Sources/EnviousWisprServices/HotkeyService.swift
+++ b/Sources/EnviousWisprServices/HotkeyService.swift
@@ -224,7 +224,11 @@ public final class HotkeyService {
     // hands-free actions all ride the toggle key. (Codex code-diff #1.)
     let keyCode = trigger == .cancel ? cancelKeyCode : toggleKeyCode
     let keyShape = ModifierKeyCodes.isModifierOnly(keyCode) ? "modifier_only" : "chord"
-    telemetry.pressed(trigger.rawValue, inputMode, keyShape, action.rawValue)
+    // #1987: same key as key_shape, one level finer. `key_shape` cannot separate
+    // Globe from Right Option because both are modifier-only. Content-free class,
+    // never the key code itself.
+    let keyIdentity = HotkeyKeyIdentity.classify(keyCode: keyCode).rawValue
+    telemetry.pressed(trigger.rawValue, inputMode, keyShape, keyIdentity, action.rawValue)
   }
 
   public func start() {

--- a/Sources/EnviousWisprServices/HotkeyTelemetrySink.swift
+++ b/Sources/EnviousWisprServices/HotkeyTelemetrySink.swift
@@ -23,9 +23,15 @@ public struct HotkeyTelemetrySink: Sendable {
       ->
       Void
   /// A raw accepted hotkey keydown routed to a recording action.
+  ///
+  /// `keyIdentity` (#1987) is the content-free class of the key that produced this
+  /// press: `globe` / `right_option` / `other_modifier` / `chord`. String-typed
+  /// deliberately, because this sink is `public` and `HotkeyKeyIdentity` is
+  /// `package`; callers pass `.rawValue`. Never a raw key code.
   public var pressed:
     @MainActor (
-      _ triggerSource: String, _ inputMode: String, _ keyShape: String, _ pressAction: String
+      _ triggerSource: String, _ inputMode: String, _ keyShape: String, _ keyIdentity: String,
+      _ pressAction: String
     ) -> Void
 
   /// #1631 — a recorded hands-free intent reached a publication decision.
@@ -37,7 +43,7 @@ public struct HotkeyTelemetrySink: Sendable {
 
   public init(
     registrationFailed: @escaping @MainActor (String, String, Int32?, String) -> Void,
-    pressed: @escaping @MainActor (String, String, String, String) -> Void,
+    pressed: @escaping @MainActor (String, String, String, String, String) -> Void,
     lockResolved: @escaping @MainActor (Bool, String) -> Void = { _, _ in }
   ) {
     self.registrationFailed = registrationFailed
@@ -47,7 +53,7 @@ public struct HotkeyTelemetrySink: Sendable {
 
   /// Inert sink — the default for tests and any non-app construction.
   public static let noop = HotkeyTelemetrySink(
-    registrationFailed: { _, _, _, _ in }, pressed: { _, _, _, _ in },
+    registrationFailed: { _, _, _, _ in }, pressed: { _, _, _, _, _ in },
     lockResolved: { _, _ in })
 
   /// Production sink. Registration failure → PostHog breakdown + Sentry handled
@@ -70,7 +76,7 @@ public struct HotkeyTelemetrySink: Sendable {
         // toggle conflict and a dead NSEvent monitor are distinct issues.
         fingerprintDetail: "\(mechanism)/\(hotkeyKind)")
     },
-    pressed: { triggerSource, inputMode, keyShape, pressAction in
+    pressed: { triggerSource, inputMode, keyShape, keyIdentity, pressAction in
       // `DispatchQueue.main.async` (NOT `Task { @MainActor }`, which may run on the
       // current cycle — gotchas-audio `dispatch-main-for-runloop-deferral`) defers
       // the PostHog enqueue-write to the next run loop so the input-press turn does
@@ -80,7 +86,7 @@ public struct HotkeyTelemetrySink: Sendable {
         MainActor.assumeIsolated {
           TelemetryService.shared.hotkeyPressed(
             triggerSource: triggerSource, inputMode: inputMode,
-            keyShape: keyShape, pressAction: pressAction)
+            keyShape: keyShape, keyIdentity: keyIdentity, pressAction: pressAction)
         }
       }
     },

--- a/Sources/EnviousWisprServices/KeySymbols.swift
+++ b/Sources/EnviousWisprServices/KeySymbols.swift
@@ -11,17 +11,44 @@ public enum ModifierKeyCodes {
   public static let rightShift: UInt16 = 60
   public static let leftControl: UInt16 = 59
   public static let rightControl: UInt16 = 62
+  /// The Globe / Fn key (`kVK_Function`). Measured on real hardware (#1987): it
+  /// emits `.flagsChanged` with `.function` present on press and absent on
+  /// release, seen by the same NSEvent monitors the other eight use.
+  package static let globe: UInt16 = 63
 
-  public static let all: Set<UInt16> = [
-    leftCommand, rightCommand,
-    leftOption, rightOption,
-    leftShift, rightShift,
-    leftControl, rightControl,
+  /// The ONE mapping of standalone modifier key code to the flag it sets while held.
+  ///
+  /// Membership and flag are the same fact, so they are stored once. Before #1987
+  /// this fact lived in two private switches, one on the dispatch path and one on
+  /// the capture view, plus a separately maintained membership list, so adding a
+  /// key meant remembering all three. Deriving
+  /// membership from the mapping makes "a member with no flag" unrepresentable
+  /// rather than merely guarded: that state would make `flags.contains(flag)` true
+  /// on release as well as press, so push-to-talk would start recording and never
+  /// stop.
+  private static let flagsByKeyCode: [UInt16: NSEvent.ModifierFlags] = [
+    leftCommand: .command, rightCommand: .command,
+    leftOption: .option, rightOption: .option,
+    leftShift: .shift, rightShift: .shift,
+    leftControl: .control, rightControl: .control,
+    globe: .function,
   ]
+
+  public static let all: Set<UInt16> = Set(flagsByKeyCode.keys)
 
   /// Returns true if the given key code is a standalone modifier key.
   public static func isModifierOnly(_ keyCode: UInt16) -> Bool {
-    all.contains(keyCode)
+    flagsByKeyCode[keyCode] != nil
+  }
+
+  /// The modifier flag this standalone key sets while held, or nil if the key code
+  /// is not a standalone modifier.
+  ///
+  /// Optional by design. An empty-set return would be indistinguishable from a real
+  /// flag to `OptionSet.contains`, which is a superset test: `anything.contains([])`
+  /// is always true.
+  package static func flag(for keyCode: UInt16) -> NSEvent.ModifierFlags? {
+    flagsByKeyCode[keyCode]
   }
 
 }
@@ -140,6 +167,22 @@ public enum KeySymbols {
     format(keyCode: keyCode, modifiers: modifiers)
   }
 
+  /// Spoken projection of a shortcut, for accessibility VALUES only.
+  ///
+  /// Separate from `format` because the visible label leads with an emoji, and a
+  /// screen reader announcing "globe showing Europe-Africa Globe (Fn)" is worse
+  /// than useless to the person this key most helps. Presentation-only: nothing
+  /// may key behaviour off the returned string.
+  package static func accessibilityDescription(
+    keyCode: UInt16,
+    modifiers: NSEvent.ModifierFlags
+  ) -> String {
+    if keyCode == ModifierKeyCodes.globe {
+      return "Globe or Function key"
+    }
+    return format(keyCode: keyCode, modifiers: modifiers)
+  }
+
   /// Format just modifiers for push-to-talk display.
   /// When a keyCode is provided the label distinguishes left vs. right physical keys.
   public static func formatModifierOnly(_ flags: NSEvent.ModifierFlags, keyCode: UInt16? = nil)
@@ -155,6 +198,12 @@ public enum KeySymbols {
       case 60: return "Right ⇧"
       case 59: return "Left ⌃"
       case 62: return "Right ⌃"
+      // The Globe key is a single physical key, so unlike the eight above it
+      // carries no Left/Right qualifier. Both names are deliberate: macOS System
+      // Settings calls it the globe key and draws 🌐, which is what our setup
+      // guidance tells the user to look for, while "Fn" is what is printed on the
+      // keyboard and what users arrive saying from other dictation apps.
+      case 63: return "🌐 Globe (Fn)"
       default: break
       }
     }

--- a/Sources/EnviousWisprServices/SettingsManager.swift
+++ b/Sources/EnviousWisprServices/SettingsManager.swift
@@ -104,9 +104,11 @@ public final class SettingsManager {
   /// Claim the right to present the Globe-key guidance, exactly once per install.
   ///
   /// Lives here rather than in a view because Settings and onboarding do NOT share
-  /// bind-completion logic — they share only the capture view — so a per-surface
-  /// flag would show the explanation twice, or show it in one surface and never the
-  /// other. `SettingsManager` already owns the shared `UserDefaults` store both
+  /// bind-completion logic. They share the capture view and, since #1987, the
+  /// `HotkeyCapture` acceptance authority; what remains separate is what each does
+  /// AFTER a bind is accepted, which is exactly where this decision sits. So a
+  /// per-surface flag would show the explanation twice, or show it in one surface
+  /// and never the other. `SettingsManager` already owns the shared `UserDefaults` store both
   /// surfaces write through, which makes it the one place the answer can be
   /// consistent.
   ///

--- a/Sources/EnviousWisprServices/SettingsManager.swift
+++ b/Sources/EnviousWisprServices/SettingsManager.swift
@@ -86,7 +86,41 @@ public final class SettingsManager {
     "useStreamingASR", "warmEnginePolicy", "appearancePreference", "overlayPillPosition",
     "showBluetoothTips", "playRecordingSounds", "recordingSoundPairing",
     WhatsNewConstants.lastSeenVersionDefaultsKey,
+    globeGuidanceClaimKey,
   ]
+
+  // MARK: - Globe key guidance (#1987)
+
+  /// Not a user setting: a once-per-installation record that the "free up the
+  /// Globe key" explanation has been shown. Deliberately not in `SettingKey`, so
+  /// it emits no settings delta and appears in no snapshot.
+  ///
+  /// `unifiedDefaultsKeys` references this constant rather than repeating the
+  /// string. Written twice, the claim could migrate under one name while the
+  /// build-unification list carried the other, and the user would be re-shown the
+  /// explanation after an update with every test still green.
+  private nonisolated static let globeGuidanceClaimKey = "hasClaimedGlobeKeyGuidance"
+
+  /// Claim the right to present the Globe-key guidance, exactly once per install.
+  ///
+  /// Lives here rather than in a view because Settings and onboarding do NOT share
+  /// bind-completion logic — they share only the capture view — so a per-surface
+  /// flag would show the explanation twice, or show it in one surface and never the
+  /// other. `SettingsManager` already owns the shared `UserDefaults` store both
+  /// surfaces write through, which makes it the one place the answer can be
+  /// consistent.
+  ///
+  /// Returns true to exactly ONE caller, ever. Both binding surfaces call it after
+  /// a successful bind and only the caller receiving true presents the popover.
+  /// A non-Globe key does NOT consume the claim, so a user who binds Right Option
+  /// first still gets the explanation when they later choose Globe.
+  @discardableResult
+  package func claimGlobeKeyGuidancePresentation(for keyCode: UInt16) -> Bool {
+    guard keyCode == ModifierKeyCodes.globe else { return false }
+    guard !defaults.bool(forKey: Self.globeGuidanceClaimKey) else { return false }
+    defaults.set(true, forKey: Self.globeGuidanceClaimKey)
+    return true
+  }
 
   public var selectedBackend: ASRBackendType {
     didSet {

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -1908,26 +1908,6 @@ public final class TelemetryService {
     accessibilityWarningDismissed: Bool,
     config: [String: String] = [:]
   ) {
-    #if DEBUG
-      var hookStrings: [String: String] = [
-        "asr_backend": asrBackend,
-        "llm_provider": llmProvider,
-        "recording_mode": recordingMode,
-        "microphone_status": microphoneStatus,
-        "accessibility_status": accessibilityStatus,
-      ]
-      hookStrings.merge(config) { _, new in new }
-      testEventHook?(
-        CapturedTelemetryEvent(
-          name: "settings.snapshot",
-          stringProps: hookStrings,
-          intProps: ["custom_words_count": customWordsCount],
-          boolProps: [
-            "filler_removal": fillerRemoval,
-            "has_api_keys": hasApiKeys,
-            "accessibility_warning_dismissed": accessibilityWarningDismissed,
-          ]))
-    #endif
     var props: [String: Any] = [
       "asr_backend": asrBackend,
       "llm_provider": llmProvider,
@@ -1940,6 +1920,19 @@ public final class TelemetryService {
       "accessibility_warning_dismissed": accessibilityWarningDismissed,
     ]
     props.merge(config) { _, new in new }
+    #if DEBUG
+      // #1987: DERIVED from `props`, never re-listed. The previous shape built the
+      // test projection independently of the shipped payload, so a test could
+      // assert a property the real event did not carry, and every new `config` key
+      // had to be remembered twice. Split by value type to keep the existing
+      // string/int/bool capture shape.
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "settings.snapshot",
+          stringProps: props.compactMapValues { $0 as? String },
+          intProps: props.compactMapValues { $0 as? Int },
+          boolProps: props.compactMapValues { $0 as? Bool }))
+    #endif
     PostHogSDK.shared.capture("settings.snapshot", properties: props)
   }
 
@@ -1952,25 +1945,19 @@ public final class TelemetryService {
   /// codes). Onboarding-time writes are suppressed (the onboarding-completion
   /// baseline captures the final state).
   public func settingsChanged(setting: String, from: String, to: String, source: String) {
+    let props: [String: Any] = [
+      "setting": setting,
+      "from": from,
+      "to": to,
+      "source": source,
+    ]
     #if DEBUG
+      // #1987: derived from the same dictionary PostHog receives.
       testEventHook?(
         CapturedTelemetryEvent(
-          name: "settings.changed",
-          stringProps: [
-            "setting": setting,
-            "from": from,
-            "to": to,
-            "source": source,
-          ]))
+          name: "settings.changed", stringProps: props.compactMapValues { $0 as? String }))
     #endif
-    PostHogSDK.shared.capture(
-      "settings.changed",
-      properties: [
-        "setting": setting,
-        "from": from,
-        "to": to,
-        "source": source,
-      ])
+    PostHogSDK.shared.capture("settings.changed", properties: props)
   }
 
   /// #1635: the WhisperKit setup row's "getting the model ready" copy genuinely entered the

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -463,20 +463,21 @@ public final class TelemetryService {
   /// denominator for `dictation.invoked` (which fires post-commit and under-fires
   /// raw presses). Metadata only (low-cardinality enums; never the key codes).
   public func hotkeyPressed(
-    triggerSource: String, inputMode: String, keyShape: String, pressAction: String
+    triggerSource: String, inputMode: String, keyShape: String, keyIdentity: String,
+    pressAction: String
   ) {
     let props: [String: Any] = [
       "trigger_source": triggerSource, "input_mode": inputMode,
-      "key_shape": keyShape, "press_action": pressAction,
+      "key_shape": keyShape, "key_identity": keyIdentity, "press_action": pressAction,
     ]
     #if DEBUG
+      // #1987: DERIVED from `props`, never re-listed. The previous shape built the
+      // test projection independently of the real payload, so a test could assert a
+      // property the shipped event did not actually carry. A verifier that
+      // re-implements its subject proves only that the copy works.
       testEventHook?(
         CapturedTelemetryEvent(
-          name: "hotkey.pressed",
-          stringProps: [
-            "trigger_source": triggerSource, "input_mode": inputMode,
-            "key_shape": keyShape, "press_action": pressAction,
-          ]))
+          name: "hotkey.pressed", stringProps: props.compactMapValues { $0 as? String }))
     #endif
     PostHogSDK.shared.capture("hotkey.pressed", properties: props)
   }

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -475,9 +475,20 @@ public final class TelemetryService {
       // test projection independently of the real payload, so a test could assert a
       // property the shipped event did not actually carry. A verifier that
       // re-implements its subject proves only that the copy works.
+      //
+      // Every typed bucket is projected, not just strings. Projecting only
+      // `stringProps` makes an integer leak INVISIBLE to the privacy test: adding
+      // `props["key_code"] = 63` would reach PostHog while the hook silently
+      // dropped it, leaving a test named "no raw key code" green. The settings
+      // snapshot already checked the union; this is its twin, fixed after the
+      // integration audit found the class had been closed on one side only.
       testEventHook?(
         CapturedTelemetryEvent(
-          name: "hotkey.pressed", stringProps: props.compactMapValues { $0 as? String }))
+          name: "hotkey.pressed",
+          stringProps: props.compactMapValues { $0 as? String },
+          intProps: props.compactMapValues { $0 as? Int },
+          doubleProps: props.compactMapValues { $0 as? Double },
+          boolProps: props.compactMapValues { $0 as? Bool }))
     #endif
     PostHogSDK.shared.capture("hotkey.pressed", properties: props)
   }

--- a/Tests/EnviousWisprTests/App/SettingsChangeTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/App/SettingsChangeTelemetryTests.swift
@@ -73,6 +73,179 @@ import Testing
       #expect(SettingsProjection.value(for: .smartInsertion, settings: settings) == "off")
     }
 
+    // MARK: - #1987 toggle hotkey identity fan-out
+
+    @Test("Binding the Globe key emits an identity delta while shape stays a no-op")
+    func globeBindEmitsShapeAndIdentity() {
+      let (settings, telemetry, box, _) = makeHarness()
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      settings.toggleKeyCode = ModifierKeyCodes.globe
+      telemetry.flush()
+
+      let identity = deltas(box, setting: "toggle_hotkey_identity")
+      #expect(identity.count == 1)
+      #expect(identity.first?.stringProps["from"] == "right_option")
+      #expect(identity.first?.stringProps["to"] == "globe")
+      // Shape is unchanged: both keys are modifier-only. That is precisely why
+      // identity had to exist, so assert the shape delta is SUPPRESSED as a no-op
+      // rather than merely absent by accident.
+      #expect(deltas(box, setting: "toggle_hotkey_shape").isEmpty)
+    }
+
+    /// The two logicals must coalesce and suppress independently. A chord bind
+    /// changes both, so both must emit.
+    @Test("Binding a chord key emits both shape and identity deltas")
+    func chordBindEmitsBoth() {
+      let (settings, telemetry, box, _) = makeHarness()
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      settings.toggleKeyCode = 0  // 'A', a chord key
+      telemetry.flush()
+
+      let shape = deltas(box, setting: "toggle_hotkey_shape")
+      let identity = deltas(box, setting: "toggle_hotkey_identity")
+      #expect(shape.count == 1)
+      #expect(shape.first?.stringProps["to"] == "chord")
+      #expect(identity.count == 1)
+      #expect(identity.first?.stringProps["to"] == "chord")
+    }
+
+    @Test("A→B→A on the toggle key is a net no-op for both logicals")
+    func toggleKeyNetNoOpSuppressesBoth() {
+      let (settings, telemetry, box, _) = makeHarness()
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      settings.toggleKeyCode = ModifierKeyCodes.globe
+      settings.toggleKeyCode = ModifierKeyCodes.rightOption  // back to the default
+      telemetry.flush()
+
+      #expect(deltas(box, setting: "toggle_hotkey_identity").isEmpty)
+      #expect(deltas(box, setting: "toggle_hotkey_shape").isEmpty)
+    }
+
+    /// Guards the "shape-only" instruction: push-to-talk and cancel must NOT gain
+    /// identity telemetry, so a fan-out written for the toggle key cannot leak.
+    @Test("Push-to-talk and cancel hotkeys remain shape-only")
+    func otherHotkeyRolesStayShapeOnly() {
+      let (settings, telemetry, box, _) = makeHarness()
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      settings.pushToTalkKeyCode = ModifierKeyCodes.globe
+      settings.cancelKeyCode = 0
+      telemetry.flush()
+
+      #expect(box.all.allSatisfy { $0.stringProps["setting"] != "push_to_talk_hotkey_identity" })
+      #expect(box.all.allSatisfy { $0.stringProps["setting"] != "cancel_hotkey_identity" })
+      #expect(deltas(box, setting: "toggle_hotkey_identity").isEmpty)
+    }
+
+    /// The routing contract itself, asserted exactly. The grouped delta tests
+    /// below pass even if `.toggleModifiers` silently loses identity, because a
+    /// key-code write in the same window already enqueued it.
+    @Test("Both toggle raw keys route to exactly shape and identity")
+    func toggleKeysRouteToBothLogicals() {
+      #expect(
+        SettingsProjection.logicals(for: .toggleKeyCode)
+          == [.toggleHotkeyShape, .toggleHotkeyIdentity])
+      #expect(
+        SettingsProjection.logicals(for: .toggleModifiers)
+          == [.toggleHotkeyShape, .toggleHotkeyIdentity])
+    }
+
+    @Test("Other hotkey roles route to shape only, and uninstrumented keys to nothing")
+    func otherKeysRoutingUnchanged() {
+      #expect(SettingsProjection.logicals(for: .pushToTalkKeyCode) == [.pushToTalkHotkeyShape])
+      #expect(SettingsProjection.logicals(for: .pushToTalkModifiers) == [.pushToTalkHotkeyShape])
+      #expect(SettingsProjection.logicals(for: .cancelKeyCode) == [.cancelHotkeyShape])
+      #expect(SettingsProjection.logicals(for: .cancelModifiers) == [.cancelHotkeyShape])
+      #expect(SettingsProjection.logicals(for: .llmModel) == [.llmModel])
+      #expect(SettingsProjection.logicals(for: .ollamaModel) == [.llmModel])
+      #expect(SettingsProjection.logicals(for: .selectedBackend).isEmpty)
+    }
+
+    /// Discriminates the onboarding fan-out: the suppression branch must clear
+    /// pending state and advance the baseline for EVERY returned logical. If that
+    /// loop handled only the first, the stale second logical would emit here.
+    @Test("Onboarding suppression clears pending state for both toggle logicals")
+    func onboardingSuppressionClearsBothLogicals() {
+      let (settings, telemetry, box, _) = makeHarness()
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      // Create pending deltas on both toggle logicals while completed.
+      settings.toggleKeyCode = 0  // chord: changes shape AND identity
+      // Now drop back into onboarding and write a DIFFERENT identity.
+      settings.onboardingState = .settingUp
+      settings.toggleKeyCode = ModifierKeyCodes.globe
+      telemetry.flush()
+
+      #expect(deltas(box, setting: "toggle_hotkey_shape").isEmpty)
+      #expect(deltas(box, setting: "toggle_hotkey_identity").isEmpty)
+    }
+
+    /// Snapshot proof through the REAL emit path, not a `snapshotConfig`
+    /// reconstruction: `StandingSnapshotBuilder.emit()` -> `settingsSnapshot(...)`
+    /// -> the DEBUG hook, whose projection is now derived from the same dictionary
+    /// PostHog receives.
+    @MainActor
+    @Test("The real settings.snapshot carries toggle_hotkey_identity and no raw key code")
+    func realSnapshotCarriesIdentity() {
+      let suite = UserDefaults(suiteName: "SCT-snap-\(UUID().uuidString)")!
+      let settings = SettingsManager(defaults: suite)
+      let previousHook = TelemetryService.shared.testEventHook
+      defer { TelemetryService.shared.testEventHook = previousHook }
+
+      // The hook is `@Sendable`, so the capture cannot be a local `var`. A locked
+      // box is the same shape `StandingSnapshotBuilderTests` already uses.
+      final class Box: @unchecked Sendable {
+        private let lock = NSLock()
+        private var stored: CapturedTelemetryEvent?
+        func set(_ e: CapturedTelemetryEvent) { lock.withLock { stored = e } }
+        var value: CapturedTelemetryEvent? { lock.withLock { stored } }
+      }
+
+      func emitSnapshot() -> CapturedTelemetryEvent? {
+        let box = Box()
+        TelemetryService.shared.testEventHook = { @Sendable event in
+          if event.name == "settings.snapshot" { box.set(event) }
+        }
+        StandingSnapshotBuilder(
+          settings: settings,
+          keychainManager: KeychainManager(),
+          customWordsCoordinator: CustomWordsCoordinator(),
+          permissions: PermissionsService(accessibilityReader: { true })
+        ).emit()
+        return box.value
+      }
+
+      // Default install: the shipped default is Right Option, so a snapshot taken
+      // before any bind must say so. Without this, a classifier that returned
+      // `globe` unconditionally would still pass the Globe case below.
+      let atDefault = emitSnapshot()
+      #expect(atDefault?.stringProps["toggle_hotkey_identity"] == "right_option")
+
+      settings.toggleKeyCode = ModifierKeyCodes.globe
+      let afterBind = emitSnapshot()
+      #expect(afterBind?.stringProps["toggle_hotkey_identity"] == "globe")
+      #expect(afterBind?.stringProps["toggle_hotkey_shape"] == "modifier_only")
+
+      // The privacy boundary needs EVERY bucket checked, not just one value and
+      // not just the string bucket. Asserting "globe" has no digit would miss a
+      // separate `toggle_key_code` property beside it, and checking only
+      // `stringProps` would miss it too, because a raw key code is an Int and
+      // lands in `intProps`.
+      let allKeys =
+        Set((afterBind?.stringProps ?? [:]).keys)
+        .union((afterBind?.intProps ?? [:]).keys)
+        .union((afterBind?.doubleProps ?? [:]).keys)
+        .union((afterBind?.boolProps ?? [:]).keys)
+      #expect(!allKeys.contains("key_code"))
+      #expect(!allKeys.contains("toggle_key_code"))
+      #expect(
+        allKeys.allSatisfy { !$0.contains("key_code") },
+        "no snapshot property in any bucket may carry a raw key code")
+    }
+
     @Test("A→B→A net no-op emits nothing")
     func noOpBurst() {
       let (settings, telemetry, box, _) = makeHarness()

--- a/Tests/EnviousWisprTests/Services/HotkeyGlobeKeyTests.swift
+++ b/Tests/EnviousWisprTests/Services/HotkeyGlobeKeyTests.swift
@@ -96,12 +96,16 @@ import Testing
     var cancels = 0
     var toggles = 0
     var actions: [String] = []
+    var identities: [String] = []
     let toggleWaiter = CallbackWaiter()
 
     var sink: HotkeyTelemetrySink {
       HotkeyTelemetrySink(
         registrationFailed: { _, _, _, _ in },
-        pressed: { [weak self] _, _, _, action in self?.actions.append(action) },
+        pressed: { [weak self] _, _, _, identity, action in
+          self?.actions.append(action)
+          self?.identities.append(identity)
+        },
         lockResolved: { _, _ in })
     }
   }
@@ -308,6 +312,55 @@ import Testing
     press(service)
     await spy.toggleWaiter.wait(until: 2)
     #expect(spy.toggles == 2, "a second tap must toggle recording off")
+  }
+
+  // MARK: - Telemetry identity (#1987 chunk 2)
+
+  @Test("A Globe press reports key_identity=globe alongside the existing key_shape")
+  func globePressReportsIdentity() async {
+    let spy = Spy()
+    let clock = ManualClock()
+    let service = makeService(spy, clock: clock)
+
+    press(service)
+    await settle(service)
+
+    #expect(spy.identities == ["globe"])
+    #expect(spy.actions == ["start"], "identity must not change which action is reported")
+  }
+
+  /// The whole point of the property: `key_shape` is `modifier_only` for BOTH keys,
+  /// so only identity can tell adoption of the new key from the old default.
+  @Test("Right Option reports a different identity than Globe for the same shape")
+  func rightOptionReportsDistinctIdentity() async {
+    let spy = Spy()
+    let clock = ManualClock()
+    let service = makeService(spy, clock: clock)
+    service.toggleKeyCode = ModifierKeyCodes.rightOption
+
+    service.handleFlagsChangedValues(keyCode: ModifierKeyCodes.rightOption, flags: [.option])
+    await settle(service)
+
+    #expect(spy.identities == ["right_option"])
+  }
+
+  @Test("Every emitted identity is one of the four classes and never a key code")
+  func identitiesAreAlwaysClassified() async {
+    let spy = Spy()
+    let clock = ManualClock()
+    let service = makeService(spy, clock: clock)
+
+    press(service)
+    await settle(service)
+    release(service)
+    clock.advance(ms: 120)
+    press(service)  // lock
+
+    #expect(!spy.identities.isEmpty)
+    for identity in spy.identities {
+      #expect(["globe", "right_option", "other_modifier", "chord"].contains(identity))
+      #expect(identity.rangeOfCharacter(from: .decimalDigits) == nil)
+    }
   }
 
   // MARK: - Negative controls

--- a/Tests/EnviousWisprTests/Services/HotkeyGlobeKeyTests.swift
+++ b/Tests/EnviousWisprTests/Services/HotkeyGlobeKeyTests.swift
@@ -1,0 +1,378 @@
+import AppKit
+import EnviousWisprCore
+import EnviousWisprServices
+import Foundation
+import Testing
+
+/// #1987 — the Globe / Fn key behaves exactly like Right Option.
+///
+/// Every case drives the REAL modifier dispatch path, `handleFlagsChangedValues`,
+/// with the physical event shape measured on hardware (probe, 2026-08-08): press
+/// carries `.function`, release does not, and both arrive as `.flagsChanged` with
+/// key code 63. A suite that asserted set membership instead would prove the key
+/// is *accepted* and nothing at all about what pressing it does.
+///
+/// THREE MECHANISMS THIS SUITE GOT WRONG FIRST, recorded because each produced a
+/// failure that read like a production bug:
+///
+/// 1. A QUICK release does not stop recording. Releasing within 500 ms of the
+///    start arms a real debounce timer and waits to see whether a double-press
+///    follows (`handleRecordRelease`). Only a release after holding LONGER than
+///    that stops immediately. So a hold-to-talk case must actually hold, by
+///    advancing the pinned clock before releasing.
+/// 2. The fake must model `onLockRequested`. Production asks the app whether the
+///    hands-free lock can be published and calls `performCleanup()` on
+///    `.unavailable`; a nil callback DEFAULTS to `.unavailable`, so the service
+///    correctly destroyed the session and three gestures failed as though
+///    hands-free were broken.
+/// 3. Counting `Task.yield()` turns is a scheduling assumption, not a signal, and
+///    is flaky in both directions. Starts, stops and cancels are now awaited
+///    through the service's own `awaitInFlightStartForTesting()` seam.
+///
+/// The clock is pinned throughout for the same reason the hands-free suite pins
+/// it: the windows are measured in elapsed wall time, so an unpinned test takes
+/// whichever branch the scheduler happens to allow.
+@MainActor
+@Suite struct HotkeyGlobeKeyTests {
+
+  @MainActor final class ManualClock {
+    private(set) var now = Date(timeIntervalSince1970: 2_000_000)
+    func advance(ms: Int) { now = now.addingTimeInterval(Double(ms) / 1000.0) }
+  }
+
+  /// Signal-driven wait for a callback that has no task to await.
+  ///
+  /// The callback IS the signal; the deadline exists only so a regression fails
+  /// loudly instead of hanging CI with no failing test name. An earlier version
+  /// counted `Task.yield()` turns, which is a scheduling assumption in disguise
+  /// and flaky in both directions on a loaded machine.
+  @MainActor final class CallbackWaiter {
+    private struct Pending {
+      let id: UUID
+      let target: Int
+      let continuation: CheckedContinuation<Void, Never>
+    }
+
+    private var count = 0
+    private var pending: Pending?
+
+    func note() {
+      count += 1
+      guard let pending, count >= pending.target else { return }
+      self.pending = nil
+      pending.continuation.resume()
+    }
+
+    func wait(until target: Int, timeout: Duration = .seconds(5)) async {
+      if count >= target { return }
+      let id = UUID()
+      let timeoutTask = Task { @MainActor [weak self] in
+        // settle: deadline fallback AROUND the callback signal, never the wait
+        // itself. The callback resumes the continuation and cancels this task;
+        // this exists only so a regression fails loudly instead of hanging.
+        try? await Task.sleep(for: timeout)
+        self?.expire(id: id)
+      }
+      await withCheckedContinuation { continuation in
+        pending = Pending(id: id, target: target, continuation: continuation)
+      }
+      timeoutTask.cancel()
+    }
+
+    private func expire(id: UUID) {
+      guard let pending, pending.id == id else { return }
+      self.pending = nil
+      Issue.record(Comment(rawValue: "timed out waiting for callback count \(pending.target)"))
+      pending.continuation.resume()
+    }
+  }
+
+  /// Counts what the service asked the app to do. Start resolves immediately as a
+  /// live session: these cases are about gesture routing, not the start-acceptance
+  /// race that `HotkeyHandsFreeLockGateTests` already owns.
+  @MainActor final class Spy {
+    var starts = 0
+    var stops = 0
+    var cancels = 0
+    var toggles = 0
+    var actions: [String] = []
+    let toggleWaiter = CallbackWaiter()
+
+    var sink: HotkeyTelemetrySink {
+      HotkeyTelemetrySink(
+        registrationFailed: { _, _, _, _ in },
+        pressed: { [weak self] _, _, _, action in self?.actions.append(action) },
+        lockResolved: { _, _ in })
+    }
+  }
+
+  private func makeService(
+    _ spy: Spy, clock: ManualClock, mode: RecordingMode = .pushToTalk
+  ) -> HotkeyService {
+    let service = HotkeyService(telemetry: spy.sink, now: { clock.now })
+    service.recordingMode = mode
+    service.toggleKeyCode = ModifierKeyCodes.globe
+    service.onStartRecording = { [weak spy] in
+      spy?.starts += 1
+      return .recording("globe-session")
+    }
+    // Production asks the app whether the hands-free lock can actually be
+    // published, and tears the whole session down if the answer is no
+    // (`publishLockIfReady` -> `.unavailable` -> `performCleanup`). A spy that
+    // leaves this nil defaults to `.unavailable`, so the service correctly
+    // destroyed the recording and three gesture cases failed as though hands-free
+    // were broken. The fake must model the guard, not omit it.
+    service.onLockRequested = { _ in .published }
+    service.onStopRecording = { [weak spy] in spy?.stops += 1 }
+    service.onCancelRecording = { [weak spy] in spy?.cancels += 1 }
+    service.onToggleRecording = { [weak spy] in
+      spy?.toggles += 1
+      spy?.toggleWaiter.note()
+    }
+    return service
+  }
+
+  /// The measured press shape. `.function` present means held.
+  private func press(_ service: HotkeyService, keyCode: UInt16 = ModifierKeyCodes.globe) {
+    service.handleFlagsChangedValues(keyCode: keyCode, flags: [.function])
+  }
+
+  /// The measured release shape. The flag is gone.
+  private func release(_ service: HotkeyService, keyCode: UInt16 = ModifierKeyCodes.globe) {
+    service.handleFlagsChangedValues(keyCode: keyCode, flags: [])
+  }
+
+  /// The service's own deterministic seam (`HotkeyService.swift:378`). Start,
+  /// stop and cancel each replace `recordingTask` synchronously before returning,
+  /// so awaiting it observes the callback rather than guessing a scheduling turn.
+  /// Under the flag mutation it returns immediately because no task exists, so
+  /// assertions fail instead of hanging.
+  private func settle(_ service: HotkeyService) async {
+    await service.awaitInFlightStartForTesting()
+  }
+
+  // MARK: - Gesture 1: hold to talk
+
+  @Test("Holding past the debounce window and releasing records once and stops once")
+  func pushToTalkHoldAndRelease() async {
+    let spy = Spy()
+    let clock = ManualClock()
+    let service = makeService(spy, clock: clock)
+
+    press(service)
+    await settle(service)
+    #expect(spy.starts == 1)
+    #expect(spy.stops == 0, "recording must not stop while the key is still held")
+
+    clock.advance(ms: 800)  // a genuine hold, past the double-press window
+    release(service)
+    await settle(service)
+
+    #expect(spy.starts == 1)
+    #expect(spy.stops == 1)
+    #expect(spy.cancels == 0)
+  }
+
+  /// The specific failure the derived-membership design exists to prevent. If the
+  /// Globe key were a member with no flag, `contains([])` would be true on the
+  /// release event too, so release would read as a second PRESS and recording
+  /// would never stop. This is the case the mutation control drives RED.
+  @Test("Release is distinguishable from press, so recording can actually stop")
+  func releaseIsNotReadAsPress() async {
+    let spy = Spy()
+    let clock = ManualClock()
+    let service = makeService(spy, clock: clock)
+
+    press(service)
+    await settle(service)
+    clock.advance(ms: 800)
+    release(service)
+    await settle(service)
+
+    #expect(spy.stops == 1, "release did not stop the recording")
+    #expect(spy.starts == 1, "release was misread as a second press")
+    #expect(spy.actions == ["start"], "a misread release would emit a second start")
+  }
+
+  // MARK: - Gesture 2: double press enters hands-free
+
+  @Test("Double press inside the window locks hands-free instead of stopping")
+  func doublePressEntersHandsFree() async {
+    let spy = Spy()
+    let clock = ManualClock()
+    let service = makeService(spy, clock: clock)
+
+    press(service)
+    await settle(service)
+    release(service)  // quick release, arms the debounce
+    clock.advance(ms: 120)
+    press(service)  // inside the window
+    await settle(service)
+
+    #expect(spy.actions.contains("lock"), "second press did not request hands-free")
+    #expect(spy.stops == 0, "hands-free entry must not stop the recording")
+    #expect(spy.starts == 1, "the second press must not start a new recording")
+  }
+
+  // MARK: - The lock cooldown
+
+  @Test("A press inside the lock cooldown is ignored, not treated as a stop")
+  func pressInsideCooldownIsIgnored() async {
+    let spy = Spy()
+    let clock = ManualClock()
+    let service = makeService(spy, clock: clock)
+
+    press(service)
+    await settle(service)
+    release(service)
+    clock.advance(ms: 450)
+    press(service)  // locks, still inside the 500 ms start window
+    await settle(service)
+    release(service)
+
+    // Past the start window, but inside the 500 ms cooldown that follows the lock.
+    clock.advance(ms: 150)
+    press(service)
+    await settle(service)
+
+    #expect(spy.actions.contains("ignored_cooldown"))
+    #expect(spy.stops == 0)
+    #expect(spy.cancels == 0)
+  }
+
+  // MARK: - Gesture 3: single press after the cooldown stops hands-free
+
+  @Test("A press after the cooldown stops hands-free exactly once")
+  func singlePressAfterCooldownStops() async {
+    let spy = Spy()
+    let clock = ManualClock()
+    let service = makeService(spy, clock: clock)
+
+    press(service)
+    await settle(service)
+    release(service)
+    clock.advance(ms: 450)
+    press(service)  // locks
+    await settle(service)
+    release(service)
+
+    clock.advance(ms: 900)  // past both the start window and the lock cooldown
+    press(service)
+    await settle(service)
+
+    #expect(spy.stops == 1)
+    #expect(spy.actions.contains("stop"))
+    #expect(spy.cancels == 0)
+  }
+
+  // MARK: - Gesture 4: triple press cancels
+
+  @Test("Triple press inside the window cancels hands-free and delivers nothing")
+  func triplePressCancels() async {
+    let spy = Spy()
+    let clock = ManualClock()
+    let service = makeService(spy, clock: clock)
+
+    press(service)
+    await settle(service)
+    release(service)
+    clock.advance(ms: 100)
+    press(service)  // locks
+    await settle(service)
+    release(service)
+    clock.advance(ms: 100)
+    press(service)  // third press, still inside the start window
+    await settle(service)
+
+    #expect(spy.cancels == 1)
+    #expect(spy.stops == 0, "a cancel must not also deliver the recording")
+    #expect(spy.actions.contains("cancel"))
+  }
+
+  // MARK: - Gesture 5: toggle mode
+
+  @Test("Toggle mode acts on press and ignores release")
+  func toggleModeActsOnPressOnly() async {
+    let spy = Spy()
+    let service = makeService(spy, clock: ManualClock(), mode: .toggle)
+
+    // Toggle mode never creates a recording task, so the start seam is not the
+    // signal here; the toggle callback itself is.
+    press(service)
+    await spy.toggleWaiter.wait(until: 1)
+    #expect(spy.toggles == 1)
+
+    release(service)
+    #expect(spy.toggles == 1, "release must not toggle a second time")
+
+    press(service)
+    await spy.toggleWaiter.wait(until: 2)
+    #expect(spy.toggles == 2, "a second tap must toggle recording off")
+  }
+
+  // MARK: - Negative controls
+
+  /// Arrow keys really do carry `.function` (probe, 2026-08-08). They arrive as
+  /// `.keyDown` rather than `.flagsChanged` in production, but this drives them
+  /// through the modifier path anyway: the guard must reject them on KEY CODE, not
+  /// rely on the event type happening to differ.
+  @Test(
+    "An arrow key carrying .function cannot start dictation",
+    arguments: [UInt16(123), 124, 125, 126])
+  func arrowKeysCannotTrigger(code: UInt16) async {
+    let spy = Spy()
+    let service = makeService(spy, clock: ManualClock())
+
+    service.handleFlagsChangedValues(keyCode: code, flags: [.function])
+    await settle(service)
+
+    #expect(spy.starts == 0)
+    #expect(spy.actions.isEmpty)
+  }
+
+  /// The F-row carries `.function` too. Static membership rejection is proven in
+  /// `KeySymbolsTests`; this proves the DISPATCH seam refuses them, which is what
+  /// the plan asked for and what the earlier version only did for arrows.
+  @Test(
+    "An F-row key carrying .function cannot start dictation",
+    arguments: [UInt16(122), 120, 99, 118, 96, 97])
+  func fRowKeysCannotTrigger(code: UInt16) async {
+    let spy = Spy()
+    let service = makeService(spy, clock: ManualClock())
+
+    service.handleFlagsChangedValues(keyCode: code, flags: [.function])
+
+    #expect(spy.starts == 0)
+    #expect(spy.actions.isEmpty)
+  }
+
+  @Test("A different standalone modifier cannot drive the Globe binding")
+  func otherModifierDoesNotTrigger() async {
+    let spy = Spy()
+    let service = makeService(spy, clock: ManualClock())
+
+    service.handleFlagsChangedValues(keyCode: ModifierKeyCodes.rightOption, flags: [.option])
+    await settle(service)
+
+    #expect(spy.starts == 0, "a key that is not the bound shortcut must do nothing")
+  }
+
+  /// Parity control. The same sequence on Right Option must behave identically, so
+  /// a Globe-only regression is distinguishable from a change to the shared path.
+  @Test("Right Option still behaves exactly as the Globe key does")
+  func rightOptionParity() async {
+    let spy = Spy()
+    let clock = ManualClock()
+    let service = makeService(spy, clock: clock)
+    service.toggleKeyCode = ModifierKeyCodes.rightOption
+
+    service.handleFlagsChangedValues(keyCode: ModifierKeyCodes.rightOption, flags: [.option])
+    await settle(service)
+    clock.advance(ms: 800)
+    service.handleFlagsChangedValues(keyCode: ModifierKeyCodes.rightOption, flags: [])
+    await settle(service)
+
+    #expect(spy.starts == 1)
+    #expect(spy.stops == 1)
+  }
+}

--- a/Tests/EnviousWisprTests/Services/HotkeyHandsFreeLockGateTests.swift
+++ b/Tests/EnviousWisprTests/Services/HotkeyHandsFreeLockGateTests.swift
@@ -35,7 +35,7 @@ import EnviousWisprServices
     var sink: HotkeyTelemetrySink {
       HotkeyTelemetrySink(
         registrationFailed: { _, _, _, _ in },
-        pressed: { [weak self] _, _, _, action in self?.presses.append(action) },
+        pressed: { [weak self] _, _, _, _, action in self?.presses.append(action) },
         lockResolved: { [weak self] committed, reason in
           self?.lockDecisions.append((committed, reason))
         })

--- a/Tests/EnviousWisprTests/Services/HotkeyTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/Services/HotkeyTelemetryTests.swift
@@ -209,7 +209,6 @@ import Testing
     #expect(service.isModifierHeld)  // press was processed normally
   }
 
-
   // MARK: - #1987 key identity
 
   @Test("The two keys we report on by name classify as themselves")
@@ -291,7 +290,27 @@ import Testing
           "trigger_source": "ptt_hotkey", "input_mode": "pushToTalk",
           "key_shape": "modifier_only", "key_identity": "globe", "press_action": "start",
         ])
-      #expect(box.value?.stringProps["key_code"] == nil)
+
+      // The privacy assertion has to span EVERY typed bucket, not just strings.
+      // A raw key code would arrive as an Int, so checking `stringProps["key_code"]`
+      // asks the one bucket that cannot hold the thing being looked for: the check
+      // would pass while PostHog received the code. Reading the union means a leak
+      // in any bucket fails this test whatever its type.
+      let event = box.value
+      let allKeys =
+        Set(event?.stringProps.keys ?? [:].keys)
+        .union(event?.intProps.keys ?? [:].keys)
+        .union(event?.doubleProps.keys ?? [:].keys)
+        .union(event?.boolProps.keys ?? [:].keys)
+
+      #expect(
+        allKeys == [
+          "trigger_source", "input_mode", "key_shape", "key_identity", "press_action",
+        ],
+        "hotkey.pressed carries an unexpected property: \(allKeys.sorted())")
+      #expect(event?.intProps.isEmpty == true)
+      #expect(event?.doubleProps.isEmpty == true)
+      #expect(event?.boolProps.isEmpty == true)
     }
   #endif
 

--- a/Tests/EnviousWisprTests/Services/HotkeyTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/Services/HotkeyTelemetryTests.swift
@@ -14,7 +14,9 @@ import Testing
 /// here. The modifier-only `handleFlagsChangedValues` toggle site shares the same
 /// helper and is covered by Live UAT (the shipped default).
 @MainActor
-@Suite struct HotkeyTelemetryTests {
+// `.serialized` (#1987): the wire-payload case installs and restores the
+// process-global `testEventHook`, so no sibling case may run beside it.
+@Suite(.serialized) struct HotkeyTelemetryTests {
 
   /// Synchronous spy — records every sink call on the main actor. `@MainActor`
   /// per swift-patterns `mainactor-fntype-implicitly-sendable`.
@@ -23,6 +25,10 @@ import Testing
       let triggerSource: String
       let inputMode: String
       let keyShape: String
+      /// #1987 — content-free class of the key that produced this press. Captured
+      /// so the widened sink cannot silently drop it; every existing assertion in
+      /// this suite is unchanged.
+      let keyIdentity: String
       let pressAction: String
     }
     struct Registration: Equatable {
@@ -40,9 +46,10 @@ import Testing
           self?.registrations.append(
             Registration(mechanism: mechanism, hotkeyKind: kind, osStatus: status, keyShape: shape))
         },
-        pressed: { [weak self] ts, im, ks, pa in
+        pressed: { [weak self] ts, im, ks, ki, pa in
           self?.presses.append(
-            Press(triggerSource: ts, inputMode: im, keyShape: ks, pressAction: pa))
+            Press(
+              triggerSource: ts, inputMode: im, keyShape: ks, keyIdentity: ki, pressAction: pa))
         })
     }
   }
@@ -70,7 +77,7 @@ import Testing
       spy.presses == [
         .init(
           triggerSource: "ptt_hotkey", inputMode: "pushToTalk", keyShape: "chord",
-          pressAction: "start")
+          keyIdentity: "chord", pressAction: "start")
       ])
   }
 
@@ -83,7 +90,7 @@ import Testing
       spy.presses == [
         .init(
           triggerSource: "toggle_hotkey", inputMode: "toggle", keyShape: "chord",
-          pressAction: "toggle")
+          keyIdentity: "chord", pressAction: "toggle")
       ])
   }
 
@@ -96,7 +103,7 @@ import Testing
       spy.presses == [
         .init(
           triggerSource: "cancel_hotkey", inputMode: "pushToTalk", keyShape: "chord",
-          pressAction: "cancel")
+          keyIdentity: "chord", pressAction: "cancel")
       ])
   }
 
@@ -201,4 +208,91 @@ import Testing
     _ = service.recordMonitorInstall(nil, scope: "global")
     #expect(service.isModifierHeld)  // press was processed normally
   }
+
+
+  // MARK: - #1987 key identity
+
+  @Test("The two keys we report on by name classify as themselves")
+  func namedKeys() {
+    #expect(HotkeyKeyIdentity.classify(keyCode: ModifierKeyCodes.globe) == .globe)
+    #expect(HotkeyKeyIdentity.classify(keyCode: ModifierKeyCodes.rightOption) == .rightOption)
+  }
+
+  @Test(
+    "Every other standalone modifier classifies as other_modifier",
+    arguments: [UInt16(55), 54, 58, 56, 60, 59, 62])
+  func otherModifiers(code: UInt16) {
+    #expect(HotkeyKeyIdentity.classify(keyCode: code) == .otherModifier)
+  }
+
+  @Test(
+    "Non-modifier keys classify as chord",
+    arguments: [UInt16(0), 49, 53, 123, 122])
+  func chordKeys(code: UInt16) {
+    #expect(HotkeyKeyIdentity.classify(keyCode: code) == .chord)
+  }
+
+  /// These strings land in PostHog and get written into saved queries, so a rename
+  /// silently returns zero rows forever rather than failing. Frozen deliberately.
+  @Test("Raw values are frozen, because dashboards are built on them")
+  func rawValuesAreStable() {
+    #expect(HotkeyKeyIdentity.globe.rawValue == "globe")
+    #expect(HotkeyKeyIdentity.rightOption.rawValue == "right_option")
+    #expect(HotkeyKeyIdentity.otherModifier.rawValue == "other_modifier")
+    #expect(HotkeyKeyIdentity.chord.rawValue == "chord")
+  }
+
+  /// The privacy boundary in test form: no case may ever carry a key code.
+  @Test("No classification value contains a digit, so no key code can leak")
+  func neverEmitsAKeyCode() {
+    for identity in [
+      HotkeyKeyIdentity.globe, .rightOption, .otherModifier, .chord,
+    ] {
+      #expect(
+        identity.rawValue.rangeOfCharacter(from: .decimalDigits) == nil,
+        "\(identity.rawValue) contains a digit; key codes must never reach telemetry")
+    }
+  }
+
+  #if DEBUG
+    /// Proves the REAL `hotkey.pressed` payload carries `key_identity`, not just a
+    /// test-only projection of it. Before this chunk the DEBUG projection was built
+    /// independently of `props`, so a projection test could have passed while the
+    /// shipped event carried nothing; the projection is now derived from the same
+    /// dictionary PostHog receives.
+    final class EventBox: @unchecked Sendable {
+      private let lock = NSLock()
+      private var stored: CapturedTelemetryEvent?
+
+      func set(_ event: CapturedTelemetryEvent) {
+        lock.withLock { stored = event }
+      }
+
+      var value: CapturedTelemetryEvent? {
+        lock.withLock { stored }
+      }
+    }
+
+    @Test("hotkey.pressed wire payload carries key_identity without a raw key code")
+    func wirePayloadCarriesIdentity() {
+      let box = EventBox()
+      let previousHook = TelemetryService.shared.testEventHook
+      TelemetryService.shared.testEventHook = { event in
+        if event.name == "hotkey.pressed" { box.set(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = previousHook }
+
+      TelemetryService.shared.hotkeyPressed(
+        triggerSource: "ptt_hotkey", inputMode: "pushToTalk", keyShape: "modifier_only",
+        keyIdentity: "globe", pressAction: "start")
+
+      #expect(
+        box.value?.stringProps == [
+          "trigger_source": "ptt_hotkey", "input_mode": "pushToTalk",
+          "key_shape": "modifier_only", "key_identity": "globe", "press_action": "start",
+        ])
+      #expect(box.value?.stringProps["key_code"] == nil)
+    }
+  #endif
+
 }

--- a/Tests/EnviousWisprTests/Services/KeySymbolsTests.swift
+++ b/Tests/EnviousWisprTests/Services/KeySymbolsTests.swift
@@ -1,0 +1,126 @@
+import AppKit
+import EnviousWisprServices
+import Foundation
+import Testing
+
+/// #1987 — the standalone-modifier key set and its projections.
+///
+/// The mapping used to live in three places: a hand-written membership set plus
+/// two private key-code-to-flag switches, one on the dispatch path and one on the
+/// capture view. Adding a key meant remembering all three, and forgetting the flag
+/// half was silent: the lookup returned `[]` for an unknown code, and
+/// `OptionSet.contains` is a superset test, so
+/// `anything.contains([])` is `true`. A member without a flag therefore read as
+/// PRESSED on its release event, and push-to-talk would start recording and never
+/// stop.
+///
+/// Membership is now DERIVED from the mapping and the flag lookup returns an
+/// optional, so that state is unrepresentable rather than merely guarded. The
+/// completeness test below is characterization: it documents the invariant, it is
+/// no longer the thing protecting it.
+@Suite struct KeySymbolsTests {
+
+  /// The eight keys that shipped before the Globe key, with the flag each has
+  /// always set. Written out longhand rather than derived from the type under
+  /// test: a test that asks the implementation what it believes and then asserts
+  /// the answer matches proves only that the code equals itself.
+  private static let preExistingMappings: [(code: UInt16, flag: NSEvent.ModifierFlags)] = [
+    (55, .command), (54, .command),
+    (58, .option), (61, .option),
+    (56, .shift), (60, .shift),
+    (59, .control), (62, .control),
+  ]
+
+  @Test("The eight pre-existing keys map exactly as they did before consolidation")
+  func existingMappingsUnchanged() {
+    for (code, expected) in Self.preExistingMappings {
+      #expect(ModifierKeyCodes.isModifierOnly(code), "key code \(code) lost membership")
+      #expect(
+        ModifierKeyCodes.flag(for: code) == expected,
+        "key code \(code) changed flag under consolidation")
+    }
+  }
+
+  @Test("The Globe key is a member and maps to .function")
+  func globeIsMapped() {
+    #expect(ModifierKeyCodes.globe == 63)
+    #expect(ModifierKeyCodes.isModifierOnly(ModifierKeyCodes.globe))
+    #expect(ModifierKeyCodes.flag(for: ModifierKeyCodes.globe) == .function)
+  }
+
+  @Test("Membership is exactly nine keys, so nothing was added or lost")
+  func membershipCount() {
+    #expect(ModifierKeyCodes.all.count == 9)
+    #expect(ModifierKeyCodes.all.contains(ModifierKeyCodes.globe))
+  }
+
+  @Test("Characterization: every member has a non-nil flag, by construction")
+  func everyMemberHasAFlag() {
+    for code in ModifierKeyCodes.all {
+      #expect(
+        ModifierKeyCodes.flag(for: code) != nil,
+        "member \(code) has no flag; press and release would be indistinguishable")
+    }
+  }
+
+  /// The measured trap. Arrow keys really do carry `.function` in their event
+  /// flags (probe, 2026-08-08: `keyCode=123 raw=0xa00100 numericPad+FUNCTION`),
+  /// so an implementation that matched on the FLAG rather than the KEY CODE would
+  /// start dictation every time the user moved the cursor.
+  @Test(
+    "Arrow keys are not standalone modifiers even though their events carry .function",
+    arguments: [UInt16(123), 124, 125, 126])
+  func arrowKeysRejected(code: UInt16) {
+    #expect(!ModifierKeyCodes.isModifierOnly(code))
+    #expect(ModifierKeyCodes.flag(for: code) == nil)
+  }
+
+  @Test(
+    "F-row keys are not standalone modifiers",
+    arguments: [UInt16(122), 120, 99, 118, 96, 97])
+  func fRowKeysRejected(code: UInt16) {
+    #expect(!ModifierKeyCodes.isModifierOnly(code))
+    #expect(ModifierKeyCodes.flag(for: code) == nil)
+  }
+
+  @Test("An ordinary letter key is not a standalone modifier")
+  func letterKeyRejected() {
+    #expect(!ModifierKeyCodes.isModifierOnly(0))  // 'A'
+    #expect(ModifierKeyCodes.flag(for: 0) == nil)
+  }
+
+  // MARK: - Projections
+
+  @Test("The Globe key displays with both names and no Left/Right qualifier")
+  func globeVisibleLabel() {
+    let label = KeySymbols.formatModifierOnly([], keyCode: ModifierKeyCodes.globe)
+    #expect(label == "🌐 Globe (Fn)")
+    #expect(!label.contains("Left"))
+    #expect(!label.contains("Right"))
+  }
+
+  @Test("Existing keys keep their side-qualified visible labels")
+  func existingVisibleLabelsUnchanged() {
+    #expect(KeySymbols.formatModifierOnly([], keyCode: 61) == "Right ⌥")
+    #expect(KeySymbols.formatModifierOnly([], keyCode: 58) == "Left ⌥")
+    #expect(KeySymbols.formatModifierOnly([], keyCode: 55) == "Left ⌘")
+  }
+
+  /// The spoken value must not depend on a screen reader interpreting an emoji.
+  @Test("The Globe key speaks as words, not as its visible emoji label")
+  func globeSpokenLabel() {
+    let spoken = KeySymbols.accessibilityDescription(
+      keyCode: ModifierKeyCodes.globe, modifiers: [])
+    #expect(spoken == "Globe or Function key")
+    #expect(!spoken.contains("🌐"))
+  }
+
+  @Test("Every other key speaks exactly as it renders, so nothing else changed")
+  func otherKeysSpeakAsRendered() {
+    for (code, _) in Self.preExistingMappings {
+      let spoken = KeySymbols.accessibilityDescription(keyCode: code, modifiers: [])
+      let visible = KeySymbols.format(keyCode: code, modifiers: [])
+      #expect(spoken == visible, "key code \(code) diverged between spoken and visible")
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/Services/SettingsDefaultsRoutingTests.swift
+++ b/Tests/EnviousWisprTests/Services/SettingsDefaultsRoutingTests.swift
@@ -301,23 +301,43 @@ struct SettingsDefaultsRoutingTests {
 
   // MARK: - #1987 Globe key guidance claim
 
-  /// The claim must be shared across BOTH binding surfaces, so these cases drive
-  /// both orderings. A single-ordering test cannot distinguish a correct shared
-  /// claim from a per-surface flag: with a per-surface flag, whichever surface the
-  /// test happens to exercise first would still return true exactly once.
-  @Test("The guidance claim returns true exactly once, whichever surface binds first")
+  /// The claim is one shared owner, so a second caller gets `false` no matter who
+  /// asked first. That single-owner design is what makes the surface ORDER
+  /// irrelevant, which is why it is not simulated here.
+  ///
+  /// An earlier version of this test labelled two identical blocks "onboarding
+  /// first" and "Settings first". They executed the same two calls against
+  /// `SettingsManager`, so the labels described an ordering the code never varied
+  /// and neither surface appeared at all. Removed rather than reworded: a name
+  /// that claims more than the body does is worse than a narrower name, because
+  /// it stops the next reader looking for the missing coverage.
+  ///
+  /// NOT COVERED HERE, deliberately, and on the founder's manual pass instead:
+  /// that `ShortcutsSettingsView` and `ReadyScreenV2` actually CALL this on an
+  /// accepted bind. Both call sites live in SwiftUI view bodies that need a
+  /// rendered hierarchy, so deleting either one leaves every test in this file
+  /// green. A user who binds Globe and sees no explanation is the visible symptom.
+  @Test("A second claim on the same store returns false")
   func guidanceClaimIsOncePerInstall() {
-    // Ordering A: onboarding binds first, Settings second.
-    let suiteA = UserDefaults(suiteName: "GlobeClaimA-\(UUID().uuidString)")!
-    let settingsA = SettingsManager(defaults: suiteA)
-    #expect(settingsA.claimGlobeKeyGuidancePresentation(for: ModifierKeyCodes.globe))
-    #expect(!settingsA.claimGlobeKeyGuidancePresentation(for: ModifierKeyCodes.globe))
+    let suite = UserDefaults(suiteName: "GlobeClaim-\(UUID().uuidString)")!
+    let settings = SettingsManager(defaults: suite)
+    #expect(settings.claimGlobeKeyGuidancePresentation(for: ModifierKeyCodes.globe))
+    #expect(!settings.claimGlobeKeyGuidancePresentation(for: ModifierKeyCodes.globe))
+  }
 
-    // Ordering B: a fresh install where Settings binds first, onboarding second.
+  /// A separate installation is unaffected by another store's claim. Without this,
+  /// a claim keyed on something process-wide rather than on the defaults store
+  /// would pass every other test in this file.
+  @Test("A fresh store gets its own claim")
+  func guidanceClaimIsPerStore() {
+    let suiteA = UserDefaults(suiteName: "GlobeClaimA-\(UUID().uuidString)")!
     let suiteB = UserDefaults(suiteName: "GlobeClaimB-\(UUID().uuidString)")!
-    let settingsB = SettingsManager(defaults: suiteB)
-    #expect(settingsB.claimGlobeKeyGuidancePresentation(for: ModifierKeyCodes.globe))
-    #expect(!settingsB.claimGlobeKeyGuidancePresentation(for: ModifierKeyCodes.globe))
+    #expect(
+      SettingsManager(defaults: suiteA).claimGlobeKeyGuidancePresentation(
+        for: ModifierKeyCodes.globe))
+    #expect(
+      SettingsManager(defaults: suiteB).claimGlobeKeyGuidancePresentation(
+        for: ModifierKeyCodes.globe))
   }
 
   /// The claim must survive a relaunch, or the explanation reappears forever.

--- a/Tests/EnviousWisprTests/Services/SettingsDefaultsRoutingTests.swift
+++ b/Tests/EnviousWisprTests/Services/SettingsDefaultsRoutingTests.swift
@@ -298,4 +298,71 @@ struct SettingsDefaultsRoutingTests {
       bundleID: "com.enviouswispr.app.dev", devStore: dev, shared: shared)
     #expect(shared.object(forKey: "toggleKeyCode") == nil)  // stale dev value NOT resurrected
   }
+
+  // MARK: - #1987 Globe key guidance claim
+
+  /// The claim must be shared across BOTH binding surfaces, so these cases drive
+  /// both orderings. A single-ordering test cannot distinguish a correct shared
+  /// claim from a per-surface flag: with a per-surface flag, whichever surface the
+  /// test happens to exercise first would still return true exactly once.
+  @Test("The guidance claim returns true exactly once, whichever surface binds first")
+  func guidanceClaimIsOncePerInstall() {
+    // Ordering A: onboarding binds first, Settings second.
+    let suiteA = UserDefaults(suiteName: "GlobeClaimA-\(UUID().uuidString)")!
+    let settingsA = SettingsManager(defaults: suiteA)
+    #expect(settingsA.claimGlobeKeyGuidancePresentation(for: ModifierKeyCodes.globe))
+    #expect(!settingsA.claimGlobeKeyGuidancePresentation(for: ModifierKeyCodes.globe))
+
+    // Ordering B: a fresh install where Settings binds first, onboarding second.
+    let suiteB = UserDefaults(suiteName: "GlobeClaimB-\(UUID().uuidString)")!
+    let settingsB = SettingsManager(defaults: suiteB)
+    #expect(settingsB.claimGlobeKeyGuidancePresentation(for: ModifierKeyCodes.globe))
+    #expect(!settingsB.claimGlobeKeyGuidancePresentation(for: ModifierKeyCodes.globe))
+  }
+
+  /// The claim must survive a relaunch, or the explanation reappears forever.
+  @Test("The claim persists across a new SettingsManager on the same store")
+  func guidanceClaimPersists() {
+    let suite = UserDefaults(suiteName: "GlobeClaimPersist-\(UUID().uuidString)")!
+    #expect(
+      SettingsManager(defaults: suite).claimGlobeKeyGuidancePresentation(
+        for: ModifierKeyCodes.globe))
+    // A second manager over the same store is what a relaunch looks like.
+    #expect(
+      !SettingsManager(defaults: suite).claimGlobeKeyGuidancePresentation(
+        for: ModifierKeyCodes.globe))
+  }
+
+  /// Binding a non-Globe key must NOT consume the claim, or a user who picks Right
+  /// Option first would never see the explanation when they later choose Globe.
+  @Test("A non-Globe bind does not consume the claim")
+  func nonGlobeBindDoesNotConsumeTheClaim() {
+    let suite = UserDefaults(suiteName: "GlobeClaimOther-\(UUID().uuidString)")!
+    let settings = SettingsManager(defaults: suite)
+
+    #expect(!settings.claimGlobeKeyGuidancePresentation(for: ModifierKeyCodes.rightOption))
+    #expect(!settings.claimGlobeKeyGuidancePresentation(for: 0))
+    // The claim is still available.
+    #expect(settings.claimGlobeKeyGuidancePresentation(for: ModifierKeyCodes.globe))
+  }
+
+  /// Two separate claims, because asserting only the first leaves the gap that
+  /// prompted this test: the list could name one key while the claim wrote another,
+  /// and the claim would silently fall outside build unification. Reading the store
+  /// after a real claim ties the registered name to the key actually persisted.
+  ///
+  /// The production constant is `private`, so this asserts the literal deliberately.
+  /// That is the point: the string is what survives an app update, and changing it
+  /// re-shows the explanation to every existing user.
+  @Test("The key the claim actually writes is the one registered for unification")
+  func claimKeyIsRegisteredAndIsTheKeyWritten() {
+    #expect(SettingsManager.unifiedDefaultsKeys.contains("hasClaimedGlobeKeyGuidance"))
+
+    let suite = UserDefaults(suiteName: "GlobeClaimKeyName-\(UUID().uuidString)")!
+    #expect(suite.object(forKey: "hasClaimedGlobeKeyGuidance") == nil)
+    #expect(
+      SettingsManager(defaults: suite).claimGlobeKeyGuidancePresentation(
+        for: ModifierKeyCodes.globe))
+    #expect(suite.bool(forKey: "hasClaimedGlobeKeyGuidance"))
+  }
 }

--- a/Tests/EnviousWisprTests/Settings/WhatsNewContentTests.swift
+++ b/Tests/EnviousWisprTests/Settings/WhatsNewContentTests.swift
@@ -104,4 +104,44 @@ struct WhatsNewContentTests {
       #expect(!entry.icon.trimmingCharacters(in: .whitespaces).isEmpty, "\(entry.id): empty icon")
     }
   }
+
+  /// #1987 — the Globe-key entry, pinned field by field.
+  ///
+  /// Deliberately NOT covered by `currentVersionHasEntries` above: another 2.5.0
+  /// entry is already in the group, so that test passes whether or not this one
+  /// exists. Only an exact-ID lookup can tell the difference. (2.5.0 is the OPEN
+  /// group, not a shipped release; the newest tag is v2.4.3.)
+  ///
+  /// The description is asserted verbatim because it is founder-approved copy
+  /// naming a System Settings route, so a paraphrase sends the user looking for a
+  /// menu that is not there.
+  ///
+  /// Two separate facts, previously conflated here into a causal claim that was
+  /// simply false:
+  ///
+  /// 1. This wording says "Press Globe key to" while the help article and the
+  ///    popover both use the exact macOS label "Press 🌐 key to". That is a copy
+  ///    decision about this surface, NOT a technical limit. Measured 2026-08-09 by
+  ///    putting the symbol in this description and re-running the renderer: it
+  ///    parsed all 116 entries and emitted the symbol intact.
+  /// 2. `title`, `description`, and `version` must stay direct Swift literals
+  ///    rather than shared constants, because `scripts/ci/render-release-notes.py`
+  ///    parses the SOURCE TEXT of this file rather than compiled values.
+  @Test("the Globe key entry ships in the current version with its approved copy")
+  func globeKeyEntryShips() throws {
+    let entry = try #require(
+      WhatsNewContent.entries.first { $0.id == "globe-key-dictation-hotkey" },
+      "the #1987 Globe key entry is missing from What's New")
+
+    #expect(entry.icon == "globe")
+    #expect(entry.title == "Use the Globe key as your dictation shortcut")
+    #expect(
+      entry.description
+        == "You can now use the Globe (Fn) key as your dictation shortcut. Right Option stays "
+        + "exactly as it is unless you choose Globe. If macOS also opens emoji or switches your "
+        + "keyboard language when you press it, go to System Settings, then Keyboard, then Press "
+        + "Globe key to, and choose Do Nothing.")
+    #expect(entry.version == "2.5.0")
+    #expect(entry.version == WhatsNewConstants.currentContentVersion)
+  }
 }

--- a/Tests/EnviousWisprTests/Settings/WhatsNewContentTests.swift
+++ b/Tests/EnviousWisprTests/Settings/WhatsNewContentTests.swift
@@ -138,9 +138,16 @@ struct WhatsNewContentTests {
     #expect(
       entry.description
         == "You can now use the Globe (Fn) key as your dictation shortcut. Right Option stays "
-        + "exactly as it is unless you choose Globe. If macOS also opens emoji or switches your "
-        + "keyboard language when you press it, go to System Settings, then Keyboard, then Press "
-        + "Globe key to, and choose Do Nothing.")
+        + "exactly as it is unless you choose Globe. If macOS also opens emoji, switches your "
+        + "keyboard language, or starts its own dictation when you press it, go to System "
+        + "Settings, then Keyboard, then Press Globe key to, and choose Do Nothing.")
+
+    // Founder amendment 2026-08-09, same reason as the popover: the macOS menu
+    // offers three actions and the original copy named two. Membership rather than
+    // equality, because the defect being guarded against is a dropped member.
+    #expect(entry.description.contains("emoji"))
+    #expect(entry.description.contains("keyboard language"))
+    #expect(entry.description.contains("its own dictation"))
     #expect(entry.version == "2.5.0")
     #expect(entry.version == WhatsNewConstants.currentContentVersion)
   }

--- a/Tests/EnviousWisprTests/Views/GlobeKeyCopyTests.swift
+++ b/Tests/EnviousWisprTests/Views/GlobeKeyCopyTests.swift
@@ -26,10 +26,27 @@ import Testing
     // ADDED, which is precisely how approved copy drifts.
     #expect(
       GlobeKeyCopy.body
-        == "macOS may already use the Globe key to switch keyboard languages or open the "
-        + "emoji picker. If that happens while you dictate, you can turn it off:")
+        == "macOS may already use the Globe key to switch keyboard languages, open the "
+        + "emoji picker, or start its own dictation. If that happens while you dictate, "
+        + "you can turn it off:")
     #expect(!GlobeKeyCopy.body.contains("is using"))
     #expect(!GlobeKeyCopy.body.lowercased().contains("conflict"))
+  }
+
+  /// Founder amendment, 2026-08-09. The "Press 🌐 key to" menu offers three actions
+  /// besides Do Nothing, and the body must name all three. The original named two
+  /// and dropped Start Dictation, which is the one that takes the microphone and so
+  /// the one most likely to read as our bug.
+  ///
+  /// Asserted as membership rather than by re-stating the sentence, because the
+  /// failure this guards against is an OMISSION: a future rewrite that drops a
+  /// member would still satisfy an exact-equality check written against itself.
+  @Test("The body names every action the macOS menu can take")
+  func bodyNamesEveryMacOSAction() {
+    let body = GlobeKeyCopy.body.lowercased()
+    #expect(body.contains("keyboard languages"))
+    #expect(body.contains("emoji picker"))
+    #expect(body.contains("dictation"))
   }
 
   /// Load-bearing property 2: the closing line answers the question the popover

--- a/Tests/EnviousWisprTests/Views/GlobeKeyCopyTests.swift
+++ b/Tests/EnviousWisprTests/Views/GlobeKeyCopyTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #1987 — freezes the founder-approved Globe-key guidance copy.
+///
+/// The founder reviewed and approved this text verbatim on 2026-08-08, including
+/// the deliberate decision NOT to mention Toggle mode. These tests exist so a
+/// later edit is a conscious act rather than drift, matching the precedent set by
+/// `LiveTranscriptionCopyTests` (#1337).
+@Suite struct GlobeKeyCopyTests {
+
+  @Test("Title and dismiss button are frozen")
+  func frozenChrome() {
+    #expect(GlobeKeyCopy.title == "Free up the Globe key")
+    #expect(GlobeKeyCopy.dismissButton == "Got it")
+  }
+
+  /// Load-bearing property 1: we deliberately read no macOS preference, so we
+  /// cannot know a conflict exists. "may already use" is the only honest phrasing;
+  /// "is using" would be wrong for every user who already freed the key.
+  @Test("The body does not assert that a conflict exists")
+  func bodyDoesNotAssertAConflict() {
+    // Exact equality, not a substring: a substring check passes when text is
+    // ADDED, which is precisely how approved copy drifts.
+    #expect(
+      GlobeKeyCopy.body
+        == "macOS may already use the Globe key to switch keyboard languages or open the "
+        + "emoji picker. If that happens while you dictate, you can turn it off:")
+    #expect(!GlobeKeyCopy.body.contains("is using"))
+    #expect(!GlobeKeyCopy.body.lowercased().contains("conflict"))
+  }
+
+  /// Load-bearing property 2: the closing line answers the question the popover
+  /// itself provokes, which is "did my shortcut fail to save?".
+  @Test("The copy reassures that the shortcut is set either way")
+  func reassuranceIsPresent() {
+    #expect(
+      GlobeKeyCopy.reassurance
+        == "Your Globe key is set as your dictation shortcut either way. This only stops "
+        + "macOS doing its own thing at the same time.")
+  }
+
+  /// Load-bearing property 3: the steps quote macOS verbatim, so the user does no
+  /// translation between our words and the labels on their screen.
+  @Test("The steps quote the exact macOS labels")
+  func stepsQuoteMacOSVerbatim() {
+    // The complete ordered array, so a reordering or an inserted step fails too.
+    #expect(
+      GlobeKeyCopy.steps == [
+        "Open System Settings, then Keyboard",
+        "Click the \"Press 🌐 key to\" menu",
+        "Choose \"Do Nothing\"",
+      ])
+  }
+
+  /// Founder decision, 2026-08-08: the popover stays single-purpose. The
+  /// Toggle-mode pointer belongs in the help article, where length is free. This
+  /// test exists so a well-meaning later round cannot quietly add it back.
+  @Test("No Toggle-mode line was added to the popover")
+  func noToggleModeLine() {
+    let all =
+      ([GlobeKeyCopy.title, GlobeKeyCopy.body, GlobeKeyCopy.reassurance]
+      + GlobeKeyCopy.steps).joined(separator: " ")
+    #expect(!all.lowercased().contains("toggle"))
+  }
+
+  /// Brand rule: no em-dashes or en-dashes in user-facing copy.
+  @Test("No em-dashes or en-dashes anywhere in the copy")
+  func noDashes() {
+    let all =
+      ([
+        GlobeKeyCopy.title, GlobeKeyCopy.body, GlobeKeyCopy.reassurance,
+        GlobeKeyCopy.dismissButton, GlobeKeyCopy.accessibilityLabel,
+      ]
+      + GlobeKeyCopy.steps).joined(separator: " ")
+    #expect(!all.contains("\u{2014}"))
+    #expect(!all.contains("\u{2013}"))
+  }
+
+  /// VoiceOver must not have to interpret an emoji to know what this popover is.
+  @Test("The spoken container label is words, not the emoji")
+  func spokenLabelIsWords() {
+    #expect(GlobeKeyCopy.accessibilityLabel == "Free up the Globe key. Setup tip.")
+    #expect(!GlobeKeyCopy.accessibilityLabel.contains("🌐"))
+  }
+}

--- a/Tests/EnviousWisprTests/Views/HotkeyRecorderGlobeTests.swift
+++ b/Tests/EnviousWisprTests/Views/HotkeyRecorderGlobeTests.swift
@@ -42,9 +42,137 @@ import Testing
 
   private func makeView() -> (KeyCaptureNSView, () -> [UInt16]) {
     let view = KeyCaptureNSView()
+    // The state under test. Every capture case below describes what happens WHILE
+    // the user is recording a shortcut; `isRecording` defaults to false precisely
+    // so that a view nobody armed captures nothing.
+    view.isRecording = true
     var captured: [UInt16] = []
     view.onKeyEvent = { captured.append($0.keyCode) }
     return (view, { captured })
+  }
+
+  /// An un-armed view, for the gate cases below.
+  private func makeIdleView() -> (KeyCaptureNSView, () -> [UInt16]) {
+    let view = KeyCaptureNSView()
+    var captured: [UInt16] = []
+    view.onKeyEvent = { captured.append($0.keyCode) }
+    return (view, { captured })
+  }
+
+  /// `characters` is a parameter rather than a fixed "a" so an event that claims to
+  /// be a particular shortcut actually IS one. Review caught the Command+W case
+  /// below carrying W's key code with A's characters, which would have let the test
+  /// keep passing against an implementation that read the characters instead.
+  private func keyDown(
+    keyCode: UInt16,
+    flags: NSEvent.ModifierFlags = [],
+    characters: String = "a"
+  ) -> NSEvent {
+    NSEvent.keyEvent(
+      with: .keyDown,
+      location: .zero,
+      modifierFlags: flags,
+      timestamp: 0,
+      windowNumber: 0,
+      context: nil,
+      characters: characters,
+      charactersIgnoringModifiers: characters,
+      isARepeat: false,
+      keyCode: keyCode
+    )!
+  }
+
+  // MARK: - #1987 the capture view must be ARMED before it captures anything
+  //
+  // Founder-found, 2026-08-09, on the live build. Landing on the Shortcuts page and
+  // pressing any key rebound the shortcut immediately: no click on the box, no
+  // "press a key" prompt.
+  //
+  // The three handlers did not share one cause. `keyDown` and `flagsChanged` relied
+  // on this hidden view lacking the opportunity to become first responder outside
+  // recording, and #1987 removed that absence by making the enclosing control
+  // `.focusable()`. `performKeyEquivalent` had no such protection at any point,
+  // because AppKit can route a key equivalent through the view tree instead of to
+  // the first responder.
+  //
+  // These are the two-way control: the cases above prove capture WORKS when armed,
+  // these prove it does NOTHING when not. Without the second half, a gate that
+  // refused everything would pass the first half completely.
+
+  @Test("An un-armed view ignores a plain key press")
+  func idleViewIgnoresKeyDown() {
+    let (view, captured) = makeIdleView()
+    view.keyDown(with: keyDown(keyCode: 0))
+    #expect(captured().isEmpty)
+  }
+
+  @Test("An un-armed view ignores a bare modifier")
+  func idleViewIgnoresModifier() {
+    let (view, captured) = makeIdleView()
+    view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.globe, flags: [.function]))
+    #expect(captured().isEmpty)
+  }
+
+  /// The worst arm, because AppKit can route a key equivalent through the view tree
+  /// rather than to the first responder, so it fired even when this view held no
+  /// focus. Returning true also claimed the shortcut, so an ordinary Command+W on
+  /// the Shortcuts page both rebound the hotkey and failed to close the window.
+  @Test("An un-armed view neither captures nor claims a key equivalent")
+  func idleViewIgnoresKeyEquivalent() {
+    let (view, captured) = makeIdleView()
+    let handled = view.performKeyEquivalent(
+      with: keyDown(keyCode: 13, flags: [.command], characters: "w"))
+    #expect(captured().isEmpty)
+    #expect(!handled, "an un-armed capture view must let the system handle the key equivalent")
+  }
+
+  /// The arming edge itself: capture must start and stop with the flag, so a view
+  /// that was armed once does not keep capturing after recording ends.
+  @Test("Capture follows the armed flag in both directions")
+  func captureFollowsTheArmedFlag() {
+    let (view, captured) = makeIdleView()
+
+    view.keyDown(with: keyDown(keyCode: 0))
+    #expect(captured().isEmpty)
+
+    view.isRecording = true
+    view.keyDown(with: keyDown(keyCode: 0))
+    #expect(captured() == [0])
+
+    view.isRecording = false
+    view.keyDown(with: keyDown(keyCode: 1))
+    #expect(captured() == [0], "capture continued after recording ended")
+  }
+
+  /// The one case that needs a real window, and the reason it is worth the cost:
+  /// every other case here builds a detached view, whose `window` is nil, so the
+  /// resignation branch is unreachable and deleting the whole `didSet` body leaves
+  /// them all green. Review caught exactly that.
+  ///
+  /// What it protects: `acceptsFirstResponder` going false does NOT resign an
+  /// existing first-responder status, so without the `didSet` a view that was armed
+  /// once keeps receiving keys after recording ends, until something else happens to
+  /// take focus. That is the founder's bug again, one step later in the sequence.
+  @Test("Ending capture resigns the hidden capture view as first responder")
+  func endingCaptureResignsFirstResponder() {
+    let window = NSWindow(
+      contentRect: NSRect(x: 0, y: 0, width: 200, height: 100),
+      styleMask: [.titled],
+      backing: .buffered,
+      defer: false
+    )
+    let view = KeyCaptureNSView(frame: window.contentView!.bounds)
+    window.contentView = view
+
+    view.isRecording = true
+    #expect(view.acceptsFirstResponder)
+    #expect(window.makeFirstResponder(view))
+    #expect(window.firstResponder === view, "precondition: the armed view must hold focus")
+
+    view.isRecording = false
+
+    #expect(!view.acceptsFirstResponder)
+    #expect(window.firstResponder !== view, "the view kept keyboard focus after recording ended")
   }
 
   @Test("The recorder accepts a Globe press")

--- a/Tests/EnviousWisprTests/Views/HotkeyRecorderGlobeTests.swift
+++ b/Tests/EnviousWisprTests/Views/HotkeyRecorderGlobeTests.swift
@@ -231,9 +231,14 @@ import Testing
   // `HotkeyCapture` is what BOTH recording surfaces read. Settings goes through
   // `HotkeyRecorderView` and onboarding through `KeycapHotkeyView`, and each
   // previously carried its own copy of this logic, so the same press could bind
-  // differently depending on where the user set it. These tests cover the onboarding
-  // surface too, which is otherwise unreachable: `KeycapHotkeyView` is file-private
-  // and `@testable` does not promote private to internal.
+  // differently depending on where the user set it.
+  //
+  // These cover the shared AUTHORITY, not onboarding's delegation to it. That
+  // distinction matters: `KeycapHotkeyView` is file-private and `@testable` does
+  // not promote private to internal, so nothing here would fail if onboarding
+  // stopped calling `HotkeyCapture` and grew a private copy again. What prevents
+  // the drift is that neither view retains its own copy to drift from; what proves
+  // onboarding still delegates is the founder's manual pass.
 
   /// Escape cancels rather than binding. Without this a user pressing Escape to
   /// back out would silently bind Escape as their dictation shortcut.

--- a/Tests/EnviousWisprTests/Views/HotkeyRecorderGlobeTests.swift
+++ b/Tests/EnviousWisprTests/Views/HotkeyRecorderGlobeTests.swift
@@ -1,6 +1,7 @@
 import AppKit
 import EnviousWisprServices
 import Foundation
+import SwiftUI
 import Testing
 
 @testable import EnviousWisprAppKit
@@ -87,5 +88,214 @@ import Testing
     let (view, captured) = makeView()
     view.flagsChanged(with: flagsChanged(keyCode: code, flags: [.function]))
     #expect(captured().isEmpty)
+  }
+
+  // MARK: - #1987 accepted-binding delivery
+  //
+  // These drive `HotkeyRecorderView.acceptBinding(from:)`, the REAL production
+  // path, not the callback directly. An earlier version of this suite invoked
+  // `onBindingAccepted` by hand and was correctly rejected: it passed with the
+  // production invocation deleted. Deleting it now fails every test below.
+  //
+  // WHAT IS STILL NOT COVERED, stated rather than implied. `handleKeyEvent` reads
+  // `dictationRuntime` from `@Environment` through `stopRecording()`, which traps
+  // outside a rendered hierarchy, so ONE thing remains a manual-pass item: that
+  // `handleKeyEvent` delegates to `acceptBinding` rather than dropping the event.
+  // That is visible on the founder's manual pass — a Globe bind that silently did
+  // nothing is not a subtle failure. `DictationRuntime.init` takes thirteen
+  // collaborators, so faking one would be a large double bearing no relationship
+  // to what is under test.
+
+  /// A live binding pair backed by local storage, so the test observes what the
+  /// view WRITES. `.constant` would discard the writes and make every assertion
+  /// below vacuous.
+  private final class BindingBox {
+    var keyCode: UInt16 = ModifierKeyCodes.rightOption
+    var modifiers: NSEvent.ModifierFlags = []
+    /// The binding values as they stood at the moment the callback fired. Both
+    /// surfaces depend on the write happening FIRST: the popover anchors on a
+    /// control whose label must already read the new key.
+    var seenAtCallback: [(UInt16, NSEvent.ModifierFlags)] = []
+    var callbackArguments: [(UInt16, NSEvent.ModifierFlags)] = []
+  }
+
+  private func makeRecorder(_ box: BindingBox) -> HotkeyRecorderView {
+    HotkeyRecorderView(
+      keyCode: Binding(get: { box.keyCode }, set: { box.keyCode = $0 }),
+      modifiers: Binding(get: { box.modifiers }, set: { box.modifiers = $0 }),
+      defaultKeyCode: ModifierKeyCodes.rightOption,
+      defaultModifiers: [],
+      label: "Recording shortcut",
+      onBindingAccepted: { code, mods in
+        box.callbackArguments.append((code, mods))
+        box.seenAtCallback.append((box.keyCode, box.modifiers))
+      }
+    )
+  }
+
+  @Test("Accepting Globe stores the key and notifies the owner exactly once")
+  func acceptingGlobeNotifiesOwner() {
+    let box = BindingBox()
+    makeRecorder(box).acceptBinding(
+      from: flagsChanged(keyCode: ModifierKeyCodes.globe, flags: [.function]))
+
+    #expect(box.keyCode == ModifierKeyCodes.globe)
+    #expect(box.modifiers == [])
+    #expect(box.callbackArguments.count == 1)
+    #expect(box.callbackArguments.first?.0 == ModifierKeyCodes.globe)
+    #expect(box.callbackArguments.first?.1 == [])
+  }
+
+  /// The load-bearing ORDER. If the callback ran before the write, the guidance
+  /// popover would anchor on a control still showing the old shortcut.
+  @Test("The bindings are updated before the owner is notified")
+  func bindingsAreWrittenBeforeTheCallback() {
+    let box = BindingBox()
+    makeRecorder(box).acceptBinding(
+      from: flagsChanged(keyCode: ModifierKeyCodes.globe, flags: [.function]))
+
+    #expect(box.seenAtCallback.count == 1)
+    #expect(box.seenAtCallback.first?.0 == ModifierKeyCodes.globe)
+  }
+
+  /// A standalone modifier carries its own flag in `modifierFlags`. Storing that
+  /// flag would demand the user hold Globe WHILE pressing Globe, so the key would
+  /// never fire. Modifiers must come back empty.
+  @Test(
+    "A modifier-only key clears its own flag",
+    arguments: [
+      (ModifierKeyCodes.globe, NSEvent.ModifierFlags.function),
+      (ModifierKeyCodes.rightOption, NSEvent.ModifierFlags.option),
+      (ModifierKeyCodes.leftCommand, NSEvent.ModifierFlags.command),
+    ])
+  func modifierOnlyKeyClearsItsOwnFlag(code: UInt16, flag: NSEvent.ModifierFlags) {
+    let box = BindingBox()
+    makeRecorder(box).acceptBinding(from: flagsChanged(keyCode: code, flags: flag))
+
+    #expect(box.keyCode == code)
+    #expect(box.modifiers == [])
+    #expect(box.callbackArguments.first?.1 == [])
+  }
+
+  /// The other side of the same branch: an ordinary chord must KEEP its modifiers,
+  /// so the clearing above cannot be implemented by clearing unconditionally.
+  @Test("A chord keeps its modifiers")
+  func chordKeepsItsModifiers() {
+    let box = BindingBox()
+    let event = NSEvent.keyEvent(
+      with: .keyDown,
+      location: .zero,
+      modifierFlags: [.command, .shift],
+      timestamp: 0,
+      windowNumber: 0,
+      context: nil,
+      characters: "d",
+      charactersIgnoringModifiers: "d",
+      isARepeat: false,
+      keyCode: 2
+    )!
+    makeRecorder(box).acceptBinding(from: event)
+
+    #expect(box.keyCode == 2)
+    #expect(box.modifiers == [.command, .shift])
+    #expect(box.callbackArguments.count == 1)
+    #expect(box.callbackArguments.first?.1 == [.command, .shift])
+  }
+
+  /// An arrow key arrives as a `keyDown` carrying `.function`. It is a legitimate
+  /// chord component, so unlike the capture layer above, acceptance must NOT strip
+  /// it — but it must also not be mistaken for the Globe key.
+  @Test("An arrow key is stored as a chord, not as the Globe key")
+  func arrowKeyIsNotTreatedAsGlobe() {
+    let box = BindingBox()
+    let event = NSEvent.keyEvent(
+      with: .keyDown,
+      location: .zero,
+      modifierFlags: [.function],
+      timestamp: 0,
+      windowNumber: 0,
+      context: nil,
+      characters: "",
+      charactersIgnoringModifiers: "",
+      isARepeat: false,
+      keyCode: 126
+    )!
+    makeRecorder(box).acceptBinding(from: event)
+
+    #expect(box.keyCode == 126)
+    #expect(box.modifiers == [.function])
+  }
+
+  // MARK: - #1987 shared acceptance authority
+  //
+  // `HotkeyCapture` is what BOTH recording surfaces read. Settings goes through
+  // `HotkeyRecorderView` and onboarding through `KeycapHotkeyView`, and each
+  // previously carried its own copy of this logic, so the same press could bind
+  // differently depending on where the user set it. These tests cover the onboarding
+  // surface too, which is otherwise unreachable: `KeycapHotkeyView` is file-private
+  // and `@testable` does not promote private to internal.
+
+  /// Escape cancels rather than binding. Without this a user pressing Escape to
+  /// back out would silently bind Escape as their dictation shortcut.
+  @Test("Escape alone cancels")
+  func escapeAloneCancels() {
+    let event = NSEvent.keyEvent(
+      with: .keyDown,
+      location: .zero,
+      modifierFlags: [],
+      timestamp: 0,
+      windowNumber: 0,
+      context: nil,
+      characters: "\u{1B}",
+      charactersIgnoringModifiers: "\u{1B}",
+      isARepeat: false,
+      keyCode: 53
+    )!
+    #expect(HotkeyCapture.isCancel(event))
+  }
+
+  /// The two ways cancel must NOT fire, so it cannot be implemented as a bare
+  /// key-code check. Escape WITH a modifier is a legitimate chord a user may want,
+  /// and key code 53 arriving as a modifier change is not an Escape press at all.
+  @Test("Escape with a modifier is a binding, not a cancel")
+  func escapeWithModifierIsNotCancel() {
+    let event = NSEvent.keyEvent(
+      with: .keyDown,
+      location: .zero,
+      modifierFlags: [.command],
+      timestamp: 0,
+      windowNumber: 0,
+      context: nil,
+      characters: "\u{1B}",
+      charactersIgnoringModifiers: "\u{1B}",
+      isARepeat: false,
+      keyCode: 53
+    )!
+    #expect(!HotkeyCapture.isCancel(event))
+    #expect(HotkeyCapture.binding(for: event) == (53, [.command]))
+  }
+
+  @Test("A modifier change is never a cancel")
+  func modifierChangeIsNeverCancel() {
+    #expect(
+      !HotkeyCapture.isCancel(
+        flagsChanged(keyCode: ModifierKeyCodes.globe, flags: [.function])))
+    #expect(!HotkeyCapture.isCancel(flagsChanged(keyCode: 53, flags: [])))
+  }
+
+  /// The property both surfaces now share by construction. Before #1987 this was
+  /// two copies, so this test would have proven nothing about onboarding.
+  @Test(
+    "Every modifier-only key binds with empty modifiers",
+    arguments: [
+      ModifierKeyCodes.globe, ModifierKeyCodes.rightOption, ModifierKeyCodes.leftOption,
+      ModifierKeyCodes.leftCommand, ModifierKeyCodes.rightCommand, ModifierKeyCodes.leftShift,
+      ModifierKeyCodes.rightShift, ModifierKeyCodes.leftControl, ModifierKeyCodes.rightControl,
+    ])
+  func everyModifierOnlyKeyBindsEmpty(code: UInt16) {
+    let flag = ModifierKeyCodes.flag(for: code)!
+    let result = HotkeyCapture.binding(for: flagsChanged(keyCode: code, flags: flag))
+    #expect(result.keyCode == code)
+    #expect(result.modifiers == [])
   }
 }

--- a/Tests/EnviousWisprTests/Views/HotkeyRecorderGlobeTests.swift
+++ b/Tests/EnviousWisprTests/Views/HotkeyRecorderGlobeTests.swift
@@ -1,0 +1,91 @@
+import AppKit
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #1987 — the SECOND ingress path: assigning the Globe key in the shortcut recorder.
+///
+/// Dispatch and capture do not share code. `HotkeyService` decides what a press
+/// DOES; `KeyCaptureNSView` decides what the recorder ACCEPTS while the user is
+/// choosing a shortcut, and it has its own `flagsChanged` handler. Before #1987
+/// each carried a private copy of the key-code-to-flag mapping, so a change to one
+/// left the other refusing the key, and the feature would half-work in a way that
+/// reads as a dispatch bug.
+///
+/// This suite exercises the capture half with the event shape measured on hardware
+/// (probe, 2026-08-08). `@testable` is used deliberately here rather than widening
+/// `KeyCaptureNSView`: it is an AppKit-local view with no cross-target consumer, so
+/// the plan's access-control rule keeps it internal.
+@MainActor
+@Suite struct HotkeyRecorderGlobeTests {
+
+  /// Builds the event the OS actually delivers for a standalone modifier: a
+  /// `.flagsChanged` carrying the key code, with the flag present on press and
+  /// absent on release.
+  private func flagsChanged(keyCode: UInt16, flags: NSEvent.ModifierFlags) -> NSEvent {
+    NSEvent.keyEvent(
+      with: .flagsChanged,
+      location: .zero,
+      modifierFlags: flags,
+      timestamp: 0,
+      windowNumber: 0,
+      context: nil,
+      characters: "",
+      charactersIgnoringModifiers: "",
+      isARepeat: false,
+      keyCode: keyCode
+    )!
+  }
+
+  private func makeView() -> (KeyCaptureNSView, () -> [UInt16]) {
+    let view = KeyCaptureNSView()
+    var captured: [UInt16] = []
+    view.onKeyEvent = { captured.append($0.keyCode) }
+    return (view, { captured })
+  }
+
+  @Test("The recorder accepts a Globe press")
+  func acceptsGlobePress() {
+    let (view, captured) = makeView()
+    view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.globe, flags: [.function]))
+    #expect(captured() == [ModifierKeyCodes.globe])
+  }
+
+  /// Without this the recorder would bind on the release too, so a single tap
+  /// would register as two assignments.
+  @Test("The recorder ignores the Globe release")
+  func ignoresGlobeRelease() {
+    let (view, captured) = makeView()
+    view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.globe, flags: []))
+    #expect(captured().isEmpty)
+  }
+
+  @Test("A full press then release assigns exactly once")
+  func pressThenReleaseAssignsOnce() {
+    let (view, captured) = makeView()
+    view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.globe, flags: [.function]))
+    view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.globe, flags: []))
+    #expect(captured() == [ModifierKeyCodes.globe])
+  }
+
+  @Test("Existing modifier keys are still accepted, so capture did not regress")
+  func existingModifiersStillAccepted() {
+    let (view, captured) = makeView()
+    view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.rightOption, flags: [.option]))
+    #expect(captured() == [ModifierKeyCodes.rightOption])
+  }
+
+  /// The measured trap on the capture side. Arrow keys carry `.function` in their
+  /// flags, so a recorder that matched on the FLAG would assign itself to an arrow
+  /// key the moment the user moved the cursor while recording.
+  @Test(
+    "An arrow key carrying .function is not accepted as a shortcut",
+    arguments: [UInt16(123), 124, 125, 126])
+  func arrowKeysNotAccepted(code: UInt16) {
+    let (view, captured) = makeView()
+    view.flagsChanged(with: flagsChanged(keyCode: code, flags: [.function]))
+    #expect(captured().isEmpty)
+  }
+}

--- a/website/src/content/help/customizing-your-hotkey.md
+++ b/website/src/content/help/customizing-your-hotkey.md
@@ -27,7 +27,7 @@ You can choose almost any combination that fits how you work.
 - **A modifier on its own.** A modifier key by itself, such as Option alone or Control alone. This is worth considering, because your hand never has to leave the keys it already rests on.
 - **The Globe key on its own.** The 🌐 Globe key, labelled Fn on some keyboards, can be your recording hotkey. Choose it on its own rather than as part of a combination: press Globe by itself, not Globe together with another key. Picking Globe is optional. The right Option key is still the default, and whatever you have already chosen stays as it is.
 
-macOS may already use the Globe key to switch keyboard languages or open the emoji picker. If that happens while you dictate, open **System Settings**, go to **Keyboard**, click the **Press 🌐 key to** menu, and choose **Do Nothing**. Your Globe key stays set as your dictation shortcut either way. This only stops macOS doing its own thing at the same time.
+macOS may already use the Globe key to switch keyboard languages, open the emoji picker, or start its own dictation. If that happens while you dictate, open **System Settings**, go to **Keyboard**, click the **Press 🌐 key to** menu, and choose **Do Nothing**. Your Globe key stays set as your dictation shortcut either way. This only stops macOS doing its own thing at the same time.
 
 ### One key for both modes
 

--- a/website/src/content/help/customizing-your-hotkey.md
+++ b/website/src/content/help/customizing-your-hotkey.md
@@ -4,8 +4,8 @@ description: "Set the keys that start, stop, and cancel dictation."
 category: "recording-and-hotkeys"
 section: "Recording"
 order: 4
-keywords: ["hotkey", "shortcut", "keyboard shortcut", "change the key", "how do i change the key", "key combo", "keybinding", "remap", "different key", "fn key", "caps lock", "conflicts with another app"]
-updated: 2026-08-06
+keywords: ["hotkey", "shortcut", "keyboard shortcut", "change the key", "how do i change the key", "key combo", "keybinding", "remap", "different key", "globe key", "fn key", "caps lock", "conflicts with another app"]
+updated: 2026-08-09
 ---
 Your hotkey is the key you hold or press to record, and you can change it to whatever suits your hands. EnviousWispr arrives set to the right Option key.
 
@@ -25,10 +25,15 @@ You can choose almost any combination that fits how you work.
 
 - **A key with modifiers.** Any key, with or without Command, Option, Control, or Shift.
 - **A modifier on its own.** A modifier key by itself, such as Option alone or Control alone. This is worth considering, because your hand never has to leave the keys it already rests on.
+- **The Globe key on its own.** The 🌐 Globe key, labelled Fn on some keyboards, can be your recording hotkey. Choose it on its own rather than as part of a combination: press Globe by itself, not Globe together with another key. Picking Globe is optional. The right Option key is still the default, and whatever you have already chosen stays as it is.
+
+macOS may already use the Globe key to switch keyboard languages or open the emoji picker. If that happens while you dictate, open **System Settings**, go to **Keyboard**, click the **Press 🌐 key to** menu, and choose **Do Nothing**. Your Globe key stays set as your dictation shortcut either way. This only stops macOS doing its own thing at the same time.
 
 ### One key for both modes
 
 The recording hotkey stays the same whether you use push to talk or toggle mode. Switching between modes changes what a press does to your recording, but never which key you press.
+
+If holding a key down is uncomfortable, toggle mode asks less of your hand: one press starts recording and the next press stops it, so nothing has to be held.
 
 ### The cancel key
 


### PR DESCRIPTION
Closes #1987.

The Globe (Fn) key can now be your dictation shortcut. It was the top request on the 2.4.3 release thread, and it is the key Wispr Flow and several others default to.

Right Option stays the default. Globe is opt-in, and nobody is migrated.

## What a user gets

Pick Globe in Shortcuts or during first-run setup and it behaves exactly like any other shortcut: hold to talk, tap to toggle, double-tap into hands-free, triple-press to cancel. No new mode, no separate code path.

The first time anyone binds it, a one-time explanation appears telling them how to stop macOS using the same key for the emoji picker, language switching, or its own dictation. Once per installation, across both places you can set a shortcut, so choosing Globe during setup does not mean being told again in Settings.

## What is measured

Two content-free properties: which key class produced a press, and which key class is configured. Four values, never a raw key code. Answers the only question worth asking after shipping a top request, which is whether anyone chose it.

## Structure

Three key-code-to-flag mappings existed independently and are now one, with membership derived from it, so a key that is a member but has no flag is unrepresentable. The two shortcut recorders each carried a private copy of the accept/cancel decision; that duplication became load-bearing once accepting a bind decided who shows the explanation, so both now read one authority. Founder-approved as a scope expansion beyond the plan's test seam.

## Verification

5242 tests pass. Twelve mutation controls, each restored: deleting the acceptance callback, disabling the cancel check, removing the modifier-clearing, renaming the persisted key, injecting an integer key code, removing the release-notes entry, stripping the search signals, reverting the capture handlers to unconditional, and removing the focus resignation.

Checked against shipped implementations rather than reimplementations: the real release-notes renderer, the real website build and help checks, and the shipped search functions.

## Known limits, recorded rather than implied

- Nothing proves the shortcut recorder delegates to the shared acceptance authority on either surface. Both call sites need a rendered view hierarchy. A Globe bind that silently did nothing is the visible symptom, and it is on the manual pass.
- Whether the focus fix produces a real focus ring, adds an unexpected Tab stop, or contends with first-responder handling during recording is not unit-testable. Manual pass.
- A required search mutation control did not discriminate: removing the new keyword leaves search passing because the article body also names the key. Recorded rather than reported green. Removing both signals fails correctly, which is what proves the check can fail at all.

## Found in live UAT, fixed here

The founder ran the manual pass and hit a real defect: on the Shortcuts page, ANY key press rebound the shortcut immediately, with no click on the box and no "press a key" prompt.

The capture view's three key handlers acted unconditionally. Nothing checked whether recording was active. What had kept them quiet was that the only focus request sat in the recording branch, so nothing ever focused the view otherwise. That is an absence of opportunity, not a guard, and this PR removed the absence by making the enclosing control focusable so the guidance popover could return focus to it.

One handler was unsafe independently and beforehand: AppKit can route a key equivalent through the view tree rather than to the first responder, so it fired with no focus at all, and returning true also claimed every key equivalent reaching the view. Command+W both rebound the hotkey and failed to close the window.

All three handlers and first-responder eligibility now read one flag, gated in the shared view because it is the event source and both recording surfaces already pass their own recording state to it. At both call sites that flag is the same one driving the "press a key" prompt, so the code now does exactly what the box says it is doing.

Tests 14 to 19. The old helper never armed the view, so every pre-existing capture case was exercising the broken condition and would have passed this bug.

## Routed, not fixed

A second pre-existing defect surfaced in review of that fix: removing an event monitor does not un-queue what it already emitted, so a modifier press queued as hotkeys are disabled can still start a dictation. Real in the code, never observed, and it predates this work. Filed as #1993 under the same ruling as #1991 below, rather than widening a PR that is mid-UAT. Same class as the founder's bug: a handler acting without checking whether it was asked to.



The independent review found that the cancel-key box accepts a bare modifier that can never fire. Verified pre-existing against main: the box already accepted all eight standalone modifiers and the watcher already ignored the cancel key. This adds Globe as a ninth member. Founder decision: ship and track separately, filed as #1991.

## Prior art

The Fn key never arrives as a key press, only as a modifier-state change, so the older registration mechanism cannot bind it and a monitor can see it without consuming it. Consuming it would need an event tap and the Accessibility permission that comes with it. We do not consume it, which is exactly why the explanation exists: the macOS action on that key sits below anything we could intercept.

