### PR TITLE
fix(build): a cloned package tree now belongs to the worktree that receives it

### DIFF
--- a/scripts/lib/spm-seed-test.sh
+++ b/scripts/lib/spm-seed-test.sh
@@ -151,6 +151,48 @@ if [ -f "$(ew_seed_dir "$KEY")/workspace-state.json" ]; then
 else
   bad "snapshot state" "publish dropped workspace-state.json; ew_seed_is_complete can no longer judge a snapshot"
 fi
+# THE DONOR NEED NOT LIVE UNDER /Users, AND ITS PATH NEED NOT LOOK LIKE
+# `.derivedData/<lane>`. Releases build from `/tmp`, and `xcode-test.sh` honours a
+# `DERIVED_DATA_PATH` override naming any path at all. A location-shaped
+# discovery finds nothing for those, returns 1, and every consumer silently falls
+# back to a full resolve — a feature that has stopped working, wearing the face of
+# one that works.
+ODD="/var/folders/zz/Odd Place/build-out/SourcePackages"
+T_ODD="$TMPROOT/odd"; mkdir -p "$T_ODD/artifacts/x" "$T_ODD/checkouts/pkg/.git/objects/info"
+printf '{"object":{"artifacts":[{"path":"%s/artifacts/x/A.xcframework"}]}}\n' "$ODD" > "$T_ODD/workspace-state.json"
+printf '%s/repositories/pkg-0000/objects\n' "$ODD" > "$T_ODD/checkouts/pkg/.git/objects/info/alternates"
+printf 'a\n' > "$T_ODD/artifacts/x/A.xcframework"
+if ew_seed_localise "$T_ODD" "/final/here/SourcePackages" \
+   && ! /usr/bin/grep -rq "Odd Place" "$T_ODD" 2>/dev/null \
+   && /usr/bin/grep -rq "/final/here/SourcePackages" "$T_ODD" 2>/dev/null; then
+  ok "a donor outside /Users, with no .derivedData in its path, is still localised"
+else
+  bad "donor discovery shape" "a donor not shaped like /Users/.../.derivedData/<lane> was not rewritten"
+fi
+
+# A REWRITTEN PATH MUST RESOLVE, NOT MERELY STOP NAMING THE DONOR. A string sweep
+# passes perfectly against a plausible-but-non-existent directory, and git only
+# discovers it the first time it needs an object — the valid-looking-default trap,
+# one directory over. An independent verifier ran this against the real fix and it
+# is the check neither of us would have written without `alternates` being found.
+alt="$T_ODD/checkouts/pkg/.git/objects/info/alternates"
+target="$(cat "$alt" 2>/dev/null)"
+case "$target" in
+  /final/here/SourcePackages/repositories/*) ok "the rewritten object store points where the payload actually lands" ;;
+  *) bad "alternates target" "rewritten to '$target', which is not under the receiving tree's repositories/" ;;
+esac
+
+# THE TWIN: a tree with nothing to discover must FAIL, not silently pass. Without
+# this, the case above would also pass against a localise that returns 0 for
+# everything.
+T_NONE="$TMPROOT/nodonor"; mkdir -p "$T_NONE"
+printf '{"object":{}}\n' > "$T_NONE/workspace-state.json"
+if ew_seed_localise "$T_NONE" "/final/here/SourcePackages"; then
+  bad "donor discovery twin" "localise returned 0 with no donor to find; a clone would be accepted unrewritten"
+else
+  ok "an undiscoverable donor FAILS localisation, so the caller drops the clone"
+fi
+
 if [ -f "$DD3/SourcePackages/workspace-state.json" ] \
    && ! /usr/bin/grep -rq "$DONOR_PREFIX" "$DD3/SourcePackages" 2>/dev/null \
    && /usr/bin/grep -q "$DD3/SourcePackages" "$DD3/SourcePackages/workspace-state.json" 2>/dev/null; then

--- a/scripts/lib/spm-seed-test.sh
+++ b/scripts/lib/spm-seed-test.sh
@@ -33,9 +33,14 @@ mkdir -p "$ROOT"
 printf '{"pins":[]}\n' > "$ROOT/Package.resolved"
 
 # A tree shaped like a resolved SourcePackages.
+DONOR_PREFIX="/Users/nobody/Developer/DonorTree/.derivedData/Test/SourcePackages"
 make_tree() { # <path>
-  mkdir -p "$1/artifacts/sentry-cocoa" "$1/checkouts" "$1/repositories"
-  printf '{"object":{}}\n' > "$1/workspace-state.json"
+  mkdir -p "$1/artifacts/sentry-cocoa" "$1/checkouts/pkg/.git/objects/info" "$1/repositories"
+  # Shaped like a REAL resolved tree: the index plus a git checkout whose object
+  # store is an absolute path into the donor. The `.git` half is what the shell's
+  # ugrep shim cannot see, and it is the half that breaks a build.
+  printf '{"object":{"artifacts":[{"path":"%s/artifacts/sentry-cocoa/Sentry.xcframework"}]}}\n' "$DONOR_PREFIX" > "$1/workspace-state.json"
+  printf '%s/repositories/pkg-0000/objects\n' "$DONOR_PREFIX" > "$1/checkouts/pkg/.git/objects/info/alternates"
   printf 'artifact\n' > "$1/artifacts/sentry-cocoa/Sentry.xcframework"
   printf 'checkout\n' > "$1/checkouts/marker"
 }
@@ -120,10 +125,38 @@ fi
 
 DD3="$TMPROOT/dd3"
 out="$(ew_seed_consume "$ROOT" "$DD3" 2>&1)"
-if ew_seed_is_complete "$DD3/SourcePackages" && printf '%s' "$out" | grep -q "Seeded packages"; then
-  ok "consume clones the snapshot into an absent target"
+# The EXPENSIVE payload must arrive; `ew_seed_is_complete` is deliberately NOT
+# the assertion here, because a consumed tree no longer carries the state file
+# that check uses as its marker. Assert the content instead.
+if [ -d "$DD3/SourcePackages/artifacts" ] && [ -n "$(ls -A "$DD3/SourcePackages/artifacts" 2>/dev/null)" ] \
+   && [ -d "$DD3/SourcePackages/checkouts" ] && printf '%s' "$out" | grep -q "Seeded packages"; then
+  ok "consume clones the snapshot's payload into an absent target"
 else
-  bad "consume" "target incomplete or unannounced: '$out'"
+  bad "consume" "target missing payload or unannounced: '$out'"
+fi
+
+# THE #2178 REGRESSION. `workspace-state.json` is an INDEX holding ABSOLUTE paths
+# baked to the worktree that produced the snapshot. Cloned verbatim it names
+# another tree's directories — or, once that worktree is deleted, directories that
+# exist nowhere — and the failure is NOT the slow path this file promises
+# everywhere else: the clone succeeds, the resolve succeeds, and `xcodebuild` then
+# dies with `There is no XCFramework found at <other worktree>/...`, a hard
+# TEST FAILED with zero failing tests, accusing a dependency.
+#
+# TWO-WAY, because "absent" alone would also pass against a clone that copied
+# nothing at all: the donor's file must be PRESENT in the snapshot and ABSENT
+# from the consumed tree.
+if [ -f "$(ew_seed_dir "$KEY")/workspace-state.json" ]; then
+  ok "the snapshot still carries its own state file (its completeness marker)"
+else
+  bad "snapshot state" "publish dropped workspace-state.json; ew_seed_is_complete can no longer judge a snapshot"
+fi
+if [ -f "$DD3/SourcePackages/workspace-state.json" ] \
+   && ! /usr/bin/grep -rq "$DONOR_PREFIX" "$DD3/SourcePackages" 2>/dev/null \
+   && /usr/bin/grep -q "$DD3/SourcePackages" "$DD3/SourcePackages/workspace-state.json" 2>/dev/null; then
+  ok "#2178: every donor path is rewritten to the consuming tree"
+else
+  bad "#2178 donor path leak" "consumed tree still names the donor, or was not rewritten to its own path"
 fi
 
 # The REAL clone must leave the provenance marker, naming the key it came from.

--- a/scripts/lib/spm-seed.sh
+++ b/scripts/lib/spm-seed.sh
@@ -234,8 +234,19 @@ ew_seed_prune() {
 # that is about to stop existing.
 ew_seed_localise() { # <staging tree> <final SourcePackages path>
   local tree="$1" final="$2" donor f
-  # The donor prefix is discovered from the tree itself rather than assumed.
-  donor="$(/usr/bin/grep -rhoE "/Users/[^\"]*/\.derivedData/[A-Za-z0-9_-]+/SourcePackages" "$tree/workspace-state.json" 2>/dev/null | head -1)"
+  # DISCOVER THE DONOR BY STRUCTURE, NEVER BY ITS LOCATION. An earlier version
+  # matched `/Users/…/.derivedData/<lane>/SourcePackages`, which encodes two
+  # assumptions this repo already violates: releases build from `/tmp`
+  # (session-behavior.md RULE: root-stays-on-main), and `scripts/xcode-test.sh:30`
+  # honours a `DERIVED_DATA_PATH` override that can name any path at all. A
+  # snapshot published from either produces no match, localisation returns 1, and
+  # EVERY consumer silently discards its clone and resolves from scratch — the
+  # right direction, but a feature that has quietly stopped working reads exactly
+  # like one that is working.
+  # `artifacts/` is a fixed child of any resolved SourcePackages, so the text
+  # before it is the donor prefix wherever the tree lives.
+  donor="$(/usr/bin/grep -oE '/[^"]+/artifacts/' "$tree/workspace-state.json" 2>/dev/null | head -1)"
+  donor="${donor%/artifacts/}"
   [ -n "$donor" ] || return 1
   [ "$donor" = "$final" ] && return 0          # already local: nothing to do
   case "$donor" in */SourcePackages) ;; *) return 1 ;; esac

