### PR TITLE
test(pipeline): count async closures in the ceiling parser, and cap the home that uses the hatch

### DIFF
--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -5,23 +5,38 @@ import EnviousWisprCore
 import EnviousWisprServices
 import Foundation
 
-// MARK: - RecordingSessionKernel (epic #827, PR-3; built from PR-1 §B spec)
+// MARK: - RecordingSessionKernel (epic #827)
 //
-// The single recording-session finite state machine. One kernel owns one
-// dictation's full lifecycle — prepare, warm up, record, stop, transcribe,
-// finalize — as the 14-state FSM in PR-1 §B.1. It delegates transcription to
-// an `ASREngineAdapter` and post-ASR text-processing / storage / delivery to
-// injected closure seams (PR-3 plan §14a — closure seams match
-// the finalization house style; the kernel wires `KernelFinalizationWiring`
-// into them).
+// THE LIVE RECORDING PATH. This is the single recording-session finite state
+// machine and every dictation the product performs runs through it. Production
+// builds it at `KernelDictationDriverFactory.swift`, once per driver, for both
+// engines; the deterministic simulator drives the same type through a test-side
+// `RecordingSessionDriving` wrapper. Treat any change here as touching the
+// heart path.
 //
-// PR-3 ships this production-unwired (epic §14.3): no App-layer caller. It is
-// driven only by the deterministic PR-2 simulator through a test-side
-// `RecordingSessionDriving` wrapper. PR-4 wires it into the live app.
+// One kernel owns one dictation's full lifecycle — prepare, warm up, record,
+// stop, transcribe, finalize. It delegates transcription to an
+// `ASREngineAdapter` and post-ASR text-processing / storage / delivery to
+// injected closure seams, which the kernel wires `KernelFinalizationWiring`
+// into.
 //
-// Transitions are methods, never open `state =` mutation (epic §3.3). A
-// forbidden transition is logged and refused — never a silent no-op, never an
-// `assertionFailure` (PR-3 plan §3.10).
+// The FSM is the FIVE states of `RecordingSessionState` below, not the 14 the
+// original epic spec described: #1548 collapsed them and moved the ending
+// CATEGORY out to the sibling `RecordingOutcome`, so `state` is pure lifecycle
+// POSITION. Read those two declarations, in that order, before changing
+// anything here.
+//
+// Transitions are methods, never open `state =` mutation. A forbidden
+// transition is logged and refused — never a silent no-op, never an
+// `assertionFailure`.
+//
+// (#2067: this header used to say the type was "production-unwired… no
+// App-layer caller" and to describe a 14-state machine. Both were true at
+// PR-3 of the epic and neither has been true since PR-4 and #1548
+// respectively. Forward-looking "PR-n will do X" notes are deliberately gone
+// rather than updated — a header that describes plan sequence goes stale
+// silently, and this is the most expensive file in the product to be
+// confidently wrong about.)
 
 /// A normalized, recoverable failure reason for the `failed` terminal state
 /// (PR-1 §B.1.2 transition table).

--- a/Tests/EnviousWisprTests/Architecture/RecordingStarterCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RecordingStarterCeilingsTests.swift
@@ -88,6 +88,49 @@ import Testing
       """)
   }
 
+  /// The gate that does not depend on getting the classification right.
+  ///
+  /// The two caps above split stored dependencies into bins, and the split is
+  /// **syntactically undecidable**. `RouterCeilingParser` reads one file with no
+  /// type resolution, so a closure behind a `typealias` is an
+  /// `IdentifierTypeSyntax` and lands in `collaboratorCount`. That is not exotic
+  /// here — it is the house style: `ProgressCallback`, `ShowOverlay`,
+  /// `EvictOllamaModel`, `HostedPullStarter` and six more are function aliases
+  /// in `Sources/`. A locally declared type shadowing `Optional` is undecidable
+  /// the same way, and in the other direction.
+  ///
+  /// That makes the two caps individually bypassable whenever either has
+  /// headroom. Measured when this landed: 6/7 collaborators and 10/10 closures,
+  /// so `let progress: ProgressCallback` — a genuine eleventh closure seam —
+  /// reads as the seventh collaborator, and BOTH caps pass. Found by cloud
+  /// review on PR #2070, against the very cap #2068 added to stop this.
+  ///
+  /// The sum cannot be bypassed by moving a property between bins, because it
+  /// does not care which bin the property is in. Resolving aliases would mean
+  /// re-implementing type resolution on top of the parser, which is the
+  /// approximation business this parser was rewritten to leave.
+  ///
+  /// 16 is a FREEZE at the measured 6 + 10, on the same terms as the caps above:
+  /// it stops silent growth and is not a judgement that sixteen is right.
+  /// Ratchet DOWN freely.
+  @Test func totalStoredDependencyCount() throws {
+    let body = try RouterCeilingParser.classBody(
+      named: "RecordingStarter", at: Self.sourcePath)
+    let collaborators = RouterCeilingParser.collaboratorCount(in: body)
+    let closures = RouterCeilingParser.closureInjectedCount(in: body)
+    let total = collaborators + closures
+    #expect(
+      total <= 16,
+      """
+      RecordingStarter total stored-dependency ceiling exceeded: \(total) > 16 \
+      (\(collaborators) collaborators + \(closures) closures). This is the cap \
+      that a `typealias` cannot walk around: whichever bin a new dependency \
+      lands in, it lands here. If the two caps above still pass, that is the \
+      bypass this exists to catch, not evidence the dependency is free. \
+      Raising it requires a Bible §30 entry.
+      """)
+  }
+
   @Test func nonPrivateMethodCount() throws {
     let body = try RouterCeilingParser.classBody(
       named: "RecordingStarter", at: Self.sourcePath)

--- a/Tests/EnviousWisprTests/Architecture/RecordingStarterCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RecordingStarterCeilingsTests.swift
@@ -19,13 +19,72 @@ import Testing
     let body = try RouterCeilingParser.classBody(
       named: "RecordingStarter", at: Self.sourcePath)
     let count = RouterCeilingParser.collaboratorCount(in: body)
+    // #2068: this measures 6, not the 7 the PR10 baseline names. Two
+    // corrections, and neither is a removed dependency. `permissions` is not a
+    // stored property of this type and has not been one for some time, so the
+    // allowed list was carrying a name the file does not have. And the seventh
+    // slot was being occupied by `ensureSelectedReadyForPress`, an `async`
+    // closure that the parser could not recognise as a closure and therefore
+    // filed as a collaborator — fixed in `RouterCeilingParser.isClosureTyped`,
+    // which moved it to `closureInjectedCount` below where it belongs.
+    //
+    // Cap deliberately left at 7 rather than ratcheted to 6: the two changes
+    // above are a measurement correction, not a shrink anyone performed, and
+    // tightening a cap on the back of a counter fix would fail the next PR for
+    // a reason that has nothing to do with it. Ratchet when a real removal
+    // lands.
     #expect(
       count <= 7,
       """
       RecordingStarter collaborator ceiling exceeded: \(count) > 7. \
