### PR TITLE
Live Preview: offer only usable languages in the picker, and split the language section

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Settings/LanguageLockOptions.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LanguageLockOptions.swift
@@ -24,6 +24,49 @@ import Foundation
 /// has no `@MainActor` isolation, and can be tested without a running app.
 enum LanguageLockOptions {
 
+  /// Which languages the LIVE PREVIEW page's picker may offer.
+  ///
+  /// **Founder, 2026-08-18: the picker lists what you can switch to RIGHT NOW; the
+  /// Languages table below it is the catalogue and the place you acquire one.**
+  /// "We already have the download selector at the bottom, which is an endless
+  /// scroll. It'd be silly for us to offer another option to download... if they
+  /// download it from the bottom selection table, it should then pop up into the
+  /// selector." So on Apple this is the INSTALLED set, and a table download makes
+  /// a language appear here — which is why the caller derives
+  /// `installedPackTags` from the packs model rather than snapshotting it.
+  ///
+  /// **It is an INTERSECTION, never a replacement, and that is load-bearing.**
+  /// This picker sets the DICTATION language, so a code outside the ASR backend's
+  /// lockable set is the #1678 silent failure: the lock looks set, the code maps
+  /// to no vendor language, and the decoder quietly auto-detects. Narrowing to
+  /// installed packs must therefore happen INSIDE that set, not instead of it.
+  ///
+  /// Universal is unrestricted by installs because it has none — one model covers
+  /// every language it claims, so the only limit there is the backend's.
+  ///
+  /// Pack tags are BCP-47 (`de-DE`); catalogue codes are ISO (`de`). The language
+  /// subtag is the join, lowercased, because Apple keys packs by locale and we
+  /// lock by language.
+  static func previewLockableCodes(
+    backend: ASRBackendType,
+    previewEngine: LivePreviewEngineChoice,
+    installedPackTags: [String]
+  ) -> Set<String>? {
+    let backendCodes = lockableCodes(for: backend)
+    guard previewEngine == .apple else { return backendCodes }
+
+    let installed = Set(
+      installedPackTags.compactMap { tag -> String? in
+        let language = tag.split(separator: "-").first.map(String.init)
+        return language?.lowercased()
+      })
+
+    // nil means "no restriction from the backend", so the install set becomes the
+    // whole restriction rather than being discarded.
+    guard let backendCodes else { return installed }
+    return backendCodes.intersection(installed)
+  }
+
   /// What the sheet reports for a mode change, as one decision both of its
   /// actions read.
   ///

--- a/Sources/EnviousWisprAppKit/Views/Settings/LanguageLockOptions.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LanguageLockOptions.swift
@@ -55,17 +55,52 @@ enum LanguageLockOptions {
     let backendCodes = lockableCodes(for: backend)
     guard previewEngine == .apple else { return backendCodes }
 
-    let installed = Set(
-      installedPackTags.compactMap { tag -> String? in
-        let language = tag.split(separator: "-").first.map(String.init)
-        return language?.lowercased()
-      })
+    let installed = Set(installedPackTags.compactMap(catalogueCode(forPackTag:)))
 
     // nil means "no restriction from the backend", so the install set becomes the
     // whole restriction rather than being discarded.
     guard let backendCodes else { return installed }
     return backendCodes.intersection(installed)
   }
+
+  /// Apple's pack tag translated into this app's catalogue vocabulary, or nil if
+  /// the language is not one we can lock to.
+  ///
+  /// **A bare `split(separator: "-").first` silently loses languages, and the loss
+  /// is invisible.** Cloud review caught `nb-NO`: the subtag is `nb`, the catalogue
+  /// exposes Norwegian as `no`, so a user who downloaded Norwegian from the table
+  /// would not find it in the picker — breaking the exact promise this feature was
+  /// built on ("if they download it from the bottom selection table, it should then
+  /// pop up into the selector"). It fails as an ABSENCE, which is why no amount of
+  /// looking at the picker would explain it.
+  ///
+  /// The aliases are the cases where Apple's vocabulary and ours genuinely differ:
+  /// macro-language versus a specific written form, and the deprecated ISO codes
+  /// Foundation still emits for historical identifiers.
+  static func catalogueCode(forPackTag tag: String) -> String? {
+    let subtag = Locale(identifier: tag).language.languageCode?.identifier
+      ?? tag.split(separator: "-").first.map(String.init)
+      ?? tag
+    let lowered = subtag.lowercased()
+    return packTagAliases[lowered] ?? lowered
+  }
+
+  /// Pack subtag -> catalogue code, ONLY where the two vocabularies disagree.
+  ///
+  /// Deliberately small and explicit rather than clever: a wrong entry here sends a
+  /// user to a language they did not pick, which is worse than the row being
+  /// missing. Every entry is asserted against `LanguageCatalog` by test, so an
+  /// alias pointing at a code we do not carry fails the build rather than shipping.
+  static let packTagAliases: [String: String] = [
+    // Apple ships Norwegian as Bokmål; the catalogue carries the macro-language.
+    "nb": "no",
+    // Deprecated ISO-639 codes Foundation still returns for legacy identifiers.
+    "iw": "he",
+    "in": "id",
+    "ji": "yi",
+    // Filipino is Tagalog in the catalogue.
+    "fil": "tl",
+  ]
 
   /// What the sheet reports for a mode change, as one decision both of its
   /// actions read.

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsView.swift
@@ -105,6 +105,23 @@ struct LivePreviewSettingsView: View {
       activeDescribesAnotherLanguage: activeDescribesAnotherLanguage)
   }
 
