### PR TITLE
fix(settings): report $value in seconds everywhere, and resolve three uncalled emitters

### DIFF
--- a/Sources/EnviousWisprPostProcessing/WordSuggestionService.swift
+++ b/Sources/EnviousWisprPostProcessing/WordSuggestionService.swift
@@ -881,9 +881,16 @@ public final class WordSuggestionService: Sendable {
         // Empty after filter (with non-empty raw) means AFM degenerated into self-echoes.
         // Treat as model failure so the UI can render "No suggestions available" instead
         // of zero or duplicate chips.
-        // Phase 8 (#620) telemetry hook deferred — PostProcessing module cannot
-        // import EnviousWisprServices per the dep-direction guard. Phase 8 proper
-        // will inject a telemetry callback at the call site.
+        // Phase 8 (#620) telemetry hook still deferred — this module cannot
+        // import EnviousWisprServices under the dep-direction guard, so there is
+        // no legal emit site here. #2066 deleted the matching
+        // `TelemetryService.customWordsAfmAliasFilled` stub rather than leave a
+        // declared emitter no caller could reach.
+        //
+        // Whoever picks Phase 8 up: an injected telemetry callback is not enough
+        // on its own. This function returns `nil` for BOTH degeneration and a
+        // thrown error, so `degenerated` cannot be reconstructed by any caller —
+        // the outcome has to become distinguishable in the return type first.
         guard !filtered.isEmpty else { return nil }
         return WordSuggestions(category: raw.category, suggestedAliases: filtered)
       } catch {

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -529,8 +529,13 @@ public final class TelemetryService {
   /// raw text or a small glitch, but until now we had zero signal. ONE event for
   /// every quiet-limb site (ASR streaming finalize, output-safety classifier
   /// prewarm, Ollama eviction, cloud pre-warm, legacy-key cleanup). Metadata only —
-  /// never transcript/content/key material. `durationMs` is mirrored to `$value`
-  /// for PostHog aggregation (Phase 6/7 precedent).
+  /// never transcript/content/key material.
+  ///
+  /// #2060: `$value` carries the duration in SECONDS, the house unit for every
+  /// duration-bearing emitter in this file. It used to carry raw milliseconds,
+  /// which made any chart spanning this event and a seconds-based sibling wrong
+  /// by 1000x. The raw millisecond value is unchanged and still queryable under
+  /// `duration_ms`, so nothing is lost by the conversion.
   public func limbFailureObserved(
     limb: String, operation: String, result: String,
     errorCategory: String, durationMs: Int?
@@ -541,11 +546,17 @@ public final class TelemetryService {
     ]
     if let durationMs {
       props["duration_ms"] = durationMs
-      props["$value"] = durationMs
+      props["$value"] = Double(durationMs) / 1000.0
     }
     #if DEBUG
       var intProps: [String: Int] = [:]
-      if let durationMs { intProps["duration_ms"] = durationMs }
+      var doubleProps: [String: Double] = [:]
+      if let durationMs {
+        intProps["duration_ms"] = durationMs
+        // #2060: the unit is the thing under test, so the seam must expose the
+        // emitted `$value` itself rather than the input it was derived from.
+        doubleProps["$value"] = Double(durationMs) / 1000.0
+      }
       testEventHook?(
         CapturedTelemetryEvent(
           name: "limb.failure_observed",
@@ -553,7 +564,8 @@ public final class TelemetryService {
             "limb": limb, "operation": operation, "result": result,
             "error_category": errorCategory,
           ],
-          intProps: intProps))
+          intProps: intProps,
+          doubleProps: doubleProps))
     #endif
     PostHogSDK.shared.capture("limb.failure_observed", properties: props)
   }
