### PR TITLE
perf(paste): ask the cheap terminal question first, not last

### DIFF
--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -835,7 +835,11 @@ public enum PasteService {
 
     let dependencies = TerminalContextResolver.Dependencies(
       bundleIdentifier: { NSRunningApplication(processIdentifier: pid)?.bundleIdentifier },
-      scanProcesses: { TerminalProcessScanner.liveSnapshot() },
+      // The FILTERED sweep (#1943). Gate 1 only ever accepts a process holding a
+      // controlling terminal, so reading every other process's argv/environment
+      // blob was work whose result was always discarded — and it was the step
+      // that blew the budget and latched terminal insertion off (#1941).
+      scanProcesses: { TerminalProcessScanner.liveTerminalSnapshot() },
       readScreenTail: {
         budget.step(applying: fresh, label: "screen") { terminalScreenTail(of: fresh) }
       })

--- a/Sources/EnviousWisprServices/TerminalContextResolver.swift
+++ b/Sources/EnviousWisprServices/TerminalContextResolver.swift
@@ -360,17 +360,27 @@ package enum TerminalContextResolver {
     // Timed from out here because the process sweep is NOT an accessibility
     // call, so nothing else charges it.
     //
-    // COST, re-measured 2026-08-05 and corrected: this line previously read
-    // "Measured mean 3 ms / p95 7 ms", and that number is what the old 100 ms
-    // cap was sized against. On the real path it is 4x to 40x higher. The app's
-    // own trace across one ordinary session: 36, 49, 54, 61, 77, 77, then
-    // 114.7 ms — the last exhausted the whole cap here and tripped the breaker
-    // (#1941). A later clean session ran 60-65 ms per dictation. Standalone, the
-    // shipped scanner spans 13 ms to 862 ms depending on queue and machine load.
+    // COST — history, because the numbers here are why the budget is the size it
+    // is and a future reader will otherwise re-derive them.
     //
-    // This step is therefore the dominant consumer of the budget, not a rounding
-    // error, and #1943 exists to make it cheap. Do not restore the 3 ms figure,
-    // and do not size anything against it.
+    // This line once read "Measured mean 3 ms / p95 7 ms", and that number is
+    // what the original 100 ms cap was sized against. It was false on the real
+    // path by 4x to 40x. The app's own trace across one ordinary session ran 36,
+    // 49, 54, 61, 77, 77, then 114.7 ms — the last exhausted the whole cap in
+    // this single step and tripped the breaker, which silently turned terminal
+    // insertion off for the rest of that terminal's life (#1941). The founder
+    // raised the cap to 200 ms as an interim (#1945).
+    //
+    // FIXED in #1943: the sweep now asks the cheap, highly selective
+    // controlling-terminal question FIRST and reads the expensive argv/
+    // environment blob only for the ~3% of processes that pass it. Measured 6.5x
+    // cheaper at mean AND p95, with the veto's answer provably unchanged —
+    // `supportedCLIs` already required that same flag as its first guard.
+    //
+    // Do not restore the 3 ms figure, and do not size anything against it. If
+    // this step ever becomes the dominant consumer again, the next lever is a
+    // per-terminal cache (#1943 considered and declined it: no invalidation
+    // story was needed once the sweep got cheap).
     //
     // Every other step in the same traces is under 0.5 ms.
     let scanStart = dependencies.now()

--- a/Sources/EnviousWisprServices/TerminalProcessScanner.swift
+++ b/Sources/EnviousWisprServices/TerminalProcessScanner.swift
@@ -219,27 +219,137 @@ package enum TerminalProcessScanner {
   /// telemetry distinguishes them; an optional invites erasing that at the one
   /// call site where it matters.
   ///
-  /// No pre-filter by executable name. Measured cost for the whole sweep is
-  /// mean 3 ms / p95 7 ms against a 100 ms budget (710 processes, hardened
-  /// runtime, Developer-ID signed), so filtering would buy nothing while adding
-  /// a hand-authored guess about how CLIs are launched — the guess that would
-  /// silently drop an unusual install.
+  /// No pre-filter by executable name, and that half of the old note still
+  /// stands: a filter that guesses how a CLI is LAUNCHED — binary names, install
+  /// paths, argv shapes — is a hand-authored membership set that silently drops
+  /// an unusual install.
+  ///
+  /// **The COST half of that note was false and is deleted (#1943).** It read
+  /// "mean 3 ms / p95 7 ms against a 100 ms budget, so filtering would buy
+  /// nothing". On the real path this sweep is the budget's dominant consumer:
+  /// the app's own trace across one ordinary session ran 36, 49, 54, 61, 77,
+  /// 77 ms and then 114.7 ms, which exhausted the whole cumulative budget in
+  /// this one step and tripped the circuit breaker (#1941). Every accessibility
+  /// read in the same traces is under 0.5 ms. Do not restore the 3 ms figure and
+  /// do not size anything against it.
+  ///
+  /// The veto no longer calls this; it calls ``liveTerminalSnapshot()``, which
+  /// filters on a structural kernel fact rather than on launch shape. This entry
+  /// point remains the honest general reader — it returns EVERY readable
+  /// process, including the ones holding no terminal — and the live tests rely
+  /// on exactly that.
   static func liveSnapshot() -> TerminalProcessScan {
-    guard let pids = allProcessIdentifiers() else { return .unavailable }
+    sweep(prefilterByTerminal: false)
+  }
+
+  /// Snapshot only the processes that hold a controlling terminal — the sweep
+  /// the veto actually needs.
+  ///
+  /// Identical to ``liveSnapshot()`` except that it asks
+  /// ``holdsControllingTerminal(_:)`` FIRST and reads the executable path and
+  /// the argv/environment blob only for the survivors.
+  ///
+  /// **At one observation point this cannot change the veto's answer, and that
+  /// is structural rather than lucky:** `supportedCLIs(in:hostedBy:)`'s own first
+  /// guard is `guard snapshot.isAttachedToTerminal`, so every process dropped
+  /// here would have been dropped one step later anyway. The predicate is not
+  /// duplicated — both sites call this same function.
+  ///
+  /// **Exact TEMPORAL equivalence is not claimed**, because the change moves the
+  /// observation earlier in the per-process sequence. See the note at the guard
+  /// below for the window and why it is bounded.
+  ///
+  /// **Why it is worth a second entry point.** Measured on an 807-process
+  /// machine with the shipped source compiled verbatim (artifacts in
+  /// `docs/feature-requests/issue-1943-artifacts/`): only 24 processes (3.0%)
+  /// hold a terminal, and the tty check is simultaneously the CHEAPEST
+  /// per-process primitive and the most selective filter.
+  ///
+  /// | over all 807 pids | mean |
+  /// |---|---|
+  /// | `proc_pidinfo` (this check) | 0.35 ms |
+  /// | `proc_pidpath` | 1.71 ms |
+  /// | `sysctl KERN_PROCARGS2` | 5.58 ms |
+  ///
+  /// Whole sweep, interleaved A/B, n=100: 5.54 ms mean / 6.13 ms p95 unfiltered
+  /// versus 0.86 ms / 0.94 ms filtered — 6.5x at both. An equivalence control
+  /// over 300 comparisons found 0 mismatches with 100 positive findings.
+  ///
+  /// This is NOT the launch-shape guess that ``liveSnapshot()``'s note warns
+  /// about: holding a controlling terminal is a fact read from the kernel about
+  /// the process, not a prediction about how somebody installed it.
+  static func liveTerminalSnapshot() -> TerminalProcessScan {
+    sweep(prefilterByTerminal: true)
+  }
+
+  /// The one process-sweep both entry points run.
+  ///
+  /// Written as a single worker rather than two loops so the PID walk, the
+  /// fail-closed skips, and the `.unavailable` contract cannot drift apart —
+  /// the two entry points differ by exactly one boolean.
+  ///
+  /// Every kernel read is injected so the sweep is testable WITHOUT a real
+  /// process table. That matters more than it looks: CI runs the Debug suite on
+  /// a hosted runner where nothing holds a controlling terminal, so a test
+  /// driven by live processes would SKIP there and the filter would have no
+  /// regression gate at all.
+  ///
+  /// - Parameter prefilterByTerminal: when true, ask the cheap
+  ///   controlling-terminal question first and read nothing else for processes
+  ///   that fail it.
+  static func sweep(
+    prefilterByTerminal: Bool,
+    pids: () -> [pid_t]? = { allProcessIdentifiers() },
+    holdsTerminal: (pid_t) -> Bool = { holdsControllingTerminal($0) },
+    path: (pid_t) -> String? = { executablePath(of: $0) },
+    argumentsAndEnvironment: (pid_t) -> (arguments: [String], environment: [String: String])? = {
+      Self.argumentsAndEnvironment(of: $0)
+    }
+  ) -> TerminalProcessScan {
+    guard let identifiers = pids() else { return .unavailable }
     var snapshots: [TerminalProcessSnapshot] = []
-    snapshots.reserveCapacity(pids.count)
-    for pid in pids {
-      guard let path = executablePath(of: pid) else { continue }
+    // Allocation hint only, never a limit — the array grows if it is wrong.
+    // 32 is sized from the measured population (24 of 807 held a terminal on an
+    // ordinary day); reserving all ~810 for the filtered sweep would allocate
+    // 97% waste on every dictation.
+    snapshots.reserveCapacity(prefilterByTerminal ? 32 : identifiers.count)
+    for pid in identifiers {
+      // The cheap, selective discriminator first, when the caller wants it. A
+      // process that exits between this call and the reads below simply drops
+      // out at one of them, exactly as in the unfiltered sweep; every primitive
+      // fails closed.
+      //
+      // Honest limit, stated because it is real rather than because it matters:
+      // this reads the tty flag BEFORE the argv/environment blob, where the
+      // unfiltered sweep reads it after. A process that gained or lost its
+      // controlling terminal in that microsecond window is classified at a
+      // slightly different instant. That is not a NEW race — the unfiltered
+      // sweep has the mirror of it — and neither instant is more correct. The
+      // only process it can affect is one whose terminal is opening or closing
+      // mid-sweep, and Gate 1 is a veto whose worst outcome is the already
+      // accepted class: a wrong space or capital in one sentence, never a wrong
+      // destination.
+      var attached = true
+      if prefilterByTerminal {
+        guard holdsTerminal(pid) else { continue }
+      } else {
+        // Unfiltered: the flag is still reported, read in its original position
+        // after the other two so this entry point's timing is unchanged.
+        attached = false
+      }
+      guard let executablePath = path(pid) else { continue }
       // Reading another user's or root's process is refused by the kernel for
       // roughly a third of PIDs. That is expected and is not an error.
-      guard let (arguments, environment) = argumentsAndEnvironment(of: pid) else { continue }
+      guard let (arguments, environment) = argumentsAndEnvironment(pid) else { continue }
       snapshots.append(
         TerminalProcessSnapshot(
           processIdentifier: pid,
-          executablePath: path,
+          executablePath: executablePath,
           arguments: arguments,
           termProgram: environment["TERM_PROGRAM"],
-          isAttachedToTerminal: holdsControllingTerminal(pid)))
+          // Filtered: true by construction, the guard above is the only way in.
+          // Unfiltered: read here, exactly where it was read before.
+          isAttachedToTerminal: attached ? true : holdsTerminal(pid)))
     }
     return .available(snapshots)
   }

--- a/Tests/EnviousWisprTests/Services/TerminalProcessScannerTests.swift
+++ b/Tests/EnviousWisprTests/Services/TerminalProcessScannerTests.swift
@@ -419,4 +419,187 @@ struct TerminalProcessScannerTests {
       "only \(withArguments) processes yielded arguments — argument parsing regressed")
   }
 
+  // MARK: - Filtered sweep (#1943)
+
+  /// Whether this machine has any process holding a controlling terminal.
+  ///
+  /// A hosted CI runner generally has none, and a live control that cannot
+  /// possibly find one would pass VACUOUSLY rather than prove anything. Gating
+  /// makes it SKIP there and RUN here, instead of reporting a green that carries
+  /// no information.
+  static func machineHasATerminalProcess() -> Bool {
+    guard case .available(let snapshots) = TerminalProcessScanner.liveTerminalSnapshot() else {
+      return false
+    }
+    return snapshots.isEmpty == false
+  }
+
+  @Test("Pre-filtering by the terminal flag cannot change the veto's answer")
+  func filteringByTerminalFlagCannotChangeTheVeto() {
+    // The whole #1943 change rests on this one claim, so it is frozen against a
+    // FIXTURE rather than against live data: deterministic, and non-vacuous
+    // because the list deliberately contains both a real CLI that would be kept
+    // and decoys that must be dropped either way.
+    let snapshots = [
+      // Claude Code's executable is named after its VERSION, so `argv[0]` is the
+      // only place its name appears — a fixture without it silently identifies
+      // nothing, which is what the two-way control at the end of this test
+      // caught when it was missing.
+      snapshot(101, claudePath, ["claude"], term: "ghostty"),
+      snapshot(102, homebrewCodexPath, term: "ghostty"),
+      // Detached lookalikes — dropped by the veto today, and dropped earlier by
+      // the filtered sweep. Both routes must agree.
+      snapshot(
+        201, "/Applications/ChatGPT.app/Contents/Resources/codex", term: "ghostty",
+        terminal: false),
+      // Carries `argv[0]` too, so it WOULD identify as Claude Code but for the
+      // terminal flag — a decoy the flag alone rejects, which is the point.
+      snapshot(202, claudePath, ["claude"], term: "ghostty", terminal: false),
+      // A terminal-holding process that is not a supported CLI at all.
+      snapshot(203, "/bin/zsh", term: "ghostty"),
+    ]
+    let preFiltered = snapshots.filter(\.isAttachedToTerminal)
+    #expect(
+      preFiltered.count == 3, "fixture must exercise the filter, not sit entirely on one side")
+
+    for surface in TerminalSurface.allCases {
+      let unfiltered = TerminalProcessScanner.supportedCLIs(in: snapshots, hostedBy: surface)
+      let filtered = TerminalProcessScanner.supportedCLIs(in: preFiltered, hostedBy: surface)
+      #expect(unfiltered == filtered, "veto disagreed for \(surface)")
+    }
+    // Two-way control: the fixture actually produces a positive, so an
+    // implementation returning nothing everywhere could not pass this.
+    #expect(TerminalProcessScanner.supportedCLIs(in: snapshots, hostedBy: .ghostty).count == 2)
+  }
+
+  @Test("The filter skips the expensive reads entirely for a detached process")
+  func filteredSweepDoesNotReadDetachedProcesses() {
+    // THE CI REGRESSION GATE. Every other test of this filter needs a real
+    // process holding a controlling terminal, which a hosted runner does not
+    // have — they SKIP there, or pass vacuously on an empty result. This one
+    // injects the process table, so it runs everywhere and actually asserts the
+    // saving the whole change exists for: the expensive reads are never even
+    // attempted for a detached PID.
+    var pathReads: [pid_t] = []
+    var blobReads: [pid_t] = []
+
+    let scan = TerminalProcessScanner.sweep(
+      prefilterByTerminal: true,
+      pids: { [101, 202] },
+      holdsTerminal: { $0 == 202 },
+      path: {
+        pathReads.append($0)
+        return "/opt/homebrew/bin/codex"
+      },
+      argumentsAndEnvironment: {
+        blobReads.append($0)
+        return (["codex"], ["TERM_PROGRAM": "ghostty"])
+      })
+
+    #expect(pathReads == [202], "executable path was read for a detached process")
+    #expect(blobReads == [202], "the argv/environment blob was read for a detached process")
+
+    guard case .available(let snapshots) = scan else {
+      Issue.record("expected .available")
+      return
+    }
+    #expect(snapshots.map(\.processIdentifier) == [202])
+    #expect(snapshots.first?.isAttachedToTerminal == true)
+  }
+
+  @Test("Without the prefilter the same sweep reads every process — the two-way control")
+  func unfilteredSweepReadsEveryProcess() {
+    // Mutation control for the test above: identical injection, prefilter off.
+    // If the guard stopped doing the filtering, the two tests would agree and
+    // this pair would no longer discriminate.
+    var pathReads: [pid_t] = []
+
+    let scan = TerminalProcessScanner.sweep(
+      prefilterByTerminal: false,
+      pids: { [101, 202] },
+      holdsTerminal: { $0 == 202 },
+      path: {
+        pathReads.append($0)
+        return "/opt/homebrew/bin/codex"
+      },
+      argumentsAndEnvironment: { _ in (["codex"], ["TERM_PROGRAM": "ghostty"]) })
+
+    #expect(pathReads == [101, 202], "the unfiltered sweep must still read every process")
+
+    guard case .available(let snapshots) = scan else {
+      Issue.record("expected .available")
+      return
+    }
+    // And it still reports the flag truthfully rather than hard-coding it.
+    #expect(snapshots.map(\.processIdentifier) == [101, 202])
+    #expect(snapshots.first(where: { $0.processIdentifier == 101 })?.isAttachedToTerminal == false)
+    #expect(snapshots.first(where: { $0.processIdentifier == 202 })?.isAttachedToTerminal == true)
+  }
+
+  @Test("An unreadable PID list is .unavailable in both sweep modes")
+  func sweepPreservesUnavailable() {
+    // `.unavailable` must not collapse into `.available([])` — the distinction
+    // the typed result exists to protect, now checked for the new entry point.
+    for prefilter in [true, false] {
+      let scan = TerminalProcessScanner.sweep(
+        prefilterByTerminal: prefilter,
+        pids: { nil },
+        holdsTerminal: { _ in true },
+        path: { _ in "/bin/zsh" },
+        argumentsAndEnvironment: { _ in ([], [:]) })
+      #expect(scan == .unavailable, "prefilter=\(prefilter) lost the unavailable distinction")
+    }
+  }
+
+  @Test("The filtered sweep returns only processes holding a controlling terminal")
+  func filteredSweepReportsOnlyTerminalHolders() {
+    guard case .available(let snapshots) = TerminalProcessScanner.liveTerminalSnapshot() else {
+      Issue.record("process enumeration was unavailable")
+      return
+    }
+    // Environment-independent: true on a runner that finds none, and the
+    // contract that lets `isAttachedToTerminal: true` be hard-coded in the sweep.
+    // Counted outside the macro because `allSatisfy` is `rethrows`, which
+    // `#expect` cannot prove non-throwing; counts also name the offender.
+    let detached = snapshots.filter { $0.isAttachedToTerminal == false }.count
+    let pathless = snapshots.filter { $0.executablePath.isEmpty }.count
+    #expect(detached == 0, "\(detached) of \(snapshots.count) filtered snapshots hold no terminal")
+    #expect(pathless == 0, "\(pathless) of \(snapshots.count) filtered snapshots have no path")
+  }
+
+  @Test(
+    "The filtered sweep still finds a CLI the unfiltered sweep finds",
+    .enabled(if: machineHasATerminalProcess()))
+  func filteredSweepFindsWhatTheFullSweepFinds() {
+    // The fixture test above proves the PREDICATE is veto-neutral. This proves
+    // the SWEEP implements that predicate and nothing more — a filter that
+    // dropped too much would pass the fixture test and fail here.
+    guard case .available(let full) = TerminalProcessScanner.liveSnapshot(),
+      case .available(let filtered) = TerminalProcessScanner.liveTerminalSnapshot()
+    else {
+      Issue.record("process enumeration was unavailable")
+      return
+    }
+
+    // Compared per surface on the VETO's answer rather than on raw process sets,
+    // because the two sweeps are taken microseconds apart and an unrelated
+    // process starting or exiting between them is not a defect. A supported CLI
+    // is long-lived, so its membership does not turn over in that window.
+    for surface in TerminalSurface.allCases {
+      let fromFull = Set(
+        TerminalProcessScanner.supportedCLIs(in: full, hostedBy: surface)
+          .map(\.processIdentifier))
+      let fromFiltered = Set(
+        TerminalProcessScanner.supportedCLIs(in: filtered, hostedBy: surface)
+          .map(\.processIdentifier))
+      #expect(
+        fromFull == fromFiltered,
+        "\(surface): unfiltered found \(fromFull.sorted()), filtered found \(fromFiltered.sorted())"
+      )
+    }
+
+    // The filtered sweep must be a genuine reduction, or it is not the fix.
+    #expect(filtered.count <= full.count)
+  }
+
 }


