### PR TITLE
fix(overlay): the meter shows a record of volume, not one level nine times (#2216)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
@@ -2074,12 +2074,52 @@ struct RainbowLevelMeter: View {
   /// same value `RainbowLipsIcon` reads, so this adds no timer and no new source.
   let audioLevel: Float
 
-  /// Height of the strip. Bars are drawn symmetrically about its middle.
-  var height: CGFloat = 16
-  var barWidth: CGFloat = 2.5
-  var spacing: CGFloat = 3
+  /// The parent's poll counter, incremented once per sample whether or not the
+  /// level changed.
+  ///
+  /// **The history cannot be driven by a change in `audioLevel`, and that is not a
+  /// style preference — it is the difference between a waveform that drains and one
+  /// that freezes.** `onChange` fires on a CHANGE, and silence is the one passage
+  /// where consecutive samples are bit-identical, so a level-driven history stops
+  /// scrolling exactly when the user stops talking: the shape of their last words
+  /// sits frozen on screen until they speak again. Reading a strictly-increasing
+  /// tick makes every poll a sample, so a pause scrolls out to the silence floor
+  /// the way a record of volume should.
+  let tick: Int
 
-  /// The brand spectrum, in order. Shared with `RainbowLipsIcon`'s bar table.
+  var height: CGFloat = 16
+  var barWidth: CGFloat = 2
+  var spacing: CGFloat = 1.5
+
+  /// #2216: the last `barCount` levels, oldest first. Bar `i` is a MOMENT, not a
+  /// position on a shape.
+  ///
+  /// **The first version drew every bar from the same instant's level**, scaled by
+  /// a fixed per-bar weight, so all nine could only rise and fall together — a
+  /// level meter in a waveform's clothes. The founder caught it against the
+  /// approved mockup, where each bar ran on its own CSS timer at its own phase and
+  /// therefore only LOOKED like a record of anything. Real audio hands us one
+  /// scalar per tick, so the only honest way to get that picture is to keep the
+  /// scalars.
+  @State private var history: [CGFloat] = []
+
+  /// About 1.2 seconds of history at the parent's 50 ms poll — long enough to read
+  /// as a shape, short enough that it is recognisably what you just said.
+  static let barCount = 24
+
+  /// A bar's minimum share of the strip. Non-zero on purpose: a meter that
+  /// collapses to nothing between words reads as "it stopped hearing me", which is
+  /// the exact anxiety the preview exists to remove.
+  static let silenceFraction: CGFloat = 0.14
+
+  /// Additional share available at full level.
+  static let peakFraction: CGFloat = 0.86
+
+  /// The brand spectrum, sampled across the strip.
+  ///
+  /// **Positional, not per-sample.** The gradient stays still while heights scroll
+  /// through it, which keeps the mark recognisable — colours crawling sideways
+  /// would read as a progress bar rather than as our spectrum.
   static let spectrum: [Color] = [
     Color(red: 1.0, green: 0.165, blue: 0.251),  // #ff2a40 red
     Color(red: 1.0, green: 0.549, blue: 0.0),  // #ff8c00 orange
@@ -2092,55 +2132,99 @@ struct RainbowLevelMeter: View {
     Color(red: 0.541, green: 0.169, blue: 0.886),  // #8a2be2 violet
   ]
 
-  /// Per-bar sensitivity. Centre bars react most, edges least — the same
-  /// weighting `RainbowLipsIcon` uses, so both instruments agree about what the
-  /// same audio looks like.
-  static let sensitivity: [CGFloat] = [0.70, 0.80, 0.90, 0.95, 1.00, 0.95, 0.90, 0.80, 0.70]
+  /// The colour at position `index` of `count`, interpolated across the spectrum so
+  /// the gradient is smooth at any bar count.
+  static func colour(at index: Int, of count: Int) -> Color {
+    guard count > 1 else { return spectrum[0] }
+    let t = CGFloat(min(max(index, 0), count - 1)) / CGFloat(count - 1)
+    let scaled = t * CGFloat(spectrum.count - 1)
+    let lower = Int(scaled)
+    let upper = min(lower + 1, spectrum.count - 1)
+    let frac = scaled - CGFloat(lower)
+    return frac < 0.001
+      ? spectrum[lower] : spectrum[lower].blended(with: spectrum[upper], amount: frac)
+  }
 
-  /// Fraction of the strip a bar occupies at silence. Non-zero on purpose: a
-  /// meter that collapses to nothing between words reads as "it stopped hearing
-  /// me", which is the exact anxiety the preview exists to remove.
-  static let silenceFraction: CGFloat = 0.18
-
-  /// Additional fraction available at full level, for the most sensitive bar.
-  static let peakFraction: CGFloat = 0.82
-
-  /// Fraction of the strip bar `index` fills at `level`.
+  /// Fraction of the strip a sample occupies.
   ///
-  /// `static` and `package`-visible so a test can assert the shape without
-  /// rendering: the property that matters is monotonic in level and clamped at
-  /// both ends, and a Canvas cannot be asked about that.
-  static func fill(index: Int, level: CGFloat) -> CGFloat {
-    let clamped = min(max(level, 0), 1)
-    let weight = sensitivity[min(max(index, 0), sensitivity.count - 1)]
-    return silenceFraction + peakFraction * clamped * weight
+  /// Extracted so a test can assert it without rendering — a `Canvas` cannot be
+  /// asked what it drew.
+  static func fill(level: CGFloat) -> CGFloat {
+    silenceFraction + peakFraction * min(max(level, 0), 1)
+  }
+
+  /// Push a sample onto the history, dropping the oldest once full.
+  ///
+  /// Pure and static so the scrolling behaviour is testable directly: this is the
+  /// whole difference between a record and a level, and it is the part that was
+  /// missing.
+  static func pushed(_ history: [CGFloat], level: CGFloat, capacity: Int = barCount) -> [CGFloat] {
+    guard capacity > 0 else { return [] }
+    // Clamp on the way IN, so a bad sample cannot sit in the buffer for a second
+    // and a bit poisoning every frame it appears in.
+    var next = history + [min(max(level, 0), 1)]
+    if next.count > capacity { next.removeFirst(next.count - capacity) }
+    return next
+  }
+
+  /// The level to draw in each of `count` bars, right-aligned so the newest sample
+  /// is always at the same edge — without this the whole waveform slides sideways
+  /// for the first second of every recording.
+  ///
+  /// Extracted from the `Canvas` so it can be asserted directly: a `Canvas` cannot
+  /// be asked what it drew, and this is the step that turns a buffer into bars.
+  /// Every read is bounds-checked rather than trusting `history` to be the right
+  /// length, because this runs on the heart path and an index slip here is a crash
+  /// in the recording overlay.
+  static func bars(history: [CGFloat], count: Int = barCount) -> [CGFloat] {
+    guard count > 0 else { return [] }
+    let pad = max(0, count - history.count)
+    // A longer-than-expected buffer keeps its NEWEST samples, never its oldest.
+    let offset = max(0, history.count - count)
+    return (0..<count).map { i in
+      let index = i - pad + offset
+      return index >= 0 && index < history.count ? history[index] : 0
+    }
   }
 
   var body: some View {
-    let level = CGFloat(min(max(audioLevel, 0), 1))
     Canvas { context, size in
-      for i in 0..<Self.spectrum.count {
-        let barHeight = size.height * Self.fill(index: i, level: level)
+      let levels = Self.bars(history: history)
+      for i in 0..<Self.barCount {
+        let barHeight = size.height * Self.fill(level: levels[i])
         let x = CGFloat(i) * (barWidth + spacing)
         let rect = CGRect(
-          x: x,
-          y: (size.height - barHeight) / 2,
-          width: barWidth,
-          height: barHeight
-        )
+          x: x, y: (size.height - barHeight) / 2,
+          width: barWidth, height: barHeight)
         context.fill(
           Path(roundedRect: rect, cornerRadius: barWidth / 2),
-          with: .color(Self.spectrum[i]))
+          with: .color(Self.colour(at: i, of: Self.barCount)))
       }
     }
     .frame(width: Self.width(barWidth: barWidth, spacing: spacing), height: height)
+    .onChange(of: tick) { _, _ in
+      history = Self.pushed(history, level: CGFloat(audioLevel))
+    }
     .accessibilityHidden(true)
   }
 
-  /// Total width for nine bars and eight gaps. Derived rather than a literal, so
-  /// the frame cannot drift from what the Canvas draws.
+  /// Total width for `barCount` bars and their gaps. Derived rather than a
+  /// literal, so the frame cannot drift from what the Canvas draws.
   static func width(barWidth: CGFloat, spacing: CGFloat) -> CGFloat {
-    CGFloat(spectrum.count) * barWidth + CGFloat(spectrum.count - 1) * spacing
+    CGFloat(barCount) * barWidth + CGFloat(barCount - 1) * spacing
+  }
+}
+
+extension Color {
+  /// Linear blend towards another colour, for the meter's positional gradient.
+  fileprivate func blended(with other: Color, amount: CGFloat) -> Color {
+    let a = NSColor(self).usingColorSpace(.sRGB) ?? .white
+    let b = NSColor(other).usingColorSpace(.sRGB) ?? .white
+    let t = min(max(amount, 0), 1)
+    return Color(
+      red: a.redComponent + (b.redComponent - a.redComponent) * t,
+      green: a.greenComponent + (b.greenComponent - a.greenComponent) * t,
+      blue: a.blueComponent + (b.blueComponent - a.blueComponent) * t)
   }
 }
 
@@ -2310,7 +2394,8 @@ private struct OverlayCapsuleBackground: View {
       .fill(
         isPreview
           ? PreviewPillPalette.surface
-          : Color(red: 0.078, green: 0.078, blue: 0.11).opacity(0.82))
+          : Color(red: 0.078, green: 0.078, blue: 0.11).opacity(0.82)
+      )
       // `strokeBorder` needs an insettable shape, which the type-erased `AnyShape`
       // is not, so the two concrete shapes are named here. Kept as `strokeBorder`
       // rather than switching both to `stroke`: the capsule is shipped UI and its
@@ -2432,6 +2517,11 @@ struct RecordingOverlayView: View {
   /// #1060: transient notice banner shown inside the recording capsule.
   var noticeState: OverlayNoticeState
   @State private var audioLevel: Float = 0
+
+  /// Counts polls, not level changes. #2216: the meter's history needs a sample
+  /// every tick INCLUDING the silent ones, and consecutive silent samples are
+  /// bit-identical, so `audioLevel` alone cannot drive it.
+  @State private var audioTick: Int = 0
   @State private var elapsed: TimeInterval = 0
   @State private var preview: LivePreviewDisplay
 
@@ -2495,7 +2585,7 @@ struct RecordingOverlayView: View {
         .font(.system(size: 13, weight: .semibold, design: .monospaced))
         .foregroundStyle(PreviewPillPalette.timer)
 
-      RainbowLevelMeter(audioLevel: audioLevel)
+      RainbowLevelMeter(audioLevel: audioLevel, tick: audioTick)
 
       Spacer(minLength: 8)
 
@@ -2662,6 +2752,7 @@ struct RecordingOverlayView: View {
     .task {
       while !Task.isCancelled {
         audioLevel = audioLevelProvider()
+        audioTick &+= 1
         elapsed = recordingElapsedProvider() ?? 0
         preview = livePreviewProvider()
         try? await Task.sleep(for: .milliseconds(50))

--- a/Tests/EnviousWisprTests/App/RainbowLevelMeterTests.swift
+++ b/Tests/EnviousWisprTests/App/RainbowLevelMeterTests.swift
@@ -4,111 +4,220 @@ import Testing
 
 @testable import EnviousWisprAppKit
 
-/// #2202: the live level meter that replaces the lips mark in the preview pill's
-/// header.
+/// #2216: the meter shows a RECORD of volume over time, not one level drawn nine
+/// times.
 ///
-/// A `Canvas` cannot be asked what it drew, so the geometry decision is extracted
-/// as a static function and pinned here — the same shape
-/// `RecordingOverlayPanelInheritedGeometryTests` uses for panel arithmetic, and
-/// for the same reason.
+/// **What the first version got wrong, and why no test caught it.** Every bar was
+/// computed from the same instant's `audioLevel` scaled by a fixed per-bar weight,
+/// so the bars could only rise and fall together in a static symmetric shape. The
+/// old suite asserted the properties that design HAD — louder is taller, nothing
+/// overflows, the centre outreacts the edges — and every one passed. None of them
+/// asked the question that mattered: **can two bars ever differ for a reason other
+/// than their index?** Under the old design the answer was no, and the tests could
+/// not see it because they never showed the meter two different moments.
 ///
-/// What these protect, stated so a later reader does not have to infer it: the
-/// meter is the ONLY thing in the new header that moves, so if it stops responding
-/// to the voice the pill silently becomes a static graphic that claims to be
-/// listening. That is a product outcome, not a drift guard.
+/// So the cases here are about the history, which is the whole difference between
+/// a record and a level.
 @MainActor
 @Suite(.tags(.productOutcome))
 struct RainbowLevelMeterTests {
 
   init() { _ = NSApplication.shared }
 
-  @Test("silence still shows bars, because an empty meter reads as not hearing you")
-  func silenceIsNotEmpty() {
-    for i in 0..<RainbowLevelMeter.spectrum.count {
-      let fill = RainbowLevelMeter.fill(index: i, level: 0)
-      #expect(fill > 0, "bar \(i) vanished at silence")
-      #expect(
-        fill == RainbowLevelMeter.silenceFraction,
-        "bar \(i) filled \(fill) at silence, not the resting \(RainbowLevelMeter.silenceFraction)")
+  // MARK: - The history is a record
+
+  @Test("a sample lands at the newest end and the buffer keeps its order")
+  func samplesArriveInOrder() {
+    var h: [CGFloat] = []
+    for level in [0.1, 0.5, 0.9] as [CGFloat] {
+      h = RainbowLevelMeter.pushed(h, level: level, capacity: 5)
     }
+    #expect(h == [0.1, 0.5, 0.9], "got \(h) — the buffer is not preserving arrival order")
   }
 
-  @Test("louder is taller, for every bar")
-  func fillIsMonotonicInLevel() {
-    for i in 0..<RainbowLevelMeter.spectrum.count {
-      var previous = RainbowLevelMeter.fill(index: i, level: 0)
-      for step in 1...10 {
-        let level = CGFloat(step) / 10
-        let current = RainbowLevelMeter.fill(index: i, level: level)
-        #expect(
-          current > previous,
-          "bar \(i) did not grow from level \(level - 0.1) to \(level): \(previous) -> \(current)")
-        previous = current
-      }
+  @Test("the oldest sample falls off once the buffer is full")
+  func oldestFallsOff() {
+    var h: [CGFloat] = []
+    for level in [0.1, 0.2, 0.3, 0.4] as [CGFloat] {
+      h = RainbowLevelMeter.pushed(h, level: level, capacity: 3)
     }
+    #expect(h == [0.2, 0.3, 0.4], "got \(h) — expected the first sample to be dropped")
   }
 
-  @Test("no bar overflows its strip at full level")
-  func fillNeverExceedsTheStrip() {
-    for i in 0..<RainbowLevelMeter.spectrum.count {
-      let fill = RainbowLevelMeter.fill(index: i, level: 1)
-      #expect(fill <= 1, "bar \(i) filled \(fill) of the strip, which would clip")
+  @Test("the buffer never exceeds its capacity")
+  func capacityIsRespected() {
+    var h: [CGFloat] = []
+    for i in 0..<200 {
+      h = RainbowLevelMeter.pushed(h, level: CGFloat(i % 10) / 10, capacity: 24)
     }
+    #expect(h.count == 24, "buffer grew to \(h.count)")
   }
 
-  /// The audio level arrives from a live capture path. A meter that trusts it is
-  /// one bad sample away from drawing outside its own frame, and
-  /// `RainbowLipsIcon` already clamps for exactly this reason.
-  @Test(
-    "out-of-range levels are clamped rather than trusted",
-    arguments: [-99.0, -0.5, 1.5, 99.0] as [CGFloat])
-  func hostileLevelsAreClamped(level: CGFloat) {
-    let atFloor = RainbowLevelMeter.fill(index: 4, level: 0)
-    let atCeiling = RainbowLevelMeter.fill(index: 4, level: 1)
-    let got = RainbowLevelMeter.fill(index: 4, level: level)
-    #expect(got >= atFloor, "level \(level) drew below the resting height")
-    #expect(got <= atCeiling, "level \(level) drew above full")
-  }
-
-  @Test("an out-of-range bar index cannot crash the pill")
-  func hostileIndexIsClamped() {
-    // The pill is on the recording path's display side; an index error here must
-    // degrade rather than trap.
-    #expect(RainbowLevelMeter.fill(index: -1, level: 0.5) > 0)
-    #expect(RainbowLevelMeter.fill(index: 99, level: 0.5) > 0)
-  }
-
-  @Test("the centre bar reacts more than the edges, like the mark it replaces")
-  func centreIsMoreSensitiveThanTheEdges() {
-    let centre = RainbowLevelMeter.fill(index: 4, level: 1)
-    let edge = RainbowLevelMeter.fill(index: 0, level: 1)
+  /// **The case the old design could not pass.** Two different moments must be
+  /// able to produce two different bars. Under a single-level meter every bar is
+  /// the same number times a constant, so this is impossible by construction.
+  @Test("bars differ because the audio differed, not because of their position")
+  func barsRecordDistinctMoments() {
+    var h: [CGFloat] = []
+    for level in [0.0, 1.0, 0.0, 1.0, 0.0] as [CGFloat] {
+      h = RainbowLevelMeter.pushed(h, level: level, capacity: 5)
+    }
+    let fills = h.map { RainbowLevelMeter.fill(level: $0) }
     #expect(
-      centre > edge,
+      Set(fills).count == 2,
       """
-      centre filled \(centre) and edge \(edge) at full level — the meter is flat, \
-      which loses the shape that makes it read as a voice
+      an alternating loud/quiet passage produced \(Set(fills).count) distinct bar \
+      heights: \(fills). A record of volume must show the alternation; a meter \
+      driven by one instant cannot.
       """)
   }
 
-  @Test("nine bars carry the nine brand spectrum colours in order")
-  func spectrumIsTheBrandOrder() {
-    #expect(RainbowLevelMeter.spectrum.count == 9)
-    #expect(RainbowLevelMeter.sensitivity.count == RainbowLevelMeter.spectrum.count)
+  /// The inverse, and it is what makes the case above meaningful: a steady tone
+  /// must produce a FLAT line. The old design produced its fixed centre-weighted
+  /// shape for any input at all, so it could not tell these two passages apart.
+  @Test("a steady tone reads flat")
+  func steadyToneIsFlat() {
+    var h: [CGFloat] = []
+    for _ in 0..<10 { h = RainbowLevelMeter.pushed(h, level: 0.6, capacity: 6) }
+    let fills = Set(h.map { RainbowLevelMeter.fill(level: $0) })
+    #expect(fills.count == 1, "a constant level produced \(fills.count) heights: \(fills)")
   }
 
-  /// The frame and the drawing derive from one expression, so a change to bar
-  /// width or spacing cannot leave the Canvas drawing outside the frame it was
-  /// given — the shape of defect that produced clipped glyphs in the preview text
-  /// before #1988 settled on measured layout.
-  @Test("declared width matches what nine bars and eight gaps actually need")
-  func widthMatchesTheDrawing() {
-    let barWidth: CGFloat = 2.5
-    let spacing: CGFloat = 3
-    let declared = RainbowLevelMeter.width(barWidth: barWidth, spacing: spacing)
-    let lastBarRightEdge =
-      CGFloat(RainbowLevelMeter.spectrum.count - 1) * (barWidth + spacing) + barWidth
+  /// **A pause must DRAIN the waveform, not freeze it**, and this is the case that
+  /// sent the history to a poll counter rather than to `audioLevel`.
+  ///
+  /// `onChange` fires on a CHANGE. Silence is the one passage where consecutive
+  /// samples are bit-identical, so a level-driven history stops taking samples
+  /// exactly when the user stops talking — leaving the shape of their last words
+  /// frozen on screen until they speak again, which reads as the app having hung.
+  @Test("a pause scrolls the last words out and settles on the silence floor")
+  func silenceDrainsTheWaveform() {
+    var h: [CGFloat] = []
+    for level in [0.9, 0.8, 1.0, 0.7] as [CGFloat] {
+      h = RainbowLevelMeter.pushed(h, level: level)
+    }
+    for _ in 0..<RainbowLevelMeter.barCount {
+      h = RainbowLevelMeter.pushed(h, level: 0)
+    }
+    let heights = Set(RainbowLevelMeter.bars(history: h).map { RainbowLevelMeter.fill(level: $0) })
     #expect(
-      declared == lastBarRightEdge,
-      "frame is \(declared)pt but the last bar ends at \(lastBarRightEdge)pt")
+      heights == [RainbowLevelMeter.silenceFraction],
+      """
+      after a full buffer of silence the meter still shows \(heights.count) heights: \
+      \(heights). The loud passage never scrolled off, so the waveform is frozen \
+      rather than draining.
+      """)
+  }
+
+  // MARK: - Turning the buffer into bars
+
+  @Test("a partial buffer is right-aligned, so the newest sample never moves")
+  func partialBufferIsRightAligned() {
+    let h: [CGFloat] = [0.4, 0.9]
+    let bars = RainbowLevelMeter.bars(history: h, count: 5)
+    #expect(
+      bars == [0, 0, 0, 0.4, 0.9], "got \(bars) — the newest sample is not at the right edge")
+  }
+
+  @Test("the newest sample sits at the same edge whether the buffer is partial or full")
+  func newestSampleHoldsItsEdge() {
+    let partial = RainbowLevelMeter.bars(history: [0.4, 0.9], count: 5)
+    let full = RainbowLevelMeter.bars(history: [0.1, 0.2, 0.3, 0.4, 0.9], count: 5)
+    #expect(
+      partial.last == full.last,
+      "newest sample moved from \(String(describing: full.last)) to \(String(describing: partial.last)) as the buffer filled"
+    )
+  }
+
+  /// The heart path draws this every frame, so an index slip is a crash in the
+  /// recording overlay rather than a wrong pixel.
+  @Test("an over-long buffer keeps its newest samples and cannot read out of bounds")
+  func overLongBufferIsSafe() {
+    let h: [CGFloat] = (0..<100).map { CGFloat($0) / 100 }
+    let bars = RainbowLevelMeter.bars(history: h, count: 4)
+    #expect(bars == [0.96, 0.97, 0.98, 0.99], "got \(bars) — expected the four newest samples")
+  }
+
+  @Test("an empty buffer draws the silence floor rather than crashing")
+  func emptyBufferIsSafe() {
+    let bars = RainbowLevelMeter.bars(history: [], count: 3)
+    #expect(bars == [0, 0, 0])
+  }
+
+  @Test("a zero bar count produces no bars")
+  func zeroBarCountIsSafe() {
+    #expect(RainbowLevelMeter.bars(history: [0.5], count: 0).isEmpty)
+  }
+
+  @Test("the drawing always has exactly one level per bar")
+  func barsMatchTheBarCount() {
+    #expect(RainbowLevelMeter.bars(history: [0.5]).count == RainbowLevelMeter.barCount)
+  }
+
+  // MARK: - Hostile input
+
+  /// The level arrives from a live capture path. A bad sample must not sit in the
+  /// buffer for a second and a bit, poisoning every frame it appears in — so the
+  /// clamp is on the way IN, not at draw time.
+  @Test(
+    "out-of-range samples are clamped before entering the buffer",
+    arguments: [-99.0, -0.5, 1.5, 99.0] as [CGFloat])
+  func hostileSamplesAreClampedOnEntry(level: CGFloat) {
+    let h = RainbowLevelMeter.pushed([], level: level, capacity: 4)
+    let v = h.first ?? -1
+    #expect(v >= 0 && v <= 1, "level \(level) entered the buffer as \(v)")
+  }
+
+  @Test("a zero capacity cannot produce a negative removeFirst")
+  func zeroCapacityIsSafe() {
+    #expect(RainbowLevelMeter.pushed([0.5], level: 0.5, capacity: 0).isEmpty)
+  }
+
+  // MARK: - Drawing
+
+  @Test("silence still shows a bar, because an empty meter reads as not hearing you")
+  func silenceIsNotEmpty() {
+    #expect(RainbowLevelMeter.fill(level: 0) == RainbowLevelMeter.silenceFraction)
+    #expect(RainbowLevelMeter.fill(level: 0) > 0)
+  }
+
+  @Test("louder is taller, and full level does not overflow the strip")
+  func fillIsMonotonicAndBounded() {
+    var previous = RainbowLevelMeter.fill(level: 0)
+    for step in 1...10 {
+      let current = RainbowLevelMeter.fill(level: CGFloat(step) / 10)
+      #expect(current > previous, "level \(CGFloat(step) / 10) was not taller than the step before")
+      previous = current
+    }
+    #expect(RainbowLevelMeter.fill(level: 1) <= 1, "full level overflows the strip")
+  }
+
+  /// The gradient is positional, so it must span the spectrum regardless of how
+  /// many bars there are — the bar count changed in this issue and would have
+  /// silently truncated a hardcoded mapping.
+  @Test("the positional gradient spans the spectrum at the shipped bar count")
+  func gradientSpansTheSpectrum() {
+    let first = RainbowLevelMeter.colour(at: 0, of: RainbowLevelMeter.barCount)
+    let last = RainbowLevelMeter.colour(
+      at: RainbowLevelMeter.barCount - 1, of: RainbowLevelMeter.barCount)
+    #expect(first == RainbowLevelMeter.spectrum.first)
+    #expect(last == RainbowLevelMeter.spectrum.last)
+  }
+
+  @Test("a single-bar meter does not divide by zero")
+  func singleBarGradientIsSafe() {
+    #expect(RainbowLevelMeter.colour(at: 0, of: 1) == RainbowLevelMeter.spectrum[0])
+  }
+
+  /// The frame and the drawing derive from one expression, so the Canvas cannot
+  /// draw outside the frame it was given.
+  @Test("declared width matches what the bars and gaps actually need")
+  func widthMatchesTheDrawing() {
+    let barWidth: CGFloat = 2
+    let spacing: CGFloat = 1.5
+    let declared = RainbowLevelMeter.width(barWidth: barWidth, spacing: spacing)
+    let lastEdge =
+      CGFloat(RainbowLevelMeter.barCount - 1) * (barWidth + spacing) + barWidth
+    #expect(declared == lastEdge, "frame is \(declared)pt but the last bar ends at \(lastEdge)pt")
   }
 }


### PR DESCRIPTION
## What the founder saw

> "I'm curious about the way the lines move. right now they all expand and shrink in
> unison. whereas when we were mocking up it was closer to what you see in this
> screen grab. a record of audio volume fluctuations."

He is right, and the cause was structural rather than a tuning miss.

## The defect

`fill(index:level:)` computed **every** bar from the same instant's `audioLevel`
multiplied by a fixed per-bar weight. Nine bars, one number, one static symmetric
shape that could only scale up and down. A level meter wearing a waveform's clothes.

**The approved mockup created the expectation and could not have been honest about
it.** Each bar there ran on its own CSS period and offset — nine independent timers
reading as a waveform because they were out of PHASE, while showing no data at all.
Real audio hands us one scalar per tick, so the only way to get that picture is to
keep the scalars.

Reusable form, since mockups precede most visual work here: **when a mock animates,
ask what real value drives each animated element.** The honest answer was "one
number, shared by all nine", and asking it would have caught this before it shipped.

## The fix

A rolling history. Bar `i` is a MOMENT — newest entering at the right, oldest falling
off. 24 samples at the parent's existing 50 ms poll is about 1.2 s: long enough to
read as a shape, short enough to be recognisably what you just said.

- **Driven by a poll counter, not by the level.** `onChange` fires on a CHANGE, and
  silence is the one passage where consecutive samples are bit-identical — so a
  level-driven history stops taking samples exactly when the user stops talking,
  freezing the shape of their last words on screen until they speak again. A
  strictly-increasing tick makes every poll a sample, so a pause drains to the
  silence floor the way a record of volume should. Found in self-review.
- **The meter's per-bar sensitivity curve is gone**, with the design that needed it.
  Bar 4 was never "more sensitive"; it is 200 ms ago. The identically-shaped array on
  `RainbowLipsIcon` stays — that mark is still live in the non-preview capsule, the
  notification overlay and the settings rail, and is out of scope here.
- **Colour stays POSITIONAL.** The spectrum is a fixed gradient the heights scroll
  through, interpolated so it spans any bar count. Colours travelling sideways would
  read as a progress bar rather than as our mark.
- **Silence floor kept.** A meter that empties between words reads as "it stopped
  hearing me", which is the anxiety the preview exists to remove.
- **Partial buffers are right-aligned**, so the newest sample sits at the same edge
  from the first tick instead of the waveform sliding for a second.
- **Clamped on the way IN**, not at draw time — a hostile sample would otherwise sit
  in the buffer for 1.2 s poisoning every frame it appears in.
- **Buffer-to-bars is extracted and bounds-checked** rather than indexed inline. This
  runs on the heart path every frame, so an index slip is a crash in the recording
  overlay, not a wrong pixel.

No new timer and no new data source; the history is fed from the poll that already
existed. The `Canvas` keeps a fixed frame, so #2201's sizing and #2202's header
height are untouched.

## Why the old tests passed a design this wrong

They asserted what that design HAD — louder is taller, nothing overflows, the centre
outreacts the edges. All true, all passing. **Not one asked whether two bars could
ever differ for a reason other than their index**, which is impossible under a
single-level meter and invisible because no test ever showed the meter two different
moments.

The new suite asks exactly that, with its inverse as the control: an alternating
loud/quiet passage must produce two distinct heights, and a steady tone must read
FLAT. The old design could not tell those two passages apart at all.

## The one thing the tests do NOT bind, stated rather than implied

`silenceDrainsTheWaveform` asserts the DATA path: a buffer of silence scrolls the loud
passage out and settles on the floor. It does not reach the WIRING that feeds that
buffer — `onChange(of: tick)` is a SwiftUI modifier, and swapping it back to
`onChange(of: audioLevel)` would leave all 19 tests green. A guard written over that
source line would be a text match, which this repo already refuses to treat as
binding. The wiring is covered by the visual check below and by nothing else.

## Validation

- `RainbowLevelMeterTests` — 19 tests
- `RecordingOverlayPreviewSizingTests` — 8 tests, confirming #2201's size binding is
  unaffected
- `RecordingOverlayPreviewChromeTests` — 7 tests
- Full Debug + Release lanes
- One mutant, aimed at the line the new cases most claim to protect: dropping the
  right-alignment offset turned `bars` into the OLDEST four samples instead of the
  newest. CAUGHT — red on exactly the case that names it, restore verified
  byte-identical against a pre-mutation copy.
- **Visual, because motion is not a thing a test can see:** three frames one second
  apart across one dictation, spoken deliberately loud/quiet so a waveform had
  something to show. A record of a monotone is a flat line and would have proven
  nothing either way. The frames show the peaks travelling, and the last one reads
  the sentence — quiet on the left, loud on the right, matching audio that ended loud.

Closes #2216.
