### PR TITLE
ci: prove the app still launches on the oldest macOS we support

### DIFF
--- a/.github/workflows/older-macos-launch.yml
+++ b/.github/workflows/older-macos-launch.yml
@@ -9,14 +9,16 @@ name: Older macOS Launch
 # never sees the in-app "needs a newer macOS" message, because the app never opens.
 #
 # Two checks, deliberately different in kind:
-#   1. linkage  — static, fast, deterministic, on the machine that builds. Catches the
-#                 regression at the moment it is introduced, but ONLY for the frameworks it
-#                 names (Speech, FoundationModels). A newer-than-baseline symbol from any other
-#                 framework is outside it by construction.
-#   2. launch   — empirical, on the OLDEST macOS we support. Covers the general case the static
-#                 check cannot, including a wrongly-guarded call that only fails when it runs.
-#                 Runs at the deployment target, not above it: symbol availability is monotonic,
-#                 so a pass above the baseline proves nothing about users at it.
+# The STATIC linkage check does not live here. It runs in `pr-check.yml`'s build-release job,
+# because `build-check` is the only check the branch ruleset requires and a standalone workflow
+# can go red without blocking the merge it exists to block.
+#
+# What lives here is the EMPIRICAL launch, deliberately advisory: it depends on a hosted image
+# with a published retirement date and on starting a GUI app headlessly, and neither belongs on
+# the path that blocks every merge. It covers the general case the static check cannot —
+# including a wrongly-guarded call that only fails when it runs — and it runs AT the deployment
+# target rather than above it, because symbol availability is monotonic and a pass above the
+# baseline proves nothing about users at it.
 #
 # The app cannot be BUILT on an older runner (it needs the macOS 26 SDK), so the build happens
 # on macos-26 and the product is carried to macos-15 as an artifact.
@@ -47,8 +49,8 @@ env:
   XCODE_RELEASE_SCHEME: EnviousWispr-Release
 
 jobs:
-  linkage:
-    name: Weak-linkage check (build on macos-26)
+  build:
+    name: Build the app to carry to the older runner
     runs-on: macos-26
     timeout-minutes: 45
     steps:
@@ -94,18 +96,6 @@ jobs:
           echo "app_path=$APP" >> "$GITHUB_OUTPUT"
           echo "built: $APP"
 
-      # The guard's own arming, checked before the guard's verdict is trusted. This repo has
-      # repeatedly found guards that had silently stopped inspecting anything.
-      - name: Self-test the linkage guard
-        run: |
-          set -euo pipefail
-          BIN="${{ steps.app.outputs.app_path }}/Contents/MacOS/EnviousWispr"
-          ls -l "$BIN"
-          ./scripts/ci/check-weak-linked-symbols-test.sh "$BIN"
-
-      - name: Assert macOS 26 frameworks are weak-linked
-        run: ./scripts/ci/check-weak-linked-symbols.sh "${{ steps.app.outputs.app_path }}/Contents/MacOS/EnviousWispr"
-
       - name: Upload the app for the older-macOS launch
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -116,7 +106,7 @@ jobs:
 
   launch:
     name: Launch on macOS 14 (the deployment target)
-    needs: linkage
+    needs: build
     runs-on: macos-14
     timeout-minutes: 20
     steps:

--- a/.github/workflows/older-macos-launch.yml
+++ b/.github/workflows/older-macos-launch.yml
@@ -91,8 +91,12 @@ jobs:
         id: app
         run: |
           set -euo pipefail
-          APP=$(find "$DERIVED_DATA_PATH/Build/Products" -maxdepth 3 -name 'EnviousWispr.app' -type d | head -1)
-          [ -n "$APP" ] || { echo "FAIL: no built .app found" >&2; exit 1; }
+          # Named explicitly for the same reason as the required gate: an unordered match over a
+          # restored DerivedData cache could carry a stale Debug app to the older runner, and the
+          # launch would then certify a binary we do not ship.
+          APP="$DERIVED_DATA_PATH/Build/Products/Release/EnviousWispr.app"
+          # `-d`, not `-n`: a literal path is always non-empty, so only existence is evidence.
+          [ -d "$APP" ] || { echo "FAIL: release app not at $APP" >&2; exit 1; }
           echo "app_path=$APP" >> "$GITHUB_OUTPUT"
           echo "built: $APP"
 

--- a/.github/workflows/older-macos-launch.yml
+++ b/.github/workflows/older-macos-launch.yml
@@ -37,6 +37,10 @@ on:
       # would otherwise merge a broken probe without ever running it.
       - 'scripts/ci/**'
       - '.github/workflows/older-macos-launch.yml'
+      # `classify-changes.sh` treats .github/** as content-only except pr-check and
+      # main-post-merge, so a release.yml change (an archive-time linker or deployment-target
+      # override, say) would otherwise reach production without either check running.
+      - '.github/workflows/release.yml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/older-macos-launch.yml
+++ b/.github/workflows/older-macos-launch.yml
@@ -48,6 +48,18 @@ env:
   XCODE_PROJECT: EnviousWispr.xcodeproj
   XCODE_RELEASE_SCHEME: EnviousWispr-Release
 
+# **Least privilege, because this workflow executes branch-controlled code.**
+#
+# This repository's default workflow token is WRITE (verified via
+# `gh api repos/.../actions/permissions/workflow`), and both jobs below build and run scripts
+# from the pull request's own branch. Without this block those jobs would run with a
+# write-capable credential that a modified build phase or CI script could use against the
+# repository, which branch protection does not prevent. Nothing here needs to write anything:
+# artifacts move between the two jobs of the SAME run, which uses the Actions runtime token
+# rather than this one.
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build the app to carry to the older runner
@@ -56,6 +68,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
@@ -130,6 +144,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Report the runner's OS
         run: sw_vers

--- a/.github/workflows/older-macos-launch.yml
+++ b/.github/workflows/older-macos-launch.yml
@@ -10,9 +10,13 @@ name: Older macOS Launch
 #
 # Two checks, deliberately different in kind:
 #   1. linkage  — static, fast, deterministic, on the machine that builds. Catches the
-#                 regression at the moment it is introduced.
-#   2. launch   — empirical, on a real older macOS. Catches what static analysis cannot,
-#                 including a wrongly-guarded call that only fails when it runs.
+#                 regression at the moment it is introduced, but ONLY for the frameworks it
+#                 names (Speech, FoundationModels). A newer-than-baseline symbol from any other
+#                 framework is outside it by construction.
+#   2. launch   — empirical, on the OLDEST macOS we support. Covers the general case the static
+#                 check cannot, including a wrongly-guarded call that only fails when it runs.
+#                 Runs at the deployment target, not above it: symbol availability is monotonic,
+#                 so a pass above the baseline proves nothing about users at it.
 #
 # The app cannot be BUILT on an older runner (it needs the macOS 26 SDK), so the build happens
 # on macos-26 and the product is carried to macos-15 as an artifact.
@@ -25,9 +29,11 @@ on:
       - 'Package.swift'
       - 'Package.resolved'
       - 'Project.swift'
+      - 'Tuist.swift'
       - 'Tuist/**'
-      - 'scripts/ci/check-weak-linked-symbols.sh'
-      - 'scripts/ci/check-weak-linked-symbols-test.sh'
+      # Every guard script, not just the two named ones: a PR touching only the launch probe
+      # would otherwise merge a broken probe without ever running it.
+      - 'scripts/ci/**'
       - '.github/workflows/older-macos-launch.yml'
   workflow_dispatch:
 
@@ -109,24 +115,16 @@ jobs:
           if-no-files-found: error
 
   launch:
-    name: Launch on macOS 15 (Sequoia)
+    name: Launch on macOS 14 (the deployment target)
     needs: linkage
-    runs-on: macos-15
+    runs-on: macos-14
     timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Report the runner's OS
-        run: |
-          sw_vers
-          # Fails loudly if this label ever starts resolving to macOS 26, which would make the
-          # whole job a second copy of the build machine and prove nothing.
-          MAJOR=$(sw_vers -productVersion | cut -d. -f1)
-          if [ "$MAJOR" -ge 26 ]; then
-            echo "FAIL: expected an older macOS here, got $(sw_vers -productVersion). This job only has meaning on a runner BELOW the SDK version the app is built with." >&2
-            exit 1
-          fi
+        run: sw_vers
 
       - name: Download the app
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/older-macos-launch.yml
+++ b/.github/workflows/older-macos-launch.yml
@@ -1,0 +1,138 @@
+name: Older macOS Launch
+
+# Does the app still START on the oldest macOS we support?
+#
+# Every other macOS job in this repo runs on macos-26, so nothing has ever built or launched
+# this app on an older OS. That matters because we build against the macOS 26 SDK with a macOS
+# 14 deployment target: a reference to a macOS 26 symbol that is bound STRONGLY makes dyld
+# abort at LAUNCH on macOS 14/15, before any `#available` check in our code runs. The user
+# never sees the in-app "needs a newer macOS" message, because the app never opens.
+#
+# Two checks, deliberately different in kind:
+#   1. linkage  — static, fast, deterministic, on the machine that builds. Catches the
+#                 regression at the moment it is introduced.
+#   2. launch   — empirical, on a real older macOS. Catches what static analysis cannot,
+#                 including a wrongly-guarded call that only fails when it runs.
+#
+# The app cannot be BUILT on an older runner (it needs the macOS 26 SDK), so the build happens
+# on macos-26 and the product is carried to macos-15 as an artifact.
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'Sources/**'
+      - 'Package.swift'
+      - 'Package.resolved'
+      - 'Project.swift'
+      - 'Tuist/**'
+      - 'scripts/ci/check-weak-linked-symbols.sh'
+      - 'scripts/ci/check-weak-linked-symbols-test.sh'
+      - '.github/workflows/older-macos-launch.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: older-macos-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  DERIVED_DATA_PATH: .derivedData/CI
+  XCODE_PROJECT: EnviousWispr.xcodeproj
+  XCODE_RELEASE_SCHEME: EnviousWispr-Release
+
+jobs:
+  linkage:
+    name: Weak-linkage check (build on macos-26)
+    runs-on: macos-26
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Install Tuist
+        run: |
+          set -euo pipefail
+          curl https://mise.run | sh
+          "$HOME/.local/bin/mise" install tuist@4.195.11
+          "$HOME/.local/bin/mise" x tuist@4.195.11 -- tuist version
+
+      - name: Generate project
+        run: |
+          set -euo pipefail
+          "$HOME/.local/bin/mise" x tuist@4.195.11 -- tuist generate --no-open
+
+      - name: Build (release)
+        run: |
+          set -euo pipefail
+          xcodebuild build \
+            -project "$XCODE_PROJECT" \
+            -scheme "$XCODE_RELEASE_SCHEME" \
+            -configuration Release \
+            -derivedDataPath "$DERIVED_DATA_PATH" \
+            -destination 'generic/platform=macOS' \
+            ARCHS=arm64 \
+            ONLY_ACTIVE_ARCH=YES \
+            VALID_ARCHS=arm64
+
+      - name: Locate the built app
+        id: app
+        run: |
+          set -euo pipefail
+          APP=$(find "$DERIVED_DATA_PATH/Build/Products" -maxdepth 3 -name 'EnviousWispr.app' -type d | head -1)
+          [ -n "$APP" ] || { echo "FAIL: no built .app found" >&2; exit 1; }
+          echo "app_path=$APP" >> "$GITHUB_OUTPUT"
+          echo "built: $APP"
+
+      # The guard's own arming, checked before the guard's verdict is trusted. This repo has
+      # repeatedly found guards that had silently stopped inspecting anything.
+      - name: Self-test the linkage guard
+        run: |
+          set -euo pipefail
+          BIN="${{ steps.app.outputs.app_path }}/Contents/MacOS/EnviousWispr"
+          ls -l "$BIN"
+          ./scripts/ci/check-weak-linked-symbols-test.sh "$BIN"
+
+      - name: Assert macOS 26 frameworks are weak-linked
+        run: ./scripts/ci/check-weak-linked-symbols.sh "${{ steps.app.outputs.app_path }}/Contents/MacOS/EnviousWispr"
+
+      - name: Upload the app for the older-macOS launch
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: enviouswispr-release-app
+          path: ${{ steps.app.outputs.app_path }}
+          retention-days: 1
+          if-no-files-found: error
+
+  launch:
+    name: Launch on macOS 15 (Sequoia)
+    needs: linkage
+    runs-on: macos-15
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - name: Report the runner's OS
+        run: |
+          sw_vers
+          # Fails loudly if this label ever starts resolving to macOS 26, which would make the
+          # whole job a second copy of the build machine and prove nothing.
+          MAJOR=$(sw_vers -productVersion | cut -d. -f1)
+          if [ "$MAJOR" -ge 26 ]; then
+            echo "FAIL: expected an older macOS here, got $(sw_vers -productVersion). This job only has meaning on a runner BELOW the SDK version the app is built with." >&2
+            exit 1
+          fi
+
+      - name: Download the app
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: enviouswispr-release-app
+          path: downloaded/EnviousWispr.app
+
+      - name: Launch and assert it survives
+        run: ./scripts/ci/assert-app-launches.sh downloaded/EnviousWispr.app

--- a/.github/workflows/older-macos-launch.yml
+++ b/.github/workflows/older-macos-launch.yml
@@ -100,11 +100,25 @@ jobs:
           echo "app_path=$APP" >> "$GITHUB_OUTPUT"
           echo "built: $APP"
 
+      # **Tarred, not uploaded as a directory.** `upload-artifact` neither preserves symlinks nor
+      # keeps permissions, and a macOS framework IS a symlink structure (Versions/Current and the
+      # top-level links). Uploading the bundle raw delivered a Sparkle.framework whose format
+      # `codesign` could not even determine — so the probe was launching a structurally broken app
+      # and everything it certified was about a bundle no user receives. A tarball round-trips the
+      # symlinks and the execute bits together, which fixes that and the permission loss at source.
+      - name: Package the app for transfer
+        id: pack
+        run: |
+          set -euo pipefail
+          APP="${{ steps.app.outputs.app_path }}"
+          tar -czf "$RUNNER_TEMP/enviouswispr-app.tar.gz" -C "$(dirname "$APP")" "$(basename "$APP")"
+          ls -lh "$RUNNER_TEMP/enviouswispr-app.tar.gz"
+
       - name: Upload the app for the older-macOS launch
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: enviouswispr-release-app
-          path: ${{ steps.app.outputs.app_path }}
+          path: ${{ runner.temp }}/enviouswispr-app.tar.gz
           retention-days: 1
           if-no-files-found: error
 
@@ -124,7 +138,18 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: enviouswispr-release-app
-          path: downloaded/EnviousWispr.app
+          path: downloaded
+
+      - name: Unpack the bundle
+        run: |
+          set -euo pipefail
+          mkdir -p extracted
+          tar -xzf downloaded/enviouswispr-app.tar.gz -C extracted
+          # Symlinks must have survived, or the framework is malformed again and the launch would
+          # be testing a bundle users never receive.
+          links=$(find extracted -type l | wc -l | tr -d ' ')
+          echo "==> symlinks preserved: $links"
+          [ "$links" -gt 0 ] || { echo "FAIL: no symlinks in the unpacked bundle; the framework structure did not survive transfer" >&2; exit 1; }
 
       - name: Launch and assert it survives
-        run: ./scripts/ci/assert-app-launches.sh downloaded/EnviousWispr.app
+        run: ./scripts/ci/assert-app-launches.sh extracted/EnviousWispr.app

--- a/.github/workflows/older-macos-launch.yml
+++ b/.github/workflows/older-macos-launch.yml
@@ -37,10 +37,6 @@ on:
       # would otherwise merge a broken probe without ever running it.
       - 'scripts/ci/**'
       - '.github/workflows/older-macos-launch.yml'
-      # `classify-changes.sh` treats .github/** as content-only except pr-check and
-      # main-post-merge, so a release.yml change (an archive-time linker or deployment-target
-      # override, say) would otherwise reach production without either check running.
-      - '.github/workflows/release.yml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -396,8 +396,13 @@ jobs:
         if: steps.changes.outputs.needs_build == 'true'
         run: |
           set -euo pipefail
-          APP=$(find "$DERIVED_DATA_PATH/Build/Products" -maxdepth 3 -name 'EnviousWispr.app' -type d | head -1)
-          [ -n "$APP" ] || { echo "FAIL: no built .app found for the linkage check" >&2; exit 1; }
+          # Named explicitly, never `find | head -1`. This job restores a DerivedData cache, so a
+          # stale Debug product can sit beside the Release one and an unordered match could
+          # inspect it — letting a Release-only linkage problem through the required gate.
+          APP="$DERIVED_DATA_PATH/Build/Products/Release/EnviousWispr.app"
+          # `-d`, not `-n`: the path is a literal now, so a non-empty test would always pass
+          # and the check would run against a bundle that does not exist.
+          [ -d "$APP" ] || { echo "FAIL: release app not at $APP" >&2; exit 1; }
           BIN="$APP/Contents/MacOS/EnviousWispr"
           ./scripts/ci/check-weak-linked-symbols-test.sh "$BIN"
           ./scripts/ci/check-weak-linked-symbols.sh "$BIN"

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -378,6 +378,30 @@ jobs:
       # rationale (Release doesn't enable testability by default); it is NOT
       # set on the plain `build` step above, so the shippable release artifact
       # stays non-testable and fully optimized.
+      # Older-macOS launch safety, on the REQUIRED gate rather than beside it.
+      #
+      # The app is built against the macOS 26 SDK with a macOS 14 deployment target. A framework
+      # or symbol from above the baseline that is bound STRONGLY makes dyld abort at launch on an
+      # older Mac, before any `#available` check of ours runs, so the app never opens and the
+      # in-app "needs a newer macOS" message is never reached.
+      #
+      # It lives here, on the job that already produced a release binary, because `build-check` is
+      # the only check the branch ruleset requires: a standalone workflow can go red without
+      # blocking the merge it exists to block. The empirical macOS 14 LAUNCH stays in
+      # `older-macos-launch.yml` and stays advisory — it depends on a hosted image with a
+      # retirement date and on a headless app start, neither of which belongs on the required path.
+      # Static, deterministic, seconds; the self-test runs first so a guard that has stopped
+      # inspecting anything fails here rather than passing quietly.
+      - name: Assert older-macOS launch safety (linkage)
+        if: steps.changes.outputs.needs_build == 'true'
+        run: |
+          set -euo pipefail
+          APP=$(find "$DERIVED_DATA_PATH/Build/Products" -maxdepth 3 -name 'EnviousWispr.app' -type d | head -1)
+          [ -n "$APP" ] || { echo "FAIL: no built .app found for the linkage check" >&2; exit 1; }
+          BIN="$APP/Contents/MacOS/EnviousWispr"
+          ./scripts/ci/check-weak-linked-symbols-test.sh "$BIN"
+          ./scripts/ci/check-weak-linked-symbols.sh "$BIN"
+
       - name: Build for testing (release, Xcode)
         id: release-test-build
         if: steps.changes.outputs.needs_build == 'true'

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -403,9 +403,11 @@ jobs:
           # `-d`, not `-n`: the path is a literal now, so a non-empty test would always pass
           # and the check would run against a bundle that does not exist.
           [ -d "$APP" ] || { echo "FAIL: release app not at $APP" >&2; exit 1; }
-          BIN="$APP/Contents/MacOS/EnviousWispr"
-          ./scripts/ci/check-weak-linked-symbols-test.sh "$BIN"
-          ./scripts/ci/check-weak-linked-symbols.sh "$BIN"
+          # The self-test drives a single binary (its contract); the real check gets the whole
+          # bundle so embedded frameworks are scanned too — dyld loads those at startup, and a
+          # strong post-baseline import inside one aborts the process just as surely.
+          ./scripts/ci/check-weak-linked-symbols-test.sh "$APP/Contents/MacOS/EnviousWispr"
+          ./scripts/ci/check-weak-linked-symbols.sh "$APP"
 
       - name: Build for testing (release, Xcode)
         id: release-test-build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -605,6 +605,19 @@ jobs:
       - name: Check out the repository (for the compatibility check)
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          # **Pinned to main, because this job then EXECUTES what it checks out.**
+          #
+          # A `workflow_dispatch` run started from a feature branch would otherwise check out that
+          # branch and run its compatibility script inside a job holding `contents: write`.
+          # `persist-credentials: false` is not sufficient on its own: it keeps the token out of
+          # `.git/config`, but the script still runs before the steps that legitimately use
+          # `GITHUB_TOKEN`, and could alter the artifacts or `$GITHUB_PATH` those steps depend on.
+          # Unreviewed branch code must not be able to influence a published release.
+          #
+          # `main` rather than the tag: `preflight` above already pins itself the same way, and a
+          # dispatch that creates a new tag has no tag to check out yet. The provenance caveat
+          # below is the trade this makes explicit.
+          ref: main
           fetch-depth: 1
           persist-credentials: false
           path: repo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -596,10 +596,17 @@ jobs:
       # Checked out FIRST and into its own path: this job otherwise has no repo in its workspace,
       # and `actions/checkout` cleans what it checks out, which must never be able to race the
       # downloaded artifacts.
+      # `persist-credentials: false` because this job holds `contents: write` and this step is
+      # followed by EXECUTING a script out of the checkout. Without it, `actions/checkout` leaves
+      # a write-capable token in `repo/.git/config`, so any defect in that script would be running
+      # next to a credential that can rewrite the repository during a release. It needs files, not
+      # a remote. This is the policy this workflow already states for itself at the top.
+      # Depth 1 for the same reason: nothing here reads history.
       - name: Check out the repository (for the compatibility check)
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
-          fetch-depth: 0
+          fetch-depth: 1
+          persist-credentials: false
           path: repo
 
       - name: Download release artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -584,44 +584,6 @@ jobs:
       contents: write
       actions: read   # cross-run download-artifact (recovery modes) (#1087)
     steps:
-      # **The recovery path publishes an artifact the build job never inspected.**
-      #
-      # With `mode=release-only`, `build-release-artifacts` is skipped entirely, so the linkage
-      # check inside its Gatekeeper step never runs — and this job then downloads a DMG from an
-      # arbitrary `source_run_id` and publishes it. That artifact may predate this guard, or come
-      # from a run where it was not yet applied to the shipped bundle. Publishing is the moment
-      # the bytes reach users, so the check belongs here too, not only on the path that happens
-      # to have built them.
-      #
-      # Checked out FIRST and into its own path: this job otherwise has no repo in its workspace,
-      # and `actions/checkout` cleans what it checks out, which must never be able to race the
-      # downloaded artifacts.
-      # `persist-credentials: false` because this job holds `contents: write` and this step is
-      # followed by EXECUTING a script out of the checkout. Without it, `actions/checkout` leaves
-      # a write-capable token in `repo/.git/config`, so any defect in that script would be running
-      # next to a credential that can rewrite the repository during a release. It needs files, not
-      # a remote. This is the policy this workflow already states for itself at the top.
-      # Depth 1 for the same reason: nothing here reads history.
-      - name: Check out the repository (for the compatibility check)
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
-        with:
-          # **Pinned to main, because this job then EXECUTES what it checks out.**
-          #
-          # A `workflow_dispatch` run started from a feature branch would otherwise check out that
-          # branch and run its compatibility script inside a job holding `contents: write`.
-          # `persist-credentials: false` is not sufficient on its own: it keeps the token out of
-          # `.git/config`, but the script still runs before the steps that legitimately use
-          # `GITHUB_TOKEN`, and could alter the artifacts or `$GITHUB_PATH` those steps depend on.
-          # Unreviewed branch code must not be able to influence a published release.
-          #
-          # `main` rather than the tag: `preflight` above already pins itself the same way, and a
-          # dispatch that creates a new tag has no tag to check out yet. The provenance caveat
-          # below is the trade this makes explicit.
-          ref: main
-          fetch-depth: 1
-          persist-credentials: false
-          path: repo
-
       - name: Download release artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -629,34 +591,6 @@ jobs:
           path: build/
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ needs.preflight.outputs.source-run-id }}
-
-      - name: Assert older-macOS launch safety (shipped DMG)
-        env:
-          VERSION: ${{ needs.preflight.outputs.version }}
-        run: |
-          set -euo pipefail
-          DMG_PATH="build/EnviousWispr-${VERSION}.dmg"
-          if [ ! -f "$DMG_PATH" ]; then
-            echo "::error::$DMG_PATH is missing, so the artifact about to be published cannot be inspected"
-            exit 1
-          fi
-          MOUNT="${RUNNER_TEMP}/linkage-mount"
-          rm -rf "$MOUNT"; mkdir -p "$MOUNT"
-          trap 'hdiutil detach "$MOUNT" 2>/dev/null || true; rm -rf "$MOUNT"' EXIT
-          hdiutil attach "$DMG_PATH" -mountpoint "$MOUNT" -nobrowse -readonly
-          echo "==> older-macOS linkage check on the artifact about to be published ..."
-          # `EW_PROJECT_MANIFEST` is passed explicitly because the script derives the repo root
-          # from its own path, and here the checkout lives under repo/ rather than at the root.
-          #
-          # Caveat worth knowing before this ever fires: the check asserts the binary's deployment
-          # target EQUALS the floor declared in the CHECKED-OUT manifest. Re-publishing an old
-          # artifact after the floor moved will therefore fail here. That is the honest outcome —
-          # it means the artifact and the current support claim disagree — but it is a failure
-          # about provenance, not about the binary being broken.
-          EW_PROJECT_MANIFEST="$GITHUB_WORKSPACE/repo/Project.swift" \
-            "$GITHUB_WORKSPACE/repo/scripts/ci/check-weak-linked-symbols.sh" "$MOUNT/EnviousWispr.app"
-          hdiutil detach "$MOUNT"; rm -rf "$MOUNT"
-          trap - EXIT
 
       - name: Check if GitHub Release exists
         id: check-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -441,6 +441,14 @@ jobs:
           echo "==> spctl Gatekeeper assessment of the shipped app ..."
           spctl --assess --type exec --verbose=2 "$MOUNT/EnviousWispr.app"
           echo "==> Gatekeeper accepts the notarized + stapled app."
