### PR TITLE
feat(telemetry): promote capture transport and failure mode to Sentry tags

### DIFF
--- a/Sources/EnviousWisprPipeline/HeartPathTelemetryEmitter.swift
+++ b/Sources/EnviousWisprPipeline/HeartPathTelemetryEmitter.swift
@@ -67,7 +67,12 @@ final class HeartPathTelemetryEmitter {
     backend: ASRBackendType,
     captureTelemetry: CaptureTelemetryState,
     captureError: @escaping CaptureErrorSink = { error, category, stage, extra in
-      SentryBreadcrumb.captureError(error, category: category, stage: stage, extra: extra)
+      // #2021: promote the two groupable fields from `extra` to per-event TAGS.
+      // Sentry cannot group or filter on `extra`, so without this the transport
+      // split that decides whether a transport-gated fix worked is unanswerable.
+      SentryBreadcrumb.captureError(
+        error, category: category, stage: stage, extra: extra,
+        tags: SentryAudioExtras.promotedTags(from: extra))
     },
     addBreadcrumb: @escaping BreadcrumbSink = { stage, message, data in
       SentryBreadcrumb.add(stage: stage, message: message, level: .warning, data: data)

--- a/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
@@ -61,8 +61,13 @@ public enum KernelDictationDriverFactory {
   /// here so both inputs structs share one source of truth.
   package static let defaultCaptureErrorSink: HeartPathCaptureErrorSink = {
     error, category, stage, extra, snapshot in
+    // #2021: same promotion as the emitter's default sink. Both forward to the
+    // one `SentryBreadcrumb.captureError`, so both need the tags or the fleet
+    // sees them on only half the capture errors — which is worse than neither,
+    // because a partial tag makes an aggregate look complete.
     SentryBreadcrumb.captureError(
-      error, category: category, stage: stage, extra: extra, snapshot: snapshot)
+      error, category: category, stage: stage, extra: extra, snapshot: snapshot,
+      tags: SentryAudioExtras.promotedTags(from: extra))
   }
 
   /// Package-typed inputs for the Parakeet engine branch. Narrowed from

--- a/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
@@ -237,12 +237,20 @@ final class KernelLifecycleTelemetrySink {
         captureNativeChannelCount: captureNativeChannelCount)
     },
     captureError: @escaping CaptureErrorSink = { error, category, stage, extra in
-      SentryBreadcrumb.captureError(error, category: category, stage: stage, extra: extra)
+      // #2021: promote the groupable capture fields to per-event TAGS. This sink
+      // carries `AudioCaptureFailureExtras.build` output, so it emits the same
+      // two fields as the other three default sinks and needs the same
+      // promotion — a partially-tagged population is worse than an untagged one,
+      // because an aggregate over it looks complete.
+      SentryBreadcrumb.captureError(
+        error, category: category, stage: stage, extra: extra,
+        tags: SentryAudioExtras.promotedTags(from: extra))
     },
     captureErrorWithSnapshot: @escaping SnapshotCaptureErrorSink = {
       error, category, stage, extra, snapshot in
       SentryBreadcrumb.captureError(
-        error, category: category, stage: stage, extra: extra, snapshot: snapshot)
+        error, category: category, stage: stage, extra: extra, snapshot: snapshot,
+        tags: SentryAudioExtras.promotedTags(from: extra))
     },
     noAudioCapturedRich: NoAudioCapturedSink? = nil,
     audioCaptureInterrupted: @escaping AudioCaptureInterruptedSink = {

--- a/Sources/EnviousWisprServices/SentryAudioExtras.swift
+++ b/Sources/EnviousWisprServices/SentryAudioExtras.swift
@@ -106,6 +106,53 @@ public enum SentryAudioExtras {
     return extras
   }
 
+  /// The extras that are ALSO promoted to per-event Sentry TAGS.
+  ///
+  /// Sentry cannot group or filter on `extra`, so a field that lives only there
+  /// can be read one event at a time and never aggregated. #2021: that is why
+  /// "what is the transport split on the fixed release" — the question that
+  /// decides whether #1810's transport-gated fix worked — was unanswerable. The
+  /// only axis available was `audio.route`, which is a proxy: a route is not a
+  /// transport, and it cannot separate `all_zero_from_start` from
+  /// `became_zero_mid_capture` at all, which is the exact distinction #1788 and
+  /// #1578 were split along.
+  ///
+  /// **Per-EVENT, not scope.** `audio.route` is a scope tag
+  /// (`SentryBreadcrumb.swift`) because a route is a session property. These two
+  /// describe the FAILURE — the transport bound for that attempt and the shape
+  /// it failed in — so a scope tag would go stale and mis-attribute the NEXT
+  /// event. `captureError`'s existing `tags:` parameter is already per-event.
+  ///
+  /// **A missing value produces NO key.** Never `""` and never `"nil"`: an
+  /// empty-string bucket is the exact trap #2021 reports, where aggregating on
+  /// `input_device_transport` returned a single empty bucket that was the
+  /// instrument rather than the data.
+  ///
+  /// Both vocabularies are closed and small — `CaptureStallFailureMode` has
+  /// three cases, and `AudioDeviceManager.transportLabel(forTransportType:)` is
+  /// an exhaustive switch over CoreAudio transport constants — so neither can
+  /// blow up tag cardinality. Categories only, never content, so the telemetry
+  /// privacy boundary is unaffected.
+  ///
+  /// Reads the SAME keys `buildCaptureExtras` writes, deliberately: a second
+  /// vocabulary here would be able to drift from the payload it describes.
+  public static func promotedTags(from extras: [String: Any]?) -> [String: String] {
+    guard let extras else { return [:] }
+    var tags: [String: String] = [:]
+    for key in promotedTagKeys {
+      // Only a real String is promoted. A non-String value is SKIPPED rather
+      // than stringified — a coerced tag would be a value no query could ever
+      // match, which is worse than an absent one.
+      if let value = extras[key] as? String, !value.isEmpty {
+        tags[key] = value
+      }
+    }
+    return tags
+  }
+
+  /// The promotion list. One place, so the two default sinks cannot disagree.
+  static let promotedTagKeys = ["capture.effective_transport", "capture.failure_mode"]
+
   private static func normalizeDeviceUID(_ uid: String?) -> String? {
     guard let uid, !uid.isEmpty else { return nil }
     return uid

--- a/Tests/EnviousWisprTests/Architecture/CaptureErrorTagPromotionFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/CaptureErrorTagPromotionFreezeTests.swift
@@ -1,0 +1,79 @@
+import Foundation
+import Testing
+
+/// #2021 — every sink that forwards CAPTURE extras to Sentry must also promote
+/// them to tags.
+///
+/// Why a source scan rather than a behavioural test: the four sinks are inline
+/// DEFAULT ARGUMENTS on initialisers, so three of them cannot be invoked
+/// directly and a behavioural test can only reach the one named static. The
+/// failure this guards is a FIFTH sink added later without the promotion, and
+/// that failure is silent in the worst way — the fleet keeps receiving tagged
+/// events from the other four, so every aggregate still looks complete while
+/// quietly under-counting. A partially-tagged population is worse than an
+/// untagged one.
+///
+/// Found the hard way: this change's own plan named TWO sinks. Enumerating
+/// properly found FOUR.
+@Suite("Capture-error tag promotion is complete (#2021)")
+struct CaptureErrorTagPromotionFreezeTests {
+
+  /// Files whose `captureError` calls carry `SentryAudioExtras.buildCaptureExtras`
+  /// output. Derived by tracing every consumer of that builder.
+  private static let capturePathFiles = [
+    "Sources/EnviousWisprPipeline/HeartPathTelemetryEmitter.swift",
+    "Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift",
+    "Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift",
+  ]
+
+  @Test("every capture-path captureError call promotes the tags")
+  func everyCapturePathSinkPromotesTags() throws {
+    let root = RepoRoot.url
+    var offenders: [String] = []
+    var totalCalls = 0
+
+    for relative in Self.capturePathFiles {
+      let text = try String(
+        contentsOf: root.appendingPathComponent(relative), encoding: .utf8)
+
+      // Split on the call so each fragment after the first is one call's
+      // argument list. Checking the whole FILE for the promotion would pass a
+      // file where one of two sinks has it and the other does not — which is
+      // exactly the bug in `KernelLifecycleTelemetrySink`, whose two sinks sit
+      // four lines apart.
+      let fragments = text.components(separatedBy: "SentryBreadcrumb.captureError(")
+      guard fragments.count > 1 else {
+        offenders.append("\(relative): no captureError call found — did the file move?")
+        continue
+      }
+      for fragment in fragments.dropFirst() {
+        totalCalls += 1
+        // The argument list ends at the first line that closes it. Bounded
+        // window rather than the whole tail, so a LATER call's promotion cannot
+        // satisfy an earlier call that lacks one.
+        let window = String(fragment.prefix(400))
+        if !window.contains("SentryAudioExtras.promotedTags(from:") {
+          offenders.append(relative)
+        }
+      }
+    }
+
+    // Positive control: a scan that found nothing to check would pass vacuously.
+    #expect(
+      totalCalls >= 4,
+      """
+      expected at least 4 capture-path captureError calls, found \(totalCalls) — \
+      the scan is not reaching the sinks it claims to cover
+      """)
+
+    #expect(
+      offenders.isEmpty,
+      """
+      These capture-path `SentryBreadcrumb.captureError` calls do not pass \
+      `tags: SentryAudioExtras.promotedTags(from: extra)`, so the events they \
+      emit reach Sentry with `capture.effective_transport` and \
+      `capture.failure_mode` only as `extra` — ungroupable, and invisible to \
+      every per-transport query (#2021, #1810): \(offenders.joined(separator: ", "))
+      """)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/CaptureErrorPromotedTagsTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/CaptureErrorPromotedTagsTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+@testable import EnviousWisprServices
+
+/// #2021 — the two capture fields must reach Sentry as TAGS, not only as `extra`.
+///
+/// Three guards, each closing a different way this can silently regress:
+/// the wire contract, the production forwarding, and a future sink added
+/// without the promotion.
+@Suite("Capture error promoted tags (#2021)")
+@MainActor
+struct CaptureErrorPromotedTagsTests {
+
+  /// Captures the tag payload synchronously, before SDK dispatch.
+  ///
+  /// `SentryBreadcrumb.captureErrorTagsDelegate` is a process-global, which is
+  /// normally forbidden in tests — but the ban is on asserting ACROSS an
+  /// `await`, and this body installs, fires and restores with no suspension
+  /// point, which `swift-patterns.md` RULE: tests-no-process-global-mutable-delegate
+  /// explicitly permits.
+  /// A locked box rather than a captured `var`: the delegate is `@Sendable`, so
+  /// Swift 6 rejects mutating a captured local from inside it. (I simplified
+  /// this away from the reviewer's version and the compiler caught it — an
+  /// adopted fix still has to pass its own receipts.)
+  private final class TagBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: [String: String] = [:]
+    func set(_ tags: [String: String]) { lock.withLock { value = tags } }
+    func get() -> [String: String] { lock.withLock { value } }
+  }
+
+  private func tagsFrom(_ fire: () -> Void) -> [String: String] {
+    let box = TagBox()
+    let prior = SentryBreadcrumb.captureErrorTagsDelegate
+    SentryBreadcrumb.captureErrorTagsDelegate = { box.set($0) }
+    defer { SentryBreadcrumb.captureErrorTagsDelegate = prior }
+    fire()
+    return box.get()
+  }
+
+  @Test("the production sink forwards both promoted tags onto the event")
+  func productionSinkForwardsTags() {
+    // The unit tests on `promotedTags` prove the projection. This proves the
+    // SINK actually calls it — a correct projection nobody invokes is the
+    // a-guard-nothing-arms shape.
+    let tags = tagsFrom {
+      KernelDictationDriverFactory.defaultCaptureErrorSink(
+        KernelFallbackSentryError.captureStartFailed,
+        .audioCaptureFailed,
+        "recording",
+        [
+          "capture.failure_mode": "all_zero_from_start",
+          "capture.effective_transport": "built_in",
+        ],
+        nil)
+    }
+    #expect(tags["capture.failure_mode"] == "all_zero_from_start")
+    #expect(tags["capture.effective_transport"] == "built_in")
+    // The event's own seed tags must survive the merge.
+    #expect(tags["pipeline.stage"] == "recording")
+  }
+
+  @Test("an absent transport reaches the event as no key at all")
+  func productionSinkOmitsAbsentTransport() {
+    // Two-way control for the defect #2021 reports: a field written as "" makes
+    // an aggregate return one empty bucket, which reads as data.
+    let tags = tagsFrom {
+      KernelDictationDriverFactory.defaultCaptureErrorSink(
+        KernelFallbackSentryError.captureStartFailed,
+        .audioCaptureFailed,
+        "recording",
+        ["capture.failure_mode": "became_zero_mid_capture"],
+        nil)
+    }
+    #expect(tags["capture.failure_mode"] == "became_zero_mid_capture")
+    #expect(tags.keys.contains("capture.effective_transport") == false)
+  }
+
+  @Test("the promoted tag names are frozen as literals — this is a wire contract")
+  func tagNamesAreFrozen() {
+    // Deliberately independent string literals rather than reading
+    // `promotedTagKeys`, which would test the list against itself. These names
+    // are an EXTERNAL contract: every saved Sentry query and every future
+    // #1810 verification is written against them, so a rename of both the
+    // builder key and the promotion list together must still fail here.
+    #expect(
+      SentryAudioExtras.promotedTagKeys.sorted() == [
+        "capture.effective_transport",
+        "capture.failure_mode",
+      ])
+  }
+}

