### PR TITLE
Live Preview pill: follow the appearance setting, in light and dark (#2204)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/PreviewPillPalette.swift
+++ b/Sources/EnviousWisprAppKit/App/PreviewPillPalette.swift
@@ -1,0 +1,125 @@
+import AppKit
+import SwiftUI
+
+/// #2204: every colour the live preview pill draws, as a light/dark pair.
+///
+/// The pill was permanently dark. The founder's decision (2026-08-19) is that it
+/// follows the app's Appearance setting — System, Light or Dark — like the rest of
+/// the app.
+///
+/// ## Why these live here and not inline
+///
+/// Two reasons, and the second is the load-bearing one.
+///
+/// First, `RecordingOverlayPanel.swift` is ~3,000 lines and the pill's colours
+/// were scattered through it as literals. Collecting them makes "what does the
+/// preview pill look like" a question with one answer.
+///
+/// Second, and this is the isolation the whole epic turns on: **every modifier on
+/// `RecordingOverlayView`'s root is rendered by BOTH the preview pill and the
+/// protected 185pt capsule**, and `OverlayCapsuleBackground` has EIGHT call sites
+/// of which only one is the preview. A colour that becomes dynamic in the wrong
+/// place restyles the polishing pill, the cold-start notice, the distress variant
+/// and four others — surfaces that ship to everyone, while the preview ships OFF
+/// by default and is macOS 26+. **The leak direction is the dangerous one.**
+/// Naming these `preview*` and reading them only from preview-gated branches makes
+/// a leak visible at the call site rather than in a diff of colour literals.
+///
+/// ## The mechanism is the app's existing one
+///
+/// `Color.stDynamic` builds an `NSColor(name:)` whose resolver picks per
+/// appearance at draw time; `AppearanceController` sets `NSApplication.shared
+/// .appearance` from the user's preference. `BluetoothAwarenessCardView` is the
+/// precedent INSIDE this same panel. A borderless `NSPanel` inherits
+/// `NSApp.appearance` because `NSWindow.appearanceSource` defaults to `NSApp`, and
+/// `showPanel` sets no override — **do not add one**, it would pin the pill to a
+/// single theme.
+///
+/// ## Light is not an inversion
+///
+/// The pill floats over whatever the user is looking at, so light-on-light and
+/// dark-on-dark both happen. Both variants are near-opaque and carry their own
+/// border and shadow rather than borrowing contrast from what is behind them. The
+/// light surface is warm rather than pure white, matching the app's own
+/// lavender-tinted page colour.
+enum PreviewPillPalette {
+
+  // MARK: - Surface
+
+  /// The pill's own background. Deliberately more opaque than the capsule's 0.82:
+  /// a translucent light panel over a white document disappears, and the preview
+  /// pill is the one that carries text you have to read.
+  static let surface = Color.stDynamic(
+    lightRGB: (0.988, 0.980, 1.0, 0.94),
+    darkRGB: (0.067, 0.059, 0.094, 0.90))
+
+  /// The hairline around the pill. Light needs a real border because the surface
+  /// alone does not separate it from a pale document.
+  static let border = Color.stDynamic(
+    lightRGB: (0.059, 0.039, 0.102, 0.14),
+    darkRGB: (1.0, 1.0, 1.0, 0.13))
+
+  /// The rule between the header and the reading well.
+  static let divider = Color.stDynamic(
+    lightRGB: (0.059, 0.039, 0.102, 0.10),
+    darkRGB: (1.0, 1.0, 1.0, 0.09))
+
+  // MARK: - Header
+
+  /// Elapsed time. The one number in the pill, so it stays high-contrast.
+  static let timer = Color.stDynamic(
+    lightRGB: (0.133, 0.106, 0.200, 1.0),
+    darkRGB: (1.0, 1.0, 1.0, 0.94))
+
+  /// The quiet hold-to-talk state word.
+  static let modeQuiet = Color.stDynamic(
+    lightRGB: (0.059, 0.039, 0.102, 0.45),
+    darkRGB: (1.0, 1.0, 1.0, 0.50))
+
+  /// The hands-free badge's fill and its text.
+  static let badgeFill = Color.stDynamic(
+    lightRGB: (0.059, 0.039, 0.102, 0.09),
+    darkRGB: (1.0, 1.0, 1.0, 0.13))
+  static let badgeText = Color.stDynamic(
+    lightRGB: (0.059, 0.039, 0.102, 0.72),
+    darkRGB: (1.0, 1.0, 1.0, 0.88))
+
+  // MARK: - Reading well
+
+  /// Live words.
+  static let text = Color.stDynamic(
+    lightRGB: (0.059, 0.039, 0.102, 1.0),
+    darkRGB: (1.0, 1.0, 1.0, 0.97))
+
+  /// The dimmed states — "Listening", and the reasons the preview cannot run.
+  static let textDimmed = Color.stDynamic(
+    lightRGB: (0.059, 0.039, 0.102, 0.45),
+    darkRGB: (1.0, 1.0, 1.0, 0.50))
+
+  /// The #1060 notice banner.
+  ///
+  /// **This one is why the palette exists.** The notice is rendered by BOTH
+  /// layouts from one `Text`, and its colour was a hardcoded white — invisible on
+  /// a light pill. It has to be selected on `usesPreviewLayout` at the call site,
+  /// with the capsule keeping `.white.opacity(0.95)` exactly.
+  static let notice = Color.stDynamic(
+    lightRGB: (0.059, 0.039, 0.102, 0.88),
+    darkRGB: (1.0, 1.0, 1.0, 0.95))
+
+  // MARK: - Test seam
+
+  /// Resolve a pill colour against a named appearance, so a test can assert the
+  /// pair actually differs rather than trusting that two literals were typed.
+  ///
+  /// A `Color` built from a dynamic `NSColor` reports nothing useful until it is
+  /// resolved against an appearance, which is why this exists rather than a
+  /// comparison of the `Color` values.
+  static func resolved(_ color: Color, in appearance: NSAppearance.Name) -> NSColor? {
+    let ns = NSColor(color)
+    var out: NSColor?
+    NSAppearance(named: appearance)?.performAsCurrentDrawingAppearance {
+      out = ns.usingColorSpace(.sRGB)
+    }
+    return out
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/PreviewPillPalette.swift
+++ b/Sources/EnviousWisprAppKit/App/PreviewPillPalette.swift
@@ -72,8 +72,15 @@ enum PreviewPillPalette {
     darkRGB: (1.0, 1.0, 1.0, 0.94))
 
   /// The quiet hold-to-talk state word.
+  ///
+  /// **0.60 in light, not the 0.45 that mirrors dark.** Cloud review measured the
+  /// mirrored value at 3.10:1 against the light surface, below the 4.5:1 floor.
+  /// Dark ink losing contrast as it fades toward a near-white ground is not
+  /// symmetric with white text fading toward a near-black one, so a light palette
+  /// built by mirroring dark's alphas is wrong wherever a colour is deliberately
+  /// quiet. 0.60 measures 5.09:1.
   static let modeQuiet = Color.stDynamic(
-    lightRGB: (0.059, 0.039, 0.102, 0.45),
+    lightRGB: (0.059, 0.039, 0.102, 0.60),
     darkRGB: (1.0, 1.0, 1.0, 0.50))
 
   /// The hands-free badge's fill and its text.
@@ -92,8 +99,13 @@ enum PreviewPillPalette {
     darkRGB: (1.0, 1.0, 1.0, 0.97))
 
   /// The dimmed states — "Listening", and the reasons the preview cannot run.
+  ///
+  /// **Dimmed does not mean optional here.** This renders `.unavailable`, which is
+  /// a full sentence explaining WHY the preview is not running — read at exactly
+  /// the moment the user is confused. Cloud review measured the mirrored 0.45 at
+  /// 3.10:1 in light; 0.60 measures 5.09:1.
   static let textDimmed = Color.stDynamic(
-    lightRGB: (0.059, 0.039, 0.102, 0.45),
+    lightRGB: (0.059, 0.039, 0.102, 0.60),
     darkRGB: (1.0, 1.0, 1.0, 0.50))
 
   /// The #1060 notice banner.

--- a/Sources/EnviousWisprAppKit/App/PreviewPillPalette.swift
+++ b/Sources/EnviousWisprAppKit/App/PreviewPillPalette.swift
@@ -152,6 +152,34 @@ enum PreviewPillPalette {
   /// Every colour the pill draws.
   static let allColours: [(name: String, colour: Color)] = textColours + surfaceColours
 
+  // KNOWN LIMIT, accepted at review round 6 rather than left to be rediscovered.
+  //
+  // **The name in each tuple is a string literal, not a binding to the declaration
+  // it names.** Written as `("textDimmed", text)` by copy-paste, the parsed
+  // declaration `textDimmed` still looks accounted for while the pair and contrast
+  // tests exercise `text` twice and `textDimmed` never.
+  //
+  // It is not closable without reflection, a macro, or code generation. Swift
+  // cannot enumerate static members at runtime, and a lookup-by-name accessor
+  // (`static let surface = entries.first { $0.name == "surface" }!.colour`) trades a
+  // compile-time-visible typo for a force-unwrap that crashes the app, or a silent
+  // fallback colour — both worse than the hole.
+  //
+  // A distinctness check over resolved values would catch it, EXCEPT that
+  // `modeQuiet` and `textDimmed` legitimately hold identical values today, so it
+  // would false-positive on correct code. Changing one of them purely to enable a
+  // test would be the tail wagging the dog.
+  //
+  // What bounds the risk: all ten entries sit in one screenful directly beneath the
+  // declarations they name, so a mismatch is visible where it is written rather
+  // than three hundred lines away in another target — which is what the round-5
+  // restructure bought. The residual failure needs a copy-paste inside that
+  // screenful, and costs one colour going unchecked.
+  //
+  // **Reopen this if a colour is ever added whose values duplicate another's for a
+  // reason other than being the same colour** — at that point the distinctness
+  // check becomes viable and should be preferred to this comment.
+
   // MARK: - Test seam
 
   /// Resolve a pill colour against a named appearance, so a test can assert the

--- a/Sources/EnviousWisprAppKit/App/PreviewPillPalette.swift
+++ b/Sources/EnviousWisprAppKit/App/PreviewPillPalette.swift
@@ -118,6 +118,40 @@ enum PreviewPillPalette {
     lightRGB: (0.059, 0.039, 0.102, 0.88),
     darkRGB: (1.0, 1.0, 1.0, 0.95))
 
+  // MARK: - The canonical collections
+  //
+  // **These live in the PALETTE, not in the test, and that is the structural half
+  // of the fix.** Three review rounds ran on hand-written arrays in the test file
+  // that had to be kept in step with the declarations here; each round pinned one
+  // array and left a sibling. Two files that must agree is the defect. One file
+  // that lists its own members can still be wrong, but it is wrong where the
+  // declaration is, in the reader's eye, rather than three hundred lines away in
+  // another target.
+  //
+  // A colour belongs to exactly one of these. `allColours` is their sum and is
+  // what a test iterates.
+
+  /// Colours that draw TEXT and therefore carry a contrast obligation.
+  static let textColours: [(name: String, colour: Color)] = [
+    ("timer", timer),
+    ("modeQuiet", modeQuiet),
+    ("badgeText", badgeText),
+    ("text", text),
+    ("textDimmed", textDimmed),
+    ("notice", notice),
+  ]
+
+  /// Colours that do not draw text: surfaces, borders, fills.
+  static let surfaceColours: [(name: String, colour: Color)] = [
+    ("surface", surface),
+    ("border", border),
+    ("divider", divider),
+    ("badgeFill", badgeFill),
+  ]
+
+  /// Every colour the pill draws.
+  static let allColours: [(name: String, colour: Color)] = textColours + surfaceColours
+
   // MARK: - Test seam
 
   /// Resolve a pill colour against a named appearance, so a test can assert the

--- a/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
@@ -2297,9 +2297,20 @@ private struct OverlayCapsuleBackground: View {
     }
   }
 
+  /// #2204: the preview branch follows the appearance setting; the capsule does
+  /// not. This type has EIGHT call sites and only `.rounded` is the preview, so
+  /// every colour here is selected on `cornerStyle` and the `.capsule` values stay
+  /// byte-identical for the polishing pill, the cold-start notice, the distress
+  /// variant and four others — surfaces that ship to everyone, while the preview
+  /// ships OFF by default and is macOS 26+.
+  private var isPreview: Bool { cornerStyle == .rounded }
+
   var body: some View {
     shape
-      .fill(Color(red: 0.078, green: 0.078, blue: 0.11).opacity(0.82))
+      .fill(
+        isPreview
+          ? PreviewPillPalette.surface
+          : Color(red: 0.078, green: 0.078, blue: 0.11).opacity(0.82))
       // `strokeBorder` needs an insettable shape, which the type-erased `AnyShape`
       // is not, so the two concrete shapes are named here. Kept as `strokeBorder`
       // rather than switching both to `stroke`: the capsule is shipped UI and its
@@ -2311,7 +2322,7 @@ private struct OverlayCapsuleBackground: View {
             Capsule().strokeBorder(Color.white.opacity(0.1), lineWidth: 0.5)
           case .rounded:
             RoundedRectangle(cornerRadius: 16, style: .continuous)
-              .strokeBorder(Color.white.opacity(0.1), lineWidth: 0.5)
+              .strokeBorder(PreviewPillPalette.border, lineWidth: 0.5)
           }
         }
       )
@@ -2482,7 +2493,7 @@ struct RecordingOverlayView: View {
     HStack(spacing: 12) {
       Text(FormattingConstants.formatDuration(elapsed))
         .font(.system(size: 13, weight: .semibold, design: .monospaced))
-        .foregroundStyle(.white.opacity(0.94))
+        .foregroundStyle(PreviewPillPalette.timer)
 
       RainbowLevelMeter(audioLevel: audioLevel)
 
@@ -2494,20 +2505,20 @@ struct RecordingOverlayView: View {
         // you saw the other size a second earlier.
         HStack(spacing: 6) {
           Circle()
-            .fill(Color.white.opacity(0.88))
+            .fill(PreviewPillPalette.badgeText)
             .frame(width: 5, height: 5)
           Text(LivePreviewCopy.handsFreeMode)
         }
         .font(.system(size: 11, weight: .semibold))
-        .foregroundStyle(.white.opacity(0.88))
+        .foregroundStyle(PreviewPillPalette.badgeText)
         .padding(.horizontal, 9)
         .padding(.vertical, 3)
-        .background(Capsule().fill(Color.white.opacity(0.13)))
+        .background(Capsule().fill(PreviewPillPalette.badgeFill))
         .transition(.opacity)
       } else {
         Text(LivePreviewCopy.listeningMode)
           .font(.system(size: 11, weight: .semibold))
-          .foregroundStyle(.white.opacity(0.5))
+          .foregroundStyle(PreviewPillPalette.modeQuiet)
           .transition(.opacity)
       }
     }
@@ -2518,7 +2529,7 @@ struct RecordingOverlayView: View {
     .frame(height: Self.previewHeaderHeight)
     .overlay(alignment: .bottom) {
       Rectangle()
-        .fill(Color.white.opacity(0.09))
+        .fill(PreviewPillPalette.divider)
         .frame(height: 0.5)
     }
   }
@@ -2558,7 +2569,12 @@ struct RecordingOverlayView: View {
       if let notice = noticeState.message {
         Text(notice)
           .font(.system(size: 11, weight: .medium))
-          .foregroundStyle(.white.opacity(0.95))
+          // #2204: the notice is rendered by BOTH layouts from this one `Text`,
+          // and white is invisible on a light pill. Gated rather than made
+          // dynamic, so the capsule's paint is unchanged to the byte.
+          .foregroundStyle(
+            usesPreviewLayout ? PreviewPillPalette.notice : Color.white.opacity(0.95)
+          )
           .multilineTextAlignment(.center)
           .fixedSize(horizontal: false, vertical: true)
           // 170pt suits the 185pt capsule. The preview pill is 400pt wide, so the
@@ -2787,7 +2803,11 @@ struct PreviewWellText: View {
     Text(message)
       .font(.system(size: RecordingOverlayView.previewFontSize))
       .lineSpacing(RecordingOverlayView.previewLineSpacing)
-      .foregroundStyle(.white.opacity(dimmed ? 0.5 : 0.92))
+      .foregroundStyle(
+        usesPreviewLayout
+          ? (dimmed ? PreviewPillPalette.textDimmed : PreviewPillPalette.text)
+          : .white.opacity(dimmed ? 0.5 : 0.92)
+      )
       .multilineTextAlignment(.leading)
       .fixedSize(horizontal: false, vertical: true)
       .frame(maxWidth: .infinity, alignment: .leading)

--- a/Tests/EnviousWisprTests/App/CapsuleBackgroundFreezeTests.swift
+++ b/Tests/EnviousWisprTests/App/CapsuleBackgroundFreezeTests.swift
@@ -1,0 +1,151 @@
+import AppKit
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #2204: `OverlayCapsuleBackground`'s NON-preview paint is frozen.
+///
+/// **This is a Drift Guard, not a Product Outcome, and the distinction is not
+/// bookkeeping.** It does not prove the polishing pill looks right; it proves
+/// nobody changed it. When it fails, the user sees nothing — we changed our own
+/// code. It must never be counted as evidence that any pill renders correctly.
+///
+/// ## Why it exists anyway
+///
+/// `OverlayCapsuleBackground` has EIGHT call sites and only one is the preview.
+/// The other seven — the polishing pill, the cold-start notice, the distress
+/// variant, the notification, import-status, accessibility-toast and recovery
+/// pills — ship to EVERY user. The preview ships OFF by default and needs
+/// macOS 26+.
+///
+/// So the leak direction is badly asymmetric: a mistake in the preview's colours
+/// is seen by the few who opted in, while a mistake in the shared default is seen
+/// by everyone, on surfaces the founder explicitly reserved for a later redesign.
+/// And it is invisible to every preview test by construction, because none of them
+/// render the capsule.
+///
+/// ## Why it reads source rather than rendering
+///
+/// A `Color` literal inside a `View`'s body cannot be interrogated without
+/// rendering, and rendering a capsule proves what it looks like today rather than
+/// that it is unchanged. Reading the declaration is the only mechanism that
+/// answers "is this still what it was" — the same reason
+/// `TestInventoryFreezeTests` parses Swift rather than enumerating suites at
+/// runtime.
+///
+/// **Known limit of a text guard, stated rather than discovered later:** it
+/// asserts the literals are present, so it catches an edit and cannot catch a
+/// change made somewhere else that overrides them. It is a tripwire on the file,
+/// not a proof about the pixels.
+@MainActor
+@Suite(.tags(.driftGuard))
+struct CapsuleBackgroundFreezeTests {
+
+  init() { _ = NSApplication.shared }
+
+  private static func overlaySource() throws -> String {
+    let url = RepoRoot.url.appending(
+      path: "Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift")
+    return try String(contentsOf: url, encoding: .utf8)
+  }
+
+  /// The capsule's own values, exactly as they were before #2204.
+  /// Counts MEASURED against the tree at #2204's base, not reasoned about — the
+  /// first version guessed 2 for the border and the suite went red on its own
+  /// expectation. A drop names a deletion; a rise names a stale list.
+  ///
+  /// `capsule fill` is 2 because `DistressCapsuleBackground` carries the same
+  /// value, which is precisely how the earlier existence check managed to pass
+  /// while the capsule's own fill had been deleted. The border is 1 because only
+  /// the `.capsule` branch spells it with the `Capsule()` prefix.
+  nonisolated static let frozenCapsuleLiterals: [(what: String, expected: Int, literal: String)] = [
+    ("capsule fill", 2, "Color(red: 0.078, green: 0.078, blue: 0.11).opacity(0.82)"),
+    ("capsule border", 1, "Capsule().strokeBorder(Color.white.opacity(0.1), lineWidth: 0.5)"),
+    ("capsule notice text", 1, "Color.white.opacity(0.95)"),
+  ]
+
+  /// **Counts occurrences rather than asking whether the literal exists anywhere,
+  /// and the mutation control is what found that.** The first version used
+  /// `source.contains(...)`. Deleting the capsule fill entirely — the exact leak
+  /// this suite exists to catch — left that check GREEN, because
+  /// `DistressCapsuleBackground` carries the same literal and the whole-file
+  /// search found it there. A guard that reads the whole file cannot tell which
+  /// copy it found.
+  @Test(
+    "the capsule's own colours are unchanged",
+    arguments: CapsuleBackgroundFreezeTests.frozenCapsuleLiterals)
+  func capsuleLiteralsAreFrozen(entry: (what: String, expected: Int, literal: String)) throws {
+    let source = try Self.overlaySource()
+    let found = source.components(separatedBy: entry.literal).count - 1
+    #expect(
+      found == entry.expected,
+      """
+      the \(entry.what) literal appears \(found) times, expected \(entry.expected). \
+      #2204 is gated to the preview branch; the capsule paint is shared by seven \
+      other pills that ship to everyone and is reserved for a separate redesign. A \
+      count that DROPPED means one of them lost its colour; a count that ROSE means \
+      the freeze list is stale.
+      """)
+  }
+
+  /// The palette must not be readable from `OverlayCapsuleBackground`'s SHARED
+  /// default. That struct is the eight-call-site surface; the rest of the file's
+  /// palette reads live in `previewHeader` and `PreviewWellText`, which are
+  /// preview-only by CONSTRUCTION rather than by a nearby keyword.
+  ///
+  /// **The first version of this checked for a gate keyword within six lines of
+  /// each palette reference, and it was wrong in the way this repo keeps
+  /// recording: a comparison narrower than the language.** `previewHeader` is
+  /// reached only from `if usesPreviewLayout`, so every line in it is gated and
+  /// none of them says so. Lexical proximity is not the property; reachability is,
+  /// and the honest way to check reachability cheaply is to scope the check to the
+  /// one type where a leak is possible.
+  @Test("the shared capsule background reads the palette only on its preview branch")
+  func capsuleBackgroundGatesEveryPaletteRead() throws {
+    let source = try Self.overlaySource()
+    let lines = source.split(separator: "\n", omittingEmptySubsequences: false)
+
+    let open = try #require(
+      lines.firstIndex { $0.contains("struct OverlayCapsuleBackground") },
+      "OverlayCapsuleBackground not found — this guard is pointed at nothing")
+    let close = try #require(
+      lines[open...].firstIndex { $0.hasPrefix("private struct DistressCapsuleBackground") },
+      "could not find the end of OverlayCapsuleBackground")
+
+    var reads = 0
+    for i in open..<close where lines[i].contains("PreviewPillPalette.") {
+      reads += 1
+      let context = lines[max(open, i - 3)...min(close, i + 1)].joined(separator: "\n")
+      #expect(
+        context.contains("isPreview") || context.contains("case .rounded"),
+        """
+        line \(i + 1) of OverlayCapsuleBackground reads the preview palette outside \
+        its preview branch: \(lines[i].trimmingCharacters(in: .whitespaces)). That \
+        struct paints seven pills that are not the preview.
+        """)
+    }
+
+    #expect(
+      reads >= 2,
+      """
+      only \(reads) palette reads inside OverlayCapsuleBackground. The gate check \
+      passes vacuously with nothing to gate, so this pins that the preview branch \
+      really is wired to the palette.
+      """)
+  }
+
+  /// A two-way control: the guard above is worthless if the palette is never
+  /// mentioned at all, which would also make every line trivially "gated".
+  @Test("the palette is actually used, so the gate check is not vacuous")
+  func paletteIsActuallyReferenced() throws {
+    let source = try Self.overlaySource()
+    let count = source.components(separatedBy: "PreviewPillPalette.").count - 1
+    #expect(
+      count >= 8,
+      """
+      only \(count) references to the preview palette in RecordingOverlayPanel.swift. \
+      The gate check above passes vacuously when there is nothing to gate, so this \
+      pins that the wiring is really there.
+      """)
+  }
+}

