### PR TITLE
fix(recovery): an empty result is counted, not alerted

### DIFF
--- a/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
@@ -428,14 +428,62 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
     }
   }
 
+  /// Reasons that are COUNTED but never alert (#1942).
+  ///
+  /// `empty_text` means the recovered audio was transcribed without error and
+  /// ASR returned nothing. That is not a defect of ours: the overwhelmingly
+  /// likely cause is a recording with no speech in it, and #1900 created this
+  /// reason precisely so it would stop inflating `recovery_transcribe_failed`
+  /// and producing the false P0 in #1813. Splitting it out fixed the
+  /// CONFLATION; it left the benign half filing its own alerting error, which
+  /// is the loop this closes.
+  ///
+  /// Evidence that it is not actionable, rather than an assumption: this issue
+  /// was re-triaged on four consecutive days and every pass reached the same
+  /// verdict — best-effort post-crash replay, no live-dictation impact, hold at
+  /// P3. A condition whose triage conclusion never moves is a counted outcome
+  /// sitting on the wrong channel.
+  ///
+  /// NOTHING GOES DARK, and that was measured before the alert was removed:
+  /// `recovery.completed` already carries `reason`, and production on 2.4.3
+  /// shows `empty_text` at 13 events / 5 people — the SAME 13/5 the Sentry
+  /// fingerprint carries. The count is complete without the error.
+  ///
+  /// Deliberately narrow. `transcribe_error` (ASR threw), `model_load_failed`,
+  /// `key_missing`, `decrypt` and every future reason keep alerting: those are
+  /// ours. The general principle: Sentry errors are for OUR defects, while a
+  /// user-environment or expected outcome is counted in analytics and carries a
+  /// breadcrumb for context, never an alert.
+  nonisolated static func isCountedNotAlerted(_ reason: RecoveryTelemetryReason) -> Bool {
+    switch reason {
+    case .emptyText: return true
+    // Listed exhaustively rather than with a `default`, so a NEW reason is a
+    // compile error here and someone has to decide its channel on purpose
+    // instead of inheriting silence.
+    case .keyMissing, .keyReadFailed, .reconstructionFailed, .emptyOrUnreadableSamples,
+      .modelLoadFailed, .transcribeError, .saveFailed, .markerWriteFailed,
+      .markerClearFailed, .attemptAlreadySpent, .keychainTransient:
+      return false
+    }
+  }
+
+
   private func failUnrecoverable(
     reason: RecoveryTelemetryReason,
     failureClass: RecoveryFailureClass? = nil,
     reconstructedSampleCount: Int? = nil
   ) -> RecoveryReplayOutcome {
     let category = Self.category(for: reason)
-    SentryBreadcrumb.captureError(
-      RecoveryReplayError.failed(reason.rawValue), category: category, stage: "recovery")
+    if Self.isCountedNotAlerted(reason) {
+      SentryBreadcrumb.add(
+        stage: "recovery",
+        message: "recovery.outcome=\(reason.rawValue)",
+        level: .info,
+        data: ["recovery.reason": reason.rawValue])
+    } else {
+      SentryBreadcrumb.captureError(
+        RecoveryReplayError.failed(reason.rawValue), category: category, stage: "recovery")
+    }
     let spoolSeconds = reconstructedSampleCount.map {
       Int((Double($0) / AudioConstants.sampleRate).rounded())
     }

--- a/Tests/EnviousWisprTests/Recovery/RecoveryFailureCategoryTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryFailureCategoryTests.swift
@@ -128,4 +128,35 @@ import Testing
         "\(reason.rawValue) changed category — is that deliberate?")
     }
   }
