### PR TITLE
test(alias): give the permit-deadline hang guard room the subject's own deadline allows

### DIFF
--- a/Tests/EnviousWisprTests/Services/WordSuggestionServiceTests.swift
+++ b/Tests/EnviousWisprTests/Services/WordSuggestionServiceTests.swift
@@ -954,7 +954,21 @@ struct WordSuggestionServicePermitQueueTests {
     // physically running (its gate is still closed here), proving the
     // logical permit was released at the deadline despite the
     // non-cooperating first caller.
-    let secondResult = try await withThrowingTimeout(seconds: 5) { await second.value }
+    // 30s, not the suite's usual 5s hang guard, and the difference is deliberate.
+    // Every other guard here bounds a `Task.yield()` loop that completes almost
+    // immediately. This one awaits work that must make progress WHILE a
+    // deliberately non-cooperating task spins on the same cooperative pool, so
+    // under full-suite CI contention (465 suites in parallel) the second task can
+    // legitimately be starved for seconds. A guard TIGHTER than the subject's own
+    // `deadlineSeconds: 30` can therefore fire on correct behaviour, which is what
+    // it did on main post-merge for `c634eb0c`: `Task timed out after 5.0s` on a
+    // run whose diff touched only the kernel scenario simulator.
+    //
+    // This is a hang guard, not the assertion (see the comment above), so raising
+    // it masks nothing: a genuinely stranded permit still fails the test, just
+    // later. That is the opposite of widening a settle window, which WOULD hide the
+    // defect (swift-testing-patterns.md `yield-settle-needs-inflight-signal-not-count`).
+    let secondResult = try await withThrowingTimeout(seconds: 30) { await second.value }
     #expect(secondResult, "the second request must be granted despite the first still running")
 
     let firstResult = await first.value


### PR DESCRIPTION
Tests-only. Fixes a **main post-merge** failure.

## What happened

`nonCooperatingOperationDoesNotStrandThePermit` failed main post-merge for `c634eb0c` with `Task timed out after 5.0s`. That commit's only files were the kernel scenario simulator, and this suite passes 9/9 locally.

## Why 5s could fire on correct behaviour

The 5s is a **hang guard**, not the assertion — the test's own comment says the key claim is that the second operation is granted *while the first is still physically running*, not elapsed-time precision.

Every **other** guard in this suite bounds a `Task.yield()` loop that completes almost immediately, so 5s is right for them and they are unchanged. This one is different: it awaits work that must make progress **while a deliberately non-cooperating task spins on the same cooperative pool** (`waitIgnoringCancellation`). Under full-suite CI contention — 465 suites in parallel on a hosted runner — the second task can legitimately be starved for seconds.

The structural defect is that the guard was **tighter than the subject's own `deadlineSeconds: 30`**. A guard that expires before the behaviour it guards is allowed to take will eventually fire on correct behaviour. 30s aligns the two.

## Why raising it is safe here, and would not be elsewhere

Raising a **hang guard** masks nothing: a genuinely stranded permit still fails the test, just later.

That is the opposite of widening a **settle window**, which would hide the defect. `swift-testing-patterns.md` `yield-settle-needs-inflight-signal-not-count` governs that case — and it is why #2039 (merged an hour ago) fixed the A14 scenario flake by waiting on the kernel's conclusion **signal** rather than by raising N. Two flakes, two different correct answers.

## No mutation control, deliberately

Reverting to 5s **also passes locally**, because the failure only reproduces under CI contention that test code cannot summon. Saying so rather than dressing something up as a reproduction. The evidence is the CI failure on an unrelated diff plus the guard-tighter-than-the-deadline argument above.

Full Debug suite: **5,362 tests, TEST SUCCEEDED.** Codex whole-diff review clean (`codex-5.3-spark` fallback; the flagship is returning `Selected model is at capacity`).