-      Allowed (PR10 baseline): audioCapture, asrManager, pipeline, \
-      whisperKitKernelDriver, settings, permissions, recordingOverlay. \
-      Raising the ceiling requires a Bible §30 entry.
+      Allowed: audioCapture, asrManager, kernelDriver, whisperKitKernelDriver, \
+      settings, recordingOverlay. Note the closure cap below — a dependency \
+      added as a bare closure does not land here, which is the point of having \
+      both. Raising the ceiling requires a Bible §30 entry.
+      """)
+  }
+
+  /// #2068: the closure cap this home never had.
+  ///
+  /// `collaboratorCount` excludes closure-typed properties by construction, and
+  /// this file's own comments name the workaround three times — ":35 A bare
+  /// closure so it stays off this start-path home's collaborator count", and
+  /// twice more as "Bare closure (off the collaborator cap)". A sibling counter
+  /// exists and is asserted by six other ceiling tests; it was simply never
+  /// applied to the home that documents using the hatch. Until now a dependency
+  /// could be added here indefinitely, in the shape the code comments describe,
+  /// and no gate would fire.
+  ///
+  /// **10 is a FREEZE, not a target.** It is the measured value on the day the
+  /// assertion landed, set deliberately at the current count so this stops
+  /// silent growth without becoming a refactor ticket. Whether this home should
+  /// hold ten closures at all is a real question and explicitly not this one's;
+  /// it is refactor-tier and belongs to a dedicated inspection pass. Ratchet
+  /// DOWN freely if any are removed.
+  ///
+  /// Why 10 and not the 9 the issue estimated: 9 was a hand count of the source.
+  /// The parser measured 8, and the gap was itself a defect — `async` closures
+  /// matched neither the closure predicate nor the primitive one, so
+  /// `makeRecoveryDirective` and `ensureSelectedReadyForPress` were counted as
+  /// COLLABORATORS instead. Fixed in `RouterCeilingParser.isClosureTyped` in the
+  /// same change, which is also why `collaboratorCount` above now measures 6
+  /// rather than 7. The scoped-out homes, measured the same way: AppWindowCoord-
+  /// inator 2, BulkImportEnrichmentCoordinator 2, AudioEventRouter 1,
+  /// BackendMetadata 1, SparkleUpdateController 1, everything else 0 — the issue
+  /// asked for assertions only where the hatch is genuinely in use, and a cap on
+  /// a home holding one closure is noise.
+  @Test func closureInjectedCount() throws {
+    let body = try RouterCeilingParser.classBody(
+      named: "RecordingStarter", at: Self.sourcePath)
+    let count = RouterCeilingParser.closureInjectedCount(in: body)
+    #expect(
+      count <= 10,
+      """
+      RecordingStarter closure-injected-dependency ceiling exceeded: \(count) > 10. \
+      This home's collaborator cap is bypassable with a bare closure and this is \
+      the gate that notices. A new closure dependency is a real dependency: \
+      justify it, or put it behind an existing seam. Raising this cap requires a \
+      Bible §30 changelog entry, same as any other ceiling.
       """)
   }
 

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
@@ -33,7 +33,21 @@ enum RouterCeilingParser {
     // (`isStoredPropertyDeclaration`, `isClosureTyped`, ...) parse the real
     // declaration text (type names, attributes, default values) — only the
     // fold's continuation check masks comments/strings internally via `codeView`.
-    let code = codeView(source)
+    //
+    // `blankBlockComments: true` matches the sibling `functionBody` below, which
+    // has always passed it. This call did not, so a `}` inside a `/* ... */`
+    // closes the class body early and every declaration after the comment falls
+    // outside the returned body — a ceiling reading BELOW the truth, which is
+    // the direction that passes silently forever. One complete contiguous buffer
+    // in one pass is exactly the condition the flag requires.
+    //
+    // LATENT, not active: at the time of this fix `git grep -n '/\*' --
+    // 'Sources/**/*.swift'` returns exactly one hit (`EmojiFormatter.swift:410`,
+    // inline and brace-free), and no ceiling-tested class contains a block
+    // comment at all. No ceiling is mis-read TODAY. This closes the trap before
+    // the first brace-carrying block comment lands, because nothing about
+    // writing one would look dangerous.
+    let code = codeView(source, blankBlockComments: true)
     let sourceChars = Array(source)
     let codeChars = Array(code)  // same Character count as sourceChars
     let declarations = [
@@ -208,7 +222,22 @@ enum RouterCeilingParser {
   /// the summed `{`/`}` counts of all merged physical lines, so depth tracking
   /// downstream is unchanged.
   private static func foldContinuationLines(_ body: String) -> [String] {
-    let physical = body.split(separator: "\n", omittingEmptySubsequences: false)
+    // Blank comments ONCE over the WHOLE body, then split (cloud review, PR
+    // #2070). `blockCommentDepth` is per-CALL state, so calling `codeView` per
+    // line resets it at every line boundary: the interior lines of a multi-line
+    // `/* ... */` come back looking like code. That broke the effect-specifier
+    // lookahead (it stopped on the first interior line) and, one layer down, it
+    // is why `braceCounts` ran with blanking OFF entirely — leaving a `}` inside
+    // a comment free to drive brace depth negative and hide every declaration
+    // after it. Both are the same defect, and both close here rather than at the
+    // call sites, so a future per-line reader cannot reintroduce either.
+    //
+    // Only BLOCK-comment state spans lines. `//` comments and single-line string
+    // literals are terminated by the newline itself (see `codeView`), so per-line
+    // calls downstream remain correct on this already-blanked text, and blanking
+    // is idempotent where they repeat it.
+    let physical = codeView(body, blankBlockComments: true)
+      .split(separator: "\n", omittingEmptySubsequences: false)
       .map(String.init)
     var result: [String] = []
     var depth = 0
@@ -254,14 +283,12 @@ enum RouterCeilingParser {
   /// and comparison.
   /// First line at or after `i + 1` that carries actual code — blank lines and
   /// `//` comments are trivia and Swift permits them anywhere between tokens.
+  /// `lines` are ALREADY comment-blanked by the caller, so this only has to find
+  /// the next line with anything left on it.
   private static func nextSignificantIndex(_ lines: [String], after i: Int) -> Int? {
     var j = i + 1
     while j < lines.count {
-      if !codeView(lines[j], blankBlockComments: true)
-        .trimmingCharacters(in: .whitespaces).isEmpty
-      {
-        return j
-      }
+      if !lines[j].trimmingCharacters(in: .whitespaces).isEmpty { return j }
       j += 1
     }
     return nil
@@ -284,10 +311,11 @@ enum RouterCeilingParser {
   /// have. No Swift declaration begins with `async` / `throws` / `rethrows` /
   /// `->`, so this predicate cannot over-fold.
   private static func continuesWithEffectSpecifier(_ line: String) -> Bool {
-    let trimmed = codeView(line, blankBlockComments: true)
-      .trimmingCharacters(in: .whitespaces)
+    // `line` arrives comment-blanked from `foldContinuationLines`.
+    let trimmed = line.trimmingCharacters(in: .whitespaces)
     if trimmed.hasPrefix("->") { return true }
-    for keyword in ["async", "throws", "rethrows"] where trimmed == keyword
+    for keyword in ["async", "throws", "rethrows"]
+    where trimmed == keyword
       || trimmed.hasPrefix(keyword + " ") || trimmed.hasPrefix(keyword + "-")
       // `throws(MyError) -> ...` wrapping onto its own line.
       || trimmed.hasPrefix(keyword + "(")
@@ -330,16 +358,19 @@ enum RouterCeilingParser {
   /// are out of scope — no ceiling-tested class declaration uses them.
   ///
   /// `blankBlockComments`, when `true`, ALSO blanks `/* ... */` block comments
-  /// (nesting-aware). Defaulted `false` and left off for `braceCounts`'
-  /// per-LINE calls (PR #1634 cloud review r4, 2026-07-17): a multi-line
-  /// block comment spanning several lines would reset its depth to 0 at each
-  /// new per-line call, mis-tracking braces inside it for every OTHER
-  /// existing caller of `braceCounts` (`countTopLevelStoredProperties`,
-  /// `nonPrivateMethodCount`, `foldContinuationLines`). Safe to enable only
-  /// where a single call processes one COMPLETE contiguous buffer in one pass
-  /// (`functionBody`, `rangeOfStatement` below) — block comments are a real,
-  /// if rare, live pattern in this codebase (confirmed via
-  /// `grep -rn '/\*' Sources/EnviousWispr*/`, one hit outside test files).
+  /// (nesting-aware). `blockCommentDepth` is per-CALL state, so this flag is only
+  /// meaningful on a COMPLETE contiguous buffer processed in one pass; a per-LINE
+  /// call would reset the depth at every line boundary and mis-read the interior
+  /// of a multi-line comment as code.
+  ///
+  /// PR #1634 cloud review r4 (2026-07-17) met that constraint and resolved it by
+  /// leaving the flag OFF for `braceCounts`, which left a `}` inside a block
+  /// comment counted as a real brace. PR #2070 removed the constraint instead:
+  /// `foldContinuationLines` now blanks the whole body ONCE up front, so every
+  /// line reaching `braceCounts` and the per-line classifiers is already
+  /// comment-free and the default here no longer decides anything for them.
+  /// Block comments are a real, if rare, live pattern in this codebase
+  /// (`grep -rn '/\*' Sources/EnviousWispr*/`, one hit outside test files).
   private static func codeView(_ buffer: String, blankBlockComments: Bool = false) -> String {
     let chars = Array(buffer)
     var result: [Character] = []

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
@@ -294,7 +294,7 @@ enum RouterCeilingParser {
         let isBool = binding.initializer.map { isBooleanLiteral($0.value) } ?? false
         expand(
           pattern: binding.pattern, type: binding.typeAnnotation?.type,
-          isBooleanLiteralInitialized: isBool, depth: 0, into: &result)
+          isBooleanLiteralInitialized: isBool, into: &result)
       }
     }
     return result
@@ -312,11 +312,17 @@ enum RouterCeilingParser {
   /// TYPES. Reading only the type would conflate the two and count two injected
   /// closure seams as one collaborator: an undercount, and the direction a
   /// `<=` ceiling never reports (cloud review, PR #2070).
+  /// Unbounded on purpose, for the same reason as `unwrapped(_:)`: each step
+  /// recurses into a CHILD pattern of a finite acyclic tree, so it terminates on
+  /// the structure. A depth cap here emitted the remaining tuple as ONE property
+  /// instead of visiting its leaves — an undercount past the cap, invisible
+  /// because a `<=` ceiling only reports counts that are too HIGH (cloud review,
+  /// PR #2070).
   private static func expand(
     pattern: PatternSyntax, type: TypeSyntax?, isBooleanLiteralInitialized isBool: Bool,
-    depth: Int, into result: inout [StoredLet]
+    into result: inout [StoredLet]
   ) {
-    guard depth < 16, let tuple = pattern.as(TuplePatternSyntax.self) else {
+    guard let tuple = pattern.as(TuplePatternSyntax.self) else {
       result.append(StoredLet(type: type, isBooleanLiteralInitialized: isBool))
       return
     }
@@ -331,18 +337,18 @@ enum RouterCeilingParser {
       for (element, elementType) in zip(elements, types) {
         expand(
           pattern: element.pattern, type: elementType,
-          isBooleanLiteralInitialized: isBool, depth: depth + 1, into: &result)
+          isBooleanLiteralInitialized: isBool, into: &result)
       }
     } else if elements.count == 1, let only = elements.first {
       // `let (a): X` — parenthesised, not a real tuple; keep the type.
       expand(
         pattern: only.pattern, type: type, isBooleanLiteralInitialized: isBool,
-        depth: depth + 1, into: &result)
+        into: &result)
     } else {
       for element in elements {
         expand(
           pattern: element.pattern, type: nil, isBooleanLiteralInitialized: isBool,
-          depth: depth + 1, into: &result)
+          into: &result)
       }
     }
   }
@@ -374,14 +380,23 @@ enum RouterCeilingParser {
   /// (`(() -> Void, AlphaDep)` is a tuple), and any generic other than
   /// `Optional` (`[String: () -> Void]` is a dictionary).
   private static func isFunctionType(_ type: TypeSyntax) -> Bool {
-    unwrapped(type)?.is(FunctionTypeSyntax.self) ?? false
+    unwrapped(type).is(FunctionTypeSyntax.self)
   }
 
-  private static func unwrapped(_ type: TypeSyntax) -> TypeSyntax? {
+  /// Peels wrappers until the type underneath is reached. Total, never nil.
+  ///
+  /// Unbounded on purpose. Every branch below moves `current` to a CHILD of the
+  /// node it just examined, and a SwiftSyntax tree is finite and acyclic, so the
+  /// loop terminates on the structure itself — a depth cap adds nothing a
+  /// malformed tree could defeat, and this one is not reachable from a parse.
+  /// An earlier version capped at 64 and returned nil beyond it, which turned a
+  /// deeply wrapped closure into a collaborator: an UNDERCOUNT, the direction a
+  /// `<=` ceiling never reports (cloud review, PR #2070). The comment justifying
+  /// that cap asserted it "stops a malformed tree from spinning" — a claim about
+  /// SwiftSyntax I had not checked, and which is false.
+  private static func unwrapped(_ type: TypeSyntax) -> TypeSyntax {
     var current = type
-    // Bounded by the nesting of a single declaration, which is finite; the cap
-    // only stops a malformed tree from spinning.
-    for _ in 0..<64 {
+    while true {
       if current.is(FunctionTypeSyntax.self) { return current }
       if let attributed = current.as(AttributedTypeSyntax.self) {
         current = attributed.baseType
@@ -408,7 +423,6 @@ enum RouterCeilingParser {
       }
       return current
     }
-    return nil
   }
 
   /// `Optional<T>` / `Swift.Optional<T>` → `T`. In this swift-syntax version
@@ -441,14 +455,13 @@ enum RouterCeilingParser {
   ]
 
   private static func isPrimitive(_ type: TypeSyntax) -> Bool {
-    guard let base = unwrapped(type) else { return false }
-    guard let identifier = base.as(IdentifierTypeSyntax.self) else { return false }
+    guard let identifier = unwrapped(type).as(IdentifierTypeSyntax.self) else { return false }
     if identifier.genericArgumentClause != nil { return identifier.name.text == "Task" }
     return primitiveNames.contains(identifier.name.text)
   }
 
   private static func isNSObjectProtocol(_ type: TypeSyntax) -> Bool {
-    guard let base = unwrapped(type), let identifier = base.as(IdentifierTypeSyntax.self) else {
+    guard let identifier = unwrapped(type).as(IdentifierTypeSyntax.self) else {
       return false
     }
     return identifier.name.text == "NSObjectProtocol"

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
@@ -218,11 +218,23 @@ enum RouterCeilingParser {
       let (opens, closes) = braceCounts(buffer)
       let depthForThisLine = depth - max(0, closes - opens)
       if depthForThisLine == 0 {
-        while i + 1 < physical.count,
-          isUnterminatedDeclaration(buffer) || continuesWithEffectSpecifier(physical[i + 1])
-        {
-          i += 1
-          buffer += "\n" + physical[i]
+        while i + 1 < physical.count {
+          if isUnterminatedDeclaration(buffer) {
+            i += 1
+            buffer += "\n" + physical[i]
+            continue
+          }
+          // Look PAST blank lines and `//` comments for a continuing effect
+          // specifier or arrow, absorbing the trivia on the way (cloud review,
+          // PR #2070). An immediate-next-line check emits the declaration before
+          // it ever reaches the `async` two lines down.
+          guard let next = nextSignificantIndex(physical, after: i),
+            continuesWithEffectSpecifier(physical[next])
+          else { break }
+          while i < next {
+            i += 1
+            buffer += "\n" + physical[i]
+          }
         }
       }
       result.append(buffer)
@@ -240,6 +252,17 @@ enum RouterCeilingParser {
   /// character is a continuation operator (`:` `,` `&`, or it ends with `->`).
   /// Angle brackets are deliberately not tracked — `>` is ambiguous with `->`
   /// and comparison.
+  /// First line at or after `i + 1` that carries actual code — blank lines and
+  /// `//` comments are trivia and Swift permits them anywhere between tokens.
+  private static func nextSignificantIndex(_ lines: [String], after i: Int) -> Int? {
+    var j = i + 1
+    while j < lines.count {
+      if !codeView(lines[j]).trimmingCharacters(in: .whitespaces).isEmpty { return j }
+      j += 1
+    }
+    return nil
+  }
+
   /// #2068 (cloud review, PR #2070): a function type may wrap so that its effect
   /// specifier or arrow starts the NEXT physical line:
   ///
@@ -454,7 +477,14 @@ enum RouterCeilingParser {
     return primitives.contains { line.contains($0) }
   }
 
-  private static func isClosureTyped(_ line: String) -> Bool {
+  private static func isClosureTyped(_ rawLine: String) -> Bool {
+    // #2068: matched against the CODE VIEW, not the raw text. Swift's function-type
+    // grammar admits arbitrary trivia between every token, so a comment sitting
+    // between `()` and its effect specifier defeats a raw-text match — and a `->`
+    // inside a comment or string literal can fake one in the other direction.
+    // Blanking both to spaces makes the predicate structural, which is the only
+    // form that survives the next syntax shape nobody enumerated.
+    let line = codeView(rawLine)
     // Matches a declared closure type signature: `: (...) -> ...`
     // (with optional `@MainActor` / `@Sendable` attributes before the
     // paren). `line` may be a folded multi-line declaration; `[[:space:]]`
@@ -471,7 +501,7 @@ enum RouterCeilingParser {
     // `throws` may carry a typed-throws clause on this Swift 6 target
     // (`() throws(MyError) -> Void`), so the error type is part of the specifier
     // (cloud review, PR #2070).
-    line.range(
+    return line.range(
       of:
         #":[[:space:]]*(@[A-Za-z]+[[:space:]]+)*\([^)]*\)"#
         + #"([[:space:]]+(async|rethrows|throws([[:space:]]*\([^)]*\))?))*"#

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
@@ -499,12 +499,17 @@ enum RouterCeilingParser {
     // missing ones being `makeRecoveryDirective` and
     // `ensureSelectedReadyForPress`, both `async`.
     // `throws` may carry a typed-throws clause on this Swift 6 target
-    // (`() throws(MyError) -> Void`), so the error type is part of the specifier
-    // (cloud review, PR #2070).
+    // (`() throws(MyError) -> Void`), so the error type is part of the specifier.
+    // The error type may itself contain one level of parentheses —
+    // `throws(Failure<(Int, String)>)` — so the clause matches a balanced pair
+    // rather than stopping at the first `)` (cloud review, PR #2070). One level
+    // is where a regex's usefulness ends; deeper nesting needs a real parser, and
+    // failing to match simply counts the property as a collaborator, which is the
+    // conservative direction.
     return line.range(
       of:
         #":[[:space:]]*(@[A-Za-z]+[[:space:]]+)*\([^)]*\)"#
-        + #"([[:space:]]+(async|rethrows|throws([[:space:]]*\([^)]*\))?))*"#
+        + #"([[:space:]]+(async|rethrows|throws([[:space:]]*\(([^()]|\([^()]*\))*\))?))*"#
         + #"[[:space:]]*->[[:space:]]"#,
       options: .regularExpression) != nil
   }

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
@@ -107,7 +107,7 @@ enum RouterCeilingParser {
 
   /// Non-private `func` declarations declared directly in the class body.
   static func nonPrivateMethodCount(in body: String) -> Int {
-    members(in: body).compactMap { $0.decl.as(FunctionDeclSyntax.self) }
+    members(in: body).compactMap { $0.as(FunctionDeclSyntax.self) }
       .filter { !isPrivate($0.modifiers) }
       .count
   }
@@ -192,9 +192,22 @@ enum RouterCeilingParser {
       }
     }
 
+    // The match must not begin INSIDE an identifier. The retired implementation
+    // spelled this as a `(?<![A-Za-z0-9_])` lookbehind, and dropping it made
+    // `preassertAttached()` satisfy a guard that requires `assertAttached()` —
+    // a false green in a safety check, which is worse than a missed match
+    // (cloud review, PR #2070). Restored explicitly rather than inherited.
+    func isIdentifierByte(_ byte: UInt8) -> Bool {
+      (byte >= UInt8(ascii: "0") && byte <= UInt8(ascii: "9"))
+        || (byte >= UInt8(ascii: "A") && byte <= UInt8(ascii: "Z"))
+        || (byte >= UInt8(ascii: "a") && byte <= UInt8(ascii: "z"))
+        || byte == UInt8(ascii: "_")
+    }
+
     let target = Array(needle.utf8)
     guard !target.isEmpty, bytes.count >= target.count else { return nil }
     for start in 0...(bytes.count - target.count) {
+      guard start == 0 || !isIdentifierByte(bytes[start - 1]) else { continue }
       if Array(bytes[start..<(start + target.count)]) == target { return start }
     }
     return nil
@@ -216,12 +229,35 @@ enum RouterCeilingParser {
   /// members as top-level code keeps them genuine MEMBERS, where modifiers such
   /// as `nonisolated` and `final` are legal and mean what they mean in the real
   /// class.
-  private static func members(in body: String) -> MemberBlockItemListSyntax {
+  private static func members(in body: String) -> [DeclSyntax] {
     let tree = Parser.parse(source: "final class __CeilingProbe {\n\(body)\n}")
-    guard let probe = ClassFinder.find(named: "__CeilingProbe", in: tree) else {
-      return MemberBlockItemListSyntax([])
+    guard let probe = ClassFinder.find(named: "__CeilingProbe", in: tree) else { return [] }
+
+    var collected: [DeclSyntax] = []
+    func collect(_ list: MemberBlockItemListSyntax) {
+      for item in list {
+        // A `#if` block arrives as ONE member of kind `IfConfigDeclSyntax`, so
+        // reading `item.decl` alone skips every declaration inside it. The text
+        // scanner counted those lines — `#if` does not change brace depth — so
+        // not descending here would be a silent UNDERCOUNT relative to it, and
+        // the differential could not catch it because no ceilinged class uses
+        // `#if` today (cloud review, PR #2070).
+        //
+        // `EngineProtocolSurfaceFreezeTests` in this directory already handles
+        // this, and I read that file for its API shape without carrying the
+        // handling across — the same twin-not-copied mistake this PR keeps
+        // finding.
+        if let ifConfig = item.decl.as(IfConfigDeclSyntax.self) {
+          for clause in ifConfig.clauses {
+            if case .decls(let nested) = clause.elements { collect(nested) }
+          }
+          continue
+        }
+        collected.append(item.decl)
+      }
     }
-    return probe.memberBlock.members
+    collect(probe.memberBlock.members)
+    return collected
   }
 
   private struct StoredLet {
@@ -243,7 +279,7 @@ enum RouterCeilingParser {
   private static func storedLetBindings(in body: String) -> [StoredLet] {
     var result: [StoredLet] = []
     for member in members(in: body) {
-      guard let variable = member.decl.as(VariableDeclSyntax.self) else { continue }
+      guard let variable = member.as(VariableDeclSyntax.self) else { continue }
       guard variable.bindingSpecifier.tokenKind == .keyword(.let) else { continue }
       guard !isTypeProperty(variable.modifiers) else { continue }
       for binding in variable.bindings {

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
@@ -539,20 +539,102 @@ enum RouterCeilingParser {
     // `closureInjectedCount` read 8 against 10 closure-typed `let`s, the two
     // missing ones being `makeRecoveryDirective` and
     // `ensureSelectedReadyForPress`, both `async`.
-    // `throws` may carry a typed-throws clause on this Swift 6 target
-    // (`() throws(MyError) -> Void`), so the error type is part of the specifier.
-    // The error type may itself contain one level of parentheses —
-    // `throws(Failure<(Int, String)>)` — so the clause matches a balanced pair
-    // rather than stopping at the first `)` (cloud review, PR #2070). One level
-    // is where a regex's usefulness ends; deeper nesting needs a real parser, and
-    // failing to match simply counts the property as a collaborator, which is the
-    // conservative direction.
-    return line.range(
-      of:
-        #":[[:space:]]*(@[A-Za-z]+[[:space:]]+)*\([^)]*\)"#
-        + #"([[:space:]]+(async|rethrows|throws([[:space:]]*\(([^()]|\([^()]*\))*\))?))*"#
-        + #"[[:space:]]*->[[:space:]]"#,
-      options: .regularExpression) != nil
+    // SCANNED, not matched (cloud review, PR #2070, round six). The parameter
+    // list was `\([^)]*\)`, which stops at the first `)`, so a parenthesis
+    // nested anywhere in the parameter type —
+    // `(Result<(Int, String), DomainError>) -> Void` — ended the match before
+    // the arrow. A regex cannot balance brackets, so no widening of the
+    // character classes could have reached it: five rounds of this file's
+    // review each added one more permitted syntax shape, and this one is not a
+    // shape but a capability. The clause below balances instead, which also
+    // subsumes the earlier typed-throws nesting and the whitespace-adjacency
+    // cases rather than encoding them as alternatives.
+    let chars = Array(line)
+    var i = 0
+    while i < chars.count {
+      if chars[i] == ":", closureSignatureFollows(chars, from: i + 1) { return true }
+      i += 1
+    }
+    return false
+  }
+
+  /// A declared closure type, read structurally from just after its `:`:
+  /// `@Attribute`* `(` balanced `)` effect-specifier* `->`.
+  ///
+  /// Every position skips trivia, so whitespace is optional everywhere Swift
+  /// makes it optional and unbounded everywhere Swift allows it — the property
+  /// the previous pattern kept failing one shape at a time. Comments are already
+  /// blanked to spaces by the caller's code view, so they are trivia here too.
+  private static func closureSignatureFollows(_ chars: [Character], from start: Int) -> Bool {
+    var i = skipTrivia(chars, from: start)
+    while i < chars.count, chars[i] == "@" {
+      i += 1
+      while i < chars.count, chars[i].isLetter || chars[i].isNumber || chars[i] == "_" { i += 1 }
+      // An attribute's argument list is ADJACENT to its name — `@available(macOS
+      // 26, *)`. Skipping trivia before this check would consume the FUNCTION
+      // TYPE's own parameter list in `@MainActor (Int) -> Bool`, where the paren
+      // is separated by a space and belongs to the type, not the attribute.
+      if i < chars.count, chars[i] == "(" {
+        guard let close = matchingParen(chars, open: i) else { return false }
+        i = close + 1
+      }
+      i = skipTrivia(chars, from: i)
+    }
+    guard i < chars.count, chars[i] == "(", let close = matchingParen(chars, open: i)
+    else { return false }
+    i = skipTrivia(chars, from: close + 1)
+    while true {
+      if matchesKeyword(chars, at: i, "async") {
+        i = skipTrivia(chars, from: i + 5)
+      } else if matchesKeyword(chars, at: i, "rethrows") {
+        i = skipTrivia(chars, from: i + 8)
+      } else if matchesKeyword(chars, at: i, "throws") {
+        i = skipTrivia(chars, from: i + 6)
+        // Typed throws, to any nesting depth: `throws(Failure<(Int, String)>)`.
+        if i < chars.count, chars[i] == "(" {
+          guard let errorClose = matchingParen(chars, open: i) else { return false }
+          i = skipTrivia(chars, from: errorClose + 1)
+        }
+      } else {
+        break
+      }
+    }
+    return i + 1 < chars.count && chars[i] == "-" && chars[i + 1] == ">"
+  }
+
+  private static func skipTrivia(_ chars: [Character], from i: Int) -> Int {
+    var j = i
+    while j < chars.count, chars[j].isWhitespace { j += 1 }
+    return j
+  }
+
+  /// Index of the `)` closing the `(` at `open`, or `nil` if unbalanced. The
+  /// caller passes a code view, so parens inside comments and string literals
+  /// are already spaces and cannot skew the depth.
+  private static func matchingParen(_ chars: [Character], open: Int) -> Int? {
+    var depth = 0
+    var i = open
+    while i < chars.count {
+      if chars[i] == "(" { depth += 1 }
+      if chars[i] == ")" {
+        depth -= 1
+        if depth == 0 { return i }
+      }
+      i += 1
+    }
+    return nil
+  }
+
+  /// `word` appears at `i` and is not merely the prefix of a longer identifier,
+  /// so a type named `asyncResult` is never read as the `async` specifier.
+  private static func matchesKeyword(_ chars: [Character], at i: Int, _ word: String) -> Bool {
+    let expected = Array(word)
+    guard i >= 0, i + expected.count <= chars.count else { return false }
+    for k in 0..<expected.count where chars[i + k] != expected[k] { return false }
+    let after = i + expected.count
+    guard after < chars.count else { return true }
+    let next = chars[after]
+    return !(next.isLetter || next.isNumber || next == "_")
   }
 
   private static func isNSObjectProtocolTyped(_ line: String) -> Bool {

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
@@ -596,6 +596,21 @@ enum RouterCeilingParser {
     // Reject a `let` whose first physical line ends with `{` (trailing-closure
     // initializer body). A Swift computed property is always `var`, so a `let`
     // never reaches here as a computed property.
+    //
+    // DELIBERATE, and the reason belongs here because the mechanism alone reads
+    // like an oversight (cloud review, PR #2070, round sixteen, raised on
+    // exactly that reading). These ceilings bound INJECTED dependencies —
+    // "justify it, or put it behind an existing seam", per the freeze tests. A
+    // closure-typed `let` carrying an inline literal body is the opposite of a
+    // seam: it cannot be substituted by a caller or a test, it is not passed
+    // through `init`, and it is owned behaviour that happens to be spelled as a
+    // closure rather than a private method.
+    //
+    // Counting it would make the closure ceiling fire on a refactor that turns a
+    // private method into a stored closure, which adds no dependency at all —
+    // a false positive on the one axis a ceiling must stay trustworthy about.
+    // Measured while deciding: zero such top-level declarations across the three
+    // ceiling-tested homes, so nothing rests on this today either way.
     let firstLine =
       line.split(separator: "\n", omittingEmptySubsequences: false).first
       .map(String.init) ?? line

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
@@ -628,10 +628,24 @@ enum RouterCeilingParser {
     // shape but a capability. The clause below balances instead, which also
     // subsumes the earlier typed-throws nesting and the whitespace-adjacency
     // cases rather than encoding them as alternatives.
+    // Only the DECLARATION's own type annotation is tried, which is the `:` at
+    // bracket depth 0. Retrying after every colon meant a non-closure type
+    // holding a closure matched on an inner one: `let handlers: [String: () ->
+    // Void]` is a dictionary — a collaborator — but its value-type colon parses
+    // as a closure signature and classified the whole property as one (cloud
+    // review, PR #2070, round eleven). Verified valid Swift before fixing.
     let chars = Array(line)
+    var depth = 0
     var i = 0
     while i < chars.count {
-      if chars[i] == ":", closureSignatureFollows(chars, from: i + 1) { return true }
+      switch chars[i] {
+      case "(", "[", "<": depth += 1
+      case ")", "]": depth -= 1
+      case ">" where !(i > 0 && chars[i - 1] == "-"): depth -= 1
+      case ":" where depth == 0:
+        if closureSignatureFollows(chars, from: i + 1) { return true }
+      default: break
+      }
       i += 1
     }
     return false
@@ -663,8 +677,24 @@ enum RouterCeilingParser {
       // 26, *)`. Skipping trivia before this check would consume the FUNCTION
       // TYPE's own parameter list in `@MainActor (Int) -> Bool`, where the paren
       // is separated by a space and belongs to the type, not the attribute.
+      //
+      // Adjacency alone is not sufficient, though: `@Sendable()->Void` is valid
+      // Swift (verified — `@MainActor()->Void` is NOT, so the two cannot be told
+      // apart by shape), and there the adjacent `()` IS the parameter list.
+      // Whether an attribute accepts arguments is not knowable here, so decide
+      // by what FOLLOWS: if an arrow or effect specifier comes next, the group
+      // just consumed was the parameter list, and the scan rewinds to it (cloud
+      // review, PR #2070, round eleven).
       if i < end, chars[i] == "(" {
         guard let close = matchingParen(chars, open: i, limit: end) else { return false }
+        let afterArgs = skipTrivia(chars, from: close + 1, limit: end)
+        let arrowFollows =
+          afterArgs + 1 < end && chars[afterArgs] == "-" && chars[afterArgs + 1] == ">"
+        let specifierFollows =
+          matchesKeyword(chars, at: afterArgs, "async", limit: end)
+          || matchesKeyword(chars, at: afterArgs, "throws", limit: end)
+          || matchesKeyword(chars, at: afterArgs, "rethrows", limit: end)
+        if arrowFollows || specifierFollows { break }
         i = close + 1
       }
       i = skipTrivia(chars, from: i, limit: end)

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
@@ -630,8 +630,26 @@ enum RouterCeilingParser {
     // `static` stays OUT deliberately: a type property is not an injected
     // instance collaborator, and admitting it would change what the ceiling
     // counts rather than fix what it reads.
+    // ENUMERATED against the compiler rather than extended one modifier per
+    // review round (round twenty). Each candidate was type-checked as
+    // `<modifier> let d: AnyObject` in a class:
+    //
+    //   accepted → access modifiers, `final`, `dynamic`,
+    //              `nonisolated` / `nonisolated(unsafe)`,
+    //              `unowned` / `unowned(safe)` / `unowned(unsafe)`
+    //   rejected → `override`, `lazy`, `weak`, `mutating`, `convenience`,
+    //              `required` (none can precede a stored `let` at all)
+    //
+    // Ordering is free — `final private let` and `private final let` both
+    // compile — which is why this is one repeating alternation rather than a
+    // fixed sequence of optional groups.
+    //
+    // `static` and `class` stay OUT deliberately: a TYPE property is not an
+    // injected instance collaborator. That is the one exclusion here which is a
+    // decision about what the ceiling means rather than a fact about Swift.
     let modifiers =
-      #"((public|internal|private|fileprivate|package|open|nonisolated(\(unsafe\))?)[[:space:]]+)*"#
+      #"((public|internal|private|fileprivate|package|open|final|dynamic"#
+      + #"|nonisolated(\(unsafe\))?|unowned(\((safe|unsafe)\))?)[[:space:]]+)*"#
     return "^[[:space:]]*\(attrs)\(modifiers)let[[:space:]]+[A-Za-z_]"
   }()
 

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
@@ -707,9 +707,17 @@ enum RouterCeilingParser {
     // blind spot in `containsTopLevelComma` two rounds ago. The recursion
     // carries the same whole-type guards, so `Optional<(() -> Void, AlphaDep)>`
     // still fails the tuple test.
+    //
+    // The trailing guard is the SAME one the parenthesised path uses. Round
+    // thirteen added this branch and returned as soon as the inner type parsed,
+    // which silently reopened the metatype hole round twelve had closed:
+    // `Optional<() -> Void>.Type` is a metatype, and a new wrapper path that
+    // skips the shared check is exactly how a closed class comes back (round
+    // fourteen). Both wrapper paths now end at `onlyOptionalMarkersRemain`.
     if let angleOpen = optionalGenericOpen(chars, at: i, limit: end),
       let angleClose = lastAngleBracket(chars, from: angleOpen + 1, to: end)
     {
+      guard onlyOptionalMarkersRemain(chars, from: angleClose + 1, to: end) else { return false }
       return closureSignatureFollows(chars, from: angleOpen + 1, limit: angleClose)
     }
     guard i < end, chars[i] == "(", let close = matchingParen(chars, open: i, limit: end)
@@ -766,21 +774,29 @@ enum RouterCeilingParser {
   /// the comma in `Result<Int, Error>` is not mistaken for a tuple separator;
   /// `<`/`>` are ambiguous with comparison in general Swift, but inside a type
   /// annotation they are generic delimiters.
-  /// Index of the `<` that opens a generic `Optional<…>` / `Swift.Optional<…>`
-  /// beginning at `at`, or `nil` when the type does not start with one.
+  /// Index of the `<` that opens a generic `Optional<…>`, or `nil` when the type
+  /// does not start with one. An optional `Swift.` qualifier is accepted.
+  ///
+  /// SCANNED with trivia skipped at every join rather than matched against the
+  /// literals `"Optional<"` / `"Swift.Optional<"`, because Swift accepts
+  /// `Optional <…>`, `Swift . Optional<…>`, and `Optional /* docs */ <…>` (round
+  /// fourteen; the comment form arrives here already blanked to spaces by the
+  /// caller's code view, so it is ordinary trivia). Tolerating trivia is also
+  /// what lets the `Swift.` qualifier fall out of the scan instead of needing a
+  /// second literal — the same reason every other position in this file skips
+  /// trivia rather than enumerating spacings.
   private static func optionalGenericOpen(_ chars: [Character], at: Int, limit: Int) -> Int? {
     let end = min(limit, chars.count)
-    for prefix in ["Optional<", "Swift.Optional<"] {
-      let expected = Array(prefix)
-      guard at >= 0, at + expected.count <= end else { continue }
-      var matches = true
-      for k in 0..<expected.count where chars[at + k] != expected[k] {
-        matches = false
-        break
-      }
-      if matches { return at + expected.count - 1 }
+    var i = skipTrivia(chars, from: at, limit: end)
+    if matchesKeyword(chars, at: i, "Swift", limit: end) {
+      let afterSwift = skipTrivia(chars, from: i + 5, limit: end)
+      guard afterSwift < end, chars[afterSwift] == "." else { return nil }
+      i = skipTrivia(chars, from: afterSwift + 1, limit: end)
     }
-    return nil
+    guard matchesKeyword(chars, at: i, "Optional", limit: end) else { return nil }
+    let afterName = skipTrivia(chars, from: i + 8, limit: end)
+    guard afterName < end, chars[afterName] == "<" else { return nil }
+    return afterName
   }
 
   /// The last `>` before the type ends (at `=`, or at `to`). The `>` of an `->`

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
@@ -359,10 +359,44 @@ enum RouterCeilingParser {
     return false
   }
 
-  /// The trailing token is `@Name` — no argument list, since a `)` ending would
-  /// already have been consumed as part of the attribute's arguments and cannot
-  /// be distinguished here from a completed type.
+  /// The line's last token is an attribute, in EITHER of the two forms Swift
+  /// allows: bare `@MainActor`, or parameterised `@isolated(any)` /
+  /// `@convention(c)` / `@available(macOS 26, *)`.
+  ///
+  /// The parameterised form was missed when this rule was introduced, on the
+  /// stated reasoning that a `)` ending "cannot be distinguished here from a
+  /// completed type" (cloud review, PR #2070, round eight). It can: scan back
+  /// from the final `)` to its matching `(` and require an attribute NAME
+  /// immediately before it. `let wrapped: (AlphaDep)` finds `:` there and is
+  /// correctly left alone, which the existing over-fold controls pin.
+  ///
+  /// Those two forms are the whole grammar for an attribute, so this closes the
+  /// case rather than adding the next instance of it.
   private static func endsWithAttribute(_ trimmed: String) -> Bool {
+    let chars = Array(trimmed)
+    guard let last = chars.last else { return false }
+    if last == ")" {
+      var depth = 0
+      var i = chars.count - 1
+      var openIndex: Int?
+      while i >= 0 {
+        if chars[i] == ")" { depth += 1 }
+        if chars[i] == "(" {
+          depth -= 1
+          if depth == 0 {
+            openIndex = i
+            break
+          }
+        }
+        i -= 1
+      }
+      // The argument list is adjacent to the name, so the identifier runs right
+      // up to `(` and must be introduced by `@`.
+      guard let open = openIndex, open > 0 else { return false }
+      var j = open - 1
+      while j >= 0, chars[j].isLetter || chars[j].isNumber || chars[j] == "_" { j -= 1 }
+      return j >= 0 && chars[j] == "@" && j < open - 1
+    }
     guard let lastToken = trimmed.split(whereSeparator: { $0.isWhitespace }).last
     else { return false }
     guard lastToken.hasPrefix("@"), lastToken.count > 1 else { return false }

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
@@ -344,7 +344,29 @@ enum RouterCeilingParser {
     if let last = trimmed.last, last == ":" || last == "," || last == "&" {
       return true
     }
+    // A buffer whose last token is an ATTRIBUTE is incomplete by definition —
+    // `@MainActor` cannot end a declaration, so the type it modifies is on the
+    // next line (cloud review, PR #2070):
+    //
+    //     let dependency: @MainActor
+    //       () -> Void
+    //
+    // Handled here rather than by teaching the lookahead to accept a leading
+    // `(`, because "the next line starts with `(`" is also true of an ordinary
+    // following declaration and would over-fold. "This line ended on an
+    // attribute" is unambiguous.
+    if endsWithAttribute(trimmed) { return true }
     return false
+  }
+
+  /// The trailing token is `@Name` — no argument list, since a `)` ending would
+  /// already have been consumed as part of the attribute's arguments and cannot
+  /// be distinguished here from a completed type.
+  private static func endsWithAttribute(_ trimmed: String) -> Bool {
+    guard let lastToken = trimmed.split(whereSeparator: { $0.isWhitespace }).last
+    else { return false }
+    guard lastToken.hasPrefix("@"), lastToken.count > 1 else { return false }
+    return lastToken.dropFirst().allSatisfy { $0.isLetter || $0.isNumber || $0 == "_" }
   }
 
   /// Returns `buffer` with string-literal contents and `//` line comments
@@ -565,56 +587,78 @@ enum RouterCeilingParser {
   /// makes it optional and unbounded everywhere Swift allows it — the property
   /// the previous pattern kept failing one shape at a time. Comments are already
   /// blanked to spaces by the caller's code view, so they are trivia here too.
-  private static func closureSignatureFollows(_ chars: [Character], from start: Int) -> Bool {
-    var i = skipTrivia(chars, from: start)
-    while i < chars.count, chars[i] == "@" {
+  /// `limit` bounds the scan so a recursive call cannot read past the group it
+  /// was handed. `depth` bounds the recursion itself.
+  private static func closureSignatureFollows(
+    _ chars: [Character], from start: Int, limit: Int? = nil, depth: Int = 0
+  ) -> Bool {
+    let end = min(limit ?? chars.count, chars.count)
+    guard depth <= 8 else { return false }
+    var i = skipTrivia(chars, from: start, limit: end)
+    while i < end, chars[i] == "@" {
       i += 1
-      while i < chars.count, chars[i].isLetter || chars[i].isNumber || chars[i] == "_" { i += 1 }
+      while i < end, chars[i].isLetter || chars[i].isNumber || chars[i] == "_" { i += 1 }
       // An attribute's argument list is ADJACENT to its name — `@available(macOS
       // 26, *)`. Skipping trivia before this check would consume the FUNCTION
       // TYPE's own parameter list in `@MainActor (Int) -> Bool`, where the paren
       // is separated by a space and belongs to the type, not the attribute.
-      if i < chars.count, chars[i] == "(" {
-        guard let close = matchingParen(chars, open: i) else { return false }
+      if i < end, chars[i] == "(" {
+        guard let close = matchingParen(chars, open: i, limit: end) else { return false }
         i = close + 1
       }
-      i = skipTrivia(chars, from: i)
+      i = skipTrivia(chars, from: i, limit: end)
     }
-    guard i < chars.count, chars[i] == "(", let close = matchingParen(chars, open: i)
+    guard i < end, chars[i] == "(", let close = matchingParen(chars, open: i, limit: end)
     else { return false }
-    i = skipTrivia(chars, from: close + 1)
+    let afterGroup = skipTrivia(chars, from: close + 1, limit: end)
+    // An OPTIONAL function type parenthesises the WHOLE type: `(() -> Void)?`.
+    // Read as a parameter list, the outer group swallows the signature and the
+    // `?` that follows is not an arrow, so the property fell to COLLABORATOR
+    // (cloud review, PR #2070). When the arrow does not follow the group, scan
+    // INSIDE it as a type instead. `(AlphaDep)` and `(AlphaDep, BetaDep)` fail
+    // both paths and stay collaborators, which the controls pin.
+    let arrowFollowsGroup =
+      afterGroup + 1 < end && chars[afterGroup] == "-" && chars[afterGroup + 1] == ">"
+    if !arrowFollowsGroup,
+      closureSignatureFollows(chars, from: i + 1, limit: close, depth: depth + 1)
+    {
+      return true
+    }
+    i = afterGroup
     while true {
-      if matchesKeyword(chars, at: i, "async") {
-        i = skipTrivia(chars, from: i + 5)
-      } else if matchesKeyword(chars, at: i, "rethrows") {
-        i = skipTrivia(chars, from: i + 8)
-      } else if matchesKeyword(chars, at: i, "throws") {
-        i = skipTrivia(chars, from: i + 6)
+      if matchesKeyword(chars, at: i, "async", limit: end) {
+        i = skipTrivia(chars, from: i + 5, limit: end)
+      } else if matchesKeyword(chars, at: i, "rethrows", limit: end) {
+        i = skipTrivia(chars, from: i + 8, limit: end)
+      } else if matchesKeyword(chars, at: i, "throws", limit: end) {
+        i = skipTrivia(chars, from: i + 6, limit: end)
         // Typed throws, to any nesting depth: `throws(Failure<(Int, String)>)`.
-        if i < chars.count, chars[i] == "(" {
-          guard let errorClose = matchingParen(chars, open: i) else { return false }
-          i = skipTrivia(chars, from: errorClose + 1)
+        if i < end, chars[i] == "(" {
+          guard let errorClose = matchingParen(chars, open: i, limit: end) else { return false }
+          i = skipTrivia(chars, from: errorClose + 1, limit: end)
         }
       } else {
         break
       }
     }
-    return i + 1 < chars.count && chars[i] == "-" && chars[i + 1] == ">"
+    return i + 1 < end && chars[i] == "-" && chars[i + 1] == ">"
   }
 
-  private static func skipTrivia(_ chars: [Character], from i: Int) -> Int {
+  private static func skipTrivia(_ chars: [Character], from i: Int, limit: Int? = nil) -> Int {
+    let end = min(limit ?? chars.count, chars.count)
     var j = i
-    while j < chars.count, chars[j].isWhitespace { j += 1 }
+    while j < end, chars[j].isWhitespace { j += 1 }
     return j
   }
 
   /// Index of the `)` closing the `(` at `open`, or `nil` if unbalanced. The
   /// caller passes a code view, so parens inside comments and string literals
   /// are already spaces and cannot skew the depth.
-  private static func matchingParen(_ chars: [Character], open: Int) -> Int? {
+  private static func matchingParen(_ chars: [Character], open: Int, limit: Int? = nil) -> Int? {
+    let end = min(limit ?? chars.count, chars.count)
     var depth = 0
     var i = open
-    while i < chars.count {
+    while i < end {
       if chars[i] == "(" { depth += 1 }
       if chars[i] == ")" {
         depth -= 1
@@ -627,12 +671,15 @@ enum RouterCeilingParser {
 
   /// `word` appears at `i` and is not merely the prefix of a longer identifier,
   /// so a type named `asyncResult` is never read as the `async` specifier.
-  private static func matchesKeyword(_ chars: [Character], at i: Int, _ word: String) -> Bool {
+  private static func matchesKeyword(
+    _ chars: [Character], at i: Int, _ word: String, limit: Int? = nil
+  ) -> Bool {
+    let end = min(limit ?? chars.count, chars.count)
     let expected = Array(word)
-    guard i >= 0, i + expected.count <= chars.count else { return false }
+    guard i >= 0, i + expected.count <= end else { return false }
     for k in 0..<expected.count where chars[i + k] != expected[k] { return false }
     let after = i + expected.count
-    guard after < chars.count else { return true }
+    guard after < end else { return true }
     let next = chars[after]
     return !(next.isLetter || next.isNumber || next == "_")
   }

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
@@ -112,14 +112,21 @@ enum RouterCeilingParser {
       .count
   }
 
+  /// Every module imported by `source`, including imports behind `#if`.
+  ///
+  /// Walked with a `SyntaxVisitor` rather than by iterating `tree.statements`,
+  /// because a `#if` block arrives as ONE statement of kind `IfConfigDeclSyntax`
+  /// and an import inside it is invisible to a hand-written loop. The generated
+  /// `visitChildren` descends into every child unconditionally, so conditional
+  /// compilation needs no case of its own here (cloud review, PR #2070 — the
+  /// THIRD site of this one mistake in this file).
+  ///
+  /// Depth does not matter for imports, which is what makes the visitor usable.
+  /// `members(in:)` cannot do this: it must count only members declared DIRECTLY
+  /// in the class body, and a visitor would happily descend into nested types.
+  /// That is the only hand-written list walk left in this file.
   static func imports(in source: String) -> Set<String> {
-    let tree = Parser.parse(source: source)
-    var found: Set<String> = []
-    for statement in tree.statements {
-      guard let importDecl = statement.item.as(ImportDeclSyntax.self) else { continue }
-      if let first = importDecl.path.first { found.insert(first.name.text) }
-    }
-    return found
+    ImportFinder.modules(in: Parser.parse(source: source))
   }
 
   /// Range of the first occurrence of `statement` in `body`, located over the
@@ -364,7 +371,14 @@ enum RouterCeilingParser {
     let arguments: GenericArgumentListSyntax?
     if let identifier = type.as(IdentifierTypeSyntax.self), identifier.name.text == "Optional" {
       arguments = identifier.genericArgumentClause?.arguments
-    } else if let member = type.as(MemberTypeSyntax.self), member.name.text == "Optional" {
+    } else if let member = type.as(MemberTypeSyntax.self), member.name.text == "Optional",
+      member.baseType.as(IdentifierTypeSyntax.self)?.name.text == "Swift"
+    {
+      // Qualified only as `Swift.Optional`. Any other base — a project or
+      // dependency type that happens to nest a generic named `Optional`, such
+      // as `Box.Optional<() -> Void>` — is a DIFFERENT type, and unwrapping it
+      // would reclassify a collaborator as a closure on the strength of a name
+      // match alone (cloud review, PR #2070).
       arguments = member.genericArgumentClause?.arguments
     } else {
       return nil
@@ -415,6 +429,21 @@ enum RouterCeilingParser {
         return .skipChildren
       }
       return .visitChildren
+    }
+  }
+
+  private final class ImportFinder: SyntaxVisitor {
+    var found: Set<String> = []
+
+    static func modules(in tree: SourceFileSyntax) -> Set<String> {
+      let finder = ImportFinder(viewMode: .sourceAccurate)
+      finder.walk(tree)
+      return finder.found
+    }
+
+    override func visit(_ node: ImportDeclSyntax) -> SyntaxVisitorContinueKind {
+      if let first = node.path.first { found.insert(first.name.text) }
+      return .skipChildren
     }
   }
 

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
@@ -19,6 +19,35 @@ import Testing
 /// first inner method/init brace. A continuation-line fold (`foldContinuationLines`)
 /// joins a declaration whose type annotation wraps across physical lines, so a
 /// multi-line closure-typed `let` classifies correctly. Fixed in #808.
+///
+/// # Known limits
+///
+/// This is a source approximation of Swift's type grammar, not a Swift parser.
+/// PR #2070's review surfaced these three, each verified valid Swift with
+/// `swiftc -typecheck` and each measured for reachability before being left
+/// open. All three fail toward UNDERCOUNTING closures, so a ceiling silently
+/// reads low rather than raising a false alarm — write any of these forms in a
+/// ceiling-tested home and the freeze will not see it.
+///
+///   1. An attribute whose ARGUMENTS contain nested parens
+///      (`@Attr(Foo<(A, B)>)`). Three regexes still use a non-balancing
+///      `(\([^)]*\))?` for attribute argument lists. Measured: zero attributes
+///      with nested-paren arguments in `Sources/`.
+///   2. MULTI-BINDING declarations (`let a: () -> Void, b: () -> Void`) count
+///      once, and a declaration mixing a closure with a collaborator cannot be
+///      split, because the counter takes a per-line `(String) -> Bool`.
+///      Measured: zero, with a bracket-stripping detector and a two-way control.
+///   3. A GENERIC WRAPPER split across lines after its name (`let x: Optional`
+///      / newline / `<() -> Void>`). The fold joins on effect specifiers and
+///      unterminated brackets, not on a bare type name. Measured: zero uses of
+///      `Optional<` in `Sources/` in any spelling, so this is a line-break
+///      variant of a form the codebase does not write at all.
+///
+/// Each was left open under `validation-discipline.md` RULE:
+/// validate-automated-review-findings, which fixes an unreachable finding only
+/// when the fix is trivial. Closing (1) means balancing brackets in three
+/// regexes, (2) changes what the ceiling COUNTS, and (3) needs the fold to join
+/// on an identifier — which would fold `let a: Foo` into whatever follows it.
 enum RouterCeilingParser {
 
   static func classBody(named typeName: String, at path: String) throws -> String {

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
@@ -261,6 +261,8 @@ enum RouterCeilingParser {
     if trimmed.hasPrefix("->") { return true }
     for keyword in ["async", "throws", "rethrows"] where trimmed == keyword
       || trimmed.hasPrefix(keyword + " ") || trimmed.hasPrefix(keyword + "-")
+      // `throws(MyError) -> ...` wrapping onto its own line.
+      || trimmed.hasPrefix(keyword + "(")
     {
       return true
     }
@@ -466,9 +468,14 @@ enum RouterCeilingParser {
     // `closureInjectedCount` read 8 against 10 closure-typed `let`s, the two
     // missing ones being `makeRecoveryDirective` and
     // `ensureSelectedReadyForPress`, both `async`.
+    // `throws` may carry a typed-throws clause on this Swift 6 target
+    // (`() throws(MyError) -> Void`), so the error type is part of the specifier
+    // (cloud review, PR #2070).
     line.range(
       of:
-        #":[[:space:]]*(@[A-Za-z]+[[:space:]]+)*\([^)]*\)([[:space:]]+(async|throws|rethrows))*[[:space:]]*->[[:space:]]"#,
+        #":[[:space:]]*(@[A-Za-z]+[[:space:]]+)*\([^)]*\)"#
+        + #"([[:space:]]+(async|rethrows|throws([[:space:]]*\([^)]*\))?))*"#
+        + #"[[:space:]]*->[[:space:]]"#,
       options: .regularExpression) != nil
   }
 

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
@@ -699,6 +699,19 @@ enum RouterCeilingParser {
       }
       i = skipTrivia(chars, from: i, limit: end)
     }
+    // The GENERIC optional spelling wraps the whole type exactly as `( … )?`
+    // does: `Optional<() -> Void>` is `(() -> Void)?` desugared (cloud review,
+    // PR #2070, round thirteen). Matched by prefix and closed at the LAST `>`
+    // of the type rather than by balancing `<>`, because a bracket counter has
+    // to special-case the `>` in `->` — the exact ambiguity that already put a
+    // blind spot in `containsTopLevelComma` two rounds ago. The recursion
+    // carries the same whole-type guards, so `Optional<(() -> Void, AlphaDep)>`
+    // still fails the tuple test.
+    if let angleOpen = optionalGenericOpen(chars, at: i, limit: end),
+      let angleClose = lastAngleBracket(chars, from: angleOpen + 1, to: end)
+    {
+      return closureSignatureFollows(chars, from: angleOpen + 1, limit: angleClose)
+    }
     guard i < end, chars[i] == "(", let close = matchingParen(chars, open: i, limit: end)
     else { return false }
     let afterGroup = skipTrivia(chars, from: close + 1, limit: end)
@@ -753,6 +766,38 @@ enum RouterCeilingParser {
   /// the comma in `Result<Int, Error>` is not mistaken for a tuple separator;
   /// `<`/`>` are ambiguous with comparison in general Swift, but inside a type
   /// annotation they are generic delimiters.
+  /// Index of the `<` that opens a generic `Optional<…>` / `Swift.Optional<…>`
+  /// beginning at `at`, or `nil` when the type does not start with one.
+  private static func optionalGenericOpen(_ chars: [Character], at: Int, limit: Int) -> Int? {
+    let end = min(limit, chars.count)
+    for prefix in ["Optional<", "Swift.Optional<"] {
+      let expected = Array(prefix)
+      guard at >= 0, at + expected.count <= end else { continue }
+      var matches = true
+      for k in 0..<expected.count where chars[at + k] != expected[k] {
+        matches = false
+        break
+      }
+      if matches { return at + expected.count - 1 }
+    }
+    return nil
+  }
+
+  /// The last `>` before the type ends (at `=`, or at `to`). The `>` of an `->`
+  /// is skipped, so `Optional<() -> Void>` closes on its own bracket and not on
+  /// the arrow inside it.
+  private static func lastAngleBracket(_ chars: [Character], from: Int, to: Int) -> Int? {
+    let end = min(to, chars.count)
+    var last: Int?
+    var i = from
+    while i < end {
+      if chars[i] == "=" { break }
+      if chars[i] == ">", !(i > 0 && chars[i - 1] == "-") { last = i }
+      i += 1
+    }
+    return last
+  }
+
   /// Everything after a wrapping group is an optional marker (or an initializer,
   /// which ends the TYPE). `(() -> Void)?` and `(() -> Void)!` still describe a
   /// closure; `(() -> Void).Type` describes a metatype and must not be claimed

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
@@ -615,8 +615,24 @@ enum RouterCeilingParser {
 
   private static let storedPropertyPattern: String = {
     let attrs = #"(@[A-Za-z_][A-Za-z0-9_]*(\([^)]*\))?[[:space:]]+)*"#
-    let access = #"(public|internal|private|fileprivate|package|open)?"#
-    return "^[[:space:]]*\(attrs)\(access)[[:space:]]*let[[:space:]]+[A-Za-z_]"
+    // `nonisolated` is an isolation modifier on an INSTANCE property, so a
+    // `nonisolated let` seam is a collaborator like any other and must be
+    // counted (cloud review, PR #2070, round eighteen). Swift accepts it on
+    // either side of access control and in the `nonisolated(unsafe)` form, all
+    // verified with `swiftc -typecheck`, so one repeating alternation covers
+    // every ordering rather than enumerating the pairings.
+    //
+    // This was an oversight rather than a decision: `nonPrivateMethodPattern`
+    // below has always carried `nonisolated`, so the METHOD side already knew
+    // the modifier occurs here — 27 files use it at top level — while the
+    // property side was never updated to match. The twin is the evidence.
+    //
+    // `static` stays OUT deliberately: a type property is not an injected
+    // instance collaborator, and admitting it would change what the ceiling
+    // counts rather than fix what it reads.
+    let modifiers =
+      #"((public|internal|private|fileprivate|package|open|nonisolated(\(unsafe\))?)[[:space:]]+)*"#
+    return "^[[:space:]]*\(attrs)\(modifiers)let[[:space:]]+[A-Za-z_]"
   }()
 
   private static func isStoredPropertyDeclaration(_ line: String) -> Bool {

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
@@ -1,4 +1,6 @@
 import Foundation
+import SwiftParser
+import SwiftSyntax
 import Testing
 
 /// PR8 of #763 — strict source parser for `*EventRouter` / `WedgeRecoveryRouter`
@@ -10,1004 +12,398 @@ import Testing
 /// mutable state, lazy properties, setter-injected outlets, callback closures)
 /// are NOT collaborators and are excluded.
 ///
-/// `let` stored properties at brace-depth 0 are sub-binned into:
+/// `let` stored properties declared directly in the class body are sub-binned:
 ///   - collaborator slot: non-primitive, non-closure, non-NSObjectProtocol
 ///   - closure-injected slot: typed as `(...) -> ...`
 ///
-/// `classBody` anchors the brace-balanced scan on the class declaration's OWN
-/// `{` (found by scanning forward from the start of `final class`), not the
-/// first inner method/init brace. A continuation-line fold (`foldContinuationLines`)
-/// joins a declaration whose type annotation wraps across physical lines, so a
-/// multi-line closure-typed `let` classifies correctly. Fixed in #808.
+/// # Why this reads a syntax tree instead of text
 ///
-/// # Known limits
+/// This was 1013 lines of regex and character scanning that approximated
+/// Swift's type grammar. PR #2070's review found TEN genuine defects in it over
+/// twenty rounds, every one the same shape: a valid Swift spelling the
+/// approximation did not recognise. Block-comment state, `async` and
+/// typed-throws effect specifiers, optional and generic-wrapped function types,
+/// function metatypes, tuples containing a closure, dictionaries of closures,
+/// attribute argument lists, the `nonisolated` / `final` / `dynamic` /
+/// `unowned` modifiers, multi-line wrapping. Each fix was proven red-then-green
+/// and each was followed by another.
 ///
-/// This is a source approximation of Swift's type grammar, not a Swift parser.
-/// PR #2070's review surfaced these three, each verified valid Swift with
-/// `swiftc -typecheck` and each measured for reachability before being left
-/// open. All three fail toward UNDERCOUNTING closures, so a ceiling silently
-/// reads low rather than raising a false alarm — write any of these forms in a
-/// ceiling-tested home and the freeze will not see it.
+/// That is not bad luck, it is the price of approximating a real grammar.
+/// `SwiftParser` IS the grammar, so the class stops existing: a wrapped
+/// optional closure is an `OptionalTypeSyntax` around a `FunctionTypeSyntax`
+/// whether it was written `(() -> Void)?`, `Optional<() -> Void>`, or split
+/// across four lines with a comment in the middle. There is nothing left to
+/// spell differently.
 ///
-///   1. An attribute whose ARGUMENTS contain nested parens
-///      (`@Attr(Foo<(A, B)>)`). Three regexes still use a non-balancing
-///      `(\([^)]*\))?` for attribute argument lists. Measured: zero attributes
-///      with nested-paren arguments in `Sources/`.
-///   2. MULTI-BINDING declarations (`let a: () -> Void, b: () -> Void`) count
-///      once, and a declaration mixing a closure with a collaborator cannot be
-///      split, because the counter takes a per-line `(String) -> Bool`.
-///      Measured: zero, with a bracket-stripping detector and a two-way control.
-///   3. A GENERIC WRAPPER split across lines after its name (`let x: Optional`
-///      / newline / `<() -> Void>`). The fold joins on effect specifiers and
-///      unterminated brackets, not on a bare type name. Measured: zero uses of
-///      `Optional<` in `Sources/` in any spelling, so this is a line-break
-///      variant of a form the codebase does not write at all.
+/// The dependency was already here. `Package.swift` adds `SwiftParser` and
+/// `SwiftSyntax` to THIS test target for `EngineMutationInventoryFreezeTests`,
+/// whose manifest comment reads "real Swift parser (replaces its hand-rolled
+/// comment/string scanner)" — the same migration, already made once, in the
+/// same directory. `EngineProtocolSurfaceFreezeTests` is the second user and
+/// the model this file follows, including its fail-closed posture.
 ///
-/// Each was left open under `validation-discipline.md` RULE:
-/// validate-automated-review-findings, which fixes an unreachable finding only
-/// when the fix is trivial. Closing (1) means balancing brackets in three
-/// regexes, (2) changes what the ceiling COUNTS, and (3) needs the fold to join
-/// on an identifier — which would fold `let a: Foo` into whatever follows it.
+/// # Fail closed, never plausibly zero
+///
+/// A ceiling that reads LOW passes forever without complaining. So a source
+/// file that does not parse, or a requested class that is not found, throws.
+/// The one thing this must never do is return a confident small number.
 enum RouterCeilingParser {
 
+  struct ScanFailure: Error, CustomStringConvertible {
+    let context: String
+    let reason: String
+    var description: String { "\(context): \(reason)" }
+  }
+
+  // MARK: - Source extraction
+
+  /// The member text of `typeName`'s class body, sliced from the real source.
+  /// Returned as text because every consumer and all 52 regression tests take a
+  /// body string; the counters re-parse it rather than re-scan it.
   static func classBody(named typeName: String, at path: String) throws -> String {
     let source = try String(contentsOf: RepoRoot.sourceURL(path), encoding: .utf8)
-    // Search the declaration AND balance the body braces over a CODE VIEW
-    // (string-literal contents + `//` comments blanked to spaces, length
-    // preserved), so a `final class X {` or a stray `{`/`}` inside a comment or
-    // string literal cannot mis-anchor the declaration or unbalance the scan
-    // (#826). `codeView` preserves Character count 1:1, so an offset into the
-    // code view is the same offset into the real source; the body is sliced
-    // from the REAL source because the per-line property/method classifiers
-    // (`isStoredPropertyDeclaration`, `isClosureTyped`, ...) parse the real
-    // declaration text (type names, attributes, default values) — only the
-    // fold's continuation check masks comments/strings internally via `codeView`.
-    //
-    // `blankBlockComments: true` matches the sibling `functionBody` below, which
-    // has always passed it. This call did not, so a `}` inside a `/* ... */`
-    // closes the class body early and every declaration after the comment falls
-    // outside the returned body — a ceiling reading BELOW the truth, which is
-    // the direction that passes silently forever. One complete contiguous buffer
-    // in one pass is exactly the condition the flag requires.
-    //
-    // LATENT, not active: at the time of this fix `git grep -n '/\*' --
-    // 'Sources/**/*.swift'` returns exactly one hit (`EmojiFormatter.swift:410`,
-    // inline and brace-free), and no ceiling-tested class contains a block
-    // comment at all. No ceiling is mis-read TODAY. This closes the trap before
-    // the first brace-carrying block comment lands, because nothing about
-    // writing one would look dangerous.
-    let code = codeView(source, blankBlockComments: true)
-    let sourceChars = Array(source)
-    let codeChars = Array(code)  // same Character count as sourceChars
-    let declarations = [
-      "final class \(typeName) {",
-      "final class \(typeName):",
-      "class \(typeName) {",
-      "class \(typeName):",
-    ]
-    guard
-      let declOffset =
-        declarations
-        .compactMap({ code.range(of: $0) })
-        .map({ code.distance(from: code.startIndex, to: $0.lowerBound) })
-        .min()
-    else {
+    let tree = try parsed(source, context: "\(typeName) at \(path)")
+    guard let decl = ClassFinder.find(named: typeName, in: tree) else {
       Issue.record("\(typeName) declaration not found at \(path)")
-      throw POSIXError(.ENOENT)
+      throw ScanFailure(context: typeName, reason: "no class declaration named \(typeName)")
     }
-    // The class's OWN `{`: the first brace at or after the declaration start, in
-    // the code view (so a brace inside a comment/string between the declaration
-    // and the class body is never mistaken for it). Between the declaration
-    // start and the class brace the code holds only the type name and an
-    // optional `: Conformance, ...` list — never a real `{`.
-    guard let openBrace = (declOffset..<codeChars.count).first(where: { codeChars[$0] == "{" })
-    else {
-      Issue.record("\(typeName) declaration has no opening brace")
-      throw POSIXError(.EILSEQ)
-    }
-    var depth = 0
-    var idx = openBrace
-    while idx < codeChars.count {
-      let c = codeChars[idx]
-      if c == "{" { depth += 1 }
-      if c == "}" {
-        depth -= 1
-        if depth == 0 {
-          return String(sourceChars[(openBrace + 1)..<idx])
-        }
-      }
-      idx += 1
-    }
-    Issue.record("\(typeName) class body has unbalanced braces")
-    throw POSIXError(.EILSEQ)
+    return decl.memberBlock.members.description
   }
 
-  /// Returns the body of the FIRST function/method named `functionName` in
-  /// the file at `path`. Same anchoring approach as `classBody`: the
-  /// declaration is located and brace-balanced over the `codeView` (so a
-  /// commented-out or string-quoted declaration/brace can't mis-anchor the
-  /// scan), and the returned body is sliced from the real source text.
+  /// The body of the FIRST function/method named `functionName` in the file.
   static func functionBody(named functionName: String, at path: String) throws -> String {
     let source = try String(contentsOf: RepoRoot.sourceURL(path), encoding: .utf8)
-    let code = codeView(source, blankBlockComments: true)
-    let sourceChars = Array(source)
-    let codeChars = Array(code)  // same Character count as sourceChars
-    let pattern =
-      #"^[[:space:]]*(?:(?:private|fileprivate|internal|package|public|open|"#
-      + #"static|class|nonisolated|mutating|nonmutating|override|final|required|"#
-      + #"convenience)[[:space:]]+)*func[[:space:]]+"#
-      + NSRegularExpression.escapedPattern(for: functionName)
-      + #"[[:space:]]*\("#
-    let regex = try NSRegularExpression(pattern: pattern, options: [.anchorsMatchLines])
-    let codeRange = NSRange(code.startIndex..<code.endIndex, in: code)
-    guard
-      let match = regex.firstMatch(in: code, range: codeRange),
-      let declRange = Range(match.range, in: code)
-    else {
+    let tree = try parsed(source, context: "\(functionName) at \(path)")
+    guard let fn = FunctionFinder.find(named: functionName, in: tree) else {
       Issue.record("\(functionName) function declaration not found at \(path)")
-      throw POSIXError(.ENOENT)
+      throw ScanFailure(context: functionName, reason: "no function named \(functionName)")
     }
-    let declOffset = code.distance(from: code.startIndex, to: declRange.upperBound)
-    guard let openBrace = (declOffset..<codeChars.count).first(where: { codeChars[$0] == "{" })
-    else {
-      Issue.record("Function declaration for \(functionName) has no opening brace")
-      throw POSIXError(.EILSEQ)
+    guard let body = fn.body else {
+      Issue.record("Function \(functionName) at \(path) has no body")
+      throw ScanFailure(context: functionName, reason: "declaration has no body")
     }
-    var depth = 0
-    var idx = openBrace
-    while idx < codeChars.count {
-      let c = codeChars[idx]
-      if c == "{" { depth += 1 }
-      if c == "}" {
-        depth -= 1
-        if depth == 0 {
-          return String(sourceChars[(openBrace + 1)..<idx])
-        }
-      }
-      idx += 1
-    }
-    Issue.record("Function body for \(functionName) has unbalanced braces")
-    throw POSIXError(.EILSEQ)
+    return body.statements.description
   }
+
+  // MARK: - Counting
 
   /// Collaborator slot: non-primitive non-closure non-NSObjectProtocol `let`
-  /// stored properties at brace-depth 0 inside the class body.
+  /// stored properties declared directly in the class body.
   static func collaboratorCount(in body: String) -> Int {
-    countTopLevelStoredProperties(in: body) { line in
-      !isPrimitiveTyped(line) && !isClosureTyped(line) && !isNSObjectProtocolTyped(line)
-    }
+    storedLetBindings(in: body).filter { binding in
+      guard let type = binding.type else { return !binding.isBooleanLiteralInitialized }
+      return !isPrimitive(type) && !isFunctionType(type) && !isNSObjectProtocol(type)
+    }.count
   }
 
-  /// Closure-injected slot: instance `let` whose declared type is a closure
-  /// (`(...) -> ...`) at brace-depth 0.
+  /// Closure-injected slot: `let` whose declared type is a function type,
+  /// including every wrapping Swift permits around one.
   static func closureInjectedCount(in body: String) -> Int {
-    countTopLevelStoredProperties(in: body) { line in isClosureTyped(line) }
+    storedLetBindings(in: body).filter { binding in
+      guard let type = binding.type else { return false }
+      return isFunctionType(type)
+    }.count
   }
 
-  /// Non-private `func` declarations at brace-depth 0.
+  /// Non-private `func` declarations declared directly in the class body.
   static func nonPrivateMethodCount(in body: String) -> Int {
-    var depth = 0
-    var count = 0
-    for line in foldContinuationLines(body) {
-      let (opens, closes) = braceCounts(line)
-      let depthForThisLine = depth - max(0, closes - opens)
-      if depthForThisLine == 0, isNonPrivateMethodDeclaration(line) {
-        count += 1
-      }
-      depth += opens - closes
-    }
-    return count
+    members(in: body).compactMap { $0.decl.as(FunctionDeclSyntax.self) }
+      .filter { !isPrivate($0.modifiers) }
+      .count
   }
 
   static func imports(in source: String) -> Set<String> {
-    var result: Set<String> = []
-    let pattern = #"^[[:space:]]*import[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)"#
-    let regex = try? NSRegularExpression(pattern: pattern, options: [.anchorsMatchLines])
-    let ns = source as NSString
-    regex?.enumerateMatches(
-      in: source, options: [],
-      range: NSRange(location: 0, length: ns.length)
-    ) { match, _, _ in
-      guard let m = match, m.numberOfRanges > 1 else { return }
-      result.insert(ns.substring(with: m.range(at: 1)))
+    let tree = Parser.parse(source: source)
+    var found: Set<String> = []
+    for statement in tree.statements {
+      guard let importDecl = statement.item.as(ImportDeclSyntax.self) else { continue }
+      if let first = importDecl.path.first { found.insert(first.name.text) }
     }
-    return result
+    return found
+  }
+
+  /// Range of the first occurrence of `statement` in `body`, located over the
+  /// syntax tree so a commented-out or string-quoted occurrence cannot match,
+  /// but returned as an index into the REAL `body` text for the caller to slice
+  /// (#1634).
+  static func rangeOfStatement(_ statement: String, in body: String) -> Range<String.Index>? {
+    let needle = statement.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !needle.isEmpty else { return nil }
+    guard let offset = firstCodeOffset(of: needle, in: body) else { return nil }
+    // SwiftSyntax positions are UTF-8 byte offsets; `String.Index` takes UTF-16.
+    // Converting through the UTF-8 view keeps the two in the same unit rather
+    // than assuming they agree, which they do not for any non-ASCII source.
+    let utf8 = body.utf8
+    guard
+      let startUTF8 = utf8.index(utf8.startIndex, offsetBy: offset, limitedBy: utf8.endIndex),
+      let endUTF8 = utf8.index(startUTF8, offsetBy: needle.utf8.count, limitedBy: utf8.endIndex),
+      let start = String.Index(startUTF8, within: body),
+      let end = String.Index(endUTF8, within: body)
+    else { return nil }
+    return start..<end
+  }
+
+  /// UTF-8 offset of the first occurrence of `needle` in REAL CODE — comments
+  /// and string-literal contents masked out first, so a commented-out or quoted
+  /// occurrence cannot match (#1634).
+  ///
+  /// A SUBSTRING search, not a node match. Callers pass fragments such as
+  /// `"assertionFailure("`, which is not a whole syntax node and never equals
+  /// one; an exact-node implementation returned nil for every real call site and
+  /// was caught only by the full suite. The tree supplies the mask; the search
+  /// itself stays textual because the question is textual.
+  ///
+  /// Masking is done on BYTES and the result is used only as a byte offset.
+  /// Blanking a multi-byte character byte-by-byte would change the Character
+  /// count and silently misalign a `String.Index` computed from it.
+  private static func firstCodeOffset(of needle: String, in body: String) -> Int? {
+    var bytes = Array(body.utf8)
+    let space = UInt8(ascii: " ")
+    let newline = UInt8(ascii: "\n")
+
+    func blank(from start: Int, length: Int) {
+      var i = start
+      let end = min(start + length, bytes.count)
+      while i < end {
+        if bytes[i] != newline { bytes[i] = space }
+        i += 1
+      }
+    }
+
+    for token in Parser.parse(source: body).tokens(viewMode: .sourceAccurate) {
+      var position = token.position.utf8Offset
+      for piece in token.leadingTrivia {
+        let length = piece.sourceLength.utf8Length
+        if piece.isComment { blank(from: position, length: length) }
+        position += length
+      }
+      // `.stringSegment` carries the segment text, so it is matched as a
+      // pattern rather than compared with `==`.
+      if case .stringSegment = token.tokenKind {
+        blank(
+          from: token.positionAfterSkippingLeadingTrivia.utf8Offset,
+          length: token.trimmedLength.utf8Length)
+      }
+      var trailing = token.endPositionBeforeTrailingTrivia.utf8Offset
+      for piece in token.trailingTrivia {
+        let length = piece.sourceLength.utf8Length
+        if piece.isComment { blank(from: trailing, length: length) }
+        trailing += length
+      }
+    }
+
+    let target = Array(needle.utf8)
+    guard !target.isEmpty, bytes.count >= target.count else { return nil }
+    for start in 0...(bytes.count - target.count) {
+      if Array(bytes[start..<(start + target.count)]) == target { return start }
+    }
+    return nil
   }
 
   // MARK: - Private
 
-  /// Net `{` / `}` counts for a line, measured on its CODE VIEW so a brace
-  /// inside a string literal or `//` comment does not shift brace depth. Every
-  /// depth-tracking loop below uses this, not raw `filter`, so a `}` in a
-  /// string/comment can neither drop a real declaration below depth 0 nor close
-  /// a scope early (#826).
-  private static func braceCounts(_ line: String) -> (opens: Int, closes: Int) {
-    let code = codeView(line)
-    return (code.filter { $0 == "{" }.count, code.filter { $0 == "}" }.count)
-  }
-
-  /// KNOWN LIMIT, recorded rather than fixed (cloud review, PR #2070, round
-  /// fifteen). This counts DECLARATIONS, not bindings, so a multi-binding
-  /// declaration — `let first: () -> Void, second: () -> Void`, which Swift
-  /// accepts — contributes one, and a declaration mixing a closure with a
-  /// collaborator cannot be split at all, because `predicate` answers per LINE
-  /// and returns a Bool.
-  ///
-  /// Left as-is deliberately. Reachability was measured, not assumed: a detector
-  /// that strips bracketed spans before looking for a depth-0 `, name:` (so
-  /// tuple labels and generic arguments do not false-positive, which a plain
-  /// grep does for all ten of its hits) finds ZERO multi-binding declarations
-  /// across `Sources/**/*.swift`, with a two-way control confirming it fires on
-  /// a real one.
-  ///
-  /// Unlike the type-shape findings in this PR, closing this is not a parsing
-  /// fix: it changes what the ceiling COUNTS, which `architecture-rules.md`
-  /// documents, and it requires the predicate to classify per binding rather
-  /// than answer yes/no per line. `validation-discipline.md` RULE:
-  /// validate-automated-review-findings permits fixing an unreachable finding
-  /// only when the fix is trivial; a counting-contract change is not, so the
-  /// limit is written down here instead of guessed at.
-  private static func countTopLevelStoredProperties(
-    in body: String, where predicate: (String) -> Bool
-  ) -> Int {
-    var depth = 0
-    var count = 0
-    for line in foldContinuationLines(body) {
-      let (opens, closes) = braceCounts(line)
-      let depthForThisLine = depth - max(0, closes - opens)
-      if depthForThisLine == 0 {
-        if isStoredPropertyDeclaration(line), predicate(line) {
-          count += 1
-        }
-      }
-      depth += opens - closes
+  private static func parsed(_ source: String, context: String) throws -> SourceFileSyntax {
+    let tree = Parser.parse(source: source)
+    guard !tree.hasError else {
+      Issue.record("Source did not parse cleanly for \(context)")
+      throw ScanFailure(context: context, reason: "source did not parse cleanly (tree.hasError)")
     }
-    return count
+    return tree
   }
 
-  /// Joins each top-level declaration whose type annotation wraps across
-  /// physical lines into a single logical line, so the per-line classifiers
-  /// (`isClosureTyped`, `isPrimitiveTyped`, ...) see the full type signature.
-  /// Folding is applied only at brace-depth 0; the folded logical line carries
-  /// the summed `{`/`}` counts of all merged physical lines, so depth tracking
-  /// downstream is unchanged.
-  private static func foldContinuationLines(_ body: String) -> [String] {
-    // Blank comments ONCE over the WHOLE body, then split (cloud review, PR
-    // #2070). `blockCommentDepth` is per-CALL state, so calling `codeView` per
-    // line resets it at every line boundary: the interior lines of a multi-line
-    // `/* ... */` come back looking like code. That broke the effect-specifier
-    // lookahead (it stopped on the first interior line) and, one layer down, it
-    // is why `braceCounts` ran with blanking OFF entirely — leaving a `}` inside
-    // a comment free to drive brace depth negative and hide every declaration
-    // after it. Both are the same defect, and both close here rather than at the
-    // call sites, so a future per-line reader cannot reintroduce either.
-    //
-    // Only BLOCK-comment state spans lines. `//` comments and single-line string
-    // literals are terminated by the newline itself (see `codeView`), so per-line
-    // calls downstream remain correct on this already-blanked text, and blanking
-    // is idempotent where they repeat it.
-    let physical = codeView(body, blankBlockComments: true)
-      .split(separator: "\n", omittingEmptySubsequences: false)
-      .map(String.init)
-    var result: [String] = []
-    var depth = 0
-    var i = 0
-    while i < physical.count {
-      var buffer = physical[i]
-      let (opens, closes) = braceCounts(buffer)
-      let depthForThisLine = depth - max(0, closes - opens)
-      if depthForThisLine == 0 {
-        while i + 1 < physical.count {
-          if isUnterminatedDeclaration(buffer) {
-            i += 1
-            buffer += "\n" + physical[i]
-            continue
-          }
-          // Look PAST blank lines and `//` comments for a continuing effect
-          // specifier or arrow, absorbing the trivia on the way (cloud review,
-          // PR #2070). An immediate-next-line check emits the declaration before
-          // it ever reaches the `async` two lines down.
-          guard let next = nextSignificantIndex(physical, after: i),
-            continuesWithEffectSpecifier(physical[next])
-          else { break }
-          while i < next {
-            i += 1
-            buffer += "\n" + physical[i]
-          }
-        }
+  /// A class body is not a valid source file on its own, so it is wrapped back
+  /// into a synthetic class before parsing. Wrapping rather than parsing the
+  /// members as top-level code keeps them genuine MEMBERS, where modifiers such
+  /// as `nonisolated` and `final` are legal and mean what they mean in the real
+  /// class.
+  private static func members(in body: String) -> MemberBlockItemListSyntax {
+    let tree = Parser.parse(source: "final class __CeilingProbe {\n\(body)\n}")
+    guard let probe = ClassFinder.find(named: "__CeilingProbe", in: tree) else {
+      return MemberBlockItemListSyntax([])
+    }
+    return probe.memberBlock.members
+  }
+
+  private struct StoredLet {
+    let type: TypeSyntax?
+    let isBooleanLiteralInitialized: Bool
+  }
+
+  /// Every `let` binding declared directly in the body, one entry PER BINDING —
+  /// so `let a: A, b: B` contributes two, which the text scanner could not do
+  /// because it classified a whole line at a time.
+  ///
+  /// Excluded: `var` (owned mutable state), `static` / `class` type properties,
+  /// and any binding with an accessor block, which is a computed property or an
+  /// inline closure initializer rather than an injected seam.
+  ///
+  /// The type-property exclusion is the one rule here that is a DECISION about
+  /// what the ceiling means rather than a fact about Swift: a type property is
+  /// not an injected instance collaborator.
+  private static func storedLetBindings(in body: String) -> [StoredLet] {
+    var result: [StoredLet] = []
+    for member in members(in: body) {
+      guard let variable = member.decl.as(VariableDeclSyntax.self) else { continue }
+      guard variable.bindingSpecifier.tokenKind == .keyword(.let) else { continue }
+      guard !isTypeProperty(variable.modifiers) else { continue }
+      for binding in variable.bindings {
+        guard binding.accessorBlock == nil else { continue }
+        let isBool = binding.initializer.map { isBooleanLiteral($0.value) } ?? false
+        result.append(
+          StoredLet(type: binding.typeAnnotation?.type, isBooleanLiteralInitialized: isBool))
       }
-      result.append(buffer)
-      // Recount after folding: `buffer` may now span several physical lines.
-      let (bufOpens, bufCloses) = braceCounts(buffer)
-      depth += bufOpens - bufCloses
-      i += 1
     }
     return result
   }
 
-  /// A logical buffer is unterminated (its next physical line continues it)
-  /// when, in its code view (string literals and `//` comments removed), round
-  /// or square brackets are unbalanced-open, or the last non-whitespace
-  /// character is a continuation operator (`:` `,` `&`, or it ends with `->`).
-  /// Angle brackets are deliberately not tracked — `>` is ambiguous with `->`
-  /// and comparison.
-  /// First line at or after `i + 1` that carries actual code — blank lines and
-  /// `//` comments are trivia and Swift permits them anywhere between tokens.
-  /// `lines` are ALREADY comment-blanked by the caller, so this only has to find
-  /// the next line with anything left on it.
-  private static func nextSignificantIndex(_ lines: [String], after i: Int) -> Int? {
-    var j = i + 1
-    while j < lines.count {
-      if !lines[j].trimmingCharacters(in: .whitespaces).isEmpty { return j }
-      j += 1
+  private static func isTypeProperty(_ modifiers: DeclModifierListSyntax) -> Bool {
+    modifiers.contains {
+      $0.name.tokenKind == .keyword(.static) || $0.name.tokenKind == .keyword(.class)
+    }
+  }
+
+  private static func isPrivate(_ modifiers: DeclModifierListSyntax) -> Bool {
+    modifiers.contains {
+      $0.name.tokenKind == .keyword(.private) || $0.name.tokenKind == .keyword(.fileprivate)
+    }
+  }
+
+  private static func isBooleanLiteral(_ expr: ExprSyntax) -> Bool {
+    expr.is(BooleanLiteralExprSyntax.self)
+  }
+
+  /// Peels every wrapper Swift permits around a type and reports whether what is
+  /// left is a function type. This one function replaces the entire class of
+  /// defects the text scanner accumulated: `(() -> Void)?`,
+  /// `Optional<() -> Void>`, `@MainActor () -> Void`, `((Error) -> Void)!` and
+  /// any nesting of those are the same tree shape here.
+  ///
+  /// Deliberately NOT peeled, because each means the property is not a closure:
+  /// a metatype (`(() -> Void).Type` is a type value), a multi-element tuple
+  /// (`(() -> Void, AlphaDep)` is a tuple), and any generic other than
+  /// `Optional` (`[String: () -> Void]` is a dictionary).
+  private static func isFunctionType(_ type: TypeSyntax) -> Bool {
+    unwrapped(type)?.is(FunctionTypeSyntax.self) ?? false
+  }
+
+  private static func unwrapped(_ type: TypeSyntax) -> TypeSyntax? {
+    var current = type
+    // Bounded by the nesting of a single declaration, which is finite; the cap
+    // only stops a malformed tree from spinning.
+    for _ in 0..<64 {
+      if current.is(FunctionTypeSyntax.self) { return current }
+      if let attributed = current.as(AttributedTypeSyntax.self) {
+        current = attributed.baseType
+        continue
+      }
+      if let optional = current.as(OptionalTypeSyntax.self) {
+        current = optional.wrappedType
+        continue
+      }
+      if let forced = current.as(ImplicitlyUnwrappedOptionalTypeSyntax.self) {
+        current = forced.wrappedType
+        continue
+      }
+      // A single UNLABELLED element is a parenthesised type, not a tuple.
+      if let tuple = current.as(TupleTypeSyntax.self), tuple.elements.count == 1,
+        let only = tuple.elements.first, only.firstName == nil
+      {
+        current = only.type
+        continue
+      }
+      if let inner = soleOptionalGenericArgument(of: current) {
+        current = inner
+        continue
+      }
+      return current
     }
     return nil
   }
 
-  /// #2068 (cloud review, PR #2070): a function type may wrap so that its effect
-  /// specifier or arrow starts the NEXT physical line:
-  ///
-  ///     let dependency: ()
-  ///       async -> Void
-  ///
-  /// `isUnterminatedDeclaration` cannot see that — line one has balanced
-  /// parentheses and no trailing continuation operator, so it looks finished, and
-  /// the closure is then missed by `isClosureTyped` entirely.
-  ///
-  /// Decided by LOOKING AHEAD rather than by loosening the termination rule. "A
-  /// buffer ending in `)` might continue" would also match the complete and
-  /// common `let x: (Int)`, and folding there would swallow the FOLLOWING
-  /// declaration and undercount — the failure direction a ceiling must never
-  /// have. No Swift declaration begins with `async` / `throws` / `rethrows` /
-  /// `->`, so this predicate cannot over-fold.
-  private static func continuesWithEffectSpecifier(_ line: String) -> Bool {
-    // `line` arrives comment-blanked from `foldContinuationLines`.
-    let trimmed = line.trimmingCharacters(in: .whitespaces)
-    if trimmed.hasPrefix("->") { return true }
-    for keyword in ["async", "throws", "rethrows"]
-    where trimmed == keyword
-      || trimmed.hasPrefix(keyword + " ") || trimmed.hasPrefix(keyword + "-")
-      // `throws(MyError) -> ...` wrapping onto its own line.
-      || trimmed.hasPrefix(keyword + "(")
-    {
-      return true
+  /// `Optional<T>` / `Swift.Optional<T>` → `T`. In this swift-syntax version
+  /// `GenericArgumentSyntax.argument` is an enum (value generics), so the
+  /// `.type` case is matched explicitly rather than assumed — checked against
+  /// the pinned checkout, not remembered.
+  private static func soleOptionalGenericArgument(of type: TypeSyntax) -> TypeSyntax? {
+    let arguments: GenericArgumentListSyntax?
+    if let identifier = type.as(IdentifierTypeSyntax.self), identifier.name.text == "Optional" {
+      arguments = identifier.genericArgumentClause?.arguments
+    } else if let member = type.as(MemberTypeSyntax.self), member.name.text == "Optional" {
+      arguments = member.genericArgumentClause?.arguments
+    } else {
+      return nil
     }
-    return false
+    guard let arguments, arguments.count == 1, let only = arguments.first else { return nil }
+    guard case .type(let inner) = only.argument else { return nil }
+    return inner
   }
 
-  private static func isUnterminatedDeclaration(_ buffer: String) -> Bool {
-    let code = codeView(buffer)
-    var paren = 0
-    var bracket = 0
-    for ch in code {
-      switch ch {
-      case "(": paren += 1
-      case ")": paren -= 1
-      case "[": bracket += 1
-      case "]": bracket -= 1
-      default: break
-      }
-    }
-    if paren > 0 || bracket > 0 { return true }
-    let trimmed = code.trimmingCharacters(in: .whitespacesAndNewlines)
-    if trimmed.hasSuffix("->") { return true }
-    if let last = trimmed.last, last == ":" || last == "," || last == "&" {
-      return true
-    }
-    // A buffer whose last token is an ATTRIBUTE is incomplete by definition —
-    // `@MainActor` cannot end a declaration, so the type it modifies is on the
-    // next line (cloud review, PR #2070):
-    //
-    //     let dependency: @MainActor
-    //       () -> Void
-    //
-    // Handled here rather than by teaching the lookahead to accept a leading
-    // `(`, because "the next line starts with `(`" is also true of an ordinary
-    // following declaration and would over-fold. "This line ended on an
-    // attribute" is unambiguous.
-    if endsWithAttribute(trimmed) { return true }
-    // `let dependency` with neither a type annotation nor an initializer cannot
-    // stand alone, so the `:` opening its type is on a following line (cloud
-    // review, PR #2070, round ten):
-    //
-    //     let dependency
-    //       : () -> Void
-    //
-    // Verified against the compiler rather than taken on the report:
-    // `swiftc -swift-version 6 -typecheck` accepts it.
-    if endsWithBareLetBinding(trimmed) { return true }
-    return false
+  private static let primitiveNames: Set<String> = [
+    "Bool", "Int", "String", "Double", "Float", "UInt64",
+  ]
+
+  private static func isPrimitive(_ type: TypeSyntax) -> Bool {
+    guard let base = unwrapped(type) else { return false }
+    guard let identifier = base.as(IdentifierTypeSyntax.self) else { return false }
+    if identifier.genericArgumentClause != nil { return identifier.name.text == "Task" }
+    return primitiveNames.contains(identifier.name.text)
   }
 
-  /// The buffer is a `let` binding that has not reached its `:` or `=` yet.
-  /// Both are excluded explicitly, so `let alpha: AlphaDep` and `let flag = true`
-  /// are complete and cannot fold into the declaration after them — the
-  /// undercount direction this check must not open.
-  private static func endsWithBareLetBinding(_ trimmed: String) -> Bool {
-    guard !trimmed.contains(":"), !trimmed.contains("=") else { return false }
-    let tokens = trimmed.split(whereSeparator: { $0.isWhitespace })
-    guard tokens.count >= 2, let last = tokens.last, tokens.dropLast().contains("let")
-    else { return false }
-    guard let first = last.first, first.isLetter || first == "_" else { return false }
-    return last.allSatisfy { $0.isLetter || $0.isNumber || $0 == "_" }
-  }
-
-  /// The line's last token is an attribute, in EITHER of the two forms Swift
-  /// allows: bare `@MainActor`, or parameterised `@isolated(any)` /
-  /// `@convention(c)` / `@available(macOS 26, *)`.
-  ///
-  /// The parameterised form was missed when this rule was introduced, on the
-  /// stated reasoning that a `)` ending "cannot be distinguished here from a
-  /// completed type" (cloud review, PR #2070, round eight). It can: scan back
-  /// from the final `)` to its matching `(` and require an attribute NAME
-  /// immediately before it. `let wrapped: (AlphaDep)` finds `:` there and is
-  /// correctly left alone, which the existing over-fold controls pin.
-  ///
-  /// Those two forms are the whole grammar for an attribute, so this closes the
-  /// case rather than adding the next instance of it.
-  private static func endsWithAttribute(_ trimmed: String) -> Bool {
-    let chars = Array(trimmed)
-    guard let last = chars.last else { return false }
-    if last == ")" {
-      var depth = 0
-      var i = chars.count - 1
-      var openIndex: Int?
-      while i >= 0 {
-        if chars[i] == ")" { depth += 1 }
-        if chars[i] == "(" {
-          depth -= 1
-          if depth == 0 {
-            openIndex = i
-            break
-          }
-        }
-        i -= 1
-      }
-      // The argument list is adjacent to the name, so the identifier runs right
-      // up to `(` and must be introduced by `@`.
-      guard let open = openIndex, open > 0 else { return false }
-      var j = open - 1
-      while j >= 0, chars[j].isLetter || chars[j].isNumber || chars[j] == "_" { j -= 1 }
-      return j >= 0 && chars[j] == "@" && j < open - 1
-    }
-    guard let lastToken = trimmed.split(whereSeparator: { $0.isWhitespace }).last
-    else { return false }
-    guard lastToken.hasPrefix("@"), lastToken.count > 1 else { return false }
-    return lastToken.dropFirst().allSatisfy { $0.isLetter || $0.isNumber || $0 == "_" }
-  }
-
-  /// Returns `buffer` with string-literal contents and `//` line comments
-  /// blanked to spaces (Character count preserved 1:1), so bracket-balance,
-  /// trailing-operator checks, AND `classBody`'s declaration search + brace
-  /// scan see only real code while every offset still aligns with `buffer`. A
-  /// `//` or a bracket inside a `"..."` literal must not be read as syntax (a
-  /// `let x = "https://"` is a complete declaration, not a continuation; a `}`
-  /// inside a string must not close a class body). Handles single-line `"..."`
-  /// with `\` escapes; multi-line (`"""`) and raw (`#"..."#`) string literals
-  /// are out of scope — no ceiling-tested class declaration uses them.
-  ///
-  /// `blankBlockComments`, when `true`, ALSO blanks `/* ... */` block comments
-  /// (nesting-aware). `blockCommentDepth` is per-CALL state, so this flag is only
-  /// meaningful on a COMPLETE contiguous buffer processed in one pass; a per-LINE
-  /// call would reset the depth at every line boundary and mis-read the interior
-  /// of a multi-line comment as code.
-  ///
-  /// PR #1634 cloud review r4 (2026-07-17) met that constraint and resolved it by
-  /// leaving the flag OFF for `braceCounts`, which left a `}` inside a block
-  /// comment counted as a real brace. PR #2070 removed the constraint instead:
-  /// `foldContinuationLines` now blanks the whole body ONCE up front, so every
-  /// line reaching `braceCounts` and the per-line classifiers is already
-  /// comment-free and the default here no longer decides anything for them.
-  /// Block comments are a real, if rare, live pattern in this codebase
-  /// (`grep -rn '/\*' Sources/EnviousWispr*/`, one hit outside test files).
-  private static func codeView(_ buffer: String, blankBlockComments: Bool = false) -> String {
-    let chars = Array(buffer)
-    var result: [Character] = []
-    result.reserveCapacity(chars.count)
-    var inString = false
-    var blockCommentDepth = 0
-    var i = 0
-    while i < chars.count {
-      let c = chars[i]
-      if inString {
-        if c == "\\" {
-          // Blank the escape pair (`\"`, `\\`, ...): two input chars, two spaces
-          // out, so the escaped char cannot end the string and length is kept.
-          result.append(" ")
-          if i + 1 < chars.count { result.append(" ") }
-          i += 2
-          continue
-        }
-        if c == "\"" {
-          inString = false
-          result.append(" ")  // blank the closing quote (kept as a space, 1:1)
-          i += 1
-          continue
-        }
-        if c == "\n" {
-          inString = false  // a single-line literal cannot cross a newline
-          result.append(c)
-          i += 1
-          continue
-        }
-        result.append(" ")  // blank string content
-        i += 1
-        continue
-      }
-      if blankBlockComments, blockCommentDepth > 0 {
-        if i + 1 < chars.count, c == "/", chars[i + 1] == "*" {
-          blockCommentDepth += 1
-          result.append(" ")
-          result.append(" ")
-          i += 2
-          continue
-        }
-        if i + 1 < chars.count, c == "*", chars[i + 1] == "/" {
-          blockCommentDepth -= 1
-          result.append(" ")
-          result.append(" ")
-          i += 2
-          continue
-        }
-        result.append(c == "\n" ? "\n" : " ")
-        i += 1
-        continue
-      }
-      if c == "\"" {
-        inString = true
-        result.append(" ")  // blank the opening quote
-        i += 1
-        continue
-      }
-      if c == "/", i + 1 < chars.count, chars[i + 1] == "/" {
-        while i < chars.count, chars[i] != "\n" {
-          result.append(" ")  // blank the comment to end of line
-          i += 1
-        }
-        continue
-      }
-      if blankBlockComments, c == "/", i + 1 < chars.count, chars[i + 1] == "*" {
-        blockCommentDepth += 1
-        result.append(" ")
-        result.append(" ")
-        i += 2
-        continue
-      }
-      result.append(c)
-      i += 1
-    }
-    return String(result)
-  }
-
-  /// Returns the range of the FIRST occurrence of `statement` in `body`,
-  /// searched over `body`'s code view (comments/strings/block-comments
-  /// blanked, and a call passing `statement` as a full single buffer is safe
-  /// for `blankBlockComments`) so a commented-out or string-quoted occurrence
-  /// cannot satisfy the search — but the returned range indexes into the REAL
-  /// `body` text (cloud Codex review, PR #1634, 2026-07-17, 2 rounds: a plain
-  /// `body.range(of:)` substring search would let `// assertAttached()` or
-  /// `/* assertAttached() */` false-pass the same way the raw-count check
-  /// this file replaces once did). `codeView` preserves Character count 1:1,
-  /// so an offset into the view is the same offset into `body`.
-  ///
-  /// Requires an identifier boundary immediately before the match (round 2:
-  /// a plain substring search would let `preassertAttached()` satisfy a
-  /// search for `assertAttached()`). `statement` is always a caller-supplied
-  /// literal (call expressions like `assertAttached()`, not user input), so
-  /// `NSRegularExpression.escapedPattern` + a fixed lookbehind is safe.
-  static func rangeOfStatement(_ statement: String, in body: String) -> Range<String.Index>? {
-    let view = codeView(body, blankBlockComments: true)
-    let pattern = "(?<![A-Za-z0-9_])" + NSRegularExpression.escapedPattern(for: statement)
-    guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
-    let viewRange = NSRange(view.startIndex..<view.endIndex, in: view)
-    guard
-      let match = regex.firstMatch(in: view, range: viewRange),
-      let found = Range(match.range, in: view)
-    else { return nil }
-    let startOffset = view.distance(from: view.startIndex, to: found.lowerBound)
-    let endOffset = view.distance(from: view.startIndex, to: found.upperBound)
-    guard
-      let lower = body.index(body.startIndex, offsetBy: startOffset, limitedBy: body.endIndex),
-      let upper = body.index(body.startIndex, offsetBy: endOffset, limitedBy: body.endIndex)
-    else { return nil }
-    return lower..<upper
-  }
-
-  private static let storedPropertyPattern: String = {
-    let attrs = #"(@[A-Za-z_][A-Za-z0-9_]*(\([^)]*\))?[[:space:]]+)*"#
-    // `nonisolated` is an isolation modifier on an INSTANCE property, so a
-    // `nonisolated let` seam is a collaborator like any other and must be
-    // counted (cloud review, PR #2070, round eighteen). Swift accepts it on
-    // either side of access control and in the `nonisolated(unsafe)` form, all
-    // verified with `swiftc -typecheck`, so one repeating alternation covers
-    // every ordering rather than enumerating the pairings.
-    //
-    // This was an oversight rather than a decision: `nonPrivateMethodPattern`
-    // below has always carried `nonisolated`, so the METHOD side already knew
-    // the modifier occurs here — 27 files use it at top level — while the
-    // property side was never updated to match. The twin is the evidence.
-    //
-    // `static` stays OUT deliberately: a type property is not an injected
-    // instance collaborator, and admitting it would change what the ceiling
-    // counts rather than fix what it reads.
-    // ENUMERATED against the compiler rather than extended one modifier per
-    // review round (round twenty). Each candidate was type-checked as
-    // `<modifier> let d: AnyObject` in a class:
-    //
-    //   accepted → access modifiers, `final`, `dynamic`,
-    //              `nonisolated` / `nonisolated(unsafe)`,
-    //              `unowned` / `unowned(safe)` / `unowned(unsafe)`
-    //   rejected → `override`, `lazy`, `weak`, `mutating`, `convenience`,
-    //              `required` (none can precede a stored `let` at all)
-    //
-    // Ordering is free — `final private let` and `private final let` both
-    // compile — which is why this is one repeating alternation rather than a
-    // fixed sequence of optional groups.
-    //
-    // `static` and `class` stay OUT deliberately: a TYPE property is not an
-    // injected instance collaborator. That is the one exclusion here which is a
-    // decision about what the ceiling means rather than a fact about Swift.
-    let modifiers =
-      #"((public|internal|private|fileprivate|package|open|final|dynamic"#
-      + #"|nonisolated(\(unsafe\))?|unowned(\((safe|unsafe)\))?)[[:space:]]+)*"#
-    return "^[[:space:]]*\(attrs)\(modifiers)let[[:space:]]+[A-Za-z_]"
-  }()
-
-  private static func isStoredPropertyDeclaration(_ line: String) -> Bool {
-    guard line.range(of: storedPropertyPattern, options: .regularExpression) != nil
-    else { return false }
-    // Reject a `let` whose first physical line ends with `{` (trailing-closure
-    // initializer body). A Swift computed property is always `var`, so a `let`
-    // never reaches here as a computed property.
-    //
-    // DELIBERATE, and the reason belongs here because the mechanism alone reads
-    // like an oversight (cloud review, PR #2070, round sixteen, raised on
-    // exactly that reading). These ceilings bound INJECTED dependencies —
-    // "justify it, or put it behind an existing seam", per the freeze tests. A
-    // closure-typed `let` carrying an inline literal body is the opposite of a
-    // seam: it cannot be substituted by a caller or a test, it is not passed
-    // through `init`, and it is owned behaviour that happens to be spelled as a
-    // closure rather than a private method.
-    //
-    // Counting it would make the closure ceiling fire on a refactor that turns a
-    // private method into a stored closure, which adds no dependency at all —
-    // a false positive on the one axis a ceiling must stay trustworthy about.
-    // Measured while deciding: zero such top-level declarations across the three
-    // ceiling-tested homes, so nothing rests on this today either way.
-    let firstLine =
-      line.split(separator: "\n", omittingEmptySubsequences: false).first
-      .map(String.init) ?? line
-    if firstLine.range(of: #"\{[[:space:]]*$"#, options: .regularExpression) != nil {
+  private static func isNSObjectProtocol(_ type: TypeSyntax) -> Bool {
+    guard let base = unwrapped(type), let identifier = base.as(IdentifierTypeSyntax.self) else {
       return false
     }
-    return true
+    return identifier.name.text == "NSObjectProtocol"
   }
 
-  private static func isPrimitiveTyped(_ line: String) -> Bool {
-    let primitives = [
-      ": Bool", ": Int", ": String", ": Double", ": Float", ": UInt64",
-      "Task<", "= false", "= true",
-    ]
-    return primitives.contains { line.contains($0) }
-  }
+  // MARK: - Finders
 
-  private static func isClosureTyped(_ rawLine: String) -> Bool {
-    // #2068: matched against the CODE VIEW, not the raw text. Swift's function-type
-    // grammar admits arbitrary trivia between every token, so a comment sitting
-    // between `()` and its effect specifier defeats a raw-text match — and a `->`
-    // inside a comment or string literal can fake one in the other direction.
-    // Blanking both to spaces makes the predicate structural, which is the only
-    // form that survives the next syntax shape nobody enumerated.
-    // `blankBlockComments: true` — the default leaves `/* ... */` intact, which
-    // is the same trivia class this predicate moved to the code view to close
-    // (cloud review, PR #2070). Swift accepts
-    // `let f: () /* effect docs */ async -> Void`. The buffer here is the FOLDED
-    // declaration, so a block comment spanning its physical lines is blanked too.
-    let line = codeView(rawLine, blankBlockComments: true)
-    // Matches a declared closure type signature: `: (...) -> ...`
-    // (with optional `@MainActor` / `@Sendable` attributes before the
-    // paren). `line` may be a folded multi-line declaration; `[[:space:]]`
-    // already includes the join newline, so the signature matches across it.
-    //
-    // #2068: the effect markers between `)` and `->` are matched too. Without
-    // them `let f: @MainActor () async -> T` was not recognised as a closure at
-    // all, which had it counted as a COLLABORATOR — so an `async` dependency
-    // evaded the very closure ceiling this predicate exists to feed, and
-    // consumed a collaborator slot instead. Measured on `RecordingStarter`:
-    // `closureInjectedCount` read 8 against 10 closure-typed `let`s, the two
-    // missing ones being `makeRecoveryDirective` and
-    // `ensureSelectedReadyForPress`, both `async`.
-    // SCANNED, not matched (cloud review, PR #2070, round six). The parameter
-    // list was `\([^)]*\)`, which stops at the first `)`, so a parenthesis
-    // nested anywhere in the parameter type —
-    // `(Result<(Int, String), DomainError>) -> Void` — ended the match before
-    // the arrow. A regex cannot balance brackets, so no widening of the
-    // character classes could have reached it: five rounds of this file's
-    // review each added one more permitted syntax shape, and this one is not a
-    // shape but a capability. The clause below balances instead, which also
-    // subsumes the earlier typed-throws nesting and the whitespace-adjacency
-    // cases rather than encoding them as alternatives.
-    // Only the DECLARATION's own type annotation is tried, which is the `:` at
-    // bracket depth 0. Retrying after every colon meant a non-closure type
-    // holding a closure matched on an inner one: `let handlers: [String: () ->
-    // Void]` is a dictionary — a collaborator — but its value-type colon parses
-    // as a closure signature and classified the whole property as one (cloud
-    // review, PR #2070, round eleven). Verified valid Swift before fixing.
-    let chars = Array(line)
-    var depth = 0
-    var i = 0
-    while i < chars.count {
-      switch chars[i] {
-      case "(", "[", "<": depth += 1
-      case ")", "]": depth -= 1
-      case ">" where !(i > 0 && chars[i - 1] == "-"): depth -= 1
-      case ":" where depth == 0:
-        if closureSignatureFollows(chars, from: i + 1) { return true }
-      default: break
+  private final class ClassFinder: SyntaxVisitor {
+    let targetName: String
+    var found: ClassDeclSyntax?
+
+    init(targetName: String) {
+      self.targetName = targetName
+      super.init(viewMode: .sourceAccurate)
+    }
+
+    static func find(named name: String, in tree: SourceFileSyntax) -> ClassDeclSyntax? {
+      let finder = ClassFinder(targetName: name)
+      finder.walk(tree)
+      return finder.found
+    }
+
+    override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+      if found == nil, node.name.text == targetName {
+        found = node
+        return .skipChildren
       }
-      i += 1
+      return .visitChildren
     }
-    return false
   }
 
-  /// A declared closure type, read structurally from just after its `:`:
-  /// `@Attribute`* `(` balanced `)` effect-specifier* `->`.
-  ///
-  /// Every position skips trivia, so whitespace is optional everywhere Swift
-  /// makes it optional and unbounded everywhere Swift allows it — the property
-  /// the previous pattern kept failing one shape at a time. Comments are already
-  /// blanked to spaces by the caller's code view, so they are trivia here too.
-  /// `limit` bounds the scan so a recursive call cannot read past the group it
-  /// was handed. That bound is also what guarantees termination: each recursive
-  /// call is handed `close`, which is strictly inside the current window, so the
-  /// window shrinks on every step. An explicit depth cap was tried and removed —
-  /// it added no safety the shrinking window did not already give, and it
-  /// silently returned false past its limit, which is an UNDERCOUNT (cloud
-  /// review, PR #2070, round nine).
-  private static func closureSignatureFollows(
-    _ chars: [Character], from start: Int, limit: Int? = nil
-  ) -> Bool {
-    let end = min(limit ?? chars.count, chars.count)
-    var i = skipTrivia(chars, from: start, limit: end)
-    while i < end, chars[i] == "@" {
-      i += 1
-      while i < end, chars[i].isLetter || chars[i].isNumber || chars[i] == "_" { i += 1 }
-      // An attribute's argument list is ADJACENT to its name — `@available(macOS
-      // 26, *)`. Skipping trivia before this check would consume the FUNCTION
-      // TYPE's own parameter list in `@MainActor (Int) -> Bool`, where the paren
-      // is separated by a space and belongs to the type, not the attribute.
-      //
-      // Adjacency alone is not sufficient, though: `@Sendable()->Void` is valid
-      // Swift (verified — `@MainActor()->Void` is NOT, so the two cannot be told
-      // apart by shape), and there the adjacent `()` IS the parameter list.
-      // Whether an attribute accepts arguments is not knowable here, so decide
-      // by what FOLLOWS: if an arrow or effect specifier comes next, the group
-      // just consumed was the parameter list, and the scan rewinds to it (cloud
-      // review, PR #2070, round eleven).
-      if i < end, chars[i] == "(" {
-        guard let close = matchingParen(chars, open: i, limit: end) else { return false }
-        let afterArgs = skipTrivia(chars, from: close + 1, limit: end)
-        let arrowFollows =
-          afterArgs + 1 < end && chars[afterArgs] == "-" && chars[afterArgs + 1] == ">"
-        let specifierFollows =
-          matchesKeyword(chars, at: afterArgs, "async", limit: end)
-          || matchesKeyword(chars, at: afterArgs, "throws", limit: end)
-          || matchesKeyword(chars, at: afterArgs, "rethrows", limit: end)
-        if arrowFollows || specifierFollows { break }
-        i = close + 1
+  private final class FunctionFinder: SyntaxVisitor {
+    let targetName: String
+    var found: FunctionDeclSyntax?
+
+    init(targetName: String) {
+      self.targetName = targetName
+      super.init(viewMode: .sourceAccurate)
+    }
+
+    static func find(named name: String, in tree: SourceFileSyntax) -> FunctionDeclSyntax? {
+      let finder = FunctionFinder(targetName: name)
+      finder.walk(tree)
+      return finder.found
+    }
+
+    override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+      if found == nil, node.name.text == targetName {
+        found = node
+        return .skipChildren
       }
-      i = skipTrivia(chars, from: i, limit: end)
+      return .visitChildren
     }
-    // The GENERIC optional spelling wraps the whole type exactly as `( … )?`
-    // does: `Optional<() -> Void>` is `(() -> Void)?` desugared (cloud review,
-    // PR #2070, round thirteen). Matched by prefix and closed at the LAST `>`
-    // of the type rather than by balancing `<>`, because a bracket counter has
-    // to special-case the `>` in `->` — the exact ambiguity that already put a
-    // blind spot in `containsTopLevelComma` two rounds ago. The recursion
-    // carries the same whole-type guards, so `Optional<(() -> Void, AlphaDep)>`
-    // still fails the tuple test.
-    //
-    // The trailing guard is the SAME one the parenthesised path uses. Round
-    // thirteen added this branch and returned as soon as the inner type parsed,
-    // which silently reopened the metatype hole round twelve had closed:
-    // `Optional<() -> Void>.Type` is a metatype, and a new wrapper path that
-    // skips the shared check is exactly how a closed class comes back (round
-    // fourteen). Both wrapper paths now end at `onlyOptionalMarkersRemain`.
-    if let angleOpen = optionalGenericOpen(chars, at: i, limit: end),
-      let angleClose = lastAngleBracket(chars, from: angleOpen + 1, to: end)
-    {
-      guard onlyOptionalMarkersRemain(chars, from: angleClose + 1, to: end) else { return false }
-      return closureSignatureFollows(chars, from: angleOpen + 1, limit: angleClose)
-    }
-    guard i < end, chars[i] == "(", let close = matchingParen(chars, open: i, limit: end)
-    else { return false }
-    let afterGroup = skipTrivia(chars, from: close + 1, limit: end)
-    // An OPTIONAL function type parenthesises the WHOLE type: `(() -> Void)?`.
-    // Read as a parameter list, the outer group swallows the signature and the
-    // `?` that follows is not an arrow, so the property fell to COLLABORATOR
-    // (cloud review, PR #2070). When the arrow does not follow the group, scan
-    // INSIDE it as a type instead.
-    //
-    // Only when the group WRAPS the whole type, though. A TUPLE whose first
-    // element happens to be a closure — `(() -> Void, AlphaDep)` — would
-    // otherwise match on that element alone and count the tuple as a closure
-    // (round nine). A top-level comma is exactly what separates the two: a
-    // tuple has one, and a wrapped function type does not, because
-    // `((A, B) -> C)?`'s comma sits inside the nested parameter list one level
-    // down. That makes this a structural test, not another special case.
-    // The group must also be the WHOLE type on the trailing side, not just the
-    // leading one. `(() -> Void).Type` is a function METATYPE — a collaborator —
-    // and the inner scan succeeds on it, so without this the suffix is ignored
-    // and the metatype counts as a closure (round twelve). Only optional markers
-    // may follow a wrapper and leave it still describing a closure.
-    let arrowFollowsGroup =
-      afterGroup + 1 < end && chars[afterGroup] == "-" && chars[afterGroup + 1] == ">"
-    if !arrowFollowsGroup, !containsTopLevelComma(chars, from: i + 1, to: close),
-      onlyOptionalMarkersRemain(chars, from: close + 1, to: end),
-      closureSignatureFollows(chars, from: i + 1, limit: close)
-    {
-      return true
-    }
-    i = afterGroup
-    while true {
-      if matchesKeyword(chars, at: i, "async", limit: end) {
-        i = skipTrivia(chars, from: i + 5, limit: end)
-      } else if matchesKeyword(chars, at: i, "rethrows", limit: end) {
-        i = skipTrivia(chars, from: i + 8, limit: end)
-      } else if matchesKeyword(chars, at: i, "throws", limit: end) {
-        i = skipTrivia(chars, from: i + 6, limit: end)
-        // Typed throws, to any nesting depth: `throws(Failure<(Int, String)>)`.
-        if i < end, chars[i] == "(" {
-          guard let errorClose = matchingParen(chars, open: i, limit: end) else { return false }
-          i = skipTrivia(chars, from: errorClose + 1, limit: end)
-        }
-      } else {
-        break
-      }
-    }
-    return i + 1 < end && chars[i] == "-" && chars[i + 1] == ">"
   }
 
-  /// A comma at nesting depth 0 between `from` and `to` — the marker of a TUPLE
-  /// rather than a parenthesised single type. Angle brackets are counted too, so
-  /// the comma in `Result<Int, Error>` is not mistaken for a tuple separator;
-  /// `<`/`>` are ambiguous with comparison in general Swift, but inside a type
-  /// annotation they are generic delimiters.
-  /// Index of the `<` that opens a generic `Optional<…>`, or `nil` when the type
-  /// does not start with one. An optional `Swift.` qualifier is accepted.
-  ///
-  /// SCANNED with trivia skipped at every join rather than matched against the
-  /// literals `"Optional<"` / `"Swift.Optional<"`, because Swift accepts
-  /// `Optional <…>`, `Swift . Optional<…>`, and `Optional /* docs */ <…>` (round
-  /// fourteen; the comment form arrives here already blanked to spaces by the
-  /// caller's code view, so it is ordinary trivia). Tolerating trivia is also
-  /// what lets the `Swift.` qualifier fall out of the scan instead of needing a
-  /// second literal — the same reason every other position in this file skips
-  /// trivia rather than enumerating spacings.
-  private static func optionalGenericOpen(_ chars: [Character], at: Int, limit: Int) -> Int? {
-    let end = min(limit, chars.count)
-    var i = skipTrivia(chars, from: at, limit: end)
-    if matchesKeyword(chars, at: i, "Swift", limit: end) {
-      let afterSwift = skipTrivia(chars, from: i + 5, limit: end)
-      guard afterSwift < end, chars[afterSwift] == "." else { return nil }
-      i = skipTrivia(chars, from: afterSwift + 1, limit: end)
-    }
-    guard matchesKeyword(chars, at: i, "Optional", limit: end) else { return nil }
-    let afterName = skipTrivia(chars, from: i + 8, limit: end)
-    guard afterName < end, chars[afterName] == "<" else { return nil }
-    return afterName
-  }
-
-  /// The last `>` before the type ends (at `=`, or at `to`). The `>` of an `->`
-  /// is skipped, so `Optional<() -> Void>` closes on its own bracket and not on
-  /// the arrow inside it.
-  private static func lastAngleBracket(_ chars: [Character], from: Int, to: Int) -> Int? {
-    let end = min(to, chars.count)
-    var last: Int?
-    var i = from
-    while i < end {
-      if chars[i] == "=" { break }
-      if chars[i] == ">", !(i > 0 && chars[i - 1] == "-") { last = i }
-      i += 1
-    }
-    return last
-  }
-
-  /// Everything after a wrapping group is an optional marker (or an initializer,
-  /// which ends the TYPE). `(() -> Void)?` and `(() -> Void)!` still describe a
-  /// closure; `(() -> Void).Type` describes a metatype and must not be claimed
-  /// as one. Stopping at `=` matters because a stored property may carry a
-  /// default value — `let onFinish: (() -> Void)? = nil` — and the type ends
-  /// there, so the initializer text must not be read as part of it.
-  private static func onlyOptionalMarkersRemain(_ chars: [Character], from: Int, to: Int) -> Bool {
-    let end = min(to, chars.count)
-    var i = skipTrivia(chars, from: from, limit: end)
-    while i < end {
-      if chars[i] == "=" { return true }
-      guard chars[i] == "?" || chars[i] == "!" else { return false }
-      i = skipTrivia(chars, from: i + 1, limit: end)
-    }
-    return true
-  }
-
-  private static func containsTopLevelComma(_ chars: [Character], from: Int, to: Int) -> Bool {
-    var depth = 0
-    var i = from
-    let end = min(to, chars.count)
-    while i < end {
-      // `->` must be consumed as one token. Counting its `>` as a closing
-      // bracket drives depth to -1, and the tuple comma in
-      // `(() -> Void, AlphaDep)` then reads as nested rather than top-level —
-      // which would defeat the whole check.
-      if chars[i] == "-", i + 1 < end, chars[i + 1] == ">" {
-        i += 2
-        continue
-      }
-      switch chars[i] {
-      case "(", "[", "<": depth += 1
-      case ")", "]", ">": depth -= 1
-      case "," where depth == 0: return true
-      default: break
-      }
-      i += 1
-    }
-    return false
-  }
-
-  private static func skipTrivia(_ chars: [Character], from i: Int, limit: Int? = nil) -> Int {
-    let end = min(limit ?? chars.count, chars.count)
-    var j = i
-    while j < end, chars[j].isWhitespace { j += 1 }
-    return j
-  }
-
-  /// Index of the `)` closing the `(` at `open`, or `nil` if unbalanced. The
-  /// caller passes a code view, so parens inside comments and string literals
-  /// are already spaces and cannot skew the depth.
-  private static func matchingParen(_ chars: [Character], open: Int, limit: Int? = nil) -> Int? {
-    let end = min(limit ?? chars.count, chars.count)
-    var depth = 0
-    var i = open
-    while i < end {
-      if chars[i] == "(" { depth += 1 }
-      if chars[i] == ")" {
-        depth -= 1
-        if depth == 0 { return i }
-      }
-      i += 1
-    }
-    return nil
-  }
-
-  /// `word` appears at `i` and is not merely the prefix of a longer identifier,
-  /// so a type named `asyncResult` is never read as the `async` specifier.
-  private static func matchesKeyword(
-    _ chars: [Character], at i: Int, _ word: String, limit: Int? = nil
-  ) -> Bool {
-    let end = min(limit ?? chars.count, chars.count)
-    let expected = Array(word)
-    guard i >= 0, i + expected.count <= end else { return false }
-    for k in 0..<expected.count where chars[i + k] != expected[k] { return false }
-    let after = i + expected.count
-    guard after < end else { return true }
-    let next = chars[after]
-    return !(next.isLetter || next.isNumber || next == "_")
-  }
-
-  private static func isNSObjectProtocolTyped(_ line: String) -> Bool {
-    line.contains(": NSObjectProtocol")
-  }
-
-  private static let nonPrivateMethodPattern: String =
-    #"^[[:space:]]*(@[A-Za-z_][A-Za-z0-9_]*(\([^)]*\))?[[:space:]]+)*(nonisolated[[:space:]]+)?(public|internal|package|open)?[[:space:]]*(static[[:space:]]+)?(class[[:space:]]+)?func[[:space:]]+[A-Za-z_]"#
-
-  private static let privateMethodPattern: String =
-    #"^[[:space:]]*(@[A-Za-z_][A-Za-z0-9_]*(\([^)]*\))?[[:space:]]+)*(private|fileprivate)[[:space:]]+(static[[:space:]]+)?(class[[:space:]]+)?func[[:space:]]+[A-Za-z_]"#
-
-  private static func isNonPrivateMethodDeclaration(_ line: String) -> Bool {
-    if line.range(of: privateMethodPattern, options: .regularExpression) != nil {
-      return false
-    }
-    return line.range(of: nonPrivateMethodPattern, options: .regularExpression) != nil
-  }
 }

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
@@ -428,8 +428,18 @@ enum RouterCeilingParser {
     // (with optional `@MainActor` / `@Sendable` attributes before the
     // paren). `line` may be a folded multi-line declaration; `[[:space:]]`
     // already includes the join newline, so the signature matches across it.
+    //
+    // #2068: the effect markers between `)` and `->` are matched too. Without
+    // them `let f: @MainActor () async -> T` was not recognised as a closure at
+    // all, which had it counted as a COLLABORATOR — so an `async` dependency
+    // evaded the very closure ceiling this predicate exists to feed, and
+    // consumed a collaborator slot instead. Measured on `RecordingStarter`:
+    // `closureInjectedCount` read 8 against 10 closure-typed `let`s, the two
+    // missing ones being `makeRecoveryDirective` and
+    // `ensureSelectedReadyForPress`, both `async`.
     line.range(
-      of: #":[[:space:]]*(@[A-Za-z]+[[:space:]]+)*\([^)]*\)[[:space:]]*->[[:space:]]"#,
+      of:
+        #":[[:space:]]*(@[A-Za-z]+[[:space:]]+)*\([^)]*\)([[:space:]]+(async|throws|rethrows))*[[:space:]]*->[[:space:]]"#,
       options: .regularExpression) != nil
   }
 

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
@@ -257,7 +257,11 @@ enum RouterCeilingParser {
   private static func nextSignificantIndex(_ lines: [String], after i: Int) -> Int? {
     var j = i + 1
     while j < lines.count {
-      if !codeView(lines[j]).trimmingCharacters(in: .whitespaces).isEmpty { return j }
+      if !codeView(lines[j], blankBlockComments: true)
+        .trimmingCharacters(in: .whitespaces).isEmpty
+      {
+        return j
+      }
       j += 1
     }
     return nil
@@ -280,7 +284,8 @@ enum RouterCeilingParser {
   /// have. No Swift declaration begins with `async` / `throws` / `rethrows` /
   /// `->`, so this predicate cannot over-fold.
   private static func continuesWithEffectSpecifier(_ line: String) -> Bool {
-    let trimmed = codeView(line).trimmingCharacters(in: .whitespaces)
+    let trimmed = codeView(line, blankBlockComments: true)
+      .trimmingCharacters(in: .whitespaces)
     if trimmed.hasPrefix("->") { return true }
     for keyword in ["async", "throws", "rethrows"] where trimmed == keyword
       || trimmed.hasPrefix(keyword + " ") || trimmed.hasPrefix(keyword + "-")
@@ -484,7 +489,12 @@ enum RouterCeilingParser {
     // inside a comment or string literal can fake one in the other direction.
     // Blanking both to spaces makes the predicate structural, which is the only
     // form that survives the next syntax shape nobody enumerated.
-    let line = codeView(rawLine)
+    // `blankBlockComments: true` — the default leaves `/* ... */` intact, which
+    // is the same trivia class this predicate moved to the code view to close
+    // (cloud review, PR #2070). Swift accepts
+    // `let f: () /* effect docs */ async -> Void`. The buffer here is the FOLDED
+    // declaration, so a block comment spanning its physical lines is blanked too.
+    let line = codeView(rawLine, blankBlockComments: true)
     // Matches a declared closure type signature: `: (...) -> ...`
     // (with optional `@MainActor` / `@Sendable` attributes before the
     // paren). `line` may be a folded multi-line declaration; `[[:space:]]`

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
@@ -218,7 +218,9 @@ enum RouterCeilingParser {
       let (opens, closes) = braceCounts(buffer)
       let depthForThisLine = depth - max(0, closes - opens)
       if depthForThisLine == 0 {
-        while isUnterminatedDeclaration(buffer), i + 1 < physical.count {
+        while i + 1 < physical.count,
+          isUnterminatedDeclaration(buffer) || continuesWithEffectSpecifier(physical[i + 1])
+        {
           i += 1
           buffer += "\n" + physical[i]
         }
@@ -238,6 +240,33 @@ enum RouterCeilingParser {
   /// character is a continuation operator (`:` `,` `&`, or it ends with `->`).
   /// Angle brackets are deliberately not tracked — `>` is ambiguous with `->`
   /// and comparison.
+  /// #2068 (cloud review, PR #2070): a function type may wrap so that its effect
+  /// specifier or arrow starts the NEXT physical line:
+  ///
+  ///     let dependency: ()
+  ///       async -> Void
+  ///
+  /// `isUnterminatedDeclaration` cannot see that — line one has balanced
+  /// parentheses and no trailing continuation operator, so it looks finished, and
+  /// the closure is then missed by `isClosureTyped` entirely.
+  ///
+  /// Decided by LOOKING AHEAD rather than by loosening the termination rule. "A
+  /// buffer ending in `)` might continue" would also match the complete and
+  /// common `let x: (Int)`, and folding there would swallow the FOLLOWING
+  /// declaration and undercount — the failure direction a ceiling must never
+  /// have. No Swift declaration begins with `async` / `throws` / `rethrows` /
+  /// `->`, so this predicate cannot over-fold.
+  private static func continuesWithEffectSpecifier(_ line: String) -> Bool {
+    let trimmed = codeView(line).trimmingCharacters(in: .whitespaces)
+    if trimmed.hasPrefix("->") { return true }
+    for keyword in ["async", "throws", "rethrows"] where trimmed == keyword
+      || trimmed.hasPrefix(keyword + " ") || trimmed.hasPrefix(keyword + "-")
+    {
+      return true
+    }
+    return false
+  }
+
   private static func isUnterminatedDeclaration(_ buffer: String) -> Bool {
     let code = codeView(buffer)
     var paren = 0

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
@@ -197,6 +197,27 @@ enum RouterCeilingParser {
     return (code.filter { $0 == "{" }.count, code.filter { $0 == "}" }.count)
   }
 
+  /// KNOWN LIMIT, recorded rather than fixed (cloud review, PR #2070, round
+  /// fifteen). This counts DECLARATIONS, not bindings, so a multi-binding
+  /// declaration — `let first: () -> Void, second: () -> Void`, which Swift
+  /// accepts — contributes one, and a declaration mixing a closure with a
+  /// collaborator cannot be split at all, because `predicate` answers per LINE
+  /// and returns a Bool.
+  ///
+  /// Left as-is deliberately. Reachability was measured, not assumed: a detector
+  /// that strips bracketed spans before looking for a depth-0 `, name:` (so
+  /// tuple labels and generic arguments do not false-positive, which a plain
+  /// grep does for all ten of its hits) finds ZERO multi-binding declarations
+  /// across `Sources/**/*.swift`, with a two-way control confirming it fires on
+  /// a real one.
+  ///
+  /// Unlike the type-shape findings in this PR, closing this is not a parsing
+  /// fix: it changes what the ceiling COUNTS, which `architecture-rules.md`
+  /// documents, and it requires the predicate to classify per binding rather
+  /// than answer yes/no per line. `validation-discipline.md` RULE:
+  /// validate-automated-review-findings permits fixing an unreachable finding
+  /// only when the fix is trivial; a counting-contract change is not, so the
+  /// limit is written down here instead of guessed at.
   private static func countTopLevelStoredProperties(
     in body: String, where predicate: (String) -> Bool
   ) -> Int {

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
@@ -622,12 +622,16 @@ enum RouterCeilingParser {
   /// the previous pattern kept failing one shape at a time. Comments are already
   /// blanked to spaces by the caller's code view, so they are trivia here too.
   /// `limit` bounds the scan so a recursive call cannot read past the group it
-  /// was handed. `depth` bounds the recursion itself.
+  /// was handed. That bound is also what guarantees termination: each recursive
+  /// call is handed `close`, which is strictly inside the current window, so the
+  /// window shrinks on every step. An explicit depth cap was tried and removed —
+  /// it added no safety the shrinking window did not already give, and it
+  /// silently returned false past its limit, which is an UNDERCOUNT (cloud
+  /// review, PR #2070, round nine).
   private static func closureSignatureFollows(
-    _ chars: [Character], from start: Int, limit: Int? = nil, depth: Int = 0
+    _ chars: [Character], from start: Int, limit: Int? = nil
   ) -> Bool {
     let end = min(limit ?? chars.count, chars.count)
-    guard depth <= 8 else { return false }
     var i = skipTrivia(chars, from: start, limit: end)
     while i < end, chars[i] == "@" {
       i += 1
@@ -649,12 +653,19 @@ enum RouterCeilingParser {
     // Read as a parameter list, the outer group swallows the signature and the
     // `?` that follows is not an arrow, so the property fell to COLLABORATOR
     // (cloud review, PR #2070). When the arrow does not follow the group, scan
-    // INSIDE it as a type instead. `(AlphaDep)` and `(AlphaDep, BetaDep)` fail
-    // both paths and stay collaborators, which the controls pin.
+    // INSIDE it as a type instead.
+    //
+    // Only when the group WRAPS the whole type, though. A TUPLE whose first
+    // element happens to be a closure — `(() -> Void, AlphaDep)` — would
+    // otherwise match on that element alone and count the tuple as a closure
+    // (round nine). A top-level comma is exactly what separates the two: a
+    // tuple has one, and a wrapped function type does not, because
+    // `((A, B) -> C)?`'s comma sits inside the nested parameter list one level
+    // down. That makes this a structural test, not another special case.
     let arrowFollowsGroup =
       afterGroup + 1 < end && chars[afterGroup] == "-" && chars[afterGroup + 1] == ">"
-    if !arrowFollowsGroup,
-      closureSignatureFollows(chars, from: i + 1, limit: close, depth: depth + 1)
+    if !arrowFollowsGroup, !containsTopLevelComma(chars, from: i + 1, to: close),
+      closureSignatureFollows(chars, from: i + 1, limit: close)
     {
       return true
     }
@@ -676,6 +687,35 @@ enum RouterCeilingParser {
       }
     }
     return i + 1 < end && chars[i] == "-" && chars[i + 1] == ">"
+  }
+
+  /// A comma at nesting depth 0 between `from` and `to` — the marker of a TUPLE
+  /// rather than a parenthesised single type. Angle brackets are counted too, so
+  /// the comma in `Result<Int, Error>` is not mistaken for a tuple separator;
+  /// `<`/`>` are ambiguous with comparison in general Swift, but inside a type
+  /// annotation they are generic delimiters.
+  private static func containsTopLevelComma(_ chars: [Character], from: Int, to: Int) -> Bool {
+    var depth = 0
+    var i = from
+    let end = min(to, chars.count)
+    while i < end {
+      // `->` must be consumed as one token. Counting its `>` as a closing
+      // bracket drives depth to -1, and the tuple comma in
+      // `(() -> Void, AlphaDep)` then reads as nested rather than top-level —
+      // which would defeat the whole check.
+      if chars[i] == "-", i + 1 < end, chars[i + 1] == ">" {
+        i += 2
+        continue
+      }
+      switch chars[i] {
+      case "(", "[", "<": depth += 1
+      case ")", "]", ">": depth -= 1
+      case "," where depth == 0: return true
+      default: break
+      }
+      i += 1
+    }
+    return false
   }
 
   private static func skipTrivia(_ chars: [Character], from i: Int, limit: Int? = nil) -> Int {

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
@@ -715,9 +715,15 @@ enum RouterCeilingParser {
     // tuple has one, and a wrapped function type does not, because
     // `((A, B) -> C)?`'s comma sits inside the nested parameter list one level
     // down. That makes this a structural test, not another special case.
+    // The group must also be the WHOLE type on the trailing side, not just the
+    // leading one. `(() -> Void).Type` is a function METATYPE — a collaborator —
+    // and the inner scan succeeds on it, so without this the suffix is ignored
+    // and the metatype counts as a closure (round twelve). Only optional markers
+    // may follow a wrapper and leave it still describing a closure.
     let arrowFollowsGroup =
       afterGroup + 1 < end && chars[afterGroup] == "-" && chars[afterGroup + 1] == ">"
     if !arrowFollowsGroup, !containsTopLevelComma(chars, from: i + 1, to: close),
+      onlyOptionalMarkersRemain(chars, from: close + 1, to: end),
       closureSignatureFollows(chars, from: i + 1, limit: close)
     {
       return true
@@ -747,6 +753,23 @@ enum RouterCeilingParser {
   /// the comma in `Result<Int, Error>` is not mistaken for a tuple separator;
   /// `<`/`>` are ambiguous with comparison in general Swift, but inside a type
   /// annotation they are generic delimiters.
+  /// Everything after a wrapping group is an optional marker (or an initializer,
+  /// which ends the TYPE). `(() -> Void)?` and `(() -> Void)!` still describe a
+  /// closure; `(() -> Void).Type` describes a metatype and must not be claimed
+  /// as one. Stopping at `=` matters because a stored property may carry a
+  /// default value — `let onFinish: (() -> Void)? = nil` — and the type ends
+  /// there, so the initializer text must not be read as part of it.
+  private static func onlyOptionalMarkersRemain(_ chars: [Character], from: Int, to: Int) -> Bool {
+    let end = min(to, chars.count)
+    var i = skipTrivia(chars, from: from, limit: end)
+    while i < end {
+      if chars[i] == "=" { return true }
+      guard chars[i] == "?" || chars[i] == "!" else { return false }
+      i = skipTrivia(chars, from: i + 1, limit: end)
+    }
+    return true
+  }
+
   private static func containsTopLevelComma(_ chars: [Character], from: Int, to: Int) -> Bool {
     var depth = 0
     var i = from

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
@@ -292,11 +292,59 @@ enum RouterCeilingParser {
       for binding in variable.bindings {
         guard binding.accessorBlock == nil else { continue }
         let isBool = binding.initializer.map { isBooleanLiteral($0.value) } ?? false
-        result.append(
-          StoredLet(type: binding.typeAnnotation?.type, isBooleanLiteralInitialized: isBool))
+        expand(
+          pattern: binding.pattern, type: binding.typeAnnotation?.type,
+          isBooleanLiteralInitialized: isBool, depth: 0, into: &result)
       }
     }
     return result
+  }
+
+  /// One `StoredLet` per property a binding actually declares.
+  ///
+  /// A tuple PATTERN declares one property per element: `let (a, b): (X, Y)` is
+  /// two stored properties, and Swift accepts it — including nested, and with
+  /// the type inferred. Both forms compile, checked with `swiftc`, not recalled.
+  ///
+  /// The distinction is the PATTERN, not the type. `let pair: (X, Y)` is ONE
+  /// property whose type happens to be a tuple, and it keeps its single slot —
+  /// which is why `unwrapped(_:)` still refuses to peel multi-element tuple
+  /// TYPES. Reading only the type would conflate the two and count two injected
+  /// closure seams as one collaborator: an undercount, and the direction a
+  /// `<=` ceiling never reports (cloud review, PR #2070).
+  private static func expand(
+    pattern: PatternSyntax, type: TypeSyntax?, isBooleanLiteralInitialized isBool: Bool,
+    depth: Int, into result: inout [StoredLet]
+  ) {
+    guard depth < 16, let tuple = pattern.as(TuplePatternSyntax.self) else {
+      result.append(StoredLet(type: type, isBooleanLiteralInitialized: isBool))
+      return
+    }
+    let elements = Array(tuple.elements)
+    // Pair each sub-pattern with its own type only when the annotation is a
+    // tuple of the SAME arity. Anything else (inferred type, or a shape that
+    // does not line up) drops to nil types rather than guessing: an untyped
+    // binding still counts as a collaborator, so the property stays visible to
+    // a ceiling instead of vanishing.
+    let types = type?.as(TupleTypeSyntax.self).map { Array($0.elements).map(\.type) }
+    if let types, types.count == elements.count {
+      for (element, elementType) in zip(elements, types) {
+        expand(
+          pattern: element.pattern, type: elementType,
+          isBooleanLiteralInitialized: isBool, depth: depth + 1, into: &result)
+      }
+    } else if elements.count == 1, let only = elements.first {
+      // `let (a): X` — parenthesised, not a real tuple; keep the type.
+      expand(
+        pattern: only.pattern, type: type, isBooleanLiteralInitialized: isBool,
+        depth: depth + 1, into: &result)
+    } else {
+      for element in elements {
+        expand(
+          pattern: element.pattern, type: nil, isBooleanLiteralInitialized: isBool,
+          depth: depth + 1, into: &result)
+      }
+    }
   }
 
   private static func isTypeProperty(_ modifiers: DeclModifierListSyntax) -> Bool {

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
@@ -356,7 +356,30 @@ enum RouterCeilingParser {
     // following declaration and would over-fold. "This line ended on an
     // attribute" is unambiguous.
     if endsWithAttribute(trimmed) { return true }
+    // `let dependency` with neither a type annotation nor an initializer cannot
+    // stand alone, so the `:` opening its type is on a following line (cloud
+    // review, PR #2070, round ten):
+    //
+    //     let dependency
+    //       : () -> Void
+    //
+    // Verified against the compiler rather than taken on the report:
+    // `swiftc -swift-version 6 -typecheck` accepts it.
+    if endsWithBareLetBinding(trimmed) { return true }
     return false
+  }
+
+  /// The buffer is a `let` binding that has not reached its `:` or `=` yet.
+  /// Both are excluded explicitly, so `let alpha: AlphaDep` and `let flag = true`
+  /// are complete and cannot fold into the declaration after them — the
+  /// undercount direction this check must not open.
+  private static func endsWithBareLetBinding(_ trimmed: String) -> Bool {
+    guard !trimmed.contains(":"), !trimmed.contains("=") else { return false }
+    let tokens = trimmed.split(whereSeparator: { $0.isWhitespace })
+    guard tokens.count >= 2, let last = tokens.last, tokens.dropLast().contains("let")
+    else { return false }
+    guard let first = last.first, first.isLetter || first == "_" else { return false }
+    return last.allSatisfy { $0.isLetter || $0.isNumber || $0 == "_" }
   }
 
   /// The line's last token is an attribute, in EITHER of the two forms Swift

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
@@ -670,6 +670,43 @@ import Testing
     #expect(RouterCeilingParser.collaboratorCount(in: body) == 2)
   }
 
+  /// #2068 (cloud review, PR #2070, round thirteen). `Optional<() -> Void>` is
+  /// `(() -> Void)?` desugared — the same wrapped closure, spelled generically.
+  /// The scan required the type to begin with `(`, so it fell to COLLABORATOR.
+  ///
+  /// LATENT, measured: `git grep -n "Optional<" -- 'Sources/**/*.swift'` returns
+  /// zero hits, and the sugared form is what this codebase writes. Fixed anyway
+  /// because the fix is genuinely small and the failure is an undercount of
+  /// closures, which is the silent direction.
+  @Test func closureCount_readsTheGenericOptionalSpelling() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let alpha: AlphaDep
+          let sugarFree: Optional<() -> Void>
+          let qualified: Swift.Optional<(Int) -> Bool>
+        }
+        """)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 2)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
+  }
+
+  /// The control: the whole-type guards must still apply THROUGH the generic
+  /// wrapper. `Optional<(() -> Void, AlphaDep)>` wraps a tuple, not a closure,
+  /// and an `Optional` of an ordinary collaborator is still a collaborator.
+  @Test func closureCount_genericOptionalStillRejectsNonClosures() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let bundled: Optional<(() -> Void, AlphaDep)>
+          let plain: Optional<AlphaDep>
+          let real: Optional<() -> Void>
+        }
+        """)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 1)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 2)
+  }
+
   /// The control: the markers that may legitimately follow a wrapper must still
   /// leave it a closure — optionals, forced optionals, and a default value,
   /// whose `=` ends the TYPE rather than disqualifying it.

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
@@ -1201,4 +1201,91 @@ import Testing
         """)
     #expect(RouterCeilingParser.collaboratorCount(in: body) == 2)
   }
+
+  @Test func closureInjectedCount_unwrapsWithNoFixedDepthOfItsOwn() throws {
+    // 15 nested `Optional<...>` layers — the peel carries no limit of its own.
+    //
+    // NOT set past the 64-iteration cap this replaced, because that cap is
+    // unreachable and no passing test could exercise it. Generic angle brackets
+    // DO raise SwiftParser's nesting level, which is 20 under `#if DEBUG`
+    // (`Parser.defaultMaximumNestingLevel`, Parser.swift:134 in the pinned
+    // swift-syntax 603.0.2). Measured on this suite: depth 30 sets `hasError`
+    // so the parser throws, and depth 80 overflows the stack and takes the test
+    // process down with it.
+    //
+    // So no input can reach a 64th unwrap in a DEBUG test build, and neither
+    // bound yields a wrong COUNT — one throws, the other dies loudly. The cap
+    // was removed as dead code carrying a false justifying comment, NOT because
+    // a ceiling could be evaded through it.
+    let depth = 15
+    let type =
+      String(repeating: "Optional<", count: depth) + "() -> Void"
+      + String(repeating: ">", count: depth)
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let deeplyWrapped: \(type)
+        }
+        """)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 1)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 0)
+  }
+
+  @Test func closureInjectedCount_expandsTuplePatternsWithNoFixedDepthOfItsOwn() throws {
+    // 12 levels, comfortably inside SwiftParser's DEBUG nesting budget (see the
+    // fail-closed test below) and past nothing in particular — the point is that
+    // the walk carries no depth limit of its own, so the only bound is the
+    // parser's.
+    let depth = 12
+    // Names must be UNIQUE — two properties cannot share one, and a fixture
+    // that does not compile tests nothing. Two of this suite's original 52
+    // fixtures were invalid Swift for exactly this kind of reason.
+    let pattern =
+      (0..<depth).map { "(leaf\($0), " }.joined() + "last"
+      + String(repeating: ")", count: depth)
+    let type =
+      String(repeating: "(() -> Void, ", count: depth) + "() -> Void"
+      + String(repeating: ")", count: depth)
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let \(pattern): \(type)
+        }
+        """)
+    // One closure per leaf: `depth` left-hand leaves plus the innermost.
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == depth + 1)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 0)
+  }
+
+  @Test func classBody_failsClosedWhenNestingExceedsTheParsersOwnLimit() {
+    // The REAL bound on nesting is SwiftParser's, not ours:
+    // `Parser.defaultMaximumNestingLevel` is 20 under `#if DEBUG` and 256
+    // otherwise (Parser.swift:134 in the pinned swift-syntax 603.0.2), raised by
+    // every bracket. Tests run DEBUG, so a 30-deep tuple pattern — which
+    // `swiftc` itself accepts — exceeds it.
+    //
+    // This is the test that matters for the ceilings: past that limit the parser
+    // must THROW, never return a small confident number. A cloud-review finding
+    // argued a deeply nested seam could be miscounted as a collaborator and slip
+    // under a `<=` ceiling; it cannot, because the source never reaches the
+    // counters at all (PR #2070).
+    let depth = 30
+    let pattern =
+      (0..<depth).map { "(leaf\($0), " }.joined() + "last"
+      + String(repeating: ")", count: depth)
+    let type =
+      String(repeating: "(() -> Void, ", count: depth) + "() -> Void"
+      + String(repeating: ")", count: depth)
+    // `withKnownIssue` rather than `#expect(throws:)`: the fail-closed path
+    // ALSO calls `Issue.record` on its way out, so the recorded issue would fail
+    // this test even though throwing is the behaviour being asserted.
+    withKnownIssue("parsed(_:context:) records an issue as well as throwing") {
+      _ = try classBody(
+        of: """
+          final class Probe {
+            let \(pattern): \(type)
+          }
+          """)
+    }
+  }
 }

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
@@ -1257,6 +1257,31 @@ import Testing
     #expect(RouterCeilingParser.collaboratorCount(in: body) == 0)
   }
 
+  @Test func collaboratorCount_countsAnAliasedClosureAsACollaborator_knownLimit() throws {
+    // A KNOWN LIMIT, pinned deliberately so it is not "fixed" as a bug.
+    //
+    // `ProgressCallback` is `@Sendable (Double, String, String) -> Void`, but
+    // this parser reads ONE file and has no type resolution, so the annotation
+    // is just an identifier and the property lands in the collaborator bin.
+    // Resolving it would mean re-implementing type resolution on top of the
+    // parser — the approximation business the SwiftSyntax rewrite left.
+    //
+    // The consequence is not academic: with one bin full and the other holding
+    // a spare slot, an aliased closure passes BOTH caps. That was demonstrated
+    // against the real `RecordingStarter` on PR #2070 and is why
+    // `RecordingStarterCeilingsTests.totalStoredDependencyCount` caps the SUM,
+    // which no re-typing can move.
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let aliased: ProgressCallback
+          let literal: () -> Void
+        }
+        """)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 1)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
+  }
+
   @Test func classBody_failsClosedWhenNestingExceedsTheParsersOwnLimit() {
     // The REAL bound on nesting is SwiftParser's, not ours:
     // `Parser.defaultMaximumNestingLevel` is 20 under `#if DEBUG` and 256

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
@@ -410,6 +410,81 @@ import Testing
     #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
   }
 
+  /// #2068 (cloud review, PR #2070, round seven). An OPTIONAL function type
+  /// parenthesises the whole type — `(() -> Void)?` — so the scanner read the
+  /// outer group as the parameter list, found `?` where it wanted `->`, and gave
+  /// up. Optional callbacks are the single most ordinary closure-dependency
+  /// shape in this codebase, and they fell to COLLABORATOR.
+  @Test func closureCount_countsOptionalAndParenthesisedFunctionTypes() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let alpha: AlphaDep
+          let onFinish: (() -> Void)?
+          let onFail: ((Error) -> Void)?
+          let wrapped: (@MainActor (Int) async -> Bool)
+        }
+        """)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 3)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
+  }
+
+  /// #2068 (cloud review, PR #2070, round seven). An attribute may sit alone on
+  /// the line before the parameter list. The fold looked for an effect specifier
+  /// or an arrow, and `()` is neither, so line one was emitted as a finished
+  /// declaration.
+  ///
+  /// Closed by termination rather than by lookahead: a buffer whose last token is
+  /// `@MainActor` cannot be a complete declaration, whereas "the next line starts
+  /// with `(`" is also true of an ordinary following declaration and would
+  /// over-fold into an undercount.
+  @Test func closureCount_foldsWhenAnAttributeEndsTheLine() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let alpha: AlphaDep
+          let deferred: @MainActor
+            () -> Void
+          let beta: BetaDep
+        }
+        """)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 1)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 2)
+  }
+
+  /// The control for the recursive scan: a parenthesised NON-function type must
+  /// not become a closure just because the scanner now looks inside groups.
+  /// `(AlphaDep)` is the exact shape `closureCount_doesNotFoldACompleteParenthesizedType`
+  /// pins, and a tuple of collaborators must stay one collaborator.
+  @Test func closureCount_recursionDoesNotInventClosuresInsidePlainGroups() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let wrapped: (AlphaDep)
+          let pair: (AlphaDep, BetaDep)
+          let nested: ((AlphaDep, BetaDep), GammaDep)
+        }
+        """)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 0)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 3)
+  }
+
+  /// The control for the attribute-termination rule: an attribute that is NOT at
+  /// the end of the line must not make the declaration unterminated, or every
+  /// `@MainActor (Int) -> Bool` would swallow the line after it.
+  @Test func closureCount_attributeMidLineDoesNotFoldTheNextDeclaration() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let onEvent: @MainActor (Int) -> Bool
+          let beta: BetaDep
+          let gamma: GammaDep
+        }
+        """)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 1)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 2)
+  }
+
   /// The control for both fixtures above: balancing brackets must not turn
   /// ordinary generic collaborators into closures. None of these declares a
   /// function type, and each contains the punctuation the scanner reads.

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
@@ -496,6 +496,44 @@ import Testing
     #expect(RouterCeilingParser.collaboratorCount(in: body) == 2)
   }
 
