### PR TITLE
Stop the dictation waiting on clipboard tidy-up: 200ms off 87% of pastes (#2197)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/MenuBarController.swift
+++ b/Sources/EnviousWisprAppKit/App/MenuBarController.swift
@@ -1,5 +1,6 @@
 import AppKit
 import EnviousWisprCore
+import EnviousWisprPipeline
 import EnviousWisprServices
 import Foundation
 
@@ -287,7 +288,12 @@ final class MenuBarController: NSObject {
       }
       return nil
     }()
-    let dictationActive = liveRecordingState.isDictationActive
+    // #2197: `installEnabled` below must agree with what
+    // `UpdateCoordinator.triggerGuardedInstall` will actually DO. That guard
+    // refuses during dictation AND during the ~200 ms clipboard cleanup window
+    // that now follows one; reading only the first would render an ENABLED
+    // Install item that silently does nothing when clicked.
+    let installRefused = liveRecordingState.isDictationActive || ClipboardCleanup.hasPending
 
     return MenuBarViewState(
       pipelineState: liveRecordingState.pipelineState,
@@ -300,7 +306,7 @@ final class MenuBarController: NSObject {
       hasUpdater: sparkleUpdateController.hasUpdater,
       updateAvailable: pending != nil,
       updateDisplayVersion: pending?.displayVersion,
-      installEnabled: pending != nil && !dictationActive,
+      installEnabled: pending != nil && !installRefused,
       appearancePreference: settings.appearancePreference
     )
   }

--- a/Sources/EnviousWisprAppKit/App/MenuBarController.swift
+++ b/Sources/EnviousWisprAppKit/App/MenuBarController.swift
@@ -1,6 +1,5 @@
 import AppKit
 import EnviousWisprCore
-import EnviousWisprPipeline
 import EnviousWisprServices
 import Foundation
 
@@ -288,12 +287,13 @@ final class MenuBarController: NSObject {
       }
       return nil
     }()
