### PR TITLE
feat(recovery): the cancel pill shows its three seconds running out

### DIFF
--- a/Sources/EnviousWisprAppKit/App/EscapeRecoveryPillView.swift
+++ b/Sources/EnviousWisprAppKit/App/EscapeRecoveryPillView.swift
@@ -158,7 +158,12 @@ struct EscapeRecoveryPillFace: View {
     // which reads as cramped at the top.
     .frame(width: PillMetrics.pillWidth, height: PillMetrics.pillHeight)
     .background(Capsule().fill(palette.fill))
-    .overlay(Capsule().strokeBorder(palette.rim, lineWidth: 1))
+    // Both overlays sit IN FRONT of the button and are pure decoration, so both
+    // opt out of hit testing. A stroked shape is hit-testable by default and its
+    // stroke region overlaps the pill's rim, which is exactly where a click
+    // aimed just outside the Undo target lands. The rail already opts out inside
+    // `SpectralRail`; this is its twin, and the twin is the one that gets missed.
+    .overlay(Capsule().strokeBorder(palette.rim, lineWidth: 1).allowsHitTesting(false))
     .overlay(
       SpectralRail(progress: progress, palette: palette, showsBloom: showsBloom)
         .padding(PillMetrics.railInset)

--- a/Sources/EnviousWisprAppKit/App/EscapeRecoveryPillView.swift
+++ b/Sources/EnviousWisprAppKit/App/EscapeRecoveryPillView.swift
@@ -163,7 +163,6 @@ struct EscapeRecoveryPillFace: View {
       SpectralRail(progress: progress, palette: palette, showsBloom: showsBloom)
         .padding(PillMetrics.railInset)
     )
-    .shadow(color: palette.shadow, radius: palette.shadowRadius, y: 5)
   }
 }
 
@@ -183,8 +182,22 @@ enum PillMetrics {
   static let railInset: CGFloat = 1.5
   static let pillHeight: CGFloat = 58
 
-  /// Room for the drop shadow, so the panel never clips it.
-  static let panelMargin: CGFloat = 12
+  /// **The panel is EXACTLY the pill, and that is a placement requirement
+  /// rather than a saving (Codex review round 2, 2026-08-19).**
+  ///
+  /// `showPanel` anchors the PANEL to the configured top or bottom edge, and the
+  /// geometry code reasons about that frame as though it were the visible pill.
+  /// Any margin inside the panel therefore moves the capsule that far off its
+  /// edge, and a bottom recording-to-recovery transition jumps upward by the
+  /// margin — the continuing-presentation contract in
+  /// `.claude/knowledge/pill-position-behavior.md`
+  /// RULE: continuing-panel-vs-fresh-panel.
+  ///
+  /// A margin looked necessary because the pill drew its own SwiftUI shadow,
+  /// which a tight frame would clip. It does not: `showPanel` sets
+  /// `hasShadow = true`, and AppKit draws a window's shadow OUTSIDE its frame.
+  /// The SwiftUI shadow was redundant with it, and paying for it in placement
+  /// was paying twice.
 
   /// The pill sizes itself to the SENTENCE it renders.
   ///
@@ -200,8 +213,8 @@ enum PillMetrics {
     return leadInset + measured + midGap + actionWidth + trailInset + 2
   }()
 
-  static var panelWidth: CGFloat { pillWidth + panelMargin * 2 }
-  static var panelHeight: CGFloat { pillHeight + panelMargin * 2 }
+  static var panelWidth: CGFloat { pillWidth }
+  static var panelHeight: CGFloat { pillHeight }
 }
 
 // MARK: - Palette