+
+  @Test("only the empty-result outcome is counted without alerting (#1942)")
+  func onlyEmptyTextIsCountedNotAlerted() {
+    // `empty_text` means ASR ran cleanly and returned nothing — almost always a
+    // recording with no speech in it, and re-triaged to the same P3 verdict on
+    // four consecutive days. It is counted by `recovery.completed` (measured
+    // 13 events / 5 people on 2.4.3, matching the Sentry fingerprint exactly),
+    // so removing its alert loses no visibility.
+    #expect(RecoverySpoolReplayer.isCountedNotAlerted(.emptyText))
+
+    // THE TWO-WAY CONTROL, and the whole safety of this change: every reason
+    // that IS ours must still alert. A blanket downgrade would pass the
+    // assertion above while silencing a real ASR throw or a decrypt failure.
+    let mustAlert: [RecoveryTelemetryReason] = [
+      .keyMissing, .keyReadFailed, .reconstructionFailed, .emptyOrUnreadableSamples,
+      .modelLoadFailed, .transcribeError, .saveFailed, .markerWriteFailed,
+      .markerClearFailed, .attemptAlreadySpent, .keychainTransient,
+    ]
+    for reason in mustAlert {
+      #expect(
+        !RecoverySpoolReplayer.isCountedNotAlerted(reason),
+        "\(reason.rawValue) must keep alerting — it is a failure we own")
+    }
+
+    // Completeness: the two lists together must cover the enum, so a NEW reason
+    // cannot be silently added to neither and inherit a channel by accident.
+    // `isCountedNotAlerted` switches exhaustively with no `default`, so a new
+    // case is already a compile error there; this asserts the TEST stays
+    // exhaustive too, which the compiler cannot do for an array literal.
+    #expect(mustAlert.count + 1 == 12, "a reason was added — give it a channel here")
+  }
 }


### PR DESCRIPTION
Closes #1942.

## What this changes

`recovery_empty_text` stops filing an alerting Sentry error and becomes a counted outcome with a breadcrumb. Nothing else about recovery changes: same behaviour, same PostHog events, no user-visible difference.

## Why it is benign

It means the recovered audio decrypted and transcribed **without error**, and ASR returned nothing — overwhelmingly a recording with no speech in it. #1900 created this reason precisely so it would stop inflating `recovery_transcribe_failed` and producing the false P0 in #1813. That fixed the *conflation* and left the benign half filing its own alerting error. This closes that loop.

The strongest evidence is the issue's own history: **re-triaged on four consecutive days, every pass reaching the same verdict** — best-effort post-crash replay, no live-dictation impact, hold at P3. A condition whose triage conclusion never moves is a counted outcome sitting on the wrong channel.

## Nothing goes dark, and that was measured first

The whole risk of removing an alert is that a genuine rise becomes invisible. Checked before touching anything:

| source | events | people |
|---|---:|---:|
| Sentry `ENVIOUSWISPR-4N` (2.4.3) | 13 | 5 |
| PostHog `recovery.completed` `reason=empty_text` (2.4.3) | **13** | **5** |

An exact 1:1 match, so the count is complete without the error and a rise stays fully visible.

## Deliberately narrow

Every other reason keeps alerting, because those are ours:

- `transcribe_error` — ASR actually threw (6 events / 2 people on the same build)
- `model_load_failed`, `key_missing`, `key_read_failed`, `reconstruction_failed`, `empty_or_unreadable_samples`, `save_failed`, `marker_write_failed`, `marker_clear_failed`, `attempt_already_spent`, `keychain_transient`

The test asserts each of those **eleven by name**, so a blanket downgrade fails rather than passes. `isCountedNotAlerted` switches exhaustively with no `default`, so a new reason is a compile error and someone has to choose its channel on purpose instead of inheriting silence.

## Verification

- Recovery suite 6 → 7 tests; full suite green.
- **Mutation control:** making `empty_text` alert again fails exactly the new test and nothing else.
- **Two-way control:** the eleven must-alert reasons are asserted individually, plus a count check so adding a reason without giving it a channel fails.

## Two defects in my own first draft, caught before review

Worth recording because both are silent:

1. The new doc comment was spliced into the **middle** of `category(for:)`'s comment, leaving that one truncated and mine attached to the wrong symbol. Fixed by moving the function after it.
2. It cited a knowledge file **by bare filename** from shipped code, which `no-dotclaude-from-shipped-code` forbids — and which a path-shaped grep would not have found, since there was no `.claude/` prefix to match. The principle is now inlined instead of referenced.

## Context

This was one of two noise items. The other (#1332, paste) was investigated and **dropped**: its remaining noise is not safely separable from real paste failures until the role classification gains a third state (#1435). Reasoning recorded on that issue; no branch left behind.