+  /// #2068 (cloud review, PR #2070, round ten). The `:` opening a type
+  /// annotation may itself start the continuation line. Line one is then a bare
+  /// `let dependency`, which the fold read as a finished declaration.
+  ///
+  /// Confirmed against the compiler before fixing — `swiftc -swift-version 6
+  /// -typecheck` accepts the form — rather than taken from the report, because
+  /// the sibling finding in the same round asserted a syntax Swift rejects.
+  @Test func closureCount_foldsWhenTheColonStartsTheNextLine() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let alpha: AlphaDep
+          let deferred
+            : () -> Void
+          let beta: BetaDep
+        }
+        """)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 1)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 2)
+  }
+
+  /// The over-fold control: a `let` that HAS reached its `:` or `=` is complete
+  /// and must not swallow the declaration after it. Without this, "a `let` line
+  /// might continue" would fold every property into its neighbour and undercount
+  /// the whole class.
+  @Test func closureCount_aCompleteLetDoesNotFoldTheNextDeclaration() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let alpha: AlphaDep
+          let beta: BetaDep
+          let gamma: GammaDep
+        }
+        """)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 3)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 0)
+  }
+
   /// The control for that rule: a comma belonging to a GENERIC argument list or
   /// to the wrapped function's own parameter list is not a tuple separator, and
   /// must not block the recursion.

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
@@ -1148,4 +1148,57 @@ import Testing
     #expect(RouterCeilingParser.closureInjectedCount(in: body) == 1)
     #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
   }
