### PR TITLE
fix(ui): the waiting pill is header-only, as its comment already claimed

### DIFF
--- a/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
@@ -2786,8 +2786,20 @@ struct RecordingOverlayView: View {
       // in one small box — worse than either alone. The well shows nothing and
       // the pill stays one header tall until real words arrive. The capsule has
       // no header, so it keeps the sentence.
+      //
+      // #2222: `EmptyView()`, NOT `previewText("")`. An empty string still built a
+      // `PreviewWellText`, which applies the well's own 12/15pt inset and an empty
+      // `Text`'s line box unconditionally — so the state documented above as "one
+      // header tall" measured 75pt against the header's 34pt, three points short of
+      // a pill with words in it. Every dictation passes through here before the
+      // first word, so every user saw the pill resize before saying anything.
+      //
+      // The inset lives on `PreviewWellText` and is correct for every state that
+      // HAS a well; the defect was asking for a well to hold nothing. Fixed at the
+      // call site rather than by making the shared padding conditional, which would
+      // put an emptiness test inside a view that should not care.
       if usesPreviewLayout {
-        previewText("", dimmed: true, lines: 1)
+        EmptyView()
       } else {
         previewText(LivePreviewCopy.listening, dimmed: true, lines: 1)
       }

--- a/Tests/EnviousWisprTests/App/RecordingOverlayPreviewChromeTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingOverlayPreviewChromeTests.swift
@@ -203,17 +203,42 @@ struct RecordingOverlayPreviewChromeTests {
   /// #2202: the header says `Listening`, so the reading well must not say it too.
   /// A first-time user's very first sight of this feature is the waiting state,
   /// and the same word twice in one small box is worse than either alone.
-  @Test("the waiting state does not repeat the header's word in the well")
-  func waitingDoesNotDuplicateListening() throws {
+  ///
+  /// #2222: THIS COMPARISON USED TO BE `.waiting` AGAINST `.text("")`, WHICH IS
+  /// EQUAL BY CONSTRUCTION — both rendered the same `previewText("")`, so the
+  /// assertion could not fail, while this comment claimed the well "renders
+  /// nothing". It rendered an empty well: 75pt against the header's 34pt.
+  /// The binding comparison is `.off`, which is the only state that genuinely
+  /// draws no well, and it is what "one header tall" has to mean.
+  @Test("the waiting state is header-only in the preview layout")
+  func waitingIsHeaderOnly() throws {
     let waiting = try pillHeight(locked: false, showing: .waiting)
-    let empty = try pillHeight(locked: false, showing: .text(""))
+    let headerOnly = try pillHeight(locked: false, showing: .off)
 
     #expect(
-      waiting == empty,
+      waiting == headerOnly,
       """
-      the waiting state measured \(waiting)pt against \(empty)pt for an empty \
-      preview. In the preview layout the well renders nothing while waiting, \
-      because the header already carries the word.
+      the waiting state measured \(waiting)pt against \(headerOnly)pt for the \
+      header alone. Before any words arrive the preview pill must not reserve a \
+      well, or a normal recording visibly resizes before the user has spoken.
+      """)
+  }
+
+  /// The paired ACCEPTED case, so the fix above cannot be satisfied by emptying
+  /// every layout. The capsule has no header, so it is the one place the waiting
+  /// sentence still has to appear — and a guard that only checks the preview side
+  /// would report clean after silently deleting it.
+  @Test("the capsule still says something while waiting, because it has no header")
+  func capsuleWaitingKeepsItsSentence() throws {
+    let waiting = try pillHeight(locked: false, showing: .waiting, usesPreviewLayout: false)
+    let off = try pillHeight(locked: false, showing: .off, usesPreviewLayout: false)
+
+    #expect(
+      waiting > off,
+      """
+      the capsule's waiting state measured \(waiting)pt against \(off)pt with the \
+      preview off. The capsule draws no header, so removing its waiting sentence \
+      would leave a user with no indication anything is listening.
       """)
   }
 }


### PR DESCRIPTION
Before the first word arrives, the preview pill measured **75pt against a header-only 34pt** — three points short of a pill with words in it. The comment directly above the code said *"the pill stays one header tall until real words arrive"*. It did not.

Every dictation passes through `.waiting` before the first word, so every user saw the pill resize before they had spoken.

## Measured, not estimated

A probe over the suite's own `pillHeight` helper, reverted after reading:

| state | height | |
|---|---|---|
| `.off` | 34.0pt | header only, `EmptyView()` |
| `.waiting` | **75.0pt** | claimed to be one header tall |
| `.text("hello")` | 78.0pt | a pill with actual words |

The three-points-short figure is the one that reframes it: the waiting state is visually almost a full pill, not a mostly-collapsed one.

## Cause, and why the fix is at the call site

The branch rendered `previewText("")`. An empty string still builds a `PreviewWellText`, which applies the well's 12/15pt inset and an empty `Text`'s line box unconditionally. **Asking for a well to hold nothing still costs a well.**

Fixed with `EmptyView()` at the call site, **not** by making the shared padding conditional. That padding is correct for every state that HAS a well; pushing an emptiness test into `PreviewWellText` would make it care what it is asked to draw — a new conditional inherited by every future caller, bought for one caller's mistake. **Fix the request, not the renderer.**

`wellIsFull` is per-instance `@State`, so rendering no well leaves nothing stale: the first `.text(...)` builds a fresh instance.

## The existing test could not catch this, and its message claimed otherwise

`waitingDoesNotDuplicateListening` compared `.waiting` against `.text("")`. **Both rendered the same `previewText("")`, so the two sides were equal by construction and the assertion could never fail** — while its failure message asserted *"the well renders nothing while waiting"*, the exact claim it never observed.

A row that cannot fail, naming a subject it does not reach.

Replaced with the binding comparison — `.waiting` against `.off`, the only state that genuinely draws no well, which is what "one header tall" has to mean.

## The paired accepted case is load-bearing

A guard checking only the preview side is satisfied by **emptying every layout**, which is the shortest path to green from where the test sits. The capsule has no header, so what that would delete is the user's entire signal that anything is listening.

`capsuleWaitingKeepsItsSentence` requires the capsule's waiting state to stay taller than off. It is what makes "renders nothing" a bounded claim rather than an unbounded one.

## Control: the parent-commit check, not a synthetic mutant

Ran the new test against the **unfixed body** — stronger evidence, because the failure is the real one rather than one designed to be caught:

```
✘ (waiting → 75.0) == (headerOnly → 34.0)    EXIT=65, exactly one issue
✔ the capsule twin stayed green
```

Then restored and verified the file **byte-identical by SHA-256**.

With the fix: 8/8 in the suite, 35/35 across three neighbouring suites that read the same view, and the full Debug lane green at **6286 tests** — per-bundle lines reconciling exactly (6081 + 205), and both new tests confirmed present in that run so it is not a wrong-checkout green.

Closes #2222.
