### PR TITLE
perf(build): stop optimising test code, and take two steps off the PR critical path

### DIFF
--- a/.github/workflows/main-post-merge.yml
+++ b/.github/workflows/main-post-merge.yml
@@ -261,9 +261,12 @@ jobs:
     needs: classify
     if: needs.classify.outputs.needs_build == 'true'
     runs-on: macos-26
-    # Worst observed for these steps is ~17 min (setup ~5, debug build 2.6,
-    # debug suite 9.5). 30 is ~1.75x that, sized from the measured spread rather
-    # than a round number.
+    # Whole-job duration over the 20 most recent successful runs: 666-1008s
+    # (11.1-16.8 min), median ~850s. The CI-speed pass added coverage
+    # instrumentation to this job (see the coverage step below); pr-check.yml's
+    # build-debug ran the same suite WITH coverage at 697-1194s on the same
+    # runner class, so ~20 min is the realistic new worst case. 30 keeps ~1.5x
+    # against that, sized from the measured spread rather than a round number.
     timeout-minutes: 30
 
     steps:
@@ -317,6 +320,7 @@ jobs:
             -derivedDataPath "$DERIVED_DATA_PATH" \
             -destination 'platform=macOS,arch=arm64' \
             -resultBundlePath "$GITHUB_WORKSPACE/xcode-test-debug.xcresult" \
+            -enableCodeCoverage YES \
             ARCHS=arm64 \
             ONLY_ACTIVE_ARCH=YES \
             VALID_ARCHS=arm64 2>&1 | tee xcode-test-debug.log
@@ -329,6 +333,48 @@ jobs:
             exit 1
           fi
           echo "==> Xcode executed $TESTS_RUN tests (debug)"