### PR DESCRIPTION
Closes #1943. Root fix for #1941.

## What a user gets

Terminal dictation stops quietly dying part-way through a session. Today the seam-joining feature can switch itself off for the rest of the app's life with no pill and no message, and the only cure is quitting and reopening.

## The defect

Gate 1's process sweep read the executable path and the whole argv+environment blob for **every process on the machine** (~810), then discarded 97% of them because they hold no controlling terminal. That sweep was the dominant consumer of the delivery budget; when it exhausted the budget it tripped a circuit breaker whose `resetAll()` has no production caller, so terminal insertion stayed off permanently.

#1945 raised the cap 100ms → 200ms as an interim. This makes the cost go away instead.

## The fix

Ask the cheap, highly selective controlling-terminal question FIRST, and read the expensive blob only for the survivors.

It is not a launch-shape pre-filter. The warning against guessing how a CLI is installed still stands and is preserved verbatim in the code; holding a controlling terminal is a kernel fact about a process, not a prediction about its installer. The FALSE half of that note — "mean 3 ms / p95 7 ms, so filtering would buy nothing", the premise the original 100ms cap was sized against — is deleted.

## Evidence

**Real path, the app's own `timing=[…]` trace.** Pre-fix baseline is 454 readings from the shipped build; post-fix is 20 consecutive dictations into Ghostty on a dev build verified by executable path:

