### PR TITLE
fix(release-notes): v2.4.5's headline note rendered EMPTY and --self-test passed

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
@@ -34,17 +34,7 @@ enum WhatsNewContent {
       icon: "waveform.badge.exclamationmark",
       title: "Dictation holds up in a noisy room",
       description:
-        """
-        A fan, an engine, an air conditioner or a plane cabin used to make EnviousWispr \
-        lose your words, most often the ones you started with. What came back read \
-        perfectly and was missing the beginning, which is the worst way for it to be \
-        wrong. The part of the app that decides where you were speaking now ignores the \
-        low rumble those rooms produce, so your sentence survives them. Nothing about \
-        your recording or the audio being transcribed changed, and quiet rooms behave \
-        exactly as before. If you use auto-stop, expect its timing to move in a noisy \
-        room: it usually stops much sooner than it used to, and on the half-second \
-        setting it can now wait longer or not stop on its own at all.
-        """,
+        "A fan, an engine, an air conditioner or a plane cabin used to make EnviousWispr lose your words, most often the ones you started with. What came back read perfectly and was missing the beginning, which is the worst way for it to be wrong. The part of the app that decides where you were speaking now ignores the low rumble those rooms produce, so your sentence survives them. Nothing about your recording or the audio being transcribed changed, and quiet rooms behave exactly as before. If you use auto-stop, expect its timing to move in a noisy room: it usually stops much sooner than it used to, and on the half-second setting it can now wait longer or not stop on its own at all.",
       version: "2.4.5"
     ),
 

--- a/scripts/ci/render-release-notes.py
+++ b/scripts/ci/render-release-notes.py
@@ -130,6 +130,37 @@ def main():
                 file=sys.stderr,
             )
             return 2
+        # PER-ENTRY completeness, not just per-VERSION presence (#2234).
+        #
+        # The count check above catches an entry that DISAPPEARS. It cannot catch one
+        # that quietly EMPTIES: a field this parser cannot read still matches the
+        # regex with a zero-length capture, so the entry parses, the count is right,
+        # and the description is gone. Measured on v2.4.5, whose headline entry was
+        # written as a multiline `"""` literal and rendered as a bare title — while
+        # BOTH existing assertions passed, because sibling entries in the same
+        # version rendered and made the body non-empty.
+        #
+        # Deliberately an OUTCOME check rather than a syntax allow-list. The
+        # protocol's list of prohibited forms has now been wrong twice about which
+        # forms exist (concatenation, then multiline), and a fourth prohibition would
+        # be one more clause on a partial check. "No entry renders empty" holds
+        # whatever syntax the next author reaches for.
+        empty = [
+            f"{e['version']}: {e['title'][:60] or '(no title)'}"
+            for e in entries
+            if not e["desc"].strip() or not e["title"].strip()
+        ]
+        if empty:
+            print(
+                "error: %d entr%s parsed with an empty title or description — the "
+                "field is present in the source but this parser could not read it "
+                "(a multiline, concatenated, interpolated or raw literal). Rewrite it "
+                "as a single direct double-quoted literal:\n  %s"
+                % (len(empty), "y" if len(empty) == 1 else "ies", "\n  ".join(empty)),
+                file=sys.stderr,
+            )
+            return 2
+
         cv = current_content_version()
         if not cv:
             print("error: could not read currentContentVersion", file=sys.stderr)

--- a/scripts/ci/render-release-notes.py
+++ b/scripts/ci/render-release-notes.py
@@ -88,6 +88,35 @@ def render(entries, version):
     return rendered or None
 
 
+def empty_fields(entries):
+    """Entries whose title or description parsed EMPTY, as `version: title` strings.
+
+    A field this parser cannot read still MATCHES its regex with a zero-length capture,
+    so the entry parses, the count check is satisfied, and the text is gone. Measured on
+    v2.4.5 (#2234), whose headline entry was a multiline literal and rendered as a bare
+    title while both existing assertions passed.
+
+    An OUTCOME check rather than a syntax allow-list: the protocol's list of prohibited
+    forms has been wrong twice about which forms exist, and "no entry renders empty"
+    holds whatever syntax the next author reaches for.
+    """
+    return [
+        f"{e['version']}: {e['title'][:60] or '(no title)'}"
+        for e in entries
+        if not e["desc"].strip() or not e["title"].strip()
+    ]
+
+
+def empty_fields_message(empty):
+    return (
+        "error: %d entr%s parsed with an empty title or description — the field is "
+        "present in the source but this parser could not read it (a multiline, "
+        "concatenated, interpolated or raw literal). Rewrite it as a single direct "
+        "double-quoted literal:\n  %s"
+        % (len(empty), "y" if len(empty) == 1 else "ies", "\n  ".join(empty))
+    )
+
+
 def current_content_version():
     try:
         with open(CONSTANTS_SWIFT, encoding="utf-8") as fh:
@@ -131,34 +160,12 @@ def main():
             )
             return 2
         # PER-ENTRY completeness, not just per-VERSION presence (#2234).
-        #
-        # The count check above catches an entry that DISAPPEARS. It cannot catch one
-        # that quietly EMPTIES: a field this parser cannot read still matches the
-        # regex with a zero-length capture, so the entry parses, the count is right,
-        # and the description is gone. Measured on v2.4.5, whose headline entry was
-        # written as a multiline `"""` literal and rendered as a bare title — while
-        # BOTH existing assertions passed, because sibling entries in the same
-        # version rendered and made the body non-empty.
-        #
-        # Deliberately an OUTCOME check rather than a syntax allow-list. The
-        # protocol's list of prohibited forms has now been wrong twice about which
-        # forms exist (concatenation, then multiline), and a fourth prohibition would
-        # be one more clause on a partial check. "No entry renders empty" holds
-        # whatever syntax the next author reaches for.
-        empty = [
-            f"{e['version']}: {e['title'][:60] or '(no title)'}"
-            for e in entries
-            if not e["desc"].strip() or not e["title"].strip()
-        ]
+        # Shared with the RENDER path below — cloud review r1 P2: this check only
+        # protected `--self-test`, which runs weekly, while the release workflow
+        # invokes `--version`, which would still have emitted a bare-title bullet.
+        empty = empty_fields(entries)
         if empty:
-            print(
-                "error: %d entr%s parsed with an empty title or description — the "
-                "field is present in the source but this parser could not read it "
-                "(a multiline, concatenated, interpolated or raw literal). Rewrite it "
-                "as a single direct double-quoted literal:\n  %s"
-                % (len(empty), "y" if len(empty) == 1 else "ies", "\n  ".join(empty)),
-                file=sys.stderr,
-            )
+            print(empty_fields_message(empty), file=sys.stderr)
             return 2
 
         cv = current_content_version()
@@ -181,6 +188,27 @@ def main():
 
     if not args.version:
         print("error: --version is required", file=sys.stderr)
+        return 2
+
+    # The SAME completeness check on the PUBLISH path, not only in `--self-test`
+    # (cloud review r1 P2 on PR #2235). `--self-test` runs weekly via
+    # `ci-drift-check`; `.github/workflows/release.yml` renders with `--version`,
+    # so a guard living only in the self-test would let a bare-title bullet ship
+    # for up to a week — which is exactly how #2234 reached a release branch.
+    #
+    # FAILING HERE IS THE SAFE DIRECTION, and the workflow is already built for
+    # it: that step is `continue-on-error: true` and its own comment says the
+    # publish job "falls back to GitHub's auto-generated notes, so this step can
+    # never block a release or ship it with a blank body". So a refusal costs an
+    # auto-generated note plus a `::warning::`, where the alternative is
+    # publishing a headline with no text under it.
+    #
+    # Scoped to the entries being RENDERED: an unrelated older entry that has
+    # rotted must not block today's release.
+    for_version = [e for e in entries if e["version"] == args.version]
+    empty = empty_fields(for_version)
+    if empty:
+        print(empty_fields_message(empty), file=sys.stderr)
         return 2
 
     body = render(entries, args.version)


### PR DESCRIPTION
v2.4.5's **headline** release note renders as a bare title with no description, and `--self-test` prints `self-test OK`. v2.4.5 is not published yet, so this is caught before it ships.

## What it looks like on main

```
$ python3 scripts/ci/render-release-notes.py --version 2.4.5
- **Dictation holds up in a noisy room.**
- **Live Preview settings now show what is ready.** The Live Preview page now tells you at a glance …
- **EG-1 is better at changes of mind and spoken lists.** The built-in AI cleanup model has been …
```

Title, full stop, nothing. Every sibling renders in full.

## Cause — a FOURTH prohibited form the protocol does not list

