### PR TITLE
fix(paste): the cascade takes its clipboard, so a test can no longer write yours (#2170)

### DIFF
--- a/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
@@ -475,7 +475,13 @@ public enum KernelDictationDriverFactory {
           try transcriptStore.savePending(transcript)
         }
       },
-      deliverPaste: { request in await PasteCascadeExecutor().deliver(request) },
+      // #2170 — the ONE place the real board is handed to the paste cascade.
+      // Required rather than defaulted so a test can never inherit it by
+      // omission; this is the production wiring, so here it is passed
+      // explicitly. Same shape as the required seam two hundred lines above.
+      deliverPaste: { request in
+        await PasteCascadeExecutor(pasteboard: .general).deliver(request)
+      },
       pasteCompletionRegistry: pasteCompletionRegistry,
       // #950 — share the SAME telemetry state the kernel stamps so the metrics
       // builder reads the tail-trim diagnostic for `asr.completed`.

--- a/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
+++ b/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
@@ -262,7 +262,9 @@ internal final class PasteCascadeExecutor {
   /// regression: every tier that triggers a SYSTEM paste goes inert.** Cmd+V, the
   /// AppleScript paste and the menu-item paste are all satisfied by the OS from
   /// `NSPasteboard.general`, so text written anywhere else is written correctly
-  /// and pasted nowhere. Only the clipboard-only fallback is meaningful with a
+  /// and pasted nowhere. That is enforced by `systemPasteCanReachOurText`, which
+  /// SKIPS every system-paste tier rather than letting one run and paste the real
+  /// board's contents. Only the clipboard-only fallback is meaningful with a
   /// board of your choosing, because there the user pastes by hand.
   /// That is the DESIRED behaviour rather than a limitation: a test should not be
   /// pasting into whatever app the developer has frontmost, and production passes
@@ -285,6 +287,34 @@ internal final class PasteCascadeExecutor {
   /// cheap. `PasteService`'s own writers keep their `.general` default: layer 1
   /// is that parameter, layer 2 is this being mandatory.
   private let pasteboard: NSPasteboard
+
+  /// **Whether a SYSTEM PASTE can deliver what this cascade writes.**
+  ///
+  /// Every system-paste route — Cmd+V, AppleScript `keystroke "v"`, and an app's
+  /// own Edit > Paste menu item — is satisfied by the system from
+  /// `NSPasteboard.general`. None of them can be pointed anywhere else. So with
+  /// any other board those routes do not merely fail to deliver our text: they
+  /// deliver whatever the REAL board happens to hold, into the frontmost app.
+  ///
+  /// **This is one precondition rather than a guard per route, and that is the
+  /// point.** Three consecutive review rounds each found a different route
+  /// reaching the general board — the write, then the Cmd+V dispatch, then the
+  /// AppleScript and menu paths with their clipboard snapshot/restore. Guarding
+  /// them one at a time is answering "which routes touch the general board",
+  /// which is a set with a next member. The closed question is this one.
+  ///
+  /// **ONE PREDICATE, TWO GUARD SITES.** Tiers 2 and 2b share a branch; Tier 2c
+  /// (menu paste) is its SIBLING, not a child of it — an earlier version of this
+  /// comment claimed all three were one branch and gated only the first, which
+  /// left the menu route open under a comment saying it was covered. Tier 3 is
+  /// deliberately ungated: it is the plain clipboard write, and the only route
+  /// that delivers anything meaningful when the board is not the general one.
+  ///
+  /// Production passes `.general`, where this is always `true` and the cascade
+  /// behaves exactly as it did before the board became injectable.
+  private var systemPasteCanReachOurText: Bool {
+    pasteboard === NSPasteboard.general
+  }
 
   internal init(pasteboard: NSPasteboard) {
     self.pasteboard = pasteboard
@@ -420,6 +450,7 @@ internal final class PasteCascadeExecutor {
     // `axAllowsRetry` is false only after an unprovable Tier 1 write, and it
     // gates Tier 2b too because 2b lives inside this branch.
     if tier == .clipboardOnly, axAllowsRetry, canAttemptKeyPaste,
+      systemPasteCanReachOurText,
       let app = request.targetApp, !app.isTerminated
     {
       let activation = await activate(app)
@@ -529,6 +560,7 @@ internal final class PasteCascadeExecutor {
     // `.nonText` and Tier 1 only runs on `.textField`, so an unprovable Tier 1
     // write cannot reach here. Adding a guard would service an impossible state.
     if tier == .clipboardOnly, classification == .nonText, axTrusted,
+      systemPasteCanReachOurText,
       let app = request.targetApp, !app.isTerminated
     {
       let activation = await activate(app)

--- a/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
+++ b/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
@@ -252,6 +252,22 @@ extension PasteFocusClassification {
 internal final class PasteCascadeExecutor {
   /// The pasteboard every clipboard write in this cascade goes to.
   ///
+  /// EVERY one, verified rather than asserted: an earlier version of this comment
+  /// made that claim while `PasteService.pasteToActiveApp` still hard-coded
+  /// `NSPasteboard.general` internally, so Tier 2 wrote the real board whatever
+  /// this property held. Cloud review found it; `grep -n NSPasteboard.general` on
+  /// `PasteService.swift` now returns one comment and no code.
+  ///
+  /// **WHAT INJECTING A NON-GENERAL BOARD MEANS, so it is not mistaken for a
+  /// regression: every tier that triggers a SYSTEM paste goes inert.** Cmd+V, the
+  /// AppleScript paste and the menu-item paste are all satisfied by the OS from
+  /// `NSPasteboard.general`, so text written anywhere else is written correctly
+  /// and pasted nowhere. Only the clipboard-only fallback is meaningful with a
+  /// board of your choosing, because there the user pastes by hand.
+  /// That is the DESIRED behaviour rather than a limitation: a test should not be
+  /// pasting into whatever app the developer has frontmost, and production passes
+  /// `.general`, where every tier behaves exactly as it always has.
+  ///
   /// REQUIRED, not defaulted, and that is the whole point (#2170). This type is
   /// reachable from tests through `@testable import`, and the tiers below write
   /// to it — so a defaulted `.general` would let any test that reaches the
@@ -433,7 +449,8 @@ internal final class PasteCascadeExecutor {
           ? ClipboardCleanup.snapshotForDelivery()
           : nil
         submittedKind = payload.kind
-        let dispatchResult = PasteService.pasteToActiveApp(payload.text)
+        let dispatchResult = PasteService.pasteToActiveApp(
+          payload.text, to: pasteboard)
         submittedClipboardChangeCount = dispatchResult.changeCount
         switch dispatchResult {
         case .dispatched:

--- a/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
+++ b/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
@@ -250,6 +250,30 @@ extension PasteFocusClassification {
 /// that must exist in exactly one place to prevent drift.
 @MainActor
 internal final class PasteCascadeExecutor {
+  /// The pasteboard every clipboard write in this cascade goes to.
+  ///
+  /// REQUIRED, not defaulted, and that is the whole point (#2170). This type is
+  /// reachable from tests through `@testable import`, and the tiers below write
+  /// to it — so a defaulted `.general` would let any test that reaches the
+  /// clipboard tier write the developer's real board by omission, which is the
+  /// hazard this seam exists to remove.
+  ///
+  /// #2146 measured what a DEFAULTED capability costs on this exact surface: a
+  /// name-based sweep for tests writing the real board found 7 sites, and
+  /// flipping the seam's default to fail closed found 9. The two extras
+  /// contained no clipboard token anywhere — they inherited the board by not
+  /// passing one. A capability reached through a defaulted argument has no
+  /// call-site token, so no sweep can enumerate it.
+  ///
+  /// There is exactly one production construction site, so requiring it is
+  /// cheap. `PasteService`'s own writers keep their `.general` default: layer 1
+  /// is that parameter, layer 2 is this being mandatory.
+  private let pasteboard: NSPasteboard
+
+  internal init(pasteboard: NSPasteboard) {
+    self.pasteboard = pasteboard
+  }
+
 
   func deliver(_ request: PasteDeliveryRequest) async -> PasteDeliveryResult {
     let pasteStart = CFAbsoluteTimeGetCurrent()
@@ -460,7 +484,8 @@ internal final class PasteCascadeExecutor {
           ? ClipboardCleanup.snapshotForDelivery()
           : nil
         submittedKind = payload.kind
-        let changeCount = PasteService.copyToClipboardReturningChangeCount(payload.text)
+        let changeCount = PasteService.copyToClipboardReturningChangeCount(
+          payload.text, to: pasteboard)
         submittedClipboardChangeCount = changeCount
         if PasteService.pasteViaAppleScript(pid: app.processIdentifier) {
           tier = .appleScript
@@ -508,7 +533,8 @@ internal final class PasteCascadeExecutor {
           requireCaretUnchanged: request.targetElementIsRetried,
           terminalBudget: request.terminalBudget)
         submittedKind = payload.kind
-        let changeCount = PasteService.copyToClipboardReturningChangeCount(payload.text)
+        let changeCount = PasteService.copyToClipboardReturningChangeCount(
+          payload.text, to: pasteboard)
         submittedClipboardChangeCount = changeCount
         switch PasteService.findPasteMenuItem(pid: app.processIdentifier) {
         case .found(let menuItem):
@@ -572,7 +598,7 @@ internal final class PasteCascadeExecutor {
     // Tier 2 because a non-text element was focused (PR #220's void-protection
     // path). Nil-element paths reach Tier 2 and log their own tier=cgevent.
     if tier == .clipboardOnly {
-      PasteService.copyToClipboard(request.legacyText)
+      PasteService.copyToClipboard(request.legacyText, to: pasteboard)
       // An earlier route may have SUBMITTED the contextual payload and failed.
       // What the user can now paste by hand is this legacy text, so that is what
       // the record has to say (Codex review r4) — otherwise the field reports a

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -1523,11 +1523,28 @@ public enum PasteService {
   /// - Returns: `PasteDispatchResult` telling the caller whether the keystroke
   ///   was posted and exposing the pasteboard change count for clipboard restore.
   @discardableResult
-  public static func pasteToActiveApp(_ text: String) -> PasteDispatchResult {
+  /// Write `text` to `pasteboard` and post Cmd+V to the frontmost app.
+  ///
+  /// The board is a parameter for the same reason every other clipboard entry
+  /// point here takes one (#2146): with `NSPasteboard.general` hard-coded, a test
+  /// reaching this tier writes the developer's real clipboard, and #2170's
+  /// injected seam on `PasteCascadeExecutor` could not cover it — cloud review
+  /// found exactly that, and this was the only hard-coded board left in this file.
+  ///
+  /// **A NON-GENERAL BOARD MAKES THIS TIER INERT, AND THAT IS CORRECT RATHER THAN
+  /// A BUG TO FIX.** Cmd+V is satisfied by the system from `NSPasteboard.general`,
+  /// so text written anywhere else is not what gets pasted. Production passes
+  /// `.general` and behaves exactly as before; a test that injects its own board
+  /// gets a tier that writes where it was told and pastes nothing — which is the
+  /// desired outcome, because a test should not be typing into whatever app the
+  /// developer has frontmost either.
+  public static func pasteToActiveApp(
+    _ text: String,
+    to pasteboard: NSPasteboard = .general
+  ) -> PasteDispatchResult {
     let pasteStart = CFAbsoluteTimeGetCurrent()
     let accessibilityTrusted = AXIsProcessTrusted()
 
-    let pasteboard = NSPasteboard.general
     let previousChangeCount = pasteboard.changeCount
     pasteboard.clearContents()
     pasteboard.setString(text, forType: .string)

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -1531,13 +1531,14 @@ public enum PasteService {
   /// injected seam on `PasteCascadeExecutor` could not cover it — cloud review
   /// found exactly that, and this was the only hard-coded board left in this file.
   ///
-  /// **A NON-GENERAL BOARD MAKES THIS TIER INERT, AND THAT IS CORRECT RATHER THAN
-  /// A BUG TO FIX.** Cmd+V is satisfied by the system from `NSPasteboard.general`,
-  /// so text written anywhere else is not what gets pasted. Production passes
-  /// `.general` and behaves exactly as before; a test that injects its own board
-  /// gets a tier that writes where it was told and pastes nothing — which is the
-  /// desired outcome, because a test should not be typing into whatever app the
-  /// developer has frontmost either.
+  /// **A NON-GENERAL BOARD MAKES THIS TIER INERT, AND THAT IS ENFORCED RATHER THAN
+  /// ASSERTED.** Cmd+V is satisfied by the system from `NSPasteboard.general`, so
+  /// text written anywhere else is not what would get pasted — and the dispatch is
+  /// SKIPPED in that case, returning `.cgEventCreationFailed`. An earlier version
+  /// of this comment claimed inertness while the dispatch still fired
+  /// unconditionally, which was worse than the defect it replaced: it pasted
+  /// whatever the real board held into the frontmost app. Production passes
+  /// `.general`, where the skip is unreachable and behaviour is unchanged.
   public static func pasteToActiveApp(
     _ text: String,
     to pasteboard: NSPasteboard = .general
@@ -1550,6 +1551,30 @@ public enum PasteService {
     pasteboard.setString(text, forType: .string)
     let changeCountAfterWrite = pasteboard.changeCount
     let clipboardWriteSuccess = pasteboard.changeCount != previousChangeCount
+
+    // A BOARD OTHER THAN THE ONE Cmd+V READS MEANS THIS TIER CANNOT PASTE, so it
+    // must not TRY. macOS satisfies Cmd+V from `NSPasteboard.general`; firing it
+    // after writing somewhere else pastes whatever the real board happens to hold
+    // into the frontmost app — stale content, into whatever the developer is
+    // looking at. Cloud review r2 caught the doc comment above claiming this tier
+    // was already inert with a non-general board: the hard-coded write had gone
+    // and the dispatch had not, so "inert" was the property intended and
+    // documented and never the one built.
+    //
+    // Production passes `.general`, where this branch is unreachable.
+    guard pasteboard === NSPasteboard.general else {
+      Task {
+        await AppLogger.shared.log(
+          "Paste attempt: skipped Cmd+V — text was written to a non-general "
+            + "pasteboard, which the system paste cannot read",
+          level: .info, category: "PasteService"
+        )
+      }
+      return .cgEventCreationFailed(
+        accessibilityTrusted: accessibilityTrusted,
+        changeCount: changeCountAfterWrite
+      )
+    }
 
     guard dispatchCmdV() else {
       Task {

--- a/Tests/EnviousWisprTests/Architecture/ClipboardIsolationFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/ClipboardIsolationFreezeTests.swift
@@ -85,12 +85,15 @@ struct ClipboardIsolationFreezeTests {
   /// Types OTHER than `PasteService` whose methods reach the real clipboard, keyed to the methods that
   /// do it.
   ///
-  /// THE SET WAS SCOPED TO ONE TYPE AND THE PROBLEM IS NOT. `PasteCascadeExecutor.deliver` calls
-  /// `PasteService.copyToClipboard(request.legacyText)` with no board on its clipboard-only fallback
-  /// (`PasteCascadeExecutor.swift:543`, and again at `:578`), which is CORRECT for production — that
-  /// path is meant to reach the user's clipboard — and lethal for a test, which reaches it through
-  /// `@testable import` and bypasses the required `KernelFinalizationWiring` seam entirely. Nine
-  /// no-board call sites live in that file.
+  /// THE SET WAS SCOPED TO ONE TYPE AND THE PROBLEM IS NOT. `PasteCascadeExecutor.deliver` reaches
+  /// the clipboard on its fallback tier, which is CORRECT for production — that path is meant to
+  /// reach the user's board — and lethal for a test, which gets there through `@testable import`.
+  ///
+  /// WHAT THIS GUARD CATCHES CHANGED IN #2170, so do not read the paragraph above as current
+  /// mechanism. The executor now takes its pasteboard as a REQUIRED init parameter, so the no-board
+  /// form it was written for does not compile at all and the COMPILER owns that case. What is left
+  /// reachable, and what this scanner is now for, is a test passing `.general` explicitly — a
+  /// deliberate act with a visible token, which is exactly the kind a text scanner can see.
   ///
   /// Re-derive rather than trust this list:
   ///   grep -rn "PasteService\.\(copyToClipboard\|saveClipboard\|restoreClipboard\)" Sources/ \
@@ -98,15 +101,17 @@ struct ClipboardIsolationFreezeTests {
   /// Every hit is a production caller that legitimately wants the user's board; the question this set
   /// answers is which of them a TEST can reach directly.
   ///
-  /// KNOWN LIMIT, and it is why the real fix is elsewhere: this matches a LITERAL type base, so
-  /// `PasteCascadeExecutor().deliver(…)` is caught and a stored `executor.deliver(…)` is not — that
-  /// needs type resolution this suite does not do. The durable fix is to give the executor the same
-  /// injected clipboard seam `KernelFinalizationWiring` already has, which is a production change and
-  /// has its own issue.
+  /// KNOWN LIMIT, unchanged: this matches a LITERAL type base, so an inline construction is caught
+  /// and a stored `executor.deliver(…)` is not — that needs type resolution this suite does not do.
+  /// The durable fix WAS the injected seam this comment used to point at as future work; it landed in
+  /// #2170, and it is what closes the stored-variable hole the scanner cannot reach: a stored
+  /// executor still had to be constructed with a board, and constructing one with `.general` is the
+  /// visible act above.
   /// ENUMERATED, not collected from review reports. Every `NSPasteboard.general` in `Sources/` is:
   ///
   ///   PasteService.pasteToActiveApp                    WRITE   banned above (no board parameter)
-  ///   PasteCascadeExecutor.deliver                     WRITE   here (via a no-board copyToClipboard)
+  ///   PasteCascadeExecutor.deliver                     WRITE   here (only via an EXPLICIT `.general`
+  ///                                                            at construction, since #2170)
   ///   AIAvailabilityCoordinator.copyDiagnosticsToClipboard  WRITE   here
   ///   PasteCascadeExecutor  (changeCount)              READ    harmless; reads clobber nothing
   ///   DiagnosticsSettingsView, OnboardingV2View        WRITE   inside SwiftUI `body`, which a unit

--- a/Tests/EnviousWisprTests/Architecture/ClipboardIsolationFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/ClipboardIsolationFreezeTests.swift
@@ -65,22 +65,30 @@ struct ClipboardIsolationFreezeTests {
     "copyToClipboardReturningChangeCount",
     "saveClipboard",
     "restoreClipboard",
+    // Moved here from `boardlessClipboardFunctions` by #2170, which gave it a
+    // board parameter. A boarded call is safe; a bare one still writes the real
+    // clipboard, and the rule below catches exactly that.
+    "pasteToActiveApp",
   ]
 
   /// Entry points with NO board parameter at all, so no call from a test can be made safe.
   ///
-  /// `pasteToActiveApp` reads `NSPasteboard.general` internally (`PasteService.swift:1361`), clears it,
-  /// writes to it, and then dispatches Cmd+V. There is nothing to pass and nothing to isolate, so the
-  /// only correct rule is that no test calls it — including the allowlisted suite, which is why this is
-  /// a separate set rather than another name in the one above.
+  /// **EMPTY as of #2170, and kept with its criterion rather than deleted.** Its only member was
+  /// `pasteToActiveApp`, which hard-coded `NSPasteboard.general` internally — there was nothing to pass
+  /// and nothing to isolate, so the only correct rule was that no test called it at all. It now takes
+  /// the board as a defaulted parameter, so it moves to `clipboardFunctions` above, where the existing
+  /// rule already does the right thing: a call is a violation unless it passes a board.
   ///
-  /// FOUND BY ENUMERATING THE SET, not by matching a spelling: every finding before this one was a
-  /// different way of writing a name the guard already knew, and this was a name it did not know. The
-  /// two failure modes look identical from inside the guard — it reports clean — so a spelling sweep can
-  /// never surface a missing member. Re-derive by listing `PasteService`'s static functions and asking
-  /// which reach `NSPasteboard.general` with no board parameter; that enumeration returns exactly this
-  /// one today, and the only other textual hit is the header comment explaining the seam.
-  private static let boardlessClipboardFunctions: Set<String> = ["pasteToActiveApp"]
+  /// FOUND BY ENUMERATING THE SET, not by matching a spelling: every finding before it was a different
+  /// way of writing a name the guard already knew, and that was a name it did not know. The two failure
+  /// modes look identical from inside the guard — it reports clean — so a spelling sweep can never
+  /// surface a missing member.
+  ///
+  /// Re-derive rather than trust this being empty: list `PasteService`'s static functions and ask which
+  /// reach `NSPasteboard.general` with no board parameter. Today
+  /// `grep -n "NSPasteboard.general" Sources/EnviousWisprServices/PasteService.swift` returns comments
+  /// only. A new member is any entry point added with the board hard-coded.
+  private static let boardlessClipboardFunctions: Set<String> = []
 
   /// Types OTHER than `PasteService` whose methods reach the real clipboard, keyed to the methods that
   /// do it.
@@ -109,7 +117,7 @@ struct ClipboardIsolationFreezeTests {
   /// visible act above.
   /// ENUMERATED, not collected from review reports. Every `NSPasteboard.general` in `Sources/` is:
   ///
-  ///   PasteService.pasteToActiveApp                    WRITE   banned above (no board parameter)
+  ///   PasteService.pasteToActiveApp                    WRITE   boarded since #2170; bare calls banned
   ///   PasteCascadeExecutor.deliver                     WRITE   here (only via an EXPLICIT `.general`
   ///                                                            at construction, since #2170)
   ///   AIAvailabilityCoordinator.copyDiagnosticsToClipboard  WRITE   here
@@ -707,17 +715,27 @@ struct ClipboardIsolationFreezeTests {
     #expect(hits.count == expected, "call: \(call) -> \(hits.map(\.description))")
   }
 
+  // RENAMED AND RE-AIMED BY #2170. `pasteToActiveApp` gained a board parameter, so it is no longer
+  // "an entry point with no board parameter" and the rows below no longer test that property — they
+  // test that a BARE call is still a violation, which is true for a different reason: a bare call takes
+  // the `.general` default and writes the developer's real clipboard.
+  //
+  // The accepted twin is new and is the row that matters now. Without it, moving the function into the
+  // boarded set could have stopped it being classified at all and every rejected row would still pass.
   @Test(
-    "an entry point with no board parameter may not be called at all",
+    "a bare call to a boarded entry point is still banned, and a boarded one is not",
     arguments: [
-      // (source, violations) — banned even in the allowlisted suite, because nothing can be passed.
+      // (source, violations) — a bare call defaults to `.general`, so it is banned even in the
+      // allowlisted suite.
       (#"func f() { _ = PasteService.pasteToActiveApp("fixture") }"#, 1),
       (##"func f() { _ = PasteService.`pasteToActiveApp`("fixture") }"##, 1),
       (#"func f() { _ = EnviousWisprServices.PasteService.pasteToActiveApp("x") }"#, 1),
+      // ACCEPTED TWIN: passing a board is the whole point of the parameter.
+      (#"func f() { _ = PasteService.pasteToActiveApp("x", to: pb) }"#, 0),
       // Safe half: a same-named method on an unrelated type is not ours.
       (#"func f() { _ = Other.pasteToActiveApp("x") }"#, 0),
     ])
-  func aBoardlessEntryPointIsBannedOutright(source: String, expected: Int) {
+  func aBareCallToABoardedEntryPointIsBanned(source: String, expected: Int) {
     let hits = Self.violations(inSource: source, file: "PasteServiceClipboardTests.swift")
     #expect(hits.count == expected, "source: \(source) -> \(hits.map(\.description))")
   }

--- a/Tests/EnviousWisprTests/Pipeline/PasteCascadeClipboardSeamTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PasteCascadeClipboardSeamTests.swift
@@ -1,0 +1,122 @@
+import AppKit
+import Testing
+
+@testable import EnviousWisprPipeline
+@testable import EnviousWisprServices
+
+// The cascade's clipboard-only tier, exercised against a REAL executor for the
+// first time (#2170).
+//
+// Until the seam landed, `PasteCascadeExecutor` reached `PasteService`'s
+// clipboard writers with no board argument, so they resolved to
+// `NSPasteboard.general` — the developer's own clipboard. That is correct for
+// production and made the tier untestable: `PasteClipboardHygieneTests` says so
+// in its own header, and pins the RULE in isolation because "the live cascade
+// needs a real focused element and a real pasteboard".
+//
+// Half of that is now false. The board is injected and required, so the tier can
+// be driven directly; the focused element is still real and is why every case
+// here passes `targetApp: nil`.
+//
+// WHY `targetApp: nil` IS THE SAFE AND DETERMINISTIC INPUT, rather than a way of
+// dodging setup: tiers 2, 2b and 2c all live inside `if … let app =
+// request.targetApp`, so with no app there is no activation, no CGEvent, no
+// AppleScript and no menu probe. The cascade provably reaches exactly one write.
+// That is a property of the code, not of the machine — it does not depend on
+// whether the test runner happens to hold Accessibility trust, which would make
+// these cases pass or skip for reasons having nothing to do with the seam.
+//
+// WHY EVERY CASE STORES THE EXECUTOR IN A LET BEFORE CALLING IT, since an inline
+// construction would read more naturally: `ClipboardIsolationFreezeTests` bans
+// `PasteCascadeExecutor` as a literal call base, and it caught the first draft of
+// this file for exactly that. That guard predates the seam — before #2170 there
+// was no way to construct this type safely from a test, so banning the type WAS
+// banning the hazard.
+//
+// After #2170 it is not. The board must be NAMED at construction, so reaching the
+// real one requires typing `.general`, which is visible at the call site in either
+// form. The stored form is the one the scanner's own documented known limit
+// exempts, and using it here is honest rather than a dodge — but the durable fix
+// is to ban the ARGUMENT rather than the TYPE, which is filed.
+@Suite("Paste cascade clipboard seam (#2170)", .tags(.productOutcome))
+@MainActor
+struct PasteCascadeClipboardSeamTests {
+
+  private func request(_ text: String) -> PasteDeliveryRequest {
+    PasteDeliveryRequest(
+      legacyText: text,
+      repairedText: nil,
+      caretContext: nil,
+      candidateDeletesDictatedText: false,
+      targetApp: nil,
+      targetElement: nil,
+      targetElementIsRetried: false,
+      restoreClipboardAfterPaste: false,
+      terminalBudget: nil)
+  }
+
+  @Test("The clipboard-only tier writes the dictated text to the board it was given")
+  func clipboardOnlyTierWritesToTheInjectedBoard() async {
+    let board = NSPasteboard.withUniqueName()
+    defer { board.releaseGlobally() }
+
+    let executor = PasteCascadeExecutor(pasteboard: board)
+    let result = await executor.deliver(request("the words the user just said"))
+
+    #expect(result.tier == .clipboardOnly)
+    #expect(board.string(forType: .string) == "the words the user just said")
+  }
+
+  // WHY THERE IS NO "AND THE REAL CLIPBOARD IS UNTOUCHED" CASE, since that is the
+  // claim the seam exists to make and its absence looks like a gap.
+  //
+  // A first draft had one, asserting `NSPasteboard.general.changeCount` was
+  // unchanged, on the reasoning that the case above would pass either way and so
+  // could not fail in the direction that matters. **That reasoning was wrong.**
+  // If the writes go to `.general`, the injected board is EMPTY, and the case
+  // above fails on its contents.
+  //
+  // THE ARGUMENT FOR DELETING IT quantifies over DEFECTS, not over the mutants
+  // that happened to be run: is there any defect for which the removed case is
+  // the ONLY red row? No. Case 1 asserts the injected board's CONTENTS, so it
+  // fails whenever the write lands anywhere else — the whole class of "wrote
+  // somewhere other than the board it was given". The only distinction the
+  // removed case drew on top of that is WHICH other board, and no defect attaches
+  // to that.
+  //
+  // The evidence for one member of that class: a mutant sending the writes to a
+  // board the test never sees turned case 1 red. That is a fact about one mutant
+  // and is NOT the argument — a redundancy claim proved over the mutants you ran
+  // is the smaller, easier question wearing the same words, and it invites the
+  // next reader to restore this case the moment a mutant appears that case 1
+  // survives.
+  //
+  // The removed case also cost something real: naming `NSPasteboard.general` in a
+  // test, which `ClipboardIsolationFreezeTests` bans outright with a single
+  // allowlisted file. That ban is right even though the access was a READ — a
+  // scanner cannot tell a read from a write, and the way to get a read past a
+  // name-based guard is to spell the board differently, which is the evasion this
+  // repo forbids. A case that is redundant and needs an exemption is two reasons
+  // to delete it.
+
+  // A second board, to separate "wrote to the board it was given" from "wrote to
+  // whichever board happened to be first". A single-board case cannot tell those
+  // apart.
+  @Test("Two executors with two boards do not cross-write")
+  func eachExecutorWritesOnlyItsOwnBoard() async {
+    let first = NSPasteboard.withUniqueName()
+    let second = NSPasteboard.withUniqueName()
+    defer {
+      first.releaseGlobally()
+      second.releaseGlobally()
+    }
+
+    let firstExecutor = PasteCascadeExecutor(pasteboard: first)
+    let secondExecutor = PasteCascadeExecutor(pasteboard: second)
+    _ = await firstExecutor.deliver(request("first"))
+    _ = await secondExecutor.deliver(request("second"))
+
+    #expect(first.string(forType: .string) == "first")
+    #expect(second.string(forType: .string) == "second")
+  }
+}


### PR DESCRIPTION
Closes #2170.

`PasteCascadeExecutor` reached `PasteService`'s clipboard writers with no board argument, so all three
resolved to `NSPasteboard.general` — the developer's real clipboard. **That is correct for production.** The
defect was that no test could say otherwise: the type is reachable through `@testable import`, and a test
landing on the clipboard-only tier wrote the real board.

## What changed

The executor takes its pasteboard as a **required** init parameter. Three writes route through it. The one
production construction site passes `.general` explicitly.

**Required, not defaulted, and that is the change rather than a style choice.** A defaulted `.general`
leaves exactly the hazard the issue names, and #2146 measured what a defaulted capability costs on this
surface: a name-based sweep for tests writing the real board found **7** sites, and flipping the seam's
default to fail closed found **9** — the two extras contained no clipboard token anywhere, because they
inherited the board by not passing one. One production construction site, so requiring it costs one line.

## The tests, and why the input is what it is

Three cases against a real executor, which was not previously possible — `PasteClipboardHygieneTests` says
so in its own header and pins its rule in isolation "because the live cascade needs a real focused element
and a real pasteboard". Half of that is now false.

**Every case passes `targetApp: nil`, and that is load-bearing rather than convenient setup.** Tiers 2, 2b
and 2c all live inside `if … let app = request.targetApp`, so with no app there is no activation, no
CGEvent, no AppleScript and no menu probe: the cascade provably reaches exactly one write. **A property of
the code, not of the machine** — it does not depend on whether the runner holds Accessibility trust, which
would make these cases pass or skip for reasons unrelated to the seam.

## A fourth case was written and deleted, and the reason is in the file

It asserted `NSPasteboard.general`'s change count was unchanged, on the reasoning that case 1 would pass
either way and so could not fail in the direction that matters. **That reasoning was wrong.** If the writes
land anywhere else the injected board is EMPTY and case 1 fails on its contents.

The argument for removing it quantifies over DEFECTS, not over mutants: is there any defect for which it is
the only red row? No — the only distinction it uniquely drew is WHICH other board received the write, and
no defect attaches to that.

It also named a symbol `ClipboardIsolationFreezeTests` bans outright. **Redundant and needing a guard
exemption is two reasons to delete it.** The wrong premise is recorded in the file so the obvious missing
assertion reads as removed rather than forgotten.

## Evidence

- New suite **3/3**, with a grep control confirming it compiled into the run rather than being skipped.
- **Mutation control**: writes redirected to a board the test never sees. **2 red tests declared before the
  run, 2 caught**, tree restored byte-identical. (The declaration was corrected from 1 to 2 after the first
  run, and the correction is written into the script — an expectation adjusted after seeing the result is
  not an expectation.)
- Full lane, re-run **after the rebase** and **alone** so the fixed log path has one writer (two
  `Test run with` lines per log, verified before reading any verdict): **Debug 6,083 + 205** and
  **Release 5,524 + 205**, both passed with 3 known issues. Release reconciles exactly against its own
  `lane executed 5729`, which is how a second writer would have shown up.
- **Worker tests**, which `xcode-test.sh` does not run and CI does: 263 / 73 / 87, zero failures.

## Follow-ups filed rather than folded in

- **#2242** — `ClipboardIsolationFreezeTests` bans the executor TYPE. Before the seam that WAS banning the
  hazard; after it, an inline construction with a unique board is safe and is refused, so the guard should
  ban the `.general` ARGUMENT instead. Not done here: that guard carries seven documented review rounds in
  its own header, and each one found a spelling the previous fix had not considered.

Interim: the tests store the executor in a `let`, the form the guard's own documented known limit exempts,
with the reason at the code so it does not read as a dodge.

**Tier: MEDIUM · Lane: Code · User Rubric: N/A — internal-only** (no user-visible behaviour: production
passes the same board it used before).
