### PR TITLE
fix(hotkey): refuse an unresolvable push-to-talk binding instead of guessing a key

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -610,6 +610,21 @@ jobs:
           scripts/ci/check-download-link-utms.sh --self-test
           scripts/ci/check-download-link-utms.sh
 
+      - name: RuntimeUAT PTT binding policy + Swift/Python key parity
+        run: |
+          set -euo pipefail
+          # #1997. The UAT harness resolves which key to hold for push-to-talk.
+          # When it cannot, it must REFUSE — a harness that presses a guessed key
+          # reports the resulting silence as a product failure, which is what
+          # happened on 2026-08-10. These self-tests lock that policy, and the
+          # parity case fails if Swift's standalone-modifier set and Python's
+          # MODIFIER_KEYS drift apart in EITHER direction: an app-only key makes
+          # the harness refuse (safe), but a Python-only key makes it post a
+          # modifier event at a Carbon-registered hotkey and produce exactly that
+          # false product FAIL. Neither module imports Quartz, so both run here.
+          python3 Tests/RuntimeUAT/ptt_binding.py --self-test
+          python3 Tests/RuntimeUAT/faultInjection.py --self-test
+
       - name: Require both build lanes
         run: |
           if [ "${{ needs.build-debug.result }}" != "success" ] \

--- a/Tests/RuntimeUAT/classifier_benchmark.py
+++ b/Tests/RuntimeUAT/classifier_benchmark.py
@@ -30,6 +30,7 @@ from pathlib import Path
 
 HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(HERE))
+from ptt_binding import run_instrument_boundary  # noqa: E402
 from wispr_eyes import record_tts  # noqa: E402
 
 LOG = Path.home() / "Library/Logs/EnviousWispr/app.log"
@@ -88,7 +89,7 @@ def _events_since(t0: float):
     return clf, filt
 
 
-def main() -> int:
+def _main() -> int:
     if not LOG.exists():
         print("FAIL: app.log not found — is the DEBUG dev build running?")
         return 2
@@ -134,6 +135,12 @@ def main() -> int:
     print("Read ~/Library/Logs/EnviousWispr/app.log [OutputClassifier]/[AIPolish] "
           "for the authoritative per-line record.")
     return 0 if ok else 1
+
+
+def main() -> int:
+    # CLI boundary: an invalid binding aborts all ten dictations rather than
+    # scoring them (#1997).
+    return run_instrument_boundary(_main)
 
 
 if __name__ == "__main__":

--- a/Tests/RuntimeUAT/faultInjection.py
+++ b/Tests/RuntimeUAT/faultInjection.py
@@ -42,6 +42,15 @@ from datetime import datetime
 from pathlib import Path
 from typing import Callable, Optional
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from ptt_binding import (  # noqa: E402
+    PTTBindingError,
+    resolve,
+    run_instrument_boundary,
+    run_self_tests,
+)
+
 ENDPOINT_HOST = "127.0.0.1"
 ENDPOINT_PORT = 8765
 TOKEN_DIR = Path("~/Library/Logs/EnviousWispr").expanduser()
@@ -105,8 +114,21 @@ def run_scenario(name: str, **kwargs) -> dict:
             f"{name} is Lane B (founder-required). Re-run with founder_present=True after "
             "physically performing the manual step described in SCENARIOS.md."
         )
+    # Open a caching scope; the binding itself is resolved LAZILY on first PTT
+    # use, so menu-driven scenarios (A8a, A8b, B1) that never synthesize the key
+    # are unaffected by the PTT configuration entirely (#1997).
+    global _SCENARIO_DEPTH
+    _SCENARIO_DEPTH += 1
     started = time.monotonic()
-    result = fn(**kwargs)
+    try:
+        result = fn(**kwargs)
+    finally:
+        # Clear on EVERY exit, including the raising one: a binding that outlives
+        # its scenario would be posted by a later tap after the founder rebound
+        # the shortcut, which is this issue's defect all over again.
+        _SCENARIO_DEPTH -= 1
+        if _SCENARIO_DEPTH == 0:
+            clear_ptt_binding()
     elapsed = time.monotonic() - started
     return {"name": name, "lane": meta.lane, "elapsed_seconds": elapsed, "result": result}
 
@@ -463,25 +485,83 @@ def assert_no_zombie() -> dict:
 # ──────────────────────────── recording control helpers ────────────────────
 
 
-_RIGHT_CMD_KEYCODE = 54
+# _RIGHT_CMD_KEYCODE was deleted with the fallback it existed to serve (#1997).
+# Do not reintroduce a default keycode here: pressing a remembered key when the
+# configured one cannot be read is exactly how an instrument failure gets scored
+# as a product failure.
 _ESC_KEYCODE = 53
 
 
