### PR TITLE
fix(eval): let the behaviour judge accept a second valid repair

### DIFF
--- a/scripts/eval/behavior_judge.py
+++ b/scripts/eval/behavior_judge.py
@@ -487,6 +487,22 @@ def _rubric_identity() -> str:
         return "unreadable"
 
 
+def _external_rubric_identity(path: str | None) -> str:
+    """Provenance for IMPORTED verdicts, derived from the verdicts file itself.
+
+    A constant sentinel cannot serve: it asserts that every import shares one
+    rubric, so two files graded under different external rubrics compare equal
+    and `report_ollama_bench.py` ranks them together. Unreadable falls back to a
+    value that groups only with other unreadable ones rather than with real
+    imports."""
+    if not path:
+        return "external:unknown"
+    try:
+        return "external:" + hashlib.sha256(Path(path).read_bytes()).hexdigest()[:12]
+    except OSError:
+        return "external:unreadable"
+
+
 def judge_identity(model: str) -> str:
     """What actually graded, as one string safe to hash into a resume stamp.
 
@@ -1892,8 +1908,17 @@ def main() -> int:
         # because they share this checkout. The judge field one line above already
         # makes exactly this distinction; this is the same rule, not a new one.
         # Cloud review P1 on #2055, third round of the same class.
+        # DERIVED, never constant. A bare "external_verdicts" sentinel made every
+        # import claim one shared rubric, so two verdict files graded under
+        # DIFFERENT external rubrics compared equal and the report ranked them
+        # together — the same false claim as stamping the local digest, pointing
+        # the other way. Hashing the verdicts file gives identical imports the same
+        # identity and different ones different identities, which is what the field
+        # is for. Cloud review P1 x4 on #2055; see also the `judge` field above,
+        # which still uses a bare sentinel and has the same shape (pre-existing,
+        # not touched here).
         "rubric_identity": (_rubric_identity() if external_verdicts is None
-                            else "external_verdicts"),
+                            else _external_rubric_identity(args.verdicts)),
         "reps": args.reps if args.system == "old" else None,
         "adjudicate_pct": args.adjudicate_pct if args.system == "new" else None,
         "adjudicate_min": args.adjudicate_min if args.system == "new" else None,

--- a/scripts/eval/behavior_judge.py
+++ b/scripts/eval/behavior_judge.py
@@ -778,9 +778,14 @@ DEFAULT_ALLOWED_VARIANTS = [
 BEHAVIOR_ALLOWED_VARIANTS = {
     "grammar_fix": [
         "any grammatically correct repair of the error when the transcript admits more "
-        "than one — e.g. pluralising the noun OR adjusting the verb, adding an article OR "
-        "changing number. Judge whether the error is fixed and the speaker's content "
-        "survives, NOT whether the repair matches reference_output's choice.",
+        "than one AND the repair preserves how many things the speaker referred to — "
+        "e.g. 'the figures is ready' may be fixed by adjusting the verb ('are'), or by "
+        "any other repair that keeps the plural. Changing the NOUN's number ('the figure "
+        "is ready') is NOT a licensed variant: it silently changes the count the speaker "
+        "gave, which the meaning-preservation rule already forbids. Article choice ('the' "
+        "vs 'a') is licensed where both preserve the count. Judge whether the error is "
+        "fixed and the speaker's content survives, NOT whether the repair matches "
+        "reference_output's choice.",
     ],
     "topic_shift": [
         "any device that visibly separates the topics: blank lines, single line breaks, "

--- a/scripts/eval/behavior_judge.py
+++ b/scripts/eval/behavior_judge.py
@@ -750,6 +750,37 @@ DEFAULT_ALLOWED_VARIANTS = [
     "bullet vs numbered list when both preserve intent",
 ]
 
+# Per-behavior additions, for buckets where the transcript genuinely admits more than one
+# correct answer and `expected_output` records only the one the author happened to write.
+#
+# Why this exists: the system prompt already says reference_output is "an ILLUSTRATIVE
+# reference, NOT exact ground truth" and forbids grading by similarity to it — but
+# `allowed_variants` was a single global list of four COSMETIC items, so on a case with two
+# valid repairs the judge had nothing to license the other one and fell back to the
+# reference. Measured 2026-08-12: `reference_overfit` is a defined failure type that had
+# never been emitted once in 6,760 gradings, while grammar sat at 57% with a third of its
+# failures being alternative valid repairs.
+#
+# These entries loosen only WHICH correct answer is accepted. They do not loosen meaning,
+# entity, or content checks — a repair that changes what the speaker said still fails.
+BEHAVIOR_ALLOWED_VARIANTS = {
+    "grammar_fix": [
+        "any grammatically correct repair of the error when the transcript admits more "
+        "than one — e.g. pluralising the noun OR adjusting the verb, adding an article OR "
+        "changing number. Judge whether the error is fixed and the speaker's content "
+        "survives, NOT whether the repair matches reference_output's choice.",
+    ],
+    "topic_shift": [
+        "any device that visibly separates the topics: blank lines, single line breaks, "
+        "or bullets. reference_output uses blank lines as an authoring convention, not a "
+        "product requirement. Do not penalise the choice of separator.",
+    ],
+}
+
+
+def allowed_variants_for(behavior: str) -> list[str]:
+    return DEFAULT_ALLOWED_VARIANTS + BEHAVIOR_ALLOWED_VARIANTS.get(behavior, [])
+
 
 def behavior_key(case: dict) -> str:
     """Canonical behavior name from whatever fields a case carries. Strips the
