### PR TITLE
test(ui): a copy string is no longer counted as used because a longer sibling is

### DIFF
--- a/Tests/EnviousWisprTests/App/LivePreviewPackCopyTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewPackCopyTests.swift
@@ -129,33 +129,18 @@ struct LivePreviewPackCopyTests {
   /// so excluding it would reintroduce this bug the first time someone writes `packInstalling_v2`.
   /// The name is regex-escaped rather than interpolated raw, so a future declaration containing a
   /// metacharacter cannot silently turn this into a different pattern.
-  /// What continues a Swift identifier. **ONE definition, consulted by the scanner AND the matcher.**
+  /// The characters that END a Swift declaration name.
   ///
-  /// Cloud review returned two findings on this file and they are the same defect: the two halves
-  /// disagreed about this set, in opposite directions. The scanner used `isLetter || isNumber`, which is
-  /// Unicode-aware and excludes `_`; the matcher used an ASCII `[A-Za-z0-9_]`, which includes it. So
-  /// `packInstalling_v2` was scanned as `packInstalling` and its real reference then rejected — a false
-  /// positive on a live declaration — while an accented sibling slipped past the lookahead and
-  /// reintroduced the original #2172 bug. Two comparisons of one concept will always drift; give the
-  /// concept an owner instead.
-  nonisolated static func continuesIdentifier(_ c: Character) -> Bool {
-    // Built from the platform's own Unicode general categories rather than a hand-rolled set.
-    // `isLetter || isNumber || == "_"` was the previous shape and cloud review found the hole one
-    // round later: U+203F is Swift-valid connector punctuation and was treated as a boundary, so a
-    // declaration named `pack‿v2` would be scanned as `pack` and then reported USED by its own longer
-    // sibling's reference — the #2172 vacuous pass restored, silently. `_` is itself
-    // `connectorPunctuation`, so this SUBSUMES the old rule rather than bolting a case onto it.
-    c.unicodeScalars.allSatisfy { scalar in
-      switch scalar.properties.generalCategory {
-      case .lowercaseLetter, .uppercaseLetter, .titlecaseLetter, .modifierLetter, .otherLetter,
-        .decimalNumber, .letterNumber, .otherNumber,
-        .connectorPunctuation, .nonspacingMark, .spacingMark:
-        return true
-      default:
-        return false
-      }
-    }
-  }
+  /// **This is the CLOSED question, and asking the open one cost three review rounds.** The previous
+  /// versions asked "what CONTINUES an identifier" — first `[A-Za-z0-9_]`, then Unicode letters and
+  /// numbers, then a list of general categories — and cloud review found a gap in each: `_`, then
+  /// U+203F, then `🔒`/`·`/`¨`/U+2060. Swift's identifier grammar is large and versioned, so every
+  /// approximation of it has a next counterexample; a terminator set does not, because the grammar
+  /// REQUIRES one of these after a declaration name.
+  nonisolated static let declarationNameTerminators: Set<Character> = [
+    " ", "\t", ":", "=", "(", "<",
+  ]
+
 
   /// The declaration name on a `static let`/`static func` line, or nil.
   ///
@@ -165,27 +150,37 @@ struct LivePreviewPackCopyTests {
   nonisolated static func declaredName(in line: String) -> String? {
     guard let range = line.range(of: #"static (let|func) "#, options: .regularExpression)
     else { return nil }
-    let name = String(line[range.upperBound...].prefix(while: continuesIdentifier))
+    let name = String(
+      line[range.upperBound...].prefix(while: { declarationNameTerminators.contains($0) == false }))
     return name.isEmpty ? nil : name
   }
 
-  /// Is `name` referenced as a WHOLE identifier?
+  /// Is `declaration` referenced, as itself rather than as the opening of a longer DECLARED sibling?
   ///
-  /// **No regex, deliberately.** The previous version consulted `continuesIdentifier` in the scanner
-  /// and then re-encoded the same set as an ICU character class here — and cloud review found those two
-  /// encodings disagreeing one round after they were consolidated, which is what a rule expressed twice
-  /// always does. Scanning for the literal reference and asking the SHARED predicate about the next
-  /// character leaves exactly one definition and nothing to keep in sync. It also removes the need to
-  /// regex-escape the name at all.
-  nonisolated static func isReferenced(_ name: String, in corpus: String) -> Bool {
-    let needle = "LivePreviewSettingsCopy.\(name)"
+  /// **Closed-world, so there is no character to classify.** `siblings` is the full declaration list
+  /// this suite reads out of the copy file, which is the finite authority on what names exist. An
+  /// occurrence of `LivePreviewSettingsCopy.<declaration>` is a genuine use unless some LONGER declared
+  /// name also matches at that same position — and because the corpus is compiling Swift, every
+  /// `LivePreviewSettingsCopy.X` reference names a real member, so those are the only two possibilities.
+  ///
+  /// Three review rounds went into character classes before this: `[A-Za-z0-9_]`, then Unicode letters
+  /// and numbers, then general categories, each with a next counterexample. The set of DECLARATIONS has
+  /// no next counterexample, because it is enumerated rather than described.
+  nonisolated static func isReferenced(
+    _ declaration: String, in corpus: String, siblings: [String]
+  ) -> Bool {
+    let prefix = "LivePreviewSettingsCopy."
+    let longerSiblings = siblings.filter { $0 != declaration && $0.hasPrefix(declaration) }
+    let needle = prefix + declaration
+
     var searchFrom = corpus.startIndex
     while let hit = corpus.range(of: needle, range: searchFrom..<corpus.endIndex) {
-      // A reference at the very end of the corpus has no following character, so nothing continues it.
-      if hit.upperBound == corpus.endIndex || continuesIdentifier(corpus[hit.upperBound]) == false {
-        return true
+      let shadowed = longerSiblings.contains { sibling in
+        corpus.range(of: prefix + sibling, range: hit.lowerBound..<corpus.endIndex)?.lowerBound
+          == hit.lowerBound
       }
-      searchFrom = hit.upperBound
+      if shadowed == false { return true }
+      searchFrom = corpus.index(after: hit.lowerBound)
     }
     return false
   }
@@ -227,7 +222,9 @@ struct LivePreviewPackCopyTests {
     #expect(
       corpus.contains("LivePreviewSettingsCopy."), "control: the corpus reached real call sites")
 
-    let unused = declarations.filter { Self.isReferenced($0, in: corpus) == false }
+    let unused = declarations.filter {
+      Self.isReferenced($0, in: corpus, siblings: declarations) == false
+    }
     #expect(
       unused.isEmpty,
       """
@@ -250,12 +247,13 @@ struct LivePreviewPackCopyTests {
   @Test("A declaration referenced only as a longer sibling's prefix is not counted as used")
   func aPrefixSiblingDoesNotSatisfyADeclaration() {
     let corpus = "Text(LivePreviewSettingsCopy.universalLockedHelp)"
+    let declared = ["universalLocked", "universalLockedHelp"]
 
     #expect(
-      Self.isReferenced("universalLockedHelp", in: corpus),
+      Self.isReferenced("universalLockedHelp", in: corpus, siblings: declared),
       "the declaration actually on screen must count as used")
     #expect(
-      Self.isReferenced("universalLocked", in: corpus) == false,
+      Self.isReferenced("universalLocked", in: corpus, siblings: declared) == false,
       """
       `universalLocked` is referenced nowhere; only its longer sibling `universalLockedHelp` is. \
       A substring match reports it used, which is the #2172 defect.
@@ -269,18 +267,25 @@ struct LivePreviewPackCopyTests {
   /// accepting.
   @Test("An exact reference counts as used in every shape a call site takes")
   func anExactReferenceCountsAsUsed() {
-    #expect(Self.isReferenced("packInstalling", in: "LivePreviewSettingsCopy.packInstalling"))
-    #expect(Self.isReferenced("packInstalling", in: "Text(LivePreviewSettingsCopy.packInstalling)"))
+    let declared = ["packInstalling", "previewNeedsLanguagePack"]
+    #expect(
+      Self.isReferenced("packInstalling", in: "LivePreviewSettingsCopy.packInstalling", siblings: declared))
+    #expect(
+      Self.isReferenced(
+        "packInstalling", in: "Text(LivePreviewSettingsCopy.packInstalling)", siblings: declared))
     #expect(
       Self.isReferenced(
         "previewNeedsLanguagePack",
-        in: "LivePreviewSettingsCopy.previewNeedsLanguagePack(\"French\")"),
+        in: "LivePreviewSettingsCopy.previewNeedsLanguagePack(\"French\")",
+        siblings: declared),
       "a func declaration is referenced with an open paren straight after the name")
     #expect(
-      Self.isReferenced("packInstalling", in: "let s = LivePreviewSettingsCopy.packInstalling\n"),
+      Self.isReferenced(
+        "packInstalling", in: "let s = LivePreviewSettingsCopy.packInstalling\n", siblings: declared),
       "a reference at end of line still counts")
     #expect(
-      Self.isReferenced("packInstalling", in: "LivePreviewSettingsCopy.packInstalling.count"),
+      Self.isReferenced(
+        "packInstalling", in: "LivePreviewSettingsCopy.packInstalling.count", siblings: declared),
       "a property accessed off the string still counts")
   }
 
