### PR TITLE
fix(hotkey): refuse a modifier press queued by a torn-down monitor

### DIFF
--- a/Sources/EnviousWisprServices/HotkeyService.swift
+++ b/Sources/EnviousWisprServices/HotkeyService.swift
@@ -170,6 +170,36 @@ public final class HotkeyService {
 
   public private(set) var isSuspended = false
 
+  /// Which modifier-monitor installation the currently installed closures belong to.
+  ///
+  /// Neither lifecycle flag can identify an installation, because both are LEVEL
+  /// signals that return to their permissive value. `stop()` then `start()` —
+  /// exactly what `PipelineSettingsSync.reregisterHotkeys()` does when the user
+  /// changes their shortcut — puts `isEnabled` back to `true` inside one
+  /// main-thread turn, so a press the global monitor queued before that turn is
+  /// delivered after both and sees a permissive flag. `suspend()`/`resume()` has
+  /// the same shape for `isSuspended`.
+  ///
+  /// This token changes on every teardown instead, so a delivery stamped by an
+  /// earlier installation is refused. A wrapping `UInt64` could collide only
+  /// after 2^64 bumps, which is unreachable during a queued event's lifetime —
+  /// stated as a bound rather than as "never repeats", which is false for a
+  /// wrapping counter (#1993 grounded review r1).
+  ///
+  /// `package private(set)`: tests read the real generation the product stamped;
+  /// nothing outside this file can write it.
+  ///
+  /// PORTED, NOT INVENTED — and the closest precedent carries the same name.
+  /// `CaptureVADSignalSource.monitorGeneration` (#1780) solves the identical
+  /// problem for the VAD monitor task, bumped from its single cancellation site
+  /// (`invalidateMonitor()`) and compared before every emit; its comment makes
+  /// the same argument this one does, that an identity which can be REUSED is
+  /// not a staleness guard. `OllamaSetupService.pullEpoch` / `hostedAddEpoch`
+  /// are the same shape again. Non-trapping `&+=` follows those two rather than
+  /// `CaptureVADSignalSource`'s `+= 1`, since wrapping is defined behaviour and
+  /// a trap in a teardown path would be worse than a collision that cannot occur.
+  package private(set) var monitorGeneration: UInt64 = 0
+
   // MARK: - Telemetry (Telemetry Bible Phase 6, #1175)
 
   /// Injected hotkey/input-silence telemetry. Default `.noop` keeps legacy/test
@@ -386,7 +416,7 @@ public final class HotkeyService {
   // MARK: - Hands-Free State Machine
 
   /// Unified PTT + hands-free state machine.
-  /// Called by both `handleCarbonHotkey` and `handleFlagsChanged` for
+  /// Called by both `handleCarbonHotkey` and `handleFlagsChangedValues` for
   /// push-to-talk mode press/release events.
   private func handleRecordAction(isPress: Bool) {
     if isPress {
@@ -599,6 +629,12 @@ public final class HotkeyService {
     // Only install if the hotkey is modifier-only
     guard ModifierKeyCodes.isModifierOnly(toggleKeyCode) else { return }
 
+    // Read AFTER the teardown above, so both closures carry the identity of the
+    // installation being created here rather than the one it replaced. Both
+    // monitors are stamped with the same value on purpose: the generation
+    // identifies the INSTALLATION, and these two closures are that installation.
+    let generation = monitorGeneration
+
     globalModifierMonitor = recordMonitorInstall(
       NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged) {
         [weak self] event in
@@ -609,7 +645,8 @@ public final class HotkeyService {
         DispatchQueue.main.async {
           guard let self else { return }
           MainActor.assumeIsolated {
-            self.handleFlagsChangedValues(keyCode: keyCode, flags: flags)
+            self.handleInstalledMonitorFlagsChangedValues(
+              keyCode: keyCode, flags: flags, generation: generation)
           }
         }
       }, scope: "global")
@@ -618,7 +655,8 @@ public final class HotkeyService {
       NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) {
         [weak self] event in
         MainActor.assumeIsolated {
-          self?.handleFlagsChanged(event)
+          self?.handleInstalledMonitorFlagsChangedValues(
+            keyCode: event.keyCode, flags: event.modifierFlags, generation: generation)
         }
         return event  // pass the event through
       }, scope: "local")
@@ -645,6 +683,13 @@ public final class HotkeyService {
       NSEvent.removeMonitor(monitor)
       localModifierMonitor = nil
     }
+    // Bump on EVERY teardown, including one that removed nothing. This is the
+    // single writer of `monitorGeneration`, and it is the only NSEvent-monitor
+    // teardown path: `stop()` and `suspend()` call it directly, and
+    // `installModifierMonitors()` calls it first, so `stop(); start()` and
+    // `suspend(); resume()` each burn two generations. An event queued against
+    // any earlier installation can therefore never match again.
+    monitorGeneration &+= 1
   }
 
   private func removeCarbonEventHandler() {
@@ -730,17 +775,33 @@ public final class HotkeyService {
     }
   }
 
-  /// Called from the NSEvent flagsChanged monitors for modifier-only hotkeys.
+  /// The lifecycle gate for a modifier event arriving from an INSTALLED monitor.
   ///
-  /// NSEvent gives us the exact keyCode that changed, so we know precisely which
-  /// modifier was pressed or released without needing to diff against a previous state.
-  private func handleFlagsChanged(_ event: NSEvent) {
-    handleFlagsChangedValues(keyCode: event.keyCode, flags: event.modifierFlags)
+  /// Removing a monitor stops NEW callbacks; it cannot recall one the global
+  /// monitor has already queued with `DispatchQueue.main.async`. Such an event is
+  /// refused here on arrival rather than trusted to have been prevented by the
+  /// teardown — removing an event source does not un-queue what it emitted.
+  ///
+  /// Deliberately separate from `handleFlagsChangedValues`: this answers "is this
+  /// event from the monitor installation we currently have", while the seam below
+  /// answers "a modifier changed, what gesture is that". Folding the generation
+  /// check into the seam would silently re-scope every existing test that drives
+  /// it, none of which installs a monitor.
+  ///
+  /// `isSuspended` is NOT re-checked here — the seam owns it, and duplicating it
+  /// would not help anyway, because `suspend()`/`resume()` leaves it permissive
+  /// for exactly the delivery this guard exists to refuse (#1993).
+  package func handleInstalledMonitorFlagsChangedValues(
+    keyCode: UInt16, flags: NSEvent.ModifierFlags, generation: UInt64
+  ) {
+    guard generation == monitorGeneration else { return }
+    handleFlagsChangedValues(keyCode: keyCode, flags: flags)
   }
 
   /// Processes modifier key changes from pre-extracted values.
-  /// Used by the global monitor (which dispatches to main thread with raw values)
-  /// and directly by the local monitor via handleFlagsChanged.
+  /// Reached from both NSEvent modifier monitors through
+  /// `handleInstalledMonitorFlagsChangedValues`, which owns the installation
+  /// check; this function assumes that has already passed.
   /// Test seam (#1987): `package` rather than `private` so tests drive the REAL
   /// modifier dispatch path on a plain import. `internal` would work only through
   /// `@testable`, which couples the seam to a compilation mode.

--- a/Tests/EnviousWisprTests/Services/HotkeyGlobeKeyTests.swift
+++ b/Tests/EnviousWisprTests/Services/HotkeyGlobeKeyTests.swift
@@ -428,4 +428,103 @@ import Testing
     #expect(spy.starts == 1)
     #expect(spy.stops == 1)
   }
+
+  // MARK: - #1993: an event queued by a torn-down monitor must not act
+
+  /// Removing an `NSEvent` monitor stops NEW callbacks but cannot recall one the
+  /// global monitor already queued with `DispatchQueue.main.async`. These four
+  /// drive `handleInstalledMonitorFlagsChangedValues`, the delivery boundary the
+  /// installed closures actually call, rather than the seam above it.
+  ///
+  /// They call the real `start()` / `stop()` because the generation is stamped by
+  /// the product, not by the test — a test-only setter would prove the comparison
+  /// works and nothing about whether the lifecycle arms it
+  /// (validation-discipline.md RULE: a-guard-nothing-arms-is-not-a-guard).
+  ///
+  /// EVERY case that calls `start()` MUST unwind with `stop()`. The Carbon event
+  /// handler stores the service as an UNRETAINED pointer
+  /// (`HotkeyService.swift`, `carbonHotkeyHandler` / `takeUnretainedValue()`), so
+  /// a handler left installed past the service's lifetime dereferences freed
+  /// memory in whatever test runs next.
+
+  @Test("An event from the current installation is delivered — the two-way control")
+  func currentGenerationIsDelivered() async {
+    let spy = Spy()
+    let service = makeService(spy, clock: ManualClock())
+    service.start()
+    defer { service.stop() }
+
+    service.handleInstalledMonitorFlagsChangedValues(
+      keyCode: ModifierKeyCodes.globe, flags: [.function],
+      generation: service.monitorGeneration)
+    await settle(service)
+
+    #expect(spy.starts == 1, "the guard refused a live event — the shortcut is dead for everyone")
+  }
+
+  @Test("An event queued by a monitor that was torn down does nothing")
+  func staleGenerationAfterStopIsRefused() async {
+    let spy = Spy()
+    let service = makeService(spy, clock: ManualClock())
+    service.start()
+    let installed = service.monitorGeneration
+    service.stop()
+
+    service.handleInstalledMonitorFlagsChangedValues(
+      keyCode: ModifierKeyCodes.globe, flags: [.function], generation: installed)
+    await settle(service)
+
+    #expect(spy.starts == 0)
+    #expect(spy.actions.isEmpty)
+  }
+
+  /// The case that decides the whole design. Changing your shortcut runs
+  /// `stop(); start()` (`PipelineSettingsSync.reregisterHotkeys()`), so by the
+  /// time a queued press lands, `isEnabled` is back to `true`. A guard reading
+  /// that flag would admit this event; a guard reading installation identity
+  /// refuses it. The `isEnabled` assertion below is what pins that distinction —
+  /// without it, this case looks identical to the one above.
+  @Test("An event queued before a rebind is refused even though hotkeys are enabled again")
+  func staleGenerationSurvivesStopStartRebind() async {
+    let spy = Spy()
+    let service = makeService(spy, clock: ManualClock())
+    service.start()
+    let firstInstallation = service.monitorGeneration
+    service.stop()
+    service.start()
+    defer { service.stop() }
+
+    #expect(service.isEnabled, "precondition: the rebind re-enabled hotkeys")
+
+    service.handleInstalledMonitorFlagsChangedValues(
+      keyCode: ModifierKeyCodes.globe, flags: [.function], generation: firstInstallation)
+    await settle(service)
+
+    #expect(spy.starts == 0, "an event from the pre-rebind monitor started a dictation")
+  }
+
+  /// Asserts ADJACENT values differ, not that the counter rises forever: it is a
+  /// wrapping `UInt64`, and a comment claiming a guarantee the type cannot honour
+  /// is worse than none (#1993 grounded review r1).
+  @Test("Every lifecycle transition changes the installation identity")
+  func everyLifecycleTransitionChangesGeneration() {
+    let service = makeService(Spy(), clock: ManualClock())
+    defer { service.stop() }
+
+    var seen: [UInt64] = [service.monitorGeneration]
+    service.start()
+    seen.append(service.monitorGeneration)
+    service.suspend()
+    seen.append(service.monitorGeneration)
+    service.resume()
+    seen.append(service.monitorGeneration)
+    service.stop()
+    seen.append(service.monitorGeneration)
+    service.start()
+    seen.append(service.monitorGeneration)
+
+    for (index, pair) in zip(seen, seen.dropFirst()).enumerated() {
+      #expect(pair.0 != pair.1, "transition \(index) reused generation \(pair.0)")
+    }
+  }
 }


### PR DESCRIPTION
## What

A modifier press that arrives just as hotkeys are torn down can still start a dictation. The global monitor hands each press to the main thread with `DispatchQueue.main.async`; removing the monitor stops new callbacks but cannot recall one already queued, and the receiving code never asked which installation it came from.

Closes #1993. Found by the Codex review of PR #1992 (Globe key); pre-existing, not introduced there.

## The design changed mid-flight, and that is the important part

The obvious fix is `guard isEnabled`. **It does not work**, and the coverage round caught it before any code was written.

Turning the shortcut OFF is only half the scenario. CHANGING it runs `PipelineSettingsSync.reregisterHotkeys()` → `stop(); start()` inside a single main-thread turn (`PipelineSettingsSync.swift:425-429`, fired from `.toggleKeyCode` / `.toggleModifiers` at `:176-181`), so `isEnabled` is back to `true` by the time the queued press lands. `suspend()`/`resume()` has the identical shape for `isSuspended`. Both are **level** signals that reset, so neither can identify an installation.

So the guard reads installation identity instead: `removeModifierMonitors()` bumps a `monitorGeneration`, `installModifierMonitors()` stamps both closures with the post-bump value, and delivery refuses anything carrying a stale one. It is the single writer and the only teardown path — `stop()` and `suspend()` call it directly and `installModifierMonitors()` calls it first — so `stop(); start()` and `suspend(); resume()` each burn two generations.

## Ported, not invented

The pre-commit identifier sweep turned up `CaptureVADSignalSource.monitorGeneration` (#1780) — same name, same problem, and its comment makes the ABA argument independently:

> A session id alone is NOT a sufficient staleness guard: `finalizeAtStop` cancels a run without changing the session, and a replacement can reuse the same session, so a resumed old task would still pass a session-only check and emit into the wrong run.

`OllamaSetupService.pullEpoch` / `hostedAddEpoch` are the shape a third time. One deviation, recorded in the code: `&+=` follows the Ollama pair rather than `CaptureVADSignalSource`'s trapping `+= 1`.

## Evidence

Four tests added (14 → 18 declarations). **Both mutation controls were run before any of them was believed:**

| Mutation | Observed |
|---|---|
| Guard deleted | stale + rebind cases RED, positive control GREEN |
| Guard replaced with `guard isEnabled` | **ONLY the rebind case RED** — cases 1 and 2 pass |
| Guard restored | `Test run with 18 tests in 1 suite passed` |

The middle row is the argument for the design: under the rejected fix the suite is green except the headline scenario, so it would have shipped looking correct.

- Full suite: **5246 tests green**
- Release build: green
- Codex whole-diff review: clean — *"The generation check correctly rejects callbacks from removed monitor installations across stop/start and suspend/resume cycles... no blocking regression was found."*
- **Live UAT through the REAL hotkey path: PASS.** `test_ptt(key='fn')` on the dev build of this branch — `Pipeline timing TOTAL: 2.920s`, transcript exact, and `COLD-START [RecordingStarter] PTT-to-recording` in the log, a line emitted only by `RecordingStarter.start()` and never by the menu path. So a genuine system key event traversed the modifier monitor, hit the new boundary, matched its generation, and started a dictation — which is the closure-capture step no unit test can reach.

## Scope and honesty

**Classified HYPOTHETICAL** per `validate-automated-review-findings`: real in the code, never observed in the wild or telemetry. Built anyway because the change is small and the failure is silent — the narrow case that rule authorises.

**Validation is test-only, and the plan says so.** Rev 1 claimed existing telemetry would reveal this; that was false — dropped events emit nothing and admitted events carry only action and key-shape metadata. No counter is added, because it would measure an event never observed.

**The rebind case is proven by test, not by UAT.** Reproducing it live would mean mutating a real shortcut setting and restoring it; the deterministic test covers it and the mutation control proves that test discriminates.

**A first UAT attempt FAILED and was wrong.** `test_ptt` auto-detected the key from the stale `.dev` domain (61, Right Option) while the app listens on the shared domain (63, Globe), so it held a key nothing was waiting for — a silent no-op that reads exactly like "this change broke the hotkey". A two-arm control against unchanged `origin/main` failed identically, which cleared the code; the actual cause was then found by reading `uat-testing.md` properly. Harness defect filed as #1997 and the knowledge file now carries it as its own FACT.

**Out of scope, deliberately:** the eleven `Task { await on…?() }` action hand-offs. Those queue the *consequence* of a decision legitimately taken while the installation was current — a different question. Codex's reasoning is adopted in the plan: stop and cancel must stay deliverable because suppressing cleanup can strand a live recording, while start and toggle would need their own audit.

`handleFlagsChanged(_ event: NSEvent)` is deleted rather than orphaned — its one caller now routes through the new boundary — and the two comments naming it are corrected.

Plan: `docs/feature-requests/issue-1993-2026-08-10-hotkey-delivery-guard.md` (rev 3).