| | n | p50 | p95 | max | over 20ms |
|---|---:|---:|---:|---:|---:|
| before | 454 | 41.0 | 70.2 | 99.5 | **454/454** |
| **after** | **20** | **8.30** | **8.90** | **8.90** | **0/20** |

The max of 99.5ms sits right against the old 100ms cap — #1941's mechanism caught in the act rather than inferred. 100% of pre-fix readings exceed the 20ms bar this PR is held to, so the post-fix run is a real two-way control rather than a number chosen to be passable.

**Why it is cheaper**, shipped source compiled verbatim, 807 processes, only 24 (3.0%) holding a terminal:

| over all 807 pids | mean |
|---|---:|
| `proc_pidinfo` (the tty check) | 0.35 ms |
| `proc_pidpath` | 1.71 ms |
| `sysctl KERN_PROCARGS2` | 5.58 ms |

The tty check is simultaneously the cheapest primitive and the most selective filter. Interleaved A/B, n=100: 5.54 mean / 6.13 p95 unfiltered vs 0.86 / 0.94 filtered — **6.5x at both**. Artifacts in `docs/feature-requests/issue-1943-artifacts/`.

## Why the answer cannot change

`supportedCLIs`' own first guard is already `guard snapshot.isAttachedToTerminal`, so every process dropped by the filter would have been dropped one step later. The predicate is not duplicated — both sites call the same function.

