### PR TITLE
fix(eval): grade a spoken list on layout, which nothing was doing

### DIFF
--- a/scripts/eval/behavior_judge.py
+++ b/scripts/eval/behavior_judge.py
@@ -62,6 +62,7 @@ import http.client
 import json
 import os
 import random
+import re
 import subprocess
 import sys
 import tempfile
@@ -1003,6 +1004,36 @@ def behavior_key(case: dict) -> str:
     return raw
 
 
+# A list marker only counts when it OPENS A LINE. Anchoring to the line start is
+# what separates a real list from prose that merely contains the characters:
+# "the drop-off point" and "version 2. 0" both carry them and neither is a list.
+LIST_MARKER_RE = re.compile(r"(?:^|\n)[ \t]*(?:[-*•–]\s+|\d+[.)]\s+)")
+
+# Shapes whose cases are ABOUT producing a list. Sealed corpora carry `shape`;
+# older corpora do not, and for them this is always False, which is correct —
+# they were authored without a layout requirement and must not acquire one.
+LIST_REQUIRING_SHAPES = ("spoken_list",)
+
+
+def list_format_required(case: dict) -> bool:
+    """Does THIS case demand a real vertical list, one item per line?
+
+    Both conditions must hold, and the second is not redundant. The shape says
+    the case is about lists; the authored key says the correct answer for THIS
+    case actually is one. A `spoken_list` case deliberately authored to stay
+    prose (a trap) must not acquire a layout requirement from its shape alone.
+
+    Why this exists: the judge derives `behavior` from `subset`/`category`/
+    `gold_behavior` and never from `shape`, so every sealed case arrives as
+    `unknown` and layout is graded by nothing. Measured 2026-08-15: all 114
+    sealed `spoken_list` keys demand a list, EG-1 produced one on 1 of them,
+    and 103 of its inline answers were judged PASS.
+    """
+    if case.get("shape") not in LIST_REQUIRING_SHAPES:
+        return False
+    return bool(LIST_MARKER_RE.search(case.get("expected_output") or ""))
+
+
 def case_type_of(case: dict, behavior: str) -> str:
     subset = str(case.get("subset") or case.get("category") or "")
     if subset.endswith("_trap") or "trap_type" in case or "_trap" in str(case.get("id", "")).lower():
@@ -1083,6 +1114,7 @@ def normalize_case(case: dict) -> dict:
         # Empty for corpora that carry no spoken source; the prompt handles absence.
         "spoken_truth": _spoken_truth(case),
         "notes": case.get("notes", ""),
+        "list_format_required": list_format_required(case),
     }
 
 
@@ -1199,11 +1231,34 @@ For each case you are given:
 - risk_tier: critical | standard | cosmetic
 - reference_output: an ILLUSTRATIVE reference, NOT exact ground truth
 - allowed_variants: surface differences you must NOT penalize
+- list_format_required: true when this case must be rendered as a vertical list
 
 Grade by intent, semantic fidelity, target behavior, restraint, and cleanliness.
 Do NOT grade by string similarity to reference_output. Do NOT penalize the
 allowed_variants (punctuation, capitalization, bullet-vs-numbered list, digits-
 vs-words when number formatting is not the behavior under test).
+
+LIST-FORMAT REQUIREMENT
+
+Apply this rule ONLY when list_format_required is true.
+
+The candidate must keep the introductory framing and every spoken item, in the
+order spoken, AND render the items as a genuine vertical list: one item per
+line, each line opening with a consistent bullet or number.
+
+An inline sentence is major_fail / S3 with failure_type "wrong_format" even when
+every word and all meaning are preserved. Spoken ordinals left as prose
+("First, X. Second, Y.") are the specific failure this rule exists to catch.
+
+Markers alone do not satisfy it. It still fails if the candidate puts one marker
+in front of an inline run, merges several items onto one line, splits one item
+across several lines, drops the introduction, or drops, changes or invents an
+item. Bullet and numbered lists remain equivalent; the requirement is the line
+break, not the character.
+
+When list_format_required is false this rule is silent and must NEVER reward
+list formatting. Judge structure under the case's own behavior. Imposing list
+structure on connected prose or an inline enumeration is itself wrong_format.
 
 The deterministic layer handles number/date/URL/custom-vocabulary normalization
 BEFORE this AI step, so do NOT fail a case for unconverted numbers, lowercase
