### PR TITLE
ci(release): make the dSYM guard report its real count, not a stale literal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1027,7 +1027,7 @@ jobs:
             { [ -n "$dwarf" ] && sentry-cli debug-files check "$dwarf" >/dev/null 2>&1; } \
               || { echo "::error::dSYM parse-check failed for $b"; exit 1; }
           done
-          echo "==> dSYM guard: all 3 first-party dSYMs present and parseable."
+          echo "==> dSYM guard: all ${#FIRST_PARTY[@]} first-party dSYMs present and parseable."
 
       - name: Upload dSYMs to Sentry
         env:


### PR DESCRIPTION
## What

The release dSYM guard printed:

```
==> dSYM guard: all 3 first-party dSYMs present and parseable.
```

while `FIRST_PARTY` has held **two** entries since #1543 (`f1b2a331`) deleted the `EnviousWisprAudioService` helper target and its dSYM. Every green release since has claimed a third artifact was verified that no longer exists.

```diff
-          echo "==> dSYM guard: all 3 first-party dSYMs present and parseable."
+          echo "==> dSYM guard: all ${#FIRST_PARTY[@]} first-party dSYMs present and parseable."
```

## Why it is worth a PR

A log line carries the same evidence burden as a comment — it is read as fact by whoever is diagnosing a symbolication problem, and a wrong count sends them hunting for a missing artifact instead of looking at the two that matter. That is not hypothetical this week: #1964 spent a lead on "were the dSYMs uploaded cleanly?" and this is the step that answers it.

`ci-pipeline.md:109` already records the correct set and names `FIRST_PARTY` as authoritative, so the message was the only thing out of date.

## Why the array length rather than the literal `2`

Hardcoding `2` fixes today and re-arms the same trap the next time a target is added or removed. `${#FIRST_PARTY[@]}` tracks the array, so the count cannot go stale again — the mistake becomes impossible to write rather than merely corrected.

## Verification

- Two-way control on the expansion: the real array reports `2`, a three-element array reports `3`.
- `actionlint` clean on `release.yml` apart from one pre-existing `SC2016` at `:1237`, untouched by this change.
- YAML parses; the `Verify dSYMs present and parseable` step is intact at 21 lines.
- No behaviour change — the loop, the `sentry-cli debug-files check` calls, and every exit code are untouched. Only the success message changes.

## Note on CI coverage

`release.yml` is outside `classify-changes.sh`'s build self-force list, so this classifies `needs_build=false` and the heavy Xcode jobs skip — correctly, since nothing here can affect a build. That also makes this the first change to exercise the **skip path** of the post-merge split shipped in #2033, which that PR's own run could not cover.

Found while verifying #1964's dSYM lead.
