### PR TITLE
docs(asr): record the M5 measurement at the WhisperKit compute pin

### DIFF
--- a/Sources/EnviousWisprASR/WhisperKitBackend.swift
+++ b/Sources/EnviousWisprASR/WhisperKitBackend.swift
@@ -27,8 +27,11 @@ import Foundation
 /// (2026-08-18, #1572) against this exact variant through the pinned CLI: the
 /// ANE placement LOSES TEXT on 5 of 25 multilingual clips, including an empty
 /// string where `.cpuAndGPU` returns the correct word, stable across three
-/// repeats. `.cpuAndGPU`, `.all` and `.cpuOnly` agree with each other on every
-/// clip. The loss lands on short non-Latin utterances, which is the population
+/// repeats. That sweep is two-placement. On the separate five-clip run that
+/// exercised all FOUR placements, `.cpuAndGPU`, `.all` and `.cpuOnly` agreed
+/// with each other on every clip and only the ANE differed — which is also what
+/// stops "the shipped path diverges" being the reading; the odd one out is the
+/// ANE. The loss lands on short non-Latin utterances, which is the population
 /// this backend exists to serve, so a whole-corpus average hides it. Cold
 /// specialization also got WORSE on newer silicon, not better: ~126-158s ANE vs
 /// 5-18s here, against ~109s vs ~13s on M4. Note that `.cpuAndNeuralEngine` is

--- a/Sources/EnviousWisprASR/WhisperKitBackend.swift
+++ b/Sources/EnviousWisprASR/WhisperKitBackend.swift
@@ -19,6 +19,32 @@ import Foundation
 /// `MLComputeUnits` semantics on each device (WhisperKit forces CPU-only on the
 /// Simulator). The transcript-quality parity vs the prior ANE path is verified
 /// by live UAT before merge (#879 Phase C gate).
+///
+/// DO NOT "upgrade" this to `.cpuAndNeuralEngine`. The move is tempting because
+/// #1830 pinned the output-safety classifier TO the Neural Engine to fix #1226,
+/// and that reasoning does not transfer between models — Core ML repartitions
+/// per model and per device. Measured on Mac17,7 / M5 Max / macOS 26.4
+/// (2026-08-18, #1572) against this exact variant through the pinned CLI: the
+/// ANE placement LOSES TEXT on 5 of 25 multilingual clips, including an empty
+/// string where `.cpuAndGPU` returns the correct word, stable across three
+/// repeats. `.cpuAndGPU`, `.all` and `.cpuOnly` agree with each other on every
+/// clip. The loss lands on short non-Latin utterances, which is the population
+/// this backend exists to serve, so a whole-corpus average hides it. Cold
+/// specialization also got WORSE on newer silicon, not better: ~126-158s ANE vs
+/// 5-18s here, against ~109s vs ~13s on M4. Note that `.cpuAndNeuralEngine` is
+/// the LIBRARY's own default for both encoder and decoder on macOS 14+
+/// (`ModelComputeOptions.init`, pinned `argmax-oss-swift` 1.0.0), so the degraded
+/// placement is what you get by ceasing to override — this pin is load-bearing,
+/// not redundant with upstream.
+///
+/// What that measurement did NOT cover, stated here rather than deferred, since a
+/// comment declaring a question closed suppresses the next check instead of
+/// merely failing it: it compares placements AGAINST EACH OTHER, not against
+/// reference transcripts, so it bounds divergence and says nothing about absolute
+/// accuracy. One machine, one OS version, one model variant. A new variant or a
+/// new macOS major reopens it — Core ML repartitions per device, so re-measure
+/// rather than reason from this note. Detail:
+/// `.claude/knowledge/whisperkit-research.md` FACT: compute-options.
 private let dictationComputeOptions = ModelComputeOptions(
   melCompute: .cpuAndGPU,
   audioEncoderCompute: .cpuAndGPU,


### PR DESCRIPTION
#1572 is the reference for this change and stays closed; nothing here reopens it.

## What this is

One comment block at `WhisperKitBackend.dictationComputeOptions`. **No behaviour change, no symbol change, 26 added lines, all comment.**

## Why

The pin's existing justification is latency, plus a quality half that reads "verified by live UAT before merge (#879 Phase C gate)". Together those leave `.cpuAndNeuralEngine` looking like a pending upgrade awaiting evidence — and #1830 actively invites the move, because it pinned the output-safety classifier **to** the Neural Engine to fix #1226 on this same hardware class.

The analogy does not transfer. Core ML repartitions per model and per device, which is the whole lesson of #1226. It is now measured rather than argued.

## The measurement

The dev machine became **Mac17,7 / M5 Max / macOS 26.4** on 2026-08-17, so the hardware #1572 was blocked on from 2026-07-16 is now on the desk. Driving `whisperkit-cli` built from the pinned `argmax-oss-swift` 1.0.0 checkout, at `openai_whisper-large-v3-v20240930_turbo` (the variant `defaultModelVariant()` returns), language pinned per clip so detection is not a confound:

| axis | result |
|---|---|
| 25 multilingual clips, shipped vs ANE | **5 differ, ANE on the losing side in all 5** |
| by language | en 0/5 · es 0/5 · fr 1/5 · hi 2/5 · ja 2/5 |
| worst row | `नमस्ते` at `.cpuAndGPU`, **empty string** at ANE |
| 5 clips × 4 placements | `.cpuAndGPU`, `.all`, `.cpuOnly` agree; only ANE differs |
| determinism control, 3 runs × 5 clips × 2 placements | **0 varying cells** |
| cold specialization | ~126-158s ANE vs 5-18s shipped (M4 was ~109s vs ~13s) |

The determinism control exists because an empty string is also what a decoder emits when a fallback gives up, so the headline row and the most likely artifact were the same observation until it was repeated.

Full write-up, method, and archived raw output: #1572, comments of 2026-08-18.

## What the comment deliberately does NOT claim

It states the limits as prominently as the result: placements compared **against each other**, not against reference transcripts, so it bounds divergence and says nothing about absolute accuracy; one machine, one OS, one model variant; a new variant or a new macOS major reopens it.

That framing is the point rather than hedging. A comment that declares a question closed suppresses the next check instead of merely failing it — which is how `scripts/multilingual-eval/` drifted to a placement production does not use while its own comment asserted it mirrored production (#598, fixed separately; that path is gitignored so it cannot ride in a PR).

## Validation

- `scripts/xcode-test.sh` (Debug lane): **TEST SUCCEEDED, 5894 tests**, with `grep -ac WhisperKitBackend` on the log returning 33, so the changed file was genuinely in the run rather than a stale build passing.
- `xcodebuild build -scheme EnviousWispr-Dev`: **BUILD SUCCEEDED**, 0 errors.
- Sweep for the same claim elsewhere: `grep -rn "cpuAndNeuralEngine" Sources/ Tests/ scripts/ workers/ website/` — the only other WhisperKit consumers were the two gitignored eval packages, handled on #598.

**Unrelated blocker worth flagging for whoever hits it next:** the first Debug lane on this branch failed with `TEST FAILED` and zero `✘` marks, reporting missing XCFrameworks at paths inside a *different* worktree. That is the cloned SwiftPM snapshot from #2178 carrying donor-worktree absolute paths in `workspace-state.json`. Reported to the owning session, fix in progress. Workaround is to delete `.derivedData/Test/SourcePackages/workspace-state.json` and re-run.

Tier: SMALL | Test: not required (comment only) | Modules: ASR
council-skip: zero-blast-radius (code comment)