@@ -1203,6 +1215,12 @@ public final class TelemetryService {
   /// COUNT of contacts added and the trigger only, NEVER a name. The
   /// `check-contacts-data-flow.sh` hook allow-lists this as the one permitted
   /// telemetry sink in the contacts code.
+  ///
+  /// #2060: `$value` here is a COUNT, not a duration, and that is deliberate.
+  /// PostHog's `$value` is a generic magnitude slot, and on an event that has no
+  /// duration at all there is no unit to be inconsistent with. Kept as-is after
+  /// the seconds sweep; the seconds convention binds duration-bearing emitters
+  /// only. Do not "fix" this to a time.
   public func contactsImported(count: Int, trigger: String) {
     PostHogSDK.shared.capture(
       "contacts_imported",
@@ -1716,6 +1734,12 @@ public final class TelemetryService {
     PostHogSDK.shared.capture(event, properties: properties)
   }
 
+  /// #2060: `$value` carries the latency in SECONDS, matching every other
+  /// duration-bearing emitter here. It used to carry raw milliseconds, so a
+  /// chart placing paste next to `llm.polish_completed` read paste as ~60x
+  /// SLOWER than AI polish when it is in fact ~16x faster. `latency_ms` keeps
+  /// the raw millisecond value, so `$value` is a pure aggregation mirror and
+  /// converting it loses nothing.
   public func pasteCompleted(
     tier: String, targetApp: String?, result: String, latencyMs: Int,
     insertion: PasteInsertionTelemetry = .init(),
@@ -1726,7 +1750,7 @@ public final class TelemetryService {
       "tier": tier,
       "result": result,
       "latency_ms": latencyMs,
-      "$value": Double(latencyMs),
+      "$value": Double(latencyMs) / 1000.0,
     ]
     if let a = targetApp { props["target_app"] = a }
     props.merge(insertion.properties) { current, _ in current }
@@ -2310,23 +2334,21 @@ public final class TelemetryService {
       ])
   }
 
-  /// Emitted when the user deletes more than 50% of pasted text within 5s of insert.
-  /// `lang` is the language detected for the failed transcript.
-  ///
-  /// TODO (W6/#248 follow-up): no call site yet. v1 ships with this method
-  /// available so the analytics schema is ready, but the paste-cascade does
-  /// not observe post-insert user edits. Implementing this requires either
-  /// an AX observer on the focused text field or a clipboard diff heuristic
-  /// that ignores our own restore-clipboard writes. Deferred pending review
-  /// of whether real-world correction rates justify the AX surface.
-  public func trackCorrectionAfterInsert(lang: String?, confidence: Double, charCount: Int) {
-    var props: [String: Any] = [
-      "confidence": String(format: "%.3f", confidence),
-      "char_count": charCount,
-    ]
-    if let l = lang { props["lang"] = l }
-    PostHogSDK.shared.capture("language.correction_after_insert", properties: props)
-  }
+  // #2066: `trackCorrectionAfterInsert` (`language.correction_after_insert`) was
+  // deleted here. It shipped in W6/#248 with its own TODO saying it had no call
+  // site, so that "the analytics schema is ready" — and then had none for the
+  // whole life of the event. A declared-but-uncalled emitter is worse than no
+  // emitter: querying the event returns empty, and an empty result cannot
+  // distinguish "users never correct pasted text" from "we never wired it",
+  // which are opposite investigations.
+  //
+  // Deleted rather than wired because wiring it is not a wiring job. It needs
+  // the paste cascade to observe post-insert user EDITS, via an AX observer on
+  // the focused text field or a clipboard-diff heuristic — new product
+  // behaviour, which `observability-operations.md`
+  // RULE: instrumentation-stays-observation-only forbids adding to expose a
+  // metric. If that observation is ever wanted, it needs its own ticket and the
+  // emitter is eight lines to restore.
 
   /// Emitted when LID abstains (returned nil language).
   /// `reason` is one of: "too_short", "low_confidence", "narrow_margin".
@@ -2348,6 +2370,15 @@ public final class TelemetryService {
   /// Emitted per transcription: surfaces real-time factor per language+model for
   /// per-language perf dashboards. Kept separate from `asr.completed` (generic) so
   /// the multilingual dashboard can slice by lang without schema churn elsewhere.
+  ///
+  /// #2060: `$value` holds `msPerAudioSecond`, a RATE, not a duration — decided
+  /// and kept. This event exists so the multilingual dashboard can compare
+  /// transcription speed ACROSS languages, and a raw duration cannot do that
+  /// (a long German clip would outrank a short English one on nothing but
+  /// length). The rate is normalised and therefore the quantity worth
+  /// aggregating, so it owns the slot. The duration is still carried, beside it,
+  /// as `duration_s`. A rate is not in the seconds-vs-milliseconds family the
+  /// #2060 sweep was about; it is a different quantity, named as one.
   public func trackTranscriptionLatency(
     lang: String?,
     model: String,
@@ -2815,15 +2846,31 @@ public final class TelemetryService {
     )
   }
 
-  public func updateWatchdogFired(version: String, isCritical: Bool) {
-    PostHogSDK.shared.capture(
-      "update.watchdog_fired",
-      properties: [
-        "version": version,
-        "is_critical": isCritical,
-      ]
-    )
-  }
+  // #2066: `updateWatchdogFired` (`update.watchdog_fired`) was deleted here.
+  //
+  // This one was WIRED first and then reverted, which is worth recording because
+  // the reasoning that justified wiring it was wrong in a way that reads
+  // plausible. The 5s watchdog in `UpdateAvailabilityService.triggerInstall()` is
+  // real and does fire, so an event on it looked like a dropped call site.
+  //
+  // It is not a failure signal. `SparkleUpdateController.swift:484` deliberately
+  // does NOT call `noteResolved` on cycle-finish, because that callback fires on
+  // cancel, skip, error and install-on-quit-scheduled alike — so the watchdog is
+  // the DESIGNED path for all of them, including an ordinary user pressing
+  // Cancel. `noteResolved` has no production caller at all. An event here would
+  // therefore have counted routine user behaviour as "Sparkle went silent", and
+  // its name would have asserted the opposite of what it measured. Caught by
+  // cloud review on PR #2069; the premise went unchecked because the watchdog
+  // was read without grepping what does and does not resolve it.
+  //
+  // The outcomes it would have conflated are ALREADY carried by
+  // `update.sparkle_cycle_finished` (`error_code`, `no_update_reason` — 4007 is
+  // user-cancelled). The only thing that event cannot show is a cycle that never
+  // finished at all, and isolating that needs a JOIN, not a second timer-based
+  // counter — which is also the shape the founder rejected on #955.
+  //
+  // If the fleet-level update-failure question is ever picked up, it starts from
+  // that join and from #955, not from re-adding this.
 
   /// Why a telemetry flush was requested. Carried on `telemetry.flush_requested`.
   /// `.updateInstall` = the Sparkle pre-relaunch flush. `.appTerminate` = the
@@ -2936,22 +2983,20 @@ public final class TelemetryService {
     )
   }
 
-  /// Phase 1 (#637) — fired by `WordSuggestionService.suggest(for:)` after
-  /// the degeneration filter. `degenerated == true` means raw was non-empty
-  /// but post-filter list was empty (model returned only self-echoes).
-  /// `categorySuggested` is the category enum raw value or nil if call failed.
-  public func customWordsAfmAliasFilled(
-    resultCount: Int, degenerated: Bool, categorySuggested: String?
-  ) {
-    var props: [String: Any] = [
-      "result_count": resultCount,
-      "degenerated": degenerated,
-    ]
-    if let category = categorySuggested {
-      props["category_suggested"] = category
-    }
-    PostHogSDK.shared.capture("custom_words.afm_alias_filled", properties: props)
-  }
+  // #2066: `customWordsAfmAliasFilled` (`custom_words.afm_alias_filled`) was
+  // deleted here. Its doc named a real producer — `WordSuggestionService
+  // .suggest(for:)` after the degeneration filter — which made it read like a
+  // call site dropped by accident. It was not: that producer lives in
+  // `EnviousWisprPostProcessing`, which cannot import this module under the
+  // dependency-direction guard, and the emitter never had a legal caller. The
+  // deferral is recorded at the producer itself
+  // (`WordSuggestionService.runSuggestion`).
+  //
+  // Wiring it needs a telemetry callback injected across that module boundary,
+  // or a widened return type — `runSuggestion` currently collapses "degenerated"
+  // and "threw" into the same `nil`, so a caller in an importing module cannot
+  // reconstruct `degenerated` either. Both are design changes, not a missing
+  // line, and belong to #620 Phase 8 rather than to a telemetry cleanup.
 
   /// Phase 2 (#638) — fired by `WordCorrectionStep.process(...)` after a
   /// successful correction batch. Single summary event per process() call;

--- a/Tests/EnviousWisprTests/Services/TelemetryValueUnitTests.swift
+++ b/Tests/EnviousWisprTests/Services/TelemetryValueUnitTests.swift
@@ -1,0 +1,120 @@
+import EnviousWisprServices
+import Foundation
+import Testing
+
+#if DEBUG
+
+  /// #2060: PostHog's reserved `$value` is the slot charts aggregate on by
+  /// default, so a duration emitted there in the wrong unit is silently wrong by
+  /// 1000x on any chart that spans two events. Eleven emitters carried seconds
+  /// and two carried milliseconds; these tests pin the unit on the two that were
+  /// converted.
+  ///
+  /// Both cases FAIL against pre-fix `main`, where `$value` was the raw
+  /// millisecond count — they are regression tests, not descriptions of current
+  /// behaviour. Each asserts the unit two ways: the exact converted value, and
+  /// the inequality with the millisecond input, so a future edit that reverts the
+  /// division cannot leave the suite green.
+  @Suite("$value duration unit (#2060)", .serialized)
+  struct TelemetryValueUnitTests {
+    final class EventBox: @unchecked Sendable {
+      private let lock = NSLock()
+      private var stored: [CapturedTelemetryEvent] = []
+      func append(_ event: CapturedTelemetryEvent) { lock.withLock { stored.append(event) } }
+      var values: [CapturedTelemetryEvent] { lock.withLock { stored } }
+    }
+
+    @MainActor
+    private static func capture(
+      _ name: String, _ emit: () -> Void
+    ) -> [CapturedTelemetryEvent] {
+      let box = EventBox()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        if event.name == name { box.append(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+      emit()
+      return box.values
+    }
+
+    @MainActor
+    @Test("limb.failure_observed reports $value in seconds and keeps duration_ms raw")
+    func limbFailureValueIsSeconds() throws {
+      let durationMs = 1500
+      let events = Self.capture("limb.failure_observed") {
+        TelemetryService.shared.limbFailureObserved(
+          limb: "ollama", operation: "evict", result: "failed",
+          errorCategory: "-1004", durationMs: durationMs)
+      }
+
+      #expect(events.count == 1, "the emitter must fire exactly once")
+      let event = try #require(events.first)
+      let value = try #require(
+        event.doubleProps["$value"],
+        "$value must be projected into the DEBUG seam, or the unit is untestable")
+
+      #expect(value == 1.5, "1500 ms must be reported as 1.5 s")
+      #expect(
+        value != Double(durationMs),
+        "pre-fix behaviour: $value carried the raw millisecond count")
+      #expect(
+        event.intProps["duration_ms"] == durationMs,
+        "the raw millisecond value must survive untouched under its own name")
+    }
+
+    @MainActor
+    @Test("paste.completed reports $value in seconds and keeps latency_ms raw")
+    func pasteCompletedValueIsSeconds() throws {
+      // The real production p95 (302 ms), which is what made paste read as ~60x
+      // SLOWER than AI polish on a shared chart when it is ~16x faster.
+      let latencyMs = 302
+      let events = Self.capture("paste.completed") {
+        TelemetryService.shared.pasteCompleted(
+          tier: "accessibility", targetApp: nil, result: "success", latencyMs: latencyMs)
+      }
+
+      #expect(events.count == 1, "the emitter must fire exactly once")
+      let event = try #require(events.first)
+      let value = try #require(event.doubleProps["$value"])
+
+      // 302/1000 is not exactly representable in binary, so compare against the
+      // same computation rather than a decimal literal, then bound it
+      // independently so the assertion cannot pass by restating the production
+      // expression back to itself.
+      #expect(abs(value - Double(latencyMs) / 1000.0) < 1e-12)
+      #expect(value < 1.0, "a sub-second paste must not read as a three-digit magnitude")
+      #expect(
+        value != Double(latencyMs),
+        "pre-fix behaviour: $value carried the raw millisecond count")
+      #expect(
+        event.intProps["latency_ms"] == latencyMs,
+        "the raw millisecond value must survive untouched under its own name")
+    }
+
+    /// The convention this issue established, asserted rather than described:
+    /// both converted emitters agree with each other on the same input.
+    @MainActor
+    @Test("the two converted emitters agree on the unit for an identical input")
+    func convertedEmittersAgree() throws {
+      let ms = 750
+      let limb = Self.capture("limb.failure_observed") {
+        TelemetryService.shared.limbFailureObserved(
+          limb: "llm_prewarm", operation: "prewarm", result: "failed",
+          errorCategory: "x", durationMs: ms)
+      }
+      let paste = Self.capture("paste.completed") {
+        TelemetryService.shared.pasteCompleted(
+          tier: "clipboard", targetApp: nil, result: "success", latencyMs: ms)
+      }
+
+      // Unnested: `try #require(try #require(...))` is a recursive macro
+      // expansion and does not compile.
+      let limbEvent = try #require(limb.first)
+      let pasteEvent = try #require(paste.first)
+      let limbValue = try #require(limbEvent.doubleProps["$value"])
+      let pasteValue = try #require(pasteEvent.doubleProps["$value"])
+      #expect(limbValue == pasteValue, "same duration, same slot, same unit")
+    }
+  }
+
+#endif