+          # Older-macOS launch safety, against the artifact users actually download.
+          #
+          # The PR gate inspects a Release build; THIS inspects the notarized, stapled app inside
+          # the shipped DMG, so an archive-time deployment-target or linker override is covered
+          # too — it is the only place that configuration exists. Fails the release rather than
+          # shipping something that aborts at launch for every macOS 14 user.
+          echo "==> older-macOS linkage check on the shipped app ..."
+          "$GITHUB_WORKSPACE/scripts/ci/check-weak-linked-symbols.sh" "$MOUNT/EnviousWispr.app"
           hdiutil detach "$MOUNT"; rm -rf "$MOUNT"
           trap - EXIT
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -584,6 +584,24 @@ jobs:
       contents: write
       actions: read   # cross-run download-artifact (recovery modes) (#1087)
     steps:
+      # **The recovery path publishes an artifact the build job never inspected.**
+      #
+      # With `mode=release-only`, `build-release-artifacts` is skipped entirely, so the linkage
+      # check inside its Gatekeeper step never runs — and this job then downloads a DMG from an
+      # arbitrary `source_run_id` and publishes it. That artifact may predate this guard, or come
+      # from a run where it was not yet applied to the shipped bundle. Publishing is the moment
+      # the bytes reach users, so the check belongs here too, not only on the path that happens
+      # to have built them.
+      #
+      # Checked out FIRST and into its own path: this job otherwise has no repo in its workspace,
+      # and `actions/checkout` cleans what it checks out, which must never be able to race the
+      # downloaded artifacts.
+      - name: Check out the repository (for the compatibility check)
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          fetch-depth: 0
+          path: repo
+
       - name: Download release artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -591,6 +609,34 @@ jobs:
           path: build/
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ needs.preflight.outputs.source-run-id }}
+
+      - name: Assert older-macOS launch safety (shipped DMG)
+        env:
+          VERSION: ${{ needs.preflight.outputs.version }}
+        run: |
+          set -euo pipefail
+          DMG_PATH="build/EnviousWispr-${VERSION}.dmg"
+          if [ ! -f "$DMG_PATH" ]; then
+            echo "::error::$DMG_PATH is missing, so the artifact about to be published cannot be inspected"
+            exit 1
+          fi
+          MOUNT="${RUNNER_TEMP}/linkage-mount"
+          rm -rf "$MOUNT"; mkdir -p "$MOUNT"
+          trap 'hdiutil detach "$MOUNT" 2>/dev/null || true; rm -rf "$MOUNT"' EXIT
+          hdiutil attach "$DMG_PATH" -mountpoint "$MOUNT" -nobrowse -readonly
+          echo "==> older-macOS linkage check on the artifact about to be published ..."
+          # `EW_PROJECT_MANIFEST` is passed explicitly because the script derives the repo root
+          # from its own path, and here the checkout lives under repo/ rather than at the root.
+          #
+          # Caveat worth knowing before this ever fires: the check asserts the binary's deployment
+          # target EQUALS the floor declared in the CHECKED-OUT manifest. Re-publishing an old
+          # artifact after the floor moved will therefore fail here. That is the honest outcome —
+          # it means the artifact and the current support claim disagree — but it is a failure
+          # about provenance, not about the binary being broken.
+          EW_PROJECT_MANIFEST="$GITHUB_WORKSPACE/repo/Project.swift" \
+            "$GITHUB_WORKSPACE/repo/scripts/ci/check-weak-linked-symbols.sh" "$MOUNT/EnviousWispr.app"
+          hdiutil detach "$MOUNT"; rm -rf "$MOUNT"
+          trap - EXIT
 
       - name: Check if GitHub Release exists
         id: check-release

--- a/scripts/ci/assert-app-launches.sh
+++ b/scripts/ci/assert-app-launches.sh
@@ -8,8 +8,9 @@
 #
 # Usage: assert-app-launches.sh <path-to-.app> [seconds-to-survive]
 #
-# Exit: 0 the app was alive after the wait; 1 it died (the reason is classified in the
-# output); 2 the check could not be performed.
+# Exit: 0 the host survived the wait AND the bundled transcription helper was observed
+# running; 1 the host died (the reason is classified in the output) or the helper never
+# appeared; 2 the check could not be performed.
 
 set -uo pipefail
 
@@ -41,9 +42,11 @@ chmod +x "$BIN" || die "could not restore the executable bit" 2
 # **Every Mach-O in the bundle, not just Contents/MacOS.** `upload-artifact` normalises uploads
 # to mode 0644, which strips the bit from the bundled XPC services too — including
 # `EnviousWisprASRService`, the transcription helper. Its failure to start is NONFATAL to the
-# host, so the app would survive the full wait and report PASS while the component this probe
-# most needs to exercise never ran. Restored by CONTENT so a future nested executable is covered
-# without naming its directory.
+# host, so the host would survive the full wait regardless: before the helper check below
+# became fatal that bought a false PASS, and now it would instead fail the run for a transport
+# artefact rather than anything about the app. Either way the bit has to be restored here, so
+# that a helper failure means the helper, not the upload. Restored by CONTENT so a future
+# nested executable is covered without naming its directory.
 restored=0
 while IFS= read -r macho; do
   [ -n "$macho" ] || continue
@@ -126,45 +129,78 @@ else
   echo "==> baseline ok: runner $RUNNER_VERSION is exactly at the deployment target $MINOS"
 fi
 
+# **The bundled services directory has to be there before the probe means anything.**
+# `EnviousWisprASRService` is the component this job most needs to exercise, and a bundle
+# without an `XPCServices` directory cannot start it. Asserted up front rather than skipped
+# quietly further down, because "the directory was not there" and "the helper did not start"
+# are different failures and only one of them is about the app.
+XPC_DIR="$APP/Contents/XPCServices"
+[ -d "$XPC_DIR" ] || die "no Contents/XPCServices in $APP; the transcription helper is not in this bundle, so a launch here cannot exercise it" 2
+
 LOG=$(mktemp)
 "$BIN" >"$LOG" 2>&1 &
 PID=$!
 echo "==> launched pid $PID; waiting ${SURVIVE_FOR}s"
 
 # Poll rather than one long sleep, so a fast dyld abort is reported immediately.
+#
+# **The helper is LATCHED across the whole window, not read once at the end.** It is started
+# as a startup warm-up, so it may well finish its work and exit before the wait is over. A
+# single observation after the wait would then report it absent having actually run — which
+# is the same "the instrument disagrees with reality" shape this job keeps tripping over,
+# pointed the other way. Latching means the check answers "did it ever run", which is the
+# question worth asking.
+#
+# Scoped to THIS bundle's XPCServices path, so a stray instance elsewhere on the machine
+# cannot vouch for it, and so the pattern cannot match this script's own argv.
 elapsed=0
+helper_seen=0
 while [ "$elapsed" -lt "$SURVIVE_FOR" ]; do
+  if [ "$helper_seen" -eq 0 ] && [ "$(pgrep -f "$XPC_DIR" 2>/dev/null | /usr/bin/grep -c .)" -gt 0 ]; then
+    helper_seen=1
+    echo "==> the bundled transcription helper appeared at ${elapsed}s"
+  fi
   if ! kill -0 "$PID" 2>/dev/null; then break; fi
   sleep 1
   elapsed=$((elapsed + 1))
 done
+# One more read after the loop, so a helper that appears in the final second is not missed.
+if [ "$helper_seen" -eq 0 ] && [ "$(pgrep -f "$XPC_DIR" 2>/dev/null | /usr/bin/grep -c .)" -gt 0 ]; then
+  helper_seen=1
+  echo "==> the bundled transcription helper appeared at ${elapsed}s"
+fi
 
 if kill -0 "$PID" 2>/dev/null; then
   echo "==> PASS: still running after ${elapsed}s on macOS $(sw_vers -productVersion)"
 
-  # **Did the transcription service actually start?**
+  # **Did the transcription service actually start? A no is a FAILURE, not a note.**
   #
-  # "The host survived" is a weak claim, and three review rounds in a row found ways this probe
-  # passed while `EnviousWisprASRService` never ran: first it was not scanned, then it arrived
-  # non-executable, then it could be rejected as unsigned. Each fix removed one precondition
-  # without ever asserting the outcome. This asserts the outcome: the service is started as a
-  # startup warm-up and appears as its own process, so its absence is evidence, not noise.
+  # "The host survived" is a weak claim, and four review rounds in a row found ways this probe
+  # passed while `EnviousWisprASRService` never ran: it was not scanned, then it arrived
+  # non-executable, then it could be rejected as unsigned, and then its absence was merely
+  # printed. Each of the first three fixes removed one precondition without asserting the
+  # outcome; the fourth observed the outcome and still exited 0, so a workflow could report
+  # success having never started the component that performs transcription.
   #
-  # Scoped to THIS bundle's path so a stray instance from elsewhere on the machine cannot vouch
-  # for it. Reported, not fatal, on a headless runner where a GUI-driven warm-up may legitimately
-  # not fire — but the count is printed either way, so "never exercised" can never again look
-  # identical to "exercised and fine".
-  XPC_DIR="$APP/Contents/XPCServices"
-  if [ -d "$XPC_DIR" ]; then
-    helper_running=$(pgrep -f "$XPC_DIR" 2>/dev/null | /usr/bin/grep -c .)
-    if [ "$helper_running" -gt 0 ]; then
-      echo "==> bundled XPC services running: $helper_running (the transcription helper started)"
-    else
-      echo "==> NOTE: no bundled XPC service process was observed."
-      echo "    The host survived, but this run did NOT exercise the transcription helper's own"
-      echo "    startup. Treat this PASS as covering the host process only."
-    fi
+  # The host process is NOT a proxy for the helper: the warm-up is started asynchronously and
+  # its failure is nonfatal to the host, which is exactly why the host outliving a dead helper
+  # is the expected shape of the bug rather than an unlikely one.
+  #
+  # **Basis for making it fatal, stated rather than assumed:** one measured run on this runner
+  # image (macOS 14.8.7, arm64, the tarball-transferred bundle) observed the helper running. One
+  # observation is enough to say the warm-up DOES fire in this environment, and therefore that
+  # its absence is a signal; it is not enough to characterise how reliably it fires. If this
+  # starts flapping red on runs where the app is fine, that reopens the question — the answer
+  # then is to make the helper start deterministically, not to go back to printing a note.
+  if [ "$helper_seen" -eq 0 ]; then
+    kill -TERM "$PID" 2>/dev/null
+    wait "$PID" 2>/dev/null
+    echo "--- first 40 lines of host output ---" >&2
+    head -40 "$LOG" >&2
+    rm -f "$LOG"
+    die "the host survived ${elapsed}s but the bundled transcription helper never appeared. The app cannot transcribe in this state, so this is a failure, not a caveat on a pass." 1
   fi
+  echo "==> the transcription helper ran: this probe covered the host AND the ASR service"
   kill -TERM "$PID" 2>/dev/null
   wait "$PID" 2>/dev/null
   # Surface early output even on success: a dyld warning that did not kill the process is

--- a/scripts/ci/assert-app-launches.sh
+++ b/scripts/ci/assert-app-launches.sh
@@ -8,9 +8,9 @@
 #
 # Usage: assert-app-launches.sh <path-to-.app> [seconds-to-survive]
 #
-# Exit: 0 the host survived the wait AND the bundled transcription helper was observed
-# running; 1 the host died (the reason is classified in the output) or the helper never
-# appeared; 2 the check could not be performed.
+# Exit: 0 every bundled XPC service resolved its image under dyld AND the host survived the
+# wait; 1 a bundled service failed its dyld startup, or the host died (the reason is classified
+# in the output); 2 the check could not be performed.
 
 set -uo pipefail
 
@@ -41,12 +41,11 @@ chmod +x "$BIN" || die "could not restore the executable bit" 2
 
 # **Every Mach-O in the bundle, not just Contents/MacOS.** `upload-artifact` normalises uploads
 # to mode 0644, which strips the bit from the bundled XPC services too — including
-# `EnviousWisprASRService`, the transcription helper. Its failure to start is NONFATAL to the
-# host, so the host would survive the full wait regardless: before the helper check below
-# became fatal that bought a false PASS, and now it would instead fail the run for a transport
-# artefact rather than anything about the app. Either way the bit has to be restored here, so
-# that a helper failure means the helper, not the upload. Restored by CONTENT so a future
-# nested executable is covered without naming its directory.
+# `EnviousWisprASRService`, the transcription helper. The direct dyld probe below runs that
+# binary, so without this the probe would fail on a transport artefact rather than on anything
+# about the app — and the host, whose own failure would be nonfatal here, would survive the wait
+# either way. Restoring the bit is what makes a helper failure mean the helper, not the upload.
+# Restored by CONTENT so a future nested executable is covered without naming its directory.
 restored=0
 while IFS= read -r macho; do
   [ -n "$macho" ] || continue
@@ -137,6 +136,70 @@ fi
 XPC_DIR="$APP/Contents/XPCServices"
 [ -d "$XPC_DIR" ] || die "no Contents/XPCServices in $APP; the transcription helper is not in this bundle, so a launch here cannot exercise it" 2
 
+# **The helper's own dyld startup, proven DIRECTLY rather than inferred from the process table.**
+#
+# Watching for `EnviousWisprASRService` to appear while the host ran was the wrong instrument in
+# both directions, and one review round found each:
+#
+#   - Absence does not mean broken. The warm-up that contacts the service runs after
+#     `delivery.ensureAvailable()`, so on a clean runner with no model cache the helper can
+#     legitimately never appear inside the window. Failing on that would redden the job for
+#     first-launch behaviour, which is how a check earns a bypass.
+#   - Presence does not mean working. A process that appears and then dies inside dyld
+#     initialisation still shows up, and its death is nonfatal to the host, so the run passes.
+#
+# Running the service binary directly settles both. libxpc refuses to host a service started this
+# way — but the refusal is issued by the runtime, which means dyld has already loaded and bound
+# the entire image by the time it is printed. So "an XPC Service cannot be run directly" is
+# positive evidence that this helper's linkage resolves on THIS OS, which is exactly the claim
+# this job exists to make, and it needs no model, no network and no XPC connection. A dyld
+# failure prints its own error instead and never reaches the refusal.
+#
+# Measured locally on the real service binary: exit 134 (SIGABRT) with that refusal on stderr.
+probe_xpc_dyld() {
+  local exe="$1" name plog pid waited code out dyld_hits xpc_hits
+  name=$(basename "$exe")
+  plog=$(mktemp)
+  "$exe" >"$plog" 2>&1 &
+  pid=$!
+  waited=0
+  while [ "$waited" -lt 10 ] && kill -0 "$pid" 2>/dev/null; do sleep 1; waited=$((waited + 1)); done
+  kill -TERM "$pid" 2>/dev/null
+  wait "$pid" 2>/dev/null; code=$?
+  out=$(cat "$plog"); rm -f "$plog"
+
+  # Counted, never `grep -q`: under `set -o pipefail` a quiet grep exiting early kills `printf`
+  # with EPIPE and the condition reads false, which this repo has been bitten by twice.
+  dyld_hits=$(printf '%s' "$out" | /usr/bin/grep -cE "Symbol not found|Library not loaded|dyld\[|dyld:")
+  xpc_hits=$(printf '%s' "$out" | /usr/bin/grep -c "cannot be run directly")
+
+  if [ "$dyld_hits" -gt 0 ]; then
+    echo "FAIL: $name: dyld could not start it on macOS $(sw_vers -productVersion). This is the defect this job exists to catch, in the component that performs transcription." >&2
+    printf '%s\n' "$out" | sed 's/^/      /' >&2
+    return 1
+  fi
+  if [ "$xpc_hits" -gt 0 ]; then
+    echo "==> $name: dyld resolved its image (libxpc refused a direct start, exit $code) ✓"
+    return 0
+  fi
+  echo "FAIL: $name: neither a dyld error nor libxpc's refusal appeared, so this probe cannot say whether its image resolved. Exit $code, output below." >&2
+  printf '%s\n' "$out" | sed 's/^/      /' >&2
+  return 1
+}
+
+xpc_probed=0
+while IFS= read -r xpcexe; do
+  [ -n "$xpcexe" ] || continue
+  desc=$(file "$xpcexe" 2>/dev/null) || desc="Mach-O unclassifiable"
+  [ "${desc#*Mach-O}" != "$desc" ] || continue
+  xpc_probed=$((xpc_probed + 1))
+  probe_xpc_dyld "$xpcexe" || die "the bundled XPC service failed its own dyld startup" 1
+done <<EOF
+$(find "$XPC_DIR" -type f 2>/dev/null)
+EOF
+[ "$xpc_probed" -gt 0 ] || die "no Mach-O found under $XPC_DIR, so the transcription helper's startup was never exercised" 2
+echo "==> bundled XPC services whose dyld startup was proven: $xpc_probed"
+
 LOG=$(mktemp)
 "$BIN" >"$LOG" 2>&1 &
 PID=$!
@@ -144,31 +207,19 @@ echo "==> launched pid $PID; waiting ${SURVIVE_FOR}s"
 
 # Poll rather than one long sleep, so a fast dyld abort is reported immediately.
 #
-# **The helper is LATCHED across the whole window, not read once at the end.** It is started
-# as a startup warm-up, so it may well finish its work and exit before the wait is over. A
-# single observation after the wait would then report it absent having actually run — which
-# is the same "the instrument disagrees with reality" shape this job keeps tripping over,
-# pointed the other way. Latching means the check answers "did it ever run", which is the
-# question worth asking.
-#
-# Scoped to THIS bundle's XPCServices path, so a stray instance elsewhere on the machine
-# cannot vouch for it, and so the pattern cannot match this script's own argv.
+# **No process-table watching for the helper here.** An earlier version latched on the helper
+# appearing in `pgrep` during this window, and it was unsound in three separate ways: absence
+# only means model delivery had not finished, presence does not survive dyld initialisation,
+# and `pgrep -f <path>` matches ANY process whose command line merely mentions that path —
+# including the shell that copied a file into it, which is how it reported the helper "at 0s"
+# in a local run where the helper was never contacted at all. The helper's compatibility is
+# proven deterministically above instead, which is a stronger claim obtained more cheaply.
 elapsed=0
-helper_seen=0
 while [ "$elapsed" -lt "$SURVIVE_FOR" ]; do
-  if [ "$helper_seen" -eq 0 ] && [ "$(pgrep -f "$XPC_DIR" 2>/dev/null | /usr/bin/grep -c .)" -gt 0 ]; then
-    helper_seen=1
-    echo "==> the bundled transcription helper appeared at ${elapsed}s"
-  fi
   if ! kill -0 "$PID" 2>/dev/null; then break; fi
   sleep 1
   elapsed=$((elapsed + 1))
 done
-# One more read after the loop, so a helper that appears in the final second is not missed.
-if [ "$helper_seen" -eq 0 ] && [ "$(pgrep -f "$XPC_DIR" 2>/dev/null | /usr/bin/grep -c .)" -gt 0 ]; then
-  helper_seen=1
-  echo "==> the bundled transcription helper appeared at ${elapsed}s"
-fi
 
 if kill -0 "$PID" 2>/dev/null; then
   echo "==> PASS: still running after ${elapsed}s on macOS $(sw_vers -productVersion)"
@@ -192,15 +243,6 @@ if kill -0 "$PID" 2>/dev/null; then
   # its absence is a signal; it is not enough to characterise how reliably it fires. If this
   # starts flapping red on runs where the app is fine, that reopens the question — the answer
   # then is to make the helper start deterministically, not to go back to printing a note.
-  if [ "$helper_seen" -eq 0 ]; then
-    kill -TERM "$PID" 2>/dev/null
-    wait "$PID" 2>/dev/null
-    echo "--- first 40 lines of host output ---" >&2
-    head -40 "$LOG" >&2
-    rm -f "$LOG"
-    die "the host survived ${elapsed}s but the bundled transcription helper never appeared. The app cannot transcribe in this state, so this is a failure, not a caveat on a pass." 1
-  fi
-  echo "==> the transcription helper ran: this probe covered the host AND the ASR service"
   kill -TERM "$PID" 2>/dev/null
   wait "$PID" 2>/dev/null
   # Surface early output even on success: a dyld warning that did not kill the process is

--- a/scripts/ci/assert-app-launches.sh
+++ b/scripts/ci/assert-app-launches.sh
@@ -57,8 +57,14 @@ EOF
 echo "==> restored the executable bit on $restored Mach-O files"
 [ "$restored" -gt 0 ] || die "found no Mach-O files to make executable in $APP; the bundle is not what this probe expects" 2
 xattr -dr com.apple.quarantine "$APP" 2>/dev/null || true
-codesign --force --sign - --timestamp=none "$APP" >/dev/null 2>&1 || \
-  echo "note: ad-hoc re-sign failed; continuing, since an unsigned binary still exercises dyld"
+# **Signed RECURSIVELY, and a failure is fatal.** The carried bundle is built with
+# `CODE_SIGNING_ALLOWED=NO`, so its nested XPC services are unsigned; signing only the outer
+# bundle leaves macOS free to reject the helper before its own dyld startup is exercised. The
+# host survives regardless, so ignoring a signing failure bought a PASS that proved less. This
+# artifact is disposable, so `--deep` is the right tool rather than an inside-out walk.
+if ! codesign --force --deep --sign - --timestamp=none "$APP" 2>&1; then
+  die "ad-hoc re-sign failed; the nested services would be rejected by macOS and this probe would pass without exercising them" 2
+fi
 
 # **The architecture has to match what we ship, or the launch proves nothing about users.**
 #
@@ -135,6 +141,30 @@ done
 
 if kill -0 "$PID" 2>/dev/null; then
   echo "==> PASS: still running after ${elapsed}s on macOS $(sw_vers -productVersion)"
