### PR TITLE
feat(asr): give streaming ASR failures a stable identity across XPC

### DIFF
--- a/Sources/EnviousWisprASR/ASRManagerProxy.swift
+++ b/Sources/EnviousWisprASR/ASRManagerProxy.swift
@@ -578,8 +578,11 @@ public final class ASRManagerProxy: ASRManagerInterface {
             // the batch leg reconstructs before falling back to transport — a domain
             // match is exact, so an earlier reconstructor cannot steal another's error,
             // and leaving it last would mean a transport-shaped fallback claimed it.
+            // Cancellation comes before both: it is not a failure of any kind and must
+            // not be given a failure identity (see `reconstructCancellation`).
             let reconstructed: any Error =
-              ParakeetStreamingSentryError(reconstructingFrom: error).map { $0 as any Error }
+              Self.reconstructCancellation(error)
+              ?? ParakeetStreamingSentryError(reconstructingFrom: error).map { $0 as any Error }
               ?? XPCASRTransportError(reconstructingFrom: error).map { $0 as any Error } ?? error
             guard_.resume(throwing: reconstructed)
           } else {
@@ -590,6 +593,37 @@ public final class ASRManagerProxy: ASRManagerInterface {
         guard_.resume(throwing: XPCASRTransportError.serviceUnreachable)
       }
     }