--- a/scripts/lib/spm-seed.sh
+++ b/scripts/lib/spm-seed.sh
@@ -240,9 +240,17 @@ ew_seed_localise() { # <staging tree> <final SourcePackages path>
   [ "$donor" = "$final" ] && return 0          # already local: nothing to do
   case "$donor" in */SourcePackages) ;; *) return 1 ;; esac
 
-  # /usr/bin/grep, NEVER the shell's `grep`: this environment aliases it to a
-  # ugrep shim that skips DOT-DIRECTORIES, so it reports 1 file here where the
-  # real grep reports 36. Every path that matters lives inside `.git/`.
+  # /usr/bin/grep, NEVER the shell's `grep`. This environment aliases `grep` to a
+  # ugrep shim carrying `--exclude-dir=.git` (plus .svn/.hg/.bzr/.jj/.sl) and
+  # `--ignore-files`, so it reports 1 file here where the real grep reports 36 —
+  # 35 of them inside `.git/`, which is where a checkout's object-store pointer
+  # lives by construction.
+  # IT IS NOT "SKIPS HIDDEN FILES", and the wrong version of this misleads:
+  # `--hidden` is ON, so `.hidden/` and `.dotfile` ARE searched (measured both
+  # ways). What is invisible is anything inside a VCS ADMIN directory, or inside
+  # a gitignored path — and the second half is DATA-dependent, so the same
+  # command from two checkouts can return different results with no error and no
+  # clue. No pattern refinement reaches either case.
   while IFS= read -r f; do
     [ -f "$f" ] || continue
     LC_ALL=C /usr/bin/sed -i '' "s|$donor|$final|g" "$f" 2>/dev/null || return 1