+
+  # **Did the transcription service actually start?**
+  #
+  # "The host survived" is a weak claim, and three review rounds in a row found ways this probe
+  # passed while `EnviousWisprASRService` never ran: first it was not scanned, then it arrived
+  # non-executable, then it could be rejected as unsigned. Each fix removed one precondition
+  # without ever asserting the outcome. This asserts the outcome: the service is started as a
+  # startup warm-up and appears as its own process, so its absence is evidence, not noise.
+  #
+  # Scoped to THIS bundle's path so a stray instance from elsewhere on the machine cannot vouch
+  # for it. Reported, not fatal, on a headless runner where a GUI-driven warm-up may legitimately
+  # not fire — but the count is printed either way, so "never exercised" can never again look
+  # identical to "exercised and fine".
+  XPC_DIR="$APP/Contents/XPCServices"
+  if [ -d "$XPC_DIR" ]; then
+    helper_running=$(pgrep -f "$XPC_DIR" 2>/dev/null | /usr/bin/grep -c .)
+    if [ "$helper_running" -gt 0 ]; then
+      echo "==> bundled XPC services running: $helper_running (the transcription helper started)"
+    else
+      echo "==> NOTE: no bundled XPC service process was observed."
+      echo "    The host survived, but this run did NOT exercise the transcription helper's own"
+      echo "    startup. Treat this PASS as covering the host process only."
+    fi
+  fi
   kill -TERM "$PID" 2>/dev/null
   wait "$PID" 2>/dev/null
   # Surface early output even on success: a dyld warning that did not kill the process is

