### PR TITLE
docs(custom-words): mark the four UNPRODUCED notice cases, and say what live means

### DIFF
--- a/Sources/EnviousWisprCore/CustomWordsImportContract.swift
+++ b/Sources/EnviousWisprCore/CustomWordsImportContract.swift
@@ -15,13 +15,20 @@ import Foundation
 /// below and shares that case's status exactly. No connector returns it and no screen
 /// renders it, because the shared enrichment stage (PR-P1) does not exist.
 ///
-/// **MEASURE IT WITH A WORD BOUNDARY AND WITHOUT COMMENT LINES. Both filters are
-/// load-bearing, and the contrast between the two numbers IS the evidence:**
+/// **MEASURE IT WITH `-w` AND WITHOUT COMMENT LINES. Both filters are load-bearing, and
+/// the contrast between the two numbers IS the evidence:**
 ///
-///     BOUND='AppleIntelligenceAvailability\([^R]\|$\)'
-///     /usr/bin/grep -rn "$BOUND" Sources/ Tests/ | /usr/bin/grep -v '///'    ->  2
-///     /usr/bin/grep -rn AppleIntelligenceAvailability Sources/ Tests/ \
+///     /usr/bin/grep -rnw AppleIntelligenceAvailability Sources/ Tests/ \
+///       | /usr/bin/grep -v '///'                                             ->  2
+///     /usr/bin/grep -rn  AppleIntelligenceAvailability Sources/ Tests/ \
 ///       | /usr/bin/grep -v '///'                                             -> 25
+///
+/// **`-w`, not a hand-rolled `[^R]` class.** An earlier revision excluded the neighbour by
+/// its first LETTER, which is a rule about the one sibling that exists today. A future
+/// sibling named AppleIntelligenceAvailabilityStatus (deliberately unbackticked: no such
+/// type exists) satisfies `[^R]` and would have been counted as this type, silently
+/// breaking the number above. Measured both ways on a probe line — the hand-rolled class
+/// matches it, `-w` does not.
 ///
 /// The 2 are this declaration and that payload. The other 23 are
 /// `AppleIntelligenceAvailabilityReport`, a different and live type — see below.

--- a/Sources/EnviousWisprCore/CustomWordsImportContract.swift
+++ b/Sources/EnviousWisprCore/CustomWordsImportContract.swift
@@ -109,16 +109,28 @@ package struct CustomWordsImportCandidate: Identifiable, Sendable, Hashable {
 }
 
 /// One notices side-channel for a batch — never a second `warnings` field.