### PR DESCRIPTION
Two telemetry-hygiene issues from the 2026-08-15 architecture audit.

## #2060 — `$value` mixed seconds and milliseconds

PostHog's reserved `$value` is the slot charts aggregate on by default. It carried seconds on 11 emitters and milliseconds on 2, so any chart spanning two events was silently wrong by 1000x. On one chart paste read as ~60x **slower** than AI polish (p95 302 vs 4.89) when it is ~16x faster.

`paste.completed` and `limb.failure_observed` now divide, matching the four recovery emitters that already did. Both already expose the raw integer under `latency_ms` / `duration_ms`, so `$value` is a pure aggregation mirror and the conversion loses no data.

The two non-duration sites are **decided and documented at the call site**, not changed:
- `contacts_imported` carries a count.
- `language.transcription_latency` carries `msPerAudioSecond`, a rate whose whole purpose is the cross-language comparison a raw duration cannot give.

The seconds convention binds durations; a rate is a different quantity, named as one.

**Historical discontinuity:** events already in PostHog keep milliseconds. Recorded as `analytics-operations.md` RULE: value-slot-carries-seconds-for-durations with the version floor, so a query crossing the change knows where the step is and uses `latency_ms` / `duration_ms` for a continuous series.

## #2066 — three zero-caller emitters, resolved individually