+
+  @Test func closureInjectedCount_expandsATupleDestructuringPatternIntoOneSlotEach() throws {
+    // `let (a, b): (X, Y)` is TWO stored properties. Reading only the type sees
+    // one non-function tuple and charges a single collaborator slot, so two
+    // injected closure seams cost one — an undercount, which a `<=` ceiling
+    // never reports (cloud review, PR #2070).
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let (first, second): (() -> Void, () -> Void)
+        }
+        """)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 2)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 0)
+  }
+
+  @Test func closureInjectedCount_expandsNestedTuplePatterns() throws {
+    // Swift accepts nesting here, so the expansion recurses.
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let (outer, (innerA, innerB)): (() -> Void, (() -> Void, () -> Void))
+        }
+        """)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 3)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 0)
+  }
+
+  @Test func collaboratorCount_aTupleTYPEStillOccupiesOneSlot() throws {
+    // The counterpart the expansion must NOT break: an identifier pattern whose
+    // TYPE is a tuple is one property, not two. The distinction is the pattern.
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let pair: (AlphaDep, BetaDep)
+        }
+        """)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 0)
+  }
+
+  @Test func collaboratorCount_aDestructuredInferredTupleStaysVisible() throws {
+    // No annotation, so no per-element type is knowable. Each property must
+    // still be COUNTED — dropping to nil types keeps them collaborators rather
+    // than letting them vanish from every ceiling.
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let (first, second) = ({ print(1) }, { print(2) })
+        }
+        """)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 2)
+  }
 }

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
@@ -624,6 +624,37 @@ import Testing
     #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
   }
 