+/// **DECLARED-BUT-UNPRODUCED CASES ARE MARKED. Read the marker before wiring into one (#2048).**
+///
+/// Four of the five cases below describe an enrichment stage that was never built. Their comments
+/// used to assert, in the present tense, that a producer existed — so a reader adding a sixth case
+/// followed them and wired into nothing. `grounding-discipline.md`
+/// RULE: never-hand-a-reviewer-an-unchecked-premise ranks that shape highest-cost because it
+/// retires the check rather than failing it.
+///
+/// `incompatibleSourceEntriesExcluded` is the one that works, and it is the template: produced in
+/// `SmartImportSource`, consumed in `CustomWordsImportFlowModel`, covered by
+/// `SmartImportSourceTests`. A case is live when all three exist.
 package enum CustomWordsImportNotice: Sendable, Equatable {
-  /// Produced by the shared enrichment stage (PR-P1) in the Paste and Upload flows.
+  /// **UNPRODUCED.** Designed for the shared enrichment stage (PR-P1) in the Paste and Upload
+  /// flows; that stage does not exist, and nothing constructs this case.
   case appleIntelligenceUnavailable(AppleIntelligenceAvailability)
-  /// Produced by the shared enrichment stage (PR-P1).
+  /// **UNPRODUCED.** Designed for the shared enrichment stage (PR-P1), which does not exist.
   case suggestionsPartiallyUnavailable(count: Int)
-  /// Produced by the shared enrichment stage when the per-import
-  /// suggestion-call budget is exhausted; `remainingCount` = candidates that
-  /// proceeded without suggestions.
+  /// **UNPRODUCED.** Designed for the shared enrichment stage, for when the per-import
+  /// suggestion-call budget is exhausted; `remainingCount` = candidates that would have proceeded
+  /// without suggestions. That stage does not exist.
   case suggestionBudgetReached(remainingCount: Int)
-  /// Upload-only row-level parse warning.
+  /// **UNPRODUCED.** Designed as an Upload-only row-level parse warning; no parser emits it.
   case fileParseWarning(rowNumber: Int, reason: String)
   /// Smart Import: the source held entries and EVERY one was deliberately
   /// refused — Juno's built-in seed vocabulary, Spokenly's regex rules,

--- a/Sources/EnviousWisprCore/CustomWordsImportContract.swift
+++ b/Sources/EnviousWisprCore/CustomWordsImportContract.swift
@@ -10,9 +10,21 @@ import Foundation
 // Core, and LLM / PostProcessing / AppKit all need these types too.
 
 /// Core-level Apple Intelligence availability value for the import flow.
-/// PR-P1's connector check returns this; the import UI says so honestly when
-/// it is unavailable (unlike AI Polish, whose silent skip is deliberate —
-/// nobody asked polish for suggestions, but an importing user did).
+///
+/// **UNPRODUCED AND UNCONSUMED.** It is the payload of `.appleIntelligenceUnavailable`
+/// below and shares that case's status exactly: `/usr/bin/grep -rn` for this type across
+/// `Sources/` and `Tests/` returns TWO hits, this declaration and that payload. No
+/// connector returns it and no screen renders it, because the shared enrichment stage
+/// (PR-P1) does not exist.
+///
+/// The DESIGN INTENT is why it is not deleted: when enrichment cannot run the import UI
+/// should say so, unlike AI Polish, whose silent skip is deliberate — nobody asked polish
+/// for suggestions, but an importing user did. That describes what PR-P1 should build, not
+/// what any code does today.
+///
+/// **Do not confuse it with `AppleIntelligenceAvailabilityReport`**, which is a different,
+/// live type in AppKit with its own coordinator, persistence and settings surface. A sweep
+/// for the shorter name matches the longer one and reports this as thoroughly used.
 package enum AppleIntelligenceAvailability: Sendable, Equatable {
   case available
   case unavailable(reason: AIFailureReason, message: String)
@@ -42,8 +54,22 @@ package struct CustomWordsImportCandidate: Identifiable, Sendable, Hashable {
   package let id: UUID
   package var canonical: String
   package var aliases: CustomWordsImportField<[String]>
-  /// AI-enrichment output (PR-P1). NEVER authoritative: applied only on Add,
-  /// never on Replace, so a machine guess cannot overwrite hand-tuned aliases.
+  /// Enrichment output (PR-P1), and a THIRD status distinct from both the live and the
+  /// unproduced cases in this file: **never populated by any import source, yet fully
+  /// consumed and tested.** The commit path persists it on Add
+  /// (`CustomWordsManager.swift:1237`), the compare engine unions it across duplicate rows,
+  /// `allImportableStrings` validates it, and `suggestedAliasesNeverApplyOnReplace` covers
+  /// the Replace rule. Every shipped source leaves it empty and three suites assert that.
+  /// So the plumbing is real and only the producer is missing — unlike the notice cases
+  /// below, where nothing exists at all.
+  ///
+  /// **A NAME SWEEP SAYS OTHERWISE, so check the TYPE.** `WordSuggestions.suggestedAliases`
+  /// in `WordSuggestionService` is a different field on a different type, it is live, and it
+  /// feeds the single-word edit sheet. Most hits for this name are that one, which is what
+  /// makes "something produces this" the natural and wrong reading.
+  ///
+  /// NEVER authoritative: applied only on Add, never on Replace, so a machine guess cannot
+  /// overwrite hand-tuned aliases.
   package var suggestedAliases: [String]
   package var category: CustomWordsImportField<WordCategory>
   package var priority: CustomWordsImportField<Int>

--- a/Sources/EnviousWisprCore/CustomWordsImportContract.swift
+++ b/Sources/EnviousWisprCore/CustomWordsImportContract.swift
@@ -58,8 +58,8 @@ package struct CustomWordsImportCandidate: Identifiable, Sendable, Hashable {
   /// unproduced cases in this file: **never populated by any import source, yet fully
   /// consumed and tested.** The commit path persists it on Add
   /// (`CustomWordsManager.swift:1237`), the compare engine unions it across duplicate rows,
-  /// `allImportableStrings` validates it, and `suggestedAliasesNeverApplyOnReplace` covers
-  /// the Replace rule. Every shipped source leaves it empty and three suites assert that.
+  /// `validated()` reaches it by walking `storedValues` rather than naming fields, and
+  /// `suggestedAliasesNeverApplyOnReplace` covers the Replace rule. Every shipped source leaves it empty and three suites assert that.
   /// So the plumbing is real and only the producer is missing — unlike the notice cases
   /// below, where nothing exists at all.
   ///

--- a/Sources/EnviousWisprCore/CustomWordsImportContract.swift
+++ b/Sources/EnviousWisprCore/CustomWordsImportContract.swift
@@ -29,11 +29,14 @@ import Foundation
 /// **BOTH FILTERS WERE PAID FOR, and the second one is the interesting half.** An earlier
 /// revision claimed 2 while publishing the UNBOUNDED command, so anyone checking the claim
 /// got a much larger number and a reason to disbelieve it. Publishing the bounded command
-/// then made that command return 4, and re-measuring the unbounded one moved it from 27 to
-/// 30 — because writing a command into a comment adds occurrences of the string it counts.
+/// then changed what that command returned, because writing a command into a comment adds
+/// occurrences of the string it counts, and each later revision moved it again.
 /// **A comment that publishes a measurement of the file it lives in perturbs that
-/// measurement by existing, and each revision perturbs it again.** Only a comment-excluded
-/// count is stable enough to write down; publish that, or publish no number.
+/// measurement by existing.** Only a comment-excluded count is stable enough to write
+/// down; publish that, or publish no number. The intermediate readings are deliberately
+/// not quoted here — they are exactly the unreproducible numbers this paragraph warns
+/// against, and a reader who tried to reproduce one would be checking a file that no
+/// longer exists.
 ///
 /// The DESIGN INTENT is why it is not deleted: when enrichment cannot run the import UI
 /// should say so, unlike AI Polish, whose silent skip is deliberate — nobody asked polish
@@ -43,7 +46,7 @@ import Foundation
 /// **Do not confuse it with `AppleIntelligenceAvailabilityReport`**, which is a different,
 /// live type in AppKit with its own coordinator, persistence and settings surface. A sweep
 /// for the shorter name matches the longer one and reports this as thoroughly used, which
-/// is why the boundary above is not pedantry: it is the difference between 2 and 27.
+/// is why the boundary above is not pedantry: it is the difference between 2 and 25.
 package enum AppleIntelligenceAvailability: Sendable, Equatable {
   case available
   case unavailable(reason: AIFailureReason, message: String)

--- a/Sources/EnviousWisprCore/CustomWordsImportContract.swift
+++ b/Sources/EnviousWisprCore/CustomWordsImportContract.swift
@@ -12,10 +12,28 @@ import Foundation
 /// Core-level Apple Intelligence availability value for the import flow.
 ///
 /// **UNPRODUCED AND UNCONSUMED.** It is the payload of `.appleIntelligenceUnavailable`
-/// below and shares that case's status exactly: `/usr/bin/grep -rn` for this type across
-/// `Sources/` and `Tests/` returns TWO hits, this declaration and that payload. No
-/// connector returns it and no screen renders it, because the shared enrichment stage
-/// (PR-P1) does not exist.
+/// below and shares that case's status exactly. No connector returns it and no screen
+/// renders it, because the shared enrichment stage (PR-P1) does not exist.
+///
+/// **MEASURE IT WITH A WORD BOUNDARY AND WITHOUT COMMENT LINES. Both filters are
+/// load-bearing, and the contrast between the two numbers IS the evidence:**
+///
+///     BOUND='AppleIntelligenceAvailability\([^R]\|$\)'
+///     /usr/bin/grep -rn "$BOUND" Sources/ Tests/ | /usr/bin/grep -v '///'    ->  2
+///     /usr/bin/grep -rn AppleIntelligenceAvailability Sources/ Tests/ \
+///       | /usr/bin/grep -v '///'                                             -> 25
+///
+/// The 2 are this declaration and that payload. The other 23 are
+/// `AppleIntelligenceAvailabilityReport`, a different and live type — see below.
+///
+/// **BOTH FILTERS WERE PAID FOR, and the second one is the interesting half.** An earlier
+/// revision claimed 2 while publishing the UNBOUNDED command, so anyone checking the claim
+/// got a much larger number and a reason to disbelieve it. Publishing the bounded command
+/// then made that command return 4, and re-measuring the unbounded one moved it from 27 to
+/// 30 — because writing a command into a comment adds occurrences of the string it counts.
+/// **A comment that publishes a measurement of the file it lives in perturbs that
+/// measurement by existing, and each revision perturbs it again.** Only a comment-excluded
+/// count is stable enough to write down; publish that, or publish no number.
 ///
 /// The DESIGN INTENT is why it is not deleted: when enrichment cannot run the import UI
 /// should say so, unlike AI Polish, whose silent skip is deliberate — nobody asked polish
@@ -24,7 +42,8 @@ import Foundation
 ///
 /// **Do not confuse it with `AppleIntelligenceAvailabilityReport`**, which is a different,
 /// live type in AppKit with its own coordinator, persistence and settings surface. A sweep
-/// for the shorter name matches the longer one and reports this as thoroughly used.
+/// for the shorter name matches the longer one and reports this as thoroughly used, which
+/// is why the boundary above is not pedantry: it is the difference between 2 and 27.
 package enum AppleIntelligenceAvailability: Sendable, Equatable {
   case available
   case unavailable(reason: AIFailureReason, message: String)

--- a/Sources/EnviousWisprCore/CustomWordsImportContract.swift
+++ b/Sources/EnviousWisprCore/CustomWordsImportContract.swift
@@ -11,62 +11,24 @@ import Foundation
 
 /// Core-level Apple Intelligence availability value for the import flow.
 ///
-/// **UNPRODUCED AND UNCONSUMED.** It is the payload of `.appleIntelligenceUnavailable`
-/// below and shares that case's status exactly. No connector returns it and no screen
-/// renders it, because the shared enrichment stage (PR-P1) does not exist.
+/// **UNPRODUCED AND UNCONSUMED**, the same status as its only case
+/// `.appleIntelligenceUnavailable` below: it is that case's payload and nothing else. No
+/// connector returns it and no screen renders it, because the shared enrichment stage
+/// (PR-P1) does not exist. To check, apply the live-case test stated at
+/// `CustomWordsImportNotice` — produced, consumed, tested — and look for all three.
 ///
-/// **MEASURE IT WITH `-w` AND WITHOUT COMMENT LINES. Both filters are load-bearing, and
-/// the contrast between the two numbers IS the evidence:**
-///
-///     NOCOMMENT=':[0-9]+: *(//|\*)'
-///     /usr/bin/grep -rnw AppleIntelligenceAvailability Sources/ Tests/ \
-///       | /usr/bin/grep -vE "$NOCOMMENT"                                     ->  2
-///     /usr/bin/grep -rn  AppleIntelligenceAvailability Sources/ Tests/ \
-///       | /usr/bin/grep -vE "$NOCOMMENT"                                     -> 25
-///
-/// **WHAT THAT FILTER DOES AND DOES NOT DO, because an earlier revision published
-/// `grep -v '///'` and called the result comment-free.** It drops a line whose first
-/// non-space character is `//` or `*`, so doc comments, ordinary comments and the interior
-/// of a conventionally-formatted block comment all go. It does NOT drop a TRAILING comment
-/// on a line of code, and it does not parse Swift. Both counts are the same under either
-/// filter today because no such line exists; the difference is that the earlier one
-/// happened to be right and described itself wrongly.
-///
-/// **`-w`, not a hand-rolled `[^R]` class.** An earlier revision excluded the neighbour by
-/// its first LETTER, which is a rule about the one sibling that exists today. A future
-/// sibling named AppleIntelligenceAvailabilityStatus (deliberately unbackticked: no such
-/// type exists) satisfies `[^R]` and would have been counted as this type, silently
-/// breaking the number above. Measured both ways on a probe line — the hand-rolled class
-/// matches it, `-w` does not.
-///
-/// The 2 are this declaration and that payload. The other 23 are
-/// `AppleIntelligenceAvailabilityReport`, a different and live type — see below.
-///
-/// **BOTH FILTERS WERE PAID FOR, and the second one is the interesting half.** An earlier
-/// revision claimed 2 while publishing the UNBOUNDED command, so anyone checking the claim
-/// got a much larger number and a reason to disbelieve it. Publishing the bounded command
-/// then changed what that command returned, because writing a command into a comment adds
-/// occurrences of the string it counts, and each later revision moved it again.
-/// **A comment that publishes a measurement of the file it lives in perturbs that
-/// measurement by existing.** Only a comment-excluded count is stable enough to write
-/// down; publish that, or publish no number. The intermediate readings are deliberately
-/// not quoted here — they are exactly the unreproducible numbers this paragraph warns
-/// against, and a reader who tried to reproduce one would be checking a file that no
-/// longer exists.
+/// **Do not confuse it with `AppleIntelligenceAvailabilityReport`**, a different and fully
+/// live type declared in THIS SAME MODULE at `AppleIntelligenceDiagnostics.swift:159` and
+/// consumed by AppKit, Services, LLM and Core. **Same module is what makes the confusion
+/// likely rather than remote** — nothing about where you are reading tells you which of the
+/// two you have, and a search for the shorter name matches the longer one, so an unanchored
+/// sweep reports this dead type as thoroughly used. Search with a word boundary.
 ///
 /// The DESIGN INTENT is why it is not deleted: when enrichment cannot run the import UI
 /// should say so, unlike AI Polish, whose silent skip is deliberate — nobody asked polish
 /// for suggestions, but an importing user did. That describes what PR-P1 should build, not
 /// what any code does today.
 ///
-/// **Do not confuse it with `AppleIntelligenceAvailabilityReport`**, a different and fully
-/// live type declared in THIS SAME MODULE at `AppleIntelligenceDiagnostics.swift:159` and
-/// consumed across four (AppKit's coordinator and settings surface, Services, LLM, Core).
-/// **Same module is what makes the confusion likely rather than remote** — the dead type
-/// and the live one sit in the same target, so nothing about where you are reading tells
-/// you which you have. A sweep for the shorter name matches the longer one and reports this
-/// one as thoroughly used, which is why the boundary above is not pedantry: it is the
-/// difference between 2 and 25.
 package enum AppleIntelligenceAvailability: Sendable, Equatable {
   case available
   case unavailable(reason: AIFailureReason, message: String)

--- a/Sources/EnviousWisprCore/CustomWordsImportContract.swift
+++ b/Sources/EnviousWisprCore/CustomWordsImportContract.swift
@@ -43,10 +43,14 @@ import Foundation
 /// for suggestions, but an importing user did. That describes what PR-P1 should build, not
 /// what any code does today.
 ///
-/// **Do not confuse it with `AppleIntelligenceAvailabilityReport`**, which is a different,
-/// live type in AppKit with its own coordinator, persistence and settings surface. A sweep
-/// for the shorter name matches the longer one and reports this as thoroughly used, which
-/// is why the boundary above is not pedantry: it is the difference between 2 and 25.
+/// **Do not confuse it with `AppleIntelligenceAvailabilityReport`**, a different and fully
+/// live type declared in THIS SAME MODULE at `AppleIntelligenceDiagnostics.swift:159` and
+/// consumed across four (AppKit's coordinator and settings surface, Services, LLM, Core).
+/// **Same module is what makes the confusion likely rather than remote** — the dead type
+/// and the live one sit in the same target, so nothing about where you are reading tells
+/// you which you have. A sweep for the shorter name matches the longer one and reports this
+/// one as thoroughly used, which is why the boundary above is not pedantry: it is the
+/// difference between 2 and 25.
 package enum AppleIntelligenceAvailability: Sendable, Equatable {
   case available
   case unavailable(reason: AIFailureReason, message: String)

--- a/Sources/EnviousWisprCore/CustomWordsImportContract.swift
+++ b/Sources/EnviousWisprCore/CustomWordsImportContract.swift
@@ -18,10 +18,19 @@ import Foundation
 /// **MEASURE IT WITH `-w` AND WITHOUT COMMENT LINES. Both filters are load-bearing, and
 /// the contrast between the two numbers IS the evidence:**
 ///
+///     NOCOMMENT=':[0-9]+: *(//|\*)'
 ///     /usr/bin/grep -rnw AppleIntelligenceAvailability Sources/ Tests/ \
-///       | /usr/bin/grep -v '///'                                             ->  2
+///       | /usr/bin/grep -vE "$NOCOMMENT"                                     ->  2
 ///     /usr/bin/grep -rn  AppleIntelligenceAvailability Sources/ Tests/ \
-///       | /usr/bin/grep -v '///'                                             -> 25
+///       | /usr/bin/grep -vE "$NOCOMMENT"                                     -> 25
+///
+/// **WHAT THAT FILTER DOES AND DOES NOT DO, because an earlier revision published
+/// `grep -v '///'` and called the result comment-free.** It drops a line whose first
+/// non-space character is `//` or `*`, so doc comments, ordinary comments and the interior
+/// of a conventionally-formatted block comment all go. It does NOT drop a TRAILING comment
+/// on a line of code, and it does not parse Swift. Both counts are the same under either
+/// filter today because no such line exists; the difference is that the earlier one
+/// happened to be right and described itself wrongly.
 ///
 /// **`-w`, not a hand-rolled `[^R]` class.** An earlier revision excluded the neighbour by
 /// its first LETTER, which is a rule about the one sibling that exists today. A future

--- a/Sources/EnviousWisprCore/CustomWordsImportContract.swift
+++ b/Sources/EnviousWisprCore/CustomWordsImportContract.swift
@@ -111,11 +111,19 @@ package struct CustomWordsImportCandidate: Identifiable, Sendable, Hashable {
 /// One notices side-channel for a batch — never a second `warnings` field.
 /// **DECLARED-BUT-UNPRODUCED CASES ARE MARKED. Read the marker before wiring into one (#2048).**
 ///
-/// Four of the five cases below describe an enrichment stage that was never built. Their comments
-/// used to assert, in the present tense, that a producer existed — so a reader adding a sixth case
-/// followed them and wired into nothing. `grounding-discipline.md`
-/// RULE: never-hand-a-reviewer-an-unchecked-premise ranks that shape highest-cost because it
-/// retires the check rather than failing it.
+/// Four cases are unproduced, and they belong to TWO different missing subsystems — do not scope
+/// them as one piece of work:
+///
+///   1. The three ENRICHMENT notices — `appleIntelligenceUnavailable`,
+///      `suggestionsPartiallyUnavailable`, `suggestionBudgetReached` — wait on the shared
+///      enrichment stage (PR-P1). Their comments used to assert in the present tense that this
+///      stage produces them, so a reader followed them and wired into nothing.
+///      `grounding-discipline.md` RULE: never-hand-a-reviewer-an-unchecked-premise ranks that
+///      highest-cost, because it retires the check rather than failing it.
+///   2. `fileParseWarning` is INDEPENDENT of all of that — an upload-parser concern. Its original
+///      comment never claimed an enrichment producer and was not misleading; it is listed here only
+///      because nothing emits it either. Building PR-P1 would not produce it, and building it would
+///      not need PR-P1.
 ///
 /// `incompatibleSourceEntriesExcluded` is the one that works, and it is the template: produced in
 /// `SmartImportSource`, consumed in `CustomWordsImportFlowModel`, covered by
@@ -130,7 +138,8 @@ package enum CustomWordsImportNotice: Sendable, Equatable {
   /// suggestion-call budget is exhausted; `remainingCount` = candidates that would have proceeded
   /// without suggestions. That stage does not exist.
   case suggestionBudgetReached(remainingCount: Int)
-  /// **UNPRODUCED.** Designed as an Upload-only row-level parse warning; no parser emits it.
+  /// **UNPRODUCED, and NOT an enrichment case.** An Upload-only row-level parse warning, independent
+  /// of PR-P1: no parser emits it, and building the enrichment stage would not change that.
   case fileParseWarning(rowNumber: Int, reason: String)
   /// Smart Import: the source held entries and EVERY one was deliberately
   /// refused — Juno's built-in seed vocabulary, Spokenly's regex rules,


### PR DESCRIPTION
Comments only. No cases added, removed or renamed; no behaviour. Dev build green.

## The finding

`CustomWordsImportNotice` has five cases. **One works end to end. The other four carried doc comments asserting, in the present tense, that a producer exists:**

```swift
/// Produced by the shared enrichment stage (PR-P1) in the Paste and Upload flows.
case appleIntelligenceUnavailable(AppleIntelligenceAvailability)
/// Produced by the shared enrichment stage (PR-P1).
case suggestionsPartiallyUnavailable(count: Int)
/// Produced by the shared enrichment stage when the per-import suggestion-call budget is exhausted…
case suggestionBudgetReached(remainingCount: Int)
/// Upload-only row-level parse warning.
case fileParseWarning(rowNumber: Int, reason: String)
```

There is no shared enrichment stage. `grep -rn` for all four case names across `Sources/` and `Tests/` returns **only their own declarations** — nothing constructs any of them.

That is the highest-cost comment shape in `grounding-discipline.md` RULE: never-hand-a-reviewer-an-unchecked-premise: **it retires the check rather than failing it.** A reader adding a sixth case reads four present-tense comments, believes an enrichment stage produces notices, and wires into nothing.

## Why the fifth case makes this unarguable

`incompatibleSourceEntriesExcluded` is live and now named at the type as the template for what that means:

| | |
|---|---|
| produced | `SmartImportSource.swift:1171` |
| consumed | `CustomWordsImportFlowModel.swift:371` |
| tested | `SmartImportSourceTests.swift:1558, 1591` |

**A case is live when all three exist.** Without that contrast the enum reads as vestigial and the comments look like harmless leftovers; with it, four declarations describing a stage that was never built sit beside one that works.

## Re-measured rather than taken from the issue

#2048's central claim is that **nothing** produces or renders this type, sweep pasted. **That claim has expired.** Smart Import added the fifth case, its producer, its consumer and its tests after the issue was filed.

Acting on the issue text would have produced a write-up of a dead channel that has been half-alive for weeks. The general form is promoted into `grounding-discipline.md`: an absence claim is a measurement with a timestamp, so **re-run someone else's sweep before acting on it** — and note that what survives a re-measurement is usually sharper than the original.

## Deliberately not done

**The four cases are not deleted.** They are a designed contract for an enrichment stage that is still wanted, and the working fifth case shows the channel is the right shape. Deleting them means re-deriving that design later — the burden `deleting-a-test-carries-the-burden-of-adding-one` generalises to.

**PR-P1 is not implemented.** That is a feature, not a cleanup, and it is not what this issue is.

Part of #2048, which stays open for whatever decides the enrichment stage's fate.