--- a/Tests/EnviousWisprTests/App/PreviewPillPaletteTests.swift
+++ b/Tests/EnviousWisprTests/App/PreviewPillPaletteTests.swift
@@ -1,0 +1,147 @@
+import AppKit
+import SwiftUI
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #2204: the preview pill follows the app's Appearance setting.
+///
+/// **The risk in this chunk is not that the pill looks wrong — it is that the
+/// SEVEN other pills change.** `OverlayCapsuleBackground` has eight call sites and
+/// only one is the preview; the others are the polishing pill, the cold-start
+/// notice, the distress variant and four more, and they ship to everyone. The
+/// preview ships OFF by default and is macOS 26+, so a leak reaches vastly more
+/// users than the feature does. That asymmetry is why the capsule guard here is
+/// stricter than the preview one.
+@MainActor
+@Suite(.tags(.productOutcome))
+struct PreviewPillPaletteTests {
+
+  init() { _ = NSApplication.shared }
+
+  /// Every colour the pill draws. A new one added to the palette and forgotten
+  /// here is the failure this list exists to make loud.
+  nonisolated static let allPillColours: [(name: String, colour: Color)] = [
+    ("surface", PreviewPillPalette.surface),
+    ("border", PreviewPillPalette.border),
+    ("divider", PreviewPillPalette.divider),
+    ("timer", PreviewPillPalette.timer),
+    ("modeQuiet", PreviewPillPalette.modeQuiet),
+    ("badgeFill", PreviewPillPalette.badgeFill),
+    ("badgeText", PreviewPillPalette.badgeText),
+    ("text", PreviewPillPalette.text),
+    ("textDimmed", PreviewPillPalette.textDimmed),
+    ("notice", PreviewPillPalette.notice),
+  ]
+
+  // MARK: - The pair is real
+
+  /// A colour that resolves the SAME in both appearances is one somebody forgot to
+  /// pair — it compiles, it looks right in whichever theme they were testing, and
+  /// it ships one theme's paint into the other.
+  @Test("every pill colour actually differs between light and dark")
+  func everyColourIsAPair() throws {
+    for (name, colour) in Self.allPillColours {
+      let light = try #require(
+        PreviewPillPalette.resolved(colour, in: .aqua), "\(name) did not resolve in light")
+      let dark = try #require(
+        PreviewPillPalette.resolved(colour, in: .darkAqua), "\(name) did not resolve in dark")
+
+      let same =
+        abs(light.redComponent - dark.redComponent) < 0.001
+        && abs(light.greenComponent - dark.greenComponent) < 0.001
+        && abs(light.blueComponent - dark.blueComponent) < 0.001
+        && abs(light.alphaComponent - dark.alphaComponent) < 0.001
+
+      #expect(
+        !same,
+        """
+        \(name) resolves identically in both appearances, so it was never paired. \
+        It will ship one theme's paint into the other and look correct only in \
+        whichever theme it was written in.
+        """)
+    }
+  }
+
+  // MARK: - Light is legible
+
+  /// The pill floats over arbitrary windows, so it cannot borrow contrast from
+  /// what is behind it. Text on surface has to carry itself.
+  @Test("light text on the light surface clears a readable contrast ratio")
+  func lightTextIsLegible() throws {
+    let surface = try #require(PreviewPillPalette.resolved(PreviewPillPalette.surface, in: .aqua))
+    let text = try #require(PreviewPillPalette.resolved(PreviewPillPalette.text, in: .aqua))
+    let ratio = Self.contrastRatio(text, on: surface)
+    #expect(
+      ratio >= 4.5,
+      "light text on the light surface is \(String(format: "%.1f", ratio)):1, below 4.5:1")
+  }
+
+  @Test("dark text on the dark surface clears a readable contrast ratio")
+  func darkTextIsLegible() throws {
+    let surface = try #require(
+      PreviewPillPalette.resolved(PreviewPillPalette.surface, in: .darkAqua))
+    let text = try #require(PreviewPillPalette.resolved(PreviewPillPalette.text, in: .darkAqua))
+    let ratio = Self.contrastRatio(text, on: surface)
+    #expect(
+      ratio >= 4.5,
+      "dark text on the dark surface is \(String(format: "%.1f", ratio)):1, below 4.5:1")
+  }
+
+  /// The notice is the colour that was hardcoded white and would have been
+  /// invisible on a light pill. It carries a cap warning, so it is the one piece
+  /// of copy in the box the user must not miss.
+  @Test("the notice is legible in both appearances")
+  func noticeIsLegibleInBoth() throws {
+    for appearance in [NSAppearance.Name.aqua, .darkAqua] {
+      let surface = try #require(
+        PreviewPillPalette.resolved(PreviewPillPalette.surface, in: appearance))
+      let notice = try #require(
+        PreviewPillPalette.resolved(PreviewPillPalette.notice, in: appearance))
+      let ratio = Self.contrastRatio(notice, on: surface)
+      #expect(
+        ratio >= 4.5,
+        "the notice is \(String(format: "%.1f", ratio)):1 in \(appearance.rawValue)")
+    }
+  }
+
+  /// The pill is near-opaque on purpose: it sits over arbitrary windows and must
+  /// not borrow its legibility from whatever happens to be behind it.
+  @Test("the surface is opaque enough to carry its own contrast")
+  func surfaceIsNearlyOpaque() throws {
+    for appearance in [NSAppearance.Name.aqua, .darkAqua] {
+      let surface = try #require(
+        PreviewPillPalette.resolved(PreviewPillPalette.surface, in: appearance))
+      #expect(
+        surface.alphaComponent >= 0.88,
+        """
+        the surface is \(surface.alphaComponent) alpha in \(appearance.rawValue). Below \
+        about 0.88 the window behind it starts showing through the text.
+        """)
+    }
+  }
+
+  // MARK: - Contrast maths (WCAG relative luminance)
+
+  private static func contrastRatio(_ a: NSColor, on b: NSColor) -> CGFloat {
+    // The pill's colours carry alpha, so composite the foreground over the
+    // background before measuring — a ratio taken on the raw values would flatter
+    // every translucent colour in the palette.
+    let composited = NSColor(
+      srgbRed: a.redComponent * a.alphaComponent + b.redComponent * (1 - a.alphaComponent),
+      green: a.greenComponent * a.alphaComponent + b.greenComponent * (1 - a.alphaComponent),
+      blue: a.blueComponent * a.alphaComponent + b.blueComponent * (1 - a.alphaComponent),
+      alpha: 1)
+    let l1 = relativeLuminance(composited)
+    let l2 = relativeLuminance(b)
+    return (max(l1, l2) + 0.05) / (min(l1, l2) + 0.05)
+  }
+
+  private static func relativeLuminance(_ c: NSColor) -> CGFloat {
+    func channel(_ v: CGFloat) -> CGFloat {
+      v <= 0.03928 ? v / 12.92 : pow((v + 0.055) / 1.055, 2.4)
+    }
+    return 0.2126 * channel(c.redComponent) + 0.7152 * channel(c.greenComponent)
+      + 0.0722 * channel(c.blueComponent)
+  }
+}