@@ -975,7 +1006,7 @@ def build_new_payload(norm: dict, cand: dict, prod: dict | None) -> dict:
         "case_type": norm["case_type"],
         "risk_tier": norm["risk_tier"],
         "reference_output": norm["reference_output"],
-        "allowed_variants": DEFAULT_ALLOWED_VARIANTS,
+        "allowed_variants": allowed_variants_for(norm["behavior"]),
     }
 
 

--- a/scripts/eval/behavior_judge.py
+++ b/scripts/eval/behavior_judge.py
@@ -487,22 +487,6 @@ def _rubric_identity() -> str:
         return "unreadable"
 
 
-def _external_rubric_identity(path: str | None) -> str:
-    """Provenance for IMPORTED verdicts, derived from the verdicts file itself.
-
-    A constant sentinel cannot serve: it asserts that every import shares one
-    rubric, so two files graded under different external rubrics compare equal
-    and `report_ollama_bench.py` ranks them together. Unreadable falls back to a
-    value that groups only with other unreadable ones rather than with real
-    imports."""
-    if not path:
-        return "external:unknown"
-    try:
-        return "external:" + hashlib.sha256(Path(path).read_bytes()).hexdigest()[:12]
-    except OSError:
-        return "external:unreadable"
-
-
 def judge_identity(model: str) -> str:
     """What actually graded, as one string safe to hash into a resume stamp.
 
@@ -1917,8 +1901,24 @@ def main() -> int:
         # is for. Cloud review P1 x4 on #2055; see also the `judge` field above,
         # which still uses a bare sentinel and has the same shape (pre-existing,
         # not touched here).
-        "rubric_identity": (_rubric_identity() if external_verdicts is None
-                            else _external_rubric_identity(args.verdicts)),
+        # None for imported verdicts, exactly as `judge_identity` is empty for a run
+        # started outside the sweep: unknown provenance groups with unknown
+        # provenance rather than pretending to an identity it never resolved.
+        #
+        # Five review rounds reached this. Every invented alternative was worse:
+        # the local digest CLAIMED a rubric the import never ran under; a constant
+        # sentinel made two DIFFERENT external rubrics compare equal; hashing the
+        # verdicts file made two arms under the SAME rubric compare different,
+        # because verdict files differ by candidate outcome, which broke multi-arm
+        # external grading entirely.
+        #
+        # ACCEPTED LIMIT, stated rather than papered over: two imports graded under
+        # genuinely different external rubrics both report None and will be ranked
+        # together. That is the same accepted limit `judge_identity` already
+        # carries for legacy receipts, and the harness cannot close it without a
+        # rubric identifier the verdicts file does not contain. Supplying one is a
+        # separate change with its own flag.
+        "rubric_identity": _rubric_identity() if external_verdicts is None else None,
         "reps": args.reps if args.system == "old" else None,
         "adjudicate_pct": args.adjudicate_pct if args.system == "new" else None,
         "adjudicate_min": args.adjudicate_min if args.system == "new" else None,

--- a/scripts/eval/behavior_judge.py
+++ b/scripts/eval/behavior_judge.py
@@ -1886,7 +1886,14 @@ def main() -> int:
         # because an interrupted sweep leaves some arms re-graded and some not, and
         # `report_ollama_bench.py` compares receipts and never reads that sidecar.
         # Cloud review P1 on #2055.
-        "rubric_identity": _rubric_identity(),
+        # Imported verdicts were NOT produced by this scorer, so stamping the local
+        # digest on them would assert a provenance that never happened — and two
+        # imports graded under different external rubrics would then compare equal
+        # because they share this checkout. The judge field one line above already
+        # makes exactly this distinction; this is the same rule, not a new one.
+        # Cloud review P1 on #2055, third round of the same class.
+        "rubric_identity": (_rubric_identity() if external_verdicts is None
+                            else "external_verdicts"),
         "reps": args.reps if args.system == "old" else None,
         "adjudicate_pct": args.adjudicate_pct if args.system == "new" else None,
         "adjudicate_min": args.adjudicate_min if args.system == "new" else None,

--- a/scripts/eval/behavior_judge.py
+++ b/scripts/eval/behavior_judge.py
@@ -475,6 +475,18 @@ def _azure_served_model(deployment: str) -> str:
     return served.strip()
 
 
+def _rubric_identity() -> str:
+    """SHA of this scorer, which IS the rubric: the system prompt, the allowed
+    variants and the severity rules all live here. Over-identifies by design — a
+    comment change mints a new identity and forces a re-grade. That is the correct
+    direction: under-identifying lets two rubrics into one ranking, which is
+    undetectable in the output."""
+    try:
+        return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()[:12]
+    except OSError:
+        return "unreadable"
+
+
 def judge_identity(model: str) -> str:
     """What actually graded, as one string safe to hash into a resume stamp.
 
