### PR TITLE
fix(recovery): a load that returns unready no longer costs the recording (#2207)

### DIFF
--- a/Sources/EnviousWisprASR/ASRManagerInterface.swift
+++ b/Sources/EnviousWisprASR/ASRManagerInterface.swift
@@ -32,6 +32,36 @@ extension ASRLoadSupersededError: StableSentryErrorIdentity {
   public var sentrySemanticID: String { "asr.load_superseded" }
 }
 
+/// Thrown by `ActiveEngineOperation.load` when the load returned NORMALLY and the
+/// engine's own readiness projection is still false (#2207). `ASRManager.loadModel()`
+/// RECORDS readiness rather than requiring it (`ASRManager.swift:175-177`), so a
+/// returning load has never meant "ready"; every caller nonetheless assumed it did.
+///
+/// Semantics: FAILURE, TRANSIENT. It means only "the load returned and the
+/// postcondition was false" — deliberately NOT a claim about WHY. Readiness may
+/// never have arrived, or may have been lost between the load's final internal
+/// generation check and this one. Recovery gives either shape the same bounded
+/// retry, so the distinction would buy nothing and asserting it would be a
+/// causal claim the call site cannot observe.
+///
+/// Distinct from `ASRLoadSupersededError`, which means a supersede was detected
+/// INSIDE the load. Conflating them is the #2132 trap: supersession classifies as
+/// `.cancelled`, which recovery treats as terminal and DELETES the recording.
+public struct ASREngineNotReadyAfterLoadError: Error, Equatable {
+  public init() {}
+}
+
+/// #1525 PR G. Pinned defensively at introduction rather than retrofitted: this
+/// type IS reachable from a Sentry capture path on day one, via the recovery
+/// replayer's unrecoverable branch. NEVER change this string once shipped.
+extension ASREngineNotReadyAfterLoadError: StableSentryErrorIdentity {
+  public var sentryFingerprintDescriptor: String {
+    "EnviousWisprASR.ASREngineNotReadyAfterLoadError#1"
+  }
+
+  public var sentrySemanticID: String { "asr.engine_not_ready_after_load" }
+}
+
 /// Thrown when the ASR manager is asked to load or transcribe on an engine it
 /// does not own (#1386 PR-2: WhisperKit). WhisperKit runs in-process behind its
 /// relocation gate via `WhisperKitEngineAdapter`; the manager and its XPC helper

--- a/Sources/EnviousWisprASR/ASRManagerInterface.swift
+++ b/Sources/EnviousWisprASR/ASRManagerInterface.swift
@@ -47,8 +47,16 @@ extension ASRLoadSupersededError: StableSentryErrorIdentity {
 /// Distinct from `ASRLoadSupersededError`, which means a supersede was detected
 /// INSIDE the load. Conflating them is the #2132 trap: supersession classifies as
 /// `.cancelled`, which recovery treats as terminal and DELETES the recording.
-public struct ASREngineNotReadyAfterLoadError: Error, Equatable {
+public struct ASREngineNotReadyAfterLoadError: Error, LocalizedError, Equatable {
   public init() {}
+
+  /// Rendered to the user by the Diagnostics benchmark, which shows
+  /// `error.localizedDescription`. Without this they would read Foundation's
+  /// generated type-and-domain string. Every sibling error in this module
+  /// already conforms; this one was the outlier.
+  public var errorDescription: String? {
+    "The engine finished loading but was not ready to use."
+  }
 }
 
 /// #1525 PR G. Pinned defensively at introduction rather than retrofitted: this

--- a/Sources/EnviousWisprASR/RecoveryFailureClassification.swift
+++ b/Sources/EnviousWisprASR/RecoveryFailureClassification.swift
@@ -30,6 +30,10 @@ package func recoveryFailureClass(for error: any Error) -> RecoveryFailureClass?
   }
   // Three cancellation vehicles, one actionable class. `KernelDictationDriver`
   // already groups the latter two exactly this way.
+  // BEFORE the supersede arm deliberately: both are post-load conditions, and
+  // classifying this one as `.cancelled` is exactly the #2132 trap — cancelled is
+  // terminal, so the recording would be deleted rather than retried.
+  if error is ASREngineNotReadyAfterLoadError { return .loadReturnedNotReady }
   if error is ASRLoadSupersededError || error is ASRLoadCancelledError
     || error is CancellationError
   {

--- a/Sources/EnviousWisprAppKit/App/ActiveEngineOperation.swift
+++ b/Sources/EnviousWisprAppKit/App/ActiveEngineOperation.swift
@@ -21,6 +21,13 @@ struct ActiveEngineOperation {
   /// Whether the active engine already has a model resident.
   let isLoaded: () async -> Bool
   /// Load the active engine's model through that engine's own safe door.
+  ///
+  /// POSTCONDITION (#2207): a non-throwing return means THE ENGINE IS READY, not
+  /// merely that the load call returned. It previously meant only the latter —
+  /// `ASRManager.loadModel()` records readiness rather than requiring it
+  /// (`ASRManager.swift:175-177`) — while both callers already assumed the
+  /// stronger meaning. `ASREngineNotReadyAfterLoadError` is thrown when the
+  /// engine's own readiness projection is false after the loader returns.
   let load: () async throws -> Void
   /// Batch-transcribe on the active engine.
   let transcribe:
@@ -37,20 +44,39 @@ struct ActiveEngineOperation {
   /// WhisperKit resolves to the same in-process backend the adapter drives, so
   /// the relocation gate always runs, and the backend's single-flight makes a
   /// recovery load and an adapter warm-up ONE load rather than two models.
+  /// - Parameter afterLoadForTesting: invoked ONLY when non-nil, after the
+  ///   selected loader returns and before the readiness postcondition is read.
+  ///   Optional-and-nil rather than a default no-op closure, so production adds
+  ///   no suspension point at all.
+  ///
+  ///   It exists because the WhisperKit branch cannot produce the postcondition's
+  ///   failure naturally: `prepare()` DELIBERATELY throws superseded when an
+  ///   unload races its warm-up, precisely so it never "reports success while the
+  ///   backend is actually unloaded" (`WhisperKitBackend.swift:386-392`). Without
+  ///   a seam the test would either race a concurrent unload — timing-dependent,
+  ///   which this repo forbids — or substitute a fake loader, which would stop
+  ///   testing this factory at all.
   static func live(
-    asrManager: any ASRManagerInterface, whisperKitBackend: WhisperKitBackend
+    asrManager: any ASRManagerInterface, whisperKitBackend: WhisperKitBackend,
+    afterLoadForTesting: (@MainActor () async -> Void)? = nil
   ) -> ActiveEngineOperation {
-    ActiveEngineOperation(
-      isLoaded: {
-        asrManager.activeBackendType == .whisperKit
-          ? await whisperKitBackend.isReady : asrManager.isModelLoaded
-      },
+    let readiness: @MainActor () async -> Bool = {
+      asrManager.activeBackendType == .whisperKit
+        ? await whisperKitBackend.isReady : asrManager.isModelLoaded
+    }
+    return ActiveEngineOperation(
+      isLoaded: readiness,
       load: {
         if asrManager.activeBackendType == .whisperKit {
           try await whisperKitBackend.prepare()
         } else {
           try await asrManager.loadModel()
         }
+        if let afterLoadForTesting { await afterLoadForTesting() }
+        // The SAME projection `isLoaded` vends, deliberately: a postcondition
+        // read from a different source could disagree with what every caller
+        // then consults, which would trade one false success for another.
+        guard await readiness() else { throw ASREngineNotReadyAfterLoadError() }
       },
       transcribe: { samples, options in
         if asrManager.activeBackendType == .whisperKit {

--- a/Sources/EnviousWisprAppKit/App/BenchmarkSuite.swift
+++ b/Sources/EnviousWisprAppKit/App/BenchmarkSuite.swift
@@ -27,6 +27,14 @@ final class BenchmarkSuite {
   private(set) var results: [Result] = []
   private(set) var pipelineResult: PipelineBenchmarkResult?
   private(set) var isRunning = false
+
+  /// #2207: the last run's failure, retained AFTER `isRunning` goes false.
+  /// `progress` is rendered only while running, so a load failure used to set a
+  /// message and then vanish with the spinner — the benchmark simply stopped,
+  /// with no result and no explanation. That silence is why the postcondition
+  /// mattered here: before it, an unready engine produced BENCHMARK NUMBERS, and
+  /// now it produces a visible failure instead.
+  private(set) var lastFailure: String?
   private(set) var progress: String = ""
 
   /// #1707 Phase 3 (§3.2, rows 23/27) / #1741 Chunk 5 — the mutation-side
@@ -50,7 +58,9 @@ final class BenchmarkSuite {
       try await activeEngine.load()
       return true
     } catch {
-      progress = "Model load failed: \(error.localizedDescription)"
+      let message = "Model load failed: \(error.localizedDescription)"
+      progress = message
+      lastFailure = message
       return false
     }
   }
@@ -60,6 +70,7 @@ final class BenchmarkSuite {
     guard !isRunning else { return }
     isRunning = true
     results = []
+    lastFailure = nil
 
     // #1707 Phase 3 (§3.2, row 23) / #1741 Chunk 5: hold a mutation claim for
     // the FULL load+transcribe duration — a Diagnostics-triggered benchmark

--- a/Sources/EnviousWisprAppKit/App/BenchmarkSuite.swift
+++ b/Sources/EnviousWisprAppKit/App/BenchmarkSuite.swift
@@ -108,6 +108,9 @@ final class BenchmarkSuite {
     guard !isRunning else { return }
     isRunning = true
     pipelineResult = nil
+    // Both entry points clear it. Clearing in `run` alone left a successful
+    // pipeline run rendering the PREVIOUS ASR run's red error beside its result.
+    lastFailure = nil
 
     // #1707 Phase 3 (§3.2, row 23) / #1741 Chunk 5: hold a mutation claim for
     // the FULL load+batch-transcribe duration below — released before the

--- a/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
@@ -454,10 +454,12 @@ final class RecoveryCoordinator {
       // `discardActiveRecovery` already requested destruction. NOT a claim that
       // no attempt ran — a Discard can land after transcription.
       return false
-    case .deferred, .deferredMarkerClearFailed:
+    case .deferred, .deferredMarkerClearFailed, .deferredPersistenceFailed:
       // ASR never ran, so the attempt is unspent. `.deferredMarkerClearFailed`
       // is the transient-Keychain case #1360 closed — never treat it as a
-      // permanent deletion trigger.
+      // permanent deletion trigger. `.deferredPersistenceFailed` (#2207) is the
+      // same shape: the readiness retry could not be recorded, so the spool is
+      // held rather than destroyed.
       return false
     }
   }
@@ -478,6 +480,8 @@ final class RecoveryCoordinator {
     case .deferred: return "deferred — no attempt ran"
     case .deferredMarkerClearFailed:
       return "deferred, attempt marker not cleared — a new launch re-checks it"
+    case .deferredPersistenceFailed:
+      return "deferred, readiness retry not recorded — a new launch abandons it"
     }
   }
 
@@ -824,7 +828,11 @@ final class RecoveryCoordinator {
       // #1707 Phase 3 (§3.3): a marker-clear failure under either deferred
       // outcome means only a genuinely new launch may safely re-check this id.
       switch outcome {
-      case .deferredMarkerClearFailed:
+      case .deferredMarkerClearFailed, .deferredPersistenceFailed:
+        // #1707 Phase 3, extended by #2207: both mean the bookkeeping did not
+        // complete, so only a genuinely new launch may re-check this id. A
+        // same-launch rescan would re-enter a replay whose budget state is
+        // unknown — the one thing the bound cannot tolerate.
         nextLaunchOnlyRecoveryIDs.insert(id)
       default:
         break

--- a/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
@@ -795,6 +795,13 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
       emitDeferred(reason: .markerClearFailed, disposition: .persistenceFailed)
       return .deferredMarkerClearFailed
     }
+    // Make the deletion durable, so a power cut cannot resurrect the attempt
+    // marker and abandon a recording we just told telemetry we would retry.
+    // Best-effort DELIBERATELY: the retry budget is already durably recorded, so
+    // a failure here costs at most one retry, never an unbounded loop. Promoting
+    // it to a hard failure would turn a spool we can still redeem into one we
+    // cannot, which is the wrong direction for a limb.
+    try? spoolStore.syncSpoolDirectory()
     RecoveryLog.line(
       "replay deferred: model_load_failed class=\(diagnosis.failureClass.rawValue) "
         + "— the load returned but the engine was not ready; one retry granted")

--- a/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
@@ -840,10 +840,16 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
       // take whose audio reconstructed perfectly reported with `audio_decrypted`
       // ABSENT — read as "nothing came out of the spool", the inverse of the
       // truth and the #2205 defect one branch over.
+      //
+      // NO `retryDisposition` HERE, deliberately. This is the TRANSCRIBE-site
+      // deferral: no readiness retry was involved, no budget was consulted, and
+      // no marker was written. Tagging it `persistence_failed` counted ordinary
+      // transcription deferrals as failed readiness retries and would have
+      // corrupted the exact split the field exists to measure — a metric whose
+      // NAME is a causal claim about a state with more than one producer.
       TelemetryService.shared.recoveryCompleted(
         outcome: "deferred", reason: .markerClearFailed, failureClass: diagnosis.failureClass,
-        audioDecrypted: true, campBCandidate: true, spoolSeconds: spoolSeconds,
-        retryDisposition: .persistenceFailed)
+        audioDecrypted: true, campBCandidate: true, spoolSeconds: spoolSeconds)
       return .deferredMarkerClearFailed
     }
   }

--- a/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
@@ -31,6 +31,14 @@ enum RecoveryReplayOutcome: Equatable {
   /// rescan) may safely re-check this spool; `RecoveryCoordinator` routes
   /// this into `nextLaunchOnlyRecoveryIDs`.
   case deferredMarkerClearFailed
+
+  /// #2207: a readiness retry was earned but could NOT be persisted — the retry
+  /// marker's durable write failed. Distinct from `.deferredMarkerClearFailed`,
+  /// whose name would be false here: nothing was cleared, and the attempt marker
+  /// is deliberately left standing so the next launch abandons rather than
+  /// granting a retry the budget never recorded. Routed identically by
+  /// `RecoveryCoordinator` — retained, next-launch-only, never deleted.
+  case deferredPersistenceFailed
 }
 
 /// Why a replay `.failed`, carried to `RecoveryCoordinator` so it can apply the
@@ -138,6 +146,14 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
     self.egOneRuntime = egOneRuntime
     self.currentVocabulary = currentVocabulary
   }
+
+  /// #2207 test seam: invoked synchronously the instant the readiness-retry
+  /// marker has durably COMMITTED and before the attempt marker is deleted. Nil
+  /// in production. The commit-before-clear ordering is otherwise unobservable
+  /// from outside, and a test that inferred it from timing would be exactly the
+  /// guessing this repo forbids — a crash in that window must abandon the spool
+  /// rather than mint an uncounted retry, so the ordering is load-bearing.
+  var onReadinessRetryMarkerCommitted: (() -> Void)?
 
   enum RecoveryReplayError: Error {
     case abandonedAfterAttempt
@@ -316,8 +332,18 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
       // here", not a transient readiness loss. Deferring it would retain the
       // spool and repeat the identical failure every launch, forever, with no
       // cleanup. Only the POST-LOAD refusal below is the race this issue fixes.
+      let diagnosis = Self.diagnose(error, operation: .modelLoad)
+      // #2207: ONE class is transient rather than deterministic — the load
+      // RETURNED and the engine's readiness postcondition was false. That take
+      // deserves its attempt back, exactly once. Everything else at this site
+      // stays terminal, including `.notReady` above.
+      if case .classified(.loadReturnedNotReady) = diagnosis {
+        return attemptReadinessRetry(
+          spoolStore: spoolStore, id: id, diagnosis: diagnosis,
+          reconstructedSampleCount: recovered.samples.count)
+      }
       return failUnrecoverable(
-        reason: .modelLoadFailed, diagnosis: Self.diagnose(error, operation: .modelLoad),
+        reason: .modelLoadFailed, diagnosis: diagnosis,
         reconstructedSampleCount: recovered.samples.count)
     }
     // Discard during the model load: bail BEFORE the expensive batch transcribe.
@@ -601,7 +627,8 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
     reason: RecoveryTelemetryReason,
     failureClass: RecoveryFailureClass? = nil,
     diagnosis: RecoveryFailureDiagnosis? = nil,
-    reconstructedSampleCount: Int? = nil
+    reconstructedSampleCount: Int? = nil,
+    retryDisposition: RecoveryRetryDisposition? = nil
   ) -> RecoveryReplayOutcome {
     let category = Self.category(for: reason)
     // One value wins: a diagnosis supersedes a bare class, and both may be nil
@@ -650,7 +677,8 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
       failureClass: resolvedClass,
       audioDecrypted: reconstructedSampleCount != nil ? true : nil,
       campBCandidate: reconstructedSampleCount != nil ? true : nil,
-      spoolSeconds: spoolSeconds)
+      spoolSeconds: spoolSeconds,
+      retryDisposition: retryDisposition)
     return .failed(.unrecoverable)
   }
 
@@ -705,6 +733,13 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
       // every launch forever, and `telemetryTranscribeFailIsCampBCandidate`
       // pins its current failure semantics. Widening to it is a separate,
       // evidenced decision — not a silent side effect of this fix.
+      // #2207. Not reachable at THIS call site — the error carrying it is thrown
+      // only by `load`, and the load site routes it to `attemptReadinessRetry`
+      // before reaching here. `true` is nonetheless the honest value: the engine
+      // reported itself unready, so it never looked at the audio. Listed
+      // explicitly because this switch is the build-time gate that forces the
+      // choice rather than letting a new case inherit one.
+      case .loadReturnedNotReady: return true
       case .xpcUnreachable, .cancelled, .transcriptionFailed, .whisperKitModelLoad,
         .parakeetModelLoad, .parakeetTranscription, .xpcTransport, .other:
         return false
@@ -713,6 +748,58 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
     // failed. Listed explicitly so a future reader must choose, not inherit.
     case .unrecognized: return false
     }
+  }
+
+  /// #2207: the bounded readiness retry, exactly once per spool.
+  ///
+  /// Ordering is the whole safety property: the retry marker COMMITS before the
+  /// attempt marker is cleared, so a crash between them leaves the attempt marker
+  /// standing and the next launch abandons. The reverse order would mint a retry
+  /// nothing recorded, and a permanently unready engine would defer forever —
+  /// re-opening what the bound exists to close.
+  private func attemptReadinessRetry(
+    spoolStore: RecoverySpoolStore, id: String, diagnosis: RecoveryFailureDiagnosis,
+    reconstructedSampleCount: Int
+  ) -> RecoveryReplayOutcome {
+    // Already spent: terminal. This is the bound working, NOT a regression.
+    guard !spoolStore.hasReadinessRetryMarker(for: id) else {
+      return failUnrecoverable(
+        reason: .modelLoadFailed, diagnosis: diagnosis,
+        reconstructedSampleCount: reconstructedSampleCount, retryDisposition: .exhausted)
+    }
+    let spoolSeconds = Int(
+      (Double(reconstructedSampleCount) / AudioConstants.sampleRate).rounded())
+    // Every branch below carries the SAME reconstruction facts: the audio came
+    // back perfectly and the ENGINE was missing. Omitting them emits
+    // `audio_decrypted` ABSENT, which the field contract reads as "nothing came
+    // out of the spool" — the exact inverse, and the #2205 defect.
+    func emitDeferred(reason: RecoveryTelemetryReason, disposition: RecoveryRetryDisposition) {
+      TelemetryService.shared.recoveryCompleted(
+        outcome: "deferred", reason: reason, failureClass: diagnosis.failureClass,
+        audioDecrypted: true, campBCandidate: true, spoolSeconds: spoolSeconds,
+        retryDisposition: disposition)
+    }
+    do {
+      try spoolStore.writeReadinessRetryMarker(for: id)
+    } catch {
+      RecoveryLog.line(
+        "replay deferred: readiness retry could not be persisted — the attempt "
+          + "marker stands, so the next launch abandons rather than retrying")
+      emitDeferred(reason: .markerWriteFailed, disposition: .persistenceFailed)
+      return .deferredPersistenceFailed
+    }
+    onReadinessRetryMarkerCommitted?()
+    do {
+      try spoolStore.deleteAttemptMarker(for: id)
+    } catch {
+      emitDeferred(reason: .markerClearFailed, disposition: .persistenceFailed)
+      return .deferredMarkerClearFailed
+    }
+    RecoveryLog.line(
+      "replay deferred: model_load_failed class=\(diagnosis.failureClass.rawValue) "
+        + "— the load returned but the engine was not ready; one retry granted")
+    emitDeferred(reason: .modelLoadFailed, disposition: .granted)
+    return .deferred
   }
 
   /// Give the attempt back and leave the spool on disk for the next launch.
@@ -742,7 +829,14 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
         audioDecrypted: true, campBCandidate: true, spoolSeconds: spoolSeconds)
       return .deferred
     } catch {
-      TelemetryService.shared.recoveryCompleted(outcome: "deferred", reason: .markerClearFailed)
+      // #2207: the reconstruction facts belong here too. Emitting bare left a
+      // take whose audio reconstructed perfectly reported with `audio_decrypted`
+      // ABSENT — read as "nothing came out of the spool", the inverse of the
+      // truth and the #2205 defect one branch over.
+      TelemetryService.shared.recoveryCompleted(
+        outcome: "deferred", reason: .markerClearFailed, failureClass: diagnosis.failureClass,
+        audioDecrypted: true, campBCandidate: true, spoolSeconds: spoolSeconds,
+        retryDisposition: .persistenceFailed)
       return .deferredMarkerClearFailed
     }
   }