-def _ptt_keycode() -> int:
-    """The app's configured PTT key (shared-suite `toggleKeyCode`), falling
-    back to Right Command. The dev bundle reads the founder's REAL settings
-    (#923), so a hardcoded keycode silently misses when the configured key
-    differs — 2026-07-09: taps posted Right Cmd (54) while the configured key
-    was Right Option (61); zero presses reached the app and the A11 recovery
-    cycle failed without exercising anything."""
-    try:
-        out = subprocess.run(
-            ["defaults", "read", "com.enviouswispr.app", "toggleKeyCode"],
-            capture_output=True, text=True, timeout=5,
+def _require_fault_injection_binding(binding):
+    """This module's OWN drivability question, deliberately not `ptt_binding`'s.
+
+    `_tap_rcmd` posts only `flagsChanged` events, so it can drive a standalone
+    modifier and nothing else. `wispr_eyes` can additionally drive ordinary keys
+    through `KEY_CODES`, which is why drivability lives with each consumer rather
+    than in the shared resolver (#1997 plan §3c).
+    """
+    if not binding.is_modifier_only:
+        raise PTTBindingError(
+            "faultInjection can only post modifier events, but the configured "
+            f"key is ordinary: keycode={binding.keycode}, key={binding.key_name}"
         )
-        return int(out.stdout.strip())
-    except Exception:
-        return _RIGHT_CMD_KEYCODE
+    return binding
+
+
+# Scoped to ONE scenario, never process-lifetime. A cache that outlives its
+# scenario is this issue's own defect wearing a new hat: a later tap would post a
+# key the founder had since rebound away from, and the resulting silence would be
+# scored as a product failure. `_SCENARIO_DEPTH` is the scope: caching happens
+# only while it is nonzero, so the ad-hoc path resolves fresh every time (7.3 ms),
+# which is what the pre-#1997 code did anyway.
+_CACHED_BINDING = None
+_SCENARIO_DEPTH = 0
+
+
+def clear_ptt_binding() -> None:
+    global _CACHED_BINDING
+    _CACHED_BINDING = None
+
+
+def _ptt_binding():
+    """Resolve and validate the PTT binding, caching ONLY inside a scenario.
+
+    Three constraints meet here, and the first two drafts each satisfied two of
+    them (whole-diff review r4 and r5):
+
+    * A tap must not pay a `defaults` subprocess. `_tap_rcmd` runs inside
+      `A1_rapid_stop_start`'s 100 ms fuzz interval and the 500 ms double-tap
+      window; measured, a resolve costs 7.3 ms mean / 7.9 ms max (24/49 ms while
+      it was three reads) against 0.1 us for the cached read.
+    * A cached binding must not outlive its scenario. Otherwise a later tap posts
+      a key the founder has since rebound away from — this issue's own defect.
+    * Resolution must be LAZY. Validating up front in `run_scenario` aborted
+      menu-driven scenarios (A8a, A8b, B1) that never synthesize the PTT key at
+      all, so a toggle-mode or chord-bound user could not run valid tests.
+
+    Hence: resolve on FIRST PTT use, cache for the rest of the scenario, and
+    never cache on the ad-hoc path.
+    """
+    global _CACHED_BINDING
+    if _SCENARIO_DEPTH and _CACHED_BINDING is not None:
+        return _CACHED_BINDING
+    binding = _require_fault_injection_binding(resolve())
+    if _SCENARIO_DEPTH:
+        _CACHED_BINDING = binding
+    return binding
+
+
+def _ptt_keycode() -> int:
+    """The app's configured PTT key, or raise `PTTBindingError`.
+
+    This used to own its own `defaults` read and fall back to Right Command on
+    ANY exception. That fallback was the same defect as #1997's other half: a
+    scenario would post a key nothing was listening for and then be scored as a
+    product failure. 2026-07-09 is the recorded instance — taps posted Right Cmd
+    (54) while the configured key was Right Option (61), and the A11 recovery
+    cycle "failed" without exercising anything.
+    """
+    return _ptt_binding().keycode
 
 
 def _import_simulate_input():
@@ -512,8 +592,12 @@ def _tap_rcmd(hold_s: float = 0.05) -> None:
     sim = _import_simulate_input()
     keycode = _ptt_keycode()
     sim.modifier_down(keycode)
-    time.sleep(hold_s)
-    sim.modifier_up(keycode)
+    try:
+        time.sleep(hold_s)  # settle: the hold duration IS the gesture under test, not a wait for a signal
+    finally:
+        # Release even if the sleep is interrupted: a stuck modifier leaves the
+        # app recording and keeps capturing the founder's microphone.
+        sim.modifier_up(keycode)
 
 
 
@@ -1739,11 +1823,139 @@ def wait_crash_boundary_reached(boundary: str, trial_id: str, deadline_sec: floa
     return False
 
 
-def main(argv: list[str]) -> int:
+def _self_test_ordinary_key_is_refused() -> None:
+    """This module's own drivability policy, testable without Quartz."""
+    from ptt_binding import PTTBinding
+
+    ordinary = PTTBinding(
+        keycode=49, key_name="space", modifiers_raw=0,
+        recording_mode="pushToTalk", is_modifier_only=False,
+    )
+    try:
+        _require_fault_injection_binding(ordinary)
+    except PTTBindingError:
+        pass
+    else:
+        raise AssertionError("expected an ordinary key to be refused")
+
+    modifier = PTTBinding(
+        keycode=63, key_name="fn", modifiers_raw=0,
+        recording_mode="pushToTalk", is_modifier_only=True,
+    )
+    # Two-way control: a policy that refused everything would pass the half above.
+    assert _require_fault_injection_binding(modifier) is modifier
+
+
+def _self_test_cache_does_not_outlive_a_scenario() -> None:
+    """A cached binding must not survive its scenario, including on the raising path.
+
+    Whole-diff review r4: a process-lifetime cache means a later ad-hoc tap posts
+    a key the founder may have rebound away from — the same false product failure
+    this change removes, arriving through the fix for the timing regression.
+    """
+    from ptt_binding import PTTBinding
+
+    global _CACHED_BINDING
+    _CACHED_BINDING = PTTBinding(
+        keycode=63, key_name="fn", modifiers_raw=0,
+        recording_mode="pushToTalk", is_modifier_only=True,
+    )
+    clear_ptt_binding()
+    assert _CACHED_BINDING is None, "clear_ptt_binding did not clear"
+
+    # A menu-driven scenario must never resolve the PTT binding at all: A8a, A8b
+    # and B1 drive recording through menu controls, so a toggle-mode or
+    # chord-bound user must still be able to run them (whole-diff review r5).
+    resolves = []
+    original_resolve = globals()["resolve"]
+    original_entry = _REGISTRY.get("__selftest_menu__")
+
+    def counting_resolve(*_a, **_k):
+        resolves.append(1)
+        raise PTTBindingError("resolve must not be reached by a menu-only scenario")
+
+    def menu_only(**_kwargs):
+        return {"ok": True}
+
+    globals()["resolve"] = counting_resolve
+    _REGISTRY["__selftest_menu__"] = (menu_only, _REGISTRY["A1_rapid_stop_start"][1])
+    try:
+        run_scenario("__selftest_menu__")
+    finally:
+        globals()["resolve"] = original_resolve
+        if original_entry is None:
+            _REGISTRY.pop("__selftest_menu__", None)
+        else:
+            _REGISTRY["__selftest_menu__"] = original_entry
+    assert not resolves, "a menu-only scenario resolved the PTT binding"
+
+    # And the ad-hoc path must not populate the scenario cache.
+    stub_adhoc = PTTBinding(
+        keycode=61, key_name="ropt", modifiers_raw=0,
+        recording_mode="pushToTalk", is_modifier_only=True,
+    )
+    original_resolve = globals()["resolve"]
+    globals()["resolve"] = lambda *a, **k: stub_adhoc
+    try:
+        assert _ptt_keycode() == 61
+        assert _CACHED_BINDING is None, "an ad-hoc tap populated the scenario cache"
+    finally:
+        globals()["resolve"] = original_resolve
+
+    # And `run_scenario` must clear even when the scenario raises.
+    #
+    # `resolve` is stubbed rather than called. The first draft let the real one
+    # run, which made this case ARMED on a dev Mac and VACUOUS in CI: with no
+    # PyObjC the resolve refuses, the cache is never set, and `assert is None`
+    # passes having tested nothing — green in the one gate that matters. Proving
+    # that took applying the mutation and finding the case still passed.
+    stub = PTTBinding(
+        keycode=63, key_name="fn", modifiers_raw=0,
+        recording_mode="pushToTalk", is_modifier_only=True,
+    )
+    original_resolve = globals()["resolve"]
+    original_entry = _REGISTRY.get("__selftest__")
+    reached = []
+
+    def boom(**_kwargs):
+        # Resolution is LAZY, so ask for the key first — that is what a real
+        # PTT scenario does — then confirm the scenario cached it.
+        _ptt_keycode()
+        reached.append(_CACHED_BINDING)
+        raise RuntimeError("deliberate scenario failure")
+
+    globals()["resolve"] = lambda *a, **k: stub
+    _REGISTRY["__selftest__"] = (boom, _REGISTRY["A1_rapid_stop_start"][1])
+    try:
+        run_scenario("__selftest__")
+    except RuntimeError:
+        pass
+    finally:
+        globals()["resolve"] = original_resolve
+        if original_entry is None:
+            _REGISTRY.pop("__selftest__", None)
+        else:
+            _REGISTRY["__selftest__"] = original_entry
+
+    # Without these the case could pass by never running the scenario at all.
+    assert reached, "scenario body never ran — the case would be vacuous"
+    assert reached[0] is stub, f"binding not live DURING the scenario: {reached[0]!r}"
+    assert _CACHED_BINDING is None, "cache survived a raising scenario"
+
+
+_SELF_TEST_CASES = [
+    ("ordinary key refused, modifier accepted", _self_test_ordinary_key_is_refused),
+    ("cache does not outlive a scenario", _self_test_cache_does_not_outlive_a_scenario),
+]
+
+
+def _main(argv: list[str]) -> int:
     if not argv or argv[0] in ("-h", "--help", "list", "list_scenarios"):
         print_scenarios()
         return 0
     cmd = argv[0]
+    if cmd == "--self-test":
+        return run_self_tests(_SELF_TEST_CASES)
     if cmd == "run" and len(argv) >= 2:
         wrapped = run_scenario(argv[1])
         print(wrapped)
@@ -1757,6 +1969,13 @@ def main(argv: list[str]) -> int:
         return 0
     print(f"unknown: {cmd}", file=sys.stderr)
     return 2
+
+
+def main(argv: list[str]) -> int:
+    # A CLI boundary: an unresolvable binding is an INSTRUMENT failure and must
+    # never be scored as a scenario result (#1997). Shared adapter so every
+    # boundary emits the identical line.
+    return run_instrument_boundary(lambda: _main(argv))
 
 
 if __name__ == "__main__":

--- a/Tests/RuntimeUAT/measure_asr_xpc_recovery_latency.py
+++ b/Tests/RuntimeUAT/measure_asr_xpc_recovery_latency.py
@@ -51,6 +51,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+from ptt_binding import run_instrument_boundary  # noqa: E402
 from faultInjection import (  # noqa: E402
     APP_LOG_PATH,
     _active_state,
@@ -91,7 +92,7 @@ def run_trial(index: int) -> dict:
     return {"index": index, "ok": True, **result}
 
 
-def main(argv: list[str]) -> int:
+def _main(argv: list[str]) -> int:
     n = int(argv[0]) if argv else 30
     trials = []
     for i in range(n):
@@ -125,6 +126,11 @@ def main(argv: list[str]) -> int:
         # can never be mistaken for a clean 30/30 measurement.
         return 1
     return 0
+
+
+def main(argv: list[str]) -> int:
+    # CLI boundary: see run_gauntlet.main (#1997).
+    return run_instrument_boundary(lambda: _main(argv))
 
 
 if __name__ == "__main__":

--- a/Tests/RuntimeUAT/ptt_binding.py
+++ b/Tests/RuntimeUAT/ptt_binding.py
@@ -1,0 +1,779 @@
+"""Resolve the app's push-to-talk binding, or refuse — never guess (#1997).
+
+Why this module exists
+----------------------
+On 2026-08-10 a UAT run reported that the product ignored the hotkey. It had
+not. `wispr_eyes._resolve_ptt_key` read `toggleKeyCode` from the retired
+`com.enviouswispr.app.dev` domain while the app reads the shared
+`com.enviouswispr.app` (`SettingsDefaults.store` redirects the dev build), and
+its private 4-entry keycode->name map could not name Globe (63) even from the
+right domain, so it fell through to a hardcoded `rcmd`. The harness held a key
+nothing was listening for and returned an ordinary boolean FAIL — on a branch
+that had just changed hotkey delivery, which is the single context in which a
+hotkey FAIL is most likely to be believed.
+
+The defect class is not "wrong domain". It is **an instrument failure reported
+as a product verdict**. If the binding cannot be established, raise
+`PTTBindingError`; never return a guessed key, and never let a caller convert
+that into a PASS/FAIL about the product.
+
+Design notes that are load-bearing
+----------------------------------
+* ONE `defaults export` OF THE WHOLE DOMAIN, not a read per key. `defaults read
+  <domain> <key>` reports a missing key and an operational failure with the same
+  exit status and the same English sentence, so absence could only be guessed at
+  from locale-sensitive text. `export` sidesteps that entirely: it succeeds even
+  for a domain that does not exist (emitting an empty plist), so **key presence
+  is a dict membership test** and any nonzero exit is unambiguously an instrument
+  failure. It is also one subprocess instead of three — measured 8 ms rather than
+  24 ms mean, which matters because `faultInjection` taps inside a 100 ms fuzz
+  window and a 500 ms double-tap window.
+* AN ABSENT KEY IS NOT A GUESS. `SettingsManager` resolves an unset preference
+  through `SettingsDefaultValues` and deliberately does NOT persist it
+  (`SettingsManager.swift:691`, `:639`; #923 forbids an onboarding write, which
+  would make default users look customized). On a fresh or reset profile the app
+  really is running Right Option in push-to-talk with nothing on disk, so
+  refusing there would reject a valid configuration. Absent resolves through the
+  same canonical source the app reads; a PRESENT-but-malformed value still
+  refuses, because that tells us nothing about what the app is using.
+
+  This is not the deleted `rcmd` fallback under a new name. That pressed 54,
+  matching neither the configured key nor any default — something nothing was
+  listening for. The test is "does the harness press what the app listens for",
+  and `--self-test` asserts these constants against `SettingsDefaultValues.swift`
+  so they cannot decay into remembered values.
+* NOTHING MAY ESCAPE AS A NON-`PTTBindingError`. A caller's generic handler would
+  record it as a failed product scenario, which is this defect arriving by a side
+  door. Both known escapes — a non-`FileNotFoundError` `OSError` from the
+  subprocess launch, and an `ImportError` from the lazy `simulate_input` import
+  on a box without PyObjC — are classified, and a self-test case fails if either
+  escapes again.
+* DRIVABILITY BELONGS TO THE CONSUMER. `wispr_eyes` can hold ordinary keys and
+  modifiers; `faultInjection` posts only modifier events. This module owns
+  CONFIGURATION.
+* No top-level `simulate_input` import: it imports Quartz at module scope, so
+  importing it would make this module and its self-test unimportable in CI.
+"""
+import argparse
+import ast
+import plistlib
+import re
+import subprocess
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+# The one domain both builds read. The dev build redirects here via
+# SettingsDefaults.store (Sources/EnviousWisprServices/SettingsDefaults.swift),
+# so `com.enviouswispr.app.dev` holds only pre-#923 residue. Do not add a
+# fallback to it: reading a stale domain is what caused #1997.
+SHARED_DOMAIN = "com.enviouswispr.app"
+
+PUSH_TO_TALK = "pushToTalk"
+
+TOGGLE_KEY_CODE = "toggleKeyCode"
+TOGGLE_MODIFIERS_RAW = "toggleModifiersRaw"
+RECORDING_MODE = "recordingMode"
+
+# Canonical shipped defaults, applied by SettingsManager when a key is absent.
+# Mirrors Sources/EnviousWisprServices/SettingsDefaultValues.swift, the machine
+# authority (.claude/knowledge/settings-defaults.md is the human one).
+# `--self-test` asserts these against that Swift file, so changing a shipped
+# default breaks CI here rather than silently turning this into a guess.
+DEFAULT_TOGGLE_KEY_CODE = 61  # ModifierKeyCodes.rightOption
+DEFAULT_TOGGLE_MODIFIERS_RAW = 0
+DEFAULT_RECORDING_MODE = PUSH_TO_TALK
+
+
+class PTTBindingError(RuntimeError):
+    """The harness cannot establish a drivable binding.
+
+    Raised, never returned as a false-like sentinel: a caller writing
+    `if not result:` would silently recreate the defect this module exists to
+    fix. CLI boundaries convert it to `INSTRUMENT INVALID` + exit 2 via
+    `run_instrument_boundary`; ad-hoc callers let it propagate.
+    """
+
+
+class PreferenceFailure(str, Enum):
+    COMMAND_UNAVAILABLE = "defaults command unavailable"
+    COMMAND_FAILED = "defaults could not be launched or exited nonzero"
+    TIMEOUT = "defaults export timed out"
+    MALFORMED_DOMAIN = "domain export could not be parsed"
+    MALFORMED_VALUE = "preference value malformed"
+    INPUT_MAPS_UNAVAILABLE = "simulate_input key maps unavailable"
+
+
+class PreferenceReadError(PTTBindingError):
+    def __init__(self, key: str, failure: PreferenceFailure, detail: str = ""):
+        self.key = key
+        self.failure = failure
+        self.detail = detail
+        suffix = f": {detail}" if detail else ""
+        super().__init__(f"{key}: {failure.value}{suffix}")
+
+
+@dataclass(frozen=True)
+class PTTBinding:
+    """A fully resolved, drivable binding. Never partially populated."""
+
+    keycode: int
+    key_name: str
+    modifiers_raw: int
+    recording_mode: str
+    is_modifier_only: bool
+
+
+def read_domain(*, timeout: float = 5.0) -> dict:
+    """Export the whole shared domain once, or raise a CLASSIFIED failure.
+
+    Returns `{}` for a domain that does not exist — that is a real answer, not a
+    failure: it means every key is unset and the app is on its canonical
+    defaults. Any NONZERO exit is therefore unambiguously operational.
+    """
+    try:
+        result = subprocess.run(
+            ["defaults", "export", SHARED_DOMAIN, "-"],
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+        )
+    except FileNotFoundError as error:
+        raise PreferenceReadError(
+            SHARED_DOMAIN, PreferenceFailure.COMMAND_UNAVAILABLE
+        ) from error
+    except subprocess.TimeoutExpired as error:
+        raise PreferenceReadError(SHARED_DOMAIN, PreferenceFailure.TIMEOUT) from error
+    except OSError as error:
+        # PermissionError, ENOMEM, EMFILE... Letting a raw OSError escape would
+        # let a caller's generic handler score it as a failed product scenario.
+        raise PreferenceReadError(
+            SHARED_DOMAIN,
+            PreferenceFailure.COMMAND_FAILED,
+            f"{type(error).__name__}: {error}",
+        ) from error
+
+    if result.returncode != 0:
+        raise PreferenceReadError(
+            SHARED_DOMAIN,
+            PreferenceFailure.COMMAND_FAILED,
+            f"exit {result.returncode}: {result.stderr.decode(errors='replace').strip()}",
+        )
+
+    try:
+        parsed = plistlib.loads(result.stdout)
+    except Exception as error:  # plistlib raises several shapes
+        raise PreferenceReadError(
+            SHARED_DOMAIN,
+            PreferenceFailure.MALFORMED_DOMAIN,
+            f"{type(error).__name__}: {error}",
+        ) from error
+
+    if not isinstance(parsed, dict):
+        raise PreferenceReadError(
+            SHARED_DOMAIN,
+            PreferenceFailure.MALFORMED_DOMAIN,
+            f"expected a dict, got {type(parsed).__name__}",
+        )
+    return parsed
+
+
+def _int_or_default(domain: dict, key: str, default: int) -> int:
+    """Absent -> the canonical shipped default; PRESENT but not Int-typed -> refuse.
+
+    Absence is the one condition with a knowable answer, because an unset
+    preference is exactly what makes the app apply `SettingsDefaultValues`.
+
+    The type rule mirrors `SettingsManager`'s `as? Int`, MEASURED rather than
+    assumed (`swiftc` probe, 2026-08-10):
+
+        Int 63       -> 63        String "63"  -> nil
+        Double 63.0  -> 63        Double 63.7  -> nil
+        Bool true    -> 1
+
+    So a Python `int` (plist integer, and `bool`, which Swift bridges to 1) and an
+    exactly-integral `float` are what the app accepts. **A numeric STRING is the
+    dangerous case**: `int("63")` would make the harness press Globe while the app,
+    seeing `nil`, is listening on Right Option — this issue's exact defect, from a
+    preference written with the wrong plist type.
+
+    Anything Swift would reject REFUSES here rather than mirroring the app's
+    fallback. Both directions are defensible, and the asymmetry decides it:
+    accepting wrongly presses a key nobody is listening for and is silent, while
+    refusing wrongly costs one loud message a human fixes in a single command.
+    """
+    if key not in domain:
+        return default
+    value = domain[key]
+    if isinstance(value, bool) or isinstance(value, int):
+        return int(value)
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    raise PreferenceReadError(
+        key,
+        PreferenceFailure.MALFORMED_VALUE,
+        f"{type(value).__name__} {value!r} is not an Int the app would accept "
+        f"(`as? Int` yields nil, so the app uses its default)",
+    )
+
+
+def _load_input_key_maps() -> tuple[dict[str, int], dict[str, int]]:
+    # Production-only lazy import: simulate_input imports Quartz at module scope
+    # (simulate_input.py:25), which CI does not have. Tests inject both maps.
+    from simulate_input import KEY_CODES, MODIFIER_KEYS
+
+    return dict(KEY_CODES), dict(MODIFIER_KEYS)
+
+
+def _input_key_maps() -> tuple[dict[str, int], dict[str, int]]:
+    try:
+        return _load_input_key_maps()
+    except ImportError as error:
+        raise PreferenceReadError(
+            "simulate_input", PreferenceFailure.INPUT_MAPS_UNAVAILABLE, str(error)
+        ) from error
+
+
+def require_push_to_talk(domain_reader: Callable[[], dict] = read_domain) -> str:
+    """Refuse unless the app is in push-to-talk mode.
+
+    A precondition of the HOLD GESTURE, not of the key, so it applies even when
+    the caller supplied an explicit `key=`. In toggle mode key-down toggles once
+    and key-up is ignored (`HotkeyService.swift:756` Carbon, `:823` modifier
+    dispatch), so a hold cannot finish the recording it starts — it leaves
+    recording ACTIVE. #963 (2026-06-21) is that failure capturing founder speech.
+    """
+    return _require_push_to_talk_in(domain_reader())
+
+
+def _require_push_to_talk_in(domain: dict) -> str:
+    mode = domain.get(RECORDING_MODE, DEFAULT_RECORDING_MODE)
+    if mode != PUSH_TO_TALK:
+        raise PTTBindingError(
+            f"recordingMode is {mode!r}, not {PUSH_TO_TALK!r}: a key hold cannot "
+            "start and then stop a recording in this mode"
+        )
+    return mode
+
+
+def resolve(
+    domain_reader: Callable[[], dict] = read_domain,
+    *,
+    key_codes_by_name: dict[str, int] | None = None,
+    modifier_keys_by_name: dict[str, int] | None = None,
+) -> PTTBinding:
+    """Resolve the configured binding, or raise. Never returns a guess."""
+    if key_codes_by_name is None or modifier_keys_by_name is None:
+        prod_keys, prod_mods = _input_key_maps()
+        key_codes_by_name = prod_keys if key_codes_by_name is None else key_codes_by_name
+        modifier_keys_by_name = (
+            prod_mods if modifier_keys_by_name is None else modifier_keys_by_name
+        )
+
+    domain = domain_reader()
+    mode = _require_push_to_talk_in(domain)
+    keycode = _int_or_default(domain, TOGGLE_KEY_CODE, DEFAULT_TOGGLE_KEY_CODE)
+    modifiers_raw = _int_or_default(
+        domain, TOGGLE_MODIFIERS_RAW, DEFAULT_TOGGLE_MODIFIERS_RAW
+    )
+
+    is_modifier_only = keycode in set(modifier_keys_by_name.values())
+
+    # A nonzero modifier value only matters for an ORDINARY key. For a standalone
+    # modifier the app never consults toggleModifiers: installModifierMonitors()
+    # returns early unless isModifierOnly (HotkeyService.swift:629) and
+    # registerToggleHotkey() returns early when it is (:704).
+    if not is_modifier_only and modifiers_raw != 0:
+        raise PTTBindingError(
+            f"unsupported chord: keycode={keycode}, "
+            f"{TOGGLE_MODIFIERS_RAW}={modifiers_raw}"
+        )
+
+    key_name = _name_for_keycode(keycode, key_codes_by_name, modifier_keys_by_name)
+    if key_name is None:
+        raise PTTBindingError(
+            f"no synthesizable key for keycode={keycode}: absent from both "
+            "simulate_input.MODIFIER_KEYS and KEY_CODES"
+        )
+
+    return PTTBinding(
+        keycode=keycode,
+        key_name=key_name,
+        modifiers_raw=modifiers_raw,
+        recording_mode=mode,
+        is_modifier_only=is_modifier_only,
+    )
+
+
+def _name_for_keycode(
+    keycode: int,
+    key_codes_by_name: dict[str, int],
+    modifier_keys_by_name: dict[str, int],
+) -> str | None:
+    """Modifiers first: a keycode in both maps must resolve to the modifier
+    spelling, because the app registers it through the modifier monitor and only
+    `modifier_down`/`modifier_up` reach that path."""
+    for name, code in modifier_keys_by_name.items():
+        if code == keycode:
+            return name
+    for name, code in key_codes_by_name.items():
+        if code == keycode:
+            return name
+    return None
+
+
+def run_instrument_boundary(action: Callable[[], int]) -> int:
+    """Wrap a CLI entry point so an invalid instrument never looks like a verdict.
+
+    One shared adapter rather than four hand-written formatters, so the output is
+    lexically identical everywhere and the acceptance criterion is mechanical.
+    """
+    try:
+        return action()
+    except PTTBindingError as error:
+        print(f"INSTRUMENT INVALID: {error}", file=sys.stderr)
+        return 2
+
+
+# --- Swift <-> Python parity ------------------------------------------------
+# Static extraction: neither module is imported, so this runs on a CI box with
+# no Quartz and no Swift toolchain.
+
+
+def python_dict_literal(path: Path, name: str) -> dict[str, int]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if any(isinstance(t, ast.Name) and t.id == name for t in node.targets):
+            value = ast.literal_eval(node.value)
+            if not isinstance(value, dict):
+                break
+            return {str(k): int(v) for k, v in value.items()}
+    raise AssertionError(f"{name} literal not found in {path}")
+
+
+def swift_modifier_constants(path: Path) -> dict[str, int]:
+    return {
+        name: int(value)
+        for name, value in re.findall(
+            r"(?:public|package|private|internal)?\s*static let (\w+): UInt16 = (\d+)",
+            path.read_text(encoding="utf-8"),
+        )
+    }
+
+
+def swift_modifier_keycodes(path: Path) -> set[int]:
+    source = path.read_text(encoding="utf-8")
+    constants = swift_modifier_constants(path)
+    match = re.search(
+        r"private static let flagsByKeyCode:"
+        r"\s*\[UInt16:\s*NSEvent\.ModifierFlags\]\s*=\s*\[(.*?)\n\s*\]",
+        source,
+        re.DOTALL,
+    )
+    if match is None:
+        # Raise rather than return an empty set: a silently empty extraction
+        # would make the parity assertion vacuously true, worse than no check.
+        raise AssertionError("ModifierKeyCodes.flagsByKeyCode not found")
+    names = re.findall(r"\b([A-Za-z_]\w*)\s*:\s*\.", match.group(1))
+    try:
+        return {constants[name] for name in names}
+    except KeyError as error:
+        raise AssertionError(f"unresolved Swift modifier constant: {error}") from error
+
+
+def swift_default_values(path: Path) -> dict[str, str]:
+    """Extract `SettingsDefaultValues`' literals VERBATIM, unresolved, so the
+    caller decides how to interpret each one; a parser that silently resolved
+    them could paper over a genuine change."""
+    source = path.read_text(encoding="utf-8")
+    values = dict(
+        re.findall(r"static let (\w+)(?::\s*[\w\.<>\[\] ]+)? = ([^\n]+)", source)
+    )
+    if not values:
+        raise AssertionError(f"no `static let` declarations found in {path}")
+    return {k: v.split("//")[0].strip() for k, v in values.items()}
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def assert_modifier_table_parity() -> None:
+    root = _repo_root()
+    python_codes = set(
+        python_dict_literal(
+            root / "Tests/RuntimeUAT/simulate_input.py", "MODIFIER_KEYS"
+        ).values()
+    )
+    swift_codes = swift_modifier_keycodes(
+        root / "Sources/EnviousWisprServices/KeySymbols.swift"
+    )
+    if python_codes != swift_codes:
+        raise AssertionError(
+            "modifier table drift: "
+            f"Python-only={sorted(python_codes - swift_codes)}, "
+            f"Swift-only={sorted(swift_codes - python_codes)}"
+        )
+
+
+def assert_canonical_defaults_match_swift() -> None:
+    """Our default constants ARE the app's shipped defaults, not remembered ones.
+
+    Without this the absent-key path degrades into exactly the guess #1997 was
+    about, the moment a shipped default changes.
+    """
+    root = _repo_root()
+    swift = swift_default_values(
+        root / "Sources/EnviousWisprServices/SettingsDefaultValues.swift"
+    )
+    modifier_codes = swift_modifier_constants(
+        root / "Sources/EnviousWisprServices/KeySymbols.swift"
+    )
+
+    raw_keycode = swift.get("toggleKeyCode", "")
+    match = re.fullmatch(r"Int\(ModifierKeyCodes\.(\w+)\)", raw_keycode)
+    if match is None:
+        raise AssertionError(
+            f"toggleKeyCode default is no longer Int(ModifierKeyCodes.x): {raw_keycode!r}"
+        )
+    expected = modifier_codes.get(match.group(1))
+    if expected != DEFAULT_TOGGLE_KEY_CODE:
+        raise AssertionError(
+            f"DEFAULT_TOGGLE_KEY_CODE={DEFAULT_TOGGLE_KEY_CODE} but Swift ships "
+            f"{match.group(1)}={expected}"
+        )
+    if swift.get("toggleModifiersRaw") != str(DEFAULT_TOGGLE_MODIFIERS_RAW):
+        raise AssertionError(
+            f"DEFAULT_TOGGLE_MODIFIERS_RAW={DEFAULT_TOGGLE_MODIFIERS_RAW} but Swift "
+            f"ships {swift.get('toggleModifiersRaw')!r}"
+        )
+    if swift.get("recordingMode") != f".{DEFAULT_RECORDING_MODE}":
+        raise AssertionError(
+            f"DEFAULT_RECORDING_MODE={DEFAULT_RECORDING_MODE!r} but Swift ships "
+            f"{swift.get('recordingMode')!r}"
+        )
+
+
+# --- Self-test --------------------------------------------------------------
+
+TEST_KEY_CODES = {"space": 49, "return": 36, "a": 0}
+TEST_MODIFIER_KEYS = {
+    "rcmd": 54, "lcmd": 55, "lopt": 58, "ropt": 61, "lshift": 56,
+    "rshift": 60, "lctrl": 59, "rctrl": 62, "fn": 63,
+}
+
+
+def _domain(**overrides):
+    values = {RECORDING_MODE: PUSH_TO_TALK, TOGGLE_KEY_CODE: 63, TOGGLE_MODIFIERS_RAW: 0}
+    values.update(overrides)
+    return values
+
+
+def _resolve(domain) -> PTTBinding:
+    return resolve(
+        lambda: domain,
+        key_codes_by_name=TEST_KEY_CODES,
+        modifier_keys_by_name=TEST_MODIFIER_KEYS,
+    )
+
+
+def _expect_refusal(domain, *, contains: str = "") -> PTTBindingError:
+    try:
+        binding = _resolve(domain)
+    except PTTBindingError as error:
+        if contains and contains not in str(error):
+            raise AssertionError(f"expected {contains!r} in refusal, got {error!r}")
+        return error
+    raise AssertionError(f"expected a refusal, got {binding!r}")
+
+
+def _case_globe_resolves() -> None:
+    binding = _resolve(_domain())
+    assert binding.key_name == "fn" and binding.keycode == 63, binding
+    assert binding.is_modifier_only, binding
+
+
+def _case_every_modifier_resolves() -> None:
+    for name, code in TEST_MODIFIER_KEYS.items():
+        binding = _resolve(_domain(**{TOGGLE_KEY_CODE: code}))
+        assert binding.key_name == name, (name, code, binding)
+
+
+def _case_ordinary_key_resolves() -> None:
+    binding = _resolve(_domain(**{TOGGLE_KEY_CODE: 49}))
+    assert binding.key_name == "space" and binding.is_modifier_only is False, binding
+
+
+def _case_ordinary_key_with_modifiers_is_a_chord() -> None:
+    _expect_refusal(
+        _domain(**{TOGGLE_KEY_CODE: 49, TOGGLE_MODIFIERS_RAW: 1048576}),
+        contains="unsupported chord",
+    )
+
+
+def _case_modifier_with_stray_modifiers_still_resolves() -> None:
+    # Two-way control: proves the chord rule is not over-broad. The app ignores
+    # toggleModifiers on the modifier-monitor path.
+    binding = _resolve(_domain(**{TOGGLE_MODIFIERS_RAW: 1048576}))
+    assert binding.key_name == "fn", binding
+
+
+def _case_unknown_keycode_refuses() -> None:
+    _expect_refusal(_domain(**{TOGGLE_KEY_CODE: 999}), contains="999")
+
+
+def _case_fresh_install_resolves_to_canonical_defaults() -> None:
+    # Nothing persisted: SettingsManager applies SettingsDefaultValues without
+    # writing, so the app IS running Right Option in push-to-talk. `defaults
+    # export` returns {} for a domain that does not exist, so this is the real
+    # shape of that state, not a stand-in.
+    binding = _resolve({})
+    assert binding.keycode == DEFAULT_TOGGLE_KEY_CODE, binding
+    assert binding.key_name == "ropt", binding
+    assert binding.modifiers_raw == DEFAULT_TOGGLE_MODIFIERS_RAW, binding
+    assert binding.recording_mode == DEFAULT_RECORDING_MODE, binding
+
+
+def _case_absent_key_does_not_mask_a_configured_one() -> None:
+    # Two-way control: defaulting applies ONLY when the key is genuinely absent.
+    assert _resolve(_domain()).keycode == 63
+
+
+def _case_present_but_malformed_refuses() -> None:
+    # The distinction the whole absent-vs-failed design rests on: a value that is
+    # PRESENT and unusable says nothing about what the app is running.
+    _expect_refusal(_domain(**{TOGGLE_KEY_CODE: "not-a-number"}), contains="malformed")
+    _expect_refusal(_domain(**{TOGGLE_MODIFIERS_RAW: []}), contains="malformed")
+
+
+def _case_type_rule_matches_swift_as_int() -> None:
+    """Each row measured against a real `swiftc` probe, not assumed.
+
+    The numeric-STRING row is the one that matters: coercing it would make the
+    harness press Globe while the app, getting `nil` from `as? Int`, listens on
+    Right Option — this issue's defect reached through a mistyped preference.
+    """
+    # Swift ACCEPTS these, so we must resolve rather than refuse.
+    assert _resolve(_domain(**{TOGGLE_KEY_CODE: 63})).keycode == 63
+    assert _resolve(_domain(**{TOGGLE_KEY_CODE: 63.0})).keycode == 63
+
+    # Swift REJECTS these (`as? Int` -> nil), so pressing a coerced value would
+    # target a key the app is not listening for.
+    _expect_refusal(_domain(**{TOGGLE_KEY_CODE: "63"}), contains="not an Int")
+    _expect_refusal(_domain(**{TOGGLE_KEY_CODE: 63.7}), contains="not an Int")
+    _expect_refusal(_domain(**{TOGGLE_MODIFIERS_RAW: "0"}), contains="not an Int")
+
+
+def _case_toggle_mode_refuses() -> None:
+    _expect_refusal(_domain(**{RECORDING_MODE: "toggle"}), contains="pushToTalk")
+
+
+def _case_mode_is_checked_before_the_key() -> None:
+    # Ordering is load-bearing: an explicit-key caller depends on the mode check
+    # even when the configured key is unusable.
+    _expect_refusal(
+        _domain(**{RECORDING_MODE: "toggle", TOGGLE_KEY_CODE: "junk"}),
+        contains="pushToTalk",
+    )
+
+
+def _case_require_push_to_talk_standalone() -> None:
+    assert require_push_to_talk(lambda: {RECORDING_MODE: PUSH_TO_TALK}) == PUSH_TO_TALK
+    assert require_push_to_talk(lambda: {}) == PUSH_TO_TALK  # fresh install
+    try:
+        require_push_to_talk(lambda: {RECORDING_MODE: "toggle"})
+    except PTTBindingError:
+        return
+    raise AssertionError("expected a refusal for toggle mode")
+
+
+def _case_operational_failures_refuse() -> None:
+    """A nonzero `defaults` exit must NOT be read as 'the key is absent'.
+
+    This is why the module exports the whole domain: `defaults read <key>` gives
+    a missing key and an operational error the same exit status and the same
+    English sentence, so absence could only be guessed at. `export` succeeds even
+    for a nonexistent domain, making any nonzero exit unambiguously operational.
+    """
+    for failure in (
+        PreferenceFailure.COMMAND_UNAVAILABLE,
+        PreferenceFailure.COMMAND_FAILED,
+        PreferenceFailure.TIMEOUT,
+        PreferenceFailure.MALFORMED_DOMAIN,
+    ):
+        def reader(f=failure):
+            raise PreferenceReadError(SHARED_DOMAIN, f)
+
+        try:
+            resolve(
+                reader,
+                key_codes_by_name=TEST_KEY_CODES,
+                modifier_keys_by_name=TEST_MODIFIER_KEYS,
+            )
+        except PTTBindingError as error:
+            assert failure.value in str(error), (failure, error)
+        else:
+            raise AssertionError(f"{failure.name} was not refused")
+
+
+def _case_no_exception_escapes_as_a_product_verdict() -> None:
+    """The whole class, not the single instance review named.
+
+    Anything escaping as a non-`PTTBindingError` is caught by a caller's generic
+    handler and recorded as a failed product scenario.
+    """
+    original = subprocess.run
+
+    def deny(*_args, **_kwargs):
+        raise PermissionError(13, "Permission denied")
+
+    subprocess.run = deny
+    try:
+        read_domain()
+    except PTTBindingError:
+        pass
+    except Exception as error:  # noqa: BLE001
+        raise AssertionError(f"OSError escaped as {type(error).__name__}") from error
+    else:
+        raise AssertionError("expected a refusal when defaults cannot be launched")
+    finally:
+        subprocess.run = original
+
+    original_loader = globals()["_load_input_key_maps"]
+
+    def unavailable():
+        raise ImportError("No module named 'Quartz'")
+
+    globals()["_load_input_key_maps"] = unavailable
+    try:
+        resolve(lambda: _domain())
+    except PTTBindingError:
+        pass
+    except Exception as error:  # noqa: BLE001
+        raise AssertionError(f"ImportError escaped as {type(error).__name__}") from error
+    else:
+        raise AssertionError("expected a refusal when the key maps cannot load")
+    finally:
+        globals()["_load_input_key_maps"] = original_loader
+
+
+def _case_domain_export_is_read_once() -> None:
+    """One subprocess per resolve, not one per key.
+
+    `faultInjection` taps inside a 100 ms fuzz window and a 500 ms double-tap
+    window; three reads measured 24 ms mean / 49 ms max, enough to miss them and
+    report a product failure. Counting the reads is what stops that returning.
+    """
+    calls = []
+
+    def counting_reader():
+        calls.append(1)
+        return _domain()
+
+    resolve(
+        counting_reader,
+        key_codes_by_name=TEST_KEY_CODES,
+        modifier_keys_by_name=TEST_MODIFIER_KEYS,
+    )
+    assert len(calls) == 1, f"expected exactly 1 domain read, got {len(calls)}"
+
+
+def _case_swift_python_modifier_parity() -> None:
+    assert_modifier_table_parity()
+
+
+def _case_canonical_defaults_match_swift() -> None:
+    assert_canonical_defaults_match_swift()
+
+
+def _case_parity_extractor_is_armed() -> None:
+    # A parity check that silently extracts nothing would pass forever.
+    import tempfile
+
+    root = _repo_root()
+    source = (root / "Sources/EnviousWisprServices/KeySymbols.swift").read_text(
+        encoding="utf-8"
+    )
+    assert "flagsByKeyCode" in source, "fixture assumption broken"
+    with tempfile.NamedTemporaryFile("w", suffix=".swift", delete=False) as handle:
+        handle.write(source.replace("flagsByKeyCode", "renamed"))
+        temp = Path(handle.name)
+    try:
+        swift_modifier_keycodes(temp)
+    except AssertionError:
+        return
+    finally:
+        temp.unlink(missing_ok=True)
+    raise AssertionError("extractor returned instead of raising on a renamed table")
+
+
+CASES: list[tuple[str, Callable[[], None]]] = [
+    ("globe resolves to fn", _case_globe_resolves),
+    ("every modifier resolves", _case_every_modifier_resolves),
+    ("ordinary key resolves", _case_ordinary_key_resolves),
+    ("ordinary key + modifiers is a chord", _case_ordinary_key_with_modifiers_is_a_chord),
+    ("modifier + stray modifiers still resolves", _case_modifier_with_stray_modifiers_still_resolves),
+    ("unknown keycode refuses", _case_unknown_keycode_refuses),
+    ("fresh install resolves to canonical defaults", _case_fresh_install_resolves_to_canonical_defaults),
+    ("absent key does not mask a configured one", _case_absent_key_does_not_mask_a_configured_one),
+    ("present but malformed refuses", _case_present_but_malformed_refuses),
+    ("type rule matches Swift as? Int", _case_type_rule_matches_swift_as_int),
+    ("toggle mode refuses", _case_toggle_mode_refuses),
+    ("mode is checked before the key", _case_mode_is_checked_before_the_key),
+    ("require_push_to_talk standalone", _case_require_push_to_talk_standalone),
+    ("operational failures refuse", _case_operational_failures_refuse),
+    ("no exception escapes as a product verdict", _case_no_exception_escapes_as_a_product_verdict),
+    ("domain export is read once", _case_domain_export_is_read_once),
+    ("swift/python modifier parity", _case_swift_python_modifier_parity),
+    ("canonical defaults match Swift", _case_canonical_defaults_match_swift),
+    ("parity extractor is armed", _case_parity_extractor_is_armed),
+]
+
+
+def run_self_tests(cases: list[tuple[str, Callable[[], None]]]) -> int:
+    """Print EVERY failure, then exit once — a required gate must not cost one CI
+    run per defect."""
+    failures: list[str] = []
+    for name, test in cases:
+        try:
+            test()
+        except Exception as error:  # noqa: BLE001 - a self-test reports every shape
+            failures.append(f"{name}: {type(error).__name__}: {error}")
+
+    if failures:
+        for failure in failures:
+            print(f"SELF-TEST FAIL: {failure}", file=sys.stderr)
+        print(f"SELF-TEST FAILED: {len(failures)}/{len(cases)} cases", file=sys.stderr)
+        return 1
+
+    print(f"SELF-TEST PASS: {len(cases)} cases")
+    return 0
+
+
+def _main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Resolve the app's PTT binding.")
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return run_self_tests(CASES)
+
+    binding = resolve()
+    print(
+        f"key={binding.key_name} keycode={binding.keycode} "
+        f"modifiers={binding.modifiers_raw} mode={binding.recording_mode} "
+        f"modifier_only={binding.is_modifier_only}"
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    return run_instrument_boundary(lambda: _main(sys.argv[1:] if argv is None else argv))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Tests/RuntimeUAT/run_gauntlet.py
+++ b/Tests/RuntimeUAT/run_gauntlet.py
@@ -29,6 +29,8 @@ HERE = Path(__file__).resolve().parent
 if str(HERE) not in sys.path:
     sys.path.insert(0, str(HERE))
 
+from ptt_binding import PTTBindingError, run_instrument_boundary  # noqa: E402
+
 from faultInjection import (  # noqa: E402
     _assert_dictation_recovers,
     _parse_query_state,
@@ -132,7 +134,7 @@ def _write_scorecard(bench: dict, out_path: str) -> None:
 
 
 
-def main(argv: list[str]) -> int:
+def _main(argv: list[str]) -> int:
     # Subcommand routing; no subcommand ⇒ legacy Lane A gauntlet (back-compat).
 
     parser = argparse.ArgumentParser()
@@ -157,6 +159,13 @@ def main(argv: list[str]) -> int:
             inner = scenario_result.get("result", {})
             print(f"  elapsed={elapsed:.1f}s")
             print(f"  result={inner}")
+        except PTTBindingError:
+            # Re-raise ahead of the generic handler so main()'s boundary adapter
+            # reports INSTRUMENT INVALID. Without this the generic branch below
+            # scores an unresolvable PTT binding as a failed SCENARIO — the same
+            # instrument-failure-as-product-verdict defect #1997 exists to fix,
+            # one layer out.
+            raise
         except Exception as e:
             print(f"  scenario raised: {type(e).__name__}: {e}")
             results.append({
@@ -195,6 +204,12 @@ def main(argv: list[str]) -> int:
             print(f"  FAIL  {scen}  ({reason})")
     print(f"\nfinal-state: {query_state()}")
     return 0 if all(r.get("health", {}).get("healthy") for r in results) else 1
+
+
+def main(argv: list[str]) -> int:
+    # CLI boundary: an unresolvable PTT binding is an INSTRUMENT failure,
+    # never a scenario verdict (#1997).
+    return run_instrument_boundary(lambda: _main(argv))
 
 
 if __name__ == "__main__":

--- a/Tests/RuntimeUAT/wispr_eyes.py
+++ b/Tests/RuntimeUAT/wispr_eyes.py
@@ -8,6 +8,7 @@ from ui_helpers import (find_app_pid, get_ax_app, get_attr, set_attr, perform_ac
     find_element, find_all_elements, find_control_for_label, wait_for_condition,
     get_process_memory_mb, get_clipboard_text, validate_app_ready, element_frame,
     _iter_children_with_menubars)
+from ptt_binding import PTTBindingError, require_push_to_talk, resolve
 
 _pid = None
 _app = None
@@ -16,38 +17,36 @@ _TTS_PATH = "/tmp/wispr_eyes_tts.aiff"
 _OPENAI_TTS_PATH = "/tmp/wispr_eyes_tts.mp3"
 _OPENAI_KEY_FILE = os.path.expanduser("~/.enviouswispr-keys/openai-api-key")
 
-# Bundle IDs the harness might attach to (dev first, prod fallback).
-_PTT_BUNDLE_IDS = ["com.enviouswispr.app.dev", "com.enviouswispr.app"]
-# Reverse map of simulate_input.KEY_CODES for modifier keycodes we hold for PTT.
-# 54=rcmd, 55=lcmd, 58=lopt, 61=ropt. Keep in sync with
-# `Tests/RuntimeUAT/simulate_input.py` MODIFIER_KEYS table.
-_PTT_KEYCODE_TO_NAME = {54: "rcmd", 55: "lcmd", 58: "lopt", 61: "ropt"}
+def _resolve_ptt_key():
+    """Resolve the configured PTT key name, or raise `PTTBindingError`.
 
-
-def _resolve_ptt_key(fallback="rcmd"):
-    """Read the active PTT keycode from EnviousWispr's UserDefaults
-    (`toggleKeyCode`) and map it back to the simulate_input key name.
-
-    PR-A of #763 fix: harness was hardcoded to `rcmd` (Right Command). When the
-    founder rebinds PTT to a different modifier (e.g. Right Option = 61), the
-    hardcoded harness presses the wrong key and the recording never engages.
-    This resolver keeps the harness aligned with whatever the app is configured
-    for. Falls back to `fallback` (default 'rcmd') if neither bundle responds.
+    Previously this owned its own domain list, its own 4-entry keycode->name map,
+    and a hardcoded `rcmd` fallback. All three were wrong at once (#1997): it read
+    the retired `.dev` domain, could not name Globe (63), and on any failure
+    pressed a key the app was not listening for — then the caller reported that
+    silence as a product FAIL. `ptt_binding` now owns resolution and REFUSES
+    rather than guessing; see that module's header for why no fallback exists.
     """
-    for bundle_id in _PTT_BUNDLE_IDS:
-        try:
-            result = subprocess.run(
-                ["defaults", "read", bundle_id, "toggleKeyCode"],
-                capture_output=True, text=True, timeout=2,
-            )
-            if result.returncode != 0:
-                continue
-            keycode = int(result.stdout.strip())
-            if keycode in _PTT_KEYCODE_TO_NAME:
-                return _PTT_KEYCODE_TO_NAME[keycode]
-        except (subprocess.SubprocessError, ValueError, OSError):
-            continue
-    return fallback
+    return resolve().key_name
+
+
+def _ptt_binding_diagnostic(pressed_key):
+    """One line of instrument state, printed only when a PTT run produced nothing.
+
+    The 2026-08-10 failure was indistinguishable from "the product ignored the
+    hotkey": no states, no log growth, a bare timeout, and nothing anywhere
+    naming the key actually pressed. This makes the instrument's own view
+    legible at exactly the moment a reader is deciding whether to believe a FAIL.
+    """
+    try:
+        binding = resolve()
+        configured = (
+            f"configured key={binding.key_name} keycode={binding.keycode} "
+            f"modifiers={binding.modifiers_raw} mode={binding.recording_mode}"
+        )
+    except PTTBindingError as error:
+        configured = f"configured binding unreadable: {error}"
+    print(f"INSTRUMENT STATE: pressed={pressed_key}; {configured}")
 
 
 def tts(sentence="The quick brown fox jumps over the lazy dog", voice="echo", engine="openai"):
@@ -1635,10 +1634,17 @@ def test_ptt(key=None, audio=None, sentence=None, expect=None, timeout=10.0):
     """
     connect()
 
-    # Resolve PTT key from app settings if caller didn't override.
+    # Resolve PTT key from app settings if caller didn't override. Either path
+    # raises PTTBindingError rather than pressing something unverified (#1997).
     if key is None:
-        key = _resolve_ptt_key()
-        print(f"PTT key auto-detected from settings: {key}")
+        binding = resolve()
+        key = binding.key_name
+        print(f"PTT key auto-detected from settings: {key} (keycode {binding.keycode})")
+    else:
+        # An explicit key overrides the CONFIGURED KEY, never the recording mode:
+        # in toggle mode this hold-and-release cannot stop the recording it
+        # starts, whatever key is held (#963 captured real speech that way).
+        require_push_to_talk()
 
     if audio is None:
         if sentence is None:
@@ -1723,6 +1729,11 @@ def test_ptt(key=None, audio=None, sentence=None, expect=None, timeout=10.0):
     # PTT always uses audio (we played a file), so non-completion is FAIL
     # regardless of "audio was empty" semantics.
     overall_pass = _report_result(completed, audio, expect, transcription)
+    # Nothing happened at all: print what the instrument believed, so a reader
+    # can tell a real product failure from a key the app was never listening
+    # for. Gated on the silent shape so a passing run gains no noise.
+    if not completed and not states_seen:
+        _ptt_binding_diagnostic(key)
     print(f"{'=' * 60}")
     end_test()
     return overall_pass
@@ -1762,10 +1773,15 @@ def record_tts(sentence="The quick brown fox jumps over the lazy dog", key=None,
     """
     import simulate_input as _si
 
-    # Resolve PTT key from app settings if caller didn't override.
+    # Resolve PTT key from app settings if caller didn't override. See test_ptt:
+    # both paths refuse rather than press an unverified key (#1997), and the
+    # explicit-key path still requires push-to-talk mode.
     if key is None:
-        key = _resolve_ptt_key()
-        print(f"PTT key auto-detected from settings: {key}")
+        binding = resolve()
+        key = binding.key_name
+        print(f"PTT key auto-detected from settings: {key} (keycode {binding.keycode})")
+    else:
+        require_push_to_talk()
 
     # Focus paste target app
     if focus_app:


### PR DESCRIPTION
## What

The UAT harness reported that the product ignored the hotkey. It had not. The harness was pressing a key nothing was listening for and reporting the silence as a product FAIL — on a branch that had just changed hotkey delivery, which is the one context where a hotkey FAIL is most likely to be believed.

Closes #1997.

## Three defects composed into one silent failure

| | |
|---|---|
| **Wrong domain** | `_resolve_ptt_key` read `toggleKeyCode` from the retired `com.enviouswispr.app.dev` first, while both builds read shared `com.enviouswispr.app` (`SettingsDefaults.store` redirects the dev build). Shared said 63 (Globe); dev said 61. |
| **Incomplete private table** | Its keycode→name map had FOUR entries against nine in both `simulate_input.MODIFIER_KEYS` and the app's `ModifierKeyCodes`. Globe was unnameable, so fixing the domain alone still yielded `ropt` by a second route. |
| **A fallback that guessed** | Any read failure became a hardcoded `rcmd` (54) — matching neither the configured key nor any default. |

**The class is not "wrong domain". It is an instrument failure reported as a product verdict.** `faultInjection._ptt_keycode` had the same class with a different half (right domain, own fallback to 54), and #963 records its toggle-mode variant leaving recording ACTIVE and capturing founder speech.

## Design decisions that carried weight

**One `defaults export` of the whole domain, not a read per key.** This is what everything else rests on. `defaults read <key>` gives a missing key and an operational error the *same* exit status and the *same* English sentence, so absence could only be guessed at from locale-sensitive text. `export` succeeds even for a domain that does not exist, emitting an empty plist — so key presence is a dict membership test and any nonzero exit is unambiguously operational.

**An absent key is not a guess.** `SettingsManager` resolves an unset preference through `SettingsDefaultValues` and deliberately does not persist it (`SettingsManager.swift:691`, `:639`; #923 forbids an onboarding write). A fresh or reset profile genuinely runs Right Option in push-to-talk with nothing on disk, so refusing there rejects a valid configuration. **Everything else refuses** — malformed, timeout, missing binary, nonzero exit.

**Preference types mirror `as? Int`, measured with a `swiftc` probe rather than assumed:**

```
Int 63      -> 63        String "63"  -> nil
Double 63.0 -> 63        Double 63.7  -> nil
Bool true   -> 1
```

The numeric-string row is the one that bites: coercing it would press Globe while the app, seeing `nil`, listens on Right Option. Anything Swift rejects refuses here rather than mirroring the app's fallback — accepting wrongly is silent, refusing wrongly costs one loud message.

**Drivability belongs to each consumer**, because they differ: `wispr_eyes` can hold ordinary keys and modifiers, `faultInjection` posts only modifier events. Both require push-to-talk mode before pressing anything, **including when the caller passed an explicit key** — mode is a precondition of the gesture, not a property of the key, and the check completes before the first `CGEvent` so no refusal path leaves a modifier held.

**Resolution is lazy and scoped.** Three constraints meet, and my first two drafts each satisfied two of them: a tap must not pay a `defaults` subprocess (7.3 ms mean against a 100 ms fuzz interval and 500 ms double-tap window; the cached read is 0.1 µs); a cached binding must not outlive its scenario, or a later tap posts a key the founder has since rebound away from; and resolution must be lazy, because validating up front aborted menu-driven scenarios (A8a, A8b, B1) that never synthesize the key at all.

**Four CLI boundaries** convert refusal to `INSTRUMENT INVALID` + exit 2 through one shared adapter. Without that, `run_gauntlet`'s generic handler scores an unresolvable binding as a failed scenario — the same defect one layer out.

**Swift↔Python parity is gated in both directions.** An app-only key already fails closed, but a Python-only key would post `flagsChanged` at a Carbon-registered hotkey and reproduce the original false FAIL, so failing closed alone is not sufficient.

## Evidence

**Live UAT, the acceptance test.** `test_ptt()` with no `key=`:

```
PTT key auto-detected from settings: fn (keycode 63)
...
12:46:33  COLD-START [RecordingStarter] PTT-to-recording: total=84ms preWarm=71ms backend=parakeet
12:46:39  Pipeline timing TOTAL: 1.896s (ASR=0.113s, polish=1.371s, paste=0.336s)
Result: PASS
```

`PTT-to-recording` comes only from `RecordingStarter.start()` — the menu path never emits it — so a genuine synthetic Globe press traversed the modifier monitor and started a dictation.

**The diagnostic, armed in the exact shape that caused the original mistake.** `test_ptt(key='lctrl')` fails, and now says why:

```
INSTRUMENT STATE: pressed=lctrl; configured key=fn keycode=63 modifiers=0 mode=pushToTalk
```

**Nine mutation arms, each killed by its intended case and restored:** chord rule widened (the standalone-modifier control fails), mode guard deleted, refusal replaced by a fallback, name map reverted to four entries, `MODIFIER_KEYS` loses `fn:63`, absent-key defaulting deleted, `DEFAULT_TOGGLE_KEY_CODE` drifted 61→54, eager resolve in `run_scenario`, ad-hoc path caching.

Both self-tests verified against a **Quartz-blocked interpreter**, with controls proving the blocker is real and that `simulate_input` genuinely requires Quartz — so the new `build-check` step will run on a Linux runner.

## Scope and honesty

**This grew from a two-line fix, and the founder was told so mid-flight and offered the narrow version.** Codex was asked directly whether to cut anything and answered *cut nothing*: every added file is an entry point the old fallback leaked into.

**Seven whole-diff review rounds, six of which found a real P2.** Each was confirmed against the code or by measurement before being adopted, and two of my own decisions were overturned outright — refusing an absent key (which rejects every fresh install) and deleting the Swift parity check (safe in only one direction). The round count is in the plan's rev history rather than hidden.

**One self-inflicted finding worth recording:** my first mutation harness used `git diff --stat` to confirm a mutation applied and `git checkout --` to revert it. `ptt_binding.py` was untracked, so the check returned empty — read as *not applied* when it had applied — and four mutations stacked silently. The same blindness the change itself is about. Rebuilt on file copies with a content check.

**Live arms deliberately not run:** the chord, absent-key and toggle-mode refusals all happen *before* any event is posted and are covered by two-way self-tests; exercising them live means mutating the founder's real shortcut settings for evidence already held deterministically.

Plan: `docs/feature-requests/issue-1997-2026-08-10-ptt-key-resolution.md` (rev 6).
