### PR TITLE
fix(asr): give the vendor's encoder-instantiation failure its own identity again

### DIFF
--- a/Sources/EnviousWisprASR/ParakeetTranscriptionSentryError.swift
+++ b/Sources/EnviousWisprASR/ParakeetTranscriptionSentryError.swift
@@ -17,6 +17,9 @@ enum ParakeetTranscriptionSentryError: Error, LocalizedError, CustomNSError, Sen
   case unsupportedPlatform(String)
   case streamingConversionFailed(String)
   case fileAccessFailed(String)
+  /// #1654: vendor case added by the 2026-08-08 pin bump (#1985). Appended, never
+  /// inserted — every identity below is pinned by position for Sentry grouping.
+  case encoderInstantiationFailed(String)
   case unknownTranscriptionFailure(String)
 
   static let errorDomain = "EnviousWisprASR.ParakeetTranscriptionSentryError"
@@ -32,6 +35,9 @@ enum ParakeetTranscriptionSentryError: Error, LocalizedError, CustomNSError, Sen
     case .streamingConversionFailed: return 6
     case .fileAccessFailed: return 7
     case .unknownTranscriptionFailure: return 8
+    // Appended as 9, not inserted at 8: renumbering would silently re-point every
+    // existing Sentry group at a different cause.
+    case .encoderInstantiationFailed: return 9
     }
   }
 
@@ -40,7 +46,7 @@ enum ParakeetTranscriptionSentryError: Error, LocalizedError, CustomNSError, Sen
     case .notInitialized(let d), .invalidAudioData(let d), .modelLoadFailed(let d),
       .processingFailed(let d), .modelCompilationFailed(let d), .unsupportedPlatform(let d),
       .streamingConversionFailed(let d), .fileAccessFailed(let d),
-      .unknownTranscriptionFailure(let d):
+      .encoderInstantiationFailed(let d), .unknownTranscriptionFailure(let d):
       return d
     }
   }
@@ -67,6 +73,7 @@ enum ParakeetTranscriptionSentryError: Error, LocalizedError, CustomNSError, Sen
     case .unsupportedPlatform(let d): self = .unsupportedPlatform(d)
     case .streamingConversionFailed(let d): self = .streamingConversionFailed(d)
     case .fileAccessFailed(let d): self = .fileAccessFailed(d)
+    case .encoderInstantiationFailed(let d): self = .encoderInstantiationFailed(d)
     case .unknownFutureCase(let d): self = .unknownTranscriptionFailure(d)
     }
   }
@@ -87,6 +94,7 @@ enum ParakeetTranscriptionSentryError: Error, LocalizedError, CustomNSError, Sen
     case 6: self = .streamingConversionFailed(d)
     case 7: self = .fileAccessFailed(d)
     case 8: self = .unknownTranscriptionFailure(d)
+    case 9: self = .encoderInstantiationFailed(d)
     default: return nil
     }
   }
@@ -105,6 +113,8 @@ extension ParakeetTranscriptionSentryError: StableSentryErrorIdentity {
     case .unsupportedPlatform: return "FluidAudio.ASRError#5"
     case .streamingConversionFailed: return "FluidAudio.ASRError#6"
     case .fileAccessFailed: return "FluidAudio.ASRError#7"
+    // Vendor declaration ordinal 8 at pin `a1767d86`; `#8` was previously unused.
+    case .encoderInstantiationFailed: return "FluidAudio.ASRError#8"
     case .unknownTranscriptionFailure:
       return "EnviousWisprASR.ParakeetTranscriptionSentryError.unknownTranscriptionFailure"
     }
@@ -120,6 +130,8 @@ extension ParakeetTranscriptionSentryError: StableSentryErrorIdentity {
     case .unsupportedPlatform: return "parakeet_transcribe.unsupported_platform"
     case .streamingConversionFailed: return "parakeet_transcribe.streaming_conversion_failed"
     case .fileAccessFailed: return "parakeet_transcribe.file_access_failed"
+    case .encoderInstantiationFailed:
+      return "parakeet_transcribe.encoder_instantiation_failed"
     case .unknownTranscriptionFailure: return "parakeet_transcribe.unknown_transcription_failure"
     }
   }

