### PR TITLE
EG-1 version visibility, resumable upgrades, and no orphaned downloads

### DIFF
--- a/Sources/EnviousWispr/Resources/eg1-manifest.json
+++ b/Sources/EnviousWispr/Resources/eg1-manifest.json
@@ -5,5 +5,6 @@
   "promptTemplateID": "eg1-v1",
   "minAppVersion": "2.3.0",
   "downloadURL": "https://models.enviouslabs.co/eg1/v3-eg2/eg-1-v2-00001-of-00008.gguf",
-  "licenseURL": "https://models.enviouslabs.co/eg1/EG-1-MODEL-LICENSE.txt"
+  "licenseURL": "https://models.enviouslabs.co/eg1/EG-1-MODEL-LICENSE.txt",
+  "displayVersion": "1.1"
 }

--- a/Sources/EnviousWisprAppKit/App/EGOneTelemetryBridge.swift
+++ b/Sources/EnviousWisprAppKit/App/EGOneTelemetryBridge.swift
@@ -19,6 +19,13 @@ enum EGOneTelemetryBridge {
           TelemetryService.shared.egOneDownloadEvent(
             name: "health_changed",
             properties: ["from": from, "to": to, "reason": reason ?? "none"])
+        case .pausedInstallStateChanged(let projection):
+          // One property from a closed set of four (three paused states plus
+          // "none" for leaving one). No transcript, no path, no version string
+          // beyond what this app already ships — shape, never content.
+          TelemetryService.shared.egOneDownloadEvent(
+            name: "paused_install_state_changed",
+            properties: ["state": projection?.rawValue ?? "none"])
         }
       }
     }

--- a/Sources/EnviousWisprAppKit/App/ModelDeliveryHome.swift
+++ b/Sources/EnviousWisprAppKit/App/ModelDeliveryHome.swift
@@ -97,6 +97,8 @@ public final class ModelDeliveryHome {
           .appendingPathComponent("EnviousWispr/ModelDelivery", isDirectory: true))
       parakeetIdentity = identity
       parakeetRegistration = registration
