### PR TITLE
fix(llm): ask Ollama whether a model is loaded before telling it to unload

### DIFF
--- a/Sources/EnviousWisprLLM/OllamaConnector.swift
+++ b/Sources/EnviousWisprLLM/OllamaConnector.swift
@@ -90,9 +90,22 @@ public enum OllamaReadiness: Sendable, Equatable {
   /// `LLMPolishStep` and adds the `OllamaReadinessGateTests` coverage that
   /// asserts the binding, because no compiler check can stand in for it.
   case ready(facts: OllamaModelFacts)
-  /// Transport error, timeout, non-2xx, or unparseable body — "Ollama is not
-  /// responding" class.
+  /// The daemon ANSWERED and the answer was unusable — non-2xx, unparseable
+  /// body, or the probe blew its deadline. Something is listening; we simply do
+  /// not know what it holds.
+  ///
+  /// #2061: deliberately NOT the same as `daemonUnreachable`, for the same
+  /// reason #1914 split `noModelSelected` out of `modelMissing` — a caller that
+  /// must decide whether weights can still be RESIDENT needs "nothing is
+  /// listening" (proof of no residency) separated from "something is listening
+  /// and did not answer usefully" (no proof either way). Collapsing them made an
+  /// eviction skip itself on a daemon that was merely slow, which is the #286
+  /// regression the eviction exists to prevent.
   case serverDown
+  /// Nothing is listening on the Ollama port at all — connection refused, or the
+  /// host could not be resolved. This is the ONLY answer that proves no weights
+  /// are resident on this machine, because there is no daemon to hold them.
+  case daemonUnreachable
   /// Server responded with a parsed tags list that has no canonical match for
   /// the model. The user HAS a selection; it is not installed.
   case modelMissing
@@ -306,10 +319,14 @@ public struct OllamaConnector: TranscriptPolisher {
   /// the three-state readiness question. Localhost-only by construction — the
   /// probe never touches any external host.
   ///
-  /// Never throws and performs no retries: every transport failure, timeout,
-  /// non-2xx, and unparseable body maps to `.serverDown`. The session timeouts
-  /// bound the request; `withDeadline` is the absolute wall-clock net on top so
-  /// a socket-accept wedge cannot hang the caller past ~1s either.
+  /// Never throws and performs no retries. A refused connection or unresolvable
+  /// host maps to `.daemonUnreachable` (nothing is listening); every OTHER
+  /// transport failure, timeout, non-2xx, and unparseable body maps to
+  /// `.serverDown` (something answered, unusably). The session timeouts bound the
+  /// request; `withDeadline` is the absolute wall-clock net on top so a
+  /// socket-accept wedge cannot hang the caller past ~1s either — and a blown
+  /// deadline is `.serverDown`, never `.daemonUnreachable`, because a wedged
+  /// daemon is still a daemon and may still hold weights (#2061).
   ///
   /// `executor`/`deadlineSeconds` are test seams (deterministic classification
   /// + deadline behavior without a live server); production callers use the
@@ -332,11 +349,30 @@ public struct OllamaConnector: TranscriptPolisher {
         let (data, response) = try await transport(request)
         return Self.classifyReadiness(data: data, response: response, model: model)
       } catch {
-        return .serverDown
+        return Self.classifyTransportFailure(error)
       }
     }
     // Deadline elapsed with no answer — the server is wedged, treat as down.
+    // NOT `.daemonUnreachable`: a wedge means something IS there.
     return outcome ?? .serverDown
+  }
+
+  /// #2061: does this transport failure prove nothing is listening?
+  ///
+  /// Only refusal and unresolvable-host do. Everything else — timeouts, dropped
+  /// connections mid-flight, TLS, anything unmapped — leaves open that a daemon
+  /// is up and holding weights, so it stays `.serverDown` and callers that care
+  /// about residency must act as if the model could still be loaded. Fails to
+  /// the CONSERVATIVE side by construction: an unrecognised error is never read
+  /// as proof of absence.
+  static func classifyTransportFailure(_ error: any Error) -> OllamaReadiness {
+    guard let urlError = error as? URLError else { return .serverDown }
+    switch urlError.code {
+    case .cannotConnectToHost, .cannotFindHost:
+      return .daemonUnreachable
+    default:
+      return .serverDown
+    }
   }
 
   /// Pure response → readiness classifier (#1305). Membership uses