-    // #2197: `installEnabled` below must agree with what
-    // `UpdateCoordinator.triggerGuardedInstall` will actually DO. That guard
-    // refuses during dictation AND during the ~200 ms clipboard cleanup window
-    // that now follows one; reading only the first would render an ENABLED
-    // Install item that silently does nothing when clicked.
-    let installRefused = liveRecordingState.isDictationActive || ClipboardCleanup.hasPending
+    // #2197: ask the coordinator whether an install is refused rather than
+    // re-deriving the condition here. Recomputing it locally is what produced an
+    // ENABLED Install item the guard then silently swallowed, and reading it from
+    // the owner also keeps this file free of a Pipeline import it has no business
+    // holding — the architecture guard that refused that import was right.
+    let installRefused =
+      sparkleUpdateController.updateCoordinator?.installRefusedNow ?? false
 
     return MenuBarViewState(
       pipelineState: liveRecordingState.pipelineState,

--- a/Sources/EnviousWisprAppKit/App/UpdateCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/UpdateCoordinator.swift
@@ -62,6 +62,19 @@ final class UpdateCoordinator {
   /// app mid-capture. Wired in `WisprBootstrapper` to `LiveRecordingState`.
   var dictationActiveProvider: (() -> Bool)?
 
+  /// #2197: reads whether clipboard cleanup is still outstanding.
+  ///
+  /// Since #2197 the clipboard restore runs just after a dictation finishes
+  /// rather than inside it, so there is now a ~200 ms window where the session
+  /// is over — and `dictationActiveProvider` therefore reports false — while the
+  /// user's clipboard has not been handed back yet. A Sparkle install relaunches
+  /// the app, which would take the process down inside that window and lose it.
+  ///
+  /// Declining to START an install for 200 ms is a strictly smaller refusal than
+  /// the mid-dictation one already shipping beside it. Wired in
+  /// `WisprBootstrapper` to `ClipboardCleanup.hasPending`.
+  var clipboardCleanupPendingProvider: (() -> Bool)?
+
   /// #1019: when the last update-check cycle FINISHED having reached the feed
   /// (update found, none found, or user-cancelled install). Nil until the first
   /// such outcome. A genuine network/parse failure does NOT update this, so the
@@ -266,7 +279,9 @@ final class UpdateCoordinator {
   }
 
   private func triggerGuardedInstall(source: String) {
-    guard !(dictationActiveProvider?() ?? false) else { return }
+    guard !(dictationActiveProvider?() ?? false),
+      !(clipboardCleanupPendingProvider?() ?? false)
+    else { return }
     // #1029: only install when an update is actually available. With the tap
     // delegate now active on every launch, a tap on a STALE delivered
     // notification (its version already installed, pending state cleared by

--- a/Sources/EnviousWisprAppKit/App/UpdateCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/UpdateCoordinator.swift
@@ -278,10 +278,19 @@ final class UpdateCoordinator {
     triggerGuardedInstall(source: "notification")
   }
 
+  /// Whether an install must be refused right now.
+  ///
+  /// ONE authority, read by both the guard below and the menu's `installEnabled`
+  /// (#2197). They were briefly separate, and the menu rendered an ENABLED
+  /// Install item that this guard then silently swallowed — found in diff review.
+  /// Anything that can refuse an install belongs here, not in a second copy of
+  /// the condition.
+  var installRefusedNow: Bool {
+    (dictationActiveProvider?() ?? false) || (clipboardCleanupPendingProvider?() ?? false)
+  }
+
   private func triggerGuardedInstall(source: String) {
-    guard !(dictationActiveProvider?() ?? false),
-      !(clipboardCleanupPendingProvider?() ?? false)
-    else { return }
+    guard !installRefusedNow else { return }
     // #1029: only install when an update is actually available. With the tap
     // delegate now active on every launch, a tap on a STALE delivered
     // notification (its version already installed, pending state cleared by

--- a/Sources/EnviousWisprAppKit/App/UpdateCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/UpdateCoordinator.swift
@@ -374,16 +374,32 @@ final class UpdateCoordinator {
   /// Banner click. Tags source, persists install attempt, fires telemetry,
   /// flushes PostHog (so the event survives Sparkle's relaunch), then triggers
   /// the install via the service.
+  /// #2197: routed through `triggerGuardedInstall` like the other two entry
+  /// points, rather than calling `service.triggerInstall()` directly.
+  ///
+  /// This closes a hole that PREDATES this issue. #1019 added the
+  /// active-dictation guard so an install could never relaunch the app
+  /// mid-capture, and wired it to the menu item and the notification tap — but
+  /// the banner kept its own direct call, so a banner click has been able to
+  /// relaunch mid-dictation the whole time. The clipboard-cleanup clause would
+  /// have inherited exactly the same gap.
+  ///
+  /// Found by the diff review sweeping the SET of install entry points after
+  /// this change added a new member to the refusal condition; I had swept two of
+  /// three (workflow-process.md RULE: self-review-and-grep-before-codex — an
+  /// entity sweep finds wrong statements, a member sweep finds omissions).
+  ///
+  /// The click telemetry still fires on refusal, because the user DID click and
+  /// a dropped event would misreport banner engagement. Only the install is
+  /// withheld.
   func handleBannerClicked(version: String, isCritical: Bool, secondsVisible: Int) {
-    lastInstallSource = "banner"
-    recordInstallAttempt(version: version, source: "banner")
     TelemetryService.shared.updateBannerClicked(
       version: version,
       isCritical: isCritical,
       secondsVisible: secondsVisible
     )
     TelemetryService.shared.flushTelemetry(reason: .updateInstall)
-    service.triggerInstall()
+    triggerGuardedInstall(source: "banner")
   }
 
   enum InstallAttemptOutcome: Equatable {

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -1102,6 +1102,9 @@ public final class WisprBootstrapper {
     sparkleUpdateController.updateCoordinator?.dictationActiveProvider = { [weak self] in
       self?.liveRecordingState.isDictationActive ?? false
     }
+    // #2197: same refusal while clipboard cleanup is pending (why: its own doc).
+    sparkleUpdateController.updateCoordinator?
+      .clipboardCleanupPendingProvider = { ClipboardCleanup.hasPending }
     // #1029: install the notification tap delegate eagerly at launch (decoupled
     // from posting) so a tap on an already-delivered "update ready" notification —
     // or a cold launch from it — always routes, even when the once-per-version

--- a/Sources/EnviousWisprCore/Constants.swift
+++ b/Sources/EnviousWisprCore/Constants.swift
@@ -322,8 +322,25 @@ public enum RecoveryConstants {
 // MARK: - Timing Constants
 
 public enum TimingConstants {
-  /// Delay before clipboard restoration after paste.
+  /// How long the target app is given to read our payload before the clipboard
+  /// is tidied up.
+  ///
+  /// Since #2197 this is awaited OFF the delivery path, in `ClipboardCleanup`,
+  /// so it no longer delays the dictation's own completion. The value is
+  /// deliberately unchanged: measured app read times are 2-38 ms, but that is a
+  /// measurement of the fastest Mac we own, and a fixed number here has to be
+  /// safe for the slowest one. Once the wait costs the user nothing there is
+  /// nothing to buy by shortening it.
   public static let clipboardRestoreDelayMs: Int = 200
+
+  /// How long to let an app settle after activating it, before choosing the
+  /// payload to paste into it.
+  ///
+  /// Same value as `clipboardRestoreDelayMs` and unrelated to it — this one
+  /// shared that constant by accident of history until #2197. Separated so that
+  /// retuning a clipboard delay cannot silently retune an activation delay
+  /// nobody measured.
+  public static let activationSettleBeforePasteMs: Int = 200
 
   /// Delay after hiding the app before simulating paste (ms).
   public static let appHideBeforePasteDelayMs: Int = 300

--- a/Sources/EnviousWisprPipeline/ClipboardCleanup.swift
+++ b/Sources/EnviousWisprPipeline/ClipboardCleanup.swift
@@ -85,6 +85,34 @@ public enum ClipboardCleanup {
 
   private static var pending: Pending?
 
+  // KNOWN LIMIT, raised by review three times and adjudicated three times, so
+  // the reasoning is here rather than in a review thread nobody will find.
+  //
+  // If the process exits inside the 200 ms window, this task is destroyed and
+  // the user's clipboard keeps our dictated payload instead of their own.
+  //
+  // THAT LOSS IS NOT NEW. There is no `applicationShouldTerminate` in this app
+  // (swept: `AppDelegate` implements only
+  // `applicationShouldTerminateAfterLastWindowClosed`), so `NSApp.terminate` runs
+  // straight through to exit as one synchronous main-thread chain. Today's
+  // INLINE `Task.sleep` in `deliver` is abandoned by that chain in exactly the
+  // same way — a suspended task cannot interleave into it.
+  //
+  // WHAT DOES CHANGE IS LIKELIHOOD, and it is worth saying rather than claiming
+  // strict equality: after this change the session has already finished when the
+  // window opens, so the app looks idle and a user is marginally more likely to
+  // quit inside it.
+  //
+  // Both proposed fixes are worse than the defect. A synchronous flush restores
+  // BEFORE the delay expires, which can pull our payload off the board before the
+  // target app has read the ⌘V we already posted — the wrong-text failure, via a
+  // teardown hook. Deferring termination introduces an app that may not quit, in
+  // an app that has never had a termination hook at all. A lost clipboard entry
+  // is recoverable; neither of those is.
+  //
+  // What IS closed is the only newly-reachable route: an update relaunch, which
+  // `UpdateCoordinator.installRefusedNow` now refuses while cleanup is pending.
+
   // MARK: Test seams
   //
   // Deliberately NOT `#if DEBUG`. A DEBUG-only declaration referenced from a

--- a/Sources/EnviousWisprPipeline/ClipboardCleanup.swift
+++ b/Sources/EnviousWisprPipeline/ClipboardCleanup.swift
@@ -15,6 +15,28 @@ import EnviousWisprServices
 /// clipboard comes back at the same wall-clock moment it always did. What
 /// changes is that the dictation no longer waits for it.
 ///
+/// **DO NOT REPLACE THIS WITH "DETECT WHEN THE APP HAS READ IT". It was built,
+/// measured, and refused.** The obvious improvement is to stop waiting a fixed
+/// period and instead learn the moment the target app reads the pasteboard —
+/// macOS offers exactly that, via lazy provision: declare a type with an owner
+/// and `pasteboard(_:provideDataForType:)` fires when a client asks for the
+/// bytes. The mechanism works. Apps read in 2.0-38 ms, exactly one read per
+/// paste, and lazily provided text does paste correctly.
+///
+/// It is unusable because **the callback proves SOMEONE read the board, never
+/// WHO.** A clipboard manager reads it the same way the target app does, both
+/// are other processes, and the promise is one-shot — whoever reads first spends
+/// the signal. Restoring on a stolen read puts the user's PREVIOUS clipboard
+/// into their document instead of their dictation, on the one path that must
+/// never fail.
+///
+/// Timing cannot separate them, and that was measured rather than assumed:
+/// thefts land at 0.0 ms and 3.2 ms after the keystroke, against a fastest
+/// genuine app read of 2.0 ms. The distributions overlap, so no threshold
+/// exists. (The probe and the full write-up live outside the repo — `docs/` and
+/// `.claude/` are gitignored — which is why the conclusion is recorded HERE, in
+/// the file someone would edit while re-deriving it.)
+///
 /// **The one new thing is pending work, and it needs its own bookkeeping.**
 /// Cleanup can still be outstanding after `deliver` has returned, which creates
 /// states that could not previously exist. The plan enumerates them

--- a/Sources/EnviousWisprPipeline/ClipboardCleanup.swift
+++ b/Sources/EnviousWisprPipeline/ClipboardCleanup.swift
@@ -1,0 +1,274 @@
+import AppKit
+import EnviousWisprCore
+import EnviousWisprServices
+
+/// Clipboard hygiene that outlives the delivery which scheduled it (#2197).
+///
+/// **Why this type exists.** Every clipboard paste route waits 200 ms before
+/// handing the user's clipboard back, so the target app has time to read what we
+/// put there. That wait used to sit *inside* the awaited delivery call, so the
+/// dictation's own completion — terminal state, telemetry, overlay dismissal,
+/// readiness for the next one — queued behind it. Nothing downstream of delivery
+/// reads the restored board, so nothing needed to wait.
+///
+/// The delay is unchanged, the change-count guard is unchanged, and the user's
+/// clipboard comes back at the same wall-clock moment it always did. What
+/// changes is that the dictation no longer waits for it.
+///
+/// **The one new thing is pending work, and it needs its own bookkeeping.**
+/// Cleanup can still be outstanding after `deliver` has returned, which creates
+/// states that could not previously exist. The plan enumerates them
+/// exhaustively (`docs/feature-requests/issue-2197-…`, "the class, enumerated");
+/// the three that shape this file are:
+///
+/// 1. A later delivery must not photograph a board that still holds OUR payload
+///    — it would save the previous dictation as "the user's clipboard" and then
+///    faithfully restore it. `snapshotForDelivery` inherits instead.
+/// 2. …but it MUST photograph when the board has moved, or a stale snapshot
+///    overwrites something the user copied during the window. That is the same
+///    bug inverted and strictly worse: misplacing a clipboard versus destroying
+///    one.
+/// 3. Cancellation must mean ABANDON, never "run it now". `try? await
+///    Task.sleep` swallows a cancellation and falls straight through to the
+///    body, performing it *early* — before the target app has read the payload
+///    we already posted. That is the wrong-text failure, and `try?` is the
+///    shorter, equivalent-looking spelling a later tidy-up would reach for.
+///
+/// **On 3, measured rather than asserted, because the first version of this
+/// comment overstated it.** Two mechanisms protect that outcome — the
+/// `do/catch` here and the `pending?.id == id` identity check below — and a
+/// mutation run showed they are fully redundant: removing EITHER alone leaves
+/// the suite green, because the other still covers every reachable path.
+/// Removing BOTH is caught. So neither line is individually load-bearing, and
+/// neither should be deleted on the grounds that a test still passes without
+/// it. That is what defence in depth looks like from inside a mutation run, and
+/// it is easy to misread as a vacuous test.
+@MainActor
+public enum ClipboardCleanup {
+
+  /// The two kinds of pending cleanup.
+  ///
+  /// Modelled as one enum rather than a snapshot plus a flag because they carry
+  /// *different inputs*: a restore holds the user's clipboard, a legacy rewrite
+  /// holds replacement text. A type that could represent only the first had no
+  /// answer for what a later delivery should inherit while a rewrite was
+  /// pending — found by review, and the reason this is an enum.
+  private enum Operation {
+    /// Put the user's clipboard back.
+    case restore(ClipboardSnapshot)
+    /// Replace our contextual payload with the legacy one, so a manual ⌘V pastes
+    /// what the user expects. Only ever pending when clipboard restore is OFF,
+    /// because `mustRewriteClipboardToLegacy` requires `!willRestoreUserClipboard`.
+    case legacyRewrite(String)
+
+    var label: String {
+      switch self {
+      case .restore: return "restore"
+      case .legacyRewrite: return "legacy_rewrite"
+      }
+    }
+  }
+
+  private struct Pending {
+    /// Identity, so a task can tell whether the slot is still ITS work. Without
+    /// it, delivery N completing clears a slot that now belongs to N+1, and
+    /// N+1's cleanup becomes invisible to the next inherit check and to
+    /// `hasPending`.
+    let id: UUID
+    let operation: Operation
+    /// The board's change count immediately after this delivery wrote it.
+    /// Doubles as the test for "does the board still hold what this cleanup was
+    /// written for".
+    let changeCountAfterPaste: Int
+    let task: Task<Void, Never>
+  }
+
+  private static var pending: Pending?
+
+  // MARK: Test seams
+  //
+  // Deliberately NOT `#if DEBUG`. A DEBUG-only declaration referenced from a
+  // test breaks the RELEASE build, and a Debug-only local run cannot see it by
+  // construction (tools-and-apps.md RULE: xcode-test-entrypoint). Three internal
+  // statics cost nothing in the shipped binary and remove that whole class.
+
+  /// Shortens the wait so a test does not sleep 200 ms per case. Nil in
+  /// production, and nothing in `Sources/` ever assigns it.
+  static var testDelayOverrideMs: Int?
+
+  /// Awaits the currently-pending cleanup, so a test learns it is done from the
+  /// subject rather than by sleeping and hoping
+  /// (testing-philosophy.md RULE: never-guess-when-the-subject-is-finished).
+  static func awaitPendingCleanup() async {
+    await pending?.task.value
+  }
+
+  /// Drops any pending cleanup between cases. Cancels first, so an abandoned
+  /// task cannot fire against the next case's board.
+  static func resetPendingForTests() {
+    pending?.task.cancel()
+    pending = nil
+  }
+
+  /// Cancels pending cleanup and waits for that task to actually finish.
+  ///
+  /// The waiting is the point. Proving cleanup was ABANDONED means proving
+  /// something did not happen, and the tempting way to do that is to sleep and
+  /// look. A cancelled task still RUNS TO COMPLETION — it just returns early —
+  /// so awaiting it is a real signal from the subject with no clock in it
+  /// (testing-philosophy.md RULE: never-guess-when-the-subject-is-finished).
+  static func cancelPendingAndAwait() async {
+    guard let current = pending else { return }
+    pending = nil
+    current.task.cancel()
+    await current.task.value
+  }
+
+  /// Whether cleanup is outstanding.
+  ///
+  /// Read by the update coordinator, which already refuses to install an update
+  /// mid-dictation and now also refuses while cleanup is pending: a Sparkle
+  /// relaunch inside the window would take the process down before the user's
+  /// clipboard came back. Declining to *start* an install for 200 ms is a
+  /// strictly smaller refusal than the one already shipping.
+  public static var hasPending: Bool { pending != nil }
+
+  /// The user's clipboard as it stood before OUR payloads began landing on it.
+  ///
+  /// Routes call this instead of `PasteService.saveClipboard()` so a delivery
+  /// beginning while cleanup is outstanding cannot photograph our own previous
+  /// payload and mistake it for the user's clipboard.
+  static func snapshotForDelivery(from board: NSPasteboard = .general) -> ClipboardSnapshot {
+    guard let current = pending else { return PasteService.saveClipboard(from: board) }
+
+    guard board.changeCount == current.changeCountAfterPaste else {
+      // The board moved: someone else owns it now, the pending value is stale,
+      // and its cleanup must not fire either — it would overwrite whatever the
+      // user just copied.
+      current.task.cancel()
+      pending = nil
+      return PasteService.saveClipboard(from: board)
+    }
+
+    switch current.operation {
+    case .restore(let snapshot):
+      // Our payload is still on the board and a real user clipboard is being
+      // held for it. THAT is the user's clipboard, not what the board shows.
+      return snapshot
+
+    case .legacyRewrite(let legacyText):
+      // No user clipboard is held here — restore was off for that delivery. But
+      // the board holds the REPAIRED payload and this delivery is about to
+      // supersede the rewrite that would have replaced it, so photographing the
+      // board would preserve exactly the text the rewrite exists to remove.
+      // Inherit what the board WOULD have held had the rewrite run.
+      return ClipboardSnapshot(
+        items: [[.string: Data(legacyText.utf8)]],
+        changeCount: board.changeCount)
+    }
+  }
+
+  /// Hand the user's clipboard back after the target app has had time to read
+  /// ours, without making the dictation wait for it.
+  static func scheduleRestore(
+    _ snapshot: ClipboardSnapshot,
+    changeCountAfterPaste: Int,
+    tier: PasteTier,
+    on board: NSPasteboard = .general
+  ) {
+    schedule(
+      operation: .restore(snapshot),
+      changeCountAfterPaste: changeCountAfterPaste,
+      tier: tier
+    ) {
+      PasteService.restoreClipboard(
+        snapshot, changeCountAfterPaste: changeCountAfterPaste, on: board)
+    }
+  }
+
+  /// Replace our contextual payload with the legacy one after the target app has
+  /// had time to read the contextual one.
+  ///
+  /// A separate operation from the restore on purpose: the wait is shared, the
+  /// body is not. Collapsing them would swap one behaviour for the other.
+  static func scheduleLegacyRewrite(
+    legacyText: String,
+    submittedChangeCount: Int,
+    tier: PasteTier,
+    on board: NSPasteboard = .general
+  ) {
+    schedule(
+      operation: .legacyRewrite(legacyText),
+      changeCountAfterPaste: submittedChangeCount,
+      tier: tier
+    ) {
+      // The same freshness question the restore asks, asked separately because
+      // the POLICY ("should this be rewritten at all") was answered before the
+      // wait and the FRESHNESS question can only be answered after it.
+      guard
+        clipboardUntouchedSinceSubmit(
+          submitted: submittedChangeCount,
+          current: board.changeCount)
+      else { return false }
+      PasteService.copyToClipboard(legacyText, to: board)
+      return true
+    }
+  }
+
+  // MARK: - Private
+
+  /// - Parameter body: performs the cleanup and returns whether it applied.
+  ///   `false` means a guard declined, which is a normal outcome.
+  private static func schedule(
+    operation: Operation,
+    changeCountAfterPaste: Int,
+    tier: PasteTier,
+    body: @escaping @MainActor () -> Bool
+  ) {
+    let id = UUID()
+    let label = operation.label
+
+    let task = Task { @MainActor in
+      // `do/catch { return }`, NOT `try?`. A cancelled wait must ABANDON this
+      // cleanup, never fall through and perform it early — see the type doc.
+      do {
+        try await Task.sleep(
+          for: .milliseconds(testDelayOverrideMs ?? TimingConstants.clipboardRestoreDelayMs))
+      } catch {
+        return
+      }
+      // Superseded while we slept: their cleanup owns the board now.
+      guard pending?.id == id else { return }
+
+      let applied = body()
+
+      // Cleared on EVERY path that reaches here, including the one where the
+      // guard declined. A slot left populated would be inherited by the next
+      // delivery and would keep `hasPending` true, blocking update installs
+      // indefinitely.
+      finish(id)
+
+      Task {
+        await AppLogger.shared.log(
+          "Clipboard cleanup: op=\(label), applied=\(applied), "
+            + "delay=\(TimingConstants.clipboardRestoreDelayMs)ms, tier=\(tier.rawValue)",
+          level: .info, category: "PipelineTiming"
+        )
+      }
+    }
+
+    // A newer cleanup supersedes an older one outright: only one can own the
+    // board, and leaving the old task running would race it.
+    pending?.task.cancel()
+    pending = Pending(
+      id: id,
+      operation: operation,
+      changeCountAfterPaste: changeCountAfterPaste,
+      task: task)
+  }
+
+  private static func finish(_ id: UUID) {
+    guard pending?.id == id else { return }
+    pending = nil
+  }
+}

--- a/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
+++ b/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
@@ -406,7 +406,7 @@ internal final class PasteCascadeExecutor {
         // proven gap — taken because it costs one moved line.
         let snapshot: ClipboardSnapshot? =
           request.restoreClipboardAfterPaste
-          ? PasteService.saveClipboard()
+          ? ClipboardCleanup.snapshotForDelivery()
           : nil
         submittedKind = payload.kind
         let dispatchResult = PasteService.pasteToActiveApp(payload.text)
@@ -424,9 +424,10 @@ internal final class PasteCascadeExecutor {
           )
         }
         if let snapshot {
-          try? await Task.sleep(for: .milliseconds(TimingConstants.clipboardRestoreDelayMs))
-          PasteService.restoreClipboard(
-            snapshot, changeCountAfterPaste: dispatchResult.changeCount)
+          // Scheduled, not awaited (#2197). The delay and the guard are
+          // unchanged; the dictation just stops queueing behind them.
+          ClipboardCleanup.scheduleRestore(
+            snapshot, changeCountAfterPaste: dispatchResult.changeCount, tier: tier)
         }
       } else {
         // Activation timed out. Record it as a distinct failure stage so
@@ -440,7 +441,11 @@ internal final class PasteCascadeExecutor {
         tiersAttempted.append(.appleScript)
         _ = PasteService.forceActivateApp(pid: app.processIdentifier)
         app.activate()
-        try? await Task.sleep(for: .milliseconds(TimingConstants.clipboardRestoreDelayMs))
+        // Not a clipboard delay — this waits for the activation to settle before
+        // the payload is chosen. It shared `clipboardRestoreDelayMs` by accident
+        // of history; #2197 gave it its own name so an edit to one cannot
+        // silently retune the other.
+        try? await Task.sleep(for: .milliseconds(TimingConstants.activationSettleBeforePasteMs))
         let payload = PasteService.payloadAtCommitBoundary(
           legacy: request.legacyText,
           repaired: request.repairedText,
@@ -452,7 +457,7 @@ internal final class PasteCascadeExecutor {
         // Same ordering as Tier 2: snapshot after the re-check, before the write.
         let snapshot: ClipboardSnapshot? =
           request.restoreClipboardAfterPaste
-          ? PasteService.saveClipboard()
+          ? ClipboardCleanup.snapshotForDelivery()
           : nil
         submittedKind = payload.kind
         let changeCount = PasteService.copyToClipboardReturningChangeCount(payload.text)
@@ -464,8 +469,8 @@ internal final class PasteCascadeExecutor {
           emitTierFailureBreadcrumb(stage: "applescript", reason: "refused", bundleId: bundleId)
         }
         if let snapshot {
-          try? await Task.sleep(for: .milliseconds(TimingConstants.clipboardRestoreDelayMs))
-          PasteService.restoreClipboard(snapshot, changeCountAfterPaste: changeCount)
+          ClipboardCleanup.scheduleRestore(
+            snapshot, changeCountAfterPaste: changeCount, tier: tier)
         }
       }
     }
@@ -489,7 +494,7 @@ internal final class PasteCascadeExecutor {
         // Put our text on the clipboard BEFORE probing enabled-state: apps grey
         // out Paste when the clipboard is empty/incompatible (#729 Codex r1).
         let snapshot: ClipboardSnapshot? =
-          request.restoreClipboardAfterPaste ? PasteService.saveClipboard() : nil
+          request.restoreClipboardAfterPaste ? ClipboardCleanup.snapshotForDelivery() : nil
         // Selected through the same owner as every other route. A container
         // target should never HAVE a candidate — the context reader refuses any
         // role that is not a text role — but this route asks the same question
@@ -516,8 +521,8 @@ internal final class PasteCascadeExecutor {
               tier = .menuPaste
               // Restore the user's prior clipboard after the paste lands.
               if let snapshot {
-                try? await Task.sleep(for: .milliseconds(TimingConstants.clipboardRestoreDelayMs))
-                PasteService.restoreClipboard(snapshot, changeCountAfterPaste: changeCount)
+                ClipboardCleanup.scheduleRestore(
+                  snapshot, changeCountAfterPaste: changeCount, tier: tier)
               }
             } else {
               // Enabled but AXPress failed. Leave the payload on the clipboard
@@ -589,20 +594,17 @@ internal final class PasteCascadeExecutor {
       fellBackToClipboardOnly: false)
     {
       // A clipboard route delivered contextual text and nothing else is going to
-      // clear it. Wait first, for the same reason the restore path waits: the
+      // clear it. The wait exists for the same reason the restore path waits: the
       // Cmd+V we posted is read by the target app asynchronously, and replacing
       // the clipboard underneath it would deliver today's payload instead of the
       // one we just chose — silently undoing the feature at the last step.
-      try? await Task.sleep(for: .milliseconds(TimingConstants.clipboardRestoreDelayMs))
-      // ...and during that wait the user, or their clipboard manager, may have
-      // copied something. Rewriting unconditionally would destroy it. Same guard
-      // `restoreClipboard` has always applied: only touch the board if it still
-      // holds exactly what this route put there.
-      if clipboardUntouchedSinceSubmit(
-        submitted: submittedClipboardChangeCount,
-        current: NSPasteboard.general.changeCount)
-      {
-        PasteService.copyToClipboard(request.legacyText)
+      //
+      // Scheduled rather than awaited (#2197). The freshness guard still runs
+      // AFTER the wait, inside the scheduled body, because the POLICY question
+      // was answered here and the FRESHNESS question can only be answered later.
+      if let submitted = submittedClipboardChangeCount {
+        ClipboardCleanup.scheduleLegacyRewrite(
+          legacyText: request.legacyText, submittedChangeCount: submitted, tier: tier)
       }
     }
 

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -216,15 +216,19 @@ public enum PasteService {
     }
 
     pasteboard.clearContents()
+    // `setData` can refuse an item, and `writeObjects` can refuse the write.
+    // Both were previously ignored, which was harmless while the caller's own
+    // control flow revealed the outcome — and stops being harmless now that the
+    // only report of it is this function's return value (#2197).
+    var itemsAccepted = true
     let pbItems: [NSPasteboardItem] = snapshot.items.map { itemDict in
       let pbItem = NSPasteboardItem()
-      for (type, data) in itemDict {
-        pbItem.setData(data, forType: type)
+      for (type, data) in itemDict where !pbItem.setData(data, forType: type) {
+        itemsAccepted = false
       }
       return pbItem
     }
-    pasteboard.writeObjects(pbItems)
-    return true
+    return pasteboard.writeObjects(pbItems) && itemsAccepted
   }
 
   // MARK: - Tier 1: AX Direct Insertion

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -178,11 +178,17 @@ public enum PasteService {
   ///     our own paste write. Pass this value so we can detect if a clipboard
   ///     manager has modified the board before the restore fires.
   ///   - pasteboard: Defaults to the user's clipboard. Tests pass an isolated board.
+  /// - Returns: whether the board was actually written. `false` means the guard
+  ///   declined because something else claimed the board first, which is a normal
+  ///   outcome and not an error. Added for #2197: once the restore runs off the
+  ///   awaited delivery path, "did it apply" stops being observable from the
+  ///   caller's control flow, so the only way to log or test it is to return it.
+  @discardableResult
   public static func restoreClipboard(
     _ snapshot: ClipboardSnapshot,
     changeCountAfterPaste: Int,
     on pasteboard: NSPasteboard = .general
-  ) {
+  ) -> Bool {
     // Read once, up front. The unstructured logging `Task` below then captures
     // an `Int` instead of the `NSPasteboard` reference, and the number it
     // reports is the one the guard actually decided on rather than whatever the
@@ -199,14 +205,14 @@ public enum PasteService {
           level: .verbose, category: "PasteService"
         )
       }
-      return
+      return false
     }
 
     // Prior clipboard was empty — restore to empty by clearing our own paste
     // text off the board, rather than leaving it behind (#729 Codex diff review).
     guard !snapshot.items.isEmpty else {
       pasteboard.clearContents()
-      return
+      return true
     }
 
     pasteboard.clearContents()
@@ -218,6 +224,7 @@ public enum PasteService {
       return pbItem
     }
     pasteboard.writeObjects(pbItems)
+    return true
   }
 
   // MARK: - Tier 1: AX Direct Insertion

--- a/Tests/EnviousWisprTests/App/UpdateCoordinatorProactiveCheckTests.swift
+++ b/Tests/EnviousWisprTests/App/UpdateCoordinatorProactiveCheckTests.swift
@@ -339,6 +339,69 @@ struct UpdateCoordinatorProactiveCheckTests {
     #expect(coordinator.service.state == .available(availableUpdate("2.1.4")))
   }
 
+  // MARK: - Clipboard-cleanup install guard (#2197 heart-path)
+
+  @Test("installRefusedNow is true while clipboard cleanup is pending")
+  func refusedWhileClipboardCleanupPending() {
+    let coordinator = makeCoordinator()
+    coordinator.dictationActiveProvider = { false }
+    coordinator.clipboardCleanupPendingProvider = { true }
+
+    // Sparkle relaunches the app. Doing that inside the ~200 ms window between a
+    // dictation ending and the user's clipboard being handed back would take the
+    // process down before the restore ran (#2197).
+    #expect(coordinator.installRefusedNow == true)
+  }
+
+  @Test("installRefusedNow is false once nothing refuses")
+  func notRefusedWhenIdle() {
+    let coordinator = makeCoordinator()
+    coordinator.dictationActiveProvider = { false }
+    coordinator.clipboardCleanupPendingProvider = { false }
+
+    // The paired half. Without it, a predicate wired permanently ON would satisfy
+    // the case above and silently stop every update from ever installing.
+    #expect(coordinator.installRefusedNow == false)
+  }
+
+  @Test("installRefusedNow still refuses during dictation, with cleanup idle")
+  func refusedWhileDictating() {
+    let coordinator = makeCoordinator()
+    coordinator.dictationActiveProvider = { true }
+    coordinator.clipboardCleanupPendingProvider = { false }
+
+    // #2197 folded two conditions into one predicate; this is the check that the
+    // ORIGINAL one (#1019) survived that consolidation.
+    #expect(coordinator.installRefusedNow == true)
+  }
+
+  // These assert the PREDICATE, not the install side effect, and that is
+  // deliberate. The first version drove `installFromMenu()` through to
+  // `service.triggerInstall()` — which no test had ever reached from that entry
+  // point — and hung the `.serialized` suite: 27 started, 22 finished, zero `✘`
+  // marks, `TEST FAILED`. A control run of the suite at HEAD passed 22/22, which
+  // is what identified the additions rather than the change as the cause.
+  // Everything between the predicate and Sparkle is already covered by the
+  // existing dictation-guard cases.
+
+  // NOTE: the two banner-click cases that belong here are NOT here, and the gap
+  // is deliberate rather than forgotten.
+  //
+  // `handleBannerClicked` emits `TelemetryService.shared.updateBannerClicked`
+  // and then `flushTelemetry`, against the real shared telemetry service. No
+  // test had ever called it, so nothing had exercised that. Adding the obvious
+  // two cases hung the whole `.serialized` suite: 31 tests started, 22 finished,
+  // no assertion failed, and `TEST FAILED` with zero `✘` marks — which is what a
+  // hang looks like from the outside, not a broken expectation.
+  //
+  // The PRODUCTION fix stays: banner clicks now route through
+  // `triggerGuardedInstall` like the other two entry points, closing a bypass
+  // that predates #2197. What is missing is coverage of that routing, and it
+  // needs a telemetry seam this suite does not have. Tracked on #2215.
+  //
+  // The guard ITSELF is covered — `installFromMenu` and the notification tap
+  // exercise the same `installRefusedNow` predicate the banner now consults.
+
   // MARK: - Menu install guard (#1019 heart-path)
 
   @Test("installFromMenu is a no-op while dictation is active")

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -466,14 +466,25 @@ import Testing
   /// their own. Comments on both #2109 additions were folded to their code lines
   /// first, so the growth is one line of wiring and no prose. Same deterministic
   /// rule: actual 1351 + ~2, rounded up to nearest 5.
+  ///
+  /// RAISED 1355 → 1360 for #2197 (2026-08-19). Three lines: wiring
+  /// `clipboardCleanupPendingProvider` at the composition root, beside the
+  /// `dictationActiveProvider` it extends. It has to live here because this is
+  /// the composition root — the coordinator reads process-wide state through a
+  /// closure rather than importing Pipeline, which is the same shape as the
+  /// provider above it, and a closure nothing assigns is a guard that never
+  /// fires. Prose was folded FIRST, per the precedent above: the original six
+  /// lines became one comment line plus two of wiring, and the full rationale
+  /// lives on the property's own doc comment in `UpdateCoordinator`. Same
+  /// deterministic rule: actual 1356 + ~2, rounded up to nearest 5.
   @Test func envWisprAppLineCountCeilingHolds() throws {
     let url = envWisprAppURL()
     let source = try String(contentsOf: url, encoding: .utf8)
     let lineCount = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
-      lineCount <= 1355,
+      lineCount <= 1360,
       """
-      WisprBootstrapper line count exceeded: \(lineCount) > 1355. \
+      WisprBootstrapper line count exceeded: \(lineCount) > 1360. \
       Raising the ceiling requires a Bible changelog entry.
       """)
   }

--- a/Tests/EnviousWisprTests/Pipeline/ClipboardCleanupTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ClipboardCleanupTests.swift
@@ -1,0 +1,260 @@
+import AppKit
+import Testing
+
+@testable import EnviousWisprPipeline
+@testable import EnviousWisprServices
+
+// MARK: - ClipboardCleanupTests (#2197)
+//
+// Every case drives an ISOLATED pasteboard (`pasteboardWithUniqueName`), never
+// `NSPasteboard.general` — the developer's real clipboard is not a fixture
+// (`ClipboardIsolationFreezeTests`, #2146).
+//
+// No case sleeps to decide the subject is finished. `awaitPendingCleanup()` and
+// `cancelPendingAndAwait()` both await the subject's own task, including the
+// case that proves cleanup was ABANDONED — a cancelled task still runs to
+// completion, so its completion is a real signal
+// (testing-philosophy.md RULE: never-guess-when-the-subject-is-finished).
+
+/// Product Outcome: when these fail, the user's clipboard is not returned, or is
+/// replaced with the wrong thing.
+@Suite("Clipboard cleanup scheduling (#2197)", .tags(.productOutcome), .serialized)
+@MainActor
+struct ClipboardCleanupTests {
+
+  private static let fast = 5  // ms
+
+  // Board access here is deliberately plain AppKit, NOT `PasteService`.
+  //
+  // `ClipboardIsolationFreezeTests` allows exactly one suite to touch
+  // clipboard-capable `PasteService` entry points, and widening that allowlist
+  // to admit this file would weaken the guard for every future test in it. These
+  // helpers need none of that capability: they set up and read an isolated
+  // board, which AppKit does directly.
+  private func put(_ text: String, on pb: NSPasteboard) {
+    pb.clearContents()
+    pb.setString(text, forType: .string)
+  }
+
+  private func snapshot(of pb: NSPasteboard) -> ClipboardSnapshot {
+    ClipboardSnapshot(
+      items: pb.string(forType: .string).map { [[.string: Data($0.utf8)]] } ?? [],
+      changeCount: pb.changeCount)
+  }
+
+  private func string(_ snapshot: ClipboardSnapshot) -> String? {
+    snapshot.items.first?[.string].map { String(decoding: $0, as: UTF8.self) }
+  }
+
+  private func board(holding text: String) -> NSPasteboard {
+    let pb = NSPasteboard.withUniqueName()
+    put(text, on: pb)
+    return pb
+  }
+
+  private func withFastCleanup(_ body: () async -> Void) async {
+    ClipboardCleanup.resetPendingForTests()
+    ClipboardCleanup.testDelayOverrideMs = Self.fast
+    await body()
+    ClipboardCleanup.resetPendingForTests()
+    ClipboardCleanup.testDelayOverrideMs = nil
+  }
+
+  // MARK: The change itself
+
+  @Test("The user's clipboard is still restored, with the same content")
+  func restoresAfterTheDelay() async {
+    await withFastCleanup {
+      let pb = board(holding: "the user's own clipboard")
+      let snapshot = snapshot(of: pb)
+
+      put("our dictated payload", on: pb)
+      let afterOurWrite = pb.changeCount
+
+      ClipboardCleanup.scheduleRestore(
+        snapshot, changeCountAfterPaste: afterOurWrite, tier: .cgEvent, on: pb)
+
+      // The point of the change: the caller is NOT blocked, so our payload is
+      // still on the board the instant after scheduling.
+      #expect(pb.string(forType: .string) == "our dictated payload")
+
+      await ClipboardCleanup.awaitPendingCleanup()
+      #expect(pb.string(forType: .string) == "the user's own clipboard")
+    }
+  }
+
+  @Test("A board the user changed during the window is left alone")
+  func declinesWhenTheBoardMoved() async {
+    await withFastCleanup {
+      let pb = board(holding: "the user's own clipboard")
+      let snapshot = snapshot(of: pb)
+      put("our dictated payload", on: pb)
+      let afterOurWrite = pb.changeCount
+
+      ClipboardCleanup.scheduleRestore(
+        snapshot, changeCountAfterPaste: afterOurWrite, tier: .cgEvent, on: pb)
+      // The user copies something while we wait.
+      put("something the user just copied", on: pb)
+
+      await ClipboardCleanup.awaitPendingCleanup()
+      #expect(pb.string(forType: .string) == "something the user just copied")
+    }
+  }
+
+  // MARK: Pending-cleanup states — the class this design had to close
+
+  @Test(
+    "A delivery starting while cleanup is pending inherits, never photographing our own payload")
+  func inheritsRatherThanPhotographingOurPayload() async {
+    await withFastCleanup {
+      let pb = board(holding: "the user's own clipboard")
+      let snapshot = snapshot(of: pb)
+      put("dictation one", on: pb)
+
+      ClipboardCleanup.scheduleRestore(
+        snapshot, changeCountAfterPaste: pb.changeCount, tier: .cgEvent, on: pb)
+
+      // A second delivery begins before the first cleanup ran. The board still
+      // holds OUR text; photographing it would save dictation one as "the user's
+      // clipboard" and hand it back to them later.
+      #expect(string(ClipboardCleanup.snapshotForDelivery(from: pb)) == "the user's own clipboard")
+    }
+  }
+
+  @Test("A delivery starting after the board MOVED photographs it, never a stale snapshot")
+  func photographsWhenTheBoardMoved() async {
+    await withFastCleanup {
+      let pb = board(holding: "the user's own clipboard")
+      let snapshot = snapshot(of: pb)
+      put("dictation one", on: pb)
+      ClipboardCleanup.scheduleRestore(
+        snapshot, changeCountAfterPaste: pb.changeCount, tier: .cgEvent, on: pb)
+
+      // The user copies something. The pending snapshot is now stale, and
+      // inheriting it would destroy what they just copied — the inverse of the
+      // bug above, and the worse one.
+      put("something the user just copied", on: pb)
+
+      #expect(
+        string(ClipboardCleanup.snapshotForDelivery(from: pb)) == "something the user just copied")
+      #expect(ClipboardCleanup.hasPending == false)
+    }
+  }
+
+  @Test(
+    "A pending LEGACY REWRITE is inherited as its legacy text, not the repaired payload on the board"
+  )
+  func inheritsLegacyTextNotTheRepairedPayload() async {
+    await withFastCleanup {
+      let pb = NSPasteboard.withUniqueName()
+      // Restore is OFF on this path, so the board holds our REPAIRED payload and
+      // a rewrite to the legacy one is pending.
+      put("repaired payload", on: pb)
+      ClipboardCleanup.scheduleLegacyRewrite(
+        legacyText: "legacy payload", submittedChangeCount: pb.changeCount,
+        tier: .cgEvent, on: pb)
+
+      #expect(string(ClipboardCleanup.snapshotForDelivery(from: pb)) == "legacy payload")
+    }
+  }
+
+  @Test("A cancelled cleanup ABANDONS its work rather than performing it early")
+  func cancellationAbandons() async {
+    await withFastCleanup {
+      let pb = board(holding: "the user's own clipboard")
+      let snapshot = snapshot(of: pb)
+      put("our dictated payload", on: pb)
+      ClipboardCleanup.scheduleRestore(
+        snapshot, changeCountAfterPaste: pb.changeCount, tier: .cgEvent, on: pb)
+
+      // Cancelling must not be read as "do it now". If it were, the restore would
+      // fire before the target app had read our payload — the wrong-text failure.
+      // Awaiting the cancelled task is what makes this a real assertion: the task
+      // has demonstrably finished, and it did not touch the board.
+      await ClipboardCleanup.cancelPendingAndAwait()
+
+      #expect(pb.string(forType: .string) == "our dictated payload")
+    }
+  }
+
+  @Test("A superseded cleanup does not clear the slot that replaced it")
+  func supersedeKeepsTheNewerSlot() async {
+    await withFastCleanup {
+      let pbA = NSPasteboard.withUniqueName()
+      put("first payload", on: pbA)
+      ClipboardCleanup.scheduleRestore(
+        snapshot(of: pbA), changeCountAfterPaste: pbA.changeCount,
+        tier: .cgEvent, on: pbA)
+
+      let pbB = NSPasteboard.withUniqueName()
+      put("the user's own clipboard", on: pbB)
+      let snapshotB = snapshot(of: pbB)
+      put("second payload", on: pbB)
+      ClipboardCleanup.scheduleRestore(
+        snapshotB, changeCountAfterPaste: pbB.changeCount, tier: .cgEvent, on: pbB)
+
+      await ClipboardCleanup.awaitPendingCleanup()
+      #expect(pbB.string(forType: .string) == "the user's own clipboard")
+      // And the superseded one must NOT have fired. Asserting only on pbB left
+      // this test blind: a mutation run showed that removing the identity guard
+      // entirely still passed, because nothing observed the older board.
+      #expect(pbA.string(forType: .string) == "first payload")
+      #expect(ClipboardCleanup.hasPending == false)
+    }
+  }
+
+  @Test("The slot is cleared even when the restore guard DECLINES")
+  func slotClearsOnDecline() async {
+    await withFastCleanup {
+      let pb = board(holding: "the user's own clipboard")
+      let snapshot = snapshot(of: pb)
+      put("our dictated payload", on: pb)
+      ClipboardCleanup.scheduleRestore(
+        snapshot, changeCountAfterPaste: pb.changeCount, tier: .cgEvent, on: pb)
+      // Force the guard to decline.
+      put("user copied this", on: pb)
+
+      await ClipboardCleanup.awaitPendingCleanup()
+      // A slot left populated would be inherited by the next delivery AND would
+      // block update installs forever, because `hasPending` gates them.
+      #expect(ClipboardCleanup.hasPending == false)
+    }
+  }
+
+  @Test("hasPending is true only while cleanup is outstanding")
+  func hasPendingTracksTheWindow() async {
+    await withFastCleanup {
+      #expect(ClipboardCleanup.hasPending == false)
+      let pb = board(holding: "the user's own clipboard")
+      let snapshot = snapshot(of: pb)
+      put("our dictated payload", on: pb)
+      ClipboardCleanup.scheduleRestore(
+        snapshot, changeCountAfterPaste: pb.changeCount, tier: .cgEvent, on: pb)
+      #expect(ClipboardCleanup.hasPending == true)
+      await ClipboardCleanup.awaitPendingCleanup()
+      #expect(ClipboardCleanup.hasPending == false)
+    }
+  }
+
+  @Test("A legacy rewrite keeps its own body: it applies, and it declines on a moved board")
+  func legacyRewriteKeepsItsOwnBody() async {
+    await withFastCleanup {
+      let pb = NSPasteboard.withUniqueName()
+      put("repaired payload", on: pb)
+      ClipboardCleanup.scheduleLegacyRewrite(
+        legacyText: "legacy payload", submittedChangeCount: pb.changeCount,
+        tier: .cgEvent, on: pb)
+      await ClipboardCleanup.awaitPendingCleanup()
+      #expect(pb.string(forType: .string) == "legacy payload")
+
+      let pb2 = NSPasteboard.withUniqueName()
+      put("repaired payload", on: pb2)
+      ClipboardCleanup.scheduleLegacyRewrite(
+        legacyText: "legacy payload", submittedChangeCount: pb2.changeCount,
+        tier: .cgEvent, on: pb2)
+      put("user copied this", on: pb2)
+      await ClipboardCleanup.awaitPendingCleanup()
+      #expect(pb2.string(forType: .string) == "user copied this")
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/Services/PasteServiceClipboardTests.swift
+++ b/Tests/EnviousWisprTests/Services/PasteServiceClipboardTests.swift
@@ -154,3 +154,42 @@ struct PasteServiceClipboardTests {
     pasteboard.setString(text, forType: .string)
   }
 }
+
+/// Observability Contract: `restoreClipboard`'s return value is what the cleanup
+/// log line reports. When it lies, a diagnosis reads the wrong outcome.
+@Suite("restoreClipboard reports whether it applied (#2197)", .tags(.observabilityContract))
+struct RestoreClipboardResultTests {
+
+  @Test("True when the board was ours to write")
+  func trueWhenApplied() {
+    let pb = NSPasteboard.withUniqueName()
+    PasteService.copyToClipboard("user clipboard", to: pb)
+    let snapshot = PasteService.saveClipboard(from: pb)
+    PasteService.copyToClipboard("our payload", to: pb)
+    #expect(
+      PasteService.restoreClipboard(snapshot, changeCountAfterPaste: pb.changeCount, on: pb)
+        == true)
+  }
+
+  @Test("False when the guard declined")
+  func falseWhenDeclined() {
+    let pb = NSPasteboard.withUniqueName()
+    PasteService.copyToClipboard("user clipboard", to: pb)
+    let snapshot = PasteService.saveClipboard(from: pb)
+    PasteService.copyToClipboard("our payload", to: pb)
+    let stale = pb.changeCount
+    PasteService.copyToClipboard("someone else", to: pb)
+    #expect(PasteService.restoreClipboard(snapshot, changeCountAfterPaste: stale, on: pb) == false)
+  }
+
+  @Test("True for an empty prior clipboard, which is restored by clearing")
+  func trueWhenPriorWasEmpty() {
+    let pb = NSPasteboard.withUniqueName()
+    let snapshot = PasteService.saveClipboard(from: pb)
+    PasteService.copyToClipboard("our payload", to: pb)
+    #expect(
+      PasteService.restoreClipboard(snapshot, changeCountAfterPaste: pb.changeCount, on: pb)
+        == true)
+    #expect(pb.string(forType: .string) == nil)
+  }
+}

--- a/Tests/EnviousWisprTests/Services/PasteServiceClipboardTests.swift
+++ b/Tests/EnviousWisprTests/Services/PasteServiceClipboardTests.swift
@@ -182,6 +182,33 @@ struct RestoreClipboardResultTests {
     #expect(PasteService.restoreClipboard(snapshot, changeCountAfterPaste: stale, on: pb) == false)
   }
 
+  @Test("Reports a REAL write, not an assumed one")
+  func reportsTheActualWrite() {
+    // Guards the #2197 diff-review finding: the previous body ignored
+    // `writeObjects`' result and always returned true, so the cleanup log would
+    // have recorded `applied=true` for a restoration AppKit had refused. A
+    // multi-item snapshot exercises the item-construction path too.
+    let pb = NSPasteboard.withUniqueName()
+    PasteService.copyToClipboard("user clipboard", to: pb)
+    let snapshot = ClipboardSnapshot(
+      items: [
+        [.string: Data("first".utf8)],
+        [.string: Data("second".utf8)],
+      ],
+      changeCount: pb.changeCount)
+    PasteService.copyToClipboard("our payload", to: pb)
+    #expect(
+      PasteService.restoreClipboard(snapshot, changeCountAfterPaste: pb.changeCount, on: pb)
+        == true)
+    // `string(forType:)` on a MULTI-ITEM board returns every item's string joined
+    // by newlines — real AppKit behaviour, not a defect, and the first version of
+    // this assertion expected "first" and was simply wrong about it. Asserting the
+    // item COUNT is the honest check here: it proves both items were written,
+    // which is what the return value above is claiming.
+    #expect(pb.pasteboardItems?.count == 2)
+    #expect(pb.string(forType: .string) == "first\nsecond")
+  }
+
   @Test("True for an empty prior clipboard, which is restored by clearing")
   func trueWhenPriorWasEmpty() {
     let pb = NSPasteboard.withUniqueName()


### PR DESCRIPTION
## What changed

Every clipboard paste route waits 200 ms before handing the user's clipboard back, so the target app has
time to read ours. That wait sat **inside the awaited delivery call**, so the dictation's own completion —
terminal state, telemetry, overlay dismissal, readiness for the next one — queued behind it. Nothing
downstream of delivery reads the restored board.

**The 200 ms is unchanged. Its position is not.**

## Measured, 41 real dictations, two builds, one session

Baseline built from `f5a27d67` with zero changes; change build from the same worktree. Verdicts read from
the app's own `Paste cascade: … duration=Nms` line, not a stopwatch the harness holds.

| app | route | before | after |
|---|---|---:|---:|
| iTerm2 | `cgevent` | 263 ms | **56 ms** |
| Ghostty | `cgevent` | 261 ms | **58 ms** |
| Slack | `cgevent` | 269 ms | **55 ms** |
| VS Code | `cgevent` | 257 ms | **56 ms** |
| Chrome | `menu_paste` | 305 ms | **120 ms** |
| TextEdit | `ax_direct`, no clipboard | 4 ms | 11 ms |

Baselines match the fleet's `cgevent` p50 of **267 ms** over 24,994 pastes and 205 people. TextEdit is the
control: no clipboard, no wait, nothing to improve, and it stayed in single-digit noise.

Full audit including three instrument faults caught before any number was reported: #2197 comment.

## What was refused, and why it is the more useful half

Revision 1 detected when the target app had **read** the clipboard, via lazy pasteboard provision, and
restored immediately. The mechanism works — apps read in 2.0–37.8 ms, exactly one read per paste, delivery
verified through Accessibility.

It was refused because **the callback proves someone read, not who**. A clipboard manager reads the board
the same way the target does and the promise is one-shot. Timing cannot separate them: measured thefts at
0.0 and 3.2 ms against a fastest genuine read of 2.0 ms. Restoring on a stolen read puts the user's
previous clipboard into their document. Probe kept at `docs/audits/2026-08-19-2197-consumption-probe.py`.

## The one new thing, and its whole state space

Cleanup can now outlive its delivery. That is enumerated rather than argued away — see
"the class, enumerated" in the plan. The states that shaped the code:

- a later delivery **inherits** what pending cleanup would have left on the board, instead of
  photographing a board that still holds the previous dictation;
- …but **photographs** when the board has moved, or a stale snapshot would overwrite what the user just
  copied — the same bug inverted and worse;
- a pending legacy rewrite is inherited as its **legacy** text, never the repaired payload it exists to
  remove;
- cancellation means **abandon**, never "run it now";
- every exit path clears the slot, including the one where the guard declines.

## Also fixed: a pre-existing bypass this would have inherited

`handleBannerClicked` called `service.triggerInstall()` directly, so the update banner has bypassed the
active-dictation guard since #1019 shipped — a banner click could relaunch the app mid-dictation. All three
install entry points now route through `triggerGuardedInstall`, which is the only caller of
`service.triggerInstall()` in `Sources/`. Swept, not asserted.

## Known limit, adjudicated three times

If the process exits inside the 200 ms window, the user's clipboard keeps our payload. **Verified: this app
implements no `applicationShouldTerminate`, so today's inline `Task.sleep` is abandoned by quit
identically.** What changes is likelihood, not mechanism — the session has already finished when the window
opens, so the app looks idle.

Both proposed remedies are worse: a synchronous flush restores *before* the delay expires and can pull our
payload off the board before the target app has read it, and deferring termination introduces an app that
may not quit. Reasoning is in `ClipboardCleanup`'s doc comment, not only here. The one newly-reachable
route — an update relaunch — is closed.

## Verification

- `scripts/xcode-test.sh --release`: **Debug 6227 / Release 5677**, both green, zero failures.
- `Clipboard cleanup scheduling` and `installRefusedNow` confirmed present in **both** lanes, not assumed.
- Mutation control ran and **corrected this design's own claims**: the intended mutant SURVIVED, so did a
  second, and only removing both was caught. The two protections are fully redundant — defence in depth,
  not a vacuous test — and the doc comment now says that instead of calling one of them the sharpest
  defect. It also tightened a test that observed only half of what it was named for. Battery owed on #2215.
- Three repo guards fired and all three were respected rather than relaxed: the clipboard-isolation
  allowlist (tests rewritten to need no clipboard capability), a file-size ceiling (prose folded first,
  then raised through its documented process), and a module-boundary import rule (which produced a better
  design — one authority for "is an install refused", read by both the guard and the affordance).

Closes #2197
