### PR TITLE
build(package): expose EnviousWisprPipeline so the harness can grade shipped behaviour

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,17 @@ let package = Package(
     // TailBenchmarkHarness facade. Purely additive — no production code imports
     // change. (#1276 PR-2)
     .library(name: "EnviousWisprASR", targets: ["EnviousWisprASR"]),
+    // Exposed for the deterministic-layer polish harness at
+    // scripts/eval/deterministic_runner, which grades SHIPPED behaviour by
+    // running the real TextProcessingSteps around polish instead of sending raw
+    // corpus text straight to a connector. Every eval harness before this one
+    // measured polish naked, so deterministic wins (numbers, fillers, emoji
+    // restore) counted as product failures — deterministic-features.md
+    // FACT: benchmark-bypasses-this-whole-layer. Importing the steps THEMSELVES
+    // is the point: re-implementing them in the harness would grade a copy
+    // (validation-discipline.md RULE: measure-with-the-real-tool-never-a-simulation).
+    // Purely additive — no production code imports change.
+    .library(name: "EnviousWisprPipeline", targets: ["EnviousWisprPipeline"]),
   ],
   dependencies: [
     .package(url: "https://github.com/argmaxinc/argmax-oss-swift", from: "1.0.0"),


### PR DESCRIPTION
## What

Adds `EnviousWisprPipeline` to the package's `products` list. One entry, no other change.

## Why

Every polish benchmark we own measures **naked polish**: the runners send raw corpus text straight to a connector, so none of the six real `TextProcessingStep`s execute. The shipped app converts numbers, strips fillers, formats spoken emoji, and restores emoji the model dropped — all deterministically, around polish. The benchmark switches all of that off and then counts those wins as product failures.

Measured on the current 1,690-case run: **77 of 358 failures (22%)** sit on a step the benchmark disabled — 48 emoji, 24 numbers, 9 fillers. In the 90-case Wispr Flow head-to-head the asymmetry is worse than that number suggests, because their side ran through their real shipping app while ours ran with four of six steps off.

`deterministic-features.md` FACT: `benchmark-bypasses-this-whole-layer` has warned about this in its opening line; `polish-eval.md` FACT: `type-b-two-benchmark-scoring` already defines a DETERMINISTIC-ON mode that has never been runnable. This makes it runnable.

## Why expose rather than re-implement

The harness will import and run the steps themselves. Copying them into the harness was the alternative and is rejected deliberately: a verifier that re-implements its subject proves only that the copy works (`validation-discipline.md` RULE: `measure-with-the-real-tool-never-a-simulation`). These steps also carry behaviour a copy would silently drop:

- `InverseTextNormalizationStep` — a 0.5s wall-clock deadline, the `spokenPunctuationEnabled` gate (ships **off**), and the `backendSupportsLID` language gate.
- `EmojiRestoreStep` — the alignment-token length cap from #1948.

The consumer is `RecoveryTextProcessor`, which is already `public` and already runs the exact six-step chain a live dictation runs. Nothing new is being made public; only the module is made visible across the package boundary.

## Precedent

This is the fourth eval-harness exposure in the same `products` list, each marked "purely additive":

| Product | Exposed for |
|---|---|
| `EnviousWisprCore`, `EnviousWisprLLM` | multilingual polish harness |
| `EnviousWisprPostProcessing` | alias-suggestion harness (#637) |
| `EnviousWisprASR` | tail-finalization harness (#1276 PR-2) |
| `EnviousWisprPipeline` | **this PR** — deterministic-layer harness |

## Blast radius

None to the shipped app. No target, dependency edge, source file, or build setting changes. `EnviousWisprPipeline` already sits at the top of the dependency stack (Core, ASR, Audio, LLM, PostProcessing, Services, Storage), so it gains no new edge and no cycle is possible.

## Verification

- `swift package dump-package` — the manifest parses and lists the new product.
- `scripts/check-dependency-direction.sh` — `OK: dep-direction clean across 15 modules`.
- `scripts/build-dev-app.sh` in this worktree — `** BUILD SUCCEEDED **`, bundle deployed, signatures verified strict, app launched.

## Notes for review

Context is the #1832 benchmark work; this PR closes no issue. The harness that consumes the product (`scripts/eval/deterministic_runner`) is gitignored and not part of this diff.
