### PR TITLE
fix(paste): stop the false paste alarms, and fix the one real paste bug

### DIFF
--- a/Sources/EnviousWisprCore/Transcript.swift
+++ b/Sources/EnviousWisprCore/Transcript.swift
@@ -63,6 +63,13 @@ public struct ExecutionMetrics: Codable, Sendable {
   public var casingOracleClosuresCompleted: Int?
   public var casingOracleClosureMaxMs: Double?
   public var pastePayloadKind: String?
+  /// - `axDeclineReason`: WHY the Tier 1 accessibility route did not deliver, a
+  ///   closed set. Nil when it did. `not_attempted_*` values are decided before
+  ///   the write is called and are the majority (#1332).
+  /// - `axSettability`: both settability answers as one token, so the
+  ///   DISAGREEMENT between them can be grouped on without a join.
+  public var axDeclineReason: String?
+  public var axSettability: String?
   public var languageResolutionSource: String?
   public var languageConfidenceBucket: String?
   public var targetApp: String?
@@ -184,6 +191,8 @@ public struct ExecutionMetrics: Codable, Sendable {
     caretCaptureRetryMs: Double? = nil,
     repairRules: String? = nil,
     pastePayloadKind: String? = nil,
+    axDeclineReason: String? = nil,
+    axSettability: String? = nil,
     languageResolutionSource: String? = nil,
     languageConfidenceBucket: String? = nil,
     targetApp: String? = nil,
@@ -241,6 +250,8 @@ public struct ExecutionMetrics: Codable, Sendable {
     self.caretCaptureRetryMs = caretCaptureRetryMs
     self.repairRules = repairRules
     self.pastePayloadKind = pastePayloadKind
+    self.axDeclineReason = axDeclineReason
+    self.axSettability = axSettability
     self.languageResolutionSource = languageResolutionSource
     self.languageConfidenceBucket = languageConfidenceBucket
     self.targetApp = targetApp

--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -1130,6 +1130,8 @@ struct KernelFinalizationWiring {
       caretCaptureRetryMs: outcome.caretCaptureRetryMs,
       repairRules: outcome.repairRules,
       pastePayloadKind: outcome.pasteResult?.submittedPayload?.rawValue,
+      axDeclineReason: outcome.pasteResult?.axDeclineReason,
+      axSettability: outcome.pasteResult?.axSettability,
       // #1921: carried through unchanged. Each hop transports exactly what the
       // previous one produced — no normalising, no substituting a default —
       // because a value that is quietly rewritten in transit is worse than one

--- a/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
+++ b/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
@@ -520,6 +520,11 @@ internal final class PasteCascadeExecutor {
           // Scenario A: no paste target. Leave the payload on the clipboard;
           // Tier 3 overlay follows.
           menuProbe = .noTarget
+        case .depthLimited:
+          // We stopped looking before the tree ran out. Not a confirmed
+          // refusal, and delivery is unaffected — this behaves exactly as
+          // `.unreadable` does here (#1332).
+          menuProbe = .depthLimited
         case .unreadable:
           // Menu bar (or traversal) AX read failed — unknown, not a confirmed
           // refusal (#1435).
@@ -633,12 +638,18 @@ internal final class PasteCascadeExecutor {
     /// An AX read failed somewhere in the probe (menu bar, traversal, or
     /// enabled-state) — unknown, NOT a confirmed refusal (#1435).
     case unreadable
+    /// The traversal hit its own depth bound with menus it never opened —
+    /// unknown, and unknown for a DIFFERENT reason than `.unreadable`: nothing
+    /// failed, we stopped. Kept separate so #1332's suppression projection can
+    /// be measured rather than assumed.
+    case depthLimited
 
     var focusClassLabel: String {
       switch self {
       case .targetEnabled: return "non_text_with_paste_target"
       case .noTarget: return "no_paste_target"
       case .unreadable: return "non_text_menu_unreadable"
+      case .depthLimited: return "non_text_menu_depth_limit"
       }
     }
   }

--- a/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
+++ b/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
@@ -701,7 +701,10 @@ internal final class PasteCascadeExecutor {
         focusClass: focusClass
       )
       if Self.isExpectedNonTextRefusal(
-        focus: focus, roleSource: diagnostics.roleSource, focusClass: focusClass
+        tiersAttempted: tierStrings,
+        focus: focus,
+        focusClass: focusClass,
+        targetBundleID: bundle
       ) {
         SentryBreadcrumb.add(
           stage: "paste",
@@ -766,28 +769,56 @@ internal final class PasteCascadeExecutor {
     }
   }
 
-  /// True when the cascade confidently identified the focused target,
-  /// correctly determined it isn't a text field, AND the Tier 2c menu probe
-  /// positively confirmed no real paste target exists — a working-as-intended
-  /// decline, not a failure. False in every other case keeps the existing
-  /// alert-creating path, since anything short of that full confirmation is
-  /// a case that could indicate a real, scaling defect (#1430).
+  /// Whether a clipboard-only outcome is a CONFIRMED correct refusal, and so
+  /// belongs on the counted breadcrumb channel rather than the alerting error
+  /// channel (#1430, narrowed #1332). False in every other case, because
+  /// anything short of full confirmation could be a real, scaling defect.
   ///
-  /// Requires exact confirmation (`focusClass == "no_paste_target"`) rather
-  /// than defaulting an absent probe result to "no target": `canAttemptKeyPaste`
-  /// is always false for `.nonText`, so Tier 2c's menu probe is the ONLY paste
-  /// attempt for non-text targets, and `focusClass` is nil whenever that probe
-  /// never ran or never resolved — activation timeout, a terminated target
-  /// app, or no target app captured at all (Codex code-diff review r2) — none
-  /// of which is a confirmed refusal. `"non_text_with_paste_target"` means the
-  /// probe found a real, enabled paste target and pressing it failed — also a
-  /// real failure, not a refusal (Codex code-diff review r1). Any other/future
-  /// focusClass label fails closed the same way, matching the roleSource
-  /// invariant above.
+  /// Requires exact confirmation (`focusClass == "no_paste_target"`) rather than
+  /// defaulting an absent probe result to "no target": `canAttemptKeyPaste` is
+  /// always false for `.nonText`, so Tier 2c's menu probe is the ONLY paste
+  /// attempt for a non-text target, and `focusClass` is nil whenever that probe
+  /// never ran or never resolved — activation timeout, a terminated target app,
+  /// or no target app captured at all — none of which is a confirmed refusal
+  /// (Codex code-diff review r2, #1430). `"non_text_with_paste_target"` means
+  /// the probe found a real, enabled paste target and pressing it failed, which
+  /// is a real failure rather than a refusal (Codex code-diff review r1). Any
+  /// other or future label fails closed the same way.
+  ///
+  /// `roleSource` was a parameter until #1332 and is deliberately gone rather
+  /// than merely unread. It required the ELEMENT's role to have been captured
+  /// before trusting the MENU probe's answer, which lets one instrument's
+  /// failure suppress the other instrument's positive result. The menu probe is
+  /// independent evidence: since #1435 `no_paste_target` means the app's own
+  /// menu bar was read and its Paste command is confirmed absent or confirmed
+  /// disabled, and since this issue's Chunk 1a a search that merely ran out of
+  /// depth reports `non_text_menu_depth_limit` instead of masquerading as a
+  /// confirmation. Removing the parameter rather than ignoring it turns the
+  /// stale `unrecognizedRoleSourceFailsClosed` test into a compile error rather
+  /// than a test that keeps passing under a comment describing a literal
+  /// nothing reads.
+  ///
+  /// KNOWN RESIDUAL, stated so this is not read as claiming more than it
+  /// proves: a real text target whose role read fails classifies as `.nonText`,
+  /// and if that app ALSO reports its Paste command absent or disabled it is
+  /// silenced here. A failed role read is NO answer rather than a wrong one, so
+  /// the residual needs one independent role-read failure plus a misleading menu
+  /// answer. Chunks 0 and 1a narrow it to that; they do not eliminate it.
   internal static func isExpectedNonTextRefusal(
-    focus: PasteFocusClassification, roleSource: String, focusClass: String?
+    tiersAttempted: [String],
+    focus: PasteFocusClassification,
+    focusClass: String?,
+    targetBundleID: String?
   ) -> Bool {
-    focus == .nonText && roleSource == "captured_target" && focusClass == "no_paste_target"
+    // `paste_failed` should mean a paste we ATTEMPTED that failed. Every real
+    // route appends its tier before trying (ax_direct, cgevent, applescript,
+    // menu_paste), so a non-empty list is proof something was attempted and
+    // this is not a refusal at all.
+    guard tiersAttempted.isEmpty else { return false }
+    // The Mac is locked. There is no session to paste into, and no reading of
+    // the focused element can make one appear.
+    if targetBundleID == "com.apple.loginwindow" { return true }
+    return focus == .nonText && focusClass == "no_paste_target"
   }
 
   internal static func clipboardOnlyTelemetryExtra(

--- a/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
+++ b/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
@@ -81,6 +81,10 @@ internal struct PasteDeliveryResult {
   /// no route reached its write (#1785). Records what was SUBMITTED, never
   /// proof of what landed — Tier 2 only proves Cmd+V was posted.
   var submittedPayload: PasteService.PastePayloadKind?
+  /// #1332. Why the Tier 1 fast route did not deliver, and both settability
+  /// answers as one token. Nil when Tier 1 delivered.
+  var axDeclineReason: String?
+  var axSettability: String?
 
   var pasteTierLabel: String {
     if case .clipboardOnlyAccessibilityDenied = outcome {
@@ -311,6 +315,18 @@ internal final class PasteCascadeExecutor {
       targetDiagnostics = .missing
     }
     let canAttemptKeyPaste = classification.canAttemptKeyPaste
+    // Why Tier 1 did not run, decided HERE rather than inside the write. These
+    // are the majority of declines — a reason set covering only the write's own
+    // exits would be nil for most of them (#1332).
+    var axDeclineReason: PasteService.AXDeclineReason? = {
+      if !axTrusted { return .accessibilityDenied }
+      switch classification {
+      case .textField: return nil  // Tier 1 runs; the write reports its own.
+      case .missing: return .focusMissing
+      case .nonText: return .focusNonText
+      }
+    }()
+    var axSettability: PasteService.AXSettability?
     // Which payload was submitted by the route that last attempted a write.
     // Nil until one does. A later route may legitimately overwrite this: Tier 1
     // can attempt a write, PROVE nothing landed, and hand off to Tier 2, whose
@@ -341,6 +357,8 @@ internal final class PasteCascadeExecutor {
         requireFocusedElementMatch: request.targetElementIsRetried)
       let disposition = dispositionForAXDirect(insert.outcome)
       submittedKind = insert.submitted
+      axDeclineReason = insert.declineReason
+      axSettability = insert.settability
       axAllowsRetry = disposition.allowsAutomaticRetry
       switch disposition {
       case .delivered:
@@ -527,7 +545,11 @@ internal final class PasteCascadeExecutor {
           menuProbe = .depthLimited
         case .unreadable:
           // Menu bar (or traversal) AX read failed — unknown, not a confirmed
-          // refusal (#1435).
+          // refusal (#1435). Since #1332 this ALSO includes the one-second AX
+          // messaging timeout, which was never in force before. A slow or
+          // unknown probe deliberately keeps full alerting rather than becoming
+          // `no_paste_target`, so this branch can raise the alert count on a
+          // slow app even though the change as a whole reduces it.
           menuProbe = .unreadable
         }
       } else {
@@ -622,10 +644,13 @@ internal final class PasteCascadeExecutor {
     }
 
     emitPasteTelemetry(
-      outcome: outcome, tierFailures: tierFailures, focusClass: menuProbe?.focusClassLabel)
+      outcome: outcome, tierFailures: tierFailures, focusClass: menuProbe?.focusClassLabel,
+      axDeclineReason: axDeclineReason?.rawValue,
+      axSettability: axSettability?.telemetryValue)
 
     return PasteDeliveryResult(
-      tier: tier, durationMs: durationMs, outcome: outcome, submittedPayload: submittedKind)
+      tier: tier, durationMs: durationMs, outcome: outcome, submittedPayload: submittedKind,
+      axDeclineReason: axDeclineReason?.rawValue, axSettability: axSettability?.telemetryValue)
   }
 
   /// #729 Tier 2c menu-paste probe outcome. Drives `paste.focus_class`.
@@ -684,7 +709,8 @@ internal final class PasteCascadeExecutor {
   /// Fires Sentry captureError for non-delivered outcomes. Owned by the cascade
   /// so overlay UI and telemetry both derive from the same typed outcome.
   private func emitPasteTelemetry(
-    outcome: PasteDeliveryOutcome, tierFailures: [String: String], focusClass: String?
+    outcome: PasteDeliveryOutcome, tierFailures: [String: String], focusClass: String?,
+    axDeclineReason: String? = nil, axSettability: String? = nil
   ) {
     switch outcome {
     case .delivered:
@@ -692,6 +718,8 @@ internal final class PasteCascadeExecutor {
     case .clipboardOnly(let tiers, let focus, let bundle, let accessibilityTrusted, let diagnostics):
       let tierStrings = tiers.map(\.rawValue)
       let extra = Self.clipboardOnlyTelemetryExtra(
+        axDeclineReason: axDeclineReason,
+        axSettability: axSettability,
         tiersAttempted: tierStrings,
         focus: focus,
         targetBundleID: bundle,
@@ -728,6 +756,8 @@ internal final class PasteCascadeExecutor {
       // `paste.tier_failures["ax_direct"] == "unverifiable"`.
       let tierStrings = [PasteTier.axDirect.rawValue]
       let extra = Self.clipboardOnlyTelemetryExtra(
+        axDeclineReason: axDeclineReason,
+        axSettability: axSettability,
         tiersAttempted: tierStrings,
         focus: .textField,
         targetBundleID: bundle,
@@ -822,6 +852,8 @@ internal final class PasteCascadeExecutor {
   }
 
   internal static func clipboardOnlyTelemetryExtra(
+    axDeclineReason: String? = nil,
+    axSettability: String? = nil,
     tiersAttempted: [String],
     focus: PasteFocusClassification,
     targetBundleID: String?,
@@ -842,6 +874,12 @@ internal final class PasteCascadeExecutor {
       "paste.target_element_role_source": targetDiagnostics.roleSource,
       "paste.target_element_subrole_status": targetDiagnostics.subroleStatus,
     ]
+    // #1332: WHY the fast route declined, and both settability answers as one
+    // token. Genuinely OMITTED when nil rather than sent as a placeholder — a
+    // sentinel string would be indistinguishable from a real value in every
+    // query built on this, and older event shapes must stay unchanged.
+    if let axDeclineReason { extra["paste.ax_decline_reason"] = axDeclineReason }
+    if let axSettability { extra["paste.ax_settability"] = axSettability }
     // #729: present only when the Tier 2c menu probe actually ran (Scenario
     // A/B discriminator). Absent on .textField/.missing and on activation
     // timeout before probing.

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -279,6 +279,9 @@ public enum PasteService {
       _ = AXUIElementCopyAttributeValue(axElement, kAXSubroleAttribute as CFString, &subroleRef)
       let subrole = (subroleRef as? String) ?? "<nil>"
 
+      // One reader for both answers (#1332). The third attribute keeps its own
+      // local read because nothing decides on it; it is diagnostic only.
+      let settability = readAXSettability(of: axElement)
       func settable(_ attr: String) -> Bool {
         var s: DarwinBoolean = false
         let err = AXUIElementIsAttributeSettable(axElement, attr as CFString, &s)
@@ -287,10 +290,78 @@ public enum PasteService {
 
       let msg =
         "AXDiag capture: app=\(bundleId) role=\(role) subrole=\(subrole) "
-        + "valueSettable=\(settable("AXValue")) " + "selTextSettable=\(settable("AXSelectedText")) "
+        + "valueSettable=\(settability.value.rawValue) "
+        + "selTextSettable=\(settability.selectedText.rawValue) "
         + "selRangeSettable=\(settable("AXSelectedTextRange"))"
       await AppLogger.shared.log(msg, level: .info, category: "AXDiag")
     }
+  }
+
+  /// Whether a foreign app will accept a write to one of its attributes.
+  ///
+  /// THREE states, not a Bool, and that is the whole point. `AXUIElementIsAttributeSettable`
+  /// can fail to answer, and collapsing "it said no" together with "it did not
+  /// say" is what turns a defensive check into a self-inflicted regression:
+  /// Tier 1 is 18x faster than the keyboard route, so treating an unanswered
+  /// query as a refusal would drop apps onto the slow path for a transient AX
+  /// hiccup (#1332).
+  public enum AXSettableState: String, Equatable, Sendable {
+    case settable
+    case notSettable = "not_settable"
+    case unreadable
+  }
+
+  /// Both settability answers, sampled together at one moment.
+  ///
+  /// Kept as a PAIR because the interesting fact is the DISAGREEMENT. Measured
+  /// live on 2026-08-19: iTerm2 reports `AXValue` settable and `AXSelectedText`
+  /// NOT settable, 60 of 60 samples, and Tier 1 has never once succeeded there
+  /// in 944 pastes. WhatsApp and the loginwindow password field answer the same
+  /// way. TextEdit and Chrome answer settable to both, and Tier 1 wins there.
+  public struct AXSettability: Equatable, Sendable {
+    public let value: AXSettableState
+    public let selectedText: AXSettableState
+
+    /// One closed token rather than two fields, so a telemetry consumer can
+    /// group on the combination without joining.
+    public var telemetryValue: String {
+      "value_\(value.rawValue)__selected_text_\(selectedText.rawValue)"
+    }
+  }
+
+  /// The single reader for both answers.
+  ///
+  /// `AXDiag` and the Tier 1 guard used to ask this question separately, with
+  /// different attributes and different collapsing of a failed query. This is
+  /// the consolidation site. Its result is NOT cached across the gap between
+  /// capture and insertion: `AXDiag` samples at capture time and the write
+  /// happens later, so a stored answer would be about a different moment.
+  package static func readAXSettability(of element: AXUIElement) -> AXSettability {
+    func read(_ attribute: CFString) -> AXSettableState {
+      var answer: DarwinBoolean = false
+      guard AXUIElementIsAttributeSettable(element, attribute, &answer) == .success else {
+        return .unreadable
+      }
+      return answer.boolValue ? .settable : .notSettable
+    }
+    return AXSettability(
+      value: read(kAXValueAttribute as CFString),
+      selectedText: read(kAXSelectedTextAttribute as CFString)
+    )
+  }
+
+  /// Whether a Tier 1 write must be skipped for this element.
+  ///
+  /// Pure, so the one decision this adds is testable without a live AX element —
+  /// matching the precedent `classifyInsertOutcome`, `dispositionForAXDirect`
+  /// and `classifyPasteFocus` already set in this file, where the AX round trips
+  /// are live-only and the DECISION they feed is the part a test can hold.
+  ///
+  /// Only `.notSettable` refuses. `.unreadable` proceeds, because an unanswered
+  /// query is not a refusal and treating it as one would cost the fast route on
+  /// a transient AX failure.
+  package static func tier1IsRefused(by settability: AXSettability) -> Bool {
+    settability.selectedText == .notSettable
   }
 
   /// Outcome of a Tier 1 Accessibility insertion attempt.
@@ -1164,14 +1235,20 @@ public enum PasteService {
     }
     guard textRoles.contains(role) else { return (.noMutation, nil) }
 
-    // Verify the element is writable (not read-only).
-    var settableRef: DarwinBoolean = false
-    let settableErr = AXUIElementIsAttributeSettable(
-      element,
-      kAXValueAttribute as CFString,
-      &settableRef
-    )
-    guard settableErr == .success, settableRef.boolValue else { return (.noMutation, nil) }
+    // Verify the element will accept the write we are about to make.
+    //
+    // The retired check asked about `kAXValueAttribute` while the write below
+    // targets `kAXSelectedTextAttribute`. Those are different questions and real
+    // apps answer them differently: iTerm2 says yes to the first and no to the
+    // second, and then returns `.success` from a write that changes nothing —
+    // measured 225 times out of 225 on 2026-08-19. Tier 1 has never once
+    // succeeded there in 944 production pastes (#1332).
+    //
+    // Only a POSITIVE refusal skips. An unanswerable query proceeds exactly as
+    // before, because collapsing "no" together with "did not say" would drop an
+    // app onto the 18x-slower route for a transient AX failure.
+    let settability = readAXSettability(of: element)
+    if tier1IsRefused(by: settability) { return (.noMutation, nil) }
 
     // Everything needed to verify the result must be readable BEFORE we write.
     // The retired code wrote first and only then discovered it could not read

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -1434,6 +1434,11 @@ public enum PasteService {
   /// Distinguishes "read fine, no matching item" from "couldn't read the menu
   /// bar at all" — collapsing both into one `nil` hid a real AX failure behind
   /// the same telemetry label as a genuine no-target refusal (#1435).
+  /// Per-element cap on accessibility messaging while probing a foreign app's
+  /// menu bar. One second, unchanged from what the retired `"AXTimeout"` write
+  /// intended; the difference is that this one takes effect.
+  private static let menuProbeAXTimeout: Float = 1.0
+
   public enum MenuItemProbeResult {
     case found(AXUIElement)
     case confirmedAbsent
@@ -1456,7 +1461,13 @@ public enum PasteService {
   public static func findPasteMenuItem(pid: pid_t) -> MenuItemProbeResult {
     let app = AXUIElementCreateApplication(pid)
     // Cap AX round-trips so a misbehaving app can't hang the paste path.
-    AXUIElementSetAttributeValue(app, "AXTimeout" as CFString, Float(1.0) as CFTypeRef)
+    //
+    // `AXUIElementSetMessagingTimeout` is the API for this. The retired line
+    // wrote a non-existent "AXTimeout" ATTRIBUTE and discarded the result, so
+    // the cap this comment promises has never actually been in force — found by
+    // the chunk-1a build review, #1332. The timeout binds ONE element, so every
+    // handle we message has to be bounded, not just this one.
+    _ = AXUIElementSetMessagingTimeout(app, menuProbeAXTimeout)
     var menuBarRef: CFTypeRef?
     guard
       AXUIElementCopyAttributeValue(app, kAXMenuBarAttribute as CFString, &menuBarRef) == .success,
@@ -1473,6 +1484,9 @@ public enum PasteService {
   /// bug this type exists to fix, one level down (#1435 grounded review r1).
   @MainActor
   private static func firstPasteItem(in element: AXUIElement, depth: Int) -> MenuItemProbeResult {
+    // Descendant handles do NOT inherit an ancestor's messaging timeout.
+    _ = AXUIElementSetMessagingTimeout(element, menuProbeAXTimeout)
+
     // menu bar(0) → menu-bar-item(1) → menu(2) → menu-item(3); allow a little
     // slack for apps that nest an extra group, but stay bounded.
     guard depth <= 4 else { return .confirmedAbsent }
@@ -1494,6 +1508,7 @@ public enum PasteService {
 
     var encounteredUnreadableBranch = false
     for child in children {
+      _ = AXUIElementSetMessagingTimeout(child, menuProbeAXTimeout)
       var cmdCharRef: CFTypeRef?
       let commandRead = AXUIElementCopyAttributeValue(
         child, "AXMenuItemCmdChar" as CFString, &cmdCharRef)

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -1442,6 +1442,13 @@ public enum PasteService {
   public enum MenuItemProbeResult {
     case found(AXUIElement)
     case confirmedAbsent
+    /// The bounded traversal reached its depth limit with children it never
+    /// opened. Distinct from `.unreadable` (an AX read FAILED) and from
+    /// `.confirmedAbsent` (we looked everywhere and there is no ⌘V item),
+    /// because this one is our own limit rather than the app's answer — and
+    /// because keeping it separate is what makes the alert-suppression
+    /// projection in #1332 measurable instead of assumed.
+    case depthLimited
     case unreadable
   }
 
@@ -1482,14 +1489,16 @@ public enum PasteService {
   /// (`.attributeUnsupported`/`.noValue`, the normal shape for a leaf item
   /// with no children or no shortcut) — a deeper traversal failure is the same
   /// bug this type exists to fix, one level down (#1435 grounded review r1).
+  ///
+  /// Returns `.depthLimited` when the bound is reached with children still
+  /// unopened. THREE kinds of not-found, deliberately not collapsed: the app
+  /// answered and there is none (`.confirmedAbsent`), a read failed
+  /// (`.unreadable`), or we stopped first (`.depthLimited`). Only the first is
+  /// evidence, and #1332's alert suppression is allowed to rely on it alone.
   @MainActor
   private static func firstPasteItem(in element: AXUIElement, depth: Int) -> MenuItemProbeResult {
     // Descendant handles do NOT inherit an ancestor's messaging timeout.
     _ = AXUIElementSetMessagingTimeout(element, menuProbeAXTimeout)
-
-    // menu bar(0) → menu-bar-item(1) → menu(2) → menu-item(3); allow a little
-    // slack for apps that nest an extra group, but stay bounded.
-    guard depth <= 4 else { return .confirmedAbsent }
 
     var childrenRef: CFTypeRef?
     let childrenRead = AXUIElementCopyAttributeValue(
@@ -1506,7 +1515,21 @@ public enum PasteService {
       return .unreadable
     }
 
+    // menu bar(0) → menu-bar-item(1) → menu(2) → menu-item(3); allow a little
+    // slack for apps that nest an extra group, but stay bounded.
+    //
+    // The bound is read AFTER the children, because the two answers it has to
+    // separate are "nothing left to look at" and "more to look at, and I
+    // stopped". Returning `.confirmedAbsent` for both is a fail-OPEN in the one
+    // function whose job is to tell confirmed from unknown: an app nesting its
+    // Paste command deeper than this would be reported as having none
+    // (#1332, Codex grounded review r2).
+    guard depth <= 4 else {
+      return children.isEmpty ? .confirmedAbsent : .depthLimited
+    }
+
     var encounteredUnreadableBranch = false
+    var encounteredDepthLimit = false
     for child in children {
       _ = AXUIElementSetMessagingTimeout(child, menuProbeAXTimeout)
       var cmdCharRef: CFTypeRef?
@@ -1539,10 +1562,15 @@ public enum PasteService {
       switch firstPasteItem(in: child, depth: depth + 1) {
       case .found(let item): return .found(item)
       case .confirmedAbsent: break
+      case .depthLimited: encounteredDepthLimit = true
       case .unreadable: encounteredUnreadableBranch = true
       }
     }
-    return encounteredUnreadableBranch ? .unreadable : .confirmedAbsent
+    // A failed READ outranks a self-imposed limit: if any branch was unreadable
+    // the whole answer is unknown for the stronger reason, and collapsing the
+    // two would lose that.
+    if encounteredUnreadableBranch { return .unreadable }
+    return encounteredDepthLimit ? .depthLimited : .confirmedAbsent
   }
 
   /// Whether an AX menu item is currently enabled. Apps disable Edit > Paste

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -350,6 +350,16 @@ public enum PasteService {
     )
   }
 
+  /// The reason that corresponds to a classified outcome, so the mapping lives
+  /// in ONE place rather than at each construction site.
+  package static func declineReason(for outcome: AXInsertOutcome) -> AXDeclineReason? {
+    switch outcome {
+    case .verified: return nil
+    case .noMutation: return .noMutation
+    case .unverifiable: return .unverifiable
+    }
+  }
+
   /// Whether a Tier 1 write must be skipped for this element.
   ///
   /// Pure, so the one decision this adds is testable without a live AX element —
@@ -362,6 +372,68 @@ public enum PasteService {
   /// a transient AX failure.
   package static func tier1IsRefused(by settability: AXSettability) -> Bool {
     settability.selectedText == .notSettable
+  }
+
+  /// Why a Tier 1 accessibility write did not deliver.
+  ///
+  /// Tier 1 is 18x faster than the keyboard route (p50 15ms against 267ms) and
+  /// loses 76% of the time even when the caret was read in a real text field —
+  /// 7,295 declines a month, and until #1332 not one of them recorded a cause.
+  /// This is that cause, as a closed set so it can be grouped on.
+  ///
+  /// The `notAttempted*` cases are decided by the CASCADE before this function
+  /// is called, and they are the majority: a reason set covering only this
+  /// function's own exits would be nil for most declines, which is the same
+  /// silent gap it exists to close.
+  public enum AXDeclineReason: String, Equatable, Sendable {
+    case accessibilityDenied = "not_attempted_accessibility_denied"
+    case focusMissing = "not_attempted_focus_missing"
+    case focusNonText = "not_attempted_focus_non_text"
+    case roleUnreadable = "role_unreadable"
+    case roleNotText = "role_not_text"
+    case selectedTextNotSettable = "selected_text_not_settable"
+    case countUnreadableOrInvalid = "count_unreadable_or_invalid"
+    case rangeUnreadable = "range_unreadable"
+    case rangeInvalid = "range_invalid"
+    case beforeImageUnreadableOrIncomplete = "before_image_unreadable_or_incomplete"
+    case focusUnconfirmed = "focus_unconfirmed"
+    case setFailed = "set_failed"
+    case noMutation = "no_mutation"
+    case unverifiable
+  }
+
+  /// What a Tier 1 attempt produced, including the evidence behind it.
+  ///
+  /// Replaces a `(outcome, submitted)` tuple. The decision evidence used to be
+  /// discarded at this return boundary, which is why nothing downstream could
+  /// say why the fast route lost.
+  package struct AXInsertResult: Sendable {
+    package let outcome: AXInsertOutcome
+    package let submitted: PastePayloadKind?
+    package let declineReason: AXDeclineReason?
+    package let settability: AXSettability?
+
+    package init(
+      outcome: AXInsertOutcome,
+      submitted: PastePayloadKind?,
+      declineReason: AXDeclineReason?,
+      settability: AXSettability?
+    ) {
+      self.outcome = outcome
+      self.submitted = submitted
+      self.declineReason = declineReason
+      self.settability = settability
+    }
+
+    /// A decline before any write was attempted. `.noMutation` is the outcome
+    /// in every case, because nothing was mutated — the reason is what tells
+    /// the two dozen ways of getting here apart.
+    static func declined(
+      _ reason: AXDeclineReason, settability: AXSettability? = nil
+    ) -> AXInsertResult {
+      AXInsertResult(
+        outcome: .noMutation, submitted: nil, declineReason: reason, settability: settability)
+    }
   }
 
   /// Outcome of a Tier 1 Accessibility insertion attempt.
@@ -1222,7 +1294,7 @@ public enum PasteService {
     context: CaretContext? = nil,
     element: AXUIElement,
     requireFocusedElementMatch: Bool = false
-  ) -> (outcome: AXInsertOutcome, submitted: PastePayloadKind?) {
+  ) -> AXInsertResult {
     // Verify the element is a text field or text area.
     var roleRef: CFTypeRef?
     let roleErr = AXUIElementCopyAttributeValue(
@@ -1231,9 +1303,9 @@ public enum PasteService {
       &roleRef
     )
     guard roleErr == .success, let role = roleRef as? String else {
-      return (.noMutation, nil)
+      return .declined(.roleUnreadable)
     }
-    guard textRoles.contains(role) else { return (.noMutation, nil) }
+    guard textRoles.contains(role) else { return .declined(.roleNotText) }
 
     // Verify the element will accept the write we are about to make.
     //
@@ -1248,7 +1320,9 @@ public enum PasteService {
     // before, because collapsing "no" together with "did not say" would drop an
     // app onto the 18x-slower route for a transient AX failure.
     let settability = readAXSettability(of: element)
-    if tier1IsRefused(by: settability) { return (.noMutation, nil) }
+    if tier1IsRefused(by: settability) {
+      return .declined(.selectedTextNotSettable, settability: settability)
+    }
 
     // Everything needed to verify the result must be readable BEFORE we write.
     // The retired code wrote first and only then discovered it could not read
@@ -1262,9 +1336,11 @@ public enum PasteService {
       &charCountBefore
     )
     guard let countBefore = charCountBefore as? Int, countBefore >= 0 else {
-      return (.noMutation, nil)
+      return .declined(.countUnreadableOrInvalid, settability: settability)
     }
-    guard let rangeBefore = selectedRange(of: element) else { return (.noMutation, nil) }
+    guard let rangeBefore = selectedRange(of: element) else {
+      return .declined(.rangeUnreadable, settability: settability)
+    }
     // A foreign app can report a range that does not fit its own field. Reject
     // rather than compute verification windows from impossible values.
     guard
@@ -1272,7 +1348,7 @@ public enum PasteService {
       rangeBefore.length >= 0,
       rangeBefore.location <= countBefore,
       rangeBefore.length <= countBefore - rangeBefore.location
-    else { return (.noMutation, nil) }
+    else { return .declined(.rangeInvalid, settability: settability) }
 
     // The payload choice, made from the range this function just read rather
     // than from anything the caller measured earlier. A contextual candidate is
@@ -1313,7 +1389,7 @@ public enum PasteService {
     } else {
       // Without a trustworthy before-image, a successful AX call could never be
       // proven harmless. Bail while nothing has been mutated; Tier 2 is safe.
-      return (.noMutation, nil)
+      return .declined(.beforeImageUnreadableOrIncomplete, settability: settability)
     }
 
     // The payload choice, made from the range AND the surrounding text this
@@ -1354,7 +1430,7 @@ public enum PasteService {
           requireFocusedElementMatch: true,
           isFocused: freshFocusedElement(matching: element) != nil)
       else {
-        return (.noMutation, nil)
+        return .declined(.focusUnconfirmed, settability: settability)
       }
     }
 
@@ -1364,7 +1440,7 @@ public enum PasteService {
       kAXSelectedTextAttribute as CFString,
       text as CFTypeRef
     )
-    guard err == .success else { return (.noMutation, nil) }
+    guard err == .success else { return .declined(.setFailed, settability: settability) }
 
     // From here the write may have landed, so every remaining failure is
     // `unverifiable`, never `noMutation`.
@@ -1406,7 +1482,12 @@ public enum PasteService {
     // The write was attempted with this payload, whatever the verification says
     // afterwards — including an outcome later classified `unverifiable`, where
     // the text may already be in the document.
-    return (outcome, payload.kind)
+    return AXInsertResult(
+      outcome: outcome,
+      submitted: payload.kind,
+      declineReason: Self.declineReason(for: outcome),
+      settability: settability
+    )
   }
 
   // MARK: - Tier 2: CGEvent Cmd+V

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -282,6 +282,8 @@ public final class TelemetryService {
           caretCaptureRetryMs: m?.caretCaptureRetryMs,
           repairRules: m?.repairRules,
           payloadKind: m?.pastePayloadKind,
+          axDeclineReason: m?.axDeclineReason,
+          axSettability: m?.axSettability,
           languageResolutionSource: m?.languageResolutionSource,
           languageConfidenceBucket: m?.languageConfidenceBucket,
           casingDeadlinePhase: m?.casingDeadlinePhase,
@@ -2046,6 +2048,10 @@ public final class TelemetryService {
     public let caretCaptureRetryMs: Double?
     public let repairRules: String?
     public let payloadKind: String?
+    /// #1332. Why the Tier 1 route declined, and the settability pair. Both
+    /// omit-when-nil, so every prior shape is unchanged.
+    public let axDeclineReason: String?
+    public let axSettability: String?
     /// #1921. Why the language question got its answer, and how confident. A
     /// closed category and a band, never a language code or a raw score — this
     /// says how the gate behaved without shipping what language each user
@@ -2070,6 +2076,8 @@ public final class TelemetryService {
       caretCaptureRetryMs: Double? = nil,
       repairRules: String? = nil,
       payloadKind: String? = nil,
+      axDeclineReason: String? = nil,
+      axSettability: String? = nil,
       languageResolutionSource: String? = nil,
       languageConfidenceBucket: String? = nil,
       casingDeadlinePhase: String? = nil,
@@ -2087,6 +2095,8 @@ public final class TelemetryService {
       self.caretCaptureRetryMs = caretCaptureRetryMs
       self.repairRules = repairRules
       self.payloadKind = payloadKind
+      self.axDeclineReason = axDeclineReason
+      self.axSettability = axSettability
       self.languageResolutionSource = languageResolutionSource
       self.languageConfidenceBucket = languageConfidenceBucket
       self.casingDeadlinePhase = casingDeadlinePhase
@@ -2110,6 +2120,8 @@ public final class TelemetryService {
       if let caretCaptureRetryMs { out["caret_capture_retry_ms"] = caretCaptureRetryMs }
       if let repairRules { out["repair_rules"] = repairRules }
       if let payloadKind { out["payload_kind"] = payloadKind }
+      if let axDeclineReason { out["ax_decline_reason"] = axDeclineReason }
+      if let axSettability { out["ax_settability"] = axSettability }
       if let languageResolutionSource {
         out["language_resolution_source"] = languageResolutionSource
       }

--- a/Tests/EnviousWisprTests/Pipeline/PasteTelemetryPayloadTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PasteTelemetryPayloadTests.swift
@@ -215,6 +215,9 @@ struct PasteTelemetryPayloadTests {
     #expect(
       PasteCascadeExecutor.MenuPasteProbe.unreadable.focusClassLabel
         == "non_text_menu_unreadable")
+    #expect(
+      PasteCascadeExecutor.MenuPasteProbe.depthLimited.focusClassLabel
+        == "non_text_menu_depth_limit")
   }
 
   @Test("unreadable menu probe keeps full alerting (#1435)")

--- a/Tests/EnviousWisprTests/Pipeline/PasteTelemetryPayloadTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PasteTelemetryPayloadTests.swift
@@ -147,6 +147,28 @@ struct PasteTelemetryPayloadTests {
   /// compile error rather than a row · real paste target keeps alerting ->
   /// rows 4 AND 12, because the real press-failure path always carries the
   /// `menu_paste` tier that row 4 alone omits.
+  /// #1332 whole-diff review: the code comment claims these are OMITTED when
+  /// nil. A sentinel string would be indistinguishable from a real value in
+  /// every query built on this, so the claim needs a test rather than a comment.
+  @Test("the #1332 diagnostic keys are absent when nil and present when supplied")
+  func diagnosticKeysOmitWhenNil() {
+    let absent = PasteCascadeExecutor.clipboardOnlyTelemetryExtra(
+      tiersAttempted: [], focus: .nonText, targetBundleID: "com.apple.finder",
+      accessibilityTrusted: true, targetDiagnostics: .unavailable, tierFailures: [:])
+    #expect(absent["paste.ax_decline_reason"] == nil)
+    #expect(absent["paste.ax_settability"] == nil)
+
+    let present = PasteCascadeExecutor.clipboardOnlyTelemetryExtra(
+      axDeclineReason: "selected_text_not_settable",
+      axSettability: "value_settable__selected_text_not_settable",
+      tiersAttempted: [], focus: .nonText, targetBundleID: "com.apple.finder",
+      accessibilityTrusted: true, targetDiagnostics: .unavailable, tierFailures: [:])
+    #expect(present["paste.ax_decline_reason"] as? String == "selected_text_not_settable")
+    #expect(
+      present["paste.ax_settability"] as? String
+        == "value_settable__selected_text_not_settable")
+  }
+
   @Test("expected-refusal predicate fails closed across documented decision boundaries")
   func expectedRefusalMatrix() {
     let cases: [([String], PasteFocusClassification, String?, String?, Bool)] = [

--- a/Tests/EnviousWisprTests/Pipeline/PasteTelemetryPayloadTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PasteTelemetryPayloadTests.swift
@@ -127,83 +127,59 @@ struct PasteTelemetryPayloadTests {
     assertNoContentLikeKeys(noTarget)
   }
 
-  @Test("absent menu probe keeps full alerting, does not default to downgrade (Codex code-diff r2)")
-  func absentMenuProbeKeepsAlerting() {
-    // focusClass is nil whenever Tier 2c's probe never ran or never resolved:
-    // activation timeout, a terminated target app, or no target app captured
-    // at all. None of these confirm "no real target" -- only an explicit
-    // "no_paste_target" result does, so nil must NOT default to a downgrade.
-    #expect(
-      PasteCascadeExecutor.isExpectedNonTextRefusal(
-        focus: .nonText, roleSource: "captured_target", focusClass: nil
-      ) == false
-    )
-  }
-
-  @Test("confident non-text refusal with a confirmed-no-target probe downgrades")
-  func confirmedNoTargetProbeDowngrades() {
-    #expect(
-      PasteCascadeExecutor.isExpectedNonTextRefusal(
-        focus: .nonText, roleSource: "captured_target", focusClass: "no_paste_target"
-      ) == true
-    )
-  }
-
-  @Test("menu probe finding a real paste target keeps full alerting (Codex code-diff r1)")
-  func menuProbeFoundRealTargetKeepsAlerting() {
-    // Tier 2c found an enabled Edit > Paste item and pressing it failed
-    // (tierFailures["menu_paste"] == "press_failed") -- a real paste failure,
-    // not a no-target refusal, even though the earlier AX role read said
-    // non-text with high confidence.
-    #expect(
-      PasteCascadeExecutor.isExpectedNonTextRefusal(
-        focus: .nonText, roleSource: "captured_target",
-        focusClass: "non_text_with_paste_target"
-      ) == false
-    )
-  }
-
-  @Test("failed role identification keeps full alerting")
-  func failedRoleIdentificationKeepsAlerting() {
-    #expect(
-      PasteCascadeExecutor.isExpectedNonTextRefusal(
-        focus: .nonText, roleSource: "unavailable", focusClass: nil
-      ) == false
-    )
-  }
-
-  @Test("missing target keeps full alerting regardless of roleSource")
-  func missingTargetKeepsAlerting() {
-    #expect(
-      PasteCascadeExecutor.isExpectedNonTextRefusal(
-        focus: .missing, roleSource: "captured_target", focusClass: nil
-      ) == false
-    )
-  }
-
-  @Test("text field focus keeps full alerting regardless of roleSource")
-  func textFieldFocusKeepsAlerting() {
-    #expect(
-      PasteCascadeExecutor.isExpectedNonTextRefusal(
-        focus: .textField, roleSource: "captured_target", focusClass: nil
-      ) == false
-    )
-  }
-
-  @Test("unrecognized roleSource string fails closed to full alerting")
-  func unrecognizedRoleSourceFailsClosed() {
-    // Guards against an unrelated future rename of the "captured_target"
-    // literal elsewhere silently reopening the false-positive noise (#1430).
-    #expect(
-      PasteCascadeExecutor.isExpectedNonTextRefusal(
-        focus: .nonText, roleSource: "ax_success", focusClass: nil
-      ) == false
-    )
-    #expect(
-      PasteCascadeExecutor.isExpectedNonTextRefusal(
-        focus: .nonText, roleSource: "", focusClass: nil
-      ) == false
-    )
+  /// One decision-boundary table replaces nine per-case tests (#1332). Not a
+  /// generated cross-product — four arguments do not enumerate — so it is
+  /// boundary rows, each ACCEPTED one paired with a near-identical REJECTED one
+  /// so a predicate that stopped classifying anything cannot look clean.
+  ///
+  /// Rows 2 and 11 pin combinations that are NOT reachable today (appending
+  /// `menu_paste` requires an enabled item, and a CGEvent failure becomes
+  /// `.cgEventCreationFailed` and bypasses this predicate). They are kept as
+  /// defence in depth and are deliberately NOT counted as evidence that the
+  /// guard binds reachable behaviour — rows 12 and 13 do that.
+  ///
+  /// What the retired tests protected, and where each now lives:
+  /// absent menu probe -> row 3 · confirmed-no-target downgrades -> row 1 ·
+  /// failed role identification -> row 3 (roleSource is no longer an input) ·
+  /// missing target -> row 8 · text-field focus -> row 9 ·
+  /// unreadable menu probe -> row 5 · unrecognised focusClass -> row 7 ·
+  /// unrecognised roleSource -> removed by the predicate signature, so it is a
+  /// compile error rather than a row · real paste target keeps alerting ->
+  /// rows 4 AND 12, because the real press-failure path always carries the
+  /// `menu_paste` tier that row 4 alone omits.
+  @Test("expected-refusal predicate fails closed across documented decision boundaries")
+  func expectedRefusalMatrix() {
+    let cases: [([String], PasteFocusClassification, String?, String?, Bool)] = [
+      ([], .nonText, "no_paste_target", "com.apple.finder", true),
+      (["menu_paste"], .nonText, "no_paste_target", "com.apple.finder", false),
+      ([], .nonText, nil, "com.apple.finder", false),
+      ([], .nonText, "non_text_with_paste_target", "com.apple.finder", false),
+      ([], .nonText, "non_text_menu_unreadable", "com.apple.finder", false),
+      ([], .nonText, "non_text_menu_depth_limit", "com.apple.finder", false),
+      ([], .nonText, "some_future_label", "com.apple.finder", false),
+      ([], .missing, "no_paste_target", "com.apple.finder", false),
+      ([], .textField, "no_paste_target", "com.apple.finder", false),
+      ([], .missing, nil, "com.apple.loginwindow", true),
+      (["cgevent"], .missing, nil, "com.apple.loginwindow", false),
+      // Reachable states the first eleven rows missed (Codex chunk-1b review).
+      // A menu press that FAILED still carries its tier and an enabled-target
+      // label, which is the real shape of the retired real-paste-target test.
+      (["menu_paste"], .nonText, "non_text_with_paste_target", "com.apple.finder", false),
+      // An attempted paste on the LOCK SCREEN: binds the empty-tiers guard's
+      // precedence over the lock-screen acceptance, which nothing else pins.
+      (["applescript"], .missing, nil, "com.apple.loginwindow", false),
+    ]
+    for (tiers, focus, focusClass, bundle, expected) in cases {
+      #expect(
+        PasteCascadeExecutor.isExpectedNonTextRefusal(
+          tiersAttempted: tiers,
+          focus: focus,
+          focusClass: focusClass,
+          targetBundleID: bundle
+        ) == expected,
+        "tiers=\(tiers) focus=\(focus) focusClass=\(focusClass ?? "nil") bundle=\(bundle ?? "nil")"
+      )
+    }
   }
 
   @Test("menu probe outcomes map to stable focus-class labels")
@@ -220,27 +196,7 @@ struct PasteTelemetryPayloadTests {
         == "non_text_menu_depth_limit")
   }
 
-  @Test("unreadable menu probe keeps full alerting (#1435)")
-  func unreadableMenuProbeKeepsAlerting() {
-    let focusClass = PasteCascadeExecutor.MenuPasteProbe.unreadable.focusClassLabel
-    #expect(
-      PasteCascadeExecutor.isExpectedNonTextRefusal(
-        focus: .nonText, roleSource: "captured_target", focusClass: focusClass
-      ) == false
-    )
-  }
 
-  @Test("unrecognized focusClass string fails closed to full alerting")
-  func unrecognizedFocusClassFailsClosed() {
-    // Guards the same fail-closed invariant for the focusClass corroboration:
-    // an unrelated future label added to MenuPasteProbe must not silently
-    // reopen the false-positive noise by being mistaken for "no target".
-    #expect(
-      PasteCascadeExecutor.isExpectedNonTextRefusal(
-        focus: .nonText, roleSource: "captured_target", focusClass: "some_future_label"
-      ) == false
-    )
-  }
 
   private func assertNoContentLikeKeys(_ extra: [String: Any]) {
     for key in extra.keys {

--- a/Tests/EnviousWisprTests/Services/PasteSettabilityTests.swift
+++ b/Tests/EnviousWisprTests/Services/PasteSettabilityTests.swift
@@ -63,3 +63,71 @@ struct PasteSettabilityTests {
         == "value_unreadable__selected_text_settable")
   }
 }
+
+/// #1332 Chunk 3. The decline reason is a TELEMETRY CONTRACT: its raw values are
+/// grouped on in PostHog and Sentry, so a rename is a silent data break, not a
+/// refactor. Observability rather than product outcome — when these fail, a
+/// dashboard lies; no user notices.
+@Suite("PasteService.AXDeclineReason", .tags(.observabilityContract))
+struct PasteDeclineReasonTests {
+
+  @Test("a verified write has no decline reason")
+  func verifiedHasNoReason() {
+    #expect(PasteService.declineReason(for: .verified) == nil)
+  }
+
+  @Test("the two non-delivering outcomes map to distinct reasons")
+  func outcomesMapDistinctly() {
+    // These are opposite instructions to the cascade — one authorises a second
+    // paste, the other forbids it — so they must never collapse in the data.
+    #expect(PasteService.declineReason(for: .noMutation) == .noMutation)
+    #expect(PasteService.declineReason(for: .unverifiable) == .unverifiable)
+    #expect(
+      PasteService.declineReason(for: .noMutation)
+        != PasteService.declineReason(for: .unverifiable))
+  }
+
+  @Test("every one of the fourteen raw values is pinned exactly")
+  func rawValuesAreStable() {
+    // Frozen because they are grouped on in PostHog and Sentry, so a rename is a
+    // silent data break rather than a refactor. All fourteen, not a sample: the
+    // earlier version pinned five and would have let a rename of the other nine
+    // through (chunk whole-diff review).
+    //
+    // The `not_attempted_` prefix is load bearing. Those declines happen before
+    // the write is ever called and are the MAJORITY, so a query must separate
+    // them without a join.
+    let expected: [(PasteService.AXDeclineReason, String)] = [
+      (.accessibilityDenied, "not_attempted_accessibility_denied"),
+      (.focusMissing, "not_attempted_focus_missing"),
+      (.focusNonText, "not_attempted_focus_non_text"),
+      (.roleUnreadable, "role_unreadable"),
+      (.roleNotText, "role_not_text"),
+      (.selectedTextNotSettable, "selected_text_not_settable"),
+      (.countUnreadableOrInvalid, "count_unreadable_or_invalid"),
+      (.rangeUnreadable, "range_unreadable"),
+      (.rangeInvalid, "range_invalid"),
+      (.beforeImageUnreadableOrIncomplete, "before_image_unreadable_or_incomplete"),
+      (.focusUnconfirmed, "focus_unconfirmed"),
+      (.setFailed, "set_failed"),
+      (.noMutation, "no_mutation"),
+      (.unverifiable, "unverifiable"),
+    ]
+    for (reason, rawValue) in expected {
+      #expect(reason.rawValue == rawValue, "raw value drifted for \(reason)")
+    }
+    #expect(expected.count == 14)
+  }
+
+  @Test("no two reasons share a raw value")
+  func rawValuesAreUnique() {
+    // A duplicate would silently merge two causes in every chart built on this.
+    let all: [PasteService.AXDeclineReason] = [
+      .accessibilityDenied, .focusMissing, .focusNonText, .roleUnreadable, .roleNotText,
+      .selectedTextNotSettable, .countUnreadableOrInvalid, .rangeUnreadable, .rangeInvalid,
+      .beforeImageUnreadableOrIncomplete, .focusUnconfirmed, .setFailed, .noMutation, .unverifiable,
+    ]
+    #expect(Set(all.map(\.rawValue)).count == all.count)
+    #expect(all.count == 14)
+  }
+}

--- a/Tests/EnviousWisprTests/Services/PasteSettabilityTests.swift
+++ b/Tests/EnviousWisprTests/Services/PasteSettabilityTests.swift
@@ -1,0 +1,65 @@
+import Testing
+
+@testable import EnviousWisprServices
+
+/// #1332 Chunk 2. The Tier 1 write targets `kAXSelectedTextAttribute` while its
+/// guard asked about `kAXValueAttribute`. These cover the DECISION that fixes
+/// that; the AX round trips themselves are live-only, matching the precedent in
+/// `PasteAccessibilityInsertionTests`.
+@Suite("PasteService.tier1IsRefused", .tags(.productOutcome))
+struct PasteSettabilityTests {
+
+  private func settability(
+    value: PasteService.AXSettableState,
+    selectedText: PasteService.AXSettableState
+  ) -> PasteService.AXSettability {
+    PasteService.AXSettability(value: value, selectedText: selectedText)
+  }
+
+  @Test("a positive refusal on the WRITTEN attribute skips Tier 1")
+  func positiveRefusalSkips() {
+    // iTerm2, measured 60/60 on 2026-08-19: value settable, selected text not.
+    // Tier 1 has never succeeded there in 944 production pastes.
+    #expect(
+      PasteService.tier1IsRefused(
+        by: settability(value: .settable, selectedText: .notSettable)) == true)
+  }
+
+  @Test("an UNANSWERED query does not skip — this is the whole point of three states")
+  func unreadableProceeds() {
+    // Collapsing "did not say" into "said no" would drop an app onto the
+    // 18x-slower route for a transient AX failure. Both shapes must proceed.
+    #expect(
+      PasteService.tier1IsRefused(
+        by: settability(value: .settable, selectedText: .unreadable)) == false)
+    #expect(
+      PasteService.tier1IsRefused(
+        by: settability(value: .unreadable, selectedText: .unreadable)) == false)
+  }
+
+  @Test("the attribute we do NOT write cannot refuse on its own")
+  func valueAttributeDoesNotDecide() {
+    // Ghostty reports AXValue not settable and still produced 2 ax_direct wins
+    // in 30 days, so this axis must not gate the write we actually make.
+    #expect(
+      PasteService.tier1IsRefused(
+        by: settability(value: .notSettable, selectedText: .settable)) == false)
+  }
+
+  @Test("both settable proceeds — TextEdit and Chrome, where Tier 1 wins")
+  func bothSettableProceeds() {
+    #expect(
+      PasteService.tier1IsRefused(
+        by: settability(value: .settable, selectedText: .settable)) == false)
+  }
+
+  @Test("the telemetry token carries BOTH answers, because the disagreement is the finding")
+  func telemetryTokenPairsBothAnswers() {
+    #expect(
+      settability(value: .settable, selectedText: .notSettable).telemetryValue
+        == "value_settable__selected_text_not_settable")
+    #expect(
+      settability(value: .unreadable, selectedText: .settable).telemetryValue
+        == "value_unreadable__selected_text_settable")
+  }
+}


### PR DESCRIPTION
Founder scope, verbatim: *"I want to know if there's truly a problem with our pasting. If there is, then
let's fix it. If there isn't, then let's stop the false alarms."*

**Both. There is a real problem and it is small — 18 outcomes across 7 people in 30 days — and 44 of the
84 alerts today's classifier still considers alert-worthy are the app correctly declining and then filing
an error about it.**

## The five commits, and why they are in this order

| | Commit | What |
|---|---|---|
| 1 | `51c389ad` | The menu-probe timeout was never in force |
| 2 | `fb8fd8ec` | The menu search said "confirmed absent" when it had stopped looking |
| 3 | `0589421b` | **Stop filing an error when the app has confirmed it cannot paste** |
| 4 | `f6e6341c` | **Ask the app about the attribute we are about to write** |
| 5 | `1974dce2` | Record WHY the fast insertion route declined |

3 and 4 are the founder's two asks. 1 and 2 exist because 3 was not safe without them — Codex rejected the
first version of this work for exactly the reason it rejected a similar change in August, and it was
right both times.

**Commit 2 is the one that unblocked it.** `firstPasteItem` returned `.confirmedAbsent` on reaching its
depth bound, without having opened the menus below it — a fail-open in the one function whose job is to
tell a confirmed answer from an unknown one. Silencing alerts on the strength of that label was unsafe
while it could be produced by a search that never finished.

**Commit 1 is a pre-existing defect this work surfaced.** The code capped its accessibility round-trips by
writing an `"AXTimeout"` attribute and discarding the result. There is no such attribute — verified
against the SDK, `AXUIElement.h:402` declares `AXUIElementSetMessagingTimeout`. The cap has been
decorative since #729.

## Evidence

Per-event analysis of all 143 Sentry events for `ENVIOUSWISPR-24`, 30 days, production:

| What it is | Events | People |
|---|---:|---:|
| Menu bar read, app has no enabled Paste command, cascade correctly declined | 103 | 30 |
| Menu bar unreadable, or the probe never ran | 22 | 19 |
| **A paste route ran and did not verifiably land** | **18** | **7** |

The real failures are 17 `ax_direct=unverifiable` plus one activation timeout. 12 of the 17 are iTerm2.

**Live measurement on the dev machine**, reimplementing `insertViaAccessibility` including its
`AXStringForRange` parameterized read: iTerm2 reports `AXValue` settable and `AXSelectedText` NOT settable,
60/60 samples; the write returns `.success` **225/225** with the character count and whole field
byte-identical afterwards. Tier 1 has never once succeeded there in 944 production pastes.

PostHog, current builds, 30 days: `cgevent` 24,994 at p50 267 ms · `ax_direct` 2,319 at p50 **15 ms** ·
`menu_paste` 921 · `clipboard_only` 505. With a readable caret in a real text field, Tier 1 still loses
76% of the time — 7,295 declines a month with no recorded cause until commit 5.

## What this does NOT claim

**The alert reduction is expected, not guaranteed.** Replaying the 30-day set takes 84 alert-worthy
outcomes to 40, and 55 to 30 on current builds. But commits 1 and 2 mean a slow app can now produce
`.unreadable` or `.depthLimited` where it previously answered, and commit 3 correctly keeps both alerting.
The replayed events never experienced either behaviour, so the replay cannot prove a net reduction.
Commit 2's new `non_text_menu_depth_limit` label is what supplies the real number after one release.

**Commit 3 can still silence a real failure**, when an app's role read fails AND its menu answer is
misleading as evidence about the focused target. Commits 1 and 2 narrow that to one silence plus one
misleading answer; they do not eliminate it. Stated in the predicate's own doc comment, not only here.

**Commits 1 and 4 can change delivery.** A now-enforced timeout can cut off a slow menu press; a refused
element enters the fallback cascade and usually takes the keyboard route ~250 ms later, but activation
failure can end at a manual paste.

**The 17 production failures were not reproduced.** 225 live attempts produced zero. Commit 4 rests on an
argument about what we should not attempt, not on a reproduction.

## Validation

- Full Debug lane **6,184 tests**, `TEST SUCCEEDED`, per-bundle counts reconciling exactly (5,980 + 204).
- Workers `node --test`: daily-report 263/263, weekly-digest 73/73, sentry-triage 87/87.
- **Five mutants**, each restored and each restore verified: depth-limit label collapsed → caught;
  empty-tiers guard removed → caught, but its rows were then shown unreachable so it is not cited as
  evidence; guard precedence inverted → caught on the reachable lock-screen row; settability gate reverted
  to `kAXValueAttribute` → caught on exactly the two cases where the attributes disagree.
- Two new suites, both class-tagged. Nine hand-written predicate tests replaced by a thirteen-row
  decision-boundary table; each retired test names the row that now covers it.
- Eleven Codex rounds: five on the plan, five per-chunk, one whole-diff.

## Live UAT — required before merge

1. iTerm2 at a shell prompt → words arrive, `tier=cgevent`, no `ax_direct` attempted.
2. TextEdit, blank document → `tier=ax_direct`. **The control that commit 4 did not disable the fast route.**
3. Apple Notes, Bear, Gemini, OpenAI chat → must stay `ax_direct`. **1,298 Tier 1 wins between them and
   none has been sampled. If any reports a refusal, commit 4 is wrong and does not ship.**
4. **Microsoft Word** → must still deliver by the menu route. 134 of its 145 pastes take it, and commit 1
   is the reason this is on the list.
5. Finder frontmost → clipboard notice, and NO error filed.
6. Lock screen → no error filed.

## Related

Refs #1332. Split out and not in scope: #2196 (first-dictation experience, 100 people), #2197 (the 200 ms
clipboard-restore wait inside paste latency). The `.axWriteUnverifiable` notice still says "press ⌘V" in
the one case where the text may already have landed; that needs typed presentation plumbing and is
deliberately not smuggled in here.
