### PR TITLE
fix(recovery): expiry stops depending on whether a window is open (#2186)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/TranscriptCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/TranscriptCoordinator.swift
@@ -46,8 +46,7 @@ final class TranscriptCoordinator {
   /// is the instrument that decides whether this feature earns its keep.
   private let emitEscapeRecoveryKept: (_ ageMs: Int, _ takeID: String) -> Void
   private let emitEscapeRecoveryExpired: (_ ageMs: Int, _ takeID: String) -> Void
-  private let emitEscapeRecoveryRestoredFromHistory:
-    (_ ageMs: Int, _ takeID: String) -> Void
+  private let emitEscapeRecoveryRestoredFromHistory: (_ ageMs: Int, _ takeID: String) -> Void
   private var loadTask: Task<Void, Never>?
   private var pulseTask: Task<Void, Never>?
 
@@ -153,6 +152,23 @@ final class TranscriptCoordinator {
   /// whether a file is still there.
   private var unremovablePendingCount = 0
 
+  /// Rows still counting down ON DISK, from the last COMPLETE sweep (#2186).
+  ///
+  /// The countdown used to arm only from `livePendingCount`, which reads
+  /// `transcripts`, which only `load()` fills — and `load()`'s one production
+  /// caller is the History view. So a row carried over from a PREVIOUS session
+  /// was invisible to the timer for the entire session: nothing deleted it at
+  /// its moment, and it waited for a relaunch. Founder, 2026-08-20: "As long as
+  /// the application is running, the timer should be ticking… and then it just
+  /// deletes."
+  ///
+  /// Written only when `walkComplete`, because the store's count means nothing
+  /// otherwise — a walk that could not enumerate the directory reports zero,
+  /// which would read as "nothing is counting down" and stop the pulse on the
+  /// one occasion it must keep running. An incomplete walk leaves this ALONE and
+  /// `lastSweepIncomplete` keeps the pulse alive on its own.
+  private var liveOnDiskPendingCount = 0
+
   /// Whether the last sweep failed to READ the directory, or threw.
   ///
   /// Separate from the count because it means the opposite of what the count
@@ -170,7 +186,27 @@ final class TranscriptCoordinator {
   /// lapsed row it did not find, so this returns to zero after one pass.
   private var pendingSweepIsDue: Bool {
     lapsedPendingCount > 0 || unremovablePendingCount > 0 || lastSweepIncomplete
+      || liveOnDiskLapsedByNow
   }
+
+  /// #2186: a disk row that has crossed its deadline SINCE the last sweep.
+  ///
+  /// `lapsedPendingCount` cannot see it — that reads `transcripts`, and a row
+  /// carried over from a previous session is not in memory unless History
+  /// loaded it. Without this the pulse would arm (because live rows exist on
+  /// disk) and then never find anything due, so it would spin until it stopped
+  /// and delete nothing at the moment it was supposed to.
+  ///
+  /// Deliberately time-based rather than a stored flag: the pulse's whole job is
+  /// to notice a deadline passing while nothing else changes, and only a clock
+  /// read can do that. The sweep it triggers is what corrects the count.
+  private var liveOnDiskLapsedByNow: Bool {
+    guard liveOnDiskPendingCount > 0 else { return false }
+    return Date() >= nextDiskExpiryDeadline ?? .distantFuture
+  }
+
+  /// When the soonest disk row is due, from the last complete sweep (#2186).
+  private var nextDiskExpiryDeadline: Date?
 
   /// Whether the pulse has any reason to keep running.
   ///
@@ -184,6 +220,7 @@ final class TranscriptCoordinator {
   /// pulse alive over a file that is already gone.
   private var pendingPulseHasWork: Bool {
     livePendingCount > 0 || unremovablePendingCount > 0 || lastSweepIncomplete
+      || liveOnDiskPendingCount > 0
   }
 
   /// A held row is visible only while `PendingAdmission` calls it live.
@@ -289,6 +326,15 @@ final class TranscriptCoordinator {
       // the pass that just ran, so a file that finally went must stop counting.
       unremovablePendingCount = swept.unremovable
       lastSweepIncomplete = !swept.walkComplete
+      // #2186: DISK truth, and only from a walk that could actually look.
+      // `walkComplete == false` means the store counted nothing, so its zero is
+      // "I could not see" rather than "nothing is counting down" — writing it
+      // here would stop the timer on the one occasion it must keep going.
+      // `lastSweepIncomplete` above already keeps the pulse alive in that case.
+      if swept.walkComplete {
+        liveOnDiskPendingCount = swept.remainingLive
+        nextDiskExpiryDeadline = swept.nextLiveDeadline
+      }
       // Evict on EVERY deletion, not only the telemetry-eligible ones. A
       // future-skewed or corrupt row is deleted without a receipt, and leaving
       // it in memory kept `lapsedPendingCount` above zero — so the pulse
@@ -672,6 +718,21 @@ final class TranscriptCoordinator {
     /// after a sweep rather than keeping the directory walk alive.
     // periphery:ignore - test seam
     var lapsedPendingCountForTesting: Int { lapsedPendingCount }
+
+    /// #2186: the disk deadline the pulse waits for.
+    ///
+    /// A seam rather than a wall-clock wait. The production deadline comes from
+    /// the store's own walk, and a test that made a row expire a fraction of a
+    /// second in the future and let the loop spin until it did would be flaky by
+    /// construction — the same defect `pulseSweepsOnDetection` records having
+    /// already been fixed once in this file.
+    // periphery:ignore - test seam
+    func setDiskExpiryDeadlineForTesting(_ date: Date?) {
+      nextDiskExpiryDeadline = date
+    }
+
+    // periphery:ignore - test seam
+    var liveOnDiskPendingCountForTesting: Int { liveOnDiskPendingCount }
 
     /// Awaits the pulse loop's own completion — a real signal, so a test never
     /// guesses how long the loop needs. Captured before awaiting because the

--- a/Sources/EnviousWisprAppKit/App/TranscriptCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/TranscriptCoordinator.swift
@@ -486,7 +486,7 @@ final class TranscriptCoordinator {
       if selectedTranscriptID == transcript.id {
         selectedTranscriptID = nil
       }
-      stopPulseIfIdle()
+      refreshDiskStateThenStopIfIdle()
     } catch {
       Task {
         await AppLogger.shared.log(
@@ -579,7 +579,7 @@ final class TranscriptCoordinator {
       }
       guard let index = transcripts.firstIndex(where: { $0.id == transcript.id }) else { return }
       transcripts[index] = transcripts[index].promotedFromPending()
-      stopPulseIfIdle()
+      refreshDiskStateThenStopIfIdle()
     } catch {
       Task {
         await AppLogger.shared.log(
@@ -612,7 +612,7 @@ final class TranscriptCoordinator {
       try store.deleteAll()
       transcripts.removeAll()
       selectedTranscriptID = nil
-      stopPulseIfIdle()
+      refreshDiskStateThenStopIfIdle()
     } catch {
       Task {
         await AppLogger.shared.log(
@@ -707,6 +707,46 @@ final class TranscriptCoordinator {
     pulseTask = nil
   }
 
+  /// #2186: after an action that REMOVES pending files, re-read disk truth
+  /// before deciding the pulse is idle.
+  ///
+  /// `liveOnDiskPendingCount` is a CACHE of the last sweep, and Keep, Delete and
+  /// Delete All all change the directory it describes. Calling `stopPulseIfIdle`
+  /// on the stale value means `pendingPulseHasWork` still sees the removed row,
+  /// so the pulse never stops — a directory walk every minute for the life of
+  /// the app, which is precisely the stranded-retry this file's own comments
+  /// warn about, reintroduced through a cache those comments predate.
+  ///
+  /// A sweep rather than zeroing the count: zeroing is wrong whenever ANOTHER
+  /// pending row is still counting down, and it would stop that row's timer.
+  /// Only the directory knows. The sweep re-arms if work remains, so the stop
+  /// below can then be trusted. Cloud review, P2.
+  private func refreshDiskStateThenStopIfIdle() {
+    // SYNCHRONOUS first, and that is a contract rather than an optimisation:
+    // `Keep stops the pulse once the last held row is gone` asserts the pulse is
+    // gone the instant Keep returns. Making this purely async broke it — the
+    // full lane caught it, this suite did not, because the new tests await the
+    // refresh and the old one does not.
+    //
+    // The cache is INVALIDATED rather than trusted or preserved. It describes a
+    // directory this removal just changed, so keeping it blocks the stop (the
+    // round-2 P2), and believing its old value is what made it stale. Zeroing
+    // can only stop the pulse EARLY; the refresh below re-arms within moments if
+    // another row is still counting down, and only the directory can say.
+    liveOnDiskPendingCount = 0
+    nextDiskExpiryDeadline = nil
+    pendingRetainedForSpool = 0
+    stopPulseIfIdle()
+    refreshTask = Task { [weak self] in
+      await self?.sweepExpiredPending()
+      self?.stopPulseIfIdle()
+    }
+  }
+
+  /// Held so a test can await the refresh rather than guess at a duration —
+  /// a signal the subject itself fires, never a sleep or a yield count.
+  private var refreshTask: Task<Void, Never>?
+
   #if DEBUG
     // periphery:ignore - test seam
     var hasPendingPulseForTesting: Bool { pulseTask != nil }
@@ -744,6 +784,14 @@ final class TranscriptCoordinator {
 
     // periphery:ignore - test seam
     var liveOnDiskPendingCountForTesting: Int { liveOnDiskPendingCount }
+
+    /// Awaits the post-removal disk refresh. Captured before awaiting because
+    /// the task clears nothing but may be replaced by a later removal.
+    // periphery:ignore - test seam
+    func waitForRefreshForTesting() async {
+      let running = refreshTask
+      await running?.value
+    }
 
     /// Awaits the pulse loop's own completion — a real signal, so a test never
     /// guesses how long the loop needs. Captured before awaiting because the

--- a/Sources/EnviousWisprAppKit/App/TranscriptCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/TranscriptCoordinator.swift
@@ -324,18 +324,38 @@ final class TranscriptCoordinator {
     // layer would defeat both halves — `await` resuming before the work was
     // done, and a row that lapsed DURING the in-flight sweep never being
     // re-examined by the later clock that can see it.
+    // Captured BEFORE the await, so a removal that lands while this walk is in
+    // flight makes the walk stale by construction rather than by timing.
+    let generation = diskStateGeneration
     do {
       let swept = try await store.deleteExpiredPending(now: now)
+      #if DEBUG
+        // The ONE window this guard exists for: the walk has finished and has
+        // not yet written its result. A Live removal here is what makes the
+        // result stale, and it cannot be staged from outside — the two tasks
+        // resume in whatever order the runtime picks, so a test that raced them
+        // would prove nothing on the run where it happened to win.
+        onSweepWalkFinishedForTesting?()
+      #endif
+      // The four fields below DESCRIBE the directory, and this walk looked at a
+      // directory a later removal has since changed — so its whole picture is
+      // superseded, not merely its count. Applying any part of it writes a state
+      // that never existed. The deletions and telemetry beneath this block are
+      // FACTS about files that really went, so they are recorded either way, and
+      // the newer walk arms the pulse from the state it actually finds.
+      let describesCurrentDirectory = generation == diskStateGeneration
       // Replaced, never accumulated: this is the state of the directory after
       // the pass that just ran, so a file that finally went must stop counting.
-      unremovablePendingCount = swept.unremovable
-      lastSweepIncomplete = !swept.walkComplete
+      if describesCurrentDirectory {
+        unremovablePendingCount = swept.unremovable
+        lastSweepIncomplete = !swept.walkComplete
+      }
       // #2186: DISK truth, and only from a walk that could actually look.
       // `walkComplete == false` means the store counted nothing, so its zero is
       // "I could not see" rather than "nothing is counting down" — writing it
       // here would stop the timer on the one occasion it must keep going.
       // `lastSweepIncomplete` above already keeps the pulse alive in that case.
-      if swept.walkComplete {
+      if swept.walkComplete, describesCurrentDirectory {
         liveOnDiskPendingCount = swept.remainingLive
         nextDiskExpiryDeadline = swept.nextLiveDeadline
       }
@@ -345,7 +365,9 @@ final class TranscriptCoordinator {
       // the pulse stops, and the row waits for a relaunch instead of going on
       // the pass after recovery clears its spool. Same stranded retry the
       // `unremovable` count already exists to prevent, by a second route.
-      pendingRetainedForSpool = swept.retainedForSpool
+      if describesCurrentDirectory {
+        pendingRetainedForSpool = swept.retainedForSpool
+      }
       // Evict on EVERY deletion, not only the telemetry-eligible ones. A
       // future-skewed or corrupt row is deleted without a receipt, and leaving
       // it in memory kept `lapsedPendingCount` above zero — so the pulse
@@ -394,7 +416,14 @@ final class TranscriptCoordinator {
     } catch {
       // A sweep that THREW measured nothing, so it must not read as a finished
       // one — same reasoning as an unreadable directory, one layer out.
-      lastSweepIncomplete = true
+      //
+      // Gated with the success path for one reason: a superseded FAILURE landing
+      // after a newer walk succeeded would mark the directory unread when it had
+      // just been read. `startPulseIfNeeded` below is unconditional, so a genuine
+      // failure still leaves a retry armed either way.
+      if generation == diskStateGeneration {
+        lastSweepIncomplete = true
+      }
       startPulseIfNeeded()
       // History is a limb, not the heart. A failed sweep leaves rows the
       // read-time filter already hides.
@@ -733,15 +762,44 @@ final class TranscriptCoordinator {
     // round-2 P2), and believing its old value is what made it stale. Zeroing
     // can only stop the pulse EARLY; the refresh below re-arms within moments if
     // another row is still counting down, and only the directory can say.
-    liveOnDiskPendingCount = 0
-    nextDiskExpiryDeadline = nil
-    pendingRetainedForSpool = 0
+    invalidateDiskState()
     stopPulseIfIdle()
     refreshTask = Task { [weak self] in
       await self?.sweepExpiredPending()
       self?.stopPulseIfIdle()
     }
   }
+
+  /// Drops what this coordinator believes about the pending directory, and
+  /// supersedes any walk already in flight over it.
+  ///
+  /// Both halves belong to one removal and are why this is a function rather
+  /// than four assignments at the call site: zeroing without bumping leaves an
+  /// older walk free to write its stale picture back, and bumping without
+  /// zeroing leaves the removed row counting until the refresh lands.
+  private func invalidateDiskState() {
+    liveOnDiskPendingCount = 0
+    nextDiskExpiryDeadline = nil
+    pendingRetainedForSpool = 0
+    diskStateGeneration &+= 1
+  }
+
+  /// Bumped by every pending REMOVAL, and read by `sweepExpiredPending` across
+  /// its one `await`, so a walk that started before a removal cannot write its
+  /// picture of the directory over a newer one's.
+  ///
+  /// Cloud review, P2: the store serialises the walks, but each sweep writes its
+  /// result back on the main actor AFTER resuming, and resumptions are not
+  /// ordered — so without this, two quick removals can let the first walk's
+  /// stale count land on top of the second walk's empty one and strand the pulse
+  /// until a row that no longer exists reaches its former deadline.
+  ///
+  /// A generation rather than cancellation: the walk itself is still doing real
+  /// work — it deletes files and its deletions must be recorded whoever wins —
+  /// and only the four fields DESCRIBING the directory go stale. Those four are
+  /// gated together rather than one at a time; they are one snapshot, and a
+  /// partial application is a directory state that never existed.
+  private var diskStateGeneration = 0
 
   /// Held so a test can await the refresh rather than guess at a duration —
   /// a signal the subject itself fires, never a sleep or a yield count.
@@ -784,6 +842,22 @@ final class TranscriptCoordinator {
 
     // periphery:ignore - test seam
     var liveOnDiskPendingCountForTesting: Int { liveOnDiskPendingCount }
+
+    /// Fired once the pending walk has finished and BEFORE its result is
+    /// written back — the only window in which a removal can make that result
+    /// stale. A seam rather than a raced pair of tasks: the two resume in an
+    /// order the runtime picks, so a racing test proves nothing on the run where
+    /// it happens to win.
+    // periphery:ignore - test seam
+    var onSweepWalkFinishedForTesting: (@MainActor () -> Void)?
+
+    /// What a removal does to this coordinator's picture of the directory, with
+    /// the refresh it would also arm left off — so a test can put a removal in
+    /// the window above without a second walk racing in to correct the answer.
+    // periphery:ignore - test seam
+    func simulateRemovalDuringWalkForTesting() {
+      invalidateDiskState()
+    }
 
     /// Awaits the post-removal disk refresh. Captured before awaiting because
     /// the task clears nothing but may be replaced by a later removal.

--- a/Sources/EnviousWisprAppKit/App/TranscriptCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/TranscriptCoordinator.swift
@@ -169,6 +169,10 @@ final class TranscriptCoordinator {
   /// `lastSweepIncomplete` keeps the pulse alive on its own.
   private var liveOnDiskPendingCount = 0
 
+  /// Expired rows the last sweep KEPT because their spool survives (#2186).
+  /// A retry owed, not a failure and not a countdown.
+  private var pendingRetainedForSpool = 0
+
   /// Whether the last sweep failed to READ the directory, or threw.
   ///
   /// Separate from the count because it means the opposite of what the count
@@ -186,7 +190,7 @@ final class TranscriptCoordinator {
   /// lapsed row it did not find, so this returns to zero after one pass.
   private var pendingSweepIsDue: Bool {
     lapsedPendingCount > 0 || unremovablePendingCount > 0 || lastSweepIncomplete
-      || liveOnDiskLapsedByNow
+      || liveOnDiskLapsedByNow || pendingRetainedForSpool > 0
   }
 
   /// #2186: a disk row that has crossed its deadline SINCE the last sweep.
@@ -220,7 +224,7 @@ final class TranscriptCoordinator {
   /// pulse alive over a file that is already gone.
   private var pendingPulseHasWork: Bool {
     livePendingCount > 0 || unremovablePendingCount > 0 || lastSweepIncomplete
-      || liveOnDiskPendingCount > 0
+      || liveOnDiskPendingCount > 0 || pendingRetainedForSpool > 0
   }
 
   /// A held row is visible only while `PendingAdmission` calls it live.
@@ -335,6 +339,13 @@ final class TranscriptCoordinator {
         liveOnDiskPendingCount = swept.remainingLive
         nextDiskExpiryDeadline = swept.nextLiveDeadline
       }
+      // #2186: rows the sweep KEPT because their spool is still on disk. Not a
+      // failure and not a live countdown — a retry owed. Without it the sweep
+      // reads as finished (nothing deleted, nothing unremovable, walk complete),
+      // the pulse stops, and the row waits for a relaunch instead of going on
+      // the pass after recovery clears its spool. Same stranded retry the
+      // `unremovable` count already exists to prevent, by a second route.
+      pendingRetainedForSpool = swept.retainedForSpool
       // Evict on EVERY deletion, not only the telemetry-eligible ones. A
       // future-skewed or corrupt row is deleted without a receipt, and leaving
       // it in memory kept `lapsedPendingCount` above zero — so the pulse

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -1118,10 +1118,14 @@ public final class WisprBootstrapper {
 
   public func applicationDidFinishLaunching() {
     appLifecycleCoordinator.runDidFinishLaunching()
-    // #1063 PR2: scan for orphan crash-recovery spools and recover them behind the
-    // blocking "recovering" pill (replaces PR1's purge). Strict limb, single-flight,
-    // one attempt per orphan. No-orphan launch is byte-identical to today.
+    // #1063 PR2: recover orphan crash-recovery spools behind the blocking
+    // "recovering" pill. Strict limb, single-flight, one attempt per orphan.
     Task { await recoveryCoordinator.scanAndRecover() }
+    // #2186: deletion must not depend on a view mounting. Its OWN task, NO
+    // ordering against the scan — the sweep refuses to delete a row whose spool
+    // survives, so it is safe whenever it runs. Chaining it was tried and cloud
+    // review refuted both halves. Bound by `EscapeRecoveryDiskExpiryTests`.
+    Task { await transcriptCoordinator.sweepExpiredPending() }
   }
 
   public func applicationDidBecomeActive() {

--- a/Sources/EnviousWisprStorage/TranscriptStore.swift
+++ b/Sources/EnviousWisprStorage/TranscriptStore.swift
@@ -236,9 +236,14 @@ public final class TranscriptStore {
       return PendingSweepResult(deletedIDs: [], expired: [])
     }
     let retention = AppConstants.pendingTranscriptRetention
-    // #2186: read ONCE on the main actor, before the detached walk, so the
-    // injected seam does not have to be reachable from inside it.
-    let spoolIDs = liveSpoolIDs()
+    // #2186: the CLOSURE crosses onto the detached walk, never its result.
+    // Local review, P2: calling it here ran the read on the MAIN ACTOR, and the
+    // production implementation does far more than read — it creates the
+    // recovery directory, chmods it, writes metadata, then enumerates and sorts
+    // every spool. That is a filesystem stall in front of app launch and of
+    // every retry pulse, in the one method whose whole design is to keep the
+    // walk off the main actor. `@Sendable` is what makes moving it legal.
+    let readSpoolIDs = liveSpoolIDs
     // The ROOT namespace, so the sweep can tell a genuinely expired row from a
     // shadow left behind by a promotion that already succeeded.
     let root = directory
@@ -254,7 +259,7 @@ public final class TranscriptStore {
       #endif
       return Self.sweepExpired(
         in: dir, permanentDir: root, now: now, retention: retention,
-        spoolIDs: spoolIDs)
+        spoolIDs: readSpoolIDs())
     }
     sweepGeneration &+= 1
     let generation = sweepGeneration
@@ -376,6 +381,15 @@ public final class TranscriptStore {
     let nextLiveDeadline = liveCandidates.compactMap { $0.deadline(retention: retention) }.min()
     var retainedForSpool = 0
     for candidate in candidates where !candidate.isLive {
+      // A permanent twin answers BOTH questions below, so it is asked first.
+      // Local review, P2: with the spool guard ahead of it, a Keep whose shadow
+      // removal failed AND whose spool survived was retained forever — the
+      // permanent row already carries the de-dup key, so the shadow protects
+      // nothing and the pulse walks the directory every minute for the life of
+      // the app. Checked by FILE rather than by loading the row: this runs off
+      // the main actor, and existence is the whole question.
+      let hasPermanentTwin = FileManager.default.fileExists(
+        atPath: permanentDir.appendingPathComponent(candidate.url.lastPathComponent).path)
       // #2186: this row is the only proof its spool was already recovered.
       // Delete it while the spool survives and the next scan replays that spool
       // as a fresh dictation — handing back the take the user CANCELLED. Retain
@@ -384,7 +398,8 @@ public final class TranscriptStore {
       // The enum answers for `.live`/`.expired`; `.invalid` carries no
       // transcript by design, so ask the FILE with the de-dup reader's own
       // permissive decode. Anything that reader would count, this must protect.
-      if let session = candidate.recoverySessionID ?? recoverySessionID(of: candidate.url),
+      if !hasPermanentTwin,
+        let session = candidate.recoverySessionID ?? recoverySessionID(of: candidate.url),
         spoolIDs.map({ $0.contains(session) }) ?? true
       {
         retainedForSpool += 1
@@ -399,14 +414,8 @@ public final class TranscriptStore {
       // expired ratio is the one number this funnel exists to produce, and it
       // would be wrong in the direction that makes the feature look worse.
       //
-      // Deleted (it is litter) and NOT reported (nothing expired). Checked by
-      // FILE rather than by loading the row: this runs off the main actor, and
-      // existence is the whole question.
-      if FileManager.default.fileExists(
-        atPath: permanentDir.appendingPathComponent(
-          candidate.url.lastPathComponent
-        ).path)
-      {
+      // Deleted (it is litter) and NOT reported (nothing expired).
+      if hasPermanentTwin {
         try? fm.removeItem(at: candidate.url)
         if fm.fileExists(atPath: candidate.url.path) {
           unremovable += 1

--- a/Sources/EnviousWisprStorage/TranscriptStore.swift
+++ b/Sources/EnviousWisprStorage/TranscriptStore.swift
@@ -306,6 +306,24 @@ public final class TranscriptStore {
   /// directory is not an empty one, and flattening it into `[]` is what would
   /// delete a row's dedup proof at exactly the moment we cannot see the spool it
   /// protects. `RecoverySpoolStore` already draws this distinction by throwing.
+  /// The recovery id the DE-DUP READER would see for this file (#2186).
+  ///
+  /// Asks the file with the same permissive decode `decodeAnyPendingIdentities`
+  /// uses, because the sweep's question is that reader's question: would
+  /// deleting this file remove a de-dup key? An `.invalid` candidate carries no
+  /// transcript by design, so the enum cannot answer, and returning `nil` for it
+  /// deleted precisely the rows the reader honours — a future-skewed stamp, a
+  /// missing stamp, a filename mismatch. Each is a real row whose audio was
+  /// already turned into text, and dropping its key replays that spool.
+  ///
+  /// Only reached for `.invalid`; the other cases answer from the enum.
+  private nonisolated static func recoverySessionID(of url: URL) -> String? {
+    guard let data = try? Data(contentsOf: url),
+      let transcript = try? JSONDecoder().decode(Transcript.self, from: data)
+    else { return nil }
+    return transcript.recoverySessionID
+  }
+
   private nonisolated static func spoolIDsFromDisk() -> Set<String>? {
     guard let ids = try? RecoverySpoolStore().listSpoolSessionIDs() else { return nil }
     return Set(ids)
@@ -363,7 +381,10 @@ public final class TranscriptStore {
       // as a fresh dictation — handing back the take the user CANCELLED. Retain
       // instead; recovery clears the spool at launch or on wake, and the row
       // goes on the pass after that. `nil` (directory unlistable) retains too.
-      if let session = candidate.recoverySessionID,
+      // The enum answers for `.live`/`.expired`; `.invalid` carries no
+      // transcript by design, so ask the FILE with the de-dup reader's own
+      // permissive decode. Anything that reader would count, this must protect.
+      if let session = candidate.recoverySessionID ?? recoverySessionID(of: candidate.url),
         spoolIDs.map({ $0.contains(session) }) ?? true
       {
         retainedForSpool += 1
@@ -493,6 +514,18 @@ public final class TranscriptStore {
     }
 
     /// The spool this row proves was already recovered, if it names one (#2186).
+    ///
+    /// `.invalid` CANNOT answer from the enum — it carries a URL and no
+    /// transcript, deliberately, so an unreadable file can never present a
+    /// fabricated identity. But `decodeAnyPendingIdentities` counts an invalid
+    /// row's `recoverySessionID` anyway, and says why: *"a row we refuse to count
+    /// here becomes a spool we replay again, which is a duplicate dictation."*
+    ///
+    /// So the sweep must ask the FILE, not this enum, for the invalid case —
+    /// see `recoverySessionID(of:)`. Returning `nil` here made the sweep delete
+    /// exactly the rows whose ids the de-dup reader honours: a future-skewed
+    /// stamp, a missing stamp, or a filename mismatch, each of which is a real
+    /// row whose audio was already transcribed. Cloud review, P1.
     var recoverySessionID: String? {
       switch self {
       case .live(_, let t), .expired(_, let t): return t.recoverySessionID

--- a/Sources/EnviousWisprStorage/TranscriptStore.swift
+++ b/Sources/EnviousWisprStorage/TranscriptStore.swift
@@ -296,6 +296,13 @@ public final class TranscriptStore {
       return PendingSweepResult(
         deletedIDs: [], expired: [], unremovable: 0, walkComplete: false)
     }
+    // #2186: counted from the SAME enumeration that decides what to delete, so
+    // the two can never disagree about one directory. Taken before the loop
+    // because the loop only visits `!isLive` rows and leaves live ones
+    // untouched — there is nothing later that could change this number.
+    let liveCandidates = candidates.filter(\.isLive)
+    let remainingLive = liveCandidates.count
+    let nextLiveDeadline = liveCandidates.compactMap { $0.deadline(retention: retention) }.min()
     for candidate in candidates where !candidate.isLive {
       // A SHADOW, not an expiry (cloud review). `promotePending` writes the
       // permanent row first and removes the pending file second, so a crash or a
@@ -311,7 +318,8 @@ public final class TranscriptStore {
       // existence is the whole question.
       if FileManager.default.fileExists(
         atPath: permanentDir.appendingPathComponent(
-          candidate.url.lastPathComponent).path)
+          candidate.url.lastPathComponent
+        ).path)
       {
         try? fm.removeItem(at: candidate.url)
         if fm.fileExists(atPath: candidate.url.path) {
@@ -385,7 +393,9 @@ public final class TranscriptStore {
         if fm.fileExists(atPath: stray.path) { unremovable += 1 }
       }
     }
-    return PendingSweepResult(deletedIDs: deleted, expired: reported, unremovable: unremovable)
+    return PendingSweepResult(
+      deletedIDs: deleted, expired: reported, unremovable: unremovable,
+      remainingLive: remainingLive, nextLiveDeadline: nextLiveDeadline)
   }
 
   /// Why a pending file is or is not still offered.
@@ -427,6 +437,14 @@ public final class TranscriptStore {
     }
 
     var isLive: Bool { liveTranscript != nil }
+
+    /// When this row stops being offered (#2186). Nil unless it is still live
+    /// and carries a stamp, so it can never invent a deadline for a row that
+    /// has no clock.
+    func deadline(retention: TimeInterval) -> Date? {
+      guard let stamped = liveTranscript?.escapeRecoveredAt else { return nil }
+      return stamped.addingTimeInterval(retention)
+    }
   }
 
   /// `nil` means the directory could NOT be read, which is not the same fact as
@@ -691,15 +709,42 @@ public struct PendingSweepResult: Sendable {
   /// False when the directory could not be enumerated. Nothing else about this
   /// result can be trusted as a statement about the directory's contents.
   public let walkComplete: Bool
+  /// Rows still counting down ON DISK when this walk ran (#2186).
+  ///
+  /// DISK truth, deliberately, because the caller's own list is not a substitute
+  /// and that is the defect this exists to close. `TranscriptCoordinator` arms
+  /// its expiry pulse from `livePendingCount`, which reads `transcripts`, which
+  /// only `load()` populates — and `load()`'s sole production caller is the
+  /// History view. So a row carried over from a PREVIOUS session was invisible
+  /// to the countdown for the whole session: nothing deleted it at its moment,
+  /// and it waited for a relaunch.
+  ///
+  /// Meaningless when `walkComplete` is false — a walk that could not enumerate
+  /// the directory counted nothing, and reporting `0` there would read as "no
+  /// rows are counting down" and stop the pulse. Callers must check
+  /// `walkComplete` first; `init` defaults this to `0` only because a
+  /// short-circuit result has genuinely seen nothing.
+  public let remainingLive: Int
+
+  /// When the SOONEST still-live row is due, from this same walk (#2186).
+  ///
+  /// Carried so a caller can wake exactly when something is due instead of
+  /// re-walking the directory on every tick to find out. `remainingLive` alone
+  /// would force that choice: keep the timer running and walk every minute for
+  /// the life of the app, or stop it and miss the deadline. Nil when nothing is
+  /// counting down.
+  public let nextLiveDeadline: Date?
 
   public init(
     deletedIDs: Set<UUID>, expired: [ExpiredPendingRow], unremovable: Int = 0,
-    walkComplete: Bool = true
+    walkComplete: Bool = true, remainingLive: Int = 0, nextLiveDeadline: Date? = nil
   ) {
     self.deletedIDs = deletedIDs
     self.expired = expired
     self.unremovable = unremovable
     self.walkComplete = walkComplete
+    self.remainingLive = remainingLive
+    self.nextLiveDeadline = nextLiveDeadline
   }
 }
 

--- a/Sources/EnviousWisprStorage/TranscriptStore.swift
+++ b/Sources/EnviousWisprStorage/TranscriptStore.swift
@@ -14,9 +14,17 @@ import Foundation
 public final class TranscriptStore {
   private let directory: URL
 
+  /// Which spools are still on disk, or `nil` when that cannot be determined
+  /// (#2186). Injected so the sweep's spool guard is testable and so a test
+  /// store pointed at a temp directory does not read the USER'S real spool
+  /// directory — the production default reaches `AppConstants.appSupportURL`,
+  /// which every test would otherwise share.
+  private let liveSpoolIDs: @Sendable () -> Set<String>?
+
   public init() {
     directory = AppConstants.appSupportURL
       .appendingPathComponent(AppConstants.transcriptsDir, isDirectory: true)
+    liveSpoolIDs = Self.spoolIDsFromDisk
     Self.prepareDirectory(at: directory)
     Self.scheduleMigration(in: directory)
   }
@@ -28,8 +36,15 @@ public final class TranscriptStore {
   // scans `--exclude-tests` so this init appears unused from production;
   // the annotation suppresses that false positive.
   // periphery:ignore
-  internal init(directory: URL) {
+  internal init(
+    directory: URL,
+    liveSpoolIDs: @escaping @Sendable () -> Set<String>? = { [] }
+  ) {
     self.directory = directory
+    // Defaults to EMPTY, not to the disk reader: a test store must never touch
+    // the user's real spool directory, and "no spools" is the state every
+    // existing pending test already assumes.
+    self.liveSpoolIDs = liveSpoolIDs
     Self.prepareDirectory(at: directory)
     Self.scheduleMigration(in: directory)
   }
@@ -221,6 +236,9 @@ public final class TranscriptStore {
       return PendingSweepResult(deletedIDs: [], expired: [])
     }
     let retention = AppConstants.pendingTranscriptRetention
+    // #2186: read ONCE on the main actor, before the detached walk, so the
+    // injected seam does not have to be reachable from inside it.
+    let spoolIDs = liveSpoolIDs()
     // The ROOT namespace, so the sweep can tell a genuinely expired row from a
     // shadow left behind by a promotion that already succeeded.
     let root = directory
@@ -235,7 +253,8 @@ public final class TranscriptStore {
         await gate?()
       #endif
       return Self.sweepExpired(
-        in: dir, permanentDir: root, now: now, retention: retention)
+        in: dir, permanentDir: root, now: now, retention: retention,
+        spoolIDs: spoolIDs)
     }
     sweepGeneration &+= 1
     let generation = sweepGeneration
@@ -280,8 +299,21 @@ public final class TranscriptStore {
   /// `nonisolated` so the walk genuinely leaves the main actor. A detached task
   /// calling back into an isolated method would hop straight back and block
   /// exactly what it was meant to protect.
+  /// The `recoverySessionID`s of every spool still on disk, or `nil` when the
+  /// directory could not be listed (#2186).
+  ///
+  /// `nil` is a THIRD answer and the caller must keep it that way: an unlistable
+  /// directory is not an empty one, and flattening it into `[]` is what would
+  /// delete a row's dedup proof at exactly the moment we cannot see the spool it
+  /// protects. `RecoverySpoolStore` already draws this distinction by throwing.
+  private nonisolated static func spoolIDsFromDisk() -> Set<String>? {
+    guard let ids = try? RecoverySpoolStore().listSpoolSessionIDs() else { return nil }
+    return Set(ids)
+  }
+
   private nonisolated static func sweepExpired(
-    in dir: URL, permanentDir: URL, now: Date, retention: TimeInterval
+    in dir: URL, permanentDir: URL, now: Date, retention: TimeInterval,
+    spoolIDs: Set<String>?
   ) -> PendingSweepResult {
     let fm = FileManager.default
     var reported: [ExpiredPendingRow] = []
@@ -300,10 +332,43 @@ public final class TranscriptStore {
     // the two can never disagree about one directory. Taken before the loop
     // because the loop only visits `!isLive` rows and leaves live ones
     // untouched — there is nothing later that could change this number.
+    // #2186: a pending row is the PROOF that its spool was already recovered —
+    // `allRecoveredSessionIDs()` reads exactly these rows, and its own doc
+    // comment ignores expiry for that reason: "filtering by expiry here would
+    // let a spool whose row aged out get replayed a second time, handing the
+    // user a duplicate dictation exactly 24 hours later."
+    //
+    // So DELETING an expired row while its spool is still on disk is what
+    // resurrects a dictation the user CANCELLED. Cloud review found that as a P1
+    // against an earlier design that ordered the sweep after the recovery scan;
+    // ordering only narrows the window, because the scan can abort before taking
+    // its snapshot and a wedged replay can block the sweep for a whole session.
+    //
+    // Skipping instead removes the hazard STRUCTURALLY: no ordering, no signal,
+    // no waiting. A row whose spool survives is retained until recovery clears
+    // that spool, which is bounded — recovery scans at launch and on wake.
+    //
+    // FAIL CLOSED. `nil` means the spool directory could not be listed, which is
+    // NOT the same as "no spools"; treating it as empty is what would delete the
+    // proof precisely when we cannot see what it protects. Rows carrying no
+    // recovery id are unaffected either way — nothing can replay them.
+
     let liveCandidates = candidates.filter(\.isLive)
     let remainingLive = liveCandidates.count
     let nextLiveDeadline = liveCandidates.compactMap { $0.deadline(retention: retention) }.min()
+    var retainedForSpool = 0
     for candidate in candidates where !candidate.isLive {
+      // #2186: this row is the only proof its spool was already recovered.
+      // Delete it while the spool survives and the next scan replays that spool
+      // as a fresh dictation — handing back the take the user CANCELLED. Retain
+      // instead; recovery clears the spool at launch or on wake, and the row
+      // goes on the pass after that. `nil` (directory unlistable) retains too.
+      if let session = candidate.recoverySessionID,
+        spoolIDs.map({ $0.contains(session) }) ?? true
+      {
+        retainedForSpool += 1
+        continue
+      }
       // A SHADOW, not an expiry (cloud review). `promotePending` writes the
       // permanent row first and removes the pending file second, so a crash or a
       // failed removal in between leaves the stamped copy beside its permanent
@@ -395,7 +460,8 @@ public final class TranscriptStore {
     }
     return PendingSweepResult(
       deletedIDs: deleted, expired: reported, unremovable: unremovable,
-      remainingLive: remainingLive, nextLiveDeadline: nextLiveDeadline)
+      remainingLive: remainingLive, retainedForSpool: retainedForSpool,
+      nextLiveDeadline: nextLiveDeadline)
   }
 
   /// Why a pending file is or is not still offered.
@@ -424,6 +490,14 @@ public final class TranscriptStore {
     var liveTranscript: Transcript? {
       if case .live(_, let transcript) = self { return transcript }
       return nil
+    }
+
+    /// The spool this row proves was already recovered, if it names one (#2186).
+    var recoverySessionID: String? {
+      switch self {
+      case .live(_, let t), .expired(_, let t): return t.recoverySessionID
+      case .invalid: return nil
+      }
     }
 
     /// Non-nil only for a genuinely expired row, which is what makes a false
@@ -726,6 +800,16 @@ public struct PendingSweepResult: Sendable {
   /// short-circuit result has genuinely seen nothing.
   public let remainingLive: Int
 
+  /// Expired rows this walk deliberately KEPT because their spool is still on
+  /// disk, or because the spool directory could not be listed (#2186).
+  ///
+  /// Reported so the caller can keep retrying. Without it the sweep looks
+  /// finished — nothing deleted, nothing unremovable, walk complete — and the
+  /// countdown stops, so the row waits for a relaunch instead of going on the
+  /// pass after recovery clears its spool. That is the same stranded-retry the
+  /// `unremovable` count already exists to prevent, arriving by a second route.
+  public let retainedForSpool: Int
+
   /// When the SOONEST still-live row is due, from this same walk (#2186).
   ///
   /// Carried so a caller can wake exactly when something is due instead of
@@ -737,13 +821,15 @@ public struct PendingSweepResult: Sendable {
 
   public init(
     deletedIDs: Set<UUID>, expired: [ExpiredPendingRow], unremovable: Int = 0,
-    walkComplete: Bool = true, remainingLive: Int = 0, nextLiveDeadline: Date? = nil
+    walkComplete: Bool = true, remainingLive: Int = 0, retainedForSpool: Int = 0,
+    nextLiveDeadline: Date? = nil
   ) {
     self.deletedIDs = deletedIDs
     self.expired = expired
     self.unremovable = unremovable
     self.walkComplete = walkComplete
     self.remainingLive = remainingLive
+    self.retainedForSpool = retainedForSpool
     self.nextLiveDeadline = nextLiveDeadline
   }
 }

--- a/Tests/EnviousWisprTests/App/EscapeRecoveryDiskExpiryTests.swift
+++ b/Tests/EnviousWisprTests/App/EscapeRecoveryDiskExpiryTests.swift
@@ -41,10 +41,16 @@ import Testing
 @Suite("Escape Recovery disk expiry (#2186)", .tags(.productOutcome))
 struct EscapeRecoveryDiskExpiryTests {
 
-  private func makeStore() -> TranscriptStore {
+  /// `spools` defaults to EMPTY — never the real disk reader. A test store must
+  /// not read the user's own crash-recovery directory, and "no spools" is the
+  /// state the sibling pending suites already assume.
+  private func makeStore(spools: @escaping @Sendable () -> Set<String>? = { [] })
+    -> TranscriptStore
+  {
     TranscriptStore(
       directory: FileManager.default.temporaryDirectory
-        .appendingPathComponent("ew-2186-\(UUID().uuidString)", isDirectory: true))
+        .appendingPathComponent("ew-2186-\(UUID().uuidString)", isDirectory: true),
+      liveSpoolIDs: spools)
   }
 
   private final class EventLog {
@@ -191,6 +197,91 @@ struct EscapeRecoveryDiskExpiryTests {
         "and the plaintext must actually be gone from disk, not merely hidden")
     }
   #endif
+
+  // MARK: - The spool guard
+  //
+  // A pending row is the PROOF its spool was already recovered —
+  // `allRecoveredSessionIDs()` reads exactly these rows. Delete an expired one
+  // while its spool survives and the next scan replays that spool as a fresh
+  // dictation, handing back the take the user CANCELLED. These three are the
+  // only tests that exercise it: the 19 in `EscapeRecoveryTelemetryTests` set no
+  // `recoverySessionID`, so they pass whatever this rule does.
+
+  @Test("an expired dictation whose audio is still on disk is KEPT, not deleted")
+  func expiredRowWithSurvivingSpoolIsRetained() async throws {
+    let session = UUID().uuidString
+    let store = makeStore(spools: { [session] })
+    let log = EventLog()
+    let coordinator = makeCoordinator(log, store: store)
+
+    try store.savePending(
+      Transcript(
+        text: "cancelled, and its audio has not been cleared yet",
+        recoverySessionID: session,
+        escapeRecoveredAt: Date().addingTimeInterval(
+          -(AppConstants.pendingTranscriptRetention + 3600)),
+        escapeRecoveryTakeID: "take-spool-alive"))
+
+    await coordinator.sweepExpiredPending()
+
+    #expect(
+      log.expired.isEmpty,
+      """
+      #2186: an expired row whose spool SURVIVES must not be swept. Deleting it removes the only \
+      proof that spool was already recovered, so the next crash-recovery scan replays it and \
+      hands the user back a dictation they cancelled.
+      """)
+    #expect(
+      coordinator.hasPendingPulseForTesting,
+      "and the retry must stay armed, or the row waits for a relaunch after recovery clears it")
+  }
+
+  @Test("once the audio is gone the same dictation is deleted")
+  func expiredRowIsSweptOnceSpoolIsCleared() async throws {
+    let session = UUID().uuidString
+    // The paired ACCEPTED case: identical row, identical clock, spool absent.
+    // Without it, a guard that simply never sweeps anything would pass above.
+    let store = makeStore(spools: { [] })
+    let log = EventLog()
+    let coordinator = makeCoordinator(log, store: store)
+
+    try store.savePending(
+      Transcript(
+        text: "cancelled, audio already cleared",
+        recoverySessionID: session,
+        escapeRecoveredAt: Date().addingTimeInterval(
+          -(AppConstants.pendingTranscriptRetention + 3600)),
+        escapeRecoveryTakeID: "take-spool-gone"))
+
+    await coordinator.sweepExpiredPending()
+
+    #expect(log.expired.map(\.takeID) == ["take-spool-gone"])
+    #expect(try await store.loadPending().isEmpty, "and the plaintext is gone from disk")
+  }
+
+  @Test("an unreadable audio folder keeps the dictation rather than guessing")
+  func unreadableSpoolDirectoryRetains() async throws {
+    // `nil` is the THIRD answer — could not determine — and it must not collapse
+    // into "no spools". Collapsing it deletes the dedup proof at exactly the
+    // moment we cannot see what it protects, which is the fail-OPEN direction.
+    let store = makeStore(spools: { nil })
+    let log = EventLog()
+    let coordinator = makeCoordinator(log, store: store)
+
+    try store.savePending(
+      Transcript(
+        text: "cancelled, and we cannot see the audio folder",
+        recoverySessionID: UUID().uuidString,
+        escapeRecoveredAt: Date().addingTimeInterval(
+          -(AppConstants.pendingTranscriptRetention + 3600)),
+        escapeRecoveryTakeID: "take-spools-unknown"))
+
+    await coordinator.sweepExpiredPending()
+
+    #expect(
+      log.expired.isEmpty,
+      "#2186: cannot-determine must fail CLOSED — retain, never delete on a guess")
+  }
 
   @Test("an install with no held dictations leaves the countdown off")
   func emptyStoreLeavesTheCountdownOff() async throws {

--- a/Tests/EnviousWisprTests/App/EscapeRecoveryDiskExpiryTests.swift
+++ b/Tests/EnviousWisprTests/App/EscapeRecoveryDiskExpiryTests.swift
@@ -169,7 +169,7 @@ struct EscapeRecoveryDiskExpiryTests {
       // leaves the LIVE one on disk beside the expired one — `remainingLive`
       // never reaches zero, `pendingPulseHasWork` never goes false, and the loop
       // spins forever against a gate that no longer sleeps. Caught as a hung
-      // `xctest` at 5m31s with no compiler running: a livelock, not a slow build.
+      // xctest process at 5m31s with no compiler running: a livelock, not a slow build.
       let id = UUID()
       try store.savePending(
         Transcript(
@@ -189,7 +189,7 @@ struct EscapeRecoveryDiskExpiryTests {
       // counting down, which only happens if the sweep deletes the row. Break
       // the sweep — which is exactly what the mutation battery does — and the
       // gate returns instantly forever, so the test SPINS instead of failing.
-      // Measured: a hung `xctest` at 5m48s on a suite that passes in 0.005s.
+      // Measured: a hung xctest process at 5m48s on a suite that passes in 0.005s.
       //
       // So the cap fires LOUDLY and names itself, per this repo's rule that an
       // exhausted budget must never be mistaken for a settle.
@@ -271,7 +271,7 @@ struct EscapeRecoveryDiskExpiryTests {
     // KEEP behaviour above must be proven in BOTH configurations, and only the
     // retry check needs a hook that does not exist in a Release build. An
     // unwrapped seam here breaks the Release COMPILE, which a Debug-only run
-    // cannot see (`check-debug-seam-tests.py` is the pre-check for exactly this).
+    // cannot see.
     #if DEBUG
       #expect(
         coordinator.hasPendingPulseForTesting,

--- a/Tests/EnviousWisprTests/App/EscapeRecoveryDiskExpiryTests.swift
+++ b/Tests/EnviousWisprTests/App/EscapeRecoveryDiskExpiryTests.swift
@@ -231,9 +231,16 @@ struct EscapeRecoveryDiskExpiryTests {
       proof that spool was already recovered, so the next crash-recovery scan replays it and \
       hands the user back a dictation they cancelled.
       """)
-    #expect(
-      coordinator.hasPendingPulseForTesting,
-      "and the retry must stay armed, or the row waits for a relaunch after recovery clears it")
+    // DEBUG-only seam, so the assertion is wrapped rather than the test: the
+    // KEEP behaviour above must be proven in BOTH configurations, and only the
+    // retry check needs a hook that does not exist in a Release build. An
+    // unwrapped seam here breaks the Release COMPILE, which a Debug-only run
+    // cannot see (`check-debug-seam-tests.py` is the pre-check for exactly this).
+    #if DEBUG
+      #expect(
+        coordinator.hasPendingPulseForTesting,
+        "and the retry must stay armed, or the row waits for a relaunch after recovery clears it")
+    #endif
   }
 
   @Test("once the audio is gone the same dictation is deleted")
@@ -295,10 +302,12 @@ struct EscapeRecoveryDiskExpiryTests {
     // the app over an empty directory.
     await coordinator.sweepExpiredPending()
 
-    #expect(coordinator.liveOnDiskPendingCountForTesting == 0)
-    #expect(
-      !coordinator.hasPendingPulseForTesting,
-      "nothing is counting down, so nothing should be watching")
+    #if DEBUG
+      #expect(coordinator.liveOnDiskPendingCountForTesting == 0)
+      #expect(
+        !coordinator.hasPendingPulseForTesting,
+        "nothing is counting down, so nothing should be watching")
+    #endif
   }
 
   // NOT COVERED HERE, and named rather than left to be discovered: the

--- a/Tests/EnviousWisprTests/App/EscapeRecoveryDiskExpiryTests.swift
+++ b/Tests/EnviousWisprTests/App/EscapeRecoveryDiskExpiryTests.swift
@@ -266,6 +266,37 @@ struct EscapeRecoveryDiskExpiryTests {
     #expect(try await store.loadPending().isEmpty, "and the plaintext is gone from disk")
   }
 
+  @Test("an INVALID row whose audio survives is kept too — its id still de-dupes")
+  func invalidRowWithSurvivingSpoolIsRetained() async throws {
+    let session = UUID().uuidString
+    let store = makeStore(spools: { [session] })
+    let log = EventLog()
+    let coordinator = makeCoordinator(log, store: store)
+
+    // A FUTURE-skewed stamp makes this `.invalid` — it carries no transcript in
+    // the sweep's enum, so the enum cannot report its recovery id. But
+    // `decodeAnyPendingIdentities` counts an invalid row's id anyway, on the
+    // stated grounds that "a row we refuse to count here becomes a spool we
+    // replay again". Deleting it therefore strips a live de-dup key.
+    // Cloud review found this; the first version of the guard swept it.
+    try store.savePending(
+      Transcript(
+        text: "clock-skewed, but its audio was already transcribed",
+        recoverySessionID: session,
+        escapeRecoveredAt: Date().addingTimeInterval(86_400 * 30),
+        escapeRecoveryTakeID: "take-invalid-spool-alive"))
+
+    await coordinator.sweepExpiredPending()
+
+    #expect(
+      try await !store.pendingRecoverySessionIDs().isEmpty,
+      """
+      #2186: the sweep deleted an INVALID pending row whose spool is still on disk. Its \
+      recoverySessionID is de-dup proof that `allRecoveredSessionIDs()` honours, so removing \
+      the file makes the next scan replay that spool and hand back a cancelled dictation.
+      """)
+  }
+
   @Test("an unreadable audio folder keeps the dictation rather than guessing")
   func unreadableSpoolDirectoryRetains() async throws {
     // `nil` is the THIRD answer — could not determine — and it must not collapse

--- a/Tests/EnviousWisprTests/App/EscapeRecoveryDiskExpiryTests.swift
+++ b/Tests/EnviousWisprTests/App/EscapeRecoveryDiskExpiryTests.swift
@@ -150,6 +150,94 @@ struct EscapeRecoveryDiskExpiryTests {
         """)
     }
 
+    @Test("a removal re-reads the directory instead of assuming it is now empty")
+    func removalRearmsAnotherRowStillOnDisk() async throws {
+      let store = makeStore()
+      let log = EventLog()
+      let coordinator = makeCoordinator(log, store: store)
+
+      // The row the user is about to remove: in memory AND on disk.
+      let removed = Transcript(
+        id: UUID(), text: "the one the user deletes",
+        escapeRecoveredAt: Date().addingTimeInterval(-60),
+        escapeRecoveryTakeID: "take-removed")
+      // The row this test exists for: on disk ONLY, still counting down. That is
+      // a dictation held from a previous session with History never opened, so
+      // nothing in `transcripts` knows it exists.
+      try store.savePending(removed)
+      try store.savePending(
+        Transcript(
+          text: "carried over, nobody has looked at it",
+          escapeRecoveredAt: Date().addingTimeInterval(-120),
+          escapeRecoveryTakeID: "take-carried-over"))
+      coordinator.setTranscriptsForTesting([removed])
+      await coordinator.sweepExpiredPending()
+      #expect(coordinator.liveOnDiskPendingCountForTesting == 2, "control: both rows counted")
+
+      coordinator.delete(removed)
+      await coordinator.waitForRefreshForTesting()
+
+      // Zeroing the cache is what lets the pulse stop, and it is only ever
+      // provisional — the directory decides. A removal that zeroed and never
+      // looked again would be indistinguishable from this on the single-row
+      // case, which is why that case cannot bind the re-read.
+      #expect(
+        coordinator.liveOnDiskPendingCountForTesting == 1,
+        """
+        #2186: after removing one held row the app assumed the directory was empty. A dictation \
+        cancelled in an earlier session is still on disk and still counting down, and nothing is \
+        watching its deadline any more.
+        """)
+      #expect(
+        coordinator.hasPendingPulseForTesting,
+        "and the countdown that row needs has stopped, so it survives to the next launch")
+    }
+
+    @Test("a walk overtaken by a removal does not write its stale count back")
+    func supersededWalkDoesNotWriteItsResult() async throws {
+      let store = makeStore()
+      let log = EventLog()
+      let coordinator = makeCoordinator(log, store: store)
+
+      let id = UUID()
+      let row = Transcript(
+        id: id, text: "still counting down while a walk is in flight",
+        escapeRecoveredAt: Date().addingTimeInterval(-60),
+        escapeRecoveryTakeID: "take-superseded")
+      try store.savePending(row)
+      coordinator.setTranscriptsForTesting([row])
+
+      // The removal lands in the ONE window that matters: the walk has finished
+      // and counted this row, and has not yet written that count back. In the
+      // app the two arrive as separate tasks whose main-actor resumptions are
+      // unordered, so this is staged through the subject's own seam rather than
+      // raced — a race would pass on the runs where it happened to win, which is
+      // indistinguishable from a guard that works.
+      //
+      // One-shot: cleared before it acts, or the walk it arms re-enters here.
+      coordinator.onSweepWalkFinishedForTesting = { [weak coordinator] in
+        coordinator?.onSweepWalkFinishedForTesting = nil
+        coordinator?.simulateRemovalDuringWalkForTesting()
+      }
+      await coordinator.sweepExpiredPending()
+
+      #expect(
+        coordinator.liveOnDiskPendingCountForTesting == 0,
+        """
+        #2186 cloud review P2: a walk that finished BEFORE the user's removal wrote its count back \
+        anyway. That count describes a directory that no longer exists, so the countdown stays \
+        armed until a row that is already deleted reaches its former deadline.
+        """)
+
+      // Deliberately NOT asserting the pulse is stopped here, and the reason is
+      // the finding rather than a caveat: this scenario supersedes a walk, it
+      // does not remove the row, so the row is still live in memory and the
+      // pulse is correctly armed for it. Asserting a stop would pass only
+      // because a DIFFERENT input was broken. The removal-and-stop outcome is
+      // owned by `removalRefreshesTheDiskCache` above, which drives the real
+      // `delete` path end to end.
+    }
+
     @Test("and it is deleted at its moment, still with History never loaded")
     func carriedOverRowIsDeletedAtItsMoment() async throws {
       let store = makeStore()

--- a/Tests/EnviousWisprTests/App/EscapeRecoveryDiskExpiryTests.swift
+++ b/Tests/EnviousWisprTests/App/EscapeRecoveryDiskExpiryTests.swift
@@ -1,0 +1,223 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprStorage
+
+/// #2186: a cancelled dictation is deleted at its moment, whatever the UI is doing.
+///
+/// ## The requirement
+///
+/// Founder, 2026-08-20: *"the software shouldn't be based on whether the
+/// window's open or not. As long as the application is running, the timer should
+/// be ticking… And then it just deletes. And if they close the application and
+/// then they reopen the application, it should know how long it's been since the
+/// last time that message was and run any cleanups at that time."*
+///
+/// ## What was actually wrong, measured rather than read
+///
+/// Not what the issue said. `sweepExpiredPending()` DOES run at launch today —
+/// a probe inside it fired on a build whose launch path never calls it — because
+/// SwiftUI materialises the `Window(id: "main")` scene, `SettingsView`'s
+/// `@State selectedSection` defaults to `.history`, and `HistoryContentView`'s
+/// `.task` calls `load()`. That window is never on screen: `CGWindowList`
+/// reports it under `ALL` and not under `ON-SCREEN`.
+///
+/// So the promise is kept by an invisible view mounting, which is the fragility
+/// worth removing rather than a defect a user can see.
+///
+/// **The genuine gap is the middle case, and no issue named it.** A row carried
+/// over from a PREVIOUS session is not in `transcripts` unless History loaded it,
+/// and the countdown arms from `livePendingCount`, which reads `transcripts`. So
+/// while the app runs, nothing is watching that row's deadline: it survives its
+/// moment and waits for a relaunch.
+///
+/// These are Product Outcome tests. When they fail, the plaintext of a dictation
+/// the user CANCELLED outlives the window three shipped surfaces promise —
+/// `help/escape-recovery.md`, `help/what-data-is-collected.md`, and the in-app
+/// countdown that renders "Deleted in 23h".
+@MainActor
+@Suite("Escape Recovery disk expiry (#2186)", .tags(.productOutcome))
+struct EscapeRecoveryDiskExpiryTests {
+
+  private func makeStore() -> TranscriptStore {
+    TranscriptStore(
+      directory: FileManager.default.temporaryDirectory
+        .appendingPathComponent("ew-2186-\(UUID().uuidString)", isDirectory: true))
+  }
+
+  private final class EventLog {
+    var expired: [(ageMs: Int, takeID: String)] = []
+  }
+
+  private func makeCoordinator(_ log: EventLog, store: TranscriptStore) -> TranscriptCoordinator {
+    TranscriptCoordinator(
+      store: store,
+      emitEscapeRecoveryKept: { _, _ in },
+      emitEscapeRecoveryExpired: { log.expired.append((ageMs: $0, takeID: $1)) })
+  }
+
+  #if DEBUG
+    /// `@MainActor` explicitly: a nested type does NOT inherit the suite's
+    /// isolation, and the pulse's sleep seam is `@Sendable`. Global-actor
+    /// isolation is what makes this capturable there.
+    @MainActor
+    private final class PulseGate {
+      var iterations = 0
+      var onWait: ((Int) -> Void)?
+      func advance() {
+        iterations += 1
+        onWait?(iterations)
+      }
+    }
+
+    @Test(
+      "a dictation held from a previous session starts the countdown, with History never loaded")
+    func carriedOverRowArmsTheCountdown() async throws {
+      let store = makeStore()
+      let log = EventLog()
+      let coordinator = makeCoordinator(log, store: store)
+
+      // On disk and STILL COUNTING DOWN — the state after a relaunch. Nothing
+      // puts it in `transcripts`, because that is what `load()` does and History
+      // is never opened here.
+      try store.savePending(
+        Transcript(
+          text: "cancelled yesterday, still offered",
+          escapeRecoveredAt: Date().addingTimeInterval(-60),
+          escapeRecoveryTakeID: "take-carried-over"))
+
+      #expect(
+        !coordinator.hasPendingPulseForTesting,
+        "control: nothing is watching before a sweep — the row is not in memory")
+
+      await coordinator.sweepExpiredPending()
+
+      #expect(
+        log.expired.isEmpty, "control: a live row must not be swept or reported")
+      #expect(
+        coordinator.liveOnDiskPendingCountForTesting == 1,
+        "the sweep must report what is still counting down ON DISK")
+      #expect(
+        coordinator.hasPendingPulseForTesting,
+        """
+        #2186: a dictation held from a previous session left the countdown unarmed, so nothing \
+        was watching its deadline for the whole session. It would survive its moment and wait \
+        for a relaunch — while three shipped surfaces say it is deleted.
+        """)
+    }
+
+    @Test("and it is deleted at its moment, still with History never loaded")
+    func carriedOverRowIsDeletedAtItsMoment() async throws {
+      let store = makeStore()
+      let log = EventLog()
+      let gate = PulseGate()
+      // Constructed inline rather than through the helper: routing the
+      // `@Sendable` sleep seam through an extra parameter loses the isolation
+      // that makes capturing `gate` legal. Matches `pulseSweepsOnDetection`.
+      let coordinator = TranscriptCoordinator(
+        store: store,
+        pendingPulseSleep: { _ in await gate.advance() },
+        emitEscapeRecoveryKept: { _, _ in },
+        emitEscapeRecoveryExpired: { log.expired.append((ageMs: $0, takeID: $1)) })
+
+      // The id is pinned and REUSED below, and that is not tidiness. `Transcript`
+      // mints a fresh id when none is given, so writing a second row without it
+      // leaves the LIVE one on disk beside the expired one — `remainingLive`
+      // never reaches zero, `pendingPulseHasWork` never goes false, and the loop
+      // spins forever against a gate that no longer sleeps. Caught as a hung
+      // `xctest` at 5m31s with no compiler running: a livelock, not a slow build.
+      let id = UUID()
+      try store.savePending(
+        Transcript(
+          id: id, text: "cancelled yesterday, still offered",
+          escapeRecoveredAt: Date().addingTimeInterval(-60),
+          escapeRecoveryTakeID: "take-carried-over"))
+      await coordinator.sweepExpiredPending()
+      #expect(coordinator.hasPendingPulseForTesting, "control: the countdown is running")
+
+      // The row crosses its deadline while the app runs. Driven by SIGNAL, not by
+      // a wall clock: the SAME row is rewritten already past its window and the
+      // deadline seam is brought forward, so the next tick is where expiry
+      // happens. Racing a real 0.4s deadline is the flake this file's sibling
+      // suite already had to remove once.
+      // LIVELOCK NET, and it is required rather than defensive. This loop's exit
+      // condition is the very thing under test: the pulse stops when nothing is
+      // counting down, which only happens if the sweep deletes the row. Break
+      // the sweep — which is exactly what the mutation battery does — and the
+      // gate returns instantly forever, so the test SPINS instead of failing.
+      // Measured: a hung `xctest` at 5m48s on a suite that passes in 0.005s.
+      //
+      // So the cap fires LOUDLY and names itself, per this repo's rule that an
+      // exhausted budget must never be mistaken for a settle.
+      var capFired = false
+      gate.onWait = { [weak coordinator] iteration in
+        guard let coordinator else { return }
+        if iteration == 1 {
+          try? store.savePending(
+            Transcript(
+              id: id, text: "cancelled yesterday, still offered",
+              escapeRecoveredAt: Date().addingTimeInterval(
+                -(AppConstants.pendingTranscriptRetention + 1)),
+              escapeRecoveryTakeID: "take-carried-over"))
+          coordinator.setDiskExpiryDeadlineForTesting(.distantPast)
+          return
+        }
+        if iteration >= 20 {
+          capFired = true
+          coordinator.cancelPulseForTesting()
+        }
+      }
+      await coordinator.waitForPulseForTesting()
+
+      #expect(
+        !capFired,
+        """
+        #2186 livelock net: the countdown ran 20 iterations without the row being swept, so the \
+        loop never ran out of work. That is the pulse spinning, NOT a settle — read this as the \
+        sweep failing to delete the disk row, not as a slow test.
+        """)
+
+      #expect(
+        log.expired.map(\.takeID) == ["take-carried-over"],
+        """
+        #2186: the row crossed its deadline with the app running and nothing deleted it. \
+        "As long as the application is running, the timer should be ticking… and then it just \
+        deletes." Events seen: \(log.expired.map(\.takeID))
+        """)
+      #expect(
+        try await store.loadPending().isEmpty,
+        "and the plaintext must actually be gone from disk, not merely hidden")
+    }
+  #endif
+
+  @Test("an install with no held dictations leaves the countdown off")
+  func emptyStoreLeavesTheCountdownOff() async throws {
+    let store = makeStore()
+    let log = EventLog()
+    let coordinator = makeCoordinator(log, store: store)
+
+    // No pending directory at all — the ordinary case, since Escape Recovery is
+    // off by default. The sweep short-circuits and reports a COMPLETE walk of
+    // nothing, so the countdown must stay off rather than run for the life of
+    // the app over an empty directory.
+    await coordinator.sweepExpiredPending()
+
+    #expect(coordinator.liveOnDiskPendingCountForTesting == 0)
+    #expect(
+      !coordinator.hasPendingPulseForTesting,
+      "nothing is counting down, so nothing should be watching")
+  }
+
+  // NOT COVERED HERE, and named rather than left to be discovered: the
+  // UNREADABLE-directory case. A walk that could not enumerate reports
+  // `walkComplete == false`, and the coordinator must then leave
+  // `liveOnDiskPendingCount` ALONE — storing that walk's zero would read as
+  // "nothing is counting down" and stop the countdown on the one occasion it
+  // must keep running. An earlier version of the test above claimed that
+  // property in its NAME while asserting only the absent-directory path, which
+  // short-circuits to a COMPLETE walk. Reaching the real case needs a directory
+  // that exists and cannot be read; the guard is in `sweepExpiredPending` and is
+  // currently held by `lastSweepIncomplete` alone.
+}

--- a/Tests/EnviousWisprTests/App/EscapeRecoveryDiskExpiryTests.swift
+++ b/Tests/EnviousWisprTests/App/EscapeRecoveryDiskExpiryTests.swift
@@ -53,6 +53,28 @@ struct EscapeRecoveryDiskExpiryTests {
       liveSpoolIDs: spools)
   }
 
+  /// Written from the detached walk and read on the main actor, so it carries
+  /// its own lock rather than relying on the two never overlapping.
+  private final class MainThreadFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: Bool?
+    func record(_ isMain: Bool) {
+      lock.lock()
+      defer { lock.unlock() }
+      value = isMain
+    }
+    var wasCalled: Bool {
+      lock.lock()
+      defer { lock.unlock() }
+      return value != nil
+    }
+    var onMain: Bool? {
+      lock.lock()
+      defer { lock.unlock() }
+      return value
+    }
+  }
+
   private final class EventLog {
     var expired: [(ageMs: Int, takeID: String)] = []
   }
@@ -147,6 +169,70 @@ struct EscapeRecoveryDiskExpiryTests {
         """
         #2186: nothing is pending after the user removed the only held row, yet the countdown is \
         still running. It will walk the pending directory every minute for the life of the app.
+        """)
+    }
+
+    @Test("a kept dictation's leftover copy is deleted even when its audio survives")
+    func keptShadowIsDeletedDespiteSurvivingSpool() async throws {
+      let store = makeStore(spools: { ["session-kept"] })
+
+      // The state a half-failed Keep leaves behind: the permanent row written,
+      // the pending copy NOT removed. `promotePending` does exactly this pair
+      // in this order, and its removal is best-effort.
+      let id = UUID()
+      let row = Transcript(
+        id: id, text: "the user pressed Keep on this", recoverySessionID: "session-kept",
+        escapeRecoveredAt: Date().addingTimeInterval(-48 * 3600),
+        escapeRecoveryTakeID: "take-kept")
+      try store.savePending(row)
+      try store.save(row.promotedFromPending())
+
+      let swept = try await store.deleteExpiredPending()
+
+      // Local review, P2. The spool guard exists to stop a row being deleted
+      // while it is the only proof its audio was already recovered — but the
+      // PERMANENT row carries that same proof, so this copy proves nothing and
+      // protects nothing. Retaining it kept the pulse walking the directory
+      // every minute for the life of the app, for a dictation the user KEPT.
+      #expect(
+        swept.retainedForSpool == 0,
+        """
+        #2186: a leftover copy of a KEPT dictation was retained because its audio survives. The \
+        kept row already carries that proof, so this one is litter that is never collected — and \
+        the countdown keeps running against it forever.
+        """)
+      #expect(swept.deletedIDs.contains(id), "it must be swept as the litter it is")
+      #expect(
+        swept.expired.isEmpty,
+        "and NOT reported as expired — the user kept this dictation, nothing lapsed")
+    }
+
+    @Test("the recovery folder is never read on the main thread")
+    func spoolReadHappensOffTheMainActor() async throws {
+      // The production reader does far more than read: it creates the recovery
+      // directory, chmods it, writes metadata, then enumerates and sorts every
+      // spool. On the main actor that is a filesystem stall in front of app
+      // launch and of every retry pulse. Local review, P2.
+      let sawMainThread = MainThreadFlag()
+      let store = makeStore(spools: {
+        sawMainThread.record(Thread.isMainThread)
+        return []
+      })
+      try store.savePending(
+        Transcript(
+          text: "anything, so the walk has a row to consider",
+          escapeRecoveredAt: Date().addingTimeInterval(-48 * 3600),
+          escapeRecoveryTakeID: "take-offmain"))
+
+      _ = try await store.deleteExpiredPending()
+
+      #expect(sawMainThread.wasCalled, "control: the reader ran at all")
+      #expect(
+        sawMainThread.onMain == false,
+        """
+        #2186: the recovery folder was scanned on the main thread. That scan creates a directory, \
+        changes its permissions, writes a file and sorts every recording in it — in front of the \
+        app appearing, and again on every retry.
         """)
     }
 

--- a/Tests/EnviousWisprTests/App/EscapeRecoveryDiskExpiryTests.swift
+++ b/Tests/EnviousWisprTests/App/EscapeRecoveryDiskExpiryTests.swift
@@ -114,6 +114,42 @@ struct EscapeRecoveryDiskExpiryTests {
         """)
     }
 
+    @Test("a Keep or Delete stops the countdown instead of walking the directory forever")
+    func removalRefreshesTheDiskCache() async throws {
+      let store = makeStore()
+      let log = EventLog()
+      let coordinator = makeCoordinator(log, store: store)
+
+      let id = UUID()
+      let row = Transcript(
+        id: id, text: "held, then deleted by the user",
+        escapeRecoveredAt: Date().addingTimeInterval(-60),
+        escapeRecoveryTakeID: "take-then-deleted")
+      try store.savePending(row)
+      coordinator.setTranscriptsForTesting([row])
+      await coordinator.sweepExpiredPending()
+      #expect(coordinator.hasPendingPulseForTesting, "control: the countdown is running")
+      #expect(coordinator.liveOnDiskPendingCountForTesting == 1, "control: disk truth cached")
+
+      // The user removes it. `liveOnDiskPendingCount` is a CACHE of the last
+      // sweep and this changes the directory it describes, so stopping on the
+      // stale value leaves the pulse alive with nothing to do — a directory walk
+      // every minute for the life of the app, which is the stranded retry this
+      // file's own comments warn about. Cloud review, P2.
+      coordinator.delete(row)
+      await coordinator.waitForRefreshForTesting()
+
+      #expect(
+        coordinator.liveOnDiskPendingCountForTesting == 0,
+        "the cache must be re-read from disk after a removal, not trusted")
+      #expect(
+        !coordinator.hasPendingPulseForTesting,
+        """
+        #2186: nothing is pending after the user removed the only held row, yet the countdown is \
+        still running. It will walk the pending directory every minute for the life of the app.
+        """)
+    }
+
     @Test("and it is deleted at its moment, still with History never loaded")
     func carriedOverRowIsDeletedAtItsMoment() async throws {
       let store = makeStore()


### PR DESCRIPTION
## Expiry stops depending on whether a window is open

Founder direction, 2026-08-20:

> the software shouldn't be based on whether the window's open or not. As long as the application is running, the timer should be ticking. Right? And then it just deletes. And if they close the application and then they reopen the application, it should know how long it's been since the last time that message was and run any cleanups at that time.

**#2186 as filed does not reproduce, and the measurement is on the issue.** `sweepExpiredPending()` already runs at launch — a probe inside it fired on a build whose launch path never calls it — because SwiftUI materialises the `Window(id: "main")` scene, `SettingsView`'s `@State selectedSection` defaults to `.history`, and `HistoryContentView.task` calls `load()`. That window is **never on screen**: `CGWindowList` reports it under `ALL` and not under `ON-SCREEN`, and AX reports zero windows for the process.

So the published promise is kept today **by an invisible view mounting**. This PR removes that dependency, and closes a real gap nobody had filed.

## The gap no issue named

A row carried over from a PREVIOUS session is not in `transcripts` unless History loaded it, and the countdown arms from `livePendingCount`, which reads `transcripts`. **So while the app runs, nothing watches that row's deadline.** It survives its moment and waits for a relaunch — the exact case the founder's second sentence describes.

## What changed

| Part | Change |
|---|---|
| Countdown | `PendingSweepResult` carries `remainingLive` and `nextLiveDeadline`, both from the SAME enumeration that already decides what to delete. The coordinator arms from disk truth, and only when `walkComplete` — a walk that could not enumerate reports zero, and storing that zero would stop the timer on the one occasion it must keep running. |
| Safety | The sweep **skips any expired row whose spool is still on disk**. That row is the proof its spool was already recovered; deleting it makes the next scan replay the spool and hand back a dictation the user CANCELLED. |
| Retry | `retainedForSpool` is reported and arms the pulse, so a retained row goes on the pass after recovery clears its spool rather than waiting for a relaunch. |
| Launch | One line, its own task, **no ordering** against the recovery scan. |

### Why the sweep skips instead of being sequenced

An earlier design (PR #2245, closed) chained the sweep after `scanAndRecover()`. Cloud review refuted both halves:

- **P1** — `listSpoolSessionIDs()` can throw while `scanAndRecover()` returns normally, so the sweep runs with no de-dup snapshot taken at all.
- **P2** — chaining lets a wedged replay block the sweep for a whole session.

The two pull opposite ways; every fix to one made the other worse. Skipping removes the hazard structurally, so ordering stops mattering and the launch call needs no coordination.

**Fail closed.** `nil` from the spool reader means the directory could not be listed, which is not "no spools". Collapsing it would delete the proof precisely when we cannot see what it protects.

**The spool source is injected**, which is a correctness fix rather than a testing convenience: the sweep read the REAL spool directory, so the guard could not be tested and every test run touched the user's own crash-recovery folder. The test default is EMPTY, never the disk reader.

## Validation

**Mutation battery, real runner, 9/9 CAUGHT** (14-17s each), baseline green before and after, every file byte-restored. Rows 7, 8 and 9 were added by cloud-review rounds 2, 3 and 4; row 8 was RE-BOUND after round 4 un-covered it (below).

| Row | Result |
|---|---|
| countdown ignores disk truth (pre-fix behaviour) | CAUGHT |
| countdown arms but never finds a disk row due | CAUGHT |
| store stops reporting what is counting down | CAUGHT |
| **spool guard removed — delete the row though its audio survives** | CAUGHT |
| **cannot-determine fails OPEN instead of closed** | CAUGHT |
| retained rows stop arming the retry | CAUGHT |
| **INVALID rows lose their de-dup protection** (round-2 P1) | CAUGHT |
| **no re-read after Keep/Delete** (round-3 P2, re-bound) | CAUGHT |
| **superseded walk writes anyway** (round-4 P2) | CAUGHT |

**Both lanes green, suite EXECUTES in both** (`@Suite` display name present in each log, not merely compiled).

### A row that had been CAUGHT came back SURVIVED, and that is the finding

Round 4's fix un-bound round 3's row. `removalRefreshesTheDiskCache` holds ONE pending row, and once the removal path zeroed the cache synchronously, that single row could no longer distinguish *"zeroed the cache"* from *"zeroed it and re-read the directory"* — the two produce an identical observation when there is nothing else on disk. So the mutation that deletes the refresh entirely came back green, having gone red ninety minutes earlier. Nothing failed anywhere; the previous battery's 8/8 was a true statement about a tree that no longer existed.

Resolved by observing more tightly, never by relaxing an assertion (`GR-NEVER-WEAKEN-GUARDRAILS`). `removalRearmsAnotherRowStillOnDisk` adds a second row that exists **on disk only** — the carried-over case this whole issue is about — and asserts the cache re-reads to 1 with the pulse still armed. Caught again in 16s.

**The general form: a fixture with one row is a world too small to contain the question.** Ask what a fixture makes IMPOSSIBLE, not what it covers.

### Cloud review rounds

| Round | Finding | Resolution |
|---|---|---|
| 1 | P2 lexical guard satisfiable by a string literal or inactive `#if`; P3 cited a gitignored path | Rewrote as a SwiftParser `SyntaxVisitor` skipping `IfConfigDeclSyntax`; dropped the citation |
| 2 | **P1** — an `.invalid` pending row lost its de-dup protection, so its id could stop protecting a spool the reader still counts | Per-file permissive decode, matching `decodeAnyPendingIdentities` exactly: anything that reader would count, the sweep must protect |
| 3 | **P2** — `keep`/`delete`/`deleteAll` stopped the pulse on a cached count describing a directory they had just changed | `invalidateDiskState()` + re-read; the synchronous stop is a contract a neighbouring pre-existing test depends on |
| 4 | **P2** — a superseded walk could write its stale result over a newer one's | Generation counter; a walk that finished before a removal cannot write back |

**Round 4 refuted a "known limit" I had asserted on round 3** — that overlapping refreshes were harmless because "the later task wins". That was a claim about my own change, not a measurement. The store serialises the directory walks, but each sweep writes its result back on the main actor AFTER resuming, and main-actor resumptions are not ordered.

**The general form, because it is the premise that produced the defect: an actor serialises its hops, not your operation.** Anything computed before an `await` and written after it has crossed a boundary where nothing holds its place in line.

### Testing a race that cannot be staged honestly

The two tasks resume in an order the runtime picks, so a racing test proves nothing on the run where it happens to win. A DEBUG seam fires in the one window that matters — walk finished, result not yet written — and the test performs a removal there.

`supersededWalkDoesNotWriteItsResult` deliberately does **not** assert the pulse stops: that scenario supersedes a walk, it does not remove the row, so the row is still live and the pulse is correctly armed for it. Asserting a stop would have passed only because a different input was broken.

### Live UAT — redesigned, because the first design could not have told the truth

The first version watched the file disappear. **The invisible window deletes it anyway**, so that measurement cannot distinguish this change from the app's existing behaviour — it passed and meant nothing. The negative control is the only thing that caught it.

This version counts how many times the sweep ANNOUNCES ITSELF:

| Arm | Sweeps | File gone |
|---|---|---|
| **A** — fixed build | **2** (launch + History mount) | yes |
| **B** — launch call removed, rebuilt | **1** (History mount only) | yes |

The second sweep is this change and nothing else produces it. **Note the right-hand column is identical in both arms** — that is the proof the original design was worthless. Build state was verified before each arm rather than assumed: probe present in the deployed dylib, launch call present/absent in source.

## Known limits, stated rather than discovered later

- A row retained because its spool survives is deleted on the pass AFTER recovery clears that spool. Bounded — recovery scans at launch and on wake — and the direction is deliberate: retain the de-dup proof rather than resurrect a cancelled dictation.
- Two rapid removals arm two overlapping refresh sweeps. Nothing cancels the earlier one; the generation counter makes its result inert rather than absent.
- The refresh re-reads the pending directory, not the recovery spool. A row whose spool disappears between sweeps is picked up on the next pulse tick rather than immediately.

Part of #2186