--- a/Tests/EnviousWisprTests/Services/SentryAudioExtrasTests.swift
+++ b/Tests/EnviousWisprTests/Services/SentryAudioExtrasTests.swift
@@ -254,4 +254,82 @@ struct SentryAudioExtrasTests {
     #expect(extras["capture.route_resolution_source"] as? String == "app_derived")
     #expect(extras["capture.input_resolution_source"] as? String == "pinned_uid")
   }
+
+  // MARK: - #2021 tag promotion
+
+  @Test("both promoted fields become tags when present")
+  func promotesBothFields() {
+    let tags = SentryAudioExtras.promotedTags(from: [
+      "capture.effective_transport": "bluetooth",
+      "capture.failure_mode": "all_zero_from_start",
+      "capture.route": "built_in_mic",
+    ])
+    #expect(tags["capture.effective_transport"] == "bluetooth")
+    #expect(tags["capture.failure_mode"] == "all_zero_from_start")
+    // Only the promotion list is promoted; an unrelated extra stays an extra.
+    #expect(tags["capture.route"] == nil)
+    #expect(tags.count == 2)
+  }
+
+  @Test("an absent transport produces NO key, never an empty bucket")
+  func absentTransportOmitsTheKey() {
+    // The two-way control for the exact defect #2021 reports: aggregating on a
+    // field that was written as "" returns one empty bucket, which reads as data
+    // and is the instrument. An absent value must not create a key at all.
+    let tags = SentryAudioExtras.promotedTags(from: [
+      "capture.failure_mode": "became_zero_mid_capture"
+    ])
+    #expect(tags["capture.effective_transport"] == nil)
+    #expect(tags.keys.contains("capture.effective_transport") == false)
+    #expect(tags.count == 1)
+  }
+
+  @Test("an empty-string value is dropped rather than promoted")
+  func emptyStringIsDropped() {
+    let tags = SentryAudioExtras.promotedTags(from: [
+      "capture.effective_transport": "",
+      "capture.failure_mode": "no_buffers",
+    ])
+    #expect(tags["capture.effective_transport"] == nil)
+    #expect(tags.count == 1)
+  }
+
+  @Test("nil extras promote nothing")
+  func nilExtrasPromoteNothing() {
+    #expect(SentryAudioExtras.promotedTags(from: nil).isEmpty)
+  }
+
+  @Test("a non-String value is skipped, not stringified")
+  func nonStringIsSkipped() {
+    // A coerced tag would be a value no query could ever match, which is worse
+    // than an absent one.
+    let tags = SentryAudioExtras.promotedTags(from: [
+      "capture.effective_transport": 42,
+      "capture.failure_mode": "all_zero_from_start",
+    ])
+    #expect(tags["capture.effective_transport"] == nil)
+    #expect(tags.count == 1)
+  }
+
+  @Test("the promotion list matches keys the builder actually writes")
+  func promotionListCannotDriftFromTheBuilder() {
+    // Freezes the one way these can silently diverge: a renamed extra key would
+    // leave the promotion list pointing at a key nobody writes, and every tag
+    // would quietly vanish with no test failing.
+    let extras = SentryAudioExtras.buildCaptureExtras(
+      route: "built_in_mic",
+      sourceType: "hal_device_input",
+      sessionID: 1,
+      isActivelyCapturing: true,
+      inputDeviceUIDPreferred: nil,
+      inputDeviceUIDSystemDefault: nil,
+      failureMode: "all_zero_from_start",
+      effectiveTransport: "usb")
+    for key in SentryAudioExtras.promotedTagKeys {
+      #expect(extras[key] != nil, "builder no longer writes \(key)")
+    }
+    let tags = SentryAudioExtras.promotedTags(from: extras)
+    #expect(tags["capture.failure_mode"] == "all_zero_from_start")
+    #expect(tags["capture.effective_transport"] == "usb")
+  }
 }


