### PR TITLE
feat(asr): register the universal Live Preview model for delivery

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -400,6 +400,13 @@ let project = Project(
         // (contract 4a). Same Bundle.main route as eg1-manifest.json.
         "Sources/EnviousWispr/Resources/parakeet-delivery-manifest.json",
         "Sources/EnviousWispr/Resources/whisperkit-delivery-manifest.json",
+        // #2102 (epic #2077 chunk 3): the SECOND WhisperKit-family artifact —
+        // the small multilingual model Live Preview offers as the universal
+        // alternative to Apple's engine. Listed individually because this array
+        // is the only thing that bundles a manifest; nothing globs Resources/,
+        // so a file merely placed beside its siblings ships in no build.
+        // Nothing loads it until the preview recognizer arrives (chunk 4).
+        "Sources/EnviousWispr/Resources/whisperkit-preview-delivery-manifest.json",
         // #1348 Phase 3: EG-1 delivery manifest — the DELIVERY trust root for
         // EG-1's convergence onto the shared engine (the runtime trust root
         // stays eg1-manifest.json). Same Bundle.main route.

--- a/Sources/EnviousWispr/Resources/whisperkit-preview-delivery-manifest.json
+++ b/Sources/EnviousWispr/Resources/whisperkit-preview-delivery-manifest.json
@@ -1,0 +1,148 @@
+{
+  "schemaVersion": 1,
+  "identity": {
+    "family": "whisper_kit",
+    "name": "whisperkit-coreml",
+    "revision": "97a5bf9bbc74c7d9c12c755d04dea59e672e3808",
+    "variant": "openai_whisper-small_216MB",
+    "runtimeABI": "whisperkit-1.0.0"
+  },
+  "runtimeCompatibility": {
+    "minAppVersion": "2.5.0"
+  },
+  "files": [
+    {
+      "path": "AudioEncoder.mlmodelc/analytics/coremldata.bin",
+      "sizeBytes": 243,
+      "sha256": "0c33d98d0f2046b711d75041260eb53fd0ca1c3226930a779fe9082bc4763449",
+      "component": "AudioEncoder.mlmodelc"
+    },
+    {
+      "path": "AudioEncoder.mlmodelc/coremldata.bin",
+      "sizeBytes": 347,
+      "sha256": "bb991927256c8b71c8f5df3eb652bd0d67d933d7c36da4e53a5eb15a0a635ca1",
+      "component": "AudioEncoder.mlmodelc"
+    },
+    {
+      "path": "AudioEncoder.mlmodelc/metadata.json",
+      "sizeBytes": 1942,
+      "sha256": "cc5b8143fddf32493a28fbd9cdda8222a862912162a665f40290f94dcbf5b4b5",
+      "component": "AudioEncoder.mlmodelc"
+    },
+    {
+      "path": "AudioEncoder.mlmodelc/model.mil",
+      "sizeBytes": 353690,
+      "sha256": "885cd28872db8a8e471ee49c1438aa0f55bb43bec1fbeb82e89096bac61d52b4",
+      "component": "AudioEncoder.mlmodelc"
+    },
+    {
+      "path": "AudioEncoder.mlmodelc/model.mlmodel",
+      "sizeBytes": 293185,
+      "sha256": "21680c8556cfc807eb68ae78cf498b15d805b6e655350909bd6a7a0b54b2daeb",
+      "component": "AudioEncoder.mlmodelc"
+    },
+    {
+      "path": "AudioEncoder.mlmodelc/weights/weight.bin",
+      "sizeBytes": 62057344,
+      "sha256": "dfbda1e30a5cea269ea93e2ec69d78a6c5070c0b27982690f02d23e71fecb2d6",
+      "component": "AudioEncoder.mlmodelc"
+    },
+    {
+      "path": "MelSpectrogram.mlmodelc/analytics/coremldata.bin",
+      "sizeBytes": 243,
+      "sha256": "c4f367993f0198e9858a4d89fb054318982c91a9bb5946e29231421c2f1100b9",
+      "component": "MelSpectrogram.mlmodelc"
+    },
+    {
+      "path": "MelSpectrogram.mlmodelc/coremldata.bin",
+      "sizeBytes": 328,
+      "sha256": "806321f1034184a10b04dc50816219dec8ae9789698712050c81edecb9bb5aa7",
+      "component": "MelSpectrogram.mlmodelc"
+    },
+    {
+      "path": "MelSpectrogram.mlmodelc/metadata.json",
+      "sizeBytes": 1878,
+      "sha256": "6a95b18553edd73f018fe954d203d9c3cfa70dfa596d140c20f519ca471fe6be",
+      "component": "MelSpectrogram.mlmodelc"
+    },
+    {
+      "path": "MelSpectrogram.mlmodelc/model.mil",
+      "sizeBytes": 10134,
+      "sha256": "7877c0f519a97a7c0dc1e0e9f8ae316bd864afcb2cffa89c770184b07e7767c9",
+      "component": "MelSpectrogram.mlmodelc"
+    },
+    {
+      "path": "MelSpectrogram.mlmodelc/weights/weight.bin",
+      "sizeBytes": 354080,
+      "sha256": "801024dbc7a89c677be1f8b285de3409e35f7d1786c9c8d9d0d6842ac57a1c83",
+      "component": "MelSpectrogram.mlmodelc"
+    },
+    {
+      "path": "TextDecoder.mlmodelc/analytics/coremldata.bin",
+      "sizeBytes": 243,
+      "sha256": "7883317b9bd8a263bd395091bfd1ebbd098826dc7c75569dcaa870691ab46554",
+      "component": "TextDecoder.mlmodelc"
+    },
+    {
+      "path": "TextDecoder.mlmodelc/coremldata.bin",
+      "sizeBytes": 633,
+      "sha256": "ab598c8f928071a2eee05cdc2163acea3b8d6c7d69b66b31a93dac6681c26a79",
+      "component": "TextDecoder.mlmodelc"
+    },
+    {
+      "path": "TextDecoder.mlmodelc/metadata.json",
+      "sizeBytes": 4935,
+      "sha256": "8bea59efa6a97b0fd5c9237a1ecb5d1c2d00b1c19970c04b2f3cef0d411cad70",
+      "component": "TextDecoder.mlmodelc"
+    },
+    {
+      "path": "TextDecoder.mlmodelc/model.mil",
+      "sizeBytes": 618369,
+      "sha256": "62f97fc5ba7a452d5394d48657b8c245137115a749c16680fc3b159a106d1bd2",
+      "component": "TextDecoder.mlmodelc"
+    },
+    {
+      "path": "TextDecoder.mlmodelc/model.mlmodel",
+      "sizeBytes": 518452,
+      "sha256": "2dac33b92f19491a71d67460384b95d56489b226f46c6074c17f3e81479bcca6",
+      "component": "TextDecoder.mlmodelc"
+    },
+    {
+      "path": "TextDecoder.mlmodelc/weights/weight.bin",
+      "sizeBytes": 153130482,
+      "sha256": "2be2985330071f8188e1c2ab029e1b69d6e8c42865c8d58b20b8d41856da9ed3",
+      "component": "TextDecoder.mlmodelc"
+    },
+    {
+      "path": "config.json",
+      "sizeBytes": 1456,
+      "sha256": "12f8d45c3e5da28148d88d257684e77296e4d922009e1bc5289b05b756859422",
+      "component": "config.json"
+    },
+    {
+      "path": "generation_config.json",
+      "sizeBytes": 2779,
+      "sha256": "169e76633bb28ac383cdfaad2527e662d0d532a15f8437ce94c02c10bc713b71",
+      "component": "generation_config.json"
+    }
+  ],
+  "optionalFiles": [],
+  "totalBytes": 217350763,
+  "sources": [
+    {
+      "id": "hf_pinned",
+      "baseURL": "https://huggingface.co/argmaxinc/whisperkit-coreml/resolve/97a5bf9bbc74c7d9c12c755d04dea59e672e3808/openai_whisper-small_216MB/"
+    }
+  ],
+  "license": {
+    "name": "No declared license (Argmax CoreML packaging); underlying OpenAI Whisper weights are MIT",
+    "url": "https://huggingface.co/argmaxinc/whisperkit-coreml"
+  },
+  "admission": {
+    "layout": "componentSet",
+    "installLocation": "whisperPreviewModelsCache",
+    "diskHeadroomFactor": "2.2",
+    "evictPreviousRevisions": false
+  },
+  "manifestDigest": "235dd98cedfa0ac999fbe18ca24c91d46970c299c1177a0030f5faf2d14aef16"
+}

--- a/Tests/EnviousWisprTests/ModelDelivery/DeliveryManifestTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/DeliveryManifestTests.swift
@@ -225,6 +225,168 @@ enum ManifestFixture {
   }
 }
 