@@ -1274,6 +1329,10 @@ def build_new_payload(norm: dict, cand: dict, prod: dict | None) -> dict:
         "risk_tier": norm["risk_tier"],
         "reference_output": norm["reference_output"],
         "allowed_variants": allowed_variants_for(norm["behavior"]),
+        # Carries the layout requirement independently of reference_output, so it
+        # survives --blind. The flag states THAT a list is required; it never
+        # reveals what the list should say.
+        "list_format_required": norm.get("list_format_required", False),
     }
 
 

--- a/scripts/eval/behavior_judge.py
+++ b/scripts/eval/behavior_judge.py
@@ -1586,7 +1586,17 @@ def score_new(norm_cases: dict, cands: dict, prod: dict | None,
     report = aggregate_new(per_case, rep_scores, judged_ids, has_production,
                            missing_count=len(missing), skipped_count=len(skipped),
                            adjudication_missing_count=len(adjudication_batch.missing),
-                           blind=blind)
+                           # With --verdicts this scorer sends no payload and no
+                           # system prompt, so the local --blind flag describes
+                           # THIS process and not the judging that produced those
+                           # verdicts. Recording it there would assert something
+                           # nobody observed. The external format carries no such
+                           # field, so the honest value is "unknown".
+                           #
+                           # Same distinction `cacheable` already draws: an ABSENT
+                           # answer and a FALSE answer are different situations,
+                           # and collapsing them shipped a wrong claim twice.
+                           blind=None if external_verdicts is not None else blind)
     report["skipped"] = skipped
     report["missing_scores"] = missing
     report["per_case"] = per_case
@@ -1623,7 +1633,8 @@ def _is_pass(verdict: str) -> bool:
 
 def aggregate_new(per_case: list[dict], rep_scores: list[dict], judged_ids: list[str],
                   has_production: bool, missing_count: int = 0, skipped_count: int = 0,
-                  adjudication_missing_count: int = 0, blind: bool = False) -> dict:
+                  adjudication_missing_count: int = 0,
+                  blind: bool | None = False) -> dict:
     total = len(per_case)
 
     def rate(items, pred):