### PR DESCRIPTION
Closes #2021. Unblocks verification of #1810 (P0).

## The problem

Sentry cannot group or filter on `extra`. `capture.effective_transport` and `capture.failure_mode` live only there, so they can be read one event at a time and never aggregated.

That is why the question deciding whether #1810's fix worked — *what is the transport split on the fixed release?* — is unanswerable today. The only available axis is `audio.route`, a proxy that cannot separate `all_zero_from_start` from `became_zero_mid_capture` at all, which is the exact distinction #1788 and #1578 were split along.

## The change

Promote both to per-event **tags**. No new data is collected; the same two values move from an un-queryable slot to a queryable one, and both stay in `extra`, so every existing query keeps working.

`SentryBreadcrumb.captureError` has always accepted `tags:`, so this needs no new Sentry plumbing and **no sink signature change** — the values are already in `extra` at every forwarding site.

## Four sinks, not two

My own plan named the two I had found. Enumerating the consumers of `SentryAudioExtras.buildCaptureExtras` found **two more**, both default arguments in `KernelLifecycleTelemetrySink` sitting four lines apart.

Shipping the two I had would have produced a **partially-tagged population**, which is worse than an untagged one: every aggregate over it still looks complete while quietly under-counting. Same class as reading a pooled average as a mechanism.

