### PR TITLE
fix(llm): correct the Phi-2 Ollama id and six drifted download sizes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,10 @@ scripts/*
 !scripts/build-dev-app.sh
 !scripts/check-xpc-error-hygiene.sh
 !scripts/check-contacts-data-flow.sh
+# #1951: catalog ids are pull targets, so a wrong one ships a dead Download
+# button. Tracked deliberately — a gitignored validator can only be run by
+# someone who remembers it exists, which is how the false green happens.
+!scripts/check-ollama-catalog-sizes.sh
 !scripts/xcode-test.sh
 !scripts/indexnow-submit.py
 # UAT scripts — required by workflow tooling (workflow-process.md §1 step 9 + §11)

--- a/Sources/EnviousWisprLLM/OllamaSetupService.swift
+++ b/Sources/EnviousWisprLLM/OllamaSetupService.swift
@@ -264,40 +264,59 @@ public final class OllamaSetupService {
   /// Curated suggestions for users who haven't downloaded models yet.
   /// `nonisolated`: immutable Sendable constant, readable from the pure catalog
   /// assembly (`dynamicCatalog(from:)`) and telemetry without a MainActor hop.
+  ///
+  /// EVERY `name` HERE IS A PULL TARGET, so a wrong one ships a Download button
+  /// that can only ever fail — `dynamicCatalog` offers each undownloaded entry as
+  /// a suggestion row and its button calls `pullModel(entry.name)`. `phi-2` was
+  /// wrong for the whole life of this table (`phi-2` 404s; Phi-2 is published as
+  /// `phi`), and nothing detected it because a 500 from `/api/pull` looks like
+  /// any other pull failure (#1951).
+  ///
+  /// `downloadSize` is a DATED literal, not a fact about the registry. Sizes
+  /// re-measured against `registry.ollama.ai` on 2026-08-10: six of the ten
+  /// surviving rows had drifted, five of them past the 5% the checker allows.
+  /// Largest was `gemma3n:e4b` at 1.5 GB, then `llama3.2:1b` at 520 MB —
+  /// a row that told the user 800 MB and downloads 1.3 GB.
+  ///
+  /// Re-measure with `scripts/check-ollama-catalog-sizes.sh` rather than by hand.
+  /// It reads the ids and literals out of THIS table, queries the registry for
+  /// each manifest, and fails closed on any non-200, unparseable literal, or
+  /// name/size count mismatch, so a half-broken probe cannot print a plausible
+  /// number. It needs the network, so it is manual and deliberately not in CI.
   public nonisolated static let modelCatalog: [OllamaModelCatalogEntry] = [
     OllamaModelCatalogEntry(
       name: "gemma3n:e4b", displayName: "Gemma 3 Nano (4B)", parameterCount: "4B",
-      qualityTier: .best, downloadSize: "~6 GB"),
+      qualityTier: .best, downloadSize: "~7.5 GB"),
     OllamaModelCatalogEntry(
       name: "llama3.2", displayName: "Llama 3.2", parameterCount: "3B", qualityTier: .best,
       downloadSize: "~2 GB"),
     OllamaModelCatalogEntry(
       name: "llama3.2:1b", displayName: "Llama 3.2 (1B)", parameterCount: "1B",
-      qualityTier: .medium, downloadSize: "~800 MB"),
+      qualityTier: .medium, downloadSize: "~1.3 GB"),
     OllamaModelCatalogEntry(
       name: "mistral", displayName: "Mistral", parameterCount: "7B", qualityTier: .best,
-      downloadSize: "~4 GB"),
+      downloadSize: "~4.4 GB"),
     OllamaModelCatalogEntry(
       name: "phi3", displayName: "Phi-3 Mini", parameterCount: "3.8B", qualityTier: .medium,
-      downloadSize: "~2.3 GB"),
+      downloadSize: "~2.2 GB"),
     OllamaModelCatalogEntry(
       name: "gemma2:2b", displayName: "Gemma 2 (2B)", parameterCount: "2B", qualityTier: .medium,
       downloadSize: "~1.6 GB"),
     OllamaModelCatalogEntry(
       name: "gemma2", displayName: "Gemma 2", parameterCount: "9B", qualityTier: .best,
-      downloadSize: "~5.5 GB"),
+      downloadSize: "~5.4 GB"),
     OllamaModelCatalogEntry(
       name: "qwen2.5:3b", displayName: "Qwen 2.5 (3B)", parameterCount: "3B", qualityTier: .medium,
       downloadSize: "~1.9 GB"),
     OllamaModelCatalogEntry(
       name: "qwen2.5:7b", displayName: "Qwen 2.5 (7B)", parameterCount: "7B", qualityTier: .best,
-      downloadSize: "~4.4 GB"),
+      downloadSize: "~4.7 GB"),
     OllamaModelCatalogEntry(
       name: "tinyllama", displayName: "TinyLlama", parameterCount: "1.1B", qualityTier: .worst,
       downloadSize: "~638 MB"),
     OllamaModelCatalogEntry(
-      name: "phi-2", displayName: "Phi-2", parameterCount: "2.7B", qualityTier: .worst,
-      downloadSize: "~1.7 GB"),
+      name: "phi", displayName: "Phi-2", parameterCount: "2.7B", qualityTier: .worst,
+      downloadSize: "~1.6 GB"),
   ]
 
   /// First-party curated metadata for models that are NOT publicly pullable (#1269).

--- a/scripts/check-ollama-catalog-sizes.sh
+++ b/scripts/check-ollama-catalog-sizes.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+#
+# Check every `OllamaSetupService.modelCatalog` id against the live Ollama
+# registry: does the id EXIST, and is the `downloadSize` literal still true?
+#
+# Why this is a script and not a test: it needs the network and a third-party
+# registry, so it cannot run in CI without making an unrelated outage fail the
+# build. It is a manual instrument. Run it when touching the catalog, and
+# whenever a size is about to be quoted to a user.
+#
+# #1951: `phi-2` shipped as a catalog id that has never existed in the registry,
+# so its Download button returned HTTP 500 every time for the life of the row.
+# The same run found six of the ten other rows quoting a stale size.
+#
+# FAILS CLOSED. Any non-200, absent manifest, or jq failure prints the reason and
+# exits nonzero, because a probe that half-worked and still printed a number is
+# indistinguishable from a real result
+# (validation-discipline.md RULE: measure-with-the-real-tool-never-a-simulation).
+#
+# Usage:  scripts/check-ollama-catalog-sizes.sh
+# Exit:   0 = every id resolves and every size is within tolerance
+#         1 = at least one id is missing or at least one size has drifted
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CATALOG="$REPO_ROOT/Sources/EnviousWisprLLM/OllamaSetupService.swift"
+REGISTRY="https://registry.ollama.ai/v2/library"
+# A size literal is "still true" within this fraction. Catalog strings are
+# deliberately approximate ("~4.4 GB"), so an exact compare would be noise —
+# but the tolerance must stay BELOW one rounding step of the stated precision or
+# it swallows real drift. Measured on the pre-fix table: at 0.08 both `phi3`
+# (~2.3 vs 2.17, 5.6%) and `qwen2.5:7b` (~4.4 vs 4.68, 6.4%) passed as ok while
+# genuinely stale. At 0.05 both are caught and every correctly-rounded row still
+# passes, the widest being `gemma2` at 1.1%.
+TOLERANCE="0.05"
+
+command -v jq >/dev/null || { echo "FAIL: jq not installed"; exit 1; }
+command -v bc >/dev/null || { echo "FAIL: bc not installed"; exit 1; }
+[ -r "$CATALOG" ] || { echo "FAIL: cannot read $CATALOG"; exit 1; }
+
+# Pull `name:` / `downloadSize:` pairs straight out of the shipped source, so the
+# script can never drift from the table it is checking. Only the `modelCatalog`
+# block is read: `curatedPrivateCatalog` below it is deliberately NOT publicly
+# pullable, so a 404 there is correct and must not be reported as a failure.
+BLOCK="$(awk '/static let modelCatalog/,/^  \]/' "$CATALOG")"
+[ -n "$BLOCK" ] || { echo "FAIL: could not locate modelCatalog in $CATALOG"; exit 1; }
+
+# Entries wrap across lines, so read the two fields as separate ordered lists and
+# pair them by index. A single flattened regex was tried first and is NOT used:
+# `.*?` is not lazy in POSIX ERE, so one match swallowed several entries and the
+# pairing silently came out wrong. The index check below is what catches that.
+NAMES="$(printf '%s' "$BLOCK" | grep -oE 'name: "[^"]+"' | sed 's/name: "//; s/"//')"
+SIZES="$(printf '%s' "$BLOCK" | grep -oE 'downloadSize: "[^"]+"' | sed 's/downloadSize: "//; s/"//')"
+
+N_NAMES=$(printf '%s\n' "$NAMES" | grep -c . || true)
+N_SIZES=$(printf '%s\n' "$SIZES" | grep -c . || true)
+if [ "$N_NAMES" -eq 0 ] || [ "$N_NAMES" != "$N_SIZES" ]; then
+  echo "FAIL: parsed $N_NAMES names and $N_SIZES sizes from modelCatalog — refusing to guess"
+  exit 1
+fi
+echo "Parsed $N_NAMES catalog rows from $(basename "$CATALOG")"
+echo
+
+# Catalog literals are decimal ("~638 MB" == 637,699,655 bytes), not binary.
+to_bytes() {
+  local n unit
+  n=$(printf '%s' "$1" | sed 's/^~//' | awk '{print $1}')
+  unit=$(printf '%s' "$1" | awk '{print $2}')
+  case "$unit" in
+    GB) echo "scale=0; $n * 1000000000 / 1" | bc ;;
+    MB) echo "scale=0; $n * 1000000 / 1" | bc ;;
+    *)  echo "" ;;
+  esac
+}
+
+RC=0
+i=0
+while IFS= read -r ref; do
+  i=$((i + 1))
+  claimed=$(printf '%s\n' "$SIZES" | sed -n "${i}p")
+
+  name="${ref%%:*}"
+  tag="${ref#*:}"
+  [ "$tag" = "$ref" ] && tag="latest"
+
+  resp=$(curl -sS -w '\n%{http_code}' --max-time 30 \
+    -H 'Accept: application/vnd.docker.distribution.manifest.v2+json' \
+    "$REGISTRY/$name/manifests/$tag" 2>/dev/null)
+  code=$(printf '%s' "$resp" | tail -1)
+  body=$(printf '%s' "$resp" | sed '$d')
+
+  if [ "$code" != "200" ]; then
+    printf 'MISSING  %-16s HTTP %s — this row ships a Download button that cannot succeed\n' \
+      "$ref" "$code"
+    RC=1
+    continue
+  fi
+
+  actual=$(printf '%s' "$body" | jq -e '[.layers[].size] | add' 2>/dev/null)
+  if [ -z "$actual" ] || [ "$actual" = "null" ]; then
+    printf 'FAIL     %-16s manifest had no readable layer sizes\n' "$ref"
+    RC=1
+    continue
+  fi
+
+  want=$(to_bytes "$claimed")
+  if [ -z "$want" ]; then
+    printf 'FAIL     %-16s unparseable size literal "%s"\n' "$ref" "$claimed"
+    RC=1
+    continue
+  fi
+
+  drift=$(echo "scale=4; d = ($actual - $want) / $want; if (d < 0) -d else d" | bc)
+  live=$(echo "scale=2; $actual / 1000000000" | bc)
+  if [ "$(echo "$drift > $TOLERANCE" | bc)" = "1" ]; then
+    printf 'DRIFT    %-16s catalog says %-10s registry says %s GB\n' "$ref" "$claimed" "$live"
+    RC=1
+  else
+    printf 'ok       %-16s %-10s (registry %s GB)\n' "$ref" "$claimed" "$live"
+  fi
+done <<< "$NAMES"
+
+echo
+if [ "$RC" -eq 0 ]; then
+  echo "CLEAR: every catalog id resolves and every size is within ${TOLERANCE} of the registry."
+else
+  echo "ACTION NEEDED: update Sources/EnviousWisprLLM/OllamaSetupService.swift and"
+  echo ".claude/knowledge/ollama-operations.md FACT: shipped catalog together."
+fi
+exit $RC


### PR DESCRIPTION
## What

Manage Models offered **Phi-2** with a Download button that could never succeed. `phi-2` is not a published Ollama id, so `pullModel("phi-2")` returned HTTP 500 every time, for the entire life of the row. Ollama publishes Phi-2 as `phi`.

Closes #1951.

Nothing detected it, and that is the interesting half: a 500 from `/api/pull` is indistinguishable from any other pull failure, and the `downloadSize` literals have no oracle at all — they are hand-written approximations nobody re-checks. Six of the ten other rows had gone stale.

## Measured live, not recalled

`registry.ollama.ai` manifest layer sums, 2026-08-10, with every other catalog id as the positive control (all HTTP 200, so the 404 is the id and not a broken probe):

| id | catalog said | registry says |
|---|---|---|
| `phi-2` → `phi` | ~1.7 GB | **404** → 1.60 GB |
| `gemma3n:e4b` | ~6 GB | 7.54 GB |
| `llama3.2:1b` | ~800 MB | 1.32 GB |
| `mistral` | ~4 GB | 4.37 GB |
| `qwen2.5:7b` | ~4.4 GB | 4.68 GB |
| `phi3` | ~2.3 GB | 2.17 GB |
| `gemma2` | ~5.5 GB | 5.44 GB (within rounding, corrected anyway) |

These are user-visible: `AIPolishSettingsView.swift:1870` renders `"\(parameterCount) · \(downloadSize)"` on every local row. A row really did tell the user 800 MB for a 1.3 GB download.

The `.claude/knowledge/ollama-operations.md` table is updated in the same change, per its own instruction to change both together. It had in fact recorded this exact `phi-2` finding on 2026-07-20 and the code stayed wrong for three weeks — which is the argument for the next section.

## The checker, and why it is tracked

Adds `scripts/check-ollama-catalog-sizes.sh` with a `.gitignore` negation. It reads the ids and literals **out of `OllamaSetupService.swift` itself**, so it cannot drift from the table it checks, and fails closed on any non-200, unparseable literal, or name/size count mismatch — a half-broken probe must not be able to print a plausible number.

Tracked deliberately. `scripts/*` is gitignored, and #1944 already recorded the cost: a validator only its author knows about is one nobody runs.

**Two-way control run before trusting it:**
- against the unfixed catalog → exit 1, `phi-2` MISSING plus 5 DRIFT
- against the fixed catalog → exit 0, CLEAR

Tolerance is 5%, not the 8% first written: at 8% both `phi3` and `qwen2.5:7b` passed as ok while genuinely stale. At 5% both are caught and every correctly-rounded row still passes, widest being `gemma2` at 1.1%.

**No unit test, stated rather than implied.** The check needs the network and a third-party registry, so putting it in CI would let an unrelated Ollama outage fail the build. It is a manual instrument and the code comment says so — it does not pretend an automated guard exists.

## Checked, not assumed

`phi` cannot collide with `phi3`: `dynamicCatalog` matches on `canonicalModelName` **equality**, and `canonicalOllamaName` only strips `:latest` (`LLMResult.swift:248`). Prefix matching would have made this a much worse change than the bug.

## Evidence

- Full suite: **5242 tests green** (`OllamaModelCatalogTests` asserts catalog count, which is unchanged at 11)
- Release build: green
- Codex whole-diff review: see below

## Not built, for you to decide

The sizes will rot again — six of eleven in about three weeks. The durable fix is a scheduled job that runs this checker weekly and opens an issue on drift. That is new CI spend and a standing job, so it is a founder call rather than mine; raising it rather than quietly building it.

`council-skip: zero-blast-radius (model-catalog rows)` — no new symbols, no control flow, single-commit revert.
