### PR TITLE
fix(ui): stop promising a recovered recording will land in History

### DIFF
--- a/Sources/EnviousWisprAppKit/App/DictationNarrator.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationNarrator.swift
@@ -216,7 +216,24 @@ enum DictationNarrator {
   static let clipboardFallbackText = "Copied. Press \u{2318}V to paste"
   static let accessibilityToastText = "Auto-paste needs Accessibility"
   static let recoveryTitle = "Recovering your last recording…"
-  static let recoverySubtitle = "Saved to History when it's done"
+  /// #1897 — CONDITIONAL, and it must stay that way. This read "Saved to History
+  /// when it's done", which asserts an outcome the app cannot know yet: ~93% of
+  /// recoveries reconstruct the audio perfectly and find no speech in it, so
+  /// nothing lands in History and the pill has already promised that it would.
+  /// Roughly 302 events across 50 users a month, every one a broken promise.
+  ///
+  /// Founder decision 2026-08-12, given the choice between adding a failure
+  /// notice and removing the promise: *"stop promising, just close the loop
+  /// quietly."* An empty recording is normal behaviour — someone pressed the key
+  /// and chose not to speak — so announcing it would be wrong; the defect was
+  /// only ever the promise. `OverlayIntent` therefore keeps exactly its two
+  /// recovery cases and gains NO failure case, which is what this issue's body
+  /// originally proposed and what that decision explicitly declines.
+  ///
+  /// The quiet close needs no code: this pill is a transient notice with a 6s
+  /// auto-dismiss (`RecordingOverlayPanel`), so a recovery that yields nothing
+  /// already ends by the pill simply going away.
+  static let recoverySubtitle = "Anything found goes to History"
   /// The recovery pill's CONTAINER accessibility label (no ellipsis — distinct
   /// bytes from `recoveryTitle`). VoiceOver reads it as the group's spoken status.
   static let recoveryAccessibilityLabel = "Recovering your last recording"

--- a/Sources/EnviousWisprAppKit/App/DictationNarrator.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationNarrator.swift
@@ -218,17 +218,33 @@ enum DictationNarrator {
   static let recoveryTitle = "Recovering your last recording…"
   /// #1897 — CONDITIONAL, and it must stay that way. This read "Saved to History
   /// when it's done", which asserts an outcome the app cannot know yet: ~93% of
-  /// recoveries reconstruct the audio perfectly and find no speech in it, so
-  /// nothing lands in History and the pill has already promised that it would.
+  /// recoveries reconstruct the audio perfectly and then have ASR return an
+  /// empty result, so nothing lands in History and the pill has already promised
+  /// that it would. (An empty ASR result, never "the recording was silent" — see
+  /// the cause paragraph below.)
   /// Roughly 302 events across 50 users a month, every one a broken promise.
   ///
   /// Founder decision 2026-08-12, given the choice between adding a failure
   /// notice and removing the promise: *"stop promising, just close the loop
-  /// quietly."* An empty recording is normal behaviour — someone pressed the key
-  /// and chose not to speak — so announcing it would be wrong; the defect was
-  /// only ever the promise. `OverlayIntent` therefore keeps exactly its two
-  /// recovery cases and gains NO failure case, which is what this issue's body
-  /// originally proposed and what that decision explicitly declines.
+  /// quietly."* The defect was only ever the promise. `OverlayIntent` therefore
+  /// keeps exactly its two recovery cases and gains NO failure case, which is
+  /// what this issue's body originally proposed and what that decision
+  /// explicitly declines.
+  ///
+  /// **Why an announcement would be wrong is the ABSENCE of a cause, not a known
+  /// one.** All that is observed on this path is that ASR ran without error and
+  /// returned nothing — see the `recoveryEmptyText` contract in
+  /// `SentryBreadcrumb`, which states outright that this is deliberately NOT
+  /// "the recording was silent", because the replay path holds no speech
+  /// evidence and neither duration nor energy can supply it. A recogniser miss
+  /// on real speech and a person who chose not to speak are indistinguishable
+  /// here. That is a STRONGER argument for staying quiet than a known cause
+  /// would be: any sentence naming a reason would be asserting one of two
+  /// possibilities we cannot tell apart.
+  ///
+  /// (An earlier draft of this comment said "someone pressed the key and chose
+  /// not to speak", which contradicted that contract 200 lines away in this same
+  /// change. Cloud review caught it. Do not reintroduce a cause here.)
   ///
   /// The quiet close needs no code: this pill is a transient notice with a 6s
   /// auto-dismiss (`RecordingOverlayPanel`), so a recovery that yields nothing

--- a/Sources/EnviousWisprAppKit/App/DictationNarrator.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationNarrator.swift
@@ -217,12 +217,9 @@ enum DictationNarrator {
   static let accessibilityToastText = "Auto-paste needs Accessibility"
   static let recoveryTitle = "Recovering your last recording…"
   /// #1897 — CONDITIONAL, and it must stay that way. This read "Saved to History
-  /// when it's done", which asserts an outcome the app cannot know yet: ~93% of
-  /// recoveries reconstruct the audio perfectly and then have ASR return an
-  /// empty result, so nothing lands in History and the pill has already promised
-  /// that it would. (An empty ASR result, never "the recording was silent" — see
-  /// the cause paragraph below.)
-  /// Roughly 302 events across 50 users a month, every one a broken promise.
+  /// when it's done", which asserts an outcome the app cannot know yet, and a
+  /// recovery that ends without text says nothing at all — so the pill had
+  /// already promised something that never arrived.
   ///
   /// Founder decision 2026-08-12, given the choice between adding a failure
   /// notice and removing the promise: *"stop promising, just close the loop
@@ -231,27 +228,29 @@ enum DictationNarrator {
   /// what this issue's body originally proposed and what that decision
   /// explicitly declines.
   ///
-  /// **Why an announcement would be wrong is the ABSENCE of a cause, not a known
-  /// one.** All that is observed on this path is that ASR ran without error and
-  /// returned nothing — see the `recoveryEmptyText` contract in
-  /// `SentryBreadcrumb`, which states outright that this is deliberately NOT
-  /// "the recording was silent", because the replay path holds no speech
-  /// evidence and neither duration nor energy can supply it. A recogniser miss
-  /// on real speech and a person who chose not to speak are indistinguishable
-  /// here. That is a STRONGER argument for staying quiet than a known cause
-  /// would be: any sentence naming a reason would be asserting one of two
-  /// possibilities we cannot tell apart.
+  /// **An announcement would be wrong because the cause is UNKNOWN, not because
+  /// it is known-benign.** The single authority on what an empty recovery result
+  /// does and does not establish is the `recoveryEmptyText` doc comment in
+  /// `SentryBreadcrumb` — read it there rather than trusting any restatement,
+  /// including this one. Its consequence for copy: a recogniser miss on real
+  /// speech and a person who chose not to speak are indistinguishable here, so
+  /// any sentence naming a reason asserts one of two possibilities we cannot
+  /// tell apart.
   ///
-  /// (An earlier draft of this comment said "someone pressed the key and chose
-  /// not to speak", which contradicted that contract 200 lines away in this same
-  /// change. Cloud review caught it. Do not reintroduce a cause here.)
+  /// **Four review rounds on this one string each killed a different unsupported
+  /// claim in this comment** — a promised delivery, a promise conditioned on the
+  /// wrong link, an invented cause, and a statistic quoted with the wrong
+  /// denominator. Every one was a fact restated here that is owned somewhere
+  /// else. Hence the rule this block now follows: state the DECISION and point at
+  /// the owner; do not reproduce its numbers or its reasoning. If you find
+  /// yourself adding a figure here, put it where the contract lives instead.
   ///
   /// The quiet close needs no code: this pill is a transient notice with a 6s
   /// auto-dismiss (`RecordingOverlayPanel`), so a recovery that yields nothing
   /// already ends by the pill simply going away.
   ///
-  /// **TWO axes can each defeat delivery, and a fix that closes only one is the
-  /// same defect again.** This shipped as "Anything found goes to History" and
+  /// **MORE THAN ONE link can defeat delivery, and a fix that closes only one
+  /// is the same defect again.** This shipped as "Anything found goes to History" and
   /// cloud review killed it: conditioning on *found* still asserts the save.
   /// `RecoverySpoolReplayer` can produce text and then have
   /// `transcriptStore.save` throw (disk full, History unwritable), returning

--- a/Sources/EnviousWisprAppKit/App/DictationNarrator.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationNarrator.swift
@@ -233,7 +233,19 @@ enum DictationNarrator {
   /// The quiet close needs no code: this pill is a transient notice with a 6s
   /// auto-dismiss (`RecordingOverlayPanel`), so a recovery that yields nothing
   /// already ends by the pill simply going away.
-  static let recoverySubtitle = "Anything found goes to History"
+  ///
+  /// **TWO axes can each defeat delivery, and a fix that closes only one is the
+  /// same defect again.** This shipped as "Anything found goes to History" and
+  /// cloud review killed it: conditioning on *found* still asserts the save.
+  /// `RecoverySpoolReplayer` can produce text and then have
+  /// `transcriptStore.save` throw (disk full, History unwritable), returning
+  /// `.failed(.save)`; `RecoveryCoordinator` posts its notice only for
+  /// `.recovered`, so that path shows nothing and the pill has again promised an
+  /// outcome that never happened. Condition on the LAST link instead: only a
+  /// transcript that actually saved reaches History, and that holds by
+  /// construction because `transcriptCoordinator.append` is non-throwing and runs
+  /// immediately after a successful `save`.
+  static let recoverySubtitle = "Anything saved lands in History"
   /// The recovery pill's CONTAINER accessibility label (no ellipsis — distinct
   /// bytes from `recoveryTitle`). VoiceOver reads it as the group's spoken status.
   static let recoveryAccessibilityLabel = "Recovering your last recording"

--- a/Sources/EnviousWisprServices/SentryBreadcrumb.swift
+++ b/Sources/EnviousWisprServices/SentryBreadcrumb.swift
@@ -421,10 +421,15 @@ public enum SentryBreadcrumb {
     /// mismatch, or an empty/torn prefix). Non-crash limb — the orphan is deleted.
     /// #1897: this said "and the user sees 'couldn't recover'". It does not.
     /// `OverlayIntent` has exactly two recovery cases, `recoveringLastRecording`
-    /// and `recoverySucceeded`; there is no failure case, so nothing is shown and
-    /// the "Saved to History when it's done" promise is dropped in silence. The
-    /// #1063 PR2 plan §2 required "no silent disappearance" and it was never
-    /// built. Do not restore that sentence here without a user-visible surface.
+    /// and `recoverySucceeded`; there is no failure case, so nothing is shown.
+    ///
+    /// That silence is now the INTENDED ending, not a gap. The #1063 PR2 plan §2
+    /// required "no silent disappearance", and the resolution was to remove the
+    /// disappearing promise rather than to announce the failure: the recovery
+    /// pill's subtitle no longer asserts that anything will be saved
+    /// (`DictationNarrator.recoverySubtitle`, founder decision 2026-08-12).
+    /// Do not add a failure sentence here or a failure case to `OverlayIntent`
+    /// without reopening that decision.
     case recoveryDecryptFailed = "recovery_decrypt_failed"
     /// #1063 PR2: transcribing a recovered spool THREW. Non-crash limb (one
     /// attempt) — the orphan is deleted, and see `recoveryDecryptFailed` above

--- a/Tests/EnviousWisprTests/App/DictationNarratorTests.swift
+++ b/Tests/EnviousWisprTests/App/DictationNarratorTests.swift
@@ -295,12 +295,12 @@ import Testing
   /// control — it fails against the string this issue removed, and passes
   /// against the conditional one that replaced it. Verified in both directions.
   ///
-  /// A recovery reconstructs the audio perfectly and then gets an EMPTY ASR
-  /// result about 93% of the time, so the in-progress pill cannot know that
-  /// anything will be saved. Only the success pill, which fires after text has
-  /// landed, may say so. (Empty result, not "the recording was silent" — that
-  /// inference is refused by the `recoveryEmptyText` contract in
-  /// `SentryBreadcrumb`, because the replay path holds no speech evidence.)
+  /// A recovery can end without producing text, so the in-progress pill cannot
+  /// know that anything will be saved. Only the success pill, which fires after
+  /// text has landed, may say so. Rates and what an empty result does and does
+  /// not establish are owned by the `recoveryEmptyText` doc comment in
+  /// `SentryBreadcrumb`; deliberately not restated here, because four review
+  /// rounds on this change killed four restatements.
   ///
   /// **What this test does NOT catch, stated so nobody trusts it further than it
   /// goes.** It is a REVERT guard, not a promise detector. The first fix for this

--- a/Tests/EnviousWisprTests/App/DictationNarratorTests.swift
+++ b/Tests/EnviousWisprTests/App/DictationNarratorTests.swift
@@ -254,7 +254,7 @@ import Testing
     #expect(DictationNarrator.clipboardFallbackText == "Copied. Press \u{2318}V to paste")
     #expect(DictationNarrator.accessibilityToastText == "Auto-paste needs Accessibility")
     #expect(DictationNarrator.recoveryTitle == "Recovering your last recording…")
-    #expect(DictationNarrator.recoverySubtitle == "Anything found goes to History")
+    #expect(DictationNarrator.recoverySubtitle == "Anything saved lands in History")
     #expect(DictationNarrator.recoveryAccessibilityLabel == "Recovering your last recording")
     #expect(DictationNarrator.recoverySucceededTitle == "Recovered your last recording")
     #expect(DictationNarrator.recoverySucceededSubtitle == "Saved to History")
@@ -298,6 +298,16 @@ import Testing
   /// A recovery reconstructs the audio perfectly and finds no speech in it about
   /// 93% of the time, so the in-progress pill cannot know that anything will be
   /// saved. Only the success pill, which fires after text has landed, may say so.
+  ///
+  /// **What this test does NOT catch, stated so nobody trusts it further than it
+  /// goes.** It is a REVERT guard, not a promise detector. The first fix for this
+  /// issue shipped "Anything found goes to History", which passes here and was
+  /// still a promise — it conditions on speech being found while silently
+  /// asserting the save, and `transcriptStore.save` can throw. Cloud review
+  /// caught that; this assertion could not have. A differently-worded promise
+  /// will pass. The durable check is the reasoning recorded on
+  /// `DictationNarrator.recoverySubtitle`: enumerate every link that can defeat
+  /// delivery, and condition on the LAST one.
   @Test("the in-progress recovery subtitle never asserts the success claim")
   func recoveryInProgressSubtitleMakesNoPromise() {
     #expect(

--- a/Tests/EnviousWisprTests/App/DictationNarratorTests.swift
+++ b/Tests/EnviousWisprTests/App/DictationNarratorTests.swift
@@ -254,7 +254,7 @@ import Testing
     #expect(DictationNarrator.clipboardFallbackText == "Copied. Press \u{2318}V to paste")
     #expect(DictationNarrator.accessibilityToastText == "Auto-paste needs Accessibility")
     #expect(DictationNarrator.recoveryTitle == "Recovering your last recording…")
-    #expect(DictationNarrator.recoverySubtitle == "Saved to History when it's done")
+    #expect(DictationNarrator.recoverySubtitle == "Anything found goes to History")
     #expect(DictationNarrator.recoveryAccessibilityLabel == "Recovering your last recording")
     #expect(DictationNarrator.recoverySucceededTitle == "Recovered your last recording")
     #expect(DictationNarrator.recoverySucceededSubtitle == "Saved to History")
@@ -281,5 +281,29 @@ import Testing
     // The recovery AX label has no ellipsis; the visible title does.
     #expect(DictationNarrator.recoveryAccessibilityLabel != DictationNarrator.recoveryTitle)
     #expect(!DictationNarrator.recoveryAccessibilityLabel.contains("…"))
+  }
+
+  /// #1897 — the IN-PROGRESS recovery subtitle must not assert the outcome the
+  /// SUCCESS subtitle asserts. The byte-exact test above pins today's wording;
+  /// this one pins the founder's 2026-08-12 decision ("stop promising"), so a
+  /// future rewording cannot quietly reintroduce a promise while staying green.
+  ///
+  /// The check is a substring test rather than a word list because the defect
+  /// had exactly that shape: the old subtitle was "Saved to History when it's
+  /// done", which CONTAINS the success claim "Saved to History" verbatim and
+  /// merely appends a timing clause. So this assertion is a genuine two-way
+  /// control — it fails against the string this issue removed, and passes
+  /// against the conditional one that replaced it. Verified in both directions.
+  ///
+  /// A recovery reconstructs the audio perfectly and finds no speech in it about
+  /// 93% of the time, so the in-progress pill cannot know that anything will be
+  /// saved. Only the success pill, which fires after text has landed, may say so.
+  @Test("the in-progress recovery subtitle never asserts the success claim")
+  func recoveryInProgressSubtitleMakesNoPromise() {
+    #expect(
+      !DictationNarrator.recoverySubtitle.contains(DictationNarrator.recoverySucceededSubtitle))
+    // Guard the control itself: if the success subtitle ever stopped making an
+    // unconditional save claim, the assertion above would pass vacuously.
+    #expect(DictationNarrator.recoverySucceededSubtitle == "Saved to History")
   }
 }

--- a/Tests/EnviousWisprTests/App/DictationNarratorTests.swift
+++ b/Tests/EnviousWisprTests/App/DictationNarratorTests.swift
@@ -295,9 +295,12 @@ import Testing
   /// control — it fails against the string this issue removed, and passes
   /// against the conditional one that replaced it. Verified in both directions.
   ///
-  /// A recovery reconstructs the audio perfectly and finds no speech in it about
-  /// 93% of the time, so the in-progress pill cannot know that anything will be
-  /// saved. Only the success pill, which fires after text has landed, may say so.
+  /// A recovery reconstructs the audio perfectly and then gets an EMPTY ASR
+  /// result about 93% of the time, so the in-progress pill cannot know that
+  /// anything will be saved. Only the success pill, which fires after text has
+  /// landed, may say so. (Empty result, not "the recording was silent" — that
+  /// inference is refused by the `recoveryEmptyText` contract in
+  /// `SentryBreadcrumb`, because the replay path holds no speech evidence.)
   ///
   /// **What this test does NOT catch, stated so nobody trusts it further than it
   /// goes.** It is a REVERT guard, not a promise detector. The first fix for this


### PR DESCRIPTION
Closes #1897.

## What the user saw

The recovery pill said **"Saved to History when it's done"**, and then roughly **302 times a month across 50 users** nothing arrived and nothing was ever said. The #1063 PR2 plan required "no silent disappearance"; that notice was never built.

## Why the fix is to remove the promise, not to add the notice

Offered the choice, the founder decided (2026-08-12): **"stop promising, just close the loop quietly."**

That is the right call on the measurement rather than merely the cheaper one. **~93% of those events carry `audio_decrypted=true`** — the spool was written, encrypted, found, decrypted and reconstructed correctly, ASR ran without error, and returned an empty result. Nothing failed.

And crucially we do **not** know why it was empty. The `recoveryEmptyText` contract says so outright: this is deliberately NOT "the recording was silent", because the replay path holds no speech evidence and neither duration nor energy can supply it. A recogniser miss on real speech and a person who chose not to speak are indistinguishable here.

That absence is a *stronger* argument for staying quiet than a known cause would be — any sentence naming a reason would assert one of two possibilities we cannot tell apart, which is a second false statement delivered to more people than the first one.

**Deliberately NOT shipped: a failure case on `OverlayIntent`.** That is what the issue body proposed and what this decision declines. It stays at exactly its two recovery cases.

**The quiet close needed no code.** The pill is a transient notice with a 6s auto-dismiss, so a recovery yielding nothing already ends by the pill going away.

## The change

| | before | after |
|---|---|---|
| in-progress subtitle | `Saved to History when it's done` | `Anything saved lands in History` |
| success subtitle | `Saved to History` | unchanged — a statement of fact made after text lands |

Plus a correction to the `SentryBreadcrumb` comment that described the dropped promise. It read as a gap awaiting a fix; the silence is now the intended ending, and the comment says so and names what would reopen the decision.

## Scope verified, not assumed

The promise existed in exactly one place. `grep -rn "Saved to History"` across `Sources/ Tests/ docs/ workers/ website/ scripts/` and root files returns 9 hits, all classified: one promise (removed), the rest post-success statements of fact that stay, plus the test comment quoting the old string as history. A **positive control** ("history" → 12 files in the help centre) proves the web sweep could have found something had it been there.

## Round 2 — cloud review caught the same defect in the fix

The first fix read `Anything found goes to History`. Cloud review (P2) correctly killed it: conditioning on *found* still asserts the save. `RecoverySpoolReplayer.swift:349-367` can produce text and then have `transcriptStore.save` throw (disk full, History unwritable), returning `.failed(.save)`, and `RecoveryCoordinator.swift:848-849` posts its notice only for `.recovered` — so that path shows nothing and the pill has again promised an outcome that never happened.

**Two axes can each defeat delivery, and closing one is the same defect again.** The final wording conditions on the LAST link: only a transcript that actually saved reaches History, which holds by construction because `transcriptCoordinator.append` is non-throwing and runs immediately after a successful `save`.

Classified before fixing. **HYPOTHETICAL, not reproducible:** `recovery.completed` carries **zero** `save_failed` events in 90 days. A positive control on the same query returned all 11 live reason values, and the spelling was verified against `RecoveryTelemetryReason:67` rather than guessed, so the zero is the world and not the instrument. Fixed anyway because the exception applies exactly — the change is trivial AND the failure is silent by construction, which is this issue's entire subject.

## Tests

The byte-exact freeze row is updated, and a new property test pins the **decision** rather than the letters: the in-progress subtitle must not *contain* the success subtitle.

That is a genuine two-way control against the string this issue removed, because the old wording was literally `Saved to History` with a timing clause appended. **Verified in both directions** — reverting the subtitle fails both tests, restoring passes both. It also guards its own control against the success subtitle ever ceasing to make an unconditional claim, which would make it pass vacuously.

**What it does NOT catch, said plainly rather than left implied.** It is a revert guard, not a promise detector: `Anything found goes to History` — the round-1 wording cloud review rejected — passes it. A differently-worded promise will pass too. That limitation is now written into the test body, because a test that looks stronger than it is will stop the next author doing the reasoning. The durable check is the note recorded at the constant: enumerate every link that can defeat delivery, and condition on the last one.

- Full Debug suite: **5363 tests, TEST SUCCEEDED**, re-run after rebasing onto current `origin/main`.
- Local `codex review --base origin/main`: **clean, zero findings.**
- Dev app rebuilt and relaunched.

## UAT note, stated rather than skipped

No live recovery-pill UAT. Staging one requires an interrupted recording with a leftover spool, and the change is a single static string whose value is covered byte-exact in two directions. Layout risk is nil in the direction that matters: the new string is 30 characters against the old 31, in the same view.

`council-skip: zero-blast-radius (user-facing copy)`