--- a/Tests/EnviousWisprTests/App/PreviewPillPaletteTests.swift
+++ b/Tests/EnviousWisprTests/App/PreviewPillPaletteTests.swift
@@ -150,7 +150,7 @@ struct PreviewPillPaletteTests {
   /// is the only authority available — the same mechanism
   /// `LivePreviewSettingsCopyTests.everyCopyPropertyIsCovered` uses, and for the
   /// same reason.
-  @Test("every colour in the palette is either contrast-checked or declared non-text")
+  @Test("every colour in the palette reaches BOTH hand-written arrays")
   func everyPaletteColourIsAccountedFor() throws {
     let url = RepoRoot.url.appending(
       path: "Sources/EnviousWisprAppKit/App/PreviewPillPalette.swift")
@@ -169,6 +169,27 @@ struct PreviewPillPaletteTests {
     #expect(
       declared.count >= 10,
       "parsed only \(declared.count) colours out of PreviewPillPalette.swift — the reader is wrong, not the palette")
+
+    // BOTH hand-written arrays are pinned to the parsed source, not just the one
+    // review named. `allPillColours` drives the light/dark pairing check and is a
+    // SIBLING of `textColours`: fixing one and leaving the other is the same
+    // defect one level down, which is exactly what happened between the previous
+    // two review rounds.
+    let paired = Set(Self.allPillColours.map(\.name))
+    let missingFromPairing = Set(declared).subtracting(paired).sorted()
+    #expect(
+      missingFromPairing.isEmpty,
+      """
+      \(missingFromPairing.joined(separator: ", ")) exist in PreviewPillPalette but are \
+      not in `allPillColours`, so their light and dark values are never compared. A \
+      colour that resolves the same in both themes would ship one theme's paint into \
+      the other and nothing here would notice.
+      """)
+
+    let stalePairing = paired.subtracting(Set(declared)).sorted()
+    #expect(
+      stalePairing.isEmpty,
+      "\(stalePairing.joined(separator: ", ")) are in `allPillColours` but no longer declared")
 
     let checked = Set(Self.textColours.map(\.name))
     let accounted = checked.union(Self.nonTextColours)

