### PR TITLE
chore(release): bump version to 2.4.4

### DIFF
--- a/Sources/EnviousWispr/Resources/Info.plist
+++ b/Sources/EnviousWispr/Resources/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4.3</string>
+	<string>2.4.4</string>
 	<key>CFBundleVersion</key>
-	<string>2.4.3</string>
+	<string>2.4.4</string>
 	<key>LSArchitecturePriority</key>
 	<array>
 		<string>arm64</string>

--- a/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
@@ -18,24 +18,69 @@ enum WhatsNewContent {
   }
 
   static let entries: [Entry] = [
-    // MARK: - v2.5.0
+    // MARK: - v2.4.4
+
+    Entry(
+      id: "globe-key-dictation-hotkey",
+      icon: "globe",
+      title: "Use the Globe key, or Fn, as your dictation shortcut",
+      description:
+        "You can now use the Globe key, marked Fn on many Macs, as your dictation shortcut. Right Option stays exactly as it is unless you choose Globe. If macOS also opens emoji, switches your keyboard language, or starts its own dictation when you press it, go to System Settings, then Keyboard, then Press 🌐 key to, and choose Do Nothing.",
+      version: "2.4.4"
+    ),
 
     Entry(
       id: "ollama-cloud-models-appear-automatically",
       icon: "cloud",
       title: "Ollama Cloud models now appear automatically",
       description:
-        "Ollama Cloud models used to appear in Manage Models only after you added them on that Mac. The full lineup now appears there automatically on every install and after every update. The button now says Add instead of Download because nothing is downloading, and cloud models can no longer be deleted. The models available without a paid Ollama plan when checked on August 5, 2026 are listed first.",
-      version: "2.5.0"
+        "Ollama Cloud models used to appear in Manage Models only after you added them on that Mac. The full lineup now appears there automatically on every install and after every update. The button now says Add instead of Download because nothing is downloading, and cloud models can no longer be deleted. For 30 days after the August 5, 2026 check, the models available without a paid Ollama plan are listed first. After that the list returns to a neutral order.",
+      version: "2.4.4"
     ),
 
     Entry(
-      id: "globe-key-dictation-hotkey",
-      icon: "globe",
-      title: "Use the Globe key as your dictation shortcut",
+      id: "ollama-cloud-supported-end-to-end",
+      icon: "checkmark.icloud",
+      title: "Ollama Cloud models are now properly supported end to end",
       description:
-        "You can now use the Globe (Fn) key as your dictation shortcut. Right Option stays exactly as it is unless you choose Globe. If macOS also opens emoji, switches your keyboard language, or starts its own dictation when you press it, go to System Settings, then Keyboard, then Press Globe key to, and choose Do Nothing.",
-      version: "2.5.0"
+        "If you polish with an Ollama Cloud model, EnviousWispr used to treat it as a small model running on your Mac. It gave the model too little room to work, spent your cloud quota on warm-up calls it did not need, and when something failed it told you to start Ollama even though Ollama was already running. Cloud models are now recognised for what they are, and if you are signed out of Ollama the message says so. Models that run on your own Mac also get a prompt written for them, replacing one that was quietly working against itself on most dictations.",
+      version: "2.4.4"
+    ),
+
+    Entry(
+      id: "ollama-settings-stay-accurate",
+      icon: "arrow.clockwise.circle",
+      title: "Ollama settings and the model list now stay accurate",
+      description:
+        "The Ollama status in Settings could get stuck: still saying it was starting after it was ready, or still saying ready after you had quit Ollama. It now keeps itself current while you have the panel open. The model picker also showed two different models under one identical name, so there was no way to tell them apart. Each one is now labelled so you can.",
+      version: "2.4.4"
+    ),
+
+    Entry(
+      id: "continuation-casing-eleven-languages",
+      icon: "character.book.closed",
+      title: "Dictating into the middle of a sentence now works in eleven more languages",
+      description:
+        "When you type part of a sentence and dictate the rest, EnviousWispr matches the capitalisation you would have used yourself. Until now that only worked in English, so every other language got a capital letter dropped into the middle of your sentence. It now works in German, French, Italian, Spanish, Portuguese, Dutch, Danish, Swedish, Finnish, Russian and Turkish. Measured against real published writing, this went from right 7% of the time to right 94%. We also found several ways to make it more accurate everywhere, so it now works reliably in far more of the places you dictate.",
+      version: "2.4.4"
+    ),
+
+    Entry(
+      id: "fewer-transcription-errors",
+      icon: "exclamationmark.bubble",
+      title: "Fewer transcription errors",
+      description:
+        "A quick press with no dictation used to fire an error that had nothing to explain. No more. And a microphone that sent no audio at all now asks you to check your mic, instead of blaming transcription for something transcription never saw.",
+      version: "2.4.4"
+    ),
+
+    Entry(
+      id: "fixes-you-should-never-notice",
+      icon: "checkmark.shield",
+      title: "Fixes you should never notice",
+      description:
+        "Custom Words saves are now much more resilient to an app crash or a power cut. After an update, a leftover model file can no longer be mistaken for a good one. And the speech engine has picked up newer transcription repairs from upstream. All real, all invisible unless something goes wrong.",
+      version: "2.4.4"
     ),
 
     // MARK: - v2.4.3

--- a/Sources/EnviousWisprCore/WhatsNewConstants.swift
+++ b/Sources/EnviousWisprCore/WhatsNewConstants.swift
@@ -4,7 +4,7 @@ import Foundation
 /// EnviousWisprServices (SettingsManager) and the app shell can reference it.
 public enum WhatsNewConstants {
   /// Bump when bundled What's New content changes in a user-visible way.
-  public static let currentContentVersion = "2.5.0"
+  public static let currentContentVersion = "2.4.4"
 
   /// UserDefaults key for the last content version the user has viewed.
   public static let lastSeenVersionDefaultsKey = "lastSeenWhatsNewVersion"

--- a/Tests/EnviousWisprTests/Settings/WhatsNewContentTests.swift
+++ b/Tests/EnviousWisprTests/Settings/WhatsNewContentTests.swift
@@ -59,7 +59,7 @@ struct WhatsNewContentTests {
     // untouched by #1493; asserting the real sequence is the falsifiable version.
     #expect(
       WhatsNewContent.versions == [
-        "2.5.0", "2.4.3", "2.4.1", "2.4.0",
+        "2.4.4", "2.4.3", "2.4.1", "2.4.0",
         "2.3.2", "2.3.1", "2.3.0",
         "2.2.1", "2.2.0",
         "2.1.4", "2.1.3", "2.1.2", "2.1.1", "2.1.0",
@@ -107,10 +107,9 @@ struct WhatsNewContentTests {
 
   /// #1987 — the Globe-key entry, pinned field by field.
   ///
-  /// Deliberately NOT covered by `currentVersionHasEntries` above: another 2.5.0
-  /// entry is already in the group, so that test passes whether or not this one
-  /// exists. Only an exact-ID lookup can tell the difference. (2.5.0 is the OPEN
-  /// group, not a shipped release; the newest tag is v2.4.3.)
+  /// Deliberately NOT covered by `currentVersionHasEntries` above: other 2.4.4
+  /// entries are already in the group, so that test passes whether or not this one
+  /// exists. Only an exact-ID lookup can tell the difference.
   ///
   /// The description is asserted verbatim because it is founder-approved copy
   /// naming a System Settings route, so a paraphrase sends the user looking for a
@@ -119,11 +118,15 @@ struct WhatsNewContentTests {
   /// Two separate facts, previously conflated here into a causal claim that was
   /// simply false:
   ///
-  /// 1. This wording says "Press Globe key to" while the help article and the
-  ///    popover both use the exact macOS label "Press 🌐 key to". That is a copy
-  ///    decision about this surface, NOT a technical limit. Measured 2026-08-09 by
-  ///    putting the symbol in this description and re-running the renderer: it
-  ///    parsed all 116 entries and emitted the symbol intact.
+  /// 1. This wording now uses the exact macOS label "Press 🌐 key to", matching
+  ///    the help article and the popover. It previously said "Press Globe key to",
+  ///    recorded as a copy decision with no rationale beside it while the sentence
+  ///    directly above asserted the opposite principle — that a paraphrase sends
+  ///    the user looking for a menu that is not there. Three surfaces describe one
+  ///    System Settings route and this was the only one paraphrasing it. Changed
+  ///    2026-08-09 (v2.4.4). It was never a technical limit: measured the same day
+  ///    by putting the symbol in this description and re-running the renderer,
+  ///    which parsed all 116 entries and emitted the symbol intact.
   /// 2. `title`, `description`, and `version` must stay direct Swift literals
   ///    rather than shared constants, because `scripts/ci/render-release-notes.py`
   ///    parses the SOURCE TEXT of this file rather than compiled values.
@@ -134,13 +137,14 @@ struct WhatsNewContentTests {
       "the #1987 Globe key entry is missing from What's New")
 
     #expect(entry.icon == "globe")
-    #expect(entry.title == "Use the Globe key as your dictation shortcut")
+    #expect(entry.title == "Use the Globe key, or Fn, as your dictation shortcut")
     #expect(
       entry.description
-        == "You can now use the Globe (Fn) key as your dictation shortcut. Right Option stays "
-        + "exactly as it is unless you choose Globe. If macOS also opens emoji, switches your "
-        + "keyboard language, or starts its own dictation when you press it, go to System "
-        + "Settings, then Keyboard, then Press Globe key to, and choose Do Nothing.")
+        == "You can now use the Globe key, marked Fn on many Macs, as your dictation shortcut. "
+        + "Right Option stays exactly as it is unless you choose Globe. If macOS also opens "
+        + "emoji, switches your keyboard language, or starts its own dictation when you press "
+        + "it, go to System Settings, then Keyboard, then Press 🌐 key to, and choose Do "
+        + "Nothing.")
 
     // Founder amendment 2026-08-09, same reason as the popover: the macOS menu
     // offers three actions and the original copy named two. Membership rather than
@@ -148,7 +152,7 @@ struct WhatsNewContentTests {
     #expect(entry.description.contains("emoji"))
     #expect(entry.description.contains("keyboard language"))
     #expect(entry.description.contains("its own dictation"))
-    #expect(entry.version == "2.5.0")
+    #expect(entry.version == "2.4.4")
     #expect(entry.version == WhatsNewConstants.currentContentVersion)
   }
 }


### PR DESCRIPTION
## Summary

Version bump to v2.4.4 with seven What's New entries covering the 21 user-visible
changes shipped since v2.4.3 (2026-08-01).

The open What's New group was pre-staged as `2.5.0` with two entries. Founder chose
2.4.4, so the group, `WhatsNewConstants.currentContentVersion` and the pinned
sequence in `WhatsNewContentTests` all move together.

### Entries

1. Use the Globe key, or Fn, as your dictation shortcut (#1987)
2. Ollama Cloud models now appear automatically (#1956)
3. Ollama Cloud models are now properly supported end to end (#1914, #1948)
4. Ollama settings and the model list now stay accurate (#1918, #1947)
5. Dictating into the middle of a sentence now works in eleven more languages
   (#1922, #1921, #1926, #1980, #1986)
6. Fewer transcription errors (#1920, #1923, #1925)
7. Fixes you should never notice (#1978, #1977, #1981)

Not given entries, deliberately: the terminal-specific continuation-casing fixes
(folded into entry 5), the help-centre migration and rewrite (#1944, #1961, #1963 —
website, not in-app), and eight internal changes.

## Four false claims caught and fixed before shipping

Local review ran four rounds. Rounds 1 and 2 each found user-facing copy asserting
more than the code delivers, so rather than patch a third instance I enumerated
EVERY factual, quantitative and absolute claim across all seven entries against code
or the originating PR. Four were wrong:

- **Entry 2** stated free-tier Ollama models "are listed first" as permanent fact.
  `OllamaCatalogPresentation.tierSnapshotLifetime` is 30 days and `resolveTierSplit`
  returns nil past it, so the ordering ends **2026-09-04** while a patch note is
  forever. Now scoped to the window, and says what follows it.
- **Entry 7** said "74 fixes from upstream". #1985 says 74 **commits**. The number
  was laundered through a chat summary; removed rather than re-derived.
- **Entry 7** promised Custom Words "survive a crash or a power cut". The
  containing-directory sync is deliberately best-effort (`_ = fcntl(dirFD,
  F_FULLFSYNC)`, whose own comment says a failure "only narrows the crash window").
  Softened to "much more resilient".
- **Entry 4** said each colliding model "shows its own size". #1976 appends the size,
  then falls back to the exact tag when two variants share one. Reworded.

Verified-and-unchanged claims are listed individually in the commit body, including
the signed-out Ollama message read from `PolishFailureReason`, the 92% figure behind
entry 3, and entry 5's eleven languages and 7%→94% measurement.

## Two adjudicated review findings

- **ADOPTED (r4):** the Globe entry directed users to "Press Globe key to"; the macOS
  control is labelled `Press 🌐 key to`, which the popover and help article already
  quote. This entry was the only one of three surfaces paraphrasing it. The prior
  record called the paraphrase a copy decision but gave no rationale, while the line
  above it stated the opposing principle. Fixed in the entry and its verbatim test.
- **REJECTED (r3), founder decision 2026-08-09:** splitting entry 7 into three. Asked
  directly with `whats-new-protocol.md`'s no-generic-bucket rule quoted; founder chose
  one entry. That rule's stated reason targets REPEATING headers, and this title is
  one-off, last, and follows six specific ones. `whats-new-protocol.md` now carries the
  exception with its four conditions so it is not re-litigated every release.

## Test plan

- [x] `scripts/xcode-test.sh` — **5242 executed, 0 failures**
- [x] `WhatsNewContentTests` run alone — **9 tests, 1 suite, passed** (the full run
      reports per-bundle totals only, so it never names this suite)
- [x] Reachability gate: all 206 `#if DEBUG` blocks enumerated, every one in a file
      touching an announced feature read and classified. None gate an announced
      surface.
- [x] Release binary built and probed with a positive control (a v2.4.3 entry, FOUND)
      and a negative control (nonsense string, ABSENT)
- [x] `render-release-notes.py --version 2.4.4` emits all seven entries with the glyph
      intact
- [x] `scripts/build-dev-app.sh` — dev app reports 2.4.4
- [ ] `build-check` CI passes on this PR
- [ ] Tag v2.4.4 after merge triggers the release pipeline