@@ -1746,10 +1757,16 @@ def aggregate_new(per_case: list[dict], rep_scores: list[dict], judged_ids: list
 
     return {
         "system": "new",
-        # Whether the judge saw expected_output. Recorded because a blind and a
-        # sighted run are NOT comparable: showing the key moved 122 of 472
-        # verdicts. Two receipts differing on this flag must never be diffed as
-        # if they measured the same thing.
+        # Whether the judge saw expected_output. THREE states, not two, because
+        # an unknown answer and a "no" are different situations:
+        #   True  — judged blind by this run
+        #   False — judged sighted by this run
+        #   None  — verdicts were IMPORTED; this process did no judging and
+        #           cannot speak for how they were produced
+        # Recorded because a blind and a sighted run are NOT comparable (showing
+        # the key moved 122 of 472 verdicts), and `report_ollama_bench.py` folds
+        # this into the comparison identity so two receipts differing on it
+        # refuse to rank together rather than being silently diffed.
         "judge_blind": blind,
         # Completeness on its own, independent of the verdict. `BLOCK` takes
         # precedence over `INCOMPLETE`, so the verdict alone cannot express

--- a/scripts/eval/behavior_judge.py
+++ b/scripts/eval/behavior_judge.py
@@ -1277,6 +1277,47 @@ def build_new_payload(norm: dict, cand: dict, prod: dict | None) -> dict:
     }
 
 
+# --- blinded judging -------------------------------------------------------
+# The prompt ALREADY tells the judge that reference_output is illustrative and
+# must not be string-matched (see NEW_JUDGE_SYSTEM). That instruction was
+# measured and it does not work: showing the judge the key moved 122 of 472
+# verdicts (McNemar chi2=79.9), and adding the "not ground truth" wording
+# changed nothing (polish-eval.md, Judge protocol).
+#
+# So the anchor has to be REMOVED, not disclaimed. Blinding drops the field from
+# the payload entirely, leaving the judge to grade adherence to
+# expected_behavior against raw_transcript.
+#
+# This matters more than usual here because the sampler cannot be pinned: this
+# Azure deployment REJECTS temperature=0 with HTTP 400 and permits only its
+# default of 1, and the Claude CLI route exposes no temperature control. Neither
+# transport can make the judge deterministic, so removing an input that is known
+# to move verdicts is one of the few levers that remain.
+BLIND_DROP_FIELDS = ("reference_output",)
+
+
+def blind_payload(payload: dict) -> dict:
+    """Strip the answer key from a judge payload.
+
+    Returns a NEW dict; never mutates the caller's, because the same normalised
+    case feeds both the primary and adjudication passes and an in-place strip
+    would silently blind a pass that was meant to be sighted.
+    """
+    return {k: v for k, v in payload.items() if k not in BLIND_DROP_FIELDS}
+
+
+BLIND_JUDGE_SYSTEM = (
+    NEW_JUDGE_SYSTEM
+    .replace("- reference_output: an ILLUSTRATIVE reference, NOT exact ground truth\n", "")
+    .replace(
+        "Do NOT grade by string similarity to reference_output. Do NOT penalize the",
+        "You are NOT given a reference answer. Grade whether candidate_output "
+        "performs expected_behavior on raw_transcript, and whether it preserves "
+        "meaning, entities and voice. There is usually more than one correct "
+        "output; accept any that satisfies expected_behavior. Do NOT penalize the")
+)
+
+
 def coerce_new_score(raw: dict, has_production: bool) -> dict:
     """Validate/repair one new-system score object into a known shape."""
     verdict = raw.get("verdict")
@@ -1366,7 +1407,8 @@ def score_new(norm_cases: dict, cands: dict, prod: dict | None,
               external_verdicts: dict | None,
               adjudicate_pct: float = DEFAULT_ADJUDICATE_PCT,
               adjudicate_min: int = DEFAULT_ADJUDICATE_MIN,
-              adjudicate: bool = True) -> dict:
+              adjudicate: bool = True,
+              blind: bool = False) -> dict:
     """Run (or ingest) the behavior-aware judge and aggregate. Returns the full
     report dict. Cases with no candidate or an engine error are recorded as
     infra-skips (NOT scored as fails — an engine error is not a grading signal).
@@ -1397,8 +1439,17 @@ def score_new(norm_cases: dict, cands: dict, prod: dict | None,
         payloads = [build_new_payload(norm_cases[cid], cands[cid],
                                       prod.get(cid) if prod else None)
                     for cid in judged_ids]
-        print(f"[new] primary pass over {len(payloads)} cases", file=sys.stderr)
-        primary_batch = run_judge(judge, NEW_JUDGE_SYSTEM, payloads, chunk_size)
+        # Blinding is applied to BOTH passes or neither. A sighted primary with
+        # a blind adjudication would merge verdicts formed against different
+        # evidence, and `_worse_new_score` would then resolve that mismatch by
+        # always taking the harsher one.
+        judge_system = BLIND_JUDGE_SYSTEM if blind else NEW_JUDGE_SYSTEM
+        if blind:
+            payloads = [blind_payload(p) for p in payloads]
+        print(f"[new] primary pass over {len(payloads)} cases"
+              f"{' (BLIND: no answer key shown)' if blind else ''}",
+              file=sys.stderr)
+        primary_batch = run_judge(judge, judge_system, payloads, chunk_size)
         primary = {cid: coerce_new_score(s, has_production)
                   for cid, s in primary_batch.accepted.items()}
 
@@ -1422,7 +1473,7 @@ def score_new(norm_cases: dict, cands: dict, prod: dict | None,
                       f"({len(adjudicated_ids)*100//max(len(primary),1)}% of primary)",
                       file=sys.stderr)
                 adj_payloads = [p for p in payloads if p["id"] in set(adjudicated_ids)]
-                adjudication_batch = run_judge(judge, NEW_JUDGE_SYSTEM, adj_payloads, chunk_size)
+                adjudication_batch = run_judge(judge, judge_system, adj_payloads, chunk_size)
                 adjudication = {cid: coerce_new_score(s, has_production)
                                 for cid, s in adjudication_batch.accepted.items()}
                 for cid, adj_score in adjudication.items():
@@ -1441,18 +1492,42 @@ def score_new(norm_cases: dict, cands: dict, prod: dict | None,
 
     missing = primary_batch.missing
 
+    # Persist BOTH looks, not just the merged one. Without this the receipt can
+    # report "disagreements=124" while making it impossible to ask WHICH cases
+    # moved or in WHICH direction — the harness discarding the evidence needed to
+    # audit its own noise. Cost is a few fields per row.
+    #
+    # Read these knowing the merge is ONE-DIRECTIONAL: `_worse_new_score` keeps
+    # the more severe look, so `adjudication_changed_outcome` can only ever mean
+    # the case got worse. A re-judge that would have IMPROVED a case is recorded
+    # here as a disagreement but never changes the score.
+    _premerge = locals().get("primary_premerge") or {}
+    _adjud = locals().get("adjudication") or {}
     per_case = []
     for cid in judged_ids:
         if cid not in primary:
             continue
         s = primary[cid]
-        per_case.append({**norm_cases[cid], **s,
+        pre = _premerge.get(cid)
+        adj = _adjud.get(cid)
+        audit = {
+            "adjudicated": cid in _adjud,
+            "primary_verdict": (pre or s).get("verdict"),
+            "primary_severity": (pre or s).get("severity"),
+            "adjudication_verdict": adj.get("verdict") if adj else None,
+            "adjudication_severity": adj.get("severity") if adj else None,
+            "adjudication_changed_outcome": bool(
+                pre and adj and (pre.get("verdict") != s.get("verdict")
+                                 or pre.get("severity") != s.get("severity"))),
+        }
+        per_case.append({**norm_cases[cid], **s, **audit,
                          "candidate_output": cands[cid].get("candidate"),
                          "latencyMs": cands[cid].get("latencyMs")})
 
     report = aggregate_new(per_case, rep_scores, judged_ids, has_production,
                            missing_count=len(missing), skipped_count=len(skipped),
-                           adjudication_missing_count=len(adjudication_batch.missing))
+                           adjudication_missing_count=len(adjudication_batch.missing),
+                           blind=blind)
     report["skipped"] = skipped
     report["missing_scores"] = missing
     report["per_case"] = per_case
@@ -1489,7 +1564,7 @@ def _is_pass(verdict: str) -> bool:
 
 def aggregate_new(per_case: list[dict], rep_scores: list[dict], judged_ids: list[str],
                   has_production: bool, missing_count: int = 0, skipped_count: int = 0,
-                  adjudication_missing_count: int = 0) -> dict:
+                  adjudication_missing_count: int = 0, blind: bool = False) -> dict:
     total = len(per_case)
 
     def rate(items, pred):
@@ -1612,6 +1687,11 @@ def aggregate_new(per_case: list[dict], rep_scores: list[dict], judged_ids: list
 
     return {
         "system": "new",
+        # Whether the judge saw expected_output. Recorded because a blind and a
+        # sighted run are NOT comparable: showing the key moved 122 of 472
+        # verdicts. Two receipts differing on this flag must never be diffed as
+        # if they measured the same thing.
+        "judge_blind": blind,
         # Completeness on its own, independent of the verdict. `BLOCK` takes
         # precedence over `INCOMPLETE`, so the verdict alone cannot express
         # "failed AND partial" — which is why keying a cache on it is wrong.
@@ -2044,6 +2124,12 @@ def main() -> int:
                     help=f"(new system) floor on the calibration sample size (default {DEFAULT_ADJUDICATE_MIN})")
     ap.add_argument("--no-adjudicate", action="store_true",
                     help="(new system) single primary pass only, skip the S3/S4 + sample re-judge")
+    ap.add_argument("--blind", action="store_true",
+                    help="do not show the judge expected_output. The sighted "
+                         "prompt already calls the key illustrative and that was "
+                         "measured to change nothing (122/472 verdicts moved by "
+                         "showing the key); this REMOVES the anchor instead of "
+                         "disclaiming it. Recorded in the receipt as judge_blind.")
     ap.add_argument("--chunk-size", type=int, default=DEFAULT_CHUNK_SIZE)
     ap.add_argument("--out", required=True, help="output directory")
     args = ap.parse_args()
@@ -2115,7 +2201,7 @@ def main() -> int:
     if args.system == "new":
         report = score_new(norm_cases, cands, prod, args.judge, args.chunk_size,
                            external_verdicts, args.adjudicate_pct, args.adjudicate_min,
-                           adjudicate=not args.no_adjudicate)
+                           adjudicate=not args.no_adjudicate, blind=args.blind)
     else:
         report = score_old(norm_cases, cands, args.judge, args.reps, args.chunk_size)
 

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -2743,6 +2743,106 @@ def test_spoken_truth_reads_both_corpus_schemas():
         assert bj._spoken_truth(case) == "", f"{case!r} must yield empty, not raise"
 
 
+def test_a_blind_arm_and_a_sighted_arm_are_refused_like_a_mixed_judge():
+    """Blinding changes what a score MEANS, so it belongs in the identity.
+
+    Showing the judge the answer key moved 122 of 472 verdicts. That is larger
+    than any arm difference this report exists to rank, so ranking a blind arm
+    against a sighted one is not a comparison. `judge_blind` sits at the TOP
+    LEVEL of the receipt rather than under `meta`, which is exactly why the
+    original identity tuple — built only from `meta` fields — could not see it.
+
+    THREE-WAY, because `judge_blind` has three legal states. `None` means the
+    verdicts were imported and this scorer did no judging, which is an UNKNOWN
+    rather than a "no": folding it into "sighted" would assert something nobody
+    observed, the same absent-vs-false collapse that shipped wrong twice on
+    `cacheable`.
+    """
+    def tree_with_two(blind_a, blind_b):
+        meta = {"judge": "azure/j", "judge_identity": "azure/j@aaa",
+                "judge_model_version": "v1", "rubric_identity": "RUBRIC_ONE"}
+        t = report_tree(healthy_receipt(meta=meta, judge_blind=blind_a))
+        b = t / "judged" / "modelB"
+        b.mkdir(parents=True)
+        (b / "summary.json").write_text(
+            json.dumps(healthy_receipt(meta=meta, judge_blind=blind_b)))
+        (b / "per_case.jsonl").write_text(
+            (t / "judged" / "modelA" / "per_case.jsonl").read_text())
+        run = json.loads((t / "run-summary.json").read_text())
+        m = dict(run["models"][0]); m["model"] = "modelB"
+        m["candidates"] = str(t / "cand" / "modelB.jsonl")
+        run["models"].append(m)
+        (t / "run-summary.json").write_text(json.dumps(run))
+        return t
+
+    # Refuses: one arm saw the key, the other did not.
+    rc, log = run_report(tree_with_two(True, False))
+    assert "mixes judges or rubrics" in log, f"blind and sighted were ranked together:\n{log}"
+    assert rc != 0, log
+    # And the refusal must SAY it was the blinding, or it reads as a bug in the
+    # guard: every other identity field is identical between these two arms.
+    assert "no answer key shown" in log and "answer key shown" in log, log
+
+    # Refuses: a known mode against an imported-verdict receipt of unknown mode.
+    rc, log = run_report(tree_with_two(False, None))
+    assert "mixes judges or rubrics" in log, f"unknown blinding ranked as sighted:\n{log}"
+    assert "blinding unknown" in log, log
+
+    # Accepts: both blind, and both sighted. Without this half a guard that
+    # refused every run would pass the refusal cases while making the report
+    # permanently unusable.
+    for same in (True, False, None):
+        rc, log = run_report(tree_with_two(same, same))
+        assert "mixes judges or rubrics" not in log, f"one blinding mode was refused:\n{log}"
+
+
+def test_imported_verdicts_cannot_claim_a_blinding_mode():
+    """--verdicts sends no payload and no system prompt, so this process did not
+    decide whether the judge saw the answer key and must not record that it did.
+
+    The local --blind flag describes THIS run. Stamping it onto imported verdicts
+    asserts a fact about someone else's judging that was never observed, and the
+    external verdict format carries no such field to check it against.
+    """
+    norm = {"c1": bj.normalize_case(
+        {"id": "c1", "asr_input": "um hello there", "expected_output": "Hello there."})}
+    cands = {"c1": {"candidate": "Hello there."}}
+    verdicts = {"c1": {"id": "c1", "verdict": "pass", "severity": "S0",
+                       "behavior_correct": True, "meaning_preserved": True,
+                       "restraint_correct": True, "clean_output": True,
+                       "failure_types": [], "changed_or_missing_content": [],
+                       "rationale": ""}}
+
+    # Both local flags must land on "unknown", not on their own value.
+    for local_flag in (True, False):
+        rep = bj.score_new(norm, cands, None, "unused-judge", 8,
+                           external_verdicts=verdicts, adjudicate=False,
+                           blind=local_flag)
+        assert rep["judge_blind"] is None, (
+            f"--blind={local_flag} was stamped onto imported verdicts as "
+            f"{rep['judge_blind']!r}; nobody observed how they were graded")
+
+    # Control: when this process DOES judge, the flag is recorded faithfully.
+    # Without this half the fix could be "always None", which loses the field.
+    captured = {}
+
+    def fake_run_judge(judge, system, payloads, chunk):
+        captured["saw_key"] = "reference_output" in (payloads[0] if payloads else {})
+        return bj.reconcile_judge_batch(verdicts, [p["id"] for p in payloads])
+
+    real = bj.run_judge
+    bj.run_judge = fake_run_judge
+    try:
+        for flag in (True, False):
+            rep = bj.score_new(norm, cands, None, "unused-judge", 8,
+                               external_verdicts=None, adjudicate=False, blind=flag)
+            assert rep["judge_blind"] is flag, rep["judge_blind"]
+            assert captured["saw_key"] is (not flag), (
+                "the recorded flag must match what the judge was actually sent")
+    finally:
+        bj.run_judge = real
+
+
 def test_list_format_requirement_fires_only_where_a_list_is_actually_wanted():
     """The layout requirement must be armed by the case, not by the judge's mood.
 
