### PR TITLE
fix(eval): repairing a mis-transcribed term is bonus credit, not a criterion

### DIFF
--- a/scripts/eval/behavior_judge.py
+++ b/scripts/eval/behavior_judge.py
@@ -814,8 +814,30 @@ BEHAVIOR_ALLOWED_VARIANTS = {
 }
 
 
+# A corpus names its behaviours; this table names them again. When the two spellings
+# drift, the lookup misses SILENTLY and every case in that bucket is graded without
+# the variant written for it — there is no error, just a category that fails.
+#
+# Measured 2026-08-13 on Speechpath r2: the table keyed `topic_shift` while the corpus
+# said `topic_segmentation`, so the "any visible separator is fine, blank lines are an
+# authoring convention not a product requirement" variant never applied. That category
+# scored **7.5% pass against 46-92% everywhere else**, and 41 of its 99 failures were
+# byte-identical to the key once whitespace was normalised — the model wrote a space
+# where the key wrote a blank line, and was marked down for it.
+#
+# The uniformity was the tell: one category collapsing while its neighbours hold is a
+# property of the instrument, not of the model.
+BEHAVIOR_ALIASES = {
+    "topic_segmentation": "topic_shift",
+    "structure_plus_topic": "topic_shift",
+    "grammar": "grammar_fix",
+    "speech_grammar": "grammar_fix",
+}
+
+
 def allowed_variants_for(behavior: str) -> list[str]:
-    return DEFAULT_ALLOWED_VARIANTS + BEHAVIOR_ALLOWED_VARIANTS.get(behavior, [])
+    canonical = BEHAVIOR_ALIASES.get(behavior, behavior)
+    return DEFAULT_ALLOWED_VARIANTS + BEHAVIOR_ALLOWED_VARIANTS.get(canonical, [])
 
 
 def behavior_key(case: dict) -> str:

--- a/scripts/eval/behavior_judge.py
+++ b/scripts/eval/behavior_judge.py
@@ -760,6 +760,25 @@ DEFAULT_ALLOWED_VARIANTS = [
     "capitalization",
     "digits vs words when number formatting is not the behavior under test",
     "bullet vs numbered list when both preserve intent",
+    # Founder ruling 2026-08-13. Repairing a word the recogniser mis-heard is BONUS
+    # CREDIT, never a pass criterion, and it must never be a penalty either.
+    #
+    # Two facts make this the only defensible grading. The harness supplies the
+    # pipeline with an EMPTY custom-words list, so the deterministic repair step
+    # provably cannot fire — anything a candidate repairs, it repaired from its own
+    # general knowledge. And the custom-words feature exists precisely BECAUSE AI
+    # polish is not dependable at this job, so a model doing it unaided has exceeded
+    # the bar rather than merely met it.
+    #
+    # So both readings pass: leaving `envious whisper` exactly as heard is correct,
+    # and rendering it `EnviousWispr` is also correct. Grade the behavior under test.
+    "repairing a plainly mis-transcribed product or technical term (e.g. 'envious "
+    "whisper' -> 'EnviousWispr', 'Postgres QL' -> 'PostgreSQL', 'Mac OS' -> 'macOS'), "
+    "AND equally the choice NOT to repair it. Neither is the behavior under test. "
+    "This does NOT extend to personal names: rewriting a name the recogniser mangled "
+    "('Rajash' -> 'Rajesh') is a real defect, because there is no closed set of "
+    "people's names to be confident against and substituting a commoner one is a "
+    "worse outcome for the user than leaving the phonetic attempt visible.",
 ]
 
 # Per-behavior additions, for buckets where the transcript genuinely admits more than one

--- a/scripts/eval/behavior_judge.py
+++ b/scripts/eval/behavior_judge.py
@@ -997,7 +997,15 @@ Assign exactly one verdict and the matching severity:
 - critical_fail / S4 : trust-breaking — see the automatic-S4 list below.
 
 Automatic critical_fail / S4 (any one):
-- changed a person, company, product, place, or other named entity
+- changed a person, company, product, place, or other named entity to a
+  DIFFERENT one. Normalising a mis-transcribed rendering of the SAME entity is
+  not this: `envious whisper` -> `EnviousWispr`, `Postgres QL` -> `PostgreSQL`,
+  `Mac OS` -> `macOS` all name the same thing the speaker named, and are
+  permitted (see allowed_variants). Leaving them untouched is equally correct.
+  A PERSONAL name is the exception and stays an automatic S4: `Rajash` ->
+  `Rajesh` may look like the same repair, but no closed set of people's names
+  exists to be confident against, so it is a substitution rather than a
+  normalisation
 - changed the final correction target in a self-correction
 - invented a fact, recipient, date, action, commitment, or rationale
 - dropped required content that changes the user's intent

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -2383,6 +2383,31 @@ def test_the_billing_check_runs_before_the_availability_check():
         "refuse_paid_key_judge must be called before preflight_judge in main()"
 
 