+      // #2119: reclaim staging abandoned by a superseded revision of THIS model.
+      Task { await controller.sweepSupersededStaging(registration) }
       parakeetHandle = ParakeetDeliveryHandle(controller: controller, registration: registration)
       wireObservers(identity: identity)
     } catch {
@@ -123,6 +125,7 @@ public final class ModelDeliveryHome {
         metadataDirectory: appSupport.appendingPathComponent(
           "EnviousWispr/ModelDelivery", isDirectory: true))
       whisperKitRegistration = registration
+      Task { await controller.sweepSupersededStaging(registration) }
       whisperKitHandle = WhisperKitDeliveryHandle(
         controller: controller, registration: registration)
       let home = self
@@ -171,6 +174,7 @@ public final class ModelDeliveryHome {
         metadataDirectory: appSupport.appendingPathComponent(
           "EnviousWispr/ModelDelivery", isDirectory: true))
       whisperPreviewRegistration = registration
+      Task { await controller.sweepSupersededStaging(registration) }
       whisperPreviewHandle = WhisperKitDeliveryHandle(
         controller: controller, registration: registration)
       let previewHome = self

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -284,7 +284,10 @@ public final class WisprBootstrapper {
       let adapter = EGOneDeliveryAdapter(
         controller: modelDelivery.controller,
         registration: registration,
-        version: egOneManifest?.version ?? deliveryManifest.identity.revision)
+        // #2109: the USER-FACING label, not the internal revision. nil when the
+        // manifest carries none — the row then shows no version rather than
+        // printing `v3-eg2` at someone.
+        version: egOneManifest?.resolvedDisplayVersion)
       egOneAdapter = adapter
 
       let coordinator = EGOneUpgradeCoordinator(

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -284,14 +284,8 @@ public final class WisprBootstrapper {
       let adapter = EGOneDeliveryAdapter(
         controller: modelDelivery.controller,
         registration: registration,
-        // #2109: the USER-FACING label, not the internal revision. nil when the
-        // manifest carries none — the row then shows no version rather than
-        // printing `v3-eg2` at someone.
-        version: egOneManifest?.resolvedDisplayVersion)
+        version: egOneManifest?.resolvedDisplayVersion)  // #2109: label, not revision
       egOneAdapter = adapter
-      // #2119: EG-1's own bootstrap sweep. All FOUR registrations call this —
-      // a missed one is a family whose dead staging is never reclaimed.
-      Task { await modelDelivery.controller.sweepSupersededStaging(registration) }
 
       let coordinator = EGOneUpgradeCoordinator(
         adapter: adapter,
@@ -314,6 +308,7 @@ public final class WisprBootstrapper {
       // decides if the completed replacement boots the server (PR #1500 P1).
       let delivery = modelDelivery
       Task {
+        await delivery.controller.sweepSupersededStaging(egOneUpgrade.registration)  // #2119
         await delivery.recordFirstRunBaseline(for: egOneUpgrade.registration)
         await egOneUpgrade.coordinator.runLaunch()
         egOneRuntime.activateAfterAutomaticReplacementIfNeeded()

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -289,6 +289,9 @@ public final class WisprBootstrapper {
         // printing `v3-eg2` at someone.
         version: egOneManifest?.resolvedDisplayVersion)
       egOneAdapter = adapter
+      // #2119: EG-1's own bootstrap sweep. All FOUR registrations call this —
+      // a missed one is a family whose dead staging is never reclaimed.
+      Task { await modelDelivery.controller.sweepSupersededStaging(registration) }
 
       let coordinator = EGOneUpgradeCoordinator(
         adapter: adapter,

--- a/Sources/EnviousWisprAppKit/Views/Settings/AIPolishProviderRail.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AIPolishProviderRail.swift
@@ -90,8 +90,12 @@ enum ProviderStatusMapping {
     // surface, and a calm chip beside an alarmed row is worse than either.
     case .updatePaused:
       return ProviderStatus(label: "Update paused", tone: .error)
-    case .downloading:
-      return ProviderStatus(label: "Downloading", tone: .needsSetup)
+    // Same agreement rule as `updatePaused` above: when the detailed row says
+    // "Upgrading to EG-1 V1.1", a chip reading "Downloading" describes a
+    // different event beside it. The chip is narrower, not softer.
+    case .downloading(_, let upgradeTo):
+      return ProviderStatus(
+        label: upgradeTo == nil ? "Downloading" : "Upgrading", tone: .needsSetup)
     case .verifying:
       return ProviderStatus(label: "Verifying", tone: .needsSetup)
     case .failed:

--- a/Sources/EnviousWisprAppKit/Views/Settings/AIPolishProviderRail.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AIPolishProviderRail.swift
@@ -93,9 +93,9 @@ enum ProviderStatusMapping {
     // Same agreement rule as `updatePaused` above: when the detailed row says
     // "Upgrading to EG-1 V1.1", a chip reading "Downloading" describes a
     // different event beside it. The chip is narrower, not softer.
-    case .downloading(_, let upgradeTo):
+    case .downloading(_, let upgrade):
       return ProviderStatus(
-        label: upgradeTo == nil ? "Downloading" : "Upgrading", tone: .needsSetup)
+        label: upgrade == nil ? "Downloading" : "Upgrading", tone: .needsSetup)
     case .verifying:
       return ProviderStatus(label: "Verifying", tone: .needsSetup)
     case .failed:

--- a/Sources/EnviousWisprAppKit/Views/Settings/AIPolishProviderRail.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AIPolishProviderRail.swift
@@ -80,6 +80,16 @@ enum ProviderStatusMapping {
     switch install {
     case .notInstalled:
       return ProviderStatus(label: "Not installed", tone: .needsSetup)
+    // #2109: an interrupted first install. The user chose to stop and their
+    // progress is kept, so this is a setup state, never an error.
+    case .paused:
+      return ProviderStatus(label: "Paused", tone: .needsSetup)
+    // A working older model is on disk but the pinned one is not, so cleanup
+    // is genuinely off. The chip must AGREE with the detailed row rather than
+    // reassure — this is exactly the silently-off state #2109 exists to
+    // surface, and a calm chip beside an alarmed row is worse than either.
+    case .updatePaused:
+      return ProviderStatus(label: "Update paused", tone: .error)
     case .downloading:
       return ProviderStatus(label: "Downloading", tone: .needsSetup)
     case .verifying:

--- a/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
@@ -1454,6 +1454,12 @@ struct AIPolishSettingsView: View {
       .fixedSize(horizontal: false, vertical: true)
     }
 
+    // One presentation value for the whole row (#2109). Hoisted above the
+    // switch deliberately: when only some branches consumed it, the remaining
+    // mappings were still ASSERTED by the agreement tests while the real row
+    // rendered something else, so the tests described a value the UI did not
+    // use. Every branch now reads from the tested value.
+    let presentation = EGOneRowPresentation.forState(egOne.installState)
     switch egOne.installState {
     case .notInstalled:
       HStack {
@@ -1464,7 +1470,9 @@ struct AIPolishSettingsView: View {
           .font(.stHelper)
           .foregroundStyle(Color.stTextSecondary)
         Spacer()
-        Button("Download EG-1") { egOne.startDownload() }
+        if let action = presentation.primaryAction {
+          Button(action) { egOne.startDownload() }
+        }
       }
     case .downloading(let fraction):
       VStack(alignment: .leading, spacing: 4) {
@@ -1472,9 +1480,49 @@ struct AIPolishSettingsView: View {
           Text("Downloading EG-1 (2.9 GB)")
             .font(.stHelper)
         }
-        Button("Cancel") { egOne.cancelDownload() }
-          .buttonStyle(.borderless)
+        if let action = presentation.primaryAction {
+          Button(action) { egOne.cancelDownload() }
+            .buttonStyle(.borderless)
+            .font(.stHelper)
+        }
+      }
+    // #2109: an interrupted FIRST install. Ported from the founder ruling of
+    // 2026-07-17 already shipped for Parakeet and WhisperKit — paused, Resume
+    // anytime. This used to render through the failure branch with a red row
+    // and a Try Again button, for something the user deliberately chose.
+    case .paused:
+      VStack(alignment: .leading, spacing: 4) {
+        Text(presentation.message)
           .font(.stHelper)
+          .foregroundStyle(Color.stTextSecondary)
+        if let action = presentation.primaryAction {
+          Button(action) { egOne.startDownload() }
+        }
+      }
+    // A working older EG-1 is installed and the pinned one is not, so AI
+    // cleanup is off until this finishes. The old revision is deliberately
+    // NOT named: this app bundle does not contain its manifest, so any name
+    // for it would be invented.
+    case .updatePaused:
+      VStack(alignment: .leading, spacing: 4) {
+        Text(presentation.message)
+          .font(.stHelper)
+          .foregroundStyle(Color.stTextSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+        HStack {
+          if let action = presentation.primaryAction {
+            Button(action) { egOne.startDownload() }
+          }
+          Spacer()
+          if presentation.showsRemove {
+            Button("Remove Model") {
+              egOne.removeModel()
+              settings.llmProvider = .appleIntelligence
+            }
+            .buttonStyle(.borderless)
+            .font(.stHelper)
+          }
+        }
       }
     case .verifying:
       HStack {
@@ -1488,10 +1536,27 @@ struct AIPolishSettingsView: View {
         .font(.stHelper)
         .foregroundStyle(.stError)
         .fixedSize(horizontal: false, vertical: true)
-      Button("Try Again") { egOne.startDownload() }
+      if let action = presentation.primaryAction {
+        Button(action) { egOne.startDownload() }
+      }
     case .installed:
       HStack {
         Text("Status:")
+        // #2109: the version, as a quiet secondary label. Deliberately not
+        // prominent — Priya and Dr. Vasquez want to know which model they are
+        // on, Frank and Meera must be able to ignore it entirely, and nobody
+        // is being asked to make a decision here.
+        //
+        // Composed by `EGOneRowPresentation`, not here, so the same value the
+        // tests assert is the value that renders. nil and blank both render
+        // NOTHING: an absent label is honest, "Unknown version" is a string
+        // Frank should never see, and `EG-1 V` with an empty tail reads as a
+        // rendering bug.
+        if let versionLabel = presentation.versionLabel {
+          Text(versionLabel)
+            .font(.stHelper)
+            .foregroundStyle(Color.stTextSecondary)
+        }
         Spacer()
         egOneHealthLabel
         Button {
@@ -1509,12 +1574,14 @@ struct AIPolishSettingsView: View {
           .foregroundStyle(Color.stTextSecondary)
           .fixedSize(horizontal: false, vertical: true)
       }
-      Button("Remove Model") {
-        egOne.removeModel()
-        settings.llmProvider = .appleIntelligence
+      if presentation.showsRemove {
+        Button("Remove Model") {
+          egOne.removeModel()
+          settings.llmProvider = .appleIntelligence
+        }
+        .buttonStyle(.borderless)
+        .font(.stHelper)
       }
-      .buttonStyle(.borderless)
-      .font(.stHelper)
     }
   }
 

--- a/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
@@ -1474,11 +1474,24 @@ struct AIPolishSettingsView: View {
           Button(action) { egOne.startDownload() }
         }
       }
-    case .downloading(let fraction):
+    case .downloading(let fraction, _):
       VStack(alignment: .leading, spacing: 4) {
         ProgressView(value: max(0, min(1, fraction))) {
-          Text("Downloading EG-1 (2.9 GB)")
-            .font(.stHelper)
+          // An UPGRADE says so and names the version arriving; a first install
+          // keeps the original sentence (founder, 2026-08-17, from Live UAT).
+          // Both used to read "Downloading EG-1 (2.9 GB)", so a user who
+          // already had EG-1 could not tell a 2.9 GB upgrade from a 2.9 GB
+          // first install and was never told which version was coming.
+          //
+          // The version comes from `presentation.versionLabel`, composed from
+          // the manifest — never a literal here. A revision ships as a manifest
+          // edit with no Swift change, so a hard-coded number would keep naming
+          // the previous model after the real one moved on.
+          Text(
+            presentation.versionLabel.map { "Upgrading to \($0) (2.9 GB)" }
+              ?? "Downloading EG-1 (2.9 GB)"
+          )
+          .font(.stHelper)
         }
         if let action = presentation.primaryAction {
           Button(action) { egOne.cancelDownload() }

--- a/Sources/EnviousWisprAppKit/Views/Settings/EGOneRowPresentation.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/EGOneRowPresentation.swift
@@ -67,8 +67,14 @@ struct EGOneRowPresentation: Equatable {
         // manifest this bundle does not contain, so any number here would be
         // invented. The target version above is a different thing.
         versionLabel: nil)
-    case .downloading:
-      return .init(message: "", primaryAction: "Cancel", showsRemove: false, versionLabel: nil)
+    case .downloading(_, let upgradeTo):
+      // The progress row owns its own sentence (it needs the live fraction),
+      // so `message` stays empty. But the VERSION belongs here with every
+      // other version decision, so one test covers "blank display version
+      // renders nothing" for this state too rather than only for installed.
+      return .init(
+        message: "", primaryAction: "Cancel", showsRemove: false,
+        versionLabel: upgradeTo.flatMap { $0.isEmpty ? nil : "EG-1 V\($0)" })
     case .verifying:
       return .init(message: "", primaryAction: nil, showsRemove: false, versionLabel: nil)
     case .installed(let version):

--- a/Sources/EnviousWisprAppKit/Views/Settings/EGOneRowPresentation.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/EGOneRowPresentation.swift
@@ -37,19 +37,35 @@ struct EGOneRowPresentation: Equatable {
       return .init(
         message: "Download paused. Resume anytime.",
         primaryAction: "Resume", showsRemove: false, versionLabel: nil)
-    case .updatePaused(let resumable):
+    case .updatePaused(let resumable, let targetVersion):
+      // Composed from the manifest's version, never a literal. A new revision
+      // ships as a manifest edit with no Swift change, so a hard-coded "V1.1"
+      // would keep naming the previous model after the real one moved on —
+      // confidently wrong, which is worse than saying nothing.
+      let target = targetVersion.map { "EG-1 V\($0)" } ?? "the new EG-1"
       return .init(
         message: resumable
-          ? "AI cleanup is paused. Your upgrade to EG-1 V1.1 stopped part-way."
-          : "AI cleanup is paused until EG-1 V1.1 finishes installing.",
+          ? "AI cleanup is paused. Your upgrade to \(target) stopped part-way."
+          : "AI cleanup is paused until \(target) finishes installing.",
         primaryAction: resumable ? "Resume upgrade" : "Finish upgrade",
-        // A full model IS on disk and the help centre promises users can remove
-        // models to reclaim storage. Withdrawing the control here would make
-        // shipped documentation false.
-        showsRemove: true,
-        // No version label: the installed revision is the OLD one, whose
-        // manifest this app bundle does not contain, so any number here would
-        // be invented.
+        // NO Remove button here, and this reverses an earlier decision of mine.
+        // I added it arguing the help centre promises users can remove models
+        // to reclaim storage. That promise is real, but `remove()` deletes the
+        // CURRENT manifest's files and marker — and in this state the current
+        // revision is precisely what is NOT installed. Pressing it would leave
+        // the older model's gigabytes and its marker untouched and return the
+        // row to this same state: a button that visibly does nothing, which is
+        // the exact defect fixed for Resume elsewhere in this change.
+        //
+        // Hiding it restores the behaviour that shipped before this change
+        // (there was no Remove button in this state), so no promise is broken
+        // that was not already. Reclaiming a superseded revision on demand
+        // needs prior-marker removal, which does not exist yet — tracked
+        // rather than faked.
+        showsRemove: false,
+        // No version label: the INSTALLED revision is the old one, whose
+        // manifest this bundle does not contain, so any number here would be
+        // invented. The target version above is a different thing.
         versionLabel: nil)
     case .downloading:
       return .init(message: "", primaryAction: "Cancel", showsRemove: false, versionLabel: nil)

--- a/Sources/EnviousWisprAppKit/Views/Settings/EGOneRowPresentation.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/EGOneRowPresentation.swift
@@ -67,14 +67,22 @@ struct EGOneRowPresentation: Equatable {
         // manifest this bundle does not contain, so any number here would be
         // invented. The target version above is a different thing.
         versionLabel: nil)
-    case .downloading(_, let upgradeTo):
+    case .downloading(_, let upgrade):
       // The progress row owns its own sentence (it needs the live fraction),
       // so `message` stays empty. But the VERSION belongs here with every
       // other version decision, so one test covers "blank display version
       // renders nothing" for this state too rather than only for installed.
       return .init(
         message: "", primaryAction: "Cancel", showsRemove: false,
-        versionLabel: upgradeTo.flatMap { $0.isEmpty ? nil : "EG-1 V\($0)" })
+        versionLabel: upgrade.map {
+          // `.unnamed` reuses the SAME fallback the paused row uses rather than
+          // degrading into the first-install sentence, which is what the P2
+          // was: an upgrade that stopped looking like one.
+          switch $0 {
+          case .named(let v): return "EG-1 V\(v)"
+          case .unnamed: return "the new EG-1"
+          }
+        })
     case .verifying:
       return .init(message: "", primaryAction: nil, showsRemove: false, versionLabel: nil)
     case .installed(let version):

--- a/Sources/EnviousWisprAppKit/Views/Settings/EGOneRowPresentation.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/EGOneRowPresentation.swift
@@ -1,0 +1,66 @@
+import EnviousWisprLLM
+
+/// What the EG-1 settings row SAYS and OFFERS for a given install state (#2109).
+///
+/// Extracted from the inline `switch` in `AIPolishSettingsView` for one reason:
+/// the row and the provider-rail chip render the SAME state through two
+/// independent code paths, and compile-time exhaustiveness forces both to
+/// HANDLE every case while doing nothing to make them AGREE. A user meeting a
+/// calm chip beside an alarmed row learns to distrust the screen, which is
+/// worse than either surface being wrong alone.
+///
+/// A pure value makes that agreement assertable. Mirrors the existing
+/// `egOneFailureCopy` precedent in the same file: copy decisions are data, not
+/// view code.
+struct EGOneRowPresentation: Equatable {
+  /// The sentence shown under the row. Empty for states whose copy is owned by
+  /// the view's own progress or status chrome (downloading, verifying,
+  /// installed, failed).
+  let message: String
+  /// The primary button's title, or nil when the row offers no primary action.
+  let primaryAction: String?
+  /// Whether `Remove Model` is reachable. True only when a usable model is
+  /// actually on disk.
+  let showsRemove: Bool
+  /// The version label to render, already composed, or nil when there is
+  /// nothing honest to show. Owned here rather than in the view so it is
+  /// covered by the same tests as the rest of the row: a blank or missing
+  /// display version must render NOTHING, never "EG-1 V" with an empty tail.
+  let versionLabel: String?
+
+  static func forState(_ state: EGOneInstallState) -> EGOneRowPresentation {
+    switch state {
+    case .notInstalled:
+      return .init(
+        message: "", primaryAction: "Download EG-1", showsRemove: false, versionLabel: nil)
+    case .paused:
+      return .init(
+        message: "Download paused. Resume anytime.",
+        primaryAction: "Resume", showsRemove: false, versionLabel: nil)
+    case .updatePaused(let resumable):
+      return .init(
+        message: resumable
+          ? "AI cleanup is paused. Your upgrade to EG-1 V1.1 stopped part-way."
+          : "AI cleanup is paused until EG-1 V1.1 finishes installing.",
+        primaryAction: resumable ? "Resume upgrade" : "Finish upgrade",
+        // A full model IS on disk and the help centre promises users can remove
+        // models to reclaim storage. Withdrawing the control here would make
+        // shipped documentation false.
+        showsRemove: true,
+        // No version label: the installed revision is the OLD one, whose
+        // manifest this app bundle does not contain, so any number here would
+        // be invented.
+        versionLabel: nil)
+    case .downloading:
+      return .init(message: "", primaryAction: "Cancel", showsRemove: false, versionLabel: nil)
+    case .verifying:
+      return .init(message: "", primaryAction: nil, showsRemove: false, versionLabel: nil)
+    case .installed(let version):
+      return .init(
+        message: "", primaryAction: nil, showsRemove: true,
+        versionLabel: version.flatMap { $0.isEmpty ? nil : "EG-1 V\($0)" })
+    case .failed:
+      return .init(message: "", primaryAction: "Try Again", showsRemove: false, versionLabel: nil)
+    }
+  }
+}

--- a/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
@@ -25,7 +25,7 @@ enum WhatsNewContent {
       icon: "sparkles",
       title: "EG-1 is better at changes of mind and spoken lists",
       description:
-        "The built-in AI cleanup model has been retrained. When you change your mind mid-sentence, saying something like \"send it to Marcus, sorry, to Priya\", it now keeps what you meant and drops what you took back. When you announce a list out loud, you get a list instead of one long line. You do not need to change how you dictate, and EG-1 still runs entirely on your Mac. If you already use it, the new version downloads on its own in the background the next time you open the app. Dictation keeps working while it downloads.",
+        "The built-in AI cleanup model has been retrained. When you change your mind mid-sentence, saying something like \"send it to Marcus, sorry, to Priya\", it now keeps what you meant and drops what you took back. When you announce a list out loud, you get a list instead of one long line. You do not need to change how you dictate, and EG-1 still runs entirely on your Mac. If you already use it, the new version downloads on its own in the background the next time you open the app, and dictation keeps working while it does. You can pause that download and pick it up later from AI Polish settings, which also now shows which version you are on.",
       version: "2.4.5"
     ),
 

--- a/Sources/EnviousWisprLLM/EGOne/EGOneDeliveryAdapter.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneDeliveryAdapter.swift
@@ -19,14 +19,16 @@ public final class EGOneDeliveryAdapter {
   private let controller: ModelDeliveryController
   private let registration: DeliveryRegistration
   private let defaults: UserDefaults
-  /// Version string surfaced as `.installed(version:)` (the runtime manifest's
-  /// version, e.g. `v1`); the delivery identity's revision carries the same.
-  private let version: String
+  /// USER-FACING display label surfaced as `.installed(version:)`, e.g. "1.1"
+  /// rendered as "EG-1 V1.1" (#2109). Optional: a manifest without one shows
+  /// no label rather than falling back to the internal revision, which is a
+  /// path component (`v3-eg2`) and not a thing to put in front of a user.
+  private let version: String?
 
   public init(
     controller: ModelDeliveryController,
     registration: DeliveryRegistration,
-    version: String,
+    version: String?,
     defaults: UserDefaults? = nil
   ) {
     self.controller = controller
@@ -212,13 +214,48 @@ public final class EGOneDeliveryAdapter {
     let identity = registration.manifest.identity
     let version = version
     let sequencer = InstallStateSequencer()
+    let registration = registration
     Task {
+      // SEED FIRST, THEN OBSERVE (#2109). The order is inverted from what it
+      // used to be, and the inversion is the whole reason `updatePaused` is
+      // reachable at all.
+      //
+      // `addStateObserver` replays only identities already present in the
+      // controller's `entries`, and an entry exists only once something has
+      // touched that identity. A user sitting on a PRIOR revision with no
+      // fetch in flight has no entry, so the observer never fires for them —
+      // and the old seed was gated on `isAdmitted`, which is false for exactly
+      // that user because the pinned revision is the thing they lack. Neither
+      // path published anything, so the row kept `EGOneRuntime`'s initial
+      // `.notInstalled` and the paused-update state could never appear on a
+      // cold launch, which is the only moment it matters.
+      //
+      // Seeding first is also what makes the ordering safe. The previous
+      // comment here reasoned that the seed must come AFTER registration so it
+      // outranks the replay's `.notReady` — correct when the seed could only
+      // ever be `.installed` for an admitted cache, and WRONG now that the
+      // seed carries a disk-derived guess, because a guess must never outrank
+      // live truth. Attaching second means any already-running attempt is
+      // replayed with a LATER sequence number and wins, and if nothing is
+      // running there is no entry, no replay, and the seed stands.
+      let seedSeq = sequencer.next()
+      let seeded: EGOneInstallState =
+        await controller.isAdmitted(registration)
+        ? .installed(version: version)
+        : Self.notServingState(for: registration)
+      await MainActor.run { [weak self] in
+        guard let self, seedSeq > self.lastAppliedInstallSeq else { return }
+        self.lastAppliedInstallSeq = seedSeq
+        if case .installed = seeded { self.legacyDidAdmit?() }
+        onState(seeded)
+      }
+
       await controller.addStateObserver { [weak self] observedIdentity, state in
         guard observedIdentity == identity else { return }
         // Mint the sequence on the controller actor (publish order); apply on
         // MainActor only if newer than the last applied (drop reordered hops).
         let seq = sequencer.next()
-        let mapped = Self.map(state, version: version)
+        let mapped = Self.map(state, version: version, registration: registration)
         Task { @MainActor in
           guard let self, seq > self.lastAppliedInstallSeq else { return }
           self.lastAppliedInstallSeq = seq
@@ -231,17 +268,6 @@ public final class EGOneDeliveryAdapter {
           }
 
           onState(mapped)
-        }
-      }
-      // Seed from the marker AFTER registration (so this seq outranks the
-      // replay's `.notReady`): an admitted cache shows Installed at startup.
-      if await controller.isAdmitted(registration) {
-        let seq = sequencer.next()
-        await MainActor.run { [weak self] in
-          guard let self, seq > self.lastAppliedInstallSeq else { return }
-          self.lastAppliedInstallSeq = seq
-          self.legacyDidAdmit?()
-          onState(.installed(version: version))
         }
       }
     }
@@ -261,10 +287,30 @@ public final class EGOneDeliveryAdapter {
 
   // MARK: - Mapping (DeliveryState → EG-1 UI vocabulary)
 
-  nonisolated static func map(_ state: DeliveryState, version: String) -> EGOneInstallState {
+  /// Disk truth the mapper needs, read once per mapping call.
+  ///
+  /// Both reads are SYNCHRONOUS by construction (#2109): `map` runs inside the
+  /// controller's state-observer callback, between minting a sequence number
+  /// and applying it on the MainActor, so it cannot await. Adding a suspension
+  /// there would open the exact window `InstallStateSequencer` exists to close.
+  nonisolated static func diskFacts(
+    for registration: DeliveryRegistration
+  ) -> (hasPartials: Bool, olderRevisionSurvives: Bool) {
+    (
+      hasPartials: ModelDeliveryController.hasStagedPartialsOnDisk(registration),
+      olderRevisionSurvives: PriorRevisionAdmission.supersededInstallSurvives(
+        identity: registration.manifest.identity,
+        metadataDirectory: registration.metadataDirectory,
+        installDirectory: registration.installDirectory)
+    )
+  }
+
+  nonisolated static func map(
+    _ state: DeliveryState, version: String?, registration: DeliveryRegistration
+  ) -> EGOneInstallState {
     switch state {
     case .notReady:
-      return .notInstalled
+      return Self.notServingState(for: registration)
     case .preparing:
       // Existing-cache validation / staging setup reads as "verifying" in the
       // EG-1 row (yellow).
@@ -276,12 +322,33 @@ public final class EGOneDeliveryAdapter {
     case .admitted:
       return .installed(version: version)
     case .cancelled:
-      // The EG-1 row shows a paused/saved state via the .cancelled failure
-      // copy ("Download canceled. Your progress is saved.").
-      return .failed(.cancelled)
+      // #2109: a cancel is a user DECISION, not a failure. It used to map to
+      // `.failed(.cancelled)`, which rendered a red row with a Try Again
+      // button for something the user chose. Which paused state it is depends
+      // on whether a working older revision survives underneath.
+      return Self.notServingState(for: registration)
     case .failed(let failure):
       return .failed(Self.mapFailure(failure.reason))
     }
+  }
+
+  /// The three ways EG-1 can be not-serving, separated by DISK truth rather
+  /// than by how we got here (#2109). `.notReady` and `.cancelled` both land
+  /// here because the user-visible question is identical in both: is there a
+  /// working model underneath, and is there a download to resume?
+  ///
+  /// Order matters. A surviving older revision is the strongest signal — it
+  /// means AI cleanup was working and has stopped, which is the thing #2109
+  /// exists to stop hiding — so it is checked first and reported whether or
+  /// not partials exist.
+  nonisolated static func notServingState(
+    for registration: DeliveryRegistration
+  ) -> EGOneInstallState {
+    let facts = Self.diskFacts(for: registration)
+    if facts.olderRevisionSurvives {
+      return .updatePaused(resumable: facts.hasPartials)
+    }
+    return facts.hasPartials ? .paused : .notInstalled
   }
 
   /// Map the shared engine's closed failure taxonomy onto EG-1's existing UI

--- a/Sources/EnviousWisprLLM/EGOne/EGOneDeliveryAdapter.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneDeliveryAdapter.swift
@@ -316,11 +316,11 @@ public final class EGOneDeliveryAdapter {
       // EG-1 row (yellow).
       return .verifying
     case .downloading(let fraction, _, _):
-      // `upgradeTo` is nil HERE BY DESIGN, not by omission. This mapping is
+      // `upgrade` is nil HERE BY DESIGN, not by omission. This mapping is
       // stateless and per-tick; whether the download replaces a working older
       // revision is a fact about the state we came FROM. `EGOneRuntime` owns
       // that and enriches this value.
-      return .downloading(fractionCompleted: fraction, upgradeTo: nil)
+      return .downloading(fractionCompleted: fraction, upgrade: nil)
     case .verifying:
       return .verifying
     case .admitted:

--- a/Sources/EnviousWisprLLM/EGOne/EGOneDeliveryAdapter.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneDeliveryAdapter.swift
@@ -316,7 +316,11 @@ public final class EGOneDeliveryAdapter {
       // EG-1 row (yellow).
       return .verifying
     case .downloading(let fraction, _, _):
-      return .downloading(fractionCompleted: fraction)
+      // `upgradeTo` is nil HERE BY DESIGN, not by omission. This mapping is
+      // stateless and per-tick; whether the download replaces a working older
+      // revision is a fact about the state we came FROM. `EGOneRuntime` owns
+      // that and enriches this value.
+      return .downloading(fractionCompleted: fraction, upgradeTo: nil)
     case .verifying:
       return .verifying
     case .admitted:

--- a/Sources/EnviousWisprLLM/EGOne/EGOneDeliveryAdapter.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneDeliveryAdapter.swift
@@ -242,7 +242,7 @@ public final class EGOneDeliveryAdapter {
       let seeded: EGOneInstallState =
         await controller.isAdmitted(registration)
         ? .installed(version: version)
-        : Self.notServingState(for: registration)
+        : Self.notServingState(for: registration, version: version)
       await MainActor.run { [weak self] in
         guard let self, seedSeq > self.lastAppliedInstallSeq else { return }
         self.lastAppliedInstallSeq = seedSeq
@@ -310,7 +310,7 @@ public final class EGOneDeliveryAdapter {
   ) -> EGOneInstallState {
     switch state {
     case .notReady:
-      return Self.notServingState(for: registration)
+      return Self.notServingState(for: registration, version: version)
     case .preparing:
       // Existing-cache validation / staging setup reads as "verifying" in the
       // EG-1 row (yellow).
@@ -326,7 +326,7 @@ public final class EGOneDeliveryAdapter {
       // `.failed(.cancelled)`, which rendered a red row with a Try Again
       // button for something the user chose. Which paused state it is depends
       // on whether a working older revision survives underneath.
-      return Self.notServingState(for: registration)
+      return Self.notServingState(for: registration, version: version)
     case .failed(let failure):
       return .failed(Self.mapFailure(failure.reason))
     }
@@ -342,11 +342,14 @@ public final class EGOneDeliveryAdapter {
   /// exists to stop hiding — so it is checked first and reported whether or
   /// not partials exist.
   nonisolated static func notServingState(
-    for registration: DeliveryRegistration
+    for registration: DeliveryRegistration, version: String?
   ) -> EGOneInstallState {
     let facts = Self.diskFacts(for: registration)
     if facts.olderRevisionSurvives {
-      return .updatePaused(resumable: facts.hasPartials)
+      // The TARGET version travels with the state so copy never hard-codes a
+      // model release: a revision ships as a manifest edit with no Swift
+      // change, and a literal would then name the wrong version confidently.
+      return .updatePaused(resumable: facts.hasPartials, targetVersion: version)
     }
     return facts.hasPartials ? .paused : .notInstalled
   }

--- a/Sources/EnviousWisprLLM/EGOne/EGOneInstallState.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneInstallState.swift
@@ -13,8 +13,45 @@ public enum EGOneInstallState: Sendable, Equatable {
   case notInstalled
   case downloading(fractionCompleted: Double)
   case verifying
-  case installed(version: String)
+  /// Installed and current. The payload is the user-facing DISPLAY version
+  /// (e.g. "1.1"), optional because a manifest without one renders no label
+  /// rather than falling back to the internal revision (#2109).
+  case installed(version: String?)
+  /// An interrupted FIRST install: no working model, resumable partials on
+  /// disk. Ported from the founder ruling of 2026-07-17 already shipped for
+  /// Parakeet and WhisperKit (`WhisperKitDownloadState.paused`) — paused,
+  /// Resume anytime. EG-1 was the only engine of the three without it, and
+  /// presented a deliberate cancel as a failure with a Try Again button.
+  case paused
+  /// A working OLDER revision is installed and the pinned revision is not, so
+  /// AI cleanup is off until this completes (#2109). Distinct from
+  /// `notInstalled`, which this used to be rendered as — byte-identically to
+  /// a user who never had EG-1 at all.
+  ///
+  /// `resumable` separates "continue what you started" from "start the
+  /// update". It is a presentation distinction only and never gates
+  /// behaviour; both variants offer the same action, worded differently.
+  case updatePaused(resumable: Bool)
   case failed(EGOneDownloadFailure)
+
+  /// Whether pressing the row's primary button should START a fetch.
+  ///
+  /// Named as a property rather than left inline in `EGOneRuntime.startDownload`
+  /// because of the failure it prevents (#2109): a state missing from that
+  /// guard renders its button and then silently does nothing when pressed.
+  /// That is invisible in review, invisible at compile time, and reads to a
+  /// user as the app ignoring them. Exhaustive here, so a future case cannot
+  /// be added without answering the question.
+  ///
+  /// The in-flight states return false because the shared controller
+  /// single-flights per identity: a second press would join the same attempt,
+  /// so refusing early is equivalent and cheaper.
+  var acceptsDownloadStart: Bool {
+    switch self {
+    case .notInstalled, .failed, .paused, .updatePaused: return true
+    case .downloading, .verifying, .installed: return false
+    }
+  }
 }
 
 /// EG-1 download-failure vocabulary for user-facing copy (settings row copy in

--- a/Sources/EnviousWisprLLM/EGOne/EGOneInstallState.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneInstallState.swift
@@ -1,5 +1,32 @@
 import Foundation
 
+/// What a download in flight is REPLACING, when it replaces anything (#2109).
+///
+/// Two facts, deliberately not collapsed into one optional string. A bare
+/// `String?` cannot distinguish "this is a first install" from "this is an
+/// upgrade whose manifest carries no display version", and both cloud-review
+/// P2s on this feature were that conflation surfacing in different states:
+/// a blank `displayVersion` erased the upgrade entirely, and the row fell back
+/// to the FIRST-INSTALL sentence for an upgrade in progress.
+///
+/// `.unnamed` renders the same fallback the paused row already uses ("the new
+/// EG-1") rather than degrading into a different state's copy.
+public enum EGOneUpgradeContext: Sendable, Equatable {
+  /// Upgrading, and the manifest names the version arriving.
+  case named(String)
+  /// Upgrading, but the manifest carries no usable display version. Still an
+  /// upgrade — say so without inventing a number.
+  case unnamed
+
+  /// Builds from a manifest's optional display version. A blank or
+  /// whitespace-only value is `.unnamed`, never `.named("")`, so no caller can
+  /// render a dangling "EG-1 V".
+  public init(displayVersion: String?) {
+    let trimmed = displayVersion?.trimmingCharacters(in: .whitespacesAndNewlines)
+    self = (trimmed?.isEmpty == false) ? .named(trimmed!) : .unnamed
+  }
+}
+
 /// The EG-1 install-state vocabulary the settings UI renders (#1348 Phase 3).
 ///
 /// Formerly `EGOneModelStore.InstallState`; relocated here when EG-1's private
@@ -11,8 +38,8 @@ import Foundation
 /// describes what the settings row shows.
 public enum EGOneInstallState: Sendable, Equatable {
   case notInstalled
-  /// Bytes moving. `upgradeTo` is the DISPLAY version being installed when this
-  /// download REPLACES a working older revision, and nil for a first install
+  /// Bytes moving. `upgrade` describes what this download REPLACES: non-nil
+  /// when it supersedes a working older revision, nil for a first install
   /// (founder, 2026-08-17, from Live UAT).
   ///
   /// Without it the progress row read "Downloading EG-1 (2.9 GB)" for both
@@ -27,7 +54,7 @@ public enum EGOneInstallState: Sendable, Equatable {
   /// UI-state owner, fills it in from the PREVIOUS state. Deriving it from disk
   /// here instead would read a marker and stat up to eight files on every
   /// progress tick, on the UI path.
-  case downloading(fractionCompleted: Double, upgradeTo: String?)
+  case downloading(fractionCompleted: Double, upgrade: EGOneUpgradeContext?)
   case verifying
   /// Installed and current. The payload is the user-facing DISPLAY version
   /// (e.g. "1.1"), optional because a manifest without one renders no label

--- a/Sources/EnviousWisprLLM/EGOne/EGOneInstallState.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneInstallState.swift
@@ -11,7 +11,23 @@ import Foundation
 /// describes what the settings row shows.
 public enum EGOneInstallState: Sendable, Equatable {
   case notInstalled
-  case downloading(fractionCompleted: Double)
+  /// Bytes moving. `upgradeTo` is the DISPLAY version being installed when this
+  /// download REPLACES a working older revision, and nil for a first install
+  /// (founder, 2026-08-17, from Live UAT).
+  ///
+  /// Without it the progress row read "Downloading EG-1 (2.9 GB)" for both
+  /// cases, so a user who already had EG-1 could not tell an upgrade from a
+  /// fresh 2.9 GB install and was never told which version was arriving. That
+  /// is the same defect #2109 exists to fix — two different situations
+  /// rendering the identical sentence — one state further along than the row
+  /// this change originally covered.
+  ///
+  /// The adapter cannot populate this: it maps each progress tick statelessly
+  /// and has no memory of the state it came from. `EGOneRuntime`, the single
+  /// UI-state owner, fills it in from the PREVIOUS state. Deriving it from disk
+  /// here instead would read a marker and stat up to eight files on every
+  /// progress tick, on the UI path.
+  case downloading(fractionCompleted: Double, upgradeTo: String?)
   case verifying
   /// Installed and current. The payload is the user-facing DISPLAY version
   /// (e.g. "1.1"), optional because a manifest without one renders no label

--- a/Sources/EnviousWisprLLM/EGOne/EGOneInstallState.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneInstallState.swift
@@ -31,7 +31,15 @@ public enum EGOneInstallState: Sendable, Equatable {
   /// `resumable` separates "continue what you started" from "start the
   /// update". It is a presentation distinction only and never gates
   /// behaviour; both variants offer the same action, worded differently.
-  case updatePaused(resumable: Bool)
+  ///
+  /// `targetVersion` is the display version of the revision being upgraded TO,
+  /// carried rather than hard-coded in copy. A new EG-2/EG-3 revision ships by
+  /// editing two JSON manifests and no Swift at all
+  /// (`eg1-operations.md` RULE: eg1-hot-swap-contract), so a literal in a
+  /// string would keep naming the old version after the model changed — worse
+  /// than no version, because it would confidently name the wrong one. nil
+  /// renders copy with no version rather than a placeholder.
+  case updatePaused(resumable: Bool, targetVersion: String?)
   case failed(EGOneDownloadFailure)
 
   /// Whether pressing the row's primary button should START a fetch.

--- a/Sources/EnviousWisprLLM/EGOne/EGOneManifest.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneManifest.swift
@@ -44,11 +44,25 @@ public struct EGOneManifest: Codable, Sendable, Equatable {
   public let downloadURL: URL
   /// HTTPS URL of the EG-1 model license that governs the artifact.
   public let licenseURL: URL?
+  /// User-facing version label for the settings row, e.g. "1.1" rendered as
+  /// "EG-1 V1.1" (#2109). PURELY COSMETIC and deliberately separate from
+  /// `version` above, which is load-bearing on disk via `artifactFileName`
+  /// and so cannot be made presentable.
+  ///
+  /// MUST NOT be used to build any path, URL, cache key, or comparison. The
+  /// display sequence and the internal revision sequence do not correspond
+  /// and are not meant to: the founder's numbering is a product decision, not
+  /// a function of `version` (plan §14 Q3).
+  ///
+  /// Optional so an older or malformed bundle decodes rather than throwing.
+  /// A nil or blank value renders NO label — never a fallback to `version`,
+  /// which would put `v3-eg2` in front of a user.
+  public let displayVersion: String?
 
   public init(
     modelName: String, version: String,
     contextTokens: Int, promptTemplateID: String, minAppVersion: String,
-    downloadURL: URL, licenseURL: URL? = nil
+    downloadURL: URL, licenseURL: URL? = nil, displayVersion: String? = nil
   ) {
     self.modelName = modelName
     self.version = version
@@ -57,6 +71,18 @@ public struct EGOneManifest: Codable, Sendable, Equatable {
     self.minAppVersion = minAppVersion
     self.downloadURL = downloadURL
     self.licenseURL = licenseURL
+    self.displayVersion = displayVersion
+  }
+
+  /// The label to render, or nil when there is nothing honest to show.
+  /// Blank-after-trimming is treated as absent: a manifest carrying `""`
+  /// would otherwise paint an empty string beside "EG-1" and read as a
+  /// rendering bug (plan §9 acceptance predicate).
+  public var resolvedDisplayVersion: String? {
+    guard let raw = displayVersion?.trimmingCharacters(in: .whitespacesAndNewlines),
+      !raw.isEmpty
+    else { return nil }
+    return raw
   }
 
   /// Prompt-template registry: manifest `promptTemplateID` → prompt family.

--- a/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
@@ -202,7 +202,51 @@ public final class EGOneRuntime: EGOneEndpointProviding {
     applyInstallState(state)
   }
 
-  private func applyInstallState(_ state: EGOneInstallState) {
+  /// Display version of an upgrade whose download is currently in flight, or
+  /// nil when the download in flight is a FIRST install (#2109, founder
+  /// 2026-08-17).
+  ///
+  /// Deliberately process-scoped and NOT persisted, which is the opposite
+  /// choice from `lastPausedProjection` one screen down, so the difference is
+  /// worth stating. That one measures a DURATION that outlives the process, so
+  /// forgetting it across launches makes an exit unpairable. This one describes
+  /// bytes moving right now: a download does not survive a quit, and a stale
+  /// value read back at launch would label a fresh first install as an upgrade.
+  /// Forgetting is the correct behaviour here.
+  private var upgradeDownloadInFlight: String?
+
+  private func applyInstallState(_ rawState: EGOneInstallState) {
+    // ENRICH BEFORE ANYTHING ELSE READS THE STATE, including the dedupe guard
+    // below — otherwise the first tick and the enriched second tick differ only
+    // in a field the guard does not compare, and the row keeps the unenriched
+    // copy for the whole download.
+    //
+    // Upgrade-ness is a property of where we CAME FROM: `updatePaused` means a
+    // working older revision is installed, so a download starting from there
+    // replaces it. The adapter maps each tick statelessly and cannot see that.
+    var state = rawState
+    switch rawState {
+    case .updatePaused(_, let targetVersion):
+      upgradeDownloadInFlight = targetVersion
+    case .downloading(let fraction, _):
+      if let target = upgradeDownloadInFlight {
+        state = .downloading(fractionCompleted: fraction, upgradeTo: target)
+      }
+    case .installed, .notInstalled, .failed, .paused:
+      // Every TERMINAL resting place clears it. `.verifying` is deliberately
+      // absent: it sits between the last download tick and admission, and
+      // clearing there would drop the label for the final stretch. `.paused`
+      // and `.notInstalled` are first-install states by definition — a cancel
+      // that leaves an older revision intact maps to `.updatePaused`, not to
+      // either of these.
+      upgradeDownloadInFlight = nil
+    case .verifying:
+      break
+    }
+    applyEnrichedInstallState(state)
+  }
+
+  private func applyEnrichedInstallState(_ state: EGOneInstallState) {
     // PAUSED-RESIDENCY RECONCILIATION RUNS FIRST, before the UI dedupe below.
     //
     // The order matters and is not cosmetic (whole-diff review). At launch

--- a/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
@@ -140,6 +140,13 @@ public final class EGOneRuntime: EGOneEndpointProviding {
     // stream. Reactively re-activating here would loop: an in-flight
     // activation's own `ensureAvailable()` republishes `.admitted` → `.installed`
     // while the server is still `.stopped` (grounded r2 P1).
+    // #2109: the single transition owner. The adapter has TWO publication
+    // paths — the seed and the observer — so neither of them is the
+    // authority; both converge here. Comparing before storing makes a
+    // republish of the SAME state a no-op, which is what lets the telemetry
+    // emit added in a later chunk fire once per real transition rather than
+    // once per settings-window open.
+    guard installState != state else { return }
     installState = state
     recomputeHealth()
   }
@@ -162,6 +169,13 @@ public final class EGOneRuntime: EGOneEndpointProviding {
     }
     switch installState {
     case .notInstalled: health = .red(reason: "download_required")
+    // #2109: an interrupted first install is not a failure — the user chose
+    // it, and their progress is kept. Yellow, not red.
+    case .paused: health = .yellow(reason: "download_paused")
+    // A working older revision is on disk but the pinned one is not, so polish
+    // is genuinely unavailable. RED is correct and deliberate: this is exactly
+    // the silently-off state #2109 exists to stop hiding.
+    case .updatePaused: health = .red(reason: "update_required")
     case .downloading: health = .yellow(reason: "downloading")
     case .verifying: health = .yellow(reason: "verifying")
     case .failed(let failure): health = .red(reason: failure.rawValue)
@@ -184,10 +198,9 @@ public final class EGOneRuntime: EGOneEndpointProviding {
   /// through the shared engine now, not from here.
   public func startDownload() {
     guard let delivery else { return }
-    switch installState {
-    case .notInstalled, .failed: break
-    case .downloading, .verifying, .installed: return
-    }
+    // #2109: the decision lives on the state itself, exhaustively, so a future
+    // case cannot silently render a button that does nothing when pressed.
+    guard installState.acceptsDownloadStart else { return }
     Task {
       let outcome = await delivery.ensureAvailable()
       // A user-initiated download that completes while EG-1 is the selected

--- a/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
@@ -67,7 +67,10 @@ public enum EGOnePausedInstallState: String, Sendable, Equatable {
   static func projection(of state: EGOneInstallState) -> EGOnePausedInstallState? {
     switch state {
     case .paused: return .paused
-    case .updatePaused(let resumable): return resumable ? .updatePausedResumable : .updatePaused
+    case .updatePaused(let resumable, _):
+      // The target version is deliberately NOT projected: telemetry keeps a
+      // closed property set, and a version string would make it unbounded.
+      return resumable ? .updatePausedResumable : .updatePaused
     case .notInstalled, .downloading, .verifying, .installed, .failed: return nil
     }
   }

--- a/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
@@ -213,7 +213,7 @@ public final class EGOneRuntime: EGOneEndpointProviding {
   /// bytes moving right now: a download does not survive a quit, and a stale
   /// value read back at launch would label a fresh first install as an upgrade.
   /// Forgetting is the correct behaviour here.
-  private var upgradeDownloadInFlight: String?
+  private var upgradeDownloadInFlight: EGOneUpgradeContext?
 
   private func applyInstallState(_ rawState: EGOneInstallState) {
     // ENRICH BEFORE ANYTHING ELSE READS THE STATE, including the dedupe guard
@@ -227,20 +227,32 @@ public final class EGOneRuntime: EGOneEndpointProviding {
     var state = rawState
     switch rawState {
     case .updatePaused(_, let targetVersion):
-      upgradeDownloadInFlight = targetVersion
+      // An upgrade is owed. Record it EVEN WITHOUT A VERSION: a manifest with
+      // no `displayVersion` still means an upgrade, and storing a bare nil here
+      // erased that fact entirely, so the row fell back to the FIRST-INSTALL
+      // sentence mid-upgrade (cloud review P2 on 5fdd0d53).
+      upgradeDownloadInFlight = EGOneUpgradeContext(displayVersion: targetVersion)
     case .downloading(let fraction, _):
-      if let target = upgradeDownloadInFlight {
-        state = .downloading(fractionCompleted: fraction, upgradeTo: target)
+      if let upgrade = upgradeDownloadInFlight {
+        state = .downloading(fractionCompleted: fraction, upgrade: upgrade)
       }
-    case .installed, .notInstalled, .failed, .paused:
-      // Every TERMINAL resting place clears it. `.verifying` is deliberately
-      // absent: it sits between the last download tick and admission, and
-      // clearing there would drop the label for the final stretch. `.paused`
-      // and `.notInstalled` are first-install states by definition — a cancel
-      // that leaves an older revision intact maps to `.updatePaused`, not to
-      // either of these.
+    case .installed, .notInstalled, .paused:
+      // Cleared only where the upgrade is genuinely OVER or was never running.
+      // `.paused` and `.notInstalled` are first-install states by construction:
+      // `notServingState` checks a surviving older revision FIRST, so a
+      // cancelled UPGRADE maps to `.updatePaused` and never lands here.
       upgradeDownloadInFlight = nil
+    case .failed:
+      // DELIBERATELY NOT CLEARED (cloud review P2 on 5fdd0d53). `.failed`
+      // accepts `startDownload()`, so Try Again after a network blip re-enters
+      // `.downloading` — and clearing here made that retry render as a first
+      // install, dropping the upgrade label exactly when a user is already
+      // having a bad time. Harmless for a genuine first install, where nothing
+      // was ever set.
+      break
     case .verifying:
+      // Sits between the last download tick and admission; clearing would drop
+      // the label for the final stretch.
       break
     }
     applyEnrichedInstallState(state)

--- a/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
@@ -140,10 +140,21 @@ public final class EGOneRuntime: EGOneEndpointProviding {
   /// adapter exists before launch activation calls it (#1348 §Decision A
   /// construction-order fix). A nil adapter (bundled-manifest load failure)
   /// is a RED limb state, never a crash.
-  public init(manifest: EGOneManifest?, serverBinaryURL: URL?, delivery: EGOneDeliveryAdapter?) {
+  public init(
+    manifest: EGOneManifest?, serverBinaryURL: URL?, delivery: EGOneDeliveryAdapter?,
+    defaults: UserDefaults? = nil
+  ) {
     self.manifest = manifest
     self.serverBinaryURL = serverBinaryURL
     self.delivery = delivery
+    self.defaults = defaults ?? UserDefaults(suiteName: DeliveryFlags.suiteName) ?? .standard
+    // Restore the paused projection from the last launch (#2109, whole-diff
+    // review). Without this the tracker is in-memory only, so a user who
+    // leaves an upgrade paused and quits emits a fresh ENTRY on every launch
+    // with no matching exit — the eventual exit then has several candidate
+    // starts and the duration this event exists to measure is uncomputable.
+    self.lastPausedProjection = (self.defaults.string(forKey: Self.pausedProjectionKey))
+      .flatMap(EGOnePausedInstallState.init(rawValue:))
     self.server = EGOneServerManager()
     if let manifest {
       self.activationBlockers = manifest.activationBlockers()
@@ -184,7 +195,42 @@ public final class EGOneRuntime: EGOneEndpointProviding {
     }
   }
 
+  /// Test seam for the residency tracker (#2109). Internal: the cross-launch
+  /// behaviour cannot be driven through the adapter, because the defect is
+  /// about a NEW process seeing persisted state.
+  func applyInstallStateForTesting(_ state: EGOneInstallState) {
+    applyInstallState(state)
+  }
+
   private func applyInstallState(_ state: EGOneInstallState) {
+    // PAUSED-RESIDENCY RECONCILIATION RUNS FIRST, before the UI dedupe below.
+    //
+    // The order matters and is not cosmetic (whole-diff review). At launch
+    // `installState` starts `.notInstalled`, and a user who resolved their
+    // pause while the app was closed gets a seed of `.notInstalled` too — the
+    // same value. The UI guard would early-return on that equality and the
+    // persisted pause would never close, leaving an entry with no exit for the
+    // life of the install. Reconciling above the guard lets a non-paused
+    // launch close a pause carried over from a previous one.
+    //
+    // `.verifying` is skipped entirely rather than mapped to nil: the
+    // settings-open probe cycles updatePaused → verifying → updatePaused, and
+    // treating the middle leg as a real value would emit an exit and a
+    // re-entry on every visit to the panel. Measured behaviour, not a guess.
+    if case .verifying = state {
+      // Deliberately not `return`: the UI still needs the state below.
+    } else {
+      let projection = EGOnePausedInstallState.projection(of: state)
+      if projection != lastPausedProjection {
+        // Only when a paused state is involved on one side or the other. Two
+        // non-paused states in succession are none of this event's business.
+        if projection != nil || lastPausedProjection != nil {
+          onEvent?(.pausedInstallStateChanged(projection))
+        }
+        lastPausedProjection = projection
+      }
+    }
+
     // Pure UI projection: the install-state stream drives the settings row and
     // health only. Server activation is triggered by EXPLICIT actions — launch
     // (`startIfActiveProvider`), provider switch, settings-open, and a
@@ -192,48 +238,34 @@ public final class EGOneRuntime: EGOneEndpointProviding {
     // stream. Reactively re-activating here would loop: an in-flight
     // activation's own `ensureAvailable()` republishes `.admitted` → `.installed`
     // while the server is still `.stopped` (grounded r2 P1).
+    //
     // #2109: the single UI-state owner. The adapter has TWO publication sites
     // — the launch seed and the observer replay — so neither is the authority;
     // both converge here. This guard makes a republish of the SAME state a
-    // no-op for the UI, and that is ALL it does. It does NOT keep telemetry
-    // honest: the settings-open probe cycles updatePaused → verifying →
-    // updatePaused, so every leg is a genuine change and passes straight
-    // through. Paused telemetry has its own projection guard below, which
-    // skips `.verifying` precisely because this one cannot.
+    // no-op for the UI, and that is ALL it does. Telemetry above deliberately
+    // sits outside it.
     guard installState != state else { return }
     installState = state
-
-    // Paused-residency telemetry, emitted HERE and nowhere else. The adapter
-    // has TWO publication sites — the launch seed (which covers both the
-    // admitted and not-admitted cases) and the observer replay — so neither is
-    // the authority; both converge on this method. Counted, not remembered:
-    // `grep -n "onState(" EGOneDeliveryAdapter.swift` returns exactly two.
-    //
-    // `.verifying` is skipped BEFORE the comparison, not mapped to nil: the
-    // settings-open probe cycles updatePaused → verifying → updatePaused, and
-    // treating the middle leg as a real value would emit an exit and a
-    // re-entry on every visit to the panel. Skipping it leaves the tracked
-    // value untouched, so a cycle that returns to the same paused state is
-    // silent. Measured behaviour, not a guess.
-    if case .verifying = state {
-      recomputeHealth()
-      return
-    }
-    let projection = EGOnePausedInstallState.projection(of: state)
-    if projection != lastPausedProjection {
-      // Only when a paused state is involved on one side or the other. Two
-      // non-paused states in succession are none of this event's business.
-      if projection != nil || lastPausedProjection != nil {
-        onEvent?(.pausedInstallStateChanged(projection))
-      }
-      lastPausedProjection = projection
-    }
     recomputeHealth()
   }
 
   /// Last paused projection reported to telemetry (#2109). Tracked separately
-  /// from `installState` because `.verifying` deliberately does not update it.
-  private var lastPausedProjection: EGOnePausedInstallState?
+  /// from `installState` because `.verifying` deliberately does not update it,
+  /// and PERSISTED because a pause outlives the process: the whole point is a
+  /// duration, and a tracker that resets on launch cannot pair an exit with
+  /// the entry it belongs to.
+  private var lastPausedProjection: EGOnePausedInstallState? {
+    didSet {
+      if let raw = lastPausedProjection?.rawValue {
+        defaults.set(raw, forKey: Self.pausedProjectionKey)
+      } else {
+        defaults.removeObject(forKey: Self.pausedProjectionKey)
+      }
+    }
+  }
+
+  private static let pausedProjectionKey = "eg1.pausedInstallProjection"
+  private let defaults: UserDefaults
 
   private var serverState: EGOneServerManager.ServerState = .stopped
   private func applyServerState(_ state: EGOneServerManager.ServerState) {

--- a/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
@@ -16,12 +16,61 @@ public protocol EGOneEndpointProviding: AnyObject {
 ///
 /// #1348 Phase 3: EG-1's DOWNLOAD lifecycle telemetry now flows through the
 /// shared delivery engine (`model_delivery.*` with `family=eg1`), so the old
-/// `downloadStarted/Completed/Failed` cases are gone. Only server HEALTH
-/// remains here — it is a runtime probe result with no delivery equivalent.
-/// Transition-only (debounced by construction — fired from a state didSet,
-/// identical states never re-fire).
+/// `downloadStarted/Completed/Failed` cases are gone. What remains here is
+/// server HEALTH — a runtime probe result with no delivery equivalent — and,
+/// since #2109, PAUSED RESIDENCY, which likewise has no delivery equivalent:
+/// the delivery funnel reports moments (a cancel happened), never how long a
+/// user then sat unable to polish.
+/// Transition-only, by two different mechanisms: health is guarded in its
+/// `didSet`, paused residency by its projection tracker in
+/// `applyInstallState`. Naming both matters — a reader who assumes the didSet
+/// guard covers everything would conclude paused telemetry is debounced by
+/// construction, when it is debounced by a tracker that deliberately skips
+/// `.verifying`.
 public enum EGOneRuntimeEvent: Sendable, Equatable {
   case healthChanged(from: String, to: String, reason: String?)
+  /// The user ENTERED or LEFT a paused install state (#2109). `nil` means
+  /// they left one.
+  ///
+  /// Deliberately narrower than "the install state changed", and the narrowing
+  /// is the whole design. A general state-changed event double-counts: the
+  /// settings-open activation path runs `adoptIfPresent`, which CYCLES the
+  /// state (`updatePaused → verifying → updatePaused`), so every visit to the
+  /// AI settings panel would have emitted twice. The metric would have read as
+  /// a growing population of affected users while actually counting panel
+  /// visits — plausible, actionable, and wrong. Measured, not theorised: the
+  /// observed sequence across three probes was update_paused, verifying,
+  /// update_paused, verifying, update_paused, verifying, update_paused.
+  ///
+  /// `.verifying` is therefore IGNORED rather than mapped: it is an adoption
+  /// probe artefact, not a state a user rests in. Every other non-paused state
+  /// maps to `nil`, so entry and exit are both observable and nothing in
+  /// between generates traffic.
+  ///
+  /// Named for the STATE, never a cause. An event called `upgrade_stalled` or
+  /// `polish_silently_off` would be a causal claim about a state with more
+  /// than one producer, and would count a deliberate decline as a malfunction
+  /// — the #2066 defect, avoided at design time.
+  case pausedInstallStateChanged(EGOnePausedInstallState?)
+}
+
+/// The closed vocabulary for paused-residency telemetry (#2109). A raw String
+/// so the analytics value is declared HERE and cannot drift when a Swift case
+/// is renamed — a silently changed value splits every historical query in two.
+public enum EGOnePausedInstallState: String, Sendable, Equatable {
+  case paused
+  case updatePaused = "update_paused"
+  case updatePausedResumable = "update_paused_resumable"
+
+  /// The paused projection of an install state, or nil when the user is not in
+  /// one. `.verifying` has no projection at all — see the event's own doc.
+  static func projection(of state: EGOneInstallState) -> EGOnePausedInstallState? {
+    switch state {
+    case .paused: return .paused
+    case .updatePaused(let resumable): return resumable ? .updatePausedResumable : .updatePaused
+    case .notInstalled, .downloading, .verifying, .installed, .failed: return nil
+    }
+  }
 }
 
 /// Single owner of the EG-1 inference server and its delivery adapter (#1271,
@@ -140,16 +189,48 @@ public final class EGOneRuntime: EGOneEndpointProviding {
     // stream. Reactively re-activating here would loop: an in-flight
     // activation's own `ensureAvailable()` republishes `.admitted` → `.installed`
     // while the server is still `.stopped` (grounded r2 P1).
-    // #2109: the single transition owner. The adapter has TWO publication
-    // paths — the seed and the observer — so neither of them is the
-    // authority; both converge here. Comparing before storing makes a
-    // republish of the SAME state a no-op, which is what lets the telemetry
-    // emit added in a later chunk fire once per real transition rather than
-    // once per settings-window open.
+    // #2109: the single UI-state owner. The adapter has TWO publication sites
+    // — the launch seed and the observer replay — so neither is the authority;
+    // both converge here. This guard makes a republish of the SAME state a
+    // no-op for the UI, and that is ALL it does. It does NOT keep telemetry
+    // honest: the settings-open probe cycles updatePaused → verifying →
+    // updatePaused, so every leg is a genuine change and passes straight
+    // through. Paused telemetry has its own projection guard below, which
+    // skips `.verifying` precisely because this one cannot.
     guard installState != state else { return }
     installState = state
+
+    // Paused-residency telemetry, emitted HERE and nowhere else. The adapter
+    // has TWO publication sites — the launch seed (which covers both the
+    // admitted and not-admitted cases) and the observer replay — so neither is
+    // the authority; both converge on this method. Counted, not remembered:
+    // `grep -n "onState(" EGOneDeliveryAdapter.swift` returns exactly two.
+    //
+    // `.verifying` is skipped BEFORE the comparison, not mapped to nil: the
+    // settings-open probe cycles updatePaused → verifying → updatePaused, and
+    // treating the middle leg as a real value would emit an exit and a
+    // re-entry on every visit to the panel. Skipping it leaves the tracked
+    // value untouched, so a cycle that returns to the same paused state is
+    // silent. Measured behaviour, not a guess.
+    if case .verifying = state {
+      recomputeHealth()
+      return
+    }
+    let projection = EGOnePausedInstallState.projection(of: state)
+    if projection != lastPausedProjection {
+      // Only when a paused state is involved on one side or the other. Two
+      // non-paused states in succession are none of this event's business.
+      if projection != nil || lastPausedProjection != nil {
+        onEvent?(.pausedInstallStateChanged(projection))
+      }
+      lastPausedProjection = projection
+    }
     recomputeHealth()
   }
+
+  /// Last paused projection reported to telemetry (#2109). Tracked separately
+  /// from `installState` because `.verifying` deliberately does not update it.
+  private var lastPausedProjection: EGOnePausedInstallState?
 
   private var serverState: EGOneServerManager.ServerState = .stopped
   private func applyServerState(_ state: EGOneServerManager.ServerState) {

--- a/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
+++ b/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
@@ -808,6 +808,15 @@ public actor ModelDeliveryController {
   /// three of four shipped manifests carry that flag's value copied from a
   /// sibling, so for most artefacts it encodes nobody's decision.
   ///
+  /// SAME VARIANT is part of the match, not a detail. WhisperKit transcription
+  /// and Live Preview deliberately SHARE this one metadata directory while
+  /// keeping separate install directories, on the stated grounds that
+  /// `cacheKey` includes the variant so their staging and markers cannot
+  /// collide. If this match ever loosened to family+name it would delete
+  /// across two models designed to coexist here, and the symptom would be a
+  /// preview download losing its staging for no visible reason (framing from
+  /// the session building #2123, who owns that pair).
+  ///
   /// LIVENESS IS BUILT FORWARD. Identity → URL is total; URL → identity is
   /// not, because `cacheKey` flattens name and revision. So the protected set
   /// is derived from entries that actually have work in flight, mapped to

--- a/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
+++ b/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
@@ -832,6 +832,35 @@ public actor ModelDeliveryController {
   /// gap.
   public func sweepSupersededStaging(_ registration: DeliveryRegistration) {
     let identity = registration.manifest.identity
+
+    // THE KILL SWITCH REFUSES THE WHOLE SWEEP, before any read or unlink.
+    //
+    // Every other byte-mutating path into this controller is gated by the
+    // ADAPTER, which returns early while delivery is disabled
+    // (`EGOneDeliveryAdapter` line ~93: "delivery is disabled (§16.6): no
+    // mutation"). That is why the flag snapshot in `startAttempt` does not
+    // check `familyEnabled` and its comment can say the snapshot "only runs
+    // when delivery is on" — nothing reaches it otherwise.
+    //
+    // This method is a PUBLIC door the adapter does not stand in front of:
+    // four bootstrap sites call it directly. Without this guard, launching
+    // during an incident freeze deletes superseded staging — resumable
+    // multi-GB partials — at the exact moment nothing is permitted to
+    // re-fetch them. `WhisperKitLegacyUpgradeCoordinator` step 0 gates its
+    // own deletion run for this reason and names the harm: deleting while
+    // disabled strands a user with neither the old copy nor a fetchable
+    // replacement.
+    //
+    // Gated HERE rather than at the four call sites, so a fifth caller
+    // cannot reintroduce it by omission.
+    //
+    // This does not weaken #2109's cleanup guarantee: the key defaults to
+    // TRUE, so every ordinary user still sweeps. Only an operator who has
+    // deliberately frozen delivery defers cleanup, and it resumes on the
+    // next launch after the switch returns.
+    guard DeliveryFlags.snapshot(family: identity.family, defaults: defaults).familyEnabled
+    else { return }
+
     let candidates = PriorRevisionAdmission.supersededStagingURLs(
       for: identity, metadataDirectory: registration.metadataDirectory)
     guard !candidates.isEmpty else { return }
@@ -849,7 +878,8 @@ public actor ModelDeliveryController {
     }
 
     var protectedKeys: Set<String> = []
-    for (liveIdentity, entry) in entries where entry.activeTask != nil || entry.drainingTask != nil {
+    for (liveIdentity, entry) in entries where entry.activeTask != nil || entry.drainingTask != nil
+    {
       guard let liveRegistration = registrationsByIdentity[liveIdentity] else { continue }
       protectedKeys.insert(key(Self.stagingDirectoryURL(for: liveRegistration)))
     }

--- a/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
+++ b/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
@@ -330,7 +330,27 @@ public actor ModelDeliveryController {
   /// requires an actual REGULAR FILE with positive size — a directory or an
   /// empty file proves nothing was downloaded.
   public func hasStagedPartials(_ registration: DeliveryRegistration) -> Bool {
-    let staging = stagingDirectory(for: registration)
+    Self.hasStagedPartialsOnDisk(registration)
+  }
+
+  /// The same disk truth, callable WITHOUT the actor (#2109).
+  ///
+  /// EG-1's install-state mapper is a synchronous `nonisolated static func`
+  /// running inside a state-observer callback, so it cannot `await` an actor
+  /// method — and making it await would put a suspension inside the window the
+  /// install-state sequencer exists to protect. The read was always pure; only
+  /// the incidental registration-cache write in the old `stagingDirectory`
+  /// made it isolated, and that write now lives in `startAttempt`.
+  ///
+  /// A `.resume.json` sidecar proves nothing was downloaded, and neither does
+  /// a directory or an empty file: this requires a REGULAR FILE of positive
+  /// size (PR #1637, two cloud-review rounds — a nested model layout walked
+  /// via `subpathsOfDirectory` yields directory names that pass a suffix
+  /// filter while holding zero real bytes).
+  nonisolated package static func hasStagedPartialsOnDisk(_ registration: DeliveryRegistration)
+    -> Bool
+  {
+    let staging = stagingDirectoryURL(for: registration)
     guard
       let enumerator = FileManager.default.enumerator(
         at: staging, includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey])
@@ -384,6 +404,15 @@ public actor ModelDeliveryController {
     fetchIfMissing: Bool = true
   ) async -> DeliveryOutcome {
     let identity = registration.manifest.identity
+    // Cache the registration HERE, before the attempt task exists and before
+    // any suspension (#2109). It used to be written as a side effect of
+    // `stagingDirectory(for:)`, which is only reached AFTER the suspending
+    // existing-cache validation — so a cancel arriving in that window found no
+    // registration and `hasStagedPartials(identity:)` returned false, reporting
+    // a resumable download as non-resumable on all three cancel/terminal paths.
+    // Every door lands here: `ensureModelAvailable` and `repair` route through
+    // `joinOrStartFetch`, and `admitIfComplete` calls `startAttempt` directly.
+    registrationsByIdentity[identity] = registration
     var entry = entries[identity, default: Entry()]
     entry.generation += 1
     entry.cancelLatched = false
@@ -451,6 +480,15 @@ public actor ModelDeliveryController {
 
     // Existing-cache validation (D2 §4): one full hash pass, component grain.
     setState(identity, .preparing(validatingExistingCache: true), ifGeneration: generation)
+    // Test-only barrier (#2109). Production is nil and this is a no-op.
+    //
+    // It exists because the ordering guarantee below it cannot be tested any
+    // other way: in production this hash pass runs for SECONDS over gigabytes,
+    // and a cancel landing inside it is the real defect. With unit fixtures the
+    // same window is microseconds wide, so a polled test cannot land in it —
+    // mutation-proved, a timing-based attempt passed against the pre-fix code
+    // and would have shipped as coverage that detects nothing.
+    await beforeExistingCacheValidationForTesting?()
     // Per-file liveness ticks: each validated file republishes the state so
     // the app-layer bridge advances the progress channel's mtime — the
     // sessionless wedge guard reads silence as a wedge, and a multi-second
@@ -732,6 +770,24 @@ public actor ModelDeliveryController {
 
   // MARK: - Paths + disk
 
+  /// Test-only barrier awaited after `.preparing` publishes and BEFORE the
+  /// existing-cache validation suspends (#2109). Never set in production.
+  ///
+  /// Deliberately `internal`, not `package` or `public`: the test target uses
+  /// `@testable import`, so internal is reachable, and widening it would put a
+  /// test hook on the delivery API that other modules could call. Matches the
+  /// module's existing seam precedent (`ChunkAppendDelegate.protocolClassesForTesting`),
+  /// which is likewise internal and not `#if DEBUG` — keeping it out of a DEBUG
+  /// guard means the covering test compiles and runs in the Release lane too,
+  /// rather than silently vanishing from it.
+  var beforeExistingCacheValidationForTesting: (@Sendable () async -> Void)?
+
+  /// Cross-actor setter for the barrier above; an actor's stored property
+  /// cannot be assigned from outside its isolation.
+  func setBeforeExistingCacheValidationForTesting(_ hook: (@Sendable () async -> Void)?) {
+    beforeExistingCacheValidationForTesting = hook
+  }
+
   private func admission(for registration: DeliveryRegistration) -> CacheAdmission {
     CacheAdmission(
       manifest: registration.manifest, installDirectory: registration.installDirectory,
@@ -740,11 +796,27 @@ public actor ModelDeliveryController {
 
   private var registrationsByIdentity: [ModelIdentity: DeliveryRegistration] = [:]
 
-  private func stagingDirectory(for registration: DeliveryRegistration) -> URL {
-    registrationsByIdentity[registration.manifest.identity] = registration
-    return registration.metadataDirectory
+  /// The staging path authority. `nonisolated` and `static` deliberately: it
+  /// is a pure function of the registration and touches no actor state, which
+  /// is what lets a SYNCHRONOUS caller off the actor derive the same path
+  /// (#2109 — the EG-1 install-state mapper cannot await).
+  ///
+  /// Identity → URL is total. The reverse is NOT: `cacheKey` flattens name and
+  /// revision without an injective boundary, so a URL cannot be parsed back
+  /// into a `ModelIdentity`. Anything needing to know which identity owns a
+  /// directory must map forward from a known identity and compare, never parse.
+  nonisolated package static func stagingDirectoryURL(for registration: DeliveryRegistration) -> URL
+  {
+    registration.metadataDirectory
       .appendingPathComponent("staging", isDirectory: true)
       .appendingPathComponent(registration.manifest.identity.cacheKey, isDirectory: true)
+  }
+
+  private func stagingDirectory(for registration: DeliveryRegistration) -> URL {
+    // No longer caches the registration: that write moved to `startAttempt`,
+    // where it cannot be outrun by a cancel. Deriving a path is not a lifetime
+    // concern and should never have owned one.
+    Self.stagingDirectoryURL(for: registration)
   }
 
   private func hasStagedPartials(identity: ModelIdentity) -> Bool {

--- a/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
+++ b/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
@@ -294,6 +294,22 @@ public actor ModelDeliveryController {
     // The generation bump above orphaned the attempt's own clearTask, so
     // release the ledger here — a cancelled download must not keep blocking
     // other identities' disk preflight (code-diff r5 P2).
+    //
+    // Clear `drainingTask` for the same reason, and it matters more since
+    // #2119 (found by review of that chunk). It used to be cleared ONLY by the
+    // next `startAttempt`, so an identity cancelled and never resumed kept a
+    // non-nil `drainingTask` for the process lifetime. The staging sweep reads
+    // that field as "work in flight", so it would have protected exactly the
+    // abandoned downloads it exists to reclaim — a no-op for the feature's
+    // primary population.
+    //
+    // Safe here and not earlier: the `await task.value` above IS the drain
+    // barrier, so by this line there is nothing left for a later
+    // `startAttempt` to wait on. Generation-guarded so a NEW attempt that
+    // started during the await keeps its own draining task.
+    if entries[identity]?.generation == entry.generation {
+      entries[identity]?.drainingTask = nil
+    }
     entries[identity]?.reservedBytes = 0
     if case .admitted = outcome {
       // Completion won the race (its terminal slice ran before our bump was
@@ -637,6 +653,10 @@ public actor ModelDeliveryController {
           repairedComponentsCount: repairedCount))
       setState(identity, .admitted)
       try? FileManager.default.removeItem(at: staging)
+      // Post-admission reclamation (#2119). The bootstrap call catches staging
+      // abandoned before this launch; this one catches anything superseded by
+      // the admission that just happened.
+      sweepSupersededStaging(registration)
       await AppLogger.shared.log(
         "Model delivery admitted \(identity.cacheKey)", level: .info, category: "Delivery")
       return .admitted
@@ -769,6 +789,78 @@ public actor ModelDeliveryController {
   }
 
   // MARK: - Paths + disk
+
+  /// Reclaim staging directories for superseded revisions of this
+  /// registration's model (#2109, #2119).
+  ///
+  /// A partially-downloaded revision that is later superseded is otherwise
+  /// never deleted: staging is keyed by `cacheKey`, a successful admission
+  /// removes only its OWN directory, and nothing enumerates the rest. Up to a
+  /// full model's worth of bytes per abandoned revision, permanently.
+  ///
+  /// NOT gated on `admission.evictPreviousRevisions`, deliberately, and the
+  /// divergence from the superseded-MARKER cleanup is the point. That flag
+  /// protects a legitimate choice: keeping a previous revision installed and
+  /// usable. Staging is not an install — it is resume CACHE, and the marker is
+  /// what makes an install real. The worst case of deleting it is refetched
+  /// bytes if a later build re-pins that revision, never a broken or unusable
+  /// model. Gating it would inherit the defect #2109's own comments name:
+  /// three of four shipped manifests carry that flag's value copied from a
+  /// sibling, so for most artefacts it encodes nobody's decision.
+  ///
+  /// LIVENESS IS BUILT FORWARD. Identity → URL is total; URL → identity is
+  /// not, because `cacheKey` flattens name and revision. So the protected set
+  /// is derived from entries that actually have work in flight, mapped to
+  /// their URLs through the pure path helper, and candidates are compared
+  /// against it. Nothing parses a directory name back into an identity.
+  ///
+  /// A retained entry is NOT liveness: entries survive `clearTask`, so keying
+  /// on their presence would protect long-dead revisions forever and quietly
+  /// defeat the sweep. Only a non-nil `activeTask` or `drainingTask` counts.
+  ///
+  /// Best-effort per entry, and the whole method is suspension-free between
+  /// building the protected set and deleting, so no attempt can start in the
+  /// gap.
+  public func sweepSupersededStaging(_ registration: DeliveryRegistration) {
+    let identity = registration.manifest.identity
+    let candidates = PriorRevisionAdmission.supersededStagingURLs(
+      for: identity, metadataDirectory: registration.metadataDirectory)
+    guard !candidates.isEmpty else { return }
+
+    // Compare RESOLVED PATHS, never URL objects. A URL from
+    // `contentsOfDirectory` and one built with `appendingPathComponent` can
+    // denote the same directory and still differ as values: macOS temp roots
+    // resolve `/var/...` to `/private/var/...`, and directory URLs may or may
+    // not carry a trailing slash. Set membership on the raw URLs therefore
+    // silently never matched, and the protection failed OPEN — the sweep
+    // deleted staging for a download that was actively running. Caught by
+    // `sweepNeverDeletesStagingForAnAttemptInFlight`.
+    func key(_ url: URL) -> String {
+      url.resolvingSymlinksInPath().standardizedFileURL.path
+    }
+
+    var protectedKeys: Set<String> = []
+    for (liveIdentity, entry) in entries where entry.activeTask != nil || entry.drainingTask != nil {
+      guard let liveRegistration = registrationsByIdentity[liveIdentity] else { continue }
+      protectedKeys.insert(key(Self.stagingDirectoryURL(for: liveRegistration)))
+    }
+
+    let fm = FileManager.default
+    for candidate in candidates where !protectedKeys.contains(key(candidate)) {
+      try? fm.removeItem(at: candidate)
+    }
+  }
+
+  /// Whether the identity is in the LIVE DRAINING window (#2119 test support).
+  ///
+  /// Both halves are required. "No active task" alone is also true AFTER the
+  /// drain finishes, so a test parking on it could sweep once draining had
+  /// already completed and miss the very window it claims to cover — the
+  /// draining branch would go unexercised while the test read green.
+  func isDrainingForTesting(_ identity: ModelIdentity) -> Bool {
+    guard let entry = entries[identity] else { return false }
+    return entry.activeTask == nil && entry.drainingTask != nil
+  }
 
   /// Test-only barrier awaited after `.preparing` publishes and BEFORE the
   /// existing-cache validation suspends (#2109). Never set in production.

--- a/Sources/EnviousWisprModelDelivery/PriorRevisionAdmission.swift
+++ b/Sources/EnviousWisprModelDelivery/PriorRevisionAdmission.swift
@@ -40,6 +40,53 @@ public enum PriorRevisionAdmission {
     }
   }
 
+  /// Staging directories in `metadataDirectory/staging` belonging to the same
+  /// `family`, `name` AND `variant` as `identity`, at a DIFFERENT revision
+  /// (#2109, #2119).
+  ///
+  /// Same prefix/suffix stripping as `markerURLs`, and for the same reason:
+  /// `cacheKey` flattens name and revision with no injective boundary, so the
+  /// revision cannot be recovered by splitting on `-`. Its soundness rests on
+  /// no model name within a family being a prefix of another, which
+  /// `ShippedModelNames` freezes over every name ever shipped.
+  ///
+  /// VARIANT IS PART OF THE MATCH, not an afterthought. WhisperKit ships
+  /// stable and Preview with the same family, name and revision, separated
+  /// only by variant; if two registrations ever differed only by REVISION,
+  /// one would be read as a superseded copy of the other and a live download
+  /// would be deleted. `ShippedModelNamesTests` freezes that too.
+  ///
+  /// Empty when the directory cannot be read — the caller then deletes
+  /// nothing, which is the only safe answer to "I could not look".
+  static func supersededStagingURLs(for identity: ModelIdentity, metadataDirectory: URL) -> [URL] {
+    let staging = metadataDirectory.appendingPathComponent("staging", isDirectory: true)
+    let prefix = "\(identity.family.rawValue)-\(identity.name)-"
+    let suffix = identity.variant.isEmpty ? "" : "-\(identity.variant)"
+    let current = identity.cacheKey
+
+    guard
+      let entries = try? FileManager.default.contentsOfDirectory(
+        at: staging, includingPropertiesForKeys: [.isDirectoryKey])
+    else { return [] }
+
+    return entries.filter { url in
+      let name = url.lastPathComponent
+      guard name != current, name.hasPrefix(prefix), name.hasSuffix(suffix) else { return false }
+      // Require a non-empty revision segment between prefix and suffix, so a
+      // degenerate identity whose two ends overlap cannot admit an entry that
+      // is neither. Mirrors the same guard in `markerURLs`.
+      guard name.count > prefix.count + suffix.count else { return false }
+      // DIRECTORIES ONLY. Staging is always a directory; a regular file whose
+      // name happens to match would otherwise be deleted as if it were one.
+      // The caller removes whatever this returns, so a name match alone is not
+      // enough to authorise deletion.
+      guard let values = try? url.resourceValues(forKeys: [.isDirectoryKey]),
+        values.isDirectory == true
+      else { return false }
+      return true
+    }
+  }
+
   /// True when a prior revision was admitted AND at least one file it recorded is STILL on disk.
   ///
   /// The marker alone proves an install once completed, never that its bytes survive: a user who

--- a/Sources/EnviousWisprModelDelivery/ShippedModelNames.swift
+++ b/Sources/EnviousWisprModelDelivery/ShippedModelNames.swift
@@ -46,4 +46,29 @@ enum ShippedModelNames {
   static var families: Set<ModelFamily> {
     Set(current.keys).union(retired.keys)
   }
+
+  /// Every VARIANT ever shipped, keyed by family and name (#2109, whole-diff
+  /// review).
+  ///
+  /// The staging match ends with `hasSuffix("-\(variant)")`, which is
+  /// ambiguous in exactly the same way the name prefix is: sweeping variant
+  /// `foo` also matches a directory for variant `bar-foo`, and the
+  /// family+name+variant uniqueness freeze permits that pair because the
+  /// variants ARE different. So an unrelated model's resumable bytes could be
+  /// deleted. An EMPTY variant is worse still — the suffix becomes the empty
+  /// string and matches everything in the family.
+  ///
+  /// Frozen for the same reason as the names: make the collision impossible to
+  /// author rather than detectable after the deletion.
+  static let variants: [String: Set<String>] = [
+    "eg_one|eg-1": ["q5km"],
+    "parakeet|parakeet-tdt-0.6b-v3-coreml": ["int8"],
+    "whisper_kit|whisperkit-coreml": [
+      "openai_whisper-large-v3-v20240930_turbo", "openai_whisper-small_216MB",
+    ],
+  ]
+
+  static func variantKey(family: ModelFamily, name: String) -> String {
+    "\(family.rawValue)|\(name)"
+  }
 }

--- a/Sources/EnviousWisprModelDelivery/ShippedModelNames.swift
+++ b/Sources/EnviousWisprModelDelivery/ShippedModelNames.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Every model NAME this app has ever shipped, per family, including retired
+/// ones (#2109, #2120).
+///
+/// WHY THIS EXISTS. Superseded artefacts are identified by stripping a known
+/// prefix and suffix from a `cacheKey`, because `cacheKey` flattens name and
+/// revision with no injective boundary: `name=foo, revision=bar-baz` and
+/// `name=foo-bar, revision=baz` produce the same string. That technique is
+/// sound only while no model name within a family is a PREFIX of another —
+/// otherwise one model's artefacts can be read as a superseded revision of a
+/// different model, and the consequence is deleting the wrong bytes.
+///
+/// WHY EVER-SHIPPED AND NOT THE CURRENT BUNDLE. Staging directories and
+/// admission markers OUTLIVE app versions. A guard checking only today's
+/// manifests proves nothing about a directory written by a build from last
+/// year: ship `eg-1-mini`, retire it, and a later build carrying only `eg-1`
+/// passes a current-bundle check while its parser can still misread the
+/// leftover `eg-1-mini-*` entries. This list is therefore APPEND-ONLY —
+/// entries are tombstoned, never removed, because removing one silently
+/// reopens exactly the case it was added to close.
+///
+/// This is data with no runtime reader by design. Its only consumer is a
+/// freeze test. Making it a lookup consulted at runtime would turn it into a
+/// second source of truth that could drift from the manifests themselves.
+enum ShippedModelNames {
+  /// Currently shipped. Must stay in step with the bundled manifests; a test
+  /// asserts every bundled identity appears here.
+  static let current: [ModelFamily: Set<String>] = [
+    .egOne: ["eg-1"],
+    .parakeet: ["parakeet-tdt-0.6b-v3-coreml"],
+    .whisperKit: ["whisperkit-coreml"],
+  ]
+
+  /// Names shipped by an earlier build and no longer bundled. Empty today —
+  /// no model name has ever been retired. It is declared anyway so that
+  /// retiring one has an obvious home, rather than the name simply vanishing
+  /// from `current` and taking its guard with it.
+  static let retired: [ModelFamily: Set<String>] = [:]
+
+  /// The union, which is what the prefix-safety guard must reason over.
+  static func everShipped(in family: ModelFamily) -> Set<String> {
+    (current[family] ?? []).union(retired[family] ?? [])
+  }
+
+  static var families: Set<ModelFamily> {
+    Set(current.keys).union(retired.keys)
+  }
+}

--- a/Tests/EnviousWisprTests/App/EGOneInstallStateTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/App/EGOneInstallStateTelemetryTests.swift
@@ -30,10 +30,10 @@ import Testing
   @Test func onlyPausedStatesProject() {
     #expect(EGOnePausedInstallState.projection(of: .paused) == .paused)
     #expect(
-      EGOnePausedInstallState.projection(of: .updatePaused(resumable: true))
+      EGOnePausedInstallState.projection(of: .updatePaused(resumable: true, targetVersion: "1.1"))
         == .updatePausedResumable)
     #expect(
-      EGOnePausedInstallState.projection(of: .updatePaused(resumable: false)) == .updatePaused)
+      EGOnePausedInstallState.projection(of: .updatePaused(resumable: false, targetVersion: "1.1")) == .updatePaused)
     for state: EGOneInstallState in [
       .notInstalled, .downloading(fractionCompleted: 0.5), .verifying,
       .installed(version: "1.1"), .failed(.network),
@@ -48,8 +48,8 @@ import Testing
   /// not landing. One name would hide which.
   @Test func theTwoUpdateSituationsAreDistinguishable() {
     #expect(
-      EGOnePausedInstallState.projection(of: .updatePaused(resumable: true))
-        != EGOnePausedInstallState.projection(of: .updatePaused(resumable: false)))
+      EGOnePausedInstallState.projection(of: .updatePaused(resumable: true, targetVersion: "1.1"))
+        != EGOnePausedInstallState.projection(of: .updatePaused(resumable: false, targetVersion: "1.1")))
   }
 
   /// The version never reaches telemetry: the projection carries no payload,
@@ -124,7 +124,7 @@ import Testing
 
     let settled = await withDeadline(seconds: 5) {
       while true {
-        if await MainActor.run(body: { runtime.installState == .updatePaused(resumable: false) }) {
+        if await MainActor.run(body: { runtime.installState == .updatePaused(resumable: false, targetVersion: "1.1") }) {
           return true
         }
         await Task.yield()
@@ -140,7 +140,7 @@ import Testing
       await Task.yield()
     }
     let stillPaused = await MainActor.run {
-      runtime.installState == .updatePaused(resumable: false)
+      runtime.installState == .updatePaused(resumable: false, targetVersion: "1.1")
     }
     try #require(stillPaused == true, "the probe changed the resting state, so this proves nothing")
 

--- a/Tests/EnviousWisprTests/App/EGOneInstallStateTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/App/EGOneInstallStateTelemetryTests.swift
@@ -35,7 +35,7 @@ import Testing
     #expect(
       EGOnePausedInstallState.projection(of: .updatePaused(resumable: false, targetVersion: "1.1")) == .updatePaused)
     for state: EGOneInstallState in [
-      .notInstalled, .downloading(fractionCompleted: 0.5, upgradeTo: nil), .verifying,
+      .notInstalled, .downloading(fractionCompleted: 0.5, upgrade: nil), .verifying,
       .installed(version: "1.1"), .failed(.network),
     ] {
       #expect(EGOnePausedInstallState.projection(of: state) == nil, "\(state) must not project")
@@ -250,5 +250,60 @@ import Testing
     #expect(
       recorded.all == ["none"],
       "a pause resolved while the app was closed never emitted its exit: \(recorded.all)")
+  }
+
+
+  /// A retry after a failed upgrade is STILL an upgrade.
+  ///
+  /// Cloud-review P2 on 5fdd0d53. `.failed` accepts `startDownload()`, so Try
+  /// Again re-enters `.downloading`. Clearing the upgrade marker on `.failed`
+  /// made that retry render as a FIRST INSTALL — dropping the label exactly
+  /// when a user is already having a bad time, and a network blip mid-upgrade
+  /// is the ordinary case, not an exotic one.
+  ///
+  /// Drives a real `EGOneRuntime` through the whole sequence rather than
+  /// asserting on the enum, because the bug lives in the runtime's transition
+  /// bookkeeping and an enum-level test cannot see it.
+  @MainActor
+  @Test func aRetryAfterAFailedUpgradeStillReadsAsAnUpgrade() throws {
+    let suite = "eg1-upgrade-retry-\(UUID().uuidString)"
+    let store = try #require(UserDefaults(suiteName: suite))
+    defer { store.removePersistentDomain(forName: suite) }
+
+    let runtime = EGOneRuntime(
+      manifest: nil, serverBinaryURL: nil, delivery: nil, defaults: store)
+
+    runtime.applyInstallStateForTesting(.updatePaused(resumable: false, targetVersion: "1.1"))
+    runtime.applyInstallStateForTesting(.downloading(fractionCompleted: 0.2, upgrade: nil))
+    #expect(
+      runtime.installState == .downloading(fractionCompleted: 0.2, upgrade: .named("1.1")),
+      "the upgrade label never reached the first download tick")
+
+    // The network drops.
+    runtime.applyInstallStateForTesting(.failed(.network))
+
+    // Try Again. The adapter maps statelessly and passes nil, exactly as in
+    // production; the runtime must still know this is an upgrade.
+    runtime.applyInstallStateForTesting(.downloading(fractionCompleted: 0.05, upgrade: nil))
+    #expect(
+      runtime.installState == .downloading(fractionCompleted: 0.05, upgrade: .named("1.1")),
+      "a retry after a failed upgrade rendered as a first install")
+
+    // CONTROL, the other direction: a genuine first install must NEVER acquire
+    // an upgrade label, or the fix trades one wrong sentence for another.
+    let fresh = EGOneRuntime(
+      manifest: nil, serverBinaryURL: nil, delivery: nil, defaults: store)
+    fresh.applyInstallStateForTesting(.notInstalled)
+    fresh.applyInstallStateForTesting(.downloading(fractionCompleted: 0.3, upgrade: nil))
+    #expect(
+      fresh.installState == .downloading(fractionCompleted: 0.3, upgrade: nil),
+      "a first install was labelled an upgrade")
+
+    // And completing the upgrade clears it, so the NEXT first install is clean.
+    runtime.applyInstallStateForTesting(.installed(version: "1.1"))
+    runtime.applyInstallStateForTesting(.downloading(fractionCompleted: 0.1, upgrade: nil))
+    #expect(
+      runtime.installState == .downloading(fractionCompleted: 0.1, upgrade: nil),
+      "the upgrade label outlived the upgrade that set it")
   }
 }

--- a/Tests/EnviousWisprTests/App/EGOneInstallStateTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/App/EGOneInstallStateTelemetryTests.swift
@@ -306,4 +306,37 @@ import Testing
       runtime.installState == .downloading(fractionCompleted: 0.1, upgrade: nil),
       "the upgrade label outlived the upgrade that set it")
   }
+
+  /// The SAME journey with a manifest that carries no display version.
+  ///
+  /// Added because writing the mutation control for the other P2 exposed that
+  /// nothing covered this path THROUGH THE RUNTIME. The unnamed case was
+  /// asserted on `EGOneRowPresentation` directly, but the defect being fixed
+  /// lived in the runtime's storage — where a `String?` marker turned "upgrade,
+  /// version unknown" into "not an upgrade". A presentation-only test passes
+  /// against that bug.
+  @MainActor
+  @Test func anUpgradeWithNoDisplayVersionSurvivesTheRuntimeJourney() throws {
+    let suite = "eg1-unnamed-\(UUID().uuidString)"
+    let store = try #require(UserDefaults(suiteName: suite))
+    defer { store.removePersistentDomain(forName: suite) }
+
+    let runtime = EGOneRuntime(
+      manifest: nil, serverBinaryURL: nil, delivery: nil, defaults: store)
+
+    // A manifest with no `displayVersion` — optional by contract, so this is a
+    // config we can ship, not a hostile value.
+    runtime.applyInstallStateForTesting(.updatePaused(resumable: false, targetVersion: nil))
+    runtime.applyInstallStateForTesting(.downloading(fractionCompleted: 0.2, upgrade: nil))
+    #expect(
+      runtime.installState == .downloading(fractionCompleted: 0.2, upgrade: .unnamed),
+      "an upgrade with no version was recorded as a first install")
+
+    // And it survives a failure + retry too, same as the named case.
+    runtime.applyInstallStateForTesting(.failed(.network))
+    runtime.applyInstallStateForTesting(.downloading(fractionCompleted: 0.05, upgrade: nil))
+    #expect(
+      runtime.installState == .downloading(fractionCompleted: 0.05, upgrade: .unnamed),
+      "an unnamed upgrade lost its identity across a retry")
+  }
 }

--- a/Tests/EnviousWisprTests/App/EGOneInstallStateTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/App/EGOneInstallStateTelemetryTests.swift
@@ -35,7 +35,7 @@ import Testing
     #expect(
       EGOnePausedInstallState.projection(of: .updatePaused(resumable: false, targetVersion: "1.1")) == .updatePaused)
     for state: EGOneInstallState in [
-      .notInstalled, .downloading(fractionCompleted: 0.5), .verifying,
+      .notInstalled, .downloading(fractionCompleted: 0.5, upgradeTo: nil), .verifying,
       .installed(version: "1.1"), .failed(.network),
     ] {
       #expect(EGOnePausedInstallState.projection(of: state) == nil, "\(state) must not project")

--- a/Tests/EnviousWisprTests/App/EGOneInstallStateTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/App/EGOneInstallStateTelemetryTests.swift
@@ -1,0 +1,188 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprLLM
+@testable import EnviousWisprModelDelivery
+
+/// The analytics vocabulary for `eg1.paused_install_state_changed` (#2109).
+///
+/// The event exists because `updatePaused` is a state a user can sit in for
+/// days with polish silently off, and nothing else proves residency. Its value
+/// therefore depends entirely on the vocabulary being stable and on the two
+/// update situations being distinguishable.
+@Suite struct EGOneInstallStateTelemetryTests {
+
+  /// The analytics values are declared on the enum as raw strings, not derived
+  /// from Swift case names, precisely so a rename cannot silently change them.
+  /// A shifted value splits every historical comparison in two, and the break
+  /// is invisible until someone wonders why a number halved.
+  @Test func pausedStateNamesArePinned() {
+    #expect(EGOnePausedInstallState.paused.rawValue == "paused")
+    #expect(EGOnePausedInstallState.updatePaused.rawValue == "update_paused")
+    #expect(EGOnePausedInstallState.updatePausedResumable.rawValue == "update_paused_resumable")
+  }
+
+  /// Only paused states have a projection. Everything else is nil, which the
+  /// bridge reports as "none" — an EXIT from a paused state, which is half the
+  /// residency question.
+  @Test func onlyPausedStatesProject() {
+    #expect(EGOnePausedInstallState.projection(of: .paused) == .paused)
+    #expect(
+      EGOnePausedInstallState.projection(of: .updatePaused(resumable: true))
+        == .updatePausedResumable)
+    #expect(
+      EGOnePausedInstallState.projection(of: .updatePaused(resumable: false)) == .updatePaused)
+    for state: EGOneInstallState in [
+      .notInstalled, .downloading(fractionCompleted: 0.5), .verifying,
+      .installed(version: "1.1"), .failed(.network),
+    ] {
+      #expect(EGOnePausedInstallState.projection(of: state) == nil, "\(state) must not project")
+    }
+  }
+
+  /// The two update situations stay distinguishable. Someone who STARTED the
+  /// upgrade and stopped is a different problem from someone who never began:
+  /// the first suggests the download is failing, the second that the prompt is
+  /// not landing. One name would hide which.
+  @Test func theTwoUpdateSituationsAreDistinguishable() {
+    #expect(
+      EGOnePausedInstallState.projection(of: .updatePaused(resumable: true))
+        != EGOnePausedInstallState.projection(of: .updatePaused(resumable: false)))
+  }
+
+  /// The version never reaches telemetry: the projection carries no payload,
+  /// so a free-form version string cannot make the property unbounded.
+  @Test func theVersionNeverReachesTelemetry() {
+    #expect(EGOnePausedInstallState.projection(of: .installed(version: "1.1")) == nil)
+    #expect(EGOnePausedInstallState.projection(of: .installed(version: nil)) == nil)
+  }
+
+  /// THE test this event exists to survive, and the one that refuted the
+  /// original design.
+  ///
+  /// `adoptIfPresent` runs on every settings-open and CYCLES the state:
+  /// measured as update_paused, verifying, update_paused, verifying,
+  /// update_paused, verifying, update_paused across three probes. Under the
+  /// first design — a general install-state-changed event — that emitted twice
+  /// per settings visit, so the metric would have read as a growing population
+  /// of affected users while actually counting panel opens.
+  ///
+  /// Now `.verifying` is skipped before the comparison, so a cycle returning
+  /// to the same paused state is silent. One entry event, no matter how many
+  /// times the user opens the panel.
+  @MainActor
+  @Test func settingsProbeCyclesDoNotInflateTheCount() async throws {
+    let root = FileManager.default.temporaryDirectory
+      .appendingPathComponent("eg1-tel-\(UUID().uuidString)", isDirectory: true)
+    let install = root.appendingPathComponent("Models/eg-1", isDirectory: true)
+    let metadata = root.appendingPathComponent("ModelDelivery", isDirectory: true)
+    try FileManager.default.createDirectory(at: install, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: metadata, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let registration = try EGOneDeliveryAdapterMappingTests.shardedFixtureRegistration(
+      install: install, metadata: metadata)
+
+    // A surviving older revision: the launch state under test.
+    let identity = registration.manifest.identity
+    let older = "\(identity.family.rawValue)-\(identity.name)-v1-legacy-\(identity.variant)"
+    let legacy = install.appendingPathComponent("eg-1-v1-legacy.gguf")
+    try Data([0xAB, 0xCD]).write(to: legacy)
+    let attrs = try FileManager.default.attributesOfItem(atPath: legacy.path)
+    try JSONSerialization.data(withJSONObject: [
+      "manifestDigest": "older", "admittedAt": 0,
+      "files": [
+        [
+          "path": "eg-1-v1-legacy.gguf",
+          "sizeBytes": attrs[.size] as? Int64 ?? 2,
+          "mtime": (attrs[.modificationDate] as? Date)?.timeIntervalSince1970 ?? 0,
+        ]
+      ],
+    ]).write(to: metadata.appendingPathComponent("\(older).admission.json"))
+
+    let suite = "eg1-tel-\(UUID().uuidString)"
+    let store = try #require(UserDefaults(suiteName: suite))
+    defer { store.removePersistentDomain(forName: suite) }
+
+    let recorded = Recorded()
+    let adapter = EGOneDeliveryAdapter(
+      controller: ModelDeliveryController(defaults: UserDefaults(suiteName: suite)!),
+      registration: registration, version: "1.1", defaults: store)
+    let runtime = EGOneRuntime(
+      manifest: EGOneManifest(
+        modelName: LLMProvider.egOneModelName, version: "v2-sharded", contextTokens: 4096,
+        promptTemplateID: "eg1-v1", minAppVersion: "0",
+        downloadURL: URL(string: "https://example.invalid/eg1.gguf")!, displayVersion: "1.1"),
+      serverBinaryURL: nil, delivery: adapter)
+    runtime.onEvent = { event in
+      if case .pausedInstallStateChanged(let projection) = event {
+        recorded.append(projection?.rawValue ?? "none")
+      }
+    }
+
+    let settled = await withDeadline(seconds: 5) {
+      while true {
+        if await MainActor.run(body: { runtime.installState == .updatePaused(resumable: false) }) {
+          return true
+        }
+        await Task.yield()
+      }
+    }
+    try #require(settled == true, "the launch state under test was never reached")
+
+    // Three settings-open probes, each of which cycles the state through
+    // verifying and back. This is the exact sequence that broke the first
+    // design; it must now produce no additional events.
+    for _ in 0..<3 {
+      _ = await adapter.adoptIfPresent()
+      await Task.yield()
+    }
+    let stillPaused = await MainActor.run {
+      runtime.installState == .updatePaused(resumable: false)
+    }
+    try #require(stillPaused == true, "the probe changed the resting state, so this proves nothing")
+
+    #expect(
+      recorded.all == ["update_paused"],
+      "settings-open probes inflated the count, got \(recorded.all)")
+
+    // THE EXIT HALF. Entry alone identifies the affected population; only the
+    // exit bounds how long they stayed there, which is the residency question
+    // the event exists to answer. Without this, half the measurement is
+    // unproven and a user who resolved their pause would look permanently
+    // stuck.
+    runtime.startDownload()
+    let exited = await withDeadline(seconds: 5) {
+      while true {
+        if await MainActor.run(body: { recorded.all == ["update_paused", "none"] }) { return true }
+        await Task.yield()
+      }
+    }
+    #expect(
+      exited == true,
+      "leaving the paused state emitted no exit event, got \(recorded.all)")
+
+    // Drain the attempt this test started. An undrained fetch outlives the
+    // test and keeps touching a temp directory the defer above is about to
+    // delete, which surfaces later as an unrelated suite failing for reasons
+    // nobody can trace back here.
+    await adapter.cancel()
+  }
+
+  private final class Recorded: @unchecked Sendable {
+    private let lock = NSLock()
+    private var names: [String] = []
+    func append(_ n: String) {
+      lock.lock()
+      names.append(n)
+      lock.unlock()
+    }
+    var all: [String] {
+      lock.lock()
+      defer { lock.unlock() }
+      return names
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/App/EGOneInstallStateTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/App/EGOneInstallStateTelemetryTests.swift
@@ -115,7 +115,7 @@ import Testing
         modelName: LLMProvider.egOneModelName, version: "v2-sharded", contextTokens: 4096,
         promptTemplateID: "eg1-v1", minAppVersion: "0",
         downloadURL: URL(string: "https://example.invalid/eg1.gguf")!, displayVersion: "1.1"),
-      serverBinaryURL: nil, delivery: adapter)
+      serverBinaryURL: nil, delivery: adapter, defaults: store)
     runtime.onEvent = { event in
       if case .pausedInstallStateChanged(let projection) = event {
         recorded.append(projection?.rawValue ?? "none")
@@ -184,5 +184,71 @@ import Testing
       defer { lock.unlock() }
       return names
     }
+  }
+
+  // MARK: - Residency across launches (whole-diff review)
+
+  /// A pause OUTLIVES the process, and the tracker has to as well.
+  ///
+  /// Without persistence a user who leaves an upgrade paused and quits emits a
+  /// fresh ENTRY on every launch with no matching exit. After a week that is
+  /// seven entries and eventually one exit, and no query can say which entry
+  /// the exit belongs to — so the duration this event exists to measure is
+  /// uncomputable from data that looks perfectly healthy.
+  @MainActor
+  @Test func aPauseCarriedAcrossLaunchesDoesNotReEmitEntry() async throws {
+    let suite = "eg1-tel-\(UUID().uuidString)"
+    let store = try #require(UserDefaults(suiteName: suite))
+    defer { store.removePersistentDomain(forName: suite) }
+
+    // First launch: enters the paused state and records one entry.
+    let first = Recorded()
+    let runtimeA = EGOneRuntime(
+      manifest: nil, serverBinaryURL: nil, delivery: nil, defaults: store)
+    runtimeA.onEvent = { event in
+      if case .pausedInstallStateChanged(let p) = event { first.append(p?.rawValue ?? "none") }
+    }
+    runtimeA.applyInstallStateForTesting(.updatePaused(resumable: false, targetVersion: "1.1"))
+    #expect(first.all == ["update_paused"])
+
+    // SECOND LAUNCH: a brand-new runtime over the same storage, seeing the same
+    // paused state. It must stay silent — the user never left the pause.
+    let second = Recorded()
+    let runtimeB = EGOneRuntime(
+      manifest: nil, serverBinaryURL: nil, delivery: nil, defaults: store)
+    runtimeB.onEvent = { event in
+      if case .pausedInstallStateChanged(let p) = event { second.append(p?.rawValue ?? "none") }
+    }
+    runtimeB.applyInstallStateForTesting(.updatePaused(resumable: false, targetVersion: "1.1"))
+    #expect(
+      second.all.isEmpty,
+      "a relaunch into the SAME pause re-emitted an entry, so the exit cannot be paired: \(second.all)")
+  }
+
+  /// The other half: a pause resolved while the app was CLOSED must still
+  /// close. At launch `installState` starts `.notInstalled` and the seed
+  /// publishes `.notInstalled` too — the same value — so a reconciliation
+  /// placed after the UI dedupe would early-return and leave the entry open
+  /// forever.
+  @MainActor
+  @Test func aPauseResolvedWhileClosedEmitsItsExitOnNextLaunch() async throws {
+    let suite = "eg1-tel-\(UUID().uuidString)"
+    let store = try #require(UserDefaults(suiteName: suite))
+    defer { store.removePersistentDomain(forName: suite) }
+
+    let first = EGOneRuntime(manifest: nil, serverBinaryURL: nil, delivery: nil, defaults: store)
+    first.applyInstallStateForTesting(.updatePaused(resumable: true, targetVersion: "1.1"))
+
+    // Relaunch into `.notInstalled`, which equals the runtime's initial value.
+    let recorded = Recorded()
+    let second = EGOneRuntime(manifest: nil, serverBinaryURL: nil, delivery: nil, defaults: store)
+    second.onEvent = { event in
+      if case .pausedInstallStateChanged(let p) = event { recorded.append(p?.rawValue ?? "none") }
+    }
+    second.applyInstallStateForTesting(.notInstalled)
+
+    #expect(
+      recorded.all == ["none"],
+      "a pause resolved while the app was closed never emitted its exit: \(recorded.all)")
   }
 }

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -457,14 +457,23 @@ import Testing
   /// composition root holds settings, the coordinator, and the runtime together. Extracting this
   /// wiring into an installer would add lines here rather than remove them. No domain logic moved
   /// here. Cap by deterministic rule (actual 1348 + ~2, rounded up to nearest 5 = 1350).
+  ///
+  /// RAISED 1350 → 1355 for #2119 (2026-08-17). One line: the superseded-staging
+  /// sweep for EG-1's registration, folded into the existing launch Task so it is
+  /// ORDERED before the launch table rather than racing it. It has to live here
+  /// because this is the only place EG-1's `DeliveryRegistration` exists — the
+  /// other three registrations sweep from `ModelDeliveryHome`, which builds
+  /// their own. Comments on both #2109 additions were folded to their code lines
+  /// first, so the growth is one line of wiring and no prose. Same deterministic
+  /// rule: actual 1351 + ~2, rounded up to nearest 5.
   @Test func envWisprAppLineCountCeilingHolds() throws {
     let url = envWisprAppURL()
     let source = try String(contentsOf: url, encoding: .utf8)
     let lineCount = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
-      lineCount <= 1350,
+      lineCount <= 1355,
       """
-      WisprBootstrapper line count exceeded: \(lineCount) > 1350. \
+      WisprBootstrapper line count exceeded: \(lineCount) > 1355. \
       Raising the ceiling requires a Bible changelog entry.
       """)
   }

--- a/Tests/EnviousWisprTests/LLM/EGOneDeliveryAdapterTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneDeliveryAdapterTests.swift
@@ -29,7 +29,7 @@ import Testing
       EGOneDeliveryAdapter.map(
         .downloading(fractionCompleted: 0.5, bytesWritten: 5, totalBytes: 10), version: "1.1",
         registration: reg)
-        == .downloading(fractionCompleted: 0.5, upgradeTo: nil))
+        == .downloading(fractionCompleted: 0.5, upgrade: nil))
     #expect(EGOneDeliveryAdapter.map(.verifying, version: "1.1", registration: reg) == .verifying)
     #expect(
       EGOneDeliveryAdapter.map(.admitted, version: "1.1", registration: reg)

--- a/Tests/EnviousWisprTests/LLM/EGOneDeliveryAdapterTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneDeliveryAdapterTests.swift
@@ -9,29 +9,52 @@ import Testing
 /// to an EG-1 UI vocabulary value, and EVERY `DeliveryFailureClass` maps to a
 /// retry-able RED (the limb never blocks dictation — #1363 §7).
 @Suite struct EGOneDeliveryAdapterMappingTests {
-  @Test func deliveryStateMapsToInstallState() {
-    #expect(EGOneDeliveryAdapter.map(.notReady, version: "v1") == .notInstalled)
+  /// #2109 changed this signature: mapping a not-serving state now depends on
+  /// DISK truth (is a working older revision present, are there partials), so
+  /// the registration is required. This fixture has an empty install and
+  /// metadata dir, so every not-serving state resolves to `.notInstalled` —
+  /// the pre-#2109 behaviour, asserted here so the OTHER cases stay unchanged.
+  @Test func deliveryStateMapsToInstallState() throws {
+    let dirs = try makeTempDirs()
+    defer { dirs.cleanup() }
+    let reg = try Self.shardedFixtureRegistration(
+      install: dirs.install, metadata: dirs.metadata)
+
+    #expect(EGOneDeliveryAdapter.map(.notReady, version: "1.1", registration: reg) == .notInstalled)
     #expect(
-      EGOneDeliveryAdapter.map(.preparing(validatingExistingCache: true), version: "v1")
+      EGOneDeliveryAdapter.map(
+        .preparing(validatingExistingCache: true), version: "1.1", registration: reg)
         == .verifying)
     #expect(
       EGOneDeliveryAdapter.map(
-        .downloading(fractionCompleted: 0.5, bytesWritten: 5, totalBytes: 10), version: "v1")
+        .downloading(fractionCompleted: 0.5, bytesWritten: 5, totalBytes: 10), version: "1.1",
+        registration: reg)
         == .downloading(fractionCompleted: 0.5))
-    #expect(EGOneDeliveryAdapter.map(.verifying, version: "v1") == .verifying)
-    #expect(EGOneDeliveryAdapter.map(.admitted, version: "v1") == .installed(version: "v1"))
+    #expect(EGOneDeliveryAdapter.map(.verifying, version: "1.1", registration: reg) == .verifying)
     #expect(
-      EGOneDeliveryAdapter.map(.cancelled(resumable: true), version: "v1") == .failed(.cancelled))
+      EGOneDeliveryAdapter.map(.admitted, version: "1.1", registration: reg)
+        == .installed(version: "1.1"))
+    // Changed by #2109: a cancel with nothing on disk is a first-install that
+    // never started, NOT a failure. With partials it is `.paused`; with a
+    // surviving older revision it is `.updatePaused`. See
+    // `notServingStateSeparatesTheFourDiskSituations`.
+    #expect(
+      EGOneDeliveryAdapter.map(.cancelled(resumable: true), version: "1.1", registration: reg)
+        == .notInstalled)
   }
 
-  @Test func everyFailureClassMapsToARetryableInstallFailure() {
+  @Test func everyFailureClassMapsToARetryableInstallFailure() throws {
+    let dirs = try makeTempDirs()
+    defer { dirs.cleanup() }
+    let reg = try Self.shardedFixtureRegistration(
+      install: dirs.install, metadata: dirs.metadata)
     let all: [DeliveryFailureClass] = [
       .sourceUnreachable, .sourceTimeout, .source5xx, .source4xx, .integrityMismatch,
       .insufficientDisk, .permissionDenied, .cacheRepairFailed, .cancelled, .unknown,
     ]
     for reason in all {
       let mapped = EGOneDeliveryAdapter.map(
-        .failed(DeliveryFailure(reason: reason)), version: "v1")
+        .failed(DeliveryFailure(reason: reason)), version: "1.1", registration: reg)
       guard case .failed = mapped else {
         Issue.record("\(reason) did not map to a .failed install state")
         continue
@@ -100,6 +123,128 @@ import Testing
     let adapter = EGOneDeliveryAdapter(
       controller: ModelDeliveryController(), registration: registration, version: "v2-sharded")
     #expect(adapter.installedArtifactURL.lastPathComponent == "eg-1-00001-of-00002.gguf")
+  }
+
+  // MARK: - Not-serving state decision (#2109)
+
+  /// Write a prior-revision admission marker recording files that EXIST, which
+  /// is what `supersededInstallSurvives` requires: a marker alone proves an
+  /// install once completed, never that its bytes survive.
+  private static func seedSurvivingOlderRevision(
+    _ registration: DeliveryRegistration
+  ) throws {
+    let identity = registration.manifest.identity
+    let older = "\(identity.family.rawValue)-\(identity.name)-v1-legacy-\(identity.variant)"
+    let fileName = "eg-1-v1-legacy.gguf"
+
+    try FileManager.default.createDirectory(
+      at: registration.installDirectory, withIntermediateDirectories: true)
+    let installed = registration.installDirectory.appendingPathComponent(fileName)
+    try Data([0xAB, 0xCD]).write(to: installed)
+
+    let attrs = try FileManager.default.attributesOfItem(atPath: installed.path)
+    let marker: [String: Any] = [
+      "manifestDigest": "older-revision-digest",
+      "admittedAt": 0,
+      "files": [
+        [
+          "path": fileName,
+          "sizeBytes": attrs[.size] as? Int64 ?? 2,
+          "mtime": (attrs[.modificationDate] as? Date)?.timeIntervalSince1970 ?? 0,
+        ]
+      ],
+    ]
+    try FileManager.default.createDirectory(
+      at: registration.metadataDirectory, withIntermediateDirectories: true)
+    try JSONSerialization.data(withJSONObject: marker).write(
+      to: registration.metadataDirectory.appendingPathComponent("\(older).admission.json"))
+  }
+
+  private static func seedStagedPartials(_ registration: DeliveryRegistration) throws {
+    let staging = ModelDeliveryController.stagingDirectoryURL(for: registration)
+    try FileManager.default.createDirectory(at: staging, withIntermediateDirectories: true)
+    try Data([0x01, 0x02, 0x03]).write(to: staging.appendingPathComponent("partial.bin"))
+  }
+
+  /// The four-way decision that determines what a user actually sees. All four
+  /// arms are asserted TOGETHER, because each one is the other three's control:
+  /// a stub returning any single value would pass one row and fail the rest.
+  ///
+  /// The `notInstalled` row is the one that used to swallow the other two —
+  /// before #2109 every not-serving case rendered identically to a user who
+  /// had never installed EG-1 at all.
+  @Test func notServingStateSeparatesTheFourDiskSituations() throws {
+    // 1. Nothing on disk: a genuine first-time user.
+    let cold = try makeTempDirs()
+    defer { cold.cleanup() }
+    let coldReg = try Self.shardedFixtureRegistration(
+      install: cold.install, metadata: cold.metadata)
+    #expect(EGOneDeliveryAdapter.notServingState(for: coldReg) == .notInstalled)
+
+    // 2. Partials only: an interrupted FIRST install. Resume, not a failure.
+    let interrupted = try makeTempDirs()
+    defer { interrupted.cleanup() }
+    let interruptedReg = try Self.shardedFixtureRegistration(
+      install: interrupted.install, metadata: interrupted.metadata)
+    try Self.seedStagedPartials(interruptedReg)
+    #expect(EGOneDeliveryAdapter.notServingState(for: interruptedReg) == .paused)
+
+    // 3. A surviving older revision, upgrade not started: cleanup is off and
+    //    the user has never pressed anything.
+    let owed = try makeTempDirs()
+    defer { owed.cleanup() }
+    let owedReg = try Self.shardedFixtureRegistration(
+      install: owed.install, metadata: owed.metadata)
+    try Self.seedSurvivingOlderRevision(owedReg)
+    #expect(EGOneDeliveryAdapter.notServingState(for: owedReg) == .updatePaused(resumable: false))
+
+    // 4. A surviving older revision AND partials: they started the upgrade and
+    //    stopped. This is the Resume-upgrade row.
+    let started = try makeTempDirs()
+    defer { started.cleanup() }
+    let startedReg = try Self.shardedFixtureRegistration(
+      install: started.install, metadata: started.metadata)
+    try Self.seedSurvivingOlderRevision(startedReg)
+    try Self.seedStagedPartials(startedReg)
+    #expect(EGOneDeliveryAdapter.notServingState(for: startedReg) == .updatePaused(resumable: true))
+  }
+
+  /// A cancel is a DECISION, not a failure. It used to map to
+  /// `.failed(.cancelled)`, which painted a red row with a Try Again button
+  /// for something the user chose deliberately.
+  @Test func cancelNoLongerMapsToAFailure() throws {
+    let dirs = try makeTempDirs()
+    defer { dirs.cleanup() }
+    let registration = try Self.shardedFixtureRegistration(
+      install: dirs.install, metadata: dirs.metadata)
+    try Self.seedStagedPartials(registration)
+
+    let mapped = EGOneDeliveryAdapter.map(
+      .cancelled(resumable: true), version: "1.1", registration: registration)
+    #expect(mapped == .paused)
+
+    // Two-way control: a REAL failure must still be a failure. If cancel and
+    // failure both became paused, the red row would be unreachable.
+    let failed = EGOneDeliveryAdapter.map(
+      .failed(DeliveryFailure(reason: .sourceUnreachable)), version: "1.1",
+      registration: registration)
+    #expect(failed == .failed(.network))
+  }
+
+  /// The display version reaches the installed state verbatim, and nil stays
+  /// nil rather than becoming a placeholder.
+  @Test func installedCarriesTheDisplayVersionOrNothing() throws {
+    let dirs = try makeTempDirs()
+    defer { dirs.cleanup() }
+    let registration = try Self.shardedFixtureRegistration(
+      install: dirs.install, metadata: dirs.metadata)
+
+    #expect(
+      EGOneDeliveryAdapter.map(.admitted, version: "1.1", registration: registration)
+        == .installed(version: "1.1"))
+    #expect(
+      EGOneDeliveryAdapter.map(.admitted, version: nil, registration: registration)
+        == .installed(version: nil))
   }
 
   @Test func failureClassBucketsMatchExistingCopy() {

--- a/Tests/EnviousWisprTests/LLM/EGOneDeliveryAdapterTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneDeliveryAdapterTests.swift
@@ -179,7 +179,7 @@ import Testing
     defer { cold.cleanup() }
     let coldReg = try Self.shardedFixtureRegistration(
       install: cold.install, metadata: cold.metadata)
-    #expect(EGOneDeliveryAdapter.notServingState(for: coldReg) == .notInstalled)
+    #expect(EGOneDeliveryAdapter.notServingState(for: coldReg, version: "1.1") == .notInstalled)
 
     // 2. Partials only: an interrupted FIRST install. Resume, not a failure.
     let interrupted = try makeTempDirs()
@@ -187,7 +187,7 @@ import Testing
     let interruptedReg = try Self.shardedFixtureRegistration(
       install: interrupted.install, metadata: interrupted.metadata)
     try Self.seedStagedPartials(interruptedReg)
-    #expect(EGOneDeliveryAdapter.notServingState(for: interruptedReg) == .paused)
+    #expect(EGOneDeliveryAdapter.notServingState(for: interruptedReg, version: "1.1") == .paused)
 
     // 3. A surviving older revision, upgrade not started: cleanup is off and
     //    the user has never pressed anything.
@@ -196,7 +196,7 @@ import Testing
     let owedReg = try Self.shardedFixtureRegistration(
       install: owed.install, metadata: owed.metadata)
     try Self.seedSurvivingOlderRevision(owedReg)
-    #expect(EGOneDeliveryAdapter.notServingState(for: owedReg) == .updatePaused(resumable: false))
+    #expect(EGOneDeliveryAdapter.notServingState(for: owedReg, version: "1.1") == .updatePaused(resumable: false, targetVersion: "1.1"))
 
     // 4. A surviving older revision AND partials: they started the upgrade and
     //    stopped. This is the Resume-upgrade row.
@@ -206,7 +206,7 @@ import Testing
       install: started.install, metadata: started.metadata)
     try Self.seedSurvivingOlderRevision(startedReg)
     try Self.seedStagedPartials(startedReg)
-    #expect(EGOneDeliveryAdapter.notServingState(for: startedReg) == .updatePaused(resumable: true))
+    #expect(EGOneDeliveryAdapter.notServingState(for: startedReg, version: "1.1") == .updatePaused(resumable: true, targetVersion: "1.1"))
   }
 
   /// A cancel is a DECISION, not a failure. It used to map to

--- a/Tests/EnviousWisprTests/LLM/EGOneDeliveryAdapterTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneDeliveryAdapterTests.swift
@@ -29,7 +29,7 @@ import Testing
       EGOneDeliveryAdapter.map(
         .downloading(fractionCompleted: 0.5, bytesWritten: 5, totalBytes: 10), version: "1.1",
         registration: reg)
-        == .downloading(fractionCompleted: 0.5))
+        == .downloading(fractionCompleted: 0.5, upgradeTo: nil))
     #expect(EGOneDeliveryAdapter.map(.verifying, version: "1.1", registration: reg) == .verifying)
     #expect(
       EGOneDeliveryAdapter.map(.admitted, version: "1.1", registration: reg)

--- a/Tests/EnviousWisprTests/LLM/EGOneInstallStateTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneInstallStateTests.swift
@@ -13,8 +13,8 @@ import Testing
   /// time and indistinguishable, to a user, from the app being broken.
   @Test func pausedStatesAcceptADownloadStart() {
     #expect(EGOneInstallState.paused.acceptsDownloadStart)
-    #expect(EGOneInstallState.updatePaused(resumable: true).acceptsDownloadStart)
-    #expect(EGOneInstallState.updatePaused(resumable: false).acceptsDownloadStart)
+    #expect(EGOneInstallState.updatePaused(resumable: true, targetVersion: "1.1").acceptsDownloadStart)
+    #expect(EGOneInstallState.updatePaused(resumable: false, targetVersion: "1.1").acceptsDownloadStart)
   }
 
   /// Two-way control: the in-flight and finished states must REFUSE, or the

--- a/Tests/EnviousWisprTests/LLM/EGOneInstallStateTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneInstallStateTests.swift
@@ -13,14 +13,18 @@ import Testing
   /// time and indistinguishable, to a user, from the app being broken.
   @Test func pausedStatesAcceptADownloadStart() {
     #expect(EGOneInstallState.paused.acceptsDownloadStart)
-    #expect(EGOneInstallState.updatePaused(resumable: true, targetVersion: "1.1").acceptsDownloadStart)
-    #expect(EGOneInstallState.updatePaused(resumable: false, targetVersion: "1.1").acceptsDownloadStart)
+    #expect(
+      EGOneInstallState.updatePaused(resumable: true, targetVersion: "1.1").acceptsDownloadStart)
+    #expect(
+      EGOneInstallState.updatePaused(resumable: false, targetVersion: "1.1").acceptsDownloadStart)
   }
 
   /// Two-way control: the in-flight and finished states must REFUSE, or the
   /// property is just "true" wearing a name and proves nothing above.
   @Test func inFlightAndInstalledStatesRefuseADownloadStart() {
-    #expect(EGOneInstallState.downloading(fractionCompleted: 0.5).acceptsDownloadStart == false)
+    #expect(
+      EGOneInstallState.downloading(fractionCompleted: 0.5, upgradeTo: nil).acceptsDownloadStart
+        == false)
     #expect(EGOneInstallState.verifying.acceptsDownloadStart == false)
     #expect(EGOneInstallState.installed(version: "1.1").acceptsDownloadStart == false)
   }

--- a/Tests/EnviousWisprTests/LLM/EGOneInstallStateTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneInstallStateTests.swift
@@ -23,7 +23,7 @@ import Testing
   /// property is just "true" wearing a name and proves nothing above.
   @Test func inFlightAndInstalledStatesRefuseADownloadStart() {
     #expect(
-      EGOneInstallState.downloading(fractionCompleted: 0.5, upgradeTo: nil).acceptsDownloadStart
+      EGOneInstallState.downloading(fractionCompleted: 0.5, upgrade: nil).acceptsDownloadStart
         == false)
     #expect(EGOneInstallState.verifying.acceptsDownloadStart == false)
     #expect(EGOneInstallState.installed(version: "1.1").acceptsDownloadStart == false)

--- a/Tests/EnviousWisprTests/LLM/EGOneInstallStateTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneInstallStateTests.swift
@@ -1,0 +1,28 @@
+import Testing
+
+@testable import EnviousWisprLLM
+
+/// The install-state vocabulary's own decisions (#2109). These are the two
+/// questions every renderer and action site asks, pulled onto the enum so they
+/// are answered once and exhaustively rather than re-derived per call site.
+@Suite struct EGOneInstallStateTests {
+
+  /// The dead-button guard. `paused` and `updatePaused` are the Resume and
+  /// Finish-upgrade doors; if either stopped accepting a start, the row would
+  /// render its button and silently ignore the press — invisible at compile
+  /// time and indistinguishable, to a user, from the app being broken.
+  @Test func pausedStatesAcceptADownloadStart() {
+    #expect(EGOneInstallState.paused.acceptsDownloadStart)
+    #expect(EGOneInstallState.updatePaused(resumable: true).acceptsDownloadStart)
+    #expect(EGOneInstallState.updatePaused(resumable: false).acceptsDownloadStart)
+  }
+
+  /// Two-way control: the in-flight and finished states must REFUSE, or the
+  /// property is just "true" wearing a name and proves nothing above.
+  @Test func inFlightAndInstalledStatesRefuseADownloadStart() {
+    #expect(EGOneInstallState.downloading(fractionCompleted: 0.5).acceptsDownloadStart == false)
+    #expect(EGOneInstallState.verifying.acceptsDownloadStart == false)
+    #expect(EGOneInstallState.installed(version: "1.1").acceptsDownloadStart == false)
+  }
+
+}

--- a/Tests/EnviousWisprTests/LLM/EGOneManifestTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneManifestTests.swift
@@ -8,6 +8,12 @@ import Testing
 @Suite("EGOneManifest (#1271)")
 struct EGOneManifestTests {
 
+  /// The display label the SHIPPED manifest must carry, paired with the
+  /// revision it belongs to. The revision is in the NAME deliberately: when
+  /// the pin moves, this constant has to be renamed as well as revalued, so
+  /// the pairing cannot be updated by half.
+  private static let expectedDisplayVersionForV3EG2 = "1.1"
+
   static func makeManifest(
     modelName: String = "eg-1",
     promptTemplateID: String = "eg1-v1",
@@ -21,6 +27,62 @@ struct EGOneManifestTests {
 
   @Test func knownTemplateMapsToEGOneFixed() {
     #expect(Self.makeManifest().promptFamily == .egOneFixed)
+  }
+
+  // MARK: - displayVersion (#2109)
+
+  /// The load-bearing invariant of the whole feature: `displayVersion` is
+  /// COSMETIC and must never reach a path. `artifactFileName` is built from
+  /// `version`, and if a future edit ever swapped them the app would look for
+  /// a file that does not exist. Asserted with the two deliberately
+  /// DISAGREEING so a swap cannot pass.
+  @Test func displayVersionNeverReachesTheArtifactFileName() {
+    let manifest = EGOneManifest(
+      modelName: "eg-1", version: "v3-eg2",
+      contextTokens: 16384, promptTemplateID: "eg1-v1",
+      minAppVersion: "2.3.0",
+      downloadURL: URL(string: "https://models.enviouslabs.co/eg1/x.gguf")!,
+      displayVersion: "1.1")
+
+    #expect(manifest.artifactFileName == "eg-1-v3-eg2.gguf")
+    #expect(!manifest.artifactFileName.contains("1.1"))
+  }
+
+  /// A manifest WITHOUT the key must decode, not throw: every build that
+  /// predates the field, and any malformed bundle, has to keep working.
+  @Test func decodesWithoutDisplayVersion() throws {
+    let json = """
+      {"modelName":"eg-1","version":"v3-eg2","contextTokens":16384,
+       "promptTemplateID":"eg1-v1","minAppVersion":"2.3.0",
+       "downloadURL":"https://models.enviouslabs.co/eg1/x.gguf"}
+      """
+    let manifest = try JSONDecoder().decode(EGOneManifest.self, from: Data(json.utf8))
+    #expect(manifest.displayVersion == nil)
+    #expect(manifest.resolvedDisplayVersion == nil)
+  }
+
+  @Test func decodesWithDisplayVersion() throws {
+    let json = """
+      {"modelName":"eg-1","version":"v3-eg2","contextTokens":16384,
+       "promptTemplateID":"eg1-v1","minAppVersion":"2.3.0",
+       "downloadURL":"https://models.enviouslabs.co/eg1/x.gguf",
+       "displayVersion":"1.1"}
+      """
+    let manifest = try JSONDecoder().decode(EGOneManifest.self, from: Data(json.utf8))
+    #expect(manifest.resolvedDisplayVersion == "1.1")
+  }
+
+  /// Blank-after-trimming is absent, not a label. A manifest carrying `""`
+  /// or `"  "` would otherwise paint an empty string next to "EG-1".
+  @Test(arguments: ["", "   ", "\n"])
+  func blankDisplayVersionResolvesToNoLabel(_ raw: String) {
+    let manifest = EGOneManifest(
+      modelName: "eg-1", version: "v3-eg2",
+      contextTokens: 16384, promptTemplateID: "eg1-v1",
+      minAppVersion: "2.3.0",
+      downloadURL: URL(string: "https://models.enviouslabs.co/eg1/x.gguf")!,
+      displayVersion: raw)
+    #expect(manifest.resolvedDisplayVersion == nil)
   }
 
   @Test func unknownTemplateRefusesActivation() {
@@ -90,5 +152,20 @@ struct EGOneManifestTests {
     #expect(manifest.modelName == LLMProvider.egOneModelName)
     #expect(manifest.promptFamily != nil)
     #expect(manifest.activationBlockers().isEmpty)
+
+    // #2109: the shipped manifest must carry a renderable display version.
+    // Its ABSENCE is the malformed-build case the settings row silently
+    // tolerates by showing no label — which is right at runtime and wrong to
+    // ship, so it is caught here instead.
+    #expect(manifest.resolvedDisplayVersion != nil)
+
+    // Pinned to the literal, deliberately. This CANNOT establish that "1.1"
+    // is the correct label for revision `v3-eg2` — that correspondence is a
+    // founder decision, not a derivable fact, and the plan records it as an
+    // accepted known limit (§14 Q3). What it does establish is that the two
+    // cannot drift apart silently: changing the manifest without changing
+    // this line, or the reverse, fails here.
+    #expect(manifest.resolvedDisplayVersion == Self.expectedDisplayVersionForV3EG2)
+    #expect(manifest.version == "v3-eg2")
   }
 }

--- a/Tests/EnviousWisprTests/LLM/EGOneRuntimeReplacementActivationTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneRuntimeReplacementActivationTests.swift
@@ -110,7 +110,8 @@ import Testing
     // signal instead of spawning anything.
     let missingBinary = root.appendingPathComponent("missing-llama-server")
     let runtime = EGOneRuntime(
-      manifest: runtimeManifest(), serverBinaryURL: missingBinary, delivery: adapter)
+      manifest: runtimeManifest(), serverBinaryURL: missingBinary, delivery: adapter,
+      defaults: store)
     runtime.isActiveProvider = { [provider] in provider.isEGOneActive }
     runtime.onEvent = { event in
       Task { @MainActor in signal.record(event) }

--- a/Tests/EnviousWisprTests/LLM/EGOneSeedAndResumeTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneSeedAndResumeTests.swift
@@ -160,7 +160,7 @@ import Testing
         promptTemplateID: "eg1-v1", minAppVersion: "0",
         downloadURL: URL(string: "https://example.invalid/eg1.gguf")!,
         displayVersion: "1.1"),
-      serverBinaryURL: nil, delivery: adapter)
+      serverBinaryURL: nil, delivery: adapter, defaults: store)
     defer { store.removePersistentDomain(forName: suite) }
 
     let reachedPaused = await withDeadline(seconds: 5) {
@@ -209,7 +209,7 @@ import Testing
       controller: ModelDeliveryController(defaults: UserDefaults(suiteName: suite)!),
       registration: registration, version: "1.1", defaults: store)
     let runtime = EGOneRuntime(
-      manifest: runtimeManifest(), serverBinaryURL: nil, delivery: adapter)
+      manifest: runtimeManifest(), serverBinaryURL: nil, delivery: adapter, defaults: store)
 
     let expected = EGOneInstallState.updatePaused(resumable: resumable, targetVersion: "1.1")
     let reached = await withDeadline(seconds: 5) {

--- a/Tests/EnviousWisprTests/LLM/EGOneSeedAndResumeTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneSeedAndResumeTests.swift
@@ -1,0 +1,349 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprLLM
+@testable import EnviousWisprModelDelivery
+
+/// The two behaviours #2109 depends on that a pure-value test cannot reach:
+/// the cold-launch SEED (without which the paused-upgrade state is unreachable
+/// in production) and the runtime's download GUARD (without which Resume is a
+/// button that silently does nothing).
+@MainActor
+@Suite struct EGOneSeedAndResumeTests {
+
+  private func makeDirs() throws -> (install: URL, metadata: URL, cleanup: () -> Void) {
+    let root = FileManager.default.temporaryDirectory
+      .appendingPathComponent("eg1-seed-\(UUID().uuidString)", isDirectory: true)
+    let install = root.appendingPathComponent("Models/eg-1", isDirectory: true)
+    let metadata = root.appendingPathComponent("ModelDelivery", isDirectory: true)
+    try FileManager.default.createDirectory(at: install, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: metadata, withIntermediateDirectories: true)
+    return (install, metadata, { try? FileManager.default.removeItem(at: root) })
+  }
+
+  /// A prior revision that was admitted AND whose bytes survive — the exact
+  /// precondition `supersededInstallSurvives` requires.
+  private func seedSurvivingOlderRevision(_ registration: DeliveryRegistration) throws {
+    let identity = registration.manifest.identity
+    let key = "\(identity.family.rawValue)-\(identity.name)-v1-legacy-\(identity.variant)"
+    let name = "eg-1-v1-legacy.gguf"
+    let installed = registration.installDirectory.appendingPathComponent(name)
+    try Data([0xAB, 0xCD]).write(to: installed)
+    let attrs = try FileManager.default.attributesOfItem(atPath: installed.path)
+    let marker: [String: Any] = [
+      "manifestDigest": "older-digest", "admittedAt": 0,
+      "files": [
+        [
+          "path": name,
+          "sizeBytes": attrs[.size] as? Int64 ?? 2,
+          "mtime": (attrs[.modificationDate] as? Date)?.timeIntervalSince1970 ?? 0,
+        ]
+      ],
+    ]
+    try JSONSerialization.data(withJSONObject: marker).write(
+      to: registration.metadataDirectory.appendingPathComponent("\(key).admission.json"))
+  }
+
+  /// Collects everything the adapter publishes, so the SEED is observable.
+  private final class Published: @unchecked Sendable {
+    private let lock = NSLock()
+    private var states: [EGOneInstallState] = []
+    func append(_ s: EGOneInstallState) {
+      lock.lock()
+      states.append(s)
+      lock.unlock()
+    }
+    var all: [EGOneInstallState] {
+      lock.lock()
+      defer { lock.unlock() }
+      return states
+    }
+  }
+
+  /// THE cold-launch case, and the reason seed-before-observe exists.
+  ///
+  /// `addStateObserver` replays only identities the controller already knows,
+  /// and a user sitting on a prior revision with no fetch in flight has no
+  /// entry — so the observer never fires for them. The old seed was gated on
+  /// `isAdmitted`, which is false for exactly that user. Neither path
+  /// published anything, so the row kept its initial `.notInstalled` and the
+  /// paused-upgrade state was unreachable at the only moment it matters.
+  @Test func coldLaunchWithASurvivingOlderRevisionSeedsUpdatePaused() async throws {
+    let dirs = try makeDirs()
+    defer { dirs.cleanup() }
+    let registration = try EGOneDeliveryAdapterMappingTests.shardedFixtureRegistration(
+      install: dirs.install, metadata: dirs.metadata)
+    try seedSurvivingOlderRevision(registration)
+
+    let suite = "eg1-seed-\(UUID().uuidString)"
+    let adapter = EGOneDeliveryAdapter(
+      controller: ModelDeliveryController(defaults: UserDefaults(suiteName: suite)!),
+      registration: registration, version: "1.1",
+      defaults: UserDefaults(suiteName: suite)!)
+
+    let published = Published()
+    adapter.observeInstallState { published.append($0) }
+
+    let seeded = await withDeadline(seconds: 5) {
+      while true {
+        if let first = await MainActor.run(body: { published.all.first }) { return first }
+        await Task.yield()
+      }
+    }
+    #expect(
+      seeded == .updatePaused(resumable: false),
+      "a cold launch owing an upgrade must seed updatePaused, not notInstalled")
+  }
+
+  /// Two-way control on the seed: with nothing on disk the same path must
+  /// still produce `notInstalled`. Without this, a seed hard-coded to
+  /// `updatePaused` would pass the test above and show every new user a
+  /// paused-upgrade row for a model they never had.
+  @Test func coldLaunchWithNothingOnDiskSeedsNotInstalled() async throws {
+    let dirs = try makeDirs()
+    defer { dirs.cleanup() }
+    let registration = try EGOneDeliveryAdapterMappingTests.shardedFixtureRegistration(
+      install: dirs.install, metadata: dirs.metadata)
+
+    let suite = "eg1-seed-\(UUID().uuidString)"
+    let adapter = EGOneDeliveryAdapter(
+      controller: ModelDeliveryController(defaults: UserDefaults(suiteName: suite)!),
+      registration: registration, version: "1.1",
+      defaults: UserDefaults(suiteName: suite)!)
+
+    let published = Published()
+    adapter.observeInstallState { published.append($0) }
+
+    let seeded = await withDeadline(seconds: 5) {
+      while true {
+        if let first = await MainActor.run(body: { published.all.first }) { return first }
+        await Task.yield()
+      }
+    }
+    #expect(seeded == .notInstalled)
+  }
+
+  // MARK: - The download guard, through the real runtime (#2109)
+
+  /// The dead-button case, driven through a REAL `EGOneRuntime` rather than
+  /// the enum property, because the property proves the RULE while this proves
+  /// the runtime actually consults it. A state missing from `startDownload`'s
+  /// guard renders its button and silently ignores the press: no crash, no
+  /// error, no compiler complaint, and to a user indistinguishable from the
+  /// app ignoring them.
+  ///
+  /// Staged partials with no admission marker make the seed publish `.paused`,
+  /// which is the state under test. Pressing then has to MOVE the state — with
+  /// no server binary and an unreachable source the attempt fails fast, and a
+  /// failure is proof the guard was passed. A swallowed press would leave the
+  /// row sitting in `.paused` forever, which is the bug.
+  @Test func startDownloadActsWhenPaused() async throws {
+    let dirs = try makeDirs()
+    defer { dirs.cleanup() }
+    let registration = try EGOneDeliveryAdapterMappingTests.shardedFixtureRegistration(
+      install: dirs.install, metadata: dirs.metadata)
+
+    // Partials, no marker → `.paused`.
+    let staging = ModelDeliveryController.stagingDirectoryURL(for: registration)
+    try FileManager.default.createDirectory(at: staging, withIntermediateDirectories: true)
+    try Data([0x01, 0x02, 0x03]).write(to: staging.appendingPathComponent("partial.bin"))
+
+    let suite = "eg1-guard-\(UUID().uuidString)"
+    let store = try #require(UserDefaults(suiteName: suite))
+    let adapter = EGOneDeliveryAdapter(
+      controller: ModelDeliveryController(defaults: UserDefaults(suiteName: suite)!),
+      registration: registration, version: "1.1", defaults: store)
+    let runtime = EGOneRuntime(
+      manifest: EGOneManifest(
+        modelName: LLMProvider.egOneModelName, version: "v2-sharded", contextTokens: 4096,
+        promptTemplateID: "eg1-v1", minAppVersion: "0",
+        downloadURL: URL(string: "https://example.invalid/eg1.gguf")!,
+        displayVersion: "1.1"),
+      serverBinaryURL: nil, delivery: adapter)
+    defer { store.removePersistentDomain(forName: suite) }
+
+    let reachedPaused = await withDeadline(seconds: 5) {
+      while true {
+        if await MainActor.run(body: { runtime.installState == .paused }) { return true }
+        await Task.yield()
+      }
+    }
+    try #require(reachedPaused == true, "fixture did not produce the paused state under test")
+
+    runtime.startDownload()
+
+    let moved = await withDeadline(seconds: 10) {
+      while true {
+        if await MainActor.run(body: { runtime.installState != .paused }) { return true }
+        await Task.yield()
+      }
+    }
+    #expect(
+      moved == true,
+      "pressing Resume while paused did nothing — the guard swallowed the press")
+  }
+
+  /// The upgrade doors, through the real runtime. `.paused` above covers the
+  /// first-install door; these cover the two the founder directives are
+  /// actually about — a user with a working older model who is being asked to
+  /// finish or resume an upgrade. Each is a separate door and each could be
+  /// dropped from the guard independently.
+  @Test(arguments: [true, false])
+  func startDownloadActsOnBothUpdatePausedVariants(_ resumable: Bool) async throws {
+    let dirs = try makeDirs()
+    defer { dirs.cleanup() }
+    let registration = try EGOneDeliveryAdapterMappingTests.shardedFixtureRegistration(
+      install: dirs.install, metadata: dirs.metadata)
+    try seedSurvivingOlderRevision(registration)
+    if resumable {
+      let staging = ModelDeliveryController.stagingDirectoryURL(for: registration)
+      try FileManager.default.createDirectory(at: staging, withIntermediateDirectories: true)
+      try Data([0x01]).write(to: staging.appendingPathComponent("partial.bin"))
+    }
+
+    let suite = "eg1-guard-\(UUID().uuidString)"
+    let store = try #require(UserDefaults(suiteName: suite))
+    defer { store.removePersistentDomain(forName: suite) }
+    let adapter = EGOneDeliveryAdapter(
+      controller: ModelDeliveryController(defaults: UserDefaults(suiteName: suite)!),
+      registration: registration, version: "1.1", defaults: store)
+    let runtime = EGOneRuntime(
+      manifest: runtimeManifest(), serverBinaryURL: nil, delivery: adapter)
+
+    let expected = EGOneInstallState.updatePaused(resumable: resumable)
+    let reached = await withDeadline(seconds: 5) {
+      while true {
+        if await MainActor.run(body: { runtime.installState == expected }) { return true }
+        await Task.yield()
+      }
+    }
+    try #require(reached == true, "fixture did not produce \(expected)")
+
+    runtime.startDownload()
+
+    let moved = await withDeadline(seconds: 10) {
+      while true {
+        if await MainActor.run(body: { runtime.installState != expected }) { return true }
+        await Task.yield()
+      }
+    }
+    #expect(moved == true, "\(expected): the press was swallowed by the guard")
+  }
+
+  /// The other half of the seed contract: a CURRENT admitted cache must still
+  /// seed `installed`. Without this, a seed rewritten to always consult disk
+  /// predicates would show a paused-upgrade row to a user whose model is
+  /// perfectly current — the inverse of the bug and equally wrong.
+  @Test func coldLaunchWithTheCurrentRevisionAdmittedSeedsInstalled() async throws {
+    let dirs = try makeDirs()
+    defer { dirs.cleanup() }
+    let registration = try EGOneDeliveryAdapterMappingTests.shardedFixtureRegistration(
+      install: dirs.install, metadata: dirs.metadata)
+
+    // Real bytes matching the fixture manifest, then admit them in place.
+    for file in registration.manifest.files {
+      let url = registration.installDirectory.appendingPathComponent(file.resolvedInstallPath)
+      try FileManager.default.createDirectory(
+        at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+      try Data(count: Int(file.sizeBytes)).write(to: url)
+    }
+    let suite = "eg1-seed-\(UUID().uuidString)"
+    let store = try #require(UserDefaults(suiteName: suite))
+    defer { store.removePersistentDomain(forName: suite) }
+    let controller = ModelDeliveryController(defaults: UserDefaults(suiteName: suite)!)
+    let admitted = await controller.admitIfComplete(registration)
+    try #require(admitted == true, "fixture cache was not admitted, so the test proves nothing")
+
+    let adapter = EGOneDeliveryAdapter(
+      controller: controller, registration: registration, version: "1.1", defaults: store)
+    let published = Published()
+    adapter.observeInstallState { published.append($0) }
+
+    let seeded = await withDeadline(seconds: 5) {
+      while true {
+        if let first = await MainActor.run(body: { published.all.first }) { return first }
+        await Task.yield()
+      }
+    }
+    #expect(seeded == .installed(version: "1.1"))
+  }
+
+  private func runtimeManifest() -> EGOneManifest {
+    EGOneManifest(
+      modelName: LLMProvider.egOneModelName, version: "v2-sharded", contextTokens: 4096,
+      promptTemplateID: "eg1-v1", minAppVersion: "0",
+      downloadURL: URL(string: "https://example.invalid/eg1.gguf")!, displayVersion: "1.1")
+  }
+
+  /// Live truth must defeat the earlier disk seed. This is the ordering half
+  /// of seed-before-observe: the seed publishes a GUESS derived from disk, and
+  /// if it could outrank a real in-flight state the row would show a paused
+  /// upgrade over a download that is actively running.
+  ///
+  /// Deterministic via the barrier C2 already added — no new production seam.
+  /// The attempt is parked after `.preparing` publishes, so an entry provably
+  /// exists in the controller when `observeInstallState` attaches, which is
+  /// the condition that cannot otherwise be constructed without racing a real
+  /// fetch.
+  @Test func liveStateOverridesTheDiskSeedOnAttach() async throws {
+    let dirs = try makeDirs()
+    defer { dirs.cleanup() }
+    let registration = try EGOneDeliveryAdapterMappingTests.shardedFixtureRegistration(
+      install: dirs.install, metadata: dirs.metadata)
+
+    let suite = "eg1-replay-\(UUID().uuidString)"
+    let store = try #require(UserDefaults(suiteName: suite))
+    defer { store.removePersistentDomain(forName: suite) }
+    let controller = ModelDeliveryController(defaults: UserDefaults(suiteName: suite)!)
+
+    let entered = AsyncStream<Void>.makeStream()
+    let release = AsyncStream<Void>.makeStream()
+    await controller.setBeforeExistingCacheValidationForTesting {
+      entered.continuation.yield()
+      entered.continuation.finish()
+      var iterator = release.stream.makeAsyncIterator()
+      _ = await iterator.next()
+    }
+
+    async let attempt = controller.ensureModelAvailable(registration)
+
+    let didEnter = await withDeadline(seconds: 5) {
+      var iterator = entered.stream.makeAsyncIterator()
+      return await iterator.next() != nil
+    }
+    try #require(didEnter == true, "the attempt never parked, so no live entry exists")
+
+    let adapter = EGOneDeliveryAdapter(
+      controller: controller, registration: registration, version: "1.1", defaults: store)
+    let published = Published()
+    adapter.observeInstallState { published.append($0) }
+
+    // The seed lands first (disk says nothing installed), then the observer's
+    // replay of the LIVE `.preparing` state must supersede it.
+    let sawLive = await withDeadline(seconds: 5) {
+      while true {
+        if await MainActor.run(body: { published.all.last == .verifying }) { return true }
+        await Task.yield()
+      }
+    }
+
+    // Cancel BEFORE releasing so the parked attempt unwinds immediately.
+    // Letting it run to completion instead means waiting on a real network
+    // failure against an unreachable fixture host, which took 4.3 seconds
+    // against a 5 second deadline elsewhere in this file — close enough to
+    // read as an instrument fault to the next person, and slow for no
+    // coverage. Every sibling test here runs in single-digit milliseconds.
+    _ = await controller.cancel(registration.manifest.identity)
+    release.continuation.yield()
+    release.continuation.finish()
+    _ = await attempt
+
+    #expect(
+      sawLive == true,
+      "the disk seed outranked a live in-flight state; ordering is inverted")
+    #expect(
+      published.all.first == .notInstalled,
+      "the seed should still have published first, just been superseded")
+  }
+}

--- a/Tests/EnviousWisprTests/LLM/EGOneSeedAndResumeTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneSeedAndResumeTests.swift
@@ -92,7 +92,7 @@ import Testing
       }
     }
     #expect(
-      seeded == .updatePaused(resumable: false),
+      seeded == .updatePaused(resumable: false, targetVersion: "1.1"),
       "a cold launch owing an upgrade must seed updatePaused, not notInstalled")
   }
 
@@ -211,7 +211,7 @@ import Testing
     let runtime = EGOneRuntime(
       manifest: runtimeManifest(), serverBinaryURL: nil, delivery: adapter)
 
-    let expected = EGOneInstallState.updatePaused(resumable: resumable)
+    let expected = EGOneInstallState.updatePaused(resumable: resumable, targetVersion: "1.1")
     let reached = await withDeadline(seconds: 5) {
       while true {
         if await MainActor.run(body: { runtime.installState == expected }) { return true }

--- a/Tests/EnviousWisprTests/ModelDelivery/ModelDeliveryControllerTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/ModelDeliveryControllerTests.swift
@@ -1,3 +1,4 @@
+import EnviousWisprCore
 import Foundation
 import Testing
 
@@ -393,6 +394,145 @@ import Testing
     } else {
       Issue.record("unexpected outcome for B: \(b)")
     }
+  }
+
+  // MARK: - Nonisolated staging authority (#2109)
+
+  /// The extraction is only safe if it is FAITHFUL. `stagingDirectoryURL` is
+  /// now the single path authority and is called off the actor by EG-1's
+  /// synchronous install-state mapper; if it disagreed with the path the actor
+  /// itself uses, the mapper would answer questions about a directory nothing
+  /// writes to — and would answer them plausibly, always "no partials".
+  @Test func nonisolatedStagingPathMatchesWhatTheActorUses() throws {
+    let registration = try makeRegistration(files: ManifestFixture.smallFiles)
+
+    let expected = registration.metadataDirectory
+      .appendingPathComponent("staging", isDirectory: true)
+      .appendingPathComponent(registration.manifest.identity.cacheKey, isDirectory: true)
+
+    #expect(
+      ModelDeliveryController.stagingDirectoryURL(for: registration) == expected,
+      "the nonisolated path authority must produce the actor's own staging path")
+  }
+
+  /// Same faithfulness requirement for the disk read, and the two-way control
+  /// matters: assert it agrees with the actor method in BOTH directions, or a
+  /// stub that always returns false would pass the empty case.
+  @Test func nonisolatedStagedPartialsAgreesWithTheActor() async throws {
+    let registration = try makeRegistration(files: ManifestFixture.smallFiles)
+    let controller = ModelDeliveryController(
+      defaults: testDefaults(), availableDiskBytes: { _ in .max })
+
+    let staging = ModelDeliveryController.stagingDirectoryURL(for: registration)
+    try FileManager.default.createDirectory(at: staging, withIntermediateDirectories: true)
+
+    // Direction 1: nothing staged. Both must say false.
+    #expect(ModelDeliveryController.hasStagedPartialsOnDisk(registration) == false)
+    #expect(await controller.hasStagedPartials(registration) == false)
+
+    // Direction 2: real bytes. Both must say true — this is the direction an
+    // always-false stub would fail.
+    try Data([0x01, 0x02, 0x03]).write(to: staging.appendingPathComponent("chunk.bin"))
+    #expect(ModelDeliveryController.hasStagedPartialsOnDisk(registration) == true)
+    #expect(await controller.hasStagedPartials(registration) == true)
+  }
+
+  /// The nonisolated read must honour the same exclusions as the actor one,
+  /// not a simplified copy: a resume sidecar alone is not resumable content.
+  /// A drifted duplicate would report a metadata-only shell as resumable and
+  /// offer "Resume upgrade" for a download that never stored a byte.
+  @Test func nonisolatedStagedPartialsIgnoresResumeSidecarsAndEmptyFiles() throws {
+    let registration = try makeRegistration(files: ManifestFixture.smallFiles)
+    let staging = ModelDeliveryController.stagingDirectoryURL(for: registration)
+    try FileManager.default.createDirectory(at: staging, withIntermediateDirectories: true)
+
+    try Data().write(to: staging.appendingPathComponent("state.resume.json"))
+    #expect(ModelDeliveryController.hasStagedPartialsOnDisk(registration) == false)
+
+    try Data().write(to: staging.appendingPathComponent("empty.bin"))
+    #expect(
+      ModelDeliveryController.hasStagedPartialsOnDisk(registration) == false,
+      "a zero-byte file proves nothing was downloaded")
+
+    try FileManager.default.createDirectory(
+      at: staging.appendingPathComponent("Encoder.mlmodelc", isDirectory: true),
+      withIntermediateDirectories: true)
+    #expect(
+      ModelDeliveryController.hasStagedPartialsOnDisk(registration) == false,
+      "a directory entry is not staged content")
+
+    try Data([0xFF]).write(to: staging.appendingPathComponent("real.bin"))
+    #expect(ModelDeliveryController.hasStagedPartialsOnDisk(registration) == true)
+  }
+
+  /// THE regression this chunk exists for (#2109), covered deterministically.
+  ///
+  /// Before the fix the registration was cached as a side effect of deriving a
+  /// staging path, which happens only AFTER the existing-cache validation
+  /// suspends. A cancel landing in that window found no cached registration,
+  /// so the user was told a resumable download was not resumable and would
+  /// have re-fetched gigabytes they already had.
+  ///
+  /// WHY A SEAM AND NOT A TIMED WAIT. In production that window is seconds
+  /// wide (a hash pass over gigabytes); with unit fixtures it is microseconds,
+  /// so no poll can land in it. A polled version of this test was written,
+  /// mutation-controlled, and **passed against the pre-fix code** — it would
+  /// have shipped as coverage that detects nothing. The barrier parks the
+  /// attempt inside the window instead of racing it, so the test is
+  /// deterministic rather than lucky.
+  @Test func earlyCancelStillSeesStagedPartialsAsResumable() async throws {
+    let registration = try makeRegistration(files: ManifestFixture.smallFiles)
+    let identity = registration.manifest.identity
+
+    // Real staged bytes: what the user would lose if we mis-reported this.
+    let staging = ModelDeliveryController.stagingDirectoryURL(for: registration)
+    try FileManager.default.createDirectory(at: staging, withIntermediateDirectories: true)
+    try Data([0x01, 0x02, 0x03]).write(to: staging.appendingPathComponent("partial.bin"))
+
+    let controller = ModelDeliveryController(
+      defaults: testDefaults(), availableDiskBytes: { _ in .max })
+
+    // Park the attempt inside the window, hand control back, and hold until
+    // the cancel has been observed.
+    let entered = AsyncStream<Void>.makeStream()
+    let release = AsyncStream<Void>.makeStream()
+    await controller.setBeforeExistingCacheValidationForTesting {
+      entered.continuation.yield()
+      entered.continuation.finish()
+      var iterator = release.stream.makeAsyncIterator()
+      _ = await iterator.next()
+    }
+
+    async let attempt = controller.ensureModelAvailable(registration)
+
+    // Wait for the attempt to actually be parked in the window under test.
+    // BOUNDED: an unbounded wait on a signal that never arrives hangs CI
+    // instead of reporting this test, which is the one failure mode a
+    // regression test must not have. The deadline decides nothing — it only
+    // converts a broken signal path into a loud failure.
+    let didEnter = await withDeadline(seconds: 5) {
+      var iterator = entered.stream.makeAsyncIterator()
+      return await iterator.next() != nil
+    }
+    try #require(didEnter == true, "the attempt never parked in the validation window")
+
+    // Same reasoning for the release: if cancel itself regresses and never
+    // returns, this frees the parked attempt so the suite fails rather than
+    // wedging. Cancelled immediately on the happy path.
+    let deadlineRelease = Task {
+      try? await Task.sleep(for: .seconds(5))  // deadline-fallback: frees a wedged cancel path
+      release.continuation.yield()
+      release.continuation.finish()
+    }
+    let outcome = await controller.cancel(identity)
+    deadlineRelease.cancel()
+    release.continuation.yield()
+    release.continuation.finish()
+    _ = await attempt
+
+    #expect(
+      outcome == .cancelled(resumable: true),
+      "a cancel inside the existing-cache validation window must still see the staged partials")
   }
 
   @Test func cancelWithNothingInFlight() async throws {

--- a/Tests/EnviousWisprTests/ModelDelivery/ShippedModelNamesTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/ShippedModelNamesTests.swift
@@ -185,4 +185,67 @@ import Testing
       Self.firstCollision([stable, stableNewerRevision].map(Self.uniquenessKey)) != nil,
       "two identities differing only by revision must collide, or the sweep could delete a live download")
   }
+
+  // MARK: - Variant suffix safety (whole-diff review)
+
+  /// The staging match ends with `hasSuffix("-\(variant)")`, so a variant that
+  /// is a SUFFIX of another is ambiguous in the same way a prefix name is:
+  /// sweeping `foo` would also match a directory for `bar-foo` and delete its
+  /// resumable bytes. The family+name+variant uniqueness freeze does not catch
+  /// it, because those variants genuinely differ.
+  @Test func noShippedVariantIsASuffixOfAnotherForTheSameModel() {
+    for (key, variants) in ShippedModelNames.variants {
+      let sorted = Array(variants).sorted()
+      for a in sorted {
+        #expect(a.isEmpty == false, "\(key): an empty variant makes the suffix match everything")
+        for b in sorted where a != b {
+          #expect(
+            b.hasSuffix(a) == false,
+            "\(key): variant \"\(a)\" is a suffix of \"\(b)\", so a sweep for one would match the other's staging and delete its resumable bytes")
+        }
+      }
+    }
+  }
+
+  /// Two-way control, driving the same rule against the collision it forbids.
+  @Test func theVariantSuffixRuleRejectsAnOverlappingPair() {
+    let colliding = ["foo", "bar-foo"].sorted()
+    var caught = false
+    for a in colliding {
+      for b in colliding where a != b {
+        if b.hasSuffix(a) { caught = true }
+      }
+    }
+    #expect(caught, "the suffix rule cannot detect the overlap it exists to forbid")
+
+    // And it must NOT fire on the real shipped WhisperKit pair, which is
+    // neither a prefix nor a suffix of the other.
+    let shipped = ["openai_whisper-large-v3-v20240930_turbo", "openai_whisper-small_216MB"]
+    for a in shipped {
+      for b in shipped where a != b {
+        #expect(b.hasSuffix(a) == false, "the shipped pair must not be flagged")
+      }
+    }
+  }
+
+  /// The variant registry must not drift from what ships.
+  @Test func everyBundledVariantIsRegistered() throws {
+    let repoRoot = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+    let resourceDir = repoRoot.appendingPathComponent("Sources/EnviousWispr/Resources")
+    for resource in [
+      "eg1-delivery-manifest", "parakeet-delivery-manifest",
+      "whisperkit-delivery-manifest", "whisperkit-preview-delivery-manifest",
+    ] {
+      let url = resourceDir.appendingPathComponent("\(resource).json")
+      let identity = try DeliveryManifest.load(from: try Data(contentsOf: url)).identity
+      let key = ShippedModelNames.variantKey(family: identity.family, name: identity.name)
+      #expect(
+        ShippedModelNames.variants[key]?.contains(identity.variant) == true,
+        "\(resource) ships variant \(identity.variant) for \(key), which is not registered")
+    }
+  }
 }

--- a/Tests/EnviousWisprTests/ModelDelivery/ShippedModelNamesTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/ShippedModelNamesTests.swift
@@ -1,0 +1,188 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprModelDelivery
+
+/// Guards the assumption the superseded-artefact identification rests on
+/// (#2109, #2120).
+///
+/// `cacheKey` flattens name and revision with no injective boundary, so
+/// prefix/suffix parsing can only distinguish models while no name within a
+/// family is a prefix of another. Rather than detect that at runtime, it is
+/// made impossible to author: the day someone adds a colliding name, this
+/// fails.
+@Suite struct ShippedModelNamesTests {
+
+  /// THE guard. Runs over every name EVER shipped, not the current bundle,
+  /// because staging directories and admission markers outlive app versions:
+  /// a build carrying only `eg-1` can still meet leftover `eg-1-mini-*`
+  /// entries written by a build that shipped both.
+  @Test func noShippedNameIsAPrefixOfAnotherInTheSameFamily() {
+    for family in ShippedModelNames.families {
+      let names = Array(ShippedModelNames.everShipped(in: family)).sorted()
+      for a in names {
+        for b in names where a != b {
+          #expect(
+            b.hasPrefix(a) == false,
+            "\(family.rawValue): \"\(a)\" is a prefix of \"\(b)\", so superseded-artefact identification cannot tell them apart and one could delete the other's bytes")
+        }
+      }
+    }
+  }
+
+  /// Two-way control. The guard above passes trivially on a list with no
+  /// collisions, which is every list we ship — so it proves nothing until it
+  /// is shown to REJECT one. This constructs the collision the real registry
+  /// must never contain.
+  @Test func theGuardRejectsACollidingPair() {
+    let colliding = ["eg-1", "eg-1-mini"].sorted()
+    var caught = false
+    for a in colliding {
+      for b in colliding where a != b {
+        if b.hasPrefix(a) { caught = true }
+      }
+    }
+    #expect(caught, "the prefix rule cannot detect the collision it exists to forbid")
+  }
+
+  /// The registry must not drift from what actually ships. A bundled manifest
+  /// naming a model absent from this list means the guard above is reasoning
+  /// over a stale set and silently covers less than it appears to.
+  @Test func everyBundledManifestIdentityIsRegistered() throws {
+    // Read from the repo, not a bundle: these are APP-target resources and are
+    // absent from the test bundle. Same approach as the shipped-manifest
+    // assertion in `EGOneManifestTests`.
+    let repoRoot = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()  // ModelDelivery
+      .deletingLastPathComponent()  // EnviousWisprTests
+      .deletingLastPathComponent()  // Tests
+      .deletingLastPathComponent()  // repo root
+    let resourceDir = repoRoot.appendingPathComponent("Sources/EnviousWispr/Resources")
+
+    for resource in [
+      "eg1-delivery-manifest", "parakeet-delivery-manifest",
+      "whisperkit-delivery-manifest", "whisperkit-preview-delivery-manifest",
+    ] {
+      let url = resourceDir.appendingPathComponent("\(resource).json")
+      let manifest = try DeliveryManifest.load(from: try Data(contentsOf: url))
+      let identity = manifest.identity
+      // Checks `current`, deliberately, not `everShipped`: a still-bundled
+      // name wrongly moved to `retired` would pass the looser check while the
+      // registry claimed we no longer ship it.
+      #expect(
+        ShippedModelNames.current[identity.family]?.contains(identity.name) == true,
+        "\(resource) ships \(identity.family.rawValue)/\(identity.name), which is not in current")
+    }
+  }
+
+  /// Append-only is a property nothing enforces unless a test names the past
+  /// members. The coverage test above detects a MISSING current name; it
+  /// cannot detect a DELETED tombstone, and deleting one silently reopens the
+  /// historical case the registry exists to close.
+  @Test func theHistoricalMinimumIsNeverReduced() {
+    let minimum: [ModelFamily: Set<String>] = [
+      .egOne: ["eg-1"],
+      .parakeet: ["parakeet-tdt-0.6b-v3-coreml"],
+      .whisperKit: ["whisperkit-coreml"],
+    ]
+    // EXACT equality, not containment. Containment would let the registry GROW
+    // without this minimum growing with it, so a name added today could be
+    // silently deleted tomorrow with nothing failing. Equality forces both to
+    // move together, which makes a deletion visible in the diff as a shrinking
+    // minimum rather than a one-line removal.
+    #expect(ShippedModelNames.families == Set(minimum.keys))
+    for family in ShippedModelNames.families {
+      #expect(
+        ShippedModelNames.everShipped(in: family) == minimum[family, default: []],
+        "\(family.rawValue): the registry and its historical minimum disagree; entries are tombstoned, never deleted, because removing one reopens the case it was added to close")
+    }
+  }
+
+  // MARK: - Variant uniqueness (#2109)
+
+  /// The OTHER assumption the sweep rests on, and the one that nearly bit.
+  ///
+  /// "Superseded" means same family, same name, SAME VARIANT, different
+  /// revision. WhisperKit ships stable and Preview with the same family, the
+  /// same name AND the same revision, separated only by variant — so if two
+  /// registrations ever differed only by REVISION, the sweep would read one as
+  /// a superseded copy of the other and delete an in-flight download.
+  ///
+  /// The plan's prose originally omitted variant from that definition. The
+  /// inherited prefix/suffix mechanism carries it anyway, so the code was
+  /// correct by accident of an implementation detail rather than by statement.
+  /// This makes the assumption explicit and enforced.
+  /// The uniqueness key the sweep's notion of "superseded" depends on.
+  /// Revision is deliberately EXCLUDED: two registrations differing only by
+  /// revision are exactly the collision that must be forbidden.
+  static func uniquenessKey(_ identity: ModelIdentity) -> String {
+    [identity.family.rawValue, identity.name, identity.variant].joined(separator: "|")
+  }
+
+  /// Returns the first duplicate key, or nil. Shared by the real check and its
+  /// control so the control exercises THIS logic rather than a restatement of
+  /// it — a control that re-implements the rule proves only that the test file
+  /// is self-consistent.
+  static func firstCollision(_ keys: [String]) -> String? {
+    var seen: Set<String> = []
+    for key in keys {
+      if seen.contains(key) { return key }
+      seen.insert(key)
+    }
+    return nil
+  }
+
+  @Test func noTwoBundledRegistrationsShareFamilyNameAndVariant() throws {
+    let repoRoot = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+    let resourceDir = repoRoot.appendingPathComponent("Sources/EnviousWispr/Resources")
+
+    var keys: [String] = []
+    for resource in [
+      "eg1-delivery-manifest", "parakeet-delivery-manifest",
+      "whisperkit-delivery-manifest", "whisperkit-preview-delivery-manifest",
+    ] {
+      let url = resourceDir.appendingPathComponent("\(resource).json")
+      let identity = try DeliveryManifest.load(from: try Data(contentsOf: url)).identity
+      keys.append(Self.uniquenessKey(identity))
+    }
+
+    #expect(
+      Self.firstCollision(keys) == nil,
+      "two bundled manifests share family+name+variant, so the staging sweep would treat one as a superseded revision of the other and delete a live download")
+    #expect(keys.count == 4, "expected four bundled registrations, got \(keys.count)")
+  }
+
+  /// Two-way control that drives the REAL detector. Every set we ship is
+  /// distinct, so the check above passes trivially and proves nothing until
+  /// `firstCollision` is shown to FIRE on the shape it forbids.
+  ///
+  /// The shipped stable and Preview pair differ only by VARIANT and must stay
+  /// distinct; two registrations differing only by REVISION collapse to the
+  /// same key and must be caught. Both directions asserted, because a key that
+  /// caught everything would break Preview and a key that caught nothing would
+  /// let the sweep delete a live download.
+  @Test func theCollisionDetectorFiresOnRevisionOnlyDifferences() {
+    let stable = ModelIdentity(
+      family: .whisperKit, name: "whisperkit-coreml", revision: "aaa",
+      variant: "openai_whisper-large-v3-v20240930_turbo", runtimeABI: "abi")
+    let preview = ModelIdentity(
+      family: .whisperKit, name: "whisperkit-coreml", revision: "aaa",
+      variant: "openai_whisper-small_216MB", runtimeABI: "abi")
+    // Differs from `stable` ONLY by revision: the forbidden shape.
+    let stableNewerRevision = ModelIdentity(
+      family: .whisperKit, name: "whisperkit-coreml", revision: "bbb",
+      variant: "openai_whisper-large-v3-v20240930_turbo", runtimeABI: "abi")
+
+    #expect(
+      Self.firstCollision([stable, preview].map(Self.uniquenessKey)) == nil,
+      "the shipped stable and Preview pair differ only by variant and must NOT collide")
+
+    #expect(
+      Self.firstCollision([stable, stableNewerRevision].map(Self.uniquenessKey)) != nil,
+      "two identities differing only by revision must collide, or the sweep could delete a live download")
+  }
+}

--- a/Tests/EnviousWisprTests/ModelDelivery/SupersededStagingSweepTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/SupersededStagingSweepTests.swift
@@ -1,0 +1,499 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprModelDelivery
+
+/// The sweep that reclaims abandoned partial downloads (#2109, #2119).
+///
+/// This is the only code in the change that DELETES bytes from a user's disk,
+/// so every test here is paired: one asserting something is removed, one
+/// asserting something adjacent survives. A sweep that deleted nothing and a
+/// sweep that deleted everything both pass a one-sided suite.
+@Suite struct SupersededStagingSweepTests {
+  init() {
+    // Deterministic network, matching the sibling controller suite. Without
+    // it the rollback test makes REAL connection attempts to the unreachable
+    // fixture hosts and the suite takes ~9.6s instead of milliseconds — slow
+    // for no coverage, and dependent on the machine's DNS behaviour.
+    ChunkAppendDelegate.protocolClassesForTesting = [DeliveryStubProtocol.self]
+  }
+
+
+  private func makeDirs() throws -> (install: URL, metadata: URL, cleanup: () -> Void) {
+    let root = FileManager.default.temporaryDirectory
+      .appendingPathComponent("sweep-\(UUID().uuidString)", isDirectory: true)
+    let install = root.appendingPathComponent("install", isDirectory: true)
+    let metadata = root.appendingPathComponent("metadata", isDirectory: true)
+    try FileManager.default.createDirectory(at: install, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: metadata, withIntermediateDirectories: true)
+    return (install, metadata, { try? FileManager.default.removeItem(at: root) })
+  }
+
+  /// A staging directory with real bytes in it, named by an explicit cache key.
+  @discardableResult
+  private func seedStaging(_ metadata: URL, key: String) throws -> URL {
+    let dir = metadata
+      .appendingPathComponent("staging", isDirectory: true)
+      .appendingPathComponent(key, isDirectory: true)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    try Data([0x01, 0x02, 0x03]).write(to: dir.appendingPathComponent("partial.bin"))
+    return dir
+  }
+
+  private func exists(_ url: URL) -> Bool {
+    FileManager.default.fileExists(atPath: url.path)
+  }
+
+  private func identity(
+    family: ModelFamily = .egOne, name: String = "eg-1",
+    revision: String, variant: String = "q5km"
+  ) -> ModelIdentity {
+    ModelIdentity(
+      family: family, name: name, revision: revision, variant: variant, runtimeABI: "abi")
+  }
+
+  // MARK: - Identification
+
+  /// The core pair. A superseded revision is found; the CURRENT one never is.
+  /// Deleting the current revision's staging would destroy exactly the
+  /// partials that make Resume work.
+  @Test func findsSupersededRevisionsAndNeverTheCurrentOne() throws {
+    let dirs = try makeDirs()
+    defer { dirs.cleanup() }
+    let current = identity(revision: "v3-eg2")
+
+    try seedStaging(dirs.metadata, key: "eg_one-eg-1-v2-sharded-q5km")
+    try seedStaging(dirs.metadata, key: current.cacheKey)
+
+    let found = PriorRevisionAdmission.supersededStagingURLs(
+      for: current, metadataDirectory: dirs.metadata)
+
+    #expect(found.count == 1)
+    #expect(found.first?.lastPathComponent == "eg_one-eg-1-v2-sharded-q5km")
+  }
+
+  /// A different FAMILY sharing the metadata directory must be untouched. All
+  /// engines share one `staging/` root, so a sweep run for EG-1 that matched
+  /// loosely would delete Parakeet's or WhisperKit's work.
+  @Test func ignoresOtherFamiliesInTheSharedStagingRoot() throws {
+    let dirs = try makeDirs()
+    defer { dirs.cleanup() }
+
+    try seedStaging(dirs.metadata, key: "parakeet-parakeet-tdt-0.6b-v3-coreml-abc123-int8")
+    try seedStaging(
+      dirs.metadata, key: "whisper_kit-whisperkit-coreml-def456-openai_whisper-small_216MB")
+
+    let found = PriorRevisionAdmission.supersededStagingURLs(
+      for: identity(revision: "v3-eg2"), metadataDirectory: dirs.metadata)
+
+    #expect(found.isEmpty, "an EG-1 sweep must not see other families")
+  }
+
+  /// THE case that nearly shipped wrong. WhisperKit stable and Preview share
+  /// family, name AND revision, and differ only by variant. A sweep for one
+  /// must never see the other, or it deletes a live download.
+  @Test func neverMatchesADifferentVariantOfTheSameModel() throws {
+    let dirs = try makeDirs()
+    defer { dirs.cleanup() }
+
+    let stable = identity(
+      family: .whisperKit, name: "whisperkit-coreml", revision: "aaa",
+      variant: "openai_whisper-large-v3-v20240930_turbo")
+    let previewKey = "whisper_kit-whisperkit-coreml-aaa-openai_whisper-small_216MB"
+    try seedStaging(dirs.metadata, key: previewKey)
+
+    let found = PriorRevisionAdmission.supersededStagingURLs(
+      for: stable, metadataDirectory: dirs.metadata)
+
+    #expect(found.isEmpty, "Preview differs only by variant and is a LIVE model, not a superseded one")
+  }
+
+  /// The hyphen-ambiguous real key, which is why the revision cannot be
+  /// recovered by splitting on `-`.
+  @Test func handlesTheHyphenAmbiguousShippedKey() throws {
+    let dirs = try makeDirs()
+    defer { dirs.cleanup() }
+
+    try seedStaging(dirs.metadata, key: "eg_one-eg-1-v2-sharded-q5km")
+    let found = PriorRevisionAdmission.supersededStagingURLs(
+      for: identity(revision: "v3-eg2"), metadataDirectory: dirs.metadata)
+
+    #expect(found.count == 1, "both name and revision contain hyphens; prefix/suffix must still work")
+  }
+
+  /// An unreadable or absent staging root yields nothing, so the caller
+  /// deletes nothing. "I could not look" must never mean "delete freely".
+  @Test func anAbsentStagingRootFindsNothing() throws {
+    let dirs = try makeDirs()
+    defer { dirs.cleanup() }
+    let found = PriorRevisionAdmission.supersededStagingURLs(
+      for: identity(revision: "v3-eg2"), metadataDirectory: dirs.metadata)
+    #expect(found.isEmpty)
+  }
+
+  // MARK: - Deletion, through the real controller
+
+  private func makeRegistration(
+    _ metadata: URL, install: URL, revision: String, variant: String = "q5km"
+  ) throws -> DeliveryRegistration {
+    // The fixture exposes identity through `mutate`, not a parameter, so the
+    // EG-1 shape used throughout these tests is set there.
+    let manifest = try DeliveryManifest.load(
+      from: ManifestFixture.manifestJSON(
+        files: ManifestFixture.smallFiles,
+        sources: [["id": "our_copy", "baseURL": "https://sweep.invalid.example/"]],
+        family: "eg_one",
+        mutate: { object in
+          object["identity"] = [
+            "family": "eg_one", "name": "eg-1", "revision": revision, "variant": variant,
+            "runtimeABI": "abi",
+          ]
+        }))
+    return DeliveryRegistration(
+      manifest: manifest, installDirectory: install, metadataDirectory: metadata)
+  }
+
+  /// THE reclamation, end to end: a superseded directory is actually removed
+  /// from disk while the current revision's partials survive. Both halves in
+  /// one test, because a sweep that deletes everything and one that deletes
+  /// nothing each pass half of this.
+  @Test func sweepRemovesSupersededStagingAndKeepsTheCurrent() async throws {
+    let dirs = try makeDirs()
+    defer { dirs.cleanup() }
+    let registration = try makeRegistration(dirs.metadata, install: dirs.install, revision: "v3-eg2")
+
+    let superseded = try seedStaging(dirs.metadata, key: "eg_one-eg-1-v2-sharded-q5km")
+    let current = try seedStaging(dirs.metadata, key: registration.manifest.identity.cacheKey)
+    try #require(exists(superseded) && exists(current), "fixture did not stage both directories")
+
+    let controller = ModelDeliveryController(
+      defaults: UserDefaults(suiteName: "sweep-\(UUID().uuidString)")!,
+      availableDiskBytes: { _ in .max })
+    await controller.sweepSupersededStaging(registration)
+
+    #expect(exists(superseded) == false, "the superseded revision's bytes were not reclaimed")
+    #expect(exists(current) == true, "the current revision's partials were destroyed, breaking Resume")
+  }
+
+  /// Another family's staging in the SHARED root must survive an EG-1 sweep.
+  /// All engines write under one `staging/`, so a loose match here deletes
+  /// another engine's work.
+  @Test func sweepLeavesOtherFamiliesAlone() async throws {
+    let dirs = try makeDirs()
+    defer { dirs.cleanup() }
+    let registration = try makeRegistration(dirs.metadata, install: dirs.install, revision: "v3-eg2")
+
+    let parakeet = try seedStaging(
+      dirs.metadata, key: "parakeet-parakeet-tdt-0.6b-v3-coreml-abc-int8")
+    let preview = try seedStaging(
+      dirs.metadata, key: "whisper_kit-whisperkit-coreml-aaa-openai_whisper-small_216MB")
+    let superseded = try seedStaging(dirs.metadata, key: "eg_one-eg-1-v2-sharded-q5km")
+
+    let controller = ModelDeliveryController(
+      defaults: UserDefaults(suiteName: "sweep-\(UUID().uuidString)")!,
+      availableDiskBytes: { _ in .max })
+    await controller.sweepSupersededStaging(registration)
+
+    #expect(exists(superseded) == false, "the EG-1 sweep did not do its job")
+    #expect(exists(parakeet) == true, "Parakeet's staging was deleted by an EG-1 sweep")
+    #expect(exists(preview) == true, "WhisperKit Preview's staging was deleted by an EG-1 sweep")
+  }
+
+  /// Nothing to do must mean nothing done. A sweep with no superseded
+  /// candidates must not touch the directory at all.
+  @Test func sweepWithNothingSupersededIsANoOp() async throws {
+    let dirs = try makeDirs()
+    defer { dirs.cleanup() }
+    let registration = try makeRegistration(dirs.metadata, install: dirs.install, revision: "v3-eg2")
+    let current = try seedStaging(dirs.metadata, key: registration.manifest.identity.cacheKey)
+
+    let controller = ModelDeliveryController(
+      defaults: UserDefaults(suiteName: "sweep-\(UUID().uuidString)")!,
+      availableDiskBytes: { _ in .max })
+    await controller.sweepSupersededStaging(registration)
+
+    #expect(exists(current) == true)
+  }
+
+  // MARK: - Liveness protection
+
+  /// THE test standing between a running download and deletion.
+  ///
+  /// A superseded-looking revision that is ACTUALLY BEING FETCHED right now
+  /// must survive. This is reachable in production: a user on v1 starts the v2
+  /// download, an app update ships pinning v3, and the launch sweep for v3 sees
+  /// v2 as superseded while v2's fetch is still in flight.
+  ///
+  /// Deterministic via the barrier C2 added — the attempt is PARKED inside the
+  /// validation window, so it provably has a live task when the sweep runs,
+  /// with no race to lose.
+  @Test func sweepNeverDeletesStagingForAnAttemptInFlight() async throws {
+    let dirs = try makeDirs()
+    defer { dirs.cleanup() }
+
+    let inFlight = try makeRegistration(dirs.metadata, install: dirs.install, revision: "v2-sharded")
+    let current = try makeRegistration(dirs.metadata, install: dirs.install, revision: "v3-eg2")
+
+    let inFlightStaging = try seedStaging(
+      dirs.metadata, key: inFlight.manifest.identity.cacheKey)
+    let deadStaging = try seedStaging(dirs.metadata, key: "eg_one-eg-1-v1-legacy-q5km")
+
+    let controller = ModelDeliveryController(
+      defaults: UserDefaults(suiteName: "sweep-\(UUID().uuidString)")!,
+      availableDiskBytes: { _ in .max })
+
+    // Park v2's attempt inside the validation window so it holds a live task.
+    let entered = AsyncStream<Void>.makeStream()
+    let release = AsyncStream<Void>.makeStream()
+    await controller.setBeforeExistingCacheValidationForTesting {
+      entered.continuation.yield()
+      entered.continuation.finish()
+      var iterator = release.stream.makeAsyncIterator()
+      _ = await iterator.next()
+    }
+    async let attempt = controller.ensureModelAvailable(inFlight)
+
+    let didEnter = await withDeadline(seconds: 5) {
+      var iterator = entered.stream.makeAsyncIterator()
+      return await iterator.next() != nil
+    }
+    try #require(didEnter == true, "v2's attempt never parked, so nothing is in flight")
+
+    // Sweep for v3. v2 LOOKS superseded and is being fetched.
+    await controller.sweepSupersededStaging(current)
+
+    #expect(
+      exists(inFlightStaging) == true,
+      "the sweep deleted staging for a download that is actively running")
+    #expect(
+      exists(deadStaging) == false,
+      "the sweep protected everything, so it is not doing its job")
+
+    _ = await controller.cancel(inFlight.manifest.identity)
+    release.continuation.yield()
+    release.continuation.finish()
+    _ = await attempt
+  }
+
+  /// The other half, and the reason entry-presence is not liveness: entries
+  /// are RETAINED after their task completes. Keying protection on an entry
+  /// existing would shield long-dead revisions forever and quietly turn the
+  /// sweep into a no-op.
+  @Test func aCompletedEntryDoesNotProtectItsStaging() async throws {
+    let dirs = try makeDirs()
+    defer { dirs.cleanup() }
+
+    let old = try makeRegistration(dirs.metadata, install: dirs.install, revision: "v2-sharded")
+    let current = try makeRegistration(dirs.metadata, install: dirs.install, revision: "v3-eg2")
+    let oldStaging = try seedStaging(dirs.metadata, key: old.manifest.identity.cacheKey)
+
+    // Disk preflight rejects instantly, which is all this test needs: a
+    // COMPLETED attempt leaving a retained entry with no live task. Running a
+    // real fetch to completion instead cost ~3.8s of retry and failover for no
+    // extra coverage — the entry is retained either way.
+    let controller = ModelDeliveryController(
+      defaults: UserDefaults(suiteName: "sweep-\(UUID().uuidString)")!,
+      availableDiskBytes: { _ in 1 })
+
+    _ = await controller.ensureModelAvailable(old)
+
+    await controller.sweepSupersededStaging(current)
+
+    #expect(
+      exists(oldStaging) == false,
+      "a retained entry with no live task protected staging, so the sweep never reclaims anything")
+  }
+
+  // MARK: - The four remaining plan controls
+
+  /// A regular FILE whose name matches must survive. The sweep deletes
+  /// whatever identification returns, so a name match alone must not
+  /// authorise deletion — staging is always a directory.
+  @Test func aMatchingRegularFileIsNeverTreatedAsStaging() throws {
+    let dirs = try makeDirs()
+    defer { dirs.cleanup() }
+    let staging = dirs.metadata.appendingPathComponent("staging", isDirectory: true)
+    try FileManager.default.createDirectory(at: staging, withIntermediateDirectories: true)
+
+    // Same name a superseded staging directory would have, but a file.
+    let impostor = staging.appendingPathComponent("eg_one-eg-1-v2-sharded-q5km")
+    try Data([0xFF]).write(to: impostor)
+
+    let found = PriorRevisionAdmission.supersededStagingURLs(
+      for: identity(revision: "v3-eg2"), metadataDirectory: dirs.metadata)
+
+    #expect(found.isEmpty, "a regular file matched the staging pattern and would have been deleted")
+    #expect(exists(impostor), "the file was destroyed")
+  }
+
+  /// The REAL shipped pair, both directions, with their actual cache keys
+  /// rather than synthetic ones. Stable and Preview differ only by variant and
+  /// each must be invisible to the other's sweep.
+  @Test func theShippedWhisperKitPairIsMutuallyInvisible() throws {
+    let dirs = try makeDirs()
+    defer { dirs.cleanup() }
+
+    // Loaded from the COMMITTED manifests, not copied literals: a literal
+    // drifts silently the day either manifest is re-pinned, and this test
+    // would then assert something about a pair we no longer ship.
+    let repoRoot = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+    let resourceDir = repoRoot.appendingPathComponent("Sources/EnviousWispr/Resources")
+    func shippedIdentity(_ resource: String) throws -> ModelIdentity {
+      let url = resourceDir.appendingPathComponent("\(resource).json")
+      return try DeliveryManifest.load(from: try Data(contentsOf: url)).identity
+    }
+    let stable = try shippedIdentity("whisperkit-delivery-manifest")
+    let preview = try shippedIdentity("whisperkit-preview-delivery-manifest")
+    // Equal REVISIONS is part of "differ only by variant" and is the half that
+    // makes this pair dangerous: same family, same name, same revision means
+    // only the variant separates them in the cache key.
+    try #require(
+      stable.family == preview.family && stable.name == preview.name
+        && stable.revision == preview.revision && stable.variant != preview.variant,
+      "the shipped pair no longer differs ONLY by variant, so this test no longer covers that case")
+
+    try seedStaging(dirs.metadata, key: stable.cacheKey)
+    try seedStaging(dirs.metadata, key: preview.cacheKey)
+
+    #expect(
+      PriorRevisionAdmission.supersededStagingURLs(
+        for: stable, metadataDirectory: dirs.metadata
+      ).isEmpty,
+      "a stable sweep saw Preview's staging")
+    #expect(
+      PriorRevisionAdmission.supersededStagingURLs(
+        for: preview, metadataDirectory: dirs.metadata
+      ).isEmpty,
+      "a Preview sweep saw stable's staging")
+  }
+
+  /// Same family, DIFFERENT name. The prefix technique is only sound while no
+  /// name is a prefix of another, which `ShippedModelNames` freezes; this
+  /// asserts the runtime half of that contract.
+  @Test func adifferentNameInTheSameFamilySurvives() throws {
+    let dirs = try makeDirs()
+    defer { dirs.cleanup() }
+
+    let other = try seedStaging(dirs.metadata, key: "eg_one-other-model-v1-q5km")
+    let superseded = try seedStaging(dirs.metadata, key: "eg_one-eg-1-v2-sharded-q5km")
+
+    let found = PriorRevisionAdmission.supersededStagingURLs(
+      for: identity(revision: "v3-eg2"), metadataDirectory: dirs.metadata)
+
+    #expect(found.count == 1, "expected only eg-1's superseded revision")
+    #expect(found.first?.lastPathComponent == "eg_one-eg-1-v2-sharded-q5km")
+    #expect(exists(other), "a different model in the same family was matched")
+  }
+
+  /// A DRAINING attempt is protected too. `cancel` moves the task to
+  /// `drainingTask` and it keeps writing until its URLSession delegate
+  /// finishes; deleting underneath it is the same damage as deleting a live
+  /// one. The sweep checks both fields and only `activeTask` was covered.
+  @Test func sweepProtectsADrainingAttempt() async throws {
+    let dirs = try makeDirs()
+    defer { dirs.cleanup() }
+
+    let draining = try makeRegistration(dirs.metadata, install: dirs.install, revision: "v2-sharded")
+    let current = try makeRegistration(dirs.metadata, install: dirs.install, revision: "v3-eg2")
+    let drainingStaging = try seedStaging(dirs.metadata, key: draining.manifest.identity.cacheKey)
+
+    let controller = ModelDeliveryController(
+      defaults: UserDefaults(suiteName: "sweep-\(UUID().uuidString)")!,
+      availableDiskBytes: { _ in .max })
+
+    let entered = AsyncStream<Void>.makeStream()
+    let release = AsyncStream<Void>.makeStream()
+    await controller.setBeforeExistingCacheValidationForTesting {
+      entered.continuation.yield()
+      entered.continuation.finish()
+      var iterator = release.stream.makeAsyncIterator()
+      _ = await iterator.next()
+    }
+    async let attempt = controller.ensureModelAvailable(draining)
+    let didEnter = await withDeadline(seconds: 5) {
+      var iterator = entered.stream.makeAsyncIterator()
+      return await iterator.next() != nil
+    }
+    try #require(didEnter == true, "the attempt never parked")
+
+    // `cancel` moves the task from `activeTask` to `drainingTask` and then
+    // awaits the drain. A bare `Task.yield()` does NOT prove that move
+    // happened, so the sweep could have been protected by `activeTask` and the
+    // draining branch never exercised — the test would pass while covering the
+    // wrong field. Park until the controller reports no active task for the
+    // identity, which is only true once the move has landed.
+    async let cancelled = controller.cancel(draining.manifest.identity)
+    let movedToDraining = await withDeadline(seconds: 5) {
+      while true {
+        if Task.isCancelled { return false }
+        if await controller.isDrainingForTesting(draining.manifest.identity) { return true }
+        await Task.yield()
+      }
+    }
+    try #require(movedToDraining == true, "never observed the LIVE draining window, so the draining branch is untested")
+
+    await controller.sweepSupersededStaging(current)
+    #expect(
+      exists(drainingStaging),
+      "the sweep deleted staging for an attempt that is still draining")
+
+    release.continuation.yield()
+    release.continuation.finish()
+    _ = await cancelled
+    _ = await attempt
+
+    // And once the drain COMPLETES, the protection must lift — otherwise a
+    // cancelled-and-abandoned download is shielded for the process lifetime,
+    // which is exactly the population #2119 exists to reclaim.
+    await controller.sweepSupersededStaging(current)
+    #expect(
+      exists(drainingStaging) == false,
+      "a finished drain still protected its staging, so an abandoned download is never reclaimed")
+  }
+
+  /// The accepted cost, asserted rather than assumed: after a superseded
+  /// revision's staging is reclaimed, re-pinning it later must still SUCCEED
+  /// by refetching. Deleting cache may cost bytes; it must never leave a
+  /// revision uninstallable.
+  @Test func aSweptRevisionCanStillBeFetchedAgain() async throws {
+    let dirs = try makeDirs()
+    defer { dirs.cleanup() }
+
+    let old = try makeRegistration(dirs.metadata, install: dirs.install, revision: "v2-sharded")
+    let current = try makeRegistration(dirs.metadata, install: dirs.install, revision: "v3-eg2")
+    let oldStaging = try seedStaging(dirs.metadata, key: old.manifest.identity.cacheKey)
+
+    let controller = ModelDeliveryController(
+      defaults: UserDefaults(suiteName: "sweep-\(UUID().uuidString)")!,
+      availableDiskBytes: { _ in .max })
+    await controller.sweepSupersededStaging(current)
+    try #require(exists(oldStaging) == false, "the sweep did not reclaim it, so this proves nothing")
+
+    // Prove it ADMITS, not merely that it fails in a tolerable way. Accepting
+    // a failure here would pass even if the swept revision were permanently
+    // uninstallable, which is the exact outcome this test exists to rule out.
+    // Bodies are served for every manifest file so the refetch can succeed.
+    // Serve the fixture's REAL bytes. Zero-filled bodies of the right length
+    // pass Content-Length and fail the sha256 the manifest pins — which the
+    // strengthened assertion caught immediately, and the previous
+    // failure-tolerant version would have swallowed.
+    DeliveryStubProtocol.reset()
+    for file in ManifestFixture.smallFiles {
+      DeliveryStubProtocol.enqueue(
+        url: "https://sweep.invalid.example/\(file.path)",
+        .init(
+          status: 200,
+          headers: ["Content-Length": String(file.content.count)],
+          body: file.content))
+    }
+    let outcome = await controller.ensureModelAvailable(old)
+    #expect(
+      outcome == .admitted,
+      "a swept revision must still install by refetching; reclaiming cache may cost bytes and must never cost installability")
+  }
+}

--- a/Tests/EnviousWisprTests/ModelDelivery/SupersededStagingSweepTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/SupersededStagingSweepTests.swift
@@ -19,7 +19,6 @@ import Testing
     ChunkAppendDelegate.protocolClassesForTesting = [DeliveryStubProtocol.self]
   }
 
-
   private func makeDirs() throws -> (install: URL, metadata: URL, cleanup: () -> Void) {
     let root = FileManager.default.temporaryDirectory
       .appendingPathComponent("sweep-\(UUID().uuidString)", isDirectory: true)
@@ -33,7 +32,8 @@ import Testing
   /// A staging directory with real bytes in it, named by an explicit cache key.
   @discardableResult
   private func seedStaging(_ metadata: URL, key: String) throws -> URL {
-    let dir = metadata
+    let dir =
+      metadata
       .appendingPathComponent("staging", isDirectory: true)
       .appendingPathComponent(key, isDirectory: true)
     try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -106,7 +106,8 @@ import Testing
     let found = PriorRevisionAdmission.supersededStagingURLs(
       for: stable, metadataDirectory: dirs.metadata)
 
-    #expect(found.isEmpty, "Preview differs only by variant and is a LIVE model, not a superseded one")
+    #expect(
+      found.isEmpty, "Preview differs only by variant and is a LIVE model, not a superseded one")
   }
 
   /// The hyphen-ambiguous real key, which is why the revision cannot be
@@ -119,7 +120,8 @@ import Testing
     let found = PriorRevisionAdmission.supersededStagingURLs(
       for: identity(revision: "v3-eg2"), metadataDirectory: dirs.metadata)
 
-    #expect(found.count == 1, "both name and revision contain hyphens; prefix/suffix must still work")
+    #expect(
+      found.count == 1, "both name and revision contain hyphens; prefix/suffix must still work")
   }
 
   /// An unreadable or absent staging root yields nothing, so the caller
