### PR TITLE
test(pipeline): wait for the terminal a scenario asserts, not for quiescence

### DIFF
--- a/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
@@ -54,6 +54,15 @@ protocol RecordingSessionDriving: AnyObject {
   /// step ordering against a real FSM). No-op for the synchronous stub.
   func drainReadyWork() async
 
+  /// Wait for the SUT's own conclusion signal, then drain (#1868).
+  ///
+  /// A protocol REQUIREMENT rather than an extension-only method so a
+  /// protocol-typed caller dispatches to the kernel wrapper's real
+  /// implementation. As a plain extension member this would statically
+  /// dispatch to the default below and silently do nothing extra, which is
+  /// the failure this exists to remove.
+  func drainUntilConcluded() async
+
   /// Inject a limb / finalizer / storage failure (PR-3 plan §14a). The
   /// kernel-wrapper records it; its `processText` / `store` seams read it.
   /// No-op for the stub (PR-2's `.limb` step was data-only).
@@ -63,6 +72,9 @@ protocol RecordingSessionDriving: AnyObject {
 extension RecordingSessionDriving {
   /// Default — a synchronous SUT (`StubRecordingSession`) has no async work.
   func drainReadyWork() async {}
+  /// Default — a synchronous SUT concludes inline, so there is no separate
+  /// conclusion signal to wait on and quiescence IS conclusion.
+  func drainUntilConcluded() async { await drainReadyWork() }
   /// Default — the stub does not model limb failures.
   func inject(_ limb: LimbDirective) {}
 }

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioRunner.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioRunner.swift
@@ -60,7 +60,30 @@ struct ScenarioRunner {
     // the released forward-path work run to its terminal state.
     context.clock.drainPending()
     context.vad.finish()
-    await context.sut.drainReadyWork()
+    // #1868: `drainReadyWork` is a QUIESCENCE heuristic, not a completion
+    // signal. Its own Scope note predicted recurrence at continuations other
+    // than the recording-exit hand-off, and CI hit exactly that: A14 ("adapter
+    // fails after audio captured, retry also exhausted") settled while the
+    // finalize-then-retry continuation was still a ready task, so the check
+    // below read a stale `transcribing` and reported a stuck session on a
+    // healthy kernel. A14 has no `advanceClock` and no VAD step, so the
+    // trigger is any continuation losing the scheduler lottery for the whole
+    // 64-yield window, not only a clock-resumed one.
+    //
+    // Where the scenario asserts a TERMINAL state, wait for the kernel's own
+    // conclusion signal instead — the thing being asserted is the thing to
+    // wait on. Do NOT widen the stability window (swift-testing-patterns.md
+    // `yield-settle-needs-inflight-signal-not-count`).
+    //
+    // Gated on `isTerminal` because A16 ("stop without active session")
+    // expects `.idle`: no session is ever minted, so no conclusion is ever
+    // published and a wait would burn the livelock cap and record a failure.
+    // `drainUntilConcluded` ends in `drainReadyWork`, so this is a superset.
+    if scenario.expected.terminalState.isTerminal {
+      await context.sut.drainUntilConcluded()
+    } else {
+      await context.sut.drainReadyWork()
+    }
 
     failures.append(contentsOf: checkOutcome(scenario.expected, context: context))
     return ScenarioResult(scenarioID: scenario.id, failures: failures)

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioRunnerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioRunnerTests.swift
@@ -127,4 +127,65 @@ struct ScenarioRunnerTests {
     _ = await ScenarioRunner().run(scenario, context: makeContext(sut: stub))
     #expect(stub.triggerLog == [.start, .stop, .reset])
   }
+
+  // MARK: - #1868: the runner waits on the asserted signal, not on quiescence
+
+  /// Records which drain the runner chose. The contention tests in
+  /// `DrainReadyWorkSettleTests` are honest that they cannot prove
+  /// red-without-fix (cooperative executor ordering is not controllable from
+  /// test code), so the ROUTING is what gets locked deterministically here.
+  @MainActor
+  private final class DrainSpy: RecordingSessionDriving {
+    private(set) var state: FSMState = .idle
+    private(set) var effects = SessionEffects()
+    private(set) var concludedCalls = 0
+    private(set) var readyWorkCalls = 0
+
+    func apply(_ trigger: SessionTrigger) async {}
+    func drainReadyWork() async { readyWorkCalls += 1 }
+    func drainUntilConcluded() async {
+      concludedCalls += 1
+      await drainReadyWork()
+    }
+    func inject(_ limb: LimbDirective) {}
+  }
+
+  @Test("a scenario asserting a TERMINAL state waits for the conclusion signal")
+  func terminalAssertingScenarioWaitsForConclusion() async {
+    let spy = DrainSpy()
+    let scenario = Scenario(
+      id: "SELFTEST-1868-TERMINAL",
+      name: "terminal-asserting scenario routes to the conclusion wait",
+      steps: [.trigger(.start), .trigger(.stop)],
+      expected: ExpectedOutcome(
+        terminalState: .failed(.asrFailed), pasteCount: 0, pasteOutcome: .none,
+        transcript: .none))
+    _ = await ScenarioRunner().run(scenario, context: makeContext(sut: spy))
+    #expect(
+      spy.concludedCalls == 1,
+      """
+      #1868: the teardown drain must wait for the kernel's own conclusion signal \
+      when a terminal is asserted. Quiescence alone let A14 read a stale \
+      `transcribing` and report a stuck session on a healthy kernel.
+      """)
+  }
+
+  @Test("a scenario asserting a NON-terminal state must not wait for a conclusion")
+  func nonTerminalScenarioDoesNotWaitForConclusion() async {
+    let spy = DrainSpy()
+    // A16's shape: `stop` with no active session, so no session is ever minted
+    // and no conclusion is ever published. Waiting would burn the livelock cap
+    // and record a give-up failure on a scenario that is behaving correctly.
+    let scenario = Scenario(
+      id: "SELFTEST-1868-IDLE",
+      name: "no-session scenario keeps the plain drain",
+      steps: [.trigger(.stop)],
+      expected: ExpectedOutcome(
+        terminalState: .idle, pasteCount: 0, pasteOutcome: .none, transcript: .none))
+    _ = await ScenarioRunner().run(scenario, context: makeContext(sut: spy))
+    #expect(
+      spy.concludedCalls == 0,
+      "#1868: `.idle` is not terminal, so A16 and its kin must keep the plain drain.")
+    #expect(spy.readyWorkCalls > 0, "the plain drain must still run")
+  }
 }