--- a/Tests/EnviousWisprTests/App/PreviewPillPaletteTests.swift
+++ b/Tests/EnviousWisprTests/App/PreviewPillPaletteTests.swift
@@ -19,20 +19,14 @@ struct PreviewPillPaletteTests {
 
   init() { _ = NSApplication.shared }
 
-  /// Every colour the pill draws. A new one added to the palette and forgotten
-  /// here is the failure this list exists to make loud.
-  nonisolated static let allPillColours: [(name: String, colour: Color)] = [
-    ("surface", PreviewPillPalette.surface),
-    ("border", PreviewPillPalette.border),
-    ("divider", PreviewPillPalette.divider),
-    ("timer", PreviewPillPalette.timer),
-    ("modeQuiet", PreviewPillPalette.modeQuiet),
-    ("badgeFill", PreviewPillPalette.badgeFill),
-    ("badgeText", PreviewPillPalette.badgeText),
-    ("text", PreviewPillPalette.text),
-    ("textDimmed", PreviewPillPalette.textDimmed),
-    ("notice", PreviewPillPalette.notice),
-  ]
+  /// **Read from the palette, never re-listed here.** Three review rounds ran on
+  /// hand-written copies of these lists in this file; each fix pinned one array and
+  /// left a sibling, and the last round found that comparing NAMES cannot catch a
+  /// tuple whose colour reference is wrong. Two files that must agree is the defect,
+  /// so there is now one file and this one reads it.
+  nonisolated static var allPillColours: [(name: String, colour: Color)] {
+    PreviewPillPalette.allColours
+  }
 
   // MARK: - The pair is real
 
@@ -88,35 +82,10 @@ struct PreviewPillPaletteTests {
       "dark text on the dark surface is \(String(format: "%.1f", ratio)):1, below 4.5:1")
   }
 
