### PR TITLE
fix(recovery): a cancelled dictation is deleted at launch, as three pages promise (#2186)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/TranscriptCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/TranscriptCoordinator.swift
@@ -46,8 +46,7 @@ final class TranscriptCoordinator {
   /// is the instrument that decides whether this feature earns its keep.
   private let emitEscapeRecoveryKept: (_ ageMs: Int, _ takeID: String) -> Void
   private let emitEscapeRecoveryExpired: (_ ageMs: Int, _ takeID: String) -> Void
-  private let emitEscapeRecoveryRestoredFromHistory:
-    (_ ageMs: Int, _ takeID: String) -> Void
+  private let emitEscapeRecoveryRestoredFromHistory: (_ ageMs: Int, _ takeID: String) -> Void
   private var loadTask: Task<Void, Never>?
   private var pulseTask: Task<Void, Never>?
 
@@ -362,11 +361,27 @@ final class TranscriptCoordinator {
       // is about to delete. Reclaims disk and produces the `expired` half of the
       // ratio that judges the feature.
       //
-      // Placed here rather than at process launch deliberately: this is the
-      // path that already does History disk I/O, and read-time expiry means an
-      // unswept row is invisible regardless — so the sweep governs disk and
-      // telemetry, never what the user can see. That is also why a missed sweep
-      // is not a user-facing bug.
+      // #2186: this is NO LONGER THE ONLY SWEEP, and the reasoning that made it
+      // the only one was wrong in a way worth keeping written down.
+      //
+      // It used to read: placed here rather than at process launch
+      // deliberately, because this is the path that already does History disk
+      // I/O, and read-time expiry means an unswept row is invisible regardless
+      // — "so a missed sweep is not a user-facing bug."
+      //
+      // That is sound about the UI and silent about the DISK, and three shipped
+      // surfaces promise the disk: `help/escape-recovery.md` and
+      // `help/what-data-is-collected.md` both say a lapsed row is removed
+      // "while the app is running, or the next time you launch it", and the
+      // in-app countdown renders "Deleted in 23h". Hiding is not deleting. A
+      // user who never opened History never swept, so the plaintext of a
+      // dictation they CANCELLED stayed on disk indefinitely.
+      //
+      // `WisprBootstrapper.applicationDidFinishLaunching()` now sweeps too.
+      // This call stays exactly as it is — sweeping BEFORE reading is what
+      // stops the load picking up a row this pass is about to delete, which is
+      // a property of the READ and unrelated to who else sweeps. The store
+      // coalesces, so the two callers cannot double-report one expiry.
       await sweepExpiredPending()
       do {
         let diskRows = try await store.loadAll()

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -1122,6 +1122,33 @@ public final class WisprBootstrapper {
     // blocking "recovering" pill (replaces PR1's purge). Strict limb, single-flight,
     // one attempt per orphan. No-orphan launch is byte-identical to today.
     Task { await recoveryCoordinator.scanAndRecover() }
+    // #2186: delete Escape Recovery rows whose 24-hour window ended, WITHOUT
+    // waiting for the user to open History.
+    //
+    // Three shipped surfaces promise this deletion — `help/escape-recovery.md`
+    // and `help/what-data-is-collected.md` both say a row is removed "while the
+    // app is running, or the next time you launch it", and the in-app countdown
+    // renders "Deleted in 23h" — while the only production caller of
+    // `TranscriptCoordinator.load()`, and so of the sweep, was the History
+    // view's `.task`. The expiry pulse cannot substitute: it arms on
+    // `pendingPulseHasWork`, which reads `transcripts`, which only `load()`
+    // populates. So a user who never opened History never swept, and the
+    // plaintext of a dictation they CANCELLED stayed on disk indefinitely.
+    //
+    // Its own `Task`, not folded into the recovery scan above: the two touch
+    // different namespaces (audio spools vs pending transcripts), so no
+    // ordering is required, and chaining would let a slow orphan replay delay a
+    // deletion the user was promised.
+    //
+    // A limb, exactly like the line above. `sweepExpiredPending()` returns Void
+    // and absorbs its own failures into `unremovablePendingCount` /
+    // `lastSweepIncomplete`, which is also what arms the pulse to retry a file
+    // it could not remove — a retry that previously never came on a
+    // launch-only session. No guard here: `TranscriptStore.deleteExpiredPending`
+    // already coalesces, so a launch racing a History open is safe by
+    // construction. With Escape Recovery off (the default) the pending
+    // directory does not exist and this costs one `fileExists`.
+    Task { await transcriptCoordinator.sweepExpiredPending() }
   }
 
   public func applicationDidBecomeActive() {

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -1118,37 +1118,15 @@ public final class WisprBootstrapper {
 
   public func applicationDidFinishLaunching() {
     appLifecycleCoordinator.runDidFinishLaunching()
-    // #1063 PR2: scan for orphan crash-recovery spools and recover them behind the
-    // blocking "recovering" pill (replaces PR1's purge). Strict limb, single-flight,
-    // one attempt per orphan. No-orphan launch is byte-identical to today.
-    Task { await recoveryCoordinator.scanAndRecover() }
-    // #2186: delete Escape Recovery rows whose 24-hour window ended, WITHOUT
-    // waiting for the user to open History.
-    //
-    // Three shipped surfaces promise this deletion — `help/escape-recovery.md`
-    // and `help/what-data-is-collected.md` both say a row is removed "while the
-    // app is running, or the next time you launch it", and the in-app countdown
-    // renders "Deleted in 23h" — while the only production caller of
-    // `TranscriptCoordinator.load()`, and so of the sweep, was the History
-    // view's `.task`. The expiry pulse cannot substitute: it arms on
-    // `pendingPulseHasWork`, which reads `transcripts`, which only `load()`
-    // populates. So a user who never opened History never swept, and the
-    // plaintext of a dictation they CANCELLED stayed on disk indefinitely.
-    //
-    // Its own `Task`, not folded into the recovery scan above: the two touch
-    // different namespaces (audio spools vs pending transcripts), so no
-    // ordering is required, and chaining would let a slow orphan replay delay a
-    // deletion the user was promised.
-    //
-    // A limb, exactly like the line above. `sweepExpiredPending()` returns Void
-    // and absorbs its own failures into `unremovablePendingCount` /
-    // `lastSweepIncomplete`, which is also what arms the pulse to retry a file
-    // it could not remove — a retry that previously never came on a
-    // launch-only session. No guard here: `TranscriptStore.deleteExpiredPending`
-    // already coalesces, so a launch racing a History open is safe by
-    // construction. With Escape Recovery off (the default) the pending
-    // directory does not exist and this costs one `fileExists`.
-    Task { await transcriptCoordinator.sweepExpiredPending() }
+    // #1063 PR2: recover orphan crash-recovery spools behind the blocking
+    // "recovering" pill. Strict limb, single-flight, one attempt per orphan.
+    // #2186: then sweep expired rows, not only on History's `.task`. ORDER IS
+    // LOAD-BEARING — the scan de-dupes against `allRecoveredSessionIDs()`, which
+    // reads the rows this deletes. Bound by `EscapeRecoveryLaunchSweepTests`.
+    Task {
+      await recoveryCoordinator.scanAndRecover()
+      await transcriptCoordinator.sweepExpiredPending()
+    }
   }
 
   public func applicationDidBecomeActive() {

--- a/Tests/EnviousWisprTests/App/EscapeRecoveryLaunchSweepTests.swift
+++ b/Tests/EnviousWisprTests/App/EscapeRecoveryLaunchSweepTests.swift
@@ -68,7 +68,12 @@ struct EscapeRecoveryLaunchSweepTests {
   /// names the coordinator many times, so a file-wide search would be satisfied
   /// by construction and could never fail.
   final class LaunchCallCollector: SyntaxVisitor {
-    private(set) var calls: Set<String> = []
+    /// ORDERED, not a set. Round 2 found that the sweep deleting a pending row
+    /// before `scanAndRecover()` reads `allRecoveredSessionIDs()` strips the key
+    /// proving a spool was already recovered, so the scan replays a cancelled
+    /// dictation as a fresh one. Sequence is therefore part of the contract, and
+    /// a set could not express it.
+    private(set) var calls: [String] = []
 
     /// A call that exists only under a compilation condition is not wired for
     /// the shipping build, so it must not count as wired at all.
@@ -80,13 +85,13 @@ struct EscapeRecoveryLaunchSweepTests {
       if let member = node.calledExpression.as(MemberAccessExprSyntax.self),
         let receiver = member.base?.as(DeclReferenceExprSyntax.self)
       {
-        calls.insert("\(receiver.baseName.text).\(member.declName.baseName.text)")
+        calls.append("\(receiver.baseName.text).\(member.declName.baseName.text)")
       }
       return .visitChildren
     }
   }
 
-  static func calls(inFunctionNamed name: String, source: String) -> Set<String>? {
+  static func calls(inFunctionNamed name: String, source: String) -> [String]? {
     final class Finder: SyntaxVisitor {
       let wanted: String
       var body: CodeBlockSyntax?
@@ -124,7 +129,7 @@ struct EscapeRecoveryLaunchSweepTests {
       """
       #2186 control: the neighbouring crash-recovery limb is missing from the parsed launch \
       body, so this guard could not see the launch path at all. Fix the parse before reading \
-      the assertion below. Calls found: \(calls.sorted())
+      the assertion below. Calls found: \(calls)
       """)
 
     #expect(
@@ -135,7 +140,27 @@ struct EscapeRecoveryLaunchSweepTests {
       dictation is removed "the next time you launch it", and the in-app countdown says \
       "Deleted in 23h". Without this call the only sweep is the History view's .task, so a \
       user who never opens History keeps the plaintext of a dictation they cancelled, \
-      indefinitely. Calls found: \(calls.sorted())
+      indefinitely. Calls found: \(calls)
+      """)
+
+    // ORDER, and it is a correctness property rather than tidiness. The scan
+    // de-dupes against `allRecoveredSessionIDs()`, which reads the pending rows
+    // the sweep deletes; a saved row is what proves its spool was already
+    // recovered. Sweep first and that proof can be gone before the scan looks,
+    // so a spool the user CANCELLED is replayed as a fresh dictation — the exact
+    // outcome Escape Recovery exists to prevent.
+    // `#require`, not an `if let`: a missing call must FAIL here rather than
+    // quietly skip the ordering assertion. A guard that can opt itself out is
+    // the vacuity this suite exists to avoid.
+    let scan = try #require(calls.firstIndex(of: "recoveryCoordinator.scanAndRecover"))
+    let sweep = try #require(calls.firstIndex(of: "transcriptCoordinator.sweepExpiredPending"))
+    #expect(
+      scan < sweep,
+      """
+      #2186: the launch sweep must run AFTER the crash-recovery scan has read its \
+      de-duplication ids. Deleting a pending row first strips the proof that its spool was \
+      already recovered, and the scan then replays a cancelled dictation as a new one. \
+      Order found: \(calls)
       """)
   }
 
@@ -163,12 +188,12 @@ struct EscapeRecoveryLaunchSweepTests {
 
     #expect(
       !found.contains("transcriptCoordinator.sweepExpiredPending"),
-      "a commented, quoted or #if-only sweep must not satisfy the launch guard: \(found.sorted())")
+      "a commented, quoted or #if-only sweep must not satisfy the launch guard: \(found)")
     // Paired accepted case in the same fixture, so a walker that simply finds
     // nothing cannot pass this suite.
     #expect(
       found.contains("recoveryCoordinator.scanAndRecover"),
-      "the walker missed a live call in the same body: \(found.sorted())")
+      "the walker missed a live call in the same body: \(found)")
   }
 
   @Test("a real call is still found when it sits inside a Task closure")

--- a/Tests/EnviousWisprTests/App/EscapeRecoveryLaunchSweepTests.swift
+++ b/Tests/EnviousWisprTests/App/EscapeRecoveryLaunchSweepTests.swift
@@ -1,4 +1,6 @@
 import Foundation
+import SwiftParser
+import SwiftSyntax
 import Testing
 
 /// #2186: the launch path must sweep expired Escape Recovery rows.
@@ -6,10 +8,9 @@ import Testing
 /// ## The promise this binds
 ///
 /// Three shipped surfaces tell the user a cancelled dictation is DELETED on a
-/// schedule, and `testing-philosophy.md`
-/// RULE: a-public-product-promise-needs-a-binding-test says a claim like that
-/// gets one test that fails when it stops being true. There was none, which is
-/// how the copy and the code drifted apart in silence:
+/// schedule, and a public deletion promise needs a test that fails when it stops
+/// being true. There was none, which is how the copy and the code drifted apart
+/// in silence:
 ///
 /// - `website/src/content/help/escape-recovery.md` — "removes it while the app
 ///   is running, **or the next time you launch it** … a dictation whose window
@@ -32,146 +33,158 @@ import Testing
 /// `sweepExpiredPending()` directly; duplicating that here would multiply an
 /// axis without reaching a new branch.
 ///
-/// ## Why it reads source
+/// ## Why it reads source, and why it PARSES rather than matches text
 ///
 /// `applicationDidFinishLaunching()` cannot be constructed in a unit test — it
 /// needs the whole object graph and `NSApp`. This repo has no unit test
-/// asserting ANY launch-time wiring: the neighbouring `scanAndRecover()` limb
-/// is proven by Live UAT (`Tests/RuntimeUAT/SCENARIOS.md`), and the app-layer
-/// ceilings suites parse source for the same reason. Reading the declaration is
-/// the only mechanism available, so this is a tripwire on the launch method,
-/// paired with the Live UAT that proves the behaviour end to end.
+/// asserting ANY launch-time wiring: the neighbouring `scanAndRecover()` limb is
+/// proven by Live UAT, and the app-layer ceilings suites read source for the
+/// same reason. Reading the declaration is the only mechanism available, so this
+/// is a tripwire on the launch method, paired with the Live UAT that proves the
+/// behaviour end to end.
 ///
-/// **Comments are stripped before matching, and that is load-bearing rather
-/// than tidy.** The production call ships under a comment block that names
-/// `sweepExpiredPending()` in prose. A guard matching raw text would be
-/// satisfied by that comment alone, so deleting the actual statement would
-/// leave this test GREEN — the mutant would survive and the guard would be a
-/// decoration. `theGuardIsNotSatisfiedByAComment` is the paired rejected case
-/// that holds the stripper honest.
+/// **The first version of this guard matched text, and review was right to
+/// refuse it.** The shipped call sits under a comment block that names
+/// `sweepExpiredPending()` in prose, so a raw match stayed green after the
+/// statement was deleted — a guard that looks binding and is not, which is worse
+/// than none. Stripping comments fixed one lexical form and left the class:
+/// a string literal, or a call surviving only inside an inactive `#if` branch,
+/// would both have satisfied it, and the positive control could not tell.
+///
+/// So this walks a `SwiftParser` tree and requires an actual call expression.
+/// Comments and every string form are excluded STRUCTURALLY rather than one
+/// spelling at a time. `#if` blocks are skipped outright, which is deliberately
+/// stronger than review asked for: a launch sweep reachable only under a
+/// compilation condition does not ship to the users the promise was made to.
 @Suite(.tags(.driftGuard))
 struct EscapeRecoveryLaunchSweepTests {
 
   private static let sourcePath = "Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift"
 
-  private static func bootstrapperSource() throws -> String {
-    try String(contentsOf: RepoRoot.url.appending(path: sourcePath), encoding: .utf8)
+  /// Every `<receiver>.<method>(` call made directly by `functionNamed`, with
+  /// `#if` subtrees skipped.
+  ///
+  /// Scoped to the METHOD on purpose: `WisprBootstrapper` is ~1,200 lines and
+  /// names the coordinator many times, so a file-wide search would be satisfied
+  /// by construction and could never fail.
+  final class LaunchCallCollector: SyntaxVisitor {
+    private(set) var calls: Set<String> = []
+
+    /// A call that exists only under a compilation condition is not wired for
+    /// the shipping build, so it must not count as wired at all.
+    override func visit(_ node: IfConfigDeclSyntax) -> SyntaxVisitorContinueKind {
+      .skipChildren
+    }
+
+    override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+      if let member = node.calledExpression.as(MemberAccessExprSyntax.self),
+        let receiver = member.base?.as(DeclReferenceExprSyntax.self)
+      {
+        calls.insert("\(receiver.baseName.text).\(member.declName.baseName.text)")
+      }
+      return .visitChildren
+    }
   }
 
-  /// The body of `applicationDidFinishLaunching()`, by brace matching.
-  ///
-  /// Scoped to the METHOD rather than the file on purpose: `WisprBootstrapper`
-  /// is ~1,200 lines and mentions the coordinator many times, so a file-wide
-  /// match would be satisfied by construction and could never fail. The
-  /// question is whether the LAUNCH reaches the sweep.
-  static func launchBody(in source: String) -> String? {
-    guard let signature = source.range(of: "func applicationDidFinishLaunching()") else {
-      return nil
+  static func calls(inFunctionNamed name: String, source: String) -> Set<String>? {
+    final class Finder: SyntaxVisitor {
+      let wanted: String
+      var body: CodeBlockSyntax?
+      init(_ wanted: String) {
+        self.wanted = wanted
+        super.init(viewMode: .sourceAccurate)
+      }
+      override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+        if node.name.text == wanted { body = node.body }
+        return .visitChildren
+      }
     }
-    guard let open = source[signature.upperBound...].firstIndex(of: "{") else { return nil }
-    var depth = 0
-    var index = open
-    while index < source.endIndex {
-      if source[index] == "{" { depth += 1 }
-      if source[index] == "}" {
-        depth -= 1
-        if depth == 0 {
-          return String(source[source.index(after: open)..<index])
-        }
-      }
-      index = source.index(after: index)
-    }
-    return nil
-  }
-
-  /// Remove `//` line comments and `/* */` block comments.
-  ///
-  /// Deliberately does NOT try to respect string literals: the launch body
-  /// contains none, and a stripper that models Swift's full lexical grammar is
-  /// a bigger surface than the thing it guards. If a literal ever appears here
-  /// the positive control below fails first, loudly.
-  static func strippingComments(_ body: String) -> String {
-    var out = ""
-    var iterator = body.startIndex
-    var inLine = false
-    var inBlock = false
-    while iterator < body.endIndex {
-      let rest = body[iterator...]
-      if !inLine, !inBlock, rest.hasPrefix("//") {
-        inLine = true
-        iterator = body.index(iterator, offsetBy: 2)
-        continue
-      }
-      if !inLine, !inBlock, rest.hasPrefix("/*") {
-        inBlock = true
-        iterator = body.index(iterator, offsetBy: 2)
-        continue
-      }
-      if inBlock, rest.hasPrefix("*/") {
-        inBlock = false
-        iterator = body.index(iterator, offsetBy: 2)
-        continue
-      }
-      if inLine, body[iterator] == "\n" { inLine = false }
-      if !inLine, !inBlock { out.append(body[iterator]) }
-      iterator = body.index(after: iterator)
-    }
-    return out
+    let finder = Finder(name)
+    finder.walk(Parser.parse(source: source))
+    guard let body = finder.body else { return nil }
+    let collector = LaunchCallCollector(viewMode: .sourceAccurate)
+    collector.walk(body)
+    return collector.calls
   }
 
   @Test("the launch deletes expired cancelled dictations without waiting for History")
   func launchSweepsExpiredPendingRows() throws {
-    let source = try Self.bootstrapperSource()
-    let body = try #require(
-      Self.launchBody(in: source),
+    let source = try String(
+      contentsOf: RepoRoot.url.appending(path: Self.sourcePath), encoding: .utf8)
+    let calls = try #require(
+      Self.calls(inFunctionNamed: "applicationDidFinishLaunching", source: source),
       "applicationDidFinishLaunching() not found — this guard's subject moved, it did not pass")
-    let code = Self.strippingComments(body)
 
-    // POSITIVE CONTROL, and it runs first for a reason: if the extraction or
-    // the stripper broke, BOTH assertions fail and the failure is about this
-    // instrument rather than about the launch path. Without it, an empty `code`
-    // reads exactly like a deleted call.
+    // POSITIVE CONTROL, first for a reason: if the parse or the scoping broke,
+    // BOTH assertions fail and the failure is about this instrument rather than
+    // about the launch path. Without it, an empty set reads exactly like a
+    // deleted call.
     #expect(
-      code.contains("scanAndRecover("),
+      calls.contains("recoveryCoordinator.scanAndRecover"),
       """
-      #2186 control: the neighbouring crash-recovery limb is missing from the extracted \
-      launch body, so this guard could not see the launch path at all. Fix the extraction \
-      before reading the assertion below.
+      #2186 control: the neighbouring crash-recovery limb is missing from the parsed launch \
+      body, so this guard could not see the launch path at all. Fix the parse before reading \
+      the assertion below. Calls found: \(calls.sorted())
       """)
 
     #expect(
-      code.contains("transcriptCoordinator.sweepExpiredPending("),
+      calls.contains("transcriptCoordinator.sweepExpiredPending"),
       """
       #2186: applicationDidFinishLaunching() no longer sweeps expired Escape Recovery rows. \
       help/escape-recovery.md and help/what-data-is-collected.md both promise a cancelled \
       dictation is removed "the next time you launch it", and the in-app countdown says \
       "Deleted in 23h". Without this call the only sweep is the History view's .task, so a \
       user who never opens History keeps the plaintext of a dictation they cancelled, \
-      indefinitely.
+      indefinitely. Calls found: \(calls.sorted())
       """)
   }
 
-  @Test("the guard is not satisfied by a comment that merely names the sweep")
-  func theGuardIsNotSatisfiedByAComment() {
-    // The rejected twin of the accepted case above. The real launch body ships
-    // a comment naming `sweepExpiredPending()`, so without stripping, deleting
-    // the statement would leave the guard green — a guard that looks binding
-    // and is not, which is worse than none.
-    let commentOnly = """
-        appLifecycleCoordinator.runDidFinishLaunching()
-        Task { await recoveryCoordinator.scanAndRecover() }
-        // #2186: Task { await transcriptCoordinator.sweepExpiredPending() }
-        /* transcriptCoordinator.sweepExpiredPending() */
+  @Test("no unexecuted spelling of the sweep can satisfy the launch guard")
+  func unexecutedSpellingsDoNotCount() throws {
+    // The rejected twin of the accepted case above, over every form that
+    // defeated the earlier text version: a line comment, a block comment, a
+    // string literal, and a call alive only inside an inactive `#if`. Without
+    // this, a future simplification back to text matching would look equivalent.
+    let decoys = """
+      final class Fixture {
+        func applicationDidFinishLaunching() {
+          recoveryCoordinator.scanAndRecover()
+          // transcriptCoordinator.sweepExpiredPending()
+          /* transcriptCoordinator.sweepExpiredPending() */
+          log("transcriptCoordinator.sweepExpiredPending()")
+          #if DEBUG
+            Task { await transcriptCoordinator.sweepExpiredPending() }
+          #endif
+        }
+      }
       """
-    let stripped = Self.strippingComments(commentOnly)
+    let found = try #require(
+      Self.calls(inFunctionNamed: "applicationDidFinishLaunching", source: decoys))
 
     #expect(
-      !stripped.contains("transcriptCoordinator.sweepExpiredPending("),
-      "a commented-out sweep must not satisfy the launch guard")
-    // Paired accepted case, so a stripper that simply deletes everything cannot
-    // pass this suite.
+      !found.contains("transcriptCoordinator.sweepExpiredPending"),
+      "a commented, quoted or #if-only sweep must not satisfy the launch guard: \(found.sorted())")
+    // Paired accepted case in the same fixture, so a walker that simply finds
+    // nothing cannot pass this suite.
     #expect(
-      stripped.contains("scanAndRecover("),
-      "the stripper removed live code, not just comments")
+      found.contains("recoveryCoordinator.scanAndRecover"),
+      "the walker missed a live call in the same body: \(found.sorted())")
+  }
+
+  @Test("a real call is still found when it sits inside a Task closure")
+  func aCallInsideATaskClosureCounts() throws {
+    // The shipping shape. Asserted separately so that if the production call is
+    // ever moved out of its `Task`, the failure names the shape rather than
+    // looking like a deleted call.
+    let shipped = """
+      final class Fixture {
+        func applicationDidFinishLaunching() {
+          Task { await transcriptCoordinator.sweepExpiredPending() }
+        }
+      }
+      """
+    let found = try #require(
+      Self.calls(inFunctionNamed: "applicationDidFinishLaunching", source: shipped))
+    #expect(found.contains("transcriptCoordinator.sweepExpiredPending"))
   }
 }

--- a/Tests/EnviousWisprTests/App/EscapeRecoveryLaunchSweepTests.swift
+++ b/Tests/EnviousWisprTests/App/EscapeRecoveryLaunchSweepTests.swift
@@ -1,0 +1,177 @@
+import Foundation
+import Testing
+
+/// #2186: the launch path must sweep expired Escape Recovery rows.
+///
+/// ## The promise this binds
+///
+/// Three shipped surfaces tell the user a cancelled dictation is DELETED on a
+/// schedule, and `testing-philosophy.md`
+/// RULE: a-public-product-promise-needs-a-binding-test says a claim like that
+/// gets one test that fails when it stops being true. There was none, which is
+/// how the copy and the code drifted apart in silence:
+///
+/// - `website/src/content/help/escape-recovery.md` — "removes it while the app
+///   is running, **or the next time you launch it** … a dictation whose window
+///   ended while the app was closed is **removed at the next launch**"
+/// - `website/src/content/help/what-data-is-collected.md` — "After that it is
+///   removed while the app is running, or the next time you launch it."
+/// - `EscapeRecoveryRowPresentation.countdown` — "Deleted in 23h", "Deleting"
+///
+/// Before this guard, `TranscriptCoordinator.sweepExpiredPending()` was
+/// reachable only from `load()`, whose one production caller is the History
+/// view's `.task`, and from a pulse that arms on `pendingPulseHasWork` — which
+/// reads `transcripts`, which only `load()` populates. A user who never opened
+/// History never swept, so "removed at the next launch" did not happen at the
+/// next launch.
+///
+/// ## This is a Drift Guard, and saying so is not bookkeeping
+///
+/// It proves the CALL is wired, never that a file left disk. The sweep's own
+/// behaviour is already covered by `EscapeRecoveryTelemetryTests`, which drives
+/// `sweepExpiredPending()` directly; duplicating that here would multiply an
+/// axis without reaching a new branch.
+///
+/// ## Why it reads source
+///
+/// `applicationDidFinishLaunching()` cannot be constructed in a unit test — it
+/// needs the whole object graph and `NSApp`. This repo has no unit test
+/// asserting ANY launch-time wiring: the neighbouring `scanAndRecover()` limb
+/// is proven by Live UAT (`Tests/RuntimeUAT/SCENARIOS.md`), and the app-layer
+/// ceilings suites parse source for the same reason. Reading the declaration is
+/// the only mechanism available, so this is a tripwire on the launch method,
+/// paired with the Live UAT that proves the behaviour end to end.
+///
+/// **Comments are stripped before matching, and that is load-bearing rather
+/// than tidy.** The production call ships under a comment block that names
+/// `sweepExpiredPending()` in prose. A guard matching raw text would be
+/// satisfied by that comment alone, so deleting the actual statement would
+/// leave this test GREEN — the mutant would survive and the guard would be a
+/// decoration. `theGuardIsNotSatisfiedByAComment` is the paired rejected case
+/// that holds the stripper honest.
+@Suite(.tags(.driftGuard))
+struct EscapeRecoveryLaunchSweepTests {
+
+  private static let sourcePath = "Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift"
+
+  private static func bootstrapperSource() throws -> String {
+    try String(contentsOf: RepoRoot.url.appending(path: sourcePath), encoding: .utf8)
+  }
+
+  /// The body of `applicationDidFinishLaunching()`, by brace matching.
+  ///
+  /// Scoped to the METHOD rather than the file on purpose: `WisprBootstrapper`
+  /// is ~1,200 lines and mentions the coordinator many times, so a file-wide
+  /// match would be satisfied by construction and could never fail. The
+  /// question is whether the LAUNCH reaches the sweep.
+  static func launchBody(in source: String) -> String? {
+    guard let signature = source.range(of: "func applicationDidFinishLaunching()") else {
+      return nil
+    }
+    guard let open = source[signature.upperBound...].firstIndex(of: "{") else { return nil }
+    var depth = 0
+    var index = open
+    while index < source.endIndex {
+      if source[index] == "{" { depth += 1 }
+      if source[index] == "}" {
+        depth -= 1
+        if depth == 0 {
+          return String(source[source.index(after: open)..<index])
+        }
+      }
+      index = source.index(after: index)
+    }
+    return nil
+  }
+
+  /// Remove `//` line comments and `/* */` block comments.
+  ///
+  /// Deliberately does NOT try to respect string literals: the launch body
+  /// contains none, and a stripper that models Swift's full lexical grammar is
+  /// a bigger surface than the thing it guards. If a literal ever appears here
+  /// the positive control below fails first, loudly.
+  static func strippingComments(_ body: String) -> String {
+    var out = ""
+    var iterator = body.startIndex
+    var inLine = false
+    var inBlock = false
+    while iterator < body.endIndex {
+      let rest = body[iterator...]
+      if !inLine, !inBlock, rest.hasPrefix("//") {
+        inLine = true
+        iterator = body.index(iterator, offsetBy: 2)
+        continue
+      }
+      if !inLine, !inBlock, rest.hasPrefix("/*") {
+        inBlock = true
+        iterator = body.index(iterator, offsetBy: 2)
+        continue
+      }
+      if inBlock, rest.hasPrefix("*/") {
+        inBlock = false
+        iterator = body.index(iterator, offsetBy: 2)
+        continue
+      }
+      if inLine, body[iterator] == "\n" { inLine = false }
+      if !inLine, !inBlock { out.append(body[iterator]) }
+      iterator = body.index(after: iterator)
+    }
+    return out
+  }
+
+  @Test("the launch deletes expired cancelled dictations without waiting for History")
+  func launchSweepsExpiredPendingRows() throws {
+    let source = try Self.bootstrapperSource()
+    let body = try #require(
+      Self.launchBody(in: source),
+      "applicationDidFinishLaunching() not found — this guard's subject moved, it did not pass")
+    let code = Self.strippingComments(body)
+
+    // POSITIVE CONTROL, and it runs first for a reason: if the extraction or
+    // the stripper broke, BOTH assertions fail and the failure is about this
+    // instrument rather than about the launch path. Without it, an empty `code`
+    // reads exactly like a deleted call.
+    #expect(
+      code.contains("scanAndRecover("),
+      """
+      #2186 control: the neighbouring crash-recovery limb is missing from the extracted \
+      launch body, so this guard could not see the launch path at all. Fix the extraction \
+      before reading the assertion below.
+      """)
+
+    #expect(
+      code.contains("transcriptCoordinator.sweepExpiredPending("),
+      """
+      #2186: applicationDidFinishLaunching() no longer sweeps expired Escape Recovery rows. \
+      help/escape-recovery.md and help/what-data-is-collected.md both promise a cancelled \
+      dictation is removed "the next time you launch it", and the in-app countdown says \
+      "Deleted in 23h". Without this call the only sweep is the History view's .task, so a \
+      user who never opens History keeps the plaintext of a dictation they cancelled, \
+      indefinitely.
+      """)
+  }
+
+  @Test("the guard is not satisfied by a comment that merely names the sweep")
+  func theGuardIsNotSatisfiedByAComment() {
+    // The rejected twin of the accepted case above. The real launch body ships
+    // a comment naming `sweepExpiredPending()`, so without stripping, deleting
+    // the statement would leave the guard green — a guard that looks binding
+    // and is not, which is worse than none.
+    let commentOnly = """
+        appLifecycleCoordinator.runDidFinishLaunching()
+        Task { await recoveryCoordinator.scanAndRecover() }
+        // #2186: Task { await transcriptCoordinator.sweepExpiredPending() }
+        /* transcriptCoordinator.sweepExpiredPending() */
+      """
+    let stripped = Self.strippingComments(commentOnly)
+
+    #expect(
+      !stripped.contains("transcriptCoordinator.sweepExpiredPending("),
+      "a commented-out sweep must not satisfy the launch guard")
+    // Paired accepted case, so a stripper that simply deletes everything cannot
+    // pass this suite.
+    #expect(
+      stripped.contains("scanAndRecover("),
+      "the stripper removed live code, not just comments")
+  }
+}