@@ -1868,6 +1880,13 @@ def main() -> int:
         # always could. Empty for a run started outside the sweep, which groups with other such
         # runs rather than pretending to an identity it never resolved.
         "judge_identity": os.environ.get("EW_JUDGE_IDENTITY") or _resolved_judge_identity,
+        # WHICH RUBRIC produced this receipt. `judge_identity` answers "who graded
+        # it"; this answers "against what bar". Both change what a score MEANS, so
+        # both have to travel WITH the receipt — the resume stamp cannot serve this,
+        # because an interrupted sweep leaves some arms re-graded and some not, and
+        # `report_ollama_bench.py` compares receipts and never reads that sidecar.
+        # Cloud review P1 on #2055.
+        "rubric_identity": _rubric_identity(),
         "reps": args.reps if args.system == "old" else None,
         "adjudicate_pct": args.adjudicate_pct if args.system == "new" else None,
         "adjudicate_min": args.adjudicate_min if args.system == "new" else None,

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -250,7 +250,8 @@ def forge_stamp(t, judge=None):
         ["bash", "-c",
          'if command -v shasum >/dev/null 2>&1; then H="shasum -a 256"; else H=sha256sum; fi; '
          f'{{ printf "judge=%s\\n" "{judge}"; '
-         f'$H "{t / "cand" / "modelA.jsonl"}" "{t / "corpus.jsonl"}"; }} | $H | cut -d" " -f1'],
+         f'$H "{t / "cand" / "modelA.jsonl"}" "{t / "corpus.jsonl"}" '
+         f'"{t / "scripts" / "eval" / "behavior_judge.py"}"; }} | $H | cut -d" " -f1'],
         capture_output=True, text=True).stdout.strip()
     assert forged, "could not compute a stamp"
     (t / "judged" / "modelA" / ".inputs-sha256").write_text(forged + "\n")

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -897,56 +897,35 @@ def test_a_receipt_from_the_same_judge_is_still_skipped():
 
 
 