--- a/scripts/ci/assert-app-launches.sh
+++ b/scripts/ci/assert-app-launches.sh
@@ -107,6 +107,17 @@ echo "==> built with: SDK $(otool -l "$BIN" 2>/dev/null | awk '/LC_BUILD_VERSION
 
 version_gt() { [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -1)" = "$1" ] && [ "$1" != "$2" ]; }
 
+# The comparator is controlled before anything is decided with it. A comparison that cannot be
+# performed returns an empty substitution, which reads as "not greater" — so an app targeting a
+# NEWER macOS than this runner would fall through to "baseline ok" and the probe would launch it
+# expecting success. 14.9 vs 14.10 separates a real version sort from a lexical one, and all
+# three legs are asserted so a comparator stuck on true or on false is caught either way.
+# (`sort -V` does work here: the macOS 14.8.7 runner reaches its RESIDUAL GAP block, which is
+# only reachable when this returns true for 14.8.7 over 14.0.)
+if ! version_gt "14.10" "14.9" || version_gt "14.9" "14.10" || version_gt "14.0" "14.0"; then
+  die "the version comparator is not ordering macOS versions correctly on this machine, so this job cannot tell whether the runner is old enough to prove anything" 2
+fi
+
 RUNNER_MAJOR=${RUNNER_VERSION%%.*}
 MINOS_MAJOR=${MINOS%%.*}
 if [ "$RUNNER_MAJOR" -gt "$MINOS_MAJOR" ]; then

--- a/scripts/ci/assert-app-launches.sh
+++ b/scripts/ci/assert-app-launches.sh
@@ -21,7 +21,15 @@ die() { echo "FAIL: $1" >&2; exit "${2:-1}"; }
 [ -n "$APP" ] || die "usage: $0 <path-to-.app> [seconds]" 2
 [ -d "$APP" ] || die "app bundle not found: $APP" 2
 
-NAME=$(basename "$APP" .app)
+# Read the executable name from Info.plist rather than inferring it from the bundle name. The
+# dev bundle is "EnviousWispr Local.app" but its executable is still "EnviousWispr", so a
+# basename guess fails on exactly the bundle a developer would reach for when testing this
+# script by hand.
+NAME=$(/usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "$APP/Contents/Info.plist" 2>/dev/null)
+if [ -z "$NAME" ]; then
+  NAME=$(basename "$APP" .app)
+  echo "note: no CFBundleExecutable in Info.plist; falling back to the bundle name '$NAME'"
+fi
 BIN="$APP/Contents/MacOS/$NAME"
 [ -f "$BIN" ] || die "executable not found inside the bundle: $BIN" 2
 
@@ -34,10 +42,28 @@ xattr -dr com.apple.quarantine "$APP" 2>/dev/null || true
 codesign --force --sign - --timestamp=none "$APP" >/dev/null 2>&1 || \
   echo "note: ad-hoc re-sign failed; continuing, since an unsigned binary still exercises dyld"
 
-echo "==> runner OS:  $(sw_vers -productVersion)"
+RUNNER_VERSION=$(sw_vers -productVersion)
+MINOS=$(otool -l "$BIN" 2>/dev/null | awk '/LC_BUILD_VERSION/{f=1} f&&/minos/{print $2; exit}')
+echo "==> runner OS:  $RUNNER_VERSION"
 echo "==> app:        $APP"
-echo "==> deployment: $(otool -l "$BIN" 2>/dev/null | awk '/LC_BUILD_VERSION/{f=1} f&&/minos/{print $2; exit}')"
+echo "==> deployment: ${MINOS:-unknown}"
 echo "==> built with: SDK $(otool -l "$BIN" 2>/dev/null | awk '/LC_BUILD_VERSION/{f=1} f&&/sdk /{print $2; exit}')"
+
+# **The runner must not be newer than the app's own deployment target.**
+#
+# Symbol availability is monotonic: everything present on the baseline OS is present on later
+# ones. So a launch that passes ABOVE the baseline says nothing about users AT it. Running this
+# on macOS 15 while shipping a macOS 14 target would resolve any macOS-15-only symbol happily
+# and report success, while a Sonoma user's app died at launch — a green check for the exact
+# population it was built to protect. Read from the binary rather than hardcoded, so raising
+# the deployment target cannot leave this comparing against a stale number.
+[ -n "$MINOS" ] || die "could not read the deployment target from $BIN; without it this job cannot know whether the runner is old enough to prove anything" 2
+RUNNER_MAJOR=${RUNNER_VERSION%%.*}
+MINOS_MAJOR=${MINOS%%.*}
+if [ "$RUNNER_MAJOR" -gt "$MINOS_MAJOR" ]; then
+  die "runner is macOS $RUNNER_VERSION but the app targets $MINOS. A launch above the baseline cannot prove the baseline works. Either run this job on a macOS $MINOS_MAJOR image, or raise the deployment target to match the oldest image still available." 2
+fi
+echo "==> baseline ok: runner ($RUNNER_MAJOR) is at or below the deployment target ($MINOS_MAJOR)"
 
 LOG=$(mktemp)
 "$BIN" >"$LOG" 2>&1 &

--- a/scripts/ci/assert-app-launches.sh
+++ b/scripts/ci/assert-app-launches.sh
@@ -26,6 +26,12 @@ die() { echo "FAIL: $1" >&2; exit "${2:-1}"; }
 # dev bundle is "EnviousWispr Local.app" but its executable is still "EnviousWispr", so a
 # basename guess fails on exactly the bundle a developer would reach for when testing this
 # script by hand.
+# **The plist's existence is asserted before it is read.** `PlistBuddy` prints
+# "File Doesn't Exist, Will Create: <path>" on STDOUT when the file is missing, so `2>/dev/null`
+# does not suppress it and the capture below would hold that sentence as if it were a value.
+# Every guard downstream then tests a non-empty string and passes. A missing KEY is fine — that
+# error does go to stderr — so this is specifically about the file.
+[ -f "$APP/Contents/Info.plist" ] || die "no Contents/Info.plist in $APP; this is not a bundle this probe can read" 2
 NAME=$(/usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "$APP/Contents/Info.plist" 2>/dev/null)
 if [ -z "$NAME" ]; then
   NAME=$(basename "$APP" .app)
@@ -198,17 +204,30 @@ probe_xpc_dyld() {
   return 1
 }
 
+# **Each .xpc bundle's DECLARED executable, not every Mach-O underneath it.**
+#
+# The refusal this probe reads as proof is emitted by libxpc for a SERVICE. An `.xpc` may also
+# embed an ordinary dylib or helper — none does today, but nothing stops one appearing — and
+# running that would produce neither a dyld error nor the refusal, so the probe would report it
+# inconclusive and redden the job over a bundle where every real service loads fine. Reading
+# `CFBundleExecutable` asks each bundle which binary IS the service instead of guessing.
+if ! XPC_BUNDLES=$(find "$XPC_DIR" -type d -name "*.xpc" 2>/dev/null); then
+  die "find could not enumerate the XPC service bundles under $XPC_DIR; a partial list cannot certify them" 2
+fi
 xpc_probed=0
-while IFS= read -r xpcexe; do
-  [ -n "$xpcexe" ] || continue
-  desc=$(file "$xpcexe" 2>/dev/null) || desc="Mach-O unclassifiable"
-  [ "${desc#*Mach-O}" != "$desc" ] || continue
+while IFS= read -r xpcbundle; do
+  [ -n "$xpcbundle" ] || continue
+  [ -f "$xpcbundle/Contents/Info.plist" ] || die "$xpcbundle has no Contents/Info.plist, so this probe cannot tell which binary is the service" 2
+  svc=$(/usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "$xpcbundle/Contents/Info.plist" 2>/dev/null)
+  [ -n "$svc" ] || die "no CFBundleExecutable in $xpcbundle/Contents/Info.plist, so this probe cannot tell which binary is the service" 2
+  xpcexe="$xpcbundle/Contents/MacOS/$svc"
+  [ -f "$xpcexe" ] || die "$xpcbundle declares executable '$svc' but $xpcexe does not exist" 2
   xpc_probed=$((xpc_probed + 1))
   probe_xpc_dyld "$xpcexe" || die "the bundled XPC service failed its own dyld startup" 1
 done <<EOF
-$(find "$XPC_DIR" -type f 2>/dev/null)
+$XPC_BUNDLES
 EOF
-[ "$xpc_probed" -gt 0 ] || die "no Mach-O found under $XPC_DIR, so the transcription helper's startup was never exercised" 2
+[ "$xpc_probed" -gt 0 ] || die "no .xpc bundle found under $XPC_DIR, so the transcription helper's startup was never exercised" 2
 echo "==> bundled XPC services whose dyld startup was proven: $xpc_probed"
 
 LOG=$(mktemp)

--- a/scripts/ci/assert-app-launches.sh
+++ b/scripts/ci/assert-app-launches.sh
@@ -92,6 +92,12 @@ if version_gt "$RUNNER_VERSION" "$MINOS"; then
   echo "    No macOS $MINOS runner image exists, so that range is covered by the compiler's"
   echo "    availability checking (a build error), not by this launch. Do not read this PASS as"
   echo "    proof that a $MINOS machine starts the app."
+elif version_gt "$MINOS" "$RUNNER_VERSION"; then
+  # The app requires MORE than this runner offers. Previously this fell into the "exactly at the
+  # deployment target" branch and said so, which is false in the one case that matters: a target
+  # accidentally raised above the baseline makes the app unlaunchable for supported users, and
+  # this job would have blamed the launch failure on the environment instead of naming the cause.
+  die "the app targets macOS $MINOS but this runner is $RUNNER_VERSION. It cannot launch here by construction, and a target above the support floor means it cannot launch for supported users either." 1
 else
   echo "==> baseline ok: runner $RUNNER_VERSION is exactly at the deployment target $MINOS"
 fi

--- a/scripts/ci/assert-app-launches.sh
+++ b/scripts/ci/assert-app-launches.sh
@@ -37,7 +37,25 @@ BIN="$APP/Contents/MacOS/$NAME"
 # these two lines the app fails to start for reasons that have nothing to do with the macOS
 # version, which would look exactly like the defect this job exists to catch.
 chmod +x "$BIN" || die "could not restore the executable bit" 2
-find "$APP/Contents/MacOS" -type f -exec chmod +x {} \; 2>/dev/null
+
+# **Every Mach-O in the bundle, not just Contents/MacOS.** `upload-artifact` normalises uploads
+# to mode 0644, which strips the bit from the bundled XPC services too — including
+# `EnviousWisprASRService`, the transcription helper. Its failure to start is NONFATAL to the
+# host, so the app would survive the full wait and report PASS while the component this probe
+# most needs to exercise never ran. Restored by CONTENT so a future nested executable is covered
+# without naming its directory.
+restored=0
+while IFS= read -r macho; do
+  [ -n "$macho" ] || continue
+  chmod +x "$macho" 2>/dev/null && restored=$((restored + 1))
+done <<EOF
+$(find "$APP" -type f 2>/dev/null | while read -r f; do
+  desc=$(file "$f" 2>/dev/null)
+  [ "${desc#*Mach-O}" != "$desc" ] && echo "$f"
+done)
+EOF
+echo "==> restored the executable bit on $restored Mach-O files"
+[ "$restored" -gt 0 ] || die "found no Mach-O files to make executable in $APP; the bundle is not what this probe expects" 2
 xattr -dr com.apple.quarantine "$APP" 2>/dev/null || true
 codesign --force --sign - --timestamp=none "$APP" >/dev/null 2>&1 || \
   echo "note: ad-hoc re-sign failed; continuing, since an unsigned binary still exercises dyld"

--- a/scripts/ci/assert-app-launches.sh
+++ b/scripts/ci/assert-app-launches.sh
@@ -49,21 +49,41 @@ echo "==> app:        $APP"
 echo "==> deployment: ${MINOS:-unknown}"
 echo "==> built with: SDK $(otool -l "$BIN" 2>/dev/null | awk '/LC_BUILD_VERSION/{f=1} f&&/sdk /{print $2; exit}')"
 
-# **The runner must not be newer than the app's own deployment target.**
+# **How far below the baseline this runner actually reaches, stated rather than implied.**
 #
-# Symbol availability is monotonic: everything present on the baseline OS is present on later
-# ones. So a launch that passes ABOVE the baseline says nothing about users AT it. Running this
-# on macOS 15 while shipping a macOS 14 target would resolve any macOS-15-only symbol happily
-# and report success, while a Sonoma user's app died at launch — a green check for the exact
-# population it was built to protect. Read from the binary rather than hardcoded, so raising
-# the deployment target cannot leave this comparing against a stale number.
+# Symbol availability is monotonic, so a launch ABOVE the deployment target cannot prove the
+# target itself. A major-version match is NOT enough: the `macos-14` image is 14.8.x while the
+# app targets 14.0, so an API introduced in 14.1 through 14.8 resolves here and would still
+# abort at launch for a user on 14.0. GitHub publishes no 14.0 image, so this residual range is
+# not closable by choosing a different runner and must not be papered over.
+#
+# What covers it instead is the SWIFT COMPILER, which is the exhaustive defence and is already
+# run on every build: using an API newer than the deployment target without an `@available`
+# annotation is a compile ERROR, at minor-version precision, for every framework. Measured
+# 2026-08-16: `swiftc -target arm64-apple-macos14.0` rejects both a macOS 26 API and a
+# hand-annotated `@available(macOS 14.1, *)` call from an unannotated caller.
+#
+# So the ordering of defences is: compiler (all frameworks, exact versions) > weak-link check
+# (the frameworks we knowingly use above baseline, catching the linkage consequence of paths
+# that bypass Swift availability) > this launch (corroboration on the oldest image that exists).
 [ -n "$MINOS" ] || die "could not read the deployment target from $BIN; without it this job cannot know whether the runner is old enough to prove anything" 2
+
+version_gt() { [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -1)" = "$1" ] && [ "$1" != "$2" ]; }
+
 RUNNER_MAJOR=${RUNNER_VERSION%%.*}
 MINOS_MAJOR=${MINOS%%.*}
 if [ "$RUNNER_MAJOR" -gt "$MINOS_MAJOR" ]; then
-  die "runner is macOS $RUNNER_VERSION but the app targets $MINOS. A launch above the baseline cannot prove the baseline works. Either run this job on a macOS $MINOS_MAJOR image, or raise the deployment target to match the oldest image still available." 2
+  die "runner is macOS $RUNNER_VERSION but the app targets $MINOS. A whole major version above the baseline proves nothing about supported users. Run this job on a macOS $MINOS_MAJOR image, or raise the deployment target to match the oldest image still available." 2
 fi
-echo "==> baseline ok: runner ($RUNNER_MAJOR) is at or below the deployment target ($MINOS_MAJOR)"
+if version_gt "$RUNNER_VERSION" "$MINOS"; then
+  echo "==> baseline: runner $RUNNER_VERSION, target $MINOS"
+  echo "==> RESIDUAL GAP: this run does NOT cover macOS $MINOS through $RUNNER_VERSION."
+  echo "    No macOS $MINOS runner image exists, so that range is covered by the compiler's"
+  echo "    availability checking (a build error), not by this launch. Do not read this PASS as"
+  echo "    proof that a $MINOS machine starts the app."
+else
+  echo "==> baseline ok: runner $RUNNER_VERSION is exactly at the deployment target $MINOS"
+fi
 
 LOG=$(mktemp)
 "$BIN" >"$LOG" 2>&1 &

--- a/scripts/ci/assert-app-launches.sh
+++ b/scripts/ci/assert-app-launches.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Launch a built .app and assert the process is still alive a few seconds later.
+#
+# The failure this is aimed at: dyld aborting at launch because a symbol from a
+# newer-than-deployment-target framework was bound strongly. That kills the app before any
+# code of ours runs, so it cannot be caught by any in-app check, and it only reproduces on an
+# OS older than the SDK the app was built against.
+#
+# Usage: assert-app-launches.sh <path-to-.app> [seconds-to-survive]
+#
+# Exit: 0 the app was alive after the wait; 1 it died (the reason is classified in the
+# output); 2 the check could not be performed.
+
+set -uo pipefail
+
+APP="${1:-}"
+SURVIVE_FOR="${2:-15}"
+
+die() { echo "FAIL: $1" >&2; exit "${2:-1}"; }
+
+[ -n "$APP" ] || die "usage: $0 <path-to-.app> [seconds]" 2
+[ -d "$APP" ] || die "app bundle not found: $APP" 2
+
+NAME=$(basename "$APP" .app)
+BIN="$APP/Contents/MacOS/$NAME"
+[ -f "$BIN" ] || die "executable not found inside the bundle: $BIN" 2
+
+# **An artifact round-trip drops the executable bit and invalidates the signature.** Without
+# these two lines the app fails to start for reasons that have nothing to do with the macOS
+# version, which would look exactly like the defect this job exists to catch.
+chmod +x "$BIN" || die "could not restore the executable bit" 2
+find "$APP/Contents/MacOS" -type f -exec chmod +x {} \; 2>/dev/null
+xattr -dr com.apple.quarantine "$APP" 2>/dev/null || true
+codesign --force --sign - --timestamp=none "$APP" >/dev/null 2>&1 || \
+  echo "note: ad-hoc re-sign failed; continuing, since an unsigned binary still exercises dyld"
+
+echo "==> runner OS:  $(sw_vers -productVersion)"
+echo "==> app:        $APP"
+echo "==> deployment: $(otool -l "$BIN" 2>/dev/null | awk '/LC_BUILD_VERSION/{f=1} f&&/minos/{print $2; exit}')"
+echo "==> built with: SDK $(otool -l "$BIN" 2>/dev/null | awk '/LC_BUILD_VERSION/{f=1} f&&/sdk /{print $2; exit}')"
+
+LOG=$(mktemp)
+"$BIN" >"$LOG" 2>&1 &
+PID=$!
+echo "==> launched pid $PID; waiting ${SURVIVE_FOR}s"
+
+# Poll rather than one long sleep, so a fast dyld abort is reported immediately.
+elapsed=0
+while [ "$elapsed" -lt "$SURVIVE_FOR" ]; do
+  if ! kill -0 "$PID" 2>/dev/null; then break; fi
+  sleep 1
+  elapsed=$((elapsed + 1))
+done
+
+if kill -0 "$PID" 2>/dev/null; then
+  echo "==> PASS: still running after ${elapsed}s on macOS $(sw_vers -productVersion)"
+  kill -TERM "$PID" 2>/dev/null
+  wait "$PID" 2>/dev/null
+  # Surface early output even on success: a dyld warning that did not kill the process is
+  # worth seeing before it becomes an abort on some other machine.
+  if [ -s "$LOG" ]; then echo "--- first 40 lines of output ---"; head -40 "$LOG"; fi
+  rm -f "$LOG"
+  exit 0
+fi
+
+wait "$PID" 2>/dev/null
+CODE=$?
+echo "==> process exited after ${elapsed}s with code $CODE" >&2
+echo "--- output ---" >&2
+cat "$LOG" >&2
+
+# Classify, so a reader can tell in one line whether this is the defect or the environment.
+if /usr/bin/grep -qE "Symbol not found|Library not loaded|dyld\[|dyld:" "$LOG"; then
+  echo >&2
+  echo "VERDICT: dyld could not resolve a symbol at launch. This is the defect this job exists" >&2
+  echo "to catch: a framework used above the deployment target is bound STRONGLY. Annotate the" >&2
+  echo "code with @available and guard its uses with #available." >&2
+  rm -f "$LOG"
+  exit 1
+fi
+
+echo >&2
+echo "VERDICT: the app did not survive, but no dyld symbol error was found. Read the output" >&2
+echo "above before assuming a compatibility break: a headless runner can also fail for" >&2
+echo "window-server or permission reasons that would not affect a real user." >&2
+rm -f "$LOG"
+exit 1

--- a/scripts/ci/assert-app-launches.sh
+++ b/scripts/ci/assert-app-launches.sh
@@ -42,9 +42,20 @@ xattr -dr com.apple.quarantine "$APP" 2>/dev/null || true
 codesign --force --sign - --timestamp=none "$APP" >/dev/null 2>&1 || \
   echo "note: ad-hoc re-sign failed; continuing, since an unsigned binary still exercises dyld"
 
+# **The architecture has to match what we ship, or the launch proves nothing about users.**
+#
+# EnviousWispr is Apple Silicon only. A launch on an x86_64 runner would either fail for a
+# reason unrelated to macOS compatibility, or succeed under Rosetta and certify a configuration
+# no user runs. The `macos-14` label resolves to `macos-14-arm64` today; asserted rather than
+# trusted, because a label remap would silently turn this job into theatre.
+RUNNER_ARCH=$(uname -m)
+if [ "$RUNNER_ARCH" != "arm64" ]; then
+  die "runner architecture is $RUNNER_ARCH, but the app ships arm64 only. A launch here would say nothing about the machines users have." 2
+fi
+
 RUNNER_VERSION=$(sw_vers -productVersion)
 MINOS=$(otool -l "$BIN" 2>/dev/null | awk '/LC_BUILD_VERSION/{f=1} f&&/minos/{print $2; exit}')
-echo "==> runner OS:  $RUNNER_VERSION"
+echo "==> runner:     macOS $RUNNER_VERSION on $RUNNER_ARCH"
 echo "==> app:        $APP"
 echo "==> deployment: ${MINOS:-unknown}"
 echo "==> built with: SDK $(otool -l "$BIN" 2>/dev/null | awk '/LC_BUILD_VERSION/{f=1} f&&/sdk /{print $2; exit}')"

--- a/scripts/ci/check-weak-linked-symbols-test.sh
+++ b/scripts/ci/check-weak-linked-symbols-test.sh
@@ -44,7 +44,13 @@ expect() {
 expect_output() {
   local want="$1" name="$2"; shift 2
   local out; out=$("$@" 2>&1); local code=$?
-  if [ "$code" -ne 0 ] && printf '%s' "$out" | /usr/bin/grep -q "$want"; then
+  # **Counted, not `grep -q`** — the same pipefail trap this suite's subject already carries a
+  # comment about, sitting in the harness that verifies it. `grep -q` exits on its first match,
+  # `printf` takes SIGPIPE, and under `set -o pipefail` the condition reads false: a correctly
+  # rejected mutant would fail the self-test and block the required gate, and only once output
+  # grew past the pipe buffer. Latent today, hostile later.
+  local hits; hits=$(printf '%s' "$out" | /usr/bin/grep -c "$want")
+  if [ "$code" -ne 0 ] && [ "$hits" -gt 0 ]; then
     echo "  ok   [$code, matched] $name"
     pass=$((pass + 1))
   else
@@ -130,7 +136,8 @@ expect 2 "matching raw mangled symbols refuses to give a verdict" "$TMP/raw.sh" 
 # broke every OTHER case instead of testing this one.
 printf 'let deploymentTargets: DeploymentTargets = .macOS("99.0")\n' > "$TMP/Fake.swift"
 out=$(EW_PROJECT_MANIFEST="$TMP/Fake.swift" "$SUT" "$BIN" 2>&1); code=$?
-if [ "$code" -ne 0 ] && printf '%s' "$out" | /usr/bin/grep -q "Reconcile the two deliberately"; then
+floor_hits=$(printf '%s' "$out" | /usr/bin/grep -c "Reconcile the two deliberately")
+if [ "$code" -ne 0 ] && [ "$floor_hits" -gt 0 ]; then
   echo "  ok   [$code, matched] a binary whose target disagrees with the declared floor is rejected"
   pass=$((pass + 1))
 else

--- a/scripts/ci/check-weak-linked-symbols-test.sh
+++ b/scripts/ci/check-weak-linked-symbols-test.sh
@@ -229,6 +229,14 @@ expect_output "records no deployment target" \
   "an embedded binary with no readable deployment target is refused, not certified" \
   "$TMP/nominos.sh" "$BUNDLE"
 
+# Same shape for the load-command list: an empty parse used to make every framework check below
+# skip without a word. Measured on the real bundle, its embedded binaries report 1 to 63 load
+# commands, so empty means the parser broke.
+variant "$TMP/noloads.sh" '    extra_loads=.*' '    extra_loads=""'
+expect_output "no dynamic library load commands were parsed" \
+  "an embedded binary whose load commands cannot be parsed is refused, not certified" \
+  "$TMP/noloads.sh" "$BUNDLE"
+
 # A bundle that yields no embedded Mach-O means the enumeration broke. It used to print
 # "scanned: 0" and pass.
 rm -f "$BUNDLE/Contents/Frameworks/Embedded.dylib"

--- a/scripts/ci/check-weak-linked-symbols-test.sh
+++ b/scripts/ci/check-weak-linked-symbols-test.sh
@@ -92,13 +92,13 @@ expect 0 "the shipped binary passes" "$SUT" "$BIN"
 # The assertion fires. AppKit is linked normally, so guarding it MUST report strong symbols
 # AND a strong LC_LOAD_DYLIB. This one variant covers both failure kinds, which is why the
 # next case exists: to prove the load-command check can fail on its own.
-variant "$TMP/strong.sh" 'ABSENT_AT_BASELINE_FRAMEWORKS="FoundationModels"' 'ABSENT_AT_BASELINE_FRAMEWORKS="AppKit"'
+variant "$TMP/strong.sh" 'ABSENT_AT_BASELINE_FRAMEWORKS=.*' 'ABSENT_AT_BASELINE_FRAMEWORKS="AppKit"'
 expect 1 "a strongly-bound framework is rejected" "$TMP/strong.sh" "$BIN"
 
 # The load-command check must be shown to FIRE, not merely to be present. Exit code alone
 # cannot show it: a strongly-loaded framework usually has strong symbols too, so the symbol
 # check would explain the failure by itself. Asserting the message attributes the failure.
-variant "$TMP/load.sh" 'ABSENT_AT_BASELINE_FRAMEWORKS="FoundationModels"' 'ABSENT_AT_BASELINE_FRAMEWORKS="AVFoundation"'
+variant "$TMP/load.sh" 'ABSENT_AT_BASELINE_FRAMEWORKS=.*' 'ABSENT_AT_BASELINE_FRAMEWORKS="AVFoundation"'
 expect_output "must be LC_LOAD_WEAK_DYLIB" "a strongly-LOADED framework is named as such" "$TMP/load.sh" "$BIN"
 
 # The instrument's own control. If it cannot tell weak from strong, it must refuse to answer
@@ -110,14 +110,18 @@ expect_output "must be LC_LOAD_WEAK_DYLIB" "a strongly-LOADED framework is named
 # this mutant would stop refusing, and the self-test would block a change the guard permits.
 # `FoundationModels` cannot drift that way, because the guard itself requires it to be fully
 # weak — if it ever were not, the real check would fail before this control could mislead.
-variant "$TMP/badctl.sh" 'CONTROL_FRAMEWORK="AppKit"' 'CONTROL_FRAMEWORK="FoundationModels"'
+variant "$TMP/badctl.sh" 'CONTROL_FRAMEWORK=.*' 'CONTROL_FRAMEWORK="FoundationModels"'
 expect 2 "a control that reports weak refuses to give a verdict" "$TMP/badctl.sh" "$BIN"
 
-variant "$TMP/noctl.sh" 'CONTROL_FRAMEWORK="AppKit"' 'CONTROL_FRAMEWORK="NoSuchFrameworkXYZ"'
+variant "$TMP/noctl.sh" 'CONTROL_FRAMEWORK=.*' 'CONTROL_FRAMEWORK="NoSuchFrameworkXYZ"'
 expect 2 "an absent control refuses to give a verdict" "$TMP/noctl.sh" "$BIN"
 
 # A guard list matching nothing is a guard checking nothing, and must not pass.
-variant "$TMP/nofw.sh" 'NEWER_SYMBOL_PATTERNS="SpeechAnalyzer DictationTranscriber AssetInventory"' 'NEWER_SYMBOL_PATTERNS="NoSuchTypeXYZ"'
+# Matched by PREFIX, not by the full literal list. Pinning the whole value meant that extending
+# the watched types silently turned this mutation into a no-op — `variant()` caught it, which is
+# why it refuses a substitution that changes nothing, but a prefix match makes the case survive
+# the next edit to that list instead of needing one of its own.
+variant "$TMP/nofw.sh" 'NEWER_SYMBOL_PATTERNS=.*' 'NEWER_SYMBOL_PATTERNS="NoSuchTypeXYZ"'
 expect 2 "a symbol-pattern list matching nothing refuses to pass" "$TMP/nofw.sh" "$BIN"
 
 # **The regression that made this whole check vacuous for one type.** Matching against RAW nm

--- a/scripts/ci/check-weak-linked-symbols-test.sh
+++ b/scripts/ci/check-weak-linked-symbols-test.sh
@@ -71,6 +71,10 @@ variant() {
   chmod +x "$path"
 }
 
+# Variants live in $TMP, where `$0/../..` is not the repo. Give them the real manifest so the
+# deployment-target assertion resolves for every case that is not about the manifest itself.
+export EW_PROJECT_MANIFEST="$HERE/../../Project.swift"
+
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 
@@ -115,6 +119,35 @@ expect 2 "a symbol-pattern list matching nothing refuses to pass" "$TMP/nofw.sh"
 # shellcheck disable=SC2016  # deliberate: these are sed patterns, the $ must stay literal
 variant "$TMP/raw.sh" 'SYMS_READABLE=\$(printf .%s\\n. "\$SYMS" | xcrun swift-demangle 2>\/dev\/null)' 'SYMS_READABLE="$SYMS"'
 expect 2 "matching raw mangled symbols refuses to give a verdict" "$TMP/raw.sh" "$BIN"
+
+# **A raised deployment target must be rejected, not merely printed.** This is the failure that
+# would leave every check below immaculate and the product unlaunchable for supported users:
+# every weak-linkage verdict is RELATIVE to the target, so raising it keeps them all green.
+#
+# Driven by pointing the real script at a manifest declaring a different floor, rather than by
+# editing the script. Editing it was the first approach and it was wrong twice over: the sed
+# pattern contained slashes, and a copy in a temp dir resolves its repo root elsewhere, which
+# broke every OTHER case instead of testing this one.
+printf 'let deploymentTargets: DeploymentTargets = .macOS("99.0")\n' > "$TMP/Fake.swift"
+out=$(EW_PROJECT_MANIFEST="$TMP/Fake.swift" "$SUT" "$BIN" 2>&1); code=$?
+if [ "$code" -ne 0 ] && printf '%s' "$out" | /usr/bin/grep -q "Reconcile the two deliberately"; then
+  echo "  ok   [$code, matched] a binary whose target disagrees with the declared floor is rejected"
+  pass=$((pass + 1))
+else
+  echo "  FAIL [exit $code; wanted nonzero AND the reconcile message] declared-floor mismatch" >&2
+  printf '%s\n' "$out" | sed 's/^/       /' >&2
+  fail=$((fail + 1))
+fi
+
+# An unreadable manifest must refuse, not fall back to trusting the binary.
+out=$(EW_PROJECT_MANIFEST="$TMP/does-not-exist.swift" "$SUT" "$BIN" 2>&1); code=$?
+if [ "$code" -eq 2 ]; then
+  echo "  ok   [2] an unreadable manifest refuses to certify the deployment target"
+  pass=$((pass + 1))
+else
+  echo "  FAIL [got $code, want 2] unreadable manifest" >&2
+  fail=$((fail + 1))
+fi
 
 # Fails closed on every input it cannot measure.
 expect 2 "missing file" "$SUT" "$TMP/does-not-exist"

--- a/scripts/ci/check-weak-linked-symbols-test.sh
+++ b/scripts/ci/check-weak-linked-symbols-test.sh
@@ -55,9 +55,19 @@ expect_output() {
 }
 
 # Variants are generated from the real script so they cannot drift away from it.
+#
+# **A substitution that changes nothing is refused.** Renaming a variable in the subject used to
+# leave these variants byte-identical to it, so the cases that must FAIL quietly passed and the
+# suite still reported green on the ones that could not drift. A mutation that does not mutate is
+# a test of nothing.
 variant() {
   local path="$1" from="$2" to="$3"
   sed "s/^$from/$to/" "$SUT" > "$path" || return 1
+  if cmp -s "$SUT" "$path"; then
+    echo "  FAIL [variant is identical to the subject] pattern never matched: $from" >&2
+    fail=$((fail + 1))
+    return 1
+  fi
   chmod +x "$path"
 }
 
@@ -72,13 +82,13 @@ expect 0 "the shipped binary passes" "$SUT" "$BIN"
 # The assertion fires. AppKit is linked normally, so guarding it MUST report strong symbols
 # AND a strong LC_LOAD_DYLIB. This one variant covers both failure kinds, which is why the
 # next case exists: to prove the load-command check can fail on its own.
-variant "$TMP/strong.sh" 'GUARDED_FRAMEWORKS="Speech FoundationModels"' 'GUARDED_FRAMEWORKS="AppKit"'
+variant "$TMP/strong.sh" 'ABSENT_AT_BASELINE_FRAMEWORKS="FoundationModels"' 'ABSENT_AT_BASELINE_FRAMEWORKS="AppKit"'
 expect 1 "a strongly-bound framework is rejected" "$TMP/strong.sh" "$BIN"
 
 # The load-command check must be shown to FIRE, not merely to be present. Exit code alone
 # cannot show it: a strongly-loaded framework usually has strong symbols too, so the symbol
 # check would explain the failure by itself. Asserting the message attributes the failure.
-variant "$TMP/load.sh" 'GUARDED_FRAMEWORKS="Speech FoundationModels"' 'GUARDED_FRAMEWORKS="AVFoundation"'
+variant "$TMP/load.sh" 'ABSENT_AT_BASELINE_FRAMEWORKS="FoundationModels"' 'ABSENT_AT_BASELINE_FRAMEWORKS="AVFoundation"'
 expect_output "must be LC_LOAD_WEAK_DYLIB" "a strongly-LOADED framework is named as such" "$TMP/load.sh" "$BIN"
 
 # The instrument's own control. If it cannot tell weak from strong, it must refuse to answer
@@ -90,8 +100,8 @@ variant "$TMP/noctl.sh" 'CONTROL_FRAMEWORK="AppKit"' 'CONTROL_FRAMEWORK="NoSuchF
 expect 2 "an absent control refuses to give a verdict" "$TMP/noctl.sh" "$BIN"
 
 # A guard list matching nothing is a guard checking nothing, and must not pass.
-variant "$TMP/nofw.sh" 'GUARDED_FRAMEWORKS="Speech FoundationModels"' 'GUARDED_FRAMEWORKS="NoSuchFrameworkXYZ"'
-expect 2 "a guard list matching nothing refuses to pass" "$TMP/nofw.sh" "$BIN"
+variant "$TMP/nofw.sh" 'NEWER_SYMBOL_PATTERNS="SpeechAnalyzer DictationTranscriber AssetInventory"' 'NEWER_SYMBOL_PATTERNS="NoSuchTypeXYZ"'
+expect 2 "a symbol-pattern list matching nothing refuses to pass" "$TMP/nofw.sh" "$BIN"
 
 # Fails closed on every input it cannot measure.
 expect 2 "missing file" "$SUT" "$TMP/does-not-exist"

--- a/scripts/ci/check-weak-linked-symbols-test.sh
+++ b/scripts/ci/check-weak-linked-symbols-test.sh
@@ -223,7 +223,7 @@ fi
 cp "$BIN" "$BUNDLE/Contents/Frameworks/Embedded.dylib"
 rm -f "$BUNDLE/Contents/Frameworks/Truncated.dylib"
 ctl_out=$("$SUT" "$BUNDLE" 2>&1); ctl_code=$?
-ctl_scanned=$(printf '%s' "$ctl_out" | /usr/bin/grep -c "embedded Mach-O files scanned: 1")
+ctl_scanned=$(printf '%s' "$ctl_out" | /usr/bin/grep -c "of which arm64 and inspected: 1")
 ctl_skipped=$(printf '%s' "$ctl_out" | /usr/bin/grep -c "no arm64 slice")
 if [ "$ctl_code" -eq 0 ] && [ "$ctl_scanned" -gt 0 ] && [ "$ctl_skipped" -eq 0 ]; then
   echo "  ok   [0] the same bundle with a readable arm64 embedded Mach-O passes, having actually inspected it"
@@ -285,11 +285,28 @@ rm -rf "$BUNDLE/Contents/Frameworks/Old.framework"
 expect 2 "an app plist with no minimum at all refuses to certify the bundle" "$SUT" "$BUNDLE"
 /usr/libexec/PlistBuddy -c "Add :LSMinimumSystemVersion string $DECLARED_FLOOR" "$BUNDLE/Contents/Info.plist" >/dev/null 2>&1
 
-# A bundle that yields no embedded Mach-O means the enumeration broke. It used to print
-# "scanned: 0" and pass.
+# **A bundle whose embedded Mach-O files are all the wrong architecture inspected nothing.**
+#
+# The count used to increment BEFORE the architecture skip, so a file that was found and then
+# skipped still satisfied the "something was inspected" assertion. `/usr/lib/dyld` is the honest
+# fixture for this: it is `x86_64 arm64e`, with no plain arm64 slice, which is exactly why it
+# made an earlier version of the control case above pass without inspecting anything.
 rm -f "$BUNDLE/Contents/Frameworks/Embedded.dylib"
-expect_output "no embedded Mach-O file was inspected" \
-  "a bundle with nothing embedded is refused, not certified" \
+if [ -f /usr/lib/dyld ] && [ "$(lipo -archs /usr/lib/dyld 2>/dev/null | /usr/bin/grep -cE '(^| )arm64( |$)')" -eq 0 ]; then
+  cp /usr/lib/dyld "$BUNDLE/Contents/Frameworks/WrongArch.dylib"
+  expect_output "no embedded arm64 Mach-O file was inspected" \
+    "a bundle whose embedded binaries are all the wrong architecture is refused, not certified" \
+    "$SUT" "$BUNDLE"
+  rm -f "$BUNDLE/Contents/Frameworks/WrongArch.dylib"
+else
+  echo "  FAIL [fixture] /usr/lib/dyld now reports a plain arm64 slice, so it no longer tests the architecture skip" >&2
+  fail=$((fail + 1))
+fi
+
+# A bundle that yields no embedded Mach-O at all means the enumeration broke. It used to print
+# "scanned: 0" and pass.
+expect_output "found 0 Mach-O in total" \
+  "a bundle with nothing embedded at all is refused, not certified" \
   "$SUT" "$BUNDLE"
 
 echo "==> $pass passed, $fail failed"

--- a/scripts/ci/check-weak-linked-symbols-test.sh
+++ b/scripts/ci/check-weak-linked-symbols-test.sh
@@ -103,6 +103,19 @@ expect 2 "an absent control refuses to give a verdict" "$TMP/noctl.sh" "$BIN"
 variant "$TMP/nofw.sh" 'NEWER_SYMBOL_PATTERNS="SpeechAnalyzer DictationTranscriber AssetInventory"' 'NEWER_SYMBOL_PATTERNS="NoSuchTypeXYZ"'
 expect 2 "a symbol-pattern list matching nothing refuses to pass" "$TMP/nofw.sh" "$BIN"
 
+# **The regression that made this whole check vacuous for one type.** Matching against RAW nm
+# output finds nothing for `SpeechAnalyzer`, because Swift mangles it as `0A8Analyzer` — the
+# module prefix is substituted away. The guard read that as "type unused" and passed. Every
+# pattern is now required to match, so reverting to raw symbols must fail, not shrug.
+# Caught by the demangler control, which fires BEFORE the pattern loop: raw mangled output
+# contains no readable Swift signature, so the guard refuses to give a verdict at all rather
+# than reaching the patterns and reporting a type as unused. Asserting the refusal (exit 2) is
+# asserting the real behaviour; an earlier draft of this case expected the later message and
+# failed, which is the defence-in-depth working, not a bug.
+# shellcheck disable=SC2016  # deliberate: these are sed patterns, the $ must stay literal
+variant "$TMP/raw.sh" 'SYMS_READABLE=\$(printf .%s\\n. "\$SYMS" | xcrun swift-demangle 2>\/dev\/null)' 'SYMS_READABLE="$SYMS"'
+expect 2 "matching raw mangled symbols refuses to give a verdict" "$TMP/raw.sh" "$BIN"
+
 # Fails closed on every input it cannot measure.
 expect 2 "missing file" "$SUT" "$TMP/does-not-exist"
 expect 2 "not a Mach-O binary" "$SUT" "$SUT"

--- a/scripts/ci/check-weak-linked-symbols-test.sh
+++ b/scripts/ci/check-weak-linked-symbols-test.sh
@@ -103,7 +103,14 @@ expect_output "must be LC_LOAD_WEAK_DYLIB" "a strongly-LOADED framework is named
 
 # The instrument's own control. If it cannot tell weak from strong, it must refuse to answer
 # rather than report the pass it would otherwise print.
-variant "$TMP/badctl.sh" 'CONTROL_FRAMEWORK="AppKit"' 'CONTROL_FRAMEWORK="Speech"'
+#
+# **The stand-in must be a framework that is guaranteed to stay fully weak.** `Speech` was the
+# obvious pick and was wrong: the production guard deliberately ALLOWS baseline-era Speech APIs,
+# so adding something like `SFSpeechRecognizer` would legitimately give Speech strong symbols,
+# this mutant would stop refusing, and the self-test would block a change the guard permits.
+# `FoundationModels` cannot drift that way, because the guard itself requires it to be fully
+# weak — if it ever were not, the real check would fail before this control could mislead.
+variant "$TMP/badctl.sh" 'CONTROL_FRAMEWORK="AppKit"' 'CONTROL_FRAMEWORK="FoundationModels"'
 expect 2 "a control that reports weak refuses to give a verdict" "$TMP/badctl.sh" "$BIN"
 
 variant "$TMP/noctl.sh" 'CONTROL_FRAMEWORK="AppKit"' 'CONTROL_FRAMEWORK="NoSuchFrameworkXYZ"'
@@ -179,8 +186,19 @@ cat > "$BUNDLE/Contents/Info.plist" <<'PLIST'
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0"><dict>
 <key>CFBundleExecutable</key><string>Probe</string>
+<key>LSMinimumSystemVersion</key><string>14.0</string>
 </dict></plist>
 PLIST
+
+# Read the declared floor the same way the subject does, so these cases assert against the real
+# value rather than a second hardcoded copy of it that could drift away from Project.swift.
+DECLARED_FLOOR=$(/usr/bin/grep -oE 'DeploymentTargets = \.macOS\("[0-9]+\.[0-9]+"\)' "$EW_PROJECT_MANIFEST" | /usr/bin/grep -oE '[0-9]+\.[0-9]+' | head -1)
+if [ -z "$DECLARED_FLOOR" ]; then
+  echo "  FAIL [fixture] could not read the declared floor from $EW_PROJECT_MANIFEST" >&2
+  fail=$((fail + 1))
+  DECLARED_FLOOR="14.0"
+fi
+/usr/libexec/PlistBuddy -c "Set :LSMinimumSystemVersion $DECLARED_FLOOR" "$BUNDLE/Contents/Info.plist" >/dev/null 2>&1
 
 # A truncated Mach-O: `file` still classifies it, so the enumeration picks it up, while `lipo`
 # and `nm` refuse it. Before the exit statuses were checked this printed "no arm64 slice ()" —
@@ -236,6 +254,36 @@ variant "$TMP/noloads.sh" '    extra_loads=.*' '    extra_loads=""'
 expect_output "no dynamic library load commands were parsed" \
   "an embedded binary whose load commands cannot be parsed is refused, not certified" \
   "$TMP/noloads.sh" "$BUNDLE"
+
+# **Launch Services minimum.** This value is a hardcoded literal in checked-in plists, derived
+# from nothing, and Launch Services reads it instead of the Mach-O load command — so raising it
+# locks macOS 14 users out of an app whose binary checks are all green. The launch probe cannot
+# see it either, because invoking the executable directly bypasses Launch Services.
+/usr/libexec/PlistBuddy -c "Set :LSMinimumSystemVersion 99.0" "$BUNDLE/Contents/Info.plist" >/dev/null 2>&1
+expect_output "Launch Services would refuse to start the app" \
+  "an app plist demanding a newer macOS than the declared floor is rejected" \
+  "$SUT" "$BUNDLE"
+
+# A BUNDLED plist may legitimately declare an OLDER minimum — Sparkle says 10.13, PostHog 10.15 —
+# so the rule for those is "may not exceed", not "must equal". Without this case the check could
+# be tightened to equality and fail on honest dependencies.
+/usr/libexec/PlistBuddy -c "Set :LSMinimumSystemVersion $DECLARED_FLOOR" "$BUNDLE/Contents/Info.plist" >/dev/null 2>&1
+mkdir -p "$BUNDLE/Contents/Frameworks/Old.framework"
+printf '<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0"><dict><key>LSMinimumSystemVersion</key><string>10.13</string></dict></plist>\n' \
+  > "$BUNDLE/Contents/Frameworks/Old.framework/Info.plist"
+expect 0 "a bundled plist declaring an OLDER minimum is accepted" "$SUT" "$BUNDLE"
+
+# ...but one declaring a NEWER minimum is not.
+/usr/libexec/PlistBuddy -c "Set :LSMinimumSystemVersion 99.0" "$BUNDLE/Contents/Frameworks/Old.framework/Info.plist" >/dev/null 2>&1
+expect_output "above the declared floor" \
+  "a bundled plist demanding a newer macOS than the declared floor is rejected" \
+  "$SUT" "$BUNDLE"
+rm -rf "$BUNDLE/Contents/Frameworks/Old.framework"
+
+# An app plist that declares no minimum at all has asserted nothing about whether it can start.
+/usr/libexec/PlistBuddy -c "Delete :LSMinimumSystemVersion" "$BUNDLE/Contents/Info.plist" >/dev/null 2>&1
+expect 2 "an app plist with no minimum at all refuses to certify the bundle" "$SUT" "$BUNDLE"
+/usr/libexec/PlistBuddy -c "Add :LSMinimumSystemVersion string $DECLARED_FLOOR" "$BUNDLE/Contents/Info.plist" >/dev/null 2>&1
 
 # A bundle that yields no embedded Mach-O means the enumeration broke. It used to print
 # "scanned: 0" and pass.

--- a/scripts/ci/check-weak-linked-symbols-test.sh
+++ b/scripts/ci/check-weak-linked-symbols-test.sh
@@ -197,14 +197,41 @@ fi
 
 # Control for the case above: the SAME bundle with a readable embedded Mach-O must pass. Without
 # this, "the bundle case fails" would be indistinguishable from "bundle mode is broken".
-cp /usr/lib/dyld "$BUNDLE/Contents/Frameworks/Truncated.dylib" 2>/dev/null ||
-  cp /bin/echo "$BUNDLE/Contents/Frameworks/Truncated.dylib"
-expect 0 "the same bundle with a readable embedded Mach-O passes" \
-  "$SUT" "$BUNDLE"
+#
+# **The control binary must carry an arm64 slice, or it proves nothing.** A first draft used
+# `/usr/lib/dyld`, which is `x86_64 arm64e` — no plain arm64 — so the script skipped it and the
+# case passed without inspecting anything, which is the very failure this section exists to
+# catch. The subject binary is arm64 by definition, so it is the honest control.
+cp "$BIN" "$BUNDLE/Contents/Frameworks/Embedded.dylib"
+rm -f "$BUNDLE/Contents/Frameworks/Truncated.dylib"
+ctl_out=$("$SUT" "$BUNDLE" 2>&1); ctl_code=$?
+ctl_scanned=$(printf '%s' "$ctl_out" | /usr/bin/grep -c "embedded Mach-O files scanned: 1")
+ctl_skipped=$(printf '%s' "$ctl_out" | /usr/bin/grep -c "no arm64 slice")
+if [ "$ctl_code" -eq 0 ] && [ "$ctl_scanned" -gt 0 ] && [ "$ctl_skipped" -eq 0 ]; then
+  echo "  ok   [0] the same bundle with a readable arm64 embedded Mach-O passes, having actually inspected it"
+  pass=$((pass + 1))
+else
+  echo "  FAIL [exit $ctl_code; scanned=$ctl_scanned skipped=$ctl_skipped] readable embedded control" >&2
+  printf '%s\n' "$ctl_out" | sed 's/^/       /' >&2
+  fail=$((fail + 1))
+fi
+
+# **An embedded binary whose deployment target cannot be read must not be certified.** The
+# assertion used to be written `[ -n "$extra_minos" ] && [ ... ]`, so a binary that did not say
+# what it required was waved through — a macOS 15 dependency certified for 14 by silence.
+#
+# Driven by a mutant rather than a fixture, because no supported linker will emit a Mach-O with
+# no version load command: `ld` rejects `-no_version_load_command`, and all 9 arm64 Mach-O files
+# in the real bundle carry LC_BUILD_VERSION. Blanking the primary parse leaves the legacy
+# LC_VERSION_MIN_MACOSX fallback to find nothing either, which is exactly the state under test.
+variant "$TMP/nominos.sh" '    extra_minos=.*' '    extra_minos=""'
+expect_output "records no deployment target" \
+  "an embedded binary with no readable deployment target is refused, not certified" \
+  "$TMP/nominos.sh" "$BUNDLE"
 
 # A bundle that yields no embedded Mach-O means the enumeration broke. It used to print
 # "scanned: 0" and pass.
-rm -f "$BUNDLE/Contents/Frameworks/Truncated.dylib"
+rm -f "$BUNDLE/Contents/Frameworks/Embedded.dylib"
 expect_output "no embedded Mach-O file was inspected" \
   "a bundle with nothing embedded is refused, not certified" \
   "$SUT" "$BUNDLE"

--- a/scripts/ci/check-weak-linked-symbols-test.sh
+++ b/scripts/ci/check-weak-linked-symbols-test.sh
@@ -163,6 +163,14 @@ else
   fail=$((fail + 1))
 fi
 
+# **The version comparator's own control must fire.** Every deployment-target and
+# LSMinimumSystemVersion verdict is a version comparison, so a comparator that cannot compare
+# would report everything acceptable — the fail-open shape, sitting inside the guard itself.
+variant "$TMP/badver.sh" 'version_is_above() .*' 'version_is_above() { return 1; }'
+expect_output "not ordering macOS versions correctly" \
+  "a comparator that cannot compare versions refuses to give a verdict" \
+  "$TMP/badver.sh" "$BIN"
+
 # Fails closed on every input it cannot measure.
 expect 2 "missing file" "$SUT" "$TMP/does-not-exist"
 expect 2 "not a Mach-O binary" "$SUT" "$SUT"

--- a/scripts/ci/check-weak-linked-symbols-test.sh
+++ b/scripts/ci/check-weak-linked-symbols-test.sh
@@ -161,5 +161,53 @@ expect 2 "missing file" "$SUT" "$TMP/does-not-exist"
 expect 2 "not a Mach-O binary" "$SUT" "$SUT"
 expect 2 "no argument" "$SUT"
 
+# ---------------------------------------------------------------------------------------------
+# BUNDLE MODE.
+#
+# Everything above drives a plain Mach-O, which exercises the main-executable path only. The
+# EMBEDDED path had no coverage at all, and that is where the reads used to fail open: `lipo`,
+# `otool` and `nm` had their exit statuses discarded, so a binary the script could not read
+# produced empty output, and empty output is spelled the same as "inspected and clean".
+#
+# The bundle is assembled from the real subject binary so the main-executable checks pass and
+# the embedded behaviour is what is under test.
+BUNDLE="$TMP/Probe.app"
+mkdir -p "$BUNDLE/Contents/MacOS" "$BUNDLE/Contents/Frameworks"
+cp "$BIN" "$BUNDLE/Contents/MacOS/Probe"
+cat > "$BUNDLE/Contents/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>CFBundleExecutable</key><string>Probe</string>
+</dict></plist>
+PLIST
+
+# A truncated Mach-O: `file` still classifies it, so the enumeration picks it up, while `lipo`
+# and `nm` refuse it. Before the exit statuses were checked this printed "no arm64 slice ()" —
+# the same sentence as a legitimate skip, differing only by an empty parenthesis — and passed.
+head -c 512 "$BIN" > "$BUNDLE/Contents/Frameworks/Truncated.dylib"
+if [ "$(file "$BUNDLE/Contents/Frameworks/Truncated.dylib" | grep -c 'Mach-O')" -eq 0 ]; then
+  echo "  FAIL [fixture] the truncated file is not classified as Mach-O, so the enumeration would skip it and this case would test nothing" >&2
+  fail=$((fail + 1))
+else
+  expect_output "refusing to certify a binary this script cannot inspect" \
+    "an embedded Mach-O the tools cannot read fails the gate instead of passing quietly" \
+    "$SUT" "$BUNDLE"
+fi
+
+# Control for the case above: the SAME bundle with a readable embedded Mach-O must pass. Without
+# this, "the bundle case fails" would be indistinguishable from "bundle mode is broken".
+cp /usr/lib/dyld "$BUNDLE/Contents/Frameworks/Truncated.dylib" 2>/dev/null ||
+  cp /bin/echo "$BUNDLE/Contents/Frameworks/Truncated.dylib"
+expect 0 "the same bundle with a readable embedded Mach-O passes" \
+  "$SUT" "$BUNDLE"
+
+# A bundle that yields no embedded Mach-O means the enumeration broke. It used to print
+# "scanned: 0" and pass.
+rm -f "$BUNDLE/Contents/Frameworks/Truncated.dylib"
+expect_output "no embedded Mach-O file was inspected" \
+  "a bundle with nothing embedded is refused, not certified" \
+  "$SUT" "$BUNDLE"
+
 echo "==> $pass passed, $fail failed"
 [ "$fail" -eq 0 ] || exit 1

--- a/scripts/ci/check-weak-linked-symbols-test.sh
+++ b/scripts/ci/check-weak-linked-symbols-test.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# Self-test for check-weak-linked-symbols.sh.
+#
+# Exists because a guard that cannot fail is indistinguishable from a guard that passes, and
+# this repo has repeatedly found guards that had quietly stopped inspecting anything. Every
+# case below drives the real script against a real binary and asserts the EXIT CODE, including
+# the cases where the script must refuse to answer.
+#
+# Usage: check-weak-linked-symbols-test.sh <path-to-macho-binary>
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SUT="$HERE/check-weak-linked-symbols.sh"
+BIN="${1:-}"
+
+[ -n "$BIN" ] || { echo "usage: $0 <path-to-macho-binary>" >&2; exit 2; }
+[ -f "$BIN" ] || { echo "FAIL: binary not found: $BIN" >&2; exit 2; }
+[ -x "$SUT" ] || { echo "FAIL: subject not executable: $SUT" >&2; exit 2; }
+
+# A mutant that does not RUN exits 126/127 and reads as failure everywhere, which would hide
+# that the defence was never exercised. Parse-check first.
+bash -n "$SUT" || { echo "FAIL: subject does not parse" >&2; exit 2; }
+
+pass=0
+fail=0
+
+expect() {
+  local want="$1" name="$2"; shift 2
+  local out; out=$("$@" 2>&1); local got=$?
+  if [ "$got" -eq "$want" ]; then
+    echo "  ok   [$got] $name"
+    pass=$((pass + 1))
+  else
+    echo "  FAIL [got $got, want $want] $name" >&2
+    printf '%s\n' "$out" | sed 's/^/       /' >&2
+    fail=$((fail + 1))
+  fi
+}
+
+# Variants are generated from the real script so they cannot drift away from it.
+variant() {
+  local path="$1" from="$2" to="$3"
+  sed "s/^$from/$to/" "$SUT" > "$path" || return 1
+  chmod +x "$path"
+}
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+echo "==> self-test: $SUT"
+
+# The real binary must pass. Without this the suite could go green with everything broken.
+expect 0 "the shipped binary passes" "$SUT" "$BIN"
+
+# The assertion fires. AppKit is linked normally, so guarding it MUST report strong symbols.
+variant "$TMP/strong.sh" 'GUARDED_FRAMEWORKS="Speech FoundationModels"' 'GUARDED_FRAMEWORKS="AppKit"'
+expect 1 "a strongly-bound framework is rejected" "$TMP/strong.sh" "$BIN"
+
+# The instrument's own control. If it cannot tell weak from strong, it must refuse to answer
+# rather than report the pass it would otherwise print.
+variant "$TMP/badctl.sh" 'CONTROL_FRAMEWORK="AppKit"' 'CONTROL_FRAMEWORK="Speech"'
+expect 2 "a control that reports weak refuses to give a verdict" "$TMP/badctl.sh" "$BIN"
+
+variant "$TMP/noctl.sh" 'CONTROL_FRAMEWORK="AppKit"' 'CONTROL_FRAMEWORK="NoSuchFrameworkXYZ"'
+expect 2 "an absent control refuses to give a verdict" "$TMP/noctl.sh" "$BIN"
+
+# A guard list matching nothing is a guard checking nothing, and must not pass.
+variant "$TMP/nofw.sh" 'GUARDED_FRAMEWORKS="Speech FoundationModels"' 'GUARDED_FRAMEWORKS="NoSuchFrameworkXYZ"'
+expect 2 "a guard list matching nothing refuses to pass" "$TMP/nofw.sh" "$BIN"
+
+# Fails closed on every input it cannot measure.
+expect 2 "missing file" "$SUT" "$TMP/does-not-exist"
+expect 2 "not a Mach-O binary" "$SUT" "$SUT"
+expect 2 "no argument" "$SUT"
+
+echo "==> $pass passed, $fail failed"
+[ "$fail" -eq 0 ] || exit 1

--- a/scripts/ci/check-weak-linked-symbols-test.sh
+++ b/scripts/ci/check-weak-linked-symbols-test.sh
@@ -38,6 +38,22 @@ expect() {
   fi
 }
 
+# Asserts on a MESSAGE rather than an exit code, for checks whose failure another check would
+# also produce. A non-zero exit is required too: a matching message on a passing run would mean
+# the text appeared somewhere harmless.
+expect_output() {
+  local want="$1" name="$2"; shift 2
+  local out; out=$("$@" 2>&1); local code=$?
+  if [ "$code" -ne 0 ] && printf '%s' "$out" | /usr/bin/grep -q "$want"; then
+    echo "  ok   [$code, matched] $name"
+    pass=$((pass + 1))
+  else
+    echo "  FAIL [exit $code; wanted nonzero AND '$want'] $name" >&2
+    printf '%s\n' "$out" | sed 's/^/       /' >&2
+    fail=$((fail + 1))
+  fi
+}
+
 # Variants are generated from the real script so they cannot drift away from it.
 variant() {
   local path="$1" from="$2" to="$3"
@@ -53,9 +69,17 @@ echo "==> self-test: $SUT"
 # The real binary must pass. Without this the suite could go green with everything broken.
 expect 0 "the shipped binary passes" "$SUT" "$BIN"
 
-# The assertion fires. AppKit is linked normally, so guarding it MUST report strong symbols.
+# The assertion fires. AppKit is linked normally, so guarding it MUST report strong symbols
+# AND a strong LC_LOAD_DYLIB. This one variant covers both failure kinds, which is why the
+# next case exists: to prove the load-command check can fail on its own.
 variant "$TMP/strong.sh" 'GUARDED_FRAMEWORKS="Speech FoundationModels"' 'GUARDED_FRAMEWORKS="AppKit"'
 expect 1 "a strongly-bound framework is rejected" "$TMP/strong.sh" "$BIN"
+
+# The load-command check must be shown to FIRE, not merely to be present. Exit code alone
+# cannot show it: a strongly-loaded framework usually has strong symbols too, so the symbol
+# check would explain the failure by itself. Asserting the message attributes the failure.
+variant "$TMP/load.sh" 'GUARDED_FRAMEWORKS="Speech FoundationModels"' 'GUARDED_FRAMEWORKS="AVFoundation"'
+expect_output "must be LC_LOAD_WEAK_DYLIB" "a strongly-LOADED framework is named as such" "$TMP/load.sh" "$BIN"
 
 # The instrument's own control. If it cannot tell weak from strong, it must refuse to answer
 # rather than report the pass it would otherwise print.

--- a/scripts/ci/check-weak-linked-symbols.sh
+++ b/scripts/ci/check-weak-linked-symbols.sh
@@ -62,6 +62,9 @@ case "$TARGET" in
   *.app)
     IS_BUNDLE=1
     [ -d "$TARGET" ] || die "bundle not found: $TARGET" 2
+    # Existence asserted first: `PlistBuddy` reports a missing FILE on STDOUT, so the capture
+    # would otherwise hold "File Doesn't Exist, Will Create: ..." and read as a real value.
+    [ -f "$TARGET/Contents/Info.plist" ] || die "no Contents/Info.plist in $TARGET; this is not a bundle this check can read" 2
     MAIN_NAME=$(/usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "$TARGET/Contents/Info.plist" 2>/dev/null)
     [ -n "$MAIN_NAME" ] || die "no CFBundleExecutable in $TARGET/Contents/Info.plist; cannot identify the main binary" 2
     BIN="$TARGET/Contents/MacOS/$MAIN_NAME"

--- a/scripts/ci/check-weak-linked-symbols.sh
+++ b/scripts/ci/check-weak-linked-symbols.sh
@@ -47,6 +47,21 @@ count_strong_for() {
   printf '%s\n' "$SYMS" | /usr/bin/grep "(from $1)" | /usr/bin/grep -vc 'weak external'
 }
 
+# **The load command matters independently of the symbols.**
+#
+# A framework recorded as LC_LOAD_DYLIB is loaded STRONGLY: if it is absent on the running OS,
+# dyld aborts before it resolves a single symbol, so every symbol being weak buys nothing.
+# FoundationModels does not exist at all below macOS 26, which makes this the more severe of
+# the two failures — and it is invisible to `nm`, since symbol annotations and load commands
+# are set independently (manual linker flags, or a post-link edit, can move one without the
+# other). Review round 3 found this gap; the earlier version checked only symbols.
+LOADS=$(otool -l "$BIN" 2>/dev/null |
+  awk '/^ *cmd LC_LOAD(_WEAK)?_DYLIB/{c=$2} /^ *name /{if(c!=""){print c, $2; c=""}}')
+
+load_command_for() {
+  printf '%s\n' "$LOADS" | awk -v fw="/$1.framework/" 'index($2, fw) {print $1; exit}'
+}
+
 # --- Instrument control, BEFORE any verdict -----------------------------------------------
 # Runs first so a broken detector can never produce a green run.
 CONTROL_TOTAL=$(count_for "$CONTROL_FRAMEWORK")
@@ -59,25 +74,53 @@ if [ "$CONTROL_STRONG" -eq 0 ]; then
 fi
 echo "==> control ok:        $CONTROL_FRAMEWORK has $CONTROL_STRONG strong of $CONTROL_TOTAL (detector distinguishes weak from strong)"
 
+# The load-command reader needs its own control, for the same reason: a parser that returns
+# nothing would make every "weakly loaded" verdict below vacuous.
+[ -n "$LOADS" ] || die "could not read any dylib load commands from $BIN; the load-command check below would be vacuous" 2
+CONTROL_LOAD=$(load_command_for "$CONTROL_FRAMEWORK")
+if [ "$CONTROL_LOAD" != "LC_LOAD_DYLIB" ]; then
+  die "control framework $CONTROL_FRAMEWORK reports load command '${CONTROL_LOAD:-none}', expected LC_LOAD_DYLIB. A normally-linked framework must load strongly, so this parser cannot tell a weak load from a strong one" 2
+fi
+echo "==> control ok:        $CONTROL_FRAMEWORK loads as LC_LOAD_DYLIB (parser distinguishes weak from strong loads)"
+
 # --- The actual assertion ------------------------------------------------------------------
 status=0
 checked=0
 for fw in $GUARDED_FRAMEWORKS; do
   total=$(count_for "$fw")
+  load=$(load_command_for "$fw")
+
+  # **The load command is checked FIRST, and for every guarded framework.** An earlier version
+  # skipped a framework contributing no symbols, which would have waved through the worst case
+  # available: a framework reached only through the ObjC runtime, strongly loaded, absent on the
+  # older OS. Zero symbols is the state in which the load command matters MOST, not least.
+  if [ -n "$load" ]; then
+    checked=$((checked + 1))
+    if [ "$load" != "LC_LOAD_WEAK_DYLIB" ]; then
+      echo "    $fw: loaded as $load, must be LC_LOAD_WEAK_DYLIB" >&2
+      status=1
+    fi
+  fi
+
   if [ "$total" -eq 0 ]; then
-    # Not an error on its own: a framework can legitimately go unused. Say so, so that a
+    # Not an error on its own: a framework can legitimately go unused. Said out loud, so a
     # silently-dropped dependency is visible rather than passing as "nothing strong found".
-    echo "    $fw: no symbols in this binary (framework unused here)"
+    if [ -n "$load" ]; then
+      echo "    $fw: no symbols in this binary, loaded as $load"
+    else
+      echo "    $fw: not linked into this binary at all"
+    fi
     continue
   fi
+
   checked=$((checked + 1))
   strong=$(count_strong_for "$fw")
   if [ "$strong" -ne 0 ]; then
     echo "    $fw: $strong of $total symbols are STRONGLY bound" >&2
     printf '%s\n' "$SYMS" | /usr/bin/grep "(from $fw)" | /usr/bin/grep -v 'weak external' | sed 's/^/      /' >&2
     status=1
-  else
-    echo "    $fw: all $total symbols weak ✓"
+  elif [ "$load" = "LC_LOAD_WEAK_DYLIB" ]; then
+    echo "    $fw: all $total symbols weak, loaded weakly ✓"
   fi
 done
 
@@ -87,10 +130,14 @@ fi
 
 if [ "$status" -ne 0 ]; then
   echo >&2
-  echo "A strongly-bound symbol from a framework we only use above the deployment target means" >&2
-  echo "dyld aborts at launch on older macOS. Annotate the offending code with @available and" >&2
-  echo "guard its uses with #available, which makes Swift emit a weak binding." >&2
+  echo "Either failure means dyld aborts at LAUNCH on older macOS, before any #available check" >&2
+  echo "of ours runs:" >&2
+  echo "  - a strongly BOUND symbol: annotate the offending code with @available and guard its" >&2
+  echo "    uses with #available, which makes Swift emit a weak binding." >&2
+  echo "  - a strongly LOADED framework: link it weakly (Xcode 'Optional' / -weak_framework)." >&2
+  echo "    A framework absent on the older OS aborts the process before symbols are consulted," >&2
+  echo "    so weak symbols do not save it." >&2
   exit 1
 fi
 
-echo "==> PASS: every guarded framework is fully weak-bound; the app can start below macOS 26."
+echo "==> PASS: every guarded framework is weakly loaded and fully weak-bound."

--- a/scripts/ci/check-weak-linked-symbols.sh
+++ b/scripts/ci/check-weak-linked-symbols.sh
@@ -64,11 +64,22 @@ case "$TARGET" in
     [ -n "$MAIN_NAME" ] || die "no CFBundleExecutable in $TARGET/Contents/Info.plist; cannot identify the main binary" 2
     BIN="$TARGET/Contents/MacOS/$MAIN_NAME"
     [ -f "$BIN" ] || die "main executable not found: $BIN" 2
-    if [ -d "$TARGET/Contents/Frameworks" ]; then
-      EMBEDDED=$(find "$TARGET/Contents/Frameworks" -type f -perm +111 2>/dev/null | while read -r f; do
-        file "$f" 2>/dev/null | /usr/bin/grep -q "Mach-O" && echo "$f"
-      done)
-    fi
+    # **The WHOLE bundle, not a list of directories someone remembered.**
+    #
+    # Scanning `Contents/Frameworks` alone missed `Contents/XPCServices` — which holds
+    # `EnviousWisprASRService.xpc`, the service that performs transcription. That one is the worst
+    # possible miss: the launch probe would still pass, because the main process survives, and the
+    # app would open on macOS 14 and simply fail to transcribe. CLAUDE.md's core promise is that
+    # dictation works across the whole supported range, so a gate that certifies a bundle whose
+    # ASR service cannot load is certifying the wrong thing.
+    #
+    # This bundle also carries a Mach-O under `Contents/Resources`, which a
+    # Frameworks-plus-XPCServices list would have missed in turn. Enumerating every Mach-O under
+    # Contents is exhaustive by construction, so no future directory can be forgotten.
+    EMBEDDED=$(find "$TARGET/Contents" -type f -perm +111 2>/dev/null | while read -r f; do
+      [ "$f" = "$BIN" ] && continue
+      file "$f" 2>/dev/null | /usr/bin/grep -q "Mach-O" && echo "$f"
+    done)
     ;;
   *)
     BIN="$TARGET"

--- a/scripts/ci/check-weak-linked-symbols.sh
+++ b/scripts/ci/check-weak-linked-symbols.sh
@@ -80,7 +80,14 @@ case "$TARGET" in
     # Contents is exhaustive by construction, so no future directory can be forgotten.
     # Identified by CONTENT, never by the executable bit: a mode-0644 dylib is still loadable by
     # dyld, so `-perm +111` would skip one silently. 136 files here, 0.08s to classify them all.
-    EMBEDDED=$(find "$TARGET/Contents" -type f 2>/dev/null | while read -r f; do
+    # **`find`'s exit status is checked.** A permission or I/O error partway through leaves it
+    # printing the files it did reach and exiting non-zero, so a PARTIAL scan would certify the
+    # bundle on the strength of whatever happened to be listed before the error. The count
+    # assertions further down prove something was inspected; only this proves the list was whole.
+    if ! MACHO_CANDIDATES=$(find "$TARGET/Contents" -type f 2>/dev/null); then
+      die "find could not enumerate $TARGET/Contents completely; a partial list cannot certify the bundle" 2
+    fi
+    EMBEDDED=$(printf '%s\n' "$MACHO_CANDIDATES" | while read -r f; do
       [ "$f" = "$BIN" ] && continue
       # Substring test via parameter expansion: no `grep -q` (pipefail/EPIPE) and no `case`
       # pattern, whose closing paren bash mis-parses inside a $( ) command substitution.
@@ -327,6 +334,10 @@ assert_ls_min() { # <label> <value> <is-main:0|1>; returns 1 if the value is una
 }
 
 if [ "$IS_BUNDLE" -eq 1 ]; then
+  # Same reasoning as the Mach-O enumeration: a partial plist list must not certify the bundle.
+  if ! PLIST_LIST=$(find "$TARGET" -name "Info.plist" 2>/dev/null); then
+    die "find could not enumerate the Info.plist files in $TARGET completely; a partial list cannot certify the bundle" 2
+  fi
   main_plist_seen=0
   while IFS= read -r plist; do
     [ -n "$plist" ] || continue
@@ -345,7 +356,7 @@ if [ "$IS_BUNDLE" -eq 1 ]; then
       assert_ls_min "$rel: LSMinimumSystemVersionByArchitecture:arm64" "$lsarm" "$is_main" || status=1
     fi
   done <<EOF
-$(find "$TARGET" -name "Info.plist" 2>/dev/null)
+$PLIST_LIST
 EOF
   # The app's own plist declaring nothing is not a pass: it is the one Launch Services consults,
   # and a check that never found it has asserted nothing about whether the app can start.

--- a/scripts/ci/check-weak-linked-symbols.sh
+++ b/scripts/ci/check-weak-linked-symbols.sh
@@ -53,6 +53,29 @@ command -v otool >/dev/null 2>&1 || die "otool not available" 2
 SYMS=$(nm -m -u "$BIN" 2>/dev/null)
 [ -n "$SYMS" ] || die "nm produced no undefined symbols for $BIN — wrong file type, or a stripped or thin binary" 2
 
+# **Match type names against DEMANGLED symbols, never the raw mangled ones.**
+#
+# Swift mangling substitutes a repeated module prefix, so `Speech.SpeechAnalyzer` is spelled
+# `_$s6Speech0A8AnalyzerC…` in the binary and the literal string "SpeechAnalyzer" appears
+# nowhere. The previous version matched raw output, found zero, and printed "type unused here,
+# or renamed" over 15 real imports — evidence printed and misread, which is worse than no check.
+# Demangling removes the guesswork: the readable name is what the pattern list already names.
+SYMS_READABLE=$(printf '%s\n' "$SYMS" | xcrun swift-demangle 2>/dev/null)
+if [ -z "$SYMS_READABLE" ]; then
+  # No silent fallback to raw symbols: that is precisely the state that produced a false pass.
+  die "swift-demangle produced nothing; type-name patterns cannot be matched against mangled symbols without silently missing them" 2
+fi
+# Control for the demangler itself: a readable Swift name must appear, or it did not demangle.
+#
+# Counted, NOT `grep -q`. Under `set -o pipefail`, `grep -q` exits on its first match, `printf`
+# then dies of EPIPE, and the pipeline reports failure — so this control fired against 1502
+# genuine matches and killed a correct run. A guard whose success path looks like its failure
+# path is worse than no guard, and this is the second pipefail trap in this file's history.
+READABLE_SIGNATURES=$(printf '%s\n' "$SYMS_READABLE" | /usr/bin/grep -cE '\.getter|\.setter| -> |\.init\(')
+if [ "$READABLE_SIGNATURES" -eq 0 ]; then
+  die "swift-demangle output contains no recognisably demangled Swift signature; every type-name verdict below would be vacuous" 2
+fi
+
 # Report the deployment target so a reader can see WHY this check matters for this build.
 MINOS=$(otool -l "$BIN" 2>/dev/null | awk '/LC_BUILD_VERSION/{f=1} f&&/minos/{print $2; exit}')
 echo "==> binary:            $BIN"
@@ -142,33 +165,31 @@ done
 # (2) Newer types inside frameworks that DO exist at the baseline. Only these symbols are
 #     constrained; the framework's load command and its baseline-era symbols are left alone, so
 #     adding an API that macOS 14 already has does not trip this guard.
-matched_patterns=0
+# **Every configured pattern must match.** Tolerating a zero-match pattern is what let a
+# mangling mismatch read as "unused": the other two patterns still matched, the run passed, and
+# a strong SpeechAnalyzer import would have sailed through. A type that genuinely stops being
+# used should be REMOVED from the list by a person, which is a deliberate act that gets reviewed.
+unmatched=""
 for pattern in $NEWER_SYMBOL_PATTERNS; do
-  hits=$(printf '%s\n' "$SYMS" | /usr/bin/grep -c "$pattern")
+  hits=$(printf '%s\n' "$SYMS_READABLE" | /usr/bin/grep -c "$pattern")
   if [ "$hits" -eq 0 ]; then
-    # Said out loud rather than skipped in silence. A pattern matching nothing is either a type
-    # the app no longer uses or one that has been renamed, and the second case is a guard that
-    # has quietly stopped watching something. Not fatal on its own — the list as a whole still
-    # has to match something — but never invisible.
-    echo "    $pattern: no symbols (type unused here, or renamed)"
+    echo "    $pattern: NO SYMBOLS — renamed, or no longer used" >&2
+    unmatched="$unmatched $pattern"
     continue
   fi
-  matched_patterns=$((matched_patterns + 1))
   checked=$((checked + 1))
-  strong=$(printf '%s\n' "$SYMS" | /usr/bin/grep "$pattern" | /usr/bin/grep -vc 'weak external')
+  strong=$(printf '%s\n' "$SYMS_READABLE" | /usr/bin/grep "$pattern" | /usr/bin/grep -vc 'weak external')
   if [ "$strong" -ne 0 ]; then
     echo "    $pattern: $strong of $hits symbols are STRONGLY bound" >&2
-    printf '%s\n' "$SYMS" | /usr/bin/grep "$pattern" | /usr/bin/grep -v 'weak external' | sed 's/^/      /' >&2
+    printf '%s\n' "$SYMS_READABLE" | /usr/bin/grep "$pattern" | /usr/bin/grep -v 'weak external' | sed 's/^/      /' >&2
     status=1
   else
     echo "    $pattern: all $hits symbols weak ✓"
   fi
 done
 
-# A pattern list that matches nothing has gone stale — the types were renamed, or the app
-# stopped using them — and would report a confident pass having inspected nothing.
-if [ "$matched_patterns" -eq 0 ]; then
-  die "none of the newer-symbol patterns ($NEWER_SYMBOL_PATTERNS) matched anything in this binary. Either the wrong binary was passed, or these types were renamed and this half of the guard is now checking nothing" 2
+if [ -n "$unmatched" ]; then
+  die "these newer-symbol patterns matched nothing:$unmatched. Either the type was renamed (the guard has stopped watching it) or the app no longer uses it (remove it from NEWER_SYMBOL_PATTERNS deliberately). A pattern that inspects nothing must not contribute to a pass" 2
 fi
 
 if [ "$checked" -eq 0 ]; then

--- a/scripts/ci/check-weak-linked-symbols.sh
+++ b/scripts/ci/check-weak-linked-symbols.sh
@@ -76,10 +76,34 @@ if [ "$READABLE_SIGNATURES" -eq 0 ]; then
   die "swift-demangle output contains no recognisably demangled Swift signature; every type-name verdict below would be vacuous" 2
 fi
 
-# Report the deployment target so a reader can see WHY this check matters for this build.
 MINOS=$(otool -l "$BIN" 2>/dev/null | awk '/LC_BUILD_VERSION/{f=1} f&&/minos/{print $2; exit}')
 echo "==> binary:            $BIN"
 echo "==> deployment target: ${MINOS:-unknown}"
+
+# **The deployment target is ASSERTED against the declared support floor, not merely printed.**
+#
+# Everything below is relative: raise the target to 15.0 and macOS 26 symbols are still weak
+# relative to it, so every check here still passes — while the app has become unlaunchable for
+# every macOS 14 user we claim to support. The linkage would be immaculate and the product
+# broken for a whole population, which is a worse outcome than the defect this script was
+# written for. Read from `Project.swift` so there is one source of truth; a mismatch means
+# either an accidental bump or a deliberate one that has not updated the floor here.
+[ -n "$MINOS" ] || die "could not read the deployment target from $BIN; every relative check below would be meaningless" 2
+
+REPO_ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+# Overridable so the self-test can point at a manifest declaring a DIFFERENT floor and prove this
+# assertion rejects it. Without the override the test would have to edit this script, and a copy
+# placed elsewhere resolves `$0/../..` to the wrong root — which is how the first draft of that
+# test broke every other case rather than testing this one.
+MANIFEST="${EW_PROJECT_MANIFEST:-$REPO_ROOT/Project.swift}"
+[ -f "$MANIFEST" ] || die "cannot find $MANIFEST to read the declared support floor; refusing to certify a deployment target against nothing" 2
+DECLARED=$(/usr/bin/grep -oE 'DeploymentTargets = \.macOS\("[0-9]+\.[0-9]+"\)' "$MANIFEST" | /usr/bin/grep -oE '[0-9]+\.[0-9]+' | head -1)
+[ -n "$DECLARED" ] || die "could not parse the declared macOS floor from $MANIFEST; the pattern has drifted and this assertion would silently stop running" 2
+
+if [ "$MINOS" != "$DECLARED" ]; then
+  die "binary targets macOS $MINOS but $MANIFEST declares $DECLARED. A raised target ships an app that will not launch for supported users, and every weak-linkage check below is relative to the target so it would still pass. Reconcile the two deliberately." 1
+fi
+echo "==> floor asserted:    binary $MINOS matches Project.swift $DECLARED"
 
 count_for() { printf '%s\n' "$SYMS" | /usr/bin/grep -c "(from $1)"; }
 count_strong_for() {

--- a/scripts/ci/check-weak-linked-symbols.sh
+++ b/scripts/ci/check-weak-linked-symbols.sh
@@ -303,22 +303,46 @@ fi
 # dependency legitimately supports older systems than we ship to. Measured on the real bundle:
 # 14 Info.plist files, ours declaring 14.0 and Sparkle's and PostHog's declaring 10.13 and 10.15,
 # so an equality rule applied to all of them would fail on honest dependencies.
+#
+# **TWO keys govern this, not one.** `LSMinimumSystemVersionByArchitecture` carries a per-arch
+# override, so a plist can keep the generic key at the floor and raise the `arm64` entry, which
+# is the only architecture we ship. Checking one key and not the other is how a sweep of a SET
+# misses a member. Neither key's arm64 entry appears anywhere in this repo or in any of the 14
+# plists in the built bundle today, so this is a guard against a future edit rather than a live
+# defect — and whether Launch Services honours an arm64 entry is NOT established here, only that
+# covering it costs one more read.
+assert_ls_min() { # <label> <value> <is-main:0|1>; returns 1 if the value is unacceptable
+  local label="$1" value="$2" is_main="$3"
+  if [ "$is_main" -eq 1 ]; then
+    if [ "$value" != "$DECLARED" ]; then
+      echo "    $label is $value but the declared floor is $DECLARED. Launch Services would refuse to start the app for supported users, or advertise support this build does not provide" >&2
+      return 1
+    fi
+  elif [ "$value" != "$DECLARED" ] &&
+       [ "$(printf '%s\n%s\n' "$value" "$DECLARED" | sort -V | tail -1)" = "$value" ]; then
+    echo "    $label is $value, above the declared floor $DECLARED" >&2
+    return 1
+  fi
+  return 0
+}
+
 if [ "$IS_BUNDLE" -eq 1 ]; then
   main_plist_seen=0
   while IFS= read -r plist; do
     [ -n "$plist" ] || continue
+    rel="${plist#"$TARGET"/}"
+    is_main=0
+    [ "$plist" = "$TARGET/Contents/Info.plist" ] && is_main=1
+
     lsmin=$(/usr/libexec/PlistBuddy -c "Print :LSMinimumSystemVersion" "$plist" 2>/dev/null)
-    [ -n "$lsmin" ] || continue
-    if [ "$plist" = "$TARGET/Contents/Info.plist" ]; then
-      main_plist_seen=1
-      if [ "$lsmin" != "$DECLARED" ]; then
-        echo "    Contents/Info.plist: LSMinimumSystemVersion is $lsmin but the declared floor is $DECLARED. Launch Services would refuse to start the app for supported users, or advertise support this build does not provide" >&2
-        status=1
-      fi
-    elif [ "$lsmin" != "$DECLARED" ] &&
-         [ "$(printf '%s\n%s\n' "$lsmin" "$DECLARED" | sort -V | tail -1)" = "$lsmin" ]; then
-      echo "    ${plist#"$TARGET"/}: LSMinimumSystemVersion is $lsmin, above the declared floor $DECLARED" >&2
-      status=1
+    if [ -n "$lsmin" ]; then
+      [ "$is_main" -eq 1 ] && main_plist_seen=1
+      assert_ls_min "$rel: LSMinimumSystemVersion" "$lsmin" "$is_main" || status=1
+    fi
+
+    lsarm=$(/usr/libexec/PlistBuddy -c "Print :LSMinimumSystemVersionByArchitecture:arm64" "$plist" 2>/dev/null)
+    if [ -n "$lsarm" ]; then
+      assert_ls_min "$rel: LSMinimumSystemVersionByArchitecture:arm64" "$lsarm" "$is_main" || status=1
     fi
   done <<EOF
 $(find "$TARGET" -name "Info.plist" 2>/dev/null)
@@ -336,6 +360,7 @@ fi
 #     fail every honest dependency. The main executable above is what carries the
 #     something-was-inspected requirement.
 embedded_count=0
+embedded_arm64_count=0
 if [ -n "$EMBEDDED" ]; then
   while IFS= read -r extra; do
     [ -n "$extra" ] || continue
@@ -366,6 +391,11 @@ if [ -n "$EMBEDDED" ]; then
       echo "    $(basename "$extra"): no arm64 slice ($extra_archs); not checked"
       continue ;;
     esac
+    # Counted AFTER the architecture skip, because the file counted above may never be inspected.
+    # `embedded_count` alone was satisfied by a file this loop then skipped, so a bundle whose
+    # embedded binaries were all x86_64-only would satisfy the assertion below having inspected
+    # nothing for the architecture we actually ship.
+    embedded_arm64_count=$((embedded_arm64_count + 1))
 
     # Read the load commands ONCE and derive both answers from that single output, so the load
     # list and the deployment target can never come from two different reads of the same file.
@@ -462,7 +492,7 @@ if [ -n "$EMBEDDED" ]; then
   done <<EOF
 $EMBEDDED
 EOF
-  echo "    embedded Mach-O files scanned: $embedded_count (none may reference a baseline-absent framework strongly)"
+  echo "    embedded Mach-O files found: $embedded_count, of which arm64 and inspected: $embedded_arm64_count"
 fi
 
 # **A bundle that yielded no embedded Mach-O is a broken enumeration, not a clean bundle.**
@@ -472,8 +502,8 @@ fi
 # `Contents/Frameworks` and `Contents/XPCServices/EnviousWisprASRService.xpc`, both of which
 # contain Mach-O, so zero cannot be an honest answer for this product. Bundle mode only; a
 # plain file legitimately has nothing embedded, which is the self-test's contract.
-if [ "$IS_BUNDLE" -eq 1 ] && [ "$embedded_count" -eq 0 ]; then
-  die "no embedded Mach-O file was inspected in $TARGET. This app ships frameworks and an XPC service, so an empty enumeration means the scan broke, not that the bundle is clean" 2
+if [ "$IS_BUNDLE" -eq 1 ] && [ "$embedded_arm64_count" -eq 0 ]; then
+  die "no embedded arm64 Mach-O file was inspected in $TARGET (found $embedded_count Mach-O in total). This app ships arm64 frameworks and an arm64 XPC service, so nothing inspected means the scan broke or the bundle is built for the wrong architecture, not that it is clean" 2
 fi
 
 if [ "$status" -ne 0 ]; then

--- a/scripts/ci/check-weak-linked-symbols.sh
+++ b/scripts/ci/check-weak-linked-symbols.sh
@@ -36,7 +36,26 @@ ABSENT_AT_BASELINE_FRAMEWORKS="FoundationModels"
 # (2) Types that are newer than the deployment target inside a framework that IS present. Only
 #     these symbols must be weak; the framework's load command and its baseline-era symbols are
 #     none of this guard's business. Matched against the mangled name, which carries the type.
-NEWER_SYMBOL_PATTERNS="SpeechAnalyzer DictationTranscriber AssetInventory"
+#
+# **The list must cover every post-baseline type the app actually imports.** Three of these were
+# watched and four were not, so a strong binding on `AnalyzerInput`, `SpeechModule`,
+# `SpeechModuleResult` or `AssetInstallationRequest` would have aborted dyld on macOS 14 with
+# this gate green. Measured on the current binary (demangled undefined symbols, weak/strong):
+#
+#     SpeechAnalyzer 15/0 strong      AnalyzerInput             5/0 strong
+#     DictationTranscriber 18/0       SpeechModule              9/0 strong
+#     AssetInventory 10/0             SpeechModuleResult        2/0 strong
+#                                     AssetInstallationRequest  4/0 strong
+#
+# `SpeechDetector` and `SpeechTranscriber` are deliberately ABSENT: they match zero symbols here,
+# and a pattern matching nothing is fatal by design further down, so adding them on the guess that
+# we might use them later would break the build today.
+#
+# Maintenance hazard, stated rather than assumed away: this list is hand-maintained, so adopting a
+# further macOS 26 Speech type without adding it here reopens exactly the gap this line closes.
+# Nothing detects that automatically; the check is to re-run the measurement above when the Speech
+# usage changes.
+NEWER_SYMBOL_PATTERNS="SpeechAnalyzer DictationTranscriber AssetInventory AnalyzerInput SpeechModule SpeechModuleResult AssetInstallationRequest"
 
 # A framework we link normally. Its symbols MUST come back strong. This is the instrument's
 # own control: if it ever reports weak, `nm` output has changed shape and every "0 strong

--- a/scripts/ci/check-weak-linked-symbols.sh
+++ b/scripts/ci/check-weak-linked-symbols.sh
@@ -258,6 +258,34 @@ if [ -n "$EMBEDDED" ]; then
     extra_loads=$(otool -l "$extra" 2>/dev/null |
       awk '/^ *cmd LC_LOAD(_WEAK)?_DYLIB/{c=$2} /^ *name /{if(c!=""){print c, $2; c=""}}')
     extra_syms=$(nm -m -u "$extra" 2>/dev/null)
+
+    # **Its own deployment target, which the main executable's says nothing about.** A dependency
+    # rebuilt for macOS 15 refuses to load on 14 and takes the app down with it. NOT required to
+    # EQUAL the floor the way the main binary is: an embedded framework may legitimately target
+    # something older. It may only not exceed it.
+    extra_minos=$(otool -l "$extra" 2>/dev/null | awk '/LC_BUILD_VERSION/{f=1} f&&/minos/{print $2; exit}')
+    if [ -n "$extra_minos" ] && [ "$extra_minos" != "$DECLARED" ]; then
+      if [ "$(printf '%s\n%s\n' "$extra_minos" "$DECLARED" | sort -V | tail -1)" = "$extra_minos" ]; then
+        echo "    $(basename "$extra"): targets macOS $extra_minos, above the declared floor $DECLARED — it will not load for supported users" >&2
+        status=1
+      fi
+    fi
+
+    # **The newer-symbol patterns apply here too.** Checking embedded files only against the
+    # absent-at-baseline frameworks left the other half unguarded: an embedded framework that
+    # strongly imports SpeechAnalyzer aborts dyld on macOS 14 while the main executable passes.
+    extra_readable=$(printf '%s\n' "$extra_syms" | xcrun swift-demangle 2>/dev/null)
+    [ -n "$extra_readable" ] || extra_readable="$extra_syms"
+    for pattern in $NEWER_SYMBOL_PATTERNS; do
+      extra_hits=$(printf '%s\n' "$extra_readable" | /usr/bin/grep -c "$pattern")
+      [ "$extra_hits" -eq 0 ] && continue
+      extra_pattern_strong=$(printf '%s\n' "$extra_readable" | /usr/bin/grep "$pattern" | /usr/bin/grep -vc 'weak external')
+      if [ "$extra_pattern_strong" -ne 0 ]; then
+        echo "    $(basename "$extra"): $extra_pattern_strong strong $pattern symbols" >&2
+        status=1
+      fi
+    done
+
     for fw in $ABSENT_AT_BASELINE_FRAMEWORKS; do
       extra_load=$(printf '%s\n' "$extra_loads" | awk -v f="/$fw.framework/" 'index($2, f) {print $1; exit}')
       [ -n "$extra_load" ] || continue

--- a/scripts/ci/check-weak-linked-symbols.sh
+++ b/scripts/ci/check-weak-linked-symbols.sh
@@ -154,6 +154,31 @@ MANIFEST="${EW_PROJECT_MANIFEST:-$REPO_ROOT/Project.swift}"
 DECLARED=$(/usr/bin/grep -oE 'DeploymentTargets = \.macOS\("[0-9]+\.[0-9]+"\)' "$MANIFEST" | /usr/bin/grep -oE '[0-9]+\.[0-9]+' | head -1)
 [ -n "$DECLARED" ] || die "could not parse the declared macOS floor from $MANIFEST; the pattern has drifted and this assertion would silently stop running" 2
 
+# **The version comparator is controlled, like every other instrument in this file.**
+#
+# NOT because `sort -V` is unavailable here. That claim has been raised by review three times and
+# is false: `/usr/bin/sort` is `2.3-Apple (199)` and supports it, and the macOS 14.8.7 runner
+# PROVED it by printing its `RESIDUAL GAP` block, which is reachable only when the comparison
+# reports 14.8.7 > 14.0. Recorded so the fourth reviewer does not have to re-derive it, and so a
+# future reader does not "fix" a working comparison. What WOULD reopen the question: a runner
+# image whose `sort` is not Apple's, or the control below failing.
+#
+# The reason the control exists is the failure MODE that claim describes, which is real whatever
+# its cause. If the comparison could not be performed, the substitution would be empty, the
+# condition would read false, and a version ABOVE the floor would be reported acceptable — a
+# comparison that cannot run answering "fine". That is the same fail-open shape as everything
+# else this script guards, sitting in the guard itself.
+# <candidate> <floor>: true when candidate is strictly newer. One line so the self-test can
+# substitute it wholesale and prove the control below actually fires.
+version_is_above() { [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -1)" = "$1" ] && [ "$1" != "$2" ]; }
+# 14.9 vs 14.10 separates a real version sort from a lexical one: lexically "14.10" sorts first.
+# All three legs are asserted, so a comparator stuck on true or on false is caught either way.
+if ! version_is_above "14.10" "14.9" ||
+   version_is_above "14.9" "14.10" ||
+   version_is_above "14.0" "14.0"; then
+  die "the version comparator is not ordering macOS versions correctly on this machine, so every deployment-target and LSMinimumSystemVersion verdict below would be unreliable" 2
+fi
+
 if [ "$MINOS" != "$DECLARED" ]; then
   die "binary targets macOS $MINOS but $MANIFEST declares $DECLARED. A raised target ships an app that will not launch for supported users, and every weak-linkage check below is relative to the target so it would still pass. Reconcile the two deliberately." 1
 fi
@@ -326,7 +351,7 @@ assert_ls_min() { # <label> <value> <is-main:0|1>; returns 1 if the value is una
       return 1
     fi
   elif [ "$value" != "$DECLARED" ] &&
-       [ "$(printf '%s\n%s\n' "$value" "$DECLARED" | sort -V | tail -1)" = "$value" ]; then
+       version_is_above "$value" "$DECLARED"; then
     echo "    $label is $value, above the declared floor $DECLARED" >&2
     return 1
   fi
@@ -450,7 +475,7 @@ if [ -n "$EMBEDDED" ]; then
       echo "    $(basename "$extra"): records no deployment target (neither LC_BUILD_VERSION nor LC_VERSION_MIN_MACOSX), so it cannot be certified to load on macOS $DECLARED" >&2
       status=1
     elif [ "$extra_minos" != "$DECLARED" ]; then
-      if [ "$(printf '%s\n%s\n' "$extra_minos" "$DECLARED" | sort -V | tail -1)" = "$extra_minos" ]; then
+      if version_is_above "$extra_minos" "$DECLARED"; then
         echo "    $(basename "$extra"): targets macOS $extra_minos, above the declared floor $DECLARED — it will not load for supported users" >&2
         status=1
       fi

--- a/scripts/ci/check-weak-linked-symbols.sh
+++ b/scripts/ci/check-weak-linked-symbols.sh
@@ -76,7 +76,9 @@ case "$TARGET" in
     # This bundle also carries a Mach-O under `Contents/Resources`, which a
     # Frameworks-plus-XPCServices list would have missed in turn. Enumerating every Mach-O under
     # Contents is exhaustive by construction, so no future directory can be forgotten.
-    EMBEDDED=$(find "$TARGET/Contents" -type f -perm +111 2>/dev/null | while read -r f; do
+    # Identified by CONTENT, never by the executable bit: a mode-0644 dylib is still loadable by
+    # dyld, so `-perm +111` would skip one silently. 136 files here, 0.08s to classify them all.
+    EMBEDDED=$(find "$TARGET/Contents" -type f 2>/dev/null | while read -r f; do
       [ "$f" = "$BIN" ] && continue
       file "$f" 2>/dev/null | /usr/bin/grep -q "Mach-O" && echo "$f"
     done)
@@ -266,15 +268,25 @@ if [ -n "$EMBEDDED" ]; then
   while IFS= read -r extra; do
     [ -n "$extra" ] || continue
     embedded_count=$((embedded_count + 1))
-    extra_loads=$(otool -l "$extra" 2>/dev/null |
+    # **The arm64 slice specifically.** Every Sparkle binary here is universal, and an
+    # unqualified otool/nm reports every slice at once: `awk ... exit` then takes whichever load
+    # command appears first, which may be the x86_64 one. We ship arm64 only, so an x86_64 slice
+    # targeting macOS 11 must never vouch for an arm64 slice targeting 15. Measured on this
+    # bundle: Sparkle's x86_64 slice carries no LC_BUILD_VERSION at all, so the unqualified read
+    # landed on arm64 by luck rather than by design.
+    if ! lipo -archs "$extra" 2>/dev/null | /usr/bin/grep -q arm64; then
+      echo "    $(basename "$extra"): no arm64 slice ($(lipo -archs "$extra" 2>/dev/null)); not checked"
+      continue
+    fi
+    extra_loads=$(otool -arch arm64 -l "$extra" 2>/dev/null |
       awk '/^ *cmd LC_LOAD(_WEAK)?_DYLIB/{c=$2} /^ *name /{if(c!=""){print c, $2; c=""}}')
-    extra_syms=$(nm -m -u "$extra" 2>/dev/null)
+    extra_syms=$(nm -arch arm64 -m -u "$extra" 2>/dev/null)
 
     # **Its own deployment target, which the main executable's says nothing about.** A dependency
     # rebuilt for macOS 15 refuses to load on 14 and takes the app down with it. NOT required to
     # EQUAL the floor the way the main binary is: an embedded framework may legitimately target
     # something older. It may only not exceed it.
-    extra_minos=$(otool -l "$extra" 2>/dev/null | awk '/LC_BUILD_VERSION/{f=1} f&&/minos/{print $2; exit}')
+    extra_minos=$(otool -arch arm64 -l "$extra" 2>/dev/null | awk '/LC_BUILD_VERSION/{f=1} f&&/minos/{print $2; exit}')
     if [ -n "$extra_minos" ] && [ "$extra_minos" != "$DECLARED" ]; then
       if [ "$(printf '%s\n%s\n' "$extra_minos" "$DECLARED" | sort -V | tail -1)" = "$extra_minos" ]; then
         echo "    $(basename "$extra"): targets macOS $extra_minos, above the declared floor $DECLARED — it will not load for supported users" >&2

--- a/scripts/ci/check-weak-linked-symbols.sh
+++ b/scripts/ci/check-weak-linked-symbols.sh
@@ -57,8 +57,10 @@ command -v otool >/dev/null 2>&1 || die "otool not available" 2
 # introduce exactly that without the required gate noticing. Given a .app, every startup-loaded
 # Mach-O is inspected; given a plain file, only that file, which keeps the self-test's contract.
 EMBEDDED=""
+IS_BUNDLE=0
 case "$TARGET" in
   *.app)
+    IS_BUNDLE=1
     [ -d "$TARGET" ] || die "bundle not found: $TARGET" 2
     MAIN_NAME=$(/usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "$TARGET/Contents/Info.plist" 2>/dev/null)
     [ -n "$MAIN_NAME" ] || die "no CFBundleExecutable in $TARGET/Contents/Info.plist; cannot identify the main binary" 2
@@ -82,7 +84,10 @@ case "$TARGET" in
       [ "$f" = "$BIN" ] && continue
       # Substring test via parameter expansion: no `grep -q` (pipefail/EPIPE) and no `case`
       # pattern, whose closing paren bash mis-parses inside a $( ) command substitution.
-      desc=$(file "$f" 2>/dev/null)
+      # A `file` that FAILS means this path could not be classified, which is not the same as
+      # "not a Mach-O". Included rather than dropped, so an unreadable file surfaces downstream
+      # as a binary the tools cannot inspect instead of vanishing from the enumeration.
+      desc=$(file "$f" 2>/dev/null) || desc="Mach-O unclassifiable"
       [ "${desc#*Mach-O}" != "$desc" ] && echo "$f"
     done)
     ;;
@@ -276,8 +281,8 @@ fi
 #     referenced: an embedded framework has no obligation to use them, so requiring a match would
 #     fail every honest dependency. The main executable above is what carries the
 #     something-was-inspected requirement.
+embedded_count=0
 if [ -n "$EMBEDDED" ]; then
-  embedded_count=0
   while IFS= read -r extra; do
     [ -n "$extra" ] || continue
     embedded_count=$((embedded_count + 1))
@@ -287,20 +292,47 @@ if [ -n "$EMBEDDED" ]; then
     # targeting macOS 11 must never vouch for an arm64 slice targeting 15. Measured on this
     # bundle: Sparkle's x86_64 slice carries no LC_BUILD_VERSION at all, so the unqualified read
     # landed on arm64 by luck rather than by design.
-    extra_archs=$(lipo -archs "$extra" 2>/dev/null)
+    # **Every read here FAILS CLOSED, the way the main binary's reads already do.**
+    #
+    # This loop used to swallow the exit status of `lipo`, `otool` and `nm` and keep whatever
+    # they left behind, which was the empty string. Empty output then passes every test below:
+    # no architectures reads as "no arm64 slice, skip", no load commands reads as "does not
+    # reference the framework, skip", and no symbols makes every `grep -c` return zero, which
+    # is spelled exactly like "inspected and clean". So a binary this script could not read at
+    # all contributed a silent PASS to a REQUIRED gate.
+    #
+    # The main-executable path above already dies on each of these. The asymmetry was the bug:
+    # the same failure was fatal for one file and invisible for the next one along.
+    if ! extra_archs=$(lipo -archs "$extra" 2>&1); then
+      echo "    $(basename "$extra"): lipo could not read its architectures ($extra_archs); refusing to certify a binary this script cannot inspect" >&2
+      status=1
+      continue
+    fi
     case " $extra_archs " in *" arm64 "*) ;; *)
       echo "    $(basename "$extra"): no arm64 slice ($extra_archs); not checked"
       continue ;;
     esac
-    extra_loads=$(otool -arch arm64 -l "$extra" 2>/dev/null |
+
+    # Read the load commands ONCE and derive both answers from that single output, so the load
+    # list and the deployment target can never come from two different reads of the same file.
+    if ! extra_otool=$(otool -arch arm64 -l "$extra" 2>&1); then
+      echo "    $(basename "$extra"): otool could not read its load commands ($extra_otool); refusing to certify a binary this script cannot inspect" >&2
+      status=1
+      continue
+    fi
+    extra_loads=$(printf '%s\n' "$extra_otool" |
       awk '/^ *cmd LC_[A-Z_]*DYLIB/ && $2 != "LC_ID_DYLIB" {c=$2} /^ *name /{if(c!=""){print c, $2; c=""}}')
-    extra_syms=$(nm -arch arm64 -m -u "$extra" 2>/dev/null)
+    if ! extra_syms=$(nm -arch arm64 -m -u "$extra" 2>&1); then
+      echo "    $(basename "$extra"): nm could not read its undefined symbols ($extra_syms); every symbol verdict below would be vacuously clean" >&2
+      status=1
+      continue
+    fi
 
     # **Its own deployment target, which the main executable's says nothing about.** A dependency
     # rebuilt for macOS 15 refuses to load on 14 and takes the app down with it. NOT required to
     # EQUAL the floor the way the main binary is: an embedded framework may legitimately target
     # something older. It may only not exceed it.
-    extra_minos=$(otool -arch arm64 -l "$extra" 2>/dev/null | awk '/LC_BUILD_VERSION/{f=1} f&&/minos/{print $2; exit}')
+    extra_minos=$(printf '%s\n' "$extra_otool" | awk '/LC_BUILD_VERSION/{f=1} f&&/minos/{print $2; exit}')
     if [ -n "$extra_minos" ] && [ "$extra_minos" != "$DECLARED" ]; then
       if [ "$(printf '%s\n%s\n' "$extra_minos" "$DECLARED" | sort -V | tail -1)" = "$extra_minos" ]; then
         echo "    $(basename "$extra"): targets macOS $extra_minos, above the declared floor $DECLARED — it will not load for supported users" >&2
@@ -311,8 +343,24 @@ if [ -n "$EMBEDDED" ]; then
     # **The newer-symbol patterns apply here too.** Checking embedded files only against the
     # absent-at-baseline frameworks left the other half unguarded: an embedded framework that
     # strongly imports SpeechAnalyzer aborts dyld on macOS 14 while the main executable passes.
-    extra_readable=$(printf '%s\n' "$extra_syms" | xcrun swift-demangle 2>/dev/null)
-    [ -n "$extra_readable" ] || extra_readable="$extra_syms"
+    # Demangled, for the reason the main binary is: `Speech.SpeechAnalyzer` is spelled
+    # `_$s6Speech0A8AnalyzerC…`, so a literal pattern matches nothing against raw symbols.
+    # The old silent fallback to raw output here reproduced, for embedded files, exactly the
+    # false pass the main path now dies on.
+    if [ -n "$extra_syms" ]; then
+      extra_readable=$(printf '%s\n' "$extra_syms" | xcrun swift-demangle 2>/dev/null)
+      if [ -z "$extra_readable" ]; then
+        echo "    $(basename "$extra"): swift-demangle produced nothing from its symbols; type-name patterns would silently miss every match" >&2
+        status=1
+        continue
+      fi
+    else
+      # nm succeeded and reported nothing. Legitimate for a binary that imports nothing, but it
+      # makes every symbol verdict below vacuous, so it is stated rather than left to look like
+      # a clean inspection.
+      echo "    $(basename "$extra"): no undefined symbols; the symbol checks below inspect nothing for this file"
+      extra_readable=""
+    fi
     for pattern in $NEWER_SYMBOL_PATTERNS; do
       extra_hits=$(printf '%s\n' "$extra_readable" | /usr/bin/grep -c "$pattern")
       [ "$extra_hits" -eq 0 ] && continue
@@ -340,6 +388,17 @@ if [ -n "$EMBEDDED" ]; then
 $EMBEDDED
 EOF
   echo "    embedded Mach-O files scanned: $embedded_count (none may reference a baseline-absent framework strongly)"
+fi
+
+# **A bundle that yielded no embedded Mach-O is a broken enumeration, not a clean bundle.**
+#
+# The count above was printed and never asserted, so `find` or `file` failing — or the layout
+# moving under a future Xcode — would report "scanned: 0" and pass. This bundle ships
+# `Contents/Frameworks` and `Contents/XPCServices/EnviousWisprASRService.xpc`, both of which
+# contain Mach-O, so zero cannot be an honest answer for this product. Bundle mode only; a
+# plain file legitimately has nothing embedded, which is the self-test's contract.
+if [ "$IS_BUNDLE" -eq 1 ] && [ "$embedded_count" -eq 0 ]; then
+  die "no embedded Mach-O file was inspected in $TARGET. This app ships frameworks and an XPC service, so an empty enumeration means the scan broke, not that the bundle is clean" 2
 fi
 
 if [ "$status" -ne 0 ]; then

--- a/scripts/ci/check-weak-linked-symbols.sh
+++ b/scripts/ci/check-weak-linked-symbols.sh
@@ -18,9 +18,25 @@ set -uo pipefail
 
 BIN="${1:-}"
 
-# Frameworks whose APIs we use above the deployment target. Adding an API from a new framework
-# means adding it here; the self-test below fails loudly if this list stops matching reality.
-GUARDED_FRAMEWORKS="Speech FoundationModels"
+# **Two different rules, because two different things can be missing.** Collapsing them into one
+# list produced a false positive that would have failed honest work: review round 4 pointed out
+# that `SFSpeechRecognizer` has existed since macOS 10.15, so adding it would legitimately emit a
+# strong symbol and flip Speech to LC_LOAD_DYLIB — and the guard would have called that a
+# compatibility defect. A guard that fires on safe code is how guards get bypassed.
+#
+# Verified with `swiftc -target arm64-apple-macos14.0 -typecheck` on 2026-08-16:
+#   SFSpeechRecognizer     compiles clean       -> Speech itself is present at the baseline
+#   SystemLanguageModel    "only available in macOS 26.0 or newer"
+
+# (1) Frameworks that do not EXIST at the deployment target. A strong load of one of these kills
+#     the process before any symbol is resolved, so both the load command and every symbol must
+#     be weak. Add a framework here only if the framework itself is absent on macOS 14.
+ABSENT_AT_BASELINE_FRAMEWORKS="FoundationModels"
+
+# (2) Types that are newer than the deployment target inside a framework that IS present. Only
+#     these symbols must be weak; the framework's load command and its baseline-era symbols are
+#     none of this guard's business. Matched against the mangled name, which carries the type.
+NEWER_SYMBOL_PATTERNS="SpeechAnalyzer DictationTranscriber AssetInventory"
 
 # A framework we link normally. Its symbols MUST come back strong. This is the instrument's
 # own control: if it ever reports weak, `nm` output has changed shape and every "0 strong
@@ -86,25 +102,24 @@ echo "==> control ok:        $CONTROL_FRAMEWORK loads as LC_LOAD_DYLIB (parser d
 # --- The actual assertion ------------------------------------------------------------------
 status=0
 checked=0
-for fw in $GUARDED_FRAMEWORKS; do
+# (1) Frameworks absent at the baseline: both the load command and every symbol must be weak.
+for fw in $ABSENT_AT_BASELINE_FRAMEWORKS; do
   total=$(count_for "$fw")
   load=$(load_command_for "$fw")
 
-  # **The load command is checked FIRST, and for every guarded framework.** An earlier version
-  # skipped a framework contributing no symbols, which would have waved through the worst case
-  # available: a framework reached only through the ObjC runtime, strongly loaded, absent on the
-  # older OS. Zero symbols is the state in which the load command matters MOST, not least.
+  # **The load command is checked FIRST, and whether or not the framework contributed symbols.**
+  # An earlier version skipped a framework with no symbols, which would have waved through the
+  # worst case available: one reached only through the ObjC runtime, strongly loaded, absent on
+  # the older OS. Zero symbols is when the load command matters MOST, not least.
   if [ -n "$load" ]; then
     checked=$((checked + 1))
     if [ "$load" != "LC_LOAD_WEAK_DYLIB" ]; then
-      echo "    $fw: loaded as $load, must be LC_LOAD_WEAK_DYLIB" >&2
+      echo "    $fw: loaded as $load, must be LC_LOAD_WEAK_DYLIB (framework absent below the baseline)" >&2
       status=1
     fi
   fi
 
   if [ "$total" -eq 0 ]; then
-    # Not an error on its own: a framework can legitimately go unused. Said out loud, so a
-    # silently-dropped dependency is visible rather than passing as "nothing strong found".
     if [ -n "$load" ]; then
       echo "    $fw: no symbols in this binary, loaded as $load"
     else
@@ -124,8 +139,40 @@ for fw in $GUARDED_FRAMEWORKS; do
   fi
 done
 
+# (2) Newer types inside frameworks that DO exist at the baseline. Only these symbols are
+#     constrained; the framework's load command and its baseline-era symbols are left alone, so
+#     adding an API that macOS 14 already has does not trip this guard.
+matched_patterns=0
+for pattern in $NEWER_SYMBOL_PATTERNS; do
+  hits=$(printf '%s\n' "$SYMS" | /usr/bin/grep -c "$pattern")
+  if [ "$hits" -eq 0 ]; then
+    # Said out loud rather than skipped in silence. A pattern matching nothing is either a type
+    # the app no longer uses or one that has been renamed, and the second case is a guard that
+    # has quietly stopped watching something. Not fatal on its own — the list as a whole still
+    # has to match something — but never invisible.
+    echo "    $pattern: no symbols (type unused here, or renamed)"
+    continue
+  fi
+  matched_patterns=$((matched_patterns + 1))
+  checked=$((checked + 1))
+  strong=$(printf '%s\n' "$SYMS" | /usr/bin/grep "$pattern" | /usr/bin/grep -vc 'weak external')
+  if [ "$strong" -ne 0 ]; then
+    echo "    $pattern: $strong of $hits symbols are STRONGLY bound" >&2
+    printf '%s\n' "$SYMS" | /usr/bin/grep "$pattern" | /usr/bin/grep -v 'weak external' | sed 's/^/      /' >&2
+    status=1
+  else
+    echo "    $pattern: all $hits symbols weak ✓"
+  fi
+done
+
+# A pattern list that matches nothing has gone stale — the types were renamed, or the app
+# stopped using them — and would report a confident pass having inspected nothing.
+if [ "$matched_patterns" -eq 0 ]; then
+  die "none of the newer-symbol patterns ($NEWER_SYMBOL_PATTERNS) matched anything in this binary. Either the wrong binary was passed, or these types were renamed and this half of the guard is now checking nothing" 2
+fi
+
 if [ "$checked" -eq 0 ]; then
-  die "none of the guarded frameworks ($GUARDED_FRAMEWORKS) appear in this binary. Either the wrong binary was passed, or the app stopped using them and this guard is now checking nothing" 2
+  die "nothing was inspected: neither the absent-at-baseline frameworks ($ABSENT_AT_BASELINE_FRAMEWORKS) nor the newer-symbol patterns appear in this binary" 2
 fi
 
 if [ "$status" -ne 0 ]; then
@@ -140,4 +187,4 @@ if [ "$status" -ne 0 ]; then
   exit 1
 fi
 
-echo "==> PASS: every guarded framework is weakly loaded and fully weak-bound."
+echo "==> PASS: baseline-absent frameworks load weakly, and every newer-than-baseline symbol is weak."

--- a/scripts/ci/check-weak-linked-symbols.sh
+++ b/scripts/ci/check-weak-linked-symbols.sh
@@ -175,8 +175,19 @@ count_strong_for() {
 # the two failures — and it is invisible to `nm`, since symbol annotations and load commands
 # are set independently (manual linker flags, or a post-link edit, can move one without the
 # other). Review round 3 found this gap; the earlier version checked only symbols.
-LOADS=$(otool -l "$BIN" 2>/dev/null |
-  awk '/^ *cmd LC_[A-Z_]*DYLIB/ && $2 != "LC_ID_DYLIB" {c=$2} /^ *name /{if(c!=""){print c, $2; c=""}}')
+# One parser, used for the main binary and for every embedded one. It was duplicated verbatim,
+# which is how the two halves of this script drifted apart in the first place: a rule tightened
+# in one copy and not the other reads as a rule that applies everywhere.
+#
+# Emits "<load-command> <path>" per linked dylib. LC_ID_DYLIB is excluded because it is the
+# library's own install name, not a dependency; LC_REEXPORT_DYLIB is deliberately included,
+# since re-exporting is as strong a load as any.
+dylib_loads_from() {
+  printf '%s\n' "$1" |
+    awk '/^ *cmd LC_[A-Z_]*DYLIB/ && $2 != "LC_ID_DYLIB" {c=$2} /^ *name /{if(c!=""){print c, $2; c=""}}'
+}
+
+LOADS=$(dylib_loads_from "$(otool -l "$BIN" 2>/dev/null)")
 
 load_command_for() {
   printf '%s\n' "$LOADS" | awk -v fw="/$1.framework/" 'index($2, fw) {print $1; exit}'
@@ -320,8 +331,14 @@ if [ -n "$EMBEDDED" ]; then
       status=1
       continue
     fi
-    extra_loads=$(printf '%s\n' "$extra_otool" |
-      awk '/^ *cmd LC_[A-Z_]*DYLIB/ && $2 != "LC_ID_DYLIB" {c=$2} /^ *name /{if(c!=""){print c, $2; c=""}}')
+    extra_loads=$(dylib_loads_from "$extra_otool")
+    # A Mach-O that links nothing would make every framework check below skip silently. Measured:
+    # all 9 arm64 embedded Mach-O files in the real bundle report between 1 and 63 load commands,
+    # so an empty list means the parse stopped working, not that the binary is self-contained.
+    if [ -z "$extra_loads" ]; then
+      echo "    $(basename "$extra"): no dynamic library load commands were parsed, so the framework checks below would inspect nothing" >&2
+      status=1
+    fi
     if ! extra_syms=$(nm -arch arm64 -m -u "$extra" 2>&1); then
       echo "    $(basename "$extra"): nm could not read its undefined symbols ($extra_syms); every symbol verdict below would be vacuously clean" >&2
       status=1

--- a/scripts/ci/check-weak-linked-symbols.sh
+++ b/scripts/ci/check-weak-linked-symbols.sh
@@ -332,8 +332,23 @@ if [ -n "$EMBEDDED" ]; then
     # rebuilt for macOS 15 refuses to load on 14 and takes the app down with it. NOT required to
     # EQUAL the floor the way the main binary is: an embedded framework may legitimately target
     # something older. It may only not exceed it.
+    #
+    # **An unreadable target is not a passing target.** `[ -n "$extra_minos" ] && ...` skipped the
+    # whole assertion whenever the version could not be read, so a binary requiring macOS 15 got
+    # certified for 14 by virtue of not saying what it required — the same fail-open shape as the
+    # reads above, one level in.
     extra_minos=$(printf '%s\n' "$extra_otool" | awk '/LC_BUILD_VERSION/{f=1} f&&/minos/{print $2; exit}')
-    if [ -n "$extra_minos" ] && [ "$extra_minos" != "$DECLARED" ]; then
+    if [ -z "$extra_minos" ]; then
+      # Binaries predating LC_BUILD_VERSION record the floor as LC_VERSION_MIN_MACOSX instead.
+      # Measured on the real bundle: all 9 arm64 embedded Mach-O files use LC_BUILD_VERSION and
+      # none uses the legacy command, so this is future-proofing rather than a live path — which
+      # is also why failing closed below costs nothing today.
+      extra_minos=$(printf '%s\n' "$extra_otool" | awk '/LC_VERSION_MIN_MACOSX/{f=1} f&&/^ *version /{print $2; exit}')
+    fi
+    if [ -z "$extra_minos" ]; then
+      echo "    $(basename "$extra"): records no deployment target (neither LC_BUILD_VERSION nor LC_VERSION_MIN_MACOSX), so it cannot be certified to load on macOS $DECLARED" >&2
+      status=1
+    elif [ "$extra_minos" != "$DECLARED" ]; then
       if [ "$(printf '%s\n%s\n' "$extra_minos" "$DECLARED" | sort -V | tail -1)" = "$extra_minos" ]; then
         echo "    $(basename "$extra"): targets macOS $extra_minos, above the declared floor $DECLARED — it will not load for supported users" >&2
         status=1

--- a/scripts/ci/check-weak-linked-symbols.sh
+++ b/scripts/ci/check-weak-linked-symbols.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Assert that every symbol we import from a newer-than-deployment-target framework is
+# WEAKLY bound, so the app starts on the oldest macOS we support.
+#
+# The failure this prevents: the app is built against the macOS 26 SDK but ships with a
+# macOS 14 deployment target. A reference to a macOS 26 symbol that is bound STRONGLY makes
+# dyld abort at launch on macOS 14/15 — before any `#available` check in our code can run, so
+# the app never opens and no in-app "needs a newer macOS" message is ever reached. Swift emits
+# weak bindings automatically for correctly `@available`-annotated code; the regression is
+# therefore silent on the machine that builds it, which is always a macOS 26 runner.
+#
+# Usage: check-weak-linked-symbols.sh <path-to-macho-binary>
+#
+# Exit: 0 all guarded frameworks fully weak; 1 a strong binding was found; 2 the check could
+# not be performed (fails closed — a check that cannot measure must never report success).
+
+set -uo pipefail
+
+BIN="${1:-}"
+
+# Frameworks whose APIs we use above the deployment target. Adding an API from a new framework
+# means adding it here; the self-test below fails loudly if this list stops matching reality.
+GUARDED_FRAMEWORKS="Speech FoundationModels"
+
+# A framework we link normally. Its symbols MUST come back strong. This is the instrument's
+# own control: if it ever reports weak, `nm` output has changed shape and every "0 strong
+# symbols" result above is meaningless rather than reassuring.
+CONTROL_FRAMEWORK="AppKit"
+
+die() { echo "FAIL: $1" >&2; exit "${2:-1}"; }
+
+[ -n "$BIN" ] || die "usage: $0 <path-to-macho-binary>" 2
+[ -f "$BIN" ] || die "binary not found: $BIN" 2
+command -v nm >/dev/null 2>&1 || die "nm not available" 2
+command -v otool >/dev/null 2>&1 || die "otool not available" 2
+
+SYMS=$(nm -m -u "$BIN" 2>/dev/null)
+[ -n "$SYMS" ] || die "nm produced no undefined symbols for $BIN — wrong file type, or a stripped or thin binary" 2
+
+# Report the deployment target so a reader can see WHY this check matters for this build.
+MINOS=$(otool -l "$BIN" 2>/dev/null | awk '/LC_BUILD_VERSION/{f=1} f&&/minos/{print $2; exit}')
+echo "==> binary:            $BIN"
+echo "==> deployment target: ${MINOS:-unknown}"
+
+count_for() { printf '%s\n' "$SYMS" | /usr/bin/grep -c "(from $1)"; }
+count_strong_for() {
+  printf '%s\n' "$SYMS" | /usr/bin/grep "(from $1)" | /usr/bin/grep -vc 'weak external'
+}
+
+# --- Instrument control, BEFORE any verdict -----------------------------------------------
+# Runs first so a broken detector can never produce a green run.
+CONTROL_TOTAL=$(count_for "$CONTROL_FRAMEWORK")
+CONTROL_STRONG=$(count_strong_for "$CONTROL_FRAMEWORK")
+if [ "$CONTROL_TOTAL" -eq 0 ]; then
+  die "control framework $CONTROL_FRAMEWORK contributed no symbols; this binary is not the app, or nm output changed" 2
+fi
+if [ "$CONTROL_STRONG" -eq 0 ]; then
+  die "control framework $CONTROL_FRAMEWORK reported ZERO strong symbols. A normally-linked framework must be strong, so this detector cannot tell weak from strong and its results below are meaningless" 2
+fi
+echo "==> control ok:        $CONTROL_FRAMEWORK has $CONTROL_STRONG strong of $CONTROL_TOTAL (detector distinguishes weak from strong)"
+
+# --- The actual assertion ------------------------------------------------------------------
+status=0
+checked=0
+for fw in $GUARDED_FRAMEWORKS; do
+  total=$(count_for "$fw")
+  if [ "$total" -eq 0 ]; then
+    # Not an error on its own: a framework can legitimately go unused. Say so, so that a
+    # silently-dropped dependency is visible rather than passing as "nothing strong found".
+    echo "    $fw: no symbols in this binary (framework unused here)"
+    continue
+  fi
+  checked=$((checked + 1))
+  strong=$(count_strong_for "$fw")
+  if [ "$strong" -ne 0 ]; then
+    echo "    $fw: $strong of $total symbols are STRONGLY bound" >&2
+    printf '%s\n' "$SYMS" | /usr/bin/grep "(from $fw)" | /usr/bin/grep -v 'weak external' | sed 's/^/      /' >&2
+    status=1
+  else
+    echo "    $fw: all $total symbols weak ✓"
+  fi
+done
+
+if [ "$checked" -eq 0 ]; then
+  die "none of the guarded frameworks ($GUARDED_FRAMEWORKS) appear in this binary. Either the wrong binary was passed, or the app stopped using them and this guard is now checking nothing" 2
+fi
+
+if [ "$status" -ne 0 ]; then
+  echo >&2
+  echo "A strongly-bound symbol from a framework we only use above the deployment target means" >&2
+  echo "dyld aborts at launch on older macOS. Annotate the offending code with @available and" >&2
+  echo "guard its uses with #available, which makes Swift emit a weak binding." >&2
+  exit 1
+fi
+
+echo "==> PASS: every guarded framework is fully weak-bound; the app can start below macOS 26."

--- a/scripts/ci/check-weak-linked-symbols.sh
+++ b/scripts/ci/check-weak-linked-symbols.sh
@@ -80,7 +80,10 @@ case "$TARGET" in
     # dyld, so `-perm +111` would skip one silently. 136 files here, 0.08s to classify them all.
     EMBEDDED=$(find "$TARGET/Contents" -type f 2>/dev/null | while read -r f; do
       [ "$f" = "$BIN" ] && continue
-      file "$f" 2>/dev/null | /usr/bin/grep -q "Mach-O" && echo "$f"
+      # Substring test via parameter expansion: no `grep -q` (pipefail/EPIPE) and no `case`
+      # pattern, whose closing paren bash mis-parses inside a $( ) command substitution.
+      desc=$(file "$f" 2>/dev/null)
+      [ "${desc#*Mach-O}" != "$desc" ] && echo "$f"
     done)
     ;;
   *)
@@ -151,6 +154,16 @@ count_strong_for() {
 
 # **The load command matters independently of the symbols.**
 #
+# **Any dylib command except the library's own ID counts as a dependency, and only
+# LC_LOAD_WEAK_DYLIB counts as weak.** Matching just LC_LOAD_DYLIB and LC_LOAD_WEAK_DYLIB ignored
+# LC_REEXPORT_DYLIB entirely — a strong requirement dyld still enforces, so a framework built with
+# `-reexport_framework FoundationModels` would have passed with no direct symbols of its own.
+# Written as "everything except LC_ID_DYLIB" rather than a list of strong forms, so a command type
+# nobody here has seen is treated as strong instead of ignored. LC_ID_DYLIB is excluded because it
+# is the library's OWN install name, not something it depends on; matching it would fail every
+# framework against itself. Forms present in this bundle today: LC_ID_DYLIB, LC_LOAD_DYLIB,
+# LC_LOAD_WEAK_DYLIB.
+#
 # A framework recorded as LC_LOAD_DYLIB is loaded STRONGLY: if it is absent on the running OS,
 # dyld aborts before it resolves a single symbol, so every symbol being weak buys nothing.
 # FoundationModels does not exist at all below macOS 26, which makes this the more severe of
@@ -158,7 +171,7 @@ count_strong_for() {
 # are set independently (manual linker flags, or a post-link edit, can move one without the
 # other). Review round 3 found this gap; the earlier version checked only symbols.
 LOADS=$(otool -l "$BIN" 2>/dev/null |
-  awk '/^ *cmd LC_LOAD(_WEAK)?_DYLIB/{c=$2} /^ *name /{if(c!=""){print c, $2; c=""}}')
+  awk '/^ *cmd LC_[A-Z_]*DYLIB/ && $2 != "LC_ID_DYLIB" {c=$2} /^ *name /{if(c!=""){print c, $2; c=""}}')
 
 load_command_for() {
   printf '%s\n' "$LOADS" | awk -v fw="/$1.framework/" 'index($2, fw) {print $1; exit}'
@@ -274,12 +287,13 @@ if [ -n "$EMBEDDED" ]; then
     # targeting macOS 11 must never vouch for an arm64 slice targeting 15. Measured on this
     # bundle: Sparkle's x86_64 slice carries no LC_BUILD_VERSION at all, so the unqualified read
     # landed on arm64 by luck rather than by design.
-    if ! lipo -archs "$extra" 2>/dev/null | /usr/bin/grep -q arm64; then
-      echo "    $(basename "$extra"): no arm64 slice ($(lipo -archs "$extra" 2>/dev/null)); not checked"
-      continue
-    fi
+    extra_archs=$(lipo -archs "$extra" 2>/dev/null)
+    case " $extra_archs " in *" arm64 "*) ;; *)
+      echo "    $(basename "$extra"): no arm64 slice ($extra_archs); not checked"
+      continue ;;
+    esac
     extra_loads=$(otool -arch arm64 -l "$extra" 2>/dev/null |
-      awk '/^ *cmd LC_LOAD(_WEAK)?_DYLIB/{c=$2} /^ *name /{if(c!=""){print c, $2; c=""}}')
+      awk '/^ *cmd LC_[A-Z_]*DYLIB/ && $2 != "LC_ID_DYLIB" {c=$2} /^ *name /{if(c!=""){print c, $2; c=""}}')
     extra_syms=$(nm -arch arm64 -m -u "$extra" 2>/dev/null)
 
     # **Its own deployment target, which the main executable's says nothing about.** A dependency

--- a/scripts/ci/check-weak-linked-symbols.sh
+++ b/scripts/ci/check-weak-linked-symbols.sh
@@ -288,6 +288,49 @@ if [ "$checked" -eq 0 ]; then
   die "nothing was inspected: neither the absent-at-baseline frameworks ($ABSENT_AT_BASELINE_FRAMEWORKS) nor the newer-symbol patterns appear in this binary" 2
 fi
 
+# (2b) `LSMinimumSystemVersion`, which decides whether the app launches AT ALL.
+#
+# This value is a hardcoded literal in checked-in Info.plist files and is derived from nothing:
+# raising it to 15.0 while the deployment target stays at 14.0 leaves the Mach-O checks above
+# entirely green, because the binary is unchanged. Launch Services reads the plist, not the load
+# command, so Finder and `open` would refuse to start the app for every macOS 14 user while both
+# compatibility checks report success. The launch probe cannot catch it either: it invokes the
+# executable directly, which bypasses Launch Services by construction.
+#
+# The rule mirrors the binary rule exactly, and for the same reasons. The app's OWN plist must
+# EQUAL the declared floor: above it locks out supported users, below it advertises support the
+# build does not provide. Every other plist may only not EXCEED the floor, because a bundled
+# dependency legitimately supports older systems than we ship to. Measured on the real bundle:
+# 14 Info.plist files, ours declaring 14.0 and Sparkle's and PostHog's declaring 10.13 and 10.15,
+# so an equality rule applied to all of them would fail on honest dependencies.
+if [ "$IS_BUNDLE" -eq 1 ]; then
+  main_plist_seen=0
+  while IFS= read -r plist; do
+    [ -n "$plist" ] || continue
+    lsmin=$(/usr/libexec/PlistBuddy -c "Print :LSMinimumSystemVersion" "$plist" 2>/dev/null)
+    [ -n "$lsmin" ] || continue
+    if [ "$plist" = "$TARGET/Contents/Info.plist" ]; then
+      main_plist_seen=1
+      if [ "$lsmin" != "$DECLARED" ]; then
+        echo "    Contents/Info.plist: LSMinimumSystemVersion is $lsmin but the declared floor is $DECLARED. Launch Services would refuse to start the app for supported users, or advertise support this build does not provide" >&2
+        status=1
+      fi
+    elif [ "$lsmin" != "$DECLARED" ] &&
+         [ "$(printf '%s\n%s\n' "$lsmin" "$DECLARED" | sort -V | tail -1)" = "$lsmin" ]; then
+      echo "    ${plist#"$TARGET"/}: LSMinimumSystemVersion is $lsmin, above the declared floor $DECLARED" >&2
+      status=1
+    fi
+  done <<EOF
+$(find "$TARGET" -name "Info.plist" 2>/dev/null)
+EOF
+  # The app's own plist declaring nothing is not a pass: it is the one Launch Services consults,
+  # and a check that never found it has asserted nothing about whether the app can start.
+  if [ "$main_plist_seen" -eq 0 ]; then
+    die "no LSMinimumSystemVersion in $TARGET/Contents/Info.plist. That is the value Launch Services uses to decide whether this app runs, and an absent one cannot be reconciled with the declared floor $DECLARED" 2
+  fi
+  echo "==> LSMinimumSystemVersion: app declares $DECLARED, no bundled plist exceeds it"
+fi
+
 # (3) Embedded Mach-O files. Only the baseline-absent frameworks are checked here, and only IF
 #     referenced: an embedded framework has no obligation to use them, so requiring a match would
 #     fail every honest dependency. The main executable above is what carries the

--- a/scripts/ci/check-weak-linked-symbols.sh
+++ b/scripts/ci/check-weak-linked-symbols.sh
@@ -16,7 +16,7 @@
 
 set -uo pipefail
 
-BIN="${1:-}"
+TARGET="${1:-}"
 
 # **Two different rules, because two different things can be missing.** Collapsing them into one
 # list produced a false positive that would have failed honest work: review round 4 pointed out
@@ -45,10 +45,36 @@ CONTROL_FRAMEWORK="AppKit"
 
 die() { echo "FAIL: $1" >&2; exit "${2:-1}"; }
 
-[ -n "$BIN" ] || die "usage: $0 <path-to-macho-binary>" 2
-[ -f "$BIN" ] || die "binary not found: $BIN" 2
+[ -n "$TARGET" ] || die "usage: $0 <path-to-.app-or-macho-binary>" 2
 command -v nm >/dev/null 2>&1 || die "nm not available" 2
 command -v otool >/dev/null 2>&1 || die "otool not available" 2
+
+# **A bundle is more than its main executable.**
+#
+# dyld loads embedded frameworks at startup, so a strong post-baseline import inside one of them
+# aborts the process just as surely — and none of it appears in the main executable's own
+# symbols. This bundle embeds Sparkle (five Mach-O files today), so a dependency bump could
+# introduce exactly that without the required gate noticing. Given a .app, every startup-loaded
+# Mach-O is inspected; given a plain file, only that file, which keeps the self-test's contract.
+EMBEDDED=""
+case "$TARGET" in
+  *.app)
+    [ -d "$TARGET" ] || die "bundle not found: $TARGET" 2
+    MAIN_NAME=$(/usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "$TARGET/Contents/Info.plist" 2>/dev/null)
+    [ -n "$MAIN_NAME" ] || die "no CFBundleExecutable in $TARGET/Contents/Info.plist; cannot identify the main binary" 2
+    BIN="$TARGET/Contents/MacOS/$MAIN_NAME"
+    [ -f "$BIN" ] || die "main executable not found: $BIN" 2
+    if [ -d "$TARGET/Contents/Frameworks" ]; then
+      EMBEDDED=$(find "$TARGET/Contents/Frameworks" -type f -perm +111 2>/dev/null | while read -r f; do
+        file "$f" 2>/dev/null | /usr/bin/grep -q "Mach-O" && echo "$f"
+      done)
+    fi
+    ;;
+  *)
+    BIN="$TARGET"
+    [ -f "$BIN" ] || die "binary not found: $BIN" 2
+    ;;
+esac
 
 SYMS=$(nm -m -u "$BIN" 2>/dev/null)
 [ -n "$SYMS" ] || die "nm produced no undefined symbols for $BIN — wrong file type, or a stripped or thin binary" 2
@@ -73,7 +99,7 @@ fi
 # path is worse than no guard, and this is the second pipefail trap in this file's history.
 READABLE_SIGNATURES=$(printf '%s\n' "$SYMS_READABLE" | /usr/bin/grep -cE '\.getter|\.setter| -> |\.init\(')
 if [ "$READABLE_SIGNATURES" -eq 0 ]; then
-  die "swift-demangle output contains no recognisably demangled Swift signature; every type-name verdict below would be vacuous" 2
+  die "swift-demangle output contains no recognisably demangled Swift signature; every type-name verdict below would be vacuous. If this is a DEBUG bundle, its Contents/MacOS/<name> is a thin launcher and the code lives in <name>.debug.dylib — pass that file directly. CI passes the Release .app, whose main executable carries the code." 2
 fi
 
 MINOS=$(otool -l "$BIN" 2>/dev/null | awk '/LC_BUILD_VERSION/{f=1} f&&/minos/{print $2; exit}')
@@ -218,6 +244,37 @@ fi
 
 if [ "$checked" -eq 0 ]; then
   die "nothing was inspected: neither the absent-at-baseline frameworks ($ABSENT_AT_BASELINE_FRAMEWORKS) nor the newer-symbol patterns appear in this binary" 2
+fi
+
+# (3) Embedded Mach-O files. Only the baseline-absent frameworks are checked here, and only IF
+#     referenced: an embedded framework has no obligation to use them, so requiring a match would
+#     fail every honest dependency. The main executable above is what carries the
+#     something-was-inspected requirement.
+if [ -n "$EMBEDDED" ]; then
+  embedded_count=0
+  while IFS= read -r extra; do
+    [ -n "$extra" ] || continue
+    embedded_count=$((embedded_count + 1))
+    extra_loads=$(otool -l "$extra" 2>/dev/null |
+      awk '/^ *cmd LC_LOAD(_WEAK)?_DYLIB/{c=$2} /^ *name /{if(c!=""){print c, $2; c=""}}')
+    extra_syms=$(nm -m -u "$extra" 2>/dev/null)
+    for fw in $ABSENT_AT_BASELINE_FRAMEWORKS; do
+      extra_load=$(printf '%s\n' "$extra_loads" | awk -v f="/$fw.framework/" 'index($2, f) {print $1; exit}')
+      [ -n "$extra_load" ] || continue
+      if [ "$extra_load" != "LC_LOAD_WEAK_DYLIB" ]; then
+        echo "    $(basename "$extra"): loads $fw as $extra_load, must be LC_LOAD_WEAK_DYLIB" >&2
+        status=1
+      fi
+      extra_strong=$(printf '%s\n' "$extra_syms" | /usr/bin/grep "(from $fw)" | /usr/bin/grep -vc 'weak external')
+      if [ "$extra_strong" -ne 0 ]; then
+        echo "    $(basename "$extra"): $extra_strong strong $fw symbols" >&2
+        status=1
+      fi
+    done
+  done <<EOF
+$EMBEDDED
+EOF
+  echo "    embedded Mach-O files scanned: $embedded_count (none may reference a baseline-absent framework strongly)"
 fi
 
 if [ "$status" -ne 0 ]; then


### PR DESCRIPTION
Answers a question that turned out to have no coverage at all: does the app still **start** on the oldest macOS we support?

## Why this had no coverage

Every macOS job in this repo runs on `macos-26` — six of them, across `pr-check`, `main-post-merge` and `release`. Nothing has ever built or launched this app on an older OS.

That matters for one specific failure. The app is built against the macOS 26 SDK with a **macOS 14 deployment target**. A reference to a macOS 26 symbol that is bound **strongly** makes dyld abort at *launch* on macOS 14/15 — before any `#available` check of ours runs. The user never sees the in-app "needs a newer macOS" message, because the app never opens.

Swift emits weak bindings automatically for correctly `@available`-annotated code, which is exactly what makes the regression dangerous: it is invisible on every machine we build on.

## Current state (measured, not assumed)

Release build, as measured by this workflow's own run:

| framework | symbols | strongly bound |
|---|---|---|
| Speech | 50 | 0 |
| FoundationModels | 59 | 0 |
| **AppKit (control)** | **48** | **48** |

(The debug build reports 65 for FoundationModels rather than 59. Symbol counts vary by build configuration, which is why the guard asserts the *ratio* — zero strong — and never a fixed count.)

The control row is the point. A detector that reports "no strong symbols" is indistinguishable from a broken detector until you show it can see a strong symbol.

## Three defences, in order of how much they actually guarantee

Review made this ordering explicit, and it demoted the thing this PR started out as.

**1. The Swift compiler — the real guarantee, already running on every build.** Using an API newer than the macOS 14.0 deployment target without an `@available` annotation is a compile *error*, for every framework, at minor-version precision. Measured rather than assumed:

```
$ xcrun swiftc -target arm64-apple-macos14.0 -typecheck ...
error: 'DictationTranscriber' is only available in macOS 26.0 or newer
error: 'addedIn14_1()' is only available in macOS 14.1 or newer
```

**2. `scripts/ci/check-weak-linked-symbols.sh` — narrow, and worth having anyway.** It covers only the frameworks it names, and catches the *linkage* consequence of paths the compiler does not see (ObjC interop, manual linkage). Seconds, on the machine that already builds.

**3. The launch on `macos-14` — corroboration, with a stated gap.** Verified to run on `macos-14-arm64`; the script asserts the architecture, because a launch on x86_64 would either fail for unrelated reasons or pass under Rosetta and certify a configuration no user runs. The image is 14.8.7 while the app targets 14.0, and GitHub publishes no 14.0 image, so this run cannot cover 14.0 through 14.8. It prints that range explicitly rather than letting a green tick imply otherwise:

```
==> baseline: runner 14.8.7, target 14.0
==> RESIDUAL GAP: this run does NOT cover macOS 14.0 through 14.8.7.
==> PASS: still running after 15s on macOS 14.8.7
```

That range is covered by defence 1, which is why the ordering above matters more than the check this PR set out to add.

## Two checks, different in kind

**`scripts/ci/check-weak-linked-symbols.sh`** — static, seconds, on the machine that already builds. This is the one that actually prevents the regression, because it fails at the moment the problem is introduced.

**A launch on a real `macos-14` runner** — empirical. The app cannot be *built* there (it needs the 26 SDK), so the build stays on `macos-26` and the product is carried over as an artifact. Catches what static analysis cannot, including a wrongly-guarded call that only fails when it runs.

## Both fail closed

The linkage guard verifies its own instrument *before* giving a verdict: it asserts that a normally-linked framework reports strong symbols, and refuses to answer if it does not. It also refuses to pass when its guarded list matches nothing, so a guard that has quietly stopped inspecting anything reports as a failure rather than a pass.

`check-weak-linked-symbols-test.sh` drives all of this against a real binary and asserts exit codes, including every refuse-to-answer case. CI runs it before trusting the guard.

```
ok [0] the shipped binary passes
ok [1] a strongly-bound framework is rejected
ok [2] a control that reports weak refuses to give a verdict
ok [2] an absent control refuses to give a verdict
ok [2] a guard list matching nothing refuses to pass
ok [2] missing file
ok [2] not a Mach-O binary
ok [2] no argument
```

The launch job asserts the runner is actually below macOS 26, so if that label ever starts resolving to 26 the job fails loudly instead of silently becoming a second copy of the build machine.

The launch script restores the executable bit and re-signs ad hoc first: an artifact round-trip drops both, and without that the app would fail to start for reasons unrelated to the macOS version — which would look exactly like the defect being hunted. It also classifies a death as dyld-symbol versus environmental, so a headless-runner problem is not misread as a compatibility break.

## Scope

- **The static check IS on the required gate.** It runs as a step in `pr-check.yml`'s `build-release`, which already produced a release binary, so it is covered by `build-check` — the only check the branch ruleset requires. An earlier revision of this PR left it standalone and therefore advisory; review was right that a guard which can go red without blocking the merge is not guarding much.
- **The macOS 14 launch stays advisory,** in its own workflow, deliberately. It depends on a hosted image with a published retirement date and on starting a GUI app headlessly; neither belongs on the path that blocks every merge.
- No branch-ruleset change was needed for either.
- Path-filtered to `Sources/**`, the build manifests, the guard scripts, and this workflow, so unrelated PRs do not pay for it.
- Both scripts live under `scripts/ci/` because root `scripts/*` is gitignored here. A guard CI cannot check out is not a guard.

## What this PR does not claim

The `macos-14` job proves the app survives its first seconds on macOS 14.8.7. It is not a functional test of the app on that OS, a headless runner is not a user's desktop, and it does not reach 14.0. The compiler is the load-bearing defence; everything here is corroboration and blast-radius reduction.


## Scheduled follow-up, not addressed here

Review reports the hosted `macos-14` image is scheduled for retirement on **2026-11-02**. When that lands, the empirical launch job stops running; the required static check and the compiler defence are unaffected. The options are to accept the loss, move to a maintained image and widen the stated residual gap, or self-host. That last one is spend, so it is a founder decision rather than one to make inside this PR.