--- a/scripts/lib/spm-seed.sh
+++ b/scripts/lib/spm-seed.sh
@@ -211,6 +211,53 @@ ew_seed_prune() {
 # ew_seed_consume <project_root> <derived_data_path>
 # Clones a snapshot into an ABSENT target. Prints what it did and why; a silent
 # fast path is indistinguishable from a broken one.
+# Rewrite every ABSOLUTE path a cloned tree inherited from the worktree that
+# produced it. Returns 1 if it cannot be done completely, which callers treat as
+# "discard the clone and resolve normally".
+#
+# A resolved SourcePackages is FULL of self-references, not just one index:
+# measured on the live snapshot, 36 files carry the donor's path — the
+# `workspace-state.json` index, plus five `.git` files in each of seven checkouts
+# (`config`, `objects/info/alternates`, and three `logs/` entries). The
+# load-bearing one is `objects/info/alternates`, which points a checkout's object
+# store at the donor's `repositories/<pkg>-<hash>/objects`. The snapshot carries
+# `repositories/` too, so after the rewrite each checkout borrows from ITS OWN
+# copy; without it, a checkout whose donor worktree has been deleted has no
+# object store at all.
+#
+# ONE prefix covers every case — the donor's `.../.derivedData/<lane>/SourcePackages`
+# — so this is a single substitution rather than a format-aware edit, and it does
+# not need to understand SwiftPM's or git's file formats.
+#
+# $2 is the FINAL destination, never the staging directory: the tree is renamed
+# after this runs, so rewriting to the staging path would bake in a directory
+# that is about to stop existing.
+ew_seed_localise() { # <staging tree> <final SourcePackages path>
+  local tree="$1" final="$2" donor f
+  # The donor prefix is discovered from the tree itself rather than assumed.
+  donor="$(/usr/bin/grep -rhoE "/Users/[^\"]*/\.derivedData/[A-Za-z0-9_-]+/SourcePackages" "$tree/workspace-state.json" 2>/dev/null | head -1)"
+  [ -n "$donor" ] || return 1
+  [ "$donor" = "$final" ] && return 0          # already local: nothing to do
+  case "$donor" in */SourcePackages) ;; *) return 1 ;; esac
+
+  # /usr/bin/grep, NEVER the shell's `grep`: this environment aliases it to a
+  # ugrep shim that skips DOT-DIRECTORIES, so it reports 1 file here where the
+  # real grep reports 36. Every path that matters lives inside `.git/`.
+  while IFS= read -r f; do
+    [ -f "$f" ] || continue
+    LC_ALL=C /usr/bin/sed -i '' "s|$donor|$final|g" "$f" 2>/dev/null || return 1
+  done <<EOF
+$(/usr/bin/grep -rl "$donor" "$tree" 2>/dev/null)
+EOF
+
+  # FAIL CLOSED: prove no donor path survived. A partial rewrite is worse than
+  # none — it builds, and then fails somewhere unrelated.
+  if /usr/bin/grep -rq "$donor" "$tree" 2>/dev/null; then
+    return 1
+  fi
+  return 0
+}
+
 ew_seed_consume() {
   local root="$1" dd="$2" key snap target tmp _stale
   target="$dd/SourcePackages"
@@ -274,7 +321,45 @@ ew_seed_consume() {
   # An atomic rename makes the tree and its marker appear together or not at all,
   # which is the same fix the lock's owner record already needed one file over —
   # a proven pattern that should have been ported rather than rediscovered.
+  # STRIP THE STATE FILE BEFORE HANDING THE TREE OVER, and this is the whole
+  # reason the clone is safe to reuse across worktrees.
+  #
+  # `workspace-state.json` is an INDEX, and it stores ABSOLUTE paths: measured on
+  # the live snapshot, 11 of them across `artifacts[].path`,
+  # `prebuilts[].checkoutPath` and `prebuilts[].path`, every one baked to the
+  # worktree that produced the snapshot. Cloned into a different tree it names
+  # directories that belong to somebody else, or — once the donor worktree is
+  # removed — directories that do not exist at all.
+  #
+  # THE FAILURE IS NOT A SLOW BUILD, WHICH IS WHAT THE REST OF THIS FILE
+  # PROMISES. The clone succeeds, the completeness check passes, the resolve
+  # succeeds, and `xcodebuild` then fails with `There is no XCFramework found
+  # at <other worktree>/...` — a hard TEST FAILED, zero test failures, accusing
+  # a missing dependency. The next reader goes looking at the dependency graph.
+  # Measured 2026-08-18 on main at 7e4b8cff: a peer session hit it in a fresh
+  # worktree on a comment-only change, and only spotted the cause because the
+  # donor worktree's NAME was sitting inside the error string.
+  #
+  # Dropping it loses nothing. The expensive payload — checkouts and artifacts,
+  # ~3.6 GB — is tree-INDEPENDENT and arrives intact; the state file is a cheap
+  # index over content that is already correctly in place, and SwiftPM rebuilds
+  # it for THIS tree during the resolve that `ew_seed_resolve_or_unseed` already
+  # runs. Verified by a path-SHAPE sweep of the whole snapshot rather than a
+  # search for the donor's name: exactly ONE file references this machine. The
+  # other 139 hits are Sentry's vendored dSYM relocation maps pointing at
+  # `/Users/runner`, which are identical in every checkout and inert here.
+  #
+  # Removed AFTER `ew_seed_is_complete`, never before: that check uses this file
+  # as its marker for "a real resolved tree rather than a partial copy", so
+  # stripping it first would make every snapshot look incomplete.
+  #
+  # GENERAL FORM, and it is the half this design missed: `ew_seed_key` was made
+  # independent of the creating tree, and nothing asked the same question of what
+  # the snapshot CONTAINS. **When you make an artifact position-independent, ask
+  # it again of everything inside it.** Applies to any cached, cloned, snapshotted
+  # or vendored tree, not just this one.
   if cp -Rc "$snap" "$tmp" 2>/dev/null && ew_seed_is_complete "$tmp" \
+     && ew_seed_localise "$tmp" "$target" \
      && printf '%s\n' "$key" > "$tmp/$EW_SEED_PROVENANCE_FILE" 2>/dev/null \
      && ew_seed_rename_exclusive "$tmp" "$target"; then
     ew_seed_lock_release "$key"


### PR DESCRIPTION
Fixes a defect **#2178 introduced on main**. `Part of #2157`.

## What breaks today

Any fresh worktree that consumes the package snapshot fails its test lane:

```
error: There is no XCFramework found at
'/Users/…/EnviousWispr-2157/.derivedData/Test/SourcePackages/artifacts/fluidaudio/…'
  (in target 'EnviousWisprASRService' … at path '/Users/…/EnviousWispr-m5-compute/EnviousWispr.xcodeproj')
```

Two different worktrees in one error line: the reader's project, somebody else's artifacts. Hard `TEST FAILED`, **zero failing tests**, and the message accuses a missing dependency — so the next reader goes looking at the dependency graph. Found by a peer session hitting it on a comment-only change, located only because the donor worktree's name was sitting inside the error string.

**This is not the slow path the seed library promises everywhere else.** The clone succeeds, the completeness check passes, the resolve succeeds, and it fails afterwards in `xcodebuild`. A guarantee that covers the failures I enumerated is not a guarantee.

## Cause

#2178 made the seed **key** independent of the tree that created it, and never asked the same question of what the snapshot **contains**.

**36 files carry the donor worktree's absolute path**, measured on the live snapshot: `workspace-state.json`, plus five `.git` files in each of seven checkouts (`config`, `objects/info/alternates`, and three `logs/` entries). The load-bearing one is `objects/info/alternates`, which points a checkout's object store at the donor's `repositories/<pkg>-<hash>/objects`. Once the donor worktree is deleted — which is automatic on merge — those paths name nothing at all.

## Fix

`ew_seed_localise` rewrites the donor's `.../.derivedData/<lane>/SourcePackages` prefix to the receiving tree's own, then **fails closed**: any surviving donor path returns 1, the `&&` chain drops the clone, and the build takes the ordinary resolve. A partial rewrite is worse than none — it builds, then fails somewhere unrelated.

One prefix covers all 36 files, so it is a single substitution needing no knowledge of SwiftPM's or git's formats. The snapshot ships `repositories/` too, so after the rewrite each checkout borrows from its own copy. It runs on the staging tree but writes the **final** path, because the rename happens after.

## Evidence

| | |
|---|---|
| Unit suites | 51 / 32 / 26 passing across the three seed suites |
| Mutation control | removing the `ew_seed_localise` call fails that case **and only that case** |
| Real reproduction | against the actually-poisoned live snapshot: **36 donor paths in, 0 out**, all 36 rewritten, `alternates` pointing at the receiving tree's own `repositories/` |
| Lint | `shellcheck -x` clean |

The fixture was upgraded first: it now builds a tree shaped like a real one — an index **and** a checkout whose `.git/objects/info/alternates` is an absolute donor path — because the `.git` half is exactly what the original sweep could not see. Two-way: the snapshot must still carry its own state file (`ew_seed_is_complete` uses it as the marker for a real resolved tree) while the consumed tree must name only itself.

## The instrument lied by 36x, and that is the transferable part

The first sweep used the shell's `grep` and reported **one** file. `/usr/bin/grep -rl` reports **36**.

That shim is `ugrep --hidden -I --ignore-files --exclude-dir=.git` (plus the other VCS admin dirs). **It is not "skips hidden files"** — `--hidden` is on, and a measured control confirms it finds `.hidden/nested/a.txt` and `.dotfile.txt` fine while missing only the `.git` one. What is invisible is anything inside a **VCS admin directory**, or inside a **gitignored path**. `objects/info/alternates` sits in the first category by construction, so no pattern refinement could ever have found it.

The second half is worse: `--ignore-files` makes the blindness **data-dependent**, tracking `.gitignore`, so the identical command from two checkouts returns different results with no error and no clue.

A first version of this PR stated the reason as "skips dot-directories". A peer refuted it by measurement; the correction is in the branch, because the wrong version sends the next reader distrusting `.claude/` and `.derivedData/` sweeps for a reason that does not exist, and fails to predict the case that actually bit us.

Worse, the obvious correction did not catch it. A reviewer pointed out I had searched for the donor's *name* rather than the path *shape*; widening the pattern returned 140 hits and looked like confirmation — the extra hits were Sentry's vendored dSYMs pointing at `/Users/runner`, inert and identical in every checkout. **The pattern was never the problem.** Use `/usr/bin/grep` for any sweep whose emptiness you intend to interpret.

My first verification script had the same shape one level up: it grepped for `EnviousWispr-`, which matches the **consumer's own correctly-rewritten paths**, so it reported FAILURE on a perfect run.

## Workaround until this merges

Delete `.derivedData/Test/SourcePackages/workspace-state.json` and re-run. SwiftPM re-resolves against the checkouts already present.