+/// The SECOND artifact in the `whisperKit` family (#2102, epic #2077 chunk 3):
+/// the small multilingual model Live Preview offers as the universal
+/// alternative to Apple's engine, which only recognises languages Apple has
+/// already installed and does not exist below macOS 26 at all.
+///
+/// Nothing loads this manifest yet — the preview recognizer arrives in chunk 4.
+/// It is registered and provable now so that chunk builds on a pinned,
+/// digest-locked artifact rather than authoring one under deadline.
+///
+/// Two manifests in one family are unambiguous ONLY because every load site
+/// names its resource literally (`ModelDeliveryHome`, `WisprBootstrapper`);
+/// nothing resolves a manifest by `ModelFamily`. Do not add a generic
+/// enumerator without revisiting that.
+@Suite struct WhisperKitPreviewManifestTests {
+  static var previewManifestURL: URL {
+    ParakeetShippedManifestTests.repoRoot.appendingPathComponent(
+      "Sources/EnviousWispr/Resources/whisperkit-preview-delivery-manifest.json")
+  }
+
+  /// Golden digest, same contract as the transcription manifest above: the
+  /// authoring script and the Swift loader must agree or a valid manifest is
+  /// rejected at runtime. `DeliveryManifest.load` recomputes it and THROWS on
+  /// mismatch, so a manifest that loads at all has had this value confirmed by
+  /// the shipped Swift canonicalization independently of how it was authored.
+  static let goldenDigest = "235dd98cedfa0ac999fbe18ca24c91d46970c299c1177a0030f5faf2d14aef16"
+
+  /// Every byte-level constant below was MEASURED, not transcribed: each file
+  /// was downloaded through its pinned `resolve/<sha>/` URL and hashed from the
+  /// stream actually received, and the count and total were cross-checked
+  /// against an independent earlier download of the same revision.
+  ///
+  /// A digest alone would lock whatever was authored, INCLUDING the wrong
+  /// artifact — an internally-consistent manifest for `openai_whisper-base`
+  /// would pass a digest-only test. These assertions are what make the digest
+  /// mean "the model we chose" rather than "some model".
+  @Test func previewManifestLoadsAndMatchesGoldenDigest() throws {
+    let data = try Data(contentsOf: Self.previewManifestURL)
+    let manifest = try DeliveryManifest.load(from: data)
+    #expect(manifest.manifestDigest == Self.goldenDigest)
+    #expect(try DeliveryManifest.canonicalDigest(of: data) == Self.goldenDigest)
+
+    #expect(manifest.identity.family == .whisperKit)
+    #expect(manifest.identity.name == "whisperkit-coreml")
+    #expect(manifest.identity.variant == "openai_whisper-small_216MB")
+    #expect(manifest.identity.runtimeABI == "whisperkit-1.0.0")
+    #expect(manifest.files.count == 19)
+    #expect(manifest.totalBytes == 217_350_763)
+    #expect(manifest.optionalFiles.isEmpty)
+
+    let components = Set(manifest.files.map(\.component))
+    for required in [
+      "AudioEncoder.mlmodelc", "MelSpectrogram.mlmodelc", "TextDecoder.mlmodelc", "config.json",
+    ] {
+      #expect(components.contains(required), "missing component \(required)")
+    }
+    // The small variant genuinely has no prefill decoder at this revision,
+    // unlike large-v3-turbo. Asserting its ABSENCE keeps the required-component
+    // list above from being quietly copied from the transcription manifest,
+    // where it would then be describing a different model.
+    #expect(!components.contains("TextDecoderContextPrefill.mlmodelc"))
+  }
+
+  /// The pin is the whole point, and this artifact has NO mirror of our own to
+  /// fall back to — we are not licensed to re-host these bytes — so a movable
+  /// ref would be the only thing standing between us and silently different
+  /// weights.
+  @Test func previewSourceIsPinnedToAnImmutableCommitNotABranch() throws {
+    let manifest = try DeliveryManifest.load(from: Data(contentsOf: Self.previewManifestURL))
+    #expect(manifest.sources.count == 1)
+    #expect(manifest.sources.first?.id == "hf_pinned")
+    let baseURL = try #require(manifest.sources.first?.baseURL.absoluteString)
+    #expect(baseURL.hasPrefix("https://huggingface.co/argmaxinc/whisperkit-coreml/resolve/"))
+    #expect(!baseURL.contains("/resolve/main/"), "a branch ref would let the bytes change")
+    #expect(baseURL.hasSuffix("/openai_whisper-small_216MB/"), "must fetch the preview variant")
+
+    let revision = manifest.identity.revision
+    #expect(revision.count == 40, "revision must be a full commit SHA, never a short ref or tag")
+    #expect(revision.allSatisfy { $0.isHexDigit })
+    #expect(baseURL.contains(revision), "the fetch URL must pin the SAME commit the identity names")
+    #expect(!baseURL.contains("@") && !baseURL.contains("token"))
+  }
+
+  /// The one thing in this chunk that could destroy user data.
+  ///
+  /// `CacheAdmission` treats its install directory as exhaustive truth and
+  /// removes every top-level entry the active manifest does not list. Two
+  /// manifests admitted into ONE directory would therefore delete each other's
+  /// files on every admission — the transcription model, a heart-path artifact,
+  /// wiped by a limb.
+  ///
+  /// The token asserted here does not itself resolve to a path: it is metadata
+  /// (`DeliveryManifest.Admission.installLocation` is a free `String` nothing in
+  /// ModelDelivery interprets), and the real filesystem authority is the
+  /// caller-supplied `DeliveryRegistration.installDirectory`. So this test
+  /// cannot prove the directories differ — it pins the DECLARATION, so that a
+  /// chunk-4 author wiring the registration cannot read the two manifests as
+  /// asking to share a home.
+  @Test func previewInstallLocationIsDistinctFromTheTranscriptionModel() throws {
+    let preview = try DeliveryManifest.load(from: Data(contentsOf: Self.previewManifestURL))
+    let transcription = try DeliveryManifest.load(
+      from: Data(contentsOf: WhisperKitShippedManifestTests.shippedManifestURL))
+
+    #expect(preview.admission.installLocation == "whisperPreviewModelsCache")
+    #expect(
+      preview.admission.installLocation != transcription.admission.installLocation,
+      "two manifests sharing an install directory delete each other's files")
+    // Same family, same source repo, same pinned revision — everything that
+    // makes a collision plausible is genuinely true here. Only the variant and
+    // the install location separate them.
+    #expect(preview.identity.family == transcription.identity.family)
+    #expect(preview.identity.revision == transcription.identity.revision)
+    #expect(preview.identity.variant != transcription.identity.variant)
+  }
+
+  /// A digest test that only ever sees the good file proves nothing. Both
+  /// mutations below must be REJECTED, and the second is the load-bearing one:
+  /// `runtimeCompatibility` is not a declared property of `DeliveryManifest` at
+  /// all, so the decoder ignores it — yet canonicalization re-serializes the RAW
+  /// JSON, so an undeclared field still participates in the digest. Without this
+  /// case, silently dropping such a field would look like a passing test.
+  @Test func aMutatedPreviewManifestIsRejected() throws {
+    let data = try Data(contentsOf: Self.previewManifestURL)
+    let object = try #require(
+      try JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+    func expectRejected(_ mutated: [String: Any], _ label: String) throws {
+      let mutatedData = try JSONSerialization.data(withJSONObject: mutated)
+      #expect(throws: DeliveryManifest.ManifestError.self, "\(label) must not load") {
+        try DeliveryManifest.load(from: mutatedData)
+      }
+    }
+
+    var byteCount = object
+    byteCount["totalBytes"] = 217_350_764
+    try expectRejected(byteCount, "a manifest claiming one extra byte")
+
+    var undeclaredField = object
+    undeclaredField["runtimeCompatibility"] = ["minAppVersion": "99.0.0"]
+    try expectRejected(undeclaredField, "a manifest with an edited undecoded field")
+
+    // Two-way control: the SAME round-trip through JSONSerialization with no
+    // mutation must still load, or the two cases above would be proving only
+    // that re-serialization breaks manifests.
+    let roundTripped = try JSONSerialization.data(withJSONObject: object)
+    #expect(try DeliveryManifest.load(from: roundTripped).manifestDigest == Self.goldenDigest)
+  }
+
+  /// `Project.swift` lists every manifest individually and nothing globs
+  /// `Resources/`, so a file merely placed beside its siblings is not a build
+  /// input and would be ABSENT from the signed app while every other test here
+  /// still passed — they all read the source tree.
+  @Test func previewManifestIsDeclaredAsAppResource() throws {
+    let project = try String(
+      contentsOf: ParakeetShippedManifestTests.repoRoot.appendingPathComponent("Project.swift"),
+      encoding: .utf8)
+    #expect(
+      project.contains(
+        "Sources/EnviousWispr/Resources/whisperkit-preview-delivery-manifest.json"),
+      "whisperkit-preview-delivery-manifest.json must be listed in the app target's resources")
+  }
+}
+
 @Suite struct ParakeetShippedManifestTests {
   /// Repo-relative path via #filePath — the ceilings-test house pattern for
   /// reading source-tree files from unit tests.


### PR DESCRIPTION
Closes #2102. Part of #2077 (chunk 3 of 5).

## What this is

One bundled manifest registering `openai_whisper-small_216MB` — the universal Live Preview engine —
as a delivery-managed artifact, plus its tests. **Nothing user-reachable changes.** No setting, no
engine choice, no download is triggered by anything this chunk adds. The first thing that can ask for
it is chunk 4.

`Live UAT: N` for that reason — there would be nothing to drive. The evidence obligation is met
instead by the fetch-and-verify run below plus a golden-digest test with a mutation control.

## The plan's falsifiable claim held

The plan said this needs **no code change in ModelDelivery**, and that if it did, the design was
wrong. Grounded review round 1 came back `PROCEED-AS-PLANNED` with zero findings after checking
exactly that: `admission.installLocation` decodes as a free `String`
(`DeliveryManifest.swift:43-52`), not an enum, so a new token needs no case; `ModelFamily.whisperKit`
and the mirror-first carve-out at `:129` already exist; and nothing enumerates manifests generically
— three literal resource names at `ModelDeliveryHome.swift:72`/`:99` and `WisprBootstrapper.swift:278`.

Diff is one new JSON, one line in `Project.swift`, one test suite. No ModelDelivery source file is
touched.

## Every number was measured

All 19 files were downloaded through their pinned `resolve/<sha>/` URLs and SHA-256'd from the stream
actually received — not re-read from an earlier snapshot fetched some other way. The script fails
closed on any HTTP error, size mismatch or short read.

```
COUNT 19  TOTAL 217350763
```

Cross-checked byte-for-byte against an independent earlier download of the same revision: **zero
differing files.** The digest was then reproduced by the repo's own
`scripts/regen-delivery-manifest-digest.py` (`MATCH`), which is a different implementation from the
one that authored it, and confirmed again by the Swift loader inside the test.

## Two silent failures this ships guards against

**1. The manifest would not have been bundled at all.** `Project.swift:398-409` lists each manifest
individually and nothing globs `Resources/`. A file merely placed beside its siblings is not a build
input — it would have been absent from the signed app while every other test here still passed,
because they all read the source tree. Caught by the coverage round; now a line in `Project.swift`
and an assertion that it is there.

**2. Two manifests sharing an install directory would DELETE EACH OTHER'S FILES.** `CacheAdmission`
treats its install directory as exhaustive truth — "unlisted entries are stale revisions' leftovers
or foreign debris" — and removes every top-level entry the active manifest does not list. Admitting
the preview model into `whisperModelsCache` would have wiped the transcription model, a heart-path
artifact, from a limb.

The manifest declares a distinct `whisperPreviewModelsCache`. **That token is documentary and the
test says so:** ModelDelivery never resolves `installLocation` to a path, and the real filesystem
authority is the caller-supplied `DeliveryRegistration.installDirectory`
(`ModelDeliveryController.swift:4-15`, `:735-738`). What the assertion buys is that a chunk-4 author
wiring the registration cannot read the two manifests as asking to share a home. **Chunk 4's
acceptance criterion is the directory, not the string.**

## Tests

`WhisperKitPreviewManifestTests`, 5 tests — **all 5 pass, `** TEST SUCCEEDED **`.**

- **Golden digest + semantic identity.** A digest alone locks whatever was authored, *including the
  wrong artifact*: an internally consistent manifest for `openai_whisper-base` would pass a
  digest-only test. So family, name, variant, full 40-char revision, 19 files and 217,350,763 bytes
  are all pinned. It also asserts `TextDecoderContextPrefill.mlmodelc` is **absent** — the small
  variant genuinely has no prefill decoder at this revision, and asserting the absence stops the
  required-component list being copied from the transcription manifest, where it would be describing
  a different model.
- **Immutable source.** Single `hf_pinned` HTTPS source, no `/resolve/main/`, 40-hex revision
  embedded in the fetch URL, correct variant folder, no embedded token.
- **Distinct install location**, with the family/revision equality assertions that show everything
  making a collision plausible is genuinely true here.
- **Mutation control, two-way.** A manifest claiming one extra byte is rejected; so is one with an
  edited `runtimeCompatibility` — the load-bearing case, because that field is **not a declared
  property of `DeliveryManifest` at all**, yet canonicalization re-serializes the raw JSON so it still
  participates in the digest. Without it, silently dropping such a field would look like a pass. The
  unmutated round-trip must still load, or the two rejections would only be proving that
  re-serialization breaks manifests.
- **Resource declaration** in `Project.swift`.

Full Debug suite on this branch: see the receipt below.

## Variant choice, and the limits of the evidence

`openai_whisper-small_216MB` over `openai_whisper-base` (~146 MB), decided on the **shape** of the
errors rather than the mean. 120 German sentences through the real shipped decode: **24.14% → 17.39%
WER**, 54 per-clip wins to 16, worst case **0.32× real time**. base emits confident nonsense
(`Dass die Pio-Eument lief`, `Neue Zäule`), which is disqualifying for a feature whose entire value is
watching words appear and trusting them.

Carried forward rather than buried: that measurement covers the **finalize** path, not the preview's
LocalAgreement-2 confirmed-prefix trajectory — no harness arm exposes the confirmed prefix alone.
German only, synthetic TTS, n=120, and absolute WER is inflated for both arms because the references
spell numbers out.

## Accepted risk, already on record

This stays the **only** artifact with a single source and no mirror of ours. We are not licensed to
re-host Argmax's CoreML bytes (#2101 corrects the record that suggested otherwise), so if the pinned
revision is deleted upstream the preview becomes uninstallable for new users until we react.
Installed apps are unaffected. **Do not "fix" this by adding `our_copy`.**

The epic's own text says delivery goes through our CDN. It cannot for this artifact, for that reason.
Founder acknowledged at Gate 2.

## Blast radius

Adding an unreferenced resource. Nothing loads it until chunk 4; rollback is deleting one file, one
`Project.swift` line and one suite. The blast-radius claim was verified rather than assumed: no CI or
Tuist mechanism enumerates `Resources/*.json` generically.

Sibling-safety was checked too — `WhisperKitLegacyUpgradeCoordinator` explicitly never touches
sibling variants, and its existing test already names `openai_whisper-small_216MB` as the sibling it
must leave alone.

## Process

Tier MEDIUM · Lane `Code` · `User Rubric: N/A — internal-only`. Coverage round found three real
problems before any code existed (two of them above); grounded review round 1 returned
`PROCEED-AS-PLANNED`; Gate 2 signed off. Plan:
`docs/feature-requests/issue-2102-2026-08-16-universal-preview-model.md`.
