### PR TITLE
test(settings): lock the guard that stops a cloud provider inheriting a local model

### DIFF
--- a/Tests/EnviousWisprTests/Services/ProviderModelDesyncTests.swift
+++ b/Tests/EnviousWisprTests/Services/ProviderModelDesyncTests.swift
@@ -1,0 +1,179 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprServices
+
+/// #2064: a cloud provider must never be left holding another provider's model.
+///
+/// Production evidence, 90 days to 2026-08-15: one user emitted **443**
+/// `llm.polish_failed` rows carrying `provider=gemini model=llama3.2
+/// reason=api_key_missing` — 59% of all polish failures in the window, and every
+/// AI polish that user attempted for three weeks. `llama3.2` is an Ollama model
+/// name. Their settings history shows the cause exactly: on v2.3.1 they moved
+/// `egOne → ollama → gemini` inside eleven seconds, and the Ollama model id was
+/// still sitting in `llmModel` when Gemini started reading it.
+///
+/// **These tests do NOT fail against current `main`.** The repair already exists:
+/// `canonicalizeLLMModelForProvider`'s `modelIDLooksLikeCloudProvider` clause,
+/// added by #1712 and first released in v2.4.1. The same user's telemetry
+/// confirms it worked in the field — their failures stop at their upgrade to
+/// v2.4.4 and their next settings snapshot reads `gemini-3.5-flash`, with no
+/// user action in between.
+///
+/// So what these lock is the GUARD, which had no direct coverage for this shape
+/// and is one deleted `||` clause away from reopening a defect that silently
+/// disables AI polish forever.
+///
+/// **Mutation-verified, not asserted.** Dropping the
+/// `modelIDLooksLikeCloudProvider` clause from `canonicalizeLLMModelForProvider`
+/// and re-running this suite: 4 of 7 cases fail with 16 issues, and they fail by
+/// reproducing the exact production pairing —
+/// `effectiveLLMModel → "llama3.2"` under `provider = .gemini`. The remaining 3
+/// are the two-way controls below and they stay GREEN under the mutant, which is
+/// what shows they are independent checks rather than the same assertion
+/// restated.
+@MainActor
+@Suite("Provider/model desync (#2064)")
+struct ProviderModelDesyncTests {
+
+  private func freshSettings() -> SettingsManager {
+    SettingsManager(defaults: UserDefaults(suiteName: "SM-2064-\(UUID().uuidString)")!)
+  }
+
+  /// The exact field-observed sequence, at the seam that produced it.
+  @Test("switching away from Ollama sweeps the Ollama model name off the cloud field")
+  func switchingAwayFromOllamaSweepsTheOllamaModelName() {
+    let settings = freshSettings()
+    settings.llmProvider = .ollama
+    settings.ollamaModel = "llama3.2"
+    settings.llmModel = "llama3.2"
+
+    settings.llmProvider = .gemini
+
+    #expect(
+      settings.effectiveLLMModel != "llama3.2",
+      "a Gemini request must never be sent with an Ollama model name")
+    #expect(settings.effectiveLLMModel == "gemini-3.5-flash")
+    // The remembered Ollama preference is untouched — #1305 relies on it for the
+    // Download-suggestion copy, and sweeping it here would fix one bug with
+    // another.
+    #expect(settings.ollamaModel == "llama3.2")
+  }
+
+  /// The user's real path was three providers in eleven seconds, not one hop.
+  /// A guard that only fires on the immediately-previous provider would pass the
+  /// case above and still ship the defect.
+  @Test("a rapid multi-provider hop leaves no foreign model behind")
+  func rapidProviderHopLeavesNoForeignModel() {
+    let settings = freshSettings()
+    settings.ollamaModel = "llama3.2"
+    settings.llmProvider = .appleIntelligence
+    settings.llmProvider = .egOne
+    settings.llmProvider = .ollama
+    settings.llmModel = "llama3.2"
+    settings.llmProvider = .gemini
+
+    #expect(settings.effectiveLLMModel == "gemini-3.5-flash")
+  }
+
+  /// Every cloud destination, not just the one that showed up in telemetry.
+  /// `openAI` appeared once and `claude` never, which is sample size rather than
+  /// immunity — they share the single guard.
+  nonisolated static let cloudDestinations: [(LLMProvider, String)] = [
+    (.gemini, "gemini-3.5-flash"),
+    (.openAI, "gpt-4o-mini"),
+    (.claude, "claude-haiku-4-5"),
+  ]
+
+  @Test("no cloud provider inherits a local model name", arguments: cloudDestinations)
+  func cloudProvidersNeverInheritLocalModels(provider: LLMProvider, expected: String) {
+    for localName in ["llama3.2", "gemma4:e4b", "qwen2.5:3b", "deepseek-r1:8b"] {
+      let settings = freshSettings()
+      settings.llmProvider = .ollama
+      settings.llmModel = localName
+      settings.llmProvider = provider
+
+      #expect(
+        settings.effectiveLLMModel == expected,
+        "\(provider.rawValue) inherited \(localName)")
+    }
+  }
+
+  /// A relaunch must repair a machine already stuck in the bad state, or the 443
+  /// user would have stayed broken until they happened to touch the picker.
+  /// This is the path their recovery actually took: no user action, just a
+  /// launch on a build that had the guard.
+  @Test("a persisted desync is repaired at launch, with no user action")
+  func persistedDesyncIsRepairedAtLaunch() {
+    let suite = UserDefaults(suiteName: "SM-2064-stuck-\(UUID().uuidString)")!
+    // The on-disk state the stuck user was in on v2.4.0.
+    suite.set(LLMProvider.gemini.rawValue, forKey: "llmProvider")
+    suite.set("llama3.2", forKey: "llmModel")
+    suite.set("llama3.2", forKey: "ollamaModel")
+
+    let settings = SettingsManager(defaults: suite)
+
+    #expect(
+      settings.effectiveLLMModel == "gemini-3.5-flash",
+      "launch-time canonicalization must repair a stuck install")
+    #expect(settings.llmProvider == .gemini, "the user's provider choice is not overridden")
+  }
+
+  // MARK: - Two-way controls
+
+  /// The guard must not be a blanket wipe. A legitimate cloud selection has to
+  /// survive a switch, or "never inherits a foreign model" would be trivially
+  /// satisfiable by resetting the field every time and the tests above would
+  /// pass a strictly worse implementation.
+  @Test("a legitimate cloud model survives its own provider's canonicalization")
+  func legitimateCloudSelectionSurvives() {
+    let settings = freshSettings()
+    settings.llmProvider = .openAI
+    settings.llmModel = "gpt-5.4-mini"
+    // Re-entering the same provider re-runs the guard.
+    settings.llmProvider = .gemini
+    settings.llmProvider = .openAI
+    settings.llmModel = "gpt-5.4-mini"
+
+    #expect(
+      settings.effectiveLLMModel == "gpt-5.4-mini",
+      "the user's own OpenAI pick must not be swept")
+  }
+
+  /// The reverse direction is deliberately NOT symmetric, and that is the
+  /// documented #1305/#1914 decision rather than an oversight: for Ollama the
+  /// armed model is `ollamaModel`, so a cloud id left in `llmModel` cannot reach
+  /// a request. Pinned so nobody "fixes" the asymmetry and re-arms the phantom
+  /// picker selection #1305 removed.
+  @Test("switching to Ollama reads ollamaModel, so a leftover cloud id cannot be sent")
+  func ollamaReadsItsOwnFieldNotTheCloudLeftover() {
+    let settings = freshSettings()
+    settings.llmProvider = .openAI
+    settings.llmModel = "gpt-4o-mini"
+    settings.ollamaModel = "llama3.2"
+
+    settings.llmProvider = .ollama
+
+    #expect(settings.effectiveLLMModel == "llama3.2")
+    #expect(settings.effectiveLLMModel != "gpt-4o-mini")
+  }
+
+  /// The guard's own predicate, stated directly. `llama3.2` must not read as a
+  /// plausible model for any cloud provider — if this ever returns `true` the
+  /// sweep above stops firing and every test here passes for the wrong reason.
+  @Test("an Ollama model name is not mistaken for a cloud model id")
+  func localNamesDoNotLookLikeCloudModels() {
+    for name in ["llama3.2", "gemma4:e4b", "qwen2.5:3b"] {
+      for provider in [LLMProvider.gemini, .openAI, .claude] {
+        #expect(
+          LLMProvider.modelIDLooksLikeCloudProvider(name, provider) == false,
+          "\(name) must not pass as a \(provider.rawValue) model")
+      }
+    }
+    // Two-way: real cloud ids still pass, so the predicate is not simply false.
+    #expect(LLMProvider.modelIDLooksLikeCloudProvider("gemini-3.5-flash", .gemini))
+    #expect(LLMProvider.modelIDLooksLikeCloudProvider("gpt-5.4-mini", .openAI))
+    #expect(LLMProvider.modelIDLooksLikeCloudProvider("claude-haiku-4-5", .claude))
+  }
+}