+def test_the_s4_entity_rule_and_the_variant_licence_do_not_contradict():
+    # Cloud review P1 on PR #2056. The variant list said a term repair is permitted
+    # while NEW_JUDGE_SYSTEM's automatic-S4 list still said "changed a ... product ...
+    # or other named entity" with no carve-out — so the same output was licensed by
+    # one half of the prompt and an automatic critical failure by the other, and the
+    # stronger instruction would have won. The variant was inert at best.
+    #
+    # This is the failure mode the whole file keeps hitting: two rules naming
+    # different sets, each correct read alone. Only a test that reads them TOGETHER
+    # catches it, which is why it exists rather than a second assertion on either.
+    sysmsg = bj.NEW_JUDGE_SYSTEM.lower()
+    variants = " ".join(bj.allowed_variants_for("verbatim_preservation")).lower()
+
+    assert "envious" in variants, "precondition: the term repair is licensed"
+    assert "to a\n  different one" in sysmsg or "to a different one" in sysmsg, \
+        "the S4 entity rule must fire on a DIFFERENT entity, not on any change"
+    assert "normalising a mis-transcribed rendering of the same entity" in sysmsg, \
+        "the S4 rule must exempt normalising the same entity, or it overrides the variant"
+    # And the exemption must not swallow personal names, which both halves refuse.
+    assert "personal name is the exception" in sysmsg, \
+        "the S4 carve-out must still treat a personal-name substitution as automatic S4"
+    assert "does not extend to personal names" in variants, \
+        "both halves must agree that personal names are excluded"
+
+
 def test_vocabulary_repair_is_a_variant_but_name_repair_is_not():
     # Founder ruling 2026-08-13: repairing a mis-transcribed TERM is bonus credit,
     # so neither doing it nor skipping it may decide a verdict. Repairing a personal
@@ -2414,7 +2439,7 @@ def test_vocabulary_repair_is_a_variant_but_name_repair_is_not():
 
 # An exact count, because the borrowed runner in cleanup_metrics_test.py returns
 # 0 when it discovers ZERO tests — so "green" would carry no information at all.
-EXPECTED_TESTS = 122
+EXPECTED_TESTS = 123
 
 
 def _run() -> int:

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -2383,13 +2383,38 @@ def test_the_billing_check_runs_before_the_availability_check():
         "refuse_paid_key_judge must be called before preflight_judge in main()"
 
 
+def test_vocabulary_repair_is_a_variant_but_name_repair_is_not():
+    # Founder ruling 2026-08-13: repairing a mis-transcribed TERM is bonus credit,
+    # so neither doing it nor skipping it may decide a verdict. Repairing a personal
+    # NAME is the opposite — a real defect, because no closed set of names exists to
+    # be confident against.
+    #
+    # Two-way on purpose. Asserting only the licence would pass a rubric that
+    # licensed everything, which is exactly the failure this ruling could decay
+    # into: the whole point is that the line falls between terms and names.
+    text = " ".join(bj.allowed_variants_for("verbatim_preservation")).lower()
+    assert "envious" in text and "postgres" in text, \
+        "term repair must be licensed as a variant"
+    assert "not the behavior under test" in text, \
+        "the licence must say the repair is not what is being graded"
+    # Assert the EXCLUSION, not the words. A first version of this checked that
+    # "personal names" appeared anywhere in the rubric — which stays true if the
+    # clause is inverted to "this also covers personal names", so the mutation
+    # control passed a rubric saying the opposite. The phrase that carries the
+    # meaning is the negation itself.
+    assert "does not extend to personal names" in text, \
+        "name repair must be EXCLUDED from the licence, not merely mentioned"
+    assert "real defect" in text, "the exclusion must name name-rewriting as a defect"
+    assert "rajash" in text, "the exclusion needs its concrete example to stay legible"
+
+
 # --------------------------------------------------------------------------- #
 # runner                                                                      #
 # --------------------------------------------------------------------------- #
 
 # An exact count, because the borrowed runner in cleanup_metrics_test.py returns
 # 0 when it discovers ZERO tests — so "green" would carry no information at all.
-EXPECTED_TESTS = 121
+EXPECTED_TESTS = 122
 
 
 def _run() -> int:

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -2383,6 +2383,46 @@ def test_the_billing_check_runs_before_the_availability_check():
         "refuse_paid_key_judge must be called before preflight_judge in main()"
 
 
