### PR TITLE
fix(test): wait on a signal for the draining window, never poll it

### DIFF
--- a/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
+++ b/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
@@ -286,6 +286,11 @@ public actor ModelDeliveryController {
     entry.drainingTask = task
     entry.activeTask = nil
     entries[identity] = entry
+    // The move to draining has LANDED here, so this is the only honest place to
+    // announce it. Fired before `task.cancel()` because a test that wants to
+    // observe the live draining window must be released while the window is
+    // open, not after the drain has been asked to end (#2119 test support).
+    afterMovedToDrainingForTesting?()
     task.cancel()
     // Drain barrier: the attempt task finishes only after its URLSession
     // delegate delivered terminal completion and file handles closed —
@@ -917,6 +922,27 @@ public actor ModelDeliveryController {
   /// cannot be assigned from outside its isolation.
   func setBeforeExistingCacheValidationForTesting(_ hook: (@Sendable () async -> Void)?) {
     beforeExistingCacheValidationForTesting = hook
+  }
+
+  /// Fired the instant `cancel` moves an attempt from `activeTask` to
+  /// `drainingTask` (#2119 test support). Never set in production.
+  ///
+  /// Exists because the alternative is POLLING, and polling this particular
+  /// transition starves it: every probe is a hop onto this actor, so a tight
+  /// `Task.yield()` loop keeps the controller answering "are you draining yet"
+  /// instead of draining. That test passed locally and timed out on post-merge
+  /// main, where the runner has fewer cores — a signal removes the race rather
+  /// than betting against it (test-timing.md: wait on a signal, use a deadline
+  /// only as the fallback AROUND it).
+  ///
+  /// Synchronous and non-async on purpose: it runs inside the actor-isolated
+  /// window between the move landing and `task.cancel()`, so it must not
+  /// suspend and let that window close before the waiter is released.
+  var afterMovedToDrainingForTesting: (@Sendable () -> Void)?
+
+  /// Cross-actor setter; see `setBeforeExistingCacheValidationForTesting`.
+  func setAfterMovedToDrainingForTesting(_ hook: (@Sendable () -> Void)?) {
+    afterMovedToDrainingForTesting = hook
   }
 
   private func admission(for registration: DeliveryRegistration) -> CacheAdmission {

--- a/Tests/EnviousWisprTests/ModelDelivery/SupersededStagingSweepTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/SupersededStagingSweepTests.swift
@@ -435,17 +435,38 @@ import Testing
     // draining branch never exercised — the test would pass while covering the
     // wrong field. Park until the controller reports no active task for the
     // identity, which is only true once the move has landed.
+    // WAIT ON THE SIGNAL, NOT ON A POLL.
+    //
+    // This used to spin on `isDrainingForTesting` with `Task.yield()`, which
+    // STARVES the transition it waits for: every probe is a hop onto the
+    // controller actor, so the loop keeps the controller answering "are you
+    // draining yet" instead of draining. It passed locally and timed out on
+    // post-merge main (fewer cores, more contention) — `movedToDraining` came
+    // back nil and the test correctly reported the draining branch as untested.
+    // The controller now announces the move at the instant it lands.
+    let moved = AsyncStream<Void>.makeStream()
+    await controller.setAfterMovedToDrainingForTesting {
+      moved.continuation.yield()
+      moved.continuation.finish()
+    }
     async let cancelled = controller.cancel(draining.manifest.identity)
     let movedToDraining = await withDeadline(seconds: 5) {
-      while true {
-        if Task.isCancelled { return false }
-        if await controller.isDrainingForTesting(draining.manifest.identity) { return true }
-        await Task.yield()
-      }
+      var iterator = moved.stream.makeAsyncIterator()
+      return await iterator.next() != nil
     }
     try #require(
       movedToDraining == true,
       "never observed the LIVE draining window, so the draining branch is untested")
+
+    // THE SIGNAL AND THE STATE ARE TWO CONDITIONS. The signal proves the move
+    // HAPPENED; it does not prove the window is still OPEN when the sweep runs.
+    // They coincide here only because the attempt is parked on `release` and so
+    // cannot finish draining — assert it rather than rely on that reasoning,
+    // because a future change to the park would silently turn this into a test
+    // of the already-drained path while still passing.
+    try #require(
+      await controller.isDrainingForTesting(draining.manifest.identity),
+      "the draining window closed before the sweep, so the protection is untested")
 
     await controller.sweepSupersededStaging(current)
     #expect(

--- a/Tests/EnviousWisprTests/ModelDelivery/SupersededStagingSweepTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/SupersededStagingSweepTests.swift
@@ -415,12 +415,30 @@ import Testing
       availableDiskBytes: { _ in .max })
 
     let entered = AsyncStream<Void>.makeStream()
