### PR TITLE
fix(ui): say the fast engine is loading instead of calling it Unloaded

### DIFF
--- a/Sources/EnviousWisprAppKit/App/BackendMetadata.swift
+++ b/Sources/EnviousWisprAppKit/App/BackendMetadata.swift
@@ -1,4 +1,3 @@
-import EnviousWisprASR
 import EnviousWisprCore
 import EnviousWisprServices
 import Observation
@@ -11,7 +10,6 @@ import Observation
 @Observable @MainActor
 final class BackendMetadata {
   let settings: SettingsManager
-  let asrManager: any ASRManagerInterface
   let llmDiscovery: LLMModelDiscoveryCoordinator
   /// Whether the ACTIVE engine's model is resident — the EngineCoordinator's
   /// published truth, injected as a closure. The manager's own flag stopped
@@ -19,14 +17,15 @@ final class BackendMetadata {
   /// a warmed multilingual model rendered "Unloaded").
   let activeModelLoaded: @MainActor () -> Bool
 
+  /// #2065 dropped the `asrManager` collaborator: its only reader was the
+  /// per-engine branch in `statusText(for:)`, so collapsing that left it
+  /// assigned and never read.
   init(
     settings: SettingsManager,
-    asrManager: any ASRManagerInterface,
     llmDiscovery: LLMModelDiscoveryCoordinator,
     activeModelLoaded: @escaping @MainActor () -> Bool
   ) {
     self.settings = settings
-    self.asrManager = asrManager
     self.llmDiscovery = llmDiscovery
     self.activeModelLoaded = activeModelLoaded
   }
@@ -60,25 +59,25 @@ final class BackendMetadata {
     return model
   }
 
+  /// #2065: ONE table, not one per engine. This branched on `activeBackendType`
+  /// and the arms were identical apart from `.loadingModel`, which only the
+  /// WhisperKit arm handled — so the sidebar called the fast engine "Unloaded"
+  /// mid-load. Collapsed, not copied across: two hand-synchronised tables is
+  /// what produced the bug. Exhaustive, so a new `PipelineState` fails to
+  /// compile here rather than silently landing on the health label.
   func statusText(for state: PipelineState) -> String {
-    if asrManager.activeBackendType == .whisperKit {
-      switch state {
-      case .loadingModel: return DictationNarrator.loadingModelSidebar
-      case .recording: return DictationNarrator.recordingStatus
-      case .transcribing: return DictationNarrator.shortCopy(for: .transcribing)
-      case .polishing: return DictationNarrator.shortCopy(for: .polishing)
-      case .error: return DictationNarrator.errorStatus
-      // #1891: `.advisory` deliberately falls through to the engine-health
-      // label ("Loaded" / "Unloaded") rather than showing "Error" in the
-      // sidebar. The microphone sent nothing; the engine is fine.
-      default: break
-      }
-    } else {
-      if state == .recording { return DictationNarrator.recordingStatus }
-      if state == .transcribing { return DictationNarrator.shortCopy(for: .transcribing) }
-      if state == .polishing { return DictationNarrator.shortCopy(for: .polishing) }
-      if case .error = state { return DictationNarrator.errorStatus }
+    switch state {
+    case .loadingModel: return DictationNarrator.loadingModelSidebar
+    case .recording: return DictationNarrator.recordingStatus
+    case .transcribing: return DictationNarrator.shortCopy(for: .transcribing)
+    case .polishing: return DictationNarrator.shortCopy(for: .polishing)
+    case .error: return DictationNarrator.errorStatus
+    // #1891: `.advisory` deliberately falls through to the engine-health label
+    // ("Loaded" / "Unloaded") rather than showing "Error" in the sidebar. The
+    // microphone sent nothing; the engine is fine. Kept distinct from `.error`
+    // on purpose — do not collapse them.
+    case .advisory, .idle, .complete:
+      return activeModelLoaded() ? "Loaded" : "Unloaded"
     }
-    return activeModelLoaded() ? "Loaded" : "Unloaded"
   }
 }

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -796,7 +796,6 @@ public final class WisprBootstrapper {
     let lastRecordingResult = LastRecordingResult()
     let backendMetadata = BackendMetadata(
       settings: settings,
-      asrManager: asrManager,
       llmDiscovery: llmDiscovery,
       // The coordinator's published snapshot covers BOTH engines; the manager's
       // own flag is Parakeet-only since #1386 (cloud review P2).

--- a/Tests/EnviousWisprTests/App/BackendMetadataTests.swift
+++ b/Tests/EnviousWisprTests/App/BackendMetadataTests.swift
@@ -4,7 +4,6 @@ import EnviousWisprServices
 import Foundation
 import Testing
 
-@testable import EnviousWisprASR
 @testable import EnviousWisprAppKit
 
 /// Unit tests for `BackendMetadata` (PR7 of epic #763). Covers the three
@@ -136,80 +135,80 @@ struct BackendMetadataTests {
     #expect(bm.polishLabel == "llama3.2")
   }
 
-  // MARK: - statusText(for:) — Parakeet branch
+  // MARK: - statusText(for:)
 
-  @Test("statusText Parakeet: .recording returns 'Recording'")
-  func statusTextParakeetRecording() {
+  /// #2065 replaced the per-engine cases here. There used to be a Parakeet block
+  /// and a WhisperKit block, each pinning the active engine and
+  /// asserting the same four strings — and only the WhisperKit block covered
+  /// `.loadingModel`, which is precisely why the missing Parakeet case shipped.
+  /// Two tables tested twice still leaves the untested cell untested.
+  ///
+  /// `statusText` no longer reads the engine at all, so an engine dimension here
+  /// would assert a coupling the code does not have.
+  nonisolated static let activeStates: [(PipelineState, String)] = [
+    (.loadingModel, "Loading Model"),
+    (.recording, "Recording"),
+    (.transcribing, "Transcribing"),
+    (.polishing, "Polishing"),
+    (.error(.modelWedged), "Error"),
+  ]
+
+  @Test("statusText names every active phase, whichever engine is running", arguments: activeStates)
+  func statusTextNamesActivePhases(state: PipelineState, expected: String) {
     let bm = makeBackendMetadata()
-    bm.asrManager.setInitialBackendType(.parakeet)
-    #expect(bm.statusText(for: .recording) == "Recording")
+    #expect(bm.statusText(for: state) == expected)
   }
 
-  @Test("statusText Parakeet: .transcribing returns 'Transcribing'")
-  func statusTextParakeetTranscribing() {
-    let bm = makeBackendMetadata()
-    bm.asrManager.setInitialBackendType(.parakeet)
-    #expect(bm.statusText(for: .transcribing) == "Transcribing")
+  /// The regression this issue was filed for. Against pre-fix `main` this case
+  /// returns "Unloaded" — the engine-health label — while the model is loading.
+  @Test("statusText: a loading model never reports the engine-health label")
+  func loadingModelNeverReportsHealthLabel() {
+    // Both health values, because the pre-fix bug rendered whichever one the
+    // health closure happened to hold: "Unloaded" mid-load, or a flat "Loaded"
+    // that is equally wrong while a load is in flight.
+    for loaded in [true, false] {
+      let bm = makeBackendMetadata(modelLoaded: loaded)
+      let text = bm.statusText(for: .loadingModel)
+      #expect(text == "Loading Model")
+      #expect(text != "Unloaded")
+      #expect(text != "Loaded")
+    }
   }
 
-  @Test("statusText Parakeet: .polishing returns 'Polishing'")
-  func statusTextParakeetPolishing() {
-    let bm = makeBackendMetadata()
-    bm.asrManager.setInitialBackendType(.parakeet)
-    #expect(bm.statusText(for: .polishing) == "Polishing")
+  /// The two-way control for the fix: the states that SHOULD show engine health
+  /// still do. Without this, deleting the health fallback entirely would pass
+  /// the case above.
+  @Test("statusText: idle, complete and advisory still report engine health")
+  func restingStatesReportEngineHealth() {
+    let unloaded = makeBackendMetadata(modelLoaded: false)
+    #expect(unloaded.statusText(for: .idle) == "Unloaded")
+    #expect(unloaded.statusText(for: .complete) == "Unloaded")
+
+    let loaded = makeBackendMetadata(modelLoaded: true)
+    #expect(loaded.statusText(for: .idle) == "Loaded")
   }
 
-  @Test("statusText Parakeet: .error returns 'Error'")
-  func statusTextParakeetError() {
-    let bm = makeBackendMetadata()
-    bm.asrManager.setInitialBackendType(.parakeet)
-    #expect(bm.statusText(for: .error(.modelWedged)) == "Error")
-  }
-
-  @Test("statusText Parakeet: .idle falls back to model-loaded label")
-  func statusTextParakeetIdleFallback() {
-    let bm = makeBackendMetadata()
-    bm.asrManager.setInitialBackendType(.parakeet)
-    // Default isModelLoaded is false → "Unloaded"
-    #expect(bm.statusText(for: .idle) == "Unloaded")
-  }
-
-  // MARK: - statusText(for:) — WhisperKit branch
-
-  @Test("statusText WhisperKit: .loadingModel returns 'Loading Model'")
-  func statusTextWhisperKitLoadingModel() {
-    let bm = makeBackendMetadata()
-    bm.asrManager.setInitialBackendType(.whisperKit)
-    #expect(bm.statusText(for: .loadingModel) == "Loading Model")
-  }
-
-  @Test("statusText WhisperKit: .recording returns 'Recording'")
-  func statusTextWhisperKitRecording() {
-    let bm = makeBackendMetadata()
-    bm.asrManager.setInitialBackendType(.whisperKit)
-    #expect(bm.statusText(for: .recording) == "Recording")
-  }
-
-  @Test("statusText WhisperKit: .idle falls back to model-loaded label")
-  func statusTextWhisperKitIdleFallback() {
-    let bm = makeBackendMetadata()
-    bm.asrManager.setInitialBackendType(.whisperKit)
-    #expect(bm.statusText(for: .idle) == "Unloaded")
+  /// #1891, pinned so the #2065 collapse cannot quietly take it with it: an
+  /// advisory is NOT an error in the sidebar. The microphone sent nothing; the
+  /// engine is fine, so the health label is the honest answer.
+  @Test("statusText: advisory keeps falling through to health, never 'Error'")
+  func advisoryIsNotAnError() {
+    let bm = makeBackendMetadata(modelLoaded: true)
+    #expect(bm.statusText(for: .advisory(.noTransport)) == "Loaded")
+    #expect(bm.statusText(for: .advisory(.noTransport)) != "Error")
   }
 
   // MARK: - Fixture
 
-  private func makeBackendMetadata() -> BackendMetadata {
+  /// `modelLoaded` drives the engine-health label, which is what `.loadingModel`
+  /// used to be mistaken for on the non-WhisperKit path (#2065).
+  private func makeBackendMetadata(modelLoaded: Bool = false) -> BackendMetadata {
     let settings = SettingsManager()
-    let asrManager = ASRManager(engineMutationScope: .alwaysAllowedForTesting)
     let llmDiscovery = LLMModelDiscoveryCoordinator(keychainManager: KeychainManager())
     return BackendMetadata(
       settings: settings,
-      asrManager: asrManager,
       llmDiscovery: llmDiscovery,
-      // Mirrors production's closure shape; the fixture manager never loads,
-      // so the idle fallback renders "Unloaded" exactly as before.
-      activeModelLoaded: { [weak asrManager] in asrManager?.isModelLoaded ?? false }
+      activeModelLoaded: { modelLoaded }
     )
   }
 }

--- a/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
+++ b/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
@@ -372,7 +372,7 @@ struct MenuBarControllerTests {
       audioCapture: audioCapture, asrManager: asrManager)
     let settings = SettingsManager()
     let backendMetadata = BackendMetadata(
-      settings: settings, asrManager: asrManager,
+      settings: settings,
       llmDiscovery: LLMModelDiscoveryCoordinator(keychainManager: KeychainManager()),
       activeModelLoaded: { [weak asrManager] in asrManager?.isModelLoaded ?? false })
     // Nil-fake updater factory — no real Sparkle boot in the test process.

--- a/Tests/EnviousWisprTests/Architecture/BackendMetadataCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/BackendMetadataCeilingsTests.swift
@@ -40,12 +40,14 @@ import Testing
       named: "BackendMetadata", in: source)
     let total = bodies.reduce(0) { $0 + CeilingsTestSupport.countTopLevelLetCollaborators(in: $1) }
     #expect(
-      total == 4,
+      total == 3,
       """
-      BackendMetadata stored-property count mismatch: expected exactly 4 \
-      (settings + asrManager + llmDiscovery + activeModelLoaded), found \(total). \
-      Adding a stored property requires a Bible §30 entry; if this dropped, \
-      ratchet down.
+      BackendMetadata stored-property count mismatch: expected exactly 3 \
+      (settings + llmDiscovery + activeModelLoaded), found \(total). \
+      Ratcheted 4 → 3 by #2065, which removed `asrManager`: its only reader was \
+      the per-engine branch in `statusText(for:)`, and collapsing that table to \
+      one left it assigned and never read. Adding a stored property requires a \
+      Bible §30 entry; if this dropped again, ratchet down.
       """)
   }
 


### PR DESCRIPTION
While the fast engine (Parakeet) loaded its model, the sidebar showed the engine-health label — **"Loaded" or "Unloaded"** — instead of "Loading Model". "Unloaded" during a load is the opposite of what is happening, on the one surface a user checks to find out why nothing is responding yet.

`statusText(for:)` branched on the active engine, and the two arms were identical **apart from `.loadingModel`**, which only the WhisperKit arm handled. The state is genuinely reachable on both: each driver is a `KernelDictationDriver` and its arming path always publishes it.

## Collapsed to one table, not taught to the second arm

Two hand-synchronised tables is what produced the bug — the second was simply never told about a state the first knew. Copying the case across would leave the same shape in place for the next state.

There is now no per-engine arm for a future state to be forgotten in, and the switch is exhaustive, so a new `PipelineState` case **fails to compile here** instead of silently landing on the health label. It also drops an `activeBackendType` identity read from a place that was never asking an identity question (`architecture-rules.md` RULE: gate-on-capability-not-identity-literal).

`.advisory` still falls through to the health label, deliberately (#1891: the microphone sent nothing, the engine is fine), and now has a test pinning it so the collapse cannot quietly take it along.

## Two consequences worth calling out

**`asrManager` became dead.** Its only reader was the per-engine branch, so the collapse left it assigned and never read. Removed rather than left in place — an injected dependency nothing consults reads as a live coupling to the next person, and this type is display-only labels. `BackendMetadataCeilingsTests` ratchets 4 → 3 accordingly.

**The old tests are why this shipped.** There was a Parakeet block and a WhisperKit block asserting the same four strings, and only the WhisperKit block covered `.loadingModel`. Two tables tested twice still leaves the untested cell untested. Replaced with:

- one parameterised case over the active phases (no engine dimension — `statusText` no longer reads the engine, so asserting one would assert a coupling the code does not have);
- the regression case itself, checked against **both** health values, since the pre-fix bug rendered whichever one the closure happened to hold;
- a two-way control that idle/complete/advisory still report engine health — without it, deleting the health fallback entirely would pass.

## Validation

`scripts/xcode-test.sh` full run. Two ceiling tests failed on the first pass and both were real: the stored-property count (`== 4`, now 3) and the line ceiling (my doc comments overran 85). The comments were **trimmed to fit rather than the cap raised** — a ceiling bump for prose is not a ceiling bump worth taking.

Closes #2065
