### PR TITLE
docs(recovery): the defer list named two classes the code deletes on

### DIFF
--- a/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
@@ -709,12 +709,34 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
   /// SCOPE: this is consulted ONLY on the post-load transcription refusal. A
   /// load-time refusal is terminal — see the `.modelLoadFailed` call site.
   ///
-  /// The line drawn here is availability versus verdict: `.notReady`,
-  /// `.xpcUnreachable`, `.managerNotOwned` and `.cancelled` all mean the engine
-  /// was never in a position to try, so this take deserves its attempt back.
-  /// A genuine decode failure (`.transcriptionFailed`, `.parakeetTranscription`)
-  /// or a model that will not load stays unrecoverable — retrying those forever
-  /// would strand a spool no launch can ever redeem.
+  /// The line drawn here is availability versus verdict: `.notReady` and
+  /// `.managerNotOwned` mean the engine was never in a position to try, so this
+  /// take deserves its attempt back. A genuine decode failure
+  /// (`.transcriptionFailed`, `.parakeetTranscription`) or a model that will not
+  /// load stays unrecoverable — retrying those forever would strand a spool no
+  /// launch can ever redeem.
+  ///
+  /// **`.xpcUnreachable` AND `.cancelled` ARE NOT IN THE DEFER LIST, and this
+  /// sentence used to say they were (#2240).** Both delete. Where each exclusion
+  /// is justified:
+  ///   - `.xpcUnreachable` — the inline note on its own `case` arm below: a
+  ///     permanently dead helper would defer every launch forever. (Named, not
+  ///     located: a line offset written into this comment is invalidated by the
+  ///     comment itself, which is #2237's lesson.)
+  ///   - `.cancelled` — `RecoveryFailureClassification.swift`, at the arm that
+  ///     classifies the three cancellation vehicles. Its comment states the
+  ///     class is terminal and routes `ASREngineNotReadyAfterLoadError` ahead of
+  ///     it precisely so that error does not inherit the deletion.
+  ///
+  /// **Whether `.cancelled` SHOULD be terminal is an open question and is not
+  /// settled by this comment.** All three vehicles mean the engine never decoded
+  /// a sample, which is the criterion stated above, and the existence of
+  /// `.loadReturnedNotReady` as a class that exists to route around this one is
+  /// evidence that at least one member was felt to be wrongly terminal. That is
+  /// a behaviour change on the path that decides whether a recording survives,
+  /// and it inherits the unestablished question of what bounds the number of
+  /// times a spool may be handed its attempt back. Tracked on #2240; this change
+  /// only stops the comment asserting something the code does not do.
   ///
   /// Mirrors `deferForTransientKeychainFailure` exactly, which is the shipped
   /// precedent for "transient condition, give the attempt back".

--- a/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
@@ -728,15 +728,29 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
   ///     class is terminal and routes `ASREngineNotReadyAfterLoadError` ahead of
   ///     it precisely so that error does not inherit the deletion.
   ///
