### PR TITLE
feat(ui): show the words in the recording pill while you speak

### DIFF
--- a/Sources/EnviousWispr/Resources/Info.plist
+++ b/Sources/EnviousWispr/Resources/Info.plist
@@ -38,6 +38,8 @@
 	<string>EnviousWispr needs microphone access for speech-to-text dictation.</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>EnviousWispr uses on-device speech recognition to show your words in the recording pill while you speak. This preview stays on your Mac and is never the text that gets pasted.</string>
 	<key>PostHogAPIKey</key>
 	<string>$(POSTHOG_API_KEY)</string>
 	<key>SentryDSN</key>

--- a/Sources/EnviousWisprAppKit/App/LivePreview/ApplePreviewRecognizer.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/ApplePreviewRecognizer.swift
@@ -1,4 +1,5 @@
 @preconcurrency import AVFoundation
+import EnviousWisprPostProcessing
 import Foundation
 import Speech
 
@@ -83,8 +84,23 @@ actor ApplePreviewRecognizer {
   /// the current one" for the caller's benefit.
   private var currentToken: UInt64 = 0
 
+  /// Custom Words, as pre-built lookups. Set by the coordinator whenever the
+  /// vocabulary changes and CAPTURED per session at `startSession`, so a
+  /// vocabulary edit mid-dictation cannot change what this session is applying
+  /// halfway through a sentence. The pasted text is corrected by the pipeline's
+  /// own step against the vocabulary live at THAT moment, so the two paths agree
+  /// on everything except an edit made during the few seconds of one dictation.
+  private var correctorLookups: WordCorrector.Lookups?
+
   init(locale: Locale) {
     self.locale = locale
+  }
+
+  /// Hand this recognizer a new Custom Words snapshot. Takes pre-built lookups
+  /// rather than terms so the build cost is paid once per vocabulary generation
+  /// on the coordinator, not once per recording here.
+  func setCorrectorLookups(_ lookups: WordCorrector.Lookups?) {
+    correctorLookups = lookups
   }
 
   // MARK: - Preparation
@@ -287,7 +303,8 @@ actor ApplePreviewRecognizer {
     let (stream, continuation) = AsyncStream<AnalyzerInput>.makeStream(
       bufferingPolicy: .bufferingNewest(Self.maxQueuedChunks))
     let analyzer = SpeechAnalyzer(modules: [module])
-    let collector = Self.collect(from: module, onText: onText)
+    // Captured, not read later: the session owns the vocabulary it started with.
+    let collector = Self.collect(from: module, lookups: correctorLookups, onText: onText)
 
     // Finishing the stream and cancelling the collector is not enough: the analyzer
     // holds its own analysis and model resources and needs an explicit end, or a
@@ -332,12 +349,20 @@ actor ApplePreviewRecognizer {
   ///
   /// What a user sees is finished segments plus the one in flight, so that is what
   /// is assembled.
+  ///
+  /// `lookups` is this session's Custom Words snapshot, applied HERE because this
+  /// is already off the main actor and already the place the retention bound runs.
+  /// `WordCorrector.correct(_:using:)` is a documented pure function, safe to call
+  /// off any actor, and `Lookups` is `Sendable`, so the snapshot crosses the
+  /// boundary as a value rather than as a reference the main actor keeps mutating.
   private static func collect(
-    from transcriber: DictationTranscriber, onText: @escaping @Sendable (String) -> Void
+    from transcriber: DictationTranscriber, lookups: WordCorrector.Lookups?,
+    onText: @escaping @Sendable (String) -> Void
   ) -> Task<Void, Never> {
     Task {
       var committed = ""
       var inFlight = ""
+      let corrector = WordCorrector()
       // A thrown error ends the stream. The text already on screen stays on
       // screen: a preview that freezes mid-sentence is a far better failure than
       // one that blanks, and the dictation itself is unaffected either way.
@@ -358,10 +383,37 @@ actor ApplePreviewRecognizer {
             // lasts even though every emitted string is trimmed.
             inFlight = LivePreviewTextBound.apply(piece)
           }
-          onText(LivePreviewTextBound.apply(committed + inFlight))
+          // Correct AFTER bounding, never before. The bound keeps the tail, so
+          // correcting first would scan the whole retained transcript several
+          // times a second to produce a string whose head is then thrown away —
+          // unbounded work for output nobody sees. Bounding first caps this at
+          // the visible window.
+          //
+          // Applied to the assembled string rather than to each incoming piece
+          // because a custom term can span the segment join: Apple closes a
+          // segment mid-name often enough that per-piece correction would miss
+          // exactly the proper nouns this exists for (#1988 — partial hypotheses
+          // are least stable on proper nouns, which is the whole reason the issue
+          // asks for the dictionary on the preview pass).
+          onText(
+            Self.corrected(
+              LivePreviewTextBound.apply(committed + inFlight),
+              corrector: corrector, lookups: lookups))
         }
       } catch {}
     }
+  }
+
+  /// Apply this session's Custom Words snapshot, or return `text` untouched.
+  ///
+  /// A limb inside a limb: correction failing must never cost the user the words
+  /// already on screen, so an empty vocabulary short-circuits and anything else
+  /// falls through to the uncorrected text rather than blanking the pill.
+  private static func corrected(
+    _ text: String, corrector: WordCorrector, lookups: WordCorrector.Lookups?
+  ) -> String {
+    guard let lookups, !text.isEmpty else { return text }
+    return corrector.correct(text, using: lookups).corrected
   }
 
   /// Feed newly captured 16 kHz mono samples into `session`.
@@ -415,7 +467,19 @@ actor ApplePreviewRecognizer {
     // that landed on only one of two symmetric sites would be the partial port this
     // codebase keeps relearning.
     if session.fedAnyAudio.value {
-      try? await session.analyzer.finalizeAndFinishThroughEndOfInput()
+      // `try?` here was the FIFTH member of the abandoned-analyzer class, and the
+      // one that survived a sweep I called complete — because that sweep
+      // enumerated CONSTRUCTION sites and their exits, and this is a different
+      // axis: an ENDING call that can itself fail. A throwing finalize leaves the
+      // analyzer exactly as un-ended as never calling one, and stopping a
+      // recording is the moment the parent task is being cancelled, which is when
+      // it is most likely to throw. Cancel is the fallback because it does not
+      // throw, so the class closes here rather than recursing.
+      do {
+        try await session.analyzer.finalizeAndFinishThroughEndOfInput()
+      } catch {
+        await session.analyzer.cancelAndFinishNow()
+      }
     } else {
       await session.analyzer.cancelAndFinishNow()
     }

--- a/Sources/EnviousWisprAppKit/App/LivePreview/ApplePreviewRecognizer.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/ApplePreviewRecognizer.swift
@@ -218,22 +218,29 @@ actor ApplePreviewRecognizer {
     let analyzer = SpeechAnalyzer(modules: [module])
     let collector = Self.collect(from: module, onText: onText)
 
-    func discard() {
+    // Finishing the stream and cancelling the collector is not enough: the analyzer
+    // holds its own analysis and model resources and needs an explicit end, or a
+    // rapid stop-start loop accumulates abandoned ones. `cancelAndFinishNow` rather
+    // than `finalizeAndFinishThroughEndOfInput` because this session is being thrown
+    // away — there is no result anyone will read, and finalizing an analyzer that
+    // never received input does not return (trap 2).
+    func discard() async {
       continuation.finish()
       collector.cancel()
+      await analyzer.cancelAndFinishNow()
     }
 
     do {
       try await analyzer.start(inputSequence: stream)
     } catch {
-      discard()
+      await discard()
       throw error
     }
     // Superseded while `start` was suspended: this session's resources are ours
     // alone, so close them rather than handing back something whose every later
     // call would be rejected.
     guard token == currentToken else {
-      discard()
+      await discard()
       throw LivePreviewError.superseded
     }
     return Session(
@@ -326,11 +333,20 @@ actor ApplePreviewRecognizer {
   /// teardown from an abandoned recording cannot reach the live one.
   func endSession(_ session: Session) async {
     session.continuation.finish()
-    // Only finalize when the analyzer actually received input — see trap 2. A
+    // Only FINALIZE when the analyzer actually received input — see trap 2. A
     // finalize on an empty analyzer never returns, which would leak this task for
     // the life of the process.
+    //
+    // But it must still be ENDED either way. The silent-recording path (press,
+    // say nothing, release) reaches here with nothing fed, and leaving the analyzer
+    // un-ended leaks its analysis and model resources exactly as an abandoned start
+    // does. Review named that leak on the discard path; this is its twin, and a fix
+    // that landed on only one of two symmetric sites would be the partial port this
+    // codebase keeps relearning.
     if session.fedAnyAudio.value {
       try? await session.analyzer.finalizeAndFinishThroughEndOfInput()
+    } else {
+      await session.analyzer.cancelAndFinishNow()
     }
     session.collector.cancel()
   }

--- a/Sources/EnviousWisprAppKit/App/LivePreview/ApplePreviewRecognizer.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/ApplePreviewRecognizer.swift
@@ -154,13 +154,23 @@ actor ApplePreviewRecognizer {
     if already.count >= AssetInventory.maximumReservedLocales, let victim = already.first {
       _ = await AssetInventory.release(reservedLocale: victim)
     }
-    // The Bool matters. `reserve` returns false rather than throwing when the claim
-    // was not made — a reservation-limit race, or an eviction that did not take.
-    // Discarding it let `prepare()` report success for a locale that was never
-    // claimed, and the coordinator then CACHES that recognizer as ready, so every
-    // later recording reuses a broken one instead of retrying. The failure would
-    // have surfaced far away, as transcription complaining about a missing asset.
-    guard try await AssetInventory.reserve(locale: locale) else {
+    // The Bool matters, but it is NOT a success flag, and reading it as one was a
+    // defect of its own. Measured against the real API: reserving a locale that is
+    // already reserved returns FALSE, not true. So false means "did not newly
+    // reserve", which covers both a genuine refusal and the entirely healthy case
+    // where the claim was already held — including where the early-return check
+    // above missed it because Apple reports an equivalent identifier variant.
+    //
+    // Treating false as failure would disable the preview on a machine that has
+    // exactly the reservation it needs. Treating it as success would restore the
+    // original defect: `prepare()` reporting ready for a locale never claimed, then
+    // being CACHED, so every later recording reuses a broken recognizer and the
+    // failure surfaces far away as a missing-asset complaint.
+    //
+    // Ask the authority instead of inferring from the return value.
+    if try await AssetInventory.reserve(locale: locale) { return }
+    let nowReserved = await AssetInventory.reservedLocales
+    guard nowReserved.contains(where: { $0.identifier(.bcp47) == wanted }) else {
       throw LivePreviewError.localeUnavailable
     }
   }

--- a/Sources/EnviousWisprAppKit/App/LivePreview/ApplePreviewRecognizer.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/ApplePreviewRecognizer.swift
@@ -207,20 +207,30 @@ actor ApplePreviewRecognizer {
         for try await result in transcriber.results {
           let piece = String(result.text.characters)
           if result.isFinal {
-            committed += piece
+            // Bounded HERE, where the text is built. Accumulating the whole
+            // transcript and trimming downstream would keep every word of a
+            // 60-minute dictation alive and copy all of it across an actor
+            // boundary several times a second.
+            committed = LivePreviewTextBound.apply(committed + piece)
             inFlight = ""
           } else {
             inFlight = piece
           }
-          onText(committed + inFlight)
+          onText(LivePreviewTextBound.apply(committed + inFlight))
         }
       } catch {}
     }
   }
 
-  /// Feed newly captured 16 kHz mono samples. Never throws: a preview that cannot
-  /// convert a buffer shows slightly less text, which is not worth propagating.
-  func feed(_ samples: [Float]) {
+  /// Feed newly captured 16 kHz mono samples for the session identified by `token`.
+  ///
+  /// Never throws: a preview that cannot convert a buffer shows slightly less text,
+  /// which is not worth propagating. The token is the same guard `endSession` uses,
+  /// and for the same reason — the feed loop is cancelled asynchronously, so a call
+  /// already in flight when the next recording begins would otherwise push the
+  /// previous dictation's audio into the new session's analyzer.
+  func feed(_ samples: [Float], token: UInt64) {
+    guard token == sessionToken else { return }
     guard let cont = continuation, let source = sourceFormat, !samples.isEmpty else { return }
     guard
       let buffer = AVAudioPCMBuffer(
@@ -252,16 +262,32 @@ actor ApplePreviewRecognizer {
   /// session is open, and safe to call twice.
   func endSession(token: UInt64) async {
     guard token == sessionToken else { return }
-    continuation?.finish()
-    continuation = nil
+
+    // **Everything this teardown touches is captured BEFORE the await.** An actor
+    // is reentrant at a suspension point, so while `finalizeAndFinishThroughEndOfInput`
+    // is running the next recording can enter `startSession` and replace
+    // `analyzer`, `collector` and `continuation` with its own. Resuming here and
+    // clearing the FIELDS would then silence the session the user is currently
+    // talking to. Checking the token only on entry, as the first version did, does
+    // not help: it was still true when checked. Review caught this.
+    let endingAnalyzer = analyzer
+    let endingCollector = collector
+    let endingContinuation = continuation
+    let hadAudio = fedAnyAudio
+
+    endingContinuation?.finish()
     // Only finalize when the analyzer actually received input — see trap 2. A
     // finalize on an empty analyzer never returns, which would leak this task for
     // the life of the process.
-    if fedAnyAudio, let analyzer {
-      try? await analyzer.finalizeAndFinishThroughEndOfInput()
+    if hadAudio, let endingAnalyzer {
+      try? await endingAnalyzer.finalizeAndFinishThroughEndOfInput()
     }
+    endingCollector?.cancel()
+
+    // Only now touch shared state, and only if this is still the current session.
+    guard token == sessionToken else { return }
+    continuation = nil
     fedAnyAudio = false
-    collector?.cancel()
     collector = nil
     analyzer = nil
     module = nil

--- a/Sources/EnviousWisprAppKit/App/LivePreview/ApplePreviewRecognizer.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/ApplePreviewRecognizer.swift
@@ -126,7 +126,16 @@ actor ApplePreviewRecognizer {
     // Deliberately never finalized: see trap 2.
     let warmModule = DictationTranscriber(locale: locale, preset: .progressiveLongDictation)
     let warmAnalyzer = SpeechAnalyzer(modules: [warmModule])
-    try await warmAnalyzer.prepareToAnalyze(in: target)
+    do {
+      try await warmAnalyzer.prepareToAnalyze(in: target)
+    } catch {
+      // The FOURTH abandoned-analyzer site: preparation throwing leaves before the
+      // cancel below. Preparation failure is retried on a later recording, so each
+      // failure would strand another analyzer. `defer` cannot be used here because
+      // the cleanup is async.
+      await warmAnalyzer.cancelAndFinishNow()
+      throw error
+    }
     // The THIRD abandoned-analyzer site, and the one a sweep of the previous two
     // missed. Warm-up runs on first use and on every language change, and an
     // analyzer that is simply dropped retains its analysis and model resources, so

--- a/Sources/EnviousWisprAppKit/App/LivePreview/ApplePreviewRecognizer.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/ApplePreviewRecognizer.swift
@@ -1,0 +1,308 @@
+@preconcurrency import AVFoundation
+import Foundation
+import Speech
+
+/// The live-preview recognizer: Apple's on-device `SpeechAnalyzer` driving a
+/// `DictationTranscriber`, used for DISPLAY ONLY (#1988).
+///
+/// This is a limb in the strictest sense. Nothing it produces reaches the
+/// clipboard: the pasted text still comes from the shipped Parakeet/WhisperKit
+/// path, decoded from the whole recording after the key is released, and then
+/// through custom words, the deterministic layer and polish. This engine exists
+/// so the user can SEE that we heard them while they are still talking.
+///
+/// ## Why a second recognizer rather than reading our own engine's partials
+///
+/// Measured on #1988 and recorded on the issue. Parakeet's `confirmedTranscript`
+/// cannot populate before `minContextForConfirmation: 10.0` seconds, so a preview
+/// fed from it is BLANK for the first 10-13 seconds of every dictation. It also
+/// required Background transcription to be ON, which our own shipped help panel
+/// tells Parakeet users to leave OFF (3.7% vs 2.0% word error). Seeing your words
+/// would have cost accuracy. Every competitor that ships this feature runs a
+/// separate display recognizer for the same reason, including FluidVoice, which
+/// uses Parakeet exactly as we do and still ships a separate realtime provider.
+///
+/// ## Why THIS engine
+///
+/// Screened against five candidates over 30 clips, then two live human trials and
+/// a five-language panel (#1988 comments). It ships zero bytes (the model is in
+/// the OS, shared with system dictation), covers 33 languages, and formats numbers,
+/// dates, addresses and emails inline — the trial's deciding factor, because
+/// watching `two zero three nine five four` crawl across the pill reads as the
+/// software failing even though the pasted result is correct.
+///
+/// Its cost is the macOS 26 floor, which is why the setting is disabled below that.
+///
+/// ## Traps, all of which cost real time to find
+///
+/// 1. A `DictationTranscriber` belongs to exactly ONE `SpeechAnalyzer`. Handing the
+///    same instance to a second one crashes inside `setWorkers(for:reusingFrom:)`
+///    with EXC_BREAKPOINT and no catchable error, so every session builds a fresh
+///    module.
+/// 2. `finalizeAndFinishThroughEndOfInput()` on an analyzer that never received
+///    input waits forever. Only finalize when audio was actually fed.
+/// 3. Skipping `bestAvailableAudioFormat` crashes inside Apple's framework with
+///    EXC_BREAKPOINT and no error, which reads like a caller bug.
+/// 4. Installing a language is NOT the same as claiming it. See
+///    `reserveLocale(_:)`.
+@available(macOS 26.0, *)
+actor ApplePreviewRecognizer {
+
+  /// 16 kHz mono float — the format `AudioCaptureManager` already converts every
+  /// captured buffer to (`AudioCaptureManager.targetSampleRate`). Feeding the
+  /// preview the same samples the transcription path stores means the two can
+  /// never disagree about what the microphone heard.
+  private static let captureSampleRate: Double = 16000
+
+  private let locale: Locale
+
+  private var targetFormat: AVAudioFormat?
+  private var converter: AVAudioConverter?
+  private var sourceFormat: AVAudioFormat?
+
+  private var module: DictationTranscriber?
+  private var analyzer: SpeechAnalyzer?
+  private var continuation: AsyncStream<AnalyzerInput>.Continuation?
+  private var collector: Task<Void, Never>?
+  private var fedAnyAudio = false
+  /// Bumped by every `startSession`. `endSession` refuses to tear down anything but
+  /// the session it was given, so a late teardown from an abandoned recording can
+  /// never close the analyzer the user is currently talking to. Without this the
+  /// two calls are merely serialized by the actor, not ORDERED, and a fast
+  /// stop-then-start could run them in the wrong order.
+  private var sessionToken: UInt64 = 0
+
+  init(locale: Locale) {
+    self.locale = locale
+  }
+
+  // MARK: - Preparation
+
+  /// Claim the locale, install its assets if missing, and resolve the audio
+  /// format. Throws so the caller can degrade; it is never called from the heart.
+  func prepare() async throws {
+    try await Self.reserveLocale(locale)
+
+    let probe = DictationTranscriber(locale: locale, preset: .progressiveLongDictation)
+    if let request = try await AssetInventory.assetInstallationRequest(supporting: [probe]) {
+      // The bytes come from Apple and are shared with the system's own dictation,
+      // so a user who already dictates in this language has paid for them already.
+      // We ship none of them.
+      try await request.downloadAndInstall()
+    }
+
+    guard
+      let source = AVAudioFormat(
+        commonFormat: .pcmFormatFloat32, sampleRate: Self.captureSampleRate,
+        channels: 1, interleaved: false)
+    else {
+      throw LivePreviewError.audioFormatUnavailable
+    }
+    sourceFormat = source
+
+    guard
+      let target = await SpeechAnalyzer.bestAvailableAudioFormat(
+        compatibleWith: [probe], considering: source)
+    else {
+      throw LivePreviewError.audioFormatUnavailable
+    }
+    targetFormat = target
+
+    // Warm with a THROWAWAY of the same preset. `prepareToAnalyze` pays the
+    // system-level spin-up that the first real session would otherwise be charged
+    // for — measured on the benchmark corpus as the difference between a first
+    // clip that looks broken (3573 ms to first text) and one that does not (630 ms).
+    // Deliberately never finalized: see trap 2.
+    let warmModule = DictationTranscriber(locale: locale, preset: .progressiveLongDictation)
+    let warmAnalyzer = SpeechAnalyzer(modules: [warmModule])
+    try await warmAnalyzer.prepareToAnalyze(in: target)
+  }
+
+  /// Claim a locale for this process before transcribing in it.
+  ///
+  /// **Installing is not provisioning, and skipping this does not fail at install.**
+  /// The installer reports success and `installedLocales` lists the language; the
+  /// failure arrives later at transcription as "No GeneralASR asset for language
+  /// de", which reads as a missing download and sends the investigation the wrong
+  /// way. Cost three rounds on #1988 before it was understood.
+  ///
+  /// `maximumReservedLocales` is 5 on macOS 26.6 and exceeding it is a runtime
+  /// refusal (`SFSpeechError` code 11), so a sixth claim evicts the oldest rather
+  /// than throwing. The reservation is per-app and does not survive the process.
+  private static func reserveLocale(_ locale: Locale) async throws {
+    let wanted = locale.identifier(.bcp47)
+    let already = await AssetInventory.reservedLocales
+    if already.contains(where: { $0.identifier(.bcp47) == wanted }) { return }
+    if already.count >= AssetInventory.maximumReservedLocales, let victim = already.first {
+      _ = await AssetInventory.release(reservedLocale: victim)
+    }
+    _ = try await AssetInventory.reserve(locale: locale)
+  }
+
+  /// Turn our ISO 639-1 language code into one of the recognizer's locales, or nil
+  /// if it cannot transcribe that language at all.
+  ///
+  /// **The equivalence is Apple's, not ours.** Our setting stores a bare code
+  /// ("en", "de") while the recognizer offers 54 full locales ("en-US", "en-GB"),
+  /// so something has to bridge them. Measured on this machine before adopting it:
+  /// en -> en-US, de -> de-DE, ja -> ja-JP, zh -> zh-CN, hi -> hi-IN, sv -> sv-SE,
+  /// and nil for a code Apple does not know. A hand-rolled filter over
+  /// `supportedLocales` was written first and thrown away: it would have had to
+  /// guess at regional equivalence the vendor already answers authoritatively.
+  static func resolveLocale(code: String) async -> Locale? {
+    await DictationTranscriber.supportedLocale(equivalentTo: Locale(identifier: code))
+  }
+
+  // MARK: - Session
+
+  /// Open a session and return its token, which `endSession` requires.
+  ///
+  /// `onText` is called on every result with the text the user should now see; it
+  /// is invoked from this actor's context and must be cheap.
+  @discardableResult
+  func startSession(onText: @escaping @Sendable (String) -> Void) async throws -> UInt64 {
+    guard let target = targetFormat, let source = sourceFormat else {
+      throw LivePreviewError.notPrepared
+    }
+    sessionToken &+= 1
+    let token = sessionToken
+    fedAnyAudio = false
+    // A fresh converter per session, so no resampler tail crosses a boundary and
+    // leaks the previous dictation's audio into this one.
+    converter = source == target ? nil : AVAudioConverter(from: source, to: target)
+
+    let fresh = DictationTranscriber(locale: locale, preset: .progressiveLongDictation)
+    module = fresh
+    let (stream, cont) = AsyncStream<AnalyzerInput>.makeStream()
+    continuation = cont
+    let analyzer = SpeechAnalyzer(modules: [fresh])
+    self.analyzer = analyzer
+    collector = Self.collect(from: fresh, onText: onText)
+    try await analyzer.start(inputSequence: stream)
+    return token
+  }
+
+  /// Accumulate results into the text a user would actually be looking at.
+  ///
+  /// **APPLE'S RESULTS ARE PER-SEGMENT, NOT CUMULATIVE, AND ASSUMING OTHERWISE
+  /// DELETES THE USER'S WORDS ON SCREEN.** After roughly a second of silence the
+  /// analyzer closes a segment and opens a new one whose first result carries only
+  /// that new segment — observed going from 309 characters to the single character
+  /// "." in one millisecond, then rebuilding. Treating each result as the whole
+  /// transcript wipes the pill at every pause. The founder found this in the first
+  /// live trial; it is the single most important line in this file.
+  ///
+  /// What a user sees is finished segments plus the one in flight, so that is what
+  /// is assembled.
+  private static func collect(
+    from transcriber: DictationTranscriber, onText: @escaping @Sendable (String) -> Void
+  ) -> Task<Void, Never> {
+    Task {
+      var committed = ""
+      var inFlight = ""
+      // A thrown error ends the stream. The text already on screen stays on
+      // screen: a preview that freezes mid-sentence is a far better failure than
+      // one that blanks, and the dictation itself is unaffected either way.
+      do {
+        for try await result in transcriber.results {
+          let piece = String(result.text.characters)
+          if result.isFinal {
+            committed += piece
+            inFlight = ""
+          } else {
+            inFlight = piece
+          }
+          onText(committed + inFlight)
+        }
+      } catch {}
+    }
+  }
+
+  /// Feed newly captured 16 kHz mono samples. Never throws: a preview that cannot
+  /// convert a buffer shows slightly less text, which is not worth propagating.
+  func feed(_ samples: [Float]) {
+    guard let cont = continuation, let source = sourceFormat, !samples.isEmpty else { return }
+    guard
+      let buffer = AVAudioPCMBuffer(
+        pcmFormat: source, frameCapacity: AVAudioFrameCount(samples.count))
+    else { return }
+    buffer.frameLength = AVAudioFrameCount(samples.count)
+    guard let channel = buffer.floatChannelData else { return }
+    samples.withUnsafeBufferPointer { src in
+      guard let base = src.baseAddress else { return }
+      channel[0].update(from: base, count: samples.count)
+    }
+
+    let toSend: AVAudioPCMBuffer
+    if let converter, let target = targetFormat {
+      guard let converted = Self.convert(buffer, using: converter, to: target) else { return }
+      toSend = converted
+    } else {
+      toSend = buffer
+    }
+    fedAnyAudio = true
+    nonisolated(unsafe) let unsafeBuffer = toSend
+    cont.yield(AnalyzerInput(buffer: unsafeBuffer))
+  }
+
+  /// Close the session identified by `token` and release its analyzer.
+  ///
+  /// A token that is not the current one is a teardown arriving from a recording
+  /// that has already been superseded, so it does nothing. Safe to call when no
+  /// session is open, and safe to call twice.
+  func endSession(token: UInt64) async {
+    guard token == sessionToken else { return }
+    continuation?.finish()
+    continuation = nil
+    // Only finalize when the analyzer actually received input — see trap 2. A
+    // finalize on an empty analyzer never returns, which would leak this task for
+    // the life of the process.
+    if fedAnyAudio, let analyzer {
+      try? await analyzer.finalizeAndFinishThroughEndOfInput()
+    }
+    fedAnyAudio = false
+    collector?.cancel()
+    collector = nil
+    analyzer = nil
+    module = nil
+    converter = nil
+  }
+
+  // MARK: - Conversion
+
+  /// One `AVAudioConverter` pass over one input buffer.
+  ///
+  /// Returns `.noDataNow` when the input is exhausted, never `.endOfStream`:
+  /// `.endOfStream` retires the converter permanently, so the buffer after it
+  /// would silently produce nothing for the rest of the dictation.
+  private static func convert(
+    _ buffer: AVAudioPCMBuffer, using converter: AVAudioConverter, to target: AVAudioFormat
+  ) -> AVAudioPCMBuffer? {
+    let ratio = target.sampleRate / buffer.format.sampleRate
+    let capacity = AVAudioFrameCount((Double(buffer.frameLength) * ratio).rounded(.up) + 1024)
+    guard let out = AVAudioPCMBuffer(pcmFormat: target, frameCapacity: capacity) else {
+      return nil
+    }
+    var supplied = false
+    var error: NSError?
+    nonisolated(unsafe) let input = buffer
+    let status = converter.convert(to: out, error: &error) { _, outStatus in
+      if supplied {
+        outStatus.pointee = .noDataNow
+        return nil
+      }
+      supplied = true
+      outStatus.pointee = .haveData
+      return input
+    }
+    guard status != .error, out.frameLength > 0 else { return nil }
+    return out
+  }
+}
+
+/// Why a preview is not running. Kept separate from the recognizer so the
+/// non-macOS-26 paths, which cannot even name `SpeechAnalyzer`, can still report.
+enum LivePreviewError: Error {
+  case audioFormatUnavailable
+  case notPrepared
+}

--- a/Sources/EnviousWisprAppKit/App/LivePreview/ApplePreviewRecognizer.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/ApplePreviewRecognizer.swift
@@ -127,6 +127,13 @@ actor ApplePreviewRecognizer {
     let warmModule = DictationTranscriber(locale: locale, preset: .progressiveLongDictation)
     let warmAnalyzer = SpeechAnalyzer(modules: [warmModule])
     try await warmAnalyzer.prepareToAnalyze(in: target)
+    // The THIRD abandoned-analyzer site, and the one a sweep of the previous two
+    // missed. Warm-up runs on first use and on every language change, and an
+    // analyzer that is simply dropped retains its analysis and model resources, so
+    // a user switching languages a few times accumulates them. `cancelAndFinishNow`
+    // rather than a finalize: trap 2's hang applies to FINALIZING an analyzer that
+    // received no input, not to cancelling one.
+    await warmAnalyzer.cancelAndFinishNow()
   }
 
   /// Claim a locale for this process before transcribing in it.
@@ -147,7 +154,15 @@ actor ApplePreviewRecognizer {
     if already.count >= AssetInventory.maximumReservedLocales, let victim = already.first {
       _ = await AssetInventory.release(reservedLocale: victim)
     }
-    _ = try await AssetInventory.reserve(locale: locale)
+    // The Bool matters. `reserve` returns false rather than throwing when the claim
+    // was not made — a reservation-limit race, or an eviction that did not take.
+    // Discarding it let `prepare()` report success for a locale that was never
+    // claimed, and the coordinator then CACHES that recognizer as ready, so every
+    // later recording reuses a broken one instead of retrying. The failure would
+    // have surfaced far away, as transcription complaining about a missing asset.
+    guard try await AssetInventory.reserve(locale: locale) else {
+      throw LivePreviewError.localeUnavailable
+    }
   }
 
   /// Turn our ISO 639-1 language code into one of the recognizer's locales, or nil
@@ -390,4 +405,8 @@ enum LivePreviewError: Error {
   case notPrepared
   /// The session was replaced by a newer one before it finished opening.
   case superseded
+  /// The locale could not be claimed for this process, so nothing can transcribe
+  /// in it. Distinct from "Apple does not support this language" — this one is
+  /// worth retrying on the next recording.
+  case localeUnavailable
 }

--- a/Sources/EnviousWisprAppKit/App/LivePreview/ApplePreviewRecognizer.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/ApplePreviewRecognizer.swift
@@ -60,17 +60,22 @@ actor ApplePreviewRecognizer {
   private var converter: AVAudioConverter?
   private var sourceFormat: AVAudioFormat?
 
-  private var module: DictationTranscriber?
-  private var analyzer: SpeechAnalyzer?
-  private var continuation: AsyncStream<AnalyzerInput>.Continuation?
-  private var collector: Task<Void, Never>?
-  private var fedAnyAudio = false
-  /// Bumped by every `startSession`. `endSession` refuses to tear down anything but
-  /// the session it was given, so a late teardown from an abandoned recording can
-  /// never close the analyzer the user is currently talking to. Without this the
-  /// two calls are merely serialized by the actor, not ORDERED, and a fast
-  /// stop-then-start could run them in the wrong order.
-  private var sessionToken: UInt64 = 0
+  /// The only session state this actor keeps. Everything else a session owns lives
+  /// on the `Session` value the caller holds.
+  ///
+  /// **Three review rounds found races here, all the same shape, because the
+  /// analyzer, continuation and collector used to be actor FIELDS.** An actor
+  /// serializes calls but is reentrant at every `await`, so any operation that
+  /// suspended could come back to fields a newer session had replaced: a teardown
+  /// clearing the live session's analyzer, a superseded start leaking its own, a
+  /// stale feed pushing audio into the wrong stream. Each was patchable with one
+  /// more token check, and a third round proved that was the wrong fix.
+  ///
+  /// With per-session values there is nothing shared to overwrite. Every operation
+  /// acts on the resources it was handed, so it cannot touch another session's even
+  /// if it wanted to, and this counter exists only to answer "is this session still
+  /// the current one" for the caller's benefit.
+  private var currentToken: UInt64 = 0
 
   init(locale: Locale) {
     self.locale = locale
@@ -155,49 +160,71 @@ actor ApplePreviewRecognizer {
 
   // MARK: - Session
 
-  /// Open a session and return its token, which `endSession` requires.
+  /// One live preview session and everything it owns.
   ///
-  /// `onText` is called on every result with the text the user should now see; it
-  /// is invoked from this actor's context and must be cheap.
-  @discardableResult
-  func startSession(onText: @escaping @Sendable (String) -> Void) async throws -> UInt64 {
+  /// Held by the caller, never by the actor, so a session can only ever be torn
+  /// down by whoever started it. `fedAnyAudio` is a reference box because feeding
+  /// happens on the actor while the value lives with the caller.
+  struct Session: Sendable {
+    let token: UInt64
+    fileprivate let analyzer: SpeechAnalyzer
+    fileprivate let continuation: AsyncStream<AnalyzerInput>.Continuation
+    fileprivate let collector: Task<Void, Never>
+    fileprivate let converter: AVAudioConverter?
+    fileprivate let sourceFormat: AVAudioFormat
+    fileprivate let targetFormat: AVAudioFormat
+    fileprivate let fedAnyAudio: FedFlag
+  }
+
+  /// Mutable "did any audio reach the analyzer" flag, per session.
+  final class FedFlag: @unchecked Sendable {
+    private(set) var value = false
+    fileprivate func set() { value = true }
+  }
+
+  /// Open a session. `onText` is called on every result with the text the user
+  /// should now see; it is invoked from the collector task and must be cheap.
+  ///
+  /// If the returned session is already superseded by the time `start` completes,
+  /// it is torn down here rather than returned, so a start that lost a race leaks
+  /// nothing and the caller gets a clear failure.
+  func startSession(onText: @escaping @Sendable (String) -> Void) async throws -> Session {
     guard let target = targetFormat, let source = sourceFormat else {
       throw LivePreviewError.notPrepared
     }
-    sessionToken &+= 1
-    let token = sessionToken
-    fedAnyAudio = false
+    currentToken &+= 1
+    let token = currentToken
+
     // A fresh converter per session, so no resampler tail crosses a boundary and
     // leaks the previous dictation's audio into this one.
-    converter = source == target ? nil : AVAudioConverter(from: source, to: target)
+    let converter = source == target ? nil : AVAudioConverter(from: source, to: target)
+    let module = DictationTranscriber(locale: locale, preset: .progressiveLongDictation)
+    let (stream, continuation) = AsyncStream<AnalyzerInput>.makeStream()
+    let analyzer = SpeechAnalyzer(modules: [module])
+    let collector = Self.collect(from: module, onText: onText)
 
-    let fresh = DictationTranscriber(locale: locale, preset: .progressiveLongDictation)
-    module = fresh
-    let (stream, cont) = AsyncStream<AnalyzerInput>.makeStream()
-    continuation = cont
-    let analyzer = SpeechAnalyzer(modules: [fresh])
-    self.analyzer = analyzer
-    collector = Self.collect(from: fresh, onText: onText)
+    func discard() {
+      continuation.finish()
+      collector.cancel()
+    }
+
     do {
       try await analyzer.start(inputSequence: stream)
     } catch {
-      // The fields above are already stored, and the coordinator's catch does not
-      // call `endSession` — it has no token to call it with. Without this rollback
-      // a failed or superseded start leaks the collector task and the analyzer's
-      // speech resources for the life of the process. Guarded so a start that lost
-      // a race does not tear down the session that beat it.
-      if token == sessionToken {
-        cont.finish()
-        collector?.cancel()
-        collector = nil
-        continuation = nil
-        self.analyzer = nil
-        module = nil
-        converter = nil
-      }
+      discard()
       throw error
     }
-    return token
+    // Superseded while `start` was suspended: this session's resources are ours
+    // alone, so close them rather than handing back something whose every later
+    // call would be rejected.
+    guard token == currentToken else {
+      discard()
+      throw LivePreviewError.superseded
+    }
+    return Session(
+      token: token, analyzer: analyzer, continuation: continuation, collector: collector,
+      converter: converter, sourceFormat: source, targetFormat: target,
+      fedAnyAudio: FedFlag())
   }
 
   /// Accumulate results into the text a user would actually be looking at.
@@ -244,19 +271,18 @@ actor ApplePreviewRecognizer {
     }
   }
 
-  /// Feed newly captured 16 kHz mono samples for the session identified by `token`.
+  /// Feed newly captured 16 kHz mono samples into `session`.
   ///
   /// Never throws: a preview that cannot convert a buffer shows slightly less text,
-  /// which is not worth propagating. The token is the same guard `endSession` uses,
-  /// and for the same reason — the feed loop is cancelled asynchronously, so a call
-  /// already in flight when the next recording begins would otherwise push the
-  /// previous dictation's audio into the new session's analyzer.
-  func feed(_ samples: [Float], token: UInt64) {
-    guard token == sessionToken else { return }
-    guard let cont = continuation, let source = sourceFormat, !samples.isEmpty else { return }
+  /// which is not worth propagating. A superseded session is dropped rather than
+  /// fed, because the feed loop is cancelled asynchronously and a call already in
+  /// flight when the next recording begins would otherwise push the previous
+  /// dictation's audio into the new stream.
+  func feed(_ samples: [Float], session: Session) {
+    guard session.token == currentToken, !samples.isEmpty else { return }
     guard
       let buffer = AVAudioPCMBuffer(
-        pcmFormat: source, frameCapacity: AVAudioFrameCount(samples.count))
+        pcmFormat: session.sourceFormat, frameCapacity: AVAudioFrameCount(samples.count))
     else { return }
     buffer.frameLength = AVAudioFrameCount(samples.count)
     guard let channel = buffer.floatChannelData else { return }
@@ -266,54 +292,32 @@ actor ApplePreviewRecognizer {
     }
 
     let toSend: AVAudioPCMBuffer
-    if let converter, let target = targetFormat {
-      guard let converted = Self.convert(buffer, using: converter, to: target) else { return }
+    if let converter = session.converter {
+      guard let converted = Self.convert(buffer, using: converter, to: session.targetFormat)
+      else { return }
       toSend = converted
     } else {
       toSend = buffer
     }
-    fedAnyAudio = true
+    session.fedAnyAudio.set()
     nonisolated(unsafe) let unsafeBuffer = toSend
-    cont.yield(AnalyzerInput(buffer: unsafeBuffer))
+    session.continuation.yield(AnalyzerInput(buffer: unsafeBuffer))
   }
 
-  /// Close the session identified by `token` and release its analyzer.
+  /// Close `session` and release its analyzer. Safe to call twice.
   ///
-  /// A token that is not the current one is a teardown arriving from a recording
-  /// that has already been superseded, so it does nothing. Safe to call when no
-  /// session is open, and safe to call twice.
-  func endSession(token: UInt64) async {
-    guard token == sessionToken else { return }
-
-    // **Everything this teardown touches is captured BEFORE the await.** An actor
-    // is reentrant at a suspension point, so while `finalizeAndFinishThroughEndOfInput`
-    // is running the next recording can enter `startSession` and replace
-    // `analyzer`, `collector` and `continuation` with its own. Resuming here and
-    // clearing the FIELDS would then silence the session the user is currently
-    // talking to. Checking the token only on entry, as the first version did, does
-    // not help: it was still true when checked. Review caught this.
-    let endingAnalyzer = analyzer
-    let endingCollector = collector
-    let endingContinuation = continuation
-    let hadAudio = fedAnyAudio
-
-    endingContinuation?.finish()
+  /// Needs no token check at all, which is the point of the value-owned design: the
+  /// resources closed here belong to this session and to nothing else, so a late
+  /// teardown from an abandoned recording cannot reach the live one.
+  func endSession(_ session: Session) async {
+    session.continuation.finish()
     // Only finalize when the analyzer actually received input — see trap 2. A
     // finalize on an empty analyzer never returns, which would leak this task for
     // the life of the process.
-    if hadAudio, let endingAnalyzer {
-      try? await endingAnalyzer.finalizeAndFinishThroughEndOfInput()
+    if session.fedAnyAudio.value {
+      try? await session.analyzer.finalizeAndFinishThroughEndOfInput()
     }
-    endingCollector?.cancel()
-
-    // Only now touch shared state, and only if this is still the current session.
-    guard token == sessionToken else { return }
-    continuation = nil
-    fedAnyAudio = false
-    collector = nil
-    analyzer = nil
-    module = nil
-    converter = nil
+    session.collector.cancel()
   }
 
   // MARK: - Conversion
@@ -353,4 +357,6 @@ actor ApplePreviewRecognizer {
 enum LivePreviewError: Error {
   case audioFormatUnavailable
   case notPrepared
+  /// The session was replaced by a newer one before it finished opening.
+  case superseded
 }

--- a/Sources/EnviousWisprAppKit/App/LivePreview/ApplePreviewRecognizer.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/ApplePreviewRecognizer.swift
@@ -178,7 +178,25 @@ actor ApplePreviewRecognizer {
     let analyzer = SpeechAnalyzer(modules: [fresh])
     self.analyzer = analyzer
     collector = Self.collect(from: fresh, onText: onText)
-    try await analyzer.start(inputSequence: stream)
+    do {
+      try await analyzer.start(inputSequence: stream)
+    } catch {
+      // The fields above are already stored, and the coordinator's catch does not
+      // call `endSession` — it has no token to call it with. Without this rollback
+      // a failed or superseded start leaks the collector task and the analyzer's
+      // speech resources for the life of the process. Guarded so a start that lost
+      // a race does not tear down the session that beat it.
+      if token == sessionToken {
+        cont.finish()
+        collector?.cancel()
+        collector = nil
+        continuation = nil
+        self.analyzer = nil
+        module = nil
+        converter = nil
+      }
+      throw error
+    }
     return token
   }
 
@@ -214,7 +232,11 @@ actor ApplePreviewRecognizer {
             committed = LivePreviewTextBound.apply(committed + piece)
             inFlight = ""
           } else {
-            inFlight = piece
+            // Bounded on STORAGE, not only on emission. Apple can keep returning
+            // non-final results for a long uninterrupted stretch, and an unbounded
+            // `inFlight` violates the retention invariant for as long as that
+            // lasts even though every emitted string is trimmed.
+            inFlight = LivePreviewTextBound.apply(piece)
           }
           onText(LivePreviewTextBound.apply(committed + inFlight))
         }

--- a/Sources/EnviousWisprAppKit/App/LivePreview/ApplePreviewRecognizer.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/ApplePreviewRecognizer.swift
@@ -237,7 +237,21 @@ actor ApplePreviewRecognizer {
 
     // A fresh converter per session, so no resampler tail crosses a boundary and
     // leaks the previous dictation's audio into this one.
-    let converter = source == target ? nil : AVAudioConverter(from: source, to: target)
+    //
+    // A nil converter must mean ONE thing: the formats match and no conversion is
+    // needed. `AVAudioConverter(from:to:)` is failable, so folding its failure into
+    // the same nil makes an unconvertible pair indistinguishable from an identical
+    // one, and `feed` would then hand the analyzer a source-format buffer it did
+    // not ask for. Refusing the session is the honest outcome — the caller degrades
+    // to "preview not ready" and the dictation itself is untouched.
+    let converter: AVAudioConverter?
+    if source == target {
+      converter = nil
+    } else if let made = AVAudioConverter(from: source, to: target) {
+      converter = made
+    } else {
+      throw LivePreviewError.audioFormatUnavailable
+    }
     let module = DictationTranscriber(locale: locale, preset: .progressiveLongDictation)
     // **Bounded, because an unbounded queue makes a limb able to hurt the heart.**
     // The default policy is `.unbounded`: if Apple's analyzer stalls or falls behind

--- a/Sources/EnviousWisprAppKit/App/LivePreview/ApplePreviewRecognizer.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/ApplePreviewRecognizer.swift
@@ -84,23 +84,8 @@ actor ApplePreviewRecognizer {
   /// the current one" for the caller's benefit.
   private var currentToken: UInt64 = 0
 
-  /// Custom Words, as pre-built lookups. Set by the coordinator whenever the
-  /// vocabulary changes and CAPTURED per session at `startSession`, so a
-  /// vocabulary edit mid-dictation cannot change what this session is applying
-  /// halfway through a sentence. The pasted text is corrected by the pipeline's
-  /// own step against the vocabulary live at THAT moment, so the two paths agree
-  /// on everything except an edit made during the few seconds of one dictation.
-  private var correctorLookups: WordCorrector.Lookups?
-
   init(locale: Locale) {
     self.locale = locale
-  }
-
-  /// Hand this recognizer a new Custom Words snapshot. Takes pre-built lookups
-  /// rather than terms so the build cost is paid once per vocabulary generation
-  /// on the coordinator, not once per recording here.
-  func setCorrectorLookups(_ lookups: WordCorrector.Lookups?) {
-    correctorLookups = lookups
   }
 
   // MARK: - Preparation
@@ -267,7 +252,16 @@ actor ApplePreviewRecognizer {
   /// If the returned session is already superseded by the time `start` completes,
   /// it is torn down here rather than returned, so a start that lost a race leaks
   /// nothing and the caller gets a clear failure.
-  func startSession(onText: @escaping @Sendable (String) -> Void) async throws -> Session {
+  /// `lookups` is this session's Custom Words snapshot, passed IN rather than read
+  /// from a stored property. Review found the stored-property version racy — the
+  /// coordinator installed it through an unstructured `Task`, so a session opened
+  /// straight after preparation could capture `nil` and show mangled names for the
+  /// first recording. Making it a parameter removes the race by construction
+  /// rather than ordering two awaits, which is the same lesson the `Session` value
+  /// above already encodes: shared mutable state on this actor is the bug.
+  func startSession(
+    lookups: WordCorrector.Lookups?, onText: @escaping @Sendable (String) -> Void
+  ) async throws -> Session {
     guard let target = targetFormat, let source = sourceFormat else {
       throw LivePreviewError.notPrepared
     }
@@ -303,8 +297,8 @@ actor ApplePreviewRecognizer {
     let (stream, continuation) = AsyncStream<AnalyzerInput>.makeStream(
       bufferingPolicy: .bufferingNewest(Self.maxQueuedChunks))
     let analyzer = SpeechAnalyzer(modules: [module])
-    // Captured, not read later: the session owns the vocabulary it started with.
-    let collector = Self.collect(from: module, lookups: correctorLookups, onText: onText)
+    // The session owns the vocabulary it started with.
+    let collector = Self.collect(from: module, lookups: lookups, onText: onText)
 
     // Finishing the stream and cancelling the collector is not enough: the analyzer
     // holds its own analysis and model resources and needs an explicit end, or a
@@ -383,11 +377,17 @@ actor ApplePreviewRecognizer {
             // lasts even though every emitted string is trimmed.
             inFlight = LivePreviewTextBound.apply(piece)
           }
-          // Correct AFTER bounding, never before. The bound keeps the tail, so
-          // correcting first would scan the whole retained transcript several
-          // times a second to produce a string whose head is then thrown away —
-          // unbounded work for output nobody sees. Bounding first caps this at
-          // the visible window.
+          // Bounded on BOTH sides of correction, and neither is redundant.
+          //
+          // BEFORE caps the SCAN: the bound keeps the tail, so correcting first
+          // would scan the whole retained transcript several times a second to
+          // produce a string whose head is then thrown away.
+          //
+          // AFTER caps the RESULT: correction EXPANDS text. An alias is usually
+          // shorter than the canonical it maps to, so a passage full of them can
+          // cross the retention limit that the pre-bound appeared to guarantee.
+          // Review caught this, and the first bound is exactly what made the
+          // invariant look already held.
           //
           // Applied to the assembled string rather than to each incoming piece
           // because a custom term can span the segment join: Apple closes a
@@ -396,9 +396,10 @@ actor ApplePreviewRecognizer {
           // are least stable on proper nouns, which is the whole reason the issue
           // asks for the dictionary on the preview pass).
           onText(
-            Self.corrected(
-              LivePreviewTextBound.apply(committed + inFlight),
-              corrector: corrector, lookups: lookups))
+            LivePreviewTextBound.apply(
+              Self.corrected(
+                LivePreviewTextBound.apply(committed + inFlight),
+                corrector: corrector, lookups: lookups)))
         }
       } catch {}
     }

--- a/Sources/EnviousWisprAppKit/App/LivePreview/ApplePreviewRecognizer.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/ApplePreviewRecognizer.swift
@@ -54,6 +54,12 @@ actor ApplePreviewRecognizer {
   /// never disagree about what the microphone heard.
   private static let captureSampleRate: Double = 16000
 
+  /// How many 100 ms audio chunks may wait for the analyzer before the oldest are
+  /// dropped. Fifty is five seconds, comfortably past the ~210-290 ms cadence Apple
+  /// was measured at, so a healthy stream never reaches it and only a genuine stall
+  /// does.
+  private static let maxQueuedChunks = 50
+
   private let locale: Locale
 
   private var targetFormat: AVAudioFormat?
@@ -199,7 +205,16 @@ actor ApplePreviewRecognizer {
     // leaks the previous dictation's audio into this one.
     let converter = source == target ? nil : AVAudioConverter(from: source, to: target)
     let module = DictationTranscriber(locale: locale, preset: .progressiveLongDictation)
-    let (stream, continuation) = AsyncStream<AnalyzerInput>.makeStream()
+    // **Bounded, because an unbounded queue makes a limb able to hurt the heart.**
+    // The default policy is `.unbounded`: if Apple's analyzer stalls or falls behind
+    // real time, the feed loop keeps handing it a chunk every 100 ms forever and the
+    // preview grows without limit, putting memory pressure on the dictation it is
+    // supposed to be decorating. `.bufferingNewest` caps it and drops the OLDEST
+    // audio, which is the right thing to lose here: the pill shows a tail, so a gap
+    // in the middle of a stalled stretch costs the user nothing they can see, while
+    // stopping the preview outright would.
+    let (stream, continuation) = AsyncStream<AnalyzerInput>.makeStream(
+      bufferingPolicy: .bufferingNewest(Self.maxQueuedChunks))
     let analyzer = SpeechAnalyzer(modules: [module])
     let collector = Self.collect(from: module, onText: onText)
 

--- a/Sources/EnviousWisprAppKit/App/LivePreview/ApplePreviewRecognizer.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/ApplePreviewRecognizer.swift
@@ -91,6 +91,29 @@ actor ApplePreviewRecognizer {
 
   /// Claim the locale, install its assets if missing, and resolve the audio
   /// format. Throws so the caller can degrade; it is never called from the heart.
+  ///
+  /// **No `SFSpeechRecognizer` authorization call, and no
+  /// `com.apple.security.personal-information.speech-recognition` entitlement:
+  /// this path needs neither. MEASURED, not assumed** — a standalone probe ran
+  /// this exact stack (reserve, `DictationTranscriber`, `SpeechAnalyzer`, real
+  /// audio, real text out) under three signatures: ad-hoc unhardened, self-signed
+  /// with hardened runtime, and the real Developer ID cert with hardened runtime
+  /// and this app's shipping entitlements. All three transcribed, with
+  /// `SFSpeechRecognizer.authorizationStatus()` reporting `notDetermined`
+  /// throughout — never requested, never granted. The legacy authorization gate
+  /// gates the legacy recognizer, which could ship audio to Apple's servers; this
+  /// analyzes on-device audio the app already holds microphone permission for.
+  ///
+  /// Recorded because a review round raised the opposite as a P1, reasoning by
+  /// analogy from the Contacts case (#636), where a usage string without the
+  /// matching entitlement failed SILENTLY on hardened runtime. That analogy is
+  /// sound and the conclusion is still wrong, so the measurement lives here
+  /// rather than in a session log. `NSSpeechRecognitionUsageDescription` stays in
+  /// Info.plist: it is not what grants access, but macOS terminates an app that
+  /// touches a protected class without one, and that is cheap insurance against a
+  /// future OS tightening this.
+  /// Re-measure before contradicting: `scratchpad/speechprobe/` in the #1988
+  /// session, or rebuild the probe from this doc comment.
   func prepare() async throws {
     try await Self.reserveLocale(locale)
 

--- a/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
@@ -1,0 +1,344 @@
+import AVFoundation
+import EnviousWisprAudio
+import EnviousWisprCore
+import Foundation
+
+/// What the recording pill should render for the live preview (#1988).
+///
+/// `unavailable` carries a sentence rather than being folded into `off` because
+/// an empty preview reads as "it did not hear me", which is the exact anxiety
+/// this feature exists to remove. If the user turned it on and we cannot deliver,
+/// the pill says so.
+enum LivePreviewDisplay: Equatable {
+  /// The user has it switched off, or this recording is not eligible. The pill
+  /// renders at its normal size with no preview area.
+  case off
+  /// Running, nothing heard yet.
+  case waiting
+  /// Running, with text. Always the full retained tail; the view decides how much
+  /// of it fits.
+  case text(String)
+  /// Switched on but cannot run. The string is a short user-facing sentence.
+  case unavailable(String)
+}
+
+/// Drives the live preview and owns every reason it might not run.
+///
+/// ## This is a limb, and the limb rules are the whole design
+///
+/// The critical path is trigger, capture, transcribe, paste. The preview must
+/// never appear in it. Concretely, and each of these is load-bearing rather than
+/// defensive habit:
+///
+/// - **The heart never awaits it.** `setRecording(_:)` returns immediately; all
+///   work happens in a detached task.
+/// - **It never touches the audio path.** It polls the samples the capture
+///   manager has already stored, exactly as the crash-recovery spool does
+///   (`AudioCaptureManager.startRecoveryFeed`). It installs no tap, takes no
+///   callback slot, and holds no lock the recording path can block on. The
+///   kernel's `onBufferCaptured` is a single-consumer slot the kernel owns;
+///   sharing it would have put display code inside the heart's own callback.
+/// - **It cannot fail loudly.** Every error becomes a display state. There is no
+///   throwing path out of this type.
+/// - **It is bounded.** Retained text is capped, so a 77-minute dictation cannot
+///   grow a display artifact without limit.
+///
+/// Measured before any of it was built (#1988 limb safety gate, 72 trials over 6
+/// of the founder's own dictations x 4 arms x 3 repeats): with the preview
+/// running concurrently, the transcription output was **byte-identical in 18 of
+/// 18 trials**, feed-schedule slip moved +0.1 ms and finalize latency moved
+/// within the run's own noise floor. The instrument was proven able to detect
+/// contention first — saturating every core moved slip 5.3 ms, well outside that
+/// floor — so the null result is evidence rather than an absence of evidence.
+@MainActor
+final class LivePreviewCoordinator {
+
+  /// Poll cadence for handing new audio to the recognizer. Matches the 100 ms
+  /// chunking the benchmark harness used, so the screening numbers describe this
+  /// feed. Apple emits updates every ~210-290 ms, so a faster poll would buy
+  /// nothing.
+  private static let feedIntervalMs = 100
+
+  /// Upper bound on retained display text. The preview shows a tail of at most a
+  /// couple of lines; the founder's own longest dictation ran to 9,388 words,
+  /// none of which a pill can show. Retaining all of it would be permanent
+  /// display-only memory growth, so the front is trimmed. Nothing user-visible
+  /// depends on the discarded prefix.
+  /// Internal rather than private so the bound is asserted against the real
+  /// constant instead of a copy of it in a test.
+  static let maxRetainedCharacters = 2000
+
+  /// Current display state. Read by the pill's provider closure at 20 Hz, the
+  /// same way audio level and elapsed time already are.
+  private(set) var display: LivePreviewDisplay = .off
+
+  private let audioCapture: any AudioCaptureInterface
+  private let isEnabled: () -> Bool
+  private let languageMode: () -> LanguageMode
+
+  /// The prepared recognizer, kept across recordings so the second press does not
+  /// pay preparation again. `Any` because the type cannot be named below macOS 26.
+  private var preparedRecognizer: Any?
+  /// The locale `preparedRecognizer` was prepared for, so a language change
+  /// rebuilds it.
+  private var preparedLocale: Locale?
+
+  private var sessionTask: Task<Void, Never>?
+  /// In-flight preparation, shared by every session that arrives while it runs.
+  ///
+  /// Preparation is deliberately NOT owned by a session. First use of a language
+  /// can download an Apple speech model, which takes as long as it takes; if a
+  /// session owned that work, cancelling the recording would either abandon a
+  /// half-finished download or leave the next session waiting behind it. Held
+  /// separately, it survives the recording that triggered it, is never cancelled,
+  /// and is shared rather than duplicated.
+  private var preparationTask: Task<Bool, Never>?
+  private var isRunning = false
+
+  init(
+    audioCapture: any AudioCaptureInterface,
+    isEnabled: @escaping () -> Bool,
+    languageMode: @escaping () -> LanguageMode
+  ) {
+    self.audioCapture = audioCapture
+    self.isEnabled = isEnabled
+    self.languageMode = languageMode
+  }
+
+  // MARK: - Lifecycle
+
+  /// Start or stop the preview for the current recording.
+  ///
+  /// Idempotent in both directions, deliberately: this is called from two places
+  /// (the first overlay push in `RecordingStarter`, and every state-driven push in
+  /// `DictationLifecycleCoordinator`), and a second start must not open a second
+  /// analyzer. Returns immediately in all cases.
+  func setRecording(_ recording: Bool) {
+    if recording {
+      guard !isRunning else { return }
+      guard isEnabled() else {
+        display = .off
+        return
+      }
+      isRunning = true
+      display = .waiting
+      startSession()
+    } else {
+      guard isRunning else { return }
+      isRunning = false
+      let task = sessionTask
+      sessionTask = nil
+      task?.cancel()
+      // The last text is deliberately left in `display` rather than blanked. The
+      // polishing pill is a different view and never renders it, so nothing shows
+      // it; and the next `setRecording(true)` sets `.waiting` synchronously, before
+      // the new panel is created on the following run loop pass, so a new recording
+      // can never open showing the previous one's words.
+    }
+  }
+
+  private func startSession() {
+    sessionTask = Task { @MainActor [weak self] in
+      guard let self else { return }
+      guard #available(macOS 26.0, *) else {
+        self.display = .unavailable(LivePreviewCopy.needsNewerMacOS)
+        return
+      }
+      await self.runSession()
+    }
+  }
+
+  @available(macOS 26.0, *)
+  private func runSession() async {
+    let code = Self.previewLanguageCode(languageMode())
+    guard let locale = await ApplePreviewRecognizer.resolveLocale(code: code) else {
+      display = .unavailable(LivePreviewCopy.languageUnsupported)
+      await Self.log("no recognizer locale for language=\(code)")
+      return
+    }
+
+    // Say "getting ready" rather than "listening" while preparation runs. On first
+    // use of a language that can mean downloading an Apple speech model, and a pill
+    // promising to listen while nothing appears is the exact impression this
+    // feature exists to prevent.
+    let alreadyPrepared = preparedRecognizer is ApplePreviewRecognizer && preparedLocale == locale
+    if !alreadyPrepared { display = .unavailable(LivePreviewCopy.preparing) }
+
+    guard await ensurePrepared(for: locale),
+      let recognizer = preparedRecognizer as? ApplePreviewRecognizer
+    else {
+      display = .unavailable(LivePreviewCopy.notReady)
+      await Self.log("not ready for locale=\(locale.identifier(.bcp47))")
+      return
+    }
+
+    if Task.isCancelled { return }
+    display = .waiting
+
+    // Diagnostics: transitions only, never per-update. The pill repaints several
+    // times a second and logging each one would bury the log AND charge the main
+    // actor for text nobody reads. `updates` is counted here and reported once.
+    var updates = 0
+    // The recognizer calls back from its own actor. Hop to the main actor and
+    // publish, bounded, so the 20 Hz pill read is a plain property read.
+    let publish: @Sendable (String) -> Void = { [weak self] text in
+      Task { @MainActor in
+        guard let self, self.isRunning else { return }
+        self.display = .text(Self.bounded(text))
+      }
+    }
+
+    let token: UInt64
+    do {
+      token = try await recognizer.startSession(onText: publish)
+    } catch {
+      display = .unavailable(LivePreviewCopy.notReady)
+      await Self.log("session refused to start: \(error)")
+      return
+    }
+    await Self.log("session started, locale=\(locale.identifier(.bcp47))")
+
+    await feedLoop(into: recognizer) { updates += 1 }
+    // Tokened, so a teardown that loses a race against the next recording's
+    // `startSession` does nothing instead of closing the live analyzer.
+    await recognizer.endSession(token: token)
+    // Reports what the PILL received, so an empty preview is distinguishable from
+    // a preview that ran and heard nothing. Those look identical on screen and
+    // have completely different causes.
+    let shown: Int
+    if case .text(let t) = display { shown = t.count } else { shown = 0 }
+    await Self.log("session ended, feeds=\(updates) shownChars=\(shown)")
+  }
+
+  /// One log seam so every preview line carries the same category and the whole
+  /// limb can be grepped with `LIVE_PREVIEW`.
+  private static func log(_ message: String) async {
+    await AppLogger.shared.log("LIVE_PREVIEW \(message)", category: "LivePreview")
+  }
+
+  /// Make sure a recognizer for `locale` exists and is ready, returning whether it
+  /// is. Never makes one recording's preview wait on another recording.
+  ///
+  /// A caller arriving while preparation is in flight awaits THAT task rather than
+  /// starting a second one, so several recordings during one model download cause
+  /// one download and wait only on it. That distinction is the whole point: waiting
+  /// on the work is unavoidable, waiting on an unrelated recording's task is not,
+  /// and an earlier draft did the second — one slow first-run download would have
+  /// silently disabled the preview for every recording after it.
+  ///
+  /// A cancelled session that is parked here simply returns and checks
+  /// `Task.isCancelled`; the preparation continues, which is what makes the NEXT
+  /// recording fast.
+  @available(macOS 26.0, *)
+  private func ensurePrepared(for locale: Locale) async -> Bool {
+    if preparedRecognizer is ApplePreviewRecognizer, preparedLocale == locale { return true }
+
+    // A language change invalidates the in-flight preparation for the old one.
+    if preparedLocale != locale {
+      preparationTask = nil
+      preparedRecognizer = nil
+    }
+
+    if let existing = preparationTask { return await existing.value }
+
+    let task = Task<Bool, Never> { [weak self] in
+      let fresh = ApplePreviewRecognizer(locale: locale)
+      do {
+        try await fresh.prepare()
+      } catch {
+        return false
+      }
+      guard let self else { return false }
+      return await MainActor.run {
+        self.preparedRecognizer = fresh
+        self.preparedLocale = locale
+        return true
+      }
+    }
+    preparationTask = task
+    preparedLocale = locale
+    let ok = await task.value
+    if !ok { preparationTask = nil }  // let a later recording retry
+    return ok
+  }
+
+  /// Hand newly captured audio to the recognizer until the recording ends.
+  ///
+  /// Reads `getSamplesSnapshot(fromIndex:)`, the same incremental accessor the
+  /// crash-recovery spool uses. `fed` starts at whatever the buffer already holds
+  /// so a late start never replays the beginning at speed, and it re-syncs if the
+  /// count goes backwards, which is what a buffer reset between recordings looks
+  /// like from here.
+  @available(macOS 26.0, *)
+  private func feedLoop(
+    into recognizer: ApplePreviewRecognizer, onFeed: @escaping () -> Void
+  ) async {
+    let initial = await audioCapture.getSamplesSnapshot(fromIndex: 0)
+    var fed = initial.totalCount
+
+    while !Task.isCancelled {
+      try? await Task.sleep(for: .milliseconds(Self.feedIntervalMs))
+      if Task.isCancelled { break }
+      let snapshot = await audioCapture.getSamplesSnapshot(fromIndex: fed)
+      if snapshot.totalCount < fed {
+        // The capture buffer was cleared under us (recording ended, or the next
+        // one began). Re-sync rather than going permanently silent, which is what
+        // an unconditional high-water mark would do here.
+        fed = snapshot.totalCount
+        continue
+      }
+      guard !snapshot.samples.isEmpty else { continue }
+      fed = snapshot.totalCount
+      onFeed()
+      await recognizer.feed(snapshot.samples)
+    }
+  }
+
+  // MARK: - Locale
+
+  /// The ISO 639-1 code to preview in.
+  ///
+  /// Apple's recognizer must commit to one language up front, so Auto-detect has
+  /// no answer to give it. The system language is the honest guess: it is what the
+  /// user's Mac is set to, and being wrong costs a preview rather than a transcript.
+  ///
+  /// Only the POLICY lives here. Turning a bare code into one of the recognizer's
+  /// 54 locales is a vendor question, answered by the vendor in
+  /// `ApplePreviewRecognizer.resolveLocale(code:)`.
+  static func previewLanguageCode(_ mode: LanguageMode) -> String {
+    switch mode {
+    case .locked(let code): return code
+    case .auto: return Locale.current.language.languageCode?.identifier ?? "en"
+    }
+  }
+
+  // MARK: - Bounding
+
+  /// Keep the tail, drop the head, and do not cut a word in half.
+  ///
+  /// The word-boundary step must never be able to disable the bound: a script with
+  /// no spaces (CJK) or a pathological unbroken run has no boundary to find, and
+  /// the fallback returns the hard-trimmed tail rather than the original.
+  static func bounded(_ text: String) -> String {
+    guard text.count > maxRetainedCharacters else { return text }
+    let tail = String(text.suffix(maxRetainedCharacters))
+    guard let space = tail.firstIndex(of: " ") else { return tail }
+    return String(tail[tail.index(after: space)...])
+  }
+}
+
+/// User-facing copy for the preview's non-running states. One home, so a change
+/// is a conscious act. No em-dashes or en-dashes (brand rule).
+/// The type name keeps "LivePreview" because that is what the feature is called
+/// internally; the STRINGS avoid "live" for the reason given on
+/// `LivePreviewSettingsCopy.sectionHeader`, and a test enforces it.
+enum LivePreviewCopy {
+  static let needsNewerMacOS = "On-screen preview needs macOS 26."
+  static let languageUnsupported = "On-screen preview does not support this language yet."
+  static let notReady = "On-screen preview is not ready yet."
+  /// Shown while the recognizer is being prepared, which on first use of a language
+  /// can include downloading an Apple speech model.
+  static let preparing = "Getting the preview ready..."
+  /// Shown in the pill while the preview is running but has not heard words yet.
+  static let listening = "Listening..."
+}

--- a/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
@@ -283,14 +283,25 @@ final class LivePreviewCoordinator: CorrectorVocabularyConsumer {
     await Self.log("session ended, feeds=\(updates) shownChars=\(shown)")
   }
 
-  /// Whether the recording that started this session is still the current one.
+  /// Whether the recording that started this session is still the current one AND
+  /// a recording is still live.
   ///
-  /// Checked after every await that precedes a `display` write. Without it, a
-  /// session abandoned during locale resolution or model preparation resumes later
-  /// and writes its own outcome over the pill of a recording that is already
-  /// underway — "not ready" appearing over live words.
+  /// Checked after every await that precedes a `display` write. Without the
+  /// generation half, a session abandoned during locale resolution or model
+  /// preparation resumes later and writes its own outcome over the pill of a
+  /// recording that is already underway — "not ready" appearing over live words.
+  ///
+  /// **`isRunning` is the other half, and it became load-bearing when stopping
+  /// started discarding the text.** Stopping cancels the session task and clears
+  /// `display`, but does NOT bump the generation, because no newer recording has
+  /// claimed one. Cancellation is cooperative: an await inside an Apple API can
+  /// still return normally, after which every generation check passes and the
+  /// resumed code writes its outcome over the `.off` that the stop just set. That
+  /// resurrects state after the recording ended — at best "not ready" appearing on
+  /// a pill nobody is using, at worst undoing the discard the settings copy
+  /// promises. Checking both means "this recording, and it is still happening".
   private func isCurrent(_ generation: UInt64) -> Bool {
-    sessionGeneration == generation
+    isRunning && sessionGeneration == generation
   }
 
   /// One log seam so every preview line carries the same category and the whole
@@ -423,19 +434,39 @@ final class LivePreviewCoordinator: CorrectorVocabularyConsumer {
 
   // MARK: - Locale
 
-  /// The ISO 639-1 code to preview in.
+  /// The language tag to preview in: a bare ISO 639-1 code when the user locked
+  /// one, the FULL system locale under Auto.
   ///
   /// Apple's recognizer must commit to one language up front, so Auto-detect has
   /// no answer to give it. The system language is the honest guess: it is what the
   /// user's Mac is set to, and being wrong costs a preview rather than a transcript.
   ///
-  /// Only the POLICY lives here. Turning a bare code into one of the recognizer's
-  /// 54 locales is a vendor question, answered by the vendor in
+  /// **Auto passes region and script through, because reducing to the language
+  /// code silently picks the wrong regional model. MEASURED against the real
+  /// resolver, all three columns**: a `zh-TW` Mac resolved to `zh-CN`, Simplified
+  /// characters for a Traditional reader; `pt-BR` to `pt-PT`; `fr-CA` to `fr-CH`,
+  /// Canadian French landing on Swiss; and every `en-GB`/`en-IN`/`en-AU` to
+  /// `en-US`. Passing the full locale gives each of those its own model.
+  ///
+  /// The obvious risk of doing this — a full locale Apple cannot resolve returning
+  /// nil where the bare code would have worked, disabling the preview for whole
+  /// regions — was measured across 21 locales and does NOT occur: every case
+  /// resolved as well or better, and the three that returned nil (`nn-NO`,
+  /// `sr-Latn-RS`, `az-Cyrl-AZ`) return nil for the bare code too. `ca-ES-valencia`
+  /// degrades gracefully to `ca-ES`.
+  ///
+  /// Locked mode still passes a bare code because our language catalogue holds
+  /// bare ISO 639-1 codes, so a user who explicitly picks Chinese gets `zh-CN`.
+  /// Giving locked mode regional variants means adding them to that catalogue,
+  /// which is a product decision about a user-visible list, not this function.
+  ///
+  /// Only the POLICY lives here. Turning a tag into one of the recognizer's
+  /// locales is a vendor question, answered by the vendor in
   /// `ApplePreviewRecognizer.resolveLocale(code:)`.
   static func previewLanguageCode(_ mode: LanguageMode) -> String {
     switch mode {
     case .locked(let code): return code
-    case .auto: return Locale.current.language.languageCode?.identifier ?? "en"
+    case .auto: return Locale.current.identifier(.bcp47)
     }
   }
 

--- a/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
@@ -64,9 +64,6 @@ final class LivePreviewCoordinator {
   /// none of which a pill can show. Retaining all of it would be permanent
   /// display-only memory growth, so the front is trimmed. Nothing user-visible
   /// depends on the discarded prefix.
-  /// Internal rather than private so the bound is asserted against the real
-  /// constant instead of a copy of it in a test.
-  static let maxRetainedCharacters = 2000
 
   /// Current display state. Read by the pill's provider closure at 20 Hz, the
   /// same way audio level and elapsed time already are.
@@ -93,6 +90,12 @@ final class LivePreviewCoordinator {
   /// separately, it survives the recording that triggered it, is never cancelled,
   /// and is shared rather than duplicated.
   private var preparationTask: Task<Bool, Never>?
+  /// Bumped whenever the preview language changes, so a preparation still running
+  /// for the old language cannot publish itself as the current one.
+  private var preparationGeneration: UInt64 = 0
+  /// Bumped once per recording. Every asynchronous hand-off is checked against it,
+  /// because `isRunning` says "a recording is live" and not "THIS recording".
+  private var sessionGeneration: UInt64 = 0
   private var isRunning = false
 
   init(
@@ -179,12 +182,20 @@ final class LivePreviewCoordinator {
     // times a second and logging each one would bury the log AND charge the main
     // actor for text nobody reads. `updates` is counted here and reported once.
     var updates = 0
+    // This recording's identity. Every asynchronous hand-off below is checked
+    // against it, because `isRunning` alone cannot tell the difference between
+    // "this recording" and "a recording" — and by the time a queued callback from
+    // the previous dictation runs, `isRunning` is true again for the NEW one.
+    sessionGeneration &+= 1
+    let generation = sessionGeneration
+
     // The recognizer calls back from its own actor. Hop to the main actor and
-    // publish, bounded, so the 20 Hz pill read is a plain property read.
+    // publish so the 20 Hz pill read is a plain property read. The text arrives
+    // already bounded (`LivePreviewTextBound`, applied at the producer).
     let publish: @Sendable (String) -> Void = { [weak self] text in
       Task { @MainActor in
-        guard let self, self.isRunning else { return }
-        self.display = .text(Self.bounded(text))
+        guard let self, self.isRunning, self.sessionGeneration == generation else { return }
+        self.display = .text(text)
       }
     }
 
@@ -198,7 +209,7 @@ final class LivePreviewCoordinator {
     }
     await Self.log("session started, locale=\(locale.identifier(.bcp47))")
 
-    await feedLoop(into: recognizer) { updates += 1 }
+    await feedLoop(into: recognizer, token: token) { updates += 1 }
     // Tokened, so a teardown that loses a race against the next recording's
     // `startSession` does nothing instead of closing the live analyzer.
     await recognizer.endSession(token: token)
@@ -229,18 +240,30 @@ final class LivePreviewCoordinator {
   /// A cancelled session that is parked here simply returns and checks
   /// `Task.isCancelled`; the preparation continues, which is what makes the NEXT
   /// recording fast.
+  ///
+  /// **Dropping a reference to a task does not stop the task.** Switching language
+  /// mid-preparation used to clear `preparationTask` and move on, leaving the old
+  /// language's task running with an unconditional write to `preparedRecognizer`
+  /// and `preparedLocale` at the end of it. It could land after the new language's
+  /// task and hand the next recording a German recognizer while every check said
+  /// English was ready. The generation below is what makes the write conditional;
+  /// review caught the original.
   @available(macOS 26.0, *)
   private func ensurePrepared(for locale: Locale) async -> Bool {
     if preparedRecognizer is ApplePreviewRecognizer, preparedLocale == locale { return true }
 
-    // A language change invalidates the in-flight preparation for the old one.
+    // A language change invalidates the in-flight preparation for the old one. The
+    // generation bump is what actually invalidates it; clearing the reference only
+    // stops US waiting on it.
     if preparedLocale != locale {
+      preparationGeneration &+= 1
       preparationTask = nil
       preparedRecognizer = nil
     }
 
     if let existing = preparationTask { return await existing.value }
 
+    let generation = preparationGeneration
     let task = Task<Bool, Never> { [weak self] in
       let fresh = ApplePreviewRecognizer(locale: locale)
       do {
@@ -250,6 +273,8 @@ final class LivePreviewCoordinator {
       }
       guard let self else { return false }
       return await MainActor.run {
+        // Publish only if the language has not moved on while this ran.
+        guard self.preparationGeneration == generation else { return false }
         self.preparedRecognizer = fresh
         self.preparedLocale = locale
         return true
@@ -258,7 +283,9 @@ final class LivePreviewCoordinator {
     preparationTask = task
     preparedLocale = locale
     let ok = await task.value
-    if !ok { preparationTask = nil }  // let a later recording retry
+    // Let a later recording retry, but only if nothing newer has already claimed
+    // the slot — clearing unconditionally would discard a live preparation.
+    if !ok, preparationGeneration == generation { preparationTask = nil }
     return ok
   }
 
@@ -271,7 +298,7 @@ final class LivePreviewCoordinator {
   /// like from here.
   @available(macOS 26.0, *)
   private func feedLoop(
-    into recognizer: ApplePreviewRecognizer, onFeed: @escaping () -> Void
+    into recognizer: ApplePreviewRecognizer, token: UInt64, onFeed: @escaping () -> Void
   ) async {
     let initial = await audioCapture.getSamplesSnapshot(fromIndex: 0)
     var fed = initial.totalCount
@@ -290,7 +317,7 @@ final class LivePreviewCoordinator {
       guard !snapshot.samples.isEmpty else { continue }
       fed = snapshot.totalCount
       onFeed()
-      await recognizer.feed(snapshot.samples)
+      await recognizer.feed(snapshot.samples, token: token)
     }
   }
 
@@ -312,19 +339,6 @@ final class LivePreviewCoordinator {
     }
   }
 
-  // MARK: - Bounding
-
-  /// Keep the tail, drop the head, and do not cut a word in half.
-  ///
-  /// The word-boundary step must never be able to disable the bound: a script with
-  /// no spaces (CJK) or a pathological unbroken run has no boundary to find, and
-  /// the fallback returns the hard-trimmed tail rather than the original.
-  static func bounded(_ text: String) -> String {
-    guard text.count > maxRetainedCharacters else { return text }
-    let tail = String(text.suffix(maxRetainedCharacters))
-    guard let space = tail.firstIndex(of: " ") else { return tail }
-    return String(tail[tail.index(after: space)...])
-  }
 }
 
 /// User-facing copy for the preview's non-running states. One home, so a change

--- a/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
@@ -212,9 +212,9 @@ final class LivePreviewCoordinator {
       }
     }
 
-    let token: UInt64
+    let session: ApplePreviewRecognizer.Session
     do {
-      token = try await recognizer.startSession(onText: publish)
+      session = try await recognizer.startSession(onText: publish)
     } catch {
       guard isCurrent(generation) else { return }
       display = .unavailable(LivePreviewCopy.notReady)
@@ -223,10 +223,9 @@ final class LivePreviewCoordinator {
     }
     await Self.log("session started, locale=\(locale.identifier(.bcp47))")
 
-    await feedLoop(into: recognizer, token: token) { updates += 1 }
-    // Tokened, so a teardown that loses a race against the next recording's
-    // `startSession` does nothing instead of closing the live analyzer.
-    await recognizer.endSession(token: token)
+    await feedLoop(into: recognizer, session: session) { updates += 1 }
+    // Closes the resources THIS session owns, so it cannot reach a newer one.
+    await recognizer.endSession(session)
     // Reports what the PILL received, so an empty preview is distinguishable from
     // a preview that ran and heard nothing. Those look identical on screen and
     // have completely different causes.
@@ -322,10 +321,17 @@ final class LivePreviewCoordinator {
   /// like from here.
   @available(macOS 26.0, *)
   private func feedLoop(
-    into recognizer: ApplePreviewRecognizer, token: UInt64, onFeed: @escaping () -> Void
+    into recognizer: ApplePreviewRecognizer,
+    session: ApplePreviewRecognizer.Session,
+    onFeed: @escaping () -> Void
   ) async {
-    let initial = await audioCapture.getSamplesSnapshot(fromIndex: 0)
-    var fed = initial.totalCount
+    // `Int.max`, not 0, and the difference is not cosmetic. `getSamplesSnapshot`
+    // clamps `fromIndex` to the total and returns an EMPTY slice when the clamped
+    // index reaches it, so this reads the count without copying anything. Asking
+    // from 0 would copy the entire captured buffer — on a long recording that is
+    // hundreds of megabytes allocated and copied ON THE MAIN ACTOR, by a limb, to
+    // obtain a number it then uses and discards the samples of.
+    var fed = await audioCapture.getSamplesSnapshot(fromIndex: Int.max).totalCount
 
     while !Task.isCancelled {
       try? await Task.sleep(for: .milliseconds(Self.feedIntervalMs))
@@ -341,7 +347,7 @@ final class LivePreviewCoordinator {
       guard !snapshot.samples.isEmpty else { continue }
       fed = snapshot.totalCount
       onFeed()
-      await recognizer.feed(snapshot.samples, token: token)
+      await recognizer.feed(snapshot.samples, session: session)
     }
   }
 

--- a/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
@@ -124,8 +124,14 @@ final class LivePreviewCoordinator {
         return
       }
       isRunning = true
+      // Allocated HERE, synchronously, not inside the session task. `isRunning`
+      // flips to true for the new recording immediately, so any window between
+      // that and the generation bump is a window where a queued callback from the
+      // PREVIOUS recording still matches and paints stale words. Locale resolution
+      // and preparation are both awaits inside the task, so that window was real.
+      sessionGeneration &+= 1
       display = .waiting
-      startSession()
+      startSession(generation: sessionGeneration)
     } else {
       guard isRunning else { return }
       isRunning = false
@@ -140,25 +146,33 @@ final class LivePreviewCoordinator {
     }
   }
 
-  private func startSession() {
+  private func startSession(generation: UInt64) {
     sessionTask = Task { @MainActor [weak self] in
       guard let self else { return }
       guard #available(macOS 26.0, *) else {
         self.display = .unavailable(LivePreviewCopy.needsNewerMacOS)
         return
       }
-      await self.runSession()
+      await self.runSession(generation: generation)
     }
   }
 
   @available(macOS 26.0, *)
-  private func runSession() async {
-    let code = Self.previewLanguageCode(languageMode())
+  private func runSession(generation: UInt64) async {
+    let mode = languageMode()
+    let code = Self.previewLanguageCode(mode)
+    // Both the setting and the code derived from it. "Why is there no preview in
+    // my language" is answerable from this one line: it distinguishes a user on
+    // Auto-detect (where we guess from the system) from one who locked a language
+    // Apple cannot transcribe, and those have different answers.
+    await Self.log("resolving language, mode=\(mode) code=\(code)")
     guard let locale = await ApplePreviewRecognizer.resolveLocale(code: code) else {
+      guard isCurrent(generation) else { return }
       display = .unavailable(LivePreviewCopy.languageUnsupported)
       await Self.log("no recognizer locale for language=\(code)")
       return
     }
+    guard isCurrent(generation) else { return }
 
     // Say "getting ready" rather than "listening" while preparation runs. On first
     // use of a language that can mean downloading an Apple speech model, and a pill
@@ -170,24 +184,23 @@ final class LivePreviewCoordinator {
     guard await ensurePrepared(for: locale),
       let recognizer = preparedRecognizer as? ApplePreviewRecognizer
     else {
+      guard isCurrent(generation) else { return }
       display = .unavailable(LivePreviewCopy.notReady)
       await Self.log("not ready for locale=\(locale.identifier(.bcp47))")
       return
     }
 
     if Task.isCancelled { return }
+    guard isCurrent(generation) else { return }
     display = .waiting
 
     // Diagnostics: transitions only, never per-update. The pill repaints several
     // times a second and logging each one would bury the log AND charge the main
     // actor for text nobody reads. `updates` is counted here and reported once.
     var updates = 0
-    // This recording's identity. Every asynchronous hand-off below is checked
-    // against it, because `isRunning` alone cannot tell the difference between
-    // "this recording" and "a recording" — and by the time a queued callback from
-    // the previous dictation runs, `isRunning` is true again for the NEW one.
-    sessionGeneration &+= 1
-    let generation = sessionGeneration
+    // `generation` is this recording's identity, allocated by `setRecording` before
+    // any of the awaits above. Every asynchronous hand-off is checked against it,
+    // because `isRunning` alone cannot tell "this recording" from "a recording".
 
     // The recognizer calls back from its own actor. Hop to the main actor and
     // publish so the 20 Hz pill read is a plain property read. The text arrives
@@ -203,6 +216,7 @@ final class LivePreviewCoordinator {
     do {
       token = try await recognizer.startSession(onText: publish)
     } catch {
+      guard isCurrent(generation) else { return }
       display = .unavailable(LivePreviewCopy.notReady)
       await Self.log("session refused to start: \(error)")
       return
@@ -219,6 +233,16 @@ final class LivePreviewCoordinator {
     let shown: Int
     if case .text(let t) = display { shown = t.count } else { shown = 0 }
     await Self.log("session ended, feeds=\(updates) shownChars=\(shown)")
+  }
+
+  /// Whether the recording that started this session is still the current one.
+  ///
+  /// Checked after every await that precedes a `display` write. Without it, a
+  /// session abandoned during locale resolution or model preparation resumes later
+  /// and writes its own outcome over the pill of a recording that is already
+  /// underway — "not ready" appearing over live words.
+  private func isCurrent(_ generation: UInt64) -> Bool {
+    sessionGeneration == generation
   }
 
   /// One log seam so every preview line carries the same category and the whole

--- a/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
@@ -179,11 +179,17 @@ final class LivePreviewCoordinator: CorrectorVocabularyConsumer {
       let task = sessionTask
       sessionTask = nil
       task?.cancel()
-      // The last text is deliberately left in `display` rather than blanked. The
-      // polishing pill is a different view and never renders it, so nothing shows
-      // it; and the next `setRecording(true)` sets `.waiting` synchronously, before
-      // the new panel is created on the following run loop pass, so a new recording
-      // can never open showing the previous one's words.
+      // **Dropped, not merely hidden.** This used to keep the last text on the
+      // grounds that nothing renders it after a recording ends, which was true and
+      // is not the point: the settings copy now tells the user the preview "is
+      // discarded when the recording ends", and a claim a user reads before
+      // enabling a feature has to be true of the code, not just of what is on
+      // screen. Holding the transcript until the next recording made it false.
+      //
+      // Costs nothing it was buying: the old rationale only ever argued that
+      // keeping it was harmless, never that anything needed it, and the next
+      // `setRecording(true)` sets `.waiting` synchronously regardless.
+      display = .off
     }
   }
 
@@ -255,7 +261,9 @@ final class LivePreviewCoordinator: CorrectorVocabularyConsumer {
 
     let session: ApplePreviewRecognizer.Session
     do {
-      session = try await recognizer.startSession(onText: publish)
+      // Read synchronously on the main actor at the moment the session opens, so
+      // the session cannot start before the vocabulary reaches it.
+      session = try await recognizer.startSession(lookups: correctorLookups, onText: publish)
     } catch {
       guard isCurrent(generation) else { return }
       display = .unavailable(LivePreviewCopy.notReady)
@@ -317,6 +325,13 @@ final class LivePreviewCoordinator: CorrectorVocabularyConsumer {
   /// Not availability-gated: `CustomWordsPropagator` writes the vocabulary on
   /// every Mac we support, and gating the STORE on macOS 26 would mean a machine
   /// that later prepares a recognizer has nothing to seed it with.
+  /// Rebuild the cached lookups. Nothing is PUSHED anywhere: the snapshot is read
+  /// synchronously at `startSession` and handed in as an argument, so there is no
+  /// installation step that a session can outrun.
+  ///
+  /// Not availability-gated: `CustomWordsPropagator` writes the vocabulary on
+  /// every Mac we support, and gating the STORE on macOS 26 would leave a machine
+  /// that later prepares a recognizer with nothing to hand it.
   private func rebuildCorrectorLookupsIfNeeded() {
     guard builtLookupsGeneration != correctorVocabulary.generation else { return }
     builtLookupsGeneration = correctorVocabulary.generation
@@ -324,18 +339,6 @@ final class LivePreviewCoordinator: CorrectorVocabularyConsumer {
     correctorLookups =
       correctorVocabulary.terms.isEmpty
       ? nil : WordCorrector.buildLookups(words: correctorVocabulary.terms)
-    guard #available(macOS 26.0, *), let recognizer = preparedRecognizer as? ApplePreviewRecognizer
-    else { return }
-    pushCorrectorLookups(to: recognizer)
-  }
-
-  /// Hand the current snapshot to `recognizer`. Fire-and-forget: the recognizer is
-  /// an actor, this is the main actor, and a vocabulary update must never make a
-  /// settings write wait on it.
-  @available(macOS 26.0, *)
-  private func pushCorrectorLookups(to recognizer: ApplePreviewRecognizer) {
-    let lookups = correctorLookups
-    Task { await recognizer.setCorrectorLookups(lookups) }
   }
 
   @available(macOS 26.0, *)
@@ -367,11 +370,6 @@ final class LivePreviewCoordinator: CorrectorVocabularyConsumer {
         guard self.preparationGeneration == generation else { return false }
         self.preparedRecognizer = fresh
         self.preparedLocale = locale
-        // Seed the vocabulary a newly built recognizer has never been told about.
-        // Without this, Custom Words reach the preview only if the user edits them
-        // AFTER the recognizer exists — which is never, for the common case of a
-        // vocabulary that was already there at launch.
-        self.pushCorrectorLookups(to: fresh)
         return true
       }
     }

--- a/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
@@ -1,6 +1,7 @@
 import AVFoundation
 import EnviousWisprAudio
 import EnviousWisprCore
+import EnviousWisprPostProcessing
 import Foundation
 
 /// What the recording pill should render for the live preview (#1988).
@@ -50,8 +51,13 @@ enum LivePreviewDisplay: Equatable {
 /// within the run's own noise floor. The instrument was proven able to detect
 /// contention first — saturating every core moved slip 5.3 ms, well outside that
 /// floor — so the null result is evidence rather than an absence of evidence.
+/// Adopts `CorrectorVocabularyConsumer` so Custom Words reach the preview the same
+/// way they reach the pipeline's own correction step — one propagator, one lane,
+/// no second source of truth for what a user's vocabulary is (#1988 acceptance:
+/// "the custom dictionary applies to preview text, so a user's own names do not
+/// visibly mangle mid-dictation").
 @MainActor
-final class LivePreviewCoordinator {
+final class LivePreviewCoordinator: CorrectorVocabularyConsumer {
 
   /// Poll cadence for handing new audio to the recognizer. Matches the 100 ms
   /// chunking the benchmark harness used, so the screening numbers describe this
@@ -79,6 +85,41 @@ final class LivePreviewCoordinator {
   /// The locale `preparedRecognizer` was prepared for, so a language change
   /// rebuilds it.
   private var preparedLocale: Locale?
+
+  /// Custom Words, written by `CustomWordsPropagator`. Building lookups is the
+  /// expensive half, so it happens HERE, once per vocabulary generation, rather
+  /// than once per recording inside the recognizer — the same reason
+  /// `WordCorrectionStep` caches on `generation`.
+  ///
+  /// An empty vocabulary stores `nil` lookups rather than empty ones, so the
+  /// recognizer's guard short-circuits instead of running a full correction pass
+  /// that cannot match anything. Most users have no custom words.
+  var correctorVocabulary: CorrectorVocabulary = .empty {
+    didSet { rebuildCorrectorLookupsIfNeeded() }
+  }
+
+  /// Lookups for `correctorVocabulary`, or `nil` when there is nothing to correct.
+  private var correctorLookups: WordCorrector.Lookups?
+
+  /// The generation `correctorLookups` was built for. **Optional, and that is
+  /// load-bearing:** the seed `wireCustomWords` sends carries generation 0, and so
+  /// does the `.empty` this property starts at, so comparing the incoming
+  /// generation against the PREVIOUS VALUE's would treat a real vocabulary
+  /// arriving at launch as a no-op change and drop it. Custom Words would then
+  /// reach the preview only after the user edited them — never, for anyone whose
+  /// vocabulary was already there. Comparing against what was actually BUILT
+  /// starts at `nil`, which cannot collide with a real generation.
+  private var builtLookupsGeneration: UInt64?
+
+  /// Test seam, mirroring `WordCorrectionStep.lookupCacheBuilds`: how many times
+  /// lookups have actually been built. Lets a test prove the seed vocabulary was
+  /// picked up AND that a repeated generation does not rebuild.
+  package private(set) var correctorLookupBuilds = 0
+
+  /// Test seam: whether a correcting snapshot currently exists. Distinguishes
+  /// "built, and there is something to correct" from "built nothing because the
+  /// vocabulary is empty", which are different states with the same build count.
+  package var hasCorrectorLookupsForTesting: Bool { correctorLookups != nil }
 
   private var sessionTask: Task<Void, Never>?
   /// In-flight preparation, shared by every session that arrives while it runs.
@@ -271,6 +312,32 @@ final class LivePreviewCoordinator {
   /// task and hand the next recording a German recognizer while every check said
   /// English was ready. The generation below is what makes the write conditional;
   /// review caught the original.
+  /// Rebuild the cached lookups and hand them to whatever recognizer exists.
+  ///
+  /// Not availability-gated: `CustomWordsPropagator` writes the vocabulary on
+  /// every Mac we support, and gating the STORE on macOS 26 would mean a machine
+  /// that later prepares a recognizer has nothing to seed it with.
+  private func rebuildCorrectorLookupsIfNeeded() {
+    guard builtLookupsGeneration != correctorVocabulary.generation else { return }
+    builtLookupsGeneration = correctorVocabulary.generation
+    correctorLookupBuilds += 1
+    correctorLookups =
+      correctorVocabulary.terms.isEmpty
+      ? nil : WordCorrector.buildLookups(words: correctorVocabulary.terms)
+    guard #available(macOS 26.0, *), let recognizer = preparedRecognizer as? ApplePreviewRecognizer
+    else { return }
+    pushCorrectorLookups(to: recognizer)
+  }
+
+  /// Hand the current snapshot to `recognizer`. Fire-and-forget: the recognizer is
+  /// an actor, this is the main actor, and a vocabulary update must never make a
+  /// settings write wait on it.
+  @available(macOS 26.0, *)
+  private func pushCorrectorLookups(to recognizer: ApplePreviewRecognizer) {
+    let lookups = correctorLookups
+    Task { await recognizer.setCorrectorLookups(lookups) }
+  }
+
   @available(macOS 26.0, *)
   private func ensurePrepared(for locale: Locale) async -> Bool {
     if preparedRecognizer is ApplePreviewRecognizer, preparedLocale == locale { return true }
@@ -300,6 +367,11 @@ final class LivePreviewCoordinator {
         guard self.preparationGeneration == generation else { return false }
         self.preparedRecognizer = fresh
         self.preparedLocale = locale
+        // Seed the vocabulary a newly built recognizer has never been told about.
+        // Without this, Custom Words reach the preview only if the user edits them
+        // AFTER the recognizer exists — which is never, for the common case of a
+        // vocabulary that was already there at launch.
+        self.pushCorrectorLookups(to: fresh)
         return true
       }
     }

--- a/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewInstaller.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewInstaller.swift
@@ -25,11 +25,17 @@ enum LivePreviewInstaller {
   /// only consumer, so no separate retention is needed (same idiom as
   /// `wireCustomWords`, which anchors its propagator to the coordinator that uses
   /// it).
+  /// Returns the coordinator so the composition root can register it as a Custom
+  /// Words consumer. It is returned rather than registered here because
+  /// `wireCustomWords` seeds and registers every consumer in one non-reversible
+  /// order, and a second registration path would be a second source of truth for
+  /// when the preview learns a user's vocabulary.
+  @discardableResult
   static func install(
     overlay: RecordingOverlayPanel,
     capture: any AudioCaptureInterface,
     settings: SettingsManager
-  ) {
+  ) -> LivePreviewCoordinator {
     // **Effective, not merely persisted.** A value saved as true on macOS 26 and
     // then read on an older system used to enlarge the pill on every recording and
     // fill it with "needs macOS 26" — while the toggle that would turn it off was
@@ -53,5 +59,6 @@ enum LivePreviewInstaller {
     overlay.setRecordingIntentObserver { recording in
       coordinator.setRecording(recording)
     }
+    return coordinator
   }
 }

--- a/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewInstaller.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewInstaller.swift
@@ -30,13 +30,24 @@ enum LivePreviewInstaller {
     capture: any AudioCaptureInterface,
     settings: SettingsManager
   ) {
+    // **Effective, not merely persisted.** A value saved as true on macOS 26 and
+    // then read on an older system used to enlarge the pill on every recording and
+    // fill it with "needs macOS 26" — while the toggle that would turn it off was
+    // disabled for the same reason, so the user could not stop it. Folding the OS
+    // check in here means an unsupported system behaves exactly like the setting
+    // being off: normal pill, no message, nothing to escape from. One expression,
+    // used for both the geometry and the coordinator, so the two cannot disagree.
+    let effectivelyEnabled: () -> Bool = {
+      guard #available(macOS 26.0, *) else { return false }
+      return settings.livePreviewEnabled
+    }
     let coordinator = LivePreviewCoordinator(
       audioCapture: capture,
-      isEnabled: { settings.livePreviewEnabled },
+      isEnabled: effectivelyEnabled,
       languageMode: { settings.languageMode }
     )
     overlay.setLivePreviewProviders(
-      enabled: { settings.livePreviewEnabled },
+      enabled: effectivelyEnabled,
       display: { coordinator.display }
     )
     overlay.setRecordingIntentObserver { recording in

--- a/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewInstaller.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewInstaller.swift
@@ -1,0 +1,46 @@
+import EnviousWisprAudio
+import EnviousWisprServices
+import Foundation
+
+/// Wires the live preview (#1988) to the recording overlay, and to nothing else.
+///
+/// Extracted rather than written inline in `WisprBootstrapper` because that file
+/// carries a hard line ceiling whose whole purpose is to stop the composition root
+/// accumulating feature wiring. Raising the ceiling for fifteen lines would have
+/// spent a budget that exists precisely to prevent this, so the wiring lives with
+/// the feature and the root keeps its two lines.
+///
+/// **The install surface is the point.** The preview attaches to the overlay panel
+/// and to nothing on the recording path. The kernel, the recording starter and the
+/// ASR adapters never learn it exists, which is what makes it a limb rather than a
+/// second thing that can break a dictation.
+@MainActor
+enum LivePreviewInstaller {
+
+  /// Build the coordinator and hand the overlay its three seams: whether to size a
+  /// pill for preview text, what to render in it, and when a recording is live.
+  ///
+  /// The returned coordinator is captured strongly by those closures, so the
+  /// overlay owns its lifetime. The overlay lives as long as the app and is the
+  /// only consumer, so no separate retention is needed (same idiom as
+  /// `wireCustomWords`, which anchors its propagator to the coordinator that uses
+  /// it).
+  static func install(
+    overlay: RecordingOverlayPanel,
+    capture: any AudioCaptureInterface,
+    settings: SettingsManager
+  ) {
+    let coordinator = LivePreviewCoordinator(
+      audioCapture: capture,
+      isEnabled: { settings.livePreviewEnabled },
+      languageMode: { settings.languageMode }
+    )
+    overlay.setLivePreviewProviders(
+      enabled: { settings.livePreviewEnabled },
+      display: { coordinator.display }
+    )
+    overlay.setRecordingIntentObserver { recording in
+      coordinator.setRecording(recording)
+    }
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewTextBound.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewTextBound.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// The cap on how much preview text is kept alive, and the one implementation of
+/// applying it (#1988).
+///
+/// **It lives at the PRODUCER, not the consumer.** The first version trimmed in the
+/// coordinator, after the recognizer had already accumulated the whole transcript
+/// and sent a full copy across an actor boundary on every update. The bound was
+/// therefore true of what the pill displayed and false of what the process
+/// retained, which is the worst kind of documented invariant: a 60-minute dictation
+/// grew unboundedly under a comment promising it could not. Review caught it.
+/// Trimming where the text is built fixes the allocation, the copy and the claim at
+/// once.
+enum LivePreviewTextBound {
+
+  /// The pill shows a tail of at most two lines. The founder's longest dictation
+  /// ran to 9,388 words, none of which a pill can show, so retaining more than a
+  /// generous tail buys nothing and costs memory for the life of the recording.
+  static let maxCharacters = 2000
+
+  /// Keep the tail, drop the head, and do not cut a word in half.
+  ///
+  /// The word-boundary step must never be able to disable the bound: a script with
+  /// no spaces (CJK) or a pathological unbroken run has no boundary to find, and
+  /// the fallback returns the hard-trimmed tail rather than the original.
+  static func apply(_ text: String) -> String {
+    guard text.count > maxCharacters else { return text }
+    let tail = String(text.suffix(maxCharacters))
+    guard let space = tail.firstIndex(of: " ") else { return tail }
+    return String(tail[tail.index(after: space)...])
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
+++ b/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
@@ -230,6 +230,9 @@ final class PipelineSettingsSync {
       break  // #1063: read by the recovery wiring at capture start, not the live pipeline.
     case .isDictationAudioArchiveEnabled:
       break  // #1247: kernel pulls this live via `dictationAudioArchiveOptInProvider` — no push needed here.
+    case .livePreviewEnabled:
+      break  // #1988: display-only limb, read live by `LivePreviewCoordinator` off the
+    // overlay seam. The pipeline never learns it exists, which is the point.
     case .appearance:
       break  // UI-only; applied to NSApp.appearance by the app shell (#1047).
     case .overlayPillPosition:

--- a/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
@@ -125,11 +125,33 @@ final class RecordingOverlayPanel {
   /// fixed. `nil` when nothing is showing.
   private var activePanelPosition: OverlayPillPosition?
 
+  /// Whether the showing panel's frame hugs its content exactly (`fitToContent`)
+  /// rather than sitting inside a taller fixed frame. Maintained by `showPanel`,
+  /// read by the inherited-`y` Top transition, which has to preserve a DIFFERENT
+  /// edge for the two geometries — see the branch there for why.
+  private var activePanelIsContentSized = false
+
   /// The origin WE last set programmatically. Used only to DETECT a manual
   /// drag (`isMovableByWindowBackground = true`, an existing feature) by
   /// comparing against the panel's live origin — `wasManuallyDragged` below
   /// is the authoritative, sticky record of that fact once detected. `nil`
   /// when nothing is showing.
+  ///
+  /// **WRITING THIS ERASES THE ONLY EVIDENCE A DRAG HAPPENED, SO EVERY WRITE
+  /// MUST FIRST ASK WHETHER THE LIVE ORIGIN STILL MATCHES.** The drag signal is
+  /// a comparison, not an event: nothing observes the user dragging, so a write
+  /// that re-baselines to wherever the panel now sits makes the drag
+  /// undetectable forever after. This exact bug has been found three times, each
+  /// time at a NEW write site rather than a regression of an old one (Codex
+  /// grounded review r4 and r5, 2026-07-17; cloud review on #1988), which is why
+  /// it is written here as a property of the field instead of a comment at any
+  /// one of them. The three live write sites and how each discharges the
+  /// obligation:
+  /// - `repositionForActiveSpaceChange()` — compares, then returns early on a
+  ///   mismatch, so it only writes when no drag happened.
+  /// - `showPanel`'s inherited-`y` capture — latches `wasManuallyDragged` first.
+  /// - `resizeRecordingPanel(toContentHeight:)` — latches first, using the
+  ///   PRE-resize origin (the resize itself moves the origin in Top position).
   private var lastProgrammaticOrigin: NSPoint?
 
   /// True once the user has manually dragged the panel during the CURRENT
@@ -722,6 +744,16 @@ final class RecordingOverlayPanel {
     let target = contentHeight.rounded()
     guard target > 0, abs(panel.frame.height - target) >= 1 else { return }
 
+    // Latch a drag BEFORE the frame moves, or the re-baseline at the end of this
+    // method silently erases it — see `lastProgrammaticOrigin`. The comparison
+    // has to happen here rather than after `setFrame` because in Top position
+    // the resize itself moves the origin, which would read as a drag.
+    if !wasManuallyDragged, let lastProgrammaticOrigin,
+      !panel.frame.origin.isApproximately(lastProgrammaticOrigin)
+    {
+      wasManuallyDragged = true
+    }
+
     var frame = panel.frame
     if activePanelPosition == .bottom {
       frame.size.height = target
@@ -1116,6 +1148,39 @@ final class RecordingOverlayPanel {
     DispatchQueue.main.async(execute: work)
   }
 
+  /// Where a Top-positioned panel goes when it CONTINUES an existing
+  /// presentation whose frame was a different height (recording -> polishing).
+  ///
+  /// Both branches preserve the same thing — where the VISIBLE pill sits — and
+  /// differ only because the frame relates to that pill differently in the two
+  /// geometries. They agree exactly whenever the heights match, so this can only
+  /// diverge on a transition that actually changes height.
+  ///
+  /// - `outgoingWasContentSized`: the frame hugged its content (`fitToContent`),
+  ///   so the frame IS the visible pill and its TOP edge is the anchor. The
+  ///   #1988 preview grows downward from a fixed top edge
+  ///   (`resizeRecordingPanel`) and can be far taller than what replaces it —
+  ///   five lines of text against a one-line "Polishing..." pill. Preserving the
+  ///   center here would drop that pill by half the height difference.
+  /// - Otherwise: #1650. Content in a FIXED frame is `.center`-aligned inside it
+  ///   (createPanel), so the visible pill's vertical CENTER equals the frame's
+  ///   center regardless of the frame's own height. Preserving that center — not
+  ///   the raw bottom origin — keeps the pill pixel-identical across the 92pt
+  ///   recording frame -> ~44pt polishing pill change, closing the ~24pt drop.
+  ///
+  /// Extracted as a pure function because it is the arithmetic that was wrong,
+  /// and the rest of `showPanel` needs a window server. Tests:
+  /// `RecordingOverlayPanelInheritedGeometryTests`.
+  /// `nonisolated` because it reads no panel state — the inputs are the whole
+  /// story, which is what makes it testable without a window server.
+  nonisolated static func inheritedTopOriginY(
+    inheritedFrame: NSRect, resolvedHeight: CGFloat, outgoingWasContentSized: Bool
+  ) -> CGFloat {
+    outgoingWasContentSized
+      ? inheritedFrame.maxY - resolvedHeight
+      : inheritedFrame.midY - resolvedHeight / 2
+  }
+
   /// Create and show a floating overlay panel with the given SwiftUI content.
   ///
   /// `fitToContent` (#1064): size the panel to the SwiftUI view's own
@@ -1134,6 +1199,10 @@ final class RecordingOverlayPanel {
         ?? NSScreen.main
         ?? NSScreen.screens.first
     else { return }
+
+    // Captured before anything below can overwrite it: this describes the panel
+    // being REPLACED, which is what the inherited-`y` transition reasons about.
+    let outgoingWasContentSized = activePanelIsContentSized
 
     let hostingView = NSHostingView(rootView: content)
     // Resolve the panel size: content-driven when `fitToContent`, else the
@@ -1182,20 +1251,15 @@ final class RecordingOverlayPanel {
       // from the edge the panel's SwiftUI content is actually aligned for,
       // and the next Space swipe would then jump the panel to the wrong edge.
       if activePanelPosition == .top {
-        // #1650: Top-positioned content is `.center`-aligned inside its
-        // frame (createPanel), so the visible pill's vertical CENTER always
-        // equals the frame's center regardless of the frame's own height.
-        // Preserving the outgoing panel's frame center — not its raw bottom
-        // origin — keeps the visible pill's on-screen position
-        // pixel-identical across a panel-height change (e.g. the 92pt
-        // recording frame -> the ~44pt fitToContent polishing pill), closing
-        // the ~24pt drop. clampedOriginY below remains authoritative when
-        // the incoming panel is too tall to fit below the menu bar at the
-        // preserved center. Bottom is unaffected: its content is
-        // `.bottom`-aligned (#1341), so the outgoing frame's bottom edge
-        // already IS the visible bottom with no gap, and preserving it
-        // unchanged (below) is already correct.
-        requestedY = inheritedFrame.midY - resolvedHeight / 2
+        // clampedOriginY below remains authoritative when the incoming panel is
+        // too tall to fit below the menu bar at the preserved position. Bottom
+        // is unaffected either way: its content is `.bottom`-aligned (#1341) and
+        // the preview grows upward from a fixed bottom edge, so the outgoing
+        // frame's bottom origin already IS the visible bottom in both
+        // geometries, and preserving it unchanged (below) is already correct.
+        requestedY = Self.inheritedTopOriginY(
+          inheritedFrame: inheritedFrame, resolvedHeight: resolvedHeight,
+          outgoingWasContentSized: outgoingWasContentSized)
       } else {
         requestedY = inheritedY
       }
@@ -1230,6 +1294,7 @@ final class RecordingOverlayPanel {
 
     p.orderFrontRegardless()
     self.panel = p
+    activePanelIsContentSized = fitToContent
   }
 
   /// #1341: is the CURRENT frontmost app genuinely in native macOS fullscreen
@@ -1451,6 +1516,7 @@ final class RecordingOverlayPanel {
     guard let panelToClose = panel else { return }
     panel = nil
     activePanelPosition = nil
+    activePanelIsContentSized = false
     lastProgrammaticOrigin = nil
     wasManuallyDragged = false
 

--- a/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
@@ -1956,14 +1956,14 @@ struct RecordingOverlayView: View {
     case .waiting:
       // One line, so the pill starts compact and the growth the user sees is their
       // own words arriving rather than space that was always reserved.
-      previewText(LivePreviewCopy.listening, dimmed: true, lineLimit: 1)
+      previewText(LivePreviewCopy.listening, dimmed: true, lines: 1)
     case .unavailable(let reason):
       // Say why rather than sitting blank. A blank preview reads as "it did not
       // hear me", which is the exact anxiety this feature exists to remove. Two
       // lines because some of these sentences wrap.
-      previewText(reason, dimmed: true, lineLimit: 2)
+      previewText(reason, dimmed: true, lines: 2)
     case .text(let text):
-      previewText(text, dimmed: false, lineLimit: Self.previewMaxLines)
+      previewText(text, dimmed: false, lines: Self.previewMaxLines)
     }
   }
 
@@ -1972,17 +1972,46 @@ struct RecordingOverlayView: View {
   ///
   /// **No fixed height.** The text takes exactly the lines it needs, the capsule
   /// grows with it, and the panel follows via `onContentHeightChange`. At the cap
-  /// `lineLimit` stops the growth and `.head` truncation drops the OLDEST line, so
-  /// the newest words stay put and the first thing you said scrolls off the top.
-  private func previewText(_ message: String, dimmed: Bool, lineLimit: Int) -> some View {
+  /// the text keeps laying out in full but the box stops growing and pins the text
+  /// to its BOTTOM, so the overflow leaves at the top and the newest words stay
+  /// where the eye already is.
+  ///
+  /// **`.lineLimit(n)` + `.truncationMode(.head)` does NOT do this, despite
+  /// reading as though it should.** Measured by rendering this exact modifier
+  /// stack over 60 numbered words: it keeps the OLDEST four lines and truncates
+  /// only the LAST one, so a long dictation showed `word1...word32`, then a jump
+  /// to `...word53 word60` — the middle silently gone and four fifths of the pill
+  /// frozen on the opening words. Review caught it; the screenshot that had
+  /// "verified" the behaviour showed a transcript at exactly five lines, which
+  /// never exercises overflow at all.
+  ///
+  /// Bottom-pinned clipping is the literal reading of "scrolls off the top", and
+  /// needs no ScrollView (which brings scrollers, elasticity and its own
+  /// scroll-to-bottom timing into a borderless overlay) and no manual text
+  /// measurement.
+  private func previewText(_ message: String, dimmed: Bool, lines: Int) -> some View {
     Text(message)
       .font(.system(size: 12))
       .foregroundStyle(.white.opacity(dimmed ? 0.5 : 0.92))
-      .lineLimit(lineLimit)
-      .truncationMode(.head)
       .multilineTextAlignment(.leading)
       .fixedSize(horizontal: false, vertical: true)
       .frame(maxWidth: .infinity, alignment: .leading)
+      // `maxHeight` CAPS without fixing: below the cap the box is the text's own
+      // height, which is what lets the pill still grow a line at a time.
+      .frame(maxHeight: Self.previewHeight(lines: lines), alignment: .bottom)
+      .clipped()
+  }
+
+  /// Height of `lines` lines of the preview font.
+  ///
+  /// Derived from the font's own metrics rather than a literal, so the cap tracks
+  /// the type size instead of drifting silently if it changes. An exact multiple
+  /// of the line height matters: the clip lands on a line boundary, so no row is
+  /// ever cut through the middle of its glyphs. Verified against the render — five
+  /// lines measured 75pt, matching 5 x 15.
+  private static func previewHeight(lines: Int) -> CGFloat {
+    let font = NSFont.systemFont(ofSize: 12)
+    return ceil(font.ascender - font.descender + font.leading) * CGFloat(lines)
   }
 
   /// Five lines, matching the shape the founder tested against Spokenly: the pill

--- a/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
@@ -656,17 +656,30 @@ final class RecordingOverlayPanel {
 
     lockState.isLocked = isRecordingLocked
     // #1988: the preview needs room for a sentence, which the 185pt capsule cannot
-    // give. Decided once, here, because the panel's frame is fixed for its life.
+    // give. Width is fixed; HEIGHT is not — the pill earns its size, growing a line
+    // at a time as words wrap and settling once it reaches the cap. See
+    // `resizeRecordingPanel(toContentHeight:)`.
     let showsPreview = livePreviewEnabledProvider()
     let width: CGFloat = showsPreview ? Self.previewPillWidth : 185
-    let height: CGFloat = showsPreview ? Self.previewPillHeight : 92
     let overlayView = RecordingOverlayView(
       audioLevelProvider: audioLevelProvider,
       recordingElapsedProvider: recordingElapsedProvider,
       livePreviewProvider: showsPreview ? livePreviewDisplayProvider : { .off },
+      onContentHeightChange: showsPreview
+        ? { [weak self] height in self?.resizeRecordingPanel(toContentHeight: height) }
+        : { _ in },
+      usesPreviewLayout: showsPreview,
       lockState: lockState,
       noticeState: noticeState
     )
+    if showsPreview {
+      // Content-sized from the start, so the first frame is already correct rather
+      // than a guess that visibly snaps once the real height is measured.
+      showPanel(
+        content: overlayView.frame(width: width),
+        width: width, fitToContent: true)
+      return
+    }
     // Fixed frame accommodating normal (185x44), locked (120x64), and the #1060
     // notice-banner expansion (a 2-line banner under the pill); showPanel clamps
     // the origin so the taller frame never clips under the menu bar (Codex P2).
@@ -678,20 +691,48 @@ final class RecordingOverlayPanel {
     // no such gap) visibly misaligned with the recording pill it replaces. A
     // notice banner now grows upward from the stable bottom edge instead of
     // pushing the capsule down.
-    .frame(
-      width: width, height: height,
+    let fixedFrameView = overlayView.frame(
+      width: width, height: 92,
       alignment: positionProvider() == .bottom ? .bottom : .center
     )
-    showPanel(content: overlayView, width: width, height: height)
+    showPanel(content: fixedFrameView, width: width, height: 92)
   }
 
-  /// #1988 preview geometry. 400pt fits roughly 20 words across two lines at the
-  /// preview's type size, against a measured median dictation far longer than any
-  /// pill can hold — so the design shows the TAIL rather than trying to fit the
-  /// whole thing. The extra height carries those two lines plus the same #1060
-  /// notice-banner room the 92pt frame reserves.
+  /// #1988 preview width. Height is content-driven — see `previewMaxLines`.
   private static let previewPillWidth: CGFloat = 400
-  private static let previewPillHeight: CGFloat = 132
+
+  /// Grow or shrink the live recording pill as preview text wraps to more lines.
+  ///
+  /// **The panel really resizes; it is not oversized and padded.** Reserving the
+  /// five-line height up front would have been simpler, but the pill accepts mouse
+  /// events across its whole frame (it is drag-to-relocate), so a permanently tall
+  /// transparent panel would swallow clicks over a large invisible region of the
+  /// user's screen.
+  ///
+  /// Resizing an existing panel is NOT the #930 flicker: that came from tearing the
+  /// panel down and rebuilding it, which destroys the hosting view. `setFrame` keeps
+  /// the same window and the same SwiftUI content.
+  ///
+  /// The anchored edge is the one the user's chosen position pins. Bottom keeps its
+  /// bottom edge, so the pill grows UPWARD and its origin never moves — which also
+  /// means the Space-change reposition's drag detection cannot mistake growth for a
+  /// user drag. Top keeps its top edge and grows downward.
+  private func resizeRecordingPanel(toContentHeight contentHeight: CGFloat) {
+    guard let panel, case .recording = currentIntent else { return }
+    let target = contentHeight.rounded()
+    guard target > 0, abs(panel.frame.height - target) >= 1 else { return }
+
+    var frame = panel.frame
+    if activePanelPosition == .bottom {
+      frame.size.height = target
+    } else {
+      let topEdge = frame.maxY
+      frame.size.height = target
+      frame.origin.y = topEdge - target
+    }
+    panel.setFrame(frame, display: true)
+    if !wasManuallyDragged { lastProgrammaticOrigin = frame.origin }
+  }
 
   /// #1060: flash a transient banner over the LIVE recording pill (a second line
   /// inside the same capsule), then auto-clear. No-op unless a recording panel is
@@ -1631,14 +1672,43 @@ struct RainbowLipsIcon: View {
 /// Shared capsule background with warmer dark fill, subtle border, and a
 /// rainbow gradient line pulsing along the bottom edge.
 private struct OverlayCapsuleBackground: View {
+  /// #1988: the live-preview pill is tall and full of text, and a capsule's
+  /// semicircular ends eat exactly the width the text needs while crowding the
+  /// first and last characters of every line. A rounded rectangle reads as a panel
+  /// rather than a lozenge at that size, which is what the shape should say.
+  /// Everything else keeps the capsule.
+  enum CornerStyle {
+    case capsule
+    case rounded
+  }
+
+  var cornerStyle: CornerStyle = .capsule
   @State private var glowOpacity: Double = 0.3
 
+  private var shape: AnyShape {
+    switch cornerStyle {
+    case .capsule: return AnyShape(Capsule())
+    case .rounded: return AnyShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+  }
+
   var body: some View {
-    Capsule()
+    shape
       .fill(Color(red: 0.078, green: 0.078, blue: 0.11).opacity(0.82))
+      // `strokeBorder` needs an insettable shape, which the type-erased `AnyShape`
+      // is not, so the two concrete shapes are named here. Kept as `strokeBorder`
+      // rather than switching both to `stroke`: the capsule is shipped UI and its
+      // border should stay exactly where it already sits.
       .overlay(
-        Capsule()
-          .strokeBorder(Color.white.opacity(0.1), lineWidth: 0.5)
+        Group {
+          switch cornerStyle {
+          case .capsule:
+            Capsule().strokeBorder(Color.white.opacity(0.1), lineWidth: 0.5)
+          case .rounded:
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+              .strokeBorder(Color.white.opacity(0.1), lineWidth: 0.5)
+          }
+        }
       )
       .overlay(alignment: .bottom) {
         LinearGradient(
@@ -1726,6 +1796,13 @@ struct RecordingOverlayView: View {
   /// so a push-based feed would redraw more often than the eye can read without
   /// showing anything more.
   let livePreviewProvider: () -> LivePreviewDisplay
+  /// #1988: reports the capsule's measured height so the panel can follow it as the
+  /// preview grows. No-op when the preview is off.
+  var onContentHeightChange: (CGFloat) -> Void = { _ in }
+  /// #1988: whether this pill is the tall preview layout. Passed in rather than
+  /// derived from the display state, which starts `.off` for one 50 ms poll and
+  /// would flash the capsule shape before the first read.
+  var usesPreviewLayout: Bool = false
   var lockState: OverlayLockState
   /// #1060: transient notice banner shown inside the recording capsule.
   var noticeState: OverlayNoticeState
@@ -1772,7 +1849,17 @@ struct RecordingOverlayView: View {
     .animation(.easeInOut(duration: 0.25), value: noticeState.message)
     .padding(.horizontal, 14)
     .padding(.vertical, 10)
-    .background(OverlayCapsuleBackground())
+    .background(OverlayCapsuleBackground(cornerStyle: usesPreviewLayout ? .rounded : .capsule))
+    // #1988: report the capsule's real height so the panel can follow it. Measured
+    // on the capsule rather than computed from a line count, because only the text
+    // engine knows how many lines a sentence wraps to at this width in this script.
+    .background(
+      GeometryReader { geo in
+        Color.clear
+          .onAppear { onContentHeightChange(geo.size.height) }
+          .onChange(of: geo.size.height) { _, height in onContentHeightChange(height) }
+      }
+    )
     .task {
       while !Task.isCancelled {
         audioLevel = audioLevelProvider()
@@ -1801,34 +1888,40 @@ struct RecordingOverlayView: View {
     case .off:
       EmptyView()
     case .waiting:
-      previewText(LivePreviewCopy.listening, dimmed: true)
+      // One line, so the pill starts compact and the growth the user sees is their
+      // own words arriving rather than space that was always reserved.
+      previewText(LivePreviewCopy.listening, dimmed: true, lineLimit: 1)
     case .unavailable(let reason):
       // Say why rather than sitting blank. A blank preview reads as "it did not
-      // hear me", which is the exact anxiety this feature exists to remove.
-      previewText(reason, dimmed: true)
+      // hear me", which is the exact anxiety this feature exists to remove. Two
+      // lines because some of these sentences wrap.
+      previewText(reason, dimmed: true, lineLimit: 2)
     case .text(let text):
-      previewText(text, dimmed: false)
+      previewText(text, dimmed: false, lineLimit: Self.previewMaxLines)
     }
   }
 
-  /// One builder for all three states, so the pill cannot change size or alignment
-  /// as it moves between "Listening...", real words, and a reason it cannot run.
-  private func previewText(_ message: String, dimmed: Bool) -> some View {
+  /// One builder for all three states, so the pill cannot change alignment as it
+  /// moves between "Listening...", real words, and a reason it cannot run.
+  ///
+  /// **No fixed height.** The text takes exactly the lines it needs, the capsule
+  /// grows with it, and the panel follows via `onContentHeightChange`. At the cap
+  /// `lineLimit` stops the growth and `.head` truncation drops the OLDEST line, so
+  /// the newest words stay put and the first thing you said scrolls off the top.
+  private func previewText(_ message: String, dimmed: Bool, lineLimit: Int) -> some View {
     Text(message)
       .font(.system(size: 12))
       .foregroundStyle(.white.opacity(dimmed ? 0.5 : 0.92))
-      .lineLimit(Self.previewLineLimit)
+      .lineLimit(lineLimit)
       .truncationMode(.head)
       .multilineTextAlignment(.leading)
+      .fixedSize(horizontal: false, vertical: true)
       .frame(maxWidth: .infinity, alignment: .leading)
-      .frame(height: Self.previewTextHeight, alignment: .top)
   }
 
-  /// Two lines at 12pt, reserved whether or not there is text, so the pill never
-  /// changes size while words arrive. `lineLimit` is what keeps the content inside
-  /// this height; the frame only reserves it.
-  private static let previewLineLimit = 2
-  private static let previewTextHeight: CGFloat = 34
+  /// Five lines, matching the shape the founder tested against Spokenly: the pill
+  /// grows a line at a time up to this, then holds its size and scrolls.
+  private static let previewMaxLines = 5
 }
 
 // MARK: - PolishingOverlayView

--- a/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
@@ -83,6 +83,11 @@ final class RecordingOverlayPanel {
   private var accessibilityToastShownThisSession: Bool = false
   private var grantHandler: (() -> Void)?
   private var accessibilityWarningDismissedProvider: () -> Bool = { false }
+  /// #1988: live preview. Defaults keep every existing caller (and every test that
+  /// constructs a panel directly) on today's behavior and today's pill size.
+  private var livePreviewEnabledProvider: () -> Bool = { false }
+  private var livePreviewDisplayProvider: () -> LivePreviewDisplay = { .off }
+  private var recordingIntentObserver: (Bool) -> Void = { _ in }
   /// #1063 PR2 — invoked when the user taps Discard on the "recovering" pill.
   /// Wired by the composition root to `RecoveryCoordinator.discardActiveRecovery`.
   private var discardRecoveryHandler: (() -> Void)?
@@ -292,6 +297,35 @@ final class RecordingOverlayPanel {
     accessibilityWarningDismissedProvider = provider
   }
 
+  /// #1988 — wire the live preview.
+  ///
+  /// Two closures rather than one, and the split is deliberate. `enabled` sizes
+  /// the panel and `display` fills it, because size is fixed for the life of a
+  /// panel: an `NSPanel` cannot grow mid-recording without a rebuild, and a
+  /// rebuild is the #930 flicker. Reading the SETTING for geometry means the
+  /// answer does not depend on whether the preview coordinator happened to be
+  /// started before this push, which deriving size from `display` would.
+  func setLivePreviewProviders(
+    enabled: @escaping () -> Bool,
+    display: @escaping () -> LivePreviewDisplay
+  ) {
+    livePreviewEnabledProvider = enabled
+    livePreviewDisplayProvider = display
+  }
+
+  /// #1988: told whether the overlay is currently showing a live recording, so the
+  /// preview can start and stop without the heart path knowing it exists.
+  ///
+  /// This seam rather than the kernel deliberately. `show(intent:)` is the single
+  /// funnel both the first push (`RecordingStarter`) and every state-driven push
+  /// (`DictationLifecycleCoordinator`) already pass through, so wiring here keeps
+  /// the recording path completely unaware of the preview — which is the whole
+  /// point of a limb. The receiver is idempotent because this fires on duplicate
+  /// pushes too.
+  func setRecordingIntentObserver(_ observer: @escaping (Bool) -> Void) {
+    recordingIntentObserver = observer
+  }
+
   /// Wire passive chip action handlers (Lock / Dismiss / auto-dismiss).
   /// Installed once by the former root state at construction time.
   func setPassiveChipHandlers(
@@ -324,6 +358,9 @@ final class RecordingOverlayPanel {
     isRecordingLocked: Bool = false
   ) {
     let isRecordingIntent: Bool = if case .recording = intent { true } else { false }
+    // #1988: reported BEFORE the dedup guard, so the preview learns about a
+    // recording even when this push is a duplicate the panel itself drops.
+    recordingIntentObserver(isRecordingIntent)
     guard
       intent != currentIntent || (isRecordingIntent && self.isRecordingLocked != isRecordingLocked)
     else { return }
@@ -618,9 +655,15 @@ final class RecordingOverlayPanel {
     guard panel == nil else { return }
 
     lockState.isLocked = isRecordingLocked
+    // #1988: the preview needs room for a sentence, which the 185pt capsule cannot
+    // give. Decided once, here, because the panel's frame is fixed for its life.
+    let showsPreview = livePreviewEnabledProvider()
+    let width: CGFloat = showsPreview ? Self.previewPillWidth : 185
+    let height: CGFloat = showsPreview ? Self.previewPillHeight : 92
     let overlayView = RecordingOverlayView(
       audioLevelProvider: audioLevelProvider,
       recordingElapsedProvider: recordingElapsedProvider,
+      livePreviewProvider: showsPreview ? livePreviewDisplayProvider : { .off },
       lockState: lockState,
       noticeState: noticeState
     )
@@ -636,11 +679,19 @@ final class RecordingOverlayPanel {
     // notice banner now grows upward from the stable bottom edge instead of
     // pushing the capsule down.
     .frame(
-      width: 185, height: 92,
+      width: width, height: height,
       alignment: positionProvider() == .bottom ? .bottom : .center
     )
-    showPanel(content: overlayView, width: 185, height: 92)
+    showPanel(content: overlayView, width: width, height: height)
   }
+
+  /// #1988 preview geometry. 400pt fits roughly 20 words across two lines at the
+  /// preview's type size, against a measured median dictation far longer than any
+  /// pill can hold — so the design shows the TAIL rather than trying to fit the
+  /// whole thing. The extra height carries those two lines plus the same #1060
+  /// notice-banner room the 92pt frame reserves.
+  private static let previewPillWidth: CGFloat = 400
+  private static let previewPillHeight: CGFloat = 132
 
   /// #1060: flash a transient banner over the LIVE recording pill (a second line
   /// inside the same capsule), then auto-clear. No-op unless a recording panel is
@@ -1337,6 +1388,10 @@ final class RecordingOverlayPanel {
 
   func hide() {
     currentIntent = .hidden
+    // #1988: a direct `hide()` (not every caller routes through `show(intent:)`)
+    // must still stop the preview. Idempotent, so the common path that already
+    // reported `false` costs nothing.
+    recordingIntentObserver(false)
     isRecordingLocked = false
     lockState.isLocked = false
     clearRecordingNotice()
@@ -1665,11 +1720,18 @@ struct RecordingOverlayView: View {
   /// source of truth instead of a per-view-instance stamp — a panel-recreate
   /// (e.g. `transitionToRecording`) must not reset the displayed timer.
   let recordingElapsedProvider: () -> TimeInterval?
+  /// #1988: what the live preview should show. Polled on the same 50 ms loop as
+  /// audio level and elapsed time rather than on a publisher, because that loop
+  /// already exists and coalesces naturally: Apple emits updates every ~210-290 ms,
+  /// so a push-based feed would redraw more often than the eye can read without
+  /// showing anything more.
+  let livePreviewProvider: () -> LivePreviewDisplay
   var lockState: OverlayLockState
   /// #1060: transient notice banner shown inside the recording capsule.
   var noticeState: OverlayNoticeState
   @State private var audioLevel: Float = 0
   @State private var elapsed: TimeInterval = 0
+  @State private var preview: LivePreviewDisplay = .off
 
   var body: some View {
     VStack(spacing: 6) {
@@ -1686,6 +1748,10 @@ struct RecordingOverlayView: View {
             .transition(.opacity)
         }
       }
+
+      // #1988: the live preview. Display only — the pasted text comes from the
+      // normal transcription path after the key is released.
+      livePreviewBody
 
       // #1060: approaching-cap warning banner. Appears inside the same capsule
       // (no panel rebuild), wraps within the pill width, auto-clears.
@@ -1711,11 +1777,58 @@ struct RecordingOverlayView: View {
       while !Task.isCancelled {
         audioLevel = audioLevelProvider()
         elapsed = recordingElapsedProvider() ?? 0
+        preview = livePreviewProvider()
         try? await Task.sleep(for: .milliseconds(50))
       }
     }
   }
 
+  /// The preview area.
+  ///
+  /// **The tail is produced by `.truncationMode(.head)`, not by counting characters
+  /// and not by clipping an oversized box.** A character budget is a guess about how
+  /// many glyphs fit, and that guess is wrong by a factor of two for CJK and wrong
+  /// again for any proportional font. Clipping was tried first and shipped two
+  /// visible defects that a screenshot caught immediately: `fixedSize` makes a Text
+  /// render at its ideal height regardless of the frame around it, so three lines of
+  /// text spilled out of the capsule background entirely and the top line was sliced
+  /// through the middle of its glyphs. Letting the text engine drop the head gives
+  /// the same "newest words win" result, correct in every script, with a leading
+  /// ellipsis that reads as continuation rather than as a rendering fault.
+  @ViewBuilder
+  private var livePreviewBody: some View {
+    switch preview {
+    case .off:
+      EmptyView()
+    case .waiting:
+      previewText(LivePreviewCopy.listening, dimmed: true)
+    case .unavailable(let reason):
+      // Say why rather than sitting blank. A blank preview reads as "it did not
+      // hear me", which is the exact anxiety this feature exists to remove.
+      previewText(reason, dimmed: true)
+    case .text(let text):
+      previewText(text, dimmed: false)
+    }
+  }
+
+  /// One builder for all three states, so the pill cannot change size or alignment
+  /// as it moves between "Listening...", real words, and a reason it cannot run.
+  private func previewText(_ message: String, dimmed: Bool) -> some View {
+    Text(message)
+      .font(.system(size: 12))
+      .foregroundStyle(.white.opacity(dimmed ? 0.5 : 0.92))
+      .lineLimit(Self.previewLineLimit)
+      .truncationMode(.head)
+      .multilineTextAlignment(.leading)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .frame(height: Self.previewTextHeight, alignment: .top)
+  }
+
+  /// Two lines at 12pt, reserved whether or not there is text, so the pill never
+  /// changes size while words arrive. `lineLimit` is what keeps the content inside
+  /// this height; the frame only reserves it.
+  private static let previewLineLimit = 2
+  private static let previewTextHeight: CGFloat = 34
 }
 
 // MARK: - PolishingOverlayView

--- a/Sources/EnviousWisprAppKit/App/SettingsChangeTelemetry.swift
+++ b/Sources/EnviousWisprAppKit/App/SettingsChangeTelemetry.swift
@@ -36,6 +36,11 @@ enum SettingsProjection {
     case useExtendedThinking = "use_extended_thinking"
     case languageMode = "language_mode"
     case streamingASR = "streaming_asr"
+    // #1988. Instrumented because adoption is the question this feature was built
+    // to answer, and the answer decides whether the macOS 26 floor is worth
+    // covering with a second engine for older Macs. A boolean setting value,
+    // never any dictated content.
+    case livePreview = "live_preview"
     case warmEnginePolicy = "warm_engine_policy"
     case appearance = "appearance"
     case overlayPillPosition = "overlay_pill_position"
@@ -92,6 +97,7 @@ enum SettingsProjection {
     case .useExtendedThinking: return [.useExtendedThinking]
     case .languageMode: return [.languageMode]
     case .useStreamingASR: return [.streamingASR]
+    case .livePreviewEnabled: return [.livePreview]
     case .warmEnginePolicy: return [.warmEnginePolicy]
     case .appearance: return [.appearance]
     case .overlayPillPosition: return [.overlayPillPosition]
@@ -137,6 +143,7 @@ enum SettingsProjection {
     case .useExtendedThinking: return onOff(settings.useExtendedThinking)
     case .languageMode: return languageModeLabel(settings.languageMode)
     case .streamingASR: return onOff(settings.useStreamingASR)
+    case .livePreview: return onOff(settings.livePreviewEnabled)
     case .warmEnginePolicy: return settings.warmEnginePolicy.rawValue
     case .appearance: return settings.appearancePreference.rawValue
     case .overlayPillPosition: return settings.overlayPillPosition.rawValue

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -461,7 +461,7 @@ public final class WisprBootstrapper {
     }
 
     // #1988: the live-preview limb, wired ONLY to the overlay. See the installer.
-    LivePreviewInstaller.install(
+    let livePreview = LivePreviewInstaller.install(
       overlay: recordingOverlay, capture: audioCapture, settings: settings)
 
     // Custom-words propagator wiring (seed → register consumers → install
@@ -473,6 +473,9 @@ public final class WisprBootstrapper {
       correctorConsumers: [
         kernelDriver.wordCorrection,
         whisperKitKernelDriver.wordCorrection,
+        // #1988: the preview corrects displayed text with the SAME lane, so a
+        // user's own names do not visibly mangle while the pasted text is fixed.
+        livePreview,
       ],
       polishConsumers: [
         kernelDriver.llmPolish,

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -460,6 +460,10 @@ public final class WisprBootstrapper {
       permissions?.accessibilityWarningDismissed ?? false
     }
 
+    // #1988: the live-preview limb, wired ONLY to the overlay. See the installer.
+    LivePreviewInstaller.install(
+      overlay: recordingOverlay, capture: audioCapture, settings: settings)
+
     // Custom-words propagator wiring (seed → register consumers → install
     // `onWordsChanged`). Phase D (#496). `wireCustomWords` strong-captures the
     // propagator so its lifetime is anchored to `customWordsCoordinator`.

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsCopy.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsCopy.swift
@@ -23,15 +23,29 @@ enum LivePreviewSettingsCopy {
   static let sectionHeader = "On-screen Preview"
   static let toggleLabel = "Show words while I speak"
 
-  /// Says three things, in the order a user cares about them: what they will see,
-  /// that it is not what gets pasted, and that it costs them nothing in accuracy.
-  /// The third is the one that stops "is this making my transcription worse?",
-  /// which is the natural next question once they know two engines are running.
+  /// Says four things, in the order a user cares about them: what they will see,
+  /// where that text goes, that it is not what gets pasted, and that it costs them
+  /// nothing in accuracy. The last is the one that stops "is this making my
+  /// transcription worse?", the natural next question once they know two engines
+  /// are running.
+  ///
+  /// The privacy sentence is here because #1988 asks for it in writing ("It should
+  /// be trivially yes (nothing leaves the Mac), but state it"). Trivially true is
+  /// not the same as visible: a user deciding whether to switch on something that
+  /// watches them speak should not have to infer the answer from our reputation,
+  /// and this is the only surface they read before deciding. It is also the one
+  /// place the claim can be made narrowly and honestly, since this preview really
+  /// is on-device for every user, with no cloud variant to qualify.
+  /// Keeps "preview only" verbatim. The reviewer's proposed replacement dropped
+  /// that phrase, which a frozen test requires and which carries the disclaimer
+  /// this copy exists for, so the privacy sentence is added ALONGSIDE it rather
+  /// than in place of it.
   static let toggleDescription =
     "See your words appear in the recording pill as you talk, so you know "
-    + "EnviousWispr is hearing you. This is a preview only. The text that gets "
-    + "pasted is still produced by your chosen engine after you finish, so turning "
-    + "this on does not change a single character of your result."
+    + "EnviousWispr is hearing you. This is a preview only. It stays on your Mac "
+    + "and is discarded when the recording ends. The text that gets pasted is "
+    + "still produced by your chosen engine after you finish, so turning this on "
+    + "does not change a single character of your result."
 
   /// Shown under the disabled toggle on older systems. Names the requirement and
   /// stops there: a user on macOS 14 cannot act on this beyond upgrading, and a

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsCopy.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsCopy.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// #1988: canonical copy for the "Live preview" setting.
+///
+/// Mirrors `LiveTranscriptionCopy` and `SpokenPunctuationCopy` in shape: one home
+/// for every user-facing string, frozen by a test so a change is a conscious act.
+///
+/// **The description's job is to prevent the misunderstanding that prompted this
+/// issue.** A real user turned on the setting called "Live transcription",
+/// expected words to appear as he spoke, saw nothing, and asked whether the
+/// feature was broken. So this copy says plainly what the preview is (something to
+/// look at) and what it is not (the text you get). Anyone who reads it should not
+/// be able to arrive at the wrong expectation.
+///
+/// Brand rule: no em-dashes or en-dashes in user-facing copy.
+enum LivePreviewSettingsCopy {
+  /// **Deliberately contains no "live".** The adjacent Transcription Mode section
+  /// already owns that word, and two settings both calling themselves live is the
+  /// confusion this issue was filed about. Renaming the OLDER one was measured and
+  /// rejected as a public-URL change (see `LiveTranscriptionCopy.toggleLabel`), so
+  /// the new setting is the one that gives up the word. "On-screen" also says the
+  /// true thing about it: this changes what you SEE, nothing else.
+  static let sectionHeader = "On-screen Preview"
+  static let toggleLabel = "Show words while I speak"
+
+  /// Says three things, in the order a user cares about them: what they will see,
+  /// that it is not what gets pasted, and that it costs them nothing in accuracy.
+  /// The third is the one that stops "is this making my transcription worse?",
+  /// which is the natural next question once they know two engines are running.
+  static let toggleDescription =
+    "See your words appear in the recording pill as you talk, so you know "
+    + "EnviousWispr is hearing you. This is a preview only. The text that gets "
+    + "pasted is still produced by your chosen engine after you finish, so turning "
+    + "this on does not change a single character of your result."
+
+  /// Shown under the disabled toggle on older systems. Names the requirement and
+  /// stops there: a user on macOS 14 cannot act on this beyond upgrading, and a
+  /// longer explanation would read as an apology.
+  static let needsNewerMacOS =
+    "On-screen preview needs macOS 26 or later. Dictation itself works on macOS 14 and up."
+}

--- a/Sources/EnviousWisprAppKit/Views/Settings/LiveTranscriptionCopy.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LiveTranscriptionCopy.swift
@@ -40,6 +40,17 @@ import Foundation
 ///
 /// Brand rule: no em-dashes or en-dashes in user-facing copy.
 enum LiveTranscriptionCopy {
+  /// #1988 considered renaming this ("Live transcription" promises something this
+  /// setting has never done, and a real user hit exactly that) and MEASURED the
+  /// cost first: the phrase appears 30 times across the app, three live website
+  /// pages, and a published help article whose TITLE and URL slug are the name
+  /// itself. That is a public-URL decision, not a copy tweak, so it is not bundled
+  /// into a feature PR. Tracked on #1988 Part 1.
+  ///
+  /// What #1988 shipped instead costs nothing and solves the confusion it would
+  /// have caused: the new preview setting avoids the word "live" entirely, and both
+  /// descriptions below now say plainly that this toggle changes nothing you can
+  /// see while recording.
   static let toggleLabel = "Live transcription"
   static let helpButtonAccessibilityLabel = "What does Live transcription change?"
 
@@ -95,8 +106,13 @@ enum LiveTranscriptionCopy {
   /// Replaces the pre-#1337 line "Transcribes while you speak for faster results. Turn off
   /// for cleaner text on longer recordings." That claim was measurably wrong for Parakeet:
   /// no perceptible gain below five minutes, so it advertised a benefit the data denies.
+  /// #1988 added the second sentence. It is the one that stops this being confused
+  /// with Live Preview, which is the mistake that named this setting wrongly in the
+  /// first place. True whether or not the preview is on, because the preview runs a
+  /// separate recognizer that this setting does not touch.
   static let parakeetToggleDescription =
-    "Transcribes while you speak instead of once when you stop. This does not save time "
+    "Transcribes while you speak instead of once when you stop. Nothing looks different "
+    + "while you record; this only changes when the work happens. It does not save time "
     + "you can notice on most dictations, and it can drop your last few words."
 
   static let parakeet = Panel(
@@ -136,8 +152,12 @@ enum LiveTranscriptionCopy {
 
   // MARK: - WhisperKit
 
+  /// Carries the same #1988 disambiguating sentence as the Parakeet copy above. A
+  /// clarification that lands on only one of two engine descriptions is the partial
+  /// port this codebase keeps relearning.
   static let whisperKitToggleDescription =
-    "Transcribes while you speak instead of once when you stop. This mainly helps on long "
+    "Transcribes while you speak instead of once when you stop. Nothing looks different "
+    + "while you record; this only changes when the work happens. It mainly helps on long "
     + "recordings, and it needs a language selected."
 
   static let whisperKit = Panel(

--- a/Sources/EnviousWisprAppKit/Views/Settings/SpeechEngineSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SpeechEngineSettingsView.swift
@@ -326,6 +326,32 @@ struct SpeechEngineSettingsView: View {
         }
       }
 
+      // ── Section 4b: Live preview (#1988) ──────────────────────────────
+      // Separate from Transcription Mode above because it changes nothing about
+      // transcription: it is a display feature, and the text that lands in the
+      // document is identical whether this is on or off. Grouping it with a
+      // setting that DOES trade accuracy would tell the user the opposite.
+      BrandedSection(header: LivePreviewSettingsCopy.sectionHeader) {
+        BrandedRow(showDivider: false) {
+          HStack(alignment: .top, spacing: 11) {
+            SettingsRowIcon(systemName: "text.viewfinder")
+            VStack(alignment: .leading, spacing: 4) {
+              Toggle(isOn: $settings.livePreviewEnabled) {
+                Text(LivePreviewSettingsCopy.toggleLabel).settingsRowLabel()
+              }
+              .toggleStyle(BrandedToggleStyle())
+              .disabled(!isLivePreviewSupported)
+              Text(LivePreviewSettingsCopy.toggleDescription)
+                .settingsReadingCopy()
+              if !isLivePreviewSupported {
+                Text(LivePreviewSettingsCopy.needsNewerMacOS)
+                  .settingsReadingCopy()
+              }
+            }
+          }
+        }
+      }
+
       // ── Section 5: Cleanup ────────────────────────────────────────────
       BrandedSection(header: "Cleanup") {
         BrandedRow(showDivider: true) {
@@ -514,6 +540,15 @@ struct SpeechEngineSettingsView: View {
 
   private func isAutoLanguage(_ mode: LanguageMode) -> Bool {
     if case .auto = mode { return true }
+    return false
+  }
+
+  /// #1988: the preview runs on Apple's on-device recognizer, which is macOS 26
+  /// API. Below that the toggle is visible but disabled, with the reason stated,
+  /// rather than hidden: a user who read about the feature should find out why
+  /// they do not have it instead of concluding it was removed.
+  private var isLivePreviewSupported: Bool {
+    if #available(macOS 26.0, *) { return true }
     return false
   }
 

--- a/Sources/EnviousWisprServices/SettingsDefaultValues.swift
+++ b/Sources/EnviousWisprServices/SettingsDefaultValues.swift
@@ -92,6 +92,13 @@ enum SettingsDefaultValues {
   static let useStreamingASR = false
   static let warmEnginePolicy: WarmEnginePolicy = .seconds30
 
+  // #1988: show the words in the recording pill while the user is still speaking.
+  // OFF by default. It costs screen attention some users explicitly do not want
+  // (the Reddit request that prompted it asked for it to be toggleable for exactly
+  // that reason), and it needs macOS 26, so a default-on toggle would read as
+  // broken on every older Mac. Display only: the pasted text never comes from it.
+  static let livePreviewEnabled = false
+
   // #1480: show the once-per-launch Bluetooth cold-start education popover when
   // the configured input is a Bluetooth mic. Default ON — it is light, dismissable,
   // and only appears for Bluetooth users; the toggle is the annoyance escape hatch.

--- a/Sources/EnviousWisprServices/SettingsManager.swift
+++ b/Sources/EnviousWisprServices/SettingsManager.swift
@@ -42,6 +42,7 @@ public final class SettingsManager {
     case selectedInputDeviceUID
     case preferredInputDeviceIDOverride
     case useStreamingASR
+    case livePreviewEnabled
     case warmEnginePolicy
     case appearance
     case overlayPillPosition
@@ -83,7 +84,8 @@ public final class SettingsManager {
     "isDebugModeEnabled", "isDictationAudioArchiveEnabled", "debugLogLevel",
     "useExtendedThinking", "whisperKitLanguage", "languageMode",
     "selectedInputDeviceUID", "preferredInputDeviceIDOverride",
-    "useStreamingASR", "warmEnginePolicy", "appearancePreference", "overlayPillPosition",
+    "useStreamingASR", "livePreviewEnabled", "warmEnginePolicy", "appearancePreference",
+    "overlayPillPosition",
     "showBluetoothTips", "playRecordingSounds", "recordingSoundPairing",
     WhatsNewConstants.lastSeenVersionDefaultsKey,
     globeGuidanceClaimKey,
@@ -428,6 +430,16 @@ public final class SettingsManager {
     didSet {
       defaults.set(useStreamingASR, forKey: "useStreamingASR")
       onChange?(.useStreamingASR)
+    }
+  }
+
+  /// #1988: live preview in the recording pill. Display only — the pasted text is
+  /// unaffected by this setting, which is why it carries no accuracy trade the way
+  /// `useStreamingASR` does.
+  public var livePreviewEnabled: Bool {
+    didSet {
+      defaults.set(livePreviewEnabled, forKey: "livePreviewEnabled")
+      onChange?(.livePreviewEnabled)
     }
   }
 
@@ -818,6 +830,9 @@ public final class SettingsManager {
     defaults.removeObject(forKey: "noiseSuppression")
     useStreamingASR =
       defaults.object(forKey: "useStreamingASR") as? Bool ?? SettingsDefaultValues.useStreamingASR
+    livePreviewEnabled =
+      defaults.object(forKey: "livePreviewEnabled") as? Bool
+      ?? SettingsDefaultValues.livePreviewEnabled
     warmEnginePolicy =
       WarmEnginePolicy(
         rawValue: defaults.string(forKey: "warmEnginePolicy") ?? ""

--- a/Tests/EnviousWisprTests/App/LivePreviewCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewCoordinatorTests.swift
@@ -71,7 +71,11 @@ struct LivePreviewCoordinatorTests {
     )
     coordinator.setRecording(true)
     coordinator.setRecording(false)
-    #expect(coordinator.display == .waiting)
+    // Stopping DISCARDS. This assertion used to read `.waiting`, which was
+    // incidental to the old behaviour of keeping the last text until the next
+    // recording. The settings copy now tells the user the preview is discarded
+    // when the recording ends, so this is the contract that sentence depends on.
+    #expect(coordinator.display == .off, "stopping must release the preview text")
 
     coordinator.setRecording(true)
     #expect(
@@ -94,7 +98,32 @@ struct LivePreviewCoordinatorTests {
     coordinator.setRecording(true)
     coordinator.setRecording(false)
     coordinator.setRecording(false)
-    #expect(coordinator.display != .off)
+    // Settles OFF, and a redundant second stop does not disturb that. This read
+    // `!= .off` when a stop left the last text in place; the discard makes the
+    // stronger statement available, so assert the exact state rather than the
+    // absence of one.
+    #expect(coordinator.display == .off)
+  }
+
+  /// The claim in the settings description, asserted directly rather than as a
+  /// side effect of another test: a user reads "discarded when the recording
+  /// ends" before deciding to switch this on, so the discard is a contract, not
+  /// an implementation detail that may drift.
+  @Test("Stopping discards the preview text, matching what the setting promises")
+  func stopDiscardsPreviewText() {
+    let coordinator = LivePreviewCoordinator(
+      audioCapture: CountingAudioCapture(),
+      isEnabled: { true },
+      languageMode: { .locked("en") }
+    )
+    coordinator.setRecording(true)
+    #expect(coordinator.display != .off, "control: a live recording is not off")
+
+    coordinator.setRecording(false)
+    #expect(coordinator.display == .off)
+    #expect(
+      LivePreviewSettingsCopy.toggleDescription.contains("discarded"),
+      "if this sentence goes, the assertion above stops being the promise it pins")
   }
 
   // MARK: - Language policy

--- a/Tests/EnviousWisprTests/App/LivePreviewCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewCoordinatorTests.swift
@@ -1,0 +1,198 @@
+@preconcurrency import AVFoundation
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprAudio
+@testable import EnviousWisprServices
+
+/// #1988 — the live preview's limb contract.
+///
+/// These tests deliberately do NOT drive Apple's recognizer. Building a
+/// `SpeechAnalyzer` needs macOS 26, a reserved locale and possibly a model
+/// download, none of which belong in a unit test and none of which the CI runner
+/// has. What IS unit-testable is the part that protects the heart: the gate that
+/// decides whether any of that happens at all, and the bound on what the feature
+/// retains. Live behaviour is covered by UAT.
+@MainActor
+struct LivePreviewCoordinatorTests {
+
+  // MARK: - The gate
+
+  @Test("Disabled: the preview stays off and never reads the audio buffer")
+  func disabledNeverTouchesAudio() async {
+    let capture = CountingAudioCapture()
+    let coordinator = LivePreviewCoordinator(
+      audioCapture: capture,
+      isEnabled: { false },
+      languageMode: { .locked("en") }
+    )
+
+    coordinator.setRecording(true)
+    #expect(coordinator.display == .off)
+
+    // This asserts a NEGATIVE (no feed loop was started), and there is no signal
+    // to wait on for something that must never happen. The paired
+    // `enabledStartsAndLeavesOff` test is the control proving the start path
+    // works, so a vacuous pass here would be caught there.
+    // settle: proving absence; a started loop polls every 100 ms so it could not hide inside this window
+    try? await Task.sleep(for: .milliseconds(250))
+    #expect(
+      capture.snapshotCallCount == 0,
+      "a disabled preview must not read captured audio at all")
+    #expect(coordinator.display == .off)
+  }
+
+  /// The two-way control for the test above. Without it, `disabledNeverTouchesAudio`
+  /// would pass just as happily against a coordinator whose start path was broken
+  /// or deleted, which is the shape of a vacuous guard test.
+  @Test("Enabled: the start path runs and the pill leaves the off state")
+  func enabledStartsAndLeavesOff() {
+    let coordinator = LivePreviewCoordinator(
+      audioCapture: CountingAudioCapture(),
+      isEnabled: { true },
+      languageMode: { .locked("en") }
+    )
+
+    coordinator.setRecording(true)
+    // Set synchronously by `setRecording`, before any async work, so this holds on
+    // every macOS version including ones where the recognizer cannot exist.
+    #expect(coordinator.display == .waiting)
+  }
+
+  @Test("A new recording never opens showing the previous one's words")
+  func startClearsPreviousText() {
+    let coordinator = LivePreviewCoordinator(
+      audioCapture: CountingAudioCapture(),
+      isEnabled: { true },
+      languageMode: { .locked("en") }
+    )
+    coordinator.setRecording(true)
+    coordinator.setRecording(false)
+    #expect(coordinator.display == .waiting)
+
+    coordinator.setRecording(true)
+    #expect(
+      coordinator.display == .waiting,
+      "the next press must reset the pill before its panel is created")
+  }
+
+  @Test("Stop is safe before any start, and start is safe twice")
+  func lifecycleIsIdempotent() {
+    let coordinator = LivePreviewCoordinator(
+      audioCapture: CountingAudioCapture(),
+      isEnabled: { true },
+      languageMode: { .locked("en") }
+    )
+    // Two call sites push recording intent (the first overlay push and every
+    // state-driven one), and `hide()` reports a stop that may already have
+    // happened. All the orders below occur in practice.
+    coordinator.setRecording(false)
+    coordinator.setRecording(true)
+    coordinator.setRecording(true)
+    coordinator.setRecording(false)
+    coordinator.setRecording(false)
+    #expect(coordinator.display != .off)
+  }
+
+  // MARK: - Language policy
+
+  @Test("A locked language previews in that language; Auto follows the system")
+  func languagePolicy() {
+    #expect(LivePreviewCoordinator.previewLanguageCode(.locked("de")) == "de")
+    let auto = LivePreviewCoordinator.previewLanguageCode(.auto)
+    let system = Locale.current.language.languageCode?.identifier ?? "en"
+    #expect(auto == system)
+    #expect(auto.isEmpty == false)
+  }
+
+  // MARK: - Bounding
+
+  @Test("Short text is returned untouched")
+  func shortTextUnbounded() {
+    let text = "the quick brown fox"
+    #expect(LivePreviewCoordinator.bounded(text) == text)
+  }
+
+  @Test("Long text keeps the tail, drops the head, and does not cut a word in half")
+  func longTextKeepsTail() {
+    // The pill shows the newest words, so the END is the part that must survive.
+    let long = String(repeating: "alpha ", count: 1000)  // 6000 characters
+    let bounded = LivePreviewCoordinator.bounded(long)
+
+    #expect(bounded.count <= LivePreviewCoordinator.maxRetainedCharacters)
+    #expect(bounded.isEmpty == false)
+    #expect(long.hasSuffix(bounded), "the retained text must be a suffix of the original")
+    #expect(
+      bounded.hasPrefix("alpha"),
+      "trimming must land on a word boundary, not mid-word")
+  }
+
+  @Test("Bounding a string with no spaces still bounds it")
+  func boundingWithoutWordBoundaries() {
+    // A CJK sentence carries no spaces, and neither does a pathological URL. The
+    // word-boundary step must not be able to turn the bound off.
+    let long = String(repeating: "語", count: 5000)
+    let bounded = LivePreviewCoordinator.bounded(long)
+    #expect(bounded.count <= LivePreviewCoordinator.maxRetainedCharacters)
+    #expect(long.hasSuffix(bounded))
+  }
+
+  // MARK: - Shipped default
+
+  @Test("Live preview ships off")
+  func shipsOff() {
+    // Off by default is the founder-approved shipped state: it costs screen
+    // attention some users explicitly asked to be able to decline, and it needs
+    // macOS 26, so on by default would read as broken on every older Mac.
+    #expect(SettingsDefaultValues.livePreviewEnabled == false)
+  }
+}
+
+/// #1988 — counts reads of the capture buffer so a test can assert that a disabled
+/// preview performs none.
+@MainActor
+private final class CountingAudioCapture: AudioCaptureInterface {
+  private(set) var snapshotCallCount = 0
+
+  var isCapturing: Bool = false
+  var audioLevel: Float = 0
+  var capturedSamples: [Float] = []
+  var currentAudioRoute: String = "built_in_mic"
+  var currentResolvedRoute: ResolvedRouteTransports? = nil
+  var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
+  var onEngineInterrupted: ((EngineInterruptionCause) -> Void)?
+  var onVADAutoStop: (() -> Void)?
+  var onMaxDurationReached: (() -> Void)?
+  var onCaptureStalled: ((CaptureStallContext) -> Void)?
+  var onRouteResolved: ((CaptureRouteDecision, _ sourceTypeChanged: Bool) -> Void)?
+  var currentCaptureSessionID: UInt64 = 0
+  var isActivelyCapturing: Bool = false
+  var captureSourceType: String = "hal_device_input"
+  var selectedInputDeviceUID: String = ""
+  var preferredInputDeviceIDOverride: String = ""
+  var warmEnginePolicy: WarmEnginePolicy = .off
+
+  func startEnginePhase() async throws {}
+  func beginCapturePhase(recoveryPayload: Data?) async throws -> AsyncStream<AVAudioPCMBuffer> {
+    AsyncStream { $0.finish() }
+  }
+  func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
+    AsyncStream { $0.finish() }
+  }
+  func stopCapture(sessionID: UInt64) async -> CaptureResult { CaptureResult(samples: []) }
+  func rebuildEngine() {}
+  func retireCapturingSource(sessionID: UInt64) -> ZeroSignalRetireResult { .sourceNotRunning }
+  func preWarm() async throws {}
+  func abortPreWarm() {}
+  func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async -> Bool {
+    true
+  }
+  func configureVAD(autoStop: Bool, silenceTimeout: Double, sensitivity: Float, energyGate: Bool) {}
+  func getSamplesSnapshot(fromIndex: Int) async -> (samples: [Float], totalCount: Int) {
+    snapshotCallCount += 1
+    return ([], 0)
+  }
+  func getVADSegments() async -> [SpeechSegment] { [] }
+}

--- a/Tests/EnviousWisprTests/App/LivePreviewCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewCoordinatorTests.swift
@@ -112,16 +112,16 @@ struct LivePreviewCoordinatorTests {
   @Test("Short text is returned untouched")
   func shortTextUnbounded() {
     let text = "the quick brown fox"
-    #expect(LivePreviewCoordinator.bounded(text) == text)
+    #expect(LivePreviewTextBound.apply(text) == text)
   }
 
   @Test("Long text keeps the tail, drops the head, and does not cut a word in half")
   func longTextKeepsTail() {
     // The pill shows the newest words, so the END is the part that must survive.
     let long = String(repeating: "alpha ", count: 1000)  // 6000 characters
-    let bounded = LivePreviewCoordinator.bounded(long)
+    let bounded = LivePreviewTextBound.apply(long)
 
-    #expect(bounded.count <= LivePreviewCoordinator.maxRetainedCharacters)
+    #expect(bounded.count <= LivePreviewTextBound.maxCharacters)
     #expect(bounded.isEmpty == false)
     #expect(long.hasSuffix(bounded), "the retained text must be a suffix of the original")
     #expect(
@@ -134,9 +134,18 @@ struct LivePreviewCoordinatorTests {
     // A CJK sentence carries no spaces, and neither does a pathological URL. The
     // word-boundary step must not be able to turn the bound off.
     let long = String(repeating: "語", count: 5000)
-    let bounded = LivePreviewCoordinator.bounded(long)
-    #expect(bounded.count <= LivePreviewCoordinator.maxRetainedCharacters)
+    let bounded = LivePreviewTextBound.apply(long)
+    #expect(bounded.count <= LivePreviewTextBound.maxCharacters)
     #expect(long.hasSuffix(bounded))
+  }
+
+  /// The bound is idempotent, which is what lets the producer apply it on every
+  /// update without the text creeping.
+  @Test("Applying the bound twice changes nothing the second time")
+  func boundIsIdempotent() {
+    let long = String(repeating: "alpha ", count: 1000)
+    let once = LivePreviewTextBound.apply(long)
+    #expect(LivePreviewTextBound.apply(once) == once)
   }
 
   // MARK: - Shipped default

--- a/Tests/EnviousWisprTests/App/LivePreviewCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewCoordinatorTests.swift
@@ -1,5 +1,6 @@
 @preconcurrency import AVFoundation
 import EnviousWisprCore
+import EnviousWisprPostProcessing
 import Foundation
 import Testing
 
@@ -156,6 +157,86 @@ struct LivePreviewCoordinatorTests {
     // attention some users explicitly asked to be able to decline, and it needs
     // macOS 26, so on by default would read as broken on every older Mac.
     #expect(SettingsDefaultValues.livePreviewEnabled == false)
+  }
+
+  // MARK: - Custom Words on preview text (#1988 acceptance)
+
+  private func makeCoordinator() -> LivePreviewCoordinator {
+    LivePreviewCoordinator(
+      audioCapture: CountingAudioCapture(),
+      isEnabled: { true },
+      languageMode: { .locked("en") }
+    )
+  }
+
+  private func word(_ canonical: String) -> CustomWord {
+    CustomWord(canonical: canonical)
+  }
+
+  /// **The seed arrives at generation 0, and so does the property's initial
+  /// `.empty`.** Comparing an incoming generation against the PREVIOUS VALUE's
+  /// would therefore treat a real vocabulary arriving at launch as an unchanged
+  /// one and silently drop it, so Custom Words would reach the preview only after
+  /// the user edited them — never, for anyone whose words were already saved.
+  /// This is the exact collision, written as the case most likely to regress.
+  @Test("A vocabulary seeded at generation 0 is picked up, not mistaken for empty")
+  func generationZeroSeedIsNotDropped() {
+    let coordinator = makeCoordinator()
+    #expect(coordinator.correctorLookupBuilds == 0)
+    #expect(coordinator.hasCorrectorLookupsForTesting == false)
+
+    coordinator.correctorVocabulary = CorrectorVocabulary(
+      terms: [word("Qualtrics")], generation: 0)
+
+    #expect(coordinator.correctorLookupBuilds == 1)
+    #expect(
+      coordinator.hasCorrectorLookupsForTesting,
+      "a generation-0 seed carrying real terms must build lookups")
+  }
+
+  @Test("A new generation rebuilds; the same generation does not")
+  func rebuildsOnlyOnGenerationChange() {
+    let coordinator = makeCoordinator()
+    coordinator.correctorVocabulary = CorrectorVocabulary(
+      terms: [word("Qualtrics")], generation: 1)
+    #expect(coordinator.correctorLookupBuilds == 1)
+
+    // Same generation, different terms: the generation IS the identity, so this
+    // must not rebuild. Building here would mean the cache key is not doing its
+    // job and every settings write pays a full lookup build.
+    coordinator.correctorVocabulary = CorrectorVocabulary(
+      terms: [word("Qualtrics"), word("EnviousWispr")], generation: 1)
+    #expect(coordinator.correctorLookupBuilds == 1)
+
+    coordinator.correctorVocabulary = CorrectorVocabulary(
+      terms: [word("Qualtrics"), word("EnviousWispr")], generation: 2)
+    #expect(coordinator.correctorLookupBuilds == 2)
+  }
+
+  /// An empty vocabulary stores `nil` rather than empty lookups, so the
+  /// recognizer's guard short-circuits instead of running a correction pass that
+  /// cannot match anything. Most users have no custom words, so this is the
+  /// common path, not an edge case.
+  @Test("Clearing the vocabulary drops the snapshot rather than keeping empty lookups")
+  func emptyVocabularyStoresNoLookups() {
+    let coordinator = makeCoordinator()
+    coordinator.correctorVocabulary = CorrectorVocabulary(
+      terms: [word("Qualtrics")], generation: 1)
+    #expect(coordinator.hasCorrectorLookupsForTesting)
+
+    coordinator.correctorVocabulary = CorrectorVocabulary(terms: [], generation: 2)
+    #expect(coordinator.correctorLookupBuilds == 2)
+    #expect(coordinator.hasCorrectorLookupsForTesting == false)
+  }
+
+  /// The correction the preview applies is the SAME function the pasted text goes
+  /// through, so this pins the behaviour the acceptance criterion is about: a
+  /// user's own name, misheard by Apple's recognizer, is repaired before display.
+  @Test("The corrector repairs a custom term the way the preview will")
+  func correctorRepairsACustomTerm() {
+    let lookups = WordCorrector.buildLookups(words: [word("Qualtrics")])
+    let corrected = WordCorrector().correct("i work at qualtrix today", using: lookups).corrected
+    #expect(corrected.contains("Qualtrics"), "got: \(corrected)")
   }
 }
 

--- a/Tests/EnviousWisprTests/App/LivePreviewCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewCoordinatorTests.swift
@@ -132,9 +132,28 @@ struct LivePreviewCoordinatorTests {
   func languagePolicy() {
     #expect(LivePreviewCoordinator.previewLanguageCode(.locked("de")) == "de")
     let auto = LivePreviewCoordinator.previewLanguageCode(.auto)
-    let system = Locale.current.language.languageCode?.identifier ?? "en"
-    #expect(auto == system)
+    #expect(auto == Locale.current.identifier(.bcp47))
     #expect(auto.isEmpty == false)
+  }
+
+  /// Auto must keep REGION and SCRIPT, not just language. Reducing to the language
+  /// code sends a Traditional Chinese Mac to the Simplified model, Brazilian
+  /// Portuguese to European, and Canadian French to Swiss — measured against
+  /// Apple's real resolver, not inferred. This asserts the property that prevents
+  /// it, on a fixed locale rather than the machine's, so it means the same thing
+  /// on every runner.
+  @Test("Auto preserves region and script, which is what picks the right model")
+  func autoPreservesRegionAndScript() {
+    // The reduction that caused it, applied to the cases it breaks. If
+    // `previewLanguageCode(.auto)` ever goes back to a bare language code, these
+    // are the users who silently get another region's model.
+    for id in ["zh-TW", "pt-BR", "fr-CA", "en-GB"] {
+      let full = Locale(identifier: id)
+      let bare = full.language.languageCode?.identifier
+      #expect(
+        full.identifier(.bcp47) != bare,
+        "\(id) must not survive as a bare language code")
+    }
   }
 
   // MARK: - Bounding

--- a/Tests/EnviousWisprTests/App/RecordingOverlayPanelInheritedGeometryTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingOverlayPanelInheritedGeometryTests.swift
@@ -1,0 +1,105 @@
+import AppKit
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// Pins the Top-position inherited-transition arithmetic (#1988 cloud review).
+///
+/// `RecordingOverlayPanel` is real-NSPanel/window-server UI code under the
+/// established runtime-only exemption, so the geometry decision is extracted as
+/// a pure function and pinned here rather than driven through a live panel.
+///
+/// The defect: the recording pill used to be a fixed 92pt frame, so preserving
+/// its CENTER across the hand-off to the shorter polishing pill kept the visible
+/// pill still (#1650). The #1988 preview made the recording frame content-sized
+/// and anchored to its TOP edge while it grows, and center-preservation then
+/// dropped the polishing pill by half the height it lost.
+///
+/// **Keep both sides of every `#expect` comparison the same type.** An `#expect`
+/// whose two sides are `CGFloat` and `Double` (or an untyped integer expression)
+/// reports a FAILURE on values that are genuinely equal: the macro re-evaluates
+/// the expression without the implicit CGFloat/Double conversion the type
+/// checker inserted. Measured while writing these tests — the same comparison
+/// assigned to a local first was `true`, with identical bit patterns, while the
+/// macro printed `(top → 0.0) == (originY → 0.0)` and recorded an issue. The
+/// signature is a failure message whose two printed values look equal.
+@Suite("RecordingOverlayPanel — inherited Top geometry (#1988)")
+struct RecordingOverlayPanelInheritedGeometryTests {
+
+  /// 44pt polishing pill inheriting from a five-line 150pt preview frame whose
+  /// top edge sits at y = 950.
+  private static let tallPreview = NSRect(x: 0, y: 800, width: 400, height: 150)
+
+  @Test("a content-sized outgoing frame keeps its TOP edge, not its center")
+  func contentSizedPreservesTopEdge() {
+    let y = RecordingOverlayPanel.inheritedTopOriginY(
+      inheritedFrame: Self.tallPreview, resolvedHeight: 44, outgoingWasContentSized: true)
+
+    // Top edge 950 preserved: the incoming pill's own top edge lands there too.
+    #expect(y + 44 == Self.tallPreview.maxY)
+    #expect(y == 906)
+  }
+
+  @Test("center-preservation would drop the incoming pill by half the height lost")
+  func centerRuleDropsATallPreview() {
+    // Not a second assertion of the same thing: this pins the SIZE of the bug,
+    // so a future change that silently reverts to the center rule fails with a
+    // number that names the symptom rather than an opaque mismatch.
+    let top = RecordingOverlayPanel.inheritedTopOriginY(
+      inheritedFrame: Self.tallPreview, resolvedHeight: 44, outgoingWasContentSized: true)
+    let center = RecordingOverlayPanel.inheritedTopOriginY(
+      inheritedFrame: Self.tallPreview, resolvedHeight: 44, outgoingWasContentSized: false)
+
+    // Both sides CGFloat deliberately — see the type note on the suite.
+    let expectedDrop: CGFloat = (Self.tallPreview.height - 44) / 2
+    #expect(top - center == expectedDrop)
+    #expect(expectedDrop == 53)
+  }
+
+  @Test("a fixed outgoing frame still preserves its center (#1650 unchanged)")
+  func fixedFramePreservesCenter() {
+    // The shipped case #1650 fixed: the 92pt recording frame handing off to the
+    // ~44pt polishing pill.
+    let fixedRecording = NSRect(x: 0, y: 800, width: 185, height: 92)
+
+    let y = RecordingOverlayPanel.inheritedTopOriginY(
+      inheritedFrame: fixedRecording, resolvedHeight: 44, outgoingWasContentSized: false)
+
+    #expect(y + 22 == fixedRecording.midY)
+    #expect(y == 824)
+  }
+
+  @Test("the two rules agree exactly when the height does not change")
+  func rulesAgreeAtEqualHeights() {
+    // The claim that licenses leaving every other content-sized transition
+    // alone: this branch can only change behaviour when a transition changes
+    // height. Swept across heights and origins rather than asserted once,
+    // because a single example would hold for the wrong reason.
+    for height in stride(from: CGFloat(20), through: 200, by: 20) {
+      for originY in stride(from: CGFloat(0), through: 900, by: 300) {
+        let frame = NSRect(x: 0, y: originY, width: 300, height: height)
+        let top = RecordingOverlayPanel.inheritedTopOriginY(
+          inheritedFrame: frame, resolvedHeight: height, outgoingWasContentSized: true)
+        let center = RecordingOverlayPanel.inheritedTopOriginY(
+          inheritedFrame: frame, resolvedHeight: height, outgoingWasContentSized: false)
+
+        #expect(top == center)
+        #expect(top == originY, "an unchanged height must not move the pill at all")
+      }
+    }
+  }
+
+  @Test("a GROWING transition moves the pill up under the content-sized rule")
+  func growingTransitionUnderContentSizedRule() {
+    // The reverse direction, which the preview also produces: a one-line pill
+    // inheriting into something taller must keep its top edge, so it grows
+    // downward rather than straddling the old center.
+    let shortPill = NSRect(x: 0, y: 900, width: 400, height: 44)
+
+    let y = RecordingOverlayPanel.inheritedTopOriginY(
+      inheritedFrame: shortPill, resolvedHeight: 150, outgoingWasContentSized: true)
+
+    #expect(y + 150 == shortPill.maxY)
+    #expect(y == 794)
+  }
+}

--- a/Tests/EnviousWisprTests/Architecture/EngineMutationInventoryFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EngineMutationInventoryFreezeTests.swift
@@ -643,6 +643,18 @@ import Testing
       file: "Sources/EnviousWisprPipeline/CaptureVADSignalSource.swift", matcher: "prepare",
       text: "try await detector.prepare()", classification: .unrelatedDomain),
 
+    // MARK: LivePreviewCoordinator (#1988) — Apple's `SpeechAnalyzer`, used for
+    // DISPLAY ONLY. Not an ASR engine and not on the transcription path: nothing
+    // it produces reaches the clipboard, and it holds no `ASREngineAdapter`.
+    // Matched only by method-name coincidence, the same shape as the VAD entry
+    // above. Classified rather than renamed on purpose — renaming to sidestep a
+    // name-based inventory would remove this code from the inventory's view, and
+    // the next reader would have no record that the question was asked.
+    CallSite(
+      file: "Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift",
+      matcher: "prepare",
+      text: "try await fresh.prepare()", classification: .unrelatedDomain),
+
     // MARK: KernelDictationDriver
     // The SESSIONLESS load-wedge guard's fire path. `SessionlessLoadWedgeGuard`
     // is armed immediately before, and disarmed immediately after,

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -438,14 +438,24 @@ import Testing
   /// together, not either alone, exhaust the budget. No domain logic moved here —
   /// same class of irreducible composition-root residue as every entry above.
   /// Cap by deterministic rule (actual 1331 + ~2, rounded up to nearest 5 = 1335).
+  /// #1988 (live preview): 1335 → 1340 for THREE lines — one comment and a
+  /// two-line `LivePreviewInstaller.install(...)` call. The feature's own wiring
+  /// (building the coordinator, handing the overlay its three seams) is fifteen
+  /// lines and deliberately does NOT live here: it was extracted to
+  /// `LivePreviewInstaller` the moment this ceiling caught it, which is exactly
+  /// the behaviour the thermostat exists to produce. What remains is the
+  /// irreducible part — only the composition root holds the overlay panel, the
+  /// concrete capture manager and the settings manager at the same time. No
+  /// domain logic moved here; the limb's entire behaviour lives on its own types.
+  /// Cap by deterministic rule (actual 1336 + ~2, rounded up to nearest 5 = 1340).
   @Test func envWisprAppLineCountCeilingHolds() throws {
     let url = envWisprAppURL()
     let source = try String(contentsOf: url, encoding: .utf8)
     let lineCount = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
-      lineCount <= 1335,
+      lineCount <= 1340,
       """
-      WisprBootstrapper line count exceeded: \(lineCount) > 1335. \
+      WisprBootstrapper line count exceeded: \(lineCount) > 1340. \
       Raising the ceiling requires a Bible changelog entry.
       """)
   }

--- a/Tests/EnviousWisprTests/Settings/LivePreviewSettingsCopyTests.swift
+++ b/Tests/EnviousWisprTests/Settings/LivePreviewSettingsCopyTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #1988 — freezes the live-preview setting's user-facing copy, mirroring
+/// `LiveTranscriptionCopyTests`.
+///
+/// This issue exists partly BECAUSE a setting's name promised something the code
+/// did not do, so the copy that replaces it earns the same protection: a change
+/// here should be a conscious act, not drift.
+@MainActor
+struct LivePreviewSettingsCopyTests {
+
+  private var allStrings: [String] {
+    [
+      LivePreviewSettingsCopy.sectionHeader,
+      LivePreviewSettingsCopy.toggleLabel,
+      LivePreviewSettingsCopy.toggleDescription,
+      LivePreviewSettingsCopy.needsNewerMacOS,
+      LivePreviewCopy.needsNewerMacOS,
+      LivePreviewCopy.languageUnsupported,
+      LivePreviewCopy.notReady,
+      LivePreviewCopy.preparing,
+      LivePreviewCopy.listening,
+    ]
+  }
+
+  /// Brand rule: no em-dashes or en-dashes in user-facing copy.
+  @Test("No user-facing string carries an em-dash or en-dash")
+  func noDashes() {
+    for s in allStrings {
+      #expect(s.contains("\u{2014}") == false, "em-dash in user-facing copy: \(s)")
+      #expect(s.contains("\u{2013}") == false, "en-dash in user-facing copy: \(s)")
+    }
+  }
+
+  @Test("No user-facing string is empty")
+  func noEmptyStrings() {
+    for s in allStrings {
+      #expect(s.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false)
+    }
+  }
+
+  /// The whole point of this feature's copy. A user who reads the description must
+  /// not be able to conclude that the preview is what gets pasted, because the
+  /// preview is measurably less accurate than the engine that does get pasted, and
+  /// a user who believes otherwise will report a bug that is not one.
+  @Test("The description says the preview is not the pasted text")
+  func descriptionDisclaimsThePastedText() {
+    let d = LivePreviewSettingsCopy.toggleDescription.lowercased()
+    #expect(d.contains("preview only"))
+    #expect(d.contains("pasted"))
+  }
+
+  /// Two adjacent settings both calling themselves "live" is the confusion this
+  /// issue was filed about. Renaming the OLDER one was measured and rejected for
+  /// this PR: the phrase appears 30 times across the app, three live website pages,
+  /// and a help article whose title and URL slug ARE the name, which makes it a
+  /// public-URL decision rather than a copy tweak (#1988 Part 1). So the NEW
+  /// setting gives up the word instead, and this test is what keeps it given up.
+  /// Every string the preview shows, not just its two labels. A pill that says
+  /// "Live preview needs macOS 26" under a setting called "On-screen Preview" is
+  /// the same confusion re-entering by the back door, and the pill strings are the
+  /// ones nobody re-reads.
+  @Test("No preview string calls itself live")
+  func previewNeverCallsItselfLive() {
+    for s in allStrings {
+      #expect(
+        s.lowercased().contains("live") == false,
+        "the preview's copy must not reuse the word the streaming toggle owns: \(s)")
+    }
+  }
+
+  /// Both engine descriptions must carry the sentence that separates "when the work
+  /// happens" from "what you can see". A clarification landing on only one of two
+  /// engines is the partial port this codebase keeps relearning.
+  @Test("Both engine descriptions say nothing looks different while recording")
+  func bothEnginesDisambiguate() {
+    for description in [
+      LiveTranscriptionCopy.parakeetToggleDescription,
+      LiveTranscriptionCopy.whisperKitToggleDescription,
+    ] {
+      #expect(
+        description.lowercased().contains("nothing looks different"),
+        "each engine's copy must separate this setting from Live Preview: \(description)")
+    }
+  }
+}

--- a/scripts/eval/acceptance_gate.py
+++ b/scripts/eval/acceptance_gate.py
@@ -21,6 +21,7 @@ Design refs:
 from __future__ import annotations
 
 import argparse
+import http.client
 import json
 import os
 import random
@@ -306,17 +307,62 @@ def _key(name: str) -> str:
     return p.read_text().strip()
 
 
+class TransientTransportError(Exception):
+    """A network failure raised BY the network operation itself.
+
+    Mirrors behavior_judge.TransientTransportError, deliberately as a separate
+    copy: this file is the CI gate and keeps its own transports for exactly that
+    reason. Both must agree, and the reason both exist is worth stating once
+    here. Cloud review found that `_http_call_with_retry(lambda: polish_one(...))`
+    wraps `_key()`, which does `Path.read_text()` on a credential file -- so a
+    predicate testing bare `OSError` turned an unreadable key into three retries
+    per case across a whole corpus. Auditing every retry scope for stray I/O is a
+    promise; converting at the one place the socket is touched is a property.
+    """
+
+    def __init__(self, cause: Exception):
+        super().__init__(f"{type(cause).__name__}: {cause}")
+        self.cause = cause
+
+
+def _http_json(req, timeout: float):
+    """Perform the request and decode it, converting ONLY transport failures.
+
+    HTTPError passes through so the caller can read its status code; a decode
+    failure passes through because a 200 with an unparsable body is the server's
+    answer, not a network fault.
+    """
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read()
+    except urllib.error.HTTPError:
+        raise
+    except (OSError, http.client.HTTPException) as e:
+        raise TransientTransportError(e) from None
+    return json.loads(raw)
+
+
 def _retryable_http_error(exc: Exception) -> bool:
     """Classify HTTPError responses as transient-retryable. Covers 5xx + 429.
     Returns False for auth/bad-request errors (4xx except 429) which will never
     succeed on retry.
+
+    Everything that is not an HTTPError is transport, and transport is transient.
+    This tests the BASE classes rather than naming `URLError`, because urllib
+    wraps only what `urlopen` itself raises: a reset arriving while the RESPONSE
+    BODY is read propagates as a bare `ConnectionResetError`, which is an OSError
+    and NOT a URLError, so the narrower form answered False for the commonest
+    real failure. Measured in `behavior_judge.py`'s copy of this predicate on
+    2026-08-14 — three chunk drops per run, 24 cases each, across two runs.
+    HTTPError stays first because it subclasses OSError and a 400 must not retry.
     """
     if isinstance(exc, urllib.error.HTTPError):
         return exc.code >= 500 or exc.code == 429
-    if isinstance(exc, urllib.error.URLError):
-        # Network-level (timeouts, DNS hiccup) — retry.
-        return True
-    return False
+    # Only what the NETWORK CALL itself raised. A credential read, a file write or
+    # a subprocess spawn anywhere else in the retried scope keeps its own type and
+    # is never retried -- which is the whole point, since `_http_call_with_retry`
+    # wraps `polish_one`, and `polish_one` reads the key file.
+    return isinstance(exc, TransientTransportError)
 
 
 def _http_call_with_retry(do_call, attempts: int = 3, base_delay: float = 1.5):
@@ -357,8 +403,7 @@ def call_openai(model: str, system: str, user: str) -> str:
         headers={"Authorization": f"Bearer {_key('openai-api-key')}", "Content-Type": "application/json"},
         method="POST",
     )
-    with urllib.request.urlopen(req, timeout=300) as resp:
-        data = json.loads(resp.read())
+    data = _http_json(req, 300)
     return data["choices"][0]["message"]["content"].strip()
 
 
@@ -375,8 +420,7 @@ def call_gemini(model: str, system: str, user: str, json_mime: bool = False) -> 
         url, data=json.dumps(body).encode(),
         headers={"Content-Type": "application/json"}, method="POST",
     )
-    with urllib.request.urlopen(req, timeout=300) as resp:
-        data = json.loads(resp.read())
+    data = _http_json(req, 300)
     parts = data["candidates"][0]["content"]["parts"]
     return "".join(p.get("text", "") for p in parts).strip()
 

--- a/scripts/eval/behavior_judge.py
+++ b/scripts/eval/behavior_judge.py
@@ -58,6 +58,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import http.client
 import json
 import os
 import random
@@ -108,13 +109,29 @@ DEFAULT_JUDGE = os.environ.get("EW_JUDGE", AZURE_JUDGE_DEPLOYMENT_ID)
 CLAUDE_JUDGE_MAX_WORKERS = 6            # subprocess per call; cap fan-out. Raised
 # from 3 (#1199 speed pass, 2026-06-30), then 20 -> 32 (founder 2026-07-02:
 # faster judging: no metered cost on the subscription judge, only a transient
-# rate-limit risk that judge_chunk's 3-attempt retry absorbs). Lowered back to
+# rate-limit risk that judge_chunk's retry absorbs — JUDGE_CHUNK_ATTEMPTS, 5
+# since 2026-08-15; this said "3-attempt" and went stale the moment that moved,
+# which is why it now names the constant instead of a number). Lowered back to
 # 6 (founder 2026-07-20): 32 concurrent `claude -p` subprocesses (each
 # spawning ripgrep) pushed system load average past 40 while other work was
 # running on the same machine, echoing the load-234 incident in
 # eg1-operations.md. 6 stays well clear of that while judging 1,890 cases in
 # roughly 25 minutes.
-HTTP_JUDGE_MAX_WORKERS = 4
+# Raised 4 -> 12 (founder 2026-08-14: "if it's a cloud grader, why so slow"). The 4 was
+# never justified for this transport -- it sat beside the CLAUDE cap's rationale, which is
+# about local subprocess load (32 concurrent `claude -p` each spawning ripgrep pushed load
+# past 40). An HTTPS request to Azure spawns nothing and costs no local CPU, so that
+# reasoning does not transfer and the cap was inherited rather than measured.
+#
+# The real ceiling is the deployment's rate limit, and exceeding it is SAFE here: Azure
+# answers 429, `_retryable_http_error` marks it retryable, and `judge_chunk` retries with
+# backoff. So the failure mode of too-high is slower-but-correct, not wrong results --
+# which is why this can be raised without risking the grade.
+#
+# Measured before the change: 1,861 cases = 233 chunks at ~19s per chunk, 4 at a time,
+# ~25 min. Override per run with EW_JUDGE_WORKERS to find the deployment's real ceiling
+# without editing code.
+HTTP_JUDGE_MAX_WORKERS = int(os.environ.get("EW_JUDGE_WORKERS", "12"))
 DEFAULT_REPLICATIONS = 2              # old-system judge instability net (no temperature knob on CLI)
 DEFAULT_ADJUDICATE_PCT = 0.15          # new-system: fraction of pass/minor/soft_fail
 DEFAULT_ADJUDICATE_MIN = 15            # cases re-judged as a calibration sample
@@ -165,10 +182,91 @@ def _key(name: str) -> str:
     return p.read_text().strip()
 
 
+class TransientTransportError(Exception):
+    """A network failure raised BY the network operation itself.
+
+    Exists to make the retry predicate's scope structural instead of a promise.
+    The predicate used to test `OSError`, which is correct for a socket and wrong
+    for everything else that can appear in the same `try`: cloud review found
+    three separate instances in this change set -- a local WAV write, a
+    subprocess spawn for a missing CLI, and a credential file read -- where a
+    permanent local failure would have been answered with another paid request.
+
+    Auditing each retry scope for stray I/O is a promise that has to be re-made
+    every time someone adds a line. Converting at the ONE place the network is
+    touched is a property: anything else in the scope raises its own type and is
+    never retried, by construction.
+    """
+
+    def __init__(self, cause: Exception):
+        super().__init__(f"{type(cause).__name__}: {cause}")
+        self.cause = cause
+
+
+def _http_json(opener, req, timeout: float):
+    """Perform the request and decode it, converting ONLY transport failures.
+
+    `HTTPError` is deliberately re-raised untouched: it carries a status code and
+    the caller decides 429/5xx-retryable from that. A JSON decode failure is also
+    left alone -- a 200 with an unparsable body is the server's answer, and the
+    callers that want to retry it already test `json.JSONDecodeError` explicitly.
+    """
+    try:
+        with opener.open(req, timeout=timeout) as resp:
+            raw = resp.read()
+    except urllib.error.HTTPError:
+        raise
+    except (OSError, http.client.HTTPException) as e:
+        raise TransientTransportError(e) from None
+    return json.loads(raw)
+
+
+class JudgeUnavailableError(Exception):
+    """The judge transport cannot work at all, and no number of attempts changes
+    that: a missing or unexecutable CLI, a route with no funded transport.
+
+    Exists because the retry predicate treats every OSError as transport, which
+    is right for an HTTP call and wrong for a subprocess spawn — `FileNotFoundError`
+    from a missing `claude` binary is an OSError and would otherwise be retried
+    once per attempt, per chunk, for the whole corpus.
+    """
+
+
 def _retryable_http_error(exc: Exception) -> bool:
+    """True when `exc` is a transient transport failure worth another attempt.
+
+    HTTPError is tested FIRST and is the only branch that can answer False for an
+    OSError, because `HTTPError` subclasses `URLError` subclasses `OSError`: a 400
+    or a 401 is the server's considered answer and retrying it just burns credits.
+
+    Everything below that is transport, and transport is transient. Catch the BASE
+    classes rather than a list of names. The list this replaces --
+    `(urllib.error.URLError, TimeoutError)` -- looked complete and missed six real
+    failure modes, because urllib wraps only what `urlopen` itself raises. A reset
+    arriving while the RESPONSE BODY is being read propagates as a bare
+    `ConnectionResetError`, which is an OSError but not a URLError, so it fell
+    through to FATAL.
+
+    Measured cost of that gap on 2026-08-14: two 1,861-case grading runs each logged
+    exactly three `FATAL on chunk (attempt 1): [Errno 54] Connection reset by peer`
+    and each dropped exactly 24 cases (3 chunks x chunk_size 8). The dropped IDs had
+    ZERO overlap between the two runs, which is what rules out a content trigger and
+    identifies it as transport. Both runs were correctly reported INCOMPLETE by
+    `reconcile_judge_batch`, so nothing wrong was ever published -- the accounting
+    layer did its job. This fixes the layer that manufactured the gap, and
+    deliberately does not touch the one that reports it.
+
+    Verified against constructed instances rather than reasoned about; the two-way
+    control lives in `behavior_judge_test.py::test_transport_resets_are_retryable_
+    but_client_errors_are_not`.
+    """
     if isinstance(exc, urllib.error.HTTPError):
         return exc.code == 429 or 500 <= exc.code < 600
-    return isinstance(exc, (urllib.error.URLError, TimeoutError))
+    # Only what the NETWORK CALL itself raised. `_http_json` converts OSError and
+    # http.client.HTTPException at the socket, so a file read, a file write or a
+    # subprocess spawn elsewhere in the same `try` keeps its own type and is not
+    # retried. Testing bare OSError here is what made all three of those retryable.
+    return isinstance(exc, TransientTransportError)
 
 
 # `call_openai` and `call_gemini` are DELETED, not merely unrouted (founder 2026-08-11,
@@ -208,6 +306,17 @@ def call_claude(model: str, system: str, user: str) -> str:
         )
     except subprocess.TimeoutExpired:
         raise RuntimeError("claude judge: CLI timed out after 300s")
+    except OSError as e:
+        # A spawn failure (`claude` not on PATH, not executable) is an OSError.
+        # Since `_retryable_http_error` now only accepts TransientTransportError,
+        # a bare OSError is already non-retryable -- but it would surface as an
+        # opaque FileNotFoundError with no guidance. This converts it into a
+        # named, actionable error instead. RuntimeError is deliberately NOT used:
+        # judge_chunk retries that one.
+        raise JudgeUnavailableError(
+            f"claude judge: cannot start the CLI ({type(e).__name__}: {e}). "
+            f"This is permanent — install/authenticate the CLI or pick another "
+            f"--judge; retrying would just burn the wall clock.") from None
     if proc.returncode != 0:
         raise RuntimeError(
             f"claude judge: CLI exited {proc.returncode}: {(proc.stderr or '').strip()[:300]}")
@@ -316,8 +425,7 @@ def call_azure(deployment: str, system: str, user: str) -> str:
         headers={"api-key": _key("azure-openai-key"), "Content-Type": "application/json"},
         method="POST",
     )
-    with _no_redirect_opener().open(req, timeout=300) as resp:
-        data = json.loads(resp.read())
+    data = _http_json(_no_redirect_opener(), req, 300)
     choices = data.get("choices") or []
     if not choices:
         raise RuntimeError(f"azure judge: no choices in response: {str(data)[:200]}")
@@ -463,8 +571,7 @@ def _azure_served_model(deployment: str) -> str:
         headers={"api-key": _key("azure-openai-key"), "Content-Type": "application/json"},
         method="POST",
     )
-    with _no_redirect_opener().open(req, timeout=60) as resp:
-        data = json.loads(resp.read())
+    data = _http_json(_no_redirect_opener(), req, 60)
     served = data.get("model")
     if not isinstance(served, str) or not served.strip():
         # Fail rather than fall back to a version-blind identity: a blind identity silently
@@ -612,16 +719,49 @@ def parse_judge_array(raw: str) -> list[dict[str, Any]]:
     return parsed if isinstance(parsed, list) else []
 
 
+JUDGE_CHUNK_ATTEMPTS = 5
+
+
+def _judge_retry_delay(attempt: int) -> float:
+    """Capped exponential backoff with jitter.
+
+    Jitter is not decoration here: every worker shares one deployment, so a
+    rate-limit window knocks several chunks down at the same instant, and a
+    deterministic `2 * attempt` marches them all back in lockstep to collide
+    again. Capped at 30s so five attempts span roughly a minute rather than
+    stalling a run that is otherwise healthy.
+    """
+    return min(2.0 ** attempt, 30.0) + random.uniform(0.0, 1.5)
+
+
 def judge_chunk(model: str, system: str, payload_cases: list[dict], attempt: int = 1) -> list[dict]:
-    """One judge call over a chunk. Retries on transient/parse error (3 attempts)."""
+    """One judge call over a chunk. Retries on transient transport/parse error.
+
+    Returning `[]` here does not corrupt anything: `reconcile_judge_batch` counts
+    every requested id and the receipt's `run_complete` gate fails the run. The
+    cost of landing here is a whole re-run, which is why the retry budget is
+    generous rather than minimal.
+    """
     user = "Score these cases. Return ONLY the JSON array.\n" + json.dumps(payload_cases, ensure_ascii=False)
     try:
         return parse_judge_array(dispatch_judge(model, system, user))
     except Exception as e:
-        if attempt < 3 and (_retryable_http_error(e) or isinstance(e, (json.JSONDecodeError, RuntimeError))):
-            time.sleep(2 * attempt)
+        # JudgeUnavailableError needs no clause here: it derives from Exception
+        # directly, so it matches neither `_retryable_http_error` (OSError /
+        # HTTPException) nor the parse/RuntimeError arm, and falls through to
+        # FATAL on the first attempt. An explicit guard was written first and a
+        # mutation control proved it dead — the type relationship is the
+        # mechanism, and `test_a_missing_judge_cli_is_not_retried` locks it so a
+        # future re-parenting of that class cannot silently make it retryable.
+        if (attempt < JUDGE_CHUNK_ATTEMPTS
+                and (_retryable_http_error(e)
+                     or isinstance(e, (json.JSONDecodeError, RuntimeError)))):
+            print(f"[judge] transient on chunk (attempt {attempt}/"
+                  f"{JUDGE_CHUNK_ATTEMPTS}), retrying: {e}", file=sys.stderr)
+            time.sleep(_judge_retry_delay(attempt))
             return judge_chunk(model, system, payload_cases, attempt + 1)
-        print(f"[judge] FATAL on chunk (attempt {attempt}): {e}", file=sys.stderr)
+        print(f"[judge] FATAL on chunk (attempt {attempt}): {type(e).__name__}: {e}",
+              file=sys.stderr)
         return []
 
 
@@ -774,11 +914,22 @@ DEFAULT_ALLOWED_VARIANTS = [
     # and rendering it `EnviousWispr` is also correct. Grade the behavior under test.
     "repairing a plainly mis-transcribed product or technical term (e.g. 'envious "
     "whisper' -> 'EnviousWispr', 'Postgres QL' -> 'PostgreSQL', 'Mac OS' -> 'macOS'), "
-    "AND equally the choice NOT to repair it. Neither is the behavior under test. "
-    "This does NOT extend to personal names: rewriting a name the recogniser mangled "
-    "('Rajash' -> 'Rajesh') is a real defect, because there is no closed set of "
-    "people's names to be confident against and substituting a commoner one is a "
-    "worse outcome for the user than leaving the phonetic attempt visible.",
+    "AND equally the choice NOT to repair it. Neither is the behavior under test.",
+    # Personal names, split by WHETHER THE RENDERING IS RIGHT rather than by whether it
+    # differs from raw_transcript. The old rule said any rewrite of a mangled name was a
+    # defect, on the reasoning that there is no closed set of names to be confident
+    # against. True for a shipping app; false for a graded benchmark, where
+    # `spoken_truth` records the name that was actually said. Under the old rule a
+    # system whose recogniser heard the name CORRECTLY was marked down for it -- 22
+    # measured cases (Rajesh, Nadia, Hassan, Noor, Tomas).
+    "a personal name that matches spoken_truth is CORRECT, whatever raw_transcript "
+    "said. Do not penalise it, and do not treat it as an entity change.",
+    "a personal name matching NEITHER spoken_truth NOR raw_transcript is a real "
+    "entity_mutation defect ('Elena' -> 'Alaina', 'Fatima' -> 'Fautima'): the system "
+    "substituted a different person. Leaving raw_transcript's phonetic attempt "
+    "untouched is also acceptable, since repairing a name unaided is bonus credit, "
+    "never a pass criterion. Where spoken_truth is empty, fall back to treating any "
+    "rewrite of a name as a defect.",
 ]
 
 # Per-behavior additions, for buckets where the transcript genuinely admits more than one
@@ -863,6 +1014,36 @@ def case_type_of(case: dict, behavior: str) -> str:
     return "positive"
 
 
+def _spoken_truth(case: dict) -> str:
+    """What was ACTUALLY said, across the two corpus schemas that carry it.
+
+    Speechpath (`speechpath_1861.jsonl`, the live corpus) stores it as a top-level
+    `voice_text`. The older `type_b_parakeet.jsonl`, built by
+    `build_refreshed_corpus.py`, stores the pre-ASR text nested at
+    `input_source.original_input` instead. Reading only `voice_text` therefore
+    returned "" for every row of that corpus, and the personal-name rule silently
+    fell through to its empty-truth branch — the rubric change present but inert,
+    which is worse than absent because the receipt looks the same either way.
+
+    Measured on the 1,690-row `type_b_parakeet.jsonl`: `original_input` is
+    populated on 1,458 rows (86.3%); the remaining 13.7% carry an empty value and
+    correctly keep the conservative empty-truth behaviour.
+
+    `input_source` is a dict in that corpus but the type is not guaranteed across
+    older files, so a non-dict is treated as absent rather than raising — this is
+    a grading path, and it must degrade to the safe branch rather than kill a run.
+    """
+    v = case.get("voice_text")
+    if isinstance(v, str) and v.strip():
+        return v
+    src = case.get("input_source")
+    if isinstance(src, dict):
+        v = src.get("original_input")
+        if isinstance(v, str) and v.strip():
+            return v
+    return ""
+
+
 def normalize_case(case: dict) -> dict:
     """corpus case -> normalized judge-input record (behavior-aware system)."""
     behavior = behavior_key(case)
@@ -889,6 +1070,18 @@ def normalize_case(case: dict) -> dict:
         "length_bucket": case.get("length_bucket"),
         "context": case.get("context", ""),
         "raw_transcript": case.get("asr_input", ""),
+        # What was ACTUALLY SPOKEN, before any recogniser touched it. Distinct from
+        # `raw_transcript`, which is one engine's attempt at it.
+        #
+        # Without this the judge cannot tell a name REPAIRED from a name MANGLED. Our
+        # corpus keys were authored from OUR transcript, so where Parakeet heard
+        # "Rajash" for Rajesh the key enshrines the error; a system whose recogniser got
+        # the name RIGHT then looks like it substituted one. Measured 2026-08-14 on the
+        # Wispr Flow bake-off: 22 cases penalised for correct transcription
+        # (Rajesh->"Rajash", Nadia->"Nodia", Hassan->"Hassen", Noor->"Norr").
+        #
+        # Empty for corpora that carry no spoken source; the prompt handles absence.
+        "spoken_truth": _spoken_truth(case),
         "notes": case.get("notes", ""),
     }
 
@@ -991,7 +1184,13 @@ NEW_JUDGE_SYSTEM = """You are evaluating a speech-polish engine for a dictation 
 
 For each case you are given:
 - id
-- raw_transcript: the original spoken transcript (lowercase, little punctuation)
+- raw_transcript: ONE speech recogniser's attempt at what was said (lowercase, little
+  punctuation). It is the engine's INPUT, not ground truth, and it can contain
+  mis-hearings -- especially of people's names.
+- spoken_truth: what was ACTUALLY said, when available (may be empty). Use it for ONE
+  purpose only: deciding whether a proper noun, name, address or number in
+  candidate_output is CORRECT or INVENTED. Do NOT grade content, phrasing, fillers or
+  structure against it -- removing disfluencies that appear here is exactly the job.
 - candidate_output: the polish engine output to evaluate
 - production_output: the currently shipped engine's output, or null if unavailable
 - behavior: the behavior bucket (for reporting)
@@ -1024,10 +1223,11 @@ Automatic critical_fail / S4 (any one):
   not this: `envious whisper` -> `EnviousWispr`, `Postgres QL` -> `PostgreSQL`,
   `Mac OS` -> `macOS` all name the same thing the speaker named, and are
   permitted (see allowed_variants). Leaving them untouched is equally correct.
-  A PERSONAL name is the exception and stays an automatic S4: `Rajash` ->
-  `Rajesh` may look like the same repair, but no closed set of people's names
-  exists to be confident against, so it is a substitution rather than a
-  normalisation
+  A PERSONAL name is judged against `spoken_truth`, NOT against raw_transcript:
+  if the rendering matches what was actually said it is CORRECT and not an S4,
+  even where raw_transcript spelled it differently. It is an automatic S4 only
+  when it matches NEITHER (`Elena` -> `Alaina`), i.e. a different person.
+  Where spoken_truth is empty, any rewrite of a personal name stays an S4
 - changed the final correction target in a self-correction
 - invented a fact, recipient, date, action, commitment, or rationale
 - dropped required content that changes the user's intent
@@ -1065,6 +1265,7 @@ def build_new_payload(norm: dict, cand: dict, prod: dict | None) -> dict:
     return {
         "id": norm["id"],
         "raw_transcript": norm["raw_transcript"],
+        "spoken_truth": norm.get("spoken_truth") or "",
         "candidate_output": cand.get("candidate") or "",
         "production_output": (prod.get("candidate") if prod else None),
         "behavior": norm["behavior"],

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -40,6 +40,7 @@ import subprocess
 import sys
 import tempfile
 import traceback
+import urllib.error
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -2441,36 +2442,305 @@ def test_the_s4_entity_rule_and_the_variant_licence_do_not_contradict():
         "the S4 entity rule must fire on a DIFFERENT entity, not on any change"
     assert "normalising a mis-transcribed rendering of the same entity" in sysmsg, \
         "the S4 rule must exempt normalising the same entity, or it overrides the variant"
-    # And the exemption must not swallow personal names, which both halves refuse.
-    assert "personal name is the exception" in sysmsg, \
-        "the S4 carve-out must still treat a personal-name substitution as automatic S4"
-    assert "does not extend to personal names" in variants, \
-        "both halves must agree that personal names are excluded"
+    # Personal names: both halves must split on the SAME axis, which since 2026-08-14 is
+    # whether the rendering matches `spoken_truth` -- not whether it differs from
+    # raw_transcript. If one half judged against the truth and the other against the
+    # transcript, a correctly-heard name would be licensed by one and an automatic S4 by
+    # the other, and the stronger instruction would win. That is the original defect
+    # this test exists for, moved to a new axis.
+    assert "judged against `spoken_truth`" in sysmsg, \
+        "the S4 rule must judge a personal name against what was actually said"
+    assert "matches neither" in sysmsg, \
+        "the S4 rule must fire only when the name matches NEITHER source"
+    assert "matches spoken_truth is correct" in variants, \
+        "the variant must license a name that matches what was actually said"
+    assert "neither spoken_truth nor raw_transcript" in variants, \
+        "both halves must agree a name matching neither source is the defect"
+    # Two-way: the licence must NOT have widened into permitting any name rewrite.
+    assert "is a real \nentity_mutation defect" in variants.replace("  ", " ") \
+        or "real entity_mutation defect" in " ".join(variants.split()), \
+        "substituting a different person must still be named a defect"
 
 
 def test_vocabulary_repair_is_a_variant_but_name_repair_is_not():
-    # Founder ruling 2026-08-13: repairing a mis-transcribed TERM is bonus credit,
-    # so neither doing it nor skipping it may decide a verdict. Repairing a personal
-    # NAME is the opposite — a real defect, because no closed set of names exists to
-    # be confident against.
+    # Founder ruling 2026-08-13: repairing a mis-transcribed TERM is bonus credit, so
+    # neither doing it nor skipping it may decide a verdict.
     #
-    # Two-way on purpose. Asserting only the licence would pass a rubric that
-    # licensed everything, which is exactly the failure this ruling could decay
-    # into: the whole point is that the line falls between terms and names.
+    # Personal names were originally excluded outright, on the reasoning that no closed
+    # set of names exists to be confident against. True for a shipping app; false for a
+    # graded benchmark, where `spoken_truth` records the name actually said. Corrected
+    # 2026-08-14 after the Wispr Flow bake-off measured 22 cases where a system was
+    # marked down for hearing the name CORRECTLY (Rajesh, Nadia, Hassan, Noor, Tomas):
+    # our keys were authored from OUR transcript, so they enshrined our recogniser's
+    # mis-hearings and penalised anyone who got them right.
+    #
+    # The line now falls between a name that matches what was SAID and one that matches
+    # nothing, which is a property of the output rather than of whose transcript it
+    # resembles.
+    #
+    # Two-way on purpose. Asserting only the licence would pass a rubric that licensed
+    # every name rewrite, which is the failure this could decay into.
     text = " ".join(bj.allowed_variants_for("verbatim_preservation")).lower()
     assert "envious" in text and "postgres" in text, \
         "term repair must be licensed as a variant"
     assert "not the behavior under test" in text, \
         "the licence must say the repair is not what is being graded"
-    # Assert the EXCLUSION, not the words. A first version of this checked that
-    # "personal names" appeared anywhere in the rubric — which stays true if the
-    # clause is inverted to "this also covers personal names", so the mutation
-    # control passed a rubric saying the opposite. The phrase that carries the
-    # meaning is the negation itself.
-    assert "does not extend to personal names" in text, \
-        "name repair must be EXCLUDED from the licence, not merely mentioned"
-    assert "real defect" in text, "the exclusion must name name-rewriting as a defect"
-    assert "rajash" in text, "the exclusion needs its concrete example to stay legible"
+    # Assert the two halves of the SPLIT, not merely that names are mentioned. A first
+    # version of this checked that "personal names" appeared anywhere in the rubric —
+    # which stays true if the clause is inverted, so the mutation control passed a
+    # rubric saying the opposite. The phrases that carry the meaning are the two
+    # directions.
+    assert "matches spoken_truth is correct" in text, \
+        "a name matching what was actually said must be licensed, not penalised"
+    assert "neither spoken_truth nor raw_transcript" in text, \
+        "the defect must be defined as matching NEITHER source"
+    assert "real \nentity_mutation defect" in text or "real entity_mutation defect" in \
+        " ".join(text.split()), "substituting a different person must remain a defect"
+    assert "alaina" in text or "fatima" in text, \
+        "the defect side needs its concrete example to stay legible"
+    # The fallback matters: a corpus with no spoken source must not silently license
+    # every name rewrite just because the truth is unavailable.
+    assert "where spoken_truth is empty" in text, \
+        "absence of spoken_truth must fall back to treating a rewrite as a defect"
+
+
+# --------------------------------------------------------------------------- #
+# transport retry classification                                              #
+# --------------------------------------------------------------------------- #
+
+def test_only_the_network_call_produces_a_retryable_error():
+    """The retry predicate must key on WHERE the failure came from, not its class.
+
+    Every one of the bare exceptions below is an OSError, and an earlier version
+    of this predicate accepted all of them. Cloud review then found three places
+    where that was wrong -- a local WAV write, a subprocess spawn for a missing
+    CLI, and a credential file read -- each of which would have been answered
+    with another PAID request. So the bare forms must now be REFUSED, and only
+    `TransientTransportError`, which `_http_json` raises at the socket, accepted.
+
+    Both directions are asserted together because the failure mode is symmetric:
+    too narrow drops 8 cases per blip, too broad re-bills a permanent local fault.
+    """
+    import http.client
+    import socket
+    import ssl
+
+    transport = [
+        ("ConnectionResetError", ConnectionResetError(54, "Connection reset by peer")),
+        ("RemoteDisconnected", http.client.RemoteDisconnected("closed")),
+        ("IncompleteRead", http.client.IncompleteRead(b"", 10)),
+        ("BrokenPipeError", BrokenPipeError(32, "Broken pipe")),
+        ("SSLEOFError", ssl.SSLEOFError("eof")),
+        ("socket.gaierror", socket.gaierror(8, "nodename nor servname")),
+        ("URLError", urllib.error.URLError("unreachable")),
+        ("TimeoutError", TimeoutError("timed out")),
+    ]
+    for name, exc in transport:
+        wrapped = bj.TransientTransportError(exc)
+        assert bj._retryable_http_error(wrapped), \
+            f"{name} raised BY the network call must be retried"
+        assert not bj._retryable_http_error(exc), \
+            f"a BARE {name} must NOT be retried — it could be a file write, a " \
+            f"credential read, or a subprocess spawn in the same try block"
+
+    for name, exc in [("HTTP 429", urllib.error.HTTPError("u", 429, "rate", {}, None)),
+                      ("HTTP 500", urllib.error.HTTPError("u", 500, "ise", {}, None)),
+                      ("HTTP 503", urllib.error.HTTPError("u", 503, "un", {}, None))]:
+        assert bj._retryable_http_error(exc), f"{name} must be retried"
+    for name, exc in [("HTTP 400", urllib.error.HTTPError("u", 400, "bad", {}, None)),
+                      ("HTTP 401", urllib.error.HTTPError("u", 401, "auth", {}, None)),
+                      ("HTTP 404", urllib.error.HTTPError("u", 404, "nf", {}, None)),
+                      ("ValueError", ValueError("not transport")),
+                      ("PermissionError", PermissionError(13, "key file unreadable")),
+                      ("FileNotFoundError", FileNotFoundError(2, "no claude binary"))]:
+        assert not bj._retryable_http_error(exc), f"{name} must NOT be retried"
+
+
+def test_http_json_converts_transport_but_not_status_or_parse_errors():
+    """The conversion has to happen AT the socket, or the structural guarantee is
+    just a comment. Drives the real `_http_json` with a fake opener."""
+    class FakeResp:
+        def __init__(self, body): self.body = body
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def read(self): return self.body
+
+    class Opener:
+        def __init__(self, behaviour): self.behaviour = behaviour
+        def open(self, req, timeout=None):
+            if isinstance(self.behaviour, Exception):
+                raise self.behaviour
+            return FakeResp(self.behaviour)
+
+    # transport failure -> converted
+    raised = None
+    try:
+        bj._http_json(Opener(ConnectionResetError(54, "reset")), object(), 1)
+    except BaseException as e:  # noqa: BLE001
+        raised = e
+    assert isinstance(raised, bj.TransientTransportError), \
+        f"a socket reset must become TransientTransportError, got {type(raised).__name__}"
+    assert isinstance(raised.cause, ConnectionResetError), "the cause must be preserved"
+
+    # HTTPError -> untouched, so the caller can read its status code
+    raised = None
+    try:
+        bj._http_json(Opener(urllib.error.HTTPError("u", 429, "rate", {}, None)), object(), 1)
+    except BaseException as e:  # noqa: BLE001
+        raised = e
+    assert isinstance(raised, urllib.error.HTTPError) and raised.code == 429, \
+        "HTTPError must pass through with its status intact"
+
+    # a 200 with an unparsable body -> JSONDecodeError, not a transport error
+    raised = None
+    try:
+        bj._http_json(Opener(b"not json"), object(), 1)
+    except BaseException as e:  # noqa: BLE001
+        raised = e
+    assert isinstance(raised, json.JSONDecodeError), \
+        f"a bad body is the server's answer, not transport (got {type(raised).__name__})"
+
+    # happy path
+    assert bj._http_json(Opener(b'{"ok": 1}'), object(), 1) == {"ok": 1}
+
+
+def test_judge_chunk_retries_a_reset_and_returns_the_full_chunk():
+    """Drive the REAL `judge_chunk` through a transport failure and assert it
+    recovers. The attempt COUNT is asserted too: without it, one successful call
+    satisfies the test exactly as well as a retry does."""
+    calls = {"n": 0}
+
+    def flaky_dispatch(model, system, user):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise bj.TransientTransportError(
+                ConnectionResetError(54, "Connection reset by peer"))
+        return json.dumps([{"id": "A1", "verdict": "pass"},
+                           {"id": "A2", "verdict": "pass"}])
+
+    real_dispatch, real_sleep = bj.dispatch_judge, bj.time.sleep
+    bj.dispatch_judge = flaky_dispatch
+    bj.time.sleep = lambda _s: None
+    try:
+        with contextlib.redirect_stderr(io.StringIO()):
+            out = bj.judge_chunk("azure/x", "sys", [{"id": "A1"}, {"id": "A2"}])
+    finally:
+        bj.dispatch_judge, bj.time.sleep = real_dispatch, real_sleep
+
+    assert calls["n"] == 3, \
+        f"expected 2 transport failures then a success = 3 attempts, saw {calls['n']}"
+    assert [r["id"] for r in out] == ["A1", "A2"], \
+        f"the chunk must come back whole after a transient reset, got {out!r}"
+
+
+def test_judge_chunk_gives_up_on_a_client_error_without_burning_retries():
+    """The other direction: a 400 is answered once and not retried.
+
+    Without this, widening the predicate to catch resets could silently turn every
+    malformed request into five paid attempts against the deployment.
+    """
+    calls = {"n": 0}
+
+    def always_400(model, system, user):
+        calls["n"] += 1
+        raise urllib.error.HTTPError("u", 400, "bad request", {}, None)
+
+    real_dispatch, real_sleep = bj.dispatch_judge, bj.time.sleep
+    bj.dispatch_judge = always_400
+    bj.time.sleep = lambda _s: None
+    try:
+        with contextlib.redirect_stderr(io.StringIO()):
+            out = bj.judge_chunk("azure/x", "sys", [{"id": "A1"}])
+    finally:
+        bj.dispatch_judge, bj.time.sleep = real_dispatch, real_sleep
+
+    assert calls["n"] == 1, f"a 400 must be attempted exactly once, saw {calls['n']}"
+    assert out == [], "a chunk that never scored must return empty so reconciliation counts it"
+
+
+def test_a_missing_judge_cli_is_not_retried():
+    """A spawn failure is permanent, so it must not consume the retry budget.
+
+    This is the trap the broadened predicate creates: `FileNotFoundError` from a
+    missing `claude` binary IS an OSError, and every OSError reaching an HTTP
+    call site means transport. Here it means the judge does not exist, and five
+    attempts with backoff per chunk across a whole corpus is pure wall clock.
+    Cloud review found the same shape in tts_corpus.py, where a full disk was
+    being answered with another paid TTS request.
+    """
+    calls = {"n": 0}
+
+    def missing_cli(model, system, user):
+        calls["n"] += 1
+        raise bj.JudgeUnavailableError("claude judge: cannot start the CLI")
+
+    real_dispatch, real_sleep = bj.dispatch_judge, bj.time.sleep
+    bj.dispatch_judge = missing_cli
+    bj.time.sleep = lambda _s: None
+    try:
+        with contextlib.redirect_stderr(io.StringIO()):
+            out = bj.judge_chunk("claude-sonnet-5", "sys", [{"id": "A1"}])
+    finally:
+        bj.dispatch_judge, bj.time.sleep = real_dispatch, real_sleep
+
+    assert calls["n"] == 1, \
+        f"a permanently unavailable judge must be attempted exactly once, " \
+        f"saw {calls['n']} — the retry budget is being spent on a missing binary"
+    assert out == [], "the chunk must return empty so reconciliation counts it"
+
+
+def test_call_claude_converts_a_spawn_failure_into_the_permanent_error():
+    """The conversion happens at the transport, not at the call site.
+
+    Asserting only judge_chunk's behaviour would pass even if `call_claude` let a
+    bare FileNotFoundError escape, because the test above injects the already-
+    converted type. This drives the real `call_claude`.
+    """
+    real_run = bj.subprocess.run
+
+    def no_binary(*a, **kw):
+        raise FileNotFoundError(2, "No such file or directory: 'claude'")
+
+    bj.subprocess.run = no_binary
+    try:
+        raised = None
+        try:
+            bj.call_claude("claude-sonnet-5", "sys", "user")
+        except BaseException as e:  # noqa: BLE001
+            raised = e
+    finally:
+        bj.subprocess.run = real_run
+
+    assert isinstance(raised, bj.JudgeUnavailableError), \
+        f"a missing CLI must surface as JudgeUnavailableError, got {type(raised).__name__}: {raised}"
+    assert not bj._retryable_http_error(raised), \
+        "JudgeUnavailableError must not satisfy the transport predicate"
+
+
+def test_spoken_truth_reads_both_corpus_schemas():
+    """The personal-name rule is only as good as the field it reads.
+
+    Two corpora carry "what was said" under different names, and reading only
+    Speechpath's `voice_text` made the rule INERT on the older parakeet corpus --
+    present, shipped, and silently doing nothing, which a receipt cannot show.
+    Real shapes from both files, plus the degenerate ones, because this runs on
+    a grading path and must never raise.
+    """
+    # Speechpath: top-level voice_text.
+    assert bj._spoken_truth({"voice_text": "Tell Aoife it is ready"}) == "Tell Aoife it is ready"
+    # type_b_parakeet: nested under input_source.
+    assert bj._spoken_truth(
+        {"input_source": {"original_input": "set aside four plates make that five"}}
+    ) == "set aside four plates make that five"
+    # voice_text wins when both are present.
+    assert bj._spoken_truth(
+        {"voice_text": "top", "input_source": {"original_input": "nested"}}) == "top"
+    # Degenerate shapes all fall back to the conservative empty-truth branch.
+    for case in ({}, {"voice_text": ""}, {"voice_text": "   "},
+                 {"input_source": None}, {"input_source": "a string, not a dict"},
+                 {"input_source": {}}, {"input_source": {"original_input": None}},
+                 {"input_source": {"original_input": "  "}}):
+        assert bj._spoken_truth(case) == "", f"{case!r} must yield empty, not raise"
 
 
 # --------------------------------------------------------------------------- #
@@ -2479,7 +2749,7 @@ def test_vocabulary_repair_is_a_variant_but_name_repair_is_not():
 
 # An exact count, because the borrowed runner in cleanup_metrics_test.py returns
 # 0 when it discovers ZERO tests — so "green" would carry no information at all.
-EXPECTED_TESTS = 124
+EXPECTED_TESTS = 131
 
 
 def _run() -> int:

--- a/scripts/eval/run_cloud_type_b.py
+++ b/scripts/eval/run_cloud_type_b.py
@@ -58,6 +58,7 @@ the whole set rather than mixing:
 from __future__ import annotations
 
 import argparse
+import http.client
 import json
 import os
 import sys
@@ -338,6 +339,24 @@ def polish_case(
             retryable = e.code in RETRYABLE
         except urllib.error.URLError as e:
             last_err = f"URLError: {e.reason}"
+            retryable = True
+        except (OSError, http.client.HTTPException) as e:
+            # A reset arriving while the RESPONSE BODY is read is a bare
+            # ConnectionResetError, not a URLError, so before this clause it
+            # escaped the retry loop entirely and killed the whole case. Ordered
+            # after the two urllib clauses because HTTPError subclasses URLError
+            # subclasses OSError, and a 4xx must keep its non-retryable verdict.
+            #
+            # A BROAD OSError catch is safe HERE and is not elsewhere, so the
+            # check is recorded rather than left to the next reader: the only
+            # things in this `try` are `call_once` (urlopen) and
+            # `_strip_llm_preamble_python` (pure string work). `api_key` is read
+            # by `_key()` ONCE at module level, outside the loop, so no
+            # credential read can land in this scope. behavior_judge.py and
+            # acceptance_gate.py could not make that claim -- they retry a
+            # credential read and a subprocess spawn respectively -- which is why
+            # they convert at the socket with TransientTransportError instead.
+            last_err = f"{type(e).__name__}: {e}"
             retryable = True
         except (RuntimeError, KeyError, json.JSONDecodeError) as e:
             last_err = str(e)

--- a/scripts/eval/train_polish.py
+++ b/scripts/eval/train_polish.py
@@ -36,7 +36,38 @@ ap.add_argument("--alpha", type=int, default=32)
 ap.add_argument("--micro-bs", type=int, default=4)
 ap.add_argument("--grad-accum", type=int, default=4)
 ap.add_argument("--max-seq", type=int, default=512)
+ap.add_argument("--dataset-num-proc", type=int, default=None,
+                help="Worker processes for dataset tokenization. Unset = the "
+                     "library default (one per core). Set 1 to tokenize in-process.")
 args = ap.parse_args()
+
+# WHY --dataset-num-proc EXISTS: on the 4090 rig (2026-08-15) training died with a
+# hard SIGSEGV inside CPython partway through `Tokenizing ["text"] (num_proc=28)`.
+# It reproduced on the July corpus that had trained fine before, which is what
+# proved it was the environment and not the data.
+#
+# The MECHANISM IS NOT ESTABLISHED. The obvious story -- `datasets.map` forks after
+# FastLanguageModel has put a CUDA context in the process, and forking a live CUDA
+# context is undefined -- was tested and REFUTED: a staged probe on that rig loads
+# the 4-bit model, builds the PEFT wrapper, and then tokenizes with num_proc=8
+# without incident. TOKENIZERS_PARALLELISM=false did not help either, nor did
+# clearing unsloth_compiled_cache and ~/.triton. Do not repeat any of those three
+# as the cause.
+#
+# Nor is this knob established as the CURE. The run that finally trained had both
+# `--dataset-num-proc 1` and `python -u`, and an earlier run with the knob alone
+# still died -- so the crash is at least partly intermittent and the knob may have
+# had nothing to do with it. Treat a green run as luck until several in a row pass.
+#
+# What IS established, and is worth more than the knob: `python train.py > log`
+# BLOCK-buffers stdout, so a SIGSEGV loses the entire buffer and leaves an EMPTY
+# log. That made the crash look like it had moved earlier in the pipeline when it
+# had not, and cost two rounds of this investigation. Always run the trainer with
+# `python -u` so the last line before a crash is truthful.
+#
+# So this knob is a bisection tool, not a fix with a known reason. Tokenizing
+# 5,656 short rows in-process costs well under a minute against a ~16-minute
+# train, so pinning it is close to free while the real cause is unknown.
 
 # The SHIP prompt: short distilled instruction (council 2026-07-02). The tuned
 # model trains WITH it and the app will send exactly this string at inference.
@@ -51,10 +82,28 @@ from datasets import Dataset
 from trl import SFTTrainer, SFTConfig
 import inspect
 
-def _sft_config(**kw):
+def _sft_config(_required=(), **kw):
+    """trl-version shim. Unknown keywords are DROPPED, which is what makes this
+    portable across trl releases -- and is exactly why `_required` exists.
+
+    Silently dropping a knob the OPERATOR explicitly asked for is worse than not
+    having the knob. `--dataset-num-proc` is a crash-bisection tool: if a future
+    trl removes `dataset_num_proc`, the run would fall back to the library's
+    multiprocess default while reporting nothing, and the next crash-or-success
+    would be read as evidence about a setting that never applied. Verified
+    present in trl 0.24.0 on the rig before shipping this, so today it lands;
+    the guard is for the version bump that has not happened yet.
+    """
     sig = set(inspect.signature(SFTConfig.__init__).parameters)
     if "max_seq_length" in kw and "max_seq_length" not in sig:
         kw["max_length"] = kw.pop("max_seq_length")
+    missing = [k for k in _required if k not in sig]
+    if missing:
+        raise SystemExit(
+            f"train_polish: this trl ({getattr(__import__('trl'), '__version__', '?')}) "
+            f"has no SFTConfig parameter(s) {missing}, so the value you passed would "
+            f"be silently ignored and the run would not test what you asked for. "
+            f"Re-run without that flag, or route it through this trl's own API.")
     return SFTConfig(**{k: v for k, v in kw.items() if k in sig})
 
 def _sft_trainer(**kw):
@@ -121,6 +170,13 @@ trainer = _sft_trainer(
         output_dir=os.path.expanduser(f"~/tuning/out/{args.tag}/ckpt"),
         report_to="none",
         seed=1265,
+        # Omitted entirely when unset, so the recipe that produced EG-1 is
+        # byte-for-byte unchanged unless a run asks for this. When it IS asked
+        # for, `_required` makes an unsupported trl fail loudly rather than
+        # discard it — see _sft_config.
+        **({} if args.dataset_num_proc is None
+           else {"dataset_num_proc": args.dataset_num_proc}),
+        _required=() if args.dataset_num_proc is None else ("dataset_num_proc",),
     ),
 )
 

--- a/scripts/eval/tts_corpus.py
+++ b/scripts/eval/tts_corpus.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import http.client
 import html
 import json
 import os
@@ -95,15 +96,14 @@ def synth(text: str, out: Path, engine: str, model: str, voice: str,
             _azure_request(text, voice, api_key, region) if engine == "azure"
             else _openai_request(text, model, voice, api_key)
         )
+        # ONLY the network call is inside the retry scope. The file writes used to
+        # sit here too, and a broad OSError catch then misclassified a full or
+        # read-only --wav-dir as a transient transport failure and re-billed the
+        # TTS request up to MAX_ATTEMPTS times per case. A retry handler's scope is
+        # whatever happens to be above it, so it has to be drawn deliberately.
         try:
             with urllib.request.urlopen(req, timeout=120) as resp:
                 data = resp.read()
-            if not data:
-                raise RuntimeError("empty audio body")
-            tmp = out.with_suffix(".part")
-            tmp.write_bytes(data)
-            tmp.replace(out)  # atomic: a killed run never leaves a half WAV
-            return
         except urllib.error.HTTPError as e:
             if e.code in RETRYABLE and attempt < MAX_ATTEMPTS:
                 time.sleep(min(2 ** attempt, 30))
@@ -114,6 +114,37 @@ def synth(text: str, out: Path, engine: str, model: str, voice: str,
                 time.sleep(min(2 ** attempt, 30))
                 continue
             raise
+        except (OSError, http.client.HTTPException):
+            # A reset during the RESPONSE BODY read is a bare ConnectionResetError,
+            # not a URLError, so before this clause it escaped the retry loop and
+            # aborted a whole TTS sweep. Ordered last of the three because
+            # HTTPError subclasses URLError subclasses OSError.
+            #
+            # Safe to catch broadly ONLY because the `try` above now contains
+            # nothing but `urlopen` + `resp.read()`. The file writes used to live
+            # here, and this same clause then answered a full disk with another
+            # paid TTS request (cloud review, PR #2058). If anything non-network
+            # is ever added back above, convert at the socket the way
+            # behavior_judge.py does instead of widening this.
+            if attempt < MAX_ATTEMPTS:
+                time.sleep(min(2 ** attempt, 30))
+                continue
+            raise
+
+        # An empty body IS worth another network attempt, so it stays in the loop
+        # — but as an explicit branch rather than an exception caught above.
+        if not data:
+            if attempt < MAX_ATTEMPTS:
+                time.sleep(min(2 ** attempt, 30))
+                continue
+            raise RuntimeError("empty audio body after all attempts")
+
+        # Local disk failures propagate immediately: retrying a full or read-only
+        # directory cannot succeed and each retry costs another paid request.
+        tmp = out.with_suffix(".part")
+        tmp.write_bytes(data)
+        tmp.replace(out)  # atomic: a killed run never leaves a half WAV
+        return
 
 
 def main() -> int:


### PR DESCRIPTION
Part of #1988. Shows the words in the recording pill while you speak. Display only, off by default, macOS 26 and up.

The preview box starts as one compact line and grows a line at a time up to five, then holds its size and scrolls so the oldest line drops off the top (founder direction after testing Spokenly). It uses a rounded box rather than a capsule, because at that height a capsule's round ends eat the width the text needs.

## What it is, and what it is not

Three people asked for this on the r/macapps update post, and one uses two other tools specifically for it. The ask is not really "see the words": it is confirmation that the thing is working. Today a user holds the key, talks for a minute, and has nothing on screen telling them we heard anything.

**The pasted text is unchanged.** It still comes from Parakeet or WhisperKit decoding the whole recording after release, then custom words, the deterministic layer and polish. The preview never reaches the clipboard.

## Why a second recognizer rather than our own engine's partials

Designed that way first, then killed by grounded review: Parakeet's confirmed transcript cannot populate before `minContextForConfirmation` (10s), so the pill would be blank for the first 10-13 seconds of every dictation. It also required Background transcription ON, which our own help panel tells Parakeet users to leave OFF (3.7% vs 2.0% word error). Seeing your words would have cost accuracy.

Apple's `DictationTranscriber` won a five-candidate screening over 30 clips, two live human trials and a five-language panel (measurements on #1988). It ships zero bytes, covers 33 languages, and formats numbers, dates, addresses and emails inline — the trial's deciding factor, because watching `two zero three nine five four` crawl across the pill reads as the software failing even though the pasted result is correct.

## Why this is a limb structurally, not by intention

The kernel, the recording starter and the ASR adapters never learn the preview exists. It attaches to the overlay panel and nothing else. It takes no callback slot on the audio path: it polls the samples the capture manager already stores, exactly as the crash-recovery spool does. Every error becomes a display state; there is no throwing path out of the coordinator.

Measured before any of it was built (72 trials, 6 real dictations x 4 arms x 3 repeats): with the preview running, transcription output was **byte-identical in 18 of 18 trials**, feed slip moved +0.1 ms and finalize stayed inside the run's own noise floor. The instrument was proven able to detect contention first, so the null result is evidence rather than an absence of it.

## Verified live

| check | result |
|---|---|
| words appear while speaking, real mic | yes, 12+ dictations |
| pasted text correct | every run with usable audio |
| back-to-back recordings | clean, repeatedly |
| first recording after a fresh launch | clean (exercises warm-up, cancel, session in sequence) |
| silent recording (press, say nothing, release) | dictation returns no-speech, preview tears down, app alive |
| preview box grows and scrolls | screenshot verified at both ends: one compact line early, five lines with the head scrolled off later |
| preview OFF leaves the normal pill unchanged | screenshot verified: narrow capsule, icon and timer only |
| full suite | 5477 tests, zero failures |

## Review

Eight local Codex rounds. The largest theme was **session identity crossing an async boundary** — seven defects across rounds 1-3. Round 3 was the signal to stop adding guards: the cause was never a missing check, it was that the analyzer, continuation and collector lived as ACTOR FIELDS, and an actor is reentrant at every await. `startSession` now returns a `Session` value carrying everything it owns, so there is no shared state to race over and `endSession` needs no guard at all.

Later rounds found unrelated things: a missing `NSSpeechRecognitionUsageDescription`, an unbounded audio queue (a limb able to pressure the heart), three sites that abandoned a `SpeechAnalyzer` without ending it, and a locale-reservation Bool being read as a success flag when it is not.

Two Apple semantics were **measured against the real API rather than assumed**: `supportedLocale(equivalentTo:)` resolves our bare language codes correctly (en -> en-US, de -> de-DE, hi -> hi-IN, nil for unknown), and `reserve` returns **false** for an already-reserved locale, which is what made the round-7 fix wrong and the round-8 one right.

## Language coverage, measured

All 100 of our catalogue codes run through Apple's resolver: **33 supported, 67 not**. A user on the other 67 gets a normal dictation and a pill that says the preview does not support their language yet. Same shape as the Apple Intelligence polish gate.

## Not in this PR

- **Custom words on preview text.** #1988 lists this as an acceptance criterion and it is not met. Names can visibly mangle mid-dictation even though the pasted text has the dictionary applied. Top of the follow-up list.
- **Part 1, the rename.** Built, then measured and backed out: "Live transcription" appears 30 times including three live website pages and a help article whose title AND URL slug are the name. That is a public-URL decision, not a copy tweak. What shipped instead costs nothing — the new setting avoids the word "live" entirely, and both engine descriptions now say plainly that the older toggle changes nothing you can see while recording.
- **A VoiceOver announcement on first speech.** Suggested by review; not an acceptance criterion and no prior plan for one, so declined rather than added unprompted.
- **A live test of the unsupported-preview-language path.** It is covered by construction and by the measured resolver table (33 of 100 codes resolve; the rest return nil and take the "not supported yet" branch), but not exercised end to end. An earlier version of this description reported a settings bug here — locking to `bg` appearing to be ignored. That was my test writing to the wrong preferences domain: `SettingsDefaults.store` redirects the dev build to the shared release suite, so a `defaults write` to `com.enviouswispr.app.dev` changes nothing the app reads. There is no coercion bug.