-  /// **Every colour that draws TEXT, not just the ones I happened to think of.**
-  ///
-  /// The first version of this suite checked `text` and `notice` and stopped
-  /// there. Cloud review found `modeQuiet` and `textDimmed` sitting at about
-  /// 3.1:1 in light — and `textDimmed` is what renders the `.unavailable`
-  /// message, which is a full sentence the user has to read to learn why the
-  /// preview is not running.
-  ///
-  /// Enumerating the SET rather than picking members is the fix: a colour added
-  /// to the palette and forgotten here now fails, instead of being legible only
-  /// if somebody remembered to add a case.
-  /// Colours that do NOT draw text, and so are exempt from the contrast floor.
-  ///
-  /// **This is the list that must be maintained, not the text one** — and that
-  /// inversion is the point. A new colour is a text colour unless someone
-  /// deliberately says otherwise here, so forgetting to update anything makes the
-  /// completeness check fail LOUD rather than pass quietly.
-  nonisolated static let nonTextColours: Set<String> = [
-    "surface", "border", "divider", "badgeFill",
-  ]
-
-  nonisolated static let textColours: [(name: String, colour: Color)] = [
-    ("text", PreviewPillPalette.text),
-    ("textDimmed", PreviewPillPalette.textDimmed),
-    ("timer", PreviewPillPalette.timer),
-    ("modeQuiet", PreviewPillPalette.modeQuiet),
-    ("badgeText", PreviewPillPalette.badgeText),
-    ("notice", PreviewPillPalette.notice),
-  ]
+  /// Read from the palette. See `allPillColours`.
+  nonisolated static var textColours: [(name: String, colour: Color)] {
+    PreviewPillPalette.textColours
+  }
 
   @Test(
     "every text colour clears 4.5:1 on the pill surface, in both appearances",
@@ -156,60 +125,61 @@ struct PreviewPillPaletteTests {
       path: "Sources/EnviousWisprAppKit/App/PreviewPillPalette.swift")
     let source = try String(contentsOf: url, encoding: .utf8)
 
-    let declared = source
-      .split(separator: "\n")
-      .compactMap { line -> String? in
-        guard let r = line.range(of: #"static let \w+ = Color\.stDynamic"#, options: .regularExpression)
-        else { return nil }
-        return String(line[r]).replacingOccurrences(of: "static let ", with: "")
-          .replacingOccurrences(of: " = Color.stDynamic", with: "")
-      }
+    // **Whole-source match, not line-by-line.** Review round 5: a declaration
+    // formatted as `static let futureLabel =` with `Color.stDynamic(...)` on the
+    // NEXT line was silently skipped by a per-line regex, and the ten existing
+    // declarations still cleared the count floor — so a colour could be absent
+    // from every collection while this check passed. That is the same shape as
+    // every other finding on this file: a comparison narrower than the language.
+    let pattern = #"static\s+let\s+(\w+)\s*(?::\s*Color\s*)?=\s*Color\s*\.\s*stDynamic"#
+    let regex = try NSRegularExpression(pattern: pattern, options: [.dotMatchesLineSeparators])
+    let ns = source as NSString
+    let declared = regex
+      .matches(in: source, range: NSRange(location: 0, length: ns.length))
+      .map { ns.substring(with: $0.range(at: 1)) }
 
     // Fail closed: a parse that finds nothing would make every check below vacuous.
     #expect(
       declared.count >= 10,
       "parsed only \(declared.count) colours out of PreviewPillPalette.swift — the reader is wrong, not the palette")
 
-    // BOTH hand-written arrays are pinned to the parsed source, not just the one
-    // review named. `allPillColours` drives the light/dark pairing check and is a
-    // SIBLING of `textColours`: fixing one and leaving the other is the same
-    // defect one level down, which is exactly what happened between the previous
-    // two review rounds.
+    // The palette's own collections must account for every declaration. This is
+    // now the ONLY hand-written mapping in the system, it lives beside the
+    // declarations it lists, and nothing in the test target duplicates it.
     let paired = Set(Self.allPillColours.map(\.name))
     let missingFromPairing = Set(declared).subtracting(paired).sorted()
     #expect(
       missingFromPairing.isEmpty,
       """
-      \(missingFromPairing.joined(separator: ", ")) exist in PreviewPillPalette but are \
-      not in `allPillColours`, so their light and dark values are never compared. A \
-      colour that resolves the same in both themes would ship one theme's paint into \
-      the other and nothing here would notice.
+      \(missingFromPairing.joined(separator: ", ")) are declared in PreviewPillPalette \
+      but absent from `allColours`, so they are never checked for a light/dark pair \
+      or for contrast. A colour resolving the same in both themes would ship one \
+      theme's paint into the other and nothing would notice.
       """)
 
     let stalePairing = paired.subtracting(Set(declared)).sorted()
     #expect(
       stalePairing.isEmpty,
