### PR TITLE
docs(audio): the mute fail-closed reason was measurably false; state the real one (Part of #1859)

### DIFF
--- a/Sources/EnviousWisprAudio/CoreAudioDeviceLiveness.swift
+++ b/Sources/EnviousWisprAudio/CoreAudioDeviceLiveness.swift
@@ -85,10 +85,16 @@ public enum DeviceMuteState: Sendable, Equatable {
   case muted
   /// `Mute` answered no.
   case unmuted
-  /// Core Audio failed the query, or it doesn't support the property (common
-  /// on devices with no hardware mute control). We do NOT know whether the
-  /// device is muted, so the caller must fail closed — same posture as
-  /// `DeviceLiveness.unverified`.
+  /// We have no trustworthy answer. `classify` reaches this two ways: the device
+  /// does not advertise the property (`AudioObjectHasProperty` is false, so no
+  /// read happens at all), or the read returned a non-`noErr` status, whose
+  /// out-parameter contents are not trustworthy. Either way we do NOT know
+  /// whether the device is muted, so the caller must fail closed — same posture
+  /// as `DeviceLiveness.unverified`.
+  ///
+  /// Property absence is a real path. On the four devices measured on macOS 26.6,
+  /// however, the input-scope property was present and settable (#1809; three
+  /// re-measured in #1578).
   case unverified
 }
 
@@ -102,17 +108,37 @@ public enum CoreAudioDeviceMute {
   /// The pure decision, split out for boundary testing.
   ///
   /// - Parameter isMuted: the out-parameter as Core Audio left it. Meaningful
-  ///   ONLY when `status == noErr`; on every other status it is still its
-  ///   zero initializer and is deliberately not read.
+  ///   ONLY when `status == noErr`; on every other status its contents are not
+  ///   trustworthy — `AudioObjectGetPropertyData` promises nothing about what it
+  ///   leaves there — so it is deliberately not read.
   public static func interpret(status: OSStatus, isMuted: UInt32) -> DeviceMuteState {
     switch status {
     case noErr:
       return isMuted == 0 ? .unmuted : .muted
 
-    // Many input devices (most built-in mics) have no hardware mute control
-    // and simply don't implement this property — that is NOT evidence the
-    // device is unmuted, so it must fail closed to `.unverified`, same as
-    // any other non-`noErr` status.
+    // On a non-`noErr` status the out-parameter's contents are NOT trustworthy —
+    // `AudioObjectGetPropertyData` makes no promise about what it leaves there —
+    // so there is nothing to read. Absence of an answer is not an answer of
+    // "unmuted", so this fails closed to `.unverified`.
+    //
+    // The previous justification here — "most built-in mics have no hardware
+    // mute control and simply don't implement this property" — was measurably
+    // FALSE on our hardware: built-in, USB webcam and both virtual drivers all
+    // implement it and all are settable (#1809 measured four, #1578 three). The
+    // conclusion was right for the wrong reason, which is worse than no comment,
+    // because it invites the next reader to trust a claim that does not hold.
+    //
+    // Two things this comment deliberately does NOT claim, both because a review
+    // of its first draft caught them as fresh unsupported premises:
+    //   * that the buffer is left untouched or still holds its zero initializer.
+    //     It is merely untrustworthy; the guarantee does not exist.
+    //   * that property-absence cannot produce `.unverified`. It can — `classify`
+    //     returns early when `AudioObjectHasProperty` is false, without reaching
+    //     this switch at all.
+    //
+    // And the genuinely interesting caveat lives one level up, independent of
+    // status: a VIRTUAL driver can accept a mute write and keep reading 0 — the
+    // Teams loopback did exactly that (#1809). So even `noErr` is not proof.
     default:
       return .unverified
     }
@@ -159,7 +185,10 @@ public enum ZeroSignalEligibility: String, Sendable, CaseIterable {
   /// which fails closed per the #1317 binding decision.
   case notAlive = "not_alive"
   /// The input-scope mute read succeeded and reported muted. Trustworthy in this
-  /// direction only: `.unmuted` is NOT trustworthy (`gotchas-audio.md`).
+  /// direction only: `.unmuted` is NOT trustworthy, because a device can mute in
+  /// its own firmware and still report unmuted here (the Plantronics Blackwire
+  /// 5220 does exactly that), and a virtual driver can accept a mute write and
+  /// keep reading 0 (#1809).
   case deviceMuted = "device_muted"
   /// The mute property is absent, or the read returned non-`noErr`. "Cannot
   /// tell" is a distinct answer from "not muted"; collapsing them was part of

--- a/Tests/EnviousWisprTests/Audio/CoreAudioDeviceMuteTests.swift
+++ b/Tests/EnviousWisprTests/Audio/CoreAudioDeviceMuteTests.swift
@@ -25,9 +25,17 @@ struct CoreAudioDeviceMuteTests {
     #expect(CoreAudioDeviceMute.interpret(status: noErr, isMuted: 0) == .unmuted)
   }
 
-  /// Most built-in mics have no hardware mute control and simply don't
-  /// implement `kAudioDevicePropertyMute` — that silence must fail closed,
-  /// never read as "confirmed unmuted."
+  /// On a non-`noErr` status the out-parameter's contents are not trustworthy, so
+  /// there is nothing to read and this must fail closed — never "confirmed
+  /// unmuted."
+  ///
+  /// Not because devices lack a mute control: measured across built-in / USB
+  /// webcam / two virtual drivers, all four implement `kAudioDevicePropertyMute`
+  /// on the INPUT scope and all four are settable (#1809, #1578). The earlier
+  /// wording here claimed the opposite and was false on our own hardware.
+  /// (Property-absence IS a separate real path to `.unverified`, but it short-
+  /// circuits in `classify` before `interpret` is ever called, so it is out of
+  /// scope for this parameterised case.)
   @Test(
     "any non-noErr status → unverified, never an unmuted claim",
     arguments: [


### PR DESCRIPTION
## What was wrong

`CoreAudioDeviceMute.interpret` justified failing closed to `.unverified` with:

> Many input devices (most built-in mics) have no hardware mute control and simply don't implement this property

The **conclusion is right and the code is correct.** The **justification is false on our own hardware**: measured on macOS 26.6 across built-in / USB webcam / two virtual drivers, all four implement `kAudioDevicePropertyMute` on the INPUT scope and all four are settable (#1809 measured four, #1578 re-measured three).

A comment that justifies a design choice carries the plan's evidence burden, and a right conclusion resting on a wrong reason is worse than no comment at all: it answers the next reader's question and stops them checking.

## What it says now

The real reason a non-`noErr` status must fail closed is simpler and true: **the out-parameter's contents are not trustworthy** — `AudioObjectGetPropertyData` promises nothing about what it leaves there — so there is nothing to read, and absence of an answer is not an answer of "unmuted".

Also recorded, because it is the genuinely interesting caveat and sits one level up, independent of status: a **virtual driver can accept a mute write and keep reading 0** — the Teams loopback did exactly that (#1809). So even `noErr` is not proof.

## Six sites, because the class was bigger than the issue named

| Site | Why |
|---|---|
| `DeviceMuteState.unverified` doc | named in the issue |
| `CoreAudioDeviceMute.interpret` inline | named in the issue |
| `CoreAudioDeviceMuteTests` doc | named in `gotchas-audio.md` |
| `interpret`'s `isMuted` parameter doc | **pre-existing**, same false "zero initializer" premise |
| the two review findings below | introduced by my own first draft |

## Three review rounds, each finding something real — and each one mine

Worth stating plainly, because the pattern is the lesson:

1. **My replacement made two new unsupported claims.** I wrote "This is NOT 'the device has no mute control'" — wrong, because `classify` returns `.unverified` at `AudioObjectHasProperty` being false, with no read and no status, so property-absence genuinely *is* a path to that state. And I wrote that the buffer "is still its zero initializer", which is a guarantee Core Audio does not make.
2. **My second attempt generalised again** — "NOT the common case it was once documented as" turns four measured devices into a prevalence claim about all supported microphones. Replaced with only what those four establish.
3. **It also cited `grounding-discipline.md` from shipped source**, violating `conventions.md` RULE: no-dotclaude-from-shipped-code — that file lives only in the untracked project brain, so the attribution is broken on GitHub and in a fresh clone.

Fixing (3) surfaced a **pre-existing** instance of the same violation on `MuteRefusalReason.deviceMuted`, so that is inlined too and the substance now travels with the code.

**My own residue sweep for that violation was a false negative.** I grepped `'\.claude/'` and got a clean result, because the reference was a bare filename with no path. The correct sweep is any `*.md` filename in shipped source — and running *that* is what found the pre-existing instance. Recorded on the rule.

## Verification

- `CoreAudioDeviceMuteTests` — 5/5 pass
- Full suite — **5,293 tests executed, TEST SUCCEEDED**, no failures
- Dev build succeeds (`build-dev-app.sh`)
- Codex review clean on a confirming round after the fixes above

Comment-only: no behaviour change, no symbol change, no control flow touched.

## Scope

`Part of #1859` — **not** `Closes`. Part 1 of that issue stays open: verifying `reason=device_muted` on a USB headset whose mute survives a client open needs hardware we do not have. The founder's Plantronics Blackwire 5220 mutes in its own firmware and reports `.unmuted`, which makes it the **negative** control rather than the positive arm.

Part of #1859