-    let release = AsyncStream<Void>.makeStream()
+    // THE PARK MUST SURVIVE CANCELLATION, and an `AsyncStream` iterator does
+    // not (cloud-review P1 on the first version of this fix).
+    //
+    // `cancel` fires the draining signal and then IMMEDIATELY calls
+    // `task.cancel()`. An attempt parked in `AsyncStream.Iterator.next()`
+    // returns `nil` on cancellation, so it finishes, `await task.value`
+    // returns, and `drainingTask` is cleared — possibly before this test's
+    // waiter has reacquired the actor. That reintroduces the very
+    // intermittency this change exists to remove, one mechanism over: version
+    // one failed by STARVATION, this would fail by the window CLOSING early.
+    //
+    // `withCheckedContinuation` (non-throwing) is not cancellation-aware, so
+    // the attempt stays parked until the test opens the gate explicitly. The
+    // drain window is then held open BY CONSTRUCTION rather than by winning a
+    // race.
+    //
+    // `sweepNeverDeletesStagingForAnAttemptInFlight` keeps the plain
+    // `AsyncStream` park deliberately: it asserts BEFORE it cancels, so the
+    // cancellation never closes a window it still needs.
+    let gate = CancellationInsensitiveGate()
     await controller.setBeforeExistingCacheValidationForTesting {
       entered.continuation.yield()
       entered.continuation.finish()
-      var iterator = release.stream.makeAsyncIterator()
-      _ = await iterator.next()
+      await gate.wait()
     }
     async let attempt = controller.ensureModelAvailable(draining)
     let didEnter = await withDeadline(seconds: 5) {
@@ -473,8 +491,9 @@ import Testing
       exists(drainingStaging),
       "the sweep deleted staging for an attempt that is still draining")
 
-    release.continuation.yield()
-    release.continuation.finish()
+    // Open the gate only now — after the sweep has run against a window this
+    // test held open deliberately.
+    await gate.open()
     _ = await cancelled
     _ = await attempt
 
@@ -608,5 +627,31 @@ import Testing
       exists(superseded) == false,
       "an unset kill switch froze the sweep, so no ordinary user would ever reclaim abandoned downloads"
     )
+  }
+}
+
+/// A park that CANCELLATION CANNOT OPEN.
+///
+/// `AsyncStream.Iterator.next()` returns `nil` when its task is cancelled, so a
+/// test parking on one cannot hold a window open across a `cancel()` — the
+/// subject finishes early and the state under test is gone before the
+/// assertion runs. `withCheckedContinuation` (non-throwing) has no
+/// cancellation path, so the only way out is `open()`.
+///
+/// Not a clock wait and not a poll: the waiter suspends until explicitly
+/// resumed. Use it when the test must OWN when the subject proceeds.
+actor CancellationInsensitiveGate {
+  private var continuation: CheckedContinuation<Void, Never>?
+  private var isOpen = false
+
+  func wait() async {
+    if isOpen { return }
+    await withCheckedContinuation { continuation = $0 }
+  }
+
+  func open() {
+    isOpen = true
+    continuation?.resume()
+    continuation = nil
   }
 }

--- a/Tests/EnviousWisprTests/ModelDelivery/SupersededStagingSweepTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/SupersededStagingSweepTests.swift
@@ -435,6 +435,10 @@ import Testing
     // `AsyncStream` park deliberately: it asserts BEFORE it cancels, so the
     // cancellation never closes a window it still needs.
     let gate = CancellationInsensitiveGate()