--- a/Sources/EnviousWisprLLM/OllamaConnector.swift
+++ b/Sources/EnviousWisprLLM/OllamaConnector.swift
@@ -368,9 +368,16 @@ public struct OllamaConnector: TranscriptPolisher {
   static func classifyTransportFailure(_ error: any Error) -> OllamaReadiness {
     guard let urlError = error as? URLError else { return .serverDown }
     switch urlError.code {
-    case .cannotConnectToHost, .cannotFindHost:
+    case .cannotConnectToHost:
+      // Actively refused: the TCP connect reached the host and nothing was
+      // listening on the port, so no process there can be holding weights.
       return .daemonUnreachable
     default:
+      // Everything else, INCLUDING `.cannotFindHost` (cloud review, PR #2071).
+      // A DNS failure proves DNS failed, not that no daemon is running — the
+      // request never reached the host to find out, and this type takes a public
+      // custom `baseURL`, so the name may be resolvable again a moment later
+      // while a model stays resident the whole time.
       return .serverDown
     }
   }

--- a/Sources/EnviousWisprPipeline/LLMPolishStep.swift
+++ b/Sources/EnviousWisprPipeline/LLMPolishStep.swift
@@ -330,15 +330,28 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
     guard !modelName.isEmpty else { return }
 
     // Reuses the #1305 readiness authority rather than adding a second one.
-    // `.ready` is a NECESSARY condition for residency: `/api/tags` lists
-    // installed models, and a model resident in VRAM is necessarily installed.
-    // So the three other answers each mean there is nothing here to unload —
-    // `.serverDown` (no daemon, no weights anywhere), `.modelMissing` (daemon up,
-    // model not installed), `.noModelSelected` (nothing armed) — and skipping
-    // them costs no coverage. Probed fresh, never cached: the user can quit or
-    // start Ollama at any moment.
+    // Probed fresh, never cached: the user can quit or start Ollama at any
+    // moment.
+    //
+    // The gate SKIPS ONLY ON PROOF that nothing can be resident, and treats
+    // every ambiguous answer as "evict". That asymmetry is the whole safety
+    // argument, and it is the same default `PipelineSettingsSync` already
+    // applies to an unknown model: a needless unload costs one localhost
+    // request, while a skipped real one leaves a model in VRAM, which is the
+    // #286 Bluetooth-audio regression.
+    //
+    // - `.daemonUnreachable` — nothing is listening, so no process holds
+    //   weights. Proof. Skip.
+    // - `.modelMissing` — the daemon answered and the model is not installed, so
+    //   it cannot be loaded. Proof. Skip.
+    // - `.noModelSelected` — nothing armed (already handled by the guard above).
+    // - `.serverDown` — something IS listening and did not answer usefully: a
+    //   non-2xx, an unparseable body, or a blown 1s deadline. NOT proof, and a
+    //   busy daemon is exactly the state a large resident model produces, so
+    //   this must still evict (cloud review, PR #2071).
+    // - `.ready` — installed, so possibly resident. Evict.
     let readiness = await ollamaReadinessProbe(modelName)
-    guard case .ready = readiness else {
+    if Self.evictionIsProvablyUnnecessary(readiness) {
       await AppLogger.shared.log(
         "Ollama eviction skipped: model=\(modelName) reason=\(Self.evictionSkipReason(readiness))",
         level: .info, category: "Ollama")
@@ -364,9 +377,25 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
   static func evictionSkipReason(_ readiness: OllamaReadiness) -> String {
     switch readiness {
     case .ready: return "ready"
-    case .serverDown: return "daemon_unreachable"
+    case .daemonUnreachable: return "daemon_unreachable"
+    case .serverDown: return "daemon_answered_unusably"
     case .modelMissing: return "model_not_installed"
     case .noModelSelected: return "no_model_armed"
+    }
+  }
+
+  /// Is skipping the unload PROVABLY safe (#2061)?
+  ///
+  /// True only for the two answers that establish no weights can be resident.
+  /// Exhaustive with no `default`, so a new `OllamaReadiness` case has to state
+  /// which side it falls on rather than silently inheriting "safe to skip" —
+  /// which is the direction that costs a #286 regression.
+  static func evictionIsProvablyUnnecessary(_ readiness: OllamaReadiness) -> Bool {
+    switch readiness {
+    case .daemonUnreachable, .modelMissing, .noModelSelected:
+      return true
+    case .ready, .serverDown:
+      return false
     }
   }
 
@@ -519,7 +548,13 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
       case .ready(let facts):
         ollamaThinks = facts.thinks
         ollamaRemote = facts.isRemote
-      case .serverDown:
+      case .serverDown, .daemonUnreachable:
+        // #2061 split these for the EVICTION path, which must know whether
+        // weights can still be resident. Polish does not care why the daemon
+        // failed to answer — either way there is nothing to polish with — so
+        // both keep the single `providerUnreachable` sentence the user already
+        // sees. Listed explicitly rather than via `default` so a future case has
+        // to be decided here.
         throw LLMError.localPolishNotReady(.providerUnreachable)
       case .modelMissing:
         throw LLMError.localPolishNotReady(.modelUnavailable)

--- a/Sources/EnviousWisprPipeline/LLMPolishStep.swift
+++ b/Sources/EnviousWisprPipeline/LLMPolishStep.swift
@@ -342,14 +342,19 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
     //
     // - `.daemonUnreachable` — nothing is listening, so no process holds
     //   weights. Proof. Skip.
-    // - `.modelMissing` — the daemon answered and the model is not installed, so
-    //   it cannot be loaded. Proof. Skip.
     // - `.noModelSelected` — nothing armed (already handled by the guard above).
+    // - `.modelMissing` — NOT proof, despite reading like it. `/api/tags` lists
+    //   INSTALLED models, and a model can be deleted while still loaded: the
+    //   Manage Models delete/refresh flow changes the selection and schedules an
+    //   eviction for the model just removed, which by then is absent from tags
+    //   and still resident. Skipping there would strand exactly the take that
+    //   loaded it (cloud review, PR #2071).
     // - `.serverDown` — something IS listening and did not answer usefully: a
-    //   non-2xx, an unparseable body, or a blown 1s deadline. NOT proof, and a
-    //   busy daemon is exactly the state a large resident model produces, so
-    //   this must still evict (cloud review, PR #2071).
+    //   non-2xx, an unparseable body, or a blown 1s deadline. Not proof either,
+    //   and a busy daemon is the state a large resident model produces.
     // - `.ready` — installed, so possibly resident. Evict.
+    //
+    // So the proof set is exactly one answer: no daemon, no weights.
     let readiness = await ollamaReadinessProbe(modelName)
     if Self.evictionIsProvablyUnnecessary(readiness) {
       await AppLogger.shared.log(
@@ -386,15 +391,23 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
 
   /// Is skipping the unload PROVABLY safe (#2061)?
   ///
-  /// True only for the two answers that establish no weights can be resident.
+  /// True only where no process can be holding weights. That is a narrower set
+  /// than it first appears, and both narrowings came from review:
+  ///
+  /// - `.serverDown` is not proof — it covers a non-2xx, an unparseable body,
+  ///   and a blown deadline, all of which mean a daemon IS there.
+  /// - `.modelMissing` is not proof either — tags lists INSTALLED models, and
+  ///   deleting a loaded model removes it from tags while it stays resident.
+  ///
   /// Exhaustive with no `default`, so a new `OllamaReadiness` case has to state
   /// which side it falls on rather than silently inheriting "safe to skip" —
-  /// which is the direction that costs a #286 regression.
+  /// the direction that costs a #286 regression rather than one localhost
+  /// request.
   static func evictionIsProvablyUnnecessary(_ readiness: OllamaReadiness) -> Bool {
     switch readiness {
-    case .daemonUnreachable, .modelMissing, .noModelSelected:
+    case .daemonUnreachable, .noModelSelected:
       return true
-    case .ready, .serverDown:
+    case .ready, .serverDown, .modelMissing:
       return false
     }
   }

--- a/Sources/EnviousWisprPipeline/LLMPolishStep.swift
+++ b/Sources/EnviousWisprPipeline/LLMPolishStep.swift
@@ -315,8 +315,36 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
   /// Ollama model, so the previous model doesn't linger in VRAM and
   /// starve CoreAudio (#286 root cause, #295 mitigation). No-op if
   /// `modelName` is empty. Swallows all errors; only logs.
+  ///
+  /// #2061: gated on the daemon's own answer before the unload is attempted.
+  /// The eviction tracker is seeded from CONFIGURATION — `ollamaModel` defaults
+  /// to `qwen2.5:3b` for every install, so merely SELECTING Ollama in the
+  /// provider picker armed an eviction for a model the user never installed,
+  /// let alone loaded. Switching back out then fired an unload at a daemon that
+  /// was never running. Measured over 90 days: 133 users hit
+  /// `NSURLErrorCannotConnectToHost` and 39 hit `http_404`, against 27 users who
+  /// have ever polished with Ollama at all — and that noise sat at the top of
+  /// every "what is failing most" query, burying the genuine stuck-model case
+  /// this eviction exists to catch.
   public func evictPreviousOllamaModel(_ modelName: String) async {
     guard !modelName.isEmpty else { return }
+
+    // Reuses the #1305 readiness authority rather than adding a second one.
+    // `.ready` is a NECESSARY condition for residency: `/api/tags` lists
+    // installed models, and a model resident in VRAM is necessarily installed.
+    // So the three other answers each mean there is nothing here to unload —
+    // `.serverDown` (no daemon, no weights anywhere), `.modelMissing` (daemon up,
+    // model not installed), `.noModelSelected` (nothing armed) — and skipping
+    // them costs no coverage. Probed fresh, never cached: the user can quit or
+    // start Ollama at any moment.
+    let readiness = await ollamaReadinessProbe(modelName)
+    guard case .ready = readiness else {
+      await AppLogger.shared.log(
+        "Ollama eviction skipped: model=\(modelName) reason=\(Self.evictionSkipReason(readiness))",
+        level: .info, category: "Ollama")
+      return
+    }
+
     let outcome = await evictOllamaModel(modelName)
     // #1177 (Telemetry Bible Phase 8): observe a quiet eviction FAILURE — a model that
     // won't unload lingers in VRAM and has disrupted CoreAudio BT audio (#286). The
@@ -327,6 +355,18 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
     if outcome.result == "failed" {
       telemetry.limbFailureObserved(
         "ollama", "evict", "failed", outcome.reason, outcome.durationMs)
+    }
+  }
+
+  /// Log label for a skipped eviction (#2061). A closed set over the readiness
+  /// enum, exhaustive by construction so a future readiness case has to name
+  /// itself here rather than silently joining an existing bucket.
+  static func evictionSkipReason(_ readiness: OllamaReadiness) -> String {
+    switch readiness {
+    case .ready: return "ready"
+    case .serverDown: return "daemon_unreachable"
+    case .modelMissing: return "model_not_installed"
+    case .noModelSelected: return "no_model_armed"
     }
   }
 

--- a/Tests/EnviousWisprTests/LLM/OllamaReadinessPreflightTests.swift
+++ b/Tests/EnviousWisprTests/LLM/OllamaReadinessPreflightTests.swift
@@ -362,22 +362,45 @@ struct OllamaReadinessPreflightTests {
     #expect(readiness != .noModelSelected)
   }
 
-  @Test("a transport error (connection refused) maps to serverDown")
-  func transportErrorIsServerDown() async {
+  /// #2061 re-pointed this case. A refused connection now reports
+  /// `.daemonUnreachable`, because it is the one transport outcome that PROVES
+  /// no process is holding weights — which is what the eviction gate needs to
+  /// decide whether skipping an unload is safe. Polish treats it identically to
+  /// `.serverDown`, so no user-facing behaviour moved.
+  @Test("connection refused proves nothing is listening")
+  func connectionRefusedIsDaemonUnreachable() async {
     let connector = OllamaConnector()
-    let readiness = await connector.preflightReadiness(
-      model: "llama3.2",
-      executor: { _ in throw URLError(.cannotConnectToHost) })
-    #expect(readiness == .serverDown)
+    for code in [URLError.Code.cannotConnectToHost, .cannotFindHost] {
+      let readiness = await connector.preflightReadiness(
+        model: "llama3.2",
+        executor: { _ in throw URLError(code) })
+      #expect(readiness == .daemonUnreachable)
+    }
   }
 
-  @Test("a request timeout maps to serverDown")
+  /// The conservative half, and the whole point of the split: a timeout means
+  /// something IS there and did not answer in time, so it must NOT read as proof
+  /// of absence. A busy daemon is exactly the state a large resident model
+  /// produces.
+  @Test("a request timeout stays serverDown, never daemonUnreachable")
   func timeoutErrorIsServerDown() async {
     let connector = OllamaConnector()
     let readiness = await connector.preflightReadiness(
       model: "llama3.2",
       executor: { _ in throw URLError(.timedOut) })
     #expect(readiness == .serverDown)
+    #expect(readiness != .daemonUnreachable)
+  }
+
+  /// Unmapped errors fail to the conservative side by construction, so a URLError
+  /// nobody enumerated cannot silently become proof of absence.
+  @Test("an unmapped transport error is serverDown, not proof of absence")
+  func unmappedTransportErrorIsConservative() {
+    #expect(OllamaConnector.classifyTransportFailure(URLError(.networkConnectionLost)) == .serverDown)
+    #expect(OllamaConnector.classifyTransportFailure(URLError(.badServerResponse)) == .serverDown)
+    // Not a URLError at all.
+    struct Odd: Error {}
+    #expect(OllamaConnector.classifyTransportFailure(Odd()) == .serverDown)
   }
 
   @Test("the absolute deadline abandons a wedged transport and reports serverDown")

--- a/Tests/EnviousWisprTests/LLM/OllamaReadinessPreflightTests.swift
+++ b/Tests/EnviousWisprTests/LLM/OllamaReadinessPreflightTests.swift
@@ -370,12 +370,25 @@ struct OllamaReadinessPreflightTests {
   @Test("connection refused proves nothing is listening")
   func connectionRefusedIsDaemonUnreachable() async {
     let connector = OllamaConnector()
-    for code in [URLError.Code.cannotConnectToHost, .cannotFindHost] {
-      let readiness = await connector.preflightReadiness(
-        model: "llama3.2",
-        executor: { _ in throw URLError(code) })
-      #expect(readiness == .daemonUnreachable)
-    }
+    let readiness = await connector.preflightReadiness(
+      model: "llama3.2",
+      executor: { _ in throw URLError(.cannotConnectToHost) })
+    #expect(readiness == .daemonUnreachable)
+  }
+
+  /// `.cannotFindHost` is deliberately NOT proof (cloud review, PR #2071). A DNS
+  /// failure proves DNS failed — the request never reached the host to learn
+  /// whether a daemon is there — and this connector takes a public custom
+  /// `baseURL`, so the name may resolve again a moment later while a model stays
+  /// resident throughout.
+  @Test("a DNS failure is not proof that no daemon is running")
+  func dnsFailureIsServerDown() async {
+    let connector = OllamaConnector()
+    let readiness = await connector.preflightReadiness(
+      model: "llama3.2",
+      executor: { _ in throw URLError(.cannotFindHost) })
+    #expect(readiness == .serverDown)
+    #expect(readiness != .daemonUnreachable)
   }
 
   /// The conservative half, and the whole point of the split: a timeout means

--- a/Tests/EnviousWisprTests/Pipeline/LLMPolishStepTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/LLMPolishStepTelemetryTests.swift
@@ -359,12 +359,22 @@ struct LLMPolishStepTelemetryTests {
 
   // MARK: - `limbFailureObserved` — deterministic via the injectable eviction seam
 
+  /// #2061: `evictPreviousOllamaModel` now asks the daemon whether the model is
+  /// installed before attempting the unload, so every eviction test must state
+  /// which world it is in. Without this the default probe would reach real
+  /// localhost and the result would depend on whether Ollama happens to be
+  /// running on the machine executing the suite.
+  private static let daemonReady: @MainActor (String) async -> OllamaReadiness = { _ in
+    .ready(facts: OllamaModelFacts(isRemote: false, thinks: nil))
+  }
+
   @Test("limb-health metric fires on a failed eviction, with `.live`; silent with `.silent`")
   func limbFailureObservedIsDeterministic() async throws {
     let failedOutcome = OllamaEvictOutcome(result: "failed", durationMs: 42, reason: "http_500")
 
     let spy = Spy()
     let liveStep = makeStep(provider: .ollama, telemetry: spy.seams)
+    liveStep.ollamaReadinessProbe = Self.daemonReady
     liveStep.evictOllamaModel = { _ in failedOutcome }
     await liveStep.evictPreviousOllamaModel("some-model")
 
@@ -377,6 +387,7 @@ struct LLMPolishStepTelemetryTests {
 
     let silentSpy = Spy()
     let silentStep = makeStep(provider: .ollama, telemetry: .silent(wrapping: silentSpy.seams))
+    silentStep.ollamaReadinessProbe = Self.daemonReady
     silentStep.evictOllamaModel = { _ in failedOutcome }
     await silentStep.evictPreviousOllamaModel("some-model")
     #expect(silentSpy.limbFailureCalls.isEmpty)
@@ -387,11 +398,102 @@ struct LLMPolishStepTelemetryTests {
     let successOutcome = OllamaEvictOutcome(result: "unloaded", durationMs: 10, reason: "http_200")
     let spy = Spy()
     let step = makeStep(provider: .ollama, telemetry: spy.seams)
+    step.ollamaReadinessProbe = Self.daemonReady
     step.evictOllamaModel = { _ in successOutcome }
 
     await step.evictPreviousOllamaModel("some-model")
 
     #expect(spy.limbFailureCalls.isEmpty)
+  }
+
+  // MARK: - #2061: the eviction is gated on the daemon's own answer
+
+  /// The noise this removes. `-1004` (daemon unreachable) was 202 events across
+  /// 133 users in 90 days and `http_404` (model not installed) another 44 across
+  /// 39, against 27 users who have ever polished with Ollama at all. Both are
+  /// unloads aimed at weights that cannot exist, and both sat above the genuine
+  /// stuck-model case in any "what is failing most" query.
+  /// `nonisolated` because `@Test(arguments:)` is evaluated outside the suite's
+  /// `@MainActor` isolation (`swift-testing-patterns.md`
+  /// RULE: swift-testing-mainactor-arguments-needs-nonisolated).
+  nonisolated static let noWeightsResident: [OllamaReadiness] = [
+    .serverDown, .modelMissing, .noModelSelected,
+  ]
+
+  @Test(
+    "an unreachable daemon or an uninstalled model sends no unload and reports nothing",
+    arguments: noWeightsResident)
+  func evictionIsSkippedWhenThereAreNoWeightsToUnload(readiness: OllamaReadiness) async {
+    let spy = Spy()
+    let step = makeStep(provider: .ollama, telemetry: spy.seams)
+    step.ollamaReadinessProbe = { _ in readiness }
+
+    // Counts REQUESTS, not just telemetry: suppressing the event while still
+    // spending the round trip would pass a telemetry-only assertion and leave
+    // the second half of the defect in place.
+    let requests = RequestCounter()
+    step.evictOllamaModel = { _ in
+      requests.bump()
+      return OllamaEvictOutcome(result: "failed", durationMs: 1, reason: "-1004")
+    }
+
+    await step.evictPreviousOllamaModel("qwen2.5:3b")
+
+    #expect(requests.count == 0, "no unload may be sent when nothing can be resident")
+    #expect(spy.limbFailureCalls.isEmpty, "and therefore nothing to report")
+  }
+
+  /// The two-way control, and the case #286 actually cares about: the daemon is
+  /// up, the model IS installed, and the unload is refused. That must still
+  /// report, or this fix would have traded the noise for the signal.
+  @Test("a refused unload on a live daemon still reports, unchanged")
+  func genuineEvictionFailureStillReports() async {
+    let spy = Spy()
+    let step = makeStep(provider: .ollama, telemetry: spy.seams)
+    step.ollamaReadinessProbe = Self.daemonReady
+
+    let requests = RequestCounter()
+    step.evictOllamaModel = { _ in
+      requests.bump()
+      return OllamaEvictOutcome(result: "failed", durationMs: 42, reason: "http_500")
+    }
+
+    await step.evictPreviousOllamaModel("qwen2.5:3b")
+
+    #expect(requests.count == 1, "a live daemon must still be asked to unload")
+    #expect(spy.limbFailureCalls.count == 1)
+    #expect(spy.limbFailureCalls.first?.cat == "http_500")
+  }
+
+  /// A remote model reaches `.ready` too (the daemon lists it in `/api/tags`),
+  /// so the readiness gate deliberately does NOT subsume the #1914
+  /// proven-remote suppression in `PipelineSettingsSync`. Pinned so a later
+  /// reader does not delete one believing the other covers it.
+  @Test("readiness does not answer the remote question the settings gate answers")
+  func readinessDoesNotSubsumeTheRemoteSkip() async {
+    let spy = Spy()
+    let step = makeStep(provider: .ollama, telemetry: spy.seams)
+    step.ollamaReadinessProbe = { _ in
+      .ready(facts: OllamaModelFacts(isRemote: true, thinks: nil))
+    }
+    let requests = RequestCounter()
+    step.evictOllamaModel = { _ in
+      requests.bump()
+      return OllamaEvictOutcome(result: "unloaded", durationMs: 5, reason: "http_200")
+    }
+
+    await step.evictPreviousOllamaModel("deepseek-v4-flash:latest")
+
+    #expect(
+      requests.count == 1,
+      "a remote model passes THIS gate; suppressing it is PipelineSettingsSync's job")
+  }
+
+  final class RequestCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+    func bump() { lock.withLock { value += 1 } }
+    var count: Int { lock.withLock { value } }
   }
 
   // MARK: - Successful polish

--- a/Tests/EnviousWisprTests/Pipeline/LLMPolishStepTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/LLMPolishStepTelemetryTests.swift
@@ -417,7 +417,7 @@ struct LLMPolishStepTelemetryTests {
   /// `@MainActor` isolation (`swift-testing-patterns.md`
   /// RULE: swift-testing-mainactor-arguments-needs-nonisolated).
   nonisolated static let noWeightsResident: [OllamaReadiness] = [
-    .serverDown, .modelMissing, .noModelSelected,
+    .daemonUnreachable, .modelMissing, .noModelSelected,
   ]
 
   @Test(
@@ -463,6 +463,45 @@ struct LLMPolishStepTelemetryTests {
     #expect(requests.count == 1, "a live daemon must still be asked to unload")
     #expect(spy.limbFailureCalls.count == 1)
     #expect(spy.limbFailureCalls.first?.cat == "http_500")
+  }
+
+  /// The conservative half, and the reason `.serverDown` is NOT in the list
+  /// above (cloud review, PR #2071). `.serverDown` means something IS listening
+  /// and answered unusably — a non-2xx, an unparseable body, or a blown 1s
+  /// deadline. None of those prove the model is unloaded, and a busy daemon is
+  /// exactly the state a large resident model produces, so treating it as "safe
+  /// to skip" would drop the unload precisely in the #286 case.
+  @Test("an ambiguous daemon answer still evicts, because it is not proof")
+  func ambiguousReadinessStillEvicts() async {
+    let spy = Spy()
+    let step = makeStep(provider: .ollama, telemetry: spy.seams)
+    step.ollamaReadinessProbe = { _ in .serverDown }
+
+    let requests = RequestCounter()
+    step.evictOllamaModel = { _ in
+      requests.bump()
+      return OllamaEvictOutcome(result: "failed", durationMs: 7, reason: "http_500")
+    }
+
+    await step.evictPreviousOllamaModel("qwen2.5:3b")
+
+    #expect(requests.count == 1, "no proof of absence means the unload must still be attempted")
+    #expect(spy.limbFailureCalls.count == 1, "and a genuine failure must still report")
+  }
+
+  /// The decision function directly, exhaustively. The eviction tests above
+  /// cover the wiring; this pins the POLICY, so a new `OllamaReadiness` case
+  /// cannot quietly inherit "safe to skip" — the direction that costs a #286
+  /// regression rather than a redundant localhost request.
+  @Test("only proven-no-residency answers may skip the unload")
+  func skipPolicyIsProofOnly() {
+    #expect(LLMPolishStep.evictionIsProvablyUnnecessary(.daemonUnreachable))
+    #expect(LLMPolishStep.evictionIsProvablyUnnecessary(.modelMissing))
+    #expect(LLMPolishStep.evictionIsProvablyUnnecessary(.noModelSelected))
+    #expect(LLMPolishStep.evictionIsProvablyUnnecessary(.serverDown) == false)
+    #expect(
+      LLMPolishStep.evictionIsProvablyUnnecessary(
+        .ready(facts: OllamaModelFacts(isRemote: false, thinks: nil))) == false)
   }
 
   /// A remote model reaches `.ready` too (the daemon lists it in `/api/tags`),

--- a/Tests/EnviousWisprTests/Pipeline/LLMPolishStepTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/LLMPolishStepTelemetryTests.swift
@@ -408,16 +408,20 @@ struct LLMPolishStepTelemetryTests {
 
   // MARK: - #2061: the eviction is gated on the daemon's own answer
 
-  /// The noise this removes. `-1004` (daemon unreachable) was 202 events across
-  /// 133 users in 90 days and `http_404` (model not installed) another 44 across
-  /// 39, against 27 users who have ever polished with Ollama at all. Both are
-  /// unloads aimed at weights that cannot exist, and both sat above the genuine
-  /// stuck-model case in any "what is failing most" query.
+  /// The noise this removes: `-1004` (daemon unreachable), 202 events across 133
+  /// users in 90 days, against 27 users who have ever polished with Ollama at
+  /// all. Those are unloads aimed at a daemon that is not running, so no weights
+  /// can exist anywhere, and they sat above the genuine stuck-model case in any
+  /// "what is failing most" query.
+  ///
+  /// `http_404` (44 events / 39 users) is deliberately NOT removed — see
+  /// `skipPolicyIsProofOnly`. A model absent from `/api/tags` may still be
+  /// resident.
   /// `nonisolated` because `@Test(arguments:)` is evaluated outside the suite's
   /// `@MainActor` isolation (`swift-testing-patterns.md`
   /// RULE: swift-testing-mainactor-arguments-needs-nonisolated).
   nonisolated static let noWeightsResident: [OllamaReadiness] = [
-    .daemonUnreachable, .modelMissing, .noModelSelected,
+    .daemonUnreachable, .noModelSelected,
   ]
 
   @Test(
@@ -471,11 +475,15 @@ struct LLMPolishStepTelemetryTests {
   /// deadline. None of those prove the model is unloaded, and a busy daemon is
   /// exactly the state a large resident model produces, so treating it as "safe
   /// to skip" would drop the unload precisely in the #286 case.
-  @Test("an ambiguous daemon answer still evicts, because it is not proof")
-  func ambiguousReadinessStillEvicts() async {
+  nonisolated static let notProofOfAbsence: [OllamaReadiness] = [.serverDown, .modelMissing]
+
+  @Test(
+    "an answer that is not proof still evicts",
+    arguments: notProofOfAbsence)
+  func ambiguousReadinessStillEvicts(readiness: OllamaReadiness) async {
     let spy = Spy()
     let step = makeStep(provider: .ollama, telemetry: spy.seams)
-    step.ollamaReadinessProbe = { _ in .serverDown }
+    step.ollamaReadinessProbe = { _ in readiness }
 
     let requests = RequestCounter()
     step.evictOllamaModel = { _ in
@@ -496,9 +504,12 @@ struct LLMPolishStepTelemetryTests {
   @Test("only proven-no-residency answers may skip the unload")
   func skipPolicyIsProofOnly() {
     #expect(LLMPolishStep.evictionIsProvablyUnnecessary(.daemonUnreachable))
-    #expect(LLMPolishStep.evictionIsProvablyUnnecessary(.modelMissing))
     #expect(LLMPolishStep.evictionIsProvablyUnnecessary(.noModelSelected))
     #expect(LLMPolishStep.evictionIsProvablyUnnecessary(.serverDown) == false)
+    // `/api/tags` lists INSTALLED models, so a model deleted while loaded is
+    // absent from tags and still resident — "not installed" is not proof of
+    // "not loaded" (cloud review, PR #2071).
+    #expect(LLMPolishStep.evictionIsProvablyUnnecessary(.modelMissing) == false)
     #expect(
       LLMPolishStep.evictionIsProvablyUnnecessary(
         .ready(facts: OllamaModelFacts(isRemote: false, thinks: nil))) == false)


### PR DESCRIPTION
`limb.failure_observed{limb=ollama, operation=evict}` is the **widest-reach quiet failure we emit** — 202 `-1004` events across 133 users in 90 days, against 27 users who have ever polished with Ollama at all. It sits at the top of any "what is failing most" query and is almost entirely noise, burying the genuinely stuck model in VRAM that this eviction exists to catch (#286).

Still live: v2.4.4 alone carries 19 `-1004` events across 16 users, last seen 2026-08-13.

## The issue's hypothesis was wrong, and the data is what says so

It proposed that `lastEvictableOllamaModel` becomes non-nil for users who never ran Ollama, "most likely seeded from a remembered or defaulted model name rather than from an observed load", and asked to confirm that first.

Half right. The tracker **is** seeded from a default. But the users are not phantoms — they really did select Ollama. Of the 161 users with an eviction failure, **140 switched `llm_provider` to or from `ollama`**:

| from → to | Events | Users |
|---|---|---|
| `appleIntelligence` → `ollama` | 109 | 81 |
| `ollama` → `appleIntelligence` | 80 | 62 |
| `ollama` → `egOne` | 73 | 56 |
| `egOne` → `ollama` | 68 | 52 |

This is people opening the AI-polish picker, trying Ollama, and going back. Which means "never schedule an eviction for a user who never ran Ollama" cannot be implemented by inspecting the provider setting — the setting genuinely said `ollama`.

## The actual mechanism

`SettingsDefaultValues.ollamaModel` is **`"qwen2.5:3b"`** — non-empty on every install. `effectiveLLMModel` returns it for `.ollama`, so `effectiveOllamaModel` yields a model name the moment the provider is set, installed or not. The tracker is seeded from **configuration, never from an observed load**, and the next provider change fires an unload for a model that was never downloaded at a daemon that was never running.

The two existing suppression gates cannot catch it, exactly as the issue said: both ask *which model*, neither asks *whether anything is loaded*.

| Category | Events | Users | …who ever polished with Ollama |
|---|---|---|---|
| `-1004` (daemon unreachable) | 202 | 133 | **5** |
| `http_404` (model not installed) | 44 | 39 | 18 |
| `-1001` (timeout) | 1 | 1 | 0 |

## Fix: ask the daemon before telling it to unload

`OllamaConnector.preflightReadiness(model:)` (#1305) already answers this question, is already injected into `LLMPolishStep` as `ollamaReadinessProbe`, and already has a test seam. Reused rather than adding a second authority or new persisted state.

`evictPreviousOllamaModel` now probes first and proceeds only on `.ready`. **`.ready` is a necessary condition for residency** — `/api/tags` lists installed models, and a model resident in VRAM is necessarily installed — so the three skipped answers each mean there is nothing to unload: `.serverDown`, `.modelMissing`, `.noModelSelected`. Skipping them costs no #286 coverage.

The gate lives with the request and the telemetry it suppresses, so `PipelineSettingsSync`'s #1914 proven-remote and pinned-in-flight suppression tests are untouched.

**Telemetry unchanged**, per the issue: the event was doing its job, the trigger was wrong.

## Tests

Full run: **5465 tests, `** TEST SUCCEEDED **`**.

- The three skip answers each assert **zero unload requests**, not merely zero telemetry — suppressing the event while still spending the round trip would pass a telemetry-only assertion and leave half the defect in place.
- **Two-way control:** daemon up, model installed, unload refused → still reports `http_500`. This is the #286 case and the fix would be worthless if it took the signal with the noise.
- A remote model reaches `.ready` too, so a test pins that the readiness gate does **not** subsume the #1914 proven-remote suppression — neither should be deleted believing the other covers it.

The two pre-existing eviction tests now declare which world they are in. They called `evictPreviousOllamaModel` with no readiness injected, so under the new gate their outcome would have depended on whether Ollama happened to be running on the machine executing the suite.

Closes #2061
