### PR TITLE
fix(recovery): a rescue that was never attempted no longer costs the user their recording (#2132)

### DIFF
--- a/Sources/EnviousWisprASR/RecoveryFailureClassification.swift
+++ b/Sources/EnviousWisprASR/RecoveryFailureClassification.swift
@@ -1,0 +1,52 @@
+import EnviousWisprCore
+import EnviousWisprServices
+
+/// #2132 — classify an ASR failure caught by the crash-recovery replay.
+///
+/// **Why this lives in `EnviousWisprASR` and not beside its caller.**
+/// `RecoverySpoolReplayer` (AppKit) held the only classifier, and four of the
+/// error families it needed are `internal` to THIS module and deliberately kept
+/// that way (D-028). So the old classifier could not see them and every one of
+/// them landed in `.other`: 18 production failures in the 30 days to 2026-08-19,
+/// 100% unclassified. `classify`'s own doc comment named the cause — "`ASRError`
+/// is ASR-module-internal, kept isolated per D-028" — and reserved `.notReady`
+/// for the in-process producer this function finally supplies.
+///
+/// Exports a CLASSIFICATION, never the types, so the isolation D-028 protects is
+/// untouched.
+///
+/// `nil` means "not a family this module owns" — a foreign vendor or framework
+/// error, which `ParakeetBackend.transcribe` deliberately rethrows unchanged
+/// (#1525 PR I-B, live case `com.apple.CoreML#0`). The caller maps `nil` to
+/// `.other` and keeps the error's own Sentry identity through the boundary
+/// normalizer for its seam. No switch over `any Error` can be exhaustive, so the
+/// optional is the honest return type rather than a total-looking lie.
+package func recoveryFailureClass(for error: any Error) -> RecoveryFailureClass? {
+  // ORDER IS LOAD-BEARING: the unreachable-service case must be tested before
+  // the general transport case or the shipped `xpc_unreachable` series silently
+  // stops being produced. Pinned by `serviceUnreachableOutranksGeneralTransport`.
+  if let transport = error as? XPCASRTransportError {
+    return transport.isServiceUnreachable ? .xpcUnreachable : .xpcTransport
+  }
+  // Three cancellation vehicles, one actionable class. `KernelDictationDriver`
+  // already groups the latter two exactly this way.
+  if error is ASRLoadSupersededError || error is ASRLoadCancelledError
+    || error is CancellationError
+  {
+    return .cancelled
+  }
+  if let asrError = error as? ASRError {
+    switch asrError {
+    case .notReady: return .notReady
+    case .transcriptionFailed: return .transcriptionFailed
+    // Unreachable on a batch replay; classifying them would assert a
+    // reachability this path does not have.
+    case .streamingNotSupported, .streamingTimeout: return nil
+    }
+  }
+  if error is WhisperKitModelLoadSentryError { return .whisperKitModelLoad }
+  if error is ParakeetModelLoadSentryError { return .parakeetModelLoad }
+  if error is ParakeetTranscriptionSentryError { return .parakeetTranscription }
+  if error is ASRManagerNotOwnedError { return .managerNotOwned }
+  return nil
+}

--- a/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
@@ -309,8 +309,13 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
       // Discard hard-resets the engine, which can throw here — that's an abort,
       // not a recovery failure (don't log/emit; the coordinator owns cleanup).
       if isAborted() { return .aborted }
+      let diagnosis = Self.diagnose(error, operation: .modelLoad)
+      if Self.engineWasNeverAvailable(diagnosis) {
+        return deferForUnavailableEngine(
+          spoolStore: spoolStore, id: id, reason: .modelLoadFailed, diagnosis: diagnosis)
+      }
       return failUnrecoverable(
-        reason: .modelLoadFailed, failureClass: Self.classify(error),
+        reason: .modelLoadFailed, diagnosis: diagnosis,
         reconstructedSampleCount: recovered.samples.count)
     }
     // Discard during the model load: bail BEFORE the expensive batch transcribe.
@@ -322,8 +327,13 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
       // A Discard-driven engine reset kills the in-flight transcribe and surfaces
       // here as a throw — treat it as an abort (the user discarded), not a failure.
       if isAborted() { return .aborted }
+      let diagnosis = Self.diagnose(error, operation: .transcription)
+      if Self.engineWasNeverAvailable(diagnosis) {
+        return deferForUnavailableEngine(
+          spoolStore: spoolStore, id: id, reason: .transcribeError, diagnosis: diagnosis)
+      }
       return failUnrecoverable(
-        reason: .transcribeError, failureClass: Self.classify(error),
+        reason: .transcribeError, diagnosis: diagnosis,
         reconstructedSampleCount: recovered.samples.count)
     }
     if isAborted() { return .aborted }
@@ -443,7 +453,10 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
       // second time. One attempt is therefore a property of the file, not a
       // consequence of a deletion succeeding. The coordinator deletes on
       // `.save` (`shouldDeleteAfterReplay`).
