### PR TITLE
perf(telemetry): stop emitting the uninformative Sparkle update cycle

### DIFF
--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -2567,6 +2567,44 @@ public final class TelemetryService {
     )
   }
 
+  /// Sparkle's `SUNoUpdateError` (`SUErrors.h:41`) as `SparkleUpdateController` renders
+  /// it — `"\(domain).\(code)"`. Sparkle reports "no update available" AS an error, so
+  /// this code is the benign outcome, not a failure.
+  ///
+  /// `SparkleUpdateControllerTests.benignNoUpdateCodeMatchesSparklesOwnEnum` fails if
+  /// Sparkle's own enum stops producing this exact string, because this module cannot
+  /// import Sparkle to say so in types.
+  public static let sparkleBenignNoUpdateErrorCode = "SUSparkleErrorDomain.1001"
+
+  /// #1979: true for the ONE cycle shape that carries no information — the reason, the
+  /// staleness bucket and the error code all agree that nothing happened and the user is
+  /// already current. Measured 2026-08-12 (30d production, dev excluded): 48,943 of the
+  /// event's 56,678 rows, which is **8.9% of ALL production telemetry**, emitted hourly
+  /// per user forever.
+  ///
+  /// Everything else still emits, deliberately:
+  /// - reason/bucket CONTRADICTIONS (`on_latest_version` + `patch_behind` 251 +
+  ///   `minor_behind` 86 = 337 rows) — that disagreement is how #847 (Sparkle telling a
+  ///   behind user they are current) would be caught recurring, so it is the case worth
+  ///   the most per row.
+  /// - real failures: `1005` `SURunningTranslocated` (4,144), `2001` `SUDownloadError`
+  ///   (3,078), and every install/verify error.
+  /// - every cycle that actually found an update.
+  ///
+  /// All three fields are checked even though `SparkleUpdateController.noUpdateReason`
+  /// only returns non-nil for domain `SUSparkleErrorDomain` code `1001` (`:322`), which
+  /// makes the error check redundant TODAY. They arrive here as independent parameters,
+  /// so this must not silently depend on a coupling established in another module.
+  static func isUninformativeUpdateCycle(
+    errorCode: String?,
+    noUpdateReason: String?,
+    versionStalenessBucket: String
+  ) -> Bool {
+    errorCode == sparkleBenignNoUpdateErrorCode
+      && noUpdateReason == "on_latest_version"
+      && versionStalenessBucket == "on_latest"
+  }
+
   public func updateSparkleCycleFinished(
     version: String,
     isCritical: Bool,
@@ -2577,6 +2615,15 @@ public final class TelemetryService {
     currentAppVersion: String,
     versionStalenessBucket: String  // #1178 (Phase 9, B3): on_latest/patch/minor/major_behind.
   ) {
+    // #1979: suppressed BEFORE the DEBUG hook as well as the capture, so a test observes
+    // exactly what production emits rather than a shape only tests can see.
+    if Self.isUninformativeUpdateCycle(
+      errorCode: errorCode,
+      noUpdateReason: noUpdateReason,
+      versionStalenessBucket: versionStalenessBucket
+    ) {
+      return
+    }
     #if DEBUG
       var hookStringProps: [String: String] = [
         "version": version,

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -2591,16 +2591,31 @@ public final class TelemetryService {
   ///   (3,078), and every install/verify error.
   /// - every cycle that actually found an update.
   ///
-  /// All three fields are checked even though `SparkleUpdateController.noUpdateReason`
+  /// - **any check the USER asked for.** An attended "Check for Updates" from the menu or
+  ///   Settings produces the identical outcome tuple, but it is an intentional user
+  ///   action with a result, not background noise: someone asked a question and we
+  ///   answered it. 419 rows / 248 users in 30d, 0.86% of the shape below, so keeping
+  ///   them costs 0.08% of total volume and preserves the whole signal. Cloud review
+  ///   caught this (PR #2037 r3764532583); the first version keyed on the OUTCOME and
+  ///   ignored the TRIGGER.
+  ///
+  /// `checkKind` is an ALLOWLIST of the one background value, never a denylist of
+  /// `user_initiated`. `SparkleUpdateController.checkKindString` (`:350`) also produces
+  /// `informational` and `unrecognized`, and an unmapped future case must EMIT rather
+  /// than vanish, so the unknown direction has to fail open.
+  ///
+  /// All four fields are checked even though `SparkleUpdateController.noUpdateReason`
   /// only returns non-nil for domain `SUSparkleErrorDomain` code `1001` (`:322`), which
   /// makes the error check redundant TODAY. They arrive here as independent parameters,
   /// so this must not silently depend on a coupling established in another module.
   static func isUninformativeUpdateCycle(
     errorCode: String?,
     noUpdateReason: String?,
-    versionStalenessBucket: String
+    versionStalenessBucket: String,
+    checkKind: String
   ) -> Bool {
-    errorCode == sparkleBenignNoUpdateErrorCode
+    checkKind == "background"
+      && errorCode == sparkleBenignNoUpdateErrorCode
       && noUpdateReason == "on_latest_version"
       && versionStalenessBucket == "on_latest"
   }
@@ -2620,7 +2635,8 @@ public final class TelemetryService {
     if Self.isUninformativeUpdateCycle(
       errorCode: errorCode,
       noUpdateReason: noUpdateReason,
-      versionStalenessBucket: versionStalenessBucket
+      versionStalenessBucket: versionStalenessBucket,
+      checkKind: checkKind
     ) {
       return
     }

--- a/Tests/EnviousWisprTests/App/SparkleUpdateControllerTests.swift
+++ b/Tests/EnviousWisprTests/App/SparkleUpdateControllerTests.swift
@@ -683,7 +683,8 @@ struct SparkleUpdateControllerTests {
     private func capturedCycle(
       errorCode: String?,
       noUpdateReason: String?,
-      versionStalenessBucket: String
+      versionStalenessBucket: String,
+      checkKind: String = "background"
     ) async -> CapturedTelemetryEvent? {
       let box = EventBox()
       let originalHook = TelemetryService.shared.testEventHook
@@ -695,7 +696,7 @@ struct SparkleUpdateControllerTests {
       TelemetryService.shared.updateSparkleCycleFinished(
         version: "2.4.5", isCritical: false, source: "background",
         errorCode: errorCode, noUpdateReason: noUpdateReason,
-        checkKind: "background", currentAppVersion: "2.4.5",
+        checkKind: checkKind, currentAppVersion: "2.4.5",
         versionStalenessBucket: versionStalenessBucket)
 
       await Task.yield()
@@ -723,6 +724,7 @@ struct SparkleUpdateControllerTests {
       let reason: String?
       let bucket: String
       let why: String
+      var checkKind: String = "background"
     }
 
     @Test(
@@ -750,11 +752,27 @@ struct SparkleUpdateControllerTests {
         CycleShape(
           errorCode: nil, reason: nil, bucket: "major_behind",
           why: "an update was found for a badly stale user"),
+        // The outcome tuple below is IDENTICAL to the suppressed one. Only the trigger
+        // differs, and the trigger is what makes it worth keeping: the user asked.
+        CycleShape(
+          errorCode: "SUSparkleErrorDomain.1001", reason: "on_latest_version",
+          bucket: "on_latest",
+          why: "the USER clicked Check for Updates and is owed the answer (#2037 r3764532583)",
+          checkKind: "user_initiated"),
+        CycleShape(
+          errorCode: "SUSparkleErrorDomain.1001", reason: "on_latest_version",
+          bucket: "on_latest", why: "an informational check, not a background one",
+          checkKind: "informational"),
+        CycleShape(
+          errorCode: "SUSparkleErrorDomain.1001", reason: "on_latest_version",
+          bucket: "on_latest",
+          why: "an UNMAPPED future SPUUpdateCheck case must fail OPEN, never vanish",
+          checkKind: "unrecognized"),
       ])
     func informativeCyclesStillEmit(shape: CycleShape) async {
       let evt = await capturedCycle(
         errorCode: shape.errorCode, noUpdateReason: shape.reason,
-        versionStalenessBucket: shape.bucket)
+        versionStalenessBucket: shape.bucket, checkKind: shape.checkKind)
       #expect(
         evt != nil,
         Comment(rawValue: "#1979 must KEEP emitting this shape: \(shape.why)"))

--- a/Tests/EnviousWisprTests/App/SparkleUpdateControllerTests.swift
+++ b/Tests/EnviousWisprTests/App/SparkleUpdateControllerTests.swift
@@ -513,7 +513,10 @@ struct SparkleUpdateControllerTests {
         noUpdateReason: "on_latest_version",
         checkKind: "background",
         currentAppVersion: "v2.0.4",
-        versionStalenessBucket: "on_latest"
+        // #1979: `on_latest` here would make this the uninformative cycle, which is now
+        // suppressed entirely. `patch_behind` keeps the propagation assertions meaningful
+        // AND is the reason/bucket contradiction we most want to keep emitting.
+        versionStalenessBucket: "patch_behind"
       )
 
       await Task.yield()
@@ -672,6 +675,103 @@ struct SparkleUpdateControllerTests {
 
       let evt = box.events.first { $0.name == "update.sparkle_cycle_finished" }
       #expect(evt?.stringProps["version_staleness_bucket"] == "minor_behind")
+    }
+
+    // MARK: - #1979: uninformative-cycle suppression
+
+    /// Drives the REAL emit path and returns the cycle event if one was emitted.
+    private func capturedCycle(
+      errorCode: String?,
+      noUpdateReason: String?,
+      versionStalenessBucket: String
+    ) async -> CapturedTelemetryEvent? {
+      let box = EventBox()
+      let originalHook = TelemetryService.shared.testEventHook
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        Task { @MainActor in box.events.append(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = originalHook }
+
+      TelemetryService.shared.updateSparkleCycleFinished(
+        version: "2.4.5", isCritical: false, source: "background",
+        errorCode: errorCode, noUpdateReason: noUpdateReason,
+        checkKind: "background", currentAppVersion: "2.4.5",
+        versionStalenessBucket: versionStalenessBucket)
+
+      await Task.yield()
+      await Task.yield()
+      return box.events.first { $0.name == "update.sparkle_cycle_finished" }
+    }
+
+    @Test("the self-consistent 'you are already current' cycle is not emitted at all")
+    func uninformativeCycleIsSuppressed() async {
+      let evt = await capturedCycle(
+        errorCode: TelemetryService.sparkleBenignNoUpdateErrorCode,
+        noUpdateReason: "on_latest_version",
+        versionStalenessBucket: "on_latest")
+      #expect(
+        evt == nil,
+        """
+        #1979: reason, staleness bucket and error code all agree that nothing happened, \
+        so this cycle carries no information. It was 48,943 of 56,678 rows and 8.9% of \
+        ALL production telemetry, emitted hourly per user forever.
+        """)
+    }
+
+    struct CycleShape: Sendable {
+      let errorCode: String?
+      let reason: String?
+      let bucket: String
+      let why: String
+    }
+
+    @Test(
+      "every cycle shape that still carries information keeps emitting",
+      arguments: [
+        CycleShape(
+          errorCode: "SUSparkleErrorDomain.1001", reason: "on_latest_version",
+          bucket: "patch_behind",
+          why: "#847 recurrence: Sparkle claims current, staleness says behind"),
+        CycleShape(
+          errorCode: "SUSparkleErrorDomain.1001", reason: "on_latest_version",
+          bucket: "minor_behind", why: "#847 recurrence, a larger gap"),
+        CycleShape(
+          errorCode: "SUSparkleErrorDomain.1001", reason: "on_newer_than_latest_version",
+          bucket: "on_latest", why: "a different no-update reason"),
+        CycleShape(
+          errorCode: "SUSparkleErrorDomain.1005", reason: nil, bucket: "on_latest",
+          why: "SURunningTranslocated — the user can never update (#1919)"),
+        CycleShape(
+          errorCode: "SUSparkleErrorDomain.2001", reason: nil, bucket: "patch_behind",
+          why: "SUDownloadError"),
+        CycleShape(
+          errorCode: nil, reason: nil, bucket: "on_latest",
+          why: "a cycle with no error at all"),
+        CycleShape(
+          errorCode: nil, reason: nil, bucket: "major_behind",
+          why: "an update was found for a badly stale user"),
+      ])
+    func informativeCyclesStillEmit(shape: CycleShape) async {
+      let evt = await capturedCycle(
+        errorCode: shape.errorCode, noUpdateReason: shape.reason,
+        versionStalenessBucket: shape.bucket)
+      #expect(
+        evt != nil,
+        Comment(rawValue: "#1979 must KEEP emitting this shape: \(shape.why)"))
+    }
+
+    @Test("the benign no-update code constant still matches Sparkle's own enum")
+    func benignNoUpdateCodeMatchesSparklesOwnEnum() {
+      // `EnviousWisprServices` cannot import Sparkle, so the constant is a string there.
+      // This is the freeze that catches Sparkle renaming or renumbering it.
+      let rendered = "\(SUSparkleErrorDomain).\(SUError.noUpdateError.rawValue)"
+      #expect(
+        TelemetryService.sparkleBenignNoUpdateErrorCode == rendered,
+        """
+        Sparkle's SUNoUpdateError no longer renders as the constant #1979's suppression \
+        keys on. The uninformative cycle would start emitting again (volume regression), \
+        or worse, a DIFFERENT error would start being suppressed.
+        """)
     }
 
   #endif  // DEBUG


### PR DESCRIPTION
**Part of #1979.** This is candidate 1 of three, narrowed to the one shape the measurement actually justifies. #1979 stays open: `proactive_check_triggered`, `hotkey.pressed`, the three-events-per-dictation fold, and the founder call on trim-vs-pay are all untouched.

## What changes

`update.sparkle_cycle_finished` no longer emits when the cycle is fully self-consistent and benign — `no_update_reason=on_latest_version` **and** `version_staleness_bucket=on_latest` **and** `error_code=SUSparkleErrorDomain.1001`.

Measured 2026-08-12 (30d, production, 3 dev ids excluded, 548,800 events): that is **48,943 of the event's 56,678 rows — 8.9% of ALL production telemetry**, emitted hourly per user forever, saying only "we checked, you are already current".

## What deliberately still emits

Sparkle reports "no update available" **as an error**, so error-presence is not a failure signal and a naive "drop the successes" cut would have been wrong. The cross-tab is what shaped the predicate:

| `no_update_reason` | `version_staleness_bucket` | `error_code` | rows | |
|---|---|---|---:|---|
| `on_latest_version` | `on_latest` | `.1001` | 48,943 | **dropped** |
| `on_latest_version` | `patch_behind` | `.1001` | 251 | kept |
| `on_latest_version` | `minor_behind` | `.1001` | 86 | kept |
| `on_newer_than_latest_version` | `on_latest` | `.1001` | 1 | kept |
| (absent) | any | `.1005` `SURunningTranslocated` | 4,144 | kept |
| (absent) | any | `.2001` `SUDownloadError` | 3,078 | kept |
| (absent) | any | `.4007` / `.4005` / `.1003` / none | rest | kept |

The **337 contradiction rows** are the ones worth the most per row: a reason saying "you are current" beside a bucket saying "you are behind" is exactly how #847 (Sparkle telling a stale user they are up to date) would be seen recurring. A cruder trim would have deleted the detector for the bug the property was added to diagnose.

`.1005` is the #1919 population who can never update at all. Keeping it was not optional.

## Why it is safe

- **No consumer.** No worker queries any `update.*` event. Positive control: `dictation.completed` returns 9 worker hits, so the sweep finds things.
- **Fleet staleness survives.** `version-scorecard.js` derives version from `app_version` on ordinary telemetry, never from `version_staleness_bucket`.
- **The purpose is discharged.** `no_update_reason` was added by #847 Phase 1 for a diagnosis that closed 2026-05-31.

## What it costs, stated plainly

Successful no-update cycles are no longer a denominator, so a Sparkle **error rate** is not computable from this event alone. `update.proactive_check_triggered` still answers "are checks running".

That event is **deliberately not trimmed here**, though it is 7.0% of volume: its own doc comment says the non-fired cases are what this event cannot show, so suppressing them would delete the reason it exists. If volume later forces it, sample and record the rate — do not suppress.

## Tests

- 1 suppression case.
- 7 retention cases: both contradictions, `on_newer_than_latest_version`, `.1005`, `.2001`, no-error, and an update found for a stale user.
- A **freeze test** tying the error-code constant to Sparkle's own `SUError.noUpdateError`, because `EnviousWisprServices` cannot import Sparkle to say it in types. If Sparkle renumbers, the alternative to this test is either the volume silently returning or a *different* error being silently suppressed.

**Mutation control:** removing the gate fails the suppression test **alone** and leaves all 7 retention cases green — so the guard fires on its target and not on healthy shapes.

Suppression runs **before** the DEBUG hook as well as the capture, so tests observe exactly what production emits.

Full Debug suite: **5,360 tests, TEST SUCCEEDED.**

## Note for whoever reads the graph later

Expect a volume cliff on this event at the release that carries this, and do not read it as update checks stopping. Recorded in `analytics-operations.md` FACT: app-posthog-events, which had no `update.*` rows before this change.