-def test_two_external_rubrics_get_two_identities():
-    """A provenance field must be DERIVED from what it describes, never a constant.
-
-    A bare "external_verdicts" sentinel gave every import one shared identity, so
-    two verdict files graded under DIFFERENT external rubrics compared equal and
-    the report ranked them together — the same false claim as stamping the local
-    digest, pointing the other way. Cloud review P1 x4 on #2055.
-
-    THREE-WAY: different files must differ, identical CONTENT must match (the
-    identity is the bytes, not the path), and neither may collide with the local
-    digest.
-    """
-    t = Path(tempfile.mkdtemp())
-    a = t / "a.jsonl"; a.write_text('{"id":"A","verdict":"pass"}\n')
-    b = t / "b.jsonl"; b.write_text('{"id":"A","verdict":"critical_fail"}\n')
-    c = t / "c.jsonl"; c.write_text(a.read_text())          # same bytes, other path
-
-    ia, ib, ic = (bj._external_rubric_identity(str(x)) for x in (a, b, c))
-    assert ia != ib, f"two different verdict files share an identity: {ia}"
-    assert ia == ic, f"identical verdicts got different identities: {ia} vs {ic}"
-    assert ia != bj._rubric_identity(), "an import claimed the local rubric"
-    assert ia.startswith("external:"), ia
-
-    # missing and unreadable group with their own kind, not with real imports
-    assert bj._external_rubric_identity(None) == "external:unknown"
-    assert bj._external_rubric_identity(str(t / "nope.jsonl")) == "external:unreadable"
-    assert bj._external_rubric_identity(None) != ia
-
-def test_imported_verdicts_do_not_claim_the_local_rubric():
+def test_imported_verdicts_carry_no_rubric_identity():
     """`--verdicts` imports judgments this scorer did not produce, so the receipt
-    must not stamp them with this checkout's rubric digest. Doing so asserts a
-    provenance that never happened, and makes two imports graded under different
-    external rubrics compare equal because they share this checkout.
+    records None — exactly as `judge_identity` is empty for a run started outside
+    the sweep. Unknown provenance groups with unknown provenance rather than
+    claiming an identity it never resolved.
 
-    The `judge` field beside it has always made this distinction; this is the same
-    rule. Cloud review P1 on #2055, third round of the same class.
+    Five review rounds reached this, and every invented alternative was worse: the
+    local digest CLAIMED a rubric the import never ran under; a constant sentinel
+    made two different external rubrics compare equal; hashing the verdicts file
+    made two arms under the SAME rubric compare different, because verdict files
+    differ by candidate outcome — which broke multi-arm external grading.
+
+    ACCEPTED LIMIT, pinned here so it cannot be forgotten: two imports under
+    genuinely different external rubrics both report None and will rank together.
+    Closing it needs a rubric identifier the verdicts file does not carry.
 
     TWO-WAY: a normal run must still record the real digest, or a fix that always
-    returned the sentinel would pass while destroying the guard it feeds.
+    returned None would pass while disabling the guard entirely.
     """
     src = (Path(__file__).parent / "behavior_judge.py").read_text()
-    i = src.index('"rubric_identity": (')
-    expr = src[i:src.index("),", i) + 2]
+    i = src.index('"rubric_identity":')
+    expr = src[i:src.index("\n", i)]
     assert "external_verdicts is None" in expr, expr
-    assert "_external_rubric_identity(" in expr, expr
+    assert expr.rstrip().endswith("else None,"), expr
     assert "_rubric_identity()" in expr, expr
 
-    # the real digest is a stable 12-hex of this file, not the sentinel
     a = bj._rubric_identity()
