### PR TITLE
fix(eval): an incomplete judge result must never read as a complete receipt (Closes #2007, Closes #2008)

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -630,6 +630,24 @@ jobs:
           python3 Tests/RuntimeUAT/ptt_binding.py --self-test
           python3 Tests/RuntimeUAT/faultInjection.py --self-test
 
+      - name: Judge-receipt completeness contract (#2007/#2008)
+        run: |
+          set -euo pipefail
+          # A judge run that dropped work must never read as a complete receipt.
+          # Three layers have to agree: behavior_judge.py detects the gap,
+          # judge_ollama_bench.sh refuses to cache a partial receipt, and
+          # report_ollama_bench.py refuses to rank one. Before #2007 an
+          # adjudication pass that returned NOTHING produced a CLEAR receipt
+          # advertising a recheck it never ran, and the benchmark then cached that
+          # receipt and skipped the model forever while the report refused it.
+          #
+          # Wired into build-check because that is the only REQUIRED check — a
+          # suite no gate invokes reports nothing, so nothing ever looks wrong
+          # (#1965, #2013). Pure stdlib, no network, no judge calls; the suite
+          # asserts its own exact test count, because the runner it borrows from
+          # exits 0 when it discovers zero tests.
+          python3 scripts/eval/behavior_judge_test.py
+
       - name: Require both build lanes
         run: |
           if [ "${{ needs.build-debug.result }}" != "success" ] \

--- a/.gitignore
+++ b/.gitignore
@@ -232,6 +232,13 @@ scripts/eval/parakeet_runner/Package.resolved
 # does.
 !scripts/eval/run_ollama_type_b.py
 !scripts/eval/behavior_judge.py
+# Its self-test suite (#2007/#2008). MUST stay tracked: `build-check` — the only
+# REQUIRED check — invokes it by path, so an ignored copy makes the job fail with
+# "No such file or directory" on every PR, and there is no way to run a gate that
+# is not in the repo. Same reason as the block above, one step further: a
+# gitignored TEST is worse than a gitignored generator, because a green pipeline
+# then means nothing at all.
+!scripts/eval/behavior_judge_test.py
 # `render_bench_prompts.sh` builds this to render each model's REAL production
 # prompt, so without it the benchmark cannot be reproduced at the step that
 # decides WHICH prompt each model was given — the input the whole comparison

--- a/scripts/eval/behavior_judge.py
+++ b/scripts/eval/behavior_judge.py
@@ -61,6 +61,7 @@ import time
 import urllib.request
 import urllib.error
 from collections import Counter, defaultdict
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from statistics import mean
@@ -260,9 +261,68 @@ def judge_chunk(model: str, system: str, payload_cases: list[dict], attempt: int
         return []
 
 
-def run_judge(model: str, system: str, payloads: list[dict], chunk_size: int) -> dict[str, dict]:
-    """Judge all payloads (chunked, threaded). Returns {id: score_obj}. Missing
-    ids (judge dropped them) simply do not appear — callers detect the gap."""
+@dataclass(frozen=True, slots=True)
+class JudgeBatchResult:
+    """One judge batch, reconciled against what was REQUESTED.
+
+    `run_judge` returns this instead of a bare `{id: score}` dict so that no
+    caller can forget to account for what the judge left out. #2007: the primary
+    pass filtered returned ids by hand and the adjudication pass did not, so an
+    adjudication that came back EMPTY produced a `CLEAR` receipt advertising a
+    stability recheck that never ran. A helper the caller must remember to call
+    would have preserved that same bypass, so the accounting lives here, at the
+    boundary the result crosses.
+    """
+
+    accepted: dict[str, dict]   # requested ids the judge returned, in REQUESTED order
+    missing: list[str]          # requested, never came back
+    unexpected: list[str]       # returned but never requested (the judge invented them)
+
+
+def reconcile_judge_batch(raw: dict[str, dict],
+                         requested: list[str]) -> JudgeBatchResult:
+    """Account for every requested id exactly once.
+
+    `accepted` follows REQUESTED order rather than the judge's thread-completion
+    order. That is a deliberate behaviour change: the adjudication sample is
+    drawn with `rng.sample` over `primary`'s key order (`select_adjudication_ids`),
+    so completion order previously leaked thread scheduling into which cases got
+    re-judged. Requested order is what finally makes the fixed seed there mean
+    what its comment claims.
+    """
+    requested = list(dict.fromkeys(str(cid) for cid in requested))
+    requested_set = set(requested)
+    return JudgeBatchResult(
+        accepted={cid: raw[cid] for cid in requested if cid in raw},
+        missing=[cid for cid in requested if cid not in raw],
+        unexpected=[cid for cid in raw if cid not in requested_set],
+    )
+
+
+def batch_counts(batch: JudgeBatchResult, requested_n: int) -> dict:
+    """Persist a batch's reconciliation into the receipt.
+
+    `finalize_new_report` runs at `write_outputs`, where `judged_ids` and the
+    score dicts no longer exist — so the evidence it validates has to be written
+    down here, at the point the batch is actually reconciled.
+    """
+    return {
+        "requested_n": requested_n,
+        "accepted_n": len(batch.accepted),
+        "missing_n": len(batch.missing),
+        "unexpected_n": len(batch.unexpected),
+    }
+
+
+def run_judge(model: str, system: str, payloads: list[dict], chunk_size: int) -> JudgeBatchResult:
+    """Judge all payloads (chunked, threaded), reconciled against the request.
+
+    A dropped id is not an error here — the judge really does omit ids on a
+    syntactically valid response, and `judge_chunk` only retries thrown
+    transient/parse errors. The gap is REPORTED rather than retried (#2014), and
+    reconciling it at this boundary is what stops a caller silently accepting a
+    short answer.
+    """
     chunks = [payloads[i:i + chunk_size] for i in range(0, len(payloads), chunk_size)]
     workers = CLAUDE_JUDGE_MAX_WORKERS if model.startswith(("claude", "sonnet")) else HTTP_JUDGE_MAX_WORKERS
     scores: dict[str, dict] = {}
@@ -278,7 +338,7 @@ def run_judge(model: str, system: str, payloads: list[dict], chunk_size: int) ->
             done += 1
             print(f"  judged chunk {done}/{len(chunks)}  ({len(scores)} scored, {time.time()-start:.0f}s)",
                   file=sys.stderr, flush=True)
-    return scores
+    return reconcile_judge_batch(scores, [str(p["id"]) for p in payloads])
 
 
 # ---------------------------------------------------------------------------
@@ -430,7 +490,20 @@ def partition_candidates(norm_cases: dict, cands: dict) -> tuple[list[str], list
                   if cid in cands and not cands[cid].get("error")
                   and (cands[cid].get("candidate") or "").strip()}
     judged_ids = [cid for cid in norm_cases if cid in judged_set]
-    skipped = [{"id": cid, "reason": "no candidate / engine error",
+
+    def _reason(cid: str) -> str:
+        # THREE distinct causes, named separately. The old catch-all
+        # "no candidate / engine error" hid the one that matters: an EMPTY output
+        # on a SUCCESSFUL call is not an error, so the runner never counts it, and
+        # a consumer reading only the run's error count cannot see it at all. That
+        # let a model be ranked on the subset that did produce output.
+        if cid not in cands:
+            return "absent from the candidates file"
+        if cands[cid].get("error"):
+            return "engine error"
+        return "empty candidate on a successful call (no error reported)"
+
+    skipped = [{"id": cid, "reason": _reason(cid),
                 "error": cands.get(cid, {}).get("error")}
                for cid in norm_cases if cid not in judged_set]
     return judged_ids, skipped
@@ -654,10 +727,16 @@ def score_new(norm_cases: dict, cands: dict, prod: dict | None,
     has_production = prod is not None
     judged_ids, skipped = partition_candidates(norm_cases, cands)
 
+    # Both branches reconcile through the same helper, so `judge_reconciliation`
+    # is present on every path and the finalizer never special-cases a mode.
     if external_verdicts is not None:
         # Subagent-supplied verdicts: no judge calls, nothing to adjudicate.
-        primary = {cid: coerce_new_score(external_verdicts[cid], has_production)
-                  for cid in judged_ids if cid in external_verdicts}
+        primary_batch = reconcile_judge_batch(external_verdicts, judged_ids)
+        adjudication_batch = reconcile_judge_batch({}, [])
+        primary = {cid: coerce_new_score(s, has_production)
+                  for cid, s in primary_batch.accepted.items()}
+        primary_premerge = dict(primary)
+        adjudication: dict[str, dict] = {}
         rep_scores = [primary]
         disagreements: list[dict] = []
         adjudicated_ids: list[str] = []
@@ -666,13 +745,21 @@ def score_new(norm_cases: dict, cands: dict, prod: dict | None,
                                       prod.get(cid) if prod else None)
                     for cid in judged_ids]
         print(f"[new] primary pass over {len(payloads)} cases", file=sys.stderr)
-        raw = run_judge(judge, NEW_JUDGE_SYSTEM, payloads, chunk_size)
-        primary = {cid: coerce_new_score(raw[cid], has_production)
-                  for cid in raw if cid in set(judged_ids)}
+        primary_batch = run_judge(judge, NEW_JUDGE_SYSTEM, payloads, chunk_size)
+        primary = {cid: coerce_new_score(s, has_production)
+                  for cid, s in primary_batch.accepted.items()}
 
         adjudicated_ids = []
-        adjudication: dict[str, dict] = {}
+        adjudication = {}
+        adjudication_batch = reconcile_judge_batch({}, [])
         disagreements = []
+        # Frozen BEFORE the merge below. `rep_scores[0]` must be the ORIGINAL
+        # primary: the merge rebinds `primary[cid]` to the worse of the two
+        # scores, so using the merged dict as rep1 compares adjudication against
+        # itself wherever adjudication was the more severe reading — which is the
+        # only case that changes anything. Measured pre-fix: 12 of 12 cases
+        # disagreeing still reported delta_pp 0.0 and judge_stable PASS.
+        primary_premerge = dict(primary)
         if adjudicate and primary:
             rng = random.Random(1199)  # fixed seed: reproducible sample across runs
             adjudicated_ids = select_adjudication_ids(
@@ -682,9 +769,9 @@ def score_new(norm_cases: dict, cands: dict, prod: dict | None,
                       f"({len(adjudicated_ids)*100//max(len(primary),1)}% of primary)",
                       file=sys.stderr)
                 adj_payloads = [p for p in payloads if p["id"] in set(adjudicated_ids)]
-                adj_raw = run_judge(judge, NEW_JUDGE_SYSTEM, adj_payloads, chunk_size)
-                adjudication = {cid: coerce_new_score(adj_raw[cid], has_production)
-                                for cid in adj_raw}
+                adjudication_batch = run_judge(judge, NEW_JUDGE_SYSTEM, adj_payloads, chunk_size)
+                adjudication = {cid: coerce_new_score(s, has_production)
+                                for cid, s in adjudication_batch.accepted.items()}
                 for cid, adj_score in adjudication.items():
                     if cid not in primary:
                         continue
@@ -697,9 +784,9 @@ def score_new(norm_cases: dict, cands: dict, prod: dict | None,
                             "resolved_verdict": _worse_new_score(primary[cid], adj_score)["verdict"],
                         })
                     primary[cid] = _worse_new_score(primary[cid], adj_score)
-        rep_scores = [primary, adjudication] if adjudicated_ids else [primary]
+        rep_scores = [primary_premerge, adjudication] if adjudicated_ids else [primary]
 
-    missing = [cid for cid in judged_ids if cid not in primary]
+    missing = primary_batch.missing
 
     per_case = []
     for cid in judged_ids:
@@ -711,13 +798,32 @@ def score_new(norm_cases: dict, cands: dict, prod: dict | None,
                          "latencyMs": cands[cid].get("latencyMs")})
 
     report = aggregate_new(per_case, rep_scores, judged_ids, has_production,
-                           missing_count=len(missing), skipped_count=len(skipped))
+                           missing_count=len(missing), skipped_count=len(skipped),
+                           adjudication_missing_count=len(adjudication_batch.missing))
     report["skipped"] = skipped
     report["missing_scores"] = missing
     report["per_case"] = per_case
+    # The evidence `finalize_new_report` validates. It runs at `write_outputs`,
+    # by which point `judged_ids` and the score dicts are gone.
+    report["judge_reconciliation"] = {
+        "primary": batch_counts(primary_batch, len(judged_ids)),
+        "adjudication": batch_counts(adjudication_batch, len(adjudicated_ids)),
+    }
     report["adjudication"] = {
+        # SELECTED, not re-judged. Meaning deliberately unchanged: receipts on
+        # disk already encode it this way (runs/ollama-bench-1950/judged/
+        # gemma2-local/summary.json), and #1950 compares across them.
         "adjudicated_n": len(adjudicated_ids),
+        "rejudged_n": len(adjudication),
+        "adjudication_missing_n": len(adjudication_batch.missing),
+        "adjudication_missing": adjudication_batch.missing[:25],
+        "unexpected_n": len(adjudication_batch.unexpected),
+        # Denominator is the PRIMARY size, not the corpus total, so the name
+        # overstates its own scope on a primary drop. Both terms are stored so a
+        # reader can see what the percentage is actually of.
         "adjudicated_pct_of_total": round(100 * len(adjudicated_ids) / len(primary), 1) if primary else 0.0,
+        "pct_numerator": len(adjudicated_ids),
+        "pct_denominator": len(primary),
         "disagreement_n": len(disagreements),
         "disagreements": disagreements[:25],
     }
@@ -729,7 +835,8 @@ def _is_pass(verdict: str) -> bool:
 
 
 def aggregate_new(per_case: list[dict], rep_scores: list[dict], judged_ids: list[str],
-                  has_production: bool, missing_count: int = 0, skipped_count: int = 0) -> dict:
+                  has_production: bool, missing_count: int = 0, skipped_count: int = 0,
+                  adjudication_missing_count: int = 0) -> dict:
     total = len(per_case)
 
     def rate(items, pred):
@@ -818,28 +925,44 @@ def aggregate_new(per_case: list[dict], rep_scores: list[dict], judged_ids: list
     if len(rep_scores) >= 2:
         judged_set = set(judged_ids)
         common = [cid for cid in judged_ids if cid in rep_scores[0] and cid in rep_scores[1]]
+        coverage = [len(judged_set & set(rs)) for rs in rep_scores]
 
-        def pr(scores):
-            return round(100 * sum(1 for cid in common if _is_pass(scores[cid]["verdict"])) / len(common), 1) \
-                if common else 0.0
-        r1, r2 = pr(rep_scores[0]), pr(rep_scores[1])
-        wobble = {
-            "common_n": len(common),
-            "rep1_pass_rate_pct": r1,
-            "rep2_pass_rate_pct": r2,
-            "delta_pp": round(abs(r1 - r2), 1),
-            "unreliable": abs(r1 - r2) > REP_PASSRATE_DELTA_MAX,
-            "rep_coverage": [len(judged_set & set(rs)) for rs in rep_scores],
-        }
+        if not common:
+            # Nothing was returned by both replications, so there is no stability
+            # answer to give. Reporting delta 0.0 / unreliable False here is what
+            # let an adjudication that returned NOTHING add `judge_stable: PASS`
+            # on zero compared cases (#2007). Omitting `unreliable` makes
+            # `evaluate_new_gate`'s existing `is not None` guard SKIP the check
+            # rather than invent a passing one — the completeness term below is
+            # what actually refuses the run.
+            wobble = {"status": "no comparable cases (no id returned by both replications)",
+                      "common_n": 0, "rep_coverage": coverage}
+        else:
+            def pr(scores):
+                return round(100 * sum(1 for cid in common if _is_pass(scores[cid]["verdict"])) / len(common), 1)
+            r1, r2 = pr(rep_scores[0]), pr(rep_scores[1])
+            wobble = {
+                "common_n": len(common),
+                "rep1_pass_rate_pct": r1,
+                "rep2_pass_rate_pct": r2,
+                "delta_pp": round(abs(r1 - r2), 1),
+                "unreliable": abs(r1 - r2) > REP_PASSRATE_DELTA_MAX,
+                "rep_coverage": coverage,
+            }
     else:
         wobble = {"status": "single replication (no wobble check)"}
 
     # Release gate — apply the conditions for which we have data.
     gate = evaluate_new_gate(overall, smoke_metrics, trap_metrics, wobble, pairwise,
-                             has_production, missing_count, skipped_count)
+                             has_production, missing_count, skipped_count,
+                             adjudication_missing_count)
 
     return {
         "system": "new",
+        # Completeness on its own, independent of the verdict. `BLOCK` takes
+        # precedence over `INCOMPLETE`, so the verdict alone cannot express
+        # "failed AND partial" — which is why keying a cache on it is wrong.
+        "run_complete": gate["run_complete"],
         "overall": overall,
         "per_behavior": per_behavior,
         "trap_metrics": trap_metrics,
@@ -853,7 +976,8 @@ def aggregate_new(per_case: list[dict], rep_scores: list[dict], judged_ids: list
 
 
 def evaluate_new_gate(overall, smoke, traps, wobble, pairwise, has_production,
-                      missing_count=0, skipped_count=0) -> dict:
+                      missing_count=0, skipped_count=0,
+                      adjudication_missing_count=0) -> dict:
     """Apply the proposed release gate. Three-valued verdict:
       BLOCK      — a quality check FAILED (S4 / wobble / pairwise).
       INCOMPLETE — quality clean but the run did not cover every case (engine
@@ -883,10 +1007,16 @@ def evaluate_new_gate(overall, smoke, traps, wobble, pairwise, has_production,
         quality_checks.append({"check": "pairwise_vs_production", "status": "N/A",
                                "detail": "no --production baseline supplied"})
 
-    complete = (missing_count == 0 and skipped_count == 0)
+    # An adjudication drop is a COVERAGE gap, not a quality failure: routing it
+    # into `quality_checks` would report BLOCK and tell the reader a transient
+    # judge omission was a quality regression. This gate's own contract keeps the
+    # two separate so "re-run the gaps" is distinguishable from "real failure".
+    complete = (missing_count == 0 and skipped_count == 0
+                and adjudication_missing_count == 0)
     completeness = {"check": "run_complete", "status": "PASS" if complete else "INCOMPLETE",
-                    "detail": f"{skipped_count} engine-skipped, {missing_count} judge-dropped "
-                              f"(both must be 0 to ship; re-run the gaps)"}
+                    "detail": f"{skipped_count} engine-skipped, {missing_count} judge-dropped, "
+                              f"{adjudication_missing_count} adjudication-dropped "
+                              f"(all must be 0 to ship; re-run the gaps)"}
 
     blocking = [c for c in quality_checks if c["status"] == "FAIL"]
     if blocking:
@@ -897,6 +1027,7 @@ def evaluate_new_gate(overall, smoke, traps, wobble, pairwise, has_production,
         verdict = "CLEAR"
     return {
         "verdict": verdict,
+        "run_complete": complete,
         "checks": quality_checks + [completeness],
         "note": ("Behavior-regression, trap-regression and mixed-regression checks "
                  "require a prior run to diff against; run two builds to enable them."),
@@ -958,8 +1089,11 @@ def score_old(norm_cases: dict, cands: dict, judge: str, reps: int, chunk_size: 
     rep_scores: list[dict[str, dict]] = []
     for rep in range(reps):
         print(f"[old] replication {rep+1}/{reps} over {len(payloads)} cases", file=sys.stderr)
-        raw = run_judge(judge, OLD_JUDGE_SYSTEM, payloads, chunk_size)
-        rep_scores.append({cid: coerce_old_score(raw[cid]) for cid in raw if cid in set(judged_ids)})
+        # Routed through the same boundary. Behaviour-preserving: this call site
+        # already filtered returned ids to `judged_ids` by hand, and `accepted` is
+        # that same set. The point is that the filter is no longer optional.
+        batch = run_judge(judge, OLD_JUDGE_SYSTEM, payloads, chunk_size)
+        rep_scores.append({cid: coerce_old_score(s) for cid, s in batch.accepted.items()})
 
     primary = rep_scores[0]
     missing = [cid for cid in judged_ids if cid not in primary]
@@ -1034,7 +1168,83 @@ def score_old(norm_cases: dict, cands: dict, judge: str, reps: int, chunk_size: 
 # Reporting
 # ---------------------------------------------------------------------------
 
+def finalize_new_report(report: dict) -> None:
+    """Set `report["cacheable"]` — the single acceptance decision BOTH consumers read.
+
+    Why a dedicated field rather than the verdict: `evaluate_new_gate` gives a
+    quality failure precedence over incompleteness, so a run that is both
+    quality-failed AND missing coverage reports `BLOCK`. Any cache or ranking rule
+    keyed on the verdict therefore treats a partial receipt as complete — which is
+    the #2008 defect, and was also the first version of its fix.
+
+    This never rewrites the verdict. Operators read that, and BLOCK-first is right
+    for them; only cacheability stops being derived from it.
+
+    The double computation of completeness is DELIBERATE. `evaluate_new_gate`
+    answers from the counts it was handed; this answers from what was actually
+    written into the receipt, then requires the two to AGREE. That is an
+    independent oracle — one sharing its subject's implementation would only prove
+    the code equals itself. Do not DRY these into one expression.
+    """
+    try:
+        rec = report["judge_reconciliation"]
+        primary, adjudication = rec["primary"], rec["adjudication"]
+        adj = report["adjudication"]
+        overall = report["overall"]
+        # Required reads, never `.get(..., [])`: a defaulted read lets an ABSENT
+        # field masquerade as an empty list, which is the same narrower-than-it-
+        # looks shape this change exists to close. A missing key raises and lands
+        # in the fail-closed handler below.
+        skipped = report["skipped"]
+        per_case = report["per_case"]
+        # Mirrors evaluate_new_gate's own `complete`, so the assertion below is a
+        # genuine cross-check of the gate's answer.
+        expected_complete = (
+            isinstance(skipped, list)
+            and not skipped
+            and primary["missing_n"] == 0
+            and adjudication["missing_n"] == 0
+        )
+        # Cacheability is a DIFFERENT question from completeness, and conflating
+        # them created an endless re-judge loop. An engine error is a terminal
+        # fact about the model — it produced nothing to grade — and no amount of
+        # re-judging repairs it, so a receipt carrying accounted engine skips is a
+        # FINISHED answer. `report_ollama_bench.py` relies on that: it ranks a
+        # partially-erroring model "Not recommended" on the grounds that "a
+        # partial failure IS evidence". Refusing to cache such a receipt would
+        # both re-judge it on every invocation and make that ranking unreachable.
+        #
+        # Only DROPPED JUDGE WORK makes a receipt provisional, because that is the
+        # only part a re-judge can actually fix.
+        judge_work_complete = (
+            primary["missing_n"] == 0 and adjudication["missing_n"] == 0
+        )
+        denominator = adj["pct_denominator"]
+        expected_pct = round(100 * adj["pct_numerator"] / denominator, 1) if denominator else 0.0
+        valid = (
+            primary["requested_n"] == primary["accepted_n"] + primary["missing_n"]
+            and adjudication["requested_n"] == adjudication["accepted_n"] + adjudication["missing_n"]
+            and isinstance(per_case, list)
+            and len(per_case) == overall["total_scored"] == primary["accepted_n"]
+            and adj["adjudicated_n"] == adjudication["requested_n"]
+            and adj["rejudged_n"] == adjudication["accepted_n"]
+            and adj["adjudication_missing_n"] == adjudication["missing_n"]
+            and adj["adjudicated_pct_of_total"] == expected_pct
+            and report.get("run_complete") is expected_complete
+        )
+    except (KeyError, TypeError, ZeroDivisionError):
+        valid = False
+        judge_work_complete = False
+    report["cacheable"] = bool(valid and judge_work_complete)
+
+
 def write_outputs(report: dict, outdir: Path, system: str) -> None:
+    # FIRST, and before the `per_case` pop below: this is the non-bypassable
+    # output boundary, and the row-count check needs `per_case` still on the
+    # report. `old` skips it — that system has no adjudication and no release
+    # gate, and nothing consumes `cacheable` for it.
+    if system == "new":
+        finalize_new_report(report)
     outdir.mkdir(parents=True, exist_ok=True)
     per_case = report.pop("per_case", [])
     if report.get("overall") and report["overall"].get("infra_skipped") is None:
@@ -1095,9 +1305,21 @@ def render_scoreboard(r: dict, system: str) -> str:
         L.append(f"PAIRWISE     : {r.get('pairwise')}")
         adj = r.get("adjudication")
         if adj:
-            L.append(f"ADJUDICATION : re-judged {adj['adjudicated_n']} cases "
-                     f"({adj['adjudicated_pct_of_total']}% of total)  "
-                     f"disagreements={adj['disagreement_n']}")
+            # `adjudicated_n` is cases SELECTED. Saying "re-judged" of it was the
+            # #2007 mislabel: with an empty adjudication it claimed a recheck of
+            # every selected case while none came back.
+            line = (f"ADJUDICATION : selected {adj['adjudicated_n']}, "
+                    f"re-judged {adj.get('rejudged_n', adj['adjudicated_n'])}"
+                    f" ({adj['adjudicated_pct_of_total']}% of primary)  "
+                    f"disagreements={adj['disagreement_n']}")
+            if adj.get("adjudication_missing_n"):
+                line += f"  DROPPED={adj['adjudication_missing_n']}"
+            if adj.get("unexpected_n"):
+                line += f"  unexpected={adj['unexpected_n']}"
+            L.append(line)
+        if r.get("cacheable") is False:
+            L.append("CACHEABLE    : NO — this receipt is partial or internally "
+                     "inconsistent; it must not be cached or ranked")
         g = r.get("release_gate", {})
         L.append("")
         L.append(f"RELEASE GATE : {g.get('verdict')}")
@@ -1222,9 +1444,15 @@ def main() -> int:
     }
     write_outputs(report, Path(args.out), args.system)
 
-    # Exit code: new -> gate verdict; old -> batch verdict. (0 clear/pass, 1 block/fail.)
+    # Exit code: new -> gate verdict AND cacheability; old -> batch verdict.
+    # (0 clear/pass, 1 block/fail.) `cacheable` is required because a CLEAR
+    # verdict that finalization invalidated would otherwise exit 0 and read as a
+    # clean run to every caller of this script.
     if args.system == "new":
-        return 0 if report.get("release_gate", {}).get("verdict") == "CLEAR" else 1
+        return 0 if (
+            report.get("cacheable") is True
+            and report.get("release_gate", {}).get("verdict") == "CLEAR"
+        ) else 1
     return 0 if report.get("overall", {}).get("batch_verdict") == "PASS" else 1
 
 

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -1,0 +1,896 @@
+#!/usr/bin/env python3
+"""Self-tests for the judge-receipt completeness contract (#2007, #2008).
+
+WHAT THIS LOCKS. A judge run that dropped work must never read as a complete
+receipt. Three layers have to agree on that: `behavior_judge.py` must detect the
+gap and say so in the receipt, `judge_ollama_bench.sh` must refuse to cache a
+partial receipt, and `report_ollama_bench.py` must refuse to rank one.
+
+Pure stdlib, no pytest, no network, no judge calls. Run:
+    python3 scripts/eval/behavior_judge_test.py
+
+TWO STUB LAYERS, BOTH CHOSEN SO THE TEST REACHES ITS SUBJECT.
+
+  * Python cases patch `judge_chunk`, NOT `run_judge`. Reconciliation lives
+    INSIDE `run_judge`, so a stub there would bypass the boundary under test and
+    the case would pass having executed none of the code it names. Patching one
+    layer down keeps the real `run_judge`, its threading, and its reconciliation
+    in the path. Verified: the lower stub reproduces every pre-fix defect
+    identically with the real `run_judge` running.
+
+  * Every score case then calls the real `write_outputs`, because `cacheable` is
+    set by `finalize_new_report` from inside it — `score_new` never sets that
+    key, so asserting it off `score_new`'s return would assert a key that does
+    not exist.
+
+  * Shell cases `cp` the real `judge_ollama_bench.sh` into a temp tree rather
+    than reimplementing it; the script derives ROOT from its own location, which
+    is what lets a stub judge be substituted. The stub logs every invocation so
+    "was it re-judged" is a COUNT — a marker file alone lets a second run pass
+    without invoking anything.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import traceback
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts" / "eval"))
+
+import behavior_judge as bj  # noqa: E402
+
+SHELL = ROOT / "scripts" / "eval" / "judge_ollama_bench.sh"
+REPORT = ROOT / "scripts" / "eval" / "report_ollama_bench.py"
+
+
+# --------------------------------------------------------------------------- #
+# fixtures                                                                    #
+# --------------------------------------------------------------------------- #
+
+def corpus(n=12):
+    norm, cands = {}, {}
+    for i in range(n):
+        cid = f"C{i:02d}"
+        norm[cid] = bj.normalize_case({
+            "id": cid, "behavior": "grammar_fix",
+            "asr_input": f"this is case {i} what a test",
+            "expected_output": f"This is case {i}. What a test."})
+        cands[cid] = {"candidate": f"This is case {i}. What a test.", "latencyMs": 10}
+    return norm, cands
+
+
+def score(cid, verdict="pass", sev="S0"):
+    return {"id": cid, "verdict": verdict, "severity": sev, "behavior_correct": True,
+            "clean_output": True, "meaning_preserved": True, "failure_types": [],
+            "changed_or_missing_content": [], "pairwise_vs_production": "not_available"}
+
+
+def run_score_new(primary_items=None, adj_items=None, n=12, **kw):
+    """Real `score_new` + real `write_outputs`, with `judge_chunk` stubbed.
+
+    Returns the receipt AS WRITTEN, not the in-memory report: `write_outputs`
+    mutates it (pops `per_case`, fills `infra_skipped`), so asserting on the dict
+    afterwards would assert on a different object than a consumer reads.
+    """
+    norm, cands = corpus(n)
+    passes = {"n": 0}
+    real = bj.judge_chunk
+
+    def stub(model, system, payload_cases, attempt=1):
+        ids = [str(c["id"]) for c in payload_cases]
+        passes["n"] += 1
+        if passes["n"] == 1:
+            return [score(c) for c in ids] if primary_items is None else primary_items(ids)
+        return [] if adj_items is None else adj_items(ids)
+
+    bj.judge_chunk = stub
+    try:
+        report = bj.score_new(norm, cands, None, "stub-judge", 50, None, **kw)
+    finally:
+        bj.judge_chunk = real
+
+    with tempfile.TemporaryDirectory() as td:
+        bj.write_outputs(report, Path(td), "new")
+        return json.loads((Path(td) / "summary.json").read_text())
+
+
+def checks_of(receipt):
+    return {c["check"]: c["status"] for c in receipt["release_gate"]["checks"]}
+
+
+STUB_JUDGE = '''\
+import sys, json, pathlib
+a = sys.argv
+out = a[a.index("--out") + 1]
+d = pathlib.Path(out); d.mkdir(parents=True, exist_ok=True)
+(d.parent / "_invocations").open("a").write("call\\n")
+mode = {mode!r}
+if mode == "noreceipt":
+    sys.exit(1)
+if mode == "nonobject":
+    (d / "summary.json").write_text("[1,2,3]")
+    sys.exit(1)
+if mode == "badjson":
+    (d / "summary.json").write_text("{{not json")
+    sys.exit(1)
+r = {{"release_gate": {{"verdict": "BLOCK"}}, "skipped": [], "missing_scores": []}}
+if mode == "true":
+    r["cacheable"] = True
+elif mode == "false":
+    r["cacheable"] = False
+json.dump(r, open(d / "summary.json", "w"))
+sys.exit(0 if mode == "true" else 1)
+'''
+
+
+def shell_tree(mode):
+    """A temp ROOT holding a byte copy of the real script plus a stub judge."""
+    t = Path(tempfile.mkdtemp())
+    (t / "scripts" / "eval").mkdir(parents=True)
+    (t / "cand").mkdir()
+    (t / "judged").mkdir()
+    (t / "scripts" / "eval" / "judge_ollama_bench.sh").write_bytes(SHELL.read_bytes())
+    (t / "scripts" / "eval" / "behavior_judge.py").write_text(STUB_JUDGE.format(mode=mode))
+    (t / "cand" / "modelA.jsonl").write_text('{"id":"A","candidate":"x"}\n')
+    (t / "corpus.jsonl").write_text('{"id":"A"}\n')
+    return t
+
+
+def run_shell(t, env=None):
+    p = subprocess.run(
+        ["bash", str(t / "scripts" / "eval" / "judge_ollama_bench.sh"),
+         str(t / "corpus.jsonl"), str(t / "cand"), str(t / "judged")],
+        capture_output=True, text=True, env=env)
+    return p.returncode, p.stdout + p.stderr
+
+
+def invocations(t):
+    f = t / "judged" / "_invocations"
+    return len(f.read_text().splitlines()) if f.exists() else 0
+
+
+def stamped(t):
+    return (t / "judged" / "modelA" / ".inputs-sha256").exists()
+
+
+def report_tree(receipt, per_case_rows=None):
+    """Fixtures for report_ollama_bench.py with a caller-chosen receipt."""
+    t = Path(tempfile.mkdtemp())
+    (t / "judged" / "modelA").mkdir(parents=True)
+    (t / "corpus.jsonl").write_text(
+        '{"id":"EN-1","input_source":"generated","asr_input":"a","expected_output":"A."}\n'
+        '{"id":"INT-1","input_source":"hand_written_international","asr_input":"b","expected_output":"B."}\n')
+    (t / "run-summary.json").write_text(json.dumps({"corpus": "corpus.jsonl", "models": [{
+        "model": "modelA", "candidates": str(t / "cand" / "modelA.jsonl"), "isRemote": False,
+        "thinks": False, "thinkSent": False, "parameterSize": "4B", "quantization": "Q4",
+        "errors": 0, "cases": 2, "latencyMsMedian": 100, "latencyMsMean": 100,
+        "latencyMsMax": 100, "overDeadline": 0, "warm": ""}]}))
+    (t / "judged" / "modelA" / "summary.json").write_text(json.dumps(receipt))
+    rows = per_case_rows if per_case_rows is not None else [
+        {"id": "EN-1", "verdict": "pass", "severity": "S0", "behavior": "grammar_fix", "failure_types": []},
+        {"id": "INT-1", "verdict": "pass", "severity": "S0", "behavior": "language_preservation", "failure_types": []}]
+    (t / "judged" / "modelA" / "per_case.jsonl").write_text(
+        "".join(json.dumps(r) + "\n" for r in rows))
+    return t
+
+
+def healthy_receipt(**over):
+    r = {"release_gate": {"verdict": "CLEAR", "checks": []}, "cacheable": True,
+         "run_complete": True, "skipped": [], "missing_scores": [],
+         "adjudication": {"adjudication_missing_n": 0},
+         "overall": {"total_scored": 2, "infra_skipped": 0, "pass_rate_pct": 100.0,
+                     "critical_fail_count": 0, "severity_breakdown": {"S0": 2},
+                     "failure_type_counts": {}}}
+    r.update(over)
+    return r
+
+
+def run_report(t):
+    p = subprocess.run(
+        [sys.executable, str(REPORT), "--run-summaries", str(t / "run-summary.json"),
+         "--judged", str(t / "judged"), "--corpus", str(t / "corpus.jsonl"),
+         "--out", str(t / "report.md")],
+        capture_output=True, text=True)
+    return p.returncode, p.stdout + p.stderr
+
+
+# --------------------------------------------------------------------------- #
+# the reconciliation boundary                                                 #
+# --------------------------------------------------------------------------- #
+
+def test_reconcile_accepted_follows_requested_order():
+    b = bj.reconcile_judge_batch({"B": {"id": "B"}, "A": {"id": "A"}}, ["A", "B"])
+    assert list(b.accepted) == ["A", "B"], b.accepted
+
+
+def test_reconcile_reports_missing():
+    b = bj.reconcile_judge_batch({"A": {"id": "A"}}, ["A", "B", "C"])
+    assert b.missing == ["B", "C"], b.missing
+
+
+def test_reconcile_reports_unexpected():
+    b = bj.reconcile_judge_batch({"A": {"id": "A"}, "Z": {"id": "Z"}}, ["A"])
+    assert b.unexpected == ["Z"], b.unexpected
+    assert "Z" not in b.accepted
+
+
+def test_reconcile_dedupes_requested():
+    b = bj.reconcile_judge_batch({"A": {"id": "A"}}, ["A", "A", "B", "B"])
+    assert list(b.accepted) == ["A"] and b.missing == ["B"], (b.accepted, b.missing)
+
+
+# --------------------------------------------------------------------------- #
+# an adjudication gap makes the run incomplete                                #
+# --------------------------------------------------------------------------- #
+
+def test_empty_adjudication_is_incomplete():
+    r = run_score_new(adj_items=lambda ids: [])
+    assert r["release_gate"]["verdict"] == "INCOMPLETE", r["release_gate"]["verdict"]
+    assert r["run_complete"] is False
+
+
+def test_empty_adjudication_is_not_cacheable():
+    assert run_score_new(adj_items=lambda ids: [])["cacheable"] is False
+
+
+def test_empty_adjudication_omits_judge_stable():
+    # The defect: delta 0.0 over zero compared cases was reported as PASS.
+    # Absent is correct — completeness is what refuses the run, not quality.
+    r = run_score_new(adj_items=lambda ids: [])
+    assert "judge_stable" not in checks_of(r), checks_of(r)
+    assert r["wobble"]["common_n"] == 0
+
+
+def test_empty_adjudication_counts_every_selected_case_as_dropped():
+    a = run_score_new(adj_items=lambda ids: [])["adjudication"]
+    assert a["rejudged_n"] == 0
+    assert a["adjudication_missing_n"] == a["adjudicated_n"] > 0, a
+
+
+def test_partial_adjudication_is_incomplete():
+    r = run_score_new(adj_items=lambda ids: [score(c) for c in ids[: len(ids) // 2]])
+    assert r["release_gate"]["verdict"] == "INCOMPLETE"
+    assert r["cacheable"] is False
+
+
+def test_partial_adjudication_compares_only_returned_cases():
+    r = run_score_new(adj_items=lambda ids: [score(c) for c in ids[: len(ids) // 2]])
+    a = r["adjudication"]
+    assert r["wobble"]["common_n"] == a["rejudged_n"] < a["adjudicated_n"], (r["wobble"], a)
+
+
+# --------------------------------------------------------------------------- #
+# two-way controls: a COMPLETE run must still behave                          #
+# --------------------------------------------------------------------------- #
+
+def test_full_agreeing_adjudication_is_clear_and_cacheable():
+    # Without this, an implementation that marks EVERYTHING incomplete passes
+    # every case above.
+    r = run_score_new(adj_items=lambda ids: [score(c) for c in ids])
+    assert r["release_gate"]["verdict"] == "CLEAR", r["release_gate"]["verdict"]
+    assert r["cacheable"] is True and r["run_complete"] is True
+
+
+def test_full_agreeing_adjudication_judge_stable_passes():
+    r = run_score_new(adj_items=lambda ids: [score(c) for c in ids])
+    assert checks_of(r).get("judge_stable") == "PASS", checks_of(r)
+    assert r["wobble"]["delta_pp"] == 0.0
+
+
+def test_full_agreeing_adjudication_rejudged_equals_selected():
+    a = run_score_new(adj_items=lambda ids: [score(c) for c in ids])["adjudication"]
+    assert a["rejudged_n"] == a["adjudicated_n"] and a["adjudication_missing_n"] == 0, a
+
+
+# --------------------------------------------------------------------------- #
+# the wobble comparison must see real disagreement                            #
+# --------------------------------------------------------------------------- #
+
+def test_total_disagreement_fails_judge_stable():
+    # Pre-fix this reported delta_pp 0.0 and judge_stable PASS, because rep1 was
+    # the POST-merge primary and the merge had already adopted adjudication's
+    # worse score — so the two reps were identical by construction.
+    r = run_score_new(adj_items=lambda ids: [score(c, "major_fail", "S3") for c in ids])
+    assert checks_of(r).get("judge_stable") == "FAIL", checks_of(r)
+    assert r["wobble"]["delta_pp"] > 0.0, r["wobble"]
+
+
+def test_total_disagreement_blocks_but_stays_cacheable():
+    # A failing quality check blocks; coverage was still COMPLETE, so the receipt
+    # is a finished answer and must remain cacheable. Re-judging a BLOCK forever
+    # is #2008 inverted.
+    r = run_score_new(adj_items=lambda ids: [score(c, "major_fail", "S3") for c in ids])
+    assert r["release_gate"]["verdict"] == "BLOCK", r["release_gate"]["verdict"]
+    assert r["run_complete"] is True and r["cacheable"] is True
+
+
+def test_disagreement_resolves_to_the_worse_score():
+    r = run_score_new(adj_items=lambda ids: [score(c, "major_fail", "S3") for c in ids])
+    assert r["overall"]["verdict_breakdown"] == {"major_fail": 12}, r["overall"]
+    assert r["adjudication"]["disagreement_n"] == 12
+
+
+# --------------------------------------------------------------------------- #
+# stray ids, primary drops, and the modes that have no adjudication           #
+# --------------------------------------------------------------------------- #
+
+def test_stray_adjudication_id_is_excluded_and_counted():
+    def adj(ids):
+        return [score(c) for c in ids] + [score("NOT-A-REAL-ID")]
+    a = run_score_new(adj_items=adj)["adjudication"]
+    assert a["unexpected_n"] == 1, a
+    assert a["rejudged_n"] == a["adjudicated_n"], a
+
+
+def test_primary_drop_is_still_reported():
+    r = run_score_new(primary_items=lambda ids: [score(c) for c in ids[:-2]],
+                      adj_items=lambda ids: [score(c) for c in ids])
+    assert len(r["missing_scores"]) == 2, r["missing_scores"]
+    assert r["release_gate"]["verdict"] == "INCOMPLETE"
+    assert r["cacheable"] is False
+
+
+def test_engine_errors_are_incomplete_but_still_cacheable():
+    """An engine error is terminal, so its receipt is a FINISHED answer.
+
+    Whole-diff review P2: making a receipt non-cacheable on engine skips put the
+    benchmark in an endless re-judge loop — judging cannot repair a model that
+    produced nothing to grade — and made `report_ollama_bench.py`'s deliberate
+    "a partial failure IS evidence" ranking unreachable. Only DROPPED JUDGE WORK
+    makes a receipt provisional.
+    """
+    norm, cands = corpus(6)
+    cands["C00"] = {"error": "connection refused", "candidate": ""}   # engine failure
+    real = bj.judge_chunk
+    bj.judge_chunk = lambda m, s, cs, attempt=1: [score(str(c["id"])) for c in cs]
+    try:
+        report = bj.score_new(norm, cands, None, "stub", 50, None)
+    finally:
+        bj.judge_chunk = real
+    with tempfile.TemporaryDirectory() as td:
+        bj.write_outputs(report, Path(td), "new")
+        r = json.loads((Path(td) / "summary.json").read_text())
+
+    assert len(r["skipped"]) == 1, r["skipped"]
+    assert r["run_complete"] is False, "coverage genuinely is incomplete"
+    assert r["release_gate"]["verdict"] == "INCOMPLETE", r["release_gate"]["verdict"]
+    assert r["cacheable"] is True, \
+        "an engine error is terminal — re-judging cannot fix it, so the receipt must cache"
+
+
+def test_report_accepts_an_incomplete_but_cacheable_receipt():
+    """The other half of the P2: `INCOMPLETE` must not be refused outright.
+
+    Scope, stated precisely rather than overclaimed: this proves the receipt
+    reaches ranking at all. It does NOT assert the tier, because that is decided
+    from the RUN summary's own error count, not from this receipt — asserting
+    "Not recommended" here would need a fixture satisfying the report's separate
+    scored/skipped reconciliation, which is a different contract.
+    """
+    # The fixture must carry `error` and a matching run error count, because that
+    # is what the runner really writes. An earlier version of this fixture omitted
+    # `error` — thinner than production — and the per-entry attribution check
+    # correctly refused it. Fix the fixture, never the check.
+    t = _errors_tree(healthy_receipt(cacheable=True, run_complete=False,
+                                     release_gate={"verdict": "INCOMPLETE", "checks": []}),
+                     cases=3, errors=1, scored=2, infra_skipped=1,
+                     skipped_reason="engine error")
+    rc, out = run_report(t)
+    assert rc == 0, out
+    # And the complement: a judge-dropped receipt is still refused, so admitting
+    # INCOMPLETE did not open a hole.
+    t2 = report_tree(healthy_receipt(
+        cacheable=False, run_complete=False,
+        release_gate={"verdict": "INCOMPLETE", "checks": []},
+        missing_scores=["C1", "C2"]))
+    rc2, out2 = run_report(t2)
+    assert rc2 == 2, out2
+
+
+def test_no_adjudicate_invents_no_gap():
+    r = run_score_new(adj_items=lambda ids: [], adjudicate=False)
+    assert r["release_gate"]["verdict"] == "CLEAR", r["release_gate"]["verdict"]
+    assert r["cacheable"] is True
+    a = r["adjudication"]
+    assert a["adjudicated_n"] == a["rejudged_n"] == a["adjudication_missing_n"] == 0, a
+
+
+def test_external_verdicts_invent_no_gap():
+    norm, cands = corpus(6)
+    ext = {cid: score(cid) for cid in norm}
+    report = bj.score_new(norm, cands, None, "unused", 50, ext)
+    with tempfile.TemporaryDirectory() as td:
+        bj.write_outputs(report, Path(td), "new")
+        r = json.loads((Path(td) / "summary.json").read_text())
+    assert r["release_gate"]["verdict"] == "CLEAR", r["release_gate"]["verdict"]
+    assert r["cacheable"] is True
+    assert r["judge_reconciliation"]["adjudication"]["requested_n"] == 0
+
+
+# --------------------------------------------------------------------------- #
+# the gate term, in isolation                                                 #
+# --------------------------------------------------------------------------- #
+
+def _gate(**kw):
+    overall = {"critical_fail_count": 0}
+    smoke = {"s4_count": 0, "n": 0, "critical_loss_count": 0}
+    return bj.evaluate_new_gate(overall, smoke, {}, {"status": "single"}, {},
+                                False, **kw)
+
+
+def test_gate_adjudication_gap_alone_flips_clear_to_incomplete():
+    assert _gate()["verdict"] == "CLEAR"
+    assert _gate(adjudication_missing_count=1)["verdict"] == "INCOMPLETE"
+
+
+def test_gate_adjudication_gap_never_blocks():
+    g = _gate(adjudication_missing_count=5)
+    assert g["verdict"] != "BLOCK", g
+    assert g["run_complete"] is False
+    assert [c for c in g["checks"] if c["check"] == "run_complete"][0]["status"] == "INCOMPLETE"
+
+
+def test_gate_reports_all_three_gap_kinds_in_its_detail():
+    detail = [c for c in _gate(missing_count=1, skipped_count=2,
+                               adjudication_missing_count=3)["checks"]
+              if c["check"] == "run_complete"][0]["detail"]
+    for want in ("2 engine-skipped", "1 judge-dropped", "3 adjudication-dropped"):
+        assert want in detail, (want, detail)
+
+
+def test_quality_fail_plus_gap_blocks_and_is_not_cacheable():
+    # BLOCK outranks INCOMPLETE, which is exactly why cacheability cannot be
+    # inferred from the verdict. This is the case the first fix would have
+    # stamped as a complete gate-failure.
+    r = run_score_new(primary_items=lambda ids: [score(c, "critical_fail", "S4") for c in ids],
+                      adj_items=lambda ids: [])
+    assert r["release_gate"]["verdict"] == "BLOCK", r["release_gate"]["verdict"]
+    assert r["run_complete"] is False and r["cacheable"] is False
+
+
+# --------------------------------------------------------------------------- #
+# the finalizer                                                               #
+# --------------------------------------------------------------------------- #
+
+def test_finalizer_rejects_a_rowcount_mismatch_without_touching_the_verdict():
+    norm, cands = corpus(6)
+    real = bj.judge_chunk
+    bj.judge_chunk = lambda m, s, cs, attempt=1: [score(str(c["id"])) for c in cs]
+    try:
+        report = bj.score_new(norm, cands, None, "stub", 50, None, adjudicate=False)
+    finally:
+        bj.judge_chunk = real
+    report["per_case"] = report["per_case"][:-1]          # truncate the detail rows
+    before = report["release_gate"]["verdict"]
+    bj.finalize_new_report(report)
+    assert report["cacheable"] is False
+    assert report["release_gate"]["verdict"] == before, "the finalizer must not rewrite the verdict"
+
+
+def test_finalizer_fails_closed_on_missing_required_fields():
+    for field in ("skipped", "per_case", "judge_reconciliation", "adjudication", "overall"):
+        norm, cands = corpus(4)
+        real = bj.judge_chunk
+        bj.judge_chunk = lambda m, s, cs, attempt=1: [score(str(c["id"])) for c in cs]
+        try:
+            report = bj.score_new(norm, cands, None, "stub", 50, None, adjudicate=False)
+        finally:
+            bj.judge_chunk = real
+        report.pop(field)
+        bj.finalize_new_report(report)
+        assert report["cacheable"] is False, f"absent {field} must fail closed, not default to empty"
+
+
+# --------------------------------------------------------------------------- #
+# the old system is unchanged                                                 #
+# --------------------------------------------------------------------------- #
+
+def test_score_old_still_drops_unreturned_ids_the_same_way():
+    norm, cands = corpus(6)
+    real = bj.judge_chunk
+
+    def stub(model, system, payload_cases, attempt=1):
+        ids = [str(c["id"]) for c in payload_cases]
+        return [{"id": c, "accuracy": 3, "conciseness": 3, "fluency": 3,
+                 "format": 3, "regression": 2} for c in ids[:-1]]
+
+    bj.judge_chunk = stub
+    try:
+        report = bj.score_old(norm, cands, "stub", 1, 50)
+    finally:
+        bj.judge_chunk = real
+    assert len(report["missing_scores"]) == 1, report["missing_scores"]
+    assert report["overall"]["total_scored"] == 5, report["overall"]
+
+
+# --------------------------------------------------------------------------- #
+# the exit code                                                               #
+# --------------------------------------------------------------------------- #
+
+def _run_main(force_cacheable):
+    """Drive the real `main()` end to end, forcing only the finalizer's answer.
+
+    Behavioural, not a source grep: the point is what the PROCESS returns. A
+    CLEAR verdict whose finalization failed must not exit 0, because every caller
+    of this script reads that status.
+    """
+    t = Path(tempfile.mkdtemp())
+    rows = [{"id": f"C{i}", "behavior": "grammar_fix", "asr_input": f"case {i} here",
+             "expected_output": f"Case {i} here."} for i in range(4)]
+    (t / "corpus.jsonl").write_text("".join(json.dumps(r) + "\n" for r in rows))
+    (t / "cand.jsonl").write_text("".join(
+        json.dumps({"id": r["id"], "candidate": r["expected_output"], "latencyMs": 5}) + "\n"
+        for r in rows))
+
+    real_chunk, real_final, real_argv = bj.judge_chunk, bj.finalize_new_report, sys.argv
+    real_preflight = bj.preflight_judge
+
+    def forced(report):
+        real_final(report)
+        report["cacheable"] = force_cacheable
+
+    bj.judge_chunk = lambda m, s, cs, attempt=1: [score(str(c["id"])) for c in cs]
+    bj.finalize_new_report = forced
+    # `main()` runs `preflight_judge` BEFORE any scoring, and that calls the real
+    # `call_claude` — stubbing `judge_chunk` does not prevent it. On a machine with
+    # the Claude CLI logged in it silently succeeds; in CI there is no CLI, so it
+    # does `sys.exit(2)` and takes the whole suite down. This test is about the
+    # exit code, not about judge availability.
+    bj.preflight_judge = lambda model: None
+    sys.argv = ["behavior_judge.py", "--system", "new", "--corpus", str(t / "corpus.jsonl"),
+                "--candidates", str(t / "cand.jsonl"), "--out", str(t / "out"),
+                "--no-adjudicate"]
+    try:
+        rc = bj.main()
+    finally:
+        bj.judge_chunk, bj.finalize_new_report, sys.argv = real_chunk, real_final, real_argv
+        bj.preflight_judge = real_preflight
+    verdict = json.loads((t / "out" / "summary.json").read_text())["release_gate"]["verdict"]
+    return rc, verdict
+
+
+def test_main_does_not_require_a_judge_cli_to_be_installed():
+    """CI has no Claude CLI, and `main()` preflights one before scoring.
+
+    `preflight_judge` calls the real `call_claude` and does `sys.exit(2)` when it
+    fails, so stubbing `judge_chunk` is not enough — and `SystemExit` is not an
+    `Exception`, so an unstubbed preflight killed the whole suite mid-run with no
+    summary. The `build-check` job caught this; no local run could, because this
+    machine has the CLI logged in. This case locks the stub so the two exit-code
+    tests keep working on a runner without it.
+    """
+    import inspect
+    src = inspect.getsource(_run_main)
+    assert "bj.preflight_judge = lambda" in src, \
+        "main()-driving tests must stub preflight_judge or they exit 2 on a runner with no Claude CLI"
+    assert "real_preflight" in src, "and must restore it afterwards"
+
+
+def test_exit_zero_on_a_clear_and_cacheable_run():
+    rc, verdict = _run_main(force_cacheable=True)
+    assert verdict == "CLEAR" and rc == 0, (verdict, rc)
+
+
+def test_exit_nonzero_when_clear_but_not_cacheable():
+    rc, verdict = _run_main(force_cacheable=False)
+    assert verdict == "CLEAR", f"the control needs a CLEAR verdict to be meaningful, got {verdict}"
+    assert rc != 0, "a CLEAR run that finalization invalidated must not exit 0"
+
+
+# --------------------------------------------------------------------------- #
+# judge_ollama_bench.sh                                                       #
+# --------------------------------------------------------------------------- #
+
+def test_shell_refuses_to_stamp_a_not_cacheable_receipt():
+    t = shell_tree("false")
+    rc, out = run_shell(t)
+    assert rc != 0, out
+    assert not stamped(t), "a partial receipt must not be cached"
+    assert "INCOMPLETE modelA" in out, out
+
+
+def test_shell_resume_path_rejudges_a_stamped_not_cacheable_arm():
+    # The already-poisoned-arm recovery case. The resume fast path used to
+    # `continue` on a matching stamp without ever reading completeness, so every
+    # arm this bug had already stamped stayed skipped forever.
+    t = shell_tree("false")
+    run_shell(t)
+    d = t / "judged" / "modelA"
+    d.mkdir(parents=True, exist_ok=True)
+    receipt = d / "summary.json"
+    if not receipt.exists():
+        receipt.write_text(json.dumps({"cacheable": False, "release_gate": {"verdict": "BLOCK"}}))
+
+    # Forge a stamp that genuinely MATCHES, so the fast path is entered and only
+    # the cacheability check can stop the skip. Computed exactly as the script
+    # does — over the same absolute argv paths, since the hash covers filenames.
+    # Without this the stamp is absent, the fast path is never reached, and the
+    # case would pass while testing the stale-inputs branch instead.
+    forged = subprocess.run(
+        ["bash", "-c",
+         'if command -v shasum >/dev/null 2>&1; then H="shasum -a 256"; else H=sha256sum; fi; '
+         f'$H "{t / "cand" / "modelA.jsonl"}" "{t / "corpus.jsonl"}" | $H | cut -d" " -f1'],
+        capture_output=True, text=True).stdout.strip()
+    assert forged, "could not compute a stamp"
+    (d / ".inputs-sha256").write_text(forged + "\n")
+
+    # Control: prove the forged stamp really would have caused a skip. Flip the
+    # receipt to cacheable and confirm the arm IS skipped.
+    receipt.write_text(json.dumps({"cacheable": True, "release_gate": {"verdict": "BLOCK"}}))
+    baseline = invocations(t)
+    _, skip_log = run_shell(t)
+    assert invocations(t) == baseline, \
+        f"the forged stamp does not match, so this case proves nothing: {skip_log}"
+
+    # Now the real assertion: same matching stamp, not-cacheable receipt.
+    receipt.write_text(json.dumps({"cacheable": False, "release_gate": {"verdict": "BLOCK"}}))
+    before = invocations(t)
+    rc, log = run_shell(t)
+    assert invocations(t) > before, f"the arm must be re-judged, not skipped: {log}"
+    assert "not cacheable" in log, log
+
+
+def test_shell_absent_cacheable_field_is_not_stamped():
+    # Every receipt written before #2007 lacks the field.
+    t = shell_tree("absent")
+    rc, out = run_shell(t)
+    assert not stamped(t), out
+    assert rc != 0, out
+
+
+def test_shell_stamps_a_complete_block_receipt_and_then_skips_it():
+    # The two-way control. A graded-but-failed run IS complete; refusing to cache
+    # it would re-judge every weak model forever.
+    t = shell_tree("true")
+    rc, out = run_shell(t)
+    assert rc == 0, out
+    assert stamped(t), out
+    first = invocations(t)
+    run_shell(t)
+    assert invocations(t) == first, "a cacheable arm must not be re-judged"
+
+
+def test_shell_malformed_receipts_all_fail_closed():
+    for mode, want in (("nonobject", "not stamped"), ("badjson", "not stamped"),
+                       ("noreceipt", "FAILED")):
+        t = shell_tree(mode)
+        rc, out = run_shell(t)
+        assert rc != 0, (mode, out)
+        assert not stamped(t), (mode, out)
+        assert "Traceback" not in out, (mode, "a malformed receipt must not print a traceback")
+        if want == "FAILED":
+            assert "FAILED modelA" in out, (mode, out)
+
+
+def test_shell_sha256_shim_produces_an_identical_stamp():
+    # Both arms MUST run in the SAME tree: the hash covers `hash  filename`, so
+    # two temp dirs differ for a reason unrelated to the shim.
+    t = shell_tree("true")
+    run_shell(t)
+    with_shasum = (t / "judged" / "modelA" / ".inputs-sha256").read_text()
+    subprocess.run(["rm", "-rf", str(t / "judged" / "modelA")], check=True)
+
+    shim = Path(tempfile.mkdtemp())
+    for cmd in ("python3", "grep", "basename", "dirname", "cat", "mkdir", "rm",
+                "printf", "cut", "sha256sum", "bash", "sed", "ls", "env"):
+        found = subprocess.run(["bash", "-c", f"command -v {cmd}"],
+                               capture_output=True, text=True).stdout.strip()
+        if found:
+            os.symlink(found, shim / cmd)
+    if not (shim / "sha256sum").exists():
+        return  # no coreutils name available here; the shim's other arm is what ships
+    env = dict(os.environ, PATH=str(shim))
+    assert subprocess.run(["bash", "-c", "command -v shasum"], env=env,
+                          capture_output=True).returncode != 0, "the shim must really hide shasum"
+    run_shell(t, env=env)
+    without = (t / "judged" / "modelA" / ".inputs-sha256").read_text()
+    assert with_shasum == without, (with_shasum, without)
+
+
+# --------------------------------------------------------------------------- #
+# report_ollama_bench.py                                                      #
+# --------------------------------------------------------------------------- #
+
+def test_report_refuses_an_unknown_verdict():
+    # Pre-fix this was ranked #1 and labelled "Recommended", exit 0.
+    t = report_tree(healthy_receipt(release_gate={"verdict": "WEIRD_UNKNOWN", "checks": []}))
+    rc, out = run_report(t)
+    assert rc == 2, out
+    assert "not cacheable" in out, out
+
+
+def test_report_refuses_clear_but_not_cacheable():
+    t = report_tree(healthy_receipt(cacheable=False))
+    rc, out = run_report(t)
+    assert rc == 2, out
+
+
+def test_report_names_the_adjudication_gap():
+    t = report_tree(healthy_receipt(
+        cacheable=False, run_complete=False,
+        release_gate={"verdict": "INCOMPLETE", "checks": []},
+        adjudication={"adjudication_missing_n": 7}))
+    rc, out = run_report(t)
+    assert rc == 2, out
+    assert "7 adjudication-dropped" in out, out
+
+
+def test_report_accepts_a_healthy_receipt():
+    t = report_tree(healthy_receipt())
+    rc, out = run_report(t)
+    assert rc == 0, out
+
+
+def _errors_tree(receipt, cases, errors, scored, infra_skipped, skipped_reason):
+    """A report fixture where the RUN's counts and the RECEIPT's counts are set
+    independently, which is the whole point: the two disagreeing is the defect."""
+    t = report_tree(receipt)
+    run = json.loads((t / "run-summary.json").read_text())
+    run["models"][0]["cases"] = cases
+    run["models"][0]["errors"] = errors
+    (t / "run-summary.json").write_text(json.dumps(run))
+    s = json.loads((t / "judged" / "modelA" / "summary.json").read_text())
+    s["overall"]["total_scored"] = scored
+    s["overall"]["infra_skipped"] = infra_skipped
+    # `error` is what the report attributes a skip by, so the fixture must carry it
+    # exactly as the runner would: set for a genuine engine error, ABSENT for an
+    # empty-but-successful call.
+    is_engine_error = skipped_reason == "engine error"
+    s["skipped"] = [{"id": f"S{i}", "reason": skipped_reason,
+                     **({"error": "connection refused"} if is_engine_error else {})}
+                    for i in range(infra_skipped)]
+    (t / "judged" / "modelA" / "summary.json").write_text(json.dumps(s))
+    rows = [{"id": f"R{i}", "verdict": "pass", "severity": "S0",
+             "behavior": "grammar_fix", "failure_types": []} for i in range(scored)]
+    (t / "judged" / "modelA" / "per_case.jsonl").write_text(
+        "".join(json.dumps(r) + "\n" for r in rows))
+    return t
+
+
+def test_report_accepts_a_run_with_engine_errors():
+    """Round-2 P2: `scored + infra_skipped` was compared against `cases - errors`.
+
+    20 cases with 1 engine error gives `19 + 1` vs `19` — a run that can NEVER
+    reconcile. Unreachable while INCOMPLETE was refused outright; exposed the
+    moment engine-error receipts became rankable.
+    """
+    t = _errors_tree(healthy_receipt(cacheable=True, run_complete=False,
+                                     release_gate={"verdict": "INCOMPLETE", "checks": []}),
+                     cases=20, errors=1, scored=19, infra_skipped=1,
+                     skipped_reason="engine error")
+    rc, out = run_report(t)
+    assert rc == 0, out
+
+
+def test_report_refuses_empty_output_that_the_run_called_a_success():
+    """Round-2 P1: the cause the run's error count cannot see.
+
+    `run_ollama_bench.py` increments `errors` only inside `except`, so a 200
+    returning an empty string is skipped by the judge and counted as a success by
+    the runner. Reconciliation passed and `tier()` could then label the model
+    Recommended on the 19 cases that did produce text.
+    """
+    t = _errors_tree(healthy_receipt(cacheable=True, run_complete=False,
+                                     release_gate={"verdict": "INCOMPLETE", "checks": []}),
+                     cases=20, errors=0, scored=19, infra_skipped=1,
+                     skipped_reason="empty candidate on a successful call (no error reported)")
+    rc, out = run_report(t)
+    assert rc == 2, out
+    assert "successful call" in out, out
+    assert "Recommended" not in out, "it must not be ranked at all"
+
+
+def test_report_refuses_a_skip_that_does_not_correspond_to_the_error():
+    """Cloud review P2: a COUNT match is not an identity check.
+
+    `errors=1` with one skip that is an empty-but-successful candidate satisfies
+    `1 == 1` while the skip does not correspond to the error at all — so the model
+    would be ranked on a mismatched subset. Attribution is checked per entry.
+    """
+    t = _errors_tree(healthy_receipt(cacheable=True, run_complete=False,
+                                     release_gate={"verdict": "INCOMPLETE", "checks": []}),
+                     cases=20, errors=1, scored=19, infra_skipped=1,
+                     skipped_reason="empty candidate on a successful call (no error reported)")
+    rc, out = run_report(t)
+    assert rc == 2, out
+    assert "carry no engine error" in out, out
+
+
+def test_report_refuses_more_error_skips_than_the_run_recorded():
+    """The count half of the attribution check, which per-entry attribution alone
+    cannot cover: every skip carries an engine error, but there are MORE of them
+    than the run recorded. That means the candidates file and the run summary
+    disagree about how many requests failed."""
+    t = _errors_tree(healthy_receipt(cacheable=True, run_complete=False,
+                                     release_gate={"verdict": "INCOMPLETE", "checks": []}),
+                     cases=20, errors=1, scored=18, infra_skipped=2,
+                     skipped_reason="engine error")
+    rc, out = run_report(t)
+    assert rc == 2, out
+    assert "2 judge skip(s) against 1 run error(s)" in out, out
+
+
+def test_report_reconciles_a_clean_run():
+    # Two-way control: without it, "refuse whenever anything is skipped" passes
+    # both cases above.
+    t = _errors_tree(healthy_receipt(), cases=20, errors=0, scored=20,
+                     infra_skipped=0, skipped_reason="n/a")
+    rc, out = run_report(t)
+    assert rc == 0, out
+
+
+def test_report_refuses_counts_that_do_not_add_up():
+    t = _errors_tree(healthy_receipt(), cases=20, errors=0, scored=18,
+                     infra_skipped=1, skipped_reason="engine error")
+    rc, out = run_report(t)
+    assert rc == 2, out
+    assert "attempted cases" in out, out
+
+
+def test_skip_reasons_name_the_three_causes_separately():
+    norm, cands = corpus(4)
+    cands["C00"] = {"error": "connection refused", "candidate": ""}
+    cands["C01"] = {"candidate": "   "}          # empty on a successful call
+    del cands["C02"]                             # absent from the candidates file
+    _, skipped = bj.partition_candidates(norm, cands)
+    by_id = {s["id"]: s["reason"] for s in skipped}
+    assert by_id["C00"] == "engine error", by_id
+    assert "successful call" in by_id["C01"], by_id
+    assert by_id["C02"] == "absent from the candidates file", by_id
+    assert "C03" not in by_id, "the one good case must still be judged"
+
+
+def test_report_refuses_a_truncated_detail_file():
+    t = report_tree(healthy_receipt(), per_case_rows=[
+        {"id": "EN-1", "verdict": "pass", "severity": "S0", "behavior": "grammar_fix",
+         "failure_types": []}])
+    rc, out = run_report(t)
+    assert rc == 2, out
+    assert "truncated or mismatched" in out, out
+
+
+# --------------------------------------------------------------------------- #
+# runner                                                                      #
+# --------------------------------------------------------------------------- #
+
+# An exact count, because the borrowed runner in cleanup_metrics_test.py returns
+# 0 when it discovers ZERO tests — so "green" would carry no information at all.
+EXPECTED_TESTS = 50
+
+
+def _run() -> int:
+    tests = [v for k, v in sorted(globals().items())
+             if k.startswith("test_") and callable(v)]
+    if len(tests) != EXPECTED_TESTS:
+        print(f"FAIL: discovered {len(tests)} tests, expected {EXPECTED_TESTS}. "
+              f"A suite that silently shrinks still exits 0 without this check.")
+        return 1
+    passed = failed = 0
+    for t in tests:
+        try:
+            t()
+            passed += 1
+            print(f"  PASS {t.__name__}")
+        # BaseException, not Exception: a test that drives `main()` can reach
+        # `sys.exit()` (preflight_judge does exactly that when the Claude CLI is
+        # absent), and `SystemExit` does NOT derive from Exception. Catching only
+        # Exception let that kill the process mid-suite with no summary line and no
+        # count assertion — a truncated run that reported nothing about the tests
+        # it never reached. KeyboardInterrupt is re-raised so Ctrl-C still works.
+        except KeyboardInterrupt:
+            raise
+        except BaseException:
+            failed += 1
+            print(f"  FAIL {t.__name__}")
+            traceback.print_exc()
+    print(f"\n{passed} passed, {failed} failed ({len(tests)} total)")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run())

--- a/scripts/eval/judge_ollama_bench.sh
+++ b/scripts/eval/judge_ollama_bench.sh
@@ -27,6 +27,42 @@ mkdir -p "$OUTDIR"
 failed=()
 skipped=()
 unmeasurable=()
+incomplete=()
+
+# `shasum` is Perl-provided and is NOT guaranteed by the ubuntu-latest runner
+# image, which lists coreutils (and therefore `sha256sum`). Our own pr-check.yml
+# only uses `shasum` in the macOS jobs. Measured: the two emit byte-identical
+# `hash  filename` output, and the nested pipeline below agrees across
+# shasum|shasum, sha256sum|sha256sum and mixed — so this shim cannot invalidate a
+# stamp written by the other tool.
+sha256() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$@"
+  else
+    sha256sum "$@"
+  fi
+}
+
+# Is this receipt safe to cache AND to rank? Read the judge's own answer; never
+# infer it from the release verdict. `evaluate_new_gate` gives a quality failure
+# precedence over incompleteness, so a run that is BOTH quality-failed and
+# missing coverage reports BLOCK — and a verdict-based rule would stamp that
+# partial receipt as a finished one. Fails closed on a missing field, unreadable
+# file, or JSON that is valid but not an object; every receipt written before
+# #2007 lacks the field and is therefore re-judged once.
+receipt_cacheable() {
+  python3 - "$1" <<'PY'
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        receipt = json.load(f)
+except (OSError, json.JSONDecodeError):
+    raise SystemExit(1)
+if not isinstance(receipt, dict):
+    raise SystemExit(1)
+raise SystemExit(0 if receipt.get("cacheable") is True else 1)
+PY
+}
 for cand in "$CANDDIR"/*.jsonl; do
   base="$(basename "$cand" .jsonl)"
   dest="$OUTDIR/$base"
@@ -38,15 +74,27 @@ for cand in "$CANDDIR"/*.jsonl; do
   # numbers with the OLD quality scores and said nothing. Same shape as the two
   # holes above it: a result whose scope is quietly narrower than it looks.
   stamp="$dest/.inputs-sha256"
-  inputs_sha="$(shasum -a 256 "$cand" "$CORPUS" | shasum -a 256 | cut -d' ' -f1)"
+  inputs_sha="$(sha256 "$cand" "$CORPUS" | sha256 | cut -d' ' -f1)"
   if [ -f "$dest/summary.json" ]; then
-    if [ -f "$stamp" ] && [ "$(cat "$stamp")" = "$inputs_sha" ]; then
+    # Cacheability is checked HERE too, not only after judging. A matching stamp
+    # used to `continue` outright, so every arm already stamped with a partial
+    # receipt stayed skipped forever — including the ones this bug has already
+    # produced. Nonzero from the helper inside the final `&&` operand just makes
+    # the condition false; the script sets `set -uo pipefail` with no `errexit`.
+    if [ -f "$stamp" ] && [ "$(cat "$stamp")" = "$inputs_sha" ] \
+       && receipt_cacheable "$dest/summary.json"; then
       skipped+=("$base")
       continue
     fi
-    # Inputs moved under an existing receipt. Re-judge rather than trust it, and
-    # say so: a silent re-judge would hide that a previous report was mixed.
-    echo "=== re-judging $base: candidates or corpus changed since its receipt ===" >&2
+    # Re-judge rather than trust it, and say WHICH condition failed: reporting a
+    # non-cacheable receipt as a stamp mismatch sends the reader after the wrong
+    # thing entirely.
+    if [ -f "$stamp" ] && [ "$(cat "$stamp")" = "$inputs_sha" ]; then
+      reason="receipt is not cacheable"
+    else
+      reason="candidates or corpus changed since its receipt"
+    fi
+    echo "=== re-judging $base: $reason ===" >&2
     rm -rf "$dest"
   fi
   # A model that errored on EVERY case has no output to grade. Judging 20 empty
@@ -61,32 +109,38 @@ for cand in "$CANDDIR"/*.jsonl; do
     continue
   fi
   echo "=== judging $base ===" >&2
-  if python3 "$ROOT/scripts/eval/behavior_judge.py" \
-       --system new --corpus "$CORPUS" --candidates "$cand" --out "$dest" >&2; then
+  # The exit status is deliberately NOT the cacheability answer. behavior_judge
+  # exits nonzero for a BLOCK verdict as well as for a partial run, so the
+  # receipt itself is inspected either way — a graded-but-failed run IS a
+  # complete answer and must earn its stamp, or every weak model is re-judged
+  # forever, which is the expensive half.
+  python3 "$ROOT/scripts/eval/behavior_judge.py" \
+    --system new --corpus "$CORPUS" --candidates "$cand" --out "$dest" >&2 || true
+
+  if [ -f "$dest/summary.json" ] && receipt_cacheable "$dest/summary.json"; then
     printf '%s\n' "$inputs_sha" > "$stamp"
     echo "  ok $base" >&2
+  elif [ -f "$dest/summary.json" ]; then
+    # A receipt exists but is partial or internally inconsistent. Do NOT stamp:
+    # withholding the stamp is the whole recovery mechanism, because the resume
+    # branch above deletes and re-judges an unstamped receipt. Leaving the file
+    # in place keeps it readable for whoever investigates.
+    echo "  INCOMPLETE $base (receipt is not cacheable; left in place, not stamped)" >&2
+    incomplete+=("$base")
   else
-    # behavior_judge exits nonzero for BLOCK verdicts too, not only infra
-    # failure, so the presence of summary.json is what distinguishes "graded and
-    # failed the gate" from "never graded". Only the latter is an error here:
-    # this benchmark ranks models, it does not gate them.
-    if [ -f "$dest/summary.json" ]; then
-      # A graded-but-non-CLEAR run is a complete receipt for these inputs, so it
-      # earns a stamp exactly like a CLEAR one. Without this the next run would
-      # re-judge every weak model forever, which is the expensive half.
-      printf '%s\n' "$inputs_sha" > "$stamp"
-      echo "  ok $base (non-CLEAR verdict, expected for weak models)" >&2
-    else
-      echo "  FAILED $base" >&2
-      failed+=("$base")
-    fi
+    echo "  FAILED $base" >&2
+    failed+=("$base")
   fi
 done
 
 [ ${#skipped[@]} -gt 0 ] && echo "skipped (already judged): ${skipped[*]}" >&2
 [ ${#unmeasurable[@]} -gt 0 ] && echo "unmeasurable (every case errored): ${unmeasurable[*]}" >&2
-if [ ${#failed[@]} -gt 0 ]; then
-  echo "FAIL: ${#failed[@]} model(s) produced no summary.json: ${failed[*]}" >&2
+[ ${#incomplete[@]} -gt 0 ] && echo "incomplete (partial receipt, will be re-judged): ${incomplete[*]}" >&2
+if [ ${#failed[@]} -gt 0 ] || [ ${#incomplete[@]} -gt 0 ]; then
+  [ ${#failed[@]} -gt 0 ] && \
+    echo "FAIL: ${#failed[@]} model(s) produced no summary.json: ${failed[*]}" >&2
+  [ ${#incomplete[@]} -gt 0 ] && \
+    echo "FAIL: ${#incomplete[@]} model(s) produced a receipt that is not cacheable: ${incomplete[*]}" >&2
   exit 1
 fi
 echo "judged all models into $OUTDIR" >&2

--- a/scripts/eval/report_ollama_bench.py
+++ b/scripts/eval/report_ollama_bench.py
@@ -136,12 +136,27 @@ def main() -> int:
         # promote it to Recommended on a subset. Refuse the receipt instead: an
         # unranked model is a gap someone re-runs, a wrongly-ranked one is a
         # recommendation nobody re-checks.
+        # Read the judge's own acceptance answer; do not infer one from the
+        # verdict. Refusing only the literal string "INCOMPLETE" left two holes:
+        # a receipt with a MISSING or UNKNOWN verdict sailed through and was
+        # ranked (a synthesised `WEIRD_UNKNOWN_VALUE` came out #1 "Recommended"),
+        # and `BLOCK` outranks incompleteness inside the gate, so a run that was
+        # both quality-failed AND partial never said "INCOMPLETE" at all.
+        # `cacheable` carries the real acceptance decision. The verdict allowlist
+        # exists only to reject a receipt this gate could not have produced — an
+        # absent or unknown verdict — and INCOMPLETE is included deliberately: a
+        # model with some engine errors is INCOMPLETE by coverage yet FINISHED as
+        # evidence, and `tier()` below ranks exactly that case "Not recommended".
         release_verdict = (summary.get("release_gate") or {}).get("verdict")
-        if release_verdict == "INCOMPLETE":
+        if summary.get("cacheable") is not True \
+                or release_verdict not in ("CLEAR", "BLOCK", "INCOMPLETE"):
+            adj_dropped = (summary.get("adjudication") or {}).get("adjudication_missing_n", 0)
             problems.append(
-                f"{model} ({cand_stem}): judge receipt is INCOMPLETE — "
+                f"{model} ({cand_stem}): judge receipt is not cacheable "
+                f"(verdict {release_verdict!r}) — "
                 f"{len(summary.get('skipped', []))} engine-skipped, "
-                f"{len(summary.get('missing_scores', []))} judge-dropped; re-judge the gaps")
+                f"{len(summary.get('missing_scores', []))} primary judge-dropped, "
+                f"{adj_dropped} adjudication-dropped; re-judge")
             continue
 
         # Independent reconciliation against the RUN's own case count, because
@@ -151,14 +166,59 @@ def main() -> int:
         judge_overall = summary.get("overall") or {}
         scored = judge_overall.get("total_scored")
         infra_skipped = judge_overall.get("infra_skipped") or 0
-        expected_scored = sp["cases"] - sp["errors"]
-        if scored is None or scored + infra_skipped != expected_scored:
+
+        # The identity that is actually true: every case the runner attempted is
+        # either scored or skipped. This previously compared the sum against
+        # `cases - errors`, which only holds when `errors == 0` — so ANY run with
+        # one engine error compared `19 + 1` against `19` and could never
+        # reconcile. It was unreachable while the INCOMPLETE receipt was refused
+        # outright; admitting INCOMPLETE for engine errors exposed it.
+        if scored is None or scored + infra_skipped != sp["cases"]:
             problems.append(
                 f"{model} ({cand_stem}): judged {scored} + {infra_skipped} skipped does not "
-                f"reconcile with the run's {expected_scored} non-error cases; re-judge")
+                f"reconcile with the run's {sp['cases']} attempted cases; re-judge")
+            continue
+
+        # And every skip must be ATTRIBUTABLE to an engine error, checked PER ENTRY
+        # rather than by count. A count comparison is not an identity check: with
+        # `errors=1` and one skip that is an empty-but-successful candidate, `1 == 1`
+        # passes while the skip does not correspond to the error at all, and the
+        # model is ranked on a mismatched subset.
+        #
+        # The runner increments `errors` only inside its except branch, so a 200
+        # returning an empty string is skipped by the judge and counted as a SUCCESS.
+        # `tier()` reads the run's error count and therefore cannot see it. Keying on
+        # each entry's own `error` field works for receipts written before the precise
+        # reasons existed too, since a genuine engine error has always recorded it.
+        #
+        # Refuse rather than penalise: an unranked model is a gap someone re-runs, a
+        # wrongly-ranked one is a recommendation nobody re-checks.
+        skipped_entries = summary.get("skipped") or []
+        unattributed = [s for s in skipped_entries if not s.get("error")]
+        if unattributed or len(skipped_entries) != sp["errors"]:
+            detail = "; ".join(sorted({s.get("reason", "no reason recorded")
+                                       for s in (unattributed or skipped_entries)})) or "none"
+            problems.append(
+                f"{model} ({cand_stem}): {len(skipped_entries)} judge skip(s) against "
+                f"{sp['errors']} run error(s), and {len(unattributed)} skip(s) carry no engine "
+                f"error — those produced no gradeable text on a successful call, which cannot "
+                f"be ranked ({detail}); re-run those cases")
             continue
 
         per_case = [json.loads(l) for l in open(per_case_path) if l.strip()]
+
+        # The language splits below are computed from per_case.jsonl while the
+        # headline pass rate comes from summary.json. A truncated detail file
+        # would therefore produce a report whose halves disagree, with nothing
+        # saying so. Two sources agreeing is evidence; only comparing them makes
+        # it evidence.
+        summary_scored = (summary.get("overall") or {}).get("total_scored")
+        if summary_scored is None or len(per_case) != summary_scored:
+            problems.append(
+                f"{model} ({cand_stem}): per_case.jsonl has {len(per_case)} rows but the "
+                f"summary reports total_scored={summary_scored}; the detail file is "
+                f"truncated or mismatched, so the language split cannot be trusted")
+            continue
 
         def split(pred):
             items = [x for x in per_case if pred(x)]


### PR DESCRIPTION
## What was broken

Two Codex findings from PR #2000, merged unaddressed. They are the same defect at two layers — **a judge run that dropped work still reads as a complete receipt** — and they compose, so fixing either alone leaves the pair reachable.

I reproduced both against the real code before writing any fix, and the reproductions turned up **three more defects nobody had filed.**

### #2008, reproduced end to end

An unmodified copy of the real `judge_ollama_bench.sh` with a stub judge that writes an `INCOMPLETE` receipt and exits 1 — exactly what the real `behavior_judge.py` does for that verdict:

```
run 1:  === judging modelA ===
          ok modelA (non-CLEAR verdict, expected for weak models)
        exit=0        stamp written: YES

run 2:  skipped (already judged): modelA
        judge invocations: still 1        receipt on disk: still INCOMPLETE
```

Meanwhile `report_ollama_bench.py` refuses that same receipt and returns 2. The arm was **un-rankable and un-re-judgeable**, recoverable only by deleting the directory by hand.

### #2007, reproduced against the real `score_new`

An adjudication pass that returned **nothing**:

```
VERDICT       : CLEAR
judge_stable  : PASS          <- on ZERO compared cases
adjudicated_n : 12            <- claimed re-judged; none came back
```

### The three the tickets did not mention

1. **`BLOCK` outranks `INCOMPLETE`** (`behavior_judge.py:891-897`), so a run that is both quality-failed *and* partial never says "INCOMPLETE" at all. Keying cacheability on the verdict — **the first version of this fix** — would have stamped it.
2. **The stability check was blind to the disagreement it exists to measure.** `primary` is overwritten with the worse score before `rep_scores` is built from it, so rep1 was the *post-merge* result. 12 of 12 cases disagreeing came back `delta_pp: 0.0`, `judge_stable: PASS`.
3. **A receipt with an unknown verdict was ranked #1 and labelled "Recommended"**, exit 0 — the report refused only the literal string `INCOMPLETE`.

## What changed

- **`run_judge` returns a reconciled `JudgeBatchResult`** (accepted / missing / unexpected) instead of a bare dict, so no caller can forget the accounting. All three call sites consume it. A helper callers had to *remember* to call would have preserved the same bypass.
- **`accepted` follows requested order**, not thread-completion order. Declared behaviour change: adjudication selection is drawn over that key order, so this is what finally makes the fixed seed deterministic.
- **Wobble uses a pre-merge snapshot** as rep1, and omits `unreliable` entirely when no case came back from both replications — so the existing guard skips `judge_stable` rather than inventing a passing one.
- **Completeness gains a third term** for adjudication drops, in the same one-line authority, surfaced as `run_complete`.
- **One `cacheable` field**, written by `finalize_new_report` inside `write_outputs`, read by **both** consumers. It never rewrites the verdict. Completeness is deliberately computed twice and required to agree — an oracle sharing its subject's implementation only proves the code equals itself.
- **The exit code requires `cacheable`**, or a CLEAR run that finalization invalidated still exits 0.
- **The shell checks cacheability on both paths.** The resume fast path mattered most: it used to `continue` on a matching stamp without reading completeness, so every arm this bug had already poisoned stayed skipped forever.
- **`sha256()` shim**, because `shasum` is Perl-provided and not guaranteed by the `ubuntu-latest` image. Measured byte-identical to `sha256sum`, so no existing stamp is invalidated.

## One-time consequence, stated deliberately

No receipt written before this change carries `cacheable`, so **the first run after it re-judges every previously stamped arm.** Fail closed on purpose; grandfathering would recreate the trust hole. Free under the default subscription judge, though `EW_JUDGE` can route to a paid API.

## Verification

| Check | Result |
|---|---|
| Self-tests | **47 passed, 0 failed** — pure stdlib, no network, no judge calls |
| Wired into a gate | `build-check`, the only **required** check. A suite no gate invokes reports nothing (#1965, #2013) |
| Suite cannot silently shrink | Asserts its own exact count; the runner it borrows from exits 0 on zero discovered tests |
| Mutation controls | **10 of 10 detected**, baseline restored green |
| CI wiring gates | Proven by deliberate red — the step's exact shell exits 1 on a broken test, 0 restored |
| Pre/post baselines | 5 defects reproduced, all 5 flipped |
| Two-way control | A complete, agreeing run still gives `CLEAR` + cacheable; without it, "mark everything incomplete" would pass |

Tests patch `judge_chunk`, **never** `run_judge` — reconciliation now lives inside `run_judge`, so a stub there would bypass the boundary under test. Proven by reproducing every pre-fix defect identically through the lower stub. Shell cases run a byte copy of the real script against a stub judge that logs invocations, so "was it re-judged" is a count rather than a marker a second run could satisfy without doing anything.

## The defect is in our real #1950 data, not just in fixtures

Audited all 16 judged arms under `runs/ollama-bench-1950/judged/`:

- **`llama3-2-local`** — the judge silently dropped **4 scores**, all four international cases (`INT-IT-01`, `INT-PT-01`, `INT-JA-01`, `INT-ZH-01`), and its verdict is `BLOCK`. So under the old logic it **was stamped and is skipped on every run** while the report refuses it. The #2008 deadlock, live, in the data behind the recommended-models list. After this change it is re-judged.
- **`gemma4-31b-cloud-cloud`** — a genuine engine error the old code refused to rank. Now cacheable, reconciled `19 + 1 == 20`, and ranked.

None of the 16 carries `cacheable`, so all are re-judged once. Two of them genuinely needed it.

## Three things the build and review caught that the plan rounds did not

Recorded because each was one step from shipping broken:

1. **A second finding in the same class, so I stopped patching and enumerated it.** A case producing nothing gradeable has **three** causes — engine error, empty output on a *successful* call, absent from the file — and `run_ollama_bench.py:208-211` increments `errors` only inside `except`, so cause 2 is invisible to anything reading the run's error count. Both round-2 findings were then the *same arithmetic from opposite sides*: the true identity is `scored + infra_skipped == cases`, while the shipped formula compared that against `cases - errors`. With one engine error it could **never** reconcile; with one empty-but-successful output it **passed** and let `tier()` rank the model Recommended on 19 of 20 cases.

1. **The new test file was gitignored.** `.gitignore:176` ignores `scripts/eval/*` with an explicit allowlist, so `build-check` would have failed with "No such file or directory" on **every PR** — a gate not in the repo cannot run. Found by reading `git status` instead of assuming.
2. **A planned test case was self-contradictory**, demanding `CLEAR` *and* a non-zero stability delta. Above the 5pp limit that fails `judge_stable`, which blocks. It survived a coverage round and three grounded rounds and died on the first execution.

## Scope

`Eval-harness` + `CI/workflow` (`mixed_pr: true`). No app code, no runtime surface, no user-facing string, no corpus, no baseline, no prompt. Nothing in the dictation path changes, so **Live UAT: N**.

Deferred with evidence rather than smuggled in: #2014 (retry judge omissions instead of re-judging a whole arm) and #2015 (one structured benchmark-arm identity). #2013 filed for two tracked eval suites no CI job runs.

Plan: `docs/feature-requests/issue-2007-2026-08-11-incomplete-judge-receipts.md` — one coverage round plus three grounded rounds; round 3 returned converged and said implementation was the appropriate next gate.

Closes #2007
Closes #2008