--- a/Sources/EnviousWisprFluidAudioBridge/FluidAudioASRErrorKind.swift
+++ b/Sources/EnviousWisprFluidAudioBridge/FluidAudioASRErrorKind.swift
@@ -15,6 +15,12 @@ package enum FluidAudioASRErrorKind: Sendable, Equatable {
   case unsupportedPlatform(String)
   case streamingConversionFailed(String)
   case fileAccessFailed(String)
+  /// #1654: added by the vendor in the 2026-08-08 pin bump (#1985, `afb9aab` ->
+  /// `a1767d86`). Until now it fell through `@unknown default` into
+  /// `unknownFutureCase`, so a real named cause was arriving as the junk bucket —
+  /// the exact collapse the #1525 epic exists to prevent. Found by the compiler
+  /// while building the streaming classifier; nothing re-verified the pin bump.
+  case encoderInstantiationFailed(String)
   case unknownFutureCase(String)
 }
 
@@ -30,6 +36,7 @@ package func classifyFluidAudioASRError(_ error: any Error) -> FluidAudioASRErro
   case .unsupportedPlatform: return .unsupportedPlatform(description)
   case .streamingConversionFailed: return .streamingConversionFailed(description)
   case .fileAccessFailed: return .fileAccessFailed(description)
+  case .encoderInstantiationFailed: return .encoderInstantiationFailed(description)
   @unknown default: return .unknownFutureCase(description)
   }
 }