--- a/Tests/EnviousWisprTests/Services/ProviderModelDesyncTests.swift
+++ b/Tests/EnviousWisprTests/Services/ProviderModelDesyncTests.swift
@@ -25,14 +25,21 @@ import Testing
 /// and is one deleted `||` clause away from reopening a defect that silently
 /// disables AI polish forever.
 ///
-/// **Mutation-verified, not asserted.** Dropping the
-/// `modelIDLooksLikeCloudProvider` clause from `canonicalizeLLMModelForProvider`
-/// and re-running this suite: 4 of 7 cases fail with 16 issues, and they fail by
-/// reproducing the exact production pairing —
-/// `effectiveLLMModel → "llama3.2"` under `provider = .gemini`. The remaining 3
-/// are the two-way controls below and they stay GREEN under the mutant, which is
-/// what shows they are independent checks rather than the same assertion
-/// restated.
+/// **Mutation-verified in both directions, each measured against this exact
+/// 8-case suite rather than inferred** (the numbers below were re-run after the
+/// launch control was added — cloud review, PR #2074):
+///
+/// 1. Delete the `modelIDLooksLikeCloudProvider` clause from
+///    `canonicalizeLLMModelForProvider`: **4 fail, 16 issues**, and they fail by
+///    reproducing the production pairing exactly —
+///    `effectiveLLMModel → "llama3.2"` under `provider = .gemini`. The 4
+///    controls stay GREEN, which is what shows they are independent checks
+///    rather than the same assertion restated.
+/// 2. Replace that whole `if` with an unconditional reset (a blanket wipe):
+///    **exactly the 2 preservation controls fail** and nothing else.
+///
+/// The partition is clean in both runs — guard cases and controls never fail
+/// together — so neither set is passing for the other's reason.
 @MainActor
 @Suite("Provider/model desync (#2064)")
 struct ProviderModelDesyncTests {

--- a/Tests/EnviousWisprTests/Services/ProviderModelDesyncTests.swift
+++ b/Tests/EnviousWisprTests/Services/ProviderModelDesyncTests.swift
@@ -123,22 +123,49 @@ struct ProviderModelDesyncTests {
   // MARK: - Two-way controls
 
   /// The guard must not be a blanket wipe. A legitimate cloud selection has to
-  /// survive a switch, or "never inherits a foreign model" would be trivially
-  /// satisfiable by resetting the field every time and the tests above would
-  /// pass a strictly worse implementation.
+  /// survive canonicalization, or "never inherits a foreign model" would be
+  /// trivially satisfiable by resetting the field on every switch and the tests
+  /// above would pass a strictly worse implementation.
+  ///
+  /// **Nothing writes `llmModel` after the guard runs** (cloud review, PR #2074).
+  /// An earlier version of this case re-set the model AFTER the provider
+  /// assignments, so the expectation observed that manual write rather than the
+  /// guard's preservation — it would have passed against a canonicalization that
+  /// wiped the field every time, which is the exact implementation it exists to
+  /// rule out. A control that restores the value it is checking is not a control.
   @Test("a legitimate cloud model survives its own provider's canonicalization")
   func legitimateCloudSelectionSurvives() {
     let settings = freshSettings()
     settings.llmProvider = .openAI
     settings.llmModel = "gpt-5.4-mini"
-    // Re-entering the same provider re-runs the guard.
-    settings.llmProvider = .gemini
+
+    // Re-assigning the SAME provider re-runs `canonicalizeLLMModelForProvider`
+    // (its didSet calls it unconditionally, not only on a value change), so the
+    // guard gets another look at a model it must leave alone. A blanket wipe
+    // would make this `gpt-4o-mini`.
     settings.llmProvider = .openAI
-    settings.llmModel = "gpt-5.4-mini"
 
     #expect(
       settings.effectiveLLMModel == "gpt-5.4-mini",
       "the user's own OpenAI pick must not be swept")
+  }
+
+  /// The same control at the OTHER seam. `persistedDesyncIsRepairedAtLaunch`
+  /// proves launch canonicalization REPAIRS a foreign model; this proves it does
+  /// not also flatten a legitimate one. Both run the same guard, and a wipe would
+  /// pass the repair case while silently resetting every valid install on every
+  /// launch.
+  @Test("a legitimate cloud model survives launch canonicalization")
+  func legitimateCloudSelectionSurvivesLaunch() {
+    let suite = UserDefaults(suiteName: "SM-2064-valid-\(UUID().uuidString)")!
+    suite.set(LLMProvider.openAI.rawValue, forKey: "llmProvider")
+    suite.set("gpt-5.4-mini", forKey: "llmModel")
+
+    let settings = SettingsManager(defaults: suite)
+
+    #expect(
+      settings.effectiveLLMModel == "gpt-5.4-mini",
+      "launch must not reset a model the user legitimately chose")
   }
 
   /// The reverse direction is deliberately NOT symmetric, and that is the


