### PR TITLE
fix(test): wait on the kernel's conclusion signal wherever a terminal is asserted

### DIFF
--- a/Tests/EnviousWisprTests/Pipeline/KernelEngineHookCallSitesTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelEngineHookCallSitesTests.swift
@@ -94,7 +94,7 @@ struct KernelEngineHookCallSitesTests {
     fx.capture.deliverBuffer()
     await fx.wrapper.drainReadyWork()
     fx.kernel.requestStop()
-    await fx.wrapper.drainReadyWork()
+    await fx.wrapper.drainUntilConcluded()
   }
 
   // MARK: 1. preWarm fires warmUpFromCache once and NOT cancelPendingUnload

--- a/Tests/EnviousWisprTests/Pipeline/KernelFormatStabilizationRebuildTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelFormatStabilizationRebuildTests.swift
@@ -97,7 +97,7 @@ struct KernelFormatStabilizationRebuildTests {
 
     wrapper.testKernel.cancel()  // cancelRequested latched pre-recording
     capture.releaseStabilizationGate()
-    await wrapper.drainReadyWork()
+    await wrapper.drainUntilConcluded()
 
     #expect(wrapper.testKernel.recordingOutcome == .cancelled)
     #expect(capture.rebuildEngineCallCount == 1)  // rebuild had already happened

--- a/Tests/EnviousWisprTests/Pipeline/KernelFrozenBindGuardTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelFrozenBindGuardTests.swift
@@ -68,7 +68,7 @@ struct KernelFrozenBindGuardTests {
     ctx.vad.evidence = .confirmedNoSpeech
     await ctx.wrapper.drainReadyWork()
     await ctx.wrapper.apply(.stop)
-    await ctx.wrapper.drainReadyWork()
+    await ctx.wrapper.drainUntilConcluded()
   }
 
   /// A bind built from a device this machine reports as genuinely alive AND unmuted,

--- a/Tests/EnviousWisprTests/Pipeline/KernelInputResolutionFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelInputResolutionFreezeTests.swift
@@ -34,9 +34,18 @@ struct KernelInputResolutionFreezeTests {
     return (capture, wrapper)
   }
 
-  private func startAndSettle(_ wrapper: KernelRecordingSession) async {
+  /// #1857: `concluding: true` for the fault-injected starts whose caller then
+  /// asserts the kernel reached its FAILED terminal. Epoch quiescence can settle
+  /// while the failure path is still a ready task, so `state` would read the
+  /// in-flight value. A healthy start has no terminal coming and keeps the plain
+  /// drain — the conclusion wait would spin to its livelock cap there.
+  private func startAndSettle(_ wrapper: KernelRecordingSession, concluding: Bool = false) async {
     await wrapper.apply(.start)
-    await wrapper.drainReadyWork()
+    if concluding {
+      await wrapper.drainUntilConcluded()
+    } else {
+      await wrapper.drainReadyWork()
+    }
   }
 
   // MARK: 1 — the ordinary success path
@@ -61,7 +70,7 @@ struct KernelInputResolutionFreezeTests {
     capture.inputResolutionSourcePerAttempt = ["list_fallback"]
     capture.failEngineStart = true
 
-    await startAndSettle(wrapper)
+    await startAndSettle(wrapper, concluding: true)
 
     // Asserted AFTER the kernel reached its failed terminal, not before the
     // throw: a pre-throw assertion would prove the fake, not the freeze.
@@ -93,7 +102,7 @@ struct KernelInputResolutionFreezeTests {
     // Attempt 1 succeeds; the rebuild attempt throws.
     capture.failEngineStartOnAttempt = 2
 
-    await startAndSettle(wrapper)
+    await startAndSettle(wrapper, concluding: true)
 
     #expect(capture.startEnginePhaseCallCount == 2)
     #expect(wrapper.testKernel.state == .idle)
@@ -136,7 +145,7 @@ struct KernelInputResolutionFreezeTests {
     // asserted a "cleared" value that was really just session 1's, never
     // overwritten because session 2 never ran.
     await wrapper.apply(.stop)
-    await wrapper.drainReadyWork()
+    await wrapper.drainUntilConcluded()
     #expect(wrapper.testKernel.state == .idle, "session 1 must have finished")
 
     // Park session 2 AFTER engine start publishes its new source but BEFORE the

--- a/Tests/EnviousWisprTests/Pipeline/KernelPhase2RetryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelPhase2RetryTests.swift
@@ -115,7 +115,7 @@ struct KernelPhase2RetryTests {
 
     // Chunk 1's drained continuation: the suspended decode now fails.
     ctx.engine.resolveHeldFinalizeAsHelperDeath()
-    await ctx.wrapper.drainReadyWork()
+    await ctx.wrapper.drainUntilConcluded()
 
     #expect(ctx.engine.finalizeCallCount == 1, "the initial decode ran exactly once")
     #expect(
@@ -150,7 +150,7 @@ struct KernelPhase2RetryTests {
     #expect(ctx.engine.retryDecodeCallCount == 0)
 
     ctx.engine.resolveHeldFinalizeAsHelperDeath()
-    await ctx.wrapper.drainReadyWork()
+    await ctx.wrapper.drainUntilConcluded()
 
     #expect(ctx.engine.finalizeCallCount == 1)
     #expect(ctx.engine.recoverFromASRInterruptionCallCount == 0)
@@ -391,7 +391,7 @@ struct KernelPhase2RetryTests {
   func preCaptureFailureNeverConsultsRetry() async {
     let ctx = makeContext(behavior: .failLoad(ASREngineError.loadFailed))
     await ctx.wrapper.apply(.start)
-    await ctx.wrapper.drainReadyWork()
+    await ctx.wrapper.drainUntilConcluded()
     let kernel = ctx.wrapper.testKernel
 
     #expect(kernel.recordingOutcome == .failed(.modelLoadFailed))
@@ -424,7 +424,7 @@ struct KernelPhase2RetryTests {
         text: "rescued after recovery", language: nil, duration: 0, processingTime: 0,
         backendType: .parakeet))
     kernel.externalASRInterrupted()
-    await ctx.wrapper.drainReadyWork()
+    await ctx.wrapper.drainUntilConcluded()
 
     #expect(kernel.recordingOutcome == .completed)
     #expect(kernel.deliveredTranscript == "rescued after recovery")
@@ -463,7 +463,7 @@ struct KernelPhase2RetryTests {
     // still parked — mirrors the kernel's own documented "Concurrent" class
     // (§5): a cancel landing while the retry awaits.
     kernel.cancel()
-    await ctx.wrapper.drainReadyWork()
+    await ctx.wrapper.drainUntilConcluded()
     #expect(kernel.recordingOutcome == .cancelled)
 
     // Session B starts and completes normally before A's abandoned retry
@@ -474,7 +474,7 @@ struct KernelPhase2RetryTests {
     deliverVoicedCapture(ctx)
     await ctx.wrapper.drainReadyWork()
     await ctx.wrapper.apply(.stop)
-    await ctx.wrapper.drainReadyWork()
+    await ctx.wrapper.drainUntilConcluded()
     #expect(kernel.recordingOutcome == .completed)
     #expect(kernel.deliveredTranscript == "session B text")
 

--- a/Tests/EnviousWisprTests/Pipeline/KernelSalvageRetryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelSalvageRetryTests.swift
@@ -56,7 +56,7 @@ struct KernelSalvageRetryTests {
     // otherwise the stop aborts a still-Arming session as released-before-recording.
     await ctx.wrapper.drainReadyWork()
     await ctx.wrapper.apply(.stop)
-    await ctx.wrapper.drainReadyWork()
+    await ctx.wrapper.drainUntilConcluded()
   }
 
   @Test("empty primary decode + non-empty retry → salvaged completion delivers the retry text")
@@ -106,7 +106,7 @@ struct KernelSalvageRetryTests {
     // false and this retry never fired.
     ctx.engine.behavior = .emptyThenScripted(text: "salvaged streaming take", emptyCalls: 1)
     kernel.externalASRInterrupted()
-    await ctx.wrapper.drainReadyWork()
+    await ctx.wrapper.drainUntilConcluded()
 
     #expect(
       kernel.recordingOutcome == .completed,
@@ -146,7 +146,7 @@ struct KernelSalvageRetryTests {
     // salvage-ladder fix already covered above.
     ctx.engine.behavior = .batchSuccess(text: "recovered take")
     kernel.externalASRInterrupted()
-    await ctx.wrapper.drainReadyWork()
+    await ctx.wrapper.drainUntilConcluded()
 
     #expect(kernel.recordingOutcome == .completed)
     #expect(kernel.deliveredTranscript == "recovered take")
@@ -197,7 +197,7 @@ struct KernelSalvageRetryTests {
     // #1548 D1: commit the first buffer (Arming -> Live) before stopping.
     await ctx.wrapper.drainReadyWork()
     await ctx.wrapper.apply(.stop)
-    await ctx.wrapper.drainReadyWork()
+    await ctx.wrapper.drainUntilConcluded()
     let kernel = ctx.wrapper.testKernel
 
     #expect(kernel.recordingOutcome == .asrEmptyDespiteAudio)
@@ -233,7 +233,7 @@ struct KernelSalvageRetryTests {
     // #1548 D1: commit the first buffer (Arming -> Live) before stopping.
     await ctx.wrapper.drainReadyWork()
     await ctx.wrapper.apply(.stop)
-    await ctx.wrapper.drainReadyWork()
+    await ctx.wrapper.drainUntilConcluded()
     let kernel = ctx.wrapper.testKernel
 
     #expect(kernel.recordingOutcome.kind == .noSpeech)
@@ -259,7 +259,7 @@ struct KernelSalvageRetryTests {
     // #1548 D1: commit the first buffer (Arming -> Live) before stopping.
     await ctx.wrapper.drainReadyWork()
     await ctx.wrapper.apply(.stop)
-    await ctx.wrapper.drainReadyWork()
+    await ctx.wrapper.drainUntilConcluded()
     let kernel = ctx.wrapper.testKernel
 
     #expect(kernel.recordingOutcome == .completed)

--- a/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelExternalInterruptionTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelExternalInterruptionTests.swift
@@ -74,7 +74,7 @@ import Testing
       #expect(kernel.state == .live)
 
       kernel.externalEngineInterrupted(.engineLost)
-      await wrapper.drainReadyWork()
+      await wrapper.drainUntilConcluded()
 
       #expect(kernel.recordingOutcome == .audioInterrupted(.engineLost))
     }
@@ -94,7 +94,7 @@ import Testing
       #expect(kernel.state == .live)
 
       kernel.externalASRInterrupted()
-      await wrapper.drainReadyWork()
+      await wrapper.drainUntilConcluded()
 
       // From `.live` the outcome carries `wasRecording: true` — pin the payload,
       // not just the category, so the kernel can't silently drop/invert it
@@ -119,7 +119,7 @@ import Testing
       #expect(kernel.state == .live)
 
       kernel.externalASRInterrupted()
-      await wrapper.drainReadyWork()
+      await wrapper.drainUntilConcluded()
 
       #expect(kernel.recordingOutcome == .completed)
       #expect(context.paste.pasteCount == 1)
@@ -199,7 +199,7 @@ import Testing
       #expect(kernel.state == .live)
 
       kernel.externalCaptureStalled(context.capture.makeStallContext())
-      await wrapper.drainReadyWork()
+      await wrapper.drainUntilConcluded()
 
       #expect(kernel.recordingOutcome == .failed(.captureStalled))
     }
@@ -213,7 +213,7 @@ import Testing
 
       await startToRecording(context)
       kernel.externalEngineInterrupted(.engineLost)
-      await wrapper.drainReadyWork()
+      await wrapper.drainUntilConcluded()
       let firstOutcome = kernel.recordingOutcome
       #expect(firstOutcome == .audioInterrupted(.engineLost))
 
@@ -233,7 +233,7 @@ import Testing
 
       await startToRecording(context)
       kernel.externalASRInterrupted()
-      await wrapper.drainReadyWork()
+      await wrapper.drainUntilConcluded()
       let firstOutcome = kernel.recordingOutcome
       #expect(firstOutcome.kind == .asrInterrupted)
 
@@ -249,7 +249,7 @@ import Testing
 
       await startToRecording(context)
       kernel.externalCaptureStalled(context.capture.makeStallContext())
-      await wrapper.drainReadyWork()
+      await wrapper.drainUntilConcluded()
       let firstOutcome = kernel.recordingOutcome
       #expect(firstOutcome == .failed(.captureStalled))
 
@@ -283,13 +283,13 @@ import Testing
 
       await startToRecording(context)
       await wrapper.apply(.cancel)  // → cancelled
-      await wrapper.drainReadyWork()
+      await wrapper.drainUntilConcluded()
       #expect(kernel.recordingOutcome == .cancelled)
 
       kernel.externalEngineInterrupted(.engineLost)
       kernel.externalASRInterrupted()
       kernel.externalCaptureStalled(context.capture.makeStallContext())
-      await wrapper.drainReadyWork()
+      await wrapper.drainUntilConcluded()
 
       #expect(kernel.recordingOutcome == .cancelled)
     }
@@ -308,7 +308,7 @@ import Testing
       // `.audioInterrupted(.engineLost)` — the FIRST exit, deterministically.
       kernel.externalEngineInterrupted(.engineLost)
       kernel.externalASRInterrupted()
-      await wrapper.drainReadyWork()
+      await wrapper.drainUntilConcluded()
 
       #expect(kernel.recordingOutcome == .audioInterrupted(.engineLost))
     }
@@ -331,7 +331,7 @@ import Testing
       // Second, in the post-latch / pre-transition window: a generic engine loss.
       // Its exit is ignored; it must NOT overwrite the stamped cause.
       kernel.externalEngineInterrupted(.engineLost)
-      await wrapper.drainReadyWork()
+      await wrapper.drainUntilConcluded()
 
       #expect(kernel.recordingOutcome == .audioInterrupted(.deviceRemoved))
       #expect(
@@ -365,7 +365,7 @@ import Testing
         inputDeviceUIDSystemDefault: nil,
         failureMode: .noBuffers)
       kernel.externalCaptureStalled(crossDomain)
-      await wrapper.drainReadyWork()
+      await wrapper.drainUntilConcluded()
 
       #expect(kernel.recordingOutcome == .failed(.captureStalled))
     }

--- a/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelSalvageTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelSalvageTests.swift
@@ -142,7 +142,7 @@ struct ExhaustedRetrySpoolDeletionTests {
       await startRecording(context)
 
       wrapper.testKernel.externalEngineInterrupted(cause)
-      await wrapper.drainReadyWork()
+      await wrapper.drainUntilConcluded()
 
       #expect(wrapper.testKernel.recordingOutcome == .completed)
       #expect(context.paste.pasteCount == 1)
@@ -172,7 +172,7 @@ struct ExhaustedRetrySpoolDeletionTests {
 
       await startRecording(context)
       await context.sut.apply(.stop)
-      await wrapper.drainReadyWork()
+      await wrapper.drainUntilConcluded()
 
       #expect(
         wrapper.telemetryState.transcriptionFailureError as? KernelLimbError
@@ -202,7 +202,7 @@ struct ExhaustedRetrySpoolDeletionTests {
 
       await startRecording(context)
       await context.sut.apply(.stop)
-      await wrapper.drainReadyWork()
+      await wrapper.drainUntilConcluded()
 
       #expect(
         wrapper.telemetryState.transcriptionFailureError as? KernelLimbError
@@ -288,7 +288,7 @@ struct ExhaustedRetrySpoolDeletionTests {
       await startRecording(context, buffers: 1)
 
       await context.sut.apply(.stop)
-      await context.sut.drainReadyWork()
+      await context.sut.drainUntilConcluded()
 
       #expect(wrapper.testKernel.recordingOutcome == .discarded(.tooShort))
       #expect(
@@ -304,7 +304,7 @@ struct ExhaustedRetrySpoolDeletionTests {
       // The clock never advances, so the elapsed window is below the minimum —
       // the same sub-minimum gate the user-stop pair lands on, but interrupted.
       wrapper.testKernel.externalEngineInterrupted(.engineLost)
-      await wrapper.drainReadyWork()
+      await wrapper.drainUntilConcluded()
 
       #expect(wrapper.testKernel.recordingOutcome == .audioInterrupted(.engineLost))
       // #1755: the floor now preserves honest TERMINAL/notice semantics only —
@@ -322,7 +322,7 @@ struct ExhaustedRetrySpoolDeletionTests {
       await startRecording(context, buffers: 2)
 
       wrapper.testKernel.externalEngineInterrupted(.engineLost)
-      await wrapper.drainReadyWork()
+      await wrapper.drainUntilConcluded()
 
       #expect(wrapper.testKernel.recordingOutcome.kind == .audioInterrupted)
     }
@@ -340,7 +340,7 @@ struct ExhaustedRetrySpoolDeletionTests {
       await startRecording(context, amplitude: 0.001)
 
       wrapper.testKernel.externalEngineInterrupted(.engineLost)
-      await wrapper.drainReadyWork()
+      await wrapper.drainUntilConcluded()
 
       #expect(wrapper.testKernel.recordingOutcome.kind == .audioInterrupted)
       #expect(context.paste.pasteCount == 0)
@@ -364,7 +364,7 @@ struct ExhaustedRetrySpoolDeletionTests {
       await startRecording(context, amplitude: 0.1)
 
       wrapper.testKernel.externalEngineInterrupted(.engineLost)
-      await wrapper.drainReadyWork()
+      await wrapper.drainUntilConcluded()
 
       #expect(
         wrapper.testKernel.recordingOutcome.kind == .audioInterrupted,
@@ -396,7 +396,7 @@ struct ExhaustedRetrySpoolDeletionTests {
       await startRecording(context, buffers: site.buffers, amplitude: site.amplitude)
 
       wrapper.testKernel.externalEngineInterrupted(.engineLost)
-      await wrapper.drainReadyWork()
+      await wrapper.drainUntilConcluded()
 
       #expect(
         wrapper.testKernel.recordingOutcome.kind == .audioInterrupted,
@@ -421,7 +421,7 @@ struct ExhaustedRetrySpoolDeletionTests {
       await startRecording(context, buffers: bufferCount)
 
       wrapper.testKernel.externalEngineInterrupted(cause)
-      await wrapper.drainReadyWork()
+      await wrapper.drainUntilConcluded()
 
       let terminal = wrapper.testKernel.recordingOutcome
       #expect(
@@ -456,7 +456,7 @@ struct ExhaustedRetrySpoolDeletionTests {
       )
 
       await wrapper.apply(.cancel)
-      await wrapper.drainReadyWork()
+      await wrapper.drainUntilConcluded()
 
       #expect(wrapper.testKernel.recordingOutcome == .cancelled)
       #expect(context.paste.pasteCount == 0)
@@ -601,7 +601,7 @@ struct ExhaustedRetrySpoolDeletionTests {
 
       await startRecording(context)
       kernel.externalASRInterrupted()
-      await wrapper.drainReadyWork()
+      await wrapper.drainUntilConcluded()
 
       #expect(
         kernel.recordingOutcome == .asrInterrupted(wasRecording: true),
@@ -628,7 +628,7 @@ struct ExhaustedRetrySpoolDeletionTests {
 
       await startRecording(context)
       kernel.externalASRInterrupted()
-      await wrapper.drainReadyWork()
+      await wrapper.drainUntilConcluded()
 
       #expect(kernel.recordingOutcome == .asrInterrupted(wasRecording: true))
       #expect(context.paste.pasteCount == 0)
@@ -696,7 +696,7 @@ struct ExhaustedRetrySpoolDeletionTests {
 
       // And the floor is genuinely inert again: an ordinary stop discards.
       await wrapper.apply(.stop)
-      await wrapper.drainReadyWork()
+      await wrapper.drainUntilConcluded()
       #expect(wrapper.testKernel.recordingOutcome.kind == .discarded)
     }
 

--- a/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelTests.swift
@@ -44,9 +44,24 @@ import Testing
     }
 
     /// Drive one trigger and settle the kernel.
-    private func apply(_ trigger: SessionTrigger, to wrapper: KernelRecordingSession) async {
+    ///
+    /// #1857: pass `concluding: true` for a trigger this caller then asserts a
+    /// TERMINAL after. Epoch quiescence is a heuristic — a continuation resumed
+    /// synchronously inside the trigger is absorbed into the drain's initial
+    /// `workEpoch`, so under MainActor contention the plain drain can return
+    /// while the session is still in flight and the terminal assertion reads a
+    /// bare `nil`. `.start` and mid-session triggers keep the plain drain,
+    /// because no terminal is coming and the conclusion wait would spin to its
+    /// livelock cap.
+    private func apply(
+      _ trigger: SessionTrigger, to wrapper: KernelRecordingSession, concluding: Bool = false
+    ) async {
       await wrapper.apply(trigger)
-      await wrapper.drainReadyWork()
+      if concluding {
+        await wrapper.drainUntilConcluded()
+      } else {
+        await wrapper.drainReadyWork()
+      }
     }
 
     /// Start a session and drive it to `.live`. #1548 D1: reaching `.live` now
@@ -69,11 +84,11 @@ import Testing
 
       await apply(.start, to: wrapper)
       let first = kernel.currentSessionID
-      await apply(.cancel, to: wrapper)  // recording → cancelled
+      await apply(.cancel, to: wrapper, concluding: true)  // recording → cancelled
 
       await apply(.start, to: wrapper)
       let second = kernel.currentSessionID
-      await apply(.cancel, to: wrapper)
+      await apply(.cancel, to: wrapper, concluding: true)
 
       await apply(.start, to: wrapper)
       let third = kernel.currentSessionID
@@ -90,7 +105,7 @@ import Testing
       let kernel = wrapper.testKernel
 
       await apply(.start, to: wrapper)
-      await apply(.cancel, to: wrapper)  // → cancelled (terminal)
+      await apply(.cancel, to: wrapper, concluding: true)  // → cancelled (terminal)
       let terminalSID = kernel.currentSessionID
 
       await apply(.reset, to: wrapper)  // cancelled → idle
@@ -121,7 +136,7 @@ import Testing
       let kernel = wrapper.testKernel
 
       await apply(.start, to: wrapper)
-      await apply(.cancel, to: wrapper)  // concludes .cancelled; the FSM returns to .idle
+      await apply(.cancel, to: wrapper, concluding: true)  // concludes .cancelled; the FSM returns to .idle
       #expect(kernel.recordingOutcome == .cancelled)
 
       // From the concluded `.idle`, only `idle → arming` is legal (#1548 D1); a
@@ -141,12 +156,12 @@ import Testing
       let kernel = wrapper.testKernel
 
       await apply(.start, to: wrapper)
-      await apply(.cancel, to: wrapper)
+      await apply(.cancel, to: wrapper, concluding: true)
       #expect(kernel.recordingOutcome == .cancelled)
 
       // Every further trigger except start / reset is ignored.
-      await apply(.cancel, to: wrapper)
-      await apply(.stop, to: wrapper)
+      await apply(.cancel, to: wrapper, concluding: true)
+      await apply(.stop, to: wrapper, concluding: true)
       #expect(kernel.recordingOutcome == .cancelled)
     }
 
@@ -180,7 +195,7 @@ import Testing
       let kernel = wrapper.testKernel
 
       await apply(.start, to: wrapper)
-      await apply(.cancel, to: wrapper)
+      await apply(.cancel, to: wrapper, concluding: true)
       #expect(kernel.recordingOutcome == .cancelled)
       #expect(kernel.testActiveTaskCount == 0)
     }
@@ -194,7 +209,7 @@ import Testing
       // The load wedges and parks; advance logical time so the wedge watcher
       // fires and the kernel reaches its terminal state.
       context.clock.advance(by: 4)
-      await wrapper.drainReadyWork()
+      await wrapper.drainUntilConcluded()
 
       #expect(kernel.recordingOutcome == .failed(.modelWedged))
       // The wedged warm-up task ignored cooperative cancellation, yet the kernel
@@ -254,7 +269,7 @@ import Testing
     func ordinaryTerminalUsesCheapCancel() async {
       let (context, wrapper) = makeWrapper()
       await apply(.start, to: wrapper)
-      await apply(.cancel, to: wrapper)  // recording → cancelled (an ordinary discard)
+      await apply(.cancel, to: wrapper, concluding: true)  // recording → cancelled (an ordinary discard)
 
       #expect(wrapper.testKernel.recordingOutcome == .cancelled)
       #expect(context.engine.cancelCallCount >= 1, "ordinary discard must call cheap cancel()")
@@ -268,7 +283,7 @@ import Testing
       let (context, wrapper) = makeWrapper(behavior: .wedgeOnLoad)
       await apply(.start, to: wrapper)
       context.clock.advance(by: 4)  // let the wedge watcher fire
-      await wrapper.drainReadyWork()
+      await wrapper.drainUntilConcluded()
 
       #expect(wrapper.testKernel.recordingOutcome == .failed(.modelWedged))
       #expect(
@@ -292,7 +307,7 @@ import Testing
       await apply(.start, to: wrapper)
       context.capture.deliverBuffer()
       await wrapper.drainReadyWork()
-      await apply(.stop, to: wrapper)
+      await apply(.stop, to: wrapper, concluding: true)
 
       #expect(kernel.recordingOutcome == .completed)
       #expect(kernel.deliveredTranscript == "raw asr text")
@@ -370,7 +385,7 @@ import Testing
       // still needs it), but the PUBLIC `recordingElapsedSeconds` value now
       // correctly goes nil the moment state leaves `.recording`, closing the
       // exact stale-value window the overlay's first pill push could hit.
-      await apply(.cancel, to: wrapper)  // recording → cancelled (terminal)
+      await apply(.cancel, to: wrapper, concluding: true)  // recording → cancelled (terminal)
       #expect(kernel.recordingElapsedSeconds == nil, "gated on .recording, not on the raw tick")
 
       await apply(.reset, to: wrapper)  // cancelled → idle
@@ -403,7 +418,7 @@ import Testing
       let first = kernel.currentSessionID
       #expect(wrapper.telemetryState.takeID == first.raw.uuidString)
 
-      await apply(.cancel, to: wrapper)  // recording → cancelled (terminal)
+      await apply(.cancel, to: wrapper, concluding: true)  // recording → cancelled (terminal)
       await apply(.reset, to: wrapper)  // cancelled → idle
 
       await startToLive(context, wrapper)
@@ -439,7 +454,7 @@ import Testing
         kernel.lastTakeID == nil,
         "in flight is not concluded — this names the CONCLUDED take, like lastStopReason")
 
-      await apply(.cancel, to: wrapper)  // recording → cancelled (a terminal)
+      await apply(.cancel, to: wrapper, concluding: true)  // recording → cancelled (a terminal)
       #expect(
         kernel.lastTakeID == firstSessionID.raw.uuidString,
         "the accepted terminal must stamp the take that concluded")

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioRunner.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioRunner.swift
@@ -154,6 +154,21 @@ struct ScenarioRunner {
       context.sut.inject(directive)
 
     case .expectState(let expected):
+      // #1857: a MID-scenario terminal expectation is the same assertion the
+      // teardown check makes, so it needs the same wait. The preceding step's
+      // per-step `drainReadyWork()` is epoch quiescence — a continuation resumed
+      // synchronously inside that step is absorbed into the drain's initial
+      // `workEpoch`, so under contention this check can read the in-flight state
+      // and report a stuck session on a healthy kernel. That is the historical
+      // `step N: expected <terminal>, got recording` signature.
+      //
+      // Gated on `isTerminal` for the same reason the teardown is: `.idle` and
+      // the in-flight states publish no conclusion, and waiting for one would
+      // burn the livelock cap. `drainUntilConcluded` ends in `drainReadyWork`,
+      // so the terminal branch is a superset of what ran before.
+      if expected.isTerminal {
+        await context.sut.drainUntilConcluded()
+      }
       if context.sut.state != expected {
         failures.append(
           "step \(stepIndex): expected state \(expected), got \(context.sut.state)")

--- a/Tests/EnviousWisprTests/Pipeline/ZeroSignalRecoveryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ZeroSignalRecoveryTests.swift
@@ -90,7 +90,7 @@ struct ZeroSignalRecoveryTests {
 
     ctx.wrapper.testKernel.externalCaptureStalled(
       stallContext(ctx, failureMode: .allZeroFromStart))
-    await ctx.wrapper.drainReadyWork()
+    await ctx.wrapper.drainUntilConcluded()
 
     #expect(ctx.wrapper.testKernel.recordingOutcome == .failed(.zeroSignal))
     #expect(ctx.wrapper.testKernel.zeroSignalFailureMode == .allZeroFromStart)
@@ -115,7 +115,7 @@ struct ZeroSignalRecoveryTests {
     #expect(ctx.wrapper.testKernel.state == .live)
 
     ctx.wrapper.testKernel.externalCaptureStalled(stallContext(ctx, failureMode: .noBuffers))
-    await ctx.wrapper.drainReadyWork()
+    await ctx.wrapper.drainUntilConcluded()
 
     #expect(ctx.wrapper.testKernel.recordingOutcome == .noTransport)
     #expect(ctx.wrapper.testKernel.zeroSignalFailureMode == nil)
@@ -138,7 +138,7 @@ struct ZeroSignalRecoveryTests {
     await startToRecording(a)
     a.wrapper.testKernel.externalCaptureStalled(stallContext(a, failureMode: .noBuffers))
     await a.wrapper.apply(.stop)
-    await a.wrapper.drainReadyWork()
+    await a.wrapper.drainUntilConcluded()
     #expect(a.wrapper.testKernel.recordingOutcome == .noTransport)
 
     // Ordering B — stop first: the stop latches the recording exit; the later
@@ -148,7 +148,7 @@ struct ZeroSignalRecoveryTests {
     await startToRecording(b)
     await b.wrapper.apply(.stop)
     b.wrapper.testKernel.externalCaptureStalled(stallContext(b, failureMode: .noBuffers))
-    await b.wrapper.drainReadyWork()
+    await b.wrapper.drainUntilConcluded()
     if case .discarded = b.wrapper.testKernel.recordingOutcome {
       // stop won — correct
     } else {
@@ -181,7 +181,7 @@ struct ZeroSignalRecoveryTests {
       stallContext(ctx, failureMode: .becameZeroMidCapture))
     await ctx.wrapper.apply(.stop)
     ctx.capture.releaseStabilizationGate()
-    await ctx.wrapper.drainReadyWork()
+    await ctx.wrapper.drainUntilConcluded()
 
     // The zero-signal exit was consumed and processed (its failure mode is
     // stamped), NOT overwritten by the later stop's discard or a cancelled adapter.
@@ -229,7 +229,7 @@ struct ZeroSignalRecoveryTests {
 
     ctx.wrapper.testKernel.externalCaptureStalled(
       stallContext(ctx, failureMode: .becameZeroMidCapture))
-    await ctx.wrapper.drainReadyWork()
+    await ctx.wrapper.drainUntilConcluded()
 
     #expect(ctx.wrapper.testKernel.recordingOutcome == .completed)
     #expect(ctx.wrapper.testKernel.deliveredTranscript == "hello")
@@ -252,7 +252,7 @@ struct ZeroSignalRecoveryTests {
     // otherwise the stop aborts a still-Arming session.
     await ctx.wrapper.drainReadyWork()
     await ctx.wrapper.apply(.stop)
-    await ctx.wrapper.drainReadyWork()
+    await ctx.wrapper.drainUntilConcluded()
 
     #expect(ctx.wrapper.testKernel.recordingOutcome == .failed(.zeroSignal))
     #expect(ctx.wrapper.testKernel.zeroSignalFailureMode == .allZeroFromStart)
@@ -277,7 +277,7 @@ struct ZeroSignalRecoveryTests {
     // otherwise the stop aborts a still-Arming session.
     await ctx.wrapper.drainReadyWork()
     await ctx.wrapper.apply(.stop)
-    await ctx.wrapper.drainReadyWork()
+    await ctx.wrapper.drainUntilConcluded()
 
     #expect(ctx.wrapper.testKernel.recordingOutcome == .completed)
     #expect(ctx.wrapper.testKernel.deliveredTranscript == "hello")
@@ -311,7 +311,7 @@ struct ZeroSignalRecoveryTests {
     // otherwise the stop aborts a still-Arming session.
     await ctx.wrapper.drainReadyWork()
     await ctx.wrapper.apply(.stop)
-    await ctx.wrapper.drainReadyWork()
+    await ctx.wrapper.drainUntilConcluded()
 
     #expect(ctx.wrapper.testKernel.recordingOutcome == .completed)
     #expect(ctx.wrapper.testKernel.deliveredTranscript == "hello")
@@ -330,7 +330,7 @@ struct ZeroSignalRecoveryTests {
 
     ctx.wrapper.testKernel.externalCaptureStalled(
       stallContext(ctx, failureMode: .becameZeroMidCapture))
-    await ctx.wrapper.drainReadyWork()
+    await ctx.wrapper.drainUntilConcluded()
 
     #expect(ctx.wrapper.testKernel.recordingOutcome == .completed)
     #expect(ctx.wrapper.testKernel.deliveredTranscript == "hello")
@@ -357,7 +357,7 @@ struct ZeroSignalRecoveryTests {
     // otherwise the stop aborts a still-Arming session.
     await ctx.wrapper.drainReadyWork()
     await ctx.wrapper.apply(.stop)
-    await ctx.wrapper.drainReadyWork()
+    await ctx.wrapper.drainUntilConcluded()
 
     #expect(ctx.wrapper.testKernel.recordingOutcome == .completed)
     #expect(ctx.wrapper.testKernel.deliveredTranscript == "hello")
@@ -383,7 +383,7 @@ struct ZeroSignalRecoveryTests {
     // otherwise the stop aborts a still-Arming session.
     await ctx.wrapper.drainReadyWork()
     await ctx.wrapper.apply(.stop)
-    await ctx.wrapper.drainReadyWork()
+    await ctx.wrapper.drainUntilConcluded()
 
     #expect(ctx.wrapper.testKernel.recordingOutcome.kind == .noSpeech)
     #expect(ctx.wrapper.testKernel.zeroSignalFailureMode == nil)
@@ -412,7 +412,7 @@ struct ZeroSignalRecoveryTests {
     // otherwise the stop aborts a still-Arming session.
     await ctx.wrapper.drainReadyWork()
     await ctx.wrapper.apply(.stop)
-    await ctx.wrapper.drainReadyWork()
+    await ctx.wrapper.drainUntilConcluded()
 
     #expect(ctx.wrapper.testKernel.recordingOutcome.kind == .noSpeech)
     #expect(ctx.wrapper.testKernel.zeroSignalFailureMode == nil)
@@ -439,7 +439,7 @@ struct ZeroSignalRecoveryTests {
 
     ctx.wrapper.testKernel.externalCaptureStalled(
       stallContext(ctx, failureMode: .allZeroFromStart))
-    await ctx.wrapper.drainReadyWork()
+    await ctx.wrapper.drainUntilConcluded()
 
     #expect(ctx.wrapper.testKernel.recordingOutcome == .failed(.zeroSignal))
     // STOP-time telemetry never fires for a reactive win — the reactive
@@ -472,7 +472,7 @@ struct ZeroSignalRecoveryTests {
     // otherwise the stop aborts a still-Arming session.
     await ctx.wrapper.drainReadyWork()
     await ctx.wrapper.apply(.stop)
-    await ctx.wrapper.drainReadyWork()
+    await ctx.wrapper.drainUntilConcluded()
 
     #expect(ctx.wrapper.testKernel.recordingOutcome.kind == .discarded)
     #expect(ctx.wrapper.testKernel.zeroSignalFailureMode == nil)
@@ -504,7 +504,7 @@ struct ZeroSignalRecoveryTests {
     // otherwise the stop aborts a still-Arming session.
     await ctx.wrapper.drainReadyWork()
     await ctx.wrapper.apply(.stop)
-    await ctx.wrapper.drainReadyWork()
+    await ctx.wrapper.drainUntilConcluded()
 
     #expect(ctx.wrapper.testKernel.recordingOutcome == .failed(.zeroSignal))
     #expect(ctx.capture.rebuildEngineCallCount == 1)  // format-stabilization only
@@ -526,7 +526,7 @@ struct ZeroSignalRecoveryTests {
       // otherwise the stop aborts a still-Arming session.
       await ctx.wrapper.drainReadyWork()
       await ctx.wrapper.apply(.stop)
-      await ctx.wrapper.drainReadyWork()
+      await ctx.wrapper.drainUntilConcluded()
 
       #expect(ctx.wrapper.testKernel.recordingOutcome == .failed(.zeroSignal))
       // Best-effort convergence (§3.3): the retire is fire-and-forget, so a


### PR DESCRIPTION
## What broke, measured

`main` post-merge run [32064894858](https://github.com/saurabhav88/EnviousWispr/actions/runs/32064894858) attempt 1, commit `c109aea9`, release lane, failed one test: `KernelPhase2RetryTests/helperDeathMidDecodeExhaustsOnce()` — `asrRetryOutcome → .attempted` (expected `.retryExhausted`) and `recordingOutcome → nil` (expected `.failed(.asrFailed)`). Attempt 2, identical commit, no code change: **green**. Sibling assertions on the same test passed, so the retry itself ran.

**No give-up message was recorded**, so `drainReadyWork` did NOT exhaust its 20000-yield cap. It returned at the false-convergence branch (`RecordingSessionDriving.swift:424`) — `workEpoch` stable for 64 yields, no unconsumed recording exit — while the session was still in flight. That is #1857's second documented mechanism, the one the recording-exit gate does not cover.

## Why the previous fix did not hold

#1857's first fix added `drainUntilConcluded()` and wired it into `KernelPhase2RetryTests.runToTerminal` and `ScenarioRunner`'s teardown. It was never applied to the rest of the class. A sweep of `Tests/EnviousWisprTests/Pipeline/**` found 61 direct sites where a plain quiescence drain is followed by an assertion on a signal that is `nil` until the kernel concludes, plus six terminal-owning helpers and one runner path that no forward-window matcher can see.

Every one is the same coin flip under MainActor contention. Today's failure is one of them.

## The change

Wait on the signal being asserted, everywhere it is asserted.

- 60 direct sites converted to `drainUntilConcluded()`.
- `RecordingSessionKernelTests.apply` and `KernelInputResolutionFreezeTests.startAndSettle` take a `concluding:` flag instead of being converted wholesale — both also drive `.start` and `.reset`, which publish no conclusion, so an unconditional wait would spin the livelock cap.
- `KernelSalvageRetryTests.runToTerminal`, `KernelEngineHookCallSitesTests.driveCompleteToggleSession` and `KernelFrozenBindGuardTests.driveAllZeroCapture` always end in a terminal; their final drain is converted.
- `ScenarioRunner` now waits on the conclusion signal before a **mid-scenario** `.expectState(<terminal>)`, matching what its teardown check already does. That is the historical `step N: expected <terminal>, got recording` signature.

### Deliberately not converted

| Site | Reason |
|---|---|
| `DrainReadyWorkSettleTests.swift:102` | the test **of** `drainReadyWork`'s own recording-exit gate |
| `KernelEngineHookCallSitesTests.swift:308` | a `preWarm` drain; the terminal lands inside a later helper |
| `RecordingSessionKernelExternalInterruptionTests.swift:172` | the next line asserts `recordingOutcome == nil` on purpose — recovery is parked on the fake clock |
| `KernelPhase2RetryTests.swift:484` | the terminal is already published; that drain releases a stale cross-session retry |
| every `.reset` / `.start` drain | `reset()` clears `recordingOutcome`; `start()` publishes none |

## How reachability was proven

Not by reading 65 sites. A conversion at a site with no reachable conclusion **fails loudly and names the helper** (`RecordingSessionDriving.swift:458`), so the full lanes are the oracle. Both ran clean.

The two-way control already in the tree re-ran and still behaves: `DrainReadyWorkSettleTests.neverConcludingSessionIsReportedLoudly` (a `.heldFinalize` session that can never conclude) still records its known issue. The wait can still tell a stuck kernel from a settled one — exactly one give-up appears in either log, and it is that control.

## Test evidence

| Lane | Result |
|---|---|
| Debug | `Test run with 5595 tests in 493 suites passed`, 0 failures, 3 known issues (one is the control above, two pre-existing `RouterCeilingParser`) |
| Release | `Test run with 5156 tests in 450 suites passed`, 0 failures |

The release count matches the CI run that went red exactly (5156 / 450), so this is a like-for-like Release-to-Release comparison, not Debug-against-Release.

**Contention trial.** `DrainReadyWorkSettleTests.a8SurvivesSweepUnderContention` runs scenario A8 across all 64 interleaving schedules while 128 cooperative `@MainActor` noise tasks compete for the same actor. A8 carries a mid-scenario `.expectState(.cancelled)`, so **this patch routes that stress test through the new wait**. Passed in both lanes (2.26s Debug, 2.11s Release).

## Classification

**REPRODUCIBLE** — the input is full-suite MainActor contention on a hosted runner, observed three times: branch 2026-08-12, main 2026-08-13, main 2026-08-17.

## Review

Codex reviewed the plan before the build (`docs/audits/2026-08-17-1857-codex-design.txt`) and corrected the sweep in two directions: one site my matcher flagged that must not be converted, and roughly twenty helper-mediated sites it could not see.

Its diff review raised one P1 — that a yield-poll loop can starve the transition it waits on (`~/.claude/knowledge/dev/test-timing.md`). **Withdrawn on evidence** (`docs/audits/2026-08-17-1857-codex-r2.txt`): that rule's mechanism is a *cross-actor* probe, and there is none here — `RecordingSessionKernel` is `@MainActor` (`RecordingSessionKernel.swift:239`), the wrapper and suites are `@MainActor`, `recordingOutcome` is read synchronously (`RecordingSessionDriving.swift:453`), and the only suspension is `Task.yield()`, which relinquishes the actor. The A8 contention trial above is the direct measurement against the predicted starvation.

## Rejected alternative, recorded

A source-scanning lint that fails on a new plain drain before a terminal assertion. My own v1 matcher produced a false positive and missed five classes — helper-mediated waits, `.kind` reads, `if case` binds, a terminal captured into a local, and the runner path — and it cannot see whether a later step makes conclusion reachable. It would encode an incomplete parser with a growing exemption list rather than the lifecycle contract.

## Known limit

`KernelPhase2RetryTests.lateAbandonedRetryDoesNotCorruptNewSession` drains after a clock advance to let session A's abandoned retry resolve, then asserts session B is uncorrupted. Nothing signals that the stale retry actually resolved, so under contention that assertion can pass without exercising the `isCurrent(sid)` guard. That is vacuity, not flakiness — the same missing-signal shape as #1868. Out of scope here, noted on the issue.

Closes #1857

Tier: MEDIUM | Lane: Code | Test: harness-only | Plan: `docs/feature-requests/issue-1857-2026-08-17-drain-until-concluded.md`
