### PR TITLE
fix(eval): a connection reset is transient, and a name is judged against what was spoken

### DIFF
--- a/scripts/eval/acceptance_gate.py
+++ b/scripts/eval/acceptance_gate.py
@@ -21,6 +21,7 @@ Design refs:
 from __future__ import annotations
 
 import argparse
+import http.client
 import json
 import os
 import random
@@ -310,13 +311,22 @@ def _retryable_http_error(exc: Exception) -> bool:
     """Classify HTTPError responses as transient-retryable. Covers 5xx + 429.
     Returns False for auth/bad-request errors (4xx except 429) which will never
     succeed on retry.
+
+    Everything that is not an HTTPError is transport, and transport is transient.
+    This tests the BASE classes rather than naming `URLError`, because urllib
+    wraps only what `urlopen` itself raises: a reset arriving while the RESPONSE
+    BODY is read propagates as a bare `ConnectionResetError`, which is an OSError
+    and NOT a URLError, so the narrower form answered False for the commonest
+    real failure. Measured in `behavior_judge.py`'s copy of this predicate on
+    2026-08-14 — three chunk drops per run, 24 cases each, across two runs.
+    HTTPError stays first because it subclasses OSError and a 400 must not retry.
     """
     if isinstance(exc, urllib.error.HTTPError):
         return exc.code >= 500 or exc.code == 429
-    if isinstance(exc, urllib.error.URLError):
-        # Network-level (timeouts, DNS hiccup) — retry.
-        return True
-    return False
+    # OSError covers URLError, TimeoutError, every ConnectionError (reset, aborted,
+    # broken pipe, refused), socket.gaierror and ssl.SSLError. HTTPException covers
+    # the http.client family that is not an OSError, e.g. IncompleteRead.
+    return isinstance(exc, (OSError, http.client.HTTPException))
 
 
 def _http_call_with_retry(do_call, attempts: int = 3, base_delay: float = 1.5):

--- a/scripts/eval/acceptance_gate.py
+++ b/scripts/eval/acceptance_gate.py
@@ -307,6 +307,41 @@ def _key(name: str) -> str:
     return p.read_text().strip()
 
 
+class TransientTransportError(Exception):
+    """A network failure raised BY the network operation itself.
+
+    Mirrors behavior_judge.TransientTransportError, deliberately as a separate
+    copy: this file is the CI gate and keeps its own transports for exactly that
+    reason. Both must agree, and the reason both exist is worth stating once
+    here. Cloud review found that `_http_call_with_retry(lambda: polish_one(...))`
+    wraps `_key()`, which does `Path.read_text()` on a credential file -- so a
+    predicate testing bare `OSError` turned an unreadable key into three retries
+    per case across a whole corpus. Auditing every retry scope for stray I/O is a
+    promise; converting at the one place the socket is touched is a property.
+    """
+
+    def __init__(self, cause: Exception):
+        super().__init__(f"{type(cause).__name__}: {cause}")
+        self.cause = cause
+
+
+def _http_json(req, timeout: float):
+    """Perform the request and decode it, converting ONLY transport failures.
+
+    HTTPError passes through so the caller can read its status code; a decode
+    failure passes through because a 200 with an unparsable body is the server's
+    answer, not a network fault.
+    """
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read()
+    except urllib.error.HTTPError:
+        raise
+    except (OSError, http.client.HTTPException) as e:
+        raise TransientTransportError(e) from None
+    return json.loads(raw)
+
+
 def _retryable_http_error(exc: Exception) -> bool:
     """Classify HTTPError responses as transient-retryable. Covers 5xx + 429.
     Returns False for auth/bad-request errors (4xx except 429) which will never
@@ -323,10 +358,11 @@ def _retryable_http_error(exc: Exception) -> bool:
     """
     if isinstance(exc, urllib.error.HTTPError):
         return exc.code >= 500 or exc.code == 429
-    # OSError covers URLError, TimeoutError, every ConnectionError (reset, aborted,
-    # broken pipe, refused), socket.gaierror and ssl.SSLError. HTTPException covers
-    # the http.client family that is not an OSError, e.g. IncompleteRead.
-    return isinstance(exc, (OSError, http.client.HTTPException))
+    # Only what the NETWORK CALL itself raised. A credential read, a file write or
+    # a subprocess spawn anywhere else in the retried scope keeps its own type and
+    # is never retried -- which is the whole point, since `_http_call_with_retry`
+    # wraps `polish_one`, and `polish_one` reads the key file.
+    return isinstance(exc, TransientTransportError)
 
 
 def _http_call_with_retry(do_call, attempts: int = 3, base_delay: float = 1.5):
@@ -367,8 +403,7 @@ def call_openai(model: str, system: str, user: str) -> str:
         headers={"Authorization": f"Bearer {_key('openai-api-key')}", "Content-Type": "application/json"},
         method="POST",
     )
-    with urllib.request.urlopen(req, timeout=300) as resp:
-        data = json.loads(resp.read())
+    data = _http_json(req, 300)
     return data["choices"][0]["message"]["content"].strip()
 
 
@@ -385,8 +420,7 @@ def call_gemini(model: str, system: str, user: str, json_mime: bool = False) -> 
         url, data=json.dumps(body).encode(),
         headers={"Content-Type": "application/json"}, method="POST",
     )
-    with urllib.request.urlopen(req, timeout=300) as resp:
-        data = json.loads(resp.read())
+    data = _http_json(req, 300)
     parts = data["candidates"][0]["content"]["parts"]
     return "".join(p.get("text", "") for p in parts).strip()
 

--- a/scripts/eval/behavior_judge.py
+++ b/scripts/eval/behavior_judge.py
@@ -1014,6 +1014,36 @@ def case_type_of(case: dict, behavior: str) -> str:
     return "positive"
 
 
+def _spoken_truth(case: dict) -> str:
+    """What was ACTUALLY said, across the two corpus schemas that carry it.
+
+    Speechpath (`speechpath_1861.jsonl`, the live corpus) stores it as a top-level
+    `voice_text`. The older `type_b_parakeet.jsonl`, built by
+    `build_refreshed_corpus.py`, stores the pre-ASR text nested at
+    `input_source.original_input` instead. Reading only `voice_text` therefore
+    returned "" for every row of that corpus, and the personal-name rule silently
+    fell through to its empty-truth branch — the rubric change present but inert,
+    which is worse than absent because the receipt looks the same either way.
+
+    Measured on the 1,690-row `type_b_parakeet.jsonl`: `original_input` is
+    populated on 1,458 rows (86.3%); the remaining 13.7% carry an empty value and
+    correctly keep the conservative empty-truth behaviour.
+
+    `input_source` is a dict in that corpus but the type is not guaranteed across
+    older files, so a non-dict is treated as absent rather than raising — this is
+    a grading path, and it must degrade to the safe branch rather than kill a run.
+    """
+    v = case.get("voice_text")
+    if isinstance(v, str) and v.strip():
+        return v
+    src = case.get("input_source")
+    if isinstance(src, dict):
+        v = src.get("original_input")
+        if isinstance(v, str) and v.strip():
+            return v
+    return ""
+
+
 def normalize_case(case: dict) -> dict:
     """corpus case -> normalized judge-input record (behavior-aware system)."""
     behavior = behavior_key(case)
@@ -1051,7 +1081,7 @@ def normalize_case(case: dict) -> dict:
         # (Rajesh->"Rajash", Nadia->"Nodia", Hassan->"Hassen", Noor->"Norr").
         #
         # Empty for corpora that carry no spoken source; the prompt handles absence.
-        "spoken_truth": case.get("voice_text", ""),
+        "spoken_truth": _spoken_truth(case),
         "notes": case.get("notes", ""),
     }
 

--- a/scripts/eval/behavior_judge.py
+++ b/scripts/eval/behavior_judge.py
@@ -58,6 +58,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import http.client
 import json
 import os
 import random
@@ -166,9 +167,39 @@ def _key(name: str) -> str:
 
 
 def _retryable_http_error(exc: Exception) -> bool:
+    """True when `exc` is a transient transport failure worth another attempt.
+
+    HTTPError is tested FIRST and is the only branch that can answer False for an
+    OSError, because `HTTPError` subclasses `URLError` subclasses `OSError`: a 400
+    or a 401 is the server's considered answer and retrying it just burns credits.
+
+    Everything below that is transport, and transport is transient. Catch the BASE
+    classes rather than a list of names. The list this replaces --
+    `(urllib.error.URLError, TimeoutError)` -- looked complete and missed six real
+    failure modes, because urllib wraps only what `urlopen` itself raises. A reset
+    arriving while the RESPONSE BODY is being read propagates as a bare
+    `ConnectionResetError`, which is an OSError but not a URLError, so it fell
+    through to FATAL.
+
+    Measured cost of that gap on 2026-08-14: two 1,861-case grading runs each logged
+    exactly three `FATAL on chunk (attempt 1): [Errno 54] Connection reset by peer`
+    and each dropped exactly 24 cases (3 chunks x chunk_size 8). The dropped IDs had
+    ZERO overlap between the two runs, which is what rules out a content trigger and
+    identifies it as transport. Both runs were correctly reported INCOMPLETE by
+    `reconcile_judge_batch`, so nothing wrong was ever published -- the accounting
+    layer did its job. This fixes the layer that manufactured the gap, and
+    deliberately does not touch the one that reports it.
+
+    Verified against constructed instances rather than reasoned about; the two-way
+    control lives in `behavior_judge_test.py::test_transport_resets_are_retryable_
+    but_client_errors_are_not`.
+    """
     if isinstance(exc, urllib.error.HTTPError):
         return exc.code == 429 or 500 <= exc.code < 600