The issue explicitly said not to bulk-delete on the assumption they were the same case. They were not.

| Emitter | Outcome | Why |
|---|---|---|
| `updateWatchdogFired` | **Wired** | The watchdog exists (`UpdateAvailabilityService.triggerInstall`, since #343), is in this same module, and had both fields in hand. Only the emit was missing. |
| `trackCorrectionAfterInsert` | **Deleted** | Its own TODO recorded that it shipped without a call site. Wiring it needs an AX observer on the focused text field — new product behaviour, which `observability-operations.md` RULE: instrumentation-stays-observation-only forbids adding to expose a metric. |
| `customWordsAfmAliasFilled` | **Deleted** | Named a real producer, but that producer is in `EnviousWisprPostProcessing`, which cannot import Services under the dependency-direction guard — it never had a legal caller. `runSuggestion` also returns `nil` for both degeneration and error, so no caller could reconstruct the field. Both facts now recorded at the producer, replacing a stale note promising the hook was coming. |

A declared-but-uncalled emitter is worse than none: the query returns empty, and empty cannot distinguish "the feature never fires" from "we never wired it" — opposite investigations.

Wiring the watchdog also closed a real coverage gap. Its restore branch had **no test at all**, because reaching it meant waiting out the 5s timer. Its decision is extracted to `restoreAvailableAfterWatchdogTimeout()` so both the restore and the emit are now covered without a clock wait.

## Validation

`scripts/xcode-test.sh` full run: **5467 tests, `** TEST SUCCEEDED **`**. Read from the log, not the exit code — this branch already caught one run that exited 0 while printing `** TEST FAILED **` behind a `tail` pipe.

The two `$value` cases fail against pre-fix `main` by construction (they assert 1.5 and 0.302 where it emitted 1500 and 302), and each also asserts inequality with the millisecond input so a reverted division cannot leave them green. The watchdog pair includes the two-way control that a watchdog losing the race to a real terminal outcome emits nothing — without it, an emitter firing on every tick would also pass.

Closes #2060
Closes #2066