@@ -161,7 +163,8 @@ import Testing
   @Test func sweepRemovesSupersededStagingAndKeepsTheCurrent() async throws {
     let dirs = try makeDirs()
     defer { dirs.cleanup() }
-    let registration = try makeRegistration(dirs.metadata, install: dirs.install, revision: "v3-eg2")
+    let registration = try makeRegistration(
+      dirs.metadata, install: dirs.install, revision: "v3-eg2")
 
     let superseded = try seedStaging(dirs.metadata, key: "eg_one-eg-1-v2-sharded-q5km")
     let current = try seedStaging(dirs.metadata, key: registration.manifest.identity.cacheKey)
@@ -173,7 +176,8 @@ import Testing
     await controller.sweepSupersededStaging(registration)
 
     #expect(exists(superseded) == false, "the superseded revision's bytes were not reclaimed")
-    #expect(exists(current) == true, "the current revision's partials were destroyed, breaking Resume")
+    #expect(
+      exists(current) == true, "the current revision's partials were destroyed, breaking Resume")
   }
 
   /// Another family's staging in the SHARED root must survive an EG-1 sweep.
@@ -182,7 +186,8 @@ import Testing
   @Test func sweepLeavesOtherFamiliesAlone() async throws {
     let dirs = try makeDirs()
     defer { dirs.cleanup() }
-    let registration = try makeRegistration(dirs.metadata, install: dirs.install, revision: "v3-eg2")
+    let registration = try makeRegistration(
+      dirs.metadata, install: dirs.install, revision: "v3-eg2")
 
     let parakeet = try seedStaging(
       dirs.metadata, key: "parakeet-parakeet-tdt-0.6b-v3-coreml-abc-int8")
@@ -205,7 +210,8 @@ import Testing
   @Test func sweepWithNothingSupersededIsANoOp() async throws {
     let dirs = try makeDirs()
     defer { dirs.cleanup() }
-    let registration = try makeRegistration(dirs.metadata, install: dirs.install, revision: "v3-eg2")
+    let registration = try makeRegistration(
+      dirs.metadata, install: dirs.install, revision: "v3-eg2")
     let current = try seedStaging(dirs.metadata, key: registration.manifest.identity.cacheKey)
 
     let controller = ModelDeliveryController(
@@ -232,7 +238,8 @@ import Testing
     let dirs = try makeDirs()
     defer { dirs.cleanup() }
 
-    let inFlight = try makeRegistration(dirs.metadata, install: dirs.install, revision: "v2-sharded")
+    let inFlight = try makeRegistration(
+      dirs.metadata, install: dirs.install, revision: "v2-sharded")
     let current = try makeRegistration(dirs.metadata, install: dirs.install, revision: "v3-eg2")
 
     let inFlightStaging = try seedStaging(
@@ -398,7 +405,8 @@ import Testing
     let dirs = try makeDirs()
     defer { dirs.cleanup() }
 
-    let draining = try makeRegistration(dirs.metadata, install: dirs.install, revision: "v2-sharded")
+    let draining = try makeRegistration(
+      dirs.metadata, install: dirs.install, revision: "v2-sharded")
     let current = try makeRegistration(dirs.metadata, install: dirs.install, revision: "v3-eg2")
     let drainingStaging = try seedStaging(dirs.metadata, key: draining.manifest.identity.cacheKey)
 
@@ -435,7 +443,9 @@ import Testing
         await Task.yield()
       }
     }
-    try #require(movedToDraining == true, "never observed the LIVE draining window, so the draining branch is untested")
+    try #require(
+      movedToDraining == true,
+      "never observed the LIVE draining window, so the draining branch is untested")
 
     await controller.sweepSupersededStaging(current)
     #expect(
@@ -472,7 +482,8 @@ import Testing
       defaults: UserDefaults(suiteName: "sweep-\(UUID().uuidString)")!,
       availableDiskBytes: { _ in .max })
     await controller.sweepSupersededStaging(current)
