### PR TITLE
fix(hotkey): make a bare modifier work as the cancel key (#1991)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
+++ b/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
@@ -171,8 +171,10 @@ final class PipelineSettingsSync {
       if settings.hotkeyEnabled { hotkeyService.start() } else { hotkeyService.stop() }
     case .cancelKeyCode:
       hotkeyService.cancelKeyCode = settings.cancelKeyCode
+      hotkeyService.reapplyCancelBinding()
     case .cancelModifiers:
       hotkeyService.cancelModifiers = settings.cancelModifiers
+      hotkeyService.reapplyCancelBinding()
     case .toggleKeyCode:
       hotkeyService.toggleKeyCode = settings.toggleKeyCode
       reregisterHotkeys()
@@ -425,7 +427,9 @@ final class PipelineSettingsSync {
   /// Re-register Carbon hotkeys after a config change.
   private func reregisterHotkeys() {
     guard hotkeyService.isEnabled else { return }
-    hotkeyService.stop()
-    hotkeyService.start()
+    // Not `stop()` + `start()`: that pair disarms an in-flight recording's cancel
+    // key, because `start()` deliberately leaves cancel to the recording that
+    // owns it. The service preserves the arming across the restart instead.
+    hotkeyService.restartPreservingCancelArming()
   }
 }

--- a/Sources/EnviousWisprAppKit/Views/Main/MainWindowView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/MainWindowView.swift
@@ -113,8 +113,16 @@ struct StatusView: View {
               Task { await dictationRuntime.cancelRecording() }
             } label: {
               HStack(spacing: 4) {
-                Text("Esc")
-                  .font(.caption.monospaced())
+                // The CONFIGURED cancel key, not a hard-coded "Esc". This label
+                // said Escape regardless of the setting, so the users whose
+                // cancel key did nothing (#1991) were also being told to press
+                // the wrong key — the display agreed with the default rather
+                // than with them.
+                Text(
+                  KeySymbols.formatHotkey(
+                    keyCode: settings.cancelKeyCode, modifiers: settings.cancelModifiers)
+                )
+                .font(.caption.monospaced())
                 Text("Cancel")
               }
               .foregroundStyle(.secondary)

--- a/Sources/EnviousWisprServices/HotkeyService.swift
+++ b/Sources/EnviousWisprServices/HotkeyService.swift
@@ -69,6 +69,18 @@ public final class HotkeyService {
   private var toggleHotkeyRef: EventHotKeyRef?
   private var cancelHotkeyRef: EventHotKeyRef?
 
+  /// Whether the cancel role is currently armed.
+  ///
+  /// Not derivable from `cancelHotkeyRef`: a bare-modifier cancel key has no
+  /// Carbon registration to hold a ref, so a nil ref means "unarmed" for a chord
+  /// and says nothing at all for a modifier. Tracking arming explicitly is what
+  /// lets the modifier dispatch path know whether a recording is in flight.
+  private var isCancelArmed = false
+
+  /// Cancel's armed state at the moment `suspend()` ran, so `resume()` can put a
+  /// still-running recording back where it was.
+  private var cancelArmedBeforeSuspend = false
+
   // MARK: - NSEvent Modifier Monitors
 
   private var globalModifierMonitor: Any?
@@ -283,7 +295,19 @@ public final class HotkeyService {
   /// Temporarily unregister all hotkeys so the recorder can capture key combos.
   public func suspend() {
     guard isEnabled, !isSuspended else { return }
+    // Remember whether cancel was armed, because the recorder can be opened
+    // while a recording is running and `resume()` must put the user back exactly
+    // where they were. Before #1991 resume restored only the record hotkey and
+    // the monitors, so opening the shortcut box mid-recording silently disarmed
+    // cancel for the rest of that recording.
+    //
+    // Captured BEFORE and assigned AFTER, because `unregisterCancelHotkey()`
+    // deliberately clears the snapshot too — that is what stops the snapshot
+    // outliving its recording. Assigning first would have it wipe the value it
+    // was just given.
+    let wasArmed = isCancelArmed
     unregisterCancelHotkey()
+    cancelArmedBeforeSuspend = wasArmed
     unregisterToggleHotkey()
     removeModifierMonitors()
     isSuspended = true
@@ -297,10 +321,22 @@ public final class HotkeyService {
     registerToggleHotkey()
     installModifierMonitors()
     isSuspended = false
+    if cancelArmedBeforeSuspend { registerCancelHotkey() }
+    cancelArmedBeforeSuspend = false
   }
 
   /// Register the cancel hotkey. Call on `.recording` entry.
+  ///
+  /// Arms the role for BOTH dispatch mechanisms. A chord goes to Carbon exactly
+  /// as before; a bare modifier cannot be registered with Carbon at all, so for
+  /// that shape arming is the flag alone and the already-installed `NSEvent`
+  /// monitors do the observing. Before #1991 this called `registerHotkey`
+  /// unconditionally, so a bare-modifier cancel key was handed to Carbon, failed,
+  /// reported a registration failure, and left the user with a key that is
+  /// stored, displayed, and inert.
   public func registerCancelHotkey() {
+    isCancelArmed = true
+    guard cancelBinding.isCarbonRegistrable else { return }
     guard cancelHotkeyRef == nil else { return }
     cancelHotkeyRef = registerHotkey(
       id: HotkeyID.cancel.rawValue,
@@ -310,11 +346,64 @@ public final class HotkeyService {
   }
 
   /// Remove the cancel hotkey. Call whenever recording ends.
+  ///
+  /// Clears the SUSPENDED snapshot as well as the live flag, because a recording
+  /// can end while the shortcut recorder is still open — VAD auto-stop, the
+  /// duration cap, or the window's own Cancel button all do it. Without this the
+  /// snapshot outlived the recording that justified it, `resume()` re-armed
+  /// cancel onto an idle app, and nothing later would disarm it because the
+  /// recording that owned it had already finished.
   public func unregisterCancelHotkey() {
+    isCancelArmed = false
+    cancelArmedBeforeSuspend = false
     if let ref = cancelHotkeyRef {
       UnregisterEventHotKey(ref)
       cancelHotkeyRef = nil
     }
+  }
+
+  /// Tear down and re-install every hotkey, preserving cancel's armed state.
+  ///
+  /// The settings path re-registers by calling `stop()` then `start()`, which is
+  /// a full teardown: it disarms cancel, and `start()` deliberately does not
+  /// re-arm it because cancel belongs to a recording, not to the service. So
+  /// changing the RECORD key while a recording was in flight silently disarmed
+  /// that recording's cancel key — the same defect as the recorder path, reached
+  /// through a different door.
+  package func restartPreservingCancelArming() {
+    // `!isSuspended` is load-bearing, not defensive. Changing the RECORD binding
+    // is exactly what the shortcut editor does, and the editor suspends first —
+    // so while suspended the armed state lives in `cancelArmedBeforeSuspend` and
+    // `isCancelArmed` reads false. Restarting here would snapshot that false,
+    // and `stop()` would clear the real snapshot on its way through, leaving
+    // cancel dead for the rest of the recording. Precisely the bug this whole
+    // change exists to fix, reintroduced through the most realistic path of all.
+    //
+    // Skipping is safe because `resume()` already registers the latest binding
+    // and restores arming; there is nothing for a restart to add.
+    guard isEnabled, !isSuspended else { return }
+    let wasArmed = isCancelArmed
+    stop()
+    start()
+    if wasArmed { registerCancelHotkey() }
+  }
+
+  /// Re-apply the cancel binding to whichever mechanism now owns it.
+  ///
+  /// The cancel key can change while a recording is in flight (the Settings
+  /// window is reachable then), and it can change shape — chord to bare modifier
+  /// or back — which moves it between Carbon and the monitors. Re-registering
+  /// without re-installing the monitors would leave the new shape unobserved, so
+  /// both are redone together.
+  ///
+  /// Safe while idle: it preserves `isCancelArmed`, so this cannot arm a cancel
+  /// key for a recording that is not running.
+  package func reapplyCancelBinding() {
+    guard isEnabled, !isSuspended else { return }
+    let wasArmed = isCancelArmed
+    unregisterCancelHotkey()
+    installModifierMonitors()
+    if wasArmed { registerCancelHotkey() }
   }
 
   /// Reset all hands-free state. Called before every stop/cancel callback
@@ -623,11 +712,47 @@ public final class HotkeyService {
 
   // MARK: - NSEvent Modifier Monitors
 
+  /// Whether either role needs the `NSEvent` modifier monitors.
+  ///
+  /// #1991, blocker 2. This was `isModifierOnly(toggleKeyCode)` — the RECORD key
+  /// only — so a user pairing a bare-modifier CANCEL key with a chord record key
+  /// got no monitor at all, and nothing could observe their cancel key. That is
+  /// the default record shape, so it is the configuration the affected users are
+  /// actually in. Fixing the dispatch comparison alone would have left them
+  /// exactly as broken while every dispatch-level test passed.
+  ///
+  /// `package` so the install condition is testable directly. Testing it through
+  /// `installModifierMonitors()` would assert on `NSEvent` monitor objects, which
+  /// says nothing about the decision being made here.
+  package var shouldInstallModifierMonitors: Bool {
+    recordBinding.isBareModifier || cancelBinding.isBareModifier
+  }
+
+  /// The current record binding, as one value.
+  package var recordBinding: ShortcutBinding {
+    .keyboard(keyCode: toggleKeyCode, modifiers: toggleModifiers)
+  }
+
+  /// The current cancel binding, as one value.
+  package var cancelBinding: ShortcutBinding {
+    .keyboard(keyCode: cancelKeyCode, modifiers: cancelModifiers)
+  }
+
+  /// Which roles a press may currently trigger.
+  ///
+  /// Record is live whenever the service is; cancel only between
+  /// `registerCancelHotkey()` and `unregisterCancelHotkey()`, which the lifecycle
+  /// drives on `.recording` entry and exit. The Carbon path gets this for free —
+  /// an unregistered hotkey delivers no event — but the modifier monitors stay
+  /// installed the whole time, so the modifier path has to ask.
+  private var armedRoles: Set<ShortcutRole> {
+    isCancelArmed ? [.record, .cancel] : [.record]
+  }
+
   private func installModifierMonitors() {
     removeModifierMonitors()
 
-    // Only install if the hotkey is modifier-only
-    guard ModifierKeyCodes.isModifierOnly(toggleKeyCode) else { return }
+    guard shouldInstallModifierMonitors else { return }
 
     // Read AFTER the teardown above, so both closures carry the identity of the
     // installation being created here rather than the one it replaced. Both
@@ -669,7 +794,18 @@ public final class HotkeyService {
   /// abstracting the whole `NSEvent` stack.
   func recordMonitorInstall(_ monitor: Any?, scope: String) -> Any? {
     if monitor == nil {
-      telemetry.registrationFailed("nsevent_\(scope)", "toggle", nil, "modifier_only")
+      // Which ROLE dies if this monitor is missing. It used to hard-code
+      // "toggle", which was true while the monitors only ever existed for a
+      // modifier-only RECORD key. Now they also install when only CANCEL is a
+      // bare modifier, so a hard-coded kind would report a dead cancel shortcut
+      // as a toggle failure — mislabelling the telemetry for exactly the users
+      // this change is for, in the one signal that would tell us it broke.
+      //
+      // Record wins when both are bare modifiers: it is armed for the whole
+      // session while cancel is armed only during a recording, so it is the
+      // more severe loss and the field holds one value.
+      let kind = recordBinding.isBareModifier ? "toggle" : "cancel"
+      telemetry.registrationFailed("nsevent_\(scope)", kind, nil, "modifier_only")
     }
     return monitor
   }
@@ -704,8 +840,11 @@ public final class HotkeyService {
   private func registerToggleHotkey() {
     unregisterToggleHotkey()
     // Modifier-only hotkeys are handled via NSEvent flagsChanged monitors —
-    // Carbon RegisterEventHotKey cannot register a bare modifier key.
-    guard !ModifierKeyCodes.isModifierOnly(toggleKeyCode) else { return }
+    // Carbon RegisterEventHotKey cannot register a bare modifier key. Asked
+    // through the binding, the same way the cancel path asks it: two spellings
+    // of one question is how the record and cancel paths drifted apart in the
+    // first place.
+    guard recordBinding.isCarbonRegistrable else { return }
     toggleHotkeyRef = registerHotkey(
       id: HotkeyID.toggle.rawValue,
       keyCode: toggleKeyCode,
@@ -817,8 +956,50 @@ public final class HotkeyService {
     // Determine press vs. release by checking whether the flag is present
     let isPress = currentFlags.contains(flag)
 
-    // Unified shortcut — both modes use toggleKeyCode
-    guard keyCode == toggleKeyCode else { return }
+    // #1991, blocker 1. This was `guard keyCode == toggleKeyCode`, which asked
+    // "is this the RECORD key" and returned early for everything else — so a
+    // bare modifier bound to CANCEL reached here and was dropped on the floor.
+    // The comparison now goes through the matcher, which is the single authority
+    // both dispatch paths consult, so a role cannot be handled by one mechanism
+    // and silently omitted from the other again.
+    guard
+      let role = ShortcutMatcher.role(
+        forBareModifierKeyCode: keyCode,
+        record: recordBinding,
+        cancel: cancelBinding,
+        armed: armedRoles)
+    else { return }
+
+    if role == .cancel {
+      // A modifier RELEASE is not a press, on the common path.
+      guard isPress else { return }
+
+      // But `isPress` is NOT proof of a key-down, and this guard alone is not
+      // enough. `.command` / `.option` / `.shift` / `.control` are AGGREGATE,
+      // device-independent flags: with Left Command held, releasing Right
+      // Command leaves `.command` set, so the release reads as a press and the
+      // same physical tap cancels twice. An earlier version of this comment
+      // claimed the guard above prevented exactly that, which was wrong — the
+      // two-key case defeats it, and cloud review caught the claim.
+      //
+      // Disarming here closes it: cancelling ENDS the recording, so the role is
+      // no longer armed the instant it fires, and the stray release finds
+      // nothing to cancel. The lifecycle still calls `unregisterCancelHotkey()`
+      // on the way down; doing it synchronously here also closes the async
+      // window that call leaves open, since `onCancelRecording` is awaited in a
+      // Task that has not run yet when the release arrives.
+      //
+      // Residual, stated rather than engineered around: the aggregate-flag
+      // imprecision is pre-existing and still governs the RECORD path, which
+      // computes `isPress` the same way. Narrowing that needs the device-
+      // dependent left/right masks and would change heart-path dispatch, so it
+      // is not folded into a cancel-key fix.
+      isCancelArmed = false
+      performCleanup()
+      Task { await onCancelRecording?() }
+      emitHotkeyPressed(.cancel, trigger: .cancel)
+      return
+    }
 
     if recordingMode == .toggle {
       guard isPress else { return }

--- a/Sources/EnviousWisprServices/ShortcutBinding.swift
+++ b/Sources/EnviousWisprServices/ShortcutBinding.swift
@@ -1,0 +1,124 @@
+import AppKit
+
+/// Which action a shortcut triggers.
+///
+/// A closed set, deliberately: the #1991 defect was possible because "record"
+/// and "cancel" were never named as members of one thing, so a dispatch path
+/// could handle one and silently omit the other and nothing said so.
+package enum ShortcutRole: String, Sendable, CaseIterable {
+  case record
+  case cancel
+}
+
+/// One shortcut, whatever kind it is.
+///
+/// Today this is keyboard-only. It exists as an enum rather than a struct
+/// because a mouse case is the next member (#1996) and the whole point of the
+/// type is that adding a kind forces every consumer to say what it does with
+/// it, instead of a new kind being quietly invisible to one of two dispatch
+/// paths — which is exactly how a bare-modifier cancel key came to be stored,
+/// displayed, and completely inert for six users.
+///
+/// **A bare modifier stores empty modifiers, not its own flag.** Settled by
+/// #1987: a standalone Right Command is `keyboard(keyCode: 54, modifiers: [])`,
+/// because storing `.command` would require the user to hold the key while
+/// pressing it. `isBareModifier` is the single reader of that convention.
+package enum ShortcutBinding: Equatable, Sendable {
+  case keyboard(keyCode: UInt16, modifiers: NSEvent.ModifierFlags)
+
+  /// True when this is a standalone modifier key with no chord around it — the
+  /// shape Carbon cannot register and the `NSEvent` monitors must observe.
+  package var isBareModifier: Bool {
+    switch self {
+    case .keyboard(let keyCode, let modifiers):
+      return modifiers.isEmpty && ModifierKeyCodes.isModifierOnly(keyCode)
+    }
+  }
+
+  /// True when Carbon can register this binding. The complement of
+  /// `isBareModifier` today; a distinct name because the two questions diverge
+  /// the moment a non-keyboard kind exists, and a caller asking "can Carbon take
+  /// this" must not be answered by "is it a bare modifier".
+  package var isCarbonRegistrable: Bool {
+    switch self {
+    case .keyboard:
+      return !isBareModifier
+    }
+  }
+
+  /// The modifiers this binding requires to be HELD. Empty for a bare modifier,
+  /// which stores its own flag as empty by the #1987 convention.
+  package var requiredModifiers: NSEvent.ModifierFlags {
+    switch self {
+    case .keyboard(_, let modifiers):
+      return modifiers
+    }
+  }
+}
+
+/// The single authority for what an input means.
+///
+/// Pure and `nonisolated` by construction: no state, no timers, no side effects.
+/// That is what makes it testable without a live event stream, and it is a
+/// requirement rather than a nicety for #1996, where the mouse tap callback must
+/// reach a verdict synchronously on its own thread.
+package enum ShortcutMatcher {
+
+  /// Which armed role a bare-modifier key press belongs to, if any.
+  ///
+  /// `armed` is passed in rather than inferred because the two roles are not
+  /// symmetric: record is live whenever the service is running, while cancel is
+  /// armed only for the duration of a recording. A matcher that assumed both
+  /// were always live would cancel recordings that had not started.
+  ///
+  /// **Record wins a tie, and nothing currently prevents the tie.** No conflict
+  /// check has ever existed at either capture surface, so a user can already
+  /// have both roles on one key and some may. Preferring record keeps their
+  /// behaviour exactly as it is today — the old dispatch compared against the
+  /// record key alone, so record won there too — which means this change is not
+  /// a regression for them, merely not yet a fix.
+  ///
+  /// Refusing the pair belongs at capture time, where it can be explained in the
+  /// UI, and it needs both recorders plus user-visible copy. That is the next
+  /// slice's work and is NOT implemented here. This comment says so rather than
+  /// implying a guard exists, and no unused `conflicts(...)` helper ships ahead
+  /// of the consumers that would call it.
+  package static func role(
+    forBareModifierKeyCode keyCode: UInt16,
+    record: ShortcutBinding,
+    cancel: ShortcutBinding,
+    armed: Set<ShortcutRole>
+  ) -> ShortcutRole? {
+    if armed.contains(.record), record == .keyboard(keyCode: keyCode, modifiers: []) {
+      return .record
+    }
+    if armed.contains(.cancel), cancel == .keyboard(keyCode: keyCode, modifiers: []) {
+      // REFUSE when this modifier is also the first half of the record chord.
+      //
+      // Cancel on bare Right Command with record on Command+D: pressing Command
+      // to STOP the recording arrives here first, as a bare Command press that
+      // matches the cancel binding exactly, and the recording is discarded
+      // before D is ever pressed. The user loses everything they just said while
+      // trying to stop — and it is deterministic, not a race.
+      //
+      // Pre-fix dispatch compared against the record key alone and returned
+      // early, so this is a regression THIS change introduced, and it lands
+      // hardest on precisely the users it was written for.
+      //
+      // Refusing is the correct direction, not a compromise: while the record
+      // chord needs this modifier, a bare press of it is genuinely ambiguous —
+      // nothing here can distinguish "cancel" from "starting the record chord",
+      // and no amount of waiting makes it unambiguous without inventing a
+      // timeout that would itself be wrong. Accepting wrongly destroys dictation
+      // the user authored; refusing wrongly costs a shortcut that could never
+      // have worked reliably in that configuration.
+      if let flag = ModifierKeyCodes.flag(for: keyCode),
+        record.requiredModifiers.contains(flag)
+      {
+        return nil
+      }
+      return .cancel
+    }
+    return nil
+  }
+}

--- a/Tests/EnviousWisprTests/Services/HotkeyCancelShortcutTests.swift
+++ b/Tests/EnviousWisprTests/Services/HotkeyCancelShortcutTests.swift
@@ -1,0 +1,476 @@
+import AppKit
+import EnviousWisprCore
+import EnviousWisprServices
+import Foundation
+import Testing
+
+/// #1991 — a bare modifier set as the CANCEL key must actually cancel.
+///
+/// Six production users are in this state right now. The key they chose is
+/// stored, displayed, and completely inert, which is worse than a refusal
+/// because nothing tells them it is dead.
+///
+/// TWO INDEPENDENT BLOCKERS, and a suite that exercised only one would pass a
+/// build that is still broken for every real user:
+///
+/// 1. **Dispatch.** `handleFlagsChangedValues` compared the incoming key code
+///    against the *record* key only, so a modifier bound to cancel returned
+///    early and no cancel ever fired.
+/// 2. **Installation.** The `NSEvent` modifier monitors were installed only when
+///    the RECORD key was modifier-only. The affected users pair a bare-modifier
+///    cancel with a chord record key — the default shape — so no monitor existed
+///    to observe the cancel key in the first place. Fixing (1) alone would leave
+///    them exactly as broken, and every test that drives the dispatch seam
+///    directly would still pass.
+///
+/// So the install cases below go through `shouldInstallModifierMonitors`, the
+/// same expression the installer guards on, rather than the dispatch seam.
+///
+/// Every dispatch case drives the REAL seam, `handleFlagsChangedValues`, with
+/// the physical event shape a modifier produces: the flag is PRESENT on press
+/// and ABSENT on release (measured on hardware for #1987). Asserting on set
+/// membership instead would prove the key is accepted and nothing about what
+/// pressing it does.
+@MainActor
+@Suite struct HotkeyCancelShortcutTests {
+
+  private let rightCommand = ModifierKeyCodes.rightCommand
+  private let rightOption = ModifierKeyCodes.rightOption
+  /// A plain chord record key — the DEFAULT shape for the affected users, and
+  /// the one that hides blocker 2. `kVK_ANSI_D`.
+  private let chordKeyCode: UInt16 = 2
+
+  /// Records which callbacks the service invoked.
+  @MainActor final class Sink {
+    var cancels = 0
+    var toggles = 0
+  }
+
+  /// Signal-based wait: the callback IS the signal. The deadline is a fallback
+  /// AROUND that signal, never the wait itself, and it exists only so a
+  /// regression fails with a test name instead of hanging.
+  ///
+  /// The deadline is not decoration. The first version of this helper had no
+  /// timeout, and the mutation control for the dispatch fix — removing the
+  /// cancel branch from the matcher, which IS the #1991 bug — made the suite
+  /// hang rather than fail. A test that hangs on the regression it exists to
+  /// catch reports nothing at all, which is worse than a red test and much
+  /// harder to read in CI.
+  @MainActor final class Waiter {
+    private var fired = false
+    private var pending: (id: UUID, continuation: CheckedContinuation<Void, Never>)?
+
+    func note() {
+      fired = true
+      guard let pending else { return }
+      self.pending = nil
+      pending.continuation.resume()
+    }
+
+    func wait(timeout: Duration = .seconds(5)) async {
+      if fired { return }
+      let id = UUID()
+      let timeoutTask = Task { @MainActor [weak self] in
+        // settle: deadline fallback around the callback signal; the callback resumes and cancels this
+        try? await Task.sleep(for: timeout)
+        self?.expire(id: id)
+      }
+      await withCheckedContinuation { continuation in
+        pending = (id, continuation)
+      }
+      timeoutTask.cancel()
+    }
+
+    private func expire(id: UUID) {
+      guard let pending, pending.id == id else { return }
+      self.pending = nil
+      Issue.record(Comment(rawValue: "timed out waiting for the callback"))
+      pending.continuation.resume()
+    }
+  }
+
+  private func makeService(
+    recordKey: UInt16,
+    cancelKey: UInt16,
+    mode: RecordingMode = .toggle
+  ) -> (HotkeyService, Sink, Waiter, Waiter) {
+    let sink = Sink()
+    let cancelWaiter = Waiter()
+    let toggleWaiter = Waiter()
+    let service = HotkeyService()
+    service.recordingMode = mode
+    service.toggleKeyCode = recordKey
+    service.toggleModifiers = []
+    service.cancelKeyCode = cancelKey
+    service.cancelModifiers = []
+    service.onCancelRecording = {
+      sink.cancels += 1
+      cancelWaiter.note()
+    }
+    service.onToggleRecording = {
+      sink.toggles += 1
+      toggleWaiter.note()
+    }
+    return (service, sink, cancelWaiter, toggleWaiter)
+  }
+
+  // MARK: - Blocker 1: dispatch
+
+  @Test("a bare-modifier cancel key cancels while cancel is armed")
+  func bareModifierCancelFires() async {
+    let (service, sink, cancelWaiter, _) = makeService(
+      recordKey: chordKeyCode, cancelKey: rightCommand)
+    // Cancel is armed only during a recording, exactly as the lifecycle does it.
+    service.registerCancelHotkey()
+
+    service.handleFlagsChangedValues(keyCode: rightCommand, flags: [.command])
+    await cancelWaiter.wait()
+
+    #expect(sink.cancels == 1)
+    #expect(sink.toggles == 0)
+  }
+
+  /// The other half of the arming contract. Without this, a build that cancels
+  /// on every press of the key — including while idle — passes the case above.
+  @Test("a bare-modifier cancel key does nothing while cancel is NOT armed")
+  func bareModifierCancelSilentWhenUnarmed() async {
+    let (service, sink, _, _) = makeService(recordKey: chordKeyCode, cancelKey: rightCommand)
+    // No registerCancelHotkey: no recording is in flight.
+
+    service.handleFlagsChangedValues(keyCode: rightCommand, flags: [.command])
+    await Task.yield()
+
+    #expect(sink.cancels == 0)
+  }
+
+  @Test("cancel stops firing once the recording ends")
+  func cancelDisarmsAfterRecording() async {
+    let (service, sink, cancelWaiter, _) = makeService(
+      recordKey: chordKeyCode, cancelKey: rightCommand)
+    service.registerCancelHotkey()
+    service.handleFlagsChangedValues(keyCode: rightCommand, flags: [.command])
+    await cancelWaiter.wait()
+    #expect(sink.cancels == 1)
+
+    service.unregisterCancelHotkey()
+    service.handleFlagsChangedValues(keyCode: rightCommand, flags: [.command])
+    await Task.yield()
+
+    #expect(sink.cancels == 1, "a disarmed cancel key must not fire again")
+  }
+
+  /// A modifier RELEASE is not a press. Without this, an implementation that
+  /// ignores the flag would cancel twice per physical press.
+  @Test("releasing the cancel modifier does not cancel")
+  func cancelIgnoresRelease() async {
+    let (service, sink, _, _) = makeService(recordKey: chordKeyCode, cancelKey: rightCommand)
+    service.registerCancelHotkey()
+
+    // Release: the key code arrives with its flag ABSENT.
+    service.handleFlagsChangedValues(keyCode: rightCommand, flags: [])
+    await Task.yield()
+
+    #expect(sink.cancels == 0)
+  }
+
+  /// The record key must keep working unchanged while a cancel binding exists.
+  @Test("a bare-modifier record key still toggles when cancel is also a modifier")
+  func recordStillWorksAlongsideModifierCancel() async {
+    let (service, sink, _, toggleWaiter) = makeService(
+      recordKey: rightOption, cancelKey: rightCommand)
+
+    service.handleFlagsChangedValues(keyCode: rightOption, flags: [.option])
+    await toggleWaiter.wait()
+
+    #expect(sink.toggles == 1)
+    #expect(sink.cancels == 0)
+  }
+
+  /// An unrelated modifier must reach neither role.
+  @Test("an unbound modifier does nothing")
+  func unboundModifierIsInert() async {
+    let (service, sink, _, _) = makeService(recordKey: chordKeyCode, cancelKey: rightCommand)
+    service.registerCancelHotkey()
+
+    service.handleFlagsChangedValues(
+      keyCode: ModifierKeyCodes.leftControl, flags: [.control])
+    await Task.yield()
+
+    #expect(sink.cancels == 0)
+    #expect(sink.toggles == 0)
+  }
+
+  // MARK: - Blocker 2: installation
+
+  /// This is the case the six affected users are actually in, and the one a
+  /// dispatch-only suite cannot see.
+  @Test("monitors install when only the CANCEL key is a bare modifier")
+  func installsForModifierCancelWithChordRecord() {
+    let (service, _, _, _) = makeService(recordKey: chordKeyCode, cancelKey: rightCommand)
+    #expect(service.shouldInstallModifierMonitors)
+  }
+
+  @Test("monitors install when only the RECORD key is a bare modifier")
+  func installsForModifierRecordWithChordCancel() {
+    let (service, _, _, _) = makeService(recordKey: rightOption, cancelKey: 53)
+    #expect(service.shouldInstallModifierMonitors)
+  }
+
+  @Test("monitors install when BOTH keys are bare modifiers")
+  func installsForBothModifiers() {
+    let (service, _, _, _) = makeService(recordKey: rightOption, cancelKey: rightCommand)
+    #expect(service.shouldInstallModifierMonitors)
+  }
+
+  /// The negative control. Without it, an implementation that always installs
+  /// passes all three cases above while doing unnecessary work on every launch.
+  @Test("monitors do NOT install when neither key is a bare modifier")
+  func doesNotInstallForTwoChords() {
+    let (service, _, _, _) = makeService(recordKey: chordKeyCode, cancelKey: 53)
+    #expect(!service.shouldInstallModifierMonitors)
+  }
+
+  // MARK: - Arming across suspend / resume
+
+  /// Opening the shortcut recorder mid-recording must not disarm that
+  /// recording's cancel key. `resume()` used to restore the record hotkey and
+  /// the monitors only, so the user lost cancel for the rest of the recording
+  /// and nothing said so.
+  @Test("cancel survives the recorder opening and closing mid-recording")
+  func cancelSurvivesSuspendResume() async {
+    let (service, sink, cancelWaiter, _) = makeService(
+      recordKey: chordKeyCode, cancelKey: rightCommand)
+    service.start()
+    service.registerCancelHotkey()
+
+    service.suspend()
+    service.resume()
+
+    service.handleFlagsChangedValues(keyCode: rightCommand, flags: [.command])
+    await cancelWaiter.wait()
+
+    #expect(sink.cancels == 1)
+    service.stop()
+  }
+
+  /// The negative control for the case above. Without it, a `resume()` that
+  /// unconditionally arms cancel — rather than restoring what was armed — passes
+  /// the previous test while arming cancel for a recording that never started.
+  @Test("resume does NOT arm cancel when no recording was in flight")
+  func resumeDoesNotArmCancelWhenIdle() async {
+    let (service, sink, _, _) = makeService(recordKey: chordKeyCode, cancelKey: rightCommand)
+    service.start()
+    // No registerCancelHotkey: nothing is recording.
+
+    service.suspend()
+    service.resume()
+
+    service.handleFlagsChangedValues(keyCode: rightCommand, flags: [.command])
+    await Task.yield()
+
+    #expect(sink.cancels == 0)
+    service.stop()
+  }
+
+  /// Changing the cancel key WHILE the recorder is open is the real sequence:
+  /// the recorder suspends the service, the new binding is written, then resume
+  /// runs. `reapplyCancelBinding()` deliberately no-ops while suspended, so this
+  /// asserts that `resume()` picks up the new key rather than restoring the old
+  /// one — a stale-snapshot bug that would look exactly like #1991 all over
+  /// again to the one user most likely to hit it.
+  @Test("a cancel key changed during suspension takes effect on resume")
+  func cancelKeyChangedWhileSuspendedTakesEffect() async {
+    let (service, sink, cancelWaiter, _) = makeService(
+      recordKey: chordKeyCode, cancelKey: rightCommand)
+    service.start()
+    service.registerCancelHotkey()
+
+    service.suspend()
+    service.cancelKeyCode = ModifierKeyCodes.rightControl
+    service.reapplyCancelBinding()  // no-op while suspended, by design
+    service.resume()
+
+    // The OLD key must be inert.
+    service.handleFlagsChangedValues(keyCode: rightCommand, flags: [.command])
+    await Task.yield()
+    #expect(sink.cancels == 0, "the previous cancel key must stop working")
+
+    // The NEW key must cancel.
+    service.handleFlagsChangedValues(
+      keyCode: ModifierKeyCodes.rightControl, flags: [.control])
+    await cancelWaiter.wait()
+    #expect(sink.cancels == 1)
+    service.stop()
+  }
+
+  /// A recording can END while the recorder is still open — VAD auto-stop, the
+  /// duration cap, or the window's Cancel button. The saved arming snapshot must
+  /// die with it, or `resume()` arms cancel onto an idle app and nothing later
+  /// disarms it, because the recording that owned it already finished.
+  ///
+  /// Found by review, not by me: the two suspend/resume tests above both end
+  /// their recording AFTER resume, so neither could reach this ordering.
+  @Test("a recording ending during suspension does not leave cancel armed")
+  func recordingEndingWhileSuspendedDoesNotRearmCancel() async {
+    let (service, sink, _, _) = makeService(recordKey: chordKeyCode, cancelKey: rightCommand)
+    service.start()
+    service.registerCancelHotkey()
+
+    service.suspend()
+    // The recording ends while the recorder is still open.
+    service.unregisterCancelHotkey()
+    service.resume()
+
+    service.handleFlagsChangedValues(keyCode: rightCommand, flags: [.command])
+    await Task.yield()
+
+    #expect(sink.cancels == 0, "cancel must not be armed once its recording has ended")
+    service.stop()
+  }
+
+  /// Changing the RECORD key while the shortcut editor is open is the single
+  /// most likely way to reach this code, because changing the record key IS what
+  /// the editor does — and the editor suspends first.
+  ///
+  /// While suspended the armed state lives in the snapshot and `isCancelArmed`
+  /// reads false, so a restart here would preserve `false` and `stop()` would
+  /// clear the real snapshot on its way through, leaving cancel dead for the rest
+  /// of the recording. That is the #1991 bug itself, reintroduced by its own fix
+  /// in a neighbouring branch; review caught it, not me.
+  @Test("changing the record key while the editor is open keeps cancel alive")
+  func recordKeyChangedWhileSuspendedKeepsCancelArmed() async {
+    let (service, sink, cancelWaiter, _) = makeService(
+      recordKey: chordKeyCode, cancelKey: rightCommand)
+    service.start()
+    service.registerCancelHotkey()
+
+    service.suspend()
+    // The editor writes a new record binding, which drives a re-registration.
+    service.toggleKeyCode = ModifierKeyCodes.rightOption
+    service.restartPreservingCancelArming()
+    service.resume()
+
+    service.handleFlagsChangedValues(keyCode: rightCommand, flags: [.command])
+    await cancelWaiter.wait()
+
+    #expect(sink.cancels == 1, "cancel must survive a record-key change made in the editor")
+    service.stop()
+  }
+
+  /// The same call while NOT suspended must still do its job, or the guard has
+  /// simply disabled the path rather than scoped it.
+  @Test("changing the record key while idle still preserves cancel arming")
+  func recordKeyChangedWhileRunningKeepsCancelArmed() async {
+    let (service, sink, cancelWaiter, _) = makeService(
+      recordKey: chordKeyCode, cancelKey: rightCommand)
+    service.start()
+    service.registerCancelHotkey()
+
+    service.toggleKeyCode = ModifierKeyCodes.rightOption
+    service.restartPreservingCancelArming()
+
+    service.handleFlagsChangedValues(keyCode: rightCommand, flags: [.command])
+    await cancelWaiter.wait()
+
+    #expect(sink.cancels == 1)
+    service.stop()
+  }
+
+  /// `.command` is an AGGREGATE device-independent flag: with Left Command held,
+  /// releasing Right Command leaves `.command` set, so the release reads as a
+  /// press and the same physical tap cancels twice. The `guard isPress` alone
+  /// does not stop it — an earlier comment claimed it did, and cloud review
+  /// showed the two-key case defeats it.
+  @Test("a cancel modifier released while its twin is held does not cancel twice")
+  func cancelDoesNotFireTwiceWhenOppositeSideKeyIsHeld() async {
+    let (service, sink, cancelWaiter, _) = makeService(
+      recordKey: chordKeyCode, cancelKey: rightCommand)
+    service.registerCancelHotkey()
+
+    // Down: Right Command pressed while Left Command is already held.
+    service.handleFlagsChangedValues(keyCode: rightCommand, flags: [.command])
+    await cancelWaiter.wait()
+    #expect(sink.cancels == 1)
+
+    // Up: Right Command released, but Left Command still holds `.command` set,
+    // so the aggregate flag still reads as pressed.
+    service.handleFlagsChangedValues(keyCode: rightCommand, flags: [.command])
+    await Task.yield()
+
+    #expect(sink.cancels == 1, "one physical tap must cancel exactly once")
+  }
+
+  // MARK: - Cancel modifier shadowing the record chord
+
+  /// Cancel on bare Right Command, record on Command+D. Pressing Command to STOP
+  /// the recording arrives as a bare Command press that matches the cancel
+  /// binding exactly, so without a guard the recording is discarded before D is
+  /// ever pressed — the user loses everything they just said while trying to
+  /// stop, deterministically.
+  ///
+  /// A regression this change introduced: the pre-fix dispatch compared against
+  /// the record key alone and returned early here. Found by review.
+  @Test("a cancel modifier required by the record chord does not cancel")
+  func cancelModifierShadowedByRecordChordIsRefused() async {
+    let sink = Sink()
+    let service = HotkeyService()
+    service.recordingMode = .toggle
+    service.toggleKeyCode = chordKeyCode  // D
+    service.toggleModifiers = [.command]  // record is ⌘D
+    service.cancelKeyCode = rightCommand
+    service.cancelModifiers = []
+    service.onCancelRecording = { sink.cancels += 1 }
+    service.registerCancelHotkey()
+
+    service.handleFlagsChangedValues(keyCode: rightCommand, flags: [.command])
+    await Task.yield()
+
+    #expect(sink.cancels == 0, "pressing ⌘ to stop must not discard the recording")
+  }
+
+  /// The control that keeps the guard SCOPED. A cancel modifier the record chord
+  /// does not require is unambiguous and must still cancel — otherwise the fix
+  /// above has simply disabled bare-modifier cancel for every chord user.
+  @Test("a cancel modifier NOT required by the record chord still cancels")
+  func cancelModifierUnrelatedToRecordChordStillWorks() async {
+    let sink = Sink()
+    let waiter = Waiter()
+    let service = HotkeyService()
+    service.recordingMode = .toggle
+    service.toggleKeyCode = chordKeyCode
+    service.toggleModifiers = [.command]  // record is ⌘D
+    service.cancelKeyCode = ModifierKeyCodes.rightOption  // cancel is bare ⌥
+    service.cancelModifiers = []
+    service.onCancelRecording = {
+      sink.cancels += 1
+      waiter.note()
+    }
+    service.registerCancelHotkey()
+
+    service.handleFlagsChangedValues(keyCode: ModifierKeyCodes.rightOption, flags: [.option])
+    await waiter.wait()
+
+    #expect(sink.cancels == 1)
+  }
+
+  // MARK: - Conflicting pair
+
+  /// A pre-existing user may ALREADY have both roles on one key, because no
+  /// conflict check has ever existed at either capture surface. Dispatch must
+  /// stay deterministic for them and keep doing what it does today, which is to
+  /// treat the press as the record key — the old dispatch compared against the
+  /// record key alone, so record won there too. Refusing the pair belongs at
+  /// capture time with user-visible copy, and is the next slice's work.
+  @Test("a conflicting pair still dispatches to record, not cancel")
+  func conflictingPairPrefersRecord() async {
+    let (service, sink, _, toggleWaiter) = makeService(
+      recordKey: rightCommand, cancelKey: rightCommand)
+    service.registerCancelHotkey()
+
+    service.handleFlagsChangedValues(keyCode: rightCommand, flags: [.command])
+    await toggleWaiter.wait()
+
+    #expect(sink.toggles == 1)
+    #expect(sink.cancels == 0)
+  }
+}


### PR DESCRIPTION
Six users have a cancel key that is stored, displayed, and completely inert. That is worse than a refusal, because nothing tells them it is dead — and the recording window was simultaneously telling them to press a different key.

## Two independent blockers

Both verified against live code before either fix was written.

**Dispatch.** `handleFlagsChangedValues` compared the incoming key code against the RECORD key only (`guard keyCode == toggleKeyCode`), so a modifier bound to cancel reached the function and was dropped.

**Installation.** The `NSEvent` modifier monitors installed only when the RECORD key was modifier-only. The affected users pair a bare-modifier cancel with a chord record key — the default record shape — so no monitor existed to observe their cancel key at all.

Fixing the first alone leaves them exactly as broken, and every dispatch-level test still passes. That is why the suite tests the install condition through its own expression rather than through the dispatch seam.

## The root cause is one thing

Two dispatch mechanisms that disagreed about what a valid shortcut is, with cancel only ever wired into one of them. Mouse buttons (#1996) would have been a third and would have recreated the same defect.

So this adds `ShortcutBinding` and `ShortcutMatcher` — one pure, `nonisolated` authority that both paths consult — and routes `registerToggleHotkey` through the same `isCarbonRegistrable` question the cancel path asks, instead of spelling it a second way. Two spellings of one question is how the paths drifted apart to begin with.

Cancel arming is now explicit rather than inferred from the Carbon ref, because a bare-modifier cancel key has no Carbon registration: a nil ref means "unarmed" for a chord and says nothing at all for a modifier.

## Three latent bugs, same defect through different doors

- Changing the cancel key never re-applied it. A shape change (chord ↔ bare modifier) also moves the binding between Carbon and the monitors, so the new shape went unobserved.
- Opening the shortcut recorder mid-recording disarmed that recording's cancel key permanently — `resume()` restored the record hotkey and monitors only.
- Changing the RECORD key mid-recording did the same thing via `stop()` + `start()`. **Found by sweeping for other callers, not by a reviewer.**

Plus the visible one: the recording window displayed `Esc` beside Cancel regardless of the setting.

## Deliberately not done here

The stored shortcut-kind field. It exists to carry a mouse binding, and this slice has no mouse, so introducing it would create a persisted field that no code path here can produce and every code path here must defend against. Persistence is unchanged, no new defaults key, no migration. The field and its round-trip test land in Slice B, where something needs them. Recorded as a deviation in the plan with its cost stated.

## Verification

19 new tests. Every fix was proven to be detected by mutation rather than assumed — I reverted each one in turn and confirmed the right tests went red and nothing else did:

| Mutation | Result |
|---|---|
| Install condition reverted to the pre-fix expression | Exactly one test fails — the one describing the affected users' configuration |
| Cancel branch removed from the matcher | Exactly the two cancel-dispatch tests fail |
| `resume()` reverted to not restoring arming | Exactly the two dependent tests fail; the idle negative control stays green |
| Suspend snapshot not cleared on unregister | Exactly the one recording-ended-while-suspended test fails |
| Suspended-restart guard removed | Exactly the editor-open test fails; the idle counterpart stays green |
| Shadowing guard removed | Exactly the data-loss test fails; the unrelated-modifier control stays green |

The second mutation initially made the suite **hang** rather than fail, because the waiter had no deadline. A test that hangs on the regression it exists to catch reports nothing at all, and reads as broken infrastructure rather than a broken feature. Fixed by adopting the bounded waiter the neighbouring Globe-key suite already uses instead of inventing a second one.

Negative controls throughout, because without them a build that cancels on every press, or always installs monitors, would pass every positive case: an unarmed cancel key does nothing; a modifier RELEASE does not cancel; an unbound modifier reaches neither role; and the monitors do NOT install when neither key is a bare modifier.

### The one that mattered, found in round three

A bare-modifier cancel key whose modifier the RECORD chord also requires **destroyed the recording when the user tried to stop it**. Cancel on bare Right Command with record on ⌘D: pressing ⌘ to stop arrives first as a bare ⌘ press, matches the cancel binding exactly, and discards the recording before D is ever pressed. Deterministic, not a race.

It was a regression *this change introduced* — the pre-fix dispatch compared against the record key alone and returned early — and it landed on precisely the users #1991 exists to help, turning "cancel does nothing" into "stopping destroys your words". It survived three review rounds, seven earlier fixes and 5263 passing tests, because every cancel test used a modifier unrelated to the record shortcut, so the fixture set could not contain the failure.

The matcher now refuses to cancel when the record chord requires that modifier. Refusal is correct rather than a compromise: while the record chord needs it, a bare press is genuinely indistinguishable from the start of that chord, and no wait resolves it without inventing a timeout that would itself be wrong. Accepting wrongly destroys authored dictation; refusing wrongly costs a shortcut that could never have worked.

**Known limit, recorded rather than papered over:** in that one configuration the cancel key is silently inert — the same silent-dead-shortcut shape this change exists to remove, narrowed to one combination and deliberately chosen over data loss. It also raises Slice B's bar: the conflict authority was specified as *equality*, and this pair is not equal and still unusable, so capture must refuse **overlap**.

**Full suite: 5265 tests, zero failures. Four review rounds; the last returned no findings.**

## Swept and deliberately unchanged

- The `Esc` in onboarding is the shortcut recorder's own abort key (hard-coded 53), not the dictation cancel shortcut.
- The help centre already documents that the cancel key is configurable, in two articles.

Closes #1991