-      "\(stalePairing.joined(separator: ", ")) are in `allPillColours` but no longer declared")
+      "\(stalePairing.joined(separator: ", ")) are in `allColours` but no longer declared")
 
-    let checked = Set(Self.textColours.map(\.name))
-    let accounted = checked.union(Self.nonTextColours)
-    let missing = Set(declared).subtracting(accounted).sorted()
+    // The palette's two collections must PARTITION the declarations: every colour
+    // is text or surface, never both, never neither. `allColours` is their sum, so
+    // the check above already covers "neither" — this covers "both", which would
+    // make a surface colour carry a contrast obligation it cannot meet.
+    let textNames = Set(PreviewPillPalette.textColours.map(\.name))
+    let surfaceNames = Set(PreviewPillPalette.surfaceColours.map(\.name))
+    let inBoth = textNames.intersection(surfaceNames).sorted()
+    #expect(
+      inBoth.isEmpty,
+      "\(inBoth.joined(separator: ", ")) appear in BOTH textColours and surfaceColours")
 
     #expect(
-      missing.isEmpty,
+      textNames.count + surfaceNames.count == Self.allPillColours.count,
       """
-      \(missing.joined(separator: ", ")) exist in PreviewPillPalette but are neither \
-      contrast-checked nor listed as non-text. Add each to `textColours` if it draws \
-      text, or to `nonTextColours` if it does not — silence here is what let the \
-      unreadable dimmed pair ship in the first place.
+      the two collections hold \(textNames.count) + \(surfaceNames.count) names but \
+      allColours has \(Self.allPillColours.count) entries — a duplicate inside one of \
+      them would silently drop a colour from these set comparisons.
       """)