@@ -2831,7 +2931,7 @@ def test_list_requirement_reaches_the_judge_and_survives_blinding():
 # originally borrowed from cleanup_metrics_test.py, deleted 2026-08-15 with the
 # rest of the deterministic polish grading; the zero-test trap it guards is
 # unchanged.)
-EXPECTED_TESTS = 133
+EXPECTED_TESTS = 135
 
 
 def _run() -> int:

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -2747,8 +2747,11 @@ def test_spoken_truth_reads_both_corpus_schemas():
 # runner                                                                      #
 # --------------------------------------------------------------------------- #
 
-# An exact count, because the borrowed runner in cleanup_metrics_test.py returns
-# 0 when it discovers ZERO tests — so "green" would carry no information at all.
+# An exact count, because this file's runner returns 0 when it discovers ZERO
+# tests — so "green" would carry no information at all. (The runner was
+# originally borrowed from cleanup_metrics_test.py, deleted 2026-08-15 with the
+# rest of the deterministic polish grading; the zero-test trap it guards is
+# unchanged.)
 EXPECTED_TESTS = 131
 
 

--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -2743,6 +2743,85 @@ def test_spoken_truth_reads_both_corpus_schemas():
         assert bj._spoken_truth(case) == "", f"{case!r} must yield empty, not raise"
 
 