-    return isinstance(exc, (urllib.error.URLError, TimeoutError))
+    # OSError covers URLError, TimeoutError, every ConnectionError (reset, aborted,
+    # broken pipe, refused), socket.gaierror and ssl.SSLError. HTTPException covers
+    # the http.client family that is NOT an OSError, e.g. IncompleteRead.
+    return isinstance(exc, (OSError, http.client.HTTPException))
 
 
 # `call_openai` and `call_gemini` are DELETED, not merely unrouted (founder 2026-08-11,
@@ -612,16 +643,42 @@ def parse_judge_array(raw: str) -> list[dict[str, Any]]:
     return parsed if isinstance(parsed, list) else []
 
 
+JUDGE_CHUNK_ATTEMPTS = 5
+
+
+def _judge_retry_delay(attempt: int) -> float:
+    """Capped exponential backoff with jitter.
+
+    Jitter is not decoration here: every worker shares one deployment, so a
+    rate-limit window knocks several chunks down at the same instant, and a
+    deterministic `2 * attempt` marches them all back in lockstep to collide
+    again. Capped at 30s so five attempts span roughly a minute rather than
+    stalling a run that is otherwise healthy.
+    """
+    return min(2.0 ** attempt, 30.0) + random.uniform(0.0, 1.5)
+
+
 def judge_chunk(model: str, system: str, payload_cases: list[dict], attempt: int = 1) -> list[dict]:
-    """One judge call over a chunk. Retries on transient/parse error (3 attempts)."""
+    """One judge call over a chunk. Retries on transient transport/parse error.
+
+    Returning `[]` here does not corrupt anything: `reconcile_judge_batch` counts
+    every requested id and the receipt's `run_complete` gate fails the run. The
+    cost of landing here is a whole re-run, which is why the retry budget is
+    generous rather than minimal.
+    """
     user = "Score these cases. Return ONLY the JSON array.\n" + json.dumps(payload_cases, ensure_ascii=False)
     try:
         return parse_judge_array(dispatch_judge(model, system, user))
     except Exception as e:
-        if attempt < 3 and (_retryable_http_error(e) or isinstance(e, (json.JSONDecodeError, RuntimeError))):
-            time.sleep(2 * attempt)
+        if (attempt < JUDGE_CHUNK_ATTEMPTS
+                and (_retryable_http_error(e)
+                     or isinstance(e, (json.JSONDecodeError, RuntimeError)))):
+            print(f"[judge] transient on chunk (attempt {attempt}/"
+                  f"{JUDGE_CHUNK_ATTEMPTS}), retrying: {e}", file=sys.stderr)
+            time.sleep(_judge_retry_delay(attempt))
             return judge_chunk(model, system, payload_cases, attempt + 1)
-        print(f"[judge] FATAL on chunk (attempt {attempt}): {e}", file=sys.stderr)
+        print(f"[judge] FATAL on chunk (attempt {attempt}): {type(e).__name__}: {e}",
+              file=sys.stderr)
         return []
 
 

--- a/scripts/eval/behavior_judge.py
+++ b/scripts/eval/behavior_judge.py
@@ -182,6 +182,45 @@ def _key(name: str) -> str:
     return p.read_text().strip()
 
 
+class TransientTransportError(Exception):
+    """A network failure raised BY the network operation itself.
+
+    Exists to make the retry predicate's scope structural instead of a promise.
+    The predicate used to test `OSError`, which is correct for a socket and wrong
+    for everything else that can appear in the same `try`: cloud review found
+    three separate instances in this change set -- a local WAV write, a
+    subprocess spawn for a missing CLI, and a credential file read -- where a
+    permanent local failure would have been answered with another paid request.
+
+    Auditing each retry scope for stray I/O is a promise that has to be re-made
+    every time someone adds a line. Converting at the ONE place the network is
+    touched is a property: anything else in the scope raises its own type and is
+    never retried, by construction.
+    """
+
+    def __init__(self, cause: Exception):
+        super().__init__(f"{type(cause).__name__}: {cause}")
+        self.cause = cause
+
+
+def _http_json(opener, req, timeout: float):
+    """Perform the request and decode it, converting ONLY transport failures.
+
+    `HTTPError` is deliberately re-raised untouched: it carries a status code and
+    the caller decides 429/5xx-retryable from that. A JSON decode failure is also
+    left alone -- a 200 with an unparsable body is the server's answer, and the
+    callers that want to retry it already test `json.JSONDecodeError` explicitly.
+    """
+    try:
+        with opener.open(req, timeout=timeout) as resp:
+            raw = resp.read()
+    except urllib.error.HTTPError:
+        raise
+    except (OSError, http.client.HTTPException) as e:
+        raise TransientTransportError(e) from None
+    return json.loads(raw)
+
+
 class JudgeUnavailableError(Exception):
     """The judge transport cannot work at all, and no number of attempts changes
     that: a missing or unexecutable CLI, a route with no funded transport.
@@ -223,10 +262,11 @@ def _retryable_http_error(exc: Exception) -> bool:
     """
     if isinstance(exc, urllib.error.HTTPError):
         return exc.code == 429 or 500 <= exc.code < 600
-    # OSError covers URLError, TimeoutError, every ConnectionError (reset, aborted,
-    # broken pipe, refused), socket.gaierror and ssl.SSLError. HTTPException covers
-    # the http.client family that is NOT an OSError, e.g. IncompleteRead.
-    return isinstance(exc, (OSError, http.client.HTTPException))
+    # Only what the NETWORK CALL itself raised. `_http_json` converts OSError and
+    # http.client.HTTPException at the socket, so a file read, a file write or a
+    # subprocess spawn elsewhere in the same `try` keeps its own type and is not
+    # retried. Testing bare OSError here is what made all three of those retryable.
+    return isinstance(exc, TransientTransportError)
 
 
 # `call_openai` and `call_gemini` are DELETED, not merely unrouted (founder 2026-08-11,
@@ -267,12 +307,12 @@ def call_claude(model: str, system: str, user: str) -> str:
     except subprocess.TimeoutExpired:
         raise RuntimeError("claude judge: CLI timed out after 300s")
     except OSError as e:
-        # A spawn failure (`claude` not on PATH, not executable) is an OSError,
-        # and `_retryable_http_error` answers True for every OSError because in
-        # an HTTP call site that means transport. Here it does not: the CLI will
-        # be just as missing on the fifth attempt, so this must NOT be retried.
-        # Raised as its own type rather than RuntimeError, which judge_chunk
-        # deliberately does retry.
+        # A spawn failure (`claude` not on PATH, not executable) is an OSError.
+        # Since `_retryable_http_error` now only accepts TransientTransportError,
+        # a bare OSError is already non-retryable -- but it would surface as an
+        # opaque FileNotFoundError with no guidance. This converts it into a
+        # named, actionable error instead. RuntimeError is deliberately NOT used:
+        # judge_chunk retries that one.
         raise JudgeUnavailableError(
             f"claude judge: cannot start the CLI ({type(e).__name__}: {e}). "
             f"This is permanent — install/authenticate the CLI or pick another "
@@ -385,8 +425,7 @@ def call_azure(deployment: str, system: str, user: str) -> str:
         headers={"api-key": _key("azure-openai-key"), "Content-Type": "application/json"},
         method="POST",
     )
-    with _no_redirect_opener().open(req, timeout=300) as resp:
-        data = json.loads(resp.read())
+    data = _http_json(_no_redirect_opener(), req, 300)
     choices = data.get("choices") or []
     if not choices:
         raise RuntimeError(f"azure judge: no choices in response: {str(data)[:200]}")
@@ -532,8 +571,7 @@ def _azure_served_model(deployment: str) -> str:
         headers={"api-key": _key("azure-openai-key"), "Content-Type": "application/json"},
         method="POST",
     )
-    with _no_redirect_opener().open(req, timeout=60) as resp:
-        data = json.loads(resp.read())
+    data = _http_json(_no_redirect_opener(), req, 60)
     served = data.get("model")
     if not isinstance(served, str) or not served.strip():
         # Fail rather than fall back to a version-blind identity: a blind identity silently