--- a/Sources/EnviousWisprAppKit/Views/Settings/DiagnosticsSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/DiagnosticsSettingsView.swift
@@ -205,6 +205,16 @@ struct DiagnosticsSettingsView: View {
             }
           }
         } else {
+          // #2207: a failed run leaves nothing else on screen — `progress` is
+          // rendered only while running, so without this the benchmark just
+          // stops. Idle is exactly when the user is looking for the answer.
+          if let failure = diagnostics.benchmark.lastFailure {
+            BrandedRow {
+              Text(failure)
+                .font(.stHelper)
+                .foregroundStyle(.red)
+            }
+          }
           BrandedRow {
             HStack {
               Button("Run ASR Benchmark") {

--- a/Sources/EnviousWisprCore/Constants.swift
+++ b/Sources/EnviousWisprCore/Constants.swift
@@ -288,6 +288,12 @@ public enum RecoveryConstants {
   /// for that spool, so it is abandoned rather than retried (the one-attempt
   /// guard). Named `<recoverySessionID>.attempt`.
   public static let attemptFileExtension = "attempt"
+  /// File extension for a per-spool READINESS-RETRY marker (#2207). Presence means
+  /// this spool has already spent its ONE retry for a load that returned while the
+  /// engine was not ready, so a second such refusal is terminal. Written durably
+  /// BEFORE the attempt marker is cleared, so a crash in between abandons the spool
+  /// rather than minting an uncounted retry. Named `<recoverySessionID>.readiness-retry`.
+  public static let readinessRetryFileExtension = "readiness-retry"
   /// File extension for a per-spool ESCAPE RECOVERY marker (#2087). Metadata
   /// only — no audio, no text. Its presence on the next launch tells replay that
   /// this spool belongs to a cancelled-but-kept dictation, so the recovered

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -124,6 +124,23 @@ public enum EscapeRecoveryPasteResult: String, Sendable, CaseIterable {
 /// narrow (D-030 / plan §3.2): widen only when Phase 2 producer tests prove a new
 /// class stays distinguishable after the ASR XPC wrapper collapses decode errors.
 /// The `NSError` domain/code is the classifier INPUT, never emitted.
+/// Why a `load_returned_not_ready` failure did or did not get its one retry
+/// (#2207). Without this the retry bound is unmeasurable: `outcome` alone cannot
+/// separate a first refusal that was GRANTED a retry from a second that was
+/// terminal, and both persistence-failure branches report `deferred` too.
+public enum RecoveryRetryDisposition: String, Sendable {
+  /// The retry marker committed and the attempt marker cleared. Outcome
+  /// `deferred`, and the spool is genuinely eligible again.
+  case granted
+  /// The retry marker was already present, so this refusal is terminal. Outcome
+  /// `failed`. This is the bound doing its job, NOT a regression.
+  case exhausted
+  /// The retry-marker write or the attempt-marker clear failed. Outcome
+  /// `deferred`, but on the next-launch-only route: the surviving attempt marker
+  /// makes the next launch abandon before any load or transcription.
+  case persistenceFailed = "persistence_failed"
+}
+
 public enum RecoveryFailureClass: String, Sendable {
   case xpcUnreachable = "xpc_unreachable"
   case cancelled
@@ -147,6 +164,12 @@ public enum RecoveryFailureClass: String, Sendable {
   case parakeetModelLoad = "parakeet_model_load"
   case parakeetTranscription = "parakeet_transcription"
   case xpcTransport = "xpc_transport"
+  /// #2207: the engine's load returned NORMALLY and its readiness projection was
+  /// still false. Distinct from `notReady`, which is a DETERMINISTIC refusal at
+  /// the load site with no model admitted — conflating the two restores the #2132
+  /// deletion, because only this one is transient enough to earn a retry. Same
+  /// version floor as the six above.
+  case loadReturnedNotReady = "load_returned_not_ready"
   case managerNotOwned = "manager_not_owned"
   case other
 }
@@ -1642,7 +1665,8 @@ public final class TelemetryService {
     campBCandidate: Bool? = nil,
     recoveredSeconds: Int? = nil,
     spoolSeconds: Int? = nil,
-    polishFellBack: Bool? = nil
+    polishFellBack: Bool? = nil,
+    retryDisposition: RecoveryRetryDisposition? = nil
   ) {
     #if DEBUG
       // Mirror the PostHog property set below by exact production spelling so the
@@ -1650,6 +1674,7 @@ public final class TelemetryService {
       var hookStringProps: [String: String] = ["outcome": outcome]
       if let reason { hookStringProps["reason"] = reason.rawValue }
       if let failureClass { hookStringProps["failure_class"] = failureClass.rawValue }
+      if let retryDisposition { hookStringProps["retry_disposition"] = retryDisposition.rawValue }
       if let recoveredSeconds {
         hookStringProps["recovered_seconds_bucket"] = Self.recoverySecondsBucket(recoveredSeconds)
       }
@@ -1667,6 +1692,7 @@ public final class TelemetryService {
     var properties: [String: Any] = ["outcome": outcome]
     if let reason { properties["reason"] = reason.rawValue }
     if let failureClass { properties["failure_class"] = failureClass.rawValue }
+    if let retryDisposition { properties["retry_disposition"] = retryDisposition.rawValue }
     if let audioDecrypted { properties["audio_decrypted"] = audioDecrypted }
     if let campBCandidate { properties["camp_b_candidate"] = campBCandidate }
     if let recoveredSeconds {

--- a/Sources/EnviousWisprStorage/RecoverySpoolStore.swift
+++ b/Sources/EnviousWisprStorage/RecoverySpoolStore.swift
@@ -269,8 +269,41 @@ public struct RecoverySpoolStore: Sendable {
         } else {
           try fm.moveItem(at: tmpURL, to: url)
         }
+        // The file's own bytes are already fsynced; the RENAME lives in the
+        // containing DIRECTORY, which is a separate durability question.
+        // `audio-recovery-internals.md` records that `writeAttemptMarker` leaves
+        // this unproven. It matters more here, because the whole point of
+        // committing this marker BEFORE clearing the attempt marker is that a
+        // crash in between must find the budget recorded. An unsynced rename can
+        // vanish, which would give back an attempt whose retry nothing recorded.
+        // Fails CLOSED: the throw routes to row C, which retains the attempt.
+        try RecoverySpoolStore.syncDirectory(containing: url)
       },
       cleanupTemp: { tmpURL in try FileManager.default.removeItem(at: tmpURL) })
+  }
+
+  /// `F_FULLFSYNC` the directory holding `url`, so a rename or unlink inside it
+  /// survives power loss. Opened read-only: this syncs directory metadata, and
+  /// nothing writes through this descriptor.
+  static func syncDirectory(containing url: URL) throws {
+    let dir = url.deletingLastPathComponent()
+    let fd = Foundation.open(dir.path, O_RDONLY)
+    guard fd >= 0 else { throw RecoverySpoolStoreError.readinessRetryMarkerWriteFailed(errno) }
+    defer { Foundation.close(fd) }
+    if fcntl(fd, F_FULLFSYNC) == -1 {
+      throw RecoverySpoolStoreError.readinessRetryMarkerWriteFailed(errno)
+    }
+  }
+
+  /// Make a completed attempt-marker deletion durable (#2207). Separate from the
+  /// deletion itself because the two have DIFFERENT failure meanings: a failed
+  /// delete means the attempt was never given back, while a failed sync means it
+  /// was given back and may not survive a power cut. Best-effort at the call
+  /// site, and the reason is the direction of the risk: the retry budget is
+  /// already durably recorded by then, so the worst case is one lost retry
+  /// rather than an unbounded one.
+  public func syncSpoolDirectory() throws {
+    try Self.syncDirectory(containing: directory.appendingPathComponent("x"))
   }
 
   /// Sidecar path for a spool's readiness-retry marker (`<id>.readiness-retry`).

--- a/Sources/EnviousWisprStorage/RecoverySpoolStore.swift
+++ b/Sources/EnviousWisprStorage/RecoverySpoolStore.swift
@@ -19,6 +19,13 @@ import Foundation
 public struct RecoverySpoolStore: Sendable {
   private let directory: URL
 
+  /// #2207 injection seam for the readiness-retry marker's three file operations.
+  /// Carried on the INSTANCE rather than passed per call, so a test can reach it
+  /// through the replayer's `makeSpoolStore` closure — rows C and H of the
+  /// transition table are replayer outcomes, and a store-only injection point
+  /// would leave the production path they actually take untested.
+  var readinessRetryFileOps: ReadinessRetryFileOps = .live
+
   public init() {
     directory = AppConstants.appSupportURL
       .appendingPathComponent(RecoveryConstants.spoolDirectoryName, isDirectory: true)
@@ -163,6 +170,9 @@ public struct RecoverySpoolStore: Sendable {
     do { try deleteEscapeMarker(for: recoverySessionID) } catch {
       firstFailure = firstFailure ?? error
     }
+    do { try deleteReadinessRetryMarker(for: recoverySessionID) } catch {
+      firstFailure = firstFailure ?? error
+    }
     if let firstFailure { throw firstFailure }
   }
 
@@ -222,6 +232,98 @@ public struct RecoverySpoolStore: Sendable {
     let url = attemptMarkerURL(for: recoverySessionID)
     do {
       try FileManager.default.removeItem(at: url)
+    } catch let error as CocoaError where error.code == .fileNoSuchFile {
+      return
+    }
+  }
+
+  // MARK: - Readiness-retry marker (#2207)
+
+  /// Injection seam for the retry marker's three file operations, so a test can
+  /// fail the COMMIT and the ensuing CLEANUP independently. Rows C and H of the
+  /// #2207 transition table differ only in whether cleanup was attempted and
+  /// failed, so a single failure switch cannot tell them apart and the row-H
+  /// test would be indistinguishable from row C.
+  struct ReadinessRetryFileOps: Sendable {
+    var writeTemp: @Sendable (URL) throws -> Void
+    var commit: @Sendable (URL, URL) throws -> Void
+    var cleanupTemp: @Sendable (URL) throws -> Void
+
+    static let live = ReadinessRetryFileOps(
+      writeTemp: { tmpURL in
+        let fd = Foundation.open(tmpURL.path, O_CREAT | O_WRONLY | O_TRUNC, 0o600)
+        guard fd >= 0 else { throw RecoverySpoolStoreError.readinessRetryMarkerWriteFailed(errno) }
+        let handle = FileHandle(fileDescriptor: fd, closeOnDealloc: true)
+        try handle.write(contentsOf: Data([0x31]))
+        if fcntl(fd, F_FULLFSYNC) == -1 {
+          let code = errno
+          try? handle.close()
+          throw RecoverySpoolStoreError.readinessRetryMarkerWriteFailed(code)
+        }
+        try handle.close()
+      },
+      commit: { tmpURL, url in
+        let fm = FileManager.default
+        if fm.fileExists(atPath: url.path) {
+          _ = try fm.replaceItemAt(url, withItemAt: tmpURL)
+        } else {
+          try fm.moveItem(at: tmpURL, to: url)
+        }
+      },
+      cleanupTemp: { tmpURL in try FileManager.default.removeItem(at: tmpURL) })
+  }
+
+  /// Sidecar path for a spool's readiness-retry marker (`<id>.readiness-retry`).
+  private func readinessRetryMarkerURL(for recoverySessionID: String) -> URL {
+    directory.appendingPathComponent(
+      "\(recoverySessionID).\(RecoveryConstants.readinessRetryFileExtension)")
+  }
+
+  private func readinessRetryTempURL(for recoverySessionID: String) -> URL {
+    directory.appendingPathComponent(
+      ".\(recoverySessionID).\(RecoveryConstants.readinessRetryFileExtension).tmp")
+  }
+
+  /// Whether this spool has already spent its one readiness retry (#2207).
+  /// Presence is the whole signal; the file's contents are never read.
+  public func hasReadinessRetryMarker(for recoverySessionID: String) -> Bool {
+    FileManager.default.fileExists(atPath: readinessRetryMarkerURL(for: recoverySessionID).path)
+  }
+
+  /// Durably write the readiness-retry marker, in the same shape as
+  /// `writeAttemptMarker`: temp file, `F_FULLFSYNC`, atomic rename. The caller
+  /// commits this BEFORE clearing the attempt marker, so a crash between the two
+  /// leaves the attempt marker standing and the spool is abandoned rather than
+  /// granted an uncounted retry.
+  public func writeReadinessRetryMarker(for recoverySessionID: String) throws {
+    try writeReadinessRetryMarker(for: recoverySessionID, ops: readinessRetryFileOps)
+  }
+
+  func writeReadinessRetryMarker(
+    for recoverySessionID: String, ops: ReadinessRetryFileOps
+  ) throws {
+    let url = readinessRetryMarkerURL(for: recoverySessionID)
+    let tmpURL = readinessRetryTempURL(for: recoverySessionID)
+    do {
+      try ops.writeTemp(tmpURL)
+      try ops.commit(tmpURL, url)
+    } catch {
+      // Best-effort, and its failure is DELIBERATELY not surfaced over the write
+      // failure: the caller's contract is "the retry was not persisted", which is
+      // true either way, and a surviving temp file is inert (nothing reads it —
+      // only the final marker's presence is ever consulted).
+      try? ops.cleanupTemp(tmpURL)
+      if let storeError = error as? RecoverySpoolStoreError { throw storeError }
+      throw RecoverySpoolStoreError.readinessRetryMarkerWriteFailed(errno)
+    }
+  }
+
+  /// Delete a spool's readiness-retry marker. Idempotent — a missing marker is
+  /// success. The interrupted-write temp goes FIRST, matching `deleteEscapeMarker`.
+  public func deleteReadinessRetryMarker(for recoverySessionID: String) throws {
+    try? FileManager.default.removeItem(at: readinessRetryTempURL(for: recoverySessionID))
+    do {
+      try FileManager.default.removeItem(at: readinessRetryMarkerURL(for: recoverySessionID))
     } catch let error as CocoaError where error.code == .fileNoSuchFile {
       return
     }
@@ -435,6 +537,11 @@ public enum RecoverySpoolStoreError: Error, Equatable {
   /// `errno`). The caller treats this as fail-closed: skip recovering this spool
   /// this launch rather than risk an un-guarded retry.
   case attemptMarkerWriteFailed(Int32)
+  /// The readiness-retry marker could not be written durably (carries `errno`).
+  /// The caller fails CLOSED: it retains the spool WITH its attempt marker, so the
+  /// next launch abandons rather than replaying — never a retry the budget did not
+  /// record, which is the hole the bound exists to close (#2207).
+  case readinessRetryMarkerWriteFailed(Int32)
   /// The Escape Recovery marker could not be written durably (carries `errno`).
   ///
   /// Fail closed at the call site by performing today's ordinary destructive

--- a/Tests/EnviousWisprTests/Recovery/ReadinessRetryTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/ReadinessRetryTests.swift
@@ -446,6 +446,42 @@ struct ReadinessRetryRecoveryTests {
     #expect(!h.store.hasReadinessRetryMarker(for: h.id), "and no budget was spent")
   }
 
+  /// THE BRANCH THE ROW ABOVE CANNOT REACH, and the reason this test exists
+  /// separately: the leak Codex found was in the marker-clear CATCH, which only
+  /// runs when the clear throws. The success-path test passes whether or not that
+  /// catch is correct, and a mutation control proved exactly that — the leaked
+  /// field survived it. Reaching a function is not reaching its branch.
+  ///
+  /// The clear is forced to fail by making the spool directory read-only at the
+  /// last moment the attempt marker is already written: `onTranscribe` fires
+  /// after the marker write and before the refusal.
+  @Test("an unrelated deferral whose marker clear FAILS also claims no retry")
+  func transcribeSiteClearFailureDoesNotClaimAReadinessRetry() async throws {
+    let h = try Fixture.make()
+    let fm = FileManager.default
+    defer { try? fm.setAttributes([.posixPermissions: 0o700], ofItemAtPath: h.spoolDir.path) }
+
+    h.asr.transcribeError = ASRError.notReady
+    h.asr.onTranscribe = { [dir = h.spoolDir] in
+      try? fm.setAttributes([.posixPermissions: 0o500], ofItemAtPath: dir.path)
+    }
+
+    var outcome: RecoveryReplayOutcome?
+    let box = await Fixture.capturingTelemetry {
+      outcome = await h.replayer.replay(recoverySessionID: h.id, isAborted: { false })
+    }
+
+    #expect(outcome == .deferredMarkerClearFailed, "the branch under test was REACHED")
+    let e = try #require(box.recoveryEvents().first)
+    #expect(e.stringProps["reason"] == "marker_clear_failed")
+    #expect(
+      e.stringProps["retry_disposition"] == nil,
+      "still no readiness retry here — this is the leak Codex found")
+    // The r2 fix must survive: the audio reconstructed, and saying otherwise is
+    // the #2205 defect.
+    #expect(e.boolProps["audio_decrypted"] == true)
+  }
+
   /// Spool deletion must ATTEMPT every readiness-retry artifact, and keep
   /// attempting the others when one fails — the store's cleanup is best-effort
   /// by design, so this asserts attempts, never guarantees.

--- a/Tests/EnviousWisprTests/Recovery/ReadinessRetryTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/ReadinessRetryTests.swift
@@ -422,6 +422,30 @@ struct ReadinessRetryRecoveryTests {
     #expect(e.stringProps["retry_disposition"] == "persistence_failed")
   }
 
+  /// The field must appear ONLY on the bounded readiness retry. Codex found it
+  /// leaking onto the transcribe-site deferral, where no budget is consulted and
+  /// no marker is written — which would have counted ordinary transcription
+  /// deferrals as failed readiness retries and corrupted the very split the
+  /// field exists to measure.
+  @Test("an unrelated deferral carries no retry disposition")
+  func transcribeSiteDeferralDoesNotClaimAReadinessRetry() async throws {
+    let h = try Fixture.make()
+    h.asr.transcribeError = ASRError.notReady  // the TRANSCRIBE site, not the load site
+
+    var outcome: RecoveryReplayOutcome?
+    let box = await Fixture.capturingTelemetry {
+      outcome = await h.replayer.replay(recoverySessionID: h.id, isAborted: { false })
+    }
+
+    #expect(outcome == .deferred, "unchanged #2205 behaviour")
+    let e = try #require(box.recoveryEvents().first)
+    #expect(e.stringProps["failure_class"] == "not_ready")
+    #expect(
+      e.stringProps["retry_disposition"] == nil,
+      "no readiness retry happened here, so claiming one falsifies the dashboard")
+    #expect(!h.store.hasReadinessRetryMarker(for: h.id), "and no budget was spent")
+  }
+
   /// Spool deletion must ATTEMPT every readiness-retry artifact, and keep
   /// attempting the others when one fails — the store's cleanup is best-effort
   /// by design, so this asserts attempts, never guarantees.

--- a/Tests/EnviousWisprTests/Recovery/ReadinessRetryTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/ReadinessRetryTests.swift
@@ -94,6 +94,40 @@ struct ReadinessRetryTelemetryContractTests {
     #expect(error.sentrySemanticID == "asr.engine_not_ready_after_load")
   }
 
+  /// Codex diff review found the OTHER entry point never cleared it, so a
+  /// successful pipeline run rendered the previous ASR run's red error beside
+  /// its result. Both entry points are driven here; asserting only `run` would
+  /// have passed against the defect.
+  @Test("both benchmark entry points clear a stale failure")
+  @MainActor
+  func bothBenchmarkEntryPointsClearLastFailure() async {
+    let manager = RecoverySpoolReplayerTests.FakeBatchASR()
+    manager.readyAfterLoad = false
+    let engine = ActiveEngineOperation.live(
+      asrManager: manager, whisperKitBackend: WhisperKitBackend(admittedModelFolder: { nil }))
+    let suite = BenchmarkSuite(engineMutationScope: .alwaysAllowedForTesting)
+
+    await suite.run(using: manager, activeEngine: engine)
+    #expect(suite.lastFailure != nil, "a load that returns unready must SAY so")
+
+    // Now let the engine come good and drive the OTHER entry point.
+    manager.readyAfterLoad = true
+    await suite.runPipelineBenchmark(using: manager, activeEngine: engine)
+    #expect(
+      suite.lastFailure == nil,
+      "a successful run must not leave the previous run's error on screen")
+  }
+
+  /// Codex diff review: without this the Diagnostics row renders Foundation's
+  /// generated type-and-domain string at the user.
+  @Test("the new error reads as plain English, not a type name")
+  func newErrorHasAUserFacingDescription() {
+    let described = ASREngineNotReadyAfterLoadError().localizedDescription
+    #expect(described == "The engine finished loading but was not ready to use.")
+    #expect(!described.contains("ASREngineNotReadyAfterLoad"), "never show the type name")
+    #expect(!described.contains("EnviousWispr"), "never show the module name")
+  }
+
   /// The classifier must not route this through the supersede arm — that maps to
   /// `.cancelled`, which recovery treats as terminal and DELETES the recording.
   @Test("classification routes the new error away from the cancelled arm")

--- a/Tests/EnviousWisprTests/Recovery/ReadinessRetryTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/ReadinessRetryTests.swift
@@ -1,0 +1,421 @@
+@preconcurrency import AVFoundation
+import EnviousWisprAudio
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprASR
+@testable import EnviousWisprLLM
+@testable import EnviousWisprServices
+@testable import EnviousWisprStorage
+
+/// #2207. `ActiveEngineOperation.load` used to mean "the load call returned".
+/// `ASRManager.loadModel()` RECORDS readiness rather than requiring it, so a load
+/// could return while the engine was not ready — and recovery, believing it,
+/// transcribed, failed, and DELETED a recording it had successfully saved.
+///
+/// These suites protect the fix's two halves: the door now refuses a false
+/// success, and recovery gives that specific failure exactly ONE retry rather
+/// than destroying the take.
+
+// MARK: - The engine door
+
+/// Isolated postcondition behaviour on the production factory. `.driftGuard`:
+/// a failure here means we changed our own contract, not that a user lost audio.
+@Suite("Active engine load postcondition (#2207)", .tags(.driftGuard))
+@MainActor
+struct ActiveEngineLoadPostconditionTests {
+
+  /// A backend the parakeet branch never touches; `.live` requires one.
+  private static func unusedBackend() -> WhisperKitBackend {
+    WhisperKitBackend(admittedModelFolder: { nil })
+  }
+
+  /// Constructed through `.live(...)`, never the memberwise initializer — a
+  /// hand-built `load` closure that throws the expected error would prove only
+  /// that a closure can throw.
+  @Test("a load that returns while the engine is not ready throws instead of reporting success")
+  func activeEngineLoadThrowsWhenReadinessDoesNotFollow() async throws {
+    let manager = RecoverySpoolReplayerTests.FakeBatchASR()
+    manager.readyAfterLoad = false
+
+    let op = ActiveEngineOperation.live(
+      asrManager: manager, whisperKitBackend: Self.unusedBackend())
+
+    await #expect(throws: ASREngineNotReadyAfterLoadError.self) {
+      try await op.load()
+    }
+    #expect(manager.isModelLoaded == false, "the projection the postcondition read")
+  }
+
+  /// THE ORDERING CONTROL, and without it the test above is not binding: a cold
+  /// engine starts not-ready, so a guard placed BEFORE the load would refuse
+  /// every healthy first load while the negative test still passed.
+  @Test("the check runs AFTER the load, so an ordinary cold start still succeeds")
+  func activeEngineLoadChecksAfterLoadNotBeforeIt() async throws {
+    let manager = RecoverySpoolReplayerTests.FakeBatchASR()
+    manager.readyAfterLoad = true  // begins false; the loader makes it true
+    #expect(manager.isModelLoaded == false, "cold: a pre-load guard would refuse here")
+
+    let op = ActiveEngineOperation.live(
+      asrManager: manager, whisperKitBackend: Self.unusedBackend())
+
+    try await op.load()
+    #expect(manager.isModelLoaded, "the loader made it ready and the postcondition agreed")
+  }
+}
+
+// MARK: - Telemetry vocabulary
+
+@Suite("Readiness retry telemetry contract (#2207)", .tags(.observabilityContract))
+struct ReadinessRetryTelemetryContractTests {
+
+  @Test("every disposition has the exact wire spelling the dashboards will query")
+  func dispositionsCarryTheirWireSpelling() {
+    #expect(RecoveryRetryDisposition.granted.rawValue == "granted")
+    #expect(RecoveryRetryDisposition.exhausted.rawValue == "exhausted")
+    #expect(RecoveryRetryDisposition.persistenceFailed.rawValue == "persistence_failed")
+  }
+
+  @Test("the new failure class is distinct from the deterministic load refusal")
+  func failureClassIsDistinctFromNotReady() {
+    #expect(RecoveryFailureClass.loadReturnedNotReady.rawValue == "load_returned_not_ready")
+    #expect(RecoveryFailureClass.loadReturnedNotReady != RecoveryFailureClass.notReady)
+  }
+
+  /// #1525 PR G. Pinned at introduction; changing either string re-groups every
+  /// historical Sentry issue for this error.
+  @Test("the new error carries its pinned Sentry identity")
+  func newErrorCarriesItsPinnedIdentity() {
+    let error = ASREngineNotReadyAfterLoadError()
+    #expect(
+      error.sentryFingerprintDescriptor == "EnviousWisprASR.ASREngineNotReadyAfterLoadError#1")
+    #expect(error.sentrySemanticID == "asr.engine_not_ready_after_load")
+  }
+
+  /// The classifier must not route this through the supersede arm — that maps to
+  /// `.cancelled`, which recovery treats as terminal and DELETES the recording.
+  @Test("classification routes the new error away from the cancelled arm")
+  func classificationDoesNotFallIntoCancelled() {
+    let classified = recoveryFailureClass(for: ASREngineNotReadyAfterLoadError())
+    #expect(classified == .loadReturnedNotReady)
+    #expect(classified != .cancelled, "cancelled is terminal — this is the #2132 trap")
+  }
+}
+
+// MARK: - The recovery outcome
+
+// Telemetry capture rides `TelemetryService.testEventHook`, which is DEBUG-only.
+// An unwrapped reference compiles in Debug and breaks the RELEASE build ~20
+// minutes later with zero failure marks, so the whole suite is gated.
+#if DEBUG
+
+  /// Wires the REAL replayer, store and spool cipher. Only the ASR engine and the
+  /// retry marker's file operations are injected — everything the assertions read
+  /// is production code.
+  @MainActor
+  enum Fixture {
+    struct Bundle {
+      let replayer: RecoverySpoolReplayer
+      let asr: RecoverySpoolReplayerTests.FakeBatchASR
+      let store: RecoverySpoolStore
+      let spoolDir: URL
+      let id: String
+      var spoolExists: Bool {
+        FileManager.default.fileExists(atPath: store.spoolURL(for: id).path)
+      }
+    }
+
+    static func tempDir() -> URL {
+      let dir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("ew-readiness-\(UUID().uuidString)", isDirectory: true)
+      try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+      return dir
+    }
+
+    /// Commit fails; cleanup succeeds. Row C.
+    static func failingCommit() -> RecoverySpoolStore.ReadinessRetryFileOps {
+      var ops = RecoverySpoolStore.ReadinessRetryFileOps.live
+      ops.commit = { _, _ in throw RecoverySpoolStoreError.readinessRetryMarkerWriteFailed(28) }
+      return ops
+    }
+
+    /// Commit fails AND the ensuing cleanup fails, counting both. Row H — the two
+    /// counters are what distinguish it from row C.
+    static func failingCommitAndCleanup(counter: Counter)
+      -> RecoverySpoolStore.ReadinessRetryFileOps
+    {
+      var ops = RecoverySpoolStore.ReadinessRetryFileOps.live
+      ops.commit = { _, _ in throw RecoverySpoolStoreError.readinessRetryMarkerWriteFailed(28) }
+      ops.cleanupTemp = { _ in
+        counter.recordAttempt()
+        counter.recordFailure()
+        throw CocoaError(.fileWriteNoPermission)
+      }
+      return ops
+    }
+
+    static func make(
+      ops: RecoverySpoolStore.ReadinessRetryFileOps = .live
+    ) throws -> Bundle {
+      let spoolDir = tempDir()
+      let keyStore = RecoveryKeyStore(backend: .file, fileDirectory: tempDir())
+      let transcriptStore = TranscriptStore(directory: tempDir())
+      let transcriptCoordinator = TranscriptCoordinator(store: transcriptStore)
+      let asr = RecoverySpoolReplayerTests.FakeBatchASR()
+      let replayer = RecoverySpoolReplayer(
+        activeEngine: ActiveEngineOperation(
+          isLoaded: { asr.isModelLoaded },
+          load: { try await asr.loadModel() },
+          transcribe: { samples, options in
+            try await asr.transcribe(audioSamples: samples, options: options)
+          },
+          hardCancel: {}),
+        keyStore: keyStore,
+        makeSpoolStore: {
+          var store = RecoverySpoolStore(directory: spoolDir)
+          store.readinessRetryFileOps = ops
+          return store
+        },
+        transcriptStore: transcriptStore,
+        transcriptCoordinator: transcriptCoordinator,
+        keychainManager: KeychainManager(),
+        outputClassifierHolder: OutputClassifierHolder(),
+        now: { Date() },
+        currentVocabulary: { (.empty, .empty) })
+      var store = RecoverySpoolStore(directory: spoolDir)
+      store.readinessRetryFileOps = ops
+      let id = "readiness-\(UUID().uuidString)"
+      let bundle = Bundle(
+        replayer: replayer, asr: asr, store: store, spoolDir: spoolDir, id: id)
+      try seed(bundle, keyStore: keyStore)
+      return bundle
+    }
+
+    private static func seed(_ b: Bundle, keyStore: RecoveryKeyStore) throws {
+      let keyData = Data(repeating: 7, count: RecoveryConstants.aesKeyByteCount)
+      try keyStore.store(keyData: keyData, for: b.id)
+      let writer = RecoverySpoolWriter(
+        recoverySessionID: b.id, spoolURL: b.store.spoolURL(for: b.id),
+        cipher: RecoverySpoolCipher(mode: .aesGcm256, keyData: keyData),
+        settings: RecordingSettingsSnapshot(
+          backendType: .parakeet, backendSupportsLanguageDetection: false,
+          languageMode: .auto, wordCorrectionEnabled: false, fillerRemovalEnabled: false,
+          emojiFormatterEnabled: false, spokenPunctuationEnabled: false,
+          customWordsVersion: nil, llmProvider: "none", llmModel: "",
+          polishPromptVersion: nil),
+        appVersion: "1.0.0", createdAt: Date(timeIntervalSince1970: 0))
+      writer.start()
+      writer.append([0.1, 0.2, 0.3])
+      let done = DispatchSemaphore(value: 0)
+      writer.finalize(reason: .cleanFinalized) { done.signal() }
+      done.wait()
+    }
+
+    static func capturingTelemetry(
+      _ body: () async throws -> Void
+    ) async rethrows -> RecoverySpoolReplayerTests.TelemetryBox {
+      let box = RecoverySpoolReplayerTests.TelemetryBox()
+      TelemetryService.shared.testEventHook = { @Sendable e in box.add(e) }
+      defer { TelemetryService.shared.testEventHook = nil }
+      try await body()
+      return box
+    }
+  }
+
+
+/// `.productOutcome`: when one of these fails, a dictation the user recorded is
+/// gone. `.serialized` because the telemetry hook is process-global.
+@Suite("Readiness retry recovery outcomes (#2207)", .serialized, .tags(.productOutcome))
+@MainActor
+struct ReadinessRetryRecoveryTests {
+
+  /// ROW A. The first refusal keeps the recording and gives the attempt back.
+  /// Red here means a recording that was never decoded is being destroyed again.
+  @Test("the first refusal keeps the recording and spends one retry")
+  func firstEngineUnavailableRefusalGetsOneRetry() async throws {
+    let h = try Fixture.make()
+    h.asr.loadError = ASREngineNotReadyAfterLoadError()
+
+    var outcome: RecoveryReplayOutcome?
+    let box = await Fixture.capturingTelemetry {
+      outcome = await h.replayer.replay(recoverySessionID: h.id, isAborted: { false })
+    }
+
+    #expect(outcome == .deferred, "the engine never looked at the audio")
+    #expect(h.store.hasReadinessRetryMarker(for: h.id), "the retry is now RECORDED, not implied")
+    #expect(!h.store.hasAttemptMarker(for: h.id), "cleared, so a later pass may retry")
+    #expect(h.spoolExists, "THE POINT: the recording is still on disk")
+    #expect(h.asr.transcribeCallCount == 0, "the load never succeeded, so nothing was decoded")
+
+    let e = try #require(box.recoveryEvents().first)
+    #expect(e.stringProps["outcome"] == "deferred")
+    #expect(e.stringProps["failure_class"] == "load_returned_not_ready")
+    #expect(e.stringProps["retry_disposition"] == "granted")
+    // The audio reconstructed perfectly; only the engine was missing. Absent
+    // `audio_decrypted` reads as "nothing came out of the spool" — the inverse.
+    #expect(e.boolProps["audio_decrypted"] == true)
+    #expect(e.boolProps["camp_b_candidate"] == true)
+  }
+
+  /// ROW B — THE BOUND. Without it a permanently unready engine defers forever
+  /// and spools accumulate with nothing ever cleaning them up.
+  @Test("a second refusal is terminal, so a broken engine cannot defer forever")
+  func repeatedEngineUnavailableRefusalTerminates() async throws {
+    let h = try Fixture.make()
+    h.asr.loadError = ASREngineNotReadyAfterLoadError()
+    try h.store.writeReadinessRetryMarker(for: h.id)  // the retry is already spent
+
+    var outcome: RecoveryReplayOutcome?
+    let box = await Fixture.capturingTelemetry {
+      outcome = await h.replayer.replay(recoverySessionID: h.id, isAborted: { false })
+    }
+
+    #expect(outcome == .failed(.unrecoverable), "one retry, then we stop")
+    let e = try #require(box.recoveryEvents().first)
+    #expect(e.stringProps["outcome"] == "failed")
+    #expect(e.stringProps["retry_disposition"] == "exhausted")
+    #expect(e.stringProps["failure_class"] == "load_returned_not_ready")
+  }
+
+  /// THE TRAP, specified so it cannot be satisfied trivially. Two independent
+  /// spools, two errors injected through the REAL load closure, one real replay
+  /// each. An earlier draft of this row was satisfiable by two mocked outcomes
+  /// and proved nothing about the live catch.
+  @Test("the two load-site refusals do not share an outcome")
+  func theTwoLoadSiteRefusalsDoNotShareAnOutcome() async throws {
+    let transient = try Fixture.make()
+    transient.asr.loadError = ASREngineNotReadyAfterLoadError()
+    let deterministic = try Fixture.make()
+    deterministic.asr.loadError = ASRError.notReady
+
+    var transientOutcome: RecoveryReplayOutcome?
+    var deterministicOutcome: RecoveryReplayOutcome?
+    let box = await Fixture.capturingTelemetry {
+      transientOutcome = await transient.replayer.replay(
+        recoverySessionID: transient.id, isAborted: { false })
+      deterministicOutcome = await deterministic.replayer.replay(
+        recoverySessionID: deterministic.id, isAborted: { false })
+    }
+
+    #expect(transientOutcome == .deferred, "the load RETURNED and readiness was false")
+    #expect(
+      deterministicOutcome == .failed(.unrecoverable),
+      "no model is admitted; retrying repeats this failure every launch forever")
+    #expect(transient.spoolExists, "kept")
+    #expect(transient.asr.transcribeCallCount == 0)
+    #expect(deterministic.asr.transcribeCallCount == 0)
+
+    let classes = box.recoveryEvents().compactMap { $0.stringProps["failure_class"] }
+    #expect(classes == ["load_returned_not_ready", "not_ready"], "one label each, never shared")
+  }
+
+  /// ROW C. The retry was earned and could not be recorded, so we must NOT clear
+  /// the attempt marker — a retry the budget never recorded is the hole the
+  /// bound exists to close.
+  @Test("a retry that cannot be persisted leaves the attempt spent")
+  func readinessRetryMarkerWriteFailureKeepsAttemptSpent() async throws {
+    let h = try Fixture.make(ops: Fixture.failingCommit())
+    h.asr.loadError = ASREngineNotReadyAfterLoadError()
+
+    var outcome: RecoveryReplayOutcome?
+    let box = await Fixture.capturingTelemetry {
+      outcome = await h.replayer.replay(recoverySessionID: h.id, isAborted: { false })
+    }
+
+    #expect(outcome == .deferredPersistenceFailed)
+    #expect(!h.store.hasReadinessRetryMarker(for: h.id), "nothing committed")
+    #expect(h.store.hasAttemptMarker(for: h.id), "stands, so the next launch abandons")
+    #expect(h.spoolExists, "still not deleted — that is the whole point")
+    #expect(
+      !RecoveryCoordinator.shouldDeleteAfterReplay(.deferredPersistenceFailed),
+      "the coordinator is the sole destructor and must retain this outcome")
+
+    let e = try #require(box.recoveryEvents().first)
+    #expect(e.stringProps["reason"] == "marker_write_failed")
+    #expect(e.stringProps["failure_class"] == "load_returned_not_ready")
+    #expect(e.stringProps["retry_disposition"] == "persistence_failed")
+    #expect(e.boolProps["audio_decrypted"] == true)
+    #expect(e.boolProps["camp_b_candidate"] == true)
+  }
+
+  /// ROW A's ORDERING, continuing into ROW D. The retry marker must COMMIT before
+  /// the attempt marker is cleared: a crash in that window has to abandon the
+  /// spool rather than mint an uncounted retry. Observed through a production
+  /// seam the subject itself fires — never inferred from timing.
+  @Test("the retry marker commits before the attempt marker is cleared")
+  func retryMarkerWritePrecedesAttemptMarkerClear() async throws {
+    let h = try Fixture.make()
+    h.asr.loadError = ASREngineNotReadyAfterLoadError()
+
+    var bothPresentAtCommit = false
+    h.replayer.onReadinessRetryMarkerCommitted = { [store = h.store, id = h.id] in
+      bothPresentAtCommit =
+        store.hasReadinessRetryMarker(for: id) && store.hasAttemptMarker(for: id)
+    }
+
+    _ = await h.replayer.replay(recoverySessionID: h.id, isAborted: { false })
+
+    #expect(
+      bothPresentAtCommit,
+      "at the instant of commit BOTH markers exist; the reverse order would grant a retry nothing recorded")
+  }
+
+  /// ROW H, and it must be distinguishable from ROW C. Asserting only the routing
+  /// would pass whether cleanup succeeded, failed, or was never attempted.
+  @Test("a failed cleanup after a failed commit still holds the recording")
+  func readinessRetryMarkerWriteAndCleanupFailureStaysDeferred() async throws {
+    let cleanupAttempts = Counter()
+    let h = try Fixture.make(ops: Fixture.failingCommitAndCleanup(counter: cleanupAttempts))
+    h.asr.loadError = ASREngineNotReadyAfterLoadError()
+
+    var outcome: RecoveryReplayOutcome?
+    let box = await Fixture.capturingTelemetry {
+      outcome = await h.replayer.replay(recoverySessionID: h.id, isAborted: { false })
+    }
+
+    // THE DISTINCTION from row C. Without these two the case is row C rewritten.
+    #expect(cleanupAttempts.value == 1, "cleanup was ATTEMPTED exactly once")
+    #expect(cleanupAttempts.failuresRaised == 1, "and the injected failure was CONSUMED")
+
+    #expect(outcome == .deferredPersistenceFailed, "a failed cleanup changes nothing for the user")
+    #expect(!h.store.hasReadinessRetryMarker(for: h.id))
+    #expect(h.store.hasAttemptMarker(for: h.id))
+    #expect(h.spoolExists)
+    let e = try #require(box.recoveryEvents().first)
+    #expect(e.stringProps["reason"] == "marker_write_failed")
+    #expect(e.stringProps["retry_disposition"] == "persistence_failed")
+  }
+
+  /// Spool deletion must ATTEMPT every readiness-retry artifact, and keep
+  /// attempting the others when one fails — the store's cleanup is best-effort
+  /// by design, so this asserts attempts, never guarantees.
+  @Test("deleting a spool clears its readiness-retry marker and interrupted temp")
+  func spoolDeletionAttemptsEveryReadinessRetryArtifact() async throws {
+    let h = try Fixture.make()
+    try h.store.writeReadinessRetryMarker(for: h.id)
+    let temp = h.spoolDir.appendingPathComponent(".\(h.id).readiness-retry.tmp")
+    try Data([0x31]).write(to: temp)
+
+    try h.store.delete(recoverySessionID: h.id)
+
+    #expect(!h.store.hasReadinessRetryMarker(for: h.id), "no stale marker outlives its spool")
+    #expect(
+      !FileManager.default.fileExists(atPath: temp.path),
+      "the interrupted-write temp goes too, or it is orphaned permanently")
+  }
+}
+
+/// Counts cleanup attempts so row H can prove it differs from row C.
+final class Counter: @unchecked Sendable {
+  private let lock = NSLock()
+  private var attempts = 0
+  private var failures = 0
+  var value: Int { lock.withLock { attempts } }
+  var failuresRaised: Int { lock.withLock { failures } }
+  func recordAttempt() { lock.withLock { attempts += 1 } }
+  func recordFailure() { lock.withLock { failures += 1 } }
+}
+
+#endif

--- a/Tests/EnviousWisprTests/Recovery/RecoveryLogLabelTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryLogLabelTests.swift
@@ -18,10 +18,24 @@ import Testing
 @MainActor
 @Suite struct RecoveryLogLabelTests {
 
-  /// Every outcome the replayer can return. Written out rather than derived so
-  /// adding a case to `RecoveryReplayOutcome` fails to compile here until it is
-  /// listed — the label switch is exhaustive, but nothing would otherwise force
-  /// this test to cover a new member.
+  /// Forces this file to be updated when `RecoveryReplayOutcome` gains a case.
+  ///
+  /// #2207: the array below previously carried a comment claiming that adding a
+  /// case "fails to compile here until it is listed". It does NOT — an array
+  /// literal is not exhaustive over an enum, so `.deferredPersistenceFailed` was
+  /// added and this file compiled unchanged, silently dropping the new outcome
+  /// from every assertion below. A justification comment that is false is worse
+  /// than none: it stops the next reader checking. This switch is the real
+  /// mechanism the comment described.
+  private static func exhaustivenessWitness(_ outcome: RecoveryReplayOutcome) {
+    switch outcome {
+    case .recovered, .abandoned, .failed, .aborted, .deferred,
+      .deferredMarkerClearFailed, .deferredPersistenceFailed:
+      break
+    }
+  }
+
+  /// Every outcome the replayer can return. Kept in sync by the witness above.
   private static let allOutcomes: [RecoveryReplayOutcome] = [
     .recovered,
     .abandoned,
@@ -30,6 +44,7 @@ import Testing
     .aborted,
     .deferred,
     .deferredMarkerClearFailed,
+    .deferredPersistenceFailed,
   ]
 
   @Test("every outcome reads differently in the log")
@@ -67,7 +82,9 @@ import Testing
     // `shouldDeleteAfterReplay` retains on both deferrals: ASR never ran, so the
     // one attempt is unspent. The label has to carry that, or a reader sees
     // "deferred" and cannot tell whether the recording is still on disk.
-    for outcome: RecoveryReplayOutcome in [.deferred, .deferredMarkerClearFailed] {
+    for outcome: RecoveryReplayOutcome in [
+      .deferred, .deferredMarkerClearFailed, .deferredPersistenceFailed,
+    ] {
       #expect(RecoveryCoordinator.logLabel(outcome).contains("deferred"))
       #expect(RecoveryCoordinator.shouldDeleteAfterReplay(outcome) == false)
     }

--- a/Tests/EnviousWisprTests/Recovery/RecoverySpoolReplayerTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoverySpoolReplayerTests.swift
@@ -49,10 +49,16 @@ struct RecoverySpoolReplayerTests {
     /// post-load refusal (transient race). The two must not share an outcome.
     var loadError: (any Error)?
 
+    /// #2207: whether readiness FOLLOWS a successful load. Default true, so every
+    /// pre-existing test keeps its exact behaviour. Set false to reproduce the
+    /// shipped shape this issue fixes — `ASRManager.loadModel()` RECORDS readiness
+    /// rather than requiring it, so a load can return while the engine is not ready.
+    var readyAfterLoad = true
+
     func loadModel() async throws {
       onLoadModel?()
       if let loadError { throw loadError }
-      isModelLoaded = true
+      isModelLoaded = readyAfterLoad
     }
     func unloadModel() async {}
     func setInitialBackendType(_ type: ASRBackendType) { activeBackendType = type }


### PR DESCRIPTION
Closes #2207

## What was wrong

`ActiveEngineOperation.load` meant "the load call returned", never "the engine is ready". `ASRManager.loadModel()` RECORDS readiness rather than requiring it (`ASRManager.swift:175-177`), so a load can return while the backend is unready. Both callers assumed the stronger meaning.

Crash recovery believed it, transcribed, failed, and **deleted a spool it had successfully saved**. Reproduced in `app.log` on this machine 2026-08-01 and 2026-08-18: a replay failing in the same second it was attempted, no engine activity between, recording destroyed.

This is the door behind #2132. That issue fixed the *mislabelling*; this one closes the door that produces it.

## What changed

1. **The door checks its own postcondition.** `load` reads the engine's readiness projection after the loader returns and throws `ASREngineNotReadyAfterLoadError` when false. Same projection `isLoaded` vends, deliberately.
2. **Recovery routes by cause, exactly once.** That one class defers instead of deleting, and a second refusal is terminal so a permanently unready engine cannot defer forever. `ASRError.notReady` at the load site stays terminal, as #2205 decided.
3. **The bookkeeping is durable and ordered.** The retry marker commits before the attempt marker clears, and both transitions sync the directory. A crash between them abandons rather than minting an uncounted retry.
4. **`retry_disposition`** (`granted` / `exhausted` / `persistence_failed`) makes the bound measurable. Without it `outcome` cannot separate a first refusal from an exhausted one.

## Two live defects fixed on the way

- **The marker-clear deferral emitted without the reconstruction facts**, so a take whose audio reconstructed perfectly reported `audio_decrypted` ABSENT, read as "nothing came out of the spool". The inverse of the truth, and the #2205 defect one branch over.
- **`RecoveryLogLabelTests` carried a false justification comment** claiming a new outcome "fails to compile here until it is listed". An array literal is not exhaustive over an enum: the new outcome compiled unchanged and was silently dropped from every assertion. Replaced with a switch that actually binds.

## Deliberately NOT fixed

`writeAttemptMarker` has the same unsynced-rename gap. It is **pre-existing**, documented at `audio-recovery-internals.md` FACT: replay-delete-retain-after-attempt since #1063, and affects every recovery rather than this path. Stated rather than silently widened.

## Verification

| Check | Result |
|---|---|
| Full lane, final code | Debug **6240** / Release **5681**, reconciled exactly against per-bundle sums |
| Presence control | new suites confirmed in the lane, not merely "green" |
| New tests | 9 readiness-retry + 2 postcondition + 6 telemetry-contract |
| Pre-existing recovery suite | 25 green |
| `worker-tests` | 423 green (a Swift enum changed) |
| Eval packages | `apple_runner` + `alias_runner` build |
| Mutation controls | every new test controlled; tree verified byte-identical after each restore |

**One control caught a vacuous test of my own.** The first scope guard passed with the bug re-applied: it reached `deferForUnavailableEngine` but not the marker-clear CATCH where the leak lived. Replaced with a case that forces the clear to fail and asserts the branch was REACHED.

## Review

Four Codex diff rounds. Rounds 1-3 each found one real defect — stale Diagnostics state, a missing `LocalizedError` conformance, an unsynced rename, and a telemetry field leaking onto an unrelated deferral (that one introduced by round 2's own fix). Round 4 clean.

All four are one class: **a new member not carrying exactly its family's obligations**. Round 3 proved my first enumeration covered only the under-application direction; it was redone in both directions and every member re-verified. Recorded in `/tmp/.codex-class-attested`.

Four rounds triggered the founder-choice gate. Taken as **accept with rationale** under the standing delegation for #2207, recorded in `/tmp/.codex-founder-choice` with the case against each other option.

## Not covered

No Live UAT. The failure needs a real engine to report itself ready while unready, which cannot be staged by hand; the guard is bound by tests and the mutation control instead. Post-release, `recovery.completed` split by `app_version`, `failure_class`, `outcome` and `retry_disposition` is the regression monitor.