--- a/Tests/EnviousWisprASRTests/FluidAudioBridgeClassificationTests.swift
+++ b/Tests/EnviousWisprASRTests/FluidAudioBridgeClassificationTests.swift
@@ -14,7 +14,7 @@ import Testing
 @Suite("FluidAudio error classification (#1525 PR I-B)")
 struct FluidAudioBridgeClassificationTests {
 
-  // MARK: - FluidAudioASRErrorKind (transcription path, 8 real cases)
+  // MARK: - FluidAudioASRErrorKind (transcription path, 9 real cases)
 
   @Test("classifyFluidAudioASRError maps every real ASRError case")
   func classifiesAllASRErrorCases() {
@@ -46,6 +46,14 @@ struct FluidAudioBridgeClassificationTests {
           ASRError.fileAccessFailed(
             URL(fileURLWithPath: "/tmp/x"), NSError(domain: "fixture", code: 2)
           ).localizedDescription)
+      ),
+      // #1654: the vendor added this in the 2026-08-08 pin bump (#1985). Until it was
+      // enumerated it fell through `@unknown default` into `unknownFutureCase`, so a
+      // real named cause was reaching Sentry as the junk bucket. This row is what
+      // makes that drift a test failure instead of a silent collapse.
+      (
+        .encoderInstantiationFailed("x"),
+        .encoderInstantiationFailed(ASRError.encoderInstantiationFailed("x").localizedDescription)
       ),
     ]
     for (vendorError, expected) in cases {

--- a/Tests/EnviousWisprTests/ASR/ParakeetTranscriptionSentryErrorTests.swift
+++ b/Tests/EnviousWisprTests/ASR/ParakeetTranscriptionSentryErrorTests.swift
@@ -35,6 +35,10 @@ struct ParakeetTranscriptionSentryErrorTests {
     ),
     (.fileAccessFailed("x"), "FluidAudio.ASRError#7", "parakeet_transcribe.file_access_failed"),
     (
+      .encoderInstantiationFailed("x"), "FluidAudio.ASRError#8",
+      "parakeet_transcribe.encoder_instantiation_failed"
+    ),
+    (
       .unknownTranscriptionFailure("x"),
       "EnviousWisprASR.ParakeetTranscriptionSentryError.unknownTranscriptionFailure",
       "parakeet_transcribe.unknown_transcription_failure"
@@ -51,11 +55,11 @@ struct ParakeetTranscriptionSentryErrorTests {
     }
   }
 
-  @Test("all 9 declared identities are unique")
+  @Test("all 10 declared identities are unique")
   func identitiesAreUnique() {
     let errors = Self.pins.map(\.0)
-    #expect(Set(errors.map(\.sentryFingerprintDescriptor)).count == 9)
-    #expect(Set(errors.map(\.sentrySemanticID)).count == 9)
+    #expect(Set(errors.map(\.sentryFingerprintDescriptor)).count == 10)
+    #expect(Set(errors.map(\.sentrySemanticID)).count == 10)
   }
 
   // MARK: - B. Mapping completeness — built from FluidAudioASRErrorKind
@@ -71,6 +75,7 @@ struct ParakeetTranscriptionSentryErrorTests {
       (.unsupportedPlatform("f"), .unsupportedPlatform("f")),
       (.streamingConversionFailed("g"), .streamingConversionFailed("g")),
       (.fileAccessFailed("h"), .fileAccessFailed("h")),
+      (.encoderInstantiationFailed("j"), .encoderInstantiationFailed("j")),
       (.unknownFutureCase("i"), .unknownTranscriptionFailure("i")),
     ]
     for (kind, expected) in cases {


### PR DESCRIPTION
Found by the compiler while building #1654's streaming classifier. **Not a regression introduced here — a live one that has been shipping since the 2026-08-08 fork bump.**

## What broke, and when

`FluidAudio.ASRError` gained a **ninth** case, `encoderInstantiationFailed(String)`, in #1985 (`afb9aab` → `a1767d86`). Our batch classifier was written against the eight that existed at PR I-B time.

Since that bump the new case has fallen through `@unknown default` into `unknownFutureCase`, reaching Sentry as `ParakeetTranscriptionSentryError.unknownTranscriptionFailure` — the junk bucket. The vendor's own description for it is **"Encoder ANE program failed to instantiate"**, a specific and actionable ASR failure. Collapsing exactly that into an unnamed bucket is the failure the #1525 epic exists to prevent.

**Nothing could have caught it.** No test fed the vendor enum, so the drift was invisible; the compiler's exhaustiveness warning was the only signal, and it appeared solely because #1654 added a second switch over the same type. The plan for #1654 says reachability "must be re-verified on any FluidAudio pin bump" — this is that re-verification, happening at the only moment anyone was going to do it.

## What ships

- `FluidAudioASRErrorKind` gains the case; `classifyFluidAudioASRError` maps it.
- `ParakeetTranscriptionSentryError` gains the matching case with `errorCode` **9 — appended, never inserted at 8.** Renumbering would silently re-point every existing Sentry group at a different cause (`sentry-operations.md` RULE: sentry-identity-is-declared-never-inherited).
- Fingerprint `FluidAudio.ASRError#8` — the vendor's own declaration ordinal at the shipped pin, previously unused, matching the convention every sibling follows.
- Semantic ID `parakeet_transcribe.encoder_instantiation_failed`.

**Expected Sentry effect, stated so it is not a surprise:** events currently in `unknownTranscriptionFailure` whose cause is encoder instantiation will split into a new group. That is the point, not a side effect.

## The test asymmetry is the interesting part

The identity tests in `ParakeetTranscriptionSentryErrorTests` start from the **kind**, so they cannot see classifier drift. Verified rather than assumed: with the classifier case removed, those 7 tests **still pass**, while the bridge test fails with

```
.unknownFutureCase("Encoder ANE program failed to instantiate: x")
  != .encoderInstantiationFailed("Encoder ANE program failed to instantiate: x")
```

That asymmetry is precisely why the drift shipped. The new row in `FluidAudioBridgeClassificationTests` — which feeds the **real vendor error** — is what makes the next pin bump a test failure instead of a silent collapse.

Mutation control run in both directions, restored and re-verified green.

## Scope

Deliberately **not** part of #1654. That issue covers the streaming path; this is the batch path and an earlier-PR contract bug, which `workflow-process.md` RULE: route-gaps-not-block-on-them says to route separately rather than absorb. #1654's streaming work continues on its own branch.

Closes no issue. Full Debug suite: **5,362 tests, TEST SUCCEEDED.** Codex whole-diff review clean (`codex-5.3-spark` fallback; flagship at capacity).
