### PR TITLE
fix(delivery): record what the WhisperKit repo actually licenses

### DIFF
--- a/Sources/EnviousWispr/Resources/whisperkit-delivery-manifest.json
+++ b/Sources/EnviousWispr/Resources/whisperkit-delivery-manifest.json
@@ -165,7 +165,7 @@
     }
   ],
   "license": {
-    "name": "MIT",
+    "name": "No declared license (Argmax CoreML packaging); underlying OpenAI Whisper weights are MIT",
     "url": "https://huggingface.co/argmaxinc/whisperkit-coreml"
   },
   "admission": {
@@ -174,5 +174,5 @@
     "diskHeadroomFactor": "2.2",
     "evictPreviousRevisions": false
   },
-  "manifestDigest": "3759d7401b2a0f4c4808a006e1edf04495ddfeed4dc9e9cab479bf3c5f1f140b"
+  "manifestDigest": "75996a983589ad730bff39bc650be022414f3d0fb2660907e83d6ead5541c3bb"
 }

--- a/Tests/EnviousWisprTests/ModelDelivery/DeliveryManifestTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/DeliveryManifestTests.swift
@@ -175,7 +175,7 @@ enum ManifestFixture {
   /// script — `DeliveryManifest.load` recomputes the digest and THROWS on a
   /// mismatch, so a manifest that loads at all has already had this value
   /// confirmed by the shipped Swift canonicalization, independently.
-  static let goldenDigest = "3759d7401b2a0f4c4808a006e1edf04495ddfeed4dc9e9cab479bf3c5f1f140b"
+  static let goldenDigest = "75996a983589ad730bff39bc650be022414f3d0fb2660907e83d6ead5541c3bb"
 
   @Test func shippedManifestLoadsAndMatchesGoldenDigest() throws {
     let data = try Data(contentsOf: Self.shippedManifestURL)


### PR DESCRIPTION
Closes #2101.

## What was wrong

The shipped WhisperKit delivery manifest recorded `license.name: "MIT"` against
`https://huggingface.co/argmaxinc/whisperkit-coreml` — a repo that declares no licence at all: no
licence tag, no LICENSE file, no statement. Under default copyright that is all-rights-reserved.

MIT is true of something here, just not of what the URL points at. The underlying OpenAI Whisper
weights are MIT; **Argmax's CoreML packaging is the thing the URL names and the thing we actually
fetch**, and it is the reason this is the only manifest in the repo that cannot ship `our_copy`
first. The family-scoped carve-out at `DeliveryManifest.swift:129` exists precisely because we are
not licensed to re-host those bytes.

So the field paired the permissive half of the story with the restrictive source, and a reader
landing on it would reasonably conclude the repo is mirror-able. It is not.

## What changed

```
-    "name": "MIT",
+    "name": "No declared license (Argmax CoreML packaging); underlying OpenAI Whisper weights are MIT",
```

plus the `manifestDigest` and the golden-digest test constant that move with it.

## Why the digest had to move with it

`DeliveryManifest.load` recomputes the canonical digest on every launch and **throws** on mismatch,
so editing a manifest without regenerating its digest bricks model loading. Regenerated with
`scripts/regen-delivery-manifest-digest.py`, which fails closed: before writing anything it
reproduces the digest the file already declares, and it printed
`control OK: reproduced the committed baseline digest (3759d7401b2a…)` — so the new value comes from
an implementation proven equivalent on this exact file, not from a reimplementation taken on trust.

`3759d7401b2a…` → `75996a983589…`

## Blast radius

Documentation and provenance only. **`DeliveryManifest` does not decode a `license` field**, so no
runtime behaviour changes and no cache is invalidated — the digest is not part of any admission key
comparison for this artifact. Two live sites carry the value and both moved together; every other
occurrence in the repo is a dated audit transcript, deliberately untouched.

No public claim depends on this: a sweep of `website/src/content/` and `website/src/pages/` for
`argmax` / `whisperkit` found no licence statement about the packaging repo anywhere user-facing.

## Validation

- Full Debug suite on this branch: **5624 tests, `** TEST SUCCEEDED **`, exit 0**.
- `EnviousWisprTests/WhisperKitShippedManifestTests` specifically: 3 tests, 1 suite, passed — this is
  the suite that would have gone red on a stale digest.
- Dev app built from this branch after commit.
- Classification per `validate-automated-review-findings`: **REPRODUCIBLE** as a documentation
  defect — the wrong string is in the shipped bundle today. No runtime failure to reproduce.

## Why now rather than later

Epic #2077 chunk 3 (#2102) adds a **second** manifest from this same repo, which copies this shape.
Correcting the record before it propagates is cheaper than correcting two.