**Exact TEMPORAL equivalence is not claimed.** The change moves the observation earlier in the per-process sequence, so a process acquiring or losing a tty inside that window is classified at a different instant. The unfiltered sweep has the mirror of that race and neither instant is more correct; the window is documented at the guard. An equivalence control over 300 comparisons found 0 mismatches with 100 positive findings.

## Tests

Both entry points now share one injected sweep worker. The injection is not tidiness: **CI runs the Debug suite on a hosted runner where nothing holds a controlling terminal**, so every live-process test SKIPS there and the filter would have no regression gate. Three deterministic tests run everywhere:

- the filter never even attempts the expensive reads for a detached PID
- the two-way control that unfiltered mode still reads every process
- `.unavailable` preserved in both modes

Mutation-verified: removing the guard fails all four assertions of the first, and the live contract test catches 517 detached processes. Full suite **5,347 tests green**.

## Review

- Coverage round: `docs/audits/2026-08-12-1943-coverage.txt`. Findings A/B/C/D/F all adopted — adjudication table in the plan §13a.
- Whole-diff `codex review`: **clean, no findings.**
- One declared deviation: the coverage round advised leaving `TerminalContextResolver.swift` alone. That file's comment says "#1943 exists to make it cheap", which this change falsifies, so it is corrected here.

## Not in scope

The breaker's missing reset path (#1941 direction 3). A per-terminal cache — considered and declined: it needs an invalidation story and can serve a stale answer, and the sweep is no longer the budget's dominant consumer. Recorded as the next lever if it ever is again.