+  /// Installed Apple packs, read LIVE from the model rather than snapshotted.
+  ///
+  /// The reactivity is the founder's actual requirement, not an implementation
+  /// detail: "if they download it from the bottom selection table, it should then
+  /// pop up into the selector." `install(tag:)` republishes the loaded list on its
+  /// way out, so a computed property re-evaluates and the sheet's next open — or
+  /// its current render — sees the new language. A stored copy taken when the page
+  /// appeared would show a language the user just downloaded as still missing.
+  ///
+  /// Empty while loading or on a read failure, which is correct: `.failed` means we
+  /// could not ask macOS, and offering a language we cannot confirm is installed is
+  /// the claim this page is not allowed to make.
+  private var installedPackTags: [String] {
+    guard case .loaded(let packs) = self.packs.state else { return [] }
+    return packs.filter(\.isInstalled).map(\.tag)
+  }
+
   /// **The ONE place the streaming refusal is read, for the same reason
   /// `currentActive` is the one place staleness is decided.**
   ///
@@ -193,7 +210,10 @@ struct LivePreviewSettingsView: View {
       // decoder falls back to auto-detect while the user believes they are
       // locked (#1678).
       LanguageLockSheet(
-        lockableCodes: LanguageLockOptions.lockableCodes(for: settings.selectedBackend))
+        lockableCodes: LanguageLockOptions.previewLockableCodes(
+          backend: settings.selectedBackend,
+          previewEngine: settings.livePreviewEngine,
+          installedPackTags: installedPackTags))
     }
   }
 
@@ -420,18 +440,22 @@ struct LivePreviewSettingsView: View {
       universalLanguageSection
     }
     if showsApplePacks, isPreviewOn, let active = currentActive {
+      // **TWO containers, not one — founder 2026-08-18, comparing the shipped
+      // page against his mockup: "you combined it into 1 container instead of
+      // keeping it 2 containers."** The language row is a CONTROL you act on; the
+      // explainer is background you read once. Folding them into a single card
+      // made the row look like a paragraph with a button in it, and buried the
+      // thing the user came here to change.
+      //
+      // Always visible rather than behind a disclosure: the whole problem was not
+      // knowing where the language comes from, and an explanation you must first
+      // discover does not solve that.
       BrandedSection(header: LivePreviewSettingsCopy.activeHeader) {
         BrandedRow(showDivider: false) {
-          VStack(alignment: .leading, spacing: 10) {
-            activeSummary(active)
-            // `InsetNotice` is the app's existing idiom for a quiet explanation
-            // inside a card. Always visible rather than behind a disclosure: the
-            // whole problem was not knowing where the language comes from, and
-            // an explanation you must first discover does not solve that.
-            InsetNotice(text: LivePreviewSettingsCopy.activeExplainer)
-          }
+          activeSummary(active)
         }
       }
+      InsetNotice(text: LivePreviewSettingsCopy.activeExplainer)
     }
   }
 

