### PR TITLE
fix(settings): stop promising Auto follows the macOS default when it may not

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Settings/AudioSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AudioSettingsView.swift
@@ -45,8 +45,16 @@ struct AudioSettingsView: View {
       BrandedPanel(
         icon: "mic",
         header: "Input Device",
+        // #2030: this promised Auto "follows the input device currently selected in
+        // macOS", which #2022 made false for the diverted cohort: when that device is
+        // proven not to be a microphone and a real one is available, the ladder refuses
+        // it and binds the physical device instead. The status pill beside this copy
+        // already names the device actually opened, so leaving the promise unqualified
+        // made the card contradict itself on exactly the machines the divert exists for.
         description:
-          "Select which microphone to use for recording. \"Auto\" follows the input device currently selected in macOS."
+          "Select which microphone to use for recording. \"Auto\" follows the input "
+          + "device selected in macOS. If that device turns out not to be a real "
+          + "microphone, recording uses an available microphone instead."
       ) {
         HStack(spacing: 10) {
           Picker("", selection: inputDeviceSelection) {


### PR DESCRIPTION
**Closes #2030.** Second half of a cloud-review finding whose first half shipped inside the PR that produced it.

## The contradiction

The Input Device card told the user Auto *"follows the input device currently selected in macOS."* #2022/#2025 made that false for a specific cohort: when the system default is proven **not** to be a microphone (a virtual or aggregate device such as Krisp) and a real microphone is available, the resolver refuses the default at rung 3 and binds the physical device at rung 4.

The card then contradicted **itself**. The status pill directly beside this sentence was already fixed in #2025 to name the device actually opened (`autoInputDeviceName` → `AudioDeviceEnumerator.resolvedAutoInputDeviceID()`), so on exactly the machines the divert exists for the user saw:

> Using **MacBook Pro Microphone**
> *"Auto" follows the input device currently selected in macOS.* ← and macOS was set to Krisp

## The wording, and why it is conditional

> Select which microphone to use for recording. "Auto" follows the input device selected in macOS. If that device turns out not to be a real microphone, recording uses an available microphone instead.

The conditional is deliberate. The ladder only refuses the default **when an eligible physical device exists**, so a flat "skips virtual devices" would be the same overpromise pointing the other way.

## Sibling

#2031 (the Bluetooth classifier reading the raw default) was **also** fixed in #2025 and is now closed with the verification. Both were filed from the same review of the same PR and both were addressed before it merged; nobody closed them. This PR is the only part that was genuinely still outstanding.

## Verification

- **Single instance before changing it.** Swept the *claim*, not the file, across `website/src/content/help`, `website/src/pages` and the settings views: this line only. Control: 14 help articles mention "microphone", so the sweep reaches that tree.
- No test asserted the old string.
- Full Debug suite: **5,357 tests, TEST SUCCEEDED.**
- Codex whole-diff review: clean. Run on the `codex-5.3-spark` fallback because the flagship returned `Selected model is at capacity` twice, which is the documented fallback path, not a bypass.
