### PR TITLE
docs(content): help article on using a mouse button for dictation (Part of #1996)

### DIFF
--- a/website/src/content/help/using-a-mouse-button-for-dictation.md
+++ b/website/src/content/help/using-a-mouse-button-for-dictation.md
@@ -1,0 +1,85 @@
+---
+title: "Using a Mouse Button for Dictation"
+description: "Start dictation from a side button on a gaming mouse."
+category: "recording-and-hotkeys"
+section: "Recording"
+order: 6
+keywords: ["mouse", "mouse button", "gaming mouse", "side buttons", "thumb buttons", "razer", "naga", "logitech", "mmo mouse", "extra buttons", "bind mouse button", "middle click", "scroll wheel click", "start dictation with mouse", "hotkey on mouse"]
+related: ["customizing-your-hotkey"]
+updated: 2026-08-10
+---
+The **Shortcuts** page accepts keyboard keys, so there is no mouse button to pick from a list. Most extra buttons on a gaming mouse can still start dictation, because those buttons already send keyboard keys rather than mouse clicks.
+
+### Find out what your buttons send
+
+The hotkey box itself is the test, because it shows you exactly what EnviousWispr
+receives from that button.
+
+1. **Open settings.** Click the EnviousWispr icon in your menu bar, choose **Settings**, and go to **Shortcuts**.
+2. **Select the hotkey box.** Click the **Recording hotkey** box.
+3. **Press one of the extra buttons on your mouse.** Use a side button or a thumb button, not left or right click.
+
+Whatever appears in the box is what that button sends.
+
+| What appears in the box | What it means | What to do |
+|---|---|---|
+| `F13`, or another key you never type | The button is already sending an unused key | Nothing more. Save it and you are done. |
+| A letter, number or punctuation mark | The button sends a key you type with | Remap it first, or your hotkey fires every time you type that character |
+| A modifier such as Right Option | The button is acting as a modifier | Works, with the trade-off in the table below |
+| Nothing at all | The button sends something EnviousWispr cannot bind | See the last section |
+
+A twelve button thumb grid often sends the number row, so the buttons come
+through as `1`, `2`, `3` and so on. Every mouse is different, which is why it is
+worth checking yours rather than assuming.
+
+Pressing the button into an ordinary text field is a quicker rough check, but it
+cannot tell you everything. A button already set to F13, to an arrow key, or to a
+modifier types no character at all, and silence in a text field looks identical
+to a button that sends nothing. The hotkey box tells the two apart.
+
+### Remap the button, then bind it
+
+Sending `4` is not useful on its own, because setting `4` as your hotkey would swallow that key everywhere you type. The fix is to point the button at a key that nothing else uses, then set that as your hotkey.
+
+**F13 through F20 are the keys to aim for.** Most Mac keyboards stop at F12, so these keys are usually sitting unused and nothing competes for them.
+
+1. **Remap the button to F13 in your mouse software.** Most gaming mouse software can assign a keyboard key to a button. Assign F13 to the button you want to dictate with.
+2. **Press the mouse button in the Recording hotkey box.** `F13` appears in the box and saves immediately.
+3. **Try it.** Click into a text field and press the button. Recording starts.
+
+### If your mouse software does not run on macOS
+
+Several manufacturers have thin macOS support, and Razer's Synapse 3 does not run on macOS at all. Two ways around it:
+
+- **Configure it on a Windows PC.** Many gaming mice store the mapping in onboard memory on the mouse itself, so a profile you set up on Windows keeps working once you plug the mouse into your Mac. Check whether your model has onboard memory before relying on this.
+- **Remap on the Mac with a third party tool.** [Karabiner-Elements](https://karabiner-elements.pqrs.org) is a free keyboard customizer for macOS that can remap keys for one specific device. That last part matters: it can turn `1` coming from your mouse into F13 while leaving the `1` on your keyboard alone. Its bundled EventViewer also shows exactly what each button sends.
+
+### Choosing the key
+
+| Key you remap to | Worth choosing? |
+|---|---|
+| F13 to F20 | Best choice. Most Mac keyboards stop at F12, so nothing else is listening. |
+| A letter or number | No. Your hotkey would fire every time you typed that character. |
+| Right Option or another modifier | Works, but the button then behaves as that modifier everywhere. Holding it changes what your other keys and clicks do. |
+
+### Buttons the box cannot capture
+
+If nothing appeared in the **Recording hotkey** box, the button is sending
+something EnviousWispr does not accept as a shortcut. That is usually one of two
+things, and they are worth telling apart because only one of them is a dead end.
+
+- **A real mouse click.** The scroll wheel click is the common case. It already
+  opens links in new tabs and closes tabs in every browser, so taking it over for
+  dictation costs you that.
+- **A media key.** Buttons set to play, pause, volume or track skip send a
+  different kind of event that the shortcut box does not read, even though they
+  are not mouse clicks.
+
+Either way the fix is the same: open your mouse software and assign the button a
+keyboard key instead, F13 for preference, then follow the steps above. If your
+software does not show you what the button is currently set to, the EventViewer
+bundled with [Karabiner-Elements](https://karabiner-elements.pqrs.org) will.
+
+### Which mode to use
+
+Once the button is set as your hotkey it behaves like any other. Push to talk records while you hold the button, and toggle mode starts on one press and stops on the next. Toggle mode suits a mouse button well, because holding a mouse button down while you speak is more tiring than holding a key.


### PR DESCRIPTION
A new help-centre article: **Using a Mouse Button for Dictation**, at `/help/using-a-mouse-button-for-dictation/`.

## Why this exists instead of a feature

#1996 proposed building mouse-button shortcuts. Probing the founder's actual hardware killed the premise:

- A **Razer Naga V2 HyperSpeed**'s twelve thumb buttons emit the **number row as ordinary keyboard keys** (measured key codes 18-29), not mouse buttons. A mouse-button feature could not bind them at all.
- A **3-button Logitech** exposes only middle click, which already opens links in new tabs.

Both mice are already reachable through the shipped keyboard path after a one-time remap the user does in software they already have. The article documents that instead.

## The instructions are measured, not reasoned

A help article's steps are executable, so they carry `validation-discipline.md` RULE: test-fixes-to-actionable-docs.

**A bare F13 was bound in the real dev app** and a synthesized press started a recording:

```
[HotkeyService] Carbon hotkey event: id=1, isRelease=false, mode=toggle
[Telemetry] dictation_started take=E14CCFE1-…
[Pipeline] Recording started. Backend: parakeet
```

A second press ended the take. That is the article's central instruction, confirmed end to end.

**An earlier version of that test said F13 did NOT work.** It was a command-line tool with no `NSApplication`, so registration returned `noErr` and delivered nothing — `gotchas.md` RULE: carbon-hotkey-after-nsapp-run. Rerun as a real app carrying a known-good chord as a positive control, both fired. Without the control, "F13 fired" and "the harness is broken" are the same observation.

**Also confirmed on the way:** `RegisterEventHotKey` returns `noErr` for a bare modifier and never delivers, the #1175 trap. Registration status is never evidence of delivery.

The article's first step — press a mouse button into a text field and see whether a character appears — is exactly how the Naga finding was made, so the reader needs nothing installed to diagnose their own mouse.

## Two claims tightened after drafting

Both were overstated, and both would have been wrong in a reader's hands:

| Drafted | Shipped | Why |
|---|---|---|
| "F13-F20 appear on no Mac keyboard" | "Most Mac keyboards stop at F12" | Apple full-size keyboards carry F13 and above. The original was false. |
| "Razer, Logitech, SteelSeries and others all support assigning a keyboard key" | "Most gaming mouse software can assign a keyboard key" | Only Razer was actually checked. |

Razer's macOS gap (Synapse 3 absent on macOS, curated device support in the Mac build), the onboard-memory route and Karabiner-Elements are sourced from Razer's own support pages and the published `naga-karabiner` config, cited in the #1996 thread.

## Voice and checks

Mode E per `content-brand.md`: answers the page's own question first, carries no product definition, bold-labelled steps, a table wherever options are compared. Gemini 3.5 Flash Lite proofread it and returned `VERDICT: ALL CLEAR`.

- help content: 53 articles, 0 errors
- help routes: 66 expected / 66 built / 66 in sitemap, 0 dead internal links
- help search: 37 passed, 0 failed — the new page steals no query from an existing article, which is the documented risk when adding help content
- Corrected copy confirmed present in the built HTML; the superseded claim confirmed absent

Part of #1996