--- a/scripts/eval/behavior_judge.py
+++ b/scripts/eval/behavior_judge.py
@@ -109,13 +109,29 @@ DEFAULT_JUDGE = os.environ.get("EW_JUDGE", AZURE_JUDGE_DEPLOYMENT_ID)
 CLAUDE_JUDGE_MAX_WORKERS = 6            # subprocess per call; cap fan-out. Raised
 # from 3 (#1199 speed pass, 2026-06-30), then 20 -> 32 (founder 2026-07-02:
 # faster judging: no metered cost on the subscription judge, only a transient
-# rate-limit risk that judge_chunk's 3-attempt retry absorbs). Lowered back to
+# rate-limit risk that judge_chunk's retry absorbs — JUDGE_CHUNK_ATTEMPTS, 5
+# since 2026-08-15; this said "3-attempt" and went stale the moment that moved,
+# which is why it now names the constant instead of a number). Lowered back to
 # 6 (founder 2026-07-20): 32 concurrent `claude -p` subprocesses (each
 # spawning ripgrep) pushed system load average past 40 while other work was
 # running on the same machine, echoing the load-234 incident in
 # eg1-operations.md. 6 stays well clear of that while judging 1,890 cases in
 # roughly 25 minutes.
-HTTP_JUDGE_MAX_WORKERS = 4
+# Raised 4 -> 12 (founder 2026-08-14: "if it's a cloud grader, why so slow"). The 4 was
+# never justified for this transport -- it sat beside the CLAUDE cap's rationale, which is
+# about local subprocess load (32 concurrent `claude -p` each spawning ripgrep pushed load
+# past 40). An HTTPS request to Azure spawns nothing and costs no local CPU, so that
+# reasoning does not transfer and the cap was inherited rather than measured.
+#
+# The real ceiling is the deployment's rate limit, and exceeding it is SAFE here: Azure
+# answers 429, `_retryable_http_error` marks it retryable, and `judge_chunk` retries with
+# backoff. So the failure mode of too-high is slower-but-correct, not wrong results --
+# which is why this can be raised without risking the grade.
+#
+# Measured before the change: 1,861 cases = 233 chunks at ~19s per chunk, 4 at a time,
+# ~25 min. Override per run with EW_JUDGE_WORKERS to find the deployment's real ceiling
+# without editing code.
+HTTP_JUDGE_MAX_WORKERS = int(os.environ.get("EW_JUDGE_WORKERS", "12"))
 DEFAULT_REPLICATIONS = 2              # old-system judge instability net (no temperature knob on CLI)
 DEFAULT_ADJUDICATE_PCT = 0.15          # new-system: fraction of pass/minor/soft_fail
 DEFAULT_ADJUDICATE_MIN = 15            # cases re-judged as a calibration sample
@@ -831,11 +847,22 @@ DEFAULT_ALLOWED_VARIANTS = [
     # and rendering it `EnviousWispr` is also correct. Grade the behavior under test.
     "repairing a plainly mis-transcribed product or technical term (e.g. 'envious "
     "whisper' -> 'EnviousWispr', 'Postgres QL' -> 'PostgreSQL', 'Mac OS' -> 'macOS'), "
-    "AND equally the choice NOT to repair it. Neither is the behavior under test. "
-    "This does NOT extend to personal names: rewriting a name the recogniser mangled "
-    "('Rajash' -> 'Rajesh') is a real defect, because there is no closed set of "
-    "people's names to be confident against and substituting a commoner one is a "
-    "worse outcome for the user than leaving the phonetic attempt visible.",
+    "AND equally the choice NOT to repair it. Neither is the behavior under test.",
+    # Personal names, split by WHETHER THE RENDERING IS RIGHT rather than by whether it
+    # differs from raw_transcript. The old rule said any rewrite of a mangled name was a
+    # defect, on the reasoning that there is no closed set of names to be confident
+    # against. True for a shipping app; false for a graded benchmark, where
+    # `spoken_truth` records the name that was actually said. Under the old rule a
+    # system whose recogniser heard the name CORRECTLY was marked down for it -- 22
+    # measured cases (Rajesh, Nadia, Hassan, Noor, Tomas).
+    "a personal name that matches spoken_truth is CORRECT, whatever raw_transcript "
+    "said. Do not penalise it, and do not treat it as an entity change.",
+    "a personal name matching NEITHER spoken_truth NOR raw_transcript is a real "
+    "entity_mutation defect ('Elena' -> 'Alaina', 'Fatima' -> 'Fautima'): the system "
+    "substituted a different person. Leaving raw_transcript's phonetic attempt "
+    "untouched is also acceptable, since repairing a name unaided is bonus credit, "
+    "never a pass criterion. Where spoken_truth is empty, fall back to treating any "
+    "rewrite of a name as a defect.",
 ]
 
 # Per-behavior additions, for buckets where the transcript genuinely admits more than one
@@ -946,6 +973,18 @@ def normalize_case(case: dict) -> dict:
         "length_bucket": case.get("length_bucket"),
         "context": case.get("context", ""),
         "raw_transcript": case.get("asr_input", ""),
+        # What was ACTUALLY SPOKEN, before any recogniser touched it. Distinct from
+        # `raw_transcript`, which is one engine's attempt at it.
+        #
+        # Without this the judge cannot tell a name REPAIRED from a name MANGLED. Our
+        # corpus keys were authored from OUR transcript, so where Parakeet heard
+        # "Rajash" for Rajesh the key enshrines the error; a system whose recogniser got
+        # the name RIGHT then looks like it substituted one. Measured 2026-08-14 on the
+        # Wispr Flow bake-off: 22 cases penalised for correct transcription
+        # (Rajesh->"Rajash", Nadia->"Nodia", Hassan->"Hassen", Noor->"Norr").
+        #
+        # Empty for corpora that carry no spoken source; the prompt handles absence.
+        "spoken_truth": case.get("voice_text", ""),
         "notes": case.get("notes", ""),
     }
 
@@ -1048,7 +1087,13 @@ NEW_JUDGE_SYSTEM = """You are evaluating a speech-polish engine for a dictation 
 
 For each case you are given:
 - id
-- raw_transcript: the original spoken transcript (lowercase, little punctuation)
+- raw_transcript: ONE speech recogniser's attempt at what was said (lowercase, little
+  punctuation). It is the engine's INPUT, not ground truth, and it can contain
+  mis-hearings -- especially of people's names.
+- spoken_truth: what was ACTUALLY said, when available (may be empty). Use it for ONE
+  purpose only: deciding whether a proper noun, name, address or number in
+  candidate_output is CORRECT or INVENTED. Do NOT grade content, phrasing, fillers or
+  structure against it -- removing disfluencies that appear here is exactly the job.
 - candidate_output: the polish engine output to evaluate
 - production_output: the currently shipped engine's output, or null if unavailable
 - behavior: the behavior bucket (for reporting)
@@ -1081,10 +1126,11 @@ Automatic critical_fail / S4 (any one):
   not this: `envious whisper` -> `EnviousWispr`, `Postgres QL` -> `PostgreSQL`,
   `Mac OS` -> `macOS` all name the same thing the speaker named, and are
   permitted (see allowed_variants). Leaving them untouched is equally correct.
-  A PERSONAL name is the exception and stays an automatic S4: `Rajash` ->
-  `Rajesh` may look like the same repair, but no closed set of people's names
-  exists to be confident against, so it is a substitution rather than a
-  normalisation
+  A PERSONAL name is judged against `spoken_truth`, NOT against raw_transcript:
+  if the rendering matches what was actually said it is CORRECT and not an S4,
+  even where raw_transcript spelled it differently. It is an automatic S4 only
+  when it matches NEITHER (`Elena` -> `Alaina`), i.e. a different person.
+  Where spoken_truth is empty, any rewrite of a personal name stays an S4
 - changed the final correction target in a self-correction
 - invented a fact, recipient, date, action, commitment, or rationale
 - dropped required content that changes the user's intent
@@ -1122,6 +1168,7 @@ def build_new_payload(norm: dict, cand: dict, prod: dict | None) -> dict:
     return {
         "id": norm["id"],
         "raw_transcript": norm["raw_transcript"],
+        "spoken_truth": norm.get("spoken_truth") or "",
         "candidate_output": cand.get("candidate") or "",
         "production_output": (prod.get("candidate") if prod else None),
         "behavior": norm["behavior"],

--- a/scripts/eval/behavior_judge.py
+++ b/scripts/eval/behavior_judge.py
@@ -182,6 +182,17 @@ def _key(name: str) -> str:
     return p.read_text().strip()
 
 
+class JudgeUnavailableError(Exception):
+    """The judge transport cannot work at all, and no number of attempts changes
+    that: a missing or unexecutable CLI, a route with no funded transport.
+
+    Exists because the retry predicate treats every OSError as transport, which
+    is right for an HTTP call and wrong for a subprocess spawn — `FileNotFoundError`
+    from a missing `claude` binary is an OSError and would otherwise be retried
+    once per attempt, per chunk, for the whole corpus.
+    """
+
+
 def _retryable_http_error(exc: Exception) -> bool:
     """True when `exc` is a transient transport failure worth another attempt.
 
