### PR TITLE
ci: split the post-merge check into parallel debug and release jobs

### DIFF
--- a/.github/actions/xcode-ci-setup/action.yml
+++ b/.github/actions/xcode-ci-setup/action.yml
@@ -1,0 +1,127 @@
+name: Xcode CI setup
+description: >-
+  Toolchain selection, Tuist install, DerivedData cache redirect, build-cache
+  restore, and Xcode project generation — the setup every macOS validation job
+  in main-post-merge.yml needs before it can build or test.
+
+# Why this exists (#1994): main-post-merge.yml runs its debug and release
+# validation as two parallel jobs, and each needs an identical eleven-step
+# setup. Two hand-mirrored copies of one decision is the shape that diverges —
+# .claude/rules/workflow-process.md RULE: port-proven-patterns-wholesale
+# records two separate cases in this repo where exactly that happened. One
+# owner, both callers.
+#
+# The caller must check the repository out BEFORE using this action: a local
+# `uses: ./...` action is read from the working tree, so it cannot perform its
+# own checkout.
+
+inputs:
+  derived-data-path:
+    description: DerivedData directory, relative to the workspace.
+    required: true
+  tuist-version:
+    description: Tuist version pinned via mise.
+    required: false
+    default: 4.195.11
+
+outputs:
+  cache-primary-key:
+    description: Primary key the build cache was restored under (for a later save).
+    value: ${{ steps.xcode-cache.outputs.cache-primary-key }}
+  cache-hit:
+    description: Whether the restore was an exact hit on the primary key.
+    value: ${{ steps.xcode-cache.outputs.cache-hit }}
+
+runs:
+  using: composite
+  steps:
+    - name: Select Xcode
+      uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
+      with:
+        xcode-version: latest-stable
+
+    - name: Verify environment
+      shell: bash
+      run: |
+        set -euo pipefail
+        swift --version
+        xcodebuild -version
+        SDK_VER="$(xcrun --sdk macosx --show-sdk-version)"
+        echo "macOS SDK: $SDK_VER"
+
+        if ! swift --version 2>&1 | grep -q "Swift version 6"; then
+          echo "::error::Swift 6.0+ required"
+          exit 1
+        fi
+
+        if [ "$(printf '%s\n' "26.0" "$SDK_VER" | sort -V | head -n1)" != "26.0" ]; then
+          echo "::error::macOS SDK 26.0+ required for FoundationModels (found: $SDK_VER)"
+          exit 1
+        fi
+
+    - name: Install mise + Tuist
+      shell: bash
+      env:
+        TUIST_VERSION: ${{ inputs.tuist-version }}
+      run: |
+        set -euo pipefail
+        curl https://mise.run | sh
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        "$HOME/.local/bin/mise" install "tuist@${TUIST_VERSION}"
+        "$HOME/.local/bin/mise" x "tuist@${TUIST_VERSION}" -- tuist version
+
+    # See pr-check.yml's "Configure DerivedData cache redirect" comment
+    # (issue #1295) — same rationale. main-post-merge.yml remains the cache
+    # WRITER, so it must produce the same directory shape pr-check.yml restores.
+    - name: Configure DerivedData cache redirect
+      shell: bash
+      run: scripts/ci/configure-tuist-deriveddata-cache.sh "$GITHUB_WORKSPACE/${{ inputs.derived-data-path }}"
+
+    - name: Compute Xcode build cache key
+      id: xcode-cache-key
+      shell: bash
+      env:
+        TUIST_VERSION: ${{ inputs.tuist-version }}
+      run: |
+        set -euo pipefail
+        TOOLCHAIN_ID="$(
+          { xcodebuild -version; xcrun --sdk macosx --show-sdk-version; "$HOME/.local/bin/mise" x "tuist@${TUIST_VERSION}" -- tuist version; } |
+          shasum -a 256 | cut -c1-12
+        )"
+        echo "toolchain_id=$TOOLCHAIN_ID" >> "$GITHUB_OUTPUT"
+
+    # The third path entry is a glob (issue #1295) — see pr-check.yml's restore
+    # step comment for why.
+    #
+    # These paths are derived from the input rather than hardcoded to
+    # `.derivedData/CI`, which is what the single-job version did. With two
+    # callers the hardcoded form becomes a silent trap: a caller passing a
+    # different derived-data-path would build in one place and cache another,
+    # and the only symptom is a permanently cold cache. pr-check.yml's restore
+    # paths must continue to match whatever this resolves to.
+    - name: Restore Xcode build cache
+      id: xcode-cache
+      uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+      with:
+        path: |
+          ${{ inputs.derived-data-path }}/SourcePackages
+          ${{ inputs.derived-data-path }}/Build
+          ${{ inputs.derived-data-path }}/*/SourcePackages
+        key: ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-${{ steps.xcode-cache-key.outputs.toolchain_id }}-${{ hashFiles('Package.resolved', 'Project.swift', 'Workspace.swift', 'Tuist.swift', 'Tuist/**/*.swift') }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-${{ steps.xcode-cache-key.outputs.toolchain_id }}-${{ hashFiles('Package.resolved', 'Project.swift', 'Workspace.swift', 'Tuist.swift', 'Tuist/**/*.swift') }}-
+          ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-${{ steps.xcode-cache-key.outputs.toolchain_id }}-
+          ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-
+
+    - name: Generate Xcode project
+      shell: bash
+      env:
+        TUIST_VERSION: ${{ inputs.tuist-version }}
+      run: |
+        set -euo pipefail
+        "$HOME/.local/bin/mise" x "tuist@${TUIST_VERSION}" -- tuist generate --no-open
+        git status --porcelain -- '*.xcodeproj' '*.xcworkspace' '.derivedData'
+
+    - name: Log DerivedData package-resolution location
+      shell: bash
+      run: find "${{ inputs.derived-data-path }}" -maxdepth 3 -type d -name SourcePackages -print 2>/dev/null || true