--- a/Tests/EnviousWisprTests/Settings/LanguageLockOptionsTests.swift
+++ b/Tests/EnviousWisprTests/Settings/LanguageLockOptionsTests.swift
@@ -292,4 +292,55 @@ struct LanguageLockOptionsTests {
       backend: .whisperKit, previewEngine: .apple, installedPackTags: [])
     #expect(codes == [], "empty, never nil — nil would mean unrestricted")
   }
+
+  /// **The alias table's own correctness, asserted against the catalogue.**
+  ///
+  /// An alias pointing at a code the catalogue does not carry would translate a
+  /// real pack into a language that cannot be locked — the same disappearance it
+  /// exists to prevent, one step later. This fails the build instead.
+  @Test("Every pack-tag alias resolves to a code the catalogue actually carries")
+  func aliasesResolveToRealCatalogueCodes() {
+    let catalogue = Set(LanguageCatalog.sortedByEnglishName.map(\.code))
+    #expect(catalogue.count > 50, "control: the catalogue was found and parsed")
+    for (packSubtag, catalogueCode) in LanguageLockOptions.packTagAliases {
+      #expect(
+        catalogue.contains(catalogueCode),
+        "alias \(packSubtag) -> \(catalogueCode) points at a code the catalogue does not carry")
+      #expect(
+        !catalogue.contains(packSubtag),
+        "alias \(packSubtag) is unnecessary: the catalogue already carries that code")
+    }
+  }
+
+  /// **The case cloud review caught, as a behaviour rather than a table lookup.**
+  ///
+  /// Apple ships Norwegian as `nb-NO`. A bare first-component split yields `nb`,
+  /// which the catalogue does not carry, so the language silently vanished from
+  /// the picker after the user downloaded it — breaking the one promise this
+  /// feature rests on.
+  @Test("A downloaded Norwegian pack appears in the picker despite the tag mismatch")
+  func norwegianPackSurvivesTagTranslation() {
+    #expect(
+      LanguageLockOptions.catalogueCode(forPackTag: "nb-NO") == "no",
+      "nb-NO must translate to the catalogue's Norwegian")
+
+    let codes = LanguageLockOptions.previewLockableCodes(
+      backend: .whisperKit, previewEngine: .apple,
+      installedPackTags: ["nb-NO"])
+    #expect(
+      codes?.contains("no") == true,
+      "a downloaded Norwegian pack must be offered by the picker")
+    #expect(codes?.contains("nb") != true, "and never under a code the catalogue lacks")
+  }
+
+  /// Ordinary tags must pass through untouched — the translation must not become a
+  /// second vocabulary of its own.
+  @Test("Ordinary pack tags translate to their plain language code")
+  func ordinaryTagsPassThrough() {
+    for (tag, expected) in [("en-US", "en"), ("de-DE", "de"), ("fr-FR", "fr"), ("pt-BR", "pt")] {
+      #expect(
+        LanguageLockOptions.catalogueCode(forPackTag: tag) == expected,
+        "\(tag) should translate to \(expected)")
+    }
+  }
 }

--- a/Tests/EnviousWisprTests/Settings/LanguageLockOptionsTests.swift
+++ b/Tests/EnviousWisprTests/Settings/LanguageLockOptionsTests.swift
@@ -207,4 +207,89 @@ struct LanguageLockOptionsTests {
         "the sheet must not emit the chip CTA's reason for \(from) -> \(to)")
     }
   }