-  /// **Whether `.cancelled` SHOULD be terminal is an open question and is not
-  /// settled by this comment.** All three vehicles mean the engine never decoded
-  /// a sample, which is the criterion stated above, and the existence of
-  /// `.loadReturnedNotReady` as a class that exists to route around this one is
-  /// evidence that at least one member was felt to be wrongly terminal. That is
-  /// a behaviour change on the path that decides whether a recording survives,
-  /// and it inherits the unestablished question of what bounds the number of
-  /// times a spool may be handed its attempt back. Tracked on #2240; this change
-  /// only stops the comment asserting something the code does not do.
+  /// **THE THREE CANCELLATION VEHICLES ARE NOT ALIKE, AND THAT IS WHY THE CLASS
+  /// IS TERMINAL AS A WHOLE.** `ASRLoadSupersededError` is thrown only by
+  /// load/warm guards (`isModelLoaded`, a stale `loadGeneration`, a `.warming`
+  /// state) and `ASRLoadCancelledError` only by a pending LOAD completion, so
+  /// both genuinely mean the engine never reached the audio. **`CancellationError`
+  /// does not:** `ParakeetBackend.transcribe` wraps the `manager.transcribe` call
+  /// and rethrows it, so a cancellation arriving after the decode has started
+  /// lands in the same class. Deferring the class wholesale would hand an attempt
+  /// back to a take the engine had already begun processing.
+  ///
+  /// An earlier draft of this comment claimed all three mean the engine never
+  /// decoded a sample, and used that to argue the class might be wrongly
+  /// terminal. Cloud review refuted it. The mixed membership is an argument FOR
+  /// the current behaviour, and it also explains `.loadReturnedNotReady`: the
+  /// surgical fix was correct precisely because the cancellation class cannot be
+  /// deferred as a unit.
+  ///
+  /// What remains genuinely open is narrower — whether the two LOAD-time vehicles
+  /// deserve separating from `CancellationError` so they can defer. That is a
+  /// behaviour change on the path deciding whether a recording survives, and it
+  /// inherits the unestablished question of what bounds the number of times a
+  /// spool may be handed its attempt back. Tracked on #2240; this change only
+  /// stops the comment asserting something the code does not do.
   ///
   /// Mirrors `deferForTransientKeychainFailure` exactly, which is the shipped
   /// precedent for "transient condition, give the attempt back".


### PR DESCRIPTION
`engineWasNeverAvailable` decides whether a crash-recovered recording is retried or **deleted**. Its doc comment named four failure classes as deserving their attempt back. The code defers three, and **two of the four it named sit in the delete arm**.

```swift
/// … `.notReady`, `.xpcUnreachable`, `.managerNotOwned` and `.cancelled` all mean the engine
/// was never in a position to try, so this take deserves its attempt back.

case .notReady, .managerNotOwned: return true
case .loadReturnedNotReady: return true
case .xpcUnreachable, .cancelled, .transcriptionFailed, … : return false   // ← deletes
```

A second comment on the `.xpcUnreachable` case arm already explained that exclusion, so **two comments in one function contradicted each other, and the doc comment — the one a reader hits first — was the wrong one.**

This is the shape `grounding-discipline.md` RULE: never-hand-a-reviewer-an-unchecked-premise ranks highest: **it retires the check rather than failing it.** Someone deciding whether a cancelled replay costs a user their recording reads it, believes the attempt comes back, and stops looking.

## `.cancelled`'s exclusion is documented — in the producer, not the consumer

I filed #2240 saying `.cancelled` was "explained nowhere in the function". True, and an absence claim made from one file. The explanation is in the **classifier that mints the value**, `RecoveryFailureClassification.swift`:

> *classifying this one as `.cancelled` is exactly the #2132 trap — cancelled is terminal, so the recording would be deleted rather than retried*

It routes `ASREngineNotReadyAfterLoadError` ahead of the cancellation arm **precisely so that error does not inherit the deletion**. I had swept the consumer and not the producer.

Both exclusions are now cited where each is justified.

## What this deliberately does not do

**It does not decide whether `.cancelled` should be terminal, and the comment says so.**

All three cancellation vehicles mean the engine never decoded a sample — which is the criterion the comment itself states. And `.loadReturnedNotReady` exists as a class **to route around this one**, which is a workaround, and evidence that at least one member was felt to be wrongly terminal.

That is a behaviour change on the path deciding whether a recording survives, and it inherits an unestablished question: what bounds the number of times a spool may be handed its attempt back. **Bundling it here would let a comment fix carry a data-path change past review on the comment fix's evidence.** #2240 stays open for it.

## No line offsets or counts in the added text

The first draft said the `.xpcUnreachable` note was "twelve lines below". It was **33** — because this comment pushed it down. A positional claim about a file, written into that file, is invalidated by the writing.

That is #2237's lesson reproduced within minutes of applying it, so the note is now **named rather than located**.

## Verification

Comments only. No cases added, removed or renamed; no behaviour. Dev build green.

Every claim checked against the tree: both switch arms, the classifier's comment, and `ASREngineNotReadyAfterLoadError`'s existence. `check-cited-symbols.py` passes — and it found one defect in itself doing so, treating a backticked bare filename as a symbol, now fixed with paired test arms and a mutation control.

Part of #2240.