## Design decisions worth stating

**Per-EVENT, not scope.** `audio.route` is a scope tag because a route is a session property. These two describe the *failure* — the transport bound for that attempt and the shape it failed in — so a scope tag would go stale and mis-attribute the next event.

**A missing value produces NO key** — never `""`, never `"nil"`. An empty-string bucket is precisely the defect this issue reports, where aggregating on `input_device_transport` returned one empty bucket that was the instrument rather than the data.

**Cardinality is bounded.** `CaptureStallFailureMode` has 3 cases; `transportLabel(forTransportType:)` is an exhaustive switch over CoreAudio constants. Categories only, never content — the telemetry privacy boundary is unaffected.

## Three guards

1. **Unit tests** on the pure projection, including the absent-transport control.
2. **A production-sink test** observing the real tag payload through `captureErrorTagsDelegate`, synchronously before SDK dispatch. A correct projection nobody invokes is the `a-guard-nothing-arms-is-not-a-guard` shape.
3. **A source-scan freeze** asserting every capture-path `captureError` promotes, with a positive control that it found ≥4 calls. **Mutation-verified**: removing the promotion from one of the four fails it and names the file.

Tag names are frozen against **independent string literals** rather than against `promotedTagKeys` — which would test the list against itself. They are an external contract that every saved Sentry query is written on.

Full suite **5,357 tests green**.

## Review

Coverage round: `docs/audits/2026-08-12-2021-coverage.txt`. **All findings adopted**; adjudication table in plan §13a. Two of them materially improved this: it caught the self-referential drift test, and it replaced a manual "look in Sentry" ship criterion with the synchronous pre-dispatch observation that is now guard 2.

## Cautions for whoever runs the #1810 verification

Recorded in plan §13b because this change can mislead the person it was built for:

1. **Filter to the first release containing this change or later.** Earlier events have no tags, and a `GROUP BY` buckets them as missing — which reads as "unknown transport" rather than "before the instrument existed". Same shape as the retired-enum-name trap that produced #1878's phantom P0.
2. **Always show the missing-transport count beside the grouped counts.** A nil transport produces no tag by design, so a per-transport table silently omits those events.
