### PR TITLE
feat(eg1): fetch a superseded model revision automatically at launch

### DIFF
--- a/Sources/EnviousWispr/Resources/eg1-delivery-manifest.json
+++ b/Sources/EnviousWispr/Resources/eg1-delivery-manifest.json
@@ -3,7 +3,7 @@
   "identity": {
     "family": "eg_one",
     "name": "eg-1",
-    "revision": "v2-sharded",
+    "revision": "v3-eg2",
     "variant": "q5km",
     "runtimeABI": "llamacpp-eg1-v1"
   },
@@ -12,60 +12,60 @@
   },
   "files": [
     {
-      "path": "v2-sharded/eg-1-v1-00001-of-00008.gguf",
-      "installPath": "eg-1-v1-00001-of-00008.gguf",
+      "path": "v3-eg2/eg-1-v2-00001-of-00008.gguf",
+      "installPath": "eg-1-v2-00001-of-00008.gguf",
       "sizeBytes": 399884576,
-      "sha256": "77fecf22dabbcb441bb44b8e1f5c6cba7a3f728bc5c22ff76dfb97fd5fbe55af",
-      "component": "eg-1-v1-00001-of-00008.gguf"
+      "sha256": "7169a0f1e6d356f75b464960c2104a36859f74e7d37dfcd95248ea50d660a64e",
+      "component": "eg-1-v2-00001-of-00008.gguf"
     },
     {
-      "path": "v2-sharded/eg-1-v1-00002-of-00008.gguf",
-      "installPath": "eg-1-v1-00002-of-00008.gguf",
+      "path": "v3-eg2/eg-1-v2-00002-of-00008.gguf",
+      "installPath": "eg-1-v2-00002-of-00008.gguf",
       "sizeBytes": 395007008,
-      "sha256": "0808f51149fc30587741c90fa8d026dabdba336a8d9dcc456b8069dd09052c9f",
-      "component": "eg-1-v1-00002-of-00008.gguf"
+      "sha256": "e6660da85546f9c92fc98cbf5c7668047cfc96bb466719a1fd4cbeb117ce79d1",
+      "component": "eg-1-v2-00002-of-00008.gguf"
     },
     {
-      "path": "v2-sharded/eg-1-v1-00003-of-00008.gguf",
-      "installPath": "eg-1-v1-00003-of-00008.gguf",
+      "path": "v3-eg2/eg-1-v2-00003-of-00008.gguf",
+      "installPath": "eg-1-v2-00003-of-00008.gguf",
       "sizeBytes": 393972896,
-      "sha256": "feb7d533d28cb7ca28aaa3d5b0152ff55cb5c5930ae701ec9c726b2d2ee3a1ab",
-      "component": "eg-1-v1-00003-of-00008.gguf"
+      "sha256": "eeeb38446e304f58522b81a88d8a0edcabe50243747662d5b5cf14e88691ab73",
+      "component": "eg-1-v2-00003-of-00008.gguf"
     },
     {
-      "path": "v2-sharded/eg-1-v1-00004-of-00008.gguf",
-      "installPath": "eg-1-v1-00004-of-00008.gguf",
+      "path": "v3-eg2/eg-1-v2-00004-of-00008.gguf",
+      "installPath": "eg-1-v2-00004-of-00008.gguf",
       "sizeBytes": 397618336,
-      "sha256": "d0a2171e05f94623bef61ae823d38b85bae0a5c3a68d4299142c4d1fa7529bd4",
-      "component": "eg-1-v1-00004-of-00008.gguf"
+      "sha256": "bee2eb0dabdbaaef177e1e053e8d30edb4349ac12886c60c9bb76a710f9ffa79",
+      "component": "eg-1-v2-00004-of-00008.gguf"
     },
     {
-      "path": "v2-sharded/eg-1-v1-00005-of-00008.gguf",
-      "installPath": "eg-1-v1-00005-of-00008.gguf",
+      "path": "v3-eg2/eg-1-v2-00005-of-00008.gguf",
+      "installPath": "eg-1-v2-00005-of-00008.gguf",
       "sizeBytes": 389508864,
-      "sha256": "f9753de7d96d209e6172ddaaf702eaffd72145cf2f3950965503724fba39ef57",
-      "component": "eg-1-v1-00005-of-00008.gguf"
+      "sha256": "97d9a9cf56774fe5f598ac05d91dc59a4ddfd235b95ea1810b379a41bdc57d55",
+      "component": "eg-1-v2-00005-of-00008.gguf"
     },
     {
-      "path": "v2-sharded/eg-1-v1-00006-of-00008.gguf",
-      "installPath": "eg-1-v1-00006-of-00008.gguf",
+      "path": "v3-eg2/eg-1-v2-00006-of-00008.gguf",
+      "installPath": "eg-1-v2-00006-of-00008.gguf",
       "sizeBytes": 388606432,
-      "sha256": "d0107bf94efdd18735d7325fe3037b9e00b738471b53f5e1b0d17861ff07eb8d",
-      "component": "eg-1-v1-00006-of-00008.gguf"
+      "sha256": "c810a8e2d3c51e4b70d67f25d2c861909ecf32cb315a5c00d86439b11080626a",
+      "component": "eg-1-v2-00006-of-00008.gguf"
     },
     {
-      "path": "v2-sharded/eg-1-v1-00007-of-00008.gguf",
-      "installPath": "eg-1-v1-00007-of-00008.gguf",
+      "path": "v3-eg2/eg-1-v2-00007-of-00008.gguf",
+      "installPath": "eg-1-v2-00007-of-00008.gguf",
       "sizeBytes": 397168384,
-      "sha256": "917ad0a83d94a10a8d46113936de56b9fb868241024519b31cb0d612e3e247f3",
-      "component": "eg-1-v1-00007-of-00008.gguf"
+      "sha256": "9dc0f6258253f96f51b1c7b48d4385c4e40dc2fa5c0494902ff36262bd0712fa",
+      "component": "eg-1-v2-00007-of-00008.gguf"
     },
     {
-      "path": "v2-sharded/eg-1-v1-00008-of-00008.gguf",
-      "installPath": "eg-1-v1-00008-of-00008.gguf",
+      "path": "v3-eg2/eg-1-v2-00008-of-00008.gguf",
+      "installPath": "eg-1-v2-00008-of-00008.gguf",
       "sizeBytes": 127746048,
-      "sha256": "83c5c80b3c97c94fe9d5c2d903f0a1511e2a4d600091a18a5a2143f99d9ab286",
-      "component": "eg-1-v1-00008-of-00008.gguf"
+      "sha256": "b212ce6af1fc83ed2df28f8f7c517b627747e8436aee452ac62185fa54da6546",
+      "component": "eg-1-v2-00008-of-00008.gguf"
     }
   ],
   "optionalFiles": [],
@@ -85,7 +85,7 @@
     "installLocation": "polishModelsCache",
     "diskHeadroomFactor": "2.2",
     "evictPreviousRevisions": true,
-    "entrypointFile": "eg-1-v1-00001-of-00008.gguf"
+    "entrypointFile": "eg-1-v2-00001-of-00008.gguf"
   },
-  "manifestDigest": "07550d07e242aa660393f5e62d36106ed7916ffa8852d9fb66f5420854a6b70d"
+  "manifestDigest": "dd3cc5d3eb3c237f8e18fd85138da1cffcd4eb0f263ef0f6fc96a60d2e742f1b"
 }

--- a/Sources/EnviousWispr/Resources/eg1-manifest.json
+++ b/Sources/EnviousWispr/Resources/eg1-manifest.json
@@ -1,9 +1,9 @@
 {
   "modelName": "eg-1",
-  "version": "v2-sharded",
+  "version": "v3-eg2",
   "contextTokens": 16384,
   "promptTemplateID": "eg1-v1",
   "minAppVersion": "2.3.0",
-  "downloadURL": "https://models.enviouslabs.co/eg1/v2-sharded/eg-1-v1-00001-of-00008.gguf",
+  "downloadURL": "https://models.enviouslabs.co/eg1/v3-eg2/eg-1-v2-00001-of-00008.gguf",
   "licenseURL": "https://models.enviouslabs.co/eg1/EG-1-MODEL-LICENSE.txt"
 }

--- a/Sources/EnviousWisprAppKit/App/EGOneTelemetryBridge.swift
+++ b/Sources/EnviousWisprAppKit/App/EGOneTelemetryBridge.swift
@@ -2,18 +2,14 @@ import EnviousWisprLLM
 import EnviousWisprServices
 import Foundation
 
-/// Maps EG-1 runtime HEALTH events onto `TelemetryService` (#1271).
+/// Maps EG-1-specific runtime health and replacement lifecycle events onto `TelemetryService`.
 ///
