### PR TITLE
feat(user): read custom words out of Handy

### DIFF
--- a/Sources/EnviousWisprCore/CustomWordsImportContract.swift
+++ b/Sources/EnviousWisprCore/CustomWordsImportContract.swift
@@ -132,10 +132,11 @@ package enum CustomWordsImportNotice: Sendable, Equatable {
 
 package struct CustomWordsImportBatch: Sendable, Equatable {
   /// Stable adapter identifier (`ImportFileParser.identifier` /
-  /// `SmartImportSourceDescriptor.id` / "paste" / "backup") — the value
-  /// telemetry emits; never a filename or display string.
+  /// `SmartImportSourceDescriptor.id` / "paste" / "backup"); never a filename
+  /// or display string. Carried through validation with the batch, and read by
+  /// no consumer today — there is no source-attributed import telemetry (#2052).
   package let sourceID: String
-  /// What the UI shows ("Wispr Flow", "CSV file", …); never emitted to telemetry.
+  /// What the UI shows ("Wispr Flow", "CSV file", …).
   package let sourceDisplayName: String
   package let candidates: [CustomWordsImportCandidate]
   package let notices: [CustomWordsImportNotice]

--- a/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
+++ b/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
@@ -54,7 +54,8 @@ package enum ImportFileError: LocalizedError, Sendable, Equatable {
 /// That seam is the reason the plan asked for a registry at all, and it stays
 /// even though v1 registers only two formats.
 package protocol ImportFileParser: Sendable {
-  /// Stable identifier, emitted as the batch's `sourceID` for telemetry.
+  /// Stable identifier carried in the import batch for source attribution.
+  /// No consumer reads it today (#2052).
   var identifier: String { get }
   /// What the user sees.
   var displayName: String { get }

--- a/Sources/EnviousWisprPostProcessing/SmartImportSource.swift
+++ b/Sources/EnviousWisprPostProcessing/SmartImportSource.swift
@@ -48,7 +48,8 @@ package enum SmartImportError: LocalizedError, Sendable, Equatable {
 /// inspected in the background. `isInstalled` is only consulted once the user
 /// is looking at the app picker, and `loadWords` only after they choose one.
 package protocol SmartImportAdapter: Sendable {
-  /// Stable identifier emitted as the batch's `sourceID` for telemetry.
+  /// Stable identifier carried in the import batch for source attribution.
+  /// No consumer reads it today (#2052).
   var identifier: String { get }
   /// What the user sees.
   var displayName: String { get }
@@ -86,11 +87,12 @@ package struct SmartImportWord: Sendable, Equatable {
 
 /// What an adapter read, and how much of the source it deliberately refused.
 ///
-/// Five of the seven adapters exclude source rows on purpose — Superwhisper
+/// Five of the eight adapters exclude source rows on purpose — Superwhisper
 /// (no usable destination), Wispr Flow (soft-deletes, snippets), TypeWhisper
 /// (disabled rows, non-allowlisted entry types), Spokenly (regex rules, empty
-/// replacements) and Juno (vocabulary the user did not author). Only the
-/// adapter can know how many, and without that count an import that refused
+/// replacements) and Juno (vocabulary the user did not author). Vox, Handy and
+/// FluidVoice exclude nothing: their stores hold only what the user typed. Only
+/// the adapter can know how many, and without that count an import that refused
 /// every row is indistinguishable from a source that was empty — which is a
 /// false statement to a Juno user whose 401 entries were all built-in.
 package struct SmartImportReadResult: Sendable, Equatable {
@@ -104,6 +106,45 @@ package struct SmartImportReadResult: Sendable, Equatable {
     self.words = words
     self.excludedCount = excludedCount
   }
+}
+
+/// Up to `attempts` acquisitions; each reads twice and accepts only bytes that
+/// agreed, and then only if `accept` succeeds on them.
+///
+/// Two adapters need exactly this and for the same reason: a competitor app can
+/// rewrite its store while we read it, so bytes that merely parsed are not
+/// bytes that coexisted. TypeWhisper can checkpoint its WAL between two
+/// sequential part reads; Handy truncates its JSON file in place, and a read
+/// spanning the rewrite can splice two generations into a document that parses
+/// perfectly and describes a word list that never existed.
+///
+/// `accept` running INSIDE the loop is load-bearing rather than tidiness. Two
+/// identical ZERO-BYTE reads agree perfectly, and Handy's truncation window
+/// produces exactly that — measured, 2 zero-byte reads in 604,959 across three
+/// writes. Accepting outside the loop would spend the whole budget on the first
+/// attempt and then fail (#2052).
+///
+/// Note for a future third caller: a throw from `accept` is swallowed and
+/// becomes `.unreadable`. Correct for both callers today — Handy's is a decode,
+/// TypeWhisper's is the identity function and cannot throw — but an `accept`
+/// that can throw something meaningful, a ceiling error say, would lose it here.
+/// Errors from `read` are NOT swallowed; they propagate immediately.
+private func acquireStableSnapshot<Snapshot, Accepted>(
+  appName: String,
+  attempts: Int,
+  read: () throws -> Snapshot,
+  agrees: (Snapshot, Snapshot) -> Bool,
+  accept: (Snapshot) throws -> Accepted
+) throws -> Accepted {
+  for _ in 0..<attempts {
+    let first = try read()
+    let second = try read()
+    guard agrees(first, second) else { continue }
+    if let accepted = try? accept(first) { return accepted }
+  }
+  // The other app is actively writing. Refusing is the honest half, and the
+  // `.unreadable` copy already tells the user to quit it and try again.
+  throw SmartImportError.unreadable(appName)
 }
 
 /// The one owner of a SQLite read: open, prepare, step, verify completion,
@@ -684,19 +725,28 @@ package struct TypeWhisperAdapter: SmartImportAdapter {
   /// main file and a WAL from different moments — a snapshot that never
   /// existed. Two agreeing passes prove the accepted bytes coexisted during
   /// the overlap between them.
+  ///
+  /// The loop itself lives in `acquireStableSnapshot(appName:attempts:read:agrees:accept:)`,
+  /// shared with Handy. Only the vendor knowledge is here: what the parts are,
+  /// and what it means for two reads of them to agree.
+  /// Every closure below is explicitly typed. Left to inference, the generic
+  /// call takes longer than the type-checker's budget and fails to build.
   private func acquireStableSnapshot(at url: URL) throws -> [(String, Data)] {
-    for _ in 0..<Self.acquisitionAttempts {
-      let first = try readAllParts(at: url)
-      let second = try readAllParts(at: url)
-      if first.map(\.0) == second.map(\.0),
-        zip(first, second).allSatisfy({ $0.1 == $1.1 })
-      {
-        return first
-      }
+    typealias Parts = [(String, Data)]
+    let read: () throws -> Parts = { try readAllParts(at: url) }
+    let agrees: (Parts, Parts) -> Bool = { first, second in
+      first.map(\.0) == second.map(\.0)
+        && zip(first, second).allSatisfy { $0.1 == $1.1 }
     }
-    // The other app is actively writing. Refusing is the honest half, and the
-    // `.unreadable` copy already tells the user to quit it and try again.
-    throw SmartImportError.unreadable(displayName)
+    // Identity: TypeWhisper's acceptance is the agreement itself. The bytes are
+    // opened as SQLite later, from a private copy.
+    let accept: (Parts) throws -> Parts = { $0 }
+    return try EnviousWisprPostProcessing.acquireStableSnapshot(
+      appName: displayName,
+      attempts: Self.acquisitionAttempts,
+      read: read,
+      agrees: agrees,
+      accept: accept)
   }
 
   private func readAllParts(at url: URL) throws -> [(String, Data)] {
@@ -889,18 +939,117 @@ package struct JunoAdapter: SmartImportAdapter {
 
 // MARK: - Registry and source
 
+// MARK: - Handy
+
+/// One JSON file, read twice, with the word list one level down.
+///
+/// Handy writes `settings_store.json` IN PLACE on every settings change — the
+/// inode is unchanged across writes — so there is a real window in which a
+/// reader sees a truncated file. Measured on 0.9.5: 604,959 reads across three
+/// writes returned 2 zero-byte files, and no partial sizes in between. Hence
+/// the shared two-pass acquisition; a document that merely decodes is not a
+/// document that existed, because a read spanning the rewrite can splice two
+/// generations into valid JSON describing a word list nobody typed.
+///
+/// Nothing else about it is hard. It writes on every change rather than on
+/// quit, so the app need not be closed — the file is byte-identical either side
+/// of quitting — and nothing sits beside it: no WAL, no lock, no temp file.
+///
+/// `custom_words` is a flat `[String]` with no alias concept, the same shape as
+/// Vox and TypeWhisper's Terms. Handy ships NO vocabulary of its own, verified
+/// by moving the store aside and letting 0.9.5 author a fresh one: it wrote
+/// `"custom_words": []`. So the Juno seed-word hazard does not apply and no
+/// provenance filter is needed.
+///
+/// `custom_filler_words` is deliberately NOT imported. It is a REMOVAL list —
+/// words the user asked Handy to strip — so importing it would add the very
+/// words they asked to have taken out. Same reasoning that excludes Vox's
+/// `context` paragraph.
+package struct HandyAdapter: SmartImportAdapter {
+  package let identifier = "handy"
+  package let displayName = "Handy"
+
+  /// Bounded read of the store, injected so a test can drive an exact
+  /// torn/torn/good/good sequence without racing a real app.
+  package typealias DataReader = @Sendable (URL) throws -> Data
+
+  /// Two agreeing reads per acquisition, and at most this many acquisitions.
+  private static let acquisitionAttempts = 3
+
+  private let readOverride: DataReader?
+
+  /// Both levels are OPTIONAL because that is what Handy's own decoder does,
+  /// not because it is the lenient choice.
+  ///
+  /// `AppSettings` carries a container-level `#[serde(default)]` and
+  /// `custom_words` a field-level one, and its own test
+  /// `empty_store_parses_with_defaults` asserts that `{}` parses. An explicit
+  /// `null` reaches the same place by a different route: `Vec<String>` cannot
+  /// deserialize from null, so the strict decode fails and Handy's
+  /// `salvage_settings` drops the field and keeps the default empty vector.
+  ///
+  /// So a document missing `settings`, missing `custom_words`, or holding null
+  /// is not damaged — Handy itself reads it as a user with no custom words, and
+  /// refusing it would tell them their store is unreadable while Handy opens
+  /// the same file and shows them an empty list.
+  ///
+  /// Verified in `cjpais/Handy` at commit `db003f38`, `src-tauri/src/settings.rs`
+  /// lines 338-340, 398-399, 949, 1002 and test 1140.
+  ///
+  /// ACCEPTED LIMIT: a future Handy that RENAMES or MOVES `custom_words` is
+  /// therefore indistinguishable from a user with no custom words, and we would
+  /// say "no words were found". Unhandled on purpose — every available fix
+  /// requires predicting a schema nobody has seen, and the alternative refuses
+  /// today's legitimate partial stores to defend against a speculative one.
+  private struct Store: Decodable {
+    struct Settings: Decodable {
+      let customWords: [String]?
+      enum CodingKeys: String, CodingKey { case customWords = "custom_words" }
+    }
+    let settings: Settings?
+  }
+
+  package var candidatePaths: [URL] {
+    [
+      FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent("Library/Application Support/com.pais.handy/settings_store.json")
+    ]
+  }
+
+  package init(readData: DataReader? = nil) {
+    self.readOverride = readData
+  }
+
+  package func loadWords(at url: URL) throws -> SmartImportReadResult {
+    let store: Store = try acquireStableSnapshot(
+      appName: displayName,
+      attempts: Self.acquisitionAttempts,
+      read: { try readData(at: url) },
+      agrees: { $0 == $1 },
+      accept: { try JSONDecoder().decode(Store.self, from: $0) })
+
+    // Only these two keys are decoded, which is also why an unrelated poisoned
+    // field cannot block the read. Handy salvages such a document field by
+    // field and keeps valid vocabulary out of it; decoding its WHOLE settings
+    // object would refuse a file Handy itself reads happily.
+    return SmartImportReadResult(
+      words: (store.settings?.customWords ?? []).map { SmartImportWord(canonical: $0) })
+  }
+
+  private func readData(at url: URL) throws -> Data {
+    if let readOverride { return try readOverride(url) }
+    return try boundedData(at: url, appName: displayName)
+  }
+}
+
 package struct SmartImportRegistry: Sendable {
   package let adapters: [any SmartImportAdapter]
 
-  /// Handy is deliberately absent: its `custom_words` element schema is a bare
-  /// `string[]` grounded from its own public source, but the app is not
-  /// installed on any machine available here, so an adapter could not be
-  /// exercised end to end against real data — the same rule that kept
-  /// TypeWhisper out until #1773 read its populated store (#1773).
   package static let v1 = SmartImportRegistry(
     adapters: [
       WisprFlowAdapter(), FluidVoiceAdapter(), SuperwhisperAdapter(),
       VoxAdapter(), TypeWhisperAdapter(), SpokenlyAdapter(), JunoAdapter(),
+      HandyAdapter(),
     ])
 
   /// The display names, in registry order, for whoever writes the picker copy.

--- a/Tests/EnviousWisprTests/PostProcessing/SmartImportSourceTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SmartImportSourceTests.swift
@@ -126,7 +126,8 @@ struct SmartImportSourceTests {
       as: "settings.json"
     )
 
-    #expect(try SuperwhisperAdapter().loadWords(at: url).words == [SmartImportWord(canonical: "Saurabh")])
+    #expect(
+      try SuperwhisperAdapter().loadWords(at: url).words == [SmartImportWord(canonical: "Saurabh")])
   }
 
   @Test("a Superwhisper replacement carries its original as the alias")
@@ -152,7 +153,9 @@ struct SmartImportSourceTests {
       as: "settings.json")
 
     #expect(
-      try SuperwhisperAdapter().loadWords(at: url).words == [SmartImportWord(canonical: "Superwhisper")])
+      try SuperwhisperAdapter().loadWords(at: url).words == [
+        SmartImportWord(canonical: "Superwhisper")
+      ])
   }
 
   @Test("a Superwhisper replacement missing with is dropped, as today")
@@ -508,7 +511,9 @@ struct SmartImportSourceTests {
       let identifier = "missing"
       let displayName = "Nothing"
       var candidatePaths: [URL] { [URL(fileURLWithPath: "/nonexistent/nope.json")] }
-      func loadWords(at url: URL) throws -> SmartImportReadResult { SmartImportReadResult(words: []) }
+      func loadWords(at url: URL) throws -> SmartImportReadResult {
+        SmartImportReadResult(words: [])
+      }
     }
     await #expect(throws: SmartImportError.appNotFound("Nothing")) {
       _ = try await SmartImportSource(adapter: Missing()).loadCandidates()
@@ -681,20 +686,207 @@ struct SmartImportSourceTests {
     #expect(actualScalars == [Array(nfc.unicodeScalars), Array(nfd.unicodeScalars)])
   }
 
-  @Test("the registry ships every verified app and not the unverifiable one")
+  @Test("the registry ships every app whose store has been read on a live install")
   func registryShipsOnlyVerifiedAdapters() {
     let ids = SmartImportRegistry.v1.adapters.map(\.identifier)
     #expect(
       ids.sorted() == [
-        "fluidvoice", "juno", "spokenly", "superwhisper", "typewhisper", "vox", "wispr-flow",
+        "fluidvoice", "handy", "juno", "spokenly", "superwhisper", "typewhisper", "vox",
+        "wispr-flow",
       ])
-    // Handy is absent deliberately: its element schema is grounded from its
-    // own public source, but the app is not installed on any machine here, so
-    // an adapter could not be exercised end to end against real data (#1773).
-    #expect(!ids.contains("handy"))
-    // Identifiers reach telemetry as `sourceID`, so a collision would silently
-    // merge two competitors' import counts.
+    // Identifiers drive adapter lookup and label the import batch, so a
+    // collision would make the registry ambiguous. They reach no telemetry:
+    // `CustomWordsImportBatch.sourceID` has no consumer (#2052).
     #expect(Set(ids).count == ids.count)
+  }
+
+  // MARK: - Handy
+
+  private func handyStore(_ json: String, in dir: URL) throws -> URL {
+    try write(json, to: dir, as: "settings_store.json")
+  }
+
+  @Test("Handy words import from the nested key with no alias")
+  func handyWordsImport() throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try handyStore(
+      #"{ "settings": { "custom_words": ["Handyfold", "Quixotropic"], "word_correction_threshold": 0.18 } }"#,
+      in: dir)
+
+    let result = try HandyAdapter().loadWords(at: url)
+    #expect(
+      result.words == [
+        SmartImportWord(canonical: "Handyfold"), SmartImportWord(canonical: "Quixotropic"),
+      ])
+    // Handy excludes nothing of its own: it ships no seed vocabulary, verified
+    // by letting 0.9.5 author a store from scratch (it wrote `[]`).
+    #expect(result.excludedCount == 0)
+  }
+
+  @Test("a top-level custom_words is not Handy's key and is never imported")
+  func handyIgnoresTopLevelKey() throws {
+    // The trap #2052 names: the list lives one level down, so a top-level read
+    // looks like "this user has no custom words" rather than like a path bug.
+    // Empty is the right answer here, not a refusal — Handy itself defaults a
+    // missing `settings` object to an empty vocabulary.
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try handyStore(#"{ "custom_words": ["NeverImportMe"] }"#, in: dir)
+    #expect(try HandyAdapter().loadWords(at: url).words.isEmpty)
+  }
+
+  @Test("Handy's own missing-field defaults are an empty vocabulary, not a damaged store")
+  func handyMissingFieldsAreEmpty() throws {
+    // Verified in cjpais/Handy at commit db003f38, src-tauri/src/settings.rs:
+    // container-level #[serde(default)] on AppSettings (338-340), field-level
+    // on custom_words (398-399), and the test empty_store_parses_with_defaults
+    // (1140). Refusing these would tell the user their store is unreadable
+    // while Handy opens the same file and shows them an empty list.
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    for (label, json) in [
+      ("absent settings", #"{ "other": 1 }"#),
+      ("absent custom_words", #"{ "settings": { "debug_mode": false } }"#),
+      ("empty array", #"{ "settings": { "custom_words": [] } }"#),
+      // Null takes a different route to the same place: Vec<String> cannot
+      // deserialize from null, so Handy's strict decode fails and its
+      // salvage_settings (1002) drops the field and keeps the default.
+      ("explicit null", #"{ "settings": { "custom_words": null } }"#),
+    ] {
+      let url = try handyStore(json, in: dir)
+      #expect(try HandyAdapter().loadWords(at: url).words.isEmpty, "\(label) should read as empty")
+    }
+  }
+
+  @Test("a Handy word list of the wrong type refuses the whole import")
+  func handyWrongTypeRefuses() throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    for json in [
+      #"{ "settings": { "custom_words": ["Quorvex", 7] } }"#,
+      #"{ "settings": { "custom_words": { "a": "b" } } }"#,
+      #"{ "settings": { "custom_words": "Quorvex" } }"#,
+      #"{ "settings": "not an object" }"#,
+      #"{ not json at all "#,
+    ] {
+      let url = try handyStore(json, in: dir)
+      #expect(throws: SmartImportError.unreadable("Handy")) {
+        _ = try HandyAdapter().loadWords(at: url)
+      }
+    }
+  }
+
+  @Test("an unrelated wrongly-typed Handy setting does not block the word list")
+  func handyUnrelatedPoisonedFieldStillImports() throws {
+    // Handy salvages such a document field by field and keeps valid vocabulary
+    // out of it — its own salvage_drops_only_wrong_typed_fields (1293) puts
+    // exactly this `paste_delay_ms` in and still asserts the words survive. A
+    // reader that decoded Handy's WHOLE settings object would refuse a file
+    // Handy reads happily; ours decodes two keys, so it matches by design.
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try handyStore(
+      #"{ "settings": { "custom_words": ["Handyfold"], "paste_delay_ms": "sixty" } }"#, in: dir)
+    #expect(try HandyAdapter().loadWords(at: url).words.map(\.canonical) == ["Handyfold"])
+  }
+
+  @Test("Handy multi-word and non-ASCII entries survive unchanged")
+  func handyPreservesEntriesVerbatim() throws {
+    // Handy's own Add button refuses a space and accepts an umlaut (both
+    // measured on 0.9.5). We inherit neither judgement: the file is the
+    // contract, our shared text policy decides what is storable, and a
+    // hand-edited file may legitimately hold a phrase.
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try handyStore(
+      #"{ "settings": { "custom_words": ["Envious Labs", "Müller"] } }"#, in: dir)
+
+    let words = try HandyAdapter().loadWords(at: url).words
+    #expect(words.map(\.canonical) == ["Envious Labs", "Müller"])
+    // Compared by scalars: a normalization slip would still pass a == on the
+    // rendered string in some fonts.
+    #expect(Array(words[1].canonical.unicodeScalars) == Array("Müller".unicodeScalars))
+  }
+
+  @Test("an unknown Handy schema version still imports, and only a moved key reads as empty")
+  func handyForwardCompatibility() throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    // Fail-open: a future version we do not recognise must not break an import
+    // whose word list is still exactly where we look for it.
+    let future = try handyStore(
+      #"{ "settings": { "settings_schema_version": 99, "custom_words": ["Zephyrine"], "brand_new_key": {} } }"#,
+      in: dir)
+    #expect(try HandyAdapter().loadWords(at: future).words.map(\.canonical) == ["Zephyrine"])
+
+    // ACCEPTED LIMIT, frozen here so nobody "fixes" it into a refusal without
+    // reading why: a future Handy that MOVED the key is indistinguishable from
+    // a user with no custom words, because Handy defines a missing key AS an
+    // empty vocabulary. Refusing this shape would refuse today's legitimate
+    // partial stores to defend against a schema nobody has seen (#2052).
+    let moved = try handyStore(
+      #"{ "settings": { "settings_schema_version": 99, "vocabulary": ["Zephyrine"] } }"#, in: dir)
+    #expect(try HandyAdapter().loadWords(at: moved).words.isEmpty)
+  }
+
+  @Test("a Handy store caught mid-rewrite is re-read rather than refused or misread")
+  func handyRetriesATornRead() throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try handyStore(#"{ "settings": { "custom_words": ["Handyfold"] } }"#, in: dir)
+
+    // Handy rewrites this file in place, so a reader can catch the truncation
+    // window: measured 2 zero-byte reads in 604,959 across three writes. Two
+    // EMPTY reads agree perfectly, which is why acceptance must live inside the
+    // retry — outside it, this exact sequence would consume the whole budget on
+    // attempt one and throw.
+    nonisolated(unsafe) var reads = 0
+    let torn = HandyAdapter(readData: { real in
+      reads += 1
+      if reads <= 2 { return Data() }
+      return try Data(contentsOf: real)
+    })
+    #expect(try torn.loadWords(at: url).words.map(\.canonical) == ["Handyfold"])
+    // Exactly two acquisitions: the first pair agreed but did not decode, the
+    // second pair did. Without this the test would pass against an adapter that
+    // never entered the recovery path at all.
+    #expect(reads == 4)
+
+    // Two-way control: a reader that is torn forever refuses, so the success
+    // above is the recovery working and not the injection being ignored.
+    nonisolated(unsafe) var alwaysTorn = 0
+    let hopeless = HandyAdapter(readData: { _ in
+      alwaysTorn += 1
+      return Data()
+    })
+    #expect(throws: SmartImportError.unreadable("Handy")) {
+      _ = try hopeless.loadWords(at: url)
+    }
+    #expect(alwaysTorn == 6, "three acquisitions × two reads")
+  }
+
+  @Test("Handy bytes that disagree between the two reads are never spliced into a word list")
+  func handyRefusesDisagreeingReads() throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try handyStore(#"{ "settings": { "custom_words": ["Handyfold"] } }"#, in: dir)
+
+    // Both reads decode fine and describe DIFFERENT vocabularies. Decoding
+    // alone cannot catch this, which is the whole reason acceptance is not the
+    // agreement check.
+    nonisolated(unsafe) var flip = 0
+    let unstable = HandyAdapter(readData: { _ in
+      flip += 1
+      let word = flip % 2 == 0 ? "Second" : "First"
+      return Data(#"{ "settings": { "custom_words": ["\#(word)"] } }"#.utf8)
+    })
+    #expect(throws: SmartImportError.unreadable("Handy")) {
+      _ = try unstable.loadWords(at: url)
+    }
   }
 
   // MARK: - Shared SQLite reader
@@ -962,6 +1154,11 @@ struct SmartImportSourceTests {
     #expect(throws: SmartImportError.unreadable("TypeWhisper")) {
       _ = try unstable.loadWords(at: store.url)
     }
+    // Freezes the ATTEMPT COUNT, not just the outcome. The counter above has
+    // always existed and was never asserted, so this test passed equally
+    // against an adapter that gave up after one attempt — which is exactly the
+    // regression moving this loop into the shared helper could cause (#2052).
+    #expect(pass == 6, "three acquisitions × two complete reads each")
 
     // Positive counterpart: a reader that returns stable bytes succeeds, so
     // the refusal above is the instability and not the injection itself.
@@ -1022,7 +1219,9 @@ struct SmartImportSourceTests {
   // MARK: - Spokenly
 
   private func spokenlyEnvelope(_ items: String) -> Data {
-    Data(#"{"dirty":true,"serverVersion":0,"envelope":{"orderUpdatedAt":1,"items":[\#(items)],"tombstones":[{"id":"gone","deletedAt":2}]}}"#.utf8)
+    Data(
+      #"{"dirty":true,"serverVersion":0,"envelope":{"orderUpdatedAt":1,"items":[\#(items)],"tombstones":[{"id":"gone","deletedAt":2}]}}"#
+        .utf8)
   }
 
   private func spokenlyItem(
@@ -1045,7 +1244,8 @@ struct SmartImportSourceTests {
     // `original` holds a PATTERN, not a word — verified by creating one
     // through Spokenly's own Use Regular Expression checkbox.
     let data = spokenlyEnvelope(
-      spokenlyItem("hanooman", "Hanuman") + "," + spokenlyItem(#"\\bk\\s*eight\\s*s\\b"#, "k8s", isRegex: true))
+      spokenlyItem("hanooman", "Hanuman") + ","
+        + spokenlyItem(#"\\bk\\s*eight\\s*s\\b"#, "k8s", isRegex: true))
     let result = try SpokenlyAdapter(readDomain: { _ in data })
       .loadWords(at: URL(fileURLWithPath: "/unused"))
     #expect(result.words.map(\.canonical) == ["Hanuman"])
@@ -1072,7 +1272,8 @@ struct SmartImportSourceTests {
       .loadWords(at: URL(fileURLWithPath: "/unused"))
     #expect(withoutItem.words.isEmpty)
 
-    let resurrected = #"{"updatedAt":1,"value":{"id":"gone","original":"a","replacement":"Alive","isRegex":false,"timing":"beforeAI","createdAt":1}}"#
+    let resurrected =
+      #"{"updatedAt":1,"value":{"id":"gone","original":"a","replacement":"Alive","isRegex":false,"timing":"beforeAI","createdAt":1}}"#
     let withItem = try SpokenlyAdapter(readDomain: { _ in self.spokenlyEnvelope(resurrected) })
       .loadWords(at: URL(fileURLWithPath: "/unused"))
     #expect(withItem.words.map(\.canonical) == ["Alive"])
@@ -1241,7 +1442,8 @@ struct SmartImportSourceTests {
       """, in: dir)
 
     let words = try JunoAdapter().loadWords(at: url).words
-    #expect(words[0] == SmartImportWord(canonical: "Apple Silicon", aliases: ["apple silicon chip"]))
+    #expect(
+      words[0] == SmartImportWord(canonical: "Apple Silicon", aliases: ["apple silicon chip"]))
     // A blank canonical form falls back to the term rather than dropping the row.
     #expect(words[1].canonical == "Fallback")
   }
@@ -1277,7 +1479,8 @@ struct SmartImportSourceTests {
     defer { try? FileManager.default.removeItem(at: dir) }
     let url = try write(#"{ "terms": [ { "text": "Kubernetes" } ] }"#, to: dir, as: "v.json")
     #expect(
-      try FluidVoiceAdapter().loadWords(at: url).words == [SmartImportWord(canonical: "Kubernetes")])
+      try FluidVoiceAdapter().loadWords(at: url).words == [SmartImportWord(canonical: "Kubernetes")]
+    )
   }
 
   @Test("a truncated read is refused even though nothing shrinks it anymore")
@@ -1405,7 +1608,8 @@ struct SmartImportSourceTests {
       }
     }
     let batch = try await SmartImportSource(adapter: Fixed()).loadCandidates()
-    #expect(batch.candidates.map(\.caseSensitive) == [.supplied(true), .supplied(false), .unspecified])
+    #expect(
+      batch.candidates.map(\.caseSensitive) == [.supplied(true), .supplied(false), .unspecified])
   }
 
   /// FluidVoice is the real amplification vector this ceiling exists for: its

--- a/website/src/content/help/importing-and-exporting-custom-words.md
+++ b/website/src/content/help/importing-and-exporting-custom-words.md
@@ -16,16 +16,19 @@ Importing adds new terms to your list without changing the words you already hav
 
 **Open the import tool.** Click **Import** on the Your Words page.
 
-**Choose your source.** Select whether you want to paste a list of words, open a saved file, or import from another dictation app. EnviousWispr can read your existing vocabulary straight out of Wispr Flow, FluidVoice, Superwhisper, Vox, TypeWhisper, Spokenly, or Juno if you have them installed. If you are importing from a file, that file can be a previous export from EnviousWispr or any plain text document with one word per line.
+**Choose your source.** Select whether you want to paste a list of words, open a saved file, or import from another dictation app. EnviousWispr can read your existing vocabulary straight out of Wispr Flow, FluidVoice, Superwhisper, Vox, TypeWhisper, Spokenly, Juno, or Handy if you have them installed. If you are importing from a file, that file can be a previous export from EnviousWispr or any plain text document with one word per line.
 
 **What comes across, app by app.** EnviousWispr brings over the words you added yourself, along with any misspellings that app was already correcting for you. A few apps store more than a word list, and only the word list comes across:
 
+- **Handy** keeps a separate list of filler words it strips out of your dictation. Those are not brought across, because they are words you asked Handy to remove rather than words you want kept. Its prompts and tuning settings stay behind too. You do not need to quit Handy first.
 - **Juno** ships with around 400 built-in terms of its own. Only the words you added are imported, so your list stays yours.
 - **Spokenly** can store find-and-replace rules written as patterns rather than plain words. Those are skipped, because a pattern is not a word.
 - **TypeWhisper** entries you have switched off stay off, and its case-sensitivity setting for each word comes across with it. Its match-strictness setting does not.
 - **Wispr Flow** text shortcuts are skipped. Those are text expansions rather than vocabulary.
 
 If an app holds entries but none of them can come across, EnviousWispr tells you how many it found rather than saying it found nothing.
+
+**Nothing is read until you ask for it, and nothing leaves your Mac.** EnviousWispr does not look inside another app's files in the background. It reads them only after you pick that app in the import screen, it reads them on your Mac, and it never sends what it finds anywhere. The other app's own files are only ever read, never changed, and you review every word before anything is added to your list.
 
 **Review and confirm.** Check the list of terms it found, then add them to your list.
 

--- a/website/src/content/help/importing-and-exporting-custom-words.md
+++ b/website/src/content/help/importing-and-exporting-custom-words.md
@@ -28,7 +28,9 @@ Importing adds new terms to your list without changing the words you already hav
 
 If an app holds entries but none of them can come across, EnviousWispr tells you how many it found rather than saying it found nothing.
 
-**Nothing is read until you ask for it, and nothing leaves your Mac.** EnviousWispr does not look inside another app's files in the background. It reads them only after you pick that app in the import screen, it reads them on your Mac, and it never sends what it finds anywhere. The other app's own files are only ever read, never changed, and you review every word before anything is added to your list.
+**Nothing is read until you ask for it.** EnviousWispr does not look inside another app's files in the background. It reads them only after you pick that app in the import screen, and it reads them on your Mac. Envious Labs never receives your words. The other app's own files are only ever read, never changed, and you review every word before anything is added to your list.
+
+Once you add them, they are ordinary custom words and behave like any others. If you have chosen a cloud provider for AI Polish, your custom words are sent to that provider along with your text so your spellings survive the rewrite, exactly as described in [Adding custom words](/help/adding-custom-words/). The import itself does not change that either way.
 
 **Review and confirm.** Check the list of terms it found, then add them to your list.
 


### PR DESCRIPTION
Adds **Handy** as the eighth Smart Import source, and the last one from #1773 — which deferred it only because it was not installed. It is now (0.9.5, via `brew install --cask handy`), and every claim below is a measurement against the real store, not a reading of its source.

Plan: `docs/feature-requests/issue-2052-2026-08-13-smart-import-handy.md` (rev 6, one coverage round + four grounded rounds).

## Handy is the easy one, except in one respect

Writes on every change rather than on quit, so the app need not be closed — the file is byte-identical either side of quitting. Nothing sits beside it: no WAL, no lock, no temp file. `custom_words` is a flat `[String]` one level under `settings`, with no alias concept.

**The exception: it rewrites that file IN PLACE.** The inode is unchanged across writes, so a reader can catch it mid-rewrite. Measured — a 20-second loop across three writes: **604,959 reads, 2 of them a 0-byte file**, sizes `{0, 6243, 6262, 6284, 6308}` and nothing partial in between.

The first design retried until the bytes decoded, arguing a torn read cannot parse. That holds for a PREFIX and this is not necessarily a prefix: `boundedData` reads in a loop, so a rewrite landing mid-loop returns bytes from two generations, and two similar documents splice into valid JSON describing a word list nobody typed — silent, not loud. So acquisition takes **two byte-identical reads that must also decode**, up to three attempts.

That loop is identical to the one `TypeWhisperAdapter` already needs, so it moves into a shared `acquireStableSnapshot` and TypeWhisper migrates onto it. **Acceptance runs INSIDE the retry**, which is load-bearing rather than tidy: two zero-byte reads agree perfectly, so accepting outside would spend the whole budget on attempt one and throw.

## The word list is decoded optionally, following Handy's decoder rather than our convention

Verified in `cjpais/Handy` at commit `db003f38` (`src-tauri/src/settings.rs`): container-level `#[serde(default)]` on `AppSettings` (`:338-340`), field-level on `custom_words` (`:398-399`), and a test `empty_store_parses_with_defaults` (`:1140`) asserting `{}` parses. An explicit `null` reaches the same place by a different route — `Vec<String>` cannot deserialize from null, so their strict decode fails and `salvage_settings` (`:1002`) drops the field and keeps the default.

So a document missing `settings` or `custom_words` is not damaged. **Handy itself reads it as a user with no custom words**, and refusing it would tell someone their store is unreadable while Handy opens the same file and shows them an empty list.

Their salvage path also explains why our narrow two-key decode is right rather than lucky: `salvage_drops_only_wrong_typed_fields` (`:1293`) puts `paste_delay_ms: "sixty"` in the document and still asserts the words survive. A reader modelling Handy's WHOLE settings object would refuse a file Handy reads happily; ours decodes two keys, so an unrelated poisoned field is invisible to it. That is a test, not a hope.

**Accepted limit, frozen in a test so nobody "fixes" it without reading why:** a future Handy that RENAMED or MOVED the key is therefore indistinguishable from a user with no custom words. Every available fix requires predicting a schema nobody has seen, and the alternative refuses today's legitimate partial stores to defend against a speculative one.

## Handy ships no vocabulary of its own

The Juno hazard (400 vendor words against the user's 1) does not exist here — verified by moving the store aside and letting 0.9.5 author a fresh one, which wrote `"custom_words": []`. Its February-era predecessor said the same, so an upgrade does not seed either. No provenance filter is needed.

Its **filler-word list is deliberately not imported**: those are words the user asked Handy to REMOVE, so importing them would add the very words they wanted taken out. The Juno defect with the sign flipped.

## Corrected along the way: `sourceID` reaches no telemetry

Found while checking whether `"handy"` would become a new telemetry value. It would not. `CustomWordsImportBatch.sourceID` is written by all three import paths, preserved through validation, and **read by nothing** — there is no source-attributed import event, so we cannot say whether anyone imports from any of the eight apps. Four shipped comments claim otherwise and are corrected here.

Imports are not telemetry-silent, which the first draft of this PR got wrong in the comfortable direction: a non-empty commit fires the existing vocabulary propagator, emitting counts only (no content, no source). The missing telemetry itself affects all seven existing adapters equally and is routed to **#2048**.

Also fixed: a comment reading "five of the seven adapters exclude source rows" that adding an eighth silently falsified.

## Live UAT — every number measured from the store first

Run on the rebuilt dev app against the real Handy install, with the running process verified by executable path rather than name.

| Case | Expectation | Result |
|---|---|---|
| A. Handy in the picker | offered | ✅ eighth in the list |
| **B. Import while Handy is RUNNING** | 4 new + 1 already have | ✅ "4 new words found. 1 you already have." |
| C. Non-ASCII survives | `Müller` intact | ✅ umlaut preserved |
| D. Commit path | 32 → 36 | ✅ all four present, `Qualtrics` not duplicated |
| E. Handy's store untouched | md5 equal either side of the READ | ✅ `3391f142…` both times, no sidecars created |
| F. Library restored | back to 32 | ✅ md5 `d03414ac…` |

Case B is the load-bearing one: with Handy live, the import still returns all five rows. **It is the inverse of what Spokenly needed** — that one writes nothing until it quits.

Expected counts were computed from `settings_store.json` and the existing library BEFORE the import, never read off the result.

## Tests

`scripts/xcode-test.sh` green: **5462**, up from a 5453 baseline on the same worktree.

**Three mutation controls, each run and each confirmed to fail without its fix:**
- read the top-level key instead of the nested one → 4 tests fail, including the one guarding that exact trap
- drop the second read → the Handy retry tests fail **and so does TypeWhisper's**, which is precisely the regression the migration could have caused
- require both levels → the empty-success tests fail

That TypeWhisper assertion is new. `typeWhisperRefusesAnUnstableSnapshot` already counted its reads into a `pass` variable and never asserted on it, so it passed equally against an adapter that gave up after one attempt. It now requires exactly six reads — three acquisitions × two.

Also covered: an injected reader driving an exact torn/torn/good/good sequence with an **attempt-count assertion** (a retry test that does not count attempts cannot tell recovery from the first read happening to work), two reads that both decode but describe different vocabularies, multi-word and non-ASCII round-trips, and the four missing/null/wrong-type shapes.

## Not in scope

- **Source-attributed import telemetry** — missing for all eight adapters equally. #2048.
- **Juno's Corrections / Replacements / Snippets tabs** — still ungroundable here; its Add button is inert in this build.

Closes #2052
