### PR TITLE
fix(update): strip quarantine so the relocation rescue actually works (#2006)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/ApplicationRelocationCoordinator+Live.swift
+++ b/Sources/EnviousWisprAppKit/App/ApplicationRelocationCoordinator+Live.swift
@@ -548,7 +548,8 @@ public struct NSWorkspaceRelocationRelauncher: RelocationRelaunching {
   public init() {}
 
   public func relaunch(
-    _ installedURL: URL, attemptID: String, reason: String, destinationScope: String
+    _ installedURL: URL, attemptID: String, reason: String, destinationScope: String,
+    expectedBundleVersion: String
   ) async -> Bool {
     let config = NSWorkspace.OpenConfiguration()
     config.createsNewApplicationInstance = true
@@ -561,6 +562,10 @@ public struct NSWorkspaceRelocationRelauncher: RelocationRelaunching {
       "EW_RELOCATION_ATTEMPT_ID": attemptID,
       "EW_RELOCATION_REASON": reason,
       "EW_RELOCATION_DESTINATION_SCOPE": destinationScope,
+      // The child validates these before claiming completion, so a different
+      // registered copy cannot report success for our attempt (review P2).
+      "EW_RELOCATION_EXPECTED_PATH": installedURL.standardizedFileURL.path,
+      "EW_RELOCATION_EXPECTED_VERSION": expectedBundleVersion,
     ]
     return await withCheckedContinuation { continuation in
       NSWorkspace.shared.openApplication(at: installedURL, configuration: config) { app, error in

--- a/Sources/EnviousWisprAppKit/App/ApplicationRelocationCoordinator+Live.swift
+++ b/Sources/EnviousWisprAppKit/App/ApplicationRelocationCoordinator+Live.swift
@@ -250,7 +250,8 @@ public final class CenteredRelocationPresenter: RelocationPresenting {
     // works: this arm also covers a full disk and a non-writable Applications
     // folder, which dragging cannot overcome either.
     case .destinationCreation, .stagingCopy, .stagedBundleInvalid, .signatureInvalid,
-      .stripFailedBeforePlacement, .stripFailedAtDestination, .ackUnhealthyTranslocated,
+      .stripFailedBeforePlacement, .stripFailedAtDestination, .stripFailedAfterPlacement,
+      .ackUnhealthyTranslocated,
       .ackUnhealthyOther, .ackPathMismatch, .ackVersionMismatch, .ackMalformed, .ackTimeout,
       .relaunchRejected, .unknown:
       return (
@@ -439,7 +440,10 @@ public struct FileManagerApplicationMover: ApplicationMoving {
     // that matters. Idempotent and cheap: the probe-first path returns
     // immediately for every already-clean item.
     guard Self.stripQuarantine(at: destination) else {
-      return .failure(.stripFailedAtDestination)
+      // OUR copy, so the route is `installed` — a distinct case from the
+      // existing-destination one, or the telemetry reports a fresh install as
+      // an existing copy (cloud review, second round).
+      return .failure(.stripFailedAfterPlacement)
     }
     // `isStructurallyValid` above asserted the staged bundle's CFBundleVersion
     // equals `currentVersion`, so this IS the version the mover verified.

--- a/Sources/EnviousWisprAppKit/App/ApplicationRelocationCoordinator+Live.swift
+++ b/Sources/EnviousWisprAppKit/App/ApplicationRelocationCoordinator+Live.swift
@@ -167,18 +167,47 @@ public final class CenteredRelocationPresenter: RelocationPresenting {
     progressPanel = nil
   }
 
-  public func showFailure(_ failure: RelocationFailure) {
+  public func showFailure(_ presentation: RelocationFailurePresentation) {
     dismissProgress()
-    let (title, message) = Self.failureCopy(failure)
+    let (title, message) = Self.failureCopy(presentation)
+    // Show in Finder exists ONLY on Message B, and its target comes from the
+    // presentation rather than being recomputed here — the coordinator owns the
+    // destination (#2006 §3b/§3c). Message A structurally cannot carry one.
+    var revealURL: URL?
+    if case .installedNotConfirmed(_, let destination) = presentation {
+      revealURL = destination
+    }
     let card = RelocationCard(title: title, message: message) {
-      Button {
-        NSApp.stopModal()
-      } label: {
-        Text("OK")
-          .font(.system(size: 17, weight: .semibold))
-          .frame(maxWidth: .infinity).padding(.vertical, 4)
+      VStack(spacing: 10) {
+        if let revealURL {
+          Button {
+            NSWorkspace.shared.activateFileViewerSelecting([revealURL])
+            NSApp.stopModal()
+          } label: {
+            Text("Show in Finder")
+              .font(.system(size: 17, weight: .semibold))
+              .frame(maxWidth: .infinity).padding(.vertical, 4)
+          }
+          .buttonStyle(.borderedProminent).controlSize(.large).tint(Self.accent)
+          Button {
+            NSApp.stopModal()
+          } label: {
+            Text("OK")
+              .font(.system(size: 17, weight: .medium))
+              .frame(maxWidth: .infinity).padding(.vertical, 4)
+          }
+          .buttonStyle(.bordered).controlSize(.large)
+        } else {
+          Button {
+            NSApp.stopModal()
+          } label: {
+            Text("OK")
+              .font(.system(size: 17, weight: .semibold))
+              .frame(maxWidth: .infinity).padding(.vertical, 4)
+          }
+          .buttonStyle(.borderedProminent).controlSize(.large).tint(Self.accent)
+        }
       }
-      .buttonStyle(.borderedProminent).controlSize(.large).tint(Self.accent)
     }
     let panel = makeCardPanel(card)
     NSApp.activate(ignoringOtherApps: true)
@@ -187,8 +216,21 @@ public final class CenteredRelocationPresenter: RelocationPresenting {
     panel.orderOut(nil)
   }
 
-  private static func failureCopy(_ failure: RelocationFailure) -> (String, String) {
-    switch failure {
+  /// TWO message families, not one per failure class (founder 2026-08-10,
+  /// #2006 §3.3). Three pre-placement sentences survive as overrides inside
+  /// Message A because each names a precondition the user must clear before any
+  /// manual drag can succeed — collapsing those would REMOVE information.
+  /// Package-internal (not `private`) so the mapping is exhaustively testable.
+  static func failureCopy(_ presentation: RelocationFailurePresentation) -> (String, String) {
+    // Message B: a verified copy IS at the destination; only handoff failed.
+    if case .installedNotConfirmed = presentation {
+      return (
+        "EnviousWispr is now in your Applications folder.",
+        "You can quit this copy and use the one in Applications."
+      )
+    }
+    // Message A, with the three surviving precondition overrides.
+    switch presentation.failure {
     case .diskFull:
       return (
         "Not enough space to move EnviousWispr.",
@@ -204,10 +246,16 @@ public final class CenteredRelocationPresenter: RelocationPresenting {
         "A different app is already in that Applications spot.",
         "Nothing was changed. EnviousWispr is still working. You can move it yourself in Finder anytime."
       )
-    default:
+    // Generic Message A. Deliberately does NOT promise a manual drag always
+    // works: this arm also covers a full disk and a non-writable Applications
+    // folder, which dragging cannot overcome either.
+    case .destinationCreation, .stagingCopy, .stagedBundleInvalid, .signatureInvalid,
+      .stripFailedBeforePlacement, .stripFailedAtDestination, .ackUnhealthyTranslocated,
+      .ackUnhealthyOther, .ackPathMismatch, .ackVersionMismatch, .ackMalformed, .ackTimeout,
+      .relaunchRejected, .unknown:
       return (
-        "We couldn't move EnviousWispr.",
-        "Nothing was changed. EnviousWispr is still working. Reopen it anytime to try again."
+        "We couldn't move EnviousWispr automatically.",
+        "Drag EnviousWispr to your Applications folder in Finder. EnviousWispr keeps working in the meantime."
       )
     }
   }
@@ -297,7 +345,8 @@ public struct FileManagerApplicationMover: ApplicationMoving {
       let isRunning = Self.isRunning(bundleIdentifier: expectedBundleIdentifier, at: destination)
       // Signature is only load-bearing for the open-existing verdict; compute it
       // once here so the decision function stays pure.
-      let signatureValid = Self.hasValidSignature(destination)
+      let signatureValid = Self.hasValidSignature(
+        destination, expectedBundleIdentifier: expectedBundleIdentifier)
       switch Self.decideExistingDestination(
         existingBundleIdentifier: existing?.bundleIdentifier,
         expectedBundleIdentifier: expectedBundleIdentifier,
@@ -306,12 +355,19 @@ public struct FileManagerApplicationMover: ApplicationMoving {
       {
       case .openExisting:
         // Same-or-newer, verified, not running: open it fresh, do not downgrade
-        // or overwrite.
-        return .success(.existingUsable(destination))
+        // or overwrite. Strip BEFORE launching it: a copy left behind by a
+        // previous failed attempt is still quarantined, which is precisely the
+        // repeat path person A was stuck in — without this, attempt N+1 fails
+        // identically to attempt N (#2006). Verified above, so stripping is a
+        // trust action taken only on a bundle proven ours.
+        guard Self.stripQuarantine(at: destination) else {
+          return .failure(.stripFailedAtDestination)
+        }
+        return .success(.existingUsable(destination, bundleVersion: existingVersion))
       case .activateRunning:
         // Same-or-newer, verified, already running: activate it, never spawn a
         // duplicate (cloud Codex review #1490).
-        return .success(.existingRunning(destination))
+        return .success(.existingRunning(destination, bundleVersion: existingVersion))
       case .refuseRunningOlder:
         // Older + running: never downgrade to it, and a running bundle cannot be
         // safely overwritten. Keep the current app alive (Codex r2 P1).
@@ -346,7 +402,18 @@ public struct FileManagerApplicationMover: ApplicationMoving {
     else { return .failure(.stagedBundleInvalid) }
 
     // A4: code-signature validity + our signing identity, before overwrite.
-    guard Self.hasValidSignature(staging) else { return .failure(.signatureInvalid) }
+    guard Self.hasValidSignature(staging, expectedBundleIdentifier: expectedBundleIdentifier)
+    else { return .failure(.signatureInvalid) }
+
+    // Strip quarantine while the bundle is still at its UUID-named staging
+    // path, so the copy only ever appears under the real destination name
+    // already clean. Order is load-bearing — verify, THEN strip, THEN place:
+    // stripping is a trust action, and doing it before validation could leave
+    // an untrusted staged bundle dequarantined if cleanup were interrupted.
+    // Removing this one xattr does not alter code-signed content (#2006).
+    guard Self.stripQuarantine(at: staging) else {
+      return .failure(.stripFailedBeforePlacement)
+    }
 
     // Place it: atomic replace when a destination exists, else move in.
     do {
@@ -358,7 +425,9 @@ public struct FileManagerApplicationMover: ApplicationMoving {
     } catch {
       return .failure(.unknown)
     }
-    return .success(.installed(destination))
+    // `isStructurallyValid` above asserted the staged bundle's CFBundleVersion
+    // equals `currentVersion`, so this IS the version the mover verified.
+    return .success(.installed(destination, bundleVersion: currentVersion))
   }
 
   static func isRunning(bundleIdentifier: String, at url: URL) -> Bool {
@@ -378,19 +447,95 @@ public struct FileManagerApplicationMover: ApplicationMoving {
     return true
   }
 
-  static func hasValidSignature(_ url: URL) -> Bool {
+  static func hasValidSignature(_ url: URL, expectedBundleIdentifier: String) -> Bool {
+    // The identifier is interpolated into a requirement string, so a value
+    // carrying a quote or backslash could change the requirement's meaning.
+    // Ours cannot, but a requirement built from unvalidated input is a defect
+    // shape regardless of reachability; refuse before building it rather than
+    // relying on SecRequirementCreateWithString to fail closed (#2006).
+    guard !expectedBundleIdentifier.isEmpty,
+      !expectedBundleIdentifier.contains("\""),
+      !expectedBundleIdentifier.contains("\\")
+    else { return false }
     var staticCode: SecStaticCode?
     guard SecStaticCodeCreateWithPath(url as CFURL, [], &staticCode) == errSecSuccess,
       let code = staticCode
     else { return false }
-    // Validity anchored to Apple's chain AND our Developer ID Team ID.
+    // Validity anchored to Apple's chain, our Developer ID Team ID, AND this
+    // exact product. `isStructurallyValid` already asserts the identifier from
+    // the Info.plist a statement earlier; binding it into the requirement makes
+    // identity part of the CRYPTOGRAPHIC assertion instead, so the two checks
+    // cannot pass against different states of the bundle (#2006).
     let requirementText =
-      "anchor apple generic and certificate leaf[subject.OU] = \"\(teamID)\"" as CFString
+      """
+      anchor apple generic \
+      and identifier "\(expectedBundleIdentifier)" \
+      and certificate leaf[subject.OU] = "\(teamID)"
+      """ as CFString
     var requirement: SecRequirement?
     guard SecRequirementCreateWithString(requirementText, [], &requirement) == errSecSuccess,
       let req = requirement
     else { return false }
     return SecStaticCodeCheckValidity(code, [], req) == errSecSuccess
+  }
+
+  // MARK: - Quarantine
+
+  /// Removes `com.apple.quarantine` from `root` and every descendant.
+  ///
+  /// THE fix for #2006. A translocated bundle carries the attribute on its
+  /// randomized mount (measured: `00c3;00000000;Safari;`), `FileManager` copies
+  /// preserve it, and macOS then translocates the placed copy AGAIN under a new
+  /// UUID — so the move "succeeds" and the relaunched copy is still trapped.
+  /// Mirrors Sparkle's `SUFileManager.releaseItemFromQuarantineAtRootURL`
+  /// (`SUFileManager.m:22,86-164`) in shape, with one deliberate difference:
+  /// Sparkle treats aggregate failure as advisory because it is polishing an
+  /// already-installed app, whereas for us stripping IS the transaction, so any
+  /// failure is fatal to the relocation.
+  ///
+  /// Removes ONLY this attribute — never a blanket `xattr -c` — and never
+  /// follows symlinks, so a link inside the bundle cannot be used to clear the
+  /// attribute on a file outside it.
+  static func stripQuarantine(at root: URL) -> Bool {
+    let attr = "com.apple.quarantine"
+
+    func remove(_ url: URL) -> Bool {
+      let ok = url.withUnsafeFileSystemRepresentation { path -> Bool in
+        guard let path else { return false }
+        // XATTR_NOFOLLOW: act on the link itself, never its target.
+        if removexattr(path, attr, XATTR_NOFOLLOW) == 0 { return true }
+        // Nothing to remove is success; anything else is a real failure.
+        return errno == ENOATTR
+      }
+      return ok
+    }
+
+    guard remove(root) else { return false }
+
+    // A subtree we could not read is NOT a clean bundle. Record the first
+    // traversal error and stop; returning success after silently skipping an
+    // inaccessible directory would report a stripped bundle that still carries
+    // the attribute, which is the exact false-negative this change exists to
+    // remove.
+    var traversalFailed = false
+    guard
+      let walker = FileManager.default.enumerator(
+        at: root,
+        includingPropertiesForKeys: nil,
+        // No options: the target IS an .app package, so package descendants
+        // must be visited, and hidden files inside a bundle carry the
+        // attribute too.
+        options: [],
+        errorHandler: { _, _ in
+          traversalFailed = true
+          return false  // stop enumerating
+        })
+    else { return false }
+
+    for case let item as URL in walker {
+      guard remove(item) else { return false }
+    }
+    return !traversalFailed
   }
 }
 
@@ -402,13 +547,20 @@ public struct FileManagerApplicationMover: ApplicationMoving {
 public struct NSWorkspaceRelocationRelauncher: RelocationRelaunching {
   public init() {}
 
-  public func relaunch(_ installedURL: URL, attemptID: String) async -> Bool {
+  public func relaunch(
+    _ installedURL: URL, attemptID: String, reason: String, destinationScope: String
+  ) async -> Bool {
     let config = NSWorkspace.OpenConfiguration()
     config.createsNewApplicationInstance = true
     config.activates = true
+    // Reason + scope let the CHILD emit its own `completed` event. A child that
+    // receives neither (old parent) still writes its health ack and simply
+    // emits nothing (#2006 §9).
     config.environment = [
       "EW_RELOCATION_RELAUNCH": "1",
       "EW_RELOCATION_ATTEMPT_ID": attemptID,
+      "EW_RELOCATION_REASON": reason,
+      "EW_RELOCATION_DESTINATION_SCOPE": destinationScope,
     ]
     return await withCheckedContinuation { continuation in
       NSWorkspace.shared.openApplication(at: installedURL, configuration: config) { app, error in
@@ -442,6 +594,12 @@ public struct FileRelocationHandshake: RelocationHandshaking {
   private struct Ack: Codable {
     let resolvedPath: String
     let healthy: Bool
+    /// Both optional ON THE WIRE. An ack written by an OLDER child carries
+    /// neither. `decodeIfPresent` semantics come free from the optionals; an
+    /// absent value must read as UNKNOWN, never as a mismatch, or every
+    /// cross-version handoff breaks (#2006 §4).
+    let stateLabel: String?
+    let bundleVersion: String?
   }
 
   public init(
@@ -463,28 +621,50 @@ public struct FileRelocationHandshake: RelocationHandshaking {
     directory.appendingPathComponent("relocation-ack-\(attemptID).json")
   }
 
-  public func writeAck(attemptID: String, resolvedPath: String, healthy: Bool) {
+  public func writeAck(
+    attemptID: String, resolvedPath: String, healthy: Bool, stateLabel: String?,
+    bundleVersion: String?
+  ) {
     let fm = FileManager.default
     try? fm.createDirectory(at: directory, withIntermediateDirectories: true)
-    guard let data = try? JSONEncoder().encode(Ack(resolvedPath: resolvedPath, healthy: healthy))
+    guard
+      let data = try? JSONEncoder().encode(
+        Ack(
+          resolvedPath: resolvedPath, healthy: healthy, stateLabel: stateLabel,
+          bundleVersion: bundleVersion))
     else { return }
     try? data.write(to: ackURL(attemptID), options: .atomic)
   }
 
-  public func awaitAck(attemptID: String, destination: URL, timeout: TimeInterval) async -> Bool {
+  public func awaitAck(
+    attemptID: String, destination: URL, expectedBundleVersion: String, timeout: TimeInterval
+  ) async -> RelocationAckOutcome {
     let url = ackURL(attemptID)
     let deadline = Date().addingTimeInterval(timeout)
     defer { try? FileManager.default.removeItem(at: url) }
     while Date() < deadline {
-      if let data = try? Data(contentsOf: url),
-        let ack = try? JSONDecoder().decode(Ack.self, from: data)
-      {
-        return ack.healthy
-          && ack.resolvedPath == destination.standardizedFileURL.path
+      if let data = try? Data(contentsOf: url) {
+        guard let ack = try? JSONDecoder().decode(Ack.self, from: data) else {
+          // A file exists but will not decode. Do not keep polling a corpse.
+          return .malformed
+        }
+        // Order is load-bearing: health, then exact path, then version. A
+        // version check must never pre-empt the two conditions that already
+        // work (#2006 §3.2).
+        guard ack.healthy else { return .unhealthy(stateLabel: ack.stateLabel) }
+        guard ack.resolvedPath == destination.standardizedFileURL.path else {
+          return .pathMismatch
+        }
+        // Compare ONLY when the child supplied a version. Absent means an old
+        // child, which must still confirm.
+        if let actual = ack.bundleVersion, actual != expectedBundleVersion {
+          return .versionMismatch
+        }
+        return .confirmed
       }
       try? await Task.sleep(nanoseconds: UInt64(pollInterval * 1_000_000_000))
     }
-    return false
+    return .timedOut
   }
 }
 
@@ -500,19 +680,34 @@ public struct TelemetryServiceRelocationSink: RelocationTelemetrySink {
     TelemetryService.shared.updateRelocationOffered(
       reason: reason, destinationScope: destinationScope)
   }
-  public func accepted(reason: String, destinationScope: String) {
+  public func accepted(reason: String, destinationScope: String, attemptID: String) {
     TelemetryService.shared.updateRelocationAccepted(
-      reason: reason, destinationScope: destinationScope)
+      reason: reason, destinationScope: destinationScope, attemptID: attemptID)
   }
   public func declined(reason: String) {
     TelemetryService.shared.updateRelocationDeclined(reason: reason)
   }
-  public func failed(reason: String, failureClass: String) {
-    TelemetryService.shared.updateRelocationFailed(reason: reason, failureClass: failureClass)
+  public func failed(
+    reason: String, failureClass: String, attemptID: String, installResolution: String
+  ) {
+    TelemetryService.shared.updateRelocationFailed(
+      reason: reason, failureClass: failureClass, attemptID: attemptID,
+      installResolution: installResolution)
   }
-  public func relaunched(reason: String, destinationScope: String, relaunchConfirmed: Bool) {
+  public func relaunched(
+    reason: String, destinationScope: String, relaunchConfirmed: Bool, attemptID: String,
+    installResolution: String
+  ) {
     TelemetryService.shared.updateRelocationRelaunched(
-      reason: reason, destinationScope: destinationScope, relaunchConfirmed: relaunchConfirmed)
+      reason: reason, destinationScope: destinationScope, relaunchConfirmed: relaunchConfirmed,
+      attemptID: attemptID, installResolution: installResolution)
+  }
+  public func completed(
+    reason: String, destinationScope: String, attemptID: String, completionSource: String
+  ) {
+    TelemetryService.shared.updateRelocationCompleted(
+      reason: reason, destinationScope: destinationScope, attemptID: attemptID,
+      completionSource: completionSource)
   }
 }
 

--- a/Sources/EnviousWisprAppKit/App/ApplicationRelocationCoordinator+Live.swift
+++ b/Sources/EnviousWisprAppKit/App/ApplicationRelocationCoordinator+Live.swift
@@ -626,10 +626,11 @@ public struct FileRelocationHandshake: RelocationHandshaking {
     directory.appendingPathComponent("relocation-ack-\(attemptID).json")
   }
 
+  @discardableResult
   public func writeAck(
     attemptID: String, resolvedPath: String, healthy: Bool, stateLabel: String?,
     bundleVersion: String?
-  ) {
+  ) -> Bool {
     let fm = FileManager.default
     try? fm.createDirectory(at: directory, withIntermediateDirectories: true)
     guard
@@ -637,8 +638,16 @@ public struct FileRelocationHandshake: RelocationHandshaking {
         Ack(
           resolvedPath: resolvedPath, healthy: healthy, stateLabel: stateLabel,
           bundleVersion: bundleVersion))
-    else { return }
-    try? data.write(to: ackURL(attemptID), options: .atomic)
+    else { return false }
+    // Report publication rather than swallowing it: an unwritable Application
+    // Support or a full disk means the parent never sees this and times out,
+    // so the child must not go on to claim success (review P2).
+    do {
+      try data.write(to: ackURL(attemptID), options: .atomic)
+      return true
+    } catch {
+      return false
+    }
   }
 
   public func awaitAck(

--- a/Sources/EnviousWisprAppKit/App/ApplicationRelocationCoordinator+Live.swift
+++ b/Sources/EnviousWisprAppKit/App/ApplicationRelocationCoordinator+Live.swift
@@ -416,14 +416,30 @@ public struct FileManagerApplicationMover: ApplicationMoving {
     }
 
     // Place it: atomic replace when a destination exists, else move in.
+    // `.usingNewMetadataOnly` says explicitly: the bundle we just verified and
+    // stripped is the source of truth, not the item it replaces. Measured on
+    // APFS 2026-08-10, quarantine is NOT inherited either way — so this is not
+    // fixing an observed bug, it is removing the need to rely on a metadata
+    // rule we do not control (cloud review P1).
     do {
       if fm.fileExists(atPath: destination.path) {
-        _ = try fm.replaceItemAt(destination, withItemAt: staging)
+        _ = try fm.replaceItemAt(
+          destination, withItemAt: staging, backupItemName: nil,
+          options: .usingNewMetadataOnly)
       } else {
         try fm.moveItem(at: staging, to: destination)
       }
     } catch {
       return .failure(.unknown)
+    }
+
+    // VERIFY THE END STATE, do not assume it. Everything above establishes
+    // that the bundle was clean at its staging path; this establishes that it
+    // is clean WHERE IT WILL ACTUALLY LAUNCH FROM, which is the only property
+    // that matters. Idempotent and cheap: the probe-first path returns
+    // immediately for every already-clean item.
+    guard Self.stripQuarantine(at: destination) else {
+      return .failure(.stripFailedAtDestination)
     }
     // `isStructurallyValid` above asserted the staged bundle's CFBundleVersion
     // equals `currentVersion`, so this IS the version the mover verified.

--- a/Sources/EnviousWisprAppKit/App/ApplicationRelocationCoordinator+Live.swift
+++ b/Sources/EnviousWisprAppKit/App/ApplicationRelocationCoordinator+Live.swift
@@ -502,10 +502,21 @@ public struct FileManagerApplicationMover: ApplicationMoving {
     func remove(_ url: URL) -> Bool {
       let ok = url.withUnsafeFileSystemRepresentation { path -> Bool in
         guard let path else { return false }
-        // XATTR_NOFOLLOW: act on the link itself, never its target.
-        if removexattr(path, attr, XATTR_NOFOLLOW) == 0 { return true }
-        // Nothing to remove is success; anything else is a real failure.
-        return errno == ENOATTR
+        // PROBE BEFORE REMOVING. `removexattr` on an item owned by root or
+        // another admin returns EPERM even when the attribute is ABSENT, so
+        // removing unconditionally would fail a perfectly clean destination
+        // copy and send its user Message A instead of opening it — a
+        // regression on the already-supported existing-destination path
+        // (whole-diff review r3). Reading an xattr needs no write permission,
+        // so the probe succeeds exactly where the removal cannot.
+        // XATTR_NOFOLLOW throughout: act on the link itself, never its target.
+        if getxattr(path, attr, nil, 0, 0, XATTR_NOFOLLOW) < 0 {
+          // Absent is success; any other probe error means we cannot tell.
+          return errno == ENOATTR
+        }
+        // Present: it must actually come off. The ENOATTR retry covers the
+        // benign race where something else removed it after the probe.
+        return removexattr(path, attr, XATTR_NOFOLLOW) == 0 || errno == ENOATTR
       }
       return ok
     }

--- a/Sources/EnviousWisprAppKit/App/ApplicationRelocationCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/ApplicationRelocationCoordinator.swift
@@ -107,8 +107,14 @@ public enum RelocationFailure: String, Error, Sendable, CaseIterable {
   case stripFailedBeforePlacement
   /// Quarantine removal failed on a bundle already at the destination, which we
   /// therefore may have left partially stripped. Never invite the user to open
-  /// that copy (#2006).
+  /// that copy (#2006). Arises ONLY on the `.existingUsable` route.
   case stripFailedAtDestination
+  /// The post-placement verification of OUR freshly placed copy failed. A copy
+  /// IS at the destination and may be unclean. Distinct from
+  /// `stripFailedAtDestination` because the route differs and therefore so
+  /// does `install_resolution` — reusing that case reported a fresh install as
+  /// `existing_usable` (cloud review, second round).
+  case stripFailedAfterPlacement
   case relaunchRejected
   // The six ack-specific cases below REPLACE the former `relaunchUnconfirmed`,
   // which collapsed four distinct conditions into one label and so told every
@@ -145,6 +151,9 @@ public enum RelocationFailure: String, Error, Sendable, CaseIterable {
     switch self {
     case .stripFailedAtDestination:
       return InstallResolution.TelemetryLabel.existingUsable
+    case .stripFailedAfterPlacement:
+      // We placed this copy ourselves; the route is `installed`.
+      return InstallResolution.TelemetryLabel.installed
     case .destinationCreation, .destinationRunning, .stagingCopy, .stagedBundleInvalid,
       .signatureInvalid, .destinationConflict, .diskFull, .stripFailedBeforePlacement,
       .relaunchRejected, .ackUnhealthyTranslocated, .ackUnhealthyOther, .ackPathMismatch,
@@ -680,7 +689,10 @@ public final class ApplicationRelocationCoordinator {
     // unhealthy acks are placed-but-suspect, so they must NOT become B.
     case .destinationCreation, .destinationRunning, .stagingCopy, .stagedBundleInvalid,
       .signatureInvalid, .destinationConflict, .diskFull, .stripFailedBeforePlacement,
-      .stripFailedAtDestination, .ackUnhealthyTranslocated, .ackUnhealthyOther, .unknown:
+      .stripFailedAtDestination, .stripFailedAfterPlacement, .ackUnhealthyTranslocated,
+      .ackUnhealthyOther, .unknown:
+      // A copy that may be unclean is never offered for opening, whichever
+      // route left it that way.
       return .nothingMoved(failure)
     }
   }

--- a/Sources/EnviousWisprAppKit/App/ApplicationRelocationCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/ApplicationRelocationCoordinator.swift
@@ -258,11 +258,18 @@ public struct RelocationEnvironment: Sendable {
   /// suppress only the telemetry, never the health ack (#2006 §9).
   public let relaunchReason: String?
   public let relaunchDestinationScope: String?
+  /// The path and version the PARENT expects this child to be. The child emits
+  /// `completed` only when it matches BOTH, so a different registered copy that
+  /// Launch Services happened to open cannot report success for an attempt the
+  /// parent is about to fail (whole-diff review P2, #2006).
+  public let relaunchExpectedPath: String?
+  public let relaunchExpectedVersion: String?
 
   public init(
     bundleURL: URL, bundleIdentifier: String, currentVersion: String,
     relaunchAttemptID: String?, relaunchReason: String? = nil,
-    relaunchDestinationScope: String? = nil
+    relaunchDestinationScope: String? = nil, relaunchExpectedPath: String? = nil,
+    relaunchExpectedVersion: String? = nil
   ) {
     self.bundleURL = bundleURL
     self.bundleIdentifier = bundleIdentifier
@@ -270,6 +277,8 @@ public struct RelocationEnvironment: Sendable {
     self.relaunchAttemptID = relaunchAttemptID
     self.relaunchReason = relaunchReason
     self.relaunchDestinationScope = relaunchDestinationScope
+    self.relaunchExpectedPath = relaunchExpectedPath
+    self.relaunchExpectedVersion = relaunchExpectedVersion
   }
 
   /// Production environment read from the running process.
@@ -285,7 +294,9 @@ public struct RelocationEnvironment: Sendable {
       currentVersion: version,
       relaunchAttemptID: attemptID,
       relaunchReason: isRelaunch ? env["EW_RELOCATION_REASON"] : nil,
-      relaunchDestinationScope: isRelaunch ? env["EW_RELOCATION_DESTINATION_SCOPE"] : nil)
+      relaunchDestinationScope: isRelaunch ? env["EW_RELOCATION_DESTINATION_SCOPE"] : nil,
+      relaunchExpectedPath: isRelaunch ? env["EW_RELOCATION_EXPECTED_PATH"] : nil,
+      relaunchExpectedVersion: isRelaunch ? env["EW_RELOCATION_EXPECTED_VERSION"] : nil)
   }
 }
 
@@ -319,7 +330,8 @@ public protocol ApplicationMoving: Sendable {
 /// Launches the installed copy with the relaunch marker + attempt ID.
 public protocol RelocationRelaunching: Sendable {
   func relaunch(
-    _ installedURL: URL, attemptID: String, reason: String, destinationScope: String
+    _ installedURL: URL, attemptID: String, reason: String, destinationScope: String,
+    expectedBundleVersion: String
   ) async -> Bool
   /// Bring an ALREADY-running instance at this URL to the front (no new
   /// instance). Returns false if no such running instance is found.
@@ -470,7 +482,17 @@ public final class ApplicationRelocationCoordinator {
       // Telemetry metadata is best-effort and must NEVER gate the health ack
       // above: an OLD parent launches us without it, and a missing label must
       // cost only the `completed` event, never the handshake itself.
-      if healthy, let reason = env.relaunchReason,
+      // `completed` asserts a usable DESTINATION copy was observed, so the
+      // child must confirm it IS that copy before claiming it. Launch Services
+      // can route an open request to another registered copy; that copy is
+      // healthy, would emit success, and the parent would independently record
+      // a path/version mismatch — one attempt counted as both completed and
+      // failed, corrupting the success rate this change exists to produce
+      // (whole-diff review P2). Match the parent's own criteria exactly.
+      let isExpectedCopy =
+        env.relaunchExpectedPath == env.bundleURL.standardizedFileURL.path
+        && env.relaunchExpectedVersion == env.currentVersion
+      if healthy, isExpectedCopy, let reason = env.relaunchReason,
         let scope = env.relaunchDestinationScope
       {
         telemetry.completed(
@@ -647,7 +669,8 @@ public final class ApplicationRelocationCoordinator {
     guard
       await relauncher.relaunch(
         installedURL, attemptID: attemptID, reason: reason,
-        destinationScope: destination.scope)
+        destinationScope: destination.scope,
+        expectedBundleVersion: resolution.bundleVersion)
     else {
       presenter.dismissProgress()
       telemetry.failed(

--- a/Sources/EnviousWisprAppKit/App/ApplicationRelocationCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/ApplicationRelocationCoordinator.swift
@@ -130,6 +130,28 @@ public enum RelocationFailure: String, Error, Sendable, CaseIterable {
   /// `handshakeTimeout`.
   case ackTimeout
   case unknown
+
+  /// The install route this failure ITSELF identifies, for the terminal events
+  /// where the mover returned no resolution to read.
+  ///
+  /// Only `stripFailedAtDestination` identifies one: it can arise ONLY on the
+  /// `.existingUsable` route, where a verified copy was already at the
+  /// destination. Reporting it as `unresolved` would erase exactly the
+  /// existing-copy distinction this field exists to measure, and make the
+  /// repeat path indistinguishable from a failure before any destination was
+  /// resolved (whole-diff review r4). No `default` arm on purpose: a future
+  /// case must answer this question rather than inherit `unresolved`.
+  public var impliedInstallResolution: String {
+    switch self {
+    case .stripFailedAtDestination:
+      return InstallResolution.TelemetryLabel.existingUsable
+    case .destinationCreation, .destinationRunning, .stagingCopy, .stagedBundleInvalid,
+      .signatureInvalid, .destinationConflict, .diskFull, .stripFailedBeforePlacement,
+      .relaunchRejected, .ackUnhealthyTranslocated, .ackUnhealthyOther, .ackPathMismatch,
+      .ackVersionMismatch, .ackMalformed, .ackTimeout, .unknown:
+      return InstallResolution.TelemetryLabel.unresolved
+    }
+  }
 }
 
 /// How the handshake ended. Replaces a `Bool` that could not distinguish the
@@ -216,12 +238,23 @@ public enum InstallResolution: Equatable, Sendable {
     return false
   }
 
+  /// One home for the bounded `install_resolution` vocabulary, so the failure
+  /// path and the success path cannot drift apart.
+  public enum TelemetryLabel {
+    public static let installed = "installed"
+    public static let existingUsable = "existing_usable"
+    public static let existingRunning = "existing_running"
+    /// The mover failed BEFORE producing any resolution. Asserts nothing about
+    /// whether a destination existed.
+    public static let unresolved = "unresolved"
+  }
+
   /// Bounded telemetry label for which route the mover took.
   public var telemetryLabel: String {
     switch self {
-    case .installed: return "installed"
-    case .existingUsable: return "existing_usable"
-    case .existingRunning: return "existing_running"
+    case .installed: return TelemetryLabel.installed
+    case .existingUsable: return TelemetryLabel.existingUsable
+    case .existingRunning: return TelemetryLabel.existingRunning
     }
   }
 }
@@ -613,11 +646,12 @@ public final class ApplicationRelocationCoordinator {
     switch result {
     case .failure(let failure):
       presenter.dismissProgress()
-      // No resolution exists: the mover returns Result<InstallResolution, _>,
-      // so a pre-placement failure has no route to report (#2006 §3.4d).
+      // The mover returns Result<InstallResolution, _>, so a failure carries no
+      // resolution to read — but the failure itself can still identify the
+      // route (see `impliedInstallResolution`).
       telemetry.failed(
         reason: reason, failureClass: failure.rawValue, attemptID: attemptID,
-        installResolution: "unresolved")
+        installResolution: failure.impliedInstallResolution)
       presenter.showFailure(Self.presentation(for: failure, destination: destination.url))
     case .success(let resolution) where resolution.isExistingRunning:
       // A verified same-or-newer copy is already running: bring it to the front

--- a/Sources/EnviousWisprAppKit/App/ApplicationRelocationCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/ApplicationRelocationCoordinator.swift
@@ -51,6 +51,19 @@ public enum ApplicationLocationState: Equatable, Sendable {
     case .healthy, .detectionFailed: return nil
     }
   }
+
+  /// Label the relaunched child puts in its ack so the parent can say WHY the
+  /// handoff failed. Unlike `reasonLabel` this is non-nil for every state,
+  /// including `detectionFailed`, because an unhealthy child must always be
+  /// classifiable rather than falling through as "malformed" (#2006 §3.2).
+  public var ackStateLabel: String {
+    switch self {
+    case .healthy: return "healthy"
+    case .translocated: return "translocated"
+    case .readOnlyVolume: return "read_only_volume"
+    case .detectionFailed: return "detection_failed"
+    }
+  }
 }
 
 /// Pure, injectable detector. Deliberately mirrors Sparkle's own observable
@@ -81,7 +94,7 @@ public struct ApplicationLocationDetector: Sendable {
 
 /// Bounded failure classification for UX copy, logs, and telemetry. No raw
 /// paths, usernames, or free-form filesystem detail crosses this boundary.
-public enum RelocationFailure: String, Error, Sendable {
+public enum RelocationFailure: String, Error, Sendable, CaseIterable {
   case destinationCreation
   case destinationRunning
   case stagingCopy
@@ -89,28 +102,126 @@ public enum RelocationFailure: String, Error, Sendable {
   case signatureInvalid
   case destinationConflict
   case diskFull
+  /// Quarantine removal failed on the staged copy, before placement. Staging is
+  /// discarded by `install`'s `defer`, so nothing was placed (#2006).
+  case stripFailedBeforePlacement
+  /// Quarantine removal failed on a bundle already at the destination, which we
+  /// therefore may have left partially stripped. Never invite the user to open
+  /// that copy (#2006).
+  case stripFailedAtDestination
   case relaunchRejected
-  case relaunchUnconfirmed
+  // The six ack-specific cases below REPLACE the former `relaunchUnconfirmed`,
+  // which collapsed four distinct conditions into one label and so told every
+  // user the same untrue sentence. Classification is only derivable where the
+  // ack is read, so `RelocationHandshaking` owns it (#2006 §3.2).
+  /// Child ran and is STILL translocated: the move did not free it.
+  case ackUnhealthyTranslocated
+  /// Child ran and reported some other unhealthy state, or an old child
+  /// reported unhealthy without naming a state.
+  case ackUnhealthyOther
+  /// Healthy child, but running from a path that is not the destination.
+  case ackPathMismatch
+  /// Healthy child at the right path reporting a DIFFERENT version: another
+  /// registered copy answered instead of the one we placed.
+  case ackVersionMismatch
+  /// An ack appeared but could not be decoded.
+  case ackMalformed
+  /// No decodable ack before the deadline. The only class implicating
+  /// `handshakeTimeout`.
+  case ackTimeout
   case unknown
+}
+
+/// How the handshake ended. Replaces a `Bool` that could not distinguish the
+/// four conditions the parent then had to guess between (#2006 §3.2).
+public enum RelocationAckOutcome: Equatable, Sendable {
+  case confirmed
+  case unhealthy(stateLabel: String?)
+  case pathMismatch
+  case versionMismatch
+  case malformed
+  case timedOut
+
+  /// The single mapping from outcome to taxonomy, so no call site invents one.
+  public var failure: RelocationFailure {
+    switch self {
+    case .confirmed: return .unknown  // never used; `confirmed` is not a failure
+    case .unhealthy(let label):
+      return label == ApplicationLocationState.translocated.reasonLabel
+        ? .ackUnhealthyTranslocated : .ackUnhealthyOther
+    case .pathMismatch: return .ackPathMismatch
+    case .versionMismatch: return .ackVersionMismatch
+    case .malformed: return .ackMalformed
+    case .timedOut: return .ackTimeout
+    }
+  }
+}
+
+/// What the user is shown, and whether a Finder button is even possible.
+///
+/// Founder decision 2026-08-10 (#2006 §3.3): user-facing copy is TWO families,
+/// not one per failure class. Binding the family to the Finder affordance in a
+/// single type makes them impossible to mis-pair — `.nothingMoved` structurally
+/// cannot carry a destination and `.installedNotConfirmed` structurally cannot
+/// lack one. It does NOT prove the correct family was chosen; that is enforced
+/// by the 18-origin routing test.
+public enum RelocationFailurePresentation: Equatable, Sendable {
+  /// Message A. Nothing usable was placed, OR a placed copy is known/suspected
+  /// unhealthy and must never be offered for opening.
+  case nothingMoved(RelocationFailure)
+  /// Message B. A verified copy is at the destination and only the handoff is
+  /// unconfirmed.
+  case installedNotConfirmed(RelocationFailure, destination: URL)
+
+  public var failure: RelocationFailure {
+    switch self {
+    case .nothingMoved(let f), .installedNotConfirmed(let f, _): return f
+    }
+  }
 }
 
 /// What the mover did with the chosen destination.
 public enum InstallResolution: Equatable, Sendable {
   /// We staged, validated, and placed our own copy at this URL → launch fresh +
   /// handshake.
-  case installed(URL)
+  case installed(URL, bundleVersion: String)
   /// A same-identity, same-or-newer healthy copy already exists here but is NOT
   /// running → launch it fresh + handshake.
-  case existingUsable(URL)
+  case existingUsable(URL, bundleVersion: String)
   /// A same-identity, same-or-newer healthy copy is ALREADY RUNNING here →
   /// activate that instance and terminate self; never spawn a duplicate, and no
   /// handshake is needed (the copy is verified and already live). Cloud Codex
   /// review #1490.
-  case existingRunning(URL)
+  case existingRunning(URL, bundleVersion: String)
 
   public var url: URL {
     switch self {
-    case .installed(let u), .existingUsable(let u), .existingRunning(let u): return u
+    case .installed(let u, _), .existingUsable(let u, _), .existingRunning(let u, _): return u
+    }
+  }
+
+  /// The version the MOVER observed on the bundle it decided to launch. The
+  /// only authority for the expected ack version: `.existingUsable`
+  /// deliberately accepts a same-or-NEWER destination, so comparing against the
+  /// running app's own version would reject a valid newer copy (#2006 §3.2).
+  public var bundleVersion: String {
+    switch self {
+    case .installed(_, let v), .existingUsable(_, let v), .existingRunning(_, let v): return v
+    }
+  }
+
+  /// True only for the route that launches no child and needs no handshake.
+  public var isExistingRunning: Bool {
+    if case .existingRunning = self { return true }
+    return false
+  }
+
+  /// Bounded telemetry label for which route the mover took.
+  public var telemetryLabel: String {
+    switch self {
+    case .installed: return "installed"
+    case .existingUsable: return "existing_usable"
+    case .existingRunning: return "existing_running"
     }
   }
 }
@@ -142,15 +253,23 @@ public struct RelocationEnvironment: Sendable {
   /// the original passed via `EW_RELOCATION_ATTEMPT_ID`. Presence means "report
   /// your health back, do not prompt."
   public let relaunchAttemptID: String?
+  /// Attempt context the parent passes through so the CHILD can emit its own
+  /// `completed` event. Both are nil when an OLD parent launched us; that must
+  /// suppress only the telemetry, never the health ack (#2006 §9).
+  public let relaunchReason: String?
+  public let relaunchDestinationScope: String?
 
   public init(
     bundleURL: URL, bundleIdentifier: String, currentVersion: String,
-    relaunchAttemptID: String?
+    relaunchAttemptID: String?, relaunchReason: String? = nil,
+    relaunchDestinationScope: String? = nil
   ) {
     self.bundleURL = bundleURL
     self.bundleIdentifier = bundleIdentifier
     self.currentVersion = currentVersion
     self.relaunchAttemptID = relaunchAttemptID
+    self.relaunchReason = relaunchReason
+    self.relaunchDestinationScope = relaunchDestinationScope
   }
 
   /// Production environment read from the running process.
@@ -164,7 +283,9 @@ public struct RelocationEnvironment: Sendable {
       bundleURL: Bundle.main.bundleURL,
       bundleIdentifier: Bundle.main.bundleIdentifier ?? "com.enviouswispr.app",
       currentVersion: version,
-      relaunchAttemptID: attemptID)
+      relaunchAttemptID: attemptID,
+      relaunchReason: isRelaunch ? env["EW_RELOCATION_REASON"] : nil,
+      relaunchDestinationScope: isRelaunch ? env["EW_RELOCATION_DESTINATION_SCOPE"] : nil)
   }
 }
 
@@ -182,7 +303,7 @@ public protocol RelocationSuppressionStore: Sendable {
   func present() async -> RelocationChoice
   func showProgress()
   func dismissProgress()
-  func showFailure(_ failure: RelocationFailure)
+  func showFailure(_ presentation: RelocationFailurePresentation)
 }
 
 /// Copies + installs the bundle into the destination, resolving any existing
@@ -197,7 +318,9 @@ public protocol ApplicationMoving: Sendable {
 
 /// Launches the installed copy with the relaunch marker + attempt ID.
 public protocol RelocationRelaunching: Sendable {
-  func relaunch(_ installedURL: URL, attemptID: String) async -> Bool
+  func relaunch(
+    _ installedURL: URL, attemptID: String, reason: String, destinationScope: String
+  ) async -> Bool
   /// Bring an ALREADY-running instance at this URL to the front (no new
   /// instance). Returns false if no such running instance is found.
   func activateRunning(_ url: URL) async -> Bool
@@ -207,19 +330,36 @@ public protocol RelocationRelaunching: Sendable {
 /// ack. Returns true only when the new instance reports healthy at the exact
 /// destination for THIS attempt.
 public protocol RelocationHandshaking: Sendable {
-  func awaitAck(attemptID: String, destination: URL, timeout: TimeInterval) async -> Bool
+  func awaitAck(
+    attemptID: String, destination: URL, expectedBundleVersion: String, timeout: TimeInterval
+  ) async -> RelocationAckOutcome
   /// Called by the relaunched child to report its own health (A2).
-  func writeAck(attemptID: String, resolvedPath: String, healthy: Bool)
+  /// `stateLabel` and `bundleVersion` are optional on the wire: an ack written
+  /// by an OLDER child carries neither, and absence must mean UNKNOWN, never
+  /// mismatch, or every cross-version handoff breaks (#2006 §4).
+  func writeAck(
+    attemptID: String, resolvedPath: String, healthy: Bool, stateLabel: String?,
+    bundleVersion: String?)
 }
 
 /// Bounded `update.relocation_*` telemetry. Live impl forwards to
 /// `TelemetryService` (also `@MainActor`) synchronously; tests record.
 @MainActor public protocol RelocationTelemetrySink {
   func offered(reason: String, destinationScope: String)
-  func accepted(reason: String, destinationScope: String)
+  func accepted(reason: String, destinationScope: String, attemptID: String)
   func declined(reason: String)
-  func failed(reason: String, failureClass: String)
-  func relaunched(reason: String, destinationScope: String, relaunchConfirmed: Bool)
+  /// `installResolution` is `unresolved` when the mover failed BEFORE returning
+  /// a resolution — the mover returns `Result<InstallResolution, _>`, so on a
+  /// pre-placement failure no route exists to report (#2006 §3.4d).
+  func failed(
+    reason: String, failureClass: String, attemptID: String, installResolution: String)
+  func relaunched(
+    reason: String, destinationScope: String, relaunchConfirmed: Bool, attemptID: String,
+    installResolution: String)
+  /// Emitted by the healthy CHILD after its own health check, or by the parent
+  /// after a successful `.existingRunning` activation, which launches no child.
+  func completed(
+    reason: String, destinationScope: String, attemptID: String, completionSource: String)
 }
 
 // MARK: - Coordinator
@@ -316,10 +456,27 @@ public final class ApplicationRelocationCoordinator {
     // detection, so a failed move cannot masquerade as healthy) and return.
     if let attemptID = env.relaunchAttemptID {
       let healthy = state == .healthy
+      // The ack is the ONLY channel by which the parent learns why a handoff
+      // failed, so it carries the child's own state label and its version.
+      // Version lets the parent tell "our copy came up" from "some other
+      // registered copy answered" — Launch Services may route an open request
+      // to an already-registered bundle (#2006 §3.2).
       handshake.writeAck(
         attemptID: attemptID,
         resolvedPath: env.bundleURL.standardizedFileURL.path,
-        healthy: healthy)
+        healthy: healthy,
+        stateLabel: state.ackStateLabel,
+        bundleVersion: env.currentVersion)
+      // Telemetry metadata is best-effort and must NEVER gate the health ack
+      // above: an OLD parent launches us without it, and a missing label must
+      // cost only the `completed` event, never the handshake itself.
+      if healthy, let reason = env.relaunchReason,
+        let scope = env.relaunchDestinationScope
+      {
+        telemetry.completed(
+          reason: reason, destinationScope: scope, attemptID: attemptID,
+          completionSource: "child_health")
+      }
       // If the move did not clear the blocking location, the original process
       // stays alive as the authoritative copy (its handshake fails). Quit this
       // redundant child rather than leave two blocked instances running (cloud
@@ -391,12 +548,18 @@ public final class ApplicationRelocationCoordinator {
       suppression.recordDecline(at: now(), version: env.currentVersion)
       telemetry.declined(reason: reason)
     case .move:
-      telemetry.accepted(reason: reason, destinationScope: destination.scope)
-      await performMove(reason: reason, destination: destination)
+      // Mint the id BEFORE `accepted` so the ingress event and every terminal
+      // event share one join key. It used to be minted inside the relaunch
+      // path, so `accepted` carried none and nothing could be joined to it —
+      // which is why four accepted attempts in 30 d have no known outcome.
+      let attemptID = makeAttemptID()
+      telemetry.accepted(
+        reason: reason, destinationScope: destination.scope, attemptID: attemptID)
+      await performMove(reason: reason, destination: destination, attemptID: attemptID)
     }
   }
 
-  private func performMove(reason: String, destination: Destination) async {
+  private func performMove(reason: String, destination: Destination, attemptID: String) async {
     guard !moveInProgress else { return }
     moveInProgress = true
     defer { moveInProgress = false }
@@ -410,30 +573,66 @@ public final class ApplicationRelocationCoordinator {
     switch result {
     case .failure(let failure):
       presenter.dismissProgress()
-      telemetry.failed(reason: reason, failureClass: failure.rawValue)
-      presenter.showFailure(failure)
-    case .success(.existingRunning(let url)):
+      // No resolution exists: the mover returns Result<InstallResolution, _>,
+      // so a pre-placement failure has no route to report (#2006 §3.4d).
+      telemetry.failed(
+        reason: reason, failureClass: failure.rawValue, attemptID: attemptID,
+        installResolution: "unresolved")
+      presenter.showFailure(Self.presentation(for: failure, destination: destination.url))
+    case .success(let resolution) where resolution.isExistingRunning:
       // A verified same-or-newer copy is already running: bring it to the front
       // and terminate this translocated duplicate. No new instance, no
       // handshake (cloud Codex review #1490).
-      await activateAndHandOff(reason: reason, destination: destination, runningURL: url)
+      await activateAndHandOff(
+        reason: reason, destination: destination, resolution: resolution, attemptID: attemptID)
     case .success(let resolution):
       await relaunchAndHandOff(
-        reason: reason, destination: destination, installedURL: resolution.url)
+        reason: reason, destination: destination, resolution: resolution, attemptID: attemptID)
+    }
+  }
+
+  /// The sole A/B routing decision (#2006 §3.3). Message B requires positive
+  /// evidence that a verified copy is present and not known-bad; every other
+  /// origin gets Message A, whose instruction — drag it yourself — is safe in
+  /// EVERY state. The asymmetry is deliberate: a wrong B invites the user to
+  /// open a broken copy, a wrong A costs one redundant drag.
+  static func presentation(for failure: RelocationFailure, destination: URL)
+    -> RelocationFailurePresentation
+  {
+    switch failure {
+    case .ackMalformed, .ackTimeout, .ackPathMismatch, .ackVersionMismatch, .relaunchRejected:
+      return .installedNotConfirmed(failure, destination: destination)
+    // Everything below is Message A. `stripFailedAtDestination` and both
+    // unhealthy acks are placed-but-suspect, so they must NOT become B.
+    case .destinationCreation, .destinationRunning, .stagingCopy, .stagedBundleInvalid,
+      .signatureInvalid, .destinationConflict, .diskFull, .stripFailedBeforePlacement,
+      .stripFailedAtDestination, .ackUnhealthyTranslocated, .ackUnhealthyOther, .unknown:
+      return .nothingMoved(failure)
     }
   }
 
   /// The good copy is already running: activate it, then terminate self. If it
   /// cannot be activated, keep the current process alive and report failure.
-  private func activateAndHandOff(reason: String, destination: Destination, runningURL: URL) async {
-    guard await relauncher.activateRunning(runningURL) else {
+  private func activateAndHandOff(
+    reason: String, destination: Destination, resolution: InstallResolution, attemptID: String
+  ) async {
+    guard await relauncher.activateRunning(resolution.url) else {
       presenter.dismissProgress()
-      telemetry.failed(reason: reason, failureClass: RelocationFailure.relaunchRejected.rawValue)
-      presenter.showFailure(.relaunchRejected)
+      telemetry.failed(
+        reason: reason, failureClass: RelocationFailure.relaunchRejected.rawValue,
+        attemptID: attemptID, installResolution: resolution.telemetryLabel)
+      presenter.showFailure(
+        Self.presentation(for: .relaunchRejected, destination: resolution.url))
       return
     }
     telemetry.relaunched(
-      reason: reason, destinationScope: destination.scope, relaunchConfirmed: true)
+      reason: reason, destinationScope: destination.scope, relaunchConfirmed: true,
+      attemptID: attemptID, installResolution: resolution.telemetryLabel)
+    // This route launches NO child, so a child-only `completed` would silently
+    // drop the whole existing-running success path from the success rate.
+    telemetry.completed(
+      reason: reason, destinationScope: destination.scope, attemptID: attemptID,
+      completionSource: "existing_running_activation")
     flushTelemetry()
     terminate()
   }
@@ -441,30 +640,44 @@ public final class ApplicationRelocationCoordinator {
   /// Relaunch, then wait for the new instance's health ack BEFORE terminating
   /// the current (only known-good) process. NSWorkspace acceptance alone is not
   /// a sufficient handoff boundary (A1).
-  private func relaunchAndHandOff(reason: String, destination: Destination, installedURL: URL) async
-  {
-    let attemptID = makeAttemptID()
-    guard await relauncher.relaunch(installedURL, attemptID: attemptID) else {
+  private func relaunchAndHandOff(
+    reason: String, destination: Destination, resolution: InstallResolution, attemptID: String
+  ) async {
+    let installedURL = resolution.url
+    guard
+      await relauncher.relaunch(
+        installedURL, attemptID: attemptID, reason: reason,
+        destinationScope: destination.scope)
+    else {
       presenter.dismissProgress()
-      telemetry.failed(reason: reason, failureClass: RelocationFailure.relaunchRejected.rawValue)
-      presenter.showFailure(.relaunchRejected)
+      telemetry.failed(
+        reason: reason, failureClass: RelocationFailure.relaunchRejected.rawValue,
+        attemptID: attemptID, installResolution: resolution.telemetryLabel)
+      presenter.showFailure(Self.presentation(for: .relaunchRejected, destination: installedURL))
       return
     }
 
-    let confirmed = await handshake.awaitAck(
-      attemptID: attemptID, destination: installedURL, timeout: handshakeTimeout)
-    guard confirmed else {
+    // Expected version comes from the MOVER's resolution, never from
+    // env.currentVersion: `.existingUsable` accepts a same-or-newer copy, so
+    // the destination's version can legitimately exceed ours (#2006 §3.2).
+    let outcome = await handshake.awaitAck(
+      attemptID: attemptID, destination: installedURL,
+      expectedBundleVersion: resolution.bundleVersion, timeout: handshakeTimeout)
+    guard outcome == .confirmed else {
       // The new copy never confirmed healthy at the destination. Keep the
       // current process alive rather than strand the user with no working app.
       presenter.dismissProgress()
+      let failure = outcome.failure
       telemetry.failed(
-        reason: reason, failureClass: RelocationFailure.relaunchUnconfirmed.rawValue)
-      presenter.showFailure(.relaunchUnconfirmed)
+        reason: reason, failureClass: failure.rawValue, attemptID: attemptID,
+        installResolution: resolution.telemetryLabel)
+      presenter.showFailure(Self.presentation(for: failure, destination: installedURL))
       return
     }
 
     telemetry.relaunched(
-      reason: reason, destinationScope: destination.scope, relaunchConfirmed: true)
+      reason: reason, destinationScope: destination.scope, relaunchConfirmed: true,
+      attemptID: attemptID, installResolution: resolution.telemetryLabel)
     // A5: best-effort, non-blocking flush; never delays the handoff.
     flushTelemetry()
     terminate()

--- a/Sources/EnviousWisprAppKit/App/ApplicationRelocationCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/ApplicationRelocationCoordinator.swift
@@ -349,9 +349,13 @@ public protocol RelocationHandshaking: Sendable {
   /// `stateLabel` and `bundleVersion` are optional on the wire: an ack written
   /// by an OLDER child carries neither, and absence must mean UNKNOWN, never
   /// mismatch, or every cross-version handoff breaks (#2006 §4).
+  /// Returns whether the ack was actually PUBLISHED. A silent failure here
+  /// (unwritable Application Support, full disk) means the parent will never
+  /// see it and will time out, so the child must not then claim success.
+  @discardableResult
   func writeAck(
     attemptID: String, resolvedPath: String, healthy: Bool, stateLabel: String?,
-    bundleVersion: String?)
+    bundleVersion: String?) -> Bool
 }
 
 /// Bounded `update.relocation_*` telemetry. Live impl forwards to
@@ -473,7 +477,7 @@ public final class ApplicationRelocationCoordinator {
       // Version lets the parent tell "our copy came up" from "some other
       // registered copy answered" — Launch Services may route an open request
       // to an already-registered bundle (#2006 §3.2).
-      handshake.writeAck(
+      let ackPublished = handshake.writeAck(
         attemptID: attemptID,
         resolvedPath: env.bundleURL.standardizedFileURL.path,
         healthy: healthy,
@@ -482,17 +486,31 @@ public final class ApplicationRelocationCoordinator {
       // Telemetry metadata is best-effort and must NEVER gate the health ack
       // above: an OLD parent launches us without it, and a missing label must
       // cost only the `completed` event, never the handshake itself.
-      // `completed` asserts a usable DESTINATION copy was observed, so the
-      // child must confirm it IS that copy before claiming it. Launch Services
-      // can route an open request to another registered copy; that copy is
-      // healthy, would emit success, and the parent would independently record
-      // a path/version mismatch — one attempt counted as both completed and
-      // failed, corrupting the success rate this change exists to produce
-      // (whole-diff review P2). Match the parent's own criteria exactly.
+      // THE RULE FOR THIS EVENT, enumerated once rather than patched per
+      // instance (two review rounds found two members of the same class):
+      // `completed` asserts "a usable DESTINATION copy was observed", so the
+      // child emits it only when it has VERIFIED every part of that claim:
+      //   1. it is healthy;
+      //   2. it IS the copy the parent placed — Launch Services can route an
+      //      open request to another registered copy, which would be healthy
+      //      and would claim success for an attempt the parent fails as a
+      //      path/version mismatch;
+      //   3. its ack was actually published — a silent write failure means the
+      //      parent times out and fails the attempt.
+      // Any of these missing and the same attempt id carries both `completed`
+      // and `failed`, corrupting the success rate this whole change exists to
+      // produce.
+      //
+      // ACCEPTED RESIDUAL, stated rather than engineered around: the child
+      // cannot know the parent's deadline, so a child that comes up healthy
+      // just after the parent gave up still emits `completed` while the parent
+      // emits `ackTimeout`. That pair is genuine information (the copy IS
+      // usable, the handoff was not confirmed) and is reported separately in
+      // the success-rate query rather than silently folded into either column.
       let isExpectedCopy =
         env.relaunchExpectedPath == env.bundleURL.standardizedFileURL.path
         && env.relaunchExpectedVersion == env.currentVersion
-      if healthy, isExpectedCopy, let reason = env.relaunchReason,
+      if healthy, isExpectedCopy, ackPublished, let reason = env.relaunchReason,
         let scope = env.relaunchDestinationScope
       {
         telemetry.completed(

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -2386,16 +2386,17 @@ public final class TelemetryService {
       properties: ["reason": reason, "destination_scope": destinationScope])
   }
 
-  public func updateRelocationAccepted(reason: String, destinationScope: String) {
+  public func updateRelocationAccepted(
+    reason: String, destinationScope: String, attemptID: String
+  ) {
+    let props = [
+      "reason": reason, "destination_scope": destinationScope, "attempt_id": attemptID,
+    ]
     #if DEBUG
       testEventHook?(
-        CapturedTelemetryEvent(
-          name: "update.relocation_accepted",
-          stringProps: ["reason": reason, "destination_scope": destinationScope]))
+        CapturedTelemetryEvent(name: "update.relocation_accepted", stringProps: props))
     #endif
-    PostHogSDK.shared.capture(
-      "update.relocation_accepted",
-      properties: ["reason": reason, "destination_scope": destinationScope])
+    PostHogSDK.shared.capture("update.relocation_accepted", properties: props)
   }
 
   public func updateRelocationDeclined(reason: String) {
@@ -2407,35 +2408,54 @@ public final class TelemetryService {
     PostHogSDK.shared.capture("update.relocation_declined", properties: ["reason": reason])
   }
 
-  public func updateRelocationFailed(reason: String, failureClass: String) {
+  public func updateRelocationFailed(
+    reason: String, failureClass: String, attemptID: String, installResolution: String
+  ) {
+    let props = [
+      "reason": reason, "failure_class": failureClass, "attempt_id": attemptID,
+      "install_resolution": installResolution,
+    ]
+    #if DEBUG
+      testEventHook?(CapturedTelemetryEvent(name: "update.relocation_failed", stringProps: props))
+    #endif
+    PostHogSDK.shared.capture("update.relocation_failed", properties: props)
+  }
+
+  /// A usable destination copy was OBSERVED. Two legitimate emitters, because
+  /// there are two successful routes: the healthy child after its own health
+  /// check, and the parent after an `.existingRunning` activation, which
+  /// launches no child at all (#2006 §3.4a).
+  public func updateRelocationCompleted(
+    reason: String, destinationScope: String, attemptID: String, completionSource: String
+  ) {
+    let props = [
+      "reason": reason, "destination_scope": destinationScope, "attempt_id": attemptID,
+      "completion_source": completionSource,
+    ]
     #if DEBUG
       testEventHook?(
-        CapturedTelemetryEvent(
-          name: "update.relocation_failed",
-          stringProps: ["reason": reason, "failure_class": failureClass]))
+        CapturedTelemetryEvent(name: "update.relocation_completed", stringProps: props))
     #endif
-    PostHogSDK.shared.capture(
-      "update.relocation_failed",
-      properties: ["reason": reason, "failure_class": failureClass])
+    PostHogSDK.shared.capture("update.relocation_completed", properties: props)
   }
 
   public func updateRelocationRelaunched(
-    reason: String, destinationScope: String, relaunchConfirmed: Bool
+    reason: String, destinationScope: String, relaunchConfirmed: Bool, attemptID: String,
+    installResolution: String
   ) {
+    let stringProps = [
+      "reason": reason, "destination_scope": destinationScope, "attempt_id": attemptID,
+      "install_resolution": installResolution,
+    ]
     #if DEBUG
       testEventHook?(
         CapturedTelemetryEvent(
-          name: "update.relocation_relaunched",
-          stringProps: ["reason": reason, "destination_scope": destinationScope],
+          name: "update.relocation_relaunched", stringProps: stringProps,
           boolProps: ["relaunch_confirmed": relaunchConfirmed]))
     #endif
-    PostHogSDK.shared.capture(
-      "update.relocation_relaunched",
-      properties: [
-        "reason": reason,
-        "destination_scope": destinationScope,
-        "relaunch_confirmed": relaunchConfirmed,
-      ])
+    var props: [String: Any] = stringProps
+    props["relaunch_confirmed"] = relaunchConfirmed
+    PostHogSDK.shared.capture("update.relocation_relaunched", properties: props)
   }
 
   /// Issue #958: a proactive launch/foreground trigger evaluated, whether it

--- a/Tests/EnviousWisprTests/App/ApplicationRelocationCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/ApplicationRelocationCoordinatorTests.swift
@@ -59,13 +59,16 @@ struct ApplicationRelocationCoordinatorTests {
     private(set) var activatedURL: URL?
     private(set) var lastReason: String?
     private(set) var lastDestinationScope: String?
+    private(set) var lastExpectedVersion: String?
     func relaunch(
-      _ installedURL: URL, attemptID: String, reason: String, destinationScope: String
+      _ installedURL: URL, attemptID: String, reason: String, destinationScope: String,
+      expectedBundleVersion: String
     ) async -> Bool {
       relaunchCalls += 1
       lastAttemptID = attemptID
       lastReason = reason
       lastDestinationScope = destinationScope
+      lastExpectedVersion = expectedBundleVersion
       return success
     }
     func activateRunning(_ url: URL) async -> Bool {
@@ -163,6 +166,10 @@ struct ApplicationRelocationCoordinatorTests {
     bundleURL: URL,
     version: String = "2.3.0",
     relaunchAttemptID: String? = nil,
+    relaunchReason: String? = nil,
+    relaunchDestinationScope: String? = nil,
+    relaunchExpectedPath: String? = nil,
+    relaunchExpectedVersion: String? = nil,
     moverResult: Result<InstallResolution, RelocationFailure> = .success(
       .installed(URL(fileURLWithPath: "/Applications/EnviousWispr.app"), bundleVersion: "1.0")),
     now: Date = Date(timeIntervalSince1970: 1_000_000)
@@ -177,7 +184,10 @@ struct ApplicationRelocationCoordinatorTests {
     let coordinator = ApplicationRelocationCoordinator(
       env: RelocationEnvironment(
         bundleURL: bundleURL, bundleIdentifier: "com.enviouswispr.app",
-        currentVersion: version, relaunchAttemptID: relaunchAttemptID),
+        currentVersion: version, relaunchAttemptID: relaunchAttemptID,
+        relaunchReason: relaunchReason, relaunchDestinationScope: relaunchDestinationScope,
+        relaunchExpectedPath: relaunchExpectedPath,
+        relaunchExpectedVersion: relaunchExpectedVersion),
       detector: ApplicationLocationDetector(),
       suppression: suppression,
       presenter: presenter,
@@ -191,6 +201,70 @@ struct ApplicationRelocationCoordinatorTests {
     return Harness(
       coordinator: coordinator, suppression: suppression, presenter: presenter, mover: mover,
       relauncher: relauncher, handshake: handshake, telemetry: telemetry, terminate: terminate)
+  }
+
+  // MARK: Child completion is claimed ONLY by the copy we actually placed
+
+  /// A real, existing, writable path so the detector reports `.healthy`. With
+  /// a non-existent path the child is unhealthy and every "no completion"
+  /// assertion would pass VACUOUSLY, proving nothing about the guard.
+  private static var placedURL: URL { healthyURL }
+  private static var placedPath: String { placedURL.standardizedFileURL.path }
+
+  @Test("the expected child emits completed")
+  func childCompletedWhenItIsTheExpectedCopy() async {
+    let h = Self.makeHarness(
+      bundleURL: Self.placedURL, version: "2.3.0",
+      relaunchAttemptID: "attempt-1", relaunchReason: "translocated",
+      relaunchDestinationScope: "system_applications",
+      relaunchExpectedPath: Self.placedPath, relaunchExpectedVersion: "2.3.0")
+    h.coordinator.evaluateAndOfferIfNeeded()
+    await h.coordinator.pendingWork?.value
+    #expect(h.telemetry.completedEvents.count == 1)
+    #expect(h.telemetry.completedEvents.first?.source == "child_health")
+    #expect(h.handshake.writes.first?.healthy == true)
+  }
+
+  @Test("a healthy child at ANOTHER path writes its ack but claims NO completion")
+  func childAtWrongPathDoesNotClaimCompletion() async {
+    // Launch Services can route an open request to a different registered copy.
+    // That copy is healthy, so without this guard it would report success for
+    // an attempt the parent is about to fail as ackPathMismatch — one attempt
+    // counted as BOTH, corrupting the success rate (whole-diff review P2).
+    let h = Self.makeHarness(
+      bundleURL: URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true),
+      version: "2.3.0", relaunchAttemptID: "attempt-1", relaunchReason: "translocated",
+      relaunchDestinationScope: "system_applications",
+      relaunchExpectedPath: Self.placedPath, relaunchExpectedVersion: "2.3.0")
+    h.coordinator.evaluateAndOfferIfNeeded()
+    await h.coordinator.pendingWork?.value
+    #expect(h.telemetry.completedEvents.isEmpty)
+    // The health ack is safety-critical and must STILL be written.
+    #expect(h.handshake.writes.count == 1)
+  }
+
+  @Test("a healthy child of the RIGHT path but wrong version claims no completion")
+  func childWithWrongVersionDoesNotClaimCompletion() async {
+    let h = Self.makeHarness(
+      bundleURL: Self.placedURL, version: "9.9.9",
+      relaunchAttemptID: "attempt-1", relaunchReason: "translocated",
+      relaunchDestinationScope: "system_applications",
+      relaunchExpectedPath: Self.placedPath, relaunchExpectedVersion: "2.3.0")
+    h.coordinator.evaluateAndOfferIfNeeded()
+    await h.coordinator.pendingWork?.value
+    #expect(h.telemetry.completedEvents.isEmpty)
+    #expect(h.handshake.writes.count == 1)
+  }
+
+  @Test("an OLD parent's child still acks, and simply emits nothing")
+  func childFromOldParentStillAcks() async {
+    let h = Self.makeHarness(
+      bundleURL: Self.placedURL, relaunchAttemptID: "attempt-1")
+    h.coordinator.evaluateAndOfferIfNeeded()
+    await h.coordinator.pendingWork?.value
+    #expect(h.telemetry.completedEvents.isEmpty)
+    #expect(h.handshake.writes.count == 1)
+    #expect(h.handshake.writes.first?.healthy == true)
   }
 
   // MARK: Detection

--- a/Tests/EnviousWisprTests/App/ApplicationRelocationCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/ApplicationRelocationCoordinatorTests.swift
@@ -228,6 +228,34 @@ struct ApplicationRelocationCoordinatorTests {
     }
   }
 
+  @Test("a post-placement verify failure reports installed, not existing_usable")
+  func postPlacementStripFailureKeepsTheInstalledRoute() async {
+    // We placed this copy ourselves. Reusing the existing-destination case
+    // here reported a FRESH install as an existing copy, erasing the route
+    // distinction in the opposite direction (cloud review, second round).
+    let h = Self.makeHarness(
+      bundleURL: Self.translocatedURL,
+      moverResult: .failure(.stripFailedAfterPlacement))
+    h.coordinator.evaluateAndOfferIfNeeded()
+    await h.coordinator.pendingWork?.value
+    #expect(h.telemetry.lastFailedInstallResolution == "installed")
+    // Still Message A: a copy that may be unclean is never offered for opening.
+    if case .nothingMoved = h.presenter.presentations[0] {} else {
+      Issue.record("a possibly-unclean placed copy must produce Message A")
+    }
+  }
+
+  @Test("every failure case maps to exactly one install_resolution, exhaustively")
+  func everyFailureHasAnImpliedResolution() {
+    // CaseIterable + no default arm means a future case cannot silently
+    // inherit `unresolved`; this asserts the three routes stay partitioned.
+    let byResolution = Dictionary(
+      grouping: RelocationFailure.allCases, by: { $0.impliedInstallResolution })
+    #expect(byResolution["existing_usable"] == [.stripFailedAtDestination])
+    #expect(byResolution["installed"] == [.stripFailedAfterPlacement])
+    #expect(byResolution["unresolved"]?.count == RelocationFailure.allCases.count - 2)
+  }
+
   @Test("a genuinely pre-placement failure still reports unresolved")
   func prePlacementFailureIsUnresolved() async {
     // The two-way control: without it, a mapping that returned existing_usable

--- a/Tests/EnviousWisprTests/App/ApplicationRelocationCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/ApplicationRelocationCoordinatorTests.swift
@@ -28,11 +28,15 @@ struct ApplicationRelocationCoordinatorTests {
     var choice: RelocationChoice = .move
     var progressShown = 0
     var progressDismissed = 0
-    var failures: [RelocationFailure] = []
+    var presentations: [RelocationFailurePresentation] = []
+    /// Convenience for the many existing assertions that only care about class.
+    var failures: [RelocationFailure] { presentations.map(\.failure) }
     func present() async -> RelocationChoice { choice }
     func showProgress() { progressShown += 1 }
     func dismissProgress() { progressDismissed += 1 }
-    func showFailure(_ failure: RelocationFailure) { failures.append(failure) }
+    func showFailure(_ presentation: RelocationFailurePresentation) {
+      presentations.append(presentation)
+    }
   }
 
   final class FakeMover: ApplicationMoving, @unchecked Sendable {
@@ -53,9 +57,15 @@ struct ApplicationRelocationCoordinatorTests {
     private(set) var lastAttemptID: String?
     private(set) var relaunchCalls = 0
     private(set) var activatedURL: URL?
-    func relaunch(_ installedURL: URL, attemptID: String) async -> Bool {
+    private(set) var lastReason: String?
+    private(set) var lastDestinationScope: String?
+    func relaunch(
+      _ installedURL: URL, attemptID: String, reason: String, destinationScope: String
+    ) async -> Bool {
       relaunchCalls += 1
       lastAttemptID = attemptID
+      lastReason = reason
+      lastDestinationScope = destinationScope
       return success
     }
     func activateRunning(_ url: URL) async -> Bool {
@@ -65,15 +75,28 @@ struct ApplicationRelocationCoordinatorTests {
   }
 
   final class FakeHandshake: RelocationHandshaking, @unchecked Sendable {
-    var ackHealthy = true
-    private(set) var awaitCalls = 0
-    private(set) var writes: [(attemptID: String, path: String, healthy: Bool)] = []
-    func awaitAck(attemptID: String, destination: URL, timeout: TimeInterval) async -> Bool {
-      awaitCalls += 1
-      return ackHealthy
+    /// Existing tests set this; `true` means confirmed, `false` means the
+    /// generic unhealthy-other outcome. New tests set `outcome` directly.
+    var ackHealthy = true {
+      didSet { outcome = ackHealthy ? .confirmed : .unhealthy(stateLabel: "read_only_volume") }
     }
-    func writeAck(attemptID: String, resolvedPath: String, healthy: Bool) {
-      writes.append((attemptID, resolvedPath, healthy))
+    var outcome: RelocationAckOutcome = .confirmed
+    private(set) var awaitCalls = 0
+    private(set) var lastExpectedVersion: String?
+    private(set) var writes:
+      [(attemptID: String, path: String, healthy: Bool, stateLabel: String?, version: String?)] = []
+    func awaitAck(
+      attemptID: String, destination: URL, expectedBundleVersion: String, timeout: TimeInterval
+    ) async -> RelocationAckOutcome {
+      awaitCalls += 1
+      lastExpectedVersion = expectedBundleVersion
+      return outcome
+    }
+    func writeAck(
+      attemptID: String, resolvedPath: String, healthy: Bool, stateLabel: String?,
+      bundleVersion: String?
+    ) {
+      writes.append((attemptID, resolvedPath, healthy, stateLabel, bundleVersion))
     }
   }
 
@@ -83,18 +106,37 @@ struct ApplicationRelocationCoordinatorTests {
     var declinedEvents: [String] = []
     var failedEvents: [(String, String)] = []
     var relaunchedEvents: [(String, String, Bool)] = []
+    var completedEvents: [(reason: String, scope: String, attemptID: String, source: String)] = []
+    var lastAcceptedAttemptID: String?
+    var lastFailedAttemptID: String?
+    var lastFailedInstallResolution: String?
+    var lastRelaunchedInstallResolution: String?
     func offered(reason: String, destinationScope: String) {
       offeredEvents.append((reason, destinationScope))
     }
-    func accepted(reason: String, destinationScope: String) {
+    func accepted(reason: String, destinationScope: String, attemptID: String) {
       acceptedEvents.append((reason, destinationScope))
+      lastAcceptedAttemptID = attemptID
     }
     func declined(reason: String) { declinedEvents.append(reason) }
-    func failed(reason: String, failureClass: String) {
+    func failed(
+      reason: String, failureClass: String, attemptID: String, installResolution: String
+    ) {
       failedEvents.append((reason, failureClass))
+      lastFailedAttemptID = attemptID
+      lastFailedInstallResolution = installResolution
     }
-    func relaunched(reason: String, destinationScope: String, relaunchConfirmed: Bool) {
+    func completed(
+      reason: String, destinationScope: String, attemptID: String, completionSource: String
+    ) {
+      completedEvents.append((reason, destinationScope, attemptID, completionSource))
+    }
+    func relaunched(
+      reason: String, destinationScope: String, relaunchConfirmed: Bool, attemptID: String,
+      installResolution: String
+    ) {
       relaunchedEvents.append((reason, destinationScope, relaunchConfirmed))
+      lastRelaunchedInstallResolution = installResolution
     }
   }
 
@@ -122,7 +164,7 @@ struct ApplicationRelocationCoordinatorTests {
     version: String = "2.3.0",
     relaunchAttemptID: String? = nil,
     moverResult: Result<InstallResolution, RelocationFailure> = .success(
-      .installed(URL(fileURLWithPath: "/Applications/EnviousWispr.app"))),
+      .installed(URL(fileURLWithPath: "/Applications/EnviousWispr.app"), bundleVersion: "1.0")),
     now: Date = Date(timeIntervalSince1970: 1_000_000)
   ) -> Harness {
     let suppression = FakeSuppression()
@@ -286,16 +328,72 @@ struct ApplicationRelocationCoordinatorTests {
 
   // MARK: Handshake failure keeps the original alive (A1)
 
-  @Test("ack unconfirmed -> original NEVER terminates, reports relaunchUnconfirmed")
+  @Test("ack unconfirmed -> original NEVER terminates, and reports the SPECIFIC reason")
   func moveAckTimeout() async {
     let h = Self.makeHarness(bundleURL: Self.translocatedURL)
-    h.handshake.ackHealthy = false
+    // A read-only-volume child: unhealthy for a reason that is NOT translocation.
+    h.handshake.outcome = .unhealthy(stateLabel: "read_only_volume")
     h.coordinator.evaluateAndOfferIfNeeded()
     await h.coordinator.pendingWork?.value
     #expect(h.terminate.count == 0)  // the only known-good copy stays alive
     #expect(h.telemetry.relaunchedEvents.isEmpty)
-    #expect(h.telemetry.failedEvents.map(\.1) == ["relaunchUnconfirmed"])
-    #expect(h.presenter.failures == [.relaunchUnconfirmed])
+    // #2006: this used to be the single `relaunchUnconfirmed` bucket for four
+    // distinct conditions. The class is now specific, and the user gets
+    // Message A because an unhealthy child is NOT evidence of a good copy.
+    #expect(h.telemetry.failedEvents.map(\.1) == ["ackUnhealthyOther"])
+    #expect(h.presenter.presentations.count == 1)
+    if case .nothingMoved(let f) = h.presenter.presentations[0] {
+      #expect(f == .ackUnhealthyOther)
+    } else {
+      Issue.record("an unhealthy child must never produce Message B")
+    }
+  }
+
+  @Test("a STILL-TRANSLOCATED child is classified apart, and never told to just open it")
+  func moveAckStillTranslocated() async {
+    let h = Self.makeHarness(bundleURL: Self.translocatedURL)
+    h.handshake.outcome = .unhealthy(stateLabel: "translocated")
+    h.coordinator.evaluateAndOfferIfNeeded()
+    await h.coordinator.pendingWork?.value
+    #expect(h.terminate.count == 0)
+    #expect(h.telemetry.failedEvents.map(\.1) == ["ackUnhealthyTranslocated"])
+    // The loop person A repeated four times: "open it from Applications" when
+    // the Applications copy is itself still trapped. Must be Message A.
+    if case .nothingMoved = h.presenter.presentations[0] {} else {
+      Issue.record("a still-translocated child must never produce Message B")
+    }
+  }
+
+  @Test("a healthy ack that never arrives DOES offer the Applications copy")
+  func moveAckTimedOutOffersDestination() async {
+    let h = Self.makeHarness(bundleURL: Self.translocatedURL)
+    h.handshake.outcome = .timedOut
+    h.coordinator.evaluateAndOfferIfNeeded()
+    await h.coordinator.pendingWork?.value
+    #expect(h.terminate.count == 0)
+    #expect(h.telemetry.failedEvents.map(\.1) == ["ackTimeout"])
+    // Placed and signature-verified, no evidence of breakage -> Message B,
+    // carrying the destination so Show in Finder has a real target.
+    if case .installedNotConfirmed(_, let url) = h.presenter.presentations[0] {
+      #expect(url.path == "/Applications/EnviousWispr.app")
+    } else {
+      Issue.record("a timed-out ack on a verified copy should produce Message B")
+    }
+  }
+
+  @Test("the expected version comes from the MOVER, not the running app")
+  func expectedVersionComesFromMover() async {
+    // A NEWER copy already at the destination is explicitly allowed. If the
+    // parent compared against its own version, this would be reported as a
+    // mismatch and the user told to quit every copy — a false failure.
+    let h = Self.makeHarness(
+      bundleURL: Self.translocatedURL,
+      moverResult: .success(
+        .existingUsable(
+          URL(fileURLWithPath: "/Applications/EnviousWispr.app"), bundleVersion: "9.9")))
+    h.coordinator.evaluateAndOfferIfNeeded()
+    await h.coordinator.pendingWork?.value
+    #expect(h.handshake.lastExpectedVersion == "9.9")
   }
 
   @Test("relaunch rejected -> failure, no terminate")
@@ -408,7 +506,7 @@ struct ApplicationRelocationCoordinatorTests {
   func existingUsableHandshakes() async {
     let dest = URL(fileURLWithPath: "/Applications/EnviousWispr.app")
     let h = Self.makeHarness(
-      bundleURL: Self.translocatedURL, moverResult: .success(.existingUsable(dest)))
+      bundleURL: Self.translocatedURL, moverResult: .success(.existingUsable(dest, bundleVersion: "1.0")))
     h.handshake.ackHealthy = true
     h.coordinator.evaluateAndOfferIfNeeded()
     await h.coordinator.pendingWork?.value
@@ -423,7 +521,7 @@ struct ApplicationRelocationCoordinatorTests {
   func existingRunningActivates() async {
     let dest = URL(fileURLWithPath: "/Applications/EnviousWispr.app")
     let h = Self.makeHarness(
-      bundleURL: Self.translocatedURL, moverResult: .success(.existingRunning(dest)))
+      bundleURL: Self.translocatedURL, moverResult: .success(.existingRunning(dest, bundleVersion: "1.0")))
     h.coordinator.evaluateAndOfferIfNeeded()
     await h.coordinator.pendingWork?.value
     #expect(h.relauncher.activatedURL == dest)  // brought the live copy to front
@@ -437,7 +535,7 @@ struct ApplicationRelocationCoordinatorTests {
   func existingRunningActivateFailure() async {
     let dest = URL(fileURLWithPath: "/Applications/EnviousWispr.app")
     let h = Self.makeHarness(
-      bundleURL: Self.translocatedURL, moverResult: .success(.existingRunning(dest)))
+      bundleURL: Self.translocatedURL, moverResult: .success(.existingRunning(dest, bundleVersion: "1.0")))
     h.relauncher.activateSuccess = false
     h.coordinator.evaluateAndOfferIfNeeded()
     await h.coordinator.pendingWork?.value

--- a/Tests/EnviousWisprTests/App/ApplicationRelocationCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/ApplicationRelocationCoordinatorTests.swift
@@ -207,6 +207,38 @@ struct ApplicationRelocationCoordinatorTests {
       relauncher: relauncher, handshake: handshake, telemetry: telemetry, terminate: terminate)
   }
 
+  // MARK: install_resolution keeps the existing-copy distinction
+
+  @Test("a strip failure at the destination is recorded as existing_usable, not unresolved")
+  func stripFailureAtDestinationKeepsTheRoute() async {
+    // This failure can arise ONLY on the existing-copy route, which is the
+    // repeat path that made every retry fail identically. Recording it as
+    // `unresolved` would erase the one distinction the field exists to measure
+    // (whole-diff review r4).
+    let h = Self.makeHarness(
+      bundleURL: Self.translocatedURL,
+      moverResult: .failure(.stripFailedAtDestination))
+    h.coordinator.evaluateAndOfferIfNeeded()
+    await h.coordinator.pendingWork?.value
+    #expect(h.telemetry.failedEvents.map(\.1) == ["stripFailedAtDestination"])
+    #expect(h.telemetry.lastFailedInstallResolution == "existing_usable")
+    // A placed-but-suspect copy must never be offered for opening.
+    if case .nothingMoved = h.presenter.presentations[0] {} else {
+      Issue.record("a partially stripped destination must produce Message A")
+    }
+  }
+
+  @Test("a genuinely pre-placement failure still reports unresolved")
+  func prePlacementFailureIsUnresolved() async {
+    // The two-way control: without it, a mapping that returned existing_usable
+    // for EVERYTHING would pass the test above.
+    let h = Self.makeHarness(
+      bundleURL: Self.translocatedURL, moverResult: .failure(.diskFull))
+    h.coordinator.evaluateAndOfferIfNeeded()
+    await h.coordinator.pendingWork?.value
+    #expect(h.telemetry.lastFailedInstallResolution == "unresolved")
+  }
+
   // MARK: Child completion is claimed ONLY by the copy we actually placed
 
   /// A real, existing, writable path so the detector reports `.healthy`. With

--- a/Tests/EnviousWisprTests/App/ApplicationRelocationCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/ApplicationRelocationCoordinatorTests.swift
@@ -95,11 +95,15 @@ struct ApplicationRelocationCoordinatorTests {
       lastExpectedVersion = expectedBundleVersion
       return outcome
     }
+    /// Set false to model an unwritable Application Support or a full disk.
+    var ackPublishes = true
+    @discardableResult
     func writeAck(
       attemptID: String, resolvedPath: String, healthy: Bool, stateLabel: String?,
       bundleVersion: String?
-    ) {
+    ) -> Bool {
       writes.append((attemptID, resolvedPath, healthy, stateLabel, bundleVersion))
+      return ackPublishes
     }
   }
 
@@ -253,6 +257,23 @@ struct ApplicationRelocationCoordinatorTests {
     h.coordinator.evaluateAndOfferIfNeeded()
     await h.coordinator.pendingWork?.value
     #expect(h.telemetry.completedEvents.isEmpty)
+    #expect(h.handshake.writes.count == 1)
+  }
+
+  @Test("a child whose ack cannot be PUBLISHED claims no completion")
+  func childWithUnpublishableAckDoesNotClaimCompletion() async {
+    // Unwritable Application Support or a full disk: the parent will never see
+    // the ack and will fail this attempt on timeout, so a `completed` here
+    // would make one attempt both a success and a failure (review r2 P2).
+    let h = Self.makeHarness(
+      bundleURL: Self.placedURL, version: "2.3.0", relaunchAttemptID: "attempt-1",
+      relaunchReason: "translocated", relaunchDestinationScope: "system_applications",
+      relaunchExpectedPath: Self.placedPath, relaunchExpectedVersion: "2.3.0")
+    h.handshake.ackPublishes = false
+    h.coordinator.evaluateAndOfferIfNeeded()
+    await h.coordinator.pendingWork?.value
+    #expect(h.telemetry.completedEvents.isEmpty)
+    // The attempt to publish still happened; only the CLAIM is withheld.
     #expect(h.handshake.writes.count == 1)
   }
 

--- a/Tests/EnviousWisprTests/App/QuarantineStripTests.swift
+++ b/Tests/EnviousWisprTests/App/QuarantineStripTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #2006 — the quarantine strip is THE fix: a translocated bundle carries
+/// `com.apple.quarantine`, `FileManager` copies preserve it, and macOS then
+/// translocates the placed copy again. These tests run against a real temp
+/// bundle tree with real extended attributes, never a simulation of one.
+@Suite("QuarantineStrip")
+struct QuarantineStripTests {
+
+  private static let attr = "com.apple.quarantine"
+  private static let value = "0083;00000000;Safari;"
+
+  private static func setQuarantine(_ url: URL) {
+    _ = url.withUnsafeFileSystemRepresentation { path -> Int32 in
+      guard let path else { return -1 }
+      return Array(value.utf8).withUnsafeBufferPointer {
+        setxattr(path, attr, $0.baseAddress, $0.count, 0, XATTR_NOFOLLOW)
+      }
+    }
+  }
+
+  private static func hasQuarantine(_ url: URL) -> Bool {
+    url.withUnsafeFileSystemRepresentation { path -> Bool in
+      guard let path else { return false }
+      return getxattr(path, attr, nil, 0, 0, XATTR_NOFOLLOW) >= 0
+    }
+  }
+
+  /// A bundle-shaped tree: root, a nested dir, and a nested file.
+  private static func makeBundle() throws -> (root: URL, inner: URL) {
+    let root = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("ew-strip-\(UUID().uuidString).app")
+    let macos = root.appendingPathComponent("Contents/MacOS")
+    try FileManager.default.createDirectory(at: macos, withIntermediateDirectories: true)
+    let inner = macos.appendingPathComponent("EnviousWispr")
+    try Data("binary".utf8).write(to: inner)
+    return (root, inner)
+  }
+
+  @Test("strips the attribute from the root AND every descendant")
+  func stripsRecursively() throws {
+    let (root, inner) = try Self.makeBundle()
+    defer { try? FileManager.default.removeItem(at: root) }
+    Self.setQuarantine(root)
+    Self.setQuarantine(inner)
+    // Positive control: the instrument can SEE the attribute before we strip.
+    #expect(Self.hasQuarantine(root))
+    #expect(Self.hasQuarantine(inner))
+
+    #expect(FileManagerApplicationMover.stripQuarantine(at: root))
+
+    #expect(!Self.hasQuarantine(root))
+    // The nested one is the mutation control: a non-recursive implementation
+    // clears the root, returns true, and leaves the bundle still trapped —
+    // which is exactly the shipped bug wearing a passing test.
+    #expect(!Self.hasQuarantine(inner))
+  }
+
+  @Test("a tree that never carried the attribute is untouched and still succeeds")
+  func cleanTreeSucceeds() throws {
+    let (root, inner) = try Self.makeBundle()
+    defer { try? FileManager.default.removeItem(at: root) }
+    #expect(!Self.hasQuarantine(root))
+
+    #expect(FileManagerApplicationMover.stripQuarantine(at: root))
+
+    #expect(!Self.hasQuarantine(root))
+    #expect(!Self.hasQuarantine(inner))
+    // ENOATTR is success, not failure: a clean bundle must not fail the install.
+    #expect(FileManager.default.fileExists(atPath: inner.path))
+  }
+
+  @Test("a symlink inside the bundle is not followed; its target keeps its attribute")
+  func doesNotFollowSymlinks() throws {
+    let (root, _) = try Self.makeBundle()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let outside = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("ew-strip-outside-\(UUID().uuidString)")
+    try Data("outside".utf8).write(to: outside)
+    defer { try? FileManager.default.removeItem(at: outside) }
+    Self.setQuarantine(outside)
+
+    let link = root.appendingPathComponent("Contents/link")
+    try FileManager.default.createSymbolicLink(at: link, withDestinationURL: outside)
+
+    #expect(FileManagerApplicationMover.stripQuarantine(at: root))
+
+    // XATTR_NOFOLLOW: a link inside our bundle must never be usable to clear
+    // the attribute on a file outside it.
+    #expect(Self.hasQuarantine(outside))
+  }
+}

--- a/Tests/EnviousWisprTests/App/QuarantineStripTests.swift
+++ b/Tests/EnviousWisprTests/App/QuarantineStripTests.swift
@@ -100,6 +100,31 @@ struct QuarantineStripTests {
     #expect(FileManagerApplicationMover.stripQuarantine(at: root))
   }
 
+  @Test("replacing a QUARANTINED destination leaves the placed bundle clean")
+  func replacingAQuarantinedDestinationYieldsACleanBundle() throws {
+    // Cloud review P1 argued FileManager.replaceItemAt could merge the old
+    // destination's quarantine back onto our clean staged bundle. Measured on
+    // APFS 2026-08-10: it does not, with default options or with
+    // .usingNewMetadataOnly. This test LOCKS that platform behaviour, so if a
+    // future macOS changes it we find out here rather than from a user who
+    // cannot update. The mover additionally re-verifies the destination after
+    // placement, so the guarantee does not depend on this behaviour holding.
+    let (dest, _) = try Self.makeBundle()
+    let (stage, _) = try Self.makeBundle()
+    defer {
+      try? FileManager.default.removeItem(at: dest)
+      try? FileManager.default.removeItem(at: stage)
+    }
+    Self.setQuarantine(dest)
+    try #require(Self.hasQuarantine(dest))  // positive control
+    #expect(!Self.hasQuarantine(stage))
+
+    _ = try FileManager.default.replaceItemAt(
+      dest, withItemAt: stage, backupItemName: nil, options: .usingNewMetadataOnly)
+
+    #expect(!Self.hasQuarantine(dest))
+  }
+
   @Test("a symlink inside the bundle is not followed; its target keeps its attribute")
   func doesNotFollowSymlinks() throws {
     let (root, _) = try Self.makeBundle()

--- a/Tests/EnviousWisprTests/App/QuarantineStripTests.swift
+++ b/Tests/EnviousWisprTests/App/QuarantineStripTests.swift
@@ -73,6 +73,33 @@ struct QuarantineStripTests {
     #expect(FileManager.default.fileExists(atPath: inner.path))
   }
 
+  @Test("a CLEAN item we cannot modify still succeeds (probe before removing)")
+  func cleanButUnmodifiableItemSucceeds() throws {
+    // An app in /Applications owned by root or another admin returns EPERM
+    // from `removexattr` EVEN WHEN the attribute is absent. Removing
+    // unconditionally would fail a perfectly clean destination copy and send
+    // its user the wrong message (whole-diff review r3).
+    //
+    // Reproduced WITHOUT root by setting the user-immutable flag, which makes
+    // `removexattr` fail while `getxattr` still reports the attribute absent —
+    // exactly the shape of the ownership case. This is the test that
+    // discriminates the fix: the clean-tree test above passes either way.
+    let (root, inner) = try Self.makeBundle()
+    defer {
+      _ = inner.withUnsafeFileSystemRepresentation { $0.map { chflags($0, 0) } }
+      try? FileManager.default.removeItem(at: root)
+    }
+    #expect(!Self.hasQuarantine(inner))
+    let flagged = inner.withUnsafeFileSystemRepresentation { path -> Bool in
+      guard let path else { return false }
+      return chflags(path, UInt32(UF_IMMUTABLE)) == 0
+    }
+    // Positive control: if the flag did not take, this proves nothing.
+    try #require(flagged)
+
+    #expect(FileManagerApplicationMover.stripQuarantine(at: root))
+  }
+
   @Test("a symlink inside the bundle is not followed; its target keeps its attribute")
   func doesNotFollowSymlinks() throws {
     let (root, _) = try Self.makeBundle()


### PR DESCRIPTION
## What was broken

A user who opens EnviousWispr straight out of Downloads is run by macOS from a randomized read-only mount, and Sparkle then refuses to update them — permanently. We already offer to move ourselves into Applications. **That rescue was failing, and then lying about it.**

The move preserved the bundle's `com.apple.quarantine` attribute, so macOS translocated the **placed copy** again under a fresh UUID. The copy judged itself unhealthy and quit; the original reported `relaunchUnconfirmed` and told the user **"Nothing was changed"** — false, because a working copy was now sitting in Applications. One person accepted the offer four times, was told it failed four times, and stopped using the app.

## Root cause, measured rather than reasoned

Run end to end on the real Developer-ID **v2.4.4 release**, using the shipped app's own ack file as the instrument. Script retained at `docs/audits/2026-08-10-2006-transloc-experiment.sh` so anyone can re-run it.

| Stage | quarantine | ran from | healthy |
|---|---|---|---|
| quarantined download | `0083;…;Safari;` | `AppTranslocation/8E3A…` | false |
| **the translocated mount itself** | **`00c3;…;Safari;`** | — | — |
| placed copy | `02c3;…` | `AppTranslocation/**2D9C…**` | false |
| after recursive strip | none | its real Applications path | **true** |

The second row was the open unknown; it is present. The fourth is the fix. Lab timings (3.29 s fresh / 0.84 s warm / 0.49 s stripped) land on the production bands (successes 3.12/3.27/3.70 s, failures 0.41/0.56/0.65 s) without being fitted to them.

## The change

**The fix.** `stripQuarantine(at:)` removes only `com.apple.quarantine`, recursively, `XATTR_NOFOLLOW`, any other errno fatal — and a traversal error is fatal too, because returning success after skipping an unreadable subtree would report a clean bundle that still carries the attribute. Wired into **both** launch-bearing routes: the fresh copy, and an existing destination copy. The second is not optional — a copy left by a previous failed attempt is still quarantined, which is exactly why every retry failed identically.

We deliberately differ from Sparkle, which does the same removal but treats aggregate failure as advisory (`SUPlainInstaller.m:48-53`). Correct for polishing an already-installed app; wrong here, where stripping *is* the transaction.

**Honest failure.** The handshake returned `Bool`, collapsing four distinct conditions into one label and one untrue sentence. It now returns `RelocationAckOutcome`, evaluated in a load-bearing order (health → exact path → version), and the taxonomy is 17 classes.

**Two user-facing messages, not one per class** (founder decision). A: *nothing usable was moved, drag it yourself.* B: *it is in Applications, only the handoff failed*, with Show in Finder. Routing is **asymmetric on purpose** — B requires positive evidence a verified copy is present, because a wrong B invites someone to open a broken copy while a wrong A costs one redundant drag. `RelocationFailurePresentation` binds message and button so they cannot be mis-paired.

**A false-failure trap avoided.** The expected ack version comes from the mover's resolution, never the running app's own: `.existingUsable` deliberately accepts a same-or-**newer** destination, so comparing against ours would have flagged a valid newer copy as a mismatch and told the user to quit every copy.

**Measurement that answers both questions.** `attempt_id` is minted *before* `relocation_accepted` (it used to be minted later, so nothing could join to it — which is why four accepted attempts in 30 d have no known outcome). `install_resolution` separates a fresh placement from an existing copy. `relocation_completed` has both legitimate emitters: the healthy child, and the parent on existing-running activation, which launches no child at all.

## Testing

5272 tests pass. The strip tests run against a real bundle tree with real extended attributes — not a simulation — with a positive control that the instrument can see the attribute before stripping.

**Mutation-verified.** Disabling the recursion makes the nested-file assertion fail, pointing at exactly the file that would still be tagged. A root-only implementation would look successful, return success, and leave the user just as stuck; it cannot pass this suite.

## Known limits, stated rather than buried

- **The two currently-affected people cannot receive this through the app.** Being translocated is what blocks their updates. This prevents future occurrences; it does not rescue them.
- **In-app end-to-end Live UAT is still owed** and needs a signed build plus a real quarantined download. The §3.0 experiment drove the child directly; it did not exercise the prompt, mover and handshake as one flow.
- **Three production users with `reason=translocated` succeeded**, which a deterministic mechanism says should be impossible on a fresh-copy path. Leading candidate: their destination already held a clean copy, so the mover copied nothing. Today's data cannot distinguish those routes — `install_resolution` is exactly the field that will.

Part of #2006