+    // UNCONDITIONAL. Any `#require` between here and the explicit open would
+    // otherwise leave the attempt parked on a park cancellation cannot wake,
+    // so the test would HANG instead of reporting the failed requirement.
+    defer { gate.open() }
     await controller.setBeforeExistingCacheValidationForTesting {
       entered.continuation.yield()
       entered.continuation.finish()
@@ -493,7 +497,7 @@ import Testing
 
     // Open the gate only now — after the sweep has run against a window this
     // test held open deliberately.
-    await gate.open()
+    gate.open()
     _ = await cancelled
     _ = await attempt
 
@@ -638,20 +642,42 @@ import Testing
 /// assertion runs. `withCheckedContinuation` (non-throwing) has no
 /// cancellation path, so the only way out is `open()`.
 ///
-/// Not a clock wait and not a poll: the waiter suspends until explicitly
-/// resumed. Use it when the test must OWN when the subject proceeds.
-actor CancellationInsensitiveGate {
+/// A LOCK, NOT AN ACTOR, forced by the FAILURE path rather than by taste.
+/// Being cancellation-proof means a `#require` that throws before the gate
+/// opens would leave the subject parked forever: scope exit cancels the
+/// structured child, cancellation cannot wake this park, and the test HANGS
+/// instead of reporting the requirement it failed — a loud failure converted
+/// into a silent one (cloud-review P1 on the actor version). `defer` cannot
+/// `await`, so `open()` must be synchronous to be callable from unconditional
+/// cleanup. Every caller pairs `let gate = …` with `defer { gate.open() }` on
+/// the next line.
+final class CancellationInsensitiveGate: @unchecked Sendable {
+  private let lock = NSLock()
   private var continuation: CheckedContinuation<Void, Never>?
   private var isOpen = false
 
   func wait() async {
-    if isOpen { return }
-    await withCheckedContinuation { continuation = $0 }
+    await withCheckedContinuation { c in
+      lock.lock()
+      // Opened before anyone waited: resume rather than park forever. Tested
+      // inside the lock so `open()` cannot land between the check and the store.
+      if isOpen {
+        lock.unlock()
+        c.resume()
+        return
+      }
+      continuation = c
+      lock.unlock()
+    }
   }
 
   func open() {
+    lock.lock()
     isOpen = true
-    continuation?.resume()
+    let waiter = continuation
     continuation = nil
+    lock.unlock()
+    // Resumed OUTSIDE the lock: a continuation resume can run arbitrary code.
+    waiter?.resume()
   }
 }


### PR DESCRIPTION
## Unblocks main and every open PR

`sweepProtectsADrainingAttempt` timed out on post-merge main for `6a8390d8`
(#2124) — 1 failure in 5756. Because GitHub tests each branch MERGED with
current main, this failed every open PR too, not just main. A peer spent time
suspecting their own diff before pulling the raw job log for the failing test's
NAME; `--log-failed` truncates it.

## Root

The test POLLED an actor-isolated probe with `Task.yield()`:

```swift
while true {
  if await controller.isDrainingForTesting(identity) { return true }
  await Task.yield()          // <- starves the transition it waits for
}
```

Every probe is a hop onto the controller actor, so the loop keeps the controller
answering "are you draining yet" instead of draining. Green locally twice, lost
the race on a hosted runner with fewer cores. The symptom is a DEADLINE EXPIRY,
which reads as "the feature is slow" rather than "my test caused this".

## Fix

`afterMovedToDrainingForTesting`, fired at the instant `cancel` moves
`activeTask` to `drainingTask`, **before** `task.cancel()` so a waiter is
released while the window is still open. Synchronous by design: it runs inside
the actor-isolated window and must not suspend and let that window close.
Internal rather than `#if DEBUG`, matching `beforeExistingCacheValidation-
ForTesting` — a DEBUG-only seam would make the covering test vanish from the
Release lane.

**Rejected: sleeping between probes.** Still a clock wait, and
`check-test-timing.sh` correctly refused it. A signal removes the race; a sleep
bets against it, and the bet is worse on the runner than on this machine.

## Added, because they are two conditions

The signal proves the move HAPPENED, not that the window is still OPEN at sweep
time. They coincide only because the attempt is parked and cannot finish
draining. Asserted rather than reasoned, so a future change to the park cannot
silently convert this into a test of the already-drained path while still
passing.

## Evidence

Debug **5756**, Release **5322**, both green, 0 failures. The test now passes in
**0.003s** where it was expiring at **5.014s**.

**Mutation control**: dropping `drainingTask` from the sweep's protection gives
0 compile errors and fails on the ASSERTION (`exists(drainingStaging)`), not on
the clock — so the coverage survived the fix. Verified the mutant APPLIED before
trusting the verdict; the first attempt's anchor did not match a wrapped line
and ran green against unmutated code, which would have read as "the test is
useless".

## Class, not an instance

`~/.claude/knowledge/dev/test-timing.md` now names this hazard. The gap it fills:
that file explicitly blesses `await Task.yield()` as needing no marker — CORRECT,
it is not a clock wait — which is exactly why yield-polling passes every timing
check and still dies on CI. A peer counted **37** instances of the same shape in
`LivePreviewCoordinatorTests`.

Fixes the post-merge failure on #2124.