+  /// #2068 (cloud review, PR #2070, round nineteen). The report was that
+  /// `let d: @MainActor@Sendable` — adjacent attributes with NO whitespace —
+  /// followed by `() -> Void` is not folded, because `endsWithAttribute` takes
+  /// the last whitespace-separated token and `@MainActor@Sendable` is not a
+  /// single attribute name. The premise is true and the form compiles.
+  ///
+  /// It cannot persist in this repository, though: swift-format normalises the
+  /// spacing on write. Handed that exact source, the formatter produces the
+  /// shape below — annotation colon on line one, attributes on line two, the
+  /// function type on line three — which is what a contributor's file actually
+  /// contains after saving.
+  ///
+  /// So this pins the reachable form rather than the reported one. It folds
+  /// through two rules already here: the `:`-terminated line (original) and the
+  /// attribute-terminated line (round fourteen). Worth a test because nothing
+  /// previously covered them CHAINED across three physical lines.
+  @Test func closureCount_foldsTheFormatterNormalisedAttributeWrap() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let alpha: AlphaDep
+          let dependency:
+            @MainActor @Sendable
+            () -> Void
+          let beta: BetaDep
+        }
+        """)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 1)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 2)
+  }
+
   /// The over-fold control: a `let` that HAS reached its `:` or `=` is complete
   /// and must not swallow the declaration after it. Without this, "a `let` line
   /// might continue" would fold every property into its neighbour and undercount

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
@@ -287,6 +287,109 @@ import Testing
     #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
   }
 
+  /// #2068 (cloud review, PR #2070, the finding after the structural fix): the
+  /// trivia the fold looks past can be a `/* ... */` that SPANS lines. The
+  /// lookahead used to call `codeView` on each candidate line separately, and
+  /// block-comment depth is per-call state — so it reset at every line boundary
+  /// and the comment's INTERIOR lines came back as code. The lookahead stopped
+  /// on the first of them, found no effect specifier, and gave up.
+  ///
+  /// The fix blanks the whole body ONCE and splits after, which is why the
+  /// fixture's comment body is three lines rather than one: a single-line block
+  /// comment is blanked correctly either way and would prove nothing.
+  ///
+  /// `(Renderer)`, not `(Int)` — a primitive `let` is excluded from BOTH
+  /// counters, so a fixture using one holds every number still whether the fold
+  /// works or not. Here the miscount moves both: unfolded, `spanning` leaves the
+  /// closure count and lands in the collaborator count.
+  @Test func closureCount_foldsPastAMultiLineBlockComment() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let alpha: AlphaDep
+          let spanning: (Renderer)
+            /* the daemon can answer late,
+               so this dependency is
+               deliberately deferred */
+            async -> Void
+          let beta: BetaDep
+        }
+        """)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 1)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 2)
+  }
+
+  /// The same class, one layer down and load-bearing: BRACE DEPTH. `braceCounts`
+  /// deliberately ran without block-comment blanking, and `codeView`'s own doc
+  /// recorded why — a per-LINE call resets the depth, so blanking there would
+  /// mis-track braces inside a multi-line comment. The cost of leaving it off was
+  /// never written down: a `}` inside a block comment is counted as real, drives
+  /// brace depth NEGATIVE, and every following declaration is then judged
+  /// non-top-level and skipped.
+  ///
+  /// That is an UNDERCOUNT of a ceiling — the one direction
+  /// `closureCount_doesNotFoldACompleteParenthesizedType` already says a ceiling
+  /// must never fail in. Blanking once over the whole body is what makes it safe
+  /// to close, which is why this arrives with the lookahead fix and not later.
+  ///
+  /// No ceiling was mis-read when this landed: `Sources/` held exactly one block
+  /// comment, inline and brace-free. The fixture below is therefore the only
+  /// place the bug can be observed, which is precisely why it is worth pinning —
+  /// the failure needs no unusual code to appear, just an ordinary `/* ... */`
+  /// that happens to contain a brace, and it would then read LOW and pass.
+  @Test func braceDepth_ignoresBracesInsideABlockComment() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let alpha: AlphaDep
+          /* a note containing a stray } brace
+             and a second line with { too */
+          let beta: BetaDep
+          let gamma: GammaDep
+        }
+        """)
+    // Without blanking, the stray `}` drops depth to -1 and `beta`/`gamma` are
+    // never seen as top-level: the count reads 1 instead of 3.
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 3)
+  }
+
+  /// The control: real braces must still move depth, or the fix above could pass
+  /// by blanking too much. A nested type's members are NOT top-level properties
+  /// of the outer class and must stay excluded.
+  @Test func braceDepth_stillExcludesMembersOfANestedType() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let alpha: AlphaDep
+          struct Inner {
+            let notCounted: BetaDep
+            let alsoNotCounted: GammaDep
+          }
+          let beta: BetaDep
+        }
+        """)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 2)
+  }
+
+  /// The two-way control for the fixture above. A multi-line block comment that
+  /// is NOT followed by an effect specifier must still leave the declaration
+  /// unfolded — otherwise the test above could pass because the fold became
+  /// greedy rather than because it learned to see past the comment.
+  @Test func closureCount_doesNotFoldPastACommentWhenNoSpecifierFollows() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let alpha: AlphaDep
+          let wrapped: (Renderer)
+            /* a note that spans
+               more than one line */
+          let beta: BetaDep
+        }
+        """)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 0)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 3)
+  }
+
   /// The other half of matching on the code view: an arrow that only LOOKS like
   /// a closure type must not create one. Before this, `isClosureTyped` read raw
   /// text, so a comment or string containing `-> ` could fake a signature — the

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
@@ -213,6 +213,44 @@ import Testing
     #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
   }
 
+  /// #2068 (cloud review, PR #2070): the effect specifier can START the next
+  /// physical line, leaving line one with balanced parens and no trailing
+  /// continuation operator — so it reads as a finished declaration and the
+  /// closure is missed entirely.
+  @Test func closureCount_foldsWhenTheEffectSpecifierStartsTheNextLine() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let alpha: AlphaDep
+          let dependency: ()
+            async -> Void
+          let other: (Int)
+            throws -> Bool
+          let arrowOnly: (String)
+            -> Int
+        }
+        """)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 3)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
+  }
+
+  /// The over-folding control. A complete parenthesized type must NOT swallow
+  /// the declaration after it — that would UNDERCOUNT, which is the direction a
+  /// ceiling must never fail in. This is why the fold looks ahead for an effect
+  /// specifier instead of treating a trailing `)` as a continuation.
+  @Test func closureCount_doesNotFoldACompleteParenthesizedType() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let wrapped: (AlphaDep)
+          let beta: BetaDep
+          let gamma: GammaDep
+        }
+        """)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 0)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 3)
+  }
+
   @Test func nonPrivateMethodCount_countsNonPrivateExcludesPrivateAndInit() throws {
     let body = try classBody(
       of: """

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
@@ -647,7 +647,15 @@ import Testing
         final class Probe {
           let alpha: AlphaDep
           let isolated: @isolated(any) () -> Void
-          let gated: @available(macOS 26, *) (Int) -> Bool
+          // Was `@available(macOS 26, *)` until the SwiftSyntax rewrite refused
+          // to parse it: `@available` is a DECLARATION attribute and cannot be
+          // applied to a type ("attribute can only be applied to declarations,
+          // not types" — verified with swiftc). The text scanner accepted the
+          // fixture because it validated nothing, so this test spent twelve
+          // rounds asserting behaviour on Swift that cannot exist.
+          // `@convention(c)` is a real TYPE attribute that takes arguments,
+          // which is what the test was always trying to exercise.
+          let gated: @convention(c) (Int) -> Bool
         }
         """)
     #expect(RouterCeilingParser.closureInjectedCount(in: body) == 2)
@@ -746,7 +754,13 @@ import Testing
       of: """
         final class Probe {
           let wrapped: (AlphaDep)
-          let built: Factory(config)
+          // Was `Factory(config)`, which is not a type at all — swiftc rejects
+          // it with "unexpected initializer in pattern". Same story as the
+          // fixture above: invented to end a line in `)`, accepted by a scanner
+          // that never parsed, and only caught once a real parser read it.
+          // A tuple is a genuine type that ends in `)`, which is the property
+          // this control actually needs.
+          let built: (AlphaDep, BetaDep)
           let beta: BetaDep
         }
         """)

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
@@ -254,6 +254,57 @@ import Testing
     #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
   }
 
+  /// #2068, the CLASS rather than another instance. Three review rounds each
+  /// found one more permitted-but-unhandled placement in the same predicate
+  /// (`async`, then the specifier on the next line, then typed throws), which is
+  /// the signal to stop patching shapes: Swift's function-type grammar admits
+  /// arbitrary trivia between every token, so any matcher keyed to
+  /// physically-adjacent text has an unbounded tail of these.
+  ///
+  /// Closed structurally instead — the predicate matches the CODE VIEW (comments
+  /// and string contents blanked to spaces) and the fold looks PAST trivia — so
+  /// these cases pass by construction rather than by enumeration. This is the
+  /// exhaustive sweep of the class, not the next entry in it.
+  @Test func closureCount_toleratesTriviaAnywhereInTheSignature() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let alpha: AlphaDep
+          let commented: ()
+            // why this one is async
+            async -> Void
+          let blankLine: (Int)
+
+            throws -> Bool
+          let inlineComment: (String)  // a trailing note
+            -> Int
+          let both: ()
+            // documented
+            async throws(DomainError) -> Void
+        }
+        """)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 4)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
+  }
+
+  /// The other half of matching on the code view: an arrow that only LOOKS like
+  /// a closure type must not create one. Before this, `isClosureTyped` read raw
+  /// text, so a comment or string containing `-> ` could fake a signature — the
+  /// same class of false positive `classBody` already guards against for braces
+  /// (#826).
+  @Test func closureCount_ignoresArrowsInCommentsAndStrings() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let alpha: AlphaDep  // maps (Int) -> Bool internally
+          let label: Renderer = makeRenderer("(Int) -> Bool")
+          let real: @MainActor (Int) -> Bool
+        }
+        """)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 1)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 2)
+  }
+
   /// The over-folding control. A complete parenthesized type must NOT swallow
   /// the declaration after it — that would UNDERCOUNT, which is the direction a
   /// ceiling must never fail in. This is why the fold looks ahead for an effect

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
@@ -148,6 +148,36 @@ import Testing
     #expect(RouterCeilingParser.closureInjectedCount(in: body) == 1)
   }
 
+  /// #2068 (cloud review, PR #2070, round twenty). The report was `final let`,
+  /// which the modifier alternation omitted. Rather than add that one word and
+  /// wait for the next modifier, the set was ENUMERATED against the compiler:
+  /// every candidate was type-checked as `<modifier> let d: AnyObject`.
+  ///
+  /// Accepted and now handled: access modifiers, `final`, `dynamic`,
+  /// `nonisolated(unsafe)?`, `unowned((safe|unsafe))?`. Rejected by Swift
+  /// outright, so they cannot appear and need no handling: `override`, `lazy`,
+  /// `weak`, `mutating`, `convenience`, `required`.
+  ///
+  /// All three newly added modifiers measure zero in `Sources/`, so this is
+  /// unreachable today — taken because closing the whole set costs one
+  /// alternation, which is cheaper than three more review rounds.
+  @Test func collaboratorCount_countsEveryModifierSwiftAllowsOnAStoredLet() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          final let alpha: AlphaDep
+          dynamic let beta: BetaDep
+          unowned let gamma: GammaDep
+          unowned(unsafe) let delta: DeltaDep
+          final private let epsilon: EpsilonDep
+          private final let zeta: ZetaDep
+          final let onEvent: @Sendable (Int) -> Bool
+        }
+        """)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 6)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 1)
+  }
+
   /// The control for that widening: `static let` is a TYPE property, not an
   /// injected instance collaborator, and must stay excluded. Admitting
   /// `nonisolated` to the modifier alternation is exactly the edit that could

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
@@ -371,6 +371,61 @@ import Testing
     #expect(RouterCeilingParser.collaboratorCount(in: body) == 2)
   }
 
