### PR TITLE
docs(readme): the landing page was four releases behind what we ship

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ On our own benchmark of 1,890 real dictation-cleanup cases, EG-1 passed 93.7%, a
 
 - 🎙️ **Dual ASR engines** with [Parakeet v3](https://github.com/FluidInference/FluidAudio) (NVIDIA NeMo) and [WhisperKit](https://github.com/argmaxinc/argmax-oss-swift) (OpenAI Whisper)
 - 👀 **Live Preview**: watch your words appear in the recording pill while you speak, so you can see it is working without waiting for the paste. Optional, and it never changes the text you get
-- ↩️ **Escape Recovery**: cancel a dictation by mistake and get it back. Turn it on and a cancelled dictation is kept for 24 hours instead of discarded. Off by default, and only the text is kept, never the audio
+- ↩️ **Escape Recovery**: hit your cancel keybind by mistake and get the dictation back. Turn it on and a keybind cancel keeps the text for 24 hours instead of discarding it. The Cancel button in the recording pill still discards on the spot, so you keep one way to mean it. Off by default, and only the text is kept, never the audio
 - ✨ **AI polish that respects your words**: strips filler words and false starts, fixes grammar and punctuation, formats numbers, dates, and URLs, and honors your custom vocabulary, all in your spoken language (never translated or rewritten)
 - 🔒 **Polish that can stay private**: run it fully on-device with EG-1 (our own custom model), Apple Intelligence (macOS 26+), or Ollama, or in the cloud via OpenAI GPT / Google Gemini with your own API key
 - 🌍 **Multilingual with automatic language detection**: speak in any supported language and EnviousWispr detects it, then offers to lock it in for faster, more accurate transcription
@@ -122,7 +122,7 @@ On our own benchmark of 1,890 real dictation-cleanup cases, EG-1 passed 93.7%, a
 
 EnviousWispr ships often. A few of the user-facing improvements from recent releases:
 
-- **Recover a dictation you cancelled by mistake.** Turn on Escape Recovery and cancelling keeps the text for 24 hours instead of throwing it away. Only the transcript is kept, never the audio. (v2.4.5)
+- **Recover a dictation you cancelled by mistake.** Turn on Escape Recovery and hitting your cancel keybind keeps the text for 24 hours instead of throwing it away. The Cancel button still discards deliberately. Only the transcript is kept, never the audio. (v2.4.5)
 - **See your words as you speak.** The recording pill can now show what it is hearing, live, with a choice of two preview engines. The text you actually get is unchanged: it is still transcribed from the whole recording when you stop. (v2.4.5)
 - **Dictation no longer records silence on a virtual microphone.** If your Mac's default input was a virtual device (Krisp, Loopback, BlackHole, an aggregate, a meeting app's mic), the app bound it and captured nothing at all. It now prefers a real microphone. (v2.4.5)
 - **EG-1 retrained on its weakest spots.** Announcing a list out loud produces a real list far more often, and changes of mind mid-sentence now land level with a frontier cloud model on our held-out benchmark. It is also about 14% faster. (v2.4.5)

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ On our own benchmark of 1,890 real dictation-cleanup cases, EG-1 passed 93.7%, a
 ## Features
 
 - 🎙️ **Dual ASR engines** with [Parakeet v3](https://github.com/FluidInference/FluidAudio) (NVIDIA NeMo) and [WhisperKit](https://github.com/argmaxinc/argmax-oss-swift) (OpenAI Whisper)
+- 👀 **Live Preview**: watch your words appear in the recording pill while you speak, so you can see it is working without waiting for the paste. Optional, and it never changes the text you get
+- ↩️ **Escape Recovery**: cancel a dictation by mistake and get it back. Turn it on and a cancelled dictation is kept for 24 hours instead of discarded. Off by default, and only the text is kept, never the audio
 - ✨ **AI polish that respects your words**: strips filler words and false starts, fixes grammar and punctuation, formats numbers, dates, and URLs, and honors your custom vocabulary, all in your spoken language (never translated or rewritten)
 - 🔒 **Polish that can stay private**: run it fully on-device with EG-1 (our own custom model), Apple Intelligence (macOS 26+), or Ollama, or in the cloud via OpenAI GPT / Google Gemini with your own API key
 - 🌍 **Multilingual with automatic language detection**: speak in any supported language and EnviousWispr detects it, then offers to lock it in for faster, more accurate transcription
@@ -120,12 +122,15 @@ On our own benchmark of 1,890 real dictation-cleanup cases, EG-1 passed 93.7%, a
 
 EnviousWispr ships often. A few of the user-facing improvements from recent releases:
 
-- **Pasting lands in more apps.** Text now reliably reaches apps that previously said "Copied" but never pasted (Word, Excel, Pages, Numbers, OneNote, and others). (v2.1.4)
-- **Vocabulary packs and Contacts import.** Turn on a pack for brands and jargon, or import the names of people you know in one tap, so hard-to-spell names come out right. Your contacts never leave your Mac. (v2.1.3)
-- **No swallowed first word after a break.** After idling, the engine re-wakes in a fraction of a second and captures your words, including the very first one. (v2.1.2 and v2.1.3)
-- **Soft and distant speech captured.** Quiet, whispered, or far-from-the-mic speech is now transcribed instead of dropped. (v2.1.2)
-- **Automatic update checks.** The app looks for new versions on its own, with a clear "Check for Updates" control in Settings. (v2.1.2)
-- **Clearer AI polish errors.** Cloud and local polish failures (OpenAI, Gemini, Ollama) now show a specific, actionable message, and your raw text still arrives.
+- **Recover a dictation you cancelled by mistake.** Turn on Escape Recovery and cancelling keeps the text for 24 hours instead of throwing it away. Only the transcript is kept, never the audio. (v2.4.5)
+- **See your words as you speak.** The recording pill can now show what it is hearing, live, with a choice of two preview engines. The text you actually get is unchanged: it is still transcribed from the whole recording when you stop. (v2.4.5)
+- **Dictation no longer records silence on a virtual microphone.** If your Mac's default input was a virtual device (Krisp, Loopback, BlackHole, an aggregate, a meeting app's mic), the app bound it and captured nothing at all. It now prefers a real microphone. (v2.4.5)
+- **EG-1 retrained on its weakest spots.** Announcing a list out loud produces a real list far more often, and changes of mind mid-sentence now land level with a frontier cloud model on our held-out benchmark. It is also about 14% faster. (v2.4.5)
+- **Bring your vocabulary over from another dictation app.** Custom words import from eight other Mac dictation apps, from a file, or from a pasted list, and export to a backup you own. (v2.4.1, expanded in v2.4.5)
+- **Use the Globe key for dictation.** The Globe key, marked Fn on many Macs, works as your keybind. (v2.4.4)
+- **Bluetooth and USB audio properly supported**, with customizable sound cues and your choice of recording pill location. (v2.4.0)
+- **Meet EG-1**, our own on-device polish model, and a full visual refresh of Settings. (v2.3.0)
+- **Dark mode, and recordings up to an hour long.** (v2.2.0)
 
 See the [full release history](https://github.com/saurabhav88/EnviousWispr/releases) for every version.
 


### PR DESCRIPTION
**Lane:** Content · **Tier:** SMALL (README prose only)

The GitHub landing page is the first thing a stranger sees, and it had gone stale while
the app moved on. Found while checking, after shipping v2.4.5, whether every channel that
tells people about the app had actually been updated. The download paths and the release
page had; this had not.

## Two gaps

**"Recent improvements" ended at v2.1.4** — four minor releases back. A visitor saw nothing
about Escape Recovery, Live Preview, EG-1, or importing a vocabulary from another app. Now
covers v2.2.0 through v2.4.5, newest first, each item tagged with the version it landed in.

**The Features list omitted the two headline features of the current release.** Live Preview
and Escape Recovery are both added, each stating its own limits inline rather than leaving
them to a footnote: the preview never changes the pasted text, and recovery is off by
default and keeps only the transcript, never audio.

## Grounding

Every item is sourced from the shipped What's New copy in `WhatsNewContent.swift`, not from
memory, so nothing here claims a feature the app does not have or attributes one to the
wrong release. The specific claims were re-checked against this evening's release
verification: 24-hour retention, eight import sources, two preview engines, the
virtual-microphone device list, and EG-1's held-out result and speed figure.

Checked and clean: no em or en dashes (`GR-NO-DASHES`), and no surviving reference to the
old "Shortcuts" page name, which #2181 renamed to Keybinds.

## One thing deliberately NOT changed

**The EG-1 benchmark paragraph is stale on three axes and wants a founder call (#2254).**
It reports 93.7% for EG-1 against GPT-5.4-mini and Gemini 3.5 Flash:

- the model was **retrained and shipped in v2.4.5**, so the figure describes a version
  users no longer run;
- both comparison models have been superseded on our own side (Gemini now defaults to
  3.7 Flash);
- it measured cases EG-1 had **trained on**, and we now have a genuinely held-out number,
  including a dead tie with a frontier cloud model on self-correction.

Changing a published benchmark is a positioning decision rather than a docs fix, so it
stays until #2254 is answered.

**Also correcting the scope of #2254 itself:** that issue named only `how-it-works.astro`.
The same figure lives here in `README.md` too. One claim, two surfaces.

## Test plan

- [x] Sourced every item from shipped in-app copy rather than memory
- [x] Dash and stale-page-name sweep clean
- [ ] Cloud review to an explicit all-clear
- [ ] `build-check` green