+
+      # #1600, MOVED here from pr-check.yml's build-debug lane in the CI-speed
+      # pass. It was always informational — no percentage gate, because coverage
+      # measures execution rather than assertion quality and a threshold would
+      # invite padding tests to hit a number. Instrumenting every first-party
+      # module cost that on the PR critical path for a figure nothing gated, so
+      # it now runs once per merge instead of once per push, on the same Debug
+      # suite and the same runner.
+      #
+      # Never allowed to fail this job: continue-on-error at the step level, plus
+      # internal fail-open logic with no `set -e`.
+      - name: Coverage summary (debug, informational only)
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          REPORT=$(xcrun xccov view --report --json "$GITHUB_WORKSPACE/xcode-test-debug.xcresult" 2>/dev/null) || true
+          if [ -z "$REPORT" ]; then
+            echo "==> Coverage summary unavailable (xccov produced no output)"
+            exit 0
+          fi
+          # The report's root `.lineCoverage` aggregates EVERY instrumented
+          # target, including the .xctest bundles themselves and third-party
+          # static libraries (FluidAudio alone carries ~45k executable lines) —
+          # inflating/diluting the number away from actual Sources/ coverage.
+          # Every first-party module is named `EnviousWispr*` 1:1 with its
+          # Sources/ directory (frameworks + the thin app shell + the ASR XPC
+          # service); filter to those and exclude .xctest/.bundle to isolate real
+          # production-code coverage. (#1600)
+          FIRST_PARTY=$(echo "$REPORT" | jq '
+            [.targets[] | select(.name | startswith("EnviousWispr"))
+              | select((.name | endswith(".xctest")) or (.name | endswith(".bundle")) | not)]
+            | {covered: (map(.coveredLines) | add // 0), executable: (map(.executableLines) | add // 0)}
+          ' 2>/dev/null)
+          COVERED=$(echo "$FIRST_PARTY" | jq -r '.covered // empty' 2>/dev/null)
+          EXECUTABLE=$(echo "$FIRST_PARTY" | jq -r '.executable // empty' 2>/dev/null)
+          if [ -n "$COVERED" ] && [ -n "$EXECUTABLE" ] && [ "$EXECUTABLE" -gt 0 ]; then
+            PCT_DISPLAY=$(awk -v c="$COVERED" -v e="$EXECUTABLE" 'BEGIN{printf "%.1f", (c/e)*100}')
+            echo "==> Debug-lane first-party line coverage: ${PCT_DISPLAY}% (${COVERED}/${EXECUTABLE} lines)"
+            echo "Debug-lane first-party line coverage: **${PCT_DISPLAY}%** (${COVERED}/${EXECUTABLE} lines — Sources/ only, excludes test bundles and third-party deps; informational, no gate)" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "==> Coverage summary unavailable (could not parse xccov JSON or no first-party targets found)"
+          fi
 
       # The release job had failure diagnostics and the debug job did not, which
       # meant a debug-only failure on main left nothing to read. Same treatment

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -186,7 +186,6 @@ jobs:
             -derivedDataPath "$DERIVED_DATA_PATH" \
             -destination 'platform=macOS,arch=arm64' \
             -resultBundlePath "$GITHUB_WORKSPACE/xcode-test-debug.xcresult" \
-            -enableCodeCoverage YES \
             ARCHS=arm64 \
             ONLY_ACTIVE_ARCH=YES \
             VALID_ARCHS=arm64 | tee xcode-test-debug.log
@@ -202,45 +201,17 @@ jobs:
           fi
           echo "==> Xcode executed $TESTS_RUN tests (debug)"
 
-      # #1600 (CI-test-audit finding): coverage was never measured anywhere in
-      # CI, so nobody could ask "which production branches actually execute"
-      # with a number. Informational only — no percentage gate; coverage
-      # measures execution, not assertion quality, so a threshold here would
-      # invite padding tests to hit a number rather than testing real behavior.
-      # Never allowed to fail the required build-debug lane: continue-on-error
-      # at the step level, plus internal fail-open logic with no `set -e`.
-      - name: Coverage summary (debug, informational only)
-        if: steps.changes.outputs.needs_build == 'true'
-        continue-on-error: true
-        run: |
-          set -uo pipefail
-          REPORT=$(xcrun xccov view --report --json "$GITHUB_WORKSPACE/xcode-test-debug.xcresult" 2>/dev/null) || true
-          if [ -z "$REPORT" ]; then
-            echo "==> Coverage summary unavailable (xccov produced no output)"
-            exit 0
-          fi
-          # Codex review: the report's root `.lineCoverage` aggregates EVERY
-          # instrumented target, including the .xctest bundles themselves and
-          # third-party static libraries (FluidAudio alone carries ~45k
-          # executable lines) — inflating/diluting the number away from actual
-          # Sources/ coverage. Every first-party module is named
-          # `EnviousWispr*` 1:1 with its Sources/ directory (frameworks + the
-          # thin app shell + the ASR XPC service); filter to those and exclude
-          # .xctest/.bundle to isolate real production-code coverage.
-          FIRST_PARTY=$(echo "$REPORT" | jq '
-            [.targets[] | select(.name | startswith("EnviousWispr"))
-              | select((.name | endswith(".xctest")) or (.name | endswith(".bundle")) | not)]
-            | {covered: (map(.coveredLines) | add // 0), executable: (map(.executableLines) | add // 0)}
-          ' 2>/dev/null)
-          COVERED=$(echo "$FIRST_PARTY" | jq -r '.covered // empty' 2>/dev/null)
-          EXECUTABLE=$(echo "$FIRST_PARTY" | jq -r '.executable // empty' 2>/dev/null)
-          if [ -n "$COVERED" ] && [ -n "$EXECUTABLE" ] && [ "$EXECUTABLE" -gt 0 ]; then
-            PCT_DISPLAY=$(awk -v c="$COVERED" -v e="$EXECUTABLE" 'BEGIN{printf "%.1f", (c/e)*100}')
-            echo "==> Debug-lane first-party line coverage: ${PCT_DISPLAY}% (${COVERED}/${EXECUTABLE} lines)"
-            echo "Debug-lane first-party line coverage: **${PCT_DISPLAY}%** (${COVERED}/${EXECUTABLE} lines — Sources/ only, excludes test bundles and third-party deps; informational, no gate)" >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "==> Coverage summary unavailable (could not parse xccov JSON or no first-party targets found)"
-          fi
+      # #1600's coverage measurement MOVED to main-post-merge.yml's
+      # debug-validation job in the CI-speed pass. It was informational by
+      # explicit design — no percentage gate, `continue-on-error`, fail-open
+      # internals — so it never decided a merge, but `-enableCodeCoverage YES`
+      # instruments every first-party module on the PR critical path. The number
+      # is just as useful measured once per merge as once per push, and
+      # debug-validation runs the same Debug suite on the same runner. #1600's
+      # intent (be able to ask "which production branches actually execute" with
+      # a number) is preserved there, including the first-party-only xccov
+      # filtering. Do not re-add it here without a reason the number has to be
+      # per-PR.
 
   # Release lane: Xcode release build + Release test-target compile +
   # FoundationModels compile probe. Runs in parallel with build-debug (issue
@@ -461,29 +432,81 @@ jobs:
 
           echo "==> FoundationModels compile probe PASSED"
 
-      # #1836: scripts/eval/{apple_runner,alias_runner,prompt_render} are STANDALONE
-      # SwiftPM packages that path-depend on EnviousWisprCore. Nothing compiled
-      # them — not scripts/xcode-test.sh, not any workflow — so a public Core
-      # signature change broke them with a fully green local suite AND a green
-      # PR. #1770 collapsed LLMProviderConfig's two thinking optionals into one
-      # and left apple_runner uncompilable; 4,374 local tests passed and only a
-      # human reading the call site caught it.
-      #
-      # Compile-only: no run, no corpus, no model download. It lives INSIDE this
-      # lane on purpose. build-check is the only required status context, so a
-      # separate advisory job would reproduce the exact invisibility this fixes,
-      # and a new required context would need a ruleset change.
-      #
-      # `swift build` is correct here and does NOT contravene
-      # conventions.md RULE: xcode-build-engine-cli. That rule governs the app,
-      # XPC, release and repo-test gates; these packages are invisible to
-      # Tuist/Xcode, so SwiftPM is the only thing that can build them. Debug
-      # `swift build` is explicitly allowed as an informal compile check.
-      #
-      # prompt_render joined this loop when it was first tracked: it renders the
-      # per-model polish prompts the Ollama benchmark measures, so a Core prompt
-      # -builder signature change breaking it would silently invalidate the next
-      # benchmark rather than fail anything.
+  # #1836: scripts/eval/{apple_runner,alias_runner,prompt_render} are STANDALONE
+  # SwiftPM packages that path-depend on EnviousWisprCore. Nothing compiled
+  # them — not scripts/xcode-test.sh, not any workflow — so a public Core
+  # signature change broke them with a fully green local suite AND a green
+  # PR. #1770 collapsed LLMProviderConfig's two thinking optionals into one
+  # and left apple_runner uncompilable; 4,374 local tests passed and only a
+  # human reading the call site caught it.
+  #
+  # Compile-only: no run, no corpus, no model download.
+  #
+  # THIS WAS A STEP INSIDE build-release until the CI-speed pass. It sat there
+  # because "build-check is the only required status context, so a separate
+  # advisory job would reproduce the exact invisibility this fixes." That premise
+  # is right and the conclusion no longer follows: this job is NOT advisory — it
+  # is listed in build-check's `needs:` and in its fail-closed check, exactly like
+  # worker-tests and website-check already are, so it gates merges without any
+  # ruleset change. What it stops doing is sitting on the critical path.
+  #
+  # Measured on PR run 31969994752: 301s (20:37:42 to 20:42:43) at the END of
+  # build-release, which was the whole PR's critical path at 1668s. These packages
+  # read no DerivedData and have no dependency on the Xcode build in that job
+  # (Package.swift path-depends on the repo root only), so the sequencing was
+  # incidental, not required. As its own job the 301s overlaps build-debug's ~930s
+  # and costs zero wall clock.
+  #
+  # No build cache here on purpose: `.build/` would be a PR-written cache, and the
+  # post-merge-only cache policy (#804) keeps PR jobs restore-only to protect the
+  # 10 GiB repository budget. Cold is affordable once it is parallel.
+  #
+  # The cost, stated rather than glossed: this is a THIRD macOS runner per PR
+  # against the 5-slot macOS limit #804 weighed. One PR plus a post-merge is now 5
+  # and sits exactly at it; two PRs plus a post-merge is 8 and queues. That is
+  # acceptable for the reason measured when main-post-merge.yml was split into
+  # parallel jobs (#2033): queue time does NOT count against
+  # `timeout-minutes`, so oversubscription degrades to slower feedback and never to
+  # a killed job. This job also holds its slot for ~300s, not the ~1600s the lane it
+  # left holds, so it frees up long before the build lanes do.
+  #
+  # `swift build` is correct here and does NOT contravene the project's
+  # Xcode-build-engine policy. That policy governs the app,
+  # XPC, release and repo-test gates; these packages are invisible to
+  # Tuist/Xcode, so SwiftPM is the only thing that can build them. Debug
+  # `swift build` is explicitly allowed as an informal compile check.
+  #
+  # prompt_render joined this loop when it was first tracked: it renders the
+  # per-model polish prompts the Ollama benchmark measures, so a Core prompt
+  # -builder signature change breaking it would silently invalidate the next
+  # benchmark rather than fail anything.
+  eval-packages:
+    runs-on: macos-26
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          # Full history for the same reason as the build lanes (#825): "Detect
+          # code changes" diffs pull_request.base.sha, which can predate a shallow
+          # clone when main advances mid-PR.
+          fetch-depth: 0
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Detect code changes
+        id: changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: scripts/ci/classify-changes.sh "$BASE_SHA" "$HEAD_SHA"
+
+      # STEP-level gating, matching build-debug and website-check: a job-level
+      # `if` reports `skipped`, which a needs-based aggregator treats as
+      # not-success. A content-only PR runs this job, skips the work, succeeds.
       - name: Compile standalone eval packages
         if: steps.changes.outputs.needs_build == 'true'
         run: |
@@ -520,16 +543,16 @@ jobs:
             # a break behind `#if DEBUG` — a real class here, since Core carries
             # DEBUG-only members.
             #
-            # This is NOT the case conventions.md RULE: xcode-build-engine-cli
-            # forbids. That rule governs the APP release/DoD gate, where Xcode
-            # owns bundle and resource assembly. These two packages have no
+            # This is NOT the case the Xcode-build-engine policy
+            # forbids. That policy governs the APP release/DoD gate, where Xcode
+            # owns bundle and resource assembly. These three packages have no
             # Xcode representation at all, so SwiftPM is the only thing that can
             # build them, and release is what they are actually run as. The
             # local `check-swift-build-gate.sh` nudge does not apply to CI.
             echo "==> swift build -c release --package-path $pkg (locked to root pins)"
             swift build -c release --package-path "$pkg" --only-use-versions-from-resolved-file
           done
-          echo "==> Both standalone eval packages compile against current Core"
+          echo "==> All three standalone eval packages compile against current Core"
 
   # Worker unit suites (#1589). Deliberately UNCONDITIONAL and deliberately
   # running BOTH workers every time: the point is to catch a change under
@@ -626,7 +649,7 @@ jobs:
   # fail closed), but is skipped when the whole run is cancelled (a superseded
   # push) so the obsolete SHA shows "cancelled", not a false "Failure".
   build-check:
-    needs: [build-debug, build-release, worker-tests, website-check]
+    needs: [build-debug, build-release, eval-packages, worker-tests, website-check]
     if: always() && !cancelled()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -702,16 +725,17 @@ jobs:
           python3 scripts/eval/tests/test_alias_scorer.py
           python3 scripts/eval/tests/test_v4_adversarial_runner.py
 
-      - name: Require both build lanes
+      - name: Require every lane
         run: |
           if [ "${{ needs.build-debug.result }}" != "success" ] \
              || [ "${{ needs.build-release.result }}" != "success" ] \
+             || [ "${{ needs.eval-packages.result }}" != "success" ] \
              || [ "${{ needs.worker-tests.result }}" != "success" ] \
              || [ "${{ needs.website-check.result }}" != "success" ]; then
-            echo "::error::lane failed — build-debug=${{ needs.build-debug.result }} build-release=${{ needs.build-release.result }} worker-tests=${{ needs.worker-tests.result }} website-check=${{ needs.website-check.result }}"
+            echo "::error::lane failed — build-debug=${{ needs.build-debug.result }} build-release=${{ needs.build-release.result }} eval-packages=${{ needs.eval-packages.result }} worker-tests=${{ needs.worker-tests.result }} website-check=${{ needs.website-check.result }}"
             exit 1
           fi
-          echo "==> Both build lanes and the worker unit suites passed."
+          echo "==> Both build lanes, the eval-package compile, and the worker unit suites passed."
 
       - name: Report build status
         run: |

--- a/Project.swift
+++ b/Project.swift
@@ -103,6 +103,68 @@ func targetSettings(
   )
 }
 
+// TEST targets only. Identical to `projectSettings` in Debug and Dev; the Release
+// configuration drops optimization for the two unit-test bundles and nothing else.
+//
+// Why: `EnviousWisprTests` is one 128,735-line module, and compiling it at
+// `-O`/`wholemodule` is the single most expensive thing in CI. Measured on PR run
+// 31969994752, step `Build for testing (release, Xcode)`: the line
+// `SwiftDriver Compilation EnviousWisprTests normal arm64` at 20:25:13 to the step
+// end at 20:37:35 is 742 seconds — 12m22s optimizing test code that this step then
+// throws away without executing. The whole PR wall clock was ~28 minutes.
+//
+// What the Release TEST build is for is a CONFIGURATION check, not an optimization
+// one: a test file referencing a `#if DEBUG`-only Sources symbol without gating
+// itself compiles in Debug and vanishes in Release (pr-check.yml's
+// `Build for testing (release, Xcode)`; recurred twice in three days, #1358/#1498
+// and #1536/#1538). `DEBUG` comes from SWIFT_ACTIVE_COMPILATION_CONDITIONS
+// (`debugConfigSettings` above), never from SWIFT_OPTIMIZATION_LEVEL, so that
+// entire failure class — plus type checking, Sendable, actor isolation, access
+// control, `@testable` resolution, and test-bundle linking — is untouched here.
+//
+// Deliberately NOT set on the xcodebuild command line: a command-line
+// `SETTING=value` has highest precedence and applies to EVERY target in the
+// invocation, which would de-optimize the PRODUCT modules too. Per-target is what
+// the intent actually is, and it keeps `main-post-merge.yml`'s release suite
+// running unoptimized tests against fully optimized product code — so the
+// Debug/Release behavioural divergences that job exists to catch (#2070/#2083,
+// `Parser.defaultMaximumNestingLevel` is 20 under `#if DEBUG` and 256 otherwise)
+// stay caught.
+//
+// The one thing this gives up: optimization-sensitive behavior inside TEST code,
+// the reachable case being a side effect inside `assert(...)`, which `-O` strips
+// and `-Onone` keeps. Verified empty at the time of writing — `grep -rnE
+// "(^|[^.A-Za-z])assert\(" Tests/` returns 0 hits and there is no
+// `_isDebugAssertConfiguration` anywhere in the repo. Do not put a side effect
+// inside an `assert` in a test; use `#expect` or `precondition`.
+//
+// DEBUGGING POINTER, and the honest cost of this setting. Debug and Release now
+// compile TEST code differently in one more way than before, so a lane-specific
+// failure has one more axis to hide along. #2070 is the cautionary case: a test
+// passed in one configuration and failed in the other because
+// `Parser.defaultMaximumNestingLevel` is 20 under `#if DEBUG` and 256 otherwise,
+// costing ~40 minutes of red main (#2083). Ladder for a suspicious failure, in
+// order, because "just re-run it" cannot tell these apart:
+//   fails under load, passes isolated ....... machine contention (or app.log
+//                                             corruption if it is an AppLogger
+//                                             test: those write a marker to the
+//                                             shared log and read it back, so a
+//                                             second concurrent appender breaks
+//                                             UTF-8 boundaries and the read
+//                                             returns empty — #2080)
+//   fails isolated in Debug, passes Release .. configuration divergence
+//   fails isolated in BOTH ................... now it is the diff
+// Measured when this landed, so a future reader has a reference point: Debug
+// executed 5,631 tests and Release 5,197, a 434 gap. That gap is structural, not
+// a regression — `#if DEBUG` tests do not exist in the Release binary at all.
+// Compare Release against a Release baseline, never against Debug.
+let testTargetSettings = targetSettings(
+  releaseExtra: [
+    "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+    "SWIFT_COMPILATION_MODE": "singlefile",
+  ]
+)
+
 // Per-config IDENTITY (bundle id + Sparkle feed) is set on every config. The
 // `.dev` identity lives on BOTH Debug (PR2, kept for CI's unsigned debug build)
 // AND Dev (the local signed bundle). Dev additionally carries self-signed manual
@@ -474,7 +536,7 @@ let project = Project(
         .package(product: "SwiftParser"),
         .package(product: "SwiftSyntax"),
       ],
-      settings: projectSettings
+      settings: testTargetSettings
     ),
     .target(
       name: "EnviousWisprASRTests",
@@ -496,7 +558,7 @@ let project = Project(
         // resolved here too (Xcode doesn't propagate transitive static-link).
         .package(product: "FluidAudio"),
       ],
-      settings: projectSettings
+      settings: testTargetSettings
     ),
   ],
   schemes: [


### PR DESCRIPTION
Closes #2114. PR checks run ~27 min median (worst 34) and only ~5 of those minutes execute tests. Three changes, no test deleted and no guard weakened.

`Tier: MEDIUM | Test: full Debug + Release suites, both arms, plus the PR's own run | Modules: CI, Project.swift`
`Lane: CI/workflow` + `Project.swift` (tracked build manifest) — `mixed_pr: true`, primary lane `CI/workflow`

## The measurement

`build-release` is the entire critical path. On run 31969994752 (job total 1668s):

| step | seconds |
|---|---|
| `Build for testing (release, Xcode)` | **937** |
| `Compile standalone eval packages` | 301 |
| `Build (release, Xcode)` | 247 |
| `Restore Xcode build cache` | 97 |
| generate / linkage / probe / rest | ~86 |

Inside that 937s step, from the job log: 20:21:58 → 20:25:13 (195s) rebuilds every third-party and first-party module because `ENABLE_TESTABILITY=YES` changes the settings hash; then 20:25:13 → 20:37:35 is **742s on one line** — `SwiftDriver Compilation EnviousWisprTests normal arm64` — whole-module-optimising a 128,735-line test module that the step discards without running a test.

`build-debug`'s 659s test step is 377s compiling and **282s actually running 5,640 tests**. The suite's cost is compile cost, not run cost, which is why deleting tests is not the lever.

## What the expensive half has caught

Last 300 `pr-check` runs (from 2026-07-31): 138 success, 156 cancelled, 5 failure. Every failing step: `Require both build lanes` ×4 (downstream), `Run logic tests (debug, Xcode)` ×2, `Verify third-party notices are in sync` ×1, `Judge-receipt completeness contract` ×1. **`Build for testing (release, Xcode)` failed zero times**, as did every other `build-release` step.

Last 120 `main-post-merge` runs: 75 success, 43 cancelled, 2 failure — both `Run logic tests (release config, Xcode)` with `debug=success`. The Release **execution** caught what compilation cannot.

That is an argument for making the compile cheap, not for deleting it: the failure class it defends recurred twice in three days in July (#1358/#1498, #1536/#1538), and 17 days of zero does not retire it.

## The changes

**1. `Project.swift` — test targets get `-Onone`/`singlefile` in Release.** The Release test build is a *configuration* check. `DEBUG` comes from `SWIFT_ACTIVE_COMPILATION_CONDITIONS`, never from `SWIFT_OPTIMIZATION_LEVEL`, so the defended class is untouched, along with type checking, Sendable, actor isolation, access control, `@testable` resolution and test-bundle linking.

Per-target, **not** on the `xcodebuild` command line: a command-line `SETTING=value` has highest precedence and applies to every target in the invocation, which would de-optimise the product modules too. This keeps `Sources/` at `-O`/`wholemodule`, so `main-post-merge`'s release suite still runs unoptimised tests against **fully optimised product code** and the #2070/#2083 divergence class stays caught. It speeds that post-merge job (currently 1393-2376s against a 45-min cap) and `xcode-test.sh --release` too.

**2. `eval-packages` is its own job.** 301s at the tail of `build-release`, reading no DerivedData — `Package.swift` path-depends on the repo root only, and `Package.resolved`/`Package.swift` are both tracked, so the job is self-sufficient after checkout. It is in `build-check`'s `needs:` and its fail-closed check, like `worker-tests` and `website-check`, so it still gates merges with no ruleset change.

**3. Coverage moves to `main-post-merge`'s `debug-validation`.** `-enableCodeCoverage YES` instrumented every first-party module on the PR critical path for a number that is informational by design (#1600: no gate, `continue-on-error`, fail-open). Both the flag and the first-party-only `xccov` summary moved.

## Evidence

Generated project, per-target settings — the change does what it says and nothing more:

- `EnviousWisprTests`, `EnviousWisprASRTests` @ Release: `-Onone` / `singlefile`
- `EnviousWisprCore`, `EnviousWispr` @ Release: `-O` / `wholemodule` (unchanged)
- Two-way control on the guard: `SWIFT_ACTIVE_COMPILATION_CONDITIONS` is ` DEBUG DEBUG DEBUG` in Debug and **unset** in Release
- `SwiftSyntax`/`SwiftParser` (where #2070's `Parser.defaultMaximumNestingLevel` lives) are **not targets in this project** — SPM-resolved, so a per-target `settings:` cannot reach them. Verified with a positive control: `xcodebuild -list` shows `EnviousWisprTests` present and both absent.

Cold `build-for-testing -configuration Release ENABLE_TESTABILITY=YES`: exit 0, both `.xctest` bundles and the `.xctestrun` produced, and the single serial `SwiftDriver Compilation EnviousWisprTests` is replaced by batched parallel `SwiftCompile` groups — the mechanism, not just the outcome.

Full suites, **both arms contended** (load peaked at 18 with three sessions building):

| arm | Debug | Release | issues | exit | wall (both lanes) |
|---|---|---|---|---|---|
| baseline (`origin/main` @ `5c5ab537`, own worktree, own script) | 5,631 | 5,197 | 0 | 0 | 928s |
| branch | 5,631 | 5,197 | 0 | 0 | **559s** |

Counts identical in **both** configurations — nothing silently dropped, which is the failure mode a per-target settings change on exactly the two test targets could plausibly cause and which `run_lane`'s `n < 1` guard would not catch. Zero recorded issues on both arms. 369s faster locally (40%) for the same work; that is a 14-core machine running both lanes sequentially, so it is corroboration of direction and mechanism, not a prediction of the CI number.

The control is Release-against-Release and Debug-against-Debug. **Comparing Debug to Release is invalid**: `#if DEBUG` tests are absent from the Release binary by construction, a ~434-test structural gap reproduced independently on two unrelated branches. An equality gate across configurations would fire on every clean tree.

## Costs, stated

- **A third macOS runner per PR** against the 5-slot limit #804 weighed. One PR plus a post-merge is now exactly 5; two PRs plus a post-merge queues. Acceptable because queue time does not count against `timeout-minutes` (ci-pipeline.md FACT: deferred-job-splitting), and the job holds its slot ~300s rather than the ~1600s of the lane it left.
- **Optimisation-sensitive behaviour in test code** — the reachable case is a side effect inside `assert(...)`, which `-O` strips and `-Onone` keeps. Verified empty: `grep -rnE "(^|[^.A-Za-z])assert\(" Tests/` returns 0, no `_isDebugAssertConfiguration` in the repo.
- **One more axis for a lane-specific failure to hide along.** Real even when it causes nothing. A discriminator ladder is recorded at the setting in `Project.swift` — contention (or `app.log` corruption for AppLogger tests) vs configuration divergence vs the diff — with the 434-gap note.
- **Timing.** Repeats bound a flake rate; they are not evidence of absence. If an intermittent post-merge red appears in a timing-sensitive suite later, this change is a suspect.

## Review

Codex, two grounded rounds. Peer review from three concurrent sessions corrected two of my instruments: the Debug-vs-Release count comparison (invalid by construction) and the plan to generate contention with a second concurrent suite (manufactures the documented `app.log` corruption of #2080 and would have invited attribution to `-Onone`).

The PR measures itself — `pr-check.yml` self-forces full Xcode work, and per-step timings attribute all three changes separately against the baseline above.