+def test_list_format_requirement_fires_only_where_a_list_is_actually_wanted():
+    """The layout requirement must be armed by the case, not by the judge's mood.
+
+    This exists because the requirement was previously armed by NOTHING.
+    `behavior_key` reads subset/category/gold_behavior and never `shape`, so
+    every sealed case arrived as `unknown` and layout was graded by no rule at
+    all. Measured 2026-08-15: all 114 sealed `spoken_list` keys demand a list,
+    EG-1 produced one on 1 of them, and 103 of its inline answers were judged
+    PASS. A pass rate built that way carries no information about list building.
+
+    Both conditions are load-bearing and the second is not redundant. Shape says
+    the case is ABOUT lists; the authored key says the right answer for THIS
+    case IS one. A `spoken_list` case deliberately authored to stay prose is a
+    trap, and a trap must not inherit a requirement from its shape.
+    """
+    bulleted = "Do these:\n- alpha\n- beta"
+    numbered = "Do these:\n1. alpha\n2. beta"
+
+    # Armed: the shape is about lists and the key really is one.
+    assert bj.list_format_required({"shape": "spoken_list", "expected_output": bulleted})
+    assert bj.list_format_required({"shape": "spoken_list", "expected_output": numbered})
+
+    # Disarmed by the key: a list-shaped case whose correct answer stays prose.
+    assert not bj.list_format_required(
+        {"shape": "spoken_list", "expected_output": "Do these: alpha and beta."})
+
+    # Disarmed by the shape: every other shape, even when its key happens to be
+    # a list. Nothing may acquire a layout requirement it was not authored with.
+    for shape in ("clean", "inline_enumeration", "connected_prose", "self_correction",
+                  "fillers_only", "unfinished", "topic_shift", "voice_at_risk",
+                  "numbers_dates", "quoted_instruction"):
+        assert not bj.list_format_required({"shape": shape, "expected_output": bulleted}), shape
+
+    # Legacy corpora carry no `shape`. They were authored without a layout
+    # requirement and must not gain one retroactively.
+    assert not bj.list_format_required({"expected_output": bulleted})
+
+    # A marker only counts when it OPENS a line, or ordinary prose arms the rule.
+    assert not bj.list_format_required(
+        {"shape": "spoken_list", "expected_output": "meet at the drop-off point at 2. 0"})
+
+    # Degenerate shapes must return False, never raise: this runs on a grading path.
+    for case in ({}, {"shape": None}, {"shape": "spoken_list"},
+                 {"shape": "spoken_list", "expected_output": None},
+                 {"shape": "spoken_list", "expected_output": ""}):
+        assert bj.list_format_required(case) is False, f"{case!r} must be False, not raise"
+
+
+def test_list_requirement_reaches_the_judge_and_survives_blinding():
+    """A criterion the judge never receives is not a criterion.
+
+    The flag travels separately from `reference_output` on purpose. Blinding
+    strips the answer key, and the layout requirement must outlive that: the
+    flag says THAT a list is required and never what the list should say, so it
+    is safe to keep and useless as an anchor.
+    """
+    case = {"id": "L1", "shape": "spoken_list", "subset": "spoken_list",
+            "asr_input": "Here's the plan. First, alpha. Second, beta.",
+            "expected_output": "Here's the plan:\n- alpha\n- beta"}
+    payload = bj.build_new_payload(bj.normalize_case(case), {"candidate": "x"}, None)
+    assert payload["list_format_required"] is True
+
+    blinded = bj.blind_payload(payload)
+    assert "reference_output" not in blinded, "blinding must still drop the answer key"
+    assert blinded["list_format_required"] is True, "the requirement must survive blinding"
+
+    # And the rule itself has to be in BOTH prompts, or blind runs grade layout
+    # by nothing — which is the exact defect this change exists to fix.
+    assert "LIST-FORMAT REQUIREMENT" in bj.NEW_JUDGE_SYSTEM
+    assert "LIST-FORMAT REQUIREMENT" in bj.BLIND_JUDGE_SYSTEM
+
+    # A case with no layout requirement must carry the flag as False rather than
+    # omit it: the prompt branches on the field, and an absent field is unread.
+    prose = bj.build_new_payload(
+        bj.normalize_case({"id": "P1", "shape": "connected_prose", "asr_input": "a",
+                           "expected_output": "a"}), {"candidate": "x"}, None)
+    assert prose["list_format_required"] is False
+
+
 # --------------------------------------------------------------------------- #
 # runner                                                                      #
 # --------------------------------------------------------------------------- #