-/// Lives here (AppKit) because the LLM module cannot import Services; the
-/// composition root installs `handler` as `EGOneRuntime.onEvent`. Content-
-/// free by construction: reasons are a closed string set, identity is our
-/// manifest's, and no transcript/prompt content exists on this path.
-///
-/// #1348 Phase 3: EG-1's DOWNLOAD telemetry (`download_started/completed/
-/// failed`) was retired — those attempts now speak `model_delivery.*` with
-/// `family=eg1` through the shared engine's bridge (`ModelDeliveryHome`). Only
-/// server health (a runtime probe result with no delivery equivalent) remains
-/// on this path.
+/// Lives here because the LLM module cannot import Services. The composition root installs
+/// `handler` for runtime health (#1271) and `upgradeHandler` for replacement events (#1386, #2096).
+/// Both paths are content-free: reasons are a closed string set, identity is our manifest's, and no
+/// transcript or prompt content exists on either. Shared download progress and failures remain
+/// exclusively on `model_delivery.*` with `family=eg1` (#1348 Phase 3, which retired this path's
+/// own `download_started/completed/failed`).
 enum EGOneTelemetryBridge {
   static var handler: @Sendable (EGOneRuntimeEvent) -> Void {
     { event in
@@ -28,14 +24,11 @@ enum EGOneTelemetryBridge {
     }
   }
 
-  /// #1386 PR-1: the legacy-upgrade lifecycle (`eg1.legacy_detected` /
-  /// `legacy_retired` / `legacy_retirement_failed` / `replacement_completed` /
-  /// `replacement_declined`). Bounded and content-free: the only properties
-  /// are a fixed failure-reason set and `selected_provider` on detection
-  /// (attached here so the coordinator stays provider-ignorant). Download
-  /// progress/failure stays on the shared `model_delivery.*` funnel — this
-  /// path never duplicates it.
-  static func legacyUpgradeHandler(
+  /// Maps the complete EG-1 replacement lifecycle onto bounded, content-free events.
+  /// Legacy-monolith events retain their existing keys; revision upgrades add
+  /// `upgrade_eligible` and `upgrade_declined`. Download progress and failure remain
+  /// on the shared `model_delivery.*` funnel, so this path never duplicates them.
+  static func upgradeHandler(
     selectedProvider: @escaping @MainActor @Sendable () -> Bool
   ) -> @MainActor @Sendable (EGOneUpgradeCoordinator.Event) -> Void {
     { event in
@@ -62,6 +55,29 @@ enum EGOneTelemetryBridge {
       case .replacementDeclined:
         name = "replacement_declined"
         properties = [:]
+
+      // #2096. `upgrade_eligible` is the DENOMINATOR: every install that could have taken a new
+      // revision, including the ones that went nowhere. `first_run` cannot serve this — its
+      // baseline is keyed to the CURRENT identity, so prior-revision users arrive as
+      // `first_run=true` and a query filtering on false would silently return zero and read as
+      // "the rollout never happened".
+      case .upgradeEligible(
+        let routing, let targetRevision, let deliveryEnabled, let onboardingComplete):
+        name = "upgrade_eligible"
+        properties = [
+          "routing": routing.rawValue,
+          "target_revision": targetRevision,
+          "selected_provider": selectedProvider() ? "true" : "false",
+          "delivery_enabled": deliveryEnabled ? "true" : "false",
+          "onboarding_complete": onboardingComplete ? "true" : "false",
+        ]
+
+      // Named for what HAPPENED, not for a cause it cannot observe. Both producers are explicit
+      // upstream (Remove while owed, or Cancel of our own in-flight upgrade), so this asserts a
+      // user decision and nothing about why they made it.
+      case .upgradeDeclined(let targetRevision):
+        name = "upgrade_declined"
+        properties = ["target_revision": targetRevision]
       }
 
       TelemetryService.shared.egOneDownloadEvent(

--- a/Sources/EnviousWisprAppKit/App/EGOneTelemetryBridge.swift
+++ b/Sources/EnviousWisprAppKit/App/EGOneTelemetryBridge.swift
@@ -37,7 +37,7 @@ enum EGOneTelemetryBridge {
   /// path never duplicates it.
   static func legacyUpgradeHandler(
     selectedProvider: @escaping @MainActor @Sendable () -> Bool
-  ) -> @MainActor @Sendable (EGOneLegacyUpgradeCoordinator.Event) -> Void {
+  ) -> @MainActor @Sendable (EGOneUpgradeCoordinator.Event) -> Void {
     { event in
       let name: String
       let properties: [String: String]

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -295,7 +295,7 @@ public final class WisprBootstrapper {
         isOnboardingComplete: { [weak settings] in settings?.onboardingState == .completed })
       // `selected_provider` attaches here (settings in scope); coordinator
       // stays provider-ignorant.
-      coordinator.onEvent = EGOneTelemetryBridge.legacyUpgradeHandler(
+      coordinator.onEvent = EGOneTelemetryBridge.upgradeHandler(
         selectedProvider: { [weak settings] in settings?.llmProvider == .egOne })
       egOneUpgrade = (registration, coordinator)
     }

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -273,8 +273,8 @@ public final class WisprBootstrapper {
     let egOneAppSupport = FileManager.default.urls(
       for: .applicationSupportDirectory, in: .userDomainMask)[0]
     var egOneAdapter: EGOneDeliveryAdapter?
-    var egOneLegacyUpgrade:
-      (registration: DeliveryRegistration, coordinator: EGOneLegacyUpgradeCoordinator)?
+    var egOneUpgrade:
+      (registration: DeliveryRegistration, coordinator: EGOneUpgradeCoordinator)?
     if let deliveryManifest = try? DeliveryManifest.loadBundled(resource: "eg1-delivery-manifest") {
       let registration = DeliveryRegistration(
         manifest: deliveryManifest,
@@ -288,26 +288,26 @@ public final class WisprBootstrapper {
         version: egOneManifest?.version ?? deliveryManifest.identity.revision)
       egOneAdapter = adapter
 
-      let coordinator = EGOneLegacyUpgradeCoordinator(
+      let coordinator = EGOneUpgradeCoordinator(
         adapter: adapter,
         appSupportDirectory: egOneAppSupport)
       // `selected_provider` attaches here (settings in scope); coordinator
       // stays provider-ignorant.
       coordinator.onEvent = EGOneTelemetryBridge.legacyUpgradeHandler(
         selectedProvider: { [weak settings] in settings?.llmProvider == .egOne })
-      egOneLegacyUpgrade = (registration, coordinator)
+      egOneUpgrade = (registration, coordinator)
     }
     let egOneRuntime = EGOneRuntime(
       manifest: egOneManifest, serverBinaryURL: egOneServerBinaryURL, delivery: egOneAdapter)
     egOneRuntime.isActiveProvider = { [weak settings] in settings?.llmProvider == .egOne }
     egOneRuntime.onEvent = EGOneTelemetryBridge.handler
-    if let egOneLegacyUpgrade {
+    if let egOneUpgrade {
       // First-run baseline (#1348 §16.2) → legacy launch table → the RUNTIME
       // decides if the completed replacement boots the server (PR #1500 P1).
       let delivery = modelDelivery
       Task {
-        await delivery.recordFirstRunBaseline(for: egOneLegacyUpgrade.registration)
-        await egOneLegacyUpgrade.coordinator.runLaunch()
+        await delivery.recordFirstRunBaseline(for: egOneUpgrade.registration)
+        await egOneUpgrade.coordinator.runLaunch()
         egOneRuntime.activateAfterAutomaticReplacementIfNeeded()
       }
     }

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -273,8 +273,7 @@ public final class WisprBootstrapper {
     let egOneAppSupport = FileManager.default.urls(
       for: .applicationSupportDirectory, in: .userDomainMask)[0]
     var egOneAdapter: EGOneDeliveryAdapter?
-    var egOneUpgrade:
-      (registration: DeliveryRegistration, coordinator: EGOneUpgradeCoordinator)?
+    var egOneUpgrade: (registration: DeliveryRegistration, coordinator: EGOneUpgradeCoordinator)?
     if let deliveryManifest = try? DeliveryManifest.loadBundled(resource: "eg1-delivery-manifest") {
       let registration = DeliveryRegistration(
         manifest: deliveryManifest,
@@ -290,7 +289,9 @@ public final class WisprBootstrapper {
 
       let coordinator = EGOneUpgradeCoordinator(
         adapter: adapter,
-        appSupportDirectory: egOneAppSupport)
+        appSupportDirectory: egOneAppSupport,
+        identity: deliveryManifest.identity,
+        installDirectory: registration.installDirectory)
       // `selected_provider` attaches here (settings in scope); coordinator
       // stays provider-ignorant.
       coordinator.onEvent = EGOneTelemetryBridge.legacyUpgradeHandler(

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -291,7 +291,8 @@ public final class WisprBootstrapper {
         adapter: adapter,
         appSupportDirectory: egOneAppSupport,
         identity: deliveryManifest.identity,
-        installDirectory: registration.installDirectory)
+        installDirectory: registration.installDirectory,
+        isOnboardingComplete: { [weak settings] in settings?.onboardingState == .completed })
       // `selected_provider` attaches here (settings in scope); coordinator
       // stays provider-ignorant.
       coordinator.onEvent = EGOneTelemetryBridge.legacyUpgradeHandler(
@@ -514,7 +515,7 @@ public final class WisprBootstrapper {
     settings.onChange = {
       [
         weak settingsSync, weak settings, weak settingsChangeTelemetry, outputClassifierHolder,
-        bluetoothAwarenessPresenterHolder
+        bluetoothAwarenessPresenterHolder, weak egOneCoordinator = egOneUpgrade?.coordinator
       ] key
       in
       guard let settingsSync, let settings else { return }
@@ -533,6 +534,15 @@ public final class WisprBootstrapper {
       if key == .llmProvider {
         WisprBootstrapper.prewarmOutputClassifierIfNeeded(
           holder: outputClassifierHolder, provider: settings.llmProvider)
+      }
+      // #2096: EG-1's automatic model upgrade stands aside while first-run setup runs, so the
+      // heart's model download owns the bandwidth. `runLaunch` fires once at bootstrap, so
+      // without this the deferral would mean "never until relaunch" rather than "later".
+      if key == .onboardingState, settings.onboardingState == .completed {
+        Task {
+          guard await egOneCoordinator?.onboardingDidComplete() == true else { return }
+          egOneRuntime.activateAfterAutomaticReplacementIfNeeded()
+        }
       }
       // #1480: tips on/off, input-device change, and onboarding completion each
       // re-evaluate the Bluetooth card (dismiss/suppress, route re-check, or first

--- a/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
@@ -1457,7 +1457,10 @@ struct AIPolishSettingsView: View {
     switch egOne.installState {
     case .notInstalled:
       HStack {
-        Text("One-time download: 2.9 GB")
+        // NOT "one-time" (#2096): a new model revision downloads again, on its own, when an app
+        // update ships one. Promising a single download was true only while EG-1 could never be
+        // replaced, and that stopped being true the moment the automatic upgrade path existed.
+        Text("Download size: 2.9 GB")
           .font(.stHelper)
           .foregroundStyle(Color.stTextSecondary)
         Spacer()

--- a/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
@@ -25,12 +25,7 @@ enum WhatsNewContent {
       icon: "sparkles",
       title: "EG-1 is better at changes of mind and spoken lists",
       description:
-        "The built-in AI cleanup model has been retrained. When you change your mind mid-sentence, "
-        + "saying something like \"send it to Marcus, sorry, to Priya\", it now keeps what you meant "
-        + "and drops what you took back. When you announce a list out loud, you get a list instead "
-        + "of one long line. You do not need to change how you dictate, and EG-1 still runs "
-        + "entirely on your Mac. If you already use it, the new version downloads on its own in "
-        + "the background the next time you open the app. Dictation keeps working while it downloads.",
+        "The built-in AI cleanup model has been retrained. When you change your mind mid-sentence, saying something like \"send it to Marcus, sorry, to Priya\", it now keeps what you meant and drops what you took back. When you announce a list out loud, you get a list instead of one long line. You do not need to change how you dictate, and EG-1 still runs entirely on your Mac. If you already use it, the new version downloads on its own in the background the next time you open the app. Dictation keeps working while it downloads.",
       version: "2.4.5"
     ),
 

--- a/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
@@ -21,6 +21,20 @@ enum WhatsNewContent {
     // MARK: - v2.4.5
 
     Entry(
+      id: "eg1-improved-corrections-and-lists",
+      icon: "sparkles",
+      title: "EG-1 is better at changes of mind and spoken lists",
+      description:
+        "The built-in AI cleanup model has been retrained. When you change your mind mid-sentence, "
+        + "saying something like \"send it to Marcus, sorry, to Priya\", it now keeps what you meant "
+        + "and drops what you took back. When you announce a list out loud, you get a list instead "
+        + "of one long line. You do not need to change how you dictate, and EG-1 still runs "
+        + "entirely on your Mac. If you already use it, the new version downloads on its own in "
+        + "the background the next time you open the app. Dictation keeps working while it downloads.",
+      version: "2.4.5"
+    ),
+
+    Entry(
       id: "ollama-model-recommendations-from-tests",
       icon: "checkmark.seal",
       title: "Local AI model recommendations now come from our tests",

--- a/Sources/EnviousWisprLLM/EGOne/EGOneDeliveryAdapter.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneDeliveryAdapter.swift
@@ -41,13 +41,20 @@ public final class EGOneDeliveryAdapter {
   /// adapter stays the single delivery doorway; the coordinator's monolith
   /// retirement runs before any fetch door, and admission/decline outcomes are
   /// reported back so the owed marker never drifts from delivery reality.
+  ///
+  /// `beforeDecline` carries WHICH action fired it (#2096). `cancel()` and `remove()` both
+  /// reach it and they do not mean the same thing: Remove is about the model, Cancel is about
+  /// one download, and the settings row can start a download the coordinator did not. Passing
+  /// the producer keeps that distinction explicit here instead of leaving the coordinator to
+  /// infer it from in-flight state that a user-initiated download would also set.
   private var legacyPrepareBeforeEnsure: (@MainActor @Sendable () async -> Bool)?
-  private var legacyRecordDecline: (@MainActor @Sendable () -> Bool)?
+  private var legacyRecordDecline:
+    (@MainActor @Sendable (EGOneUpgradeCoordinator.DeclineSource) -> Bool)?
   private var legacyDidAdmit: (@MainActor @Sendable () -> Void)?
 
   func installLegacyUpgradeHooks(
     beforeEnsure: @escaping @MainActor @Sendable () async -> Bool,
-    beforeDecline: @escaping @MainActor @Sendable () -> Bool,
+    beforeDecline: @escaping @MainActor @Sendable (EGOneUpgradeCoordinator.DeclineSource) -> Bool,
     onAdmitted: @escaping @MainActor @Sendable () -> Void
   ) {
     legacyPrepareBeforeEnsure = beforeEnsure
@@ -163,7 +170,7 @@ public final class EGOneDeliveryAdapter {
   /// model bytes, never the user's recorded decision). If admission already
   /// won the race, the verified model simply stays installed.
   public func cancel() async {
-    if let legacyRecordDecline, !legacyRecordDecline() {
+    if let legacyRecordDecline, !legacyRecordDecline(.cancel) {
       return
     }
 
@@ -176,7 +183,7 @@ public final class EGOneDeliveryAdapter {
   /// A3 - Explicit decline is recorded before the switch is consulted. The
   /// switch still prevents current-model deletion.
   public func remove() async -> ModelDeliveryController.RemoveOutcome {
-    if let legacyRecordDecline, !legacyRecordDecline() {
+    if let legacyRecordDecline, !legacyRecordDecline(.remove) {
       return .failed(
         DeliveryFailure(reason: .permissionDenied, detail: "replacement_marker_clear"))
     }

--- a/Sources/EnviousWisprLLM/EGOne/EGOneDeliveryAdapter.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneDeliveryAdapter.swift
@@ -37,7 +37,7 @@ public final class EGOneDeliveryAdapter {
 
   // MARK: - Legacy-upgrade hooks (#1386 PR-1)
 
-  /// Installed by `EGOneLegacyUpgradeCoordinator` at the composition root. The
+  /// Installed by `EGOneUpgradeCoordinator` at the composition root. The
   /// adapter stays the single delivery doorway; the coordinator's monolith
   /// retirement runs before any fetch door, and admission/decline outcomes are
   /// reported back so the owed marker never drifts from delivery reality.

--- a/Sources/EnviousWisprLLM/EGOne/EGOneUpgradeCoordinator.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneUpgradeCoordinator.swift
@@ -8,7 +8,7 @@ import Foundation
 /// them. Those responsibilities stay in EGOneDeliveryAdapter and
 /// ModelDeliveryController.
 @MainActor
-public final class EGOneLegacyUpgradeCoordinator {
+public final class EGOneUpgradeCoordinator {
   public struct TrustedArtifact: Sendable, Equatable {
     public let name: String
     public let sizeBytes: Int64

--- a/Sources/EnviousWisprLLM/EGOne/EGOneUpgradeCoordinator.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneUpgradeCoordinator.swift
@@ -94,6 +94,15 @@ public final class EGOneUpgradeCoordinator {
   private var automaticUpgradeInFlightCount = 0
   private var automaticUpgradeInFlight: Bool { automaticUpgradeInFlightCount > 0 }
 
+  /// Whether first-run setup has finished. EG-1 polish is a LIMB; during onboarding the HEART's
+  /// model (Parakeet or WhisperKit) is downloading, and dictation does not work at all until it
+  /// lands. A limb must never compete with it for bandwidth or disk.
+  private let isOnboardingComplete: @MainActor @Sendable () -> Bool
+
+  /// Set when a launch was turned away by onboarding, and the only thing `onboardingDidComplete`
+  /// acts on. Without it that entry point would be a second, unconditional launch trigger.
+  private var deferredForOnboarding = false
+
   private let ensureCurrentModel:
     @MainActor @Sendable () async -> ModelDeliveryController.DeliveryOutcome
   private let currentModelIsAdmitted: @MainActor @Sendable () async -> Bool
@@ -112,6 +121,7 @@ public final class EGOneUpgradeCoordinator {
     appSupportDirectory: URL,
     identity: ModelIdentity,
     installDirectory: URL,
+    isOnboardingComplete: @escaping @MainActor @Sendable () -> Bool,
     defaults: UserDefaults? = nil,
     trustedArtifact: TrustedArtifact = shippedLegacyArtifact
   ) {
@@ -123,6 +133,7 @@ public final class EGOneUpgradeCoordinator {
         ?? UserDefaults(suiteName: DeliveryFlags.suiteName)
         ?? .standard,
       trustedArtifact: trustedArtifact,
+      isOnboardingComplete: isOnboardingComplete,
       ensureCurrentModel: { [weak adapter] in
         guard let adapter else {
           return .failed(DeliveryFailure(reason: .unknown, detail: "adapter_released"))
@@ -151,6 +162,7 @@ public final class EGOneUpgradeCoordinator {
     installDirectory: URL,
     defaults: UserDefaults,
     trustedArtifact: TrustedArtifact,
+    isOnboardingComplete: @escaping @MainActor @Sendable () -> Bool = { true },
     ensureCurrentModel:
       @escaping @MainActor @Sendable () async -> ModelDeliveryController.DeliveryOutcome,
     currentModelIsAdmitted: @escaping @MainActor @Sendable () async -> Bool,
@@ -161,6 +173,7 @@ public final class EGOneUpgradeCoordinator {
     self.appSupportDirectory = appSupportDirectory
     self.identity = identity
     self.installDirectory = installDirectory
+    self.isOnboardingComplete = isOnboardingComplete
     self.defaults = defaults
     self.trustedArtifact = trustedArtifact
     self.ensureCurrentModel = ensureCurrentModel
@@ -240,6 +253,15 @@ public final class EGOneUpgradeCoordinator {
   public func runLaunch() async {
     guard isEnabled else { return }
 
+    // C15 - Defer the WHOLE launch while first-run setup is unfinished, before preparation and
+    // before any obligation is classified. Preparation can hash a 2.9 GB monolith, so gating only
+    // the fetch would still put a limb in the heart's way. Nothing is lost by waiting: this is
+    // re-entered the moment onboarding completes, in the same session.
+    guard isOnboardingComplete() else {
+      deferredForOnboarding = true
+      return
+    }
+
     let admitted = await currentModelIsAdmitted()
 
     // C11 - Classify the REVISION obligation BEFORE preparation runs.
@@ -279,6 +301,25 @@ public final class EGOneUpgradeCoordinator {
     if case .admitted = outcome {
       handleAdmission()
     }
+  }
+
+  /// Re-entry when first-run setup finishes, WITHOUT waiting for a relaunch.
+  ///
+  /// `runLaunch()` runs once at bootstrap, so a deferral with no re-arm would not mean "later" —
+  /// it would mean "never, until the app is restarted", and the user would sit on a superseded
+  /// model with nothing to tell them why. Guarded on `deferredForOnboarding` so this is a
+  /// RESUMPTION of a turned-away launch rather than a second unconditional trigger: an app whose
+  /// onboarding was already complete at launch does nothing here.
+  /// Returns whether a deferred launch was actually resumed. The caller needs that answer: the
+  /// bootstrap launch path is `runLaunch()` FOLLOWED BY `activateAfterAutomaticReplacementIfNeeded()`,
+  /// and a resumption that ran only the first half would admit the model and never boot the server,
+  /// leaving polish silently unavailable until some other activation path happened to run.
+  @discardableResult
+  public func onboardingDidComplete() async -> Bool {
+    guard deferredForOnboarding else { return false }
+    deferredForOnboarding = false
+    await runLaunch()
+    return true
   }
 
   /// The adapter's `beforeEnsure` door, and the ONLY caller that may clear a decline.

--- a/Sources/EnviousWisprLLM/EGOne/EGOneUpgradeCoordinator.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneUpgradeCoordinator.swift
@@ -2,13 +2,36 @@ import CryptoKit
 import EnviousWisprModelDelivery
 import Foundation
 
-/// Retires exactly one unsupported, app-owned EG-1 artifact.
+/// Owns one concern: **EG-1's installed bytes are superseded and a replacement is owed.**
 ///
-/// It does not understand current shards, download them, verify them, or admit
-/// them. Those responsibilities stay in EGOneDeliveryAdapter and
-/// ModelDeliveryController.
+/// That obligation has exactly two sources, and one response path serves both (#2096 §3b):
+///
+/// 1. **An unsupported, app-owned monolith** — the original `eg-1-v1.gguf`. Detected by a pinned
+///    size+digest, marked owed, then unlinked. This source, and only this source, deletes bytes.
+/// 2. **A superseded revision** — a prior revision of the SAME model was admitted, its bytes are
+///    still on disk, and the manifest this app ships names a different revision. Deletes nothing;
+///    the shared promotion path orphan-cleans the old shards once the new set is admitted.
+///
+/// The response is identical either way: owe, fetch through the adapter, then admit or decline.
+/// The delete-first step stays gated behind the digest-pinned `TrustedArtifact` and is unreachable
+/// from the revision trigger.
+///
+/// It still does not understand current shards, download them, verify them, or admit them. Those
+/// responsibilities stay in EGOneDeliveryAdapter and ModelDeliveryController.
 @MainActor
 public final class EGOneUpgradeCoordinator {
+  /// Which user action produced a decline. Cancel and Remove reach one hook but do NOT mean the
+  /// same thing, and #2066's lesson is not to attach meaning to a state with several producers
+  /// without distinguishing them. Remove is a statement about the MODEL; Cancel is a statement
+  /// about THIS DOWNLOAD, and the settings row can start a download we did not.
+  /// Internal on purpose. Both producers (`EGOneDeliveryAdapter.cancel` and `.remove`) and the
+  /// hook that carries this live in this module, so widening it to `public` would enlarge the
+  /// shipped surface for no consumer.
+  enum DeclineSource: Sendable, Equatable {
+    case cancel
+    case remove
+  }
+
   public struct TrustedArtifact: Sendable, Equatable {
     public let name: String
     public let sizeBytes: Int64
@@ -53,6 +76,24 @@ public final class EGOneUpgradeCoordinator {
   private let defaults: UserDefaults
   private let trustedArtifact: TrustedArtifact
 
+  /// The identity and install location of the manifest THIS app ships. Needed to recognise a
+  /// marker belonging to a different revision of the same model, and to check whether that
+  /// revision's files survive. Injected from the composition root, which already holds the
+  /// registration, rather than widening the adapter's surface to expose it.
+  private let identity: ModelIdentity
+  private let installDirectory: URL
+
+  /// True only while THIS coordinator is driving a fetch it started itself. It distinguishes an
+  /// automatic upgrade from a download the user began in settings — the two reach the same
+  /// adapter hooks and must not mean the same thing on cancel.
+  ///
+  /// A COUNT, not a flag. `runLaunch()` runs once at bootstrap today, but it is re-entered within
+  /// the same session when onboarding completes, so two automatic attempts can overlap. With a
+  /// plain Boolean the first to finish would clear it while the second was still fetching, and a
+  /// Cancel belonging to that second attempt would be misread as the user's own.
+  private var automaticUpgradeInFlightCount = 0
+  private var automaticUpgradeInFlight: Bool { automaticUpgradeInFlightCount > 0 }
+
   private let ensureCurrentModel:
     @MainActor @Sendable () async -> ModelDeliveryController.DeliveryOutcome
   private let currentModelIsAdmitted: @MainActor @Sendable () async -> Bool
@@ -69,11 +110,15 @@ public final class EGOneUpgradeCoordinator {
   public convenience init(
     adapter: EGOneDeliveryAdapter,
     appSupportDirectory: URL,
+    identity: ModelIdentity,
+    installDirectory: URL,
     defaults: UserDefaults? = nil,
     trustedArtifact: TrustedArtifact = shippedLegacyArtifact
   ) {
     self.init(
       appSupportDirectory: appSupportDirectory,
+      identity: identity,
+      installDirectory: installDirectory,
       defaults: defaults
         ?? UserDefaults(suiteName: DeliveryFlags.suiteName)
         ?? .standard,
@@ -93,8 +138,8 @@ public final class EGOneUpgradeCoordinator {
     // The adapter retains these closures, and therefore this coordinator.
     // The coordinator's adapter closures above are weak: no cycle.
     adapter.installLegacyUpgradeHooks(
-      beforeEnsure: { [self] in await prepareForDownload() },
-      beforeDecline: { [self] in recordUserDecline() },
+      beforeEnsure: { [self] in await prepareForEnsure() },
+      beforeDecline: { [self] source in recordUserDecline(source: source) },
       onAdmitted: { [self] in handleAdmission() }
     )
   }
@@ -102,6 +147,8 @@ public final class EGOneUpgradeCoordinator {
   /// Internal test seam. It changes no production abstraction.
   init(
     appSupportDirectory: URL,
+    identity: ModelIdentity,
+    installDirectory: URL,
     defaults: UserDefaults,
     trustedArtifact: TrustedArtifact,
     ensureCurrentModel:
@@ -112,6 +159,8 @@ public final class EGOneUpgradeCoordinator {
     removeItem: (@MainActor @Sendable (URL) throws -> Void)? = nil
   ) {
     self.appSupportDirectory = appSupportDirectory
+    self.identity = identity
+    self.installDirectory = installDirectory
     self.defaults = defaults
     self.trustedArtifact = trustedArtifact
     self.ensureCurrentModel = ensureCurrentModel
@@ -143,6 +192,44 @@ public final class EGOneUpgradeCoordinator {
     FileManager.default.fileExists(atPath: owedMarkerURL.path)
   }
 
+  /// Revision-scoped, so declining THIS model never suppresses the NEXT one. Keyed by
+  /// `cacheKey`, which is documented filesystem-safe and already carries family, name,
+  /// revision and variant.
+  private var revisionDeclineMarkerURL: URL {
+    metadataDirectory.appendingPathComponent("eg1-revision-decline-\(identity.cacheKey)")
+  }
+
+  private var isRevisionDeclined: Bool {
+    FileManager.default.fileExists(atPath: revisionDeclineMarkerURL.path)
+  }
+
+  /// D2 + D2b + D3 of plan §3.2. **D1 (the current manifest is not admitted) is deliberately NOT
+  /// here** — `runLaunch` already computes it asynchronously, and keeping this property
+  /// synchronous is what lets the decline path consult it.
+  ///
+  /// D2 is "a prior revision was admitted", never "the install directory has files in it".
+  /// `remove()` deletes only the roots the CURRENT manifest claims
+  /// (`ModelDeliveryController.remove`), so a previous revision's shards outlive it — testing
+  /// for files would resurrect a model the user deliberately deleted.
+  private var isRevisionUpgradeOwed: Bool {
+    guard !isRevisionDeclined else { return false }
+    return PriorRevisionAdmission.supersededInstallSurvives(
+      identity: identity,
+      metadataDirectory: metadataDirectory,
+      installDirectory: installDirectory)
+  }
+
+  @discardableResult
+  private func writeRevisionDecline() -> Bool {
+    guard !isRevisionDeclined else { return true }
+    return writeMarker(revisionDeclineMarkerURL)
+  }
+
+  private func clearRevisionDecline() {
+    guard isRevisionDeclined else { return }
+    try? removeItem(revisionDeclineMarkerURL)
+  }
+
   // C1 - One real switch for adapter and coordinator.
   private var isEnabled: Bool {
     EGOneDeliveryAdapter.isDeliveryEnabled(defaults: defaults)
@@ -155,20 +242,58 @@ public final class EGOneUpgradeCoordinator {
 
     let admitted = await currentModelIsAdmitted()
 
-    guard await prepareForDownload(), !containmentRefused else { return }
+    // C11 - Classify the REVISION obligation BEFORE preparation runs.
+    //
+    // Preparation can latch `containmentRefused` on a legacy-store topology that a revision
+    // upgrade neither reads nor deletes. Deciding afterwards would let that refusal suppress
+    // every future model upgrade permanently and silently, on a machine layout the user cannot
+    // know is the cause. Fail-closed is correct for deleting bytes; it is not correct for
+    // declining to fetch them.
+    let revisionUpgradeOwed = !admitted && isRevisionUpgradeOwed
+
+    // C3 - Preparation still runs on EVERY enabled launch, unconditionally. It is not merely a
+    // check: it is where an unmarked monolith is discovered, fingerprinted, marked owed, and
+    // unlinked. Gating it on a known obligation would mean a first-encounter monolith is never
+    // retired at all.
+    let prepared = await prepareForDownload()
 
     if admitted {
       handleAdmission()
       return
     }
 
-    guard isReplacementOwed else { return }
+    // The LEGACY obligation keeps both of its original guards: preparation must have succeeded
+    // and containment must not have been refused. Only its scope narrowed.
+    let legacyOwed = prepared && !containmentRefused && isReplacementOwed
+
+    guard legacyOwed || revisionUpgradeOwed else { return }
 
     // C7 - The existing adapter/controller is the only download door.
+    //
+    // Marked in-flight across the fetch so a Cancel arriving through the adapter's shared
+    // decline hook is attributable to US rather than to the settings row.
+    automaticUpgradeInFlightCount += 1
     let outcome = await ensureCurrentModel()
+    automaticUpgradeInFlightCount -= 1
+
     if case .admitted = outcome {
       handleAdmission()
     }
+  }
+
+  /// The adapter's `beforeEnsure` door, and the ONLY caller that may clear a decline.
+  ///
+  /// Reached by both an automatic upgrade and a user pressing Download / Try Again. Only the
+  /// second clears: pressing Download is the clearest possible statement of intent, while our
+  /// own fetch must not erase the record of a refusal it is about to act against. `runLaunch`
+  /// calls `prepareForDownload()` directly rather than coming through here, so a launch can
+  /// never clear a decline on its way past.
+  ///
+  /// This lives on the coordinator rather than inside the composition root's closure so it is
+  /// reachable from the test seam; logic that only exists in a wiring closure cannot be tested.
+  func prepareForEnsure() async -> Bool {
+    if !automaticUpgradeInFlight { clearRevisionDecline() }
+    return await prepareForDownload()
   }
 
   // C3 - Launch and a simultaneous Download click share one fingerprint/delete.
@@ -342,7 +467,15 @@ public final class EGOneUpgradeCoordinator {
   // C8 - Admission clears the marker only while model delivery is enabled and
   // preparation did not refuse the old-store topology.
   private func handleAdmission() {
-    guard isEnabled, !containmentRefused else { return }
+    guard isEnabled else { return }
+
+    // C12 - A successful admission settles the REVISION decline regardless of legacy
+    // containment. Containment describes the old PolishModels store, which this obligation
+    // never touched; leaving a decline behind after the model demonstrably installed would
+    // suppress the NEXT revision for no reason the user could discover.
+    clearRevisionDecline()
+
+    guard !containmentRefused else { return }
     let wasOwed = isReplacementOwed
     guard clearOwedMarker() else { return }
     if wasOwed {
@@ -351,7 +484,23 @@ public final class EGOneUpgradeCoordinator {
   }
 
   // C9 - Explicit Cancel/Remove records decline even while delivery is off.
-  func recordUserDecline() -> Bool {
+  //
+  // C13 - The two producers are separated rather than inferred. **Remove** is a statement about
+  // the MODEL and always declines while an upgrade is owed — without it, `remove()` leaves the
+  // previous revision's marker and shards untouched, so the next launch would re-fetch 2.9 GB of
+  // the very thing the user just deleted. **Cancel** is a statement about THIS DOWNLOAD, so it
+  // declines only when the download was ours; the settings row's own Cancel must not poison the
+  // automatic path.
+  // C14 - A decline that could not be PERSISTED must block the action, exactly as the legacy
+  // marker write does. Ignoring a failed write would let Cancel/Remove succeed while the refusal
+  // existed only in memory, and the next launch would automatically re-fetch the model the user
+  // just declined — the failure being silent is precisely what makes it worth failing closed.
+  // Written before the owed marker is cleared, so a failure leaves BOTH markers in their
+  // pre-decline state rather than a half-applied one.
+  func recordUserDecline(source: DeclineSource) -> Bool {
+    let declinesRevision = source == .remove ? isRevisionUpgradeOwed : automaticUpgradeInFlight
+    guard !declinesRevision || writeRevisionDecline() else { return false }
+
     let wasOwed = isReplacementOwed
     guard clearOwedMarker() else { return false }
     if wasOwed {

--- a/Sources/EnviousWisprLLM/EGOne/EGOneUpgradeCoordinator.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneUpgradeCoordinator.swift
@@ -51,12 +51,27 @@ public final class EGOneUpgradeCoordinator {
     case containment
   }
 
+  /// Where an ELIGIBLE upgrade actually went. Emitted for every eligible install, including the
+  /// ones that go nowhere, because the denominator is the point: an upgrade that never begins is
+  /// the exact failure this whole path exists to prevent, and counting only started attempts
+  /// would grade the successes and hide it.
+  public enum UpgradeRouting: String, Sendable, Equatable {
+    case started
+    case declined
+    case disabled
+    case deferredOnboarding = "deferred_onboarding"
+  }
+
   public enum Event: Sendable, Equatable {
     case legacyDetected
     case legacyRetired
     case legacyRetirementFailed(reason: FailureReason)
     case replacementCompleted
     case replacementDeclined
+    case upgradeEligible(
+      routing: UpgradeRouting, targetRevision: String,
+      deliveryEnabled: Bool, onboardingComplete: Bool)
+    case upgradeDeclined(targetRevision: String)
   }
 
   public static let shippedLegacyArtifact = TrustedArtifact(
@@ -224,6 +239,37 @@ public final class EGOneUpgradeCoordinator {
   /// `remove()` deletes only the roots the CURRENT manifest claims
   /// (`ModelDeliveryController.remove`), so a previous revision's shards outlive it — testing
   /// for files would resurrect a model the user deliberately deleted.
+  /// D2 + D2b ALONE — a prior revision was admitted and its bytes survive. Deliberately separate
+  /// from the decline check so eligibility can be classified BEFORE any gate: a declined or
+  /// disabled install is still an install that could have upgraded, and it belongs in the
+  /// denominator.
+  private var hasSupersededInstall: Bool {
+    PriorRevisionAdmission.supersededInstallSurvives(
+      identity: identity,
+      metadataDirectory: metadataDirectory,
+      installDirectory: installDirectory)
+  }
+
+  /// Which gate an eligible upgrade will actually meet, evaluated in the order the gates are
+  /// taken so the reported reason is the OUTERMOST one that stops it. `.started` is a statement
+  /// about routing, not about success: the fetch can still fail, and that failure is reported by
+  /// the shared `model_delivery.*` funnel rather than duplicated here.
+  /// Evaluated in the order `runLaunch` ACTUALLY takes the gates — disabled, then onboarding,
+  /// then decline — so the reported reason is the one that really stopped this install. An
+  /// earlier draft checked decline before onboarding and would have reported `.declined` for an
+  /// install that was in fact waiting on first-run setup.
+  ///
+  /// Both facts are passed in rather than re-read, so the routing cannot disagree with the gates
+  /// the same launch then takes.
+  private func currentRouting(
+    deliveryEnabled: Bool, onboardingComplete: Bool
+  ) -> UpgradeRouting {
+    if !deliveryEnabled { return .disabled }
+    if !onboardingComplete { return .deferredOnboarding }
+    if isRevisionDeclined { return .declined }
+    return .started
+  }
+
   private var isRevisionUpgradeOwed: Bool {
     guard !isRevisionDeclined else { return false }
     return PriorRevisionAdmission.supersededInstallSurvives(
@@ -251,18 +297,36 @@ public final class EGOneUpgradeCoordinator {
   // C2 - Prepare before the admitted return so an exact reintroduced monolith
   // is still retired.
   public func runLaunch() async {
-    guard isEnabled else { return }
+    // C16 - Classify ELIGIBILITY before every gate, and emit it before taking any of them.
+    //
+    // This is the denominator, and it must count the installs that go nowhere. #1386's ship
+    // criterion counted from `attempt_started`, which grades only the upgrades that began — but an
+    // upgrade that never begins is the exact failure this path exists to prevent, so that shape
+    // would have reported success while hiding it. Reading admission while the kill switch is off
+    // is a read, never a mutation, and matches what `adoptIfPresent` already does when disabled.
+    let admitted = await currentModelIsAdmitted()
+    let deliveryEnabled = isEnabled
+    let onboardingComplete = isOnboardingComplete()
+    if !admitted, hasSupersededInstall {
+      emit(
+        .upgradeEligible(
+          routing: currentRouting(
+            deliveryEnabled: deliveryEnabled, onboardingComplete: onboardingComplete),
+          targetRevision: identity.revision,
+          deliveryEnabled: deliveryEnabled,
+          onboardingComplete: onboardingComplete))
+    }
+
+    guard deliveryEnabled else { return }
 
     // C15 - Defer the WHOLE launch while first-run setup is unfinished, before preparation and
     // before any obligation is classified. Preparation can hash a 2.9 GB monolith, so gating only
     // the fetch would still put a limb in the heart's way. Nothing is lost by waiting: this is
     // re-entered the moment onboarding completes, in the same session.
-    guard isOnboardingComplete() else {
+    guard onboardingComplete else {
       deferredForOnboarding = true
       return
     }
-
-    let admitted = await currentModelIsAdmitted()
 
     // C11 - Classify the REVISION obligation BEFORE preparation runs.
     //
@@ -541,6 +605,9 @@ public final class EGOneUpgradeCoordinator {
   func recordUserDecline(source: DeclineSource) -> Bool {
     let declinesRevision = source == .remove ? isRevisionUpgradeOwed : automaticUpgradeInFlight
     guard !declinesRevision || writeRevisionDecline() else { return false }
+    // Emitted only after the decline is DURABLE. An event for a refusal that failed to persist
+    // would report an outcome the next launch is about to contradict.
+    if declinesRevision { emit(.upgradeDeclined(targetRevision: identity.revision)) }
 
     let wasOwed = isReplacementOwed
     guard clearOwedMarker() else { return false }

--- a/Sources/EnviousWisprModelDelivery/CacheAdmission.swift
+++ b/Sources/EnviousWisprModelDelivery/CacheAdmission.swift
@@ -285,6 +285,26 @@ struct CacheAdmission {
     let marker = AdmissionMarker(
       manifestDigest: manifest.manifestDigest, admittedAt: Date(), files: stamps)
     try JSONEncoder().encode(marker).write(to: markerURL, options: .atomic)
+
+    // (5) Superseded-marker cleanup (#2096). Step (3) already removed the previous revision's
+    // FILES, because they sit in this install dir and the current manifest does not list them.
+    // Its markers do not: they live in the metadata directory, which every family shares, so
+    // nothing here has ever swept them. That is the half `evictPreviousRevisions` named and never
+    // delivered — the flag has shipped decoded and unread, `true` for EG-1 and `false` for
+    // Parakeet and WhisperKit, so honouring it changes exactly the family that asked for it.
+    //
+    // AFTER the marker write, never before: running it earlier and then failing at (4) would
+    // leave the machine with no admitted revision AND no record that one was ever admitted.
+    // Best-effort for the same reason a failure here is not a correctness problem — the model is
+    // admitted, and a leftover marker only means the next launch sees an already-admitted current
+    // revision and stops. Blocking admission over hygiene would be the worse trade.
+    if manifest.admission.evictPreviousRevisions {
+      for superseded in PriorRevisionAdmission.markerURLs(
+        for: manifest.identity, metadataDirectory: metadataDirectory)
+      {
+        try? fm.removeItem(at: superseded)
+      }
+    }
   }
 
   /// Whether ANY manifest file of this component exists in the install dir

--- a/Sources/EnviousWisprModelDelivery/LegacyArtifactRetirement.swift
+++ b/Sources/EnviousWisprModelDelivery/LegacyArtifactRetirement.swift
@@ -8,9 +8,10 @@ import Foundation
 /// business in a type that also serves a foreign Hugging Face cache, and WhisperKit's
 /// Documents/TCC concerns must never leak into EG-1.
 ///
-/// Extracted from `EGOneLegacyUpgradeCoordinator` (#1386 PR-2a), which keeps 100% of its
-/// policy and calls this for the mechanism. That coordinator's 29 tests are this
-/// extraction's oracle and must pass unmodified.
+/// Extracted from `EGOneUpgradeCoordinator` (#1386 PR-2a, when it was named
+/// `EGOneLegacyUpgradeCoordinator`), which keeps 100% of its policy and calls this for the
+/// mechanism. The 29 tests that coordinator had at extraction time are this extraction's
+/// oracle and must keep passing unmodified; later chunks may ADD cases beside them.
 public enum LegacyRetirement {
 
   // MARK: - Inputs

--- a/Sources/EnviousWisprModelDelivery/PriorRevisionAdmission.swift
+++ b/Sources/EnviousWisprModelDelivery/PriorRevisionAdmission.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+/// Reads the admission markers of OTHER revisions of the same model (#2096).
+///
+/// This module owns the admission-marker FORMAT, so reading it lives here. The POLICY of what
+/// to do about a superseded revision — whether to fetch, when to defer, what a decline means —
+/// stays in the owning family's coordinator, which is the only place that knows it. Nothing in
+/// this type decides anything; it answers two questions about files on disk.
+///
+/// Markers are named `<cacheKey>.admission.json` and share ONE metadata directory across every
+/// family, so identification must be exact. `cacheKey` is
+/// `family-name-revision[-variant]` and BOTH `name` and `revision` may contain hyphens
+/// (`eg_one-eg-1-v3-eg2-q5km`), so the revision cannot be recovered by splitting on `-`.
+/// Instead the known-constant prefix and suffix are stripped: everything between
+/// `family-name-` and `[-variant].admission.json` is the revision, whatever it contains.
+public enum PriorRevisionAdmission {
+
+  /// Markers in `metadataDirectory` for the same `family` AND `name` as `identity`, at a
+  /// DIFFERENT revision. Empty when the directory cannot be read — the caller treats an
+  /// unreadable metadata directory as "no prior revision", which fails closed (no download).
+  /// Internal: only `supersededInstallSurvives` is needed across modules, and chunk 4's marker
+  /// cleanup lives in this same module. Keeping the public surface to exactly one function.
+  static func markerURLs(for identity: ModelIdentity, metadataDirectory: URL) -> [URL] {
+    let prefix = "\(identity.family.rawValue)-\(identity.name)-"
+    let suffix =
+      identity.variant.isEmpty ? ".admission.json" : "-\(identity.variant).admission.json"
+    let current = "\(identity.cacheKey).admission.json"
+
+    guard
+      let entries = try? FileManager.default.contentsOfDirectory(
+        at: metadataDirectory, includingPropertiesForKeys: nil)
+    else { return [] }
+
+    return entries.filter { url in
+      let name = url.lastPathComponent
+      guard name != current, name.hasPrefix(prefix), name.hasSuffix(suffix) else { return false }
+      // A degenerate identity could make prefix and suffix overlap in a short name and admit a
+      // file that is neither. Require a non-empty revision segment between them.
+      return name.count > prefix.count + suffix.count
+    }
+  }
+
+  /// True when a prior revision was admitted AND at least one file it recorded is STILL on disk.
+  ///
+  /// The marker alone proves an install once completed, never that its bytes survive: a user who
+  /// reclaimed space in Finder or with a cleaner tool must not have gigabytes re-fetched unasked.
+  /// This is a `stat` per recorded file with no hashing — it answers "is there something left to
+  /// supersede", not "is it valid".
+  ///
+  /// Fails closed in every direction: an unreadable directory, an undecodable marker, a marker
+  /// recording no files, or files that are all gone all yield `false`, and `false` means no
+  /// automatic download.
+  public static func supersededInstallSurvives(
+    identity: ModelIdentity, metadataDirectory: URL, installDirectory: URL
+  ) -> Bool {
+    let fm = FileManager.default
+    for markerURL in markerURLs(for: identity, metadataDirectory: metadataDirectory) {
+      guard let data = try? Data(contentsOf: markerURL),
+        let marker = try? JSONDecoder().decode(CacheAdmission.AdmissionMarker.self, from: data),
+        !marker.files.isEmpty
+      else { continue }
+
+      for stamp in marker.files
+      where fm.fileExists(atPath: installDirectory.appendingPathComponent(stamp.path).path) {
+        return true
+      }
+    }
+    return false
+  }
+}

--- a/Sources/EnviousWisprPipeline/WhisperKitLegacyUpgradeCoordinator.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitLegacyUpgradeCoordinator.swift
@@ -9,7 +9,7 @@ import Foundation
 /// epic #1348 exists to delete. This runs on **every launch, forever**: ~700 downloads to date
 /// must still work whenever those users upgrade, so the common path has to stay free.
 ///
-/// Mirrors `EGOneLegacyUpgradeCoordinator`'s shape and shares its mechanism via
+/// Mirrors `EGOneUpgradeCoordinator`'s shape and shares its mechanism via
 /// `LegacyRetirement` (#1386 PR-2a). What differs is policy, and only policy: EG-1 retires one
 /// flat app-owned file; this retires 24 nested files from a foreign cache another app may also
 /// be writing.

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -348,7 +348,7 @@ import Testing
   /// all decision logic lives on the presenter, not here. Cap by deterministic
   /// rule (actual 1018 + 7, rounded up to nearest 5 = 1025).
   /// Ratcheted 1025→1045 in #1386 PR-1 (2026-07-11): the composition root
-  /// constructs `EGOneLegacyUpgradeCoordinator` over the existing adapter,
+  /// constructs `EGOneUpgradeCoordinator` over the existing adapter,
   /// wires its telemetry handler (attaching `selected_provider` here, where
   /// settings is in scope, so the coordinator stays provider-ignorant), and
   /// runs the one-time legacy launch table after the first-run baseline. All

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -448,14 +448,23 @@ import Testing
   /// concrete capture manager and the settings manager at the same time. No
   /// domain logic moved here; the limb's entire behaviour lives on its own types.
   /// Cap by deterministic rule (actual 1336 + ~2, rounded up to nearest 5 = 1340).
+  /// #2096 (automatic model-revision upgrade): 1340 → 1350 for TEN lines — one argument on the
+  /// coordinator's construction, one capture-list entry, and an eight-line resume block (three of
+  /// them comment) on the existing settings-change handler. The deferral behaviour lives on
+  /// `EGOneUpgradeCoordinator`: it owns the deferred flag, decides what a deferral means, and
+  /// exposes `onboardingDidComplete()` as the resumption. This root passes a FACT, forwards one
+  /// event, and follows a real resumption with the existing runtime activation call. Only the
+  /// composition root holds settings, the coordinator, and the runtime together. Extracting this
+  /// wiring into an installer would add lines here rather than remove them. No domain logic moved
+  /// here. Cap by deterministic rule (actual 1348 + ~2, rounded up to nearest 5 = 1350).
   @Test func envWisprAppLineCountCeilingHolds() throws {
     let url = envWisprAppURL()
     let source = try String(contentsOf: url, encoding: .utf8)
     let lineCount = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
-      lineCount <= 1340,
+      lineCount <= 1350,
       """
-      WisprBootstrapper line count exceeded: \(lineCount) > 1340. \
+      WisprBootstrapper line count exceeded: \(lineCount) > 1350. \
       Raising the ceiling requires a Bible changelog entry.
       """)
   }

--- a/Tests/EnviousWisprTests/LLM/EGOneDeliveryAdapterTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneDeliveryAdapterTests.swift
@@ -167,7 +167,10 @@ import Testing
       controller: controller, registration: registration, version: "v2-sharded",
       defaults: store)
     let coordinator = EGOneUpgradeCoordinator(
-      adapter: adapter, appSupportDirectory: root, defaults: store)
+      adapter: adapter, appSupportDirectory: root,
+      identity: registration.manifest.identity,
+      installDirectory: registration.installDirectory,
+      defaults: store)
     let events = EventBox()
     coordinator.onEvent = { [events] event in
       events.events.append(event)

--- a/Tests/EnviousWisprTests/LLM/EGOneDeliveryAdapterTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneDeliveryAdapterTests.swift
@@ -170,6 +170,7 @@ import Testing
       adapter: adapter, appSupportDirectory: root,
       identity: registration.manifest.identity,
       installDirectory: registration.installDirectory,
+      isOnboardingComplete: { true },
       defaults: store)
     let events = EventBox()
     coordinator.onEvent = { [events] event in

--- a/Tests/EnviousWisprTests/LLM/EGOneDeliveryAdapterTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneDeliveryAdapterTests.swift
@@ -126,7 +126,7 @@ import Testing
     let store: UserDefaults
     let suite: String
     let adapter: EGOneDeliveryAdapter
-    let coordinator: EGOneLegacyUpgradeCoordinator
+    let coordinator: EGOneUpgradeCoordinator
     let controller: ModelDeliveryController
     let registration: DeliveryRegistration
     let events: EventBox
@@ -139,7 +139,7 @@ import Testing
 
   @MainActor
   final class EventBox {
-    var events: [EGOneLegacyUpgradeCoordinator.Event] = []
+    var events: [EGOneUpgradeCoordinator.Event] = []
   }
 
   private func markerURL(_ root: URL) -> URL {
@@ -166,7 +166,7 @@ import Testing
     let adapter = EGOneDeliveryAdapter(
       controller: controller, registration: registration, version: "v2-sharded",
       defaults: store)
-    let coordinator = EGOneLegacyUpgradeCoordinator(
+    let coordinator = EGOneUpgradeCoordinator(
       adapter: adapter, appSupportDirectory: root, defaults: store)
     let events = EventBox()
     coordinator.onEvent = { [events] event in

--- a/Tests/EnviousWisprTests/LLM/EGOneRevisionUpgradeTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneRevisionUpgradeTests.swift
@@ -96,7 +96,8 @@ import Testing
     defaults: UserDefaults,
     probe: Probe,
     identity: ModelIdentity? = nil,
-    writeMarker: (@MainActor @Sendable (URL) -> Bool)? = nil
+    writeMarker: (@MainActor @Sendable (URL) -> Bool)? = nil,
+    isOnboardingComplete: @escaping @MainActor @Sendable () -> Bool = { true }
   ) -> EGOneUpgradeCoordinator {
     let subject = EGOneUpgradeCoordinator(
       appSupportDirectory: root,
@@ -104,6 +105,7 @@ import Testing
       installDirectory: installDirectory(root),
       defaults: defaults,
       trustedArtifact: .init(name: "eg-1-v1.gguf", sizeBytes: 11, sha256: "unused-here"),
+      isOnboardingComplete: isOnboardingComplete,
       ensureCurrentModel: {
         probe.ensureCount += 1
         return probe.ensureOutcome
@@ -117,6 +119,82 @@ import Testing
     )
     subject.onEvent = { event in probe.events.append(event) }
     return subject
+  }
+
+  // MARK: - Onboarding deferral
+
+  /// EG-1 polish is a LIMB. During first-run setup the HEART's model is downloading and dictation
+  /// does not work at all until it lands, so a limb must never compete with it.
+  @MainActor
+  @Test func upgradeDefersWhileOnboardingIncomplete() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    try stagePriorAdmission(root: root)
+    let probe = Probe()
+    let subject = coordinator(
+      root: root, defaults: store, probe: probe, isOnboardingComplete: { false })
+
+    await subject.runLaunch()
+
+    #expect(probe.ensureCount == 0, "the limb stands aside while the heart's model downloads")
+  }
+
+  /// The deferral must RE-ARM in the same session. `runLaunch` fires once at bootstrap, so without
+  /// this the deferral would silently mean "never, until the app is restarted" and the user would
+  /// sit on a superseded model with nothing to tell them why.
+  @MainActor
+  @Test func upgradeStartsWhenOnboardingCompletesWithoutRelaunch() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    try stagePriorAdmission(root: root)
+    let probe = Probe()
+    let onboarded = OnboardingGate()
+    let subject = coordinator(
+      root: root, defaults: store, probe: probe,
+      isOnboardingComplete: { [onboarded] in onboarded.complete })
+
+    await subject.runLaunch()
+    #expect(probe.ensureCount == 0, "precondition: it really did defer")
+
+    onboarded.complete = true
+    #expect(await subject.onboardingDidComplete(), "it reports a REAL resumption to its caller")
+
+    #expect(probe.ensureCount == 1, "the upgrade resumes without waiting for a relaunch")
+  }
+
+  /// The control that keeps the resume from becoming a second, unconditional launch trigger. An
+  /// app whose onboarding was already finished at launch has nothing deferred, so completing
+  /// onboarding again must do nothing at all.
+  @MainActor
+  @Test func onboardingCompletionDoesNothingWhenNothingWasDeferred() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    try stagePriorAdmission(root: root)
+    let probe = Probe()
+    let subject = coordinator(root: root, defaults: store, probe: probe)
+
+    await subject.runLaunch()
+    #expect(probe.ensureCount == 1)
+
+    #expect(
+      !(await subject.onboardingDidComplete()),
+      "nothing was deferred, so the caller must NOT be told to run post-upgrade activation")
+
+    #expect(probe.ensureCount == 1, "no second fetch: nothing had been deferred")
+  }
+
+  @MainActor
+  private final class OnboardingGate {
+    var complete = false
   }
 
   // MARK: - D2: a prior revision was admitted

--- a/Tests/EnviousWisprTests/LLM/EGOneRevisionUpgradeTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneRevisionUpgradeTests.swift
@@ -121,6 +121,137 @@ import Testing
     return subject
   }
 
+  // MARK: - Telemetry: the eligibility denominator
+
+  @MainActor
+  private func eligibleRoutings(_ probe: Probe) -> [EGOneUpgradeCoordinator.UpgradeRouting] {
+    probe.events.compactMap {
+      if case .upgradeEligible(let routing, _, _, _) = $0 { return routing }
+      return nil
+    }
+  }
+
+  /// The denominator must be emitted BEFORE every gate, including the gates that stop the upgrade
+  /// dead. #1386's ship criterion counted from `attempt_started`, which grades only the upgrades
+  /// that began — but an upgrade that never begins is the exact failure this path exists to
+  /// prevent, so that shape reports success while hiding it.
+  @MainActor
+  @Test func eligibleEventFiresBeforeEveryGate() async throws {
+    for (label, arrange, expected) in [
+      (
+        "disabled",
+        { (store: UserDefaults, _: URL) in
+          store.set(false, forKey: DeliveryFlags.key("enabled", family: .egOne))
+        },
+        EGOneUpgradeCoordinator.UpgradeRouting.disabled
+      ),
+      (
+        "declined",
+        { (_: UserDefaults, root: URL) in
+          try? Data().write(to: self.declineMarker(root))
+        },
+        .declined
+      ),
+      ("started", { (_: UserDefaults, _: URL) in }, .started),
+    ] {
+      let root = try makeRoot()
+      defer { try? FileManager.default.removeItem(at: root) }
+      let (store, suite) = try defaults()
+      defer { store.removePersistentDomain(forName: suite) }
+
+      try stagePriorAdmission(root: root)
+      arrange(store, root)
+
+      let probe = Probe()
+      let subject = coordinator(root: root, defaults: store, probe: probe)
+      await subject.runLaunch()
+
+      #expect(
+        eligibleRoutings(probe) == [expected],
+        "eligible install routed \(label) must still emit exactly one denominator event")
+    }
+  }
+
+  /// The onboarding routing, which needs its own case because the deferral gate sits between the
+  /// kill switch and the decline check.
+  @MainActor
+  @Test func eligibleEventReportsOnboardingDeferral() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    try stagePriorAdmission(root: root)
+    // A decline is ALSO recorded. Onboarding must still win, because that is the gate this launch
+    // actually meets first. Without this the case would pass under either ordering.
+    try Data().write(to: declineMarker(root))
+    let probe = Probe()
+    let subject = coordinator(
+      root: root, defaults: store, probe: probe, isOnboardingComplete: { false })
+
+    await subject.runLaunch()
+
+    #expect(
+      eligibleRoutings(probe) == [.deferredOnboarding],
+      "onboarding outranks decline, matching the order runLaunch takes the gates")
+  }
+
+  /// The control. An install that could never have upgraded is NOT in the denominator, or the
+  /// completion rate would be diluted by every user who was never a candidate.
+  @MainActor
+  @Test func ineligibleInstallIsNotCountedInTheDenominator() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    // No prior admission at all: a first-run user.
+    let probe = Probe()
+    let subject = coordinator(root: root, defaults: store, probe: probe)
+    await subject.runLaunch()
+    #expect(eligibleRoutings(probe).isEmpty, "a first-run user was never a candidate")
+
+    // And an already-admitted current revision, which has nothing left to take.
+    let root2 = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root2) }
+    try stagePriorAdmission(root: root2)
+    let probe2 = Probe()
+    probe2.admitted = true
+    let subject2 = coordinator(root: root2, defaults: store, probe: probe2)
+    await subject2.runLaunch()
+    #expect(eligibleRoutings(probe2).isEmpty, "already on the current revision")
+  }
+
+  /// `upgrade_declined` reports a DURABLE refusal. Emitting one for a decline that failed to
+  /// persist would report an outcome the very next launch contradicts.
+  @MainActor
+  @Test func declinedEventFiresOnlyWhenTheDeclinePersisted() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    try stagePriorAdmission(root: root)
+
+    let ok = Probe()
+    let succeeds = coordinator(root: root, defaults: store, probe: ok)
+    #expect(succeeds.recordUserDecline(source: .remove))
+    #expect(
+      ok.events.contains(.upgradeDeclined(targetRevision: Self.currentRevision)),
+      "a persisted decline is reported")
+
+    let root2 = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root2) }
+    try stagePriorAdmission(root: root2)
+    let failed = Probe()
+    let fails = coordinator(
+      root: root2, defaults: store, probe: failed, writeMarker: { _ in false })
+    #expect(fails.recordUserDecline(source: .remove) == false)
+    #expect(
+      !failed.events.contains(.upgradeDeclined(targetRevision: Self.currentRevision)),
+      "an unpersisted decline is NOT reported")
+  }
+
   // MARK: - Onboarding deferral
 
   /// EG-1 polish is a LIMB. During first-run setup the HEART's model is downloading and dictation

--- a/Tests/EnviousWisprTests/LLM/EGOneRevisionUpgradeTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneRevisionUpgradeTests.swift
@@ -1,0 +1,698 @@
+import CryptoKit
+import Foundation
+import Testing
+
+@testable import EnviousWisprLLM
+@testable import EnviousWisprModelDelivery
+
+/// The SECOND obligation source on `EGOneUpgradeCoordinator` (#2096 §3.2): a prior revision of
+/// the same model was admitted, its bytes are still on disk, and this app ships a different
+/// revision. Kept in its own suite so `EGOneUpgradeCoordinatorTests` stays recognisable as the
+/// 29-case monolith-retirement oracle that `LegacyRetirement` names as its extraction oracle —
+/// these cases stage admission markers, those stage a monolith, and mixing the fixtures would
+/// make both harder to read.
+///
+/// Every guard here is proven against a negative control: the test that shows a protection holds
+/// is paired with one showing the same code fetches when the protection is removed, so a guard
+/// that silently stopped working could not pass both.
+@Suite struct EGOneRevisionUpgradeTests {
+  static let currentRevision = "v3-eg2"
+  static let priorRevision = "v2-sharded"
+
+  static func identity(revision: String = currentRevision) -> ModelIdentity {
+    ModelIdentity(
+      family: .egOne, name: "eg-1", revision: revision, variant: "q5km", runtimeABI: "test")
+  }
+
+  @MainActor
+  private final class Probe {
+    var admitted = false
+    var ensureCount = 0
+    var ensureOutcome: ModelDeliveryController.DeliveryOutcome = .admitted
+    var removedURLs: [URL] = []
+    var events: [EGOneUpgradeCoordinator.Event] = []
+  }
+
+  // MARK: - Fixtures
+
+  private func makeRoot() throws -> URL {
+    let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+      "eg1-revision-upgrade-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    return root
+  }
+
+  private func metadataDirectory(_ root: URL) -> URL {
+    root.appendingPathComponent("EnviousWispr/ModelDelivery", isDirectory: true)
+  }
+
+  private func installDirectory(_ root: URL) -> URL {
+    root.appendingPathComponent("EnviousWispr/Models/eg-1", isDirectory: true)
+  }
+
+  private func declineMarker(_ root: URL, revision: String = currentRevision) -> URL {
+    metadataDirectory(root).appendingPathComponent(
+      "eg1-revision-decline-\(Self.identity(revision: revision).cacheKey)")
+  }
+
+  private func defaults() throws -> (UserDefaults, String) {
+    let suite = "eg1-revision-test-\(UUID().uuidString)"
+    return (try #require(UserDefaults(suiteName: suite)), suite)
+  }
+
+  /// Writes a REAL `CacheAdmission.AdmissionMarker` for `revision`, and optionally the files it
+  /// records. Using the production type rather than hand-rolled JSON means a change to the
+  /// marker's shape breaks these tests instead of silently making them test nothing.
+  @discardableResult
+  private func stagePriorAdmission(
+    root: URL,
+    revision: String = priorRevision,
+    fileNames: [String] = ["eg-1-v1-00001-of-00008.gguf", "eg-1-v1-00002-of-00008.gguf"],
+    createFiles: Bool = true
+  ) throws -> URL {
+    let metadata = metadataDirectory(root)
+    let install = installDirectory(root)
+    try FileManager.default.createDirectory(at: metadata, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: install, withIntermediateDirectories: true)
+
+    var stamps: [CacheAdmission.AdmissionMarker.FileStamp] = []
+    for name in fileNames {
+      let url = install.appendingPathComponent(name)
+      if createFiles { try Data("prior-revision-bytes".utf8).write(to: url) }
+      stamps.append(.init(path: name, sizeBytes: 20, mtime: 1))
+    }
+
+    let marker = CacheAdmission.AdmissionMarker(
+      manifestDigest: "prior-digest", admittedAt: Date(timeIntervalSince1970: 1), files: stamps)
+    let url = metadata.appendingPathComponent(
+      "\(Self.identity(revision: revision).cacheKey).admission.json")
+    try JSONEncoder().encode(marker).write(to: url)
+    return url
+  }
+
+  @MainActor
+  private func coordinator(
+    root: URL,
+    defaults: UserDefaults,
+    probe: Probe,
+    identity: ModelIdentity? = nil,
+    writeMarker: (@MainActor @Sendable (URL) -> Bool)? = nil
+  ) -> EGOneUpgradeCoordinator {
+    let subject = EGOneUpgradeCoordinator(
+      appSupportDirectory: root,
+      identity: identity ?? Self.identity(),
+      installDirectory: installDirectory(root),
+      defaults: defaults,
+      trustedArtifact: .init(name: "eg-1-v1.gguf", sizeBytes: 11, sha256: "unused-here"),
+      ensureCurrentModel: {
+        probe.ensureCount += 1
+        return probe.ensureOutcome
+      },
+      currentModelIsAdmitted: { probe.admitted },
+      writeMarker: writeMarker,
+      removeItem: { url in
+        probe.removedURLs.append(url)
+        try FileManager.default.removeItem(at: url)
+      }
+    )
+    subject.onEvent = { event in probe.events.append(event) }
+    return subject
+  }
+
+  // MARK: - D2: a prior revision was admitted
+
+  @MainActor
+  @Test func autoUpgradeStartsWhenPriorRevisionMarkerExists() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    try stagePriorAdmission(root: root)
+    let probe = Probe()
+    let subject = coordinator(root: root, defaults: store, probe: probe)
+
+    await subject.runLaunch()
+
+    #expect(probe.ensureCount == 1, "a superseded revision with surviving bytes owes a fetch")
+  }
+
+  /// The negative control for the case above, and the invariant `EGOneRuntime`'s never-fetch
+  /// comment protects: a user who never had EG-1 has no prior marker, so nothing starts behind
+  /// their back. Same code, same launch, only the marker removed.
+  @MainActor
+  @Test func autoUpgradeDoesNotStartForFirstRunUser() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    let probe = Probe()
+    let subject = coordinator(root: root, defaults: store, probe: probe)
+
+    await subject.runLaunch()
+
+    #expect(probe.ensureCount == 0, "no prior admission means no automatic download, ever")
+  }
+
+  /// A marker proves an install once completed, never that its bytes survive. Someone who
+  /// reclaimed space in Finder must not have 2.9 GB re-fetched unasked.
+  @MainActor
+  @Test func markerWithoutFilesOnDiskDoesNotTriggerReinstall() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    try stagePriorAdmission(root: root, createFiles: false)
+    let probe = Probe()
+    let subject = coordinator(root: root, defaults: store, probe: probe)
+
+    await subject.runLaunch()
+
+    #expect(probe.ensureCount == 0, "D2b: the marker survived but its bytes did not")
+  }
+
+  /// D1. An already-admitted current manifest owes nothing, even with a prior marker present.
+  @MainActor
+  @Test func admittedCurrentRevisionOwesNoUpgrade() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    try stagePriorAdmission(root: root)
+    let probe = Probe()
+    probe.admitted = true
+    let subject = coordinator(root: root, defaults: store, probe: probe)
+
+    await subject.runLaunch()
+
+    #expect(probe.ensureCount == 0)
+  }
+
+  /// An admission marker for ANOTHER family in the same shared metadata directory must not read
+  /// as a superseded EG-1 revision. The directory is shared by every family, so identification
+  /// has to be exact rather than "some marker is present".
+  @MainActor
+  @Test func anotherFamilysMarkerDoesNotTriggerUpgrade() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    let metadata = metadataDirectory(root)
+    let install = installDirectory(root)
+    try FileManager.default.createDirectory(at: metadata, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: install, withIntermediateDirectories: true)
+    let foreign = ModelIdentity(
+      family: .parakeet, name: "parakeet", revision: "v9", variant: "q5km", runtimeABI: "test")
+    let file = "parakeet-weights.bin"
+    try Data("x".utf8).write(to: install.appendingPathComponent(file))
+    let marker = CacheAdmission.AdmissionMarker(
+      manifestDigest: "d", admittedAt: Date(timeIntervalSince1970: 1),
+      files: [.init(path: file, sizeBytes: 1, mtime: 1)])
+    try JSONEncoder().encode(marker).write(
+      to: metadata.appendingPathComponent("\(foreign.cacheKey).admission.json"))
+
+    let probe = Probe()
+    let subject = coordinator(root: root, defaults: store, probe: probe)
+
+    await subject.runLaunch()
+
+    #expect(probe.ensureCount == 0, "a foreign family's marker is not our superseded revision")
+  }
+
+  /// Nil-class row of the lifecycle audit. An unreadable metadata directory yields no prior
+  /// revision, which means no download — the failure direction that cannot cost a user bytes.
+  @MainActor
+  @Test func unreadableMetadataFailsClosed() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    // A FILE where the metadata directory should be: enumeration throws rather than returning
+    // an empty list, which is the case a `try?` could quietly turn into "no markers".
+    try FileManager.default.createDirectory(
+      at: root.appendingPathComponent("EnviousWispr", isDirectory: true),
+      withIntermediateDirectories: true)
+    try Data("not a directory".utf8).write(to: metadataDirectory(root))
+
+    let probe = Probe()
+    let subject = coordinator(root: root, defaults: store, probe: probe)
+
+    await subject.runLaunch()
+
+    #expect(probe.ensureCount == 0)
+  }
+
+  // MARK: - D4: the kill switch
+
+  @MainActor
+  @Test func killSwitchSuppressesAutomaticUpgrade() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    try stagePriorAdmission(root: root)
+    store.set(false, forKey: DeliveryFlags.key("enabled", family: .egOne))
+
+    let probe = Probe()
+    let subject = coordinator(root: root, defaults: store, probe: probe)
+
+    await subject.runLaunch()
+
+    #expect(probe.ensureCount == 0, "delivery disabled means no automatic fetch")
+  }
+
+  // MARK: - The delete-first path stays monolith-only
+
+  /// The highest-consequence assertion in this suite. The revision trigger must never reach the
+  /// legacy delete-first branch: that branch is gated behind a digest-pinned `TrustedArtifact`,
+  /// and a revision upgrade neither owns nor may remove the old store's bytes.
+  @MainActor
+  @Test func revisionTriggerNeverEntersLegacyDeleteFirst() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    try stagePriorAdmission(root: root)
+
+    // A file sitting exactly where the monolith would live, whose bytes do NOT match the
+    // trusted fingerprint. Nothing on the revision path may touch it.
+    let oldStore = root.appendingPathComponent("EnviousWispr/PolishModels", isDirectory: true)
+    try FileManager.default.createDirectory(at: oldStore, withIntermediateDirectories: true)
+    let decoy = oldStore.appendingPathComponent("eg-1-v1.gguf")
+    try Data("not the trusted monolith".utf8).write(to: decoy)
+
+    let probe = Probe()
+    let subject = coordinator(root: root, defaults: store, probe: probe)
+
+    await subject.runLaunch()
+
+    #expect(probe.ensureCount == 1, "the revision upgrade still runs")
+    #expect(
+      FileManager.default.fileExists(atPath: decoy.path),
+      "the revision trigger must never delete old-store bytes")
+    #expect(!probe.removedURLs.contains(decoy))
+    #expect(!probe.events.contains(.legacyDetected))
+    #expect(!probe.events.contains(.legacyRetired))
+  }
+
+  /// Preparation is not a no-op and must keep running on every launch, but WITHOUT the trusted
+  /// fingerprint it may only sweep retired sidecars — never model bytes, and never the legacy
+  /// owed marker. Asserts what preparation must NOT do, rather than that it did nothing.
+  @MainActor
+  @Test func legacyPreparationPreservesModelBytesWithoutTheMonolithFingerprint() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    try stagePriorAdmission(root: root)
+    let shard = installDirectory(root).appendingPathComponent("eg-1-v1-00001-of-00008.gguf")
+    let owedMarker = metadataDirectory(root).appendingPathComponent("eg1-v1-replacement-owed")
+
+    let probe = Probe()
+    let subject = coordinator(root: root, defaults: store, probe: probe)
+
+    await subject.runLaunch()
+
+    #expect(FileManager.default.fileExists(atPath: shard.path), "model bytes survive preparation")
+    #expect(
+      !FileManager.default.fileExists(atPath: owedMarker.path),
+      "no legacy owed marker is written without a fingerprint match")
+  }
+
+  // MARK: - Containment scoping
+
+  /// A legacy-store containment refusal describes the OLD store, which a revision upgrade never
+  /// reads or deletes. Letting it block would permanently and silently deny every future model
+  /// upgrade on a machine layout the user cannot know is the cause.
+  @MainActor
+  @Test func legacyContainmentRefusalDoesNotSuppressRevisionUpgrade() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    try stagePriorAdmission(root: root)
+    try makeOldStoreEscapeContainment(root: root)
+
+    let probe = Probe()
+    let subject = coordinator(root: root, defaults: store, probe: probe)
+
+    await subject.runLaunch()
+
+    #expect(
+      probe.events.contains(.legacyRetirementFailed(reason: .containment)),
+      "precondition: containment really was refused")
+    #expect(probe.ensureCount == 1, "the revision upgrade proceeds regardless")
+  }
+
+  /// The two-way control: the SAME containment refusal must still block the LEGACY obligation.
+  /// Without this, the fix above could have widened into "containment never blocks anything".
+  @MainActor
+  @Test func legacyContainmentRefusalStillBlocksTheLegacyObligation() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    // Legacy owed, and NO prior-revision admission: the only obligation is the legacy one.
+    let metadata = metadataDirectory(root)
+    try FileManager.default.createDirectory(at: metadata, withIntermediateDirectories: true)
+    try Data().write(to: metadata.appendingPathComponent("eg1-v1-replacement-owed"))
+    try makeOldStoreEscapeContainment(root: root)
+
+    let probe = Probe()
+    let subject = coordinator(root: root, defaults: store, probe: probe)
+
+    await subject.runLaunch()
+
+    #expect(probe.events.contains(.legacyRetirementFailed(reason: .containment)))
+    #expect(probe.ensureCount == 0, "containment still blocks the legacy obligation")
+  }
+
+  /// Points the old store at a symlink outside the app-support tree, which is what
+  /// `prepareOnce`'s containment check refuses.
+  private func makeOldStoreEscapeContainment(root: URL) throws {
+    let outside = FileManager.default.temporaryDirectory.appendingPathComponent(
+      "eg1-outside-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: outside, withIntermediateDirectories: true)
+    let tree = root.appendingPathComponent("EnviousWispr", isDirectory: true)
+    try FileManager.default.createDirectory(at: tree, withIntermediateDirectories: true)
+    try FileManager.default.createSymbolicLink(
+      at: tree.appendingPathComponent("PolishModels", isDirectory: true),
+      withDestinationURL: outside)
+  }
+
+  // MARK: - Decline semantics
+
+  /// Remove is a statement about the MODEL. Without a recorded decline the previous revision's
+  /// marker and shards outlive `remove()`, so the next launch would re-fetch exactly what the
+  /// user just deleted.
+  @MainActor
+  @Test func autoUpgradeDoesNotStartAfterUserRemovedTheModel() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    try stagePriorAdmission(root: root)
+    let probe = Probe()
+    let subject = coordinator(root: root, defaults: store, probe: probe)
+
+    #expect(subject.recordUserDecline(source: .remove))
+    #expect(FileManager.default.fileExists(atPath: declineMarker(root).path))
+
+    await subject.runLaunch()
+
+    #expect(probe.ensureCount == 0, "a removed model stays removed, with its bytes still present")
+  }
+
+  /// The multi-producer distinction. A download the USER started and then cancelled must not
+  /// switch off the automatic path — the settings row's own Cancel reaches the same hook.
+  @MainActor
+  @Test func userInitiatedCancelDoesNotRecordDecline() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    try stagePriorAdmission(root: root)
+    let probe = Probe()
+    let subject = coordinator(root: root, defaults: store, probe: probe)
+
+    #expect(subject.recordUserDecline(source: .cancel))
+    #expect(
+      !FileManager.default.fileExists(atPath: declineMarker(root).path),
+      "no automatic upgrade was in flight, so this cancel says nothing about the model")
+
+    await subject.runLaunch()
+
+    #expect(probe.ensureCount == 1, "the automatic path is untouched by a user's own cancel")
+  }
+
+  /// The other half of that distinction: a cancel arriving WHILE our own upgrade is running is
+  /// attributable to us and does record a decline.
+  @MainActor
+  @Test func cancelDuringAutomaticUpgradeRecordsDecline() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    try stagePriorAdmission(root: root)
+    let probe = Probe()
+
+    // Cancel from inside the fetch, which is exactly when the adapter's hook would fire.
+    let box = CancelBox()
+    let subject = EGOneUpgradeCoordinator(
+      appSupportDirectory: root,
+      identity: Self.identity(),
+      installDirectory: installDirectory(root),
+      defaults: store,
+      trustedArtifact: .init(name: "eg-1-v1.gguf", sizeBytes: 11, sha256: "unused-here"),
+      ensureCurrentModel: {
+        probe.ensureCount += 1
+        _ = box.coordinator?.recordUserDecline(source: .cancel)
+        return .failed(DeliveryFailure(reason: .unknown, detail: "cancelled"))
+      },
+      currentModelIsAdmitted: { probe.admitted })
+    box.coordinator = subject
+
+    await subject.runLaunch()
+
+    #expect(probe.ensureCount == 1)
+    #expect(
+      FileManager.default.fileExists(atPath: declineMarker(root).path),
+      "a cancel during OUR upgrade is a decline of the upgrade")
+  }
+
+  @MainActor
+  private final class CancelBox {
+    var coordinator: EGOneUpgradeCoordinator?
+  }
+
+  /// Pressing Download or Try Again is the clearest possible statement of intent, so it clears a
+  /// decline. It arrives through the adapter's `beforeEnsure` door.
+  @MainActor
+  @Test func userInitiatedDownloadClearsDecline() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    try stagePriorAdmission(root: root)
+    let probe = Probe()
+    let subject = coordinator(root: root, defaults: store, probe: probe)
+
+    #expect(subject.recordUserDecline(source: .remove))
+    #expect(FileManager.default.fileExists(atPath: declineMarker(root).path))
+
+    _ = await subject.prepareForEnsure()
+
+    #expect(!FileManager.default.fileExists(atPath: declineMarker(root).path))
+
+    await subject.runLaunch()
+    #expect(probe.ensureCount == 1, "the automatic path is armed again after an explicit ask")
+  }
+
+  /// A launch must NOT clear a decline on its way past. `runLaunch` deliberately calls
+  /// `prepareForDownload()` rather than the `beforeEnsure` door for exactly this reason, and
+  /// without that separation the decline would survive nothing.
+  @MainActor
+  @Test func launchDoesNotClearARecordedDecline() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    try stagePriorAdmission(root: root)
+    let probe = Probe()
+    let subject = coordinator(root: root, defaults: store, probe: probe)
+
+    #expect(subject.recordUserDecline(source: .remove))
+    await subject.runLaunch()
+    await subject.runLaunch()
+
+    #expect(
+      FileManager.default.fileExists(atPath: declineMarker(root).path),
+      "two launches must not erase the user's refusal")
+    #expect(probe.ensureCount == 0)
+  }
+
+  /// Declining THIS revision must not suppress the NEXT one. The decline is keyed by cache key,
+  /// so a later app shipping a newer revision reads a different marker.
+  @MainActor
+  @Test func declineIsScopedToTheRevisionThatWasDeclined() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    try stagePriorAdmission(root: root)
+
+    let declined = Probe()
+    let first = coordinator(root: root, defaults: store, probe: declined)
+    #expect(first.recordUserDecline(source: .remove))
+    await first.runLaunch()
+    #expect(declined.ensureCount == 0)
+
+    // A later app version shipping the NEXT revision, same machine, same markers.
+    let next = Probe()
+    let second = coordinator(
+      root: root, defaults: store, probe: next, identity: Self.identity(revision: "v4-eg3"))
+    await second.runLaunch()
+
+    #expect(next.ensureCount == 1, "declining one model says nothing about the next one")
+  }
+
+  /// A decline that cannot be PERSISTED must block the action. If the write fails and we proceed
+  /// anyway, the refusal exists only in memory and the next launch re-fetches the model the user
+  /// just declined — silently, which is what makes failing closed the only safe direction.
+  @MainActor
+  @Test func declineThatCannotBePersistedBlocksTheAction() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    try stagePriorAdmission(root: root)
+    // The legacy owed marker must survive a failed decline rather than being cleared by a
+    // half-applied one.
+    let owedMarker = metadataDirectory(root).appendingPathComponent("eg1-v1-replacement-owed")
+    try Data().write(to: owedMarker)
+
+    let probe = Probe()
+    let subject = coordinator(
+      root: root, defaults: store, probe: probe, writeMarker: { _ in false })
+
+    #expect(
+      subject.recordUserDecline(source: .remove) == false,
+      "an unpersistable decline must not report success")
+    #expect(!FileManager.default.fileExists(atPath: declineMarker(root).path))
+    #expect(
+      FileManager.default.fileExists(atPath: owedMarker.path),
+      "the legacy marker is untouched, so nothing is left half-applied")
+  }
+
+  /// Overlapping automatic attempts. `runLaunch` is re-entered within one session when onboarding
+  /// completes, so two automatic fetches can be live at once. With a Boolean flag the inner
+  /// attempt's completion would clear it while the outer was still fetching, and a Cancel
+  /// belonging to the outer attempt would be misattributed to the user's own download.
+  @MainActor
+  @Test func overlappingAutomaticAttemptsKeepCancelAttributedToUs() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    try stagePriorAdmission(root: root)
+    let probe = Probe()
+    let box = CancelBox()
+
+    let subject = EGOneUpgradeCoordinator(
+      appSupportDirectory: root,
+      identity: Self.identity(),
+      installDirectory: installDirectory(root),
+      defaults: store,
+      trustedArtifact: .init(name: "eg-1-v1.gguf", sizeBytes: 11, sha256: "unused-here"),
+      ensureCurrentModel: {
+        probe.ensureCount += 1
+        if probe.ensureCount == 1 {
+          // Re-enter while THIS attempt is still in flight, and let the inner one finish.
+          await box.coordinator?.runLaunch()
+          // The inner attempt has completed. A Boolean would now read false.
+          _ = box.coordinator?.recordUserDecline(source: .cancel)
+        }
+        return .failed(DeliveryFailure(reason: .unknown, detail: "cancelled"))
+      },
+      currentModelIsAdmitted: { probe.admitted })
+    box.coordinator = subject
+
+    await subject.runLaunch()
+
+    #expect(probe.ensureCount == 2, "precondition: the attempts really did overlap")
+    #expect(
+      FileManager.default.fileExists(atPath: declineMarker(root).path),
+      "the outer attempt was still ours when the cancel arrived")
+  }
+
+  /// Every other case in this suite calls `recordUserDecline` on the coordinator DIRECTLY, which
+  /// proves the coordinator's logic but says nothing about the wiring that feeds it. This one goes
+  /// through the REAL adapter, so a future edit that passed the wrong producer — or the same one
+  /// twice — fails here rather than shipping a Remove that reads as a Cancel.
+  @MainActor
+  @Test func declineHookReceivesDistinctAdapterProducers() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    let install = installDirectory(root)
+    let metadata = metadataDirectory(root)
+    try FileManager.default.createDirectory(at: install, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: metadata, withIntermediateDirectories: true)
+
+    let registration = try EGOneDeliveryAdapterMappingTests.shardedFixtureRegistration(
+      install: install, metadata: metadata)
+    let controllerSuite = "eg1-revision-adapter-\(UUID().uuidString)"
+    // The actor gets its OWN suite instance, constructed inline so it is region-moved rather than
+    // bound into this test's isolation region first — the ModelDeliveryControllerTests pattern.
+    let controller = ModelDeliveryController(defaults: UserDefaults(suiteName: controllerSuite)!)
+    defer { UserDefaults.standard.removePersistentDomain(forName: controllerSuite) }
+
+    let adapter = EGOneDeliveryAdapter(
+      controller: controller, registration: registration, version: "v3-eg2", defaults: store)
+
+    let recorder = ProducerRecorder()
+    adapter.installLegacyUpgradeHooks(
+      beforeEnsure: { true },
+      beforeDecline: { [recorder] source in
+        recorder.sources.append(source)
+        return true
+      },
+      onAdmitted: {})
+
+    await adapter.cancel()
+    _ = await adapter.remove()
+
+    #expect(
+      recorder.sources == [.cancel, .remove],
+      "the adapter must report WHICH action declined, in order, and never the same one twice")
+  }
+
+  @MainActor
+  private final class ProducerRecorder {
+    var sources: [EGOneUpgradeCoordinator.DeclineSource] = []
+  }
+
+  /// A successful admission settles the decline: leaving it behind would suppress the next
+  /// revision for a reason the user could never discover.
+  @MainActor
+  @Test func admissionClearsTheDecline() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    try stagePriorAdmission(root: root)
+    let probe = Probe()
+    let subject = coordinator(root: root, defaults: store, probe: probe)
+
+    #expect(subject.recordUserDecline(source: .remove))
+    #expect(FileManager.default.fileExists(atPath: declineMarker(root).path))
+
+    probe.admitted = true
+    await subject.runLaunch()
+
+    #expect(
+      !FileManager.default.fileExists(atPath: declineMarker(root).path),
+      "the model demonstrably installed, so the refusal no longer describes reality")
+  }
+}

--- a/Tests/EnviousWisprTests/LLM/EGOneRuntimeReplacementActivationTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneRuntimeReplacementActivationTests.swift
@@ -209,6 +209,8 @@ import Testing
     let coordinator = EGOneUpgradeCoordinator(
       adapter: h.adapter,
       appSupportDirectory: h.root,
+      identity: h.registration.manifest.identity,
+      installDirectory: h.registration.installDirectory,
       defaults: h.store,
       trustedArtifact: .init(
         name: "eg-1-v1.gguf",
@@ -239,6 +241,8 @@ import Testing
     let coordinator = EGOneUpgradeCoordinator(
       adapter: h.adapter,
       appSupportDirectory: h.root,
+      identity: h.registration.manifest.identity,
+      installDirectory: h.registration.installDirectory,
       defaults: h.store,
       trustedArtifact: .init(
         name: "eg-1-v1.gguf",

--- a/Tests/EnviousWisprTests/LLM/EGOneRuntimeReplacementActivationTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneRuntimeReplacementActivationTests.swift
@@ -211,6 +211,7 @@ import Testing
       appSupportDirectory: h.root,
       identity: h.registration.manifest.identity,
       installDirectory: h.registration.installDirectory,
+      isOnboardingComplete: { true },
       defaults: h.store,
       trustedArtifact: .init(
         name: "eg-1-v1.gguf",
@@ -243,6 +244,7 @@ import Testing
       appSupportDirectory: h.root,
       identity: h.registration.manifest.identity,
       installDirectory: h.registration.installDirectory,
+      isOnboardingComplete: { true },
       defaults: h.store,
       trustedArtifact: .init(
         name: "eg-1-v1.gguf",

--- a/Tests/EnviousWisprTests/LLM/EGOneRuntimeReplacementActivationTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneRuntimeReplacementActivationTests.swift
@@ -206,7 +206,7 @@ import Testing
     try stageMonolith(h.root, bytes: bytes)
     try stageValidShards(h.registration)
 
-    let coordinator = EGOneLegacyUpgradeCoordinator(
+    let coordinator = EGOneUpgradeCoordinator(
       adapter: h.adapter,
       appSupportDirectory: h.root,
       defaults: h.store,
@@ -236,7 +236,7 @@ import Testing
     try stageMonolith(h.root, bytes: bytes)
     try stageValidShards(h.registration)
 
-    let coordinator = EGOneLegacyUpgradeCoordinator(
+    let coordinator = EGOneUpgradeCoordinator(
       adapter: h.adapter,
       appSupportDirectory: h.root,
       defaults: h.store,

--- a/Tests/EnviousWisprTests/LLM/EGOneUpgradeCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneUpgradeCoordinatorTests.swift
@@ -11,6 +11,13 @@ import Testing
 /// from disk truth alone. Every destructive path is proven against its
 /// negative twin: same-size wrong bytes, renamed files, symlinked stores.
 @Suite struct EGOneUpgradeCoordinatorTests {
+  /// The identity these legacy cases run under. Its revision is irrelevant to every assertion
+  /// in this suite: the temp metadata directory holds no admission marker for any OTHER
+  /// revision, so the #2096 revision trigger evaluates false throughout and the monolith
+  /// behaviour below is measured in isolation, exactly as it was before that trigger existed.
+  static let legacyOracleIdentity = ModelIdentity(
+    family: .egOne, name: "eg-1", revision: "v3-eg2", variant: "q5km", runtimeABI: "test")
+
   @MainActor
   private final class Probe {
     var admitted = false
@@ -80,6 +87,11 @@ import Testing
   ) -> EGOneUpgradeCoordinator {
     let subject = EGOneUpgradeCoordinator(
       appSupportDirectory: root,
+      // These 29 cases are the LEGACY oracle. The metadata directory they use holds no
+      // prior-revision admission marker, so the revision trigger is inert here by
+      // construction and every legacy assertion below still measures what it always did.
+      identity: Self.legacyOracleIdentity,
+      installDirectory: root.appendingPathComponent("EnviousWispr/Models/eg-1", isDirectory: true),
       defaults: defaults,
       trustedArtifact: .init(
         name: "eg-1-v1.gguf",
@@ -795,12 +807,12 @@ import Testing
     let subject = coordinator(
       root: root, defaults: store, bytes: Data("trusted".utf8), probe: probe)
 
-    #expect(subject.recordUserDecline())
+    #expect(subject.recordUserDecline(source: .cancel))
     #expect(!FileManager.default.fileExists(atPath: marker(root).path))
     #expect(probe.events == [.replacementDeclined])
 
     // Idempotent: a second decline with no marker succeeds and stays silent.
-    #expect(subject.recordUserDecline())
+    #expect(subject.recordUserDecline(source: .cancel))
     #expect(probe.events == [.replacementDeclined])
   }
 
@@ -820,7 +832,7 @@ import Testing
     let subject = coordinator(
       root: root, defaults: store, bytes: Data("trusted".utf8), probe: probe)
 
-    #expect(subject.recordUserDecline())
+    #expect(subject.recordUserDecline(source: .cancel))
     #expect(!FileManager.default.fileExists(atPath: marker(root).path))
     #expect(probe.events == [.replacementDeclined])
   }

--- a/Tests/EnviousWisprTests/LLM/EGOneUpgradeCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneUpgradeCoordinatorTests.swift
@@ -10,7 +10,7 @@ import Testing
 /// admission or explicit decline), the containment gate, and crash recovery
 /// from disk truth alone. Every destructive path is proven against its
 /// negative twin: same-size wrong bytes, renamed files, symlinked stores.
-@Suite struct EGOneLegacyUpgradeCoordinatorTests {
+@Suite struct EGOneUpgradeCoordinatorTests {
   @MainActor
   private final class Probe {
     var admitted = false
@@ -19,7 +19,7 @@ import Testing
       .failed(DeliveryFailure(reason: .sourceUnreachable))
     var markerExistedAtDelete = false
     var hashCount = 0
-    var events: [EGOneLegacyUpgradeCoordinator.Event] = []
+    var events: [EGOneUpgradeCoordinator.Event] = []
   }
 
   private func digest(_ data: Data) -> String {
@@ -77,8 +77,8 @@ import Testing
     writeMarker: (@MainActor @Sendable (URL) -> Bool)? = nil,
     removeItem: (@MainActor @Sendable (URL) throws -> Void)? = nil,
     hashError: Bool = false
-  ) -> EGOneLegacyUpgradeCoordinator {
-    let subject = EGOneLegacyUpgradeCoordinator(
+  ) -> EGOneUpgradeCoordinator {
+    let subject = EGOneUpgradeCoordinator(
       appSupportDirectory: root,
       defaults: defaults,
       trustedArtifact: .init(

--- a/Tests/EnviousWisprTests/ModelDelivery/CacheAdmissionTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/CacheAdmissionTests.swift
@@ -207,6 +207,101 @@ import Testing
     #expect(gate.isAdmitted())
   }
 
+  // MARK: Superseded-marker cleanup (#2096 §3.3)
+
+  /// A manifest whose files live in this install dir gets its previous revision's FILES swept by
+  /// orphan cleanup, but its previous revision's MARKER lives in the metadata directory, which
+  /// every family shares. Nothing swept those until now, which is the half `evictPreviousRevisions`
+  /// named and never delivered.
+  private func manifest(
+    files: [(path: String, content: Data, component: String)],
+    revision: String,
+    evictPreviousRevisions: Bool
+  ) throws -> DeliveryManifest {
+    try DeliveryManifest.load(
+      from: ManifestFixture.manifestJSON(files: files) { object in
+        var identity = object["identity"] as! [String: Any]
+        identity["revision"] = revision
+        object["identity"] = identity
+        var admission = object["admission"] as! [String: Any]
+        admission["evictPreviousRevisions"] = evictPreviousRevisions
+        object["admission"] = admission
+      })
+  }
+
+  private func stageForeignMarker(metadata: URL, cacheKey: String) throws -> URL {
+    let url = metadata.appendingPathComponent("\(cacheKey).admission.json")
+    try Data("{}".utf8).write(to: url)
+    return url
+  }
+
+  @Test func supersededMarkersAreRemovedOnAdmission() async throws {
+    let (install, metadata, staging) = try makeDirs()
+    let files = ManifestFixture.smallFiles
+    for f in files { try write(f.content, under: install, path: f.path) }
+
+    // A marker left behind by the revision this app supersedes, and one belonging to an entirely
+    // different model. Only the first may be swept.
+    let priorRevision = try stageForeignMarker(
+      metadata: metadata, cacheKey: "parakeet-fixture-model-rev0-int8")
+    let otherFamily = try stageForeignMarker(
+      metadata: metadata, cacheKey: "eg_one-eg-1-v3-eg2-q5km")
+
+    let gate = CacheAdmission(
+      manifest: try manifest(files: files, revision: "rev1", evictPreviousRevisions: true),
+      installDirectory: install, metadataDirectory: metadata)
+    try gate.promoteAndAdmit(
+      stagedComponents: [], stagingDirectory: staging, untouchedComponents: [])
+
+    #expect(gate.isAdmitted(), "the current revision is admitted")
+    #expect(
+      !FileManager.default.fileExists(atPath: priorRevision.path),
+      "the superseded revision's marker is swept")
+    #expect(
+      FileManager.default.fileExists(atPath: otherFamily.path),
+      "a different model's marker in the shared metadata dir is untouched")
+  }
+
+  /// The control that ARMS the flag. `evictPreviousRevisions` shipped decoded and unread for
+  /// months; without this case the cleanup could ignore it entirely and still pass the test above,
+  /// and Parakeet and WhisperKit — which both set it `false` — would silently change behaviour.
+  @Test func supersededCleanupRespectsTheManifestFlag() async throws {
+    let (install, metadata, staging) = try makeDirs()
+    let files = ManifestFixture.smallFiles
+    for f in files { try write(f.content, under: install, path: f.path) }
+
+    let priorRevision = try stageForeignMarker(
+      metadata: metadata, cacheKey: "parakeet-fixture-model-rev0-int8")
+
+    let gate = CacheAdmission(
+      manifest: try manifest(files: files, revision: "rev1", evictPreviousRevisions: false),
+      installDirectory: install, metadataDirectory: metadata)
+    try gate.promoteAndAdmit(
+      stagedComponents: [], stagingDirectory: staging, untouchedComponents: [])
+
+    #expect(gate.isAdmitted())
+    #expect(
+      FileManager.default.fileExists(atPath: priorRevision.path),
+      "a family that did not opt in keeps its previous markers")
+  }
+
+  /// Cleanup must never take the marker it just wrote. The current revision's own marker matches
+  /// the same family and name, and differs only by revision.
+  @Test func supersededCleanupNeverRemovesTheCurrentMarker() async throws {
+    let (install, metadata, staging) = try makeDirs()
+    let files = ManifestFixture.smallFiles
+    for f in files { try write(f.content, under: install, path: f.path) }
+
+    let gate = CacheAdmission(
+      manifest: try manifest(files: files, revision: "rev1", evictPreviousRevisions: true),
+      installDirectory: install, metadataDirectory: metadata)
+    try gate.promoteAndAdmit(
+      stagedComponents: [], stagingDirectory: staging, untouchedComponents: [])
+
+    #expect(FileManager.default.fileExists(atPath: gate.markerURL.path))
+    #expect(gate.isAdmitted())
+  }
+
   @Test func markerFastPathRejectsSizeDrift() async throws {
     let (install, metadata, staging) = try makeDirs()
     let files = ManifestFixture.smallFiles

--- a/Tests/EnviousWisprTests/ModelDelivery/InstallPathDecouplingTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/InstallPathDecouplingTests.swift
@@ -230,7 +230,22 @@ private enum InstallPathFixture {
   // DeliveryManifest.canonicalDigest algorithm against the authored manifest,
   // first cross-checked against the OLD single-file manifest's known-good
   // digest to prove the recompute technique was faithful before trusting it.
-  static let goldenDigest = "07550d07e242aa660393f5e62d36106ed7916ffa8852d9fb66f5420854a6b70d"
+  //
+  // EG-2 (2026-08-16, #2096): revision v3-eg2, same 8-shard componentSet
+  // layout, retrained weights. The digest was recomputed the same way and the
+  // technique was re-proved the same way — the authoring script reproduces
+  // v2-sharded's 07550d07e242aa66… before it is trusted on this one, with a
+  // negative control confirming the recipe is sensitive to a changed field.
+  //
+  // Two axes, deliberately distinct: the delivery REVISION is `v3-eg2` (third
+  // delivery generation) and the WEIGHTS generation is `eg-1-v2-*`. The
+  // campaign's own arm number (`v20`) is lab notation and must never reach
+  // `identity.revision`, the R2 path, or the user-visible install state.
+  //
+  // Per-shard sizes are byte-identical to v2-sharded's because the
+  // architecture and quantization did not change; only the sha256 values move.
+  // That coincidence was verified against the real files rather than assumed.
+  static let goldenDigest = "dd3cc5d3eb3c237f8e18fd85138da1cffcd4eb0f263ef0f6fc96a60d2e742f1b"
 
   @Test func shippedDeliveryManifestLoadsAndMatchesGoldenDigest() throws {
     let data = try Data(contentsOf: Self.deliveryManifestURL)
@@ -238,7 +253,7 @@ private enum InstallPathFixture {
     #expect(manifest.manifestDigest == Self.goldenDigest)
     #expect(try DeliveryManifest.canonicalDigest(of: data) == Self.goldenDigest)
     #expect(manifest.identity.family == .egOne)
-    #expect(manifest.identity.revision == "v2-sharded")
+    #expect(manifest.identity.revision == "v3-eg2")
     #expect(manifest.admission.layout == "componentSet")
     #expect(manifest.files.count == 8)
     #expect(manifest.totalBytes == manifest.files.reduce(0) { $0 + $1.sizeBytes })
@@ -247,11 +262,11 @@ private enum InstallPathFixture {
         file.sizeBytes <= 450_000_000, "\(file.path) exceeds the cache-eligible shard ceiling")
     }
     let entrypointPath = try #require(manifest.resolvedEntrypointPath)
-    #expect(entrypointPath == "eg-1-v1-00001-of-00008.gguf")
+    #expect(entrypointPath == "eg-1-v2-00001-of-00008.gguf")
     let entrypointFile = try #require(
       manifest.files.first { $0.resolvedInstallPath == entrypointPath })
-    #expect(entrypointFile.path == "v2-sharded/eg-1-v1-00001-of-00008.gguf")  // server object key
-    #expect(entrypointFile.component == "eg-1-v1-00001-of-00008.gguf")
+    #expect(entrypointFile.path == "v3-eg2/eg-1-v2-00001-of-00008.gguf")  // server object key
+    #expect(entrypointFile.component == "eg-1-v2-00001-of-00008.gguf")
     #expect(manifest.sources.map(\.id) == ["our_copy"])
   }
 


### PR DESCRIPTION
## What a user gets

Anyone already using the built-in on-device cleanup model gets the retrained one automatically, in the background, the next time they open the app. They do nothing. Dictation keeps working normally while it downloads.

The retrained model is better at two things people actually do out loud: changing your mind mid-sentence ("send it to Marcus, sorry, to Priya" now keeps Priya and drops Marcus), and announcing a list (you get a list, not one long line).

Nobody who has never used the model is touched. Anyone who has declined stays declined.

## Why this PR exists at all

Every mechanism to fetch a new model revision already shipped. `runLaunch()` already prepared, fetched, admitted and activated. One predicate gated all of it off: `isReplacementOwed` is about retiring the ORIGINAL monolith, and a user already on a sharded revision never owed a replacement, so a shipped-and-working upgrade path was unreachable for exactly the population it was built for.

The change is a second, narrower trigger beside it, not a new machine.

## The trigger, stated exactly

An automatic revision upgrade starts only when ALL of these hold:

- the current revision is NOT admitted, and
- an admission marker exists for a DIFFERENT revision of the same family and name, and
- at least one file that marker recorded is STILL on disk, and
- the user has not declined this revision, and
- delivery is enabled, and
- onboarding is complete (otherwise it defers and resumes in-session, without a relaunch).

Each clause fails closed: an unreadable metadata directory, an undecodable marker, a marker recording no files, or files all deleted each yield "no download". A user who reclaimed 2.9GB in Finder does not have it silently re-fetched.

## Blast radius

155 installs on EG-1 today, 190 hold EG-1 bytes. Paced by Sparkle adoption. The download is 2.9GB, silent and background, not wifi-gated — that is the founder decision from #1419 (2026-07-29), unchanged here.

Rollback is the kill switch that already exists: delivery disabled suppresses the automatic path entirely, and that guard is asserted by test.

## What could go wrong, and what stops it

- **Delete-first on the wrong path.** The legacy path deletes the monolith before fetching. A revision upgrade must never enter it. `revisionTriggerNeverEntersLegacyDeleteFirst` is the highest-consequence assertion in this PR.
- **Cancel misread as a permanent decline.** Cancel and Remove are different intentions with the same landing state — the #2066 failure mode. They are distinguished at the producer (`DeclineSource`), not inferred downstream.
- **A decline that does not persist.** A failed marker write used to report success. It now fails closed, writing before clearing the legacy marker.
- **The limb competing with the heart.** During first-run setup the whole launch defers rather than racing the model download the user is already waiting on.

## Measurement

`attempt_started` cannot grade this. It counts upgrades that STARTED, and the defect this exists to prevent is an upgrade that never starts — invisible to a start-event. #1386's criterion had exactly this hole.

So `eg1.upgrade_eligible` is emitted once at the top of `runLaunch()`, before any gate, carrying `routing` (started / deferred_onboarding / declined / disabled), `target_revision`, `selected_provider`, `delivery_enabled`, `onboarding_complete`. Eligible-minus-started becomes directly observable. `eg1.upgrade_declined` makes a refusal observable at all.

Content-free: no transcripts, no prompts, no document text. Bounded enums and booleans only.

Query caveat, recorded so it is not rediscovered: a deferred-then-resumed install correctly emits TWO route observations, so the eligible population must be deduplicated by install and target_revision.

## Validation

- **Full suite both lanes**, from the worktree's absolute path, on the final head. Debug 5655 tests, Release 5221 tests, 0 real failures either lane (3 deliberate known issues each), exit 0.
- **Independent whole-diff Codex review, clean on the confirming round**: "No actionable correctness defect was found in the changed code."
- **Live UAT, all six steps**, against a real dev build doing a real 2.9GB download from R2. Verdicts read from `app.log`, never the clipboard.
- **Both new events verified** on the dev build in the development PostHog environment, all five properties, and critically **`routing=declined` observed** — a user who refuses still lands in the denominator, which is the entire measurement thesis.

### Live UAT results

| Step | Result |
|---|---|
| 1. Upgrade happens unattended | PASS. 8 shards fetched in 36s, **all 8 hash-match the manifest, no extras**. Marker advanced to `v3-eg2`; **both superseded markers swept**, including a stale one deliberately left in place so one run also exercised §3.3 eviction. |
| 2. Change of mind | PASS. `…to Marcus, sorry, to Priya, before the stand-up tomorrow?` → `Can you send the roof survey to Priya before the stand-up tomorrow?` Pipeline 0.921s, polish 0.454s. |
| 2. Announced list | PASS. One run-on sentence → a real bulleted list with the lead-in kept. Polish 1.027s. |
| 3. Decline respected | PASS. Cancel mid-download wrote `eg1-revision-decline-…-v3-eg2-q5km` and left the old shards untouched. Quit + relaunch + 50s: no restart, no new admission, and the pane offers `Download EG-1`. |
| 4. Download after decline | PASS. Installed normally, decline cleared, superseded marker swept. |
| 5. Never-had-it user | PASS. Empty install dir and no markers: launch logged, nothing downloaded, no marker written, and **no eligibility event** — the denominator correctly excludes first-run users. |
| 6. Restore | PASS. Machine returned to shipped `v2-sharded`, all 8 SHA-256 verified against a pinned manifest, no unlisted files, shipped marker back, no decline marker. |

### Three instrument faults hit during validation, none of them defects in this diff

Recorded because each returned a confident wrong answer, and two of them nearly became findings:

- The harness reported the **announced-list result as truncated to one line**. It is not: `record_tts` reads `Polished:` with a single-line grep and a list output spans many lines. This is the exact trap in `tools-and-apps.md` RULE: uat-verdicts-from-app-log, and it would have been filed as the headline feature failing.
- A `find … -newermt "-5 minutes" 2>/dev/null` check reported "no download in flight" **while the download was completing in that directory**. `find` here is a `bfs` shim that rejects relative times and errors to stderr; the `2>/dev/null` turned a loud failure into a silent absence. Promoted to `validation-discipline.md`.
- **PostHog ingestion lagged ~1 minute**, so the `routing=declined` row was absent from one query and present from the next. A fresh-event absence is not a missing emission.

A fourth is a caveat on evidence rather than a fault: **HEAD 200 is not a downloadability check.** Measured today, one of these object URLs returns HEAD 200, GET 206 under curl's UA, and GET **403** under `Python-urllib/3.x`. The prefix is nonetheless proven downloadable by the real client, by far stronger evidence than any HEAD: the app fetched all 8 three separate times and they hash-match on disk each time.

One review finding was adopted: the v2.4.5 headline release note was written as concatenated string literals, and `render-release-notes.py` parses source TEXT and stops at the first literal, so the generated GitHub note ended mid-sentence at a comma with the announcement dropped. Reproduced with the real generator before adopting. Compiled string is byte-identical, 522 characters, so no approved copy moved. The missing GUARD is filed as #2105 rather than fixed here: the weekly `--self-test` compares entry COUNT and passes on a truncated entry, so it never fires on this shape.

One review finding was adopted: the v2.4.5 headline release note was written as concatenated string literals, and `render-release-notes.py` parses source TEXT and stops at the first literal, so the generated GitHub note ended mid-sentence at a comma with the announcement dropped. Reproduced with the real generator before adopting. Compiled string is byte-identical, 522 characters, so no approved copy moved. The missing GUARD is filed as #2105 rather than fixed here: the weekly `--self-test` compares entry COUNT and passes on a truncated entry, so it never fires on this shape.

## Not done here, deliberately

- **The 8 hosted objects are re-hashed immediately before merge**, and again before tagging. Today's evidence is strong but is not that check.

- `promptTemplateID` stays `eg1-v1`. The new weights were trained on the SHIPPED prompt, so the prompt contract is unchanged. Changing it would need a new `PromptFamily` case and older apps would reject the model with `app_update_required`.
- The Cloudflare cache and transform rule for the new prefix is founder-gated and still undeployed, as it is for the current revision.
- The release is a separate gate. The manifest ships INSIDE the app, so no user gets the new revision without an app update.

Part of #2096