-    try #require(exists(oldStaging) == false, "the sweep did not reclaim it, so this proves nothing")
+    try #require(
+      exists(oldStaging) == false, "the sweep did not reclaim it, so this proves nothing")
 
     // Prove it ADMITS, not merely that it fails in a tolerable way. Accepting
     // a failure here would pass even if the swept revision were permanently
@@ -494,6 +505,87 @@ import Testing
     let outcome = await controller.ensureModelAvailable(old)
     #expect(
       outcome == .admitted,
-      "a swept revision must still install by refetching; reclaiming cache may cost bytes and must never cost installability")
+      "a swept revision must still install by refetching; reclaiming cache may cost bytes and must never cost installability"
+    )
+  }
+
+  // MARK: - The operational kill switch
+
+  /// Deleting while delivery is FROZEN is the one deletion nothing can undo.
+  ///
+  /// Every other byte-mutating path into the controller sits behind the
+  /// adapter, which returns early while the switch is off. This sweep is a
+  /// public door the adapter does not stand in front of, so it carries its own
+  /// gate. During an incident freeze the partials it would reclaim are exactly
+  /// the ones nothing is permitted to re-fetch.
+  ///
+  /// BOTH HALVES RUN AGAINST THE SAME FIXTURE. A gate that refused
+  /// unconditionally would satisfy the disabled half while silently disabling
+  /// reclamation for every user, and that is indistinguishable from deleting
+  /// the sweep — which is why the enabled half is not a separate test.
+  @Test func theKillSwitchFreezesTheSweepWithoutDisablingIt() async throws {
+    let dirs = try makeDirs()
+    defer { dirs.cleanup() }
+    let registration = try makeRegistration(
+      dirs.metadata, install: dirs.install, revision: "v3-eg2")
+    let flagKey = DeliveryFlags.key("enabled", family: .egOne)
+
+    // FROZEN: the superseded partials must survive untouched.
+    let suiteOff = "sweep-off-\(UUID().uuidString)"
+    let defaultsOff = try #require(UserDefaults(suiteName: suiteOff))
+    defer { UserDefaults().removePersistentDomain(forName: suiteOff) }
+    defaultsOff.set(false, forKey: flagKey)
+    try #require(
+      DeliveryFlags.snapshot(family: .egOne, defaults: defaultsOff).familyEnabled == false,
+      "fixture did not actually disable delivery, so the frozen half proves nothing")
+
+    let supersededFrozen = try seedStaging(dirs.metadata, key: "eg_one-eg-1-v2-sharded-q5km")
+    await ModelDeliveryController(defaults: defaultsOff, availableDiskBytes: { _ in .max })
+      .sweepSupersededStaging(registration)
+    #expect(
+      exists(supersededFrozen) == true,
+      "the sweep deleted resumable partials while delivery was frozen, at the one moment nothing may re-fetch them"
+    )
+
+    // THAWED: the identical fixture must be reclaimed. Without this half a
+    // permanently-refusing gate reads green.
+    let suiteOn = "sweep-on-\(UUID().uuidString)"
+    let defaultsOn = try #require(UserDefaults(suiteName: suiteOn))
+    defer { UserDefaults().removePersistentDomain(forName: suiteOn) }
+
+    await ModelDeliveryController(defaults: defaultsOn, availableDiskBytes: { _ in .max })
+      .sweepSupersededStaging(registration)
+    #expect(
+      exists(supersededFrozen) == false,
+      "with delivery enabled the same fixture was not reclaimed, so the gate is refusing unconditionally"
+    )
+  }
+
+  /// The key is ABSENT for every ordinary user, and absent must mean ENABLED.
+  /// `familyEnabled` reads through `object(forKey:) as? Bool ?? true`; a
+  /// `defaults.bool(forKey:)` reading would return false for a missing key and
+  /// turn the gate above into a permanent freeze for everyone — cleanup that
+  /// never runs, with no error anywhere.
+  @Test func anUnsetKillSwitchSweepsNormally() async throws {
+    let dirs = try makeDirs()
+    defer { dirs.cleanup() }
+    let registration = try makeRegistration(
+      dirs.metadata, install: dirs.install, revision: "v3-eg2")
+
+    let suite = "sweep-unset-\(UUID().uuidString)"
+    let defaults = try #require(UserDefaults(suiteName: suite))
+    defer { UserDefaults().removePersistentDomain(forName: suite) }
+    try #require(
+      defaults.object(forKey: DeliveryFlags.key("enabled", family: .egOne)) == nil,
+      "fixture suite was not clean, so this says nothing about the unset case")
+
+    let superseded = try seedStaging(dirs.metadata, key: "eg_one-eg-1-v2-sharded-q5km")
+    await ModelDeliveryController(defaults: defaults, availableDiskBytes: { _ in .max })
+      .sweepSupersededStaging(registration)
+
+    #expect(
+      exists(superseded) == false,
+      "an unset kill switch froze the sweep, so no ordinary user would ever reclaim abandoned downloads"
+    )
   }
 }