--- a/.github/workflows/ci-drift-check.yml
+++ b/.github/workflows/ci-drift-check.yml
@@ -14,11 +14,48 @@ jobs:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
+      # Composite actions are scanned alongside workflows (#1994). Every check
+      # in this job looped over `.github/workflows/*` only, so moving CI logic
+      # into `.github/actions/**/action.yml` moved it out of drift coverage
+      # entirely — a floating action ref or a missing script there would pass
+      # this job and fail at runtime post-merge. This is the second instance of
+      # one class in a single change: `scripts/ci/classify-changes.sh` had the
+      # same blind spot for the build decision. Both are fixed together.
+      - name: Enumerate scannable CI definition files
+        id: ci-files
+        run: |
+          set -euo pipefail
+          # `find`, not shell globs. An unmatched glob behaves differently in
+          # bash (passes through literally) and zsh (aborts the command), so a
+          # glob-based list cannot be verified locally against what CI will do.
+          # find has no such dependency and produces the same list in both.
+          {
+            find .github/workflows -maxdepth 1 \( -name '*.yml' -o -name '*.yaml' \) -type f 2>/dev/null || true
+            find .github/actions -mindepth 2 -maxdepth 2 \( -name 'action.yml' -o -name 'action.yaml' \) -type f 2>/dev/null || true
+          } | sed 's|^\./||' | sort -u > /tmp/ci-definition-files.txt
+
+          COUNT=$(wc -l < /tmp/ci-definition-files.txt | tr -d ' ')
+          echo "==> $COUNT CI definition file(s) in scope:"
+          sed 's/^/    /' /tmp/ci-definition-files.txt
+
+          # Fail closed. An empty list would make every check below vacuously
+          # pass, which is the exact silent-green shape this job exists to stop.
+          if [ "$COUNT" -lt 1 ]; then
+            echo "::error::No CI definition files found — the drift scan would pass vacuously"
+            exit 1
+          fi
+          # Composite actions are optional, but if the directory exists it must
+          # contribute at least one file, or a typo'd path silently drops them.
+          if [ -d .github/actions ] && ! grep -q '^\.github/actions/' /tmp/ci-definition-files.txt; then
+            echo "::error::.github/actions exists but contributed no action.yml — scan glob is wrong"
+            exit 1
+          fi
+
       - name: Check action refs are SHA-pinned
         run: |
           echo "==> Checking for floating action refs ..."
           FAIL=0