@@ -2752,7 +2831,7 @@ def test_spoken_truth_reads_both_corpus_schemas():
 # originally borrowed from cleanup_metrics_test.py, deleted 2026-08-15 with the
 # rest of the deterministic polish grading; the zero-test trap it guards is
 # unchanged.)
-EXPECTED_TESTS = 131
+EXPECTED_TESTS = 133
 
 
 def _run() -> int:

--- a/scripts/eval/report_ollama_bench.py
+++ b/scripts/eval/report_ollama_bench.py
@@ -385,6 +385,12 @@ def main() -> int:
             # below reads a field nobody sets and can never fire.
             "rubric_identity": receipt_meta.get("rubric_identity"),
             "judge_model_version": receipt_meta.get("judge_model_version"),
+            # WHETHER THE JUDGE SAW THE ANSWER KEY. Top-level on the receipt, not
+            # under `meta`. Without it on the row, a blind arm and a sighted arm
+            # rank together as though they were measured the same way, and they
+            # were not: showing the key moved 122 of 472 verdicts. That is a
+            # larger effect than any arm difference this report exists to rank.
+            "judge_blind": summary.get("judge_blind"),
             "isRemote": sp["isRemote"],
             "thinks": sp["thinks"],
             "thinkSent": sp["thinkSent"],