@@ -292,9 +297,10 @@ struct LivePreviewPackCopyTests {
   @Test("An underscore continues an identifier, so a longer sibling does not satisfy the shorter")
   func underscoreDoesNotEndAnIdentifier() {
     let corpus = "Text(LivePreviewSettingsCopy.packInstalling_v2)"
-    #expect(Self.isReferenced("packInstalling_v2", in: corpus))
+    let declared = ["packInstalling", "packInstalling_v2"]
+    #expect(Self.isReferenced("packInstalling_v2", in: corpus, siblings: declared))
     #expect(
-      Self.isReferenced("packInstalling", in: corpus) == false,
+      Self.isReferenced("packInstalling", in: corpus, siblings: declared) == false,
       "`_` continues a Swift identifier, so this is a different declaration entirely")
   }
 
@@ -311,7 +317,7 @@ struct LivePreviewPackCopyTests {
 
     let corpus = "Text(LivePreviewSettingsCopy.packInstalling_v2)"
     #expect(
-      Self.isReferenced(declared ?? "", in: corpus),
+      Self.isReferenced(declared ?? "", in: corpus, siblings: ["packInstalling", "packInstalling_v2"]),
       """
       A real declaration was reported unused: the scanner truncated the name at `_` and the matcher \
       then refused the genuine reference. That is a FALSE POSITIVE on live copy, which is worse than \
@@ -325,9 +331,12 @@ struct LivePreviewPackCopyTests {
     #expect(declared == "packInstallingé", "the scanner keeps Unicode letters")
 
     let corpus = "Text(LivePreviewSettingsCopy.packInstallingé)"
-    #expect(Self.isReferenced("packInstallingé", in: corpus), "its own reference must match")
+    let siblings = ["packInstalling", "packInstallingé"]
     #expect(
-      Self.isReferenced("packInstalling", in: corpus) == false,
+      Self.isReferenced("packInstallingé", in: corpus, siblings: siblings),
+      "its own reference must match")
+    #expect(
+      Self.isReferenced("packInstalling", in: corpus, siblings: siblings) == false,
       """
       An ASCII-only lookahead treats `é` as a boundary, so the shorter name is satisfied by its longer \
       sibling — the original #2172 defect, in Unicode clothing.
@@ -347,9 +356,12 @@ struct LivePreviewPackCopyTests {
     #expect(declared == "pack\u{203F}v2", "the scanner must not stop at connector punctuation")
 
     let corpus = "Text(LivePreviewSettingsCopy.pack\u{203F}v2)"
-    #expect(Self.isReferenced("pack\u{203F}v2", in: corpus), "its own reference must match")
+    let siblings = ["pack", "pack\u{203F}v2"]
     #expect(
-      Self.isReferenced("pack", in: corpus) == false,
+      Self.isReferenced("pack\u{203F}v2", in: corpus, siblings: siblings),
+      "its own reference must match")
+    #expect(
+      Self.isReferenced("pack", in: corpus, siblings: siblings) == false,
       """
       `pack` is referenced nowhere; only `pack‿v2` is. Treating U+203F as a boundary restores the \
       vacuous pass this whole guard exists to remove, and nothing would go red.

--- a/Tests/EnviousWisprTests/App/LivePreviewPackCopyTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewPackCopyTests.swift
@@ -112,6 +112,29 @@ struct LivePreviewPackCopyTests {
     #expect(LivePreviewSettingsCopy.packInstalling.localizedCaseInsensitiveContains("download"))
   }
 
+  /// Is `name` referenced as a WHOLE identifier, rather than merely as the opening characters
+  /// of a longer sibling's name?
+  ///
+  /// **A substring test passes a declaration vacuously whenever a longer sibling is on screen.**
+  /// Measured on PR #2169 head `7cc70be1`: a refactor left four strings referenced only from
+  /// inside the copy file, and this guard reported exactly two of them —
+  /// `universalLockedPaused` and `universalAutoPaused`, the two with no prefix sibling.
+  /// `universalLocked` and `universalAuto` were in the identical situation and passed, because
+  /// `universalLockedHelp` and `universalAutoHelp` were rendered. The guard caught the strings
+  /// that had no sibling and missed the ones that did, which is the defect demonstrating itself
+  /// on a live run.
+  ///
+  /// The trailing `(?![A-Za-z0-9_])` is what makes the match a whole identifier. Underscore is in
+  /// that set even though no declaration uses one today: a Swift identifier may continue with it,
+  /// so excluding it would reintroduce this bug the first time someone writes `packInstalling_v2`.
+  /// The name is regex-escaped rather than interpolated raw, so a future declaration containing a
+  /// metacharacter cannot silently turn this into a different pattern.
+  nonisolated static func isReferenced(_ name: String, in corpus: String) -> Bool {
+    let escaped = NSRegularExpression.escapedPattern(for: name)
+    let pattern = "LivePreviewSettingsCopy\\.\(escaped)(?![A-Za-z0-9_])"
+    return corpus.range(of: pattern, options: .regularExpression) != nil
+  }
+
   /// Every string this page declares must actually reach a screen.
   ///
   /// **Written because one did not.** `packInstallFailed` was declared, referenced by the dash
@@ -153,7 +176,7 @@ struct LivePreviewPackCopyTests {
     #expect(
       corpus.contains("LivePreviewSettingsCopy."), "control: the corpus reached real call sites")
 
-    let unused = declarations.filter { !corpus.contains("LivePreviewSettingsCopy.\($0)") }
+    let unused = declarations.filter { Self.isReferenced($0, in: corpus) == false }
     #expect(
       unused.isEmpty,
       """
@@ -161,6 +184,67 @@ struct LivePreviewPackCopyTests {
       Either wire it into the page or delete it — a string that exists and is never shown reads \
       as done in review and is missing in the product.
       """)
+  }
+
+  /// Two-way control for the matcher above.
+  ///
+  /// **Written because a guard that stops firing is indistinguishable from one that was deleted.**
+  /// The suite's existing `declarations.count > 10` control covers a parse failure and says
+  /// nothing about MATCHING, so without these the tightening could be reverted — or broken by a
+  /// future edit — with every test still green.
+  ///
+  /// Not parameterized on purpose. A named parameterized test prints
+  /// `Test "..." with N test cases passed`, a shape `mutation-battery.py` cannot match, so it can
+  /// never be named as a recipe's `expect_fail` and the overnight battery cannot reach it.
+  @Test("A declaration referenced only as a longer sibling's prefix is not counted as used")
+  func aPrefixSiblingDoesNotSatisfyADeclaration() {
+    let corpus = "Text(LivePreviewSettingsCopy.universalLockedHelp)"
+
+    #expect(
+      Self.isReferenced("universalLockedHelp", in: corpus),
+      "the declaration actually on screen must count as used")
+    #expect(
+      Self.isReferenced("universalLocked", in: corpus) == false,
+      """
+      `universalLocked` is referenced nowhere; only its longer sibling `universalLockedHelp` is. \
+      A substring match reports it used, which is the #2172 defect.
+      """)
+  }
+
+  /// The exact-reference side, in the shapes a call site really takes.
+  ///
+  /// A word-boundary rule that was too strict would be just as wrong as the substring rule, and
+  /// would fail LOUDLY on every real declaration, so each of these is a shape the guard must keep
+  /// accepting.
+  @Test("An exact reference counts as used in every shape a call site takes")
+  func anExactReferenceCountsAsUsed() {
+    #expect(Self.isReferenced("packInstalling", in: "LivePreviewSettingsCopy.packInstalling"))
+    #expect(Self.isReferenced("packInstalling", in: "Text(LivePreviewSettingsCopy.packInstalling)"))
+    #expect(
+      Self.isReferenced(
+        "previewNeedsLanguagePack",
+        in: "LivePreviewSettingsCopy.previewNeedsLanguagePack(\"French\")"),
+      "a func declaration is referenced with an open paren straight after the name")
+    #expect(
+      Self.isReferenced("packInstalling", in: "let s = LivePreviewSettingsCopy.packInstalling\n"),
+      "a reference at end of line still counts")
+    #expect(
+      Self.isReferenced("packInstalling", in: "LivePreviewSettingsCopy.packInstalling.count"),
+      "a property accessed off the string still counts")
+  }
+
+  /// The underscore case, which the issue's proposed pattern would have missed.
+  ///
+  /// `(?![A-Za-z0-9])` alone treats `_` as a boundary, so `packInstalling` would be reported used
+  /// by a reference to `packInstalling_v2`. No declaration uses an underscore today; this pins the
+  /// wider character class so that stays safe when one does.
+  @Test("An underscore continues an identifier, so a longer sibling does not satisfy the shorter")
+  func underscoreDoesNotEndAnIdentifier() {
+    let corpus = "Text(LivePreviewSettingsCopy.packInstalling_v2)"
+    #expect(Self.isReferenced("packInstalling_v2", in: corpus))
+    #expect(
+      Self.isReferenced("packInstalling", in: corpus) == false,
+      "`_` continues a Swift identifier, so this is a different declaration entirely")
   }
 
   /// The pill sentence must keep matching the phrasing the app already uses for a missing model,

--- a/Tests/EnviousWisprTests/App/LivePreviewPackCopyTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewPackCopyTests.swift
@@ -129,9 +129,37 @@ struct LivePreviewPackCopyTests {
   /// so excluding it would reintroduce this bug the first time someone writes `packInstalling_v2`.
   /// The name is regex-escaped rather than interpolated raw, so a future declaration containing a
   /// metacharacter cannot silently turn this into a different pattern.
+  /// What continues a Swift identifier. **ONE definition, consulted by the scanner AND the matcher.**
+  ///
+  /// Cloud review returned two findings on this file and they are the same defect: the two halves
+  /// disagreed about this set, in opposite directions. The scanner used `isLetter || isNumber`, which is
+  /// Unicode-aware and excludes `_`; the matcher used an ASCII `[A-Za-z0-9_]`, which includes it. So
+  /// `packInstalling_v2` was scanned as `packInstalling` and its real reference then rejected — a false
+  /// positive on a live declaration — while an accented sibling slipped past the lookahead and
+  /// reintroduced the original #2172 bug. Two comparisons of one concept will always drift; give the
+  /// concept an owner instead.
+  nonisolated static func continuesIdentifier(_ c: Character) -> Bool {
+    c.isLetter || c.isNumber || c == "_"
+  }
+
+  /// The declaration name on a `static let`/`static func` line, or nil.
+  ///
+  /// Extracted so the SCANNER and the MATCHER can be tested as the pair they are. The unit control
+  /// written with the original fix fed `isReferenced` directly and so could not see them disagree —
+  /// which is exactly how the underscore case shipped.
+  nonisolated static func declaredName(in line: String) -> String? {
+    guard let range = line.range(of: #"static (let|func) "#, options: .regularExpression)
+    else { return nil }
+    let name = String(line[range.upperBound...].prefix(while: continuesIdentifier))
+    return name.isEmpty ? nil : name
+  }
+
   nonisolated static func isReferenced(_ name: String, in corpus: String) -> Bool {
     let escaped = NSRegularExpression.escapedPattern(for: name)
-    let pattern = "LivePreviewSettingsCopy\\.\(escaped)(?![A-Za-z0-9_])"
+    // `\p{L}` and `\p{N}` are ICU's Unicode letter and number categories, so this lookahead accepts
+    // exactly what `continuesIdentifier` accepts. An ASCII class here is what let an accented sibling
+    // satisfy a shorter name.
+    let pattern = "LivePreviewSettingsCopy\\.\(escaped)(?![\\p{L}\\p{N}_])"
     return corpus.range(of: pattern, options: .regularExpression) != nil
   }
 
@@ -151,11 +179,7 @@ struct LivePreviewPackCopyTests {
     let copyFile = settings.appending(path: "LivePreviewSettingsCopy.swift")
     let declarations = try String(contentsOf: copyFile, encoding: .utf8)
       .split(separator: "\n")
-      .compactMap { line -> String? in
-        guard let range = line.range(of: #"static (let|func) "#, options: .regularExpression)
-        else { return nil }
-        return String(line[range.upperBound...].prefix { $0.isLetter || $0.isNumber })
-      }
+      .compactMap { Self.declaredName(in: String($0)) }
     #expect(declarations.count > 10, "control: the copy surface was found and parsed")
 
     // Every source file that could render it — the page itself plus the coordinator that puts
@@ -245,6 +269,42 @@ struct LivePreviewPackCopyTests {
     #expect(
       Self.isReferenced("packInstalling", in: corpus) == false,
       "`_` continues a Swift identifier, so this is a different declaration entirely")
+  }
+
+  /// The scanner and the matcher must agree, in BOTH directions.
+  ///
+  /// **Written because they did not, and the unit control could not see it.** The cases above feed
+  /// `isReferenced` directly, so they exercise the matcher alone; these run a declaration line through
+  /// the SCANNER first and then ask the MATCHER about the result, which is the pair the real guard uses.
+  /// Cloud review on PR #2230 found both directions.
+  @Test("A declaration name with an underscore survives the scanner and matches its own reference")
+  func theScannerAndMatcherAgreeOnUnderscores() {
+    let declared = Self.declaredName(in: "  static let packInstalling_v2 = \"x\"")
+    #expect(declared == "packInstalling_v2", "the scanner must not stop at the underscore")
+
+    let corpus = "Text(LivePreviewSettingsCopy.packInstalling_v2)"
+    #expect(
+      Self.isReferenced(declared ?? "", in: corpus),
+      """
+      A real declaration was reported unused: the scanner truncated the name at `_` and the matcher \
+      then refused the genuine reference. That is a FALSE POSITIVE on live copy, which is worse than \
+      the vacuous pass this guard was tightened to fix.
+      """)
+  }
+
+  @Test("A non-ASCII identifier continuation is a boundary for neither half")
+  func theScannerAndMatcherAgreeOnUnicode() {
+    let declared = Self.declaredName(in: "  static let packInstallingé = \"x\"")
+    #expect(declared == "packInstallingé", "the scanner keeps Unicode letters")
+
+    let corpus = "Text(LivePreviewSettingsCopy.packInstallingé)"
+    #expect(Self.isReferenced("packInstallingé", in: corpus), "its own reference must match")
+    #expect(
+      Self.isReferenced("packInstalling", in: corpus) == false,
+      """
+      An ASCII-only lookahead treats `é` as a boundary, so the shorter name is satisfied by its longer \
+      sibling — the original #2172 defect, in Unicode clothing.
+      """)
   }
 
   /// The pill sentence must keep matching the phrasing the app already uses for a missing model,

--- a/Tests/EnviousWisprTests/App/LivePreviewPackCopyTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewPackCopyTests.swift
@@ -139,7 +139,22 @@ struct LivePreviewPackCopyTests {
   /// reintroduced the original #2172 bug. Two comparisons of one concept will always drift; give the
   /// concept an owner instead.
   nonisolated static func continuesIdentifier(_ c: Character) -> Bool {
-    c.isLetter || c.isNumber || c == "_"
+    // Built from the platform's own Unicode general categories rather than a hand-rolled set.
+    // `isLetter || isNumber || == "_"` was the previous shape and cloud review found the hole one
+    // round later: U+203F is Swift-valid connector punctuation and was treated as a boundary, so a
+    // declaration named `pack‿v2` would be scanned as `pack` and then reported USED by its own longer
+    // sibling's reference — the #2172 vacuous pass restored, silently. `_` is itself
+    // `connectorPunctuation`, so this SUBSUMES the old rule rather than bolting a case onto it.
+    c.unicodeScalars.allSatisfy { scalar in
+      switch scalar.properties.generalCategory {
+      case .lowercaseLetter, .uppercaseLetter, .titlecaseLetter, .modifierLetter, .otherLetter,
+        .decimalNumber, .letterNumber, .otherNumber,
+        .connectorPunctuation, .nonspacingMark, .spacingMark:
+        return true
+      default:
+        return false
+      }
+    }
   }
 
   /// The declaration name on a `static let`/`static func` line, or nil.
@@ -154,13 +169,25 @@ struct LivePreviewPackCopyTests {
     return name.isEmpty ? nil : name
   }
 
+  /// Is `name` referenced as a WHOLE identifier?
+  ///
+  /// **No regex, deliberately.** The previous version consulted `continuesIdentifier` in the scanner
+  /// and then re-encoded the same set as an ICU character class here — and cloud review found those two
+  /// encodings disagreeing one round after they were consolidated, which is what a rule expressed twice
+  /// always does. Scanning for the literal reference and asking the SHARED predicate about the next
+  /// character leaves exactly one definition and nothing to keep in sync. It also removes the need to
+  /// regex-escape the name at all.
   nonisolated static func isReferenced(_ name: String, in corpus: String) -> Bool {
-    let escaped = NSRegularExpression.escapedPattern(for: name)
-    // `\p{L}` and `\p{N}` are ICU's Unicode letter and number categories, so this lookahead accepts
-    // exactly what `continuesIdentifier` accepts. An ASCII class here is what let an accented sibling
-    // satisfy a shorter name.
-    let pattern = "LivePreviewSettingsCopy\\.\(escaped)(?![\\p{L}\\p{N}_])"
-    return corpus.range(of: pattern, options: .regularExpression) != nil
+    let needle = "LivePreviewSettingsCopy.\(name)"
+    var searchFrom = corpus.startIndex
+    while let hit = corpus.range(of: needle, range: searchFrom..<corpus.endIndex) {
+      // A reference at the very end of the corpus has no following character, so nothing continues it.
+      if hit.upperBound == corpus.endIndex || continuesIdentifier(corpus[hit.upperBound]) == false {
+        return true
+      }
+      searchFrom = hit.upperBound
+    }
+    return false
   }
 
   /// Every string this page declares must actually reach a screen.
@@ -304,6 +331,28 @@ struct LivePreviewPackCopyTests {
       """
       An ASCII-only lookahead treats `é` as a boundary, so the shorter name is satisfied by its longer \
       sibling — the original #2172 defect, in Unicode clothing.
+      """)
+  }
+
+  /// Connector punctuation continues a Swift identifier, and it is not a letter, a number or `_`.
+  ///
+  /// **The input is exotic and the failure is SILENT, which is what earns it a case**
+  /// (testing-philosophy.md RULE: dont-test-what-cannot-happen). Nobody will name a copy constant
+  /// `pack‿v2`. But if they did, a predicate built from `isLetter || isNumber || == "_"` treats U+203F
+  /// as a boundary, so the shorter `pack` is reported USED by the longer name's reference and nothing
+  /// goes red — the original #2172 defect, restored, one round after it was fixed.
+  @Test("Connector punctuation continues an identifier for both the scanner and the matcher")
+  func connectorPunctuationContinuesAnIdentifier() {
+    let declared = Self.declaredName(in: "  static let pack\u{203F}v2 = \"x\"")
+    #expect(declared == "pack\u{203F}v2", "the scanner must not stop at connector punctuation")
+
+    let corpus = "Text(LivePreviewSettingsCopy.pack\u{203F}v2)"
+    #expect(Self.isReferenced("pack\u{203F}v2", in: corpus), "its own reference must match")
+    #expect(
+      Self.isReferenced("pack", in: corpus) == false,
+      """
+      `pack` is referenced nowhere; only `pack‿v2` is. Treating U+203F as a boundary restores the \
+      vacuous pass this whole guard exists to remove, and nothing would go red.
       """)
   }
 

--- a/Tests/EnviousWisprTests/App/LivePreviewPackCopyTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewPackCopyTests.swift
@@ -150,8 +150,13 @@ struct LivePreviewPackCopyTests {
   nonisolated static func declaredName(in line: String) -> String? {
     guard let range = line.range(of: #"static (let|func) "#, options: .regularExpression)
     else { return nil }
-    let name = String(
+    let raw = String(
       line[range.upperBound...].prefix(while: { declarationNameTerminators.contains($0) == false }))
+    // SPELLING is normalised HERE, once. A backtick-escaped declaration —
+    // `static let `repeat` = "…"` — names the same member as an unescaped one, and the compiler
+    // treats the two as identical, so a reader that kept the backticks would look for a reference
+    // nobody writes. Backticks are Swift's only identifier escape, so this closes the axis.
+    let name = raw.trimmingCharacters(in: CharacterSet(charactersIn: "`"))
     return name.isEmpty ? nil : name
   }
 
@@ -171,16 +176,23 @@ struct LivePreviewPackCopyTests {
   ) -> Bool {
     let prefix = "LivePreviewSettingsCopy."
     let longerSiblings = siblings.filter { $0 != declaration && $0.hasPrefix(declaration) }
-    let needle = prefix + declaration
 
-    var searchFrom = corpus.startIndex
-    while let hit = corpus.range(of: needle, range: searchFrom..<corpus.endIndex) {
-      let shadowed = longerSiblings.contains { sibling in
-        corpus.range(of: prefix + sibling, range: hit.lowerBound..<corpus.endIndex)?.lowerBound
-          == hit.lowerBound
+    // A reference to a backtick-escaped member compiles written EITHER way, so both spellings of the
+    // one name are searched. Two renderings of the same thing, not two things.
+    func spellings(_ name: String) -> [String] { [prefix + name, prefix + "`" + name + "`"] }
+
+    for needle in spellings(declaration) {
+      var searchFrom = corpus.startIndex
+      while let hit = corpus.range(of: needle, range: searchFrom..<corpus.endIndex) {
+        let shadowed = longerSiblings.contains { sibling in
+          spellings(sibling).contains { longer in
+            corpus.range(of: longer, range: hit.lowerBound..<corpus.endIndex)?.lowerBound
+              == hit.lowerBound
+          }
+        }
+        if shadowed == false { return true }
+        searchFrom = corpus.index(after: hit.lowerBound)
       }
-      if shadowed == false { return true }
-      searchFrom = corpus.index(after: hit.lowerBound)
     }
     return false
   }
@@ -366,6 +378,31 @@ struct LivePreviewPackCopyTests {
       `pack` is referenced nowhere; only `pack‿v2` is. Treating U+203F as a boundary restores the \
       vacuous pass this whole guard exists to remove, and nothing would go red.
       """)
+  }
+
+  /// A backtick-escaped declaration names the same member as an unescaped one.
+  ///
+  /// **SPELLING, not meaning** — the distinction testing-philosophy.md's axes table draws, where
+  /// "backtick-escaped identifier" is the first spelling row because it already cost
+  /// `TestInventoryFreezeTests` a review round. `default`, `repeat` and `for` are ordinary words for
+  /// UI copy, so this is not a far-fetched input even though none exists today.
+  @Test("A backtick-escaped declaration is found by its ordinary reference")
+  func backtickEscapedDeclarationsAreNormalised() {
+    #expect(
+      Self.declaredName(in: "  static let `repeat` = \"Try again\"") == "repeat",
+      "the backticks are a SPELLING of the name, not part of it")
+
+    // Swift accepts the reference written either way; both must count.
+    #expect(
+      Self.isReferenced(
+        "repeat", in: "Text(LivePreviewSettingsCopy.repeat)", siblings: ["repeat"]))
+    #expect(
+      Self.isReferenced(
+        "repeat", in: "Text(LivePreviewSettingsCopy.`repeat`)", siblings: ["repeat"]))
+    #expect(
+      Self.isReferenced("repeat", in: "Text(LivePreviewSettingsCopy.other)", siblings: ["repeat"])
+        == false,
+      "and it is still not satisfied by an unrelated reference")
   }
 
   /// The pill sentence must keep matching the phrasing the app already uses for a missing model,


