### PR TITLE
fix(battery): grade rows from the result bundle, not from scraped console text

### DIFF
--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -635,10 +635,10 @@ check_row("the named test failing scores CAUGHT",
 # never reached anything the suite observes — today that scored identically to a
 # working guard, which is the verdict that sends an overnight session to "fix" a
 # test that is fine.
-check_row("a mutant that changes NOTHING is SURVIVED-NOOP, not a survivor to fix",
+check_row("a mutant that changes NOTHING is SURVIVED-UNOBSERVED, not a survivor to fix",
           (5, [], True, "log", 0, 3.0,
            mk_results({VALID_ROW["expect_fail"]: "Passed", "some other case": "Passed"})),
-          expect_marker="SURVIVED-NOOP", expect_rc=1)
+          expect_marker="SURVIVED-UNOBSERVED", expect_rc=1)
 
 check_row("a DIFFERENT test failing is CAUGHT-ELSEWHERE, never evidence about this guard",
           (5, [], True, "log", 65, 3.0,
@@ -775,6 +775,68 @@ else:
             "one claim, and moving only one silently retires the check.")
     else:
         print("  ok  the stubbed lane returns the same shape as the real one")
+
+# ---- cloud review r1 on #2246: three findings, each with a case that fails
+# ---- against the pre-fix code.
+
+# P2: a CATCH REQUIRES A FAILURE. Passed -> Skipped is a status CHANGE and is not
+# another guard going red; crediting it would score a disappearance as detection.
+ran += 1
+_base = mk_results({"guard": "Passed", "sibling": "Passed"})
+_mut = mk_results({"guard": "Passed", "sibling": "Skipped"})
+_v, _d = battery.classify_row(_base, _mut, "guard")
+if _v == battery.VERDICT_CAUGHT_ELSEWHERE:
+    failures.append("a skipped sibling is not another guard catching the mutation — it was scored "
+                    "CAUGHT-ELSEWHERE, so a disappearance reads as detection")
+elif _v != battery.VERDICT_SURVIVED:
+    failures.append(f"a skipped sibling is not another guard catching the mutation — got {_v}")
+elif "newly failed" not in _d:
+    failures.append("a skipped sibling is not another guard catching the mutation — the detail does "
+                    "not say nothing newly failed")
+else:
+    print("  ok  a skipped sibling is not another guard catching the mutation")
+
+# The accepted counterpart, so the check above cannot pass by refusing everything.
+ran += 1
+_mut2 = mk_results({"guard": "Passed", "sibling": "Failed"})
+_v2, _ = battery.classify_row(_base, _mut2, "guard")
+if _v2 != battery.VERDICT_CAUGHT_ELSEWHERE:
+    failures.append(f"a sibling that newly FAILS is still CAUGHT-ELSEWHERE — got {_v2}")
+else:
+    print("  ok  a sibling that newly FAILS is still CAUGHT-ELSEWHERE")
+
+# P1b: an unchanged test set has TWO causes and the statuses cannot separate them.
+# The verdict must name both, never assert the recipe is at fault — that reverses
+# the tool's guidance for the ordinary surviving mutant, which is its main subject.
+ran += 1
+_v3, _d3 = battery.classify_row(_base, mk_results({"guard": "Passed", "sibling": "Passed"}), "guard")
+_problems = []
+if _v3 != battery.VERDICT_NOOP:
+    _problems.append(f"verdict {_v3}")
+if "no assertion for what the mutation changed" not in _d3:
+    _problems.append("the detail does not offer the missing-assertion cause")
+if "RECIPE needs re-aiming" not in _d3:
+    _problems.append("the detail does not offer the no-op cause")
+if "cannot separate them" not in _d3:
+    _problems.append("the detail does not say the statuses cannot distinguish the two")
+if _problems:
+    failures.append("an unchanged test set names BOTH causes and asserts neither — "
+                    + "; ".join(_problems))
+else:
+    print("  ok  an unchanged test set names BOTH causes and asserts neither")
+
+# P1a: the row gate is fed from the BUNDLE, so a parameterized identifier resolves.
+# The console has no addressable name for one, so a console-derived gate refused
+# the very recipes #2225 exists to enable — before the verdict path ever ran.
+ran += 1
+_par = mk_results({"egOneUpdatePausedReadsAsNeedingAttention(_:)": "Passed"})
+if "StubSuite/egOneUpdatePausedReadsAsNeedingAttention(_:)" not in set(_par.aliases):
+    failures.append("a parameterized identifier is a legal recipe name — the qualified form is "
+                    "absent from the alias index, so a recipe naming it would be refused")
+elif not _par.resolve("StubSuite/egOneUpdatePausedReadsAsNeedingAttention(_:)"):
+    failures.append("a parameterized identifier is a legal recipe name — it does not resolve")
+else:
+    print("  ok  a parameterized identifier is a legal recipe name")
 
 # A mutation that removes a completion or cancellation path is among the most valuable to write and the
 # most likely to HANG. Unbounded, the unattended battery sits on that row all night and never reaches
@@ -1057,7 +1119,7 @@ for _label, _will_run, _want_refusal in [
 check_row("a known issue does not change status, so it is a NO-OP, never CAUGHT",
           (5, [], True, "log", 0, 3.0,
            mk_results({VALID_ROW["expect_fail"]: "Passed", "some other case": "Passed"})),
-          expect_marker="SURVIVED-NOOP", expect_rc=1)
+          expect_marker="SURVIVED-UNOBSERVED", expect_rc=1)
 
 # The exclusion's own case: a RED lane where the ONLY mention of the named test is a known issue. If
 # known-issue lines counted as failures this would score CAUGHT; excluded, the row is correctly not a

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -2054,6 +2054,65 @@ if not _probs4 or "timed out" not in _probs4[0]:
 else:
     print("  ok  a lane timeout is still a baseline problem")
 
+# UNREACHABLE IN PRODUCTION, PINNED ANYWAY. A lane that compiles and passes but yields
+# no result bundle cannot happen as the callers stand: that branch requires `compiled`,
+# and `run_suite` returns a SuiteResults whenever it compiled because the reader raises
+# rather than returning None. The branch used to fall back to console-scraped names —
+# the exact defect this branch removed, and console naming cannot see a parameterized
+# test at all. An unreachable branch that WOULD be a defect if reachable is the one
+# nothing can catch: no test, no review, no mutation row can enter it, so it is not
+# wrong today and becomes wrong silently the moment some unrelated change makes it
+# reachable. `baseline` takes its lane, so a fake one reaches it here and holds it.
+class _NoResultsLane:
+    def run_suite(self, suite, tag):
+        return (5, [], True, Path("/tmp/x.log"), 0, 1.0, None)
+
+
+ran += 1
+_seen_nr = {}
+_probs_nr = battery.baseline(_NoResultsLane(), ["EnviousWisprTests/Odd"], "before",
+                             seen_names=_seen_nr)
+if not _probs_nr:
+    failures.append("a compiled lane with no result bundle refuses — it did not: baseline accepted "
+                    "it, and would name tests from console text, which cannot see a parameterized "
+                    "test at all")
+elif _seen_nr:
+    failures.append(f"a compiled lane with no result bundle refuses — it recorded names anyway: "
+                    f"{_seen_nr}")
+else:
+    print("  ok  a compiled lane with no result bundle refuses rather than scraping the console")
+
+# --- a documented return shape must match the code ------------------------------
+# `_STUB_ARITY` above pins run_suite's arity and says to update the stubs and the
+# constant together. It said nothing about the DOCSTRING, so that drifted: it promised
+# a 4-tuple while the function had returned 7 since this branch began, and it was found
+# by an AST check during self-audit rather than by anyone reading it. A docstring is the
+# one artifact with no compiler, so give it a mechanical check instead of an intention.
+# Structural, over the AST — no text patterns, no phrase matching.
+ran += 1
+import ast as _ast_d  # noqa: E402
+import re as _re_d  # noqa: E402
+_tree_d = _ast_d.parse(Path(battery.__file__).read_text())
+_mismatch = []
+for _fn in _ast_d.walk(_tree_d):
+    if not isinstance(_fn, (_ast_d.FunctionDef, _ast_d.AsyncFunctionDef)):
+        continue
+    _doc = _ast_d.get_docstring(_fn)
+    if not _doc:
+        continue
+    _m = _re_d.search(r"\(([^)]*,[^)]*)\)", _doc.splitlines()[0])
+    if not _m:
+        continue
+    _promised = len([p for p in _m.group(1).split(",") if p.strip()])
+    _arities = {len(s.value.elts) for s in _ast_d.walk(_fn)
+                if isinstance(s, _ast_d.Return) and isinstance(s.value, _ast_d.Tuple)}
+    if _arities and _promised not in _arities:
+        _mismatch.append(f"{_fn.name}: docstring promises {_promised}, code returns {sorted(_arities)}")
+if _mismatch:
+    failures.append("a documented return shape matches the code — it does not: " + "; ".join(_mismatch))
+else:
+    print("  ok  a documented return shape matches the code")
+
 print()
 if failures:
     print(f"{len(failures)} of {ran} FAILED:")

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -1908,6 +1908,67 @@ finally:
     battery.Lane._run_package_prep = _real_prep
     battery.run = _real_run7
 
+# --- the operator-facing summary ------------------------------------------------
+# Nothing rendered this block before: it was declared inside `main()`, after a full
+# lane, so the self-test could not reach it. `classify_row` had a dozen cases and the
+# text a human acts on had none — which is how "re-aim the RECIPE" survived here for a
+# review round after being removed from the classifier one screen up.
+
+# STRUCTURAL, and the strongest of the three: every verdict the module declares must
+# have an entry. The old `.get(verdict, "")` rendered a BLANK line for an unmapped one,
+# so adding a verdict constant would silently ship a report with no guidance under it.
+# Closed set, enumerated from the module itself rather than a hand-written list, so a
+# verdict added tomorrow is covered without editing this case.
+ran += 1
+# The set is the code's OWN partition, not every constant: `main` computes
+# `bad = [r for r in results if r[0] != VERDICT_CAUGHT]`, so a CATCH never reaches
+# the report and needs no entry. Derived that way rather than by a hand-written
+# exclusion, so a verdict added later is covered without editing this case — the
+# first version quantified over every VERDICT_* and reported CAUGHT as a defect.
+_verdicts = {v for k, v in vars(battery).items()
+             if k.startswith("VERDICT_") and isinstance(v, str)} - {battery.VERDICT_CAUGHT}
+_unmapped = sorted(v for v in _verdicts if v not in battery.WHAT_IT_MEANS)
+if _unmapped:
+    failures.append(f"every declared verdict has operator guidance — {_unmapped} do not, so the "
+                    f"report prints a blank line where the guidance belongs")
+else:
+    print("  ok  every declared verdict has operator guidance")
+
+ran += 1
+try:
+    battery.explain_verdict("NOT-A-VERDICT")
+    failures.append("an unmapped verdict fails loud rather than rendering a blank line — it did "
+                    "not: explain_verdict returned instead of raising")
+except AssertionError:
+    print("  ok  an unmapped verdict fails loud rather than rendering a blank line")
+
+# A verdict whose cause the statuses CANNOT determine must not be handed a single
+# remediation here. `classify_row` says an unchanged test set has two causes and that
+# the statuses cannot separate them; a summary line that picks one contradicts the
+# classifier, and the summary is what gets acted on.
+ran += 1
+_noop = battery.WHAT_IT_MEANS[battery.VERDICT_NOOP]
+_blames_recipe = "recipe" in _noop.lower()
+_blames_test = "test" in _noop.lower()
+if _blames_recipe and not _blames_test:
+    failures.append(f"an undetermined cause is not given a single remediation in the summary — it "
+                    f"is: {battery.VERDICT_NOOP} reads {_noop!r}, prescribing the RECIPE alone, while "
+                    f"classify_row says the statuses cannot say which of two causes it is. The "
+                    f"operator is sent to re-aim a recipe when the TEST may be at fault.")
+else:
+    print("  ok  an undetermined cause is not given a single remediation in the summary")
+
+# PAIRED ACCEPTED CASE, so the check above cannot pass by refusing every summary that
+# mentions a recipe. CAUGHT-ELSEWHERE has ONE cause the statuses do establish — another
+# test went red — and its summary is allowed to say so plainly.
+ran += 1
+_elsewhere = battery.WHAT_IT_MEANS[battery.VERDICT_CAUGHT_ELSEWHERE]
+if "different test caught it" not in _elsewhere:
+    failures.append(f"a verdict whose cause IS established still states it plainly — it does not: "
+                    f"CAUGHT-ELSEWHERE reads {_elsewhere!r}")
+else:
+    print("  ok  a verdict whose cause IS established still states it plainly")
+
 print()
 if failures:
     print(f"{len(failures)} of {ran} FAILED:")

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -838,6 +838,67 @@ elif not _par.resolve("StubSuite/egOneUpdatePausedReadsAsNeedingAttention(_:)"):
 else:
     print("  ok  a parameterized identifier is a legal recipe name")
 
+# ---- cloud review r2 on #2246
+
+# (b) AMBIGUITY ANYWHERE IS AMBIGUITY. With `mutated or baseline`, a name that is
+# ambiguous in the BASELINE resolved to a singleton whenever execution stopped
+# before the second test reached the mutated bundle — so the ambiguity check was
+# skipped exactly when the run was cut short.
+ran += 1
+_amb_base = battery.SuiteResults(
+    {"A/shared": "Passed", "B/shared": "Passed"},
+    {"shared": {"A/shared", "B/shared"}}, {})
+_amb_mut = battery.SuiteResults({"A/shared": "Failed"}, {"shared": {"A/shared"}}, {})
+_v, _d = battery.classify_row(_amb_base, _amb_mut, "shared")
+if _v != battery.VERDICT_INVALID:
+    failures.append("a name ambiguous in the BASELINE stays ambiguous when the mutated run is cut "
+                    f"short — got {_v}, so the row was graded against whichever test happened to run")
+elif "ambiguous" not in _d:
+    failures.append("a name ambiguous in the BASELINE stays ambiguous — the detail does not say so")
+else:
+    print("  ok  a name ambiguous in the BASELINE stays ambiguous")
+
+# The accepted counterpart, so the check above cannot pass by refusing everything.
+ran += 1
+_ok_base = battery.SuiteResults({"A/only": "Passed"}, {"only": {"A/only"}}, {})
+_ok_mut = battery.SuiteResults({"A/only": "Failed"}, {"only": {"A/only"}}, {})
+_v2, _ = battery.classify_row(_ok_base, _ok_mut, "only")
+if _v2 != battery.VERDICT_CAUGHT:
+    failures.append(f"an unambiguous name still resolves and scores CAUGHT — got {_v2}")
+else:
+    print("  ok  an unambiguous name still resolves and scores CAUGHT")
+
+# (a) A STALE BUNDLE MUST STOP THE ROW, NEVER BE READ. `ignore_errors=True` let a
+# bundle that could not be removed survive; xcodebuild then declines to overwrite
+# it and the read returns the PREVIOUS row's results under this row's name.
+ran += 1
+import tempfile as _t9  # noqa: E402
+with _t9.TemporaryDirectory() as _td9:
+    _ld = Path(_td9) / "logs"
+    _ld.mkdir()
+    _l9 = battery.Lane(Path(_td9), Path(_td9) / "dd", _ld)
+    _l9.generated = True
+    _stale = _l9.bundle_path("tag")
+    _stale.mkdir(parents=True)
+    # Make it undeletable so the removal cannot succeed, which is the case
+    # `ignore_errors=True` swallowed.
+    (_stale / "keep").write_text("x")
+    import os as _os9
+    _os9.chmod(_stale, 0o500)
+    try:
+        _l9.run_suite("EnviousWisprTests/Whatever", "tag")
+        failures.append("a stale result bundle that cannot be removed STOPS the row — it did not; "
+                        "the row would be graded against an earlier run's results")
+    except battery._RowFailed as _e9:
+        if "could not be removed" not in str(_e9):
+            failures.append(f"a stale result bundle stops the row — wrong reason: {_e9}")
+        else:
+            print("  ok  a stale result bundle that cannot be removed STOPS the row")
+    except Exception as _e9:  # noqa: BLE001
+        failures.append(f"a stale result bundle stops the row — raised {type(_e9).__name__}: {_e9}")
+    finally:
+        _os9.chmod(_stale, 0o700)
+
 # A mutation that removes a completion or cancellation path is among the most valuable to write and the
 # most likely to HANG. Unbounded, the unattended battery sits on that row all night and never reaches
 # its restore — leaving a mutated tree behind, which is the one outcome worse than a wrong verdict.

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -880,11 +880,16 @@ with _t9.TemporaryDirectory() as _td9:
     _l9.generated = True
     _stale = _l9.bundle_path("tag")
     _stale.mkdir(parents=True)
-    # Make it undeletable so the removal cannot succeed, which is the case
-    # `ignore_errors=True` swallowed.
     (_stale / "keep").write_text("x")
-    import os as _os9
-    _os9.chmod(_stale, 0o500)
+    # SIMULATED AT THE SEAM, NOT WITH PERMISSION BITS. The first version chmod'd the
+    # bundle 0o500 to make the removal fail. As root that does not stop `rmtree` at
+    # all, so the removal SUCCEEDS, the row takes the unexpected path, and the
+    # `finally` then chmods a directory that no longer exists — a FileNotFoundError
+    # outside every except clause, aborting the entire self-test rather than failing
+    # one case. A control that depends on privilege proves nothing on half the
+    # machines that run it and takes the others down with it.
+    _real_rmtree9 = battery.shutil.rmtree
+    battery.shutil.rmtree = lambda *a, **k: None   # the removal that did not remove
     try:
         _l9.run_suite("EnviousWisprTests/Whatever", "tag")
         failures.append("a stale result bundle that cannot be removed STOPS the row — it did not; "
@@ -897,7 +902,7 @@ with _t9.TemporaryDirectory() as _td9:
     except Exception as _e9:  # noqa: BLE001
         failures.append(f"a stale result bundle stops the row — raised {type(_e9).__name__}: {_e9}")
     finally:
-        _os9.chmod(_stale, 0o700)
+        battery.shutil.rmtree = _real_rmtree9
 
 # A mutation that removes a completion or cancellation path is among the most valuable to write and the
 # most likely to HANG. Unbounded, the unattended battery sits on that row all night and never reaches
@@ -1968,6 +1973,86 @@ if "different test caught it" not in _elsewhere:
                     f"CAUGHT-ELSEWHERE reads {_elsewhere!r}")
 else:
     print("  ok  a verdict whose cause IS established still states it plainly")
+
+# --- baseline()'s own exception handling ----------------------------------------
+# `baseline` is replaced by `_stub_baseline` in every case that goes near it, so its
+# handlers had never been executed. A nonexistent suite makes xcodebuild SUCCEED with
+# an empty bundle, the read raises, and an uncaught raise printed a traceback instead
+# of the diagnostic written for exactly that case.
+
+
+class _RaisingLane:
+    """A lane whose suite run fails in a named way. Only `run_suite` is reached."""
+
+    def __init__(self, exc):
+        self._exc = exc
+
+    def run_suite(self, suite, tag):
+        raise self._exc
+
+
+class _CleanLane:
+    def run_suite(self, suite, tag):
+        return (5, [], True, Path("/tmp/x.log"), 0, 1.0,
+                battery.SuiteResults({"S/a()": "Passed"}, {"a()": {"S/a()"}}, {}))
+
+
+# CALLED ONCE, GUARDED, and both assertions read the result. The second case used to
+# call `baseline` again with no guard, so under the very mutant these cases exist to
+# catch it raised and took the whole self-test down before the summary printed — and
+# the control then reported WRONG-RED on a mutant case one had detected perfectly. A
+# case that can ABORT the run is worse than one that fails: it destroys every verdict
+# after it, including its own.
+_probs = None
+ran += 1
+try:
+    _probs = battery.baseline(_RaisingLane(battery.BundleUnreadable("zero Test Case nodes")),
+                              ["EnviousWisprTests/Gone"], "before")
+except battery.BundleUnreadable:
+    failures.append("an unreadable result bundle becomes a baseline problem — it did not: the "
+                    "exception ESCAPED baseline, so main prints a traceback instead of the "
+                    "diagnostic written for a nonexistent suite")
+if _probs is None:
+    pass
+elif not _probs:
+    failures.append("an unreadable result bundle becomes a baseline problem — it did not: baseline "
+                    "reported NO problems, so a run against a nonexistent suite would proceed to "
+                    "mutate")
+elif "could not be read" not in _probs[0]:
+    failures.append(f"an unreadable result bundle becomes a baseline problem — recorded, but with "
+                    f"the wrong reason: {_probs[0][:120]}")
+else:
+    print("  ok  an unreadable result bundle becomes a baseline problem")
+
+# The named cause has to survive into the message, because the message is the only
+# thing that sends an operator to the right place — a stale suite name.
+ran += 1
+if not _probs:
+    failures.append("the unreadable-bundle problem names the suite and the likely cause — there was "
+                    "no problem recorded to name anything")
+elif "@Suite" not in _probs[0] or "Gone" not in _probs[0]:
+    failures.append(f"the unreadable-bundle problem names the suite and the likely cause — it does "
+                    f"not: {_probs[0][:160]}")
+else:
+    print("  ok  the unreadable-bundle problem names the suite and the likely cause")
+
+# PAIRED ACCEPTED CASE, so the handler above cannot pass by reporting a problem for
+# everything: a suite that ran and passed produces NO problem.
+ran += 1
+_probs3 = battery.baseline(_CleanLane(), ["EnviousWisprTests/Fine"], "before")
+if _probs3:
+    failures.append(f"a clean suite produces no baseline problem — it produced {_probs3}")
+else:
+    print("  ok  a clean suite produces no baseline problem")
+
+# And the pre-existing timeout path still works, so the new clause did not displace it.
+ran += 1
+_probs4 = battery.baseline(_RaisingLane(battery._LaneTimedOut("timed out at 900s")),
+                           ["EnviousWisprTests/Slow"], "before")
+if not _probs4 or "timed out" not in _probs4[0]:
+    failures.append(f"a lane timeout is still a baseline problem — got {_probs4}")
+else:
+    print("  ok  a lane timeout is still a baseline problem")
 
 print()
 if failures:

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -77,7 +77,31 @@ ONLY_ACTIVE = [l for l in CANONICAL_STUB.split("\n") if "ONLY_ACTIVE_ARCH" in l]
 assert ONLY_ACTIVE in CANONICAL_STUB, "the stub line the drift cases edit must exist verbatim"
 
 
-def _stub_baseline(lane, suites, phase, seen_names=None):
+def mk_results(statuses, crashed=None):
+    """Build a `SuiteResults` the way a real bundle read would.
+
+    The stubbed cases drive `classify_row` directly, so they need the real class
+    rather than a dict — a hand-rolled stand-in could accept a shape the real
+    reader never produces, and the case would pass against a reader that cannot.
+    `statuses` maps a bare test name to its result; ids are qualified so the
+    alias index is exercised the same way it is in production.
+    """
+    by_id, aliases = {}, {}
+    for name, result in statuses.items():
+        ident = f"StubSuite/{name}"
+        by_id[ident] = result
+        for spelling in (ident, name):
+            aliases.setdefault(spelling, set()).add(ident)
+    return battery.SuiteResults(by_id, aliases, dict(crashed or {}))
+
+
+# The unmutated tree every stubbed row is graded against: the named guard passing,
+# one unrelated sibling passing. A row's verdict is the DIFF against this.
+def _baseline_results():
+    return mk_results({VALID_ROW["expect_fail"]: "Passed", "some other case": "Passed"})
+
+
+def _stub_baseline(lane, suites, phase, seen_names=None, results_out=None):
     """Stands in for the real baseline in stubbed-lane cases.
 
     It MUST populate `seen_names`: the runner refuses when a suite's baseline yielded no test
@@ -88,6 +112,9 @@ def _stub_baseline(lane, suites, phase, seen_names=None):
     if seen_names is not None:
         for suite in suites:
             seen_names[suite] = {VALID_ROW["expect_fail"], "some other case"}
+    if results_out is not None:
+        for suite in suites:
+            results_out[suite] = _baseline_results()
     return []
 
 
@@ -600,35 +627,57 @@ def check_row(name, lane_result, *, expect_marker, expect_rc, raise_instead=None
 
 # (count, failures, compiled, log, rc, elapsed)
 check_row("the named test failing scores CAUGHT",
-          (5, ["✘ Test \"the guard holds\" recorded an issue"], True, "log", 65, 3.0),
-          expect_marker="ok", expect_rc=0)
+          (5, [], True, "log", 65, 3.0,
+           mk_results({VALID_ROW["expect_fail"]: "Failed", "some other case": "Passed"})),
+          expect_marker="CAUGHT", expect_rc=0)
 
-check_row("the suite staying green scores SURVIVED, not a pass",
-          (5, [], True, "log", 0, 3.0),
-          expect_marker="SURV", expect_rc=1)
+# THE STATE THE CONSOLE COULD NOT EXPRESS. Nothing changed status, so the mutation
+# never reached anything the suite observes — today that scored identically to a
+# working guard, which is the verdict that sends an overnight session to "fix" a
+# test that is fine.
+check_row("a mutant that changes NOTHING is SURVIVED-NOOP, not a survivor to fix",
+          (5, [], True, "log", 0, 3.0,
+           mk_results({VALID_ROW["expect_fail"]: "Passed", "some other case": "Passed"})),
+          expect_marker="SURVIVED-NOOP", expect_rc=1)
 
-check_row("a DIFFERENT test failing is SURVIVED — something else caught it, so this test is not the guard",
-          (5, ["✘ Test \"some other case\" recorded an issue"], True, "log", 65, 3.0),
-          expect_marker="SURV", expect_rc=1)
+check_row("a DIFFERENT test failing is CAUGHT-ELSEWHERE, never evidence about this guard",
+          (5, [], True, "log", 65, 3.0,
+           mk_results({VALID_ROW["expect_fail"]: "Passed", "some other case": "Failed"})),
+          expect_marker="CAUGHT-ELSEWHERE", expect_rc=1)
+
+# A CRASH prints ZERO failure marks, so the console could not see it at all and
+# scored it SURVIVED while saying the lane was green. Both halves were false.
+check_row("a CRASH in the named test is CAUGHT, and the crash is named",
+          (5, [], True, "log", 65, 3.0,
+           mk_results({VALID_ROW["expect_fail"]: "Failed", "some other case": "Passed"},
+                      crashed={f'StubSuite/{VALID_ROW["expect_fail"]}':
+                               "Crash: xctest at StubSuite.theGuardHolds()"})),
+          expect_marker="crash:", expect_rc=0)
+
+# NOT COVERED HERE, deliberately and stated: "the guard was ALREADY red on the
+# unmutated tree" is INVALID-ROW in `classify_row`, and this harness cannot reach
+# it — `_stub_baseline` always reports the target passing. Reaching it needs a
+# per-case baseline, which is worth doing and is not done. Saying so beats a case
+# that asserts CAUGHT under an INVALID-ROW name.
 
 check_row("zero executed tests is an ERROR, never a survivor and never a catch",
-          (0, [], True, "log", 0, 3.0),
-          expect_marker="ERR", expect_rc=1)
+          (0, [], True, "log", 0, 3.0, None),
+          expect_marker="ERROR", expect_rc=1)
 
 check_row("no test summary at all is an ERROR",
-          (None, [], True, "log", 65, 3.0),
-          expect_marker="ERR", expect_rc=1)
+          (None, [], True, "log", 0, 3.0, None),
+          expect_marker="ERROR", expect_rc=1)
 
 check_row("a mutant that does not compile is an ERROR — a red lane proves nothing if nothing ran",
-          (None, [], False, "log", 65, 3.0),
-          expect_marker="ERR", expect_rc=1)
+          (None, [], False, "log", 65, 3.0, None),
+          expect_marker="ERROR", expect_rc=1)
 
 # The most dangerous defect this tool has had, and it is invisible to a byte comparison. `copy2`
 # restores the original MODIFICATION TIME along with the bytes. Against warm DerivedData, a replacement
 # the SAME SIZE as its anchor therefore leaves a file that is byte-identical AND older than the object
 # compiled from the mutant, so the next row can run mutant code while every check reports clean.
 ran += 1
-_res = drive_row((5, ['✘ Test "the guard holds" recorded an issue'], True, "log", 65, 3.0),
+_res = drive_row((5, [], True, "log", 65, 3.0, None),
                  expect_verdict=None, expect_detail=None)
 # drive_row returns (rc, out, after, during); re-run it capturing the file's mtime instead.
 import tempfile as _t3  # noqa: E402
@@ -651,7 +700,7 @@ with _t3.TemporaryDirectory() as td:
             pass
 
         def run_suite(self, suite, tag):
-            return (5, ['✘ Test "the guard holds" recorded an issue'], True, "log", 65, 3.0)
+            return (5, [], True, "log", 65, 3.0, None)
 
     _rl, _rb = battery.Lane, battery.baseline
     battery.Lane, battery.baseline = _StubLane, (_stub_baseline)
@@ -679,7 +728,7 @@ ran += 1
 _real_pids = battery.dev_app_pids
 battery.dev_app_pids = lambda wt: ["99999"]
 try:
-    rc, out, after, during = drive_row((5, [], True, "log", 0, 3.0),
+    rc, out, after, during = drive_row((5, [], True, "log", 0, 3.0, None),
                                        expect_verdict=None, expect_detail=None)
     problems = []
     if "ERR" not in out or "appeared mid-run" not in out:
@@ -712,13 +761,18 @@ if len(_returns) != 1:
     failures.append("the stubbed lane returns the same shape as the real one: Lane.run_suite has "
                     f"{len(_returns)} return statements; the stub assumes exactly 1")
 else:
+    # The stubs hand back a 7-tuple: (count, failures, compiled, log, rc, elapsed, results).
+    # The last slot is the parsed result bundle, and it is what every VERDICT now
+    # reads — a stub that omitted it would grade rows against `None` and score
+    # every one of them an error while looking like a shape mismatch.
+    _STUB_ARITY = 7
     _arity = len([t for t in _returns[0].split(",")])
-    if _arity != 6:
+    if _arity != _STUB_ARITY:
         failures.append(
             "the stubbed lane returns the same shape as the real one: "
-            f"Lane.run_suite now returns {_arity} values, but the stubbed-lane cases hand back 6. "
-            "Update the stub, or every row case is exercising a double that no longer resembles the "
-            "real lane.")
+            f"Lane.run_suite now returns {_arity} values, but the stubbed-lane cases hand back "
+            f"{_STUB_ARITY}. Update the stubs AND this constant together — they are two halves of "
+            "one claim, and moving only one silently retires the check.")
     else:
         print("  ok  the stubbed lane returns the same shape as the real one")
 
@@ -787,7 +841,15 @@ battery.run = _capture
 try:
     _lane = battery.Lane(Path("."), Path("."), Path("."))
     _lane.generated = True  # skip tuist; this case is about the test lane's timeout only
-    _lane.run_suite("EnviousWisprTests/Whatever", "tag")
+    try:
+        _lane.run_suite("EnviousWisprTests/Whatever", "tag")
+    except battery.BundleUnreadable:
+        # EXPECTED AND NOT WHAT IS UNDER TEST. `run` is stubbed, so no lane ran and
+        # no bundle exists; the assertion below is on the timeout kwarg `run_suite`
+        # passed, which has already happened by the time the read is attempted.
+        # Swallowing only this exception keeps the case honest — any other failure
+        # still surfaces.
+        pass
 finally:
     battery.run = _real_run
 
@@ -888,7 +950,10 @@ ran += 1
 _flagish = {a for a in _cmd if a.startswith("-") and not a.startswith("-only-testing")
             and a not in ("-project", "-scheme", "-configuration", "-derivedDataPath", "-destination")}
 _settings = {a for a in _cmd if "=" in a and a.split("=", 1)[0].isupper()}
-_extra = sorted((_flagish | _settings) - battery.CANONICAL_TOKENS)
+# RUNNER_ONLY_TOKENS is subtracted DELIBERATELY and is not a hole: each member
+# is declared at its definition with the reason it cannot change the build, so a
+# reviewer sees the divergence rather than inferring it from a green guard.
+_extra = sorted((_flagish | _settings) - battery.CANONICAL_TOKENS - battery.RUNNER_ONLY_TOKENS)
 if _extra:
     failures.append("the runner's command carries no setting the drift guard is blind to — it DOES: "
                     + ", ".join(_extra) + " would move unnoticed")
@@ -984,9 +1049,15 @@ for _label, _will_run, _want_refusal in [
 # Swift Testing prints ✘ for a KNOWN issue and the lane still exits 0. A test wrapped in
 # `withKnownIssue` is explicitly configured NOT to go red, so crediting it with detecting a mutation
 # is a false CAUGHT — the direction that fails toward confidence.
-check_row("a known issue on a GREEN lane is SURVIVED, never CAUGHT",
-          (5, ['✘ Test "the guard holds" recorded a known issue'], True, "log", 0, 3.0),
-          expect_marker="SURV", expect_rc=1)
+# A test wrapped in `withKnownIssue` is configured NOT to go red, so its status
+# does not change and the bundle records it as Passed. Under the diff that is a
+# NO-OP verdict, which is both correct and STRONGER than the old "SURVIVED":
+# it says nothing in the suite moved, rather than implying the guard was tested
+# and found wanting.
+check_row("a known issue does not change status, so it is a NO-OP, never CAUGHT",
+          (5, [], True, "log", 0, 3.0,
+           mk_results({VALID_ROW["expect_fail"]: "Passed", "some other case": "Passed"})),
+          expect_marker="SURVIVED-NOOP", expect_rc=1)
 
 # The exclusion's own case: a RED lane where the ONLY mention of the named test is a known issue. If
 # known-issue lines counted as failures this would score CAUGHT; excluded, the row is correctly not a
@@ -1013,14 +1084,21 @@ else:
 # The accepted counterpart: the same named test on a RED lane is a genuine catch.
 # Through the ROW LOOP, which is where expect_fail is compared. The direct failed_test_identities
 # cases use exact set membership and so cannot detect substring matching returning here.
-check_row("a sibling whose name contains the expected one does not score CAUGHT",
-          (5, ['✘ Test "the guard holds under load" recorded an issue at F.swift:1:1'],
-           True, "log", 65, 3.0),
-          expect_marker="SURV", expect_rc=1)
+# SUBSTRING MATCHING CANNOT RETURN, because the bundle is keyed exactly. The old
+# console path matched `expect_fail` with `in` against a whole ✘ line carrying the
+# display name, the file path AND the message, so a sibling whose name merely
+# CONTAINED the expected one scored CAUGHT. Here the sibling is a different key,
+# so it presents as CAUGHT-ELSEWHERE: something went red, and it was not the guard.
+check_row("a sibling whose name CONTAINS the expected one is not this guard",
+          (5, [], True, "log", 65, 3.0,
+           mk_results({VALID_ROW["expect_fail"]: "Passed",
+                       VALID_ROW["expect_fail"] + " under load": "Failed"})),
+          expect_marker="CAUGHT-ELSEWHERE", expect_rc=1)
 
-check_row("the same named test on a RED lane is still CAUGHT",
-          (5, ['✘ Test "the guard holds" recorded an issue'], True, "log", 65, 3.0),
-          expect_marker="ok", expect_rc=0)
+check_row("the named test itself going red is still CAUGHT",
+          (5, [], True, "log", 65, 3.0,
+           mk_results({VALID_ROW["expect_fail"]: "Failed", "some other case": "Passed"})),
+          expect_marker="CAUGHT", expect_rc=0)
 
 # A timeout must kill the whole process GROUP. xcodebuild spawns the test runner as a descendant, so
 # killing only the parent leaves a hung mutant test process holding the shared DerivedData and writing
@@ -1214,7 +1292,7 @@ with tempfile.TemporaryDirectory() as _td:
 
         def run_suite(self, suite, tag):
             _lanes.append(tag)
-            return (5, ['✘ Test "the guard holds" recorded an issue'], True, "log", 65, 3.0)
+            return (5, [], True, "log", 65, 3.0, None)
 
     _rl, _rb = battery.Lane, battery.baseline
     battery.Lane, battery.baseline = _CountingLane, (_stub_baseline)
@@ -1257,7 +1335,7 @@ def _boom(self, *a, **k):
 try:
     Path.write_text = _boom
     try:
-        _rc, _out, _after, _during = drive_row((5, [], True, "log", 0, 3.0),
+        _rc, _out, _after, _during = drive_row((5, [], True, "log", 0, 3.0, None),
                                                expect_verdict=None, expect_detail=None)
     except BaseException as _esc:   # noqa: BLE001 — an escape IS the defect this case exists for
         _rc, _out = -1, f"escaped as {type(_esc).__name__}"
@@ -1291,7 +1369,7 @@ def _copy_then_fail(src, dst, *a, **k):
 battery.shutil.copy2 = _copy_then_fail
 try:
     try:
-        _rc, _out, _after, _during = drive_row((5, [], True, "log", 0, 3.0),
+        _rc, _out, _after, _during = drive_row((5, [], True, "log", 0, 3.0, None),
                                                expect_verdict=None, expect_detail=None)
     except BaseException as _esc:   # noqa: BLE001 — escaping IS the defect this case exists for
         _rc, _out = -1, f"escaped as {type(_esc).__name__}"
@@ -1334,7 +1412,7 @@ _installed_at = []
 _real_sig = battery.signal.signal
 _real_base = battery.baseline
 battery.signal.signal = lambda sig, fn: _installed_at.append("handler")
-battery.baseline = lambda lane, suites, phase, seen_names=None: (_installed_at.append(f"baseline-{phase}"), [])[1]
+battery.baseline = lambda lane, suites, phase, seen_names=None, results_out=None: (_installed_at.append(f"baseline-{phase}"), [])[1]
 
 
 class _NullLane:
@@ -1477,7 +1555,7 @@ except Exception as exc:
 # identity lines, so empty means the READER broke.
 ran += 1
 _real_base2 = battery.baseline
-battery.baseline = lambda lane, suites, phase, seen_names=None: []   # green, but yields NO names
+battery.baseline = lambda lane, suites, phase, seen_names=None, results_out=None: []   # green, but yields NO names
 _rl2, battery.Lane = battery.Lane, type("L", (), {
     "__init__": lambda self, *a, **k: None,
     "generate_once": lambda self: None,

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -55,10 +55,16 @@ RECIPE FORMAT (JSON; the same block that goes in the `test-hardening` issue body
           "anchor":      "exact source text, must occur EXACTLY once",
           "replacement": "exact replacement text",
           "suite":       "EnviousWisprTests/FooTests",   // optional if suite_default is set
-          "expect_fail": "the test that must go red"     // substring-matched against failure lines
+          "expect_fail": "theGuard()"                    // FULL name, never a prefix: see below
         }
       ]
     }
+
+    `expect_fail` NAMES A TEST AND IS MATCHED EXACTLY — it is not a substring of the
+    failure line. Any one of the three spellings the result bundle carries will do:
+    the `Suite/function()` identifier, the bare `function()`, or the display name in
+    `@Test("...")`. A parameterized test keeps its `(_:)`. A prefix is refused before
+    anything is mutated, with the full name it was probably meant to be.
 
 USAGE
     scripts/mutation-battery.py --from-issue 2156        # the overnight form: recipe from the issue
@@ -623,6 +629,44 @@ VERDICT_SURVIVED = "SURVIVED"
 # recipe precisely when the TEST was at fault.
 VERDICT_NOOP = "SURVIVED-UNOBSERVED"
 VERDICT_INVALID = "INVALID-ROW"
+
+
+# WHAT TO DO ABOUT A ROW DEPENDS ON WHY IT IS NOT A CATCH, and the old report
+# collapsed every non-catch into "needs work" — which sent an overnight session to
+# tighten a test when the RECIPE was the problem.
+#
+# MODULE LEVEL SO IT CAN BE TESTED. It lived inside `main()`, reachable only after a
+# full lane, so nothing rendered it and the self-test could not see it. That is why
+# the categorical "re-aim the RECIPE" claim survived HERE for a whole review round
+# after being removed from `classify_row`: the classifier is heavily covered and the
+# text the operator actually acts on had no coverage at all.
+#
+# A VERDICT WHOSE CAUSE THE STATUSES CANNOT DETERMINE MUST NOT BE GIVEN A SINGLE
+# REMEDIATION HERE. `classify_row` owns that judgement; a second sentence of guidance
+# is a second owner, and it is the one that drifted.
+WHAT_IT_MEANS = {
+    VERDICT_NOOP: "no test changed status; the two causes, and how to tell them apart, are below",
+    VERDICT_CAUGHT_ELSEWHERE: "a different test caught it; this row says nothing about its own guard",
+    VERDICT_INVALID: "the row cannot prove anything as written",
+    VERDICT_SURVIVED: "the test did not detect the mutation",
+    "ERROR": "the row did not produce a verdict",
+}
+
+
+def explain_verdict(verdict):
+    """-> the one-line meaning shown beneath a non-catch row.
+
+    FAILS LOUD on an unmapped verdict. `WHAT_IT_MEANS.get(verdict, "")` rendered a
+    BLANK line for one, so adding a verdict constant would have silently produced a
+    report with no explanation under it — an empty string reading as an answer, which
+    is the defect class this whole tool exists to police.
+    """
+    try:
+        return WHAT_IT_MEANS[verdict]
+    except KeyError:
+        raise AssertionError(
+            f"verdict {verdict!r} has no entry in WHAT_IT_MEANS, so the report would print a blank "
+            f"line where the operator's guidance belongs. Add one when adding a verdict.")
 
 
 def classify_row(baseline: "SuiteResults", mutated: "SuiteResults", expect_fail: str):
@@ -1494,19 +1538,9 @@ def main(argv=None):
     bad = [r for r in results if r[0] != VERDICT_CAUGHT]
     print(f"\n{'=' * 72}\n{len(caught)}/{len(results)} CAUGHT, baseline green before and after.")
     if bad:
-        # WHAT TO DO ABOUT A ROW DEPENDS ON WHY IT IS NOT A CATCH, and the old
-        # report collapsed every non-catch into "needs work" — which sent an
-        # overnight session to tighten a test when the RECIPE was the problem.
-        WHAT_IT_MEANS = {
-            VERDICT_NOOP: "re-aim the RECIPE: the mutation changed nothing the suite observes",
-            VERDICT_CAUGHT_ELSEWHERE: "a different test caught it; this row says nothing about its own guard",
-            VERDICT_INVALID: "the row cannot prove anything as written",
-            VERDICT_SURVIVED: "the test did not detect the mutation",
-            "ERROR": "the row did not produce a verdict",
-        }
         print(f"\n{len(bad)} row(s) need work:")
         for verdict, label, detail in bad:
-            print(f"  {verdict}: {label}\n    {WHAT_IT_MEANS.get(verdict, '')}\n    {detail}")
+            print(f"  {verdict}: {label}\n    {explain_verdict(verdict)}\n    {detail}")
         return 1
     print("\nEvery mutation was detected by the test that claimed to guard it.")
     print("This proves the tests fire on the mutations written here. It does NOT prove they are")

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -850,7 +850,12 @@ class Lane:
         ]
 
     def run_suite(self, suite: str, tag: str):
-        """Returns (count, failures, compiled, log_path). count is None when no summary was printed."""
+        """-> (count, failures, compiled, log_path, rc, elapsed, results).
+
+        `count` is None when no summary was printed; `results` is a SuiteResults, or None when the
+        lane did not compile and so wrote no bundle. Every VERDICT comes from `results`; `count` and
+        `compiled` answer only whether the lane reached the test phase at all.
+        """
         self.generate_once()
         log_path = self.log_dir / f"{tag}.log"
         bundle = self.bundle_path(tag)
@@ -1284,7 +1289,21 @@ def baseline(lane: Lane, suites, phase: str, seen_names: dict = None,
                 if suite_results is not None:
                     seen_names[suite] = set(suite_results.aliases)
                 else:
-                    seen_names[suite] = suite_test_names(log)
+                    # NO CONSOLE FALLBACK. Falling back to `suite_test_names(log)` here
+                    # would reintroduce exactly the defect this branch removed: console
+                    # naming refuses a parameterized recipe before anything is mutated,
+                    # and it would do it SILENTLY, on a run that looks normal.
+                    # Unreachable as the call graph stands — this branch requires
+                    # `compiled`, and `run_suite` returns a SuiteResults whenever it
+                    # compiled, because the reader raises rather than returning None.
+                    # Kept and made loud anyway: "unreachable" is a property of today's
+                    # callers, and this file already carried one comment saying `should
+                    # be unreachable` about something that was not.
+                    problems.append(
+                        f"{suite}: the lane compiled and passed but produced no result bundle, so "
+                        f"the recipe's test names cannot be checked against reality. Refusing rather "
+                        f"than falling back to console-scraped names, which cannot see a "
+                        f"parameterized test at all.")
             # The UNMUTATED per-test status map. Every row's verdict is a DIFF
             # against this, so without it a row can only ask "did the named test
             # go red" — which cannot tell a working guard from a mutation that

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -616,7 +616,12 @@ def read_result_bundle(bundle: Path) -> "SuiteResults":
 VERDICT_CAUGHT = "CAUGHT"
 VERDICT_CAUGHT_ELSEWHERE = "CAUGHT-ELSEWHERE"
 VERDICT_SURVIVED = "SURVIVED"
-VERDICT_NOOP = "SURVIVED-NOOP"
+# NOT "SURVIVED-NOOP". An unchanged test set has TWO causes and result statuses
+# cannot tell them apart: the mutant was a no-op or unreachable, or it executed
+# and changed behaviour NO ASSERTION COVERS — the ordinary surviving mutant this
+# whole tool exists to surface. Naming the first told operators to re-aim the
+# recipe precisely when the TEST was at fault.
+VERDICT_NOOP = "SURVIVED-UNOBSERVED"
 VERDICT_INVALID = "INVALID-ROW"
 
 
@@ -648,6 +653,11 @@ def classify_row(baseline: "SuiteResults", mutated: "SuiteResults", expect_fail:
         i for i in set(baseline.by_id) | set(mutated.by_id)
         if baseline.by_id.get(i) != mutated.by_id.get(i)
     }
+    # A CATCH REQUIRES A FAILURE, NOT MERELY A DIFFERENCE. Passed -> Skipped, or a
+    # test vanishing because execution stopped early, is a status change and is
+    # not another guard going red. Keying "something else caught it" on any
+    # difference credits a disappearance as detection.
+    newly_failed = mutated.failed() - baseline.failed()
     target_failed = target in mutated.failed()
     crash_note = f" (crash: {mutated.crashed[target]})" if target in mutated.crashed else ""
 
@@ -662,13 +672,25 @@ def classify_row(baseline: "SuiteResults", mutated: "SuiteResults", expect_fail:
             f"isolated to it.")
     if not changed:
         return VERDICT_NOOP, (
-            f"NOT ONE test changed status. The mutation is a no-op, or the named test never "
-            f"executes the mutated line. This is not evidence about `{target}` — it is a fact "
-            f"about the MUTANT, and the recipe needs re-aiming rather than the test tightening.")
-    return VERDICT_CAUGHT_ELSEWHERE, (
-        f"`{target}` stayed {base_result}, but {len(changed)} other test(s) changed status "
-        f"({', '.join(sorted(changed)[:5])}). Something else caught this mutation; that is not "
-        f"evidence that `{target}` is the guard.")
+            f"NOT ONE test changed status. Two causes produce this and the statuses cannot "
+            f"separate them: (1) the suite has no assertion for what the mutation changed — an "
+            f"ordinary surviving mutant, and `{target}` needs tightening; (2) the mutation was a "
+            f"no-op, or `{target}` never executes that line — the RECIPE needs re-aiming. Read the "
+            f"mutated line and ask whether the named test can reach it before deciding which.")
+    others_failed = sorted(newly_failed - {target})
+    if others_failed:
+        return VERDICT_CAUGHT_ELSEWHERE, (
+            f"`{target}` stayed {base_result}, but {len(others_failed)} other test(s) newly FAILED "
+            f"({', '.join(others_failed[:5])}). Something else caught this mutation; that is not "
+            f"evidence that `{target}` is the guard.")
+    # Statuses moved, but nothing newly failed — a test was skipped, or vanished
+    # because execution stopped early. That is not a catch by anyone, and calling
+    # it one would credit a disappearance as detection.
+    return VERDICT_SURVIVED, (
+        f"`{target}` stayed {base_result} and NOTHING newly failed, though {len(changed)} test(s) "
+        f"changed status ({', '.join(sorted(changed)[:5])}) — skipped, or absent from the mutated "
+        f"run. No guard went red, so the mutation was not detected; check whether the run was cut "
+        f"short before reading this as a weak test.")
 
 
 class Lane:
@@ -1162,7 +1184,17 @@ def baseline(lane: Lane, suites, phase: str, seen_names: dict = None,
             problems.append(f"{suite}: {len(failures)} failing on an unmutated tree ({log})")
         else:
             if seen_names is not None:
-                seen_names[suite] = suite_test_names(log)
+                # FROM THE BUNDLE, NOT THE CONSOLE. This set gates every row BEFORE
+                # any mutation runs, so a console-derived set refuses a recipe the
+                # verdict path would have resolved perfectly — which left #2225
+                # fixed in the verdict and broken in validation, the half that runs
+                # first. `aliases` carries every legal spelling: the display name,
+                # the bare function name, and the `Suite/function()` identifier,
+                # which is the only addressable identity a parameterized test has.
+                if suite_results is not None:
+                    seen_names[suite] = set(suite_results.aliases)
+                else:
+                    seen_names[suite] = suite_test_names(log)
             # The UNMUTATED per-test status map. Every row's verdict is a DIFF
             # against this, so without it a row can only ask "did the named test
             # go red" — which cannot tell a working guard from a mutation that

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -1242,9 +1242,28 @@ def baseline(lane: Lane, suites, phase: str, seen_names: dict = None,
         except _LaneTimedOut as exc:
             problems.append(f"{suite}: {exc}")
             continue
+        except BundleUnreadable as exc:
+            # A NONEXISTENT SUITE ARRIVES HERE, NOT AT THE ZERO-TEST BRANCH BELOW, and
+            # that is why this catch matters more than it looks. `xcodebuild` REPORTS
+            # SUCCESS for a filter that matched nothing; the bundle then holds zero
+            # Test Case nodes and the read raises — before `count < 1` is ever
+            # consulted. Uncaught it printed a traceback, so the branch below, whose
+            # own text calls this the worst failure the battery has, was unreachable
+            # for its own primary trigger.
+            # The ROW path already caught this: it wraps `run_suite` in a bare
+            # `except Exception`. Only the baseline was bare, and only the baseline
+            # had no test.
+            problems.append(
+                f"{suite}: the result bundle could not be read — {exc}. The usual cause is a filter "
+                f"naming a suite that does not exist here: renamed, moved to another target, or read "
+                f"off a filename rather than off its @Suite declaration. Nothing was mutated.")
+            continue
         if not compiled:
             problems.append(f"{suite}: did not compile ({log})")
         elif count is None or count < 1:
+            # Reached when the bundle IS readable and the CONSOLE still reported no
+            # tests — a disagreement between the two readers. The nonexistent-suite
+            # case is caught above, at the bundle read.
             problems.append(
                 f"{suite}: executed ZERO tests and REPORTED SUCCESS. Nothing was mutated. The "
                 f"filter names a suite that does not exist here — renamed, moved to another target, "

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -143,6 +143,22 @@ CANONICAL_SCRIPT = "scripts/xcode-test.sh"
 # canonical lane GAINS a build setting, an environment wrapper, or a flag, every fragment it already had
 # is still there, the guard stays green, and the battery quietly measures a differently-configured build
 # than the lane everyone else trusts. Cloud review, PR #2158.
+# FLAGS THIS RUNNER PASSES THAT THE CANONICAL LANE DOES NOT.
+#
+# The drift guard is deliberately two-directional: a battery quietly building
+# something different from the lane everyone trusts is its whole subject. So a
+# flag the runner adds cannot simply be absent from the comparison — it has to
+# be DECLARED, with the reason it is safe, where a reviewer will see it.
+#
+# `-resultBundlePath` qualifies because it changes only what is WRITTEN, never
+# what is built or run: `xcodebuild test` emits an `.xcresult` on every run
+# regardless, and the flag only chooses where. Measured at 4.5s/4.5s with it
+# against 4.6s/4.6s without, 208K per bundle on a 35-test suite.
+#
+# Anything that could alter the BUILD belongs in CANONICAL_TOKENS and in the
+# canonical script, not here. This set is not a general escape hatch.
+RUNNER_ONLY_TOKENS = {"-resultBundlePath"}
+
 CANONICAL_TOKENS = {
     "-project", "-scheme", "-configuration", "-derivedDataPath", "-destination",
     "ARCHS=arm64", "VALID_ARCHS=arm64", "ONLY_ACTIVE_ARCH=YES",
@@ -440,6 +456,221 @@ def failed_test_identities(failure_lines):
     return identities
 
 
+# ---------------------------------------------------------------------------
+# RESULT BUNDLE — the structured verdict, replacing console scraping (#2225,
+# #2227, #2228).
+#
+# `xcodebuild test` writes an `.xcresult` on EVERY run whether or not
+# `-resultBundlePath` is passed; the flag only makes it ADDRESSABLE, and it
+# costs nothing measurable. Three defects are unreachable from the bundle and
+# unavoidable from the console:
+#
+#   #2225  a parameterized test's console verdict has no addressable name. The
+#          bundle gives `nodeIdentifier = Suite/function(_:)`. Measured on
+#          ProviderStatusMappingTests: 35 cases, one parameterized, its two
+#          `Arguments` children carrying results and `nodeIdentifier: None`.
+#   #2227  a CRASH prints ZERO failure marks, so the console cannot see it at
+#          all. The bundle records `result: Failed` with a `Failure Message`
+#          child reading `Crash: xctest at <Suite>.<test>()`.
+#   #2228  xctest interleaves its stderr into the same stream, so a verdict line
+#          need not start at column 0 and line-anchored regexes lose a DIFFERENT
+#          set every run. A JSON field cannot be interleaved.
+#
+# NAME YOUR OWN PATH. The default `<derivedData>/Logs/Test/` accumulates one
+# bundle per run and is shared, so "newest wins" there carries the same
+# concurrent-writer hazard as the fixed log path this repo already documents.
+#
+# FAILS CLOSED. A missing bundle, a tool error, or an unparseable payload RAISES.
+# It never falls back to the console: a half-failed measurer that returns a
+# plausible number is the defect this section exists to remove, and a silent
+# fallback would reintroduce it under a structured name.
+
+BUNDLE_TOOL_TIMEOUT_SECONDS = 120
+
+
+class BundleUnreadable(Exception):
+    """The result bundle could not be read. Never downgraded to a console parse."""
+
+
+class SuiteResults:
+    """Every Test Case in one run, indexed by every name a recipe may legally use.
+
+    `by_id` is the authority: one entry per test, keyed by `nodeIdentifier`
+    (`Suite/function()`), which is unique and stable. `aliases` maps the other
+    spellings a recipe may carry — the display name, the bare function name, and
+    the identifier itself — onto those ids. A recipe naming a display name shared
+    by two suites therefore resolves to TWO ids and is refused as ambiguous
+    rather than silently matching one.
+    """
+
+    def __init__(self, by_id, aliases, crashed):
+        self.by_id = by_id            # nodeIdentifier -> "Passed" | "Failed" | ...
+        self.aliases = aliases        # spelling -> set(nodeIdentifier)
+        self.crashed = crashed        # nodeIdentifier -> crash message
+
+    def __len__(self):
+        return len(self.by_id)
+
+    def resolve(self, spelling: str):
+        """-> set of nodeIdentifiers a recipe's `expect_fail` names. Never a substring match.
+
+        Substring matching is what made the console path credit a sibling whose
+        name merely CONTAINS the expected one; the bundle has exact keys, so the
+        looser form has no reason to exist here.
+        """
+        return set(self.aliases.get(spelling, ()))
+
+    def failed(self):
+        return {i for i, r in self.by_id.items() if r not in ("Passed", "Skipped", "Expected Failure")}
+
+
+def _walk_nodes(node, out_cases):
+    if node.get("nodeType") == "Test Case":
+        out_cases.append(node)
+        # A parameterized case's `Arguments` children carry their own results and
+        # `nodeIdentifier: None`, so they are NOT separately addressable. The
+        # function's own aggregate result is what a recipe can name. Stated as a
+        # chosen limit: per-argument targeting would need a key the bundle does
+        # not provide.
+        return
+    for kid in node.get("children") or ():
+        _walk_nodes(kid, out_cases)
+
+
+def read_result_bundle(bundle: Path) -> "SuiteResults":
+    if not bundle.exists():
+        raise BundleUnreadable(
+            f"no result bundle at {bundle}. `xcodebuild test` writes one on every run, so its "
+            f"absence means the lane did not reach the test phase — check for a compile error.")
+    argv = ["xcrun", "xcresulttool", "get", "test-results", "tests", "--path", str(bundle)]
+    try:
+        proc = subprocess.run(argv, capture_output=True, text=True,
+                              timeout=BUNDLE_TOOL_TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired:
+        raise BundleUnreadable(f"`xcresulttool` ran past {BUNDLE_TOOL_TIMEOUT_SECONDS}s on {bundle}")
+    if proc.returncode != 0:
+        # The deprecated spelling (`get test-report tests`) refuses with a message
+        # naming --legacy. Surface the tool's own words rather than guessing.
+        raise BundleUnreadable(
+            f"`xcresulttool` exited {proc.returncode} on {bundle}:\n{proc.stderr.strip()[:400]}")
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise BundleUnreadable(f"`xcresulttool` output was not JSON ({exc}) for {bundle}")
+
+    roots = payload.get("testNodes")
+    if not isinstance(roots, list):
+        raise BundleUnreadable(f"no `testNodes` array in the bundle payload for {bundle}")
+
+    cases = []
+    for root in roots:
+        _walk_nodes(root, cases)
+    if not cases:
+        raise BundleUnreadable(
+            f"the bundle at {bundle} contains ZERO Test Case nodes. An empty result is not a "
+            f"passing result — a filter that matched nothing looks exactly like this.")
+
+    by_id, aliases, crashed = {}, {}, {}
+    for case in cases:
+        ident = case.get("nodeIdentifier")
+        if not ident:
+            raise BundleUnreadable(
+                f"a Test Case in {bundle} has no nodeIdentifier; the bundle shape has changed and "
+                f"every verdict below it would be unattributable")
+        by_id[ident] = case.get("result")
+        for spelling in (ident, case.get("name"), ident.split("/")[-1]):
+            if spelling:
+                aliases.setdefault(spelling, set()).add(ident)
+        for kid in case.get("children") or ():
+            if kid.get("nodeType") == "Failure Message":
+                text = (kid.get("name") or "")
+                if text.startswith("Crash:"):
+                    crashed[ident] = text
+    return SuiteResults(by_id, aliases, crashed)
+
+
+# --- the row verdict -------------------------------------------------------
+#
+# A DIFF AGAINST THE UNMUTATED BASELINE, not "did the named test go red".
+#
+# The console could afford only the second question, because it yielded one
+# count and a set of failure LINES. The bundle yields the status of EVERY test
+# on a run already being paid for, so the row can finally distinguish a guard
+# doing its job from three things that look identical at the console:
+#
+#   * a mutant that changed nothing (a no-op edit, or a line the named test
+#     never executes) — today scored exactly like a working guard;
+#   * a row whose named test was ALREADY failing, which proves nothing;
+#   * a different test catching the mutation, which is real information and is
+#     not evidence about the named guard.
+#
+# STATED LIMIT, because a verdict that implies more than it proves is the defect
+# class this tool exists to police: this diff is computed inside ONE suite run
+# and cannot see a cause OUTSIDE the process. A test that reddens for an
+# environmental reason — a concurrent writer, a shared resource, a machine
+# state — presents here as a genuine catch. Peer-measured 2026-08-20: a
+# three-arm control whose negative arm failed for exactly that reason, with the
+# mutation real and the test genuinely red. Nothing in this function closes it;
+# only a two-way control on the unmutated tree does.
+
+VERDICT_CAUGHT = "CAUGHT"
+VERDICT_CAUGHT_ELSEWHERE = "CAUGHT-ELSEWHERE"
+VERDICT_SURVIVED = "SURVIVED"
+VERDICT_NOOP = "SURVIVED-NOOP"
+VERDICT_INVALID = "INVALID-ROW"
+
+
+def classify_row(baseline: "SuiteResults", mutated: "SuiteResults", expect_fail: str):
+    """-> (verdict, detail). Never raises on a legitimate result; raises only on a broken premise."""
+    targets = mutated.resolve(expect_fail) or baseline.resolve(expect_fail)
+    if not targets:
+        return VERDICT_INVALID, (
+            f"`{expect_fail}` names no test in this suite. The bundle keys are exact — a display "
+            f"name, a bare function name, or a `Suite/function()` identifier — so a near miss is a "
+            f"wrong recipe rather than a missed match.")
+    if len(targets) > 1:
+        return VERDICT_INVALID, (
+            f"`{expect_fail}` is ambiguous: it names {len(targets)} tests "
+            f"({', '.join(sorted(targets))}). Use the `Suite/function()` identifier.")
+    target = targets.pop()
+
+    base_result = baseline.by_id.get(target)
+    if base_result is None:
+        return VERDICT_INVALID, (
+            f"`{target}` did not run on the unmutated tree, so this row has no baseline to differ "
+            f"from and cannot prove anything.")
+    if base_result not in ("Passed", "Expected Failure"):
+        return VERDICT_INVALID, (
+            f"`{target}` was already {base_result} BEFORE the mutation. A row whose guard is red on "
+            f"a clean tree cannot demonstrate that the guard binds.")
+
+    changed = {
+        i for i in set(baseline.by_id) | set(mutated.by_id)
+        if baseline.by_id.get(i) != mutated.by_id.get(i)
+    }
+    target_failed = target in mutated.failed()
+    crash_note = f" (crash: {mutated.crashed[target]})" if target in mutated.crashed else ""
+
+    if target_failed and changed == {target}:
+        return VERDICT_CAUGHT, f"`{target}` went {base_result} -> {mutated.by_id[target]}{crash_note}"
+    if target_failed:
+        others = sorted(changed - {target})
+        return VERDICT_CAUGHT, (
+            f"`{target}` went {base_result} -> {mutated.by_id[target]}{crash_note}; "
+            f"{len(others)} other test(s) also changed status ({', '.join(others[:5])}"
+            f"{' …' if len(others) > 5 else ''}). The guard fired, and the mutation is not "
+            f"isolated to it.")
+    if not changed:
+        return VERDICT_NOOP, (
+            f"NOT ONE test changed status. The mutation is a no-op, or the named test never "
+            f"executes the mutated line. This is not evidence about `{target}` — it is a fact "
+            f"about the MUTANT, and the recipe needs re-aiming rather than the test tightening.")
+    return VERDICT_CAUGHT_ELSEWHERE, (
+        f"`{target}` stayed {base_result}, but {len(changed)} other test(s) changed status "
+        f"({', '.join(sorted(changed)[:5])}). Something else caught this mutation; that is not "
+        f"evidence that `{target}` is the guard.")
+
+
 class Lane:
     """One filtered Debug test run against warm DerivedData."""
 
@@ -521,7 +752,12 @@ class Lane:
             timeout=GENERATE_TIMEOUT_SECONDS,
         )
 
-    def build_command(self, suite: str):
+    def bundle_path(self, tag: str) -> Path:
+        """Where this row's result bundle lands. `xcodebuild` REFUSES to overwrite an existing
+        bundle, so a re-run of the same tag must start from a clean path."""
+        return self.log_dir / f"{tag}.xcresult"
+
+    def build_command(self, suite: str, tag: str = "lane"):
         """The invocation this runner issues. Extracted so the self-test can assert it agrees with
         CANONICAL_TOKENS — the drift guard compares that constant against the SCRIPT, and nothing
         compared it against the command actually run, so the two could silently disagree."""
@@ -534,6 +770,11 @@ class Lane:
             "-destination", "platform=macOS,arch=arm64",
             "-onlyUsePackageVersionsFromResolvedFile",
             "ARCHS=arm64", "VALID_ARCHS=arm64", "ONLY_ACTIVE_ARCH=YES",
+            # OUR OWN PATH, never the default under `<derivedData>/Logs/Test/`.
+            # That directory accumulates one bundle per run and is shared, so
+            # "newest wins" there carries the same concurrent-writer hazard this
+            # repo already documents for the fixed log path.
+            "-resultBundlePath", str(self.bundle_path(tag)),
             f"-only-testing:{suite}",
         ]
 
@@ -541,7 +782,14 @@ class Lane:
         """Returns (count, failures, compiled, log_path). count is None when no summary was printed."""
         self.generate_once()
         log_path = self.log_dir / f"{tag}.log"
-        cmd = self.build_command(suite)
+        bundle = self.bundle_path(tag)
+        # `xcodebuild` refuses to write into an existing bundle path, and a row
+        # that silently reused a previous row's bundle would grade this mutation
+        # against the LAST one's results — a wrong subject, which is the defect
+        # class this whole change removes.
+        if bundle.exists():
+            shutil.rmtree(bundle, ignore_errors=True)
+        cmd = self.build_command(suite, tag)
         started = time.monotonic()
         try:
             rc, out = run(cmd, cwd=self.worktree, log_path=log_path,
@@ -559,7 +807,14 @@ class Lane:
         count, failures = classify_lane_output(out)
         # A red lane with compiler diagnostics and no test summary never ran the tests.
         compiled = not (count is None and COMPILE_ERROR_RE.search(out) is not None)
-        return count, failures, compiled, log_path, rc, elapsed
+        # THE CONSOLE IS STILL PARSED, FOR EXACTLY ONE THING IT CAN ANSWER AND THE
+        # BUNDLE CANNOT: whether the lane REACHED the test phase. A compile failure
+        # writes no bundle, so `compiled` has to come from the diagnostics. Every
+        # VERDICT below comes from the bundle; this is not a fallback.
+        results = None
+        if compiled:
+            results = read_result_bundle(bundle)
+        return count, failures, compiled, log_path, rc, elapsed, results
 
 
 def check_canonical_settings(worktree: Path):
@@ -878,7 +1133,8 @@ def suite_test_names(log_path) -> set:
     return names
 
 
-def baseline(lane: Lane, suites, phase: str, seen_names: dict = None):
+def baseline(lane: Lane, suites, phase: str, seen_names: dict = None,
+             results_out: dict = None):
     """Every named suite must run at least one test and pass. This is both the clean-tree control and
     the filter validation: a suite name that does not exist executes zero tests and SUCCEEDS.
 
@@ -889,7 +1145,7 @@ def baseline(lane: Lane, suites, phase: str, seen_names: dict = None):
     for suite in sorted(suites):
         tag = f"baseline-{phase}-{suite.replace('/', '_')}"
         try:
-            count, failures, compiled, log, rc, elapsed = lane.run_suite(suite, tag)
+            count, failures, compiled, log, rc, elapsed, suite_results = lane.run_suite(suite, tag)
         except _LaneTimedOut as exc:
             problems.append(f"{suite}: {exc}")
             continue
@@ -907,6 +1163,12 @@ def baseline(lane: Lane, suites, phase: str, seen_names: dict = None):
         else:
             if seen_names is not None:
                 seen_names[suite] = suite_test_names(log)
+            # The UNMUTATED per-test status map. Every row's verdict is a DIFF
+            # against this, so without it a row can only ask "did the named test
+            # go red" — which cannot tell a working guard from a mutation that
+            # changed nothing, nor from a test that was already failing.
+            if results_out is not None and suite_results is not None:
+                results_out[suite] = suite_results
             print(f"    baseline {phase}: {suite} — {count} tests green in {elapsed:.0f}s")
     return problems
 
@@ -993,7 +1255,9 @@ def main(argv=None):
     print(f"\n[1/3] baseline on a clean tree — {len(suites)} suite(s)")
     try:
         baseline_names = {}
-        problems = baseline(lane, suites, "before", seen_names=baseline_names)
+        baseline_results = {}
+        problems = baseline(lane, suites, "before", seen_names=baseline_names,
+                            results_out=baseline_results)
     except Refusal as exc:
         print(f"\nREFUSED — {exc}", file=sys.stderr)
         return 2
@@ -1079,8 +1343,8 @@ def main(argv=None):
                     detail = "mutation did not land on re-read"
                 else:
                     try:
-                        count, failures, compiled, log, rc_run, elapsed = lane.run_suite(
-                            row["suite"], tag)
+                        count, failures, compiled, log, rc_run, elapsed, row_results = (
+                            lane.run_suite(row["suite"], tag))
                     except Exception as exc:  # noqa: BLE001 — any lane failure is this row's problem
                         raise _RowFailed(f"the lane raised {type(exc).__name__}: {exc}") from exc
                     if not compiled:
@@ -1091,30 +1355,18 @@ def main(argv=None):
                             f"suite was renamed and the recipe is stale, or the filter never matched. "
                             f"Read the name off its @Suite declaration, never off the filename ({log})"
                         )
-                    elif rc_run == 0:
-                        # A green lane cannot have caught anything. Reached when the only ✘ lines were
-                        # known issues, which Swift Testing prints while still exiting 0.
-                        verdict = "SURVIVED"
+                    elif row_results is None:
+                        detail = f"the lane produced no result bundle to grade ({log})"
+                    elif row["suite"] not in baseline_results:
                         detail = (
-                            f"{count} tests and the lane exited GREEN with the code broken. Any ✘ here "
-                            f"was a KNOWN issue, which is a test configured not to fail — it cannot "
-                            f"have detected the mutation ({log})"
-                        )
-                    elif row["expect_fail"] in failed_test_identities(failures):
-                        verdict = "CAUGHT"
-                        others = [l for l in failures if row["expect_fail"] not in l]
-                        detail = f"{row['expect_fail']} went red in {elapsed:.0f}s"
-                        if others:
-                            detail += f" (+{len(others)} other failing)"
-                    elif failures:
-                        detail = (
-                            f"suite went red but NOT via {row['expect_fail']} — something else "
-                            f"caught it, so this test is not the guard ({log})"
-                        )
-                        verdict = "SURVIVED"
+                            f"no unmutated baseline was recorded for {row['suite']}, so this row has "
+                            f"nothing to differ from ({log})")
                     else:
