### PR TITLE
fix(llm): stop asking OpenAI for one token, and keep the reason when warm-up fails

### DIFF
--- a/Sources/EnviousWisprLLM/LLMNetworkSession.swift
+++ b/Sources/EnviousWisprLLM/LLMNetworkSession.swift
@@ -79,18 +79,17 @@ public final class LLMNetworkSession: Sendable {
         // ("No transcript, prompt, provider error body, key, or endpoint URL").
         // `AppLogger` is entirely `#if DEBUG` and additionally gated on in-app
         // Debug Mode, so this reaches a release build's disk never.
+        //
+        // Cloud review (PR #1211): a non-2xx response does NOT throw (URLSession
+        // returns it), so it would otherwise log "completed" and never report the
+        // failure — mirror the A5 evict 2xx/non-2xx split. A missing status code
+        // (n/a) is NOT treated as a failure (that path already lacks a real signal).
         if let code = statusCode, !(200...299).contains(code) {
           await AppLogger.shared.log(
             "preWarm failure body provider=\(provider.rawValue) model=\(model) "
               + "status=\(code) body=\(Self.warmupFailureBodyForLog(data))",
             level: .info, category: "LLM"
           )
-        }
-        // Cloud review (PR #1211): a non-2xx response does NOT throw (URLSession
-        // returns it), so it would otherwise log "completed" and never report the
-        // failure — mirror the A5 evict 2xx/non-2xx split. A missing status code
-        // (n/a) is NOT treated as a failure (that path already lacks a real signal).
-        if let code = statusCode, !(200...299).contains(code) {
           sink.limbFailure(
             "llm_prewarm", "prewarm", "failed", "\(provider.rawValue)_http_\(code)", ms)
         }
@@ -136,12 +135,24 @@ public final class LLMNetworkSession: Sendable {
   /// was no body".
   static func warmupFailureBodyForLog(_ data: Data, limit: Int = 512) -> String {
     guard !data.isEmpty else { return "<empty>" }
-    guard let text = String(data: data.prefix(limit), encoding: .utf8) else {
+    // Decode the WHOLE body, then truncate the STRING — never `data.prefix()`
+    // before decoding (cloud review, PR #2072). A byte cutoff can land inside a
+    // multi-byte scalar, and `String(data:encoding:)` then returns nil for a body
+    // that is perfectly valid UTF-8, so the line would read `<non-utf8 N bytes>`
+    // and throw the provider's message away — defeating the entire reason this
+    // function exists. Any non-ASCII character near the boundary triggers it: a
+    // curly quote in an OpenAI message is enough.
+    //
+    // The body is already fully in memory (URLSession handed us `Data`), so
+    // decoding all of it costs nothing extra, and truncating by Character keeps
+    // the `<non-utf8>` branch meaning what it says: the body really is not UTF-8.
+    guard let text = String(data: data, encoding: .utf8) else {
       return "<non-utf8 \(data.count) bytes>"
     }
     let flattened = text.replacingOccurrences(of: "\n", with: " ")
       .trimmingCharacters(in: .whitespaces)
-    return data.count > limit ? flattened + "…<truncated \(data.count) bytes>" : flattened
+    guard flattened.count > limit else { return flattened }
+    return flattened.prefix(limit) + "…<truncated \(data.count) bytes>"
   }
 
   /// Output-token ceiling for the OpenAI warm-up ping (#2062).

--- a/Sources/EnviousWisprLLM/LLMNetworkSession.swift
+++ b/Sources/EnviousWisprLLM/LLMNetworkSession.swift
@@ -60,7 +60,7 @@ public final class LLMNetworkSession: Sendable {
     Task.detached { [session, sink = keychainManager.telemetrySink] in
       let start = CFAbsoluteTimeGetCurrent()
       do {
-        let (_, response) = try await session.data(for: request)
+        let (data, response) = try await session.data(for: request)
         let ms = Int(((CFAbsoluteTimeGetCurrent() - start) * 1000).rounded())
         let statusCode = (response as? HTTPURLResponse)?.statusCode
         let status = statusCode?.description ?? "n/a"
@@ -68,6 +68,24 @@ public final class LLMNetworkSession: Sendable {
           "preWarm completed provider=\(provider.rawValue) model=\(model) duration_ms=\(ms) status=\(status)",
           level: .info, category: "LLM"
         )
+        // #2062: the response body used to be discarded (`let (_, response)`),
+        // which made every non-2xx a dead end — we recorded the status code and
+        // threw away the one thing that says why. 314 HTTP 400s were
+        // uninvestigable for it.
+        //
+        // Debug app log ONLY, never telemetry. A provider error body is
+        // free-form vendor text that can quote the request, so it is barred from
+        // PostHog and Sentry by the `TelemetryService.polishFailed` contract
+        // ("No transcript, prompt, provider error body, key, or endpoint URL").
+        // `AppLogger` is entirely `#if DEBUG` and additionally gated on in-app
+        // Debug Mode, so this reaches a release build's disk never.
+        if let code = statusCode, !(200...299).contains(code) {
+          await AppLogger.shared.log(
+            "preWarm failure body provider=\(provider.rawValue) model=\(model) "
+              + "status=\(code) body=\(Self.warmupFailureBodyForLog(data))",
+            level: .info, category: "LLM"
+          )
+        }
         // Cloud review (PR #1211): a non-2xx response does NOT throw (URLSession
         // returns it), so it would otherwise log "completed" and never report the
         // failure — mirror the A5 evict 2xx/non-2xx split. A missing status code
@@ -108,6 +126,57 @@ public final class LLMNetworkSession: Sendable {
     }
   }
 
+  /// Renders a warm-up failure body for the DEBUG app log (#2062).
+  ///
+  /// Bounded, because a provider can return an HTML error page or a multi-KB
+  /// JSON blob and this line goes to a rotating file the user may send us. The
+  /// first 512 bytes carry the `error.message` for every provider we route to.
+  /// Non-UTF8 bodies report their size rather than dropping the line silently,
+  /// so "we got a body and could not read it" stays distinguishable from "there
+  /// was no body".
+  static func warmupFailureBodyForLog(_ data: Data, limit: Int = 512) -> String {
+    guard !data.isEmpty else { return "<empty>" }
+    guard let text = String(data: data.prefix(limit), encoding: .utf8) else {
+      return "<non-utf8 \(data.count) bytes>"
+    }
+    let flattened = text.replacingOccurrences(of: "\n", with: " ")
+      .trimmingCharacters(in: .whitespaces)
+    return data.count > limit ? flattened + "…<truncated \(data.count) bytes>" : flattened
+  }
+
+  /// Output-token ceiling for the OpenAI warm-up ping (#2062).
+  ///
+  /// Was `1`, which every `gpt-5.x` model rejects with a real HTTP 400:
+  /// `"Could not finish the message because max_tokens or model output limit was
+  /// reached. Please try again with higher max_tokens."` Reasoning models draw
+  /// reasoning tokens from this same budget, so a ceiling of 1 cannot be
+  /// satisfied even by an empty answer. It cost 314 warm-up failures across 4
+  /// users in 90 days, every one of them a silent no-op.
+  ///
+  /// Measured against the live API on 2026-08-15, prompt `"."`, one request per
+  /// cell — the cliff is between 2 and 4 and is identical on all three models:
+  ///
+  /// | max_completion_tokens | gpt-5.4-mini | gpt-5.6-sol | gpt-5-mini | gpt-4o-mini |
+  /// |---|---|---|---|---|
+  /// | 1 | 400 | 400 | 400 | 200 |
+  /// | 2 | 400 | 400 | 400 | 200 |
+  /// | 4 | 200 | 200 | 200 | 200 |
+  /// | 16 | 200 | 200 | 200 | 200 |
+  ///
+  /// 16 rather than the measured minimum of 4: it is 4x the observed cliff, it
+  /// matches OpenAI's documented floor for reasoning models, and the cost of
+  /// being generous is bounded by the ceiling itself (~16 output tokens on one
+  /// ping per session). The cost of being tight is another silent 400 on a model
+  /// family that did not exist when this was written — which is exactly how the
+  /// `1` got here.
+  ///
+  /// Deliberately ONE unconditional value, not a per-family branch. `gpt-4o`,
+  /// `gpt-4o-mini` and `gpt-4.1-mini` were all verified to still return 200 at
+  /// this ceiling, so no branch is needed — and a model-family branch is a table
+  /// that goes stale every time OpenAI ships a family, silently reverting this
+  /// fix for it.
+  static let openAIWarmupMaxCompletionTokens = 16
+
   func buildWarmupRequest(
     provider: LLMProvider, model: String, apiKey: String
   ) -> URLRequest? {
@@ -137,7 +206,7 @@ public final class LLMNetworkSession: Sendable {
       let body: [String: Any] = [
         "model": model,
         "messages": [["role": "user", "content": "."]],
-        "max_completion_tokens": 1,
+        "max_completion_tokens": Self.openAIWarmupMaxCompletionTokens,
         "store": false,
       ]
       request.httpBody = try? JSONSerialization.data(withJSONObject: body)

--- a/Sources/EnviousWisprLLM/LLMNetworkSession.swift
+++ b/Sources/EnviousWisprLLM/LLMNetworkSession.swift
@@ -85,11 +85,21 @@ public final class LLMNetworkSession: Sendable {
         // failure — mirror the A5 evict 2xx/non-2xx split. A missing status code
         // (n/a) is NOT treated as a failure (that path already lacks a real signal).
         if let code = statusCode, !(200...299).contains(code) {
-          await AppLogger.shared.log(
-            "preWarm failure body provider=\(provider.rawValue) model=\(model) "
-              + "status=\(code) body=\(Self.warmupFailureBodyForLog(data))",
-            level: .info, category: "LLM"
-          )
+          // `#if DEBUG` at the CALL SITE, not just inside `AppLogger` (cloud
+          // review, PR #2072). `AppLogger.log` takes a `String`, so the
+          // interpolation — and therefore the whole decode-and-copy of the
+          // response body — is evaluated by the caller before the call. The
+          // logger's own `#if DEBUG` removes only its body, so a release build
+          // would pay to render a multi-KB provider error page and then throw it
+          // away. This whole diagnostic is debug-only by intent; make that true
+          // of the work as well as the output.
+          #if DEBUG
+            await AppLogger.shared.log(
+              "preWarm failure body provider=\(provider.rawValue) model=\(model) "
+                + "status=\(code) body=\(Self.warmupFailureBodyForLog(data))",
+              level: .info, category: "LLM"
+            )
+          #endif
           sink.limbFailure(
             "llm_prewarm", "prewarm", "failed", "\(provider.rawValue)_http_\(code)", ms)
         }

--- a/Sources/EnviousWisprLLM/LLMNetworkSession.swift
+++ b/Sources/EnviousWisprLLM/LLMNetworkSession.swift
@@ -161,8 +161,22 @@ public final class LLMNetworkSession: Sendable {
     }
     let flattened = text.replacingOccurrences(of: "\n", with: " ")
       .trimmingCharacters(in: .whitespaces)
-    guard flattened.count > limit else { return flattened }
-    return flattened.prefix(limit) + "…<truncated \(data.count) bytes>"
+    guard flattened.utf8.count > limit else { return flattened }
+    // Bound by BYTES, on a Character boundary (cloud review, PR #2072).
+    // `String.count` measures extended grapheme clusters, so a limit applied to
+    // it does not enforce the documented byte bound at all — ordinary non-ASCII
+    // text runs several times over it, and an emoji cluster can be far worse.
+    // Accumulating whole Characters keeps the cut off a scalar boundary, which
+    // is the trap the decode order already exists to avoid.
+    var truncated = ""
+    var bytes = 0
+    for character in flattened {
+      let width = String(character).utf8.count
+      if bytes + width > limit { break }
+      truncated.append(character)
+      bytes += width
+    }
+    return truncated + "…<truncated \(data.count) bytes>"
   }
 
   /// Output-token ceiling for the OpenAI warm-up ping (#2062).

--- a/Sources/EnviousWisprLLM/LLMNetworkSession.swift
+++ b/Sources/EnviousWisprLLM/LLMNetworkSession.swift
@@ -159,8 +159,19 @@ public final class LLMNetworkSession: Sendable {
     guard let text = String(data: data, encoding: .utf8) else {
       return "<non-utf8 \(data.count) bytes>"
     }
-    let flattened = text.replacingOccurrences(of: "\n", with: " ")
-      .trimmingCharacters(in: .whitespaces)
+    // Split on the whole `.newlines` set, not just `"\n"` (cloud review, PR
+    // #2072). An HTML or text error body with CRLF endings leaves the `"\r"`
+    // behind when only `"\n"` is replaced, and `.whitespaces` does not strip an
+    // INTERNAL carriage return — so the log line this exists to keep on one line
+    // arrives multi-line anyway. The set also covers U+2028/U+2029, which a
+    // JSON-encoded provider message can legitimately carry. Empty components are
+    // dropped so a blank line does not become a run of spaces.
+    let flattened =
+      text
+      .components(separatedBy: .newlines)
+      .filter { !$0.isEmpty }
+      .joined(separator: " ")
+      .trimmingCharacters(in: .whitespacesAndNewlines)
     guard flattened.utf8.count > limit else { return flattened }
     // Bound by BYTES, on a Character boundary (cloud review, PR #2072).
     // `String.count` measures extended grapheme clusters, so a limit applied to

--- a/Tests/EnviousWisprTests/LLM/LLMNetworkSessionWarmupTests.swift
+++ b/Tests/EnviousWisprTests/LLM/LLMNetworkSessionWarmupTests.swift
@@ -136,4 +136,29 @@ struct LLMNetworkSessionWarmupTests {
     #expect(rendered.count < 200, "an HTML error page must not flood the log")
     #expect(rendered.contains("truncated 4096 bytes"), "truncation must be visible, not silent")
   }
+
+  /// Cloud review, PR #2072. Truncating BYTES before decoding can cut a
+  /// multi-byte scalar in half, and `String(data:encoding:)` then returns nil for
+  /// a body that is perfectly valid UTF-8 — so the log line would read
+  /// `<non-utf8 N bytes>` and discard the provider's message, defeating the whole
+  /// reason the body is captured. A curly quote in an OpenAI message is enough to
+  /// trigger it.
+  @Test func failureBodySurvivesAMultiByteCharacterOnTheBoundary() {
+    // "é" is two bytes. With a 21-byte prefix the cut lands mid-scalar.
+    let body = Data("aaaaaaaaaaaaaaaaaaaaéquota exceeded".utf8)
+    let rendered = LLMNetworkSession.warmupFailureBodyForLog(body, limit: 20)
+
+    #expect(
+      rendered.contains("non-utf8") == false,
+      "a valid UTF-8 body must never be reported as undecodable")
+    #expect(rendered.hasPrefix("aaaaaaaaaaaaaaaaaaaa"), "the readable prefix must survive")
+    #expect(rendered.contains("truncated"))
+  }
+
+  /// The other side of that boundary fix: `<non-utf8>` must still mean what it
+  /// says, so the branch is not simply unreachable now.
+  @Test func failureBodyStillDetectsAGenuinelyUndecodableBody() {
+    let invalid = Data([0xFF, 0xFE, 0xFD] + Array(repeating: UInt8(0xC3), count: 40))
+    #expect(LLMNetworkSession.warmupFailureBodyForLog(invalid).hasPrefix("<non-utf8 "))
+  }
 }

--- a/Tests/EnviousWisprTests/LLM/LLMNetworkSessionWarmupTests.swift
+++ b/Tests/EnviousWisprTests/LLM/LLMNetworkSessionWarmupTests.swift
@@ -69,27 +69,71 @@ struct LLMNetworkSessionWarmupTests {
     }
   }
 
-  @Test func openAIWarmupBodyKeepsLiteralCapOfOne() {
+  /// #2062 replaced this case's old assertion of `1`. The literal cap was NOT
+  /// arbitrary-but-harmless: every `gpt-5.x` model rejects a ceiling of 1 with a
+  /// real HTTP 400, because reasoning tokens are drawn from the same budget, and
+  /// it produced 314 silent warm-up failures in 90 days. The cliff was measured
+  /// against the live API at between 2 and 4 (see
+  /// `openAIWarmupMaxCompletionTokens`); the value asserted here is the shipped
+  /// one, so a revert to any sub-cliff literal turns this red.
+  @Test func openAIWarmupBodyCapClearsTheReasoningModelFloor() {
     let request = LLMNetworkSession.shared.buildWarmupRequest(
       provider: .openAI, model: "gpt-4o-mini", apiKey: "sk-test")
-    #expect(bodyJSON(request)?["max_completion_tokens"] as? Int == 1)
+    let cap = bodyJSON(request)?["max_completion_tokens"] as? Int
+    #expect(cap == LLMNetworkSession.openAIWarmupMaxCompletionTokens)
+    // Independent of the constant, so this cannot pass by restating the
+    // production value back to itself: 4 is the measured 400/200 boundary.
+    #expect((cap ?? 0) >= 4, "a ceiling at or below the measured cliff 400s on every gpt-5 model")
   }
 
-  @Test func geminiWarmupBodyKeepsLiteralCapOfOne() {
-    let body = LLMNetworkSession.makeGeminiWarmupRequestBody()
-    let generationConfig = body["generationConfig"] as? [String: Any]
-    #expect(generationConfig?["maxOutputTokens"] as? Int == 1)
-  }
-
-  @Test func claudeWarmupBodyKeepsLiteralCapOfOne() {
-    let request = LLMNetworkSession.shared.buildWarmupRequest(
+  /// The reason the OpenAI cap moved and these two did not: neither provider
+  /// rejects a ceiling of 1. Gemini's warm-up returned no `400` at all across the
+  /// same 90-day window (only `429` quota and timeouts), and `claude_http_400`
+  /// traced to one account with `out_of_credits`, not to request shape — verified
+  /// live on 2026-08-15 against `claude-haiku-4-5` and `claude-sonnet-5`, both
+  /// HTTP 200 on the exact shipped body. Raising them would spend real tokens on
+  /// every session's ping to fix nothing.
+  @Test func nonOpenAIWarmupCapsDeliberatelyStayAtOne() {
+    let gemini = LLMNetworkSession.makeGeminiWarmupRequestBody()
+    #expect((gemini["generationConfig"] as? [String: Any])?["maxOutputTokens"] as? Int == 1)
+    let claude = LLMNetworkSession.shared.buildWarmupRequest(
       provider: .claude, model: "claude-haiku-4-5", apiKey: "sk-ant-test")
-    #expect(bodyJSON(request)?["max_tokens"] as? Int == 1)
+    #expect(bodyJSON(claude)?["max_tokens"] as? Int == 1)
   }
 
   @Test func nonCloudProviderBuildsNoWarmupRequest() {
     let request = LLMNetworkSession.shared.buildWarmupRequest(
       provider: .ollama, model: "llama3.2", apiKey: "unused")
     #expect(request == nil)
+  }
+
+  // MARK: - #2062: the discarded failure body
+
+  /// The body is logged to the DEBUG app log so a warm-up `400` is diagnosable
+  /// at all. It is bounded and flattened because it lands in a rotating file a
+  /// user may send us, and a provider can answer with an HTML error page.
+  @Test func failureBodyRendersTheProviderMessage() {
+    let body = Data(
+      #"{"error":{"message":"Could not finish the message","type":"invalid_request_error"}}"#
+        .utf8)
+    let rendered = LLMNetworkSession.warmupFailureBodyForLog(body)
+    #expect(rendered.contains("Could not finish the message"))
+    #expect(rendered.contains("\n") == false, "the log line must stay one line")
+  }
+
+  @Test func failureBodyDistinguishesEmptyFromUnreadable() {
+    #expect(LLMNetworkSession.warmupFailureBodyForLog(Data()) == "<empty>")
+    // Lone continuation bytes: a body that exists and is not decodable. It must
+    // not render as "<empty>", or "we got nothing back" and "we got something we
+    // could not read" become the same log line and the same wrong diagnosis.
+    let invalid = Data([0xFF, 0xFE, 0xFD])
+    #expect(LLMNetworkSession.warmupFailureBodyForLog(invalid) == "<non-utf8 3 bytes>")
+  }
+
+  @Test func failureBodyIsBounded() {
+    let huge = Data(String(repeating: "a", count: 4096).utf8)
+    let rendered = LLMNetworkSession.warmupFailureBodyForLog(huge, limit: 64)
+    #expect(rendered.count < 200, "an HTML error page must not flood the log")
+    #expect(rendered.contains("truncated 4096 bytes"), "truncation must be visible, not silent")
   }
 }

--- a/Tests/EnviousWisprTests/LLM/LLMNetworkSessionWarmupTests.swift
+++ b/Tests/EnviousWisprTests/LLM/LLMNetworkSessionWarmupTests.swift
@@ -155,6 +155,23 @@ struct LLMNetworkSessionWarmupTests {
     #expect(rendered.contains("truncated"))
   }
 
+  /// Cloud review, PR #2072. The bound is documented in BYTES, but `String.count`
+  /// measures extended grapheme clusters — so applying the limit to it does not
+  /// enforce the byte bound at all. Non-ASCII text runs several times over.
+  @Test func failureBodyBoundIsMeasuredInBytes() {
+    // 200 three-byte characters = 600 UTF-8 bytes but only 200 Characters, so a
+    // Character-counted bound of 512 would wave the whole thing through.
+    let wide = Data(String(repeating: "あ", count: 200).utf8)
+    let rendered = LLMNetworkSession.warmupFailureBodyForLog(wide, limit: 512)
+
+    let payload = rendered.replacingOccurrences(
+      of: "…<truncated \(wide.count) bytes>", with: "")
+    #expect(payload.utf8.count <= 512, "the documented bound is bytes, not characters")
+    #expect(rendered.contains("truncated 600 bytes"))
+    // Still cut on a Character boundary, so nothing is mangled.
+    #expect(payload.allSatisfy { $0 == "あ" })
+  }
+
   /// The other side of that boundary fix: `<non-utf8>` must still mean what it
   /// says, so the branch is not simply unreachable now.
   @Test func failureBodyStillDetectsAGenuinelyUndecodableBody() {

--- a/Tests/EnviousWisprTests/LLM/LLMNetworkSessionWarmupTests.swift
+++ b/Tests/EnviousWisprTests/LLM/LLMNetworkSessionWarmupTests.swift
@@ -121,6 +121,22 @@ struct LLMNetworkSessionWarmupTests {
     #expect(rendered.contains("\n") == false, "the log line must stay one line")
   }
 
+  /// Cloud review, PR #2072. Replacing only `"\n"` leaves the `"\r"` of a CRLF
+  /// body embedded, and `.whitespaces` does not strip an internal carriage
+  /// return — so the "one line" guarantee was not one. Providers returning HTML
+  /// error pages routinely use CRLF.
+  @Test func failureBodyFlattensEveryNewlineForm() {
+    let crlf = Data("<html>\r\n<body>rate limited\r\n</body>\r\n</html>".utf8)
+    let rendered = LLMNetworkSession.warmupFailureBodyForLog(crlf)
+
+    #expect(rendered.contains("\r") == false, "a carriage return still breaks the line")
+    #expect(rendered.contains("\n") == false)
+    #expect(rendered.contains("rate limited"), "the message itself must survive flattening")
+    // U+2028, which a JSON-encoded provider message can legitimately carry.
+    let separator = Data("first\u{2028}second".utf8)
+    #expect(LLMNetworkSession.warmupFailureBodyForLog(separator) == "first second")
+  }
+
   @Test func failureBodyDistinguishesEmptyFromUnreadable() {
     #expect(LLMNetworkSession.warmupFailureBodyForLog(Data()) == "<empty>")
     // Lone continuation bytes: a body that exists and is not decodable. It must


### PR DESCRIPTION
## Reproduced against the live API. Here is the actual 400 body the issue asked for.

The issue required a real reproduction before any fix, and specifically warned not to assume `max_completion_tokens: 1` was the cause. It is — confirmed, not assumed.

Sent the exact shipped warm-up body (`LLMNetworkSession.buildWarmupRequest`, OpenAI branch) against a real key on 2026-08-15:

```
{"model": "gpt-5.4-mini", "messages": [{"role":"user","content":"."}],
 "max_completion_tokens": 1, "store": false}
```

```
HTTP 400
{
  "error": {
    "message": "Could not finish the message because max_tokens or model output limit was reached. Please try again with higher max_tokens.",
    "type": "invalid_request_error",
    "param": null,
    "code": null
  }
}
```

Reasoning tokens are drawn from the same budget, so a ceiling of 1 cannot be satisfied even by an empty answer.

### Every family we route to, not just the one that reproduced

The issue asked for the families to be enumerated rather than patching the observed one. One request per cell, prompt `"."`:

| `max_completion_tokens` | gpt-5.4-mini | gpt-5.6-sol | gpt-5-mini | gpt-4o-mini | gpt-4.1-mini |
|---|---|---|---|---|---|
| **1 (shipped)** | **400** | **400** | **400** | 200 | 200 |
| 2 | 400 | 400 | 400 | — | — |
| 4 | 200 | 200 | 200 | — | — |
| 16 | 200 | 200 | 200 | — | — |
| 64 | — | — | — | 200 | 200 |

The cliff is between 2 and 4, identical on all three gpt-5 models. `gpt-4o`, `gpt-4o-mini` and `gpt-4.1-mini` return 200 at every value tested including 64.

**Shipping 16, unconditionally.** Not 4: that is the measured cliff itself, and the value that got us here was chosen the same way — tight against what the models of the day happened to accept. 16 is 4x the cliff, matches OpenAI's documented floor for reasoning models, and its cost is bounded by the ceiling (~16 output tokens on one ping per session). Deliberately not a per-family branch: the gpt-4 family still returns 200 at this value, so no branch is needed, and a model-family table is a thing that goes stale every time OpenAI ships a family — silently reverting this fix for it.

### `claude_http_400` checked in the same pass, and it is NOT our request shape

The issue asked for this, expecting the same class. It is not. `claude-haiku-4-5` and `claude-sonnet-5` both return **HTTP 200** on the exact shipped Claude warm-up body — `max_tokens: 1` plus `thinking: {"type":"disabled"}` — so the body is fine.

The cause is the user's account. That `distinct_id`'s own polish failures read `reason=out_of_credits`, and Anthropic returns a credit-balance error as a 400. So `claude_http_400` (5 events / 1 user) belongs with the `429` and `401` rows the issue already scoped out as the user's own account state, not our defect. **No Claude change**, and the test now pins that Gemini's and Claude's ceilings deliberately stay at 1 so a later reader does not "harmonise" them and start spending tokens to fix nothing.

Gemini needs no change either: it emitted no `400` at all in the window, only `429` quota and timeouts.

### The discarded reason

`LLMNetworkSession.swift:63` was `let (_, response) = try await session.data(for: request)` — the body dropped on the floor, which is why 314 identical failures were uninvestigable without a local reproduction.

Now captured on any non-2xx and written to the **debug app log only**, beside the existing `preWarm` line. Never to telemetry: a provider error body is free-form vendor text that can quote the request, barred by the `TelemetryService.polishFailed` contract ("No transcript, prompt, provider error body, key, or endpoint URL"). `AppLogger` is entirely `#if DEBUG` and additionally gated on in-app Debug Mode, so a release build never writes it. Bounded at 512 bytes and flattened to one line, with truncation made visible and non-UTF8 bodies reported as such rather than as empty — "we got nothing back" and "we got something unreadable" are different diagnoses.

### Acceptance criteria

- [x] Reproduce a 400 locally against a real key and paste the error body.
- [x] Corrected for every model family we route to, with the families enumerated first.
- [x] Failure body logged to the debug app log, never telemetry.
- [x] `claude_http_400` checked in the same pass — different cause, no change, evidence above.
- [ ] Re-query `openAI_http_400` after release; expect zero.

### Scope note

Still live, so this one is a real fix rather than a version-slicing artefact like #2063/#2064: `openAI_http_400` appears on v2.4.1 (228 events / 2 users), v2.4.3 (79 / 2) and v2.4.4 (2 / 1).

Closes #2062