### PR DESCRIPTION
**Closes #1868.** Tests-only. Removes a flake on the merge-blocking heart-path gate.

## The flake, and why it now matters more

`ScenarioRunner`'s teardown used `drainReadyWork()`, a **quiescence heuristic**: it returns once `workEpoch` has been stable for 64 yields and no recording-exit hand-off is outstanding. That is not a completion signal, and its own Scope note named the next recurrence verbatim:

> If a future flake reports a stale `transcribing` / `warmingUp` after an `advanceClock` or VAD step, those are the next signals to gate the same way.

CI hit exactly that on PR #2037, a telemetry-only diff touching no pipeline, kernel, audio or FSM code:

```
scenario A14 (adapter fails after audio captured, retry also exhausted):
  final state: expected failed(asrFailed), got transcribing
  no terminal state reached — session is stuck at transcribing
```

`build-debug` is the sole required check, so this **blocks merges** rather than costing a local re-run. The expensive failure mode is not the lost minutes: it is a real regression eventually waved through as "probably the known flake".

**New fact:** A14 has no `advanceClock`, no VAD step and no clock manipulation. Its steps are `crashOnFinalize`, a failing retry result, `start`, `deliverBuffer`, `stop`. The trigger is *any* continuation losing the scheduler lottery for the whole 64-yield window, so the Scope note's framing was narrower than the real trigger set.

## The fix

Where a scenario asserts a **terminal** state, wait for the kernel's own conclusion signal via the existing `drainUntilConcluded()` (#1857) rather than for quiescence. The thing being asserted is the thing to wait on.

The stability window is **not** widened. `swift-testing-patterns.md` `yield-settle-needs-inflight-signal-not-count` forbids raising N, and a larger N makes this rarer without removing it.

Three load-bearing details:

- **`drainUntilConcluded` is promoted to a protocol requirement.** As an extension-only member it would statically dispatch to the default for a protocol-typed `sut` and silently do nothing extra, which is precisely the failure being removed. The default (`await drainReadyWork()`) is correct for `StubRecordingSession`, which concludes inline.
- **Gated on `expected.terminalState.isTerminal`**, so A16 ("stop without active session", expects `.idle`) keeps the plain drain. A16 mints no session, so no conclusion is ever published and an ungated wait would burn the 20,000-yield livelock cap and record a give-up failure on a healthy scenario.
- **`drainUntilConcluded` ends in `drainReadyWork`**, so this is a superset of the old behaviour, never a replacement.

## Why the tests lock routing rather than reproduce the flake

`DrainReadyWorkSettleTests` is explicit that its contention test **cannot** prove red-without-fix, because cooperative executor ordering is not controllable from test code. The scenario suite passes 5/5 locally before and after. So the deterministic guarantee is the routing itself: a `DrainSpy` records which drain the runner chose.

- terminal-asserting scenario → takes the conclusion wait
- `.idle`-asserting scenario → does **not**, and the plain drain still runs

**Mutation control:** reverting the routing fails the terminal case alone and leaves the non-terminal one green.

Full Debug suite: **5,362 tests, TEST SUCCEEDED.** Codex whole-diff review clean (run on the `codex-5.3-spark` fallback; the flagship returned `Selected model is at capacity`).

## Adjacent surface, stated rather than swept

14 other test files call `drainReadyWork()` directly with their own assertions rather than through the runner, and only one has adopted the conclusion wait. **Not touched here.** Each has its own context and its own asserted signal, so a blanket rewrite would be a partial port done blind. The merge-blocking gate is the one that was failing and the one fixed.
