### PR TITLE
feat(user): read custom words out of four more dictation apps

### DIFF
--- a/Sources/EnviousWisprAppKit/App/CustomWordsImportFlowModel.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsImportFlowModel.swift
@@ -70,8 +70,14 @@ final class CustomWordsImportFlowModel {
 
   enum Result: Equatable {
     case completed(added: Int, replaced: Int)
-    /// The source produced no candidates at all.
+    /// The source produced no candidates at all, and had nothing to refuse.
     case nothingFound
+    /// The source held entries and every one was deliberately refused —
+    /// Juno's built-in seed vocabulary, Spokenly's regex rules, TypeWhisper's
+    /// disabled rows. Distinct from `.nothingFound` because telling someone
+    /// with 401 Juno entries that "no words were found" is simply untrue
+    /// (#1773).
+    case nothingCompatible(found: Int)
     /// Candidates were found and reviewed, but every one was skipped. Distinct
     /// from `.nothingFound` because "we found nothing" and "you kept nothing"
     /// are different things to tell someone.
@@ -237,8 +243,9 @@ final class CustomWordsImportFlowModel {
 
   /// True iff closing the sheet right now, by any path, would silently throw
   /// away words the user already typed (#1700). Excludes `.working(.committing)`
-  /// — an active write in flight is not "a draft." Includes `.result(.nothingFound)`
-  /// and `.result(.failed)`, since neither committed anything and the pasted
+  /// — an active write in flight is not "a draft." Includes
+  /// `.result(.nothingFound)`, `.result(.nothingCompatible)` and
+  /// `.result(.failed)`, since none of them committed anything and the pasted
   /// text is still sitting, uncommitted, in `pasteDraft`.
   ///
   /// `.result(.completed)`/`.result(.nothingApproved)` are only genuinely
@@ -256,7 +263,7 @@ final class CustomWordsImportFlowModel {
       return hasNonWhitespacePasteDraft
     case .methodPicker, .paste, .upload, .smartImportAppPicker, .review,
       .working(.loadingCandidates), .working(.comparing),
-      .result(.nothingFound), .result(.failed):
+      .result(.nothingFound), .result(.nothingCompatible), .result(.failed):
       return hasNonWhitespacePasteDraft
     }
   }
@@ -273,8 +280,8 @@ final class CustomWordsImportFlowModel {
 
   /// "Keep editing" from a confirmation dialog (#1700). No `.result` case has
   /// a Back button, so any terminal result `hasDiscardableDraft` judged worth
-  /// protecting — `.nothingFound`/`.failed` always, or `.completed`/
-  /// `.nothingApproved` when they're guarding an abandoned draft from a
+  /// protecting — `.nothingFound`/`.nothingCompatible`/`.failed` always, or
+  /// `.completed`/`.nothingApproved` when they're guarding an abandoned draft from a
   /// different, already-finished method (Codex code-diff review) — actively
   /// returns to Paste with the draft intact. Everywhere else there is nothing
   /// to do: the user is already looking at their editable draft, or the guard
@@ -357,7 +364,14 @@ final class CustomWordsImportFlowModel {
       let batch = try await source.loadCandidates()
       guard isCurrent(generation) else { return }
       guard !batch.candidates.isEmpty else {
-        showResult(.nothingFound)
+        // An empty batch is either a source that had nothing or a source whose
+        // every row we refused. Those are different sentences, and the notice
+        // is the only thing that can tell them apart — a field this model has
+        // always received and, until #1773, always discarded.
+        let excludedCount = batch.notices.reduce(into: 0) { count, notice in
+          if case .incompatibleSourceEntriesExcluded(let excluded) = notice { count += excluded }
+        }
+        showResult(excludedCount > 0 ? .nothingCompatible(found: excludedCount) : .nothingFound)
         return
       }
       candidates = batch.candidates

--- a/Sources/EnviousWisprAppKit/App/CustomWordsImportReviewRow.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsImportReviewRow.swift
@@ -29,6 +29,11 @@ enum CustomWordsImportResultCopy {
       return "\(addedPhrase) Replaced \(replaced). Your words are ready to use."
     case .nothingFound:
       return "No words were found, and nothing was changed."
+    case .nothingCompatible(let found):
+      // Names what was there and why it did not come across, instead of
+      // claiming the source was empty when it plainly was not.
+      let entries = found == 1 ? "entry" : "entries"
+      return "Found \(found) \(entries), but none were compatible. Nothing was changed."
     case .nothingApproved:
       return "You skipped everything, so nothing was changed."
     case .failed(let message):

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
@@ -140,9 +140,10 @@ struct CustomWordsImportSheet: View {
       Spacer()
       switch model.step {
       case .result:
-        // Routed through requestCancel() (#1700): a `.nothingFound`/`.failed`
-        // result still holds an uncommitted draft, so Done confirms first in
-        // that case; `.completed`/`.nothingApproved` proceed silently, same
+        // Routed through requestCancel() (#1700): a `.nothingFound`,
+        // `.nothingCompatible` or `.failed` result still holds an uncommitted
+        // draft, so Done confirms first in those cases;
+        // `.completed`/`.nothingApproved` proceed silently, same
         // as before. The overlaid, zero-opacity button gives Escape the same
         // route: without it, this screen has no `.cancelAction` button at
         // all, so Escape would dismiss the system sheet directly and reach
@@ -203,6 +204,7 @@ struct CustomWordsImportSheet: View {
     case .working(.committing): return "Saving"
     case .result(.completed): return "Import complete"
     case .result(.nothingFound): return "Nothing to import"
+    case .result(.nothingCompatible): return "Nothing compatible"
     case .result(.nothingApproved): return "Nothing added"
     case .result(.failed): return "Import didn't finish"
     }
@@ -596,7 +598,7 @@ private struct ImportSmartAppPickerScreen: View {
       } else if installed.isEmpty {
         InsetNotice(
           text: "No supported dictation apps found on this Mac. "
-            + "EnviousWispr can read Wispr Flow, FluidVoice, and Superwhisper.")
+            + "EnviousWispr can read \(SmartImportSupportedAppsCopy.sentence(for: registry)).")
       } else {
         ForEach(registry.adapters.filter { installed.contains($0.identifier) }, id: \.identifier) {
           adapter in
@@ -706,7 +708,7 @@ private struct ImportResultScreen: View {
   private var icon: String {
     switch result {
     case .completed: return "checkmark.circle.fill"
-    case .nothingFound, .nothingApproved: return "info.circle"
+    case .nothingFound, .nothingCompatible, .nothingApproved: return "info.circle"
     case .failed: return "exclamationmark.triangle"
     }
   }
@@ -714,7 +716,7 @@ private struct ImportResultScreen: View {
   private var tint: Color {
     switch result {
     case .completed: return .stSuccess
-    case .nothingFound, .nothingApproved: return .stAccent
+    case .nothingFound, .nothingCompatible, .nothingApproved: return .stAccent
     case .failed: return .stWarning
     }
   }
@@ -750,3 +752,27 @@ private struct ImportResultScreen: View {
     }
   }
 #endif
+
+/// The picker's "EnviousWispr can read …" list, built from the registry.
+///
+/// The registry owns the NAMES and this owns the SENTENCE. Keeping the
+/// formatter in AppKit rather than pushing user-facing English down into
+/// PostProcessing is deliberate: moving presentation copy a layer down purely
+/// so a PostProcessing test could reach it is the "convenience is not
+/// justification" case, and the AppKit test target can reach it here anyway.
+///
+/// Generated rather than hand-written because a page that wrongly LEAVES AN
+/// APP OUT contains no mention of it to find — the omission is invisible to any
+/// sweep for the new app's name (#1944). A hand-maintained list goes stale on
+/// the next adapter; this one cannot.
+package enum SmartImportSupportedAppsCopy {
+  package static func sentence(for registry: SmartImportRegistry) -> String {
+    let names = registry.displayNames
+    switch names.count {
+    case 0: return "no apps yet"
+    case 1: return names[0]
+    case 2: return "\(names[0]) and \(names[1])"
+    default: return names.dropLast().joined(separator: ", ") + ", and \(names[names.count - 1])"
+    }
+  }
+}

--- a/Sources/EnviousWisprCore/CustomWordsImportContract.swift
+++ b/Sources/EnviousWisprCore/CustomWordsImportContract.swift
@@ -120,6 +120,14 @@ package enum CustomWordsImportNotice: Sendable, Equatable {
   case suggestionBudgetReached(remainingCount: Int)
   /// Upload-only row-level parse warning.
   case fileParseWarning(rowNumber: Int, reason: String)
+  /// Smart Import: the source held entries and EVERY one was deliberately
+  /// refused — Juno's built-in seed vocabulary, Spokenly's regex rules,
+  /// TypeWhisper's disabled rows, Wispr Flow's snippets and soft-deletes.
+  ///
+  /// Without it "the source was empty" and "we refused all of it" render
+  /// identically, and the first is a false statement to a Juno user whose 401
+  /// entries were all built-in (#1773). A COUNT only, never the content.
+  case incompatibleSourceEntriesExcluded(count: Int)
 }
 
 package struct CustomWordsImportBatch: Sendable, Equatable {

--- a/Sources/EnviousWisprPostProcessing/SmartImportSource.swift
+++ b/Sources/EnviousWisprPostProcessing/SmartImportSource.swift
@@ -6,6 +6,18 @@ import SQLite3
 package enum SmartImportError: LocalizedError, Sendable, Equatable {
   case appNotFound(String)
   case unreadable(String)
+  /// Spokenly only: the live preferences domain holds nothing and the only
+  /// store present is the pre-migration App Store container copy. Named apart
+  /// from `.unreadable` because the user has a button that fixes this, and
+  /// "try quitting the app" does not (#1773).
+  case legacyMigrationRequired(String)
+  /// More source rows than the shared candidate ceiling, counted BEFORE the
+  /// adapter's own exclusions.
+  ///
+  /// Distinct from `ImportFileError.tooManyWords`, whose copy says "That file"
+  /// and "split it into smaller files" — both false for a competitor's
+  /// database, and which would call deleted rows and snippets "words".
+  case tooManySourceEntries(appName: String, limit: Int)
 
   package var errorDescription: String? {
     switch self {
@@ -14,6 +26,14 @@ package enum SmartImportError: LocalizedError, Sendable, Equatable {
     case .unreadable(let app):
       return
         "Couldn't read your \(app) words. If \(app) is open, try quitting it and importing again."
+    case .legacyMigrationRequired(let app):
+      return
+        "\(app)'s older App Store data can't be imported directly yet. In \(app), choose "
+        + "Migrate Settings from App Store Version, then try again."
+    case .tooManySourceEntries(let app, let limit):
+      return
+        "\(app) has more than \(limit) dictionary entries, including entries it may hide or "
+        + "disable. EnviousWispr stopped without importing anything."
     }
   }
 }
@@ -36,7 +56,7 @@ package protocol SmartImportAdapter: Sendable {
   var candidatePaths: [URL] { get }
   /// Read the canonical words, alongside any misspelling the source app
   /// itself records as correcting to that word.
-  func loadWords(at url: URL) throws -> [SmartImportWord]
+  func loadWords(at url: URL) throws -> SmartImportReadResult
 }
 
 /// One word an adapter found, with the human-typed misspelling it corrects
@@ -46,9 +66,167 @@ package protocol SmartImportAdapter: Sendable {
 package struct SmartImportWord: Sendable, Equatable {
   package let canonical: String
   package let aliases: [String]
-  package init(canonical: String, aliases: [String] = []) {
+  /// Whether the source app records this word as case-sensitive.
+  ///
+  /// `.unspecified` for every source with no such concept, so nothing is
+  /// claimed on their behalf. Only TypeWhisper supplies it today, from its own
+  /// per-entry "Case sensitive" checkbox.
+  package let caseSensitive: CustomWordsImportField<Bool>
+
+  package init(
+    canonical: String,
+    aliases: [String] = [],
+    caseSensitive: CustomWordsImportField<Bool> = .unspecified
+  ) {
     self.canonical = canonical
     self.aliases = aliases
+    self.caseSensitive = caseSensitive
+  }
+}
+
+/// What an adapter read, and how much of the source it deliberately refused.
+///
+/// Five of the seven adapters exclude source rows on purpose — Superwhisper
+/// (no usable destination), Wispr Flow (soft-deletes, snippets), TypeWhisper
+/// (disabled rows, non-allowlisted entry types), Spokenly (regex rules, empty
+/// replacements) and Juno (vocabulary the user did not author). Only the
+/// adapter can know how many, and without that count an import that refused
+/// every row is indistinguishable from a source that was empty — which is a
+/// false statement to a Juno user whose 401 entries were all built-in.
+package struct SmartImportReadResult: Sendable, Equatable {
+  package let words: [SmartImportWord]
+  /// Source rows deliberately refused, before shared normalization. A COUNT
+  /// only — never the content, which would put a competitor's excluded text
+  /// into our UI.
+  package let excludedCount: Int
+
+  package init(words: [SmartImportWord], excludedCount: Int = 0) {
+    self.words = words
+    self.excludedCount = excludedCount
+  }
+}
+
+/// The one owner of a SQLite read: open, prepare, step, verify completion,
+/// finalize, close.
+///
+/// ACQUISITION — how the database being opened came to be safe to open — is
+/// deliberately NOT here. Wispr Flow validates a 151 MB live database in place
+/// and refuses when its sidecars say another process holds uncommitted content;
+/// TypeWhisper takes a bounded stable copy of its 296 KB store because it never
+/// checkpoints its WAL. Those are two measured answers to one question, and
+/// folding them into a single "policy" would be a false single authority. What
+/// they genuinely share is the read sequence below.
+package enum SmartImportSQLiteReader {
+  /// Step every row through `mapRow`, then hand control back to the caller
+  /// while the connection is still open.
+  ///
+  /// `mapRow` returning nil is an ordinary EXCLUSION and is counted; a THROW is
+  /// a malformed source and refuses the whole read. Those are different things.
+  ///
+  /// `afterRowsRead` runs after `SQLITE_DONE` and BEFORE this scope's finalize
+  /// and close defers, which is exactly where Wispr Flow's post-read sidecar
+  /// recheck sat when that adapter owned the whole sequence. Passing the hook
+  /// through the reader rather than letting the caller run it after `read`
+  /// returns is the entire reason this parameter exists: returning first would
+  /// move the check past cleanup and widen the window it exists to close.
+  static func read(
+    uri: String,
+    sql: String,
+    appName: String,
+    mapRow: (OpaquePointer?) throws -> SmartImportWord?,
+    afterRowsRead: () throws -> Void = {}
+  ) throws -> SmartImportReadResult {
+    var db: OpaquePointer?
+    guard
+      sqlite3_open_v2(uri, &db, SQLITE_OPEN_READONLY | SQLITE_OPEN_URI, nil) == SQLITE_OK,
+      let db
+    else {
+      sqlite3_close(db)
+      throw SmartImportError.unreadable(appName)
+    }
+    defer { sqlite3_close(db) }
+
+    var statement: OpaquePointer?
+    guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+      sqlite3_finalize(statement)
+      throw SmartImportError.unreadable(appName)
+    }
+    defer { sqlite3_finalize(statement) }
+
+    var words: [SmartImportWord] = []
+    var excludedCount = 0
+    var result = sqlite3_step(statement)
+    while result == SQLITE_ROW {
+      if let word = try mapRow(statement) { words.append(word) } else { excludedCount += 1 }
+      result = sqlite3_step(statement)
+    }
+    // Only SQLITE_DONE means "that was all of them" (code review, #1686). The
+    // first version treated every non-ROW result as the end, so SQLITE_BUSY on
+    // a database the other app was writing — or IOERR, or CORRUPT — returned
+    // whatever prefix had been read, possibly nothing, and reported success. A
+    // partial read presented as a complete one is the same false-pass shape as
+    // a test that never runs.
+    guard result == SQLITE_DONE else { throw SmartImportError.unreadable(appName) }
+    try afterRowsRead()
+    return SmartImportReadResult(words: words, excludedCount: excludedCount)
+  }
+
+  /// The canonical "a corrected spelling is the word, the misspelling that
+  /// prompted it is the alias" mapping (#1706), shared because Wispr Flow and
+  /// TypeWhisper encode exactly that under different column names.
+  static func word(
+    canonical: String?,
+    alias: String,
+    caseSensitive: CustomWordsImportField<Bool> = .unspecified
+  ) -> SmartImportWord {
+    // `.whitespacesAndNewlines` also strips tabs and newlines, unlike the
+    // ASCII-space-only SQL `TRIM()` this replaced.
+    let trimmed = canonical?.trimmingCharacters(in: .whitespacesAndNewlines)
+    if let trimmed, !trimmed.isEmpty {
+      return SmartImportWord(canonical: trimmed, aliases: [alias], caseSensitive: caseSensitive)
+    }
+    return SmartImportWord(canonical: alias, caseSensitive: caseSensitive)
+  }
+
+  // MARK: - Strict column reads
+  //
+  // SQLite columns are dynamically typed, so a schema that drifts under us can
+  // hand back an INTEGER where text belongs, or NULL where a value must exist.
+  // Converting those silently turns a malformed source into plausible-looking
+  // words. Malformed STRUCTURE refuses the whole read; valid-but-incompatible
+  // CONTENT is a nil from the mapper and gets counted.
+
+  static func requiredText(
+    _ statement: OpaquePointer?, _ column: Int32, _ appName: String
+  ) throws -> String {
+    guard sqlite3_column_type(statement, column) == SQLITE_TEXT,
+      let value = sqlite3_column_text(statement, column)
+    else { throw SmartImportError.unreadable(appName) }
+    return String(cString: value)
+  }
+
+  static func optionalText(
+    _ statement: OpaquePointer?, _ column: Int32, _ appName: String
+  ) throws -> String? {
+    let type = sqlite3_column_type(statement, column)
+    guard type != SQLITE_NULL else { return nil }
+    guard type == SQLITE_TEXT, let value = sqlite3_column_text(statement, column) else {
+      throw SmartImportError.unreadable(appName)
+    }
+    return String(cString: value)
+  }
+
+  static func requiredBoolean(
+    _ statement: OpaquePointer?, _ column: Int32, _ appName: String
+  ) throws -> Bool {
+    guard sqlite3_column_type(statement, column) == SQLITE_INTEGER else {
+      throw SmartImportError.unreadable(appName)
+    }
+    switch sqlite3_column_int(statement, column) {
+    case 0: return false
+    case 1: return true
+    default: throw SmartImportError.unreadable(appName)
+    }
   }
 }
 
@@ -115,15 +293,17 @@ package struct FluidVoiceAdapter: SmartImportAdapter {
 
   package init() {}
 
-  package func loadWords(at url: URL) throws -> [SmartImportWord] {
+  package func loadWords(at url: URL) throws -> SmartImportReadResult {
     let data = try boundedData(at: url, appName: displayName)
     guard let vocabulary = try? JSONDecoder().decode(Vocabulary.self, from: data) else {
       throw SmartImportError.unreadable(displayName)
     }
     // `terms` absent entirely is a legitimate fresh install, not a failure.
-    return (vocabulary.terms ?? []).map {
-      SmartImportWord(canonical: $0.text, aliases: $0.aliases ?? [])
-    }
+    // FluidVoice excludes nothing: every term it stores is one the user added.
+    return SmartImportReadResult(
+      words: (vocabulary.terms ?? []).map {
+        SmartImportWord(canonical: $0.text, aliases: $0.aliases ?? [])
+      })
   }
 }
 
@@ -160,7 +340,7 @@ package struct SuperwhisperAdapter: SmartImportAdapter {
 
   package init() {}
 
-  package func loadWords(at url: URL) throws -> [SmartImportWord] {
+  package func loadWords(at url: URL) throws -> SmartImportReadResult {
     let data = try boundedData(at: url, appName: displayName)
     guard let settings = try? JSONDecoder().decode(Settings.self, from: data) else {
       throw SmartImportError.unreadable(displayName)
@@ -169,14 +349,24 @@ package struct SuperwhisperAdapter: SmartImportAdapter {
     // the user actually wants, which is the word worth bringing across; its
     // `original` side, when present, is the misspelling that prompted it.
     let plain = (settings.vocabulary ?? []).map { SmartImportWord(canonical: $0) }
-    let corrected = (settings.replacements ?? []).compactMap { replacement -> SmartImportWord? in
+    var corrected: [SmartImportWord] = []
+    var excludedCount = 0
+    for replacement in settings.replacements ?? [] {
+      // A replacement with no destination has no word in it. It was always
+      // dropped here; #1773 only started COUNTING it, so a Superwhisper file
+      // holding nothing but blank replacements stops reporting as "no words
+      // found" and says what it actually did.
       guard let with = replacement.with?.trimmingCharacters(in: .whitespacesAndNewlines),
         !with.isEmpty
-      else { return nil }
+      else {
+        excludedCount += 1
+        continue
+      }
       let alias = replacement.original?.trimmingCharacters(in: .whitespacesAndNewlines)
-      return SmartImportWord(canonical: with, aliases: (alias?.isEmpty == false) ? [alias!] : [])
+      corrected.append(
+        SmartImportWord(canonical: with, aliases: (alias?.isEmpty == false) ? [alias!] : []))
     }
-    return plain + corrected
+    return SmartImportReadResult(words: plain + corrected, excludedCount: excludedCount)
   }
 }
 
@@ -196,7 +386,7 @@ package struct WisprFlowAdapter: SmartImportAdapter {
 
   package init() {}
 
-  package func loadWords(at url: URL) throws -> [SmartImportWord] {
+  package func loadWords(at url: URL) throws -> SmartImportReadResult {
     // isDeleted: a soft-delete flag. Importing unfiltered would resurrect
     // words the user deliberately removed — the single worst thing this
     // adapter could do.
@@ -210,10 +400,16 @@ package struct WisprFlowAdapter: SmartImportAdapter {
     // to mean anything. `id` (VARCHAR(36) PRIMARY KEY) is ordered, not
     // `rowid` — this table's PK does not alias `rowid`, and an unaliased
     // `rowid` is not guaranteed persistent across a `VACUUM`.
+    //
+    // Both filters moved OUT of the WHERE clause in #1773: an adapter cannot
+    // count rows SQL never returns, and without that count an import that
+    // refused everything looks identical to an empty source. The consequence
+    // is deliberate — `LIMIT` now bounds TOTAL rows rather than surviving
+    // ones, so a dictionary above the ceiling is refused rather than silently
+    // importing whichever survivors happened to fit.
     let sql = """
-      SELECT phrase, replacement
+      SELECT phrase, replacement, isDeleted, isSnippet
       FROM Dictionary
-      WHERE isDeleted = 0 AND isSnippet = 0
       ORDER BY id COLLATE BINARY ASC
       LIMIT \(CustomWordsImportLimits.maximumCandidates + 1)
       """
@@ -285,68 +481,409 @@ package struct WisprFlowAdapter: SmartImportAdapter {
     // than report. Immutable cannot create one, so a sidecar found afterwards
     // is always the other app's doing, never ours.
 
-    var db: OpaquePointer?
-    guard
-      sqlite3_open_v2(uri, &db, SQLITE_OPEN_READONLY | SQLITE_OPEN_URI, nil) == SQLITE_OK,
-      let db
-    else {
-      sqlite3_close(db)
-      throw SmartImportError.unreadable(displayName)
-    }
-    defer { sqlite3_close(db) }
+    return try SmartImportSQLiteReader.read(
+      uri: uri, sql: sql, appName: displayName,
+      mapRow: { statement in
+        let phrase = try SmartImportSQLiteReader.requiredText(statement, 0, displayName)
+        let replacement = try SmartImportSQLiteReader.optionalText(statement, 1, displayName)
+        let isDeleted = try SmartImportSQLiteReader.requiredBoolean(statement, 2, displayName)
+        let isSnippet = try SmartImportSQLiteReader.requiredBoolean(statement, 3, displayName)
+        // Both exclusions are this adapter's whole point, and both are now
+        // COUNTED rather than hidden by SQL. Returning nil is an exclusion;
+        // a throw above is a malformed database.
+        guard !isDeleted, !isSnippet else { return nil }
+        return SmartImportSQLiteReader.word(canonical: replacement, alias: phrase)
+      },
+      // Re-check the sidecar state the connection mode was chosen from. If
+      // Wispr Flow began or finished writing while this read was in flight,
+      // the mode no longer matches the database and these words may be a stale
+      // view, so refuse rather than hand back something that looks complete.
+      //
+      // This runs INSIDE the reader — after SQLITE_DONE, before its finalize
+      // and close defers — which is exactly where it sat when this adapter
+      // owned the sequence itself. Hoisting it to after `read` returned would
+      // move it past cleanup and widen the window it exists to close.
+      afterRowsRead: {
+        guard !sidecarsExist() else { throw SmartImportError.unreadable(displayName) }
+      })
+  }
+}
 
-    var statement: OpaquePointer?
-    guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
-      sqlite3_finalize(statement)
-      throw SmartImportError.unreadable(displayName)
-    }
-    defer { sqlite3_finalize(statement) }
+// MARK: - Vox
 
-    let words = try readWords(from: statement)
+/// Single JSON settings file. `dictionary` is a flat list of terms with no
+/// alias concept — structurally FluidVoice minus its alias array.
+package struct VoxAdapter: SmartImportAdapter {
+  package let identifier = "vox"
+  package let displayName = "Vox"
 
-    // Re-check the sidecar state the mode was chosen from. If Wispr Flow began
-    // or finished writing while this read was in flight, the connection mode no
-    // longer matches the database and these words may be a stale view. Refuse
-    // rather than hand back something that looks complete — the error already
-    // tells the user to quit the other app and try again.
-    guard !sidecarsExist() else {
-      throw SmartImportError.unreadable(displayName)
-    }
-    return words
+  private struct Settings: Decodable {
+    let dictionary: [String]?
   }
 
-  private func readWords(from statement: OpaquePointer?) throws -> [SmartImportWord] {
+  package var candidatePaths: [URL] {
+    [
+      FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent("Library/Application Support/com.vox.app/vox-settings.json")
+    ]
+  }
 
-    var words: [SmartImportWord] = []
-    var result = sqlite3_step(statement)
-    while result == SQLITE_ROW {
-      guard let phraseText = sqlite3_column_text(statement, 0) else {
-        result = sqlite3_step(statement)
-        continue
-      }
-      let phrase = String(cString: phraseText)
-      let replacement = sqlite3_column_text(statement, 1).map { String(cString: $0) }
-      // `.whitespacesAndNewlines` also strips tabs/newlines, unlike the
-      // ASCII-space-only `TRIM()` this replaced — matching the trim already
-      // used everywhere else in this file.
-      let trimmedReplacement = replacement?.trimmingCharacters(in: .whitespacesAndNewlines)
-      if let trimmedReplacement, !trimmedReplacement.isEmpty {
-        words.append(SmartImportWord(canonical: trimmedReplacement, aliases: [phrase]))
-      } else {
-        words.append(SmartImportWord(canonical: phrase))
-      }
-      result = sqlite3_step(statement)
-    }
-    // Only SQLITE_DONE means "that was all of them" (code review). The first
-    // version treated every non-ROW result as the end, so SQLITE_BUSY on a
-    // database Wispr Flow was writing — or IOERR, or CORRUPT — returned
-    // whatever prefix had been read so far, possibly nothing at all, and the
-    // import reported success. A partial read presented as a complete one is
-    // the same false-pass shape as a test that never runs.
-    guard result == SQLITE_DONE else {
+  package init() {}
+
+  package func loadWords(at url: URL) throws -> SmartImportReadResult {
+    let data = try boundedData(at: url, appName: displayName)
+    guard let settings = try? JSONDecoder().decode(Settings.self, from: data) else {
       throw SmartImportError.unreadable(displayName)
     }
-    return words
+    // `dictionary` absent entirely is a legitimate fresh install, not a
+    // failure — the treatment FluidVoice's `terms` already gets.
+    //
+    // Every other key in this file is ignored, and `context` deliberately so:
+    // it is a free-text paragraph the user writes about themselves for Vox's
+    // polish step, not vocabulary, and importing it would drop a whole
+    // sentence into the custom-words list.
+    return SmartImportReadResult(
+      words: (settings.dictionary ?? []).map { SmartImportWord(canonical: $0) })
+  }
+}
+
+// MARK: - TypeWhisper
+
+/// Core Data store, read through a private, stability-checked copy.
+///
+/// Wispr Flow's policy — refuse when a sidecar exists, else open `immutable=1`
+/// — does NOT transfer here, and the difference is measured rather than
+/// assumed. TypeWhisper never checkpoints its WAL: quit the app and
+/// `dictionary.store-wal` remains, 193 KB on the machine this was written
+/// against, holding rows the main file does not have. So refusing on a sidecar
+/// would refuse forever after its first run, and `immutable=1` — which skips
+/// WAL processing — returned 36 rows against a true 38, silently, opened in
+/// place with both sidecars present. Wispr Flow leaves no sidecars once quit,
+/// which is why its own policy is still right for it.
+///
+/// Copying is cheap here and was not there: 296 KB against 151 MB. That number
+/// is the whole reason the same reasoning reaches the opposite answer, so it is
+/// stated rather than the conclusion alone.
+///
+/// The copy is also what makes this read-only in the sense a user would
+/// recognise. Opening the SOURCE read-only returns the right rows too, but it
+/// MODIFIES their `-shm` (verified by hash), and writing inside another app's
+/// data directory is what #1686 removed.
+package struct TypeWhisperAdapter: SmartImportAdapter {
+  package let identifier = "typewhisper"
+  package let displayName = "TypeWhisper"
+
+  /// Bounded read of one store part, injected so a test can mutate the WAL
+  /// between the two verification passes. Returns nil when the part is absent.
+  package typealias PartReader = @Sendable (URL) throws -> Data?
+
+  /// `-shm` is deliberately absent: it is a regenerable shared-memory index,
+  /// not durable vocabulary. Measured — copying main+`-wal` alone still
+  /// returns every row, with SQLite rebuilding the index beside the copy.
+  private static let storeSuffixes = ["", "-wal"]
+
+  /// Two passes must agree before a snapshot is used, and at most this many
+  /// whole acquisitions are attempted.
+  private static let acquisitionAttempts = 3
+
+  private let readPart: PartReader
+
+  package var candidatePaths: [URL] {
+    [
+      FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent("Library/Application Support/TypeWhisper/dictionary.store")
+    ]
+  }
+
+  package init(readPart: @escaping PartReader = TypeWhisperAdapter.readPartFromDisk) {
+    self.readPart = readPart
+  }
+
+  /// Bounded by the shared vocabulary ceiling, applied to the bytes ACTUALLY
+  /// READ rather than to a pre-read file size — a size checked before the read
+  /// does not bound a file that grows during it.
+  package static func readPartFromDisk(_ url: URL) throws -> Data? {
+    guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+    guard let handle = try? FileHandle(forReadingFrom: url) else {
+      throw SmartImportError.unreadable("TypeWhisper")
+    }
+    defer { try? handle.close() }
+    let ceiling = TypeWhisperAdapter.maximumVocabularyBytes + 1
+    var data = Data()
+    while data.count < ceiling {
+      let chunk: Data?
+      do { chunk = try handle.read(upToCount: ceiling - data.count) } catch {
+        throw SmartImportError.unreadable("TypeWhisper")
+      }
+      guard let chunk, !chunk.isEmpty else { break }
+      data.append(chunk)
+    }
+    return data
+  }
+
+  package func loadWords(at url: URL) throws -> SmartImportReadResult {
+    let snapshot = try acquireStableSnapshot(at: url)
+
+    let fm = FileManager.default
+    let scratch = fm.temporaryDirectory
+      .appendingPathComponent("ew-typewhisper-\(UUID().uuidString)", isDirectory: true)
+    guard (try? fm.createDirectory(at: scratch, withIntermediateDirectories: true)) != nil else {
+      throw SmartImportError.unreadable(displayName)
+    }
+    // Removed on every exit, including a throw from the read below.
+    defer { try? fm.removeItem(at: scratch) }
+
+    let copy = scratch.appendingPathComponent(url.lastPathComponent)
+    for (suffix, bytes) in snapshot {
+      guard (try? bytes.write(to: URL(fileURLWithPath: copy.path + suffix))) != nil else {
+        throw SmartImportError.unreadable(displayName)
+      }
+    }
+
+    // No filtering WHERE clause: the mapper must SEE disabled and
+    // non-allowlisted rows in order to count them.
+    //
+    // ZENTRYTYPE is an ALLOWLIST. Both members are observed on real rows. A
+    // future third type is refused rather than guessed — TypeWhisper already
+    // ships a separate snippets store, and text expansions are the one thing
+    // Wispr Flow's adapter exists to exclude.
+    //
+    // ZSOURCERAWVALUE is deliberately not read: it is provenance, not
+    // structure, so the unobserved "auto-learned" value flows down the correct
+    // path instead of hitting a branch nobody wrote.
+    let sql = """
+      SELECT ZORIGINAL, ZREPLACEMENT, ZCASESENSITIVE, ZISENABLED, ZENTRYTYPE
+      FROM ZDICTIONARYENTRY
+      ORDER BY Z_PK ASC
+      LIMIT \(CustomWordsImportLimits.maximumCandidates + 1)
+      """
+
+    return try SmartImportSQLiteReader.read(
+      uri: "file:\(copy.path)?mode=ro", sql: sql, appName: displayName
+    ) { statement in
+      let original = try SmartImportSQLiteReader.requiredText(statement, 0, displayName)
+      let replacement = try SmartImportSQLiteReader.optionalText(statement, 1, displayName)
+      let caseSensitive = try SmartImportSQLiteReader.requiredBoolean(statement, 2, displayName)
+      let isEnabled = try SmartImportSQLiteReader.requiredBoolean(statement, 3, displayName)
+      let entryType = try SmartImportSQLiteReader.requiredText(statement, 4, displayName)
+      guard isEnabled, entryType == "term" || entryType == "correction" else { return nil }
+      // A `term` row carries the word in ZORIGINAL with ZREPLACEMENT empty; a
+      // `correction` row carries the wrong spelling in ZORIGINAL and the right
+      // one in ZREPLACEMENT. Reading the row STRUCTURALLY covers both without a
+      // per-type branch, which is what WisprFlowAdapter already does under its
+      // own column names.
+      return SmartImportSQLiteReader.word(
+        canonical: replacement, alias: original, caseSensitive: .supplied(caseSensitive))
+    }
+  }
+
+  /// Read every store part twice and accept only a byte-identical pair.
+  ///
+  /// Copying the parts one after another is NOT enough: TypeWhisper can
+  /// checkpoint or replace the WAL between two sequential reads, producing a
+  /// main file and a WAL from different moments — a snapshot that never
+  /// existed. Two agreeing passes prove the accepted bytes coexisted during
+  /// the overlap between them.
+  private func acquireStableSnapshot(at url: URL) throws -> [(String, Data)] {
+    for _ in 0..<Self.acquisitionAttempts {
+      let first = try readAllParts(at: url)
+      let second = try readAllParts(at: url)
+      if first.map(\.0) == second.map(\.0),
+        zip(first, second).allSatisfy({ $0.1 == $1.1 })
+      {
+        return first
+      }
+    }
+    // The other app is actively writing. Refusing is the honest half, and the
+    // `.unreadable` copy already tells the user to quit it and try again.
+    throw SmartImportError.unreadable(displayName)
+  }
+
+  private func readAllParts(at url: URL) throws -> [(String, Data)] {
+    var parts: [(String, Data)] = []
+    var total = 0
+    for suffix in Self.storeSuffixes {
+      guard let bytes = try readPart(URL(fileURLWithPath: url.path + suffix)) else { continue }
+      total += bytes.count
+      guard total <= Self.maximumVocabularyBytes else {
+        throw SmartImportError.unreadable(displayName)
+      }
+      parts.append((suffix, bytes))
+    }
+    guard !parts.isEmpty else { throw SmartImportError.unreadable(displayName) }
+    return parts
+  }
+}
+
+// MARK: - Spokenly
+
+/// Preferences-backed, read from the LIVE domain rather than the plist file.
+///
+/// Spokenly writes nothing to disk until it terminates — creating a
+/// replacement modified no file anywhere in the home directory — so parsing
+/// `~/Library/Preferences/app.spokenly.plist` returns whatever was last
+/// flushed and quietly omits anything added since. Reading the domain goes
+/// where the OS goes and needs no quit.
+///
+/// Verified to work under HARDENED RUNTIME, which matters because the dev
+/// build is not hardened and the release build is, so a runtime test on the
+/// dev build could never have established it: one binary, run unsigned and
+/// then re-signed with `--options runtime`, returned the identical value.
+package struct SpokenlyAdapter: SmartImportAdapter {
+  package let identifier = "spokenly"
+  package let displayName = "Spokenly"
+
+  /// The shipping build's key. Bare `wordReplacements` is the pre-migration
+  /// App Store copy, which lives in the sandboxed container.
+  private static let liveKey = "wordReplacements.v2"
+  private static let domain = "app.spokenly"
+
+  /// Injected so the domain read can be driven from a test. Ordinary
+  /// dependency injection of a byte source — nothing here is time-dependent,
+  /// so this is NOT one of the timing seams.
+  private let readDomain: @Sendable (String) -> Data?
+
+  package init(
+    readDomain: @escaping @Sendable (String) -> Data? = { key in
+      UserDefaults(suiteName: SpokenlyAdapter.domain)?.data(forKey: key)
+    }
+  ) {
+    self.readDomain = readDomain
+  }
+
+  /// Detection probes BOTH stores, current first, so the card appears for
+  /// either install. Which one was found decides what `loadWords` does when
+  /// the live domain is empty.
+  package var candidatePaths: [URL] {
+    let home = FileManager.default.homeDirectoryForCurrentUser
+    return [
+      home.appendingPathComponent("Library/Preferences/app.spokenly.plist"),
+      home.appendingPathComponent(
+        "Library/Containers/app.spokenly/Data/Library/Preferences/app.spokenly.plist"),
+    ]
+  }
+
+  private struct Rule: Decodable {
+    let original: String?
+    let replacement: String?
+    let isRegex: Bool?
+  }
+  private struct Item: Decodable { let value: Rule }
+  private struct Envelope: Decodable { let items: [Item]? }
+  private struct Document: Decodable { let envelope: Envelope? }
+
+  package func loadWords(at url: URL) throws -> SmartImportReadResult {
+    guard let data = readDomain(Self.liveKey) else {
+      // Nothing live. If the only store we found is the sandboxed container,
+      // that is the pre-migration App Store copy — three weeks stale on the
+      // machine this was written against. Reading a store the vendor itself
+      // treats as needing migration is how an importer silently returns words
+      // the user never typed and calls it success. Name the button they have
+      // instead. An absent live value does NOT prove they are on the App Store
+      // build, which is why this keys on which store was detected.
+      let isContainerStore = url.path.contains("/Library/Containers/")
+      throw isContainerStore
+        ? SmartImportError.legacyMigrationRequired(displayName)
+        : SmartImportError.appNotFound(displayName)
+    }
+
+    // Two guarded steps, plist value then JSON — the value is a `data` blob
+    // whose contents are UTF-8 JSON, not a plist array.
+    guard let document = try? JSONDecoder().decode(Document.self, from: data) else {
+      throw SmartImportError.unreadable(displayName)
+    }
+
+    // `tombstones` is never parsed, and that is not a shortcut: deleting a
+    // replacement REMOVES it from `items` and leaves only `{id, deletedAt}`
+    // behind. Verified by creating five and deleting one. So reading `items`
+    // alone cannot resurrect a word the user deleted.
+    var words: [SmartImportWord] = []
+    var excludedCount = 0
+    for item in document.envelope?.items ?? [] {
+      let rule = item.value
+      // A regex rule holds a PATTERN in `original`, not a word — verified by
+      // creating one through Spokenly's own Use Regular Expression checkbox.
+      // An empty replacement is a delete-this-text rule with no word in it.
+      let canonical = rule.replacement?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+      guard rule.isRegex != true, !canonical.isEmpty else {
+        excludedCount += 1
+        continue
+      }
+      let alias = rule.original?.trimmingCharacters(in: .whitespacesAndNewlines)
+      words.append(
+        SmartImportWord(canonical: canonical, aliases: (alias?.isEmpty == false) ? [alias!] : []))
+    }
+    return SmartImportReadResult(words: words, excludedCount: excludedCount)
+  }
+}
+
+// MARK: - Juno
+
+/// Single JSON lexicon mixing Juno's own shipped seed vocabulary with the
+/// user's. Only the latter belongs in someone's custom words.
+package struct JunoAdapter: SmartImportAdapter {
+  package let identifier = "juno"
+  package let displayName = "Juno"
+
+  /// The only provenance value that means "the user typed this".
+  ///
+  /// An ALLOWLIST rather than a denylist on the seed value, because the two
+  /// directions do not fail equally: admitting an unseen machine-generated
+  /// provenance puts words in the list the user never chose, while refusing an
+  /// unseen user-ish one costs them a word they can retype and can see is
+  /// missing. Measured on a real install: 400 of 401 rows are seeds, including
+  /// bare lowercase words like `accessibility` and `dictation` that would
+  /// actively bias transcription if imported.
+  private static let userAuthoredSource = "user_edit"
+
+  private struct Entry: Decodable {
+    let term: String?
+    let canonicalForm: String?
+    let aliases: [String]?
+    let source: String?
+
+    enum CodingKeys: String, CodingKey {
+      case term
+      case canonicalForm = "canonical_form"
+      case aliases
+      case source
+    }
+  }
+
+  package var candidatePaths: [URL] {
+    [
+      FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent("Library/Application Support/com.juno.shell/memory/lexicon.json")
+    ]
+  }
+
+  package init() {}
+
+  package func loadWords(at url: URL) throws -> SmartImportReadResult {
+    let data = try boundedData(at: url, appName: displayName)
+    guard let entries = try? JSONDecoder().decode([Entry].self, from: data) else {
+      throw SmartImportError.unreadable(displayName)
+    }
+    var words: [SmartImportWord] = []
+    var excludedCount = 0
+    for entry in entries {
+      guard entry.source == Self.userAuthoredSource else {
+        excludedCount += 1
+        continue
+      }
+      // `canonical_form` is the spelling Juno settles on; `term` is the key it
+      // is filed under. They match on every observed row, but the canonical
+      // form is the one that means "how this should be written".
+      let canonicalForm = entry.canonicalForm?.trimmingCharacters(in: .whitespacesAndNewlines)
+      let fallback = entry.term?.trimmingCharacters(in: .whitespacesAndNewlines)
+      let canonical = (canonicalForm?.isEmpty == false ? canonicalForm : fallback) ?? ""
+      guard !canonical.isEmpty else {
+        excludedCount += 1
+        continue
+      }
+      words.append(SmartImportWord(canonical: canonical, aliases: entry.aliases ?? []))
+    }
+    return SmartImportReadResult(words: words, excludedCount: excludedCount)
   }
 }
 
@@ -355,12 +892,23 @@ package struct WisprFlowAdapter: SmartImportAdapter {
 package struct SmartImportRegistry: Sendable {
   package let adapters: [any SmartImportAdapter]
 
-  /// TypeWhisper is deliberately absent: its schema is confirmed but its table
-  /// is empty on the only machine available, so an adapter would be written
-  /// against a shape nobody has seen populated, and its WAL sidecar files add
-  /// a correctness question that cannot be tested without real content.
+  /// Handy is deliberately absent: its `custom_words` element schema is a bare
+  /// `string[]` grounded from its own public source, but the app is not
+  /// installed on any machine available here, so an adapter could not be
+  /// exercised end to end against real data — the same rule that kept
+  /// TypeWhisper out until #1773 read its populated store (#1773).
   package static let v1 = SmartImportRegistry(
-    adapters: [WisprFlowAdapter(), FluidVoiceAdapter(), SuperwhisperAdapter()])
+    adapters: [
+      WisprFlowAdapter(), FluidVoiceAdapter(), SuperwhisperAdapter(),
+      VoxAdapter(), TypeWhisperAdapter(), SpokenlyAdapter(), JunoAdapter(),
+    ])
+
+  /// The display names, in registry order, for whoever writes the picker copy.
+  ///
+  /// The registry owns the NAMES; AppKit owns the SENTENCE. Keeping the
+  /// formatter out of here stops user-facing English being pushed down a layer
+  /// for test convenience, and the AppKit test target can reach it where it is.
+  package var displayNames: [String] { adapters.map(\.displayName) }
 
   package init(adapters: [any SmartImportAdapter]) {
     self.adapters = adapters
@@ -392,10 +940,12 @@ package struct SmartImportSource: CustomWordsImportSource {
     }
     try Task.checkCancellation()
 
-    let words = try adapter.loadWords(at: path)
+    let readResult = try adapter.loadWords(at: path)
+    let words = readResult.words
     try Task.checkCancellation()
 
-    // Check the RAW row count, before deduplication (code review r10).
+    // Check the SCANNED row count, before deduplication (code review r10) and
+    // before the adapter's own exclusions are subtracted.
     //
     // The adapters read one past the ceiling so that "too many" is knowable.
     // But dedup shrinks the list, so a source whose first 25,001 rows contain
@@ -403,13 +953,18 @@ package struct SmartImportSource: CustomWordsImportSource {
     // import that had silently dropped everything beyond it. Every ceiling
     // needs a signal for having been reached; counting after the shrink loses
     // that signal — the same mistake the pasted-text parser made.
-    guard words.count <= CustomWordsImportLimits.maximumCandidates else {
-      // `found` is a real count here, not a stop-sentinel: the adapters read
-      // exactly one past the ceiling, so this is what was actually seen. The
-      // message says "more than" either way, so it never states a figure it
-      // cannot stand behind.
-      throw ImportFileError.tooManyWords(
-        found: words.count, limit: CustomWordsImportLimits.maximumCandidates)
+    //
+    // Counting SCANNED rather than SURVIVING rows is new in #1773 and closes
+    // the same loophole one layer out: an adapter that filtered 25,001 rows
+    // down to one would otherwise look like a one-row source.
+    let scannedCount = words.count + readResult.excludedCount
+    guard scannedCount <= CustomWordsImportLimits.maximumCandidates else {
+      // Deliberately NOT `ImportFileError.tooManyWords`, whose copy says "That
+      // file" and "split it into smaller files" — a competitor's database is
+      // neither a file the user chose nor splittable, and its deleted rows and
+      // snippets are not "words".
+      throw SmartImportError.tooManySourceEntries(
+        appName: adapter.displayName, limit: CustomWordsImportLimits.maximumCandidates)
     }
 
     // Trim aliases up front so both the ceiling below and candidate
@@ -443,17 +998,32 @@ package struct SmartImportSource: CustomWordsImportSource {
     // downstream — the existing, already-tested owner of "should these merge"
     // (§3c) — rather than re-deciding it locally with a different key.
     var canonicals: [CustomWordsImportCandidate] = []
+    // Blank canonicals dropped HERE are exclusions too. Leaving them out of
+    // the count would let a source that produced only blanks still report
+    // "no words were found", which is the untruth this count exists to stop.
+    var excludedCount = readResult.excludedCount
     for (word, aliases) in zip(words, trimmedAliasesByIndex) {
       let trimmed = word.canonical.trimmingCharacters(in: .whitespacesAndNewlines)
-      guard !CustomWordsImportCompareEngine.normalize(trimmed).isEmpty else { continue }
+      guard !CustomWordsImportCompareEngine.normalize(trimmed).isEmpty else {
+        excludedCount += 1
+        continue
+      }
       canonicals.append(
         CustomWordsImportCandidate(
           canonical: trimmed,
-          aliases: aliases.isEmpty ? .unspecified : .supplied(aliases)))
+          aliases: aliases.isEmpty ? .unspecified : .supplied(aliases),
+          caseSensitive: word.caseSensitive))
     }
+
+    // One notice, only when the source had rows and none of them survived.
+    // Counts only, never content.
+    let notices: [CustomWordsImportNotice] =
+      canonicals.isEmpty && excludedCount > 0
+      ? [.incompatibleSourceEntriesExcluded(count: excludedCount)]
+      : []
 
     return CustomWordsImportBatch(
       sourceID: adapter.identifier, sourceDisplayName: adapter.displayName,
-      candidates: canonicals)
+      candidates: canonicals, notices: notices)
   }
 }

--- a/Tests/EnviousWisprTests/App/CustomWordsImportFlowModelTests.swift
+++ b/Tests/EnviousWisprTests/App/CustomWordsImportFlowModelTests.swift
@@ -105,6 +105,28 @@ struct CustomWordsImportFlowModelTests {
     #expect(model.step == .result(.nothingFound))
   }
 
+  @Test("an all-excluded import is a discardable draft, like nothing-found")
+  func nothingCompatibleIsDiscardable() {
+    // `.nothingCompatible` is a terminal that changed nothing, so a pasted
+    // draft behind it is still worth confirming before discard — the same
+    // reasoning as `.nothingFound` and `.failed` (#1700).
+    let model = Self.makeModel()
+    model.select(.paste)
+    model.pasteDraft = "some words"
+    model.showResult(.nothingCompatible(found: 401))
+    #expect(model.hasDiscardableDraft)
+  }
+
+  @Test("nothing-compatible is a distinct terminal from nothing-found")
+  func nothingCompatibleIsItsOwnTerminal() {
+    let model = Self.makeModel()
+    model.select(.smartImport)
+    model.beginWork(.loadingCandidates)
+    model.showResult(.nothingCompatible(found: 12))
+    #expect(model.step == .result(.nothingCompatible(found: 12)))
+    #expect(model.step != .result(.nothingFound))
+  }
+
   @Test("reset clears the selected method and returns to the picker")
   func resetClearsSelectedMethodAndReturnsToPicker() {
     let model = Self.makeModel()

--- a/Tests/EnviousWisprTests/App/CustomWordsImportReviewFlowTests.swift
+++ b/Tests/EnviousWisprTests/App/CustomWordsImportReviewFlowTests.swift
@@ -487,6 +487,23 @@ struct CustomWordsImportReviewFlowTests {
     #expect(later.contains("Replaced 2"))
   }
 
+  @Test("an all-excluded source is told apart from an empty one, with its count")
+  func nothingCompatibleCopyNamesWhatWasRefused() {
+    // "No words were found" is a false statement to a Juno user whose 401
+    // entries were all built-in seeds, so the two outcomes read differently.
+    let empty = CustomWordsImportResultCopy.message(for: .nothingFound)
+    #expect(empty == "No words were found, and nothing was changed.")
+
+    let refused = CustomWordsImportResultCopy.message(for: .nothingCompatible(found: 401))
+    #expect(refused == "Found 401 entries, but none were compatible. Nothing was changed.")
+    #expect(refused != empty)
+
+    // Singular, because "Found 1 entries" reads as a bug to the person seeing it.
+    #expect(
+      CustomWordsImportResultCopy.message(for: .nothingCompatible(found: 1))
+        == "Found 1 entry, but none were compatible. Nothing was changed.")
+  }
+
   @Test("finding no candidates and approving none are different outcomes")
   func nothingFoundAndNothingApprovedAreDistinct() async {
     let compare = CompareSpy()

--- a/Tests/EnviousWisprTests/App/SmartImportSupportedAppsCopyTests.swift
+++ b/Tests/EnviousWisprTests/App/SmartImportSupportedAppsCopyTests.swift
@@ -1,0 +1,46 @@
+import EnviousWisprPostProcessing
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// The picker's "EnviousWispr can read …" sentence (#1773).
+///
+/// It lives in AppKit and is tested here rather than being pushed down into
+/// PostProcessing so a PostProcessing test could reach it — moving user-facing
+/// English a layer down for test convenience is exactly what "convenience is
+/// not justification" forbids, and this target already links AppKit.
+@Suite("SmartImportSupportedAppsCopy")
+struct SmartImportSupportedAppsCopyTests {
+
+  @Test("the picker sentence names every adapter the registry ships")
+  func namesEveryRegisteredAdapter() {
+    // A page that wrongly LEAVES AN APP OUT contains no mention of it to find,
+    // so a sweep for the new name can never catch the omission (#1944). This
+    // is the freeze test that makes the copy follow the registry instead of
+    // being remembered.
+    let sentence = SmartImportSupportedAppsCopy.sentence(for: .v1)
+    for name in SmartImportRegistry.v1.displayNames {
+      #expect(sentence.contains(name), "picker copy omits \(name)")
+    }
+  }
+
+  @Test("the picker sentence reads naturally at one, two and many apps")
+  func grammarAcrossCounts() {
+    func sentence(_ adapters: [any SmartImportAdapter]) -> String {
+      SmartImportSupportedAppsCopy.sentence(for: SmartImportRegistry(adapters: adapters))
+    }
+    #expect(sentence([VoxAdapter()]) == "Vox")
+    #expect(sentence([VoxAdapter(), JunoAdapter()]) == "Vox and Juno")
+    #expect(
+      sentence([VoxAdapter(), JunoAdapter(), SpokenlyAdapter()]) == "Vox, Juno, and Spokenly")
+  }
+
+  @Test("an empty registry still produces a readable sentence")
+  func emptyRegistry() {
+    // Unreachable in production — `v1` is never empty — but the formatter must
+    // not produce "EnviousWispr can read ." if a future refactor empties it.
+    #expect(
+      SmartImportSupportedAppsCopy.sentence(for: SmartImportRegistry(adapters: []))
+        == "no apps yet")
+  }
+}

--- a/Tests/EnviousWisprTests/PostProcessing/SmartImportSourceTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SmartImportSourceTests.swift
@@ -43,7 +43,7 @@ struct SmartImportSourceTests {
       """, to: dir, as: "v.json")
 
     #expect(
-      try FluidVoiceAdapter().loadWords(at: url)
+      try FluidVoiceAdapter().loadWords(at: url).words
         == [
           SmartImportWord(canonical: "FluidVoice", aliases: ["fluid voice"]),
           SmartImportWord(canonical: "Kubernetes", aliases: []),
@@ -56,7 +56,7 @@ struct SmartImportSourceTests {
     let dir = makeDirectory()
     defer { try? FileManager.default.removeItem(at: dir) }
     let url = try write(#"{ "alpha": 2.8 }"#, to: dir, as: "v.json")
-    #expect(try FluidVoiceAdapter().loadWords(at: url).isEmpty)
+    #expect(try FluidVoiceAdapter().loadWords(at: url).words.isEmpty)
   }
 
   @Test("FluidVoice aliases present as a non-array refuses the whole import")
@@ -104,7 +104,7 @@ struct SmartImportSourceTests {
       let displayName = "FluidVoice"
       let url: URL
       var candidatePaths: [URL] { [url] }
-      func loadWords(at url: URL) throws -> [SmartImportWord] {
+      func loadWords(at url: URL) throws -> SmartImportReadResult {
         try FluidVoiceAdapter().loadWords(at: url)
       }
     }
@@ -126,7 +126,7 @@ struct SmartImportSourceTests {
       as: "settings.json"
     )
 
-    #expect(try SuperwhisperAdapter().loadWords(at: url) == [SmartImportWord(canonical: "Saurabh")])
+    #expect(try SuperwhisperAdapter().loadWords(at: url).words == [SmartImportWord(canonical: "Saurabh")])
   }
 
   @Test("a Superwhisper replacement carries its original as the alias")
@@ -139,7 +139,7 @@ struct SmartImportSourceTests {
       """, to: dir, as: "settings.json")
 
     #expect(
-      try SuperwhisperAdapter().loadWords(at: url)
+      try SuperwhisperAdapter().loadWords(at: url).words
         == [SmartImportWord(canonical: "Superwhisper", aliases: ["super whisper"])])
   }
 
@@ -152,7 +152,7 @@ struct SmartImportSourceTests {
       as: "settings.json")
 
     #expect(
-      try SuperwhisperAdapter().loadWords(at: url) == [SmartImportWord(canonical: "Superwhisper")])
+      try SuperwhisperAdapter().loadWords(at: url).words == [SmartImportWord(canonical: "Superwhisper")])
   }
 
   @Test("a Superwhisper replacement missing with is dropped, as today")
@@ -163,7 +163,7 @@ struct SmartImportSourceTests {
       #"{ "replacements": [ { "id": "A", "original": "super whisper" } ] }"#, to: dir,
       as: "settings.json")
 
-    #expect(try SuperwhisperAdapter().loadWords(at: url).isEmpty)
+    #expect(try SuperwhisperAdapter().loadWords(at: url).words.isEmpty)
   }
 
   @Test(
@@ -180,7 +180,7 @@ struct SmartImportSourceTests {
                            { "id": "B", "original": "y", "with": "   " } ] }
       """, to: dir, as: "settings.json")
 
-    #expect(try SuperwhisperAdapter().loadWords(at: url).isEmpty)
+    #expect(try SuperwhisperAdapter().loadWords(at: url).words.isEmpty)
   }
 
   @Test("Superwhisper original present as a non-string value refuses the whole import")
@@ -201,7 +201,7 @@ struct SmartImportSourceTests {
     let dir = makeDirectory()
     defer { try? FileManager.default.removeItem(at: dir) }
     let url = try write(#"{ "modeKeys": [] }"#, to: dir, as: "settings.json")
-    #expect(try SuperwhisperAdapter().loadWords(at: url).isEmpty)
+    #expect(try SuperwhisperAdapter().loadWords(at: url).words.isEmpty)
   }
 
   @Test("Superwhisper probes the current location before the legacy one")
@@ -261,7 +261,7 @@ struct SmartImportSourceTests {
     defer { try? FileManager.default.removeItem(at: dir) }
     let url = try makeWisprFlowDatabase(in: dir)
 
-    let words = try WisprFlowAdapter().loadWords(at: url)
+    let words = try WisprFlowAdapter().loadWords(at: url).words
     #expect(!words.map(\.canonical).contains("deleted word"))
   }
 
@@ -272,7 +272,7 @@ struct SmartImportSourceTests {
     let url = try makeWisprFlowDatabase(in: dir)
 
     // Snippets are a different feature, not vocabulary.
-    let words = try WisprFlowAdapter().loadWords(at: url).map(\.canonical)
+    let words = try WisprFlowAdapter().loadWords(at: url).words.map(\.canonical)
     #expect(!words.contains("my long signature"))
     #expect(!words.contains("sig"))
   }
@@ -283,7 +283,7 @@ struct SmartImportSourceTests {
     defer { try? FileManager.default.removeItem(at: dir) }
     let url = try makeWisprFlowDatabase(in: dir)
 
-    let words = try WisprFlowAdapter().loadWords(at: url)
+    let words = try WisprFlowAdapter().loadWords(at: url).words
     // `btw → by the way`: the corrected side is the word worth having, and
     // the misspelling that prompted it comes across as the alias.
     #expect(words.contains(SmartImportWord(canonical: "by the way", aliases: ["btw"])))
@@ -298,7 +298,7 @@ struct SmartImportSourceTests {
     let url = try makeWisprFlowDatabase(in: dir)
 
     // An empty-but-present replacement would otherwise import a blank word.
-    let words = try WisprFlowAdapter().loadWords(at: url)
+    let words = try WisprFlowAdapter().loadWords(at: url).words
     #expect(words.contains(SmartImportWord(canonical: "blank replacement")))
   }
 
@@ -322,7 +322,7 @@ struct SmartImportSourceTests {
       """
     #expect(sqlite3_exec(db, schema, nil, nil, nil) == SQLITE_OK)
 
-    let words = try WisprFlowAdapter().loadWords(at: url)
+    let words = try WisprFlowAdapter().loadWords(at: url).words
     #expect(words == [SmartImportWord(canonical: "tab word")])
   }
 
@@ -344,7 +344,7 @@ struct SmartImportSourceTests {
       """
     #expect(sqlite3_exec(db, schema, nil, nil, nil) == SQLITE_OK)
 
-    let words = try WisprFlowAdapter().loadWords(at: url)
+    let words = try WisprFlowAdapter().loadWords(at: url).words
     #expect(words == [SmartImportWord(canonical: "Superwhisper", aliases: ["Superwhisper"])])
   }
 
@@ -368,7 +368,7 @@ struct SmartImportSourceTests {
       """
     #expect(sqlite3_exec(db, schema, nil, nil, nil) == SQLITE_OK)
 
-    let canonicals = try WisprFlowAdapter().loadWords(at: url).map(\.canonical)
+    let canonicals = try WisprFlowAdapter().loadWords(at: url).words.map(\.canonical)
     let alphaIndex = try #require(canonicals.firstIndex(of: "alpha word"))
     let zebraIndex = try #require(canonicals.firstIndex(of: "zebra word"))
     #expect(alphaIndex < zebraIndex)
@@ -393,7 +393,7 @@ struct SmartImportSourceTests {
       """
     #expect(sqlite3_exec(db, schema, nil, nil, nil) == SQLITE_OK)
 
-    let words = try WisprFlowAdapter().loadWords(at: url)
+    let words = try WisprFlowAdapter().loadWords(at: url).words
     #expect(words == [SmartImportWord(canonical: "")])
   }
 
@@ -422,7 +422,7 @@ struct SmartImportSourceTests {
       let displayName = "Wispr Flow"
       let url: URL
       var candidatePaths: [URL] { [url] }
-      func loadWords(at url: URL) throws -> [SmartImportWord] {
+      func loadWords(at url: URL) throws -> SmartImportReadResult {
         try WisprFlowAdapter().loadWords(at: url)
       }
     }
@@ -508,7 +508,7 @@ struct SmartImportSourceTests {
       let identifier = "missing"
       let displayName = "Nothing"
       var candidatePaths: [URL] { [URL(fileURLWithPath: "/nonexistent/nope.json")] }
-      func loadWords(at url: URL) throws -> [SmartImportWord] { [] }
+      func loadWords(at url: URL) throws -> SmartImportReadResult { SmartImportReadResult(words: []) }
     }
     await #expect(throws: SmartImportError.appNotFound("Nothing")) {
       _ = try await SmartImportSource(adapter: Missing()).loadCandidates()
@@ -527,7 +527,7 @@ struct SmartImportSourceTests {
       let displayName = "FluidVoice"
       let url: URL
       var candidatePaths: [URL] { [url] }
-      func loadWords(at url: URL) throws -> [SmartImportWord] {
+      func loadWords(at url: URL) throws -> SmartImportReadResult {
         try FluidVoiceAdapter().loadWords(at: url)
       }
     }
@@ -554,7 +554,7 @@ struct SmartImportSourceTests {
       let displayName = "FluidVoice"
       let url: URL
       var candidatePaths: [URL] { [url] }
-      func loadWords(at url: URL) throws -> [SmartImportWord] {
+      func loadWords(at url: URL) throws -> SmartImportReadResult {
         try FluidVoiceAdapter().loadWords(at: url)
       }
     }
@@ -584,7 +584,7 @@ struct SmartImportSourceTests {
       let displayName = "FluidVoice"
       let url: URL
       var candidatePaths: [URL] { [url] }
-      func loadWords(at url: URL) throws -> [SmartImportWord] {
+      func loadWords(at url: URL) throws -> SmartImportReadResult {
         try FluidVoiceAdapter().loadWords(at: url)
       }
     }
@@ -612,7 +612,7 @@ struct SmartImportSourceTests {
       let displayName = "Superwhisper"
       let url: URL
       var candidatePaths: [URL] { [url] }
-      func loadWords(at url: URL) throws -> [SmartImportWord] {
+      func loadWords(at url: URL) throws -> SmartImportReadResult {
         try SuperwhisperAdapter().loadWords(at: url)
       }
     }
@@ -641,7 +641,7 @@ struct SmartImportSourceTests {
       let displayName = "FluidVoice"
       let url: URL
       var candidatePaths: [URL] { [url] }
-      func loadWords(at url: URL) throws -> [SmartImportWord] {
+      func loadWords(at url: URL) throws -> SmartImportReadResult {
         try FluidVoiceAdapter().loadWords(at: url)
       }
     }
@@ -667,7 +667,7 @@ struct SmartImportSourceTests {
       let displayName = "FluidVoice"
       let url: URL
       var candidatePaths: [URL] { [url] }
-      func loadWords(at url: URL) throws -> [SmartImportWord] {
+      func loadWords(at url: URL) throws -> SmartImportReadResult {
         try FluidVoiceAdapter().loadWords(at: url)
       }
     }
@@ -681,14 +681,579 @@ struct SmartImportSourceTests {
     #expect(actualScalars == [Array(nfc.unicodeScalars), Array(nfd.unicodeScalars)])
   }
 
-  @Test("the registry ships the three verified apps and not the unverified one")
+  @Test("the registry ships every verified app and not the unverifiable one")
   func registryShipsOnlyVerifiedAdapters() {
     let ids = SmartImportRegistry.v1.adapters.map(\.identifier)
-    #expect(ids.sorted() == ["fluidvoice", "superwhisper", "wispr-flow"])
-    // TypeWhisper is absent deliberately: its table is empty on the only
-    // machine available, so an adapter would be written against a shape nobody
-    // has seen populated.
-    #expect(!ids.contains("typewhisper"))
+    #expect(
+      ids.sorted() == [
+        "fluidvoice", "juno", "spokenly", "superwhisper", "typewhisper", "vox", "wispr-flow",
+      ])
+    // Handy is absent deliberately: its element schema is grounded from its
+    // own public source, but the app is not installed on any machine here, so
+    // an adapter could not be exercised end to end against real data (#1773).
+    #expect(!ids.contains("handy"))
+    // Identifiers reach telemetry as `sourceID`, so a collision would silently
+    // merge two competitors' import counts.
+    #expect(Set(ids).count == ids.count)
+  }
+
+  // MARK: - Shared SQLite reader
+
+  private func makeReaderDatabase(in dir: URL) throws -> URL {
+    let url = dir.appendingPathComponent("reader.sqlite")
+    var db: OpaquePointer?
+    #expect(sqlite3_open(url.path, &db) == SQLITE_OK)
+    defer { sqlite3_close(db) }
+    #expect(
+      sqlite3_exec(
+        db,
+        """
+        CREATE TABLE T (a VARCHAR, b VARCHAR);
+        INSERT INTO T VALUES ('one', NULL);
+        INSERT INTO T VALUES ('two', 'Two');
+        """, nil, nil, nil) == SQLITE_OK)
+    return url
+  }
+
+  @Test("a row mapper returning nil is an exclusion; a mapper that throws is a failure")
+  func readerDistinguishesExclusionFromFailure() throws {
+    // These are different things and an earlier draft conflated them: nil
+    // means "this row is not vocabulary", a throw means "this database is not
+    // what we think it is".
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try makeReaderDatabase(in: dir)
+
+    let excluded = try SmartImportSQLiteReader.read(
+      uri: "file:\(url.path)?mode=ro", sql: "SELECT a, b FROM T ORDER BY a", appName: "Probe"
+    ) { statement in
+      let a = try SmartImportSQLiteReader.requiredText(statement, 0, "Probe")
+      return a == "one" ? nil : SmartImportWord(canonical: a)
+    }
+    #expect(excluded.words.map(\.canonical) == ["two"])
+    #expect(excluded.excludedCount == 1)
+
+    struct Boom: Error {}
+    #expect(throws: Boom.self) {
+      _ = try SmartImportSQLiteReader.read(
+        uri: "file:\(url.path)?mode=ro", sql: "SELECT a, b FROM T", appName: "Probe"
+      ) { _ in throw Boom() }
+    }
+  }
+
+  @Test("afterRowsRead runs while the connection is still open, and its throw refuses the read")
+  func readerRunsValidationBeforeCleanup() throws {
+    // Wispr Flow's post-read sidecar recheck sits exactly here. Running it
+    // after the reader returned would move it past finalize and close and
+    // widen the window it exists to close.
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try makeReaderDatabase(in: dir)
+
+    struct Refused: Error {}
+    var sawRows = false
+    #expect(throws: Refused.self) {
+      _ = try SmartImportSQLiteReader.read(
+        uri: "file:\(url.path)?mode=ro", sql: "SELECT a, b FROM T", appName: "Probe",
+        mapRow: { statement in
+          sawRows = true
+          return SmartImportWord(
+            canonical: try SmartImportSQLiteReader.requiredText(statement, 0, "Probe"))
+        },
+        afterRowsRead: { throw Refused() })
+    }
+    // Ordering: every row was stepped BEFORE validation ran, and no partial
+    // result escaped.
+    #expect(sawRows)
+  }
+
+  @Test("a result other than SQLITE_DONE refuses rather than returning a prefix")
+  func readerRefusesAPartialRead() throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = dir.appendingPathComponent("corrupt.sqlite")
+    try Data("SQLite format 3\u{0}garbage-not-a-real-database".utf8).write(to: url)
+    #expect(throws: SmartImportError.unreadable("Probe")) {
+      _ = try SmartImportSQLiteReader.read(
+        uri: "file:\(url.path)?mode=ro", sql: "SELECT a FROM T", appName: "Probe"
+      ) { _ in nil }
+    }
+  }
+
+  @Test("strict column reads refuse a NULL or wrongly-typed required value")
+  func readerStrictColumnTypes() throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = dir.appendingPathComponent("types.sqlite")
+    var db: OpaquePointer?
+    #expect(sqlite3_open(url.path, &db) == SQLITE_OK)
+    #expect(
+      sqlite3_exec(
+        db,
+        """
+        CREATE TABLE T (required VARCHAR, flag INTEGER);
+        INSERT INTO T VALUES (NULL, 1);
+        """, nil, nil, nil) == SQLITE_OK)
+    sqlite3_close(db)
+
+    #expect(throws: SmartImportError.unreadable("Probe")) {
+      _ = try SmartImportSQLiteReader.read(
+        uri: "file:\(url.path)?mode=ro", sql: "SELECT required, flag FROM T", appName: "Probe"
+      ) { statement in
+        SmartImportWord(
+          canonical: try SmartImportSQLiteReader.requiredText(statement, 0, "Probe"))
+      }
+    }
+  }
+
+  // MARK: - TypeWhisper
+
+  /// Builds a store with TypeWhisper's real Core Data column shape.
+  ///
+  /// Returns the url AND the open writer connection. The caller must keep that
+  /// connection alive across the read and close it in a `defer`: closing it
+  /// first CHECKPOINTS the WAL into the main file (measured — `-wal` drops to
+  /// zero bytes), which destroys the very state the WAL tests exist to
+  /// reproduce and quietly makes them pass against the design they exist to
+  /// reject.
+  private func makeTypeWhisperStore(
+    in dir: URL, walOnlyRow: Bool
+  ) throws -> (url: URL, writer: OpaquePointer?) {
+    let url = dir.appendingPathComponent("dictionary.store")
+    var db: OpaquePointer?
+    #expect(sqlite3_open(url.path, &db) == SQLITE_OK)
+    sqlite3_exec(db, "PRAGMA journal_mode=WAL;", nil, nil, nil)
+    sqlite3_exec(db, "PRAGMA wal_autocheckpoint=0;", nil, nil, nil)
+    let schema = """
+      CREATE TABLE ZDICTIONARYENTRY (Z_PK INTEGER PRIMARY KEY, ZISENABLED INTEGER,
+        ZCASESENSITIVE INTEGER, ZENTRYTYPE VARCHAR, ZORIGINAL VARCHAR, ZREPLACEMENT VARCHAR);
+      INSERT INTO ZDICTIONARYENTRY VALUES (1,1,1,'term','Nuxt',NULL);
+      INSERT INTO ZDICTIONARYENTRY VALUES (2,1,0,'correction','envius wisper','EnviousWispr');
+      INSERT INTO ZDICTIONARYENTRY VALUES (3,0,0,'term','DisabledWord',NULL);
+      INSERT INTO ZDICTIONARYENTRY VALUES (4,1,0,'snippet','sig','my long signature');
+      """
+    #expect(sqlite3_exec(db, schema, nil, nil, nil) == SQLITE_OK)
+    if walOnlyRow {
+      // Force everything so far into the main file, then write one more row
+      // that must stay in the WAL alone.
+      sqlite3_exec(db, "PRAGMA wal_checkpoint(TRUNCATE);", nil, nil, nil)
+      sqlite3_exec(
+        db, "INSERT INTO ZDICTIONARYENTRY VALUES (5,1,0,'term','WalOnlyWord',NULL);",
+        nil, nil, nil)
+    }
+    return (url, db)
+  }
+
+  @Test("TypeWhisper terms and corrections both map through one structural rule")
+  func typeWhisperMapsBothEntryTypes() throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let store = try makeTypeWhisperStore(in: dir, walOnlyRow: false)
+    defer { sqlite3_close(store.writer) }
+
+    let result = try TypeWhisperAdapter().loadWords(at: store.url)
+    // A `term` carries the word with no replacement; a `correction` carries
+    // the wrong spelling and the right one.
+    #expect(
+      result.words == [
+        SmartImportWord(canonical: "Nuxt", caseSensitive: .supplied(true)),
+        SmartImportWord(
+          canonical: "EnviousWispr", aliases: ["envius wisper"], caseSensitive: .supplied(false)),
+      ])
+    // The disabled row and the non-allowlisted `snippet` type.
+    #expect(result.excludedCount == 2)
+  }
+
+  @Test("TypeWhisper never imports a row the user disabled, or a type we have not verified")
+  func typeWhisperExcludesDisabledAndUnknownTypes() throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let store = try makeTypeWhisperStore(in: dir, walOnlyRow: false)
+    defer { sqlite3_close(store.writer) }
+
+    let canonicals = try TypeWhisperAdapter().loadWords(at: store.url).words.map(\.canonical)
+    #expect(!canonicals.contains("DisabledWord"))
+    // `snippet` is not in the allowlist. Text expansions are the one thing
+    // Wispr Flow's adapter exists to exclude, and TypeWhisper ships a separate
+    // snippets store, so admitting an unverified type is the wrong direction.
+    #expect(!canonicals.contains("my long signature"))
+    #expect(!canonicals.contains("sig"))
+  }
+
+  @Test("rows that live only in an un-checkpointed WAL still come across")
+  func typeWhisperReadsRowsHeldOnlyInTheWAL() throws {
+    // The regression test for the defect that redesigned this adapter.
+    // TypeWhisper never checkpoints: quit the app and the WAL still holds rows
+    // the main file does not have. Reading the main file `immutable=1` — which
+    // skips WAL processing — returned 36 rows against a true 38 on the real
+    // store, silently.
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let store = try makeTypeWhisperStore(in: dir, walOnlyRow: true)
+    defer { sqlite3_close(store.writer) }
+
+    // Precondition, so a pass means something: the main file alone genuinely
+    // cannot see the WAL-only row. Without this the test would still pass
+    // against the design it exists to reject.
+    let mainOnly = dir.appendingPathComponent("main-only.store")
+    try FileManager.default.copyItem(at: store.url, to: mainOnly)
+    var probe: OpaquePointer?
+    #expect(
+      sqlite3_open_v2(
+        "file:\(mainOnly.path)?immutable=1", &probe,
+        SQLITE_OPEN_READONLY | SQLITE_OPEN_URI, nil) == SQLITE_OK)
+    var statement: OpaquePointer?
+    #expect(
+      sqlite3_prepare_v2(
+        probe, "SELECT COUNT(*) FROM ZDICTIONARYENTRY WHERE ZORIGINAL = 'WalOnlyWord'", -1,
+        &statement, nil) == SQLITE_OK)
+    #expect(sqlite3_step(statement) == SQLITE_ROW)
+    #expect(sqlite3_column_int(statement, 0) == 0)
+    sqlite3_finalize(statement)
+    sqlite3_close(probe)
+
+    let canonicals = try TypeWhisperAdapter().loadWords(at: store.url).words.map(\.canonical)
+    #expect(canonicals.contains("WalOnlyWord"))
+  }
+
+  @Test("reading TypeWhisper leaves every byte of its store untouched")
+  func typeWhisperLeavesTheSourceUnchanged() throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let store = try makeTypeWhisperStore(in: dir, walOnlyRow: true)
+    defer { sqlite3_close(store.writer) }
+
+    func fingerprint() -> [String: Data] {
+      var out: [String: Data] = [:]
+      for suffix in ["", "-wal", "-shm"] {
+        let path = store.url.path + suffix
+        if let data = FileManager.default.contents(atPath: path) { out[suffix] = data }
+      }
+      return out
+    }
+    let before = fingerprint()
+    _ = try TypeWhisperAdapter().loadWords(at: store.url)
+    // Opening the SOURCE read-only also returns the right rows, but it
+    // MODIFIES their `-shm`. Writing inside another app's data directory is
+    // what #1686 removed, so the copy is the point rather than an optimisation.
+    #expect(fingerprint() == before)
+  }
+
+  @Test("a snapshot whose parts change between the two passes is refused, not read")
+  func typeWhisperRefusesAnUnstableSnapshot() throws {
+    // Copying main and WAL one after another can capture two different
+    // generations if the other app checkpoints in between — a snapshot that
+    // never existed. The reader takes two passes and accepts only a matching
+    // pair; this drives the injected byte reader so the branch is reachable
+    // deterministically rather than by racing a real app.
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let store = try makeTypeWhisperStore(in: dir, walOnlyRow: true)
+    defer { sqlite3_close(store.writer) }
+
+    nonisolated(unsafe) var pass = 0
+    let unstable = TypeWhisperAdapter(readPart: { url in
+      guard let data = FileManager.default.contents(atPath: url.path) else { return nil }
+      guard url.lastPathComponent.hasSuffix("-wal") else { return data }
+      // A different WAL on every read: no two passes can ever agree.
+      pass += 1
+      return data + Data("\(pass)".utf8)
+    })
+    #expect(throws: SmartImportError.unreadable("TypeWhisper")) {
+      _ = try unstable.loadWords(at: store.url)
+    }
+
+    // Positive counterpart: a reader that returns stable bytes succeeds, so
+    // the refusal above is the instability and not the injection itself.
+    let stable = TypeWhisperAdapter(readPart: { url in
+      FileManager.default.contents(atPath: url.path)
+    })
+    #expect(try !stable.loadWords(at: store.url).words.isEmpty)
+  }
+
+  @Test("a TypeWhisper store whose columns hold the wrong types is refused, never guessed")
+  func typeWhisperMalformedColumnsRefuse() throws {
+    // SQLite columns are dynamically typed, so a schema that drifts under us
+    // can hand back a BLOB where text belongs. Converting silently turns a
+    // malformed source into plausible-looking words.
+    //
+    // A BLOB rather than an integer on purpose: `VARCHAR` carries TEXT
+    // AFFINITY, so SQLite converts an integer literal to text on insert and
+    // the column reads back as SQLITE_TEXT — an integer fixture here asserts
+    // nothing at all. Affinity does not convert blobs.
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = dir.appendingPathComponent("dictionary.store")
+    var db: OpaquePointer?
+    #expect(sqlite3_open(url.path, &db) == SQLITE_OK)
+    let schema = """
+      CREATE TABLE ZDICTIONARYENTRY (Z_PK INTEGER PRIMARY KEY, ZISENABLED INTEGER,
+        ZCASESENSITIVE INTEGER, ZENTRYTYPE VARCHAR, ZORIGINAL VARCHAR, ZREPLACEMENT VARCHAR);
+      INSERT INTO ZDICTIONARYENTRY VALUES (1,1,1,'term',x'DEADBEEF',NULL);
+      """
+    #expect(sqlite3_exec(db, schema, nil, nil, nil) == SQLITE_OK)
+    sqlite3_close(db)
+
+    #expect(throws: SmartImportError.unreadable("TypeWhisper")) {
+      _ = try TypeWhisperAdapter().loadWords(at: url)
+    }
+  }
+
+  @Test("a TypeWhisper boolean outside 0 and 1 is refused rather than coerced")
+  func typeWhisperNonBooleanFlagRefuses() throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = dir.appendingPathComponent("dictionary.store")
+    var db: OpaquePointer?
+    #expect(sqlite3_open(url.path, &db) == SQLITE_OK)
+    let schema = """
+      CREATE TABLE ZDICTIONARYENTRY (Z_PK INTEGER PRIMARY KEY, ZISENABLED INTEGER,
+        ZCASESENSITIVE INTEGER, ZENTRYTYPE VARCHAR, ZORIGINAL VARCHAR, ZREPLACEMENT VARCHAR);
+      INSERT INTO ZDICTIONARYENTRY VALUES (1,7,0,'term','Weird',NULL);
+      """
+    #expect(sqlite3_exec(db, schema, nil, nil, nil) == SQLITE_OK)
+    sqlite3_close(db)
+
+    #expect(throws: SmartImportError.unreadable("TypeWhisper")) {
+      _ = try TypeWhisperAdapter().loadWords(at: url)
+    }
+  }
+
+  // MARK: - Spokenly
+
+  private func spokenlyEnvelope(_ items: String) -> Data {
+    Data(#"{"dirty":true,"serverVersion":0,"envelope":{"orderUpdatedAt":1,"items":[\#(items)],"tombstones":[{"id":"gone","deletedAt":2}]}}"#.utf8)
+  }
+
+  private func spokenlyItem(
+    _ original: String, _ replacement: String, isRegex: Bool = false
+  ) -> String {
+    #"{"updatedAt":1,"value":{"id":"x","original":"\#(original)","replacement":"\#(replacement)","isRegex":\#(isRegex),"timing":"beforeAI","createdAt":1}}"#
+  }
+
+  @Test("a Spokenly replacement takes the corrected spelling and carries its original as the alias")
+  func spokenlyMapsReplacementDirection() throws {
+    let data = spokenlyEnvelope(spokenlyItem("hanooman", "Hanuman"))
+    let result = try SpokenlyAdapter(readDomain: { _ in data })
+      .loadWords(at: URL(fileURLWithPath: "/unused"))
+    #expect(result.words == [SmartImportWord(canonical: "Hanuman", aliases: ["hanooman"])])
+    #expect(result.excludedCount == 0)
+  }
+
+  @Test("a Spokenly regex rule is never imported as a word")
+  func spokenlyRegexRuleIsExcluded() throws {
+    // `original` holds a PATTERN, not a word — verified by creating one
+    // through Spokenly's own Use Regular Expression checkbox.
+    let data = spokenlyEnvelope(
+      spokenlyItem("hanooman", "Hanuman") + "," + spokenlyItem(#"\\bk\\s*eight\\s*s\\b"#, "k8s", isRegex: true))
+    let result = try SpokenlyAdapter(readDomain: { _ in data })
+      .loadWords(at: URL(fileURLWithPath: "/unused"))
+    #expect(result.words.map(\.canonical) == ["Hanuman"])
+    #expect(result.excludedCount == 1)
+  }
+
+  @Test("a Spokenly rule with an empty replacement has no word in it")
+  func spokenlyEmptyReplacementIsExcluded() throws {
+    let data = spokenlyEnvelope(spokenlyItem("zylo fantric", "") + "," + spokenlyItem("q", "Q"))
+    let result = try SpokenlyAdapter(readDomain: { _ in data })
+      .loadWords(at: URL(fileURLWithPath: "/unused"))
+    #expect(result.words.map(\.canonical) == ["Q"])
+    #expect(result.excludedCount == 1)
+  }
+
+  @Test("a Spokenly entry the user deleted is already absent and cannot come back")
+  func spokenlyTombstonesAreNotItems() throws {
+    // Deleting REMOVES the entry from `items` and leaves only `{id, deletedAt}`
+    // behind — verified by creating five and deleting one. This proves the
+    // tombstone block is not read as a source of words: the fixture's tombstone
+    // carries no text at all, and a hand-crafted item with the same id IS
+    // returned, so the adapter keys on `items` and nothing else.
+    let withoutItem = try SpokenlyAdapter(readDomain: { _ in self.spokenlyEnvelope("") })
+      .loadWords(at: URL(fileURLWithPath: "/unused"))
+    #expect(withoutItem.words.isEmpty)
+
+    let resurrected = #"{"updatedAt":1,"value":{"id":"gone","original":"a","replacement":"Alive","isRegex":false,"timing":"beforeAI","createdAt":1}}"#
+    let withItem = try SpokenlyAdapter(readDomain: { _ in self.spokenlyEnvelope(resurrected) })
+      .loadWords(at: URL(fileURLWithPath: "/unused"))
+    #expect(withItem.words.map(\.canonical) == ["Alive"])
+  }
+
+  @Test("Spokenly bytes that are not valid UTF-8 JSON refuse the whole import")
+  func spokenlyMalformedBytesRefuse() throws {
+    for bytes in [Data([0xFF, 0xFE, 0xFD]), Data("not json".utf8), Data("[1,2,3]".utf8)] {
+      #expect(throws: SmartImportError.unreadable("Spokenly")) {
+        _ = try SpokenlyAdapter(readDomain: { _ in bytes })
+          .loadWords(at: URL(fileURLWithPath: "/unused"))
+      }
+    }
+  }
+
+  @Test("with no live value and only the App Store store, Spokenly says how to migrate")
+  func spokenlyLegacyStoreAsksForMigration() throws {
+    // "No live value" does not prove "App Store build", so this keys on WHICH
+    // store was detected. Reading the pre-migration container copy directly
+    // would import words the user stopped editing weeks ago and call it
+    // success; naming the button they actually have does not.
+    let container = URL(
+      fileURLWithPath:
+        "/Users/x/Library/Containers/app.spokenly/Data/Library/Preferences/app.spokenly.plist")
+    #expect(throws: SmartImportError.legacyMigrationRequired("Spokenly")) {
+      _ = try SpokenlyAdapter(readDomain: { _ in nil }).loadWords(at: container)
+    }
+
+    // Positive counterpart: the CURRENT store with nothing live is an ordinary
+    // not-found, not a migration instruction.
+    let outer = URL(fileURLWithPath: "/Users/x/Library/Preferences/app.spokenly.plist")
+    #expect(throws: SmartImportError.appNotFound("Spokenly")) {
+      _ = try SpokenlyAdapter(readDomain: { _ in nil }).loadWords(at: outer)
+    }
+  }
+
+  @Test("a live value always wins over the legacy store")
+  func spokenlyLiveValueWinsOverLegacy() throws {
+    // Even when the detected path IS the container, a live domain value is
+    // decoded rather than the legacy bytes — so a migrated user can never be
+    // served the stale copy.
+    let container = URL(
+      fileURLWithPath:
+        "/Users/x/Library/Containers/app.spokenly/Data/Library/Preferences/app.spokenly.plist")
+    let data = spokenlyEnvelope(spokenlyItem("q", "Quorvex"))
+    let words = try SpokenlyAdapter(readDomain: { _ in data }).loadWords(at: container).words
+    #expect(words.map(\.canonical) == ["Quorvex"])
+  }
+
+  // MARK: - Vox
+
+  @Test("Vox terms import with no alias")
+  func voxTermsImport() throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try write(
+      #"{ "dictionary": ["Zylophantric", "K8s dashboard"], "context": "I am a founder." }"#,
+      to: dir, as: "vox-settings.json")
+
+    let result = try VoxAdapter().loadWords(at: url)
+    #expect(
+      result.words == [
+        SmartImportWord(canonical: "Zylophantric"), SmartImportWord(canonical: "K8s dashboard"),
+      ])
+    #expect(result.excludedCount == 0)
+  }
+
+  @Test("Vox's personal context paragraph is never imported as a word")
+  func voxContextIsNotVocabulary() throws {
+    // `context` is a paragraph the user writes about themselves for Vox's
+    // polish step. Importing it would drop a whole sentence into the
+    // custom-words list.
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try write(
+      #"{ "dictionary": ["Quorvex"], "context": "I work on billing at Acme." }"#,
+      to: dir, as: "vox-settings.json")
+
+    let words = try VoxAdapter().loadWords(at: url).words
+    #expect(words.map(\.canonical) == ["Quorvex"])
+  }
+
+  @Test("a Vox file with no dictionary key is a fresh install, not a failure")
+  func voxMissingDictionaryKeyIsEmpty() throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try write(#"{ "hotkey": "Cmd+Alt+Period" }"#, to: dir, as: "vox-settings.json")
+    #expect(try VoxAdapter().loadWords(at: url).words.isEmpty)
+  }
+
+  @Test("a Vox dictionary present as a non-array refuses the whole import")
+  func voxNonArrayDictionaryRefuses() throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try write(#"{ "dictionary": "Quorvex" }"#, to: dir, as: "vox-settings.json")
+    #expect(throws: SmartImportError.unreadable("Vox")) {
+      _ = try VoxAdapter().loadWords(at: url)
+    }
+  }
+
+  @Test("a non-string element inside the Vox dictionary refuses the whole import")
+  func voxNonStringElementRefuses() throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try write(#"{ "dictionary": ["Quorvex", 7] }"#, to: dir, as: "vox-settings.json")
+    #expect(throws: SmartImportError.unreadable("Vox")) {
+      _ = try VoxAdapter().loadWords(at: url)
+    }
+  }
+
+  // MARK: - Juno
+
+  private func junoLexicon(_ rows: String, in dir: URL) throws -> URL {
+    try write(rows, to: dir, as: "lexicon.json")
+  }
+
+  @Test("Juno imports only vocabulary the user authored, never its shipped seeds")
+  func junoKeepsOnlyUserAuthoredEntries() throws {
+    // Measured on a real install: 400 of 401 rows are Juno's own seed list,
+    // including bare lowercase words like `accessibility` that would actively
+    // bias transcription if imported as custom words.
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try junoLexicon(
+      """
+      [{"term":"Saurabh","canonical_form":"Saurabh","aliases":[],"source":"user_edit"},
+       {"term":"accessibility","canonical_form":"accessibility","aliases":[],
+        "source":"seed_promotion"},
+       {"term":"Chrome","canonical_form":"Chrome","aliases":[],"source":"seed_promotion"}]
+      """, in: dir)
+
+    let result = try JunoAdapter().loadWords(at: url)
+    #expect(result.words.map(\.canonical) == ["Saurabh"])
+    #expect(result.excludedCount == 2)
+  }
+
+  @Test("an unrecognised Juno provenance is refused, not admitted")
+  func junoUnknownProvenanceIsRefused() throws {
+    // The allowlist's own two-way control. A denylist on the seed value would
+    // ADMIT this row, and an unseen provenance is far more likely to be
+    // another machine-generated list than something the user typed.
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try junoLexicon(
+      """
+      [{"term":"Kept","canonical_form":"Kept","aliases":[],"source":"user_edit"},
+       {"term":"Learned","canonical_form":"Learned","aliases":[],"source":"auto_learned"},
+       {"term":"NoSource","canonical_form":"NoSource","aliases":[]},
+       {"term":"NullSource","canonical_form":"NullSource","aliases":[],"source":null}]
+      """, in: dir)
+
+    let result = try JunoAdapter().loadWords(at: url)
+    #expect(result.words.map(\.canonical) == ["Kept"])
+    #expect(result.excludedCount == 3)
+  }
+
+  @Test("Juno prefers the canonical form over the key it is filed under")
+  func junoPrefersCanonicalForm() throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try junoLexicon(
+      """
+      [{"term":"apple silicon","canonical_form":"Apple Silicon",
+        "aliases":["apple silicon chip"],"source":"user_edit"},
+       {"term":"Fallback","canonical_form":"   ","aliases":[],"source":"user_edit"}]
+      """, in: dir)
+
+    let words = try JunoAdapter().loadWords(at: url).words
+    #expect(words[0] == SmartImportWord(canonical: "Apple Silicon", aliases: ["apple silicon chip"]))
+    // A blank canonical form falls back to the term rather than dropping the row.
+    #expect(words[1].canonical == "Fallback")
+  }
+
+  @Test("a Juno lexicon that is not an array refuses the whole import")
+  func junoNonArrayRefuses() throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try junoLexicon(#"{"term":"Saurabh"}"#, in: dir)
+    #expect(throws: SmartImportError.unreadable("Juno")) {
+      _ = try JunoAdapter().loadWords(at: url)
+    }
   }
 
   @Test("an implausibly large vocabulary file is refused before decoding")
@@ -712,7 +1277,7 @@ struct SmartImportSourceTests {
     defer { try? FileManager.default.removeItem(at: dir) }
     let url = try write(#"{ "terms": [ { "text": "Kubernetes" } ] }"#, to: dir, as: "v.json")
     #expect(
-      try FluidVoiceAdapter().loadWords(at: url) == [SmartImportWord(canonical: "Kubernetes")])
+      try FluidVoiceAdapter().loadWords(at: url).words == [SmartImportWord(canonical: "Kubernetes")])
   }
 
   @Test("a truncated read is refused even though nothing shrinks it anymore")
@@ -726,23 +1291,121 @@ struct SmartImportSourceTests {
       let identifier = "flood"
       let displayName = "Flood"
       var candidatePaths: [URL] { [URL(fileURLWithPath: "/dev/null")] }
-      func loadWords(at url: URL) throws -> [SmartImportWord] {
+      func loadWords(at url: URL) throws -> SmartImportReadResult {
         // One past the ceiling, and all identical — would look like a tiny
         // successful import if this layer merged duplicates, which it no
         // longer does.
-        Array(
-          repeating: SmartImportWord(canonical: "duplicate"),
-          count: CustomWordsImportLimits.maximumCandidates + 1)
+        SmartImportReadResult(
+          words: Array(
+            repeating: SmartImportWord(canonical: "duplicate"),
+            count: CustomWordsImportLimits.maximumCandidates + 1))
       }
     }
 
+    // Deliberately NOT `ImportFileError.tooManyWords` since #1773: its copy
+    // says "That file" and "split it into smaller files", which is false for a
+    // competitor's database, and it would call deleted rows and snippets
+    // "words".
     await #expect(
-      throws: ImportFileError.tooManyWords(
-        found: CustomWordsImportLimits.maximumCandidates + 1,
-        limit: CustomWordsImportLimits.maximumCandidates)
+      throws: SmartImportError.tooManySourceEntries(
+        appName: "Flood", limit: CustomWordsImportLimits.maximumCandidates)
     ) {
       _ = try await SmartImportSource(adapter: Flood()).loadCandidates()
     }
+  }
+
+  @Test("the ceiling counts rows the adapter excluded, not just the survivors")
+  func ceilingCountsScannedRowsNotSurvivors() async throws {
+    // Before #1773 the adapters filtered in SQL, so the ceiling only ever saw
+    // survivors: a source that refused 25,001 rows down to one looked like a
+    // one-row import. Counting what was SCANNED closes that.
+    struct MostlyExcluded: SmartImportAdapter {
+      let identifier = "mostly-excluded"
+      let displayName = "MostlyExcluded"
+      var candidatePaths: [URL] { [URL(fileURLWithPath: "/dev/null")] }
+      func loadWords(at url: URL) throws -> SmartImportReadResult {
+        SmartImportReadResult(
+          words: [SmartImportWord(canonical: "survivor")],
+          excludedCount: CustomWordsImportLimits.maximumCandidates)
+      }
+    }
+    await #expect(
+      throws: SmartImportError.tooManySourceEntries(
+        appName: "MostlyExcluded", limit: CustomWordsImportLimits.maximumCandidates)
+    ) {
+      _ = try await SmartImportSource(adapter: MostlyExcluded()).loadCandidates()
+    }
+  }
+
+  @Test("a source that refused every row says so instead of claiming it was empty")
+  func allExcludedEmitsACountedNotice() async throws {
+    // "No words were found" is a false statement to a Juno user whose 401
+    // entries were all built-in seeds. The notice is what lets the result
+    // screen tell the two apart, and it carries a COUNT only.
+    struct AllExcluded: SmartImportAdapter {
+      let identifier = "all-excluded"
+      let displayName = "AllExcluded"
+      var candidatePaths: [URL] { [URL(fileURLWithPath: "/dev/null")] }
+      func loadWords(at url: URL) throws -> SmartImportReadResult {
+        SmartImportReadResult(words: [], excludedCount: 401)
+      }
+    }
+    let batch = try await SmartImportSource(adapter: AllExcluded()).loadCandidates()
+    #expect(batch.candidates.isEmpty)
+    #expect(batch.notices == [.incompatibleSourceEntriesExcluded(count: 401)])
+  }
+
+  @Test("a genuinely empty source emits no notice, so it still reads as empty")
+  func genuinelyEmptySourceEmitsNoNotice() async throws {
+    // The positive counterpart: without this, any empty result would claim
+    // entries had been refused.
+    struct Empty: SmartImportAdapter {
+      let identifier = "empty"
+      let displayName = "Empty"
+      var candidatePaths: [URL] { [URL(fileURLWithPath: "/dev/null")] }
+      func loadWords(at url: URL) throws -> SmartImportReadResult {
+        SmartImportReadResult(words: [])
+      }
+    }
+    let batch = try await SmartImportSource(adapter: Empty()).loadCandidates()
+    #expect(batch.candidates.isEmpty)
+    #expect(batch.notices.isEmpty)
+  }
+
+  @Test("blank canonicals dropped by shared normalization count as exclusions too")
+  func blankCanonicalsCountTowardTheNotice() async throws {
+    // Otherwise a source whose every row normalizes to blank still reports
+    // "no words found" — the same untruth one layer further down.
+    struct AllBlank: SmartImportAdapter {
+      let identifier = "all-blank"
+      let displayName = "AllBlank"
+      var candidatePaths: [URL] { [URL(fileURLWithPath: "/dev/null")] }
+      func loadWords(at url: URL) throws -> SmartImportReadResult {
+        SmartImportReadResult(words: [SmartImportWord(canonical: "   ")])
+      }
+    }
+    let batch = try await SmartImportSource(adapter: AllBlank()).loadCandidates()
+    #expect(batch.notices == [.incompatibleSourceEntriesExcluded(count: 1)])
+  }
+
+  @Test("TypeWhisper case sensitivity reaches the candidate in both directions")
+  func caseSensitivityTravelsToTheCandidate() async throws {
+    // A one-way test passes for an implementation that returns a constant.
+    struct Fixed: SmartImportAdapter {
+      let identifier = "typewhisper"
+      let displayName = "TypeWhisper"
+      var candidatePaths: [URL] { [URL(fileURLWithPath: "/dev/null")] }
+      func loadWords(at url: URL) throws -> SmartImportReadResult {
+        SmartImportReadResult(
+          words: [
+            SmartImportWord(canonical: "Sensitive", caseSensitive: .supplied(true)),
+            SmartImportWord(canonical: "Insensitive", caseSensitive: .supplied(false)),
+            SmartImportWord(canonical: "Unstated"),
+          ])
+      }
+    }
+    let batch = try await SmartImportSource(adapter: Fixed()).loadCandidates()
+    #expect(batch.candidates.map(\.caseSensitive) == [.supplied(true), .supplied(false), .unspecified])
   }
 
   /// FluidVoice is the real amplification vector this ceiling exists for: its
@@ -760,7 +1423,7 @@ struct SmartImportSourceTests {
     let displayName = "FluidVoice"
     let url: URL
     var candidatePaths: [URL] { [url] }
-    func loadWords(at url: URL) throws -> [SmartImportWord] {
+    func loadWords(at url: URL) throws -> SmartImportReadResult {
       try FluidVoiceAdapter().loadWords(at: url)
     }
   }
@@ -830,7 +1493,7 @@ struct SmartImportSourceTests {
     var identifier: String { base.identifier }
     var displayName: String { base.displayName }
     var candidatePaths: [URL] { [url] }
-    func loadWords(at url: URL) throws -> [SmartImportWord] {
+    func loadWords(at url: URL) throws -> SmartImportReadResult {
       try base.loadWords(at: url)
     }
   }

--- a/website/src/content/help/importing-and-exporting-custom-words.md
+++ b/website/src/content/help/importing-and-exporting-custom-words.md
@@ -16,7 +16,16 @@ Importing adds new terms to your list without changing the words you already hav
 
 **Open the import tool.** Click **Import** on the Your Words page.
 
-**Choose your source.** Select whether you want to paste a list of words, open a saved file, or import from another dictation app. EnviousWispr can read your existing vocabulary straight out of Wispr Flow, FluidVoice, or Superwhisper if you have them installed. If you are importing from a file, that file can be a previous export from EnviousWispr or any plain text document with one word per line.
+**Choose your source.** Select whether you want to paste a list of words, open a saved file, or import from another dictation app. EnviousWispr can read your existing vocabulary straight out of Wispr Flow, FluidVoice, Superwhisper, Vox, TypeWhisper, Spokenly, or Juno if you have them installed. If you are importing from a file, that file can be a previous export from EnviousWispr or any plain text document with one word per line.
+
+**What comes across, app by app.** EnviousWispr brings over the words you added yourself, along with any misspellings that app was already correcting for you. A few apps store more than a word list, and only the word list comes across:
+
+- **Juno** ships with around 400 built-in terms of its own. Only the words you added are imported, so your list stays yours.
+- **Spokenly** can store find-and-replace rules written as patterns rather than plain words. Those are skipped, because a pattern is not a word.
+- **TypeWhisper** entries you have switched off stay off, and its case-sensitivity setting for each word comes across with it. Its match-strictness setting does not.
+- **Wispr Flow** text shortcuts are skipped. Those are text expansions rather than vocabulary.
+
+If an app holds entries but none of them can come across, EnviousWispr tells you how many it found rather than saying it found nothing.
 
 **Review and confirm.** Check the list of terms it found, then add them to your list.
 


### PR DESCRIPTION
Adds **Vox, TypeWhisper, Spokenly and Juno** to Smart Import, so a switcher's vocabulary comes across instead of being retyped one word at a time. Registry goes 3 → 7.

Plan: `docs/feature-requests/issue-1773-2026-08-13-smart-import-four-more-apps.md` (rev 4, one coverage round + three grounded rounds).

## Every store was confirmed on a live install

Words were added through each app's own settings UI and the resulting disk change was read directly. Full grounding record on #1773. Two of the four needed a design the obvious one gets wrong.

### TypeWhisper never checkpoints its WAL

Quit the app and `dictionary.store-wal` remains, 193 KB here, holding rows the main file does not have. So the shipped Wispr Flow policy does **not** transfer:

| approach | rows returned | true count |
|---|---:|---:|
| refuse when a sidecar exists | refuses forever after first run | — |
| `immutable=1` in place, both sidecars present | **36** | 38 |
| plain `mode=ro` in place | 38 | 38 — but it **modifies their `-shm`** |
| **bounded two-pass snapshot → read a private copy** | **38** | 38, source byte-identical |

Wispr Flow *does* checkpoint on exit, so its own policy stays right for it. The difference is measured, not assumed, and both numbers are in the code comments.

The snapshot reads main + WAL twice and accepts only a byte-identical pair — copying them one after another can capture two different generations if the app checkpoints in between. `-shm` is not copied; SQLite rebuilds it beside our temp copy.

### Spokenly writes nothing until it quits

Parsing its plist returns whatever was last flushed. It now reads the live preferences domain, verified under **hardened runtime** with a two-way control (one binary run unsigned, then re-signed `--options runtime`) — the dev build is not hardened and the release build is, so a runtime test on dev could never have established it.

Also corrected here: the key is `wordReplacements.v2` in the outer plist. The path previously recorded on #1773 was the dormant App Store container copy, three weeks stale — an adapter built to it would have imported one word the user never typed and reported success.

### Juno ships ~400 seed terms against the user's 1

The adapter keeps only user-authored provenance. An allowlist rather than a denylist, because the directions do not fail equally: admitting an unseen machine-generated provenance puts words in a hand-curated list that the user never chose.

## Three changes fall out of that filtering

- **Row classification moved from SQL `WHERE` into the mapper**, because an adapter cannot count what SQL never returns. The ceiling therefore counts scanned rather than surviving rows, which refuses a source above 25,000 **total** rows where it previously imported the survivors. Deliberate: a count shown to the user has to be true, and a truncated scan cannot produce one.
- **An import that refused every row said "No words were found"** — false for a Juno user with 401 entries. It now says how many it found and that none were compatible.
- **The ceiling error said "That file… split it into smaller files"**, neither of which describes a competitor's database. It has its own wording now.

Wispr Flow's SQLite sequence moved into a shared reader both database adapters use. Its post-read sidecar recheck runs through an `afterRowsRead` hook so it still executes *before* finalize and close, where it sat before — hoisting it outside would have moved it past cleanup and widened the window it exists to close.

## Live UAT — every number reconciled against the real stores first

Run through the real dev app against the founder's own installs. Expected counts were measured from each store beforehand, not read off the result.

| App | raw rows | expected | review screen showed | excluded, and confirmed absent |
|---|---:|---:|---|---|
| Vox | 4 | 4 | 3 new + 1 already have | the `context` paragraph |
| TypeWhisper (quit) | 38 | 38 | 34 new + 4 already have | — |
| **TypeWhisper (running)** | 38 | 38 | 33 new + 5 already have | — |
| Spokenly | 4 items + 1 tombstone | 3 | 2 new + 1 already have | the regex rule; the deleted entry |
| Juno | 401 | 1 | `Saurabh` only | all 400 seed words |

- **The WAL rows came through.** `Zylophantric` and `EnviousWispr` exist only in TypeWhisper's un-checkpointed WAL; both appear in the review list, and the totals are 38 rather than 36.
- **The running-app control is the inverse of the old expectation.** With TypeWhisper live — WAL and `-shm` both present — the import still returns all 38. The previous design would have refused with "quit the other app".
- **Alias spellings distinguish the adapters.** TypeWhisper and Spokenly both yield canonical `EnviousWispr`, with aliases `envius wisper` and `envious wisper` respectively, so each row is traceable to the adapter that produced it regardless of import order.
- **Commit path proven**: committed Vox's 3 new words, library 32 → 35, all three present.
- **Source untouched**: TypeWhisper's store md5 is identical before and after every read.
- The founder's word list was backed up before UAT and **restored byte-identical afterwards** (md5 `d03414ac…`, back to 32 words).

Not live-verified: the all-excluded result screen. Producing it needs a source with entries but none eligible, which would mean mutating a competitor's data further. Covered by unit tests on the notice, the result case and both copy branches.

## Tests

`scripts/xcode-test.sh` green: **5453** tests, up from a 5415 baseline on the same worktree.

Notable ones, because two nearly shipped vacuous:
- **The WAL regression test has exactly one working fixture shape.** Closing the writer checkpoints the WAL into the main file (measured: `-wal` drops to 0 bytes) and `SQLITE_FCNTL_PERSIST_WAL` plus a held-open second connection still checkpoints — both shapes pass against the design the test exists to reject. The writer connection is held open across the read, and the test asserts the precondition that a main-file-only control cannot see the WAL-only row.
- **The malformed-column test uses a BLOB, not an integer.** `VARCHAR` carries TEXT affinity, so SQLite converts an integer literal on insert and the column reads back as `SQLITE_TEXT` — the first version asserted nothing.
- Reader-level tests for a throwing mapper vs a `nil` (excluded) one, `afterRowsRead` ordering, finalize/close on every throwing exit.
- Two-way controls throughout: Juno's allowlist against unknown/missing/null provenance, case-sensitivity in both directions, snapshot instability against a stable reader, genuinely-empty against all-excluded.

## Not in scope

- **Handy** — schema grounded from its public source, but not installed on this machine, so an adapter could not be exercised against real data. Stays on #1773.
- **Juno's Corrections / Replacements / Snippets tabs** — ungroundable here: Juno's Add button is inert in this build, verified three ways, so no example can be created.
- **Per-reason exclusion telemetry, and the dead notices channel** — filed as #2048. That channel is documented as working and has no producer or renderer at all.

Closes #1773