### PR DESCRIPTION
**No production change.** This adds the regression coverage for #2064, whose defect is already fixed on `main`.

## What happened, from the affected user's own events

One user emitted **443** `llm.polish_failed` rows carrying `provider=gemini model=llama3.2 reason=api_key_missing` — 59% of all polish failures in 90 days, and every AI polish they attempted for three weeks. `llama3.2` is an Ollama model name.

| When | App | Event |
|---|---|---|
| 2026-07-07 12:54:53 | 2.3.1 | `provider.changed` egOne → **ollama** |
| 2026-07-07 12:55:04 | 2.3.1 | `provider.changed` **ollama → gemini** |
| 2026-07-08 … 2026-08-10 | 2.3.1, 2.4.0 | `settings.snapshot` `llm_provider=gemini`, `llm_model=custom` |
| 2026-07-22 → 2026-08-13 01:08 | 2.4.0 | **443 × `llm.polish_failed`** |
| 2026-08-13 01:24:39 | **2.4.4** | `settings.snapshot` `llm_model=`**`gemini-3.5-flash`** |

Three provider switches in 26 seconds, landing on Gemini with an Ollama model id still in `llmModel`. Not the brief post-switch lag #1173 described — a persisted state that never re-converged. (`llm_model=custom` is #1173's settings-telemetry allowlist bucketing a non-allowlisted name, which corroborates that the field really held a local model name throughout.)

