### PR TITLE
fix(eval): a refused judge receipt must name its own reason (Closes #2019, Part of #1950)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -239,6 +239,7 @@ scripts/eval/parakeet_runner/Package.resolved
 # gitignored TEST is worse than a gitignored generator, because a green pipeline
 # then means nothing at all.
 !scripts/eval/behavior_judge_test.py
+!scripts/eval/receipt_state.py
 # `render_bench_prompts.sh` builds this to render each model's REAL production
 # prompt, so without it the benchmark cannot be reproduced at the step that
 # decides WHICH prompt each model was given — the input the whole comparison

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -46,6 +46,7 @@ import behavior_judge as bj  # noqa: E402
 
 SHELL = ROOT / "scripts" / "eval" / "judge_ollama_bench.sh"
 REPORT = ROOT / "scripts" / "eval" / "report_ollama_bench.py"
+RECEIPT_STATE = ROOT / "scripts" / "eval" / "receipt_state.py"
 
 
 # --------------------------------------------------------------------------- #
@@ -135,6 +136,12 @@ def shell_tree(mode):
     (t / "cand").mkdir()
     (t / "judged").mkdir()
     (t / "scripts" / "eval" / "judge_ollama_bench.sh").write_bytes(SHELL.read_bytes())
+    # The script derives ROOT from its own location and now DELEGATES refusal
+    # classification to `receipt_state.py`, so the temp ROOT needs a real copy.
+    # Without it `python3 <missing>` exits 2, which collides with the UNREADABLE
+    # state and would make every refusal read "unreadable" — a fixture omission
+    # that produces plausible wrong messages rather than an obvious error.
+    (t / "scripts" / "eval" / "receipt_state.py").write_bytes(RECEIPT_STATE.read_bytes())
     (t / "scripts" / "eval" / "behavior_judge.py").write_text(STUB_JUDGE.format(mode=mode))
     (t / "cand" / "modelA.jsonl").write_text('{"id":"A","candidate":"x"}\n')
     (t / "corpus.jsonl").write_text('{"id":"A"}\n')
@@ -725,6 +732,53 @@ def test_shell_resume_names_an_unsupported_verdict_not_legacy():
         assert "predates" not in log, f"{label} mislabelled as legacy: {log}"
 
 
+def test_both_layers_give_the_same_diagnosis_for_the_same_receipt():
+    """The alignment that two review rounds found broken, now asserted.
+
+    The shell and the report each have to explain a refused receipt, and they must
+    agree — an operator who sees "predates the cacheable field" from one and
+    "corrupt or hand-edited" from the other cannot tell which to believe. Two
+    copies in two languages diverged twice in one PR (verdict classification, then
+    metadata validation), so classification moved into `receipt_state.py` and this
+    test is what stops it drifting apart again.
+
+    Drives the SHELL's real resume path and the REPORT's real entry point over the
+    same receipt bodies, rather than comparing either against a reimplementation.
+    """
+    cases = [
+        # receipt body, shell phrase, report phrase
+        ({"release_gate": {"verdict": "BLOCK"}, "cacheable": False},
+         "receipt is not cacheable", "is not cacheable"),
+        ({"release_gate": {"verdict": "BLOCK"}},
+         "predates the cacheable field", "predates the `cacheable` field"),
+        ({"release_gate": {"verdict": "WEIRD"}},
+         "verdict this gate cannot produce", "cannot produce"),
+        ({"release_gate": {"verdict": "BLOCK"}, "skipped": "not a list"},
+         "malformed metadata", "malformed"),
+        ({"release_gate": ["bad"]},
+         "verdict this gate cannot produce", "cannot produce"),
+    ]
+
+    t = shell_tree("false")
+    run_shell(t)
+    d = t / "judged" / "modelA"
+    d.mkdir(parents=True, exist_ok=True)
+
+    for receipt, shell_phrase, report_phrase in cases:
+        forge_stamp(t)
+        (d / "summary.json").write_text(json.dumps(receipt))
+        before = invocations(t)
+        _, log = run_shell(t)
+        assert invocations(t) > before, f"{receipt} must re-judge: {log}"
+        assert shell_phrase in log, f"shell said the wrong thing for {receipt}: {log}"
+
+        rt = report_tree(receipt)
+        rc, out = run_report(rt)
+        assert rc == 2, f"{receipt} -> rc={rc}: {out}"
+        assert report_phrase in out, f"report said the wrong thing for {receipt}: {out}"
+        assert "Traceback" not in out, f"{receipt} raised: {out}"
+
+
 def test_shell_absent_cacheable_field_is_not_stamped():
     # Every receipt written before #2007 lacks the field.
     t = shell_tree("absent")
@@ -1197,7 +1251,7 @@ def test_report_refuses_a_truncated_detail_file():
 
 # An exact count, because the borrowed runner in cleanup_metrics_test.py returns
 # 0 when it discovers ZERO tests — so "green" would carry no information at all.
-EXPECTED_TESTS = 66
+EXPECTED_TESTS = 67
 
 
 def _run() -> int:

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -969,6 +969,11 @@ def test_report_survives_every_malformed_legacy_metadata_shape():
         # absent, so the number dropped is unknowable — and it was coerced to
         # zero and reported as "no gaps". Unknowable is not zero.
         {"adjudication": {}, "wobble": {"rep_coverage": [20, 0]}},
+        # Round 10, the mirror of round 9: `adjudicated_n > 0` guarantees two
+        # coverage entries (behavior_judge.py:787), so one entry means the pass
+        # ran and its result is missing — unknowable, not zero.
+        {"adjudication": no_count, "wobble": {"rep_coverage": [20]}},
+        {"adjudication": {"adjudicated_n": 1}, "wobble": {"rep_coverage": []}},
 
         {"adjudication": no_count, "wobble": ["bad"]},
         {"adjudication": no_count, "wobble": "bad"},
@@ -1000,8 +1005,13 @@ def test_report_survives_every_malformed_legacy_metadata_shape():
     # Well-formed but degenerate: valid types, nothing to compare. These must
     # reach the ordinary legacy message, NOT the malformed one — the guard has to
     # fire on bad types without also rejecting honest empty evidence.
-    for shape in ({"adjudication": no_count, "wobble": {"rep_coverage": [20]}},
-                  {"adjudication": no_count, "wobble": {"rep_coverage": []}},
+    # THIRD time I misclassified a row in this table, so the rule is written out:
+    # a degenerate-but-valid receipt needs `adjudicated_n` to be 0 or absent. With
+    # selected > 0 and fewer than two coverage entries it is inconsistent, not
+    # degenerate, which is what round 10 found — my earlier "valid, just
+    # degenerate" reading of `no_count` + `[20]` was simply wrong.
+    for shape in ({"adjudication": {"adjudicated_n": 0}, "wobble": {"rep_coverage": [20]}},
+                  {"adjudication": {}, "wobble": {"rep_coverage": []}},
                   # Two coverage entries but a VALID explicit count, which wins:
                   # the derivation is never needed, so nothing is unknowable.
                   {"wobble": {"rep_coverage": [20, 0]}}):

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -956,6 +956,15 @@ def test_report_survives_every_malformed_legacy_metadata_shape():
     # adjudication pass ran. Blanket-asserting one expectation over a table is how
     # a row ends up testing the wrong thing.
     malformed_shapes = [
+        # Cloud rounds 7 and 8: the axis was TYPE, and it needed to be type AND
+        # range AND relationship. A negative count passes `_is_int` and prints
+        # "-1 adjudication-dropped"; a coverage exceeding the selected count is
+        # impossible and the derivation's `max(0, ...)` clamped it to zero and
+        # claimed no gap. Both erase corruption instead of naming it.
+        {"adjudication": {"adjudication_missing_n": -1}},
+        {"adjudication": {"adjudicated_n": -5}},
+        {"adjudication": no_count, "wobble": {"rep_coverage": [20, -3]}},
+        {"adjudication": {"adjudicated_n": 1}, "wobble": {"rep_coverage": [20, 5]}},
         {"adjudication": no_count, "wobble": ["bad"]},
         {"adjudication": no_count, "wobble": "bad"},
         {"adjudication": no_count, "wobble": 7},

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -853,6 +853,23 @@ def test_report_claims_no_adjudication_drop_when_none_ran():
     assert "records no gaps of its own" in out, out
 
 
+def test_report_prefers_the_verdict_problem_over_the_legacy_one():
+    """Cloud review P2. A receipt can be BOTH legacy AND carry a verdict this
+    gate cannot emit; checking field-absence first called it merely old and
+    suppressed the stronger signal — and the advice differs, since "re-judge
+    once" is wrong for a file that is not one of ours.
+
+    Safe by measurement: all 16 shipped #1950 arms carry `BLOCK`, so no genuine
+    legacy receipt is mislabelled by this precedence."""
+    r = healthy_receipt(release_gate={"verdict": "WEIRD_UNKNOWN_VALUE", "checks": []})
+    del r["cacheable"]
+    t = report_tree(r)
+    rc, out = run_report(t)
+    assert rc == 2, out
+    assert "cannot produce" in out, out
+    assert "predates" not in out, out
+
+
 def test_report_names_a_pre_cacheable_receipt_as_such():
     """Every one of the 16 real #1950 arms hits this branch, because no receipt
     written before #2007 carries the field. The old message printed three zero
@@ -1033,7 +1050,7 @@ def test_report_refuses_a_truncated_detail_file():
 
 # An exact count, because the borrowed runner in cleanup_metrics_test.py returns
 # 0 when it discovers ZERO tests — so "green" would carry no information at all.
-EXPECTED_TESTS = 60
+EXPECTED_TESTS = 61
 
 
 def _run() -> int:

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -682,9 +682,14 @@ def test_shell_resume_does_not_call_a_corrupt_receipt_a_legacy_one():
     d = t / "judged" / "modelA"
     d.mkdir(parents=True, exist_ok=True)
 
-    for label, body in (("malformed", "{not json"), ("non-object", "[1,2,3]")):
+    for label, body in (("malformed", b"{not json"), ("non-object", b"[1,2,3]"),
+                        # Invalid UTF-8: raises UnicodeDecodeError, not
+                        # JSONDecodeError, and an escaped exception exits 1 —
+                        # which this caller maps to the LEGACY branch, so an
+                        # undecodable file was announced as merely old.
+                        ("undecodable", b'{"cacheable": "\xff\xfe"}')):
         forge_stamp(t)
-        (d / "summary.json").write_text(body)
+        (d / "summary.json").write_bytes(body)
         before = invocations(t)
         _, log = run_shell(t)
         assert invocations(t) > before, f"{label} must re-judge: {log}"
@@ -783,6 +788,30 @@ def test_report_refuses_an_unreadable_receipt_by_name():
     assert rc == 2, out
     assert "judge receipt is unreadable" in out, out
     assert "modelA" in out, out
+    assert "Traceback" not in out, out
+
+
+def test_report_refuses_an_undecodable_receipt():
+    """Cloud review P2, round 2: invalid UTF-8 raises UnicodeDecodeError, which a
+    `json.JSONDecodeError`-only tuple misses entirely. Both are ValueError
+    subclasses, so the guard catches the BASE rather than a list of names that
+    can miss the next member — the axis I under-enumerated was exception TYPE,
+    having already enumerated corrupt SHAPE."""
+    t = report_tree(healthy_receipt())
+    (t / "judged" / "modelA" / "summary.json").write_bytes(b'{"cacheable": "\xff\xfe"}')
+    rc, out = run_report(t)
+    assert rc == 2, out
+    assert "judge receipt is unreadable" in out, out
+    assert "UnicodeDecodeError" in out, out
+    assert "Traceback" not in out, out
+
+
+def test_report_refuses_an_undecodable_per_case_file():
+    t = report_tree(healthy_receipt())
+    (t / "judged" / "modelA" / "per_case.jsonl").write_bytes(b'{"id": "\xff\xfe"}\n')
+    rc, out = run_report(t)
+    assert rc == 2, out
+    assert "per_case.jsonl is unreadable" in out, out
     assert "Traceback" not in out, out
 
 
@@ -1050,7 +1079,7 @@ def test_report_refuses_a_truncated_detail_file():
 
 # An exact count, because the borrowed runner in cleanup_metrics_test.py returns
 # 0 when it discovers ZERO tests — so "green" would carry no information at all.
-EXPECTED_TESTS = 61
+EXPECTED_TESTS = 63
 
 
 def _run() -> int:

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -158,6 +158,22 @@ def stamped(t):
     return (t / "judged" / "modelA" / ".inputs-sha256").exists()
 
 
+def forge_stamp(t):
+    """Write a stamp that genuinely MATCHES, so the resume fast path is entered
+    and only the cacheability check can stop the skip. Computed exactly as the
+    script does — over the same absolute argv paths, since the hash covers
+    filenames. Without it the stamp is absent, the fast path is never reached,
+    and a case would pass while testing the stale-inputs branch instead."""
+    forged = subprocess.run(
+        ["bash", "-c",
+         'if command -v shasum >/dev/null 2>&1; then H="shasum -a 256"; else H=sha256sum; fi; '
+         f'$H "{t / "cand" / "modelA.jsonl"}" "{t / "corpus.jsonl"}" | $H | cut -d" " -f1'],
+        capture_output=True, text=True).stdout.strip()
+    assert forged, "could not compute a stamp"
+    (t / "judged" / "modelA" / ".inputs-sha256").write_text(forged + "\n")
+    return forged
+
+
 def report_tree(receipt, per_case_rows=None):
     """Fixtures for report_ollama_bench.py with a caller-chosen receipt."""
     t = Path(tempfile.mkdtemp())
@@ -606,18 +622,7 @@ def test_shell_resume_path_rejudges_a_stamped_not_cacheable_arm():
     if not receipt.exists():
         receipt.write_text(json.dumps({"cacheable": False, "release_gate": {"verdict": "BLOCK"}}))
 
-    # Forge a stamp that genuinely MATCHES, so the fast path is entered and only
-    # the cacheability check can stop the skip. Computed exactly as the script
-    # does — over the same absolute argv paths, since the hash covers filenames.
-    # Without this the stamp is absent, the fast path is never reached, and the
-    # case would pass while testing the stale-inputs branch instead.
-    forged = subprocess.run(
-        ["bash", "-c",
-         'if command -v shasum >/dev/null 2>&1; then H="shasum -a 256"; else H=sha256sum; fi; '
-         f'$H "{t / "cand" / "modelA.jsonl"}" "{t / "corpus.jsonl"}" | $H | cut -d" " -f1'],
-        capture_output=True, text=True).stdout.strip()
-    assert forged, "could not compute a stamp"
-    (d / ".inputs-sha256").write_text(forged + "\n")
+    forge_stamp(t)
 
     # Control: prove the forged stamp really would have caused a skip. Flip the
     # receipt to cacheable and confirm the arm IS skipped.
@@ -633,6 +638,36 @@ def test_shell_resume_path_rejudges_a_stamped_not_cacheable_arm():
     rc, log = run_shell(t)
     assert invocations(t) > before, f"the arm must be re-judged, not skipped: {log}"
     assert "not cacheable" in log, log
+
+
+def test_shell_resume_names_a_pre_cacheable_receipt_separately():
+    """Both cases are re-judged, so the CACHING behaviour is identical and only
+    the reader is affected — which is the point. A stamped receipt written before
+    #2007 has no acceptance field at all; calling that "not cacheable" sends the
+    reader looking for gaps that were never recorded. Every arm of the shipped
+    #1950 sweep is in exactly this state, so it is the message people will meet."""
+    t = shell_tree("false")
+    run_shell(t)
+    d = t / "judged" / "modelA"
+    d.mkdir(parents=True, exist_ok=True)
+    forge_stamp(t)
+
+    # Control: with the field present and false, the wording stays the old one.
+    (d / "summary.json").write_text(json.dumps(
+        {"cacheable": False, "release_gate": {"verdict": "BLOCK"}}))
+    before = invocations(t)
+    _, log_false = run_shell(t)
+    assert invocations(t) > before, f"must re-judge: {log_false}"
+    assert "not cacheable" in log_false, log_false
+    assert "predates" not in log_false, log_false
+
+    # The case under test: same matching stamp, field absent entirely.
+    forge_stamp(t)
+    (d / "summary.json").write_text(json.dumps({"release_gate": {"verdict": "BLOCK"}}))
+    before = invocations(t)
+    rc, log_absent = run_shell(t)
+    assert invocations(t) > before, f"must re-judge: {log_absent}"
+    assert "predates the cacheable field" in log_absent, log_absent
 
 
 def test_shell_absent_cacheable_field_is_not_stamped():
@@ -701,13 +736,48 @@ def test_report_refuses_an_unknown_verdict():
     t = report_tree(healthy_receipt(release_gate={"verdict": "WEIRD_UNKNOWN", "checks": []}))
     rc, out = run_report(t)
     assert rc == 2, out
-    assert "not cacheable" in out, out
+    # The receipt IS cacheable and its gap counts are all zero, so the generic
+    # "not cacheable — 0, 0, 0" sentence described none of what is wrong. The
+    # refusal now names the actual reason: this gate cannot emit that verdict.
+    assert "cannot produce" in out, out
+    assert "0 engine-skipped" not in out, out
 
 
 def test_report_refuses_clear_but_not_cacheable():
     t = report_tree(healthy_receipt(cacheable=False))
     rc, out = run_report(t)
     assert rc == 2, out
+    assert "not cacheable" in out, out
+
+
+def test_report_names_a_pre_cacheable_receipt_as_such():
+    """Every one of the 16 real #1950 arms hits this branch, because no receipt
+    written before #2007 carries the field. The old message printed three zero
+    counts and refused anyway, which reads as "nothing is wrong, yet rejected"."""
+    r = healthy_receipt()
+    del r["cacheable"]
+    t = report_tree(r)
+    rc, out = run_report(t)
+    assert rc == 2, out
+    assert "predates the `cacheable` field" in out, out
+    assert "records no gaps of its own" in out, out
+    # The three-count string is the OTHER branch's sentence and must not appear:
+    # printing "0 engine-skipped, 0 primary judge-dropped" here is the defect.
+    assert "engine-skipped" not in out, out
+
+
+def test_report_still_names_the_gaps_a_pre_cacheable_receipt_records():
+    """A pre-field receipt lacks the ACCEPTANCE answer, not its gap record. Real
+    data: llama3.2's #1950 receipt has no `cacheable` and four dropped
+    international scores, so an unconditional "no gap is implied" would be false."""
+    r = healthy_receipt(missing_scores=["INT-1", "INT-2", "INT-3", "INT-4"])
+    del r["cacheable"]
+    t = report_tree(r)
+    rc, out = run_report(t)
+    assert rc == 2, out
+    assert "predates the `cacheable` field" in out, out
+    assert "4 primary judge-dropped" in out, out
+    assert "no gaps of its own" not in out, out
 
 
 def test_report_names_the_adjudication_gap():
@@ -860,7 +930,7 @@ def test_report_refuses_a_truncated_detail_file():
 
 # An exact count, because the borrowed runner in cleanup_metrics_test.py returns
 # 0 when it discovers ZERO tests — so "green" would carry no information at all.
-EXPECTED_TESTS = 50
+EXPECTED_TESTS = 53
 
 
 def _run() -> int:

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -895,31 +895,63 @@ def test_report_survives_every_malformed_legacy_metadata_shape():
     # short-circuits the derivation. A table whose rows cannot enter the branch is
     # zero coverage wearing a passing badge.
     no_count = {"adjudicated_n": 20}  # deliberately omits adjudication_missing_n
-    shapes = [
+
+    # THREE GROUPS, because type-validity and value-degeneracy are different axes
+    # and my first table conflated them — it asserted "malformed" for a perfectly
+    # well-formed `rep_coverage: [20]`, which is valid and simply means no
+    # adjudication pass ran. Blanket-asserting one expectation over a table is how
+    # a row ends up testing the wrong thing.
+    malformed_shapes = [
         {"adjudication": no_count, "wobble": ["bad"]},
         {"adjudication": no_count, "wobble": "bad"},
         {"adjudication": no_count, "wobble": 7},
         {"adjudication": no_count, "wobble": {"rep_coverage": "not a list"}},
         {"adjudication": no_count, "wobble": {"rep_coverage": [20, "seventeen"]}},
-        {"adjudication": no_count, "wobble": {"rep_coverage": [20]}},
-        {"adjudication": no_count, "wobble": {"rep_coverage": []}},
-        {"adjudication": ["bad"], "wobble": {"rep_coverage": [20, 17]}},
-        {"adjudication": "bad", "wobble": {"rep_coverage": [20, 17]}},
-        {"adjudication": {"adjudicated_n": "twenty"}, "wobble": {"rep_coverage": [20, 17]}},
+        {"adjudication": ["bad"]},
+        {"adjudication": "bad"},
+        {"adjudication": {"adjudicated_n": "twenty"}},
         {"adjudication": {"adjudication_missing_n": "seven"}},
         {"adjudication": {"adjudication_missing_n": True}},
         {"skipped": "not a list"},
         {"missing_scores": {"not": "a list"}},
-        {"release_gate": ["bad"]},
     ]
-    for shape in shapes:
+    for shape in malformed_shapes:
         r = healthy_receipt(**shape)
         del r["cacheable"]
         t = report_tree(r)
         rc, out = run_report(t)
         assert rc == 2, f"{shape} -> rc={rc}: {out}"
         assert "Traceback" not in out, f"{shape} raised: {out}"
-        assert "modelA" in out, f"{shape} did not name the model: {out}"
+        # Cloud review round 5 found what a "did not crash" assertion allows: the
+        # message claimed the receipt "records no gaps of its own", a false claim
+        # built by coercing a corrupt field to empty. Name it, never erase it.
+        assert "malformed" in out, f"{shape} was coerced instead of refused: {out}"
+        assert "no gaps of its own" not in out, \
+            f"{shape} claimed no gaps from unusable metadata: {out}"
+
+    # Well-formed but degenerate: valid types, nothing to compare. These must
+    # reach the ordinary legacy message, NOT the malformed one — the guard has to
+    # fire on bad types without also rejecting honest empty evidence.
+    for shape in ({"adjudication": no_count, "wobble": {"rep_coverage": [20]}},
+                  {"adjudication": no_count, "wobble": {"rep_coverage": []}}):
+        r = healthy_receipt(**shape)
+        del r["cacheable"]
+        t = report_tree(r)
+        rc, out = run_report(t)
+        assert rc == 2, f"{shape} -> rc={rc}: {out}"
+        assert "Traceback" not in out, f"{shape} raised: {out}"
+        assert "malformed" not in out, f"{shape} wrongly called malformed: {out}"
+        assert "predates the `cacheable` field" in out, f"{shape}: {out}"
+
+    # A non-object `release_gate` is caught EARLIER, by the verdict check, because
+    # its verdict reads as None. Asserting "malformed" here would have been wrong
+    # about which branch owns it.
+    r = healthy_receipt(release_gate=["bad"])
+    del r["cacheable"]
+    rc, out = run_report(report_tree(r))
+    assert rc == 2, out
+    assert "cannot produce" in out, out
+    assert "Traceback" not in out, out
 
 
 def test_report_classifies_a_hand_edited_receipt_before_reading_its_metadata():

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -965,6 +965,11 @@ def test_report_survives_every_malformed_legacy_metadata_shape():
         {"adjudication": {"adjudicated_n": -5}},
         {"adjudication": no_count, "wobble": {"rep_coverage": [20, -3]}},
         {"adjudication": {"adjudicated_n": 1}, "wobble": {"rep_coverage": [20, 5]}},
+        # Round 9: a pass RAN (two coverage entries) but `adjudicated_n` is
+        # absent, so the number dropped is unknowable — and it was coerced to
+        # zero and reported as "no gaps". Unknowable is not zero.
+        {"adjudication": {}, "wobble": {"rep_coverage": [20, 0]}},
+
         {"adjudication": no_count, "wobble": ["bad"]},
         {"adjudication": no_count, "wobble": "bad"},
         {"adjudication": no_count, "wobble": 7},
@@ -996,7 +1001,10 @@ def test_report_survives_every_malformed_legacy_metadata_shape():
     # reach the ordinary legacy message, NOT the malformed one — the guard has to
     # fire on bad types without also rejecting honest empty evidence.
     for shape in ({"adjudication": no_count, "wobble": {"rep_coverage": [20]}},
-                  {"adjudication": no_count, "wobble": {"rep_coverage": []}}):
+                  {"adjudication": no_count, "wobble": {"rep_coverage": []}},
+                  # Two coverage entries but a VALID explicit count, which wins:
+                  # the derivation is never needed, so nothing is unknowable.
+                  {"wobble": {"rep_coverage": [20, 0]}}):
         r = healthy_receipt(**shape)
         del r["cacheable"]
         t = report_tree(r)

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -697,6 +697,34 @@ def test_shell_resume_does_not_call_a_corrupt_receipt_a_legacy_one():
         assert "predates" not in log, f"{label} was mislabelled as legacy: {log}"
 
 
+def test_shell_resume_names_an_unsupported_verdict_not_legacy():
+    """Cloud review round 4. The shell classified only field-presence, so a
+    hand-edited receipt with no `cacheable` was announced as "predates the
+    cacheable field" — the same defect the report had, one layer over. The two
+    layers must agree on precedence, or they describe the same file differently.
+
+    Includes a non-object `release_gate`, because a bare `.get` there would raise
+    instead of classifying, and a hand-edited file is where that shape lives."""
+    t = shell_tree("false")
+    run_shell(t)
+    d = t / "judged" / "modelA"
+    d.mkdir(parents=True, exist_ok=True)
+
+    for label, receipt in (
+        ("unsupported verdict", {"release_gate": {"verdict": "WEIRD"}}),
+        ("absent verdict", {"release_gate": {}}),
+        ("absent release_gate", {"foo": "bar"}),
+        ("non-object release_gate", {"release_gate": ["bad"]}),
+    ):
+        forge_stamp(t)
+        (d / "summary.json").write_text(json.dumps(receipt))
+        before = invocations(t)
+        _, log = run_shell(t)
+        assert invocations(t) > before, f"{label} must re-judge: {log}"
+        assert "verdict this gate cannot produce" in log, f"{label}: {log}"
+        assert "predates" not in log, f"{label} mislabelled as legacy: {log}"
+
+
 def test_shell_absent_cacheable_field_is_not_stamped():
     # Every receipt written before #2007 lacks the field.
     t = shell_tree("absent")
@@ -847,6 +875,64 @@ def test_report_refuses_a_non_object_per_case_row():
     rc, out = run_report(t)
     assert rc == 2, out
     assert "row that is not an object" in out, out
+    assert "Traceback" not in out, out
+
+
+def test_report_survives_every_malformed_legacy_metadata_shape():
+    """Cloud review round 4, and the point at which patching one cell per round
+    stopped being the right move. `{"wobble": ["bad"]}` made a `.get` raise
+    AttributeError, so the refusal path CRASHED while explaining why a receipt
+    was untrusted — a refusal treating its own input as well-formed.
+
+    Every one of these carries a VALID verdict, so precedence cannot save them;
+    only the type-safe accessors can. Table-driven because the axis is "any JSON
+    value in any legacy field", not a list of remembered examples."""
+    # EVERY wobble row must also make `adjudication_missing_n` unusable, or the
+    # `rep_coverage` read is never reached and the row proves nothing. My first
+    # version of this table did not, and the mutation control caught it: reverting
+    # the accessors to bare `.get` left all 66 tests green, because
+    # `healthy_receipt` supplies a valid `adjudication_missing_n: 0` that
+    # short-circuits the derivation. A table whose rows cannot enter the branch is
+    # zero coverage wearing a passing badge.
+    no_count = {"adjudicated_n": 20}  # deliberately omits adjudication_missing_n
+    shapes = [
+        {"adjudication": no_count, "wobble": ["bad"]},
+        {"adjudication": no_count, "wobble": "bad"},
+        {"adjudication": no_count, "wobble": 7},
+        {"adjudication": no_count, "wobble": {"rep_coverage": "not a list"}},
+        {"adjudication": no_count, "wobble": {"rep_coverage": [20, "seventeen"]}},
+        {"adjudication": no_count, "wobble": {"rep_coverage": [20]}},
+        {"adjudication": no_count, "wobble": {"rep_coverage": []}},
+        {"adjudication": ["bad"], "wobble": {"rep_coverage": [20, 17]}},
+        {"adjudication": "bad", "wobble": {"rep_coverage": [20, 17]}},
+        {"adjudication": {"adjudicated_n": "twenty"}, "wobble": {"rep_coverage": [20, 17]}},
+        {"adjudication": {"adjudication_missing_n": "seven"}},
+        {"adjudication": {"adjudication_missing_n": True}},
+        {"skipped": "not a list"},
+        {"missing_scores": {"not": "a list"}},
+        {"release_gate": ["bad"]},
+    ]
+    for shape in shapes:
+        r = healthy_receipt(**shape)
+        del r["cacheable"]
+        t = report_tree(r)
+        rc, out = run_report(t)
+        assert rc == 2, f"{shape} -> rc={rc}: {out}"
+        assert "Traceback" not in out, f"{shape} raised: {out}"
+        assert "modelA" in out, f"{shape} did not name the model: {out}"
+
+
+def test_report_classifies_a_hand_edited_receipt_before_reading_its_metadata():
+    """The reviewer's exact example: an unsupported verdict AND malformed legacy
+    metadata together. Classifying the verdict first means the crash-prone reads
+    never run for the receipts most likely to break them."""
+    r = healthy_receipt(release_gate={"verdict": "WEIRD"},
+                        adjudication={"adjudicated_n": 1}, wobble=["bad"])
+    del r["cacheable"]
+    t = report_tree(r)
+    rc, out = run_report(t)
+    assert rc == 2, out
+    assert "cannot produce" in out, out
     assert "Traceback" not in out, out
 
 
@@ -1079,7 +1165,7 @@ def test_report_refuses_a_truncated_detail_file():
 
 # An exact count, because the borrowed runner in cleanup_metrics_test.py returns
 # 0 when it discovers ZERO tests — so "green" would carry no information at all.
-EXPECTED_TESTS = 63
+EXPECTED_TESTS = 66
 
 
 def _run() -> int:

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -772,6 +772,87 @@ def test_report_refuses_clear_but_not_cacheable():
     assert "not cacheable" in out, out
 
 
+def test_report_refuses_an_unreadable_receipt_by_name():
+    """#2019, folded in rather than deferred: shipping "a refusal names its own
+    reason" while one input shape still produces a traceback would make that
+    claim false. Pre-fix both corrupt shapes exit 1 through an unhandled
+    exception, so the exit-code assertion alone fails without the guard."""
+    t = report_tree(healthy_receipt())
+    (t / "judged" / "modelA" / "summary.json").write_text("{not json")
+    rc, out = run_report(t)
+    assert rc == 2, out
+    assert "judge receipt is unreadable" in out, out
+    assert "modelA" in out, out
+    assert "Traceback" not in out, out
+
+
+def test_report_refuses_a_non_object_receipt_by_name():
+    t = report_tree(healthy_receipt())
+    (t / "judged" / "modelA" / "summary.json").write_text("[1,2,3]")
+    rc, out = run_report(t)
+    assert rc == 2, out
+    assert "not an object" in out, out
+    assert "Traceback" not in out, out
+
+
+def test_report_refuses_an_unreadable_per_case_file():
+    """Checked rather than assumed: a malformed per_case.jsonl crashed the same
+    way, so it is the same class and belongs in the same change."""
+    t = report_tree(healthy_receipt())
+    (t / "judged" / "modelA" / "per_case.jsonl").write_text("{not json")
+    rc, out = run_report(t)
+    assert rc == 2, out
+    assert "per_case.jsonl is unreadable" in out, out
+    assert "Traceback" not in out, out
+
+
+def test_report_refuses_a_non_object_per_case_row():
+    """The guard is reachable: a `[1,2]` row parses fine and would reach the
+    `.get`-calling split predicates, so this is a real path, not a formality."""
+    t = report_tree(healthy_receipt(), per_case_rows=[{"id": "EN-1", "verdict": "pass",
+                                                      "severity": "S0",
+                                                      "behavior": "grammar_fix",
+                                                      "failure_types": []}])
+    p = t / "judged" / "modelA" / "per_case.jsonl"
+    p.write_text(p.read_text() + "[1,2]\n")
+    rc, out = run_report(t)
+    assert rc == 2, out
+    assert "row that is not an object" in out, out
+    assert "Traceback" not in out, out
+
+
+def test_report_recovers_a_legacy_adjudication_drop():
+    """Review r2 P2, and an incomplete port of my own fix: I read a legacy
+    receipt's `skipped` and `missing_scores` but let `adjudication_missing_n`
+    default to zero, so a receipt whose own fields PROVE an adjudication drop was
+    reported as recording no gaps. `rep_scores[1]` is the adjudication pass, so
+    `rep_coverage[1]` is what it returned against `adjudicated_n` selected.
+
+    The 16 shipped #1950 receipts all compute 0 here, so this case is the only
+    thing standing between the recovery and a silent regression."""
+    r = healthy_receipt(adjudication={"adjudicated_n": 20},
+                        wobble={"common_n": 17, "rep_coverage": [20, 17]})
+    del r["cacheable"]
+    t = report_tree(r)
+    rc, out = run_report(t)
+    assert rc == 2, out
+    assert "3 adjudication-dropped" in out, out
+    assert "no gaps of its own" not in out, out
+
+
+def test_report_claims_no_adjudication_drop_when_none_ran():
+    """Two-way control for the recovery above. With no adjudication pass,
+    `rep_coverage` has a single entry, so the difference is not computable and
+    must read as zero rather than as `adjudicated_n` dropped."""
+    r = healthy_receipt(adjudication={"adjudicated_n": 0},
+                        wobble={"common_n": 0, "rep_coverage": [20]})
+    del r["cacheable"]
+    t = report_tree(r)
+    rc, out = run_report(t)
+    assert rc == 2, out
+    assert "records no gaps of its own" in out, out
+
+
 def test_report_names_a_pre_cacheable_receipt_as_such():
     """Every one of the 16 real #1950 arms hits this branch, because no receipt
     written before #2007 carries the field. The old message printed three zero
@@ -952,7 +1033,7 @@ def test_report_refuses_a_truncated_detail_file():
 
 # An exact count, because the borrowed runner in cleanup_metrics_test.py returns
 # 0 when it discovers ZERO tests — so "green" would carry no information at all.
-EXPECTED_TESTS = 54
+EXPECTED_TESTS = 60
 
 
 def _run() -> int:

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -670,6 +670,28 @@ def test_shell_resume_names_a_pre_cacheable_receipt_separately():
     assert "predates the cacheable field" in log_absent, log_absent
 
 
+def test_shell_resume_does_not_call_a_corrupt_receipt_a_legacy_one():
+    """Review r1 P2. A two-way "does it carry the field" test answers false for
+    an unreadable file too, so a corrupt receipt was announced as "predates the
+    cacheable field" — a message asserting a cause it never observed, which is
+    the exact defect this pass exists to remove. Both still re-judge; only the
+    diagnostic differs, and hiding corruption behind "this file is just old" is
+    what sends the reader after the wrong thing."""
+    t = shell_tree("false")
+    run_shell(t)
+    d = t / "judged" / "modelA"
+    d.mkdir(parents=True, exist_ok=True)
+
+    for label, body in (("malformed", "{not json"), ("non-object", "[1,2,3]")):
+        forge_stamp(t)
+        (d / "summary.json").write_text(body)
+        before = invocations(t)
+        _, log = run_shell(t)
+        assert invocations(t) > before, f"{label} must re-judge: {log}"
+        assert "unreadable or is not a JSON object" in log, f"{label}: {log}"
+        assert "predates" not in log, f"{label} was mislabelled as legacy: {log}"
+
+
 def test_shell_absent_cacheable_field_is_not_stamped():
     # Every receipt written before #2007 lacks the field.
     t = shell_tree("absent")
@@ -930,7 +952,7 @@ def test_report_refuses_a_truncated_detail_file():
 
 # An exact count, because the borrowed runner in cleanup_metrics_test.py returns
 # 0 when it discovers ZERO tests — so "green" would carry no information at all.
-EXPECTED_TESTS = 53
+EXPECTED_TESTS = 54
 
 
 def _run() -> int:

--- a/scripts/eval/judge_ollama_bench.sh
+++ b/scripts/eval/judge_ollama_bench.sh
@@ -64,19 +64,28 @@ raise SystemExit(0 if receipt.get("cacheable") is True else 1)
 PY
 }
 
-# Distinguishes "the field is absent" from "the field says false" for the resume
-# message only. Deliberately NOT part of the caching decision: both cases fail
-# closed and are re-judged, so this changes what the reader is told and nothing
-# else. Fails closed the same way, because an unreadable receipt has no field.
-receipt_has_cacheable_field() {
+# Why the receipt was refused, for the resume MESSAGE only. Deliberately NOT
+# part of the caching decision: every state below fails closed and is re-judged,
+# so this changes what the reader is told and nothing else.
+#
+# Three states, not two. A two-way "does it have the field" test folds an
+# unreadable or non-object receipt in with a legacy one and announces "predates
+# the cacheable field" about a file it could not even parse — asserting a cause
+# it never observed, which is the whole defect this pass exists to remove.
+#   0 = object carrying `cacheable` (so the field says false)
+#   1 = object without it (written before #2007)
+#   2 = unreadable, malformed, or valid JSON that is not an object
+receipt_refusal_state() {
   python3 - "$1" <<'PY'
 import json, sys
 try:
     with open(sys.argv[1]) as f:
         receipt = json.load(f)
 except (OSError, json.JSONDecodeError):
-    raise SystemExit(1)
-raise SystemExit(0 if isinstance(receipt, dict) and "cacheable" in receipt else 1)
+    raise SystemExit(2)
+if not isinstance(receipt, dict):
+    raise SystemExit(2)
+raise SystemExit(0 if "cacheable" in receipt else 1)
 PY
 }
 for cand in "$CANDDIR"/*.jsonl; do
@@ -114,11 +123,12 @@ for cand in "$CANDDIR"/*.jsonl; do
       # so this is the path a reader actually meets. The post-judge branch below
       # keeps the plain wording deliberately: the judge that just wrote that
       # receipt always sets the field, so there `false` is the only way to get in.
-      if receipt_has_cacheable_field "$dest/summary.json"; then
-        reason="receipt is not cacheable"
-      else
-        reason="receipt predates the cacheable field"
-      fi
+      receipt_refusal_state "$dest/summary.json"
+      case $? in
+        0) reason="receipt is not cacheable" ;;
+        1) reason="receipt predates the cacheable field" ;;
+        *) reason="receipt is unreadable or is not a JSON object" ;;
+      esac
     else
       reason="candidates or corpus changed since its receipt"
     fi

--- a/scripts/eval/judge_ollama_bench.sh
+++ b/scripts/eval/judge_ollama_bench.sh
@@ -73,13 +73,19 @@ PY
 # part of the caching decision: every state below fails closed and is re-judged,
 # so this changes what the reader is told and nothing else.
 #
-# Three states, not two. A two-way "does it have the field" test folds an
-# unreadable or non-object receipt in with a legacy one and announces "predates
-# the cacheable field" about a file it could not even parse — asserting a cause
-# it never observed, which is the whole defect this pass exists to remove.
+# FOUR states, and every widening here came from a review round finding one more
+# receipt shape the previous set folded into the wrong bucket. A two-way "does it
+# have the field" test announces "predates the cacheable field" about a file it
+# could not even parse, or about a hand-edited one — asserting a cause it never
+# observed, which is the whole defect this pass exists to remove.
+#
+# These MUST match `report_ollama_bench.py`'s precedence, verdict before
+# field-absence, or the two layers describe the same file differently and the
+# reader cannot tell which to believe.
 #   0 = object carrying `cacheable` (so the field says false)
-#   1 = object without it (written before #2007)
+#   1 = object without it, with a verdict this gate can emit (pre-#2007)
 #   2 = unreadable, malformed, or valid JSON that is not an object
+#   3 = object carrying a verdict this gate cannot emit (not ours / hand-edited)
 receipt_refusal_state() {
   python3 - "$1" <<'PY'
 import json, sys
@@ -95,6 +101,14 @@ except (OSError, ValueError):
     raise SystemExit(2)
 if not isinstance(receipt, dict):
     raise SystemExit(2)
+# Verdict FIRST, matching the report: an unsupported verdict is the stronger
+# signal and carries different advice than "this file is merely old". Read
+# defensively, because a hand-edited receipt is exactly where a non-object
+# `release_gate` shows up and a bare `.get` would raise instead of classifying.
+gate = receipt.get("release_gate")
+verdict = gate.get("verdict") if isinstance(gate, dict) else None
+if verdict not in ("CLEAR", "BLOCK", "INCOMPLETE"):
+    raise SystemExit(3)
 raise SystemExit(0 if "cacheable" in receipt else 1)
 PY
 }
@@ -137,6 +151,7 @@ for cand in "$CANDDIR"/*.jsonl; do
       case $? in
         0) reason="receipt is not cacheable" ;;
         1) reason="receipt predates the cacheable field" ;;
+        3) reason="receipt carries a verdict this gate cannot produce" ;;
         *) reason="receipt is unreadable or is not a JSON object" ;;
       esac
     else

--- a/scripts/eval/judge_ollama_bench.sh
+++ b/scripts/eval/judge_ollama_bench.sh
@@ -73,44 +73,22 @@ PY
 # part of the caching decision: every state below fails closed and is re-judged,
 # so this changes what the reader is told and nothing else.
 #
-# FOUR states, and every widening here came from a review round finding one more
-# receipt shape the previous set folded into the wrong bucket. A two-way "does it
-# have the field" test announces "predates the cacheable field" about a file it
-# could not even parse, or about a hand-edited one — asserting a cause it never
-# observed, which is the whole defect this pass exists to remove.
+# Why the receipt was refused, for the resume MESSAGE only — DELEGATED, not
+# reimplemented. This used to be an inline copy of the report's logic, and the
+# copy fell behind twice in one PR: first it did not classify verdicts, then it
+# did not validate metadata, and both times it announced "predates the cacheable
+# field" about a file the report correctly called hand-edited or corrupt. A
+# comment asking for parity cannot enforce it, so `receipt_state.py` is the single
+# authority and both layers ask it.
 #
-# These MUST match `report_ollama_bench.py`'s precedence, verdict before
-# field-absence, or the two layers describe the same file differently and the
-# reader cannot tell which to believe.
+# Exit code IS the state; stdout carries malformed field names.
 #   0 = object carrying `cacheable` (so the field says false)
-#   1 = object without it, with a verdict this gate can emit (pre-#2007)
+#   1 = object without it, valid verdict, usable metadata (pre-#2007)
 #   2 = unreadable, malformed, or valid JSON that is not an object
-#   3 = object carrying a verdict this gate cannot emit (not ours / hand-edited)
+#   3 = a verdict this gate cannot emit (not ours / hand-edited)
+#   4 = valid verdict but gap metadata whose types prove nothing
 receipt_refusal_state() {
-  python3 - "$1" <<'PY'
-import json, sys
-try:
-    with open(sys.argv[1]) as f:
-        receipt = json.load(f)
-# ValueError, not JSONDecodeError: invalid UTF-8 raises UnicodeDecodeError,
-# which a JSONDecodeError-only tuple misses. Both are ValueError subclasses,
-# so catching the base is the enumeration rather than a list that can miss
-# the next member — and an escaped exception here exits 1, which the caller
-# maps to "predates the cacheable field" for a file it could not decode.
-except (OSError, ValueError):
-    raise SystemExit(2)
-if not isinstance(receipt, dict):
-    raise SystemExit(2)
-# Verdict FIRST, matching the report: an unsupported verdict is the stronger
-# signal and carries different advice than "this file is merely old". Read
-# defensively, because a hand-edited receipt is exactly where a non-object
-# `release_gate` shows up and a bare `.get` would raise instead of classifying.
-gate = receipt.get("release_gate")
-verdict = gate.get("verdict") if isinstance(gate, dict) else None
-if verdict not in ("CLEAR", "BLOCK", "INCOMPLETE"):
-    raise SystemExit(3)
-raise SystemExit(0 if "cacheable" in receipt else 1)
-PY
+  python3 "$ROOT/scripts/eval/receipt_state.py" "$1"
 }
 for cand in "$CANDDIR"/*.jsonl; do
   base="$(basename "$cand" .jsonl)"
@@ -147,11 +125,12 @@ for cand in "$CANDDIR"/*.jsonl; do
       # so this is the path a reader actually meets. The post-judge branch below
       # keeps the plain wording deliberately: the judge that just wrote that
       # receipt always sets the field, so there `false` is the only way to get in.
-      receipt_refusal_state "$dest/summary.json"
+      bad_fields="$(receipt_refusal_state "$dest/summary.json")"
       case $? in
         0) reason="receipt is not cacheable" ;;
         1) reason="receipt predates the cacheable field" ;;
         3) reason="receipt carries a verdict this gate cannot produce" ;;
+        4) reason="receipt has malformed metadata ($bad_fields), so its gap counts prove nothing" ;;
         *) reason="receipt is unreadable or is not a JSON object" ;;
       esac
     else

--- a/scripts/eval/judge_ollama_bench.sh
+++ b/scripts/eval/judge_ollama_bench.sh
@@ -63,6 +63,22 @@ if not isinstance(receipt, dict):
 raise SystemExit(0 if receipt.get("cacheable") is True else 1)
 PY
 }
+
+# Distinguishes "the field is absent" from "the field says false" for the resume
+# message only. Deliberately NOT part of the caching decision: both cases fail
+# closed and are re-judged, so this changes what the reader is told and nothing
+# else. Fails closed the same way, because an unreadable receipt has no field.
+receipt_has_cacheable_field() {
+  python3 - "$1" <<'PY'
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        receipt = json.load(f)
+except (OSError, json.JSONDecodeError):
+    raise SystemExit(1)
+raise SystemExit(0 if isinstance(receipt, dict) and "cacheable" in receipt else 1)
+PY
+}
 for cand in "$CANDDIR"/*.jsonl; do
   base="$(basename "$cand" .jsonl)"
   dest="$OUTDIR/$base"
@@ -90,7 +106,19 @@ for cand in "$CANDDIR"/*.jsonl; do
     # non-cacheable receipt as a stamp mismatch sends the reader after the wrong
     # thing entirely.
     if [ -f "$stamp" ] && [ "$(cat "$stamp")" = "$inputs_sha" ]; then
-      reason="receipt is not cacheable"
+      # A refusal must name its own reason, and these are two different
+      # situations: a receipt written before #2007 simply has no acceptance field
+      # and needs one re-judge, while a receipt carrying `cacheable: false`
+      # recorded real gaps. Calling the first one "not cacheable" reads as a
+      # broken receipt. Every arm of the shipped #1950 sweep hits the first case,
+      # so this is the path a reader actually meets. The post-judge branch below
+      # keeps the plain wording deliberately: the judge that just wrote that
+      # receipt always sets the field, so there `false` is the only way to get in.
+      if receipt_has_cacheable_field "$dest/summary.json"; then
+        reason="receipt is not cacheable"
+      else
+        reason="receipt predates the cacheable field"
+      fi
     else
       reason="candidates or corpus changed since its receipt"
     fi

--- a/scripts/eval/judge_ollama_bench.sh
+++ b/scripts/eval/judge_ollama_bench.sh
@@ -56,7 +56,12 @@ import json, sys
 try:
     with open(sys.argv[1]) as f:
         receipt = json.load(f)
-except (OSError, json.JSONDecodeError):
+# ValueError, not JSONDecodeError: invalid UTF-8 raises UnicodeDecodeError,
+# which a JSONDecodeError-only tuple misses. Both are ValueError subclasses,
+# so catching the base is the enumeration rather than a list that can miss
+# the next member — and an escaped exception here exits 1, which the caller
+# maps to "predates the cacheable field" for a file it could not decode.
+except (OSError, ValueError):
     raise SystemExit(1)
 if not isinstance(receipt, dict):
     raise SystemExit(1)
@@ -81,7 +86,12 @@ import json, sys
 try:
     with open(sys.argv[1]) as f:
         receipt = json.load(f)
-except (OSError, json.JSONDecodeError):
+# ValueError, not JSONDecodeError: invalid UTF-8 raises UnicodeDecodeError,
+# which a JSONDecodeError-only tuple misses. Both are ValueError subclasses,
+# so catching the base is the enumeration rather than a list that can miss
+# the next member — and an escaped exception here exits 1, which the caller
+# maps to "predates the cacheable field" for a file it could not decode.
+except (OSError, ValueError):
     raise SystemExit(2)
 if not isinstance(receipt, dict):
     raise SystemExit(2)

--- a/scripts/eval/receipt_state.py
+++ b/scripts/eval/receipt_state.py
@@ -56,6 +56,18 @@ def _is_int(v) -> bool:
     return isinstance(v, int) and not isinstance(v, bool)
 
 
+def _is_count(v) -> bool:
+    """A count: a non-negative integer.
+
+    Type validity alone is not enough, and stopping there was an axis I cut too
+    narrow. `adjudication_missing_n: -1` passes `_is_int` and prints "-1
+    adjudication-dropped", which is not a fact about anything. A number whose
+    VALUE is impossible is as corrupt as one whose type is wrong, and both must be
+    named rather than rendered.
+    """
+    return _is_int(v) and v >= 0
+
+
 def _as_int(v) -> int:
     return v if _is_int(v) else 0
 
@@ -77,13 +89,25 @@ def malformed_metadata_fields(receipt: dict) -> list[str]:
     if isinstance(adj, dict):
         names += [f"adjudication.{k}" for k in
                   ("adjudication_missing_n", "adjudicated_n")
-                  if k in adj and not _is_int(adj[k])]
+                  if k in adj and not _is_count(adj[k])]
 
     wobble = receipt.get("wobble")
+    rc = wobble.get("rep_coverage") if isinstance(wobble, dict) else None
     if isinstance(wobble, dict) and "rep_coverage" in wobble:
-        rc = wobble["rep_coverage"]
-        if not isinstance(rc, list) or not all(_is_int(x) for x in rc):
+        if not isinstance(rc, list) or not all(_is_count(x) for x in rc):
             names.append("wobble.rep_coverage")
+
+    # RELATIONSHIP, not just range. An adjudication pass cannot return more cases
+    # than were selected for it, so `rep_coverage[1] > adjudicated_n` is
+    # impossible — and the derivation's `max(0, ...)` would quietly clamp that to
+    # zero and report "no adjudication gap", erasing the corruption instead of
+    # naming it. Only checked when the derivation would actually run, i.e. when
+    # the explicit count is absent and there are two coverage entries.
+    if (isinstance(adj, dict) and not _is_count(adj.get("adjudication_missing_n"))
+            and isinstance(rc, list) and len(rc) > 1
+            and all(_is_count(x) for x in rc) and _is_count(adj.get("adjudicated_n"))
+            and rc[1] > adj["adjudicated_n"]):
+        names.append("adjudication.adjudicated_n vs wobble.rep_coverage")
 
     return sorted(names)
 
@@ -128,10 +152,14 @@ def adjudication_dropped(receipt: dict) -> int:
     """
     adj = _as_dict(receipt.get("adjudication"))
     explicit = adj.get("adjudication_missing_n")
-    if _is_int(explicit):
+    if _is_count(explicit):
         return explicit
     rep_coverage = _as_list(_as_dict(receipt.get("wobble")).get("rep_coverage"))
     if len(rep_coverage) > 1:
+        # `max(0, ...)` is defence only. An impossible coverage-exceeds-selected
+        # relationship is rejected as malformed before this runs, precisely so the
+        # clamp cannot erase it — clamping a contradiction to zero and calling it
+        # "no gap" is the failure this guard exists to prevent.
         return max(0, _as_int(adj.get("adjudicated_n")) - _as_int(rep_coverage[1]))
     return 0
 

--- a/scripts/eval/receipt_state.py
+++ b/scripts/eval/receipt_state.py
@@ -68,10 +68,6 @@ def _is_count(v) -> bool:
     return _is_int(v) and v >= 0
 
 
-def _as_int(v) -> int:
-    return v if _is_int(v) else 0
-
-
 def malformed_metadata_fields(receipt: dict) -> list[str]:
     """Gap fields that are PRESENT with an unusable type, sorted.
 

--- a/scripts/eval/receipt_state.py
+++ b/scripts/eval/receipt_state.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Why a judge receipt cannot be trusted — ONE classifier, two consumers.
+
+`report_ollama_bench.py` (ranking) and `judge_ollama_bench.sh` (caching) both have
+to explain a refused receipt, and they must give the SAME explanation for the same
+file or an operator cannot tell which to believe.
+
+They were two copies of the same logic in two languages, and copies diverge: in
+one PR the shell fell behind twice, first on verdict classification and then on
+malformed metadata, each time announcing "predates the `cacheable` field" about a
+file the report correctly called hand-edited or corrupt. Both were caught by
+review rather than by anything structural, because a comment asking for parity
+cannot enforce it. So this module is the single authority and the shell shells out
+to it rather than reimplementing it.
+
+A REFUSAL MUST NEVER RAISE AND MUST NEVER GUESS. Every field read here goes
+through an accessor that cannot raise on any JSON value, and a field that is
+present with the wrong type is reported as malformed rather than coerced —
+coercing `"skipped": "not a list"` to `[]` manufactures the claim "records no
+gaps", which is a false statement about a receipt that records nothing usable.
+
+CLI contract, used by the shell: exit code IS the state, stdout carries the
+malformed field names (empty otherwise).
+"""
+from __future__ import annotations
+
+import json
+import sys
+
+# Verdicts this gate can actually emit. Anything else means the receipt was not
+# produced by `evaluate_new_gate` — hand-edited, or from another tool.
+ALLOWED_VERDICTS = ("CLEAR", "BLOCK", "INCOMPLETE")
+
+# States, ordered by precedence rather than severity. Verdict is classified before
+# metadata is read, for two independent reasons: an unsupported verdict is the
+# stronger signal and carries different advice than "this file is merely old", and
+# it marks a hand-edited file, which is exactly where malformed metadata lives —
+# so the fragile reads never run for the receipts most likely to break them.
+NOT_CACHEABLE = 0      # object carrying `cacheable`, so the field says false
+LEGACY = 1             # object without it, valid verdict (written before #2007)
+UNREADABLE = 2         # missing, undecodable, malformed JSON, or not an object
+UNSUPPORTED_VERDICT = 3  # a verdict this gate cannot emit
+MALFORMED_METADATA = 4   # valid verdict, but gap fields whose types prove nothing
+
+
+def _as_dict(v):
+    return v if isinstance(v, dict) else {}
+
+
+def _as_list(v):
+    return v if isinstance(v, list) else []
+
+
+def _is_int(v) -> bool:
+    # `bool` is an `int` subclass, and `True` must not read as 1 in a count.
+    return isinstance(v, int) and not isinstance(v, bool)
+
+
+def _as_int(v) -> int:
+    return v if _is_int(v) else 0
+
+
+def malformed_metadata_fields(receipt: dict) -> list[str]:
+    """Gap fields that are PRESENT with an unusable type, sorted.
+
+    Absent is not malformed: it means nothing was recorded, which a pre-#2007
+    receipt does legitimately. Only a present-but-wrong-typed field is a lie
+    waiting to be told.
+    """
+    names = []
+    for key, coerce in (("skipped", _as_list), ("missing_scores", _as_list),
+                        ("adjudication", _as_dict), ("wobble", _as_dict)):
+        if key in receipt and coerce(receipt[key]) is not receipt[key]:
+            names.append(key)
+
+    adj = receipt.get("adjudication")
+    if isinstance(adj, dict):
+        names += [f"adjudication.{k}" for k in
+                  ("adjudication_missing_n", "adjudicated_n")
+                  if k in adj and not _is_int(adj[k])]
+
+    wobble = receipt.get("wobble")
+    if isinstance(wobble, dict) and "rep_coverage" in wobble:
+        rc = wobble["rep_coverage"]
+        if not isinstance(rc, list) or not all(_is_int(x) for x in rc):
+            names.append("wobble.rep_coverage")
+
+    return sorted(names)
+
+
+def classify(path) -> tuple[int, list[str]]:
+    """Returns (state, malformed field names). Never raises."""
+    try:
+        with open(path) as f:
+            receipt = json.load(f)
+    # ValueError, not JSONDecodeError: invalid UTF-8 raises UnicodeDecodeError,
+    # which a JSONDecodeError-only tuple misses. Both are ValueError subclasses,
+    # so catching the base is the enumeration rather than a list of names that can
+    # miss the next member.
+    except (OSError, ValueError):
+        return UNREADABLE, []
+    if not isinstance(receipt, dict):
+        return UNREADABLE, []
+
+    verdict = _as_dict(receipt.get("release_gate")).get("verdict")
+    if verdict not in ALLOWED_VERDICTS:
+        return UNSUPPORTED_VERDICT, []
+
+    malformed = malformed_metadata_fields(receipt)
+    if malformed:
+        return MALFORMED_METADATA, malformed
+
+    return (NOT_CACHEABLE if "cacheable" in receipt else LEGACY), []
+
+
+def adjudication_dropped(receipt: dict) -> int:
+    """How many adjudication scores this receipt records as dropped.
+
+    A pre-#2007 receipt has no explicit `adjudication_missing_n` but DOES carry
+    the evidence, so defaulting to zero would claim "no adjudication gap" from a
+    receipt that proves one. `behavior_judge` sets `rep_scores =
+    [primary_premerge, adjudication]`, so `wobble.rep_coverage[1]` is how many
+    judged ids the adjudication pass returned while `adjudicated_n` is how many
+    were selected; the difference is the drop. Only meaningful when a pass ran —
+    with none, `rep_coverage` has a single entry and there is nothing to compare.
+
+    Callers must reject malformed metadata first; this assumes usable types.
+    """
+    adj = _as_dict(receipt.get("adjudication"))
+    explicit = adj.get("adjudication_missing_n")
+    if _is_int(explicit):
+        return explicit
+    rep_coverage = _as_list(_as_dict(receipt.get("wobble")).get("rep_coverage"))
+    if len(rep_coverage) > 1:
+        return max(0, _as_int(adj.get("adjudicated_n")) - _as_int(rep_coverage[1]))
+    return 0
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: receipt_state.py <summary.json>", file=sys.stderr)
+        return 64
+    state, malformed = classify(sys.argv[1])
+    if malformed:
+        print(", ".join(malformed))
+    return state
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/eval/receipt_state.py
+++ b/scripts/eval/receipt_state.py
@@ -97,16 +97,21 @@ def malformed_metadata_fields(receipt: dict) -> list[str]:
         if not isinstance(rc, list) or not all(_is_count(x) for x in rc):
             names.append("wobble.rep_coverage")
 
-    # RELATIONSHIP, not just range. An adjudication pass cannot return more cases
-    # than were selected for it, so `rep_coverage[1] > adjudicated_n` is
-    # impossible — and the derivation's `max(0, ...)` would quietly clamp that to
-    # zero and report "no adjudication gap", erasing the corruption instead of
-    # naming it. Only checked when the derivation would actually run, i.e. when
-    # the explicit count is absent and there are two coverage entries.
-    if (isinstance(adj, dict) and not _is_count(adj.get("adjudication_missing_n"))
-            and isinstance(rc, list) and len(rc) > 1
-            and all(_is_count(x) for x in rc) and _is_count(adj.get("adjudicated_n"))
-            and rc[1] > adj["adjudicated_n"]):
+    # UNKNOWABLE IS NOT ZERO, and asking the derivation is how we find out.
+    #
+    # Four separate review rounds landed here, each naming one more way the
+    # two-pass derivation could be handed inputs that cannot support a count while
+    # it confidently returned one: an impossible coverage-exceeds-selected
+    # relationship, a negative entry, and then an ABSENT `adjudicated_n` coerced to
+    # zero. Adding a precondition per round was the wrong shape — the cause is that
+    # the derivation could not express "I do not know", so every missing input
+    # became a confident zero.
+    #
+    # `adjudication_dropped` now returns None for exactly that, and this asks it
+    # rather than re-deriving the preconditions. One authority for "can this be
+    # computed", shared by the validator and the renderer, so the two cannot
+    # disagree about whether a number exists.
+    if adjudication_dropped(receipt) is None:
         names.append("adjudication.adjudicated_n vs wobble.rep_coverage")
 
     return sorted(names)
@@ -137,31 +142,47 @@ def classify(path) -> tuple[int, list[str]]:
     return (NOT_CACHEABLE if "cacheable" in receipt else LEGACY), []
 
 
-def adjudication_dropped(receipt: dict) -> int:
-    """How many adjudication scores this receipt records as dropped.
+def adjudication_dropped(receipt: dict) -> "int | None":
+    """How many adjudication scores this receipt records as dropped, or None if
+    that is UNKNOWABLE from what it records.
 
     A pre-#2007 receipt has no explicit `adjudication_missing_n` but DOES carry
     the evidence, so defaulting to zero would claim "no adjudication gap" from a
     receipt that proves one. `behavior_judge` sets `rep_scores =
     [primary_premerge, adjudication]`, so `wobble.rep_coverage[1]` is how many
     judged ids the adjudication pass returned while `adjudicated_n` is how many
-    were selected; the difference is the drop. Only meaningful when a pass ran —
-    with none, `rep_coverage` has a single entry and there is nothing to compare.
+    were selected; the difference is the drop.
 
-    Callers must reject malformed metadata first; this assumes usable types.
+    THE THREE ANSWERS ARE DISTINCT AND CONFLATING TWO OF THEM WAS THE DEFECT:
+      a number  — computable, from the explicit count or the two-pass difference
+      0         — no adjudication pass ran, so nothing was dropped
+      None      — a pass ran but the receipt does not record enough to say
+
+    `malformed_metadata_fields` asks this and reports None as malformed, so a
+    caller that has already passed validation always gets a number.
     """
     adj = _as_dict(receipt.get("adjudication"))
     explicit = adj.get("adjudication_missing_n")
     if _is_count(explicit):
         return explicit
+
     rep_coverage = _as_list(_as_dict(receipt.get("wobble")).get("rep_coverage"))
-    if len(rep_coverage) > 1:
-        # `max(0, ...)` is defence only. An impossible coverage-exceeds-selected
-        # relationship is rejected as malformed before this runs, precisely so the
-        # clamp cannot erase it — clamping a contradiction to zero and calling it
-        # "no gap" is the failure this guard exists to prevent.
-        return max(0, _as_int(adj.get("adjudicated_n")) - _as_int(rep_coverage[1]))
-    return 0
+    if len(rep_coverage) < 2:
+        # Fewer than two replications means no adjudication pass ran, so nothing
+        # was dropped. Genuinely zero, not unknown.
+        return 0
+
+    # A pass DID run, so a count exists in principle and the only question is
+    # whether this receipt records enough to compute it. Returning None rather
+    # than a clamped zero is the whole point: `max(0, ...)` over a missing or
+    # contradictory input reports "no gap" about a receipt that cannot support
+    # that claim, which is the same manufactured-fact defect as coercing a
+    # corrupt list to empty.
+    selected = adj.get("adjudicated_n")
+    returned = rep_coverage[1]
+    if not _is_count(selected) or not _is_count(returned) or returned > selected:
+        return None
+    return selected - returned
 
 
 def main() -> int:

--- a/scripts/eval/receipt_state.py
+++ b/scripts/eval/receipt_state.py
@@ -162,10 +162,23 @@ def adjudication_dropped(receipt: dict) -> "int | None":
     if _is_count(explicit):
         return explicit
 
+    selected = adj.get("adjudicated_n")
     rep_coverage = _as_list(_as_dict(receipt.get("wobble")).get("rep_coverage"))
     if len(rep_coverage) < 2:
-        # Fewer than two replications means no adjudication pass ran, so nothing
-        # was dropped. Genuinely zero, not unknown.
+        # Fewer than two replications normally means no adjudication pass ran, so
+        # nothing was dropped — genuinely zero, not unknown.
+        #
+        # BUT the two must agree. `behavior_judge` sets `rep_scores =
+        # [primary_premerge, adjudication] if adjudicated_ids else [primary]`, so a
+        # non-zero `adjudicated_n` GUARANTEES two coverage entries. Selected > 0
+        # with fewer than two is internally inconsistent: a pass ran and its result
+        # is missing, which makes the drop unknowable rather than zero.
+        #
+        # This branch is the mirror of the one below, and my previous commit fixed
+        # only the other half — half an invariant is the partial port this file's
+        # own history keeps demonstrating.
+        if _is_count(selected) and selected > 0:
+            return None
         return 0
 
     # A pass DID run, so a count exists in principle and the only question is
@@ -174,7 +187,6 @@ def adjudication_dropped(receipt: dict) -> "int | None":
     # contradictory input reports "no gap" about a receipt that cannot support
     # that claim, which is the same manufactured-fact defect as coercing a
     # corrupt list to empty.
-    selected = adj.get("adjudicated_n")
     returned = rep_coverage[1]
     if not _is_count(selected) or not _is_count(returned) or returned > selected:
         return None

--- a/scripts/eval/report_ollama_bench.py
+++ b/scripts/eval/report_ollama_bench.py
@@ -127,7 +127,25 @@ def main() -> int:
                 continue
             problems.append(f"{model}: no quality receipt at {jdir}")
             continue
-        summary = load_json(summary_path)
+        # A corrupt receipt is a refusal like any other and must name the MODEL,
+        # not a line number. Reading it unguarded aborted the WHOLE report on one
+        # bad file — losing fifteen good arms — and printed a traceback where
+        # every sibling refusal prints "<model> (<arm>): <reason>; re-judge".
+        # The caching layer has always shape-checked here (`receipt_cacheable`'s
+        # isinstance guard); this closes the same gap in the ranking layer.
+        # Guarded at the call site rather than inside `load_json`, because the
+        # run-summary caller above wants a DIFFERENT message with no per-model
+        # attribution, and one shared sentence would be wrong for both.
+        try:
+            summary = load_json(summary_path)
+        except (OSError, json.JSONDecodeError) as exc:
+            problems.append(f"{model} ({cand_stem}): judge receipt is unreadable "
+                            f"({exc.__class__.__name__}); re-judge")
+            continue
+        if not isinstance(summary, dict):
+            problems.append(f"{model} ({cand_stem}): judge receipt is valid JSON but not "
+                            f"an object ({type(summary).__name__}); re-judge")
+            continue
 
         # A judge receipt can exist and still be PARTIAL. When cases are dropped
         # or engine-skipped, behavior_judge writes summary.json, marks its
@@ -162,7 +180,25 @@ def main() -> int:
             # they get different sentences: a pre-field receipt needs one re-judge
             # and nothing else, while a `cacheable: false` receipt has real gaps
             # worth reading.
-            adj_dropped = (summary.get("adjudication") or {}).get("adjudication_missing_n", 0)
+            adj = summary.get("adjudication") or {}
+            adj_dropped = adj.get("adjudication_missing_n")
+            if adj_dropped is None:
+                # A pre-#2007 receipt has no explicit count but DOES carry the
+                # evidence, so defaulting to zero would claim "no adjudication
+                # gap" from a receipt that proves one. `behavior_judge` sets
+                # `rep_scores = [primary_premerge, adjudication]`, so
+                # `wobble.rep_coverage[1]` is how many judged ids the
+                # adjudication pass returned while `adjudicated_n` is how many
+                # were selected; the difference is the drop. Only meaningful
+                # when an adjudication pass ran — with none, `rep_coverage` has
+                # a single entry and there is nothing to compare.
+                #
+                # This matters precisely for old receipts: a silently dropped
+                # adjudication IS the defect #2007 was opened for, so the
+                # receipts most likely to carry one are the legacy ones.
+                rep_coverage = (summary.get("wobble") or {}).get("rep_coverage") or []
+                adj_dropped = (max(0, adj.get("adjudicated_n", 0) - rep_coverage[1])
+                               if len(rep_coverage) > 1 else 0)
             gaps = (f"{len(summary.get('skipped', []))} engine-skipped, "
                     f"{len(summary.get('missing_scores', []))} primary judge-dropped, "
                     f"{adj_dropped} adjudication-dropped")
@@ -237,7 +273,22 @@ def main() -> int:
                 f"be ranked ({detail}); re-run those cases")
             continue
 
-        per_case = [json.loads(l) for l in open(per_case_path) if l.strip()]
+        # Same class as the receipt guard above; measured to fail identically.
+        # The row shape-check is not padding: every consumer below reaches rows
+        # through `pred(x)` predicates that call `.get`, so a valid-JSON
+        # non-object row would crash there instead, one layer further from the
+        # cause.
+        try:
+            per_case = [json.loads(l) for l in open(per_case_path) if l.strip()]
+        except (OSError, json.JSONDecodeError) as exc:
+            problems.append(f"{model} ({cand_stem}): per_case.jsonl is unreadable "
+                            f"({exc.__class__.__name__}); re-judge")
+            continue
+        if not all(isinstance(row, dict) for row in per_case):
+            problems.append(f"{model} ({cand_stem}): per_case.jsonl contains a row that is "
+                            f"not an object, so the language split cannot be computed; "
+                            f"re-judge")
+            continue
 
         # The language splits below are computed from per_case.jsonl while the
         # headline pass rate comes from summary.json. A truncated detail file

--- a/scripts/eval/report_ollama_bench.py
+++ b/scripts/eval/report_ollama_bench.py
@@ -45,31 +45,21 @@ def load_json(p: Path):
         return json.load(f)
 
 
-# Verdicts this gate can actually emit. A receipt carrying anything else was not
-# produced by `evaluate_new_gate` — it is hand-edited or from another tool.
-ALLOWED_VERDICTS = ("CLEAR", "BLOCK", "INCOMPLETE")
-
-
-# A REFUSAL MUST NEVER RAISE. Four review rounds each found one more receipt
-# shape that made the refusal path crash or mislabel — malformed JSON, a
-# non-object, invalid UTF-8, then a hand-edited `"wobble": ["bad"]` turning a
-# `.get` into an AttributeError. Patching the named cell each round is the
-# iterate-the-gaps failure `parse-structured-input-dont-regex-and-iterate`
-# forbids, so these three accessors close the whole class instead: every field a
-# refusal reads goes through one, and none of them can raise on any JSON value.
-# A receipt being refused is by definition untrusted input; treating it as
-# well-formed while explaining why it is not trusted was the contradiction.
-def _as_dict(v) -> dict:
-    return v if isinstance(v, dict) else {}
-
-
-def _as_list(v) -> list:
-    return v if isinstance(v, list) else []
-
-
-def _as_int(v) -> int:
-    # `bool` is an `int` subclass, and `True` must not read as 1 here.
-    return v if isinstance(v, int) and not isinstance(v, bool) else 0
+# Why a receipt is refused is classified in ONE place, shared with
+# `judge_ollama_bench.sh`, because two copies in two languages diverged twice in
+# one PR — the shell announced "predates the `cacheable` field" about files this
+# script correctly called hand-edited and then corrupt. A comment asking for
+# parity cannot enforce it; a shared module can.
+from receipt_state import (  # noqa: E402
+    LEGACY,
+    MALFORMED_METADATA,
+    NOT_CACHEABLE,
+    UNSUPPORTED_VERDICT,
+    _as_dict,
+    _as_list,
+    adjudication_dropped,
+    classify,
+)
 
 
 def main() -> int:
@@ -196,8 +186,8 @@ def main() -> int:
         # model with some engine errors is INCOMPLETE by coverage yet FINISHED as
         # evidence, and `tier()` below ranks exactly that case "Not recommended".
         release_verdict = _as_dict(summary.get("release_gate")).get("verdict")
-        if summary.get("cacheable") is not True \
-                or release_verdict not in ALLOWED_VERDICTS:
+        state, malformed = classify(summary_path)
+        if state != NOT_CACHEABLE or summary.get("cacheable") is not True:
             # A refusal must NAME ITS OWN REASON. Reporting the three gap counts
             # unconditionally printed "0 engine-skipped, 0 primary judge-dropped,
             # 0 adjudication-dropped" for a receipt written before `cacheable`
@@ -222,76 +212,28 @@ def main() -> int:
             # Safe against mislabelling a genuine legacy receipt: all 16 shipped
             # #1950 arms carry `BLOCK`, which is allowlisted, so a real
             # pre-#2007 receipt still reaches the legacy message below.
-            if release_verdict not in ALLOWED_VERDICTS:
+            if state == UNSUPPORTED_VERDICT:
                 problems.append(
                     f"{model} ({cand_stem}): judge receipt carries verdict "
                     f"{release_verdict!r}, which this gate cannot produce — the file is "
                     f"not one of ours or was hand-edited; re-judge")
                 continue
 
-            # VALIDATE BEFORE READING, because coercion makes a FALSE CLAIM.
-            # The accessors below stop the refusal path crashing, but silently
-            # turning a corrupt `"skipped": "not a list"` into `[]` produces
-            # "records no gaps of its own" about a receipt that records nothing
-            # trustworthy — trading a crash for a wrong sentence, which is the
-            # very defect this whole change set exists to remove. A malformed gap
-            # field is no evidence that the gap is zero.
-            #
-            # Absent is fine and means "genuinely nothing recorded". Present with
-            # the wrong type means corrupt or hand-edited, and gets said out loud.
-            # This is the parse-then-use half of
-            # `parse-structured-input-dont-regex-and-iterate`; coercing first was
-            # the shortcut that produced the false claim.
-            def _is_int(v) -> bool:
-                return isinstance(v, int) and not isinstance(v, bool)
-
-            raw_adj = summary.get("adjudication")
-            raw_wobble = summary.get("wobble")
-            checks = [
-                ("skipped", "skipped" in summary, summary.get("skipped"), _as_list),
-                ("missing_scores", "missing_scores" in summary,
-                 summary.get("missing_scores"), _as_list),
-                ("adjudication", "adjudication" in summary, raw_adj, _as_dict),
-                ("wobble", "wobble" in summary, raw_wobble, _as_dict),
-            ]
-            malformed = [name for name, present, value, coerce in checks
-                         if present and coerce(value) is not value]
-            if isinstance(raw_adj, dict):
-                malformed += [f"adjudication.{k}" for k in
-                              ("adjudication_missing_n", "adjudicated_n")
-                              if k in raw_adj and not _is_int(raw_adj[k])]
-            if isinstance(raw_wobble, dict) and "rep_coverage" in raw_wobble:
-                rc = raw_wobble["rep_coverage"]
-                if not isinstance(rc, list) or not all(_is_int(x) for x in rc):
-                    malformed.append("wobble.rep_coverage")
-            if malformed:
+            if state == MALFORMED_METADATA:
+                # Coercing a corrupt `"skipped": "not a list"` to `[]` would
+                # manufacture "records no gaps of its own" about a receipt that
+                # records nothing usable — a false claim, and the very defect this
+                # change set exists to remove. A malformed field is no evidence the
+                # gap is zero, so it is named rather than erased.
                 problems.append(
                     f"{model} ({cand_stem}): judge receipt has malformed "
-                    f"{', '.join(sorted(malformed))}, so its gap counts prove nothing — "
+                    f"{', '.join(malformed)}, so its gap counts prove nothing — "
                     f"the file is corrupt or hand-edited; re-judge")
                 continue
 
             skipped = _as_list(summary.get("skipped"))
             missing = _as_list(summary.get("missing_scores"))
-            adj = _as_dict(summary.get("adjudication"))
-            adj_dropped = adj.get("adjudication_missing_n")
-            if not isinstance(adj_dropped, int) or isinstance(adj_dropped, bool):
-                # Absent OR non-numeric. A pre-#2007 receipt has no explicit
-                # count but DOES carry the evidence, so defaulting to zero would
-                # claim "no adjudication gap" from a receipt that proves one.
-                # `behavior_judge` sets `rep_scores = [primary_premerge,
-                # adjudication]`, so `wobble.rep_coverage[1]` is how many judged
-                # ids the adjudication pass returned while `adjudicated_n` is how
-                # many were selected; the difference is the drop. Only meaningful
-                # when an adjudication pass ran — with none, `rep_coverage` has a
-                # single entry and there is nothing to compare.
-                #
-                # This matters precisely for old receipts: a silently dropped
-                # adjudication IS the defect #2007 was opened for, so the
-                # receipts most likely to carry one are the legacy ones.
-                rep_coverage = _as_list(_as_dict(summary.get("wobble")).get("rep_coverage"))
-                adj_dropped = (max(0, _as_int(adj.get("adjudicated_n")) - _as_int(rep_coverage[1]))
-                               if len(rep_coverage) > 1 else 0)
+            adj_dropped = adjudication_dropped(summary)
             gaps = (f"{len(skipped)} engine-skipped, "
                     f"{len(missing)} primary judge-dropped, "
                     f"{adj_dropped} adjudication-dropped")

--- a/scripts/eval/report_ollama_bench.py
+++ b/scripts/eval/report_ollama_bench.py
@@ -204,7 +204,22 @@ def main() -> int:
                     f"{adj_dropped} adjudication-dropped")
             any_gap = (summary.get("skipped") or summary.get("missing_scores") or adj_dropped)
 
-            if "cacheable" not in summary:
+            # ORDER MATTERS, and cloud review caught it the other way round. A
+            # receipt can be BOTH legacy AND carry a verdict this gate cannot
+            # emit; checking field-absence first reported it as merely old and
+            # suppressed the stronger signal. The two also carry different
+            # ADVICE — "re-judge once" is wrong for a file that is not one of
+            # ours — so the verdict check goes first.
+            #
+            # Safe against mislabelling a genuine legacy receipt: all 16 shipped
+            # #1950 arms carry `BLOCK`, which is allowlisted, so a real
+            # pre-#2007 receipt still reaches the legacy message below.
+            if release_verdict not in ("CLEAR", "BLOCK", "INCOMPLETE"):
+                problems.append(
+                    f"{model} ({cand_stem}): judge receipt carries verdict "
+                    f"{release_verdict!r}, which this gate cannot produce — the file is "
+                    f"not one of ours or was hand-edited; re-judge")
+            elif "cacheable" not in summary:
                 # A pre-#2007 receipt still RECORDS its gaps; what it lacks is the
                 # judge's acceptance answer. So report the recorded gaps when there
                 # are any and stay silent about them when there are none — saying
@@ -216,11 +231,6 @@ def main() -> int:
                 problems.append(
                     f"{model} ({cand_stem}): judge receipt predates the `cacheable` "
                     f"field (written before #2007) {detail}; re-judge once")
-            elif release_verdict not in ("CLEAR", "BLOCK", "INCOMPLETE"):
-                problems.append(
-                    f"{model} ({cand_stem}): judge receipt carries verdict "
-                    f"{release_verdict!r}, which this gate cannot produce — the file is "
-                    f"not one of ours or was hand-edited; re-judge")
             else:
                 problems.append(
                     f"{model} ({cand_stem}): judge receipt is not cacheable "

--- a/scripts/eval/report_ollama_bench.py
+++ b/scripts/eval/report_ollama_bench.py
@@ -150,13 +150,45 @@ def main() -> int:
         release_verdict = (summary.get("release_gate") or {}).get("verdict")
         if summary.get("cacheable") is not True \
                 or release_verdict not in ("CLEAR", "BLOCK", "INCOMPLETE"):
+            # A refusal must NAME ITS OWN REASON. Reporting the three gap counts
+            # unconditionally printed "0 engine-skipped, 0 primary judge-dropped,
+            # 0 adjudication-dropped" for a receipt written before `cacheable`
+            # existed — all zeros, yet refused, which reads as "nothing is wrong
+            # and I rejected it anyway". Measured against the real #1950 run data:
+            # 14 of 16 arms produced exactly that. Same shape as the adjudication
+            # message that printed two zeros before #2007 fixed it.
+            #
+            # These are genuinely different situations with different responses, so
+            # they get different sentences: a pre-field receipt needs one re-judge
+            # and nothing else, while a `cacheable: false` receipt has real gaps
+            # worth reading.
             adj_dropped = (summary.get("adjudication") or {}).get("adjudication_missing_n", 0)
-            problems.append(
-                f"{model} ({cand_stem}): judge receipt is not cacheable "
-                f"(verdict {release_verdict!r}) — "
-                f"{len(summary.get('skipped', []))} engine-skipped, "
-                f"{len(summary.get('missing_scores', []))} primary judge-dropped, "
-                f"{adj_dropped} adjudication-dropped; re-judge")
+            gaps = (f"{len(summary.get('skipped', []))} engine-skipped, "
+                    f"{len(summary.get('missing_scores', []))} primary judge-dropped, "
+                    f"{adj_dropped} adjudication-dropped")
+            any_gap = (summary.get("skipped") or summary.get("missing_scores") or adj_dropped)
+
+            if "cacheable" not in summary:
+                # A pre-#2007 receipt still RECORDS its gaps; what it lacks is the
+                # judge's acceptance answer. So report the recorded gaps when there
+                # are any and stay silent about them when there are none — saying
+                # "no gap is implied" unconditionally would have been false on the
+                # real #1950 data, where llama3.2's receipt records four dropped
+                # international scores.
+                detail = (f"and records {gaps}" if any_gap
+                          else "and records no gaps of its own")
+                problems.append(
+                    f"{model} ({cand_stem}): judge receipt predates the `cacheable` "
+                    f"field (written before #2007) {detail}; re-judge once")
+            elif release_verdict not in ("CLEAR", "BLOCK", "INCOMPLETE"):
+                problems.append(
+                    f"{model} ({cand_stem}): judge receipt carries verdict "
+                    f"{release_verdict!r}, which this gate cannot produce — the file is "
+                    f"not one of ours or was hand-edited; re-judge")
+            else:
+                problems.append(
+                    f"{model} ({cand_stem}): judge receipt is not cacheable "
+                    f"(verdict {release_verdict!r}) — {gaps}; re-judge")
             continue
 
         # Independent reconciliation against the RUN's own case count, because

--- a/scripts/eval/report_ollama_bench.py
+++ b/scripts/eval/report_ollama_bench.py
@@ -45,6 +45,33 @@ def load_json(p: Path):
         return json.load(f)
 
 
+# Verdicts this gate can actually emit. A receipt carrying anything else was not
+# produced by `evaluate_new_gate` — it is hand-edited or from another tool.
+ALLOWED_VERDICTS = ("CLEAR", "BLOCK", "INCOMPLETE")
+
+
+# A REFUSAL MUST NEVER RAISE. Four review rounds each found one more receipt
+# shape that made the refusal path crash or mislabel — malformed JSON, a
+# non-object, invalid UTF-8, then a hand-edited `"wobble": ["bad"]` turning a
+# `.get` into an AttributeError. Patching the named cell each round is the
+# iterate-the-gaps failure `parse-structured-input-dont-regex-and-iterate`
+# forbids, so these three accessors close the whole class instead: every field a
+# refusal reads goes through one, and none of them can raise on any JSON value.
+# A receipt being refused is by definition untrusted input; treating it as
+# well-formed while explaining why it is not trusted was the contradiction.
+def _as_dict(v) -> dict:
+    return v if isinstance(v, dict) else {}
+
+
+def _as_list(v) -> list:
+    return v if isinstance(v, list) else []
+
+
+def _as_int(v) -> int:
+    # `bool` is an `int` subclass, and `True` must not read as 1 here.
+    return v if isinstance(v, int) and not isinstance(v, bool) else 0
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--run-summaries", required=True, nargs="+", type=Path)
@@ -168,9 +195,9 @@ def main() -> int:
         # absent or unknown verdict — and INCOMPLETE is included deliberately: a
         # model with some engine errors is INCOMPLETE by coverage yet FINISHED as
         # evidence, and `tier()` below ranks exactly that case "Not recommended".
-        release_verdict = (summary.get("release_gate") or {}).get("verdict")
+        release_verdict = _as_dict(summary.get("release_gate")).get("verdict")
         if summary.get("cacheable") is not True \
-                or release_verdict not in ("CLEAR", "BLOCK", "INCOMPLETE"):
+                or release_verdict not in ALLOWED_VERDICTS:
             # A refusal must NAME ITS OWN REASON. Reporting the three gap counts
             # unconditionally printed "0 engine-skipped, 0 primary judge-dropped,
             # 0 adjudication-dropped" for a receipt written before `cacheable`
@@ -179,50 +206,59 @@ def main() -> int:
             # 14 of 16 arms produced exactly that. Same shape as the adjudication
             # message that printed two zeros before #2007 fixed it.
             #
-            # These are genuinely different situations with different responses, so
-            # they get different sentences: a pre-field receipt needs one re-judge
-            # and nothing else, while a `cacheable: false` receipt has real gaps
-            # worth reading.
-            adj = summary.get("adjudication") or {}
-            adj_dropped = adj.get("adjudication_missing_n")
-            if adj_dropped is None:
-                # A pre-#2007 receipt has no explicit count but DOES carry the
-                # evidence, so defaulting to zero would claim "no adjudication
-                # gap" from a receipt that proves one. `behavior_judge` sets
-                # `rep_scores = [primary_premerge, adjudication]`, so
-                # `wobble.rep_coverage[1]` is how many judged ids the
-                # adjudication pass returned while `adjudicated_n` is how many
-                # were selected; the difference is the drop. Only meaningful
-                # when an adjudication pass ran — with none, `rep_coverage` has
-                # a single entry and there is nothing to compare.
-                #
-                # This matters precisely for old receipts: a silently dropped
-                # adjudication IS the defect #2007 was opened for, so the
-                # receipts most likely to carry one are the legacy ones.
-                rep_coverage = (summary.get("wobble") or {}).get("rep_coverage") or []
-                adj_dropped = (max(0, adj.get("adjudicated_n", 0) - rep_coverage[1])
-                               if len(rep_coverage) > 1 else 0)
-            gaps = (f"{len(summary.get('skipped', []))} engine-skipped, "
-                    f"{len(summary.get('missing_scores', []))} primary judge-dropped, "
-                    f"{adj_dropped} adjudication-dropped")
-            any_gap = (summary.get("skipped") or summary.get("missing_scores") or adj_dropped)
-
-            # ORDER MATTERS, and cloud review caught it the other way round. A
-            # receipt can be BOTH legacy AND carry a verdict this gate cannot
-            # emit; checking field-absence first reported it as merely old and
-            # suppressed the stronger signal. The two also carry different
-            # ADVICE — "re-judge once" is wrong for a file that is not one of
-            # ours — so the verdict check goes first.
+            # THREE REASONS, IN THIS ORDER, AND THE ORDER IS THE DESIGN.
+            #
+            # The verdict is classified FIRST, before any other field is read.
+            # Two independent reasons, both found by review the other way round:
+            # a receipt can be BOTH legacy AND carry a verdict this gate cannot
+            # emit, and calling that one "merely old" suppresses the stronger
+            # signal while giving the wrong advice ("re-judge once" is not what
+            # you do with a file that is not ours). Second, an unsupported
+            # verdict is the marker of a hand-edited file, which is exactly where
+            # malformed metadata lives — so classifying it before touching
+            # `adjudication` or `wobble` means the crash-prone reads never run
+            # for the receipts most likely to break them.
             #
             # Safe against mislabelling a genuine legacy receipt: all 16 shipped
             # #1950 arms carry `BLOCK`, which is allowlisted, so a real
             # pre-#2007 receipt still reaches the legacy message below.
-            if release_verdict not in ("CLEAR", "BLOCK", "INCOMPLETE"):
+            if release_verdict not in ALLOWED_VERDICTS:
                 problems.append(
                     f"{model} ({cand_stem}): judge receipt carries verdict "
                     f"{release_verdict!r}, which this gate cannot produce — the file is "
                     f"not one of ours or was hand-edited; re-judge")
-            elif "cacheable" not in summary:
+                continue
+
+            # Every read below goes through a type-safe accessor, because a
+            # receipt with a VALID verdict can still carry malformed metadata and
+            # ordering alone would not save it.
+            skipped = _as_list(summary.get("skipped"))
+            missing = _as_list(summary.get("missing_scores"))
+            adj = _as_dict(summary.get("adjudication"))
+            adj_dropped = adj.get("adjudication_missing_n")
+            if not isinstance(adj_dropped, int) or isinstance(adj_dropped, bool):
+                # Absent OR non-numeric. A pre-#2007 receipt has no explicit
+                # count but DOES carry the evidence, so defaulting to zero would
+                # claim "no adjudication gap" from a receipt that proves one.
+                # `behavior_judge` sets `rep_scores = [primary_premerge,
+                # adjudication]`, so `wobble.rep_coverage[1]` is how many judged
+                # ids the adjudication pass returned while `adjudicated_n` is how
+                # many were selected; the difference is the drop. Only meaningful
+                # when an adjudication pass ran — with none, `rep_coverage` has a
+                # single entry and there is nothing to compare.
+                #
+                # This matters precisely for old receipts: a silently dropped
+                # adjudication IS the defect #2007 was opened for, so the
+                # receipts most likely to carry one are the legacy ones.
+                rep_coverage = _as_list(_as_dict(summary.get("wobble")).get("rep_coverage"))
+                adj_dropped = (max(0, _as_int(adj.get("adjudicated_n")) - _as_int(rep_coverage[1]))
+                               if len(rep_coverage) > 1 else 0)
+            gaps = (f"{len(skipped)} engine-skipped, "
+                    f"{len(missing)} primary judge-dropped, "
+                    f"{adj_dropped} adjudication-dropped")
+            any_gap = bool(skipped or missing or adj_dropped)
+
+            if "cacheable" not in summary:
                 # A pre-#2007 receipt still RECORDS its gaps; what it lacks is the
                 # judge's acceptance answer. So report the recorded gaps when there
                 # are any and stay silent about them when there are none — saying

--- a/scripts/eval/report_ollama_bench.py
+++ b/scripts/eval/report_ollama_bench.py
@@ -138,7 +138,10 @@ def main() -> int:
         # attribution, and one shared sentence would be wrong for both.
         try:
             summary = load_json(summary_path)
-        except (OSError, json.JSONDecodeError) as exc:
+        # ValueError covers BOTH decode failures: json.JSONDecodeError and
+        # UnicodeDecodeError (invalid UTF-8) are both subclasses, and a
+        # JSONDecodeError-only tuple silently missed the second one.
+        except (OSError, ValueError) as exc:
             problems.append(f"{model} ({cand_stem}): judge receipt is unreadable "
                             f"({exc.__class__.__name__}); re-judge")
             continue
@@ -290,7 +293,10 @@ def main() -> int:
         # cause.
         try:
             per_case = [json.loads(l) for l in open(per_case_path) if l.strip()]
-        except (OSError, json.JSONDecodeError) as exc:
+        # ValueError covers BOTH decode failures: json.JSONDecodeError and
+        # UnicodeDecodeError (invalid UTF-8) are both subclasses, and a
+        # JSONDecodeError-only tuple silently missed the second one.
+        except (OSError, ValueError) as exc:
             problems.append(f"{model} ({cand_stem}): per_case.jsonl is unreadable "
                             f"({exc.__class__.__name__}); re-judge")
             continue

--- a/scripts/eval/report_ollama_bench.py
+++ b/scripts/eval/report_ollama_bench.py
@@ -51,7 +51,6 @@ def load_json(p: Path):
 # script correctly called hand-edited and then corrupt. A comment asking for
 # parity cannot enforce it; a shared module can.
 from receipt_state import (  # noqa: E402
-    LEGACY,
     MALFORMED_METADATA,
     NOT_CACHEABLE,
     UNSUPPORTED_VERDICT,

--- a/scripts/eval/report_ollama_bench.py
+++ b/scripts/eval/report_ollama_bench.py
@@ -229,9 +229,48 @@ def main() -> int:
                     f"not one of ours or was hand-edited; re-judge")
                 continue
 
-            # Every read below goes through a type-safe accessor, because a
-            # receipt with a VALID verdict can still carry malformed metadata and
-            # ordering alone would not save it.
+            # VALIDATE BEFORE READING, because coercion makes a FALSE CLAIM.
+            # The accessors below stop the refusal path crashing, but silently
+            # turning a corrupt `"skipped": "not a list"` into `[]` produces
+            # "records no gaps of its own" about a receipt that records nothing
+            # trustworthy — trading a crash for a wrong sentence, which is the
+            # very defect this whole change set exists to remove. A malformed gap
+            # field is no evidence that the gap is zero.
+            #
+            # Absent is fine and means "genuinely nothing recorded". Present with
+            # the wrong type means corrupt or hand-edited, and gets said out loud.
+            # This is the parse-then-use half of
+            # `parse-structured-input-dont-regex-and-iterate`; coercing first was
+            # the shortcut that produced the false claim.
+            def _is_int(v) -> bool:
+                return isinstance(v, int) and not isinstance(v, bool)
+
+            raw_adj = summary.get("adjudication")
+            raw_wobble = summary.get("wobble")
+            checks = [
+                ("skipped", "skipped" in summary, summary.get("skipped"), _as_list),
+                ("missing_scores", "missing_scores" in summary,
+                 summary.get("missing_scores"), _as_list),
+                ("adjudication", "adjudication" in summary, raw_adj, _as_dict),
+                ("wobble", "wobble" in summary, raw_wobble, _as_dict),
+            ]
+            malformed = [name for name, present, value, coerce in checks
+                         if present and coerce(value) is not value]
+            if isinstance(raw_adj, dict):
+                malformed += [f"adjudication.{k}" for k in
+                              ("adjudication_missing_n", "adjudicated_n")
+                              if k in raw_adj and not _is_int(raw_adj[k])]
+            if isinstance(raw_wobble, dict) and "rep_coverage" in raw_wobble:
+                rc = raw_wobble["rep_coverage"]
+                if not isinstance(rc, list) or not all(_is_int(x) for x in rc):
+                    malformed.append("wobble.rep_coverage")
+            if malformed:
+                problems.append(
+                    f"{model} ({cand_stem}): judge receipt has malformed "
+                    f"{', '.join(sorted(malformed))}, so its gap counts prove nothing — "
+                    f"the file is corrupt or hand-edited; re-judge")
+                continue
+
             skipped = _as_list(summary.get("skipped"))
             missing = _as_list(summary.get("missing_scores"))
             adj = _as_dict(summary.get("adjudication"))


### PR DESCRIPTION
## What was wrong

A refused judge receipt printed one sentence for several different situations, and for the commonest one that sentence described nothing that was wrong:

```
llama3.2 (llama3-2-local): judge receipt is not cacheable (verdict 'BLOCK') —
  0 engine-skipped, 0 primary judge-dropped, 0 adjudication-dropped; re-judge
```

All zeros, and refused. **Measured against the shipped #1950 receipts: 14 of 16 arms print exactly that.** No receipt written before #2007 carries the acceptance field, so all sixteen land in that branch.

## What it says now

Five states, each naming its own reason, classified in one place:

| state | message |
|---|---|
| unsupported verdict | `carries verdict 'X', which this gate cannot produce — not one of ours or hand-edited` |
| malformed metadata | `has malformed <fields>, so its gap counts prove nothing — corrupt or hand-edited` |
| unreadable / non-object | `is unreadable (UnicodeDecodeError)` / `is valid JSON but not an object (list)` |
| pre-#2007, no gaps | `predates the cacheable field … and records no gaps of its own; re-judge once` |
| pre-#2007, gaps recorded | `… and records 0 engine-skipped, 4 primary judge-dropped, 0 adjudication-dropped` |
| `cacheable: false` | the original sentence, with its counts, unchanged |

Precedence is part of the design: verdict before metadata, because an unsupported verdict marks a hand-edited file and that is exactly where malformed metadata lives.

## One owner, because two copies diverged twice

`receipt_state.py` now owns "why is this receipt refused". The report imports it; the shell runs it and switches on the exit code. Previously the two were hand-mirrored, and in this PR the shell fell behind twice — first on verdict classification, then on metadata validation — each time announcing "predates the field" about a file the report correctly called hand-edited or corrupt. Its own comment claimed they matched.

`test_both_layers_give_the_same_diagnosis_for_the_same_receipt` drives both real entry points over the same receipts. That test, not a comment, is what keeps them equal.

## Six validation axes, found one review round at a time

The expensive part of this PR, kept here because the pattern is the lesson:

| axis | what got through |
|---|---|
| shape | malformed JSON, then valid-JSON-but-not-an-object |
| exception type | invalid UTF-8 raises `UnicodeDecodeError`, missed by a `JSONDecodeError`-only catch |
| field type | `"wobble": ["bad"]` turned a `.get` into an `AttributeError` — the refusal path crashing while explaining why its input is untrusted |
| coerce vs refuse | type-safe accessors then coerced a corrupt `"skipped": "not a list"` to `[]`, manufacturing "records no gaps of its own" — a crash traded for a false statement, failing open |
| value range | `adjudication_missing_n: -1` prints "-1 adjudication-dropped" |
| unknowable vs zero | a pass ran but `adjudicated_n` is absent, so the count is unknowable and was reported as zero |

Each is a separate cut of the same input space, and passing one says nothing about the others. The last one is now structural rather than another precondition: `adjudication_dropped` returns **None** when the answer is unknowable, so a function that could not represent absence stopped inventing a value.

Full enumeration and the meta-lesson are on `workflow-process.md` RULE: parse-structured-input-dont-regex-and-iterate.

## Verification

- **67 self-tests, up from 50.** All three eval suites run in `build-check`.
- **A mutation control per change**, each failing exactly its own cases:

| reverted | fails |
|---|---|
| pre-field branch | the 2 legacy-message cases |
| shell state machine | the corrupt-vs-legacy case |
| adjudication recovery | the recovery case |
| both corruption guards | the 4 corruption cases |
| narrow exception tuple | the 3 undecodable cases |
| malformed gate | the metadata table |
| `_is_count` range check | the metadata table |
| relationship check | the metadata table |
| unknowable→zero | the metadata table |
| shell/report parity | the parity test |

- **Two-way controls** throughout: 16 malformed shapes must be named, 3 well-formed-but-degenerate shapes must not be; field-present-and-false keeps the old wording; a healthy receipt still ranks.
- **Real #1950 data re-run after every commit**, unchanged at each: 16 refused, 14 reporting no recorded gaps, 2 naming real ones (`llama3.2` four dropped scores, `gemma4:31b-cloud` one engine skip), 0 malformed, 0 tracebacks. Cross-checked against an independent read of the receipt files.
- `bash -n` and `shellcheck -S warning` clean.

Three of the mutation controls caught **my own vacuous or wrong tests** before review did: a table whose rows could not reach the branch they named, a table asserting only "did not crash" and so passing a false message, and a table blanket-asserting one expectation across two different axes.

## Scope

Eval-harness only. No shipped app code. No behaviour change to caching or ranking — every state here already failed closed and still does. What changed is what the reader is told.

Closes #2019
Part of #1950