+  /// #2068 (cloud review, PR #2070, round six). The parameter list was matched
+  /// with `\([^)]*\)`, which stops at the FIRST `)` — so any parenthesis nested
+  /// inside the parameter type ends the match early and the outer `->` is never
+  /// reached. A regex cannot balance brackets; five rounds of widening the
+  /// character classes could not have fixed this, because it is not a missing
+  /// syntax shape but a missing capability.
+  ///
+  /// Fails toward COLLABORATOR, so the closure ceiling silently stops counting
+  /// the dependency it exists to bound.
+  @Test func closureCount_balancesParenthesesNestedInTheParameterType() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let alpha: AlphaDep
+          let handler: (Result<(Int, String), DomainError>) -> Void
+          let deep: @MainActor (Outcome<(A, (B, C)), Failure>) async -> Bool
+        }
+        """)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 2)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
+  }
+
+  /// Swift requires no whitespace around effect specifiers or the arrow, but the
+  /// pattern demanded at least one space before each. `()async->Void` is a valid
+  /// stored closure and read as a collaborator.
+  @Test func closureCount_acceptsEffectSpecifiersWithNoSurroundingWhitespace() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let alpha: AlphaDep
+          let tight: ()async->Void
+          let strict: ()throws(DomainError)->Bool
+          let plain: (Int)->String
+        }
+        """)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 3)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
+  }
+
+  /// The control for both fixtures above: balancing brackets must not turn
+  /// ordinary generic collaborators into closures. None of these declares a
+  /// function type, and each contains the punctuation the scanner reads.
+  @Test func closureCount_stillRejectsGenericsThatMerelyContainParentheses() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let store: Storage<(Int, String)>
+          let pair: (AlphaDep, BetaDep)
+          let factory: Provider<Handler>
+        }
+        """)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 0)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 3)
+  }
+
   /// The two-way control for the fixture above. A multi-line block comment that
   /// is NOT followed by an effect specifier must still leave the declaration
   /// unfolded — otherwise the test above could pass because the fold became

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
@@ -1095,4 +1095,57 @@ import Testing
         """)
     #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
   }