### PR DESCRIPTION
Closes #2172.

`everyStringIsActuallyUsed` decided whether a declared copy string reaches a screen with a plain substring
test, so a declaration whose name is a strict PREFIX of another, used declaration passed vacuously.

## The defect demonstrating itself

Measured on PR #2169 head `7cc70be1`, where a refactor left four strings referenced only from inside the
copy file. CI flagged exactly two:

```
✘ Expectation failed: (unused → ["universalLockedPaused", "universalAutoPaused"]).isEmpty → false
```

`universalLocked` and `universalAuto` were in the identical situation — declared, referenced nowhere
outside `LivePreviewSettingsCopy.swift` — and passed, because `universalLockedHelp` and `universalAutoHelp`
were on screen. **The guard caught the two strings with no prefix sibling and missed the two that had one.**

## What changed

The match is now a whole identifier, via a small `isReferenced(_:in:)` helper so the matching logic can be
tested directly rather than only through the real tree.

**Two deliberate deviations from the fix the issue proposed, both stated so a reviewer can overrule them:**

1. The trailing character class is `[A-Za-z0-9_]`, not the issue's `[A-Za-z0-9]`. `_` continues a Swift
   identifier, so treating it as a boundary would report `packInstalling` as used by a reference to
   `packInstalling_v2` — the same bug one character over. No declaration uses an underscore today; the
   wider class is what keeps that true.