### PR DESCRIPTION
## A cancelled dictation is now deleted at launch, as three shipped surfaces promise

Escape Recovery holds a dictation you cancelled for 24 hours and then deletes it. Three shipped surfaces say so:

| Surface | Text |
|---|---|
| `help/escape-recovery.md` | "removes it while the app is running, **or the next time you launch it** … a dictation whose window ended while the app was closed is **removed at the next launch**" |
| `help/what-data-is-collected.md` | "After that it is **removed** while the app is running, or the next time you launch it." |
| in-app countdown | `"Deleted in 23h"`, `"Deleting"` |

The sweep that performs that deletion was reachable from exactly two places: `TranscriptCoordinator.load()`, whose only production caller is the History view's `.task`, and an expiry pulse that arms on `pendingPulseHasWork` — which reads `transcripts`, which only `load()` populates. `applicationDidFinishLaunching()` reached neither.

**So on a launch where History is never opened, nothing looks at the pending directory at all.** Read-time expiry hides the row; the plaintext of a dictation the user CANCELLED stays on disk indefinitely. "Removed at the next launch" did not happen at the next launch.

## The change

The launch now sweeps, **after** the crash-recovery scan, in one task. No guard is needed — `TranscriptStore.deleteExpiredPending` already coalesces, so a launch racing a History open is safe by construction. With Escape Recovery off (the default) the pending directory does not exist and this costs one `fileExists`.