`WhatsNewContent.swift` had exactly one entry written as a multiline `"""` literal — the v2.4.5 headline (#2184). The generator reads Swift source TEXT:

```python
description:\s*\n?\s*"((?:[^"\\]|\\.)*)"
```

Against `"""` this matches the first quote, captures **zero characters** (the next character is a quote, which the class excludes), and closes on the second. The description parses as the empty string.

`whats-new-protocol.md` prohibits "raw strings, interpolation, named constants, or concatenation". A multiline literal is **none of those four**, so nothing told the author it was forbidden — and it is the form the file actually used.

## Why both existing protections passed

| protection | why it passed |
|---|---|
| entry COUNT vs `version:` fields | the entry parses — all three fields match — so the count is right |
| non-empty BODY for `currentContentVersion` | the other v2.4.5 entries render, so the body is non-empty |

**Both measure PRESENCE where the property that matters is COMPLETENESS.** An entry that disappears is caught; one that quietly empties is not.

## The change

**1. Content.** That description is now a single-line double-quoted literal, matching every sibling.

**The compiled value is unchanged, verified with the Swift compiler rather than by derivation.** I had hand-derived what Swift does with `"""` plus backslash continuations, but a derivation is a simulation. So the ORIGINAL block was taken straight from `git show HEAD:`, the NEW literal from the working tree, both compiled side by side and compared:

```
IDENTICAL — 682 characters
```

The in-app What's New screen is provably unaffected; only the generator's view of the source changes.

**2. Guard.** `--self-test` now fails if any parsed entry has an empty title or description, naming the version and title.

### Why an outcome check and not a fourth syntax prohibition

The protocol's forbidden-forms list has now been wrong **twice** about which forms exist — concatenation (#2105), then multiline. A fourth clause is one more clause on a partial check, which `validation-discipline.md` RULE: a-partial-check-looks-exactly-like-a-complete-one says to stop adding. **"No entry renders empty" holds whatever syntax the next author reaches for.**

`whats-new-protocol.md` FACT: whats-new-feeds-github-release-notes already said *"Compare PARSED VALUES with expected strings, never counts alone"*. The guidance was right; nothing enforced it.

## Two-way control

Both arms run with the old script's relative paths resolving correctly — the first attempt ran it from a scratchpad, where it failed for an unrelated missing-`Constants.swift` reason, and was redone.

| arm | result |
|---|---|
| **old** self-test, broken content | **exit 0** — `self-test OK: 125 entries parsed (matches source); 2.4.5 renders 4 item(s)` |
| the note that arm would publish | `- **Dictation holds up in a noisy room.** ` — nothing after it |
| **new** self-test, broken content | **exit 2** — names `2.4.5: Dictation holds up in a noisy room` |
| **new** self-test, fixed content | **exit 0** |

`self-test OK` printed while the headline note is an empty bullet is the whole issue in one line.

## Measured: what every prohibited form actually does

Rather than assert the guard's reach, each form was substituted into the real entry and run through the real generator:

| form | `--self-test` | rendered description |
|---|---|---|
| single-line literal (correct) | PASSES | full text |
| **multiline triple-quote** | **FAILS(2)** — this PR's new guard | `''` |
| **concatenation** | **PASSES** | `'A fan, an engine, an air conditioner'` — truncated |
| **interpolation** | **PASSES** | `'A fan, an engine \(productName) loses your words'` |
| raw string `#"…"#` | FAILS(2) — existing count check | entry absent |
| named constant | FAILS(2) — existing count check | entry absent |

**Two forms still publish a wrong note while every check passes**, and this PR closes only one of them. Stating that here so the guard is not read as complete:

- **concatenation** truncates; #2105 owns that one;
- **interpolation** emits **unresolved Swift into a public GitHub release note**. `whats-new-protocol.md` already predicts this (*"interpolation can emit unresolved Swift"*) and nothing enforces it.

That interpolation row is new information, and it is arguably the worst of the three: truncation loses text, an empty description loses a note, and interpolation *publishes source syntax to users*. Added to #2105, which owns the remaining forms.

The matrix is also the argument for that issue's preferred fix over any further prohibition: **comparing PARSED against COMPILED collapses all six rows into one check**, because in every failing row the parsed value differs from the compiled one.

## Scope

**#2105 stays open** — it owns the TRUNCATING form and this PR does not address it. A concatenated description parses non-empty and shortened, so this guard cannot see it. That issue's preferred fix — compare PARSED values against COMPILED ones — subsumes both forms, and is the right place for it.

Closes #2234