2. The name is passed through `NSRegularExpression.escapedPattern(for:)` rather than interpolated raw. The
   issue notes every declaration is currently `[A-Za-z0-9]`; escaping means a future one containing a
   metacharacter cannot silently turn this into a different pattern.

## Controls

Three cases, because the suite's existing `declarations.count > 10` control covers a PARSE failure and says
nothing about MATCHING — so without them the tightening could be reverted, or broken by a later edit, with
everything still green.

**Deliberately not parameterized.** A named parameterized test prints `Test "..." with N test cases passed`,
a shape `mutation-battery.py` cannot match, so it could never be named as a recipe's `expect_fail` and the
overnight battery could not reach it. That is a live constraint tonight, not a hypothetical: see #2224.

## Verification

- `scripts/xcode-test.sh --filter EnviousWisprTests/LivePreviewPackCopyTests` — **9/9**, exit 0. The suite
  had 6 tests; the three new ones are named in the log.
- **Mutation control**, restoring the substring match: exactly the two prefix cases go red, exit 65, restore
  verified byte-identical.

```
✘ Test "A declaration referenced only as a longer sibling's prefix is not counted as used" failed
✘ Test "An underscore continues an identifier, so a longer sibling does not satisfy the shorter" failed
✘ Test run with 9 tests in 1 suite failed after 0.291 seconds with 2 issues.
```

**`everyStringIsActuallyUsed` stayed GREEN under that mutant, and that is the point.** The issue measured
that zero declarations pass vacuously on the current tree, so the real-tree guard cannot distinguish the two
matchers today — which is exactly why the synthetic control has to exist and why this is the cheapest
possible moment to make the change.

## Scope

`Tier: SMALL | Test: required | Modules: EnviousWisprTests`
`Lane: Code | Class: Drift Guard`

Classification: **REPRODUCIBLE** — the input is the PR #2169 refactor above, not a hypothetical.

No production code changes. Zero declarations change status on the current tree, so this is pure future
protection with no backlog to triage.
