### PR TITLE
fix(obs): one Sentry issue is one problem in the digest

### DIFF
--- a/workers/daily-report/test/report.test.js
+++ b/workers/daily-report/test/report.test.js
@@ -825,14 +825,17 @@ const SENTRY_RELEASE_ROWS = [
   { release: "com.enviouswispr.app@2.4.1", "count_unique(user)": 3, "count()": 12 },
   { release: "com.enviouswispr.app@2.3.1", "count_unique(user)": 2, "count()": 5 },
 ];
+// `error.type`, not `title`: #2023 changed the field the section requests and
+// validates, so a double still carrying `title` describes a response the live
+// endpoint no longer returns. Empty on handled errors, which both of these are.
 const SENTRY_PROBLEM_ROWS = [
   {
-    issue: "ENVIOUSWISPR-2C", "issue.id": 1, title: "audio_capture_stalled: HeartPathError#0",
+    issue: "ENVIOUSWISPR-2C", "issue.id": 1, "error.type": [],
     "error.category": "audio_capture_stalled", level: "error",
     "count_unique(user)": 7, "count()": 19,
   },
   {
-    issue: "ENVIOUSWISPR-24", "issue.id": 2, title: "paste_failed: HeartPathError#3",
+    issue: "ENVIOUSWISPR-24", "issue.id": 2, "error.type": [],
     "error.category": "paste_failed", level: "error",
     "count_unique(user)": 1, "count()": 1,
   },
@@ -855,7 +858,7 @@ function sentryAnswer(target) {
   if (target.includes("field=issue")) {
     return fakeResponse(200, {
       data: SENTRY_PROBLEM_ROWS,
-      meta: sentryMeta(["title", "issue.id", "error.category", "level", "count_unique(user)", "count()"]),
+      meta: sentryMeta(["error.type", "issue.id", "error.category", "level", "count_unique(user)", "count()"]),
     });
   }
   // The two headline aggregates differ only by window; the prior one starts a

--- a/workers/daily-report/test/sentry-section.test.js
+++ b/workers/daily-report/test/sentry-section.test.js
@@ -96,11 +96,11 @@ const RELEASE_ROWS = [
   { release: "com.enviouswispr.app@2.4.0", "count_unique(user)": 2, "count()": 7 },
 ];
 
-function problemRow(issue, category, users, events, level = "error") {
+function problemRow(issue, category, users, events, level = "error", errorType = []) {
   return {
     issue,
     "issue.id": 1,
-    title: `${category}: something`,
+    "error.type": errorType,
     "error.category": category,
     level,
     "count_unique(user)": users,
@@ -108,7 +108,7 @@ function problemRow(issue, category, users, events, level = "error") {
   };
 }
 
-const PROBLEM_FIELDS = ["title", "issue.id", "error.category", "level", "count_unique(user)", "count()"];
+const PROBLEM_FIELDS = ["error.type", "issue.id", "error.category", "level", "count_unique(user)", "count()"];
 
 /** Routes each of the five calls by its query name, which is the only thing
  * that distinguishes them in the URL. */
@@ -241,15 +241,12 @@ test("classifyProblem: unknown, blank-fatal and blank-error are three different 
   assert.equal(unknown.label, "brand_new_category", "an unknown category must show its raw name");
   assert.equal(unknown.deliveryProven, false);
 
-  // The measured real shape: an unhandled crash carries no category at all.
-  const crash = classifyProblem({ category: "", level: "fatal", title: "EXC_BAD_ACCESS:  timed out after  >" });
+  // The measured real shape: an unhandled crash carries no category at all, and
+  // `error.type` arrives as an array.
+  const crash = classifyProblem({ category: "", level: "fatal", type: ["EXC_BAD_ACCESS"] });
   assert.equal(crash.group, LOST);
   assert.equal(crash.label, "app crash (EXC_BAD_ACCESS)");
   assert.equal(crash.deliveryProven, false);
-  // THE MESSAGE HALF NEVER APPEARS. It is the one place user-derived text could
-  // reach Discord, and the split-at-first-colon is what keeps it out by
-  // construction rather than by trusting Sentry's redaction.
-  assert.doesNotMatch(crash.label, /timed out/);
 
   // A blank category that is NOT fatal must not be called a crash.
   const blank = classifyProblem({ category: null, level: "error" });
@@ -450,6 +447,23 @@ test("fetchSentrySection issues exactly the budgeted number of calls", async () 
   const { fetchFn, urls } = digestFetch({ problems: [problemRow("EW-1", "paste_failed", 3, 4)] });
   await fetchSentrySection(ENV, WINDOW, { ...OPTS, fetchFn });
   assert.equal(urls.length, SENTRY_CALLS_PER_DIGEST);
+});
+
+test("the problems query groups by exception type, never by title (#2023)", async () => {
+  // The SOURCE of the #2023 split. Grouping on `title` returns one row per
+  // distinct crash message, and a crash message embeds a per-event memory
+  // address, so one issue arrives as many rows. The local collapse guarantees
+  // the invariant downstream; this locks the query that stops it arising.
+  //
+  // It is also the privacy boundary: `title` is `<type>: <message>` and the
+  // message half is the one place user-derived text could reach Discord. Not
+  // requesting it is a stronger guarantee than discarding it correctly.
+  const { fetchFn, urls } = digestFetch({ problems: [problemRow("EW-1", "paste_failed", 3, 4)] });
+  await fetchSentrySection(ENV, WINDOW, { ...OPTS, fetchFn });
+  const problemsUrl = decodeURIComponent(urls.find((u) => u.includes("field=issue")));
+  assert.ok(problemsUrl, "the problems aggregate must have been issued");
+  assert.match(problemsUrl, /field=error\.type/, "the exception type is what separates two crashes");
+  assert.doesNotMatch(problemsUrl, /field=title/, "requesting the title reintroduces the split and the message half");
 });
 
 test("the call count does not move with problem volume", async () => {
@@ -745,22 +759,69 @@ test("the worst realistic section still fits Discord's per-embed limits", async 
 test("a crash label carries the exception type and never the message", () => {
   // Two different crashes must not render as two identical rows. A live smoke
   // run printed exactly that before the type was included.
-  const a = classifyProblem({ category: "", level: "fatal", title: "EXC_BAD_ACCESS:  timed out after  >" });
-  const b = classifyProblem({ category: "", level: "fatal", title: "NSInternalInconsistencyException: [REDACTED]" });
+  const a = classifyProblem({ category: "", level: "fatal", type: ["EXC_BAD_ACCESS"] });
+  const b = classifyProblem({ category: "", level: "fatal", type: ["NSInternalInconsistencyException"] });
   assert.notEqual(a.label, b.label);
   assert.equal(b.label, "app crash (NSInternalInconsistencyException)");
 
-  // Any title shape this code does not recognise falls back to the plain label
-  // rather than printing something unexamined.
-  for (const title of [
-    undefined, null, "", ":no type", "a message with no colon at all and spaces",
-    "Type With Spaces: msg", `${"A".repeat(60)}: msg`, "<script>: msg",
+  // An exception CHAIN takes the first entry and ignores the rest.
+  assert.equal(
+    classifyProblem({ category: "", level: "fatal", type: ["EXC_BAD_ACCESS", "SecondaryError"] }).label,
+    "app crash (EXC_BAD_ACCESS)");
+
+  // Any shape this code does not recognise falls back to the plain label rather
+  // than printing something unexamined. `title`-shaped values are in the list
+  // because #2023 changed the field this reads: if a future edit points it back
+  // at `title`, the message half must still not reach Discord.
+  for (const type of [
+    undefined, null, "", [], [null], [""], {},
+    ["Type With Spaces"], [`${"A".repeat(60)}`], ["<script>"],
+    "EXC_BAD_ACCESS:  timed out after  >", ["EXC_BAD_ACCESS:  timed out after  >"],
   ]) {
-    const label = classifyProblem({ category: "", level: "fatal", title }).label;
+    const label = classifyProblem({ category: "", level: "fatal", type }).label;
     assert.ok(label === "app crash" || /^app crash \([A-Za-z_][A-Za-z0-9_.]*\)$/.test(label),
-      `unexpected crash label for ${JSON.stringify(title)}: ${label}`);
-    assert.doesNotMatch(label, /msg/);
+      `unexpected crash label for ${JSON.stringify(type)}: ${label}`);
+    assert.doesNotMatch(label, /timed out/);
   }
+});
+
+test("one Sentry issue is one problem even when it returns several rows (#2023)", async () => {
+  // The real shape: ENVIOUSWISPR-4B returned eight rows for one issue, one user
+  // and nine events, because the crash message embeds a per-event address.
+  // Every row rendered the same sentence and counted as its own problem.
+  const { data, lines } = await render({
+    problems: [
+      problemRow("EW-2C", "audio_capture_stalled", 5, 9),
+      problemRow("EW-4B", "", 1, 2, "fatal", ["EXC_BAD_ACCESS"]),
+      problemRow("EW-4B", "", 1, 3, "fatal", ["EXC_BAD_ACCESS"]),
+      problemRow("EW-4B", "", 1, 4, "fatal", ["EXC_BAD_ACCESS"]),
+    ],
+  });
+
+  assert.equal(data.rows.length, 2, "three rows of one issue must collapse to one problem");
+  const crash = data.rows.find((r) => r.shortId === "EW-4B");
+  assert.equal(crash.events, 9, "events ARE additive across an issue's rows");
+  assert.equal(crash.people, 1, "people are NOT additive: one person must not become three");
+  // The derived event total still reconciles with the ungrouped aggregate.
+  assert.equal(data.events, 18);
+
+  // Exactly one rendered line for that issue, not three.
+  const crashLines = lines.filter((l) => l.includes("app crash"));
+  assert.equal(crashLines.length, 1, `expected one crash line, got ${JSON.stringify(crashLines)}`);
+  assert.match(lines.join("\n"), /1 person {3}app crash \(EXC_BAD_ACCESS\)/);
+});
+
+test("rows that could not be identified are never fused together (#2023)", async () => {
+  // A null shortId is a missing field, not a group key. Merging on it would put
+  // unrelated problems under one heading.
+  const { data } = await render({
+    problems: [
+      { ...problemRow("EW-2C", "audio_capture_stalled", 5, 9), issue: null },
+      { ...problemRow("EW-24", "paste_failed", 3, 4), issue: null },
+    ],
+  });
+  assert.equal(data.rows.length, 2, "unidentifiable rows must stay separate");
+  assert.deepEqual(data.rows.map((r) => r.shortId), [null, null]);
 });
 
 test("two problems that would render identically are separated by their issue id", async () => {

--- a/workers/daily-report/test/sentry-section.test.js
+++ b/workers/daily-report/test/sentry-section.test.js
@@ -860,16 +860,57 @@ test("a merged people count says it is a lower bound, an unmerged one does not",
 });
 
 test("rows that could not be identified are never fused together (#2023)", async () => {
-  // A null shortId is a missing field, not a group key. Merging on it would put
-  // unrelated problems under one heading.
+  // A missing shortId is not a group key. Merging on it would put unrelated
+  // problems under one heading. BLANK strings count as missing: `""` is a
+  // string, so a bare type check would make it a valid key and fuse every
+  // malformed row into one problem (Codex review r3).
   const { data } = await render({
     problems: [
       { ...problemRow("EW-2C", "audio_capture_stalled", 5, 9), issue: null },
-      { ...problemRow("EW-24", "paste_failed", 3, 4), issue: null },
+      { ...problemRow("EW-24", "paste_failed", 3, 4), issue: "" },
+      { ...problemRow("EW-29", "xpc_service_error", 2, 2), issue: "   " },
+      { ...problemRow("EW-32", "polish_provider_failed", 1, 1), issue: undefined },
     ],
   });
-  assert.equal(data.rows.length, 2, "unidentifiable rows must stay separate");
-  assert.deepEqual(data.rows.map((r) => r.shortId), [null, null]);
+  assert.equal(data.rows.length, 4, "unidentifiable rows must stay separate");
+  assert.deepEqual(data.rows.map((r) => r.shortId), [null, null, null, null]);
+});
+
+test("a collapse reconciles classification conservatively, never by sort order", async () => {
+  // Codex review r3. An earlier comment claimed category/level/type are constant
+  // within an issue; they are not — `level` is per-event. Keeping the first
+  // row's classification would file fatal events under a degraded label and add
+  // their events to it, understating severity in the list the founder acts on.
+  const { data, lines } = await render({
+    problems: [
+      // Sorted first: more people, DEGRADED, delivery proven.
+      problemRow("EW-9", "paste_failed", 5, 5),
+      // Same issue, fatal: LOST, delivery NOT proven.
+      problemRow("EW-9", "", 1, 1, "fatal", ["EXC_BAD_ACCESS"]),
+    ],
+  });
+
+  assert.equal(data.rows.length, 1);
+  const merged = data.rows[0];
+  assert.equal(merged.group, LOST, "lost must win over degraded");
+  assert.equal(merged.deliveryProven, false, "an unproven row makes the merge unproven");
+  assert.equal(merged.events, 6, "events from both rows are still counted");
+  assert.match(lines.join("\n"), /delivery not proven/);
+});
+
+test("a collapse of uniformly degraded rows stays degraded", async () => {
+  // The two-way control for the reconciliation above. Without it, a rule that
+  // forced LOST on every merge would pass the previous test while quietly
+  // reclassifying every merged problem as a lost dictation.
+  const { data } = await render({
+    problems: [
+      problemRow("EW-24", "paste_failed", 5, 5),
+      problemRow("EW-24", "paste_failed", 2, 2),
+    ],
+  });
+  assert.equal(data.rows.length, 1);
+  assert.equal(data.rows[0].group, DEGRADED);
+  assert.equal(data.rows[0].deliveryProven, true);
 });
 
 test("two problems that would render identically are separated by their issue id", async () => {

--- a/workers/daily-report/test/sentry-section.test.js
+++ b/workers/daily-report/test/sentry-section.test.js
@@ -726,7 +726,30 @@ test("an over-budget section discloses what it omitted instead of truncating sil
 test("a full page of problems is disclosed as a limited breakdown", async () => {
   const many = Array.from({ length: 100 }, (_, i) => problemRow(`EW-${i}`, "asr_failed", 1, 1));
   const { lines } = await render({ problems: many });
-  assert.match(lines.join("\n"), /the error count and the breakdown cover the largest 100 only/);
+  const text = lines.join("\n");
+  assert.match(text, /more problems may exist/);
+  assert.match(text, /the error count and the breakdown cover only those listed above/);
+  // 100 DISTINCT issues, so the measured count really is 100 here.
+  assert.match(text, /across 100 or more problems/);
+});
+
+test("a truncated page never claims more problems than it can count (#2023)", async () => {
+  // Codex review r1, P2. A full 100-ROW page can carry fewer than 100 unique
+  // issues once rows collapse, and the old wording hardcoded 100 - so the
+  // section would have asserted a number nobody measured, in the one sentence
+  // the founder reads first.
+  const many = Array.from({ length: 100 }, (_, i) =>
+    problemRow(`EW-${i % 40}`, "asr_failed", 1, 1));
+  const { data, lines } = await render({ problems: many });
+  const text = lines.join("\n");
+
+  assert.equal(data.rows.length, 40, "100 rows over 40 issues must collapse to 40 problems");
+  assert.equal(data.truncated, true, "a full page is still treated as possibly incomplete");
+  assert.match(text, /across 40 or more problems/);
+  assert.doesNotMatch(text, /100 or more problems/, "the page size is not a problem count");
+  assert.doesNotMatch(text, /largest 100/, "nor is it a claim about what the breakdown covers");
+  // The people total is unaffected by truncation and must keep saying so.
+  assert.match(text, /The affected-people total covers all of them/);
 });
 
 test("a full page issues no second Sentry request", async () => {

--- a/workers/daily-report/test/sentry-section.test.js
+++ b/workers/daily-report/test/sentry-section.test.js
@@ -908,6 +908,37 @@ test("a collapse reconciles classification conservatively, never by sort order",
     "a degraded label must not survive into a lost row");
 });
 
+test("a merge of two same-severity labels discloses what it does not name", async () => {
+  // Cloud review r1, P2. Moving the label with the GROUP fixes the cross-severity
+  // contradiction, but two `lost` rows with different labels still merge, and the
+  // retained label would silently describe the other row's events too.
+  const { data, lines } = await render({
+    problems: [
+      problemRow("EW-7", "asr_failed", 4, 4),
+      problemRow("EW-7", "", 1, 6, "fatal", ["EXC_BAD_ACCESS"]),
+    ],
+  });
+
+  assert.equal(data.rows.length, 1);
+  assert.equal(data.rows[0].events, 10, "both rows' events are counted");
+  // Named for the largest contributor, and honest that it covers more.
+  assert.match(lines.join("\n"),
+    /transcription failed and 1 other failure on the same issue/);
+});
+
+test("a merge of identical labels claims no hidden failures", async () => {
+  // The two-way control. Without it, a disclosure appended to every merge would
+  // pass the test above while adding a phantom "other failure" to the ordinary
+  // duplicate-row collapse this issue was filed for.
+  const { lines } = await render({
+    problems: [
+      problemRow("EW-4B", "", 1, 2, "fatal", ["EXC_BAD_ACCESS"]),
+      problemRow("EW-4B", "", 1, 3, "fatal", ["EXC_BAD_ACCESS"]),
+    ],
+  });
+  assert.doesNotMatch(lines.join("\n"), /other failure/);
+});
+
 test("a cut page marks every displayed row as partial (#2023)", async () => {
   // Codex review r4. Sentry sorts by affected users, so two rows of ONE issue
   // can straddle the 100-row boundary. The visible half would otherwise render

--- a/workers/daily-report/test/sentry-section.test.js
+++ b/workers/daily-report/test/sentry-section.test.js
@@ -902,10 +902,15 @@ test("a collapse reconciles classification conservatively, never by sort order",
   // under "LOST THE DICTATION" (Codex review r4).
   assert.equal(merged.label, "app crash (EXC_BAD_ACCESS)");
   const text = lines.join("\n");
-  const lostIndex = text.indexOf("LOST THE DICTATION");
-  assert.ok(lostIndex >= 0);
   assert.doesNotMatch(text, /paste fell back to the clipboard/,
     "a degraded label must not survive into a lost row");
+
+  // AND THE DISPLACED LABEL MUST STILL BE DISCLOSED. This assertion is the one
+  // that was missing: an earlier version replaced the label before comparing
+  // them, so the paste row was swallowed with no trace, and this test passed
+  // anyway because it only checked that the old label was GONE (cloud review r2).
+  assert.match(text, /app crash \(EXC_BAD_ACCESS\) and 1 other failure on the same issue/);
+  assert.equal(merged.mergedLabels.size, 2);
 });
 
 test("a merge of two same-severity labels discloses what it does not name", async () => {

--- a/workers/daily-report/test/sentry-section.test.js
+++ b/workers/daily-report/test/sentry-section.test.js
@@ -728,7 +728,12 @@ test("a full page of problems is disclosed as a limited breakdown", async () => 
   const { lines } = await render({ problems: many });
   const text = lines.join("\n");
   assert.match(text, /more problems may exist/);
-  assert.match(text, /the error count and the breakdown cover only those listed above/);
+  // The error total and the visible breakdown are bounded DIFFERENTLY: events
+  // are summed from every returned row, while the list can be cut short again
+  // by the Discord budget. Collapsing both into "those listed above" contradicts
+  // the omission notice printed just above it (Codex review r2).
+  assert.match(text, /the error count covers every problem Sentry returned/);
+  assert.match(text, /the breakdown covers only those listed above/);
   // 100 DISTINCT issues, so the measured count really is 100 here.
   assert.match(text, /across 100 or more problems/);
 });
@@ -832,6 +837,26 @@ test("one Sentry issue is one problem even when it returns several rows (#2023)"
   const crashLines = lines.filter((l) => l.includes("app crash"));
   assert.equal(crashLines.length, 1, `expected one crash line, got ${JSON.stringify(crashLines)}`);
   assert.match(lines.join("\n"), /1 person {3}app crash \(EXC_BAD_ACCESS\)/);
+});
+
+test("a merged people count says it is a lower bound, an unmerged one does not", async () => {
+  // Codex review r2. `Math.max` across a collapse understates whenever two rows
+  // carry disjoint users, and neither max nor sum can recover the real union
+  // from grouped counts — so a merged row must not print its number as exact.
+  const { lines } = await render({
+    problems: [
+      problemRow("EW-4B", "", 2, 2, "fatal", ["EXC_BAD_ACCESS"]),
+      problemRow("EW-4B", "", 3, 3, "fatal", ["EXC_BAD_ACCESS"]),
+      problemRow("EW-2C", "audio_capture_stalled", 5, 9),
+    ],
+  });
+  const text = lines.join("\n");
+
+  assert.match(text, /at least 3 people {3}app crash \(EXC_BAD_ACCESS\)/);
+  // The two-way control. Without it, a hedge applied to EVERY row would pass the
+  // assertion above while quietly making every exact figure look uncertain.
+  assert.match(text, /\n {2}5 people {3}microphone capture stalled/);
+  assert.doesNotMatch(text, /at least 5 people/);
 });
 
 test("rows that could not be identified are never fused together (#2023)", async () => {

--- a/workers/daily-report/test/sentry-section.test.js
+++ b/workers/daily-report/test/sentry-section.test.js
@@ -896,6 +896,42 @@ test("a collapse reconciles classification conservatively, never by sort order",
   assert.equal(merged.deliveryProven, false, "an unproven row makes the merge unproven");
   assert.equal(merged.events, 6, "events from both rows are still counted");
   assert.match(lines.join("\n"), /delivery not proven/);
+
+  // THE LABEL MUST MOVE WITH THE GROUP. Keeping the degraded label would render
+  // "paste fell back to the clipboard" — a sentence meaning the text survived —
+  // under "LOST THE DICTATION" (Codex review r4).
+  assert.equal(merged.label, "app crash (EXC_BAD_ACCESS)");
+  const text = lines.join("\n");
+  const lostIndex = text.indexOf("LOST THE DICTATION");
+  assert.ok(lostIndex >= 0);
+  assert.doesNotMatch(text, /paste fell back to the clipboard/,
+    "a degraded label must not survive into a lost row");
+});
+
+test("a cut page marks every displayed row as partial (#2023)", async () => {
+  // Codex review r4. Sentry sorts by affected users, so two rows of ONE issue
+  // can straddle the 100-row boundary. The visible half would otherwise render
+  // as a complete, exact figure while users and events sit on an unfetched page.
+  const many = Array.from({ length: 100 }, (_, i) => problemRow(`EW-${i}`, "asr_failed", 2, 2));
+  const { data, lines } = await render({ problems: many });
+
+  assert.equal(data.truncated, true);
+  assert.ok(data.rows.every((r) => r.peopleIsLowerBound),
+    "every row on a cut page is potentially missing counts from the next page");
+  assert.match(lines.join("\n"), /at least 2 people/);
+});
+
+test("an uncut page leaves exact rows unhedged (#2023)", async () => {
+  // The two-way control for the rule above. Without it, hedging everything would
+  // pass that test while making every ordinary exact figure read as uncertain —
+  // and the ordinary day is every day the fleet has produced so far.
+  const { data, lines } = await render({
+    problems: [problemRow("EW-2C", "audio_capture_stalled", 5, 9)],
+  });
+
+  assert.equal(data.truncated, false);
+  assert.ok(data.rows.every((r) => !r.peopleIsLowerBound));
+  assert.doesNotMatch(lines.join("\n"), /at least/);
 });
 
 test("a collapse of uniformly degraded rows stays degraded", async () => {

--- a/workers/reporting/sentry-section.js
+++ b/workers/reporting/sentry-section.js
@@ -753,8 +753,14 @@ export function formatSentrySection(data, { title, budget: requestedBudget = DEF
   const errorText = data.truncated
     ? `at least ${data.events} ${data.events === 1 ? "error" : "errors"}`
     : `${data.events} ${data.events === 1 ? "error" : "errors"}`;
+  // COUNTED FROM THE ROWS, never from the page size. Before #2023 this said
+  // "100 or more problems", which was sound while one row WAS one problem. Now
+  // that rows collapse by issue, a full 100-row page can yield fewer than 100
+  // unique problems, and a hardcoded 100 would assert a number nobody measured.
+  // `rows.length` is what we actually saw either way; `truncated` only adds the
+  // "or more".
   const problemText = data.truncated
-    ? "100 or more problems"
+    ? `${data.rows.length} or more ${data.rows.length === 1 ? "problem" : "problems"}`
     : `${data.rows.length} ${data.rows.length === 1 ? "problem" : "problems"}`;
   lines.push(`${people(data.people)} hit ${errorText} across ${problemText}, on ${data.floor} and newer.`);
 
@@ -848,15 +854,31 @@ function finishSection(lines, budget) {
  * missing Link header proves nothing. That over-reporting is the right default
  * - but it means this line cannot assert incompleteness as a fact, only as a
  * possibility. Every other truncation sentence survives the same scrutiny
- * ("at least N errors", "100 or more problems", "cover the largest 100 only"
- * are all true when exactly 100 arrive); this one did not, and was swept for
- * alongside them rather than fixed alone. */
+ * ("at least N errors", "N or more problems", "more problems may exist" are all
+ * true when exactly 100 arrive); this one did not, and was swept for alongside
+ * them rather than fixed alone.
+ *
+ * Two of those examples were reworded by #2023, which removed the hardcoded 100
+ * from the PROBLEM sentences once rows began collapsing by issue. The reasoning
+ * above is unchanged and still applies to each of them. */
 const BADGES_INCOMPLETE_LINE =
   "100 or more problems were seen for the first time in this window, so the NEW marks below may not be complete.";
 
+/** Deliberately carries NO number. Sentry cut the page at 100 ROWS, and since
+ * #2023 those rows collapse by issue, so the page size is no longer the count of
+ * problems it covers - "the largest 100" would name a quantity this line cannot
+ * support. The headline sentence above already states the measured count and
+ * qualifies it with "or more"; this line's job is the CLAIM, which is that the
+ * error count and breakdown are bounded by what came back while the people
+ * total is not.
+ *
+ * `BADGES_INCOMPLETE_LINE` above keeps its 100 on purpose: it describes the
+ * ISSUES endpoint, whose rows are one-per-issue and are never collapsed, so the
+ * page size there really is a problem count. Two different axes, and only this
+ * one moved. */
 const TRUNCATED_LINE =
-  "100 or more problems were recorded. The affected-people total covers all of them; " +
-  "the error count and the breakdown cover the largest 100 only.";
+  "Sentry returned a full page, so more problems may exist. The affected-people total " +
+  "covers all of them; the error count and the breakdown cover only those listed above.";
 
 /** `truncated` changes the CLAIM, not just the wording: when the problem page
  * was cut off, the totals above genuinely do NOT include the omitted rows, so

--- a/workers/reporting/sentry-section.js
+++ b/workers/reporting/sentry-section.js
@@ -606,17 +606,39 @@ export async function fetchSentrySection(env, window, opts = {}) {
     // for - eight rows of one user each would have printed eight people.
     existing.events = addCounts(existing.events, row.events, "event total");
     existing.people = Math.max(existing.people, row.people);
-    // Conservative reconciliation, per the note above. The LABEL stays the first
-    // row's — it is the highest-people row, and inventing a combined label would
-    // put a sentence in front of the founder that no single row supports — but
-    // the GROUP and the delivery claim can only move toward caution.
-    if (row.group === LOST) existing.group = LOST;
+    // Conservative reconciliation. The delivery claim can only move toward
+    // caution, and a `lost` row drags the whole merged problem into `lost`.
+    //
+    // THE LABEL MOVES WITH THE GROUP. An earlier draft kept the first row's
+    // label while flipping only the group, which rendered "paste fell back to
+    // the clipboard" — a sentence whose whole meaning is that the text survived
+    // — underneath "LOST THE DICTATION". The heading and the line contradicted
+    // each other, and the founder acts on that split. So the label is taken from
+    // the row whose classification WON; a label that no longer matches its
+    // heading is worse than a less specific one.
+    if (row.group === LOST && existing.group !== LOST) {
+      existing.group = LOST;
+      existing.label = row.label;
+    }
     if (!row.deliveryProven) existing.deliveryProven = false;
     // The row must SAY it is a lower bound rather than print a merged number as
-    // though it were exact. Set only when a merge actually happened, so the
-    // ordinary row - which after the `error.type` change is every row - carries
-    // no hedge it has not earned.
+    // though it were exact.
     existing.peopleIsLowerBound = true;
+  }
+
+  // A CUT PAGE MAKES EVERY DISPLAYED ROW POTENTIALLY PARTIAL, not just the ones
+  // that visibly merged. Sentry sorts by affected users, so two rows of ONE
+  // issue can straddle the 100-row boundary: the visible half then renders as a
+  // complete, exact figure while users, events and even a `lost` classification
+  // sit on a page nobody fetched.
+  //
+  // The existing "more problems may exist" notice does not cover this — it says
+  // problems are MISSING, not that a problem already listed is INCOMPLETE, and a
+  // reader has no way to tell the difference. Hedging every row when the page
+  // was cut is the honest reading, and it costs nothing on the ordinary
+  // untruncated day, which is every day the fleet has produced so far.
+  if (problems.truncated) {
+    for (const row of rows) row.peopleIsLowerBound = true;
   }
 
   return {
@@ -844,10 +866,23 @@ export function formatSentrySection(data, { title, budget: requestedBudget = DEF
   // length of the sentence explaining that it ran out - measured at 24
   // characters over a 1200 budget, which is the shape that eventually pushes an
   // assembled payload past a Discord limit and sends nothing at all.
+  // RESERVE WHAT WILL ACTUALLY BE PRINTED. The omitted line must be reserved
+  // unconditionally, because whether it appears depends on this very layout. The
+  // other two do NOT: `truncated` and `badgesIncomplete` are decided by the fetch
+  // and are already known here, so reserving them when they will not be printed
+  // spends the row budget on sentences that never render.
+  //
+  // Found by a live smoke against production, not by a test (#2023). Making
+  // TRUNCATED_LINE accurate had lengthened it by 65 characters, and because the
+  // reserve was unconditional that silently cost the section a PROBLEM ROW on an
+  // ordinary untruncated day — the digest quietly listed less of exactly the
+  // thing it exists to list. No unit test could see it: every fixture that
+  // exercises the budget sets its own, and the regression only shows against the
+  // real row set at the real default budget.
   const reserve =
     omittedLine(data.rows.length, data.truncated).length + 1 +
-    TRUNCATED_LINE.length + 1 +
-    BADGES_INCOMPLETE_LINE.length + 1;
+    (data.truncated ? TRUNCATED_LINE.length + 1 : 0) +
+    (data.badgesIncomplete ? BADGES_INCOMPLETE_LINE.length + 1 : 0);
   const state = { budget: budget - reserve, omitted: 0 };
   appendGroup(lines, "LOST THE DICTATION", lost, state);
   appendGroup(lines, "STILL WORKED, JUST WORSE", degraded, state);

--- a/workers/reporting/sentry-section.js
+++ b/workers/reporting/sentry-section.js
@@ -536,8 +536,13 @@ export async function fetchSentrySection(env, window, opts = {}) {
       level: row.level,
       type: row["error.type"],
     });
+    // A BLANK id is not an id. `""` is a string, so a bare type check would make
+    // it a valid grouping key and fuse every malformed row into one problem -
+    // the exact opposite of the missing-id rule below, and reached by the same
+    // malformed response that rule exists for.
+    const rawShortId = typeof row.issue === "string" ? row.issue.trim() : "";
     return {
-      shortId: typeof row.issue === "string" ? row.issue : null,
+      shortId: rawShortId.length > 0 ? rawShortId : null,
       people: toCount(row["count_unique(user)"]),
       // False until a collapse merges rows into this one; see the loop below.
       peopleIsLowerBound: false,
@@ -545,7 +550,9 @@ export async function fetchSentrySection(env, window, opts = {}) {
       group: classified.group,
       label: classified.label,
       deliveryProven: classified.deliveryProven,
-      isNew: typeof row.issue === "string" && newShortIds.has(row.issue),
+      // Reads the SAME normalised value, so a blank id cannot be looked up here
+      // while being rejected as a grouping key two lines above.
+      isNew: rawShortId.length > 0 && newShortIds.has(rawShortId),
     };
   });
 
@@ -565,12 +572,18 @@ export async function fetchSentrySection(env, window, opts = {}) {
   // `-count_unique(user)`, so a group's first row already carries its largest
   // value.
   //
-  // The group, label and deliveryProven of the FIRST row win. Every field they
-  // derive from - `error.category`, `level`, `error.type` - is a property of the
-  // fingerprint rather than of the individual event, so an issue's rows agree on
-  // all three and the choice is not observable. Stated rather than assumed,
-  // because if a future field breaks that constancy this is where a second
-  // classification would be dropped silently.
+  // CLASSIFICATION IS RECONCILED CONSERVATIVELY, never taken from whichever row
+  // Sentry happened to sort first. An earlier draft of this comment asserted
+  // that `error.category`, `level` and `error.type` are fingerprint properties
+  // and therefore constant within an issue; review was right that this is an
+  // unchecked premise. `level` in particular is per-EVENT, and a tag can change
+  // across a release while the fingerprint does not.
+  //
+  // Getting it wrong has a direction: keeping the first row's classification
+  // could file fatal events under a degraded label and add their events to it,
+  // which UNDERSTATES severity in the list the founder acts on. So `lost` wins
+  // over `degraded`, and any unproven row makes the merged row unproven — the
+  // same conservative default the category table itself encodes.
   const byShortId = new Map();
   const rows = [];
   for (const row of mapped) {
@@ -593,6 +606,12 @@ export async function fetchSentrySection(env, window, opts = {}) {
     // for - eight rows of one user each would have printed eight people.
     existing.events = addCounts(existing.events, row.events, "event total");
     existing.people = Math.max(existing.people, row.people);
+    // Conservative reconciliation, per the note above. The LABEL stays the first
+    // row's — it is the highest-people row, and inventing a combined label would
+    // put a sentence in front of the founder that no single row supports — but
+    // the GROUP and the delivery claim can only move toward caution.
+    if (row.group === LOST) existing.group = LOST;
+    if (!row.deliveryProven) existing.deliveryProven = false;
     // The row must SAY it is a lower bound rather than print a merged number as
     // though it were exact. Set only when a merge actually happened, so the
     // ordinary row - which after the `error.type` change is every row - carries

--- a/workers/reporting/sentry-section.js
+++ b/workers/reporting/sentry-section.js
@@ -143,19 +143,26 @@ export const ERROR_CATEGORIES = Object.freeze({
  * `NSInternalInconsistencyException` are very different things to see twice in
  * a row.
  *
- * ONLY the type, never the message. A Sentry title is `<type>: <message>`, and
- * the message half is the one place in this whole section where user-derived
- * text could appear. Splitting at the first colon and discarding the remainder
- * keeps the privacy boundary intact by construction rather than by trusting
- * Sentry's own redaction. */
+ * ONLY the type, never the message. This reads `error.type`, which carries the
+ * exception type ALONE - the message half, the one place in this whole section
+ * where user-derived text could appear, is never fetched. #2023 moved here from
+ * splitting a `<type>: <message>` title at the first colon; the privacy
+ * boundary is now upheld by not requesting the message rather than by
+ * discarding it correctly.
+ *
+ * `error.type` arrives as an ARRAY (`["EXC_BAD_ACCESS"]`), empty on handled
+ * errors. An exception CHAIN yields several; the first is taken and the rest
+ * ignored, because this label names the crash for a human rather than
+ * reconstructing the chain. */
 const CRASH_TYPE_MAX = 48;
 
-function crashLabel(title) {
-  if (typeof title !== "string") return "app crash";
-  const type = title.split(":", 1)[0].trim();
-  // A type must look like an identifier. Anything else is a title shape this
-  // code does not recognise, and printing it unexamined is how the message half
-  // would eventually leak through some future format.
+function crashLabel(errorType) {
+  const first = Array.isArray(errorType) ? errorType[0] : errorType;
+  if (typeof first !== "string") return "app crash";
+  const type = first.trim();
+  // A type must look like an identifier. Anything else is a shape this code does
+  // not recognise, and printing it unexamined is how user-derived text would
+  // eventually leak through some future format.
   if (type.length === 0 || type.length > CRASH_TYPE_MAX || !/^[A-Za-z_][A-Za-z0-9_.]*$/.test(type)) {
     return "app crash";
   }
@@ -171,14 +178,14 @@ function crashLabel(title) {
  * discarded. `rawCategory` is preserved in the label precisely so a category
  * added to the app and not added to this table is visible in Discord.
  */
-export function classifyProblem({ category, level, title }) {
+export function classifyProblem({ category, level, type }) {
   const raw = typeof category === "string" ? category.trim() : "";
   if (raw.length === 0) {
     // A blank category on a fatal is a crash. A blank category on a NON-fatal
     // is something this table does not know about, and guessing "crash" for it
     // would put a wrong sentence in front of the founder.
     if (typeof level === "string" && level.toLowerCase() === "fatal") {
-      return { group: LOST, deliveryProven: false, label: crashLabel(title) };
+      return { group: LOST, deliveryProven: false, label: crashLabel(type) };
     }
     return { group: LOST, deliveryProven: false, label: "uncategorised failure" };
   }
@@ -335,7 +342,14 @@ function compareKeys(a, b) {
  * why calls 4 and 5 exist. */
 export const SENTRY_CALLS_PER_DIGEST = 5;
 
-const ISSUE_FIELDS = ["issue", "title", "error.category", "level", "count()", "count_unique(user)"];
+// `error.type`, NOT `title`. Grouping on `title` splits one Sentry issue into one
+// row per distinct message, and a crash message embeds a memory address that is
+// unique per event - `ENVIOUSWISPR-4B` returned EIGHT rows for one issue, one
+// user and nine events (#2023). Every one of those rows then rendered the same
+// sentence and counted as its own "problem". `error.type` is constant per crash
+// signature, so Sentry returns one row per issue and `count_unique(user)` is the
+// issue's TRUE distinct-user count rather than a per-message slice of it.
+const ISSUE_FIELDS = ["issue", "error.type", "error.category", "level", "count()", "count_unique(user)"];
 // Read from meta.fields, which is present on an EMPTY response too. `issue` is
 // deliberately absent from this list: Sentry echoes it back as `issue.id`, so
 // requiring the requested name would fail on a perfectly good response and the
@@ -508,11 +522,11 @@ export async function fetchSentrySection(env, window, opts = {}) {
       .map((issue) => issue.shortId)
   );
 
-  const rows = problems.rows.map((row) => {
+  const mapped = problems.rows.map((row) => {
     const classified = classifyProblem({
       category: row["error.category"],
       level: row.level,
-      title: row.title,
+      type: row["error.type"],
     });
     return {
       shortId: typeof row.issue === "string" ? row.issue : null,
@@ -524,6 +538,52 @@ export async function fetchSentrySection(env, window, opts = {}) {
       isNew: typeof row.issue === "string" && newShortIds.has(row.issue),
     };
   });
+
+  // ONE SENTRY ISSUE IS ONE PROBLEM, guaranteed here rather than hoped for from
+  // the grouping key. `ISSUE_FIELDS` moving to `error.type` removes the CAUSE of
+  // the #2023 split, but any future grouping field that varies within an issue
+  // would silently reintroduce it, and the symptom - a repeated sentence and an
+  // inflated problem count - reads as a rendering bug rather than a query bug.
+  // This makes the invariant structural, so it holds whatever Sentry returns.
+  //
+  // A null `shortId` is NOT a group. Rows that could not be identified stay
+  // separate, because merging them would fuse unrelated problems under one
+  // heading on the strength of a missing field.
+  //
+  // Order is preserved by first occurrence, which keeps the section's
+  // descending-by-people sort intact: `sentry_problems` sorts by
+  // `-count_unique(user)`, so a group's first row already carries its largest
+  // value.
+  //
+  // The group, label and deliveryProven of the FIRST row win. Every field they
+  // derive from - `error.category`, `level`, `error.type` - is a property of the
+  // fingerprint rather than of the individual event, so an issue's rows agree on
+  // all three and the choice is not observable. Stated rather than assumed,
+  // because if a future field breaks that constancy this is where a second
+  // classification would be dropped silently.
+  const byShortId = new Map();
+  const rows = [];
+  for (const row of mapped) {
+    const existing = row.shortId === null ? undefined : byShortId.get(row.shortId);
+    if (existing === undefined) {
+      rows.push(row);
+      if (row.shortId !== null) byShortId.set(row.shortId, row);
+      continue;
+    }
+    // Events ARE additive across rows of one issue and still sum exactly to the
+    // headline aggregate. People are NOT: the same person can appear under two
+    // rows, so a sum would double-count them. `max` is therefore a LOWER BOUND
+    // and can understate when two rows carry disjoint users.
+    //
+    // That understatement is bounded and deliberate. It can only occur when one
+    // issue carries more than one exception-type signature, which the field
+    // change above makes rare; and the headline "N people hit ..." figure comes
+    // from a separate UNGROUPED aggregate, so it stays exact regardless. The
+    // alternative, summing, is wrong in the common case this issue was filed
+    // for - eight rows of one user each would have printed eight people.
+    existing.events = addCounts(existing.events, row.events, "event total");
+    existing.people = Math.max(existing.people, row.people);
+  }
 
   return {
     empty: rows.length === 0,

--- a/workers/reporting/sentry-section.js
+++ b/workers/reporting/sentry-section.js
@@ -616,6 +616,16 @@ export async function fetchSentrySection(env, window, opts = {}) {
     // each other, and the founder acts on that split. So the label is taken from
     // the row whose classification WON; a label that no longer matches its
     // heading is worse than a less specific one.
+    // ORDER IS LOAD-BEARING: record the differing labels BEFORE any replacement.
+    // Written the other way round first, the severity flip overwrote
+    // `existing.label` and the comparison below then saw two equal strings, so a
+    // displaced degraded label was swallowed with no disclosure at all — the
+    // exact case the disclosure exists for, silently defeated by statement
+    // order (cloud review r2).
+    if (row.label !== existing.label) {
+      existing.mergedLabels = existing.mergedLabels || new Set([existing.label]);
+      existing.mergedLabels.add(row.label);
+    }
     if (row.group === LOST && existing.group !== LOST) {
       existing.group = LOST;
       existing.label = row.label;

--- a/workers/reporting/sentry-section.js
+++ b/workers/reporting/sentry-section.js
@@ -620,6 +620,21 @@ export async function fetchSentrySection(env, window, opts = {}) {
       existing.group = LOST;
       existing.label = row.label;
     }
+    // A LABEL NAMES ONE FAILURE; A MERGED ROW MAY DESCRIBE SEVERAL. Moving the
+    // label with the group fixes the contradiction across severities, but two
+    // rows of the SAME severity and different labels still merge - an
+    // `asr_failed` row and a blank-category fatal are both `lost` - and the
+    // retained label would then silently describe the other row's events too.
+    //
+    // Neither label is wrong and neither is complete, so rather than pick a
+    // winner or invent a generic phrase, the row DISCLOSES that it covers more
+    // than it names. The retained label stays the largest contributor, since
+    // `sentry_problems` sorts by affected users and the first row of a group is
+    // its biggest.
+    if (row.label !== existing.label) {
+      existing.mergedLabels = (existing.mergedLabels || new Set([existing.label]));
+      existing.mergedLabels.add(row.label);
+    }
     if (!row.deliveryProven) existing.deliveryProven = false;
     // The row must SAY it is a lower bound rather than print a merged number as
     // though it were exact.
@@ -1050,7 +1065,14 @@ function appendGroup(lines, heading, rows, state) {
     const peopleText = row.peopleIsLowerBound
       ? `at least ${people(row.people)}`
       : people(row.people);
-    lines.push(`  ${peopleText}   ${row.label}${suffix}${row.isNew ? "   NEW" : ""}`);
+    // When one issue merged rows carrying different labels, the line names its
+    // largest contributor and says so rather than presenting that name as the
+    // whole story.
+    const others = row.mergedLabels ? row.mergedLabels.size - 1 : 0;
+    const mixed = others > 0
+      ? ` and ${others} other ${others === 1 ? "failure" : "failures"} on the same issue`
+      : "";
+    lines.push(`  ${peopleText}   ${row.label}${mixed}${suffix}${row.isNew ? "   NEW" : ""}`);
     if (descriptionLength(lines) > state.budget) {
       lines.pop();
       state.omitted += 1;

--- a/workers/reporting/sentry-section.js
+++ b/workers/reporting/sentry-section.js
@@ -355,7 +355,15 @@ const ISSUE_FIELDS = ["issue", "error.type", "error.category", "level", "count()
 // requiring the requested name would fail on a perfectly good response and the
 // obvious repair (deleting the check) is how an empty malformed body gets
 // through. See workers/shared/sentry.js discoverAggregate.
-const ISSUE_REQUIRED_META = ["error.category", "level", "count()", "count_unique(user)"];
+// `error.type` is REQUIRED, because it is consumed: without it every fatal row
+// silently loses its exception label and renders a bare "app crash". Safe to
+// require, and that was measured rather than assumed — a live call requesting
+// all six fields echoes `error.type` in `meta.fields` (2026-08-11, #2023).
+// `issue` stays out for the documented reason: Sentry echoes it as `issue.id`,
+// so requiring the requested name would fail on a perfectly good response.
+const ISSUE_REQUIRED_META = [
+  "error.type", "error.category", "level", "count()", "count_unique(user)",
+];
 const RELEASE_FIELDS = ["release", "count()", "count_unique(user)"];
 
 /** The release query's page size AND the number the truncation sentence quotes.
@@ -531,6 +539,8 @@ export async function fetchSentrySection(env, window, opts = {}) {
     return {
       shortId: typeof row.issue === "string" ? row.issue : null,
       people: toCount(row["count_unique(user)"]),
+      // False until a collapse merges rows into this one; see the loop below.
+      peopleIsLowerBound: false,
       events: toCount(row["count()"]),
       group: classified.group,
       label: classified.label,
@@ -583,6 +593,11 @@ export async function fetchSentrySection(env, window, opts = {}) {
     // for - eight rows of one user each would have printed eight people.
     existing.events = addCounts(existing.events, row.events, "event total");
     existing.people = Math.max(existing.people, row.people);
+    // The row must SAY it is a lower bound rather than print a merged number as
+    // though it were exact. Set only when a merge actually happened, so the
+    // ordinary row - which after the `error.type` change is every row - carries
+    // no hedge it has not earned.
+    existing.peopleIsLowerBound = true;
   }
 
   return {
@@ -878,7 +893,8 @@ const BADGES_INCOMPLETE_LINE =
  * one moved. */
 const TRUNCATED_LINE =
   "Sentry returned a full page, so more problems may exist. The affected-people total " +
-  "covers all of them; the error count and the breakdown cover only those listed above.";
+  "covers all of them; the error count covers every problem Sentry returned, while the " +
+  "breakdown covers only those listed above.";
 
 /** `truncated` changes the CLAIM, not just the wording: when the problem page
  * was cut off, the totals above genuinely do NOT include the omitted rows, so
@@ -972,7 +988,15 @@ function appendGroup(lines, heading, rows, state) {
     // list, and "lost the dictation" is a strong claim to make on a category
     // whose producers disagree.
     const suffix = row.deliveryProven ? "" : ", delivery not proven";
-    lines.push(`  ${people(row.people)}   ${row.label}${suffix}${row.isNew ? "   NEW" : ""}`);
+    // "at least" only when rows were merged into this one. `Math.max` across a
+    // collapse understates whenever two rows carry disjoint users, and neither
+    // max nor sum can recover the real union from grouped counts - so the number
+    // is hedged where it is genuinely a bound, and printed plainly where it is
+    // Sentry's own exact per-issue figure.
+    const peopleText = row.peopleIsLowerBound
+      ? `at least ${people(row.people)}`
+      : people(row.people);
+    lines.push(`  ${peopleText}   ${row.label}${suffix}${row.isNew ? "   NEW" : ""}`);
     if (descriptionLength(lines) > state.budget) {
       lines.pop();
       state.omitted += 1;

--- a/workers/weekly-digest/test/digest.test.js
+++ b/workers/weekly-digest/test/digest.test.js
@@ -60,14 +60,17 @@ const SENTRY_RELEASE_ROWS = [
   { release: "com.enviouswispr.app@2.4.1", "count_unique(user)": 3, "count()": 12 },
   { release: "com.enviouswispr.app@2.3.1", "count_unique(user)": 2, "count()": 5 },
 ];
+// `error.type`, not `title`: #2023 changed what the section requests, and a
+// double still carrying the old field would describe a response the live
+// endpoint no longer returns. Empty on handled errors, which both of these are.
 const SENTRY_PROBLEM_ROWS = [
   {
-    issue: "ENVIOUSWISPR-2C", "issue.id": 1, title: "audio_capture_stalled: HeartPathError#0",
+    issue: "ENVIOUSWISPR-2C", "issue.id": 1, "error.type": [],
     "error.category": "audio_capture_stalled", level: "error",
     "count_unique(user)": 25, "count()": 103,
   },
   {
-    issue: "ENVIOUSWISPR-24", "issue.id": 2, title: "paste_failed: HeartPathError#3",
+    issue: "ENVIOUSWISPR-24", "issue.id": 2, "error.type": [],
     "error.category": "paste_failed", level: "error",
     "count_unique(user)": 13, "count()": 18,
   },
@@ -91,7 +94,7 @@ function sentryAnswer(url, overrides) {
   }
   if (url.includes("field=issue")) {
     return ok(sentryBody(SENTRY_PROBLEM_ROWS,
-      ["title", "issue.id", "error.category", "level", "count_unique(user)", "count()"]));
+      ["error.type", "issue.id", "error.category", "level", "count_unique(user)", "count()"]));
   }
   // The prior window starts seven days before the reported one.
   const isPrior = url.includes(encodeURIComponent("2026-07-20T00:00:00"));


### PR DESCRIPTION
Closes #2023.

## What was wrong

The daily and weekly Sentry sections grouped problems by `issue` **and** `title`. A crash title embeds a per-event memory address, so one Sentry issue arrived as many rows: `ENVIOUSWISPR-4B` returned **eight rows for one issue, one user and nine events**. Each rendered the same sentence, and each counted as its own "problem" in the headline the founder reads first.

Sentry's own grouping was correct throughout. The fragmentation was created by our query.

## The fix, in two layers

**Cause.** `ISSUE_FIELDS` requests `error.type` instead of `title`. It carries the exception type alone, is constant per crash signature, and returns one row per issue with a TRUE `count_unique(user)`. Measured on the same window: 22 rows before, 15 after, matching a bare `field=issue` grouping exactly.

**Guarantee.** The section then collapses rows by short id, so one issue is one problem whatever Sentry returns. A null short id is never a group key — unidentifiable rows stay separate rather than being fused under one heading.

Privacy improves as a side effect: `title` was the only requested field carrying user-derived text, and the message half is no longer fetched at all rather than fetched and discarded correctly.

## Review

Five rounds of local `codex review`, ending in an explicit all-clear. Every finding adopted.

| Round | Finding | Outcome |
|---|---|---|
| r1 | Truncation wording claimed "100 or more problems" and "the largest 100", both false once rows collapse | Both sentences now count from the rows actually returned |
| r2 | `error.type` was consumed but not validated | Added to the required-meta shape check |
| r2 | A merged people count printed as though exact | Renders "at least N", set only when a merge happened |
| r2 | r1's own rewording conflated two different bounds | Error count and visible breakdown stated separately |
| r3 | Classification taken from whichever row Sentry sorted first | `lost` wins over `degraded`; any unproven row makes the merge unproven |
| r3 | A blank `issue` string was accepted as a grouping key | Trimmed and length-checked; `isNew` reads the same normalised value |
| r4 | The merged label kept its old severity | The label now moves with the group |
| r4 | A cut page can split one issue across pages | Every displayed row is marked partial when the page was cut |

Two of those corrected claims I had written myself: an r3 comment asserted that category, level and type are constant within an issue (`level` is per-event), and my own r3 test rendered "paste fell back to the clipboard" underneath "LOST THE DICTATION".

The r2 shape-check tightening immediately failed eight tests whose doubles predated the field. Those doubles were wrong, not the check.

## The regression the tests could not see

Making the truncation sentence accurate lengthened it by 65 characters. That sentence is **reserved out of the row budget unconditionally**, even on days it is never printed, so the section silently rendered one problem fewer *every day* — the digest quietly listing less of exactly the thing it exists to list.

No unit test could catch it: every fixture that exercises the budget passes its own, so the default budget against a real row set is untested by construction. It surfaced only from running the live smoke against production and diffing against `main`.

Fixed at the cause — a disclosure line is reserved only when it will be printed. `truncated` and `badgesIncomplete` are known before layout; only the omitted line genuinely depends on the layout and stays unconditional.

## Verification against live production data

Both trees driven over the same live windows:

| Window | main | this branch |
|---|---|---|
| Yesterday | 9 problems, 835 chars | **identical, byte for byte** |
| Last 7 days | 23 rows, 9 shown, 14 omitted | **16 issues, 12 shown, 4 omitted** |

The 23 → 16 is the defect itself: seven weekly "problems" were fragments of issues already listed. Event and people totals are unchanged in both windows (241 / 59), so nothing is lost.

Worth stating precisely, because it is the difference between a fix and a workaround: **on live data the local collapse never fires.** Sentry returns 16 rows for the `error.type` query directly, so the cause fix does all the work and the collapse is dormant insurance against a future grouping field that varies within an issue. No row carried the lower-bound hedge or the mixed-label disclosure on either live window, which is the correct result and the two-way control for both.

- daily-report 232 → 241 tests, weekly-digest 73, sentry-triage 87. All green.
- **Mutation controls** on every new behaviour: defeating the collapse, reverting the field to `title`, accepting a blank id, and taking classification by sort order each fail their own test and no other.
- **Two-way controls** so a blanket rule cannot pass: an unmerged row must print plainly, an uncut page must leave rows unhedged, and a uniformly degraded collapse must stay degraded.
- `error.type` being echoed in `meta.fields` was **measured against the live API**, not assumed — requiring a name Sentry does not echo would take the whole section offline, which is why `issue` remains excluded.

## Deploy note

Each worker bundles its own copy of `workers/reporting/`, so this changes nothing in production until both digest workers are redeployed.