@@ -442,12 +448,36 @@ def main() -> int:
                     f"{type(value).__name__}, not a string, so its judge cannot be identified")
                 value = None
             key.append(value)
+        # Blinding is validated separately because it is the one identity field
+        # that is a BOOL on the receipt, so the str-or-None coercion above would
+        # reject every well-formed value. Three legal states, and `None` is a
+        # real one (verdicts imported, this scorer did no judging and cannot say)
+        # rather than a missing answer — so it groups with other unknowns instead
+        # of being quietly folded into "sighted".
+        blind_value = row.get("judge_blind")
+        if blind_value is None:
+            key.append(None)
+        elif isinstance(blind_value, bool):
+            key.append("blind" if blind_value else "sighted")
+        else:
+            problems.append(
+                f"{row.get('model')} ({row.get('arm')}): receipt `judge_blind` is "
+                f"{type(blind_value).__name__}, not a boolean, so it cannot be shown "
+                f"whether that arm was graded against the answer key")
+            key.append(None)
         judges.setdefault(tuple(key), []).append(row.get("model"))
     if len(judges) > 1:
         detail = "; ".join(
             f"{j[1] or j[0]}"
             + (f" serving {j[2]}" if j[2] else "")
             + (f" under rubric {j[3]}" if len(j) > 3 and j[3] else "")
+            # Named explicitly, because blinding can be the ONLY differing field.
+            # Without this the refusal prints two groups that look identical and
+            # gives no reason, which reads as a bug in the guard rather than as
+            # the real incompatibility it is.
+            + (f" ({'no answer key shown' if j[4] == 'blind' else 'answer key shown'})"
+               if len(j) > 4 and j[4] else
+               (" (blinding unknown: verdicts were imported)" if len(j) > 4 else ""))
             + f": {', '.join(sorted(m for m in models if m))}"
             for j, models in sorted(judges.items(), key=lambda kv: str(kv)))
         problems.append(


### PR DESCRIPTION
## Why

The sealed benchmark could not see list layout, so it graded the one capability we are worst at by nothing at all.

`behavior_key()` derives the behaviour bucket from `subset` / `category` / `gold_behavior` and never from `shape`. Sealed cases carry `shape`, so all 1,462 arrive as `unknown` and no rule ever asks whether a list was required. The rubric was not lenient; the criterion was absent.

Measured on `runs/sealed-2026-08-15/`:

| arm | emitted a list | left it inline | judge passed the inline answers |
|---|---|---|---|
| **EG-1 (shipped)** | **1 / 114 (0.9%)** | 113 | **91.2%** |
| `dpo3` | 25 / 114 (21.9%) | 89 | 88.8% |
| `dpo4` | 21 / 114 (18.4%) | 93 | 89.2% |
| cloud | 90 / 114 (78.9%) | 24 | 79.2% |

All 114 keys demand a vertical list. **103 EG-1 inline answers passed a list-demanding key.** That is where `spoken_list` 91.2% came from, and it is why "EG-1 beats cloud on lists 91.2 vs 73.7" was backwards: cloud does the asked-for thing 79% of the time and was marked down for an unrelated defect, dropping the lead-in on 17 of its 25 formatted-list failures.

Consequence beyond this one slice: every local arm's overall score is inflated. Projected honest rates once inline answers can no longer pass — EG-1 89.7% → 82.6%, `dpo4` 90.6% → 85.0%, cloud 90.1% → 88.8%. The "EG-1 is at cloud parity" reading was an artefact.

## What changed

`list_format_required`, true only when **both** hold: the case's shape is about lists, **and** the authored key really is one. The second condition is not redundant — a `spoken_list` case deliberately authored to stay prose is a trap and must not inherit a requirement from its shape. Legacy corpora carry no `shape`, so the flag is False for them and nothing acquires a layout requirement retroactively.

The flag travels separately from `reference_output` so it survives `--blind`. It states **that** a list is required and never what the list should say, which makes it safe to keep and useless as an anchor. The rubric clause is in both the sighted and blind prompts, or blind runs would grade layout by nothing — the exact defect being fixed.

Bullet and numbered lists remain equivalent; the requirement is the line break, not the character. When the flag is false the rule is silent and must never reward list formatting, because imposing structure on connected prose is itself `wrong_format`.

Also lands a `--blind` mode recovered from an uncommitted working tree, where it was sitting complete and green. It strips `reference_output` from the payload rather than disclaiming it, because the disclaimer was measured not to work: showing the key moved 122 of 472 verdicts and adding "not ground truth" wording changed nothing. Default off, so no stored score changes. Committed separately so it can be reviewed on its own.

## Verification

- **133 self-tests green** (`EXPECTED_TESTS` raised 131 → 133 in the same change, per the suite's own count assertion).
- **Mutation control, five mutants of the predicate, every one killed by the new tests:** always-true, always-false, shape-only, key-only, and an unanchored marker match. A test that cannot fail proves nothing, so this is the evidence that the tests are armed rather than merely present. The file was restored byte-for-byte and the suite re-run green afterwards.
- **Against the real corpus:** exactly 114 of 1,462 sealed cases arm the rule, all of them `spoken_list`; the flag survives `blind_payload` while `reference_output` does not.

## Blast radius

Grades already on disk are unaffected until arms are re-graded. Re-grading the four stored arms needs no model inference — the candidate outputs are saved. Non-sealed corpora are unaffected because they carry no `shape`.

Campaign context and the goal this serves: `docs/eg2-campaign/CAMPAIGN.md`.