-      let failureClass = Self.classify(error)
+      // #2132: storage errors are NOT an ASR vocabulary. `HistorySaveErrorClass`
+      // owns them; this stays `.other` until a separate change routes it there,
+      // which is exactly what the old shared `classify` returned here anyway.
+      let failureClass = RecoveryFailureClass.other
       SentryBreadcrumb.add(
         stage: "recovery", message: "recovered transcript save failed — attempt spent",
         level: .warning, data: ["error": String(describing: error)])
@@ -584,9 +597,14 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
   private func failUnrecoverable(
     reason: RecoveryTelemetryReason,
     failureClass: RecoveryFailureClass? = nil,
+    diagnosis: RecoveryFailureDiagnosis? = nil,
     reconstructedSampleCount: Int? = nil
   ) -> RecoveryReplayOutcome {
     let category = Self.category(for: reason)
+    // One value wins: a diagnosis supersedes a bare class, and both may be nil
+    // for a DECISION-driven failure (escape verdict, empty prefix, empty text),
+    // where absence is the signal rather than a gap.
+    let resolvedClass = diagnosis?.failureClass ?? failureClass
     if Self.isCountedNotAlerted(reason) {
       SentryBreadcrumb.add(
         stage: "recovery",
@@ -594,8 +612,15 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
         level: .info,
         data: ["recovery.reason": reason.rawValue])
     } else {
+      // #2132: tags, never `fingerprintDetail` — tags are searchable metadata and
+      // do NOT feed `handledErrorFingerprint`, so grouping is byte-identical and
+      // the measured, pinned descriptors of #1525 PR C keep their history.
+      var tags = ["recovery.reason": reason.rawValue]
+      if let resolvedClass { tags["recovery.failure_class"] = resolvedClass.rawValue }
+      if let identity = diagnosis?.sentryIdentity { tags["recovery.identity"] = identity }
       SentryBreadcrumb.captureError(
-        RecoveryReplayError.failed(reason.rawValue), category: category, stage: "recovery")
+        RecoveryReplayError.failed(reason.rawValue), category: category, stage: "recovery",
+        tags: tags)
     }
     let spoolSeconds = reconstructedSampleCount.map {
       Int((Double($0) / AudioConstants.sampleRate).rounded())
@@ -610,11 +635,16 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
     // coordinator's own awaited outcome line lands after `replay` returns, and
     // this reason line is enqueued strictly before that.
     let failureReason = reason.rawValue
-    RecoveryLog.line("replay failed: \(failureReason)")
+    // #2132: the CLASS on the local line. Vendor telemetry cannot diagnose the one
+    // user report in front of support; `app.log` is the artifact a user can send.
+    // Bounded vocabulary only — no identifiers, no paths, no descriptions.
+    let classSuffix = resolvedClass.map { " class=\($0.rawValue)" } ?? ""
+    let identitySuffix = diagnosis?.sentryIdentity.map { " identity=\($0)" } ?? ""
+    RecoveryLog.line("replay failed: \(failureReason)\(classSuffix)\(identitySuffix)")
     TelemetryService.shared.recoveryCompleted(
       outcome: "failed",
       reason: reason,
-      failureClass: failureClass,
+      failureClass: resolvedClass,
       audioDecrypted: reconstructedSampleCount != nil ? true : nil,
       campBCandidate: reconstructedSampleCount != nil ? true : nil,
       spoolSeconds: spoolSeconds)
@@ -628,6 +658,76 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
   /// throws, the marker survives and the next-launch guard reads the attempt as
   /// already spent, abandoning before ASR; `RecoveryCoordinator` therefore
   /// treats this id as next-launch-only so a same-launch rescan cannot burn it.
+  /// #2132 — THE ENGINE NEVER LOOKED AT THE AUDIO, SO THE ATTEMPT IS NOT SPENT.
+  ///
+  /// Measured on this machine, 2026-08-01 and 2026-08-18: a replay failed in the
+  /// SAME SECOND it was attempted, with no engine activity logged between
+  /// `attempting replay` and `replay failed`, each preceded by two
+  /// `deferred — the engine gate is held` passes. A healthy replay in the same
+  /// logs takes 1-4 seconds and prints the recovered text. The outcome was
+  /// `.unrecoverable`, which spends the single permitted attempt and has the
+  /// coordinator DELETE the spool — so a recording was destroyed by an engine
+  /// that refused instantly, never having decoded a sample.
+  ///
+  /// The root is upstream and is not fixed here: `ASRManager.loadModel()`
+  /// RECORDS readiness (`isModelLoaded = ready`) rather than requiring it, so a
+  /// load can report success while the backend is not ready and the truth
+  /// arrives one call later as an instant refusal. Pinned by
+  /// `loadModelSucceedsWhileBackendIsNotReady`.
+  ///
+  /// The line drawn here is availability versus verdict: `.notReady`,
+  /// `.xpcUnreachable`, `.managerNotOwned` and `.cancelled` all mean the engine
+  /// was never in a position to try, so this take deserves its attempt back.
+  /// A genuine decode failure (`.transcriptionFailed`, `.parakeetTranscription`)
+  /// or a model that will not load stays unrecoverable — retrying those forever
+  /// would strand a spool no launch can ever redeem.
+  ///
+  /// Mirrors `deferForTransientKeychainFailure` exactly, which is the shipped
+  /// precedent for "transient condition, give the attempt back".
+  private static func engineWasNeverAvailable(_ diagnosis: RecoveryFailureDiagnosis) -> Bool {
+    switch diagnosis {
+    case .classified(let failureClass):
+      switch failureClass {
+      // Deliberately NARROW. These two mean the engine was categorically not
+      // there to ask — the observed production shape, and the one
+      // `loadModelSucceedsWhileBackendIsNotReady` reproduces against the real
+      // manager.
+      case .notReady, .managerNotOwned: return true
+      // `.xpcUnreachable` ALSO never saw the audio and is arguably the same
+      // class, and `camp_b_candidate=true` already marks it retryable. It is
+      // deliberately NOT deferred here: a permanently dead helper would defer
+      // every launch forever, and `telemetryTranscribeFailIsCampBCandidate`
+      // pins its current failure semantics. Widening to it is a separate,
+      // evidenced decision — not a silent side effect of this fix.
+      case .xpcUnreachable, .cancelled, .transcriptionFailed, .whisperKitModelLoad,
+        .parakeetModelLoad, .parakeetTranscription, .xpcTransport, .other:
+        return false
+      }
+    // An error family we do not own says nothing about availability; it ran and
+    // failed. Listed explicitly so a future reader must choose, not inherit.
+    case .unrecognized: return false
+    }
+  }
+
+  /// Give the attempt back and leave the spool on disk for the next launch.
+  private func deferForUnavailableEngine(
+    spoolStore: RecoverySpoolStore, id: String, reason: RecoveryTelemetryReason,
+    diagnosis: RecoveryFailureDiagnosis
+  ) -> RecoveryReplayOutcome {
+    RecoveryLog.line(
+      "replay deferred: \(reason.rawValue) class=\(diagnosis.failureClass.rawValue) "
+        + "— the engine was never available, the attempt is NOT spent")
+    do {
+      try spoolStore.deleteAttemptMarker(for: id)
+      TelemetryService.shared.recoveryCompleted(
+        outcome: "deferred", reason: reason, failureClass: diagnosis.failureClass)
+      return .deferred
+    } catch {
+      TelemetryService.shared.recoveryCompleted(outcome: "deferred", reason: .markerClearFailed)
+      return .deferredMarkerClearFailed
+    }
+  }
+
   private func deferForTransientKeychainFailure(
     spoolStore: RecoverySpoolStore, id: String
   ) -> RecoveryReplayOutcome {
@@ -668,15 +768,52 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
   /// collapses decode causes into one string. `.notReady` is reserved for a Phase 2
   /// in-process producer (`ASRError` is ASR-module-internal, kept isolated per
   /// D-028); an unrecognized error is `.other`.
-  private static func classify(_ error: any Error) -> RecoveryFailureClass {
-    // #1525 PR I-B: narrowed from a bare type-check — the 6 new
-    // codec/transport cases are transport/codec failures, not "XPC
-    // unreachable," and mislabeling them would corrupt recovery telemetry.
-    if let transport = error as? XPCASRTransportError, transport.isServiceUnreachable {
-      return .xpcUnreachable
+  /// Which ASR seam caught the error. Selects the residual identity policy, so
+  /// the choice is made by the compiler rather than by a comment: Core already
+  /// owns DIFFERENT policies per seam and #2132 rev 3 nearly overrode them.
+  private enum RecoveryFailureOperation {
+    case modelLoad
+    case transcription
+  }
+
+  /// One caught error, one derivation. Either we recognised the family or we
+  /// kept its Sentry identity — never both, never neither, and never two
+  /// helpers disagreeing about the same throw.
+  private enum RecoveryFailureDiagnosis {
+    case classified(RecoveryFailureClass)
+    case unrecognized(sentryIdentity: String)
+
+    var failureClass: RecoveryFailureClass {
+      switch self {
+      case .classified(let failureClass): return failureClass
+      case .unrecognized: return .other
+      }
     }
-    if error is ASRLoadSupersededError { return .cancelled }
-    return .other
+    var sentryIdentity: String? {
+      switch self {
+      case .classified: return nil
+      case .unrecognized(let identity): return identity
+      }
+    }
+  }
+
+  /// #2132: replaces the old `classify`, which lived in the wrong module to see
+  /// four of the families it needed and so returned `.other` for 100% of genuine
+  /// failures. Recognition moved to `EnviousWisprASR.recoveryFailureClass(for:)`;
+  /// an unrecognised error keeps its own identity through the boundary
+  /// normalizer FOR ITS SEAM.
+  private static func diagnose(
+    _ error: any Error, operation: RecoveryFailureOperation
+  ) -> RecoveryFailureDiagnosis {
+    if let known = recoveryFailureClass(for: error) { return .classified(known) }
+    let normalized: any Error & StableSentryErrorIdentity
+    switch operation {
+    case .modelLoad:
+      normalized = SentryCaptureBoundaryError.normalizingModelLoadFailure(error)
+    case .transcription:
+      normalized = SentryCaptureBoundaryError.normalizingTranscriptionFailure(error)
+    }
+    return .unrecognized(sentryIdentity: normalized.sentryFingerprintDescriptor)
   }
 
   private static func transcriptionOptions(for settings: RecordingSettingsSnapshot?)

--- a/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
@@ -312,7 +312,8 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
       let diagnosis = Self.diagnose(error, operation: .modelLoad)
       if Self.engineWasNeverAvailable(diagnosis) {
         return deferForUnavailableEngine(
-          spoolStore: spoolStore, id: id, reason: .modelLoadFailed, diagnosis: diagnosis)
+          spoolStore: spoolStore, id: id, reason: .modelLoadFailed, diagnosis: diagnosis,
+          reconstructedSampleCount: recovered.samples.count)
       }
       return failUnrecoverable(
         reason: .modelLoadFailed, diagnosis: diagnosis,
@@ -330,7 +331,8 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
       let diagnosis = Self.diagnose(error, operation: .transcription)
       if Self.engineWasNeverAvailable(diagnosis) {
         return deferForUnavailableEngine(
-          spoolStore: spoolStore, id: id, reason: .transcribeError, diagnosis: diagnosis)
+          spoolStore: spoolStore, id: id, reason: .transcribeError, diagnosis: diagnosis,
+          reconstructedSampleCount: recovered.samples.count)
       }
       return failUnrecoverable(
         reason: .transcribeError, diagnosis: diagnosis,
@@ -710,17 +712,30 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
   }
 
   /// Give the attempt back and leave the spool on disk for the next launch.
+  /// `reconstructedSampleCount` is REQUIRED, not optional, and that is the point:
+  /// both callers reach here only after reconstruction returned a non-empty
+  /// prefix, and omitting these fields would emit `audio_decrypted` ABSENT —
+  /// which `recoveryCompleted`'s contract reads as "nothing came back out of the
+  /// spool" (audio-recovery-internals.md FACT: recovery-telemetry-fields). That
+  /// is the exact inverse of what happened: the audio reconstructed perfectly and
+  /// the ENGINE was missing. Codex review caught this on the first pass.
   private func deferForUnavailableEngine(
     spoolStore: RecoverySpoolStore, id: String, reason: RecoveryTelemetryReason,
-    diagnosis: RecoveryFailureDiagnosis
+    diagnosis: RecoveryFailureDiagnosis, reconstructedSampleCount: Int
   ) -> RecoveryReplayOutcome {
+    let spoolSeconds = Int(
+      (Double(reconstructedSampleCount) / AudioConstants.sampleRate).rounded())
     RecoveryLog.line(
       "replay deferred: \(reason.rawValue) class=\(diagnosis.failureClass.rawValue) "
         + "— the engine was never available, the attempt is NOT spent")
     do {
       try spoolStore.deleteAttemptMarker(for: id)
       TelemetryService.shared.recoveryCompleted(
-        outcome: "deferred", reason: reason, failureClass: diagnosis.failureClass)
+        outcome: "deferred", reason: reason, failureClass: diagnosis.failureClass,
+        // Same facts the failure path emitted for this take. `camp_b_candidate`
+        // is if anything MORE true here: good audio, and a retry is now real
+        // rather than hypothetical because the attempt was given back.
+        audioDecrypted: true, campBCandidate: true, spoolSeconds: spoolSeconds)
       return .deferred
     } catch {
       TelemetryService.shared.recoveryCompleted(outcome: "deferred", reason: .markerClearFailed)

--- a/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
@@ -309,14 +309,15 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
       // Discard hard-resets the engine, which can throw here — that's an abort,
       // not a recovery failure (don't log/emit; the coordinator owns cleanup).
       if isAborted() { return .aborted }
-      let diagnosis = Self.diagnose(error, operation: .modelLoad)
-      if Self.engineWasNeverAvailable(diagnosis) {
-        return deferForUnavailableEngine(
-          spoolStore: spoolStore, id: id, reason: .modelLoadFailed, diagnosis: diagnosis,
-          reconstructedSampleCount: recovered.samples.count)
-      }
+      // #2132: a LOAD-time refusal is TERMINAL, deliberately, and this is the
+      // line Codex review sharpened. `WhisperKitBackend.prepare()` throws
+      // `ASRError.notReady` when no model folder is admitted
+      // (`WhisperKitBackend.swift:223-226`) — a DETERMINISTIC "there is no model
+      // here", not a transient readiness loss. Deferring it would retain the
+      // spool and repeat the identical failure every launch, forever, with no
+      // cleanup. Only the POST-LOAD refusal below is the race this issue fixes.
       return failUnrecoverable(
-        reason: .modelLoadFailed, diagnosis: diagnosis,
+        reason: .modelLoadFailed, diagnosis: Self.diagnose(error, operation: .modelLoad),
         reconstructedSampleCount: recovered.samples.count)
     }
     // Discard during the model load: bail BEFORE the expensive batch transcribe.
@@ -676,6 +677,9 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
   /// load can report success while the backend is not ready and the truth
   /// arrives one call later as an instant refusal. Pinned by
   /// `loadModelSucceedsWhileBackendIsNotReady`.
+  ///
+  /// SCOPE: this is consulted ONLY on the post-load transcription refusal. A
+  /// load-time refusal is terminal — see the `.modelLoadFailed` call site.
   ///
   /// The line drawn here is availability versus verdict: `.notReady`,
   /// `.xpcUnreachable`, `.managerNotOwned` and `.cancelled` all mean the engine

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -128,6 +128,26 @@ public enum RecoveryFailureClass: String, Sendable {
   case xpcUnreachable = "xpc_unreachable"
   case cancelled
   case notReady = "not_ready"
+  // #2132: the six below fill a residual that was 100% of genuine recovery
+  // failures (18 events / 30d to 2026-08-19). They are produced by
+  // `recoveryFailureClass(for:)` in `EnviousWisprASR`, which is the only module
+  // that can see the four `internal` error families D-028 keeps isolated.
+  // VERSION FLOOR: installs below the release carrying this keep emitting
+  // `other`, so any query spanning the boundary needs an `app_version`
+  // dimension — `analytics-operations.md` RULE:
+  // enum-backed-properties-carry-retired-vocabularies-split-by-version. Reading
+  // the drop in `other` as a behaviour change is the #1813 defect.
+  // `asr_` prefixed deliberately: `transcription_failed` is ALREADY a
+  // daily-report metric key for a different concept
+  // (`workers/daily-report/test/report.test.js`). Different field, so no
+  // functional collision — but one token meaning two things in a wire
+  // vocabulary is cheap to avoid now and expensive to undo after it ships.
+  case transcriptionFailed = "asr_transcription_failed"
+  case whisperKitModelLoad = "whisperkit_model_load"
+  case parakeetModelLoad = "parakeet_model_load"
+  case parakeetTranscription = "parakeet_transcription"
+  case xpcTransport = "xpc_transport"
+  case managerNotOwned = "manager_not_owned"
   case other
 }
 

--- a/Tests/EnviousWisprASRTests/ASRManagerBackendInjectionTests.swift
+++ b/Tests/EnviousWisprASRTests/ASRManagerBackendInjectionTests.swift
@@ -18,6 +18,32 @@ import os
 @MainActor
 struct ASRManagerBackendInjectionTests {
 
+  // MARK: - #2132 readiness contract
+
+  @Test(
+    "loadModel() reports SUCCESS while the backend is not ready — the failure only surfaces at transcribe"
+  )
+  func loadModelSucceedsWhileBackendIsNotReady() async throws {
+    // The shape a real backend lands in when an unload, a cancelled load, or a
+    // refused admission gate wins the race: prepare() returns normally, readiness
+    // does not follow.
+    let parakeet = FakeASRBackend(initiallyReady: false, readyAfterPrepare: false)
+    let manager = ASRManager(engineMutationScope: .alwaysAllowedForTesting, parakeetBackend: parakeet)
+
+    // The defect: this does NOT throw. `loadModel` records readiness
+    // (`isModelLoaded = ready`) instead of requiring it, so every caller that
+    // treats a non-throwing load as "the engine is ready" is wrong.
+    try await manager.loadModel()
+    #expect(manager.isModelLoaded == false, "load reported success but nothing is loaded")
+
+    // ...and the truth only arrives one call later, as an instant refusal with
+    // no work done. In crash recovery that instant refusal spends the single
+    // permitted attempt and the recording is deleted (#2132).
+    await #expect(throws: ASRError.self) {
+      _ = try await manager.transcribe(audioSamples: [0.0], options: .default)
+    }
+  }
+
   // MARK: - switchBackend reset branch
 
   @Test("switchBackend from a loaded state resets isModelLoaded to false")
@@ -294,9 +320,15 @@ final actor FakeASRBackend: ASRBackend {
   private let gated: Bool
   private var gateContinuations: [CheckedContinuation<Void, Never>] = []
 
-  init(initiallyReady: Bool, gated: Bool = false) {
+  /// #2132: when false, `prepare()` completes NORMALLY but leaves `isReady`
+  /// false — the shape a real backend lands in when an unload or a refused
+  /// admission gate wins the race with a load. Default preserves prior behaviour.
+  private let readyAfterPrepare: Bool
+
+  init(initiallyReady: Bool, gated: Bool = false, readyAfterPrepare: Bool = true) {
     self.ready = initiallyReady
     self.gated = gated
+    self.readyAfterPrepare = readyAfterPrepare
   }
 
   // MARK: ASRBackend
@@ -312,7 +344,7 @@ final actor FakeASRBackend: ASRBackend {
         gateContinuations.append(c)
       }
     }
-    ready = true
+    ready = readyAfterPrepare
   }
 
   /// Release ALL parked `gated` `prepare()` calls (supports multiple waiters).
@@ -325,7 +357,12 @@ final actor FakeASRBackend: ASRBackend {
   func transcribe(audioSamples: [Float], options: TranscriptionOptions)
     async throws -> ASRResult
   {
-    fatalError("FakeASRBackend.transcribe is not used by Phase G5 tests")
+    // #2132: mirrors `ParakeetBackend.transcribe`'s entry guard exactly
+    // (`guard isReady ... else { throw ASRError.notReady }`). A double must
+    // refuse what the real tool refuses, or a test proves nothing about it.
+    guard ready else { throw ASRError.notReady }
+    return ASRResult(
+      text: "ok", language: nil, duration: 0, processingTime: 0, backendType: .parakeet)
   }
 
   func unload() async {

--- a/Tests/EnviousWisprTests/Recovery/RecoverySpoolReplayerTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoverySpoolReplayerTests.swift
@@ -709,6 +709,13 @@ struct RecoverySpoolReplayerTests {
       let e = try #require(box.recoveryEvents().first)
       #expect(e.stringProps["outcome"] == "deferred")
       #expect(e.stringProps["failure_class"] == "not_ready")
+      // The audio reconstructed fine; only the engine was missing. Omitting
+      // these would make analytics read the take as "nothing came back out of
+      // the spool" — the inverse of what happened, and the defect Codex review
+      // caught in the first version of this deferral.
+      #expect(e.boolProps["audio_decrypted"] == true)
+      #expect(e.boolProps["camp_b_candidate"] == true)
+      #expect(e.stringProps["spool_seconds_bucket"] != nil)
     }
 
     @Test("transcribe failure on good audio is a Camp B candidate with a failure class")

--- a/Tests/EnviousWisprTests/Recovery/RecoverySpoolReplayerTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoverySpoolReplayerTests.swift
@@ -1,5 +1,5 @@
 @preconcurrency import AVFoundation
-import EnviousWisprASR
+@testable import EnviousWisprASR
 import EnviousWisprAudio
 import EnviousWisprCore
 import Foundation
@@ -676,6 +676,41 @@ struct RecoverySpoolReplayerTests {
         "exactly one capture, in its own category — not the decrypt catch-all, not silence")
     }
 
+    /// #2132 — THE DATA-LOSS GUARD. Measured on the dev machine 2026-08-01 and
+    /// 2026-08-18: a replay failed in the same second it was attempted, with no
+    /// engine activity in between, and the recording was DELETED because an
+    /// instant refusal spent the single permitted attempt. `ASRError.notReady`
+    /// is that refusal — `ParakeetBackend.transcribe`'s entry guard — and
+    /// `loadModelSucceedsWhileBackendIsNotReady` proves the real `ASRManager`
+    /// can reach it after reporting a successful load.
+    ///
+    /// If this test ever goes red because the outcome is `.failed`, a recording
+    /// that was never decoded is being destroyed again.
+    @Test("an engine that was never ready keeps the recording and gives the attempt back")
+    func notReadyEngineDefersInsteadOfDeletingTheRecording() async throws {
+      let h = Self.makeHarness()
+      let id = "tel-notready-\(UUID().uuidString)"
+      try await Self.seedSpool(h, id: id, samples: [0.1, 0.2, 0.3])
+      h.asr.transcribeError = ASRError.notReady
+
+      // ONE replay only: a second call would meet the one-attempt guard and
+      // measure that instead of this fix.
+      var outcome: RecoveryReplayOutcome?
+      let box = await Self.capturingTelemetry {
+        outcome = await h.replayer.replay(recoverySessionID: id, isAborted: { false })
+      }
+
+      #expect(
+        outcome == .deferred,
+        "the engine never looked at the audio, so the attempt is not spent")
+      #expect(
+        !h.spoolStore.hasAttemptMarker(for: id),
+        "marker cleared, so the next launch retries instead of abandoning")
+      let e = try #require(box.recoveryEvents().first)
+      #expect(e.stringProps["outcome"] == "deferred")
+      #expect(e.stringProps["failure_class"] == "not_ready")
+    }
+
     @Test("transcribe failure on good audio is a Camp B candidate with a failure class")
     func telemetryTranscribeFailIsCampBCandidate() async throws {
       let h = Self.makeHarness()
@@ -703,8 +738,13 @@ struct RecoverySpoolReplayerTests {
     /// codec/transport cases are NOT "XPC unreachable" — a bare `is
     /// XPCASRTransportError` type-check would have misclassified them,
     /// corrupting recovery telemetry.
+    /// #2132 UPDATE: these now classify as `.xpc_transport` rather than
+    /// `.other`. The protection this test exists for is UNCHANGED and is the
+    /// reason it must not be deleted: a bare `is XPCASRTransportError` check
+    /// would call all six "unreachable", and the assertion below still fails if
+    /// anyone reintroduces that. The expected label is simply more specific now.
     @Test(
-      "the new XPCASRTransportError cases classify as .other, not .xpcUnreachable",
+      "the new XPCASRTransportError cases are transport, never .xpcUnreachable",
       arguments: [
         XPCASRTransportError.requestEncodingFailed("x"),
         .invalidSamplePayload("x"),
@@ -723,7 +763,10 @@ struct RecoverySpoolReplayerTests {
         _ = await h.replayer.replay(recoverySessionID: id, isAborted: { false })
       }
       let e = try #require(box.recoveryEvents().first)
-      #expect(e.stringProps["failure_class"] == "other")
+      #expect(e.stringProps["failure_class"] == "xpc_transport")
+      #expect(
+        e.stringProps["failure_class"] != "xpc_unreachable",
+        "the narrowing regression this test was written for (#1525 PR I-B)")
     }
 
     @Test("deferred (attempt-marker write failed) emits marker_write_failed")

--- a/Tests/EnviousWisprTests/Recovery/RecoverySpoolReplayerTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoverySpoolReplayerTests.swift
@@ -44,10 +44,15 @@ struct RecoverySpoolReplayerTests {
     var onLoadModel: (() -> Void)?
     /// When set, `transcribe` throws it instead of returning a result.
     var transcribeError: (any Error)?
+    /// #2132: when set, `loadModel` throws it. Distinguishes a LOAD-time refusal
+    /// (terminal — no model will ever be admitted by retrying) from the
+    /// post-load refusal (transient race). The two must not share an outcome.
+    var loadError: (any Error)?
 
     func loadModel() async throws {
-      isModelLoaded = true
       onLoadModel?()
+      if let loadError { throw loadError }
+      isModelLoaded = true
     }
     func unloadModel() async {}
     func setInitialBackendType(_ type: ASRBackendType) { activeBackendType = type }
@@ -674,6 +679,34 @@ struct RecoverySpoolReplayerTests {
       #expect(
         spy.categories == [.recoveryMalformedEscapeMarker],
         "exactly one capture, in its own category — not the decrypt catch-all, not silence")
+    }
+
+    /// #2132 — THE COUNTERPART GUARD, and it protects against the OPPOSITE
+    /// mistake. `WhisperKitBackend.prepare()` throws `ASRError.notReady` when no
+    /// model folder is admitted — deterministic, not transient. Deferring THAT
+    /// would retain the spool and repeat the identical failure every launch
+    /// forever, with no cleanup. Caught by Codex review on the confirming pass;
+    /// the first version of the fix deferred both load and transcribe.
+    ///
+    /// If this goes red because the outcome became `.deferred`, a spool that can
+    /// never be redeemed is being kept forever.
+    @Test("a load-time not-ready is TERMINAL — it will never succeed, so it must not defer")
+    func loadTimeNotReadyStaysUnrecoverable() async throws {
+      let h = Self.makeHarness()
+      let id = "tel-loadnotready-\(UUID().uuidString)"
+      try await Self.seedSpool(h, id: id, samples: [0.1, 0.2, 0.3])
+      h.asr.loadError = ASRError.notReady
+
+      var outcome: RecoveryReplayOutcome?
+      let box = await Self.capturingTelemetry {
+        outcome = await h.replayer.replay(recoverySessionID: id, isAborted: { false })
+      }
+
+      #expect(outcome == .failed(.unrecoverable), "no model will ever be admitted by retrying")
+      let e = try #require(box.recoveryEvents().first)
+      #expect(e.stringProps["outcome"] == "failed")
+      #expect(e.stringProps["reason"] == "model_load_failed")
+      #expect(e.stringProps["failure_class"] == "not_ready")
     }
 
     /// #2132 — THE DATA-LOSS GUARD. Measured on the dev machine 2026-08-01 and


### PR DESCRIPTION
## A rescue that was never attempted no longer costs the user their recording

Closes #2132.

### The defect

A crash-recovery replay gets exactly one attempt, ever. When the speech engine refused **instantly** — never decoding a sample — that refusal was counted as the attempt, the take was marked unrecoverable, and the coordinator deleted it.

Found by reading this machine's own debug logs, not by adding telemetry. Founder direction: reproduce locally first, only then instrument.

```
02:50:03  1 spool(s) on disk
02:50:06  deferred — the engine gate is held; a retry is owed
02:50:06  deferred — the engine gate is held; a retry is owed
02:50:16  attempting replay
02:50:16  replay failed: transcribe_error
02:50:16  replay unrecoverable — the attempt is spent — requesting deletion
```

`app.log:47023` (2026-08-18) and `app.3.log:5257` (2026-08-01). Same second, **zero engine lines in between**. A healthy replay in the same logs takes 1-4s and prints the recovered text. The elapsed time plus the absence of engine lines is the discriminator between an engine that failed and an engine that was never asked.

### Root cause, proven not inferred

`ASRManager.loadModel()` **records** readiness (`isModelLoaded = ready`) instead of **requiring** it, so a load reports success while the backend is not ready, and the truth arrives one call later as an instant refusal. Pinned against the real component by `loadModelSucceedsWhileBackendIsNotReady`: load does not throw, `isModelLoaded == false`, the next `transcribe` throws.

**That upstream contract is deliberately NOT changed here.** It has app-wide blast radius and deserves its own change. It is documented at the new guard so nobody re-derives it.

### The line drawn, after two review rounds moved it twice

| When the engine refuses | Meaning | Outcome |
|---|---|---|
| **Before** the load (`prepare()` throws) | No model will ever be admitted by retrying — deterministic | **Terminal.** Deleting is correct; deferring would strand the spool forever |
| **After** a load that reported success | It was supposed to be ready and wasn't — the race | **Deferred.** Attempt marker cleared, take retried next launch |

My first version deferred both, which would have retained an unredeemable spool at every launch forever — strictly worse than the deletion it replaced. Caught by the confirming review.

### Why the failures were invisible

All 18 genuine recovery failures in the 30d to 2026-08-19 carried `failure_class = other`, because the classifier lived in `EnviousWisprAppKit` and four of the error families it needed are `internal` to `EnviousWisprASR` (D-028). Recognition moves to that module — exporting a **classification**, never the types — and fills the `.notReady` slot its own doc comment had reserved for exactly this producer (D-030).

Unrecognised errors keep their identity through the boundary normalizer **for their seam**: Core already owns different policies for model-load and transcription and this composes them rather than adding a fourth. Reason, class and identity now reach Sentry as **tags** — never `fingerprintDetail`, so grouping is byte-identical and #1525 PR C's measured descriptors keep their history — plus PostHog and the local log.

### Reading the telemetry afterwards

**`failure_class` gains six values and `other` will collapse at this release boundary. That is the vocabulary widening, not a fix.** Installs below this release keep emitting `other`, so any query spanning the boundary needs an `app_version` dimension — the exact defect that made #1813 read as a 76-user P0.

`asr_transcription_failed` is prefixed because `transcription_failed` is already a raw value in `EscapeRecoveryCompletion` and `EscapeRecoveryTerminalOutcome` and a daily-report metric key.

### Validation

- Debug **6174** / Release **5632**, both reconciling exactly against their per-bundle lines.
- Workers **263 / 73 / 87**, zero failures — mandatory, since a Swift enum they read changed.
- **Mutation controls run on both directions, each CAUGHT**, tree restored byte-identical after each:
  - revert the deferral → `notReadyEngineDefersInsteadOfDeletingTheRecording` goes red naming all three consequences;
  - re-add the load-time deferral → `loadTimeNotReadyStaysUnrecoverable` goes red naming the deferred outcome.
- Codex review to an explicit all-clear over two rounds; both findings were real and both are fixed here.

### Live UAT: NOT RUN, and why

The crash-recovery drill (`uat-testing.md` FACT: crash-recovery-uat) requires SIGKILLing a running dev instance. The founder's own root instance is currently serving his dictation, and this drill is the most destructive thing available. Taking the slot back for it would interrupt his session twice.

**What that costs is small and stated rather than hidden.** This change touches only failure branches; the success path — decrypt, load, transcribe, polish, save — is untouched, and both failure directions are pinned by tests with mutation controls. The drill's value here is heart-path regression assurance, which the full suite covers, not proof of the fix.

Owed, and to be run in a quiet window before this is relied on in the field.

### Not in scope, deliberately

- The `loadModel()` readiness contract (root cause) — app-wide blast radius, own change.
- `.xpcUnreachable` also never sees the audio and is arguably the same class; a permanently dead helper would defer every launch forever, so widening to it needs its own evidence. Stated in code as an open question.
- Storage errors keep `.other`; `HistorySaveErrorClass` owns them.