+
+  @Test func imports_descendIntoConditionalCompilationBlocks() {
+    // An import behind `#if` arrives as an `IfConfigDeclSyntax` statement, not
+    // an `ImportDeclSyntax`. A hand-written loop over `tree.statements` misses
+    // it, so an import-restriction guard would report a forbidden module as
+    // absent — a false green, and the third instance of this one mistake in
+    // this file (cloud review, PR #2070).
+    let source = """
+      import Foundation
+      #if DEBUG
+        import EnviousWisprServices
+      #else
+        import EnviousWisprCore
+      #endif
+      """
+    #expect(
+      RouterCeilingParser.imports(in: source)
+        == ["Foundation", "EnviousWisprServices", "EnviousWisprCore"])
+  }
+
+  @Test func closureInjectedCount_excludesAnInferredClosureThatCannotBeInjected() throws {
+    // `let seam = { ... }` has no type annotation, so it is NOT an injected
+    // seam and must not consume a closure slot: Swift REQUIRES a type
+    // annotation on a stored property with no initializer ("type annotation
+    // missing in pattern"), so an omitted annotation proves the property
+    // initializes itself. It still counts as a collaborator, so it cannot grow
+    // the class past a ceiling unobserved — the two counters together admit no
+    // gap (cloud review, PR #2070).
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let injected: () -> Void
+          let selfMade = { print("hi") }
+        }
+        """)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 1)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
+  }
+
+  @Test func collaboratorCount_doesNotUnwrapAnOptionalNestedInAnotherType() throws {
+    // `Box.Optional<T>` is not `Swift.Optional<T>`; it is whatever `Box` says
+    // it is. Unwrapping on the member name alone would reclassify a
+    // collaborator as a closure on a name match (cloud review, PR #2070).
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let real: Swift.Optional<() -> Void>
+          let impostor: Box.Optional<() -> Void>
+        }
+        """)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 1)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
+  }
 }

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
@@ -185,6 +185,34 @@ import Testing
     #expect(RouterCeilingParser.closureInjectedCount(in: body) == 1)
   }
 