+
+  // MARK: - Preview picker scope (founder 2026-08-18)
+
+  /// **The picker offers what you can switch to NOW; the table below is the
+  /// catalogue.** Founder: "we already have the download selector at the bottom,
+  /// which is an endless scroll. It'd be silly for us to offer another option to
+  /// download."
+  @Test("On Apple the picker offers only languages whose pack is installed")
+  func applyPickerIsInstalledOnly() {
+    let codes = LanguageLockOptions.previewLockableCodes(
+      backend: .whisperKit, previewEngine: .apple,
+      installedPackTags: ["en-US", "de-DE"])
+    #expect(codes == ["en", "de"], "only installed packs, as ISO language codes")
+    #expect(
+      codes?.contains("fr") != true,
+      "a language with no installed pack must not be offered")
+  }
+
+  /// **The reactivity IS the requirement, not an implementation detail.** Founder:
+  /// "if they download it from the bottom selection table, it should then pop up
+  /// into the selector." Same call, one more installed tag, one more offered code.
+  @Test("Downloading a pack makes that language available to the picker")
+  func downloadedPackAppearsInPicker() {
+    let before = LanguageLockOptions.previewLockableCodes(
+      backend: .whisperKit, previewEngine: .apple, installedPackTags: ["en-US"])
+    #expect(before?.contains("de") != true, "German is absent before its pack exists")
+
+    let after = LanguageLockOptions.previewLockableCodes(
+      backend: .whisperKit, previewEngine: .apple, installedPackTags: ["en-US", "de-DE"])
+    #expect(
+      after?.contains("de") == true,
+      "after the table installs German it must appear in the picker")
+  }
+
+  /// Universal has no per-language installs — one model covers everything it
+  /// claims — so the install set is irrelevant there and must not narrow it.
+  @Test("On Universal the picker ignores installed packs entirely")
+  func universalPickerIgnoresInstalls() {
+    let none = LanguageLockOptions.previewLockableCodes(
+      backend: .whisperKit, previewEngine: .universal, installedPackTags: [])
+    #expect(
+      none == LanguageLockOptions.lockableCodes(for: .whisperKit),
+      "Universal must offer the backend's whole set even with no packs installed")
+
+    let some = LanguageLockOptions.previewLockableCodes(
+      backend: .parakeet, previewEngine: .universal, installedPackTags: ["en-US"])
+    #expect(
+      some == LanguageLockOptions.lockableCodes(for: .parakeet),
+      "an installed Apple pack must not change what Universal offers")
+  }
+
+  /// **INTERSECTION, never replacement — this is the #1678 silent failure.** The
+  /// picker sets the DICTATION language, so a code outside the ASR backend's
+  /// lockable set produces a lock that looks set while the decoder auto-detects.
+  /// Narrowing to installed packs happens INSIDE that set.
+  @Test("The picker never offers a code the dictation engine cannot honour")
+  func neverEscapesTheBackendSet() {
+    guard let parakeet = LanguageLockOptions.lockableCodes(for: .parakeet) else {
+      Issue.record("expected Parakeet to restrict its lockable codes")
+      return
+    }
+    // Claim an installed pack for a language the fast engine does NOT claim.
+    let unclaimed = LanguageCatalog.sortedByEnglishName
+      .map(\.code).first { !parakeet.contains($0) }
+    guard let unclaimed else {
+      Issue.record("expected at least one catalogue code outside Parakeet's set")
+      return
+    }
+    let codes = LanguageLockOptions.previewLockableCodes(
+      backend: .parakeet, previewEngine: .apple,
+      installedPackTags: ["en-US", "\(unclaimed)-XX"])
+    #expect(
+      codes?.contains(unclaimed) != true,
+      "an installed pack for \(unclaimed) must not escape Parakeet's lockable set")
+    #expect(codes?.isSubset(of: parakeet) == true, "always a subset of the backend's set")
+  }
+
+  /// Nothing installed is a real state on a fresh Mac, and it must not crash or
+  /// silently fall back to "everything" — the picker simply offers Auto.
+  @Test("No installed packs offers nothing to lock, not everything")
+  func noInstalledPacksOffersNothing() {
+    let codes = LanguageLockOptions.previewLockableCodes(
+      backend: .whisperKit, previewEngine: .apple, installedPackTags: [])
+    #expect(codes == [], "empty, never nil — nil would mean unrestricted")
+  }
 }


### PR DESCRIPTION
Two founder corrections raised during #2154's Live UAT, both verified in the running app before this PR was opened.

## 1. The preview language picker is engine-aware, and installed-only on Apple

Founder, 2026-08-18: *"the Preview language selector needs to be smarter -> it needs to be dynamic based on if Apple or universal is selected"*, and *"Preview Language Selection -> Should only show languages that are installed"*.

His reasoning is the design, and it is worth keeping verbatim because it decides the split of responsibility between the two controls on this page:

> we already have the download selector at the bottom, which is an endless scroll. It'd be silly for us to offer another option to download or show that in the dropdown. So basically, if they download it from the bottom selection table, it should then pop up into the selector.

So the **table** is the catalogue and the place you acquire a language. The **picker** answers "what can I switch to right now". On Apple that is the installed set; on Universal installs are irrelevant, because one model covers everything that engine claims.

