### PR TITLE
feat(asr): let the fast engine lock to a language, and re-arm the script filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,6 +158,13 @@ scripts/*
 !scripts/lid-perf-bench.sh
 !scripts/lid-perf-bench.py
 !scripts/generate-recording-sounds.py
+# #1678: recomputes a delivery manifest's `manifestDigest`. TRACKED deliberately
+# — `DeliveryManifest.loadBundled` recomputes the digest on every launch and
+# throws on mismatch, so any manifest edit without this bricks model loading
+# (#1792 shipped exactly that past a green local build and a working dev app).
+# A gitignored copy would exist on one machine only, which is how the check gets
+# skipped by whoever does the next pin bump.
+!scripts/regen-delivery-manifest-digest.py
 # Output-safety classifier: conversion recipe + its numerical gates (#1226).
 # Tracked because these settings ship to users inside the model bytes.
 !scripts/convert-output-classifier.py

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/saurabhav88/FluidAudio.git",
       "state" : {
-        "revision" : "a1767d862dd1ba221593af4b92c81d004c2cc86b"
+        "revision" : "bf9fe27f837c86ee786a3f0ddb9966eeeeb4915d"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
     .package(url: "https://github.com/argmaxinc/argmax-oss-swift", from: "1.0.0"),
     .package(
       url: "https://github.com/saurabhav88/FluidAudio.git",
-      revision: "a1767d862dd1ba221593af4b92c81d004c2cc86b"),
+      revision: "bf9fe27f837c86ee786a3f0ddb9966eeeeb4915d"),
     .package(url: "https://github.com/sparkle-project/Sparkle.git", from: "2.6.0"),
     .package(url: "https://github.com/PostHog/posthog-ios.git", from: "3.0.0"),
     .package(url: "https://github.com/getsentry/sentry-cocoa.git", from: "9.8.0"),

--- a/Sources/EnviousWispr/Resources/parakeet-delivery-manifest.json
+++ b/Sources/EnviousWispr/Resources/parakeet-delivery-manifest.json
@@ -5,7 +5,7 @@
     "name": "parakeet-tdt-0.6b-v3-coreml",
     "revision": "aed02740059203c4a87495924f685de3722ae9ce",
     "variant": "int8",
-    "runtimeABI": "fluidAudio-a1767d86"
+    "runtimeABI": "fluidAudio-bf9fe27f"
   },
   "runtimeCompatibility": {
     "minAppVersion": "2.4.0"
@@ -172,5 +172,5 @@
     "diskHeadroomFactor": "2.2",
     "evictPreviousRevisions": false
   },
-  "manifestDigest": "2fe5bab08d88b3d0f32c3ab0bce126855c600f3a0cab382953d7a25b56249657"
+  "manifestDigest": "65db6162cd87891d15b4e6becbb4ecea2e5b3c41ef32dc98de103f5803c2d24c"
 }

--- a/Sources/EnviousWisprASR/ParakeetBackend.swift
+++ b/Sources/EnviousWisprASR/ParakeetBackend.swift
@@ -158,10 +158,25 @@ public actor ParakeetBackend: ASRBackend {
     let startTime = CFAbsoluteTimeGetCurrent()
     // Vendor API: the caller owns decoder state (fresh per one-shot batch decode;
     // upstream's ChunkProcessor also makes fresh state per chunk internally); there
-    // is no `source:` parameter. Language hint deliberately NOT passed — parked
-    // with #1678 (the fork's decode-time language machinery ships a French-tuned
-    // blocklist that measurably corrupts other languages; FluidInference#840).
+    // is no `source:` parameter.
+    //
+    // #1678: the language hint IS now passed, and passing it arms TWO vendor
+    // mechanisms rather than one — `TdtDecoderV3.swift:129` computes top-K only
+    // when `language != nil`, so nil switched off both:
+    //
+    //   1. `TokenLanguageFilter` — replaces a wrong-SCRIPT top-1 candidate with
+    //      the best right-script one. Purpose-built for exactly the reported
+    //      symptom: a German dictation coming back in Cyrillic or Greek.
+    //   2. `applyEnglishBlocklist` — a French-tuned token list that was applied
+    //      to all 21 non-English Latin languages and measurably corrupted German
+    //      (25/120 clips, median WER 0.0% -> 2.9%).
+    //
+    // The hint was parked because of (2). That kept (1) — the defence the user
+    // actually needs — switched off with it. (2) is scoped to French as of fork
+    // pin `bf9fe27f` and re-measured at 0/120, so (1) is now reachable at no
+    // measured cost.
     var decoderState = TdtDecoderState.make(decoderLayers: await manager.decoderLayerCount)
+    let languageHint = Self.fluidLanguage(for: options.language)
     #if DEBUG
       // #1707 Phase 2: the real shared-engine call boundary for the overlap
       // Live UAT oracle (§3.2a-i) — `defer` closes the interval on every
@@ -173,12 +188,37 @@ public actor ParakeetBackend: ASRBackend {
       defer { exitBatchDecodeFaultBoundary(role: batchDecodeFaultRole) }
     #endif
     do {
-      let fluidResult = try await manager.transcribe(audioSamples, decoderState: &decoderState)
+      let fluidResult = try await manager.transcribe(
+        audioSamples, decoderState: &decoderState, language: languageHint)
       let elapsed = CFAbsoluteTimeGetCurrent() - startTime
 
       return ASRResult(
         text: fluidResult.text,
-        language: "en",
+        // #1678: nil, and do NOT reintroduce a literal here.
+        //
+        // Parakeet has no language detection. FluidAudio's own result type
+        // declares no language field, so there is nothing to report even if we
+        // wanted to — nil is the honest value, and a lock is INTENT, never a
+        // measurement. Writing the locked code here would make this field
+        // indistinguishable from a real detection and promote it past
+        // `DictationLanguageResolver`'s precedence-2 guard, which exists
+        // precisely to refuse an engine that reports a constant.
+        //
+        // This was `"en"` from the first scaffold, coexisting with our own "25
+        // European languages" claim, and it was never true for a non-English
+        // take. It reached casing until #1785 / PR #1802, where German on the
+        // default engine was recased with English rules. Its remaining
+        // consumers were RECORDS rather than behaviour — History's transcript
+        // language and the `"language"` telemetry property — which is why every
+        // fast-engine dictation was reported as English. Consumers already
+        // handle nil: the telemetry sink renders `unknown`, and
+        // `RecoverySpoolReplayer` falls back to the locked code.
+        //
+        // The invariant, inlined so it travels with the code: this engine has no
+        // language detection, the vendor's own result type declares no language
+        // field, and the `language` parameter above is an INPUT that conditions
+        // decoding — never an output to echo back here.
+        language: nil,
         duration: fluidResult.duration,
         processingTime: elapsed,
         backendType: .parakeet,
@@ -199,6 +239,49 @@ public actor ParakeetBackend: ASRBackend {
     }
   }
 
+  /// Languages Parakeet TDT v3 is DECLARED to transcribe, as the intersection of
+  /// FluidAudio's `Language` enum with NVIDIA's model card for
+  /// `parakeet-tdt-0.6b-v3` (#1678).
+  ///
+  /// The vendor enum carries 27 cases; the model card claims 25. The three extra
+  /// cases below are usable by the script filter but are NOT claimed by the
+  /// model, so offering them would promise transcription quality nobody has
+  /// stated, let alone measured. Expressed as an exclusion rather than a
+  /// hand-copied list of 25 so it cannot silently drift from the enum: a vendor
+  /// adding a case appears here automatically and fails the count test below,
+  /// which forces a decision instead of a silent widening.
+  static let unclaimedByModelCard: Set<Language> = [.bosnian, .belarusian, .serbian]
+
+  /// The language codes this engine may be locked to, for the settings picker.
+  ///
+  /// Deliberately `Set<String>` rather than the vendor's `Language`: the app
+  /// layer must not import FluidAudio to render a list (dependency direction),
+  /// and `Language` is a vendor type whose spelling is not our contract.
+  ///
+  /// Offering a code outside this set would be a silent failure — `fluidLanguage`
+  /// would map it to nil, the decoder would fall back to Auto, and the user would
+  /// see a lock they had set and were not getting.
+  public static var lockableLanguageCodes: Set<String> {
+    Set(Language.allCases.lazy.filter { !unclaimedByModelCard.contains($0) }.map(\.rawValue))
+  }
+
+  /// Our language code -> the vendor's `Language`, or nil for "no hint".
+  ///
+  /// nil means Auto and disables language conditioning in the decoder entirely,
+  /// which is today's shipped behaviour and stays the default. An unrecognised
+  /// or unclaimed code also returns nil: falling back to Auto is strictly safer
+  /// than forcing a script the model was never declared to handle.
+  static func fluidLanguage(for code: String?) -> Language? {
+    guard let code, !code.isEmpty else { return nil }
+    // Normalize `de-DE`/`de_AT` to `de`; the vendor's rawValues are bare ISO codes.
+    let base = code.lowercased().split(whereSeparator: { $0 == "-" || $0 == "_" }).first.map(
+      String.init)
+    guard let base, let language = Language(rawValue: base),
+      !unclaimedByModelCard.contains(language)
+    else { return nil }
+    return language
+  }
+
   /// Numbers-only summary of FluidAudio token timings for tail-clip diagnostics (#1232).
   /// We keep only the count and the end time (ms) of the last token — never token text.
   /// Used to compute how far the decoded text reached vs the captured audio.
@@ -210,7 +293,7 @@ public actor ParakeetBackend: ASRBackend {
 
   // MARK: - Streaming ASR
 
-  public func startStreaming(options _: TranscriptionOptions) async throws {
+  public func startStreaming(options: TranscriptionOptions) async throws {
     guard isReady, let models = fluidModels else { throw ASRError.notReady }
 
     // Cancel any existing streaming session before starting a new one.
@@ -220,7 +303,11 @@ public actor ParakeetBackend: ASRBackend {
       streamingManager = nil
     }
 
+    // #1678: the lock must reach BOTH decode paths. Wiring only the batch call
+    // would give a locked user cross-alphabet protection on one path and not
+    // the other, with nothing in the UI to say which they were on.
     let config = SlidingWindowAsrConfig.streaming
+      .applying(language: Self.fluidLanguage(for: options.language))
     let manager = SlidingWindowAsrManager(config: config)
     // Vendor API: streaming starts via loadModels(_:) then startStreaming(source:).
     try await manager.loadModels(models)
@@ -247,7 +334,9 @@ public actor ParakeetBackend: ASRBackend {
 
     return ASRResult(
       text: text,
-      language: "en",
+      // #1678: nil for the same reason as the batch path above — Parakeet does
+      // not detect a language, so it must not assert one.
+      language: nil,
       duration: totalElapsed,
       processingTime: finalizeElapsed,
       backendType: .parakeet

--- a/Sources/EnviousWisprASR/ParakeetTranscriptionSentryError.swift
+++ b/Sources/EnviousWisprASR/ParakeetTranscriptionSentryError.swift
@@ -113,7 +113,7 @@ extension ParakeetTranscriptionSentryError: StableSentryErrorIdentity {
     case .unsupportedPlatform: return "FluidAudio.ASRError#5"
     case .streamingConversionFailed: return "FluidAudio.ASRError#6"
     case .fileAccessFailed: return "FluidAudio.ASRError#7"
-    // Vendor declaration ordinal 8 at pin `a1767d86`; `#8` was previously unused.
+    // Vendor declaration ordinal 8 at pin `bf9fe27f`; `#8` was previously unused.
     case .encoderInstantiationFailed: return "FluidAudio.ASRError#8"
     case .unknownTranscriptionFailure:
       return "EnviousWisprASR.ParakeetTranscriptionSentryError.unknownTranscriptionFailure"

--- a/Sources/EnviousWisprAppKit/Resources/THIRD-PARTY-NOTICES.txt
+++ b/Sources/EnviousWisprAppKit/Resources/THIRD-PARTY-NOTICES.txt
@@ -257,7 +257,7 @@ The full text of the Apache License, Version 2.0 follows.
 
 --------------------------------------------------------------------------------
 FluidAudio
-  Version: a1767d86 (fork saurabhav88/FluidAudio)
+  Version: bf9fe27f (fork saurabhav88/FluidAudio)
   License: Apache-2.0
   Source:  https://github.com/saurabhav88/FluidAudio
 --------------------------------------------------------------------------------

--- a/Sources/EnviousWisprAppKit/Views/Settings/LanguageLockSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LanguageLockSheet.swift
@@ -2,9 +2,9 @@ import EnviousWisprCore
 import EnviousWisprServices
 import SwiftUI
 
-/// Modal sheet that lets users pin WhisperKit to a specific language.
+/// Modal sheet that lets users pin the active engine to a specific language.
 ///
-/// Surfaces all 99 Whisper-supported languages with a search field and an
+/// Surfaces the engine's supported languages with a search field and an
 /// optional "Recent" section driven by the persisted `SessionLanguageMemory`
 /// usage cache. Tapping a row sets `languageMode = .locked(code)` and
 /// dismisses. The sheet is a settings detail, never an interrupt: nothing
@@ -12,6 +12,20 @@ import SwiftUI
 struct LanguageLockSheet: View {
   @Environment(SettingsManager.self) private var settings
   @Environment(\.dismiss) private var dismiss
+
+  /// Codes this engine may be locked to, or nil for "no restriction" (the
+  /// multilingual engine's 99).
+  ///
+  /// #1678: the fast engine claims 25 European languages, so the sheet must not
+  /// offer the rest. A code outside the engine's set is a SILENT failure — it
+  /// maps to no vendor language, the decoder falls back to auto-detect, and the
+  /// user sees a lock they set and are not getting. Filtering the list is what
+  /// makes the setting mean what it says.
+  let lockableCodes: Set<String>?
+
+  init(lockableCodes: Set<String>? = nil) {
+    self.lockableCodes = lockableCodes
+  }
 
   @State private var searchText: String = ""
 
@@ -178,10 +192,17 @@ struct LanguageLockSheet: View {
 
   // MARK: - Filtering
 
+  /// The engine's offerable languages. Applied BEFORE the search filter so a
+  /// search can never surface a language the active engine cannot honour.
+  private var lockableLanguages: [LanguageCatalog.Entry] {
+    guard let lockableCodes else { return LanguageCatalog.sortedByEnglishName }
+    return LanguageCatalog.sortedByEnglishName.filter { lockableCodes.contains($0.code) }
+  }
+
   private var filteredLanguages: [LanguageCatalog.Entry] {
     let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-    guard !query.isEmpty else { return LanguageCatalog.sortedByEnglishName }
-    return LanguageCatalog.sortedByEnglishName.filter { entry in
+    guard !query.isEmpty else { return lockableLanguages }
+    return lockableLanguages.filter { entry in
       entry.englishName.lowercased().contains(query)
         || entry.nativeName.lowercased().contains(query)
         || entry.code.lowercased().contains(query)
@@ -252,6 +273,13 @@ struct LanguageLockSheet: View {
     let sorted = memory.usage24h
       .filter { now.timeIntervalSince($0.value.lastSeen) <= ttl }
       .sorted { $0.value.lastSeen > $1.value.lastSeen }
+      // #1678: the engine restriction applies BEFORE the recency cap, not after.
+      // Recents are cross-engine — a user who dictated Japanese on the
+      // multilingual engine and then switched engines would otherwise be offered
+      // Japanese here, which the fast engine cannot honour. Filtering after
+      // `prefix` would also silently shorten the list instead of showing the
+      // next eligible language.
+      .filter { lockableCodes?.contains($0.key) ?? true }
       .prefix(maxRecents)
       .compactMap { pair -> LanguageCatalog.Entry? in
         guard LanguageTypes.isSupported(pair.key) else { return nil }

--- a/Sources/EnviousWisprAppKit/Views/Settings/SpeechEngineSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SpeechEngineSettingsView.swift
@@ -1,3 +1,4 @@
+import EnviousWisprASR
 import EnviousWisprCore
 import EnviousWisprModelDelivery
 import EnviousWisprServices
@@ -138,10 +139,16 @@ struct SpeechEngineSettingsView: View {
         }
       }
 
-      // ── Section 3: Language Selection (only when model is ready) ──
-      if settings.selectedBackend == .whisperKit,
-        case .ready = setup.whisperKitSetup.setupState
-      {
+      // ── Section 3: Language Selection ──
+      // #1678: one control, both engines. It was WhisperKit-only, so a German
+      // speaker on the default engine could not stop auto-detect guessing —
+      // the reported bug (Greek recognised in German speech). The two engines
+      // genuinely do different amounts with a lock, and that difference is
+      // carried by the help copy below, not by a different control or label.
+      // WhisperKit still waits for setup: its language list is only meaningful
+      // once its model is ready. Parakeet's lock is a stored preference that
+      // applies at decode time, so it needs no readiness gate.
+      if languageSectionIsAvailable {
         BrandedSection(header: "Language") {
           BrandedRow {
             HStack(alignment: .top, spacing: 11) {
@@ -161,10 +168,8 @@ struct SpeechEngineSettingsView: View {
                   Text("Auto-detect language").settingsRowLabel()
                 }
                 .toggleStyle(BrandedToggleStyle())
-                Text(
-                  "Auto-detect your language, or lock to a specific one. WhisperKit supports 99 languages."
-                )
-                .settingsReadingCopy()
+                Text(languageSectionCopy)
+                  .settingsReadingCopy()
               }
             }
           }
@@ -180,6 +185,24 @@ struct SpeechEngineSettingsView: View {
                     .foregroundStyle(.stTextSecondary)
                   Text("\(entry.nativeName) (\(entry.englishName))")
                     .settingsRowLabel()
+                  // #1678: a lock can outlive the engine that could honour it.
+                  // Someone locked to Japanese on the multilingual engine who
+                  // switches to the fast one keeps the stored code, and the
+                  // decoder silently falls back to auto-detect — a lock they set
+                  // and are not getting. We say so rather than substituting a
+                  // different language or clearing their choice, because either
+                  // would be us deciding something they did not ask for. The
+                  // stored code is preserved, so switching back restores it.
+                  if !isLockHonouredByActiveEngine(code) {
+                    Text(
+                      "The fast engine can't lock to this language, so it's detecting "
+                        + "automatically. Choose one of its 25 European languages, or switch "
+                        + "to the multilingual engine."
+                    )
+                    .font(.stHelper)
+                    .foregroundStyle(.stWarning)
+                    .fixedSize(horizontal: false, vertical: true)
+                  }
                 }
                 Spacer()
                 Button("Change") {
@@ -391,7 +414,68 @@ struct SpeechEngineSettingsView: View {
       }
     }
     .sheet(isPresented: $showLanguageLockSheet) {
-      LanguageLockSheet()
+      LanguageLockSheet(lockableCodes: lockableLanguageCodes)
+    }
+  }
+
+  // MARK: - Language section (#1678)
+
+  /// WhisperKit's list is only meaningful once its model is ready. Parakeet's
+  /// lock is a stored preference applied at decode time, so it has no such gate.
+  private var languageSectionIsAvailable: Bool {
+    switch settings.selectedBackend {
+    case .whisperKit:
+      if case .ready = setup.whisperKitSetup.setupState { return true }
+      return false
+    case .parakeet:
+      return true
+    }
+  }
+
+  /// Per-engine, because the same control genuinely does different amounts on
+  /// each and one sentence would give one of them wrong advice.
+  ///
+  /// The Parakeet wording is deliberately weaker than "only transcribe German".
+  /// The vendor's filter partitions by SCRIPT, not language, so a German lock
+  /// suppresses Greek and Cyrillic and does nothing to separate German from
+  /// Dutch. Measured: Greek audio under a German lock changes 9 of 9 clips,
+  /// while German audio is byte-identical across 120. A control must describe
+  /// what it does; copy promising more than the mechanism delivers is the
+  /// defect this issue was raised for, not a stylistic preference.
+  private var languageSectionCopy: String {
+    switch settings.selectedBackend {
+    case .whisperKit:
+      return
+        "Auto-detect your language, or lock to a specific one. WhisperKit supports 99 languages."
+    case .parakeet:
+      return """
+        Auto-detect your language, or lock to one of 25 European languages. \
+        Locking helps stop the fast engine reaching for a different alphabet, \
+        like Greek or Cyrillic appearing in German. It cannot tell apart two \
+        languages written in the same alphabet.
+        """
+    }
+  }
+
+  /// Whether the ACTIVE engine can actually honour a stored locked code.
+  ///
+  /// False is not an error state to clean up: the stored code stays exactly as
+  /// the user set it, so switching engines back restores the lock. What must not
+  /// happen is silence — the decoder falls back to auto-detect and nothing on
+  /// screen would say so.
+  private func isLockHonouredByActiveEngine(_ code: String) -> Bool {
+    guard let lockableLanguageCodes else { return true }
+    return lockableLanguageCodes.contains(code)
+  }
+
+  /// The codes the picker may offer. Restricted on the fast engine to what the
+  /// model is declared to transcribe — offering more would be a silent failure,
+  /// because an unclaimed code maps to no vendor language and the decoder
+  /// quietly falls back to auto-detect while the user believes they are locked.
+  private var lockableLanguageCodes: Set<String>? {
+    switch settings.selectedBackend {
+    case .whisperKit: return nil  // all 99
+    case .parakeet: return ParakeetBackend.lockableLanguageCodes
     }
   }
 
@@ -437,13 +521,41 @@ struct SpeechEngineSettingsView: View {
   /// to lock to. Preserve the prior locked code if we have one (comes from
   /// the W2 migration of `whisperKitLanguage`), otherwise default to English.
   private func currentOrDefaultLockCode() -> String {
-    if case .locked(let code) = settings.languageMode {
+    Self.defaultLockCode(
+      currentMode: settings.languageMode,
+      migratedCode: settings.whisperKitLanguage,
+      lockableCodes: lockableLanguageCodes)
+  }
+
+  /// Which code the Auto-detect toggle should lock to when it is switched OFF.
+  ///
+  /// Pure and `static` so it can be tested: this is the one place a lock is
+  /// created without the user choosing from the filtered picker, so it is the
+  /// one place the picker's restriction can be bypassed.
+  ///
+  /// #1678: every candidate must be honourable by the ACTIVE engine. Without
+  /// that, turning Auto off on the fast engine could restore a legacy
+  /// `whisperKitLanguage` such as Japanese — the user asks for a lock, the UI
+  /// shows a lock, and the decoder maps it straight back to auto-detect. That is
+  /// the same silent failure the picker restriction exists to prevent, arriving
+  /// through the toggle instead of the list (Codex review r1).
+  ///
+  /// - Parameter lockableCodes: nil means "no restriction" (the multilingual
+  ///   engine), which preserves the pre-#1678 behaviour exactly.
+  static func defaultLockCode(
+    currentMode: LanguageMode,
+    migratedCode: String,
+    lockableCodes: Set<String>?
+  ) -> String {
+    func honoured(_ code: String) -> Bool { lockableCodes?.contains(code) ?? true }
+
+    if case .locked(let code) = currentMode, honoured(code) {
       return code
     }
-    let migrated = settings.whisperKitLanguage
-    if LanguageTypes.isSupported(migrated) {
-      return migrated
+    if LanguageTypes.isSupported(migratedCode), honoured(migratedCode) {
+      return migratedCode
     }
+    // English is in every engine's set, so this fallback is always honourable.
     return "en"
   }
 

--- a/Sources/EnviousWisprAudio/BundledVADModelLoader.swift
+++ b/Sources/EnviousWisprAudio/BundledVADModelLoader.swift
@@ -32,7 +32,7 @@ enum BundledVADModelLoader {
     }
     do {
       // Match the pinned FluidAudio loader's compute policy
-      // (`ModelHub.swift:356-369` at fork pin a1767d86; the authority re-homed
+      // (`ModelHub.swift:356-369` at fork pin bf9fe27f; the authority re-homed
       // there through upstream's download-stack unification, #1981). Keep this
       // heart-path policy explicit across dependency updates (#1784).
       //

--- a/Sources/EnviousWisprFluidAudioBridge/FluidAudioASRErrorKind.swift
+++ b/Sources/EnviousWisprFluidAudioBridge/FluidAudioASRErrorKind.swift
@@ -16,7 +16,7 @@ package enum FluidAudioASRErrorKind: Sendable, Equatable {
   case streamingConversionFailed(String)
   case fileAccessFailed(String)
   /// #1654: added by the vendor in the 2026-08-08 pin bump (#1985, `afb9aab` ->
-  /// `a1767d86`). Until now it fell through `@unknown default` into
+  /// `bf9fe27f`). Until now it fell through `@unknown default` into
   /// `unknownFutureCase`, so a real named cause was arriving as the junk bucket —
   /// the exact collapse the #1525 epic exists to prevent. Found by the compiler
   /// while building the streaming classifier; nothing re-verified the pin bump.

--- a/Sources/EnviousWisprPipeline/DictationLanguageResolver.swift
+++ b/Sources/EnviousWisprPipeline/DictationLanguageResolver.swift
@@ -10,11 +10,18 @@ import NaturalLanguage
 /// correctly capitalised German noun. This resolves the question from positive
 /// evidence and abstains when there is none.
 ///
-/// Written because the obvious source is not evidence. `ParakeetBackend` stamps
-/// `language: "en"` on EVERY result, while the settings screen advertises
+/// Written because the obvious source is not evidence. `ParakeetBackend` USED TO
+/// stamp `language: "en"` on EVERY result, while the settings screen advertised
 /// "Parakeet's 25 European languages, not just English" — and Parakeet is the
 /// default engine. Reading that field directly meant a German dictation on the
 /// default path was recased with English rules (cloud review, PR #1802).
+///
+/// #1678 removed that constant: Parakeet now reports `nil`, because it performs
+/// no language detection and a user's lock is intent rather than a measurement.
+/// **The precedence rule below is unchanged and still load-bearing** — it keys
+/// on `engineDetectsLanguage`, not on the field's value, so it refuses a
+/// non-detecting engine's answer whatever that answer is. That is exactly why
+/// nil was the right replacement rather than writing the locked code here.
 ///
 /// #1921 replaced a LENGTH floor with a CONFIDENCE floor. The old rule demanded
 /// 24 alphabetic scalars before it would look at the recogniser's answer at all,

--- a/Sources/EnviousWisprPipeline/InverseTextNormalizationStep.swift
+++ b/Sources/EnviousWisprPipeline/InverseTextNormalizationStep.swift
@@ -138,7 +138,8 @@ final class InverseTextNormalizationStep: TextProcessingStep {
   /// - Explicit English language → run.
   /// - Explicit non-English language → skip (`non_english`).
   /// - No language (nil/empty): the live context carries only the locked-config
-  ///   language else nil; Parakeet stamps "en" internally but it never reaches here.
+  ///   language else nil. (Parakeet used to stamp "en" on its result, which never
+  ///   reached here anyway; #1678 removed that constant — it reports nil now.)
   ///   Run for non-LID backends (Parakeet-class, legacy English); defensively skip
   ///   for LID backends (WhisperKit), where nil means "couldn't identify"
   ///   (`lid_backend_nil`).

--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -257,7 +257,7 @@ The full text of the Apache License, Version 2.0 follows.
 
 --------------------------------------------------------------------------------
 FluidAudio
-  Version: a1767d86 (fork saurabhav88/FluidAudio)
+  Version: bf9fe27f (fork saurabhav88/FluidAudio)
   License: Apache-2.0
   Source:  https://github.com/saurabhav88/FluidAudio
 --------------------------------------------------------------------------------

--- a/Tests/EnviousWisprTests/ASR/ParakeetLanguageLockTests.swift
+++ b/Tests/EnviousWisprTests/ASR/ParakeetLanguageLockTests.swift
@@ -1,0 +1,96 @@
+import Testing
+
+@testable import EnviousWisprASR
+
+/// #1678: the language lock on the fast engine.
+///
+/// The set of lockable languages is the one thing here a user can see being
+/// wrong: offering a language the engine cannot honour is a SILENT failure —
+/// the mapping returns nil, the decoder falls back to Auto, and the user sees a
+/// lock they set and are not getting. So the set is frozen against NVIDIA's
+/// model card rather than against whatever the vendor enum happens to contain.
+@Suite("Parakeet language lock")
+struct ParakeetLanguageLockTests {
+
+  /// The 25 European languages NVIDIA's `parakeet-tdt-0.6b-v3` model card
+  /// claims. Written out rather than derived, deliberately: deriving it from
+  /// the vendor enum would make this test agree with any future vendor change
+  /// by construction, which is the one thing it exists to prevent.
+  static let modelCardLanguages: Set<String> = [
+    "bg", "hr", "cs", "da", "nl", "en", "et", "fi", "fr", "de", "el", "hu",
+    "it", "lv", "lt", "mt", "pl", "pt", "ro", "sk", "sl", "es", "sv", "ru", "uk",
+  ]
+
+  @Test("We offer exactly the model card's 25 languages")
+  func offersExactlyTheModelCard() {
+    #expect(Self.modelCardLanguages.count == 25)
+    #expect(ParakeetBackend.lockableLanguageCodes == Self.modelCardLanguages)
+  }
+
+  /// The vendor enum carries three languages the model card does not claim.
+  /// If a vendor bump adds or removes a case, the test above fails and someone
+  /// has to decide whether we claim it — which is the intended outcome. This
+  /// one names why the three are excluded so the failure is diagnosable.
+  @Test("The three vendor languages the model card does not claim are refused")
+  func refusesLanguagesTheModelDoesNotClaim() {
+    for code in ["bs", "be", "sr"] {
+      #expect(
+        ParakeetBackend.fluidLanguage(for: code) == nil,
+        "\(code) is in the vendor's script filter but is not claimed by the model card")
+      #expect(ParakeetBackend.lockableLanguageCodes.contains(code) == false)
+    }
+  }
+
+  @Test("A claimed language maps to the vendor value")
+  func mapsClaimedLanguages() {
+    #expect(ParakeetBackend.fluidLanguage(for: "de") == .german)
+    #expect(ParakeetBackend.fluidLanguage(for: "el") == .greek)
+    #expect(ParakeetBackend.fluidLanguage(for: "ru") == .russian)
+    #expect(ParakeetBackend.fluidLanguage(for: "en") == .english)
+  }
+
+  /// The catalog stores bare codes today, but a locked value can arrive from a
+  /// settings migration or a suggestion as a full BCP-47 tag. Mapping it to nil
+  /// would silently drop a lock the user set.
+  @Test("Region tags and case are normalised to the base code")
+  func normalisesRegionTags() {
+    #expect(ParakeetBackend.fluidLanguage(for: "de-DE") == .german)
+    #expect(ParakeetBackend.fluidLanguage(for: "de_AT") == .german)
+    #expect(ParakeetBackend.fluidLanguage(for: "DE") == .german)
+    #expect(ParakeetBackend.fluidLanguage(for: "pt-BR") == .portuguese)
+  }
+
+  /// Auto. nil disables language conditioning in the decoder entirely, which is
+  /// the shipped default and must stay reachable.
+  @Test("Absent or empty means Auto, not a guess")
+  func absentMeansAuto() {
+    #expect(ParakeetBackend.fluidLanguage(for: nil) == nil)
+    #expect(ParakeetBackend.fluidLanguage(for: "") == nil)
+    #expect(ParakeetBackend.fluidLanguage(for: "   ") == nil)
+  }
+
+  /// A language the engine has never claimed — Japanese is the obvious one, and
+  /// it is exactly what a user migrating from the multilingual engine could
+  /// still have stored. Falling back to Auto is safer than forcing a script the
+  /// model was never declared to handle.
+  @Test("An unsupported or malformed code falls back to Auto rather than guessing")
+  func unsupportedFallsBackToAuto() {
+    for code in ["ja", "zh", "ko", "ar", "he", "th", "hi", "xx", "not-a-language"] {
+      #expect(
+        ParakeetBackend.fluidLanguage(for: code) == nil,
+        "\(code) must fall back to Auto rather than mapping to some other language")
+    }
+  }
+
+  /// Guards the property the picker depends on: every code we offer must map to
+  /// a real vendor value. Without this, the two could drift and the picker would
+  /// list a language the decode call silently ignores.
+  @Test("Every offered code maps to a vendor language")
+  func everyOfferedCodeResolves() {
+    for code in ParakeetBackend.lockableLanguageCodes {
+      #expect(
+        ParakeetBackend.fluidLanguage(for: code) != nil,
+        "\(code) is offered in the picker but does not resolve to a vendor language")
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/Architecture/EngineMutationInventoryFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EngineMutationInventoryFreezeTests.swift
@@ -925,10 +925,13 @@ import Testing
     // the file's existing `prepare`/`loadModels`/`startStreaming` entries:
     // the concrete `ASRBackend.transcribe` implementation, forwarding to
     // FluidAudio's own manager.
+    // #1678 wrapped this call to pass `language:`, which changed the matched
+    // TEXT without changing the site: same call, same caller, same coverage.
+    // The argument is a decode-time hint (script filter + blocklist gating),
+    // not a mutation of shared engine state, so the classification is unchanged.
     CallSite(
       file: "Sources/EnviousWisprASR/ParakeetBackend.swift", matcher: "transcribe",
-      text:
-        "let fluidResult = try await manager.transcribe(audioSamples, decoderState: &decoderState)",
+      text: "let fluidResult = try await manager.transcribe(",
       classification: .transitivelyCoveredByCaller),
 
     // MARK: WhisperKitBackend — new Chunk 11 entries.

--- a/Tests/EnviousWisprTests/ModelDelivery/DeliveryManifestTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/DeliveryManifestTests.swift
@@ -256,7 +256,15 @@ enum ManifestFixture {
   // invalidates the prior Parakeet admission marker, causing one full verification
   // pass and re-admission with no re-download (CacheAdmission.isAdmitted
   // digest equality; ModelIdentity invariant 9 keeps delivery runtime-agnostic).
-  static let goldenDigest = "2fe5bab08d88b3d0f32c3ab0bce126855c600f3a0cab382953d7a25b56249657"
+  // Updated 2026-08-12 (#1678): `runtimeABI` advanced to fork pin bf9fe27f,
+  // which scopes the decoder's English token blocklist to French so a language
+  // lock stops corrupting German. Identical model bytes — the fork commit
+  // touches only `TdtDecoderV3.swift` and its tests — so this is the same
+  // re-admission-without-re-download case as #1981 above. Regenerated with
+  // `scripts/regen-delivery-manifest-digest.py`, which reproduces a manifest's
+  // existing digest before writing a new one; that control is what makes the
+  // value below trustworthy rather than merely fresh.
+  static let goldenDigest = "65db6162cd87891d15b4e6becbb4ecea2e5b3c41ef32dc98de103f5803c2d24c"
 
   @Test func shippedManifestLoadsAndMatchesGoldenDigest() throws {
     let data = try Data(contentsOf: Self.shippedManifestURL)

--- a/Tests/EnviousWisprTests/Settings/LanguageLockDefaultCodeTests.swift
+++ b/Tests/EnviousWisprTests/Settings/LanguageLockDefaultCodeTests.swift
@@ -1,0 +1,87 @@
+import EnviousWisprCore
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #1678: the Auto-detect toggle is the one place a lock is created WITHOUT the
+/// user choosing from the filtered picker, so it is the one place the picker's
+/// restriction can be bypassed. Codex review r1 found exactly that: turning Auto
+/// off on the fast engine could restore a legacy `whisperKitLanguage` such as
+/// Japanese, producing a lock the decoder maps straight back to auto-detect —
+/// the user asks for a lock, the UI shows a lock, and there is no lock.
+@Suite("Language lock default code")
+struct LanguageLockDefaultCodeTests {
+
+  /// The fast engine's set. Small stand-in for the real 25; what matters is that
+  /// it excludes `ja`, which is the legacy code a WhisperKit user can carry.
+  static let fastEngine: Set<String> = ["en", "de", "fr", "es", "el"]
+
+  @Test("An unsupported legacy code is NOT resurrected by the toggle")
+  func unsupportedLegacyCodeIsNotResurrected() {
+    let code = SpeechEngineSettingsView.defaultLockCode(
+      currentMode: .auto, migratedCode: "ja", lockableCodes: Self.fastEngine)
+    #expect(code == "en", "Japanese is not lockable on this engine, so it must not be chosen")
+  }
+
+  @Test("An unsupported CURRENT lock is not carried forward either")
+  func unsupportedCurrentLockIsNotCarriedForward() {
+    // Reachable by locking Japanese on the multilingual engine, switching to the
+    // fast one, toggling Auto on and then off again.
+    let code = SpeechEngineSettingsView.defaultLockCode(
+      currentMode: .locked("ja"), migratedCode: "ja", lockableCodes: Self.fastEngine)
+    #expect(code == "en")
+  }
+
+  @Test("A supported legacy code IS honoured — the fix must not discard valid choices")
+  func supportedLegacyCodeIsHonoured() {
+    let code = SpeechEngineSettingsView.defaultLockCode(
+      currentMode: .auto, migratedCode: "de", lockableCodes: Self.fastEngine)
+    #expect(code == "de")
+  }
+
+  @Test("A supported current lock is preserved")
+  func supportedCurrentLockIsPreserved() {
+    let code = SpeechEngineSettingsView.defaultLockCode(
+      currentMode: .locked("fr"), migratedCode: "de", lockableCodes: Self.fastEngine)
+    #expect(code == "fr")
+  }
+
+  /// The two-way control. nil means the multilingual engine, where every
+  /// Whisper language is lockable — the pre-#1678 behaviour, which this change
+  /// must leave exactly as it was. Without this, a fix that simply always
+  /// returned "en" would pass every assertion above.
+  @Test("With no restriction, behaviour is unchanged from before the fix")
+  func noRestrictionPreservesOldBehaviour() {
+    #expect(
+      SpeechEngineSettingsView.defaultLockCode(
+        currentMode: .auto, migratedCode: "ja", lockableCodes: nil) == "ja")
+    #expect(
+      SpeechEngineSettingsView.defaultLockCode(
+        currentMode: .locked("ja"), migratedCode: "en", lockableCodes: nil) == "ja")
+  }
+
+  @Test("A migrated code that is not a real language falls back to English")
+  func malformedMigratedCodeFallsBack() {
+    #expect(
+      SpeechEngineSettingsView.defaultLockCode(
+        currentMode: .auto, migratedCode: "", lockableCodes: Self.fastEngine) == "en")
+    #expect(
+      SpeechEngineSettingsView.defaultLockCode(
+        currentMode: .auto, migratedCode: "not-a-language", lockableCodes: nil) == "en")
+  }
+
+  /// Whatever this returns must itself be lockable, or the toggle creates the
+  /// silent failure by a route the cases above did not enumerate.
+  @Test("Every result is a code the active engine can honour")
+  func everyResultIsHonourable() {
+    for migrated in ["ja", "de", "", "zh", "not-a-language", "en"] {
+      for mode in [LanguageMode.auto, .locked("ja"), .locked("de")] {
+        let code = SpeechEngineSettingsView.defaultLockCode(
+          currentMode: mode, migratedCode: migrated, lockableCodes: Self.fastEngine)
+        #expect(
+          Self.fastEngine.contains(code),
+          "toggle produced '\(code)', which this engine cannot lock to")
+      }
+    }
+  }
+}

--- a/scripts/ci/gen-third-party-notices.sh
+++ b/scripts/ci/gen-third-party-notices.sh
@@ -37,7 +37,7 @@ COMPONENTS=(
   # text too, not just Argmax's MIT LICENSE (Codex audit 2026-07-10). Empty
   # identity — it is vendored inside argmax-oss-swift, not its own SwiftPM pin.
   "swift-transformers (incorporated into Argmax OSS)|n/a|Apache-2.0|argmax-oss-swift/NOTICES|https://github.com/huggingface/swift-transformers|"
-  "FluidAudio|a1767d86 (fork saurabhav88/FluidAudio)|Apache-2.0|FluidAudio/LICENSE|https://github.com/saurabhav88/FluidAudio|fluidaudio"
+  "FluidAudio|bf9fe27f (fork saurabhav88/FluidAudio)|Apache-2.0|FluidAudio/LICENSE|https://github.com/saurabhav88/FluidAudio|fluidaudio"
   "PostHog iOS|3.68.2|MIT|posthog-ios/LICENSE|https://github.com/PostHog/posthog-ios|posthog-ios"
   "Sentry Cocoa|9.23.0|MIT|sentry-cocoa/LICENSE.md|https://github.com/getsentry/sentry-cocoa|sentry-cocoa"
   "Sparkle|2.9.4|MIT (with bundled BSD/MIT components)|Sparkle/LICENSE|https://github.com/sparkle-project/Sparkle|sparkle"
@@ -50,7 +50,7 @@ COMPONENTS=(
   "swift-syntax|603.0.2|Apache-2.0|swift-syntax/LICENSE.txt|https://github.com/swiftlang/swift-syntax|swift-syntax"
   "fastcluster (bundled in FluidAudio)|n/a|BSD-2-Clause|FluidAudio/ThirdPartyLicenses/fastcluster-LICENSE.md|https://github.com/dmuellner/fastcluster|"
   "VBx (bundled in FluidAudio)|n/a|Apache-2.0|FluidAudio/ThirdPartyLicenses/vbx-LICENSE.md|https://github.com/BUTSpeechFIT/VBx|"
-  # #1981: at fork pin a1767d86, FluidAudio's target statically links the
+  # #1981: at fork pin bf9fe27f, FluidAudio's target statically links the
   # prebuilt NemoTextProcessing xcframework (text-processing-rs v0.3.0). Its
   # aggregate license file carries the NVIDIA NeMo Text Processing, rustfst,
   # and Rust-crate attributions the binary embeds. Empty identity — a binary

--- a/scripts/eval/build_parakeet_corpus.py
+++ b/scripts/eval/build_parakeet_corpus.py
@@ -8,7 +8,7 @@ score we hold was therefore measured on an input form the shipped ASR does not
 produce. This rebuilds the inputs through the ASR we actually ship.
 
 Engine fidelity: drives `fluidaudiocli tts-asr-verify` from the PINNED FluidAudio
-checkout (`.build/checkouts/FluidAudio`, revision a1767d86 per Package.resolved),
+checkout (`.build/checkouts/FluidAudio`, revision bf9fe27f per Package.resolved),
 NOT `~/Developer/EnviousLabs/FluidAudio*` — a local checkout's HEAD floats, so
 it can silently measure a different engine; the pinned checkout cannot.
 
@@ -44,7 +44,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 CLI = ROOT / ".build/checkouts/FluidAudio/.build/arm64-apple-macosx/release/fluidaudiocli"
-PIN = "a1767d862dd1ba221593af4b92c81d004c2cc86b"
+PIN = "bf9fe27f837c86ee786a3f0ddb9966eeeeb4915d"
 
 
 def check_engine() -> None:

--- a/scripts/eval/parakeet_runner/Package.swift
+++ b/scripts/eval/parakeet_runner/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 // and reloads the model each time, which is unusable for 1,890 cases.
 //
 // Depends on the SAME git URL + exact immutable revision the app pins in the
-// root Package.swift (saurabhav88/FluidAudio @ a1767d86) rather than a local
+// root Package.swift (saurabhav88/FluidAudio @ bf9fe27f) rather than a local
 // path, so this provably runs the same pinned engine the app resolves. Do not
 // repoint at a local checkout — a path dependency floats with whatever that
 // checkout happens to hold, while this remote revision cannot drift.
@@ -16,7 +16,7 @@ let package = Package(
   dependencies: [
     .package(
       url: "https://github.com/saurabhav88/FluidAudio.git",
-      revision: "a1767d862dd1ba221593af4b92c81d004c2cc86b")
+      revision: "bf9fe27f837c86ee786a3f0ddb9966eeeeb4915d")
   ],
   targets: [
     .executableTarget(name: "ParakeetRunner", dependencies: ["FluidAudio"])

--- a/scripts/regen-delivery-manifest-digest.py
+++ b/scripts/regen-delivery-manifest-digest.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Recompute `manifestDigest` for a bundled delivery manifest.
+
+WHY THIS EXISTS
+`DeliveryManifest.loadBundled` recomputes the digest on every launch and THROWS
+on mismatch, so any edit to a manifest — including a one-word `runtimeABI` bump
+riding along with a dependency pin — bricks model loading unless the digest is
+regenerated with it. #1792 shipped exactly that defect past a green local build
+and a working dev app; cloud review caught it.
+
+The algorithm mirrors `DeliveryManifest.canonicalDigest` (DeliveryManifest.swift):
+    parse -> drop "manifestDigest" -> JSONSerialization(.sortedKeys,
+    .withoutEscapingSlashes) -> SHA256 hex
+
+FAILS CLOSED, and that is the point. Before writing anything it recomputes the
+digest the file ALREADY declares. If this implementation cannot reproduce that,
+it is not equivalent to the Swift one and it refuses to touch the file — a
+reimplementation of a hashing rule is worthless without that control, because a
+wrong digest looks exactly like a right one until the app refuses to launch.
+
+    usage: regen-delivery-manifest-digest.py <manifest.json> [--write]
+"""
+import hashlib
+import json
+import subprocess
+import sys
+
+
+def canonical_digest(obj: dict) -> str:
+    """Mirror of DeliveryManifest.canonicalDigest."""
+    body = {k: v for k, v in obj.items() if k != "manifestDigest"}
+    # sortedKeys -> sort_keys; compact (JSONSerialization emits no whitespace);
+    # withoutEscapingSlashes and UTF-8 passthrough -> ensure_ascii=False.
+    canonical = json.dumps(
+        body, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def main() -> int:
+    if len(sys.argv) not in (2, 3) or (len(sys.argv) == 3 and sys.argv[2] != "--write"):
+        print(__doc__.strip().splitlines()[-1], file=sys.stderr)
+        return 2
+    path, write = sys.argv[1], len(sys.argv) == 3
+
+    raw = open(path, "rb").read()
+    obj = json.loads(raw)
+    declared = obj.get("manifestDigest")
+    if not isinstance(declared, str):
+        print("REFUSED: manifest declares no manifestDigest string", file=sys.stderr)
+        return 1
+
+    computed = canonical_digest(obj)
+    print(f"declared: {declared}")
+    print(f"computed: {computed}")
+
+    if computed == declared:
+        print("MATCH — manifest is already consistent; nothing to write.")
+        return 0
+
+    print("\nMISMATCH — the manifest has been edited since its digest was written.")
+    if not write:
+        print("(dry run — pass --write to regenerate)")
+        return 1
+
+    # THE CONTROL, and it runs here rather than being printed as advice.
+    #
+    # This is a reimplementation of a hashing rule defined in Swift. It is only
+    # trustworthy if it reproduces the digest of the file as it stood BEFORE the
+    # edit — i.e. the committed version, whose digest was written by a run that
+    # the app accepted. An earlier version of this script only PRINTED those
+    # instructions and then wrote anyway, which is a guard that never arms: on
+    # any drift between this canonicalization and Swift's, it would have written
+    # a confident wrong digest and the app would refuse to launch (Codex r1).
+    if not _baseline_reproduces(path):
+        return 1
+
+    text = raw.decode("utf-8")
+    if text.count(declared) != 1:
+        print("REFUSED: declared digest is not a unique string in the file", file=sys.stderr)
+        return 1
+    open(path, "w").write(text.replace(declared, computed))
+    print(f"\nWROTE {path}: {declared} -> {computed}")
+    return 0
+
+
+def _baseline_reproduces(path: str) -> bool:
+    """True only if we can recompute the COMMITTED version's own declared digest.
+
+    Refuses on any uncertainty — a missing git, an untracked file, a parse
+    failure. "I could not check" must never read as "the check passed".
+    """
+    try:
+        baseline = subprocess.run(
+            ["git", "show", f"HEAD:{path}"],
+            capture_output=True, check=True,
+        ).stdout
+    except (OSError, subprocess.CalledProcessError) as exc:
+        print(
+            f"REFUSED: cannot read the committed baseline for {path} ({exc}).\n"
+            "Without it this tool's canonicalization is unverified, so it will "
+            "not rewrite a digest the app validates on every launch.",
+            file=sys.stderr,
+        )
+        return False
+
+    try:
+        baseline_obj = json.loads(baseline)
+        baseline_declared = baseline_obj["manifestDigest"]
+    except (ValueError, KeyError, TypeError) as exc:
+        print(f"REFUSED: committed baseline is unreadable ({exc})", file=sys.stderr)
+        return False
+
+    baseline_computed = canonical_digest(baseline_obj)
+    if baseline_computed != baseline_declared:
+        print(
+            "REFUSED: this implementation does not reproduce the COMMITTED digest\n"
+            f"  committed declares: {baseline_declared}\n"
+            f"  this tool computes: {baseline_computed}\n"
+            "It has drifted from DeliveryManifest.canonicalDigest. Writing now "
+            "would produce a manifest the app rejects at launch.",
+            file=sys.stderr,
+        )
+        return False
+
+    print(f"control OK: reproduced the committed baseline digest ({baseline_declared[:12]}…)")
+    return True
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #1678.

A German speaker on the default engine can now say "I speak German" and have the app stop guessing. R. Schepers reported this on **12 July** and has been waiting a month.

## This is not really a picker. It re-arms a mechanism we had switched off.

The vendor's decoder takes an optional `language`, and `TdtDecoderV3.swift:129` computes top-K candidates **only when it is non-nil**. That one condition gates two separate mechanisms:

1. **`TokenLanguageFilter`** — when the top-K contains a candidate of the requested script, it substitutes that for a wrong-script top-1.
2. **`applyEnglishBlocklist`** — a French-tuned token list.

We passed nil, so **both** were off. The reason we passed nil was mechanism 2: a lock measurably corrupted German. So the defect in (2) kept (1) disabled for every user of the default engine.

On 7 August we told this user it could not be done, because "it's actually degrading the quality instead of improving it." The observation was real. The attribution was wrong.

**What mechanism 1 actually does, measured in both directions rather than read off the source:**

- **On German (Latin) speech it is inert.** Patched `--language de` is byte-identical to auto across all 120 clips. That is why the lock is free.
- **On speech the engine would render in another alphabet it fires hard.** Greek audio under a German lock changes **9 of 9** clips (reproduced twice, on both builds): `Θα σε πάρω τηλέφωνο αύριο το πρωί…` becomes `7. 12 200 000, 7.07.` — Greek tokens suppressed so completely that only script-neutral digits survive.

So a lock suppresses another alphabet when the decoder is reaching for one. **That is the mechanism the reported symptom needs, but it is not the reported case**: Schepers speaks German that is mis-rendered as Greek, whereas the measurement above is Greek audio under a German lock. Analogous, not identical.

## The fork fix, measured

`saurabhav88/FluidAudio` PR #2, pin `a1767d86` → **`bf9fe27f`**.

`applyEnglishBlocklist` was guarded by `lang.script == .latin && lang != .english`, applying it to **21 languages**. Its own comment already described its tokens as *"essentially impossible in FRENCH prose"* — the justification named French and only the predicate was broad, which is why six grounded rounds read past it. It is now scoped to French.

120-clip German corpus, all arms at the shipped revision:

| arm | vs auto baseline | purpose |
|---|---|---|
| patched, no language | **0 / 120** | control: patch inert where it must be |
| unpatched, `--language de` | **25 / 120** | control: the corpus can detect damage at all |
| patched, `--language de` | **0 / 120** | the fix |

Both controls were declared before the run. Damage removed includes compound-word corruption through sentence-piece prefixes (`sowie` → `siewie`, `herzlich` → `hertz`) and one forced translation — banning ` not` made the decoder emit `aber nicht in der Production Welt` for `aber not in the production world`.

**The corpus contains no cross-script audio, so it cannot distinguish this fix from one that disabled language handling entirely** — both score 0/120. Separate positive control on Greek audio: under a German lock the patched build still changes **9/9** clips and is byte-identical to unpatched on all four combinations. The script filter is alive and untouched.

**Independently confirmed on a different sample by a second instrument**: 30 clips from the same corpus directory, shipped `a1767d86` auto vs `--language de` → **8 differ**; the same 8 on patched `bf9fe27f` → **0 differ**.

**And every one of those 8 is a code-switch case, which reframes who this protects.** No plain-German clip moved. All eight are German with embedded English, and the blocklist damages the *English*:

| in | out under an unpatched German lock |
|---|---|
| `this feature needs to work` | `Cis Feature needs to work` |
| `I will call you back later` | `ich wall yo back later` |
| `before you start speaking` | `before U Start Speaking` |
| `know which marketing channels` | `knowwiching channels` |

German professionals code-switch with English constantly. **So the population most likely to turn a German lock on is exactly the population an unpatched lock would have damaged** — ungating the picker without the fork fix would have actively hurt the users it was for. (In fairness to the blocklist, one case improved: `aber not in the production world` → `aber nicht in der Production Welt`. It biases correctly sometimes; it is the scope that was wrong, not the idea.)

## App changes

- **The hint reaches BOTH decode paths** — batch and streaming (via the vendor's `applying(language:)`). Wiring only batch would give a locked user protection on one path and nothing on screen saying which they were on.
- **The picker is ungated for the fast engine.** One control, one place; the difference between engines is carried by help copy, not a different label — per the founder's 2026-07-31 decision.
- **The copy does not over-promise.** The filter partitions by *script*, so locking German suppresses Greek and Cyrillic and does nothing to separate German from Dutch. The Parakeet string says exactly that.
- **The lock sheet is restricted to the engine's 25 languages, including recents.** Recents are cross-engine, so a Japanese recent would otherwise still be offered. Offering an unsupported code is a *silent* failure: it maps to no vendor language and the decoder quietly falls back to auto while the user believes they are locked.
- **A stored lock can outlive the engine that could honour it** — someone locked to Japanese who switches engines now sees a notice instead of silently getting auto-detect. The stored code is preserved, so switching back restores it; substituting or clearing it would be us deciding something they did not ask for.
- **`ParakeetBackend` no longer stamps `language: "en"` on every result.** It is nil. Parakeet has no language detection, and a lock is intent rather than measurement. This is in *this* PR rather than a follow-up because it becomes newly wrong the moment a lock exists — a user explicitly tells us German and our telemetry records English.

## Pin-bump homes

Eight tracked homes plus the derived digest. Two the plan's list did not have:

- **A root-level `THIRD-PARTY-NOTICES.txt`** — missed by a sweep scoped to `Sources/` and `scripts/ci/`, caught by the generator's own `--check` gate. Both copies regenerated from the generator; `--check` passes across 16 components.
- **No tooling existed for `manifestDigest`.** `DeliveryManifest.loadBundled` recomputes it on every launch and throws on mismatch, so a manifest edit without regeneration bricks model loading (#1792 shipped exactly that past a green local build). Added `scripts/regen-delivery-manifest-digest.py`, **tracked** — a gitignored validator exists on one machine only, which is how the next person skips it. It fails closed: it reproduces the digest a manifest already declares before writing a new one, and that control passed on all three shipped manifests.

Deliberately **not** updated: the dated `scripts/eval/lang-stress/*/REPORT.md` and `german-parakeet-stress/*` files also contain the old SHA, as the provenance of which engine produced which numbers. Rewriting them would silently re-attribute measurements to an engine that never ran them.

## Measured correction to the issue

The vendor `Language` enum has **28** cases, not the 27 recorded on #1678. 28 − 3 unclaimed (`bs`, `be`, `sr`) = exactly the model card's **25**. The test freezes our 25 against a written-out model-card list rather than deriving it from the enum, so a vendor bump fails loudly instead of silently widening what we offer.

## What this does NOT establish

**It is not shown that this fixes the reported case.** The claim this change carries is the *mechanism*: `TokenLanguageFilter` exists precisely to stop a Latin-language decode emitting another script, and `TdtDecoderV3.swift:129` gates it on a non-nil language, so passing German arms it. That is verifiable by reading the vendor. Whether arming it resolves Schepers' `Ашинбренна` is **not** established.

A four-arm reproduction was attempted (shipped × patched, auto × `--language de`, over Azure German TTS of the name alone, the name in a sentence, and a plain German sentence). **All twelve cells were identical and correct**, and its pre-declared control — shipped-`de` must differ from shipped-auto somewhere, or the corpus cannot discriminate — failed. So that run is **void, not negative**: it neither supports nor undermines the fix.

The one thing it does establish: no build produced Cyrillic from clean German speech in any arm. Combined with the founder's own measurements (the isolated name failed 4 of 5 in his voice while the same name inside a sentence succeeded 3 of 3), the live suspects for the reported failure are accent, microphone or room — not the word, and not something clean studio TTS reproduces. A voice memo has been requested.

So: this ships because a safe lock is worth having and the defence is one the vendor built for this failure mode. It does not ship as a proven fix for one user's audio, and the reply to him should not say otherwise.

## Known limit, stated rather than hidden

Schepers asked for German **and** English — the two languages in his macOS settings. `LanguageMode` holds exactly one code, so what ships gives him "lock German" or "auto". This is a **partial** answer to his actual request. Nothing here forecloses a future multi-language mode: everything added keys off a `Set<String>` of lockable codes, and no copy claims the lock restricts the app to one language.

The lock also cannot separate two languages sharing an alphabet, and the vendor's filter is best-effort (`TokenLanguageFilter.swift:141`: a wrong-script token with no matching-script candidate is left unchanged).

## Live verification, and what it does not cover

**The `"en"` removal is confirmed in the real running app, by a natural before/after on the founder's own dictations** — same log, same machine, the build swapped underneath at ~12:17:

| time | reported language |
|---|---|
| every dictation up to `12:17:19` | `lang=en` |
| every dictation from `12:25:12` | `lang=unknown` |

**Control arm through the real app:** Greek audio under Auto transcribes cleanly (`Καλημέρα.`), so the app path works end to end and Greek is transcribable on this engine.

**Not directly observed in-app: the locked arm.** Four sessions were contending for the machine, so driving the settings UI and playing audio was stopped rather than risk corrupting live work. What that leaves unverified is the settings → `options.language` → backend seam under a lock — a two-line parameter pass, compile-checked, with the mapping itself unit-tested (7 cases) and the decoder's honouring of the parameter measured twice at CLI level (9/9 Greek clips). Stated as a residual rather than claimed: the obvious in-app test (lock German, dictate German) could not have covered it either, since patched-`de` is byte-identical to auto on German.

## Verification

- 7 new tests for the mapping and the offered set; full suite green.
- Two freeze tests updated deliberately, not silenced: the manifest golden digest, and the engine-mutation inventory entry whose matched *text* changed when the call gained an argument (same site, same caller, same classification).
- `swift package resolve` fetched `bf9fe27f` from the remote, so the pinned-a-local-only-SHA failure is ruled out by execution.

Artifacts: `docs/feature-requests/issue-1678-artifacts/`.