### Why the ordering is load-bearing, and why the first version got it wrong

The plan and the first commit both argued these were independent limbs: *"different namespaces (audio spools vs pending transcripts), so no ordering is required."* **That was false, and review round 2 caught it.**

`scanAndRecover()` de-dupes against `TranscriptStore.allRecoveredSessionIDs()`, which reads the very pending rows this sweep deletes — a saved row is what proves its spool was already recovered. That property's own doc comment ignores expiry for exactly this reason:

> filtering by expiry here would let a spool whose row aged out get replayed a second time, handing the user a duplicate dictation exactly 24 hours later

As two concurrent tasks, the sweep could delete that proof before the scan read it. The scan would then treat a surviving spool as new and **recreate a dictation the user cancelled** — the harm Escape Recovery exists to prevent, and the same harm #2185 was closed over, reachable through a door this change opened.

The claim was a structural assertion about what this change made true, with no oracle but the diff describing it, sitting in a comment above the line responsible. Kept in the plan as superseded text rather than quietly rewritten, because the shape is the finding.

Also corrects the comment at the `load()` call site, which stated the placement "rather than at process launch" was deliberate because "a missed sweep is not a user-facing bug." That reasoning is sound about the UI and silent about the disk, which is the half the copy promises. The superseded wording is kept and labelled rather than deleted, because the reason it was wrong is the finding.