@@ -234,8 +247,6 @@ struct PillPalette {
   var actionFillHover: Color
   var actionRim: Color
   var actionText: Color
-  var shadow: Color
-  var shadowRadius: CGFloat
   var spectrum: [Color]
 
   static func forScheme(_ scheme: ColorScheme) -> PillPalette {
@@ -250,8 +261,6 @@ struct PillPalette {
     actionFillHover: .white.opacity(0.26),
     actionRim: .clear,
     actionText: .white,
-    shadow: .black.opacity(0.55),
-    shadowRadius: 14,
     spectrum: PillSpectrum.dark
   )
 
@@ -263,8 +272,6 @@ struct PillPalette {
     actionFillHover: .black.opacity(0.13),
     actionRim: .black.opacity(0.09),
     actionText: Color(red: 0.10, green: 0.10, blue: 0.13),
-    shadow: .black.opacity(0.22),
-    shadowRadius: 16,
     spectrum: PillSpectrum.light
   )
 }

--- a/Sources/EnviousWisprAppKit/App/EscapeRecoveryPillView.swift
+++ b/Sources/EnviousWisprAppKit/App/EscapeRecoveryPillView.swift
@@ -36,6 +36,7 @@ struct EscapeRecoveryPillView: View {
   static let dwellSeconds: Double = 3.0
 
   @Environment(\.colorScheme) private var colorScheme
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
   @State private var dismissTask: Task<Void, Never>?
   /// One-shot. Without it a fast double-click restores twice — and the second
@@ -49,51 +50,17 @@ struct EscapeRecoveryPillView: View {
   private var palette: PillPalette { PillPalette.forScheme(colorScheme) }
 
   var body: some View {
-    HStack(spacing: PillMetrics.midGap) {
-      Text(DictationNarrator.escapeRecoveryPillTitle)
-        .font(.system(size: PillMetrics.titleSize, weight: .medium))
-        .foregroundStyle(palette.text)
-        .lineLimit(1)
-
-      Button(action: {
+    EscapeRecoveryPillFace(
+      progress: progress,
+      palette: palette,
+      showsBloom: RailMotion.showsBloom(reduceMotion: reduceMotion),
+      onPress: {
         guard !acted else { return }
         acted = true
         dismissTask?.cancel()
         onPaste()
-      }) {
-        Text(DictationNarrator.escapeRecoveryPillAction)
-          .font(.system(size: PillMetrics.actionSize, weight: .semibold))
-          .foregroundStyle(palette.actionText)
-          .lineLimit(1)
-          .frame(width: PillMetrics.actionWidth, height: PillMetrics.actionHeight)
-          .background(
-            RoundedRectangle(cornerRadius: PillMetrics.actionRadius, style: .continuous)
-              .fill(isActionHovered ? palette.actionFillHover : palette.actionFill)
-          )
-          .overlay(
-            RoundedRectangle(cornerRadius: PillMetrics.actionRadius, style: .continuous)
-              .strokeBorder(palette.actionRim, lineWidth: 1)
-          )
-          .contentShape(Rectangle())
       }
-      .buttonStyle(.plain)
-      .accessibilityLabel(DictationNarrator.escapeRecoveryPillAction)
-      .onHover { isActionHovered = $0 }
-    }
-    .padding(.leading, PillMetrics.leadInset)
-    .padding(.trailing, PillMetrics.trailInset)
-    // The sentence centres in the WHOLE pill, because the rail is an overlay on
-    // the rim rather than a row in a stack. Putting the bar in the layout steals
-    // height from the bottom and lifts the text above the pill's true middle,
-    // which reads as cramped at the top.
-    .frame(width: PillMetrics.pillWidth, height: PillMetrics.pillHeight)
-    .background(Capsule().fill(palette.fill))
-    .overlay(Capsule().strokeBorder(palette.rim, lineWidth: 1))
-    .overlay(
-      SpectralRail(progress: progress, palette: palette)
-        .padding(PillMetrics.railInset)
     )
-    .shadow(color: palette.shadow, radius: palette.shadowRadius, y: 5)
     .onHover { isHovering in
       if isHovering {
         dismissTask?.cancel()
@@ -135,6 +102,68 @@ struct EscapeRecoveryPillView: View {
       guard !Task.isCancelled, !acted else { return }
       onExpire()
     }
+  }
+}
+
+// MARK: - EscapeRecoveryPillFace
+
+/// The pill as it looks at ONE moment of the countdown.
+///
+/// Split from the stateful wrapper above so the appearance can be rendered at
+/// any `progress` without waiting three seconds to reach it — by a SwiftUI
+/// preview, by a screenshot harness validating the design against its mock, or
+/// by the running app. The wrapper owns the clock; this owns the picture, and
+/// neither can drift from the other because there is only one picture.
+struct EscapeRecoveryPillFace: View {
+  var progress: Double
+  var palette: PillPalette
+  var showsBloom: Bool = true
+  var onPress: () -> Void = {}
+
+  /// Purely visual, so it lives with the picture rather than the clock.
+  @State private var isActionHovered = false
+
+  var body: some View {
+    HStack(spacing: PillMetrics.midGap) {
+      Text(DictationNarrator.escapeRecoveryPillTitle)
+        .font(.system(size: PillMetrics.titleSize, weight: .medium))
+        .foregroundStyle(palette.text)
+        .lineLimit(1)
+
+      Button(action: onPress) {
+        Text(DictationNarrator.escapeRecoveryPillAction)
+          .font(.system(size: PillMetrics.actionSize, weight: .semibold))
+          .foregroundStyle(palette.actionText)
+          .lineLimit(1)
+          .frame(width: PillMetrics.actionWidth, height: PillMetrics.actionHeight)
+          .background(
+            RoundedRectangle(cornerRadius: PillMetrics.actionRadius, style: .continuous)
+              .fill(isActionHovered ? palette.actionFillHover : palette.actionFill)
+          )
+          .overlay(
+            RoundedRectangle(cornerRadius: PillMetrics.actionRadius, style: .continuous)
+              .strokeBorder(palette.actionRim, lineWidth: 1)
+          )
+          .contentShape(Rectangle())
+      }
+      .buttonStyle(.plain)
+      .accessibilityLabel(DictationNarrator.escapeRecoveryPillAction)
+      .onHover { isActionHovered = $0 }
+    }
+    .padding(.leading, PillMetrics.leadInset)
+    .padding(.trailing, PillMetrics.trailInset)
+    // The sentence centres in the WHOLE pill, because the rail is an overlay on
+    // the rim rather than a row in a stack. Putting the bar in the layout steals
+    // height from the bottom and lifts the text above the pill's true middle,
+    // which reads as cramped at the top.
+    .frame(width: PillMetrics.pillWidth, height: PillMetrics.pillHeight)
+    .background(Capsule().fill(palette.fill))
+    .overlay(Capsule().strokeBorder(palette.rim, lineWidth: 1))
+    .overlay(
+      SpectralRail(progress: progress, palette: palette, showsBloom: showsBloom)
+        .padding(PillMetrics.railInset)
+    )
+    .shadow(color: palette.shadow, radius: palette.shadowRadius, y: 5)
   }
 }
 
@@ -187,6 +216,16 @@ enum PillMetrics {
 /// recording, polishing and language pills are dark in every environment
 /// (`OverlayCapsuleBackground`), so a light Mac shows this one pill differently
 /// from its neighbours until they follow.
+///
+/// **The fills are OPAQUE, and that is a correctness requirement rather than a
+/// taste (Codex review, 2026-08-19).** The other overlay pills are translucent,
+/// but this one carries a measured contrast guarantee: every countdown colour
+/// clears 3:1 against the pill it is drawn on. A translucent fill composites
+/// with whatever the panel happens to float over, so the ground the test
+/// measures stops being the ground that renders — the dark purple rail falls to
+/// about 2.3:1 over white content. Restoring any `.opacity(...)` here silently
+/// voids that guarantee, which is why `PillSpectrum.darkGround` /
+/// `lightGround` and these fills are pinned to each other by a test.
 struct PillPalette {
   var fill: Color
   var rim: Color
@@ -204,7 +243,7 @@ struct PillPalette {
   }
 
   static let dark = PillPalette(
-    fill: Color(red: 0.078, green: 0.078, blue: 0.11).opacity(0.90),
+    fill: Color(red: 0.078, green: 0.078, blue: 0.11),
     rim: .white.opacity(0.14),
     text: .white,
     actionFill: .white.opacity(0.16),
@@ -217,7 +256,7 @@ struct PillPalette {
   )
 
   static let light = PillPalette(
-    fill: Color(red: 0.98, green: 0.98, blue: 0.99).opacity(0.94),
+    fill: Color(red: 0.98, green: 0.98, blue: 0.99),
     rim: .black.opacity(0.10),
     text: Color(red: 0.10, green: 0.10, blue: 0.13),
     actionFill: .black.opacity(0.075),
@@ -309,6 +348,24 @@ struct BottomRail: Shape {
   }
 }
 
+/// What Reduce Motion changes about the rail, and what it must NOT change.
+///
+/// **Adopted with a deviation from the review that raised it (Codex round 1,
+/// 2026-08-19).** The proposed fix was
+/// `withAnimation(reduceMotion ? nil : .linear(...))`. A nil animation does not
+/// stop the change, it applies it INSTANTLY — so the rail would jump to full the
+/// moment the pill appeared, telling a Reduce Motion user their three seconds
+/// were already gone. That is the one direction a countdown may not be wrong in,
+/// and it is the same defect the instant-hover-reset comment above describes.
+///
+/// So Reduce Motion drops the DECORATION and keeps the INFORMATION: the bloom
+/// goes, the rail still advances. A 3pt line filling in place is not the
+/// large-scale movement the setting exists to suppress, and suppressing it
+/// outright would leave exactly those users with no warning at all.
+enum RailMotion {
+  static func showsBloom(reduceMotion: Bool) -> Bool { !reduceMotion }
+}
+
 /// The three seconds, drawn along the rim.
 ///
 /// The gradient is painted across the FULL width and then MASKED by the drawn
@@ -319,14 +376,17 @@ struct BottomRail: Shape {
 struct SpectralRail: View {
   var progress: Double
   var palette: PillPalette
+  var showsBloom: Bool = true
   var lineWidth: CGFloat = 3
 
   var body: some View {
     ZStack {
-      spectrum
-        .mask { rail }
-        .blur(radius: 4)
-        .opacity(0.8)
+      if showsBloom {
+        spectrum
+          .mask { rail }
+          .blur(radius: 4)
+          .opacity(0.8)
+      }
       spectrum
         .mask { rail }
     }

--- a/Sources/EnviousWisprAppKit/App/EscapeRecoveryPillView.swift
+++ b/Sources/EnviousWisprAppKit/App/EscapeRecoveryPillView.swift
@@ -1,0 +1,360 @@
+import AppKit
+import SwiftUI
+
+// MARK: - EscapeRecoveryPillView
+
+/// The Escape Recovery pill (#2087): one sentence, one action, and a countdown
+/// that shows the offer running out.
+///
+/// Deliberately NOT a question. The founder chose this over a "Want to paste?"
+/// prompt, and the persona work agreed independently: a prompt demands attention
+/// from someone who by definition is not looking, and the whole feature exists
+/// for the case where the user has already moved on. It never steals focus (the
+/// panel is `.nonactivatingPanel`), never blocks, and never requires dismissal.
+///
+/// History is the real path for most people; this is an accelerator for whoever
+/// happens to be watching. That is why letting it expire costs nothing, and why
+/// the spoken announcement names History rather than only the button.
+///
+/// **The view owns its own dwell**, exactly as `LanguageChipView` does, because
+/// a panel-level timer cannot be paused by a hover only the view can see. Hover
+/// cancels; hover-exit restarts the FULL three seconds rather than resuming the
+/// remainder — matching the shipped chip deliberately, so two overlay pills do
+/// not behave differently under the same gesture. The rail is driven from the
+/// SAME two events, so what the user sees and what the timer is doing cannot
+/// drift apart.
+///
+/// **The countdown is the brand line doing a job (founder design 2026-08-18).**
+/// Every other overlay pill carries a static rainbow hairline along its bottom
+/// edge. Here it traces the rim as the offer expires, so the deadline is visible
+/// instead of arriving as a surprise.
+struct EscapeRecoveryPillView: View {
+  let onPaste: () -> Void
+  let onExpire: () -> Void
+
+  /// Founder-specified.
+  static let dwellSeconds: Double = 3.0
+
+  @Environment(\.colorScheme) private var colorScheme
+
+  @State private var dismissTask: Task<Void, Never>?
+  /// One-shot. Without it a fast double-click restores twice — and the second
+  /// restore lands after the first has already moved the user's cursor.
+  @State private var acted = false
+  /// How far the rail has travelled, 0 to 1. Driven by the same hover events as
+  /// `dismissTask`, never by its own clock.
+  @State private var progress: Double = 0
+  @State private var isActionHovered = false
+
+  private var palette: PillPalette { PillPalette.forScheme(colorScheme) }
+
+  var body: some View {
+    HStack(spacing: PillMetrics.midGap) {
+      Text(DictationNarrator.escapeRecoveryPillTitle)
+        .font(.system(size: PillMetrics.titleSize, weight: .medium))
+        .foregroundStyle(palette.text)
+        .lineLimit(1)
+
+      Button(action: {
+        guard !acted else { return }
+        acted = true
+        dismissTask?.cancel()
+        onPaste()
+      }) {
+        Text(DictationNarrator.escapeRecoveryPillAction)
+          .font(.system(size: PillMetrics.actionSize, weight: .semibold))
+          .foregroundStyle(palette.actionText)
+          .lineLimit(1)
+          .frame(width: PillMetrics.actionWidth, height: PillMetrics.actionHeight)
+          .background(
+            RoundedRectangle(cornerRadius: PillMetrics.actionRadius, style: .continuous)
+              .fill(isActionHovered ? palette.actionFillHover : palette.actionFill)
+          )
+          .overlay(
+            RoundedRectangle(cornerRadius: PillMetrics.actionRadius, style: .continuous)
+              .strokeBorder(palette.actionRim, lineWidth: 1)
+          )
+          .contentShape(Rectangle())
+      }
+      .buttonStyle(.plain)
+      .accessibilityLabel(DictationNarrator.escapeRecoveryPillAction)
+      .onHover { isActionHovered = $0 }
+    }
+    .padding(.leading, PillMetrics.leadInset)
+    .padding(.trailing, PillMetrics.trailInset)
+    // The sentence centres in the WHOLE pill, because the rail is an overlay on
+    // the rim rather than a row in a stack. Putting the bar in the layout steals
+    // height from the bottom and lifts the text above the pill's true middle,
+    // which reads as cramped at the top.
+    .frame(width: PillMetrics.pillWidth, height: PillMetrics.pillHeight)
+    .background(Capsule().fill(palette.fill))
+    .overlay(Capsule().strokeBorder(palette.rim, lineWidth: 1))
+    .overlay(
+      SpectralRail(progress: progress, palette: palette)
+        .padding(PillMetrics.railInset)
+    )
+    .shadow(color: palette.shadow, radius: palette.shadowRadius, y: 5)
+    .onHover { isHovering in
+      if isHovering {
+        dismissTask?.cancel()
+        // The offer is being HELD, and hover-exit restarts the full three
+        // seconds rather than resuming — so the rail returns to empty rather
+        // than freezing part-way, which would promise a resume that never comes.
+        //
+        // INSTANT, not animated, and that is load-bearing. An animated retreat
+        // is interruptible: a hover shorter than the retreat leaves the rail
+        // part-way, and the next `withAnimation` interpolates from there rather
+        // than from empty. The timer would still give a full three seconds
+        // while the rail claimed less — a countdown wrong in the only direction
+        // that matters.
+        resetRail()
+      } else {
+        scheduleExpiry()
+      }
+    }
+    .onAppear { scheduleExpiry() }
+    .onDisappear { dismissTask?.cancel() }
+  }
+
+  /// Empty the rail with no animation of its own, so whatever runs next starts
+  /// from a known presentation value rather than from wherever an interrupted
+  /// animation happened to be.
+  private func resetRail() {
+    var instant = Transaction()
+    instant.disablesAnimations = true
+    withTransaction(instant) { progress = 0 }
+  }
+
+  private func scheduleExpiry() {
+    guard !acted else { return }
+    dismissTask?.cancel()
+    resetRail()
+    withAnimation(.linear(duration: Self.dwellSeconds)) { progress = 1 }
+    dismissTask = Task { @MainActor in
+      try? await Task.sleep(for: .seconds(Self.dwellSeconds))
+      guard !Task.isCancelled, !acted else { return }
+      onExpire()
+    }
+  }
+}
+
+// MARK: - Metrics
+
+/// The pill's geometry, in one place because the PANEL has to be sized to it and
+/// a panel that disagrees with its content clips or floats.
+enum PillMetrics {
+  static let titleSize: CGFloat = 17
+  static let actionSize: CGFloat = 15
+  static let actionWidth: CGFloat = 78
+  static let actionHeight: CGFloat = 34
+  static let actionRadius: CGFloat = 12
+  static let leadInset: CGFloat = 22
+  static let midGap: CGFloat = 16
+  static let trailInset: CGFloat = 10
+  static let railInset: CGFloat = 1.5
+  static let pillHeight: CGFloat = 58
+
+  /// Room for the drop shadow, so the panel never clips it.
+  static let panelMargin: CGFloat = 12
+
+  /// The pill sizes itself to the SENTENCE it renders.
+  ///
+  /// A hand-tuned constant here is a latent truncation bug: the copy is
+  /// founder-owned and has already been revised once (#2087, 2026-08-18), and a
+  /// pill too narrow by two points silently renders "Transcript cance…". The
+  /// two points of slack absorb rounding between this measurement and the
+  /// renderer's own layout.
+  static let pillWidth: CGFloat = {
+    let font = NSFont.systemFont(ofSize: titleSize, weight: .medium)
+    let title = DictationNarrator.escapeRecoveryPillTitle as NSString
+    let measured = ceil(title.size(withAttributes: [.font: font]).width)
+    return leadInset + measured + midGap + actionWidth + trailInset + 2
+  }()
+
+  static var panelWidth: CGFloat { pillWidth + panelMargin * 2 }
+  static var panelHeight: CGFloat { pillHeight + panelMargin * 2 }
+}
+
+// MARK: - Palette
+
+/// Every colour the pill uses, for both appearances.
+///
+/// A struct rather than scattered `colorScheme == .dark ? a : b` expressions so
+/// neither theme can be half-defined: adding a colour means filling it in twice
+/// or the build fails.
+///
+/// **This is the first floating panel in the app with a light appearance.** The
+/// recording, polishing and language pills are dark in every environment
+/// (`OverlayCapsuleBackground`), so a light Mac shows this one pill differently
+/// from its neighbours until they follow.
+struct PillPalette {
+  var fill: Color
+  var rim: Color
+  var text: Color
+  var actionFill: Color
+  var actionFillHover: Color
+  var actionRim: Color
+  var actionText: Color
+  var shadow: Color
+  var shadowRadius: CGFloat
+  var spectrum: [Color]
+
+  static func forScheme(_ scheme: ColorScheme) -> PillPalette {
+    scheme == .dark ? .dark : .light
+  }
+
+  static let dark = PillPalette(
+    fill: Color(red: 0.078, green: 0.078, blue: 0.11).opacity(0.90),
+    rim: .white.opacity(0.14),
+    text: .white,
+    actionFill: .white.opacity(0.16),
+    actionFillHover: .white.opacity(0.26),
+    actionRim: .clear,
+    actionText: .white,
+    shadow: .black.opacity(0.55),
+    shadowRadius: 14,
+    spectrum: PillSpectrum.dark
+  )
+
+  static let light = PillPalette(
+    fill: Color(red: 0.98, green: 0.98, blue: 0.99).opacity(0.94),
+    rim: .black.opacity(0.10),
+    text: Color(red: 0.10, green: 0.10, blue: 0.13),
+    actionFill: .black.opacity(0.075),
+    actionFillHover: .black.opacity(0.13),
+    actionRim: .black.opacity(0.09),
+    actionText: Color(red: 0.10, green: 0.10, blue: 0.13),
+    shadow: .black.opacity(0.22),
+    shadowRadius: 16,
+    spectrum: PillSpectrum.light
+  )
+}
+
+/// The brand sequence the rail reveals.
+///
+/// **The HEAD is theme-dependent and that is the whole point.** A hot white head
+/// reads as a moving light on a dark pill and is invisible on a white one, so
+/// the light sequence leads with deep amber instead. The two themes cannot share
+/// one sequence, which is why this is not a single constant.
+enum PillSpectrum {
+  /// The pill fill each spectrum is drawn ON. Held here because the contrast
+  /// floor below is a claim about the PAIR, and a fill that moves without its
+  /// spectrum moving is exactly the change that would break it silently.
+  static let darkGround = (red: 0.078, green: 0.078, blue: 0.11)
+  static let lightGround = (red: 0.98, green: 0.98, blue: 0.99)
+
+  /// The shipped brand line, which lives on dark pills and is bright by design.
+  static let dark: [Color] = [
+    .white,
+    Color(red: 1.0, green: 0.843, blue: 0.0),
+    Color(red: 1.0, green: 0.549, blue: 0.0),
+    Color(red: 1.0, green: 0.165, blue: 0.251),
+    Color(red: 0.914, green: 0.118, blue: 0.706),
+    Color(red: 0.541, green: 0.169, blue: 0.886),
+    Color(red: 0.255, green: 0.412, blue: 0.882),
+    Color(red: 0.118, green: 0.565, blue: 1.0),
+    Color(red: 0.0, green: 0.78, blue: 0.85),
+    Color(red: 0.0, green: 0.72, blue: 0.45),
+    Color(red: 0.42, green: 0.75, blue: 0.12),
+  ]
+
+  /// **Not the dark sequence re-used.** Measured against the white pill, six of
+  /// the eleven brand colours fall under a 3:1 contrast floor — the yellow head
+  /// worst at 1.55:1, which is a countdown that appears never to start. These
+  /// hold the same hues and deepen the value until each clears the floor.
+  ///
+  /// The HEAD inverts deliberately: on a dark pill the leading spark is the
+  /// brightest colour, on a light one it is the darkest. Both read as the hot
+  /// end of the rail.
+  static let light: [Color] = [
+    Color(red: 0.62, green: 0.40, blue: 0.0),
+    Color(red: 0.84, green: 0.46, blue: 0.0),
+    Color(red: 1.0, green: 0.115, blue: 0.206),
+    Color(red: 0.914, green: 0.072, blue: 0.694),
+    Color(red: 0.52, green: 0.125, blue: 0.886),
+    Color(red: 0.211, green: 0.379, blue: 0.882),
+    Color(red: 0.068, green: 0.54, blue: 1.0),
+    Color(red: 0.0, green: 0.608, blue: 0.663),
+    Color(red: 0.0, green: 0.626, blue: 0.391),
+    Color(red: 0.328, green: 0.615, blue: 0.068),
+  ]
+}
+
+// MARK: - The rail
+
+/// The bottom edge of the capsule, as a path that can be drawn along.
+///
+/// Deliberately NOT a straight line inset from the bottom. The countdown rides
+/// the rim and curls up into both end caps, which is what makes it read as part
+/// of the pill rather than a progress bar parked inside it.
+struct BottomRail: Shape {
+  /// How far up each cap the rail climbs, in degrees past the bottom.
+  var climb: Double = 28
+
+  func path(in rect: CGRect) -> Path {
+    let radius = rect.height / 2
+    let leftCentre = CGPoint(x: rect.minX + radius, y: rect.midY)
+    let rightCentre = CGPoint(x: rect.maxX - radius, y: rect.midY)
+    var path = Path()
+    path.addArc(
+      center: leftCentre, radius: radius,
+      startAngle: .degrees(90 + climb), endAngle: .degrees(90),
+      clockwise: true)
+    path.addLine(to: CGPoint(x: rect.maxX - radius, y: rect.maxY))
+    path.addArc(
+      center: rightCentre, radius: radius,
+      startAngle: .degrees(90), endAngle: .degrees(90 - climb),
+      clockwise: true)
+    return path
+  }
+}
+
+/// The three seconds, drawn along the rim.
+///
+/// The gradient is painted across the FULL width and then MASKED by the drawn
+/// portion of the rail, so a colour never moves once it has appeared — the rail
+/// REVEALS the spectrum rather than squeezing it into whatever length it has
+/// reached so far. Painting the gradient into the trimmed path instead would
+/// make every colour slide leftward as the rail grew.
+struct SpectralRail: View {
+  var progress: Double
+  var palette: PillPalette
+  var lineWidth: CGFloat = 3
+
+  var body: some View {
+    ZStack {
+      spectrum
+        .mask { rail }
+        .blur(radius: 4)
+        .opacity(0.8)
+      spectrum
+        .mask { rail }
+    }
+    .allowsHitTesting(false)
+    .accessibilityHidden(true)
+  }
+
+  private var spectrum: some View {
+    LinearGradient(colors: palette.spectrum, startPoint: .leading, endPoint: .trailing)
+  }
+
+  /// How much of the rail is drawn for a given elapsed fraction.
+  ///
+  /// The floor keeps a visible spark at t=0, so the pill never appears with a
+  /// rim that looks broken; the ceiling stops a late or over-shooting animation
+  /// value from asking `trim` for more path than exists.
+  static func drawnFraction(for progress: Double) -> Double {
+    guard progress.isFinite else { return minimumSpark }
+    return max(minimumSpark, min(1, progress))
+  }
+
+  static let minimumSpark: Double = 0.015
+
+  private var rail: some View {
+    BottomRail()
+      .trim(from: 0, to: Self.drawnFraction(for: progress))
+      .stroke(
+        Color.white,
+        style: StrokeStyle(lineWidth: lineWidth, lineCap: .round, lineJoin: .round))
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/EscapeRecoveryPillView.swift
+++ b/Sources/EnviousWisprAppKit/App/EscapeRecoveryPillView.swift
@@ -194,9 +194,9 @@ enum PillMetrics {
   /// geometry code reasons about that frame as though it were the visible pill.
   /// Any margin inside the panel therefore moves the capsule that far off its
   /// edge, and a bottom recording-to-recovery transition jumps upward by the
-  /// margin — the continuing-presentation contract in
-  /// `.claude/knowledge/pill-position-behavior.md`
-  /// RULE: continuing-panel-vs-fresh-panel.
+  /// margin. That transition is a CONTINUING presentation — the same pill in a
+  /// replaced panel, whose frame is inherited precisely so the visible capsule
+  /// does not move — so a margin makes it move the one time it must not.
   ///
   /// A margin looked necessary because the pill drew its own SwiftUI shadow,
   /// which a tight frame would clip. It does not: `showPanel` sets

--- a/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
@@ -1649,11 +1649,16 @@ final class RecordingOverlayPanel {
     // has been superseded cannot act on its successor's payload.
     let callbacks = escapeRecoveryCallbacks(
       shownID: payload.transcriptID, paste: onEscapeRecoveryPaste)
+    // Sized from `PillMetrics`, which measures the sentence, rather than from
+    // literals here. Two places holding the same number is how a copy revision
+    // clips the pill in one of them.
     let view = EscapeRecoveryPillView(
       onPaste: callbacks.onPaste, onExpire: callbacks.onExpire
     )
-    .frame(width: 320, height: 56)
-    showPanel(content: view, width: 320, height: 56, inheritedFrame: inheritedFrame)
+    .frame(width: PillMetrics.panelWidth, height: PillMetrics.panelHeight)
+    showPanel(
+      content: view, width: PillMetrics.panelWidth, height: PillMetrics.panelHeight,
+      inheritedFrame: inheritedFrame)
   }
 
   /// Show the passive language-detection chip as a floating panel. Mirrors the
@@ -2445,93 +2450,6 @@ struct PolishingOverlayView: View {
     .padding(.horizontal, 14)
     .padding(.vertical, 10)
     .background(OverlayCapsuleBackground())
-  }
-}
-
-// MARK: - EscapeRecoveryPillView
-
-/// The Escape Recovery pill (#2087): one sentence, one action.
-///
-/// Deliberately NOT a question. The founder chose this over a "Want to paste?"
-/// prompt, and the persona work agreed independently: a prompt demands attention
-/// from someone who by definition is not looking, and the whole feature exists
-/// for the case where the user has already moved on. It never steals focus (the
-/// panel is `.nonactivatingPanel`), never blocks, and never requires dismissal.
-///
-/// History is the real path for most people; this is an accelerator for whoever
-/// happens to be watching. That is why letting it expire costs nothing, and why
-/// the spoken announcement names History rather than only the button.
-///
-/// **The view owns its own dwell**, exactly as `LanguageChipView` does, because
-/// a panel-level timer cannot be paused by a hover only the view can see. Hover
-/// cancels; hover-exit restarts the FULL three seconds rather than resuming the
-/// remainder — matching the shipped chip deliberately, so two overlay pills do
-/// not behave differently under the same gesture.
-struct EscapeRecoveryPillView: View {
-  let onPaste: () -> Void
-  let onExpire: () -> Void
-
-  /// Founder-specified.
-  private static let dwellSeconds: Double = 3.0
-
-  @State private var dismissTask: Task<Void, Never>?
-  /// One-shot. Without it a fast double-click restores twice — and the second
-  /// restore lands after the first has already moved the user's cursor.
-  @State private var acted = false
-
-  var body: some View {
-    HStack(spacing: 10) {
-      Image(systemName: "arrow.uturn.backward.circle.fill")
-        .foregroundStyle(.white.opacity(0.85))
-        .font(.system(size: 18))
-        .accessibilityHidden(true)
-
-      Text(DictationNarrator.escapeRecoveryPillTitle)
-        .font(.system(size: 13, weight: .medium))
-        .foregroundStyle(.white)
-        .lineLimit(1)
-
-      Spacer(minLength: 8)
-
-      Button(action: {
-        guard !acted else { return }
-        acted = true
-        dismissTask?.cancel()
-        onPaste()
-      }) {
-        Text(DictationNarrator.escapeRecoveryPillAction)
-          .font(.system(size: 12, weight: .semibold))
-          .foregroundStyle(.white)
-          .padding(.horizontal, 12)
-          .padding(.vertical, 5)
-          .contentShape(Rectangle())
-          .background(Capsule().fill(.white.opacity(0.18)))
-      }
-      .buttonStyle(.plain)
-      .accessibilityLabel(DictationNarrator.escapeRecoveryPillAction)
-    }
-    .padding(.horizontal, 14)
-    .padding(.vertical, 10)
-    .background(OverlayCapsuleBackground())
-    .onHover { isHovering in
-      if isHovering {
-        dismissTask?.cancel()
-      } else {
-        scheduleExpiry()
-      }
-    }
-    .onAppear { scheduleExpiry() }
-    .onDisappear { dismissTask?.cancel() }
-  }
-
-  private func scheduleExpiry() {
-    guard !acted else { return }
-    dismissTask?.cancel()
-    dismissTask = Task { @MainActor in
-      try? await Task.sleep(for: .seconds(Self.dwellSeconds))
-      guard !Task.isCancelled, !acted else { return }
-      onExpire()
-    }
   }
 }
 

--- a/Tests/EnviousWisprTests/App/EscapeRecoveryPillLayoutTests.swift
+++ b/Tests/EnviousWisprTests/App/EscapeRecoveryPillLayoutTests.swift
@@ -1,0 +1,175 @@
+import AppKit
+import Foundation
+import SwiftUI
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// The cancel pill's geometry and its countdown colours (#2087, redesign
+/// 2026-08-19).
+///
+/// Product Outcome throughout — each case finishes "when this fails, the user
+/// sees ___" with something a person would notice on screen: a clipped
+/// sentence, a pill hanging out of its panel, or a countdown that appears never
+/// to start.
+///
+/// Deliberately NOT pixel assertions. Nothing here pins a colour to a value or a
+/// width to a literal; every case states a RELATIONSHIP that has to hold however
+/// the design is retuned, which is what lets the design keep moving.
+@Suite(.tags(.productOutcome))
+struct EscapeRecoveryPillLayoutTests {
+
+  // MARK: - Geometry
+
+  @Test("The pill is wide enough for the sentence it renders")
+  func theSentenceFitsThePillItIsRenderedIn() {
+    let font = NSFont.systemFont(ofSize: PillMetrics.titleSize, weight: .medium)
+    let title = DictationNarrator.escapeRecoveryPillTitle as NSString
+    let sentence = ceil(title.size(withAttributes: [.font: font]).width)
+
+    let claimed =
+      PillMetrics.leadInset + sentence + PillMetrics.midGap
+      + PillMetrics.actionWidth + PillMetrics.trailInset
+
+    // Failing this renders "Transcript cance…", which the earlier fixed-width
+    // pill did when the copy was revised.
+    #expect(PillMetrics.pillWidth >= claimed)
+  }
+
+  @Test("A longer sentence would widen the pill rather than clip")
+  func theWidthTracksTheCopyRatherThanAConstant() {
+    let font = NSFont.systemFont(ofSize: PillMetrics.titleSize, weight: .medium)
+    let shipped = DictationNarrator.escapeRecoveryPillTitle as NSString
+    let longer = (DictationNarrator.escapeRecoveryPillTitle + " again") as NSString
+
+    let shippedWidth = ceil(shipped.size(withAttributes: [.font: font]).width)
+    let longerWidth = ceil(longer.size(withAttributes: [.font: font]).width)
+
+    // The measurement is what the pill is built from, so a wider sentence has to
+    // produce a wider measurement. A constant here would make both equal and the
+    // pill would clip the longer one silently.
+    #expect(longerWidth > shippedWidth)
+    #expect(PillMetrics.pillWidth > shippedWidth)
+  }
+
+  @Test("The panel leaves room for the pill and its shadow")
+  func thePanelDoesNotClipThePill() {
+    #expect(PillMetrics.panelWidth > PillMetrics.pillWidth)
+    #expect(PillMetrics.panelHeight > PillMetrics.pillHeight)
+    #expect(PillMetrics.panelMargin > 0)
+  }
+
+  @Test("The action is a real target, not a hairline")
+  func theActionIsBigEnoughToHit() {
+    // Well under the 44pt HIG target because this is a transient overlay the
+    // pointer is already near, but a button that shrinks toward the text size
+    // would be a regression a user feels immediately.
+    #expect(PillMetrics.actionWidth >= 60)
+    #expect(PillMetrics.actionHeight >= 28)
+    #expect(PillMetrics.actionHeight < PillMetrics.pillHeight)
+  }
+
+  // MARK: - The countdown
+
+  @Test("The rail is already visible the instant the pill appears")
+  func theRailShowsASparkAtZero() {
+    // At t=0 an untrimmed rail draws nothing, and the pill arrives looking like
+    // its rim is broken.
+    #expect(SpectralRail.drawnFraction(for: 0) > 0)
+    #expect(SpectralRail.drawnFraction(for: 0) == SpectralRail.minimumSpark)
+  }
+
+  @Test("The rail never asks for more path than exists")
+  func theRailIsClampedAtBothEnds() {
+    #expect(SpectralRail.drawnFraction(for: 1) == 1)
+    #expect(SpectralRail.drawnFraction(for: 1.4) == 1)
+    #expect(SpectralRail.drawnFraction(for: -3) == SpectralRail.minimumSpark)
+    #expect(SpectralRail.drawnFraction(for: .nan) == SpectralRail.minimumSpark)
+  }
+
+  @Test("The rail advances with the time elapsed")
+  func theRailIsMonotonic() {
+    let samples = stride(from: 0.0, through: 1.0, by: 0.1).map {
+      SpectralRail.drawnFraction(for: $0)
+    }
+    #expect(zip(samples, samples.dropFirst()).allSatisfy { $0 <= $1 })
+  }
+
+  // MARK: - Legibility in both themes
+
+  /// **The case that matters most here, and the one that caught a real defect.**
+  ///
+  /// The first light-theme attempt re-used the dark brand sequence. Six of its
+  /// eleven colours fall under 3:1 on a white pill and the yellow head measured
+  /// 1.55:1 — a countdown that a user on a light Mac would see as never
+  /// starting. 3:1 is the WCAG floor for non-text content.
+  @Test("Every countdown colour is visible on the pill it is drawn on")
+  func bothSpectraClearTheContrastFloor() {
+    let floor = 3.0
+
+    for colour in PillSpectrum.dark {
+      let ratio = contrastRatio(colour, PillSpectrum.darkGround)
+      #expect(ratio >= floor, "dark spectrum colour at \(ratio) against the dark pill")
+    }
+
+    for colour in PillSpectrum.light {
+      let ratio = contrastRatio(colour, PillSpectrum.lightGround)
+      #expect(ratio >= floor, "light spectrum colour at \(ratio) against the light pill")
+    }
+  }
+
+  @Test("The two themes do not share one sequence")
+  func eachThemeHasItsOwnSpectrum() {
+    // Not a style preference: the dark head is white, which is invisible on the
+    // light pill. Collapsing these back to one array reintroduces exactly that.
+    #expect(PillSpectrum.light != PillSpectrum.dark)
+    #expect(contrastRatio(PillSpectrum.dark[0], PillSpectrum.lightGround) < 3.0)
+  }
+
+  @Test("The text is readable on the pill in both themes")
+  func bothPalettesKeepTheSentenceLegible() {
+    // 4.5:1 is the WCAG floor for body text, and the sentence is the whole
+    // point of the pill.
+    #expect(contrastRatio(PillPalette.dark.text, PillSpectrum.darkGround) >= 4.5)
+    #expect(contrastRatio(PillPalette.light.text, PillSpectrum.lightGround) >= 4.5)
+  }
+
+  @Test("The scheme picks the matching palette")
+  func schemeSelectsThePalette() {
+    #expect(PillPalette.forScheme(.dark).spectrum == PillSpectrum.dark)
+    #expect(PillPalette.forScheme(.light).spectrum == PillSpectrum.light)
+  }
+
+  // MARK: - Contrast helper
+
+  /// WCAG 2.1 relative-luminance contrast ratio.
+  ///
+  /// Computed here rather than asserted against stored numbers, so a colour
+  /// change is measured instead of being compared to a figure someone wrote down
+  /// when the colour was different.
+  private func contrastRatio(_ colour: Color, _ ground: (red: Double, green: Double, blue: Double))
+    -> Double
+  {
+    let a = relativeLuminance(of: colour)
+    let b = relativeLuminance(red: ground.red, green: ground.green, blue: ground.blue)
+    return (max(a, b) + 0.05) / (min(a, b) + 0.05)
+  }
+
+  private func relativeLuminance(of colour: Color) -> Double {
+    guard let srgb = NSColor(colour).usingColorSpace(.sRGB) else {
+      Issue.record("a pill colour could not be resolved in sRGB")
+      return 0
+    }
+    return relativeLuminance(
+      red: Double(srgb.redComponent),
+      green: Double(srgb.greenComponent),
+      blue: Double(srgb.blueComponent))
+  }
+
+  private func relativeLuminance(red: Double, green: Double, blue: Double) -> Double {
+    func linear(_ channel: Double) -> Double {
+      channel <= 0.04045 ? channel / 12.92 : pow((channel + 0.055) / 1.055, 2.4)
+    }
+    return 0.2126 * linear(red) + 0.7152 * linear(green) + 0.0722 * linear(blue)
+  }
+}

--- a/Tests/EnviousWisprTests/App/EscapeRecoveryPillLayoutTests.swift
+++ b/Tests/EnviousWisprTests/App/EscapeRecoveryPillLayoutTests.swift
@@ -126,6 +126,42 @@ struct EscapeRecoveryPillLayoutTests {
     #expect(contrastRatio(PillSpectrum.dark[0], PillSpectrum.lightGround) < 3.0)
   }
 
+  /// **The gap Codex round 1 found, closed structurally.**
+  ///
+  /// The contrast cases measure against `PillSpectrum.darkGround` /
+  /// `lightGround`. If the pill's actual fill is translucent, or simply drifts
+  /// from those constants, every one of those cases keeps passing while
+  /// measuring a ground that is not the one on screen — the guarantee would be
+  /// bought without the cover. This pins the two together.
+  @Test("The ground the contrast cases measure is the ground that renders")
+  func theFillsAreOpaqueAndMatchTheMeasuredGround() {
+    for (fill, ground, name) in [
+      (PillPalette.dark.fill, PillSpectrum.darkGround, "dark"),
+      (PillPalette.light.fill, PillSpectrum.lightGround, "light"),
+    ] {
+      guard let srgb = NSColor(fill).usingColorSpace(.sRGB) else {
+        Issue.record("the \(name) pill fill could not be resolved in sRGB")
+        continue
+      }
+      // Opaque, so nothing the pill floats over can change the ground.
+      #expect(srgb.alphaComponent == 1.0, "the \(name) pill fill is translucent")
+      #expect(abs(Double(srgb.redComponent) - ground.red) < 0.001)
+      #expect(abs(Double(srgb.greenComponent) - ground.green) < 0.001)
+      #expect(abs(Double(srgb.blueComponent) - ground.blue) < 0.001)
+    }
+  }
+
+  @Test("Reduce Motion drops the decoration and keeps the countdown")
+  func reduceMotionRemovesTheBloomOnly() {
+    #expect(RailMotion.showsBloom(reduceMotion: false))
+    #expect(!RailMotion.showsBloom(reduceMotion: true))
+
+    // The rail still ADVANCES under Reduce Motion. Suppressing it would leave
+    // those users no warning at all, and snapping it to full — which a nil
+    // animation does — would claim the three seconds were already spent.
+    #expect(SpectralRail.drawnFraction(for: 0.5) == 0.5)
+  }
+
   @Test("The text is readable on the pill in both themes")
   func bothPalettesKeepTheSentenceLegible() {
     // 4.5:1 is the WCAG floor for body text, and the sentence is the whole

--- a/Tests/EnviousWisprTests/App/EscapeRecoveryPillLayoutTests.swift
+++ b/Tests/EnviousWisprTests/App/EscapeRecoveryPillLayoutTests.swift
@@ -52,11 +52,16 @@ struct EscapeRecoveryPillLayoutTests {
     #expect(PillMetrics.pillWidth > shippedWidth)
   }
 
-  @Test("The panel leaves room for the pill and its shadow")
-  func thePanelDoesNotClipThePill() {
-    #expect(PillMetrics.panelWidth > PillMetrics.pillWidth)
-    #expect(PillMetrics.panelHeight > PillMetrics.pillHeight)
-    #expect(PillMetrics.panelMargin > 0)
+  /// **Equality, not headroom, and the direction matters.**
+  ///
+  /// `showPanel` anchors the PANEL to the configured screen edge, so any slack
+  /// inside it moves the visible capsule that far off that edge and makes a
+  /// recording-to-recovery transition jump. The shadow is drawn by the window,
+  /// outside its frame, so no slack is needed to avoid clipping it.
+  @Test("The anchored panel is exactly the visible pill")
+  func thePanelFrameIsThePill() {
+    #expect(PillMetrics.panelWidth == PillMetrics.pillWidth)
+    #expect(PillMetrics.panelHeight == PillMetrics.pillHeight)
   }
 
   @Test("The action is a real target, not a hairline")

--- a/Tests/RuntimeUAT/escape_recovery_uat.py
+++ b/Tests/RuntimeUAT/escape_recovery_uat.py
@@ -135,6 +135,22 @@ def wait_for(what, predicate, deadline=45.0, poll=0.25):
 
 
 def defaults_write(key, value, kind="-int"):
+    """Write one preference, normalising the one value shape `defaults` refuses.
+
+    `defaults write <dom> <key> -bool 1` EXITS 255. The tool accepts only
+    true/false/yes/no for `-bool`, while `defaults read` PRINTS a boolean back as
+    `1`. So a value round-tripped through a snapshot is in a form the writer
+    rejects, and the failure lands in two places that both matter: applying the
+    ON phase, and — worse — the `finally` that restores the developer's own
+    settings. Observed 2026-08-19: the restore raised here, and the founder's
+    `escapeRecoveryEnabled` was left ABSENT rather than back on.
+
+    Normalising at the single write point covers apply and restore together,
+    which a fix at either call site would not.
+    """
+    if kind in ("-bool", "-boolean"):
+        text = str(value).strip().lower()
+        value = "true" if text in ("1", "true", "yes", "y", "on") else "false"
     subprocess.run(["defaults", "write", DOMAIN, key, kind, str(value)], check=True)
 
 
@@ -481,6 +497,16 @@ def main():
     field_a = new_textedit_doc("field-a")
     field_b = new_textedit_doc("field-b")
     print(f"targets: A={field_a}  B={field_b}")
+
+    # The AX connection has to exist before the oracle control, not only before
+    # the retarget phase below. `verify_can_read` clears the document with
+    # `w.press_key`, and every `w.*` entry point guards on `_ensure_connected`,
+    # so without this the control aborts the whole run with "Not connected" —
+    # BEFORE it has proven anything, and while reporting nothing about the
+    # product. Connecting here rather than inside the control keeps the later
+    # reconnect at the retarget phase meaningful: that one re-attaches after
+    # focus has moved, which is a different thing from attaching at all.
+    w.connect()
 
     # Before any verdict depends on reading a field, prove we CAN read one.
     # Without this the run cannot tell "the feature held the text" from "the

--- a/Tests/RuntimeUAT/escape_recovery_uat.py
+++ b/Tests/RuntimeUAT/escape_recovery_uat.py
@@ -260,6 +260,16 @@ def restore(before):
             ok = False
             print(f"    RESTORE FAILED for {key}: {failure}")
             print(f"    the developer's own {key} is NOT back to what it was")
+    # Read back what was just written. An exit status of 0 says the command ran,
+    # not that the value is there — the distinction this whole class of defect
+    # keeps turning on.
+    for key, captured in before.items():
+        now = defaults_read(key)
+        want = None if captured is None else captured[0]
+        got = None if now is None else now[0]
+        if got != want:
+            ok = False
+            print(f"    RESTORE DID NOT TAKE for {key}: wanted {want!r}, reads {got!r}")
     if not ok:
         print("    !! at least one preference was not restored — check it by hand")
     return ok
@@ -702,11 +712,19 @@ def main():
         # `finally` before the settings went back, and these are the developer's
         # REAL settings. The stop and the quit are best-effort; the restore is
         # not optional.
+        # Whether the app is CONFIRMED down. A restore written underneath a live
+        # app is a race this harness loses: `SettingsManager` writes its own
+        # values back on quit and wins, so a "successful" restore would be
+        # silently undone minutes later. `stop_app` raises when the process
+        # outlives its deadline, and the handler below only PRINTS that, so
+        # without this flag the restore reported success from exactly that state.
+        app_down = False
         try:
             try:
                 ensure_stopped(base, "cleaning up before quitting")
             finally:
                 stop_app()
+            app_down = True
         except Exception as cleanup_error:  # noqa: BLE001 - reported, never swallowed
             print(f"    (cleanup problem, restoring anyway: {cleanup_error})")
         finally:
@@ -719,6 +737,13 @@ def main():
             # very thing the nested try above exists to prevent. It travels as a
             # flag and lands on the exit status instead.
             restored = restore(before)
+            if not app_down:
+                # Attempted anyway — a restore that might be undone still beats
+                # not trying — but it cannot be REPORTED as done.
+                print("    The app was not confirmed down, so anything written")
+                print("    just now can be overwritten by it on quit. Treating")
+                print("    the restore as UNVERIFIED rather than successful.")
+                restored = False
 
     passed = [n for n, s, _ in results if s == "PASS"]
     failed = [n for n, s, _ in results if s == "FAIL"]

--- a/Tests/RuntimeUAT/escape_recovery_uat.py
+++ b/Tests/RuntimeUAT/escape_recovery_uat.py
@@ -546,6 +546,9 @@ def main():
     # the settings restore, which is the one thing that must never be skipped.
     base = log_length()
     aborted = None
+    # Assumed FAILED until the restore says otherwise, so a path that never
+    # reaches the cleanup cannot report clean settings by omission.
+    restored = False
 
     try:
         # ---- OFF path first: the promise that covers everyone -------------
@@ -651,7 +654,14 @@ def main():
             print(f"    (cleanup problem, restoring anyway: {cleanup_error})")
         finally:
             print("\n[restore] putting every setting back to what it was")
-            restore(before)
+            # The RESULT is read. `restore` reporting a failure that nothing
+            # consumes is an instrument nobody looks at: the run would print its
+            # normal summary and exit 0 while the developer's real preferences
+            # sat modified. Deliberately NOT raised from this `finally` — that
+            # would swallow whatever exception is already in flight, which is the
+            # very thing the nested try above exists to prevent. It travels as a
+            # flag and lands on the exit status instead.
+            restored = restore(before)
 
     passed = [n for n, s, _ in results if s == "PASS"]
     failed = [n for n, s, _ in results if s == "FAIL"]
@@ -670,6 +680,16 @@ def main():
         print("  This is NOT a partial pass. The remaining items were never")
         print("  exercised, and no verdict about the feature follows from it.")
     print("=" * 60)
+    if not restored:
+        # Loudest line in the summary, and it outranks the test verdicts: a green
+        # run that left the developer's own shortcut rebound is worse than a red
+        # one, because nothing else will ever mention it again.
+        print("\n  SETTINGS NOT RESTORED. Your own preferences may still be")
+        print("  changed by this run. The keys it borrows are cancelKeyCode,")
+        print("  cancelModifiersRaw and escapeRecoveryEnabled in")
+        print(f"  {DOMAIN} — check them before trusting anything above.")
+        print("=" * 60)
+        return 3
     if aborted:
         return 2
     return 1 if failed else 0

--- a/Tests/RuntimeUAT/escape_recovery_uat.py
+++ b/Tests/RuntimeUAT/escape_recovery_uat.py
@@ -59,6 +59,7 @@ writes its own values back and wins any race; and the app is quit BEFORE the
 restore, so it cannot overwrite the restored values on the way out.
 """
 import os
+import plistlib
 import subprocess
 import sys
 import time
@@ -199,6 +200,38 @@ _TYPE_FLAG = {
     "float": "-float",
     "string": "-string",
 }
+
+
+def plist_snapshot(keys):
+    """The stored values read INDEPENDENTLY of `defaults_read`, via the plist.
+
+    `defaults_read` goes through `defaults read`, whose output is text and which
+    this harness then `.strip()`s — so a string preference stored as `"  dark  "`
+    comes back as `"dark"`. That loss is invisible to any check whose EXPECTED
+    value came from the same reader: `before` is already stripped, the read-back
+    is stripped identically, and the comparison passes while the developer's
+    actual preference has changed.
+
+    A check's own instrument cannot verify that instrument
+    (validation-discipline.md
+    RULE: a-checks-own-command-is-not-independent-verification-of-that-check).
+    So this reads the domain as a property list and parses it with `plistlib`,
+    which preserves whitespace and native types. Different tool, different
+    parser, different failure modes.
+
+    Returns {key: value} for keys present, omitting absent ones. None when the
+    domain cannot be exported at all, which callers must treat as "cannot tell"
+    rather than "nothing there".
+    """
+    out = subprocess.run(
+        ["defaults", "export", DOMAIN, "-"], capture_output=True)
+    if out.returncode != 0:
+        return None
+    try:
+        whole = plistlib.loads(out.stdout)
+    except Exception:  # noqa: BLE001 — an unparseable export is "cannot tell"
+        return None
+    return {k: whole[k] for k in keys if k in whole}
 
 
 def defaults_read(key):
@@ -586,6 +619,11 @@ def main():
     # Captured BEFORE anything is written, so the `finally` restores rather
     # than resets. A developer running this must not lose their own shortcut.
     before = snapshot(("cancelKeyCode", "cancelModifiersRaw", "escapeRecoveryEnabled"))
+    # A SECOND capture through a different tool and parser. `before` is what the
+    # restore is built from; this is what it is judged against, so a loss in the
+    # text reader cannot hide inside both sides of the comparison.
+    before_plist = plist_snapshot(
+        ("cancelKeyCode", "cancelModifiersRaw", "escapeRecoveryEnabled"))
     print(f"prior settings: {before}")
 
     field_a = new_textedit_doc("field-a")
@@ -741,6 +779,21 @@ def main():
             # very thing the nested try above exists to prevent. It travels as a
             # flag and lands on the exit status instead.
             restored = restore(before)
+            # Judged by the INDEPENDENT oracle as well. `restore` verifies with
+            # the same text reader it wrote from, which cannot see a loss that
+            # reader makes on both sides — a padded string is the concrete case.
+            after_plist = plist_snapshot(
+                ("cancelKeyCode", "cancelModifiersRaw", "escapeRecoveryEnabled"))
+            if before_plist is None or after_plist is None:
+                print("    (could not read the domain as a plist — restore is")
+                print("     UNVERIFIED by the independent oracle)")
+                restored = False
+            elif after_plist != before_plist:
+                for k in sorted(set(before_plist) | set(after_plist)):
+                    if before_plist.get(k) != after_plist.get(k):
+                        print(f"    PLIST MISMATCH for {k}: was "
+                              f"{before_plist.get(k)!r}, now {after_plist.get(k)!r}")
+                restored = False
             if not app_down:
                 # Attempted anyway — a restore that might be undone still beats
                 # not trying — but it cannot be REPORTED as done.

--- a/Tests/RuntimeUAT/escape_recovery_uat.py
+++ b/Tests/RuntimeUAT/escape_recovery_uat.py
@@ -265,11 +265,15 @@ def restore(before):
     # keeps turning on.
     for key, captured in before.items():
         now = defaults_read(key)
-        want = None if captured is None else captured[0]
-        got = None if now is None else now[0]
-        if got != want:
+        # The WHOLE tuple, value AND plist type. `defaults_read` returns both and
+        # an earlier version compared only the value, which passes a restore that
+        # changed the TYPE while printing the same text: `escapeRecoveryEnabled`
+        # captured as integer 1 and handed back as boolean true reads "1" either
+        # way. The developer is left with a preference of the wrong type, the app
+        # may read it differently, and the run reports success.
+        if now != captured:
             ok = False
-            print(f"    RESTORE DID NOT TAKE for {key}: wanted {want!r}, reads {got!r}")
+            print(f"    RESTORE DID NOT TAKE for {key}: wanted {captured!r}, reads {now!r}")
     if not ok:
         print("    !! at least one preference was not restored — check it by hand")
     return ok

--- a/Tests/RuntimeUAT/escape_recovery_uat.py
+++ b/Tests/RuntimeUAT/escape_recovery_uat.py
@@ -154,8 +154,38 @@ def defaults_write(key, value, kind="-int"):
     subprocess.run(["defaults", "write", DOMAIN, key, kind, str(value)], check=True)
 
 
+def domain_is_readable():
+    """Whether `DOMAIN` can be read at all.
+
+    Asked ONCE per restore rather than per key, because it is the question a
+    per-key read-back cannot answer: `defaults read` fails identically for a key
+    that is absent and for a domain that cannot be reached, so on its own
+    "the key is gone" and "I am blind to this domain" are the same answer, and
+    the second would report a successful restore having restored nothing.
+    """
+    return subprocess.run(
+        ["defaults", "read", DOMAIN], capture_output=True).returncode == 0
+
+
 def defaults_delete(key):
+    """Remove one key and report whether it is ACTUALLY gone.
+
+    Verified by reading the key back, NOT by the exit status: `defaults delete`
+    exits 1 for a key that was already absent, which is a SUCCESS here, since
+    restoring an absent key means leaving it absent.
+
+    **Not by stderr either, and that was measured rather than assumed.** An
+    earlier version of this treated the string "does not exist" as the
+    already-absent case. Run on 2026-08-19, `defaults` emits the SAME text —
+    `Domain (X) not found. Defaults have not been changed.` — for a missing key,
+    a missing domain, and an unwritable path alike, so stderr cannot separate
+    them and any rule built on it is a coin flip. Do not reintroduce one.
+
+    The blindness this leaves is handled by `domain_is_readable`, called once by
+    `restore`, rather than pretended away here.
+    """
     subprocess.run(["defaults", "delete", DOMAIN, key], check=False, capture_output=True)
+    return defaults_read(key) is None
 
 
 # `defaults read-type` wording -> the write flag that reproduces it. Restoring
@@ -211,10 +241,18 @@ def restore(before):
     returns whether everything landed.
     """
     ok = True
+    # The blind case, asked once and first: with an unreadable domain every
+    # per-key read-back returns "absent" and the restore would report success
+    # having written nothing.
+    if not domain_is_readable():
+        print(f"    RESTORE IMPOSSIBLE: cannot read {DOMAIN} at all")
+        return False
     for key, captured in before.items():
         try:
             if captured is None:
-                defaults_delete(key)
+                if not defaults_delete(key):
+                    raise RuntimeError(
+                        f"{key} was absent before this run and will not delete now")
             else:
                 value, flag = captured
                 defaults_write(key, value, kind=flag)
@@ -311,6 +349,10 @@ def stop_app():
     running. `SettingsManager` writes its own values back on change, so a write
     made underneath a live app is a race against it, and the app wins on quit.
     """
+    # check=False BY DESIGN and the result is deliberately dropped: `pkill`
+    # exits 1 when nothing matched, which is the ordinary case here — the app
+    # may already be down. The OUTCOME is what matters and it is verified
+    # separately by `app_is_running`, not by this call's status.
     subprocess.run(["pkill", "-f", "EnviousWispr Local.app/Contents/MacOS/EnviousWispr"],
                    check=False, capture_output=True)
     if not wait_for("the old instance to exit", lambda: not app_is_running(), deadline=15.0):

--- a/Tests/RuntimeUAT/escape_recovery_uat.py
+++ b/Tests/RuntimeUAT/escape_recovery_uat.py
@@ -460,7 +460,22 @@ def dictate_then_cancel(base):
         ensure_stopped(base, "the start signal never arrived, so the take may be late",
                        grace=5.0)
         return "no-start"
-    subprocess.run(["afplay", w.tts(SENTENCE, engine="say")], timeout=60)
+    # THE SPEECH HAS TO ACTUALLY PLAY, and this used to fail open.
+    #
+    # `afplay` ran with no `check`, so a missing file, an empty synthesis or a
+    # busy audio device produced NO sound and no complaint. The recorder then
+    # captured silence, the pipeline concluded `noSpeech`, and the run reported
+    # that the recovery branch never fired — a PRODUCT verdict from a harness
+    # that never spoke. Measured by hand 2026-08-19, where it cost two runs and
+    # a wrong diagnosis before the log said `noSpeech`.
+    #
+    # Checked in both directions: the clip must exist and be big enough to be
+    # speech rather than a header, and playback must exit cleanly.
+    clip = w.tts(SENTENCE, engine="say")
+    size = os.path.getsize(clip) if os.path.exists(clip) else 0
+    if size < 8192:
+        raise Aborted(f"the speech clip is missing or too small to be speech ({size} bytes at {clip})")
+    subprocess.run(["afplay", clip], timeout=60, check=True)
     si.hold_key("lctrl", 0.12)
     if not wait_for("the session to reach a terminal",
                     lambda: "dictation_terminal" in log_since(base), deadline=60.0):

--- a/Tests/RuntimeUAT/escape_recovery_uat.py
+++ b/Tests/RuntimeUAT/escape_recovery_uat.py
@@ -195,13 +195,36 @@ def restore(before):
 
     Deleting unconditionally would silently reset a developer's own cancel
     shortcut, which is a destructive tidy-up wearing the word "restore".
+
+    **Goes through `defaults_write` like every other write, and this line is the
+    whole point of the function working at all.** It used to call `subprocess`
+    directly, so it skipped the boolean normalisation that lives there: a value
+    captured as `1` was handed back as `defaults write ... -bool 1`, which exits
+    255. With `check=False` swallowing that, the restore FAILED SILENTLY and the
+    developer's own preference was left at whatever the run had set. Measured
+    2026-08-19 against the founder's `escapeRecoveryEnabled`.
+
+    **`check=False` is kept deliberately, but no longer means "say nothing".** A
+    restore must attempt EVERY key even after one fails, so an exception here
+    would abandon the rest — but a failure that prints nothing is how the
+    original defect stayed invisible. Each key now reports, and the function
+    returns whether everything landed.
     """
+    ok = True
     for key, captured in before.items():
-        if captured is None:
-            defaults_delete(key)
-        else:
-            value, flag = captured
-            subprocess.run(["defaults", "write", DOMAIN, key, flag, value], check=False)
+        try:
+            if captured is None:
+                defaults_delete(key)
+            else:
+                value, flag = captured
+                defaults_write(key, value, kind=flag)
+        except Exception as failure:  # noqa: BLE001 — every key still gets a turn
+            ok = False
+            print(f"    RESTORE FAILED for {key}: {failure}")
+            print(f"    the developer's own {key} is NOT back to what it was")
+    if not ok:
+        print("    !! at least one preference was not restored — check it by hand")
+    return ok
 
 
 def screen_is_locked():

--- a/Tests/RuntimeUAT/test_escape_recovery_uat.py
+++ b/Tests/RuntimeUAT/test_escape_recovery_uat.py
@@ -23,7 +23,13 @@ late take is missed again, which is the old shape exactly.
 """
 import sys, types, pathlib
 
-HERE = "/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-escape-recovery/Tests/RuntimeUAT"
+# THIS file's directory, never a hardcoded one. It used to name
+# `EnviousWispr-escape-recovery`, a worktree that has since been deleted, and the
+# test kept passing only because Python puts a script's own directory on the path
+# anyway. Harmless while that path is absent; a silent wrong-subject test the
+# moment a stale copy exists there, since the import would resolve to ANOTHER
+# checkout's harness while the report named this one.
+HERE = str(pathlib.Path(__file__).resolve().parent)
 sys.path.insert(0, HERE)
 
 # The real ones need PyObjC and a live app; the subject under test is the
@@ -240,6 +246,85 @@ try:
 except uat.Aborted as e:
     ok("control: an app that does exit is fine", False, str(e))
 _sp.run = _real_run
+
+# ---------------------------------------------------------------------------
+# The restore PROPERTY, added 2026-08-19 after four consecutive review findings
+# in one place.
+#
+# Every one of those was a check that verified PART of the outcome and looked
+# like it verified all of it: the exit status but not the value, the value but
+# not the plist type, the write but not whether the app was down to receive it.
+# Adding a fifth clause would have been the same mistake again, so this asserts
+# the WHOLE property instead:
+#
+#     restore(before) returning True implies the domain now equals `before`
+#     for every key it was given — same value, same type, same presence.
+#
+# Swept over the cross-product of starting states and the ways a run can disturb
+# them, rather than over cases someone thought of.
+# ---------------------------------------------------------------------------
+
+def test_restore_property():
+    import importlib, itertools, subprocess
+    import escape_recovery_uat as _stubbed
+
+    # RELOAD FIRST. The rows above replace `defaults_write`, `defaults_delete`
+    # and `defaults_read` with in-memory fakes and never restore them, so a test
+    # written after them measures the stubs rather than the harness — the exact
+    # wrong-subject failure this whole file exists to catch. Caught here by the
+    # property failing 36/36 with "cannot read domain at all" rather than by
+    # anyone noticing the stubs.
+    harness = importlib.reload(_stubbed)
+
+    probe = "com.enviouswispr.propertyprobe"
+    saved_domain, harness.DOMAIN = harness.DOMAIN, probe
+
+    starts = [None, ("1", "-int"), ("1", "-bool"), ("0", "-bool"),
+              ("53", "-int"), ("dark", "-string")]
+    disturbances = {
+        "leave": None,
+        "delete": None,
+        "to-int-1": ("-int", "1"),
+        "to-bool-true": ("-bool", "true"),
+        "to-string-dark": ("-string", "dark"),
+        "to-int-999": ("-int", "999"),
+    }
+
+    def put(state):
+        subprocess.run(["defaults", "delete", probe, "k"], capture_output=True)
+        if state is not None:
+            # Through the harness's own writer: a raw `defaults write ... -bool 1`
+            # exits 255, which is the defect this file now guards. The first
+            # version of this test wrote raw and died on it.
+            harness.defaults_write("k", state[0], kind=state[1])
+
+    harness.defaults_write("bystander", "7", kind="-int")  # keeps the domain readable
+    violations = []
+    try:
+        for start, how in itertools.product(starts, disturbances):
+            put(start)
+            before = {"k": harness.defaults_read("k")}
+            if how == "delete":
+                subprocess.run(["defaults", "delete", probe, "k"], capture_output=True)
+            elif how != "leave":
+                kind, val = disturbances[how]
+                harness.defaults_write("k", val, kind=kind)
+            claimed = harness.restore(before)
+            after = harness.defaults_read("k")
+            if claimed and after != before["k"]:
+                violations.append(("claimed success but differs", start, how, before["k"], after))
+            if not claimed and after == before["k"]:
+                violations.append(("false alarm", start, how, before["k"], after))
+    finally:
+        subprocess.run(["defaults", "delete", probe], capture_output=True)
+        harness.DOMAIN = saved_domain
+
+    ok("restore: a claimed success always means the domain matches what was captured",
+          not violations,
+          "" if not violations else f"{len(violations)} violation(s): {violations[:3]}")
+
+
+test_restore_property()
 
 print("\n" + "=" * 56)
 print(f"{len(fails)} failed" if fails else "all rows passed")


### PR DESCRIPTION
## What changes

The Escape Recovery cancel pill takes the founder's spectral-countdown design.
The brand rainbow stops being a static hairline and traces the pill's bottom rim
as the three-second offer expires, curling into both end caps, so the deadline is
visible rather than arriving as a surprise. The pill also sizes itself to its
sentence, centres that sentence in its full height, and gains a light appearance.

**Behaviour is untouched.** Same copy, same three-second dwell, same
hover-to-hold with a full restart on exit, same one-shot press, same fallback to
History when it expires.

Part of #2087.

## Design provenance

Founder concept, iterated in-session across four shapes: segmented wide,
stacked, wide again, then the countdown. The countdown is his idea — the brand
line doing a job instead of decoration.

Validated against the mock by compiling the SHIPPED view file into a render
harness, so the comparison is a measurement rather than a drawing. It reports
what it drew: 287 x 58pt, "Transcript cancelled" / "Undo".

One deliberate difference from the mock: its stage one shows the rail about a
fifth filled at 0.5s, and 0.5 of 3 is a sixth, so the code draws slightly less.
The mock was right about the look and generous about the clock.

## Three decisions worth naming

**The rail is an OVERLAY on the rim, not a row in a stack.** Putting the bar in
the layout steals height from the bottom and lifts the sentence above the pill's
true middle, which reads as cramped at the top.

**The light spectrum is NOT the dark one re-used.** Measured against the white
pill, six of the eleven brand colours fall under a 3:1 contrast floor and the
yellow head measures 1.55:1 — a countdown a user on a light Mac would see as
never starting. Same hues, deepened until each clears the floor.
`EscapeRecoveryPillLayoutTests` COMPUTES the ratios rather than comparing against
stored numbers, so a future retune is measured rather than trusted.

**The panel is EXACTLY the pill.** `showPanel` anchors the PANEL to the
configured screen edge, so any margin inside it displaces the visible capsule and
makes a bottom recording-to-recovery transition jump. The window already draws
its own shadow, outside its frame, so the SwiftUI shadow it was making room for
was redundant.

## Known scope limit

**This is the FIRST floating panel in the app with a light appearance.** The
recording, polishing and language pills are dark in every environment, so a light
Mac shows this one pill unlike its neighbours until they follow. Flagged to the
founder; doing the rest is a separate, larger job.

## Also here: the Live UAT harness was unrunnable

`Tests/RuntimeUAT/escape_recovery_uat.py` exists so this feature can be tested at
all, and it could not complete a run. Four defects, each with its own two-way
control:

1. It called `w.press_key` before ever calling `w.connect()`, so it aborted
   inside its own oracle control with "Not connected" — before proving anything,
   and while reporting nothing about the product.
2. `defaults_write` passed `-bool 1`. `defaults` accepts only true/false/yes/no
   and exits 255, while `defaults read` PRINTS booleans back as `1`. So a
   snapshotted boolean was in a form the writer rejected. That broke the restore
   path and left the founder's `escapeRecoveryEnabled` ABSENT rather than back
   on. Fixed at the single write point.
3. `restore()` returned whether every key landed and its caller discarded the
   result, so a run could exit 0 with the developer's real preferences still
   modified. It now lands on the exit status as code 3, checked before the
   pass/fail return. Not raised from the `finally`, which would swallow an
   in-flight exception.
4. `afplay` ran without `check`, so a missing or empty speech clip produced
   silence and no complaint: the recorder captured nothing, the pipeline
   concluded `noSpeech`, and the harness reported a PRODUCT failure from a run
   that never spoke. That exact failure cost two runs and a wrong diagnosis
   during this session.

## Validation

- `scripts/xcode-test.sh --release` green throughout. Debug 6149 / Release 5616,
  zero failures, with the new suite confirmed present in the run rather than
  inferred from a green.
- 13 new tests, all Product Outcome: each finishes "when this fails, the user
  sees ___" with a clipped sentence, a pill hanging out of its panel, or a
  countdown that appears never to start.
- Inline mutation per `testing-philosophy.md`
  RULE: write-the-test-by-day-run-the-battery-by-night: the light spectrum
  reverted to the dark one is CAUGHT with 7 issues naming the white head at
  1.04:1; restore verified byte-identical. Full battery deferred to #2189 with
  ten frozen recipes.
- **Live UAT, dev build, both appearances**: a real dictation cancelled
  mid-recording, the pill's OWN window captured at t+0.0, +0.9, +1.8 and +2.5s.
  Targeting the window rather than the screen means a frame existing is proof the
  pill was up. One spark at zero, into cyan-green by t+2.5, and the pill leaves
  on its own. Every borrowed preference restored and verified against a snapshot.
- **Codex: six rounds to an explicit all-clear** — "No actionable correctness
  issues found." Six findings, all fixed. Rounds 3 and 5 shared a root (a signal
  produced and never consumed) whose remaining members were then enumerated over
  the parse tree rather than waited on, which is what found defect 4 above.

## Correction carried in the history

Commit 3483b96d claimed the boolean normalisation covered "apply and restore
together". It did not — there were two write points. Corrected in a5c84d94
rather than left standing.

One measurement was also reported wrong during the work: a full run printed
`Debug lane executed 6162 tests`, inflated because `run_lane` sums every result
line in a fixed log path and a Codex round was running the filtered suite in the
same worktree. The true count is 6149, which every other run agrees on. The
guard only rejects `n < 1`, so it catches an empty run and passes a doubled one.