-          for WF in .github/workflows/*.yml .github/workflows/*.yaml; do
+          while IFS= read -r WF; do
             [ -f "$WF" ] || continue
             # Find all 'uses:' lines with external actions, filter out SHA-pinned ones
             FLOATING=$(grep -nE 'uses:\s+[a-zA-Z]' "$WF" | grep -vE '@[0-9a-f]{40}' || true)
@@ -27,7 +64,7 @@ jobs:
               echo "::error file=$WF::Floating action ref found — pin to full SHA"
               FAIL=1
             fi
-          done
+          done < /tmp/ci-definition-files.txt
           if [ "$FAIL" -eq 0 ]; then
             echo "All action refs are SHA-pinned."
           else
@@ -38,7 +75,7 @@ jobs:
         run: |
           echo "==> Checking script references ..."
           FAIL=0
-          for WF in .github/workflows/*.yml .github/workflows/*.yaml; do
+          while IFS= read -r WF; do
             [ -f "$WF" ] || continue
             while IFS= read -r SCRIPT; do
               [ -n "$SCRIPT" ] || continue
@@ -52,7 +89,7 @@ jobs:
                 FAIL=1
               fi
             done < <(grep -oE '(\./)?scripts/[a-zA-Z0-9_./-]+\.sh' "$WF" | sort -u)
-          done
+          done < /tmp/ci-definition-files.txt
           if [ "$FAIL" -eq 0 ]; then
             echo "All referenced scripts exist."
           else
@@ -61,11 +98,14 @@ jobs:
 
       - name: Validate workflow YAML syntax
         run: |
-          echo "==> Validating workflow YAML ..."
+          set -euo pipefail
+          echo "==> Validating CI definition YAML ..."
           pip install --quiet yamllint
-          yamllint -d "{extends: default, rules: {line-length: disable, truthy: disable, document-start: disable, comments: disable, brackets: disable, comments-indentation: disable}}" \
-            .github/workflows/*.yml
-          echo "All workflows pass YAML validation."
+          # xargs over the enumerated list rather than a glob, so composite
+          # actions are linted too (#1994).
+          xargs yamllint -d "{extends: default, rules: {line-length: disable, truthy: disable, document-start: disable, comments: disable, brackets: disable, comments-indentation: disable}}" \
+            < /tmp/ci-definition-files.txt
+          echo "All CI definition files pass YAML validation."
 
       - name: Check release-notes renderer parses What's New
         run: |

--- a/.github/workflows/main-post-merge.yml
+++ b/.github/workflows/main-post-merge.yml
@@ -5,8 +5,14 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # Everything this workflow's behaviour depends on, so a PR touching any of
+    # it re-runs the workflow against itself. The composite action and the
+    # revision guard are listed because a change to either silently alters every
+    # job here while leaving the workflow file untouched (#1994).
     paths:
       - '.github/workflows/main-post-merge.yml'
+      - '.github/actions/xcode-ci-setup/action.yml'
+      - 'scripts/ci/verify-checked-out-revision.sh'
   workflow_dispatch:
 
 concurrency:
@@ -20,10 +26,33 @@ env:
   XCODE_SCHEME: EnviousWispr
   XCODE_RELEASE_SCHEME: EnviousWispr-Release
 
+# Job layout (#1994). This ran as ONE job until 2026-08-12 and grew into its
+# 45-minute cap: eleven completed runs measured 34.7 min (min) / 40.4 (median) /
+# 44.0 (max), and five runs were killed at the cap outright, so `main` went
+# unverified. Measured step costs across six complete runs:
+#
+#   release tests  19.5 - 25.8 min   <- the long pole
+#   debug tests     7.0 -  9.5 min   <- was sitting on the critical path
+#   build release   3.9 -  4.8 min
+#   build debug     1.4 -  2.6 min
+#
+# The two test suites were sequential for no sequencing reason. They now run as
+# two parallel jobs with independent budgets, which takes the debug suite off
+# the critical path and gives the release suite its own 45 minutes instead of
+# ~36 after the debug run has eaten into them.
+#
+# `release-validation` remains the sole cache WRITER and still builds BOTH
+# configurations, because pr-check.yml restores this cache (two restore steps,
+# no save) and depends on its directory shape. Splitting the cache across two
+# writers would change that contract; this change deliberately does not.
 jobs:
-  main-post-merge-build:
-    runs-on: macos-26
-    timeout-minutes: 45
+  # Cheap Linux gate so both macOS jobs share ONE classification decision
+  # rather than each computing its own and risking disagreement.
+  classify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      needs_build: ${{ steps.changes.outputs.needs_build }}
 
     steps:
       - name: Checkout PR head
@@ -44,23 +73,7 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          set -euo pipefail
-          ACTUAL_SHA="$(git rev-parse HEAD)"
-          EXPECTED_SHA="$GITHUB_SHA"
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            EXPECTED_SHA="$PR_HEAD_SHA"
-          fi
-          if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
-            echo "::error::Checked out $ACTUAL_SHA, expected $EXPECTED_SHA"
-            exit 1
-          fi
-          echo "==> Running workflow revision $ACTUAL_SHA"
-
-      - name: Select Xcode
-        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
-        with:
-          xcode-version: latest-stable
+        run: scripts/ci/verify-checked-out-revision.sh
 
       - name: Detect code changes
         id: changes
@@ -89,86 +102,48 @@ jobs:
               ;;
           esac
 
-      - name: Verify environment
-        if: steps.changes.outputs.needs_build == 'true'
-        run: |
-          set -euo pipefail
-          swift --version
-          xcodebuild -version
-          SDK_VER="$(xcrun --sdk macosx --show-sdk-version)"
-          echo "macOS SDK: $SDK_VER"
+  # The long pole, and the cache WRITER. Builds both configurations (the cache
+  # shape pr-check.yml restores) but runs only the release suite.
+  release-validation:
+    needs: classify
+    if: needs.classify.outputs.needs_build == 'true'
+    runs-on: macos-26
+    # Worst observed critical path for this job's steps is ~36 min (44.0 min
+    # whole-run max, less the 8.0 min debug suite that run executed). 45 leaves
+    # ~9 min of headroom against ~1 min before this split.
+    timeout-minutes: 45
 
-          if ! swift --version 2>&1 | grep -q "Swift version 6"; then
-            echo "::error::Swift 6.0+ required"
-            exit 1
-          fi
-
-          if [ "$(printf '%s\n' "26.0" "$SDK_VER" | sort -V | head -n1)" != "26.0" ]; then
-            echo "::error::macOS SDK 26.0+ required for FoundationModels (found: $SDK_VER)"
-            exit 1
-          fi
-
-      - name: Install mise + Tuist
-        if: steps.changes.outputs.needs_build == 'true'
-        run: |
-          set -euo pipefail
-          curl https://mise.run | sh
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          "$HOME/.local/bin/mise" install tuist@4.195.11
-          "$HOME/.local/bin/mise" x tuist@4.195.11 -- tuist version
-
-      # See pr-check.yml's "Configure DerivedData cache redirect" comment
-      # (issue #1295) — same rationale, mirrored here since this job is the
-      # cache WRITER (main-post-merge.yml must produce the same directory
-      # shape pr-check.yml restores).
-      - name: Configure DerivedData cache redirect
-        if: steps.changes.outputs.needs_build == 'true'
-        run: scripts/ci/configure-tuist-deriveddata-cache.sh "$GITHUB_WORKSPACE/${{ env.DERIVED_DATA_PATH }}"
-
-      - name: Compute Xcode build cache key
-        id: xcode-cache-key
-        if: steps.changes.outputs.needs_build == 'true'
-        run: |
-          set -euo pipefail
-          TOOLCHAIN_ID="$(
-            { xcodebuild -version; xcrun --sdk macosx --show-sdk-version; "$HOME/.local/bin/mise" x tuist@4.195.11 -- tuist version; } |
-            shasum -a 256 | cut -c1-12
-          )"
-          echo "toolchain_id=$TOOLCHAIN_ID" >> "$GITHUB_OUTPUT"
-
-      # main-post-merge.yml is the cache WRITER: restore freshest compatible
-      # cache, run the full debug+release build+test matrix, then save a new
-      # cache under the rolling commit-keyed primary key (issue #804). The
-      # third path entry is a glob (issue #1295) — see pr-check.yml's restore
-      # step comment for why.
-      - name: Restore Xcode build cache
-        id: xcode-cache
-        if: steps.changes.outputs.needs_build == 'true'
-        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+    steps:
+      - name: Checkout PR head
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
-          path: |
-            .derivedData/CI/SourcePackages
-            .derivedData/CI/Build
-            .derivedData/CI/*/SourcePackages
-          key: ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-${{ steps.xcode-cache-key.outputs.toolchain_id }}-${{ hashFiles('Package.resolved', 'Project.swift', 'Workspace.swift', 'Tuist.swift', 'Tuist/**/*.swift') }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-${{ steps.xcode-cache-key.outputs.toolchain_id }}-${{ hashFiles('Package.resolved', 'Project.swift', 'Workspace.swift', 'Tuist.swift', 'Tuist/**/*.swift') }}-
-            ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-${{ steps.xcode-cache-key.outputs.toolchain_id }}-
-            ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
 
-      - name: Generate Xcode project
-        if: steps.changes.outputs.needs_build == 'true'
-        run: |
-          set -euo pipefail
-          "$HOME/.local/bin/mise" x tuist@4.195.11 -- tuist generate --no-open
-          git status --porcelain -- '*.xcodeproj' '*.xcworkspace' '.derivedData'
+      - name: Checkout push or dispatch ref
+        if: github.event_name != 'pull_request'
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 2
 
-      - name: Log DerivedData package-resolution location
-        if: steps.changes.outputs.needs_build == 'true'
-        run: find "$DERIVED_DATA_PATH" -maxdepth 3 -type d -name SourcePackages -print 2>/dev/null || true
+      - name: Verify checked-out revision
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: scripts/ci/verify-checked-out-revision.sh
 
+      - name: Xcode CI setup
+        id: setup
+        uses: ./.github/actions/xcode-ci-setup
+        with:
+          derived-data-path: ${{ env.DERIVED_DATA_PATH }}
+
+      # Both configurations are built here because this job writes the cache
+      # pr-check.yml restores for its own debug AND release jobs. Dropping the
+      # debug build would shrink that cache and slow every future PR.
       - name: Build (debug, Xcode)
-        if: steps.changes.outputs.needs_build == 'true'
         run: |
           set -euo pipefail
           xcodebuild build \
@@ -182,7 +157,6 @@ jobs:
             VALID_ARCHS=arm64
 
       - name: Build (release, Xcode)
-        if: steps.changes.outputs.needs_build == 'true'
         run: |
           set -euo pipefail
           xcodebuild build \
@@ -195,30 +169,6 @@ jobs:
             ONLY_ACTIVE_ARCH=YES \
             VALID_ARCHS=arm64
 
-      - name: Run logic tests (debug, Xcode)
-        if: steps.changes.outputs.needs_build == 'true'
-        run: |
-          set -euo pipefail
-          set -o pipefail
-          xcodebuild test \
-            -project "$XCODE_PROJECT" \
-            -scheme "$XCODE_SCHEME" \
-            -configuration Debug \
-            -derivedDataPath "$DERIVED_DATA_PATH" \
-            -destination 'platform=macOS,arch=arm64' \
-            ARCHS=arm64 \
-            ONLY_ACTIVE_ARCH=YES \
-            VALID_ARCHS=arm64 | tee xcode-test-debug.log
-
-          # Require a positive executed-test count (see pr-check.yml rationale):
-          # a presence-grep would green a zero-test run.
-          TESTS_RUN=$(grep -oE "Test run with [0-9]+ test" xcode-test-debug.log | grep -oE "[0-9]+" | awk '{s+=$1} END{print s+0}')
-          if [ "$TESTS_RUN" -lt 1 ]; then
-            echo "::error::Xcode executed 0 debug tests (empty/misconfigured bundle) — failing"
-            exit 1
-          fi
-          echo "==> Xcode executed $TESTS_RUN tests (debug)"
-
       # ENABLE_TESTABILITY=YES is required on the release TEST invocation only:
       # the test targets use `@testable import`, which needs the first-party
       # modules built with `-enable-testing`. Debug enables testability by
@@ -228,7 +178,6 @@ jobs:
       # and fully optimized. (Mirrors the old `swift test -c release` behavior.)
       - name: Run logic tests (release config, Xcode)
         id: release-tests
-        if: steps.changes.outputs.needs_build == 'true'
         run: |
           set -euo pipefail
           set -o pipefail
@@ -244,7 +193,8 @@ jobs:
             VALID_ARCHS=arm64 \
             ENABLE_TESTABILITY=YES 2>&1 | tee xcode-test-release.log
 
-          # Require a positive executed-test count (see pr-check.yml rationale).
+          # Require a positive executed-test count (see pr-check.yml rationale):
+          # a presence-grep would green a zero-test run.
           TESTS_RUN=$(grep -oE "Test run with [0-9]+ test" xcode-test-release.log | grep -oE "[0-9]+" | awk '{s+=$1} END{print s+0}')
           if [ "$TESTS_RUN" -lt 1 ]; then
             echo "::error::Xcode executed 0 release tests (empty/misconfigured bundle) — failing"
@@ -292,31 +242,184 @@ jobs:
         if: >-
           github.event_name == 'push' &&
           github.ref == 'refs/heads/main' &&
-          steps.changes.outputs.needs_build == 'true' &&
           success() &&
-          steps.xcode-cache.outputs.cache-hit != 'true'
+          steps.setup.outputs.cache-hit != 'true'
         uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
+          # MUST stay identical to the restore paths in
+          # .github/actions/xcode-ci-setup/action.yml — a save/restore pair that
+          # disagrees produces a permanently cold cache with no error anywhere.
           path: |
-            .derivedData/CI/SourcePackages
-            .derivedData/CI/Build
-            .derivedData/CI/*/SourcePackages
-          key: ${{ steps.xcode-cache.outputs.cache-primary-key }}
+            ${{ env.DERIVED_DATA_PATH }}/SourcePackages
+            ${{ env.DERIVED_DATA_PATH }}/Build
+            ${{ env.DERIVED_DATA_PATH }}/*/SourcePackages
+          key: ${{ steps.setup.outputs.cache-primary-key }}
 
-      - name: Post result
-        if: always()
+  # Runs in parallel with release-validation. Restore-only: it never writes the
+  # cache, so the writer contract with pr-check.yml has exactly one owner.
+  debug-validation:
+    needs: classify
+    if: needs.classify.outputs.needs_build == 'true'
+    runs-on: macos-26
+    # Worst observed for these steps is ~17 min (setup ~5, debug build 2.6,
+    # debug suite 9.5). 30 is ~1.75x that, sized from the measured spread rather
+    # than a round number.
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout PR head
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Checkout push or dispatch ref
+        if: github.event_name != 'pull_request'
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 2
+
+      - name: Verify checked-out revision
         env:
-          NEEDS_BUILD: ${{ steps.changes.outputs.needs_build }}
-          JOB_STATUS: ${{ job.status }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: scripts/ci/verify-checked-out-revision.sh
+
+      - name: Xcode CI setup
+        uses: ./.github/actions/xcode-ci-setup
+        with:
+          derived-data-path: ${{ env.DERIVED_DATA_PATH }}
+
+      - name: Build (debug, Xcode)
         run: |
-          case "$JOB_STATUS:$NEEDS_BUILD" in
-            success:true)
-              echo "Full validation passed"
-              ;;
-            success:false)
-              echo "Change classified as non-code; full Xcode validation intentionally skipped"
-              ;;
-            *)
-              echo "Full validation did not pass: job_status=$JOB_STATUS needs_build=${NEEDS_BUILD:-unknown}"
-              ;;
-          esac
+          set -euo pipefail
+          xcodebuild build \
+            -project "$XCODE_PROJECT" \
+            -scheme "$XCODE_SCHEME" \
+            -configuration Debug \
+            -derivedDataPath "$DERIVED_DATA_PATH" \
+            -destination 'generic/platform=macOS' \
+            ARCHS=arm64 \
+            ONLY_ACTIVE_ARCH=YES \
+            VALID_ARCHS=arm64
+
+      - name: Run logic tests (debug, Xcode)
+        id: debug-tests
+        run: |
+          set -euo pipefail
+          set -o pipefail
+          xcodebuild test \
+            -project "$XCODE_PROJECT" \
+            -scheme "$XCODE_SCHEME" \
+            -configuration Debug \
+            -derivedDataPath "$DERIVED_DATA_PATH" \
+            -destination 'platform=macOS,arch=arm64' \
+            -resultBundlePath "$GITHUB_WORKSPACE/xcode-test-debug.xcresult" \
+            ARCHS=arm64 \
+            ONLY_ACTIVE_ARCH=YES \
+            VALID_ARCHS=arm64 2>&1 | tee xcode-test-debug.log
+
+          # Require a positive executed-test count (see pr-check.yml rationale):
+          # a presence-grep would green a zero-test run.
+          TESTS_RUN=$(grep -oE "Test run with [0-9]+ test" xcode-test-debug.log | grep -oE "[0-9]+" | awk '{s+=$1} END{print s+0}')
+          if [ "$TESTS_RUN" -lt 1 ]; then
+            echo "::error::Xcode executed 0 debug tests (empty/misconfigured bundle) — failing"
+            exit 1
+          fi
+          echo "==> Xcode executed $TESTS_RUN tests (debug)"
+
+      # The release job had failure diagnostics and the debug job did not, which
+      # meant a debug-only failure on main left nothing to read. Same treatment
+      # for both suites now that they are peers (#1994).
+      - name: Summarize debug-test failure
+        if: failure() && steps.debug-tests.outcome == 'failure'
+        run: |
+          RESULT_BUNDLE="$GITHUB_WORKSPACE/xcode-test-debug.xcresult"
+          if [ ! -d "$RESULT_BUNDLE" ]; then
+            echo "::warning::Debug-test xcresult was not created"
+            exit 0
+          fi
+
+          echo "::group::xcresult test summary"
+          xcrun xcresulttool get test-results summary \
+            --path "$RESULT_BUNDLE" \
+            --compact || echo "::warning::Test summary unavailable; raw xcresult will be uploaded"
+          echo "::endgroup::"
+
+      - name: Upload debug-test failure diagnostics
+        if: failure() && steps.debug-tests.outcome == 'failure'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: main-debug-test-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            xcode-test-debug.log
+            xcode-test-debug.xcresult
+          if-no-files-found: warn
+          retention-days: 7
+
+  # One place that says whether main is green. Without this, a reader has to
+  # combine three job results by eye, and a SKIPPED job looks like a failure.
+  post-merge-result:
+    needs: [classify, release-validation, debug-validation]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Post result
+        env:
+          NEEDS_BUILD: ${{ needs.classify.outputs.needs_build }}
+          CLASSIFY_RESULT: ${{ needs.classify.result }}
+          RELEASE_RESULT: ${{ needs.release-validation.result }}
+          DEBUG_RESULT: ${{ needs.debug-validation.result }}
+        run: |
+          set -euo pipefail
+          echo "classify=$CLASSIFY_RESULT release=$RELEASE_RESULT debug=$DEBUG_RESULT needs_build=${NEEDS_BUILD:-unknown}"
+
+          if [ "$CLASSIFY_RESULT" != "success" ]; then
+            echo "::error::Change classification did not complete (result=$CLASSIFY_RESULT) — main is UNVERIFIED"
+            exit 1
+          fi
+
+          if [ "$NEEDS_BUILD" != "true" ]; then
+            # Both validation jobs are skipped by their `if:` in this case, which
+            # is the intended outcome, not a failure.
+            echo "Change classified as non-code; full Xcode validation intentionally skipped"
+            exit 0
+          fi
+
+          # needs_build=true, so BOTH suites must have actually run and passed.
+          # Anything else — failure, cancelled (the cap), or skipped — means main
+          # was not verified, and each is reported distinctly so a cap kill is
+          # never mistaken for a test failure.
+          status=0
+          for pair in "release:$RELEASE_RESULT" "debug:$DEBUG_RESULT"; do
+            name="${pair%%:*}"
+            result="${pair#*:}"
+            case "$result" in
+              success)
+                echo "==> $name validation passed"
+                ;;
+              cancelled)
+                echo "::error::$name validation was CANCELLED — either it hit its timeout-minutes cap or a newer commit superseded this run. Check the job duration against its cap before reading this as a test failure (#1994)."
+                status=1
+                ;;
+              skipped)
+                echo "::error::$name validation was SKIPPED while needs_build=true — this is a workflow wiring defect, not a code failure"
+                status=1
+                ;;
+              *)
+                echo "::error::$name validation did not pass (result=$result)"
+                status=1
+                ;;
+            esac
+          done
+
+          if [ "$status" -ne 0 ]; then
+            echo "::error::main is NOT verified green"
+          else
+            echo "Full validation passed"
+          fi
+          exit "$status"