## Why it stopped, and why there is no code change here

`canonicalizeLLMModelForProvider`'s `modelIDLooksLikeCloudProvider` clause sweeps a foreign model off the cloud field. It arrived in `92d27f6e` (#1712) and is contained in `v2.4.1` and no earlier tag. It runs at the end of `init`, so it fires at launch with no user action — which is exactly what the timeline shows: the repaired snapshot at 01:24:39 **precedes** their next provider interaction by three minutes.

Fleet sweep: all 446 cross-provider events are on v2.4.0 or older. **Zero on v2.4.1, v2.4.3, v2.4.4.**

## The acceptance criterion that cannot be met, and what replaces it

The issue asked for "a test that fails against current `main`". That is unsatisfiable — the defect is fixed on `main`, so no test of shipped behaviour can fail against it. Saying so is more useful than manufacturing a red.

What was actually missing is coverage of the **guard**. Nothing pinned that a provider switch sweeps a foreign model, leaving the fix one deleted `||` clause away from reopening a defect whose symptom is a user whose AI polish never works again — silently, for three weeks, as it did. **Mutation-verified instead:** removing the `modelIDLooksLikeCloudProvider` clause turns these red.

Covers the exact observed sequence; the three-hop variant the user actually performed (a guard inspecting only the immediately-previous provider would pass a single hop and still ship the defect); every cloud destination against four local model names; and launch-time repair of an already-stuck install, which is the path their recovery actually took.

Two-way controls, because "never inherits a foreign model" is trivially satisfiable by wiping the field on every switch:

- a legitimate cloud pick must survive its own provider's canonicalization;
- the deliberately **asymmetric** Ollama direction is pinned — for Ollama the armed model is `ollamaModel`, so a leftover cloud id cannot reach a request (#1305/#1914) — so nobody "fixes" the asymmetry and re-arms the phantom picker selection #1305 removed;
- the guard's own predicate is asserted directly, both ways, so the sweep cannot silently stop firing while every other case still passes.

Closes #2064
