### PR TITLE
test(tooling): a mutation battery that runs unattended, so it can run overnight

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,6 +197,13 @@ scripts/lib/*
 !scripts/emit-output-classifier-golden.py
 # Cross-vendor telemetry join instrument (#1846).
 !scripts/telemetry-join.py
+# Mutation battery (#2156). TRACKED because a battery is only trustworthy if everyone runs the
+# SAME one: its four controls (clean-tree before, cp-based restore, fail-closed on zero executed
+# tests, compile-failure is not a catch) each exist because a hand-rolled run got one of them
+# wrong and reported a perfect score. A gitignored copy would drift per machine, which is how a
+# battery becomes a rubber stamp.
+!scripts/mutation-battery.py
+!scripts/mutation-battery-test.py
 # UAT helpers (per-PR Swift CLIs invoked during Live UAT, e.g. issue #845 keychain verifier)
 !scripts/uat/
 !scripts/uat/**

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -30,6 +30,14 @@ VALID_ROW = {
 failures = []
 ran = 0
 
+# A pattern that matches no process. The dev-app check is a machine-wide `pgrep`, so without this the
+# whole suite fails whenever any session has a dev app open — which is a property of the box, not of
+# the code under test. The real check gets its own two-way case below, driven directly.
+import os as _os_env  # noqa: E402
+
+NEUTRAL_ENV = dict(_os_env.environ,
+                   EW_BATTERY_DEV_APP_PATTERN="ew-battery-self-test-matches-nothing")
+
 
 # Mirrors the real scripts/xcode-test.sh closely enough for the drift guard to parse. Kept in this
 # shape deliberately: a stub that does not resemble the artifact under test proves nothing about it.
@@ -90,7 +98,7 @@ def check(name, rows, *, expect_exit, expect_text=None, extra_files=None, top=No
         proc = subprocess.run(
             [sys.executable, str(BATTERY), "--recipes", str(recipes),
              "--worktree", str(tmp), "--validate-only"],
-            capture_output=True, text=True,
+            capture_output=True, text=True, env=NEUTRAL_ENV,
         )
         out = proc.stdout + proc.stderr
         if proc.returncode != expect_exit:
@@ -218,6 +226,15 @@ check("an unrecognised shell expansion in the invocation refuses the run",
       extra_files={"scripts/xcode-test.sh": CANONICAL_STUB.replace(
           '    "$@" ', '    "${EXTRA_ARGS[@]}" ')})
 
+# Fifth instance of the drift class, and answered as a BOUND rather than another enumerated axis: the
+# runner invokes xcodebuild with its ambient environment, so anything running BEFORE xcodebuild means
+# the canonical lane can use a different toolchain. Required to be empty; no prefix list to maintain.
+check("an environment prefix before xcodebuild refuses the run",
+      [dict(VALID_ROW)], expect_exit=2, expect_text="runs BEFORE xcodebuild",
+      extra_files={"scripts/xcode-test.sh": CANONICAL_STUB.replace(
+          "  xcodebuild test \\",
+          "  DEVELOPER_DIR=/other/Xcode.app/Contents/Developer xcodebuild test \\")})
+
 check("a missing canonical script refuses the run",
       [dict(VALID_ROW)], expect_exit=2, expect_text="cannot confirm it is building the same thing",
       remove=["scripts/xcode-test.sh"])
@@ -240,7 +257,7 @@ with tempfile.TemporaryDirectory() as td:
     proc = subprocess.run(
         [sys.executable, str(BATTERY), "--recipes", str(tmp / "nope.json"),
          "--worktree", str(tmp), "--validate-only"],
-        capture_output=True, text=True,
+        capture_output=True, text=True, env=NEUTRAL_ENV,
     )
     out = proc.stdout + proc.stderr
     if proc.returncode != 2 or "cannot read the recipe file" not in out:
@@ -260,7 +277,7 @@ with tempfile.TemporaryDirectory() as td:
     proc = subprocess.run(
         [sys.executable, str(BATTERY), "--recipes", str(recipes), "--worktree", str(tmp),
          "--validate-only", "--dry-run"],
-        capture_output=True, text=True,
+        capture_output=True, text=True, env=NEUTRAL_ENV,
     )
     if proc.returncode == 0 or "silently do less" not in (proc.stdout + proc.stderr):
         failures.append("--validate-only with --dry-run should be refused, not silently narrowed")
@@ -276,6 +293,10 @@ import importlib.util  # noqa: E402
 _spec = importlib.util.spec_from_file_location("battery", BATTERY)
 battery = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(battery)
+# Same reason as NEUTRAL_ENV, for the in-process cases: the dev-app check is about the machine, and
+# every case that is not ABOUT it should not consult it. Its own case restores this and drives it.
+_REAL_CHECK_NO_DEV_APP = battery.check_no_dev_app
+battery.check_no_dev_app = lambda worktree: None
 
 
 def check_fence(name, body, *, expect_blocks):
@@ -673,6 +694,79 @@ if _seen_kwargs.get("timeout") != battery.LANE_TIMEOUT_SECONDS:
         f"timeout={_seen_kwargs.get('timeout')!r} instead, so the bound exists but is not wired")
 else:
     print("  ok  the lane passes LANE_TIMEOUT_SECONDS to the process it starts")
+
+# A row's restore lives in a `finally`, and Python's DEFAULT SIGTERM action does not run it — the
+# process dies where it stands and the production file stays MUTATED with a .mutbak beside it. An
+# overnight battery is precisely the thing that gets cancelled, so the restore is also reachable from a
+# signal handler. Driven directly rather than by killing a subprocess: what is under test is that the
+# registry restores, not that macOS delivers signals.
+ran += 1
+with tempfile.TemporaryDirectory() as td:
+    tmp = make_tree(Path(td))
+    target = tmp / "Sources" / "Thing.swift"
+    backup = target.with_suffix(target.suffix + ".mutbak")
+    import shutil as _sh
+    _sh.copy2(target, backup)
+    target.write_text("let guarded = false\n")            # a mutation is now live on disk
+    battery._ACTIVE_RESTORES[target] = backup
+
+    import io as _io4, contextlib as _cl4
+    with _cl4.redirect_stderr(_io4.StringIO()):
+        battery._restore_active("a simulated SIGTERM")
+
+    if target.read_text() != "let guarded = true\n":
+        failures.append("an interrupted row restores the file and clears its backup: it stayed "
+                        "MUTATED on disk")
+    elif backup.exists():
+        failures.append("an interrupted row restores the file and clears its backup: the .mutbak "
+                        "was left behind, which blocks the next run's preflight")
+    elif battery._ACTIVE_RESTORES:
+        failures.append("an interrupted row restores the file and clears its backup: the registry "
+                        "was not cleared")
+    else:
+        print("  ok  an interrupted row restores the file and clears its backup")
+
+# ...and the handler must actually be registered, or the restore above is unreachable in practice.
+ran += 1
+import signal as _sig  # noqa: E402
+
+_prev = {s_: _sig.getsignal(s_) for s_ in (_sig.SIGTERM, _sig.SIGINT, _sig.SIGHUP)}
+try:
+    battery._install_restore_on_signal()
+    _unhandled = [s_ for s_, _ in _prev.items()
+                  if _sig.getsignal(s_) in (_sig.SIG_DFL, _sig.default_int_handler)]
+    if _unhandled:
+        failures.append(
+            "the restore handler is registered for termination signals: "
+            f"{[s_.name for s_ in _unhandled]} still has its default action, so a cancelled run "
+            "leaves the tree mutated")
+    else:
+        print("  ok  the restore handler is registered for termination signals")
+finally:
+    for s_, h in _prev.items():
+        _sig.signal(s_, h)
+
+# The dev-app check itself, driven directly. A concurrent dev app corrupts the AppLogger tests, and
+# those failures score as mutants CAUGHT when nothing detected the sabotage (#2080) — it fails toward
+# CONFIDENCE, so it is a refusal rather than a warning, and it needs to be proven both ways.
+for _label, _rc, _out, _want in [
+    ("a running dev app refuses the whole run", 0, "43962\n", True),
+    ("no dev app lets the run proceed", 1, "", False),
+]:
+    ran += 1
+    _real_run2 = battery.run
+    battery.run = lambda cmd, cwd, log_path=None, timeout=None, _r=_rc, _o=_out: (_r, _o)
+    try:
+        _REAL_CHECK_NO_DEV_APP(Path("."))
+        _refused = False
+    except battery.Refusal as exc:
+        _refused = "A dev app is running" in str(exc)
+    finally:
+        battery.run = _real_run2
+    if _refused != _want:
+        failures.append(f"{_label}: refused={_refused}, wanted {_want}")
+    else:
+        print(f"  ok  {_label}")
 
 print()
 if failures:

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -971,6 +971,13 @@ else:
     print("  ok  a known issue is not counted as a real failure")
 
 # The accepted counterpart: the same named test on a RED lane is a genuine catch.
+# Through the ROW LOOP, which is where expect_fail is compared. The direct failed_test_identities
+# cases use exact set membership and so cannot detect substring matching returning here.
+check_row("a sibling whose name contains the expected one does not score CAUGHT",
+          (5, ['✘ Test "the guard holds under load" recorded an issue at F.swift:1:1'],
+           True, "log", 65, 3.0),
+          expect_marker="SURV", expect_rc=1)
+
 check_row("the same named test on a RED lane is still CAUGHT",
           (5, ['✘ Test "the guard holds" recorded an issue'], True, "log", 65, 3.0),
           expect_marker="ok", expect_rc=0)
@@ -1018,6 +1025,212 @@ finally:
         _probe.parent.rmdir()
     except OSError:
         pass
+
+# EVERY exit path must reap the lane, not just the timeout. Cancellation mid-lane used to restore the
+# file and leave xcodebuild's group running — the file looks recovered while an orphan keeps writing
+# the shared DerivedData. Fixing one exit path is not fixing the class.
+ran += 1
+_reaped = {}
+_real_reap = battery._reap_active_lane
+battery._reap_active_lane = lambda: _reaped.setdefault("called", True)
+_real_restore = battery._restore_active
+_order = []
+battery._restore_active = lambda why: _order.append("restore")
+battery._reap_active_lane = lambda: (_order.append("reap"), True)[1]
+try:
+    _h = None
+    _real_signal = battery.signal.signal
+
+    def _capture_signal(sig, fn):
+        nonlocal_h = fn
+        if sig == battery.signal.SIGTERM:
+            _reaped["handler"] = fn
+        return None
+
+    battery.signal.signal = _capture_signal
+    try:
+        battery._install_restore_on_signal()
+    finally:
+        battery.signal.signal = _real_signal
+    _h = _reaped.get("handler")
+    if _h is None:
+        failures.append("cancellation reaps the lane before restoring — no SIGTERM handler installed")
+    else:
+        _real_kill, battery.os.kill = battery.os.kill, lambda *a, **k: None
+        try:
+            _h(battery.signal.SIGTERM, None)
+        finally:
+            battery.os.kill = _real_kill
+        if _order[:2] != ["reap", "restore"]:
+            failures.append("cancellation reaps the lane before restoring — order was "
+                            f"{_order} rather than ['reap', 'restore']")
+        else:
+            print("  ok  cancellation reaps the lane before restoring")
+finally:
+    battery._reap_active_lane = _real_reap
+    battery._restore_active = _real_restore
+
+# A binary resource under Sources/ is a bad RECIPE, not a broken battery: read_text on a .wav raises
+# UnicodeDecodeError, which is a ValueError, so an OSError-only guard misses it and the unattended
+# command emits a traceback with exit 1 — the status reserved for a SURVIVED row.
+ran += 1
+with tempfile.TemporaryDirectory() as td:
+    _t = Path(td) / "resource.wav"
+    _t.write_bytes(b"\x00\xff\xfe RIFF not text at all \x00")
+    try:
+        battery.read_recipe_target(_t, "a binary target")
+        failures.append("a binary target is refused, not a traceback — it was ACCEPTED")
+    except battery.Refusal as exc:
+        if "is not text" not in str(exc):
+            failures.append(f"a binary target is refused, not a traceback — wrong message: {exc}")
+        else:
+            print("  ok  a binary target is refused, not a traceback")
+    except Exception as exc:
+        failures.append("a binary target is refused, not a traceback — it raised "
+                        f"{type(exc).__name__} instead of Refusal")
+
+# The accepted counterpart, so the helper is not simply rejecting everything.
+ran += 1
+with tempfile.TemporaryDirectory() as td:
+    _t = Path(td) / "ok.swift"
+    _t.write_text("let x = 1\n")
+    try:
+        assert battery.read_recipe_target(_t, "a text target") == "let x = 1\n"
+        print("  ok  an ordinary text target still reads")
+    except Exception as exc:
+        failures.append(f"an ordinary text target still reads — it did not: {exc}")
+
+# `expect_fail` is matched on test IDENTITY, not as a substring of the ✘ line. The line carries the
+# display name, the source path AND the expectation message, so substring matching produced three
+# false-CAUGHT paths — each of these is one of them, and each would have scored CAUGHT before.
+for _label, _lines, _expect, _want in [
+    ("a sibling whose name CONTAINS the expected one is not a match",
+     ['✘ Test "the guard holds under load" recorded an issue at F.swift:1:1'],
+     "the guard holds", False),
+    ("the expected test itself IS a match",
+     ['✘ Test "the guard holds" recorded an issue at F.swift:1:1'],
+     "the guard holds", True),
+    ("a match inside another test's MESSAGE does not count",
+     ['✘ Test "some other case" recorded an issue at F.swift:1:1: Expectation failed: budget == 3'],
+     "budget", False),
+    ("a match inside a FILE PATH does not count",
+     ['✘ Test "some other case" recorded an issue at BudgetTests.swift:1:1'],
+     "BudgetTests", False),
+    ("a SUITE verdict is never evidence about one test",
+     ['✘ Suite "LanguageLockDefaultCodeTests" failed after 0.1 seconds.'],
+     "LanguageLockDefaultCodeTests", False),
+    ("the bare function-name form is a match",
+     ['✘ Test unsupportedLegacyCodeIsNotResurrected() recorded an issue at F.swift:1:1'],
+     "unsupportedLegacyCodeIsNotResurrected", True),
+    ("a suite line alongside the real failure still resolves to the test",
+     ['✘ Suite "FooTests" failed after 0.1 seconds.',
+      '✘ Test "the guard holds" recorded an issue at F.swift:1:1'],
+     "the guard holds", True),
+]:
+    ran += 1
+    _got = _expect in battery.failed_test_identities(_lines)
+    if _got != _want:
+        failures.append(f"{_label}: matched={_got}, wanted {_want}")
+    else:
+        print(f"  ok  {_label}")
+
+# Only Swift is a mutation target. Sources/ also holds plists, strings, JSON and docs — readable text
+# the allow-list accepts, and nothing a filtered Swift lane executes, so such a row reports SURVIVED
+# however good the test is.
+check("a non-Swift text target under Sources/ is refused",
+      [dict(VALID_ROW, file="Sources/Info.plist")],
+      expect_exit=2, expect_text="which is not Swift",
+      extra_files={"Sources/Info.plist": "<plist/>\n"})
+
+# The accepted counterpart is VALID_ROW itself (Sources/Thing.swift), already covered above.
+
+# The leftover-backup preflight globs case-sensitively; the default APFS volume does not. A `.MUTBAK`
+# would be invisible to it and then silently overwritten and unlinked by a row.
+check("a leftover backup in different case is still caught",
+      [dict(VALID_ROW)], expect_exit=2, expect_text="did not restore",
+      extra_files={"Sources/Thing.swift.MUTBAK": "let guarded = true\n"})
+
+# A failed restore must STOP the run. Continuing means the next row on that file backs up the MUTATED
+# file as its own baseline, so every later row runs sabotaged code — the 8/8-CAUGHT incident
+# reproduced mid-run, where the pre-run clean-tree control cannot see it.
+ran += 1
+_real_cmp = battery.filecmp.cmp
+battery.filecmp.cmp = lambda a, b, shallow=True: False
+_lanes = []
+with tempfile.TemporaryDirectory() as _td:
+    _tmp = make_tree(Path(_td))
+    _recipes = _tmp / "r.json"
+    # TWO rows: with one, the loop ends whether it stopped or finished, so the case could not tell
+    # the difference. The second row running is the observable consequence of NOT stopping.
+    _recipes.write_text(json.dumps({"rows": [dict(VALID_ROW, label="first"),
+                                             dict(VALID_ROW, label="second")]}))
+
+    class _CountingLane:
+        def __init__(self, *a, **k):
+            pass
+
+        def generate_once(self):
+            pass
+
+        def run_suite(self, suite, tag):
+            _lanes.append(tag)
+            return (5, ['✘ Test "the guard holds" recorded an issue'], True, "log", 65, 3.0)
+
+    _rl, _rb = battery.Lane, battery.baseline
+    battery.Lane, battery.baseline = _CountingLane, (lambda lane, suites, phase: [])
+    _buf = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(_buf), contextlib.redirect_stderr(_buf):
+            _rc = battery.main(["--recipes", str(_recipes), "--worktree", str(_tmp)])
+    finally:
+        battery.Lane, battery.baseline = _rl, _rb
+        battery.filecmp.cmp = _real_cmp
+    _out = _buf.getvalue()
+    if "RESTORE FAILED" not in _out:
+        failures.append("a failed restore stops the run — it was not even reported")
+    elif len(_lanes) != 1:
+        failures.append("a failed restore stops the run — it did NOT: row 2 ran anyway "
+                        f"(lanes: {_lanes}), so it would have backed up a MUTATED file")
+    elif _rc != 1:
+        failures.append(f"a failed restore stops the run — exit {_rc}, wanted 1")
+    else:
+        print("  ok  a failed restore stops the run")
+
+# Any exception in the row body must fail THAT ROW, not abort before the closing baseline — the check
+# that proves the tree came back. PermissionError on a read-only target is the reproducible case.
+# NOTE ON AIM: raising from the LANE cannot prove the broad catch — the row loop converts any lane
+# exception to _RowFailed first, so it never reaches `except Exception`. This raises from the WRITE,
+# which is outside that conversion and is the reproducible case (a read-only target).
+ran += 1
+_real_wt = Path.write_text
+
+
+def _boom(self, *a, **k):
+    # ONLY the mutation write to the target itself. Patching every .swift write breaks make_tree's
+    # fixture setup, and matching on the replacement TEXT also trips on the recipe JSON that contains
+    # it as data — both are different failures wearing this case's name.
+    if self.name == "Thing.swift" and a and "guarded = false" in str(a[0]):
+        raise PermissionError("read-only file system")
+    return _real_wt(self, *a, **k)
+
+
+try:
+    Path.write_text = _boom
+    try:
+        _rc, _out, _after, _during = drive_row((5, [], True, "log", 0, 3.0),
+                                               expect_verdict=None, expect_detail=None)
+    except BaseException as _esc:   # noqa: BLE001 — an escape IS the defect this case exists for
+        _rc, _out = -1, f"escaped as {type(_esc).__name__}"
+    if "ERR" not in _out or "PermissionError" not in _out:
+        failures.append("an unexpected exception fails the row rather than aborting the run — it did "
+                        f"not: {_out.strip()[:200]}")
+    elif _rc != 1:
+        failures.append(f"an unexpected exception fails the row rather than aborting the run — "
+                        f"exit {_rc}, wanted 1")
+    else:
+        print("  ok  an unexpected exception fails the row rather than aborting the run")
+finally:
+    Path.write_text = _real_wt
 
 print()
 if failures:

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -77,6 +77,20 @@ ONLY_ACTIVE = [l for l in CANONICAL_STUB.split("\n") if "ONLY_ACTIVE_ARCH" in l]
 assert ONLY_ACTIVE in CANONICAL_STUB, "the stub line the drift cases edit must exist verbatim"
 
 
+def _stub_baseline(lane, suites, phase, seen_names=None):
+    """Stands in for the real baseline in stubbed-lane cases.
+
+    It MUST populate `seen_names`: the runner refuses when a suite's baseline yielded no test
+    identities, because an empty set means the reader broke rather than the suite being empty. A stub
+    that returned green without names would make every stubbed case hit that refusal — and weakening
+    the check to suit the stub would delete the guard the check exists to be.
+    """
+    if seen_names is not None:
+        for suite in suites:
+            seen_names[suite] = {VALID_ROW["expect_fail"], "some other case"}
+    return []
+
+
 def make_tree(tmp: Path):
     (tmp / "Sources").mkdir(parents=True, exist_ok=True)
     (tmp / "Sources" / "Thing.swift").write_text("let guarded = true\n")
@@ -549,7 +563,7 @@ def drive_row(lane_result, *, expect_verdict, expect_detail, raise_instead=None)
 
         real_lane, real_baseline = battery.Lane, battery.baseline
         battery.Lane = StubLane
-        battery.baseline = lambda lane, suites, phase, seen_names=None: []
+        battery.baseline = _stub_baseline
         buf = io.StringIO()
         try:
             with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(buf):
@@ -640,7 +654,7 @@ with _t3.TemporaryDirectory() as td:
             return (5, ['✘ Test "the guard holds" recorded an issue'], True, "log", 65, 3.0)
 
     _rl, _rb = battery.Lane, battery.baseline
-    battery.Lane, battery.baseline = _StubLane, (lambda lane, suites, phase, seen_names=None: [])
+    battery.Lane, battery.baseline = _StubLane, (_stub_baseline)
     try:
         import io as _io2, contextlib as _cl2
         with _cl2.redirect_stdout(_io2.StringIO()), _cl2.redirect_stderr(_io2.StringIO()):
@@ -729,7 +743,7 @@ with tempfile.TemporaryDirectory() as td:
             raise battery._LaneTimedOut("the lane ran past 1800s and was killed")
 
     _rl, _rb = battery.Lane, battery.baseline
-    battery.Lane, battery.baseline = _HangingLane, (lambda lane, suites, phase, seen_names=None: [])
+    battery.Lane, battery.baseline = _HangingLane, (_stub_baseline)
     try:
         import io as _io3, contextlib as _cl3
         _buf = _io3.StringIO()
@@ -903,14 +917,19 @@ class _ProbeLane:
 
 
 _rl, _rb = battery.Lane, battery.baseline
-battery.Lane, battery.baseline = _ProbeLane, (lambda lane, suites, phase, seen_names=None: [])
+battery.Lane, battery.baseline = _ProbeLane, (_stub_baseline)
 try:
     with tempfile.TemporaryDirectory() as td:
         tmp = make_tree(Path(td))
         recipes = tmp / "r.json"
         recipes.write_text(json.dumps({"rows": [dict(VALID_ROW)]}))
-        with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
-            battery.main(["--recipes", str(recipes), "--worktree", str(tmp), "--dry-run"])
+        try:
+            with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+                battery.main(["--recipes", str(recipes), "--worktree", str(tmp), "--dry-run"])
+        except BaseException as _esc:  # noqa: BLE001
+            # Name this case rather than letting the traceback kill the suite. An escape here stops
+            # every LATER case from reporting, so a mutation control reads them all as silent.
+            _seen["escaped"] = type(_esc).__name__
 finally:
     battery.Lane, battery.baseline = _rl, _rb
     if _env_before is None:
@@ -918,7 +937,10 @@ finally:
     else:
         _os_env.environ["DERIVED_DATA_PATH"] = _env_before
 
-if _seen.get("derived") != _probe:
+if _seen.get("escaped"):
+    failures.append("the battery honours DERIVED_DATA_PATH like the canonical lane — the run escaped "
+                    f"as {_seen['escaped']} before it could be checked")
+elif _seen.get("derived") != _probe:
     failures.append("the battery honours DERIVED_DATA_PATH like the canonical lane — it does NOT: "
                     f"used {_seen.get('derived')!r} instead of {_probe!r}")
 else:
@@ -1195,7 +1217,7 @@ with tempfile.TemporaryDirectory() as _td:
             return (5, ['✘ Test "the guard holds" recorded an issue'], True, "log", 65, 3.0)
 
     _rl, _rb = battery.Lane, battery.baseline
-    battery.Lane, battery.baseline = _CountingLane, (lambda lane, suites, phase, seen_names=None: [])
+    battery.Lane, battery.baseline = _CountingLane, (_stub_baseline)
     _buf = io.StringIO()
     try:
         with contextlib.redirect_stdout(_buf), contextlib.redirect_stderr(_buf):
@@ -1330,8 +1352,15 @@ try:
         tmp = make_tree(Path(td))
         recipes = tmp / "r.json"
         recipes.write_text(json.dumps({"rows": [dict(VALID_ROW)]}))
-        with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
-            battery.main(["--recipes", str(recipes), "--worktree", str(tmp), "--dry-run"])
+        try:
+            with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+                battery.main(["--recipes", str(recipes), "--worktree", str(tmp), "--dry-run"])
+        except BaseException as _esc:  # noqa: BLE001
+            # Name this case rather than letting a traceback kill the suite: an escape here
+            # stops every LATER case reporting, so a mutation control reads them as silent.
+            failures.append("cancellation handlers are installed before any lane can start "
+                            f"— the run escaped as {type(_esc).__name__}")
+            _installed_at.append('escaped')
 finally:
     battery.signal.signal = _real_sig
     battery.baseline = _real_base
@@ -1441,6 +1470,41 @@ try:
         print("  ok  an unreadable log yields no names rather than raising")
 except Exception as exc:
     failures.append(f"an unreadable log yields no names rather than raising — it raised {exc}")
+
+# An EMPTY identity set is not a pass. If the log is unreadable, or Swift Testing's output stops
+# matching the pattern, we have no evidence the named test exists — and skipping the check restores
+# exactly the false-SURVIVED it was added to stop. A suite that ran at least one test always prints
+# identity lines, so empty means the READER broke.
+ran += 1
+_real_base2 = battery.baseline
+battery.baseline = lambda lane, suites, phase, seen_names=None: []   # green, but yields NO names
+_rl2, battery.Lane = battery.Lane, type("L", (), {
+    "__init__": lambda self, *a, **k: None,
+    "generate_once": lambda self: None,
+    "run_suite": lambda self, suite, tag: (1, [], True, "log", 0, 1.0),
+})
+try:
+    with tempfile.TemporaryDirectory() as td:
+        tmp = make_tree(Path(td))
+        recipes = tmp / "r.json"
+        recipes.write_text(json.dumps({"rows": [dict(VALID_ROW)]}))
+        _buf = io.StringIO()
+        try:
+            with contextlib.redirect_stdout(_buf), contextlib.redirect_stderr(_buf):
+                _rc = battery.main(["--recipes", str(recipes), "--worktree", str(tmp)])
+        except BaseException as _esc:  # noqa: BLE001 — escaping IS a way this guard can be broken
+            _rc, _out = -1, f"escaped as {type(_esc).__name__}"
+        else:
+            _out = _buf.getvalue()
+finally:
+    battery.baseline = _real_base2
+    battery.Lane = _rl2
+
+if _rc != 2 or "could not read any test names" not in _out:
+    failures.append("unreadable baseline names refuse the run — they did NOT: "
+                    f"exit {_rc}, output {_out.strip()[:200]}")
+else:
+    print("  ok  unreadable baseline names refuse the run")
 
 print()
 if failures:

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -242,6 +242,20 @@ check("a missing canonical script refuses the run",
 # A recipe arrives from an issue body, which is data someone else wrote. It may not reach out of
 # the worktree — an absolute path, a `..`, or a symlink would otherwise have the battery back up,
 # mutate and restore a file it was never scoped to.
+# `generate_once` reuses one generated project for every row, which is only sound while a mutation
+# changes file CONTENT rather than the project's SHAPE. A recipe targeting a Tuist input would leave
+# xcodebuild consuming the clean baseline's .xcodeproj, so the row reports SURVIVED about a mutant the
+# build never saw. A doc comment asserted this precondition from the start; nothing enforced it.
+for _t in ("Project.swift", "Tuist/Config.swift", "Package.swift"):
+    check(f"a recipe targeting {_t} is refused as out of scope",
+          [dict(VALID_ROW, file=_t)],
+          expect_exit=2, expect_text="the generated Xcode project is BUILT FROM")
+
+# The accepted counterpart: an ordinary Sources file with a similar-looking name must still pass.
+check("a Sources file whose name merely resembles a Tuist input is accepted",
+      [dict(VALID_ROW, file="Sources/Thing.swift")],
+      expect_exit=0, expect_text="1 row(s) well-formed")
+
 check("an absolute target path is refused",
       [dict(VALID_ROW, file="/etc/hosts")],
       expect_exit=2, expect_text="must be repo-relative")

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -35,8 +35,13 @@ ran = 0
 # the code under test. The real check gets its own two-way case below, driven directly.
 import os as _os_env  # noqa: E402
 
-NEUTRAL_ENV = dict(_os_env.environ,
-                   EW_BATTERY_DEV_APP_PATTERN="ew-battery-self-test-matches-nothing")
+NEUTRAL_PATTERN = "ew-battery-self-test-matches-nothing"
+NEUTRAL_ENV = dict(_os_env.environ, EW_BATTERY_DEV_APP_PATTERN=NEUTRAL_PATTERN)
+# Set it in THIS process too, before the module is imported below. The subprocess cases get NEUTRAL_ENV
+# explicitly; the in-process cases read the module's own DEV_APP_PATTERN, which is resolved at import.
+# Without this the stubbed-lane rows fail whenever any session on the box has a dev app open — measured
+# exactly that way when a peer took the slot mid-suite.
+_os_env.environ["EW_BATTERY_DEV_APP_PATTERN"] = NEUTRAL_PATTERN
 
 
 # Mirrors the real scripts/xcode-test.sh closely enough for the drift guard to parse. Kept in this
@@ -249,7 +254,7 @@ check("a missing canonical script refuses the run",
 for _t in ("Project.swift", "Tuist/Config.swift", "Package.swift"):
     check(f"a recipe targeting {_t} is refused as out of scope",
           [dict(VALID_ROW, file=_t)],
-          expect_exit=2, expect_text="the generated Xcode project is BUILT FROM")
+          expect_exit=2, expect_text="which is outside Sources/")
 
 # The accepted counterpart: an ordinary Sources file with a similar-looking name must still pass.
 check("a Sources file whose name merely resembles a Tuist input is accepted",
@@ -260,9 +265,15 @@ check("an absolute target path is refused",
       [dict(VALID_ROW, file="/etc/hosts")],
       expect_exit=2, expect_text="must be repo-relative")
 
-check("a target escaping the worktree with .. is refused",
-      [dict(VALID_ROW, file="../outside.swift")],
+# Deliberately starts with Sources/ so it passes the allow-list and reaches the containment check —
+# otherwise the allow-list would catch it first and this case would silently stop testing containment.
+check("a target escaping the worktree via .. inside an allowed root is refused",
+      [dict(VALID_ROW, file="Sources/../../outside.swift")],
       expect_exit=2, expect_text="resolves OUTSIDE the worktree")
+
+check("a target outside the allowed roots is refused before containment is even considered",
+      [dict(VALID_ROW, file="../outside.swift")],
+      expect_exit=2, expect_text="which is outside Sources/")
 
 # exit 1 means "a row survived". A missing recipe file must never be able to produce it.
 ran += 1
@@ -606,6 +617,29 @@ with _t3.TemporaryDirectory() as td:
     else:
         print("  ok  a restored file is stamped NOW, so the next build cannot reuse mutant objects")
 
+# Preflight is a snapshot; an overnight battery is long. A dev app that starts after preflight and
+# stops before the closing baseline corrupts the AppLogger tests only DURING a mutant, which credits
+# the sabotage with a failure something else caused — a false CAUGHT, failing toward confidence.
+ran += 1
+_real_pids = battery.dev_app_pids
+battery.dev_app_pids = lambda wt: ["99999"]
+try:
+    rc, out, after, during = drive_row((5, [], True, "log", 0, 3.0),
+                                       expect_verdict=None, expect_detail=None)
+    problems = []
+    if "ERR" not in out or "appeared mid-run" not in out:
+        problems.append(f"row should ERROR naming the intruder; got: {out.strip()[:200]}")
+    if rc != 1:
+        problems.append(f"exit {rc}, wanted 1")
+    if after != ORIGINAL:
+        problems.append(f"file not restored: {after!r}")
+    if problems:
+        failures.append("a dev app appearing mid-run fails that row: " + "; ".join(problems))
+    else:
+        print("  ok  a dev app appearing mid-run fails that row")
+finally:
+    battery.dev_app_pids = _real_pids
+
 check_row("the file is restored even when the lane raises mid-row",
           None, expect_marker="ERR", expect_rc=1, raise_instead=RuntimeError("lane exploded"))
 
@@ -781,6 +815,30 @@ for _label, _rc, _out, _want in [
         failures.append(f"{_label}: refused={_refused}, wanted {_want}")
     else:
         print(f"  ok  {_label}")
+
+# The drift guard compares CANONICAL_TOKENS against scripts/xcode-test.sh. Nothing compared it against
+# the command this runner ACTUALLY issues — so reconciling the constant after an upstream change while
+# forgetting the command would leave the guard green and the battery building differently. That is the
+# guard's own failure mode, one level in.
+ran += 1
+_cmd = battery.Lane(Path("/tmp"), Path("/tmp/dd"), Path("/tmp/logs")).build_command("T/S")
+_missing = sorted(t for t in battery.CANONICAL_TOKENS if t not in _cmd)
+if _missing:
+    failures.append("every CANONICAL_TOKEN appears in the command this runner actually issues — it "
+                    "does NOT: the command is missing " + ", ".join(_missing))
+else:
+    print("  ok  every CANONICAL_TOKEN appears in the command this runner actually issues")
+
+ran += 1
+_flagish = {a for a in _cmd if a.startswith("-") and not a.startswith("-only-testing")
+            and a not in ("-project", "-scheme", "-configuration", "-derivedDataPath", "-destination")}
+_settings = {a for a in _cmd if "=" in a and a.split("=", 1)[0].isupper()}
+_extra = sorted((_flagish | _settings) - battery.CANONICAL_TOKENS)
+if _extra:
+    failures.append("the runner's command carries no setting the drift guard is blind to — it DOES: "
+                    + ", ".join(_extra) + " would move unnoticed")
+else:
+    print("  ok  the runner's command carries no setting the drift guard is blind to")
 
 print()
 if failures:

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -549,7 +549,7 @@ def drive_row(lane_result, *, expect_verdict, expect_detail, raise_instead=None)
 
         real_lane, real_baseline = battery.Lane, battery.baseline
         battery.Lane = StubLane
-        battery.baseline = lambda lane, suites, phase: []
+        battery.baseline = lambda lane, suites, phase, seen_names=None: []
         buf = io.StringIO()
         try:
             with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(buf):
@@ -640,7 +640,7 @@ with _t3.TemporaryDirectory() as td:
             return (5, ['✘ Test "the guard holds" recorded an issue'], True, "log", 65, 3.0)
 
     _rl, _rb = battery.Lane, battery.baseline
-    battery.Lane, battery.baseline = _StubLane, (lambda lane, suites, phase: [])
+    battery.Lane, battery.baseline = _StubLane, (lambda lane, suites, phase, seen_names=None: [])
     try:
         import io as _io2, contextlib as _cl2
         with _cl2.redirect_stdout(_io2.StringIO()), _cl2.redirect_stderr(_io2.StringIO()):
@@ -729,7 +729,7 @@ with tempfile.TemporaryDirectory() as td:
             raise battery._LaneTimedOut("the lane ran past 1800s and was killed")
 
     _rl, _rb = battery.Lane, battery.baseline
-    battery.Lane, battery.baseline = _HangingLane, (lambda lane, suites, phase: [])
+    battery.Lane, battery.baseline = _HangingLane, (lambda lane, suites, phase, seen_names=None: [])
     try:
         import io as _io3, contextlib as _cl3
         _buf = _io3.StringIO()
@@ -903,7 +903,7 @@ class _ProbeLane:
 
 
 _rl, _rb = battery.Lane, battery.baseline
-battery.Lane, battery.baseline = _ProbeLane, (lambda lane, suites, phase: [])
+battery.Lane, battery.baseline = _ProbeLane, (lambda lane, suites, phase, seen_names=None: [])
 try:
     with tempfile.TemporaryDirectory() as td:
         tmp = make_tree(Path(td))
@@ -1195,7 +1195,7 @@ with tempfile.TemporaryDirectory() as _td:
             return (5, ['✘ Test "the guard holds" recorded an issue'], True, "log", 65, 3.0)
 
     _rl, _rb = battery.Lane, battery.baseline
-    battery.Lane, battery.baseline = _CountingLane, (lambda lane, suites, phase: [])
+    battery.Lane, battery.baseline = _CountingLane, (lambda lane, suites, phase, seen_names=None: [])
     _buf = io.StringIO()
     try:
         with contextlib.redirect_stdout(_buf), contextlib.redirect_stderr(_buf):
@@ -1312,7 +1312,7 @@ _installed_at = []
 _real_sig = battery.signal.signal
 _real_base = battery.baseline
 battery.signal.signal = lambda sig, fn: _installed_at.append("handler")
-battery.baseline = lambda lane, suites, phase: (_installed_at.append(f"baseline-{phase}"), [])[1]
+battery.baseline = lambda lane, suites, phase, seen_names=None: (_installed_at.append(f"baseline-{phase}"), [])[1]
 
 
 class _NullLane:
@@ -1401,6 +1401,46 @@ elif not _seen_mask.get("restored"):
                     "never restored, so the caller's mask was widened")
 else:
     print("  ok  the handled signals are blocked across spawn-and-register")
+
+# `expect_fail` is matched on the FULL test name. A recipe naming a PREFIX used to match nothing, so
+# the row reported SURVIVED and the report said "this test is not the guard" about a test that failed
+# exactly as intended. Measured on a peer's recipe: 3 of 8 rows false-SURVIVED, all prefixes.
+ran += 1
+_log = Path(tempfile.mkdtemp(prefix="ew-battery-names-")) / "l.log"
+_log.write_text(
+    '✔ Test "Availability says On this Mac for what is installed and Available from Apple" passed\n'
+    '✘ Test "A build that cannot run the engine says so, not that a download is needed" recorded\n'
+    "✔ Test bareFunctionName() passed after 0.1 seconds.\n"
+)
+_names = battery.suite_test_names(_log)
+_want = {
+    "Availability says On this Mac for what is installed and Available from Apple",
+    "A build that cannot run the engine says so, not that a download is needed",
+    "bareFunctionName",
+}
+if _names != _want:
+    failures.append(f"the baseline's test names are enumerated from both outcomes — got {_names}")
+else:
+    print("  ok  the baseline's test names are enumerated from both outcomes")
+
+# A prefix must NOT be treated as a match — that is the false-CAUGHT bug this replaced.
+ran += 1
+_prefix = "Availability says On this Mac for what is installed"
+if _prefix in _names:
+    failures.append("a prefix is not a matching test name — it was treated as one")
+else:
+    print("  ok  a prefix is not a matching test name")
+
+# An unreadable log yields no names rather than raising, so the check degrades to not-refusing rather
+# than crashing a run that was otherwise fine.
+ran += 1
+try:
+    if battery.suite_test_names(Path("/nonexistent/nope.log")) != set():
+        failures.append("an unreadable log yields no names — it returned something else")
+    else:
+        print("  ok  an unreadable log yields no names rather than raising")
+except Exception as exc:
+    failures.append(f"an unreadable log yields no names rather than raising — it raised {exc}")
 
 print()
 if failures:

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -906,6 +906,41 @@ if _seen.get("derived") != _probe:
 else:
     print("  ok  the battery honours DERIVED_DATA_PATH like the canonical lane")
 
+# The dev-app refusal exists because concurrent app-log writes corrupt the AppLogger tests. That
+# reasoning is entirely about RUNNING tests, so a validation pass — which runs no lane and mutates
+# nothing — must not be refused for a condition that cannot affect it. Measured when a peer's UAT app
+# blocked a read-only recipe check.
+for _label, _will_run, _want_refusal in [
+    ("a run that WILL execute tests still refuses while a dev app is up", True, True),
+    ("a validate-only pass is NOT refused for a dev app it cannot be affected by", False, False),
+]:
+    ran += 1
+    _real_run3 = battery.run
+    # Report a live dev app whatever is asked, so the only variable is whether preflight consults it.
+    battery.run = lambda cmd, cwd, log_path=None, timeout=None: (0, "43962\n")
+    _real_canon = battery.check_canonical_settings
+    battery.check_canonical_settings = lambda wt: None
+    # The suite neutralises check_no_dev_app globally (line ~347) so unrelated cases do not depend on
+    # what else is running on the box. This case is ABOUT that check, so put the real one back.
+    _neutralised = battery.check_no_dev_app
+    battery.check_no_dev_app = _REAL_CHECK_NO_DEV_APP
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            _tmp = make_tree(Path(td))
+            try:
+                battery.preflight(_tmp, will_run_tests=_will_run)
+                _got = False
+            except battery.Refusal as exc:
+                _got = "A dev app is running" in str(exc)
+    finally:
+        battery.run = _real_run3
+        battery.check_canonical_settings = _real_canon
+        battery.check_no_dev_app = _neutralised
+    if _got != _want_refusal:
+        failures.append(f"{_label}: refused={_got}, wanted {_want_refusal}")
+    else:
+        print(f"  ok  {_label}")
+
 print()
 if failures:
     print(f"{len(failures)} of {ran} FAILED:")

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -31,18 +31,31 @@ failures = []
 ran = 0
 
 
+CANONICAL_STUB = """#!/usr/bin/env bash
+PROJECT="EnviousWispr.xcodeproj"
+DEBUG_SCHEME="EnviousWispr"
+DEST='platform=macOS,arch=arm64'
+TEST_ARGS=(-only-testing:"$FILTER")
+ARCHS=arm64 VALID_ARCHS=arm64 ONLY_ACTIVE_ARCH=YES
+"""
+
+
 def make_tree(tmp: Path):
     (tmp / "Sources").mkdir(parents=True, exist_ok=True)
     (tmp / "Sources" / "Thing.swift").write_text("let guarded = true\n")
+    (tmp / "scripts").mkdir(parents=True, exist_ok=True)
+    (tmp / "scripts" / "xcode-test.sh").write_text(CANONICAL_STUB)
     return tmp
 
 
-def check(name, rows, *, expect_exit, expect_text=None, extra_files=None, top=None):
+def check(name, rows, *, expect_exit, expect_text=None, extra_files=None, top=None, remove=None):
     """Run --validate-only against a throwaway tree and assert the exit code and message."""
     global ran
     ran += 1
     with tempfile.TemporaryDirectory() as td:
         tmp = make_tree(Path(td))
+        for rel in (remove or []):
+            (tmp / rel).unlink()
         for rel, body in (extra_files or {}).items():
             p = tmp / rel
             p.parent.mkdir(parents=True, exist_ok=True)
@@ -114,6 +127,17 @@ check("a non-unique anchor is refused",
       [dict(VALID_ROW, anchor="x")],
       expect_exit=2, expect_text="must be unique",
       extra_files={"Sources/Thing.swift": "let x = 1\nlet y = x + x\n"})
+
+# The runner reproduces scripts/xcode-test.sh's build settings rather than shelling out to it. That
+# buys two sources of truth, so drift must be loud: if the canonical script stops carrying a setting
+# this runner reproduces, the battery refuses rather than measuring a differently-configured build.
+check("a canonical script that has drifted refuses the run",
+      [dict(VALID_ROW)], expect_exit=2, expect_text="differently-configured build",
+      extra_files={"scripts/xcode-test.sh": "#!/usr/bin/env bash\n# settings removed\n"})
+
+check("a missing canonical script refuses the run",
+      [dict(VALID_ROW)], expect_exit=2, expect_text="cannot confirm it is building the same thing",
+      remove=["scripts/xcode-test.sh"])
 
 # --- flag-combination guard -----------------------------------------------------------------------
 ran += 1

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -941,6 +941,84 @@ for _label, _will_run, _want_refusal in [
     else:
         print(f"  ok  {_label}")
 
+# Swift Testing prints ✘ for a KNOWN issue and the lane still exits 0. A test wrapped in
+# `withKnownIssue` is explicitly configured NOT to go red, so crediting it with detecting a mutation
+# is a false CAUGHT — the direction that fails toward confidence.
+check_row("a known issue on a GREEN lane is SURVIVED, never CAUGHT",
+          (5, ['✘ Test "the guard holds" recorded a known issue'], True, "log", 0, 3.0),
+          expect_marker="SURV", expect_rc=1)
+
+# The exclusion's own case: a RED lane where the ONLY mention of the named test is a known issue. If
+# known-issue lines counted as failures this would score CAUGHT; excluded, the row is correctly not a
+# catch — something else made the lane red. The rc gate cannot cover this one, because the lane IS red.
+# The exclusion itself, driven directly. The stubbed-lane cases replace run_suite wholesale, so
+# anything parsed inside it is unreachable from them — a case aimed there passes while testing nothing.
+ran += 1
+_out = (
+    "Test run with 5 tests\n"
+    '✘ Test "the guard holds" recorded a known issue\n'
+    '✘ Test "some other case" recorded an issue\n'
+)
+_c, _f = battery.classify_lane_output(_out)
+if _c != 5:
+    failures.append(f"a known issue is not counted as a real failure — wrong count {_c}")
+elif any("the guard holds" in ln for ln in _f):
+    failures.append("a known issue is not counted as a real failure — it WAS: a withKnownIssue line "
+                    "reached the failure list, so a test told to tolerate the break would be credited")
+elif not any("some other case" in ln for ln in _f):
+    failures.append("a known issue is not counted as a real failure — but a REAL failure was dropped")
+else:
+    print("  ok  a known issue is not counted as a real failure")
+
+# The accepted counterpart: the same named test on a RED lane is a genuine catch.
+check_row("the same named test on a RED lane is still CAUGHT",
+          (5, ['✘ Test "the guard holds" recorded an issue'], True, "log", 65, 3.0),
+          expect_marker="ok", expect_rc=0)
+
+# A timeout must kill the whole process GROUP. xcodebuild spawns the test runner as a descendant, so
+# killing only the parent leaves a hung mutant test process holding the shared DerivedData and writing
+# logs while later rows run — corrupting their verdicts after the source has been restored.
+ran += 1
+import subprocess as _sp, os as _os2, time as _t2
+# A UNIQUE path per run, and a SELF-TERMINATING child. Both matter: a mutation control on this very
+# guard breaks the group kill by design, which leaks the descendant — it reparents to init and keeps
+# writing forever. With a shared path that orphan then fails this case on every LATER run, so the test
+# reports a broken guard about code that is fine. Measured exactly that way. The bounded loop caps a
+# leaked orphan's life at ~10s; the unique path means it cannot poison anyone else meanwhile.
+_probe = Path(tempfile.mkdtemp(prefix="ew-battery-groupkill-")) / "probe"
+try:
+    # The child must NOT inherit the pipe: communicate() waits for every writer to close it, so an
+    # inherited stdout makes the post-kill wait last as long as the child does — which masks exactly
+    # the defect under test. Redirected, so the wait returns as soon as the parent is gone.
+    # The loop is bounded so a leaked orphan expires (the control breaks this guard by design, which
+    # leaks one), but LONGER than the sampling window below, or the child would finish on its own and
+    # the case would pass whether or not the group was killed. The finally sweeps any survivor.
+    battery.run(["/bin/sh", "-c",
+                 f"(for _ in $(seq 1 200); do echo x >> {_probe}; sleep 0.2; done >/dev/null 2>&1 &) ; "
+                 f"sleep 30"],
+                cwd=tempfile.gettempdir(), timeout=2)
+    failures.append("a timeout kills the whole process group — run() did not even time out")
+except _sp.TimeoutExpired:
+    _t2.sleep(1.0)
+    _size_after_kill = _probe.stat().st_size if _probe.exists() else 0
+    _t2.sleep(1.0)
+    _size_later = _probe.stat().st_size if _probe.exists() else 0
+    if _size_later != _size_after_kill:
+        failures.append("a timeout kills the whole process group, not just the direct child — it does "
+                        f"NOT: a descendant kept writing after the kill ({_size_after_kill} then "
+                        f"{_size_later} bytes)")
+    else:
+        print("  ok  a timeout kills the whole process group, not just the direct child")
+finally:
+    # Sweep any descendant that outlived the run — guaranteed to exist whenever the control breaks the
+    # group kill, and it would otherwise reparent to init and outlive the suite.
+    _sp.run(["pkill", "-9", "-f", str(_probe)], capture_output=True)
+    _probe.unlink(missing_ok=True)
+    try:
+        _probe.parent.rmdir()
+    except OSError:
+        pass
+
 print()
 if failures:
     print(f"{len(failures)} of {ran} FAILED:")

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -38,6 +38,8 @@ PROJECT="EnviousWispr.xcodeproj"
 DEBUG_SCHEME="EnviousWispr"
 DEST='platform=macOS,arch=arm64'
 TEST_ARGS=(-only-testing:"$FILTER")
+DERIVED_DATA="${DERIVED_DATA_PATH:-$PROJECT_ROOT/.derivedData/Test}"
+mise x tuist@4.195.11 -- tuist generate --no-open
 run_lane() {
   xcodebuild test \\
     -project "$PROJECT" \\
@@ -51,6 +53,7 @@ run_lane() {
     "$@" \\
     "${TEST_ARGS[@]}" | tee "$PROJECT_ROOT/$log"
 }
+run_lane "$DEBUG_SCHEME" Debug build/xcode-test-debug.log
 """
 
 # The exact line the two directional drift cases add to or remove from the stub. Derived from the
@@ -167,6 +170,23 @@ check("a canonical script that ADDED a setting refuses the run",
       extra_files={"scripts/xcode-test.sh": CANONICAL_STUB.replace(
           ONLY_ACTIVE, ONLY_ACTIVE + "    ENABLE_TESTABILITY=YES \\\\\n")})
 
+# Each of these is the drift class at an axis the first two review rounds did not reach. Enumerated
+# rather than waited for: two rounds of one shape is the signal to sweep the whole class yourself.
+check("a canonical Debug call site switched to Release refuses the run",
+      [dict(VALID_ROW)], expect_exit=2, expect_text="no longer has",
+      extra_files={"scripts/xcode-test.sh": CANONICAL_STUB.replace(
+          'run_lane "$DEBUG_SCHEME" Debug', 'run_lane "$RELEASE_SCHEME" Release')})
+
+check("a canonical DerivedData default that moved refuses the run",
+      [dict(VALID_ROW)], expect_exit=2, expect_text="no longer has",
+      extra_files={"scripts/xcode-test.sh": CANONICAL_STUB.replace(
+          ".derivedData/Test", ".derivedData/Somewhere")})
+
+check("a bumped tuist pin refuses the run",
+      [dict(VALID_ROW)], expect_exit=2, expect_text="no longer has",
+      extra_files={"scripts/xcode-test.sh": CANONICAL_STUB.replace(
+          "tuist@4.195.11", "tuist@4.200.0")})
+
 check("a missing canonical script refuses the run",
       [dict(VALID_ROW)], expect_exit=2, expect_text="cannot confirm it is building the same thing",
       remove=["scripts/xcode-test.sh"])
@@ -181,6 +201,24 @@ check("an absolute target path is refused",
 check("a target escaping the worktree with .. is refused",
       [dict(VALID_ROW, file="../outside.swift")],
       expect_exit=2, expect_text="resolves OUTSIDE the worktree")
+
+# exit 1 means "a row survived". A missing recipe file must never be able to produce it.
+ran += 1
+with tempfile.TemporaryDirectory() as td:
+    tmp = make_tree(Path(td))
+    proc = subprocess.run(
+        [sys.executable, str(BATTERY), "--recipes", str(tmp / "nope.json"),
+         "--worktree", str(tmp), "--validate-only"],
+        capture_output=True, text=True,
+    )
+    out = proc.stdout + proc.stderr
+    if proc.returncode != 2 or "cannot read the recipe file" not in out:
+        failures.append(f"an unreadable recipe file should refuse with exit 2, got {proc.returncode}"
+                        f"\n{out.strip()[:300]}")
+    elif "Traceback" in out:
+        failures.append("an unreadable recipe file produced a traceback rather than a refusal")
+    else:
+        print("  ok  an unreadable recipe file refuses with exit 2, not a traceback")
 
 # --- flag-combination guard -----------------------------------------------------------------------
 ran += 1

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Two-way tests for mutation-battery.py's refusals.
+
+Every case is PAIRED: a rejected input and a near-identical accepted one. A checker that stopped
+classifying anything looks identical to a working one when you only test the rejections.
+
+These cover the paths that run BEFORE any xcodebuild, which is every input-validation refusal. The
+run paths (baseline, mutate, restore) are proven by running the battery against a real suite with a
+real mutant; a self-test cannot prove those without a build, and pretending otherwise would be the
+exact vacuity this harness exists to catch.
+"""
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+BATTERY = Path(__file__).resolve().parent / "mutation-battery.py"
+
+VALID_ROW = {
+    "label": "a representative mutation",
+    "file": "Sources/Thing.swift",
+    "anchor": "let guarded = true",
+    "replacement": "let guarded = false",
+    "suite": "EnviousWisprTests/ThingTests",
+    "expect_fail": "the guard holds",
+}
+
+failures = []
+ran = 0
+
+
+def make_tree(tmp: Path):
+    (tmp / "Sources").mkdir(parents=True, exist_ok=True)
+    (tmp / "Sources" / "Thing.swift").write_text("let guarded = true\n")
+    return tmp
+
+
+def check(name, rows, *, expect_exit, expect_text=None, extra_files=None, top=None):
+    """Run --validate-only against a throwaway tree and assert the exit code and message."""
+    global ran
+    ran += 1
+    with tempfile.TemporaryDirectory() as td:
+        tmp = make_tree(Path(td))
+        for rel, body in (extra_files or {}).items():
+            p = tmp / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(body)
+        doc = dict(top or {})
+        doc["rows"] = rows
+        recipes = tmp / "recipes.json"
+        recipes.write_text(json.dumps(doc))
+        proc = subprocess.run(
+            [sys.executable, str(BATTERY), "--recipes", str(recipes),
+             "--worktree", str(tmp), "--validate-only"],
+            capture_output=True, text=True,
+        )
+        out = proc.stdout + proc.stderr
+        if proc.returncode != expect_exit:
+            failures.append(f"{name}: exit {proc.returncode}, wanted {expect_exit}\n{out.strip()[:400]}")
+            return
+        if expect_text and expect_text not in out:
+            failures.append(f"{name}: message missing {expect_text!r}\n{out.strip()[:400]}")
+            return
+        print(f"  ok  {name}")
+
+
+# --- the accepted case, first, so a harness that rejects everything is visible immediately -------
+check("a well-formed recipe is accepted", [dict(VALID_ROW)], expect_exit=0,
+      expect_text="1 row(s) well-formed")
+
+check("suite_default supplies a missing per-row suite",
+      [{k: v for k, v in VALID_ROW.items() if k != "suite"}],
+      expect_exit=0, top={"suite_default": "EnviousWisprTests/ThingTests"})
+
+# --- each rejection, paired against the accepted case above ---------------------------------------
+for field in ("label", "file", "anchor", "replacement", "expect_fail"):
+    check(f"missing '{field}' is refused",
+          [{k: v for k, v in VALID_ROW.items() if k != field}],
+          expect_exit=2, expect_text=f"missing required field '{field}'")
+
+check("a bare suite name is refused as not target-qualified",
+      [dict(VALID_ROW, suite="ThingTests")],
+      expect_exit=2, expect_text="not target-qualified")
+
+check("no suite and no default is refused",
+      [{k: v for k, v in VALID_ROW.items() if k != "suite"}],
+      expect_exit=2, expect_text="no suite and no suite_default")
+
+check("a target file that does not exist is refused",
+      [dict(VALID_ROW, file="Sources/Absent.swift")],
+      expect_exit=2, expect_text="target does not exist")
+
+check("anchor identical to replacement is refused",
+      [dict(VALID_ROW, replacement=VALID_ROW["anchor"])],
+      expect_exit=2, expect_text="would mutate nothing")
+
+check("an empty row list is refused",
+      [], expect_exit=2, expect_text="declares no rows")
+
+# A leftover backup means an earlier battery did not restore. Continuing would layer a mutation on
+# top of an already-broken file, which is how a battery reports a perfect score against a poisoned
+# tree (2026-08-17, 8/8 CAUGHT and every row worthless).
+check("a leftover .mutbak refuses the whole run",
+      [dict(VALID_ROW)], expect_exit=2, expect_text="did not restore",
+      extra_files={"Sources/Thing.swift.mutbak": "let guarded = true\n"})
+
+check("an anchor absent from the target file is refused",
+      [dict(VALID_ROW, anchor="this text is nowhere in the file")],
+      expect_exit=2, expect_text="anchor not found")
+
+check("a non-unique anchor is refused",
+      [dict(VALID_ROW, anchor="x")],
+      expect_exit=2, expect_text="must be unique",
+      extra_files={"Sources/Thing.swift": "let x = 1\nlet y = x + x\n"})
+
+# --- flag-combination guard -----------------------------------------------------------------------
+ran += 1
+with tempfile.TemporaryDirectory() as td:
+    tmp = make_tree(Path(td))
+    recipes = tmp / "recipes.json"
+    recipes.write_text(json.dumps({"rows": [dict(VALID_ROW)]}))
+    proc = subprocess.run(
+        [sys.executable, str(BATTERY), "--recipes", str(recipes), "--worktree", str(tmp),
+         "--validate-only", "--dry-run"],
+        capture_output=True, text=True,
+    )
+    if proc.returncode == 0 or "silently do less" not in (proc.stdout + proc.stderr):
+        failures.append("--validate-only with --dry-run should be refused, not silently narrowed")
+    else:
+        print("  ok  --validate-only combined with --dry-run is refused")
+
+print()
+if failures:
+    print(f"{len(failures)} of {ran} FAILED:")
+    for f in failures:
+        print(f"  - {f}")
+    sys.exit(1)
+print(f"all {ran} cases passed")

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -1612,6 +1612,46 @@ elif "timed out after" not in _body:
 else:
     print("  ok  a timeout appends to the lane log rather than overwriting it")
 
+# The canonical lane consumes the SwiftPM seed and resolves with a fallback that discards a damaged
+# SourcePackages (xcode-test.sh:85-96). Skipping it makes the opening baseline fail against package
+# state the canonical command recovers from — an overnight run producing nothing until someone clears
+# DerivedData by hand.
+ran += 1
+_calls = []
+_real_run5 = battery.run
+
+
+def _capture_prep(cmd, cwd, log_path=None, timeout=None):
+    _calls.append(" ".join(str(c) for c in cmd))
+    return 0, ""
+
+
+battery.run = _capture_prep
+try:
+    _l = battery.Lane(Path(tempfile.gettempdir()), Path("/tmp/dd"), Path(tempfile.mkdtemp()))
+    _l.generate_once()
+finally:
+    battery.run = _real_run5
+
+_joined = " || ".join(_calls)
+if "ew_seed_consume" not in _joined or "ew_seed_resolve_or_unseed" not in _joined:
+    failures.append("the canonical package preparation runs before the first suite — it does NOT: "
+                    f"{_calls}")
+elif _calls and "ensure_generated" in _calls[0] and "seed" not in _calls[0]:
+    print("  ok  the canonical package preparation runs before the first suite")
+else:
+    failures.append("the canonical package preparation runs before the first suite — but not AFTER "
+                    f"generation, which is the order the canonical lane uses: {_calls}")
+
+# It must call THEIR helpers, not a reimplementation: this runner already carries one duplicated
+# invocation plus a guard to police it, and #2165 exists to delete both.
+ran += 1
+if "scripts/lib/spm-seed.sh" not in _joined:
+    failures.append("package preparation sources the canonical helper rather than reimplementing it — "
+                    "it does NOT")
+else:
+    print("  ok  package preparation sources the canonical helper rather than reimplementing it")
+
 print()
 if failures:
     print(f"{len(failures)} of {ran} FAILED:")

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -31,13 +31,33 @@ failures = []
 ran = 0
 
 
+# Mirrors the real scripts/xcode-test.sh closely enough for the drift guard to parse. Kept in this
+# shape deliberately: a stub that does not resemble the artifact under test proves nothing about it.
 CANONICAL_STUB = """#!/usr/bin/env bash
 PROJECT="EnviousWispr.xcodeproj"
 DEBUG_SCHEME="EnviousWispr"
 DEST='platform=macOS,arch=arm64'
 TEST_ARGS=(-only-testing:"$FILTER")
-ARCHS=arm64 VALID_ARCHS=arm64 ONLY_ACTIVE_ARCH=YES
+run_lane() {
+  xcodebuild test \\
+    -project "$PROJECT" \\
+    -scheme "$scheme" \\
+    -configuration "$config" \\
+    -derivedDataPath "$DERIVED_DATA" \\
+    -destination "$DEST" \\
+    ARCHS=arm64 \\
+    VALID_ARCHS=arm64 \\
+    ONLY_ACTIVE_ARCH=YES \\
+    "$@" \\
+    "${TEST_ARGS[@]}" | tee "$PROJECT_ROOT/$log"
+}
 """
+
+# The exact line the two directional drift cases add to or remove from the stub. Derived from the
+# stub itself rather than retyped, because a hand-typed copy of an escaped line is how both of
+# these cases silently tested nothing the first time.
+ONLY_ACTIVE = [l for l in CANONICAL_STUB.split("\n") if "ONLY_ACTIVE_ARCH" in l][0] + "\n"
+assert ONLY_ACTIVE in CANONICAL_STUB, "the stub line the drift cases edit must exist verbatim"
 
 
 def make_tree(tmp: Path):
@@ -131,13 +151,36 @@ check("a non-unique anchor is refused",
 # The runner reproduces scripts/xcode-test.sh's build settings rather than shelling out to it. That
 # buys two sources of truth, so drift must be loud: if the canonical script stops carrying a setting
 # this runner reproduces, the battery refuses rather than measuring a differently-configured build.
-check("a canonical script that has drifted refuses the run",
-      [dict(VALID_ROW)], expect_exit=2, expect_text="differently-configured build",
-      extra_files={"scripts/xcode-test.sh": "#!/usr/bin/env bash\n# settings removed\n"})
+check("a canonical script with its invocation gone refuses the run",
+      [dict(VALID_ROW)], expect_exit=2, expect_text="could not find the `xcodebuild test",
+      extra_files={"scripts/xcode-test.sh": "#!/usr/bin/env bash\n# gutted\n"})
+
+check("a canonical script that DROPPED a setting refuses the run",
+      [dict(VALID_ROW)], expect_exit=2, expect_text="no longer passes",
+      extra_files={"scripts/xcode-test.sh": CANONICAL_STUB.replace(ONLY_ACTIVE, "")})
+
+# The direction a presence-only check is blind to, and what cloud review flagged on PR #2158: the
+# lane GAINS a setting, everything the runner already knew about is still there, and a
+# one-directional guard stays green while the battery builds differently from the canonical lane.
+check("a canonical script that ADDED a setting refuses the run",
+      [dict(VALID_ROW)], expect_exit=2, expect_text="does NOT reproduce",
+      extra_files={"scripts/xcode-test.sh": CANONICAL_STUB.replace(
+          ONLY_ACTIVE, ONLY_ACTIVE + "    ENABLE_TESTABILITY=YES \\\\\n")})
 
 check("a missing canonical script refuses the run",
       [dict(VALID_ROW)], expect_exit=2, expect_text="cannot confirm it is building the same thing",
       remove=["scripts/xcode-test.sh"])
+
+# A recipe arrives from an issue body, which is data someone else wrote. It may not reach out of
+# the worktree — an absolute path, a `..`, or a symlink would otherwise have the battery back up,
+# mutate and restore a file it was never scoped to.
+check("an absolute target path is refused",
+      [dict(VALID_ROW, file="/etc/hosts")],
+      expect_exit=2, expect_text="must be repo-relative")
+
+check("a target escaping the worktree with .. is refused",
+      [dict(VALID_ROW, file="../outside.swift")],
+      expect_exit=2, expect_text="resolves OUTSIDE the worktree")
 
 # --- flag-combination guard -----------------------------------------------------------------------
 ran += 1
@@ -209,6 +252,20 @@ check_raw("a malformed recipe in an issue body is refused as JSON, not as a cras
 check_raw("an issue body recipe with no rows is refused, and says so about the ISSUE",
           '{"rows": []}', expect_text="the issue body declares no rows")
 
+# Valid JSON is not the expected SHAPE. In the unattended --from-issue path these used to surface
+# as an AttributeError traceback, which reads as "the battery is broken" rather than "the recipe
+# is wrong".
+check_raw("a recipe that is a JSON array, not an object, is refused",
+          "[]", expect_text="must be a JSON object")
+check_raw("a recipe whose 'rows' is not a list is refused",
+          '{"rows": {"a": 1}}', expect_text="'rows' that is not a list")
+check_raw("a row that is a bare number is refused, not crashed on",
+          '{"rows": [1]}', expect_text="row 1 is a int, not an object")
+check_raw("a row field of the wrong type is refused",
+          '{"rows": [{"label": 5, "file": "Sources/Thing.swift", "anchor": "a",'
+          ' "replacement": "b", "expect_fail": "c", "suite": "T/S"}]}',
+          expect_text="must be a string")
+
 # The accepted counterpart, so the two refusals above are not a checker that rejects everything.
 ran += 1
 import tempfile as _tf2  # noqa: E402
@@ -260,6 +317,109 @@ check_issue("an issue carrying TWO recipe blocks is refused rather than picking 
             expect_text="carries 2 ```json blocks")
 check_issue("a failed `gh` call is refused, never treated as an empty issue",
             rc=1, body="could not resolve to an Issue", expect_text="could not read issue #2156")
+
+# --- the row loop, with the lane stubbed -----------------------------------------------------------
+# These drive the real mutate -> evaluate -> restore machinery against a real file on disk. Everything
+# in the loop is exercised EXCEPT the xcodebuild call itself, which is replaced by a stub returning the
+# shapes a real lane produces. That boundary is stated rather than blurred: a green here is NOT evidence
+# that the battery works end to end against a Swift suite, only that every decision around the call is
+# right. The remaining gap is closed by one real run, not by more stubs.
+import io  # noqa: E402
+import contextlib  # noqa: E402
+
+ORIGINAL = "let guarded = true\n"
+
+
+def drive_row(lane_result, *, expect_verdict, expect_detail, raise_instead=None):
+    """Run one row with a stubbed lane; return (verdict, detail, file_bytes_after)."""
+    import tempfile as _t
+    with _t.TemporaryDirectory() as td:
+        tmp = make_tree(Path(td))
+        target = tmp / "Sources" / "Thing.swift"
+        recipes = tmp / "r.json"
+        recipes.write_text(json.dumps({"rows": [dict(VALID_ROW)]}))
+
+        seen = {}
+
+        class StubLane:
+            def __init__(self, *a, **k):
+                pass
+
+            def generate_once(self):
+                pass
+
+            def run_suite(self, suite, tag):
+                # Prove the mutation was actually on disk at the moment the lane ran, rather than
+                # trusting the write. A row that restores too early would still look CAUGHT.
+                seen["content_during_run"] = target.read_text()
+                if raise_instead is not None:
+                    raise raise_instead
+                return lane_result
+
+        real_lane, real_baseline = battery.Lane, battery.baseline
+        battery.Lane = StubLane
+        battery.baseline = lambda lane, suites, phase: []
+        buf = io.StringIO()
+        try:
+            with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(buf):
+                rc = battery.main_for_test(recipes, tmp)
+        finally:
+            battery.Lane, battery.baseline = real_lane, real_baseline
+        return rc, buf.getvalue(), target.read_text(), seen.get("content_during_run")
+
+
+def check_row(name, lane_result, *, expect_marker, expect_rc, raise_instead=None):
+    global ran, failures
+    ran += 1
+    try:
+        rc, out, after, during = drive_row(lane_result, expect_verdict=None, expect_detail=None,
+                                           raise_instead=raise_instead)
+    except Exception as exc:
+        failures.append(f"{name}: driver raised {type(exc).__name__}: {exc}")
+        return
+    problems = []
+    if expect_marker not in out:
+        problems.append(f"report missing {expect_marker!r}")
+    if rc != expect_rc:
+        problems.append(f"exit {rc}, wanted {expect_rc}")
+    # The control that matters most: the file must be back to byte-identical on EVERY path.
+    if after != ORIGINAL:
+        problems.append(f"FILE NOT RESTORED — on disk: {after!r}")
+    if raise_instead is None and during != "let guarded = false\n":
+        problems.append(f"mutation was not on disk when the lane ran: {during!r}")
+    if problems:
+        failures.append(f"{name}: " + "; ".join(problems))
+    else:
+        print(f"  ok  {name}")
+
+
+# (count, failures, compiled, log, rc, elapsed)
+check_row("the named test failing scores CAUGHT",
+          (5, ["✘ Test \"the guard holds\" recorded an issue"], True, "log", 65, 3.0),
+          expect_marker="ok", expect_rc=0)
+
+check_row("the suite staying green scores SURVIVED, not a pass",
+          (5, [], True, "log", 0, 3.0),
+          expect_marker="SURV", expect_rc=1)
+
+check_row("a DIFFERENT test failing is SURVIVED — something else caught it, so this test is not the guard",
+          (5, ["✘ Test \"some other case\" recorded an issue"], True, "log", 65, 3.0),
+          expect_marker="SURV", expect_rc=1)
+
+check_row("zero executed tests is an ERROR, never a survivor and never a catch",
+          (0, [], True, "log", 0, 3.0),
+          expect_marker="ERR", expect_rc=1)
+
+check_row("no test summary at all is an ERROR",
+          (None, [], True, "log", 65, 3.0),
+          expect_marker="ERR", expect_rc=1)
+
+check_row("a mutant that does not compile is an ERROR — a red lane proves nothing if nothing ran",
+          (None, [], False, "log", 65, 3.0),
+          expect_marker="ERR", expect_rc=1)
+
+check_row("the file is restored even when the lane raises mid-row",
+          None, expect_marker="ERR", expect_rc=1, raise_instead=RuntimeError("lane exploded"))
 
 print()
 if failures:

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -1652,6 +1652,61 @@ if "scripts/lib/spm-seed.sh" not in _joined:
 else:
     print("  ok  package preparation sources the canonical helper rather than reimplementing it")
 
+# `pgrep` exits 0 for a match, 1 for NO MATCH, and 2+ when the probe itself failed. Folding that third
+# answer into "none running" is fail-OPEN on a guard whose whole job is to stop a corrupted log scoring
+# as a mutant CAUGHT — the battery would proceed believing the machine is clear when it does not know.
+for _label, _rc, _want_refusal in [
+    ("a failed dev-app probe refuses rather than reading as clear", 2, True),
+    ("no match from the dev-app probe proceeds normally", 1, False),
+]:
+    ran += 1
+    _real_run6 = battery.run
+    battery.run = lambda cmd, cwd, log_path=None, timeout=None, _r=_rc: (_r, "")
+    _neutralised2 = battery.check_no_dev_app
+    battery.check_no_dev_app = _REAL_CHECK_NO_DEV_APP
+    try:
+        _REAL_CHECK_NO_DEV_APP(Path("."))
+        _got = False
+    except battery.Refusal as exc:
+        _got = "probe failed" in str(exc)
+    except Exception as exc:
+        _got = False
+        failures.append(f"{_label} — raised {type(exc).__name__} instead of Refusal")
+    finally:
+        battery.run = _real_run6
+        battery.check_no_dev_app = _neutralised2
+    if _got != _want_refusal:
+        failures.append(f"{_label}: refused={_got}, wanted {_want_refusal}")
+    else:
+        print(f"  ok  {_label}")
+
+# Every bounded call converts its timeout into a controlled error. The generation call did; the package
+# preparation added in the same commit did not, so it propagated raw.
+ran += 1
+_real_prep = battery.Lane._run_package_prep
+
+
+def _prep_timeout(self):
+    raise battery.subprocess.TimeoutExpired("prep", 1)
+
+
+battery.Lane._run_package_prep = _prep_timeout
+_real_run7 = battery.run
+battery.run = lambda cmd, cwd, log_path=None, timeout=None: (0, "")
+try:
+    _l2 = battery.Lane(Path(tempfile.gettempdir()), Path("/tmp/dd"), Path(tempfile.mkdtemp()))
+    try:
+        _l2.generate_once()
+        failures.append("a package-preparation timeout becomes a lane error — it did not raise at all")
+    except battery._LaneTimedOut:
+        print("  ok  a package-preparation timeout becomes a lane error")
+    except battery.subprocess.TimeoutExpired:
+        failures.append("a package-preparation timeout becomes a lane error — it propagated RAW, so "
+                        "the row loop cannot turn it into a controlled ERROR")
+finally:
+    battery.Lane._run_package_prep = _real_prep
+    battery.run = _real_run7
+
 print()
 if failures:
     print(f"{len(failures)} of {ran} FAILED:")

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -155,6 +155,112 @@ with tempfile.TemporaryDirectory() as td:
     else:
         print("  ok  --validate-only combined with --dry-run is refused")
 
+# --- the issue-body channel -----------------------------------------------------------------------
+# The issue IS the backlog, so extracting a recipe from one is a load-bearing path, not a convenience.
+# Driven directly rather than through the CLI because the CLI path shells out to `gh`; what is under
+# test here is the extraction and parsing, not GitHub.
+import importlib.util  # noqa: E402
+
+_spec = importlib.util.spec_from_file_location("battery", BATTERY)
+battery = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(battery)
+
+
+def check_fence(name, body, *, expect_blocks):
+    global ran, failures
+    ran += 1
+    got = len(battery.FENCE_RE.findall(body))
+    if got != expect_blocks:
+        failures.append(f"{name}: found {got} json blocks, wanted {expect_blocks}")
+    else:
+        print(f"  ok  {name}")
+
+
+check_fence("one fenced json block is found in a prose issue body",
+            "Some prose.\n\n```json\n{\"rows\": []}\n```\n\nMore prose.\n", expect_blocks=1)
+check_fence("a body with no json block yields none",
+            "Prose only, and a ```bash\necho hi\n``` block.\n", expect_blocks=0)
+check_fence("two json blocks are both seen, so the caller can refuse",
+            "```json\n{}\n```\ntext\n```json\n{}\n```\n", expect_blocks=2)
+
+
+def check_raw(name, raw, *, expect_text):
+    global ran, failures
+    ran += 1
+    import tempfile as _tf
+    with _tf.TemporaryDirectory() as td:
+        tmp = make_tree(Path(td))
+        try:
+            battery.load_recipes(None, tmp, raw=raw)
+        except battery.Refusal as exc:
+            if expect_text in str(exc):
+                print(f"  ok  {name}")
+            else:
+                failures.append(f"{name}: refused with {str(exc)[:200]!r}, wanted {expect_text!r}")
+            return
+        except Exception as exc:  # a non-Refusal escape is itself the defect
+            failures.append(f"{name}: raised {type(exc).__name__} instead of Refusal: {exc}")
+            return
+    failures.append(f"{name}: was ACCEPTED — it should have been refused")
+
+
+check_raw("a malformed recipe in an issue body is refused as JSON, not as a crash",
+          "{not json at all", expect_text="not valid JSON")
+check_raw("an issue body recipe with no rows is refused, and says so about the ISSUE",
+          '{"rows": []}', expect_text="the issue body declares no rows")
+
+# The accepted counterpart, so the two refusals above are not a checker that rejects everything.
+ran += 1
+import tempfile as _tf2  # noqa: E402
+
+with _tf2.TemporaryDirectory() as td:
+    tmp = make_tree(Path(td))
+    good = ('{"suite_default": "EnviousWisprTests/ThingTests", "rows": [{"label": "l",'
+            ' "file": "Sources/Thing.swift", "anchor": "let guarded = true",'
+            ' "replacement": "let guarded = false", "expect_fail": "x"}]}')
+    try:
+        rows = battery.load_recipes(None, tmp, raw=good)
+        assert len(rows) == 1
+        print("  ok  a well-formed recipe from an issue body is accepted")
+    except Exception as exc:
+        failures.append(f"a well-formed issue-body recipe was refused: {exc}")
+
+# The fence COUNT decisions are the fail-closed ones — zero blocks and several blocks must both refuse.
+# Driven with a stubbed `run` so this tests our decision, not GitHub's availability. The double refuses
+# what the real tool refuses: a nonzero rc still produces a Refusal rather than an empty body.
+def check_issue(name, *, rc, body, expect_text=None, expect_ok=False):
+    global ran, failures
+    ran += 1
+    real = battery.run
+    battery.run = lambda cmd, cwd, log_path=None, timeout=None: (rc, body)
+    try:
+        out = battery.recipes_from_issue(2156, Path("."))
+    except battery.Refusal as exc:
+        if expect_ok:
+            failures.append(f"{name}: refused a valid issue: {str(exc)[:200]}")
+        elif expect_text not in str(exc):
+            failures.append(f"{name}: refused with {str(exc)[:200]!r}, wanted {expect_text!r}")
+        else:
+            print(f"  ok  {name}")
+        return
+    finally:
+        battery.run = real
+    if expect_ok:
+        print(f"  ok  {name}" if out.strip() else f"  ok  {name}")
+    else:
+        failures.append(f"{name}: was ACCEPTED — it should have been refused")
+
+
+check_issue("an issue with exactly one recipe block is accepted",
+            rc=0, body='prose\n```json\n{"rows": [1]}\n```\n', expect_ok=True)
+check_issue("an issue carrying NO recipe block is refused",
+            rc=0, body="prose with no recipe at all\n", expect_text="carries no ```json recipe block")
+check_issue("an issue carrying TWO recipe blocks is refused rather than picking the first",
+            rc=0, body='```json\n{"a":1}\n```\n```json\n{"b":2}\n```\n',
+            expect_text="carries 2 ```json blocks")
+check_issue("a failed `gh` call is refused, never treated as an empty issue",
+            rc=1, body="could not resolve to an Issue", expect_text="could not read issue #2156")
+
 print()
 if failures:
     print(f"{len(failures)} of {ran} FAILED:")

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -120,6 +120,10 @@ check("a bare suite name is refused as not target-qualified",
       [dict(VALID_ROW, suite="ThingTests")],
       expect_exit=2, expect_text="not target-qualified")
 
+check("a non-string suite is refused, not crashed on",
+      [dict(VALID_ROW, suite=1)],
+      expect_exit=2, expect_text="suite must be a string")
+
 check("no suite and no default is refused",
       [{k: v for k, v in VALID_ROW.items() if k != "suite"}],
       expect_exit=2, expect_text="no suite and no suite_default")
@@ -127,6 +131,17 @@ check("no suite and no default is refused",
 check("a target file that does not exist is refused",
       [dict(VALID_ROW, file="Sources/Absent.swift")],
       expect_exit=2, expect_text="target does not exist")
+
+check("an EMPTY replacement is accepted — deleting the anchored block is a real mutation",
+      [dict(VALID_ROW, replacement="")], expect_exit=0, expect_text="1 row(s) well-formed")
+
+check("a replacement that is absent entirely is still refused",
+      [{k: v for k, v in VALID_ROW.items() if k != "replacement"}],
+      expect_exit=2, expect_text="missing required field 'replacement'")
+
+check("an empty ANCHOR is still refused — only replacement may be empty",
+      [dict(VALID_ROW, anchor="")],
+      expect_exit=2, expect_text="missing required field 'anchor'")
 
 check("anchor identical to replacement is refused",
       [dict(VALID_ROW, replacement=VALID_ROW["anchor"])],
@@ -186,6 +201,14 @@ check("a bumped tuist pin refuses the run",
       [dict(VALID_ROW)], expect_exit=2, expect_text="no longer has",
       extra_files={"scripts/xcode-test.sh": CANONICAL_STUB.replace(
           "tuist@4.195.11", "tuist@4.200.0")})
+
+# Round 3 of the drift class, at the axis the round-2 enumeration missed: it enumerated WHICH INPUTS
+# decide the build, not HOW an argument can arrive. An argument reaching xcodebuild through a variable
+# used to be dropped, so indirection read as absence.
+check("an unrecognised shell expansion in the invocation refuses the run",
+      [dict(VALID_ROW)], expect_exit=2, expect_text="cannot see",
+      extra_files={"scripts/xcode-test.sh": CANONICAL_STUB.replace(
+          '    "$@" ', '    "${EXTRA_ARGS[@]}" ')})
 
 check("a missing canonical script refuses the run",
       [dict(VALID_ROW)], expect_exit=2, expect_text="cannot confirm it is building the same thing",
@@ -458,6 +481,30 @@ check_row("a mutant that does not compile is an ERROR — a red lane proves noth
 
 check_row("the file is restored even when the lane raises mid-row",
           None, expect_marker="ERR", expect_rc=1, raise_instead=RuntimeError("lane exploded"))
+
+# A double must refuse what the real tool refuses, and it must also RETURN what the real tool returns.
+# The stubbed lane above hands back a 6-tuple; if Lane.run_suite ever returns a different shape, every
+# row case would keep passing against a double that no longer resembles the thing it replaces — the
+# stub would be testing itself. Bind them by reading the real return statement.
+ran += 1
+import inspect  # noqa: E402
+import re as _re  # noqa: E402
+
+_src = inspect.getsource(battery.Lane.run_suite)
+_returns = _re.findall(r"^\s*return (.+)$", _src, _re.MULTILINE)
+if len(_returns) != 1:
+    failures.append("the stubbed lane returns the same shape as the real one: Lane.run_suite has "
+                    f"{len(_returns)} return statements; the stub assumes exactly 1")
+else:
+    _arity = len([t for t in _returns[0].split(",")])
+    if _arity != 6:
+        failures.append(
+            "the stubbed lane returns the same shape as the real one: "
+            f"Lane.run_suite now returns {_arity} values, but the stubbed-lane cases hand back 6. "
+            "Update the stub, or every row case is exercising a double that no longer resembles the "
+            "real lane.")
+    else:
+        print("  ok  the stubbed lane returns the same shape as the real one")
 
 print()
 if failures:

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -1506,6 +1506,41 @@ if _rc != 2 or "could not read any test names" not in _out:
 else:
     print("  ok  unreadable baseline names refuse the run")
 
+# A display name may CONTAIN quotes; Swift Testing prints them unescaped. Terminating on the first
+# inner quote truncated the identity, so these tests could never be named in a recipe. All three names
+# below are REAL tests in this repo, not invented — the defect was reachable today.
+for _label, _line, _want in [
+    ("a display name with an embedded quoted phrase parses whole",
+     '✘ Test "founder repro: "Other apps." (2 words, punctuation kept) bypasses" recorded an issue at F.swift:1:1',
+     'founder repro: "Other apps." (2 words, punctuation kept) bypasses'),
+    ("a display name ending in a quoted word parses whole",
+     '✔ Test "hardware class is real, never "unknown"" passed after 0.1 seconds.',
+     'hardware class is real, never "unknown"'),
+    ("a quoted default value inside a name parses whole",
+     '✔ Test "lastObservedPhase falls back to protocol default "warmup"" passed after 0.1 seconds.',
+     'lastObservedPhase falls back to protocol default "warmup"'),
+    ("an ordinary name still parses",
+     '✘ Test "an ordinary name" failed after 0.002 seconds with 1 issue.',
+     "an ordinary name"),
+]:
+    ran += 1
+    _got = {m.group("quoted") for m in battery.TEST_NAME_ANY_RE.finditer(_line)
+            if m.group("quoted") is not None}
+    if _got != {_want}:
+        failures.append(f"{_label} — got {_got}, wanted {{{_want!r}}}")
+    else:
+        print(f"  ok  {_label}")
+
+# And the failure-matching regex must agree with the enumerating one, or a name that validates would
+# then fail to match when the row runs.
+ran += 1
+_q = '✘ Test "founder repro: "Other apps." (2 words, punctuation kept) bypasses" recorded an issue'
+if battery.failed_test_identities([_q]) != {'founder repro: "Other apps." (2 words, punctuation kept) bypasses'}:
+    failures.append("both identity readers agree on a quoted name — they do NOT, so a name that "
+                    "validates at load would fail to match when the row runs")
+else:
+    print("  ok  both identity readers agree on a quoted name")
+
 print()
 if failures:
     print(f"{len(failures)} of {ran} FAILED:")

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -1541,6 +1541,77 @@ if battery.failed_test_identities([_q]) != {'founder repro: "Other apps." (2 wor
 else:
     print("  ok  both identity readers agree on a quoted name")
 
+# Generation is bounded too. Bounding the TEST call and not the setup before it leaves an unattended
+# run able to park all night one step earlier — the exact failure the lane timeout exists to prevent.
+ran += 1
+_real_run4 = battery.run
+_seen_timeouts = []
+
+
+def _record_timeout(cmd, cwd, log_path=None, timeout=None):
+    _seen_timeouts.append((cmd[0] if cmd else "", timeout))
+    return 0, ""
+
+
+battery.run = _record_timeout
+try:
+    _lane = battery.Lane(Path(tempfile.gettempdir()), Path(tempfile.gettempdir()),
+                         Path(tempfile.mkdtemp()))
+    _lane.generate_once()
+finally:
+    battery.run = _real_run4
+
+if not _seen_timeouts or _seen_timeouts[0][1] is None:
+    failures.append("project generation is bounded by a timeout — it is NOT: "
+                    f"{_seen_timeouts}")
+else:
+    print("  ok  project generation is bounded by a timeout")
+
+# A timeout must APPEND to the lane log, not overwrite it. Overwriting throws away the record of which
+# operation hung, on the one path where that record is the whole point.
+ran += 1
+_dir = Path(tempfile.mkdtemp(prefix="ew-battery-timeoutlog-"))
+_log = _dir / "row.log"
+_real_popen2 = battery.subprocess.Popen
+
+
+class _HangingPopen:
+    def __init__(self, *a, **k):
+        self.pid = _os_env.getpid()
+        self.returncode = None
+
+    def communicate(self, timeout=None):
+        if timeout is not None:
+            raise battery.subprocess.TimeoutExpired("cmd", timeout)
+        return ("captured output that must survive\n", None)
+
+    def kill(self):
+        pass
+
+
+battery.subprocess.Popen = _HangingPopen
+_real_reap2 = battery._reap_active_lane
+battery._reap_active_lane = lambda: True
+try:
+    _log.write_text("EARLIER OUTPUT THAT MUST SURVIVE\n")
+    try:
+        battery.run(["/bin/true"], cwd=str(_dir), log_path=_log, timeout=1)
+    except battery.subprocess.TimeoutExpired:
+        pass
+finally:
+    battery.subprocess.Popen = _real_popen2
+    battery._reap_active_lane = _real_reap2
+
+_body = _log.read_text()
+if "EARLIER OUTPUT THAT MUST SURVIVE" not in _body:
+    failures.append("a timeout appends to the lane log rather than overwriting it — the earlier "
+                    "output was DESTROYED, which is the only record of what hung")
+elif "timed out after" not in _body:
+    failures.append("a timeout appends to the lane log rather than overwriting it — the timeout "
+                    "marker was not written at all")
+else:
+    print("  ok  a timeout appends to the lane log rather than overwriting it")
+
 print()
 if failures:
     print(f"{len(failures)} of {ran} FAILED:")

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -1232,6 +1232,60 @@ try:
 finally:
     Path.write_text = _real_wt
 
+# The restore COPY itself can fail — disk full, destination unwritable. That used to escape the
+# `finally` before verification and backup cleanup, leaving the source MUTATED with its .mutbak
+# alongside and no controlled stop. Last round handled the restore producing WRONG BYTES; this is the
+# restore FAILING OUTRIGHT.
+ran += 1
+_real_copy = battery.shutil.copy2
+_copies = []
+
+
+def _copy_then_fail(src, dst, *a, **k):
+    _copies.append((str(src), str(dst)))
+    if str(src).endswith(".mutbak"):      # the RESTORE direction only; the backup must still be made
+        raise OSError(28, "No space left on device")
+    return _real_copy(src, dst, *a, **k)
+
+
+battery.shutil.copy2 = _copy_then_fail
+try:
+    try:
+        _rc, _out, _after, _during = drive_row((5, [], True, "log", 0, 3.0),
+                                               expect_verdict=None, expect_detail=None)
+    except BaseException as _esc:   # noqa: BLE001 — escaping IS the defect this case exists for
+        _rc, _out = -1, f"escaped as {type(_esc).__name__}"
+    if "STOPPING" not in _out or "still MUTATED" not in _out:
+        failures.append("a failing restore COPY stops with a recovery path — it did not: "
+                        + _out.strip()[:200])
+    elif _rc != 1:
+        failures.append(f"a failing restore COPY stops with a recovery path — exit {_rc}, wanted 1")
+    else:
+        print("  ok  a failing restore COPY stops with a recovery path")
+finally:
+    battery.shutil.copy2 = _real_copy
+
+# --validate-only is documented as running nothing and touching nothing. An unconditional mkdir broke
+# that promise and crashed on a read-only checkout.
+ran += 1
+with tempfile.TemporaryDirectory() as td:
+    tmp = make_tree(Path(td))
+    recipes = tmp / "r.json"
+    recipes.write_text(json.dumps({"rows": [dict(VALID_ROW)]}))
+    proc = subprocess.run(
+        [sys.executable, str(BATTERY), "--recipes", str(recipes),
+         "--worktree", str(tmp), "--validate-only"],
+        capture_output=True, text=True, env=NEUTRAL_ENV,
+    )
+    if proc.returncode != 0:
+        failures.append("--validate-only creates nothing in the worktree — it exited "
+                        f"{proc.returncode}")
+    elif (tmp / "build").exists():
+        failures.append("--validate-only creates nothing in the worktree — it created "
+                        "build/mutation-battery anyway")
+    else:
+        print("  ok  --validate-only creates nothing in the worktree")
+
 print()
 if failures:
     print(f"{len(failures)} of {ran} FAILED:")

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -316,6 +316,20 @@ with tempfile.TemporaryDirectory() as td:
     else:
         print("  ok  an unreadable recipe file refuses with exit 2, not a traceback")
 
+# The expansions were allowlisted but not REQUIRED and not tied to position, so a lane that DELETED
+# `"${TEST_ARGS[@]}"` (it would stop filtering and run everything) or SWAPPED scheme and config passed.
+# An argument list is defined by its order.
+check("a canonical lane that dropped the test filter refuses the run",
+      [dict(VALID_ROW)], expect_exit=2, expect_text="in order",
+      extra_files={"scripts/xcode-test.sh": CANONICAL_STUB.replace(
+          '    "${TEST_ARGS[@]}" | tee', '    | tee')})
+
+check("a canonical lane with scheme and config swapped refuses the run",
+      [dict(VALID_ROW)], expect_exit=2, expect_text="in order",
+      extra_files={"scripts/xcode-test.sh": CANONICAL_STUB
+                   .replace('-scheme "$scheme"', '-scheme "$config"')
+                   .replace('-configuration "$config"', '-configuration "$scheme"')})
+
 # --- flag-combination guard -----------------------------------------------------------------------
 ran += 1
 with tempfile.TemporaryDirectory() as td:
@@ -1285,6 +1299,63 @@ with tempfile.TemporaryDirectory() as td:
                         "build/mutation-battery anyway")
     else:
         print("  ok  --validate-only creates nothing in the worktree")
+
+# The cancellation handler must be installed BEFORE anything can spawn a lane. Installed after the
+# opening baseline, a signal during `tuist generate` or the baseline itself took Python's default
+# action and orphaned that child's process group on the shared DerivedData.
+ran += 1
+_installed_at = []
+_real_sig = battery.signal.signal
+_real_base = battery.baseline
+battery.signal.signal = lambda sig, fn: _installed_at.append("handler")
+battery.baseline = lambda lane, suites, phase: (_installed_at.append(f"baseline-{phase}"), [])[1]
+
+
+class _NullLane:
+    def __init__(self, *a, **k):
+        pass
+
+    def generate_once(self):
+        _installed_at.append("generate")
+
+
+try:
+    _rl = battery.Lane
+    battery.Lane = _NullLane
+    with tempfile.TemporaryDirectory() as td:
+        tmp = make_tree(Path(td))
+        recipes = tmp / "r.json"
+        recipes.write_text(json.dumps({"rows": [dict(VALID_ROW)]}))
+        with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+            battery.main(["--recipes", str(recipes), "--worktree", str(tmp), "--dry-run"])
+finally:
+    battery.signal.signal = _real_sig
+    battery.baseline = _real_base
+    battery.Lane = _rl
+
+if "handler" not in _installed_at:
+    failures.append("cancellation handlers are installed before any lane can start — none was")
+elif _installed_at.index("handler") > _installed_at.index("baseline-before"):
+    failures.append("cancellation handlers are installed before any lane can start — they were "
+                    f"installed AFTER the opening baseline: {_installed_at}")
+else:
+    print("  ok  cancellation handlers are installed before any lane can start")
+
+# SIGQUIT (Ctrl-\ on a stuck overnight terminal) died by default action, leaving the file MUTATED.
+ran += 1
+_signals = []
+battery.signal.signal = lambda sig, fn: _signals.append(sig)
+try:
+    battery._install_restore_on_signal()
+finally:
+    battery.signal.signal = _real_sig
+_missing_sigs = [s for s in (battery.signal.SIGTERM, battery.signal.SIGINT,
+                             battery.signal.SIGHUP, battery.signal.SIGQUIT) if s not in _signals]
+if _missing_sigs:
+    failures.append("every terminating signal is handled — these are not: "
+                    + ", ".join(str(s) for s in _missing_sigs))
+else:
+    print("  ok  every terminating signal is handled")
 
 print()
 if failures:

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -52,7 +52,7 @@ DEBUG_SCHEME="EnviousWispr"
 DEST='platform=macOS,arch=arm64'
 TEST_ARGS=(-only-testing:"$FILTER")
 DERIVED_DATA="${DERIVED_DATA_PATH:-$PROJECT_ROOT/.derivedData/Test}"
-mise x tuist@4.195.11 -- tuist generate --no-open
+ew_ensure_generated "$PROJECT_ROOT"
 run_lane() {
   xcodebuild test \\
     -project "$PROJECT" \\
@@ -60,6 +60,7 @@ run_lane() {
     -configuration "$config" \\
     -derivedDataPath "$DERIVED_DATA" \\
     -destination "$DEST" \\
+    -onlyUsePackageVersionsFromResolvedFile \\
     ARCHS=arm64 \\
     VALID_ARCHS=arm64 \\
     ONLY_ACTIVE_ARCH=YES \\
@@ -210,10 +211,13 @@ check("a canonical DerivedData default that moved refuses the run",
       extra_files={"scripts/xcode-test.sh": CANONICAL_STUB.replace(
           ".derivedData/Test", ".derivedData/Somewhere")})
 
-check("a bumped tuist pin refuses the run",
+# #2178 moved generation into a sourced helper, so the toolchain pin is no longer in this script and
+# a bumped-pin case would test nothing. What matters now is the generation CALL itself: if the lane
+# stops generating, the battery would run against a stale project.
+check("a canonical lane that no longer generates the project refuses the run",
       [dict(VALID_ROW)], expect_exit=2, expect_text="no longer has",
       extra_files={"scripts/xcode-test.sh": CANONICAL_STUB.replace(
-          "tuist@4.195.11", "tuist@4.200.0")})
+          'ew_ensure_generated "$PROJECT_ROOT"', "# generation removed")})
 
 # Round 3 of the drift class, at the axis the round-2 enumeration missed: it enumerated WHICH INPUTS
 # decide the build, not HOW an argument can arrive. An argument reaching xcodebuild through a variable

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -267,13 +267,36 @@ check("an absolute target path is refused",
 
 # Deliberately starts with Sources/ so it passes the allow-list and reaches the containment check —
 # otherwise the allow-list would catch it first and this case would silently stop testing containment.
+# The allow-list must be applied to the RESOLVED path, not the raw string. A lexical prefix check
+# answers a question about the STRING; `Sources/../Tests/x.swift` satisfies it, resolves INSIDE the
+# worktree, and lands in Tests/ — where breaking an assertion yields a false CAUGHT. Cloud review found
+# this walking straight through the allow-list added one round earlier.
+check("a path that walks out of an allowed root via .. is refused",
+      [dict(VALID_ROW, file="Sources/../Tests/FooTests.swift")],
+      expect_exit=2, expect_text="which is outside Sources/")
+
+check("the same bypass aimed at a Tuist input is refused",
+      [dict(VALID_ROW, file="Sources/../Project.swift")],
+      expect_exit=2, expect_text="which is outside Sources/")
+
+# The accepted counterpart: a `..` that stays inside an allowed root is fine, so the check is about
+# WHERE it lands rather than about the characters.
+check("a .. that resolves back inside an allowed root is accepted",
+      [dict(VALID_ROW, file="Sources/sub/../Thing.swift")],
+      expect_exit=0, expect_text="1 row(s) well-formed",
+      extra_files={"Sources/sub/placeholder.swift": "// keeps the directory\n"})
+
 check("a target escaping the worktree via .. inside an allowed root is refused",
       [dict(VALID_ROW, file="Sources/../../outside.swift")],
       expect_exit=2, expect_text="resolves OUTSIDE the worktree")
 
-check("a target outside the allowed roots is refused before containment is even considered",
-      [dict(VALID_ROW, file="../outside.swift")],
-      expect_exit=2, expect_text="which is outside Sources/")
+# Inside the worktree, so it passes containment and genuinely reaches the allow-list. `../outside.swift`
+# no longer exercises this: since the resolve-first reorder it is caught by containment, and its
+# containment case above already covers that.
+check("a target inside the worktree but outside the allowed roots is refused",
+      [dict(VALID_ROW, file="docs/notes.swift")],
+      expect_exit=2, expect_text="which is outside Sources/",
+      extra_files={"docs/notes.swift": "// not a mutation target\n"})
 
 # exit 1 means "a row survived". A missing recipe file must never be able to produce it.
 ran += 1
@@ -839,6 +862,49 @@ if _extra:
                     + ", ".join(_extra) + " would move unnoticed")
 else:
     print("  ok  the runner's command carries no setting the drift guard is blind to")
+
+# The canonical lane honours DERIVED_DATA_PATH (xcode-test.sh:19) and the drift guard only compares
+# that assignment's TEXT — so a battery ignoring the override would run against the shared warm cache
+# while an operator believed it was isolated. Read at call time, so no reload is needed.
+ran += 1
+_probe = "/tmp/ew-battery-derived-probe"
+_env_before = _os_env.environ.get("DERIVED_DATA_PATH")
+_os_env.environ["DERIVED_DATA_PATH"] = _probe
+_seen = {}
+
+
+class _ProbeLane:
+    def __init__(self, wt, derived, logs):
+        _seen["derived"] = str(derived)
+
+    def generate_once(self):
+        pass
+
+    def run_suite(self, suite, tag):
+        return (1, [], True, "log", 0, 1.0)
+
+
+_rl, _rb = battery.Lane, battery.baseline
+battery.Lane, battery.baseline = _ProbeLane, (lambda lane, suites, phase: [])
+try:
+    with tempfile.TemporaryDirectory() as td:
+        tmp = make_tree(Path(td))
+        recipes = tmp / "r.json"
+        recipes.write_text(json.dumps({"rows": [dict(VALID_ROW)]}))
+        with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+            battery.main(["--recipes", str(recipes), "--worktree", str(tmp), "--dry-run"])
+finally:
+    battery.Lane, battery.baseline = _rl, _rb
+    if _env_before is None:
+        _os_env.environ.pop("DERIVED_DATA_PATH", None)
+    else:
+        _os_env.environ["DERIVED_DATA_PATH"] = _env_before
+
+if _seen.get("derived") != _probe:
+    failures.append("the battery honours DERIVED_DATA_PATH like the canonical lane — it does NOT: "
+                    f"used {_seen.get('derived')!r} instead of {_probe!r}")
+else:
+    print("  ok  the battery honours DERIVED_DATA_PATH like the canonical lane")
 
 print()
 if failures:

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -205,6 +205,14 @@ check("a bumped tuist pin refuses the run",
 # Round 3 of the drift class, at the axis the round-2 enumeration missed: it enumerated WHICH INPUTS
 # decide the build, not HOW an argument can arrive. An argument reaching xcodebuild through a variable
 # used to be dropped, so indirection read as absence.
+# The call site was matched as a PREFIX, so trailing positionals — which reach xcodebuild through
+# `"$@"`, accepted by the expansion allowlist without its contents being visible — slipped past.
+check("extra positional build settings on the canonical call site refuse the run",
+      [dict(VALID_ROW)], expect_exit=2, expect_text="no longer has",
+      extra_files={"scripts/xcode-test.sh": CANONICAL_STUB.replace(
+          'run_lane "$DEBUG_SCHEME" Debug build/xcode-test-debug.log',
+          'run_lane "$DEBUG_SCHEME" Debug build/xcode-test-debug.log ENABLE_TESTABILITY=YES')})
+
 check("an unrecognised shell expansion in the invocation refuses the run",
       [dict(VALID_ROW)], expect_exit=2, expect_text="cannot see",
       extra_files={"scripts/xcode-test.sh": CANONICAL_STUB.replace(
@@ -369,6 +377,41 @@ def check_issue(name, *, rc, body, expect_text=None, expect_ok=False):
         failures.append(f"{name}: was ACCEPTED — it should have been refused")
 
 
+# The recipe may live in a COMMENT. github-light.md records that in this repo the body is often stale
+# and the adopted plan lives in comments, so a body-only read refuses correctly-filed work as a RULE
+# rather than an edge case — it fired on a peer's issue within an hour of the format existing.
+ran += 1
+_seen_cmd = {}
+
+
+def _capture_cmd(cmd, cwd, log_path=None, timeout=None):
+    _seen_cmd["cmd"] = cmd
+    return 0, 'body text\n```json\n{"rows": [1]}\n```\n'
+
+
+_real = battery.run
+battery.run = _capture_cmd
+try:
+    battery.recipes_from_issue(2156, Path("."))
+finally:
+    battery.run = _real
+
+_cmd = _seen_cmd.get("cmd", [])
+# The VALUE of --json is what decides what GitHub returns. Matching "comments" anywhere in the command
+# was vacuous: the jq expression names it either way, so unwiring --json left this case green. Its own
+# mutation control caught that.
+_json_value = _cmd[_cmd.index("--json") + 1] if "--json" in _cmd else ""
+if "comments" not in _json_value.split(","):
+    failures.append(
+        "the issue read asks for comments as well as the body: --json requested "
+        f"{_json_value!r}, so a recipe posted as a comment would be invisible")
+elif "body" not in _json_value.split(","):
+    failures.append(
+        "the issue read asks for comments as well as the body: --json requested "
+        f"{_json_value!r}, dropping the body — a recipe in the body would be invisible")
+else:
+    print("  ok  the issue read asks for comments as well as the body")
+
 check_issue("an issue with exactly one recipe block is accepted",
             rc=0, body='prose\n```json\n{"rows": [1]}\n```\n', expect_ok=True)
 check_issue("an issue carrying NO recipe block is refused",
@@ -479,6 +522,55 @@ check_row("a mutant that does not compile is an ERROR — a red lane proves noth
           (None, [], False, "log", 65, 3.0),
           expect_marker="ERR", expect_rc=1)
 
+# The most dangerous defect this tool has had, and it is invisible to a byte comparison. `copy2`
+# restores the original MODIFICATION TIME along with the bytes. Against warm DerivedData, a replacement
+# the SAME SIZE as its anchor therefore leaves a file that is byte-identical AND older than the object
+# compiled from the mutant, so the next row can run mutant code while every check reports clean.
+ran += 1
+_res = drive_row((5, ['✘ Test "the guard holds" recorded an issue'], True, "log", 65, 3.0),
+                 expect_verdict=None, expect_detail=None)
+# drive_row returns (rc, out, after, during); re-run it capturing the file's mtime instead.
+import tempfile as _t3  # noqa: E402
+import os as _os  # noqa: E402
+with _t3.TemporaryDirectory() as td:
+    tmp = make_tree(Path(td))
+    target = tmp / "Sources" / "Thing.swift"
+    _os.utime(target, (1_000_000, 1_000_000))  # deliberately ancient
+    before_mtime = target.stat().st_mtime
+    recipes = tmp / "r.json"
+    # A replacement the SAME LENGTH as the anchor, so bytes-and-size tell you nothing.
+    same_len = dict(VALID_ROW, anchor="let guarded = true", replacement="let guarded = TRUE")
+    recipes.write_text(json.dumps({"rows": [same_len]}))
+
+    class _StubLane:
+        def __init__(self, *a, **k):
+            pass
+
+        def generate_once(self):
+            pass
+
+        def run_suite(self, suite, tag):
+            return (5, ['✘ Test "the guard holds" recorded an issue'], True, "log", 65, 3.0)
+
+    _rl, _rb = battery.Lane, battery.baseline
+    battery.Lane, battery.baseline = _StubLane, (lambda lane, suites, phase: [])
+    try:
+        import io as _io2, contextlib as _cl2
+        with _cl2.redirect_stdout(_io2.StringIO()), _cl2.redirect_stderr(_io2.StringIO()):
+            battery.main_for_test(recipes, tmp)
+    finally:
+        battery.Lane, battery.baseline = _rl, _rb
+
+    after_mtime = target.stat().st_mtime
+    if target.read_text() != "let guarded = true\n":
+        failures.append("same-length restore: content was not restored")
+    elif after_mtime <= before_mtime:
+        failures.append(
+            "a restored file is stamped NOW: it kept its OLD mtime instead, so a warm incremental "
+            "build can skip recompiling and the next row runs against mutant objects")
+    else:
+        print("  ok  a restored file is stamped NOW, so the next build cannot reuse mutant objects")
+
 check_row("the file is restored even when the lane raises mid-row",
           None, expect_marker="ERR", expect_rc=1, raise_instead=RuntimeError("lane exploded"))
 
@@ -505,6 +597,82 @@ else:
             "real lane.")
     else:
         print("  ok  the stubbed lane returns the same shape as the real one")
+
+# A mutation that removes a completion or cancellation path is among the most valuable to write and the
+# most likely to HANG. Unbounded, the unattended battery sits on that row all night and never reaches
+# its restore — leaving a mutated tree behind, which is the one outcome worse than a wrong verdict.
+ran += 1
+with tempfile.TemporaryDirectory() as td:
+    tmp = make_tree(Path(td))
+    target = tmp / "Sources" / "Thing.swift"
+    recipes = tmp / "r.json"
+    recipes.write_text(json.dumps({"rows": [dict(VALID_ROW)]}))
+
+    class _HangingLane:
+        def __init__(self, *a, **k):
+            pass
+
+        def generate_once(self):
+            pass
+
+        def run_suite(self, suite, tag):
+            raise battery._LaneTimedOut("the lane ran past 1800s and was killed")
+
+    _rl, _rb = battery.Lane, battery.baseline
+    battery.Lane, battery.baseline = _HangingLane, (lambda lane, suites, phase: [])
+    try:
+        import io as _io3, contextlib as _cl3
+        _buf = _io3.StringIO()
+        with _cl3.redirect_stdout(_buf), _cl3.redirect_stderr(_buf):
+            _rc = battery.main_for_test(recipes, tmp)
+        _out = _buf.getvalue()
+    finally:
+        battery.Lane, battery.baseline = _rl, _rb
+
+    if target.read_text() != "let guarded = true\n":
+        failures.append("a hanging lane left the tree MUTATED — the restore never ran")
+    elif _rc != 1 or "ERR" not in _out:
+        failures.append(f"a hanging lane should be a row ERROR with exit 1, got {_rc}")
+    else:
+        print("  ok  a hanging lane is a row ERROR and the tree is still restored")
+
+# The case above proves the row loop HANDLES a timeout. It does not prove the lane is bounded — its
+# stub raises the exception directly. These two prove the wiring, and neither reads source text.
+ran += 1
+with tempfile.TemporaryDirectory() as td:
+    try:
+        battery.run(["/bin/sleep", "5"], cwd=td, timeout=1)
+        failures.append("run() honours its timeout and kills the process: it ignored the timeout, so a "
+                        "hanging lane would never be killed")
+    except subprocess.TimeoutExpired:
+        print("  ok  run() honours its timeout and kills the process")
+    except Exception as exc:
+        failures.append(f"run() raised {type(exc).__name__} instead of TimeoutExpired: {exc}")
+
+ran += 1
+_seen_kwargs = {}
+
+
+def _capture(cmd, cwd, log_path=None, timeout=None):
+    _seen_kwargs["timeout"] = timeout
+    return 0, "Test run with 1 test\n"
+
+
+_real_run = battery.run
+battery.run = _capture
+try:
+    _lane = battery.Lane(Path("."), Path("."), Path("."))
+    _lane.generated = True  # skip tuist; this case is about the test lane's timeout only
+    _lane.run_suite("EnviousWisprTests/Whatever", "tag")
+finally:
+    battery.run = _real_run
+
+if _seen_kwargs.get("timeout") != battery.LANE_TIMEOUT_SECONDS:
+    failures.append(
+        "the lane passes LANE_TIMEOUT_SECONDS to the process it starts: it passed "
+        f"timeout={_seen_kwargs.get('timeout')!r} instead, so the bound exists but is not wired")
+else:
+    print("  ok  the lane passes LANE_TIMEOUT_SECONDS to the process it starts")
 
 print()
 if failures:

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -1361,6 +1361,47 @@ if _missing_sigs:
 else:
     print("  ok  every terminating signal is handled")
 
+# `Popen` creates the child in its own session BEFORE the pgid is stored. A signal landing in that
+# window saw _ACTIVE_LANE_PGID as None, re-raised, and left the group orphaned. The handled signals are
+# now blocked across spawn-and-register, and the previous mask restored rather than cleared.
+ran += 1
+_seen_mask = {}
+_real_mask = battery.signal.pthread_sigmask
+_real_popen = battery.subprocess.Popen
+
+
+def _watch_mask(how, mask=None):
+    if how == battery.signal.SIG_BLOCK:
+        _seen_mask["blocked"] = set(mask)
+    elif how == battery.signal.SIG_SETMASK:
+        _seen_mask["restored"] = True
+    return _real_mask(how, mask) if mask is not None else _real_mask(how, [])
+
+
+def _watch_popen(*a, **k):
+    # Blocked at the moment the child is created — that is the window under test.
+    _seen_mask["blocked_at_spawn"] = set(_real_mask(battery.signal.SIG_BLOCK, []))
+    return _real_popen(*a, **k)
+
+
+battery.signal.pthread_sigmask = _watch_mask
+battery.subprocess.Popen = _watch_popen
+try:
+    battery.run(["/bin/echo", "hi"], cwd=tempfile.gettempdir())
+finally:
+    battery.signal.pthread_sigmask = _real_mask
+    battery.subprocess.Popen = _real_popen
+
+_want = set(battery._HANDLED_SIGNALS)
+if not _want <= _seen_mask.get("blocked_at_spawn", set()):
+    failures.append("the handled signals are blocked across spawn-and-register — they were NOT at the "
+                    f"moment Popen ran: {sorted(_seen_mask.get('blocked_at_spawn', set()))}")
+elif not _seen_mask.get("restored"):
+    failures.append("the handled signals are blocked across spawn-and-register — the previous mask was "
+                    "never restored, so the caller's mask was widened")
+else:
+    print("  ok  the handled signals are blocked across spawn-and-register")
+
 print()
 if failures:
     print(f"{len(failures)} of {ran} FAILED:")

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -111,6 +111,10 @@ FAILURE_LINE_RE = re.compile(r"✘ .*")
 #   ✘ Test functionName() recorded an issue ...
 #   ✘ Suite "SuiteName" failed after 0.1 seconds.
 TEST_VERDICT_RE = re.compile(r'^✘\s+Test\s+(?:"(?P<quoted>[^"]*)"|(?P<bare>[A-Za-z_][\w]*)\s*\()')
+# The same identity in the same position, for EITHER outcome — used to enumerate what a clean baseline
+# actually ran, so a recipe naming a test that does not exist is refused before anything is mutated.
+TEST_NAME_ANY_RE = re.compile(
+    r'^[✔✘]\s+Test\s+(?:"(?P<quoted>[^"]*)"|(?P<bare>[A-Za-z_][\w]*)\s*\()', re.MULTILINE)
 SUITE_VERDICT_RE = re.compile(r'^✘\s+Suite\s')
 COMPILE_ERROR_RE = re.compile(r"^.*?: error: ", re.MULTILINE)
 
@@ -771,9 +775,30 @@ def load_recipes(path: Path, worktree: Path, raw: str = None):
     return rows
 
 
-def baseline(lane: Lane, suites, phase: str):
+def suite_test_names(log_path) -> set:
+    """Every test identity the lane REPORTED, pass or fail.
+
+    Swift Testing prints a line per test outcome; both the ✔ and ✘ forms carry the same identity in
+    the same position, so one pattern reads both. Used to prove a recipe's `expect_fail` names a test
+    that exists before anything is mutated.
+    """
+    try:
+        text = Path(log_path).read_text()
+    except OSError:
+        return set()
+    names = set()
+    for m in TEST_NAME_ANY_RE.finditer(text):
+        names.add(m.group("quoted") if m.group("quoted") is not None else m.group("bare"))
+    return names
+
+
+def baseline(lane: Lane, suites, phase: str, seen_names: dict = None):
     """Every named suite must run at least one test and pass. This is both the clean-tree control and
-    the filter validation: a suite name that does not exist executes zero tests and SUCCEEDS."""
+    the filter validation: a suite name that does not exist executes zero tests and SUCCEEDS.
+
+    When `seen_names` is supplied, records the test identities each suite reported, so `expect_fail`
+    can be checked against reality rather than discovered to match nothing after a mutation.
+    """
     problems = []
     for suite in sorted(suites):
         tag = f"baseline-{phase}-{suite.replace('/', '_')}"
@@ -794,6 +819,8 @@ def baseline(lane: Lane, suites, phase: str):
         elif rc != 0 or failures:
             problems.append(f"{suite}: {len(failures)} failing on an unmutated tree ({log})")
         else:
+            if seen_names is not None:
+                seen_names[suite] = suite_test_names(log)
             print(f"    baseline {phase}: {suite} — {count} tests green in {elapsed:.0f}s")
     return problems
 
@@ -829,6 +856,18 @@ def main(argv=None):
     # unconditional mkdir both breaks that promise and crashes on a read-only checkout. The Lane makes
     # it when a lane is actually about to write a log.
     log_dir = worktree / "build" / "mutation-battery"
+
+    # A --worktree that does not exist crashed with a FileNotFoundError traceback from the first
+    # subprocess, rather than refusing. Found by pointing the tool at a peer's worktree minutes after
+    # it was cleaned up on merge — an ordinary thing to do, and exit 1 is the code reserved for a row
+    # SURVIVING. Same class as every other input failure: it is a bad ARGUMENT, so it is a refusal.
+    if not worktree.is_dir():
+        print(f"\nREFUSED — the battery did not start.\n\n"
+              f"--worktree does not exist: {worktree}\n"
+              f"A merged branch's worktree is removed automatically, so a path that worked earlier in "
+              f"the day can be gone. Point it at a checkout that has the code the recipe names.",
+              file=sys.stderr)
+        return 2
 
     print(f"worktree: {worktree}")
     rc, branch = run(["git", "branch", "--show-current"], cwd=worktree)
@@ -867,7 +906,8 @@ def main(argv=None):
 
     print(f"\n[1/3] baseline on a clean tree — {len(suites)} suite(s)")
     try:
-        problems = baseline(lane, suites, "before")
+        baseline_names = {}
+        problems = baseline(lane, suites, "before", seen_names=baseline_names)
     except Refusal as exc:
         print(f"\nREFUSED — {exc}", file=sys.stderr)
         return 2
@@ -879,6 +919,27 @@ def main(argv=None):
         for p in problems:
             print(f"  - {p}", file=sys.stderr)
         return 1
+
+    # Refuse a recipe whose expect_fail names no test the clean baseline ran. The answer is already in
+    # hand at this point, and the alternative is discovering it as a SURVIVED verdict that blames the
+    # test. A PREFIX is the common case and the message says so, because that is what an author who
+    # wrote against the old substring contract will have.
+    unknown = []
+    for i, row in enumerate(rows, 1):
+        known = baseline_names.get(row["suite"])
+        if not known or row["expect_fail"] in known:
+            continue
+        near = sorted(n for n in known if row["expect_fail"] in n or n in row["expect_fail"])
+        hint = f"\n      did you mean: {near[0]!r}" if near else ""
+        unknown.append(f"row {i}: no test named {row['expect_fail']!r} ran in {row['suite']}{hint}")
+    if unknown:
+        print("\nREFUSED — nothing was mutated.\n", file=sys.stderr)
+        print("A recipe names the test that must go red, and these name a test the clean baseline did "
+              "not run. Matching is on the FULL test name, not a prefix — a recipe written when this "
+              "matched substrings will look like this.\n", file=sys.stderr)
+        for u in unknown:
+            print(f"  - {u}", file=sys.stderr)
+        return 2
 
     if args.dry_run:
         print("\n--dry-run: recipes validated, baseline green, nothing mutated.")

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -164,15 +164,28 @@ INVOCATION_RE = re.compile(r"xcodebuild test\s*\\\n(.*?)\|\s*tee", re.DOTALL)
 # xcodebuild with its ambient environment, so any prefix means the canonical lane and the battery build
 # differently, and there is no list of prefixes worth maintaining.
 INVOCATION_PREFIX_RE = re.compile(r"^([^\n]*?)xcodebuild test\s*\\", re.MULTILINE)
-# Files the generated Xcode project is BUILT FROM. `generate_once` runs `tuist generate` a single time
-# and every row after reuses that project, which is correct only while a mutation changes file CONTENT
-# and never the project's shape. Mutating one of these changes target settings, dependencies or source
-# inclusion, and xcodebuild would keep consuming the CLEAN baseline's `.xcodeproj` — so the row would
-# report SURVIVED about a mutant the build never saw. The doc comment on `generate_once` asserted this
-# precondition from the start; nothing enforced it, which is the defect. Rejected at validation rather
-# than handled by regenerating, because a battery that silently changes cost per row is worse than one
-# that says a recipe is out of scope. Cloud review, PR #2158.
-TUIST_INPUTS = ("Project.swift", "Workspace.swift", "Tuist.swift", "Package.swift", "Tuist/")
+# WHAT A RECIPE MAY MUTATE — an ALLOW-list, deliberately, and the second attempt at this.
+#
+# Review round 6 found a recipe could target a Tuist input; the fix denied those by name. Round 7 then
+# found `Tests/` reachable the same way — the identical defect at a site the deny-list did not
+# enumerate. Two rounds of one shape is the signal to stop extending a list and INVERT it
+# (codex-cli.md RULE: enumerate-the-class-when-review-rounds-repeat). The question is no longer "which
+# paths are dangerous", which is unbounded and was wrong once per round, but "where is a mutation
+# MEANINGFUL", which has one answer: production Swift the filtered lane actually executes.
+#
+# What a deny-list would have had to keep growing to cover, and why none of it is a mutation target:
+#   Tests/**       breaking the test makes `expect_fail` go red and the row reports CAUGHT. That proves
+#                  only that breaking a test breaks it, while the report claims a PRODUCTION mutation
+#                  was detected — a false CAUGHT, the exact vacuity this tool exists to prevent.
+#   Project.swift, Workspace.swift, Tuist.swift, Package.swift, Tuist/**
+#                  the project is generated FROM these and `generate_once` reuses one project for every
+#                  row, so xcodebuild keeps consuming the baseline's `.xcodeproj` and the row reports
+#                  SURVIVED about a mutant the build never saw.
+#   scripts/**     including this runner: a battery mutating its own harness reports on itself.
+#   workers/**, website/**
+#                  real code, but nothing an `xcodebuild test` lane executes, so every row reports
+#                  SURVIVED regardless of the test's quality.
+MUTABLE_ROOTS = ("Sources/",)
 # One definition, so the drift guard above and the call below cannot disagree about the version.
 TUIST_GENERATE_ARGV = ["mise", "x", "tuist@4.195.11", "--", "tuist", "generate", "--no-open"]
 
@@ -260,9 +273,9 @@ class Lane:
         pure per-row overhead. Generate once.
 
         Safe ONLY because a mutation changes file CONTENT and never the project's SHAPE. That is a real
-        precondition, not a remark: `TUIST_INPUTS` above rejects recipes targeting the files the project
-        is generated from, because a mutation there would leave xcodebuild consuming the clean
-        baseline's `.xcodeproj` and the row would report SURVIVED about a mutant the build never saw."""
+        precondition, not a remark, and `MUTABLE_ROOTS` above is what enforces it: recipes may only
+        target production Swift under Sources/, so the files the project is generated FROM are
+        unreachable by construction rather than by a list someone must remember to extend."""
         if self.generated:
             return
         rc, out = run(
@@ -274,11 +287,11 @@ class Lane:
             raise Refusal(f"tuist generate failed (rc={rc}); see {self.log_dir/'tuist-generate.log'}")
         self.generated = True
 
-    def run_suite(self, suite: str, tag: str):
-        """Returns (count, failures, compiled, log_path). count is None when no summary was printed."""
-        self.generate_once()
-        log_path = self.log_dir / f"{tag}.log"
-        cmd = [
+    def build_command(self, suite: str):
+        """The invocation this runner issues. Extracted so the self-test can assert it agrees with
+        CANONICAL_TOKENS — the drift guard compares that constant against the SCRIPT, and nothing
+        compared it against the command actually run, so the two could silently disagree."""
+        return [
             "xcodebuild", "test",
             "-project", "EnviousWispr.xcodeproj",
             "-scheme", "EnviousWispr",
@@ -288,6 +301,12 @@ class Lane:
             "ARCHS=arm64", "VALID_ARCHS=arm64", "ONLY_ACTIVE_ARCH=YES",
             f"-only-testing:{suite}",
         ]
+
+    def run_suite(self, suite: str, tag: str):
+        """Returns (count, failures, compiled, log_path). count is None when no summary was printed."""
+        self.generate_once()
+        log_path = self.log_dir / f"{tag}.log"
+        cmd = self.build_command(suite)
         started = time.monotonic()
         try:
             rc, out = run(cmd, cwd=self.worktree, log_path=log_path,
@@ -370,6 +389,12 @@ def check_canonical_settings(worktree: Path):
             "the Lane class with the script, deliberately. Do not delete the guard to make this go "
             "away."
         )
+
+
+def dev_app_pids(worktree: Path):
+    """Live pids, for the per-row recheck. Preflight raises; a mid-run appearance fails only that row."""
+    rc, out = run(["pgrep", "-f", DEV_APP_PATTERN], cwd=worktree)
+    return out.split() if rc == 0 and out.strip() else []
 
 
 def check_no_dev_app(worktree: Path):
@@ -502,18 +527,25 @@ def load_recipes(path: Path, worktree: Path, raw: str = None):
         # whoever authored the issue. Resolve BOTH sides and require containment; resolving is what
         # catches the symlink, since a lexical check cannot.
         rel = row["file"]
-        if rel in TUIST_INPUTS or any(
-            rel.startswith(t) if t.endswith("/") else rel.endswith("/" + t) for t in TUIST_INPUTS
-        ):
+        # Before the allow-list: no absolute path can start with an allowed root, so this check would
+        # be unreachable behind it — a guard nothing can arm. It also gives the precise message.
+        if Path(rel).is_absolute():
+            raise Refusal(f"row {i} file must be repo-relative, got an absolute path: {rel}")
+        if not any(rel.startswith(root) for root in MUTABLE_ROOTS):
             raise Refusal(
-                f"row {i} targets {rel}, which the generated Xcode project is BUILT FROM. This runner "
-                "generates once and reuses that project for every row, so a mutation there would "
-                "change the project's shape while xcodebuild kept consuming the clean baseline's "
-                "`.xcodeproj` — the row would report SURVIVED about a mutant the build never saw. "
-                "Out of scope for the battery; prove that kind of change with a full lane instead."
+                f"row {i} targets {rel}, which is outside {', '.join(MUTABLE_ROOTS)} — the only place a "
+                "mutation means anything here. A mutation must break PRODUCTION code the filtered lane "
+                "actually executes.\n"
+                "  Under Tests/ it would break the test itself, go red, and report CAUGHT, proving only "
+                "that breaking a test breaks it.\n"
+                "  In a Tuist input it would change the project's shape while xcodebuild kept using the "
+                "baseline's generated .xcodeproj, so the row would report SURVIVED about a mutant the "
+                "build never saw.\n"
+                "  Anywhere the lane does not execute, every row reports SURVIVED regardless of the "
+                "test's quality.\n"
+                "An allow-list on purpose: the deny-list it replaced was wrong once per review round. "
+                "Prove a change of that kind with a full lane instead."
             )
-        if Path(row["file"]).is_absolute():
-            raise Refusal(f"row {i} file must be repo-relative, got an absolute path: {row['file']}")
         target = (worktree / row["file"]).resolve()
         wt = worktree.resolve()
         if not (target == wt or wt in target.parents):
@@ -653,6 +685,19 @@ def main(argv=None):
         backup = target.with_suffix(target.suffix + ".mutbak")
         tag = f"row{i:02d}"
         verdict, detail = "ERROR", "did not run"
+        # Preflight is a SNAPSHOT and a battery is long — an overnight run is the whole point of this
+        # tool. A dev app that starts after preflight and stops before the closing baseline corrupts
+        # the AppLogger tests only DURING a mutant, producing a false CAUGHT: the sabotage is credited
+        # with a failure something else caused. That fails toward CONFIDENCE, so it is rechecked per
+        # row rather than once. Cloud review, PR #2158.
+        intruders = dev_app_pids(worktree)
+        if intruders:
+            detail = (f"a dev app appeared mid-run (pids {' '.join(intruders)}) — its app.log writes "
+                      f"corrupt the AppLogger tests, which scores as CAUGHT when nothing detected the "
+                      f"sabotage. Stop it and re-run this row.")
+            print(f"  [ ERR  ] row {i}: {row['label']}\n           {detail}")
+            results.append(("ERROR", row["label"], detail))
+            continue
         shutil.copy2(target, backup)
         _ACTIVE_RESTORES[target] = backup
         try:

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -110,11 +110,19 @@ FAILURE_LINE_RE = re.compile(r"✘ .*")
 #   ✘ Test "display name" recorded an issue at File.swift:12:3: Expectation failed: ...
 #   ✘ Test functionName() recorded an issue ...
 #   ✘ Suite "SuiteName" failed after 0.1 seconds.
-TEST_VERDICT_RE = re.compile(r'^✘\s+Test\s+(?:"(?P<quoted>[^"]*)"|(?P<bare>[A-Za-z_][\w]*)\s*\()')
+# A display name may CONTAIN quotes — Swift Testing prints them unescaped, and this repo has three:
+#   @Test("founder repro: \"Other apps.\" (2 words, punctuation kept) bypasses")
+# so terminating on the first inner quote truncated the identity to `founder repro: `, which then
+# matched nothing and made those tests unusable in a recipe. Terminate on the closing quote that is
+# FOLLOWED BY a verdict verb instead — greedy up to the last one. Cloud review, PR #2158.
+_VERDICT_VERB = r'(?:recorded|passed|failed|skipped)'
+TEST_VERDICT_RE = re.compile(
+    r'^✘\s+Test\s+(?:"(?P<quoted>.*)"\s+' + _VERDICT_VERB + r'|(?P<bare>[A-Za-z_][\w]*)\s*\()')
 # The same identity in the same position, for EITHER outcome — used to enumerate what a clean baseline
 # actually ran, so a recipe naming a test that does not exist is refused before anything is mutated.
 TEST_NAME_ANY_RE = re.compile(
-    r'^[✔✘]\s+Test\s+(?:"(?P<quoted>[^"]*)"|(?P<bare>[A-Za-z_][\w]*)\s*\()', re.MULTILINE)
+    r'^[✔✘]\s+Test\s+(?:"(?P<quoted>.*)"\s+' + _VERDICT_VERB + r'|(?P<bare>[A-Za-z_][\w]*)\s*\()',
+    re.MULTILINE)
 SUITE_VERDICT_RE = re.compile(r'^✘\s+Suite\s')
 COMPILE_ERROR_RE = re.compile(r"^.*?: error: ", re.MULTILINE)
 

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -134,6 +134,7 @@ CANONICAL_SCRIPT = "scripts/xcode-test.sh"
 CANONICAL_TOKENS = {
     "-project", "-scheme", "-configuration", "-derivedDataPath", "-destination",
     "ARCHS=arm64", "VALID_ARCHS=arm64", "ONLY_ACTIVE_ARCH=YES",
+    "-onlyUsePackageVersionsFromResolvedFile",
 }
 # Values that are shell expansions in the invocation and literals here, so they cannot be compared as
 # tokens. Two review rounds each found ONE more of these, so rather than wait for a third the axes were
@@ -159,7 +160,7 @@ CANONICAL_ASSIGNMENTS = [
     # still starts with the prefix, and those trailing positionals reach xcodebuild through `"$@"`,
     # which the expansion allowlist accepts by name without seeing its contents.
     'run_lane "$DEBUG_SCHEME" Debug build/xcode-test-debug.log\n',
-    "mise x tuist@4.195.11 -- tuist generate --no-open",
+    'ew_ensure_generated "$PROJECT_ROOT"',
 ]
 # Expansions the runner knows the contents of, because CANONICAL_ASSIGNMENTS pins each one. An
 # expansion NOT in this set hides arguments the runner cannot see, so it is a refusal rather than a
@@ -204,7 +205,13 @@ INVOCATION_PREFIX_RE = re.compile(r"^([^\n]*?)xcodebuild test\s*\\", re.MULTILIN
 #                  SURVIVED regardless of the test's quality.
 MUTABLE_ROOTS = ("Sources/",)
 # One definition, so the drift guard above and the call below cannot disagree about the version.
-TUIST_GENERATE_ARGV = ["mise", "x", "tuist@4.195.11", "--", "tuist", "generate", "--no-open"]
+# #2178 moved generation into `scripts/lib/ensure-generated.sh`, which skips `tuist generate` unless an
+# input hash changed (6.7s -> 0.06s, project.pbxproj byte-identical). Invoked through the script's own
+# helper rather than reproducing the pin, so the version lives in exactly one place — the duplication
+# this runner is stuck with is the INVOCATION, and it should not grow a second copy of the toolchain
+# pin as well.
+TUIST_GENERATE_ARGV = ["bash", "-c",
+                       'source scripts/lib/ensure-generated.sh && ew_ensure_generated "$PWD"']
 
 
 # A row's restore lives in a `finally`, and Python's DEFAULT action for SIGTERM does not run it: the
@@ -442,6 +449,7 @@ class Lane:
             "-configuration", "Debug",
             "-derivedDataPath", str(self.derived_data),
             "-destination", "platform=macOS,arch=arm64",
+            "-onlyUsePackageVersionsFromResolvedFile",
             "ARCHS=arm64", "VALID_ARCHS=arm64", "ONLY_ACTIVE_ARCH=YES",
             f"-only-testing:{suite}",
         ]

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -101,6 +101,10 @@ DEV_APP_PATTERN = os.environ.get(
     "EW_BATTERY_DEV_APP_PATTERN", "EnviousWispr Local.app/Contents/MacOS/EnviousWispr")
 
 TEST_COUNT_RE = re.compile(r"Test run with (\d+) test")
+# Swift Testing prints ✘ for a KNOWN issue too, and the lane still exits 0. A test wrapped in
+# `withKnownIssue` is explicitly configured NOT to go red, so crediting it with detecting a mutation is
+# a false CAUGHT — the direction that fails toward confidence. Matched separately and excluded.
+KNOWN_ISSUE_RE = re.compile(r"✘ .*known issue.*")
 FAILURE_LINE_RE = re.compile(r"✘ .*")
 COMPILE_ERROR_RE = re.compile(r"^.*?: error: ", re.MULTILINE)
 
@@ -249,14 +253,58 @@ LANE_TIMEOUT_SECONDS = 1800
 
 
 def run(cmd, cwd, log_path=None, timeout=None):
-    """Run a command, optionally teeing to a per-row log. Never the shared fixed log path."""
-    proc = subprocess.run(
-        cmd, cwd=str(cwd), capture_output=True, text=True, timeout=timeout, check=False
+    """Run a command, optionally teeing to a per-row log. Never the shared fixed log path.
+
+    On timeout this kills the whole PROCESS GROUP, not just the direct child. `xcodebuild` spawns the
+    test runner as a descendant, so killing only the parent leaves a hung mutant test process alive —
+    still holding the shared DerivedData and still writing logs while later rows run, which corrupts
+    their verdicts long after the source has been restored. The battery would look like it recovered.
+    Cloud review, PR #2158.
+    """
+    proc = subprocess.Popen(
+        cmd, cwd=str(cwd), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+        start_new_session=True,   # its own process group, so the kill below reaches descendants
     )
-    out = proc.stdout + proc.stderr
+    try:
+        out, _ = proc.communicate(timeout=timeout)
+        rc = proc.returncode
+    except subprocess.TimeoutExpired:
+        # Kill the GROUP, then re-raise. The raise is the existing contract — the row loop turns it into
+        # a row ERROR with a timeout-specific message — and changing it here would have quietly widened
+        # a bug fix into a behaviour change. Only the cleanup was wrong.
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            proc.kill()
+        try:
+            out, _ = proc.communicate(timeout=10)
+        except subprocess.TimeoutExpired:
+            out = ""
+        if log_path is not None:
+            Path(log_path).write_text(
+                (out or "") + f"\n[mutation-battery] timed out after {timeout}s; group killed\n")
+        raise
     if log_path is not None:
-        Path(log_path).write_text(out)
-    return proc.returncode, out
+        Path(log_path).write_text(out or "")
+    return rc, out or ""
+
+
+def classify_lane_output(out: str):
+    """Split a lane's output into (executed count, REAL failure lines).
+
+    Extracted so it can be tested without a build: the self-test's stubbed lane replaces `run_suite`
+    wholesale, so anything parsed inside it is unreachable from those cases — a check aimed there would
+    pass while testing nothing.
+
+    Swift Testing prints ✘ for a KNOWN issue as well, and the lane still exits 0. A test wrapped in
+    `withKnownIssue` is explicitly configured NOT to go red, so counting that line as a failure credits
+    it with detecting a mutation it was told to tolerate — a false CAUGHT.
+    """
+    counts = [int(n) for n in TEST_COUNT_RE.findall(out)]
+    count = sum(counts) if counts else None
+    known = set(KNOWN_ISSUE_RE.findall(out))
+    failures = [ln for ln in FAILURE_LINE_RE.findall(out) if ln not in known]
+    return count, failures
 
 
 class Lane:
@@ -321,9 +369,7 @@ class Lane:
                 f"catch ({log_path})")
         elapsed = time.monotonic() - started
 
-        counts = [int(n) for n in TEST_COUNT_RE.findall(out)]
-        count = sum(counts) if counts else None
-        failures = FAILURE_LINE_RE.findall(out)
+        count, failures = classify_lane_output(out)
         # A red lane with compiler diagnostics and no test summary never ran the tests.
         compiled = not (count is None and COMPILE_ERROR_RE.search(out) is not None)
         return count, failures, compiled, log_path, rc, elapsed
@@ -747,6 +793,15 @@ def main(argv=None):
                             f"executed ZERO tests, so this row is a verdict about nothing. Either the "
                             f"suite was renamed and the recipe is stale, or the filter never matched. "
                             f"Read the name off its @Suite declaration, never off the filename ({log})"
+                        )
+                    elif rc_run == 0:
+                        # A green lane cannot have caught anything. Reached when the only ✘ lines were
+                        # known issues, which Swift Testing prints while still exiting 0.
+                        verdict = "SURVIVED"
+                        detail = (
+                            f"{count} tests and the lane exited GREEN with the code broken. Any ✘ here "
+                            f"was a KNOWN issue, which is a test configured not to fail — it cannot "
+                            f"have detected the mutation ({log})"
                         )
                     elif any(row["expect_fail"] in line for line in failures):
                         verdict = "CAUGHT"

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -312,6 +312,9 @@ class _RowFailed(Exception):
 # so it leaves a MUTATED TREE behind. The bound is generous: it exists to convert a hang into a row
 # ERROR, not to police a slow suite (validation-discipline.md `hang-guard-vs-latency-bound`).
 LANE_TIMEOUT_SECONDS = 1800
+# Generation is bounded too. It is fast on a warm tree (0.06s when the input hash is unchanged,
+# ~7s cold), so a generous bound still catches a genuine stall without ever firing in normal use.
+GENERATE_TIMEOUT_SECONDS = int(os.environ.get("EW_BATTERY_GENERATE_TIMEOUT", "600"))
 
 
 # The process group of the lane currently running, or None. Registered before the lane starts and
@@ -379,8 +382,11 @@ def run(cmd, cwd, log_path=None, timeout=None):
         except subprocess.TimeoutExpired:
             out = ""
         if log_path is not None:
-            Path(log_path).write_text(
-                (out or "") + f"\n[mutation-battery] timed out after {timeout}s; group killed\n")
+            # APPEND. This used to overwrite what was captured before the timeout, throwing away the
+            # only record of which build or test operation hung — on the one path where it matters.
+            with open(log_path, "a") as fh:
+                fh.write((out or "")
+                         + f"\n[mutation-battery] timed out after {timeout}s; group killed\n")
         raise
     finally:
         _ACTIVE_LANE_PGID = None
@@ -454,11 +460,20 @@ class Lane:
         unreachable by construction rather than by a list someone must remember to extend."""
         if self.generated:
             return
-        rc, out = run(
-            TUIST_GENERATE_ARGV,
-            cwd=self.worktree,
-            log_path=self.log_dir / "tuist-generate.log",
-        )
+        try:
+            rc, out = run(
+                TUIST_GENERATE_ARGV,
+                cwd=self.worktree,
+                log_path=self.log_dir / "tuist-generate.log",
+                timeout=GENERATE_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            raise _LaneTimedOut(
+                f"project generation did not finish within {GENERATE_TIMEOUT_SECONDS}s. The lane "
+                "timeout bounds the TEST call; this bounds the setup before it, so an unattended run "
+                "cannot park overnight in either. Its process group was killed; see "
+                f"{self.log_dir / 'tuist-generate.log'}"
+            )
         if rc != 0:
             raise Refusal(f"tuist generate failed (rc={rc}); see {self.log_dir/'tuist-generate.log'}")
         self.generated = True

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -80,6 +80,28 @@ FAILURE_LINE_RE = re.compile(r"✘ .*")
 COMPILE_ERROR_RE = re.compile(r"^.*?: error: ", re.MULTILINE)
 
 
+# The canonical logic-test entry point is scripts/xcode-test.sh (tools-and-apps.md
+# RULE: xcode-test-entrypoint). This runner deliberately does NOT shell out to it, for two reasons:
+# that script tees to a FIXED log path and SUMS every "Test run with N test" line it finds, so two
+# lanes writing it produce an inflated count; and it runs `tuist generate` unconditionally, 6.7s of
+# byte-identical output per row. Both are correct for a one-shot run and wrong for a battery.
+#
+# The cost of that deviation is TWO SOURCES OF TRUTH for the build settings, so it is paid for with a
+# fail-closed drift guard: if the canonical script's settings stop matching the ones below, the battery
+# REFUSES rather than quietly measuring a differently-configured build. Reconcile deliberately; do not
+# silence it.
+CANONICAL_SCRIPT = "scripts/xcode-test.sh"
+CANONICAL_SETTINGS = [
+    'PROJECT="EnviousWispr.xcodeproj"',
+    'DEBUG_SCHEME="EnviousWispr"',
+    "DEST='platform=macOS,arch=arm64'",
+    "ARCHS=arm64",
+    "VALID_ARCHS=arm64",
+    "ONLY_ACTIVE_ARCH=YES",
+    'TEST_ARGS=(-only-testing:"$FILTER")',
+]
+
+
 class Refusal(Exception):
     """Preflight said no. The battery never started, so there is nothing to restore."""
 
@@ -145,7 +167,28 @@ class Lane:
         return count, failures, compiled, log_path, rc, elapsed
 
 
+def check_canonical_settings(worktree: Path):
+    """Fail closed if scripts/xcode-test.sh has drifted from the flags this runner reproduces."""
+    canonical = worktree / CANONICAL_SCRIPT
+    if not canonical.is_file():
+        raise Refusal(
+            f"{CANONICAL_SCRIPT} is missing. This runner reproduces its build settings, so it cannot "
+            "confirm it is building the same thing the canonical entry point builds."
+        )
+    text = canonical.read_text()
+    missing = [frag for frag in CANONICAL_SETTINGS if frag not in text]
+    if missing:
+        raise Refusal(
+            f"{CANONICAL_SCRIPT} no longer contains settings this runner reproduces, so the battery "
+            "would measure a differently-configured build than the canonical lane:\n  "
+            + "\n  ".join(missing)
+            + "\n\nReconcile CANONICAL_SETTINGS and the Lane class with the script, deliberately. "
+            "Do not delete the guard to make this go away."
+        )
+
+
 def preflight(worktree: Path):
+    check_canonical_settings(worktree)
     rc, out = run(["pgrep", "-f", DEV_APP_PATTERN], cwd=worktree)
     if rc == 0 and out.strip():
         raise Refusal(

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -104,8 +104,14 @@ TEST_COUNT_RE = re.compile(r"Test run with (\d+) test")
 # Swift Testing prints ✘ for a KNOWN issue too, and the lane still exits 0. A test wrapped in
 # `withKnownIssue` is explicitly configured NOT to go red, so crediting it with detecting a mutation is
 # a false CAUGHT — the direction that fails toward confidence. Matched separately and excluded.
-KNOWN_ISSUE_RE = re.compile(r"✘ .*known issue.*")
+KNOWN_ISSUE_RE = re.compile(r"✘ .*[Kk]nown issue.*")
 FAILURE_LINE_RE = re.compile(r"✘ .*")
+# Swift Testing's two verdict shapes, plus the SUITE line that must never be read as a test failing.
+#   ✘ Test "display name" recorded an issue at File.swift:12:3: Expectation failed: ...
+#   ✘ Test functionName() recorded an issue ...
+#   ✘ Suite "SuiteName" failed after 0.1 seconds.
+TEST_VERDICT_RE = re.compile(r'^✘\s+Test\s+(?:"(?P<quoted>[^"]*)"|(?P<bare>[A-Za-z_][\w]*)\s*\()')
+SUITE_VERDICT_RE = re.compile(r'^✘\s+Suite\s')
 COMPILE_ERROR_RE = re.compile(r"^.*?: error: ", re.MULTILINE)
 
 
@@ -218,6 +224,10 @@ def _restore_active(reason: str):
 
 def _install_restore_on_signal():
     def handler(signum, _frame):
+        # Reap the lane FIRST. Restoring the file while xcodebuild's group survives leaves an orphan
+        # running mutant tests and writing the shared DerivedData after we are gone — the file looks
+        # recovered and the machine is not. Fixing only the timeout path last round missed this exit.
+        _reap_active_lane()
         _restore_active(f"signal {signum}")
         # Re-raise with the default action so the exit status still says we were killed.
         signal.signal(signum, signal.SIG_DFL)
@@ -225,6 +235,27 @@ def _install_restore_on_signal():
 
     for sig in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
         signal.signal(sig, handler)
+
+
+def read_recipe_target(path: Path, what: str) -> str:
+    """Read a file a RECIPE named, converting every failure into a Refusal.
+
+    A recipe is data someone else wrote, so every way its target can fail to read is a bad recipe
+    rather than a broken battery: missing, unreadable, or not text at all. `Sources/` holds binary
+    resources too, and `read_text` on a .wav raises UnicodeDecodeError — a ValueError, so an
+    OSError-only guard misses it and the unattended command emits a traceback with exit 1, the status
+    reserved for a SURVIVED row.
+    """
+    try:
+        return path.read_text()
+    except UnicodeDecodeError:
+        raise Refusal(
+            f"{what} is not text: {path}\n"
+            "A mutation edits source. Binary resources live under Sources/ too, and they are not "
+            "mutation targets — nothing in a filtered Swift lane reads them as code."
+        )
+    except OSError as exc:
+        raise Refusal(f"cannot read {what}: {path}: {exc}")
 
 
 class Refusal(Exception):
@@ -252,6 +283,26 @@ class _RowFailed(Exception):
 LANE_TIMEOUT_SECONDS = 1800
 
 
+# The process group of the lane currently running, or None. Registered before the lane starts and
+# cleared when it ends, so EVERY exit path — timeout, cancellation, an unexpected exception — can reap
+# it. Fixing only the timeout path last round left cancellation orphaning the group; the defect was
+# never "the timeout is wrong", it was "an exit path does not reap".
+_ACTIVE_LANE_PGID = None
+
+
+def _reap_active_lane():
+    """Kill the live lane's process group if there is one. Safe to call more than once."""
+    global _ACTIVE_LANE_PGID
+    pgid, _ACTIVE_LANE_PGID = _ACTIVE_LANE_PGID, None
+    if pgid is None:
+        return False
+    try:
+        os.killpg(pgid, signal.SIGKILL)
+        return True
+    except (ProcessLookupError, PermissionError):
+        return False
+
+
 def run(cmd, cwd, log_path=None, timeout=None):
     """Run a command, optionally teeing to a per-row log. Never the shared fixed log path.
 
@@ -261,10 +312,15 @@ def run(cmd, cwd, log_path=None, timeout=None):
     their verdicts long after the source has been restored. The battery would look like it recovered.
     Cloud review, PR #2158.
     """
+    global _ACTIVE_LANE_PGID
     proc = subprocess.Popen(
         cmd, cwd=str(cwd), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
-        start_new_session=True,   # its own process group, so the kill below reaches descendants
+        start_new_session=True,   # its own process group, so the kills below reach descendants
     )
+    try:
+        _ACTIVE_LANE_PGID = os.getpgid(proc.pid)
+    except ProcessLookupError:
+        _ACTIVE_LANE_PGID = None
     try:
         out, _ = proc.communicate(timeout=timeout)
         rc = proc.returncode
@@ -272,9 +328,7 @@ def run(cmd, cwd, log_path=None, timeout=None):
         # Kill the GROUP, then re-raise. The raise is the existing contract — the row loop turns it into
         # a row ERROR with a timeout-specific message — and changing it here would have quietly widened
         # a bug fix into a behaviour change. Only the cleanup was wrong.
-        try:
-            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-        except (ProcessLookupError, PermissionError):
+        if not _reap_active_lane():
             proc.kill()
         try:
             out, _ = proc.communicate(timeout=10)
@@ -284,6 +338,8 @@ def run(cmd, cwd, log_path=None, timeout=None):
             Path(log_path).write_text(
                 (out or "") + f"\n[mutation-battery] timed out after {timeout}s; group killed\n")
         raise
+    finally:
+        _ACTIVE_LANE_PGID = None
     if log_path is not None:
         Path(log_path).write_text(out or "")
     return rc, out or ""
@@ -305,6 +361,33 @@ def classify_lane_output(out: str):
     known = set(KNOWN_ISSUE_RE.findall(out))
     failures = [ln for ln in FAILURE_LINE_RE.findall(out) if ln not in known]
     return count, failures
+
+
+def failed_test_identities(failure_lines):
+    """The set of TEST identities that failed — never suites, never message text.
+
+    `expect_fail` used to be matched with `in` against the whole ✘ line, which carries the display
+    name, the source path AND the expectation message. Three false-CAUGHT paths followed from that:
+    a sibling whose name merely CONTAINS the expected one; a short phrase matching some other test's
+    message or file path; and `✘ Suite "X" failed`, which Swift Testing prints whenever ANY member
+    fails, matching any expect_fail that is a substring of the suite name.
+
+    Identity is the quoted display name, or the bare function name for an unnamed @Test.
+    """
+    identities = set()
+    for line in failure_lines:
+        line = line.strip()
+        if SUITE_VERDICT_RE.match(line):
+            # A suite verdict is an aggregate, never evidence about one test. REDUNDANT today, and
+            # deliberately kept: TEST_VERDICT_RE already refuses to match a `✘ Suite` line, so a
+            # mutation control on this branch alone cannot fail — proven, not assumed. It stays as the
+            # explicit statement of intent, so loosening TEST_VERDICT_RE later cannot silently let
+            # suite lines through.
+            continue
+        m = TEST_VERDICT_RE.match(line)
+        if m:
+            identities.add(m.group("quoted") if m.group("quoted") is not None else m.group("bare"))
+    return identities
 
 
 class Lane:
@@ -470,7 +553,9 @@ def preflight(worktree: Path, *, will_run_tests: bool = True):
     check_canonical_settings(worktree)
     if will_run_tests:
         check_no_dev_app(worktree)
-    leftovers = list(worktree.rglob("*.mutbak"))
+    # Case-insensitive: the preflight glob is case-SENSITIVE but the default APFS volume is not, so a
+    # `.MUTBAK` would be invisible here and then silently overwritten and unlinked by a row.
+    leftovers = [q for q in worktree.rglob("*") if q.suffix.lower() == ".mutbak"]
     if leftovers:
         raise Refusal(
             "Backup files from an earlier battery are still on disk, so a previous run did not "
@@ -528,10 +613,7 @@ def load_recipes(path: Path, worktree: Path, raw: str = None):
         # A missing or unreadable file is a preflight refusal like any other. Left as an OSError it
         # escapes as a traceback with exit 1, which the documented exit codes reserve for "a row
         # SURVIVED" — the one status an unattended caller must not confuse with a real result.
-        try:
-            raw = path.read_text()
-        except OSError as exc:
-            raise Refusal(f"cannot read the recipe file {path}: {exc}")
+        raw = read_recipe_target(path, "the recipe file")
     try:
         data = json.loads(raw)
     except json.JSONDecodeError as exc:
@@ -621,12 +703,20 @@ def load_recipes(path: Path, worktree: Path, raw: str = None):
             )
         if not target.is_file():
             raise Refusal(f"row {i} target does not exist: {row['file']}")
+        if target.suffix != ".swift":
+            raise Refusal(
+                f"row {i} targets {rel}, which is not Swift. A mutation must break code the filtered "
+                "lane EXECUTES; Sources/ also holds plists, strings, JSON and docs, and a row against "
+                "any of those reports SURVIVED however good the test is."
+            )
         row["_resolved"] = str(target)
         if row["anchor"] == row["replacement"]:
             raise Refusal(f"row {i} anchor and replacement are identical — it would mutate nothing.")
         # Check anchor presence and uniqueness HERE, against the clean tree, so a bad recipe costs
         # nothing. The row re-checks at apply time because an earlier row may share the file.
-        occurrences = target.read_text().count(row["anchor"])  # target is the resolved, contained path
+        # Reads the resolved, contained path through the helper, so a binary resource under Sources/
+        # is refused HERE — before any row runs — rather than raising mid-battery.
+        occurrences = read_recipe_target(target, f"row {i}'s target").count(row["anchor"])
         if occurrences == 0:
             raise Refusal(
                 f"row {i} anchor not found in {row['file']} — the mutation would never be applied, "
@@ -769,7 +859,7 @@ def main(argv=None):
         shutil.copy2(target, backup)
         _ACTIVE_RESTORES[target] = backup
         try:
-            src = target.read_text()
+            src = read_recipe_target(target, f"row {i}'s target")
             occurrences = src.count(row["anchor"])
             if occurrences == 0:
                 detail = "anchor not found — the mutation was never applied"
@@ -778,7 +868,7 @@ def main(argv=None):
             else:
                 target.write_text(src.replace(row["anchor"], row["replacement"], 1))
                 # Prove it landed by reading the file back rather than trusting the write.
-                if row["replacement"] not in target.read_text():
+                if row["replacement"] not in read_recipe_target(target, f"row {i}'s target"):
                     detail = "mutation did not land on re-read"
                 else:
                     try:
@@ -803,7 +893,7 @@ def main(argv=None):
                             f"was a KNOWN issue, which is a test configured not to fail — it cannot "
                             f"have detected the mutation ({log})"
                         )
-                    elif any(row["expect_fail"] in line for line in failures):
+                    elif row["expect_fail"] in failed_test_identities(failures):
                         verdict = "CAUGHT"
                         others = [l for l in failures if row["expect_fail"] not in l]
                         detail = f"{row['expect_fail']} went red in {elapsed:.0f}s"
@@ -818,8 +908,10 @@ def main(argv=None):
                     else:
                         verdict = "SURVIVED"
                         detail = f"{count} tests still green with the code broken ({log})"
-        except _RowFailed as exc:
+        except (_RowFailed, Refusal) as exc:
             detail = str(exc)
+        except Exception as exc:  # noqa: BLE001 — any row failure is this row's problem, not the run's
+            detail = f"row raised {type(exc).__name__}: {exc}"
         finally:
             shutil.copy2(backup, target)
             # `copy2` restores the original MODIFICATION TIME as well as the bytes, and that is a bug
@@ -832,8 +924,18 @@ def main(argv=None):
             os.utime(target, None)
             if not filecmp.cmp(backup, target, shallow=False):
                 verdict, detail = "ERROR", "RESTORE FAILED — the tree is dirty, stop and inspect"
+                results.append((verdict, row["label"], detail))
+                print(f"  [ ERR  ] row {i}: {row['label']}\n           {detail}")
+                print(
+                    f"\nSTOPPING. {target} could not be restored, so the next row would back up a "
+                    f"MUTATED file as its own baseline and every row after it would run sabotaged "
+                    f"code. Its backup is kept at {backup} — restore it by hand and inspect before "
+                    f"running anything else.",
+                    file=sys.stderr,
+                )
+                return 1
             else:
-                backup.unlink()
+                backup.unlink()   # verified byte-identical; on failure the backup is KEPT (above)
             _ACTIVE_RESTORES.pop(target, None)
         marker = {"CAUGHT": "  ok  ", "SURVIVED": " SURV ", "ERROR": " ERR  "}[verdict]
         print(f"  [{marker}] row {i}: {row['label']}\n           {detail}")

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -241,7 +241,7 @@ def _install_restore_on_signal():
         # Ignore further signals FIRST. A second one arriving inside the restore loop re-enters this
         # handler and reaches the re-raise below before the remaining targets are copied back, so a
         # double Ctrl-C would leave files mutated.
-        for other in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP, signal.SIGQUIT):
+        for other in _HANDLED_SIGNALS:
             signal.signal(other, signal.SIG_IGN)
         # Reap the lane FIRST. Restoring the file while xcodebuild's group survives leaves an orphan
         # running mutant tests and writing the shared DerivedData after we are gone — the file looks
@@ -252,7 +252,7 @@ def _install_restore_on_signal():
         signal.signal(signum, signal.SIG_DFL)
         os.kill(os.getpid(), signum)
 
-    for sig in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP, signal.SIGQUIT):
+    for sig in _HANDLED_SIGNALS:
         signal.signal(sig, handler)
 
 
@@ -306,6 +306,9 @@ LANE_TIMEOUT_SECONDS = 1800
 # cleared when it ends, so EVERY exit path — timeout, cancellation, an unexpected exception — can reap
 # it. Fixing only the timeout path last round left cancellation orphaning the group; the defect was
 # never "the timeout is wrong", it was "an exit path does not reap".
+# One definition, so the spawn mask, the installer and the re-entrancy guard cannot drift apart.
+_HANDLED_SIGNALS = (signal.SIGTERM, signal.SIGINT, signal.SIGHUP, signal.SIGQUIT)
+
 _ACTIVE_LANE_PGID = None
 
 
@@ -332,14 +335,24 @@ def run(cmd, cwd, log_path=None, timeout=None):
     Cloud review, PR #2158.
     """
     global _ACTIVE_LANE_PGID
-    proc = subprocess.Popen(
-        cmd, cwd=str(cwd), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
-        start_new_session=True,   # its own process group, so the kills below reach descendants
-    )
+    # BLOCK the handled signals across spawn-and-register. `Popen` creates the child in its own session
+    # BEFORE the pgid is stored, so a signal landing in that window sees `_ACTIVE_LANE_PGID` as None,
+    # re-raises, and leaves an isolated tuist/xcodebuild group running after the battery exits. The
+    # window is microseconds and the failure is SILENT — an orphan holding the shared DerivedData with
+    # nothing reporting it — which is the combination that earns a fix rather than a recorded limit.
+    _blocked = signal.pthread_sigmask(signal.SIG_BLOCK, _HANDLED_SIGNALS)
     try:
-        _ACTIVE_LANE_PGID = os.getpgid(proc.pid)
-    except ProcessLookupError:
-        _ACTIVE_LANE_PGID = None
+        proc = subprocess.Popen(
+            cmd, cwd=str(cwd), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+            start_new_session=True,   # its own process group, so the kills below reach descendants
+        )
+        try:
+            _ACTIVE_LANE_PGID = os.getpgid(proc.pid)
+        except ProcessLookupError:
+            _ACTIVE_LANE_PGID = None
+    finally:
+        # Restore rather than unconditionally unblock: never widen the caller's mask.
+        signal.pthread_sigmask(signal.SIG_SETMASK, _blocked)
     try:
         out, _ = proc.communicate(timeout=timeout)
         rc = proc.returncode

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -47,6 +47,7 @@ RECIPE FORMAT (JSON; the same block that goes in the `test-hardening` issue body
     }
 
 USAGE
+    scripts/mutation-battery.py --from-issue 2156        # the overnight form: recipe from the issue
     scripts/mutation-battery.py --recipes recipes.json
     scripts/mutation-battery.py --recipes recipes.json --row 3      # one row, for iterating on a fix
     scripts/mutation-battery.py --recipes recipes.json --dry-run    # validate + baseline, no mutations
@@ -206,12 +207,49 @@ def preflight(worktree: Path):
         )
 
 
-def load_recipes(path: Path, worktree: Path):
-    data = json.loads(path.read_text())
+FENCE_RE = re.compile(r"```json\s*\n(.*?)```", re.DOTALL)
+
+
+def recipes_from_issue(number: int, worktree: Path):
+    """Pull the recipe out of a `test-hardening` issue body.
+
+    The issue IS the backlog (testing-philosophy.md RULE:
+    write-the-test-by-day-run-the-battery-by-night) — the founder hands out overnight work from the issue
+    list, so a recipe living in a repo file is invisible to that. This is what closes the loop: the
+    overnight session runs `--from-issue N` and never has to transcribe anything by hand.
+
+    Fails closed on zero or several fenced json blocks. Picking "the first one" would silently run a
+    different recipe than the one a reader of the issue believes is running.
+    """
+    rc, out = run(
+        ["gh", "issue", "view", str(number), "--json", "body", "--jq", ".body"], cwd=worktree
+    )
+    if rc != 0:
+        raise Refusal(f"could not read issue #{number}: {out.strip()[:300]}")
+    blocks = FENCE_RE.findall(out)
+    if not blocks:
+        raise Refusal(
+            f"issue #{number} carries no ```json recipe block. A test-hardening issue without its "
+            "recipe cannot be acted on cold, which is the whole reason the recipe goes in the BODY."
+        )
+    if len(blocks) > 1:
+        raise Refusal(
+            f"issue #{number} carries {len(blocks)} ```json blocks. Exactly one, or the run and the "
+            "issue disagree about what was tested."
+        )
+    return blocks[0]
+
+
+def load_recipes(path: Path, worktree: Path, raw: str = None):
+    try:
+        data = json.loads(raw if raw is not None else path.read_text())
+    except json.JSONDecodeError as exc:
+        where = f"issue body" if raw is not None else str(path)
+        raise Refusal(f"the recipe in {where} is not valid JSON: {exc}")
     default_suite = data.get("suite_default")
     rows = data.get("rows") or []
     if not rows:
-        raise Refusal(f"{path} declares no rows.")
+        raise Refusal(f"{'the issue body' if raw is not None else path} declares no rows.")
     for i, row in enumerate(rows, 1):
         for field in ("label", "file", "anchor", "replacement", "expect_fail"):
             if not row.get(field):
@@ -269,7 +307,10 @@ def baseline(lane: Lane, suites, phase: str):
 
 def main():
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--recipes", required=True, type=Path)
+    src = ap.add_mutually_exclusive_group(required=True)
+    src.add_argument("--recipes", type=Path, help="a recipe JSON file")
+    src.add_argument("--from-issue", type=int, metavar="N",
+                     help="read the recipe from the ```json block in test-hardening issue #N")
     ap.add_argument("--worktree", type=Path, default=None)
     ap.add_argument("--row", type=int, default=None, help="run a single 1-indexed row")
     ap.add_argument("--dry-run", action="store_true", help="validate recipes and baseline, mutate nothing")
@@ -292,7 +333,11 @@ def main():
 
     try:
         preflight(worktree)
-        rows = load_recipes(args.recipes.resolve(), worktree)
+        if args.from_issue is not None:
+            print(f"recipe:   issue #{args.from_issue}")
+            rows = load_recipes(None, worktree, raw=recipes_from_issue(args.from_issue, worktree))
+        else:
+            rows = load_recipes(args.recipes.resolve(), worktree)
     except Refusal as exc:
         print(f"\nREFUSED — the battery did not start.\n\n{exc}", file=sys.stderr)
         return 2

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -92,19 +92,36 @@ COMPILE_ERROR_RE = re.compile(r"^.*?: error: ", re.MULTILINE)
 # REFUSES rather than quietly measuring a differently-configured build. Reconcile deliberately; do not
 # silence it.
 CANONICAL_SCRIPT = "scripts/xcode-test.sh"
-CANONICAL_SETTINGS = [
+# The exact token set of the canonical `xcodebuild test` invocation, compared BOTH WAYS. A
+# presence-only check is one-directional and therefore blind in the direction that matters most: if the
+# canonical lane GAINS a build setting, an environment wrapper, or a flag, every fragment it already had
+# is still there, the guard stays green, and the battery quietly measures a differently-configured build
+# than the lane everyone else trusts. Cloud review, PR #2158.
+CANONICAL_TOKENS = {
+    "-project", "-scheme", "-configuration", "-derivedDataPath", "-destination",
+    "ARCHS=arm64", "VALID_ARCHS=arm64", "ONLY_ACTIVE_ARCH=YES",
+}
+# Values that are shell expansions in the script and literals here; compared separately, by assignment.
+CANONICAL_ASSIGNMENTS = [
     'PROJECT="EnviousWispr.xcodeproj"',
     'DEBUG_SCHEME="EnviousWispr"',
     "DEST='platform=macOS,arch=arm64'",
-    "ARCHS=arm64",
-    "VALID_ARCHS=arm64",
-    "ONLY_ACTIVE_ARCH=YES",
     'TEST_ARGS=(-only-testing:"$FILTER")',
 ]
+INVOCATION_RE = re.compile(r"xcodebuild test\s*\\\n(.*?)\|\s*tee", re.DOTALL)
 
 
 class Refusal(Exception):
     """Preflight said no. The battery never started, so there is nothing to restore."""
+
+
+class _RowFailed(Exception):
+    """This row cannot produce a verdict. It is an ERROR, never a catch and never a survivor.
+
+    Raised rather than returned so the restore in the row's `finally` cannot be skipped, and caught
+    per-row so one broken row does not abort the run before the closing baseline check — that check is
+    what proves the tree came back, and losing it is worse than losing the remaining rows.
+    """
 
 
 def run(cmd, cwd, log_path=None, timeout=None):
@@ -177,14 +194,41 @@ def check_canonical_settings(worktree: Path):
             "confirm it is building the same thing the canonical entry point builds."
         )
     text = canonical.read_text()
-    missing = [frag for frag in CANONICAL_SETTINGS if frag not in text]
-    if missing:
+
+    missing_assignments = [frag for frag in CANONICAL_ASSIGNMENTS if frag not in text]
+
+    match = INVOCATION_RE.search(text)
+    if not match:
         raise Refusal(
-            f"{CANONICAL_SCRIPT} no longer contains settings this runner reproduces, so the battery "
-            "would measure a differently-configured build than the canonical lane:\n  "
-            + "\n  ".join(missing)
-            + "\n\nReconcile CANONICAL_SETTINGS and the Lane class with the script, deliberately. "
-            "Do not delete the guard to make this go away."
+            f"could not find the `xcodebuild test ... | tee` invocation in {CANONICAL_SCRIPT}. The "
+            "runner reproduces that command, so it cannot confirm it still matches. Fail closed."
+        )
+    # Keep flags and literal build settings; drop continuations and anything the shell expands, since
+    # those are compared through CANONICAL_ASSIGNMENTS above.
+    found = {
+        tok for tok in match.group(1).split()
+        if tok != "\\" and "$" not in tok and tok not in ('"$@"',)
+    }
+    missing_tokens = sorted(CANONICAL_TOKENS - found)
+    extra_tokens = sorted(found - CANONICAL_TOKENS)
+
+    if missing_assignments or missing_tokens or extra_tokens:
+        lines = []
+        if missing_assignments:
+            lines.append("  settings the runner expects and the script no longer has:")
+            lines += [f"    - {m}" for m in missing_assignments]
+        if missing_tokens:
+            lines.append("  invocation tokens the runner expects and the script no longer passes:")
+            lines += [f"    - {m}" for m in missing_tokens]
+        if extra_tokens:
+            lines.append("  tokens the script now passes and the runner does NOT reproduce:")
+            lines += [f"    + {m}" for m in extra_tokens]
+        raise Refusal(
+            f"{CANONICAL_SCRIPT} has drifted from what this runner reproduces, so the battery would "
+            "measure a differently-configured build than the canonical lane:\n"
+            + "\n".join(lines)
+            + "\n\nReconcile CANONICAL_TOKENS / CANONICAL_ASSIGNMENTS and the Lane class with the "
+            "script, deliberately. Do not delete the guard to make this go away."
         )
 
 
@@ -241,19 +285,32 @@ def recipes_from_issue(number: int, worktree: Path):
 
 
 def load_recipes(path: Path, worktree: Path, raw: str = None):
+    where = "the issue body" if raw is not None else str(path)
     try:
         data = json.loads(raw if raw is not None else path.read_text())
     except json.JSONDecodeError as exc:
-        where = f"issue body" if raw is not None else str(path)
         raise Refusal(f"the recipe in {where} is not valid JSON: {exc}")
+    # Valid JSON is not the expected SHAPE. `[]`, `{"rows": [1]}`, or a row that is a string all parse
+    # fine and then raise AttributeError deep in the loop. In the unattended --from-issue path that
+    # surfaces as a traceback rather than a refusal, which is the difference between "the recipe is
+    # wrong" and "the battery is broken".
+    if not isinstance(data, dict):
+        raise Refusal(f"the recipe in {where} must be a JSON object, got {type(data).__name__}.")
+    if "rows" in data and not isinstance(data["rows"], list):
+        raise Refusal(f"the recipe in {where} has a 'rows' that is not a list.")
     default_suite = data.get("suite_default")
     rows = data.get("rows") or []
     if not rows:
         raise Refusal(f"{'the issue body' if raw is not None else path} declares no rows.")
     for i, row in enumerate(rows, 1):
+        if not isinstance(row, dict):
+            raise Refusal(f"row {i} is a {type(row).__name__}, not an object.")
         for field in ("label", "file", "anchor", "replacement", "expect_fail"):
             if not row.get(field):
                 raise Refusal(f"row {i} is missing required field '{field}'.")
+            if not isinstance(row[field], str):
+                raise Refusal(
+                    f"row {i} field '{field}' must be a string, got {type(row[field]).__name__}.")
         row.setdefault("suite", default_suite)
         if not row["suite"]:
             raise Refusal(f"row {i} has no suite and no suite_default is set.")
@@ -263,14 +320,29 @@ def load_recipes(path: Path, worktree: Path, raw: str = None):
                 "'EnviousWisprTests/<SuiteName>', and <SuiteName> comes from the @Suite "
                 "declaration, never from the filename."
             )
-        target = worktree / row["file"]
+        # An absolute path, a `..`, or a symlink pointing out of the tree would let a recipe mutate a
+        # file the battery was never scoped to — and with --from-issue the recipe is data written by
+        # whoever authored the issue. Resolve BOTH sides and require containment; resolving is what
+        # catches the symlink, since a lexical check cannot.
+        if Path(row["file"]).is_absolute():
+            raise Refusal(f"row {i} file must be repo-relative, got an absolute path: {row['file']}")
+        target = (worktree / row["file"]).resolve()
+        wt = worktree.resolve()
+        if not (target == wt or wt in target.parents):
+            raise Refusal(
+                f"row {i} resolves OUTSIDE the worktree and will not be mutated:\n"
+                f"  recipe says: {row['file']}\n"
+                f"  resolves to: {target}\n"
+                f"  worktree:    {wt}"
+            )
         if not target.is_file():
             raise Refusal(f"row {i} target does not exist: {row['file']}")
+        row["_resolved"] = str(target)
         if row["anchor"] == row["replacement"]:
             raise Refusal(f"row {i} anchor and replacement are identical — it would mutate nothing.")
         # Check anchor presence and uniqueness HERE, against the clean tree, so a bad recipe costs
         # nothing. The row re-checks at apply time because an earlier row may share the file.
-        occurrences = target.read_text().count(row["anchor"])
+        occurrences = target.read_text().count(row["anchor"])  # target is the resolved, contained path
         if occurrences == 0:
             raise Refusal(
                 f"row {i} anchor not found in {row['file']} — the mutation would never be applied, "
@@ -305,7 +377,12 @@ def baseline(lane: Lane, suites, phase: str):
     return problems
 
 
-def main():
+def main_for_test(recipes: Path, worktree: Path):
+    """Entry point for the self-test's stubbed-lane cases. Same code path as the CLI."""
+    return main(["--recipes", str(recipes), "--worktree", str(worktree)])
+
+
+def main(argv=None):
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     src = ap.add_mutually_exclusive_group(required=True)
     src.add_argument("--recipes", type=Path, help="a recipe JSON file")
@@ -316,7 +393,7 @@ def main():
     ap.add_argument("--dry-run", action="store_true", help="validate recipes and baseline, mutate nothing")
     ap.add_argument("--validate-only", action="store_true",
                     help="preflight and recipe validation only — no xcodebuild, no baseline, no mutations")
-    args = ap.parse_args()
+    args = ap.parse_args(argv)
     if args.validate_only and (args.dry_run or args.row is not None):
         ap.error("--validate-only stops before any run; combining it with --dry-run or --row would "
                  "silently do less than the other flag promises.")
@@ -377,7 +454,7 @@ def main():
     print(f"\n[2/3] {len(rows)} mutation(s), one at a time")
     results = []
     for i, row in enumerate(rows, 1):
-        target = worktree / row["file"]
+        target = Path(row["_resolved"])
         backup = target.with_suffix(target.suffix + ".mutbak")
         tag = f"row{i:02d}"
         verdict, detail = "ERROR", "did not run"
@@ -395,7 +472,11 @@ def main():
                 if row["replacement"] not in target.read_text():
                     detail = "mutation did not land on re-read"
                 else:
-                    count, failures, compiled, log, rc_run, elapsed = lane.run_suite(row["suite"], tag)
+                    try:
+                        count, failures, compiled, log, rc_run, elapsed = lane.run_suite(
+                            row["suite"], tag)
+                    except Exception as exc:  # noqa: BLE001 — any lane failure is this row's problem
+                        raise _RowFailed(f"the lane raised {type(exc).__name__}: {exc}") from exc
                     if not compiled:
                         detail = f"mutant does not compile — proves nothing about the test ({log})"
                     elif count is None or count < 1:
@@ -415,6 +496,8 @@ def main():
                     else:
                         verdict = "SURVIVED"
                         detail = f"{count} tests still green with the code broken ({log})"
+        except _RowFailed as exc:
+            detail = str(exc)
         finally:
             shutil.copy2(backup, target)
             if not filecmp.cmp(backup, target, shallow=False):

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -927,7 +927,19 @@ def main(argv=None):
     unknown = []
     for i, row in enumerate(rows, 1):
         known = baseline_names.get(row["suite"])
-        if not known or row["expect_fail"] in known:
+        # An EMPTY identity set is not a pass. It means the log was unreadable, or Swift Testing's
+        # output no longer matches the pattern — in both cases we have no evidence the named test
+        # exists, and skipping the check restores exactly the false-SURVIVED this was added to stop.
+        # A suite that ran at least one test always prints identity lines, so empty means the reader
+        # broke, not that the suite is empty. Fail closed: the whole point of this check.
+        if not known:
+            unknown.append(
+                f"row {i}: could not read any test names from {row['suite']}'s baseline run, so "
+                f"{row['expect_fail']!r} cannot be verified. The suite passed, which means it printed "
+                "test lines and the reader failed — not that the suite is empty."
+            )
+            continue
+        if row["expect_fail"] in known:
             continue
         near = sorted(n for n in known if row["expect_fail"] in n or n in row["expect_fail"])
         hint = f"\n      did you mean: {near[0]!r}" if near else ""

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -397,6 +397,7 @@ class Lane:
         self.worktree = worktree
         self.derived_data = derived_data
         self.log_dir = log_dir
+        self.log_dir.mkdir(parents=True, exist_ok=True)
         self.generated = False
 
     def generate_once(self):
@@ -784,8 +785,10 @@ def main(argv=None):
     # the shared warm cache while an operator believed it was isolated — colliding with another lane,
     # or reusing different incremental artifacts. Cloud review, PR #2158.
     derived = Path(os.environ.get("DERIVED_DATA_PATH") or (worktree / ".derivedData" / "Test"))
+    # NOT created here: --validate-only is documented as running nothing and touching nothing, and an
+    # unconditional mkdir both breaks that promise and crashes on a read-only checkout. The Lane makes
+    # it when a lane is actually about to write a log.
     log_dir = worktree / "build" / "mutation-battery"
-    log_dir.mkdir(parents=True, exist_ok=True)
 
     print(f"worktree: {worktree}")
     rc, branch = run(["git", "branch", "--show-current"], cwd=worktree)
@@ -913,7 +916,18 @@ def main(argv=None):
         except Exception as exc:  # noqa: BLE001 — any row failure is this row's problem, not the run's
             detail = f"row raised {type(exc).__name__}: {exc}"
         finally:
-            shutil.copy2(backup, target)
+            try:
+                shutil.copy2(backup, target)
+            except OSError as exc:
+                print(
+                    f"\nSTOPPING. Could not restore {target}: {exc}\n"
+                    f"The file is still MUTATED. Its original is at {backup} — copy it back by hand "
+                    f"before running anything else, including the test suite.",
+                    file=sys.stderr,
+                )
+                # Leave the backup in place: it is the only copy of the original.
+                _ACTIVE_RESTORES.pop(target, None)
+                return 1
             # `copy2` restores the original MODIFICATION TIME as well as the bytes, and that is a bug
             # here rather than a nicety. xcodebuild's incremental check is timestamp-based against a
             # deliberately WARM DerivedData: if the replacement happened to be the same SIZE as the

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -493,7 +493,22 @@ class Lane:
         invocation and a guard to police it, and #2165 exists to delete both. Sourcing their library
         adds no second copy to reconcile.
         """
-        rc, out = run(
+        try:
+            rc, out = self._run_package_prep()
+        except subprocess.TimeoutExpired:
+            raise _LaneTimedOut(
+                f"package preparation did not finish within {GENERATE_TIMEOUT_SECONDS}s. Its process "
+                f"group was killed; see {self.log_dir / 'package-prep.log'}"
+            )
+        if rc != 0:
+            # Not fatal: the canonical fallback already degrades a damaged clone to a slow unseeded
+            # resolve. If even that failed, the baseline is about to say so with a real build error,
+            # which is a better message than anything guessed here.
+            print(f"    note: package preparation exited {rc}; the baseline will report the real "
+                  f"failure if it matters ({self.log_dir / 'package-prep.log'})")
+
+    def _run_package_prep(self):
+        return run(
             ["bash", "-c",
              'set -e; source scripts/lib/spm-seed.sh; '
              'ew_seed_consume "$PWD" "$1"; '
@@ -505,12 +520,6 @@ class Lane:
             log_path=self.log_dir / "package-prep.log",
             timeout=GENERATE_TIMEOUT_SECONDS,
         )
-        if rc != 0:
-            # Not fatal: the canonical fallback already degrades a damaged clone to a slow unseeded
-            # resolve. If even that failed, the baseline is about to say so with a real build error,
-            # which is a better message than anything guessed here.
-            print(f"    note: package preparation exited {rc}; the baseline will report the real "
-                  f"failure if it matters ({self.log_dir / 'package-prep.log'})")
 
     def build_command(self, suite: str):
         """The invocation this runner issues. Extracted so the self-test can assert it agrees with
@@ -622,9 +631,25 @@ def check_canonical_settings(worktree: Path):
         )
 
 
+class _ProbeFailed(Exception):
+    """The dev-app probe could not answer. NOT the same as answering 'none running'."""
+
+
 def dev_app_pids(worktree: Path):
-    """Live pids, for the per-row recheck. Preflight raises; a mid-run appearance fails only that row."""
+    """Live pids, for the per-row recheck. Preflight raises; a mid-run appearance fails only that row.
+
+    `pgrep` exits 0 for a match, 1 for NO MATCH, and 2 or more when the probe itself failed — a bad
+    pattern, for instance. Folding that third answer into "none running" is fail-OPEN on a guard whose
+    entire job is to stop a corrupted log scoring as a mutant CAUGHT: the battery would proceed
+    believing the machine is clear when it does not know. Three-valued tool, two-valued caller.
+    """
     rc, out = run(["pgrep", "-f", DEV_APP_PATTERN], cwd=worktree)
+    if rc > 1:
+        raise _ProbeFailed(
+            f"the dev-app probe failed (pgrep exited {rc}). It cannot be read as 'no dev app is "
+            f"running' — that is the probe's third answer, not its second. Pattern: "
+            f"{DEV_APP_PATTERN!r}"
+        )
     return out.split() if rc == 0 and out.strip() else []
 
 
@@ -633,8 +658,12 @@ def check_no_dev_app(worktree: Path):
     if DEV_APP_PATTERN != "EnviousWispr Local.app/Contents/MacOS/EnviousWispr":
         print(f"NOTE: dev-app check is using a non-default pattern: {DEV_APP_PATTERN!r}",
               file=sys.stderr)
-    rc, out = run(["pgrep", "-f", DEV_APP_PATTERN], cwd=worktree)
-    if rc == 0 and out.strip():
+    try:
+        running = dev_app_pids(worktree)
+    except _ProbeFailed as exc:
+        raise Refusal(str(exc))
+    if running:
+        out = " ".join(running)
         raise Refusal(
             "A dev app is running. Its writes to ~/Library/Logs/EnviousWispr/app.log corrupt the\n"
             "AppLogger tests, and those failures score as mutants CAUGHT when nothing detected the\n"

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -477,6 +477,40 @@ class Lane:
         if rc != 0:
             raise Refusal(f"tuist generate failed (rc={rc}); see {self.log_dir/'tuist-generate.log'}")
         self.generated = True
+        self._prepare_packages()
+
+    def _prepare_packages(self):
+        """Run the canonical lane's package preparation, once, before the first suite.
+
+        `xcode-test.sh:85-96` consumes the SwiftPM seed and then RESOLVES with a fallback that discards
+        a damaged `SourcePackages` and retries unseeded. Skipping it means a seed left by an interrupted
+        run — or one carrying another worktree's absolute paths (#2179) — fails the opening baseline
+        against package state the canonical command recovers from. An overnight battery then produces no
+        results at all until someone clears DerivedData by hand, which is the same wasted night the lane
+        timeout exists to prevent.
+
+        Calls the SAME helpers rather than reproducing them: this runner already carries one duplicated
+        invocation and a guard to police it, and #2165 exists to delete both. Sourcing their library
+        adds no second copy to reconcile.
+        """
+        rc, out = run(
+            ["bash", "-c",
+             'set -e; source scripts/lib/spm-seed.sh; '
+             'ew_seed_consume "$PWD" "$1"; '
+             'ew_seed_resolve_or_unseed "$1" '
+             '  xcodebuild -resolvePackageDependencies -project EnviousWispr.xcodeproj '
+             '  -scheme EnviousWispr -derivedDataPath "$1"',
+             "_", str(self.derived_data)],
+            cwd=self.worktree,
+            log_path=self.log_dir / "package-prep.log",
+            timeout=GENERATE_TIMEOUT_SECONDS,
+        )
+        if rc != 0:
+            # Not fatal: the canonical fallback already degrades a damaged clone to a slow unseeded
+            # resolve. If even that failed, the baseline is about to say so with a real build error,
+            # which is a better message than anything guessed here.
+            print(f"    note: package preparation exited {rc}; the baseline will report the real "
+                  f"failure if it matters ({self.log_dir / 'package-prep.log'})")
 
     def build_command(self, suite: str):
         """The invocation this runner issues. Extracted so the self-test can assert it agrees with

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -124,6 +124,13 @@ CANONICAL_ASSIGNMENTS = [
     'run_lane "$DEBUG_SCHEME" Debug',
     "mise x tuist@4.195.11 -- tuist generate --no-open",
 ]
+# Expansions the runner knows the contents of, because CANONICAL_ASSIGNMENTS pins each one. An
+# expansion NOT in this set hides arguments the runner cannot see, so it is a refusal rather than a
+# token to skip — the difference between "I checked and it matches" and "I could not look".
+CANONICAL_EXPANSIONS = {
+    '"$PROJECT"', '"$scheme"', '"$config"', '"$DERIVED_DATA"', '"$DEST"',
+    '"$@"', '"${TEST_ARGS[@]}"',
+}
 INVOCATION_RE = re.compile(r"xcodebuild test\s*\\\n(.*?)\|\s*tee", re.DOTALL)
 # One definition, so the drift guard above and the call below cannot disagree about the version.
 TUIST_GENERATE_ARGV = ["mise", "x", "tuist@4.195.11", "--", "tuist", "generate", "--no-open"]
@@ -223,14 +230,14 @@ def check_canonical_settings(worktree: Path):
         )
     # Keep flags and literal build settings; drop continuations and anything the shell expands, since
     # those are compared through CANONICAL_ASSIGNMENTS above.
-    found = {
-        tok for tok in match.group(1).split()
-        if tok != "\\" and "$" not in tok and tok not in ('"$@"',)
-    }
+    raw_tokens = [tok for tok in match.group(1).split() if tok != "\\"]
+    expansions = [tok for tok in raw_tokens if "$" in tok]
+    unknown_expansions = sorted(set(expansions) - CANONICAL_EXPANSIONS)
+    found = {tok for tok in raw_tokens if "$" not in tok}
     missing_tokens = sorted(CANONICAL_TOKENS - found)
     extra_tokens = sorted(found - CANONICAL_TOKENS)
 
-    if missing_assignments or missing_tokens or extra_tokens:
+    if missing_assignments or missing_tokens or extra_tokens or unknown_expansions:
         lines = []
         if missing_assignments:
             lines.append("  settings the runner expects and the script no longer has:")
@@ -241,6 +248,10 @@ def check_canonical_settings(worktree: Path):
         if extra_tokens:
             lines.append("  tokens the script now passes and the runner does NOT reproduce:")
             lines += [f"    + {m}" for m in extra_tokens]
+        if unknown_expansions:
+            lines.append("  shell expansions whose contents this runner cannot see, so it cannot know")
+            lines.append("  whether it reproduces them:")
+            lines += [f"    ? {m}" for m in unknown_expansions]
         raise Refusal(
             f"{CANONICAL_SCRIPT} has drifted from what this runner reproduces, so the battery would "
             "measure a differently-configured build than the canonical lane:\n"
@@ -332,14 +343,25 @@ def load_recipes(path: Path, worktree: Path, raw: str = None):
         if not isinstance(row, dict):
             raise Refusal(f"row {i} is a {type(row).__name__}, not an object.")
         for field in ("label", "file", "anchor", "replacement", "expect_fail"):
-            if not row.get(field):
+            if field not in row or row[field] is None:
                 raise Refusal(f"row {i} is missing required field '{field}'.")
             if not isinstance(row[field], str):
                 raise Refusal(
                     f"row {i} field '{field}' must be a string, got {type(row[field]).__name__}.")
+            # `replacement` may legitimately be EMPTY: deleting an anchored statement or block is one
+            # of the most natural mutations there is, and a truthiness check classified that correctly
+            # typed value as missing. Every other field empty is still a mistake.
+            if field != "replacement" and not row[field]:
+                raise Refusal(f"row {i} is missing required field '{field}'.")
         row.setdefault("suite", default_suite)
         if not row["suite"]:
             raise Refusal(f"row {i} has no suite and no suite_default is set.")
+        if not isinstance(row["suite"], str):
+            raise Refusal(
+                f"row {i} suite must be a string, got {type(row['suite']).__name__}. "
+                "(A non-string here used to raise TypeError and exit 1, which the exit codes reserve "
+                "for a row SURVIVING.)"
+            )
         if "/" not in row["suite"]:
             raise Refusal(
                 f"row {i} suite '{row['suite']}' is not target-qualified. It must read "

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -62,6 +62,7 @@ EXIT CODES
 import argparse
 import filecmp
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -121,7 +122,10 @@ CANONICAL_ASSIGNMENTS = [
     "DEST='platform=macOS,arch=arm64'",
     'TEST_ARGS=(-only-testing:"$FILTER")',
     'DERIVED_DATA="${DERIVED_DATA_PATH:-$PROJECT_ROOT/.derivedData/Test}"',
-    'run_lane "$DEBUG_SCHEME" Debug',
+    # The WHOLE line, not a prefix: `run_lane "$DEBUG_SCHEME" Debug build/... ENABLE_TESTABILITY=YES`
+    # still starts with the prefix, and those trailing positionals reach xcodebuild through `"$@"`,
+    # which the expansion allowlist accepts by name without seeing its contents.
+    'run_lane "$DEBUG_SCHEME" Debug build/xcode-test-debug.log\n',
     "mise x tuist@4.195.11 -- tuist generate --no-open",
 ]
 # Expansions the runner knows the contents of, because CANONICAL_ASSIGNMENTS pins each one. An
@@ -140,6 +144,10 @@ class Refusal(Exception):
     """Preflight said no. The battery never started, so there is nothing to restore."""
 
 
+class _LaneTimedOut(Exception):
+    """The lane was killed for running past its bound. Never a catch: a hang proves nothing."""
+
+
 class _RowFailed(Exception):
     """This row cannot produce a verdict. It is an ERROR, never a catch and never a survivor.
 
@@ -147,6 +155,14 @@ class _RowFailed(Exception):
     per-row so one broken row does not abort the run before the closing baseline check — that check is
     what proves the tree came back, and losing it is worse than losing the remaining rows.
     """
+
+
+# A mutation can make the code under test WAIT FOREVER — removing a completion path or a cancellation
+# is one of the most valuable things to mutate, and also the most likely to hang. Unbounded, the
+# unattended battery sits on that row all night and never reaches its restore or its closing baseline,
+# so it leaves a MUTATED TREE behind. The bound is generous: it exists to convert a hang into a row
+# ERROR, not to police a slow suite (validation-discipline.md `hang-guard-vs-latency-bound`).
+LANE_TIMEOUT_SECONDS = 1800
 
 
 def run(cmd, cwd, log_path=None, timeout=None):
@@ -199,7 +215,17 @@ class Lane:
             f"-only-testing:{suite}",
         ]
         started = time.monotonic()
-        rc, out = run(cmd, cwd=self.worktree, log_path=log_path)
+        try:
+            rc, out = run(cmd, cwd=self.worktree, log_path=log_path,
+                          timeout=LANE_TIMEOUT_SECONDS)
+        except subprocess.TimeoutExpired:
+            elapsed = time.monotonic() - started
+            Path(log_path).write_text(
+                f"lane exceeded {LANE_TIMEOUT_SECONDS}s and was killed after {elapsed:.0f}s\n")
+            raise _LaneTimedOut(
+                f"the lane ran past {LANE_TIMEOUT_SECONDS}s and was killed. A mutation that removes a "
+                f"completion or cancellation path can hang the suite; that is a row ERROR, never a "
+                f"catch ({log_path})")
         elapsed = time.monotonic() - started
 
         counts = [int(n) for n in TEST_COUNT_RE.findall(out)]
@@ -228,8 +254,11 @@ def check_canonical_settings(worktree: Path):
             f"could not find the `xcodebuild test ... | tee` invocation in {CANONICAL_SCRIPT}. The "
             "runner reproduces that command, so it cannot confirm it still matches. Fail closed."
         )
-    # Keep flags and literal build settings; drop continuations and anything the shell expands, since
-    # those are compared through CANONICAL_ASSIGNMENTS above.
+    # Literal flags and build settings are compared as tokens, both ways. Shell EXPANSIONS cannot be
+    # compared that way, so they are allowlisted instead: each one in CANONICAL_EXPANSIONS has its
+    # contents pinned by CANONICAL_ASSIGNMENTS above, and an expansion outside that set hides arguments
+    # this runner cannot see. Silently dropping them was the round-3 defect — indirection read as
+    # absence.
     raw_tokens = [tok for tok in match.group(1).split() if tok != "\\"]
     expansions = [tok for tok in raw_tokens if "$" in tok]
     unknown_expansions = sorted(set(expansions) - CANONICAL_EXPANSIONS)
@@ -256,8 +285,9 @@ def check_canonical_settings(worktree: Path):
             f"{CANONICAL_SCRIPT} has drifted from what this runner reproduces, so the battery would "
             "measure a differently-configured build than the canonical lane:\n"
             + "\n".join(lines)
-            + "\n\nReconcile CANONICAL_TOKENS / CANONICAL_ASSIGNMENTS and the Lane class with the "
-            "script, deliberately. Do not delete the guard to make this go away."
+            + "\n\nReconcile CANONICAL_TOKENS / CANONICAL_ASSIGNMENTS / CANONICAL_EXPANSIONS and "
+            "the Lane class with the script, deliberately. Do not delete the guard to make this go "
+            "away."
         )
 
 
@@ -294,21 +324,31 @@ def recipes_from_issue(number: int, worktree: Path):
     Fails closed on zero or several fenced json blocks. Picking "the first one" would silently run a
     different recipe than the one a reader of the issue believes is running.
     """
+    # Body AND comments. github-light.md FACT: finding-issues records that in this repo "title/body
+    # often stale; adopted plan lives in comments" — so a recipe posted as a comment is the NORMAL
+    # case, not a mistake, and reading only the body would refuse correctly-filed work. The
+    # exactly-one rule below is what keeps that from being ambiguous, and it now spans both.
+    # Never bare `--comments`: in a non-TTY pipe it drops the body and prints nothing for zero
+    # comments, so a piped read of a recipe-in-body issue would look empty (cli/cli#2462).
     rc, out = run(
-        ["gh", "issue", "view", str(number), "--json", "body", "--jq", ".body"], cwd=worktree
+        ["gh", "issue", "view", str(number), "--json", "body,comments",
+         "--jq", '.body, (.comments[]?.body)'],
+        cwd=worktree,
     )
     if rc != 0:
         raise Refusal(f"could not read issue #{number}: {out.strip()[:300]}")
     blocks = FENCE_RE.findall(out)
     if not blocks:
         raise Refusal(
-            f"issue #{number} carries no ```json recipe block. A test-hardening issue without its "
-            "recipe cannot be acted on cold, which is the whole reason the recipe goes in the BODY."
+            f"issue #{number} carries no ```json recipe block in its body or any comment. A "
+            "test-hardening issue without its recipe cannot be acted on cold, which is the whole "
+            "reason the recipe is written into the issue."
         )
     if len(blocks) > 1:
         raise Refusal(
-            f"issue #{number} carries {len(blocks)} ```json blocks. Exactly one, or the run and the "
-            "issue disagree about what was tested."
+            f"issue #{number} carries {len(blocks)} ```json blocks across its body and comments. "
+            "Exactly one, or the run and the issue disagree about what was tested — edit the "
+            "superseded one out rather than adding a newer block beside it."
         )
     return blocks[0]
 
@@ -410,7 +450,11 @@ def baseline(lane: Lane, suites, phase: str):
     problems = []
     for suite in sorted(suites):
         tag = f"baseline-{phase}-{suite.replace('/', '_')}"
-        count, failures, compiled, log, rc, elapsed = lane.run_suite(suite, tag)
+        try:
+            count, failures, compiled, log, rc, elapsed = lane.run_suite(suite, tag)
+        except _LaneTimedOut as exc:
+            problems.append(f"{suite}: {exc}")
+            continue
         if not compiled:
             problems.append(f"{suite}: did not compile ({log})")
         elif count is None or count < 1:
@@ -554,6 +598,14 @@ def main(argv=None):
             detail = str(exc)
         finally:
             shutil.copy2(backup, target)
+            # `copy2` restores the original MODIFICATION TIME as well as the bytes, and that is a bug
+            # here rather than a nicety. xcodebuild's incremental check is timestamp-based against a
+            # deliberately WARM DerivedData: if the replacement happened to be the same SIZE as the
+            # anchor, the restored file is byte-identical AND older than the object compiled from the
+            # MUTANT, so the next row — or the closing baseline — can run against mutant code while
+            # every check here reports a clean tree. That fails toward false CAUGHT and false green,
+            # silently, for every row after it. Stamp the restore as NOW so the next build recompiles.
+            os.utime(target, None)
             if not filecmp.cmp(backup, target, shallow=False):
                 verdict, detail = "ERROR", "RESTORE FAILED — the tree is dirty, stop and inspect"
             else:

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -6,7 +6,7 @@ WHY THIS EXISTS
     binds is to break the thing it names and watch it go red. That is cheap to describe and expensive
     to do by hand, so this runs it unattended.
 
-THE FOUR CONTROLS, none of which are optional
+THE CONTROLS, none of which are optional — each exists because a real run got it wrong
     1. CLEAN BEFORE, not tidy after. The baseline pass runs every named suite BEFORE the first mutation
        and requires green. A battery started on an already-poisoned tree reports a perfect score, and
        verified restores cannot catch that because the poisoning predates the harness (2026-08-17:
@@ -22,6 +22,20 @@ THE FOUR CONTROLS, none of which are optional
     4. A MUTANT THAT DOES NOT COMPILE IS AN ERROR, NOT A CATCH. A compile failure turns the lane red
        while proving nothing about the test. Detected as a red lane carrying `error:` and no test-run
        summary.
+    5. THE RESTORE IS STAMPED `NOW`. `copy2` returns the file's original MODIFICATION TIME too, and
+       against warm DerivedData a replacement the same SIZE as its anchor then leaves a byte-identical
+       file OLDER than the object compiled from the mutant — so the next row runs sabotaged code while
+       every check reports clean. Invisible to a byte comparison.
+    6. THE RESTORE SURVIVES BEING CANCELLED. The row's `finally` does not run under Python's default
+       SIGTERM action, so an interrupted overnight run would leave the file MUTATED. The in-flight
+       mutation is registered outside the try/finally and restored from a signal handler.
+    7. THE LANE IS BOUNDED. A mutation that removes a completion or cancellation path can hang the
+       suite; unbounded, the battery parks all night and never restores. A timeout is a row ERROR.
+    8. NO DEV APP MAY BE RUNNING. Concurrent writes to the app log corrupt the AppLogger tests, and
+       those failures score as mutants CAUGHT when nothing detected the sabotage (#2080) — it fails
+       toward CONFIDENCE, so it is a refusal rather than a warning.
+    9. THE CANONICAL BUILD SETTINGS MUST NOT HAVE DRIFTED. This runner reproduces `xcode-test.sh`'s
+       invocation rather than calling it; the guard is the price, and #2165 is the plan to delete both.
 
 WHAT IT CANNOT DO, stated so nobody reads a green report as more than it is
     A battery only ever tries the mutations its author imagined. It proves a test fires on the shapes
@@ -65,6 +79,7 @@ import json
 import os
 import re
 import shutil
+import signal
 import subprocess
 import sys
 import time
@@ -75,7 +90,15 @@ from pathlib import Path
 # tests fail on a diff that touches no logging code (#2080). Inside a battery that scores as a mutant
 # CAUGHT when nothing detected the sabotage — it fails toward CONFIDENCE, which is the direction
 # nothing prompts you to check. So this is a refusal, not a warning.
-DEV_APP_PATTERN = "EnviousWispr Local.app/Contents/MacOS/EnviousWispr"
+# Overridable ONLY so the self-test is not machine-wide. The check is a `pgrep` across the whole box,
+# so without a seam every case in the suite fails whenever ANY session has a dev app open — which
+# happened mid-run the night this was written, and produced a suite that half passed and half refused.
+# The DEFAULT is the real pattern, so an unset environment is the safe one; the override can only make
+# the check look at something else, never skip it, and it announces itself when used. Contrast #2145,
+# where a convenience DEFAULT silently reconnected an injected seam to production — the direction
+# matters more than the presence of a seam.
+DEV_APP_PATTERN = os.environ.get(
+    "EW_BATTERY_DEV_APP_PATTERN", "EnviousWispr Local.app/Contents/MacOS/EnviousWispr")
 
 TEST_COUNT_RE = re.compile(r"Test run with (\d+) test")
 FAILURE_LINE_RE = re.compile(r"✘ .*")
@@ -136,8 +159,46 @@ CANONICAL_EXPANSIONS = {
     '"$@"', '"${TEST_ARGS[@]}"',
 }
 INVOCATION_RE = re.compile(r"xcodebuild test\s*\\\n(.*?)\|\s*tee", re.DOTALL)
+# Whatever sits between the start of the line and `xcodebuild` — an env prefix, a wrapper, a different
+# toolchain via DEVELOPER_DIR. Required to be EMPTY rather than enumerated: the runner invokes
+# xcodebuild with its ambient environment, so any prefix means the canonical lane and the battery build
+# differently, and there is no list of prefixes worth maintaining.
+INVOCATION_PREFIX_RE = re.compile(r"^([^\n]*?)xcodebuild test\s*\\", re.MULTILINE)
 # One definition, so the drift guard above and the call below cannot disagree about the version.
 TUIST_GENERATE_ARGV = ["mise", "x", "tuist@4.195.11", "--", "tuist", "generate", "--no-open"]
+
+
+# A row's restore lives in a `finally`, and Python's DEFAULT action for SIGTERM does not run it: the
+# process dies where it stands, leaving the production file MUTATED and a .mutbak beside it. That is the
+# worst state this tool can leave behind, and an overnight battery is exactly the thing someone cancels
+# — a terminal closing, a session ending, a job being killed. So the restore is also registered here,
+# outside the try/finally, and runs from the signal handler.
+_ACTIVE_RESTORES = {}
+
+
+def _restore_active(reason: str):
+    """Put every in-flight mutation back. Safe to call twice; the row's `finally` may also run."""
+    for target, backup in list(_ACTIVE_RESTORES.items()):
+        try:
+            if Path(backup).exists():
+                shutil.copy2(backup, target)
+                os.utime(target, None)
+                Path(backup).unlink()
+                print(f"  restored {target} after {reason}", file=sys.stderr)
+        except OSError as exc:  # nothing better to do while dying; say so rather than exit silently
+            print(f"  COULD NOT RESTORE {target} after {reason}: {exc}", file=sys.stderr)
+        _ACTIVE_RESTORES.pop(target, None)
+
+
+def _install_restore_on_signal():
+    def handler(signum, _frame):
+        _restore_active(f"signal {signum}")
+        # Re-raise with the default action so the exit status still says we were killed.
+        signal.signal(signum, signal.SIG_DFL)
+        os.kill(os.getpid(), signum)
+
+    for sig in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+        signal.signal(sig, handler)
 
 
 class Refusal(Exception):
@@ -259,6 +320,9 @@ def check_canonical_settings(worktree: Path):
     # contents pinned by CANONICAL_ASSIGNMENTS above, and an expansion outside that set hides arguments
     # this runner cannot see. Silently dropping them was the round-3 defect — indirection read as
     # absence.
+    prefix_match = INVOCATION_PREFIX_RE.search(text)
+    invocation_prefix = (prefix_match.group(1).strip() if prefix_match else "")
+
     raw_tokens = [tok for tok in match.group(1).split() if tok != "\\"]
     expansions = [tok for tok in raw_tokens if "$" in tok]
     unknown_expansions = sorted(set(expansions) - CANONICAL_EXPANSIONS)
@@ -266,7 +330,7 @@ def check_canonical_settings(worktree: Path):
     missing_tokens = sorted(CANONICAL_TOKENS - found)
     extra_tokens = sorted(found - CANONICAL_TOKENS)
 
-    if missing_assignments or missing_tokens or extra_tokens or unknown_expansions:
+    if missing_assignments or missing_tokens or extra_tokens or unknown_expansions or invocation_prefix:
         lines = []
         if missing_assignments:
             lines.append("  settings the runner expects and the script no longer has:")
@@ -281,6 +345,10 @@ def check_canonical_settings(worktree: Path):
             lines.append("  shell expansions whose contents this runner cannot see, so it cannot know")
             lines.append("  whether it reproduces them:")
             lines += [f"    ? {m}" for m in unknown_expansions]
+        if invocation_prefix:
+            lines.append("  something now runs BEFORE xcodebuild, so the canonical lane may use a")
+            lines.append("  different environment or toolchain than this runner's ambient one:")
+            lines.append(f"    ! {invocation_prefix}")
         raise Refusal(
             f"{CANONICAL_SCRIPT} has drifted from what this runner reproduces, so the battery would "
             "measure a differently-configured build than the canonical lane:\n"
@@ -291,8 +359,11 @@ def check_canonical_settings(worktree: Path):
         )
 
 
-def preflight(worktree: Path):
-    check_canonical_settings(worktree)
+def check_no_dev_app(worktree: Path):
+    """Its own function so the self-test can drive it directly rather than through every case."""
+    if DEV_APP_PATTERN != "EnviousWispr Local.app/Contents/MacOS/EnviousWispr":
+        print(f"NOTE: dev-app check is using a non-default pattern: {DEV_APP_PATTERN!r}",
+              file=sys.stderr)
     rc, out = run(["pgrep", "-f", DEV_APP_PATTERN], cwd=worktree)
     if rc == 0 and out.strip():
         raise Refusal(
@@ -301,6 +372,11 @@ def preflight(worktree: Path):
             "sabotage (#2080). Stop every dev instance across ALL worktrees and re-run.\n"
             f"  pids: {' '.join(out.split())}"
         )
+
+
+def preflight(worktree: Path):
+    check_canonical_settings(worktree)
+    check_no_dev_app(worktree)
     leftovers = list(worktree.rglob("*.mutbak"))
     if leftovers:
         raise Refusal(
@@ -545,6 +621,7 @@ def main(argv=None):
         print("\n--dry-run: recipes validated, baseline green, nothing mutated.")
         return 0
 
+    _install_restore_on_signal()
     print(f"\n[2/3] {len(rows)} mutation(s), one at a time")
     results = []
     for i, row in enumerate(rows, 1):
@@ -553,6 +630,7 @@ def main(argv=None):
         tag = f"row{i:02d}"
         verdict, detail = "ERROR", "did not run"
         shutil.copy2(target, backup)
+        _ACTIVE_RESTORES[target] = backup
         try:
             src = target.read_text()
             occurrences = src.count(row["anchor"])
@@ -610,6 +688,7 @@ def main(argv=None):
                 verdict, detail = "ERROR", "RESTORE FAILED — the tree is dirty, stop and inspect"
             else:
                 backup.unlink()
+            _ACTIVE_RESTORES.pop(target, None)
         marker = {"CAUGHT": "  ok  ", "SURVIVED": " SURV ", "ERROR": " ERR  "}[verdict]
         print(f"  [{marker}] row {i}: {row['label']}\n           {detail}")
         results.append((verdict, row["label"], detail))

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""Run a mutation battery: break one production line at a time and require the named test to notice.
+
+WHY THIS EXISTS
+    A test that passes when the code it guards is broken proves nothing. The only way to know a test
+    binds is to break the thing it names and watch it go red. That is cheap to describe and expensive
+    to do by hand, so this runs it unattended.
+
+THE FOUR CONTROLS, none of which are optional
+    1. CLEAN BEFORE, not tidy after. The baseline pass runs every named suite BEFORE the first mutation
+       and requires green. A battery started on an already-poisoned tree reports a perfect score, and
+       verified restores cannot catch that because the poisoning predates the harness (2026-08-17:
+       8/8 CAUGHT, every row worthless, row eight running against a file six mutations deep).
+    2. RESTORE BY FILE COPY. `git checkout --` silently no-ops on an untracked file and, for a file
+       staged as a RENAME, restores the OLD content under the NEW path. Both failures are silent. This
+       uses shutil.copy2 and then requires the bytes to match.
+    3. FAIL CLOSED ON ZERO TESTS. `-only-testing:` with a suite name that does not exist does NOT
+       error: xcodebuild prints `Executed 0 tests` and `** TEST SUCCEEDED **`. Inside a battery that
+       reads as EVERY MUTANT SURVIVED, so every filter is validated in the baseline pass and any run
+       executing zero tests is an ERROR, never a result. The suite name comes from the `@Suite`
+       declaration, never from the filename.
+    4. A MUTANT THAT DOES NOT COMPILE IS AN ERROR, NOT A CATCH. A compile failure turns the lane red
+       while proving nothing about the test. Detected as a red lane carrying `error:` and no test-run
+       summary.
+
+WHAT IT CANNOT DO, stated so nobody reads a green report as more than it is
+    A battery only ever tries the mutations its author imagined. It proves a test fires on the shapes
+    you thought of; it never proves the test is BINDING. For a guard written over identifier names or
+    source text this gap is total: an alias, a helper returning the comparison, or the same expression
+    moved upstream all walk past while every row still reports CAUGHT. Those guards need an independent
+    attempt to evade them, by someone other than their author. See
+    `.claude/rules/validation-discipline.md` RULE: verify-the-feature-not-the-crash.
+
+RECIPE FORMAT (JSON; the same block that goes in the `test-hardening` issue body)
+    {
+      "suite_default": "EnviousWisprTests/FooTests",
+      "rows": [
+        {
+          "label":       "drop the adjudication term from the completeness check",
+          "file":        "Sources/EnviousWisprPipeline/Foo.swift",
+          "anchor":      "exact source text, must occur EXACTLY once",
+          "replacement": "exact replacement text",
+          "suite":       "EnviousWisprTests/FooTests",   // optional if suite_default is set
+          "expect_fail": "the test that must go red"     // substring-matched against failure lines
+        }
+      ]
+    }
+
+USAGE
+    scripts/mutation-battery.py --recipes recipes.json
+    scripts/mutation-battery.py --recipes recipes.json --row 3      # one row, for iterating on a fix
+    scripts/mutation-battery.py --recipes recipes.json --dry-run    # validate + baseline, no mutations
+    scripts/mutation-battery.py --recipes recipes.json --validate-only  # no xcodebuild at all
+
+EXIT CODES
+    0  every row CAUGHT, baseline green before and after, every file byte-identical
+    1  at least one SURVIVED, ERRORED, or a restore failed
+    2  usage / preflight refusal (the battery never started)
+"""
+
+import argparse
+import filecmp
+import json
+import re
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# The dev app writes to ~/Library/Logs/EnviousWispr/app.log. AppLogger tests write a marker there and
+# read it back; a second concurrent writer breaks UTF-8 boundaries, the read returns empty, and ~6
+# tests fail on a diff that touches no logging code (#2080). Inside a battery that scores as a mutant
+# CAUGHT when nothing detected the sabotage — it fails toward CONFIDENCE, which is the direction
+# nothing prompts you to check. So this is a refusal, not a warning.
+DEV_APP_PATTERN = "EnviousWispr Local.app/Contents/MacOS/EnviousWispr"
+
+TEST_COUNT_RE = re.compile(r"Test run with (\d+) test")
+FAILURE_LINE_RE = re.compile(r"✘ .*")
+COMPILE_ERROR_RE = re.compile(r"^.*?: error: ", re.MULTILINE)
+
+
+class Refusal(Exception):
+    """Preflight said no. The battery never started, so there is nothing to restore."""
+
+
+def run(cmd, cwd, log_path=None, timeout=None):
+    """Run a command, optionally teeing to a per-row log. Never the shared fixed log path."""
+    proc = subprocess.run(
+        cmd, cwd=str(cwd), capture_output=True, text=True, timeout=timeout, check=False
+    )
+    out = proc.stdout + proc.stderr
+    if log_path is not None:
+        Path(log_path).write_text(out)
+    return proc.returncode, out
+
+
+class Lane:
+    """One filtered Debug test run against warm DerivedData."""
+
+    def __init__(self, worktree: Path, derived_data: Path, log_dir: Path):
+        self.worktree = worktree
+        self.derived_data = derived_data
+        self.log_dir = log_dir
+        self.generated = False
+
+    def generate_once(self):
+        """`tuist generate` output is byte-identical on a warm tree (measured 6.7s, M5 Max) so it is
+        pure per-row overhead. Generate once. Safe ONLY because a mutation changes file CONTENT, never
+        the file list — a recipe that adds or removes a file violates that and is rejected at load."""
+        if self.generated:
+            return
+        rc, out = run(
+            ["mise", "x", "tuist@4.195.11", "--", "tuist", "generate", "--no-open"],
+            cwd=self.worktree,
+            log_path=self.log_dir / "tuist-generate.log",
+        )
+        if rc != 0:
+            raise Refusal(f"tuist generate failed (rc={rc}); see {self.log_dir/'tuist-generate.log'}")
+        self.generated = True
+
+    def run_suite(self, suite: str, tag: str):
+        """Returns (count, failures, compiled, log_path). count is None when no summary was printed."""
+        self.generate_once()
+        log_path = self.log_dir / f"{tag}.log"
+        cmd = [
+            "xcodebuild", "test",
+            "-project", "EnviousWispr.xcodeproj",
+            "-scheme", "EnviousWispr",
+            "-configuration", "Debug",
+            "-derivedDataPath", str(self.derived_data),
+            "-destination", "platform=macOS,arch=arm64",
+            "ARCHS=arm64", "VALID_ARCHS=arm64", "ONLY_ACTIVE_ARCH=YES",
+            f"-only-testing:{suite}",
+        ]
+        started = time.monotonic()
+        rc, out = run(cmd, cwd=self.worktree, log_path=log_path)
+        elapsed = time.monotonic() - started
+
+        counts = [int(n) for n in TEST_COUNT_RE.findall(out)]
+        count = sum(counts) if counts else None
+        failures = FAILURE_LINE_RE.findall(out)
+        # A red lane with compiler diagnostics and no test summary never ran the tests.
+        compiled = not (count is None and COMPILE_ERROR_RE.search(out) is not None)
+        return count, failures, compiled, log_path, rc, elapsed
+
+
+def preflight(worktree: Path):
+    rc, out = run(["pgrep", "-f", DEV_APP_PATTERN], cwd=worktree)
+    if rc == 0 and out.strip():
+        raise Refusal(
+            "A dev app is running. Its writes to ~/Library/Logs/EnviousWispr/app.log corrupt the\n"
+            "AppLogger tests, and those failures score as mutants CAUGHT when nothing detected the\n"
+            "sabotage (#2080). Stop every dev instance across ALL worktrees and re-run.\n"
+            f"  pids: {' '.join(out.split())}"
+        )
+    leftovers = list(worktree.rglob("*.mutbak"))
+    if leftovers:
+        raise Refusal(
+            "Backup files from an earlier battery are still on disk, so a previous run did not "
+            "restore. Investigate before mutating anything else:\n  "
+            + "\n  ".join(str(p) for p in leftovers)
+        )
+
+
+def load_recipes(path: Path, worktree: Path):
+    data = json.loads(path.read_text())
+    default_suite = data.get("suite_default")
+    rows = data.get("rows") or []
+    if not rows:
+        raise Refusal(f"{path} declares no rows.")
+    for i, row in enumerate(rows, 1):
+        for field in ("label", "file", "anchor", "replacement", "expect_fail"):
+            if not row.get(field):
+                raise Refusal(f"row {i} is missing required field '{field}'.")
+        row.setdefault("suite", default_suite)
+        if not row["suite"]:
+            raise Refusal(f"row {i} has no suite and no suite_default is set.")
+        if "/" not in row["suite"]:
+            raise Refusal(
+                f"row {i} suite '{row['suite']}' is not target-qualified. It must read "
+                "'EnviousWisprTests/<SuiteName>', and <SuiteName> comes from the @Suite "
+                "declaration, never from the filename."
+            )
+        target = worktree / row["file"]
+        if not target.is_file():
+            raise Refusal(f"row {i} target does not exist: {row['file']}")
+        if row["anchor"] == row["replacement"]:
+            raise Refusal(f"row {i} anchor and replacement are identical — it would mutate nothing.")
+        # Check anchor presence and uniqueness HERE, against the clean tree, so a bad recipe costs
+        # nothing. The row re-checks at apply time because an earlier row may share the file.
+        occurrences = target.read_text().count(row["anchor"])
+        if occurrences == 0:
+            raise Refusal(
+                f"row {i} anchor not found in {row['file']} — the mutation would never be applied, "
+                "and a row that never applied is not a row that passed."
+            )
+        if occurrences > 1:
+            raise Refusal(
+                f"row {i} anchor occurs {occurrences} times in {row['file']}; it must be unique or "
+                "the mutation lands somewhere you did not choose."
+            )
+    return rows
+
+
+def baseline(lane: Lane, suites, phase: str):
+    """Every named suite must run at least one test and pass. This is both the clean-tree control and
+    the filter validation: a suite name that does not exist executes zero tests and SUCCEEDS."""
+    problems = []
+    for suite in sorted(suites):
+        tag = f"baseline-{phase}-{suite.replace('/', '_')}"
+        count, failures, compiled, log, rc, elapsed = lane.run_suite(suite, tag)
+        if not compiled:
+            problems.append(f"{suite}: did not compile ({log})")
+        elif count is None or count < 1:
+            problems.append(
+                f"{suite}: executed ZERO tests and reported success — the filter names a suite that "
+                f"does not exist. Read the name from its @Suite declaration. ({log})"
+            )
+        elif rc != 0 or failures:
+            problems.append(f"{suite}: {len(failures)} failing on an unmutated tree ({log})")
+        else:
+            print(f"    baseline {phase}: {suite} — {count} tests green in {elapsed:.0f}s")
+    return problems
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--recipes", required=True, type=Path)
+    ap.add_argument("--worktree", type=Path, default=None)
+    ap.add_argument("--row", type=int, default=None, help="run a single 1-indexed row")
+    ap.add_argument("--dry-run", action="store_true", help="validate recipes and baseline, mutate nothing")
+    ap.add_argument("--validate-only", action="store_true",
+                    help="preflight and recipe validation only — no xcodebuild, no baseline, no mutations")
+    args = ap.parse_args()
+    if args.validate_only and (args.dry_run or args.row is not None):
+        ap.error("--validate-only stops before any run; combining it with --dry-run or --row would "
+                 "silently do less than the other flag promises.")
+
+    worktree = (args.worktree or Path(__file__).resolve().parent.parent).resolve()
+    derived = worktree / ".derivedData" / "Test"
+    log_dir = worktree / "build" / "mutation-battery"
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"worktree: {worktree}")
+    rc, branch = run(["git", "branch", "--show-current"], cwd=worktree)
+    rc, head = run(["git", "rev-parse", "HEAD"], cwd=worktree)
+    print(f"branch:   {branch.strip()} @ {head.strip()[:12]}")
+
+    try:
+        preflight(worktree)
+        rows = load_recipes(args.recipes.resolve(), worktree)
+    except Refusal as exc:
+        print(f"\nREFUSED — the battery did not start.\n\n{exc}", file=sys.stderr)
+        return 2
+
+    if args.validate_only:
+        print(f"\n--validate-only: preflight clean, {len(rows)} row(s) well-formed. Nothing was run.")
+        return 0
+
+    if args.row is not None:
+        if not 1 <= args.row <= len(rows):
+            print(f"--row {args.row} out of range (1..{len(rows)})", file=sys.stderr)
+            return 2
+        rows = [rows[args.row - 1]]
+
+    lane = Lane(worktree, derived, log_dir)
+    suites = {row["suite"] for row in rows}
+
+    print(f"\n[1/3] baseline on a clean tree — {len(suites)} suite(s)")
+    try:
+        problems = baseline(lane, suites, "before")
+    except Refusal as exc:
+        print(f"\nREFUSED — {exc}", file=sys.stderr)
+        return 2
+    if problems:
+        print("\nBASELINE IS NOT GREEN. Nothing was mutated.", file=sys.stderr)
+        print("A failing test on a supposedly clean tree is a claim about the TREE first and the code",
+              file=sys.stderr)
+        print("second — verify the tree before believing any diagnosis.\n", file=sys.stderr)
+        for p in problems:
+            print(f"  - {p}", file=sys.stderr)
+        return 1
+
+    if args.dry_run:
+        print("\n--dry-run: recipes validated, baseline green, nothing mutated.")
+        return 0
+
+    print(f"\n[2/3] {len(rows)} mutation(s), one at a time")
+    results = []
+    for i, row in enumerate(rows, 1):
+        target = worktree / row["file"]
+        backup = target.with_suffix(target.suffix + ".mutbak")
+        tag = f"row{i:02d}"
+        verdict, detail = "ERROR", "did not run"
+        shutil.copy2(target, backup)
+        try:
+            src = target.read_text()
+            occurrences = src.count(row["anchor"])
+            if occurrences == 0:
+                detail = "anchor not found — the mutation was never applied"
+            elif occurrences > 1:
+                detail = f"anchor occurs {occurrences} times; it must be unique"
+            else:
+                target.write_text(src.replace(row["anchor"], row["replacement"], 1))
+                # Prove it landed by reading the file back rather than trusting the write.
+                if row["replacement"] not in target.read_text():
+                    detail = "mutation did not land on re-read"
+                else:
+                    count, failures, compiled, log, rc_run, elapsed = lane.run_suite(row["suite"], tag)
+                    if not compiled:
+                        detail = f"mutant does not compile — proves nothing about the test ({log})"
+                    elif count is None or count < 1:
+                        detail = f"executed ZERO tests — filter is wrong, not the test ({log})"
+                    elif any(row["expect_fail"] in line for line in failures):
+                        verdict = "CAUGHT"
+                        others = [l for l in failures if row["expect_fail"] not in l]
+                        detail = f"{row['expect_fail']} went red in {elapsed:.0f}s"
+                        if others:
+                            detail += f" (+{len(others)} other failing)"
+                    elif failures:
+                        detail = (
+                            f"suite went red but NOT via {row['expect_fail']} — something else "
+                            f"caught it, so this test is not the guard ({log})"
+                        )
+                        verdict = "SURVIVED"
+                    else:
+                        verdict = "SURVIVED"
+                        detail = f"{count} tests still green with the code broken ({log})"
+        finally:
+            shutil.copy2(backup, target)
+            if not filecmp.cmp(backup, target, shallow=False):
+                verdict, detail = "ERROR", "RESTORE FAILED — the tree is dirty, stop and inspect"
+            else:
+                backup.unlink()
+        marker = {"CAUGHT": "  ok  ", "SURVIVED": " SURV ", "ERROR": " ERR  "}[verdict]
+        print(f"  [{marker}] row {i}: {row['label']}\n           {detail}")
+        results.append((verdict, row["label"], detail))
+
+    print("\n[3/3] baseline again — every file must be back to where it started")
+    after = baseline(lane, suites, "after")
+    if after:
+        print("\nBASELINE NOT RESTORED. A restore failed; the tree is dirty.", file=sys.stderr)
+        for p in after:
+            print(f"  - {p}", file=sys.stderr)
+        return 1
+
+    caught = [r for r in results if r[0] == "CAUGHT"]
+    bad = [r for r in results if r[0] != "CAUGHT"]
+    print(f"\n{'=' * 72}\n{len(caught)}/{len(results)} CAUGHT, baseline green before and after.")
+    if bad:
+        print(f"\n{len(bad)} row(s) need work:")
+        for verdict, label, detail in bad:
+            print(f"  {verdict}: {label}\n    {detail}")
+        return 1
+    print("\nEvery mutation was detected by the test that claimed to guard it.")
+    print("This proves the tests fire on the mutations written here. It does NOT prove they are")
+    print("binding — a guard over identifier names or source text still needs an independent")
+    print("attempt to evade it, by someone other than its author.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -527,11 +527,26 @@ def load_recipes(path: Path, worktree: Path, raw: str = None):
         # whoever authored the issue. Resolve BOTH sides and require containment; resolving is what
         # catches the symlink, since a lexical check cannot.
         rel = row["file"]
-        # Before the allow-list: no absolute path can start with an allowed root, so this check would
-        # be unreachable behind it — a guard nothing can arm. It also gives the precise message.
         if Path(rel).is_absolute():
             raise Refusal(f"row {i} file must be repo-relative, got an absolute path: {rel}")
-        if not any(rel.startswith(root) for root in MUTABLE_ROOTS):
+        # RESOLVE BEFORE DECIDING. A prefix check on the raw string answers a question about the
+        # STRING; every question worth asking here is about the FILE it names. `Sources/../Tests/x.swift`
+        # passes a lexical `startswith("Sources/")`, resolves inside the worktree, and lands in Tests/ —
+        # where breaking an assertion yields a false CAUGHT. Same bypass reaches Project.swift.
+        # Cloud review, PR #2158.
+        target = (worktree / rel).resolve()
+        wt = worktree.resolve()
+        if not (target == wt or wt in target.parents):
+            raise Refusal(
+                f"row {i} resolves OUTSIDE the worktree and will not be mutated:\n"
+                f"  recipe says: {rel}\n"
+                f"  resolves to: {target}\n"
+                f"  worktree:    {wt}"
+            )
+        if not any(
+            root_path == target or root_path in target.parents
+            for root_path in ((wt / r).resolve() for r in MUTABLE_ROOTS)
+        ):
             raise Refusal(
                 f"row {i} targets {rel}, which is outside {', '.join(MUTABLE_ROOTS)} — the only place a "
                 "mutation means anything here. A mutation must break PRODUCTION code the filtered lane "
@@ -543,17 +558,11 @@ def load_recipes(path: Path, worktree: Path, raw: str = None):
                 "build never saw.\n"
                 "  Anywhere the lane does not execute, every row reports SURVIVED regardless of the "
                 "test's quality.\n"
-                "An allow-list on purpose: the deny-list it replaced was wrong once per review round. "
-                "Prove a change of that kind with a full lane instead."
-            )
-        target = (worktree / row["file"]).resolve()
-        wt = worktree.resolve()
-        if not (target == wt or wt in target.parents):
-            raise Refusal(
-                f"row {i} resolves OUTSIDE the worktree and will not be mutated:\n"
-                f"  recipe says: {row['file']}\n"
-                f"  resolves to: {target}\n"
-                f"  worktree:    {wt}"
+                "An allow-list on purpose: the deny-list it replaced was wrong once per review round, "
+                "and it is applied to the RESOLVED path, so `Sources/../Tests/x.swift` cannot walk "
+                "through it. Prove a change of that kind with a full lane instead.\n"
+                f"  recipe says: {rel}\n"
+                f"  resolves to: {target}"
             )
         if not target.is_file():
             raise Refusal(f"row {i} target does not exist: {row['file']}")
@@ -625,7 +634,11 @@ def main(argv=None):
                  "silently do less than the other flag promises.")
 
     worktree = (args.worktree or Path(__file__).resolve().parent.parent).resolve()
-    derived = worktree / ".derivedData" / "Test"
+    # The canonical lane reads DERIVED_DATA_PATH with the same default (xcode-test.sh:19). The drift
+    # guard only compares that assignment's TEXT, so a battery ignoring the override would run against
+    # the shared warm cache while an operator believed it was isolated — colliding with another lane,
+    # or reusing different incremental artifacts. Cloud review, PR #2158.
+    derived = Path(os.environ.get("DERIVED_DATA_PATH") or (worktree / ".derivedData" / "Test"))
     log_dir = worktree / "build" / "mutation-battery"
     log_dir.mkdir(parents=True, exist_ok=True)
 

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -164,6 +164,13 @@ CANONICAL_ASSIGNMENTS = [
 # Expansions the runner knows the contents of, because CANONICAL_ASSIGNMENTS pins each one. An
 # expansion NOT in this set hides arguments the runner cannot see, so it is a refusal rather than a
 # token to skip — the difference between "I checked and it matches" and "I could not look".
+# The expansions the canonical invocation must pass, IN ORDER. A set membership test accepted a lane
+# that had DELETED `"${TEST_ARGS[@]}"` — it would stop filtering to one suite and run everything — and
+# accepted `"$scheme"` and `"$config"` swapped, which builds a different configuration. An argument
+# list is defined by its order, so the comparison has to be ordered too. Cloud review, PR #2158.
+CANONICAL_EXPANSION_SEQUENCE = [
+    '"$PROJECT"', '"$scheme"', '"$config"', '"$DERIVED_DATA"', '"$DEST"', '"$@"', '"${TEST_ARGS[@]}"',
+]
 CANONICAL_EXPANSIONS = {
     '"$PROJECT"', '"$scheme"', '"$config"', '"$DERIVED_DATA"', '"$DEST"',
     '"$@"', '"${TEST_ARGS[@]}"',
@@ -224,6 +231,11 @@ def _restore_active(reason: str):
 
 def _install_restore_on_signal():
     def handler(signum, _frame):
+        # Ignore further signals FIRST. A second one arriving inside the restore loop re-enters this
+        # handler and reaches the re-raise below before the remaining targets are copied back, so a
+        # double Ctrl-C would leave files mutated.
+        for other in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP, signal.SIGQUIT):
+            signal.signal(other, signal.SIG_IGN)
         # Reap the lane FIRST. Restoring the file while xcodebuild's group survives leaves an orphan
         # running mutant tests and writing the shared DerivedData after we are gone — the file looks
         # recovered and the machine is not. Fixing only the timeout path last round missed this exit.
@@ -233,7 +245,7 @@ def _install_restore_on_signal():
         signal.signal(signum, signal.SIG_DFL)
         os.kill(os.getpid(), signum)
 
-    for sig in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+    for sig in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP, signal.SIGQUIT):
         signal.signal(sig, handler)
 
 
@@ -488,11 +500,13 @@ def check_canonical_settings(worktree: Path):
     raw_tokens = [tok for tok in match.group(1).split() if tok != "\\"]
     expansions = [tok for tok in raw_tokens if "$" in tok]
     unknown_expansions = sorted(set(expansions) - CANONICAL_EXPANSIONS)
+    expansion_sequence = expansions if expansions != CANONICAL_EXPANSION_SEQUENCE else None
     found = {tok for tok in raw_tokens if "$" not in tok}
     missing_tokens = sorted(CANONICAL_TOKENS - found)
     extra_tokens = sorted(found - CANONICAL_TOKENS)
 
-    if missing_assignments or missing_tokens or extra_tokens or unknown_expansions or invocation_prefix:
+    if (missing_assignments or missing_tokens or extra_tokens or unknown_expansions
+            or invocation_prefix or expansion_sequence is not None):
         lines = []
         if missing_assignments:
             lines.append("  settings the runner expects and the script no longer has:")
@@ -500,6 +514,11 @@ def check_canonical_settings(worktree: Path):
         if missing_tokens:
             lines.append("  invocation tokens the runner expects and the script no longer passes:")
             lines += [f"    - {m}" for m in missing_tokens]
+        if expansion_sequence is not None:
+            lines.append("  the invocation's shell expansions are not the ones this runner "
+                         "reproduces, in order:")
+            lines.append(f"    expected: {CANONICAL_EXPANSION_SEQUENCE}")
+            lines.append(f"    found:    {expansion_sequence}")
         if extra_tokens:
             lines.append("  tokens the script now passes and the runner does NOT reproduce:")
             lines += [f"    + {m}" for m in extra_tokens]
@@ -819,6 +838,12 @@ def main(argv=None):
     lane = Lane(worktree, derived, log_dir)
     suites = {row["suite"] for row in rows}
 
+    # BEFORE anything can spawn a lane. Installed after the opening baseline, a signal during `tuist
+    # generate` or the baseline itself took Python's default action and left that child's process group
+    # orphaned on the shared DerivedData. Nothing is mutated yet, so the restore half is a no-op here —
+    # the reaping half is not.
+    _install_restore_on_signal()
+
     print(f"\n[1/3] baseline on a clean tree — {len(suites)} suite(s)")
     try:
         problems = baseline(lane, suites, "before")
@@ -838,7 +863,6 @@ def main(argv=None):
         print("\n--dry-run: recipes validated, baseline green, nothing mutated.")
         return 0
 
-    _install_restore_on_signal()
     print(f"\n[2/3] {len(rows)} mutation(s), one at a time")
     results = []
     for i, row in enumerate(rows, 1):

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -164,6 +164,15 @@ INVOCATION_RE = re.compile(r"xcodebuild test\s*\\\n(.*?)\|\s*tee", re.DOTALL)
 # xcodebuild with its ambient environment, so any prefix means the canonical lane and the battery build
 # differently, and there is no list of prefixes worth maintaining.
 INVOCATION_PREFIX_RE = re.compile(r"^([^\n]*?)xcodebuild test\s*\\", re.MULTILINE)
+# Files the generated Xcode project is BUILT FROM. `generate_once` runs `tuist generate` a single time
+# and every row after reuses that project, which is correct only while a mutation changes file CONTENT
+# and never the project's shape. Mutating one of these changes target settings, dependencies or source
+# inclusion, and xcodebuild would keep consuming the CLEAN baseline's `.xcodeproj` — so the row would
+# report SURVIVED about a mutant the build never saw. The doc comment on `generate_once` asserted this
+# precondition from the start; nothing enforced it, which is the defect. Rejected at validation rather
+# than handled by regenerating, because a battery that silently changes cost per row is worse than one
+# that says a recipe is out of scope. Cloud review, PR #2158.
+TUIST_INPUTS = ("Project.swift", "Workspace.swift", "Tuist.swift", "Package.swift", "Tuist/")
 # One definition, so the drift guard above and the call below cannot disagree about the version.
 TUIST_GENERATE_ARGV = ["mise", "x", "tuist@4.195.11", "--", "tuist", "generate", "--no-open"]
 
@@ -248,8 +257,12 @@ class Lane:
 
     def generate_once(self):
         """`tuist generate` output is byte-identical on a warm tree (measured 6.7s, M5 Max) so it is
-        pure per-row overhead. Generate once. Safe ONLY because a mutation changes file CONTENT, never
-        the file list — a recipe that adds or removes a file violates that and is rejected at load."""
+        pure per-row overhead. Generate once.
+
+        Safe ONLY because a mutation changes file CONTENT and never the project's SHAPE. That is a real
+        precondition, not a remark: `TUIST_INPUTS` above rejects recipes targeting the files the project
+        is generated from, because a mutation there would leave xcodebuild consuming the clean
+        baseline's `.xcodeproj` and the row would report SURVIVED about a mutant the build never saw."""
         if self.generated:
             return
         rc, out = run(
@@ -488,6 +501,17 @@ def load_recipes(path: Path, worktree: Path, raw: str = None):
         # file the battery was never scoped to — and with --from-issue the recipe is data written by
         # whoever authored the issue. Resolve BOTH sides and require containment; resolving is what
         # catches the symlink, since a lexical check cannot.
+        rel = row["file"]
+        if rel in TUIST_INPUTS or any(
+            rel.startswith(t) if t.endswith("/") else rel.endswith("/" + t) for t in TUIST_INPUTS
+        ):
+            raise Refusal(
+                f"row {i} targets {rel}, which the generated Xcode project is BUILT FROM. This runner "
+                "generates once and reuses that project for every row, so a mutation there would "
+                "change the project's shape while xcodebuild kept consuming the clean baseline's "
+                "`.xcodeproj` — the row would report SURVIVED about a mutant the build never saw. "
+                "Out of scope for the battery; prove that kind of change with a full lane instead."
+            )
         if Path(row["file"]).is_absolute():
             raise Refusal(f"row {i} file must be repo-relative, got an absolute path: {row['file']}")
         target = (worktree / row["file"]).resolve()

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -101,14 +101,32 @@ CANONICAL_TOKENS = {
     "-project", "-scheme", "-configuration", "-derivedDataPath", "-destination",
     "ARCHS=arm64", "VALID_ARCHS=arm64", "ONLY_ACTIVE_ARCH=YES",
 }
-# Values that are shell expansions in the script and literals here; compared separately, by assignment.
+# Values that are shell expansions in the invocation and literals here, so they cannot be compared as
+# tokens. Two review rounds each found ONE more of these, so rather than wait for a third the axes were
+# enumerated exhaustively: every input that decides WHAT gets built and WHERE. Each line below is a
+# literal that must appear in the canonical script verbatim.
+#
+#   what project      -> PROJECT
+#   what scheme       -> DEBUG_SCHEME, and the CALL SITE that passes it (a scheme can be right while the
+#                        call passes the other one)
+#   what config       -> the call site again; `Lane.run_suite` hardcodes Debug, so a call site changed to
+#                        Release diverges while `run_lane` itself is untouched
+#   where it lands    -> DERIVED_DATA's default, which this runner reproduces as .derivedData/Test
+#   what destination  -> DEST
+#   how it filters    -> TEST_ARGS
+#   what generates it -> the pinned tuist version, which this runner invokes directly
 CANONICAL_ASSIGNMENTS = [
     'PROJECT="EnviousWispr.xcodeproj"',
     'DEBUG_SCHEME="EnviousWispr"',
     "DEST='platform=macOS,arch=arm64'",
     'TEST_ARGS=(-only-testing:"$FILTER")',
+    'DERIVED_DATA="${DERIVED_DATA_PATH:-$PROJECT_ROOT/.derivedData/Test}"',
+    'run_lane "$DEBUG_SCHEME" Debug',
+    "mise x tuist@4.195.11 -- tuist generate --no-open",
 ]
 INVOCATION_RE = re.compile(r"xcodebuild test\s*\\\n(.*?)\|\s*tee", re.DOTALL)
+# One definition, so the drift guard above and the call below cannot disagree about the version.
+TUIST_GENERATE_ARGV = ["mise", "x", "tuist@4.195.11", "--", "tuist", "generate", "--no-open"]
 
 
 class Refusal(Exception):
@@ -151,7 +169,7 @@ class Lane:
         if self.generated:
             return
         rc, out = run(
-            ["mise", "x", "tuist@4.195.11", "--", "tuist", "generate", "--no-open"],
+            TUIST_GENERATE_ARGV,
             cwd=self.worktree,
             log_path=self.log_dir / "tuist-generate.log",
         )
@@ -286,8 +304,16 @@ def recipes_from_issue(number: int, worktree: Path):
 
 def load_recipes(path: Path, worktree: Path, raw: str = None):
     where = "the issue body" if raw is not None else str(path)
+    if raw is None:
+        # A missing or unreadable file is a preflight refusal like any other. Left as an OSError it
+        # escapes as a traceback with exit 1, which the documented exit codes reserve for "a row
+        # SURVIVED" — the one status an unattended caller must not confuse with a real result.
+        try:
+            raw = path.read_text()
+        except OSError as exc:
+            raise Refusal(f"cannot read the recipe file {path}: {exc}")
     try:
-        data = json.loads(raw if raw is not None else path.read_text())
+        data = json.loads(raw)
     except json.JSONDecodeError as exc:
         raise Refusal(f"the recipe in {where} is not valid JSON: {exc}")
     # Valid JSON is not the expected SHAPE. `[]`, `{"rows": [1]}`, or a row that is a string all parse
@@ -301,7 +327,7 @@ def load_recipes(path: Path, worktree: Path, raw: str = None):
     default_suite = data.get("suite_default")
     rows = data.get("rows") or []
     if not rows:
-        raise Refusal(f"{'the issue body' if raw is not None else path} declares no rows.")
+        raise Refusal(f"{where} declares no rows.")
     for i, row in enumerate(rows, 1):
         if not isinstance(row, dict):
             raise Refusal(f"row {i} is a {type(row).__name__}, not an object.")
@@ -367,8 +393,10 @@ def baseline(lane: Lane, suites, phase: str):
             problems.append(f"{suite}: did not compile ({log})")
         elif count is None or count < 1:
             problems.append(
-                f"{suite}: executed ZERO tests and reported success — the filter names a suite that "
-                f"does not exist. Read the name from its @Suite declaration. ({log})"
+                f"{suite}: executed ZERO tests and REPORTED SUCCESS. Nothing was mutated. The "
+                f"filter names a suite that does not exist here — renamed, moved to another target, "
+                f"or read off a filename rather than off its @Suite declaration. Left unchecked this "
+                f"is the worst failure the battery has, because every row would score SURVIVED ({log})"
             )
         elif rc != 0 or failures:
             problems.append(f"{suite}: {len(failures)} failing on an unmutated tree ({log})")
@@ -480,7 +508,11 @@ def main(argv=None):
                     if not compiled:
                         detail = f"mutant does not compile — proves nothing about the test ({log})"
                     elif count is None or count < 1:
-                        detail = f"executed ZERO tests — filter is wrong, not the test ({log})"
+                        detail = (
+                            f"executed ZERO tests, so this row is a verdict about nothing. Either the "
+                            f"suite was renamed and the recipe is stale, or the filter never matched. "
+                            f"Read the name off its @Suite declaration, never off the filename ({log})"
+                        )
                     elif any(row["expect_fail"] in line for line in failures):
                         verdict = "CAUGHT"
                         others = [l for l in failures if row["expect_fail"] not in l]

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -412,9 +412,18 @@ def check_no_dev_app(worktree: Path):
         )
 
 
-def preflight(worktree: Path):
+def preflight(worktree: Path, *, will_run_tests: bool = True):
+    """`will_run_tests=False` for --validate-only, which runs no lane and mutates nothing.
+
+    The dev-app refusal exists because concurrent app-log writes corrupt the AppLogger tests and score
+    as mutants CAUGHT (#2080). That reasoning is entirely about RUNNING tests, so applying it to a
+    validation pass refuses a read-only check for a condition that cannot affect it — measured the first
+    time a peer's UAT app blocked a recipe validation that touches nothing. Scope a guard to the
+    situation its reasoning covers; a guard that refuses more than its reason supports trains bypasses.
+    """
     check_canonical_settings(worktree)
-    check_no_dev_app(worktree)
+    if will_run_tests:
+        check_no_dev_app(worktree)
     leftovers = list(worktree.rglob("*.mutbak"))
     if leftovers:
         raise Refusal(
@@ -648,7 +657,7 @@ def main(argv=None):
     print(f"branch:   {branch.strip()} @ {head.strip()[:12]}")
 
     try:
-        preflight(worktree)
+        preflight(worktree, will_run_tests=not args.validate_only)
         if args.from_issue is not None:
             print(f"recipe:   issue #{args.from_issue}")
             rows = load_recipes(None, worktree, raw=recipes_from_issue(args.from_issue, worktree))


### PR DESCRIPTION
Part of #2156.

## Why

The mutation battery is correct and was running at the wrong time: hand-driven, inline, during the
founder's working hours. A recent instance was 15 rows and about an hour, announced to him as "running
in the background, nothing needs you" while it consumed his session.

Founder direction 2026-08-18: write the test fast by day, file a `test-hardening` issue carrying the
recipe, and let an overnight session run the battery and **fix** what survives to all-clear. He is handed
fixed tests, not a report.

This PR ships the runner that makes the overnight half unattended. The rule changes live in gitignored
`.claude/rules/` and are therefore not in this diff; they are listed at the bottom.

## What is here

`scripts/mutation-battery.py` — declarative recipes, run one at a time, unattended. It generalises the
working-but-hardcoded pattern in the #2007 artifacts (Python-suite-only, single-issue paths) to the Swift
lane.

Four controls, each present because a hand-rolled run got that one wrong and reported a perfect score:

1. **Clean-tree baseline BEFORE the first mutant**, not tidy-up after. A battery started on an
   already-poisoned tree reports a perfect score, and verified restores cannot catch it because the
   poisoning predates the harness. This is the control that caught the 2026-08-17 incident where 8/8
   rows read CAUGHT and the eighth ran against a file six mutations deep.
2. **Restore by `shutil.copy2` plus a byte-identical comparison.** `git checkout --` silently no-ops on
   an untracked file and restores the OLD content under the NEW path for a staged rename. Both failures
   are silent, and both happened.
3. **Fail closed on zero executed tests.** `-only-testing:` naming a suite that does not exist prints
   `Executed 0 tests` and `** TEST SUCCEEDED **`. Inside a battery that reads as EVERY MUTANT SURVIVED,
   so every filter is validated against the clean tree before anything is mutated.
4. **A mutant that does not compile is an ERROR, not a catch.** A red lane proves nothing about the test
   unless the tests actually ran. Detected as a red lane carrying `error:` with no test-run summary.

Plus two refusals that are not about mutation mechanics:

- **No dev app may be running.** Concurrent writes to `~/Library/Logs/EnviousWispr/app.log` break the
  UTF-8 boundaries the `AppLogger` tests read back, failing ~6 tests on a diff that touches no logging
  code (#2080). In a battery that scores as a mutant **CAUGHT when nothing detected the sabotage** — it
  fails toward confidence, so it is a refusal rather than a warning.
- **The canonical test script must not have drifted.** The runner deliberately does not shell out to
  `scripts/xcode-test.sh`: that script tees to a FIXED log path and SUMS every `Test run with N test`
  line in it, so two lanes inflate the count, and it runs `tuist generate` unconditionally for 6.7 s of
  byte-identical output per row. Both are right for a one-shot run and wrong for a battery. The price of
  that deviation is two sources of truth for the build settings, so it is paid for with a fail-closed
  guard rather than left implicit.

Recipe validation runs **before the first build**: anchor presence and uniqueness, target existence,
target-qualified suite name, and a mutation that would change nothing are all refused up front. A
malformed recipe costs nothing instead of one compile.

## Validation

`scripts/mutation-battery-test.py` — 18 cases, every rejection paired with a near-identical **acceptance**,
because a checker that stopped classifying anything looks identical to a working one when you only test
the rejections.

All 8 guards mutation-controlled: break the guard, require the **named** case to go red, restore, confirm
byte-identical. 8/8 caught, baseline green before and after. One of those controls found its own anchor
was ambiguous and refused to run rather than mutating the wrong site — which is the behaviour under test.

## What is NOT proven, stated plainly

**The run paths — baseline, mutate, restore against a real Swift suite — have not executed.** They need a
real build, and three sessions shared one box tonight; I ran no builds and hold no reservation ahead of
the two sessions that do. A self-test that pretended to cover them would be exactly the vacuity this tool
exists to catch, so it does not.

The recipe for that proof is written and validates: two mutations of
`SpeechEngineSettingsView.defaultLockCode` against `EnviousWisprTests/LanguageLockDefaultCodeTests`,
restoring the exact #1678 bug. A peer session is taking the plain hand measurement first so the runner's
first real run has a **known expected answer** to be checked against, which is a stronger first proof
than a novel measurement.

Per-mutant wall clock is therefore **UNMEASURED** and labelled as such in the rule, with the machine
named. It is not estimated anywhere.

## Known limit, not hidden

A battery only ever tries the mutations its author imagined. It proves a test fires on the shapes you
thought of; it never proves the test is **binding**. A guard written over identifier names or source text
still needs an independent attempt to evade it — this repo has a measured instance of an external
reviewer refuting a guard its own matrix reported as CAUGHT. The runner says so in its header and on a
clean report.

## Rejected in design

Codex proposed a runtime-selectable mutation channel: permanent switches in shipped code so a test can
disable a behaviour with no rebuild. Fastest option and correctly identified as such. Rejected — it means
shipping self-sabotage hooks in the product, the same shape as the #2145 convenience default that
silently reconnected an injected seam to production and reached cloud review before anyone caught it.

## Rule changes (gitignored, not in this diff)

- `testing-philosophy.md` RULE: write-the-test-by-day-run-the-battery-by-night — the new owner.
  Includes the incentive hole GPT and Gemini both found independently: the same agent writes the test,
  picks the mutant, and fixes survivors, and "until all-clear" rewards closed issues rather than strict
  guards. Answered structurally — the recipe is frozen when filed, the overnight session adds a mutant of
  its own, and a survivor is never resolved by loosening an assertion.
- `validation-discipline.md` — "re-run the mutation set after EVERY revision" is now SCOPED to a battery
  run, which happens overnight. Full force inside that session; no longer a licence to re-run a matrix
  during the founder's day. Also two new false-positive tally entries (#23, #24).
- `workflow-process.md` RULE: definition-of-done — the `test-hardening` issue is a ship condition.
- `tools-and-apps.md` — a build not currently running does not mean the slot is free; a sequential
  battery makes a `pgrep` probe wrong periodically by construction.
- `INDEX.md` — pathway triggers widened so "mutation battery" and "harden the tests" reach the rule.

## Lane

`Docs/dev-tooling`. No `Sources/` or `Tests/` file is touched; nothing here ships to users.
