### PR TITLE
docs(test): scope userInitiatedCancelDoesNotRecordDecline's comment to what it proves

### DIFF
--- a/Tests/EnviousWisprTests/LLM/EGOneRevisionUpgradeTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneRevisionUpgradeTests.swift
@@ -623,8 +623,19 @@ import Testing
     #expect(probe.ensureCount == 0, "a removed model stays removed, with its bytes still present")
   }
 
-  /// The multi-producer distinction. A download the USER started and then cancelled must not
-  /// switch off the automatic path — the settings row's own Cancel reaches the same hook.
+  /// The multi-producer distinction, for the case this test actually stages: a cancel arriving
+  /// with NOTHING in flight. The settings row's own Cancel reaches the same hook as ours, so a
+  /// cancel that is not attributable to us must not switch off the automatic path.
+  ///
+  /// **SCOPE — the NAME is broader than the coverage, and than the code (#2110).** A cancel of a
+  /// download the user started while the coordinator has JOINED it does still write a decline:
+  /// `ModelDeliveryController` single-flights, so `ensureCurrentModel()` joins the user's fetch
+  /// while `automaticUpgradeInFlightCount` is positive, and `.cancel` reads that counter. This
+  /// test does not reach that case and passes today either way. The plan carries the same
+  /// correction (issue-2096 §3.2, amended 2026-08-16); this comment is its twin, and the twin was
+  /// missed. Do not read a green run here as evidence for the joined case, and do not write that
+  /// case against today's behaviour — #2110 has two candidate designs and the test belongs with
+  /// whichever lands.
   @MainActor
   @Test func userInitiatedCancelDoesNotRecordDecline() async throws {
     let root = try makeRoot()


### PR DESCRIPTION
Comment only. No behaviour, no assertions, no test names changed. 28/28 green on `EGOneRevisionUpgradeTests`.

## The finding

#2110's Notes ask that the repo not assert something the code does not do. **The plan half was done; its twin was missed.**

`docs/feature-requests/issue-2096-2026-08-16-eg2-model-launch.md:247` is correctly amended — it scopes the guarantee, cites #2110, names both candidate designs, explains why returning start-vs-join from the fetch door cannot work, and **retains the original claim visibly** rather than editing it away. Nothing there needs doing.

`Tests/EnviousWisprTests/LLM/EGOneRevisionUpgradeTests.swift:626` still carried the **unscoped** sentence:

```swift
/// The multi-producer distinction. A download the USER started and then cancelled must not
/// switch off the automatic path — the settings row's own Cancel reaches the same hook.
@Test func userInitiatedCancelDoesNotRecordDecline() async throws {
```

That is the exact claim the plan amended, and it is false when the coordinator has **joined** the user's download: `ModelDeliveryController` single-flights, so `ensureCurrentModel()` joins the user's fetch while `automaticUpgradeInFlightCount` is positive, and `.cancel` reads that counter.

## Why this one is worth a commit

The test's **body** and its **assertion message** are both already correct:

```swift
#expect(
  !FileManager.default.fileExists(atPath: declineMarker(root).path),
  "no automatic upgrade was in flight, so this cancel says nothing about the model")
```

So a reader asking *"is the user-started-cancel case covered?"* gets **two yeses — the name and the comment — before reaching the one accurate line.** That is worse than a test that is simply wrong. `grounding-discipline.md` RULE: never-hand-a-reviewer-an-unchecked-premise ranks it highest-cost because it retires the check rather than failing it.

It is also the missed-twin shape from `workflow-process.md` RULE: self-review-and-grep-before-codex — *"Name the TWIN of every site you change… and fix both in one edit."*

## Two judgements recorded rather than made silently

**The test NAME is left alone.** It overclaims too, but renaming churns every inventory that lists it, and the comment carries the correction more precisely than a name can.

**The joined-cancel test is NOT added, deliberately.** #2110 says it depends on which of its two designs lands, and a test written against today's behaviour would look like coverage while actually **pinning the defect**. The new comment says so explicitly, so the next reader does not write it by reflex.

## Scope check

`cancelDuringAutomaticUpgradeRecordsDecline`, immediately below, is correctly scoped in both its comment and its body — it says *"a cancel arriving WHILE our own upgrade is running"*, which is exactly what it stages. So this is one comment, not a pattern in the file.

Part of #2110, which stays open for the fix itself.