-                        verdict = "SURVIVED"
-                        detail = f"{count} tests still green with the code broken ({log})"
+                        # THE VERDICT IS A DIFF, NOT A RED/GREEN READ. See classify_row for why, and
+                        # for the limit it does NOT close.
+                        verdict, detail = classify_row(
+                            baseline_results[row["suite"]], row_results, row["expect_fail"])
+                        detail = f"{detail} — {elapsed:.0f}s ({log})"
         except (_RowFailed, Refusal) as exc:
             detail = str(exc)
         except Exception as exc:  # noqa: BLE001 — any row failure is this row's problem, not the run's
@@ -1155,7 +1407,19 @@ def main(argv=None):
             else:
                 backup.unlink()   # verified byte-identical; on failure the backup is KEPT (above)
             _ACTIVE_RESTORES.pop(target, None)
-        marker = {"CAUGHT": "  ok  ", "SURVIVED": " SURV ", "ERROR": " ERR  "}[verdict]
+        # KEYED BY EVERY VERDICT `classify_row` CAN RETURN. A bare dict lookup on a
+        # verdict it does not know raises KeyError mid-run, which is the right
+        # failure — a marker map that silently defaulted would print a row under a
+        # symbol that means something else. `.get` with a fallback was rejected for
+        # exactly that reason.
+        marker = {
+            VERDICT_CAUGHT: "  ok  ",
+            VERDICT_CAUGHT_ELSEWHERE: " ELSE ",
+            VERDICT_SURVIVED: " SURV ",
+            VERDICT_NOOP: " NOOP ",
+            VERDICT_INVALID: " BADR ",
+            "ERROR": " ERR  ",
+        }[verdict]
         print(f"  [{marker}] row {i}: {row['label']}\n           {detail}")
         results.append((verdict, row["label"], detail))
 
