### PR TITLE
build(test): let a caller give xcode-test.sh its own log directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,6 +156,8 @@ scripts/lib/*
 !scripts/lib/spm-seed-lock-test.sh
 !scripts/lib/spm-seed.sh
 !scripts/lib/spm-seed-test.sh
+!scripts/lib/log-dir.sh
+!scripts/lib/log-dir-test.sh
 # #1951: catalog ids are pull targets, so a wrong one ships a dead Download
 # button. Tracked deliberately — a gitignored validator can only be run by
 # someone who remembers it exists, which is how the false green happens.

--- a/scripts/lib/log-dir-test.sh
+++ b/scripts/lib/log-dir-test.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Two-way suite for scripts/lib/log-dir.sh (#2165).
+#
+# The point of the flag is that two lanes can no longer share one log, because
+# `run_lane` SUMS every `Test run with N tests` line it finds. So this asserts
+# BOTH halves: the historical default is unchanged, AND two distinct requests
+# genuinely resolve apart. A flag that resolves everything to the same place
+# would pass a default-only test while fixing nothing.
+#
+# Run: bash scripts/lib/log-dir-test.sh
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/log-dir.sh
+. "$HERE/log-dir.sh"
+
+PASS=0
+FAIL=0
+ROOT="/tmp/ew-fake-worktree"
+
+check() {  # <label> <expected> <actual>
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+    printf "  ok    %-56s %s\n" "$label" "$actual"
+  else
+    FAIL=$((FAIL + 1))
+    printf "  FAIL  %-56s expected %s, got %s\n" "$label" "$expected" "$actual"
+  fi
+}
+
+echo "== the historical default is unchanged =="
+# `build/xcode-test-debug.log` under the worktree is what every existing caller,
+# every rule that names the path, and check-push-discipline's freshness read all
+# expect. If this row moves, something else breaks somewhere nobody is looking.
+check "no request -> <root>/build" "$ROOT/build" "$(ew_resolve_log_dir "$ROOT")"
+check "empty request -> <root>/build" "$ROOT/build" "$(ew_resolve_log_dir "$ROOT" "")"
+
+echo "== an explicit request is honoured =="
+check "absolute stays absolute" "/tmp/rowlog" "$(ew_resolve_log_dir "$ROOT" "/tmp/rowlog")"
+check "relative is worktree-relative, not cwd-relative" \
+  "$ROOT/build/rows/3" "$(ew_resolve_log_dir "$ROOT" "build/rows/3")"
+
+echo "== the whole point: two requests must NOT collide =="
+# This is the row that justifies the flag. #2193 measured a lane total inflated
+# by exactly 13 when a second filtered run wrote the same fixed path, and an
+# earlier incident measured 10806 against a real 5387. A resolver that folded
+# distinct requests together would leave both reachable.
+a=$(ew_resolve_log_dir "$ROOT" "/tmp/row-a")
+b=$(ew_resolve_log_dir "$ROOT" "/tmp/row-b")
+if [ "$a" != "$b" ]; then
+  PASS=$((PASS + 1)); printf "  ok    %-56s %s != %s\n" "two absolute requests resolve apart" "$a" "$b"
+else
+  FAIL=$((FAIL + 1)); printf "  FAIL  %-56s both resolved to %s\n" "two absolute requests resolve apart" "$a"
+fi
+a=$(ew_resolve_log_dir "$ROOT" "build/rows/1")
+b=$(ew_resolve_log_dir "$ROOT" "build/rows/2")
+if [ "$a" != "$b" ]; then
+  PASS=$((PASS + 1)); printf "  ok    %-56s %s != %s\n" "two relative requests resolve apart" "$a" "$b"
+else
+  FAIL=$((FAIL + 1)); printf "  FAIL  %-56s both resolved to %s\n" "two relative requests resolve apart" "$a"
+fi
+# And a request must not collide with the DEFAULT either, or a caller asking for
+# its own directory would silently land back in the shared one.
+d=$(ew_resolve_log_dir "$ROOT")
+r=$(ew_resolve_log_dir "$ROOT" "/tmp/row-a")
+if [ "$d" != "$r" ]; then
+  PASS=$((PASS + 1)); printf "  ok    %-56s\n" "a request does not collide with the default"
+else
+  FAIL=$((FAIL + 1)); printf "  FAIL  %-56s both resolved to %s\n" "a request does not collide with the default" "$d"
+fi
+
+echo "== it refuses rather than guessing =="
+# A resolver that invented a root would put a lane's log somewhere unrelated to
+# the worktree under test, which is the silent direction.
+out=$(ew_resolve_log_dir "" "build" 2>/dev/null)
+rc=$?
+if [ "$rc" -ne 0 ] && [ -z "$out" ]; then
+  PASS=$((PASS + 1)); printf "  ok    %-56s rc=%s\n" "missing project_root is an error, not a guess" "$rc"
+else
+  FAIL=$((FAIL + 1)); printf "  FAIL  %-56s rc=%s out=%s\n" "missing project_root is an error, not a guess" "$rc" "$out"
+fi
+
+echo "== it does not create anything =="
+# Creating the directory here would make the resolver untestable without side
+# effects, and would silently create a tree for a path the caller then rejects.
+probe="/tmp/ew-log-dir-must-not-exist-$$"
+_=$(ew_resolve_log_dir "$ROOT" "$probe")
+if [ ! -e "$probe" ]; then
+  PASS=$((PASS + 1)); printf "  ok    %-56s\n" "resolving does not mkdir"
+else
+  FAIL=$((FAIL + 1)); printf "  FAIL  %-56s %s was created\n" "resolving does not mkdir" "$probe"
+  rmdir "$probe" 2>/dev/null
+fi
+
+echo
+printf "PASS=%d FAIL=%d\n" "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/scripts/lib/log-dir.sh
+++ b/scripts/lib/log-dir.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# scripts/lib/log-dir.sh — resolve where a test lane writes its log (#2165).
+#
+# WHY THIS EXISTS
+# `run_lane` in `scripts/xcode-test.sh` SUMS every `Test run with N tests` line
+# it finds in its log. Two runs sharing one fixed path therefore produce a total
+# that is the sum of both, and the guard beside it rejects only `n < 1` — so it
+# catches an EMPTY run and passes a DOUBLED one, which is the direction nobody
+# checks. Measured twice on this repo: a lane reporting 10806 against a real
+# 5387, and #2193's lane inflated by exactly 13 when a cloud `codex review` ran a
+# filtered suite into the same fixed path at the same time.
+#
+# So a caller that runs many lanes — a mutation battery, a matrix, a review
+# running beside a full lane — needs its own directory, or its counts are not its
+# own.
+#
+# WHY A SEPARATE FILE FOR FIVE LINES
+# Same reason as `ensure-generated.sh`: it makes the rule testable without a
+# build. Resolution inlined in `xcode-test.sh` can only be exercised by running
+# `xcodebuild`, so in practice it would never be tested at all, and a path bug
+# surfaces as a lane writing somewhere nobody reads.
+#
+# CONTRACT
+#   ew_resolve_log_dir <project_root> [requested]
+# Echoes an ABSOLUTE directory path. An empty `requested` yields the historical
+# default, `<project_root>/build`, so every existing invocation is unchanged. A
+# relative `requested` is taken as relative to the project root, never to the
+# caller's cwd — a lane's log belongs to the WORKTREE being tested, and cwd is
+# not a stable identity on a machine running five of them
+# (`tools-and-apps.md` RULE: cwd-is-sticky-never-cd-for-a-one-off).
+# The directory is NOT created here; creating it is the caller's business, and a
+# resolver with a side effect cannot be tested cheaply.
+
+ew_resolve_log_dir() {
+  local project_root="$1" requested="${2:-}"
+
+  if [ -z "$project_root" ]; then
+    echo "ew_resolve_log_dir: project_root is required" >&2
+    return 2
+  fi
+
+  if [ -z "$requested" ]; then
+    printf '%s\n' "$project_root/build"
+    return 0
+  fi
+
+  # Absolute stays absolute. `${x#/}` differs from `$x` exactly when `$x` starts
+  # with a slash, which is the portable test.
+  if [ "${requested#/}" != "$requested" ]; then
+    printf '%s\n' "$requested"
+    return 0
+  fi
+
+  printf '%s\n' "$project_root/$requested"
+}

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -65,9 +65,9 @@ run_lane() {
     VALID_ARCHS=arm64 \\
     ONLY_ACTIVE_ARCH=YES \\
     "$@" \\
-    "${TEST_ARGS[@]}" | tee "$PROJECT_ROOT/$log"
+    "${TEST_ARGS[@]}" | tee "$log"
 }
-run_lane "$DEBUG_SCHEME" Debug build/xcode-test-debug.log
+run_lane "$DEBUG_SCHEME" Debug "$LOG_DIR/xcode-test-debug.log"
 """
 
 # The exact line the two directional drift cases add to or remove from the stub. Derived from the
@@ -241,8 +241,8 @@ check("a canonical lane that no longer generates the project refuses the run",
 check("extra positional build settings on the canonical call site refuse the run",
       [dict(VALID_ROW)], expect_exit=2, expect_text="no longer has",
       extra_files={"scripts/xcode-test.sh": CANONICAL_STUB.replace(
-          'run_lane "$DEBUG_SCHEME" Debug build/xcode-test-debug.log',
-          'run_lane "$DEBUG_SCHEME" Debug build/xcode-test-debug.log ENABLE_TESTABILITY=YES')})
+          'run_lane "$DEBUG_SCHEME" Debug "$LOG_DIR/xcode-test-debug.log"',
+          'run_lane "$DEBUG_SCHEME" Debug "$LOG_DIR/xcode-test-debug.log" ENABLE_TESTABILITY=YES')})
 
 check("an unrecognised shell expansion in the invocation refuses the run",
       [dict(VALID_ROW)], expect_exit=2, expect_text="cannot see",

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -171,7 +171,7 @@ CANONICAL_ASSIGNMENTS = [
     # The WHOLE line, not a prefix: `run_lane "$DEBUG_SCHEME" Debug build/... ENABLE_TESTABILITY=YES`
     # still starts with the prefix, and those trailing positionals reach xcodebuild through `"$@"`,
     # which the expansion allowlist accepts by name without seeing its contents.
-    'run_lane "$DEBUG_SCHEME" Debug build/xcode-test-debug.log\n',
+    'run_lane "$DEBUG_SCHEME" Debug "$LOG_DIR/xcode-test-debug.log"\n',
     'ew_ensure_generated "$PROJECT_ROOT"',
 ]
 # Expansions the runner knows the contents of, because CANONICAL_ASSIGNMENTS pins each one. An

--- a/scripts/xcode-test.sh
+++ b/scripts/xcode-test.sh
@@ -21,6 +21,8 @@ PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 . "$PROJECT_ROOT/scripts/lib/ensure-generated.sh"
 # shellcheck source=scripts/lib/spm-seed.sh
 . "$PROJECT_ROOT/scripts/lib/spm-seed.sh"
+# shellcheck source=scripts/lib/log-dir.sh
+. "$PROJECT_ROOT/scripts/lib/log-dir.sh"
 trap 'ew_seed_release_all' EXIT
 # bash exits on a signal WITHOUT running the EXIT trap, which would strand a
 # seed lock. Converting each signal into a normal exit makes EXIT run.
@@ -34,17 +36,31 @@ RELEASE_SCHEME="EnviousWispr-Release"
 DEST='platform=macOS,arch=arm64'
 FILTER=""
 RUN_RELEASE=0
+# Default keeps every existing invocation byte-identical: `build/` under the
+# worktree, the two filenames unchanged.
+LOG_DIR=""
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --filter) FILTER="${2:?--filter needs a value}"; shift 2 ;;
     --release) RUN_RELEASE=1; shift ;;
-    *) echo "usage: scripts/xcode-test.sh [--filter TEST] [--release]" >&2; exit 2 ;;
+    # #2165: a per-invocation log directory. `run_lane` SUMS every
+    # `Test run with N test` line in its log, so two runs sharing one fixed path
+    # inflate the count — 10806 observed against a real 5387 — and the guard
+    # below rejects only `n < 1`, so it catches an EMPTY run and passes a DOUBLED
+    # one. A caller running many lanes (a mutation battery, a matrix) needs its
+    # own path per row or its counts are not its own.
+    --log-dir) LOG_DIR="${2:?--log-dir needs a value}"; shift 2 ;;
+    *) echo "usage: scripts/xcode-test.sh [--filter TEST] [--release] [--log-dir DIR]" >&2; exit 2 ;;
   esac
 done
 
 cd "$PROJECT_ROOT"
-mkdir -p "$PROJECT_ROOT/build"   # log dir for `tee` below; absent on a clean checkout
+# Owner: scripts/lib/log-dir.sh, which has its own two-way suite. Creating the
+# directory is deliberately the caller's job — a resolver with a side effect
+# cannot be tested without one.
+LOG_DIR="$(ew_resolve_log_dir "$PROJECT_ROOT" "$LOG_DIR")"
+mkdir -p "$LOG_DIR"   # absent on a clean checkout
 
 # Generate the Xcode project (gitignored, never committed) — only when a
 # generation input actually changed (#2157 chunk C).
@@ -71,10 +87,10 @@ run_lane() {  # $1=scheme  $2=config  $3=logfile  $4...=extra build settings
     VALID_ARCHS=arm64 \
     ONLY_ACTIVE_ARCH=YES \
     "$@" \
-    "${TEST_ARGS[@]}" | tee "$PROJECT_ROOT/$log"
+    "${TEST_ARGS[@]}" | tee "$log"
 
   local n
-  n=$(grep -oE "Test run with [0-9]+ test" "$PROJECT_ROOT/$log" | grep -oE "[0-9]+" | awk '{s+=$1} END{print s+0}')
+  n=$(grep -oE "Test run with [0-9]+ test" "$log" | grep -oE "[0-9]+" | awk '{s+=$1} END{print s+0}')
   if [ "$n" -lt 1 ]; then
     echo "ERROR: $config lane executed 0 tests (empty/misconfigured bundle)" >&2
     exit 1
@@ -93,8 +109,8 @@ ew_seed_resolve_or_unseed "$DERIVED_DATA" \
     -scheme "$DEBUG_SCHEME" \
     -derivedDataPath "$DERIVED_DATA"
 
-run_lane "$DEBUG_SCHEME" Debug build/xcode-test-debug.log
+run_lane "$DEBUG_SCHEME" Debug "$LOG_DIR/xcode-test-debug.log"
 ew_seed_publish "$PROJECT_ROOT" "$DERIVED_DATA"
 if [ "$RUN_RELEASE" = "1" ]; then
-  run_lane "$RELEASE_SCHEME" Release build/xcode-test-release.log ENABLE_TESTABILITY=YES
+  run_lane "$RELEASE_SCHEME" Release "$LOG_DIR/xcode-test-release.log" ENABLE_TESTABILITY=YES
 fi


### PR DESCRIPTION
Part of #2165 — the enabling half. **The migration itself is deliberately not here**; what I left out and
why is at the bottom, and the issue carries the measured constraints.

## What this is

`run_lane` SUMS every `Test run with N tests` line it finds in its log, and the guard beside it rejects only
`n < 1`. So it catches an EMPTY run and passes a DOUBLED one, and two runs sharing one fixed path report the
sum of both. Measured twice on this repo: a lane reporting 10806 against a real 5387, and #2193's lane
inflated by exactly 13 when a cloud `codex review` ran a filtered suite into the same path concurrently.

`--log-dir DIR`, defaulting to `build/` with the same two filenames. `run_lane` already took the log as its
third parameter; only the two call sites hardcoded it.

Resolution lives in `scripts/lib/log-dir.sh` for the reason `ensure-generated.sh` gives for itself: inlined,
the rule can only be exercised by running `xcodebuild`, so in practice it would never be tested. The
resolver deliberately does not create the directory — a resolver with a side effect cannot be tested
cheaply.

## Verification

`scripts/lib/log-dir-test.sh` — **9/9**, milliseconds, no build. It asserts BOTH halves, because a flag that
folded everything back to one place would pass a default-only test while fixing nothing:

- the historical default is unchanged (no request, and empty request)
- absolute stays absolute; relative is worktree-relative, never cwd-relative
- **two absolute requests resolve apart, two relative requests resolve apart, and a request does not
  collide with the default** — the rows that justify the flag existing
- a missing project root is an error, not a guess
- resolving does not `mkdir`

Real runs of the modified script:

| invocation | log written | default path |
|---|---|---|
| `--log-dir build/rows/row-01` | `build/rows/row-01/xcode-test-debug.log` | **not written** |
| no flag | `build/xcode-test-debug.log` | as before |

Both `Debug lane executed 6 tests`, exit 0.

`mutation-battery-test.py` — **all 120 cases pass**.

## The drift guard refused this, and that is the interesting part

The one-line change made `mutation-battery.py` refuse:

```
scripts/xcode-test.sh has drifted from what this runner reproduces, so the battery would
measure a differently-configured build than the canonical lane:
  settings the runner expects and the script no longer has:
    - run_lane "$DEBUG_SCHEME" Debug build/xcode-test-debug.log
```

It worked perfectly, named the exact line, and told me to reconcile deliberately rather than delete it. So
it is reconciled — the call site in `CANONICAL_ASSIGNMENTS`, plus three fixtures in
`mutation-battery-test.py`.

**Moving one log path required coordinated edits in three files, none of which was wrong.** That is the
maintenance cost #2165 exists to remove, paid by accident while enabling the fix for it, and it is better
evidence for the issue than anything I could have argued.

## `.gitignore`

`scripts/lib/*` is ignored and every tracked lib carries its own `!scripts/lib/<name>` negation — eight
lines, one per file. Two more added, following that convention exactly. Without them a new lib file is
silently unstageable and could never reach a PR, which is the trap `tools-and-apps.md`
RULE: claude-scripts-absolute-path-from-worktrees already records costing two sessions on #2087.

## What I left out, and why

**The migration — the runner CALLING this script, and the drift guard being DELETED — is not in this PR.**

Not because it is blocked. #2165's stated blocker (#2163) is closed, and its stated ordering concern
("a tool that has not yet run against a real suite once") was retired overnight when the runner was
exercised against nine real suites. Two of the issue's own premises have also been measured out, and both
are written up on the issue: the `tuist generate` half is already solved by `ensure-generated.sh`, and a
per-row seed cost I suspected is not real.

It is left out because of what it is: rewriting how the overnight tool invokes the build, and deleting a
fail-closed guard, in the same change that would also modify the self-test that is the only thing which
would catch a mistake. `session-behavior.md` RULE: overnight-autonomous-bounded says to stop and queue user
review when risk is uncertain, and "I would be editing the instrument and the thing it measures in one
unattended pass" is that case. Scaling the work down is not mine to decide quietly, so it is stated here and
enumerated on the issue rather than dropped.

The issue now carries everything needed to do it in one sitting, including one constraint that would
otherwise have surfaced weeks later as "the battery got slower after we simplified it".