--- a/scripts/ci/classify-changes.sh
+++ b/scripts/ci/classify-changes.sh
@@ -50,10 +50,25 @@ classify() {
     website=false
   fi
 
-  if grep -qE '^\.github/workflows/(pr-check|main-post-merge)\.yml$' <<<"$changed"; then
+  # `.github/actions/` is in the build self-force list for the SAME reason as
+  # this script is in the website list above, and it was introduced by #1994:
+  # main-post-merge.yml's shared Xcode setup (toolchain, Tuist, DerivedData
+  # redirect, cache restore, project generation) now lives in a composite
+  # action. Everything under `.github/` is otherwise excluded from the build
+  # decision two branches down, so without this line a change that rewrites the
+  # entire build setup for both macOS jobs classifies as non-code and skips
+  # every validation job — while the run still reports success. Measured, not
+  # reasoned: before this line, `.github/actions/xcode-ci-setup/action.yml`
+  # classified needs_build=false.
+  #
+  # Matched by DIRECTORY rather than by filename because the failure directions
+  # are asymmetric: a needless full build costs CI minutes, whereas a skipped
+  # one ships unvalidated build infrastructure. Any action added under that
+  # directory is by construction used by a workflow here.
+  if grep -qE '^\.github/(workflows/(pr-check|main-post-merge)\.yml$|actions/)' <<<"$changed"; then
     printf 'needs_build=true\n' >>"$GITHUB_OUTPUT"
     printf 'needs_website=%s\n' "$website" >>"$GITHUB_OUTPUT"
-    echo "==> CI build workflow changed — full Xcode build required (needs_website=$website)"
+    echo "==> CI build workflow or composite action changed — full Xcode build required (needs_website=$website)"
   elif grep -qvE '^(website/|docs/|\.github/|\.claude/|CLAUDE\.md)' <<<"$changed"; then
     printf 'needs_build=true\n' >>"$GITHUB_OUTPUT"
     printf 'needs_website=%s\n' "$website" >>"$GITHUB_OUTPUT"
@@ -248,8 +263,22 @@ self_test() {
   _expect_classify ".github/workflows/pr-check.yml" true "self-force pr-check" true
   _expect_classify "Sources/Foo.swift" true "swift source" false
   _expect_classify $'docs/x.md\nwebsite/y.astro' false "docs+website only" true
-  _expect_classify ".github/actions/foo/action.yml" false "github actions dir excluded" false
-  _expect_classify ".github/dependabot.yml" false "dependabot excluded" false
+  # FLIPPED by #1994, deliberately, and worth reading before flipping it back.
+  # This row asserted `false` because when it was written `.github/actions/`
+  # held nothing that affected the build. main-post-merge.yml now keeps its
+  # shared Xcode setup there as a composite action, so a change to that path
+  # rewrites how both macOS jobs build. The old expectation was correct for the
+  # old world and became a silent hole in the new one: the classifier would
+  # answer "non-code" about the build's own setup and every validation job
+  # would skip while the run reported success.
+  _expect_classify ".github/actions/foo/action.yml" true "composite action self-forces build" false
+  _expect_classify ".github/actions/xcode-ci-setup/action.yml" true "the real composite action self-forces" false
+  # Two-way control: the widening is scoped to `.github/actions/`, so the rest
+  # of `.github/` must still be excluded. Without this pair, a regex that
+  # accidentally matched all of `.github/` would pass the rows above.
+  _expect_classify ".github/dependabot.yml" false "dependabot still excluded" false
+  _expect_classify ".github/ISSUE_TEMPLATE/bug.md" false "issue templates still excluded" false
+  _expect_classify ".github/workflows/release.yml" false "other workflows still excluded" false
   # This file self-forces the website lane: it decides whether that lane runs,
   # so it must not be able to answer "no" about its own change. The row below
   # keeps the original coverage — an ORDINARY scripts/ path still builds

--- a/scripts/ci/verify-checked-out-revision.sh
+++ b/scripts/ci/verify-checked-out-revision.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Assert the working tree is at the revision the workflow intended to test.
+#
+# Why it is a script and not an inline step (#1994): main-post-merge.yml runs
+# three jobs that each check out independently, so this guard would otherwise
+# exist as three hand-mirrored copies. Two copies of one decision is the shape
+# that drifts — .claude/rules/workflow-process.md RULE: port-proven-patterns-wholesale
+# records two cases in this repo where exactly that happened. One owner, three
+# callers.
+#
+# Reads (all from the workflow environment):
+#   EVENT_NAME    github.event_name
+#   GITHUB_SHA    github.sha
+#   PR_HEAD_SHA   github.event.pull_request.head.sha (pull_request only)
+#
+# Exits non-zero if the checkout does not match, so a job can never validate a
+# revision nobody asked for.
+set -euo pipefail
+
+if [ "${1:-}" = "--self-test" ]; then
+  fail=0
+
+  # A matching push checkout passes.
+  out=$(EVENT_NAME=push GITHUB_SHA=abc123 ACTUAL_SHA_OVERRIDE=abc123 "$0" 2>&1) || fail=1
+  case "$out" in *"Running workflow revision abc123"*) ;; *) echo "FAIL: push match: $out"; fail=1 ;; esac
+
+  # A mismatched push checkout is refused.
+  if EVENT_NAME=push GITHUB_SHA=abc123 ACTUAL_SHA_OVERRIDE=def456 "$0" >/dev/null 2>&1; then
+    echo "FAIL: mismatched push should have exited non-zero"
+    fail=1
+  fi
+
+  # pull_request compares against the PR head, not github.sha (which is the
+  # merge commit) — the case an inline copy is most likely to get wrong.
+  out=$(EVENT_NAME=pull_request GITHUB_SHA=merge999 PR_HEAD_SHA=head777 \
+        ACTUAL_SHA_OVERRIDE=head777 "$0" 2>&1) || fail=1
+  case "$out" in *"Running workflow revision head777"*) ;; *) echo "FAIL: PR head match: $out"; fail=1 ;; esac
+
+  # And a PR checkout sitting on the merge commit is refused.
+  if EVENT_NAME=pull_request GITHUB_SHA=merge999 PR_HEAD_SHA=head777 \
+     ACTUAL_SHA_OVERRIDE=merge999 "$0" >/dev/null 2>&1; then
+    echo "FAIL: PR on merge commit should have exited non-zero"
+    fail=1
+  fi
+
+  if [ "$fail" -ne 0 ]; then
+    echo "verify-checked-out-revision.sh: SELF-TEST FAILED"
+    exit 1
+  fi
+  echo "verify-checked-out-revision.sh: self-test OK"
+  exit 0
+fi
+
+# ACTUAL_SHA_OVERRIDE exists only for the self-test above; CI never sets it.
+ACTUAL_SHA="${ACTUAL_SHA_OVERRIDE:-$(git rev-parse HEAD)}"
+EXPECTED_SHA="${GITHUB_SHA:?GITHUB_SHA is required}"
+
+if [ "${EVENT_NAME:?EVENT_NAME is required}" = "pull_request" ]; then
+  EXPECTED_SHA="${PR_HEAD_SHA:?PR_HEAD_SHA is required for a pull_request event}"
+fi
+
+if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
+  echo "::error::Checked out $ACTUAL_SHA, expected $EXPECTED_SHA"
+  exit 1
+fi
+
+echo "==> Running workflow revision $ACTUAL_SHA"

