### PR TITLE
feat(pipeline): make the casing deadline say which step was slow (Part of #1946)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/Debug/DebugFaultEndpoint.swift
+++ b/Sources/EnviousWisprAppKit/App/Debug/DebugFaultEndpoint.swift
@@ -273,9 +273,22 @@
         // Order is load-bearing and documented on the seam: `resetForTesting`
         // CLEARS any override, so it must run first.
         SeamCasingOracleRuntime.resetForTesting()
-        SeamCasingOracleRuntime.setPreparationOverrideForTesting { _ in
-          SeamCasingOracle.delayingDictionaryForFaultInjection(milliseconds: ms)
-        }
+        let slow = SeamCasingOracle.delayingDictionaryForFaultInjection(milliseconds: ms)
+        // The override alone is NOT enough, and the first version of this command
+        // shipped that bug: `resetForTesting` clears every prepared phase, so the
+        // next dictation's `snapshot(for:)` merely QUEUES preparation and answers
+        // `.oracleWarming` — it never reaches the delayed dictionary. The observed
+        // symptom was a wasted sacrificial dictation before the fault took effect,
+        // visible as `case_skipped:oracle_warming` in the run that was supposed to
+        // stall (cloud review; and it is in this session's own UAT logs).
+        //
+        // `installForTesting` publishes a READY oracle directly, so `OK` means the
+        // NEXT dictation stalls. A command that acknowledges before it is armed is
+        // a lie to whoever scripts against it.
+        SeamCasingOracleRuntime.installForTesting(slow, for: "en")
+        // Kept as well, so a non-English dictation prepared later stalls too
+        // rather than quietly answering from a real dictionary.
+        SeamCasingOracleRuntime.setPreparationOverrideForTesting { _ in slow }
         return "OK"
 
       case "clear_oracle_delay":

--- a/Sources/EnviousWisprAppKit/App/Debug/DebugFaultEndpoint.swift
+++ b/Sources/EnviousWisprAppKit/App/Debug/DebugFaultEndpoint.swift
@@ -4,6 +4,7 @@
   import EnviousWisprAudio
   import EnviousWisprCore
   import EnviousWisprPipeline
+  import EnviousWisprPostProcessing
   import EnviousWisprServices
   import Foundation
   import Network
@@ -256,6 +257,31 @@
       case "force_default_input_absent":
         guard let audioCapture else { return "ERR no_dependency" }
         return audioCapture.debugSetDefaultInputAbsent(true) ? "OK" : "ERR capture_active"
+
+      // #1946 Live UAT. Makes the casing deadline miss DETERMINISTIC instead of
+      // waiting for a loaded machine to produce one: at load 3.7-9.3 across 8
+      // real dictations it never fired, so a load-based reproduction cannot
+      // prove the trace works in the shipped app.
+      //
+      // Arms the DICTIONARY consultation to block. That is the one closure whose
+      // stall must produce `stuck=dictionary`, so any other name in the trace is
+      // a real defect rather than a quirk of the harness.
+      case let cmd where cmd.hasPrefix("force_oracle_delay("):
+        guard let arg = parseStringArgCommand(cmd, prefix: "force_oracle_delay("),
+          let ms = Double(arg), ms > 0, ms <= 5000
+        else { return "ERR bad_arg" }
+        // Order is load-bearing and documented on the seam: `resetForTesting`
+        // CLEARS any override, so it must run first.
+        SeamCasingOracleRuntime.resetForTesting()
+        SeamCasingOracleRuntime.setPreparationOverrideForTesting { _ in
+          SeamCasingOracle.delayingDictionaryForFaultInjection(milliseconds: ms)
+        }
+        return "OK"
+
+      case "clear_oracle_delay":
+        SeamCasingOracleRuntime.setPreparationOverrideForTesting(nil)
+        SeamCasingOracleRuntime.resetForTesting()
+        return "OK"
 
       case "clear_default_input_absent":
         guard let audioCapture else { return "ERR no_dependency" }

--- a/Sources/EnviousWisprCore/Transcript.swift
+++ b/Sources/EnviousWisprCore/Transcript.swift
@@ -45,6 +45,23 @@ public struct ExecutionMetrics: Codable, Sendable {
   public var caretCaptureRetried: Bool?
   public var caretCaptureRetryMs: Double?
   public var repairRules: String?
+  /// #1946. Present ONLY when the 100 ms casing deadline actually fired, which
+  /// is the only time "which step was slow" has an answer. Names and durations,
+  /// never text: `casingDeadlinePhase` is a closed-set label and
+  /// `casingOracleClosure` names WHICH lookup was in flight (`dictionary` /
+  /// `learned` / `name` / `noun`), never the word it was asked about.
+  ///
+  /// These exist because `oracle_timed_out` was previously applied to any miss
+  /// of that deadline, including misses where no oracle ran, which made four
+  /// materially different causes indistinguishable in the field.
+  public var casingDeadlinePhase: String?
+  public var casingLanguageMs: Double?
+  public var casingOracleFetchMs: Double?
+  public var casingRepairMs: Double?
+  public var casingOracleClosure: String?
+  public var casingOracleInflightMs: Double?
+  public var casingOracleClosuresCompleted: Int?
+  public var casingOracleClosureMaxMs: Double?
   public var pastePayloadKind: String?
   public var languageResolutionSource: String?
   public var languageConfidenceBucket: String?

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -1141,6 +1141,19 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
         outcome.repairRules = nil
         outcome.caretCaptureRetried = nil
         outcome.caretCaptureRetryMs = nil
+        // #1946: same hazard, eight more fields. These are written ONLY when the
+        // casing deadline actually fired, so without clearing them one timeout
+        // would file its evidence against every later healthy recording — in
+        // stored metrics AND in `paste.completed`. Caught by whole-diff review;
+        // the comment above had already named the class.
+        outcome.casingDeadlinePhase = nil
+        outcome.casingLanguageMs = nil
+        outcome.casingOracleFetchMs = nil
+        outcome.casingRepairMs = nil
+        outcome.casingOracleClosure = nil
+        outcome.casingOracleInflightMs = nil
+        outcome.casingOracleClosuresCompleted = nil
+        outcome.casingOracleClosureMaxMs = nil
         // #1167: a fresh session starts assuming the save will succeed; the
         // best-effort `store` closure flips these only on a real save throw.
         outcome.historySaved = true

--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -808,7 +808,12 @@ struct KernelFinalizationWiring {
         // is why three separate causal theories all survived contact with the
         // data. Metadata only: labels and durations, never text.
         let casingTiming: String = {
-          guard let s = casingSnapshot else { return "" }
+          // The LOG reports healthy deliveries too; telemetry above does not.
+          // Measuring the main-thread hop per target app is the open question
+          // (#1946: all 9 field timeouts sit in 4 apps, and every app with a
+          // native accessibility bridge is at zero), and a timeout-only trace
+          // can only answer it by waiting for failures.
+          guard let s = casingSnapshot ?? gate.frozenEvidence else { return "" }
           func ms(_ v: Double?) -> String { v.map { String(format: "%.1f", $0) } ?? "-" }
           var parts = [
             "phase=\(s.phase.rawValue)",

--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -90,6 +90,17 @@ final class KernelFinalizationOutcome {
   /// combine with `caretContextOutcome` to distinguish "retried and still
   /// nothing" from "retried and recovered". `caretCaptureRetryMs` is set only
   /// when `caretCaptureRetried == true`.
+  /// #1946. Populated only when the casing deadline fired; see
+  /// `LanguageRepairDeadlineGate.Snapshot`, which is the sole authority these
+  /// are copied from.
+  var casingDeadlinePhase: String?
+  var casingLanguageMs: Double?
+  var casingOracleFetchMs: Double?
+  var casingRepairMs: Double?
+  var casingOracleClosure: String?
+  var casingOracleInflightMs: Double?
+  var casingOracleClosuresCompleted: Int?
+  var casingOracleClosureMaxMs: Double?
   var caretCaptureRetried: Bool?
   var caretCaptureRetryMs: Double?
   /// #1921. `repairRules` says WHAT the repair decided; these say why the
@@ -227,8 +238,15 @@ struct KernelFinalizationWiring {
     // Takes the RESOLVED language, so it must be called after resolution, not
     // before it (grounded review r1: the snapshot used to be taken above the
     // deadline, where the language is not yet known).
-    seamCasingOracle: @escaping @MainActor (String?) -> SeamCasingOracle = {
-      SeamCasingOracleRuntime.snapshot(for: $0)
+    // #1946: `async @Sendable`, not `@MainActor`. The production default below
+    // still hops to the main actor, so runtime behaviour is unchanged — the
+    // change exists so a test can inject a closure that stalls HERE without
+    // occupying the main actor. Blocking a synchronous `@MainActor` seam also
+    // blocks `withOrderedDeadline`'s timer, which is `Task { @MainActor }`
+    // (`TaskTimeout.swift:127-132`), so the timeout could never fire and the
+    // hop-stall case was untestable by construction (grounded r1).
+    seamCasingOracle: @escaping @Sendable (String?) async -> SeamCasingOracle = {
+      language in await MainActor.run { SeamCasingOracleRuntime.snapshot(for: language) }
     },
     // Paired with the seam above. A READY snapshot holds a lease that stops the
     // preparation drain entering the shared spell checker underneath a decision
@@ -611,11 +629,14 @@ struct KernelFinalizationWiring {
         // the language stage, decline to disable, and the un-preempted operation
         // can then enter the oracle anyway.
         let gate = LanguageRepairDeadlineGate()
-        // The timeout path's resolution. It cannot ride the operation's return
-        // value, because on timeout the operation's value is discarded; and
-        // `onTimeout` is `@Sendable`, so it cannot write to a captured `var`.
-        let timedOutResolution = OSAllocatedUnfairLock<DictationLanguageResolver.Resolution?>(
-          initialState: nil)
+        // The timeout path's frozen evidence. It cannot ride the operation's
+        // return value, because on timeout the operation's value is discarded;
+        // and `onTimeout` is `@Sendable`, so it cannot write to a captured
+        // `var`. #1946 widened this from the resolution alone to the whole
+        // snapshot — the gate froze it atomically, so carrying anything less
+        // would reintroduce the two-source problem the gate exists to remove.
+        let timedOutSnapshot =
+          OSAllocatedUnfairLock<LanguageRepairDeadlineGate.Snapshot?>(initialState: nil)
 
         let deadlineResult = await withOrderedDeadline(
           seconds: 0.100,
@@ -623,12 +644,16 @@ struct KernelFinalizationWiring {
             let resolution = resolveLanguage(
               lockedLanguageCode, engineDetectsLanguage, engineReportedLanguage,
               text, surroundingText)
+            gate.mark(.languageResolved)
             guard gate.beginRepair(resolution) else {
               // The deadline already claimed the phase, so repair must not
               // start. This return value is discarded by the deadline's own
               // single-claim rule; it exists to leave the closure, not to be read.
+              // #1946: named for the DEADLINE, not the oracle — nothing here has
+              // consulted one, and the old `.oracleTimedOut` asserted otherwise.
               return (
-                CursorInsertionRepair.legacyOnly(text: text, reason: .oracleTimedOut), resolution
+                CursorInsertionRepair.legacyOnly(text: text, reason: .repairDeadlineMissed),
+                resolution
               )
             }
             // The oracle asks the gate before every consultation, which both
@@ -647,7 +672,12 @@ struct KernelFinalizationWiring {
             // holds a lease; `defer` releases it on every exit including the
             // discarded-on-timeout one, since the deadline cannot preempt this
             // closure and it always runs to completion.
-            let oracleSnapshot = await MainActor.run { seamCasingOracle(resolution.language) }
+            let oracleSnapshot = await seamCasingOracle(resolution.language)
+            // Its OWN duration, because the phase cannot separate this hop from
+            // repair's own work — both sit in `.repair(oracleTouched: false)`.
+            // Measured 2026-08-10: this hop costs exactly as long as the main
+            // thread is occupied, 1:1 (issue-1946-artifacts/2026-08-10-hop-vs-pool.out).
+            gate.mark(.oracleFetched)
             // Release ONLY IF a lease was actually taken. `snapshot(for:)` leases
             // on a ready answer and not on a refusal, so an unconditional release
             // is not merely harmless bookkeeping: leases carry no identity, so an
@@ -659,7 +689,9 @@ struct KernelFinalizationWiring {
             defer {
               if holdsOracleLease { Task { @MainActor in releaseOracleLease() } }
             }
-            let gatedOracle = oracleSnapshot.authorized { gate.authorizeOracleUse() }
+            let gatedOracle = oracleSnapshot.authorized(
+              by: { label in gate.beginOracleUse(label) },
+              didFinish: { token in gate.completeOracleUse(token) })
             let repaired = CursorInsertionRepair.repair(
               text: text,
               context: repairContext,
@@ -669,12 +701,16 @@ struct KernelFinalizationWiring {
             // Immediately after repair returns and before this closure does, so
             // the window in which a FINISHED oracle still looks stuck is as
             // small as the runtime allows.
+            gate.mark(.repairReturned)
             gate.completeRepair()
             return (repaired, resolution)
           },
           onTimeout: {
+            // One atomic freeze; everything the timeout reports comes from it.
+            // Synchronous by contract (`TaskTimeout.swift:97-103`): this is one
+            // lock take and adds no suspension point.
             let timeout = gate.timeOut()
-            timedOutResolution.withLock { $0 = timeout.resolution }
+            timedOutSnapshot.withLock { $0 = timeout }
             // Only a genuinely RUNNING oracle. A language-stage stall must not
             // disable an unrelated healthy component for the rest of the
             // process, and neither must one that had already succeeded.
@@ -682,9 +718,19 @@ struct KernelFinalizationWiring {
           }
         )
 
+        let casingSnapshot = timedOutSnapshot.withLock { $0 }
         let payloads =
-          deadlineResult?.0 ?? CursorInsertionRepair.legacyOnly(text: text, reason: .oracleTimedOut)
-        let resolution = deadlineResult?.1 ?? timedOutResolution.withLock { $0 }
+          deadlineResult?.0
+          ?? CursorInsertionRepair.legacyOnly(
+            text: text,
+            // #1946: the reason is now READ from what the gate froze, never
+            // assumed. `oracle_timed_out` is reserved for a consultation that
+            // genuinely began; every other stall says so. Reading a stale
+            // `.oracleTimedOut` here is what made three causal theories
+            // indistinguishable in the field.
+            reason: casingSnapshot?.phase == .repairAfterOracle
+              ? .oracleTimedOut : .repairDeadlineMissed)
+        let resolution = deadlineResult?.1 ?? casingSnapshot?.resolution
 
         // Why this dictation was or was not repaired, recorded before delivery
         // so it survives every route outcome. Names and shapes only (#1785 §8).
@@ -726,6 +772,22 @@ struct KernelFinalizationWiring {
         outcome.languageResolutionSource = (resolution?.source ?? .none).rawValue
         outcome.languageConfidenceBucket = (resolution?.confidenceBucket ?? .none).rawValue
 
+        // #1946. Set ONLY when the deadline actually fired, so a healthy
+        // dictation sends nothing and the fields' presence is itself the signal
+        // that this delivery lost its casing to the clock. Absent facts are
+        // omitted rather than defaulted, matching how every other optional on
+        // this carrier behaves.
+        if let casing = casingSnapshot {
+          outcome.casingDeadlinePhase = casing.phase.rawValue
+          outcome.casingLanguageMs = casing.languageMs
+          outcome.casingOracleFetchMs = casing.oracleFetchMs
+          outcome.casingRepairMs = casing.repairMs
+          outcome.casingOracleClosure = casing.oracleInFlight
+          outcome.casingOracleInflightMs = casing.oracleInFlightMs
+          outcome.casingOracleClosuresCompleted = casing.oracleClosuresCompleted
+          outcome.casingOracleClosureMaxMs = casing.oracleClosureMaxMs
+        }
+
         // #1803: the repair decision has only ever gone to telemetry, so a
         // wrong-case report could not be diagnosed locally — which cost three
         // rounds of guessing during founder testing on 2026-07-26. Names and
@@ -738,12 +800,39 @@ struct KernelFinalizationWiring {
         // undiagnosable. Empty when no bounded step ran, so a non-terminal app
         // does not gain a dangling ` timing=` on every dictation.
         let terminalTiming = terminalBudget.timingDescription
+        // #1946. Emitted ONLY on a timeout, because that is the only time the
+        // question "which step was slow" has an answer — a healthy delivery
+        // would add a line to every dictation and say nothing.
+        //
+        // This is the line the whole change exists for. The sibling terminal
+        // timer was settled in ONE session by exactly this shape
+        // (`scan=114.7ms of 115.3ms total`); this path had no equivalent, which
+        // is why three separate causal theories all survived contact with the
+        // data. Metadata only: labels and durations, never text.
+        let casingTiming: String = {
+          guard let s = casingSnapshot else { return "" }
+          func ms(_ v: Double?) -> String { v.map { String(format: "%.1f", $0) } ?? "-" }
+          var parts = [
+            "phase=\(s.phase.rawValue)",
+            "lang=\(ms(s.languageMs))ms",
+            "hop=\(ms(s.oracleFetchMs))ms",
+            "repair=\(ms(s.repairMs))ms",
+          ]
+          if let inFlight = s.oracleInFlight {
+            parts.append("stuck=\(inFlight)")
+            parts.append("stuck_for=\(ms(s.oracleInFlightMs))ms")
+          }
+          parts.append("closures=\(s.oracleClosuresCompleted)")
+          if let maxMs = s.oracleClosureMaxMs { parts.append("slowest=\(ms(maxMs))ms") }
+          return parts.joined(separator: " ")
+        }()
         await AppLogger.shared.log(
           "CURSOR_REPAIR app=\(context.targetApp?.bundleIdentifier ?? "nil") "
             + "caret=\(outcome.caretContextOutcome ?? "nil") "
             + "rules=\(outcome.repairRules ?? "none") "
             + "candidate=\(payloads.repairedText == nil ? "none" : "offered")"
             + (terminalTiming.isEmpty ? "" : " timing=[\(terminalTiming)]")
+            + (casingTiming.isEmpty ? "" : " casing=[\(casingTiming)]")
             // #1980: local diagnostic only — production recovery-rate/latency
             // authority is the `caret_capture_retried`/`caret_capture_retry_ms`
             // telemetry (Chunk 3), which survives past this DEBUG-only log.
@@ -1027,6 +1116,21 @@ struct KernelFinalizationWiring {
       // skipped. `emitFallbackFields` owns different telemetry.
       polishRanRemote: outcome.polishRanRemote
     )
+
+    // #1946: assigned AFTER construction, not as eight more initialiser
+    // arguments. With them inline the type-checker gave up on the expression
+    // ("unable to type-check in reasonable time") — a real constraint of a
+    // 40-argument memberwise init with mostly-optional parameters, not a style
+    // choice. Same transport-unchanged rule as every other field here: copied
+    // verbatim from the gate's frozen snapshot, never normalised or defaulted.
+    transcript.metrics?.casingDeadlinePhase = outcome.casingDeadlinePhase
+    transcript.metrics?.casingLanguageMs = outcome.casingLanguageMs
+    transcript.metrics?.casingOracleFetchMs = outcome.casingOracleFetchMs
+    transcript.metrics?.casingRepairMs = outcome.casingRepairMs
+    transcript.metrics?.casingOracleClosure = outcome.casingOracleClosure
+    transcript.metrics?.casingOracleInflightMs = outcome.casingOracleInflightMs
+    transcript.metrics?.casingOracleClosuresCompleted = outcome.casingOracleClosuresCompleted
+    transcript.metrics?.casingOracleClosureMaxMs = outcome.casingOracleClosureMaxMs
     outcome.transcript = transcript
   }
 

--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -644,7 +644,6 @@ struct KernelFinalizationWiring {
             let resolution = resolveLanguage(
               lockedLanguageCode, engineDetectsLanguage, engineReportedLanguage,
               text, surroundingText)
-            gate.mark(.languageResolved)
             guard gate.beginRepair(resolution) else {
               // The deadline already claimed the phase, so repair must not
               // start. This return value is discarded by the deadline's own
@@ -701,7 +700,6 @@ struct KernelFinalizationWiring {
             // Immediately after repair returns and before this closure does, so
             // the window in which a FINISHED oracle still looks stuck is as
             // small as the runtime allows.
-            gate.mark(.repairReturned)
             gate.completeRepair()
             return (repaired, resolution)
           },

--- a/Sources/EnviousWisprPipeline/LanguageRepairDeadlineGate.swift
+++ b/Sources/EnviousWisprPipeline/LanguageRepairDeadlineGate.swift
@@ -62,7 +62,14 @@ package final class LanguageRepairDeadlineGate: Sendable {
     /// is why the hop carries its own duration below — the phase alone cannot
     /// separate them.
     case repairBeforeOracle = "repair_pre_oracle"
+    /// A consultation was IN FLIGHT when the deadline fired. Only this phase
+    /// may honestly be reported as an oracle timeout.
     case repairAfterOracle = "repair_oracle"
+    /// The oracle was consulted, every consultation RETURNED, and repair then
+    /// crossed the deadline in its own work. Whole-diff review found the first
+    /// version reporting this as `repair_oracle`, which asserts a stall that
+    /// demonstrably did not happen — the exact defect this change exists to end.
+    case repairAfterOracleReturned = "repair_post_oracle"
     case completed = "completed"
     case alreadyTimedOut = "already_timed_out"
   }
@@ -298,8 +305,22 @@ package final class LanguageRepairDeadlineGate: Sendable {
     // consulted — repair may have stalled in its own spacing work, or have
     // taken an early exit, without ever reaching it.
     case .repair(let r, let oracleTouched):
-      phase = oracleTouched ? .repairAfterOracle : .repairBeforeOracle
+      // Three outcomes, not two. `oracleTouched` says a consultation happened at
+      // some point; `inFlight` says one is happening NOW, and only the second
+      // justifies reporting an oracle stall.
+      phase =
+        oracleTouched
+        ? (inFlight != nil ? .repairAfterOracle : .repairAfterOracleReturned)
+        : .repairBeforeOracle
       resolution = r
+      // DELIBERATELY UNCHANGED, and this is the one place the diagnostic and the
+      // safety net are allowed to disagree. Whole-diff review proposed gating
+      // this on an active token too, which would NARROW the latch — a change to
+      // the guard, which the founder ruled out for this change (2026-08-10).
+      // So a returned-consultation timeout still latches exactly as it always
+      // has, while the evidence now says honestly that nothing was in flight.
+      // Whether that latch is right is a real question, and it is now ASKABLE
+      // from the data instead of invisible: look for `repair_post_oracle`.
       shouldDisable = oracleTouched
     // Repair already returned, so whatever it consulted answered in time.
     case .completed(let r):

--- a/Sources/EnviousWisprPipeline/LanguageRepairDeadlineGate.swift
+++ b/Sources/EnviousWisprPipeline/LanguageRepairDeadlineGate.swift
@@ -96,11 +96,22 @@ package final class LanguageRepairDeadlineGate: Sendable {
     package var oracleClosureMaxMs: Double?
   }
 
-  /// The three sequencing points the wiring reports.
+  /// The one sequencing point that is NOT already a phase transition.
+  ///
+  /// `languageResolved` and `repairReturned` used to live here too. They are now
+  /// folded into `beginRepair` and `completeRepair`, because a separate `mark`
+  /// call meant TWO lock takes around one logical event, and the timer can claim
+  /// between them. For `repairReturned` that was not merely a lost datum: the
+  /// phase was still `.repair(oracleTouched: true)` in the gap, so a timeout
+  /// landing there would permanently disable an oracle whose work had ALREADY
+  /// completed — the instrument causing the exact failure it exists to diagnose
+  /// (`validation-discipline.md`: a diagnostic must not widen a window in the
+  /// code it observes; whole-diff review r2).
+  ///
+  /// This one is safe to leave standalone because it changes no phase: a timeout
+  /// racing it costs one missing duration, never a wrong action.
   package enum Mark: Sendable {
-    case languageResolved
     case oracleFetched
-    case repairReturned
   }
 
   // MARK: - Internal state
@@ -174,6 +185,9 @@ package final class LanguageRepairDeadlineGate: Sendable {
   package func beginRepair(_ resolution: DictationLanguageResolver.Resolution) -> Bool {
     state.withLock {
       guard $0.frozen == nil, case .resolvingLanguage = $0.phase else { return false }
+      let t = now()
+      $0.languageMs = max(0, t - $0.lastMarkAt) * 1000
+      $0.lastMarkAt = t
       $0.phase = .repair(resolution, oracleTouched: false)
       return true
     }
@@ -190,9 +204,7 @@ package final class LanguageRepairDeadlineGate: Sendable {
       let elapsed = max(0, t - $0.lastMarkAt) * 1000
       $0.lastMarkAt = t
       switch mark {
-      case .languageResolved: $0.languageMs = elapsed
       case .oracleFetched: $0.oracleFetchMs = elapsed
-      case .repairReturned: $0.repairMs = elapsed
       }
     }
   }
@@ -262,10 +274,13 @@ package final class LanguageRepairDeadlineGate: Sendable {
   @discardableResult
   package func completeRepair() -> Snapshot {
     state.withLock {
+      let t = now()
       if $0.frozen == nil, case .repair(let resolution, _) = $0.phase {
+        $0.repairMs = max(0, t - $0.lastMarkAt) * 1000
+        $0.lastMarkAt = t
         $0.phase = .completed(resolution)
       }
-      return Self.freeze(&$0, now: now())
+      return Self.freeze(&$0, now: t)
     }
   }
 

--- a/Sources/EnviousWisprPipeline/LanguageRepairDeadlineGate.swift
+++ b/Sources/EnviousWisprPipeline/LanguageRepairDeadlineGate.swift
@@ -309,6 +309,34 @@ package final class LanguageRepairDeadlineGate: Sendable {
   private static func freeze(_ state: inout State, now: Double) -> Snapshot {
     if let already = state.frozen { return already }
     let inFlight = state.oracleUses.last
+
+    // CHARGE THE UNFINISHED STAGE BEFORE PROJECTING.
+    //
+    // Every duration above is written when its stage FINISHES, so on a timeout
+    // the one stage that never finished — the slow one, the entire reason this
+    // record exists — was reported as `-`. The first version logged
+    // `phase=language lang=-ms` and that blank sat in a passing test's output
+    // without anyone reading it. Whole-diff review r3 caught it.
+    //
+    // Which field it belongs to is derived from the phase, so an in-flight
+    // duration can never be confused with a completed one: the phase names the
+    // stage, and that stage's number is the partial.
+    let running = max(0, now - state.lastMarkAt) * 1000
+    switch state.phase {
+    case .resolvingLanguage:
+      state.languageMs = running
+    case .repair:
+      // Before the fetch completed, the running stage IS the fetch; after it,
+      // repair's own work. `oracleFetchMs` is the only thing that distinguishes
+      // them, because both live in the same phase.
+      if state.oracleFetchMs == nil {
+        state.oracleFetchMs = running
+      } else {
+        state.repairMs = running
+      }
+    case .completed, .timedOut:
+      break  // nothing is running; every stage already recorded its own time
+    }
     let phase: TimeoutPhase
     var resolution: DictationLanguageResolver.Resolution?
     var shouldDisable = false

--- a/Sources/EnviousWisprPipeline/LanguageRepairDeadlineGate.swift
+++ b/Sources/EnviousWisprPipeline/LanguageRepairDeadlineGate.swift
@@ -2,7 +2,8 @@ import Foundation
 import os
 
 /// Arbitrates the single 100 ms deadline that now covers BOTH language
-/// resolution and cursor-insertion repair (#1921).
+/// resolution and cursor-insertion repair (#1921), and owns the entire
+/// diagnostic record of what that deadline saw (#1946).
 ///
 /// Before #1921 only repair sat inside `withOrderedDeadline`; language
 /// resolution ran ahead of it, unbounded, on the paste path. Moving resolution
@@ -35,7 +36,67 @@ import os
 /// Merging the flag into the phase makes the two facts one atomic transition,
 /// and it is simpler than what it replaced. Every mutation below is exactly one
 /// `withLock`, so neither side can lose a window.
+///
+/// **#1946 extends that same argument to the DIAGNOSTIC record, for the same
+/// reason.** The plan's first design put phase durations in a second lock owned
+/// by the wiring, on the theory that "where" and "how long" are disjoint facts.
+/// They are not: both answer *"what was true when the timeout claimed?"*, and
+/// two locks cannot answer that atomically. Because the operation is never
+/// preempted (`TaskTimeout.swift:123-132`), a mark written after the phase was
+/// claimed could contradict evidence the timeout had already returned — a
+/// diagnostic that looks self-consistent and is false, which is worse than the
+/// coarse label it replaces. So every mark lives here, behind this lock, and
+/// `freeze` makes everything after the claim inert.
 package final class LanguageRepairDeadlineGate: Sendable {
+
+  // MARK: - Outward shape
+
+  /// Which stage the deadline caught, as a stable label for logs and telemetry.
+  ///
+  /// Raw values are a SHIPPED closed set consumed by `paste.completed`; treat
+  /// them like any other telemetry vocabulary and never repurpose one.
+  package enum TimeoutPhase: String, Sendable, Equatable {
+    case resolvingLanguage = "language"
+    /// Repair running, no oracle consultation had begun. Covers both repair's
+    /// own spacing work AND the main-thread hop that fetches the oracle, which
+    /// is why the hop carries its own duration below — the phase alone cannot
+    /// separate them.
+    case repairBeforeOracle = "repair_pre_oracle"
+    case repairAfterOracle = "repair_oracle"
+    case completed = "completed"
+    case alreadyTimedOut = "already_timed_out"
+  }
+
+  /// The immutable projection of everything the gate knows, frozen at one
+  /// instant. The mutable state it is derived from never leaves this type.
+  /// NOT `Equatable`: `DictationLanguageResolver.Resolution` is `Sendable` only
+  /// (`DictationLanguageResolver.swift:47`), and widening a shipped type's
+  /// conformances to buy a test convenience is the wrong trade. Tests compare
+  /// the fields they are actually asserting on.
+  package struct Snapshot: Sendable {
+    package var phase: TimeoutPhase
+    package var resolution: DictationLanguageResolver.Resolution?
+    /// True ONLY for an oracle that was genuinely consulted. This is the safety
+    /// net's input and #1946 does not change how it is computed.
+    package var shouldDisableOracle: Bool
+    package var languageMs: Double?
+    package var oracleFetchMs: Double?
+    package var repairMs: Double?
+    /// Label of the consultation still running when the snapshot froze.
+    package var oracleInFlight: String?
+    package var oracleInFlightMs: Double?
+    package var oracleClosuresCompleted: Int
+    package var oracleClosureMaxMs: Double?
+  }
+
+  /// The three sequencing points the wiring reports.
+  package enum Mark: Sendable {
+    case languageResolved
+    case oracleFetched
+    case repairReturned
+  }
+
+  // MARK: - Internal state
 
   private enum Phase: Sendable {
     /// Resolution in flight. Repair has not been authorised.
@@ -50,9 +111,52 @@ package final class LanguageRepairDeadlineGate: Sendable {
     case timedOut
   }
 
-  private let phase = OSAllocatedUnfairLock(initialState: Phase.resolvingLanguage)
+  private struct OracleUse: Sendable {
+    let token: UInt64
+    let label: String
+    let startedAt: Double
+  }
 
-  package init() {}
+  private struct State: Sendable {
+    var phase: Phase = .resolvingLanguage
+    /// Set by the first `timeOut()` / `completeRepair()`. Every later mutation
+    /// is inert, which is what stops an un-preempted operation rewriting
+    /// evidence already returned. Holding the SNAPSHOT rather than a flag is
+    /// what makes re-freezing genuinely idempotent: recomputing would re-measure
+    /// `oracleInFlightMs` against a later clock and hand two callers two
+    /// different answers about the same instant.
+    var frozen: Snapshot?
+    var lastMarkAt: Double
+    var languageMs: Double?
+    var oracleFetchMs: Double?
+    var repairMs: Double?
+    /// Monotonic. Never reused, which is what makes a completion correlatable.
+    var nextToken: UInt64 = 1
+    /// A STACK, not a single label: consultations can nest, and a label alone
+    /// cannot tell a stale completion from a live consultation that happens to
+    /// carry the same label.
+    var oracleUses: [OracleUse] = []
+    var oracleClosuresCompleted = 0
+    var oracleClosureMaxMs: Double?
+  }
+
+  private let state: OSAllocatedUnfairLock<State>
+  private let now: @Sendable () -> Double
+
+  /// `now` reads a MONOTONIC clock in seconds, injectable for the same reason
+  /// `TerminalResolutionBudget` takes one (`TerminalContextResolver.swift:113-123`,
+  /// #1893): an assertion about a duration must not depend on wall time, because
+  /// a busy-wait guarantees a floor and never a ceiling.
+  package init(
+    now: @escaping @Sendable () -> Double = {
+      Double(DispatchTime.now().uptimeNanoseconds) / 1e9
+    }
+  ) {
+    self.now = now
+    self.state = OSAllocatedUnfairLock(initialState: State(lastMarkAt: now()))
+  }
+
+  // MARK: - Phase transitions
 
   /// Authorises repair, carrying the resolution the timeout would otherwise lose.
   ///
@@ -61,17 +165,35 @@ package final class LanguageRepairDeadlineGate: Sendable {
   /// repair. That is the guarantee a cancellation flag cannot give, because the
   /// operation may not have been preempted at all.
   package func beginRepair(_ resolution: DictationLanguageResolver.Resolution) -> Bool {
-    phase.withLock {
-      guard case .resolvingLanguage = $0 else { return false }
-      $0 = .repair(resolution, oracleTouched: false)
+    state.withLock {
+      guard $0.frozen == nil, case .resolvingLanguage = $0.phase else { return false }
+      $0.phase = .repair(resolution, oracleTouched: false)
       return true
     }
   }
 
-  /// May the word oracle be consulted right now, and record that it was.
+  /// Record how long a sequencing step took, measured by this gate's own clock.
+  ///
+  /// One clock and one lock: the caller says WHICH step finished, never how long
+  /// it took, so there is no second time source to disagree with the snapshot.
+  package func mark(_ mark: Mark) {
+    state.withLock {
+      guard $0.frozen == nil else { return }
+      let t = now()
+      let elapsed = max(0, t - $0.lastMarkAt) * 1000
+      $0.lastMarkAt = t
+      switch mark {
+      case .languageResolved: $0.languageMs = elapsed
+      case .oracleFetched: $0.oracleFetchMs = elapsed
+      case .repairReturned: $0.repairMs = elapsed
+      }
+    }
+  }
+
+  /// May the word oracle be consulted right now — and if so, take a token.
   ///
   /// Called from the oracle's own closures on EVERY consultation, not merely the
-  /// first — which is what makes it a guard rather than a notification. Two
+  /// first, which is what makes it a guard rather than a notification. Three
   /// jobs, and they must be one transition:
   ///
   /// 1. **Record** that the oracle was genuinely reached. `beginRepair` runs
@@ -85,53 +207,119 @@ package final class LanguageRepairDeadlineGate: Sendable {
   ///    real oracle AFTER the timeout already gave up — the unbounded blocking
   ///    call the deadline exists to bound. The wrapper's refusal keeps the
   ///    capital, so a late refusal can only be safe.
+  /// 3. **Name** which consultation is running, so a post-authorisation timeout
+  ///    says whether the dictionary, the name tagger or the noun tagger stalled
+  ///    (#1946). Without this the four post-authorisation closures produce
+  ///    byte-identical evidence and the instrument answers nothing.
   ///
-  /// Idempotent; the cost is one uncontended lock per word decision.
-  package func authorizeOracleUse() -> Bool {
-    phase.withLock {
-      guard case .repair(let resolution, _) = $0 else { return false }
-      $0 = .repair(resolution, oracleTouched: true)
-      return true
+  /// - Returns: a unique token to pass to `completeOracleUse`, or `nil` when the
+  ///   consultation is refused. A refused caller must NOT call the completion.
+  package func beginOracleUse(_ label: String) -> UInt64? {
+    state.withLock {
+      guard $0.frozen == nil, case .repair(let resolution, _) = $0.phase else { return nil }
+      $0.phase = .repair(resolution, oracleTouched: true)
+      let token = $0.nextToken
+      $0.nextToken += 1
+      $0.oracleUses.append(OracleUse(token: token, label: label, startedAt: now()))
+      return token
     }
   }
 
-  /// Marks repair finished. Must be called immediately after repair returns and
-  /// before the deadline operation's closure returns, so the window in which a
-  /// healthy oracle looks stuck is as small as the runtime allows.
+  /// Finish the consultation identified by `token`.
+  ///
+  /// Removes ONLY that token, so a stale or duplicate completion cannot clear a
+  /// newer consultation that happens to carry the same label — the defect a
+  /// label-correlated API has and this one does not. Unknown, duplicate and
+  /// post-freeze tokens are inert by construction.
+  package func completeOracleUse(_ token: UInt64) {
+    state.withLock {
+      guard $0.frozen == nil,
+        let index = $0.oracleUses.firstIndex(where: { $0.token == token })
+      else { return }
+      let use = $0.oracleUses.remove(at: index)
+      let elapsed = max(0, now() - use.startedAt) * 1000
+      $0.oracleClosuresCompleted += 1
+      $0.oracleClosureMaxMs = max($0.oracleClosureMaxMs ?? 0, elapsed)
+    }
+  }
+
+  // MARK: - Freezing
+
+  /// Marks repair finished and freezes the record. Must be called immediately
+  /// after repair returns and before the deadline operation's closure returns,
+  /// so the window in which a healthy oracle looks stuck is as small as the
+  /// runtime allows.
   ///
   /// Inert from any other phase: a `completeRepair` that never began must not
   /// promote `resolvingLanguage` into a completed run.
-  package func completeRepair() {
-    phase.withLock {
-      guard case .repair(let resolution, _) = $0 else { return }
-      $0 = .completed(resolution)
+  @discardableResult
+  package func completeRepair() -> Snapshot {
+    state.withLock {
+      if $0.frozen == nil, case .repair(let resolution, _) = $0.phase {
+        $0.phase = .completed(resolution)
+      }
+      return Self.freeze(&$0, now: now())
     }
   }
 
-  /// Claims the phase for the deadline and reports what the caller may do.
+  /// Claims the phase for the deadline and reports everything it saw.
   ///
-  /// - Returns: the resolution when one was reached, so an oracle-stage or
-  ///   post-repair timeout still reports its real source and confidence rather
-  ///   than `none` / `none`; and whether the oracle runtime may be disabled,
-  ///   which is true ONLY for an oracle that was genuinely consulted.
-  package func timeOut()
-    -> (resolution: DictationLanguageResolver.Resolution?, shouldDisableOracle: Bool)
-  {
-    phase.withLock {
-      let result: (DictationLanguageResolver.Resolution?, Bool) =
-        switch $0 {
-        // Nothing ran. Nothing to report, nothing to punish.
-        case .resolvingLanguage: (nil, false)
-        // Repair is still running. Disable ONLY if the oracle was genuinely
-        // consulted — repair may have stalled in its own spacing work, or have
-        // taken an early exit, without ever reaching it.
-        case .repair(let resolution, let oracleTouched): (resolution, oracleTouched)
-        // Repair already returned, so whatever it consulted answered in time.
-        case .completed(let resolution): (resolution, false)
-        case .timedOut: (nil, false)
-        }
-      $0 = .timedOut
-      return result
+  /// - Returns: the complete frozen `Snapshot`. `shouldDisableOracle` is true
+  ///   ONLY for an oracle that was genuinely consulted, which is unchanged by
+  ///   #1946 — the safety net's input is the same fact it always was.
+  package func timeOut() -> Snapshot {
+    state.withLock {
+      let snapshot = Self.freeze(&$0, now: now())
+      // Only a timeout is terminal. A `completeRepair` that already froze keeps
+      // its `.completed` snapshot, which correctly reports `shouldDisableOracle
+      // == false`: repair returned, so whatever it consulted answered in time.
+      $0.phase = .timedOut
+      return snapshot
     }
+  }
+
+  /// Project the current state and make every later mutation inert.
+  ///
+  /// Idempotent BY STORING the projection: a second freeze returns the first
+  /// one's evidence rather than re-measuring an in-flight duration against a
+  /// later clock, so two callers can never be told two different things about
+  /// the same instant.
+  private static func freeze(_ state: inout State, now: Double) -> Snapshot {
+    if let already = state.frozen { return already }
+    let inFlight = state.oracleUses.last
+    let phase: TimeoutPhase
+    var resolution: DictationLanguageResolver.Resolution?
+    var shouldDisable = false
+    switch state.phase {
+    // Nothing ran. Nothing to report, nothing to punish.
+    case .resolvingLanguage:
+      phase = .resolvingLanguage
+    // Repair is still running. Disable ONLY if the oracle was genuinely
+    // consulted — repair may have stalled in its own spacing work, or have
+    // taken an early exit, without ever reaching it.
+    case .repair(let r, let oracleTouched):
+      phase = oracleTouched ? .repairAfterOracle : .repairBeforeOracle
+      resolution = r
+      shouldDisable = oracleTouched
+    // Repair already returned, so whatever it consulted answered in time.
+    case .completed(let r):
+      phase = .completed
+      resolution = r
+    case .timedOut:
+      phase = .alreadyTimedOut
+    }
+    let snapshot = Snapshot(
+      phase: phase,
+      resolution: resolution,
+      shouldDisableOracle: shouldDisable,
+      languageMs: state.languageMs,
+      oracleFetchMs: state.oracleFetchMs,
+      repairMs: state.repairMs,
+      oracleInFlight: inFlight?.label,
+      oracleInFlightMs: inFlight.map { max(0, now - $0.startedAt) * 1000 },
+      oracleClosuresCompleted: state.oracleClosuresCompleted,
+      oracleClosureMaxMs: state.oracleClosureMaxMs)
+    state.frozen = snapshot
+    return snapshot
   }
 }

--- a/Sources/EnviousWisprPipeline/LanguageRepairDeadlineGate.swift
+++ b/Sources/EnviousWisprPipeline/LanguageRepairDeadlineGate.swift
@@ -174,6 +174,15 @@ package final class LanguageRepairDeadlineGate: Sendable {
     self.state = OSAllocatedUnfairLock(initialState: State(lastMarkAt: now()))
   }
 
+  /// The frozen record, whichever path froze it, or nil if neither has yet.
+  ///
+  /// Exists so the DEBUG trace can report a HEALTHY delivery's phase timings.
+  /// Telemetry deliberately stays timeout-only — a healthy dictation must send
+  /// nothing, because the fields' presence is itself the signal — but the local
+  /// log has no such constraint, and without this the per-app cost of the
+  /// main-thread hop could only be measured by waiting for a failure.
+  package var frozenEvidence: Snapshot? { state.withLock { $0.frozen } }
+
   // MARK: - Phase transitions
 
   /// Authorises repair, carrying the resolution the timeout would otherwise lose.

--- a/Sources/EnviousWisprPostProcessing/CursorInsertionRepair.swift
+++ b/Sources/EnviousWisprPostProcessing/CursorInsertionRepair.swift
@@ -60,7 +60,11 @@ public enum CursorInsertionRepair {
   // MARK: - Outputs
 
   /// Why the leading capital was left alone.
-  public enum CaseSkipReason: String, Equatable, Sendable {
+  /// `CaseIterable` so the telemetry-hygiene test can enumerate this set rather
+  /// than restate it. #1946 added a case and the hand-written list in
+  /// `PasteExecutionMetricsTests` did not fail, despite a comment claiming "a
+  /// rule added later without a name cannot slip through" — it could, and did.
+  public enum CaseSkipReason: String, Equatable, Sendable, CaseIterable {
     case alreadyLower = "already_lower"
     case protectedWord = "protected_word"
     case mixedCaseOrAcronym = "mixed_case_or_acronym"
@@ -92,9 +96,24 @@ public enum CursorInsertionRepair {
     /// launch keeps its capital — today's behaviour — rather than paying the
     /// measured 105.6 ms of one-time setup on the paste path.
     case oracleWarming = "oracle_warming"
-    /// A live decision exceeded its deadline. Latched for the process, so a
-    /// stalled spelling service can never be waited on twice.
+    /// A live ORACLE CONSULTATION exceeded its deadline. Latched for the
+    /// process, so a stalled spelling service can never be waited on twice.
+    ///
+    /// #1946 NARROWED this: it used to be applied to ANY miss of the 100 ms
+    /// block, including misses where no oracle had been consulted, which made
+    /// four materially different causes indistinguishable and produced three
+    /// successive wrong diagnoses. It now means what its name says. A miss
+    /// before any consultation is `repairDeadlineMissed`.
+    ///
+    /// The meaning therefore CHANGES at that release boundary; do not pool
+    /// `repair_rules` data across it (`analytics-operations.md` RULE:
+    /// enum-backed-properties-carry-retired-vocabularies-split-by-version).
     case oracleTimedOut = "oracle_timed_out"
+    /// The 100 ms repair deadline expired before any oracle was consulted —
+    /// during language resolution, the main-thread oracle fetch, or repair's
+    /// own work. Names the DEADLINE, because the gate proved no oracle ran
+    /// (#1946). Never latches anything.
+    case repairDeadlineMissed = "repair_deadline_missed"
     /// The dictation is not in a language whose casing rules we know. The
     /// lexicon is English, and applying it to another language is not merely
     /// useless — it is actively wrong. `See`, `Start`, `Test`, `Team` and

--- a/Sources/EnviousWisprPostProcessing/SeamCasingOracle.swift
+++ b/Sources/EnviousWisprPostProcessing/SeamCasingOracle.swift
@@ -160,6 +160,36 @@ package struct SeamCasingOracle: Sendable {
       })
   }
 
+  #if DEBUG
+    /// An oracle whose DICTIONARY lookup blocks, for Live UAT only (#1946).
+    ///
+    /// Built here because the memberwise initialiser is internal to this module,
+    /// which is the same reason `authorized` is built here.
+    ///
+    /// Why a real blocking sleep rather than a fake: the defect under test is a
+    /// consultation that does not return inside the deadline, and
+    /// `withOrderedDeadline` explicitly "cannot preempt a blocked thread". A
+    /// cooperative `await` would be preemptible and would therefore exercise a
+    /// different path than the one that latches in the field.
+    ///
+    /// Only `dictionaryVerdict` stalls. The others answer benignly and fast, so
+    /// the resulting trace names exactly one stuck consultation and any other
+    /// name in `stuck=` would be a real defect in the instrument.
+    package static func delayingDictionaryForFaultInjection(
+      milliseconds: Double
+    ) -> SeamCasingOracle {
+      SeamCasingOracle(
+        unavailableReason: nil,
+        dictionaryVerdict: { _ in
+          Thread.sleep(forTimeInterval: milliseconds / 1000)
+          return .ordinary
+        },
+        isLearnedWord: { _ in false },
+        isRecognizedName: { _, _ in false },
+        isNoun: { _ in false })
+    }
+  #endif
+
   package static func unavailable(
     _ reason: CursorInsertionRepair.CaseSkipReason
   ) -> SeamCasingOracle {

--- a/Sources/EnviousWisprPostProcessing/SeamCasingOracle.swift
+++ b/Sources/EnviousWisprPostProcessing/SeamCasingOracle.swift
@@ -111,28 +111,51 @@ package struct SeamCasingOracle: Sendable {
   /// is internal to this module, and because a type that can be wrapped should
   /// own how it is wrapped. `repair` stays unaware of any of this: it remains a
   /// pure function of the oracle it is handed.
+  /// #1946: `begin` now takes a LABEL and returns a token, and each accepted
+  /// consultation reports its end. That is what lets a post-authorisation
+  /// timeout say WHICH consultation was in flight — without it, the four
+  /// closures below produce byte-identical evidence and the four leading causes
+  /// cannot be told apart.
+  ///
+  /// Tokens rather than labels, because a label cannot be correlated: two
+  /// consultations can carry the same label, and a stale or duplicate
+  /// completion would then clear a newer live one and blank the evidence at
+  /// exactly the moment it matters.
+  ///
+  /// `didFinish` fires from `defer`, so a closure that throws or exits early
+  /// still reports. A REFUSED begin returns `nil` and must not report — that is
+  /// why each guard binds a token rather than testing a Bool.
+  ///
+  /// This module cannot name the gate's type (`EnviousWisprPostProcessing`
+  /// depends on Core only, `Package.swift:75-79`), so the contract is expressed
+  /// entirely in `String` and `UInt64`.
   package func authorized(
-    by authorize: @escaping @Sendable () -> Bool
+    by begin: @escaping @Sendable (String) -> UInt64?,
+    didFinish: @escaping @Sendable (UInt64) -> Void
   ) -> SeamCasingOracle {
     SeamCasingOracle(
       unavailableReason: unavailableReason,
       dictionaryVerdict: { word in
-        guard authorize() else { return .unavailable(.oracleTimedOut) }
+        guard let token = begin("dictionary") else { return .unavailable(.oracleTimedOut) }
+        defer { didFinish(token) }
         return dictionaryVerdict(word)
       },
       isLearnedWord: { word in
-        guard authorize() else { return true }
+        guard let token = begin("learned") else { return true }
+        defer { didFinish(token) }
         return isLearnedWord(word)
       },
       isRecognizedName: { left, payload in
-        guard authorize() else { return true }
+        guard let token = begin("name") else { return true }
+        defer { didFinish(token) }
         return isRecognizedName(left, payload)
       },
       // `true` on refusal, same as the others and for the same reason: a veto
       // answering "noun" keeps the capital, which is what the app did before
       // this feature existed.
       isNoun: { payload in
-        guard authorize() else { return true }
+        guard let token = begin("noun") else { return true }
+        defer { didFinish(token) }
         return isNoun(payload)
       })
   }

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -238,7 +238,15 @@ public final class TelemetryService {
           repairRules: m?.repairRules,
           payloadKind: m?.pastePayloadKind,
           languageResolutionSource: m?.languageResolutionSource,
-          languageConfidenceBucket: m?.languageConfidenceBucket),
+          languageConfidenceBucket: m?.languageConfidenceBucket,
+          casingDeadlinePhase: m?.casingDeadlinePhase,
+          casingLanguageMs: m?.casingLanguageMs,
+          casingOracleFetchMs: m?.casingOracleFetchMs,
+          casingRepairMs: m?.casingRepairMs,
+          casingOracleClosure: m?.casingOracleClosure,
+          casingOracleInflightMs: m?.casingOracleInflightMs,
+          casingOracleClosuresCompleted: m?.casingOracleClosuresCompleted,
+          casingOracleClosureMaxMs: m?.casingOracleClosureMaxMs),
         takeID: takeID)
     }
   }
@@ -1771,6 +1779,16 @@ public final class TelemetryService {
     /// speaks.
     public let languageResolutionSource: String?
     public let languageConfidenceBucket: String?
+    /// #1946. Typed fields, never a joined timing string: PostHog can aggregate
+    /// numbers and cannot aggregate substrings. Present only on a deadline miss.
+    public let casingDeadlinePhase: String?
+    public let casingLanguageMs: Double?
+    public let casingOracleFetchMs: Double?
+    public let casingRepairMs: Double?
+    public let casingOracleClosure: String?
+    public let casingOracleInflightMs: Double?
+    public let casingOracleClosuresCompleted: Int?
+    public let casingOracleClosureMaxMs: Double?
 
     public init(
       smartInsertionEnabled: Bool? = nil,
@@ -1780,7 +1798,15 @@ public final class TelemetryService {
       repairRules: String? = nil,
       payloadKind: String? = nil,
       languageResolutionSource: String? = nil,
-      languageConfidenceBucket: String? = nil
+      languageConfidenceBucket: String? = nil,
+      casingDeadlinePhase: String? = nil,
+      casingLanguageMs: Double? = nil,
+      casingOracleFetchMs: Double? = nil,
+      casingRepairMs: Double? = nil,
+      casingOracleClosure: String? = nil,
+      casingOracleInflightMs: Double? = nil,
+      casingOracleClosuresCompleted: Int? = nil,
+      casingOracleClosureMaxMs: Double? = nil
     ) {
       self.smartInsertionEnabled = smartInsertionEnabled
       self.caretContextOutcome = caretContextOutcome
@@ -1790,6 +1816,14 @@ public final class TelemetryService {
       self.payloadKind = payloadKind
       self.languageResolutionSource = languageResolutionSource
       self.languageConfidenceBucket = languageConfidenceBucket
+      self.casingDeadlinePhase = casingDeadlinePhase
+      self.casingLanguageMs = casingLanguageMs
+      self.casingOracleFetchMs = casingOracleFetchMs
+      self.casingRepairMs = casingRepairMs
+      self.casingOracleClosure = casingOracleClosure
+      self.casingOracleInflightMs = casingOracleInflightMs
+      self.casingOracleClosuresCompleted = casingOracleClosuresCompleted
+      self.casingOracleClosureMaxMs = casingOracleClosureMaxMs
     }
 
     /// Absent facts are OMITTED rather than sent as a placeholder, so a
@@ -1808,6 +1842,18 @@ public final class TelemetryService {
       }
       if let languageConfidenceBucket {
         out["language_confidence_bucket"] = languageConfidenceBucket
+      }
+      if let casingDeadlinePhase { out["casing_deadline_phase"] = casingDeadlinePhase }
+      if let casingLanguageMs { out["casing_language_ms"] = casingLanguageMs }
+      if let casingOracleFetchMs { out["casing_oracle_fetch_ms"] = casingOracleFetchMs }
+      if let casingRepairMs { out["casing_repair_ms"] = casingRepairMs }
+      if let casingOracleClosure { out["casing_oracle_closure"] = casingOracleClosure }
+      if let casingOracleInflightMs { out["casing_oracle_inflight_ms"] = casingOracleInflightMs }
+      if let casingOracleClosuresCompleted {
+        out["casing_oracle_closures_completed"] = casingOracleClosuresCompleted
+      }
+      if let casingOracleClosureMaxMs {
+        out["casing_oracle_closure_max_ms"] = casingOracleClosureMaxMs
       }
       return out
     }

--- a/Tests/EnviousWisprTests/Pipeline/CasingDeadlineEvidenceTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/CasingDeadlineEvidenceTests.swift
@@ -217,6 +217,46 @@ struct CasingDeadlineEvidenceTests {
       "latch behaviour is deliberately unchanged; only the EVIDENCE got honest")
   }
 
+  @Test("The stage that timed out reports HOW LONG it had been running")
+  func theSlowStageReportsItsOwnElapsedTime() {
+    // Whole-diff review r3. Every duration is written when its stage FINISHES,
+    // so the stage that never finished — the slow one, the whole reason this
+    // record exists — reported `-`. The first version logged
+    // `phase=language lang=-ms`, which is the instrument failing at its primary
+    // job for its most important field.
+
+    // Language stalls.
+    let c1 = Clock()
+    let g1 = LanguageRepairDeadlineGate(now: c1.read)
+    c1.advance(0.130)
+    let s1 = g1.timeOut()
+    #expect(s1.phase == .resolvingLanguage)
+    #expect((s1.languageMs ?? 0) >= 130, "the stalled stage must carry its elapsed time")
+
+    // The main-thread oracle fetch stalls: same phase as repair's own work, so
+    // the fetch is identified by its duration being the one still unwritten.
+    let c2 = Clock()
+    let g2 = LanguageRepairDeadlineGate(now: c2.read)
+    c2.advance(0.001)
+    #expect(g2.beginRepair(Self.resolution))
+    c2.advance(0.140)
+    let s2 = g2.timeOut()
+    #expect(s2.phase == .repairBeforeOracle)
+    #expect((s2.oracleFetchMs ?? 0) >= 140, "a stalled hop must report how long it hung")
+    #expect((s2.languageMs ?? 0) >= 1, "and the stage that DID finish keeps its real time")
+    #expect(s2.repairMs == nil, "repair never started, so it must not claim a duration")
+
+    // Repair's own work stalls, after the fetch completed.
+    let c3 = Clock()
+    let g3 = LanguageRepairDeadlineGate(now: c3.read)
+    #expect(g3.beginRepair(Self.resolution))
+    g3.mark(.oracleFetched)
+    c3.advance(0.150)
+    let s3 = g3.timeOut()
+    #expect(s3.phase == .repairBeforeOracle)
+    #expect((s3.repairMs ?? 0) >= 150, "once the fetch is recorded, the partial belongs to repair")
+  }
+
   // MARK: - Phase honesty
 
   @Test("A stall before any consultation names the deadline, not the oracle")

--- a/Tests/EnviousWisprTests/Pipeline/CasingDeadlineEvidenceTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/CasingDeadlineEvidenceTests.swift
@@ -1,0 +1,225 @@
+import Foundation
+import Testing
+import os
+
+@testable import EnviousWisprPipeline
+@testable import EnviousWisprPostProcessing
+
+// MARK: - CasingDeadlineEvidenceTests (#1946)
+//
+// The gate's DIAGNOSTIC record: which step the deadline caught, how long each
+// took, and which oracle consultation was in flight.
+//
+// Why this suite exists at all: `oracle_timed_out` used to be applied to any
+// miss of the 100 ms casing deadline, including misses where no oracle ran. Four
+// materially different causes produced byte-identical evidence, and three
+// successive causal theories were built on it and refuted. Everything here
+// asserts that two different stalls now leave two different records.
+//
+// Time is driven, never waited on: the gate takes an injectable monotonic clock
+// for the same reason `TerminalResolutionBudget` does (#1893) — a busy-wait
+// guarantees a floor and never a ceiling, so a duration assertion against wall
+// time can only be flaky (`test-timing.md`).
+@Suite("Casing deadline evidence (#1946)")
+struct CasingDeadlineEvidenceTests {
+
+  static let resolution = DictationLanguageResolver.Resolution(
+    language: "en", source: .dictation, confidenceBucket: .ge90)
+
+  /// A clock the test advances by hand.
+  private final class Clock: @unchecked Sendable {
+    private let value = OSAllocatedUnfairLock(initialState: 0.0)
+    var now: Double { value.withLock { $0 } }
+    func advance(_ seconds: Double) { value.withLock { $0 += seconds } }
+    var read: @Sendable () -> Double { { [value] in value.withLock { $0 } } }
+  }
+
+  // MARK: - The discrimination the whole change exists for
+
+  @Test("Two different post-authorisation stalls leave two different records")
+  func differentClosuresAreDistinguishable() {
+    // THE load-bearing case. Both stalls are inside the oracle, both must latch
+    // identically — the safety net does not change — and the ONLY difference
+    // must be which consultation is named. Before #1946 these two produced the
+    // same `oracle_timed_out` and nothing else, which is precisely why the
+    // spell-service-tail and executor-starvation theories could not be
+    // separated from the field data.
+    for label in ["dictionary", "name"] {
+      let clock = Clock()
+      let gate = LanguageRepairDeadlineGate(now: clock.read)
+      #expect(gate.beginRepair(Self.resolution))
+      #expect(gate.beginOracleUse(label) != nil)
+      clock.advance(0.105)
+      let snapshot = gate.timeOut()
+
+      #expect(snapshot.phase == .repairAfterOracle, "both are post-authorisation stalls")
+      #expect(snapshot.shouldDisableOracle, "the safety net is identical for both")
+      #expect(snapshot.oracleInFlight == label, "and the record names WHICH one stalled")
+      #expect(
+        (snapshot.oracleInFlightMs ?? 0) >= 105,
+        "with how long it had been stuck, which is what separates a real hang from a slow moment")
+    }
+  }
+
+  @Test("A healthy delivery records every phase and leaves the oracle enabled")
+  func healthyDeliveryRecordsAllPhases() {
+    // The two-way control. Without it, an implementation that reported a stuck
+    // closure on EVERY dictation would pass the case above while disabling the
+    // feature for everyone (`a-guard-nothing-arms-is-not-a-guard`).
+    let clock = Clock()
+    let gate = LanguageRepairDeadlineGate(now: clock.read)
+    clock.advance(0.001)
+    gate.mark(.languageResolved)
+    clock.advance(0.002)
+    #expect(gate.beginRepair(Self.resolution))
+    gate.mark(.oracleFetched)
+    let token = gate.beginOracleUse("dictionary")
+    #expect(token != nil)
+    clock.advance(0.0005)
+    gate.completeOracleUse(token!)
+    clock.advance(0.001)
+    gate.mark(.repairReturned)
+    let snapshot = gate.completeRepair()
+
+    #expect(snapshot.phase == .completed)
+    #expect(snapshot.shouldDisableOracle == false, "a finished consultation is not a stuck one")
+    #expect(snapshot.oracleInFlight == nil, "nothing is in flight once it completed")
+    #expect(snapshot.oracleClosuresCompleted == 1)
+    #expect((snapshot.languageMs ?? 0) >= 1, "each phase carries its own duration")
+    #expect((snapshot.oracleFetchMs ?? 0) >= 2)
+    #expect((snapshot.repairMs ?? 0) >= 1)
+  }
+
+  // MARK: - Token correctness
+  //
+  // A label alone cannot correlate a completion. These four cases are why the
+  // API mints a token per consultation rather than naming one.
+
+  @Test("Sequential consultations each end cleanly")
+  func sequentialConsultations() {
+    let clock = Clock()
+    let gate = LanguageRepairDeadlineGate(now: clock.read)
+    #expect(gate.beginRepair(Self.resolution))
+    let first = gate.beginOracleUse("name")!
+    clock.advance(0.002)
+    gate.completeOracleUse(first)
+    let second = gate.beginOracleUse("dictionary")!
+    clock.advance(0.001)
+    gate.completeOracleUse(second)
+
+    let snapshot = gate.timeOut()
+    #expect(snapshot.oracleInFlight == nil, "both finished, so nothing is stuck")
+    #expect(snapshot.oracleClosuresCompleted == 2)
+    #expect((snapshot.oracleClosureMaxMs ?? 0) >= 2, "the slowest completed one is kept")
+  }
+
+  @Test("A nested consultation restores its enclosing one on completion")
+  func nestedConsultationRestoresEnclosing() {
+    let clock = Clock()
+    let gate = LanguageRepairDeadlineGate(now: clock.read)
+    #expect(gate.beginRepair(Self.resolution))
+    let outer = gate.beginOracleUse("dictionary")!
+    let inner = gate.beginOracleUse("name")!
+    gate.completeOracleUse(inner)
+
+    let snapshot = gate.timeOut()
+    #expect(
+      snapshot.oracleInFlight == "dictionary",
+      "the OUTER consultation is still running and must be what the record names")
+    #expect(snapshot.oracleClosuresCompleted == 1)
+    _ = outer
+  }
+
+  @Test("A completion arriving after the timeout claimed is inert")
+  func lateCompletionCannotRewriteReturnedEvidence() {
+    // `withOrderedDeadline` cannot preempt a blocked thread
+    // (`TaskTimeout.swift:123-132`), so the operation keeps running after the
+    // timeout returned. If a late completion could still mutate the record, the
+    // evidence handed to the caller and the evidence in the gate would disagree
+    // — a diagnostic that looks self-consistent and is false.
+    let clock = Clock()
+    let gate = LanguageRepairDeadlineGate(now: clock.read)
+    #expect(gate.beginRepair(Self.resolution))
+    let token = gate.beginOracleUse("dictionary")!
+    clock.advance(0.105)
+    let atTimeout = gate.timeOut()
+    #expect(atTimeout.oracleInFlight == "dictionary")
+
+    clock.advance(1.0)
+    gate.completeOracleUse(token)
+    let afterLateCompletion = gate.timeOut()
+
+    #expect(
+      afterLateCompletion.oracleInFlight == "dictionary",
+      "the frozen record must still name the stuck consultation")
+    #expect(
+      afterLateCompletion.oracleClosuresCompleted == atTimeout.oracleClosuresCompleted,
+      "and a post-freeze completion must not be counted")
+    #expect(
+      (afterLateCompletion.oracleInFlightMs ?? 0) == (atTimeout.oracleInFlightMs ?? -1),
+      "re-reading must not re-measure against a later clock")
+  }
+
+  @Test("A duplicate completion cannot clear a NEWER consultation with the same label")
+  func duplicateCompletionCannotClearANewerSameLabelUse() {
+    // The case that makes tokens necessary rather than merely tidy, and the one
+    // a naive duplicate test misses: a duplicate that does not overlap a live
+    // same-labelled consultation passes even under the label-collision bug it
+    // exists to catch.
+    let clock = Clock()
+    let gate = LanguageRepairDeadlineGate(now: clock.read)
+    #expect(gate.beginRepair(Self.resolution))
+    let stale = gate.beginOracleUse("dictionary")!
+    gate.completeOracleUse(stale)
+
+    let live = gate.beginOracleUse("dictionary")!
+    clock.advance(0.105)
+    gate.completeOracleUse(stale)  // duplicate, for the ALREADY-finished token
+
+    let snapshot = gate.timeOut()
+    #expect(
+      snapshot.oracleInFlight == "dictionary",
+      "the live consultation must survive a stale duplicate carrying its label")
+    #expect(
+      (snapshot.oracleInFlightMs ?? 0) >= 105,
+      "and keep its real elapsed time, not be silently reset")
+    #expect(snapshot.oracleClosuresCompleted == 1, "the duplicate must not be counted twice")
+    _ = live
+  }
+
+  // MARK: - Phase honesty
+
+  @Test("A stall before any consultation names the deadline, not the oracle")
+  func preOracleStallNamesTheDeadline() {
+    // Covers the main-thread oracle fetch and repair's own work: both sit in
+    // `.repair(oracleTouched: false)`, neither has consulted an oracle, and
+    // neither may latch. This is the arm that #1946's own first hypothesis got
+    // wrong — a hop stall CANNOT disable the runtime, because nothing was
+    // consulted.
+    let clock = Clock()
+    let gate = LanguageRepairDeadlineGate(now: clock.read)
+    #expect(gate.beginRepair(Self.resolution))
+    gate.mark(.oracleFetched)
+    clock.advance(0.105)
+    let snapshot = gate.timeOut()
+
+    #expect(snapshot.phase == .repairBeforeOracle)
+    #expect(
+      snapshot.shouldDisableOracle == false,
+      "an oracle that was never consulted must not be punished for a stall before it")
+    #expect(snapshot.oracleInFlight == nil)
+    #expect(snapshot.resolution?.language == "en", "the language answer still survives")
+  }
+
+  @Test("A stall during language resolution names the language stage")
+  func languageStallNamesTheLanguageStage() {
+    let clock = Clock()
+    let gate = LanguageRepairDeadlineGate(now: clock.read)
+    clock.advance(0.105)
+    let snapshot = gate.timeOut()
+
+    #expect(snapshot.phase == .resolvingLanguage)
+    #expect(snapshot.shouldDisableOracle == false)
+    #expect(snapshot.resolution == nil, "nothing was resolved, so nothing is reported")
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/CasingDeadlineEvidenceTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/CasingDeadlineEvidenceTests.swift
@@ -187,6 +187,35 @@ struct CasingDeadlineEvidenceTests {
     _ = live
   }
 
+  @Test("A consultation that RETURNED is not reported as a stuck one")
+  func returnedConsultationIsNotReportedAsStuck() {
+    // Whole-diff review (P2). The first version reported this as `repair_oracle`
+    // and therefore as `oracle_timed_out`, asserting a stall that demonstrably
+    // did not happen: the consultation returned, and repair then crossed the
+    // deadline in its own work.
+    let clock = Clock()
+    let gate = LanguageRepairDeadlineGate(now: clock.read)
+    #expect(gate.beginRepair(Self.resolution))
+    let token = gate.beginOracleUse("dictionary")!
+    clock.advance(0.001)
+    gate.completeOracleUse(token)
+    clock.advance(0.105)  // repair's OWN work is what crosses the deadline
+    let snapshot = gate.timeOut()
+
+    #expect(
+      snapshot.phase == .repairAfterOracleReturned,
+      "the evidence must not claim an oracle was stuck when none was in flight")
+    #expect(snapshot.oracleInFlight == nil)
+    #expect(snapshot.oracleClosuresCompleted == 1, "it did run, and it finished")
+    // The latch is UNCHANGED by design: narrowing it is a change to the safety
+    // net, which is out of scope (founder, 2026-08-10). Frozen here so that a
+    // later decision to narrow it is a deliberate, visible edit rather than a
+    // silent drift.
+    #expect(
+      snapshot.shouldDisableOracle,
+      "latch behaviour is deliberately unchanged; only the EVIDENCE got honest")
+  }
+
   // MARK: - Phase honesty
 
   @Test("A stall before any consultation names the deadline, not the oracle")

--- a/Tests/EnviousWisprTests/Pipeline/CasingDeadlineEvidenceTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/CasingDeadlineEvidenceTests.swift
@@ -69,16 +69,17 @@ struct CasingDeadlineEvidenceTests {
     let clock = Clock()
     let gate = LanguageRepairDeadlineGate(now: clock.read)
     clock.advance(0.001)
-    gate.mark(.languageResolved)
-    clock.advance(0.002)
+    // The language and repair durations are recorded BY the transitions, in the
+    // same lock take — see the `Mark` doc comment for why they cannot be
+    // separate calls.
     #expect(gate.beginRepair(Self.resolution))
+    clock.advance(0.002)
     gate.mark(.oracleFetched)
     let token = gate.beginOracleUse("dictionary")
     #expect(token != nil)
     clock.advance(0.0005)
     gate.completeOracleUse(token!)
     clock.advance(0.001)
-    gate.mark(.repairReturned)
     let snapshot = gate.completeRepair()
 
     #expect(snapshot.phase == .completed)

--- a/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
@@ -1847,7 +1847,9 @@ import os
     // keep the resolution, disable.
     let running = LanguageRepairDeadlineGate()
     #expect(running.beginRepair(Self.gateResolution))
-    #expect(running.authorizeOracleUse(), "an authorised repair may consult the oracle")
+    #expect(
+      running.beginOracleUse("dictionary") != nil,
+      "an authorised repair may consult the oracle")
     let fromOracle = running.timeOut()
     #expect(fromOracle.resolution?.language == "en")
     #expect(fromOracle.resolution?.confidenceBucket == .ge90)
@@ -1878,7 +1880,7 @@ import os
     // Timeout after repair already returned: keep the resolution, do NOT disable.
     let completed = LanguageRepairDeadlineGate()
     #expect(completed.beginRepair(Self.gateResolution))
-    #expect(completed.authorizeOracleUse())
+    #expect(completed.beginOracleUse("dictionary") != nil)
     completed.completeRepair()
     let fromCompleted = completed.timeOut()
     #expect(fromCompleted.resolution?.language == "en", "a finished run keeps its answer")
@@ -1886,10 +1888,27 @@ import os
       fromCompleted.shouldDisableOracle == false,
       "a healthy oracle that already finished must NOT be disabled")
 
-    // A second timeout is inert.
+    // A second timeout is inert — and #1946 CHANGED what "inert" returns.
+    //
+    // The load-bearing invariant is unchanged and asserted first: a repeat must
+    // never punish the oracle again. That is what "inert" was protecting.
+    //
+    // What changed is the second line. Before #1946 a repeat returned a nil
+    // resolution, because the phase had become `.timedOut` and that case mapped
+    // to nil. That was the old implementation's incidental behaviour, not a
+    // required property — and for a DIAGNOSTIC it is the wrong one: the gate now
+    // stores the frozen snapshot and hands back the SAME evidence, so two
+    // readers can never be told two different things about one instant. A
+    // recomputing repeat would also re-measure `oracleInFlightMs` against a
+    // later clock. Asserting the new value rather than deleting the case,
+    // because idempotent evidence is now a property worth freezing.
     let repeated = completed.timeOut()
-    #expect(repeated.resolution == nil)
-    #expect(repeated.shouldDisableOracle == false)
+    #expect(
+      repeated.shouldDisableOracle == false,
+      "a repeated timeout must never disable the oracle a second time")
+    #expect(
+      repeated.resolution?.language == "en",
+      "and it must return the SAME frozen evidence, not a blank one (#1946)")
 
     // Repair can never start once the timeout owns the phase.
     let lateStart = LanguageRepairDeadlineGate()
@@ -1913,7 +1932,7 @@ import os
       lateTimeout.shouldDisableOracle == false,
       "it had not been consulted at the moment the deadline fired")
     #expect(
-      lateOracle.authorizeOracleUse() == false,
+      lateOracle.beginOracleUse("dictionary") == nil,
       "and it must be refused entry afterwards, not merely recorded")
 
     // `completeRepair` from a phase that never began is inert, not a promotion.

--- a/Tests/EnviousWisprTests/Pipeline/PasteExecutionMetricsTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PasteExecutionMetricsTests.swift
@@ -114,23 +114,24 @@ struct PasteExecutionMetricsTests {
 
   @Test("Every rule name is a closed reason, never the word it applied to")
   func ruleNamesCarryNoUserText() {
-    // The whole set, so a rule added later without a name cannot slip through.
-    let every: [CursorInsertionRepair.AppliedRule] = [
-      .refusedInsideWord, .refusedNoLeftAnchor, .leadingSpace, .lowercasedFirst,
-      .droppedDuplicateWord, .droppedTerminalPeriod, .trailingSpace,
-      .caseSkipped(.alreadyLower), .caseSkipped(.protectedWord),
-      .caseSkipped(.mixedCaseOrAcronym), .caseSkipped(.containsDigit),
-      .caseSkipped(.pronounI), .caseSkipped(.alwaysCapitalized),
-      .caseSkipped(.notOrdinaryWord), .caseSkipped(.dictionaryUnavailable),
-      .caseSkipped(.recognizedName), .caseSkipped(.wordClassUnavailable),
-      .caseSkipped(.learnedWord), .caseSkipped(.oracleWarming),
-      .caseSkipped(.oracleTimedOut),
-      .caseSkipped(.languageNotSupported),
-      .caseKept(.lineStart), .caseKept(.nothingLeft), .caseKept(.afterOpener),
-      .caseKept(.afterTerminator), .caseKept(.other),
-      .trailingSpaceSkipped(.rightIsSpace), .trailingSpaceSkipped(.rightIsPunctuation),
-      .trailingSpaceSkipped(.unsegmentedScript),
-    ]
+    // #1946: the skip reasons are now ENUMERATED, not restated. The previous
+    // hand-written list carried the comment "a rule added later without a name
+    // cannot slip through" — which it could not enforce, because a hand-written
+    // array cannot notice a case nobody added to it. #1946 added
+    // `repairDeadlineMissed`, this test stayed green, and the gap only surfaced
+    // because the author went looking. `allCases` makes the claim true.
+    let every: [CursorInsertionRepair.AppliedRule] =
+      [
+        .refusedInsideWord, .refusedNoLeftAnchor, .leadingSpace, .lowercasedFirst,
+        .droppedDuplicateWord, .droppedTerminalPeriod, .trailingSpace,
+        .caseKept(.lineStart), .caseKept(.nothingLeft), .caseKept(.afterOpener),
+        .caseKept(.afterTerminator), .caseKept(.other),
+        .trailingSpaceSkipped(.rightIsSpace), .trailingSpaceSkipped(.rightIsPunctuation),
+        .trailingSpaceSkipped(.unsegmentedScript),
+      ] + CursorInsertionRepair.CaseSkipReason.allCases.map { .caseSkipped($0) }
+    #expect(
+      CursorInsertionRepair.CaseSkipReason.allCases.count >= 17,
+      "a shrinking reason set means a case was deleted; check the telemetry contract first")
     let names = Set(every.map(\.telemetryName))
     #expect(names.count == every.count, "every rule needs a distinct name")
     for name in names {

--- a/Tests/EnviousWisprTests/PostProcessing/SeamCasingOracleTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SeamCasingOracleTests.swift
@@ -570,7 +570,7 @@ struct SeamCasingOracleTests {
         return false
       })
 
-    let wrapped = underlying.authorized(by: { true })
+    let wrapped = underlying.authorized(by: { _ in 1 }, didFinish: { _ in })
     let skip = wrapped.mayLower(word: "The", left: "I went to ", payload: "The museum.")
 
     #expect(skip == nil, "an authorized oracle decides exactly as the one it wraps")
@@ -618,7 +618,7 @@ struct SeamCasingOracleTests {
         return false
       })
 
-    let wrapped = underlying.authorized(by: { false })
+    let wrapped = underlying.authorized(by: { _ in nil }, didFinish: { _ in })
     let skip = wrapped.mayLower(word: "The", left: "I went to ", payload: "The museum.")
     // The veto is asked separately by the repair, so a refusal that covered only
     // `mayLower` would still let a post-deadline call reach the tagger.
@@ -646,7 +646,7 @@ struct SeamCasingOracleTests {
       isLearnedWord: { _ in false },
       isRecognizedName: { _, _ in false },
       isNoun: { _ in false })
-    let refused = permissive.authorized(by: { false })
+    let refused = permissive.authorized(by: { _ in nil }, didFinish: { _ in })
 
     #expect(
       refused.isRecognizedName("I went to ", "The museum."),


### PR DESCRIPTION
## What this does

When the 100 ms casing deadline fires, the app records **which step was in flight and how long each took**, and the reason stops naming the oracle when no oracle ran.

It fixes no timeout. That is the point: `oracle_timed_out` was applied to ANY miss of that deadline, so language identification, the main-thread oracle fetch, repair's own work, and a genuinely stalled spell service all produced byte-identical evidence — and only the last installs the permanent process-wide latch. Three successive causal theories were built on that label and all three were refuted.

Before → after, from a real run:

```
casing=[phase=language lang=105.5ms hop=-ms repair=-ms closures=0]
casing=[phase=repair_oracle lang=0.0ms hop=0.0ms repair=100.4ms
        stuck=dictionary stuck_for=100.3ms closures=2 slowest=0.0ms]
```

The second line is a complete diagnosis in one read: everything fast except the dictionary lookup, stuck 100.3 ms, while two earlier lookups finished at 0.0 ms. That separates a hanging spell service from a starved executor — the pair nothing could distinguish before.

## The safety net is unchanged

Founder constraint, 2026-08-10. Same deadline value, same permanent latch, same `shouldDisableOracle` input. Whole-diff review proposed narrowing the latch to require an active token; **declined and frozen by a test**, because narrowing the guard is out of scope for a diagnostics change. A returned-consultation timeout still latches exactly as it always has — but the evidence now says honestly that nothing was in flight, so whether that latch is right is finally askable from data (`repair_post_oracle`).

## Design

`LanguageRepairDeadlineGate` becomes the single locked owner of the record and freezes it atomically. It already owned the phase and the latch decision, so this widens an existing authority rather than adding one. Two rejected designs are worth recording:

- **Durations in a second lock owned by the wiring.** Rejected: both structures answer "what was true when the timeout claimed?", and two locks cannot answer that atomically. The operation is never preempted, so a late write could contradict evidence already returned.
- **Label-correlated oracle completion.** Rejected: two consultations can carry the same label, so a stale or duplicate completion would clear a newer live one, blanking the evidence exactly when it matters. Tokens are minted per consultation instead.

The oracle-snapshot seam becomes `async @Sendable`; the production default still performs `await MainActor.run`, so runtime behaviour is unchanged. Blocking a synchronous `@MainActor` seam also blocks the deadline's own timer, which made the hop-stall case untestable by construction.

## Measurements behind it

All on real APIs, artifacts in `docs/feature-requests/issue-1946-artifacts/`:

| Quantity | Result |
|---|---|
| Whole casing decision | 0.548 ms mean, n=200 |
| Cooperative-pool scheduling @ load 6.26 | **0.007 ms** — refutes the scheduling-starvation cause this issue previously asserted |
| `await MainActor.run` hop | costs exactly as long as the main thread is occupied, 1:1 (8.016 ms / 60.030 ms) |
| Language identification, 40 → 20,000 chars | 0.78 → 1.39 ms; does not scale with dictation length |

## Telemetry meaning change

`oracle_timed_out` narrows to genuine oracle consultation; everything earlier is `repair_deadline_missed`. **Do not pool `repair_rules` across this release boundary.** Eight typed optional fields are added to `paste.completed`, present only on a deadline miss. `analytics-operations.md` is updated with the version floor.

Four repo consumers were checked and are unaffected: `daily-report/version-scorecard.js`, `weekly-digest`, `sentry-triage`, `telemetry-join.py`. Saved PostHog insights and alert rules are external and open-world — checked, not provable absent.

## Testing

Full suite **5276 passed**. New `CasingDeadlineEvidenceTests` (10) drive an injected monotonic clock, so no assertion waits on wall time.

- **Mutation control run**: removing the label from `beginOracleUse` fails 6 of the cases, including the load-bearing one. Restored via `cp` and re-verified green. A new green test is not evidence until it fails for the right reason.
- **Two-way control**: a healthy delivery records every phase and leaves the oracle enabled.
- Also fixed a guard that could not guard: `PasteExecutionMetricsTests` claimed "a rule added later without a name cannot slip through" from a hand-written array — the new case slipped through silently. `CaseSkipReason` is now `CaseIterable` and the test enumerates rather than restates.

## Live UAT — honest result

Dev build, Debug Mode on, real dictations through the harness.

**Verified:** no regression. Real mid-sentence dictations complete in ~0.79 s with `rules=lowercased_first` — casing works — and healthy runs emit no `casing=` line, because it is timeout-only by design.

**Not verified:** I did not reproduce a live timeout. Zero occurrences across 8 attempts spanning load 3.7 to 9.3. The issue's original two-way control saw 6 of 6 fail at load ~4.3, so conditions differ; polish now runs EG-1 locally at ~0.13 s, which may be part of it. Above load ~9 the pipeline stalls in polish and never reaches the casing stage at all, so heavier load is not a stronger test — it is a different one.

The trace's behaviour on a real timeout is therefore proven by tests, not by a live capture. The instrumented build is left running on this machine, so the next natural occurrence is captured rather than lost.

Three review rounds found real defects, all fixed and each frozen by a test: evidence leaking across recordings via a reset block I failed to join, a returned consultation reported as a stuck one, a race where the diagnostic itself could have disabled a healthy oracle near the boundary, and the slow stage reporting no duration at all.

Part of #1946