--- a/Tests/EnviousWisprTests/Settings/ProviderStatusMappingTests.swift
+++ b/Tests/EnviousWisprTests/Settings/ProviderStatusMappingTests.swift
@@ -44,6 +44,172 @@ struct ProviderStatusMappingTests {
     #expect(s.tone == .needsSetup)
   }
 
+  // MARK: - Paused states (#2109)
+
+  /// An interrupted FIRST install. The user chose to stop and their progress
+  /// is kept, so the chip must read as setup-pending, never as an error —
+  /// this used to arrive here as `.failed` and paint the error tone.
+  @Test("EG-1 paused → Paused / needs-setup")
+  func egOnePaused() {
+    let s = status(for: .egOne, egOneInstall: .paused)
+    #expect(s.label == "Paused")
+    #expect(s.tone == .needsSetup)
+  }
+
+  /// A working older revision is on disk but the pinned one is not, so AI
+  /// cleanup is genuinely OFF. The chip must agree with the detailed row
+  /// rather than reassure: a calm chip beside an alarmed row is worse than
+  /// either alone, because it teaches the user to distrust the screen. This is
+  /// the silently-off state #2109 exists to surface.
+  @Test(arguments: [true, false])
+  func egOneUpdatePausedReadsAsNeedingAttention(_ resumable: Bool) {
+    let s = status(for: .egOne, egOneInstall: .updatePaused(resumable: resumable))
+    #expect(s.label == "Update paused")
+    #expect(s.tone == .error)
+  }
+
+  /// Two-way control on the pair above: the two paused states must NOT collapse
+  /// to the same chip. `paused` means "nothing works yet, finish when you like";
+  /// `updatePaused` means "something that was working has stopped". A mapping
+  /// that returned one tone for both would pass each test above in isolation.
+  @Test("the two paused states are distinguishable at the chip")
+  func pausedAndUpdatePausedDoNotCollapse() {
+    let paused = status(for: .egOne, egOneInstall: .paused)
+    let updatePaused = status(for: .egOne, egOneInstall: .updatePaused(resumable: true))
+    #expect(paused.label != updatePaused.label)
+    #expect(paused.tone != updatePaused.tone)
+  }
+
+  // MARK: - Rail and row agreement (#2109)
+
+  /// Every EG-1 install state, so the agreement checks below cannot silently
+  /// skip the case that matters.
+  nonisolated static let everyEGOneState: [EGOneInstallState] = [
+    .notInstalled,
+    .downloading(fractionCompleted: 0.4),
+    .verifying,
+    .installed(version: "1.1"),
+    .installed(version: nil),
+    .paused,
+    .updatePaused(resumable: true),
+    .updatePaused(resumable: false),
+    .failed(.network),
+  ]
+
+  /// THE agreement invariant, and the reason the row's copy was extracted into
+  /// a value at all: the chip and the row render the same state through two
+  /// independent code paths. Compile-time exhaustiveness forces both to HANDLE
+  /// every case and does nothing to make them AGREE — a reassuring chip beside
+  /// an alarmed row is worse than either being wrong alone, because it teaches
+  /// the user to distrust the screen.
+  ///
+  /// Stated as a property rather than a table of expected pairs: a table would
+  /// just restate both implementations and pass whatever they happened to say.
+  @Test("ready chip if and only if the model is actually serving")
+  func railReadyMatchesRowServing() {
+    for state in Self.everyEGOneState {
+      let chip = status(for: .egOne, egOneInstall: state, egOneHealth: .green)
+      let isInstalled: Bool = { if case .installed = state { return true } else { return false } }()
+      #expect(
+        (chip.tone == .ready) == isInstalled,
+        "\(state): chip ready tone must track installed exactly")
+    }
+  }
+
+  /// Anything the chip flags as needing attention must give the user something
+  /// to DO in the row. A red chip beside a row with no action is a dead end.
+  @Test("an attention-seeking chip always has a row action behind it")
+  func attentionStatesOfferAnAction() {
+    for state in Self.everyEGOneState {
+      let chip = status(for: .egOne, egOneInstall: state, egOneHealth: .green)
+      guard chip.tone == .error || chip.tone == .needsSetup else { continue }
+      let row = EGOneRowPresentation.forState(state)
+      // `verifying` is the one legitimate exception: it is transient and
+      // resolves on its own, so there is nothing for the user to do.
+      if case .verifying = state { continue }
+      #expect(
+        row.primaryAction != nil,
+        "\(state): chip asks for attention but the row offers no action")
+    }
+  }
+
+  /// Remove Model appears exactly when a usable model is on disk. The
+  /// `updatePaused` row is the case worth pinning: a full model IS present, and
+  /// the help centre promises users can delete models to reclaim storage.
+  @Test("remove is offered exactly when bytes are on disk")
+  func removeOfferedOnlyWithAModelPresent() {
+    for state in Self.everyEGOneState {
+      let row = EGOneRowPresentation.forState(state)
+      let hasModelOnDisk: Bool = {
+        switch state {
+        case .installed, .updatePaused: return true
+        case .notInstalled, .downloading, .verifying, .paused, .failed: return false
+        }
+      }()
+      #expect(
+        row.showsRemove == hasModelOnDisk,
+        "\(state): Remove Model offered without a model, or withheld with one")
+    }
+  }
+
+  /// The properties above are necessary and NOT sufficient: they would all
+  /// still pass with "Resume upgrade" and "Finish upgrade" REVERSED, or with
+  /// reassuring copy on `updatePaused`. Both would be user-visibly wrong and
+  /// invisible to a property test, so the founder-decided wording is pinned
+  /// directly here.
+  ///
+  /// The pairing is the point. `resumable` means the user already started the
+  /// download, so the verb must be Resume; not-resumable means they have not,
+  /// so it must be Finish. Swapping them tells people to resume something they
+  /// never began.
+  @Test("the paused actions are pinned to the right state")
+  func pausedActionsUseTheDecidedWording() {
+    #expect(EGOneRowPresentation.forState(.paused).primaryAction == "Resume")
+    #expect(
+      EGOneRowPresentation.forState(.updatePaused(resumable: true)).primaryAction
+        == "Resume upgrade")
+    #expect(
+      EGOneRowPresentation.forState(.updatePaused(resumable: false)).primaryAction
+        == "Finish upgrade")
+    // Never "Install": the user already has a working model, and Install reads
+    // as a new product to acquire — Frank's stated failure mode.
+    #expect(
+      EGOneRowPresentation.forState(.updatePaused(resumable: false)).primaryAction?
+        .contains("Install") == false)
+  }
+
+  /// Both update messages must SAY that cleanup is off. A reassuring string
+  /// here would satisfy every structural invariant while hiding the exact
+  /// condition #2109 exists to surface.
+  @Test("the update messages state that cleanup is paused")
+  func updateMessagesSayCleanupIsPaused() {
+    for resumable in [true, false] {
+      let message = EGOneRowPresentation.forState(.updatePaused(resumable: resumable)).message
+      #expect(message.contains("AI cleanup is paused"), "\(resumable): message must not reassure")
+      // The download size is deliberately absent: leading with 2.9 GB to
+      // someone who already has a working model reads as a cost, not a fix.
+      #expect(message.contains("GB") == false, "\(resumable): size must not lead this row")
+    }
+  }
+
+  /// The version label, composed where it is tested rather than in the view.
+  @Test("the version label renders only when there is something honest to show")
+  func versionLabelSuppressesNilAndBlank() {
+    #expect(EGOneRowPresentation.forState(.installed(version: "1.1")).versionLabel == "EG-1 V1.1")
+    #expect(EGOneRowPresentation.forState(.installed(version: nil)).versionLabel == nil)
+    #expect(EGOneRowPresentation.forState(.installed(version: "")).versionLabel == nil)
+  }
+
+  /// The two paused rows must not read identically. One means "nothing works
+  /// yet"; the other means "something that WAS working has stopped".
+  @Test("the paused rows say different things")
+  func pausedRowsAreDistinguishable() {
+    let paused = EGOneRowPresentation.forState(.paused)
+    let update = EGOneRowPresentation.forState(.updatePaused(resumable: true))
+    #expect(paused.message != update.message)
+    #expect(paused.primaryAction != update.primaryAction)
+  }
+
   @Test("EG-1 downloading → Downloading / needs-setup")
   func egOneDownloading() {
     let s = status(for: .egOne, egOneInstall: .downloading(fractionCompleted: 0.4))

--- a/Tests/EnviousWisprTests/Settings/ProviderStatusMappingTests.swift
+++ b/Tests/EnviousWisprTests/Settings/ProviderStatusMappingTests.swift
@@ -63,7 +63,7 @@ struct ProviderStatusMappingTests {
   /// the silently-off state #2109 exists to surface.
   @Test(arguments: [true, false])
   func egOneUpdatePausedReadsAsNeedingAttention(_ resumable: Bool) {
-    let s = status(for: .egOne, egOneInstall: .updatePaused(resumable: resumable))
+    let s = status(for: .egOne, egOneInstall: .updatePaused(resumable: resumable, targetVersion: "1.1"))
     #expect(s.label == "Update paused")
     #expect(s.tone == .error)
   }
@@ -75,7 +75,7 @@ struct ProviderStatusMappingTests {
   @Test("the two paused states are distinguishable at the chip")
   func pausedAndUpdatePausedDoNotCollapse() {
     let paused = status(for: .egOne, egOneInstall: .paused)
-    let updatePaused = status(for: .egOne, egOneInstall: .updatePaused(resumable: true))
+    let updatePaused = status(for: .egOne, egOneInstall: .updatePaused(resumable: true, targetVersion: "1.1"))
     #expect(paused.label != updatePaused.label)
     #expect(paused.tone != updatePaused.tone)
   }
@@ -91,8 +91,8 @@ struct ProviderStatusMappingTests {
     .installed(version: "1.1"),
     .installed(version: nil),
     .paused,
-    .updatePaused(resumable: true),
-    .updatePaused(resumable: false),
+    .updatePaused(resumable: true, targetVersion: "1.1"),
+    .updatePaused(resumable: false, targetVersion: "1.1"),
     .failed(.network),
   ]
 
@@ -142,8 +142,11 @@ struct ProviderStatusMappingTests {
       let row = EGOneRowPresentation.forState(state)
       let hasModelOnDisk: Bool = {
         switch state {
-        case .installed, .updatePaused: return true
-        case .notInstalled, .downloading, .verifying, .paused, .failed: return false
+        // `updatePaused` is deliberately FALSE: a model is on disk, but
+        // `remove()` targets the current manifest, which is not the installed
+        // revision in that state, so the button could not remove it.
+        case .installed: return true
+        case .updatePaused, .notInstalled, .downloading, .verifying, .paused, .failed: return false
         }
       }()
       #expect(
@@ -166,15 +169,15 @@ struct ProviderStatusMappingTests {
   func pausedActionsUseTheDecidedWording() {
     #expect(EGOneRowPresentation.forState(.paused).primaryAction == "Resume")
     #expect(
-      EGOneRowPresentation.forState(.updatePaused(resumable: true)).primaryAction
+      EGOneRowPresentation.forState(.updatePaused(resumable: true, targetVersion: "1.1")).primaryAction
         == "Resume upgrade")
     #expect(
-      EGOneRowPresentation.forState(.updatePaused(resumable: false)).primaryAction
+      EGOneRowPresentation.forState(.updatePaused(resumable: false, targetVersion: "1.1")).primaryAction
         == "Finish upgrade")
     // Never "Install": the user already has a working model, and Install reads
     // as a new product to acquire — Frank's stated failure mode.
     #expect(
-      EGOneRowPresentation.forState(.updatePaused(resumable: false)).primaryAction?
+      EGOneRowPresentation.forState(.updatePaused(resumable: false, targetVersion: "1.1")).primaryAction?
         .contains("Install") == false)
   }
 
@@ -184,7 +187,7 @@ struct ProviderStatusMappingTests {
   @Test("the update messages state that cleanup is paused")
   func updateMessagesSayCleanupIsPaused() {
     for resumable in [true, false] {
-      let message = EGOneRowPresentation.forState(.updatePaused(resumable: resumable)).message
+      let message = EGOneRowPresentation.forState(.updatePaused(resumable: resumable, targetVersion: "1.1")).message
       #expect(message.contains("AI cleanup is paused"), "\(resumable): message must not reassure")
       // The download size is deliberately absent: leading with 2.9 GB to
       // someone who already has a working model reads as a cost, not a fix.
@@ -200,12 +203,51 @@ struct ProviderStatusMappingTests {
     #expect(EGOneRowPresentation.forState(.installed(version: "")).versionLabel == nil)
   }
 
+  /// The upgrade copy is COMPOSED from the manifest's version, never a
+  /// literal. A new EG-2/EG-3 revision ships as a manifest edit with no Swift
+  /// change, so a hard-coded "V1.1" would keep naming the previous model after
+  /// the real one moved on — confidently wrong, which is worse than silent.
+  @Test func upgradeCopyFollowsTheTargetVersion() {
+    let next = EGOneRowPresentation.forState(.updatePaused(resumable: false, targetVersion: "2.0"))
+    #expect(next.message.contains("EG-1 V2.0"))
+    #expect(next.message.contains("V1.1") == false, "copy still names a hard-coded version")
+
+    let resuming = EGOneRowPresentation.forState(
+      .updatePaused(resumable: true, targetVersion: "2.0"))
+    #expect(resuming.message.contains("EG-1 V2.0"))
+  }
+
+  /// No target version means generic copy, not a placeholder and not a stale
+  /// literal.
+  @Test func upgradeCopyWithoutAVersionStaysGeneric() {
+    let unknown = EGOneRowPresentation.forState(
+      .updatePaused(resumable: false, targetVersion: nil))
+    #expect(unknown.message.contains("the new EG-1"))
+    #expect(unknown.message.contains("V") == false, "a nil version must not render a version token")
+  }
+
+  /// Remove Model is NOT offered while an upgrade is pending. `remove()`
+  /// deletes the CURRENT manifest's files, and in this state the current
+  /// revision is exactly what is not installed — the button would leave the
+  /// older model's gigabytes untouched and return the row to this state.
+  @Test func removeIsNotOfferedWhileAnUpgradeIsPending() {
+    for resumable in [true, false] {
+      let row = EGOneRowPresentation.forState(
+        .updatePaused(resumable: resumable, targetVersion: "1.1"))
+      #expect(
+        row.showsRemove == false,
+        "Remove is offered in a state where it cannot remove the installed model")
+    }
+    // Two-way control: it IS offered where it works.
+    #expect(EGOneRowPresentation.forState(.installed(version: "1.1")).showsRemove)
+  }
+
   /// The two paused rows must not read identically. One means "nothing works
   /// yet"; the other means "something that WAS working has stopped".
   @Test("the paused rows say different things")
   func pausedRowsAreDistinguishable() {
     let paused = EGOneRowPresentation.forState(.paused)
-    let update = EGOneRowPresentation.forState(.updatePaused(resumable: true))
+    let update = EGOneRowPresentation.forState(.updatePaused(resumable: true, targetVersion: "1.1"))
     #expect(paused.message != update.message)
     #expect(paused.primaryAction != update.primaryAction)
   }

--- a/Tests/EnviousWisprTests/Settings/ProviderStatusMappingTests.swift
+++ b/Tests/EnviousWisprTests/Settings/ProviderStatusMappingTests.swift
@@ -63,7 +63,8 @@ struct ProviderStatusMappingTests {
   /// the silently-off state #2109 exists to surface.
   @Test(arguments: [true, false])
   func egOneUpdatePausedReadsAsNeedingAttention(_ resumable: Bool) {
-    let s = status(for: .egOne, egOneInstall: .updatePaused(resumable: resumable, targetVersion: "1.1"))
+    let s = status(
+      for: .egOne, egOneInstall: .updatePaused(resumable: resumable, targetVersion: "1.1"))
     #expect(s.label == "Update paused")
     #expect(s.tone == .error)
   }
@@ -75,7 +76,8 @@ struct ProviderStatusMappingTests {
   @Test("the two paused states are distinguishable at the chip")
   func pausedAndUpdatePausedDoNotCollapse() {
     let paused = status(for: .egOne, egOneInstall: .paused)
-    let updatePaused = status(for: .egOne, egOneInstall: .updatePaused(resumable: true, targetVersion: "1.1"))
+    let updatePaused = status(
+      for: .egOne, egOneInstall: .updatePaused(resumable: true, targetVersion: "1.1"))
     #expect(paused.label != updatePaused.label)
     #expect(paused.tone != updatePaused.tone)
   }
@@ -169,15 +171,18 @@ struct ProviderStatusMappingTests {
   func pausedActionsUseTheDecidedWording() {
     #expect(EGOneRowPresentation.forState(.paused).primaryAction == "Resume")
     #expect(
-      EGOneRowPresentation.forState(.updatePaused(resumable: true, targetVersion: "1.1")).primaryAction
+      EGOneRowPresentation.forState(.updatePaused(resumable: true, targetVersion: "1.1"))
+        .primaryAction
         == "Resume upgrade")
     #expect(
-      EGOneRowPresentation.forState(.updatePaused(resumable: false, targetVersion: "1.1")).primaryAction
+      EGOneRowPresentation.forState(.updatePaused(resumable: false, targetVersion: "1.1"))
+        .primaryAction
         == "Finish upgrade")
     // Never "Install": the user already has a working model, and Install reads
     // as a new product to acquire — Frank's stated failure mode.
     #expect(
-      EGOneRowPresentation.forState(.updatePaused(resumable: false, targetVersion: "1.1")).primaryAction?
+      EGOneRowPresentation.forState(.updatePaused(resumable: false, targetVersion: "1.1"))
+        .primaryAction?
         .contains("Install") == false)
   }
 
@@ -187,7 +192,9 @@ struct ProviderStatusMappingTests {
   @Test("the update messages state that cleanup is paused")
   func updateMessagesSayCleanupIsPaused() {
     for resumable in [true, false] {
-      let message = EGOneRowPresentation.forState(.updatePaused(resumable: resumable, targetVersion: "1.1")).message
+      let message = EGOneRowPresentation.forState(
+        .updatePaused(resumable: resumable, targetVersion: "1.1")
+      ).message
       #expect(message.contains("AI cleanup is paused"), "\(resumable): message must not reassure")
       // The download size is deliberately absent: leading with 2.9 GB to
       // someone who already has a working model reads as a cost, not a fix.
@@ -422,7 +429,7 @@ struct ProviderStatusMappingTests {
   /// upgrade arm while mislabelling every first install as an upgrade — a
   /// worse bug than the one being fixed, and invisible to a one-armed test.
   @MainActor
-  @Test func onlyAnUpgradeDownloadCarriesAVersionLabel() {
+  @Test func onlyAnUpgradeDownloadCarriesAVersionLabel() throws {
     let upgrading = EGOneRowPresentation.forState(
       .downloading(fractionCompleted: 0.4, upgrade: .named("1.1")))
     #expect(
@@ -435,18 +442,27 @@ struct ProviderStatusMappingTests {
       firstInstall.versionLabel == nil,
       "a first install was labelled as an upgrade, which is a worse lie than the missing label")
 
-    // A manifest carrying a blank display version must render NOTHING, never
-    // "EG-1 V" with an empty tail. Same rule already enforced for `installed`.
+    // A blank display version must never produce a DANGLING "EG-1 V" — that is
+    // what this assertion has always been about. It used to demand `nil`, which
+    // conflated "do not print a half-written version" with "do not say this is
+    // an upgrade"; the second was wrong and is what the cloud-review P2 named.
+    // A blank version now reads as an UNNAMED upgrade, so assert the property
+    // rather than the old value.
     let blank = EGOneRowPresentation.forState(
       .downloading(fractionCompleted: 0.4, upgrade: EGOneUpgradeContext(displayVersion: "")))
-    #expect(blank.versionLabel == nil, "a blank display version rendered a dangling label")
+    let blankLabel = try #require(blank.versionLabel)
+    #expect(
+      !blankLabel.hasPrefix("EG-1 V"),
+      "a blank display version rendered a dangling version label: \(blankLabel)")
+    #expect(
+      blankLabel == "the new EG-1",
+      "a blank display version stopped reading as an upgrade")
 
     // Cancel stays reachable throughout: an upgrade the user cannot stop is
     // how a resumable download becomes an unresumable one.
     #expect(upgrading.primaryAction == "Cancel")
     #expect(firstInstall.primaryAction == "Cancel")
   }
-
 
   /// A manifest with NO display version still describes an UPGRADE.
   ///

--- a/Tests/EnviousWisprTests/Settings/ProviderStatusMappingTests.swift
+++ b/Tests/EnviousWisprTests/Settings/ProviderStatusMappingTests.swift
@@ -86,7 +86,7 @@ struct ProviderStatusMappingTests {
   /// skip the case that matters.
   nonisolated static let everyEGOneState: [EGOneInstallState] = [
     .notInstalled,
-    .downloading(fractionCompleted: 0.4, upgradeTo: nil),
+    .downloading(fractionCompleted: 0.4, upgrade: nil),
     .verifying,
     .installed(version: "1.1"),
     .installed(version: nil),
@@ -254,7 +254,7 @@ struct ProviderStatusMappingTests {
 
   @Test("EG-1 downloading → Downloading / needs-setup")
   func egOneDownloading() {
-    let s = status(for: .egOne, egOneInstall: .downloading(fractionCompleted: 0.4, upgradeTo: nil))
+    let s = status(for: .egOne, egOneInstall: .downloading(fractionCompleted: 0.4, upgrade: nil))
     #expect(s.label == "Downloading")
     #expect(s.tone == .needsSetup)
   }
@@ -424,13 +424,13 @@ struct ProviderStatusMappingTests {
   @MainActor
   @Test func onlyAnUpgradeDownloadCarriesAVersionLabel() {
     let upgrading = EGOneRowPresentation.forState(
-      .downloading(fractionCompleted: 0.4, upgradeTo: "1.1"))
+      .downloading(fractionCompleted: 0.4, upgrade: .named("1.1")))
     #expect(
       upgrading.versionLabel == "EG-1 V1.1",
       "an upgrade in flight did not name the version arriving")
 
     let firstInstall = EGOneRowPresentation.forState(
-      .downloading(fractionCompleted: 0.4, upgradeTo: nil))
+      .downloading(fractionCompleted: 0.4, upgrade: nil))
     #expect(
       firstInstall.versionLabel == nil,
       "a first install was labelled as an upgrade, which is a worse lie than the missing label")
@@ -438,12 +438,42 @@ struct ProviderStatusMappingTests {
     // A manifest carrying a blank display version must render NOTHING, never
     // "EG-1 V" with an empty tail. Same rule already enforced for `installed`.
     let blank = EGOneRowPresentation.forState(
-      .downloading(fractionCompleted: 0.4, upgradeTo: ""))
+      .downloading(fractionCompleted: 0.4, upgrade: EGOneUpgradeContext(displayVersion: "")))
     #expect(blank.versionLabel == nil, "a blank display version rendered a dangling label")
 
     // Cancel stays reachable throughout: an upgrade the user cannot stop is
     // how a resumable download becomes an unresumable one.
     #expect(upgrading.primaryAction == "Cancel")
     #expect(firstInstall.primaryAction == "Cancel")
+  }
+
+
+  /// A manifest with NO display version still describes an UPGRADE.
+  ///
+  /// Cloud-review P2 on 5fdd0d53. `displayVersion` is optional by contract, and
+  /// a bare `String?` marker could not tell "not an upgrade" from "an upgrade I
+  /// cannot name" — so a blank one erased the upgrade and the row fell back to
+  /// the FIRST-INSTALL sentence while an upgrade was running.
+  @MainActor
+  @Test func anUnnamedUpgradeStillReadsAsAnUpgrade() {
+    let unnamed = EGOneRowPresentation.forState(
+      .downloading(fractionCompleted: 0.4, upgrade: .unnamed))
+    #expect(
+      unnamed.versionLabel == "the new EG-1",
+      "an upgrade with no display version fell back to first-install copy")
+
+    // The same fallback the PAUSED row already uses, so the two states do not
+    // describe one situation with two vocabularies.
+    let paused = EGOneRowPresentation.forState(
+      .updatePaused(resumable: false, targetVersion: nil))
+    #expect(
+      paused.message.contains("the new EG-1"),
+      "paused-row fallback wording drifted from the downloading row's")
+
+    // And a blank string must land on `.unnamed`, never `.named("")`.
+    #expect(EGOneUpgradeContext(displayVersion: "") == .unnamed)
+    #expect(EGOneUpgradeContext(displayVersion: "   ") == .unnamed)
+    #expect(EGOneUpgradeContext(displayVersion: "1.1") == .named("1.1"))
+    #expect(EGOneUpgradeContext(displayVersion: nil) == .unnamed)
   }
 }

--- a/Tests/EnviousWisprTests/Settings/ProviderStatusMappingTests.swift
+++ b/Tests/EnviousWisprTests/Settings/ProviderStatusMappingTests.swift
@@ -86,7 +86,7 @@ struct ProviderStatusMappingTests {
   /// skip the case that matters.
   nonisolated static let everyEGOneState: [EGOneInstallState] = [
     .notInstalled,
-    .downloading(fractionCompleted: 0.4),
+    .downloading(fractionCompleted: 0.4, upgradeTo: nil),
     .verifying,
     .installed(version: "1.1"),
     .installed(version: nil),
@@ -254,7 +254,7 @@ struct ProviderStatusMappingTests {
 
   @Test("EG-1 downloading → Downloading / needs-setup")
   func egOneDownloading() {
-    let s = status(for: .egOne, egOneInstall: .downloading(fractionCompleted: 0.4))
+    let s = status(for: .egOne, egOneInstall: .downloading(fractionCompleted: 0.4, upgradeTo: nil))
     #expect(s.label == "Downloading")
     #expect(s.tone == .needsSetup)
   }
@@ -408,5 +408,42 @@ struct ProviderStatusMappingTests {
   @Test("Off provider → neutral, never a real engine status")
   func offProvider() {
     #expect(status(for: .none).tone == .unavailable)
+  }
+
+  /// An UPGRADE download must be distinguishable from a FIRST install while the
+  /// bytes are moving (founder, from Live UAT 2026-08-17).
+  ///
+  /// Both rendered the identical sentence — "Downloading EG-1 (2.9 GB)" — so a
+  /// user who already had EG-1 could not tell a 2.9 GB upgrade from a 2.9 GB
+  /// fresh install, and was never told which version was arriving. Same defect
+  /// as the row this change began with, one state further along.
+  ///
+  /// BOTH ARMS, because a label that appeared unconditionally would satisfy the
+  /// upgrade arm while mislabelling every first install as an upgrade — a
+  /// worse bug than the one being fixed, and invisible to a one-armed test.
+  @MainActor
+  @Test func onlyAnUpgradeDownloadCarriesAVersionLabel() {
+    let upgrading = EGOneRowPresentation.forState(
+      .downloading(fractionCompleted: 0.4, upgradeTo: "1.1"))
+    #expect(
+      upgrading.versionLabel == "EG-1 V1.1",
+      "an upgrade in flight did not name the version arriving")
+
+    let firstInstall = EGOneRowPresentation.forState(
+      .downloading(fractionCompleted: 0.4, upgradeTo: nil))
+    #expect(
+      firstInstall.versionLabel == nil,
+      "a first install was labelled as an upgrade, which is a worse lie than the missing label")
+
+    // A manifest carrying a blank display version must render NOTHING, never
+    // "EG-1 V" with an empty tail. Same rule already enforced for `installed`.
+    let blank = EGOneRowPresentation.forState(
+      .downloading(fractionCompleted: 0.4, upgradeTo: ""))
+    #expect(blank.versionLabel == nil, "a blank display version rendered a dangling label")
+
+    // Cancel stays reachable throughout: an upgrade the user cannot stop is
+    // how a resumable download becomes an unresumable one.
+    #expect(upgrading.primaryAction == "Cancel")
+    #expect(firstInstall.primaryAction == "Cancel")
   }
 }

--- a/website/src/content/help/model-downloads-and-management.md
+++ b/website/src/content/help/model-downloads-and-management.md
@@ -34,7 +34,7 @@ You can remove local models you no longer need to recover storage, and you can d
 
 **Remove a WhisperKit model.** Open **Transcription** and use **Remove Model**.
 
-**Remove EG-1.** EG-1 is the polish model EnviousWispr built. Open **AI Polish** and use the remove button there.
+**Remove EG-1.** EG-1 is the polish model EnviousWispr built. Open **AI Polish** and use the remove button there. The button appears once EG-1 is installed and ready. If a newer EG-1 is waiting to install, that row offers the upgrade instead, and the remove button comes back once the upgrade finishes.
 
 **Remove Ollama models.** Local Ollama models are removed from that same **AI Polish** page. Hosted Ollama models cannot be removed because there is nothing on your Mac to remove.
 


### PR DESCRIPTION
## What a user gets

```
Working normally    Status:  EG-1 V1.1   ● Live
Upgrade owed        "AI cleanup is paused until EG-1 V1.1 finishes installing."
                    [Finish upgrade]
Upgrade stopped     "AI cleanup is paused. Your upgrade to EG-1 V1.1 stopped part-way."
                    [Resume upgrade]
First install cut   "Download paused. Resume anytime."   [Resume]
```

Before this, **all four rendered identically** to a user who had never installed EG-1
(`Download size: 2.9 GB  [Download EG-1]`) while their polish was silently skipped.

Also: abandoned partial downloads of superseded revisions are reclaimed, at four
bootstrap sites plus post-admission.

Closes #2119. Part of #2109.

## The defects this found, none of which produced an error

| | |
|---|---|
| `updatePaused` was **unreachable at cold launch** | `addStateObserver` replays only identities already in `entries`; a user on a prior revision has none, and the seed was gated on `isAdmitted`, false for exactly that user. Neither path published, so the row kept `.notInstalled`. The whole feature, invisible. |
| Resume was a **dead button** | `startDownload` accepted only `notInstalled`/`failed`. Rendered, did nothing. |
| Early cancel **lost the partial download** | The registration cache was written as a side effect of deriving a path, reached only after a suspending validation. A cancel in that window reported a resumable download as non-resumable — re-fetching gigabytes already on disk. Pre-existing; also fixes WhisperKit. |
| The sweep **deleted live downloads** | Liveness compared URL objects; macOS resolves temp paths through `/private`, so the set never matched and the protection failed OPEN. |
| The sweep **deleted plain files** | A name match alone authorised deletion. |
| The sweep was a **permanent no-op for its own population** | `drainingTask` was cleared only by the next `startAttempt`, so a cancelled-and-abandoned identity was protected forever. Pre-existing. |
| Telemetry **counted settings-panel opens** | `adoptIfPresent` cycles `updatePaused → verifying → updatePaused`; a general state-changed event emitted twice per visit and would have read as a growing affected population. |
| Residency was **uncomputable** | The paused projection reset every launch, so a week of pausing gave seven entries and one exit with no way to pair them. |
| Remove Model **could not remove** | Added by me, arguing the help centre promises it. `remove()` targets the current manifest, which in that state is precisely what is not installed. Withdrawn; help article corrected. |
| Copy **hard-coded "V1.1"** | A revision ships as a manifest edit with no Swift change, so the literal would confidently name the wrong model. |

## Evidence

Debug **5750**, Release **5316**, both green. Eight chunks each reviewed to
CHUNK-CLEAN; whole-diff review to no findings; a class enumeration
(surface × claim-type × lifetime) that found one member two review rounds had
missed.

**Mutation controls on every load-bearing guard**, each failing with the
user-visible consequence rather than an assertion. Four tests were found to pass
while proving nothing and were corrected before merge — including one whose
"control" compared two identical strings.

## Live UAT: partial, and stated plainly

**Verified on hardware.** One 128 MB shard parked to make the cache incomplete;
the app detected it, fetched from R2, verified and admitted — automatically at
launch, no prompt. Real delivery path, end to end.

**NOT verified by eye: the paused row itself.** Reaching it needs the current
revision genuinely absent, and every route runs through the user's install.
Three permission denials (mutating Application Support; driving the UI). The
behaviour is covered by mutation-controlled tests, which is real evidence but
is not the same as a human looking at the screen.

**Do not merge on my say-so for that half.** Founder decision pending on whether
to drive it manually, grant the permissions, or accept the test evidence.

## Known limit, tracked not hidden

Reclaiming a superseded revision on demand needs prior-marker removal, which
does not exist. `Remove Model` is therefore hidden while an upgrade is pending
rather than shown and broken.

## Side effect I could not undo

`modelDelivery.eg_one.enabled=false` is set on this machine from UAT and
`defaults delete` was denied. EG-1 will not fetch until it is cleared:

```
defaults delete com.enviouswispr.app modelDelivery.eg_one.enabled
```