-    assert a != "external_verdicts" and len(a) == 12 and a == bj._rubric_identity(), a
+    assert a is not None and len(a) == 12 and a == bj._rubric_identity(), a
+
 
 def test_a_mixed_rubric_is_refused_like_a_mixed_judge():
     """Two arms graded under DIFFERENT rubrics must not be ranked together.
@@ -2410,7 +2389,7 @@ def test_the_billing_check_runs_before_the_availability_check():
 
 # An exact count, because the borrowed runner in cleanup_metrics_test.py returns
 # 0 when it discovers ZERO tests — so "green" would carry no information at all.
-EXPECTED_TESTS = 122
+EXPECTED_TESTS = 121
 
 
 def _run() -> int:

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -894,6 +894,43 @@ def test_a_receipt_from_the_same_judge_is_still_skipped():
     assert "skipped (already judged)" in log, log
 
 
+
+def test_a_mixed_rubric_is_refused_like_a_mixed_judge():
+    """Two arms graded under DIFFERENT rubrics must not be ranked together.
+
+    `judge_identity` answers who graded it; `rubric_identity` answers against what
+    bar. Both change what a score MEANS. The resume stamp cannot cover this: an
+    interrupted sweep leaves some arms re-graded and some not, and this report
+    compares receipts and never reads that sidecar (cloud review P1 on #2055).
+
+    TWO-WAY. Without the matching half, a guard that refused EVERY run would pass
+    the refusal case while making the report permanently unusable.
+    """
+    def tree_with_two(rubric_a, rubric_b):
+        t = report_tree(healthy_receipt(meta={
+            "judge": "azure/j", "judge_identity": "azure/j@aaa",
+            "judge_model_version": "v1", "rubric_identity": rubric_a}))
+        b = t / "judged" / "modelB"
+        b.mkdir(parents=True)
+        (b / "summary.json").write_text(json.dumps(healthy_receipt(meta={
+            "judge": "azure/j", "judge_identity": "azure/j@aaa",
+            "judge_model_version": "v1", "rubric_identity": rubric_b})))
+        (b / "per_case.jsonl").write_text(
+            (t / "judged" / "modelA" / "per_case.jsonl").read_text())
+        run = json.loads((t / "run-summary.json").read_text())
+        m = dict(run["models"][0]); m["model"] = "modelB"
+        m["candidates"] = str(t / "cand" / "modelB.jsonl")
+        run["models"].append(m)
+        (t / "run-summary.json").write_text(json.dumps(run))
+        return t
+
+    rc, log = run_report(tree_with_two("RUBRIC_ONE", "RUBRIC_TWO"))
+    assert "mixes judges or rubrics" in log, f"a mixed rubric was ranked anyway:\n{log}"
+    assert rc != 0, log
+
+    rc, log = run_report(tree_with_two("RUBRIC_ONE", "RUBRIC_ONE"))
+    assert "mixes judges or rubrics" not in log, f"one rubric was refused:\n{log}"
+
 def test_the_stamp_the_script_writes_depends_on_the_judge():
     # Reads the stamp the REAL script wrote, not one this file computed: a fixture-only
     # comparison would verify forge_stamp and pass even with the script's stamp
@@ -2320,7 +2357,7 @@ def test_the_billing_check_runs_before_the_availability_check():
 
 # An exact count, because the borrowed runner in cleanup_metrics_test.py returns
 # 0 when it discovers ZERO tests — so "green" would carry no information at all.
-EXPECTED_TESTS = 119
+EXPECTED_TESTS = 120
 
 
 def _run() -> int:

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -895,6 +895,30 @@ def test_a_receipt_from_the_same_judge_is_still_skipped():
 
 
 
+
+def test_imported_verdicts_do_not_claim_the_local_rubric():
+    """`--verdicts` imports judgments this scorer did not produce, so the receipt
+    must not stamp them with this checkout's rubric digest. Doing so asserts a
+    provenance that never happened, and makes two imports graded under different
+    external rubrics compare equal because they share this checkout.
+
+    The `judge` field beside it has always made this distinction; this is the same
+    rule. Cloud review P1 on #2055, third round of the same class.
+
+    TWO-WAY: a normal run must still record the real digest, or a fix that always
+    returned the sentinel would pass while destroying the guard it feeds.
+    """
+    src = (Path(__file__).parent / "behavior_judge.py").read_text()
+    i = src.index('"rubric_identity": (')
+    expr = src[i:src.index("),", i) + 2]
+    assert "external_verdicts is None" in expr, expr
+    assert '"external_verdicts"' in expr, expr
+    assert "_rubric_identity()" in expr, expr
+
+    # the real digest is a stable 12-hex of this file, not the sentinel
+    a = bj._rubric_identity()
+    assert a != "external_verdicts" and len(a) == 12 and a == bj._rubric_identity(), a
+
 def test_a_mixed_rubric_is_refused_like_a_mixed_judge():
     """Two arms graded under DIFFERENT rubrics must not be ranked together.
 
@@ -2357,7 +2381,7 @@ def test_the_billing_check_runs_before_the_availability_check():
 
 # An exact count, because the borrowed runner in cleanup_metrics_test.py returns
 # 0 when it discovers ZERO tests — so "green" would carry no information at all.
-EXPECTED_TESTS = 120
+EXPECTED_TESTS = 121
 
 
 def _run() -> int:

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -896,6 +896,35 @@ def test_a_receipt_from_the_same_judge_is_still_skipped():
 
 
 
+
+def test_two_external_rubrics_get_two_identities():
+    """A provenance field must be DERIVED from what it describes, never a constant.
+
+    A bare "external_verdicts" sentinel gave every import one shared identity, so
+    two verdict files graded under DIFFERENT external rubrics compared equal and
+    the report ranked them together — the same false claim as stamping the local
+    digest, pointing the other way. Cloud review P1 x4 on #2055.
+
+    THREE-WAY: different files must differ, identical CONTENT must match (the
+    identity is the bytes, not the path), and neither may collide with the local
+    digest.
+    """
+    t = Path(tempfile.mkdtemp())
+    a = t / "a.jsonl"; a.write_text('{"id":"A","verdict":"pass"}\n')
+    b = t / "b.jsonl"; b.write_text('{"id":"A","verdict":"critical_fail"}\n')
+    c = t / "c.jsonl"; c.write_text(a.read_text())          # same bytes, other path
+
+    ia, ib, ic = (bj._external_rubric_identity(str(x)) for x in (a, b, c))
+    assert ia != ib, f"two different verdict files share an identity: {ia}"
+    assert ia == ic, f"identical verdicts got different identities: {ia} vs {ic}"
+    assert ia != bj._rubric_identity(), "an import claimed the local rubric"
+    assert ia.startswith("external:"), ia
+
+    # missing and unreadable group with their own kind, not with real imports
+    assert bj._external_rubric_identity(None) == "external:unknown"
+    assert bj._external_rubric_identity(str(t / "nope.jsonl")) == "external:unreadable"
+    assert bj._external_rubric_identity(None) != ia
+
 def test_imported_verdicts_do_not_claim_the_local_rubric():
     """`--verdicts` imports judgments this scorer did not produce, so the receipt
     must not stamp them with this checkout's rubric digest. Doing so asserts a
@@ -912,7 +941,7 @@ def test_imported_verdicts_do_not_claim_the_local_rubric():
     i = src.index('"rubric_identity": (')
     expr = src[i:src.index("),", i) + 2]
     assert "external_verdicts is None" in expr, expr
-    assert '"external_verdicts"' in expr, expr
+    assert "_external_rubric_identity(" in expr, expr
     assert "_rubric_identity()" in expr, expr
 
     # the real digest is a stable 12-hex of this file, not the sentinel
@@ -2381,7 +2410,7 @@ def test_the_billing_check_runs_before_the_availability_check():
 
 # An exact count, because the borrowed runner in cleanup_metrics_test.py returns
 # 0 when it discovers ZERO tests — so "green" would carry no information at all.
-EXPECTED_TESTS = 121
+EXPECTED_TESTS = 122
 
 
 def _run() -> int:

--- a/scripts/eval/judge_ollama_bench.sh
+++ b/scripts/eval/judge_ollama_bench.sh
@@ -222,8 +222,20 @@ for cand in "$CANDDIR"/*.jsonl; do
   # Consequence, and it is intended: changing the judge invalidates every stamp and
   # the next sweep re-grades the full field. That is the only way a comparison stays
   # a comparison, and it is affordable precisely because the new judge is cheap.
+  # The RUBRIC belongs in this key for exactly the reason the judge does. Changing
+  # what the scorer will ACCEPT changes what a score means, so a receipt graded
+  # under the old rubric is not comparable with one graded under the new one — and
+  # without the scorer in the hash, a matching stamp silently serves the stale
+  # score. Found by cloud review on PR #2055, which added per-behaviour
+  # `allowed_variants` and would have been masked by every existing stamp.
+  #
+  # Hashing the WHOLE scorer over-invalidates: a comment fix re-grades the field.
+  # That is the correct direction to fail. Under-invalidating produces a number
+  # that looks like a comparison and is not one, which is undetectable afterwards,
+  # and re-grading is affordable on the current judge.
   inputs_sha="$(
-    { printf 'judge=%s\n' "$JUDGE_IDENTITY"; sha256 "$cand" "$CORPUS"; } | sha256 | cut -d' ' -f1
+    { printf 'judge=%s\n' "$JUDGE_IDENTITY"
+      sha256 "$cand" "$CORPUS" "$ROOT/scripts/eval/behavior_judge.py"; } | sha256 | cut -d' ' -f1
   )"
   if [ -f "$dest/summary.json" ]; then
     # Cacheability is checked HERE too, not only after judging. A matching stamp

--- a/scripts/eval/report_ollama_bench.py
+++ b/scripts/eval/report_ollama_bench.py
@@ -381,6 +381,9 @@ def main() -> int:
             "from_receipt": True,
             "judge": receipt_meta.get("judge"),
             "judge_identity": receipt_meta.get("judge_identity"),
+            # WHICH RUBRIC graded this arm. Without it on the row, the mixing guard
+            # below reads a field nobody sets and can never fire.
+            "rubric_identity": receipt_meta.get("rubric_identity"),
             "judge_model_version": receipt_meta.get("judge_model_version"),
             "isRemote": sp["isRemote"],
             "thinks": sp["thinks"],
@@ -431,7 +434,7 @@ def main() -> int:
         # the same failure the outer `meta` shape check was added to prevent, one level in.
         # Shape-checking a container and then trusting its contents is half a check.
         key = []
-        for field in ("judge", "judge_identity", "judge_model_version"):
+        for field in ("judge", "judge_identity", "judge_model_version", "rubric_identity"):
             value = row.get(field)
             if value is not None and not isinstance(value, str):
                 problems.append(
@@ -444,11 +447,12 @@ def main() -> int:
         detail = "; ".join(
             f"{j[1] or j[0]}"
             + (f" serving {j[2]}" if j[2] else "")
+            + (f" under rubric {j[3]}" if len(j) > 3 and j[3] else "")
             + f": {', '.join(sorted(m for m in models if m))}"
             for j, models in sorted(judges.items(), key=lambda kv: str(kv)))
         problems.append(
-            "this run mixes judges, so the ranking would not be a comparison — "
-            f"{detail}. Re-grade every arm with one judge.")
+            "this run mixes judges or rubrics, so the ranking would not be a "
+            f"comparison — {detail}. Re-grade every arm with one judge and one rubric.")
 
     if problems:
         print("FAIL: incomplete receipts:\n  " + "\n  ".join(problems), file=sys.stderr)


### PR DESCRIPTION
## What

Adds `BEHAVIOR_ALLOWED_VARIANTS` to `behavior_judge.py`, a per-behaviour
extension to the existing global `allowed_variants` list. Two buckets get an
entry: `grammar_fix` and `topic_shift`.

## Why

The system prompt already tells the judge that `reference_output` is "an
ILLUSTRATIVE reference, NOT exact ground truth" and forbids grading by similarity
to it. But `allowed_variants` was a single global list of four **cosmetic** items
(bullet vs numbered list, and similar). On a case where the transcript admits two
genuinely correct repairs, nothing licensed the second one, so the judge fell back
to the reference — exactly what the prompt forbids.

Measured 2026-08-12: `reference_overfit` is a defined failure type that had
**never been emitted once across 6,760 gradings**, while `grammar_fix` sat at 57%
with roughly a third of its failures being alternative valid repairs.

Examples the judge should accept either way:
- `grammar_fix` — "the updated figures is ready" is fixed by pluralising the verb
  OR making the noun singular.
- `topic_shift` — a blank line, a single line break, or clear sentence separation
  all make the boundary visible.

## Corroboration from a separate line of work

The Speechpath rebuild the same week measured the same effect from the other
direction: a judge that **cannot see the reference at all** scores identical model
outputs **25 points higher**, and an independent audit of 65 failures found 60%
were too harsh, dominated by formatting and layout disagreements. That work is
recorded in `polish-eval.md` FACT:
`speechpath-harness-and-measured-punctuation-survival`.

This PR is the narrow fix inside the existing scorer; Speechpath is the separate
rebuilt harness and is gitignored.

## Scope

`allowed_variants_for()` returns the global list plus the behaviour's own. It
loosens only **which correct answer is accepted**. Meaning, entity and content
checks are untouched — a repair that changes what the speaker said still fails,
and the automatic S4 rules are unchanged.

## Blast radius

None to shipped code. `behavior_judge.py` is a run-on-demand local scorer over the
private Type B corpus. **It is not the CI gate** — `acceptance_gate.py` over
`ci_corpus.jsonl` is the CI gate and is untouched by this diff.

Comparability note: scores produced before and after this change are not directly
comparable for `grammar_fix` and `topic_shift`, because the rubric moved. Any
comparison spanning it needs a re-grade of both arms.

## Verification

- `python3 scripts/eval/behavior_judge_test.py` — **119 passed, 0 failed**.
- `grep` confirms 3 definition sites, 1 call site, no other consumer.

Eval-harness lane. `council-skip: zero-blast-radius (single-value config)` — one
additive dict plus a two-line accessor, no new control flow, no shipped path.