@@ -1167,13 +1431,23 @@ def main(argv=None):
             print(f"  - {p}", file=sys.stderr)
         return 1
 
-    caught = [r for r in results if r[0] == "CAUGHT"]
-    bad = [r for r in results if r[0] != "CAUGHT"]
+    caught = [r for r in results if r[0] == VERDICT_CAUGHT]
+    bad = [r for r in results if r[0] != VERDICT_CAUGHT]
     print(f"\n{'=' * 72}\n{len(caught)}/{len(results)} CAUGHT, baseline green before and after.")
     if bad:
+        # WHAT TO DO ABOUT A ROW DEPENDS ON WHY IT IS NOT A CATCH, and the old
+        # report collapsed every non-catch into "needs work" — which sent an
+        # overnight session to tighten a test when the RECIPE was the problem.
+        WHAT_IT_MEANS = {
+            VERDICT_NOOP: "re-aim the RECIPE: the mutation changed nothing the suite observes",
+            VERDICT_CAUGHT_ELSEWHERE: "a different test caught it; this row says nothing about its own guard",
+            VERDICT_INVALID: "the row cannot prove anything as written",
+            VERDICT_SURVIVED: "the test did not detect the mutation",
+            "ERROR": "the row did not produce a verdict",
+        }
         print(f"\n{len(bad)} row(s) need work:")
         for verdict, label, detail in bad:
-            print(f"  {verdict}: {label}\n    {detail}")
+            print(f"  {verdict}: {label}\n    {WHAT_IT_MEANS.get(verdict, '')}\n    {detail}")
         return 1
     print("\nEvery mutation was detected by the test that claimed to guard it.")
     print("This proves the tests fire on the mutations written here. It does NOT prove they are")

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -627,7 +627,12 @@ VERDICT_INVALID = "INVALID-ROW"
 
 def classify_row(baseline: "SuiteResults", mutated: "SuiteResults", expect_fail: str):
     """-> (verdict, detail). Never raises on a legitimate result; raises only on a broken premise."""
-    targets = mutated.resolve(expect_fail) or baseline.resolve(expect_fail)
+    # THE UNION, never `mutated or baseline`. With `or`, a name that is ambiguous
+    # in the BASELINE resolves to a singleton whenever execution stopped before
+    # the second test appeared in the mutated bundle — so the ambiguity check is
+    # skipped exactly when the run was cut short, and the row is graded against
+    # whichever of the two happened to run.
+    targets = mutated.resolve(expect_fail) | baseline.resolve(expect_fail)
     if not targets:
         return VERDICT_INVALID, (
             f"`{expect_fail}` names no test in this suite. The bundle keys are exact — a display "
@@ -809,10 +814,24 @@ class Lane:
         # that silently reused a previous row's bundle would grade this mutation
         # against the LAST one's results — a wrong subject, which is the defect
         # class this whole change removes.
+        #
+        # SO THE REMOVAL IS PROVEN, NOT ATTEMPTED. `ignore_errors=True` was here
+        # and permitted exactly what the paragraph above forbids: a bundle that
+        # cannot be deleted stays, xcodebuild declines to overwrite it, and the
+        # read returns the PREVIOUS row's results wearing this row's name. A
+        # comment asserting a mechanism the code does not enforce — in the tool
+        # built to catch that.
         if bundle.exists():
             shutil.rmtree(bundle, ignore_errors=True)
+        if bundle.exists():
+            raise _RowFailed(
+                f"the previous result bundle at {bundle} could not be removed, so xcodebuild would "
+                f"refuse to overwrite it and this row would be graded against the LAST row's "
+                f"results. Remove it by hand and re-run.")
         cmd = self.build_command(suite, tag)
         started = time.monotonic()
+        # `monotonic` cannot be compared against a file mtime; a wall clock can.
+        started_wall = time.time()
         try:
             rc, out = run(cmd, cwd=self.worktree, log_path=log_path,
                           timeout=LANE_TIMEOUT_SECONDS)
@@ -835,6 +854,14 @@ class Lane:
         # VERDICT below comes from the bundle; this is not a fallback.
         results = None
         if compiled:
+            # A bundle predating this lane is the wrong subject, so require one
+            # created after the run began. The removal above should make this
+            # unreachable; it is checked anyway because "should be unreachable"
+            # is what the previous version's comment said too.
+            if bundle.exists() and bundle.stat().st_mtime < started_wall:
+                raise _RowFailed(
+                    f"the result bundle at {bundle} predates this lane, so it belongs to an earlier "
+                    f"run. Grading this row against it would report another mutation's outcome.")
             results = read_result_bundle(bundle)
         return count, failures, compiled, log_path, rc, elapsed, results
 


### PR DESCRIPTION
Closes #2225
Closes #2227
Closes #2228

Three issues, one root: the mutation runner recovered structured facts by parsing an **interleaved text stream**. Every one of the three defects is unreachable from that stream and trivially available in a file `xcodebuild test` already writes.

## The receipt, on #2227's own example

`RainbowLevelMeter.colour(at:of:)` guards its single-bar case. Break the guard and the test that covers it **crashes**. Run end to end on a real lane, this branch:

```
[  ok  ] row 1: breaking the single-bar guard CRASHES the test — #2227's exact case
         `RainbowLevelMeterTests/singleBarGradientIsSafe()` went Passed -> Failed
         (crash: Crash: xctest at static RainbowLevelMeter.colour(at:of:)) — 20s
1/1 CAUGHT, baseline green before and after.
```

**The same row on `main` returns `SURVIVED`, with the message `19 tests still green with the code broken`.** Both halves are false — the lane was red, and the crash *was* the detection. That verdict tells an overnight session its working test is not binding and sends it to "fix" a guard that is doing its job.

## Why the bundle

`xcodebuild test` emits an `.xcresult` on **every** run whether or not `-resultBundlePath` is passed. The flag only makes it addressable. Measured: 4.5s/4.5s with, 4.6s/4.6s without; 208K per bundle on a 35-test suite.

| issue | what the console gives | what the bundle gives |
|---|---|---|
| **#2227** crash scored SURVIVED | **zero** failure marks, exit 65 | `result: Failed` + a `Failure Message` child reading `Crash: xctest at <Suite>.<test>()` |
| **#2225** 220 parameterized tests unnameable | a verdict shape with no addressable name | `nodeIdentifier` = `Suite/function(_:)`, per-argument results as children |
| **#2228** interleaving randomises verdicts | line-anchored regexes break on interleaved stderr, losing a **different set every run** | `result` is a JSON field; a field cannot be interleaved |

Shapes verified on this machine, not taken from the issue text: a real parameterized suite returns `nodeIdentifier = 'ProviderStatusMappingTests/egOneUpdatePausedReadsAsNeedingAttention(_:)'` with two `Arguments` children carrying results and `nodeIdentifier: None`.

## The larger change: the verdict is now a DIFF

This is the part that matters more than the parsing.

The console gave one count and a set of failure lines, so a row could only ask **"did the named test go red"**. That question cannot separate a working guard from three things that look identical:

| verdict | meaning |
|---|---|
| **CAUGHT** | the named test flipped, and nothing else moved |
| **CAUGHT-ELSEWHERE** | something else went red — real information, and not evidence about *this* guard |
| **SURVIVED-NOOP** | **nothing changed at all.** The mutant is a no-op, or the named test never executes that line. Previously scored exactly like a working guard. |
| **INVALID-ROW** | the guard was already red on the clean tree, so the row proves nothing |

The bundle gives the status of **every** test on a run already being paid for, which is what makes the diff affordable. The summary now says what each non-catch means, because collapsing them all into "needs work" is what sent sessions to tighten a test when the **recipe** was the problem.

## Stated limit, written AT the verdict

This diff is computed inside **one suite run** and cannot see a cause **outside the process**. A test that reddens for an environmental reason presents here as a genuine catch.

Peer-measured the same day: a three-arm control whose negative arm failed for exactly that reason — the mutation was real, the test genuinely went red, and the conclusion was still wrong. Nothing in this change closes that; only a two-way control on the unmutated tree does. It is written at `classify_row` rather than implied away, because a verdict claiming more than it proves is the defect class this tool exists to police.

## Fails closed

A missing bundle, a tool error, an unparseable payload, a `Test Case` with no `nodeIdentifier`, or **zero test cases** all raise. There is no console fallback — a half-failed measurer returning a plausible number is precisely what this removes, and a fallback would reinstate it under a structured name.

The console is still parsed for exactly one thing the bundle cannot answer: whether the lane **reached** the test phase, since a compile failure writes no bundle.

## The drift guard

`-resultBundlePath` is **declared** in `RUNNER_ONLY_TOKENS`, with the reason it cannot change the build, rather than being quietly subtracted from the comparison. That guard is deliberately two-directional — a battery building something different from the lane everyone trusts is its whole subject — so a flag the runner adds has to be visible to a reviewer, not inferred from a green check.

It writes to its **own** path. The default `<derivedData>/Logs/Test/` accumulates one bundle per run and is shared, carrying the same concurrent-writer hazard this repo already documents for the fixed log path.

## Evidence

| check | result |
|---|---|
| `scripts/mutation-battery-test.py` | **121/121** |
| real battery run, #2227's example | **1/1 CAUGHT**, crash named, baseline green before and after, tree restored |
| `--validate-only` on the recipe | 1/1 rows runnable |

The self-test's cases now drive the real `SuiteResults` rather than a hand-rolled stand-in — a stub could otherwise accept a shape the real reader never produces, and pass against a reader that cannot.

**Its own shape guard caught me mid-change.** It asserts the stubbed lane still returns what the real one returns; when the arity moved it fired, which is exactly the case where every row would otherwise keep passing against a double that no longer resembles the thing it replaces. Its constant is updated together with the stubs, with a note that moving one without the other silently retires the check.

## Stated gap

`classify_row`'s **INVALID-ROW** path is unreachable from the stub harness, which always reports the target passing. Reaching it needs a per-case baseline, which is worth doing and is not done here. Saying so beats a case asserting `CAUGHT` under an `INVALID-ROW` name.

## Base

Branched from `main` **after** discovering the work had been built on an already-merged branch that predates #2232 — which touched both of these files. Carried across as a patch, verified #2232's line survives alongside this change, and re-ran both the self-test and the real battery on the correct base rather than citing a green from the wrong tree.
