### PR TITLE
test(engine): wait for the snapshot, not for the fake

### DIFF
--- a/Tests/EnviousWisprTests/App/EngineCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/EngineCoordinatorTests.swift
@@ -31,8 +31,27 @@ struct EngineCoordinatorTests {
     #expect(fake.switchCount == 1)
     let warmed = await enginePoll { fake.whisperKitReadiness == .ready }
     #expect(warmed, "the now-active engine must be warmed")
-    #expect(c.status.active == .whisperKit)
-    #expect(c.status.selectedReadiness == .ready)
+
+    // #2028 — wait for the SNAPSHOT, not for the fake.
+    //
+    // `c.status` is republished by the coordinator (`EngineCoordinator.swift`
+    // `selectedReadiness: deps.readiness(sel)`); it is not a live read of the
+    // fake. Polling `fake.whisperKitReadiness` above converges the moment the
+    // FAKE flips, which is strictly before the coordinator has republished — so
+    // asserting `c.status` on the next line raced, passed on a fast local
+    // machine, and failed on a loaded hosted runner. It failed `build-debug`,
+    // which feeds the required `build-check`, on PRs whose diff contained no
+    // Swift at all.
+    //
+    // This is the less obvious form of the wait-for-a-signal rule: the test DID
+    // wait for a signal rather than sleeping, but it waited for a DIFFERENT
+    // signal than the one it asserts. Both published fields are polled, because
+    // both were asserted straight off a fake-field poll and the issue named only
+    // one of them.
+    let publishedActive = await enginePoll { c.status.active == .whisperKit }
+    #expect(publishedActive, "the coordinator must publish the now-active engine")
+    let publishedReadiness = await enginePoll { c.status.selectedReadiness == .ready }
+    #expect(publishedReadiness, "the coordinator must publish the warmed readiness")
   }
 
   @Test("rapid toggles converge to the latest selection, never the intermediate")


### PR DESCRIPTION
Closes #2028.

## Why this matters beyond one test

`EngineCoordinatorTests.idleSwitchAppliesAndWarms` fails intermittently on `build-debug`, which feeds the **required** `build-check`. So it blocks merge on work that touches no Swift at all — it was observed on PR #2024, whose entire diff was four files under `workers/`. Every session paying that tax pays it on unrelated work.

## The mechanism

The test polled the FAKE's field and then asserted the COORDINATOR's published snapshot, with nothing in between:

```swift
let warmed = await enginePoll { fake.whisperKitReadiness == .ready }
#expect(c.status.selectedReadiness == .ready)
```

`c.status` is not a live read — it is captured when the coordinator republishes (`EngineCoordinator.selectedReadiness: deps.readiness(sel)`). Between the fake flipping and that republish landing there is a window where the poll has converged and the assertion has not. A fast local machine republishes first, which is exactly why this passes locally and only surfaces on a loaded hosted runner.

This is the less obvious form of the wait-for-a-signal rule: the test **did** wait on a signal rather than sleeping, but it waited on a *different* signal than the one it asserted.

## Two members, not one

The issue named `selectedReadiness`. `c.status.active` on the line above is the same defect against the same republish, asserted straight off a poll of `fake.active`. Both are fixed.

Fixing only the named instance would leave a flake with an identical signature, which comes back later looking like a regression rather than like the half-fix it was.

I swept the rest of the file for the class: every other `c.status` assertion follows a deliberately-negative `enginePoll(.milliseconds(150))` that burns the full window before asserting, so those gaps are practically closed. Two members, both fixed, no others.

## Evidence

- Targeted suite: **32 tests pass**.
- **40 consecutive filtered runs** of `EngineCoordinatorTests` to confirm stability, since a flake fix that is only run once proves nothing.
- Whole-diff `codex review`.

No production code changes — one test file.

## Note for whoever reads the flake trend

This does not fix #1868, which is the same *family* (a quiescence heuristic read as "the work finished") at a different call site in `ScenarioRunner`. That one is still open and still unprotected.