--- a/scripts/validate-pr.sh
+++ b/scripts/validate-pr.sh
@@ -232,7 +232,22 @@ detect_lane_from_diff() {
   if echo "$changed_files" | grep -qE '^(website/|assets/)'; then
     lanes="$lanes Content"
   fi
-  if echo "$changed_files" | grep -qE '^\.github/workflows/|dependabot'; then
+  # `.github/actions/` joined this pattern in #1994, when main-post-merge.yml's
+  # shared Xcode setup moved into a composite action. Measured before the fix:
+  # `.github/actions/xcode-ci-setup/action.yml` matched NO lane at all — not
+  # CI/workflow, not Docs/dev-tooling — so a change to it carried no Phase 3
+  # obligations whatsoever. Third instance of one class in this change, after
+  # `scripts/ci/classify-changes.sh` (build decision) and
+  # `.github/workflows/ci-drift-check.yml` (drift scan): each looked only at
+  # `.github/workflows/`, so moving CI logic one directory sideways escaped it.
+  #
+  # Known and deliberately NOT fixed here: `scripts/ci/*.sh` also matches no
+  # lane, because `^scripts/[^e][^v][^a][^l]/` cannot match `scripts/ci/`. That
+  # predates this change and rewriting the scripts/ lane logic has wider blast
+  # radius than this PR should carry. It does not affect this PR's own lane —
+  # the diff also touches `.github/`, so the union already resolves to
+  # CI/workflow. Recorded on #1994.
+  if echo "$changed_files" | grep -qE '^\.github/(workflows/|actions/)|dependabot'; then
     lanes="$lanes CI/workflow"
   fi
   if echo "$changed_files" | grep -qE '^scripts/eval/'; then


### PR DESCRIPTION
## What this fixes

The post-merge check on `main` grew into its 45-minute cap and was being killed, so `main` went unverified. Closes #1994.

**Eleven completed runs: 34.7 min (min) / 40.4 (median) / 44.0 (max) against a 45 cap.** Five runs were killed at the cap outright. The worst completed run used **97.8%** of its budget, so there was effectively no margin left.

## Where the time goes, measured across six complete runs

| step | min | max | mean |
|---|---:|---:|---:|
| Run logic tests (**release**) | 19.5 | **25.8** | 22.95 |
| Run logic tests (debug) | 7.0 | 9.5 | 8.37 |
| Build (release) | 3.9 | 4.8 | 4.28 |
| Build (debug) | 1.4 | 2.6 | 1.97 |
| Restore Xcode cache | 0.9 | 2.0 | 1.53 |
| Save Xcode cache | 0.9 | 1.3 | 1.10 |
| Generate Xcode project | 0.3 | 0.6 | 0.45 |

Runs sampled: `497edfa9`, `a22eb35a`, `760ba34d`, `adcd5312`, `3220d0fb`, `6dba8076`.

The two suites ran **sequentially in one job with no sequencing dependency between them**. That is the whole defect.

## The change

Three jobs where there was one:

- **`classify`** (ubuntu, 5 min) — one shared classification decision, so the two macOS jobs cannot disagree about whether to build.
- **`release-validation`** (macOS, 45 min) — the long pole. Builds **both** configurations and runs the release suite. Remains the **sole cache writer**.
- **`debug-validation`** (macOS, 30 min) — builds debug, runs the debug suite. Restore-only.
- **`post-merge-result`** (ubuntu, 5 min) — one place that says whether `main` is green, and distinguishes a cap kill from a test failure from a wiring bug.

Shared setup moved into `.github/actions/xcode-ci-setup/action.yml`; the revision guard into `scripts/ci/verify-checked-out-revision.sh`. Three jobs now check out independently, and hand-mirrored copies are the shape that drifts.

## What is deliberately NOT done

- **Not raising `timeout-minutes`.** A band-aid that re-teaches the same lesson in a few weeks.
- **Not dropping the debug re-run as redundant with `build-check`.** The `main-protection` ruleset sets `strict_required_status_checks_policy: false`, so a PR can merge without being re-tested against a moved `main`. The post-merge debug run is what catches two independently-green PRs that conflict semantically. That is coverage, not duplication.
- **Not splitting the cache across two writers.** `pr-check.yml` restores this cache (two restore steps, no save) and depends on its directory shape.

## One class of defect, three instances, all fixed together

Moving CI logic from `.github/workflows/` into `.github/actions/` escaped **three** separate gates that each looked only at `.github/workflows/`. I found the first, Codex review found the second, and enumerating the class found the third rather than patching the named instance.

**1. `scripts/ci/classify-changes.sh` — the build decision.** Measured, not reasoned:

```
.github/actions/xcode-ci-setup/action.yml -> needs_build=false     # before
.github/actions/xcode-ci-setup/action.yml -> needs_build=true      # after
```

A PR touching **only** the composite action would have classified as non-code, skipped both validation jobs, and reported success — while having rewritten the build setup for both macOS jobs.

**2. `.github/workflows/ci-drift-check.yml` — the drift scan** (Codex r1, P2). Its SHA-pin, script-exists and yamllint checks all globbed `.github/workflows/*`, so a floating action ref inside a composite action would pass the drift check and fail at runtime post-merge. All three now read one enumerated list that includes composite actions, and the enumeration **fails closed** on an empty result or on `.github/actions/` existing but contributing nothing.

**3. `scripts/validate-pr.sh` — lane detection.** Measured: `.github/actions/xcode-ci-setup/action.yml` matched **no lane at all** — not CI/workflow, not Docs/dev-tooling — so a change there carried no Phase 3 obligations whatsoever.

All three are matched by directory rather than filename, because the failure directions are asymmetric: a needless full build costs CI minutes, a skipped one ships unvalidated build infrastructure.

The classifier's flipped self-test row is updated with its reason inline rather than silently moved, and paired with three two-way controls (`dependabot.yml`, `ISSUE_TEMPLATE/`, `release.yml`) so a regex that accidentally matched all of `.github/` would fail.

**Known and deliberately not fixed:** `scripts/ci/*.sh` also matches no lane in `validate-pr.sh` (`^scripts/[^e][^v][^a][^l]/` cannot match `scripts/ci/`). That predates this change, rewriting the `scripts/` lane logic has wider blast radius than this PR should carry, and it does not affect this PR's own lane since the diff also touches `.github/`. Recorded on #1994.

## Verification

- `actionlint` clean on the workflow — **and proven to discriminate**: a deliberately broken control workflow is rejected, and mutating `steps.setup.outputs.cache-hit` to a non-existent output is caught with the exact type `{cache-hit: string; cache-primary-key: string}`, which confirms actionlint resolves the local composite action's declared outputs rather than skipping them.
- `shellcheck` clean; `bash -n` clean.
- `scripts/ci/classify-changes.sh --self-test` passes (exit 0), **with a mutation control**: flipping one expectation makes it exit 1, restoring makes it exit 0.
- `scripts/ci/verify-checked-out-revision.sh --self-test` passes, covering the pull_request case that compares against the PR head rather than the merge commit — the case an inline copy is most likely to get wrong — plus a real mismatch against live `git rev-parse`.
- This PR exercises itself: the `paths:` filter now includes the composite action and the revision guard, so a change to either re-runs this workflow against its own PR.

## Known trade-off, measured on this PR's own run

This takes the post-merge run from 1 concurrent macOS job to 2. `ci-pipeline.md` FACT: deferred-job-splitting records the macOS slot limit as why #804 rejected splitting, so the concern is real and pre-existing. **It materialised on this PR, and the numbers are below rather than an estimate.**

Run `31565734922`, created `05:11:37Z`:

| job | runner | started | queue |
|---|---|---|---:|
| `classify` | ubuntu | 05:11:40 | 3s |
| `build-debug` (pr-check) | macOS | 05:11:41 | 4s |
| `build-release` (pr-check) | macOS | 05:11:40 | 3s |
| `debug-validation` | macOS | 05:11:55 | 18s |
| **`release-validation`** | macOS | **05:17:55** | **378s (6m18s)** |

Three macOS jobs started immediately; the fourth waited six minutes. Consistent with a 3-slot macOS ceiling on this account.

**Why this does not change the decision.** `timeout-minutes` starts when a job *starts*, not when the run is created, so queueing costs latency to the signal and cannot cause the cap kill this PR exists to stop. `release-validation` began its 45-minute budget at 05:17:55 with ~36 minutes of work ahead. The old shape was ~44 minutes of work against a 45-minute cap — about one minute of margin, which five runs had already exhausted.

**And this PR is the worst case by construction.** Four macOS jobs only arise when a PR is in flight during a post-merge run. This PR touches `main-post-merge.yml`, so the `paths:` filter runs the post-merge workflow against itself *alongside* the full PR check. On an ordinary push to `main`, `pr-check` is not running and both jobs get slots immediately.

Accurately stated:

- **Uncontended (normal main push):** both jobs start within ~20s; critical path ~44 min → ~36 min, and the long job holds its own 45-minute budget instead of sharing it.
- **Contended (PR open simultaneously):** the second macOS job may wait minutes. Wall clock can approach the old figure, but the *cap* is no longer at risk.

**Watch item, with a real threshold:** if `release-validation` queue delay routinely exceeds ~10 minutes on **ordinary main pushes** — not on workflow-self-testing PRs like this one — the split costs more than it buys. One file reverts it.

**Measurement trap found while doing this**, recorded because it nearly put a wrong number in this PR: the API reported `release-validation` as `status=queued` **with a populated `startedAt` of 05:11:53** while it had not started. Reading that field gave a fabricated 16s. Read `startedAt` only after the job leaves `queued`.

## Honest limit

This buys headroom; it does not stop the suite growing. The release suite alone is 19.5–25.8 min and is 58% of its own budget. If it keeps growing, the next lever is the release suite itself (sharding, or `-parallel-testing-enabled`), and that should be argued from its own measurements rather than bolted on here.

## Review

Codex round 1 found the drift-scan gap (P2). Round 2, after the class fix, returned an explicit all-clear:

> The workflow split preserves both validation suites, keeps a single cache writer, and correctly aggregates skipped, failed, and cancelled jobs. The new scripts and workflow files pass their self-tests, ShellCheck, YAML parsing, and actionlint.

Audits: `docs/audits/2026-08-12-1994-review-r{1,2}.txt`.
