### PR TITLE
fix(audio): a fake microphone must not win the Auto path

### DIFF
--- a/Sources/EnviousWisprAppKit/App/BluetoothAwarenessPresenter.swift
+++ b/Sources/EnviousWisprAppKit/App/BluetoothAwarenessPresenter.swift
@@ -216,24 +216,26 @@ final class BluetoothAwarenessPresenter {
   /// real CoreAudio devices; the bootstrapper supplies the live `AudioDeviceEnumerator`
   /// resolvers.
   /// - Parameters:
-  ///   - defaultInputIsBluetooth: `nil` when there is no resolvable default device.
+  ///   - autoInputIsBluetooth: `nil` when Auto resolves to no device at all.
   ///   - uidIsBluetooth: `nil` when the UID does not resolve (removed/unknown device).
   static func computeEffectiveInputIsBluetooth(
     preferredOverride: String,
-    defaultInputIsBluetooth: () -> Bool?,
+    autoInputIsBluetooth: () -> Bool?,
     uidIsBluetooth: (String) -> Bool?
   ) -> Bool {
-    // Auto (empty override): capture follows the system-default input, so classify
-    // the default — never a remembered selected device HAL won't open.
+    // Auto (empty override): classify the device capture would actually OPEN —
+    // never a remembered selected device HAL won't open, and since #2022 not
+    // simply the system default either, because a virtual or aggregate default
+    // loses to a real microphone and the fallback may be the Bluetooth one.
     guard !preferredOverride.isEmpty else {
-      return defaultInputIsBluetooth() ?? false
+      return autoInputIsBluetooth() ?? false
     }
     // Explicit override: authoritative when it resolves; a stale/unresolvable
     // override falls back to the default input, mirroring HAL's own fallback.
     if let resolved = uidIsBluetooth(preferredOverride) {
       return resolved
     }
-    return defaultInputIsBluetooth() ?? false
+    return autoInputIsBluetooth() ?? false
   }
 
   // MARK: - Helpers

--- a/Sources/EnviousWisprAppKit/App/BluetoothAwarenessWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/BluetoothAwarenessWiring.swift
@@ -32,8 +32,13 @@ extension BluetoothAwarenessPresenter {
         guard let settings else { return false }
         return BluetoothAwarenessPresenter.computeEffectiveInputIsBluetooth(
           preferredOverride: settings.preferredInputDeviceIDOverride,
-          defaultInputIsBluetooth: {
-            guard let id = AudioDeviceEnumerator.defaultInputDeviceID() else { return nil }
+          autoInputIsBluetooth: {
+            // The device Auto would actually OPEN, not the system default. Since
+            // #2022 a virtual or aggregate default loses to a real microphone,
+            // and if that fallback IS a headset then reading the default here
+            // would answer "not Bluetooth" and withhold the whole awareness card
+            // from a user who is on Bluetooth (cloud review).
+            guard let id = AudioDeviceEnumerator.resolvedAutoInputDeviceID() else { return nil }
             return AudioDeviceEnumerator.isBluetoothDevice(id)
           },
           uidIsBluetooth: { uid in

--- a/Sources/EnviousWisprAppKit/Views/Settings/AudioSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AudioSettingsView.swift
@@ -12,11 +12,18 @@ struct AudioSettingsView: View {
   @Environment(SettingsManager.self) private var settings
   @Environment(AudioDeviceList.self) private var audioDeviceList
 
+  /// Names the device Auto would actually OPEN, not the system default.
+  ///
+  /// Since #2022 those differ when the default is a virtual or aggregate device
+  /// the ladder refuses. Reading the default here would print "Using Krisp"
+  /// while the microphone we actually record from is the built-in one — the
+  /// pill's only job is to say what is in use, so naming the refused device is
+  /// the one thing it must not do.
   private var autoInputDeviceName: String? {
     guard settings.preferredInputDeviceIDOverride.isEmpty,
-      let defaultID = AudioDeviceEnumerator.defaultInputDeviceID()
+      let resolvedID = AudioDeviceEnumerator.resolvedAutoInputDeviceID()
     else { return nil }
-    return audioDeviceList.availableInputDevices.first { $0.id == defaultID }?.name
+    return audioDeviceList.availableInputDevices.first { $0.id == resolvedID }?.name
   }
 
   var body: some View {

--- a/Sources/EnviousWisprAudio/AudioDeviceManager.swift
+++ b/Sources/EnviousWisprAudio/AudioDeviceManager.swift
@@ -245,9 +245,32 @@ public enum AudioDeviceEnumerator {
     return devices.first(where: { $0.uid == uid })?.id
   }
 
+  /// The device an Auto capture would actually OPEN.
+  ///
+  /// Since #2022 that is NOT always the system default: a default proven not to
+  /// be a microphone (virtual or aggregate) loses to a real one. Any consumer
+  /// answering "which input is in use" must ask THIS, not
+  /// `defaultInputDeviceID()`, or it will name the device we deliberately
+  /// refused — cloud review found exactly that in the settings pill and the
+  /// Bluetooth awareness card.
+  ///
+  /// Exists because `InputDeviceResolver` is module-internal: this is the one
+  /// public door to it, so the ladder stays the single selection authority
+  /// rather than being re-derived per consumer.
+  ///
+  /// Cost matches `defaultInputDeviceID()` on the healthy path — one extra
+  /// property read, and the enumeration only when the default is refused.
+  public static func resolvedAutoInputDeviceID() -> AudioDeviceID? {
+    InputDeviceResolver().resolve(preferredUID: nil).selectedDeviceID
+  }
+
   /// Returns the UID of the current system-default input device, or nil if
   /// none. Used by Sentry extras (`capture.input_device_uid_system_default`)
   /// so divergence vs the preferred device is measured correctly.
+  ///
+  /// Deliberately the SYSTEM DEFAULT and not the resolved device: its whole
+  /// purpose is to let divergence be measured, so it must keep reporting what
+  /// macOS says even when the ladder refuses it.
   public static func defaultInputDeviceUID() -> String? {
     guard let id = defaultInputDeviceID() else { return nil }
     return stringProperty(for: id, selector: kAudioDevicePropertyDeviceUID)

--- a/Sources/EnviousWisprAudio/InputDeviceResolver.swift
+++ b/Sources/EnviousWisprAudio/InputDeviceResolver.swift
@@ -247,16 +247,23 @@ struct InputDeviceResolver {
     // instead binds and captures silence, that is the silent-capture family
     // (#1845 / #1578 / #1809), which owns detection and is out of scope here.
     //
-    // #2022 adds ONE condition, and its second half is the whole safety of this
-    // change: divert away from a proven non-microphone default ONLY when there
-    // is a real microphone to divert TO.
+    // #2022 adds ONE condition: divert away from a proven non-microphone default
+    // ONLY when there is a real microphone to divert TO. With no alternative we
+    // bind the default exactly as before, so this change never turns a working
+    // take into an error.
     //
-    // An `aggregate` transport is NOT proof of a dead device. macOS can present
-    // a synthetic `CADefaultDeviceAggregate` on the default input path, so the
-    // aggregate we see may be the OS's own wrapper around a working microphone.
-    // Diverting unconditionally would take a user whose only listed device is
-    // that wrapper from dictating fine to "No microphone found", which is a
-    // false claim and a regression.
+    // WHAT THAT DELIBERATELY DOES NOT FIX. Binding a proven non-microphone with
+    // no alternative still loses the dictation, which is the very failure this
+    // issue targets. Refusing instead would be honest, but the outcome it lands
+    // on (`noBuiltInMicrophoneFound`) both asserts "No microphone found. Please
+    // connect one." — questionable when a user DELIBERATELY built an aggregate
+    // device, which can contain a real microphone and record perfectly well —
+    // and files an ALERTING Sentry error, which is the opposite of the reason
+    // this work was prioritised. Doing it properly needs a non-alerting
+    // environment outcome that does not exist yet.
+    //
+    // So this is a KNOWN, MEASURED LIMIT, not an oversight: aggregate defaults
+    // are one install across four releases. Founder call, not a code call.
     //
     // With `!eligible.isEmpty` required, this change introduces NO new path to
     // that message: every input that reaches it today still does, and nothing

--- a/Sources/EnviousWisprAudio/InputDeviceResolver.swift
+++ b/Sources/EnviousWisprAudio/InputDeviceResolver.swift
@@ -95,15 +95,22 @@ struct InputDeviceResolver {
   /// count and transport reported below has to describe the same list the
   /// selected device came from.
   let inputDeviceSnapshot: () -> InputDeviceSnapshot
+  /// The transport of ONE known device. A targeted property read, not a list
+  /// read, so rung 1 can ask what the system default IS without paying for the
+  /// enumeration it exists to avoid (#2022).
+  let transportForDevice: (AudioDeviceID) -> UInt32?
 
   init(
     defaultInputDeviceID: @escaping () -> AudioDeviceID? = AudioDeviceEnumerator
       .defaultInputDeviceID,
     inputDeviceSnapshot: @escaping () -> InputDeviceSnapshot = AudioDeviceEnumerator
-      .inputDeviceSnapshot
+      .inputDeviceSnapshot,
+    transportForDevice: @escaping (AudioDeviceID) -> UInt32? = AudioDeviceEnumerator
+      .transportTypeRaw(for:)
   ) {
     self.defaultInputDeviceID = defaultInputDeviceID
     self.inputDeviceSnapshot = inputDeviceSnapshot
+    self.transportForDevice = transportForDevice
   }
 
   /// Resolve the device to open. `preferredUID` is the user's pinned device;
@@ -112,10 +119,31 @@ struct InputDeviceResolver {
     let defaultID = defaultInputDeviceID()
     let hasPreferred = !(preferredUID ?? "").isEmpty
 
+    // #2022. ONE targeted transport read, computed once and consulted by rung 1
+    // and rung 3, so the two rungs can never disagree about what the default IS.
+    // Eager rather than lazy: rung 2 makes it unused when a pinned device is
+    // found, and one property read on a per-dictation path is not worth a second
+    // code path to avoid.
+    //
+    // PROOF ONLY. `isKnownNonMicrophoneTransport` is deliberately narrower than
+    // "fails the allow-list" - nil, unknown and future transports are all
+    // uncertainty and return false here - so an unreadable transport keeps
+    // today's behaviour exactly. We divert on proof, never on doubt.
+    let defaultProvenNonMicrophone =
+      defaultID.map { AudioDeviceEnumerator.isKnownNonMicrophoneTransport(transportForDevice($0)) }
+      ?? false
+
     // Rung 1 — the ordinary Auto path. A present default is taken WITHOUT
     // touching the device list, so the overwhelmingly common case does no
     // extra hardware work and reports `not_attempted` honestly.
-    if !hasPreferred, let defaultID {
+    //
+    // Unless the default is PROVEN not to be a microphone. A virtual or
+    // aggregate default records bit-exact digital silence, and on the fleet
+    // those two transports carry 21 stall events and ZERO successful dictations
+    // across 2.4.0-2.4.4. Binding one is a guaranteed lost dictation, so this
+    // pays for the enumeration it normally avoids and looks for a real
+    // microphone instead. The cost lands only on the affected cohort.
+    if !hasPreferred, let defaultID, !defaultProvenNonMicrophone {
       return InputDeviceResolution(
         outcome: .selected(defaultID, source: .systemDefault),
         defaultPresent: true,
@@ -218,7 +246,27 @@ struct InputDeviceResolver {
     // The outcome is a failed bind, which `bind_outcome = failed` records; if it
     // instead binds and captures silence, that is the silent-capture family
     // (#1845 / #1578 / #1809), which owns detection and is out of scope here.
-    if let defaultID {
+    //
+    // #2022 adds ONE condition, and its second half is the whole safety of this
+    // change: divert away from a proven non-microphone default ONLY when there
+    // is a real microphone to divert TO.
+    //
+    // An `aggregate` transport is NOT proof of a dead device. macOS can present
+    // a synthetic `CADefaultDeviceAggregate` on the default input path, so the
+    // aggregate we see may be the OS's own wrapper around a working microphone.
+    // Diverting unconditionally would take a user whose only listed device is
+    // that wrapper from dictating fine to "No microphone found", which is a
+    // false claim and a regression.
+    //
+    // With `!eligible.isEmpty` required, this change introduces NO new path to
+    // that message: every input that reaches it today still does, and nothing
+    // new does. The failure directions are asymmetric and decide it - diverting
+    // wrongly withdraws a working microphone, declining to divert merely leaves
+    // today's behaviour in place.
+    //
+    // This one condition serves both entries to this rung: a pinned device that
+    // vanished, and rung 1 falling through on a proven non-microphone default.
+    if let defaultID, !(defaultProvenNonMicrophone && !eligible.isEmpty) {
       return resolution(
         .selected(defaultID, source: .systemDefault),
         transport: candidates.first(where: { $0.id == defaultID })?.rawTransport

--- a/Sources/EnviousWisprAudio/InputDeviceResolver.swift
+++ b/Sources/EnviousWisprAudio/InputDeviceResolver.swift
@@ -372,7 +372,28 @@ struct InputDeviceResolver {
   private func matchesDefaultOrKeepsFallback(
     _ bound: BoundInputDevice, defaultID: AudioDeviceID?
   ) -> Bool {
-    if let defaultID { return bound.deviceID == defaultID }
+    if let defaultID {
+      // #2022: A DEFAULT THE COLD LADDER WOULD REFUSE CANNOT INVALIDATE A BIND
+      // THE COLD LADDER MADE BY REFUSING IT.
+      //
+      // Once rung 1 diverts away from a virtual or aggregate default, the warm
+      // bind is a physical device while the default is still the fake one. The
+      // plain equality below then answers "incompatible" on every subsequent
+      // take, so the user this change rescues would tear down and cold-open
+      // EVERY time — trading a lost dictation for a permanently slow one, on
+      // the exact population the fix exists for.
+      //
+      // A `listFallback` bind is by construction one the ladder chose over the
+      // default, so keeping it is the same answer re-resolving would give. The
+      // cheap source check is FIRST so the ordinary Auto bind — whose source is
+      // `systemDefault` — never pays for the transport read.
+      if bound.resolutionSource == InputResolutionSource.listFallback.rawValue,
+        AudioDeviceEnumerator.isKnownNonMicrophoneTransport(transportForDevice(defaultID))
+      {
+        return true
+      }
+      return bound.deviceID == defaultID
+    }
     return bound.resolutionSource == InputResolutionSource.listFallback.rawValue
   }
 }

--- a/Tests/EnviousWisprTests/App/BluetoothAwarenessPresenterTests.swift
+++ b/Tests/EnviousWisprTests/App/BluetoothAwarenessPresenterTests.swift
@@ -305,7 +305,7 @@ private func emitEquals(
   @Test func effectiveInput_overrideWinsOverBluetoothDefault() {
     let result = BluetoothAwarenessPresenter.computeEffectiveInputIsBluetooth(
       preferredOverride: "builtin",
-      defaultInputIsBluetooth: { true },
+      autoInputIsBluetooth: { true },
       uidIsBluetooth: { $0 == "airpods" }  // "builtin" -> false
     )
     #expect(result == false)  // explicit non-BT override beats a BT default
@@ -319,7 +319,7 @@ private func emitEquals(
     // selection would have resolved BT under the old precedence.
     let result = BluetoothAwarenessPresenter.computeEffectiveInputIsBluetooth(
       preferredOverride: "",
-      defaultInputIsBluetooth: { false },
+      autoInputIsBluetooth: { false },
       uidIsBluetooth: { $0 == "airpods" }
     )
     #expect(result == false)
@@ -328,7 +328,7 @@ private func emitEquals(
   @Test func effectiveInput_defaultBluetoothWhenBothEmpty() {
     let result = BluetoothAwarenessPresenter.computeEffectiveInputIsBluetooth(
       preferredOverride: "",
-      defaultInputIsBluetooth: { true },
+      autoInputIsBluetooth: { true },
       uidIsBluetooth: { _ in false }
     )
     #expect(result == true)
@@ -337,7 +337,7 @@ private func emitEquals(
   @Test func effectiveInput_defaultNotBluetoothWhenBothEmpty() {
     let result = BluetoothAwarenessPresenter.computeEffectiveInputIsBluetooth(
       preferredOverride: "",
-      defaultInputIsBluetooth: { false },
+      autoInputIsBluetooth: { false },
       uidIsBluetooth: { _ in true }
     )
     #expect(result == false)
@@ -349,7 +349,7 @@ private func emitEquals(
     // stale UID with a Bluetooth default must show the card, not fail closed.
     let result = BluetoothAwarenessPresenter.computeEffectiveInputIsBluetooth(
       preferredOverride: "ghost-device",
-      defaultInputIsBluetooth: { true },
+      autoInputIsBluetooth: { true },
       uidIsBluetooth: { _ in nil }  // removed/unknown device
     )
     #expect(result == true)
@@ -359,7 +359,7 @@ private func emitEquals(
     // Stale UID but the default input is NOT Bluetooth → no card (no false positive).
     let result = BluetoothAwarenessPresenter.computeEffectiveInputIsBluetooth(
       preferredOverride: "ghost-device",
-      defaultInputIsBluetooth: { false },
+      autoInputIsBluetooth: { false },
       uidIsBluetooth: { _ in nil }
     )
     #expect(result == false)
@@ -369,7 +369,7 @@ private func emitEquals(
     // A UID that DOES resolve is authoritative — the default is not consulted.
     let result = BluetoothAwarenessPresenter.computeEffectiveInputIsBluetooth(
       preferredOverride: "builtin",
-      defaultInputIsBluetooth: { true },  // default is BT...
+      autoInputIsBluetooth: { true },  // default is BT...
       uidIsBluetooth: { _ in false }  // ...but the pinned built-in resolves non-BT
     )
     #expect(result == false)
@@ -378,7 +378,7 @@ private func emitEquals(
   @Test func effectiveInput_noDefaultDevice_failsClosed() {
     let result = BluetoothAwarenessPresenter.computeEffectiveInputIsBluetooth(
       preferredOverride: "",
-      defaultInputIsBluetooth: { nil },  // no default input device
+      autoInputIsBluetooth: { nil },  // no default input device
       uidIsBluetooth: { _ in true }
     )
     #expect(result == false)

--- a/Tests/EnviousWisprTests/Architecture/AutoInputDeviceAuthorityFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/AutoInputDeviceAuthorityFreezeTests.swift
@@ -1,0 +1,112 @@
+import Foundation
+import Testing
+
+/// #2022 — freezes the one thing that change made possible to get wrong.
+///
+/// Before #2022, "the system default input" and "the device capture opens" were
+/// the same device on Auto, so any consumer could answer "which microphone is in
+/// use?" by reading the default. That is no longer true: a default PROVEN not to
+/// be a microphone (virtual or aggregate) loses to a real one.
+///
+/// Cloud review found two consumers still reading the default, and they failed
+/// in different ways — the settings pill would name the device we deliberately
+/// refused, and the Bluetooth awareness card would answer "not Bluetooth" and
+/// withhold itself from a user on a headset. Neither is a crash, both are
+/// silent, and a runtime test would have to construct a virtual audio device to
+/// see either.
+///
+/// So this is a STRUCTURAL freeze on the CLASS rather than a test of the two
+/// instances: a new consumer reading the default must fail the build, not wait
+/// for someone to notice their microphone name is wrong.
+///
+/// The rule: `resolvedAutoInputDeviceID()` is the only way to ask "what would
+/// Auto open". `defaultInputDeviceID()` answers a different question — "what
+/// does macOS currently call the default" — which stays legitimate for the few
+/// files below that genuinely mean it.
+@Suite struct AutoInputDeviceAuthorityFreezeTests {
+
+  /// Files permitted to read the raw system default, each for a stated reason.
+  /// Adding an entry is a deliberate act: state why the file means the SYSTEM
+  /// DEFAULT rather than the device capture will open.
+  private static let permitted: [String: String] = [
+    // Defines it, and defines `defaultInputDeviceUID()` whose whole purpose is
+    // to report the default so divergence can be measured in telemetry.
+    "Sources/EnviousWisprAudio/AudioDeviceManager.swift":
+      "declares the accessor and the deliberate system-default UID reporter",
+    // The ladder itself — this is the code that decides whether the default wins.
+    "Sources/EnviousWisprAudio/InputDeviceResolver.swift":
+      "the selection ladder, which consumes the default as an input",
+    // Route telemetry's PRE-BIND estimate, used only when the actual bound
+    // transport is unavailable; it prefers `actualBoundTransport` when present.
+    "Sources/EnviousWisprAudio/ResolvedRouteTransports.swift":
+      "pre-bind route estimate, superseded by the actual bound transport",
+    // DEBUG UAT seam that forces the no-default condition.
+    "Sources/EnviousWisprAudio/AudioCaptureManager.swift":
+      "DEBUG seam injecting a nil default to exercise the fallback",
+  ]
+
+  /// A plain substring, and precise enough BY MEASUREMENT rather than by
+  /// assumption. The two identifiers that could collide do not:
+  /// `resolvedAutoInputDeviceID(` does not contain this text (the stem is
+  /// `AutoInputDeviceID`, not `defaultInputDeviceID`), and the
+  /// `defaultInputDeviceIDProvider` seam is followed by `P`, not `(`. Swift
+  /// regex literals reject lookbehind, and precision matters more than
+  /// cleverness here — a freeze that fires on innocent names gets deleted
+  /// rather than obeyed.
+  private static let call = "defaultInputDeviceID("
+
+  @Test("only the audio module's stated owners read the raw system default")
+  func noConsumerDerivesTheInputFromTheSystemDefault() throws {
+    let root = RepoRoot.url
+    let sources = root.appendingPathComponent("Sources")
+
+    var offenders: [String] = []
+    let files = FileManager.default.enumerator(at: sources, includingPropertiesForKeys: nil)
+    while let item = files?.nextObject() as? URL {
+      guard item.pathExtension == "swift" else { continue }
+      let relative = item.path.replacingOccurrences(of: root.path + "/", with: "")
+      guard Self.permitted[relative] == nil else { continue }
+      let text = try String(contentsOf: item, encoding: .utf8)
+      if text.contains(Self.call) { offenders.append(relative) }
+    }
+
+    #expect(
+      offenders.isEmpty,
+      """
+      These files ask macOS for the system default input to decide which \
+      microphone is in use. Since #2022 that is not the device capture opens \
+      when the default is virtual or aggregate — use \
+      `AudioDeviceEnumerator.resolvedAutoInputDeviceID()`, or add the file to \
+      `permitted` with the reason it genuinely means the system default:
+      \(offenders.sorted().joined(separator: "\n"))
+      """)
+  }
+
+  /// The two-way control. A freeze whose pattern matches nothing is
+  /// indistinguishable from a clean repo, and would keep passing after someone
+  /// renames the accessor.
+  @Test("the freeze's own pattern still matches a known real call site")
+  func patternMatchesAKnownCallSite() throws {
+    let owner = RepoRoot.url
+      .appendingPathComponent("Sources/EnviousWisprAudio/InputDeviceResolver.swift")
+    let text = try String(contentsOf: owner, encoding: .utf8)
+    #expect(
+      text.contains(Self.call),
+      """
+      The resolver must still call defaultInputDeviceID(). If it does not, this \
+      freeze is checking a name that no longer exists and proves nothing.
+      """)
+  }
+
+  /// Every permitted file must still exist, so a rename or deletion turns into a
+  /// failure here rather than silently widening the allow-list to cover nothing.
+  @Test("every permitted exception still names a real file")
+  func permittedFilesExist() {
+    for (path, reason) in Self.permitted {
+      let url = RepoRoot.url.appendingPathComponent(path)
+      #expect(
+        FileManager.default.fileExists(atPath: url.path),
+        "permitted exception no longer exists (\(reason)): \(path)")
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/Audio/InputDeviceResolverTests.swift
+++ b/Tests/EnviousWisprTests/Audio/InputDeviceResolverTests.swift
@@ -193,11 +193,16 @@ struct InputDeviceResolverTests {
     #expect(result.resolutionSource == .listFallback)
   }
 
-  /// THE SAFETY CASE. macOS can present a synthetic `CADefaultDeviceAggregate`
-  /// on the default input path, so an aggregate transport can be the OS wrapping
-  /// a working microphone. If this change diverted with nowhere to divert to,
-  /// such a user would go from dictating fine to being told to connect a
-  /// microphone.
+  /// THE NO-REGRESSION CASE. With no real microphone to divert to, the default
+  /// is bound exactly as before, so #2022 never turns a working take into an
+  /// error and adds no new path to "No microphone found".
+  ///
+  /// This is a known limit rather than a fix: binding a proven non-microphone
+  /// still loses that dictation. Refusing would assert "connect a microphone" to
+  /// someone who may have deliberately built an aggregate device that records
+  /// fine, and would file an alerting error — the opposite of why this was
+  /// prioritised. Freezing the conservative behaviour so a later change to it is
+  /// a deliberate decision, not an accident.
   ///
   /// #2022 therefore introduces NO new path to "no microphone found".
   @Test("a proven non-microphone default is still used when there is no real microphone")

--- a/Tests/EnviousWisprTests/Audio/InputDeviceResolverTests.swift
+++ b/Tests/EnviousWisprTests/Audio/InputDeviceResolverTests.swift
@@ -53,6 +53,14 @@ struct InputDeviceResolverTests {
     }
   }
 
+  /// Counts targeted transport reads (#2022). Same shape as `SnapshotSpy`: the
+  /// point is that a read the resolver performs is COUNTABLE, so "at most one
+  /// per resolve" is a tested property rather than a claim in a comment.
+  private final class TransportReadCounter: @unchecked Sendable {
+    private(set) var count = 0
+    func bump() { count += 1 }
+  }
+
   private func candidate(
     _ id: AudioDeviceID, _ uid: String, _ transport: UInt32?
   ) -> InputDeviceCandidate {
@@ -61,23 +69,35 @@ struct InputDeviceResolverTests {
 
   /// The spy is the ONLY source of the snapshot, so no test can pass a snapshot
   /// that is silently ignored.
+  ///
+  /// `defaultTransport` is injected on EVERY call and never defaulted to the
+  /// production reader: `InputDeviceResolver`'s own contract is that it "cannot
+  /// smuggle in a live CoreAudio read", and leaving the #2022 parameter at its
+  /// production default would have every test below performing one against
+  /// whatever hardware the machine happens to have. Built-in is the neutral
+  /// value — a real microphone, so it changes no pre-#2022 expectation.
   private func resolve(
     preferredUID: String? = nil,
     defaultID: AudioDeviceID?,
+    defaultTransport: UInt32? = kAudioDeviceTransportTypeBuiltIn,
     spy: SnapshotSpy
   ) -> InputDeviceResolution {
     InputDeviceResolver(
       defaultInputDeviceID: { defaultID },
-      inputDeviceSnapshot: { spy.provide() }
+      inputDeviceSnapshot: { spy.provide() },
+      transportForDevice: { _ in defaultTransport }
     ).resolve(preferredUID: preferredUID)
   }
 
   private func resolve(
     preferredUID: String? = nil,
     defaultID: AudioDeviceID?,
+    defaultTransport: UInt32? = kAudioDeviceTransportTypeBuiltIn,
     snapshot: InputDeviceSnapshot
   ) -> InputDeviceResolution {
-    resolve(preferredUID: preferredUID, defaultID: defaultID, spy: SnapshotSpy(snapshot))
+    resolve(
+      preferredUID: preferredUID, defaultID: defaultID, defaultTransport: defaultTransport,
+      spy: SnapshotSpy(snapshot))
   }
 
   /// One accepted transport. A named type rather than a tuple so the
@@ -139,6 +159,137 @@ struct InputDeviceResolverTests {
     #expect(result.selectedDeviceID == 42)
     #expect(result.resolutionSource == .systemDefault)
     #expect(spy.callCount == 0)
+  }
+
+  // MARK: - Rung 1b: a system default that is proven not to be a microphone (#2022)
+
+  @Test("a virtual system default loses Auto to a real microphone")
+  func virtualDefaultDivertsToPhysical() {
+    let spy = SnapshotSpy(
+      .complete([
+        candidate(60, "BlackHole2ch", kAudioDeviceTransportTypeVirtual),
+        candidate(7, "BuiltInMicrophoneDevice", kAudioDeviceTransportTypeBuiltIn),
+      ]))
+    let result = resolve(
+      defaultID: 60, defaultTransport: kAudioDeviceTransportTypeVirtual, spy: spy)
+
+    #expect(result.selectedDeviceID == 7)
+    #expect(result.resolutionSource == .listFallback)
+    // The enumeration rung 1 normally avoids IS paid for here, and only here.
+    #expect(spy.callCount == 1)
+  }
+
+  @Test("an aggregate system default loses Auto to a real microphone")
+  func aggregateDefaultDivertsToPhysical() {
+    let spy = SnapshotSpy(
+      .complete([
+        candidate(61, "aggregate", kAudioDeviceTransportTypeAggregate),
+        candidate(8, "usb-mic", kAudioDeviceTransportTypeUSB),
+      ]))
+    let result = resolve(
+      defaultID: 61, defaultTransport: kAudioDeviceTransportTypeAggregate, spy: spy)
+
+    #expect(result.selectedDeviceID == 8)
+    #expect(result.resolutionSource == .listFallback)
+  }
+
+  /// THE SAFETY CASE. macOS can present a synthetic `CADefaultDeviceAggregate`
+  /// on the default input path, so an aggregate transport can be the OS wrapping
+  /// a working microphone. If this change diverted with nowhere to divert to,
+  /// such a user would go from dictating fine to being told to connect a
+  /// microphone.
+  ///
+  /// #2022 therefore introduces NO new path to "no microphone found".
+  @Test("a proven non-microphone default is still used when there is no real microphone")
+  func nonMicrophoneDefaultIsKeptWhenNothingElseExists() {
+    let spy = SnapshotSpy(
+      .complete([
+        candidate(60, "BlackHole2ch", kAudioDeviceTransportTypeVirtual),
+        candidate(61, "aggregate", kAudioDeviceTransportTypeAggregate),
+      ]))
+    let result = resolve(
+      defaultID: 61, defaultTransport: kAudioDeviceTransportTypeAggregate, spy: spy)
+
+    #expect(result.selectedDeviceID == 61)
+    #expect(result.resolutionSource == .systemDefault)
+    #expect(result.thrownError == nil, "diverting nowhere must never become an error")
+  }
+
+  @Test("an unreadable default transport keeps today's behaviour, never diverting on doubt")
+  func unreadableDefaultTransportFailsOpen() {
+    let spy = SnapshotSpy(.complete([candidate(7, "built-in", kAudioDeviceTransportTypeBuiltIn)]))
+    let result = resolve(defaultID: 42, defaultTransport: nil, spy: spy)
+
+    #expect(result.selectedDeviceID == 42)
+    #expect(result.resolutionSource == .systemDefault)
+    #expect(result.enumerationOutcome == .notAttempted)
+    #expect(spy.callCount == 0, "uncertainty must not buy an enumeration")
+  }
+
+  @Test("an unknown default transport keeps today's behaviour too")
+  func unknownDefaultTransportFailsOpen() {
+    let spy = SnapshotSpy(.complete([candidate(7, "built-in", kAudioDeviceTransportTypeBuiltIn)]))
+    let result = resolve(defaultID: 42, defaultTransport: 0, spy: spy)
+
+    #expect(result.selectedDeviceID == 42)
+    #expect(result.enumerationOutcome == .notAttempted)
+  }
+
+  @Test("a pinned virtual device is still the user's to choose")
+  func pinnedVirtualDeviceIsUnaffected() {
+    let spy = SnapshotSpy(
+      .complete([
+        candidate(60, "BlackHole2ch", kAudioDeviceTransportTypeVirtual),
+        candidate(7, "built-in", kAudioDeviceTransportTypeBuiltIn),
+      ]))
+    let result = resolve(
+      preferredUID: "BlackHole2ch", defaultID: 60,
+      defaultTransport: kAudioDeviceTransportTypeVirtual, spy: spy)
+
+    // Rung 2 is reached before any of this, and an explicit choice stays the
+    // user's. This is what makes the divert above safe: the deliberate user
+    // pins, so only the accidental default is rescued.
+    #expect(result.selectedDeviceID == 60)
+    #expect(result.resolutionSource == .pinnedUID)
+  }
+
+  @Test("a pinned device that vanished falls through a virtual default to a real microphone")
+  func pinnedGoneWithVirtualDefaultDivertsToPhysical() {
+    let spy = SnapshotSpy(
+      .complete([
+        candidate(60, "BlackHole2ch", kAudioDeviceTransportTypeVirtual),
+        candidate(7, "built-in", kAudioDeviceTransportTypeBuiltIn),
+      ]))
+    let result = resolve(
+      preferredUID: "unplugged-usb-mic", defaultID: 60,
+      defaultTransport: kAudioDeviceTransportTypeVirtual, spy: spy)
+
+    #expect(result.selectedDeviceID == 7)
+    #expect(result.resolutionSource == .listFallback)
+  }
+
+  @Test("the default's transport is read at most once per resolve")
+  func transportIsReadAtMostOnce() {
+    // Both rungs that consult it are mutually exclusive, and the value is
+    // computed once so they can never disagree about what the default IS.
+    let counter = TransportReadCounter()
+    let resolver = InputDeviceResolver(
+      defaultInputDeviceID: { 60 },
+      inputDeviceSnapshot: {
+        .success(
+          candidates: [
+            InputDeviceCandidate(
+              id: 60, uid: "virt", rawTransport: kAudioDeviceTransportTypeVirtual),
+            InputDeviceCandidate(id: 7, uid: "mic", rawTransport: kAudioDeviceTransportTypeBuiltIn),
+          ], complete: true)
+      },
+      transportForDevice: { _ in
+        counter.bump()
+        return kAudioDeviceTransportTypeVirtual
+      })
+
+    _ = resolver.resolve(preferredUID: nil)
+    #expect(counter.count == 1)
   }
 
   // MARK: - Rung 2: a pinned device

--- a/Tests/EnviousWisprTests/Audio/InputDeviceResolverTests.swift
+++ b/Tests/EnviousWisprTests/Audio/InputDeviceResolverTests.swift
@@ -692,15 +692,19 @@ struct InputDeviceResolverTests {
       resolutionSource: source.rawValue)
   }
 
+  /// `defaultTransport` is injected here for the same reason as the cold helper:
+  /// the #2022 parameter must never fall through to a live CoreAudio read.
   private func warmCompatible(
     _ bound: BoundInputDevice,
     preferredUID: String? = nil,
     defaultID: AudioDeviceID?,
+    defaultTransport: UInt32? = kAudioDeviceTransportTypeBuiltIn,
     spy: SnapshotSpy
   ) -> Bool {
     InputDeviceResolver(
       defaultInputDeviceID: { defaultID },
-      inputDeviceSnapshot: { spy.provide() }
+      inputDeviceSnapshot: { spy.provide() },
+      transportForDevice: { _ in defaultTransport }
     ).isWarmBindCompatible(bound, preferredUID: preferredUID)
   }
 
@@ -815,6 +819,35 @@ struct InputDeviceResolverTests {
     #expect(
       !warmCompatible(
         bind(30, .systemDefault), preferredUID: "airpods", defaultID: nil, spy: spy))
+  }
+
+  @Test("a diverted bind survives while the fake default is still the default (#2022)")
+  func divertedBindKeepsWarmReuse() {
+    // Cloud review found this: once rung 1 diverts, the warm bind is a physical
+    // device while the default is still the virtual one, so plain equality
+    // answers "incompatible" on EVERY later take. The rescued user would trade a
+    // lost dictation for a permanently cold-opening one.
+    let spy = SnapshotSpy(.complete([candidate(7, "builtin", kAudioDeviceTransportTypeBuiltIn)]))
+
+    #expect(
+      warmCompatible(
+        bind(7, .listFallback), defaultID: 60,
+        defaultTransport: kAudioDeviceTransportTypeVirtual, spy: spy))
+    // Auto must still never enumerate to answer this.
+    #expect(spy.callCount == 0)
+  }
+
+  @Test("a fallback bind does NOT survive a real default that differs")
+  func fallbackBindYieldsToARealDefault() {
+    // The two-way control. Without it, keeping every `listFallback` bind would
+    // pass the test above while ignoring a genuine microphone the user just
+    // plugged in and macOS just made the default.
+    let spy = SnapshotSpy(.complete([candidate(7, "builtin", kAudioDeviceTransportTypeBuiltIn)]))
+
+    #expect(
+      !warmCompatible(
+        bind(7, .listFallback), defaultID: 8,
+        defaultTransport: kAudioDeviceTransportTypeUSB, spy: spy))
   }
 
   // MARK: - The per-device failure-vs-empty distinction (whole-diff review)


### PR DESCRIPTION
Closes #2022.

## What was wrong

On the ordinary Auto path the resolver took whatever macOS reported as the system default input **without reading what that device is**. When the default is a virtual or aggregate device — Krisp, Loopback, BlackHole, an aggregate, a meeting app's virtual mic — we bound it and recorded bit-exact digital silence, which reached the user as a capture stall.

The allow-list that exists to refuse exactly these devices was only ever applied to the enumerated candidate list, which the common path never reaches.

## Evidence

Production, dev-excluded, 2.4.0 → 2.4.4:

| transport | stall events | successful takes ever |
|---|---:|---:|
| virtual | 14 | **0** |
| aggregate | 7 | **0** |
| bluetooth | 332 | 4,328 |
| built_in | 94 | 16,425 |

`unknown` appears on both the failure and the success event (3 / 19), which is the vocabulary control: the two events share an enum, so the zero is a finding rather than a spelling mismatch. Telemetry agrees with the code — 20 of 21 such stalls carry `selected_transport = unknown`, and rung 1 is precisely the branch that reports no selected transport.

## The change

Rung 1 performs one targeted transport read and, on **proof** that the default is not a microphone, pays for the enumeration it normally avoids and prefers a real microphone instead. Rung 3 carries the same condition, so a vanished pinned device cannot land back on a fake one.

Three limits keep it narrow, and each is load-bearing:

- **A pinned virtual device is still selected.** An explicit choice stays the user's, and this is what makes the divert safe: the deliberate user pins, so only the accidental default is rescued.
- **Proof, never doubt.** `isKnownNonMicrophoneTransport` is false for nil, unknown and future transports, so an unreadable transport keeps today's behaviour exactly.
- **The divert requires somewhere to go.** macOS can present a synthetic `CADefaultDeviceAggregate` on the default input path, so an aggregate is not proof of a dead device — it can be the OS wrapping a working microphone. Without the `!eligible.isEmpty` term, such a user would go from dictating fine to "No microphone found".

**This introduces no new path to that message.** Everything that reaches it today still does, and nothing new does. The mutation control proves it rather than asserting it: dropping the term fails the safety test with exactly `.noBuiltInMicrophoneFound`.

## A behaviour change worth naming

This overrides the documented "EW follows the system default and does not second-guess it" in one narrow case. Taken because founder priority 1 is that dictation works whenever it physically can, and a virtual device physically cannot produce dictation audio while a real microphone sits unused. Reversible in one line. The knowledge file has been amended rather than left contradicting the code.

## Verification

- Resolver suite 37 → 45 tests. Full suite **5301 tests, green**.
- Two mutation controls: reverting the rung-1 guard fails the two divert tests; dropping the safety term fails the safety test.
- The test seam now injects the transport reader on **every** call rather than inheriting the production default — this type's contract is that it "cannot smuggle in a live CoreAudio read", and the new parameter would otherwise have had every case reading whatever hardware the machine happens to have.
- The warm-bind path was checked and deliberately left alone: it is a separate projection that never calls `resolve`, and every state it can reach was reasoned through in the plan.

## Local Codex review: one P1, adjudicated as a documented limit

**The finding is real.** When the default is virtual or aggregate AND enumeration finds no eligible physical device, we bind that same proven non-microphone — reproducing the exact stall this issue targets. Not fixed here, deliberately:

- Refusing lands on `noBuiltInMicrophoneFound`, which asserts *"No microphone found. Please connect one."* A user who deliberately built an aggregate device in Audio MIDI Setup may have a working microphone inside it, so that sentence can be false.
- That outcome also files an **alerting Sentry error**, which is the opposite of why this work was prioritised (founder direction 2026-08-11: stopping it entering the error stream matters more than the message).
- The cohort is **one install across four releases**.

Doing it honestly needs a non-alerting environment outcome that does not exist yet. That is a decision about what the user should see, not a code call, so it is recorded in the code, the test and the knowledge file rather than guessed at.

## Cloud review: the finding that mattered most

Cloud review caught something that would have made this change **worse for the users it rescues**.

Once rung 1 diverts, the warm bind is a physical device while the system default is still the fake one. `matchesDefaultOrKeepsFallback` keeps a `listFallback` bind only when there is NO default — so with the fake default still present it answered "incompatible" on every subsequent take: tear down, cold open, **every single dictation**. A lost dictation traded for a permanently slow one.

The warm path now carries the same rule as the cold one: a default the ladder would REFUSE cannot invalidate a bind the ladder made by refusing it. Nothing is re-ranked, so #1714 §12's "fallback ranking is cold-open only" still holds. The cheap `resolutionSource` check runs first, so an ordinary `systemDefault` bind never pays for the transport read.

**Why I missed it.** The plan reasoned through every state the *existing* code could reach and concluded the warm path was untouched. Wrong question. This change *creates* a state none of those describe, and the question that finds it is "what new state does this create, and what does each consumer do in it?" Recorded in the plan.

## A wrong reason, caught by checking the reviewer's finding

Checking that P1 exposed something worse than the P1. My comment defending the `!eligible.isEmpty` term cited a synthetic `CADefaultDeviceAggregate` on the default input path. **That fact is scoped to the AVAudioEngine `CurrentDevice` readback, and `AVAudioEngineSource` was deleted by #1536.** `defaultInputDeviceID()` reads `kAudioHardwarePropertyDefaultInputDevice` straight from CoreAudio, so the mechanism cannot apply. A grep for the constant across `Sources/` returned exactly one hit: my own comment.

Right conclusion, wrong reason, shipped into a code comment, a test doc comment and a knowledge file. Corrected in all three. The term still stands on grounds that are established — a user-built aggregate can record, refusing files an alerting error, and the cohort is one install.

## Out of scope

No new user-facing sentence, no new terminal, no new telemetry field. Founder decision 2026-08-11: the priority is that this stops entering the error stream, not the message.
