### PR TITLE
Live Preview pill: the reading well, and the five-line rule made honest (#2203)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
@@ -2717,54 +2717,8 @@ struct RecordingOverlayView: View {
   /// scroll-to-bottom timing into a borderless overlay) and no manual text
   /// measurement.
   private func previewText(_ message: String, dimmed: Bool, lines: Int) -> some View {
-    Text(message)
-      .font(.system(size: Self.previewFontSize))
-      .lineSpacing(Self.previewLineSpacing)
-      .foregroundStyle(.white.opacity(dimmed ? 0.5 : 0.92))
-      .multilineTextAlignment(.leading)
-      .fixedSize(horizontal: false, vertical: true)
-      .frame(maxWidth: .infinity, alignment: .leading)
-      // `maxHeight` CAPS without fixing: below the cap the box is the text's own
-      // height, which is what lets the pill still grow a line at a time.
-      .frame(maxHeight: Self.previewHeight(lines: lines), alignment: .bottom)
-      .clipped()
-      // #2203: fade the top edge so overflow reads as SCROLLING rather than as a
-      // line sliced off.
-      //
-      // **This is also how older words dim, and doing it with a mask rather than
-      // per-line opacity is the point.** The obvious implementation — dim the
-      // older lines — needs to know where the text engine broke the lines, which
-      // is exactly the knowledge `previewText`'s doc comment records as
-      // unavailable: a character budget is wrong by a factor of two for CJK and
-      // wrong again for any proportional font. A gradient over the well needs no
-      // line information at all and gives the same result in every script, because
-      // older words are higher up by construction.
-      //
-      // Masking does not participate in layout, so the measured height and the
-      // five-line cap are untouched — verified by the sizing suite, which runs
-      // against this same view.
-      .mask(
-        usesPreviewLayout
-          ? AnyView(
-            LinearGradient(
-              stops: [
-                .init(color: .clear, location: 0),
-                .init(color: .white, location: Self.previewFadeFraction),
-                .init(color: .white, location: 1),
-              ],
-              startPoint: .top,
-              endPoint: .bottom))
-          : AnyView(Rectangle())
-      )
-      // #2202: the well's own inset, replacing what the shared root padding used
-      // to give it. **Outside the cap, deliberately.** Padding inserted before
-      // `.frame(maxHeight:)` is subtracted from the five-line viewport, so the
-      // box would clip at four-and-a-bit lines and the founder's five-line rule
-      // would quietly stop holding — a number that looks like it means lines
-      // while meaning something else.
-      .padding(.horizontal, usesPreviewLayout ? 16 : 0)
-      .padding(.top, usesPreviewLayout ? 12 : 0)
-      .padding(.bottom, usesPreviewLayout ? 15 : 0)
+    PreviewWellText(
+      message: message, dimmed: dimmed, lines: lines, usesPreviewLayout: usesPreviewLayout)
   }
 
   /// #2203: ONE authority for preview typography. The `Text` and the cap both read
@@ -2806,6 +2760,119 @@ struct RecordingOverlayView: View {
   /// Five lines, matching the shape the founder tested against Spokenly: the pill
   /// grows a line at a time up to this, then holds its size and scrolls.
   static let previewMaxLines = 5
+}
+
+/// #2203: the reading well's text, and the one part of the pill that has to know
+/// whether it is FULL.
+///
+/// Split out of `RecordingOverlayView` only because the fade decision needs
+/// `@State`, and a function returning a view cannot hold one.
+struct PreviewWellText: View {
+  let message: String
+  let dimmed: Bool
+  let lines: Int
+  let usesPreviewLayout: Bool
+
+  /// Whether the well is at its cap, and so whether anything is scrolling off the
+  /// top. Written from a `GeometryReader` in the BACKGROUND of the capped frame,
+  /// which does not participate in layout, and it feeds only the mask, which does
+  /// not either — so it cannot reach the panel-resize loop #2201 settled.
+  /// `RecordingOverlayPreviewSizingTests` is the check on that claim rather than
+  /// this sentence.
+  @State private var wellIsFull = false
+
+  private var cap: CGFloat { RecordingOverlayView.previewHeight(lines: lines) }
+
+  var body: some View {
+    Text(message)
+      .font(.system(size: RecordingOverlayView.previewFontSize))
+      .lineSpacing(RecordingOverlayView.previewLineSpacing)
+      .foregroundStyle(.white.opacity(dimmed ? 0.5 : 0.92))
+      .multilineTextAlignment(.leading)
+      .fixedSize(horizontal: false, vertical: true)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      // `maxHeight` CAPS without fixing: below the cap the box is the text's own
+      // height, which is what lets the pill still grow a line at a time.
+      .frame(maxHeight: cap, alignment: .bottom)
+      .background(
+        GeometryReader { geo in
+          Color.clear
+            .onAppear { updateFullness(geo.size.height) }
+            .onChange(of: geo.size.height) { _, height in updateFullness(height) }
+        }
+      )
+      .clipped()
+      // #2203: fade the top edge ONLY when something is actually above it.
+      //
+      // **Cloud review caught this applying unconditionally.** The capped frame
+      // takes the TEXT's height while the text is short, so the gradient mapped
+      // onto the first line of a one-line transcript and dimmed words the user
+      // still had to read. A fade means "there is more above this"; saying that
+      // when there is not is worse than not saying it at all.
+      //
+      // Doing it with a mask rather than per-line opacity remains the point:
+      // dimming older LINES needs to know where the text engine broke them, which
+      // is the knowledge this file records as unavailable — a character budget is
+      // wrong by 2x for CJK and wrong again for any proportional font. A gradient
+      // needs no line information and behaves identically in every script, because
+      // older words are higher up by construction.
+      //
+      // KNOWN LIMIT, recorded rather than hidden: a transcript landing at EXACTLY
+      // the cap fades slightly with nothing yet above it. Separating that from a
+      // genuine overflow needs the text's unclipped intrinsic height, which costs a
+      // second layout of the same string for a one-frame cosmetic difference at the
+      // moment the well is about to overflow anyway.
+      .mask(fadeMask)
+      // #2202: the well's own inset, replacing what the shared root padding used
+      // to give it. **Outside the cap, deliberately.** Padding inserted before
+      // `.frame(maxHeight:)` is subtracted from the five-line viewport, so the
+      // box would clip at four-and-a-bit lines and the founder's five-line rule
+      // would quietly stop holding — a number that looks like it means lines
+      // while meaning something else.
+      .padding(.horizontal, usesPreviewLayout ? 16 : 0)
+      .padding(.top, usesPreviewLayout ? 12 : 0)
+      .padding(.bottom, usesPreviewLayout ? 15 : 0)
+  }
+
+  @ViewBuilder
+  private var fadeMask: some View {
+    if usesPreviewLayout && wellIsFull {
+      LinearGradient(
+        stops: [
+          .init(color: .clear, location: 0),
+          .init(color: .white, location: RecordingOverlayView.previewFadeFraction),
+          .init(color: .white, location: 1),
+        ],
+        startPoint: .top,
+        endPoint: .bottom)
+    } else {
+      Rectangle()
+    }
+  }
+
+  /// The capped frame reports the TEXT's height below the cap and the CAP once the
+  /// text exceeds it, so "is it at the cap" is the overflow signal without
+  /// measuring the string ourselves.
+  private func updateFullness(_ height: CGFloat) {
+    let full = Self.wellIsFull(measuredHeight: height, cap: cap)
+    if full != wellIsFull { wellIsFull = full }
+  }
+
+  /// The fade decision, extracted so it can be asserted directly.
+  ///
+  /// A mask does not participate in layout, so no height test can see whether the
+  /// fade is applied — the same reason `RecordingOverlayPanel`'s inherited-geometry
+  /// arithmetic is pinned as a pure function rather than driven through a panel.
+  /// Cloud review found this applying unconditionally; a decision worth fixing is
+  /// worth pinning.
+  ///
+  /// The half-point tolerance absorbs the rounding between a laid-out frame and a
+  /// computed cap. Without it a well that is full to the pixel reports empty and
+  /// the fade flickers off at exactly the moment it is needed.
+  static func wellIsFull(measuredHeight: CGFloat, cap: CGFloat) -> Bool {
+    measuredHeight >= cap - 0.5
+  }
+
 }
 
 // MARK: - PolishingOverlayView

--- a/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
@@ -2718,7 +2718,8 @@ struct RecordingOverlayView: View {
   /// measurement.
   private func previewText(_ message: String, dimmed: Bool, lines: Int) -> some View {
     Text(message)
-      .font(.system(size: 12))
+      .font(.system(size: Self.previewFontSize))
+      .lineSpacing(Self.previewLineSpacing)
       .foregroundStyle(.white.opacity(dimmed ? 0.5 : 0.92))
       .multilineTextAlignment(.leading)
       .fixedSize(horizontal: false, vertical: true)
@@ -2727,6 +2728,34 @@ struct RecordingOverlayView: View {
       // height, which is what lets the pill still grow a line at a time.
       .frame(maxHeight: Self.previewHeight(lines: lines), alignment: .bottom)
       .clipped()
+      // #2203: fade the top edge so overflow reads as SCROLLING rather than as a
+      // line sliced off.
+      //
+      // **This is also how older words dim, and doing it with a mask rather than
+      // per-line opacity is the point.** The obvious implementation — dim the
+      // older lines — needs to know where the text engine broke the lines, which
+      // is exactly the knowledge `previewText`'s doc comment records as
+      // unavailable: a character budget is wrong by a factor of two for CJK and
+      // wrong again for any proportional font. A gradient over the well needs no
+      // line information at all and gives the same result in every script, because
+      // older words are higher up by construction.
+      //
+      // Masking does not participate in layout, so the measured height and the
+      // five-line cap are untouched — verified by the sizing suite, which runs
+      // against this same view.
+      .mask(
+        usesPreviewLayout
+          ? AnyView(
+            LinearGradient(
+              stops: [
+                .init(color: .clear, location: 0),
+                .init(color: .white, location: Self.previewFadeFraction),
+                .init(color: .white, location: 1),
+              ],
+              startPoint: .top,
+              endPoint: .bottom))
+          : AnyView(Rectangle())
+      )
       // #2202: the well's own inset, replacing what the shared root padding used
       // to give it. **Outside the cap, deliberately.** Padding inserted before
       // `.frame(maxHeight:)` is subtracted from the five-line viewport, so the
@@ -2738,21 +2767,45 @@ struct RecordingOverlayView: View {
       .padding(.bottom, usesPreviewLayout ? 15 : 0)
   }
 
-  /// Height of `lines` lines of the preview font.
+  /// #2203: ONE authority for preview typography. The `Text` and the cap both read
+  /// these, so a change to the type size cannot leave the two disagreeing.
   ///
-  /// Derived from the font's own metrics rather than a literal, so the cap tracks
-  /// the type size instead of drifting silently if it changes. An exact multiple
-  /// of the line height matters: the clip lands on a line boundary, so no row is
-  /// ever cut through the middle of its glyphs. Verified against the render — five
-  /// lines measured 75pt, matching 5 x 15.
-  private static func previewHeight(lines: Int) -> CGFloat {
-    let font = NSFont.systemFont(ofSize: 12)
-    return ceil(font.ascender - font.descender + font.leading) * CGFloat(lines)
+  /// **The previous version's doc comment claimed the cap "tracks the type size"
+  /// and it did not.** It built `NSFont.systemFont(ofSize: 12)` from its own
+  /// hardcoded 12, independent of the `Text`'s own `.font(.system(size: 12))`
+  /// twenty lines away. Two literals that had to agree, with a comment asserting
+  /// they could not drift — which is worse than no comment, because it stops the
+  /// next reader checking.
+  static let previewFontSize: CGFloat = 14
+  static let previewLineSpacing: CGFloat = 4
+
+  /// #2203: how much of the reading well's height the top fade occupies.
+  ///
+  /// Deliberately small. The fade exists to say "there is more above this", not to
+  /// hide a line — at the cap the oldest visible line is still readable, just
+  /// clearly on its way out. A larger value starts costing the user words they
+  /// have not finished reading.
+  static let previewFadeFraction: CGFloat = 0.22
+
+  /// Height of `lines` lines of the preview font, INCLUDING the gaps between them.
+  ///
+  /// **Counting the gaps is not a refinement, it is the difference between five
+  /// lines and four.** SwiftUI adds `lineSpacing` BETWEEN lines, so five lines
+  /// occupy five glyph heights plus four gaps. A cap that counts only the glyphs
+  /// under-measures by 4 x `previewLineSpacing` and clips the fifth line partway.
+  ///
+  /// An exact multiple still matters: the clip lands on a line boundary, so no row
+  /// is cut through the middle of its glyphs.
+  static func previewHeight(lines: Int) -> CGFloat {
+    let font = NSFont.systemFont(ofSize: previewFontSize)
+    let glyphHeight = ceil(font.ascender - font.descender + font.leading)
+    let gaps = max(lines - 1, 0)
+    return glyphHeight * CGFloat(lines) + previewLineSpacing * CGFloat(gaps)
   }
 
   /// Five lines, matching the shape the founder tested against Spokenly: the pill
   /// grows a line at a time up to this, then holds its size and scrolls.
-  private static let previewMaxLines = 5
+  static let previewMaxLines = 5
 }
 
 // MARK: - PolishingOverlayView

--- a/Tests/EnviousWisprTests/App/RecordingOverlayPreviewTypographyTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingOverlayPreviewTypographyTests.swift
@@ -174,3 +174,61 @@ struct RecordingOverlayPreviewTypographyTests {
     #expect(short < long, "retracted to \(short)pt from \(long)pt")
   }
 }
+
+/// #2203: when the reading well fades its top edge.
+///
+/// A mask does not participate in layout, so no height measurement can see whether
+/// the fade is applied. The decision is therefore pinned directly — the same shape
+/// `RecordingOverlayPanelInheritedGeometryTests` uses for panel arithmetic.
+///
+/// **Cloud review found the fade applying unconditionally**, so a one-line
+/// transcript had its only line dimmed with nothing above it to scroll away. A
+/// fade means "there is more above this"; saying that when there is not costs the
+/// user legibility on words they still have to read.
+@MainActor
+@Suite(.tags(.productOutcome))
+struct PreviewWellFadeTests {
+
+  init() { _ = NSApplication.shared }
+
+  private static let cap = RecordingOverlayView.previewHeight(lines: 5)
+
+  @Test("a short transcript does not fade")
+  func shortTextDoesNotFade() {
+    let oneLine = RecordingOverlayView.previewHeight(lines: 1)
+    #expect(
+      !PreviewWellText.wellIsFull(measuredHeight: oneLine, cap: Self.cap),
+      "a one-line well reported full, so its only line would be dimmed")
+  }
+
+  @Test("a well below the cap does not fade", arguments: [1, 2, 3, 4])
+  func belowTheCapDoesNotFade(lines: Int) {
+    let height = RecordingOverlayView.previewHeight(lines: lines)
+    #expect(
+      !PreviewWellText.wellIsFull(measuredHeight: height, cap: Self.cap),
+      "\(lines) lines reported full against a five-line cap")
+  }
+
+  @Test("a well at the cap fades")
+  func atTheCapFades() {
+    #expect(PreviewWellText.wellIsFull(measuredHeight: Self.cap, cap: Self.cap))
+  }
+
+  @Test("a well past the cap fades")
+  func pastTheCapFades() {
+    #expect(PreviewWellText.wellIsFull(measuredHeight: Self.cap + 40, cap: Self.cap))
+  }
+
+  /// A laid-out frame and a computed cap can disagree in the last fraction of a
+  /// point. Without tolerance the fade flickers off exactly when it is needed.
+  @Test("sub-point rounding does not switch the fade off")
+  func roundingDoesNotFlicker() {
+    #expect(PreviewWellText.wellIsFull(measuredHeight: Self.cap - 0.25, cap: Self.cap))
+  }
+
+  /// But the tolerance must not be so wide that a genuinely short well fades.
+  @Test("the tolerance is not wide enough to catch a shorter well")
+  func toleranceDoesNotOverreach() {
+    #expect(!PreviewWellText.wellIsFull(measuredHeight: Self.cap - 5, cap: Self.cap))
+  }
+}

--- a/Tests/EnviousWisprTests/App/RecordingOverlayPreviewTypographyTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingOverlayPreviewTypographyTests.swift
@@ -1,0 +1,176 @@
+import AppKit
+import SwiftUI
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #2203: the preview pill's reading well.
+///
+/// **The property under test is that five lines still means five lines.** Before
+/// this chunk the type size lived in two independent literals — the `Text`'s own
+/// `.font(.system(size: 12))` and a second hardcoded 12 inside `previewHeight` —
+/// with a doc comment asserting the cap "tracks the type size", which it did not.
+/// Raising one without the other silently changes how many lines fit, and nothing
+/// would have gone red.
+///
+/// Bigger type also needs `lineSpacing`, and a cap that counts only glyph heights
+/// under-measures by one gap per line boundary. Both of those turn "five lines"
+/// into four-and-a-bit without changing any number that looks like a line count.
+@MainActor
+@Suite(.tags(.productOutcome))
+struct RecordingOverlayPreviewTypographyTests {
+
+  init() { _ = NSApplication.shared }
+
+  private static let previewWidth: CGFloat = 400
+
+  private final class HeightLog: @unchecked Sendable {
+    private(set) var reported: [CGFloat] = []
+    func record(_ h: CGFloat) { reported.append(h) }
+  }
+
+  private func pillHeight(showing display: LivePreviewDisplay) throws -> CGFloat {
+    let log = HeightLog()
+    let view = RecordingOverlayView(
+      audioLevelProvider: { 0 },
+      recordingElapsedProvider: { 41 },
+      livePreviewProvider: { display },
+      onContentHeightChange: { log.record($0) },
+      usesPreviewLayout: true,
+      lockState: OverlayLockState(),
+      noticeState: OverlayNoticeState(),
+      initialPreview: display
+    )
+    let host = NSHostingView(rootView: view.frame(width: Self.previewWidth))
+    let frame = NSRect(x: 0, y: 0, width: Self.previewWidth, height: 65)
+    let window = NSWindow(
+      contentRect: frame, styleMask: [.borderless], backing: .buffered, defer: false)
+    window.contentView = host
+    host.frame = frame
+    host.layoutSubtreeIfNeeded()
+    window.displayIfNeeded()
+    return try #require(log.reported.last, "the view never reported a height")
+  }
+
+  /// Roughly one line at 400pt wide, then multiples of it.
+  private static func words(lines: Int) -> String {
+    String(repeating: "the quarterly numbers came in ahead of plan and we should ", count: lines)
+  }
+
+  // MARK: - The cap counts gaps, not just glyphs
+
+  @Test("the cap counts the gaps between lines, not only the lines")
+  func capIncludesLineSpacing() {
+    let one = RecordingOverlayView.previewHeight(lines: 1)
+    let two = RecordingOverlayView.previewHeight(lines: 2)
+    let five = RecordingOverlayView.previewHeight(lines: 5)
+
+    // Two lines cost one gap more than twice one line.
+    #expect(
+      two == one * 2 + RecordingOverlayView.previewLineSpacing,
+      """
+      two lines measured \(two)pt against \(one * 2)pt for twice one line. The cap \
+      is not counting the gap between them, so the last line clips.
+      """)
+
+    // Five lines cost four gaps.
+    #expect(
+      five == one * 5 + RecordingOverlayView.previewLineSpacing * 4,
+      "five lines measured \(five)pt, which is not five glyph heights plus four gaps")
+  }
+
+  @Test("one line has no gap to count")
+  func singleLineHasNoGap() {
+    let font = NSFont.systemFont(ofSize: RecordingOverlayView.previewFontSize)
+    let glyph = ceil(font.ascender - font.descender + font.leading)
+    #expect(RecordingOverlayView.previewHeight(lines: 1) == glyph)
+  }
+
+  @Test("a zero-line cap does not go negative on the gap count")
+  func zeroLinesIsSafe() {
+    #expect(RecordingOverlayView.previewHeight(lines: 0) == 0)
+  }
+
+  // MARK: - The type size has ONE home
+
+  /// The defect this chunk exists to remove: two literals that had to agree.
+  /// If someone changes the font on the `Text` without changing the constant, the
+  /// rendered line height stops matching the cap and the fifth line clips.
+  @Test("the cap is derived from the same size the text renders at")
+  func capTracksTheTextsOwnFontSize() {
+    let font = NSFont.systemFont(ofSize: RecordingOverlayView.previewFontSize)
+    let glyph = ceil(font.ascender - font.descender + font.leading)
+    let five = RecordingOverlayView.previewHeight(lines: 5)
+
+    #expect(
+      five == glyph * 5 + RecordingOverlayView.previewLineSpacing * 4,
+      """
+      the five-line cap is \(five)pt but the type actually renders at \
+      \(RecordingOverlayView.previewFontSize)pt, whose lines are \(glyph)pt. The cap \
+      and the text have drifted apart again.
+      """)
+  }
+
+  // MARK: - What the user sees
+
+  /// **Asserts the PROPERTY, not a guess about where the text wraps.**
+  ///
+  /// The first version of this walked 1...5 repetitions of a sample sentence and
+  /// required each to be strictly taller than the last. It failed at 162pt — the
+  /// capped height — because at 14pt one repetition wraps to more than one line,
+  /// so the box reached its cap before the loop reached 5. The test had encoded a
+  /// guess about text metrics as though it were the rule.
+  ///
+  /// What the founder's rule actually says is: grow a line at a time, then hold.
+  /// So: never shrink as text is added, grow in several distinct steps rather than
+  /// jumping straight to the cap, and end flat.
+  @Test("the box grows in steps as text is added, then holds")
+  func growthIsSteppedThenFlat() throws {
+    var heights: [CGFloat] = []
+    for units in 1...10 {
+      heights.append(try pillHeight(showing: .text(Self.words(lines: units))))
+    }
+
+    for (i, h) in heights.enumerated() where i > 0 {
+      #expect(
+        h >= heights[i - 1],
+        """
+        adding text SHRANK the box at step \(i + 1): \(heights[i - 1])pt -> \(h)pt. \
+        Sequence: \(heights.map { String(format: "%.0f", $0) }.joined(separator: ", "))
+        """)
+    }
+
+    let distinct = Set(heights).count
+    #expect(
+      distinct >= 4,
+      """
+      only \(distinct) distinct heights across ten lengths: \
+      \(heights.map { String(format: "%.0f", $0) }.joined(separator: ", ")). The box \
+      is meant to grow a line at a time, not jump to its cap.
+      """)
+
+    #expect(
+      heights.last == heights[heights.count - 2],
+      "the box was still growing at the longest text — the cap is not holding")
+  }
+
+  @Test("past five lines the box stops growing")
+  func growthStopsAtFive() throws {
+    let five = try pillHeight(showing: .text(Self.words(lines: 5)))
+    let eight = try pillHeight(showing: .text(Self.words(lines: 8)))
+    let twenty = try pillHeight(showing: .text(Self.words(lines: 20)))
+
+    #expect(
+      eight == twenty, "eight lines \(eight)pt vs twenty \(twenty)pt — the cap is not holding")
+    #expect(
+      eight >= five,
+      "eight lines measured \(eight)pt, less than five lines at \(five)pt")
+  }
+
+  @Test("a box at the cap returns to one-line height when the text retracts")
+  func theCapIsNotAOneWayDoor() throws {
+    let long = try pillHeight(showing: .text(Self.words(lines: 8)))
+    let short = try pillHeight(showing: .text("back to one line"))
+    #expect(short < long, "retracted to \(short)pt from \(long)pt")
+  }
+}


