### PR TITLE
Live Preview pill: rebuild the header, with a rainbow meter and the hands-free timer back (#2202)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
@@ -900,7 +900,19 @@ enum LivePreviewCopy {
   /// can include downloading an Apple speech model.
   static let preparing = "Getting the preview ready..."
   /// Shown in the pill while the preview is running but has not heard words yet.
+  ///
+  /// **Rendered by the CAPSULE layout only since #2202.** The preview pill's
+  /// header carries `listeningMode` instead, and showing both would greet a
+  /// first-time user with the same word twice in one small box.
   static let listening = "Listening..."
+  /// #2202: the preview header's state, hold-to-talk. Quiet and grey — you are
+  /// holding a key, it ends when you let go, and the state barely needs saying.
+  static let listeningMode = "Listening"
+  /// #2202: the preview header's state, hands-free. Carried on a filled badge
+  /// because this mode persists until the user presses again, and a size change
+  /// is a weak signal — you only notice it if you saw the other size a second
+  /// earlier.
+  static let handsFreeMode = "Hands-free"
   /// #2108. The universal preview model has not been downloaded. Names the
   /// action rather than the fault: nothing is broken, the user has simply not
   /// chosen to download it yet.

--- a/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
@@ -2561,7 +2561,17 @@ struct RecordingOverlayView: View {
           .foregroundStyle(.white.opacity(0.95))
           .multilineTextAlignment(.center)
           .fixedSize(horizontal: false, vertical: true)
-          .frame(maxWidth: 170)
+          // 170pt suits the 185pt capsule. The preview pill is 400pt wide, so the
+          // same cap would wrap a one-line warning into three inside a box with
+          // room to spare.
+          .frame(maxWidth: usesPreviewLayout ? .infinity : 170)
+          // #2202 row 4 of the shared-root table. The notice is rendered by BOTH
+          // layouts and its ONLY inset came from the shared root padding, which
+          // the preview now zeroes — so without this it sits flush against the
+          // pill's bottom edge. The header and the reading well each received
+          // replacement padding; this is the third section and it was missed.
+          .padding(.horizontal, usesPreviewLayout ? 16 : 0)
+          .padding(.bottom, usesPreviewLayout ? 12 : 0)
           .transition(.opacity)
       }
     }

--- a/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
@@ -2063,10 +2063,12 @@ struct SpectrumWheelIcon: View {
 /// the mark it replaces, and it means the meter's visual weight does not shift
 /// down the header as the level drops.
 ///
-/// Fixed height in every state, which is load-bearing rather than cosmetic: today
-/// hands-free scales the lips mark to 2x, and that is the single biggest height
-/// jump anywhere in the pill. A meter that occupies one strip whatever the mode is
-/// what lets the header stop changing size between hold-to-talk and hands-free.
+/// Fixed height in every state. This KEEPS a property rather than adding one: the
+/// capsule is already height-neutral across modes, because `scaleEffect` does not
+/// participate in layout (measured — `fittingSize` 95x44 at both 1.0 and 2.0).
+/// The 2x mark overflows its own slot visually and nothing resizes. A meter
+/// occupying one strip avoids reintroducing a real size change where the old
+/// design only ever had an apparent one.
 struct RainbowLevelMeter: View {
   /// Normalised audio level 0.0-1.0, polled every ~50 ms by the parent view. The
   /// same value `RainbowLipsIcon` reads, so this adds no timer and no new source.
@@ -2454,19 +2456,96 @@ struct RecordingOverlayView: View {
     _preview = State(initialValue: initialPreview)
   }
 
-  var body: some View {
-    VStack(spacing: 6) {
-      HStack(spacing: 10) {
-        // Rainbow lips icon — audio-reactive during recording.
-        // Scales to 2x in hands-free (locked) mode.
-        RainbowLipsIcon(size: 24, audioLevel: audioLevel)
-          .scaleEffect(lockState.isLocked ? 2.0 : 1.0)
+  /// #2202: the preview pill's header — timer hard left, live meter beside it,
+  /// recording mode on the right.
+  ///
+  /// **The badge buys CLARITY, not height stability — the first version of this
+  /// comment claimed the wrong thing.** It said the capsule's 2x mark was "the
+  /// single biggest height jump anywhere in the pill". It is not a height jump at
+  /// all: `scaleEffect` is a rendering transform and does not participate in
+  /// layout. Measured — an `HStack` holding a 24pt box reports `fittingSize`
+  /// 95x44 at `scaleEffect(1.0)` and 95x44 at `scaleEffect(2.0)`. The capsule is
+  /// already height-neutral across modes; the 2x mark overflows its own slot
+  /// visually and nothing resizes.
+  ///
+  /// What the badge actually fixes: a size change is a signal you can only read
+  /// by COMPARISON — you notice it only if you saw the other size a moment
+  /// earlier — while a badge naming the mode works the first time you see it.
+  /// This header is height-neutral across modes too, which is a property to KEEP
+  /// rather than one this chunk introduces.
+  ///
+  /// **The timer renders in both modes.** The capsule hides it when locked, which
+  /// is backwards: hands-free is the mode that runs for minutes, so it is the one
+  /// that needs a clock. Founder decision, 2026-08-19.
+  @ViewBuilder
+  private var previewHeader: some View {
+    HStack(spacing: 12) {
+      Text(FormattingConstants.formatDuration(elapsed))
+        .font(.system(size: 13, weight: .semibold, design: .monospaced))
+        .foregroundStyle(.white.opacity(0.94))
 
-        if !lockState.isLocked {
-          Text(FormattingConstants.formatDuration(elapsed))
-            .font(.system(size: 13, weight: .medium, design: .monospaced))
-            .foregroundStyle(.white)
-            .transition(.opacity)
+      RainbowLevelMeter(audioLevel: audioLevel)
+
+      Spacer(minLength: 8)
+
+      if lockState.isLocked {
+        // A filled badge, because the mode it announces persists until the user
+        // presses again. A size change is a weak signal — you only notice it if
+        // you saw the other size a second earlier.
+        HStack(spacing: 6) {
+          Circle()
+            .fill(Color.white.opacity(0.88))
+            .frame(width: 5, height: 5)
+          Text(LivePreviewCopy.handsFreeMode)
+        }
+        .font(.system(size: 11, weight: .semibold))
+        .foregroundStyle(.white.opacity(0.88))
+        .padding(.horizontal, 9)
+        .padding(.vertical, 3)
+        .background(Capsule().fill(Color.white.opacity(0.13)))
+        .transition(.opacity)
+      } else {
+        Text(LivePreviewCopy.listeningMode)
+          .font(.system(size: 11, weight: .semibold))
+          .foregroundStyle(.white.opacity(0.5))
+          .transition(.opacity)
+      }
+    }
+    .textCase(.uppercase)
+    .padding(.horizontal, 16)
+    .padding(.top, 9)
+    .padding(.bottom, 8)
+    .frame(height: Self.previewHeaderHeight)
+    .overlay(alignment: .bottom) {
+      Rectangle()
+        .fill(Color.white.opacity(0.09))
+        .frame(height: 0.5)
+    }
+  }
+
+  /// Fixed, so the header cannot change height between modes. Read by a test.
+  static let previewHeaderHeight: CGFloat = 34
+
+  var body: some View {
+    // #2202 row 1 of the shared-root table: the capsule wants 6pt between its
+    // stacked pieces; the preview puts a ruled header directly against its
+    // reading well and supplies its own spacing inside each section.
+    VStack(spacing: usesPreviewLayout ? 0 : 6) {
+      if usesPreviewLayout {
+        previewHeader
+      } else {
+        HStack(spacing: 10) {
+          // Rainbow lips icon — audio-reactive during recording.
+          // Scales to 2x in hands-free (locked) mode.
+          RainbowLipsIcon(size: 24, audioLevel: audioLevel)
+            .scaleEffect(lockState.isLocked ? 2.0 : 1.0)
+
+          if !lockState.isLocked {
+            Text(FormattingConstants.formatDuration(elapsed))
+              .font(.system(size: 13, weight: .medium, design: .monospaced))
+              .foregroundStyle(.white)
+              .transition(.opacity)
+          }
         }
       }
 
@@ -2509,8 +2588,14 @@ struct RecordingOverlayView: View {
       value: audioLevel
     )
     .animation(.easeInOut(duration: 0.25), value: noticeState.message)
-    .padding(.horizontal, 14)
-    .padding(.vertical, 10)
+    // #2202 row 8 of the shared-root table. The capsule keeps its uniform inset;
+    // the preview zeroes it and each section supplies its own, because a header
+    // strip over a reading well does not want one rectangle of padding wrapped
+    // around both. Migrated ATOMICALLY with the section padding above and below:
+    // split across two commits, whatever shipped in between would have had no
+    // insets at all.
+    .padding(.horizontal, usesPreviewLayout ? 0 : 14)
+    .padding(.vertical, usesPreviewLayout ? 0 : 10)
     // #2201: the preview pill's height must be a function of what it is SHOWING,
     // never of how tall it happens to be already.
     //
@@ -2578,7 +2663,17 @@ struct RecordingOverlayView: View {
     case .waiting:
       // One line, so the pill starts compact and the growth the user sees is their
       // own words arriving rather than space that was always reserved.
-      previewText(LivePreviewCopy.listening, dimmed: true, lines: 1)
+      //
+      // #2202: in the PREVIEW layout the header already says `Listening`, so
+      // repeating it here would greet a first-time user with the same word twice
+      // in one small box — worse than either alone. The well shows nothing and
+      // the pill stays one header tall until real words arrive. The capsule has
+      // no header, so it keeps the sentence.
+      if usesPreviewLayout {
+        previewText("", dimmed: true, lines: 1)
+      } else {
+        previewText(LivePreviewCopy.listening, dimmed: true, lines: 1)
+      }
     case .unavailable(let reason):
       // Say why rather than sitting blank. A blank preview reads as "it did not
       // hear me", which is the exact anxiety this feature exists to remove. Two
@@ -2622,6 +2717,15 @@ struct RecordingOverlayView: View {
       // height, which is what lets the pill still grow a line at a time.
       .frame(maxHeight: Self.previewHeight(lines: lines), alignment: .bottom)
       .clipped()
+      // #2202: the well's own inset, replacing what the shared root padding used
+      // to give it. **Outside the cap, deliberately.** Padding inserted before
+      // `.frame(maxHeight:)` is subtracted from the five-line viewport, so the
+      // box would clip at four-and-a-bit lines and the founder's five-line rule
+      // would quietly stop holding — a number that looks like it means lines
+      // while meaning something else.
+      .padding(.horizontal, usesPreviewLayout ? 16 : 0)
+      .padding(.top, usesPreviewLayout ? 12 : 0)
+      .padding(.bottom, usesPreviewLayout ? 15 : 0)
   }
 
   /// Height of `lines` lines of the preview font.

--- a/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
@@ -2046,6 +2046,102 @@ struct SpectrumWheelIcon: View {
 ///
 /// At silence (level ≈ 0) bars sit at their minimum compressed state (lips closed).
 /// At peak (level = 1.0) center bars reach maximum expansion (lips open/talking).
+/// #2202: the live level meter in the preview pill's header.
+///
+/// **Replaces the lips mark in THIS box only.** The mark stays everywhere else —
+/// the menu bar, the polishing pill, settings. Founder direction, 2026-08-19: it
+/// is a logo doing a meter's job, a square block of nine bars that has to be read
+/// as a picture before it reads as movement, and it occupies the left edge the
+/// timer should own. Nine bars on a baseline say "I can hear you" in a shape
+/// everyone knows from every recorder ever made.
+///
+/// Nine bars, nine brand spectrum colours in order, red through violet — the same
+/// palette and the same order as `RainbowLipsIcon`, so the two read as one family
+/// while the pill transitions between layouts.
+///
+/// **Symmetric about a centre line rather than growing off a floor.** That echoes
+/// the mark it replaces, and it means the meter's visual weight does not shift
+/// down the header as the level drops.
+///
+/// Fixed height in every state, which is load-bearing rather than cosmetic: today
+/// hands-free scales the lips mark to 2x, and that is the single biggest height
+/// jump anywhere in the pill. A meter that occupies one strip whatever the mode is
+/// what lets the header stop changing size between hold-to-talk and hands-free.
+struct RainbowLevelMeter: View {
+  /// Normalised audio level 0.0-1.0, polled every ~50 ms by the parent view. The
+  /// same value `RainbowLipsIcon` reads, so this adds no timer and no new source.
+  let audioLevel: Float
+
+  /// Height of the strip. Bars are drawn symmetrically about its middle.
+  var height: CGFloat = 16
+  var barWidth: CGFloat = 2.5
+  var spacing: CGFloat = 3
+
+  /// The brand spectrum, in order. Shared with `RainbowLipsIcon`'s bar table.
+  static let spectrum: [Color] = [
+    Color(red: 1.0, green: 0.165, blue: 0.251),  // #ff2a40 red
+    Color(red: 1.0, green: 0.549, blue: 0.0),  // #ff8c00 orange
+    Color(red: 1.0, green: 0.843, blue: 0.0),  // #ffd700 gold
+    Color(red: 0.678, green: 1.0, blue: 0.184),  // #adff2f lime
+    Color(red: 0.0, green: 0.98, blue: 0.604),  // #00fa9a spring
+    Color(red: 0.0, green: 1.0, blue: 1.0),  // #00ffff cyan
+    Color(red: 0.118, green: 0.565, blue: 1.0),  // #1e90ff blue
+    Color(red: 0.255, green: 0.412, blue: 0.882),  // #4169e1 royal
+    Color(red: 0.541, green: 0.169, blue: 0.886),  // #8a2be2 violet
+  ]
+
+  /// Per-bar sensitivity. Centre bars react most, edges least — the same
+  /// weighting `RainbowLipsIcon` uses, so both instruments agree about what the
+  /// same audio looks like.
+  static let sensitivity: [CGFloat] = [0.70, 0.80, 0.90, 0.95, 1.00, 0.95, 0.90, 0.80, 0.70]
+
+  /// Fraction of the strip a bar occupies at silence. Non-zero on purpose: a
+  /// meter that collapses to nothing between words reads as "it stopped hearing
+  /// me", which is the exact anxiety the preview exists to remove.
+  static let silenceFraction: CGFloat = 0.18
+
+  /// Additional fraction available at full level, for the most sensitive bar.
+  static let peakFraction: CGFloat = 0.82
+
+  /// Fraction of the strip bar `index` fills at `level`.
+  ///
+  /// `static` and `package`-visible so a test can assert the shape without
+  /// rendering: the property that matters is monotonic in level and clamped at
+  /// both ends, and a Canvas cannot be asked about that.
+  static func fill(index: Int, level: CGFloat) -> CGFloat {
+    let clamped = min(max(level, 0), 1)
+    let weight = sensitivity[min(max(index, 0), sensitivity.count - 1)]
+    return silenceFraction + peakFraction * clamped * weight
+  }
+
+  var body: some View {
+    let level = CGFloat(min(max(audioLevel, 0), 1))
+    Canvas { context, size in
+      for i in 0..<Self.spectrum.count {
+        let barHeight = size.height * Self.fill(index: i, level: level)
+        let x = CGFloat(i) * (barWidth + spacing)
+        let rect = CGRect(
+          x: x,
+          y: (size.height - barHeight) / 2,
+          width: barWidth,
+          height: barHeight
+        )
+        context.fill(
+          Path(roundedRect: rect, cornerRadius: barWidth / 2),
+          with: .color(Self.spectrum[i]))
+      }
+    }
+    .frame(width: Self.width(barWidth: barWidth, spacing: spacing), height: height)
+    .accessibilityHidden(true)
+  }
+
+  /// Total width for nine bars and eight gaps. Derived rather than a literal, so
+  /// the frame cannot drift from what the Canvas draws.
+  static func width(barWidth: CGFloat, spacing: CGFloat) -> CGFloat {
+    CGFloat(spectrum.count) * barWidth + CGFloat(spectrum.count - 1) * spacing
+  }
+}
+
 struct RainbowLipsIcon: View {
   let size: CGFloat
   /// Normalised audio level 0.0-1.0, updated every ~50 ms by the parent view.

--- a/Tests/EnviousWisprTests/App/RainbowLevelMeterTests.swift
+++ b/Tests/EnviousWisprTests/App/RainbowLevelMeterTests.swift
@@ -1,0 +1,114 @@
+import AppKit
+import SwiftUI
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #2202: the live level meter that replaces the lips mark in the preview pill's
+/// header.
+///
+/// A `Canvas` cannot be asked what it drew, so the geometry decision is extracted
+/// as a static function and pinned here — the same shape
+/// `RecordingOverlayPanelInheritedGeometryTests` uses for panel arithmetic, and
+/// for the same reason.
+///
+/// What these protect, stated so a later reader does not have to infer it: the
+/// meter is the ONLY thing in the new header that moves, so if it stops responding
+/// to the voice the pill silently becomes a static graphic that claims to be
+/// listening. That is a product outcome, not a drift guard.
+@MainActor
+@Suite(.tags(.productOutcome))
+struct RainbowLevelMeterTests {
+
+  init() { _ = NSApplication.shared }
+
+  @Test("silence still shows bars, because an empty meter reads as not hearing you")
+  func silenceIsNotEmpty() {
+    for i in 0..<RainbowLevelMeter.spectrum.count {
+      let fill = RainbowLevelMeter.fill(index: i, level: 0)
+      #expect(fill > 0, "bar \(i) vanished at silence")
+      #expect(
+        fill == RainbowLevelMeter.silenceFraction,
+        "bar \(i) filled \(fill) at silence, not the resting \(RainbowLevelMeter.silenceFraction)")
+    }
+  }
+
+  @Test("louder is taller, for every bar")
+  func fillIsMonotonicInLevel() {
+    for i in 0..<RainbowLevelMeter.spectrum.count {
+      var previous = RainbowLevelMeter.fill(index: i, level: 0)
+      for step in 1...10 {
+        let level = CGFloat(step) / 10
+        let current = RainbowLevelMeter.fill(index: i, level: level)
+        #expect(
+          current > previous,
+          "bar \(i) did not grow from level \(level - 0.1) to \(level): \(previous) -> \(current)")
+        previous = current
+      }
+    }
+  }
+
+  @Test("no bar overflows its strip at full level")
+  func fillNeverExceedsTheStrip() {
+    for i in 0..<RainbowLevelMeter.spectrum.count {
+      let fill = RainbowLevelMeter.fill(index: i, level: 1)
+      #expect(fill <= 1, "bar \(i) filled \(fill) of the strip, which would clip")
+    }
+  }
+
+  /// The audio level arrives from a live capture path. A meter that trusts it is
+  /// one bad sample away from drawing outside its own frame, and
+  /// `RainbowLipsIcon` already clamps for exactly this reason.
+  @Test(
+    "out-of-range levels are clamped rather than trusted",
+    arguments: [-99.0, -0.5, 1.5, 99.0] as [CGFloat])
+  func hostileLevelsAreClamped(level: CGFloat) {
+    let atFloor = RainbowLevelMeter.fill(index: 4, level: 0)
+    let atCeiling = RainbowLevelMeter.fill(index: 4, level: 1)
+    let got = RainbowLevelMeter.fill(index: 4, level: level)
+    #expect(got >= atFloor, "level \(level) drew below the resting height")
+    #expect(got <= atCeiling, "level \(level) drew above full")
+  }
+
+  @Test("an out-of-range bar index cannot crash the pill")
+  func hostileIndexIsClamped() {
+    // The pill is on the recording path's display side; an index error here must
+    // degrade rather than trap.
+    #expect(RainbowLevelMeter.fill(index: -1, level: 0.5) > 0)
+    #expect(RainbowLevelMeter.fill(index: 99, level: 0.5) > 0)
+  }
+
+  @Test("the centre bar reacts more than the edges, like the mark it replaces")
+  func centreIsMoreSensitiveThanTheEdges() {
+    let centre = RainbowLevelMeter.fill(index: 4, level: 1)
+    let edge = RainbowLevelMeter.fill(index: 0, level: 1)
+    #expect(
+      centre > edge,
+      """
+      centre filled \(centre) and edge \(edge) at full level — the meter is flat, \
+      which loses the shape that makes it read as a voice
+      """)
+  }
+
+  @Test("nine bars carry the nine brand spectrum colours in order")
+  func spectrumIsTheBrandOrder() {
+    #expect(RainbowLevelMeter.spectrum.count == 9)
+    #expect(RainbowLevelMeter.sensitivity.count == RainbowLevelMeter.spectrum.count)
+  }
+
+  /// The frame and the drawing derive from one expression, so a change to bar
+  /// width or spacing cannot leave the Canvas drawing outside the frame it was
+  /// given — the shape of defect that produced clipped glyphs in the preview text
+  /// before #1988 settled on measured layout.
+  @Test("declared width matches what nine bars and eight gaps actually need")
+  func widthMatchesTheDrawing() {
+    let barWidth: CGFloat = 2.5
+    let spacing: CGFloat = 3
+    let declared = RainbowLevelMeter.width(barWidth: barWidth, spacing: spacing)
+    let lastBarRightEdge =
+      CGFloat(RainbowLevelMeter.spectrum.count - 1) * (barWidth + spacing) + barWidth
+    #expect(
+      declared == lastBarRightEdge,
+      "frame is \(declared)pt but the last bar ends at \(lastBarRightEdge)pt")
+  }
+}

--- a/Tests/EnviousWisprTests/App/RecordingOverlayPreviewChromeTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingOverlayPreviewChromeTests.swift
@@ -128,6 +128,59 @@ struct RecordingOverlayPreviewChromeTests {
       """)
   }
 
+  // MARK: - The padding migration left nothing behind
+
+  /// #2202 zeroes the shared root padding for the preview layout and gives each
+  /// section its own. **The notice banner is the third section and it was missed**
+  /// — a two-part edit whose second half failed its safety check aborted the whole
+  /// script before writing, and only the half that was retried landed. Cloud
+  /// review caught it; nothing in this suite did, because every other case used a
+  /// notice-free pill.
+  ///
+  /// The property: a preview pill showing a notice must be TALLER than the same
+  /// pill without one by more than the text itself, which is only true if the
+  /// notice carries an inset. Asserting the padding constant would test the
+  /// constant; asserting the height tests the outcome.
+  @Test("a notice inside the preview pill keeps an inset of its own")
+  func noticeKeepsItsInsetAfterThePaddingMigration() throws {
+    let text = LivePreviewDisplay.text("the quarterly numbers came in")
+    let without = try pillHeight(locked: false, showing: text)
+
+    let log = HeightLog()
+    let noticeState = OverlayNoticeState()
+    noticeState.message = "Recording stops in one minute."
+    let view = RecordingOverlayView(
+      audioLevelProvider: { 0.4 },
+      recordingElapsedProvider: { 127 },
+      livePreviewProvider: { text },
+      onContentHeightChange: { log.record($0) },
+      usesPreviewLayout: true,
+      lockState: OverlayLockState(),
+      noticeState: noticeState,
+      initialPreview: text
+    )
+    let host = NSHostingView(rootView: view.frame(width: Self.previewWidth))
+    let frame = NSRect(x: 0, y: 0, width: Self.previewWidth, height: 65)
+    let window = NSWindow(
+      contentRect: frame, styleMask: [.borderless], backing: .buffered, defer: false)
+    window.contentView = host
+    host.frame = frame
+    host.layoutSubtreeIfNeeded()
+    window.displayIfNeeded()
+    let with = try #require(log.reported.last, "the notice pill never reported a height")
+
+    // One line of 11pt notice text is ~14pt. Anything at or below that means the
+    // notice is sitting flush against the pill's bottom edge.
+    let grew = with - without
+    #expect(
+      grew > 20,
+      """
+      adding a notice grew the preview pill by only \(grew)pt, which is about the \
+      text alone. The notice lost its inset when the shared root padding was zeroed \
+      and is flush against the pill's edge.
+      """)
+  }
+
   // MARK: - Copy
 
   @Test("both header words are the ones the design names")

--- a/Tests/EnviousWisprTests/App/RecordingOverlayPreviewChromeTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingOverlayPreviewChromeTests.swift
@@ -1,0 +1,166 @@
+import AppKit
+import SwiftUI
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #2202: the preview pill's header — timer hard left, live meter, mode on the
+/// right.
+///
+/// The property worth protecting is that **the header is the same height in both
+/// recording modes**. Today's capsule scales its mark to 2x when hands-free
+/// locks, which is the single biggest height change anywhere in the pill; the
+/// whole reason the mode moved onto a badge is that a badge costs no height. A
+/// regression here does not look like a bug, it looks like the pill twitching
+/// when you double-press, which is the class of thing #2201 just finished
+/// removing.
+@MainActor
+@Suite(.tags(.productOutcome))
+struct RecordingOverlayPreviewChromeTests {
+
+  init() { _ = NSApplication.shared }
+
+  private static let previewWidth: CGFloat = 400
+
+  private final class HeightLog: @unchecked Sendable {
+    private(set) var reported: [CGFloat] = []
+    func record(_ h: CGFloat) { reported.append(h) }
+  }
+
+  /// Measure the whole pill with a KNOWN display state, in a given lock mode.
+  private func pillHeight(
+    locked: Bool,
+    showing display: LivePreviewDisplay,
+    usesPreviewLayout: Bool = true
+  ) throws -> CGFloat {
+    let log = HeightLog()
+    let lockState = OverlayLockState()
+    lockState.isLocked = locked
+
+    let view = RecordingOverlayView(
+      audioLevelProvider: { 0.4 },
+      recordingElapsedProvider: { 127 },
+      livePreviewProvider: { display },
+      onContentHeightChange: { log.record($0) },
+      usesPreviewLayout: usesPreviewLayout,
+      lockState: lockState,
+      noticeState: OverlayNoticeState(),
+      initialPreview: display
+    )
+    let host = NSHostingView(rootView: view.frame(width: Self.previewWidth))
+    let frame = NSRect(x: 0, y: 0, width: Self.previewWidth, height: 65)
+    let window = NSWindow(
+      contentRect: frame, styleMask: [.borderless], backing: .buffered, defer: false)
+    window.contentView = host
+    host.frame = frame
+    host.layoutSubtreeIfNeeded()
+    window.displayIfNeeded()
+
+    return try #require(
+      log.reported.last,
+      "the view never reported a height — the measurement is missing, not failing")
+  }
+
+  // MARK: - The property the badge exists to buy
+
+  @Test("the preview pill is the same height in hold-to-talk and hands-free")
+  func headerHeightIsIdenticalAcrossModes() throws {
+    let text = LivePreviewDisplay.text("the quarterly numbers came in ahead of plan")
+    let unlocked = try pillHeight(locked: false, showing: text)
+    let locked = try pillHeight(locked: true, showing: text)
+
+    #expect(
+      unlocked == locked,
+      """
+      hold-to-talk measured \(unlocked)pt and hands-free \(locked)pt for the same \
+      words. The mode must not change the pill's size — that is the whole reason \
+      it is carried on a badge rather than by scaling the mark.
+      """)
+  }
+
+  @Test(
+    "no display state makes the mode change the pill's height",
+    arguments: RecordingOverlayPreviewChromeTests.displayStates)
+  func modeIsHeightNeutralInEveryState(state: LivePreviewDisplay) throws {
+    let unlocked = try pillHeight(locked: false, showing: state)
+    let locked = try pillHeight(locked: true, showing: state)
+    #expect(unlocked == locked, "\(state): \(unlocked)pt unlocked vs \(locked)pt locked")
+  }
+
+  nonisolated static let displayStates: [LivePreviewDisplay] = [
+    .waiting,
+    .unavailable("On-screen preview does not support this language yet."),
+    .text("the quarterly numbers came in"),
+  ]
+
+  // MARK: - The capsule is untouched
+  //
+  // The 185pt non-preview capsule is out of scope for #2198; the founder is
+  // redesigning it separately.
+  //
+  // **The first version of this test asserted the capsule CHANGES height with the
+  // mode, and it was wrong** — a premise written from the design's own
+  // justification instead of from a measurement. `scaleEffect` is a rendering
+  // transform and does not participate in layout: an `HStack` holding a 24pt box
+  // reports `fittingSize` 95x44 at `scaleEffect(1.0)` and 95x44 at 2.0. The
+  // capsule is already height-neutral; the 2x mark overflows its slot visually.
+  // Removing the timer does not change height either, because the 24pt mark is
+  // taller than the 13pt text beside it.
+  //
+  // So the useful guard is not "does it still change" but "is it still exactly
+  // what it was", pinned to the measured value.
+
+  /// The capsule's content height, measured on `main` before #2202 touched
+  /// anything: 24pt mark + 10pt vertical padding either side.
+  private static let capsuleContentHeight: CGFloat = 44
+
+  @Test(
+    "the capsule's height is untouched by this chunk, in both modes",
+    arguments: [false, true])
+  func capsuleHeightIsPinned(locked: Bool) throws {
+    let height = try pillHeight(locked: locked, showing: .off, usesPreviewLayout: false)
+    #expect(
+      height == Self.capsuleContentHeight,
+      """
+      the capsule measured \(height)pt (locked: \(locked)), not the \
+      \(Self.capsuleContentHeight)pt it has always been. This chunk is gated on \
+      usesPreviewLayout and must not reach the layout the founder reserved.
+      """)
+  }
+
+  // MARK: - Copy
+
+  @Test("both header words are the ones the design names")
+  func headerCopyIsWhatShipped() {
+    #expect(LivePreviewCopy.listeningMode == "Listening")
+    #expect(LivePreviewCopy.handsFreeMode == "Hands-free")
+  }
+
+  /// The pill's copy avoids the word "live" — a constraint that already exists on
+  /// this enum and that a new string is the likeliest thing to break.
+  @Test("the new header strings keep the pill's no-live rule")
+  func headerCopyAvoidsLive() {
+    for s in [LivePreviewCopy.listeningMode, LivePreviewCopy.handsFreeMode] {
+      #expect(
+        !s.lowercased().contains("live"),
+        "\"\(s)\" reintroduces the word the pill's copy deliberately avoids")
+    }
+  }
+
+  /// #2202: the header says `Listening`, so the reading well must not say it too.
+  /// A first-time user's very first sight of this feature is the waiting state,
+  /// and the same word twice in one small box is worse than either alone.
+  @Test("the waiting state does not repeat the header's word in the well")
+  func waitingDoesNotDuplicateListening() throws {
+    let waiting = try pillHeight(locked: false, showing: .waiting)
+    let empty = try pillHeight(locked: false, showing: .text(""))
+
+    #expect(
+      waiting == empty,
+      """
+      the waiting state measured \(waiting)pt against \(empty)pt for an empty \
+      preview. In the preview layout the well renders nothing while waiting, \
+      because the header already carries the word.
+      """)
+  }
+}

--- a/website/src/content/help/hands-free-mode-long-dictation.md
+++ b/website/src/content/help/hands-free-mode-long-dictation.md
@@ -16,7 +16,7 @@ EnviousWispr relies on a double tap of your keybind to lock the recording in pla
 
 **Tap, then tap again.** Start your recording with a normal press of your keybind, then press it a second time within half a second, before you let go.
 
-The on-screen bar grows to confirm that recording is locked on. If the bar does not change, the second press came too late, and the recording ends as usual when you release the key. Try the double tap a little quicker.
+The on-screen bar changes to confirm that recording is locked on. If it does not change, the second press came too late, and the recording ends as usual when you release the key. Try the double tap a little quicker.
 
 ### Stopping recording
 


### PR DESCRIPTION
Chunk B of #2198, on top of #2201. Timer hard left, live meter, mode on the right.

Part of #2198. Closes #2202.

Mockups, all four states at true size: https://claude.ai/code/artifact/aeb2b2f9-5c4b-4ba8-8ae1-76322922fd65

## What changes

The preview pill's header only. The lips mark leaves THIS box; it is untouched in the menu bar, the
polishing pill and settings.

| | Hold to talk | Hands-free |
|---|---|---|
| Before | mark at normal size, timer showing | mark at 2x, **timer hidden** |
| After | quiet grey `Listening` on the right | filled `Hands-free` badge, **timer stays** |

**The timer returning is the one behaviour change the founder approved separately.** Hands-free is the
mode that runs for minutes, so hiding its clock was backwards.

## A correction this PR carries about its own justification

The plan, the issue and the meter commit all said the 2x mark was "the single biggest height jump anywhere
in the pill", and that the badge's job was to stop the header resizing between modes.

**That is false, and this chunk's own test found it.** `scaleEffect` is a rendering transform and does not
participate in layout. Measured: an `HStack` holding a 24pt box reports `fittingSize` 95x44 at
`scaleEffect(1.0)` and 95x44 at 2.0. The capsule is already height-neutral across modes; the 2x mark
overflows its own slot visually and nothing resizes.

The test that caught it was written as a leak guard — "the capsule still changes height with the mode, so
if it stops, this chunk leaked into it" — and went red because the capsule never did that.

The design is unchanged and the honest reason is better: a size change is a signal readable only by
COMPARISON, so you notice it only if you saw the other size a moment earlier, while a badge naming the
mode works the first time you see it. Height-neutrality is a property both designs have and this one
keeps.

The leak guard now pins the capsule at its measured 44pt in both modes, which catches any change to that
layout rather than only the one I had imagined.

## Isolation

Every shared surface gated on `usesPreviewLayout`, per the plan's §3d table. **Every modifier on
`RecordingOverlayView`'s root is rendered by BOTH layouts**, and the 185pt capsule is out of scope — the
founder is redesigning it separately.

- Header — `else` branch preserves today's `HStack` verbatim.
- Root `VStack` spacing — 0 for preview, 6 for the capsule.
- Root padding — zeroed for preview, each section supplying its own. **Migrated atomically**: split across
  two commits, whatever shipped in between would have had no insets at all.
- The #1060 notice — rendered by both layouts, and its only inset came from that root padding.

**The reading well's inset wraps the FINISHED capped view, never inside `.frame(maxHeight:)`.** Padding
inserted before the cap is subtracted from the five-line viewport, so the box would clip at
four-and-a-bit lines and the five-line rule would quietly stop holding.

## `Listening` appears once

The header says it, so the preview well renders nothing while waiting. A first-time user's first sight of
this feature is the waiting state, and the same word twice in one small box is worse than either alone.
The capsule has no header and keeps its sentence.

## Content lane

`hands-free-mode-long-dictation.md` said the bar GROWS to confirm the lock. Now "changes".

The plan claimed that sentence became false. It became false only for the PREVIEW — the capsule's mark
still visibly grows — and the preview ships OFF by default, so a replacement describing only the new
design would have been wrong for most readers. "Changes" holds for both. Swept with
`claim-sweep.sh bar --with grows`: 1 hit across 8 surfaces, so this article is the only place.

## Evidence

- 6 chrome cases + #2201's 8 sizing cases, all green.
- Debug 6209, Release 5659, zero failures. Per-bundle lines reconcile against both totals exactly
  (6004 + 205, 5454 + 205).
- Website: content 56 articles / 0 errors, routes 69 built / 69 in sitemap / 0 dead links, search 42
  passed. All three run separately — `npm run build` alone runs only the content check, and it reported
  green here while the build itself failed for want of `node_modules`.

## Still owed

Live UAT: the meter moving with a real voice, and the `Hands-free` badge legible at normal viewing
distance (the Frank check — it replaces today's size cue). Machine-drivable now that
`tools-and-apps.md` FACT: the-record-hotkey-IS-drivable-synthetically-only-cancel-is-not is written down.
