### PR TITLE
feat(eval): grade on the expiring cloud credits, and refuse to grade on a personal key

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -630,9 +630,15 @@ jobs:
           python3 Tests/RuntimeUAT/ptt_binding.py --self-test
           python3 Tests/RuntimeUAT/faultInjection.py --self-test
 
-      - name: Judge-receipt completeness contract (#2007/#2008)
+      - name: Judge receipt + billing contracts (#2007/#2008)
         run: |
           set -euo pipefail
+          # Also carries the judge BILLING gate: grading on a personal vendor API key is
+          # banned. Routing and the billing classification both derive from one route
+          # table, and an unrecognised id is refused before either funded transport can
+          # run — the personal-key transports were deleted outright, so there is nothing
+          # for a typo to fall through to.
+          #
           # A judge run that dropped work must never read as a complete receipt.
           # Three layers have to agree: behavior_judge.py detects the gap,
           # judge_ollama_bench.sh refuses to cache a partial receipt, and

--- a/scripts/eval/behavior_judge.py
+++ b/scripts/eval/behavior_judge.py
@@ -129,6 +129,18 @@ DEFAULT_CHUNK_SIZE = 8
 #   "'temperature' does not support 0 with this model. Only the default (1)"
 AZURE_API_VERSION = "2024-10-21"
 
+# The model version pinned for THIS process, set by `judge_identity` when it probes the
+# deployment. Every grading response is then checked against it, because the probe is a
+# time-of-check and each grading call is a time-of-use: Azure can repoint a deployment
+# mid-sweep, and receipts written after that would carry the pre-change identity while holding
+# post-change scores — one scoreboard silently mixing two judge versions. Cloud review found
+# the gap; the check is one comparison on a field the response already carries.
+#
+# None means "not pinned", which happens only when nothing probed first. `call_azure` then
+# cannot verify, so `preflight_judge` pins for every azure run rather than leaving it to the
+# caller to remember.
+_azure_pinned_model: str | None = None
+
 
 class MissingSecretError(RuntimeError):
     pass
@@ -302,6 +314,16 @@ def call_azure(deployment: str, system: str, user: str) -> str:
     choices = data.get("choices") or []
     if not choices:
         raise RuntimeError(f"azure judge: no choices in response: {str(data)[:200]}")
+    # Time-of-use check against the pinned model version. A repoint between the identity probe
+    # and this call would otherwise produce scores from a new model under the old model's stamp.
+    # Raising aborts the chunk loudly, which the harness reports as a gap rather than caching.
+    served = data.get("model")
+    if _azure_pinned_model is not None and isinstance(served, str) and served.strip() \
+            and served.strip() != _azure_pinned_model:
+        raise RuntimeError(
+            f"azure judge: deployment served {served.strip()!r} but this run is pinned to "
+            f"{_azure_pinned_model!r}. The deployment was repointed mid-run; stop and re-grade "
+            f"the whole field so one scoreboard cannot mix two judge versions.")
     finish = choices[0].get("finish_reason")
     content = (choices[0].get("message") or {}).get("content")
     if not isinstance(content, str) or not content.strip():
@@ -465,6 +487,8 @@ def judge_identity(model: str) -> str:
         return model
     host = (urllib.parse.urlsplit(_validated_azure_endpoint()).hostname or "").lower()
     served = _azure_served_model(model[len("azure/"):])
+    global _azure_pinned_model
+    _azure_pinned_model = served
     digest = hashlib.sha256(
         f"{host}|{AZURE_API_VERSION}|{served}".encode()).hexdigest()[:12]
     return f"{model}@{digest}"
@@ -496,9 +520,22 @@ def refuse_paid_key_judge(model: str) -> None:
 
 
 def preflight_judge(model: str) -> None:
-    """For the Claude judge, verify the CLI is installed AND logged in before we
-    spend a long run; abort (exit 2) otherwise. No-op for HTTP judges (a bad key
-    surfaces on the first real call)."""
+    """Prove the judge can work before a long run, and abort (exit 2) otherwise.
+
+    Claude: the CLI is installed and logged in. Azure: the deployment answers, and the model
+    version it serves is PINNED for the rest of this process so every grading response can be
+    checked against it. Pinning here rather than trusting the caller, because a run started
+    directly (not through `judge_ollama_bench.sh`, which resolves the identity itself) would
+    otherwise grade with no pin and no time-of-use check.
+    """
+    if judge_transport(model) == "azure":
+        try:
+            judge_identity(model)          # probes and sets `_azure_pinned_model`
+        except Exception as e:
+            print(f"INFRA-ERROR: Azure judge unusable ({e}); aborting before any work.",
+                  file=sys.stderr)
+            sys.exit(2)
+        return
     if judge_transport(model) != "claude":
         return
     try:

--- a/scripts/eval/behavior_judge.py
+++ b/scripts/eval/behavior_judge.py
@@ -57,6 +57,7 @@ Outputs -> <outdir>/ : per_case.jsonl, summary.json, scoreboard.txt.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import random
@@ -392,6 +393,35 @@ def dispatch_judge(model: str, system: str, user: str) -> str:
     # JUDGE_ROUTES has no other transport. Raise rather than fall through, so adding a
     # route without a branch is a loud error and never a silent wrong-vendor call.
     raise RuntimeError(f"no transport for judge {model!r} (JUDGE_ROUTES is out of step)")
+
+
+def judge_identity(model: str) -> str:
+    """What actually graded, as one string safe to hash into a resume stamp.
+
+    The judge ID alone is NOT sufficient identity, and cloud review caught this. Azure
+    deployment names are RESOURCE-LOCAL: `azure/gpt-5-6-luna` on one resource and the same
+    label on another can serve different underlying deployments. `_key` reads the endpoint
+    from the environment first, so the resource can change with no change to the id — and a
+    stamp built from the id alone would then match a receipt graded by a different model and
+    skip it, silently mixing two graders in one comparison. That is exactly the defect
+    putting the judge in the stamp was meant to prevent, one level further down.
+
+    The API version is folded in for the same reason: this route's accepted parameters and
+    behaviour are version-dependent, so a version bump is a different grader.
+
+    Returns a DIGEST of the endpoint host, never the host itself. The value is written into a
+    hashed stamp and printed to a terminal, and neither is a place to put a resource name.
+
+    Raises `MissingSecretError` or `RuntimeError` if the endpoint cannot be resolved or
+    validated, so an unusable configuration fails here rather than after work is deleted.
+    """
+    if judge_lacks_funded_route(model):
+        raise RuntimeError(f"no approved funded grading route for judge {model!r}")
+    if not model.startswith("azure/"):
+        return model
+    host = (urllib.parse.urlsplit(_validated_azure_endpoint()).hostname or "").lower()
+    digest = hashlib.sha256(f"{host}|{AZURE_API_VERSION}".encode()).hexdigest()[:12]
+    return f"{model}@{digest}"
 
 
 def refuse_paid_key_judge(model: str) -> None:
@@ -1551,6 +1581,25 @@ def render_scoreboard(r: dict, system: str) -> str:
 # ---------------------------------------------------------------------------
 
 def main() -> int:
+    # Handled BEFORE argparse deliberately: `--corpus`, `--candidates` and `--out` are all
+    # required, so a caller that only wants to know which judge is configured would have to
+    # invent three paths to ask. Callers use this to VALIDATE the judge before touching any
+    # stored receipt — `judge_ollama_bench.sh` deletes a receipt whose stamp no longer
+    # matches, so a refused or mistyped EW_JUDGE would otherwise delete the whole cached set
+    # and then exit before writing replacements. Exits 2 with a reason instead.
+    #
+    # Prints two lines: the judge id, then its stamp identity. Two lines rather than one so
+    # the caller does not have to split on a separator that could appear inside either value.
+    if "--print-judge-identity" in sys.argv:
+        try:
+            identity = judge_identity(DEFAULT_JUDGE)
+        except Exception as e:
+            print(f"judge {DEFAULT_JUDGE!r} is unusable: {e}", file=sys.stderr)
+            return 2
+        print(DEFAULT_JUDGE)
+        print(identity)
+        return 0
+
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--system", choices=("new", "old"), default="new",

--- a/scripts/eval/behavior_judge.py
+++ b/scripts/eval/behavior_judge.py
@@ -141,6 +141,13 @@ AZURE_API_VERSION = "2024-10-21"
 # caller to remember.
 _azure_pinned_model: str | None = None
 
+# The full judge identity THIS process resolved, for a run started directly rather than through
+# `judge_ollama_bench.sh`. The receipt records the sweep's `EW_JUDGE_IDENTITY` when there is one
+# and this otherwise: a direct run resolves a perfectly good identity in preflight, and reading
+# only the environment threw it away, so two direct receipts from different Azure resources
+# recorded the same empty provenance and the report could not tell them apart.
+_resolved_judge_identity: str | None = None
+
 
 class MissingSecretError(RuntimeError):
     pass
@@ -498,11 +505,12 @@ def judge_identity(model: str) -> str:
         return model
     host = (urllib.parse.urlsplit(_validated_azure_endpoint()).hostname or "").lower()
     served = _azure_served_model(model[len("azure/"):])
-    global _azure_pinned_model
+    global _azure_pinned_model, _resolved_judge_identity
     _azure_pinned_model = served
     digest = hashlib.sha256(
         f"{host}|{AZURE_API_VERSION}|{served}".encode()).hexdigest()[:12]
-    return f"{model}@{digest}"
+    _resolved_judge_identity = f"{model}@{digest}"
+    return _resolved_judge_identity
 
 
 def refuse_paid_key_judge(model: str) -> None:
@@ -560,8 +568,10 @@ def preflight_judge(model: str) -> None:
         return
     if judge_transport(model) != "claude":
         return
+    global _resolved_judge_identity
     try:
         call_claude(model, "You output only JSON.", "Reply with exactly: []")
+        _resolved_judge_identity = model
     except Exception as e:
         print(f"INFRA-ERROR: Claude judge CLI unavailable/unauthed ({e}); aborting. "
               f"Run `claude` once to log in, or pass --judge azure/gpt-5-6-luna.",
@@ -1826,7 +1836,7 @@ def main() -> int:
         # same model string — which the id and version alone cannot, even though the resume stamp
         # always could. Empty for a run started outside the sweep, which groups with other such
         # runs rather than pretending to an identity it never resolved.
-        "judge_identity": os.environ.get("EW_JUDGE_IDENTITY") or None,
+        "judge_identity": os.environ.get("EW_JUDGE_IDENTITY") or _resolved_judge_identity,
         "reps": args.reps if args.system == "old" else None,
         "adjudicate_pct": args.adjudicate_pct if args.system == "new" else None,
         "adjudicate_min": args.adjudicate_min if args.system == "new" else None,

--- a/scripts/eval/behavior_judge.py
+++ b/scripts/eval/behavior_judge.py
@@ -395,6 +395,46 @@ def dispatch_judge(model: str, system: str, user: str) -> str:
     raise RuntimeError(f"no transport for judge {model!r} (JUDGE_ROUTES is out of step)")
 
 
+def _azure_served_model(deployment: str) -> str:
+    """The model AND VERSION this deployment actually serves right now.
+
+    Azure can upgrade or repoint a deployment IN PLACE: the endpoint hostname, the deployment
+    name and the API version all stay identical while the model underneath changes, depending
+    on the deployment's upgrade policy. An identity built from those three would keep matching
+    receipts graded by the previous model, so a resumed sweep would skip them and combine two
+    models' scores — the silent mixing this whole change exists to prevent, arriving by the one
+    route the client cannot see from configuration alone.
+
+    The data plane reports it: the chat-completions response carries `model`, which on this
+    resource reads `gpt-5.6-luna-2026-07-09` (measured 2026-08-11). It changes when the
+    deployment is repointed, which is exactly the signal needed.
+
+    Costs one 16-token request per sweep, and earns it twice: it also proves the deployment
+    ANSWERS before the sweep touches any receipt, which no amount of name checking can do.
+    `system_fingerprint` would be the stronger signal but this resource returns null for it.
+    """
+    endpoint = _validated_azure_endpoint()
+    url = (f"{endpoint}/openai/deployments/{deployment}/chat/completions"
+           f"?api-version={AZURE_API_VERSION}")
+    req = urllib.request.Request(
+        url,
+        data=json.dumps({"messages": [{"role": "user", "content": "."}],
+                         "max_completion_tokens": 16}).encode(),
+        headers={"api-key": _key("azure-openai-key"), "Content-Type": "application/json"},
+        method="POST",
+    )
+    with _no_redirect_opener().open(req, timeout=60) as resp:
+        data = json.loads(resp.read())
+    served = data.get("model")
+    if not isinstance(served, str) or not served.strip():
+        # Fail rather than fall back to a version-blind identity: a blind identity silently
+        # reuses receipts across a model change, which is worse than refusing to start.
+        raise RuntimeError(
+            f"azure judge: deployment {deployment!r} did not report which model served the "
+            f"request, so a receipt stamp cannot be bound to a model version")
+    return served.strip()
+
+
 def judge_identity(model: str) -> str:
     """What actually graded, as one string safe to hash into a resume stamp.
 
@@ -409,6 +449,10 @@ def judge_identity(model: str) -> str:
     The API version is folded in for the same reason: this route's accepted parameters and
     behaviour are version-dependent, so a version bump is a different grader.
 
+    And the SERVED MODEL VERSION, because Azure can repoint a deployment in place while all
+    three of those stay the same. That is the only axis a client cannot read from its own
+    configuration, so it is read from the deployment itself. See `_azure_served_model`.
+
     Returns a DIGEST of the endpoint host, never the host itself. The value is written into a
     hashed stamp and printed to a terminal, and neither is a place to put a resource name.
 
@@ -420,7 +464,9 @@ def judge_identity(model: str) -> str:
     if not model.startswith("azure/"):
         return model
     host = (urllib.parse.urlsplit(_validated_azure_endpoint()).hostname or "").lower()
-    digest = hashlib.sha256(f"{host}|{AZURE_API_VERSION}".encode()).hexdigest()[:12]
+    served = _azure_served_model(model[len("azure/"):])
+    digest = hashlib.sha256(
+        f"{host}|{AZURE_API_VERSION}|{served}".encode()).hexdigest()[:12]
     return f"{model}@{digest}"
 
 

--- a/scripts/eval/behavior_judge.py
+++ b/scripts/eval/behavior_judge.py
@@ -40,10 +40,16 @@ Inputs (both systems):
                 the judge and aggregate these (lets a subagent self-judge, then
                 this harness does the deterministic roll-up).
 
-Judge backend mirrors acceptance_gate.py exactly: `claude-sonnet-4-6` over the
-headless Claude CLI ($0 at the margin, subscription auth) by default; `gpt*` ->
-OpenAI, else Gemini, via --judge / EW_JUDGE. Every Claude sandbox flag is copied
-verbatim from the proven path (each earned a Codex round — do not change here).
+Judge backend, selected with --judge / EW_JUDGE. Two funded routes, and nothing else
+is permitted: `azure/<deployment>` on the Azure startup credits (the DEFAULT), and
+`claude*`/`sonnet*` over the headless Claude CLI (subscription auth, $0 at the margin,
+but it spends the weekly budget needed for building). Direct OpenAI and Gemini model ids
+are REFUSED, as is any unrecognised id — those bill the founder's own money, which
+grading may not do (founder 2026-08-11). Note `claude*` is NOT refused: it reaches the
+logged-in CLI rather than a direct Anthropic API-key transport, which is why it
+counts as funded. What that CLI contacts is its own business; this module only chooses
+how the judge is invoked. Every Claude sandbox flag is copied verbatim from the proven
+path (each earned a Codex round — do not change here).
 
 Outputs -> <outdir>/ : per_case.jsonl, summary.json, scoreboard.txt.
 """
@@ -60,6 +66,7 @@ import tempfile
 import time
 import urllib.request
 import urllib.error
+import urllib.parse
 from collections import Counter, defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -69,17 +76,34 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any
 
 # ---------------------------------------------------------------------------
-# Judge backend — mirrors acceptance_gate.py. Default = on-subscription Claude
-# Sonnet via headless CLI ($0). DO NOT alter the Claude sandbox flags; each one
-# earned a Codex round (polish-eval.md FACT: bench-judge-is-claude-sonnet).
+# Judge backend. Default = Azure on the startup credits since 2026-08-11; the
+# on-subscription Claude CLI is still supported and is no longer the default, so
+# this no longer mirrors acceptance_gate.py, which stays on Sonnet as the CI gate.
+# DO NOT alter the Claude sandbox flags; each one earned a Codex round
+# (polish-eval.md FACT: bench-judge-is-claude-sonnet, whose sandbox invariants are
+# still live even though its judge SELECTION is marked historical).
 # ---------------------------------------------------------------------------
 
-CLAUDE_JUDGE_MODEL_ID = "claude-sonnet-5"  # founder decision 2026-07-02: Sonnet 5
-# is the PRIMARY judge — it graded the published 1,890-case research run
-# (runs/prompt-tune-2026-07-01/full1890/*/summary.json "judge": "claude-sonnet-5");
-# claude-sonnet-4-6 (the old default) grades measurably harsher, so scores from
-# the two judges are NOT comparable. Never mix judge models within a comparison.
-DEFAULT_JUDGE = os.environ.get("EW_JUDGE", CLAUDE_JUDGE_MODEL_ID)
+CLAUDE_JUDGE_MODEL_ID = "claude-sonnet-5"  # founder decision 2026-07-02, superseded
+# below as the DEFAULT but still the id to pass when a run must be comparable to the
+# published 1,890-case research run, which it graded
+# (runs/prompt-tune-2026-07-01/full1890/*/summary.json "judge": "claude-sonnet-5").
+
+AZURE_JUDGE_DEPLOYMENT_ID = "azure/gpt-5-6-luna"  # founder decision 2026-08-11: the
+# DEFAULT judge, on the expiring Azure startup credits. The reason is which scarce
+# resource each option burns, not accuracy: the Claude subscription is building
+# capacity (~99% used by Thursday) and the Codex plan is adversarial review, while an
+# unspent credit is a pure loss. Validated over 12 local arms before the switch —
+# 0 of 12 shipped labels moved, delta median 0.0pp, and on the three substantive
+# disagreements spot-checked by hand Luna was right all three times. The full comparison
+# is recorded on issue #1950; the receipts themselves are local only, which is why the
+# durable copy lives there rather than behind a path in this repo.
+#
+# Judges are NOT interchangeable mid-comparison: re-grade every arm of a comparison
+# with one judge rather than reading a new arm against an old baseline. The earlier
+# blanket "never mix judge models" was retired by the founder on 2026-08-11 because
+# re-benchmarking is routine here, which makes the cheap judge the enabling one.
+DEFAULT_JUDGE = os.environ.get("EW_JUDGE", AZURE_JUDGE_DEPLOYMENT_ID)
 CLAUDE_JUDGE_MAX_WORKERS = 6            # subprocess per call; cap fan-out. Raised
 # from 3 (#1199 speed pass, 2026-06-30), then 20 -> 32 (founder 2026-07-02:
 # faster judging: no metered cost on the subscription judge, only a transient
@@ -95,6 +119,14 @@ DEFAULT_ADJUDICATE_PCT = 0.15          # new-system: fraction of pass/minor/soft
 DEFAULT_ADJUDICATE_MIN = 15            # cases re-judged as a calibration sample
 REP_PASSRATE_DELTA_MAX = 5.0          # pp; wobble above this flags the run unreliable
 DEFAULT_CHUNK_SIZE = 8
+
+# Azure OpenAI data-plane version for the chat-completions route. Pinned rather than
+# floating because this route's accepted PARAMETERS are version- and model-dependent,
+# and a rejection arrives as a bare HTTP 400 that reads like a broken judge. Measured
+# against this deployment on 2026-08-11, both as HTTP 400:
+#   "'max_tokens' is not supported with this model. Use 'max_completion_tokens'"
+#   "'temperature' does not support 0 with this model. Only the default (1)"
+AZURE_API_VERSION = "2024-10-21"
 
 
 class MissingSecretError(RuntimeError):
@@ -119,43 +151,15 @@ def _retryable_http_error(exc: Exception) -> bool:
     return isinstance(exc, (urllib.error.URLError, TimeoutError))
 
 
-def call_openai(model: str, system: str, user: str) -> str:
-    body = {
-        "model": model,
-        "messages": [
-            {"role": "system", "content": system},
-            {"role": "user", "content": user},
-        ],
-        "temperature": 0,
-    }
-    req = urllib.request.Request(
-        "https://api.openai.com/v1/chat/completions",
-        data=json.dumps(body).encode(),
-        headers={"Authorization": f"Bearer {_key('openai-api-key')}", "Content-Type": "application/json"},
-        method="POST",
-    )
-    with urllib.request.urlopen(req, timeout=300) as resp:
-        data = json.loads(resp.read())
-    return data["choices"][0]["message"]["content"].strip()
-
-
-def call_gemini(model: str, system: str, user: str, json_mime: bool = True) -> str:
-    body = {
-        "systemInstruction": {"parts": [{"text": system}]},
-        "contents": [{"role": "user", "parts": [{"text": user}]}],
-        "generationConfig": {"temperature": 0},
-    }
-    if json_mime:
-        body["generationConfig"]["responseMimeType"] = "application/json"
-    url = f"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={_key('gemini-api-key')}"
-    req = urllib.request.Request(
-        url, data=json.dumps(body).encode(),
-        headers={"Content-Type": "application/json"}, method="POST",
-    )
-    with urllib.request.urlopen(req, timeout=300) as resp:
-        data = json.loads(resp.read())
-    parts = data["candidates"][0]["content"]["parts"]
-    return "".join(p.get("text", "") for p in parts).strip()
+# `call_openai` and `call_gemini` are DELETED, not merely unrouted (founder 2026-08-11,
+# grading may not bill a personal key). A refusal check is a promise; a missing transport
+# is a fact, and the two differ the moment somebody calls `dispatch_judge` directly or
+# adds a route. Deleting them also removes the fall-through that made an unrecognised
+# `--judge` value bill the personal Gemini key with no warning.
+#
+# Their code is not lost: `acceptance_gate.py` keeps its own copies for the CI corpus
+# gate, which is a separate tool on a separate corpus with its own judge selection.
+# Restoring one here needs a founder decision, not a paste.
 
 
 def _judge_subprocess_env() -> dict:
@@ -203,27 +207,230 @@ def call_claude(model: str, system: str, user: str) -> str:
     return result.strip()
 
 
+def _validated_azure_endpoint() -> str:
+    """The Azure endpoint, refused unless it uses HTTPS and one of the Azure hostname
+    suffixes accepted for this route.
+
+    `_key` reads the ENVIRONMENT before the key file, so whatever is in
+    `AZURE_OPENAI_ENDPOINT` wins — and this transport then sends the Azure key to that
+    host in an `api-key` header. An endpoint variable inherited from another project, or
+    mistyped, would therefore hand our credential to somebody else's server. Nothing
+    downstream would notice, because a wrong host can answer however it likes: an error
+    that reads as a broken judge, or a plausible-looking reply.
+
+    Checks Azure-owned endpoint SHAPE rather than pinning one resource, so another
+    approved Azure OpenAI resource does not need a code edit, and so a deployment
+    configuration value does not get copied into a tracked file. This contains the
+    inherited-or-mistyped non-Azure-host risk. It is NOT an exact-resource allowlist: a
+    deliberately supplied hostname that is itself an Azure OpenAI resource would pass,
+    and the endpoint is configuration rather than the credential, so do not read this as
+    protecting the key against a hostile operator.
+
+    Redirects are disabled at the opener in `call_azure` rather than checked here: a
+    validated host can still 3xx to an arbitrary one, and urllib replays our headers.
+    """
+    endpoint = _key("azure-openai-endpoint").rstrip("/")
+    parsed = urllib.parse.urlsplit(endpoint)
+    host = (parsed.hostname or "").lower()
+    azure_openai_host = host.endswith(".openai.azure.com") or host.endswith(
+        ".cognitiveservices.azure.com")
+    if (parsed.scheme != "https" or not azure_openai_host
+            or parsed.path not in ("", "/") or parsed.query or parsed.fragment):
+        raise RuntimeError(
+            "azure judge: refusing to send the Azure key to "
+            f"{host or '(no host)'!r} — the endpoint must be an https Azure OpenAI "
+            "resource with no path, query or fragment. Check AZURE_OPENAI_ENDPOINT, "
+            "which overrides the stored key file.")
+    return endpoint
+
+
+def _no_redirect_opener() -> urllib.request.OpenerDirector:
+    """An opener that REFUSES redirects, so a 3xx cannot replay the api-key header at
+    another host. urllib follows redirects by default and re-sends headers set on the
+    Request, which would defeat the endpoint check above."""
+    class _NoRedirect(urllib.request.HTTPRedirectHandler):
+        def redirect_request(self, req, fp, code, msg, headers, newurl):
+            raise RuntimeError(
+                f"azure judge: refusing to follow a {code} redirect to {newurl!r}; "
+                f"the api-key header must not leave the validated host")
+
+    return urllib.request.build_opener(_NoRedirect)
+
+
+def call_azure(deployment: str, system: str, user: str) -> str:
+    """Azure OpenAI judge, billed to the startup CREDITS, not to a personal key.
+
+    This is the default grading transport (founder 2026-08-11). The credits expire
+    (Azure ~$5K on 2027-01-13) so an unspent credit is a pure loss, while the Claude
+    subscription and the Codex plan are both capacity the founder needs for work no
+    cloud model can do: building, and adversarial review. Grading is the ideal load to
+    move here because it is bulk, parallel and nobody is waiting on it.
+
+    `deployment` is an Azure DEPLOYMENT name, not a vendor model id. The two differ:
+    `gpt-5-6-luna` is what our resource calls it.
+    """
+    endpoint = _validated_azure_endpoint()
+    url = (f"{endpoint}/openai/deployments/{deployment}/chat/completions"
+           f"?api-version={AZURE_API_VERSION}")
+    body = {
+        "messages": [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ],
+        # No `temperature`: this model REJECTS an explicit 0 with HTTP 400 and permits
+        # only its default of 1 (measured 2026-08-11, see AZURE_API_VERSION). The Claude
+        # CLI route exposes no temperature control either, so neither supported transport
+        # pins the sampler. What bounds the resulting variation is the receipt's wobble
+        # check: over the 12 validation arms it measured 0.0pp on nine and 5.0pp on
+        # three, every one inside the existing 5.0pp limit. Note "inside" is exact for
+        # those three, which the limit permits because it flags only ABOVE 5.0pp.
+        #
+        # 16000 is measured, not guessed: this is a reasoning model, so a cap too low
+        # for the reasoning burns the whole budget and returns EMPTY (handled below).
+        # 16000 carried chunks of 8 cases with rationales across all 12 arms.
+        "max_completion_tokens": 16000,
+    }
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode(),
+        headers={"api-key": _key("azure-openai-key"), "Content-Type": "application/json"},
+        method="POST",
+    )
+    with _no_redirect_opener().open(req, timeout=300) as resp:
+        data = json.loads(resp.read())
+    choices = data.get("choices") or []
+    if not choices:
+        raise RuntimeError(f"azure judge: no choices in response: {str(data)[:200]}")
+    finish = choices[0].get("finish_reason")
+    content = (choices[0].get("message") or {}).get("content")
+    if not isinstance(content, str) or not content.strip():
+        # A cap hit and an ordinary empty reply are the same SHAPE here, so the two are
+        # split by finish_reason: only the first has an obvious operator action.
+        #
+        # Measured 2026-08-11 against the live deployment at caps of 16, 300, 800 and
+        # 2000 tokens: every one returned finish_reason='length' with content_len=0.
+        # This is a reasoning model, so the budget goes to reasoning tokens and a run
+        # that exhausts it emits NOTHING visible rather than a half-written array. That
+        # is why there is no separate partial-reply branch: not reachable in any probe.
+        # A future non-reasoning deployment could produce one, and it would surface as
+        # a json.loads error in the caller, which is the pre-existing behaviour for
+        # every other transport.
+        if finish == "length":
+            raise RuntimeError(
+                f"azure judge: no output — the whole "
+                f"max_completion_tokens={body['max_completion_tokens']} budget went to "
+                f"reasoning. Lower --chunk-size or raise the cap.")
+        raise RuntimeError(
+            f"azure judge: empty content (finish_reason={finish!r}). A dropped reply "
+            f"must fail loudly: a chunk that came back empty three times is how four "
+            f"cases went unscored in the #1950 Sonnet run.")
+    return content.strip()
+
+
+# The ONE authority for which judge ids are permitted and where each goes. Routing and
+# the billing decision are the same question, so they read the same table: two functions
+# agreeing by hand is a parity problem, and a test can only check the ids somebody
+# remembered to list. Ordered because the first matching prefix wins; today's prefixes do
+# not overlap, so keep future ones non-overlapping or put the most specific first.
+#
+# Every entry is FUNDED. There is deliberately no row for a personal key, and no
+# fall-through: an id matching nothing is refused, so an unrecognised `--judge` value
+# cannot become a charge.
+JUDGE_ROUTES: tuple[tuple[str, str], ...] = (
+    ("azure/", "azure"),    # Azure OpenAI on the expiring startup credits
+    ("claude", "claude"),   # headless Claude CLI, logged-in subscription, $0 at margin
+    ("sonnet", "claude"),
+)
+
+
+def judge_transport(model: str) -> str | None:
+    """The funded transport for `model`, or None if no funded route accepts it."""
+    for prefix, transport in JUDGE_ROUTES:
+        if model.startswith(prefix):
+            return transport
+    return None
+
+
+def judge_lacks_funded_route(model: str) -> bool:
+    """True when no approved funded route accepts `model`.
+
+    Named for what it can actually establish. The earlier name asserted that grading the
+    id WOULD spend the founder's money, which is true of a known direct-vendor id and
+    overstated for an arbitrary unknown one: an unrecognised name used to reach the
+    Gemini transport under our key, but whether that produced a charge or a rejection is
+    not something this function knows. "No funded route" is the whole test, and refusing
+    on it is correct either way.
+
+    Derived from `JUDGE_ROUTES` rather than restating it, which is what makes drift
+    impossible instead of merely tested: adding a route cannot leave this behind.
+    """
+    return judge_transport(model) is None
+
+
 def dispatch_judge(model: str, system: str, user: str) -> str:
-    """Route by model-id prefix; return raw assistant text (a JSON array, maybe
-    fenced) for the caller to fence-strip + json.loads."""
-    if model.startswith(("claude", "sonnet")):
+    """Route to a funded transport; return raw assistant text (a JSON array, maybe
+    fenced) for the caller to fence-strip + json.loads.
+
+    The billing refusal lives HERE, in the dispatcher immediately before transport
+    selection, not only in `main()`. `main()`
+    checks first for a better error before a long run, but that check is bypassed by any
+    direct call to `dispatch_judge`, `judge_chunk`, `run_judge`, `score_new` or
+    `score_old` — so the check a promise depends on has to sit where the money is spent.
+
+    `azure/<deployment>` is EXPLICIT rather than inferred from the model name, so the
+    billing target is visible in the command that runs the grade. `--judge
+    gpt-5-6-luna` names our Azure deployment but reads as an OpenAI model id, and
+    without the prefix it would spend a different pot of money.
+    """
+    refuse_paid_key_judge(model)
+    transport = judge_transport(model)
+    if transport == "azure":
+        return call_azure(model[len("azure/"):], system, user)
+    if transport == "claude":
         return call_claude(model, system, user)
-    if model.startswith("gpt"):
-        return call_openai(model, system, user)
-    return call_gemini(model, system, user)
+    # Unreachable: refuse_paid_key_judge exits on every id judge_transport rejects, and
+    # JUDGE_ROUTES has no other transport. Raise rather than fall through, so adding a
+    # route without a branch is a loud error and never a silent wrong-vendor call.
+    raise RuntimeError(f"no transport for judge {model!r} (JUDGE_ROUTES is out of step)")
+
+
+def refuse_paid_key_judge(model: str) -> None:
+    """Grading on a personal vendor API key is BANNED (founder 2026-08-11).
+
+    That money is the founder's own; the Azure/AWS credits are money that expires
+    unspent. The ban is enforced here rather than left to discipline because the old
+    default made it invisible: `--judge gpt-4o` routed to api.openai.com on a personal
+    key and looked exactly like any other judge id at the call site.
+
+    Not a blanket ban on those keys, only on GRADING. Other uses are allowed with the
+    founder's permission, which is a decision no script should make silently.
+    """
+    if not judge_lacks_funded_route(model):
+        return
+    print(
+        f"REFUSED: --judge {model} has no approved funded grading route. Grading runs "
+        f"on the startup credits, never on a personal vendor API key.\n"
+        f"  Use:  --judge azure/gpt-5-6-luna\n"
+        f"  The subscription Claude CLI judge (--judge claude-sonnet-5) still works "
+        f"but consumes the weekly budget needed for building.\n"
+        f"  An unrecognised id is refused for the same reason: no funded route matches "
+        f"it, and the transport it used to fall through to was billed to a personal key.",
+        file=sys.stderr)
+    sys.exit(2)
 
 
 def preflight_judge(model: str) -> None:
     """For the Claude judge, verify the CLI is installed AND logged in before we
     spend a long run; abort (exit 2) otherwise. No-op for HTTP judges (a bad key
     surfaces on the first real call)."""
-    if not model.startswith(("claude", "sonnet")):
+    if judge_transport(model) != "claude":
         return
     try:
         call_claude(model, "You output only JSON.", "Reply with exactly: []")
     except Exception as e:
         print(f"INFRA-ERROR: Claude judge CLI unavailable/unauthed ({e}); aborting. "
-              f"Run `claude` once to log in, or pass --judge <paid-id>.", file=sys.stderr)
+              f"Run `claude` once to log in, or pass --judge azure/gpt-5-6-luna.",
+              file=sys.stderr)
         sys.exit(2)
 
 
@@ -324,7 +531,10 @@ def run_judge(model: str, system: str, payloads: list[dict], chunk_size: int) ->
     short answer.
     """
     chunks = [payloads[i:i + chunk_size] for i in range(0, len(payloads), chunk_size)]
-    workers = CLAUDE_JUDGE_MAX_WORKERS if model.startswith(("claude", "sonnet")) else HTTP_JUDGE_MAX_WORKERS
+    # Transport decided by JUDGE_ROUTES, never by a second hand-rolled prefix test.
+    # Each transport carries its own cap, and the progress line reads this same choice.
+    workers = (CLAUDE_JUDGE_MAX_WORKERS if judge_transport(model) == "claude"
+               else HTTP_JUDGE_MAX_WORKERS)
     scores: dict[str, dict] = {}
     start = time.time()
     done = 0
@@ -1354,7 +1564,9 @@ def main() -> int:
     ap.add_argument("--verdicts", default=None,
                     help="(new only) pre-computed per-case verdicts JSONL; skip the judge, just aggregate")
     ap.add_argument("--judge", default=DEFAULT_JUDGE,
-                    help=f"judge model id (default {DEFAULT_JUDGE}); claude*/sonnet*->CLI $0, gpt*->OpenAI, else Gemini")
+                    help=f"judge model id (default {DEFAULT_JUDGE}); "
+                         f"azure/<deployment>->Azure credits, claude*/sonnet*->CLI $0. "
+                         f"Any other id is REFUSED: no approved funded route matches it")
     ap.add_argument("--reps", type=int, default=DEFAULT_REPLICATIONS,
                     help=f"(old system only) full-corpus judge replications (default {DEFAULT_REPLICATIONS})")
     ap.add_argument("--adjudicate-pct", type=float, default=DEFAULT_ADJUDICATE_PCT,
@@ -1413,11 +1625,20 @@ def main() -> int:
         prod = load_candidates(pp)
 
     if external_verdicts is None:
+        # Billing check BEFORE the availability check: refusing to spend the founder's
+        # own money must not depend on whether a CLI happens to be logged in.
+        refuse_paid_key_judge(args.judge)
         preflight_judge(args.judge)
         if args.system == "new":
             mode = "single-pass, no adjudication" if args.no_adjudicate else \
                    f"primary + adjudicate(S3/S4 + {args.adjudicate_pct*100:.0f}% sample, min {args.adjudicate_min})"
-            print(f"[judge] {args.judge}  {mode}  chunk={args.chunk_size}  workers={CLAUDE_JUDGE_MAX_WORKERS}",
+            # Report the fan-out this judge will actually use. `run_judge` picks per
+            # transport (Claude spawns a subprocess each, HTTP judges do not), so
+            # printing the Claude cap unconditionally misreported every Azure run.
+            workers = (CLAUDE_JUDGE_MAX_WORKERS
+                       if judge_transport(args.judge) == "claude"
+                       else HTTP_JUDGE_MAX_WORKERS)
+            print(f"[judge] {args.judge}  {mode}  chunk={args.chunk_size}  workers={workers}",
                   file=sys.stderr)
         else:
             print(f"[judge] {args.judge}  reps={args.reps}  chunk={args.chunk_size}", file=sys.stderr)

--- a/scripts/eval/behavior_judge.py
+++ b/scripts/eval/behavior_judge.py
@@ -529,6 +529,17 @@ def preflight_judge(model: str) -> None:
     otherwise grade with no pin and no time-of-use check.
     """
     if judge_transport(model) == "azure":
+        global _azure_pinned_model
+        inherited = os.environ.get("EW_AZURE_PINNED_MODEL", "").strip()
+        if inherited:
+            # The SWEEP already probed. Adopt its answer rather than probing again: a fresh probe
+            # would pin whatever is current, so a deployment repointed between arms would make
+            # this arm self-consistent and still wrong relative to the stamp the sweep writes.
+            # Verifying against the sweep's model means such an arm fails loudly on its first
+            # grading response instead of quietly scoring under another model's identity.
+            # It also saves one request per arm.
+            _azure_pinned_model = inherited
+            return
         try:
             judge_identity(model)          # probes and sets `_azure_pinned_model`
         except Exception as e:
@@ -1681,6 +1692,12 @@ def main() -> int:
             return 2
         print(DEFAULT_JUDGE)
         print(identity)
+        # Third line: the model version this probe observed, empty for non-Azure routes. The
+        # sweep exports it so every arm verifies against the SWEEP's model rather than its own
+        # probe. Without it each arm process probed independently, so a repoint between arms left
+        # every process self-consistent while the shell stamped them all with the first arm's
+        # identity — arms graded by different models sharing one stamp. Cloud review found it.
+        print(_azure_pinned_model or "")
         return 0
 
     ap = argparse.ArgumentParser(description=__doc__,

--- a/scripts/eval/behavior_judge.py
+++ b/scripts/eval/behavior_judge.py
@@ -1820,6 +1820,13 @@ def main() -> int:
         # in the sidecar stamp because the report reads receipts, not stamps, and a consumer that
         # cannot see the identity cannot refuse to mix it.
         "judge_model_version": _azure_pinned_model,
+        # The FULL identity the sweep resolved: judge id plus a digest of the endpoint host, the
+        # API version and the served model. Passed in rather than recomputed so every arm records
+        # the same value, and so the report can distinguish two Azure resources that serve the
+        # same model string — which the id and version alone cannot, even though the resume stamp
+        # always could. Empty for a run started outside the sweep, which groups with other such
+        # runs rather than pretending to an identity it never resolved.
+        "judge_identity": os.environ.get("EW_JUDGE_IDENTITY") or None,
         "reps": args.reps if args.system == "old" else None,
         "adjudicate_pct": args.adjudicate_pct if args.system == "new" else None,
         "adjudicate_min": args.adjudicate_min if args.system == "new" else None,

--- a/scripts/eval/behavior_judge.py
+++ b/scripts/eval/behavior_judge.py
@@ -318,12 +318,23 @@ def call_azure(deployment: str, system: str, user: str) -> str:
     # and this call would otherwise produce scores from a new model under the old model's stamp.
     # Raising aborts the chunk loudly, which the harness reports as a gap rather than caching.
     served = data.get("model")
-    if _azure_pinned_model is not None and isinstance(served, str) and served.strip() \
-            and served.strip() != _azure_pinned_model:
-        raise RuntimeError(
-            f"azure judge: deployment served {served.strip()!r} but this run is pinned to "
-            f"{_azure_pinned_model!r}. The deployment was repointed mid-run; stop and re-grade "
-            f"the whole field so one scoreboard cannot mix two judge versions.")
+    if _azure_pinned_model is not None:
+        # FAILS CLOSED on a missing or unusable field, which the first version of this check did
+        # not. It required a differing NONEMPTY STRING to refuse, so a response that omitted
+        # `model`, or returned it blank or non-string, skipped the comparison entirely and its
+        # scores were accepted — then stamped with the pinned identity. Exactly the guard shape
+        # worth distrusting: ask what input makes the condition match NOTHING, and whether it
+        # then allows or refuses. This one allowed.
+        if not isinstance(served, str) or not served.strip():
+            raise RuntimeError(
+                f"azure judge: the response did not say which model served it "
+                f"(model={served!r}), so these scores cannot be bound to the pinned version "
+                f"{_azure_pinned_model!r}. Refusing rather than stamping unverifiable scores.")
+        if served.strip() != _azure_pinned_model:
+            raise RuntimeError(
+                f"azure judge: deployment served {served.strip()!r} but this run is pinned to "
+                f"{_azure_pinned_model!r}. The deployment was repointed mid-run; stop and "
+                f"re-grade the whole field so one scoreboard cannot mix two judge versions.")
     finish = choices[0].get("finish_reason")
     content = (choices[0].get("message") or {}).get("content")
     if not isinstance(content, str) or not content.strip():

--- a/scripts/eval/behavior_judge.py
+++ b/scripts/eval/behavior_judge.py
@@ -1814,6 +1814,12 @@ def main() -> int:
     report["meta"] = {
         "system": args.system,
         "judge": args.judge if external_verdicts is None else "external_verdicts",
+        # The MODEL VERSION that graded, when the transport can tell us. The judge id alone is
+        # not identity: an Azure deployment can be repointed in place, so two receipts can share
+        # `judge` and hold scores from different models. Recorded IN the receipt rather than only
+        # in the sidecar stamp because the report reads receipts, not stamps, and a consumer that
+        # cannot see the identity cannot refuse to mix it.
+        "judge_model_version": _azure_pinned_model,
         "reps": args.reps if args.system == "old" else None,
         "adjudicate_pct": args.adjudicate_pct if args.system == "new" else None,
         "adjudicate_min": args.adjudicate_min if args.system == "new" else None,

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -119,11 +119,34 @@ import os
 # script resolves without editing the stub.
 DEFAULT_JUDGE = os.environ.get("EW_JUDGE", "azure/stub-judge")
 
+# Models the production `--print-judge-identity` contract, including its REFUSAL. A stub
+# that answered for every id would make the shell's pre-loop validation untestable: the
+# case proving a bad judge cannot delete receipts needs this to exit 2, exactly as the real
+# module does for an id with no funded route.
+if "--print-judge-identity" in sys.argv:
+    if not (DEFAULT_JUDGE.startswith("azure/") or DEFAULT_JUDGE.startswith(("claude", "sonnet"))):
+        print(f"judge {{DEFAULT_JUDGE!r}} is unusable: no approved funded grading route",
+              file=sys.stderr)
+        sys.exit(2)
+    suffix = "@stubdigest" if DEFAULT_JUDGE.startswith("azure/") else ""
+    print(DEFAULT_JUDGE)
+    print(DEFAULT_JUDGE + suffix)
+    sys.exit(0)
+
 # Guarded so an IMPORT is side-effect free and exit-free. `sys.exit` at module level
 # would raise SystemExit through the import and leave the caller with no value, which
 # looks identical to a stub that crashed.
 if __name__ == "__main__":
     a = sys.argv
+    # Models `refuse_paid_key_judge` running BEFORE any output is written. Without this the
+    # stub is more permissive than production and hides a real defect: the pre-fix script
+    # deleted a receipt on a stamp mismatch, and only production's refusal-before-write made
+    # that deletion permanent. A stub that always writes a receipt silently repairs it.
+    if "--judge" in a:
+        j = a[a.index("--judge") + 1]
+        if not (j.startswith("azure/") or j.startswith(("claude", "sonnet"))):
+            print(f"REFUSED: --judge {{j}} has no approved funded grading route", file=sys.stderr)
+            sys.exit(2)
     out = a[a.index("--out") + 1]
     d = pathlib.Path(out); d.mkdir(parents=True, exist_ok=True)
     (d.parent / "_invocations").open("a").write("call\\n")
@@ -219,7 +242,9 @@ def forge_stamp(t, judge=None):
     `judge` defaults to the stub's DEFAULT_JUDGE, i.e. what the script itself will
     resolve. Pass a different value to forge a stamp from a DIFFERENT judge, which is
     what makes "a judge change invalidates the stamp" testable."""
-    judge = judge if judge is not None else "azure/stub-judge"
+    # The script stamps the IDENTITY, not the bare label, so a fixture forging a matching
+    # stamp has to use the same value. The stub appends @stubdigest for azure routes.
+    judge = judge if judge is not None else "azure/stub-judge@stubdigest"
     forged = subprocess.run(
         ["bash", "-c",
          'if command -v shasum >/dev/null 2>&1; then H="shasum -a 256"; else H=sha256sum; fi; '
@@ -887,6 +912,54 @@ def test_the_stamp_the_script_writes_depends_on_the_judge():
     a = stamp_under("claude-sonnet-5")
     b = stamp_under("azure/gpt-5-6-luna")
     assert a and b and a != b, f"the script's stamp ignores the judge: {a} == {b}"
+
+
+def test_a_refused_judge_cannot_delete_a_single_cached_receipt():
+    """THE regression test for the P1 cloud review found on PR #2026.
+
+    Putting the judge into the stamp created a destructive path: a refused or mistyped
+    EW_JUDGE mismatches EVERY arm's stamp, the loop `rm -rf`s each receipt on a mismatch, and
+    the judge then exits before writing a replacement — so the whole cached set is destroyed
+    and the log blames "candidates or corpus changed". The fix validates the judge before the
+    loop can touch anything, so this asserts the receipt is STILL THERE afterwards.
+    """
+    t = shell_tree("true")
+    d = t / "judged" / "modelA"
+    d.mkdir(parents=True, exist_ok=True)
+    receipt = d / "summary.json"
+    receipt.write_text(json.dumps(
+        {"cacheable": True, "release_gate": {"verdict": "CLEAR"},
+         "skipped": [], "missing_scores": []}))
+    forge_stamp(t)
+    before = receipt.read_text()
+
+    p = subprocess.run(
+        ["bash", str(t / "scripts" / "eval" / "judge_ollama_bench.sh"),
+         str(t / "corpus.jsonl"), str(t / "cand"), str(t / "judged")],
+        capture_output=True, text=True, env=dict(os.environ, EW_JUDGE="gpt-4o"))
+    out = p.stdout + p.stderr
+
+    assert p.returncode == 2, f"expected refusal exit 2, got {p.returncode}:\n{out}"
+    assert receipt.exists(), f"the cached receipt was DELETED by a refused judge:\n{out}"
+    assert receipt.read_text() == before, "the cached receipt was modified"
+    assert (d / ".inputs-sha256").exists(), "the stamp was deleted"
+    assert invocations(t) == 0, f"the judge was invoked despite being refused:\n{out}"
+    assert "Nothing has been touched" in out, out
+
+
+def test_the_refusal_happens_before_any_arm_is_examined():
+    """Two-way control on the guard's PLACEMENT, not just its existence. A check that ran
+    inside the loop would refuse on the first arm and could still have deleted its receipt
+    before doing so; this asserts the script never reached the per-model work at all."""
+    t = shell_tree("true")
+    p = subprocess.run(
+        ["bash", str(t / "scripts" / "eval" / "judge_ollama_bench.sh"),
+         str(t / "corpus.jsonl"), str(t / "cand"), str(t / "judged")],
+        capture_output=True, text=True, env=dict(os.environ, EW_JUDGE="mistral-large"))
+    out = p.stdout + p.stderr
+    assert p.returncode == 2, out
+    assert "=== judging" not in out, f"an arm was entered before the judge was validated:\n{out}"
+    assert "=== judge:" not in out, f"the judge was announced as usable:\n{out}"
 
 
 def test_shell_absent_cacheable_field_is_not_stamped():
@@ -1627,7 +1700,7 @@ def test_the_billing_check_runs_before_the_availability_check():
 
 # An exact count, because the borrowed runner in cleanup_metrics_test.py returns
 # 0 when it discovers ZERO tests — so "green" would carry no information at all.
-EXPECTED_TESTS = 86
+EXPECTED_TESTS = 88
 
 
 def _run() -> int:

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -1937,6 +1937,64 @@ def test_the_identity_probe_goes_through_the_no_redirect_opener():
     assert "urllib.request.urlopen" not in body, "the probe uses a raw opener"
 
 
+@contextlib.contextmanager
+def _azure_pin(value):
+    """Pin the process to a model version, and restore it afterwards."""
+    real = bj._azure_pinned_model
+    bj._azure_pinned_model = value
+    try:
+        yield
+    finally:
+        bj._azure_pinned_model = real
+
+
+def test_a_grading_response_from_a_different_model_is_refused():
+    # Cloud review round 7. The identity probe is a time-of-CHECK; each grading call is a
+    # time-of-USE. A repoint between them would stamp post-change scores with the pre-change
+    # identity, so one scoreboard would silently hold two judge versions.
+    with _azure_pin("gpt-5.6-luna-2026-07-09"):
+        with _azure_reply({"model": "gpt-5.6-luna-2026-11-01",
+                           "choices": [{"message": {"content": "[]"},
+                                        "finish_reason": "stop"}]}):
+            try:
+                bj.call_azure("gpt-5-6-luna", "s", "u")
+            except RuntimeError as e:
+                assert "repointed mid-run" in str(e), str(e)
+            else:
+                raise AssertionError("a response from a different model was accepted")
+
+
+def test_a_grading_response_from_the_pinned_model_is_accepted():
+    # Two-way control. A check that refused everything would pass the case above while making
+    # every grading call fail — the loud failure, but it would look like Azure was broken.
+    with _azure_pin("gpt-5.6-luna-2026-07-09"):
+        with _azure_reply({"model": "gpt-5.6-luna-2026-07-09",
+                           "choices": [{"message": {"content": "[]"},
+                                        "finish_reason": "stop"}]}):
+            assert bj.call_azure("gpt-5-6-luna", "s", "u") == "[]"
+
+
+def test_an_unpinned_process_still_grades():
+    # The pin is set by preflight, so an unpinned process means nothing probed first. Grading
+    # must still work rather than refusing: this is the path a direct call takes, and there is no
+    # stamp comparison happening for it to corrupt.
+    with _azure_pin(None):
+        with _azure_reply({"model": "anything-at-all",
+                           "choices": [{"message": {"content": "[]"},
+                                        "finish_reason": "stop"}]}):
+            assert bj.call_azure("gpt-5-6-luna", "s", "u") == "[]"
+
+
+def test_preflight_pins_the_model_for_an_azure_judge():
+    # Pinned in preflight rather than left to the caller, so a run started directly still gets
+    # the time-of-use check. Without this, `_azure_pinned_model` stays None for any run that did
+    # not go through the shell, and the check above silently does nothing.
+    with _azure_pin(None):
+        with _azure_serving("gpt-5.6-luna-2026-07-09"):
+            bj.preflight_judge("azure/gpt-5-6-luna")
+            assert bj._azure_pinned_model == "gpt-5.6-luna-2026-07-09", bj._azure_pinned_model
+
+
 def test_the_billing_check_runs_before_the_availability_check():
     # Refusing to spend the founder's own money must not depend on whether some CLI
     # happens to be logged in, so the order in main() is load-bearing.
@@ -1953,7 +2011,7 @@ def test_the_billing_check_runs_before_the_availability_check():
 
 # An exact count, because the borrowed runner in cleanup_metrics_test.py returns
 # 0 when it discovers ZERO tests — so "green" would carry no information at all.
-EXPECTED_TESTS = 99
+EXPECTED_TESTS = 103
 
 
 def _run() -> int:

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -965,7 +965,7 @@ def test_a_routed_but_unusable_judge_still_cannot_delete_a_receipt():
     receipt.write_text(json.dumps(
         {"cacheable": True, "release_gate": {"verdict": "CLEAR"},
          "skipped": [], "missing_scores": []}))
-    forge_stamp(t, judge="azure/stub-judge@stubdigest")
+    original_stamp = forge_stamp(t, judge="azure/stub-judge@stubdigest")
     before = receipt.read_text()
 
     _, log = run_shell(t, env=dict(os.environ, EW_JUDGE="claude-sonet-5"))
@@ -973,8 +973,58 @@ def test_a_routed_but_unusable_judge_still_cannot_delete_a_receipt():
     assert "=== re-judging modelA" in log, f"expected a re-judge attempt:\n{log}"
     assert receipt.exists(), f"a routed-but-unusable judge DELETED the receipt:\n{log}"
     assert receipt.read_text() == before, "the receipt was modified"
-    assert "previous receipt left in place" in log, log
+    assert "previous receipt KEPT and not stamped" in log, log
     assert not (t / "judged" / "modelA.rejudge").exists(), "staging directory was left behind"
+
+    # THE OTHER HALF, and a separate P1 (cloud review round 3): surviving must not mean
+    # ADOPTED. The post-judge branch used to re-read $dest, find the old cacheable receipt and
+    # write the NEW judge's stamp onto it — so later runs skipped it and reported the previous
+    # judge's scores as this judge's, which is the silently-mixed-judges defect the stamp
+    # exists to prevent. The stamp must still hold the ORIGINAL judge's value.
+    stamp = t / "judged" / "modelA" / ".inputs-sha256"
+    assert stamp.exists(), "the original stamp should be untouched, not removed"
+    assert stamp.read_text().strip() == original_stamp, (
+        "the OLD receipt was stamped with the NEW judge's identity, so the next run would skip "
+        "it and report the previous judge's scores as this judge's")
+
+
+
+def test_a_partial_staged_receipt_does_not_evict_a_complete_one():
+    """Cloud review round 3, the sibling P1. A judge that fails AFTER scoring starts still
+    writes a summary with `cacheable: false`, so a presence-only promotion check replaced a
+    good receipt with the failure. Promotion now requires the staged receipt to be cacheable.
+    """
+    t = shell_tree("false")              # judge writes a receipt with cacheable: false
+    d = t / "judged" / "modelA"
+    d.mkdir(parents=True, exist_ok=True)
+    receipt = d / "summary.json"
+    receipt.write_text(json.dumps(
+        {"cacheable": True, "release_gate": {"verdict": "CLEAR"},
+         "skipped": [], "missing_scores": [], "marker": "the good one"}))
+    original_stamp = forge_stamp(t, judge="claude-sonnet-5")   # forces a re-judge
+    _, log = run_shell(t)
+
+    kept = json.loads(receipt.read_text())
+    assert kept.get("marker") == "the good one", (
+        f"a partial staged receipt evicted the complete one:\n{log}")
+    assert (d / ".inputs-sha256").read_text().strip() == original_stamp, (
+        "the kept receipt must not carry the new judge's stamp")
+    assert "previous receipt KEPT" in log, log
+    # The failed attempt stays inspectable rather than being silently discarded.
+    assert (t / "judged" / "modelA.rejudge" / "summary.json").exists(), (
+        f"the failed attempt should be left for diagnosis:\n{log}")
+
+
+def test_a_partial_receipt_is_still_promoted_when_there_is_nothing_to_lose():
+    """Two-way control on the clause above. If promotion required cacheable UNCONDITIONALLY, a
+    first-ever run that produced a partial receipt would leave no evidence at all — and the
+    pre-existing behaviour of keeping it for diagnosis, unstamped, would be lost."""
+    t = shell_tree("false")
+    _, log = run_shell(t)
+    d = t / "judged" / "modelA"
+    assert (d / "summary.json").exists(), f"a first partial receipt must be kept:\n{log}"
+    assert not stamped(t), "a non-cacheable receipt must never be stamped"
+    assert "not cacheable" in log, log
 
 
 def test_a_successful_rejudge_does_replace_the_old_receipt():
@@ -1752,7 +1802,7 @@ def test_the_billing_check_runs_before_the_availability_check():
 
 # An exact count, because the borrowed runner in cleanup_metrics_test.py returns
 # 0 when it discovers ZERO tests — so "green" would carry no information at all.
-EXPECTED_TESTS = 90
+EXPECTED_TESTS = 92
 
 
 def _run() -> int:

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -1206,6 +1206,91 @@ def test_shell_sha256_shim_produces_an_identical_stamp():
 # report_ollama_bench.py                                                      #
 # --------------------------------------------------------------------------- #
 
+def _two_arm_report_tree(meta_a, meta_b):
+    """A report fixture with TWO arms, each carrying its own receipt metadata.
+
+    Built by extending `report_tree`, deliberately, rather than writing a second fixture from
+    scratch: the report refuses a corpus with no international cases, and a hand-rolled corpus
+    that omitted one failed before reaching the check under test. Reusing the working fixture's
+    shape is what keeps the case pointed at its subject.
+
+    One arm can never show a mixed-judge ranking, which is why two are needed.
+    """
+    healthy = {
+        "cacheable": True,
+        "release_gate": {"verdict": "CLEAR", "checks": []},
+        "overall": {"pass_rate_pct": 50.0, "critical_fail_count": 0, "total_scored": 2,
+                    "infra_skipped": 0, "failure_type_counts": {}},
+        "skipped": [], "missing_scores": [],
+        "judge_reconciliation": {"requested": [], "accepted": [], "missing": [],
+                                 "unexpected": []},
+        "adjudication": {"adjudicated_n": 0, "disagreements": 0},
+    }
+    t = report_tree({**healthy, "meta": meta_a})
+
+    # Second arm, mirroring the first arm's on-disk shape exactly.
+    (t / "judged" / "modelB").mkdir(parents=True)
+    (t / "judged" / "modelB" / "summary.json").write_text(
+        json.dumps({**healthy, "meta": meta_b}))
+    (t / "judged" / "modelB" / "per_case.jsonl").write_text(
+        (t / "judged" / "modelA" / "per_case.jsonl").read_text())
+
+    run = json.loads((t / "run-summary.json").read_text())
+    second = dict(run["models"][0])
+    second["model"] = "modelB"
+    second["candidates"] = str(t / "cand" / "modelB.jsonl")
+    run["models"].append(second)
+    (t / "run-summary.json").write_text(json.dumps(run))
+    return t
+
+
+def test_the_report_refuses_to_rank_two_different_judges():
+    """Cloud review pointed at this root cause three times before I fixed it here rather than in
+    the sweep. A partial sweep, an interrupted sweep, a hand-copied receipt or a repointed
+    deployment all leave some arms graded by one judge and some by another. The sweep cannot close
+    every route; the layer that COMBINES arms can. Validating a receipt by whether it parses and
+    never by who produced it is what let all of them through.
+    """
+    t = _two_arm_report_tree(
+        {"judge": "claude-sonnet-5", "judge_model_version": None},
+        {"judge": "azure/gpt-5-6-luna", "judge_model_version": "gpt-5.6-luna-2026-07-09"})
+    rc, out = run_report(t)
+    assert rc == 2, out
+    assert "mixes judges" in out, out
+    assert "claude-sonnet-5" in out and "azure/gpt-5-6-luna" in out, out
+
+
+def test_the_report_refuses_two_versions_of_the_same_judge():
+    """The id alone is not identity. An Azure deployment repointed in place leaves two receipts
+    sharing `judge` while holding scores from different models — the one mixing route a
+    judge-name check cannot see."""
+    t = _two_arm_report_tree(
+        {"judge": "azure/gpt-5-6-luna", "judge_model_version": "gpt-5.6-luna-2026-07-09"},
+        {"judge": "azure/gpt-5-6-luna", "judge_model_version": "gpt-5.6-luna-2026-11-01"})
+    rc, out = run_report(t)
+    assert rc == 2, out
+    assert "mixes judges" in out, out
+    assert "2026-11-01" in out, out
+
+
+def test_the_report_ranks_a_uniform_field():
+    """Two-way control, and the important one: a check that refused any multi-arm run would pass
+    both cases above while making the report useless for its only real job."""
+    meta = {"judge": "azure/gpt-5-6-luna", "judge_model_version": "gpt-5.6-luna-2026-07-09"}
+    rc, out = run_report(_two_arm_report_tree(dict(meta), dict(meta)))
+    assert rc == 0, out
+    assert "mixes judges" not in out, out
+
+
+def test_legacy_receipts_without_a_version_rank_together():
+    """A receipt written before `judge_model_version` existed reports None. Those must group with
+    each other rather than each becoming its own judge, or every historical run turns unrankable."""
+    meta = {"judge": "claude-sonnet-5"}
+    rc, out = run_report(_two_arm_report_tree(dict(meta), dict(meta)))
+    assert rc == 0, out
+    assert "mixes judges" not in out, out
+
+
 def test_report_refuses_an_unknown_verdict():
     # Pre-fix this was ranked #1 and labelled "Recommended", exit 0.
     t = report_tree(healthy_receipt(release_gate={"verdict": "WEIRD_UNKNOWN", "checks": []}))
@@ -2094,7 +2179,7 @@ def test_the_billing_check_runs_before_the_availability_check():
 
 # An exact count, because the borrowed runner in cleanup_metrics_test.py returns
 # 0 when it discovers ZERO tests — so "green" would carry no information at all.
-EXPECTED_TESTS = 108
+EXPECTED_TESTS = 112
 
 
 def _run() -> int:

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -31,6 +31,8 @@ TWO STUB LAYERS, BOTH CHOSEN SO THE TEST REACHES ITS SUBJECT.
 """
 from __future__ import annotations
 
+import contextlib
+import io
 import json
 import os
 import subprocess
@@ -106,26 +108,41 @@ def checks_of(receipt):
 
 STUB_JUDGE = '''\
 import sys, json, pathlib
-a = sys.argv
-out = a[a.index("--out") + 1]
-d = pathlib.Path(out); d.mkdir(parents=True, exist_ok=True)
-(d.parent / "_invocations").open("a").write("call\\n")
-mode = {mode!r}
-if mode == "noreceipt":
-    sys.exit(1)
-if mode == "nonobject":
-    (d / "summary.json").write_text("[1,2,3]")
-    sys.exit(1)
-if mode == "badjson":
-    (d / "summary.json").write_text("{{not json")
-    sys.exit(1)
-r = {{"release_gate": {{"verdict": "BLOCK"}}, "skipped": [], "missing_scores": []}}
-if mode == "true":
-    r["cacheable"] = True
-elif mode == "false":
-    r["cacheable"] = False
-json.dump(r, open(d / "summary.json", "w"))
-sys.exit(0 if mode == "true" else 1)
+
+# The shell IMPORTS this module to resolve the default judge, so the module body must
+# survive an import with no argv. Before the judge became part of the resume stamp the
+# stub was only ever executed, and a stub that raises on import made the script exit 2
+# at startup while every shell test still passed — they assert what a receipt or stamp
+# does NOT contain, which is trivially true of a script that never ran.
+import os
+# Honours EW_JUDGE exactly as the real module does, so a test can change the judge the
+# script resolves without editing the stub.
+DEFAULT_JUDGE = os.environ.get("EW_JUDGE", "azure/stub-judge")
+
+# Guarded so an IMPORT is side-effect free and exit-free. `sys.exit` at module level
+# would raise SystemExit through the import and leave the caller with no value, which
+# looks identical to a stub that crashed.
+if __name__ == "__main__":
+    a = sys.argv
+    out = a[a.index("--out") + 1]
+    d = pathlib.Path(out); d.mkdir(parents=True, exist_ok=True)
+    (d.parent / "_invocations").open("a").write("call\\n")
+    mode = {mode!r}
+    if mode == "noreceipt":
+        sys.exit(1)
+    if mode == "nonobject":
+        (d / "summary.json").write_text("[1,2,3]")
+        sys.exit(1)
+    if mode == "badjson":
+        (d / "summary.json").write_text("{{not json")
+        sys.exit(1)
+    r = {{"release_gate": {{"verdict": "BLOCK"}}, "skipped": [], "missing_scores": []}}
+    if mode == "true":
+        r["cacheable"] = True
+    elif mode == "false":
+        r["cacheable"] = False
+    json.dump(r, open(d / "summary.json", "w"))
+    sys.exit(0 if mode == "true" else 1)
 '''
 
 
@@ -153,7 +170,33 @@ def run_shell(t, env=None):
         ["bash", str(t / "scripts" / "eval" / "judge_ollama_bench.sh"),
          str(t / "corpus.jsonl"), str(t / "cand"), str(t / "judged")],
         capture_output=True, text=True, env=env)
-    return p.returncode, p.stdout + p.stderr
+    out = p.stdout + p.stderr
+    # COMPLETED-THE-SUBJECT GUARD. Several shell cases assert that something is absent —
+    # no stamp, no second invocation, a particular refusal wording — and each of those is
+    # also true of a script that died before doing any work. So an early death must be an
+    # error here rather than a silent pass in each case. This fired for real: adding the
+    # judge to the stamp made the script resolve it by importing the module, the stub
+    # raised on import, and the whole suite stayed green while judging nothing.
+    #
+    # Asserts the script reached one of its two TERMINAL outcomes rather than the absence
+    # of one known error string. A guard written the second way only catches the failure
+    # its author already met — a syntax error, a missing command, or the next unforeseen
+    # early exit would sail through it, which is the same fail-open shape as a denylist.
+    # Reads the LAST non-empty stderr line, not any line anywhere. Scanning all output
+    # would let a nested program's own "FAIL:" satisfy the shell's terminal condition —
+    # no current fixture does that, but the guard would be asserting the wrong thing.
+    #
+    # NORMAL completion of the model loop ends in one of two lines: a FAIL: block then
+    # `exit 1`, or the success line. Setup failures exit before either (missing
+    # arguments, an unresolvable judge) and so does any other early death, which is
+    # precisely what this guard is here to reject. Once one of the two IS present, it is
+    # the last non-empty line and it is the shell's verdict.
+    terminal = next((ln for ln in reversed(p.stderr.splitlines()) if ln.strip()), "")
+    completed = terminal.startswith("judged all models into ")
+    reported_failure = terminal.startswith("FAIL: ")
+    assert completed or reported_failure, (
+        f"the script never reached a terminal outcome, so this case tested nothing:\n{out}")
+    return p.returncode, out
 
 
 def invocations(t):
@@ -165,16 +208,23 @@ def stamped(t):
     return (t / "judged" / "modelA" / ".inputs-sha256").exists()
 
 
-def forge_stamp(t):
+def forge_stamp(t, judge=None):
     """Write a stamp that genuinely MATCHES, so the resume fast path is entered
     and only the cacheability check can stop the skip. Computed exactly as the
     script does — over the same absolute argv paths, since the hash covers
-    filenames. Without it the stamp is absent, the fast path is never reached,
-    and a case would pass while testing the stale-inputs branch instead."""
+    filenames, and now over the JUDGE, which is part of the inputs. Without it the
+    stamp is absent, the fast path is never reached, and a case would pass while
+    testing the stale-inputs branch instead.
+
+    `judge` defaults to the stub's DEFAULT_JUDGE, i.e. what the script itself will
+    resolve. Pass a different value to forge a stamp from a DIFFERENT judge, which is
+    what makes "a judge change invalidates the stamp" testable."""
+    judge = judge if judge is not None else "azure/stub-judge"
     forged = subprocess.run(
         ["bash", "-c",
          'if command -v shasum >/dev/null 2>&1; then H="shasum -a 256"; else H=sha256sum; fi; '
-         f'$H "{t / "cand" / "modelA.jsonl"}" "{t / "corpus.jsonl"}" | $H | cut -d" " -f1'],
+         f'{{ printf "judge=%s\\n" "{judge}"; '
+         f'$H "{t / "cand" / "modelA.jsonl"}" "{t / "corpus.jsonl"}"; }} | $H | cut -d" " -f1'],
         capture_output=True, text=True).stdout.strip()
     assert forged, "could not compute a stamp"
     (t / "judged" / "modelA" / ".inputs-sha256").write_text(forged + "\n")
@@ -779,6 +829,66 @@ def test_both_layers_give_the_same_diagnosis_for_the_same_receipt():
         assert "Traceback" not in out, f"{receipt} raised: {out}"
 
 
+def test_a_receipt_from_a_different_judge_is_re_judged():
+    # THE finding this guards: the stamp used to cover only candidates + corpus, so a
+    # cacheable receipt graded by one judge was skipped after the default changed. On
+    # 2026-08-11 that was 15 stamped Sonnet arms, and the sweep would have produced a
+    # scoreboard silently mixing two judges.
+    t = shell_tree("true")
+    d = t / "judged" / "modelA"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "summary.json").write_text(json.dumps(
+        {"cacheable": True, "release_gate": {"verdict": "CLEAR"},
+         "skipped": [], "missing_scores": []}))
+
+    # A stamp that is valid in every respect EXCEPT the judge.
+    forge_stamp(t, judge="claude-sonnet-5")
+    before = invocations(t)
+    _, log = run_shell(t)
+    assert invocations(t) > before, (
+        f"a receipt from another judge was skipped instead of re-judged:\n{log}")
+
+
+def test_a_receipt_from_the_same_judge_is_still_skipped():
+    # TWO-WAY CONTROL. Without this, a stamp that never matches would pass the test
+    # above while re-grading every arm on every sweep — which is the expensive failure,
+    # and the one that looks like nothing is wrong.
+    t = shell_tree("true")
+    d = t / "judged" / "modelA"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "summary.json").write_text(json.dumps(
+        {"cacheable": True, "release_gate": {"verdict": "CLEAR"},
+         "skipped": [], "missing_scores": []}))
+
+    forge_stamp(t)  # the judge the script will actually resolve
+    before = invocations(t)
+    _, log = run_shell(t)
+    assert invocations(t) == before, f"a matching receipt was re-judged anyway:\n{log}"
+    assert "skipped (already judged)" in log, log
+
+
+def test_the_stamp_the_script_writes_depends_on_the_judge():
+    # Reads the stamp the REAL script wrote, not one this file computed: a fixture-only
+    # comparison would verify forge_stamp and pass even with the script's stamp
+    # unchanged, which is precisely how a mutation slips through.
+    # ONE tree for both runs. The stamp hashes absolute filenames, so two temp trees
+    # produce different stamps whatever the judge is — a version of this test using a
+    # fresh tree per run passed with the judge stripped back out of the stamp, i.e. it
+    # measured the temp path and not the thing under test.
+    t = shell_tree("true")
+    stamp_file = t / "judged" / "modelA" / ".inputs-sha256"
+
+    def stamp_under(judge):
+        _, log = run_shell(t, env=dict(os.environ, EW_JUDGE=judge))
+        assert f"judge: {judge}" in log, f"script did not resolve {judge}: {log}"
+        assert stamp_file.exists(), f"no stamp written for {judge}: {log}"
+        return stamp_file.read_text().strip()
+
+    a = stamp_under("claude-sonnet-5")
+    b = stamp_under("azure/gpt-5-6-luna")
+    assert a and b and a != b, f"the script's stamp ignores the judge: {a} == {b}"
+
+
 def test_shell_absent_cacheable_field_is_not_stamped():
     # Every receipt written before #2007 lacks the field.
     t = shell_tree("absent")
@@ -1273,12 +1383,251 @@ def test_report_refuses_a_truncated_detail_file():
 
 
 # --------------------------------------------------------------------------- #
+# judge billing gate                                                          #
+# --------------------------------------------------------------------------- #
+
+def _routed_transport(model):
+    """Which transport `dispatch_judge` actually reaches for `model`, with both stubbed
+    so nothing touches a network or a CLI. Returns None when the call is refused.
+
+    Drives the REAL dispatcher rather than restating its rules, so this cannot agree
+    with a router that has changed underneath it."""
+    originals = {n: getattr(bj, f"call_{n}") for n in ("azure", "claude")}
+    for n in originals:
+        setattr(bj, f"call_{n}", (lambda x: lambda *a, **k: x)(n))
+    try:
+        with contextlib.redirect_stderr(io.StringIO()):
+            return bj.dispatch_judge(model, "sys", "usr")
+    except SystemExit:
+        return None
+    finally:
+        for n, fn in originals.items():
+            setattr(bj, f"call_{n}", fn)
+
+
+# `gpt-5-6-luna` is the important trap: it is the Azure DEPLOYMENT name, so without the
+# `azure/` prefix it reads as an OpenAI model id and no funded route accepts it.
+BILLING_IDS = [
+    "azure/gpt-5-6-luna", "azure/anything",
+    "claude-sonnet-5", "claude-opus-5", "sonnet",
+    "gpt-4o", "gpt-5-6-luna", "gemini-3-pro",
+    "mistral-large", "llama-3", "claude/foo", "AZURE/gpt-5-6-luna", "",
+]
+
+
+def test_billing_gate_agrees_with_the_router_on_every_id():
+    # Both answers are DERIVED from JUDGE_ROUTES, so this is a consistency check on the
+    # table rather than on two hand-written lists: a refused id must reach no transport,
+    # and a permitted id must reach one.
+    for model in BILLING_IDS:
+        transport = _routed_transport(model)
+        unfunded = bj.judge_lacks_funded_route(model)
+        assert unfunded == (transport is None), (
+            f"{model!r} reached transport {transport!r} but the gate says "
+            f"lacks_funded_route={unfunded}")
+
+
+def test_every_funded_route_has_a_transport_branch():
+    # A route added to the table with no branch in dispatch_judge would raise. Exhaustive
+    # over the table itself, so it covers rows added after this test was written — which
+    # a fixed id list cannot do.
+    for prefix, transport in bj.JUDGE_ROUTES:
+        assert _routed_transport(f"{prefix}probe") == transport, (
+            f"route {prefix!r} does not reach transport {transport!r}")
+
+
+def test_an_unrecognised_judge_id_reaches_no_transport_at_all():
+    # The original defect: a denylist of gpt/gemini prefixes let an unknown id through
+    # and dispatch billed it to the personal Gemini key. Now there is no such transport
+    # to reach, and the dispatcher refuses before looking for one.
+    for model in ("mistral-large", "gpt-4o", "gemini-3-pro", ""):
+        assert _routed_transport(model) is None, model
+        assert bj.judge_lacks_funded_route(model), model
+
+
+def test_the_personal_key_transports_do_not_exist():
+    # Deleted rather than unrouted: a refusal is a promise, an absent function is a fact.
+    # This is the check that notices a well-meaning restore.
+    for gone in ("call_openai", "call_gemini"):
+        assert not hasattr(bj, gone), (
+            f"{gone} is back. Grading may not bill a personal key; restoring a paid "
+            f"transport here needs a founder decision.")
+
+
+def test_dispatch_refuses_without_help_from_main():
+    # The gate must hold for a caller that never goes through main(), which is what
+    # `score_new`/`run_judge`/a future sibling script would do.
+    with contextlib.redirect_stderr(io.StringIO()) as err:
+        try:
+            bj.dispatch_judge("gpt-4o", "sys", "usr")
+        except SystemExit as e:
+            assert e.code == 2
+        else:
+            raise AssertionError("dispatch_judge did not refuse a personal-key id")
+    assert "REFUSED" in err.getvalue()
+
+
+def test_the_azure_deployment_name_without_its_prefix_is_refused():
+    # `gpt-5-6-luna` is what our Azure resource calls the deployment. Bare, it reads as
+    # an OpenAI id, and it is refused so it cannot be mistaken for one that is funded.
+    assert bj.judge_lacks_funded_route("gpt-5-6-luna")
+    assert not bj.judge_lacks_funded_route("azure/gpt-5-6-luna")
+
+
+def test_refusal_exits_two_and_names_the_funded_alternative():
+    for model in ("gpt-4o", "gemini-3-pro", "mistral-large"):
+        err = io.StringIO()
+        try:
+            with contextlib.redirect_stderr(err):
+                bj.refuse_paid_key_judge(model)
+        except SystemExit as e:
+            assert e.code == 2, (model, e.code)
+        else:
+            raise AssertionError(f"{model} was not refused")
+        assert "azure/gpt-5-6-luna" in err.getvalue(), err.getvalue()
+
+
+def test_the_two_funded_judges_are_not_refused():
+    # Two-way control: without this, a gate that refuses EVERY id passes the tests
+    # above while making the harness unusable.
+    for model in ("azure/gpt-5-6-luna", "claude-sonnet-5"):
+        with contextlib.redirect_stderr(io.StringIO()):
+            bj.refuse_paid_key_judge(model)     # must not raise SystemExit
+
+
+@contextlib.contextmanager
+def _azure_reply(payload):
+    """Run call_azure against a canned response body, with the secrets stubbed so this
+    works on a runner that has no Azure credentials at all.
+
+    The stub endpoint is a REAL-shaped Azure host, because `_validated_azure_endpoint`
+    now refuses anything else — a placeholder like `https://stub.invalid` would make
+    every transport test fail for the wrong reason and hide whatever it was checking."""
+    class _Resp:
+        def read(self): return json.dumps(payload).encode()
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+
+    class _Opener:
+        def open(self, *a, **k): return _Resp()
+
+    real_key, real_opener = bj._key, bj._no_redirect_opener
+    bj._key = (lambda name: "https://stub-test.openai.azure.com"
+               if "endpoint" in name else "stub-key")
+    bj._no_redirect_opener = lambda: _Opener()
+    try:
+        yield
+    finally:
+        bj._key, bj._no_redirect_opener = real_key, real_opener
+
+
+def _azure_error(payload):
+    with _azure_reply(payload):
+        try:
+            bj.call_azure("gpt-5-6-luna", "s", "u")
+        except RuntimeError as e:
+            return str(e)
+    raise AssertionError(f"call_azure accepted {payload!r}")
+
+
+def test_azure_returns_the_assistant_text_on_a_good_reply():
+    with _azure_reply({"choices": [{"message": {"content": "  [] "},
+                                   "finish_reason": "stop"}]}):
+        assert bj.call_azure("gpt-5-6-luna", "s", "u") == "[]"
+
+
+def test_azure_names_the_token_cap_when_the_budget_ran_out():
+    # Measured shape: this deployment reasons, so exhausting the budget yields
+    # finish_reason='length' with EMPTY content, not a half-written array. The operator
+    # action is a cap or chunk-size change, so the message has to say so.
+    msg = _azure_error({"choices": [{"message": {"content": ""},
+                                     "finish_reason": "length"}]})
+    assert "max_completion_tokens" in msg and "chunk-size" in msg, msg
+
+
+def test_azure_distinguishes_a_dropped_reply_from_a_token_cap():
+    # Same empty body, different finish_reason: a dropped chunk is the #1950 failure and
+    # raising the cap would not help, so it must not borrow the cap's advice.
+    msg = _azure_error({"choices": [{"message": {"content": ""},
+                                     "finish_reason": "stop"}]})
+    assert "max_completion_tokens" not in msg, msg
+    assert "empty content" in msg, msg
+
+
+def test_azure_refuses_a_reply_with_no_choices():
+    assert "no choices" in _azure_error({"choices": []})
+
+
+@contextlib.contextmanager
+def _endpoint(value):
+    """Point the endpoint lookup at `value` without touching the real environment."""
+    real = bj._key
+    bj._key = lambda name: value if "endpoint" in name else "stub-key"
+    try:
+        yield
+    finally:
+        bj._key = real
+
+
+def test_a_non_azure_endpoint_is_refused_before_the_key_is_read():
+    # The risk: `_key` reads the environment first, so an inherited or mistyped
+    # AZURE_OPENAI_ENDPOINT would send our api-key header to somebody else's host.
+    for bad in ("https://evil.example.com", "http://x.openai.azure.com",
+                "https://x.openai.azure.com/steal", "https://x.openai.azure.com?q=1",
+                "https://openai.azure.com.evil.test", ""):
+        try:
+            with _endpoint(bad):
+                bj._validated_azure_endpoint()
+        except RuntimeError as e:
+            assert "refusing to send the Azure key" in str(e), (bad, str(e))
+        else:
+            raise AssertionError(f"accepted endpoint {bad!r}")
+
+
+def test_a_real_azure_endpoint_is_accepted():
+    # Two-way control: a validator that refuses everything would pass the test above
+    # while making the judge unusable. Both suffixes ACCEPTED FOR THIS ROUTE must pass.
+    # Deliberately not "every hostname Azure issues": Foundry exposes more FQDN families
+    # than these two, and not all of them serve this legacy chat-completions route, so
+    # this list is our accepted set rather than a claim about Azure's naming.
+    for good in ("https://x.openai.azure.com", "https://x.openai.azure.com/",
+                 "https://y.cognitiveservices.azure.com"):
+        with _endpoint(good):
+            assert bj._validated_azure_endpoint() == good.rstrip("/")
+
+
+def test_a_redirect_is_refused_rather_than_followed():
+    # A validated host can still 3xx to an arbitrary one, and urllib replays the headers
+    # we set on the Request, so the endpoint check alone does not contain the key.
+    handler = bj._no_redirect_opener().handlers
+    redirect = [h for h in handler if hasattr(h, "redirect_request")]
+    assert redirect, "no redirect handler installed"
+    try:
+        redirect[0].redirect_request(None, None, 302, "Found", {},
+                                     "https://evil.example.com/x")
+    except RuntimeError as e:
+        assert "refusing to follow" in str(e), str(e)
+    else:
+        raise AssertionError("redirect_request did not refuse")
+
+
+def test_the_billing_check_runs_before_the_availability_check():
+    # Refusing to spend the founder's own money must not depend on whether some CLI
+    # happens to be logged in, so the order in main() is load-bearing.
+    src = Path(bj.__file__).read_text()
+    body = src.split("def main(")[1]
+    assert body.index("refuse_paid_key_judge(args.judge)") \
+        < body.index("preflight_judge(args.judge)"), \
+        "refuse_paid_key_judge must be called before preflight_judge in main()"
+
+
+# --------------------------------------------------------------------------- #
 # runner                                                                      #
 # --------------------------------------------------------------------------- #
 
 # An exact count, because the borrowed runner in cleanup_metrics_test.py returns
 # 0 when it discovers ZERO tests — so "green" would carry no information at all.
-EXPECTED_TESTS = 67
+EXPECTED_TESTS = 86
 
 
 def _run() -> int:

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -1867,6 +1867,76 @@ def test_a_redirect_is_refused_rather_than_followed():
         raise AssertionError("redirect_request did not refuse")
 
 
+@contextlib.contextmanager
+def _azure_serving(model_field, host="stub-test.openai.azure.com"):
+    """Run judge_identity against a deployment that reports `model_field` as its served model."""
+    class _Resp:
+        def read(self):
+            return json.dumps({"model": model_field,
+                               "choices": [{"message": {"content": "x"},
+                                            "finish_reason": "stop"}]}).encode()
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+
+    class _Opener:
+        def open(self, *a, **k): return _Resp()
+
+    real_key, real_opener = bj._key, bj._no_redirect_opener
+    bj._key = lambda name: (f"https://{host}" if "endpoint" in name else "stub-key")
+    bj._no_redirect_opener = lambda: _Opener()
+    try:
+        yield
+    finally:
+        bj._key, bj._no_redirect_opener = real_key, real_opener
+
+
+def test_the_identity_changes_when_the_deployment_is_repointed():
+    # Cloud review round 6 P1. Azure can upgrade a deployment IN PLACE: hostname, deployment
+    # name and API version all stay identical while the model underneath changes. An identity
+    # built from configuration alone keeps matching receipts graded by the previous model, so a
+    # resumed sweep skips them and combines two models' scores.
+    with _azure_serving("gpt-5.6-luna-2026-07-09"):
+        before = bj.judge_identity("azure/gpt-5-6-luna")
+    with _azure_serving("gpt-5.6-luna-2026-11-01"):
+        after = bj.judge_identity("azure/gpt-5-6-luna")
+    assert before != after, (
+        f"the identity survived a deployment repoint, so old receipts would be reused: {before}")
+
+
+def test_the_identity_is_stable_while_the_deployment_is_not_repointed():
+    # Two-way control. An identity that changed every call would invalidate every stamp on every
+    # sweep and re-grade the whole field forever — the expensive failure, and it looks like
+    # nothing is wrong.
+    with _azure_serving("gpt-5.6-luna-2026-07-09"):
+        a = bj.judge_identity("azure/gpt-5-6-luna")
+        b = bj.judge_identity("azure/gpt-5-6-luna")
+    assert a == b, f"identity is not stable across calls: {a} != {b}"
+
+
+def test_the_served_model_is_never_absent_from_the_identity():
+    # Fail rather than fall back to a version-blind identity: blind reuse across a model change
+    # is worse than refusing to start, and this is the only axis the client cannot see from its
+    # own configuration.
+    for bad in (None, "", "   "):
+        try:
+            with _azure_serving(bad):
+                bj.judge_identity("azure/gpt-5-6-luna")
+        except RuntimeError as e:
+            assert "did not report which model" in str(e), str(e)
+        else:
+            raise AssertionError(f"accepted a served-model field of {bad!r}")
+
+
+def test_the_identity_probe_goes_through_the_no_redirect_opener():
+    # The probe sends the api-key, so it must not be able to follow a redirect off the validated
+    # host any more than the grading calls can. Asserted by construction: with the opener stubbed
+    # the probe succeeds, and `_azure_served_model` has no other transport.
+    src = Path(bj.__file__).read_text()
+    body = src.split("def _azure_served_model(")[1].split("\ndef ")[0]
+    assert "_no_redirect_opener()" in body, "the probe bypasses the no-redirect opener"
+    assert "urllib.request.urlopen" not in body, "the probe uses a raw opener"
+
+
 def test_the_billing_check_runs_before_the_availability_check():
     # Refusing to spend the founder's own money must not depend on whether some CLI
     # happens to be logged in, so the order in main() is load-bearing.
@@ -1883,7 +1953,7 @@ def test_the_billing_check_runs_before_the_availability_check():
 
 # An exact count, because the borrowed runner in cleanup_metrics_test.py returns
 # 0 when it discovers ZERO tests — so "green" would carry no information at all.
-EXPECTED_TESTS = 95
+EXPECTED_TESTS = 99
 
 
 def _run() -> int:

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -1964,6 +1964,35 @@ def test_a_grading_response_from_a_different_model_is_refused():
                 raise AssertionError("a response from a different model was accepted")
 
 
+def test_a_response_that_names_no_model_is_refused_when_pinned():
+    # Cloud review round 9, a fail-open in the round-7 check. It required a differing NONEMPTY
+    # STRING to refuse, so a response omitting `model`, or returning it blank or non-string,
+    # skipped the comparison and had its scores accepted and stamped with the pinned identity.
+    # The question that finds this class: what input makes the condition match NOTHING, and does
+    # it then allow or refuse?
+    for bad in (None, "", "   ", 42, ["gpt"]):
+        with _azure_pin("gpt-5.6-luna-2026-07-09"):
+            with _azure_reply({"model": bad,
+                               "choices": [{"message": {"content": "[]"},
+                                            "finish_reason": "stop"}]}):
+                try:
+                    bj.call_azure("gpt-5-6-luna", "s", "u")
+                except RuntimeError as e:
+                    assert "did not say which model" in str(e), (bad, str(e))
+                else:
+                    raise AssertionError(f"accepted scores with model={bad!r} while pinned")
+
+
+def test_a_missing_model_field_is_tolerated_when_NOT_pinned():
+    # Two-way control on the direction of that strictness. An unpinned process has no version to
+    # verify against and no stamp to corrupt, so requiring the field there would break the
+    # direct-call path for no benefit.
+    with _azure_pin(None):
+        with _azure_reply({"choices": [{"message": {"content": "[]"},
+                                        "finish_reason": "stop"}]}):
+            assert bj.call_azure("gpt-5-6-luna", "s", "u") == "[]"
+
+
 def test_a_grading_response_from_the_pinned_model_is_accepted():
     # Two-way control. A check that refused everything would pass the case above while making
     # every grading call fail — the loud failure, but it would look like Azure was broken.
@@ -2065,7 +2094,7 @@ def test_the_billing_check_runs_before_the_availability_check():
 
 # An exact count, because the borrowed runner in cleanup_metrics_test.py returns
 # 0 when it discovers ZERO tests — so "green" would carry no information at all.
-EXPECTED_TESTS = 106
+EXPECTED_TESTS = 108
 
 
 def _run() -> int:

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -1109,6 +1109,56 @@ def test_repeated_failures_keep_the_complete_receipt():
     assert "COMPLETE quarantine" in log, log
 
 
+def test_a_failed_quarantine_aborts_the_arm_instead_of_mis_stamping():
+    """Cloud review round 13. This script runs without `errexit`, so a permission or filesystem
+    error left `quarantine_previous` returning success (its final `echo` succeeded). The caller
+    then moved the staged receipt INSIDE the still-existing destination and the stamp landed on
+    the OLD receipt while the arm reported success — the nest-and-mis-stamp failure arriving
+    through an error path rather than a logic one.
+
+    Made to fail by removing write permission from the judged directory, so the rename genuinely
+    cannot happen. The arm must report FAILED and nothing may be stamped.
+    """
+    t = shell_tree("true")
+    d = t / "judged" / "modelA"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "summary.json").write_text(json.dumps(
+        {"cacheable": True, "release_gate": {"verdict": "CLEAR"},
+         "skipped": [], "missing_scores": [], "marker": "the previous one"}))
+    forge_stamp(t, judge="claude-sonnet-5")          # forces a re-judge
+    judged = t / "judged"
+    mode = judged.stat().st_mode
+    os.chmod(judged, 0o500)                          # readable, not writable: rename fails
+    try:
+        rc, log = run_shell(t)
+    finally:
+        os.chmod(judged, mode)
+
+    assert "FAILED modelA" in log, f"a failed quarantine was not reported as a failure:\n{log}"
+    assert rc != 0, f"the sweep exited successfully despite a failed arm:\n{log}"
+    kept = json.loads((d / "summary.json").read_text())
+    assert kept.get("marker") == "the previous one", (
+        f"the old receipt was replaced or nested into:\n{log}")
+    assert not list(d.glob("*.rejudge")), f"the staged receipt was nested inside: {list(d.iterdir())}"
+
+    # WHY THIS CASE CANNOT ISOLATE THE HELPER, stated rather than implied: both renames happen
+    # inside the same parent directory, so any permission failure trips the promote guard as well
+    # as the quarantine guard. Swallowing the helper's failure therefore still ends in a reported
+    # FAILED arm, and a mutation test over this case passes either way. It verifies the OUTCOME,
+    # which is the property that matters, and the source assertion below covers the mechanism the
+    # reviewer actually flagged.
+    src = SHELL.read_text()
+    body = src.split("quarantine_previous() {")[1].split("\n}")[0]
+    assert 'mv "$dest" "$dest.stale" || return 1' in body, (
+        "the quarantine rename does not propagate failure; without `|| return 1` the helper "
+        "returns success because its final echo does, and the caller promotes into a still-"
+        "occupied destination")
+    for call in ("if ! quarantine_previous; then",):
+        assert src.count(call) >= 3, (
+            f"expected every quarantine call site to check the result, found "
+            f"{src.count(call)} of them")
+
+
 def test_a_successful_rejudge_does_replace_the_old_receipt():
     """Two-way control. A staging swap that never promoted anything would pass the case above
     while making every re-judge a no-op, which is the expensive failure and looks like nothing
@@ -2269,7 +2319,7 @@ def test_the_billing_check_runs_before_the_availability_check():
 
 # An exact count, because the borrowed runner in cleanup_metrics_test.py returns
 # 0 when it discovers ZERO tests — so "green" would carry no information at all.
-EXPECTED_TESTS = 118
+EXPECTED_TESTS = 119
 
 
 def _run() -> int:

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -1349,6 +1349,38 @@ def test_an_absent_meta_still_ranks():
     assert "not an object" not in out, out
 
 
+def test_a_malformed_nested_identity_field_is_named_rather_than_crashing():
+    """Cloud review round 12. A hand-edited `"judge_identity": []` inside an otherwise
+    well-formed `meta` makes the grouping tuple unhashable, so `setdefault` aborts the whole
+    report with a TypeError — the same failure the outer `meta` shape check prevents, one level
+    in. Shape-checking a container and then trusting its contents is half a check."""
+    t = report_tree({**healthy_receipt(),
+                     "meta": {"judge": "azure/gpt-5-6-luna", "judge_identity": [],
+                              "judge_model_version": "v1"}})
+    rc, out = run_report(t)
+    assert rc == 2, out
+    assert "Traceback" not in out, out
+    assert "not a string" in out, out
+
+
+def test_a_direct_run_records_the_identity_it_resolved_itself():
+    """Cloud review round 12 P1. A run started directly rather than through the sweep resolves a
+    perfectly good identity in preflight, and reading only the sweep's environment variable threw
+    it away — so two direct receipts from different Azure resources recorded the same empty
+    provenance and the report could not tell them apart.
+
+    Asserts the wiring at the source: the meta field falls back to the resolved identity rather
+    than to None.
+    """
+    src = Path(bj.__file__).read_text()
+    line = next(ln for ln in src.splitlines() if '"judge_identity":' in ln and "meta" not in ln)
+    assert "_resolved_judge_identity" in line, line
+    # And the claude route sets it, or a direct claude run would record nothing while a sweep run
+    # records the model id — the two would then refuse to rank together, a false positive.
+    claude_branch = src.split("def preflight_judge(")[1].split("def ")[0]
+    assert "_resolved_judge_identity = model" in claude_branch, claude_branch
+
+
 def test_report_refuses_an_unknown_verdict():
     # Pre-fix this was ranked #1 and labelled "Recommended", exit 0.
     t = report_tree(healthy_receipt(release_gate={"verdict": "WEIRD_UNKNOWN", "checks": []}))
@@ -2237,7 +2269,7 @@ def test_the_billing_check_runs_before_the_availability_check():
 
 # An exact count, because the borrowed runner in cleanup_metrics_test.py returns
 # 0 when it discovers ZERO tests — so "green" would carry no information at all.
-EXPECTED_TESTS = 116
+EXPECTED_TESTS = 118
 
 
 def _run() -> int:

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -1040,6 +1040,74 @@ def test_a_partial_receipt_is_still_promoted_when_there_is_nothing_to_lose():
     assert "not cacheable" in log, log
 
 
+def test_a_destination_with_no_summary_does_not_swallow_the_staged_receipt():
+    """Cloud review round 6. An earlier run interrupted after creating $dest but before writing
+    summary.json leaves a directory with no receipt. A summary-only "is there a previous?" test
+    called that no-previous, so quarantine skipped it and `mv` moved the staged directory INSIDE
+    it: no canonical summary for the report, and no error anywhere.
+    """
+    t = shell_tree("true")
+    d = t / "judged" / "modelA"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "per_case.jsonl").write_text('{"id":"A"}\n')   # partial write, no summary.json
+    _, log = run_shell(t)
+
+    assert (d / "summary.json").exists(), (
+        f"the staged receipt was not promoted to the canonical path:\n{log}")
+    assert not (d / "modelA.rejudge").exists(), (
+        f"the staged directory was nested inside the destination:\n{log}")
+    assert not list(d.glob("*.rejudge")), f"nested staging directory found: {list(d.iterdir())}"
+    assert stamped(t), f"a promoted cacheable receipt must be stamped:\n{log}"
+
+
+def test_the_swap_quarantines_before_it_promotes():
+    """Cloud review round 6, the interruption-safety half. The old order was `rm -rf $dest` then
+    `mv`, so an interruption between them destroyed the old receipt while the new one was still
+    under .rejudge — and the next run clears staging, losing both.
+
+    Asserts the ORDER structurally, by its observable effect: after a successful swap the
+    previous receipt must still exist in the quarantine slot. Under `rm -rf` first it is gone.
+    """
+    t = shell_tree("true")
+    d = t / "judged" / "modelA"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "summary.json").write_text(json.dumps(
+        {"cacheable": True, "release_gate": {"verdict": "CLEAR"},
+         "skipped": [], "missing_scores": [], "marker": "the previous one"}))
+    forge_stamp(t, judge="claude-sonnet-5")      # different judge, so it re-judges
+    _, log = run_shell(t)
+
+    fresh = json.loads((d / "summary.json").read_text())
+    assert fresh.get("marker") is None, f"the new receipt was not promoted:\n{log}"
+    assert fresh.get("cacheable") is True, fresh
+
+    preserved = json.loads((t / "judged" / "modelA.stale" / "summary.json").read_text())
+    assert preserved.get("marker") == "the previous one", (
+        f"the previous receipt was deleted rather than quarantined, so an interruption "
+        f"mid-swap would lose it:\n{log}")
+
+
+def test_repeated_failures_keep_the_complete_receipt():
+    """Cloud review round 5, and the reason the quarantine slot has a rule rather than being a
+    plain overwrite. Failure one moves the complete receipt into the slot and promotes a partial;
+    failure two must NOT then displace that complete receipt with the partial."""
+    t = shell_tree("false")            # every attempt writes cacheable: false
+    d = t / "judged" / "modelA"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "summary.json").write_text(json.dumps(
+        {"cacheable": True, "release_gate": {"verdict": "CLEAR"},
+         "skipped": [], "missing_scores": [], "marker": "the only complete one"}))
+    forge_stamp(t, judge="claude-sonnet-5")
+
+    run_shell(t)                        # attempt 1: complete -> slot, partial -> canonical
+    _, log = run_shell(t)               # attempt 2: must not overwrite the slot
+
+    slot = json.loads((t / "judged" / "modelA.stale" / "summary.json").read_text())
+    assert slot.get("marker") == "the only complete one", (
+        f"a second failure ground the quarantine down to a partial receipt:\n{log}")
+    assert "COMPLETE quarantine" in log, log
+
+
 def test_a_successful_rejudge_does_replace_the_old_receipt():
     """Two-way control. A staging swap that never promoted anything would pass the case above
     while making every re-judge a no-op, which is the expensive failure and looks like nothing
@@ -1815,7 +1883,7 @@ def test_the_billing_check_runs_before_the_availability_check():
 
 # An exact count, because the borrowed runner in cleanup_metrics_test.py returns
 # 0 when it discovers ZERO tests — so "green" would carry no information at all.
-EXPECTED_TESTS = 92
+EXPECTED_TESTS = 95
 
 
 def _run() -> int:

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -35,6 +35,7 @@ import contextlib
 import io
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -1291,6 +1292,63 @@ def test_legacy_receipts_without_a_version_rank_together():
     assert "mixes judges" not in out, out
 
 
+def test_an_unmeasurable_arm_does_not_count_as_its_own_judge():
+    """Cloud review round 10. An arm where every case errored has NO receipt, so the row carries
+    no judge. Skipping only rows marked `skipped_reason` left it counted as a separate judge, and
+    any benchmark containing one fully failing or paywalled model became falsely unreportable —
+    a false positive in a guard, which is the direction that destroys trust in it."""
+    meta = {"judge": "azure/gpt-5-6-luna", "judge_identity": "azure/gpt-5-6-luna@abc123",
+            "judge_model_version": "gpt-5.6-luna-2026-07-09"}
+    t = _two_arm_report_tree(dict(meta), dict(meta))
+    # Turn modelB into an every-case-errored arm: no receipt, and the run summary says so.
+    shutil.rmtree(t / "judged" / "modelB")
+    run = json.loads((t / "run-summary.json").read_text())
+    for m in run["models"]:
+        if m["model"] == "modelB":
+            m["errors"], m["cases"] = 2, 2
+    (t / "run-summary.json").write_text(json.dumps(run))
+
+    rc, out = run_report(t)
+    assert "mixes judges" not in out, f"an unmeasurable arm was counted as a judge:\n{out}"
+    assert rc == 0, out
+
+
+def test_the_report_separates_two_azure_resources_serving_the_same_model():
+    """The (judge, version) pair could not see the endpoint. Two different Azure resources serving
+    the same model string compared equal, even though the resume stamp always distinguished them,
+    so an interrupted re-grade across resources could be ranked as one field."""
+    t = _two_arm_report_tree(
+        {"judge": "azure/gpt-5-6-luna", "judge_identity": "azure/gpt-5-6-luna@resourceA",
+         "judge_model_version": "gpt-5.6-luna-2026-07-09"},
+        {"judge": "azure/gpt-5-6-luna", "judge_identity": "azure/gpt-5-6-luna@resourceB",
+         "judge_model_version": "gpt-5.6-luna-2026-07-09"})
+    rc, out = run_report(t)
+    assert rc == 2, out
+    assert "mixes judges" in out, out
+    assert "resourceA" in out and "resourceB" in out, out
+
+
+def test_a_malformed_meta_is_named_rather_than_crashing_the_report():
+    """A truncated or hand-edited `"meta": [...]` is TRUTHY, so `or {}` leaves a list and the
+    following `.get()` raises AttributeError — aborting the whole report with a traceback instead
+    of naming the one bad receipt, which is what the per-model handling exists to do."""
+    t = report_tree({**healthy_receipt(), "meta": ["not", "an", "object"]})
+    rc, out = run_report(t)
+    assert rc == 2, out
+    assert "Traceback" not in out, out
+    assert "not an object" in out, out
+
+
+def test_an_absent_meta_still_ranks():
+    """Two-way control. Absent and malformed are different states: a receipt predating `meta`
+    ranks fine, and a first version of this check rejected every one of them."""
+    receipt = healthy_receipt()
+    receipt.pop("meta", None)
+    rc, out = run_report(report_tree(receipt))
+    assert rc == 0, out
+    assert "not an object" not in out, out
+
+
 def test_report_refuses_an_unknown_verdict():
     # Pre-fix this was ranked #1 and labelled "Recommended", exit 0.
     t = report_tree(healthy_receipt(release_gate={"verdict": "WEIRD_UNKNOWN", "checks": []}))
@@ -2179,7 +2237,7 @@ def test_the_billing_check_runs_before_the_availability_check():
 
 # An exact count, because the borrowed runner in cleanup_metrics_test.py returns
 # 0 when it discovers ZERO tests — so "green" would carry no information at all.
-EXPECTED_TESTS = 112
+EXPECTED_TESTS = 116
 
 
 def _run() -> int:

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -947,6 +947,55 @@ def test_a_refused_judge_cannot_delete_a_single_cached_receipt():
     assert "Nothing has been touched" in out, out
 
 
+def test_a_routed_but_unusable_judge_still_cannot_delete_a_receipt():
+    """The SECOND round of the same P1 (cloud review, #2026), and the reason the fix is
+    structural rather than a better check.
+
+    `claude-sonet-5` is a typo that ROUTES: it starts with `claude`, so it has a funded route
+    and passes the pre-loop validation. Its stamp still mismatches every arm, so the loop
+    still re-judges, and the CLI only rejects the model name once the judge actually runs.
+    Under the delete-first design that destroyed the receipt. Under staged-then-swapped the
+    receipt survives, and it survives for ANY reason the judge fails to produce one — a
+    capacity error, an expired key, a dropped network — none of which a probe could predict.
+    """
+    t = shell_tree("noreceipt")          # the judge runs and writes nothing
+    d = t / "judged" / "modelA"
+    d.mkdir(parents=True, exist_ok=True)
+    receipt = d / "summary.json"
+    receipt.write_text(json.dumps(
+        {"cacheable": True, "release_gate": {"verdict": "CLEAR"},
+         "skipped": [], "missing_scores": []}))
+    forge_stamp(t, judge="azure/stub-judge@stubdigest")
+    before = receipt.read_text()
+
+    _, log = run_shell(t, env=dict(os.environ, EW_JUDGE="claude-sonet-5"))
+
+    assert "=== re-judging modelA" in log, f"expected a re-judge attempt:\n{log}"
+    assert receipt.exists(), f"a routed-but-unusable judge DELETED the receipt:\n{log}"
+    assert receipt.read_text() == before, "the receipt was modified"
+    assert "previous receipt left in place" in log, log
+    assert not (t / "judged" / "modelA.rejudge").exists(), "staging directory was left behind"
+
+
+def test_a_successful_rejudge_does_replace_the_old_receipt():
+    """Two-way control. A staging swap that never promoted anything would pass the case above
+    while making every re-judge a no-op, which is the expensive failure and looks like nothing
+    is wrong. The stub writes a cacheable receipt, so the arm must end up stamped."""
+    t = shell_tree("true")
+    d = t / "judged" / "modelA"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "summary.json").write_text(json.dumps({"cacheable": False, "stale": "marker"}))
+    forge_stamp(t, judge="claude-sonnet-5")   # a different judge, so it must re-judge
+
+    _, log = run_shell(t)
+
+    fresh = json.loads((d / "summary.json").read_text())
+    assert "stale" not in fresh, f"the old receipt was not replaced:\n{log}"
+    assert fresh.get("cacheable") is True, fresh
+    assert stamped(t), f"a successful re-judge must earn a stamp:\n{log}"
+    assert not (t / "judged" / "modelA.rejudge").exists(), "staging directory was left behind"
+
+
 def test_the_refusal_happens_before_any_arm_is_examined():
     """Two-way control on the guard's PLACEMENT, not just its existence. A check that ran
     inside the loop would refuse on the first arm and could still have deleted its receipt
@@ -1003,7 +1052,10 @@ def test_shell_sha256_shim_produces_an_identical_stamp():
     subprocess.run(["rm", "-rf", str(t / "judged" / "modelA")], check=True)
 
     shim = Path(tempfile.mkdtemp())
-    for cmd in ("python3", "grep", "basename", "dirname", "cat", "mkdir", "rm",
+    # This tuple is in effect a declaration of every external command the script depends on:
+    # anything missing from it is hidden from the script under the shim. `mv` joined the list
+    # when the re-judge became staged-then-swapped, and this case is what caught the omission.
+    for cmd in ("python3", "grep", "basename", "dirname", "cat", "mkdir", "rm", "mv",
                 "printf", "cut", "sha256sum", "bash", "sed", "ls", "env"):
         found = subprocess.run(["bash", "-c", f"command -v {cmd}"],
                                capture_output=True, text=True).stdout.strip()
@@ -1700,7 +1752,7 @@ def test_the_billing_check_runs_before_the_availability_check():
 
 # An exact count, because the borrowed runner in cleanup_metrics_test.py returns
 # 0 when it discovers ZERO tests — so "green" would carry no information at all.
-EXPECTED_TESTS = 88
+EXPECTED_TESTS = 90
 
 
 def _run() -> int:

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -971,21 +971,29 @@ def test_a_routed_but_unusable_judge_still_cannot_delete_a_receipt():
     _, log = run_shell(t, env=dict(os.environ, EW_JUDGE="claude-sonet-5"))
 
     assert "=== re-judging modelA" in log, f"expected a re-judge attempt:\n{log}"
-    assert receipt.exists(), f"a routed-but-unusable judge DELETED the receipt:\n{log}"
-    assert receipt.read_text() == before, "the receipt was modified"
-    assert "previous receipt KEPT and not stamped" in log, log
     assert not (t / "judged" / "modelA.rejudge").exists(), "staging directory was left behind"
 
-    # THE OTHER HALF, and a separate P1 (cloud review round 3): surviving must not mean
-    # ADOPTED. The post-judge branch used to re-read $dest, find the old cacheable receipt and
-    # write the NEW judge's stamp onto it — so later runs skipped it and reported the previous
-    # judge's scores as this judge's, which is the silently-mixed-judges defect the stamp
-    # exists to prevent. The stamp must still hold the ORIGINAL judge's value.
-    stamp = t / "judged" / "modelA" / ".inputs-sha256"
-    assert stamp.exists(), "the original stamp should be untouched, not removed"
-    assert stamp.read_text().strip() == original_stamp, (
-        "the OLD receipt was stamped with the NEW judge's identity, so the next run would skip "
-        "it and report the previous judge's scores as this judge's")
+    # THREE separate P1s met here, one per review round, and they only reconcile as quarantine.
+    #
+    # 1. The bytes must SURVIVE — deleting them was the original defect, where one typo wiped
+    #    the whole cached set.
+    quarantined = t / "judged" / "modelA.stale" / "summary.json"
+    assert quarantined.exists(), f"the previous receipt was destroyed:\n{log}"
+    assert quarantined.read_text() == before, "the quarantined receipt was modified"
+
+    # 2. They must NOT sit at the canonical path, because `report_ollama_bench.py` reads that
+    #    path and checks cacheability but never the stamp — so a valid receipt from the previous
+    #    judge would be ranked beside newly judged arms and corrupt the comparison silently.
+    assert not receipt.exists(), (
+        f"the previous judge's receipt is still where the report will rank it:\n{log}")
+
+    # 3. Surviving must not mean ADOPTED. Nothing may carry this judge's stamp, or a later run
+    #    would skip the arm and report the previous judge's scores as this judge's.
+    assert not (t / "judged" / "modelA" / ".inputs-sha256").exists(), "canonical stamp survived"
+    stale_stamp = t / "judged" / "modelA.stale" / ".inputs-sha256"
+    assert stale_stamp.read_text().strip() == original_stamp, (
+        "the quarantined receipt was re-stamped with the NEW judge's identity")
+    assert "quarantined at" in log, log
 
 
 
@@ -1004,15 +1012,20 @@ def test_a_partial_staged_receipt_does_not_evict_a_complete_one():
     original_stamp = forge_stamp(t, judge="claude-sonnet-5")   # forces a re-judge
     _, log = run_shell(t)
 
-    kept = json.loads(receipt.read_text())
-    assert kept.get("marker") == "the good one", (
-        f"a partial staged receipt evicted the complete one:\n{log}")
-    assert (d / ".inputs-sha256").read_text().strip() == original_stamp, (
-        "the kept receipt must not carry the new judge's stamp")
-    assert "previous receipt KEPT" in log, log
-    # The failed attempt stays inspectable rather than being silently discarded.
-    assert (t / "judged" / "modelA.rejudge" / "summary.json").exists(), (
-        f"the failed attempt should be left for diagnosis:\n{log}")
+    # The complete receipt is preserved, and preserved OUT of the report's path.
+    stale = json.loads((t / "judged" / "modelA.stale" / "summary.json").read_text())
+    assert stale.get("marker") == "the good one", (
+        f"the complete receipt was not preserved:\n{log}")
+    assert (t / "judged" / "modelA.stale" / ".inputs-sha256").read_text().strip() \
+        == original_stamp, "the quarantined receipt lost or changed its own stamp"
+
+    # What sits at the canonical path is what THIS judge produced, and it is not cacheable, so
+    # the report rejects it loudly instead of ranking either receipt.
+    now = json.loads(receipt.read_text())
+    assert now.get("marker") is None, f"the old receipt is still at the ranked path:\n{log}"
+    assert now.get("cacheable") is False, now
+    assert not (d / ".inputs-sha256").exists(), "a non-cacheable receipt must never be stamped"
+    assert "quarantined at" in log, log
 
 
 def test_a_partial_receipt_is_still_promoted_when_there_is_nothing_to_lose():

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -1995,6 +1995,60 @@ def test_preflight_pins_the_model_for_an_azure_judge():
             assert bj._azure_pinned_model == "gpt-5.6-luna-2026-07-09", bj._azure_pinned_model
 
 
+def test_an_inherited_pin_is_adopted_instead_of_reprobed():
+    # Cloud review round 8. Each arm is a separate process. If each probes for itself it pins
+    # whatever is CURRENT, so a deployment repointed between arms leaves that process
+    # self-consistent while the sweep still stamps every arm with the first model's identity —
+    # two model versions under one stamp. Adopting the sweep's pin makes such an arm fail on its
+    # first grading response instead.
+    with _azure_pin(None):
+        os.environ["EW_AZURE_PINNED_MODEL"] = "gpt-5.6-luna-2026-07-09"
+        try:
+            # No serving stub: adopting the inherited pin must not require a probe at all, which
+            # is also what saves one request per arm.
+            bj.preflight_judge("azure/gpt-5-6-luna")
+            assert bj._azure_pinned_model == "gpt-5.6-luna-2026-07-09", bj._azure_pinned_model
+        finally:
+            del os.environ["EW_AZURE_PINNED_MODEL"]
+
+
+def test_an_arm_refuses_when_the_deployment_moved_since_the_sweep_probed():
+    # The consequence that makes the propagation worth it: the arm is pinned to the SWEEP's model,
+    # so a deployment now serving something else fails loudly rather than scoring under the
+    # sweep's stamp.
+    with _azure_pin(None):
+        os.environ["EW_AZURE_PINNED_MODEL"] = "gpt-5.6-luna-2026-07-09"
+        try:
+            bj.preflight_judge("azure/gpt-5-6-luna")
+            with _azure_reply({"model": "gpt-5.6-luna-2026-11-01",
+                               "choices": [{"message": {"content": "[]"},
+                                            "finish_reason": "stop"}]}):
+                try:
+                    bj.call_azure("gpt-5-6-luna", "s", "u")
+                except RuntimeError as e:
+                    assert "repointed mid-run" in str(e), str(e)
+                else:
+                    raise AssertionError("the arm graded under the wrong model version")
+        finally:
+            del os.environ["EW_AZURE_PINNED_MODEL"]
+
+
+def test_the_identity_probe_reports_the_served_model_as_its_third_line():
+    # The sweep parses line 3 to build the pin it exports. A probe that printed two lines would
+    # export an empty pin, and every per-response check would then silently do nothing.
+    src = Path(bj.__file__).read_text()
+    block = src.split('if "--print-judge-identity" in sys.argv:')[1].split("return 0")[0]
+    # Counts STDOUT lines only: the error path in the same block prints to stderr, and a naive
+    # count of "print(" includes it — which is how the first version of this assertion failed
+    # against correct code.
+    stdout_prints = [ln.strip() for ln in block.splitlines()
+                     if "print(" in ln and "file=sys.stderr" not in ln]
+    assert len(stdout_prints) == 3, f"expected three stdout lines, got {stdout_prints}"
+    assert "DEFAULT_JUDGE" in stdout_prints[0], stdout_prints
+    assert "identity" in stdout_prints[1], stdout_prints
+    assert "_azure_pinned_model" in stdout_prints[2], stdout_prints
+
+
 def test_the_billing_check_runs_before_the_availability_check():
     # Refusing to spend the founder's own money must not depend on whether some CLI
     # happens to be logged in, so the order in main() is load-bearing.
@@ -2011,7 +2065,7 @@ def test_the_billing_check_runs_before_the_availability_check():
 
 # An exact count, because the borrowed runner in cleanup_metrics_test.py returns
 # 0 when it discovers ZERO tests — so "green" would carry no information at all.
-EXPECTED_TESTS = 103
+EXPECTED_TESTS = 106
 
 
 def _run() -> int:

--- a/scripts/eval/judge_ollama_bench.sh
+++ b/scripts/eval/judge_ollama_bench.sh
@@ -37,21 +37,40 @@ skipped=()
 unmeasurable=()
 incomplete=()
 
-# Resolve the judge ONCE, from `behavior_judge.py` itself rather than from a second
-# default written here. Two defaults are a drift bug waiting to happen, and this one
-# would be invisible: the stamp would record the shell's idea of the judge while a
-# different judge did the grading. Reading DEFAULT_JUDGE also honours EW_JUDGE for
-# free, because that is where the override already lives.
+# Resolve AND VALIDATE the judge ONCE, before the loop, from `behavior_judge.py` itself
+# rather than from a second default written here. Two defaults are a drift bug waiting to
+# happen and this one would be invisible: the stamp would record the shell's idea of the
+# judge while a different judge graded.
 #
-# Fails closed. An empty answer would otherwise stamp `judge=` on every arm and make
-# all receipts look mutually comparable, which is the failure this whole change exists
-# to prevent.
-JUDGE="$(python3 -c 'import sys; sys.path.insert(0, sys.argv[1]); import behavior_judge; print(behavior_judge.DEFAULT_JUDGE)' "$ROOT/scripts/eval" 2>/dev/null)"
-if [ -z "$JUDGE" ]; then
-  echo "FATAL: could not resolve the default judge from behavior_judge.py" >&2
+# VALIDATION BEFORE THE LOOP IS LOAD-BEARING, NOT TIDINESS. The loop below `rm -rf`s any
+# receipt whose stamp no longer matches, and the judge is part of that stamp — so a refused
+# or mistyped EW_JUDGE mismatches EVERY arm, deletes every cached receipt, and then
+# `behavior_judge.py` refuses the judge and exits before writing replacements. The whole
+# stored set would be gone, with the log blaming "candidates or corpus changed". Cloud
+# review caught this on PR #2026; it is a hazard my own put-the-judge-in-the-stamp fix
+# created, so the fix has to carry its own guard. `--print-judge-identity` exits 2 on any
+# judge with no funded route, and on an endpoint that cannot be resolved or validated.
+#
+# It returns two values: the judge id for `--judge` and the log line, and an IDENTITY for
+# the stamp. They differ on purpose. Azure deployment names are resource-local, so the same
+# `azure/gpt-5-6-luna` label on a different endpoint can be a different model; the identity
+# folds in a digest of the endpoint host and the API version so a resource change
+# invalidates the stamp instead of silently reusing another grader's receipt. A digest, not
+# the host, because this value is printed and stored.
+JUDGE_LINES="$(python3 "$ROOT/scripts/eval/behavior_judge.py" --print-judge-identity 2>&1)"
+if [ $? -ne 0 ]; then
+  echo "FATAL: $JUDGE_LINES" >&2
+  echo "       Refusing to start: a bad judge would invalidate every stamp and this script" >&2
+  echo "       deletes receipts whose stamp does not match. Nothing has been touched." >&2
   exit 2
 fi
-echo "=== judge: $JUDGE ===" >&2
+JUDGE="$(printf '%s\n' "$JUDGE_LINES" | sed -n 1p)"
+JUDGE_IDENTITY="$(printf '%s\n' "$JUDGE_LINES" | sed -n 2p)"
+if [ -z "$JUDGE" ] || [ -z "$JUDGE_IDENTITY" ]; then
+  echo "FATAL: could not resolve the judge and its identity from behavior_judge.py" >&2
+  exit 2
+fi
+echo "=== judge: $JUDGE (stamp identity $JUDGE_IDENTITY) ===" >&2
 
 # `shasum` is Perl-provided and is NOT guaranteed by the ubuntu-latest runner
 # image, which lists coreutils (and therefore `sha256sum`). Our own pr-check.yml
@@ -125,7 +144,11 @@ for cand in "$CANDDIR"/*.jsonl; do
   # numbers with the OLD quality scores and said nothing. Same shape as the two
   # holes above it: a result whose scope is quietly narrower than it looks.
   stamp="$dest/.inputs-sha256"
-  # The JUDGE is part of the inputs. Without it a receipt graded by one judge is
+  # The JUDGE IDENTITY is part of the inputs, which is the judge id plus, for Azure, a digest
+  # of the endpoint host and API version. The bare id is not enough: deployment names are
+  # resource-local, so the same label on another endpoint can be another model.
+  #
+  # Without the judge at all, a receipt graded by one judge is
   # silently reused after the default changes, which is exactly what would have
   # happened on 2026-08-11: 15 arms carried stamped, cacheable Sonnet receipts, so a
   # sweep under the new Azure default would have skipped every one and produced a
@@ -136,7 +159,7 @@ for cand in "$CANDDIR"/*.jsonl; do
   # the next sweep re-grades the full field. That is the only way a comparison stays
   # a comparison, and it is affordable precisely because the new judge is cheap.
   inputs_sha="$(
-    { printf 'judge=%s\n' "$JUDGE"; sha256 "$cand" "$CORPUS"; } | sha256 | cut -d' ' -f1
+    { printf 'judge=%s\n' "$JUDGE_IDENTITY"; sha256 "$cand" "$CORPUS"; } | sha256 | cut -d' ' -f1
   )"
   if [ -f "$dest/summary.json" ]; then
     # Cacheability is checked HERE too, not only after judging. A matching stamp

--- a/scripts/eval/judge_ollama_bench.sh
+++ b/scripts/eval/judge_ollama_bench.sh
@@ -86,6 +86,23 @@ sha256() {
   fi
 }
 
+# Move a superseded receipt OUT of the report-visible path without destroying it.
+#
+# Called when a re-judge failed to produce a cacheable receipt while a previous one exists.
+# Deleting it was the original P1 (a typo wiped the cached set); leaving it at `$dest` was the
+# next P1 (`report_ollama_bench.py` validates cacheability but never reads `.inputs-sha256`, so
+# it would rank the old judge's scores beside newly judged arms). Quarantine satisfies both:
+# the bytes survive for inspection, and nothing that ranks receipts can find them.
+#
+# Uses `$dest`/`$base` from the enclosing loop. One slot per arm: a previous quarantine is
+# already superseded, so it is replaced rather than accumulating copies.
+quarantine_previous() {
+  [ "$had_previous" = 1 ] || return 0
+  rm -rf "$dest.stale"
+  mv "$dest" "$dest.stale"
+  echo "  previous receipt for $base quarantined at $dest.stale (not ranked, not stamped)" >&2
+}
+
 # Is this receipt safe to cache AND to rank? Read the judge's own answer; never
 # infer it from the release verdict. `evaluate_new_gate` gives a quality failure
 # precedence over incompleteness, so a run that is BOTH quality-failed and
@@ -278,29 +295,26 @@ for cand in "$CANDDIR"/*.jsonl; do
       echo "  ok $base" >&2
       ;;
     partial)
-      if [ "$had_previous" = 1 ]; then
-        # A partial receipt must not evict a complete one. Presence was the old test, and it
-        # promoted a run that failed after scoring started — `behavior_judge.py` still writes
-        # a summary with `cacheable: false` in that case, so the good receipt was replaced by
-        # the failure. Keep both: the old one in place, the staged one for diagnosis.
-        echo "  INCOMPLETE $base (staged receipt not cacheable; previous receipt KEPT and not" >&2
-        echo "     stamped; the failed attempt is at $staging)" >&2
-      else
-        # Nothing to lose, so promote it: a partial receipt is still the only evidence of what
-        # happened, and the resume branch re-judges it because it is unstamped.
-        mv "$staging" "$dest"
-        echo "  INCOMPLETE $base (receipt is not cacheable; left in place, not stamped)" >&2
-      fi
+      # A partial receipt must not evict a complete one, and the complete one must not stay
+      # where the REPORT can see it. Both halves are cloud-review P1s from consecutive rounds,
+      # and they pull in opposite directions until the old receipt is quarantined rather than
+      # kept or deleted: `report_ollama_bench.py` reads `$dest/summary.json` and checks
+      # cacheability but never the stamp, so a valid receipt from the PREVIOUS judge sitting at
+      # the canonical path gets ranked alongside newly judged arms — a corrupted comparison,
+      # silently, which is the failure this whole change exists to prevent.
+      quarantine_previous
+      # Promote the partial: it is what the current judge actually produced, and the report
+      # rejects a non-cacheable receipt loudly rather than ranking it. Never stamped, so the
+      # resume branch re-judges the arm next time.
+      mv "$staging" "$dest"
+      echo "  INCOMPLETE $base (receipt is not cacheable; left in place, not stamped)" >&2
       incomplete+=("$base")
       ;;
     missing)
       # The judge refused, crashed, timed out, or lost its network before writing anything.
       rm -rf "$staging"
-      if [ "$had_previous" = 1 ]; then
-        echo "  FAILED $base (no receipt produced; previous receipt KEPT and not stamped)" >&2
-      else
-        echo "  FAILED $base" >&2
-      fi
+      quarantine_previous
+      echo "  FAILED $base" >&2
       failed+=("$base")
       ;;
   esac

--- a/scripts/eval/judge_ollama_bench.sh
+++ b/scripts/eval/judge_ollama_bench.sh
@@ -94,10 +94,35 @@ sha256() {
 # it would rank the old judge's scores beside newly judged arms). Quarantine satisfies both:
 # the bytes survive for inspection, and nothing that ranks receipts can find them.
 #
-# Uses `$dest`/`$base` from the enclosing loop. One slot per arm: a previous quarantine is
-# already superseded, so it is replaced rather than accumulating copies.
+# ONE slot per arm, and the rule for what may occupy it is the whole point. An earlier version
+# replaced the slot unconditionally, reasoning that a previous quarantine "is already
+# superseded". False, and cloud review caught it: after one failed re-judge the canonical path
+# holds a PARTIAL receipt and the complete one is in the slot, so the next failure displaced the
+# complete receipt with a partial and the only good copy was gone. Repeated outages would grind
+# the quarantine down from complete to worthless, which is precisely the loss it exists to
+# prevent — the third variant of that same loss across four review rounds.
+#
+# The rule: never trade a cacheable receipt for a non-cacheable one. Everything else may be
+# replaced, so the slot cannot grow without bound.
+#
+# | slot holds     | being displaced | action                                  |
+# |----------------|-----------------|-----------------------------------------|
+# | nothing        | anything        | move it in                              |
+# | cacheable      | NOT cacheable   | KEEP the slot, discard the displaced one|
+# | cacheable      | cacheable       | replace (the newer complete one wins)   |
+# | NOT cacheable  | anything        | replace                                 |
+#
+# Uses `$dest`/`$base`/`$had_previous` from the enclosing loop.
 quarantine_previous() {
   [ "$had_previous" = 1 ] || return 0
+  if [ -f "$dest.stale/summary.json" ] \
+     && receipt_cacheable "$dest.stale/summary.json" \
+     && ! receipt_cacheable "$dest/summary.json"; then
+    rm -rf "$dest"
+    echo "  discarded an incomplete receipt for $base; the COMPLETE quarantine at" >&2
+    echo "     $dest.stale is kept (a partial must never displace a complete one)" >&2
+    return 0
+  fi
   rm -rf "$dest.stale"
   mv "$dest" "$dest.stale"
   echo "  previous receipt for $base quarantined at $dest.stale (not ranked, not stamped)" >&2
@@ -244,6 +269,15 @@ for cand in "$CANDDIR"/*.jsonl; do
   errs=$(python3 -c "import json,sys; print(sum(1 for l in open(sys.argv[1]) if l.strip() and json.loads(l).get('error')))" "$cand")
   if [ "$errs" -ge "$total" ]; then
     echo "=== skipping $base: $errs/$total cases errored, nothing to judge ===" >&2
+    # This branch `continue`s, so it never reaches the staged-outcome handling below — and once
+    # the resume branch stopped deleting, a stale receipt could sit at the canonical path while
+    # this arm is reported unmeasurable. `report_ollama_bench.py` would then read that receipt
+    # instead of seeing the missing one it expects, and reject the whole benchmark because the
+    # old skip counts do not match this run's errors. Quarantine here too: the arm has no
+    # gradeable output, so nothing at the ranked path can be current.
+    had_previous=0
+    [ -f "$dest/summary.json" ] && had_previous=1
+    quarantine_previous
     unmeasurable+=("$base")
     continue
   fi

--- a/scripts/eval/judge_ollama_bench.sh
+++ b/scripts/eval/judge_ollama_bench.sh
@@ -115,9 +115,15 @@ sha256() {
 # Uses `$dest`/`$base`/`$had_previous` from the enclosing loop.
 quarantine_previous() {
   [ "$had_previous" = 1 ] || return 0
+  # `receipt_cacheable` is only asked about files that exist: $dest may be a directory with no
+  # summary at all (an interrupted write), which is not cacheable by definition.
+  dest_is_cacheable=1
+  if [ ! -f "$dest/summary.json" ] || ! receipt_cacheable "$dest/summary.json"; then
+    dest_is_cacheable=0
+  fi
   if [ -f "$dest.stale/summary.json" ] \
      && receipt_cacheable "$dest.stale/summary.json" \
-     && ! receipt_cacheable "$dest/summary.json"; then
+     && [ "$dest_is_cacheable" = 0 ]; then
     rm -rf "$dest"
     echo "  discarded an incomplete receipt for $base; the COMPLETE quarantine at" >&2
     echo "     $dest.stale is kept (a partial must never displace a complete one)" >&2
@@ -276,7 +282,7 @@ for cand in "$CANDDIR"/*.jsonl; do
     # old skip counts do not match this run's errors. Quarantine here too: the arm has no
     # gradeable output, so nothing at the ranked path can be current.
     had_previous=0
-    [ -f "$dest/summary.json" ] && had_previous=1
+    [ -e "$dest" ] && had_previous=1
     quarantine_previous
     unmeasurable+=("$base")
     continue
@@ -316,14 +322,34 @@ for cand in "$CANDDIR"/*.jsonl; do
       staged_state=partial
     fi
   fi
+  # The DIRECTORY, not the summary inside it. An earlier run interrupted after `write_outputs`
+  # created $dest or wrote per_case.jsonl but before summary.json leaves a directory with no
+  # receipt: a summary-only test called that "no previous", quarantine skipped it, and
+  # `mv "$staging" "$dest"` then moved the staged directory INSIDE it. No canonical summary for
+  # the report, misplaced diagnostics accumulating, and no error anywhere. Cloud review caught
+  # it; `mv` into an existing directory nesting rather than replacing is the trap.
   had_previous=0
-  [ -f "$dest/summary.json" ] && had_previous=1
+  [ -e "$dest" ] && had_previous=1
 
   case "$staged_state" in
     cacheable)
       # The ONLY path that stamps. A stamp asserts "this judge produced this receipt", so it
       # is written exactly where that is true and nowhere else.
-      rm -rf "$dest"
+      #
+      # Quarantine BEFORE promoting, never `rm -rf` then `mv`. That order had a window: an
+      # interruption between the delete and the rename destroyed the old receipt while the new
+      # one was still under `.rejudge`, and the next run deletes the staging directory — so both
+      # were lost, which contradicted the interruption safety this staging was added for.
+      # Two renames instead, so at every instant at least one complete receipt exists at a
+      # path we can name.
+      #
+      # RESIDUAL LIMIT, recorded rather than engineered around: an interruption in the gap
+      # between the two renames still loses the NEW result, because the next run clears the
+      # staging directory and cannot know the staged receipt matches the current inputs. The old
+      # receipt survives in the quarantine slot and the arm is simply re-judged, so the cost is
+      # one re-run rather than lost data. Auto-promoting a leftover staged receipt would risk
+      # promoting one graded against different inputs, which is worse than a re-run.
+      quarantine_previous
       mv "$staging" "$dest"
       printf '%s\n' "$inputs_sha" > "$stamp"
       echo "  ok $base" >&2

--- a/scripts/eval/judge_ollama_bench.sh
+++ b/scripts/eval/judge_ollama_bench.sh
@@ -66,11 +66,18 @@ if [ $? -ne 0 ]; then
 fi
 JUDGE="$(printf '%s\n' "$JUDGE_LINES" | sed -n 1p)"
 JUDGE_IDENTITY="$(printf '%s\n' "$JUDGE_LINES" | sed -n 2p)"
+# Third line: the model version the probe observed, empty for non-Azure judges. Exported to
+# every arm so each one verifies against THIS sweep's model instead of probing for itself. An
+# arm that probes independently pins whatever is current, so a deployment repointed between arms
+# stays self-consistent inside that process while the stamp written here still names the first
+# model — two model versions under one stamp, which is the mixing this stamp exists to prevent.
+JUDGE_PINNED_MODEL="$(printf '%s\n' "$JUDGE_LINES" | sed -n 3p)"
+export EW_AZURE_PINNED_MODEL="$JUDGE_PINNED_MODEL"
 if [ -z "$JUDGE" ] || [ -z "$JUDGE_IDENTITY" ]; then
   echo "FATAL: could not resolve the judge and its identity from behavior_judge.py" >&2
   exit 2
 fi
-echo "=== judge: $JUDGE (stamp identity $JUDGE_IDENTITY) ===" >&2
+echo "=== judge: $JUDGE (stamp identity $JUDGE_IDENTITY${JUDGE_PINNED_MODEL:+, serving $JUDGE_PINNED_MODEL}) ===" >&2
 
 # `shasum` is Perl-provided and is NOT guaranteed by the ubuntu-latest runner
 # image, which lists coreutils (and therefore `sha256sum`). Our own pr-check.yml

--- a/scripts/eval/judge_ollama_bench.sh
+++ b/scripts/eval/judge_ollama_bench.sh
@@ -209,10 +209,15 @@ for cand in "$CANDDIR"/*.jsonl; do
     # any probe. Not deleting until a replacement exists removes every member at once,
     # including the ones nobody has thought of.
     #
-    # Leaving the old receipt is SAFE, not merely less destructive: its stamp no longer
-    # matches this judge, so the resume branch above re-judges it and never trusts it. If the
-    # judge is later set back to whatever produced it, the stamp matches again and skipping it
-    # is correct, because that judge really did produce it.
+    # Leaving the old receipt is safe ONLY because the block below stamps nothing unless a
+    # cacheable staged receipt was promoted. An earlier version of this comment argued the
+    # receipt was safe "because its stamp no longer matches this judge" — false, and the
+    # reviewer caught it: the post-judge branch re-read $dest and would have written the new
+    # stamp onto that old receipt. The safety lives in the stamping rule, not here.
+    #
+    # Given that rule: if the judge is later set back to whatever produced this receipt, its
+    # original stamp matches again and skipping it is correct, because that judge really did
+    # produce it.
   fi
   # A model that errored on EVERY case has no output to grade. Judging 20 empty
   # strings would return 20 critical failures, which reads as "measured and
@@ -243,32 +248,62 @@ for cand in "$CANDDIR"/*.jsonl; do
   python3 "$ROOT/scripts/eval/behavior_judge.py" \
     --system new --judge "$JUDGE" \
     --corpus "$CORPUS" --candidates "$cand" --out "$staging" >&2 || true
+  # The outcome is CARRIED from the staged run, never re-derived by looking at $dest.
+  #
+  # Third round of cloud review on this one area, and both remaining P1s came from reading
+  # $dest afterwards: that cannot distinguish a receipt THIS run produced from one it merely
+  # failed to replace. It let a failed re-judge write the new judge's stamp onto the previous
+  # judge's receipt, so later runs skipped it and reported the old judge's scores as the new
+  # judge's — the exact silently-mixed-judges defect this whole change exists to prevent, and
+  # one my own staging fix introduced. My comment claimed the surviving receipt was safe
+  # "because its stamp no longer matches"; the very next block was writing that stamp.
+  staged_state=missing
   if [ -f "$staging/summary.json" ]; then
-    rm -rf "$dest"
-    mv "$staging" "$dest"
-  else
-    # Nothing to promote. The judge refused, crashed, timed out, or lost its network. The
-    # previous receipt survives untouched and unstamped for this judge, so the next run
-    # re-judges it; before this, the arm was already deleted and the whole cached set could
-    # be wiped by a single typo.
-    rm -rf "$staging"
-    echo "  no receipt produced for $base; previous receipt left in place" >&2
+    if receipt_cacheable "$staging/summary.json"; then
+      staged_state=cacheable
+    else
+      staged_state=partial
+    fi
   fi
+  had_previous=0
+  [ -f "$dest/summary.json" ] && had_previous=1
 
-  if [ -f "$dest/summary.json" ] && receipt_cacheable "$dest/summary.json"; then
-    printf '%s\n' "$inputs_sha" > "$stamp"
-    echo "  ok $base" >&2
-  elif [ -f "$dest/summary.json" ]; then
-    # A receipt exists but is partial or internally inconsistent. Do NOT stamp:
-    # withholding the stamp is the whole recovery mechanism, because the resume
-    # branch above deletes and re-judges an unstamped receipt. Leaving the file
-    # in place keeps it readable for whoever investigates.
-    echo "  INCOMPLETE $base (receipt is not cacheable; left in place, not stamped)" >&2
-    incomplete+=("$base")
-  else
-    echo "  FAILED $base" >&2
-    failed+=("$base")
-  fi
+  case "$staged_state" in
+    cacheable)
+      # The ONLY path that stamps. A stamp asserts "this judge produced this receipt", so it
+      # is written exactly where that is true and nowhere else.
+      rm -rf "$dest"
+      mv "$staging" "$dest"
+      printf '%s\n' "$inputs_sha" > "$stamp"
+      echo "  ok $base" >&2
+      ;;
+    partial)
+      if [ "$had_previous" = 1 ]; then
+        # A partial receipt must not evict a complete one. Presence was the old test, and it
+        # promoted a run that failed after scoring started — `behavior_judge.py` still writes
+        # a summary with `cacheable: false` in that case, so the good receipt was replaced by
+        # the failure. Keep both: the old one in place, the staged one for diagnosis.
+        echo "  INCOMPLETE $base (staged receipt not cacheable; previous receipt KEPT and not" >&2
+        echo "     stamped; the failed attempt is at $staging)" >&2
+      else
+        # Nothing to lose, so promote it: a partial receipt is still the only evidence of what
+        # happened, and the resume branch re-judges it because it is unstamped.
+        mv "$staging" "$dest"
+        echo "  INCOMPLETE $base (receipt is not cacheable; left in place, not stamped)" >&2
+      fi
+      incomplete+=("$base")
+      ;;
+    missing)
+      # The judge refused, crashed, timed out, or lost its network before writing anything.
+      rm -rf "$staging"
+      if [ "$had_previous" = 1 ]; then
+        echo "  FAILED $base (no receipt produced; previous receipt KEPT and not stamped)" >&2
+      else
+        echo "  FAILED $base" >&2
+      fi
+      failed+=("$base")
+      ;;
+  esac
 done
 
 [ ${#skipped[@]} -gt 0 ] && echo "skipped (already judged): ${skipped[*]}" >&2

--- a/scripts/eval/judge_ollama_bench.sh
+++ b/scripts/eval/judge_ollama_bench.sh
@@ -196,7 +196,23 @@ for cand in "$CANDDIR"/*.jsonl; do
       reason="candidates or corpus changed since its receipt"
     fi
     echo "=== re-judging $base: $reason ===" >&2
-    rm -rf "$dest"
+    # DELIBERATELY NOT deleted here. The judge writes into a staging directory below and the
+    # old receipt is replaced only once a new one exists, so a judge that produces nothing
+    # cannot destroy the stored set.
+    #
+    # This is the second and structural fix for the same P1 (cloud review, #2026). The first
+    # validated the judge's funded ROUTE before the loop, and the reviewer correctly pointed
+    # out that this only closes one member of the class: `claude-sonet-5` and `azure/typo` are
+    # both routed, so they passed that check, mismatched every stamp, and reached the delete
+    # before the CLI or the endpoint rejected them. Probing harder would have narrowed the
+    # window rather than closing it — a mid-run capacity error or an expired key fails after
+    # any probe. Not deleting until a replacement exists removes every member at once,
+    # including the ones nobody has thought of.
+    #
+    # Leaving the old receipt is SAFE, not merely less destructive: its stamp no longer
+    # matches this judge, so the resume branch above re-judges it and never trusts it. If the
+    # judge is later set back to whatever produced it, the stamp matches again and skipping it
+    # is correct, because that judge really did produce it.
   fi
   # A model that errored on EVERY case has no output to grade. Judging 20 empty
   # strings would return 20 critical failures, which reads as "measured and
@@ -218,9 +234,26 @@ for cand in "$CANDDIR"/*.jsonl; do
   # `--judge "$JUDGE"` explicitly, never the implicit default: the judge that grades
   # must be the same value that went into the stamp, and letting each side resolve it
   # independently is how they drift.
+  # Staged, then swapped. `--out` points at a scratch sibling so a failed run leaves `$dest`
+  # exactly as it was; only a run that actually produced a summary.json replaces it. The
+  # swap is a rename inside $OUTDIR, so it is atomic enough for this purpose and cannot
+  # leave a half-copied receipt behind.
+  staging="$dest.rejudge"
+  rm -rf "$staging"
   python3 "$ROOT/scripts/eval/behavior_judge.py" \
     --system new --judge "$JUDGE" \
-    --corpus "$CORPUS" --candidates "$cand" --out "$dest" >&2 || true
+    --corpus "$CORPUS" --candidates "$cand" --out "$staging" >&2 || true
+  if [ -f "$staging/summary.json" ]; then
+    rm -rf "$dest"
+    mv "$staging" "$dest"
+  else
+    # Nothing to promote. The judge refused, crashed, timed out, or lost its network. The
+    # previous receipt survives untouched and unstamped for this judge, so the next run
+    # re-judges it; before this, the arm was already deleted and the whole cached set could
+    # be wiped by a single typo.
+    rm -rf "$staging"
+    echo "  no receipt produced for $base; previous receipt left in place" >&2
+  fi
 
   if [ -f "$dest/summary.json" ] && receipt_cacheable "$dest/summary.json"; then
     printf '%s\n' "$inputs_sha" > "$stamp"

--- a/scripts/eval/judge_ollama_bench.sh
+++ b/scripts/eval/judge_ollama_bench.sh
@@ -73,6 +73,10 @@ JUDGE_IDENTITY="$(printf '%s\n' "$JUDGE_LINES" | sed -n 2p)"
 # model — two model versions under one stamp, which is the mixing this stamp exists to prevent.
 JUDGE_PINNED_MODEL="$(printf '%s\n' "$JUDGE_LINES" | sed -n 3p)"
 export EW_AZURE_PINNED_MODEL="$JUDGE_PINNED_MODEL"
+# The stamp identity travels into every arm too, so each receipt RECORDS which grader produced
+# it. The report reads receipts rather than stamps, so an identity that lives only in the sidecar
+# is invisible exactly where arms get combined into a ranking.
+export EW_JUDGE_IDENTITY="$JUDGE_IDENTITY"
 if [ -z "$JUDGE" ] || [ -z "$JUDGE_IDENTITY" ]; then
   echo "FATAL: could not resolve the judge and its identity from behavior_judge.py" >&2
   exit 2

--- a/scripts/eval/judge_ollama_bench.sh
+++ b/scripts/eval/judge_ollama_bench.sh
@@ -1,21 +1,29 @@
 #!/bin/bash
 # Grade every model's #1950 benchmark candidates with the existing Type B scorer.
 #
-# ONE MODEL PER INVOCATION, SERIALLY. `behavior_judge.py`'s default judge is the
-# headless Claude CLI on the subscription ($0). Running the models concurrently
-# would put many CLI sessions in flight at once for no wall-clock benefit worth
-# the rate-limit risk, and the whole sweep is ~20 short calls.
+# ONE MODEL PER INVOCATION, SERIALLY. Running the models concurrently would put many
+# judge sessions in flight at once for no wall-clock benefit worth the rate-limit risk,
+# and the whole sweep is ~20 short calls.
 #
-# SAME JUDGE AS EVERY OTHER TYPE B NUMBER WE HOLD (claude-sonnet-5, the harness
-# default). polish-eval.md: never mix judge models within a comparison — a
-# different judge here would make these scores incomparable to #1914's and to
-# the 1,890-case research run, which is most of the value of reusing the harness.
+# WHICHEVER JUDGE `behavior_judge.py` DEFAULTS TO, resolved once below and then passed
+# explicitly. The judge is part of the resume stamp, so changing it invalidates every
+# stamped receipt and the next sweep re-grades the whole field instead of mixing two
+# judges in one scoreboard. Do not read that as "the sweep follows the default
+# automatically" — it does now, and only because the stamp was fixed to include the
+# judge; before that, 15 stamped Sonnet receipts would have been skipped straight
+# through a switch to a different judge. The 12-arm comparison that licensed the move
+# to the Azure credits is recorded on issue #1950.
 #
-# RESUMABLE. A model whose summary.json already exists is skipped, so an
-# interrupted sweep keeps its work.
+# RESUMABLE. A prior receipt is reused only when its summary.json is cacheable AND its
+# stamp matches the candidate file, the corpus and the judge; otherwise it is discarded.
+# An arm with judgeable output is then re-judged, while an arm whose every candidate
+# errored is reported as unmeasurable and never judged at all. So an interrupted sweep
+# keeps confirmed work without reusing a doubtful result.
 #
-# FAIL CLOSED per model: a judge failure leaves no summary.json, is reported at
-# the end, and exits nonzero. It never leaves a partial score that reads as real.
+# FAIL CLOSED per model: a judge failure that leaves no summary.json is reported at the
+# end and exits nonzero. An INCOMPLETE receipt is deliberately kept on disk for diagnosis
+# but never stamped, so it is re-judged next run; it is reported and also exits nonzero.
+# Neither can be mistaken for a finished score.
 set -uo pipefail
 
 CORPUS="${1:?usage: judge_ollama_bench.sh <corpus.jsonl> <candidates-dir> <judged-dir>}"
@@ -28,6 +36,22 @@ failed=()
 skipped=()
 unmeasurable=()
 incomplete=()
+
+# Resolve the judge ONCE, from `behavior_judge.py` itself rather than from a second
+# default written here. Two defaults are a drift bug waiting to happen, and this one
+# would be invisible: the stamp would record the shell's idea of the judge while a
+# different judge did the grading. Reading DEFAULT_JUDGE also honours EW_JUDGE for
+# free, because that is where the override already lives.
+#
+# Fails closed. An empty answer would otherwise stamp `judge=` on every arm and make
+# all receipts look mutually comparable, which is the failure this whole change exists
+# to prevent.
+JUDGE="$(python3 -c 'import sys; sys.path.insert(0, sys.argv[1]); import behavior_judge; print(behavior_judge.DEFAULT_JUDGE)' "$ROOT/scripts/eval" 2>/dev/null)"
+if [ -z "$JUDGE" ]; then
+  echo "FATAL: could not resolve the default judge from behavior_judge.py" >&2
+  exit 2
+fi
+echo "=== judge: $JUDGE ===" >&2
 
 # `shasum` is Perl-provided and is NOT guaranteed by the ubuntu-latest runner
 # image, which lists coreutils (and therefore `sha256sum`). Our own pr-check.yml
@@ -101,7 +125,19 @@ for cand in "$CANDDIR"/*.jsonl; do
   # numbers with the OLD quality scores and said nothing. Same shape as the two
   # holes above it: a result whose scope is quietly narrower than it looks.
   stamp="$dest/.inputs-sha256"
-  inputs_sha="$(sha256 "$cand" "$CORPUS" | sha256 | cut -d' ' -f1)"
+  # The JUDGE is part of the inputs. Without it a receipt graded by one judge is
+  # silently reused after the default changes, which is exactly what would have
+  # happened on 2026-08-11: 15 arms carried stamped, cacheable Sonnet receipts, so a
+  # sweep under the new Azure default would have skipped every one and produced a
+  # scoreboard mixing two judges with nothing saying so. The receipt records its own
+  # judge in `meta.judge`, so the mixing was detectable and simply never checked.
+  #
+  # Consequence, and it is intended: changing the judge invalidates every stamp and
+  # the next sweep re-grades the full field. That is the only way a comparison stays
+  # a comparison, and it is affordable precisely because the new judge is cheap.
+  inputs_sha="$(
+    { printf 'judge=%s\n' "$JUDGE"; sha256 "$cand" "$CORPUS"; } | sha256 | cut -d' ' -f1
+  )"
   if [ -f "$dest/summary.json" ]; then
     # Cacheability is checked HERE too, not only after judging. A matching stamp
     # used to `continue` outright, so every arm already stamped with a partial
@@ -156,8 +192,12 @@ for cand in "$CANDDIR"/*.jsonl; do
   # receipt itself is inspected either way — a graded-but-failed run IS a
   # complete answer and must earn its stamp, or every weak model is re-judged
   # forever, which is the expensive half.
+  # `--judge "$JUDGE"` explicitly, never the implicit default: the judge that grades
+  # must be the same value that went into the stamp, and letting each side resolve it
+  # independently is how they drift.
   python3 "$ROOT/scripts/eval/behavior_judge.py" \
-    --system new --corpus "$CORPUS" --candidates "$cand" --out "$dest" >&2 || true
+    --system new --judge "$JUDGE" \
+    --corpus "$CORPUS" --candidates "$cand" --out "$dest" >&2 || true
 
   if [ -f "$dest/summary.json" ] && receipt_cacheable "$dest/summary.json"; then
     printf '%s\n' "$inputs_sha" > "$stamp"

--- a/scripts/eval/judge_ollama_bench.sh
+++ b/scripts/eval/judge_ollama_bench.sh
@@ -140,8 +140,13 @@ quarantine_previous() {
     echo "     $dest.stale is kept (a partial must never displace a complete one)" >&2
     return 0
   fi
-  rm -rf "$dest.stale"
-  mv "$dest" "$dest.stale"
+  # Returns NONZERO if the move fails. This script runs without `errexit`, so a permission or
+  # filesystem error left the helper returning success (its final `echo` succeeded), the caller
+  # then moved the staged receipt INSIDE the still-existing destination, and the stamp landed on
+  # the old receipt while the arm reported success — the nest-and-mis-stamp failure arriving
+  # through an error path rather than a logic one. Every caller now aborts the arm instead.
+  rm -rf "$dest.stale" || return 1
+  mv "$dest" "$dest.stale" || return 1
   echo "  previous receipt for $base quarantined at $dest.stale (not ranked, not stamped)" >&2
 }
 
@@ -294,7 +299,12 @@ for cand in "$CANDDIR"/*.jsonl; do
     # gradeable output, so nothing at the ranked path can be current.
     had_previous=0
     [ -e "$dest" ] && had_previous=1
-    quarantine_previous
+    if ! quarantine_previous; then
+      echo "  FAILED $base (could not move the stale receipt aside; it stays where the report" >&2
+      echo "     would rank it, so this arm is reported failed rather than silently mixed)" >&2
+      failed+=("$base")
+      continue
+    fi
     unmeasurable+=("$base")
     continue
   fi
@@ -360,8 +370,20 @@ for cand in "$CANDDIR"/*.jsonl; do
       # receipt survives in the quarantine slot and the arm is simply re-judged, so the cost is
       # one re-run rather than lost data. Auto-promoting a leftover staged receipt would risk
       # promoting one graded against different inputs, which is worse than a re-run.
-      quarantine_previous
-      mv "$staging" "$dest"
+      if ! quarantine_previous; then
+        echo "  FAILED $base (could not move the previous receipt aside; refusing to promote," >&2
+        echo "     because a move into an existing directory NESTS, and the stamp would then" >&2
+        echo "     be written onto the old receipt)" >&2
+        rm -rf "$staging"
+        failed+=("$base")
+        continue
+      fi
+      if ! mv "$staging" "$dest"; then
+        echo "  FAILED $base (could not promote the staged receipt; the previous one is at" >&2
+        echo "     $dest.stale and nothing was stamped)" >&2
+        failed+=("$base")
+        continue
+      fi
       printf '%s\n' "$inputs_sha" > "$stamp"
       echo "  ok $base" >&2
       ;;
@@ -373,18 +395,25 @@ for cand in "$CANDDIR"/*.jsonl; do
       # cacheability but never the stamp, so a valid receipt from the PREVIOUS judge sitting at
       # the canonical path gets ranked alongside newly judged arms — a corrupted comparison,
       # silently, which is the failure this whole change exists to prevent.
-      quarantine_previous
+      if ! quarantine_previous; then
+        echo "  FAILED $base (could not move the previous receipt aside)" >&2
+        rm -rf "$staging"
+        failed+=("$base")
+        continue
+      fi
       # Promote the partial: it is what the current judge actually produced, and the report
       # rejects a non-cacheable receipt loudly rather than ranking it. Never stamped, so the
       # resume branch re-judges the arm next time.
-      mv "$staging" "$dest"
+      mv "$staging" "$dest" || true
       echo "  INCOMPLETE $base (receipt is not cacheable; left in place, not stamped)" >&2
       incomplete+=("$base")
       ;;
     missing)
       # The judge refused, crashed, timed out, or lost its network before writing anything.
       rm -rf "$staging"
-      quarantine_previous
+      if ! quarantine_previous; then
+        echo "  (and the stale receipt could not be moved aside, so it stays at $dest)" >&2
+      fi
       echo "  FAILED $base" >&2
       failed+=("$base")
       ;;

--- a/scripts/eval/report_ollama_bench.py
+++ b/scripts/eval/report_ollama_bench.py
@@ -350,14 +350,37 @@ def main() -> int:
         intl = split(lambda x: x["id"] in intl_ids)
         overall = summary.get("overall", {})
         # Carried onto the row so the one-judge-per-scoreboard check below has something to read.
-        # A check reading fields the rows do not carry would group everything under (None, None)
-        # and never fire — a guard that arms nothing, which is worse than no guard because it
-        # reads as one.
-        receipt_meta = summary.get("meta") or {}
+        # A check reading fields the rows do not carry would group everything under one key and
+        # never fire — a guard that arms nothing, which is worse than no guard because it reads
+        # as one.
+        #
+        # `meta` is shape-checked, not merely defaulted: a hand-edited or truncated
+        # `"meta": [...]` is truthy, so `or {}` leaves a list and the `.get()` below raises
+        # AttributeError — aborting the whole report with a traceback instead of naming the one
+        # bad receipt, which is what the surrounding per-model handling exists to do.
+        # ABSENT and MALFORMED are different states and must not be conflated. A receipt with no
+        # `meta` at all is a legacy one and ranks fine; a receipt whose `meta` is present but not
+        # an object has been truncated or hand-edited and cannot be trusted to say who graded it.
+        # Treating absent as malformed rejected every pre-meta receipt, which the existing
+        # fixtures caught immediately.
+        receipt_meta = summary.get("meta")
+        if receipt_meta is None:
+            receipt_meta = {}
+        elif not isinstance(receipt_meta, dict):
+            problems.append(
+                f"{model} ({cand_stem}): receipt `meta` is {type(receipt_meta).__name__}, not an "
+                f"object, so its judge cannot be identified")
+            receipt_meta = {}
         rows.append({
             "model": model,
             "arm": cand_stem,
+            # A POSITIVE marker that this row came from a receipt. The judge check skips rows
+            # without it. Inferring "no receipt" from a missing judge field was how an
+            # unmeasurable arm — every case errored, so no receipt exists — got counted as its
+            # own judge and made any benchmark containing one falsely unreportable.
+            "from_receipt": True,
             "judge": receipt_meta.get("judge"),
+            "judge_identity": receipt_meta.get("judge_identity"),
             "judge_model_version": receipt_meta.get("judge_model_version"),
             "isRemote": sp["isRemote"],
             "thinks": sp["thinks"],
@@ -391,18 +414,26 @@ def main() -> int:
     # be repointed in place, so `judge_model_version` distinguishes two runs that share an id.
     # A receipt written before that field existed reports None, which groups with other legacy
     # receipts and still separates them from anything newer.
+    # Compares the FULL identity the sweep computed, not just the judge id and model version.
+    # `judge_identity` folds in the endpoint host and the API version too, so two different Azure
+    # resources that happen to serve the same model string no longer compare equal — which the
+    # earlier (judge, version) pair could not distinguish even though the resume stamp already
+    # did. None groups with None, so a field of legacy receipts still ranks together while
+    # mixing a legacy receipt with an identified one refuses, because their provenance genuinely
+    # cannot be shown to match.
     judges = {}
     for row in rows:
-        if row.get("skipped_reason"):
-            continue
-        judges.setdefault((row.get("judge"), row.get("judge_model_version")), []).append(
-            row.get("model"))
+        if not row.get("from_receipt"):
+            continue          # unmeasurable or skipped: no receipt, so no judge to compare
+        judges.setdefault(
+            (row.get("judge"), row.get("judge_identity"), row.get("judge_model_version")),
+            []).append(row.get("model"))
     if len(judges) > 1:
         detail = "; ".join(
-            f"{j[0]}"
-            + (f" ({j[1]})" if j[1] else "")
+            f"{j[1] or j[0]}"
+            + (f" serving {j[2]}" if j[2] else "")
             + f": {', '.join(sorted(m for m in models if m))}"
-            for j, models in sorted(judges.items(), key=lambda kv: str(kv[0])))
+            for j, models in sorted(judges.items(), key=lambda kv: str(kv)))
         problems.append(
             "this run mixes judges, so the ranking would not be a comparison — "
             f"{detail}. Re-grade every arm with one judge.")

--- a/scripts/eval/report_ollama_bench.py
+++ b/scripts/eval/report_ollama_bench.py
@@ -425,9 +425,21 @@ def main() -> int:
     for row in rows:
         if not row.get("from_receipt"):
             continue          # unmeasurable or skipped: no receipt, so no judge to compare
-        judges.setdefault(
-            (row.get("judge"), row.get("judge_identity"), row.get("judge_model_version")),
-            []).append(row.get("model"))
+        # Each field is coerced to a hashable str-or-None. A malformed nested value — a
+        # hand-edited `"judge_identity": []` inside an otherwise well-formed `meta` — makes the
+        # tuple unhashable and `setdefault` aborts the whole report with a TypeError, which is
+        # the same failure the outer `meta` shape check was added to prevent, one level in.
+        # Shape-checking a container and then trusting its contents is half a check.
+        key = []
+        for field in ("judge", "judge_identity", "judge_model_version"):
+            value = row.get(field)
+            if value is not None and not isinstance(value, str):
+                problems.append(
+                    f"{row.get('model')} ({row.get('arm')}): receipt `meta.{field}` is "
+                    f"{type(value).__name__}, not a string, so its judge cannot be identified")
+                value = None
+            key.append(value)
+        judges.setdefault(tuple(key), []).append(row.get("model"))
     if len(judges) > 1:
         detail = "; ".join(
             f"{j[1] or j[0]}"

--- a/scripts/eval/report_ollama_bench.py
+++ b/scripts/eval/report_ollama_bench.py
@@ -349,9 +349,16 @@ def main() -> int:
         eng = split(lambda x: x["id"] not in intl_ids)
         intl = split(lambda x: x["id"] in intl_ids)
         overall = summary.get("overall", {})
+        # Carried onto the row so the one-judge-per-scoreboard check below has something to read.
+        # A check reading fields the rows do not carry would group everything under (None, None)
+        # and never fire — a guard that arms nothing, which is worse than no guard because it
+        # reads as one.
+        receipt_meta = summary.get("meta") or {}
         rows.append({
             "model": model,
             "arm": cand_stem,
+            "judge": receipt_meta.get("judge"),
+            "judge_model_version": receipt_meta.get("judge_model_version"),
             "isRemote": sp["isRemote"],
             "thinks": sp["thinks"],
             "thinkSent": sp["thinkSent"],
@@ -369,6 +376,36 @@ def main() -> int:
             "intl": intl,
             "failure_types": overall.get("failure_type_counts", {}),
         })
+
+    # ONE JUDGE PER SCOREBOARD, enforced here because this is the layer that combines arms.
+    #
+    # This closes a class the sweep cannot close from its side, and cloud review pointed at it
+    # three times before I moved: a partial sweep, an interrupted sweep, a hand-copied receipt or
+    # a repointed deployment all leave some arms graded by one judge and some by another. The
+    # sweep was patched repeatedly to keep stale receipts out of this path, but a ranking that
+    # combines receipts is the thing that has to check they are comparable — validating a receipt
+    # by whether it PARSES, and never by who produced it, is what let every one of those routes
+    # through.
+    #
+    # Reads the identity the receipt carries. `judge` alone is not enough: an Azure deployment can
+    # be repointed in place, so `judge_model_version` distinguishes two runs that share an id.
+    # A receipt written before that field existed reports None, which groups with other legacy
+    # receipts and still separates them from anything newer.
+    judges = {}
+    for row in rows:
+        if row.get("skipped_reason"):
+            continue
+        judges.setdefault((row.get("judge"), row.get("judge_model_version")), []).append(
+            row.get("model"))
+    if len(judges) > 1:
+        detail = "; ".join(
+            f"{j[0]}"
+            + (f" ({j[1]})" if j[1] else "")
+            + f": {', '.join(sorted(m for m in models if m))}"
+            for j, models in sorted(judges.items(), key=lambda kv: str(kv[0])))
+        problems.append(
+            "this run mixes judges, so the ranking would not be a comparison — "
+            f"{detail}. Re-grade every arm with one judge.")
 
     if problems:
         print("FAIL: incomplete receipts:\n  " + "\n  ".join(problems), file=sys.stderr)

--- a/scripts/eval/run_cloud_type_b.py
+++ b/scripts/eval/run_cloud_type_b.py
@@ -47,8 +47,11 @@ Usage:
       --corpus scripts/eval/corpus/type_b_parakeet.jsonl \\
       --out scripts/eval/runs/type-b-luna/candidates.jsonl
 
-Score the result with the SAME judge the baseline used:
-  python3 scripts/eval/behavior_judge.py --system new --judge claude-sonnet-5 \\
+Score the result with the SAME judge every other arm of the comparison used. That is
+the harness default (`azure/gpt-5-6-luna` since 2026-08-11), unless you are extending
+an older Sonnet-graded set, in which case pass `--judge claude-sonnet-5` and re-grade
+the whole set rather than mixing:
+  python3 scripts/eval/behavior_judge.py --system new \\
     --corpus scripts/eval/corpus/type_b_parakeet.jsonl \\
     --candidates <out> --out <run-dir>/scores
 """


### PR DESCRIPTION
Moves polish grading off the Claude subscription and onto the expiring Azure startup credits, and makes grading on a personal API key impossible rather than discouraged.

Part of #1950.

## Why

Founder directive 2026-08-11. The decision is about which scarce resource each option burns, not about accuracy:

- **Codex CLI** is the primary adversarial reviewer across concurrent sessions. Grading on it competes with the one job nothing substitutes for, and drains a weekly budget already at its limit.
- **The Claude subscription** is building capacity, roughly 99% used by Thursday most weeks.
- **The Azure credits expire unspent.** Grading is bulk, parallel and latency-tolerant, so it is the ideal load to move there.
- **Personal API keys are banned for grading.** That is the founder's own money.

## Validated before switching

12 local arms, identical candidates and corpus, only the judge changed.

**0 of 12 shipped labels move.** Median signed pass-rate change 0.0pp. Per-case exact verdict agreement 78%; on the acceptable-vs-not call a label depends on, 20/20 on eight of twelve arms.

I read both rationales on all four disagreements for one arm by hand. Three were substantive and the new judge was right in all three: an unformatted spoken list the old judge passed, a dropped word it missed entirely, and unnecessary edits to a trap case including a subject-verb error. Full comparison on #1950.

It also completed the one arm the old judge could not. That arm had four cases unscored, which had forced a hand adjudication and an entire planned mechanism for the report generator. The cause was a judge chunk returning an empty reply three times, not ungradeable content. That planned work is deleted rather than built.

## Two defects found in review

**A resumed sweep would have silently mixed two judges.** The resume stamp covered the candidate and corpus files but not the judge, so the 15 already-stamped receipts on disk would have been skipped straight through the switch. The next sweep would have produced one scoreboard containing two different graders with nothing saying so. The receipts recorded their own judge all along; nobody was checking it. The judge is now part of the stamp, so changing it re-grades the field.

**The billing refusal sat above the transport instead of at it.** It ran in the command-line path only, so any direct call into the grading functions bypassed it. Now: routing and the billing decision read one shared table, so they cannot drift; the refusal runs inside the dispatcher; and the two transports that bill a personal key are **deleted**, not merely unrouted. A refusal is a promise, an absent function is a fact.

Also fixed: the Azure endpoint is checked before the credential is read, because the lookup reads the environment first and an inherited or mistyped endpoint would have handed our key to another host. Redirects are refused, since a validated host can still bounce elsewhere and urllib replays headers. This checks the Azure hostname shape rather than pinning one resource; it contains the inherited-or-mistyped risk and is not an allowlist against a deliberately supplied Azure hostname.

## Verification

Live against the real deployment: a normal reply returns text; a full run with no judge flag grades correctly on the new default; three non-funded ids exit 2 before any network call; `temperature: 0` and `max_tokens` are both rejected HTTP 400, so the comments quote the API's own words; and at caps of 16, 300, 800 and 2000 tokens the deployment returns `finish_reason: length` with empty content, never a partial array, which is why there is no partial-reply branch.

19 new tests, suite counter 67 to 86 with none removed, already run by `build-check`. Three mutation controls: reverting the allowlist to the old denylist fails three, stripping the judge from the stamp fails seven, disabling the token-cap branch fails one.

**One finding was in the existing tests.** Several shell cases assert what a receipt or stamp does *not* contain, which is equally true of a script that died before doing any work. When the new stamp logic made the script exit early, all 86 tests stayed green while judging nothing. The shared runner now requires the script to reach one of its two terminal outcomes, verified against two true early deaths.

## Review

Five Codex rounds. Round 5: explicit all-clear, no functional, security, credential, billing, routing or resume defect. Rounds 3 and 4 were entirely accuracy findings, several of them introduced by the previous round's corrections — including a false wobble number I had already published, and a claim that Anthropic model names are refused when they are not.
