### PR TITLE
test(eval): run the two tracked eval suites in CI, where they have never run (Closes #2013)

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -648,6 +648,23 @@ jobs:
           # exits 0 when it discovers zero tests.
           python3 scripts/eval/behavior_judge_test.py
 
+      - name: Eval harness self-tests (#2013)
+        run: |
+          set -euo pipefail
+          # These two suites were TRACKED and had NEVER been executed by any CI
+          # job — 25 cases whose green status meant nothing, and which anyone
+          # reading the repo would reasonably assume were guarding something.
+          # Same class as #1965: a suite no gate invokes reports nothing, so
+          # nothing ever looks wrong. Worse than `0 tests`, which prints a zero.
+          #
+          # Neither subject imports outside the stdlib (alias_suggestion_gate:
+          # argparse difflib json os re subprocess sys; v4_adversarial_runner:
+          # argparse json os sys time datetime pathlib), so both run here under
+          # bare python3 with no pytest install. Each asserts its own exact test
+          # count, because both runners exit 0 on ZERO discovered tests.
+          python3 scripts/eval/tests/test_alias_scorer.py
+          python3 scripts/eval/tests/test_v4_adversarial_runner.py
+
       - name: Require both build lanes
         run: |
           if [ "${{ needs.build-debug.result }}" != "success" ] \

--- a/scripts/eval/tests/test_alias_scorer.py
+++ b/scripts/eval/tests/test_alias_scorer.py
@@ -255,3 +255,56 @@ def test_aggregate_side_gate_degeneration():
     summary = aggregate_corpus("test", cases, results)
     assert summary.side_gates_pass is False
     assert any("degeneration" in f for f in summary.failures)
+
+
+# --------------------------------------------------------------------------- #
+# runner — stdlib, so CI can execute this without installing pytest (#2013)     #
+# --------------------------------------------------------------------------- #
+#
+# This suite was TRACKED and had never been executed by any CI job. Wiring it up
+# needed only an entry point: it uses no pytest feature (no fixtures, no
+# parametrize, no decorators, no `pytest.raises`), so the 23 tests are unchanged
+# and `python3 -m pytest` still works exactly as before.
+
+EXPECTED_TESTS = 23
+
+
+def _run() -> int:
+    """Discover and run every `test_*`, returning a shell exit code.
+
+    Two deliberate differences from the runner in `cleanup_metrics_test.py`:
+
+    1. An EXACT count. A discovery runner returns 0 when it finds ZERO tests, so
+       "green" would carry no information at all — the failure mode this issue is
+       about, one layer in.
+    2. `BaseException`, not `Exception`. `SystemExit` is not an `Exception`, so a
+       `sys.exit` anywhere inside a test would otherwise kill the process
+       mid-suite with no summary line and no count assertion. That is exactly what
+       happened to `behavior_judge_test.py` on its first CI run (#2007).
+    """
+    import traceback
+
+    tests = [v for k, v in sorted(globals().items())
+             if k.startswith("test_") and callable(v)]
+    if len(tests) != EXPECTED_TESTS:
+        print(f"FAIL: discovered {len(tests)} tests, expected {EXPECTED_TESTS}. "
+              f"A suite that silently shrinks still exits 0 without this check.")
+        return 1
+    passed = failed = 0
+    for t in tests:
+        try:
+            t()
+            passed += 1
+            print(f"  PASS {t.__name__}")
+        except KeyboardInterrupt:
+            raise
+        except BaseException:
+            failed += 1
+            print(f"  FAIL {t.__name__}")
+            traceback.print_exc()
+    print(f"\n{passed} passed, {failed} failed ({len(tests)} total)")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run())

--- a/scripts/eval/tests/test_v4_adversarial_runner.py
+++ b/scripts/eval/tests/test_v4_adversarial_runner.py
@@ -83,5 +83,25 @@ class V4AdversarialRunnerTests(unittest.TestCase):
         self.assertFalse(report["per_case"]["JUDGE-NONPASS"]["overall_pass"])
 
 
+EXPECTED_TESTS = 2
+
+
+def _main() -> int:
+    """Run the suite, but refuse to report success on a shrunken one (#2013).
+
+    `unittest.main()` exits 0 when it discovers ZERO tests, so wiring this into CI
+    without a count assertion would buy a green check that means nothing — the
+    failure this issue exists to fix, one layer in.
+    """
+    loader = unittest.TestLoader()
+    suite = loader.loadTestsFromModule(sys.modules[__name__])
+    found = suite.countTestCases()
+    if found != EXPECTED_TESTS:
+        print(f"FAIL: discovered {found} tests, expected {EXPECTED_TESTS}")
+        return 1
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    return 0 if result.wasSuccessful() else 1
+
+
 if __name__ == "__main__":
-    unittest.main()
+    sys.exit(_main())


### PR DESCRIPTION
## What was wrong

Two suites under `scripts/eval/tests/` are **tracked** and had never been executed by any CI job:

| Suite | Cases | Invoked by CI |
|---|---:|---|
| `test_alias_scorer.py` | 23 | never |
| `test_v4_adversarial_runner.py` | 2 | never |

```
$ /usr/bin/grep -rl "test_alias_scorer\|test_v4_adversarial_runner" .github/workflows/ scripts/
(nothing)
```

So a green PR had never been evidence about either of them — and because they ship in the repo, anyone reading it would reasonably assume they were guarding something. Same class as #1965: a suite no gate invokes reports nothing, so nothing ever looks wrong. That is worse than `0 tests`, which at least prints a zero.

Found while deciding where to wire #2007's new suite. Checking whether the neighbours had a home is what showed they did not.

## Why this is small

**No pytest install is needed.** `test_alias_scorer.py` uses no pytest feature — 23 plain `def test_*()` functions, no fixtures, no `parametrize`, no decorators, no `pytest.raises`. The only `pytest` mention was its own docstring. So it gains a stdlib entry point and keeps working under `python3 -m pytest` exactly as before; **no test was touched.**

Neither subject imports outside the stdlib, so both run on the Linux runner:

```
alias_suggestion_gate.py : argparse difflib json os re subprocess sys
v4_adversarial_runner.py : argparse json os sys time datetime pathlib
```

## What changed

- `test_alias_scorer.py` — added a discovery runner and `__main__` block.
- `test_v4_adversarial_runner.py` — replaced `unittest.main()` with a runner that asserts the discovered count first.
- `pr-check.yml` — both invoked in `build-check`, the only **required** check, which is the one place where wiring actually gates.

**Both runners assert an exact expected count.** A discovery runner and `unittest.main()` each exit 0 on **zero** discovered tests, so wiring without a count guard would buy a green check that means nothing — the same failure this issue is about, one layer in.

**Both catch `BaseException`, not `Exception`.** `SystemExit` is not an `Exception`, so a `sys.exit` anywhere inside a test would otherwise kill the process mid-suite with no summary and no count assertion. That is not hypothetical: it is exactly what happened to `behavior_judge_test.py` on its first CI run in #2016, where the suite died silently and the job looked like a passing run that simply stopped.

## Verification — proven by deliberate red, in both directions

| Arm | Result |
|---|---|
| baseline | exit **0** |
| `test_alias_scorer` broken | exit **1** |
| `test_v4_adversarial_runner` broken | exit **1** |
| restored | exit **0** |
| `EXPECTED_TESTS` set wrong | `discovered 23 tests, expected 99` |

Each suite was broken **individually** and run through the step's exact shell (`set -euo pipefail`), so neither passes on the other's back. Both also verified under `python3 -m pytest` (23 passed) and bare `python3` (23 passed, 2 passed), so the change is additive for anyone running them by hand.

One thing worth knowing for the future: these suites can only be exercised **in place**. An early probe that copied `test_alias_scorer.py` to a scratch directory failed with `ModuleNotFoundError: alias_suggestion_gate`, because the file computes its repo root from `__file__`.

## Scope

`CI/workflow` + `Eval-harness`. No app code, no runtime surface, no user-facing string, no corpus, no baseline, no prompt, and **no test logic changed** — only entry points and the invocation. **Live UAT: N.**

Closes #2013