+  }
+
+  /// #1654 (cloud review P2): restores a `CancellationError` that the ASR service threw
+  /// and the XPC boundary flattened.
+  ///
+  /// **Why this is needed at all.** `XPCErrorSanitizer` preserves only domain, code and
+  /// description. A `CancellationError` bridges to domain `Swift.CancellationError`,
+  /// code 1 — measured, not assumed — and after a real archive round-trip
+  /// `(error as Error) is CancellationError` is **false**. So a cancellation that
+  /// originates in the service arrives on this side as an ordinary `NSError`.
+  ///
+  /// **What that was silently costing.** `ParakeetEngineAdapter` has three
+  /// `catch is CancellationError` arms, and none of them can match a cancellation that
+  /// crossed the boundary — they cover app-side cancellation only. That was harmless
+  /// while the streaming start leg emitted nothing; #1654 gives that leg a telemetry
+  /// event, at which point a user cancelling a recording would have been recorded as a
+  /// streaming START FAILURE. Cloud review caught it before it shipped.
+  ///
+  /// **Failure direction, stated deliberately.** The bridged domain string is the only
+  /// signal that survives, so this match is stringly-typed and could stop matching if
+  /// Swift changes the bridged name. If it misses, a cancellation is once again counted
+  /// as a failure — noise in a metric. If it over-matched, a real failure would be
+  /// silently swallowed. Matching the exact domain and code, rather than a prefix or the
+  /// description, keeps it on the noisy side of that trade.
+  /// `nonisolated` because it is a pure function of the error handed to it and touches no
+  /// actor state — the enclosing type's `@MainActor` would otherwise be inherited for no
+  /// reason. Not `private`: `ASRManagerProxyCancellationTests` drives it directly, because
+  /// the whole point is a value the XPC boundary produces, which a fake proxy cannot make.
+  nonisolated static func reconstructCancellation(_ error: NSError) -> (any Error)? {
+    guard error.domain == "Swift.CancellationError", error.code == 1 else { return nil }
+    return CancellationError()
   }
 
   public func feedAudio(_ buffer: AVAudioPCMBuffer) async throws {
@@ -627,9 +661,10 @@ public final class ASRManagerProxy: ASRManagerInterface {
       // #1654: streaming first on this leg. The batch reconstructor stays in the chain
       // rather than being replaced — `finalizeStreaming` can surface a model-load or
       // transcription-domain error from the service's own guards, and those keep their
-      // existing identities.
+      // existing identities. Cancellation precedes all of them.
       let reconstructed: any Error =
-        ParakeetStreamingSentryError(reconstructingFrom: error).map { $0 as any Error }
+        Self.reconstructCancellation(error)
+        ?? ParakeetStreamingSentryError(reconstructingFrom: error).map { $0 as any Error }
         ?? ParakeetTranscriptionSentryError(reconstructingFrom: error).map { $0 as any Error }
         ?? XPCASRTransportError(reconstructingFrom: error).map { $0 as any Error }
         ?? error

--- a/Sources/EnviousWisprASR/ASRManagerProxy.swift
+++ b/Sources/EnviousWisprASR/ASRManagerProxy.swift
@@ -574,8 +574,13 @@ public final class ASRManagerProxy: ASRManagerInterface {
           // conforming error before throwing to the adapter, matching
           // loadModel/transcribe/finalizeStreaming's reconstruction.
           if let error = nsError {
+            // #1654: the streaming identity is reconstructed FIRST, for the same reason
+            // the batch leg reconstructs before falling back to transport — a domain
+            // match is exact, so an earlier reconstructor cannot steal another's error,
+            // and leaving it last would mean a transport-shaped fallback claimed it.
             let reconstructed: any Error =
-              XPCASRTransportError(reconstructingFrom: error).map { $0 as any Error } ?? error
+              ParakeetStreamingSentryError(reconstructingFrom: error).map { $0 as any Error }
+              ?? XPCASRTransportError(reconstructingFrom: error).map { $0 as any Error } ?? error
             guard_.resume(throwing: reconstructed)
           } else {
             guard_.resume()
@@ -619,8 +624,13 @@ public final class ASRManagerProxy: ASRManagerInterface {
     if let error {
       // #1525 PR I-B: reconstruct the typed, conforming error from the
       // surviving NSError domain/code before throwing to the adapter.
+      // #1654: streaming first on this leg. The batch reconstructor stays in the chain
+      // rather than being replaced — `finalizeStreaming` can surface a model-load or
+      // transcription-domain error from the service's own guards, and those keep their
+      // existing identities.
       let reconstructed: any Error =
-        ParakeetTranscriptionSentryError(reconstructingFrom: error).map { $0 as any Error }
+        ParakeetStreamingSentryError(reconstructingFrom: error).map { $0 as any Error }
+        ?? ParakeetTranscriptionSentryError(reconstructingFrom: error).map { $0 as any Error }
         ?? XPCASRTransportError(reconstructingFrom: error).map { $0 as any Error }
         ?? error
       throw reconstructed

--- a/Sources/EnviousWisprASR/ParakeetBackend.swift
+++ b/Sources/EnviousWisprASR/ParakeetBackend.swift
@@ -309,11 +309,50 @@ public actor ParakeetBackend: ASRBackend {
     let config = SlidingWindowAsrConfig.streaming
       .applying(language: Self.fluidLanguage(for: options.language))
     let manager = SlidingWindowAsrManager(config: config)
-    // Vendor API: streaming starts via loadModels(_:) then startStreaming(source:).
-    try await manager.loadModels(models)
-    try await manager.startStreaming(source: .microphone)
+    do {
+      // Vendor API: streaming starts via loadModels(_:) then startStreaming(source:).
+      try await manager.loadModels(models)
+      try await manager.startStreaming(source: .microphone)
+    } catch is CancellationError {
+      throw CancellationError()
+    } catch {
+      // #1654: pin a stable identity before this leaves the service. A cancellation is
+      // deliberately excluded above rather than classified — a cancelled stream is not a
+      // failure and must never acquire a failure identity.
+      throw Self.streamingIdentity(for: error, operation: .start) ?? error
+    }
     self.streamingManager = manager
     self.streamingStartTime = CFAbsoluteTimeGetCurrent()
+  }
+
+  /// #1654: which streaming leg threw. Not cosmetic — it decides whether a bare vendor
+  /// `ASRError` is allowed to become an identity at all.
+  private enum StreamingLeg { case start, finalize }
+
+  /// #1654: the one place a raw FluidAudio streaming error becomes an app-owned identity.
+  ///
+  /// Order matters and is not arbitrary. `SlidingWindowAsrError` is checked first because
+  /// it is the vendor's streaming-specific type. A bare `ASRError` is mapped ONLY on the
+  /// start leg, where `SlidingWindowAsrManager` genuinely throws one; on finalize the
+  /// vendor wraps every escaping error (`SlidingWindowAsrManager.swift:640`), so a bare
+  /// `ASRError` arriving there is not something we have grounds to name. Calling it
+  /// `startFailed` because that is the mapping in hand would be a reason whose name
+  /// contradicts its producer.
+  ///
+  /// Returns `nil` for a foreign error — a raw CoreML or converter failure keeps its own
+  /// identity rather than being relabelled as ours, exactly as the batch path leaves
+  /// unrecognised errors unchanged.
+  private static func streamingIdentity(
+    for error: any Error,
+    operation: StreamingLeg
+  ) -> ParakeetStreamingSentryError? {
+    if let kind = classifyFluidAudioStreamingError(error) {
+      return ParakeetStreamingSentryError(mapping: kind)
+    }
+    switch operation {
+    case .start: return ParakeetStreamingSentryError(mappingStartFailure: error)
+    case .finalize: return nil
+    }
   }
 
   public func feedAudio(_ buffer: AVAudioPCMBuffer) async throws {
@@ -326,7 +365,16 @@ public actor ParakeetBackend: ASRBackend {
     defer { streamingManager = nil }
 
     let finalizeStart = CFAbsoluteTimeGetCurrent()
-    let text = try await manager.finish()
+    let text: String
+    do {
+      text = try await manager.finish()
+    } catch is CancellationError {
+      throw CancellationError()
+    } catch {
+      // #1654: same identity pass as the start leg. See `streamingIdentity` for why a
+      // bare `ASRError` is deliberately NOT named here.
+      throw Self.streamingIdentity(for: error, operation: .finalize) ?? error
+    }
     let finalizeEnd = CFAbsoluteTimeGetCurrent()
 
     let totalElapsed = finalizeEnd - streamingStartTime

--- a/Sources/EnviousWisprASR/ParakeetBackend.swift
+++ b/Sources/EnviousWisprASR/ParakeetBackend.swift
@@ -319,7 +319,7 @@ public actor ParakeetBackend: ASRBackend {
       // #1654: pin a stable identity before this leaves the service. A cancellation is
       // deliberately excluded above rather than classified — a cancelled stream is not a
       // failure and must never acquire a failure identity.
-      throw Self.streamingIdentity(for: error, operation: .start) ?? error
+      throw Self.streamingThrowable(for: error, operation: .start)
     }
     self.streamingManager = manager
     self.streamingStartTime = CFAbsoluteTimeGetCurrent()
@@ -329,7 +329,7 @@ public actor ParakeetBackend: ASRBackend {
   /// `ASRError` is allowed to become an identity at all.
   private enum StreamingLeg { case start, finalize }
 
-  /// #1654: the one place a raw FluidAudio streaming error becomes an app-owned identity.
+  /// #1654: the one place a raw FluidAudio streaming error becomes what we throw.
   ///
   /// Order matters and is not arbitrary. `SlidingWindowAsrError` is checked first because
   /// it is the vendor's streaming-specific type. A bare `ASRError` is mapped ONLY on the
@@ -339,19 +339,31 @@ public actor ParakeetBackend: ASRBackend {
   /// `startFailed` because that is the mapping in hand would be a reason whose name
   /// contradicts its producer.
   ///
-  /// Returns `nil` for a foreign error — a raw CoreML or converter failure keeps its own
-  /// identity rather than being relabelled as ours, exactly as the batch path leaves
-  /// unrecognised errors unchanged.
-  private static func streamingIdentity(
+  /// A foreign error is returned UNCHANGED — a raw CoreML or converter failure keeps its
+  /// own identity rather than being relabelled as ours, exactly as the batch path leaves
+  /// unrecognised errors alone.
+  ///
+  /// Returns the error to throw rather than an optional identity, deliberately. Cloud
+  /// review's fourth finding needed a cancellation nested inside a vendor wrapper to come
+  /// back out as a `CancellationError`, and an identity-returning function cannot express
+  /// that — the caller would have thrown the raw wrapper, which the adapter's
+  /// `catch is CancellationError` still cannot match. Both decisions (is this a
+  /// cancellation, and what identity does it get) now live in ONE place, so the two catch
+  /// sites cannot drift apart.
+  private static func streamingThrowable(
     for error: any Error,
     operation: StreamingLeg
-  ) -> ParakeetStreamingSentryError? {
+  ) -> any Error {
+    // A cancellation must acquire no failure identity at ANY layer. The `catch is
+    // CancellationError` arms at the call sites see only a BARE cancellation; this is the
+    // nested case, where the vendor has wrapped it.
+    if fluidAudioStreamingErrorWrapsCancellation(error) { return CancellationError() }
     if let kind = classifyFluidAudioStreamingError(error) {
       return ParakeetStreamingSentryError(mapping: kind)
     }
     switch operation {
-    case .start: return ParakeetStreamingSentryError(mappingStartFailure: error)
-    case .finalize: return nil
+    case .start: return ParakeetStreamingSentryError(mappingStartFailure: error) ?? error
+    case .finalize: return error
     }
   }
 
@@ -371,9 +383,9 @@ public actor ParakeetBackend: ASRBackend {
     } catch is CancellationError {
       throw CancellationError()
     } catch {
-      // #1654: same identity pass as the start leg. See `streamingIdentity` for why a
+      // #1654: same identity pass as the start leg. See `streamingThrowable` for why a
       // bare `ASRError` is deliberately NOT named here.
-      throw Self.streamingIdentity(for: error, operation: .finalize) ?? error
+      throw Self.streamingThrowable(for: error, operation: .finalize)
     }
     let finalizeEnd = CFAbsoluteTimeGetCurrent()
 

--- a/Sources/EnviousWisprASR/ParakeetStreamingSentryError.swift
+++ b/Sources/EnviousWisprASR/ParakeetStreamingSentryError.swift
@@ -1,0 +1,317 @@
+import EnviousWisprCore
+import EnviousWisprFluidAudioBridge
+import Foundation
+
+/// #1654: pinned Sentry identity for FluidAudio's raw `SlidingWindowAsrError` (streaming
+/// path), built from `FluidAudioStreamingErrorKind` — never from the vendor type directly
+/// (see `EnviousWisprFluidAudioBridge`'s naming-trap doc comment). Mirrors
+/// `ParakeetTranscriptionSentryError`, which does the same job for the batch path.
+///
+/// **Every description here is APP-AUTHORED, and that is the deliberate difference from
+/// the batch conformer.** The batch kind carries the vendor's `localizedDescription` on
+/// every case; the streaming kind carries no vendor text at all, because four of the
+/// vendor's seven `errorDescription` cases interpolate text we do not control (three of
+/// them an inner error's own description). So the string a reader sees is written here,
+/// and the identity is the case.
+///
+/// **The inner cause rides the `errorCode`, and it has to.** `XPCErrorSanitizer` rebuilds
+/// every error crossing the boundary with `userInfo` reduced to exactly one key
+/// (`NSLocalizedDescriptionKey`) — that is a stated invariant of that type, not an
+/// accident — so domain, code and description are the ONLY channels that survive. The
+/// inner cause is the whole diagnostic point of `allWindowsFailed`, and Sentry emission
+/// happens app-side after the crossing, so encoding it in the code is what makes it
+/// reachable at all. Hence the block allocation below rather than a flat ordinal list.
+enum ParakeetStreamingSentryError: Error, LocalizedError, CustomNSError, Sendable, Equatable {
+  case modelsNotLoaded
+  case streamAlreadyExists
+  case audioBufferProcessingFailed
+  case audioConversionFailed
+  case bufferOverflow
+  case invalidConfiguration
+  /// Every window failed. `inner` names why when we can name it, and is `nil` when the
+  /// wrapped error is not one we recognise — the outer identity stands either way.
+  case allWindowsFailed(inner: FluidAudioStreamingInnerCause?)
+  /// The streaming session failed to START, where the vendor throws a bare `ASRError`
+  /// rather than a `SlidingWindowAsrError`.
+  ///
+  /// **Correction to the plan, made at build time.** §3 said the start path should use
+  /// `classifyFluidAudioASRError` "unchanged", and mapping through that classifier lands
+  /// in `ParakeetTranscriptionSentryError`, every one of whose semantic IDs reads
+  /// `parakeet_transcribe.*`. A failure to open a stream would then have arrived in
+  /// Sentry under a name describing transcription — a reason whose name does not predict
+  /// its cause, which is the exact trap `classify-by-producer-not-by-name` exists for.
+  /// The plan's instruction is honoured where it is load-bearing (the CLASSIFIER is
+  /// reused, so no second vendor switch exists) and the IDENTITY stays in this namespace.
+  case startFailed(inner: FluidAudioStreamingInnerCause?)
+  case unknownStreamingFailure
+
+  static let errorDomain = "EnviousWisprASR.ParakeetStreamingSentryError"
+
+  /// Pinned code allocation. **Never renumber; append only.** Codes 0-6 are the flat
+  /// cases. Code 100 upward is the `allWindowsFailed` block, whose offset carries the
+  /// inner cause; 100 itself means "every window failed, cause unrecognised".
+  private enum Code {
+    static let modelsNotLoaded = 0
+    static let streamAlreadyExists = 1
+    static let audioBufferProcessingFailed = 2
+    static let audioConversionFailed = 3
+    static let bufferOverflow = 4
+    static let invalidConfiguration = 5
+    static let unknownStreamingFailure = 6
+    /// `allWindowsFailed` with no recognised inner cause. Recognised causes are
+    /// `allWindowsFailedBase + innerOffset`.
+    static let allWindowsFailedBase = 100
+    /// The block is bounded so that a code from some FUTURE block cannot be misread as
+    /// an `allWindowsFailed` with an unknown inner cause. An unbounded `> base` test
+    /// would silently absorb every code we later allocate above it — including the
+    /// `startFailed` block directly below, which is what makes the bound load-bearing
+    /// rather than theoretical.
+    static let allWindowsFailedBlockEnd = 199
+    /// Same shape, separate block: `startFailed` with no recognised inner cause.
+    static let startFailedBase = 200
+    static let startFailedBlockEnd = 299
+  }
+
+  /// Pinned offset for each inner cause inside the `allWindowsFailed` block.
+  /// **Never renumber; append only.** Kept as an explicit switch rather than a raw-value
+  /// enum so that adding a vendor case is a compile error here, not a silent shift.
+  private static func innerOffset(_ cause: FluidAudioStreamingInnerCause) -> Int {
+    switch cause {
+    case .notInitialized: return 1
+    case .invalidAudioData: return 2
+    case .modelLoadFailed: return 3
+    case .processingFailed: return 4
+    case .modelCompilationFailed: return 5
+    case .unsupportedPlatform: return 6
+    case .streamingConversionFailed: return 7
+    case .fileAccessFailed: return 8
+    case .encoderInstantiationFailed: return 9
+    case .unknownFutureCase: return 10
+    }
+  }
+
+  private static func innerCause(fromOffset offset: Int) -> FluidAudioStreamingInnerCause? {
+    switch offset {
+    case 1: return .notInitialized
+    case 2: return .invalidAudioData
+    case 3: return .modelLoadFailed
+    case 4: return .processingFailed
+    case 5: return .modelCompilationFailed
+    case 6: return .unsupportedPlatform
+    case 7: return .streamingConversionFailed
+    case 8: return .fileAccessFailed
+    case 9: return .encoderInstantiationFailed
+    case 10: return .unknownFutureCase
+    default: return nil
+    }
+  }
+
+  var errorCode: Int {
+    switch self {
+    case .modelsNotLoaded: return Code.modelsNotLoaded
+    case .streamAlreadyExists: return Code.streamAlreadyExists
+    case .audioBufferProcessingFailed: return Code.audioBufferProcessingFailed
+    case .audioConversionFailed: return Code.audioConversionFailed
+    case .bufferOverflow: return Code.bufferOverflow
+    case .invalidConfiguration: return Code.invalidConfiguration
+    case .unknownStreamingFailure: return Code.unknownStreamingFailure
+    case .allWindowsFailed(let inner):
+      guard let inner else { return Code.allWindowsFailedBase }
+      return Code.allWindowsFailedBase + Self.innerOffset(inner)
+    case .startFailed(let inner):
+      guard let inner else { return Code.startFailedBase }
+      return Code.startFailedBase + Self.innerOffset(inner)
+    }
+  }
+
+  /// App-authored. No vendor string reaches this.
+  var errorDescription: String? {
+    switch self {
+    case .modelsNotLoaded:
+      return "Live transcription could not start: the speech models were not loaded."
+    case .streamAlreadyExists:
+      return "Live transcription could not start: a stream was already open."
+    case .audioBufferProcessingFailed:
+      return "Live transcription failed while processing captured audio."
+    case .audioConversionFailed:
+      return "Live transcription failed while converting captured audio."
+    case .bufferOverflow:
+      return "Live transcription failed: the audio buffer overflowed."
+    case .invalidConfiguration:
+      return "Live transcription could not start: the streaming window is misconfigured."
+    case .allWindowsFailed(let inner):
+      guard let inner else {
+        return "Live transcription failed: every audio window failed, cause unrecognised."
+      }
+      return "Live transcription failed: every audio window failed (\(Self.innerLabel(inner)))."
+    case .startFailed(let inner):
+      guard let inner else {
+        return "Live transcription could not start, for an unrecognised reason."
+      }
+      return "Live transcription could not start (\(Self.innerLabel(inner)))."
+    case .unknownStreamingFailure:
+      return "Live transcription failed for an unrecognised reason."
+    }
+  }
+
+  /// App-authored label for an inner cause. Low cardinality by construction.
+  private static func innerLabel(_ cause: FluidAudioStreamingInnerCause) -> String {
+    switch cause {
+    case .notInitialized: return "engine not initialised"
+    case .invalidAudioData: return "invalid audio data"
+    case .modelLoadFailed: return "model load failed"
+    case .processingFailed: return "processing failed"
+    case .modelCompilationFailed: return "model compilation failed"
+    case .unsupportedPlatform: return "unsupported platform"
+    case .streamingConversionFailed: return "audio conversion failed"
+    case .fileAccessFailed: return "file access failed"
+    case .encoderInstantiationFailed: return "encoder instantiation failed"
+    case .unknownFutureCase: return "unrecognised engine failure"
+    }
+  }
+
+  /// Same reason as the batch conformer: `CustomNSError`'s default `errorUserInfo` is
+  /// empty, and an empty `userInfo` does not survive the XPC archive round-trip with the
+  /// description intact — the receiving process falls back to Foundation's generic
+  /// "operation couldn't be completed". Baking the description into `userInfo` is what
+  /// preserves it.
+  var errorUserInfo: [String: Any] {
+    [NSLocalizedDescriptionKey: errorDescription ?? ""]
+  }
+
+  init(mapping kind: FluidAudioStreamingErrorKind) {
+    switch kind {
+    case .modelsNotLoaded: self = .modelsNotLoaded
+    case .streamAlreadyExists: self = .streamAlreadyExists
+    case .audioBufferProcessingFailed: self = .audioBufferProcessingFailed
+    case .audioConversionFailed: self = .audioConversionFailed
+    case .allWindowsFailed(let inner): self = .allWindowsFailed(inner: inner)
+    case .bufferOverflow: self = .bufferOverflow
+    case .invalidConfiguration: self = .invalidConfiguration
+    case .unknownFutureCase: self = .unknownStreamingFailure
+    }
+  }
+
+  /// The streaming START path: the vendor throws a bare `ASRError` here, classified into
+  /// the same text-free inner vocabulary. A foreign error yields `nil` and the caller
+  /// leaves it raw rather than giving it a streaming identity it has not earned.
+  init?(mappingStartFailure error: any Error) {
+    guard let cause = fluidAudioStreamingInnerCause(error) else { return nil }
+    self = .startFailed(inner: cause)
+  }
+
+  /// Reconstructs the typed, conforming error from an NSError that survived the XPC
+  /// round-trip. Returns `nil` for a foreign domain — a genuinely unrelated XPC-layer
+  /// error, which must keep its own identity rather than acquire this one.
+  init?(reconstructingFrom error: NSError) {
+    guard error.domain == Self.errorDomain else { return nil }
+    switch error.code {
+    case Code.modelsNotLoaded: self = .modelsNotLoaded
+    case Code.streamAlreadyExists: self = .streamAlreadyExists
+    case Code.audioBufferProcessingFailed: self = .audioBufferProcessingFailed
+    case Code.audioConversionFailed: self = .audioConversionFailed
+    case Code.bufferOverflow: self = .bufferOverflow
+    case Code.invalidConfiguration: self = .invalidConfiguration
+    case Code.unknownStreamingFailure: self = .unknownStreamingFailure
+    case Code.allWindowsFailedBase...Code.allWindowsFailedBlockEnd:
+      // An offset this build does not know maps to nil rather than to a wrong cause:
+      // a newer service reporting a newer inner case must not be read as an older one.
+      // (`allWindowsFailedBase` itself yields nil through the same path, since offset 0
+      // is deliberately unallocated.)
+      self = .allWindowsFailed(
+        inner: Self.innerCause(fromOffset: error.code - Code.allWindowsFailedBase))
+    case Code.startFailedBase...Code.startFailedBlockEnd:
+      self = .startFailed(
+        inner: Self.innerCause(fromOffset: error.code - Code.startFailedBase))
+    default: return nil
+    }
+  }
+}
+
+extension ParakeetStreamingSentryError: StableSentryErrorIdentity {
+  /// **Measured, not reasoned about** (epic protocol, `BIBLE.md` §5), 2026-08-12:
+  /// a 90-day Sentry search returns ZERO issues matching "SlidingWindow" or "streaming",
+  /// against a working positive control ("Parakeet" returns ENVIOUSWISPR-16). The
+  /// mechanism agrees with the search rather than merely failing to contradict it: the
+  /// only streaming failure PostHog has ever recorded (one event, one person, 2026-07-30,
+  /// v2.4.1) was `result: rescued`, and a rescued failure produces no terminal, hence no
+  /// Sentry event.
+  ///
+  /// So there is no shipped grouping to preserve and these descriptors are free choices
+  /// rather than defensive pins. They are app-owned strings for that reason: inventing a
+  /// vendor-ordinal-shaped descriptor we have never actually sent would fabricate a
+  /// history, which is worse than a clean name. Once shipped they are frozen forever.
+  var sentryFingerprintDescriptor: String {
+    let base = "EnviousWisprASR.ParakeetStreamingSentryError"
+    switch self {
+    case .modelsNotLoaded: return "\(base).modelsNotLoaded"
+    case .streamAlreadyExists: return "\(base).streamAlreadyExists"
+    case .audioBufferProcessingFailed: return "\(base).audioBufferProcessingFailed"
+    case .audioConversionFailed: return "\(base).audioConversionFailed"
+    case .bufferOverflow: return "\(base).bufferOverflow"
+    case .invalidConfiguration: return "\(base).invalidConfiguration"
+    case .unknownStreamingFailure: return "\(base).unknownStreamingFailure"
+    case .allWindowsFailed(let inner):
+      // The inner cause participates in the fingerprint deliberately: separating
+      // all-windows-failed-because-processing-failed from
+      // all-windows-failed-because-not-initialised is the entire diagnostic value here.
+      guard let inner else { return "\(base).allWindowsFailed.unrecognised" }
+      return "\(base).allWindowsFailed.\(Self.innerDescriptorToken(inner))"
+    case .startFailed(let inner):
+      guard let inner else { return "\(base).startFailed.unrecognised" }
+      return "\(base).startFailed.\(Self.innerDescriptorToken(inner))"
+    }
+  }
+
+  var sentrySemanticID: String {
+    switch self {
+    case .modelsNotLoaded: return "parakeet_streaming.models_not_loaded"
+    case .streamAlreadyExists: return "parakeet_streaming.stream_already_exists"
+    case .audioBufferProcessingFailed: return "parakeet_streaming.audio_buffer_processing_failed"
+    case .audioConversionFailed: return "parakeet_streaming.audio_conversion_failed"
+    case .bufferOverflow: return "parakeet_streaming.buffer_overflow"
+    case .invalidConfiguration: return "parakeet_streaming.invalid_configuration"
+    case .unknownStreamingFailure: return "parakeet_streaming.unknown_streaming_failure"
+    case .allWindowsFailed(let inner):
+      guard let inner else { return "parakeet_streaming.all_windows_failed.unrecognised" }
+      return "parakeet_streaming.all_windows_failed.\(Self.innerSemanticToken(inner))"
+    case .startFailed(let inner):
+      guard let inner else { return "parakeet_streaming.start_failed.unrecognised" }
+      return "parakeet_streaming.start_failed.\(Self.innerSemanticToken(inner))"
+    }
+  }
+
+  /// Pinned descriptor token per inner cause. **Frozen once shipped**, same contract as
+  /// the descriptor itself — this is part of the fingerprint, not metadata.
+  private static func innerDescriptorToken(_ cause: FluidAudioStreamingInnerCause) -> String {
+    switch cause {
+    case .notInitialized: return "notInitialized"
+    case .invalidAudioData: return "invalidAudioData"
+    case .modelLoadFailed: return "modelLoadFailed"
+    case .processingFailed: return "processingFailed"
+    case .modelCompilationFailed: return "modelCompilationFailed"
+    case .unsupportedPlatform: return "unsupportedPlatform"
+    case .streamingConversionFailed: return "streamingConversionFailed"
+    case .fileAccessFailed: return "fileAccessFailed"
+    case .encoderInstantiationFailed: return "encoderInstantiationFailed"
+    case .unknownFutureCase: return "unknownFutureCase"
+    }
+  }
+
+  /// Renameable, unlike the descriptor token above: the semantic ID is metadata and
+  /// never enters the fingerprint.
+  private static func innerSemanticToken(_ cause: FluidAudioStreamingInnerCause) -> String {
+    switch cause {
+    case .notInitialized: return "not_initialized"
+    case .invalidAudioData: return "invalid_audio_data"
+    case .modelLoadFailed: return "model_load_failed"
+    case .processingFailed: return "processing_failed"
+    case .modelCompilationFailed: return "model_compilation_failed"
+    case .unsupportedPlatform: return "unsupported_platform"
+    case .streamingConversionFailed: return "streaming_conversion_failed"
+    case .fileAccessFailed: return "file_access_failed"
+    case .encoderInstantiationFailed: return "encoder_instantiation_failed"
+    case .unknownFutureCase: return "unknown_future_case"
+    }
+  }
+}

--- a/Sources/EnviousWisprFluidAudioBridge/FluidAudioStreamingErrorKind.swift
+++ b/Sources/EnviousWisprFluidAudioBridge/FluidAudioStreamingErrorKind.swift
@@ -93,6 +93,39 @@ package func fluidAudioStreamingInnerCause(_ error: any Error) -> FluidAudioStre
   }
 }
 
+/// #1654 (cloud review, fourth P2): does this vendor error actually WRAP a cancellation?
+///
+/// **Not reachable at the pinned vendor, and fixed anyway.** Measured at `bf9fe27f`:
+/// `SlidingWindowAsrManager.swift:641-644` returns early on
+/// `error is CancellationError || Task.isCancelled` BEFORE constructing
+/// `.modelProcessingFailed`, so the vendor cannot produce that shape today. Classified
+/// HYPOTHETICAL on that evidence.
+///
+/// It is fixed regardless because the guard is one comparison, the failure would be
+/// SILENT, and — the deciding reason — reachability here is a property of the VENDOR's
+/// code rather than ours. A pin bump that drops that early return would start recording
+/// every cancelled dictation as a streaming failure, with nothing to announce the change.
+/// That is exactly the #2041 shape, where a pin bump added a case nobody re-enumerated.
+///
+/// Callers must treat `true` as "throw cancellation", never as "classify differently":
+/// a cancellation must acquire no failure identity at any layer.
+package func fluidAudioStreamingErrorWrapsCancellation(_ error: any Error) -> Bool {
+  if error is CancellationError { return true }
+  guard let error = error as? SlidingWindowAsrError else { return false }
+  switch error {
+  case .modelProcessingFailed(let inner), .audioBufferProcessingFailed(let inner),
+    .audioConversionFailed(let inner):
+    return inner is CancellationError
+  case .modelsNotLoaded, .streamAlreadyExists, .bufferOverflow, .invalidConfiguration:
+    return false
+  @unknown default:
+    // A vendor case we have never seen cannot be asserted to carry a cancellation.
+    // Answering `false` leaves it to the normal classifier, which is the existing
+    // behaviour rather than a new claim.
+    return false
+  }
+}
+
 package func classifyFluidAudioStreamingError(_ error: any Error) -> FluidAudioStreamingErrorKind? {
   // Unambiguous here: this module declares no other SlidingWindowAsrError.
   guard let error = error as? SlidingWindowAsrError else { return nil }

--- a/Sources/EnviousWisprFluidAudioBridge/FluidAudioStreamingErrorKind.swift
+++ b/Sources/EnviousWisprFluidAudioBridge/FluidAudioStreamingErrorKind.swift
@@ -63,9 +63,21 @@ package enum FluidAudioStreamingErrorKind: Sendable, Equatable {
   case unknownFutureCase
 }
 
-/// Maps the inner error of `.modelProcessingFailed` to a bare semantic cause.
+/// Maps a raw FluidAudio `ASRError` to a bare, text-free semantic cause.
+///
+/// Used for two things, and the second is why this is `package` rather than private:
+/// the inner error of `.modelProcessingFailed`, and the streaming START path, where the
+/// vendor throws a bare `ASRError` that is not a `SlidingWindowAsrError` at all.
+///
+/// The batch path has its own classifier (`classifyFluidAudioASRError`) which carries the
+/// vendor's `localizedDescription` on every case. That one is deliberately NOT reused for
+/// streaming: its kinds feed `ParakeetTranscriptionSentryError`, whose semantic IDs all
+/// read `parakeet_transcribe.*`, so a streaming START failure classified through it would
+/// land in a Sentry group named after transcription. A reason's name has to predict its
+/// cause; this keeps streaming identities in the streaming namespace.
+///
 /// Returns `nil` for anything that is not FluidAudio's own `ASRError`.
-private func streamingInnerCause(_ error: any Error) -> FluidAudioStreamingInnerCause? {
+package func fluidAudioStreamingInnerCause(_ error: any Error) -> FluidAudioStreamingInnerCause? {
   guard let error = error as? ASRError else { return nil }
   switch error {
   case .notInitialized: return .notInitialized
@@ -90,7 +102,7 @@ package func classifyFluidAudioStreamingError(_ error: any Error) -> FluidAudioS
   case .audioBufferProcessingFailed: return .audioBufferProcessingFailed
   case .audioConversionFailed: return .audioConversionFailed
   case .modelProcessingFailed(let inner):
-    return .allWindowsFailed(inner: streamingInnerCause(inner))
+    return .allWindowsFailed(inner: fluidAudioStreamingInnerCause(inner))
   case .bufferOverflow: return .bufferOverflow
   case .invalidConfiguration: return .invalidConfiguration
   @unknown default: return .unknownFutureCase

--- a/Sources/EnviousWisprFluidAudioBridge/FluidAudioStreamingErrorKind.swift
+++ b/Sources/EnviousWisprFluidAudioBridge/FluidAudioStreamingErrorKind.swift
@@ -1,0 +1,98 @@
+@preconcurrency import FluidAudio
+
+/// #1654: the inner cause carried by `allWindowsFailed`, as a BARE semantic case.
+///
+/// Deliberately payload-free: the vendor's inner error is arbitrary text and must not
+/// cross this boundary. This answers "why did every window fail" and nothing else.
+package enum FluidAudioStreamingInnerCause: Sendable, Equatable {
+  case notInitialized
+  case invalidAudioData
+  case modelLoadFailed
+  case processingFailed
+  case modelCompilationFailed
+  case unsupportedPlatform
+  case streamingConversionFailed
+  case fileAccessFailed
+  /// Added by the vendor in the 2026-08-08 pin bump (#1985, `afb9aab` -> `a1767d86`).
+  case encoderInstantiationFailed
+  case unknownFutureCase
+}
+
+/// #1654: classifies FluidAudio's raw `SlidingWindowAsrError` (streaming path) into a
+/// plain, name-collision-free value, mirroring `FluidAudioASRErrorKind` for batch.
+/// Same reason that target exists: `FluidAudio` exports a struct literally named
+/// `FluidAudio`, so this is the one module that can safely name the vendor's types
+/// (`swift-patterns.md` RULE: fluidaudio-unqualified-symbols).
+///
+/// **Carries NO vendor text, unlike the batch kind, and that difference is deliberate.**
+/// The plan's privacy paragraph forbids forwarding the inner error of
+/// `.modelProcessingFailed`. Reading the vendor's `errorDescription` at the shipped pin
+/// shows the hazard is wider than the plan named: THREE cases interpolate an inner
+/// error's `localizedDescription` into their own text —
+/// `audioBufferProcessingFailed`, `audioConversionFailed` and `modelProcessingFailed`
+/// (`SlidingWindowAsrSession.swift:173-179`) — and `invalidConfiguration` interpolates a
+/// vendor-authored message. So taking the vendor description for ANY case risks
+/// forwarding arbitrary vendor text, and the safe rule is to take it for none.
+///
+/// Identity lives in the case; the human-readable string is app-authored downstream.
+///
+/// All seven vendor cases are enumerated, including the six not reachable today.
+/// Enumerating them costs nothing and means a dependency bump that starts producing one
+/// yields a named identity instead of a generic bucket. Reachability is a property of
+/// the VENDOR's code, not ours, so it must be re-verified on any FluidAudio pin bump —
+/// and #2041 is what happens when nobody does.
+package enum FluidAudioStreamingErrorKind: Sendable, Equatable {
+  case modelsNotLoaded
+  case streamAlreadyExists
+  case audioBufferProcessingFailed
+  case audioConversionFailed
+  /// The vendor's `.modelProcessingFailed`, named for its MEANING rather than its
+  /// spelling. Verified at the SHIPPED pin `a1767d86`, not the checkout on disk (which
+  /// is a revision behind): it is constructed per failing window at
+  /// `SlidingWindowAsrManager.swift:645`, but only ever THROWN at `:262`, guarded by
+  /// `processedChunks == 0`. Reaching a caller therefore means every window failed,
+  /// and the name saves each future reader from re-deriving that.
+  ///
+  /// `inner` is where the actual cause lives. The vendor always wraps rather than passes
+  /// through, and there is no deeper chain, so it is unwrapped exactly once. A foreign
+  /// inner error yields `nil` and the outer identity still stands: we know every window
+  /// failed even when we cannot name why.
+  case allWindowsFailed(inner: FluidAudioStreamingInnerCause?)
+  case bufferOverflow
+  case invalidConfiguration
+  case unknownFutureCase
+}
+
+/// Maps the inner error of `.modelProcessingFailed` to a bare semantic cause.
+/// Returns `nil` for anything that is not FluidAudio's own `ASRError`.
+private func streamingInnerCause(_ error: any Error) -> FluidAudioStreamingInnerCause? {
+  guard let error = error as? ASRError else { return nil }
+  switch error {
+  case .notInitialized: return .notInitialized
+  case .invalidAudioData: return .invalidAudioData
+  case .modelLoadFailed: return .modelLoadFailed
+  case .processingFailed: return .processingFailed
+  case .modelCompilationFailed: return .modelCompilationFailed
+  case .unsupportedPlatform: return .unsupportedPlatform
+  case .streamingConversionFailed: return .streamingConversionFailed
+  case .fileAccessFailed: return .fileAccessFailed
+  case .encoderInstantiationFailed: return .encoderInstantiationFailed
+  @unknown default: return .unknownFutureCase
+  }
+}
+
+package func classifyFluidAudioStreamingError(_ error: any Error) -> FluidAudioStreamingErrorKind? {
+  // Unambiguous here: this module declares no other SlidingWindowAsrError.
+  guard let error = error as? SlidingWindowAsrError else { return nil }
+  switch error {
+  case .modelsNotLoaded: return .modelsNotLoaded
+  case .streamAlreadyExists: return .streamAlreadyExists
+  case .audioBufferProcessingFailed: return .audioBufferProcessingFailed
+  case .audioConversionFailed: return .audioConversionFailed
+  case .modelProcessingFailed(let inner):
+    return .allWindowsFailed(inner: streamingInnerCause(inner))
+  case .bufferOverflow: return .bufferOverflow
+  case .invalidConfiguration: return .invalidConfiguration
+  @unknown default: return .unknownFutureCase
+  }
+}

--- a/Sources/EnviousWisprPipeline/ASREmptyResultDiagnostics.swift
+++ b/Sources/EnviousWisprPipeline/ASREmptyResultDiagnostics.swift
@@ -18,6 +18,9 @@ internal struct ASREmptyResultDiagnostics {
 
   var streamingResultChars: Int?
   var streamingFinalizeFailed: Bool?
+  /// #1654: carries a stable semantic ID rather than a reflected type name whenever the
+  /// error declares one. Owner of that contract is `KernelTelemetryState`'s declaration;
+  /// see it before reading this value as a type.
   var streamingFinalizeErrorType: String?
   var streamingBuffersDispatched: Int?
   var streamingBuffersFed: Int?

--- a/Sources/EnviousWisprPipeline/KernelTelemetryState.swift
+++ b/Sources/EnviousWisprPipeline/KernelTelemetryState.swift
@@ -299,6 +299,14 @@ struct KernelASRAdapterDiagnostics {
 
   var streamingResultChars: Int? = nil
   var streamingFinalizeFailed: Bool? = nil
+  /// #1654: no longer a type NAME whenever the error declares a stable identity — it now
+  /// holds that identity's semantic ID (`parakeet_streaming.all_windows_failed.…`) and
+  /// falls back to `String(reflecting: type(of:))` only for an error that declares none.
+  ///
+  /// The property and its Sentry extra key both keep the `…ErrorType` spelling on
+  /// purpose. `asr.streaming_finalize_error_type` is a shipped field name, so renaming it
+  /// would orphan its history for the sake of tidiness, and letting the Swift name drift
+  /// away from the wire name would be worse than one honest comment at the declaration.
   var streamingFinalizeErrorType: String? = nil
   var streamingBuffersDispatched: Int? = nil
   var streamingBuffersFed: Int? = nil

--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -493,6 +493,17 @@ final class ParakeetEngineAdapter: ASREngineAdapter, @unchecked Sendable {
           "Streaming ASR started during recording",
           level: .info, category: "Pipeline"
         )
+      } catch is CancellationError {
+        // #1654 (cloud review P2): a cancelled start is not a failure and must not be
+        // counted as one. Behaviour is otherwise identical to the failure arm below —
+        // same flag, same fall-through — so this changes what we RECORD, not what we do.
+        //
+        // This arm only became reachable for service-side cancellation once
+        // `ASRManagerProxy.reconstructCancellation` restored the type: the XPC boundary
+        // flattens `CancellationError` to a plain `NSError`, so the guard alone would
+        // have matched app-side cancellation only and let the real case straight through
+        // to the emit below. The mirror of the finalize leg's own cancellation arm.
+        streamingActive = false
       } catch {
         // Streaming setup failed — fall back to batch decode after stop. Not a
         // session failure; the batch rescue over `retainedPCM` covers it.

--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -517,12 +517,21 @@ final class ParakeetEngineAdapter: ASREngineAdapter, @unchecked Sendable {
         // #1654: until now this leg emitted NOTHING — a breadcrumb and a debug-only log,
         // both invisible in production. So "streaming rarely fails" was never a
         // measurement; finalize failures were counted and start failures could not be.
-        // A start failure always ends the same way, in the batch path, which is why
-        // `result` can be stated here honestly: unlike the finalize leg's rescued/failed
-        // split, it does not depend on anything the kernel decides later.
+        //
+        // `result` reports ONLY what is known at this instant: the streaming start
+        // failed. It deliberately makes no claim about what happens next.
+        //
+        // The first version of this line said `fell_back_to_batch`, justified by "a start
+        // failure always ends the same way, in the batch path". Cloud review falsified it
+        // (#2046): `cancel()` calls `discardSession()` and runs no batch decode, so a user
+        // who cancels after a failed start — or capture ending before `finalize()` — makes
+        // that a permanent record of a fallback that never happened. The failure was not
+        // the value but the forward-looking CLAIM; a report emitted at time T must not
+        // assert an outcome decided at time T+1. Whether the fallback delivered is the
+        // finalize leg's and the terminal's to say.
         TelemetryService.shared.limbFailureObserved(
           limb: "asr_streaming", operation: "start",
-          result: "fell_back_to_batch",
+          result: "failed",
           errorCategory: Self.streamingErrorCategory(error),
           durationMs: nil)
       }

--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -820,7 +820,10 @@ final class ParakeetEngineAdapter: ASREngineAdapter, @unchecked Sendable {
   /// `EnviousWisprASR` and is internal to it, so this module cannot name it — and should
   /// not want to. Any error that declares a stable identity gets to keep it here,
   /// including the batch and model-load conformers that can also surface on this path.
-  private static func streamingErrorCategory(_ error: any Error) -> String {
+  /// Not `private`: `ParakeetStreamingErrorCategoryTests` drives this directly, because
+  /// the mapping is the whole observable change and testing it through a full adapter run
+  /// would prove the emit path rather than the value.
+  static func streamingErrorCategory(_ error: any Error) -> String {
     if let identified = error as? any StableSentryErrorIdentity {
       return identified.sentrySemanticID
     }

--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -503,6 +503,17 @@ final class ParakeetEngineAdapter: ASREngineAdapter, @unchecked Sendable {
           "Streaming ASR failed to start, will use batch: \(error.localizedDescription)",
           level: .info, category: "Pipeline"
         )
+        // #1654: until now this leg emitted NOTHING — a breadcrumb and a debug-only log,
+        // both invisible in production. So "streaming rarely fails" was never a
+        // measurement; finalize failures were counted and start failures could not be.
+        // A start failure always ends the same way, in the batch path, which is why
+        // `result` can be stated here honestly: unlike the finalize leg's rescued/failed
+        // split, it does not depend on anything the kernel decides later.
+        TelemetryService.shared.limbFailureObserved(
+          limb: "asr_streaming", operation: "start",
+          result: "fell_back_to_batch",
+          errorCategory: Self.streamingErrorCategory(error),
+          durationMs: nil)
       }
     }
   }
@@ -796,6 +807,26 @@ final class ParakeetEngineAdapter: ASREngineAdapter, @unchecked Sendable {
   /// saw samples), and the KERNEL re-maps it to `.noSpeech` because it knows the
   /// segments were empty. The rescue always attempts batch when streaming
   /// yields nothing.
+  /// #1654: the low-cardinality category for a streaming failure.
+  ///
+  /// Reads the error's own declared identity when it has one, and falls back to the
+  /// reflected type name when it does not. That fallback is exactly what shipped before
+  /// this change, and it is the reason this issue exists: the only streaming failure
+  /// PostHog has ever recorded (2026-07-30, v2.4.1) carries `error_category: "NSError"`,
+  /// because the typed error did not survive the XPC crossing and every distinct cause
+  /// reads as one wrapper type.
+  ///
+  /// Deliberately keyed on the PROTOCOL, not on a concrete type. The conformer lives in
+  /// `EnviousWisprASR` and is internal to it, so this module cannot name it — and should
+  /// not want to. Any error that declares a stable identity gets to keep it here,
+  /// including the batch and model-load conformers that can also surface on this path.
+  private static func streamingErrorCategory(_ error: any Error) -> String {
+    if let identified = error as? any StableSentryErrorIdentity {
+      return identified.sentrySemanticID
+    }
+    return String(reflecting: type(of: error))
+  }
+
   private func finalizeStreamingWithRescue(
     batchSamples: [Float]?, session: SessionID?, generation: Int
   ) async -> ASREngineOutcome {
@@ -827,7 +858,7 @@ final class ParakeetEngineAdapter: ASREngineAdapter, @unchecked Sendable {
     } catch {
       // Streaming finalize failed — fall through to the batch rescue.
       diagnostics.streamingFinalizeFailed = true
-      diagnostics.streamingFinalizeErrorType = String(reflecting: type(of: error))
+      diagnostics.streamingFinalizeErrorType = Self.streamingErrorCategory(error)
       await AppLogger.shared.log(
         "Streaming finalize failed: \(error.localizedDescription), rescue triggered -> batch fallback",
         level: .info, category: "Pipeline"

--- a/Tests/EnviousWisprASRTests/ASRManagerProxyCancellationTests.swift
+++ b/Tests/EnviousWisprASRTests/ASRManagerProxyCancellationTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprASR
+
+/// #1654 (cloud review P2) — a cancellation that crosses the XPC boundary must arrive as a
+/// `CancellationError` again, not as an anonymous `NSError`.
+///
+/// **The defect this closes was mine and it was one commit from shipping.** #1654 gave the
+/// streaming START leg a telemetry event where it previously emitted nothing. The adapter
+/// guards that leg with `catch is CancellationError` — but `XPCErrorSanitizer` preserves
+/// only domain, code and description, so a service-side cancellation reaches the app as a
+/// plain `NSError` and the guard cannot match it. A user cancelling a recording would have
+/// been counted as a streaming start FAILURE.
+///
+/// The first test is the measurement the fix rests on, written as an executable assertion
+/// rather than a comment, so a Swift change to the bridged representation fails here
+/// instead of silently turning the reconstruction into a no-op.
+@Suite("Cancellation survives the XPC boundary (#1654)")
+struct ASRManagerProxyCancellationTests {
+
+  /// Pins the bridged representation. If this fails, `reconstructCancellation`'s domain
+  /// and code are wrong and every other test in this file is passing vacuously.
+  @Test("a bridged CancellationError is domain Swift.CancellationError, code 1")
+  func bridgedRepresentationIsPinned() {
+    let bridged = CancellationError() as NSError
+    #expect(bridged.domain == "Swift.CancellationError")
+    #expect(bridged.code == 1)
+  }
+
+  /// The reason the reconstruction has to exist at all: the type does NOT survive on its
+  /// own. This is the negative half — without it, someone could reasonably conclude the
+  /// whole mechanism is redundant.
+  @Test("the CancellationError TYPE does not survive a real archive round-trip")
+  func typeIsLostAcrossTheBoundary() throws {
+    let bridged = CancellationError() as NSError
+    let sanitized = NSError(
+      domain: bridged.domain, code: bridged.code,
+      userInfo: [NSLocalizedDescriptionKey: bridged.localizedDescription])
+    let data = try NSKeyedArchiver.archivedData(
+      withRootObject: sanitized, requiringSecureCoding: true)
+    let decoded = try #require(
+      try NSKeyedUnarchiver.unarchivedObject(ofClass: NSError.self, from: data))
+
+    #expect(!((decoded as Error) is CancellationError))
+  }
+
+  @Test("reconstructCancellation restores the type from the flattened error")
+  func restoresTheType() throws {
+    let bridged = CancellationError() as NSError
+    let restored = try #require(ASRManagerProxy.reconstructCancellation(bridged))
+    #expect(restored is CancellationError)
+  }
+
+  /// The two-way control. A reconstructor that returned `CancellationError()` for
+  /// everything would pass every test above while silently swallowing real failures —
+  /// which is the worse failure direction, so it gets the explicit cases.
+  @Test("reconstructCancellation refuses anything that is not a cancellation")
+  func refusesNonCancellations() {
+    let cases: [NSError] = [
+      // Our own streaming identity, which must keep its own reconstruction.
+      ParakeetStreamingSentryError.allWindowsFailed(inner: .processingFailed) as NSError,
+      // Right domain, wrong code.
+      NSError(domain: "Swift.CancellationError", code: 2),
+      // Right code, wrong domain.
+      NSError(domain: "SomeOtherDomain", code: 1),
+      // A prefix match would wrongly accept this; an exact match does not.
+      NSError(domain: "Swift.CancellationErrorish", code: 1),
+      NSError(domain: "com.apple.CoreML", code: 0),
+    ]
+    for error in cases {
+      #expect(
+        ASRManagerProxy.reconstructCancellation(error) == nil,
+        "must not claim \(error.domain)#\(error.code)")
+    }
+  }
+
+  /// Ordering matters: cancellation is checked before the identity reconstructors, so this
+  /// asserts the two cannot collide. Our identity domain is distinct, so a cancellation
+  /// can never be mistaken for a streaming failure or vice versa.
+  @Test("the cancellation domain cannot collide with the streaming identity domain")
+  func domainsAreDisjoint() {
+    #expect(ParakeetStreamingSentryError.errorDomain != "Swift.CancellationError")
+    let streaming = ParakeetStreamingSentryError.startFailed(inner: .notInitialized) as NSError
+    #expect(ASRManagerProxy.reconstructCancellation(streaming) == nil)
+    #expect(ParakeetStreamingSentryError(reconstructingFrom: CancellationError() as NSError) == nil)
+  }
+}

--- a/Tests/EnviousWisprASRTests/FluidAudioBridgeClassificationTests.swift
+++ b/Tests/EnviousWisprASRTests/FluidAudioBridgeClassificationTests.swift
@@ -216,6 +216,48 @@ struct FluidAudioBridgeClassificationTests {
     #expect(fluidAudioStreamingInnerCause(CancellationError()) == nil)
   }
 
+  /// #1654 cloud review, fourth P2 — cancellation NESTED inside a vendor wrapper.
+  ///
+  /// Unreachable at the pinned vendor (see the next test, which is the control proving
+  /// that), and guarded anyway: reachability here is a property of the VENDOR's code, so a
+  /// pin bump that drops its early return would silently start recording every cancelled
+  /// dictation as a streaming failure.
+  @Test("a cancellation wrapped by the vendor is still recognised as cancellation")
+  func nestedCancellationIsRecognised() {
+    let wrapped = SlidingWindowAsrError.modelProcessingFailed(CancellationError())
+    #expect(fluidAudioStreamingErrorWrapsCancellation(wrapped))
+    // The sibling wrapping cases too — all three carry an arbitrary inner error.
+    #expect(
+      fluidAudioStreamingErrorWrapsCancellation(
+        SlidingWindowAsrError.audioBufferProcessingFailed(CancellationError())))
+    #expect(
+      fluidAudioStreamingErrorWrapsCancellation(
+        SlidingWindowAsrError.audioConversionFailed(CancellationError())))
+    // And a bare one, which is the case the call sites' own `catch` arms handle.
+    #expect(fluidAudioStreamingErrorWrapsCancellation(CancellationError()))
+  }
+
+  /// The two-way control. Without it, a predicate returning `true` for everything would
+  /// pass the test above while suppressing every genuine streaming failure — which is the
+  /// far worse direction, since it fails SILENTLY.
+  @Test("a genuine failure is never mistaken for a cancellation")
+  func genuineFailureIsNotCancellation() {
+    let cases: [SlidingWindowAsrError] = [
+      .modelProcessingFailed(NSError(domain: "f", code: 1)),
+      .audioBufferProcessingFailed(NSError(domain: "f", code: 1)),
+      .audioConversionFailed(NSError(domain: "f", code: 1)),
+      .modelsNotLoaded,
+      .streamAlreadyExists(.microphone),
+      .bufferOverflow,
+      .invalidConfiguration("x"),
+    ]
+    for error in cases {
+      #expect(!fluidAudioStreamingErrorWrapsCancellation(error), "\(error) is not cancellation")
+    }
+    struct ForeignError: Error {}
+    #expect(!fluidAudioStreamingErrorWrapsCancellation(ForeignError()))
+  }
+
   @Test("classifyFluidAudioStreamingError returns nil for a foreign error type")
   func returnsNilForNonStreamingError() {
     struct OtherError: Error {}

--- a/Tests/EnviousWisprASRTests/FluidAudioBridgeClassificationTests.swift
+++ b/Tests/EnviousWisprASRTests/FluidAudioBridgeClassificationTests.swift
@@ -168,4 +168,96 @@ struct FluidAudioBridgeClassificationTests {
       return
     }
   }
+
+  // MARK: - FluidAudioStreamingErrorKind (streaming path, 7 vendor cases) — #1654
+
+  /// Ship criterion 1. Every case is driven from a REAL vendor error value, not a
+  /// hand-built double, so the row fails if the vendor's enum moves under us — the
+  /// #2041 drift is what happens when a classifier is only tested from its own output.
+  @Test("classifyFluidAudioStreamingError maps every SlidingWindowAsrError case")
+  func classifiesAllStreamingErrorCases() {
+    let fixture = NSError(domain: "fixture", code: 1)
+    let cases: [(SlidingWindowAsrError, FluidAudioStreamingErrorKind)] = [
+      (.modelsNotLoaded, .modelsNotLoaded),
+      (.streamAlreadyExists(.microphone), .streamAlreadyExists),
+      (.audioBufferProcessingFailed(fixture), .audioBufferProcessingFailed),
+      (.audioConversionFailed(fixture), .audioConversionFailed),
+      (.bufferOverflow, .bufferOverflow),
+      (.invalidConfiguration("x"), .invalidConfiguration),
+    ]
+    for (vendorError, expected) in cases {
+      #expect(classifyFluidAudioStreamingError(vendorError) == expected)
+    }
+  }
+
+  /// Ship criterion 2 — BOTH directions, because a one-sided test passes whether or not
+  /// the unwrap actually runs.
+  @Test("the allWindowsFailed unwrap recovers a recognised inner cause")
+  func unwrapsRecognisedInnerCause() {
+    let wrapped = SlidingWindowAsrError.modelProcessingFailed(ASRError.processingFailed("x"))
+    #expect(
+      classifyFluidAudioStreamingError(wrapped) == .allWindowsFailed(inner: .processingFailed))
+  }
+
+  @Test("the allWindowsFailed outer case survives an unrecognised inner error")
+  func keepsOuterCaseForForeignInnerError() {
+    struct ForeignError: Error {}
+    let wrapped = SlidingWindowAsrError.modelProcessingFailed(ForeignError())
+    // The outer identity must NOT collapse to nil: we still know every window failed
+    // even when we cannot name why. That distinction is the whole point of the case.
+    #expect(classifyFluidAudioStreamingError(wrapped) == .allWindowsFailed(inner: nil))
+  }
+
+  /// Ship criterion 3. A cancelled stream is not a failure and must never acquire a
+  /// failure identity — neither through the streaming classifier nor the start-path one.
+  @Test("cancellation acquires no streaming identity")
+  func cancellationGetsNoIdentity() {
+    #expect(classifyFluidAudioStreamingError(CancellationError()) == nil)
+    #expect(fluidAudioStreamingInnerCause(CancellationError()) == nil)
+  }
+
+  @Test("classifyFluidAudioStreamingError returns nil for a foreign error type")
+  func returnsNilForNonStreamingError() {
+    struct OtherError: Error {}
+    #expect(classifyFluidAudioStreamingError(OtherError()) == nil)
+    // A BATCH vendor error is foreign to the streaming classifier too. Without this the
+    // start-path mapping and the streaming mapping could quietly overlap.
+    #expect(classifyFluidAudioStreamingError(ASRError.notInitialized) == nil)
+  }
+
+  /// The start leg: the vendor throws a bare `ASRError` there, and it must classify into
+  /// the same text-free vocabulary rather than borrowing the batch path's identity.
+  @Test("the start-path classifier maps a bare ASRError to a bare inner cause")
+  func mapsStartPathASRError() {
+    #expect(fluidAudioStreamingInnerCause(ASRError.notInitialized) == .notInitialized)
+    #expect(fluidAudioStreamingInnerCause(ASRError.processingFailed("x")) == .processingFailed)
+    #expect(
+      fluidAudioStreamingInnerCause(ASRError.encoderInstantiationFailed("x"))
+        == .encoderInstantiationFailed)
+  }
+
+  /// Ship criterion 2b. Asserting the inner case is right is not the same as asserting
+  /// nothing else came with it. The vendor interpolates an inner error's own description
+  /// into four of its seven `errorDescription` cases, so this is the guard that the
+  /// streaming kind forwards none of it.
+  @Test("no vendor text rides the streaming kind")
+  func streamingKindCarriesNoVendorText() {
+    let secret = "VENDOR-TEXT-THAT-MUST-NOT-TRAVEL"
+    let inner = NSError(
+      domain: "fixture", code: 1, userInfo: [NSLocalizedDescriptionKey: secret])
+    let wrapped = SlidingWindowAsrError.modelProcessingFailed(inner)
+
+    // Control: prove the fixture actually reaches the vendor's own description, so a
+    // clean result below is the kind's doing and not a fixture that never carried it.
+    #expect(wrapped.localizedDescription.contains(secret))
+
+    let kind = classifyFluidAudioStreamingError(wrapped)
+    #expect(!String(describing: kind).contains(secret))
+
+    // Same check on the case that interpolates a vendor-authored message rather than an
+    // inner error's description.
+    let configured = SlidingWindowAsrError.invalidConfiguration(secret)
+    #expect(configured.localizedDescription.contains(secret))
+    #expect(!String(describing: classifyFluidAudioStreamingError(configured)).contains(secret))
+  }
 }

--- a/Tests/EnviousWisprASRTests/ParakeetStreamingIdentityBridgeTests.swift
+++ b/Tests/EnviousWisprASRTests/ParakeetStreamingIdentityBridgeTests.swift
@@ -1,0 +1,103 @@
+@preconcurrency import FluidAudio
+import Foundation
+import Testing
+
+@testable import EnviousWisprASR
+@testable import EnviousWisprFluidAudioBridge
+
+/// #1654 — the one place the WHOLE chain runs: a real FluidAudio error, through the
+/// bridge classifier, into the app-owned identity, out to the bridged `NSError` that
+/// actually crosses XPC.
+///
+/// **Why this is a third file rather than a section of an existing one.** Three suites
+/// now cover this feature and the split is forced by the naming trap the bridge exists
+/// for, not by taste:
+///
+/// - `FluidAudioBridgeClassificationTests` (vendor -> kind) imports FluidAudio only. It
+///   names `ASRError`, which is the vendor's.
+/// - `ParakeetStreamingSentryErrorTests` (kind -> identity -> wire) lives in
+///   `EnviousWisprTests`, which cannot import FluidAudio at all: `ASRError` there
+///   resolves to OUR type.
+/// - This file needs both `EnviousWisprASR` and FluidAudio, and importing both makes
+///   `ASRError` genuinely ambiguous — the compiler says so. So it names only
+///   `SlidingWindowAsrError`, which no target of ours shadows.
+///
+/// The consequence worth stating plainly: the start-leg positive case cannot be driven
+/// end to end from here, because constructing a vendor `ASRError` requires naming it.
+/// It is covered as two halves instead — vendor -> inner cause in the bridge suite,
+/// inner cause -> `.startFailed` in the identity suite — and those compose soundly
+/// because `FluidAudioStreamingInnerCause` is payload-free, so nothing can be lost or
+/// added between them.
+@Suite("Parakeet streaming identity, vendor error to wire (#1654)")
+struct ParakeetStreamingIdentityBridgeTests {
+
+  /// The named-cause path, whole. This is the row that would have caught the defect this
+  /// issue was filed for: the one streaming failure production has ever recorded arrived
+  /// as `error_category: "NSError"` because nothing survived the crossing.
+  @Test("a real vendor error keeps a named identity all the way to the bridged NSError")
+  func realVendorErrorKeepsItsIdentityToTheWire() throws {
+    // A vendor error whose inner cause is one we can name is not constructible here
+    // without naming `ASRError` (see the suite comment), so the inner is deliberately a
+    // foreign error and the assertion is on the OUTER identity surviving intact.
+    let vendor = SlidingWindowAsrError.modelProcessingFailed(NSError(domain: "f", code: 1))
+
+    let kind = try #require(classifyFluidAudioStreamingError(vendor))
+    let error = ParakeetStreamingSentryError(mapping: kind)
+    let bridged = error as NSError
+
+    #expect(bridged.domain == ParakeetStreamingSentryError.errorDomain)
+    // The reconstruction the proxy performs, on the value that really crosses.
+    #expect(ParakeetStreamingSentryError(reconstructingFrom: bridged) == error)
+    #expect(error.sentrySemanticID == "parakeet_streaming.all_windows_failed.unrecognised")
+  }
+
+  /// Two-way control. Without it, an implementation that gave EVERY error the streaming
+  /// identity would pass the test above — the suite would prove the identity is reachable
+  /// and not that it is earned.
+  @Test("a foreign vendor error acquires no streaming identity")
+  func foreignErrorGetsNoIdentity() {
+    struct ForeignError: Error {}
+    #expect(classifyFluidAudioStreamingError(ForeignError()) == nil)
+    #expect(ParakeetStreamingSentryError(mappingStartFailure: ForeignError()) == nil)
+  }
+
+  /// The end-to-end privacy guard: a marker planted in a real vendor error must not reach
+  /// the `NSError` that crosses the process boundary. The bridge suite proves the KIND is
+  /// clean; this proves nothing re-introduces the text downstream of it.
+  @Test("vendor text planted in a real error cannot reach the wire")
+  func vendorTextCannotReachTheWire() throws {
+    let secret = "VENDOR-TEXT-THAT-MUST-NOT-TRAVEL"
+    let inner = NSError(domain: "f", code: 1, userInfo: [NSLocalizedDescriptionKey: secret])
+    let vendor = SlidingWindowAsrError.modelProcessingFailed(inner)
+    // Control: the fixture really does carry the marker through the vendor's own
+    // description, so a clean result below belongs to our types, not to a fixture that
+    // never carried it.
+    #expect(vendor.localizedDescription.contains(secret))
+
+    let kind = try #require(classifyFluidAudioStreamingError(vendor))
+    let bridged = ParakeetStreamingSentryError(mapping: kind) as NSError
+
+    #expect(!bridged.localizedDescription.contains(secret))
+    #expect(!String(describing: bridged.userInfo).contains(secret))
+    // And it is not clean merely by discarding everything: the cause still travels.
+    #expect(bridged.localizedDescription.contains("every audio window failed"))
+  }
+
+  /// An actual archive round-trip, not an in-process cast — the same distinction the
+  /// batch conformer learned the hard way. This is the closest a unit test gets to the
+  /// XPC crossing itself.
+  @Test("the identity survives a real NSSecureCoding archive round-trip")
+  func identitySurvivesArchive() throws {
+    let vendor = SlidingWindowAsrError.bufferOverflow
+    let kind = try #require(classifyFluidAudioStreamingError(vendor))
+    let error = ParakeetStreamingSentryError(mapping: kind)
+
+    let data = try NSKeyedArchiver.archivedData(
+      withRootObject: error as NSError, requiringSecureCoding: true)
+    let decoded = try #require(
+      try NSKeyedUnarchiver.unarchivedObject(ofClass: NSError.self, from: data))
+
+    #expect(ParakeetStreamingSentryError(reconstructingFrom: decoded) == error)
+    #expect(decoded.localizedDescription == error.errorDescription)
+  }
+}

--- a/Tests/EnviousWisprTests/ASR/ParakeetStreamingSentryErrorTests.swift
+++ b/Tests/EnviousWisprTests/ASR/ParakeetStreamingSentryErrorTests.swift
@@ -1,0 +1,326 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprASR
+@testable import EnviousWisprFluidAudioBridge
+@testable import EnviousWisprServices
+
+/// #1654 — `ParakeetStreamingSentryError`'s Sentry identity is PINNED, mirroring the
+/// batch conformer's contract.
+///
+/// **Measured before pinning, per the epic protocol (`BIBLE.md` §5), 2026-08-12.** A
+/// 90-day Sentry search returns ZERO issues for "SlidingWindow" or "streaming", against
+/// a working positive control ("Parakeet" returns ENVIOUSWISPR-16). The mechanism agrees:
+/// the only streaming failure PostHog has ever recorded (one event, one person,
+/// 2026-07-30, v2.4.1) was `result: rescued`, and a rescued failure produces no terminal
+/// and therefore no Sentry event. So no shipped grouping exists to preserve, and these
+/// descriptors are app-owned strings rather than defensive vendor-ordinal pins.
+@Suite("ParakeetStreamingSentryError Sentry stable identity (#1654)")
+struct ParakeetStreamingSentryErrorTests {
+
+  private static let env = "production"
+  private static let base = "EnviousWisprASR.ParakeetStreamingSentryError"
+
+  /// Every declared identity, including one `allWindowsFailed` / `startFailed` row per
+  /// inner cause. Enumerated rather than generated: a generated table would reproduce
+  /// whatever the implementation does, which proves only that the code equals itself.
+  private static let pins: [(ParakeetStreamingSentryError, String, String)] = [
+    (.modelsNotLoaded, "\(base).modelsNotLoaded", "parakeet_streaming.models_not_loaded"),
+    (
+      .streamAlreadyExists, "\(base).streamAlreadyExists",
+      "parakeet_streaming.stream_already_exists"
+    ),
+    (
+      .audioBufferProcessingFailed, "\(base).audioBufferProcessingFailed",
+      "parakeet_streaming.audio_buffer_processing_failed"
+    ),
+    (
+      .audioConversionFailed, "\(base).audioConversionFailed",
+      "parakeet_streaming.audio_conversion_failed"
+    ),
+    (.bufferOverflow, "\(base).bufferOverflow", "parakeet_streaming.buffer_overflow"),
+    (
+      .invalidConfiguration, "\(base).invalidConfiguration",
+      "parakeet_streaming.invalid_configuration"
+    ),
+    (
+      .unknownStreamingFailure, "\(base).unknownStreamingFailure",
+      "parakeet_streaming.unknown_streaming_failure"
+    ),
+    (
+      .allWindowsFailed(inner: nil), "\(base).allWindowsFailed.unrecognised",
+      "parakeet_streaming.all_windows_failed.unrecognised"
+    ),
+    (
+      .allWindowsFailed(inner: .notInitialized), "\(base).allWindowsFailed.notInitialized",
+      "parakeet_streaming.all_windows_failed.not_initialized"
+    ),
+    (
+      .allWindowsFailed(inner: .invalidAudioData), "\(base).allWindowsFailed.invalidAudioData",
+      "parakeet_streaming.all_windows_failed.invalid_audio_data"
+    ),
+    (
+      .allWindowsFailed(inner: .modelLoadFailed), "\(base).allWindowsFailed.modelLoadFailed",
+      "parakeet_streaming.all_windows_failed.model_load_failed"
+    ),
+    (
+      .allWindowsFailed(inner: .processingFailed), "\(base).allWindowsFailed.processingFailed",
+      "parakeet_streaming.all_windows_failed.processing_failed"
+    ),
+    (
+      .allWindowsFailed(inner: .modelCompilationFailed),
+      "\(base).allWindowsFailed.modelCompilationFailed",
+      "parakeet_streaming.all_windows_failed.model_compilation_failed"
+    ),
+    (
+      .allWindowsFailed(inner: .unsupportedPlatform),
+      "\(base).allWindowsFailed.unsupportedPlatform",
+      "parakeet_streaming.all_windows_failed.unsupported_platform"
+    ),
+    (
+      .allWindowsFailed(inner: .streamingConversionFailed),
+      "\(base).allWindowsFailed.streamingConversionFailed",
+      "parakeet_streaming.all_windows_failed.streaming_conversion_failed"
+    ),
+    (
+      .allWindowsFailed(inner: .fileAccessFailed), "\(base).allWindowsFailed.fileAccessFailed",
+      "parakeet_streaming.all_windows_failed.file_access_failed"
+    ),
+    (
+      .allWindowsFailed(inner: .encoderInstantiationFailed),
+      "\(base).allWindowsFailed.encoderInstantiationFailed",
+      "parakeet_streaming.all_windows_failed.encoder_instantiation_failed"
+    ),
+    (
+      .allWindowsFailed(inner: .unknownFutureCase), "\(base).allWindowsFailed.unknownFutureCase",
+      "parakeet_streaming.all_windows_failed.unknown_future_case"
+    ),
+    (
+      .startFailed(inner: nil), "\(base).startFailed.unrecognised",
+      "parakeet_streaming.start_failed.unrecognised"
+    ),
+    (
+      .startFailed(inner: .notInitialized), "\(base).startFailed.notInitialized",
+      "parakeet_streaming.start_failed.not_initialized"
+    ),
+    (
+      .startFailed(inner: .invalidAudioData), "\(base).startFailed.invalidAudioData",
+      "parakeet_streaming.start_failed.invalid_audio_data"
+    ),
+    (
+      .startFailed(inner: .modelLoadFailed), "\(base).startFailed.modelLoadFailed",
+      "parakeet_streaming.start_failed.model_load_failed"
+    ),
+    (
+      .startFailed(inner: .processingFailed), "\(base).startFailed.processingFailed",
+      "parakeet_streaming.start_failed.processing_failed"
+    ),
+    (
+      .startFailed(inner: .modelCompilationFailed), "\(base).startFailed.modelCompilationFailed",
+      "parakeet_streaming.start_failed.model_compilation_failed"
+    ),
+    (
+      .startFailed(inner: .unsupportedPlatform), "\(base).startFailed.unsupportedPlatform",
+      "parakeet_streaming.start_failed.unsupported_platform"
+    ),
+    (
+      .startFailed(inner: .streamingConversionFailed),
+      "\(base).startFailed.streamingConversionFailed",
+      "parakeet_streaming.start_failed.streaming_conversion_failed"
+    ),
+    (
+      .startFailed(inner: .fileAccessFailed), "\(base).startFailed.fileAccessFailed",
+      "parakeet_streaming.start_failed.file_access_failed"
+    ),
+    (
+      .startFailed(inner: .encoderInstantiationFailed),
+      "\(base).startFailed.encoderInstantiationFailed",
+      "parakeet_streaming.start_failed.encoder_instantiation_failed"
+    ),
+    (
+      .startFailed(inner: .unknownFutureCase), "\(base).startFailed.unknownFutureCase",
+      "parakeet_streaming.start_failed.unknown_future_case"
+    ),
+  ]
+
+  // MARK: - A. Pinned identities
+
+  @Test("every case keeps its exact pinned fingerprint and semantic ID")
+  func pinnedIdentities() {
+    for (error, descriptor, semanticID) in Self.pins {
+      #expect(error.sentryFingerprintDescriptor == descriptor)
+      #expect(error.sentrySemanticID == semanticID)
+    }
+  }
+
+  @Test("all declared identities are unique")
+  func identitiesAreUnique() {
+    let descriptors = Self.pins.map(\.1)
+    let semanticIDs = Self.pins.map(\.2)
+    #expect(Set(descriptors).count == descriptors.count)
+    #expect(Set(semanticIDs).count == semanticIDs.count)
+    // The pin table must cover the whole space, or "unique" is a claim about a subset.
+    // 7 flat cases + 2 blocks x (10 inner causes + 1 unrecognised) = 29.
+    #expect(Self.pins.count == 29)
+  }
+
+  // MARK: - B. Code allocation
+
+  /// The inner cause has to ride the `errorCode`, because `XPCErrorSanitizer` rebuilds
+  /// every error crossing the boundary with `userInfo` reduced to exactly one key. So the
+  /// code allocation IS the wire format, and a collision would silently merge two causes.
+  @Test("every declared case has a distinct errorCode")
+  func errorCodesAreUnique() {
+    let codes = Self.pins.map { ($0.0 as NSError).code }
+    #expect(Set(codes).count == codes.count)
+  }
+
+  @Test("the two inner-cause blocks do not overlap")
+  func blocksDoNotOverlap() {
+    let allWindows = Self.pins.filter {
+      if case .allWindowsFailed = $0.0 { return true } else { return false }
+    }.map { ($0.0 as NSError).code }
+    let starts = Self.pins.filter {
+      if case .startFailed = $0.0 { return true } else { return false }
+    }.map { ($0.0 as NSError).code }
+    #expect(Set(allWindows).isDisjoint(with: Set(starts)))
+    #expect(allWindows.allSatisfy { (100...199).contains($0) })
+    #expect(starts.allSatisfy { (200...299).contains($0) })
+  }
+
+  /// A code from a block this build does not know must NOT be read as a known case with
+  /// an unknown inner cause. Without the block bound, an unbounded `> base` test would
+  /// absorb every code allocated above it — including the `startFailed` block.
+  @Test("a code outside every allocated block reconstructs to nil, not to a neighbour")
+  func unallocatedCodeReconstructsToNil() {
+    for code in [50, 99, 300, 1000] {
+      let ns = NSError(domain: ParakeetStreamingSentryError.errorDomain, code: code)
+      #expect(
+        ParakeetStreamingSentryError(reconstructingFrom: ns) == nil,
+        "code \(code) must not reconstruct")
+    }
+  }
+
+  /// The reverse direction of the same guard: an offset INSIDE a known block but not yet
+  /// allocated must degrade to "cause unrecognised", never to a wrong cause.
+  @Test("an unallocated offset inside a block degrades to an unrecognised cause")
+  func unallocatedOffsetDegradesToUnrecognised() {
+    let ns = NSError(domain: ParakeetStreamingSentryError.errorDomain, code: 150)
+    #expect(ParakeetStreamingSentryError(reconstructingFrom: ns) == .allWindowsFailed(inner: nil))
+  }
+
+  // MARK: - C. NSError round-trip (survives the XPC boundary)
+
+  @Test("every case round-trips through its NSError bridge")
+  func nsErrorRoundTrip() {
+    for (error, _, _) in Self.pins {
+      let bridged = error as NSError
+      #expect(bridged.domain == ParakeetStreamingSentryError.errorDomain)
+      guard let reconstructed = ParakeetStreamingSentryError(reconstructingFrom: bridged) else {
+        Issue.record("reconstruction failed for \(error)")
+        continue
+      }
+      #expect(reconstructed == error)
+    }
+  }
+
+  /// Same reason as the batch conformer: a plain `as NSError` cast survives in-process
+  /// but an actual archive round-trip drops the description unless `errorUserInfo`
+  /// carries it. This exercises the real archive, not the cast.
+  @Test("the description survives an actual NSSecureCoding archive round-trip")
+  func descriptionSurvivesArchiveRoundTrip() throws {
+    let error = ParakeetStreamingSentryError.allWindowsFailed(inner: .processingFailed)
+    let bridged = error as NSError
+    let data = try NSKeyedArchiver.archivedData(
+      withRootObject: bridged, requiringSecureCoding: true)
+    let decoded = try #require(
+      try NSKeyedUnarchiver.unarchivedObject(ofClass: NSError.self, from: data))
+    #expect(decoded.localizedDescription == error.errorDescription)
+    // And the identity itself survives, which is the part the diagnostics depend on.
+    #expect(ParakeetStreamingSentryError(reconstructingFrom: decoded) == error)
+  }
+
+  @Test("reconstructingFrom returns nil for an unrelated NSError domain")
+  func reconstructionRejectsForeignDomain() {
+    let foreign = NSError(domain: "SomeOtherDomain", code: 100)
+    #expect(ParakeetStreamingSentryError(reconstructingFrom: foreign) == nil)
+  }
+
+  // MARK: - D. Descriptions are app-authored
+
+  /// Ship criterion 2b at the IDENTITY layer, as far as this target can reach it.
+  ///
+  /// The end-to-end leak test — a REAL vendor error carrying a marker, driven through the
+  /// classifier and out to the wire — lives in `FluidAudioBridgeClassificationTests`,
+  /// because this target cannot import FluidAudio: `ASRError` here resolves to OUR type,
+  /// not the vendor's. That collision is the entire reason the bridge target exists, so
+  /// splitting the test follows the same boundary rather than fighting it.
+  ///
+  /// What is provable here is the other half: every description is one of ours.
+  @Test("every case's description is app-authored and non-empty")
+  func descriptionsAreAppAuthored() {
+    for (error, _, _) in Self.pins {
+      let description = try? #require(error.errorDescription)
+      #expect(description?.isEmpty == false)
+      // Every app-authored string starts this way. A vendor description would not, and
+      // an interpolated one would carry the vendor's own phrasing instead.
+      #expect(description?.hasPrefix("Live transcription") == true)
+      #expect((error as NSError).localizedDescription == description)
+    }
+  }
+
+  // MARK: - E. Mapping from the bridge kind
+
+  @Test("init(mapping:) covers every streaming kind")
+  func mappingCoversEveryKind() {
+    let kinds: [(FluidAudioStreamingErrorKind, ParakeetStreamingSentryError)] = [
+      (.modelsNotLoaded, .modelsNotLoaded),
+      (.streamAlreadyExists, .streamAlreadyExists),
+      (.audioBufferProcessingFailed, .audioBufferProcessingFailed),
+      (.audioConversionFailed, .audioConversionFailed),
+      (.bufferOverflow, .bufferOverflow),
+      (.invalidConfiguration, .invalidConfiguration),
+      (.unknownFutureCase, .unknownStreamingFailure),
+      (.allWindowsFailed(inner: nil), .allWindowsFailed(inner: nil)),
+      (
+        .allWindowsFailed(inner: .processingFailed),
+        .allWindowsFailed(inner: .processingFailed)
+      ),
+    ]
+    for (kind, expected) in kinds {
+      #expect(ParakeetStreamingSentryError(mapping: kind) == expected)
+    }
+  }
+
+  /// The positive half — a real vendor `ASRError` producing `.startFailed` — is in
+  /// `FluidAudioBridgeClassificationTests` for the import reason above. The refusals are
+  /// testable here and are the half that matters most: an error we cannot name must not
+  /// acquire a streaming identity, and a cancellation must never look like a failure.
+  @Test("init(mappingStartFailure:) refuses a foreign error and a cancellation")
+  func startFailureMappingRefusals() {
+    struct ForeignError: Error {}
+    #expect(ParakeetStreamingSentryError(mappingStartFailure: ForeignError()) == nil)
+    #expect(ParakeetStreamingSentryError(mappingStartFailure: CancellationError()) == nil)
+  }
+
+  // MARK: - F. Event-construction contract
+
+  @MainActor
+  @Test("a streaming-failure event carries the pinned fingerprint and identity tag")
+  func streamingFailureEventShape() {
+    let error = ParakeetStreamingSentryError.allWindowsFailed(inner: .processingFailed)
+
+    let event = SentryBreadcrumb.makeHandledErrorEvent(
+      error, category: .asrFailed, stage: "transcription", environment: Self.env)
+
+    #expect(
+      event.fingerprint == [
+        "handled_error", "asr_failed",
+        "\(Self.base).allWindowsFailed.processingFailed", Self.env,
+      ])
+    #expect(
+      event.tags?["error.identity"]
+        == "parakeet_streaming.all_windows_failed.processing_failed")
+  }
+}

--- a/Tests/EnviousWisprTests/Architecture/EngineMutationInventoryFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EngineMutationInventoryFreezeTests.swift
@@ -612,11 +612,11 @@ import Testing
     // engine state at the throw is whatever the vendor left it as.
     CallSite(
       file: "Sources/EnviousWisprASR/ParakeetBackend.swift", matcher: "finalize",
-      text: "throw Self.streamingIdentity(for: error, operation: .finalize) ?? error",
+      text: "throw Self.streamingThrowable(for: error, operation: .finalize)",
       classification: .structurallySafe),
     CallSite(
       file: "Sources/EnviousWisprASR/ParakeetBackend.swift", matcher: "finalize",
-      text: "case .finalize: return nil", classification: .structurallySafe),
+      text: "case .finalize: return error", classification: .structurallySafe),
 
     // MARK: WhisperKitBackend — test-seam override, always nil in production.
     CallSite(

--- a/Tests/EnviousWisprTests/Architecture/EngineMutationInventoryFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EngineMutationInventoryFreezeTests.swift
@@ -173,7 +173,9 @@ import Testing
     /// for an engine SWITCH specifically, or (c) a call that cannot conflict
     /// with recovery regardless of timing because the callee re-acquires its
     /// own claim internally on every invocation, or performs no actual engine
-    /// mutation (a pure readiness read).
+    /// mutation (a pure readiness read, or — #1654 — pure error classification
+    /// on a throw path, which mutates nothing and only renames the error
+    /// already in hand).
     case structurallySafe
     /// Present in source, reachable in theory, but never exercised by current
     /// production configuration (a test-seam override that is always nil in
@@ -600,6 +602,21 @@ import Testing
       file: "Sources/EnviousWisprASR/ParakeetBackend.swift", matcher: "startStreaming",
       text: "try await manager.startStreaming(source: .microphone)",
       classification: .transitivelyCoveredByCaller),
+
+    // MARK: ParakeetBackend — #1654 streaming error identity. Both sites match
+    // only because the word `finalize` appears in them; neither touches the
+    // engine. The first is the `catch` that renames an already-thrown error
+    // before rethrowing it, the second a `switch` arm inside the pure
+    // classifier that decides whether a bare vendor error may be named on this
+    // leg. Nothing is loaded, unloaded, started or cancelled by either — the
+    // engine state at the throw is whatever the vendor left it as.
+    CallSite(
+      file: "Sources/EnviousWisprASR/ParakeetBackend.swift", matcher: "finalize",
+      text: "throw Self.streamingIdentity(for: error, operation: .finalize) ?? error",
+      classification: .structurallySafe),
+    CallSite(
+      file: "Sources/EnviousWisprASR/ParakeetBackend.swift", matcher: "finalize",
+      text: "case .finalize: return nil", classification: .structurallySafe),
 
     // MARK: WhisperKitBackend — test-seam override, always nil in production.
     CallSite(

--- a/Tests/EnviousWisprTests/Pipeline/ParakeetStreamingErrorCategoryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ParakeetStreamingErrorCategoryTests.swift
@@ -1,0 +1,71 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprASR
+@testable import EnviousWisprFluidAudioBridge
+@testable import EnviousWisprPipeline
+
+/// #1654 ship criterion 5 — the change that makes every other part of this work
+/// observable.
+///
+/// Before this, `limb.failure_observed` carried `String(reflecting: type(of: error))`,
+/// so a streaming failure reported the name of whatever wrapper survived the trip from
+/// the transcription helper. Production has exactly one such event, from 2026-07-30, and
+/// its category is the literal string `NSError` — every distinct cause reading as one
+/// type is the defect, measured rather than argued.
+///
+/// **Scope of this suite, stated so it is not read as more than it is.** It tests the
+/// category MAPPING, not the emit path: it proves an identified error yields its semantic
+/// ID and an unidentified one still yields the type name. Whether the emission fires, and
+/// with which `result`, is the adapter's own behaviour and is covered by the existing
+/// adapter suites.
+@MainActor
+@Suite("Streaming failure category is the semantic ID, not the type name (#1654)")
+struct ParakeetStreamingErrorCategoryTests {
+
+  /// A stand-in conformer. Deliberately NOT one of the shipped identity types: the
+  /// contract under test is "any error that declares a stable identity keeps it", and
+  /// using a shipped type would let the test pass on a concrete-type check that would
+  /// silently drop every other conformer.
+  private struct IdentifiedError: Error, StableSentryErrorIdentity {
+    var sentryFingerprintDescriptor: String { "Fixture.descriptor" }
+    var sentrySemanticID: String { "fixture.semantic_id" }
+  }
+
+  private struct PlainError: Error {}
+
+  @Test("an error that declares a stable identity reports its semantic ID")
+  func identifiedErrorReportsSemanticID() {
+    #expect(
+      ParakeetEngineAdapter.streamingErrorCategory(IdentifiedError()) == "fixture.semantic_id")
+  }
+
+  /// The two-way control. Without it, a mapping that returned a constant would pass the
+  /// test above, and the suite would prove the field is populated rather than correct.
+  @Test("an error without a declared identity still falls back to its type name")
+  func plainErrorFallsBackToTypeName() {
+    let category = ParakeetEngineAdapter.streamingErrorCategory(PlainError())
+    #expect(category.contains("PlainError"))
+    #expect(category != "fixture.semantic_id")
+  }
+
+  /// The regression this issue exists for, pinned as a value rather than described. A
+  /// bridged `NSError` declares no identity, so it takes the fallback — and the fallback
+  /// is exactly what production has been sending.
+  @Test("a bare NSError still reports NSError, which is the shipped behaviour being replaced")
+  func bareNSErrorReportsTheOldShape() {
+    let category = ParakeetEngineAdapter.streamingErrorCategory(NSError(domain: "d", code: 1))
+    #expect(category.contains("NSError"))
+  }
+
+  /// And the case that closes the loop: the real shipped streaming identity, reaching the
+  /// category through the same path, produces a name that says what actually failed.
+  @Test("the shipped streaming identity produces a cause-naming category")
+  func shippedStreamingIdentityReportsItsCause() {
+    let error = ParakeetStreamingSentryError.allWindowsFailed(inner: .processingFailed)
+    #expect(
+      ParakeetEngineAdapter.streamingErrorCategory(error)
+        == "parakeet_streaming.all_windows_failed.processing_failed")
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/ParakeetStreamingStartTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ParakeetStreamingStartTelemetryTests.swift
@@ -19,8 +19,19 @@ import Testing
 /// The defect was not the value, it was the forward-looking CLAIM — a report emitted at
 /// time T asserting an outcome decided at T+1. These tests drive the real adapter through
 /// the real path and read the real emitted event, rather than asserting a string constant.
+/// `.serialized` because all three tests install and then `defer`-clear the SHARED
+/// `TelemetryService.shared.testEventHook`. `@MainActor` is not sufficient: it serialises
+/// execution, not the whole test — Swift Testing may interleave these at their `await`
+/// points, at which one test's `defer` can clear another's hook mid-run and the victim
+/// then waits for an event nobody records. That failure is intermittent and reads as a
+/// flaky product, which is the worst shape for a test to fail in.
+///
+/// House convention checked rather than assumed: of the 33 suites touching
+/// `testEventHook`, 19 carry `.serialized`. I copied the pattern from
+/// `OllamaReadinessGateTests`, which is one of the 14 that do not — a real precedent, and
+/// the wrong one to have generalised from.
 @MainActor
-@Suite("Streaming start telemetry claims nothing about what follows (#1654)")
+@Suite("Streaming start telemetry claims nothing about what follows (#1654)", .serialized)
 struct ParakeetStreamingStartTelemetryTests {
 
   #if DEBUG

--- a/Tests/EnviousWisprTests/Pipeline/ParakeetStreamingStartTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ParakeetStreamingStartTelemetryTests.swift
@@ -1,0 +1,118 @@
+@preconcurrency import AVFoundation
+import EnviousWisprASR
+import EnviousWisprCore
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+/// #1654 (cloud review, second P2) — the streaming-start telemetry must report only what
+/// is known when it fires.
+///
+/// The first version of that emission recorded `result: "fell_back_to_batch"`, justified
+/// by "a start failure always ends the same way, in the batch path". That justification
+/// was false and this suite is the executable form of why: `cancel()` calls
+/// `discardSession()` and runs no batch decode, so a user who cancels after a failed start
+/// leaves behind a permanent record of a fallback that never happened.
+///
+/// The defect was not the value, it was the forward-looking CLAIM — a report emitted at
+/// time T asserting an outcome decided at T+1. These tests drive the real adapter through
+/// the real path and read the real emitted event, rather than asserting a string constant.
+@MainActor
+@Suite("Streaming start telemetry claims nothing about what follows (#1654)")
+struct ParakeetStreamingStartTelemetryTests {
+
+  #if DEBUG
+    /// The reviewer's exact scenario: start fails, then the user cancels. No batch decode
+    /// ever runs, so nothing emitted may say one did.
+    @Test("a failed start followed by cancel records no batch-fallback claim")
+    func failedStartThenCancelClaimsNoFallback() async throws {
+      let waiter = TelemetryEventWaiter()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        MainActor.assumeIsolated { waiter.record(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      let stub = StubParakeetASRManager()
+      stub.startStreamingThrows = true
+      let adapter = ParakeetEngineAdapter(asrManager: stub)
+
+      try await adapter.beginSession(SessionID(), options: .default, streaming: true)
+      let event = try await waiter.waitForEvent(
+        matching: { $0.stringProps["operation"] == "start" },
+        describedAs: "asr_streaming start observation")
+
+      // Cancel: discardSession() runs, no batch decode happens.
+      await adapter.cancel()
+
+      #expect(event.name == "limb.failure_observed")
+      #expect(event.stringProps["limb"] == "asr_streaming")
+      #expect(event.stringProps["operation"] == "start")
+      // Reports the observation, not a consequence.
+      #expect(event.stringProps["result"] == "failed")
+
+      // The load-bearing negative: nothing anywhere in the recorded history may assert a
+      // fallback, because none occurred. Asserted over ALL events rather than the one we
+      // fetched, so a second emission elsewhere cannot smuggle the claim back in.
+      for recorded in waiter.events {
+        for value in recorded.stringProps.values {
+          #expect(
+            !value.contains("fell_back"),
+            "no event may claim a batch fallback after a cancel: \(recorded.name)")
+        }
+      }
+    }
+
+    /// Two-way control. Without it, an adapter that emitted NOTHING would satisfy the
+    /// negative assertion above perfectly — the suite would prove absence of a wrong claim
+    /// rather than presence of a right one.
+    @Test("the start-failure observation is actually emitted, with the classified cause")
+    func startFailureIsObserved() async throws {
+      let waiter = TelemetryEventWaiter()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        MainActor.assumeIsolated { waiter.record(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      let stub = StubParakeetASRManager()
+      stub.startStreamingThrows = true
+      let adapter = ParakeetEngineAdapter(asrManager: stub)
+
+      try await adapter.beginSession(SessionID(), options: .default, streaming: true)
+
+      let event = try await waiter.waitForEvent(
+        matching: { $0.stringProps["limb"] == "asr_streaming" },
+        describedAs: "asr_streaming observation")
+      #expect(event.stringProps["operation"] == "start")
+      // The category must name the cause rather than be empty or a placeholder — this is
+      // the field that was reaching production as the literal string "NSError".
+      let category = try #require(event.stringProps["error_category"])
+      #expect(!category.isEmpty)
+      #expect(category != "unknown")
+    }
+
+    /// The other half of the leg: a start that SUCCEEDS must emit no failure observation
+    /// at all. Guards against a guard that fires on every call, which would make the
+    /// metric useless while passing both tests above.
+    @Test("a successful start emits no streaming failure observation")
+    func successfulStartEmitsNothing() async throws {
+      let waiter = TelemetryEventWaiter()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        MainActor.assumeIsolated { waiter.record(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      let stub = StubParakeetASRManager()
+      stub.startStreamingThrows = false
+      let adapter = ParakeetEngineAdapter(asrManager: stub)
+
+      try await adapter.beginSession(SessionID(), options: .default, streaming: true)
+
+      let streamingFailures = waiter.events.filter {
+        $0.stringProps["limb"] == "asr_streaming"
+      }
+      #expect(streamingFailures.isEmpty, "a healthy start must record no failure")
+    }
+  #endif
+}


### PR DESCRIPTION
Closes #1654. Part of #1525.

## What was wrong

When Live transcription failed, we could not tell one cause from another. The typed error did not survive the trip to the transcription helper, so every distinct cause arrived as one wrapper type.

That is measured, not argued. The **one** streaming failure production has ever recorded — 2026-07-30, v2.4.1, one person — carries `error_category` as the literal string **`NSError`**.

## What ships

The whole chain: classify the vendor error in the bridge, wrap it in an app-owned identity, preserve it across XPC, reconstruct it on the client, and report the semantic ID instead of a reflected type name.

**And the half nobody could see: the streaming START leg emitted nothing in production** — a breadcrumb and a debug-only log, both invisible. Only finalize failures were ever counted, so "streaming rarely fails" was never a measurement. Both legs report now.

## Three findings the signed-off plan did not anticipate

Each is documented at its call site rather than only here.

**1. The inner cause has to ride the `errorCode`.** `XPCErrorSanitizer` rebuilds every crossing error with `userInfo` reduced to exactly one key — a stated invariant of that type. Domain, code and description are the only channels that survive, and the inner cause is the entire diagnostic point of `allWindowsFailed`. So it is block-allocated into the code space (100+ for `allWindowsFailed`, 200+ for start), with the blocks **bounded**: an unbounded `> base` test would silently absorb every code allocated above it, including the second block. A test proves an unallocated code reconstructs to nil rather than being read as its neighbour.

**2. A start failure would have landed in a Sentry group named for transcription.** §3 said to reuse `classifyFluidAudioASRError` unchanged, and its kinds feed an identity whose every semantic ID reads `parakeet_transcribe.*`. The classifier IS still reused, so no second vendor switch exists; the identity stays in the streaming namespace as `startFailed`.

**3. A bare vendor error is named on the start leg only.** On finalize the vendor wraps everything it throws, so a bare one arriving there is not something we have grounds to name — calling it `startFailed` because that is the mapping in hand would be a reason whose name contradicts its producer.

## Descriptors are app-owned strings, and that is a departure from the batch conformer

The batch path pinned vendor-ordinal-shaped descriptors defensively. Here a 90-day Sentry search returns **zero** streaming groups against a working positive control, and the mechanism agrees rather than merely failing to contradict: the one recorded failure was `rescued`, and a rescued failure produces no terminal and therefore no Sentry event. With no shipped grouping to preserve, inventing a descriptor shape we have never sent would fabricate a history. Clean names instead, frozen from here.

## Tests: 34 across four suites, and the split is forced rather than chosen

A file importing both `EnviousWisprASR` and FluidAudio makes `ASRError` genuinely ambiguous — the compiler says so, and it is the exact collision the bridge target exists to contain. So vendor→kind lives where FluidAudio is importable, kind→identity where it is not, and the one file that needs both names only the unambiguous type. The suite comment states which single case that leaves covered as two composed halves, and why they compose soundly.

**Two mutation controls**, because a test that cannot fail is not a test:
- Replace the inner classification with `nil` → the unwrap test fails; restored → passes.
- Remove the identity branch from the category mapping → two of four category tests fail and the two fallback tests still pass, which is the correct split rather than a blanket red.

Two `ParakeetBackend` lines match the engine-mutation freeze scanner only because the word `finalize` appears in them. Both are classified `structurallySafe` with the reason, and that case's doc now names error classification alongside the pure readiness read it already described.

## What is NOT here, dropped rather than deferred

Founder decision, 2026-08-12, on the plan's own escalation question:

- **The terminal-owned outcome.** A failed rescue can still be recovered by the kernel's Phase 2 retry, so `result: failed` can overstate. Real, and it has never happened — the single recorded event was `rescued`, which Phase 2 cannot change.
- **The Live UAT fault seam.** Forcing the failure where it originates means extending the shared debug XPC protocol, which is what escalated this to REFACTOR tier.

**No Live UAT was run, and the PR says so plainly rather than substituting a weaker check for it.** The forcing mechanism does not exist: no shipped fault command can produce a `SlidingWindowAsrError`, and the one the plan proposed would have injected on the client side of the boundary — skipping the crossing that is the entire subject. What is verified is the archive round-trip, which is the closest a unit test gets to that crossing.

Rebased onto `1c9a63b4`, so this carries the `bf9fe27f` vendor pin. Switch exhaustiveness re-verified against it: both `SlidingWindowAsrError` (7 cases) and `ASRError` (9 cases) are unchanged from the previous pin. A no-op — recorded as a check that ran, because #2041 is what a skipped one costs.

Full suite green, count read from the script's own total line.
