### PR TITLE
Rename Live transcription to Faster Transcription

### DIFF
--- a/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
@@ -429,7 +429,7 @@ final class LivePreviewCoordinator: CorrectorVocabularyConsumer {
         // exhaustively instead of waiting for the next round to surface one.
         //
         // Every refusal reason can persist for the rest of a session — the user
-        // turns live transcription on, or locks a language the model does not
+        // turns Faster Transcription on, or locks a language the model does not
         // cover, or removes the model. The prepared engine holds a loaded 217 MB
         // model that cannot serve ANY recording while the reason holds, so
         // keeping it is a pure cost. Re-preparing when the block clears costs one
@@ -906,10 +906,15 @@ enum LivePreviewCopy {
   /// chosen to download it yet.
   static let previewModelNotInstalled =
     "Download the preview model in Settings to see words appear."
-  /// #2108 Gate C. Live transcription already decodes continuously while you
-  /// speak, and a second decoder would slow it by half (measured). Says what is
-  /// happening rather than naming a setting the reader has to go and find.
-  static let heartIsStreaming = "On-screen preview pauses while live transcription is on."
+  /// #2108 Gate C. Faster Transcription already decodes continuously while you
+  /// speak, and a second decoder would slow it by half (measured).
+  ///
+  /// **This names the setting, and #2155 renamed it.** Missed by the first sweep
+  /// because `claim-sweep.sh` scoped itself to `Views/` and this copy lives under
+  /// `App/LivePreview/` — user-facing pill text outside the surface list. The tool
+  /// now covers this directory; the lesson is that a copy string is user-facing
+  /// because of where it is SHOWN, never because of which folder holds it.
+  static let heartIsStreaming = "On-screen preview pauses while Faster Transcription is on."
   /// No remedy offered ON PURPOSE. A build shipped without the engine's files is
   /// ours to fix, and a "Download" button here would point at nothing.
   static let engineUnavailableInThisBuild =

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsCopy.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsCopy.swift
@@ -294,7 +294,7 @@ enum LivePreviewSettingsCopy {
   /// `statusPausedDetail` below), the closed exception in
   /// `liveOnlyAppearsInApprovedProductNames`'s allowlist.
   ///
-  /// It names Live transcription as the REASON for the pause rather than
+  /// It names Faster Transcription as the REASON for the pause rather than
   /// calling this preview by that name, which is the distinction the guard
   /// draws. When #2155 renames that setting to "Faster Transcription", this
   /// string and the test's exception change together, in that PR.
@@ -302,9 +302,9 @@ enum LivePreviewSettingsCopy {
   /// Why the pause exists: the universal preview refuses to run while the heart
   /// decodes continuously, because concurrent decode was measured costing
   /// transcription 1.50x. Yielding is the design, not a defect.
-  static let pausedForLiveTranscription = "Paused while Live transcription is on"
+  static let pausedForFasterTranscription = "Paused while Faster Transcription is on"
   static let statusPausedDetail =
-    "Your dictation keeps its full speed. Turn Live transcription off to see the preview."
+    "Your dictation keeps its full speed. Turn Faster Transcription off to see the preview."
 
   // MARK: - Language section (#2154)
 
@@ -330,7 +330,7 @@ enum LivePreviewSettingsCopy {
   /// output, whenever the engine is refused.**
   ///
   /// `WhisperPreviewEngineResolver` returns `.blocked(.heartIsStreaming)` before
-  /// it asks anything else, so with Live transcription streaming the universal
+  /// it asks anything else, so with Faster Transcription streaming the universal
   /// preview will not run at all. The hero card reports that correctly. The row
   /// below it did not: it went on saying "Your words will appear in German" and
   /// "The preview detects your language as you speak" while nothing would appear

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewStatusMapping.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewStatusMapping.swift
@@ -253,19 +253,19 @@ enum LivePreviewStatusMapping {
     // `WhisperPreviewEngineResolver` refuses with `.heartIsStreaming` before it
     // asks whether the model is admitted, deliberately: concurrent decode was
     // measured costing the heart 1.50x, and a display limb must never contend
-    // with transcription (#2108 Gate C). So with Live transcription running,
+    // with transcription (#2108 Gate C). So with Faster Transcription running,
     // this preview will not start whatever the download says.
     //
     // The order is copied from the resolver rather than chosen for
     // actionability. Showing "needs a download" here would be equally TRUE and
     // would let the chip say the preview is one download away when turning off
-    // Live transcription is also required — a status that disagrees with what
+    // Faster Transcription is also required — a status that disagrees with what
     // pressing record actually does. A user who turns streaming off then sees
     // the download need, which is a correct sequence of answers.
     if heartIsStreaming {
       return Summary(
         chip: ProviderStatus(
-          label: LivePreviewSettingsCopy.pausedForLiveTranscription, tone: .needsSetup),
+          label: LivePreviewSettingsCopy.pausedForFasterTranscription, tone: .needsSetup),
         detail: LivePreviewSettingsCopy.statusPausedDetail)
     }
 

--- a/Sources/EnviousWisprAppKit/Views/Settings/LiveTranscriptionCopy.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LiveTranscriptionCopy.swift
@@ -1,7 +1,7 @@
 import EnviousWisprCore
 import Foundation
 
-/// #1337: canonical copy for the "Live transcription" setting and its in-app help panel.
+/// #1337: canonical copy for the "Faster Transcription" setting and its in-app help panel.
 ///
 /// Mirrors `SpokenPunctuationCopy` (#1794) in shape and intent: one place owning every
 /// user-facing string, with `LiveTranscriptionCopyTests` freezing them so a change is a
@@ -40,26 +40,38 @@ import Foundation
 ///
 /// Brand rule: no em-dashes or en-dashes in user-facing copy.
 enum LiveTranscriptionCopy {
-  /// #1988 considered renaming this ("Live transcription" promises something this
-  /// setting has never done, and a real user hit exactly that) and MEASURED the
-  /// cost first: the phrase appears 30 times across the app, three live website
-  /// pages, and a published help article whose TITLE and URL slug are the name
-  /// itself. That is a public-URL decision, not a copy tweak, so it is not bundled
-  /// into a feature PR. Tracked on #1988 Part 1.
+  /// **RENAMED from "Live transcription" by #2155 (founder, 2026-08-18).** The old
+  /// name promised something this setting has never done — a real user switched it
+  /// on expecting words on screen while speaking, saw nothing, and asked whether the
+  /// feature was broken. What it actually changes is WHEN the text lands, which is a
+  /// speed property, not a visibility one. The feature that shows words while you
+  /// speak is Live Preview.
   ///
-  /// What #1988 shipped instead costs nothing and solves the confusion it would
-  /// have caused: the new preview setting avoids the word "live" entirely, and both
-  /// descriptions below now say plainly that this toggle changes nothing you can
-  /// see while recording.
-  static let toggleLabel = "Live transcription"
-  static let helpButtonAccessibilityLabel = "What does Live transcription change?"
+  /// **The web addresses did NOT change and that was deliberate.** People search
+  /// "live transcription mac" because that is the category's name in the world, not
+  /// because it is what our toggle says; the two were never required to match.
+  /// `/blog/live-transcription-that-keeps-up-with-you` and
+  /// `/help/live-transcription-streaming-asr/` keep their slugs, the blog keeps its
+  /// title and keywords, and the help article keeps the old name as a search keyword
+  /// plus an alias sentence. Renaming a URL that exists to rank is expensive and slow
+  /// to recover; renaming a control is not.
+  ///
+  /// **What moved with it, because an instruction naming a control is FALSE the
+  /// moment the control is renamed:** every string here, the Live Preview page's two
+  /// cross-feature explanations, and the help-centre sentences telling a reader to
+  /// switch it on or off. What did NOT move: `WhatsNewContent`'s shipped release note
+  /// (a historical record — see the note there), the two comments quoting the original
+  /// user report, and `ParakeetStreamingSentryError`'s diagnostic strings, which would
+  /// change Sentry grouping and fire new-issue alerts for no user benefit.
+  static let toggleLabel = "Faster Transcription"
+  static let helpButtonAccessibilityLabel = "What does Faster Transcription change?"
 
   /// Shown under the toggle only when WhisperKit is selected AND the language is
   /// Auto-detect, because streaming must commit to one language up front and a bad early
   /// guess poisons the whole dictation (#1276). Lives here rather than inline so all of
   /// this toggle's user-facing strings have one home.
   static let autoLanguageFootnote =
-    "Live transcription needs a selected language. With Auto-detect, EnviousWispr uses "
+    "Faster Transcription needs a selected language. With Auto-detect, EnviousWispr uses "
     + "clean batch transcription for accuracy."
 
   /// One measured comparison row. `off` and `on` are display copy for the two settings.
@@ -116,7 +128,7 @@ enum LiveTranscriptionCopy {
     + "you can notice on most dictations, and it can drop your last few words."
 
   static let parakeet = Panel(
-    title: "What Live transcription changes",
+    title: "What Faster Transcription changes",
     speedHeading: "Speed",
     speedBody:
       "On dictations under a minute, both settings finish at about the same moment. The "
@@ -161,7 +173,7 @@ enum LiveTranscriptionCopy {
     + "recordings, and it needs a language selected."
 
   static let whisperKit = Panel(
-    title: "What Live transcription changes",
+    title: "What Faster Transcription changes",
     speedHeading: "Speed",
     speedBody:
       "On short dictations you will not notice a difference. On long ones it helps clearly: "

--- a/Sources/EnviousWisprAppKit/Views/Settings/SpeechEngineSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SpeechEngineSettingsView.swift
@@ -295,9 +295,9 @@ struct SpeechEngineSettingsView: View {
       }
 
       // ── Section 4: Transcription Mode ────────────────────────────────
-      // #1276 Step 2 (PR-2): the "Live transcription" toggle now shows for both
+      // #1276 Step 2 (PR-2): the "Faster Transcription" toggle now shows for both
       // engines (it binds the same `useStreamingASR`). On WhisperKit with
-      // Auto-detect language, live transcription safely uses clean batch instead
+      // Auto-detect language, streaming safely uses clean batch instead
       // (the footnote explains why); a picked language streams.
       if settings.selectedBackend == .parakeet || settings.selectedBackend == .whisperKit {
         BrandedSection(header: "Transcription Mode") {
@@ -743,7 +743,7 @@ struct SpeechEngineSettingsView: View {
     .accessibilityLabel("Re-check model status")
   }
 
-  // MARK: - Live transcription help (#1337)
+  // MARK: - Faster Transcription help (#1337)
 
   /// Same shape as `spokenPunctuationHelpButton` deliberately: a real `Button`, never a
   /// hover-only reveal, so it is reachable by keyboard and VoiceOver. The two panels are

--- a/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
@@ -182,6 +182,14 @@ enum WhatsNewContent {
     ),
 
     Entry(
+      // **"Live transcription" here is CORRECT and must not be renamed.** #2155
+      // renamed that setting to Faster Transcription, and every other mention in
+      // the app moved with it. This one is a shipped release note describing
+      // v2.4.3, when the setting WAS called Live transcription. Rewriting it
+      // would make the historical record describe a name that did not exist at
+      // the time — the same exclude-list discipline dated audits and changelog
+      // rows get (workflow-process.md RULE: self-review-and-grep-before-codex).
+      // A future sweep for the old name will find this line; leave it.
       id: "smaller-repairs-recording-settings",
       icon: "wrench.and.screwdriver",
       title: "A handful of smaller repairs across recording and settings",

--- a/Tests/EnviousWisprTests/App/LivePreviewStatusMappingTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewStatusMappingTests.swift
@@ -118,7 +118,7 @@ struct LivePreviewStatusMappingTests {
   func streamingHeartBeatsAdmission() {
     let paused = summary(engine: .universal, universalState: .admitted, heartIsStreaming: true)
     #expect(paused.chip.tone == .needsSetup)
-    #expect(paused.chip.label == LivePreviewSettingsCopy.pausedForLiveTranscription)
+    #expect(paused.chip.label == LivePreviewSettingsCopy.pausedForFasterTranscription)
     // Control: the SAME inputs without streaming are the ready state, so this
     // test cannot pass because of some other term.
     #expect(summary(engine: .universal, universalState: .admitted).chip.tone == .ready)

--- a/Tests/EnviousWisprTests/Settings/LivePreviewSettingsCopyTests.swift
+++ b/Tests/EnviousWisprTests/Settings/LivePreviewSettingsCopyTests.swift
@@ -68,7 +68,7 @@ struct LivePreviewSettingsCopyTests {
       LivePreviewSettingsCopy.statusBuildCannotRunLabel,
       LivePreviewSettingsCopy.statusBuildCannotRunDetail,
       LivePreviewSettingsCopy.statusBuildCannotRunDetailNoAlternative,
-      LivePreviewSettingsCopy.pausedForLiveTranscription,
+      LivePreviewSettingsCopy.pausedForFasterTranscription,
       LivePreviewSettingsCopy.statusPausedDetail,
       LivePreviewSettingsCopy.changeLanguageButton,
       LivePreviewSettingsCopy.changeLanguageHelp,
@@ -213,7 +213,7 @@ struct LivePreviewSettingsCopyTests {
   /// A list of banned phrases (`live transcription`, `live text`, ...) let
   /// "Your transcription appears live while you speak" through, which restates
   /// the other feature's promise almost verbatim; and it rejected this page's
-  /// own required label, "Paused while Live transcription is on". A blacklist
+  /// own required label, "Paused while Faster Transcription is on". A blacklist
   /// enumerates the collisions you imagined. An allowlist enumerates the uses
   /// you sanctioned, and only the second is closed under sentences nobody
   /// thought of.
@@ -225,7 +225,7 @@ struct LivePreviewSettingsCopyTests {
     // **The paused state is a PAIR, and the first draft of this guard allowed
     // only its label.** The full-suite run caught that immediately: the detail
     // line has to name the other setting too, because naming it IS the remedy
-    // ("turn Live transcription off"). A guard that permits the diagnosis and
+    // ("turn Faster Transcription off"). A guard that permits the diagnosis and
     // forbids the fix would have forced the copy to say what to do without
     // saying what to do it to.
     //
@@ -233,31 +233,35 @@ struct LivePreviewSettingsCopyTests {
     // not "any string about pausing" — widening it to a predicate is how an
     // allowlist quietly becomes the blacklist it replaced.
     let crossFeatureExplanations: Set<String> = [
-      LivePreviewSettingsCopy.pausedForLiveTranscription,
+      LivePreviewSettingsCopy.pausedForFasterTranscription,
       LivePreviewSettingsCopy.statusPausedDetail,
     ]
-    #expect(LivePreviewSettingsCopy.pausedForLiveTranscription == "Paused while Live transcription is on")
+    #expect(LivePreviewSettingsCopy.pausedForFasterTranscription == "Paused while Faster Transcription is on")
     #expect(
       LivePreviewSettingsCopy.statusPausedDetail
-        == "Your dictation keeps its full speed. Turn Live transcription off to see the preview.")
+        == "Your dictation keeps its full speed. Turn Faster Transcription off to see the preview.")
 
     for string in allStrings {
       let lowered = string.lowercased()
-      let withoutApprovedNames =
-        lowered
-        .replacingOccurrences(of: "live preview", with: "")
-        .replacingOccurrences(of: "live transcription", with: "")
+      // **STRICTER after #2155, not weaker.** "Live transcription" used to be an
+      // approved name here and was exempted from the check below. The setting is
+      // now Faster Transcription, which contains no "live" at all, so the
+      // exemption is gone and ANY occurrence of the old name on this page now
+      // fails — including a partial revert of the rename that left this page
+      // behind. What replaced the removed allowlist is this: nothing is allowed
+      // to say it (GR-NEVER-WEAKEN-GUARDRAILS).
+      let withoutApprovedNames = lowered.replacingOccurrences(of: "live preview", with: "")
 
       #expect(
         !withoutApprovedNames.contains("live"),
-        "live may appear only inside the product name Live Preview, or the one permitted mention of Live transcription: \(string)")
+        "live may appear only inside the product name Live Preview: \(string)")
 
-      // Only ONE string may name the other feature at all. Any other mention is
-      // this preview borrowing the name that caused the original confusion.
-      if lowered.contains("live transcription") {
+      // The cross-feature mentions must name the setting by its CURRENT name, or
+      // this page tells the user to turn off a control that does not exist.
+      if crossFeatureExplanations.contains(string) {
         #expect(
-          crossFeatureExplanations.contains(string),
-          "only the paused-state label and its detail line may name Live transcription: \(string)")
+          string.contains("Faster Transcription"),
+          "a cross-feature explanation must name the setting as the user sees it: \(string)")
       }
     }
   }
@@ -279,7 +283,7 @@ struct LivePreviewSettingsCopyTests {
 
   /// **The four cells of the universal row, because the SELECTION is the subject.**
   ///
-  /// Cloud review r8: with Live transcription streaming, `WhisperPreviewEngineResolver`
+  /// Cloud review r8: with Faster Transcription streaming, `WhisperPreviewEngineResolver`
   /// returns `.blocked(.heartIsStreaming)` and the hero correctly reads "Paused",
   /// while this row went on saying "Your words will appear in German" and "The
   /// preview detects your language as you speak". One page asserted a fact and

--- a/website/src/content/blog/live-transcription-that-keeps-up-with-you.md
+++ b/website/src/content/blog/live-transcription-that-keeps-up-with-you.md
@@ -36,6 +36,8 @@ Here is the part I find genuinely elegant. A word is only committed once two con
 
 This approach comes from a research group at Charles University that studies live speech translation, where the same problem shows up in a harder form. Their method, called [whisper_streaming](https://github.com/ufal/whisper_streaming), is the design we adapted. We benchmarked it against other candidates on real dictation before picking it; it won on both speed and text quality.
 
+**A note on the name:** in the app this setting is now called **Faster Transcription**, under Settings > Transcription. It does exactly what this post describes. The name changed because "live" was being read as "shows me my words as I speak", which is a different feature called Live Preview.
+
 By the time you release the key, nearly everything you said is already confirmed. The engine finishes the last unconfirmed words, and that is it. The end-of-dictation wait stops scaling with how long you spoke.
 
 And if anything goes wrong mid-recording, the engine keeps your full audio on the side and falls back to transcribing it in one pass, the traditional way. You always get your text. The fast path is never allowed to put your words at risk.

--- a/website/src/content/help/live-preview-words-on-screen.md
+++ b/website/src/content/help/live-preview-words-on-screen.md
@@ -21,18 +21,18 @@ Your voice and preview text stay on your Mac.
 
 **Switch on Show words while I speak.** The card at the top of the page tells you whether the preview is ready, and if it is not, what is missing.
 
-### Live Preview is not Live transcription
+### Live Preview is not Faster Transcription
 
 These are two different settings and it is easy to mix them up.
 
-| | Live Preview | Live transcription |
+| | Live Preview | Faster Transcription |
 |---|---|---|
 | What you see | Words in the recording pill, on screen | Text written into your document |
 | Where it goes | Nowhere. It is discarded when you stop | Straight into whatever you are typing in |
 | Changes your result | No | Yes, it is the result |
 | Where to find it | Settings, Record, Live Preview | Settings, Transcription |
 
-If you want to watch your words appear as you talk without anything being written yet, you want Live Preview. If you want text landing in your document before you finish speaking, you want [Live transcription](/help/live-transcription-streaming-asr/).
+If you want to watch your words appear as you talk without anything being written yet, you want Live Preview. If you want text landing in your document before you finish speaking, you want [Faster Transcription](/help/live-transcription-streaming-asr/).
 
 ### Choosing an engine
 
@@ -52,7 +52,7 @@ This works differently on the two engines, and the difference only matters if yo
 
 **On Universal**, it depends on the same setting. If you have picked a language for dictation, the preview uses that one. If your dictation language is **Auto**, this engine works out the language itself as you speak, so Auto is not a problem for it. Either way the **Change** button is there if the language is wrong.
 
-The list of downloadable languages further down is Apple's, so it only appears with the Apple engine selected. The language row and the **Change** button appear for both engines whenever Live Preview is switched on.
+The list of downloadable languages further down is Apple's, so it only appears with the Apple engine selected. The language row and the **Change** button appear for both engines whenever Live Preview is switched on. The picker lists **Auto-detect** at the top, so you can hand the choice back to the app as easily as you took it.
 
 ### If you see no words at all
 
@@ -64,6 +64,6 @@ Work down this list.
 
 **Check whether the language is downloaded.** On the Apple engine, a language your Mac does not have shows a **Download** button in the language list. Until you download it, there is nothing to show.
 
-**Check that Live transcription is off.** On the Universal engine, the preview steps aside while Live transcription is running, so your main dictation keeps its full speed. The status card says so when this is why.
+**Check that Faster Transcription is off.** On the Universal engine, the preview steps aside while Faster Transcription is running, so your main dictation keeps its full speed. The status card says so when this is why.
 
 Your dictation is unaffected in every one of these cases. An empty preview never means a lost recording.

--- a/website/src/content/help/live-transcription-streaming-asr.md
+++ b/website/src/content/help/live-transcription-streaming-asr.md
@@ -1,20 +1,20 @@
 ---
-title: "Live transcription"
+title: "Faster Transcription"
 description: "Whether to have text written while you are still speaking."
 category: "speech-engines"
 section: "Transcription"
 order: 4
-keywords: ["live", "live text", "real time", "realtime", "streaming", "as you talk", "write while i talk", "text appears while speaking"]
+keywords: ["live transcription", "live", "live text", "real time", "realtime", "streaming", "as you talk", "write while i talk", "text appears while speaking", "faster transcription"]
 seeAlso: "live-transcription-that-keeps-up-with-you"
 updated: 2026-08-06
 ---
-EnviousWispr normally writes your text once you stop talking. Live transcription writes it while you are still speaking, and it is off unless you turn it on.
+EnviousWispr normally writes your text once you stop talking. Faster Transcription, which was called Live transcription until recently, writes it while you are still speaking, and it is off unless you turn it on.
 
 **Leave it off on Parakeet. On WhisperKit, turn it on if you have picked a language and you often dictate for more than a minute.**
 
 ### Turning it on
 
-Go to **Settings** \> **Transcription** and switch on **Live transcription**. The question mark beside it explains what changes for the engine you are on.
+Go to **Settings** \> **Transcription** and switch on **Faster Transcription**. The question mark beside it explains what changes for the engine you are on.
 
 Looking for words on screen while you speak, rather than text written into your document? That is a different setting: see [Live Preview](/help/live-preview-words-on-screen/).
 

--- a/website/src/content/help/why-is-my-dictation-inaccurate.md
+++ b/website/src/content/help/why-is-my-dictation-inaccurate.md
@@ -28,9 +28,9 @@ Names, companies, and terms from your field are not in a general speech model.
 
 Parakeet, the transcription engine you start with, covers 25 European languages. For anything outside that, switch to WhisperKit under **Transcription** and pick your language. On WhisperKit, naming your language is more accurate than leaving it on auto-detect.
 
-### 5. Turn Live transcription off
+### 5. Turn Faster Transcription off
 
-If you switched Live transcription on, switch it back off under **Transcription**. On Parakeet, Live transcription measurably increases mistakes.
+If you switched Faster Transcription on, switch it back off under **Transcription**. On Parakeet, Faster Transcription measurably increases mistakes.
 
 ### 6. Work out which half went wrong
 


### PR DESCRIPTION
Renames the **Live transcription** setting to **Faster Transcription**, in the app and in every instruction that points at it. Founder decision, 2026-08-18: *"Change Live Transcription to Faster Transcription (as that's what its purpose is)."*

Closes #2155. Closes #2173. Part of #1988.

## Why

The old name promised something the setting has never done. A real user switched it on expecting words on screen while speaking, saw nothing, and asked whether the feature was broken — which is the report #1988 was filed from. What the setting actually changes is **when** the text lands, a speed property. The feature that shows words while you speak is Live Preview, shipped in #2154.

## The blast radius was re-measured, not reused

The issue recorded 30 mentions at `039c2422`. Against merged `main` it is **41**. #2169 added eleven, including two user-facing strings on the Live Preview page that name this setting as the reason the preview is paused.

Those two matter more than their count: ship the rename without them and that page tells the user to turn off a control that no longer exists, on the exact screen they are reading when they want to know why nothing is appearing. That is worse than the confusion being fixed, because it names nothing.

## Web addresses are unchanged, and that is the decision

No file renamed, no redirect, no slug touched. `/blog/live-transcription-that-keeps-up-with-you` and `/help/live-transcription-streaming-asr/` stay exactly as they are.

**The search term and the control name were never required to match.** People search "live transcription mac" because that is the category's name in the world, not because it is what our toggle says. Renaming a page that exists to rank is expensive and slow to recover; renaming a control is neither.

So the blog keeps its title, tags and keywords intact and gains **one sentence** naming the new setting, which stops it pointing at a control that is not in the app. The help article's title **does** follow the rename, because its keywords carry the search terms separately and its slug is untouched — the old name joins those keywords, plus an alias sentence in the body.

This is reversible. Switching to renamed addresses later is still fully open.

## What moved, and what deliberately did not

**Renamed** — an instruction naming a control is FALSE the moment the control is renamed:
- every string in `LiveTranscriptionCopy`, including both help-panel titles
- the Live Preview page's two cross-feature explanations, and their symbol (`pausedForLiveTranscription` → `pausedForFasterTranscription`, 5 sites)
- the help-centre sentences telling a reader to switch it on or off, across three articles

**Not renamed**, each with the reason recorded AT the site so a future sweep does not "fix" it:
- `WhatsNewContent`'s shipped release note describes v2.4.3, when the setting **was** called Live transcription. Rewriting it falsifies the historical record. An inline comment now says so.
- Two comments quoting the original user report verbatim.
- `ParakeetStreamingSentryError`'s 11 diagnostic strings. `claim-sweep.sh` scopes itself to `Views` because that is user-facing copy, so these sit outside it by design; renaming them changes Sentry grouping and fires **New Issue Detected** per new group, for no user benefit.

22 mentions of the old name survive and every one is in that justified set.

## The guard got stricter, not weaker

"Live transcription" used to be an approved name on the Live Preview page, exempted from its no-bare-`live` check. That exemption is gone. The allowlist is replaced by a **requirement** that cross-feature explanations name the current setting.

Proven rather than asserted — half-reverting the rename, leaving that page naming the old control, fails **three independent assertions**: the pinned string, the stricter bare-`live` check, and the new cross-feature requirement. `EXIT=65`, restore verified byte-identical with `cmp`.

## Verification

Suites, each invoked separately because `--filter` does not union: `LiveTranscriptionCopy` 9, `LivePreviewSettingsCopy` 8, `LivePreviewStatusMapping` 22, `LivePreviewPackCopy` 6. All `EXIT=0`, zero compile errors.

Website checked **locally**, because this edits the search keywords of the routing #2134 shipped hours earlier:
- help content: 55 articles, 0 errors
- help routes: expected 68, built 68, in sitemap 68, 9547 internal links, **0 dead**
- help search: **41 passed, 0 failed**

Worth recording for the next person: `npm run build` runs only the content check. Routes and search are `npm run check:help` and must be run separately — a clean `npm run build` proves less than it appears to.

## Also closes #2173

The Live Preview article now mentions that the picker offers **Auto-detect**, which #2169 r11 added. It rides this push rather than costing its own review cycle.