## The test, and why its first version was refused

`EscapeRecoveryLaunchSweepTests`, declared a **Drift Guard** rather than counted as product coverage: it proves the CALL is wired, never that a file left disk. The sweep's own behaviour is already covered by `EscapeRecoveryTelemetryTests`.

The first version matched text and review was right to refuse it. **The shipped call sits under a comment block that names `sweepExpiredPending()` in prose, so a raw match stayed green after the statement was deleted** — a guard that looks binding and is not, which is worse than none. Stripping comments fixed one lexical form and left the class: a string literal, or a call surviving only inside an inactive `#if`, would both have satisfied it, and the positive control could not tell.

It now walks a `SwiftParser` tree and requires an actual call expression inside `applicationDidFinishLaunching`. Comments and every string form are excluded structurally rather than one spelling at a time. `#if` subtrees are skipped outright, which is deliberately stronger than review asked for: a launch sweep reachable only under a compilation condition does not ship to the users the promise was made to.

It also collects calls **in order** rather than as a set, and requires the scan's index below the sweep's — so the ordering above is a tested contract, not a comment. The index lookups use `#require`, not `if let`, so a missing call fails rather than silently skipping the ordering assertion.

Three cases, paired accepted-and-rejected so a walker that finds nothing cannot pass:
- the real launch body reaches the sweep, in the right order (with a positive control on the neighbouring `scanAndRecover` limb, so a broken parse fails as an instrument fault rather than as a missing call);
- a comment, a block comment, a string literal and an `#if DEBUG`-only call are all rejected in one fixture;
- a real call inside a `Task` closure is still found — the shipping shape, asserted separately so moving it out of the `Task` names the shape rather than looking like a deletion.