@@ -255,6 +266,17 @@ def call_claude(model: str, system: str, user: str) -> str:
         )
     except subprocess.TimeoutExpired:
         raise RuntimeError("claude judge: CLI timed out after 300s")
+    except OSError as e:
+        # A spawn failure (`claude` not on PATH, not executable) is an OSError,
+        # and `_retryable_http_error` answers True for every OSError because in
+        # an HTTP call site that means transport. Here it does not: the CLI will
+        # be just as missing on the fifth attempt, so this must NOT be retried.
+        # Raised as its own type rather than RuntimeError, which judge_chunk
+        # deliberately does retry.
+        raise JudgeUnavailableError(
+            f"claude judge: cannot start the CLI ({type(e).__name__}: {e}). "
+            f"This is permanent — install/authenticate the CLI or pick another "
+            f"--judge; retrying would just burn the wall clock.") from None
     if proc.returncode != 0:
         raise RuntimeError(
             f"claude judge: CLI exited {proc.returncode}: {(proc.stderr or '').strip()[:300]}")
@@ -686,6 +708,13 @@ def judge_chunk(model: str, system: str, payload_cases: list[dict], attempt: int
     try:
         return parse_judge_array(dispatch_judge(model, system, user))
     except Exception as e:
+        # JudgeUnavailableError needs no clause here: it derives from Exception
+        # directly, so it matches neither `_retryable_http_error` (OSError /
+        # HTTPException) nor the parse/RuntimeError arm, and falls through to
+        # FATAL on the first attempt. An explicit guard was written first and a
+        # mutation control proved it dead — the type relationship is the
+        # mechanism, and `test_a_missing_judge_cli_is_not_retried` locks it so a
+        # future re-parenting of that class cannot silently make it retryable.
         if (attempt < JUDGE_CHUNK_ATTEMPTS
                 and (_retryable_http_error(e)
                      or isinstance(e, (json.JSONDecodeError, RuntimeError)))):

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -2442,36 +2442,66 @@ def test_the_s4_entity_rule_and_the_variant_licence_do_not_contradict():
         "the S4 entity rule must fire on a DIFFERENT entity, not on any change"
     assert "normalising a mis-transcribed rendering of the same entity" in sysmsg, \
         "the S4 rule must exempt normalising the same entity, or it overrides the variant"
-    # And the exemption must not swallow personal names, which both halves refuse.
-    assert "personal name is the exception" in sysmsg, \
-        "the S4 carve-out must still treat a personal-name substitution as automatic S4"
-    assert "does not extend to personal names" in variants, \
-        "both halves must agree that personal names are excluded"
+    # Personal names: both halves must split on the SAME axis, which since 2026-08-14 is
+    # whether the rendering matches `spoken_truth` -- not whether it differs from
+    # raw_transcript. If one half judged against the truth and the other against the
+    # transcript, a correctly-heard name would be licensed by one and an automatic S4 by
+    # the other, and the stronger instruction would win. That is the original defect
+    # this test exists for, moved to a new axis.
+    assert "judged against `spoken_truth`" in sysmsg, \
+        "the S4 rule must judge a personal name against what was actually said"
+    assert "matches neither" in sysmsg, \
+        "the S4 rule must fire only when the name matches NEITHER source"
+    assert "matches spoken_truth is correct" in variants, \
+        "the variant must license a name that matches what was actually said"
+    assert "neither spoken_truth nor raw_transcript" in variants, \
+        "both halves must agree a name matching neither source is the defect"
+    # Two-way: the licence must NOT have widened into permitting any name rewrite.
+    assert "is a real \nentity_mutation defect" in variants.replace("  ", " ") \
+        or "real entity_mutation defect" in " ".join(variants.split()), \
+        "substituting a different person must still be named a defect"
 
 
 def test_vocabulary_repair_is_a_variant_but_name_repair_is_not():
-    # Founder ruling 2026-08-13: repairing a mis-transcribed TERM is bonus credit,
-    # so neither doing it nor skipping it may decide a verdict. Repairing a personal
-    # NAME is the opposite — a real defect, because no closed set of names exists to
-    # be confident against.
+    # Founder ruling 2026-08-13: repairing a mis-transcribed TERM is bonus credit, so
+    # neither doing it nor skipping it may decide a verdict.
     #
-    # Two-way on purpose. Asserting only the licence would pass a rubric that
-    # licensed everything, which is exactly the failure this ruling could decay
-    # into: the whole point is that the line falls between terms and names.
+    # Personal names were originally excluded outright, on the reasoning that no closed
+    # set of names exists to be confident against. True for a shipping app; false for a
+    # graded benchmark, where `spoken_truth` records the name actually said. Corrected
+    # 2026-08-14 after the Wispr Flow bake-off measured 22 cases where a system was
+    # marked down for hearing the name CORRECTLY (Rajesh, Nadia, Hassan, Noor, Tomas):
+    # our keys were authored from OUR transcript, so they enshrined our recogniser's
+    # mis-hearings and penalised anyone who got them right.
+    #
+    # The line now falls between a name that matches what was SAID and one that matches
+    # nothing, which is a property of the output rather than of whose transcript it
+    # resembles.
+    #
+    # Two-way on purpose. Asserting only the licence would pass a rubric that licensed
+    # every name rewrite, which is the failure this could decay into.
     text = " ".join(bj.allowed_variants_for("verbatim_preservation")).lower()
     assert "envious" in text and "postgres" in text, \
         "term repair must be licensed as a variant"
     assert "not the behavior under test" in text, \
         "the licence must say the repair is not what is being graded"
-    # Assert the EXCLUSION, not the words. A first version of this checked that
-    # "personal names" appeared anywhere in the rubric — which stays true if the
-    # clause is inverted to "this also covers personal names", so the mutation
-    # control passed a rubric saying the opposite. The phrase that carries the
-    # meaning is the negation itself.
-    assert "does not extend to personal names" in text, \
-        "name repair must be EXCLUDED from the licence, not merely mentioned"
-    assert "real defect" in text, "the exclusion must name name-rewriting as a defect"
-    assert "rajash" in text, "the exclusion needs its concrete example to stay legible"
+    # Assert the two halves of the SPLIT, not merely that names are mentioned. A first
+    # version of this checked that "personal names" appeared anywhere in the rubric —
+    # which stays true if the clause is inverted, so the mutation control passed a
+    # rubric saying the opposite. The phrases that carry the meaning are the two
+    # directions.
+    assert "matches spoken_truth is correct" in text, \
+        "a name matching what was actually said must be licensed, not penalised"
+    assert "neither spoken_truth nor raw_transcript" in text, \
+        "the defect must be defined as matching NEITHER source"
+    assert "real \nentity_mutation defect" in text or "real entity_mutation defect" in \
+        " ".join(text.split()), "substituting a different person must remain a defect"
+    assert "alaina" in text or "fatima" in text, \
+        "the defect side needs its concrete example to stay legible"
+    # The fallback matters: a corpus with no spoken source must not silently license
+    # every name rewrite just because the truth is unavailable.
+    assert "where spoken_truth is empty" in text, \
+        "absence of spoken_truth must fall back to treating a rewrite as a defect"
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -2717,13 +2717,39 @@ def test_call_claude_converts_a_spawn_failure_into_the_permanent_error():
         "JudgeUnavailableError must not satisfy the transport predicate"
 
 
+def test_spoken_truth_reads_both_corpus_schemas():
+    """The personal-name rule is only as good as the field it reads.
+
+    Two corpora carry "what was said" under different names, and reading only
+    Speechpath's `voice_text` made the rule INERT on the older parakeet corpus --
+    present, shipped, and silently doing nothing, which a receipt cannot show.
+    Real shapes from both files, plus the degenerate ones, because this runs on
+    a grading path and must never raise.
+    """
+    # Speechpath: top-level voice_text.
+    assert bj._spoken_truth({"voice_text": "Tell Aoife it is ready"}) == "Tell Aoife it is ready"
+    # type_b_parakeet: nested under input_source.
+    assert bj._spoken_truth(
+        {"input_source": {"original_input": "set aside four plates make that five"}}
+    ) == "set aside four plates make that five"
+    # voice_text wins when both are present.
+    assert bj._spoken_truth(
+        {"voice_text": "top", "input_source": {"original_input": "nested"}}) == "top"
+    # Degenerate shapes all fall back to the conservative empty-truth branch.
+    for case in ({}, {"voice_text": ""}, {"voice_text": "   "},
+                 {"input_source": None}, {"input_source": "a string, not a dict"},
+                 {"input_source": {}}, {"input_source": {"original_input": None}},
+                 {"input_source": {"original_input": "  "}}):
+        assert bj._spoken_truth(case) == "", f"{case!r} must yield empty, not raise"
+
+
 # --------------------------------------------------------------------------- #
 # runner                                                                      #
 # --------------------------------------------------------------------------- #
 
 # An exact count, because the borrowed runner in cleanup_metrics_test.py returns
 # 0 when it discovers ZERO tests — so "green" would carry no information at all.
-EXPECTED_TESTS = 130
+EXPECTED_TESTS = 131
 
 
 def _run() -> int:

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -2612,13 +2612,72 @@ def test_judge_chunk_gives_up_on_a_client_error_without_burning_retries():
     assert out == [], "a chunk that never scored must return empty so reconciliation counts it"
 
 
+def test_a_missing_judge_cli_is_not_retried():
+    """A spawn failure is permanent, so it must not consume the retry budget.
+
+    This is the trap the broadened predicate creates: `FileNotFoundError` from a
+    missing `claude` binary IS an OSError, and every OSError reaching an HTTP
+    call site means transport. Here it means the judge does not exist, and five
+    attempts with backoff per chunk across a whole corpus is pure wall clock.
+    Cloud review found the same shape in tts_corpus.py, where a full disk was
+    being answered with another paid TTS request.
+    """
+    calls = {"n": 0}
+
+    def missing_cli(model, system, user):
+        calls["n"] += 1
+        raise bj.JudgeUnavailableError("claude judge: cannot start the CLI")
+
+    real_dispatch, real_sleep = bj.dispatch_judge, bj.time.sleep
+    bj.dispatch_judge = missing_cli
+    bj.time.sleep = lambda _s: None
+    try:
+        with contextlib.redirect_stderr(io.StringIO()):
+            out = bj.judge_chunk("claude-sonnet-5", "sys", [{"id": "A1"}])
+    finally:
+        bj.dispatch_judge, bj.time.sleep = real_dispatch, real_sleep
+
+    assert calls["n"] == 1, \
+        f"a permanently unavailable judge must be attempted exactly once, " \
+        f"saw {calls['n']} — the retry budget is being spent on a missing binary"
+    assert out == [], "the chunk must return empty so reconciliation counts it"
+
+
+def test_call_claude_converts_a_spawn_failure_into_the_permanent_error():
+    """The conversion happens at the transport, not at the call site.
+
+    Asserting only judge_chunk's behaviour would pass even if `call_claude` let a
+    bare FileNotFoundError escape, because the test above injects the already-
+    converted type. This drives the real `call_claude`.
+    """
+    real_run = bj.subprocess.run
+
+    def no_binary(*a, **kw):
+        raise FileNotFoundError(2, "No such file or directory: 'claude'")
+
+    bj.subprocess.run = no_binary
+    try:
+        raised = None
+        try:
+            bj.call_claude("claude-sonnet-5", "sys", "user")
+        except BaseException as e:  # noqa: BLE001
+            raised = e
+    finally:
+        bj.subprocess.run = real_run
+
+    assert isinstance(raised, bj.JudgeUnavailableError), \
+        f"a missing CLI must surface as JudgeUnavailableError, got {type(raised).__name__}: {raised}"
+    assert not bj._retryable_http_error(raised), \
+        "JudgeUnavailableError must not satisfy the transport predicate"
+
+
 # --------------------------------------------------------------------------- #
 # runner                                                                      #
 # --------------------------------------------------------------------------- #
 
 # An exact count, because the borrowed runner in cleanup_metrics_test.py returns
 # 0 when it discovers ZERO tests — so "green" would carry no information at all.
-EXPECTED_TESTS = 127
+EXPECTED_TESTS = 129
 
 
 def _run() -> int:

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -40,6 +40,7 @@ import subprocess
 import sys
 import tempfile
 import traceback
+import urllib.error
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -2474,12 +2475,120 @@ def test_vocabulary_repair_is_a_variant_but_name_repair_is_not():
 
 
 # --------------------------------------------------------------------------- #
+# transport retry classification                                              #
+# --------------------------------------------------------------------------- #
+
+def test_transport_resets_are_retryable_but_client_errors_are_not():
+    """Two-way control on `_retryable_http_error`.
+
+    The list it replaced -- `(urllib.error.URLError, TimeoutError)` -- looked
+    complete and answered False for all six transport rows below, including
+    `ConnectionResetError`, which is the one that actually fired: urllib wraps
+    only what `urlopen` raises, so a reset during the RESPONSE BODY read arrives
+    bare. Both directions are asserted in one table because widening the
+    predicate far enough to catch a reset is exactly the change that could make a
+    400 retryable -- `HTTPError` is an `OSError` subclass, so the order of the
+    branches is load-bearing and a positive-only test would not notice.
+    """
+    import http.client
+    import socket
+    import ssl
+
+    must_retry = [
+        ("ConnectionResetError", ConnectionResetError(54, "Connection reset by peer")),
+        ("RemoteDisconnected", http.client.RemoteDisconnected("closed")),
+        ("IncompleteRead", http.client.IncompleteRead(b"", 10)),
+        ("BrokenPipeError", BrokenPipeError(32, "Broken pipe")),
+        ("SSLEOFError", ssl.SSLEOFError("eof")),
+        ("socket.gaierror", socket.gaierror(8, "nodename nor servname")),
+        ("URLError", urllib.error.URLError("unreachable")),
+        ("TimeoutError", TimeoutError("timed out")),
+        ("HTTP 429", urllib.error.HTTPError("u", 429, "rate", {}, None)),
+        ("HTTP 500", urllib.error.HTTPError("u", 500, "ise", {}, None)),
+        ("HTTP 503", urllib.error.HTTPError("u", 503, "unavail", {}, None)),
+    ]
+    must_not_retry = [
+        ("HTTP 400", urllib.error.HTTPError("u", 400, "bad request", {}, None)),
+        ("HTTP 401", urllib.error.HTTPError("u", 401, "unauthorized", {}, None)),
+        ("HTTP 404", urllib.error.HTTPError("u", 404, "not found", {}, None)),
+        ("ValueError", ValueError("not transport at all")),
+        ("KeyError", KeyError("nope")),
+    ]
+    for name, exc in must_retry:
+        assert bj._retryable_http_error(exc), \
+            f"{name} is a transient transport failure and must be retried; " \
+            f"treating it as fatal drops a whole chunk of cases"
+    for name, exc in must_not_retry:
+        assert not bj._retryable_http_error(exc), \
+            f"{name} is the server's considered answer (or not transport at all) " \
+            f"and must NOT be retried"
+
+
+def test_judge_chunk_retries_a_reset_and_returns_the_full_chunk():
+    """Drive the REAL `judge_chunk` through a reset and assert it recovers.
+
+    Asserting only the returned scores would pass on a single successful attempt
+    just as well as on a retry, so the attempt COUNT is asserted too -- a counter
+    that is incremented and never read is the shape that makes a retry test
+    vacuous. `time.sleep` is stubbed so the real backoff schedule does not put a
+    minute of wall clock into the suite.
+    """
+    calls = {"n": 0}
+
+    def flaky_dispatch(model, system, user):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise ConnectionResetError(54, "Connection reset by peer")
+        return json.dumps([{"id": "A1", "verdict": "pass"},
+                           {"id": "A2", "verdict": "pass"}])
+
+    real_dispatch, real_sleep = bj.dispatch_judge, bj.time.sleep
+    bj.dispatch_judge = flaky_dispatch
+    bj.time.sleep = lambda _s: None
+    try:
+        out = bj.judge_chunk("azure/x", "sys", [{"id": "A1"}, {"id": "A2"}])
+    finally:
+        bj.dispatch_judge, bj.time.sleep = real_dispatch, real_sleep
+
+    assert calls["n"] == 3, \
+        f"expected 2 resets then a success = 3 attempts, saw {calls['n']}; " \
+        f"if this is 1 the reset was classified FATAL and the chunk was dropped"
+    assert [r["id"] for r in out] == ["A1", "A2"], \
+        f"the chunk must come back whole after a transient reset, got {out!r}"
+
+
+def test_judge_chunk_gives_up_on_a_client_error_without_burning_retries():
+    """The other direction: a 400 is answered once and not retried.
+
+    Without this, widening the predicate to catch resets could silently turn every
+    malformed request into five paid attempts against the deployment.
+    """
+    calls = {"n": 0}
+
+    def always_400(model, system, user):
+        calls["n"] += 1
+        raise urllib.error.HTTPError("u", 400, "bad request", {}, None)
+
+    real_dispatch, real_sleep = bj.dispatch_judge, bj.time.sleep
+    bj.dispatch_judge = always_400
+    bj.time.sleep = lambda _s: None
+    try:
+        with contextlib.redirect_stderr(io.StringIO()):
+            out = bj.judge_chunk("azure/x", "sys", [{"id": "A1"}])
+    finally:
+        bj.dispatch_judge, bj.time.sleep = real_dispatch, real_sleep
+
+    assert calls["n"] == 1, f"a 400 must be attempted exactly once, saw {calls['n']}"
+    assert out == [], "a chunk that never scored must return empty so reconciliation counts it"
+
+
+# --------------------------------------------------------------------------- #
 # runner                                                                      #
 # --------------------------------------------------------------------------- #
 
 # An exact count, because the borrowed runner in cleanup_metrics_test.py returns
 # 0 when it discovers ZERO tests — so "green" would carry no information at all.
-EXPECTED_TESTS = 124
+EXPECTED_TESTS = 127
 
 
 def _run() -> int:

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -2508,23 +2508,24 @@ def test_vocabulary_repair_is_a_variant_but_name_repair_is_not():
 # transport retry classification                                              #
 # --------------------------------------------------------------------------- #
 
-def test_transport_resets_are_retryable_but_client_errors_are_not():
-    """Two-way control on `_retryable_http_error`.
+def test_only_the_network_call_produces_a_retryable_error():
+    """The retry predicate must key on WHERE the failure came from, not its class.
 
-    The list it replaced -- `(urllib.error.URLError, TimeoutError)` -- looked
-    complete and answered False for all six transport rows below, including
-    `ConnectionResetError`, which is the one that actually fired: urllib wraps
-    only what `urlopen` raises, so a reset during the RESPONSE BODY read arrives
-    bare. Both directions are asserted in one table because widening the
-    predicate far enough to catch a reset is exactly the change that could make a
-    400 retryable -- `HTTPError` is an `OSError` subclass, so the order of the
-    branches is load-bearing and a positive-only test would not notice.
+    Every one of the bare exceptions below is an OSError, and an earlier version
+    of this predicate accepted all of them. Cloud review then found three places
+    where that was wrong -- a local WAV write, a subprocess spawn for a missing
+    CLI, and a credential file read -- each of which would have been answered
+    with another PAID request. So the bare forms must now be REFUSED, and only
+    `TransientTransportError`, which `_http_json` raises at the socket, accepted.
+
+    Both directions are asserted together because the failure mode is symmetric:
+    too narrow drops 8 cases per blip, too broad re-bills a permanent local fault.
     """
     import http.client
     import socket
     import ssl
 
-    must_retry = [
+    transport = [
         ("ConnectionResetError", ConnectionResetError(54, "Connection reset by peer")),
         ("RemoteDisconnected", http.client.RemoteDisconnected("closed")),
         ("IncompleteRead", http.client.IncompleteRead(b"", 10)),
@@ -2533,42 +2534,87 @@ def test_transport_resets_are_retryable_but_client_errors_are_not():
         ("socket.gaierror", socket.gaierror(8, "nodename nor servname")),
         ("URLError", urllib.error.URLError("unreachable")),
         ("TimeoutError", TimeoutError("timed out")),
-        ("HTTP 429", urllib.error.HTTPError("u", 429, "rate", {}, None)),
-        ("HTTP 500", urllib.error.HTTPError("u", 500, "ise", {}, None)),
-        ("HTTP 503", urllib.error.HTTPError("u", 503, "unavail", {}, None)),
     ]
-    must_not_retry = [
-        ("HTTP 400", urllib.error.HTTPError("u", 400, "bad request", {}, None)),
-        ("HTTP 401", urllib.error.HTTPError("u", 401, "unauthorized", {}, None)),
-        ("HTTP 404", urllib.error.HTTPError("u", 404, "not found", {}, None)),
-        ("ValueError", ValueError("not transport at all")),
-        ("KeyError", KeyError("nope")),
-    ]
-    for name, exc in must_retry:
-        assert bj._retryable_http_error(exc), \
-            f"{name} is a transient transport failure and must be retried; " \
-            f"treating it as fatal drops a whole chunk of cases"
-    for name, exc in must_not_retry:
+    for name, exc in transport:
+        wrapped = bj.TransientTransportError(exc)
+        assert bj._retryable_http_error(wrapped), \
+            f"{name} raised BY the network call must be retried"
         assert not bj._retryable_http_error(exc), \
-            f"{name} is the server's considered answer (or not transport at all) " \
-            f"and must NOT be retried"
+            f"a BARE {name} must NOT be retried — it could be a file write, a " \
+            f"credential read, or a subprocess spawn in the same try block"
+
+    for name, exc in [("HTTP 429", urllib.error.HTTPError("u", 429, "rate", {}, None)),
+                      ("HTTP 500", urllib.error.HTTPError("u", 500, "ise", {}, None)),
+                      ("HTTP 503", urllib.error.HTTPError("u", 503, "un", {}, None))]:
+        assert bj._retryable_http_error(exc), f"{name} must be retried"
+    for name, exc in [("HTTP 400", urllib.error.HTTPError("u", 400, "bad", {}, None)),
+                      ("HTTP 401", urllib.error.HTTPError("u", 401, "auth", {}, None)),
+                      ("HTTP 404", urllib.error.HTTPError("u", 404, "nf", {}, None)),
+                      ("ValueError", ValueError("not transport")),
+                      ("PermissionError", PermissionError(13, "key file unreadable")),
+                      ("FileNotFoundError", FileNotFoundError(2, "no claude binary"))]:
+        assert not bj._retryable_http_error(exc), f"{name} must NOT be retried"
+
+
+def test_http_json_converts_transport_but_not_status_or_parse_errors():
+    """The conversion has to happen AT the socket, or the structural guarantee is
+    just a comment. Drives the real `_http_json` with a fake opener."""
+    class FakeResp:
+        def __init__(self, body): self.body = body
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def read(self): return self.body
+
+    class Opener:
+        def __init__(self, behaviour): self.behaviour = behaviour
+        def open(self, req, timeout=None):
+            if isinstance(self.behaviour, Exception):
+                raise self.behaviour
+            return FakeResp(self.behaviour)
+
+    # transport failure -> converted
+    raised = None
+    try:
+        bj._http_json(Opener(ConnectionResetError(54, "reset")), object(), 1)
+    except BaseException as e:  # noqa: BLE001
+        raised = e
+    assert isinstance(raised, bj.TransientTransportError), \
+        f"a socket reset must become TransientTransportError, got {type(raised).__name__}"
+    assert isinstance(raised.cause, ConnectionResetError), "the cause must be preserved"
+
+    # HTTPError -> untouched, so the caller can read its status code
+    raised = None
+    try:
+        bj._http_json(Opener(urllib.error.HTTPError("u", 429, "rate", {}, None)), object(), 1)
+    except BaseException as e:  # noqa: BLE001
+        raised = e
+    assert isinstance(raised, urllib.error.HTTPError) and raised.code == 429, \
+        "HTTPError must pass through with its status intact"
+
+    # a 200 with an unparsable body -> JSONDecodeError, not a transport error
+    raised = None
+    try:
+        bj._http_json(Opener(b"not json"), object(), 1)
+    except BaseException as e:  # noqa: BLE001
+        raised = e
+    assert isinstance(raised, json.JSONDecodeError), \
+        f"a bad body is the server's answer, not transport (got {type(raised).__name__})"
+
+    # happy path
+    assert bj._http_json(Opener(b'{"ok": 1}'), object(), 1) == {"ok": 1}
 
 
 def test_judge_chunk_retries_a_reset_and_returns_the_full_chunk():
-    """Drive the REAL `judge_chunk` through a reset and assert it recovers.
-
-    Asserting only the returned scores would pass on a single successful attempt
-    just as well as on a retry, so the attempt COUNT is asserted too -- a counter
-    that is incremented and never read is the shape that makes a retry test
-    vacuous. `time.sleep` is stubbed so the real backoff schedule does not put a
-    minute of wall clock into the suite.
-    """
+    """Drive the REAL `judge_chunk` through a transport failure and assert it
+    recovers. The attempt COUNT is asserted too: without it, one successful call
+    satisfies the test exactly as well as a retry does."""
     calls = {"n": 0}
 
     def flaky_dispatch(model, system, user):
         calls["n"] += 1
         if calls["n"] < 3:
-            raise ConnectionResetError(54, "Connection reset by peer")
+            raise bj.TransientTransportError(
+                ConnectionResetError(54, "Connection reset by peer"))
         return json.dumps([{"id": "A1", "verdict": "pass"},
                            {"id": "A2", "verdict": "pass"}])
 
@@ -2576,13 +2622,13 @@ def test_judge_chunk_retries_a_reset_and_returns_the_full_chunk():
     bj.dispatch_judge = flaky_dispatch
     bj.time.sleep = lambda _s: None
     try:
-        out = bj.judge_chunk("azure/x", "sys", [{"id": "A1"}, {"id": "A2"}])
+        with contextlib.redirect_stderr(io.StringIO()):
+            out = bj.judge_chunk("azure/x", "sys", [{"id": "A1"}, {"id": "A2"}])
     finally:
         bj.dispatch_judge, bj.time.sleep = real_dispatch, real_sleep
 
     assert calls["n"] == 3, \
-        f"expected 2 resets then a success = 3 attempts, saw {calls['n']}; " \
-        f"if this is 1 the reset was classified FATAL and the chunk was dropped"
+        f"expected 2 transport failures then a success = 3 attempts, saw {calls['n']}"
     assert [r["id"] for r in out] == ["A1", "A2"], \
         f"the chunk must come back whole after a transient reset, got {out!r}"
 
@@ -2677,7 +2723,7 @@ def test_call_claude_converts_a_spawn_failure_into_the_permanent_error():
 
 # An exact count, because the borrowed runner in cleanup_metrics_test.py returns
 # 0 when it discovers ZERO tests — so "green" would carry no information at all.
-EXPECTED_TESTS = 129
+EXPECTED_TESTS = 130
 
 
 def _run() -> int:

--- a/scripts/eval/run_cloud_type_b.py
+++ b/scripts/eval/run_cloud_type_b.py
@@ -58,6 +58,7 @@ the whole set rather than mixing:
 from __future__ import annotations
 
 import argparse
+import http.client
 import json
 import os
 import sys
@@ -338,6 +339,14 @@ def polish_case(
             retryable = e.code in RETRYABLE
         except urllib.error.URLError as e:
             last_err = f"URLError: {e.reason}"
+            retryable = True
+        except (OSError, http.client.HTTPException) as e:
+            # A reset arriving while the RESPONSE BODY is read is a bare
+            # ConnectionResetError, not a URLError, so before this clause it
+            # escaped the retry loop entirely and killed the whole case. Ordered
+            # after the two urllib clauses because HTTPError subclasses URLError
+            # subclasses OSError, and a 4xx must keep its non-retryable verdict.
+            last_err = f"{type(e).__name__}: {e}"
             retryable = True
         except (RuntimeError, KeyError, json.JSONDecodeError) as e:
             last_err = str(e)

--- a/scripts/eval/run_cloud_type_b.py
+++ b/scripts/eval/run_cloud_type_b.py
@@ -346,6 +346,16 @@ def polish_case(
             # escaped the retry loop entirely and killed the whole case. Ordered
             # after the two urllib clauses because HTTPError subclasses URLError
             # subclasses OSError, and a 4xx must keep its non-retryable verdict.
+            #
+            # A BROAD OSError catch is safe HERE and is not elsewhere, so the
+            # check is recorded rather than left to the next reader: the only
+            # things in this `try` are `call_once` (urlopen) and
+            # `_strip_llm_preamble_python` (pure string work). `api_key` is read
+            # by `_key()` ONCE at module level, outside the loop, so no
+            # credential read can land in this scope. behavior_judge.py and
+            # acceptance_gate.py could not make that claim -- they retry a
+            # credential read and a subprocess spawn respectively -- which is why
+            # they convert at the socket with TransientTransportError instead.
             last_err = f"{type(e).__name__}: {e}"
             retryable = True
         except (RuntimeError, KeyError, json.JSONDecodeError) as e:

--- a/scripts/eval/train_polish.py
+++ b/scripts/eval/train_polish.py
@@ -54,6 +54,17 @@ args = ap.parse_args()
 # clearing unsloth_compiled_cache and ~/.triton. Do not repeat any of those three
 # as the cause.
 #
+# Nor is this knob established as the CURE. The run that finally trained had both
+# `--dataset-num-proc 1` and `python -u`, and an earlier run with the knob alone
+# still died -- so the crash is at least partly intermittent and the knob may have
+# had nothing to do with it. Treat a green run as luck until several in a row pass.
+#
+# What IS established, and is worth more than the knob: `python train.py > log`
+# BLOCK-buffers stdout, so a SIGSEGV loses the entire buffer and leaves an EMPTY
+# log. That made the crash look like it had moved earlier in the pipeline when it
+# had not, and cost two rounds of this investigation. Always run the trainer with
+# `python -u` so the last line before a crash is truthful.
+#
 # So this knob is a bisection tool, not a fix with a known reason. Tokenizing
 # 5,656 short rows in-process costs well under a minute against a ~16-minute
 # train, so pinning it is close to free while the real cause is unknown.

--- a/scripts/eval/train_polish.py
+++ b/scripts/eval/train_polish.py
@@ -82,10 +82,28 @@ from datasets import Dataset
 from trl import SFTTrainer, SFTConfig
 import inspect
 
-def _sft_config(**kw):
+def _sft_config(_required=(), **kw):
+    """trl-version shim. Unknown keywords are DROPPED, which is what makes this
+    portable across trl releases -- and is exactly why `_required` exists.
+
+    Silently dropping a knob the OPERATOR explicitly asked for is worse than not
+    having the knob. `--dataset-num-proc` is a crash-bisection tool: if a future
+    trl removes `dataset_num_proc`, the run would fall back to the library's
+    multiprocess default while reporting nothing, and the next crash-or-success
+    would be read as evidence about a setting that never applied. Verified
+    present in trl 0.24.0 on the rig before shipping this, so today it lands;
+    the guard is for the version bump that has not happened yet.
+    """
     sig = set(inspect.signature(SFTConfig.__init__).parameters)
     if "max_seq_length" in kw and "max_seq_length" not in sig:
         kw["max_length"] = kw.pop("max_seq_length")
+    missing = [k for k in _required if k not in sig]
+    if missing:
+        raise SystemExit(
+            f"train_polish: this trl ({getattr(__import__('trl'), '__version__', '?')}) "
+            f"has no SFTConfig parameter(s) {missing}, so the value you passed would "
+            f"be silently ignored and the run would not test what you asked for. "
+            f"Re-run without that flag, or route it through this trl's own API.")
     return SFTConfig(**{k: v for k, v in kw.items() if k in sig})
 
 def _sft_trainer(**kw):
@@ -153,9 +171,12 @@ trainer = _sft_trainer(
         report_to="none",
         seed=1265,
         # Omitted entirely when unset, so the recipe that produced EG-1 is
-        # byte-for-byte unchanged unless a run asks for this.
+        # byte-for-byte unchanged unless a run asks for this. When it IS asked
+        # for, `_required` makes an unsupported trl fail loudly rather than
+        # discard it — see _sft_config.
         **({} if args.dataset_num_proc is None
            else {"dataset_num_proc": args.dataset_num_proc}),
+        _required=() if args.dataset_num_proc is None else ("dataset_num_proc",),
     ),
 )
 

--- a/scripts/eval/train_polish.py
+++ b/scripts/eval/train_polish.py
@@ -36,7 +36,27 @@ ap.add_argument("--alpha", type=int, default=32)
 ap.add_argument("--micro-bs", type=int, default=4)
 ap.add_argument("--grad-accum", type=int, default=4)
 ap.add_argument("--max-seq", type=int, default=512)
+ap.add_argument("--dataset-num-proc", type=int, default=None,
+                help="Worker processes for dataset tokenization. Unset = the "
+                     "library default (one per core). Set 1 to tokenize in-process.")
 args = ap.parse_args()
+
+# WHY --dataset-num-proc EXISTS: on the 4090 rig (2026-08-15) training died with a
+# hard SIGSEGV inside CPython partway through `Tokenizing ["text"] (num_proc=28)`.
+# It reproduced on the July corpus that had trained fine before, which is what
+# proved it was the environment and not the data.
+#
+# The MECHANISM IS NOT ESTABLISHED. The obvious story -- `datasets.map` forks after
+# FastLanguageModel has put a CUDA context in the process, and forking a live CUDA
+# context is undefined -- was tested and REFUTED: a staged probe on that rig loads
+# the 4-bit model, builds the PEFT wrapper, and then tokenizes with num_proc=8
+# without incident. TOKENIZERS_PARALLELISM=false did not help either, nor did
+# clearing unsloth_compiled_cache and ~/.triton. Do not repeat any of those three
+# as the cause.
+#
+# So this knob is a bisection tool, not a fix with a known reason. Tokenizing
+# 5,656 short rows in-process costs well under a minute against a ~16-minute
+# train, so pinning it is close to free while the real cause is unknown.
 
 # The SHIP prompt: short distilled instruction (council 2026-07-02). The tuned
 # model trains WITH it and the app will send exactly this string at inference.
@@ -121,6 +141,10 @@ trainer = _sft_trainer(
         output_dir=os.path.expanduser(f"~/tuning/out/{args.tag}/ckpt"),
         report_to="none",
         seed=1265,
+        # Omitted entirely when unset, so the recipe that produced EG-1 is
+        # byte-for-byte unchanged unless a run asks for this.
+        **({} if args.dataset_num_proc is None
+           else {"dataset_num_proc": args.dataset_num_proc}),
     ),
 )
 

--- a/scripts/eval/tts_corpus.py
+++ b/scripts/eval/tts_corpus.py
@@ -119,6 +119,13 @@ def synth(text: str, out: Path, engine: str, model: str, voice: str,
             # not a URLError, so before this clause it escaped the retry loop and
             # aborted a whole TTS sweep. Ordered last of the three because
             # HTTPError subclasses URLError subclasses OSError.
+            #
+            # Safe to catch broadly ONLY because the `try` above now contains
+            # nothing but `urlopen` + `resp.read()`. The file writes used to live
+            # here, and this same clause then answered a full disk with another
+            # paid TTS request (cloud review, PR #2058). If anything non-network
+            # is ever added back above, convert at the socket the way
+            # behavior_judge.py does instead of widening this.
             if attempt < MAX_ATTEMPTS:
                 time.sleep(min(2 ** attempt, 30))
                 continue

--- a/scripts/eval/tts_corpus.py
+++ b/scripts/eval/tts_corpus.py
@@ -96,15 +96,14 @@ def synth(text: str, out: Path, engine: str, model: str, voice: str,
             _azure_request(text, voice, api_key, region) if engine == "azure"
             else _openai_request(text, model, voice, api_key)
         )
+        # ONLY the network call is inside the retry scope. The file writes used to
+        # sit here too, and a broad OSError catch then misclassified a full or
+        # read-only --wav-dir as a transient transport failure and re-billed the
+        # TTS request up to MAX_ATTEMPTS times per case. A retry handler's scope is
+        # whatever happens to be above it, so it has to be drawn deliberately.
         try:
             with urllib.request.urlopen(req, timeout=120) as resp:
                 data = resp.read()
-            if not data:
-                raise RuntimeError("empty audio body")
-            tmp = out.with_suffix(".part")
-            tmp.write_bytes(data)
-            tmp.replace(out)  # atomic: a killed run never leaves a half WAV
-            return
         except urllib.error.HTTPError as e:
             if e.code in RETRYABLE and attempt < MAX_ATTEMPTS:
                 time.sleep(min(2 ** attempt, 30))
@@ -124,6 +123,21 @@ def synth(text: str, out: Path, engine: str, model: str, voice: str,
                 time.sleep(min(2 ** attempt, 30))
                 continue
             raise
+
+        # An empty body IS worth another network attempt, so it stays in the loop
+        # — but as an explicit branch rather than an exception caught above.
+        if not data:
+            if attempt < MAX_ATTEMPTS:
+                time.sleep(min(2 ** attempt, 30))
+                continue
+            raise RuntimeError("empty audio body after all attempts")
+
+        # Local disk failures propagate immediately: retrying a full or read-only
+        # directory cannot succeed and each retry costs another paid request.
+        tmp = out.with_suffix(".part")
+        tmp.write_bytes(data)
+        tmp.replace(out)  # atomic: a killed run never leaves a half WAV
+        return
 
 
 def main() -> int:

--- a/scripts/eval/tts_corpus.py
+++ b/scripts/eval/tts_corpus.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import http.client
 import html
 import json
 import os
@@ -110,6 +111,15 @@ def synth(text: str, out: Path, engine: str, model: str, voice: str,
                 continue
             raise RuntimeError(f"HTTP {e.code}: {e.read().decode(errors='replace')[:200]}") from None
         except urllib.error.URLError:
+            if attempt < MAX_ATTEMPTS:
+                time.sleep(min(2 ** attempt, 30))
+                continue
+            raise
+        except (OSError, http.client.HTTPException):
+            # A reset during the RESPONSE BODY read is a bare ConnectionResetError,
+            # not a URLError, so before this clause it escaped the retry loop and
+            # aborted a whole TTS sweep. Ordered last of the three because
+            # HTTPError subclasses URLError subclasses OSError.
             if attempt < MAX_ATTEMPTS:
                 time.sleep(min(2 ** attempt, 30))
                 continue


### PR DESCRIPTION
Three eval-harness corrections found while running the Wispr Flow bake-off and starting the EG-2 retrain. All three were caught by a measurement behaving oddly, not by a test.

## 1. A connection reset was treated as fatal, so grades silently lost 8 cases per blip

Two separate 1,861-case grading runs on 2026-08-14 each logged exactly three `FATAL on chunk (attempt 1): [Errno 54] Connection reset by peer` and each dropped exactly **24** cases (3 chunks x chunk_size 8). Each cost a full re-grade.

The two dropped ID sets had **zero overlap**, which is what rules out a content trigger and identifies transport. My first theory was rate-limit contention from running two arms in parallel; the zero-overlap check killed that theory too.

Cause: `_retryable_http_error` tested a LIST of names, `(URLError, TimeoutError)`. urllib wraps only what `urlopen` itself raises, so a reset arriving while the **response body** is read propagates as a bare `ConnectionResetError` — an `OSError`, but not a `URLError`. Probed against constructed instances rather than reasoned about: **six** transport failure modes were misclassified.

Fix: test the BASE classes, `(OSError, http.client.HTTPException)`, with the `HTTPError` branch kept FIRST so a 400/401 stays non-retryable — `HTTPError` subclasses `URLError` subclasses `OSError`, so branch order is load-bearing. Retry budget 3 → 5 with capped exponential backoff plus jitter, since every worker shares one deployment and a deterministic delay marches collided chunks back in lockstep.

**Deliberately not changed:** `reconcile_judge_batch` and the `run_complete` gate. They behaved correctly throughout — both runs were reported INCOMPLETE and no wrong number was ever published. This fixes the layer that manufactured the gap, not the layer that reports it.

**Same defect in three siblings**, found by grepping the class rather than the one file that failed:
- `acceptance_gate.py` — the CI corpus gate, identical predicate
- `run_cloud_type_b.py` and `tts_corpus.py` — both caught `HTTPError` and `URLError` explicitly, so a reset escaped the retry loop entirely

## 2. The judge scored personal names against our own recogniser's guess

The Speechpath answer keys were authored FROM our Parakeet transcript, so wherever Parakeet mis-heard a name the key inherited the mis-spelling. The judge then treated `raw_transcript` as ground truth, which punished any system that heard the name **correctly** — a competitor's right answer graded as an entity mutation.

Found because a bake-off returned a result that flattered us and the founder rejected the reading rather than the competitor: *"if Wispr Flow is failing a category I would assume it's the test, not the model."* 22 name-spelling cases carried the fault.

- `normalize_case` / `build_new_payload` now carry `spoken_truth` (what the speaker actually said) alongside `raw_transcript`
- the rubric relabels `raw_transcript` as ONE recogniser's attempt, and scopes `spoken_truth` to entity adjudication only so it cannot leak into general grading
- the personal-name variant licence splits in two: matching `spoken_truth` is CORRECT whatever the transcript said; matching **neither** is still a real `entity_mutation`
- the automatic-S4 list is updated to match — without that it would have overridden the licence and made the whole change inert

Concurrency: HTTP judge workers 4 → 12, env-overridable via `EW_JUDGE_WORKERS`. Grading is bulk and parallel; too-high fails slow, not wrong, because 429 is retryable. Note in-code: do **not** run two arms at once against the one deployment.

## 3. `--dataset-num-proc` on the trainer, labelled honestly

The 4090 rig started SIGSEGV-ing partway through tokenization, reproducibly — including on the July corpus that had trained fine, which is what proved it was the environment and not my new data.

The knob is a **bisection tool, not a fix with a known cause**, and the comment says so. Three explanations were tested and refuted: forking a live CUDA context (a staged probe loads the 4-bit model, builds the PEFT wrapper, then tokenizes with `num_proc=8` without incident), `TOKENIZERS_PARALLELISM=false`, and clearing `unsloth_compiled_cache` + `~/.triton`. An earlier run with the knob alone still died, so the crash is at least partly intermittent and the knob may be incidental.

The genuinely useful finding from that hunt is also recorded: `python train.py > log` **block-buffers stdout**, so a SIGSEGV loses the whole buffer and leaves an empty log — which made the crash look like it had moved earlier in the pipeline when it had not, and cost two rounds of investigation. The rig now runs the trainer with `python -u`.

## Tests

Three new, in `behavior_judge_test.py`:
- a two-way control over **16** exception types — both that resets/5xx/429 retry, and that 400/401/404/`ValueError` do not, because widening far enough to catch a reset is exactly the change that could make a 400 retryable
- an explicit **attempt-count** assertion, so a retry test cannot pass on a single successful call
- the client-error direction, asserting a 400 is attempted exactly once and not five times

**Mutation control:** reverting the predicate fails 2 of the 3; the third correctly still passes because it guards the branch that did not change.

`127 passed, 0 failed`. `acceptance_gate.py --mode selftest` still clean. The two rubric self-consistency tests were updated to assert the new split — they previously asserted the merged rule and would have passed it unchanged.
