### PR TITLE
test(sim): the FakeClock signals a real #1868 fix needs (fixes no flake, gates nothing)

### DIFF
--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -4716,8 +4716,9 @@ final class RecordingSessionKernel {
   }
 
   /// Fire `adapter.cancel()` without blocking the caller (best-effort load /
-  /// finalize cancellation, D6). Calls `bump()` at LAUNCH and again after
-  /// `adapter.cancel()` returns.
+  /// finalize cancellation, D6). Calls `bump()` at LAUNCH; the detached task
+  /// calls it again after `adapter.cancel()` returns IF `self` still exists —
+  /// it captures `self` weakly, so the second bump is conditional.
   ///
   /// The launch bump does NOT guarantee the simulator accounts for this work: it
   /// happens before the detached task runs, so a drain starting afterwards can

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -607,9 +607,11 @@ final class RecordingSessionKernel {
   /// direct test reads it (PR-3 plan §3.10).
   private(set) var forbiddenTransitionRejected = false
 
-  /// Monotonic counter bumped on every transition / work resumption. The
-  /// simulator drains kernel work to quiescence by observing this stop
-  /// advancing (PR-3 plan §3.3 — deterministic step ordering).
+  /// Monotonic counter bumped at kernel-defined state and work milestones — the
+  /// sites that call `bump()`, which is the whole of what it observes. The
+  /// simulator samples it as ONE INPUT to a ready-work settling heuristic
+  /// (PR-3 plan §3.3 — deterministic step ordering); it is not a quiescence
+  /// guarantee, and the simulator side documents the limits.
   private(set) var workEpoch: UInt64 = 0
 
   /// The user-visible error category for the concluded session, derived from
@@ -4714,8 +4716,14 @@ final class RecordingSessionKernel {
   }
 
   /// Fire `adapter.cancel()` without blocking the caller (best-effort load /
-  /// finalize cancellation, D6). Bumps `workEpoch` so the simulator's
-  /// quiescence drain accounts for this detached work.
+  /// finalize cancellation, D6). Calls `bump()` at LAUNCH and again after
+  /// `adapter.cancel()` returns.
+  ///
+  /// The launch bump does NOT guarantee the simulator accounts for this work: it
+  /// happens before the detached task runs, so a drain starting afterwards can
+  /// absorb it into its initial sample and see nothing outstanding. That is the
+  /// same bump-absorption shape `hasUnconsumedRecordingExit` exists to gate for
+  /// the recording-exit hand-off.
   private func detachedAdapterCancel() {
     bump()
     Task { @MainActor [weak self] in

--- a/Tests/EnviousWisprASRTests/WhisperKitStreamingSessionTests.swift
+++ b/Tests/EnviousWisprASRTests/WhisperKitStreamingSessionTests.swift
@@ -510,49 +510,12 @@ import Testing
 
     init(loopResult: [TranscriptionResult]) { self.loopResult = loopResult }
 
-    // #2140: ENTRY and EXIT signals the decoder itself fires, so a test parks on
-    // the subject rather than polling or spending a budget. `ranToLimit` is only
-    // final once `transcribe` has RETURNED; reading it before that asserts a
-    // value still being decided, which is what made this suite flake.
-    private var entryWaiters: [CheckedContinuation<Void, Never>] = []
-    private var exitWaiters: [CheckedContinuation<Void, Never>] = []
-    private var hasExited = false
-
-    private func signalEntered() {
-      let waiting = entryWaiters
-      entryWaiters.removeAll()
-      for w in waiting { w.resume() }
-    }
-
-    private func signalExited() {
-      hasExited = true
-      let waiting = exitWaiters
-      exitWaiters.removeAll()
-      for w in waiting { w.resume() }
-    }
-
-    /// Suspends until the loop decode has been entered. Returns immediately if
-    /// it already has, so there is no lost-signal race with a fast decoder.
-    func waitForEntry() async {
-      if entered { return }
-      await withCheckedContinuation { entryWaiters.append($0) }
-    }
-
-    /// Suspends until the loop decode has RETURNED, by any route — abort or
-    /// exhaustion. Only after this is `ranToLimit` a final answer.
-    func waitForExit() async {
-      if hasExited { return }
-      await withCheckedContinuation { exitWaiters.append($0) }
-    }
-
     func transcribe(
       audioArray: [Float], decodeOptions: DecodingOptions?,
       shouldContinueDecoding: (@Sendable () -> Bool)?
     ) async throws -> [TranscriptionResult] {
       entered = true
       wasHandedASignal = shouldContinueDecoding != nil
-      signalEntered()
-      defer { signalExited() }
       guard let keepGoing = shouldContinueDecoding else { return loopResult }
       while polls < Self.limit {
         polls += 1
@@ -580,30 +543,13 @@ import Testing
       requiredSegmentsForConfirmation: 2, cadence: .milliseconds(1))
     await s.start(audioSamplesProvider: fixedProvider([Float](repeating: 0.3, count: 48_000)))
 
-    // #2140: park on the decoder's own ENTRY signal rather than polling. A yield
-    // loop cannot distinguish "not entered yet" from "descheduled", which is the
-    // guessing this suite's flake is made of.
-    await dec.waitForEntry()
+    while !(await dec.entered) { await Task.yield() }
     // CONTROLS, both before the act: the decode really started, and it really was
     // handed a stop signal. Without these, `ranToLimit == false` could mean the
     // decode never ran at all.
     #expect(await dec.wasHandedASignal, "control: the loop decode must receive an abort signal")
 
     await s.cancel()
-
-    // #2140: WAIT FOR THE DECODE TO RETURN before reading `ranToLimit`.
-    //
-    // `ranToLimit` is written only when the loop EXHAUSTS, so reading it while
-    // the decode is still running reads a value that is still being decided —
-    // and it reads `false`, which is a PASS. Locally the cancel wins that race
-    // and the test passes for the right reason; under CI contention the decode
-    // can exhaust first and the test fails, blaming production cancellation for
-    // a budget running out. Parking on the exit signal makes the read final on
-    // every schedule: an abort that is merely LATE still returns via
-    // `!keepGoing()` with `ranToLimit` false, and an abort that never arrives
-    // still exhausts and still fails. The `limit` remains the livelock net it
-    // was always documented to be, rather than the thing the assertion measures.
-    await dec.waitForExit()
 
     #expect(await dec.polls > 0, "control: the decode must have polled before stopping")
     #expect(

--- a/Tests/EnviousWisprASRTests/WhisperKitStreamingSessionTests.swift
+++ b/Tests/EnviousWisprASRTests/WhisperKitStreamingSessionTests.swift
@@ -510,12 +510,49 @@ import Testing
 
     init(loopResult: [TranscriptionResult]) { self.loopResult = loopResult }
 
+    // #2140: ENTRY and EXIT signals the decoder itself fires, so a test parks on
+    // the subject rather than polling or spending a budget. `ranToLimit` is only
+    // final once `transcribe` has RETURNED; reading it before that asserts a
+    // value still being decided, which is what made this suite flake.
+    private var entryWaiters: [CheckedContinuation<Void, Never>] = []
+    private var exitWaiters: [CheckedContinuation<Void, Never>] = []
+    private var hasExited = false
+
+    private func signalEntered() {
+      let waiting = entryWaiters
+      entryWaiters.removeAll()
+      for w in waiting { w.resume() }
+    }
+
+    private func signalExited() {
+      hasExited = true
+      let waiting = exitWaiters
+      exitWaiters.removeAll()
+      for w in waiting { w.resume() }
+    }
+
+    /// Suspends until the loop decode has been entered. Returns immediately if
+    /// it already has, so there is no lost-signal race with a fast decoder.
+    func waitForEntry() async {
+      if entered { return }
+      await withCheckedContinuation { entryWaiters.append($0) }
+    }
+
+    /// Suspends until the loop decode has RETURNED, by any route — abort or
+    /// exhaustion. Only after this is `ranToLimit` a final answer.
+    func waitForExit() async {
+      if hasExited { return }
+      await withCheckedContinuation { exitWaiters.append($0) }
+    }
+
     func transcribe(
       audioArray: [Float], decodeOptions: DecodingOptions?,
       shouldContinueDecoding: (@Sendable () -> Bool)?
     ) async throws -> [TranscriptionResult] {
       entered = true
       wasHandedASignal = shouldContinueDecoding != nil
+      signalEntered()
+      defer { signalExited() }
       guard let keepGoing = shouldContinueDecoding else { return loopResult }
       while polls < Self.limit {
         polls += 1
@@ -543,13 +580,30 @@ import Testing
       requiredSegmentsForConfirmation: 2, cadence: .milliseconds(1))
     await s.start(audioSamplesProvider: fixedProvider([Float](repeating: 0.3, count: 48_000)))
 
-    while !(await dec.entered) { await Task.yield() }
+    // #2140: park on the decoder's own ENTRY signal rather than polling. A yield
+    // loop cannot distinguish "not entered yet" from "descheduled", which is the
+    // guessing this suite's flake is made of.
+    await dec.waitForEntry()
     // CONTROLS, both before the act: the decode really started, and it really was
     // handed a stop signal. Without these, `ranToLimit == false` could mean the
     // decode never ran at all.
     #expect(await dec.wasHandedASignal, "control: the loop decode must receive an abort signal")
 
     await s.cancel()
+
+    // #2140: WAIT FOR THE DECODE TO RETURN before reading `ranToLimit`.
+    //
+    // `ranToLimit` is written only when the loop EXHAUSTS, so reading it while
+    // the decode is still running reads a value that is still being decided —
+    // and it reads `false`, which is a PASS. Locally the cancel wins that race
+    // and the test passes for the right reason; under CI contention the decode
+    // can exhaust first and the test fails, blaming production cancellation for
+    // a budget running out. Parking on the exit signal makes the read final on
+    // every schedule: an abort that is merely LATE still returns via
+    // `!keepGoing()` with `ranToLimit` false, and an abort that never arrives
+    // still exhausts and still fails. The `limit` remains the livelock net it
+    // was always documented to be, rather than the thing the assertion measures.
+    await dec.waitForExit()
 
     #expect(await dec.polls > 0, "control: the decode must have polled before stopping")
     #expect(

--- a/Tests/EnviousWisprTests/Pipeline/KernelEngineHookCallSitesTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelEngineHookCallSitesTests.swift
@@ -347,7 +347,7 @@ struct KernelEngineHookCallSitesTests {
     // Release the cache-warm continuation so preWarm can resume.
     fx.engine.releaseWarmUpFromCacheBlocker()
     _ = await preWarmTask.value
-    // Cancel the in-flight session to settle the kernel.
+    // Cancel the in-flight session, then apply the ready-work heuristic.
     fx.kernel.cancel()
     await fx.wrapper.drainReadyWork()
     // The stale preWarm continuation must not have crashed and must not

--- a/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelTests.swift
@@ -43,7 +43,8 @@ import Testing
       return (context, wrapper)
     }
 
-    /// Drive one trigger and settle the kernel.
+    /// Drive one trigger, then apply the requested ready-work or conclusion wait.
+    /// Neither settles the kernel; both are bounded waits that can give up.
     ///
     /// #1857: pass `concluding: true` for a trigger this caller then asserts a
     /// TERMINAL after. Epoch quiescence is a heuristic — a continuation resumed

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/DrainReadyWorkSettleTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/DrainReadyWorkSettleTests.swift
@@ -144,10 +144,15 @@ struct DrainReadyWorkSettleTests {
   // MARK: - #1857 — the conclusion wait, and its give-up report
 
   /// The fix for `retryRescuedCompletionSurvivesClipboardFallback`: after a
-  /// `stop`, `drainUntilConcluded()` returns only once the kernel has actually
-  /// published a terminal, so a caller's terminal assertions can never read the
-  /// in-flight `nil` that epoch-quiescence alone allowed.
-  @Test("drainUntilConcluded returns only once the kernel has published a terminal")
+  /// `stop`, `drainUntilConcluded()` waits for the kernel to publish a terminal —
+  /// or records a give-up and returns if its cap is exhausted — so a caller's
+  /// terminal assertions no longer read the in-flight `nil` that epoch-quiescence
+  /// alone allowed.
+  ///
+  /// The NAME below said "returns only once", which the cap path makes false. A
+  /// test name is what later readers cite, so it carries the same burden as the
+  /// comment.
+  @Test("drainUntilConcluded waits for a published terminal, or reports giving up")
   func concludedDrainWaitsForTheTerminal() async {
     // `.batchSuccess` concludes on cooperative scheduling alone. A behavior
     // gated on FakeClock ticks (`.slowFinalize`) would violate the documented

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeClock.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeClock.swift
@@ -49,6 +49,33 @@ final class FakeClock {
   /// the non-throwing form, so no cancellation path skips the decrement.
   private(set) var unrunResumedWaiters: Int = 0
 
+  /// Sleepers that have REGISTERED their waiter, counted monotonically — never
+  /// decremented, so it stays a usable signal after a waiter is resumed and
+  /// removed from `waiters`.
+  private(set) var registeredWaiterCount: Int = 0
+
+  private var registrationWaiters: [(needed: Int, continuation: CheckedContinuation<Void, Never>)] = []
+
+  /// Suspends until at least `count` sleepers have registered.
+  ///
+  /// Cloud review, PR #2233: a test that yields once and then advances is
+  /// GUESSING that one hop is enough for a freshly-created sleeper to have run
+  /// to its suspension point. Under contention it is not — `advance(by:)` then
+  /// sees no waiter, resumes nothing, and the sleeper suspends forever. That is
+  /// the exact defect #2143 names, committed inside the tests fixing it. This is
+  /// the registration signal the subject fires, so a caller waits on the event
+  /// rather than on a scheduling assumption.
+  func waitForRegistrations(_ count: Int) async {
+    if registeredWaiterCount >= count { return }
+    await withCheckedContinuation { registrationWaiters.append((count, $0)) }
+  }
+
+  private func releaseRegistrationWaiters() {
+    let ready = registrationWaiters.filter { $0.needed <= registeredWaiterCount }
+    registrationWaiters.removeAll { $0.needed <= registeredWaiterCount }
+    for r in ready { r.continuation.resume() }
+  }
+
   init() {}
 
   /// Advance the logical clock by `ticks`, resuming every waiter whose deadline
@@ -77,6 +104,8 @@ final class FakeClock {
     let deadline = now + UInt64(ticks)
     await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
       waiters.append(Waiter(deadline: deadline) { continuation.resume() })
+      registeredWaiterCount += 1
+      releaseRegistrationWaiters()
     }
     // First line that runs in the RESUMED task, which is what this counter
     // means — not the resume, which only made the task ready.

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeClock.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeClock.swift
@@ -43,9 +43,11 @@ final class FakeClock {
   /// `continuation.resume()` makes a task READY, never running. `advance(by:)`
   /// removes a waiter from `waiters` BEFORE resuming it, so `hasPendingWaiters`
   /// goes false at exactly the wrong moment — the clock reports that nothing is
-  /// waiting while a resumed sleeper has still not executed a line. A resume also
-  /// bumps `kernel.workEpoch`, which a drain absorbs into its initial `last`, so
-  /// epoch-stability does not cover the window either.
+  /// waiting while a resumed sleeper has still not executed a line. Resuming this
+  /// clock continuation does not itself bump `kernel.workEpoch` — `advance(by:)`
+  /// calls `waiter.resume()` and nothing else — so epoch-stability does not cover
+  /// the window either, for the different reason that the window is invisible to
+  /// it rather than absorbed by it.
   ///
   /// So it is a signal a future drain COULD consume, kept because the window is
   /// real and nothing else names it. What it is not is evidence that any window

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeClock.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeClock.swift
@@ -29,17 +29,29 @@ final class FakeClock {
   /// clock moved only on explicit advancement.
   private(set) var explicitAdvanceCount: Int = 0
 
-  /// Waiters whose continuation has been RESUMED but whose task has not yet
-  /// RUN — the signal `drainReadyWork` gates on so it cannot declare quiescence
-  /// across that window (#1868).
+  /// Waiters whose continuation has been RESUMED but whose task has not yet RUN.
   ///
+  /// **NO DRAIN CONSUMES THIS. It is read only by its own tests (#1868).** A gate
+  /// on it was written, measured inert, and removed; the reasoning is at
+  /// `KernelRecordingSession.drainReadyWork`, which gates on
+  /// `kernel.hasUnconsumedRecordingExit` alone. Said first and in full because
+  /// the earlier version of this comment claimed the drain gated on it, and a
+  /// reader investigating A13 would have concluded the resumed-task window was
+  /// already protected.
+  ///
+  /// What it expresses, which nothing else in this clock can:
   /// `continuation.resume()` makes a task READY, never running. `advance(by:)`
   /// removes a waiter from `waiters` BEFORE resuming it, so `hasPendingWaiters`
-  /// goes false at exactly the wrong moment: the clock reports that nothing is
-  /// waiting while a resumed sleeper has still not executed a line. Meanwhile
-  /// the resume already bumped `kernel.workEpoch`, which the drain absorbs into
-  /// its initial `last`, so epoch-stability offers no protection either. This
-  /// counter is the one signal that stays true across the whole window.
+  /// goes false at exactly the wrong moment — the clock reports that nothing is
+  /// waiting while a resumed sleeper has still not executed a line. A resume also
+  /// bumps `kernel.workEpoch`, which a drain absorbs into its initial `last`, so
+  /// epoch-stability does not cover the window either.
+  ///
+  /// So it is a signal a future drain COULD consume, kept because the window is
+  /// real and nothing else names it. What it is not is evidence that any window
+  /// is currently guarded, and A13 in particular is not: that flake is lost
+  /// between `spawn` and the sleep REGISTERING, where this counter reads zero.
+  /// `registeredWaiterCount` below is the signal that window needs.
   ///
   /// Incremented at BOTH resume sites and decremented by the resumed task
   /// itself, on the first line that runs after its `await`. `sleep(ticks:)`

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeClock.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeClock.swift
@@ -29,6 +29,26 @@ final class FakeClock {
   /// clock moved only on explicit advancement.
   private(set) var explicitAdvanceCount: Int = 0
 
+  /// Waiters whose continuation has been RESUMED but whose task has not yet
+  /// RUN — the signal `drainReadyWork` gates on so it cannot declare quiescence
+  /// across that window (#1868).
+  ///
+  /// `continuation.resume()` makes a task READY, never running. `advance(by:)`
+  /// removes a waiter from `waiters` BEFORE resuming it, so `hasPendingWaiters`
+  /// goes false at exactly the wrong moment: the clock reports that nothing is
+  /// waiting while a resumed sleeper has still not executed a line. Meanwhile
+  /// the resume already bumped `kernel.workEpoch`, which the drain absorbs into
+  /// its initial `last`, so epoch-stability offers no protection either. This
+  /// counter is the one signal that stays true across the whole window.
+  ///
+  /// Incremented at BOTH resume sites and decremented by the resumed task
+  /// itself, on the first line that runs after its `await`. `sleep(ticks:)`
+  /// returns before appending for a non-positive `ticks`, so it can never
+  /// decrement without a matching increment; every waiter is resumed exactly
+  /// once because both sites remove before resuming; and the continuation is
+  /// the non-throwing form, so no cancellation path skips the decrement.
+  private(set) var unrunResumedWaiters: Int = 0
+
   init() {}
 
   /// Advance the logical clock by `ticks`, resuming every waiter whose deadline
@@ -40,6 +60,7 @@ final class FakeClock {
       explicitAdvanceCount += 1
       let due = waiters.filter { $0.deadline <= now }
       waiters.removeAll { $0.deadline <= now }
+      unrunResumedWaiters += due.count
       for waiter in due { waiter.resume() }
     }
   }
@@ -57,6 +78,9 @@ final class FakeClock {
     await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
       waiters.append(Waiter(deadline: deadline) { continuation.resume() })
     }
+    // First line that runs in the RESUMED task, which is what this counter
+    // means — not the resume, which only made the task ready.
+    unrunResumedWaiters -= 1
   }
 
   /// `true` while at least one caller is suspended in `sleep(ticks:)`.
@@ -70,6 +94,7 @@ final class FakeClock {
   func drainPending() {
     let pending = waiters
     waiters.removeAll()
+    unrunResumedWaiters += pending.count
     for waiter in pending { waiter.resume() }
   }
 }

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeClockTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeClockTests.swift
@@ -36,8 +36,14 @@ struct FakeClockTests {
       await clock.sleep(ticks: 3)
       woke.value = true
     }
-    await Task.yield()
+    await clock.waitForRegistrations(1)
     clock.advance(by: 2)
+    // Deliberately still a yield: this one proves a NEGATIVE (the sleeper must
+    // NOT have woken), and no registration signal helps — there is no event to
+    // park on when the correct behaviour is that nothing happens. A yield gives
+    // the sleeper an opportunity it must decline. Weaker than the rest of this
+    // suite and knowingly so; binding it needs a "deadline not yet reached"
+    // signal the clock does not have.
     await Task.yield()
     #expect(woke.value == false, "sleeper must not wake before its deadline")
     clock.advance(by: 1)
@@ -60,7 +66,7 @@ struct FakeClockTests {
       await clock.sleep(ticks: 100)
       woke.value = true
     }
-    await Task.yield()
+    await clock.waitForRegistrations(1)
     #expect(clock.hasPendingWaiters == true)
     clock.drainPending()
     await sleeper.value
@@ -83,7 +89,13 @@ struct FakeClockTests {
       await clock.sleep(ticks: 1)
       woke.value = true
     }
-    await Task.yield()
+    // Park on the clock's own REGISTRATION signal, never on a yield count: a
+    // yield assumes one hop is enough for the sleeper to reach its suspension
+    // point, and under contention `advance(by:)` would then see no waiter,
+    // resume nothing, and leave the sleeper suspended forever. Cloud review
+    // caught that guess in this very suite (PR #2233) — the defect #2143 names,
+    // committed inside the tests fixing it.
+    await clock.waitForRegistrations(1)
     #expect(clock.unrunResumedWaiters == 0, "nothing has been resumed yet")
 
     clock.advance(by: 1)
@@ -105,7 +117,7 @@ struct FakeClockTests {
   func drainPendingResumesAreOutstanding() async {
     let clock = FakeClock()
     let sleeper = Task { @MainActor in await clock.sleep(ticks: 100) }
-    await Task.yield()
+    await clock.waitForRegistrations(1)
     clock.drainPending()
     #expect(
       clock.unrunResumedWaiters == 1,
@@ -129,7 +141,7 @@ struct FakeClockTests {
   func manyWaitersAreAllCounted() async {
     let clock = FakeClock()
     let sleepers = (0..<3).map { _ in Task { @MainActor in await clock.sleep(ticks: 1) } }
-    await Task.yield()
+    await clock.waitForRegistrations(3)
     clock.advance(by: 1)
     #expect(clock.unrunResumedWaiters == 3)
     for s in sleepers { await s.value }

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeClockTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeClockTests.swift
@@ -68,6 +68,74 @@ struct FakeClockTests {
     #expect(clock.now == 0, "drainPending must not advance the clock")
   }
 
+  // MARK: - #1868: resumed-but-not-yet-run waiters
+
+  /// The whole point of `unrunResumedWaiters`, and the reason no existing signal
+  /// covers this window: `advance(by:)` REMOVES a waiter from `waiters` before
+  /// resuming it, so `hasPendingWaiters` is already false while the sleeper has
+  /// not executed a line. A drain consulting only that signal declares
+  /// quiescence mid-handoff, which is the #1868 flake.
+  @Test("a resumed sleeper is still outstanding until its task actually runs")
+  func resumedWaiterIsOutstandingUntilItRuns() async {
+    let clock = FakeClock()
+    let woke = WokeFlag()
+    let sleeper = Task { @MainActor in
+      await clock.sleep(ticks: 1)
+      woke.value = true
+    }
+    await Task.yield()
+    #expect(clock.unrunResumedWaiters == 0, "nothing has been resumed yet")
+
+    clock.advance(by: 1)
+    // The resume made the task READY, not running. This is the window.
+    #expect(
+      clock.hasPendingWaiters == false,
+      "control: the old signal has already gone false here, which is the defect")
+    #expect(woke.value == false, "control: the sleeper has not run yet")
+    #expect(
+      clock.unrunResumedWaiters == 1,
+      "a resumed-but-unrun sleeper must still be outstanding")
+
+    await sleeper.value
+    #expect(woke.value == true)
+    #expect(clock.unrunResumedWaiters == 0, "the resumed task cleared it by running")
+  }
+
+  @Test("drainPending's resumes are outstanding until their tasks run")
+  func drainPendingResumesAreOutstanding() async {
+    let clock = FakeClock()
+    let sleeper = Task { @MainActor in await clock.sleep(ticks: 100) }
+    await Task.yield()
+    clock.drainPending()
+    #expect(
+      clock.unrunResumedWaiters == 1,
+      "drainPending resumes too, so it must count the same way advance does")
+    await sleeper.value
+    #expect(clock.unrunResumedWaiters == 0)
+  }
+
+  /// The counter must never go negative, or a drain gated on `== 0` could return
+  /// while work is outstanding. `sleep` returns BEFORE appending a waiter for a
+  /// non-positive tick count, so it must not decrement either.
+  @Test("a non-positive sleep neither increments nor decrements the counter")
+  func nonPositiveSleepIsBalanced() async {
+    let clock = FakeClock()
+    await clock.sleep(ticks: 0)
+    await clock.sleep(ticks: -5)
+    #expect(clock.unrunResumedWaiters == 0)
+  }
+
+  @Test("many waiters resumed by one advance are all counted")
+  func manyWaitersAreAllCounted() async {
+    let clock = FakeClock()
+    let sleepers = (0..<3).map { _ in Task { @MainActor in await clock.sleep(ticks: 1) } }
+    await Task.yield()
+    clock.advance(by: 1)
+    #expect(clock.unrunResumedWaiters == 3)
+    for s in sleepers { await s.value }
+    #expect(clock.unrunResumedWaiters == 0)
+  }
+
   @MainActor
   final class WokeFlag {
     var value = false

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeClockTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeClockTests.swift
@@ -79,8 +79,13 @@ struct FakeClockTests {
   /// The whole point of `unrunResumedWaiters`, and the reason no existing signal
   /// covers this window: `advance(by:)` REMOVES a waiter from `waiters` before
   /// resuming it, so `hasPendingWaiters` is already false while the sleeper has
-  /// not executed a line. A drain consulting only that signal declares
-  /// quiescence mid-handoff, which is the #1868 flake.
+  /// not executed a line. A drain consulting only that signal would declare
+  /// quiescence mid-handoff.
+  ///
+  /// That is a real window and this suite is the only thing that observes it —
+  /// no drain consults this counter. It is deliberately NOT the #1868 flake,
+  /// which an earlier version of this comment claimed: A13 loses its terminal
+  /// between `spawn` and the sleep REGISTERING, where this counter reads zero.
   @Test("a resumed sleeper is still outstanding until its task actually runs")
   func resumedWaiterIsOutstandingUntilItRuns() async {
     let clock = FakeClock()

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
@@ -49,9 +49,13 @@ protocol RecordingSessionDriving: AnyObject {
   /// kernel's real start / stop / cancel / reset / preWarm entry points.
   func apply(_ trigger: SessionTrigger) async
 
-  /// Run every ready async task the SUT spawned to quiescence, so the next
-  /// scenario step observes a settled state (PR-3 plan §3.3 — deterministic
-  /// step ordering against a real FSM). No-op for the synchronous stub.
+  /// Apply the SUT's ready-work SETTLING HEURISTIC before the next scenario step
+  /// (PR-3 plan §3.3 — deterministic step ordering against a real FSM). No-op for
+  /// the synchronous stub.
+  ///
+  /// Deliberately not "run every ready task to quiescence": the kernel
+  /// implementation cannot promise that, and `KernelRecordingSession.drainReadyWork`
+  /// states the actual guarantee and its limits. Do not restate them here.
   func drainReadyWork() async
 
   /// Wait for the SUT's own conclusion signal, then drain (#1868).
@@ -122,7 +126,7 @@ final class StubRecordingSession: RecordingSessionDriving {
 // The PR-3 conformer: a TRIVIAL forwarding/observation wrapper around the real
 // `RecordingSessionKernel` (PR-3 plan §3.3). It MAY forward triggers, map the
 // kernel's state onto `FSMState`, read the kernel's observable surface into
-// `SessionEffects`, and drain the kernel's async work to quiescence. It MUST
+// `SessionEffects`, and apply the kernel's ready-work settling heuristic. It MUST
 // NOT implement session policy — session filtering, terminal-state dedup,
 // cancellation ordering, stale-callback dropping, cleanup, or any latch logic
 // are kernel behaviors asserted AGAINST the kernel. Codex code-diff review
@@ -430,8 +434,10 @@ final class KernelRecordingSession: RecordingSessionDriving {
   }
 
   /// Yield until the kernel's `workEpoch` stops advancing — the FSM has settled
-  /// for everything `workEpoch` covers (the kernel bumps it on every transition,
-  /// task resumption, and progress tick). The 64-yield stability requirement is
+  /// for everything `workEpoch` covers, which is the transitions and progress
+  /// ticks the KERNEL explicitly marks. Not every task resumption: a `FakeClock`
+  /// continuation resume bumps nothing, which is why the clock's own window is
+  /// invisible here rather than absorbed. The 64-yield stability requirement is
   /// margin for a ready kernel task that loses the scheduler lottery to
   /// unrelated parallel tests across several yields under MainActor contention —
   /// not a deadline. The 20000-iteration cap is a safety net against a kernel
@@ -449,12 +455,15 @@ final class KernelRecordingSession: RecordingSessionDriving {
   /// flakes (the recurring `interleavingSweep` `got recording` failure). So gate
   /// the return on the kernel's own hand-off signal: never declare quiescence
   /// while a delivered recording-exit is still unconsumed. The forward path is a
-  /// ready task on a cooperative serial executor, so it cannot be starved
-  /// forever — the signal clears within a bounded number of yields, well under
-  /// the livelock cap.
+  /// ready task on the MainActor; the livelock cap below REPORTS prolonged
+  /// starvation rather than silently reading it as quiescence. An earlier version
+  /// of this note promised the signal clears "well under the livelock cap" — that
+  /// is not something this code can guarantee, and #1857 exists because the cap
+  /// is reachable.
   ///
-  /// Scope: this gate covers the recording-exit hand-off, the only window the
-  /// observed flakes hit (every recurrence was `got recording`). The same
+  /// Scope: this gate covers ONLY the recording-exit hand-off, behind the
+  /// recurring `interleavingSweep` `got recording` failure. It is not the only
+  /// observed window — A13 below is another, and is not covered. The same
   /// bump-absorption shape exists at other continuations resumed inside a step's
   /// `apply` — `FakeClock.advance(by:)` resuming a sleep, a VAD
   /// `AsyncStream.yield` — and neither is gated here.
@@ -470,10 +479,12 @@ final class KernelRecordingSession: RecordingSessionDriving {
   /// `spawn` and the sleep REGISTERING, during which every clock signal reads zero,
   /// including that counter. A gate here cannot see it.
   ///
-  /// So the next signal to reach for depends on the flake: a stale state after an
-  /// `advanceClock` step wants the counter clause added HERE together with a case
-  /// that drives it; A13 itself wants registration tracked, which is a different
-  /// mechanism and is recorded on #1868.
+  /// So the next signal depends on WHICH WINDOW the flake is in, not on which step
+  /// preceded it — A13 is itself a stale-state-after-`advanceClock` failure that
+  /// the counter cannot see, so "it followed an advance" does not pick the fix. A
+  /// case that deliberately opens the resume-to-run window wants the counter
+  /// clause added HERE; A13 wants registration tracked, a different mechanism,
+  /// recorded on #1868.
   func drainReadyWork() async {
     var last = kernel.workEpoch
     var stable = 0

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
@@ -439,11 +439,13 @@ final class KernelRecordingSession: RecordingSessionDriving {
   /// the FSM has settled — an earlier version of this line said "has settled" and
   /// that is the claim this whole comment exists to retract.
   ///
-  /// Nor is the covered set enumerable here: `bump()` has many call sites and a
-  /// list written into a comment drifts the first time one is added. What IS true
-  /// by construction is the boundary — it observes what calls `bump()` and nothing
-  /// else. A `FakeClock` continuation resume calls nothing, so the clock's window
-  /// is invisible here rather than absorbed. The 64-yield stability requirement is
+  /// Do not enumerate the covered set here. It IS enumerable — `bump()`'s call
+  /// sites are findable — but a list copied into a comment needs manual
+  /// synchronisation the first time one moves, and nothing enforces that. What is
+  /// true by construction is the boundary: this observes what calls `bump()` and
+  /// nothing else. A `FakeClock` continuation resume does call its continuation,
+  /// and does NOT call `bump()`, so the clock's window is invisible here rather
+  /// than absorbed. The 64-yield stability requirement is
   /// margin for a ready kernel task that loses the scheduler lottery to
   /// unrelated parallel tests across several yields under MainActor contention —
   /// not a deadline. The 20000-iteration cap is a safety net against a kernel
@@ -514,9 +516,9 @@ final class KernelRecordingSession: RecordingSessionDriving {
     Issue.record(Self.giveUpMessage(kernel: kernel, what: "drainReadyWork", reached: "quiescence"))
   }
 
-  /// Yield until the kernel PUBLISHES a terminal, then drain the remaining ready
-  /// work. #1857: `drainReadyWork` is a quiescence heuristic, not a terminal
-  /// wait. A continuation resumed synchronously inside the triggering step is
+  /// Wait for the kernel to PUBLISH a terminal, then apply the ready-work
+  /// heuristic. On cap exhaustion it records a give-up and returns instead.
+  /// #1857: `drainReadyWork` is a quiescence heuristic, not a terminal wait. A continuation resumed synchronously inside the triggering step is
   /// absorbed into the drain's initial `workEpoch` (the same bump-absorption
   /// shape `hasUnconsumedRecordingExit` gates for the recording-exit hand-off),
   /// so under full-suite MainActor contention the drain can return while the

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
@@ -182,6 +182,8 @@ final class DeadMicTelemetryLog {
 final class KernelRecordingSession: RecordingSessionDriving {
   private let kernel: RecordingSessionKernel
   private let vad: FakeVADSignalSource
+  /// Held so `drainReadyWork` can gate on `unrunResumedWaiters` (#1868).
+  private let clock: FakeClock
   private let limb = LimbInjectionBox()
 
   /// The wrapped kernel — exposed only so the direct FSM-invariant tests can
@@ -271,6 +273,7 @@ final class KernelRecordingSession: RecordingSessionDriving {
     onTerminalSnapshot: @escaping @MainActor (KernelTerminalTelemetrySnapshot) -> Void = { _ in }
   ) {
     self.vad = vad
+    self.clock = clock
     let limb = self.limb
     let telemetryState = self.telemetryState
     let stopTimeTelemetryLog = self.stopTimeTelemetryLog
@@ -453,13 +456,22 @@ final class KernelRecordingSession: RecordingSessionDriving {
   /// forever — the signal clears within a bounded number of yields, well under
   /// the livelock cap.
   ///
-  /// Scope: this gate addresses the recording-exit hand-off, the only window the
-  /// observed flakes hit (every recurrence was `got recording`). The same
-  /// bump-absorption shape exists in principle at other continuations resumed
-  /// inside a step's `apply` — `FakeClock.advance(by:)` resuming a `slowLoad` /
-  /// `slowFinalize` sleep, a VAD `AsyncStream.yield` — but none has manifested.
-  /// If a future flake reports a stale `transcribing` / `warmingUp` after an
-  /// `advanceClock` or VAD step, those are the next signals to gate the same way.
+  /// Scope: this gate began as the recording-exit hand-off, the only window the
+  /// flakes observed at the time hit (every recurrence was `got recording`). The
+  /// same bump-absorption shape exists at other continuations resumed inside a
+  /// step's `apply`, and this comment used to say none of them had manifested.
+  ///
+  /// **One since has, exactly where this note predicted it: `FakeClock.advance(by:)`
+  /// resuming a sleep (#1868, scenario A13 losing its wedge terminal to a later
+  /// cancel).** It is gated here on `clock.unrunResumedWaiters`, for the reason no
+  /// existing clock signal could serve: `advance(by:)` REMOVES a waiter from
+  /// `waiters` before resuming it, so `hasPendingWaiters` is already false while
+  /// the sleeper has not executed a line — the one signal a caller would reach for
+  /// goes false at precisely the wrong moment.
+  ///
+  /// The VAD `AsyncStream.yield` continuation is the remaining ungated case and
+  /// has still not manifested. If a future flake reports a stale state after a VAD
+  /// step, that is the next signal to gate the same way.
   func drainReadyWork() async {
     var last = kernel.workEpoch
     var stable = 0
@@ -474,7 +486,11 @@ final class KernelRecordingSession: RecordingSessionDriving {
         stable = 0
         last = now
       }
-      if stable >= 64, !kernel.hasUnconsumedRecordingExit { return }
+      if stable >= 64, !kernel.hasUnconsumedRecordingExit,
+        clock.unrunResumedWaiters == 0
+      {
+        return
+      }
     }
     // #1857: exhausting the livelock net is NOT quiescence. Returning silently
     // made a give-up indistinguishable from a settle, so the caller's terminal

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
@@ -182,8 +182,6 @@ final class DeadMicTelemetryLog {
 final class KernelRecordingSession: RecordingSessionDriving {
   private let kernel: RecordingSessionKernel
   private let vad: FakeVADSignalSource
-  /// Held so `drainReadyWork` can gate on `unrunResumedWaiters` (#1868).
-  private let clock: FakeClock
   private let limb = LimbInjectionBox()
 
   /// The wrapped kernel — exposed only so the direct FSM-invariant tests can
@@ -273,7 +271,6 @@ final class KernelRecordingSession: RecordingSessionDriving {
     onTerminalSnapshot: @escaping @MainActor (KernelTerminalTelemetrySnapshot) -> Void = { _ in }
   ) {
     self.vad = vad
-    self.clock = clock
     let limb = self.limb
     let telemetryState = self.telemetryState
     let stopTimeTelemetryLog = self.stopTimeTelemetryLog
@@ -456,22 +453,27 @@ final class KernelRecordingSession: RecordingSessionDriving {
   /// forever — the signal clears within a bounded number of yields, well under
   /// the livelock cap.
   ///
-  /// Scope: this gate began as the recording-exit hand-off, the only window the
-  /// flakes observed at the time hit (every recurrence was `got recording`). The
-  /// same bump-absorption shape exists at other continuations resumed inside a
-  /// step's `apply`, and this comment used to say none of them had manifested.
+  /// Scope: this gate covers the recording-exit hand-off, the only window the
+  /// observed flakes hit (every recurrence was `got recording`). The same
+  /// bump-absorption shape exists at other continuations resumed inside a step's
+  /// `apply` — `FakeClock.advance(by:)` resuming a sleep, a VAD
+  /// `AsyncStream.yield` — and neither is gated here.
   ///
-  /// **One since has, exactly where this note predicted it: `FakeClock.advance(by:)`
-  /// resuming a sleep (#1868, scenario A13 losing its wedge terminal to a later
-  /// cancel).** It is gated here on `clock.unrunResumedWaiters`, for the reason no
-  /// existing clock signal could serve: `advance(by:)` REMOVES a waiter from
-  /// `waiters` before resuming it, so `hasPendingWaiters` is already false while
-  /// the sleeper has not executed a line — the one signal a caller would reach for
-  /// goes false at precisely the wrong moment.
+  /// #1868 examined the clock one and deliberately left it OUT, which is worth
+  /// recording because the obvious reading of that issue is that it belongs here.
+  /// Two measurements say otherwise. `FakeClock.unrunResumedWaiters` exists and is
+  /// the signal such a gate would consult — `advance(by:)` removes a waiter before
+  /// resuming it, so `hasPendingWaiters` goes false while the sleeper has not run a
+  /// line — but adding the clause here was measured INERT: no case opens the
+  /// resume-to-run window on purpose, so mutating the clause away reddens nothing.
+  /// And A13 does not lose its terminal in that window at all. It loses it between
+  /// `spawn` and the sleep REGISTERING, during which every clock signal reads zero,
+  /// including that counter. A gate here cannot see it.
   ///
-  /// The VAD `AsyncStream.yield` continuation is the remaining ungated case and
-  /// has still not manifested. If a future flake reports a stale state after a VAD
-  /// step, that is the next signal to gate the same way.
+  /// So the next signal to reach for depends on the flake: a stale state after an
+  /// `advanceClock` step wants the counter clause added HERE together with a case
+  /// that drives it; A13 itself wants registration tracked, which is a different
+  /// mechanism and is recorded on #1868.
   func drainReadyWork() async {
     var last = kernel.workEpoch
     var stable = 0
@@ -486,11 +488,7 @@ final class KernelRecordingSession: RecordingSessionDriving {
         stable = 0
         last = now
       }
-      if stable >= 64, !kernel.hasUnconsumedRecordingExit,
-        clock.unrunResumedWaiters == 0
-      {
-        return
-      }
+      if stable >= 64, !kernel.hasUnconsumedRecordingExit { return }
     }
     // #1857: exhausting the livelock net is NOT quiescence. Returning silently
     // made a give-up indistinguishable from a settle, so the caller's terminal

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
@@ -54,8 +54,9 @@ protocol RecordingSessionDriving: AnyObject {
   /// the synchronous stub.
   ///
   /// Deliberately not "run every ready task to quiescence": the kernel
-  /// implementation cannot promise that, and `KernelRecordingSession.drainReadyWork`
-  /// states the actual guarantee and its limits. Do not restate them here.
+  /// implementation cannot promise that. See `KernelRecordingSession.drainReadyWork`
+  /// for the heuristic and its known limits. Named, not summarised — a pointer that
+  /// lists what its target says is a claim about the target.
   func drainReadyWork() async
 
   /// Wait for the SUT's own conclusion signal, then drain (#1868).
@@ -433,11 +434,16 @@ final class KernelRecordingSession: RecordingSessionDriving {
     limb.processTextThrows = true
   }
 
-  /// Yield until the kernel's `workEpoch` stops advancing — the FSM has settled
-  /// for everything `workEpoch` covers, which is the transitions and progress
-  /// ticks the KERNEL explicitly marks. Not every task resumption: a `FakeClock`
-  /// continuation resume bumps nothing, which is why the clock's own window is
-  /// invisible here rather than absorbed. The 64-yield stability requirement is
+  /// Watch `workEpoch` for 64 consecutive unchanged samples. This is a SETTLING
+  /// HEURISTIC over the kernel events that explicitly call `bump()`, never proof
+  /// the FSM has settled — an earlier version of this line said "has settled" and
+  /// that is the claim this whole comment exists to retract.
+  ///
+  /// Nor is the covered set enumerable here: `bump()` has many call sites and a
+  /// list written into a comment drifts the first time one is added. What IS true
+  /// by construction is the boundary — it observes what calls `bump()` and nothing
+  /// else. A `FakeClock` continuation resume calls nothing, so the clock's window
+  /// is invisible here rather than absorbed. The 64-yield stability requirement is
   /// margin for a ready kernel task that loses the scheduler lottery to
   /// unrelated parallel tests across several yields under MainActor contention —
   /// not a deadline. The 20000-iteration cap is a safety net against a kernel

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioRunner.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioRunner.swift
@@ -57,8 +57,9 @@ struct ScenarioRunner {
     // zeroTick contract). Checking before this drain was tried and rejected
     // in PR-3: it strands every `zeroTick`-swept clock-gated scenario in a
     // non-terminal state. `vad.finish()` closes the signal stream so the
-    // kernel's VAD-subscription task exits; the conclusion-aware branch below is
-    // what lets released forward-path work reach a terminal when one is expected.
+    // kernel's VAD-subscription task exits; when a terminal is expected, the
+    // conclusion-aware branch below WAITS for its publication before checking it.
+    // It waits; it does not make the forward path reach a terminal.
     context.clock.drainPending()
     context.vad.finish()
     // #1868: `drainReadyWork` is a QUIESCENCE heuristic, not a completion

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioRunner.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioRunner.swift
@@ -42,8 +42,9 @@ struct ScenarioRunner {
 
     for (index, step) in scenario.steps.enumerated() {
       await apply(step, context: context, stepIndex: index, into: &failures)
-      // Drain the SUT's ready async work to quiescence so the next step
-      // observes a settled FSM (PR-3 plan §3.3). No-op for the stub.
+      // Apply the SUT's ready-work settling heuristic before the next step
+      // (PR-3 plan §3.3). NOT proof every ready task has run — see the #1868 note
+      // below and `KernelRecordingSession.drainReadyWork`. No-op for the stub.
       await context.sut.drainReadyWork()
     }
 
@@ -56,8 +57,8 @@ struct ScenarioRunner {
     // zeroTick contract). Checking before this drain was tried and rejected
     // in PR-3: it strands every `zeroTick`-swept clock-gated scenario in a
     // non-terminal state. `vad.finish()` closes the signal stream so the
-    // kernel's VAD-subscription task exits; the final `drainReadyWork()` lets
-    // the released forward-path work run to its terminal state.
+    // kernel's VAD-subscription task exits; the conclusion-aware branch below is
+    // what lets released forward-path work reach a terminal when one is expected.
     context.clock.drainPending()
     context.vad.finish()
     // #1868: `drainReadyWork` is a QUIESCENCE heuristic, not a completion

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioRunner.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioRunner.swift
@@ -58,8 +58,9 @@ struct ScenarioRunner {
     // in PR-3: it strands every `zeroTick`-swept clock-gated scenario in a
     // non-terminal state. `vad.finish()` closes the signal stream so the
     // kernel's VAD-subscription task exits; when a terminal is expected, the
-    // conclusion-aware branch below WAITS for its publication before checking it.
-    // It waits; it does not make the forward path reach a terminal.
+    // conclusion-aware branch below waits for publication, or records a give-up
+    // and returns once its cap is exhausted. It waits; it does not make the
+    // forward path reach a terminal.
     context.clock.drainPending()
     context.vad.finish()
     // #1868: `drainReadyWork` is a QUIESCENCE heuristic, not a completion
@@ -158,7 +159,7 @@ struct ScenarioRunner {
     case .expectState(let expected):
       // #1857: a MID-scenario terminal expectation is the same assertion the
       // teardown check makes, so it needs the same wait. The preceding step's
-      // per-step `drainReadyWork()` is epoch quiescence — a continuation resumed
+      // per-step `drainReadyWork()` is an epoch-stability heuristic — a resumed
       // synchronously inside that step is absorbed into the drain's initial
       // `workEpoch`, so under contention this check can read the in-flight state
       // and report a stuck session on a healthy kernel. That is the historical


### PR DESCRIPTION
**This lands `FakeClock`'s missing signals, five removed registration races, and a swept class of false prose — including two claims in shipping code. It fixes no flake, gates nothing, and closes no issue.** #1868, #2140 and #2143 all stay open.

Six review rounds — four cloud, two local and grounded — plus two measurements cut this down from its original claim. **Every one of the six found the same class: prose asserting a mechanism covers a case.** The removed parts are the interesting half; round five enumerated the class instead of folding it, and round six proved that enumeration had both traded a claim and stopped at the wrong boundary.

`222 insertions, 28 deletions across 5 files; 140 of the 227 added lines are comments.` Two of those files' changes are in `Sources/EnviousWisprPipeline/RecordingSessionKernel.swift` and are comment-only — proved mechanically, not by reading: the patch parses `git diff --unified=0` for that file and refuses if any changed line is not a `///` line. A comment is the one artifact with no compiler, no test and no runtime, which is why this ratio took six rounds rather than one.

## What ships

**1. `FakeClock.unrunResumedWaiters`** — incremented at both resume sites, decremented by the resumed task itself on the first line after its `await`.

`continuation.resume()` makes a task **READY, not running**, and `advance(by:)` removes a waiter from `waiters` *before* resuming it. So `hasPendingWaiters` goes false while the sleeper has not executed a line — the signal a caller would naturally reach for goes false at exactly the wrong moment. Nothing in the harness could previously express "resumed but not yet run".

**No drain consumes it.** It is read only by its own tests. That is stated first in its own doc comment, before any of the mechanism, because the earlier version claimed the opposite.

**Balance**, since an unbalanced counter would spin a drain to its livelock cap: `sleep` returns before appending for non-positive `ticks`; both resume sites remove before resuming; the continuation is the non-throwing form, so no cancellation path skips the decrement.

**2. `FakeClock.waitForRegistrations(_:)`** plus a monotonic `registeredWaiterCount` — monotonic so it stays readable after a waiter is resumed and removed. This is the signal A13 will actually need.

**3. Five registration races removed from `FakeClockTests`** — three from this PR's own first draft, two **pre-existing**. Each was one `Task.yield()` assumed sufficient for a freshly-created MainActor sleeper to register. Under contention `advance(by:)` sees no waiter and `await sleeper.value` suspends **forever** — worse than a flake, because a hang carries no failure message.

**4. Fourteen corrected prose sites** — nine from the class sweep, five from the round that checked it. Both below.

## The class, enumerated rather than folded

Round 5 returned six more members after round 4 returned the fourth. Folding one at a time is what rounds 1-4 did, so this round swept instead: **every comment in `Tests/EnviousWisprTests/Pipeline/Simulator/` naming the drain, quiescence, or `workEpoch` — 33 lines across 6 files.**

**The sweep produced a finding no single round could see: five of those lines ALREADY state the truth** — *"a quiescence heuristic, not a completion signal"* — added by the #1857 and #1868 work. The overstatements they contradict were never removed. **The file has been arguing with itself**, and each review round picked off whichever side it happened to read.

Two were **factually false**, not merely loose:

| site | claim | reality |
|---|---|---|
| `FakeClock.swift` | resuming a clock continuation bumps `kernel.workEpoch` | `advance(by:)` calls `waiter.resume()` and nothing else; the only bumps are in `RecordingSessionKernel` |
| `RecordingSessionDriving.swift` | the kernel bumps `workEpoch` on "every transition, task resumption, and progress tick" | same false claim — and it is *why* the clock window is invisible to epoch-stability rather than absorbed by it |

**I inherited the first.** It sat in the sentence rewritten one commit earlier: the false half was carried forward while the other half was being corrected, inside the change whose whole subject is comments that claim mechanisms.

Four **overstated a guarantee**: the protocol requirement and the wrapper contract both promised "to quiescence"; the hand-off note promised the signal clears "well under the livelock cap", which this code cannot guarantee and #1857 exists because the cap is reachable; the runner's per-step comment promised the next step "observes a settled FSM".

Two were **mine, from the previous commit**: *"the only window the observed flakes hit"* is contradicted by the A13 paragraph directly beneath it, and the routing advice keyed off the preceding STEP when A13 is itself a stale-state-after-`advanceClock` failure the counter cannot see — so it would have sent the next reader to the wrong fix.

One **misattributed** terminal completion to the drain; the conclusion-aware branch supplies it.

## What was cut, and what cut it

### The `drainReadyWork` gate — REMOVED, two independent reasons

**Measured inert.** Pre-registered on #2231 before the run as *"expect SURVIVED, and that is the point"*. Removing the clause reddened **nothing**, exit 0. No case opens the resume-to-run window on purpose.

**And it closes the wrong window.** Round 3:

> the finalize-progress consumer can spawn `detectFinalizeWedge` while that task has not yet entered `clock.sleep`; during this interval `unrunResumedWaiters` is still zero, so this drain can accumulate 64 stable yields and return.

Confirmed — `RecordingSessionKernel.swift:3251` spawns, and the sleep registers inside `detectFinalizeWedge`. Between those, **every clock signal reads zero.**

`drainReadyWork` has **152 call sites across 22 test files**. An inert gate that widely shared first fires in someone else's run, on someone else's change, with no case naming it.

### The #2140 fix — ATTEMPTED, MEASURED VACUOUS, REVERTED

Not in this PR. Same mutant, two arms — delete `loopDecodeAborted.withLock { $0 = true }` from `cancel()` **only**:

| test version | result |
|---|---|
| pre-existing, at `0301b1c4` | **CAUGHT** — exit 65 |
| my fixed version | **SURVIVED** — 29/29 green, exit 0 |

The test that has been flaking for weeks **binds** that production line. Mine did not. **A flaky-but-binding test turned into a stable-and-vacuous one is strictly worse** — the flake at least failed honestly some of the time.

Three green results were in hand and every one is consistent with a vacuous test. The survivor even had an innocent explanation available (three call sites set that flag — the documented redundancy case). **What settled it was running the same mutant against the ORIGINAL test.** A fourth reason a mutant survives, now in the rules: *your change removed the binding.*

## Evidence

| check | result |
|---|---|
| `FakeClockTests` | 9/9 |
| `ScenarioRunnerTests` | 7/7 |
| `DrainReadyWorkSettleTests` | 5/5 |
| `KernelInputResolutionFreezeTests` | 8/8 |
| `SalvageLadderStaleSessionTimingTests` | 2/2 |
| dev build, `EnviousWispr-Dev` | **BUILD SUCCEEDED**, 0 errors |
| mutation control: make the counter mean *resumed* rather than *resumed-but-not-yet-run* | **RED on 3 tests**, exit 65, restore byte-identical by `cmp` |
| backticked identifiers in added lines resolving to non-comment code | 23/23 |
| `RecordingSessionKernel.swift` diff is comment-only | asserted mechanically by the patch |

The mutation control is the one that matters: it fails with `(clock.unrunResumedWaiters → 0) == 1`. That arrow **is** the READY-versus-RUNNING distinction, so the tests bind the counter's *meaning*. Three tests reddening together corroborates it — they reach the counter by three different routes.

The class patch **fails closed** on all eight retired sentences and on losing either canonical statement; the round-6 patch does the same for its five.

## Round 6 — the confirming pass, which found both things it was asked to look for

The sweep above was itself a change, so it got a confirming round rather than a victory lap. It was asked four questions: did the fix introduce a new false claim, is the class actually closed, is the sweep boundary defensible, and did anything true get deleted. It was told plainly that CLOSED and NONE were acceptable answers.

**It traded a claim.** The corrected drain doc kept *"the FSM has settled"* — the exact verb being removed from four other sites — and then narrowed coverage to *"the transitions and progress ticks the KERNEL explicitly marks"*. There are **21 `bump()` call sites**, so that enumeration was both wrong and the kind that drifts the moment one is added. Replaced with the boundary, which is true by construction: it observes what calls `bump()` and nothing else. Nothing to go stale.

**And the boundary was wrong** — the more useful half. The sweep scoped to the test directory. Two contradictions live in `Sources/EnviousWisprPipeline/RecordingSessionKernel.swift`:

| site | claim | reality |
|---|---|---|
| `workEpoch`'s own doc | "the simulator drains kernel work to quiescence by observing this stop advancing" | the identical falsehood the sweep removed from the test side, on the ship path |
| `detachedAdapterCancel` | "Bumps `workEpoch` so the simulator's quiescence drain accounts for this detached work" | `bump()` runs at **launch**, before the detached task body — a drain starting afterwards absorbs it into its initial sample and accounts for nothing |

The second is not loose wording. It is a guarantee **contradicted by where the call sits**, and it names the simulator as the thing that makes the guarantee true. It is this file's own documented bump-absorption defect, written up as a promise.

Also corrected: a pointer that **enumerated** what its target states — a claim about the target, and false while the target still promised settlement — and the runner comment saying the conclusion-aware branch *"lets released forward-path work reach a terminal"*, when it **waits** for publication rather than causing it.

Section D returned **NOTHING LOST**, citing by line that the recording-exit hand-off, the livelock reporting and bump-absorption all survive.

`#2231` holds the frozen recipes: 1-3 target `FakeClock.swift` and remain live; recipe 4 targeted the removed gate and is moot. `scripts/mutation-battery.py` cannot run any of them — both subjects are under `Tests/` and the runner allow-lists `Sources/`. Raised on #2224.

## What this does not establish

**No run can prove either flake fixed.** Both reproduce on a hosted runner under full-suite contention and pass locally, so a green lane is equally consistent with a fix working and with the flake not firing. This PR does not claim one. Suite greens show **no regression** and nothing stronger.

## Still open, deliberately

**#1868** keeps the A13 mechanism and the fork it faces. **#2140** keeps the vacuity diagnosis. **#2143** keeps the remaining exposure — three `while !(await dec.loopEntered)` polls at other call sites, and an inventory of 69 test files waiting on time or scheduling.