+  /// #2068: an `async` closure used to match neither `isClosureTyped` nor
+  /// `isPrimitiveTyped`, so it counted as a COLLABORATOR — it evaded the closure
+  /// ceiling entirely while consuming a collaborator slot. Both counters were
+  /// wrong about the same property, in opposite directions.
+  ///
+  /// Measured on the real file: `RecordingStarter.closureInjectedCount` read 8
+  /// against 10 closure-typed `let`s, the two missing being
+  /// `makeRecoveryDirective` and `ensureSelectedReadyForPress` — both `async`,
+  /// and both dependencies of exactly the shape the closure ceiling exists to
+  /// bound.
+  @Test func closureCount_countsEffectfulClosures() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let alpha: AlphaDep
+          let load: @MainActor () async -> SomeResult
+          let fetch: @MainActor (Int) throws -> Bool
+          let both: @MainActor () async throws -> SomeResult
+          let wrapped:
+            @MainActor (Settings, Backend, Bool) async -> (id: String, payload: Data)?
+        }
+        """)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 4)
+    // The two-way half: the effectful closures left the collaborator count, they
+    // did not merely join the closure count. `alpha` is the only collaborator.
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
+  }
+
   @Test func nonPrivateMethodCount_countsNonPrivateExcludesPrivateAndInit() throws {
     let body = try classBody(
       of: """

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
@@ -517,6 +517,69 @@ import Testing
     #expect(RouterCeilingParser.collaboratorCount(in: body) == 2)
   }
 
+  /// #2068 (cloud review, PR #2070, round eleven). `isClosureTyped` retried the
+  /// closure parse after EVERY colon, so a non-closure type holding a closure
+  /// matched on an inner one: `let handlers: [String: () -> Void]` is a
+  /// dictionary — a collaborator — but its value-type colon parses as a closure
+  /// signature. Now only the declaration's own annotation colon (bracket depth 0)
+  /// is tried.
+  ///
+  /// Pre-existing rather than introduced by the scanner: the regex this replaced
+  /// matched the same inner colon. Earlier in this PR I noted the behaviour and
+  /// called it "no regression", which was true and beside the point — it was
+  /// still a miscount.
+  @Test func closureCount_aDictionaryOfClosuresIsACollaborator() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let handlers: [String: () -> Void]
+          let lookup: [Int: (String) -> Bool]
+          let real: (Int) -> Bool
+        }
+        """)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 1)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 2)
+  }
+
+  /// #2068 (cloud review, PR #2070, round eleven). `@Sendable()->Void` is valid
+  /// Swift and its adjacent `()` IS the parameter list, so the adjacency rule
+  /// consumed it as attribute arguments and the property fell to COLLABORATOR.
+  ///
+  /// The report paired it with `@MainActor()->Void`, which does NOT compile
+  /// (`error: expected type`), so the two forms cannot be separated by shape.
+  /// Whether an attribute takes arguments is not knowable here, so the scan
+  /// decides by what FOLLOWS the group: an arrow or effect specifier means the
+  /// group was the parameter list.
+  @Test func closureCount_readsACompactAttributeAndParameterList() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let alpha: AlphaDep
+          let tight: @Sendable()->Void
+          let effectful: @Sendable()async->Bool
+        }
+        """)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 2)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
+  }
+
+  /// The control for that rewind: an attribute whose adjacent group really IS an
+  /// argument list must keep it, or `@isolated(any) () -> Void` loses its
+  /// parameter list and stops parsing. The discriminator is what follows the
+  /// group — here another `(`, not an arrow.
+  @Test func closureCount_keepsGenuineAttributeArgumentLists() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let alpha: AlphaDep
+          let isolated: @isolated(any) () -> Void
+          let gated: @available(macOS 26, *) (Int) -> Bool
+        }
+        """)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 2)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
+  }
+
   /// The over-fold control: a `let` that HAS reached its `:` or `=` is complete
   /// and must not swallow the declaration after it. Without this, "a `let` line
   /// might continue" would fold every property into its neighbour and undercount

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
@@ -120,6 +120,50 @@ import Testing
     #expect(RouterCeilingParser.collaboratorCount(in: body) == 2)
   }
 
+  /// #2068 (cloud review, PR #2070, round eighteen). `nonisolated let` is how a
+  /// `@MainActor` class exposes a Sendable seam, and `RecordingStarter` — whose
+  /// ceilings this parser freezes — is `@MainActor`. The stored-property pattern
+  /// allowed attributes and access control but not `nonisolated`, so such a
+  /// property was invisible to BOTH counters: not a collaborator, not a closure,
+  /// simply absent.
+  ///
+  /// Reachable, unlike the generic-spelling findings recorded as limits:
+  /// `nonisolated` appears at top level in 27 files here. The tell that it was an
+  /// oversight rather than a decision is the twin — `nonPrivateMethodPattern` has
+  /// always carried `nonisolated`, so the method side already knew.
+  ///
+  /// All four orderings verified with `swiftc -swift-version 6 -typecheck`.
+  @Test func collaboratorCount_countsNonisolatedStoredProperties() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          nonisolated let alpha: AlphaDep
+          private nonisolated let beta: BetaDep
+          nonisolated private let gamma: GammaDep
+          nonisolated(unsafe) let delta: DeltaDep
+          nonisolated let onEvent: @Sendable (Int) -> Bool
+        }
+        """)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 4)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 1)
+  }
+
+  /// The control for that widening: `static let` is a TYPE property, not an
+  /// injected instance collaborator, and must stay excluded. Admitting
+  /// `nonisolated` to the modifier alternation is exactly the edit that could
+  /// let `static` in alongside it.
+  @Test func collaboratorCount_stillExcludesStaticTypeProperties() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let alpha: AlphaDep
+          static let shared: Registry
+          private static let table: Lookup
+        }
+        """)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
+  }
+
   @Test func collaboratorCount_excludesVarStoredProperty() throws {
     // `var` is owned mutable state, not a collaborator (architecture-rules.md).
     let body = try classBody(

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
@@ -691,6 +691,61 @@ import Testing
     #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
   }
 
+  /// #2068 (cloud review, PR #2070, round fourteen). The generic-wrapper branch
+  /// added last round returned as soon as its inner type parsed and never
+  /// checked what followed, so `Optional<() -> Void>.Type` — a metatype — read as
+  /// a closure. That is the SAME hole round twelve closed for the parenthesised
+  /// wrapper, reopened by a new path that skipped the shared guard.
+  ///
+  /// Worth pinning as its own test rather than folding into the round-twelve
+  /// one: the lesson is not "metatypes are collaborators", it is that a second
+  /// wrapper path must end at the same trailing check as the first.
+  @Test func closureCount_genericOptionalRejectsAMetatypeSuffix() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let meta: Optional<() -> Void>.Type
+          let real: Optional<() -> Void>
+        }
+        """)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 1)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
+  }
+
+  /// #2068 (cloud review, PR #2070, round fourteen). Swift accepts trivia inside
+  /// the generic-Optional prefix — `Optional <…>`, `Swift . Optional<…>`, and
+  /// `Optional /* docs */ <…>`, the last arriving here already blanked to spaces
+  /// by the code view. Two string literals could not see any of them.
+  @Test func closureCount_genericOptionalToleratesTriviaInThePrefix() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let alpha: AlphaDep
+          let spaced: Optional <() -> Void>
+          let qualified: Swift . Optional<(Int) -> Bool>
+          let commented: Optional /* the callback */ <() -> Void>
+        }
+        """)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 3)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
+  }
+
+  /// The control for that tolerance: a type whose name merely ENDS in `Optional`
+  /// is not the generic wrapper, and `matchesKeyword`'s identifier-boundary
+  /// check is what keeps them apart.
+  @Test func closureCount_aTypeNamedLikeOptionalIsNotTheWrapper() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let custom: MyOptional<() -> Void>
+          let other: OptionalThing<() -> Void>
+          let real: Optional<() -> Void>
+        }
+        """)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 1)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 2)
+  }
+
   /// The control: the whole-type guards must still apply THROUGH the generic
   /// wrapper. `Optional<(() -> Void, AlphaDep)>` wraps a tuple, not a closure,
   /// and an `Optional` of an ordinary collaborator is still a collaborator.

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
@@ -473,6 +473,64 @@ import Testing
     #expect(RouterCeilingParser.collaboratorCount(in: body) == 2)
   }
 
+  /// #2068 (cloud review, PR #2070, round nine). The round-seven recursion into
+  /// a parenthesised group matched a TUPLE whose first element is a closure —
+  /// `(() -> Void, AlphaDep)` — because the scan succeeded on that element and
+  /// never checked it spanned the whole group. The tuple is a collaborator, not
+  /// a closure, so this over-counted closures and under-counted collaborators:
+  /// a defect the recursion itself introduced.
+  ///
+  /// A top-level comma is the structural separator: a tuple has one; a wrapped
+  /// function type does not, since `((A, B) -> C)?`'s comma is one level down
+  /// inside the parameter list.
+  @Test func closureCount_aTupleContainingAClosureIsNotAClosure() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let bundle: (() -> Void, AlphaDep)
+          let reversed: (AlphaDep, () -> Void)
+          let real: (() -> Void)?
+        }
+        """)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 1)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 2)
+  }
+
+  /// The control for that rule: a comma belonging to a GENERIC argument list or
+  /// to the wrapped function's own parameter list is not a tuple separator, and
+  /// must not block the recursion.
+  @Test func closureCount_commasInsideNestedTypesStillCountAsClosures() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let alpha: AlphaDep
+          let paired: ((Int, String) -> Void)?
+          let generic: ((Result<Int, DomainError>) -> Void)?
+        }
+        """)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 2)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
+  }
+
+  /// #2068 (cloud review, PR #2070, round nine). The recursion carried an
+  /// arbitrary depth cap of 8 that returned false past its limit — silently, and
+  /// in the UNDERCOUNT direction. The cap bought nothing: each recursive call is
+  /// handed the current group's closing index as its limit, so the window
+  /// strictly shrinks and termination is already guaranteed. Nine wrappers is
+  /// absurd in real code, which is exactly why a wrong answer there would never
+  /// be noticed.
+  @Test func closureCount_survivesDeeplyNestedWrappers() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let alpha: AlphaDep
+          let deep: (((((((((() -> Void)))))))))
+        }
+        """)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 1)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
+  }
+
   /// The over-fold control for that rule: a line ending in `)` that is a
   /// COMPLETED type, not an attribute, must still terminate the declaration.
   /// This is the exact failure the round-seven reasoning was guarding against

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
@@ -234,6 +234,26 @@ import Testing
     #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
   }
 
+  /// Typed throws (cloud review, PR #2070). `() throws(MyError) -> Void` is a
+  /// valid stored closure on this Swift 6 target, and the error type sits
+  /// between `throws` and `->` — so a pattern expecting the arrow immediately
+  /// after the specifier counts it as a COLLABORATOR instead. Same silent
+  /// miscount as the plain `async` case, one syntax feature further out.
+  @Test func closureCount_countsTypedThrows() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let alpha: AlphaDep
+          let strict: @MainActor () throws(DomainError) -> Void
+          let both: @MainActor (Int) async throws(DomainError) -> Bool
+          let wrapped: (String)
+            throws(DomainError) -> Int
+        }
+        """)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 3)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
+  }
+
   /// The over-folding control. A complete parenthesized type must NOT swallow
   /// the declaration after it — that would UNDERCOUNT, which is the direction a
   /// ceiling must never fail in. This is why the fold looks ahead for an effect

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
@@ -452,6 +452,44 @@ import Testing
     #expect(RouterCeilingParser.collaboratorCount(in: body) == 2)
   }
 
+  /// #2068 (cloud review, PR #2070, round eight). The attribute-termination rule
+  /// landed handling only the BARE form, so a PARAMETERISED attribute ending the
+  /// line — `@isolated(any)`, `@convention(c)` — left the buffer ending in `)`
+  /// and looking complete. Swift allows exactly two attribute forms, so covering
+  /// both closes the case instead of adding its next instance.
+  @Test func closureCount_foldsWhenAParameterisedAttributeEndsTheLine() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let alpha: AlphaDep
+          let isolated: @isolated(any)
+            () -> Void
+          let cFunc: @convention(c)
+            (Int) -> Void
+          let beta: BetaDep
+        }
+        """)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 2)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 2)
+  }
+
+  /// The over-fold control for that rule: a line ending in `)` that is a
+  /// COMPLETED type, not an attribute, must still terminate the declaration.
+  /// This is the exact failure the round-seven reasoning was guarding against
+  /// when it wrongly concluded the two cases could not be told apart.
+  @Test func closureCount_trailingParenTypeIsNotMistakenForAnAttribute() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let wrapped: (AlphaDep)
+          let built: Factory(config)
+          let beta: BetaDep
+        }
+        """)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 0)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 3)
+  }
+
   /// The control for the recursive scan: a parenthesised NON-function type must
   /// not become a closure just because the scanner now looks inside groups.
   /// `(AlphaDep)` is the exact shape `closureCount_doesNotFoldACompleteParenthesizedType`

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
@@ -20,6 +20,32 @@ import Testing
     return try RouterCeilingParser.classBody(named: typeName, at: url.path)
   }
 
+  /// #2068 (cloud review, PR #2070, on the SwiftSyntax rewrite). The retired
+  /// implementation searched with a `(?<![A-Za-z0-9_])` lookbehind so a match
+  /// could not begin inside a longer identifier. The rewrite's plain substring
+  /// search dropped it, which let `preassertAttached()` satisfy a guard that
+  /// requires `assertAttached()` — a FALSE GREEN in a safety check, which is
+  /// strictly worse than a missed match.
+  ///
+  /// The three cases below are the whole contract: a real call is found, a
+  /// longer identifier ending in the needle is not, and an occurrence inside a
+  /// comment or string is not.
+  @Test func rangeOfStatement_requiresAnIdentifierBoundaryAndIgnoresNonCode() throws {
+    let genuine = "  assertAttached()\n"
+    #expect(RouterCeilingParser.rangeOfStatement("assertAttached()", in: genuine) != nil)
+
+    let suffixOnly = "  preassertAttached()\n"
+    #expect(
+      RouterCeilingParser.rangeOfStatement("assertAttached()", in: suffixOnly) == nil,
+      "a longer identifier ending in the needle must not satisfy the guard")
+
+    let commented = "  // assertAttached()\n"
+    #expect(RouterCeilingParser.rangeOfStatement("assertAttached()", in: commented) == nil)
+
+    let quoted = "  let note = \"assertAttached()\"\n"
+    #expect(RouterCeilingParser.rangeOfStatement("assertAttached()", in: quoted) == nil)
+  }
+
   @Test func classBody_returnsClassBody_notInnerMethodBody() throws {
     // The `init` body holds its own `{` and a local `let`. The pre-#808 bug
     // anchored on that inner brace and returned the init body, counting the
@@ -192,6 +218,46 @@ import Testing
         }
         """)
     #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
+  }
+
+  /// #2068 (cloud review, PR #2070, on the SwiftSyntax rewrite). A `#if` block
+  /// arrives as ONE member of kind `IfConfigDeclSyntax`, so reading `item.decl`
+  /// alone skips every declaration inside it. The retired text scanner counted
+  /// those lines — `#if` does not change brace depth — so not descending was a
+  /// silent UNDERCOUNT introduced BY the rewrite.
+  ///
+  /// The old-versus-new differential could not catch it: no ceilinged class uses
+  /// `#if` today, so the two parsers agreed on every real source while
+  /// disagreeing on a shape none of them contained. A differential proves
+  /// equality on the code that exists, not on the code someone writes next.
+  @Test func collaboratorCount_descendsIntoConditionalCompilationBlocks() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let alpha: AlphaDep
+          #if DEBUG
+            let debugOnly: BetaDep
+            let debugHook: () -> Void
+          #endif
+        }
+        """)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 2)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 1)
+  }
+
+  /// The same descent for methods, which share the member walk.
+  @Test func nonPrivateMethodCount_descendsIntoConditionalCompilationBlocks() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          func always() {}
+          #if DEBUG
+            func debugOnly() {}
+            private func hidden() {}
+          #endif
+        }
+        """)
+    #expect(RouterCeilingParser.nonPrivateMethodCount(in: body) == 2)
   }
 
   @Test func collaboratorCount_excludesVarStoredProperty() throws {

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
@@ -649,6 +649,44 @@ import Testing
     #expect(RouterCeilingParser.collaboratorCount(in: body) == 3)
   }
 
+  /// #2068 (cloud review, PR #2070, round twelve). The recursion checked that a
+  /// wrapping group started the type but not that it FINISHED it, so
+  /// `(() -> Void).Type` — a function metatype, which is a collaborator — matched
+  /// on the inner function and the `.Type` suffix was ignored.
+  ///
+  /// Confirmed valid Swift with `swiftc -swift-version 6 -typecheck` before
+  /// fixing, as with every syntax claim since round ten produced one that did
+  /// not compile.
+  @Test func closureCount_aFunctionMetatypeIsACollaborator() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let meta: (() -> Void).Type
+          let alsoMeta: ((Int) -> Bool).Type
+          let real: (() -> Void)?
+        }
+        """)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 1)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 2)
+  }
+
+  /// The control: the markers that may legitimately follow a wrapper must still
+  /// leave it a closure — optionals, forced optionals, and a default value,
+  /// whose `=` ends the TYPE rather than disqualifying it.
+  @Test func closureCount_optionalMarkersAndDefaultsStillCountAsClosures() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let alpha: AlphaDep
+          let opt: (() -> Void)?
+          let forced: (() -> Void)!
+          let defaulted: (() -> Void)? = nil
+        }
+        """)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 3)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
+  }
+
   /// The control for the recursive scan: a parenthesised NON-function type must
   /// not become a closure just because the scanner now looks inside groups.
   /// `(AlphaDep)` is the exact shape `closureCount_doesNotFoldACompleteParenthesizedType`


### PR DESCRIPTION
Two P3 hygiene issues from the 2026-08-15 architecture audit. One of them was bigger than it looked.

## #2068 — the dependency cap had an escape hatch, and it was wider than the ticket knew

`RouterCeilingParser.collaboratorCount` excludes closure-typed properties by construction, and `RecordingStarter`'s own source comments name the workaround three times — *"A bare closure so it stays off this start-path home's collaborator count"*, and twice more as *"Bare closure (off the collaborator cap)"*. A sibling counter (`closureInjectedCount`) exists and six other ceiling tests assert it. It was simply never applied to the home that documents using the hatch.

**Measuring it found a second defect.** `isClosureTyped` matched `) -> ` but not `) async -> `, so an `async` closure matched neither the closure predicate nor the primitive one — and was therefore counted as a **collaborator**. Both counters were wrong about the same property, in opposite directions: the closure ceiling could not see it, and it silently consumed a collaborator slot.

On `RecordingStarter` that read 8 closures against 10 closure-typed `let`s, the two missing being `makeRecoveryDirective` and `ensureSelectedReadyForPress`.

So capping at the measured-8 would have shipped a gate that still could not see the shape it exists to bound. `isClosureTyped` now matches the effect markers, with parser tests covering `async` / `throws` / `async throws` and the multi-line effectful form — including the two-way half asserting those closures **left** the collaborator count rather than merely joining the closure one.

**`RecordingStarter` capped at 10 — a freeze, not a target.** Whether this home should hold ten closures is a real question, and it is refactor-tier and explicitly not this one's.

Its collaborator ceiling comment was also wrong in a way worth recording: it named `permissions`, which is not a stored property of this type, and its seventh slot was `ensureSelectedReadyForPress` being miscounted. The cap stays at 7 rather than ratcheting to the now-measured 6 — that is a measurement correction, not a shrink anyone performed, and tightening on the back of a counter fix would fail the next PR for an unrelated reason.

### Scoped narrowly, as the issue asked

Measured closure counts for every ceilinged home:

| Home | Closures | Home | Closures |
|---|---|---|---|
| **RecordingStarter** | **10** | AudioEventRouter | 1 |
| AppWindowCoordinator | 2 | BackendMetadata | 1 |
| BulkImportEnrichmentCoordinator | 2 | SparkleUpdateController | 1 |
| WedgeRecoveryRouter | 2 | all others | 0 |

Only `RecordingStarter` gains an assertion. It is the one sitting at its collaborator ceiling with ten closures beside it, which is what "uses the hatch" means. A cap on a home holding one closure is the noise the issue said not to add.

## #2067 — the kernel header claimed it was not wired to the app

`RecordingSessionKernel.swift` is the file that owns every dictation the product performs, and its header said it *"ships this production-unwired (epic §14.3): no App-layer caller"*. `KernelDictationDriverFactory` has constructed it since PR-4.

The same header also described a 14-state FSM; #1548 collapsed it to the five states of `RecordingSessionState` and moved the ending category to `RecordingOutcome`. The issue asked to check the rest of the header for the same class of staleness rather than fixing only the quoted line — that second claim is what the check found.

Both corrected. Forward-looking "PR-n will do X" notes removed rather than updated: a header describing plan sequence goes stale silently, and this is the most expensive file in the product to be confidently wrong about.

## Validation

`scripts/xcode-test.sh` full run: **5464 tests, `** TEST SUCCEEDED **`**. The full suite is the point here, not a filtered run — the parser change touches every `RouterCeilingParser`-based ceiling test, and the evidence needed is that none of them moved.

Closes #2067
Closes #2068