-
-    // And the reverse: a name in the test lists that no longer exists in the
-    // palette means the lists have gone stale against a rename or deletion.
-    let stale = accounted.subtracting(Set(declared)).sorted()
-    #expect(
-      stale.isEmpty,
-      "\(stale.joined(separator: ", ")) are listed here but no longer declared in the palette")
   }
 
   /// The notice is the colour that was hardcoded white and would have been

--- a/Tests/EnviousWisprTests/App/PreviewPillPaletteTests.swift
+++ b/Tests/EnviousWisprTests/App/PreviewPillPaletteTests.swift
@@ -99,6 +99,16 @@ struct PreviewPillPaletteTests {
   /// Enumerating the SET rather than picking members is the fix: a colour added
   /// to the palette and forgotten here now fails, instead of being legible only
   /// if somebody remembered to add a case.
+  /// Colours that do NOT draw text, and so are exempt from the contrast floor.
+  ///
+  /// **This is the list that must be maintained, not the text one** — and that
+  /// inversion is the point. A new colour is a text colour unless someone
+  /// deliberately says otherwise here, so forgetting to update anything makes the
+  /// completeness check fail LOUD rather than pass quietly.
+  nonisolated static let nonTextColours: Set<String> = [
+    "surface", "border", "divider", "badgeFill",
+  ]
+
   nonisolated static let textColours: [(name: String, colour: Color)] = [
     ("text", PreviewPillPalette.text),
     ("textDimmed", PreviewPillPalette.textDimmed),
@@ -125,6 +135,60 @@ struct PreviewPillPaletteTests {
         windows, so it cannot borrow contrast from what is behind it.
         """)
     }
+  }
+
+  /// **Every colour the palette declares is either checked for contrast or named
+  /// as a non-text colour. Nothing can be silently omitted.**
+  ///
+  /// Cloud review caught the previous version claiming set-wide protection while
+  /// using a hand-maintained array: a token added to `PreviewPillPalette` and
+  /// forgotten here would leave every contrast test passing, repeating the exact
+  /// omission that missed `modeQuiet` and `textDimmed` in the first place. A list
+  /// I maintain by hand cannot protect against me forgetting to maintain it.
+  ///
+  /// Swift cannot enumerate static members at runtime, so the palette's own source
+  /// is the only authority available — the same mechanism
+  /// `LivePreviewSettingsCopyTests.everyCopyPropertyIsCovered` uses, and for the
+  /// same reason.
+  @Test("every colour in the palette is either contrast-checked or declared non-text")
+  func everyPaletteColourIsAccountedFor() throws {
+    let url = RepoRoot.url.appending(
+      path: "Sources/EnviousWisprAppKit/App/PreviewPillPalette.swift")
+    let source = try String(contentsOf: url, encoding: .utf8)
+
+    let declared = source
+      .split(separator: "\n")
+      .compactMap { line -> String? in
+        guard let r = line.range(of: #"static let \w+ = Color\.stDynamic"#, options: .regularExpression)
+        else { return nil }
+        return String(line[r]).replacingOccurrences(of: "static let ", with: "")
+          .replacingOccurrences(of: " = Color.stDynamic", with: "")
+      }
+
+    // Fail closed: a parse that finds nothing would make every check below vacuous.
+    #expect(
+      declared.count >= 10,
+      "parsed only \(declared.count) colours out of PreviewPillPalette.swift — the reader is wrong, not the palette")
+
+    let checked = Set(Self.textColours.map(\.name))
+    let accounted = checked.union(Self.nonTextColours)
+    let missing = Set(declared).subtracting(accounted).sorted()
+
+    #expect(
+      missing.isEmpty,
+      """
+      \(missing.joined(separator: ", ")) exist in PreviewPillPalette but are neither \
+      contrast-checked nor listed as non-text. Add each to `textColours` if it draws \
+      text, or to `nonTextColours` if it does not — silence here is what let the \
+      unreadable dimmed pair ship in the first place.
+      """)
+
+    // And the reverse: a name in the test lists that no longer exists in the
+    // palette means the lists have gone stale against a rename or deletion.
+    let stale = accounted.subtracting(Set(declared)).sorted()
+    #expect(
+      stale.isEmpty,
+      "\(stale.joined(separator: ", ")) are listed here but no longer declared in the palette")
   }
 
   /// The notice is the colour that was hardcoded white and would have been

--- a/Tests/EnviousWisprTests/App/PreviewPillPaletteTests.swift
+++ b/Tests/EnviousWisprTests/App/PreviewPillPaletteTests.swift
@@ -88,6 +88,45 @@ struct PreviewPillPaletteTests {
       "dark text on the dark surface is \(String(format: "%.1f", ratio)):1, below 4.5:1")
   }
 
+  /// **Every colour that draws TEXT, not just the ones I happened to think of.**
+  ///
+  /// The first version of this suite checked `text` and `notice` and stopped
+  /// there. Cloud review found `modeQuiet` and `textDimmed` sitting at about
+  /// 3.1:1 in light — and `textDimmed` is what renders the `.unavailable`
+  /// message, which is a full sentence the user has to read to learn why the
+  /// preview is not running.
+  ///
+  /// Enumerating the SET rather than picking members is the fix: a colour added
+  /// to the palette and forgotten here now fails, instead of being legible only
+  /// if somebody remembered to add a case.
+  nonisolated static let textColours: [(name: String, colour: Color)] = [
+    ("text", PreviewPillPalette.text),
+    ("textDimmed", PreviewPillPalette.textDimmed),
+    ("timer", PreviewPillPalette.timer),
+    ("modeQuiet", PreviewPillPalette.modeQuiet),
+    ("badgeText", PreviewPillPalette.badgeText),
+    ("notice", PreviewPillPalette.notice),
+  ]
+
+  @Test(
+    "every text colour clears 4.5:1 on the pill surface, in both appearances",
+    arguments: PreviewPillPaletteTests.textColours)
+  func everyTextColourIsLegible(entry: (name: String, colour: Color)) throws {
+    for appearance in [NSAppearance.Name.aqua, .darkAqua] {
+      let surface = try #require(
+        PreviewPillPalette.resolved(PreviewPillPalette.surface, in: appearance))
+      let fg = try #require(PreviewPillPalette.resolved(entry.colour, in: appearance))
+      let ratio = Self.contrastRatio(fg, on: surface)
+      #expect(
+        ratio >= 4.5,
+        """
+        \(entry.name) is \(String(format: "%.2f", ratio)):1 against the pill surface in \
+        \(appearance.rawValue), below the 4.5:1 floor. The pill floats over arbitrary \
+        windows, so it cannot borrow contrast from what is behind it.
+        """)
+    }
+  }
+
   /// The notice is the colour that was hardcoded white and would have been
   /// invisible on a light pill. It carries a cap warning, so it is the one piece
   /// of copy in the box the user must not miss.


### PR DESCRIPTION
Last chunk of #2198. The preview pill was permanently dark; it now follows the app's Appearance setting.

Part of #2198. Closes #2204.

Mockups, light and dark side by side: https://claude.ai/code/artifact/aeb2b2f9-5c4b-4ba8-8ae1-76322922fd65

## What changes

Every colour the pill draws is a light/dark pair in `PreviewPillPalette`, through the app's EXISTING
authority: `Color.stDynamic` resolving per `NSApp.appearance`, which `AppearanceController` sets from the
preference. `BluetoothAwarenessCardView` is the precedent inside this same panel.

**No per-panel `NSAppearance` override.** A borderless `NSPanel` inherits `NSApp.appearance` because
`NSWindow.appearanceSource` defaults to `NSApp` (`NSWindow.h:614`), and setting one would pin the pill to
a single theme.

Light is not an inversion. The pill floats over arbitrary windows, so both variants are near-opaque and
carry their own border and shadow rather than borrowing contrast from whatever is behind them.

## The risk here is not the preview pill

**It is the SEVEN other pills.** `OverlayCapsuleBackground` has eight call sites and only one is the
preview; the rest are the polishing pill, cold-start notice, distress variant, notification,
import-status, accessibility-toast and recovery pills. **They ship to every user.** The preview ships OFF
by default and needs macOS 26+.

So a leak reaches vastly more people than the feature does, and it is invisible to every preview test by
construction, because none of them render a capsule.

Hence: colours selected on `cornerStyle` inside that type with `.capsule` byte-identical, and the shared
#1060 notice gated at its call site rather than made dynamic — it is one `Text` rendered by both layouts,
and white is invisible on a light pill.

## Guards, and two were wrong when first written

| Guard | What it protects |
|---|---|
| Every colour is genuinely a pair | An unpaired colour compiles, looks right in whichever theme its author was in, and ships that theme into the other |
| Text clears 4.5:1 in both themes | The pill cannot borrow contrast from what is behind it |
| The notice clears it too | It carries a cap warning — the one string in the box the user must not miss |
| The surface stays ≥0.88 alpha | Below that the window behind starts showing through the text |
| The capsule is frozen | Tagged `.driftGuard`, NOT `.productOutcome` |

The contrast maths composites alpha over the surface first. A ratio taken on raw values flatters every
translucent colour in the palette.

**The freeze guard is a Drift Guard and is labelled as one.** It does not prove the polishing pill looks
right; it proves nobody changed it. When it fails the user sees nothing — we changed our own code. It must
never be cited as evidence that any pill renders correctly.

### Both structural guards were wrong first, and the mutation control is what said so

- **The gate check** required a preview keyword within six lines of each palette read. `previewHeader` is
  reached only from `if usesPreviewLayout`, so every line in it is gated and none says so — lexical
  proximity is not the property, reachability is. Rescoped to `OverlayCapsuleBackground`, the one type
  where a leak is possible; everything else in the file is preview-only by construction.
- **The frozen-literal check** asked whether each colour still appears ANYWHERE in the file. Deleting the
  capsule fill entirely — the exact leak this suite exists to catch — left it **GREEN**, because
  `DistressCapsuleBackground` carries the same literal. A whole-file search cannot tell which copy it
  found. It counts occurrences now, and the counts are MEASURED rather than reasoned: a first pass guessed
  2 for the border and the suite went red on its own expectation.

Leak control, both directions: painting all eight callers with the preview surface turns the gate check
RED. Tree restored byte-identical, verified with `cmp`.

## Evidence

Debug 6231, Release 5681, zero failures. Per-bundle lines reconcile exactly (6026 + 205, 5476 + 205).

The lane ran before the rebase onto merged main; `git rev-parse` shows the tree hash is **identical**
before and after (`b4d1e405…`), so the result is about exactly these bytes rather than about a tree that
resembles them.

## Still owed, and one open question the founder already ruled on

Live UAT, including whether the pill REPAINTS while a recording is live when Appearance changes.

Grounded review r4 wanted a repaint failure treated as a pre-emptive ship blocker. **The founder overruled
that** (2026-08-19): "we can test this once it's built." So it is built, then measured, and a negative
result comes back with its measurement rather than being decided in advance. Recorded on #2204 so nobody
relitigates it.