**The reactivity is the requirement, not an implementation detail.** The view derives installed tags from the packs model live rather than snapshotting them, so a download in the table makes that language appear in the picker. `install(tag:)` already republishes the loaded list on its way out. Covered by its own test rather than assumed.

### It is an INTERSECTION, never a replacement

This picker sets the **dictation** language, shared with the Transcription page. A code outside the ASR backend's lockable set is the #1678 silent failure: the lock looks set, the code maps to no vendor language, and the decoder quietly auto-detects. So narrowing to installed packs happens *inside* that set.

Tested by constructing an installed pack for a language the fast engine does not claim, and asserting it never escapes.

### Measured live

| Engine | Picker rows |
|---|---|
| Apple | **2** — Auto-detect, plus English (the only pack installed on this Mac) |
| Universal | **26** — Auto-detect, plus Parakeet's 25 |

The 26 rather than ~99 is the intersection working: Universal could display more, dictation could not honour it.

## 2. The Preview Language section is two containers again

Founder, comparing the shipped page against his mockup: *"you combined it into 1 container instead of keeping it 2 containers."*

The language row is a **control you act on**; the explainer is background you read once. Folding them into a single card made the row read as a paragraph with a button in it, and buried the thing the user came to the page to change. Confirmed on screen against the mockup image.

## Also answered — no change needed

*"does changing preview language on universal do anything at all? if not, we shouldn't offer it"*

It does. `WhisperPreviewEngineResolver:99` passes a lock straight through to the recognizer and only `.auto` becomes nil, so a user locked to the wrong language genuinely gets the wrong words. Hiding the control is what would strand them — an earlier draft did exactly that and review caught it as a real defect (r7). Recorded in the code so the question is not reopened from the UI's own claim.

## Verification

Suites, each invoked separately: `LanguageLockOptions` **7 → 12**, `LivePreviewSettingsCopy` 8, `LivePreviewStatusMapping` 22, `LivePreviewPackCopy` 6. All `EXIT=0`, zero compile errors, re-run after rebasing onto `main` because a rebase moves the ground under a green result.

Live on the dev build: picker counts above, container split compared against the mockup, and the founder's own settings snapshotted by value and type before the run and verified identical afterwards.

## Live UAT status for #2154, stated rather than implied

Verified on real hardware during this session: the step 7 engine-card regression (byte-identical geometry and accessibility output, captured from a pre-#2154 build first because that comparison cannot be recreated afterwards), the off state, the on state, the language change in both directions including the Auto row, and both directions of the streaming pause — where the language row correctly switches from promising output to describing configuration.

**Not run, with the reason:** the engine card's footer press-test. Its structural half is verified (the footer action is a sibling element, not nested inside the card's selection button), but pressing it on this machine would delete an installed 217 MB model. Recorded as a known skip rather than counted as a pass.


---

## Review round 2: Apple's pack tags are not our catalogue's codes

Cloud review found the picker silently losing languages. `previewLockableCodes` took the first component of a BCP-47 tag, so `nb-NO` became `nb` — and `LanguageCatalog` carries Norwegian as `no`.

**A user who downloaded Norwegian from the table would not find it in the picker.** That is precisely the promise this change rests on, and it fails as an **absence**: no error, no wrong entry, just a missing row. Nothing about looking at the picker explains it.

Resolution now goes through `Locale.language.languageCode` rather than a string split, so region and script subtags are Foundation's problem rather than ours, with the split kept only as a fallback. On top of that, an explicit alias table for the cases where the two vocabularies genuinely differ:

| Pack subtag | Catalogue | Why |
|---|---|---|
| `nb` | `no` | Apple ships Bokmål; we carry the macro-language |
| `iw` `in` `ji` | `he` `id` `yi` | deprecated ISO codes Foundation still returns for legacy identifiers |
| `fil` | `tl` | Filipino is Tagalog in the catalogue |

Deliberately small rather than clever: a wrong entry sends the user to a language they did not pick, which is worse than a missing row.

**The table asserts itself.** A test requires every alias to resolve to a code the catalogue actually carries, *and* requires the source subtag not to be in the catalogue — so an alias that is wrong, or that has become unnecessary, fails the build rather than shipping a second silent disappearance one step later. Both directions pass today, which is what makes the table trustworthy rather than merely present.

Suites: `LanguageLockOptions` **12 → 15**, all `EXIT=0`.