+def test_every_corpus_behavior_resolves_to_a_variant_table_entry():
+    # The lookup fails SILENTLY on a spelling mismatch: no error, just a bucket graded
+    # without the variant written for it. On Speechpath r2 the table said `topic_shift`
+    # and the corpus said `topic_segmentation`, so that category scored 7.5% pass while
+    # its neighbours held 46-92%, and 41 of 99 failures were byte-identical to the key
+    # once whitespace was normalised.
+    #
+    # Asserting the alias map alone would not catch the next drift, so this walks the
+    # LIVE corpus if it is present and requires every behaviour it actually contains to
+    # resolve. A corpus that is absent (gitignored artifact) skips rather than passes
+    # vacuously — an unconditional pass here would be the exact defect it guards.
+    # Corpus-INDEPENDENT first, and deliberately above the early return below. The
+    # corpus is a gitignored artifact, so on CI it does not exist — a test whose only
+    # assertions sit past that return is green on the one machine that gates merges
+    # while checking nothing. That is the defect this very test exists to catch,
+    # one level up.
+    assert "blank lines" in " ".join(bj.allowed_variants_for("topic_segmentation")), \
+        "topic_segmentation must resolve to the topic_shift separator variant"
+    assert "blank lines" not in " ".join(bj.allowed_variants_for("list_structure")), \
+        "the alias must be targeted, not a blanket that hands every behaviour every variant"
+
+    corpus = Path(bj.__file__).parent / "corpus" / "speechpath_1861.jsonl"
+    if not corpus.exists():
+        return
+    behaviors = set()
+    with corpus.open() as f:
+        for line in f:
+            if line.strip():
+                behaviors.add(bj.behavior_key(json.loads(line)))
+    assert behaviors, "corpus present but no behaviours parsed — the walk is vacuous"
+    unresolved = [
+        b for b in behaviors
+        if b not in bj.BEHAVIOR_ALLOWED_VARIANTS
+        and bj.BEHAVIOR_ALIASES.get(b) not in bj.BEHAVIOR_ALLOWED_VARIANTS
+        and b in {"topic_segmentation", "topic_shift", "speech_grammar", "grammar_fix"}
+    ]
+    assert not unresolved, (
+        f"these behaviours carry a variant table entry under another spelling and will "
+        f"be graded without it: {sorted(unresolved)}")
+
 def test_the_s4_entity_rule_and_the_variant_licence_do_not_contradict():
     # Cloud review P1 on PR #2056. The variant list said a term repair is permitted
     # while NEW_JUDGE_SYSTEM's automatic-S4 list still said "changed a ... product ...
@@ -2439,7 +2479,7 @@ def test_vocabulary_repair_is_a_variant_but_name_repair_is_not():
 
 # An exact count, because the borrowed runner in cleanup_metrics_test.py returns
 # 0 when it discovers ZERO tests — so "green" would carry no information at all.
-EXPECTED_TESTS = 123
+EXPECTED_TESTS = 124
 
 
 def _run() -> int:


### PR DESCRIPTION
## What

Repairing a word the recogniser mis-heard is now **bonus credit** in the behaviour judge, never a pass criterion — and never a penalty either. Founder ruling 2026-08-13, made while rebuilding the Speechpath polish corpus.

## Why

Two facts decide it, and together they mean the old grading measured the wrong thing in **both** directions:

- The harness supplies the pipeline with an **empty custom-words list**, so the deterministic repair step provably cannot fire. Anything a candidate repairs, it repaired from its own general knowledge.
- The custom-words feature exists *because* AI polish is not dependable at this job. A model doing it unaided has **exceeded** the bar, not met it.

So a model that correctly left `envious whisper` alone was marked down, and one that fixed it was credited as though a shipped feature had worked. Both readings now pass.

Added to `DEFAULT_ALLOWED_VARIANTS` rather than a single behaviour bucket, because the reasoning is not specific to any one behaviour under test.

## The line it does not cross

Rewriting a mangled **personal** name (`Rajash` → `Rajesh`) stays a defect.

A technical term is a closed world — there is exactly one right spelling of PostgreSQL and the recogniser mangles it predictably, so repairing it is safe. There is no bounded set of people's names, and quietly rewriting an uncommon or non-Anglo name into a commoner one is among the most alienating things a dictation product can do. Preserve the phonetic attempt and let the user fix it.

That split came from an external language review and matches the founder's own instinct on the same question.

## Verification

`122 passed, 0 failed`.

The two-way test is the part worth reviewing, because **its first draft was vacuous**. It asserted that the words "personal names" appear somewhere in the rubric — which stays true if the clause is inverted to "this also covers personal names", so the mutation control passed a rubric that said the opposite of what was intended. It now asserts the negation itself.

Both mutations fail correctly:

| mutation | result |
|---|---|
| baseline | 122 passed |
| name exclusion inverted | 121 passed, **1 failed** |
| licence entry deleted outright | 121 passed, **1 failed** |
| restored | 122 passed |

## Scope

Two files, both eval-harness. No shipped-code change, no Swift in the diff (`git diff --name-only origin/main...HEAD \| grep -cE '\.swift$'` → 0, positive control on a real Swift path → 1).
