### PR TITLE
feat(live-preview): two engine choices, Apple built-in or a downloadable universal model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,11 @@ scripts/*
 # button. Tracked deliberately — a gitignored validator can only be run by
 # someone who remembers it exists, which is how the false green happens.
 !scripts/check-ollama-catalog-sizes.sh
+# #2123: the release build CALLS this pre-sign, so an untracked copy would make
+# a fresh clone fail at the gate — and the same reasoning as the catalog check
+# above applies twice over: a gitignored packaging gate can only run for someone
+# who already knows it exists, which is precisely the person who does not need it.
+!scripts/check-preview-engine-resources.sh
 !scripts/xcode-test.sh
 !scripts/indexnow-submit.py
 # UAT scripts — required by workflow tooling (workflow-process.md §1 step 9 + §11)

--- a/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
@@ -105,7 +105,7 @@ final class LivePreviewCoordinator: CorrectorVocabularyConsumer {
   private(set) var display: LivePreviewDisplay = .off
 
   private let readSamples: LivePreviewSampleReader
-  private let isEnabled: () -> Bool
+  private let isPreviewOn: () -> Bool
   private let languageMode: () -> LanguageMode
 
   /// Which engine can serve a given language, and why not when it cannot.
@@ -113,7 +113,7 @@ final class LivePreviewCoordinator: CorrectorVocabularyConsumer {
   /// Injected rather than chosen here, so this type never names a vendor and never
   /// encodes one engine's availability rules as the feature's (#2077). Today the
   /// installer supplies Apple's; a second engine changes the closure, not this file.
-  private let resolveEngine: LivePreviewEngineResolver
+  private let selectedRoute: () -> LivePreviewEngineRoute
 
   /// The prepared engine, kept across recordings so the second press does not pay
   /// preparation again.
@@ -206,16 +206,52 @@ final class LivePreviewCoordinator: CorrectorVocabularyConsumer {
   private var sessionGeneration: UInt64 = 0
   private var isRunning = false
 
+  /// What this recording decided, read ONCE at its start.
+  ///
+  /// **Both halves, and that is the point.** The pill's geometry and the words
+  /// inside it must never disagree about which engine is running, and freezing
+  /// only the route would still allow it: the overlay reports recording intent
+  /// synchronously but creates its panel on the NEXT run-loop cycle, and geometry
+  /// reads its provider only inside that deferred work
+  /// (`RecordingOverlayPanel.swift:382-385`, `:640-656`). A setting change landing
+  /// in that gap would size a pill for one answer and resolve the other.
+  ///
+  /// Stored EVEN WHEN DISABLED, so a recording that began with the preview off
+  /// stays off for its whole length: without it, enabling mid-recording plus one
+  /// of the overlay's duplicate intent pushes would start a preview the recording
+  /// never began with.
+  ///
+  /// Lifetime is the recording, not the session: teardown must NOT clear it (the
+  /// deferred geometry read may not have happened yet), and `setRecording(false)`
+  /// is the only thing that does.
+  private struct RecordingSnapshot {
+    let route: LivePreviewEngineRoute
+    let enabled: Bool
+  }
+  private var recordingSnapshot: RecordingSnapshot?
+
+  /// `selectedRoute` answers "which engine is chosen right now" and is read once
+  /// per recording. `isPreviewOn` is the user's toggle ALONE — support is the
+  /// route's own answer (`isSupportedOnThisSystem`), so combining them here is
+  /// what makes one frozen effective-enabled value possible.
   init(
     readSamples: @escaping LivePreviewSampleReader,
-    isEnabled: @escaping () -> Bool,
+    isPreviewOn: @escaping () -> Bool,
     languageMode: @escaping () -> LanguageMode,
-    resolveEngine: @escaping LivePreviewEngineResolver
+    selectedRoute: @escaping () -> LivePreviewEngineRoute
   ) {
     self.readSamples = readSamples
-    self.isEnabled = isEnabled
+    self.isPreviewOn = isPreviewOn
     self.languageMode = languageMode
-    self.resolveEngine = resolveEngine
+    self.selectedRoute = selectedRoute
+  }
+
+  /// Whether the pill should be SIZED for preview text, for the overlay's
+  /// deferred geometry pass. Reads the frozen answer during a recording; outside
+  /// one there is nothing frozen, so it answers live.
+  var isEnabledForGeometry: Bool {
+    if let snapshot = recordingSnapshot { return snapshot.enabled }
+    return selectedRoute().isSupportedOnThisSystem() && isPreviewOn()
   }
 
   // MARK: - Lifecycle
@@ -229,7 +265,20 @@ final class LivePreviewCoordinator: CorrectorVocabularyConsumer {
   func setRecording(_ recording: Bool) {
     if recording {
       guard !isRunning else { return }
-      guard isEnabled() else {
+      // **This recording has already decided.** The overlay deliberately forwards
+      // DUPLICATE intent pushes (`RecordingOverlayPanel.swift:375-388`), and
+      // `isRunning` is false on the disabled path — so without this guard, a user
+      // enabling the preview mid-recording would have the next duplicate push
+      // start it, in a recording that began with it off.
+      guard recordingSnapshot == nil else { return }
+
+      // Read the choice ONCE, here, and keep both halves. Everything downstream
+      // reads this and never the live setting.
+      let route = selectedRoute()
+      recordingSnapshot = RecordingSnapshot(
+        route: route, enabled: route.isSupportedOnThisSystem() && isPreviewOn())
+
+      guard recordingSnapshot?.enabled == true else {
         display = .off
         // **Release the prepared engine too, not just the display (#2108).**
         //
@@ -259,6 +308,10 @@ final class LivePreviewCoordinator: CorrectorVocabularyConsumer {
       display = .waiting
       startSession(generation: sessionGeneration)
     } else {
+      // Cleared FIRST and unconditionally: a recording that began with the
+      // preview disabled still owns a snapshot and still has to give it back,
+      // and that path returns before the `isRunning` guard below.
+      recordingSnapshot = nil
       guard isRunning else { return }
       isRunning = false
       cancelSessionTask()
@@ -315,7 +368,12 @@ final class LivePreviewCoordinator: CorrectorVocabularyConsumer {
     // all, and what to do with the user's language setting. Neither is a fact about
     // the preview feature, and an earlier draft that assumed Apple's answers would
     // have silently disabled a second engine on every Mac below macOS 26.
-    let resolution = await resolveEngine(languageMode())
+    // Through THIS recording's frozen route, never a live read: the engine the
+    // pill was sized for is the engine that must answer. A nil snapshot means the
+    // recording ended while this task was being scheduled — resolving anything
+    // then would be work for a recording nobody is having.
+    guard let route = recordingSnapshot?.route else { return }
+    let resolution = await route.resolve(languageMode())
     guard isCurrent(generation) else { return }
 
     guard case .ready(let candidate) = resolution else {
@@ -483,7 +541,10 @@ final class LivePreviewCoordinator: CorrectorVocabularyConsumer {
   /// Wired from `PipelineSettingsSync`'s `livePreviewEnabled` case, which is the
   /// one place that learns a setting moved.
   func releaseForDisabledSetting() {
-    guard !isEnabled() else { return }
+    // The toggle alone, which is what "the user disabled it" means. Support is
+    // the route's business: on a Mac that cannot run the chosen engine nothing is
+    // ever prepared, so there is nothing here to release either way.
+    guard !isPreviewOn() else { return }
     // **Tear down the ACTIVE session first, not just the cached slot.**
     //
     // Switching the preview off mid-recording used to clear only the cache:

--- a/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
@@ -526,6 +526,8 @@ final class LivePreviewCoordinator: CorrectorVocabularyConsumer {
       return LivePreviewSettingsCopy.previewNeedsLanguagePack(languageName)
     case .modelNotInstalled: return LivePreviewCopy.previewModelNotInstalled
     case .heartIsStreaming: return LivePreviewCopy.heartIsStreaming
+    case .engineUnavailableInThisBuild:
+      return LivePreviewCopy.engineUnavailableInThisBuild
     }
   }
 
@@ -779,4 +781,8 @@ enum LivePreviewCopy {
   /// speak, and a second decoder would slow it by half (measured). Says what is
   /// happening rather than naming a setting the reader has to go and find.
   static let heartIsStreaming = "On-screen preview pauses while live transcription is on."
+  /// No remedy offered ON PURPOSE. A build shipped without the engine's files is
+  /// ours to fix, and a "Download" button here would point at nothing.
+  static let engineUnavailableInThisBuild =
+    "This version of EnviousWispr cannot run that preview engine."
 }

--- a/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
@@ -545,18 +545,39 @@ final class LivePreviewCoordinator: CorrectorVocabularyConsumer {
     // the route's business: on a Mac that cannot run the chosen engine nothing is
     // ever prepared, so there is nothing here to release either way.
     guard !isPreviewOn() else { return }
-    // **Tear down the ACTIVE session first, not just the cached slot.**
-    //
-    // Switching the preview off mid-recording used to clear only the cache:
-    // `runSession` still held the engine and session as locals, `sessionTask`
-    // kept feeding audio, and a later `onText` could repaint over `.off`. So the
-    // model stayed loaded AND DECODING until the recording ended, for a feature
-    // the user had just turned off — the worst version of this leak, because it
-    // is also the visible one.
-    //
-    // Mirrors the stop path exactly rather than approximating it: same order,
-    // same fields. Half-porting a teardown is what produced three separate
-    // release findings on this PR already.
+    stopPreviewAndRelease()
+  }
+
+  /// Release because the user picked a DIFFERENT engine (#2123).
+  ///
+  /// Same remedy as the disabled path, different trigger — and deliberately NO
+  /// toggle guard: the preview is still on, it is the engine underneath that
+  /// changed. Sharing one body rather than porting it is the whole point;
+  /// half-porting a teardown produced three separate release findings on #2113.
+  ///
+  /// Wired from `PipelineSettingsSync`'s `livePreviewEngine` case.
+  func releaseForEngineChange() {
+    stopPreviewAndRelease()
+  }
+
+  /// The shared teardown: stop the live session, then drop the cached engine.
+  ///
+  /// **Tear down the ACTIVE session first, not just the cached slot.** Switching
+  /// the preview off mid-recording used to clear only the cache: `runSession`
+  /// still held the engine and session as locals, the feed loop kept running, and
+  /// a later `onText` could repaint over `.off`. So the model stayed loaded AND
+  /// DECODING for a feature the user had just changed — the worst version of the
+  /// leak, because it is also the visible one.
+  ///
+  /// **It does NOT clear `recordingSnapshot`, and that is load-bearing.** The
+  /// snapshot belongs to the RECORDING, not to the session: the overlay may not
+  /// have run its deferred geometry read yet, and clearing it here would let that
+  /// read answer live — the drift #2123 exists to remove. It is also what
+  /// suppresses restart, since `setRecording(true)` returns immediately while a
+  /// snapshot exists, so a duplicate intent push cannot start the newly chosen
+  /// engine inside the recording that was already under way. Only
+  /// `setRecording(false)` clears it.
+  private func stopPreviewAndRelease() {
     if isRunning {
       isRunning = false
       cancelSessionTask()

--- a/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
@@ -288,7 +288,22 @@ final class LivePreviewCoordinator: CorrectorVocabularyConsumer {
 
       // Nothing starts mid-removal: the files are about to go, and resolving now
       // would reload the model from a marker that has not been deleted yet.
+      //
+      // **Freeze the recording as DISABLED rather than returning bare** (#2137
+      // cloud review). Returning without a snapshot left this the one suppressed
+      // path whose decision was not sticky: the overlay forwards duplicate
+      // `.recording` pushes, so if removal finished mid-recording,
+      // `endRemovalSuppression()` cleared the guard and the next duplicate push
+      // sailed past BOTH guards — `recordingSnapshot` still nil, `isRemovingModel`
+      // now false — and started a preview partway through a recording that began
+      // with it suppressed. That is the exact behaviour the snapshot guard above
+      // exists to prevent for every other disabled path.
+      //
+      // Cleared on the matching `setRecording(false)` like any other snapshot, so
+      // the NEXT recording decides afresh and a user who removes a model mid-take
+      // is not suppressed beyond that take.
       guard !isRemovingModel else {
+        recordingSnapshot = RecordingSnapshot(route: selectedRoute(), enabled: false)
         display = .off
         return
       }

--- a/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
@@ -230,6 +230,19 @@ final class LivePreviewCoordinator: CorrectorVocabularyConsumer {
   }
   private var recordingSnapshot: RecordingSnapshot?
 
+  /// True from the moment removal starts until its files are gone.
+  ///
+  /// **Closes the reacquisition window.** Removal releases the engine first and
+  /// deletes second, and the admission marker is still present in between — so a
+  /// recording starting in that gap would resolve as admitted and load the model
+  /// again, straight back onto the files about to be unlinked. While this is set,
+  /// no recording opens a preview at all.
+  private var isRemovingModel = false
+
+  /// The removal drain in flight, so a second Remove press joins it rather than
+  /// starting a competing one.
+  private var removalDrain: Task<Void, Never>?
+
   /// `selectedRoute` answers "which engine is chosen right now" and is read once
   /// per recording. `isPreviewOn` is the user's toggle ALONE — support is the
   /// route's own answer (`isSupportedOnThisSystem`), so combining them here is
@@ -271,6 +284,13 @@ final class LivePreviewCoordinator: CorrectorVocabularyConsumer {
       // enabling the preview mid-recording would have the next duplicate push
       // start it, in a recording that began with it off.
       guard recordingSnapshot == nil else { return }
+
+      // Nothing starts mid-removal: the files are about to go, and resolving now
+      // would reload the model from a marker that has not been deleted yet.
+      guard !isRemovingModel else {
+        display = .off
+        return
+      }
 
       // Read the choice ONCE, here, and keep both halves. Everything downstream
       // reads this and never the live setting.
@@ -560,6 +580,70 @@ final class LivePreviewCoordinator: CorrectorVocabularyConsumer {
   /// Wired from `PipelineSettingsSync`'s `livePreviewEngine` case.
   func releaseForEngineChange() {
     stopPreviewAndRelease()
+  }
+
+  /// Release EVERYTHING that could be holding the model, and do not return until
+  /// it is actually let go (#2123).
+  ///
+  /// **Clearing the cache slot is not releasing the model, and that was the
+  /// defect.** FOUR things can hold it: the cached engine; a live session that
+  /// still owns it until its asynchronous `end()` completes; an in-flight
+  /// preparation task holding a fresh engine that invalidation does not stop; and
+  /// the session task itself between opening a session and registering its
+  /// teardown, when nothing else references it. The count went from three to four
+  /// mid-review, which is the whole argument for capturing holders rather than
+  /// listing them from memory.
+  /// Dropping only the first leaves an unlinked file whose blocks stay allocated,
+  /// so the disk space the user asked for never comes back.
+  ///
+  /// So this awaits the teardown rather than requesting it, and holds
+  /// `isRemovingModel` across the whole operation so nothing reacquires while the
+  /// admission marker is still on disk.
+  func releaseAndDrainForRemoval() async {
+    // **Single-flight.** The Remove button stays on screen during the drain, so a
+    // second press could otherwise enter a second removal, find the first one's
+    // holders already taken, delete while the first drain was still running, and
+    // lift the suppression early. Everyone awaits the first operation instead.
+    if let inFlight = removalDrain {
+      await inFlight.value
+      return
+    }
+
+    isRemovingModel = true
+
+    // **CAPTURE EVERY HOLDER BEFORE RELEASING ANYTHING.** The shared teardown
+    // clears `preparationTask` on its way through, so reading it afterwards
+    // always saw nil and the await did nothing — a barrier with a hole exactly
+    // where it claimed to be closed. Cloud review caught it.
+    //
+    // `sessionTask` matters for the same reason and is the holder I missed a
+    // second time: between opening a session and registering `liveTeardown`,
+    // nothing else references it, so cancelling without awaiting leaves an engine
+    // alive past the delete.
+    let preparation = preparationTask
+    let session = sessionTask
+    let alreadyDraining = drainingTeardown
+
+    let drain = Task { @MainActor [weak self] in
+      guard let self else { return }
+      self.stopPreviewAndRelease()
+
+      await alreadyDraining?.value
+      await session?.value
+      _ = await preparation?.value
+
+      // Anything a completion wrote back while we waited.
+      self.releasePreparedEngine()
+      self.drainingTeardown = nil
+      self.removalDrain = nil
+    }
+    removalDrain = drain
+    await drain.value
+  }
+
+  /// Removal is over: previews may run again.
+  func endRemovalSuppression() {
+    isRemovingModel = false
   }
 
   /// The shared teardown: stop the live session, then drop the cached engine.

--- a/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
@@ -2,6 +2,7 @@ import AVFoundation
 import EnviousWisprCore
 import EnviousWisprLivePreview
 import EnviousWisprPostProcessing
+import EnviousWisprServices
 import Foundation
 
 /// Read-only access to the audio the capture manager has already stored.
@@ -398,6 +399,12 @@ final class LivePreviewCoordinator: CorrectorVocabularyConsumer {
 
     guard case .ready(let candidate) = resolution else {
       if case .blocked(let reason) = resolution {
+        // The engine that REFUSED, from the route that answered — there is no
+        // candidate here, so the persisted choice is the only identity available.
+        // Always the ROUTE's closed id. The candidate key carries artifact
+        // identity, so reporting that would make this field high-cardinality —
+        // a new value on every model revision.
+        reportOutcome("blocked", engine: route.telemetryEngineID)
         display = .unavailable(Self.sentence(for: reason))
         // **A blocked engine must not stay cached (#2108).**
         //
@@ -429,6 +436,7 @@ final class LivePreviewCoordinator: CorrectorVocabularyConsumer {
 
     guard await ensurePrepared(candidate), let engine = preparedEngine else {
       guard isCurrent(generation) else { return }
+      reportOutcome("prepare_failed", engine: route.telemetryEngineID)
       display = .unavailable(LivePreviewCopy.notReady)
       await Self.log("not ready for \(candidate.key.engine)/\(candidate.key.commitment)")
       return
@@ -471,6 +479,7 @@ final class LivePreviewCoordinator: CorrectorVocabularyConsumer {
       session = try await engine.openSession(lookups: correctorLookups, onText: publish)
     } catch {
       guard isCurrent(generation) else { return }
+      reportOutcome("open_failed", engine: route.telemetryEngineID)
       display = .unavailable(LivePreviewCopy.notReady)
       await Self.log("session refused to start: \(error)")
       return
@@ -503,6 +512,13 @@ final class LivePreviewCoordinator: CorrectorVocabularyConsumer {
     // below. The task above still ends its session on this path.
     if isCurrent(generation) { liveTeardown = live }
 
+    // **Only for a recording that is still current.** `openSession` suspends, and
+    // a recording that ended — or a removal that started — while it was open
+    // leaves a session that is immediately torn down. Counting that as "started"
+    // would inflate the metric with previews the user never saw.
+    if isCurrent(generation) {
+      reportOutcome("started", engine: route.telemetryEngineID)
+    }
     await Self.log(
       "session started, engine=\(candidate.key.engine) on=\(candidate.key.commitment)")
     await live.value
@@ -711,6 +727,20 @@ final class LivePreviewCoordinator: CorrectorVocabularyConsumer {
     preparationTask = nil
     preparedEngine = nil
     preparedKey = nil
+  }
+
+  /// Report what this recording's preview did, exactly once (#2123).
+  ///
+  /// The engine name comes from the ROUTE's closed telemetry id — `apple` or
+  /// `universal` — and NOT from the resolved candidate's key.
+  ///
+  /// An earlier version of this comment said the opposite, and so did three of
+  /// the four call sites: the candidate key carries artifact identity, so the
+  /// universal engine reported `whisper_preview#<digest>` and the field gained a
+  /// new value on every model revision. A closed vocabulary is a dimension
+  /// someone can group by; the key is not.
+  private func reportOutcome(_ outcome: String, engine: String) {
+    TelemetryService.shared.livePreviewOutcome(engine: engine, outcome: outcome)
   }
 
   /// One log seam so every preview line carries the same category and the whole

--- a/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewInstaller.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewInstaller.swift
@@ -152,6 +152,10 @@ enum LivePreviewInstaller {
   /// because there is none — the fix is a release-build resource check, not a
   /// button.
   private static let unavailableInThisBuild = LivePreviewEngineRoute(
+    // The card the user selected is the universal one, so that is what a refusal
+    // here must report — the stand-in exists precisely because that engine could
+    // not be composed.
+    telemetryEngineID: "universal",
     isSupportedOnThisSystem: { true },
     resolve: { _ in .blocked(.engineUnavailableInThisBuild) }
   )

--- a/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewInstaller.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewInstaller.swift
@@ -1,4 +1,5 @@
 import EnviousWisprAudio
+import EnviousWisprCore
 import EnviousWisprLivePreview
 import EnviousWisprServices
 import Foundation
@@ -36,7 +37,8 @@ enum LivePreviewInstaller {
     overlay: RecordingOverlayPanel,
     capture: any AudioCaptureInterface,
     settings: SettingsManager,
-    settingsSync: PipelineSettingsSync
+    settingsSync: PipelineSettingsSync,
+    modelDelivery: ModelDeliveryHome
   ) -> LivePreviewCoordinator {
     // **Effective, not merely persisted** — the requirement this wiring exists
     // for, unchanged since #1988. A value saved as true on macOS 26 and then read
@@ -59,7 +61,14 @@ enum LivePreviewInstaller {
     // so geometry and resolution cannot disagree — which is the same guarantee
     // the old single expression gave, moved to the layer that can actually hold
     // it across the overlay's deferred panel creation.
-    let selectedRoute: () -> LivePreviewEngineRoute = { ApplePreviewEngineResolver.route }
+    // Both routes are composed ONCE; which one answers is read per recording.
+    let appleRoute = ApplePreviewEngineResolver.route
+    let universalRoute = WhisperPreviewDeliveryWiring.makeRoute(
+      modelDelivery: modelDelivery, settings: settings)
+
+    let selectedRoute: () -> LivePreviewEngineRoute = {
+      route(for: settings.livePreviewEngine, apple: appleRoute, universal: universalRoute)
+    }
     let coordinator = LivePreviewCoordinator(
       // The limb gets ONE read of already-captured audio, never the capture
       // interface itself: see `LivePreviewSampleReader`.
@@ -99,4 +108,40 @@ enum LivePreviewInstaller {
     }
     return coordinator
   }
+
+  /// Which route serves a choice — pure, so the one decision that must never
+  /// silently substitute one engine for another can be tested without a window,
+  /// an audio capture or a delivery home.
+  ///
+  /// **A missing universal route is NOT an Apple fallback.** `makeRoute` returns
+  /// nil only for a build defect — no delivery registration, or no bundled
+  /// tokenizer — and running Apple under a universal selection would make the
+  /// chosen card and the engine actually transcribing disagree, which is the
+  /// confusion this chunk exists to remove. For a user below macOS 26 it would
+  /// also silently restore the dead end this engine was added to fix: Apple's
+  /// route refuses there, so they would see "needs a newer macOS" after choosing
+  /// the engine that has no such requirement.
+  static func route(
+    for choice: LivePreviewEngineChoice,
+    apple: LivePreviewEngineRoute,
+    universal: LivePreviewEngineRoute?
+  ) -> LivePreviewEngineRoute {
+    switch choice {
+    case .apple: return apple
+    case .universal: return universal ?? unavailableInThisBuild
+    }
+  }
+
+  /// The honest stand-in when an engine cannot be composed at all.
+  ///
+  /// Supported on this system, so the pill is still SIZED and can carry the
+  /// sentence: reporting `false` here would make the preview silently do nothing,
+  /// which reads as the feature being broken rather than as this build being
+  /// wrong. Resolution refuses with the reason that offers no user remedy,
+  /// because there is none — the fix is a release-build resource check, not a
+  /// button.
+  private static let unavailableInThisBuild = LivePreviewEngineRoute(
+    isSupportedOnThisSystem: { true },
+    resolve: { _ in .blocked(.engineUnavailableInThisBuild) }
+  )
 }

--- a/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewInstaller.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewInstaller.swift
@@ -106,6 +106,17 @@ enum LivePreviewInstaller {
     settingsSync.onLivePreviewEngineChanged = { [weak coordinator] in
       coordinator?.releaseForEngineChange()
     }
+
+    // #2123: removing the model must free the DISK, and an unlinked file that is
+    // still mapped frees nothing. So the limb drops its loaded engine before the
+    // files are deleted, not after. Same teardown as an engine switch — the
+    // engine is going away either way — and weak for the same reason.
+    modelDelivery.drainPreviewHoldersBeforeRemoval = { [weak coordinator] in
+      await coordinator?.releaseAndDrainForRemoval()
+    }
+    modelDelivery.previewRemovalDidFinish = { [weak coordinator] in
+      coordinator?.endRemovalSuppression()
+    }
     return coordinator
   }
 

--- a/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewInstaller.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewInstaller.swift
@@ -38,33 +38,42 @@ enum LivePreviewInstaller {
     settings: SettingsManager,
     settingsSync: PipelineSettingsSync
   ) -> LivePreviewCoordinator {
-    // **Effective, not merely persisted.** A value saved as true on macOS 26 and
-    // then read on an older system used to enlarge the pill on every recording and
-    // fill it with "needs macOS 26" — while the toggle that would turn it off was
-    // disabled for the same reason, so the user could not stop it. Folding the OS
-    // check in here means an unsupported system behaves exactly like the setting
-    // being off: normal pill, no message, nothing to escape from. One expression,
-    // used for both the geometry and the coordinator, so the two cannot disagree.
+    // **Effective, not merely persisted** — the requirement this wiring exists
+    // for, unchanged since #1988. A value saved as true on macOS 26 and then read
+    // on an older system used to enlarge the pill on every recording and fill it
+    // with "needs macOS 26", while the toggle that would turn it off was disabled
+    // for the same reason, so the user could not stop it. An unsupported system
+    // must behave exactly like the setting being off: normal pill, no message,
+    // nothing to escape from.
     //
-    // **This line is where engine selection will live.** One route, read for both
-    // halves below: the OS check is Apple's rule rather than the feature's, and it
-    // comes from the same value the recording resolves against, so a pill sized for
-    // a preview that then refuses to run is not expressible. When the user can
-    // choose an engine, only this line changes.
-    let route = ApplePreviewEngineResolver.route
-    let effectivelyEnabled: () -> Bool = {
-      route.isSupportedOnThisSystem() && settings.livePreviewEnabled
-    }
+    // **WHERE that expression lives has moved (#2123), and the old comment here
+    // claimed three things that are now false**: that the OS check is folded in
+    // at this line, that one expression feeds both consumers from here, and that
+    // choosing an engine would change only this line. The plan's own grounding
+    // disproved the third — the installer also takes the delivery home, builds
+    // both routes, and gains a second settings hook.
+    //
+    // What is true now: the installer COMPOSES the provider, and
+    // `LivePreviewCoordinator` owns the answer. It reads this provider once per
+    // recording and freezes the route together with the effective-enabled value,
+    // so geometry and resolution cannot disagree — which is the same guarantee
+    // the old single expression gave, moved to the layer that can actually hold
+    // it across the overlay's deferred panel creation.
+    let selectedRoute: () -> LivePreviewEngineRoute = { ApplePreviewEngineResolver.route }
     let coordinator = LivePreviewCoordinator(
       // The limb gets ONE read of already-captured audio, never the capture
       // interface itself: see `LivePreviewSampleReader`.
       readSamples: { index in await capture.getSamplesSnapshot(fromIndex: index) },
-      isEnabled: effectivelyEnabled,
+      isPreviewOn: { settings.livePreviewEnabled },
       languageMode: { settings.languageMode },
-      resolveEngine: route.resolve
+      selectedRoute: selectedRoute
     )
+    // Geometry reads the COORDINATOR's frozen answer, not a second live
+    // computation. The overlay creates its panel on the next run-loop cycle and
+    // reads this inside that deferred work, so a live read here could size a pill
+    // for one engine while the recording resolves another.
     overlay.setLivePreviewProviders(
-      enabled: effectivelyEnabled,
+      enabled: { coordinator.isEnabledForGeometry },
       display: { coordinator.display }
     )
     overlay.setRecordingIntentObserver { recording in

--- a/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewInstaller.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewInstaller.swift
@@ -91,6 +91,12 @@ enum LivePreviewInstaller {
     settingsSync.onLivePreviewDisabled = { [weak coordinator] in
       coordinator?.releaseForDisabledSetting()
     }
+    // #2123: same shape, different meaning — the preview stays on and the engine
+    // beneath it changed, so the old engine's model is released. Weak for the
+    // same reason: a settings hook must never be what keeps the limb alive.
+    settingsSync.onLivePreviewEngineChanged = { [weak coordinator] in
+      coordinator?.releaseForEngineChange()
+    }
     return coordinator
   }
 }

--- a/Sources/EnviousWisprAppKit/App/LivePreview/WhisperPreviewDeliveryWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/WhisperPreviewDeliveryWiring.swift
@@ -22,9 +22,30 @@ import Foundation
 @MainActor
 enum WhisperPreviewDeliveryWiring {
 
-  /// Build the preview engine's route, or nil when the bundled manifest failed to
-  /// load — the same can't-happen-in-release condition the sibling registrations
-  /// guard.
+  /// Where the bundled tokenizer lives, or nil if this build did not ship one.
+  ///
+  /// **One authority, because the UI needs the same answer.** The picker asks
+  /// whether the universal engine exists at all; asking only whether the model is
+  /// REGISTERED would enable the toggle and offer a Download for an engine that
+  /// can never run, since a route also needs this. Cloud review found exactly
+  /// that gap.
+  static func bundledTokenizerDirectory() -> URL? {
+    Bundle.main.url(forResource: "WhisperPreviewTokenizer", withExtension: nil)
+  }
+
+  /// Whether a universal route can be composed in this build at all — the same
+  /// two conditions `makeRoute` checks, asked without building anything.
+  ///
+  /// The UI needs this answer BEFORE it offers a control: asking only whether the
+  /// model is REGISTERED would enable the toggle and offer a Download for an
+  /// engine that could never run, because a route also needs the tokenizer.
+  static func isComposable(modelDelivery: ModelDeliveryHome) -> Bool {
+    modelDelivery.whisperPreviewRegistration != nil && bundledTokenizerDirectory() != nil
+  }
+
+  /// Build the preview engine's route, or nil when this build cannot compose one
+  /// — no delivery registration, or no bundled tokenizer. The same
+  /// can't-happen-in-release condition the sibling registrations guard.
   ///
   /// **Nil means UNAVAILABLE IN THIS BUILD, not not-installed** (#2123). The
   /// caller renders `engineUnavailableInThisBuild`, which offers no user remedy,
@@ -38,10 +59,7 @@ enum WhisperPreviewDeliveryWiring {
   ) -> LivePreviewEngineRoute? {
     guard let registration = modelDelivery.whisperPreviewRegistration else { return nil }
 
-    guard
-      let tokenizerDirectory = Bundle.main.url(
-        forResource: "WhisperPreviewTokenizer", withExtension: nil)
-    else {
+    guard let tokenizerDirectory = bundledTokenizerDirectory() else {
       // No tokenizer, no engine. Refusing here is deliberate: WhisperKit's
       // tokenizer search runs independently of `download: false`, so a nil
       // folder can reach the network, and the app's other bundled tokenizer is

--- a/Sources/EnviousWisprAppKit/App/LivePreview/WhisperPreviewDeliveryWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/WhisperPreviewDeliveryWiring.swift
@@ -24,8 +24,14 @@ enum WhisperPreviewDeliveryWiring {
 
   /// Build the preview engine's route, or nil when the bundled manifest failed to
   /// load — the same can't-happen-in-release condition the sibling registrations
-  /// guard, and the same honest answer: no route means the engine reports
-  /// not-installed rather than guessing.
+  /// guard.
+  ///
+  /// **Nil means UNAVAILABLE IN THIS BUILD, not not-installed** (#2123). The
+  /// caller renders `engineUnavailableInThisBuild`, which offers no user remedy,
+  /// because there is none: nothing shipped for this engine and no download can
+  /// supply it. Reporting not-installed would send someone to a button that
+  /// cannot help, and falling back to Apple would make the chosen card and the
+  /// running engine disagree.
   static func makeRoute(
     modelDelivery: ModelDeliveryHome,
     settings: SettingsManager

--- a/Sources/EnviousWisprAppKit/App/ModelDeliveryHome.swift
+++ b/Sources/EnviousWisprAppKit/App/ModelDeliveryHome.swift
@@ -49,6 +49,28 @@ public final class ModelDeliveryHome {
 
   /// Observable mirror of the Parakeet delivery state for SwiftUI renderers.
   public private(set) var parakeetState: DeliveryState = .notReady
+
+  /// Observable mirror of the PREVIEW model's delivery state (#2123).
+  ///
+  /// Lives here rather than on the settings page because the page is destroyed
+  /// during navigation — the Apple-pack model is window-owned for exactly that
+  /// reason — and a 217 MB download must not lose its progress because someone
+  /// looked at another tab.
+  public private(set) var whisperPreviewState: DeliveryState = .notReady
+
+  /// **A SEPARATE apply guard, not a share of the Parakeet one.** Each mirror
+  /// has its own sequencer, each starting at zero, so one shared "last applied"
+  /// counter would let whichever model published first suppress the other's
+  /// updates — a download that silently stopped reporting progress, which looks
+  /// exactly like a stalled download.
+  private var lastAppliedPreviewStateSeq: UInt64 = 0
+
+  /// How many updates each mirror has APPLIED. Test seams, because "the mirror
+  /// is wired to the right identity" is otherwise unobservable: both mirrors
+  /// start `.notReady`, so comparing values cannot tell a working observer from
+  /// a deleted one or one filtered on the wrong identity.
+  package private(set) var previewStateUpdatesForTests = 0
+  package private(set) var parakeetStateUpdatesForTests = 0
   /// Monotonic apply guard (EG-1 `installStateSeqApplied` precedent, made
   /// REAL per exhaustive r7 finding 7): the sequence is minted at observer-
   /// receive time (controller actor, in publish order) and a MainActor hop
@@ -177,6 +199,7 @@ public final class ModelDeliveryHome {
       Task { await controller.sweepSupersededStaging(registration) }
       whisperPreviewHandle = WhisperKitDeliveryHandle(
         controller: controller, registration: registration)
+      wirePreviewObserver(identity: manifest.identity)
       let previewHome = self
       Task { await previewHome.recordFirstRunBaseline(for: registration) }
     } catch {
@@ -186,6 +209,34 @@ public final class ModelDeliveryHome {
             + "unavailable-in-this-build (#2123: NOT not-installed, since no download can "
             + "supply what this build never shipped): \(error)",
           level: .info, category: "Delivery")
+      }
+    }
+  }
+
+  /// Mirror the PREVIEW model's delivery state (#2123).
+  ///
+  /// **Called from the preview's own registration block, never from Parakeet's.**
+  /// The first version nested this inside `wireObservers`, which only runs when
+  /// the PARAKEET manifest loads — so a build where Parakeet failed to register
+  /// and the preview succeeded would leave this mirror permanently unwired, and
+  /// the picker would show a download that never appears to start. Two
+  /// registrations, two independent wirings.
+  private func wirePreviewObserver(identity: ModelIdentity) {
+    let home = self
+    let sequencer = DeliveryStateSequencer()
+    Task {
+      await controller.addStateObserver { observedIdentity, state in
+        guard observedIdentity == identity else { return }
+        // Minted on the controller actor in publish order, applied on the main
+        // actor only if newer — the same discipline as the Parakeet mirror, with
+        // its OWN counter. See `lastAppliedPreviewStateSeq`.
+        let seq = sequencer.next()
+        Task { @MainActor in
+          guard seq > home.lastAppliedPreviewStateSeq else { return }
+          home.lastAppliedPreviewStateSeq = seq
+          home.whisperPreviewState = state
+          home.previewStateUpdatesForTests += 1
+        }
       }
     }
   }
@@ -208,6 +259,7 @@ public final class ModelDeliveryHome {
           guard seq > home.lastAppliedStateSeq else { return }
           home.lastAppliedStateSeq = seq
           home.parakeetState = state
+          home.parakeetStateUpdatesForTests += 1
           if case .admitted = state { home.firstRunByIdentity[observedIdentity] = false }
         }
       }

--- a/Sources/EnviousWisprAppKit/App/ModelDeliveryHome.swift
+++ b/Sources/EnviousWisprAppKit/App/ModelDeliveryHome.swift
@@ -113,9 +113,15 @@ public final class ModelDeliveryHome {
   ///   running it has ever used the feature. Parakeet's ASR cache is deliberately
   ///   NOT rerouted: it comes from `AsrModels.defaultCacheDirectory` and is not
   ///   part of what the probe touches.
+  /// - Parameter deliveryFlagDefaults: where the delivery kill switches are read
+  ///   from. Production never passes it, so both handles fall back to the shared
+  ///   suite exactly as before. Tests pass an in-memory suite, because the guard
+  ///   in `startPreviewDownload` reads this and the only alternative way to
+  ///   exercise it would be writing an operational kill switch into the real
+  ///   store on a developer's machine.
   init(
     engineMutationScope: EngineMutationScope, manifestBundle: Bundle,
-    appSupportOverride: URL? = nil
+    appSupportOverride: URL? = nil, deliveryFlagDefaults: UserDefaults? = nil
   ) {
     self.engineMutationScope = engineMutationScope
     let appSupportRoot =
@@ -162,7 +168,7 @@ public final class ModelDeliveryHome {
       whisperKitRegistration = registration
       Task { await controller.sweepSupersededStaging(registration) }
       whisperKitHandle = WhisperKitDeliveryHandle(
-        controller: controller, registration: registration)
+        controller: controller, registration: registration, defaults: deliveryFlagDefaults)
       let home = self
       Task { await home.recordFirstRunBaseline(for: registration) }
     } catch {
@@ -210,7 +216,7 @@ public final class ModelDeliveryHome {
       whisperPreviewRegistration = registration
       Task { await controller.sweepSupersededStaging(registration) }
       whisperPreviewHandle = WhisperKitDeliveryHandle(
-        controller: controller, registration: registration)
+        controller: controller, registration: registration, defaults: deliveryFlagDefaults)
       let previewHome = self
       let previewIdentity = manifest.identity
       // The launch PROBE (#2123 whole-diff review).
@@ -362,8 +368,34 @@ public final class ModelDeliveryHome {
   /// that the heart never loads, so taking the claim would let a preview
   /// download block a dictation from switching engines — the limb interfering
   /// with the heart, which is the one thing this feature must never do.
+  /// **Honours the WhisperKit family kill switch** (#2137 cloud review). The
+  /// primary WhisperKit download door guards `handle.isEnabled()` immediately
+  /// before `ensureAvailable()` (`WhisperKitDeliveryWiring.swift:74,125`), because
+  /// `ensureAvailable` does NOT enforce the flag itself. This door did not, so
+  /// with `modelDelivery.whisper_kit.enabled` set false an operator had disabled
+  /// the whole family and this path would still start a 217 MB fetch — bypassing
+  /// the relaunch-free delivery rollback that flag exists to provide.
+  ///
+  /// The preview model IS in that family (same `whisper_kit` registration family,
+  /// differing only by variant), so one flag correctly covers both.
+  ///
+  /// Deliberately guards only the DOWNLOAD door. Cancel and Remove stay reachable
+  /// with the flag off: a kill switch on delivery must not trap a user with a
+  /// model they cannot cancel or delete, and neither starts network work.
   public func startPreviewDownload() {
     guard let handle = whisperPreviewHandle else { return }
+    guard handle.isEnabled() else {
+      // Logged rather than silent: a Download button that does nothing is
+      // otherwise indistinguishable from a broken one, and the flag is remote,
+      // so whoever debugs this will not know it was set.
+      Task {
+        await AppLogger.shared.log(
+          "Preview download refused: the whisper_kit delivery kill switch is off "
+            + "(modelDelivery.whisper_kit.enabled = false)",
+          level: .info, category: "Delivery")
+      }
+      return
+    }
     Task { _ = await handle.ensureAvailable() }
   }
 

--- a/Sources/EnviousWisprAppKit/App/ModelDeliveryHome.swift
+++ b/Sources/EnviousWisprAppKit/App/ModelDeliveryHome.swift
@@ -379,9 +379,23 @@ public final class ModelDeliveryHome {
   /// The preview model IS in that family (same `whisper_kit` registration family,
   /// differing only by variant), so one flag correctly covers both.
   ///
-  /// Deliberately guards only the DOWNLOAD door. Cancel and Remove stay reachable
-  /// with the flag off: a kill switch on delivery must not trap a user with a
-  /// model they cannot cancel or delete, and neither starts network work.
+  /// Adds a guard only to THIS door, because the other two doors already carry
+  /// the family's answer and they do not agree with each other:
+  ///
+  /// - `cancelActiveFetch()` is NOT gated (`WhisperKitModelDelivery.swift:111`),
+  ///   so Cancel stays reachable with the flag off. That is the right shape — a
+  ///   kill switch on delivery must not strand a user mid-download with no way
+  ///   to stop it, and cancelling starts no network work.
+  /// - `remove()` IS gated and returns `false` without touching the controller
+  ///   (`WhisperKitModelDelivery.swift:124`). That is deliberate and owned
+  ///   there: the flag stands down the WHOLE delivery layer, deletions included
+  ///   (EG-1 §16.6 precedent). So with the flag off the user genuinely CANNOT
+  ///   remove the model, and the model staying on disk is the intended
+  ///   consequence of an operator freezing delivery, not a defect here.
+  ///
+  /// Do not "fix" that asymmetry from this file. Changing `remove()` would
+  /// change a shared primitive the main transcription model also uses, against
+  /// its owner's stated intent.
   public func startPreviewDownload() {
     guard let handle = whisperPreviewHandle else { return }
     guard handle.isEnabled() else {
@@ -484,12 +498,33 @@ public final class ModelDeliveryHome {
       self?.removalStepsForTests.append("drain")
       if let substitute = self?.deletePreviewModelOverrideForTests {
         await substitute()
-      } else {
-        _ = await handle.remove()
+      } else if await handle.remove() == false {
+        // `remove()` refuses when the family kill switch is off and deletes
+        // nothing (`WhisperKitModelDelivery.swift:124`, deliberate). Logged for
+        // the same reason the download refusal is: the flag is set remotely, so
+        // whoever reads the "Remove does nothing" report cannot otherwise tell a
+        // stood-down delivery layer from a broken button.
+        //
+        // KNOWN LIMIT, deliberately not widened here: the user still sees no
+        // explanation, only a Remove that leaves the model in place. Surfacing
+        // one needs new user-facing copy and a new card state, which is a
+        // product decision rather than a review fix.
+        self?.removalStepsForTests.append("refused")
+        await AppLogger.shared.log(
+          "Preview removal deleted nothing: the whisper_kit delivery kill switch "
+            + "is off (modelDelivery.whisper_kit.enabled = false)",
+          level: .info, category: "Delivery")
       }
       self?.removalStepsForTests.append("delete")
       // Only now may a preview run again: until the marker is deleted, a
       // resolution would still read the model as admitted.
+      //
+      // Runs UNCONDITIONALLY, including on the refusal above, and that is not an
+      // oversight. This signal means "no longer removing", never "removal
+      // succeeded" — it clears `isRemovingModel` in the coordinator. Skipping it
+      // on a refusal would leave that suppression latched forever and kill Live
+      // Preview for the rest of the launch, trading a model that will not delete
+      // for a feature that will not run.
       self?.previewRemovalDidFinish?()
       self?.removalStepsForTests.append("finish")
       self?.removalTask = nil

--- a/Sources/EnviousWisprAppKit/App/ModelDeliveryHome.swift
+++ b/Sources/EnviousWisprAppKit/App/ModelDeliveryHome.swift
@@ -183,7 +183,8 @@ public final class ModelDeliveryHome {
       Task {
         await AppLogger.shared.log(
           "Live Preview model manifest unavailable — the universal preview engine will report "
-            + "not-installed: \(error)",
+            + "unavailable-in-this-build (#2123: NOT not-installed, since no download can "
+            + "supply what this build never shipped): \(error)",
           level: .info, category: "Delivery")
       }
     }

--- a/Sources/EnviousWisprAppKit/App/ModelDeliveryHome.swift
+++ b/Sources/EnviousWisprAppKit/App/ModelDeliveryHome.swift
@@ -327,6 +327,104 @@ public final class ModelDeliveryHome {
     Task { _ = await handle.ensureAvailable() }
   }
 
+  /// Called BEFORE the preview model's files are deleted, so whoever holds the
+  /// loaded model can let go of it first.
+  ///
+  /// **Unlinking an open file does not reclaim its blocks.** macOS lets the
+  /// delete succeed while a mapping is alive, and the space only returns when the
+  /// last handle closes — so deleting under a loaded engine frees nothing until
+  /// something drops it, and nothing would, if the user never records again.
+  /// Reclaiming the disk is the entire point of this control, so the release is
+  /// part of removal rather than a consequence of it.
+  /// Awaited before the files are deleted, and its completion is the promise that
+  /// nothing still holds the model. Async on purpose: a synchronous hook can only
+  /// REQUEST a release, and a live session owns the engine until its own
+  /// asynchronous teardown finishes.
+  public var drainPreviewHoldersBeforeRemoval: (() async -> Void)?
+
+  /// Called once the files are gone, so previews can run again.
+  public var previewRemovalDidFinish: (() -> Void)?
+
+  /// Delete the preview model and reclaim its ~217 MB.
+  ///
+  /// The controller's `remove` is already thorough and ordered correctly: it
+  /// cancels anything in flight, deletes the admission MARKER FIRST so
+  /// `isAdmitted()` goes false immediately, then the component roots, then
+  /// staging. Nothing here re-implements that.
+  ///
+  /// **Two earlier versions of this comment were wrong, and the second was worse
+  /// than the first, so the reasoning is recorded rather than the conclusion.**
+  ///
+  /// First it claimed the next recording would release the cached engine via
+  /// `modelNotInstalled`. The bound is real — every recording resolves before it
+  /// can reuse a cached engine, and the blocked path releases on ANY refusal —
+  /// but naming one reason was wrong: the resolver checks heart contention FIRST,
+  /// so a recording starting while the transcription engine streams refuses with
+  /// `heartIsStreaming` instead.
+  ///
+  /// Then it claimed the disk space returns immediately. It does not. Unlinking
+  /// a file that is open or memory-mapped succeeds, but its BLOCKS are not
+  /// reclaimed until the last handle closes — and "the next recording" may never
+  /// come, so a user who removes the model and stops using the app would free
+  /// nothing at all. Reclaiming space is the whole point of this control, so it
+  /// cannot depend on a later event.
+  ///
+  /// Hence `drainPreviewHoldersBeforeRemoval`, AWAITED before the delete: every
+  /// holder lets go, then the files go. Awaited rather than merely called,
+  /// because a synchronous hook can only request a release — a live session owns
+  /// its engine until its own asynchronous teardown completes.
+  /// The order removal actually executed in, for tests.
+  ///
+  /// A seam because the ORDER is the contract and nothing else can observe it.
+  /// Asserting that removal "finished after the drain" stays green with the
+  /// delete moved first, since the finish callback trails both either way —
+  /// cloud review demonstrated exactly that against an earlier test of mine.
+  package private(set) var removalStepsForTests: [String] = []
+
+  /// The removal in flight, so a second press joins nothing rather than starting
+  /// a competing delete.
+  private var removalTask: Task<Void, Never>?
+
+  /// The actual deletion, replaceable by tests.
+  ///
+  /// **Because the registration points at the REAL Application Support
+  /// directory.** `manifestBundle` redirects only where manifests are READ from;
+  /// the install root and the shared admission metadata are the user's own. A
+  /// test that calls the real removal therefore deletes a developer's installed
+  /// preview model when the suite runs — which is why the observer test above
+  /// deliberately uses a non-destructive trigger, and why the removal tests must
+  /// substitute this. Cloud review caught the regression.
+  package var deletePreviewModelOverrideForTests: (() async -> Void)?
+
+  public func removePreviewModel() {
+    guard let handle = whisperPreviewHandle else { return }
+    // **Single-flight the WHOLE operation, not just the drain.** Guarding only
+    // the coordinator's drain let two presses share it and then run two deletes
+    // and two finish callbacks — and one finish lifts the suppression while the
+    // other removal is still going, reopening the window it exists to close.
+    // The button stays on screen throughout, so a second press is ordinary.
+    guard removalTask == nil else { return }
+    removalStepsForTests = []
+    let task = Task { [weak self] in
+      // AWAIT the drain, do not merely request it. Every holder must be gone
+      // before the unlink, or the blocks stay allocated behind an open mapping.
+      await self?.drainPreviewHoldersBeforeRemoval?()
+      self?.removalStepsForTests.append("drain")
+      if let substitute = self?.deletePreviewModelOverrideForTests {
+        await substitute()
+      } else {
+        _ = await handle.remove()
+      }
+      self?.removalStepsForTests.append("delete")
+      // Only now may a preview run again: until the marker is deleted, a
+      // resolution would still read the model as admitted.
+      self?.previewRemovalDidFinish?()
+      self?.removalStepsForTests.append("finish")
+      self?.removalTask = nil
+    }
+    removalTask = task
+  }
+
   /// Stop a download in flight. Safe when nothing is running: the controller
   /// reports `nothingToCancel` and no state moves.
   public func cancelPreviewDownload() {

--- a/Sources/EnviousWisprAppKit/App/ModelDeliveryHome.swift
+++ b/Sources/EnviousWisprAppKit/App/ModelDeliveryHome.swift
@@ -311,6 +311,29 @@ public final class ModelDeliveryHome {
 
   /// Settings-row Resume / Try Again: re-enters the single door (resume-aware
   /// by construction — staged partials survive a cancel).
+  // MARK: - #2123: the preview model's own controls
+
+  /// Start, resume or retry the preview model's download — one method, because
+  /// from the delivery layer's side those are the same operation and only the
+  /// user-facing verb differs (the card decides which word to show).
+  ///
+  /// **No mutation claim, unlike Parakeet's.** That claim serializes changes to
+  /// the ENGINE the heart transcribes with; this model is a display-only limb
+  /// that the heart never loads, so taking the claim would let a preview
+  /// download block a dictation from switching engines — the limb interfering
+  /// with the heart, which is the one thing this feature must never do.
+  public func startPreviewDownload() {
+    guard let handle = whisperPreviewHandle else { return }
+    Task { _ = await handle.ensureAvailable() }
+  }
+
+  /// Stop a download in flight. Safe when nothing is running: the controller
+  /// reports `nothingToCancel` and no state moves.
+  public func cancelPreviewDownload() {
+    guard let handle = whisperPreviewHandle else { return }
+    Task { await handle.cancelActiveFetch() }
+  }
+
   public func resumeParakeetDownload() {
     guard let handle = parakeetHandle else { return }
     Task { [weak self] in

--- a/Sources/EnviousWisprAppKit/App/ModelDeliveryHome.swift
+++ b/Sources/EnviousWisprAppKit/App/ModelDeliveryHome.swift
@@ -105,8 +105,22 @@ public final class ModelDeliveryHome {
   /// so tests pass a bundle pointed at the SAME committed manifest files
   /// instead of a divergent fixture. Internal, not public — no other
   /// consumer needs it.
-  init(engineMutationScope: EngineMutationScope, manifestBundle: Bundle) {
+  /// - Parameter appSupportOverride: roots the metadata and WhisperKit install
+  ///   directories somewhere other than the user's real Application Support.
+  ///   Production never passes it. Tests do, because construction now runs a
+  ///   no-fetch launch probe against those directories, and a suite that reads
+  ///   the real ones has a fixture that changes depending on whether the machine
+  ///   running it has ever used the feature. Parakeet's ASR cache is deliberately
+  ///   NOT rerouted: it comes from `AsrModels.defaultCacheDirectory` and is not
+  ///   part of what the probe touches.
+  init(
+    engineMutationScope: EngineMutationScope, manifestBundle: Bundle,
+    appSupportOverride: URL? = nil
+  ) {
     self.engineMutationScope = engineMutationScope
+    let appSupportRoot =
+      appSupportOverride
+      ?? FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
     do {
       let manifest = try DeliveryManifest.loadBundled(
         resource: "parakeet-delivery-manifest", bundle: manifestBundle)
@@ -114,8 +128,8 @@ public final class ModelDeliveryHome {
       let registration = DeliveryRegistration(
         manifest: manifest,
         installDirectory: AsrModels.defaultCacheDirectory(for: .v3),
-        metadataDirectory: FileManager.default.urls(
-          for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        metadataDirectory:
+          appSupportRoot
           .appendingPathComponent("EnviousWispr/ModelDelivery", isDirectory: true))
       parakeetIdentity = identity
       parakeetRegistration = registration
@@ -138,8 +152,7 @@ public final class ModelDeliveryHome {
     do {
       let manifest = try DeliveryManifest.loadBundled(
         resource: "whisperkit-delivery-manifest", bundle: manifestBundle)
-      let appSupport = FileManager.default.urls(
-        for: .applicationSupportDirectory, in: .userDomainMask)[0]
+      let appSupport = appSupportRoot
       let registration = DeliveryRegistration(
         manifest: manifest,
         installDirectory: appSupport.appendingPathComponent(
@@ -181,8 +194,7 @@ public final class ModelDeliveryHome {
     do {
       let manifest = try DeliveryManifest.loadBundled(
         resource: "whisperkit-preview-delivery-manifest", bundle: manifestBundle)
-      let appSupport = FileManager.default.urls(
-        for: .applicationSupportDirectory, in: .userDomainMask)[0]
+      let appSupport = appSupportRoot
       let registration = DeliveryRegistration(
         manifest: manifest,
         // `whisper-preview`, deliberately a SIBLING of `whisper` and never that
@@ -199,9 +211,34 @@ public final class ModelDeliveryHome {
       Task { await controller.sweepSupersededStaging(registration) }
       whisperPreviewHandle = WhisperKitDeliveryHandle(
         controller: controller, registration: registration)
-      wirePreviewObserver(identity: manifest.identity)
       let previewHome = self
-      Task { await previewHome.recordFirstRunBaseline(for: registration) }
+      let previewIdentity = manifest.identity
+      // The launch PROBE (#2123 whole-diff review).
+      //
+      // A model admitted in a PREVIOUS app session leaves this controller with no
+      // in-memory entry, so there is nothing for a fresh observer to be told
+      // about and the card reports "Not downloaded yet" — hiding Remove — for a
+      // model that is on disk. `recordFirstRunBaseline` cannot fix that: it
+      // records whether this is a first run, it does not publish a state. So the
+      // launch path has to probe, and `admitIfComplete` is the safe one: it
+      // reaches `startAttempt` with `fetchIfMissing: false`, so it can adopt what
+      // is already complete and can never start a download.
+      //
+      // ONE ordered task because ONE ordering is load-bearing: the baseline must
+      // be taken BEFORE the probe, since it records `!admitted` and the probe is
+      // what changes `admitted`.
+      //
+      // Attach-before-probe is NOT load-bearing, and the first version of this
+      // comment claimed it was. `ModelDeliveryController.addStateObserver`
+      // replays the current state of every existing entry to a newly attached
+      // observer, so a probe that publishes first is still delivered. Verified by
+      // mutation: reversing these two lines leaves the suite green. Sequencing
+      // them anyway costs nothing and reads in the order it happens.
+      Task {
+        await previewHome.attachPreviewObserver(identity: previewIdentity)
+        await previewHome.recordFirstRunBaseline(for: registration)
+        _ = await previewHome.controller.admitIfComplete(registration)
+      }
     } catch {
       Task {
         await AppLogger.shared.log(
@@ -221,22 +258,25 @@ public final class ModelDeliveryHome {
   /// and the preview succeeded would leave this mirror permanently unwired, and
   /// the picker would show a download that never appears to start. Two
   /// registrations, two independent wirings.
-  private func wirePreviewObserver(identity: ModelIdentity) {
+  ///
+  /// `async` rather than spawning its own detached task, so the registration
+  /// block reads as the sequence it is. NOT because a late attach would lose a
+  /// publish — `addStateObserver` replays each existing entry's current state to
+  /// a new observer, which is what makes attach order safe either way.
+  private func attachPreviewObserver(identity: ModelIdentity) async {
     let home = self
     let sequencer = DeliveryStateSequencer()
-    Task {
-      await controller.addStateObserver { observedIdentity, state in
-        guard observedIdentity == identity else { return }
-        // Minted on the controller actor in publish order, applied on the main
-        // actor only if newer — the same discipline as the Parakeet mirror, with
-        // its OWN counter. See `lastAppliedPreviewStateSeq`.
-        let seq = sequencer.next()
-        Task { @MainActor in
-          guard seq > home.lastAppliedPreviewStateSeq else { return }
-          home.lastAppliedPreviewStateSeq = seq
-          home.whisperPreviewState = state
-          home.previewStateUpdatesForTests += 1
-        }
+    await controller.addStateObserver { observedIdentity, state in
+      guard observedIdentity == identity else { return }
+      // Minted on the controller actor in publish order, applied on the main
+      // actor only if newer — the same discipline as the Parakeet mirror, with
+      // its OWN counter. See `lastAppliedPreviewStateSeq`.
+      let seq = sequencer.next()
+      Task { @MainActor in
+        guard seq > home.lastAppliedPreviewStateSeq else { return }
+        home.lastAppliedPreviewStateSeq = seq
+        home.whisperPreviewState = state
+        home.previewStateUpdatesForTests += 1
       }
     }
   }

--- a/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
+++ b/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
@@ -245,6 +245,12 @@ final class PipelineSettingsSync {
       // recording start, which a user who simply stops using the feature never
       // reaches.
       onLivePreviewDisabled()
+    case .livePreviewEngine:
+      // #2123 chunk A: the value exists and nothing reads it yet. An explicit
+      // `break` rather than folding it into a group, so chunk C has one obvious
+      // place to wire `onLivePreviewEngineChanged` — and so the compiler keeps
+      // pointing here until it does.
+      break
     case .appearance:
       break  // UI-only; applied to NSApp.appearance by the app shell (#1047).
     case .overlayPillPosition:

--- a/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
+++ b/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
@@ -29,6 +29,10 @@ final class PipelineSettingsSync {
   /// cached engine. Same shape as `onSelectedBackendChanged` above: a closure the
   /// composition root wires, so this type still learns nothing about the preview.
   var onLivePreviewDisabled: () -> Void = {}
+  /// #2123: the chosen preview engine changed. Separate from the disabled hook
+  /// because the two mean different things — "stop previewing" versus "preview
+  /// with something else" — and a single hook would have to re-derive which.
+  var onLivePreviewEngineChanged: () -> Void = {}
 
   /// Tracks the last evictable Ollama model for #295. Independent of the
   /// kernel's polish step because SettingsManager's cascading didSet can
@@ -246,11 +250,11 @@ final class PipelineSettingsSync {
       // reaches.
       onLivePreviewDisabled()
     case .livePreviewEngine:
-      // #2123 chunk A: the value exists and nothing reads it yet. An explicit
-      // `break` rather than folding it into a group, so chunk C has one obvious
-      // place to wire `onLivePreviewEngineChanged` — and so the compiler keeps
-      // pointing here until it does.
-      break
+      // #2123: the preview is still ON — the engine underneath it changed. The
+      // limb releases what it prepared for the old one; the PIPELINE still never
+      // learns the preview exists, which is why this is a notification and not a
+      // dependency.
+      onLivePreviewEngineChanged()
     case .appearance:
       break  // UI-only; applied to NSApp.appearance by the app shell (#1047).
     case .overlayPillPosition:

--- a/Sources/EnviousWisprAppKit/App/SettingsChangeTelemetry.swift
+++ b/Sources/EnviousWisprAppKit/App/SettingsChangeTelemetry.swift
@@ -41,6 +41,11 @@ enum SettingsProjection {
     // covering with a second engine for older Macs. A boolean setting value,
     // never any dictated content.
     case livePreview = "live_preview"
+    /// #2123: WHICH engine, not whether the preview is on. The two answer
+    /// different questions — adoption vs which engine that adoption runs on —
+    /// and the second is what decides whether the download was worth shipping.
+    /// A closed enum value, never a language, a model path or any dictated text.
+    case livePreviewEngine = "live_preview_engine"
     case warmEnginePolicy = "warm_engine_policy"
     case appearance = "appearance"
     case overlayPillPosition = "overlay_pill_position"
@@ -98,6 +103,7 @@ enum SettingsProjection {
     case .languageMode: return [.languageMode]
     case .useStreamingASR: return [.streamingASR]
     case .livePreviewEnabled: return [.livePreview]
+    case .livePreviewEngine: return [.livePreviewEngine]
     case .warmEnginePolicy: return [.warmEnginePolicy]
     case .appearance: return [.appearance]
     case .overlayPillPosition: return [.overlayPillPosition]
@@ -144,6 +150,7 @@ enum SettingsProjection {
     case .languageMode: return languageModeLabel(settings.languageMode)
     case .streamingASR: return onOff(settings.useStreamingASR)
     case .livePreview: return onOff(settings.livePreviewEnabled)
+    case .livePreviewEngine: return settings.livePreviewEngine.rawValue
     case .warmEnginePolicy: return settings.warmEnginePolicy.rawValue
     case .appearance: return settings.appearancePreference.rawValue
     case .overlayPillPosition: return settings.overlayPillPosition.rawValue

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -466,7 +466,7 @@ public final class WisprBootstrapper {
     // #1988: the live-preview limb, wired ONLY to the overlay. See the installer.
     let livePreview = LivePreviewInstaller.install(
       overlay: recordingOverlay, capture: audioCapture, settings: settings,
-      settingsSync: settingsSync)
+      settingsSync: settingsSync, modelDelivery: modelDelivery)
 
     // Custom-words propagator wiring (seed → register consumers → install
     // `onWordsChanged`). Phase D (#496). `wireCustomWords` strong-captures the

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewEnginePresentation.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewEnginePresentation.swift
@@ -157,6 +157,26 @@ enum LivePreviewEnginePresentation {
     guard fraction.isFinite else { return nil }
     return min(max(fraction, 0), 1)
   }
+
+  /// Should the page offer Apple's downloadable language packs?
+  ///
+  /// Both conditions, and the second one was missing (founder, 2026-08-17). The
+  /// packs are APPLE's languages: the universal engine carries its own and has
+  /// none to manage, so showing the manager beside it asks the user to configure
+  /// something that cannot affect what they are about to see.
+  ///
+  /// Pulled out of the view body deliberately. It lived there as a two-term `if`
+  /// whose own comment already said "still Apple's question" while the condition
+  /// checked only the OS — the reasoning was written down and never implemented,
+  /// and nothing but a human eye would have caught it. A comment cannot fail; a
+  /// function can.
+  ///
+  /// `isAppleSupported` alone still governs whether the packs EXIST to manage —
+  /// below macOS 26 there are none — so it stays as the first term rather than
+  /// being folded into the engine check.
+  static func showsApplePacks(isAppleSupported: Bool, isUsingApple: Bool) -> Bool {
+    isAppleSupported && isUsingApple
+  }
 }
 
 /// Copy for the engine picker, kept beside the presentation that uses it.

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewEnginePresentation.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewEnginePresentation.swift
@@ -1,0 +1,191 @@
+import EnviousWisprCore
+import EnviousWisprLivePreview
+import EnviousWisprModelDelivery
+import Foundation
+
+/// #2123: what each engine card says, in every state the Mac can be in.
+///
+/// A TYPE rather than logic inside the view, for the reason
+/// `LivePreviewPackPresentation` records: a view-local `if` chain can only be
+/// checked by reading it, and the state space here is the whole point of the
+/// chunk — engine × OS support × admission × download progress. This is the part
+/// where "it says something sensible in every cell" is a claim that can be
+/// tested, and where a missing cell is a user staring at a card with no next step.
+///
+/// **The boundary, stated exactly:** these tests protect WHAT EACH STATE SAYS and
+/// WHICH ACTION IT OFFERS. They do NOT protect the SwiftUI wiring — if the view
+/// stopped calling this, or drew the action button without hooking it up, the
+/// tests would still pass. That half is a Live UAT item, declared in the plan.
+enum LivePreviewEnginePresentation {
+
+  /// The single action a card offers, or none.
+  ///
+  /// Closed on purpose: every action here has to be something the app can
+  /// actually do. A build defect deliberately has NO action, because inventing
+  /// one would point the user at a button that cannot help them.
+  enum Action: Equatable {
+    case download
+    case cancelDownload
+    case resumeDownload
+    case retryDownload
+    case remove
+  }
+
+  /// One rendered card.
+  struct Card: Equatable {
+    let title: String
+    /// What this engine IS, in the user's terms. Present in EVERY state, because
+    /// the Help article is routed to its own issue and a user meeting these two
+    /// names for the first time has nothing else to go on.
+    let description: String
+    /// Why it cannot run right now, or nil when it can.
+    let unavailability: String?
+    let action: Action?
+    /// Live progress, guaranteed finite and within `0...1`, or nil.
+    ///
+    /// Normalized rather than forwarded: manifest validation permits zero or
+    /// non-positive sizes, so the delivery layer can produce a NaN or an
+    /// out-of-range fraction, and a progress bar fed either draws nonsense. A
+    /// value that cannot be rendered honestly becomes no bar at all.
+    let progress: Double?
+    let isSelected: Bool
+  }
+
+  /// Apple's card. No delivery state: its languages are the OS's business and the
+  /// pack list below the picker owns them.
+  static func appleCard(isSelected: Bool, isSupported: Bool) -> Card {
+    Card(
+      title: LivePreviewEngineCopy.appleTitle,
+      description: LivePreviewEngineCopy.appleDescription,
+      unavailability: isSupported ? nil : LivePreviewEngineCopy.appleNeedsNewerMacOS,
+      // Apple's engine is never downloaded or removed by us: macOS owns it, and
+      // its per-language packs have their own controls on this page already.
+      action: nil,
+      progress: nil,
+      isSelected: isSelected)
+  }
+
+  /// The universal engine's card.
+  ///
+  /// `routeExists` is false only when the app was built without the engine's
+  /// manifest or tokenizer. It is checked FIRST because in that state the
+  /// delivery state is meaningless — there is nothing registered to download.
+  static func universalCard(
+    isSelected: Bool,
+    routeExists: Bool,
+    state: DeliveryState
+  ) -> Card {
+    guard routeExists else {
+      return Card(
+        title: LivePreviewEngineCopy.universalTitle,
+        description: LivePreviewEngineCopy.universalDescription,
+        unavailability: LivePreviewEngineCopy.unavailableInThisBuild,
+        // No action ON PURPOSE. Nothing shipped for this engine, so no button
+        // could supply it; the remedy is a release-build resource check, ours,
+        // not the user's.
+        action: nil,
+        progress: nil,
+        isSelected: isSelected)
+    }
+
+    let title = LivePreviewEngineCopy.universalTitle
+    let description = LivePreviewEngineCopy.universalDescription
+
+    switch state {
+    case .admitted:
+      return Card(
+        title: title, description: description, unavailability: nil,
+        action: .remove, progress: nil, isSelected: isSelected)
+
+    case .downloading(let fraction, _, _):
+      return Card(
+        title: title, description: description, unavailability: nil,
+        action: .cancelDownload, progress: Self.renderableProgress(fraction),
+        isSelected: isSelected)
+
+    // Preparing and verifying are both "work is happening, no fraction yet".
+    // Separate cases rather than a shared one so the compiler asks again if
+    // either ever needs its own sentence.
+    case .preparing:
+      return Card(
+        title: title, description: description, unavailability: nil,
+        action: .cancelDownload, progress: nil, isSelected: isSelected)
+    case .verifying:
+      return Card(
+        title: title, description: description, unavailability: nil,
+        action: .cancelDownload, progress: nil, isSelected: isSelected)
+
+    case .failed:
+      return Card(
+        title: title, description: description,
+        unavailability: LivePreviewEngineCopy.downloadFailed,
+        action: .retryDownload, progress: nil, isSelected: isSelected)
+
+    // **`resumable` decides the VERB and nothing more.**
+    //
+    // It reports whether STAGED PARTIALS exist, not whether the next attempt
+    // starts from zero: the controller can still retain verified in-place
+    // components and skip them on the next fetch. So "Resume" is honest when it
+    // is true, and the false case must NOT promise a fresh start — an earlier
+    // draft of this copy said "it will start again from the beginning", which
+    // sounds careful and is wrong. It says the download stopped, and offers to
+    // download, which is all we actually know.
+    case .cancelled(let resumable):
+      return Card(
+        title: title, description: description,
+        unavailability: resumable
+          ? LivePreviewEngineCopy.downloadCancelled
+          : LivePreviewEngineCopy.downloadStopped,
+        action: resumable ? .resumeDownload : .download,
+        progress: nil, isSelected: isSelected)
+
+    case .notReady:
+      return Card(
+        title: title, description: description,
+        unavailability: LivePreviewEngineCopy.notDownloadedYet,
+        action: .download, progress: nil, isSelected: isSelected)
+    }
+  }
+
+  /// A fraction the UI can draw, or nil.
+  ///
+  /// NaN and infinity are dropped rather than clamped: they mean the size was
+  /// unknown, and inventing 0% would show a bar that never moves. A merely
+  /// out-of-range finite value is clamped, since it is a real measurement that
+  /// overshot.
+  static func renderableProgress(_ fraction: Double) -> Double? {
+    guard fraction.isFinite else { return nil }
+    return min(max(fraction, 0), 1)
+  }
+}
+
+/// Copy for the engine picker, kept beside the presentation that uses it.
+///
+/// Separate from `LivePreviewCopy` (which the recording pill uses) because these
+/// sentences are read while DECIDING, not while dictating, and the two audiences
+/// want different lengths.
+enum LivePreviewEngineCopy {
+  static let sectionHeader = "Preview engine"
+
+  static let appleTitle = "Apple"
+  static let appleDescription =
+    "Uses Apple's speech recognition. No separate preview-model download; some languages may "
+    + "need an Apple language download. Needs macOS 26."
+  static let appleNeedsNewerMacOS = "Needs macOS 26 or later."
+
+  static let universalTitle = "Universal"
+  static let universalDescription =
+    "Works on macOS 14 and later, in more languages. Needs one optional 217 MB download."
+  static let notDownloadedYet = "Not downloaded yet."
+  static let downloadFailed = "The download did not finish."
+  static let downloadCancelled = "Download paused. It will pick up where it stopped."
+  /// The other half of a cancel: nothing usable was kept, so the honest verb is
+  /// "download" rather than "resume".
+  /// Deliberately claims NOTHING about what was kept. `resumable: false` means no
+  /// staged partials, not "nothing on disk" — verified components can survive and
+  /// be skipped next time, so any promise about starting over would be false.
+  static let downloadStopped = "Download stopped."
+  /// No remedy offered: a build shipped without the engine's files is ours to fix.
+  static let unavailableInThisBuild =
+    "This version of EnviousWispr cannot run that preview engine."
+}

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewPacksModel.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewPacksModel.swift
@@ -161,7 +161,13 @@ final class LivePreviewPacksModel {
     // switch being total. If the picker ever routes this page through the
     // universal engine (#2077 chunk 5), these stop being unreachable and need
     // real states rather than a fallthrough nobody re-reads.
-    case .blocked(.modelNotInstalled), .blocked(.heartIsStreaming):
+    //
+    // #2123 adds a third: a build with no universal registration or tokenizer.
+    // Also unreachable here for the same reason — this page asks APPLE'S route,
+    // which is composed from the OS and cannot fail that way. It joins the group
+    // rather than getting a pack-page state no path can enter.
+    case .blocked(.modelNotInstalled), .blocked(.heartIsStreaming),
+      .blocked(.engineUnavailableInThisBuild):
       return .unsupportedLanguage
     }
   }

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsView.swift
@@ -108,9 +108,7 @@ struct LivePreviewSettingsView: View {
     case .cancelDownload:
       modelDelivery.cancelPreviewDownload()
     case .remove:
-      // Wired in the next chunk; the card cannot produce this yet unless the
-      // model is admitted, and removal has its own confirmation question.
-      break
+      modelDelivery.removePreviewModel()
     }
   }
 

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsView.swift
@@ -1,3 +1,4 @@
+import EnviousWisprCore
 import EnviousWisprLivePreview
 import EnviousWisprServices
 import SwiftUI
@@ -22,11 +23,122 @@ struct LivePreviewSettingsView: View {
   /// download must outlive view churn. This page only renders it.
   let packs: LivePreviewPacksModel
 
+  /// #2123: the preview model's download lifecycle. Optional for the same reason
+  /// the speech-engine page's is — a preview or a test may render this page with
+  /// no delivery home in the environment.
+  @Environment(ModelDeliveryHome.self) private var modelDelivery: ModelDeliveryHome?
+
   /// View-local too: a search box is about what this page is SHOWING, not about the catalogue,
   /// so the model has no reason to know it exists.
   @State private var searchText: String = ""
 
-  private var isSupported: Bool { ApplePreviewEngineResolver.isSupportedOnThisSystem }
+  /// One engine card: selectable, with at most one action.
+  ///
+  /// Selecting is deliberately SEPARATE from acting. Tapping the card chooses the
+  /// engine; the button downloads, cancels, resumes, retries or removes. Choosing
+  /// an engine must never start a 217 MB download by itself — the founder's Gate 1
+  /// decision, and the reason the two are different gestures.
+  @ViewBuilder
+  private func engineCard(
+    _ card: LivePreviewEnginePresentation.Card,
+    choice: LivePreviewEngineChoice
+  ) -> some View {
+    HStack(alignment: .top, spacing: 11) {
+      // **The selectable area is its OWN control, and stops before the button.**
+      // An `onTapGesture` wrapped around the whole row made Download also select
+      // the engine, and `.accessibilityElement(children: .combine)` merged the two
+      // into a single element — so "selecting and downloading are separate
+      // gestures" was true of the intent and false of the code.
+      Button {
+        settings.livePreviewEngine = choice
+      } label: {
+        HStack(alignment: .top, spacing: 11) {
+          SettingsRowIcon(systemName: card.isSelected ? "checkmark.circle.fill" : "circle")
+          VStack(alignment: .leading, spacing: 4) {
+            Text(card.title).settingsRowLabel()
+            Text(card.description).settingsReadingCopy()
+            if let unavailability = card.unavailability {
+              Text(unavailability).settingsReadingCopy()
+            }
+            if let progress = card.progress {
+              ProgressView(value: progress)
+            }
+          }
+          // **Inside the label, not beside the button.** With the spacer outside,
+          // the button was only as wide as its icon and text, so tapping the blank
+          // part of the card selected nothing — a card that looks selectable
+          // across its whole width and is not. The rectangular content shape makes
+          // that whole area hittable rather than just the drawn glyphs.
+          Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .contentShape(Rectangle())
+      }
+      .buttonStyle(.plain)
+      .accessibilityAddTraits(card.isSelected ? [.isSelected] : [])
+      if let action = card.action {
+        // Removal is bordered, everything else prominent: the destructive action
+        // should not be the most inviting thing on the card.
+        if action == .remove {
+          Button(Self.label(for: action)) { perform(action) }.buttonStyle(.bordered)
+        } else {
+          Button(Self.label(for: action)) { perform(action) }.buttonStyle(.borderedProminent)
+        }
+      }
+    }
+  }
+
+  private static func label(for action: LivePreviewEnginePresentation.Action) -> String {
+    switch action {
+    case .download: return "Download"
+    case .cancelDownload: return "Cancel"
+    case .resumeDownload: return "Resume"
+    case .retryDownload: return "Try Again"
+    case .remove: return "Remove"
+    }
+  }
+
+  private func perform(_ action: LivePreviewEnginePresentation.Action) {
+    guard let modelDelivery else { return }
+    switch action {
+    // Download, resume and retry are one operation to the delivery layer; only
+    // the word on the button differs, and the card already chose it.
+    case .download, .resumeDownload, .retryDownload:
+      modelDelivery.startPreviewDownload()
+    case .cancelDownload:
+      modelDelivery.cancelPreviewDownload()
+    case .remove:
+      // Wired in the next chunk; the card cannot produce this yet unless the
+      // model is admitted, and removal has its own confirmation question.
+      break
+    }
+  }
+
+  /// Whether APPLE's engine can run here. Still the gate for the pack list and
+  /// the active-language summary, which are about Apple's packs specifically.
+  private var isAppleSupported: Bool { ApplePreviewEngineResolver.isSupportedOnThisSystem }
+
+  /// Whether the universal engine was composable in this build.
+  private var universalExists: Bool {
+    guard let modelDelivery else { return false }
+    // Registration is not enough: a route also needs the bundled tokenizer, and a
+    // build missing it would otherwise enable the toggle and offer a Download for
+    // an engine that could never run.
+    return WhisperPreviewDeliveryWiring.isComposable(modelDelivery: modelDelivery)
+  }
+
+  /// Whether APPLE is the engine actually in use. Apple-specific claims — the
+  /// active-language summary and the "In use" pack badge — are only true then.
+  private var isUsingApple: Bool { settings.livePreviewEngine == .apple }
+
+  /// **Whether the FEATURE can run at all, which is not the same question.**
+  ///
+  /// The toggle used to be disabled on `isAppleSupported`, so below macOS 26 a
+  /// user could not switch the preview on — correct while Apple's was the only
+  /// engine, and the exact dead end #2077 exists to remove now that a second
+  /// engine has no OS floor. Gating the feature on one engine's rule is what
+  /// `live-preview.md` warns against.
+  private var anyEngineAvailable: Bool { isAppleSupported || universalExists }
 
   /// The toggle's own value, NOT whether a preview could run. Anything the page says about a live
   /// preview is false while this is off, and it is off by default.
@@ -44,14 +156,43 @@ struct LivePreviewSettingsView: View {
                 Text(LivePreviewSettingsCopy.toggleLabel).settingsRowLabel()
               }
               .toggleStyle(BrandedToggleStyle())
-              .disabled(!isSupported)
+              .disabled(!anyEngineAvailable)
               Text(LivePreviewSettingsCopy.toggleDescription)
                 .settingsReadingCopy()
-              if !isSupported {
+              // Only when NEITHER engine can run. Below macOS 26 with the
+              // universal engine available this sentence would be false, and it
+              // was the only thing the page said there.
+              if !anyEngineAvailable {
                 Text(LivePreviewSettingsCopy.needsNewerMacOS)
                   .settingsReadingCopy()
               }
             }
+          }
+        }
+      }
+
+      // ── #2123: which engine draws the preview ────────────────────────
+      //
+      // Above the pack list, because it decides whether that list is even
+      // relevant: the packs belong to Apple's engine only.
+      //
+      // Both cards ALWAYS render, including the one that cannot run here.
+      // Hiding the unavailable option reads as a bug — the user knows the app
+      // has two engines — and the card is where the reason lives.
+      BrandedSection(header: LivePreviewEngineCopy.sectionHeader) {
+        BrandedRow(showDivider: false) {
+          VStack(alignment: .leading, spacing: 10) {
+            engineCard(
+              LivePreviewEnginePresentation.appleCard(
+                isSelected: settings.livePreviewEngine == .apple,
+                isSupported: isAppleSupported),
+              choice: .apple)
+            engineCard(
+              LivePreviewEnginePresentation.universalCard(
+                isSelected: settings.livePreviewEngine == .universal,
+                routeExists: universalExists,
+                state: modelDelivery?.whisperPreviewState ?? .notReady),
+              choice: .universal)
           }
         }
       }
@@ -66,7 +207,11 @@ struct LivePreviewSettingsView: View {
       // but false. Switching the toggle on reveals it, which also makes the section read as a
       // consequence of the toggle above it. The list below stays visible either way, so a pack
       // can still be downloaded before turning the feature on.
-      if isSupported, isPreviewOn, let active = packs.active {
+      // Gated on the SELECTED engine too (#2123): this summary and the "In use"
+      // badge below describe Apple's packs. With the universal engine chosen they
+      // would state, confidently and wrongly, which Apple pack is producing the
+      // words on screen.
+      if isAppleSupported, isUsingApple, isPreviewOn, let active = packs.active {
         BrandedSection(header: LivePreviewSettingsCopy.activeHeader) {
           BrandedRow(showDivider: false) {
             VStack(alignment: .leading, spacing: 10) {
@@ -82,8 +227,9 @@ struct LivePreviewSettingsView: View {
       }
 
       // Hidden entirely below macOS 26: there are no Apple packs to manage, and an empty list
-      // under a disabled toggle would read as something being broken.
-      if isSupported {
+      // under a disabled toggle would read as something being broken. Still APPLE's
+      // question — the universal engine carries its own languages and has no packs.
+      if isAppleSupported {
         BrandedSection(header: LivePreviewSettingsCopy.packsHeader) {
           BrandedRow(showDivider: false) {
             VStack(alignment: .leading, spacing: 10) {
@@ -111,7 +257,7 @@ struct LivePreviewSettingsView: View {
     // is covered without knowing this page exists. `swiftui-view-patterns.md`
     // RULE: swiftui-task-id-cancellation is the house rule for exactly this.
     .task(id: settings.languageMode) {
-      guard isSupported else { return }
+      guard isAppleSupported else { return }
       // Re-read on EVERY appearance. The model outlives this page now, so without this a
       // returning user would see the snapshot from whenever they last opened it — past a download
       // that finished meanwhile, past a macOS purge of a staged asset. The catalogue exists
@@ -242,8 +388,15 @@ struct LivePreviewSettingsView: View {
   /// Gated on the toggle for the same reason the section above is: "In use" is a claim about a
   /// running preview, and nothing runs while the feature is off. The badge and the section read
   /// the same `isPreviewOn`, so they cannot disagree about whether a language is live.
+  ///
+  /// **And on the chosen ENGINE (#2123).** These are Apple's packs. With the
+  /// universal engine selected, no Apple pack is producing anything, so the badge
+  /// would name a language that is not the one on screen — the same
+  /// false-not-merely-stale status the toggle gate was added to prevent, one
+  /// engine later. Reads `isUsingApple`, the same value as the section above, so
+  /// the two still cannot disagree.
   private func isActive(_ pack: LivePreviewPack) -> Bool {
-    guard isPreviewOn, case .ready(let tag, _) = packs.active else { return false }
+    guard isUsingApple, isPreviewOn, case .ready(let tag, _) = packs.active else { return false }
     return tag == pack.tag
   }
 

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsView.swift
@@ -209,7 +209,16 @@ struct LivePreviewSettingsView: View {
       // badge below describe Apple's packs. With the universal engine chosen they
       // would state, confidently and wrongly, which Apple pack is producing the
       // words on screen.
-      if isAppleSupported, isUsingApple, isPreviewOn, let active = packs.active {
+      //
+      // Same helper as the packs list below, deliberately: "are Apple's packs this
+      // page's business" is ONE question, and it was two inline conditions in two
+      // places until one of them silently lost a term. The extra `isPreviewOn` and
+      // `packs.active` stay here because they are about THIS section — whether
+      // there is a resolved pack to describe — not about whose engine it is.
+      if LivePreviewEnginePresentation.showsApplePacks(
+        isAppleSupported: isAppleSupported, isUsingApple: isUsingApple),
+        isPreviewOn, let active = packs.active
+      {
         BrandedSection(header: LivePreviewSettingsCopy.activeHeader) {
           BrandedRow(showDivider: false) {
             VStack(alignment: .leading, spacing: 10) {
@@ -225,9 +234,22 @@ struct LivePreviewSettingsView: View {
       }
 
       // Hidden entirely below macOS 26: there are no Apple packs to manage, and an empty list
-      // under a disabled toggle would read as something being broken. Still APPLE's
-      // question — the universal engine carries its own languages and has no packs.
-      if isAppleSupported {
+      // under a disabled toggle would read as something being broken.
+      //
+      // ALSO hidden on the universal engine (founder, 2026-08-17). These packs are Apple's
+      // languages; the universal model carries its own and has no packs to manage, so offering
+      // a language manager beside it asks the user to configure something that cannot affect
+      // what they are about to see. The comment here already SAID this was "still Apple's
+      // question" while the gate read `isAppleSupported` alone — the reasoning was written down
+      // and never implemented, which is worse than not having written it, because it stops the
+      // next reader checking.
+      //
+      // The catalogue LOAD below is deliberately NOT gated the same way: its `.task` is keyed on
+      // the dictation language, so adding the engine to the condition without adding it to the
+      // key would leave a user who switches back to Apple looking at a snapshot from before.
+      if LivePreviewEnginePresentation.showsApplePacks(
+        isAppleSupported: isAppleSupported, isUsingApple: isUsingApple)
+      {
         BrandedSection(header: LivePreviewSettingsCopy.packsHeader) {
           BrandedRow(showDivider: false) {
             VStack(alignment: .leading, spacing: 10) {

--- a/Sources/EnviousWisprCore/SettingsEnums.swift
+++ b/Sources/EnviousWisprCore/SettingsEnums.swift
@@ -18,6 +18,23 @@ public enum AppearancePreference: String, CaseIterable, Sendable {
   case dark
 }
 
+/// Which engine draws the on-screen preview (#2123, chunk 5 of #2077).
+///
+/// Persisted by rawValue; unknown or missing values resolve to `.apple`, which
+/// is the founder's Gate 1 decision: Apple's engine wherever it genuinely works,
+/// and the 217 MB universal model offered rather than imposed.
+///
+/// An enum rather than a Bool so a third engine costs a case, not a migration —
+/// this feature already replaced "the only engine" with "two engines" once.
+public enum LivePreviewEngineChoice: String, CaseIterable, Sendable {
+  /// macOS speech recognition. No separate download, needs macOS 26, and only
+  /// covers the languages macOS has already installed.
+  case apple
+  /// The downloadable universal model. No OS floor beyond the app's own, carries
+  /// its own languages, costs one optional 217 MB download.
+  case universal
+}
+
 /// Where the recording pill (and every transient overlay sharing its window —
 /// polishing, warnings, cold-start notices, the Bluetooth card) appears on
 /// screen. Persisted by rawValue; unknown/missing values resolve to `.top`.

--- a/Sources/EnviousWisprLivePreview/Engines/ApplePreviewRecognizer.swift
+++ b/Sources/EnviousWisprLivePreview/Engines/ApplePreviewRecognizer.swift
@@ -731,6 +731,7 @@ package enum ApplePreviewEngineResolver {
   /// so the pill's geometry check and the recording's resolution can never be wired
   /// from different sources.
   package static let route = LivePreviewEngineRoute(
+    telemetryEngineID: "apple",
     isSupportedOnThisSystem: { isSupportedOnThisSystem },
     resolve: { mode in await resolve(mode) }
   )

--- a/Sources/EnviousWisprLivePreview/LivePreviewEngine.swift
+++ b/Sources/EnviousWisprLivePreview/LivePreviewEngine.swift
@@ -181,6 +181,21 @@ package enum LivePreviewUnavailability: Sendable, Equatable {
   /// racing. It deliberately does not fall back to a lock the heart would await:
   /// a display-only limb must never be able to stall transcription.
   case heartIsStreaming
+
+  /// The engine cannot run because THIS BUILD is missing something it needs —
+  /// a delivery registration or a bundled tokenizer that should have shipped.
+  ///
+  /// **Not a Bypass and not a user-fixable Failure**, which is why it is neither
+  /// `modelNotInstalled` nor a reuse of it. Telling someone to download a model
+  /// when the app was packaged wrong sends them to a button that cannot help,
+  /// and the honest sentence — this build cannot do it — is the one that does not
+  /// waste their time. The remedy is ours: a release-build resource check
+  /// (#2123), not a control on screen.
+  ///
+  /// Added in #2123 because this is the chunk where a route can finally be nil
+  /// and something has to say so, matching this enum's rule that a case arrives
+  /// with the code that can report and act on it.
+  case engineUnavailableInThisBuild
 }
 
 /// Whether a preview can run, and if not, why.

--- a/Sources/EnviousWisprLivePreview/LivePreviewEngine.swift
+++ b/Sources/EnviousWisprLivePreview/LivePreviewEngine.swift
@@ -215,6 +215,20 @@ package enum LivePreviewEngineResolution: Sendable {
 /// feature exists to remove.
 package struct LivePreviewEngineRoute: Sendable {
 
+  /// Which engine this route speaks for, as a CLOSED telemetry vocabulary:
+  /// exactly `apple` or `universal`.
+  ///
+  /// **Deliberately NOT the candidate key's engine string.** That key carries
+  /// artifact identity — the universal engine's is `whisper_preview#<digest>` —
+  /// so reporting it would put a new value in the field on every model revision,
+  /// which is a high-cardinality property rather than a dimension anyone can
+  /// group by. The signed plan says `engine = apple|universal`; this is that.
+  ///
+  /// It also answers the one caller with no candidate to read: a REFUSED
+  /// resolution never produces a `LivePreviewEngineCandidate`, and "refused" is
+  /// the most interesting outcome the downloadable engine has.
+  package let telemetryEngineID: String
+
   /// Static capability only: does this Mac have what the engine fundamentally
   /// requires. NOT "is it ready right now" — anything that can change while the app
   /// runs, such as whether a model has been downloaded, belongs in `resolve`.
@@ -223,9 +237,11 @@ package struct LivePreviewEngineRoute: Sendable {
   package let resolve: LivePreviewEngineResolver
 
   package init(
+    telemetryEngineID: String,
     isSupportedOnThisSystem: @escaping @Sendable () -> Bool,
     resolve: @escaping LivePreviewEngineResolver
   ) {
+    self.telemetryEngineID = telemetryEngineID
     self.isSupportedOnThisSystem = isSupportedOnThisSystem
     self.resolve = resolve
   }

--- a/Sources/EnviousWisprServices/SettingsDefaultValues.swift
+++ b/Sources/EnviousWisprServices/SettingsDefaultValues.swift
@@ -98,6 +98,8 @@ enum SettingsDefaultValues {
   // that reason), and it needs macOS 26, so a default-on toggle would read as
   // broken on every older Mac. Display only: the pasted text never comes from it.
   static let livePreviewEnabled = false
+  /// #2123: Apple first. The universal engine is opt-in, never a default toll.
+  static let livePreviewEngine: LivePreviewEngineChoice = .apple
 
   // #1480: show the once-per-launch Bluetooth cold-start education popover when
   // the configured input is a Bluetooth mic. Default ON — it is light, dismissable,

--- a/Sources/EnviousWisprServices/SettingsManager.swift
+++ b/Sources/EnviousWisprServices/SettingsManager.swift
@@ -449,6 +449,18 @@ public final class SettingsManager {
   /// establishes the value so later chunks have one source of truth to read.
   public var livePreviewEngine: LivePreviewEngineChoice {
     didSet {
+      // The ONLY no-op guard among this type's 47 `didSet`s, and deliberately so
+      // (#2123 whole-diff review). The picker's card is a Button, so tapping the
+      // ALREADY-selected engine still assigns, and Swift runs `didSet` on a
+      // same-value assignment. Every other setting's handler is idempotent, so
+      // the redundant notification costs nothing; this one's is not. It reaches
+      // `releaseForEngineChange()`, which tears the preview down unconditionally
+      // — correctly, since a real engine change means the preview is still ON and
+      // only the engine beneath it moved, so a toggle guard would be wrong there.
+      // That reasoning cannot tell a real change from a re-tap, so the guard has
+      // to be here: without it, tapping the selected card mid-recording stops the
+      // preview for the rest of that recording.
+      guard livePreviewEngine != oldValue else { return }
       defaults.set(livePreviewEngine.rawValue, forKey: "livePreviewEngine")
       onChange?(.livePreviewEngine)
     }

--- a/Sources/EnviousWisprServices/SettingsManager.swift
+++ b/Sources/EnviousWisprServices/SettingsManager.swift
@@ -43,6 +43,7 @@ public final class SettingsManager {
     case preferredInputDeviceIDOverride
     case useStreamingASR
     case livePreviewEnabled
+    case livePreviewEngine
     case warmEnginePolicy
     case appearance
     case overlayPillPosition
@@ -84,7 +85,8 @@ public final class SettingsManager {
     "isDebugModeEnabled", "isDictationAudioArchiveEnabled", "debugLogLevel",
     "useExtendedThinking", "whisperKitLanguage", "languageMode",
     "selectedInputDeviceUID", "preferredInputDeviceIDOverride",
-    "useStreamingASR", "livePreviewEnabled", "warmEnginePolicy", "appearancePreference",
+    "useStreamingASR", "livePreviewEnabled", "livePreviewEngine",
+    "warmEnginePolicy", "appearancePreference",
     "overlayPillPosition",
     "showBluetoothTips", "playRecordingSounds", "recordingSoundPairing",
     WhatsNewConstants.lastSeenVersionDefaultsKey,
@@ -440,6 +442,15 @@ public final class SettingsManager {
     didSet {
       defaults.set(livePreviewEnabled, forKey: "livePreviewEnabled")
       onChange?(.livePreviewEnabled)
+    }
+  }
+
+  /// #2123: which engine draws the preview. Read by nothing yet — chunk A
+  /// establishes the value so later chunks have one source of truth to read.
+  public var livePreviewEngine: LivePreviewEngineChoice {
+    didSet {
+      defaults.set(livePreviewEngine.rawValue, forKey: "livePreviewEngine")
+      onChange?(.livePreviewEngine)
     }
   }
 
@@ -833,6 +844,12 @@ public final class SettingsManager {
     livePreviewEnabled =
       defaults.object(forKey: "livePreviewEnabled") as? Bool
       ?? SettingsDefaultValues.livePreviewEnabled
+    // Unknown raw value resolves to Apple rather than trapping: a defaults file
+    // written by a newer build (or by hand) must not disable the preview.
+    livePreviewEngine =
+      LivePreviewEngineChoice(
+        rawValue: defaults.string(forKey: "livePreviewEngine") ?? ""
+      ) ?? SettingsDefaultValues.livePreviewEngine
     warmEnginePolicy =
       WarmEnginePolicy(
         rawValue: defaults.string(forKey: "warmEnginePolicy") ?? ""

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -1721,6 +1721,33 @@ public final class TelemetryService {
     PostHogSDK.shared.capture(event, properties: properties)
   }
 
+  /// #2123: which preview engine ran, and how far it got.
+  ///
+  /// NOT "whether it produced anything" — `started` proves a session opened, not
+  /// that any words reached the pill. A heard-nothing signal would be a different
+  /// event with a different meaning.
+  ///
+  /// **Exactly two properties, and the bound is deliberate.** Settings telemetry
+  /// already reports whether the preview is switched ON; it cannot say which
+  /// engine that adoption runs on, which is the question that decides whether
+  /// shipping a 217 MB download was worth it. A refusal REASON was drafted as a
+  /// third property and cut: the reasons are a closed set today but they name
+  /// language and streaming state, and this event fires once per recording, so
+  /// it is the wrong place to start describing what a user was doing.
+  ///
+  /// Never a language, a model path, preview text, or any dictated content —
+  /// `sentry-operations.md` RULE: telemetry-privacy-boundary. The shape crosses
+  /// the network; what was said never does.
+  public func livePreviewOutcome(engine: String, outcome: String) {
+    let event = "live_preview.outcome"
+    let properties = ["engine": engine, "outcome": outcome]
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(name: event, stringProps: properties, boolProps: [:]))
+    #endif
+    PostHogSDK.shared.capture(event, properties: properties)
+  }
+
   /// #1348 Phase 2: owned model-delivery funnel (`model_delivery.*`, D3
   /// schema). Content-free by construction: identity fields come from OUR
   /// bundled manifest, reasons/details are closed string sets, and no user

--- a/Sources/EnviousWisprWhisperPreviewAdapter/WhisperPreviewEngineResolver.swift
+++ b/Sources/EnviousWisprWhisperPreviewAdapter/WhisperPreviewEngineResolver.swift
@@ -52,6 +52,7 @@ package enum WhisperPreviewEngineResolver {
   /// from different sources.
   package static func route(_ environment: Environment) -> LivePreviewEngineRoute {
     LivePreviewEngineRoute(
+      telemetryEngineID: "universal",
       isSupportedOnThisSystem: { true },
       resolve: { mode in await resolve(mode, environment: environment) }
     )

--- a/Tests/EnviousWisprTests/App/LivePreviewCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewCoordinatorTests.swift
@@ -17,8 +17,136 @@ import Testing
 /// has. What IS unit-testable is the part that protects the heart: the gate that
 /// decides whether any of that happens at all, and the bound on what the feature
 /// retains. Live behaviour is covered by UAT.
+/// Wraps a resolver in a route for the coordinator's `selectedRoute` provider.
+///
+/// These suites test the coordinator's POLICY, not an engine's OS capability, so
+/// support defaults to true; suites that care pass `supported: false` explicitly.
+/// Returning the PROVIDER rather than a route keeps every call site honest about
+/// the fact that the coordinator reads it once per recording.
+private func previewRoute(
+  supported: Bool = true,
+  _ resolve: @escaping LivePreviewEngineResolver
+) -> () -> LivePreviewEngineRoute {
+  { LivePreviewEngineRoute(isSupportedOnThisSystem: { supported }, resolve: resolve) }
+}
+
 @MainActor
 struct LivePreviewCoordinatorTests {
+
+  // MARK: - #2123: one engine decision per recording
+
+  /// The pill's SIZE and the words in it must never disagree about the engine.
+  ///
+  /// Freezing only at the moment intent arrives is not enough on its own: the
+  /// overlay reports intent synchronously but creates its panel on the next
+  /// run-loop cycle and reads geometry inside that deferred work. So a switch
+  /// landing in that gap must change neither half.
+  ///
+  /// Mutation control: read `selectedRoute()` live in `runSession` instead of the
+  /// snapshot and this goes red on the engine identity.
+  @Test("the engine chosen at the start of a recording is the one it uses throughout")
+  func engineIsFrozenForTheRecording() async {
+    final class Choice: @unchecked Sendable {
+      private let mutex = NSLock()
+      private var value = "first"
+      var current: String { mutex.withLock { value } }
+      func switchIt() { mutex.withLock { value = "second" } }
+    }
+    final class Seen: @unchecked Sendable {
+      private let mutex = NSLock()
+      private var ids: [String] = []
+      var all: [String] { mutex.withLock { ids } }
+      func record(_ id: String) { mutex.withLock { ids.append(id) } }
+    }
+    let choice = Choice()
+    let seen = Seen()
+
+    let coordinator = LivePreviewCoordinator(
+      readSamples: { _ in ([], 0) },
+      isPreviewOn: { true },
+      languageMode: { .locked("en") },
+      selectedRoute: {
+        // A DIFFERENT route object each read, exactly as the real provider will
+        // behave once it switches on a setting.
+        let id = choice.current
+        return LivePreviewEngineRoute(
+          isSupportedOnThisSystem: { true },
+          resolve: { _ in
+            seen.record(id)
+            return .blocked(.unsupportedLanguage)
+          })
+      }
+    )
+
+    coordinator.setRecording(true)
+    // Switch the choice immediately — before the session task has resolved.
+    choice.switchIt()
+    for _ in 0..<2000 where seen.all.isEmpty { await Task.yield() }
+
+    #expect(seen.all.first == "first", "control: the recording must have resolved something")
+    #expect(
+      !seen.all.contains("second"),
+      "the recording resolved the engine chosen after it started: \(seen.all)")
+
+    // The NEXT recording gets the new choice — the freeze is per recording, not
+    // permanent.
+    coordinator.setRecording(false)
+    coordinator.setRecording(true)
+    for _ in 0..<2000 where !seen.all.contains("second") { await Task.yield() }
+    #expect(seen.all.contains("second"), "a new recording must pick up the new choice")
+  }
+
+  /// A recording that began with the preview OFF stays off for its whole length.
+  ///
+  /// The overlay deliberately forwards duplicate intent pushes, and the disabled
+  /// path never sets `isRunning` — so without the snapshot guard, enabling the
+  /// preview mid-recording plus one duplicate push would start a preview in a
+  /// recording that never began with one.
+  @Test("enabling mid-recording cannot start a preview the recording began without")
+  func enablingMidRecordingDoesNotStartIt() async {
+    final class Toggle: @unchecked Sendable {
+      private let mutex = NSLock()
+      private var value = false
+      var isOn: Bool { mutex.withLock { value } }
+      func turnOn() { mutex.withLock { value = true } }
+    }
+    final class Resolved: @unchecked Sendable {
+      private let mutex = NSLock()
+      private var count = 0
+      var value: Int { mutex.withLock { count } }
+      func bump() { mutex.withLock { count += 1 } }
+    }
+    let toggle = Toggle()
+    let resolved = Resolved()
+
+    let coordinator = LivePreviewCoordinator(
+      readSamples: { _ in ([], 0) },
+      isPreviewOn: { toggle.isOn },
+      languageMode: { .locked("en") },
+      selectedRoute: previewRoute { _ in
+        resolved.bump()
+        return .blocked(.unsupportedLanguage)
+      }
+    )
+
+    coordinator.setRecording(true)  // begins OFF
+    #expect(coordinator.display == .off, "control: it must start off")
+    #expect(!coordinator.isEnabledForGeometry, "control: geometry must agree it is off")
+
+    toggle.turnOn()
+    coordinator.setRecording(true)  // the overlay's duplicate push
+    for _ in 0..<300 { await Task.yield() }
+
+    #expect(resolved.value == 0, "a preview started inside a recording that began without one")
+    #expect(!coordinator.isEnabledForGeometry, "geometry must stay off for this recording")
+
+    // And the next recording, begun with it on, DOES run — otherwise this test
+    // would pass against a preview that never starts at all.
+    coordinator.setRecording(false)
+    coordinator.setRecording(true)
+    for _ in 0..<2000 where resolved.value == 0 { await Task.yield() }
+    #expect(resolved.value == 1, "the next recording must honour the new setting")
+  }
 
   // MARK: - The gate
 
@@ -27,9 +155,9 @@ struct LivePreviewCoordinatorTests {
     let capture = CountingAudioCapture()
     let coordinator = LivePreviewCoordinator(
       readSamples: { await capture.getSamplesSnapshot(fromIndex: $0) },
-      isEnabled: { false },
+      isPreviewOn: { false },
       languageMode: { .locked("en") },
-      resolveEngine: { _ in .blocked(.unsupportedSystem) }
+      selectedRoute: previewRoute { _ in .blocked(.unsupportedSystem) }
     )
 
     coordinator.setRecording(true)
@@ -54,9 +182,9 @@ struct LivePreviewCoordinatorTests {
   func enabledStartsAndLeavesOff() {
     let coordinator = LivePreviewCoordinator(
       readSamples: { _ in ([], 0) },
-      isEnabled: { true },
+      isPreviewOn: { true },
       languageMode: { .locked("en") },
-      resolveEngine: { _ in .blocked(.unsupportedSystem) }
+      selectedRoute: previewRoute { _ in .blocked(.unsupportedSystem) }
     )
 
     coordinator.setRecording(true)
@@ -69,9 +197,9 @@ struct LivePreviewCoordinatorTests {
   func startClearsPreviousText() {
     let coordinator = LivePreviewCoordinator(
       readSamples: { _ in ([], 0) },
-      isEnabled: { true },
+      isPreviewOn: { true },
       languageMode: { .locked("en") },
-      resolveEngine: { _ in .blocked(.unsupportedSystem) }
+      selectedRoute: previewRoute { _ in .blocked(.unsupportedSystem) }
     )
     coordinator.setRecording(true)
     coordinator.setRecording(false)
@@ -91,9 +219,9 @@ struct LivePreviewCoordinatorTests {
   func lifecycleIsIdempotent() {
     let coordinator = LivePreviewCoordinator(
       readSamples: { _ in ([], 0) },
-      isEnabled: { true },
+      isPreviewOn: { true },
       languageMode: { .locked("en") },
-      resolveEngine: { _ in .blocked(.unsupportedSystem) }
+      selectedRoute: previewRoute { _ in .blocked(.unsupportedSystem) }
     )
     // Two call sites push recording intent (the first overlay push and every
     // state-driven one), and `hide()` reports a stop that may already have
@@ -118,9 +246,9 @@ struct LivePreviewCoordinatorTests {
   func stopDiscardsPreviewText() {
     let coordinator = LivePreviewCoordinator(
       readSamples: { _ in ([], 0) },
-      isEnabled: { true },
+      isPreviewOn: { true },
       languageMode: { .locked("en") },
-      resolveEngine: { _ in .blocked(.unsupportedSystem) }
+      selectedRoute: previewRoute { _ in .blocked(.unsupportedSystem) }
     )
     coordinator.setRecording(true)
     #expect(coordinator.display != .off, "control: a live recording is not off")
@@ -204,9 +332,9 @@ struct LivePreviewCoordinatorTests {
     let resolutions = CountingBox()
     let coordinator = LivePreviewCoordinator(
       readSamples: { _ in ([], 0) },
-      isEnabled: { true },
+      isPreviewOn: { true },
       languageMode: { .locked("en") },
-      resolveEngine: { _ in
+      selectedRoute: previewRoute { _ in
         let nth = await resolutions.next()
         return .ready(
           LivePreviewEngineCandidate(
@@ -257,9 +385,9 @@ struct LivePreviewCoordinatorTests {
         await reads.bump()
         return ([], 0)
       },
-      isEnabled: { true },
+      isPreviewOn: { true },
       languageMode: { .locked("en") },
-      resolveEngine: { _ in .blocked(.unsupportedLanguage) }
+      selectedRoute: previewRoute { _ in .blocked(.unsupportedLanguage) }
     )
 
     coordinator.setRecording(true)
@@ -321,9 +449,9 @@ struct LivePreviewCoordinatorTests {
   ) -> LivePreviewCoordinator {
     LivePreviewCoordinator(
       readSamples: readSamples,
-      isEnabled: { true },
+      isPreviewOn: { true },
       languageMode: { .locked("en") },
-      resolveEngine: { _ in
+      selectedRoute: previewRoute { _ in
         .ready(
           LivePreviewEngineCandidate(
             key: key, makeEngine: { FakePreviewEngine(probe: probe) }))
@@ -387,9 +515,9 @@ struct LivePreviewCoordinatorTests {
   private func makeCoordinator() -> LivePreviewCoordinator {
     LivePreviewCoordinator(
       readSamples: { _ in ([], 0) },
-      isEnabled: { true },
+      isPreviewOn: { true },
       languageMode: { .locked("en") },
-      resolveEngine: { _ in .blocked(.unsupportedSystem) }
+      selectedRoute: previewRoute { _ in .blocked(.unsupportedSystem) }
     )
   }
 
@@ -504,9 +632,9 @@ struct LivePreviewCoordinatorTests {
 
     let coordinator = LivePreviewCoordinator(
       readSamples: { _ in ([], 0) },
-      isEnabled: { box.enabled },
+      isPreviewOn: { box.enabled },
       languageMode: { .locked("en") },
-      resolveEngine: { _ in
+      selectedRoute: previewRoute { _ in
         .ready(
           LivePreviewEngineCandidate(
             key: LivePreviewEngineKey(engine: "test", commitment: "en"),
@@ -612,9 +740,9 @@ struct LivePreviewCoordinatorTests {
 
     let coordinator = LivePreviewCoordinator(
       readSamples: { _ in ([], 0) },
-      isEnabled: { box.enabled },
+      isPreviewOn: { box.enabled },
       languageMode: { .locked("en") },
-      resolveEngine: { _ in
+      selectedRoute: previewRoute { _ in
         .ready(
           LivePreviewEngineCandidate(
             key: LivePreviewEngineKey(engine: "test", commitment: "en"),
@@ -640,7 +768,10 @@ struct LivePreviewCoordinatorTests {
     box.enabled = false
     coordinator.releaseForDisabledSetting()
 
-    // Turn it back on and start another recording immediately.
+    // Turn it back on and start another RECORDING immediately. #2123: the
+    // recording has to end first, because a decision is frozen per recording and
+    // a second preview belongs to a second recording.
+    coordinator.setRecording(false)
     box.enabled = true
     coordinator.setRecording(true)
     for _ in 0..<200 { await Task.yield() }
@@ -736,9 +867,9 @@ struct LivePreviewCoordinatorTests {
 
     let coordinator = LivePreviewCoordinator(
       readSamples: { _ in ([], 0) },
-      isEnabled: { box.enabled },
+      isPreviewOn: { box.enabled },
       languageMode: { .locked("en") },
-      resolveEngine: { _ in
+      selectedRoute: previewRoute { _ in
         .ready(
           LivePreviewEngineCandidate(
             key: LivePreviewEngineKey(engine: "test", commitment: "en"),
@@ -758,7 +889,10 @@ struct LivePreviewCoordinatorTests {
     box.enabled = false
     coordinator.releaseForDisabledSetting()
 
-    // The next preview must run, with the first warm-up still hung.
+    // The next preview must run, with the first warm-up still hung. #2123: the
+    // next preview means the next RECORDING — a recording now freezes its
+    // decision at its start, so ending this one is what makes the next one new.
+    coordinator.setRecording(false)
     box.enabled = true
     coordinator.setRecording(true)
     for _ in 0..<2000 where counts.sessionsOpened < 1 { await Task.yield() }
@@ -849,9 +983,9 @@ struct LivePreviewCoordinatorTests {
 
     let coordinator = LivePreviewCoordinator(
       readSamples: { _ in ([], 0) },
-      isEnabled: { box.enabled },
+      isPreviewOn: { box.enabled },
       languageMode: { .locked("en") },
-      resolveEngine: { _ in
+      selectedRoute: previewRoute { _ in
         .ready(
           LivePreviewEngineCandidate(
             key: LivePreviewEngineKey(engine: "test", commitment: "en"),
@@ -872,6 +1006,9 @@ struct LivePreviewCoordinatorTests {
     // Abandon it mid-open, then run a second preview to completion of its open.
     box.enabled = false
     coordinator.releaseForDisabledSetting()
+    // #2123: end the recording before starting the next one — a decision is
+    // frozen per recording, so a second preview belongs to a second recording.
+    coordinator.setRecording(false)
     box.enabled = true
     coordinator.setRecording(true)
     for _ in 0..<2000 where !coordinator.hasLiveSessionForTests { await Task.yield() }
@@ -917,9 +1054,9 @@ struct LivePreviewCoordinatorTests {
 
     let coordinator = LivePreviewCoordinator(
       readSamples: { _ in ([], 0) },
-      isEnabled: { true },
+      isPreviewOn: { true },
       languageMode: { .locked("en") },
-      resolveEngine: { _ in
+      selectedRoute: previewRoute { _ in
         if box.blocked { return .blocked(.heartIsStreaming) }
         return .ready(
           LivePreviewEngineCandidate(
@@ -975,9 +1112,9 @@ struct LivePreviewCoordinatorTests {
     let box = Box()
     let coordinator = LivePreviewCoordinator(
       readSamples: { _ in ([], 0) },
-      isEnabled: { box.enabled },
+      isPreviewOn: { box.enabled },
       languageMode: { .locked("en") },
-      resolveEngine: { _ in
+      selectedRoute: previewRoute { _ in
         .ready(
           LivePreviewEngineCandidate(
             key: LivePreviewEngineKey(engine: "test", commitment: "en"),
@@ -1026,9 +1163,9 @@ struct LivePreviewCoordinatorTests {
     let box = Box()
     let coordinator = LivePreviewCoordinator(
       readSamples: { _ in ([], 0) },
-      isEnabled: { true },
+      isPreviewOn: { true },
       languageMode: { .locked("en") },
-      resolveEngine: { _ in
+      selectedRoute: previewRoute { _ in
         .ready(
           LivePreviewEngineCandidate(
             key: LivePreviewEngineKey(engine: "test", commitment: "en"),
@@ -1074,9 +1211,9 @@ struct LivePreviewCoordinatorTests {
 
     let coordinator = LivePreviewCoordinator(
       readSamples: { _ in ([], 0) },
-      isEnabled: { box.enabled },
+      isPreviewOn: { box.enabled },
       languageMode: { .locked("en") },
-      resolveEngine: { _ in
+      selectedRoute: previewRoute { _ in
         .ready(
           LivePreviewEngineCandidate(
             key: LivePreviewEngineKey(engine: "test", commitment: "en"),

--- a/Tests/EnviousWisprTests/App/LivePreviewCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewCoordinatorTests.swift
@@ -35,6 +35,65 @@ struct LivePreviewCoordinatorTests {
 
   // MARK: - #2123: one engine decision per recording
 
+  /// The selection itself: which route serves which choice, and what happens when
+  /// the universal one could not be composed at all.
+  ///
+  /// A pure function on purpose — this is the one decision that must never
+  /// silently substitute one engine for another, and burying it in the
+  /// installer's closure would make it reachable only through a window, an audio
+  /// capture and a delivery home.
+  @Test("the chosen engine is the one that answers, and a missing one never becomes Apple")
+  func routeSelectionNeverSubstitutesApple() async {
+    let apple = LivePreviewEngineRoute(
+      isSupportedOnThisSystem: { true },
+      resolve: { _ in
+        .ready(
+          LivePreviewEngineCandidate(
+            key: LivePreviewEngineKey(engine: "apple", commitment: "en"),
+            makeEngine: { fatalError("not built in this test") }))
+      })
+    let universal = LivePreviewEngineRoute(
+      isSupportedOnThisSystem: { true },
+      resolve: { _ in
+        .ready(
+          LivePreviewEngineCandidate(
+            key: LivePreviewEngineKey(engine: "universal", commitment: ""),
+            makeEngine: { fatalError("not built in this test") }))
+      })
+
+    func engineID(_ route: LivePreviewEngineRoute) async -> String? {
+      if case .ready(let candidate) = await route.resolve(.locked("en")) {
+        return candidate.key.engine
+      }
+      return nil
+    }
+    func refusal(_ route: LivePreviewEngineRoute) async -> LivePreviewUnavailability? {
+      if case .blocked(let reason) = await route.resolve(.locked("en")) { return reason }
+      return nil
+    }
+
+    // Each choice reaches its OWN engine. The second half is the control: without
+    // it, a selector hardwired to Apple passes the first assertion.
+    let appleChoice = LivePreviewInstaller.route(for: .apple, apple: apple, universal: universal)
+    let universalChoice = LivePreviewInstaller.route(
+      for: .universal, apple: apple, universal: universal)
+    #expect(await engineID(appleChoice) == "apple")
+    #expect(await engineID(universalChoice) == "universal")
+
+    // The build defect: universal chosen, universal not composable.
+    let broken = LivePreviewInstaller.route(for: .universal, apple: apple, universal: nil)
+    #expect(
+      await engineID(broken) != "apple",
+      "a missing universal engine silently ran Apple under a universal selection")
+    #expect(
+      await refusal(broken) == .engineUnavailableInThisBuild,
+      "the build defect must say so rather than borrowing another engine's refusal")
+    #expect(
+      broken.isSupportedOnThisSystem(),
+      "reporting unsupported would make the pill go quietly blank instead of saying why")
+  }
+
+
   /// Switching engines releases the one being switched away from — while the
   /// preview is still ON, which is what makes this a separate entry point from
   /// the disabled path rather than a second caller of it.

--- a/Tests/EnviousWisprTests/App/LivePreviewCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewCoordinatorTests.swift
@@ -27,7 +27,10 @@ private func previewRoute(
   supported: Bool = true,
   _ resolve: @escaping LivePreviewEngineResolver
 ) -> () -> LivePreviewEngineRoute {
-  { LivePreviewEngineRoute(telemetryEngineID: "universal", isSupportedOnThisSystem: { supported }, resolve: resolve) }
+  {
+    LivePreviewEngineRoute(
+      telemetryEngineID: "universal", isSupportedOnThisSystem: { supported }, resolve: resolve)
+  }
 }
 
 @MainActor
@@ -272,11 +275,27 @@ struct LivePreviewCoordinatorTests {
 
     // And once removal ends, previews work again — otherwise this passes against
     // a feature that is simply broken from then on.
-    coordinator.setRecording(false)
+    // **Removal finishing MID-RECORDING must not start a preview in the take that
+    // began suppressed** (#2137 cloud review). The overlay forwards duplicate
+    // `.recording` pushes, so a second `setRecording(true)` with no intervening
+    // `false` is the real shape here, not a contrivance. Before the fix this path
+    // stored no snapshot, so once `endRemovalSuppression()` cleared the guard the
+    // duplicate push sailed past both checks and started a preview partway
+    // through the recording.
     coordinator.endRemovalSuppression()
     coordinator.setRecording(true)
+    for _ in 0..<300 { await Task.yield() }
+    #expect(
+      opens.count == 1,
+      "removal ending mid-recording started a preview in a take that began suppressed")
+
+    // And the NEXT recording decides afresh — otherwise the fix above would be a
+    // permanent suppression rather than a per-take one, which is the same feature
+    // broken in the opposite direction.
+    coordinator.setRecording(false)
+    coordinator.setRecording(true)
     for _ in 0..<2000 where opens.count < 2 { await Task.yield() }
-    #expect(opens.count == 2, "previews must resume once removal has finished")
+    #expect(opens.count == 2, "previews must resume on the recording after removal finished")
   }
 
   // MARK: - #2123 G1: the outcome metric
@@ -604,7 +623,6 @@ struct LivePreviewCoordinatorTests {
       "reporting unsupported would make the pill go quietly blank instead of saying why")
   }
 
-
   /// Switching engines releases the one being switched away from — while the
   /// preview is still ON, which is what makes this a separate entry point from
   /// the disabled path rather than a second caller of it.
@@ -796,7 +814,6 @@ struct LivePreviewCoordinatorTests {
     for _ in 0..<2000 where opens.count < 2 { await Task.yield() }
     #expect(opens.count == 2, "the next recording must use the newly chosen engine")
   }
-
 
   /// The pill's SIZE and the words in it must never disagree about the engine.
   ///
@@ -1595,7 +1612,12 @@ struct LivePreviewCoordinatorTests {
       private var opened = 0
       var enginesMade: Int { mutex.withLock { made } }
       var sessionsOpened: Int { mutex.withLock { opened } }
-      func recordEngine() -> Int { mutex.withLock { made += 1; return made } }
+      func recordEngine() -> Int {
+        mutex.withLock {
+          made += 1
+          return made
+        }
+      }
       func recordOpen() { mutex.withLock { opened += 1 } }
     }
 
@@ -1712,7 +1734,12 @@ struct LivePreviewCoordinatorTests {
       private var entered = 0
       var enginesMade: Int { mutex.withLock { made } }
       var opensEntered: Int { mutex.withLock { entered } }
-      func recordEngine() -> Int { mutex.withLock { made += 1; return made } }
+      func recordEngine() -> Int {
+        mutex.withLock {
+          made += 1
+          return made
+        }
+      }
       func enterOpen() { mutex.withLock { entered += 1 } }
     }
 

--- a/Tests/EnviousWisprTests/App/LivePreviewCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewCoordinatorTests.swift
@@ -35,6 +35,199 @@ struct LivePreviewCoordinatorTests {
 
   // MARK: - #2123: one engine decision per recording
 
+  /// Switching engines releases the one being switched away from — while the
+  /// preview is still ON, which is what makes this a separate entry point from
+  /// the disabled path rather than a second caller of it.
+  @Test("switching engines releases the engine switched away from")
+  func switchingEnginesReleases() async {
+    final class ReadyEngine: LivePreviewEngine, @unchecked Sendable {
+      func prepare() async throws {}
+      func openSession(
+        lookups: WordCorrector.Lookups?, onText: @escaping @Sendable (String) -> Void
+      ) async throws -> any LivePreviewEngineSession {
+        struct Idle: LivePreviewEngineSession {
+          func feed(_ samples: [Float]) async {}
+          func end() async {}
+        }
+        return Idle()
+      }
+    }
+
+    let coordinator = LivePreviewCoordinator(
+      readSamples: { _ in ([], 0) },
+      isPreviewOn: { true },
+      languageMode: { .locked("en") },
+      selectedRoute: previewRoute { _ in
+        .ready(
+          LivePreviewEngineCandidate(
+            key: LivePreviewEngineKey(engine: "apple", commitment: "en"),
+            makeEngine: { ReadyEngine() }))
+      }
+    )
+
+    coordinator.setRecording(true)
+    for _ in 0..<2000 where !coordinator.hasPreparedEngineForTests { await Task.yield() }
+    #expect(coordinator.hasPreparedEngineForTests, "control: an engine must be cached first")
+
+    // The user picks the other engine. The preview stays ON throughout.
+    coordinator.releaseForEngineChange()
+    #expect(!coordinator.hasPreparedEngineForTests, "the old engine's model must be released")
+    #expect(coordinator.display == .off)
+  }
+
+  /// The engine-change release must NOT inherit the disabled path's guard.
+  ///
+  /// `releaseForDisabledSetting` returns early while the preview is on — correct
+  /// for its own trigger, and fatal here: switching engines happens with the
+  /// preview on by definition, so a shared guard would make this a no-op and the
+  /// old model would stay resident for the rest of the session.
+  @Test("the engine-change release fires even though the preview is still on")
+  func engineChangeIsNotGuardedByTheToggle() async {
+    final class ReadyEngine: LivePreviewEngine, @unchecked Sendable {
+      func prepare() async throws {}
+      func openSession(
+        lookups: WordCorrector.Lookups?, onText: @escaping @Sendable (String) -> Void
+      ) async throws -> any LivePreviewEngineSession {
+        struct Idle: LivePreviewEngineSession {
+          func feed(_ samples: [Float]) async {}
+          func end() async {}
+        }
+        return Idle()
+      }
+    }
+    let coordinator = LivePreviewCoordinator(
+      readSamples: { _ in ([], 0) },
+      isPreviewOn: { true },
+      languageMode: { .locked("en") },
+      selectedRoute: previewRoute { _ in
+        .ready(
+          LivePreviewEngineCandidate(
+            key: LivePreviewEngineKey(engine: "apple", commitment: "en"),
+            makeEngine: { ReadyEngine() }))
+      }
+    )
+    coordinator.setRecording(true)
+    for _ in 0..<2000 where !coordinator.hasPreparedEngineForTests { await Task.yield() }
+    #expect(coordinator.hasPreparedEngineForTests, "control: cached before the switch")
+
+    // CONTROL: the disabled path is a no-op here, precisely because the preview
+    // is on. If both behaved the same, the test below would prove nothing.
+    coordinator.releaseForDisabledSetting()
+    #expect(
+      coordinator.hasPreparedEngineForTests,
+      "control: the disabled path must NOT release while the preview is on")
+
+    coordinator.releaseForEngineChange()
+    #expect(!coordinator.hasPreparedEngineForTests, "the engine-change path must release")
+  }
+
+  /// An IDLE switch — the commonest one, since a user changes engines in Settings
+  /// between recordings, not during one. The mid-recording tests above say
+  /// nothing about it: `isRunning` is false, so they exercise a different branch.
+  @Test("switching engines while idle releases an engine cached by an earlier recording")
+  func idleSwitchReleasesTheCachedEngine() async {
+    let probe = PreviewEngineProbe()
+    let coordinator = makeCoordinator(probe: probe, key: key("apple", "en-US"))
+
+    coordinator.setRecording(true)
+    #expect(await reach { await probe.sessionsOpened == 1 }, "control: a session must have opened")
+    coordinator.setRecording(false)
+    #expect(
+      coordinator.hasPreparedEngineForTests,
+      "control: the engine stays cached across recordings — that is why it needs releasing")
+
+    coordinator.releaseForEngineChange()
+    #expect(
+      !coordinator.hasPreparedEngineForTests,
+      "an idle engine switch left the previous engine's model cached")
+  }
+
+  /// **Teardown must COMPLETE, not merely be requested.**
+  ///
+  /// Clearing the cached slot and the display is what the eye sees; it is not
+  /// what frees the model. A version of `releaseForEngineChange` that did only
+  /// that — leaving the live session feeding and decoding — passes every other
+  /// switch test here, which is exactly why this one counts ended sessions
+  /// through the probe rather than reading `display`.
+  @Test("switching engines mid-recording ends the live session, not just the cache")
+  func switchingEndsTheLiveSession() async {
+    let probe = PreviewEngineProbe()
+    let coordinator = makeCoordinator(
+      probe: probe,
+      key: key("apple", "en-US"),
+      readSamples: { index in
+        index == Int.max ? ([], 0) : (Array(repeating: Float(0.05), count: 160), 160)
+      })
+
+    coordinator.setRecording(true)
+    #expect(await reach { await probe.samplesFed > 0 }, "control: the session must be live")
+    #expect(await probe.sessionsEnded == 0, "control: nothing has ended yet")
+
+    coordinator.releaseForEngineChange()
+
+    #expect(
+      await reach { await probe.sessionsEnded == 1 },
+      "the switch cleared the cache but left the session running")
+    #expect(await probe.sessionsEnded == 1, "and ended it exactly once")
+  }
+
+  /// Switching mid-recording must not start the NEW engine inside the recording
+  /// that was already under way — the snapshot is what suppresses it, so this
+  /// asserts the two behaviours are wired to one rule and not two.
+  @Test("switching mid-recording does not start the new engine until the next recording")
+  func switchingMidRecordingDoesNotRestart() async {
+    final class Opens: @unchecked Sendable {
+      private let mutex = NSLock()
+      private var value = 0
+      var count: Int { mutex.withLock { value } }
+      func record() { mutex.withLock { value += 1 } }
+    }
+    let opens = Opens()
+    final class CountingEngine: LivePreviewEngine, @unchecked Sendable {
+      let opens: Opens
+      init(opens: Opens) { self.opens = opens }
+      func prepare() async throws {}
+      func openSession(
+        lookups: WordCorrector.Lookups?, onText: @escaping @Sendable (String) -> Void
+      ) async throws -> any LivePreviewEngineSession {
+        opens.record()
+        struct Idle: LivePreviewEngineSession {
+          func feed(_ samples: [Float]) async {}
+          func end() async {}
+        }
+        return Idle()
+      }
+    }
+
+    let coordinator = LivePreviewCoordinator(
+      readSamples: { _ in ([], 0) },
+      isPreviewOn: { true },
+      languageMode: { .locked("en") },
+      selectedRoute: previewRoute { _ in
+        .ready(
+          LivePreviewEngineCandidate(
+            key: LivePreviewEngineKey(engine: "apple", commitment: "en"),
+            makeEngine: { CountingEngine(opens: opens) }))
+      }
+    )
+
+    coordinator.setRecording(true)
+    for _ in 0..<2000 where opens.count < 1 { await Task.yield() }
+    #expect(opens.count == 1, "control: the first session opened")
+
+    coordinator.releaseForEngineChange()
+    coordinator.setRecording(true)  // the overlay's duplicate intent push
+    for _ in 0..<300 { await Task.yield() }
+    #expect(opens.count == 1, "the new engine started inside the old recording")
+
+    // Next recording: it does start, so this is suppression and not breakage.
+    coordinator.setRecording(false)
+    coordinator.setRecording(true)
+    for _ in 0..<2000 where opens.count < 2 { await Task.yield() }
+    #expect(opens.count == 2, "the next recording must use the newly chosen engine")
+  }
+
+
   /// The pill's SIZE and the words in it must never disagree about the engine.
   ///
   /// Freezing only at the moment intent arrives is not enough on its own: the

--- a/Tests/EnviousWisprTests/App/LivePreviewCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewCoordinatorTests.swift
@@ -27,7 +27,7 @@ private func previewRoute(
   supported: Bool = true,
   _ resolve: @escaping LivePreviewEngineResolver
 ) -> () -> LivePreviewEngineRoute {
-  { LivePreviewEngineRoute(isSupportedOnThisSystem: { supported }, resolve: resolve) }
+  { LivePreviewEngineRoute(telemetryEngineID: "universal", isSupportedOnThisSystem: { supported }, resolve: resolve) }
 }
 
 @MainActor
@@ -279,6 +279,265 @@ struct LivePreviewCoordinatorTests {
     #expect(opens.count == 2, "previews must resume once removal has finished")
   }
 
+  // MARK: - #2123 G1: the outcome metric
+
+  /// The event has to name the engine that ACTUALLY ran, and carry nothing else.
+  ///
+  /// A refusal produces no candidate, so the engine name comes from the route —
+  /// which is why routes carry an id at all. And "blocked" is the outcome that
+  /// matters most for the downloadable engine, since not-installed is its
+  /// commonest refusal: an event that could not name the engine there would fail
+  /// to answer the one question it exists for.
+  ///
+  /// The property COUNT is asserted, not just the values. An event that starts
+  /// carrying a refusal reason, a language, or anything else about what the user
+  /// was doing must fail this.
+  @Test("a refused preview reports which engine refused, and nothing more")
+  func blockedOutcomeNamesTheEngine() async throws {
+    let waiter = TelemetryEventWaiter()
+    TelemetryService.shared.testEventHook = { @Sendable event in
+      MainActor.assumeIsolated { waiter.record(event) }
+    }
+    defer { TelemetryService.shared.testEventHook = nil }
+
+    let coordinator = LivePreviewCoordinator(
+      readSamples: { _ in ([], 0) },
+      isPreviewOn: { true },
+      languageMode: { .locked("en") },
+      selectedRoute: {
+        LivePreviewEngineRoute(
+          telemetryEngineID: "universal",
+          isSupportedOnThisSystem: { true },
+          resolve: { _ in .blocked(.modelNotInstalled) })
+      }
+    )
+
+    coordinator.setRecording(true)
+    let event = try await waiter.waitForEvent(named: "live_preview.outcome")
+
+    // The CLOSED value, not the candidate key's `whisper_preview#<digest>`: a
+    // per-revision engine string would be a high-cardinality property rather
+    // than a dimension anyone can group by.
+    #expect(event.stringProps["engine"] == "universal")
+    #expect(event.stringProps["outcome"] == "blocked")
+    #expect(
+      event.stringProps.count == 2,
+      "the event grew a property: \(event.stringProps.keys.sorted())")
+  }
+
+  /// A preview that RUNS reports started, exactly once, with the closed engine
+  /// value. Testing only the refusal left three of four call sites unprotected —
+  /// a mutation at any of them stayed green.
+  @Test("a running preview reports started exactly once")
+  func startedOutcomeIsReportedOnce() async throws {
+    let waiter = TelemetryEventWaiter()
+    TelemetryService.shared.testEventHook = { @Sendable event in
+      MainActor.assumeIsolated { waiter.record(event) }
+    }
+    defer { TelemetryService.shared.testEventHook = nil }
+
+    final class ReadyEngine: LivePreviewEngine, @unchecked Sendable {
+      func prepare() async throws {}
+      func openSession(
+        lookups: WordCorrector.Lookups?, onText: @escaping @Sendable (String) -> Void
+      ) async throws -> any LivePreviewEngineSession {
+        struct Idle: LivePreviewEngineSession {
+          func feed(_ samples: [Float]) async {}
+          func end() async {}
+        }
+        return Idle()
+      }
+    }
+    let coordinator = LivePreviewCoordinator(
+      readSamples: { _ in ([], 0) },
+      isPreviewOn: { true },
+      languageMode: { .locked("en") },
+      selectedRoute: previewRoute { _ in
+        .ready(
+          LivePreviewEngineCandidate(
+            key: LivePreviewEngineKey(engine: "whisper_preview#abc123", commitment: ""),
+            makeEngine: { ReadyEngine() }))
+      }
+    )
+
+    coordinator.setRecording(true)
+    let event = try await waiter.waitForEvent(named: "live_preview.outcome")
+    #expect(event.stringProps["outcome"] == "started")
+    // The candidate key here deliberately CARRIES a digest. The event must not.
+    #expect(
+      event.stringProps["engine"] == "universal",
+      "the artifact identity leaked into the engine field")
+
+    // **"Once" has to be ASSERTED.** Waiting for the first event proves one
+    // arrived, not that a second did not — the name claimed a property the test
+    // did not check, which is the shape of a test that reads as stronger than it is.
+    for _ in 0..<300 { await Task.yield() }
+    let outcomes = waiter.events.filter { $0.name == "live_preview.outcome" }
+    #expect(outcomes.count == 1, "expected exactly one outcome, got \(outcomes.count)")
+  }
+
+  /// A session abandoned WHILE OPENING must report nothing at all.
+  ///
+  /// `openSession` suspends. If the recording ends in that window the session is
+  /// torn down immediately and the user never saw a preview, so counting it as
+  /// `started` would inflate the metric with previews that did not happen.
+  ///
+  /// Mutation control: remove the `isCurrent` guard around the `started` report
+  /// and this fails on a non-zero count.
+  @Test("a preview abandoned while opening reports nothing")
+  func staleOpenReportsNothing() async throws {
+    let waiter = TelemetryEventWaiter()
+    TelemetryService.shared.testEventHook = { @Sendable event in
+      MainActor.assumeIsolated { waiter.record(event) }
+    }
+    defer { TelemetryService.shared.testEventHook = nil }
+
+    final class Gate: @unchecked Sendable {
+      private let mutex = NSLock()
+      private var waiterC: CheckedContinuation<Void, Never>?
+      private var isOpen = false
+      private var entered = false
+      var hasEntered: Bool { mutex.withLock { entered } }
+      func wait() async {
+        mutex.withLock { entered = true }
+        await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
+          let open: Bool = mutex.withLock {
+            if isOpen { return true }
+            waiterC = c
+            return false
+          }
+          if open { c.resume() }
+        }
+      }
+      func open() {
+        let w: CheckedContinuation<Void, Never>? = mutex.withLock {
+          isOpen = true
+          let w = waiterC
+          waiterC = nil
+          return w
+        }
+        w?.resume()
+      }
+    }
+    let opening = Gate()
+
+    final class SlowOpenEngine: LivePreviewEngine, @unchecked Sendable {
+      let gate: Gate
+      init(gate: Gate) { self.gate = gate }
+      func prepare() async throws {}
+      func openSession(
+        lookups: WordCorrector.Lookups?, onText: @escaping @Sendable (String) -> Void
+      ) async throws -> any LivePreviewEngineSession {
+        await gate.wait()
+        struct Idle: LivePreviewEngineSession {
+          func feed(_ samples: [Float]) async {}
+          func end() async {}
+        }
+        return Idle()
+      }
+    }
+
+    let coordinator = LivePreviewCoordinator(
+      readSamples: { _ in ([], 0) },
+      isPreviewOn: { true },
+      languageMode: { .locked("en") },
+      selectedRoute: previewRoute { _ in
+        .ready(
+          LivePreviewEngineCandidate(
+            key: LivePreviewEngineKey(engine: "whisper_preview#abc123", commitment: ""),
+            makeEngine: { SlowOpenEngine(gate: opening) }))
+      }
+    )
+
+    coordinator.setRecording(true)
+    for _ in 0..<2000 where !opening.hasEntered { await Task.yield() }
+    #expect(opening.hasEntered, "control: the open must be in flight")
+
+    // The recording ends while the open is still suspended.
+    coordinator.setRecording(false)
+    opening.open()
+    for _ in 0..<500 { await Task.yield() }
+
+    let outcomes = waiter.events.filter { $0.name == "live_preview.outcome" }
+    #expect(
+      outcomes.isEmpty,
+      "a preview the user never saw was counted: \(outcomes.map { $0.stringProps })")
+  }
+
+  /// An engine that cannot prepare reports `prepare_failed` rather than nothing.
+  @Test("a preview that cannot prepare reports prepare_failed")
+  func prepareFailureIsReported() async throws {
+    let waiter = TelemetryEventWaiter()
+    TelemetryService.shared.testEventHook = { @Sendable event in
+      MainActor.assumeIsolated { waiter.record(event) }
+    }
+    defer { TelemetryService.shared.testEventHook = nil }
+
+    struct Boom: Error {}
+    final class FailingEngine: LivePreviewEngine, @unchecked Sendable {
+      func prepare() async throws { throw Boom() }
+      func openSession(
+        lookups: WordCorrector.Lookups?, onText: @escaping @Sendable (String) -> Void
+      ) async throws -> any LivePreviewEngineSession {
+        throw Boom()
+      }
+    }
+    let coordinator = LivePreviewCoordinator(
+      readSamples: { _ in ([], 0) },
+      isPreviewOn: { true },
+      languageMode: { .locked("en") },
+      selectedRoute: previewRoute { _ in
+        .ready(
+          LivePreviewEngineCandidate(
+            key: LivePreviewEngineKey(engine: "whisper_preview#abc123", commitment: ""),
+            makeEngine: { FailingEngine() }))
+      }
+    )
+
+    coordinator.setRecording(true)
+    let event = try await waiter.waitForEvent(named: "live_preview.outcome")
+    #expect(event.stringProps["outcome"] == "prepare_failed")
+    #expect(event.stringProps["engine"] == "universal")
+  }
+
+  /// An engine that prepares but cannot open a session reports `open_failed` —
+  /// a different outcome from failing to prepare, because they send you to
+  /// different places when the graph moves.
+  @Test("a preview that cannot open a session reports open_failed")
+  func openFailureIsReported() async throws {
+    let waiter = TelemetryEventWaiter()
+    TelemetryService.shared.testEventHook = { @Sendable event in
+      MainActor.assumeIsolated { waiter.record(event) }
+    }
+    defer { TelemetryService.shared.testEventHook = nil }
+
+    struct Boom: Error {}
+    final class OpenFailsEngine: LivePreviewEngine, @unchecked Sendable {
+      func prepare() async throws {}
+      func openSession(
+        lookups: WordCorrector.Lookups?, onText: @escaping @Sendable (String) -> Void
+      ) async throws -> any LivePreviewEngineSession {
+        throw Boom()
+      }
+    }
+    let coordinator = LivePreviewCoordinator(
+      readSamples: { _ in ([], 0) },
+      isPreviewOn: { true },
+      languageMode: { .locked("en") },
+      selectedRoute: previewRoute { _ in
+        .ready(
+          LivePreviewEngineCandidate(
+            key: LivePreviewEngineKey(engine: "whisper_preview#abc123", commitment: ""),
+            makeEngine: { OpenFailsEngine() }))
+      }
+    )
+
+    coordinator.setRecording(true)
+    let event = try await waiter.waitForEvent(named: "live_preview.outcome")
+    #expect(event.stringProps["outcome"] == "open_failed")
+    #expect(event.stringProps["engine"] == "universal")
+  }
+
   // MARK: - #2123: one engine decision per recording
 
   /// The selection itself: which route serves which choice, and what happens when
@@ -291,6 +550,7 @@ struct LivePreviewCoordinatorTests {
   @Test("the chosen engine is the one that answers, and a missing one never becomes Apple")
   func routeSelectionNeverSubstitutesApple() async {
     let apple = LivePreviewEngineRoute(
+      telemetryEngineID: "apple",
       isSupportedOnThisSystem: { true },
       resolve: { _ in
         .ready(
@@ -299,6 +559,7 @@ struct LivePreviewCoordinatorTests {
             makeEngine: { fatalError("not built in this test") }))
       })
     let universal = LivePreviewEngineRoute(
+      telemetryEngineID: "universal",
       isSupportedOnThisSystem: { true },
       resolve: { _ in
         .ready(
@@ -568,6 +829,7 @@ struct LivePreviewCoordinatorTests {
         // behave once it switches on a setting.
         let id = choice.current
         return LivePreviewEngineRoute(
+          telemetryEngineID: "universal",
           isSupportedOnThisSystem: { true },
           resolve: { _ in
             seen.record(id)

--- a/Tests/EnviousWisprTests/App/LivePreviewCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewCoordinatorTests.swift
@@ -281,262 +281,266 @@ struct LivePreviewCoordinatorTests {
 
   // MARK: - #2123 G1: the outcome metric
 
-  /// The event has to name the engine that ACTUALLY ran, and carry nothing else.
-  ///
-  /// A refusal produces no candidate, so the engine name comes from the route —
-  /// which is why routes carry an id at all. And "blocked" is the outcome that
-  /// matters most for the downloadable engine, since not-installed is its
-  /// commonest refusal: an event that could not name the engine there would fail
-  /// to answer the one question it exists for.
-  ///
-  /// The property COUNT is asserted, not just the values. An event that starts
-  /// carrying a refusal reason, a language, or anything else about what the user
-  /// was doing must fail this.
-  @Test("a refused preview reports which engine refused, and nothing more")
-  func blockedOutcomeNamesTheEngine() async throws {
-    let waiter = TelemetryEventWaiter()
-    TelemetryService.shared.testEventHook = { @Sendable event in
-      MainActor.assumeIsolated { waiter.record(event) }
-    }
-    defer { TelemetryService.shared.testEventHook = nil }
-
-    let coordinator = LivePreviewCoordinator(
-      readSamples: { _ in ([], 0) },
-      isPreviewOn: { true },
-      languageMode: { .locked("en") },
-      selectedRoute: {
-        LivePreviewEngineRoute(
-          telemetryEngineID: "universal",
-          isSupportedOnThisSystem: { true },
-          resolve: { _ in .blocked(.modelNotInstalled) })
+  // `testEventHook` is a DEBUG-only seam, so these cannot be compiled into a
+  // release build (tools-and-apps.md RULE: xcode-test-entrypoint).
+  #if DEBUG
+    /// The event has to name the engine that ACTUALLY ran, and carry nothing else.
+    ///
+    /// A refusal produces no candidate, so the engine name comes from the route —
+    /// which is why routes carry an id at all. And "blocked" is the outcome that
+    /// matters most for the downloadable engine, since not-installed is its
+    /// commonest refusal: an event that could not name the engine there would fail
+    /// to answer the one question it exists for.
+    ///
+    /// The property COUNT is asserted, not just the values. An event that starts
+    /// carrying a refusal reason, a language, or anything else about what the user
+    /// was doing must fail this.
+    @Test("a refused preview reports which engine refused, and nothing more")
+    func blockedOutcomeNamesTheEngine() async throws {
+      let waiter = TelemetryEventWaiter()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        MainActor.assumeIsolated { waiter.record(event) }
       }
-    )
+      defer { TelemetryService.shared.testEventHook = nil }
 
-    coordinator.setRecording(true)
-    let event = try await waiter.waitForEvent(named: "live_preview.outcome")
-
-    // The CLOSED value, not the candidate key's `whisper_preview#<digest>`: a
-    // per-revision engine string would be a high-cardinality property rather
-    // than a dimension anyone can group by.
-    #expect(event.stringProps["engine"] == "universal")
-    #expect(event.stringProps["outcome"] == "blocked")
-    #expect(
-      event.stringProps.count == 2,
-      "the event grew a property: \(event.stringProps.keys.sorted())")
-  }
-
-  /// A preview that RUNS reports started, exactly once, with the closed engine
-  /// value. Testing only the refusal left three of four call sites unprotected —
-  /// a mutation at any of them stayed green.
-  @Test("a running preview reports started exactly once")
-  func startedOutcomeIsReportedOnce() async throws {
-    let waiter = TelemetryEventWaiter()
-    TelemetryService.shared.testEventHook = { @Sendable event in
-      MainActor.assumeIsolated { waiter.record(event) }
-    }
-    defer { TelemetryService.shared.testEventHook = nil }
-
-    final class ReadyEngine: LivePreviewEngine, @unchecked Sendable {
-      func prepare() async throws {}
-      func openSession(
-        lookups: WordCorrector.Lookups?, onText: @escaping @Sendable (String) -> Void
-      ) async throws -> any LivePreviewEngineSession {
-        struct Idle: LivePreviewEngineSession {
-          func feed(_ samples: [Float]) async {}
-          func end() async {}
+      let coordinator = LivePreviewCoordinator(
+        readSamples: { _ in ([], 0) },
+        isPreviewOn: { true },
+        languageMode: { .locked("en") },
+        selectedRoute: {
+          LivePreviewEngineRoute(
+            telemetryEngineID: "universal",
+            isSupportedOnThisSystem: { true },
+            resolve: { _ in .blocked(.modelNotInstalled) })
         }
-        return Idle()
-      }
+      )
+
+      coordinator.setRecording(true)
+      let event = try await waiter.waitForEvent(named: "live_preview.outcome")
+
+      // The CLOSED value, not the candidate key's `whisper_preview#<digest>`: a
+      // per-revision engine string would be a high-cardinality property rather
+      // than a dimension anyone can group by.
+      #expect(event.stringProps["engine"] == "universal")
+      #expect(event.stringProps["outcome"] == "blocked")
+      #expect(
+        event.stringProps.count == 2,
+        "the event grew a property: \(event.stringProps.keys.sorted())")
     }
-    let coordinator = LivePreviewCoordinator(
-      readSamples: { _ in ([], 0) },
-      isPreviewOn: { true },
-      languageMode: { .locked("en") },
-      selectedRoute: previewRoute { _ in
-        .ready(
-          LivePreviewEngineCandidate(
-            key: LivePreviewEngineKey(engine: "whisper_preview#abc123", commitment: ""),
-            makeEngine: { ReadyEngine() }))
+
+    /// A preview that RUNS reports started, exactly once, with the closed engine
+    /// value. Testing only the refusal left three of four call sites unprotected —
+    /// a mutation at any of them stayed green.
+    @Test("a running preview reports started exactly once")
+    func startedOutcomeIsReportedOnce() async throws {
+      let waiter = TelemetryEventWaiter()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        MainActor.assumeIsolated { waiter.record(event) }
       }
-    )
+      defer { TelemetryService.shared.testEventHook = nil }
 
-    coordinator.setRecording(true)
-    let event = try await waiter.waitForEvent(named: "live_preview.outcome")
-    #expect(event.stringProps["outcome"] == "started")
-    // The candidate key here deliberately CARRIES a digest. The event must not.
-    #expect(
-      event.stringProps["engine"] == "universal",
-      "the artifact identity leaked into the engine field")
-
-    // **"Once" has to be ASSERTED.** Waiting for the first event proves one
-    // arrived, not that a second did not — the name claimed a property the test
-    // did not check, which is the shape of a test that reads as stronger than it is.
-    for _ in 0..<300 { await Task.yield() }
-    let outcomes = waiter.events.filter { $0.name == "live_preview.outcome" }
-    #expect(outcomes.count == 1, "expected exactly one outcome, got \(outcomes.count)")
-  }
-
-  /// A session abandoned WHILE OPENING must report nothing at all.
-  ///
-  /// `openSession` suspends. If the recording ends in that window the session is
-  /// torn down immediately and the user never saw a preview, so counting it as
-  /// `started` would inflate the metric with previews that did not happen.
-  ///
-  /// Mutation control: remove the `isCurrent` guard around the `started` report
-  /// and this fails on a non-zero count.
-  @Test("a preview abandoned while opening reports nothing")
-  func staleOpenReportsNothing() async throws {
-    let waiter = TelemetryEventWaiter()
-    TelemetryService.shared.testEventHook = { @Sendable event in
-      MainActor.assumeIsolated { waiter.record(event) }
-    }
-    defer { TelemetryService.shared.testEventHook = nil }
-
-    final class Gate: @unchecked Sendable {
-      private let mutex = NSLock()
-      private var waiterC: CheckedContinuation<Void, Never>?
-      private var isOpen = false
-      private var entered = false
-      var hasEntered: Bool { mutex.withLock { entered } }
-      func wait() async {
-        mutex.withLock { entered = true }
-        await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
-          let open: Bool = mutex.withLock {
-            if isOpen { return true }
-            waiterC = c
-            return false
+      final class ReadyEngine: LivePreviewEngine, @unchecked Sendable {
+        func prepare() async throws {}
+        func openSession(
+          lookups: WordCorrector.Lookups?, onText: @escaping @Sendable (String) -> Void
+        ) async throws -> any LivePreviewEngineSession {
+          struct Idle: LivePreviewEngineSession {
+            func feed(_ samples: [Float]) async {}
+            func end() async {}
           }
-          if open { c.resume() }
+          return Idle()
         }
       }
-      func open() {
-        let w: CheckedContinuation<Void, Never>? = mutex.withLock {
-          isOpen = true
-          let w = waiterC
-          waiterC = nil
-          return w
+      let coordinator = LivePreviewCoordinator(
+        readSamples: { _ in ([], 0) },
+        isPreviewOn: { true },
+        languageMode: { .locked("en") },
+        selectedRoute: previewRoute { _ in
+          .ready(
+            LivePreviewEngineCandidate(
+              key: LivePreviewEngineKey(engine: "whisper_preview#abc123", commitment: ""),
+              makeEngine: { ReadyEngine() }))
         }
-        w?.resume()
-      }
-    }
-    let opening = Gate()
+      )
 
-    final class SlowOpenEngine: LivePreviewEngine, @unchecked Sendable {
-      let gate: Gate
-      init(gate: Gate) { self.gate = gate }
-      func prepare() async throws {}
-      func openSession(
-        lookups: WordCorrector.Lookups?, onText: @escaping @Sendable (String) -> Void
-      ) async throws -> any LivePreviewEngineSession {
-        await gate.wait()
-        struct Idle: LivePreviewEngineSession {
-          func feed(_ samples: [Float]) async {}
-          func end() async {}
+      coordinator.setRecording(true)
+      let event = try await waiter.waitForEvent(named: "live_preview.outcome")
+      #expect(event.stringProps["outcome"] == "started")
+      // The candidate key here deliberately CARRIES a digest. The event must not.
+      #expect(
+        event.stringProps["engine"] == "universal",
+        "the artifact identity leaked into the engine field")
+
+      // **"Once" has to be ASSERTED.** Waiting for the first event proves one
+      // arrived, not that a second did not — the name claimed a property the test
+      // did not check, which is the shape of a test that reads as stronger than it is.
+      for _ in 0..<300 { await Task.yield() }
+      let outcomes = waiter.events.filter { $0.name == "live_preview.outcome" }
+      #expect(outcomes.count == 1, "expected exactly one outcome, got \(outcomes.count)")
+    }
+
+    /// A session abandoned WHILE OPENING must report nothing at all.
+    ///
+    /// `openSession` suspends. If the recording ends in that window the session is
+    /// torn down immediately and the user never saw a preview, so counting it as
+    /// `started` would inflate the metric with previews that did not happen.
+    ///
+    /// Mutation control: remove the `isCurrent` guard around the `started` report
+    /// and this fails on a non-zero count.
+    @Test("a preview abandoned while opening reports nothing")
+    func staleOpenReportsNothing() async throws {
+      let waiter = TelemetryEventWaiter()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        MainActor.assumeIsolated { waiter.record(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      final class Gate: @unchecked Sendable {
+        private let mutex = NSLock()
+        private var waiterC: CheckedContinuation<Void, Never>?
+        private var isOpen = false
+        private var entered = false
+        var hasEntered: Bool { mutex.withLock { entered } }
+        func wait() async {
+          mutex.withLock { entered = true }
+          await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
+            let open: Bool = mutex.withLock {
+              if isOpen { return true }
+              waiterC = c
+              return false
+            }
+            if open { c.resume() }
+          }
         }
-        return Idle()
+        func open() {
+          let w: CheckedContinuation<Void, Never>? = mutex.withLock {
+            isOpen = true
+            let w = waiterC
+            waiterC = nil
+            return w
+          }
+          w?.resume()
+        }
       }
+      let opening = Gate()
+
+      final class SlowOpenEngine: LivePreviewEngine, @unchecked Sendable {
+        let gate: Gate
+        init(gate: Gate) { self.gate = gate }
+        func prepare() async throws {}
+        func openSession(
+          lookups: WordCorrector.Lookups?, onText: @escaping @Sendable (String) -> Void
+        ) async throws -> any LivePreviewEngineSession {
+          await gate.wait()
+          struct Idle: LivePreviewEngineSession {
+            func feed(_ samples: [Float]) async {}
+            func end() async {}
+          }
+          return Idle()
+        }
+      }
+
+      let coordinator = LivePreviewCoordinator(
+        readSamples: { _ in ([], 0) },
+        isPreviewOn: { true },
+        languageMode: { .locked("en") },
+        selectedRoute: previewRoute { _ in
+          .ready(
+            LivePreviewEngineCandidate(
+              key: LivePreviewEngineKey(engine: "whisper_preview#abc123", commitment: ""),
+              makeEngine: { SlowOpenEngine(gate: opening) }))
+        }
+      )
+
+      coordinator.setRecording(true)
+      for _ in 0..<2000 where !opening.hasEntered { await Task.yield() }
+      #expect(opening.hasEntered, "control: the open must be in flight")
+
+      // The recording ends while the open is still suspended.
+      coordinator.setRecording(false)
+      opening.open()
+      for _ in 0..<500 { await Task.yield() }
+
+      let outcomes = waiter.events.filter { $0.name == "live_preview.outcome" }
+      #expect(
+        outcomes.isEmpty,
+        "a preview the user never saw was counted: \(outcomes.map { $0.stringProps })")
     }
 
-    let coordinator = LivePreviewCoordinator(
-      readSamples: { _ in ([], 0) },
-      isPreviewOn: { true },
-      languageMode: { .locked("en") },
-      selectedRoute: previewRoute { _ in
-        .ready(
-          LivePreviewEngineCandidate(
-            key: LivePreviewEngineKey(engine: "whisper_preview#abc123", commitment: ""),
-            makeEngine: { SlowOpenEngine(gate: opening) }))
+    /// An engine that cannot prepare reports `prepare_failed` rather than nothing.
+    @Test("a preview that cannot prepare reports prepare_failed")
+    func prepareFailureIsReported() async throws {
+      let waiter = TelemetryEventWaiter()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        MainActor.assumeIsolated { waiter.record(event) }
       }
-    )
+      defer { TelemetryService.shared.testEventHook = nil }
 
-    coordinator.setRecording(true)
-    for _ in 0..<2000 where !opening.hasEntered { await Task.yield() }
-    #expect(opening.hasEntered, "control: the open must be in flight")
+      struct Boom: Error {}
+      final class FailingEngine: LivePreviewEngine, @unchecked Sendable {
+        func prepare() async throws { throw Boom() }
+        func openSession(
+          lookups: WordCorrector.Lookups?, onText: @escaping @Sendable (String) -> Void
+        ) async throws -> any LivePreviewEngineSession {
+          throw Boom()
+        }
+      }
+      let coordinator = LivePreviewCoordinator(
+        readSamples: { _ in ([], 0) },
+        isPreviewOn: { true },
+        languageMode: { .locked("en") },
+        selectedRoute: previewRoute { _ in
+          .ready(
+            LivePreviewEngineCandidate(
+              key: LivePreviewEngineKey(engine: "whisper_preview#abc123", commitment: ""),
+              makeEngine: { FailingEngine() }))
+        }
+      )
 
-    // The recording ends while the open is still suspended.
-    coordinator.setRecording(false)
-    opening.open()
-    for _ in 0..<500 { await Task.yield() }
-
-    let outcomes = waiter.events.filter { $0.name == "live_preview.outcome" }
-    #expect(
-      outcomes.isEmpty,
-      "a preview the user never saw was counted: \(outcomes.map { $0.stringProps })")
-  }
-
-  /// An engine that cannot prepare reports `prepare_failed` rather than nothing.
-  @Test("a preview that cannot prepare reports prepare_failed")
-  func prepareFailureIsReported() async throws {
-    let waiter = TelemetryEventWaiter()
-    TelemetryService.shared.testEventHook = { @Sendable event in
-      MainActor.assumeIsolated { waiter.record(event) }
+      coordinator.setRecording(true)
+      let event = try await waiter.waitForEvent(named: "live_preview.outcome")
+      #expect(event.stringProps["outcome"] == "prepare_failed")
+      #expect(event.stringProps["engine"] == "universal")
     }
-    defer { TelemetryService.shared.testEventHook = nil }
 
-    struct Boom: Error {}
-    final class FailingEngine: LivePreviewEngine, @unchecked Sendable {
-      func prepare() async throws { throw Boom() }
-      func openSession(
-        lookups: WordCorrector.Lookups?, onText: @escaping @Sendable (String) -> Void
-      ) async throws -> any LivePreviewEngineSession {
-        throw Boom()
+    /// An engine that prepares but cannot open a session reports `open_failed` —
+    /// a different outcome from failing to prepare, because they send you to
+    /// different places when the graph moves.
+    @Test("a preview that cannot open a session reports open_failed")
+    func openFailureIsReported() async throws {
+      let waiter = TelemetryEventWaiter()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        MainActor.assumeIsolated { waiter.record(event) }
       }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      struct Boom: Error {}
+      final class OpenFailsEngine: LivePreviewEngine, @unchecked Sendable {
+        func prepare() async throws {}
+        func openSession(
+          lookups: WordCorrector.Lookups?, onText: @escaping @Sendable (String) -> Void
+        ) async throws -> any LivePreviewEngineSession {
+          throw Boom()
+        }
+      }
+      let coordinator = LivePreviewCoordinator(
+        readSamples: { _ in ([], 0) },
+        isPreviewOn: { true },
+        languageMode: { .locked("en") },
+        selectedRoute: previewRoute { _ in
+          .ready(
+            LivePreviewEngineCandidate(
+              key: LivePreviewEngineKey(engine: "whisper_preview#abc123", commitment: ""),
+              makeEngine: { OpenFailsEngine() }))
+        }
+      )
+
+      coordinator.setRecording(true)
+      let event = try await waiter.waitForEvent(named: "live_preview.outcome")
+      #expect(event.stringProps["outcome"] == "open_failed")
+      #expect(event.stringProps["engine"] == "universal")
     }
-    let coordinator = LivePreviewCoordinator(
-      readSamples: { _ in ([], 0) },
-      isPreviewOn: { true },
-      languageMode: { .locked("en") },
-      selectedRoute: previewRoute { _ in
-        .ready(
-          LivePreviewEngineCandidate(
-            key: LivePreviewEngineKey(engine: "whisper_preview#abc123", commitment: ""),
-            makeEngine: { FailingEngine() }))
-      }
-    )
-
-    coordinator.setRecording(true)
-    let event = try await waiter.waitForEvent(named: "live_preview.outcome")
-    #expect(event.stringProps["outcome"] == "prepare_failed")
-    #expect(event.stringProps["engine"] == "universal")
-  }
-
-  /// An engine that prepares but cannot open a session reports `open_failed` —
-  /// a different outcome from failing to prepare, because they send you to
-  /// different places when the graph moves.
-  @Test("a preview that cannot open a session reports open_failed")
-  func openFailureIsReported() async throws {
-    let waiter = TelemetryEventWaiter()
-    TelemetryService.shared.testEventHook = { @Sendable event in
-      MainActor.assumeIsolated { waiter.record(event) }
-    }
-    defer { TelemetryService.shared.testEventHook = nil }
-
-    struct Boom: Error {}
-    final class OpenFailsEngine: LivePreviewEngine, @unchecked Sendable {
-      func prepare() async throws {}
-      func openSession(
-        lookups: WordCorrector.Lookups?, onText: @escaping @Sendable (String) -> Void
-      ) async throws -> any LivePreviewEngineSession {
-        throw Boom()
-      }
-    }
-    let coordinator = LivePreviewCoordinator(
-      readSamples: { _ in ([], 0) },
-      isPreviewOn: { true },
-      languageMode: { .locked("en") },
-      selectedRoute: previewRoute { _ in
-        .ready(
-          LivePreviewEngineCandidate(
-            key: LivePreviewEngineKey(engine: "whisper_preview#abc123", commitment: ""),
-            makeEngine: { OpenFailsEngine() }))
-      }
-    )
-
-    coordinator.setRecording(true)
-    let event = try await waiter.waitForEvent(named: "live_preview.outcome")
-    #expect(event.stringProps["outcome"] == "open_failed")
-    #expect(event.stringProps["engine"] == "universal")
-  }
+  #endif
 
   // MARK: - #2123: one engine decision per recording
 

--- a/Tests/EnviousWisprTests/App/LivePreviewCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewCoordinatorTests.swift
@@ -33,6 +33,252 @@ private func previewRoute(
 @MainActor
 struct LivePreviewCoordinatorTests {
 
+  // MARK: - #2123 F3: the removal barrier, tested at the coordinator
+
+  /// **Tested HERE, not through a stand-in for the delivery home.** The previous
+  /// tests drove a fake callback, so none of them could see a coordinator holder
+  /// left un-awaited — which is exactly where the barrier had holes.
+  ///
+  /// A preview stuck in preparation still holds a fresh engine. Removal must not
+  /// return while that is true, or the files are deleted under a live mapping.
+  @Test("removal does not return while a preparation still holds an engine")
+  func removalAwaitsPreparation() async {
+    final class Gate: @unchecked Sendable {
+      private let mutex = NSLock()
+      private var waiter: CheckedContinuation<Void, Never>?
+      private var isOpen = false
+      private(set) var entered = false
+      func wait() async {
+        mutex.withLock { entered = true }
+        await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
+          let open: Bool = mutex.withLock {
+            if isOpen { return true }
+            waiter = c
+            return false
+          }
+          if open { c.resume() }
+        }
+      }
+      func open() {
+        let w: CheckedContinuation<Void, Never>? = mutex.withLock {
+          isOpen = true
+          let w = waiter
+          waiter = nil
+          return w
+        }
+        w?.resume()
+      }
+      var hasEntered: Bool { mutex.withLock { entered } }
+    }
+    final class Flag: @unchecked Sendable {
+      private let mutex = NSLock()
+      private var value = false
+      var isSet: Bool { mutex.withLock { value } }
+      func set() { mutex.withLock { value = true } }
+    }
+
+    let stuck = Gate()
+    final class StuckEngine: LivePreviewEngine, @unchecked Sendable {
+      let stuck: Gate
+      init(stuck: Gate) { self.stuck = stuck }
+      func prepare() async throws { await stuck.wait() }
+      func openSession(
+        lookups: WordCorrector.Lookups?, onText: @escaping @Sendable (String) -> Void
+      ) async throws -> any LivePreviewEngineSession {
+        struct Idle: LivePreviewEngineSession {
+          func feed(_ samples: [Float]) async {}
+          func end() async {}
+        }
+        return Idle()
+      }
+    }
+
+    let coordinator = LivePreviewCoordinator(
+      readSamples: { _ in ([], 0) },
+      isPreviewOn: { true },
+      languageMode: { .locked("en") },
+      selectedRoute: previewRoute { _ in
+        .ready(
+          LivePreviewEngineCandidate(
+            key: LivePreviewEngineKey(engine: "universal", commitment: ""),
+            makeEngine: { StuckEngine(stuck: stuck) }))
+      }
+    )
+
+    coordinator.setRecording(true)
+    for _ in 0..<2000 where !stuck.hasEntered { await Task.yield() }
+    #expect(stuck.hasEntered, "control: preparation must be in flight")
+
+    let drained = Flag()
+    async let removal: Void = {
+      await coordinator.releaseAndDrainForRemoval()
+      drained.set()
+    }()
+
+    for _ in 0..<200 { await Task.yield() }
+    #expect(
+      !drained.isSet,
+      "removal returned while a preparation still held an engine, so the delete would race it")
+
+    stuck.open()
+    await removal
+    #expect(drained.isSet)
+    #expect(!coordinator.hasPreparedEngineForTests, "and the slot is empty afterwards")
+  }
+
+  /// The FOURTH holder, and the one I missed twice: a session between opening and
+  /// registering its teardown is referenced only by `sessionTask`. Cancelling
+  /// that task without awaiting it leaves an engine alive past the delete.
+  ///
+  /// Mutation control: drop `await session?.value` from the drain and this goes
+  /// green while the holder is still alive — which is how it survived two passes.
+  @Test("removal waits for a session still being opened")
+  func removalAwaitsASessionBeingOpened() async {
+    final class Gate: @unchecked Sendable {
+      private let mutex = NSLock()
+      private var waiter: CheckedContinuation<Void, Never>?
+      private var isOpen = false
+      private var entered = false
+      var hasEntered: Bool { mutex.withLock { entered } }
+      func wait() async {
+        mutex.withLock { entered = true }
+        await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
+          let open: Bool = mutex.withLock {
+            if isOpen { return true }
+            waiter = c
+            return false
+          }
+          if open { c.resume() }
+        }
+      }
+      func open() {
+        let w: CheckedContinuation<Void, Never>? = mutex.withLock {
+          isOpen = true
+          let w = waiter
+          waiter = nil
+          return w
+        }
+        w?.resume()
+      }
+    }
+    final class Flag: @unchecked Sendable {
+      private let mutex = NSLock()
+      private var value = false
+      var isSet: Bool { mutex.withLock { value } }
+      func set() { mutex.withLock { value = true } }
+    }
+
+    let openingGate = Gate()
+    final class SlowOpenEngine: LivePreviewEngine, @unchecked Sendable {
+      let gate: Gate
+      init(gate: Gate) { self.gate = gate }
+      func prepare() async throws {}
+      func openSession(
+        lookups: WordCorrector.Lookups?, onText: @escaping @Sendable (String) -> Void
+      ) async throws -> any LivePreviewEngineSession {
+        // Held INSIDE the open: past preparation, before the coordinator can
+        // register a teardown for it.
+        await gate.wait()
+        struct Idle: LivePreviewEngineSession {
+          func feed(_ samples: [Float]) async {}
+          func end() async {}
+        }
+        return Idle()
+      }
+    }
+
+    let coordinator = LivePreviewCoordinator(
+      readSamples: { _ in ([], 0) },
+      isPreviewOn: { true },
+      languageMode: { .locked("en") },
+      selectedRoute: previewRoute { _ in
+        .ready(
+          LivePreviewEngineCandidate(
+            key: LivePreviewEngineKey(engine: "universal", commitment: ""),
+            makeEngine: { SlowOpenEngine(gate: openingGate) }))
+      }
+    )
+
+    coordinator.setRecording(true)
+    for _ in 0..<2000 where !openingGate.hasEntered { await Task.yield() }
+    #expect(openingGate.hasEntered, "control: the session must be mid-open")
+    #expect(
+      !coordinator.hasLiveSessionForTests,
+      "control: no teardown is registered yet — that is what makes this holder invisible")
+
+    let drained = Flag()
+    async let removal: Void = {
+      await coordinator.releaseAndDrainForRemoval()
+      drained.set()
+    }()
+
+    for _ in 0..<200 { await Task.yield() }
+    #expect(!drained.isSet, "removal returned while a session was still being opened")
+
+    openingGate.open()
+    await removal
+    #expect(drained.isSet)
+  }
+
+  /// Nothing may start a preview while removal is in flight: the admission marker
+  /// still exists until the files are gone, so a recording would resolve as
+  /// installed and load the model straight back onto the files being deleted.
+  @Test("no preview starts while removal is in flight")
+  func removalSuppressesNewPreviews() async {
+    final class Opens: @unchecked Sendable {
+      private let mutex = NSLock()
+      private var value = 0
+      var count: Int { mutex.withLock { value } }
+      func record() { mutex.withLock { value += 1 } }
+    }
+    let opens = Opens()
+    final class CountingEngine: LivePreviewEngine, @unchecked Sendable {
+      let opens: Opens
+      init(opens: Opens) { self.opens = opens }
+      func prepare() async throws {}
+      func openSession(
+        lookups: WordCorrector.Lookups?, onText: @escaping @Sendable (String) -> Void
+      ) async throws -> any LivePreviewEngineSession {
+        opens.record()
+        struct Idle: LivePreviewEngineSession {
+          func feed(_ samples: [Float]) async {}
+          func end() async {}
+        }
+        return Idle()
+      }
+    }
+    let coordinator = LivePreviewCoordinator(
+      readSamples: { _ in ([], 0) },
+      isPreviewOn: { true },
+      languageMode: { .locked("en") },
+      selectedRoute: previewRoute { _ in
+        .ready(
+          LivePreviewEngineCandidate(
+            key: LivePreviewEngineKey(engine: "universal", commitment: ""),
+            makeEngine: { CountingEngine(opens: opens) }))
+      }
+    )
+
+    coordinator.setRecording(true)
+    for _ in 0..<2000 where opens.count < 1 { await Task.yield() }
+    #expect(opens.count == 1, "control: a preview runs before removal")
+    coordinator.setRecording(false)
+
+    await coordinator.releaseAndDrainForRemoval()
+
+    coordinator.setRecording(true)
+    for _ in 0..<300 { await Task.yield() }
+    #expect(opens.count == 1, "a preview started while the files were being removed")
+
+    // And once removal ends, previews work again — otherwise this passes against
+    // a feature that is simply broken from then on.
+    coordinator.setRecording(false)
+    coordinator.endRemovalSuppression()
+    coordinator.setRecording(true)
+    for _ in 0..<2000 where opens.count < 2 { await Task.yield() }
+    #expect(opens.count == 2, "previews must resume once removal has finished")
+  }
+
   // MARK: - #2123: one engine decision per recording
 
   /// The selection itself: which route serves which choice, and what happens when

--- a/Tests/EnviousWisprTests/App/LivePreviewEngineChoiceTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewEngineChoiceTests.swift
@@ -1,0 +1,115 @@
+import EnviousWisprCore
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprServices
+
+/// #2123 chunk A — the persisted engine choice, before anything reads it.
+///
+/// The whole chunk is one value and its fallbacks, so the tests are about the
+/// fallbacks. The one that matters most is the CONTROL: a known `universal` raw
+/// value must load as universal. Without it, every other assertion here passes
+/// against a parser hardcoded to return Apple, which is exactly the shape a
+/// default-to-Apple requirement invites.
+@MainActor
+@Suite struct LivePreviewEngineChoiceTests {
+
+  private func store(_ name: String) throws -> UserDefaults {
+    let suite = "com.enviouswispr.tests.2123.\(name).\(UUID().uuidString)"
+    let defaults = try #require(UserDefaults(suiteName: suite))
+    return defaults
+  }
+
+  @Test("ships as Apple: the download is opt-in, never a default toll")
+  func defaultIsApple() {
+    #expect(SettingsDefaultValues.livePreviewEngine == .apple)
+  }
+
+  @Test("an absent key loads Apple, so an existing user is untouched by upgrade")
+  func absentKeyLoadsApple() throws {
+    let defaults = try store("absent")
+    let settings = SettingsManager(defaults: defaults)
+    #expect(settings.livePreviewEngine == .apple)
+  }
+
+  @Test("a value written by a newer build falls back to Apple instead of disabling the preview")
+  func unknownRawValueFallsBackToApple() throws {
+    let defaults = try store("unknown")
+    defaults.set("some-engine-we-have-not-shipped", forKey: "livePreviewEngine")
+    let settings = SettingsManager(defaults: defaults)
+    #expect(settings.livePreviewEngine == .apple)
+  }
+
+  /// THE CONTROL for both fallback tests above.
+  @Test("a known universal value loads as universal, not as Apple")
+  func knownUniversalValueLoads() throws {
+    let defaults = try store("known")
+    defaults.set("universal", forKey: "livePreviewEngine")
+    let settings = SettingsManager(defaults: defaults)
+    #expect(
+      settings.livePreviewEngine == .universal,
+      "the reader returns Apple for everything — the fallback tests above are vacuous")
+  }
+
+  @Test("both choices round-trip through a relaunch")
+  func bothChoicesPersist() throws {
+    for choice in LivePreviewEngineChoice.allCases {
+      let defaults = try store("roundtrip-\(choice.rawValue)")
+      let writer = SettingsManager(defaults: defaults)
+      writer.livePreviewEngine = choice
+      // A second manager over the same store is what a relaunch looks like.
+      let reader = SettingsManager(defaults: defaults)
+      #expect(reader.livePreviewEngine == choice, "\(choice.rawValue) did not survive a reload")
+    }
+  }
+
+  @Test("changing the engine notifies exactly once, under its own key")
+  func changeNotifiesOnce() throws {
+    let defaults = try store("notify")
+    let settings = SettingsManager(defaults: defaults)
+    final class Seen: @unchecked Sendable {
+      var keys: [SettingsManager.SettingKey] = []
+    }
+    let seen = Seen()
+    settings.onChange = { key in seen.keys.append(key) }
+
+    settings.livePreviewEngine = .universal
+
+    #expect(
+      seen.keys.filter { $0 == .livePreviewEngine }.count == 1,
+      "expected exactly one livePreviewEngine notification, got \(seen.keys)")
+    #expect(
+      !seen.keys.contains(.livePreviewEnabled),
+      "changing the ENGINE must not report the on/off setting as changed")
+  }
+
+  /// Registered ONCE, and registration is what carries it into the dev/release
+  /// defaults migration too — `SettingsDefaultsMigration.unifiedKeys` reads this
+  /// same list rather than keeping its own, so there is no second place to add it.
+  ///
+  /// The dispatch side needs no test: `handleSettingChanged` switches
+  /// exhaustively over `SettingKey`, so the compiler is the enforcer and it
+  /// already refused this chunk once for a missing case.
+  @Test("the engine key is registered for unification exactly once")
+  func keyIsRegisteredExactlyOnce() {
+    #expect(
+      SettingsManager.unifiedDefaultsKeys.filter { $0 == "livePreviewEngine" }.count == 1)
+  }
+
+  @Test("the engine value reaches telemetry as a closed enum, never as content")
+  func telemetryProjectsTheEngine() throws {
+    let defaults = try store("telemetry")
+    let settings = SettingsManager(defaults: defaults)
+
+    #expect(
+      SettingsProjection.value(for: .livePreviewEngine, settings: settings) == "apple")
+    settings.livePreviewEngine = .universal
+    #expect(
+      SettingsProjection.value(for: .livePreviewEngine, settings: settings) == "universal")
+
+    // The change must map to the engine logical, and ONLY that one.
+    #expect(SettingsProjection.logicals(for: .livePreviewEngine) == [.livePreviewEngine])
+  }
+}

--- a/Tests/EnviousWisprTests/App/LivePreviewEngineChoiceTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewEngineChoiceTests.swift
@@ -85,6 +85,41 @@ import Testing
       "changing the ENGINE must not report the on/off setting as changed")
   }
 
+  /// Re-picking the engine you are already on must be inert (#2123 whole-diff
+  /// review).
+  ///
+  /// The picker's card is a Button, so tapping the SELECTED one still assigns,
+  /// and Swift runs `didSet` on a same-value assignment. The notification is not
+  /// harmless here: it reaches `releaseForEngineChange()`, which tears the
+  /// preview down unconditionally, so a re-tap during a recording killed the
+  /// preview for the rest of that recording.
+  ///
+  /// Asserted two-way in ONE test on purpose. A test that only proved silence
+  /// would also pass against a `didSet` that never fires at all, which is the
+  /// same feature broken the other way.
+  @Test("re-picking the current engine is silent; picking a different one is not")
+  func noOpSelectionDoesNotNotify() throws {
+    let defaults = try store("noop-select")
+    let settings = SettingsManager(defaults: defaults)
+    final class Seen: @unchecked Sendable {
+      var keys: [SettingsManager.SettingKey] = []
+    }
+    let seen = Seen()
+    settings.livePreviewEngine = .universal
+    settings.onChange = { key in seen.keys.append(key) }
+
+    settings.livePreviewEngine = .universal
+    #expect(
+      seen.keys.isEmpty,
+      "re-picking the engine already selected must not notify, got \(seen.keys)")
+
+    settings.livePreviewEngine = .apple
+    #expect(
+      seen.keys.filter { $0 == .livePreviewEngine }.count == 1,
+      "a REAL change must still notify exactly once, got \(seen.keys)")
+    #expect(settings.livePreviewEngine == .apple)
+  }
+
   /// Registered ONCE, and registration is what carries it into the dev/release
   /// defaults migration too — `SettingsDefaultsMigration.unifiedKeys` reads this
   /// same list rather than keeping its own, so there is no second place to add it.

--- a/Tests/EnviousWisprTests/App/LivePreviewEnginePresentationTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewEnginePresentationTests.swift
@@ -14,6 +14,33 @@ import Testing
 /// elsewhere — and names the single deliberate exception.
 @Suite struct LivePreviewEnginePresentationTests {
 
+  /// Apple's language packs must not be offered beside the UNIVERSAL engine
+  /// (founder, 2026-08-17 — found by eye during Live UAT).
+  ///
+  /// All FOUR combinations, not just the broken one. The bug was a condition
+  /// missing its second term, and a test that only pinned the broken case would
+  /// pass equally against a helper hard-coded to `false` — which would hide the
+  /// packs from Apple users too, the same feature broken the other way.
+  ///
+  /// The two terms mean different things and that is why both are kept:
+  /// `isAppleSupported` is whether the packs EXIST to manage (there are none
+  /// below macOS 26), `isUsingApple` is whether they are RELEVANT to what the
+  /// user is about to see.
+  @Test(
+    "Apple's language packs appear only when Apple is both supported and selected",
+    arguments: [
+      (supported: true, usingApple: true, shows: true),
+      (supported: true, usingApple: false, shows: false),
+      (supported: false, usingApple: true, shows: false),
+      (supported: false, usingApple: false, shows: false),
+    ])
+  func applePacksNeedBothConditions(c: (supported: Bool, usingApple: Bool, shows: Bool)) {
+    #expect(
+      LivePreviewEnginePresentation.showsApplePacks(
+        isAppleSupported: c.supported, isUsingApple: c.usingApple) == c.shows,
+      "supported=\(c.supported) usingApple=\(c.usingApple) should show packs: \(c.shows)")
+  }
+
   private func universal(
     selected: Bool = false, routeExists: Bool = true, _ state: DeliveryState
   ) -> LivePreviewEnginePresentation.Card {

--- a/Tests/EnviousWisprTests/App/LivePreviewEnginePresentationTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewEnginePresentationTests.swift
@@ -137,6 +137,32 @@ import Testing
     }
   }
 
+  // MARK: - The action a button performs
+
+  /// Download, Resume and Try Again are three WORDS for one operation, and the
+  /// mapping must not drift: the card picks the word from the delivery state,
+  /// and all three have to reach the same call. A future edit that routes
+  /// "Try Again" somewhere else would leave a button that looks right and does
+  /// nothing.
+  @Test("the three download verbs are one operation, and cancel is not")
+  func downloadVerbsCollapseToOneOperation() {
+    let starting: Set<LivePreviewEnginePresentation.Action> = [
+      .download, .resumeDownload, .retryDownload,
+    ]
+    // Each verb is produced by a real state, so none of them is unreachable copy.
+    #expect(universal(.notReady).action == .download)
+    #expect(universal(.cancelled(resumable: true)).action == .resumeDownload)
+    #expect(
+      universal(.failed(DeliveryFailure(reason: .source5xx, detail: "t"))).action == .retryDownload)
+    #expect(starting.count == 3, "control: the three verbs are distinct cases")
+
+    // And the two that are NOT starting a download.
+    #expect(
+      universal(.downloading(fractionCompleted: 0.5, bytesWritten: 1, totalBytes: 2)).action
+        == .cancelDownload)
+    #expect(universal(.admitted).action == .remove)
+  }
+
   /// Every case of the delivery state, listed once.
   ///
   /// Hand-maintained because `DeliveryState` has associated values and cannot be

--- a/Tests/EnviousWisprTests/App/LivePreviewEnginePresentationTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewEnginePresentationTests.swift
@@ -1,0 +1,158 @@
+import EnviousWisprCore
+import EnviousWisprModelDelivery
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #2123 chunk F1 — what each engine card says, in every state.
+///
+/// The plan's acceptance is "no state where the page offers no actionable next
+/// step", scoped to RECOVERABLE states. So the load-bearing test is the
+/// exhaustive walk at the bottom: it enumerates every delivery state and asserts
+/// each one produces either an action or an explanation the user can act on
+/// elsewhere — and names the single deliberate exception.
+@Suite struct LivePreviewEnginePresentationTests {
+
+  private func universal(
+    selected: Bool = false, routeExists: Bool = true, _ state: DeliveryState
+  ) -> LivePreviewEnginePresentation.Card {
+    LivePreviewEnginePresentation.universalCard(
+      isSelected: selected, routeExists: routeExists, state: state)
+  }
+
+  @Test("both engines describe themselves in every state, since there is no Help article yet")
+  func descriptionsAlwaysRender() {
+    let apple = LivePreviewEnginePresentation.appleCard(isSelected: true, isSupported: true)
+    let appleOld = LivePreviewEnginePresentation.appleCard(isSelected: false, isSupported: false)
+    #expect(!apple.description.isEmpty)
+    #expect(appleOld.description == apple.description, "the description cannot depend on support")
+
+    for state in Self.everyState {
+      #expect(!universal(state).description.isEmpty, "no description in \(state)")
+      #expect(
+        !universal(routeExists: false, state).description.isEmpty,
+        "even an unbuildable engine must say what it would have been")
+    }
+  }
+
+  @Test("Apple's card explains the OS requirement rather than going blank")
+  func appleStatesItsRequirement() {
+    let supported = LivePreviewEnginePresentation.appleCard(isSelected: true, isSupported: true)
+    #expect(supported.unavailability == nil)
+    #expect(supported.action == nil, "we never download or remove Apple's engine")
+
+    let unsupported = LivePreviewEnginePresentation.appleCard(isSelected: false, isSupported: false)
+    #expect(unsupported.unavailability == LivePreviewEngineCopy.appleNeedsNewerMacOS)
+  }
+
+  @Test("a download in flight offers cancel and reports its progress")
+  func downloadingShowsProgressAndCancel() {
+    let card = universal(.downloading(fractionCompleted: 0.42, bytesWritten: 1, totalBytes: 2))
+    #expect(card.action == .cancelDownload)
+    #expect(card.progress == 0.42)
+    #expect(card.unavailability == nil, "a running download is not an unavailability")
+  }
+
+  /// **The verb follows `resumable`; the COPY must claim nothing beyond it.**
+  ///
+  /// `resumable` reports whether staged partials exist — not whether the next
+  /// attempt starts from zero, because verified components can survive and be
+  /// skipped. So "Resume" is honest when it is true, and the false case says the
+  /// download stopped without promising a fresh start. An earlier draft here
+  /// promised exactly that, and it sounded careful while being wrong.
+  @Test("a cancelled download offers resume only when there is something to resume")
+  func cancelledDistinguishesResumable() {
+    let resumable = universal(.cancelled(resumable: true))
+    #expect(resumable.action == .resumeDownload)
+    #expect(resumable.unavailability == LivePreviewEngineCopy.downloadCancelled)
+
+    let stopped = universal(.cancelled(resumable: false))
+    #expect(stopped.action == .download, "no staged partials, so the verb is download")
+    #expect(stopped.unavailability == LivePreviewEngineCopy.downloadStopped)
+    #expect(
+      !LivePreviewEngineCopy.downloadStopped.lowercased().contains("beginning"),
+      "this copy must not promise a restart it cannot guarantee")
+  }
+
+  /// A progress value the UI cannot draw must become NO bar, not a wrong one.
+  ///
+  /// Manifest validation permits zero or non-positive sizes, so the delivery
+  /// layer can hand over a NaN or an out-of-range fraction.
+  @Test("unrenderable progress becomes no progress rather than a nonsense bar")
+  func progressIsAlwaysRenderable() {
+    #expect(LivePreviewEnginePresentation.renderableProgress(.nan) == nil)
+    #expect(LivePreviewEnginePresentation.renderableProgress(.infinity) == nil)
+    #expect(LivePreviewEnginePresentation.renderableProgress(-0.5) == 0)
+    #expect(LivePreviewEnginePresentation.renderableProgress(1.7) == 1)
+    #expect(LivePreviewEnginePresentation.renderableProgress(0.25) == 0.25)
+
+    // Through the real card, not just the helper.
+    let nanCard = universal(
+      .downloading(fractionCompleted: .nan, bytesWritten: 0, totalBytes: 0))
+    #expect(nanCard.progress == nil, "a NaN fraction reached the card")
+    #expect(nanCard.action == .cancelDownload, "control: it is still a running download")
+  }
+
+  @Test("an installed engine offers removal, so 217 MB is reclaimable")
+  func admittedOffersRemove() {
+    let card = universal(.admitted)
+    #expect(card.action == .remove)
+    #expect(card.unavailability == nil)
+  }
+
+  @Test("a build without the engine says so and offers nothing to press")
+  func buildDefectOffersNoFalseRemedy() {
+    // Delivery state is irrelevant here: there is nothing registered to download.
+    for state in Self.everyState {
+      let card = universal(routeExists: false, state)
+      #expect(card.unavailability == LivePreviewEngineCopy.unavailableInThisBuild)
+      #expect(card.action == nil, "a build defect must not offer a button that cannot help")
+      #expect(card.progress == nil)
+    }
+  }
+
+  /// THE EXHAUSTIVE WALK. Every delivery state, with a real route, must leave the
+  /// user something to do or something true to read.
+  @Test("every state either offers an action or explains itself")
+  func noDeadEnds() {
+    for state in Self.everyState {
+      let card = universal(state)
+      #expect(
+        card.action != nil || card.unavailability != nil || card.progress != nil,
+        "\(state) renders a card with no action, no explanation and no progress")
+    }
+  }
+
+  /// Both cards must be able to show as selected, or the picker cannot indicate
+  /// which engine is in use.
+  @Test("selection is carried through, for both engines and every state")
+  func selectionIsCarried() {
+    #expect(LivePreviewEnginePresentation.appleCard(isSelected: true, isSupported: true).isSelected)
+    #expect(
+      !LivePreviewEnginePresentation.appleCard(isSelected: false, isSupported: true).isSelected)
+    for state in Self.everyState {
+      #expect(universal(selected: true, state).isSelected, "selection lost in \(state)")
+      #expect(!universal(selected: false, state).isSelected)
+    }
+  }
+
+  /// Every case of the delivery state, listed once.
+  ///
+  /// Hand-maintained because `DeliveryState` has associated values and cannot be
+  /// `CaseIterable`. If a case is added and not listed here these tests keep
+  /// passing — so the real enforcement is the exhaustive `switch` in the
+  /// presentation, which will not compile until the new state is handled. This
+  /// list is what checks the ANSWERS; the compiler is what checks the coverage.
+  static let everyState: [DeliveryState] = [
+    .notReady,
+    .preparing(validatingExistingCache: false),
+    .preparing(validatingExistingCache: true),
+    .downloading(fractionCompleted: 0.1, bytesWritten: 1, totalBytes: 10),
+    .verifying,
+    .admitted,
+    .cancelled(resumable: true),
+    .cancelled(resumable: false),
+    .failed(DeliveryFailure(reason: .source5xx, detail: "test")),
+  ]
+}

--- a/Tests/EnviousWisprTests/App/LivePreviewEnginePresentationTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewEnginePresentationTests.swift
@@ -137,6 +137,27 @@ import Testing
     }
   }
 
+  // MARK: - #2123 F3: removal keeps the picker honest
+
+  /// Removing the model must not strand the user on a selection they cannot use.
+  ///
+  /// The selection is DELIBERATELY kept. Reverting to Apple would be wrong for
+  /// exactly the people this engine exists for: below macOS 26 Apple cannot run,
+  /// so a silent revert would move them from "download this" to "needs a newer
+  /// macOS" as a consequence of reclaiming disk space. The card instead returns
+  /// to offering a download, which is both true and actionable.
+  @Test("after removal the card offers a download again, still selected")
+  func removalReturnsToDownloadWithoutLosingSelection() {
+    let installed = universal(selected: true, .admitted)
+    #expect(installed.action == .remove, "control: an installed model offers removal")
+
+    // What the state becomes once the marker and files are gone.
+    let afterRemoval = universal(selected: true, .notReady)
+    #expect(afterRemoval.action == .download, "removal must leave a way back")
+    #expect(afterRemoval.isSelected, "the user's choice survives reclaiming the disk space")
+    #expect(afterRemoval.unavailability == LivePreviewEngineCopy.notDownloadedYet)
+  }
+
   // MARK: - The action a button performs
 
   /// Download, Resume and Try Again are three WORDS for one operation, and the

--- a/Tests/EnviousWisprTests/App/LivePreviewPacksModelTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewPacksModelTests.swift
@@ -363,13 +363,19 @@ struct LivePreviewPacksModelTests {
     // The load must be reachable on EVERY appearance. Checking for one wrong spelling was too
     // narrow: a mutant guarding on a different condition entirely walked straight through it.
     // The only condition allowed here is the macOS-support gate.
+    //
+    // #2123 renamed it `isAppleSupported`. That is not cosmetic: the page now has
+    // TWO availability questions, and this list is what stops the catalogue load
+    // being re-gated on the wrong one. These are Apple's packs, so it is Apple's
+    // gate — gating on the feature's availability would try to read a pack
+    // catalogue on a Mac that has none.
     let guards =
       body
       .split(separator: "\n")
       .filter { $0.contains("guard ") }
       .map { $0.trimmingCharacters(in: .whitespaces) }
     #expect(
-      guards == ["guard isSupported else { return }"],
+      guards == ["guard isAppleSupported else { return }"],
       """
       the page must re-read on every appearance; any extra condition here means a retained window \
       can keep showing its first snapshot, past finished downloads and past a macOS purge. \

--- a/Tests/EnviousWisprTests/App/ModelDeliveryHomeTests.swift
+++ b/Tests/EnviousWisprTests/App/ModelDeliveryHomeTests.swift
@@ -415,6 +415,85 @@ struct ModelDeliveryHomeTests {
     )
   }
 
+  /// A refused removal must still END the removal, or Live Preview dies for the
+  /// rest of the launch.
+  ///
+  /// `remove()` returns `false` without touching the controller when the family
+  /// kill switch is off (`WhisperKitModelDelivery.swift:124`) — deliberate, and
+  /// owned there: the flag stands down the whole delivery layer, deletions
+  /// included. So the model legitimately stays on disk. What is NOT legitimate
+  /// is what that does to the finish callback.
+  ///
+  /// `previewRemovalDidFinish` means "no longer removing", never "removal
+  /// succeeded" — it clears `isRemovingModel` in the coordinator. Making it
+  /// conditional on success is the obvious-looking reading of a discarded result,
+  /// and it latches removal suppression forever: the model will not delete AND
+  /// the feature will not run. This pins the sequence so that reading cannot land
+  /// silently.
+  ///
+  /// Both directions, because "the steps completed" alone is satisfiable by a
+  /// build that never consults the flag at all: flag-off must record `refused`,
+  /// flag-on must NOT, and both must reach `finish`.
+  ///
+  /// **The real `remove()` runs here, unlike the ordering tests above, which
+  /// substitute it.** That is safe only because `appSupportOverride` roots BOTH
+  /// the preview model's `installDirectory` and its `metadataDirectory`
+  /// (`ModelDeliveryHome.swift:196-210`), so the flag-on half deletes inside a
+  /// temp directory rather than the developer's installed 217 MB model.
+  @Test("a kill-switch-refused preview removal still finishes, both ways")
+  func refusedPreviewRemovalStillFinishes() async throws {
+    func home(enabled: Bool) throws -> ModelDeliveryHome {
+      let suite = try #require(UserDefaults(suiteName: "ew-2137-rmswitch-\(UUID().uuidString)"))
+      suite.set(enabled, forKey: "modelDelivery.whisper_kit.enabled")
+      return ModelDeliveryHome(
+        engineMutationScope: .live(
+          tryBegin: { true }, end: { true }, wake: {}, onRefused: { _ in }),
+        manifestBundle: try Self.manifestBundle(),
+        appSupportOverride: try Self.tempAppSupport(),
+        deliveryFlagDefaults: suite)
+    }
+
+    // **Observes the CALLBACK, never the `finish` step marker**, and that
+    // distinction is the whole test. `removalStepsForTests.append("finish")` is
+    // a separate statement AFTER the callback, so it records that control
+    // reached that line — not that the callback ran. Asserting the step array
+    // passed against the exact mutation this test exists to catch (suppressing
+    // the callback on a refusal), because the marker still landed. A proxy one
+    // statement away from the subject is not an observation of it.
+    @MainActor final class Finishes {
+      private(set) var count = 0
+      func record() { count += 1 }
+    }
+
+    let off = try home(enabled: false)
+    let offFinishes = Finishes()
+    off.previewRemovalDidFinish = { offFinishes.record() }
+    for _ in 0..<400 { await Task.yield() }
+    off.removePreviewModel()
+    for _ in 0..<4000 where offFinishes.count == 0 { await Task.yield() }
+    #expect(
+      offFinishes.count == 1,
+      "a refused removal must still fire the finish callback; latching suppression kills Live Preview for the launch"
+    )
+    #expect(
+      off.removalStepsForTests.contains("refused"),
+      "control: with the flag OFF the removal must actually have been refused")
+
+    let on = try home(enabled: true)
+    let onFinishes = Finishes()
+    on.previewRemovalDidFinish = { onFinishes.record() }
+    for _ in 0..<400 { await Task.yield() }
+    on.removePreviewModel()
+    for _ in 0..<4000 where onFinishes.count == 0 { await Task.yield() }
+    #expect(
+      onFinishes.count == 1,
+      "with the flag ON removal must still finish exactly once")
+    #expect(
+      !on.removalStepsForTests.contains("refused"),
+      "with the flag ON removal must NOT be refused; a build ignoring the flag would pass the OFF half above"
+    )
+  }
+
   // MARK: - #2123 whole-diff review: the launch probe
 
   /// Launching must PROBE delivery state, not merely wire an observer to it.

--- a/Tests/EnviousWisprTests/App/ModelDeliveryHomeTests.swift
+++ b/Tests/EnviousWisprTests/App/ModelDeliveryHomeTests.swift
@@ -27,6 +27,25 @@ struct ModelDeliveryHomeTests {
     return try #require(Bundle(url: resourcesDir))
   }
 
+  /// A throwaway Application Support root, one per call.
+  ///
+  /// Construction runs a no-fetch delivery PROBE (#2123 whole-diff review), and a
+  /// probe that finds a complete cache WRITES an admission marker. Pointed at the
+  /// real Application Support, that makes this suite mutate the developer's own
+  /// machine as a side effect of running — and on a machine where another process
+  /// is measuring those markers, it plants a false row in their data rather than
+  /// merely being untidy. Every construction site here takes its own root.
+  ///
+  /// Not deleted afterwards: these live under the system temp directory, which
+  /// the OS reaps, and a `defer` per site would fire while the async work the
+  /// constructor kicked off is still running.
+  private static func tempAppSupport() throws -> URL {
+    let root = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("ew-2123-mdh-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    return root
+  }
+
   @Test("a gate-refused cancel reports the site and never releases or wakes")
   func aGateRefusedCancelReportsTheSiteAndNeverReleasesOrWakes() async throws {
     final class Box: @unchecked Sendable {
@@ -44,7 +63,8 @@ struct ModelDeliveryHomeTests {
         },
         wake: { box.wakeCalls += 1 },
         onRefused: { box.refusedSites.append($0) }),
-      manifestBundle: try Self.manifestBundle())
+      manifestBundle: try Self.manifestBundle(),
+      appSupportOverride: try Self.tempAppSupport())
 
     home.cancelParakeetDownload()
     // Signal, not clock: wait for the gate's own refusal telemetry, proving
@@ -74,7 +94,8 @@ struct ModelDeliveryHomeTests {
         },
         wake: { box.wakeCalls += 1 },
         onRefused: { box.refusedSites.append($0) }),
-      manifestBundle: try Self.manifestBundle())
+      manifestBundle: try Self.manifestBundle(),
+      appSupportOverride: try Self.tempAppSupport())
 
     home.resumeParakeetDownload()
     // Signal, not clock: wait for the gate's own refusal telemetry, proving
@@ -107,7 +128,8 @@ struct ModelDeliveryHomeTests {
     let home = ModelDeliveryHome(
       engineMutationScope: .live(
         tryBegin: { true }, end: { true }, wake: {}, onRefused: { _ in }),
-      manifestBundle: try Self.manifestBundle())
+      manifestBundle: try Self.manifestBundle(),
+      appSupportOverride: try Self.tempAppSupport())
 
     let transcription = try #require(home.whisperKitRegistration)
     let preview = try #require(home.whisperPreviewRegistration)
@@ -136,7 +158,8 @@ struct ModelDeliveryHomeTests {
     let home = ModelDeliveryHome(
       engineMutationScope: .live(
         tryBegin: { true }, end: { true }, wake: {}, onRefused: { _ in }),
-      manifestBundle: try Self.manifestBundle())
+      manifestBundle: try Self.manifestBundle(),
+      appSupportOverride: try Self.tempAppSupport())
 
     let transcription = try #require(home.whisperKitRegistration).manifest.identity
     let preview = try #require(home.whisperPreviewRegistration).manifest.identity
@@ -157,7 +180,8 @@ struct ModelDeliveryHomeTests {
     let home = ModelDeliveryHome(
       engineMutationScope: .live(
         tryBegin: { true }, end: { true }, wake: {}, onRefused: { _ in }),
-      manifestBundle: try Self.manifestBundle())
+      manifestBundle: try Self.manifestBundle(),
+      appSupportOverride: try Self.tempAppSupport())
 
     let transcription = try #require(home.whisperKitRegistration)
     let preview = try #require(home.whisperPreviewRegistration)
@@ -175,7 +199,8 @@ struct ModelDeliveryHomeTests {
     let home = ModelDeliveryHome(
       engineMutationScope: .live(
         tryBegin: { true }, end: { true }, wake: {}, onRefused: { _ in }),
-      manifestBundle: try Self.manifestBundle())
+      manifestBundle: try Self.manifestBundle(),
+      appSupportOverride: try Self.tempAppSupport())
     #expect(home.whisperPreviewHandle != nil)
   }
 
@@ -201,7 +226,8 @@ struct ModelDeliveryHomeTests {
     let home = ModelDeliveryHome(
       engineMutationScope: .live(
         tryBegin: { true }, end: { true }, wake: {}, onRefused: { _ in }),
-      manifestBundle: try Self.manifestBundle())
+      manifestBundle: try Self.manifestBundle(),
+      appSupportOverride: try Self.tempAppSupport())
 
     final class Gate: @unchecked Sendable {
       private let mutex = NSLock()
@@ -278,7 +304,8 @@ struct ModelDeliveryHomeTests {
     let home = ModelDeliveryHome(
       engineMutationScope: .live(
         tryBegin: { true }, end: { true }, wake: {}, onRefused: { _ in }),
-      manifestBundle: try Self.manifestBundle())
+      manifestBundle: try Self.manifestBundle(),
+      appSupportOverride: try Self.tempAppSupport())
 
     final class Gate: @unchecked Sendable {
       private let mutex = NSLock()
@@ -337,6 +364,48 @@ struct ModelDeliveryHomeTests {
     func record() { mutex.withLock { value += 1 } }
   }
 
+  // MARK: - #2123 whole-diff review: the launch probe
+
+  /// Launching must PROBE delivery state, not merely wire an observer to it.
+  ///
+  /// The bug this pins: a model admitted in a previous app session leaves a fresh
+  /// controller with no in-memory entry, so there is nothing for a new observer
+  /// to be told about, and the card reports "Not downloaded yet" — hiding Remove
+  /// — for a model sitting on disk. `recordFirstRunBaseline` cannot cover it; it
+  /// records whether this is a first run and publishes no state.
+  ///
+  /// **What this does and does not pin, established by mutation rather than by
+  /// argument.** Deleting the `admitIfComplete` probe from `init` fails it, which
+  /// is the regression that matters. Reversing the observer-attach and the probe
+  /// does NOT fail it — `addStateObserver` replays every existing entry's state
+  /// to a newly attached observer, so attach order is genuinely not load-bearing.
+  /// An earlier version of this test claimed to guard that ordering and did not;
+  /// the claim is recorded here so nobody re-derives it from the test's shape.
+  ///
+  /// Rooted at a temp directory rather than the real Application Support, so the
+  /// verdict does not depend on whether this machine has ever used the feature.
+  @Test("construction probes delivery state rather than only observing it")
+  func launchProbePublishesToAnAttachedObserver() async throws {
+    let root = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("ew-2123-launch-probe-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let home = ModelDeliveryHome(
+      engineMutationScope: .live(
+        tryBegin: { true }, end: { true }, wake: {}, onRefused: { _ in }),
+      manifestBundle: try Self.manifestBundle(),
+      appSupportOverride: root)
+
+    #expect(home.whisperPreviewRegistration?.metadataDirectory.path.hasPrefix(root.path) == true)
+
+    for _ in 0..<4000 where home.previewStateUpdatesForTests == 0 { await Task.yield() }
+    #expect(
+      home.previewStateUpdatesForTests > 0,
+      "launch published nothing to the preview mirror, so the no-fetch probe did not run"
+    )
+  }
+
   // MARK: - #2123: the preview model's download state is observable
 
   /// The state starts where a not-yet-downloaded model should start.
@@ -350,13 +419,19 @@ struct ModelDeliveryHomeTests {
     let home = ModelDeliveryHome(
       engineMutationScope: .live(
         tryBegin: { true }, end: { true }, wake: {}, onRefused: { _ in }),
-      manifestBundle: try Self.manifestBundle())
+      manifestBundle: try Self.manifestBundle(),
+      appSupportOverride: try Self.tempAppSupport())
 
-    #expect(home.whisperPreviewState == .notReady)
     #expect(home.parakeetState == .notReady)
+    // Safe to assert absolutely ONLY because this suite is rooted at a throwaway
+    // Application Support (see `tempAppSupport`). Construction now runs a
+    // no-fetch launch probe, so against the real directory this value would
+    // depend on whether the machine running the tests happens to have the preview
+    // model on disk — green in CI, green on a clean machine, red on a developer's
+    // machine that had used the feature. A fixture that varies by machine is not
+    // a fixture; the temp root is what makes this line a constant.
+    #expect(home.whisperPreviewState == .notReady)
 
-    // The mirrors track DIFFERENT artifacts, which is what makes separate apply
-    // guards necessary rather than tidy.
     let preview = try #require(home.whisperPreviewRegistration)
     let transcription = try #require(home.whisperKitRegistration).manifest.identity
     #expect(
@@ -371,14 +446,22 @@ struct ModelDeliveryHomeTests {
     // already on disk and never downloads, and never deletes. `remove` would
     // have published a state too, and would have deleted a real model from the
     // machine running the tests.
+    // Measured against a BASELINE, not against zero. The launch probe may already
+    // have applied an update by now, and `> 0` would then pass without this
+    // explicit trigger proving anything — the assertion would be satisfied by
+    // construction alone and would survive deleting the observer's reaction to
+    // this publish entirely.
+    let baseline = home.previewStateUpdatesForTests
+    let parakeetBaseline = home.parakeetStateUpdatesForTests
+
     _ = await home.controller.admitIfComplete(preview)
 
-    for _ in 0..<2000 where home.previewStateUpdatesForTests == 0 { await Task.yield() }
+    for _ in 0..<2000 where home.previewStateUpdatesForTests == baseline { await Task.yield() }
     #expect(
-      home.previewStateUpdatesForTests > 0,
+      home.previewStateUpdatesForTests > baseline,
       "the preview mirror never applied an update — observer missing or filtered wrongly")
     #expect(
-      home.parakeetStateUpdatesForTests == 0,
+      home.parakeetStateUpdatesForTests == parakeetBaseline,
       "a preview state reached Parakeet's mirror, so the identity filter is wrong")
   }
 }

--- a/Tests/EnviousWisprTests/App/ModelDeliveryHomeTests.swift
+++ b/Tests/EnviousWisprTests/App/ModelDeliveryHomeTests.swift
@@ -179,6 +179,164 @@ struct ModelDeliveryHomeTests {
     #expect(home.whisperPreviewHandle != nil)
   }
 
+  // MARK: - #2123: removal frees the disk, which means releasing first
+
+  /// **The drain must COMPLETE before the delete, not merely be requested.**
+  ///
+  /// Unlinking a file that is still open or mapped succeeds while its blocks stay
+  /// allocated, so the space only returns once every holder has let go. FOUR can
+  /// hold the model — the cached engine, a live session until its asynchronous
+  /// teardown finishes, an in-flight preparation, and the session task itself
+  /// between opening a session and registering its teardown — so a synchronous
+  /// "please release" hook is not enough. The count was three when this comment
+  /// was written and four by the next review pass, which is the argument for
+  /// capturing holders rather than listing them from memory. The first version of this test asserted only
+  /// that a hook had fired by the time `removePreviewModel()` returned, which
+  /// stayed green with the delete moved BEFORE it. Cloud review caught that.
+  ///
+  /// This blocks inside the drain and asserts the removal has not finished while
+  /// it is blocked — the property a request-shaped hook cannot have.
+  @Test("removal waits for every holder to let go before deleting")
+  func removalAwaitsTheDrain() async throws {
+    let home = ModelDeliveryHome(
+      engineMutationScope: .live(
+        tryBegin: { true }, end: { true }, wake: {}, onRefused: { _ in }),
+      manifestBundle: try Self.manifestBundle())
+
+    final class Gate: @unchecked Sendable {
+      private let mutex = NSLock()
+      private var waiter: CheckedContinuation<Void, Never>?
+      private var isOpen = false
+      private var entered = false
+      private var finished = false
+      var drainEntered: Bool { mutex.withLock { entered } }
+      var removalFinished: Bool { mutex.withLock { finished } }
+      func noteFinished() { mutex.withLock { finished = true } }
+      func wait() async {
+        mutex.withLock { entered = true }
+        await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
+          let alreadyOpen: Bool = mutex.withLock {
+            if isOpen { return true }
+            waiter = c
+            return false
+          }
+          if alreadyOpen { c.resume() }
+        }
+      }
+      func open() {
+        let waiting: CheckedContinuation<Void, Never>? = mutex.withLock {
+          isOpen = true
+          let w = waiter
+          waiter = nil
+          return w
+        }
+        waiting?.resume()
+      }
+    }
+    let gate = Gate()
+    home.drainPreviewHoldersBeforeRemoval = { await gate.wait() }
+    home.previewRemovalDidFinish = { gate.noteFinished() }
+    // **Never the real delete.** `manifestBundle` redirects only where manifests
+    // are READ from; the install root and admission metadata are the developer's
+    // own `~/Library/Application Support`, so a real removal here deletes their
+    // installed preview model when the suite runs.
+    home.deletePreviewModelOverrideForTests = {}
+
+    home.removePreviewModel()
+    for _ in 0..<2000 where !gate.drainEntered { await Task.yield() }
+    #expect(gate.drainEntered, "control: removal must actually ask the holders to drain")
+
+    // THE ASSERTION: while the drain is blocked, removal has not completed.
+    for _ in 0..<200 { await Task.yield() }
+    #expect(
+      !gate.removalFinished,
+      "removal completed while a holder was still draining, so the unlink could hit a mapped file")
+
+    gate.open()
+    for _ in 0..<2000 where !gate.removalFinished { await Task.yield() }
+    #expect(gate.removalFinished, "removal must finish once the holders have let go")
+
+    // **THE ORDER ITSELF**, which "finished after the drain" cannot see: the
+    // finish callback trails both steps whichever way round they are, so an
+    // earlier version of this test stayed green with the delete moved first.
+    #expect(
+      home.removalStepsForTests == ["drain", "delete", "finish"],
+      "removal ran in the wrong order: \(home.removalStepsForTests)")
+  }
+
+  /// Two presses must produce ONE removal.
+  ///
+  /// The button stays on screen during the drain, so a second press is ordinary
+  /// rather than exotic. Single-flighting only the coordinator's drain was not
+  /// enough: both presses shared that and then ran two deletes and two finish
+  /// callbacks, and one finish lifts the suppression while the other removal is
+  /// still going — reopening the window suppression exists to close.
+  ///
+  /// Mutation control: drop the `removalTask == nil` guard and the counts double.
+  @Test("pressing Remove twice removes once")
+  func removalIsSingleFlight() async throws {
+    let home = ModelDeliveryHome(
+      engineMutationScope: .live(
+        tryBegin: { true }, end: { true }, wake: {}, onRefused: { _ in }),
+      manifestBundle: try Self.manifestBundle())
+
+    final class Gate: @unchecked Sendable {
+      private let mutex = NSLock()
+      private var waiter: CheckedContinuation<Void, Never>?
+      private var isOpen = false
+      private(set) var entries = 0
+      var entered: Int { mutex.withLock { entries } }
+      func wait() async {
+        mutex.withLock { entries += 1 }
+        await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
+          let open: Bool = mutex.withLock {
+            if isOpen { return true }
+            waiter = c
+            return false
+          }
+          if open { c.resume() }
+        }
+      }
+      func open() {
+        let w: CheckedContinuation<Void, Never>? = mutex.withLock {
+          isOpen = true
+          let w = waiter
+          waiter = nil
+          return w
+        }
+        w?.resume()
+      }
+    }
+    let gate = Gate()
+    home.drainPreviewHoldersBeforeRemoval = { await gate.wait() }
+    // Counted, not performed: see the note above about Application Support.
+    let deletes = Deletes()
+    home.deletePreviewModelOverrideForTests = { deletes.record() }
+
+    home.removePreviewModel()
+    for _ in 0..<2000 where gate.entered < 1 { await Task.yield() }
+    #expect(gate.entered == 1, "control: the first removal is under way")
+
+    // The user presses it again while the first is draining.
+    home.removePreviewModel()
+    for _ in 0..<200 { await Task.yield() }
+    #expect(gate.entered == 1, "a second press started a competing removal")
+
+    gate.open()
+    for _ in 0..<2000 where !home.removalStepsForTests.contains("finish") { await Task.yield() }
+    #expect(
+      home.removalStepsForTests == ["drain", "delete", "finish"],
+      "exactly one of each step, got \(home.removalStepsForTests)")
+    #expect(deletes.count == 1, "two presses performed \(deletes.count) deletes")
+  }
+
+  private final class Deletes: @unchecked Sendable {
+    private let mutex = NSLock()
+    private var value = 0
+    var count: Int { mutex.withLock { value } }
+    func record() { mutex.withLock { value += 1 } }
+  }
+
   // MARK: - #2123: the preview model's download state is observable
 
   /// The state starts where a not-yet-downloaded model should start.

--- a/Tests/EnviousWisprTests/App/ModelDeliveryHomeTests.swift
+++ b/Tests/EnviousWisprTests/App/ModelDeliveryHomeTests.swift
@@ -178,4 +178,49 @@ struct ModelDeliveryHomeTests {
       manifestBundle: try Self.manifestBundle())
     #expect(home.whisperPreviewHandle != nil)
   }
+
+  // MARK: - #2123: the preview model's download state is observable
+
+  /// The state starts where a not-yet-downloaded model should start.
+  ///
+  /// Deliberately a separate mirror from Parakeet's rather than a shared one:
+  /// they are different models with different lifecycles, and a settings page
+  /// rendering one from the other's state would show a download that is not
+  /// happening.
+  @Test("the preview model has its own delivery state, separate from Parakeet's")
+  func previewStateIsItsOwnMirror() async throws {
+    let home = ModelDeliveryHome(
+      engineMutationScope: .live(
+        tryBegin: { true }, end: { true }, wake: {}, onRefused: { _ in }),
+      manifestBundle: try Self.manifestBundle())
+
+    #expect(home.whisperPreviewState == .notReady)
+    #expect(home.parakeetState == .notReady)
+
+    // The mirrors track DIFFERENT artifacts, which is what makes separate apply
+    // guards necessary rather than tidy.
+    let preview = try #require(home.whisperPreviewRegistration)
+    let transcription = try #require(home.whisperKitRegistration).manifest.identity
+    #expect(
+      preview.manifest.identity.cacheKey != transcription.cacheKey,
+      "two mirrors over one identity would make each model report the other's progress")
+
+    // **The observer must actually OBSERVE.** Checking the initial value cannot
+    // tell a wired mirror from a deleted one — both read `.notReady`. So publish
+    // a real state for the preview identity and watch which mirror moves.
+    //
+    // `admitIfComplete` with no fetch is the safe trigger: it validates what is
+    // already on disk and never downloads, and never deletes. `remove` would
+    // have published a state too, and would have deleted a real model from the
+    // machine running the tests.
+    _ = await home.controller.admitIfComplete(preview)
+
+    for _ in 0..<2000 where home.previewStateUpdatesForTests == 0 { await Task.yield() }
+    #expect(
+      home.previewStateUpdatesForTests > 0,
+      "the preview mirror never applied an update — observer missing or filtered wrongly")
+    #expect(
+      home.parakeetStateUpdatesForTests == 0,
+      "a preview state reached Parakeet's mirror, so the identity filter is wrong")
+  }
 }

--- a/Tests/EnviousWisprTests/App/ModelDeliveryHomeTests.swift
+++ b/Tests/EnviousWisprTests/App/ModelDeliveryHomeTests.swift
@@ -364,6 +364,57 @@ struct ModelDeliveryHomeTests {
     func record() { mutex.withLock { value += 1 } }
   }
 
+  // MARK: - #2137 cloud review: the delivery kill switch
+
+  /// The Download door must honour `modelDelivery.whisper_kit.enabled`.
+  ///
+  /// `ensureAvailable()` does NOT enforce the flag itself — the primary WhisperKit
+  /// door guards `handle.isEnabled()` immediately before calling it
+  /// (`WhisperKitDeliveryWiring.swift:74,125`). This door did not, so an operator
+  /// who had disabled the whole family could still have a 217 MB preview fetch
+  /// start, bypassing the relaunch-free rollback the flag exists to provide.
+  ///
+  /// Asserted BOTH ways in one test, because either half alone is satisfiable by
+  /// the opposite bug: flag-off must publish nothing, and flag-on must still
+  /// reach the controller. A one-way test would pass against a door welded shut,
+  /// which breaks the feature for every user to protect against a flag almost
+  /// nobody sets.
+  ///
+  /// The flag store is injected. Writing a real kill switch into the shared suite
+  /// to test it would leave an operational flag set on a developer's machine.
+  @Test("the preview Download door honours the whisper_kit kill switch, both ways")
+  func previewDownloadHonoursTheKillSwitch() async throws {
+    func home(enabled: Bool) throws -> ModelDeliveryHome {
+      let suite = try #require(UserDefaults(suiteName: "ew-2137-killswitch-\(UUID().uuidString)"))
+      suite.set(enabled, forKey: "modelDelivery.whisper_kit.enabled")
+      return ModelDeliveryHome(
+        engineMutationScope: .live(
+          tryBegin: { true }, end: { true }, wake: {}, onRefused: { _ in }),
+        manifestBundle: try Self.manifestBundle(),
+        appSupportOverride: try Self.tempAppSupport(),
+        deliveryFlagDefaults: suite)
+    }
+
+    let off = try home(enabled: false)
+    for _ in 0..<400 { await Task.yield() }
+    let offBaseline = off.previewStateUpdatesForTests
+    off.startPreviewDownload()
+    for _ in 0..<2000 { await Task.yield() }
+    #expect(
+      off.previewStateUpdatesForTests == offBaseline,
+      "the kill switch is off but the download door still reached delivery")
+
+    let on = try home(enabled: true)
+    for _ in 0..<400 { await Task.yield() }
+    let onBaseline = on.previewStateUpdatesForTests
+    on.startPreviewDownload()
+    for _ in 0..<4000 where on.previewStateUpdatesForTests == onBaseline { await Task.yield() }
+    #expect(
+      on.previewStateUpdatesForTests > onBaseline,
+      "with the flag ON the door must still reach delivery; a welded-shut door would pass the assertion above"
+    )
+  }
+
   // MARK: - #2123 whole-diff review: the launch probe
 
   /// Launching must PROBE delivery state, not merely wire an observer to it.

--- a/scripts/build-release-dmg.sh
+++ b/scripts/build-release-dmg.sh
@@ -297,6 +297,21 @@ else
     echo "::error::Output-safety classifier model missing from app bundle: neither OutputClassifier.mlmodelc nor OutputClassifier.mlpackage in Contents/Resources (#1226)"; exit 1
 fi
 
+# #2123: the universal preview engine's two bundled resources, same gate shape
+# and same reasoning as the VAD model above. Packaged ONLY by Project.swift —
+# Package.swift ships the manifest never (the app target excludes Resources) and
+# the tokenizer never (its ASR target declares no resources at all) — so a
+# dropped entry there still compiles, still passes every test, and produces an
+# app where choosing the Universal engine reports "unavailable in this build"
+# with nothing the user can do. Pre-sign, so a missing asset fails before any
+# signature is applied.
+#
+# Delegated to a script rather than inlined because it is also the only way to
+# check this at all: a unit test's `Bundle.main` is the test runner, so a test
+# here would inspect committed source files and pass while the shipped app was
+# broken.
+"$PROJ_ROOT/scripts/check-preview-engine-resources.sh" "$BUNDLE"
+
 if [[ -z "${CODESIGN_IDENTITY:-}" ]]; then
     echo "==> CODESIGN_IDENTITY not set — skipping signing (unsigned assembly only)"
 else

--- a/scripts/check-preview-engine-resources.sh
+++ b/scripts/check-preview-engine-resources.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# #2123: prove a BUILT app carries what the universal preview engine needs.
+#
+# WHY THIS IS NOT A UNIT TEST. A test process's `Bundle.main` is the test runner,
+# not the app, so it cannot see app-target resources at all — and the route
+# builder hardcodes `Bundle.main`. A unit test here would inspect committed
+# SOURCE files and pass while the shipped app was missing them, which is worse
+# than no check: it would read as coverage.
+#
+# WHAT BREAKS WITHOUT IT. Packaging happens in ONE place — Tuist's
+# `Project.swift`: a `.folderReference` for the tokenizer and a resource path for
+# the manifest. `Package.swift` ships neither, for two DIFFERENT reasons worth
+# keeping straight: the manifest lives under the `EnviousWispr` target, which
+# carries `exclude: ["Resources"]`; the tokenizer lives under `EnviousWisprASR`,
+# which excludes nothing but declares no `resources:` at all, so SwiftPM simply
+# never processes it.
+#
+# That single packaging point is the RISK, not a reassurance. A dropped entry
+# still compiles, still passes every test, and produces an app whose preview
+# engine can never run: the user picks Universal and gets "unavailable in this
+# build" with no way to fix it.
+#
+# Usage: check-preview-engine-resources.sh [/path/to/Some.app]
+# Defaults to the local dev build.
+set -euo pipefail
+
+APP="${1:-$(cd "$(dirname "$0")/.." && pwd)/build/EnviousWispr Local.app}"
+RESOURCES="$APP/Contents/Resources"
+
+fail() { echo "::error::$*"; exit 1; }
+
+# POSITIVE CONTROL, first and deliberately.
+#
+# Every check below reports "missing". So does pointing at a path that is not an
+# app bundle at all — a stale build directory, a renamed product, a typo in a CI
+# variable. Without this, "the preview resources are missing" and "I was not
+# looking at an app" produce the same red, and the second sends someone editing
+# a manifest that was never wrong.
+[ -d "$APP" ] || fail "not a directory: $APP — this is a PATH problem, not a resource problem"
+[ -f "$APP/Contents/Info.plist" ] \
+  || fail "no Info.plist under $APP — that path is not an app bundle, so nothing below is meaningful"
+
+# 1. The delivery manifest. Without it there is no registration, so the engine
+#    reports unavailable-in-this-build no matter what is on disk.
+MANIFEST="$RESOURCES/whisperkit-preview-delivery-manifest.json"
+[ -f "$MANIFEST" ] || fail "preview delivery manifest missing from the bundle: $MANIFEST"
+
+# 2. The bundled tokenizer. `WhisperPreviewDeliveryWiring.makeRoute` refuses
+#    without it — deliberately, because WhisperKit's tokenizer search runs
+#    independently of `download: false`, so a nil folder can reach the NETWORK,
+#    and the app's other bundled tokenizer is large-v3 and would silently load
+#    the wrong vocabulary into the small model. Both measured on #2108.
+TOKENIZER="$RESOURCES/WhisperPreviewTokenizer/models/openai/whisper-small/tokenizer.json"
+[ -f "$TOKENIZER" ] || fail "preview tokenizer missing from the bundle: $TOKENIZER"
+
+# 3. The manifest must be readable JSON naming the variant this engine expects.
+#    A truncated or wrong-variant file is present-but-useless, and "the file
+#    exists" is exactly the check that cannot tell the difference.
+VARIANT=$(python3 -c "
+import json, sys
+with open('$MANIFEST') as f:
+    print(json.load(f)['identity']['variant'])
+" 2>/dev/null) || fail "preview manifest is not readable JSON with an identity.variant: $MANIFEST"
+
+[ "$VARIANT" = "openai_whisper-small_216MB" ] \
+  || fail "preview manifest names variant '$VARIANT', expected openai_whisper-small_216MB"
+
+echo "OK: preview engine resources present in $(basename "$APP") (variant $VARIANT)"

--- a/scripts/check-preview-engine-resources.sh
+++ b/scripts/check-preview-engine-resources.sh
@@ -21,8 +21,79 @@
 # build" with no way to fix it.
 #
 # Usage: check-preview-engine-resources.sh [/path/to/Some.app]
+#        check-preview-engine-resources.sh --self-test
 # Defaults to the local dev build.
 set -euo pipefail
+
+EXPECTED_VARIANT="openai_whisper-small_216MB"
+
+# --self-test: prove this gate FIRES as well as passes.
+#
+# A resource check that only ever runs against a good bundle is indistinguishable
+# from one that returns 0 unconditionally — the failure this exists to catch is
+# rare by design, so it would sit green for months either way. Each case below
+# builds a fixture that is wrong in exactly ONE way and asserts this script
+# rejects it, plus a fully-correct fixture it must ACCEPT. Without that last
+# case a script hard-coded to `exit 1` would pass every other assertion.
+if [ "${1:-}" = "--self-test" ]; then
+  SELF="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
+  TMP="$(mktemp -d)"
+  trap 'rm -rf "$TMP"' EXIT
+  pass=0
+  fail_count=0
+
+  expect() {  # expect <case> <want-exit 0|1> <app-path>
+    local name="$1" want="$2" path="$3" got=0
+    "$SELF" "$path" >"$TMP/out.txt" 2>&1 || got=$?
+    if [ "$got" -eq 0 ] && [ "$want" -eq 0 ]; then
+      echo "  PASS  $name (accepted)"; pass=$((pass + 1))
+    elif [ "$got" -ne 0 ] && [ "$want" -ne 0 ]; then
+      echo "  PASS  $name (rejected: $(head -1 "$TMP/out.txt" | cut -c1-70))"; pass=$((pass + 1))
+    else
+      echo "  FAIL  $name (wanted exit $want, got $got)"; fail_count=$((fail_count + 1))
+    fi
+  }
+
+  mkbundle() {  # mkbundle <dir> <variant-or-empty> <with-tokenizer 0|1>
+    local d="$1" variant="$2" tok="$3"
+    mkdir -p "$d/Contents/Resources"
+    printf '<plist/>\n' >"$d/Contents/Info.plist"
+    if [ -n "$variant" ]; then
+      printf '{"identity":{"variant":"%s"}}\n' "$variant" \
+        >"$d/Contents/Resources/whisperkit-preview-delivery-manifest.json"
+    fi
+    if [ "$tok" -eq 1 ]; then
+      mkdir -p "$d/Contents/Resources/WhisperPreviewTokenizer/models/openai/whisper-small"
+      printf '{}\n' \
+        >"$d/Contents/Resources/WhisperPreviewTokenizer/models/openai/whisper-small/tokenizer.json"
+    fi
+  }
+
+  echo "check-preview-engine-resources.sh --self-test"
+  expect "path that does not exist"        1 "$TMP/nope.app"
+  mkdir -p "$TMP/notabundle.app"
+  expect "directory with no Info.plist"    1 "$TMP/notabundle.app"
+  mkbundle "$TMP/nomanifest.app" "" 1
+  expect "bundle missing the manifest"     1 "$TMP/nomanifest.app"
+  mkbundle "$TMP/notokenizer.app" "$EXPECTED_VARIANT" 0
+  expect "bundle missing the tokenizer"    1 "$TMP/notokenizer.app"
+  mkbundle "$TMP/wrongvariant.app" "some_other_model" 1
+  expect "manifest naming another variant" 1 "$TMP/wrongvariant.app"
+  mkdir -p "$TMP/badjson.app/Contents/Resources"
+  printf '<plist/>\n' >"$TMP/badjson.app/Contents/Info.plist"
+  printf 'not json at all' \
+    >"$TMP/badjson.app/Contents/Resources/whisperkit-preview-delivery-manifest.json"
+  mkdir -p "$TMP/badjson.app/Contents/Resources/WhisperPreviewTokenizer/models/openai/whisper-small"
+  printf '{}\n' \
+    >"$TMP/badjson.app/Contents/Resources/WhisperPreviewTokenizer/models/openai/whisper-small/tokenizer.json"
+  expect "manifest that is not valid JSON" 1 "$TMP/badjson.app"
+  mkbundle "$TMP/good.app" "$EXPECTED_VARIANT" 1
+  expect "a fully correct bundle"          0 "$TMP/good.app"
+
+  echo "$pass passed, $fail_count failed"
+  [ "$fail_count" -eq 0 ] || exit 1
+  exit 0
+fi
 
 APP="${1:-$(cd "$(dirname "$0")/.." && pwd)/build/EnviousWispr Local.app}"
 RESOURCES="$APP/Contents/Resources"
@@ -62,7 +133,7 @@ with open('$MANIFEST') as f:
     print(json.load(f)['identity']['variant'])
 " 2>/dev/null) || fail "preview manifest is not readable JSON with an identity.variant: $MANIFEST"
 
-[ "$VARIANT" = "openai_whisper-small_216MB" ] \
-  || fail "preview manifest names variant '$VARIANT', expected openai_whisper-small_216MB"
+[ "$VARIANT" = "$EXPECTED_VARIANT" ] \
+  || fail "preview manifest names variant '$VARIANT', expected $EXPECTED_VARIANT"
 
 echo "OK: preview engine resources present in $(basename "$APP") (variant $VARIANT)"


### PR DESCRIPTION
Closes #2123. Part of epic #2077.

**Lane:** Code (primary), `mixed_pr: true` — the diff also touches root `scripts/*.sh` and `.gitignore`, which are Docs/dev-tooling · **Tier:** MEDIUM · Plan: `docs/feature-requests/issue-2123-2026-08-16-two-engine-picker.md`

## What a user gets

Live Preview moves to its own page under **Record** and offers two engines instead of one.

- **Apple** — built into macOS, nothing to download, but needs macOS 26 and only recognises languages the Mac already has.
- **Universal** — a 217 MB model, downloaded on request from a pinned vendor revision, works on macOS 14+ and in far more languages. Removable from the same card to reclaim the disk.

Apple stays the default. **Selecting an engine never starts a download** — downloading is a separate, explicit button, which is the thing most likely to worry someone about tapping a card.

Below macOS 26 the Apple card is shown-as-unavailable rather than hidden, so the option is visible with its reason instead of silently missing.

## Built in 11 reviewed chunks, then two review findings fixed

Every chunk was self-reviewed, tested and taken to `CHUNK-CLEAN` before the next. The independent whole-diff review then found **two user-visible defects**, both fixed here and both mutation-controlled — the guard was removed and the test confirmed to fail before it was called done.

1. **The card lied after every relaunch.** A model admitted in a previous app session left a fresh delivery controller with no in-memory entry, so nothing replayed: the card said "Not downloaded yet" and hid Remove for a model sitting on disk. Fixed with a no-fetch launch probe (`admitIfComplete`, which cannot start a download).
2. **Re-picking the engine you were already on stopped an active preview.** The card is a `Button`, so tapping the selected one still assigns, and Swift runs `didSet` on a same-value assignment — reaching an unconditional teardown. Fixed with an `oldValue` guard, the only such guard among this type's 47 `didSet`s because it is the only one whose handler is destructive rather than idempotent.

Rather than run a third review round, the class behind both was enumerated: **the feature was written for a real change happening while the process runs, and for neither boundary of that** — a change of zero delta, and a change that happened before this process existed. Twelve members across three axes; four more settled by evidence, including one — the speech model, which shares the shape and has a visible row — closed by finding its row renders identically in both states, so there is no symptom and no follow-up issue.

## Founder testing found two more

3. **The Apple language-pack section showed while Universal was selected.** Its own comment said those packs were "still Apple's question — the universal engine carries its own languages and has no packs", while the condition checked only the macOS version. The reasoning was written down and never implemented. Now gated on the selected engine too. The catalogue *load* is deliberately left ungated: its `.task` is keyed on the dictation language, so gating without rekeying would show a stale list after switching back.
4. Design consistency with the Transcription page — filed as **#2136**, not folded in. It needs the shared card component extracted and new spec-row copy whose language count is a public claim requiring its own grounding.

## Cloud review found a fifth, and my enumeration had missed it

**A recording that begins during model removal now freezes as disabled.** The mid-removal guard returned WITHOUT storing a `recordingSnapshot`, making it the one suppressed path whose decision was not sticky. The overlay forwards duplicate `.recording` pushes, so if removal finished during that take, `endRemovalSuppression()` cleared the guard and the next duplicate push sailed past both checks — snapshot still nil, `isRemovingModel` now false — and started a preview partway through a recording that began suppressed.

The same line closes a second hole neither the reviewer nor I named: `isEnabledForGeometry` falls back to a LIVE read when no snapshot exists, so a removal-suppressed take could size the overlay pill for preview text that would never arrive. It now answers false.

Mutation-controlled: deleting the snapshot line fails with "removal ending mid-recording started a preview in a take that began suppressed", EXIT=65.

**Worth stating rather than absorbing quietly: this is a member my own class enumeration missed.** It shares the root — the feature written for a change while the process runs, not for its boundaries — but I enumerated along ENGINE CHOICE and this member lives on REMOVAL TIMING. The axis list was narrower than the class, which is the failure mode the enumeration rule warns is invisible from inside the enumeration.

## A claim of mine that was wrong

While fixing (1) I ordered the observer attach before the probe and wrote a comment justifying it as a race. It is not one — `addStateObserver` replays each existing entry's state to a newly attached observer. Proven by mutation: reversing the two lines leaves the suite green. The comment now says what is true, including that the earlier claim was wrong, and the test states what it actually pins rather than what I hoped.

## Verification

- **Debug 5728 / Release 5289**, both green, gap 439. The gap is the structural `#if DEBUG` difference, not a regression, and is never compared across configurations — each count is compared to its own prior run. Both rose by exactly one with the pack-gating test, and all four of its cases were confirmed to RUN rather than inferred from the total.
- **Real-hardware Live UAT**, run on the built app with the pid verified to resolve into this worktree: picker renders, selection does not fetch, Apple-claims gate both directions, choice persists in the shared store, 217 MB download admits, Remove reclaims the disk, and **install → quit → relaunch → still shows Remove**, which is finding (1) verified end to end.
- **Founder-driven**, covering paths automation could not reach because the download completes in seconds: Cancel leaves a 142 MB resumable partial, Resume continues from it rather than restarting, and the **Universal engine genuinely previews words** (59 characters across two sessions).
- **Engine picker on the signed build**: Apple's two language sections hidden on Universal and shown on Apple, asserted in BOTH directions — the Apple case is what proves the absence checks can fail rather than passing against a section that never renders.
- Packaging probe wired pre-sign, so a dropped resource fails the build rather than shipping an engine that can never run. It now has a `--self-test` (7 cases: six rejections plus one ACCEPT, because six rejections alone would pass against a script hard-coded to fail).
- Phase 3 run dir `.validation/runs/2026-08-17T17-51-08Z-f29b0ecf`. Obligations satisfied: tests, smoke, codex-review, shellcheck, self-test.

### One obligation NOT satisfied, and it is not a defect

**The synthetic-dictation leg did not run.** Three takes all transcribed the founder's live Zoom call instead of the fixture sentence — the test plays TTS through the speakers into the microphone, and a person talking in the room wins. Pipeline timing was healthy on every take (0.586s / 0.816s / 1.076s, ASR 0.11-0.16s), so the product side is working; this is an environment limit.

Ruled out by measurement rather than assumption: output not muted, not on Bluetooth, no media playing, and a **silent-audio control** (record 6s, play nothing) came back with words in it — which is what separates "my TTS was too quiet" from "the room is not empty". Volume was also raised from 38 to 65 to match a sibling session's successful leg and the take still failed, which is what ruled volume out as the sole cause.

Per `uat-testing.md` FACT: uat-gotchas the correct action is to DISCARD such a run rather than record a failure, and not to re-pick an expected token from what was heard. `skip-note.txt` carries the reason and the one command that closes it.

## Found along the way, filed separately

- **#2134** — no Help Centre article for on-screen Live Preview, and search routes it to the unrelated Live transcription article.
- **#2135** — model delivery writes only 3 of its 8 modelled events to the local log; start, resume, cancel, failover and repair are telemetry-only, so a cancel and a hang are indistinguishable in the artifact a user can send us.
- **#2136** — the card design consistency above.

## Known limits, stated rather than left to be discovered

- An interrupted download offers **Download** where it should say **Resume**. It does resume from the partial; only the verb is wrong. Written into #2134 so it reaches users as documentation.
- Behaviour **below macOS 26**: the CRASH-SAFETY half is covered and I had written it off twice. CI's `Older macOS Launch` workflow carries this branch's release build to a **macos-14** runner and asserts it launches and survives — green on this PR. I recorded this as "needs older hardware", corrected it to "needs a VM", and both were wrong: the repo has been doing it on every PR. What remains unobserved is only what the picker RENDERS below 26 (the Apple card shown-as-unavailable, the toggle still reachable via the universal engine), which is covered by unit tests over `isAppleSupported` but not by a screenshot.


## Cloud review rounds on this PR

Two rounds, both adopted, both on the same shape: a delivery door that did not consult the family kill switch.

- **Round 1 — the download door.** `ensureAvailable()` does not enforce `modelDelivery.whisper_kit.enabled`; the caller does, and the two existing WhisperKit doors guard it while this new one did not. Guarded now, and the refusal is logged rather than silent — the flag is set remotely, so a Download that does nothing is otherwise indistinguishable from a broken button.
- **Round 2 — the removal path.** My round-1 comment asserted "Cancel and Remove stay reachable with the flag off", having verified neither half. Cancel is ungated; `remove()` IS gated and returns `false` without touching the controller, which its own doc owns as intended (the flag stands down the whole delivery layer, deletions included). The refusal was invisible because the result was discarded. Logged now. `remove()`'s behaviour is deliberately unchanged — editing a shared primitive the transcription model also uses, from a Live Preview PR, is the drive-by this PR declined for the Parakeet sibling (#2139).
- **Round 3 — clean, no major issues.**

**The finish callback fires even on a refusal, deliberately.** It means "no longer removing", never "removal succeeded" — it clears the coordinator's removal suppression. Gating it on success latches that suppression for the rest of the launch: a model that will not delete *and* a preview that will not run. Stated at the call site so it is not "corrected" later.

**A test that looked green and measured nothing.** The first version of the removal test asserted the recorded step array, but its `finish` marker is appended on the line *after* the callback — it records that control reached the line, not that the callback ran. The mutation it exists to catch left the array identical and the test passed. Rewritten to observe the callback: the mutation now fails with `(offFinishes.count → 0) == 1`, EXIT=65, one issue, only that test. A proxy one statement from its subject passes exactly when the real behaviour breaks.

## Known limit added by round 2

With the delivery kill switch off, Remove leaves the model in place and the user sees no explanation — only the log records why. Surfacing it needs new user-facing copy and a new card state, which is a product decision rather than a review fix.