## Validation

**Mutation battery, real runner, 3/3 CAUGHT**, baseline green before and after, every file byte-restored:

| Row | Result |
|---|---|
| delete the launch sweep call | CAUGHT |
| hide it behind a compilation condition | CAUGHT |
| swap the two awaits (the round-2 P1) | CAUGHT |

- **Both lanes**, real nonzero counts, reconciled per bundle.
- **Codex review to an explicit all-clear**, confirming re-run after each round's findings were fixed.
- **Live UAT, three arms** — an expired row is gone after a launch that never opens History; an in-window row survives that same launch; with the fix reverted the expired row is still there. The middle arm is load-bearing: a malformed fixture is swept as garbage with no receipt, so without it a broken test file would delete in arm one and read as a pass.

## One thing this PR did not add, and it is not an oversight

The launch comment is three lines, not twenty-five. The first version pushed `WisprBootstrapper.swift` past the 1360-line ceiling `EnviousWisprAppCeilingsTests` enforces — a whole-file guard that no suite name, symbol, or diff line in this change points at. The rationale lives here and in the commit messages, both frozen; the comment keeps only what does not decay.

## Known limit, stated rather than discovered later

A row carried over from a previous session that lapses *during* a long session where History is never opened is still deleted at the *next* launch rather than at its moment. All three surfaces state an OR — "while the app is running, **or** the next time you launch it" — so that sits inside the promise. Closing it needs a launch-time pending load, which would put the union-by-ID merge and the append race on the launch path for a row no view is showing. Worst case after this change: deletion is late by one session. Before this change: never.

Part of #2186