### PR DESCRIPTION
Chunk C of #2198, stacked on #2211. **Do not merge before #2211** — the diff against `main` will include
chunk B's commits until that lands.

Part of #2198. Closes #2203.

14pt on a 21pt line, a hairline under the header (shipped in #2211), a fade at the top of the well.
The five-line cap, the bottom-pinned clipping and the founder's growth rule are unchanged.

## The defect this removes is a comment

The type size lived in TWO independent literals:

- `previewText` set `.font(.system(size: 12))`
- `previewHeight(lines:)` built `NSFont.systemFont(ofSize: 12)` from its OWN hardcoded 12, twenty lines
  away

…under a doc comment asserting the cap is "derived from the font's own metrics rather than a literal, so
the cap tracks the type size instead of drifting silently if it changes". It derived from its own literal
and tracked nothing. **A false justification is worse than no comment: it stops the next reader checking.**

**And raising both to 14 would still not have produced the 21pt line the design calls for.** A 14pt system
font's glyph box is 17pt; the rest is `lineSpacing`, which the cap has to COUNT. Five lines occupy five
glyph heights plus FOUR gaps, so a cap summing only glyphs under-measures by 4 × spacing and clips the
fifth line partway.

Both traps turn "five lines" into four-and-a-bit while every number that looks like a line count still
reads 5. One authority now — `previewFontSize`, `previewLineSpacing`, and a `previewHeight` that counts
the gaps.

## The fade also does the age treatment, and the mechanism is the point

Dimming older LINES requires knowing where the text engine broke them — exactly the knowledge
`previewText`'s own doc comment records as unavailable, since a character budget is wrong by 2× for CJK
and wrong again for any proportional font.

A gradient over the well needs no line information at all and behaves identically in every script, because
older words are higher up by construction. Masking does not participate in layout, so the cap is
untouched.

The fade is deliberately shallow (22% of the well). It exists to say "there is more above this", not to
hide a line: at the cap the oldest visible line is still readable, just clearly on its way out.

## A test was rewritten after failing, and the failure was the test's fault

The first version walked 1...5 repetitions of a sample sentence requiring each to be strictly taller. It
failed at the capped height, because at 14pt one repetition wraps to more than one line — the box reached
its cap before the loop reached 5. **The test had encoded a guess about text metrics as though it were the
rule.**

It now asserts what the founder's rule actually says: adding text never SHRINKS the box, growth happens in
several distinct steps rather than jumping straight to the cap, and it ends flat. That holds at any size,
width or script, and will survive chunk D.

## Evidence

- Typography suite asserts the arithmetic directly rather than a rendered result: two lines cost one gap
  more than twice one line, five lines cost four gaps, one line has no gap, zero lines does not go
  negative, and the cap derives from the same size the text renders at.
- **#2201's sizing suite re-run against this chunk: 8/8 green.** The new font, the line spacing and the
  mask do not reintroduce the proposal-dependent height that chunk fixed. This is the check that matters
  most here, and it is only possible because chunk A shipped separately.
- Debug 6217, Release 5667, zero failures. Per-bundle lines reconcile against both totals exactly
  (6012 + 205, 5462 + 205).

## Still owed

Live UAT: the fade and the larger type at true size, and that five lines still means five lines on screen.
Machine-drivable per `tools-and-apps.md` FACT: the-record-hotkey-IS-drivable-synthetically-only-cancel-is-not.
