### PR TITLE
Live Preview pill: settle its size, and stop it moving on its own (#2201)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
@@ -2179,6 +2179,19 @@ private struct OverlayCapsuleBackground: View {
   var cornerStyle: CornerStyle = .capsule
   @State private var glowOpacity: Double = 0.3
 
+  /// #2201: the preview pill's rainbow hairline holds still instead of breathing
+  /// on a permanent two-second loop.
+  ///
+  /// The loop is a nice touch on the small capsule, which shows for a moment and
+  /// carries no text. On the preview pill it sits under a box that is already
+  /// growing a line at a time while words arrive, and the two movements read as
+  /// one restless object — the founder reported the pill "pulsing", and this is
+  /// the part of that which is not the sizing defect.
+  ///
+  /// Mid-way between the loop's own 0.3 and 0.65 endpoints, so the line is no
+  /// dimmer on average than the one it replaces.
+  private static let steadyPreviewGlow: Double = 0.5
+
   private var shape: AnyShape {
     switch cornerStyle {
     case .capsule: return AnyShape(Capsule())
@@ -2223,11 +2236,16 @@ private struct OverlayCapsuleBackground: View {
           endPoint: .trailing
         )
         .frame(height: 1)
-        .opacity(glowOpacity)
+        .opacity(cornerStyle == .rounded ? Self.steadyPreviewGlow : glowOpacity)
         .padding(.horizontal, 20)
         .offset(y: -1)
       }
       .onAppear {
+        // #2201: only the capsule breathes. Arming a `repeatForever` for the
+        // preview would keep it re-rendering whether or not anything read
+        // `glowOpacity`, and the point of this chunk is that the preview pill
+        // stops moving on its own.
+        guard cornerStyle == .capsule else { return }
         withAnimation(.easeInOut(duration: 2).repeatForever(autoreverses: true)) {
           glowOpacity = 0.65
         }
@@ -2375,7 +2393,25 @@ struct RecordingOverlayView: View {
     .animation(.easeInOut(duration: 0.3), value: lockState.isLocked)
     // Single container animation prevents animation stacking: N per-element
     // modifiers × update rate creates exponential state transitions (gotchas.md).
-    .animation(.easeOut(duration: 0.08), value: audioLevel)
+    //
+    // #2201: the PREVIEW layout selects no animation here. `audioLevel` is
+    // repolled every 50 ms, so this fires ~20 times a second, and a container
+    // animation animates whatever else changed in the same update — including the
+    // preview text, and therefore the capsule's HEIGHT. That turned each genuine
+    // resize into a smoothly animated one and drove `setFrame` once per frame.
+    //
+    // The trigger VALUE is kept rather than deleted, so the non-preview capsule's
+    // animation is visibly untouched in the diff and the two branches sit side by
+    // side. Audio-reactive PAINT is unaffected in both: `RainbowLipsIcon` reads
+    // `audioLevel` directly and redraws without needing this.
+    //
+    // Not a violation of swift-patterns.md RULE: animate-the-container-not-children
+    // — that forbids per-child `.animation(value:)`, and this adds none. The
+    // container keeps its `lockState` and `noticeState` triggers in both layouts.
+    .animation(
+      usesPreviewLayout ? nil : .easeOut(duration: 0.08),
+      value: audioLevel
+    )
     .animation(.easeInOut(duration: 0.25), value: noticeState.message)
     .padding(.horizontal, 14)
     .padding(.vertical, 10)

--- a/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
@@ -912,6 +912,7 @@ final class RecordingOverlayPanel {
       wasManuallyDragged = true
     }
 
+    let previousHeight = panel.frame.height
     var frame = panel.frame
     if activePanelPosition == .bottom {
       frame.size.height = target
@@ -922,6 +923,27 @@ final class RecordingOverlayPanel {
     }
     panel.setFrame(frame, display: true)
     if !wasManuallyDragged { lastProgrammaticOrigin = frame.origin }
+
+    // #2201: every ACCEPTED resize, so "the box holds still" has a receipt an
+    // instrument can read. Until now this method logged nothing, which left the
+    // only evidence for a pill that will not stop moving a human watching it —
+    // and no way at all to tell one legitimate resize from forty.
+    //
+    // Deliberately AFTER `setFrame` and after the re-baseline, so it cannot
+    // disturb the drag-latch ordering above: `lastProgrammaticOrigin` is the only
+    // evidence a user drag happened, and the latch has to run before the frame
+    // moves. Reading `previousHeight` from before the mutation costs nothing and
+    // keeps every statement between the latch and `setFrame` untouched.
+    //
+    // No `#if DEBUG` at the call site: `AppLogger.log` is itself DEBUG-gated and
+    // compiles to a no-op in release. Fire-and-forget through a `Task` because
+    // this is a synchronous `@MainActor` method and the logger is an actor —
+    // same shape as `RecoveryLog.swift:64`.
+    Task {
+      await AppLogger.shared.log(
+        "OVERLAY_RESIZE preview height \(Int(previousHeight)) -> \(Int(target))",
+        category: "Overlay")
+    }
   }
 
   /// #1060: flash a transient banner over the LIVE recording pill (a second line
@@ -2272,15 +2294,51 @@ struct RecordingOverlayView: View {
   /// preview grows. No-op when the preview is off.
   var onContentHeightChange: (CGFloat) -> Void = { _ in }
   /// #1988: whether this pill is the tall preview layout. Passed in rather than
-  /// derived from the display state, which starts `.off` for one 50 ms poll and
-  /// would flash the capsule shape before the first read.
+  /// derived from the display state, which remains `.off` until the polling task
+  /// first runs and would flash the capsule shape before that first read.
+  ///
+  /// #2201: the previous wording said "for one 50 ms poll", which names a duration
+  /// the code does not have — the task reads its providers BEFORE its first sleep,
+  /// so the window is until it is first scheduled, not a fixed 50 ms.
   var usesPreviewLayout: Bool = false
   var lockState: OverlayLockState
   /// #1060: transient notice banner shown inside the recording capsule.
   var noticeState: OverlayNoticeState
   @State private var audioLevel: Float = 0
   @State private var elapsed: TimeInterval = 0
-  @State private var preview: LivePreviewDisplay = .off
+  @State private var preview: LivePreviewDisplay
+
+  /// Seeds `preview` so a size test can measure a KNOWN display state on the
+  /// first layout pass instead of waiting for the 50 ms poll to publish one.
+  ///
+  /// **The seam exists because the alternative is a timed wait, and this view's
+  /// whole defect is about what its height does over time.** `preview` is
+  /// `@State`, so nothing outside can set it; without this a test would have to
+  /// pump a run loop until the polling task happened to run, which is the
+  /// guess-when-the-subject-is-finished shape testing-philosophy.md forbids.
+  ///
+  /// Production never passes it. The poll is the only writer it needs, and it
+  /// overwrites this on the first tick regardless — so a wrong value here cannot
+  /// survive into a real recording, which is what makes the seam cheap.
+  init(
+    audioLevelProvider: @escaping () -> Float,
+    recordingElapsedProvider: @escaping () -> TimeInterval? = { nil },
+    livePreviewProvider: @escaping () -> LivePreviewDisplay,
+    onContentHeightChange: @escaping (CGFloat) -> Void = { _ in },
+    usesPreviewLayout: Bool = false,
+    lockState: OverlayLockState,
+    noticeState: OverlayNoticeState,
+    initialPreview: LivePreviewDisplay = .off
+  ) {
+    self.audioLevelProvider = audioLevelProvider
+    self.recordingElapsedProvider = recordingElapsedProvider
+    self.livePreviewProvider = livePreviewProvider
+    self.onContentHeightChange = onContentHeightChange
+    self.usesPreviewLayout = usesPreviewLayout
+    self.lockState = lockState
+    self.noticeState = noticeState
+    _preview = State(initialValue: initialPreview)
+  }
 
   var body: some View {
     VStack(spacing: 6) {
@@ -2321,6 +2379,32 @@ struct RecordingOverlayView: View {
     .animation(.easeInOut(duration: 0.25), value: noticeState.message)
     .padding(.horizontal, 14)
     .padding(.vertical, 10)
+    // #2201: the preview pill's height must be a function of what it is SHOWING,
+    // never of how tall it happens to be already.
+    //
+    // Without this the capsule is free to stretch into whatever room the panel
+    // offers, because `previewText`'s `.frame(maxHeight:)` grows to its cap under
+    // a large proposal. The panel is then sized FROM that measurement
+    // (`onContentHeightChange` -> `resizeRecordingPanel`) while the measurement is
+    // taken INSIDE the panel, so the pair has no single solution: measured on the
+    // real view, one line of text reported 65pt in a 65pt panel and 125pt in a
+    // 125pt one. Nothing in the loop pulls the height back down either, so a box
+    // that grew for a long sentence stayed at the cap when the recognizer revised
+    // the sentence shorter.
+    //
+    // `fixedSize` makes the stack report its IDEAL height whatever it is offered,
+    // which is the same question `showPanel(fitToContent:)` asks at creation — so
+    // the two sizing paths finally agree. Growth is unaffected: the ideal height
+    // still tracks the text (65 -> 80 -> 125 across one, three and six-plus lines).
+    //
+    // **Gated, because every modifier on this root is rendered by BOTH layouts.**
+    // The 185pt capsule sits inside a fixed 92pt frame and is out of scope for
+    // #2198; `vertical: false` leaves it exactly as it was.
+    //
+    // **Order is load-bearing:** after both paddings, before both backgrounds. The
+    // measurement is taken on the padded stack, so moving this either side of it
+    // measures a different view than the one that was proven.
+    .fixedSize(horizontal: false, vertical: usesPreviewLayout)
     .background(OverlayCapsuleBackground(cornerStyle: usesPreviewLayout ? .rounded : .capsule))
     // #1988: report the capsule's real height so the panel can follow it. Measured
     // on the capsule rather than computed from a line count, because only the text

--- a/Tests/EnviousWisprTests/App/RecordingOverlayPreviewSizingTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingOverlayPreviewSizingTests.swift
@@ -206,6 +206,62 @@ struct RecordingOverlayPreviewSizingTests {
     #expect(atCompact == atTall, "with a notice showing: \(atCompact)pt vs \(atTall)pt")
   }
 
+  // MARK: - The acceptance criterion, pinned rather than implied
+
+  /// The chunk's stated criterion is a NUMBER: while preview text, lock state and
+  /// notice state are unchanged, the panel resizes ZERO times.
+  ///
+  /// The other cases here prove height is a function of content, from which this
+  /// follows — but only by an argument, and an argument is not a test. The view is
+  /// re-laid-out on every 50 ms poll whether or not anything changed, so "the same
+  /// content re-rendered reports the same height" is the property `resizeRecordingPanel`
+  /// actually consumes: it compares against the live frame and skips anything
+  /// inside 1pt, so one stable answer means no `setFrame` at all.
+  ///
+  /// Deliberately re-lays out ONE view rather than building several, because
+  /// building a fresh view each time cannot see a height that drifts across
+  /// renders — which is exactly the shape a box that hunts would produce.
+  @Test("re-rendering unchanged content reports one height, not a drifting series")
+  func unchangedContentDoesNotMoveTheHeight() throws {
+    let log = HeightLog()
+    let view = RecordingOverlayView(
+      audioLevelProvider: { 0 },
+      recordingElapsedProvider: { 41 },
+      livePreviewProvider: { .text(Self.threeLines) },
+      onContentHeightChange: { log.record($0) },
+      usesPreviewLayout: true,
+      lockState: OverlayLockState(),
+      noticeState: OverlayNoticeState(),
+      initialPreview: .text(Self.threeLines)
+    )
+    let host = NSHostingView(rootView: view.frame(width: Self.previewWidth))
+    let frame = NSRect(x: 0, y: 0, width: Self.previewWidth, height: 65)
+    let window = NSWindow(
+      contentRect: frame, styleMask: [.borderless], backing: .buffered, defer: false)
+    window.contentView = host
+    host.frame = frame
+
+    // Ten passes stands in for the poll loop. Each one also moves the host to the
+    // height the panel would now be at, which is the feedback the defect rode on:
+    // a view that chases its container reports a new number every pass.
+    for _ in 0..<10 {
+      host.layoutSubtreeIfNeeded()
+      window.displayIfNeeded()
+      if let latest = log.reported.last {
+        host.frame = NSRect(x: 0, y: 0, width: Self.previewWidth, height: latest)
+      }
+    }
+
+    let distinct = Set(log.reported)
+    #expect(
+      distinct.count == 1,
+      """
+      unchanged content reported \(distinct.count) different heights across ten \
+      renders: \(log.reported.map { String(format: "%.0f", $0) }.joined(separator: ", ")). \
+      Every distinct value here is a panel resize the user did not ask for.
+      """)
+  }
+
   // MARK: - The protected capsule
 
   /// The 185pt non-preview capsule is out of scope for #2198 and the founder is

--- a/Tests/EnviousWisprTests/App/RecordingOverlayPreviewSizingTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingOverlayPreviewSizingTests.swift
@@ -1,0 +1,242 @@
+import AppKit
+import SwiftUI
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #2201 (chunk A of #2198): the live preview pill's height must be a function of
+/// what it is showing, not of how tall it happened to be a moment earlier.
+///
+/// ## Why this drives the production view instead of a replica
+///
+/// The defect was first measured with an offscreen probe that rebuilt the modifier
+/// stack by hand (`docs/audits/2026-08-19-live-preview-size-probe.swift`). Grounded
+/// review r1 refused that as evidence and it was right: a replica can only prove
+/// things about the replica, and a guard written the same way would stay green while
+/// the shipped panel stayed broken. So every measurement here instantiates the real
+/// `RecordingOverlayView` and reads its own `onContentHeightChange` — the exact
+/// closure `RecordingOverlayPanel.createPanel` wires to `resizeRecordingPanel`.
+///
+/// ## The loop being pinned
+///
+/// `showPanel(fitToContent:)` sizes the panel from `NSHostingView.fittingSize`, an
+/// IDEAL-height query that tracks the text. Every later resize comes from a
+/// `GeometryReader` measuring the capsule once it is laid out INSIDE that panel.
+/// Those are two different questions, and while the preview area is free to stretch
+/// into whatever room the panel offers, the second answer depends on the first —
+/// so the same words can rest at more than one height and nothing pulls the box
+/// back down.
+///
+/// ## No timed waits
+///
+/// `preview` is `@State`, published by a 50 ms poll. Waiting for that poll would
+/// mean inferring "the subject is done" from elapsed time, in a suite whose whole
+/// subject is what the height does over time. `initialPreview:` seeds the state
+/// instead, so the first layout pass already shows the text under test.
+@MainActor
+@Suite(.tags(.productOutcome))
+struct RecordingOverlayPreviewSizingTests {
+
+  init() { _ = NSApplication.shared }
+
+  /// Width the preview pill is created at (`RecordingOverlayPanel.previewPillWidth`).
+  private static let previewWidth: CGFloat = 400
+
+  /// Collects every height the view reports. The LAST value is what the panel
+  /// would have been resized to.
+  private final class HeightLog: @unchecked Sendable {
+    private(set) var reported: [CGFloat] = []
+    func record(_ h: CGFloat) { reported.append(h) }
+  }
+
+  /// Lay the production view out inside a host of `startingHeight` and return the
+  /// height it reports back.
+  ///
+  /// `startingHeight` is the panel height the view finds itself in — the variable
+  /// this suite exists to prove the answer does NOT depend on.
+  private func measuredHeight(
+    showing display: LivePreviewDisplay,
+    inPanelOfHeight startingHeight: CGFloat,
+    notice: String? = nil,
+    locked: Bool = false,
+    usesPreviewLayout: Bool = true
+  ) throws -> CGFloat {
+    let log = HeightLog()
+    let lockState = OverlayLockState()
+    lockState.isLocked = locked
+    let noticeState = OverlayNoticeState()
+    noticeState.message = notice
+
+    let view = RecordingOverlayView(
+      audioLevelProvider: { 0 },
+      recordingElapsedProvider: { 41 },
+      livePreviewProvider: { display },
+      onContentHeightChange: { log.record($0) },
+      usesPreviewLayout: usesPreviewLayout,
+      lockState: lockState,
+      noticeState: noticeState,
+      initialPreview: display
+    )
+
+    let host = NSHostingView(rootView: view.frame(width: Self.previewWidth))
+    let frame = NSRect(x: 0, y: 0, width: Self.previewWidth, height: startingHeight)
+    let window = NSWindow(
+      contentRect: frame, styleMask: [.borderless], backing: .buffered, defer: false)
+    window.contentView = host
+    host.frame = frame
+    host.layoutSubtreeIfNeeded()
+    window.displayIfNeeded()
+
+    // The GeometryReader reports on appear. If it never did, the measurement is
+    // absent rather than wrong, and an empty array must not read as a height.
+    let height = try #require(
+      log.reported.last,
+      """
+      the view never reported a height — the GeometryReader in RecordingOverlayView \
+      did not run, so this measurement is missing rather than failing
+      """)
+    return height
+  }
+
+  private static let oneLine = "the quarterly numbers came in"
+  private static let threeLines = String(
+    repeating: "the quarterly numbers came in ahead of plan ", count: 2)
+  private static let pastTheCap = String(
+    repeating: "the quarterly numbers came in ahead of plan ", count: 8)
+
+  // MARK: - The defect
+
+  @Test("the same words measure the same height whatever height the box was already at")
+  func heightDoesNotDependOnTheCurrentPanelHeight() throws {
+    // 65 is roughly one line's ideal; 125 is the five-line cap. A box that has
+    // just shown a long sentence sits at the latter when the sentence retracts.
+    let atCompact = try measuredHeight(showing: .text(Self.oneLine), inPanelOfHeight: 65)
+    let atTall = try measuredHeight(showing: .text(Self.oneLine), inPanelOfHeight: 125)
+
+    #expect(
+      atCompact == atTall,
+      """
+      one line of preview text measured \(atCompact)pt in a compact box and \(atTall)pt \
+      in a tall one. The panel is sized from this measurement and this measurement is \
+      taken inside the panel, so the pair has no single answer and the box can rest at \
+      more than one size for the same words.
+      """)
+  }
+
+  @Test("a box that grew to the cap comes back down when the text retracts")
+  func theBoxShrinksAgain() throws {
+    let tall = try measuredHeight(showing: .text(Self.pastTheCap), inPanelOfHeight: 125)
+    let retracted = try measuredHeight(showing: .text(Self.oneLine), inPanelOfHeight: tall)
+
+    #expect(
+      retracted < tall,
+      """
+      after the text retracted from \(Self.pastTheCap.count) characters to \
+      \(Self.oneLine.count), the box still measured \(retracted)pt against \(tall)pt. \
+      The recognizer revises its in-flight segment and LivePreviewTextBound trims the \
+      front, so shorter text is ordinary mid-dictation behaviour, not an edge case.
+      """)
+  }
+
+  // MARK: - Two-way controls
+  //
+  // Without these the suite passes against a view hard-coded to one height, which
+  // is the failure the fix itself could introduce.
+
+  @Test("more text is still a taller box")
+  func heightStillTracksTheText() throws {
+    let one = try measuredHeight(showing: .text(Self.oneLine), inPanelOfHeight: 65)
+    let three = try measuredHeight(showing: .text(Self.threeLines), inPanelOfHeight: 65)
+
+    #expect(
+      three > one,
+      """
+      \(Self.threeLines.count) characters measured \(three)pt against \(one)pt for \
+      \(Self.oneLine.count) — the box stopped growing with its content
+      """)
+  }
+
+  @Test("growth stops at the five-line cap")
+  func growthStopsAtTheCap() throws {
+    let three = try measuredHeight(showing: .text(Self.threeLines), inPanelOfHeight: 65)
+    let past = try measuredHeight(showing: .text(Self.pastTheCap), inPanelOfHeight: 65)
+    let wayPast = try measuredHeight(
+      showing: .text(Self.pastTheCap + Self.pastTheCap), inPanelOfHeight: 65)
+
+    #expect(past > three, "the cap is below three lines — growth stopped too early")
+    #expect(
+      past == wayPast,
+      """
+      doubling the text past the cap changed the height from \(past)pt to \(wayPast)pt, \
+      so the five-line rule is not holding
+      """)
+  }
+
+  // MARK: - The other display states share the measurement
+
+  @Test(
+    "every display state measures independently of the panel height",
+    arguments: RecordingOverlayPreviewSizingTests.displayStates)
+  func everyStateIsProposalIndependent(state: LivePreviewDisplay) throws {
+    let atCompact = try measuredHeight(showing: state, inPanelOfHeight: 65)
+    let atTall = try measuredHeight(showing: state, inPanelOfHeight: 125)
+
+    #expect(
+      atCompact == atTall,
+      "\(state) measured \(atCompact)pt compact and \(atTall)pt tall")
+  }
+
+  /// `.unavailable` is a real two-line state and is what a new user sees most —
+  /// first use of a language, below macOS 26, or a missing pack.
+  nonisolated static let displayStates: [LivePreviewDisplay] = [
+    .waiting,
+    .unavailable("On-screen preview does not support this language yet."),
+    .text("the quarterly numbers came in"),
+  ]
+
+  @Test("the notice banner shares the measurement and must not reintroduce the dependence")
+  func noticeBannerIsProposalIndependent() throws {
+    let atCompact = try measuredHeight(
+      showing: .text(Self.oneLine), inPanelOfHeight: 65,
+      notice: "Recording stops in one minute.")
+    let atTall = try measuredHeight(
+      showing: .text(Self.oneLine), inPanelOfHeight: 160,
+      notice: "Recording stops in one minute.")
+
+    #expect(atCompact == atTall, "with a notice showing: \(atCompact)pt vs \(atTall)pt")
+  }
+
+  // MARK: - The protected capsule
+
+  /// The 185pt non-preview capsule is out of scope for #2198 and the founder is
+  /// redesigning it separately. Every modifier on `RecordingOverlayView`'s root is
+  /// rendered by BOTH layouts, so a fix aimed at the preview reaches it unless it
+  /// is gated — see the plan's §3d shared-root table.
+  @Test("the non-preview capsule keeps reporting nothing")
+  func nonPreviewLayoutReportsNoHeight() throws {
+    let log = HeightLog()
+    let view = RecordingOverlayView(
+      audioLevelProvider: { 0 },
+      recordingElapsedProvider: { 41 },
+      livePreviewProvider: { .off },
+      onContentHeightChange: { log.record($0) },
+      usesPreviewLayout: false,
+      lockState: OverlayLockState(),
+      noticeState: OverlayNoticeState(),
+      initialPreview: .off
+    )
+    let host = NSHostingView(rootView: view.frame(width: 185, height: 92))
+    let frame = NSRect(x: 0, y: 0, width: 185, height: 92)
+    let window = NSWindow(
+      contentRect: frame, styleMask: [.borderless], backing: .buffered, defer: false)
+    window.contentView = host
+    host.frame = frame
+    host.layoutSubtreeIfNeeded()
+    window.displayIfNeeded()
+
+    // Production wires a no-op callback for the non-preview layout
+    // (`createPanel`), so this suite's own instrumentation is the only reader.
+    // What matters is that the view still lays out at the fixed frame it is given.
+    #expect(host.frame.height == 92, "the non-preview capsule's frame moved")
+  }
+}


### PR DESCRIPTION
Chunk A of #2198. The preview box changed size when nothing had changed, and it could only ever grow.
No redesign here — that is #2202, #2203 and #2204.

Part of #2198.

## The defect

One defect produced both symptoms: the panel is sized FROM a measurement that is taken INSIDE the panel.

`previewText`'s `.frame(maxHeight:)` grows to its cap under a large proposal, so the capsule stretched into
whatever room the panel offered. `showPanel(fitToContent:)` asks `NSHostingView.fittingSize` — an IDEAL
height that tracks the text — while every later resize came from a `GeometryReader` measuring the
laid-out capsule. Two different questions, so the same words could rest at more than one height, and
nothing pulled the height back down.

Measured on the **production** view, driven through its own `onContentHeightChange`:

| | before | after |
|---|---|---|
| one line in a 65pt panel | 65pt | 65pt |
| one line in a 125pt panel | **125pt** | 65pt |
| after the text retracts from six lines to one | **125pt, unchanged** | 65pt |
| one / three / six-plus lines | 65 / 80 / 125 | 65 / 80 / 125 |

The last row is the control: growth and the five-line cap are unaffected.

The retraction case is a real user path, not a contrived one — the recognizer revises its in-flight segment
constantly and `LivePreviewTextBound` trims the front, so shorter text mid-dictation is ordinary.

## What changed

**A1, measurement.** `.fixedSize(horizontal: false, vertical: usesPreviewLayout)` makes the stack report
its ideal height whatever it is offered, which is the same question `fitToContent` asks at creation — so
the two sizing paths agree. Placed after both paddings and before both backgrounds, which is where it was
measured; moving it either side measures a different view.

**A2, motion.** The container animation selects `nil` for the preview layout. `audioLevel` is repolled
every 50 ms, so it fired ~20 times a second, and a container animation animates whatever else changed in
the same update — including the text, and so the height. The rainbow hairline holds steady under the
preview pill instead of running a permanent two-second opacity loop.

**Instrumentation.** `resizeRecordingPanel` now logs every accepted resize. It logged nothing before, so
"the box holds still" had no receipt any instrument could read. Placed after `setFrame` so the drag-latch
ordering on `lastProgrammaticOrigin` is untouched.

**One doc comment corrected.** The display is `.off` until the polling task is first scheduled, not "for
one 50 ms poll" — the task reads its providers before its first sleep, so the old wording named a duration
the code does not have.

## Isolation

**Every modifier on `RecordingOverlayView`'s root is rendered by BOTH layouts**, and the 185pt capsule is
out of scope for #2198 (the founder is redesigning it separately). Both changes are gated on
`usesPreviewLayout`, which is the single isolation switch.

`OverlayCapsuleBackground` has **eight** call sites and only one is the preview, so the `.capsule` default
is byte-identical for the polishing pill, cold-start notice, distress variant and four others. The same
opacity block also exists in `DistressCapsuleBackground`; the edit was scoped to the one struct after a
first attempt matched both.

Plan §3d enumerates the whole shared-root class — twelve surfaces, six gated, one already gated, one
preview-only, four verbatim. Two grounded-review rounds each found one member of it before it was
enumerated by hand.

## Evidence

`RecordingOverlayPreviewSizingTests` drives the **production** `RecordingOverlayView` through the exact
closure `createPanel` wires to `resizeRecordingPanel`. It is deliberately not a copy of the modifier
stack: the defect was first found with an offscreen replica, and a guard written the same way would stay
green while the shipped panel stayed broken.

It went RED against the parent commit on both defect cases (65 vs 125, and 125 vs 125 after retraction)
and green after — stronger evidence than a synthetic mutant, because the failure is the real one. Both
directions are covered: more text is still a taller box, and growth still stops at five lines, so a view
pinned to one height would fail.

It also caught two states the plan had not listed: `.unavailable` (65 vs 80) and the #1060 notice banner
(85 vs 145). Both share the measurement and both are fixed by the same change.

`initialPreview:` seeds the view's `@State` so the suite measures a known display state on the first
layout pass. The alternative was waiting for the 50 ms poll, which is inferring "the subject is done" from
elapsed time in a suite whose subject is what the height does over time. Production never passes it and
the poll overwrites it on the first tick.

## Lanes

Debug 6179, Release 5638, zero failures. Per-bundle lines reconcile against both totals exactly
(5975 + 204 and 5434 + 204), so no second writer inflated the counts.

## Still owed on this chunk

Live UAT, which is the only thing that can confirm the visual half — that the box looks still while
someone speaks. Needs the dev app slot and a Debug build.
