### PR TITLE
test: run mutation battery through canonical test command

### DIFF
--- a/Sources/EnviousWisprCore/AppLogger.swift
+++ b/Sources/EnviousWisprCore/AppLogger.swift
@@ -41,10 +41,13 @@ public actor AppLogger {
     private let maxFileSize: Int = 10 * 1024 * 1024
     private let maxFileCount: Int = 5
 
-    private var logDirectory: URL {
-      let lib = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)[0]
-      return lib.appendingPathComponent("Logs/EnviousWispr", isDirectory: true)
-    }
+    /// Test lanes receive a private directory through Xcode's `TEST_RUNNER_`
+    /// environment forwarding. Normal app launches have no override and keep
+    /// writing to the user's standard debug-log directory.
+    private let logDirectory = AppLogger.resolveLogDirectory(
+      environment: ProcessInfo.processInfo.environment,
+      libraryDirectory: FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)[0]
+    )
     private var currentLogURL: URL { logDirectory.appendingPathComponent("app.log") }
     private var fileHandle: FileHandle?
 
@@ -148,6 +151,17 @@ public actor AppLogger {
   }
 
   #if DEBUG
+    package static func resolveLogDirectory(
+      environment: [String: String], libraryDirectory: URL
+    ) -> URL {
+      if let override = environment["EW_APP_LOG_DIRECTORY"],
+        !override.isEmpty,
+        (override as NSString).isAbsolutePath
+      {
+        return URL(fileURLWithPath: override, isDirectory: true).standardizedFileURL
+      }
+      return libraryDirectory.appendingPathComponent("Logs/EnviousWispr", isDirectory: true)
+    }
 
     // MARK: - File management (debug-only)
 

--- a/Tests/EnviousWisprTests/Core/AppLoggerCompileOutTests.swift
+++ b/Tests/EnviousWisprTests/Core/AppLoggerCompileOutTests.swift
@@ -69,10 +69,16 @@ struct AppLoggerCompileOutTests {
 
       let logDirectory = await AppLogger.shared.logDirectoryURL()
       let url = logDirectory.appendingPathComponent("app.log")
-      let configuredDirectory = try #require(
-        ProcessInfo.processInfo.environment["EW_APP_LOG_DIRECTORY"])
-      #expect(logDirectory.path == configuredDirectory)
-      #expect(logDirectory != Self.expectedLogURL.deletingLastPathComponent())
+      if let configuredDirectory = ProcessInfo.processInfo.environment["EW_APP_LOG_DIRECTORY"] {
+        // The canonical test wrapper always takes this branch, keeping a running
+        // developer app and the test process on separate files.
+        #expect(logDirectory.path == configuredDirectory)
+        #expect(logDirectory != Self.expectedLogURL.deletingLastPathComponent())
+      } else {
+        // Direct xcodebuild callers, including GitHub CI, intentionally exercise
+        // the normal app fallback instead of requiring a wrapper-only variable.
+        #expect(logDirectory == Self.expectedLogURL.deletingLastPathComponent())
+      }
       #expect(FileManager.default.fileExists(atPath: url.path))
       #expect(Self.fileContains(url, marker: marker))
 

--- a/Tests/EnviousWisprTests/Core/AppLoggerCompileOutTests.swift
+++ b/Tests/EnviousWisprTests/Core/AppLoggerCompileOutTests.swift
@@ -5,14 +5,11 @@ import Testing
 
 /// Validates Phase R3 compile-out: `AppLogger` is dev-only, release sinks are dead code.
 ///
-/// In debug builds, enabling debug mode + logging must produce content on disk under
-/// `~/Library/Logs/EnviousWispr/app.log`. In release builds, the same call sequence
+/// In debug builds, enabling debug mode + logging must produce content in the
+/// test lane's private log directory. In release builds, the same call sequence
 /// must NOT emit the marker — the sink machinery is gated behind `#if DEBUG`.
 ///
-/// Tests are non-destructive: each assertion uses a unique-per-run marker token and
-/// inspects the existing log file (or its absence) without deleting or truncating
-/// the developer's real logs. Running the suite locally never wipes
-/// `~/Library/Logs/EnviousWispr/`.
+/// Tests are non-destructive: each assertion uses a unique-per-run marker token.
 @Suite("AppLogger R3 compile-out")
 struct AppLoggerCompileOutTests {
 
@@ -43,6 +40,20 @@ struct AppLoggerCompileOutTests {
 
   #if DEBUG
 
+    @Test("test log override accepts only an absolute path")
+    func testLogOverrideAcceptsOnlyAbsolutePath() {
+      let fallback = URL(fileURLWithPath: "/tmp/ew-library", isDirectory: true)
+      let isolated = AppLogger.resolveLogDirectory(
+        environment: ["EW_APP_LOG_DIRECTORY": "/tmp/ew-tests/logger"],
+        libraryDirectory: fallback)
+      #expect(isolated.path == "/tmp/ew-tests/logger")
+
+      let rejected = AppLogger.resolveLogDirectory(
+        environment: ["EW_APP_LOG_DIRECTORY": "relative/logger"],
+        libraryDirectory: fallback)
+      #expect(rejected == fallback.appendingPathComponent("Logs/EnviousWispr", isDirectory: true))
+    }
+
     @Test("Debug build: log() emits the marker into the file sink")
     func debugBuildEmitsMarkerIntoFileSink() async throws {
       // Three separate suites toggle the AppLogger singleton and Swift Testing
@@ -56,7 +67,12 @@ struct AppLoggerCompileOutTests {
       // Drain in-flight actor work before reading the file.
       _ = await AppLogger.shared.logDirectoryURL()
 
-      let url = Self.expectedLogURL
+      let logDirectory = await AppLogger.shared.logDirectoryURL()
+      let url = logDirectory.appendingPathComponent("app.log")
+      let configuredDirectory = try #require(
+        ProcessInfo.processInfo.environment["EW_APP_LOG_DIRECTORY"])
+      #expect(logDirectory.path == configuredDirectory)
+      #expect(logDirectory != Self.expectedLogURL.deletingLastPathComponent())
       #expect(FileManager.default.fileExists(atPath: url.path))
       #expect(Self.fileContains(url, marker: marker))
 

--- a/Tests/EnviousWisprTests/Core/AppLoggerCompileOutTests.swift
+++ b/Tests/EnviousWisprTests/Core/AppLoggerCompileOutTests.swift
@@ -70,9 +70,11 @@ struct AppLoggerCompileOutTests {
       let logDirectory = await AppLogger.shared.logDirectoryURL()
       let url = logDirectory.appendingPathComponent("app.log")
       if let configuredDirectory = ProcessInfo.processInfo.environment["EW_APP_LOG_DIRECTORY"] {
+        let configuredURL = URL(fileURLWithPath: configuredDirectory, isDirectory: true)
+          .standardizedFileURL
         // The canonical test wrapper always takes this branch, keeping a running
         // developer app and the test process on separate files.
-        #expect(logDirectory.path == configuredDirectory)
+        #expect(logDirectory == configuredURL)
         #expect(logDirectory != Self.expectedLogURL.deletingLastPathComponent())
       } else {
         // Direct xcodebuild callers, including GitHub CI, intentionally exercise

--- a/Tests/EnviousWisprTests/Core/AppLoggerPreSinkBufferTests.swift
+++ b/Tests/EnviousWisprTests/Core/AppLoggerPreSinkBufferTests.swift
@@ -10,8 +10,8 @@ import Testing
 /// launch-window `finishFailed` never made it to `app.log` while the identical
 /// call at press-time did.
 ///
-/// `AppLogger` is a process-wide singleton writing to the developer's real log
-/// directory, so every test here restores the prior debug mode and log level,
+/// `AppLogger` is a process-wide singleton, so every test here restores the
+/// prior debug mode and log level,
 /// and resets the latch through the `#if DEBUG` seam so the pre-sink window is
 /// reachable regardless of suite ordering.
 #if DEBUG
@@ -69,10 +69,7 @@ import Testing
 
     /// Reads the live `app.log`. Missing or unreadable reads back as empty, so a
     /// `contains` assertion fails loudly rather than throwing something unrelated.
-    private func readLog() -> String {
-      let url = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)[0]
-        .appendingPathComponent("Logs/EnviousWispr", isDirectory: true)
-        .appendingPathComponent("app.log")
+    private func readLog(at url: URL) -> String {
       return (try? String(contentsOf: url, encoding: .utf8)) ?? ""
     }
 
@@ -91,7 +88,8 @@ import Testing
 
         await AppLogger.shared.setDebugMode(true)
 
-        let contents = readLog()
+        let directory = await AppLogger.shared.logDirectoryURL()
+        let contents = readLog(at: directory.appendingPathComponent("app.log"))
         #expect(
           contents.contains(marker),
           "the pre-sink line must reach app.log once the sink opens")
@@ -206,7 +204,8 @@ import Testing
         #expect(held == 500, "the buffer must cap at 500, got \(held)")
 
         await AppLogger.shared.setDebugMode(true)
-        let contents = readLog()
+        let directory = await AppLogger.shared.logDirectoryURL()
+        let contents = readLog(at: directory.appendingPathComponent("app.log"))
         #expect(
           contents.contains("dropped at the 500 cap"),
           "an overflowing buffer must say so rather than silently truncate")

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -1078,7 +1078,8 @@ finally:
 # before falling back to SIGKILL, or another worktree silently loses the shared seed for the rest of the
 # session. Drive both branches without sending a signal to this test process.
 for _label, _waits, _want in [
-    ("a cooperative canonical lane gets TERM and its cleanup window", [], [battery.signal.SIGTERM]),
+    ("a cooperative wrapper still has its descendant group swept after cleanup", [],
+     [battery.signal.SIGTERM, battery.signal.SIGKILL]),
     ("an uncooperative canonical lane gets SIGKILL only after TERM", [battery.subprocess.TimeoutExpired("x", 1)],
      [battery.signal.SIGTERM, battery.signal.SIGKILL]),
 ]:

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -30,18 +30,9 @@ VALID_ROW = {
 failures = []
 ran = 0
 
-# A pattern that matches no process. The dev-app check is a machine-wide `pgrep`, so without this the
-# whole suite fails whenever any session has a dev app open — which is a property of the box, not of
-# the code under test. The real check gets its own two-way case below, driven directly.
 import os as _os_env  # noqa: E402
 
-NEUTRAL_PATTERN = "ew-battery-self-test-matches-nothing"
-NEUTRAL_ENV = dict(_os_env.environ, EW_BATTERY_DEV_APP_PATTERN=NEUTRAL_PATTERN)
-# Set it in THIS process too, before the module is imported below. The subprocess cases get NEUTRAL_ENV
-# explicitly; the in-process cases read the module's own DEV_APP_PATTERN, which is resolved at import.
-# Without this the stubbed-lane rows fail whenever any session on the box has a dev app open — measured
-# exactly that way when a peer took the slot mid-suite.
-_os_env.environ["EW_BATTERY_DEV_APP_PATTERN"] = NEUTRAL_PATTERN
+NEUTRAL_ENV = dict(_os_env.environ)
 
 
 # A runnable entry point is the only preflight contract: the battery delegates every build setting to it.
@@ -305,10 +296,6 @@ import importlib.util  # noqa: E402
 _spec = importlib.util.spec_from_file_location("battery", BATTERY)
 battery = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(battery)
-# Same reason as NEUTRAL_ENV, for the in-process cases: the dev-app check is about the machine, and
-# every case that is not ABOUT it should not consult it. Its own case restores this and drives it.
-_REAL_CHECK_NO_DEV_APP = battery.check_no_dev_app
-battery.check_no_dev_app = lambda worktree: None
 
 
 def check_fence(name, body, *, expect_blocks):
@@ -626,29 +613,6 @@ with _t3.TemporaryDirectory() as td:
     else:
         print("  ok  a restored file is stamped NOW, so the next build cannot reuse mutant objects")
 
-# Preflight is a snapshot; an overnight battery is long. A dev app that starts after preflight and
-# stops before the closing baseline corrupts the AppLogger tests only DURING a mutant, which credits
-# the sabotage with a failure something else caused — a false CAUGHT, failing toward confidence.
-ran += 1
-_real_pids = battery.dev_app_pids
-battery.dev_app_pids = lambda wt: ["99999"]
-try:
-    rc, out, after, during = drive_row((5, [], True, "log", 0, 3.0, None),
-                                       expect_verdict=None, expect_detail=None)
-    problems = []
-    if "ERR" not in out or "appeared mid-run" not in out:
-        problems.append(f"row should ERROR naming the intruder; got: {out.strip()[:200]}")
-    if rc != 1:
-        problems.append(f"exit {rc}, wanted 1")
-    if after != ORIGINAL:
-        problems.append(f"file not restored: {after!r}")
-    if problems:
-        failures.append("a dev app appearing mid-run fails that row: " + "; ".join(problems))
-    else:
-        print("  ok  a dev app appearing mid-run fails that row")
-finally:
-    battery.dev_app_pids = _real_pids
-
 check_row("the file is restored even when the lane raises mid-row",
           None, expect_marker="ERR", expect_rc=1, raise_instead=RuntimeError("lane exploded"))
 
@@ -950,28 +914,6 @@ finally:
     for s_, h in _prev.items():
         _sig.signal(s_, h)
 
-# The dev-app check itself, driven directly. A concurrent dev app corrupts the AppLogger tests, and
-# those failures score as mutants CAUGHT when nothing detected the sabotage (#2080) — it fails toward
-# CONFIDENCE, so it is a refusal rather than a warning, and it needs to be proven both ways.
-for _label, _rc, _out, _want in [
-    ("a running dev app refuses the whole run", 0, "43962\n", True),
-    ("no dev app lets the run proceed", 1, "", False),
-]:
-    ran += 1
-    _real_run2 = battery.run
-    battery.run = lambda cmd, cwd, log_path=None, timeout=None, _r=_rc, _o=_out: (_r, _o)
-    try:
-        _REAL_CHECK_NO_DEV_APP(Path("."))
-        _refused = False
-    except battery.Refusal as exc:
-        _refused = "A dev app is running" in str(exc)
-    finally:
-        battery.run = _real_run2
-    if _refused != _want:
-        failures.append(f"{_label}: refused={_refused}, wanted {_want}")
-    else:
-        print(f"  ok  {_label}")
-
 # The runner invokes the executable command and gives it the filtered suite, isolated log directory,
 # result-bundle path, and derived-data environment instead of owning a second xcodebuild argument list.
 ran += 1
@@ -1033,41 +975,6 @@ elif _seen.get("derived") != _probe:
                     f"used {_seen.get('derived')!r} instead of {_probe!r}")
 else:
     print("  ok  the battery honours DERIVED_DATA_PATH like the canonical lane")
-
-# The dev-app refusal exists because concurrent app-log writes corrupt the AppLogger tests. That
-# reasoning is entirely about RUNNING tests, so a validation pass — which runs no lane and mutates
-# nothing — must not be refused for a condition that cannot affect it. Measured when a peer's UAT app
-# blocked a read-only recipe check.
-for _label, _will_run, _want_refusal in [
-    ("a run that WILL execute tests still refuses while a dev app is up", True, True),
-    ("a validate-only pass is NOT refused for a dev app it cannot be affected by", False, False),
-]:
-    ran += 1
-    _real_run3 = battery.run
-    # Report a live dev app whatever is asked, so the only variable is whether preflight consults it.
-    battery.run = lambda cmd, cwd, log_path=None, timeout=None: (0, "43962\n")
-    _real_canon = battery.check_canonical_entrypoint
-    battery.check_canonical_entrypoint = lambda wt: None
-    # The suite neutralises check_no_dev_app globally (line ~347) so unrelated cases do not depend on
-    # what else is running on the box. This case is ABOUT that check, so put the real one back.
-    _neutralised = battery.check_no_dev_app
-    battery.check_no_dev_app = _REAL_CHECK_NO_DEV_APP
-    try:
-        with tempfile.TemporaryDirectory() as td:
-            _tmp = make_tree(Path(td))
-            try:
-                battery.preflight(_tmp, will_run_tests=_will_run)
-                _got = False
-            except battery.Refusal as exc:
-                _got = "A dev app is running" in str(exc)
-    finally:
-        battery.run = _real_run3
-        battery.check_canonical_entrypoint = _real_canon
-        battery.check_no_dev_app = _neutralised
-    if _got != _want_refusal:
-        failures.append(f"{_label}: refused={_got}, wanted {_want_refusal}")
-    else:
-        print(f"  ok  {_label}")
 
 # Swift Testing prints ✘ for a KNOWN issue and the lane still exits 0. A test wrapped in
 # `withKnownIssue` is explicitly configured NOT to go red, so crediting it with detecting a mutation
@@ -1716,34 +1623,6 @@ elif "timed out after" not in _body:
                     "marker was not written at all")
 else:
     print("  ok  a timeout appends to the lane log rather than overwriting it")
-
-# `pgrep` exits 0 for a match, 1 for NO MATCH, and 2+ when the probe itself failed. Folding that third
-# answer into "none running" is fail-OPEN on a guard whose whole job is to stop a corrupted log scoring
-# as a mutant CAUGHT — the battery would proceed believing the machine is clear when it does not know.
-for _label, _rc, _want_refusal in [
-    ("a failed dev-app probe refuses rather than reading as clear", 2, True),
-    ("no match from the dev-app probe proceeds normally", 1, False),
-]:
-    ran += 1
-    _real_run6 = battery.run
-    battery.run = lambda cmd, cwd, log_path=None, timeout=None, _r=_rc: (_r, "")
-    _neutralised2 = battery.check_no_dev_app
-    battery.check_no_dev_app = _REAL_CHECK_NO_DEV_APP
-    try:
-        _REAL_CHECK_NO_DEV_APP(Path("."))
-        _got = False
-    except battery.Refusal as exc:
-        _got = "probe failed" in str(exc)
-    except Exception as exc:
-        _got = False
-        failures.append(f"{_label} — raised {type(exc).__name__} instead of Refusal")
-    finally:
-        battery.run = _real_run6
-        battery.check_no_dev_app = _neutralised2
-    if _got != _want_refusal:
-        failures.append(f"{_label}: refused={_got}, wanted {_want_refusal}")
-    else:
-        print(f"  ok  {_label}")
 
 # --- the operator-facing summary ------------------------------------------------
 # Nothing rendered this block before: it was declared inside `main()`, after a full

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -44,37 +44,10 @@ NEUTRAL_ENV = dict(_os_env.environ, EW_BATTERY_DEV_APP_PATTERN=NEUTRAL_PATTERN)
 _os_env.environ["EW_BATTERY_DEV_APP_PATTERN"] = NEUTRAL_PATTERN
 
 
-# Mirrors the real scripts/xcode-test.sh closely enough for the drift guard to parse. Kept in this
-# shape deliberately: a stub that does not resemble the artifact under test proves nothing about it.
+# A runnable entry point is the only preflight contract: the battery delegates every build setting to it.
 CANONICAL_STUB = """#!/usr/bin/env bash
-PROJECT="EnviousWispr.xcodeproj"
-DEBUG_SCHEME="EnviousWispr"
-DEST='platform=macOS,arch=arm64'
-TEST_ARGS=(-only-testing:"$FILTER")
-DERIVED_DATA="${DERIVED_DATA_PATH:-$PROJECT_ROOT/.derivedData/Test}"
-ew_ensure_generated "$PROJECT_ROOT"
-run_lane() {
-  xcodebuild test \\
-    -project "$PROJECT" \\
-    -scheme "$scheme" \\
-    -configuration "$config" \\
-    -derivedDataPath "$DERIVED_DATA" \\
-    -destination "$DEST" \\
-    -onlyUsePackageVersionsFromResolvedFile \\
-    ARCHS=arm64 \\
-    VALID_ARCHS=arm64 \\
-    ONLY_ACTIVE_ARCH=YES \\
-    "$@" \\
-    "${TEST_ARGS[@]}" | tee "$log"
-}
-run_lane "$DEBUG_SCHEME" Debug "$LOG_DIR/xcode-test-debug.log"
+exit 0
 """
-
-# The exact line the two directional drift cases add to or remove from the stub. Derived from the
-# stub itself rather than retyped, because a hand-typed copy of an escaped line is how both of
-# these cases silently tested nothing the first time.
-ONLY_ACTIVE = [l for l in CANONICAL_STUB.split("\n") if "ONLY_ACTIVE_ARCH" in l][0] + "\n"
-assert ONLY_ACTIVE in CANONICAL_STUB, "the stub line the drift cases edit must exist verbatim"
 
 
 def mk_results(statuses, crashed=None):
@@ -122,11 +95,14 @@ def make_tree(tmp: Path):
     (tmp / "Sources").mkdir(parents=True, exist_ok=True)
     (tmp / "Sources" / "Thing.swift").write_text("let guarded = true\n")
     (tmp / "scripts").mkdir(parents=True, exist_ok=True)
-    (tmp / "scripts" / "xcode-test.sh").write_text(CANONICAL_STUB)
+    canonical = tmp / "scripts" / "xcode-test.sh"
+    canonical.write_text(CANONICAL_STUB)
+    canonical.chmod(0o755)
     return tmp
 
 
-def check(name, rows, *, expect_exit, expect_text=None, extra_files=None, top=None, remove=None):
+def check(name, rows, *, expect_exit, expect_text=None, extra_files=None, top=None, remove=None,
+          non_executable=None):
     """Run --validate-only against a throwaway tree and assert the exit code and message."""
     global ran
     ran += 1
@@ -138,6 +114,8 @@ def check(name, rows, *, expect_exit, expect_text=None, extra_files=None, top=No
             p = tmp / rel
             p.parent.mkdir(parents=True, exist_ok=True)
             p.write_text(body)
+        for rel in (non_executable or []):
+            (tmp / rel).chmod(0o644)
         doc = dict(top or {})
         doc["rows"] = rows
         recipes = tmp / "recipes.json"
@@ -212,6 +190,10 @@ check("a leftover .mutbak refuses the whole run",
       [dict(VALID_ROW)], expect_exit=2, expect_text="did not restore",
       extra_files={"Sources/Thing.swift.mutbak": "let guarded = true\n"})
 
+check("a non-backup file in the dedicated backup root refuses the whole run",
+      [dict(VALID_ROW)], expect_exit=2, expect_text="dedicated backup directory",
+      extra_files={"build/mutation-battery/backups/row01/left-behind.txt": "original bytes\n"})
+
 check("an anchor absent from the target file is refused",
       [dict(VALID_ROW, anchor="this text is nowhere in the file")],
       expect_exit=2, expect_text="anchor not found")
@@ -221,81 +203,18 @@ check("a non-unique anchor is refused",
       expect_exit=2, expect_text="must be unique",
       extra_files={"Sources/Thing.swift": "let x = 1\nlet y = x + x\n"})
 
-# The runner reproduces scripts/xcode-test.sh's build settings rather than shelling out to it. That
-# buys two sources of truth, so drift must be loud: if the canonical script stops carrying a setting
-# this runner reproduces, the battery refuses rather than measuring a differently-configured build.
-check("a canonical script with its invocation gone refuses the run",
-      [dict(VALID_ROW)], expect_exit=2, expect_text="could not find the `xcodebuild test",
-      extra_files={"scripts/xcode-test.sh": "#!/usr/bin/env bash\n# gutted\n"})
-
-check("a canonical script that DROPPED a setting refuses the run",
-      [dict(VALID_ROW)], expect_exit=2, expect_text="no longer passes",
-      extra_files={"scripts/xcode-test.sh": CANONICAL_STUB.replace(ONLY_ACTIVE, "")})
-
-# The direction a presence-only check is blind to, and what cloud review flagged on PR #2158: the
-# lane GAINS a setting, everything the runner already knew about is still there, and a
-# one-directional guard stays green while the battery builds differently from the canonical lane.
-check("a canonical script that ADDED a setting refuses the run",
-      [dict(VALID_ROW)], expect_exit=2, expect_text="does NOT reproduce",
-      extra_files={"scripts/xcode-test.sh": CANONICAL_STUB.replace(
-          ONLY_ACTIVE, ONLY_ACTIVE + "    ENABLE_TESTABILITY=YES \\\\\n")})
-
-# Each of these is the drift class at an axis the first two review rounds did not reach. Enumerated
-# rather than waited for: two rounds of one shape is the signal to sweep the whole class yourself.
-check("a canonical Debug call site switched to Release refuses the run",
-      [dict(VALID_ROW)], expect_exit=2, expect_text="no longer has",
-      extra_files={"scripts/xcode-test.sh": CANONICAL_STUB.replace(
-          'run_lane "$DEBUG_SCHEME" Debug', 'run_lane "$RELEASE_SCHEME" Release')})
-
-check("a canonical DerivedData default that moved refuses the run",
-      [dict(VALID_ROW)], expect_exit=2, expect_text="no longer has",
-      extra_files={"scripts/xcode-test.sh": CANONICAL_STUB.replace(
-          ".derivedData/Test", ".derivedData/Somewhere")})
-
-# #2178 moved generation into a sourced helper, so the toolchain pin is no longer in this script and
-# a bumped-pin case would test nothing. What matters now is the generation CALL itself: if the lane
-# stops generating, the battery would run against a stale project.
-check("a canonical lane that no longer generates the project refuses the run",
-      [dict(VALID_ROW)], expect_exit=2, expect_text="no longer has",
-      extra_files={"scripts/xcode-test.sh": CANONICAL_STUB.replace(
-          'ew_ensure_generated "$PROJECT_ROOT"', "# generation removed")})
-
-# Round 3 of the drift class, at the axis the round-2 enumeration missed: it enumerated WHICH INPUTS
-# decide the build, not HOW an argument can arrive. An argument reaching xcodebuild through a variable
-# used to be dropped, so indirection read as absence.
-# The call site was matched as a PREFIX, so trailing positionals — which reach xcodebuild through
-# `"$@"`, accepted by the expansion allowlist without its contents being visible — slipped past.
-check("extra positional build settings on the canonical call site refuse the run",
-      [dict(VALID_ROW)], expect_exit=2, expect_text="no longer has",
-      extra_files={"scripts/xcode-test.sh": CANONICAL_STUB.replace(
-          'run_lane "$DEBUG_SCHEME" Debug "$LOG_DIR/xcode-test-debug.log"',
-          'run_lane "$DEBUG_SCHEME" Debug "$LOG_DIR/xcode-test-debug.log" ENABLE_TESTABILITY=YES')})
-
-check("an unrecognised shell expansion in the invocation refuses the run",
-      [dict(VALID_ROW)], expect_exit=2, expect_text="cannot see",
-      extra_files={"scripts/xcode-test.sh": CANONICAL_STUB.replace(
-          '    "$@" ', '    "${EXTRA_ARGS[@]}" ')})
-
-# Fifth instance of the drift class, and answered as a BOUND rather than another enumerated axis: the
-# runner invokes xcodebuild with its ambient environment, so anything running BEFORE xcodebuild means
-# the canonical lane can use a different toolchain. Required to be empty; no prefix list to maintain.
-check("an environment prefix before xcodebuild refuses the run",
-      [dict(VALID_ROW)], expect_exit=2, expect_text="runs BEFORE xcodebuild",
-      extra_files={"scripts/xcode-test.sh": CANONICAL_STUB.replace(
-          "  xcodebuild test \\",
-          "  DEVELOPER_DIR=/other/Xcode.app/Contents/Developer xcodebuild test \\")})
-
 check("a missing canonical script refuses the run",
-      [dict(VALID_ROW)], expect_exit=2, expect_text="cannot confirm it is building the same thing",
+      [dict(VALID_ROW)], expect_exit=2, expect_text="regular executable file",
       remove=["scripts/xcode-test.sh"])
+
+check("a non-executable canonical script refuses the run",
+      [dict(VALID_ROW)], expect_exit=2, expect_text="regular executable file",
+      non_executable=["scripts/xcode-test.sh"])
 
 # A recipe arrives from an issue body, which is data someone else wrote. It may not reach out of
 # the worktree — an absolute path, a `..`, or a symlink would otherwise have the battery back up,
 # mutate and restore a file it was never scoped to.
-# `generate_once` reuses one generated project for every row, which is only sound while a mutation
-# changes file CONTENT rather than the project's SHAPE. A recipe targeting a Tuist input would leave
-# xcodebuild consuming the clean baseline's .xcodeproj, so the row reports SURVIVED about a mutant the
-# build never saw. A doc comment asserted this precondition from the start; nothing enforced it.
+# Project inputs are intentionally outside the production-code mutation scope.
 for _t in ("Project.swift", "Tuist/Config.swift", "Package.swift"):
     check(f"a recipe targeting {_t} is refused as out of scope",
           [dict(VALID_ROW, file=_t)],
@@ -360,20 +279,6 @@ with tempfile.TemporaryDirectory() as td:
         failures.append("an unreadable recipe file produced a traceback rather than a refusal")
     else:
         print("  ok  an unreadable recipe file refuses with exit 2, not a traceback")
-
-# The expansions were allowlisted but not REQUIRED and not tied to position, so a lane that DELETED
-# `"${TEST_ARGS[@]}"` (it would stop filtering and run everything) or SWAPPED scheme and config passed.
-# An argument list is defined by its order.
-check("a canonical lane that dropped the test filter refuses the run",
-      [dict(VALID_ROW)], expect_exit=2, expect_text="in order",
-      extra_files={"scripts/xcode-test.sh": CANONICAL_STUB.replace(
-          '    "${TEST_ARGS[@]}" | tee', '    | tee')})
-
-check("a canonical lane with scheme and config swapped refuses the run",
-      [dict(VALID_ROW)], expect_exit=2, expect_text="in order",
-      extra_files={"scripts/xcode-test.sh": CANONICAL_STUB
-                   .replace('-scheme "$scheme"', '-scheme "$config"')
-                   .replace('-configuration "$config"', '-configuration "$scheme"')})
 
 # --- flag-combination guard -----------------------------------------------------------------------
 ran += 1
@@ -959,25 +864,31 @@ ran += 1
 _seen_kwargs = {}
 
 
-def _capture(cmd, cwd, log_path=None, timeout=None):
+def _capture(cmd, cwd, log_path=None, timeout=None, env=None):
     _seen_kwargs["timeout"] = timeout
+    _seen_kwargs["env"] = env
+    _seen_kwargs["cmd"] = cmd
+    row_dir = Path(cmd[cmd.index("--log-dir") + 1])
+    row_dir.mkdir(parents=True, exist_ok=True)
+    (row_dir / "xcode-test-debug.log").write_text("Test run with 1 test\n")
     return 0, "Test run with 1 test\n"
 
 
 _real_run = battery.run
 battery.run = _capture
 try:
-    _lane = battery.Lane(Path("."), Path("."), Path("."))
-    _lane.generated = True  # skip tuist; this case is about the test lane's timeout only
-    try:
-        _lane.run_suite("EnviousWisprTests/Whatever", "tag")
-    except battery.BundleUnreadable:
-        # EXPECTED AND NOT WHAT IS UNDER TEST. `run` is stubbed, so no lane ran and
-        # no bundle exists; the assertion below is on the timeout kwarg `run_suite`
-        # passed, which has already happened by the time the read is attempted.
-        # Swallowing only this exception keeps the case honest — any other failure
-        # still surfaces.
-        pass
+    with tempfile.TemporaryDirectory() as td:
+        _root = Path(td)
+        _lane = battery.Lane(_root, _root / "derived", _root / "logs")
+        try:
+            _lane.run_suite("EnviousWisprTests/Whatever", "tag")
+        except battery.BundleUnreadable:
+            # EXPECTED AND NOT WHAT IS UNDER TEST. `run` is stubbed, so no lane ran and
+            # no bundle exists; the assertion below is on the timeout kwarg `run_suite`
+            # passed, which has already happened by the time the read is attempted.
+            # Swallowing only this exception keeps the case honest — any other failure
+            # still surfaces.
+            pass
 finally:
     battery.run = _real_run
 
@@ -1061,32 +972,16 @@ for _label, _rc, _out, _want in [
     else:
         print(f"  ok  {_label}")
 
-# The drift guard compares CANONICAL_TOKENS against scripts/xcode-test.sh. Nothing compared it against
-# the command this runner ACTUALLY issues — so reconciling the constant after an upstream change while
-# forgetting the command would leave the guard green and the battery building differently. That is the
-# guard's own failure mode, one level in.
+# The runner invokes the executable command and gives it the filtered suite, isolated log directory,
+# result-bundle path, and derived-data environment instead of owning a second xcodebuild argument list.
 ran += 1
-_cmd = battery.Lane(Path("/tmp"), Path("/tmp/dd"), Path("/tmp/logs")).build_command("T/S")
-_missing = sorted(t for t in battery.CANONICAL_TOKENS if t not in _cmd)
-if _missing:
-    failures.append("every CANONICAL_TOKEN appears in the command this runner actually issues — it "
-                    "does NOT: the command is missing " + ", ".join(_missing))
+_expected = {"--filter", "EnviousWisprTests/Whatever", "--log-dir", "--result-bundle-path"}
+if not _expected.issubset(set(_seen_kwargs.get("cmd", []))):
+    failures.append("the canonical entry receives the suite, isolated log directory, and result bundle")
+elif _seen_kwargs.get("env", {}).get("DERIVED_DATA_PATH") != str(_root / "derived"):
+    failures.append("the canonical entry receives the requested DERIVED_DATA_PATH")
 else:
-    print("  ok  every CANONICAL_TOKEN appears in the command this runner actually issues")
-
-ran += 1
-_flagish = {a for a in _cmd if a.startswith("-") and not a.startswith("-only-testing")
-            and a not in ("-project", "-scheme", "-configuration", "-derivedDataPath", "-destination")}
-_settings = {a for a in _cmd if "=" in a and a.split("=", 1)[0].isupper()}
-# RUNNER_ONLY_TOKENS is subtracted DELIBERATELY and is not a hole: each member
-# is declared at its definition with the reason it cannot change the build, so a
-# reviewer sees the divergence rather than inferring it from a green guard.
-_extra = sorted((_flagish | _settings) - battery.CANONICAL_TOKENS - battery.RUNNER_ONLY_TOKENS)
-if _extra:
-    failures.append("the runner's command carries no setting the drift guard is blind to — it DOES: "
-                    + ", ".join(_extra) + " would move unnoticed")
-else:
-    print("  ok  the runner's command carries no setting the drift guard is blind to")
+    print("  ok  the canonical entry receives the isolated lane arguments")
 
 # The canonical lane honours DERIVED_DATA_PATH (xcode-test.sh:19) and the drift guard only compares
 # that assignment's TEXT — so a battery ignoring the override would run against the shared warm cache
@@ -1151,8 +1046,8 @@ for _label, _will_run, _want_refusal in [
     _real_run3 = battery.run
     # Report a live dev app whatever is asked, so the only variable is whether preflight consults it.
     battery.run = lambda cmd, cwd, log_path=None, timeout=None: (0, "43962\n")
-    _real_canon = battery.check_canonical_settings
-    battery.check_canonical_settings = lambda wt: None
+    _real_canon = battery.check_canonical_entrypoint
+    battery.check_canonical_entrypoint = lambda wt: None
     # The suite neutralises check_no_dev_app globally (line ~347) so unrelated cases do not depend on
     # what else is running on the box. This case is ABOUT that check, so put the real one back.
     _neutralised = battery.check_no_dev_app
@@ -1167,7 +1062,7 @@ for _label, _will_run, _want_refusal in [
                 _got = "A dev app is running" in str(exc)
     finally:
         battery.run = _real_run3
-        battery.check_canonical_settings = _real_canon
+        battery.check_canonical_entrypoint = _real_canon
         battery.check_no_dev_app = _neutralised
     if _got != _want_refusal:
         failures.append(f"{_label}: refused={_got}, wanted {_want_refusal}")
@@ -1271,6 +1166,36 @@ finally:
         _probe.parent.rmdir()
     except OSError:
         pass
+
+# The canonical script owns its SwiftPM seed locks. A timeout must ask it to run its TERM/EXIT cleanup
+# before falling back to SIGKILL, or another worktree silently loses the shared seed for the rest of the
+# session. Drive both branches without sending a signal to this test process.
+for _label, _waits, _want in [
+    ("a cooperative canonical lane gets TERM and its cleanup window", [], [battery.signal.SIGTERM]),
+    ("an uncooperative canonical lane gets SIGKILL only after TERM", [battery.subprocess.TimeoutExpired("x", 1)],
+     [battery.signal.SIGTERM, battery.signal.SIGKILL]),
+]:
+    ran += 1
+    _signals = []
+
+    class _GracefulProc:
+        def wait(self, timeout=None):
+            if _waits:
+                raise _waits.pop(0)
+
+    _old_pgid, _old_proc = battery._ACTIVE_LANE_PGID, battery._ACTIVE_LANE_PROC
+    _old_killpg = battery.os.killpg
+    battery._ACTIVE_LANE_PGID, battery._ACTIVE_LANE_PROC = 4242, _GracefulProc()
+    battery.os.killpg = lambda pgid, sig: _signals.append(sig)
+    try:
+        _reaped_now = battery._reap_active_lane()
+    finally:
+        battery.os.killpg = _old_killpg
+        battery._ACTIVE_LANE_PGID, battery._ACTIVE_LANE_PROC = _old_pgid, _old_proc
+    if not _reaped_now or _signals != _want:
+        failures.append(f"{_label}: signals={_signals}, wanted={_want}")
+    else:
+        print(f"  ok  {_label}")
 
 # EVERY exit path must reap the lane, not just the timeout. Cancellation mid-lane used to restore the
 # file and leave xcodebuild's group running — the file looks recovered while an orphan keeps writing
@@ -1747,32 +1672,6 @@ if battery.failed_test_identities([_q]) != {'founder repro: "Other apps." (2 wor
 else:
     print("  ok  both identity readers agree on a quoted name")
 
-# Generation is bounded too. Bounding the TEST call and not the setup before it leaves an unattended
-# run able to park all night one step earlier — the exact failure the lane timeout exists to prevent.
-ran += 1
-_real_run4 = battery.run
-_seen_timeouts = []
-
-
-def _record_timeout(cmd, cwd, log_path=None, timeout=None):
-    _seen_timeouts.append((cmd[0] if cmd else "", timeout))
-    return 0, ""
-
-
-battery.run = _record_timeout
-try:
-    _lane = battery.Lane(Path(tempfile.gettempdir()), Path(tempfile.gettempdir()),
-                         Path(tempfile.mkdtemp()))
-    _lane.generate_once()
-finally:
-    battery.run = _real_run4
-
-if not _seen_timeouts or _seen_timeouts[0][1] is None:
-    failures.append("project generation is bounded by a timeout — it is NOT: "
-                    f"{_seen_timeouts}")
-else:
-    print("  ok  project generation is bounded by a timeout")
-
 # A timeout must APPEND to the lane log, not overwrite it. Overwriting throws away the record of which
 # operation hung, on the one path where that record is the whole point.
 ran += 1
@@ -1818,46 +1717,6 @@ elif "timed out after" not in _body:
 else:
     print("  ok  a timeout appends to the lane log rather than overwriting it")
 
-# The canonical lane consumes the SwiftPM seed and resolves with a fallback that discards a damaged
-# SourcePackages (xcode-test.sh:85-96). Skipping it makes the opening baseline fail against package
-# state the canonical command recovers from — an overnight run producing nothing until someone clears
-# DerivedData by hand.
-ran += 1
-_calls = []
-_real_run5 = battery.run
-
-
-def _capture_prep(cmd, cwd, log_path=None, timeout=None):
-    _calls.append(" ".join(str(c) for c in cmd))
-    return 0, ""
-
-
-battery.run = _capture_prep
-try:
-    _l = battery.Lane(Path(tempfile.gettempdir()), Path("/tmp/dd"), Path(tempfile.mkdtemp()))
-    _l.generate_once()
-finally:
-    battery.run = _real_run5
-
-_joined = " || ".join(_calls)
-if "ew_seed_consume" not in _joined or "ew_seed_resolve_or_unseed" not in _joined:
-    failures.append("the canonical package preparation runs before the first suite — it does NOT: "
-                    f"{_calls}")
-elif _calls and "ensure_generated" in _calls[0] and "seed" not in _calls[0]:
-    print("  ok  the canonical package preparation runs before the first suite")
-else:
-    failures.append("the canonical package preparation runs before the first suite — but not AFTER "
-                    f"generation, which is the order the canonical lane uses: {_calls}")
-
-# It must call THEIR helpers, not a reimplementation: this runner already carries one duplicated
-# invocation plus a guard to police it, and #2165 exists to delete both.
-ran += 1
-if "scripts/lib/spm-seed.sh" not in _joined:
-    failures.append("package preparation sources the canonical helper rather than reimplementing it — "
-                    "it does NOT")
-else:
-    print("  ok  package preparation sources the canonical helper rather than reimplementing it")
-
 # `pgrep` exits 0 for a match, 1 for NO MATCH, and 2+ when the probe itself failed. Folding that third
 # answer into "none running" is fail-OPEN on a guard whose whole job is to stop a corrupted log scoring
 # as a mutant CAUGHT — the battery would proceed believing the machine is clear when it does not know.
@@ -1885,33 +1744,6 @@ for _label, _rc, _want_refusal in [
         failures.append(f"{_label}: refused={_got}, wanted {_want_refusal}")
     else:
         print(f"  ok  {_label}")
-
-# Every bounded call converts its timeout into a controlled error. The generation call did; the package
-# preparation added in the same commit did not, so it propagated raw.
-ran += 1
-_real_prep = battery.Lane._run_package_prep
-
-
-def _prep_timeout(self):
-    raise battery.subprocess.TimeoutExpired("prep", 1)
-
-
-battery.Lane._run_package_prep = _prep_timeout
-_real_run7 = battery.run
-battery.run = lambda cmd, cwd, log_path=None, timeout=None: (0, "")
-try:
-    _l2 = battery.Lane(Path(tempfile.gettempdir()), Path("/tmp/dd"), Path(tempfile.mkdtemp()))
-    try:
-        _l2.generate_once()
-        failures.append("a package-preparation timeout becomes a lane error — it did not raise at all")
-    except battery._LaneTimedOut:
-        print("  ok  a package-preparation timeout becomes a lane error")
-    except battery.subprocess.TimeoutExpired:
-        failures.append("a package-preparation timeout becomes a lane error — it propagated RAW, so "
-                        "the row loop cannot turn it into a controlled ERROR")
-finally:
-    battery.Lane._run_package_prep = _real_prep
-    battery.run = _real_run7
 
 # --- the operator-facing summary ------------------------------------------------
 # Nothing rendered this block before: it was declared inside `main()`, after a full
@@ -2054,6 +1886,17 @@ if not _probs4 or "timed out" not in _probs4[0]:
 else:
     print("  ok  a lane timeout is still a baseline problem")
 
+# A canonical setup failure creates no fresh Debug log. That is neither a passing
+# baseline nor a row verdict, but it must fail cleanly at the baseline boundary.
+ran += 1
+_probs5 = battery.baseline(
+    _RaisingLane(battery._RowFailed("the canonical Debug log was not created by this lane")),
+    ["EnviousWisprTests/Setup"], "before")
+if not _probs5 or "canonical Debug log" not in _probs5[0]:
+    failures.append(f"a canonical setup failure is a baseline problem — got {_probs5}")
+else:
+    print("  ok  a canonical setup failure becomes a baseline problem")
+
 # UNREACHABLE IN PRODUCTION, PINNED ANYWAY. A lane that compiles and passes but yields
 # no result bundle cannot happen as the callers stand: that branch requires `compiled`,
 # and `run_suite` returns a SuiteResults whenever it compiled because the reader raises
@@ -2081,6 +1924,27 @@ elif _seen_nr:
                     f"{_seen_nr}")
 else:
     print("  ok  a compiled lane with no result bundle refuses rather than scraping the console")
+
+# A second process must stop at the lock before it can mistake an in-flight backup for stale leftovers.
+ran += 1
+with tempfile.TemporaryDirectory() as td:
+    tmp = make_tree(Path(td))
+    recipes = tmp / "r.json"
+    recipes.write_text(json.dumps({"rows": [dict(VALID_ROW)]}))
+    battery.acquire_battery_lock(tmp)
+    try:
+        proc = subprocess.run(
+            [sys.executable, str(BATTERY), "--recipes", str(recipes), "--worktree", str(tmp), "--dry-run"],
+            capture_output=True, text=True, env=NEUTRAL_ENV,
+        )
+    finally:
+        battery.release_battery_lock()
+    out = proc.stdout + proc.stderr
+    if proc.returncode != 2 or "already owns" not in out:
+        failures.append("a concurrent battery refuses at the lock before preflight — it did not: "
+                        + out.strip()[:250])
+    else:
+        print("  ok  a concurrent battery refuses at the worktree lock")
 
 # --- a documented return shape must match the code ------------------------------
 # `_STUB_ARITY` above pins run_suite's arity and says to update the stubs and the

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -81,6 +81,8 @@ EXIT CODES
 
 import argparse
 import filecmp
+import fcntl
+import functools
 import json
 import os
 import re
@@ -133,89 +135,7 @@ SUITE_VERDICT_RE = re.compile(r'^✘\s+Suite\s')
 COMPILE_ERROR_RE = re.compile(r"^.*?: error: ", re.MULTILINE)
 
 
-# The canonical logic-test entry point is scripts/xcode-test.sh (tools-and-apps.md
-# RULE: xcode-test-entrypoint). This runner deliberately does NOT shell out to it, for two reasons:
-# that script tees to a FIXED log path and SUMS every "Test run with N test" line it finds, so two
-# lanes writing it produce an inflated count; and it runs `tuist generate` unconditionally, 6.7s of
-# byte-identical output per row. Both are correct for a one-shot run and wrong for a battery.
-#
-# The cost of that deviation is TWO SOURCES OF TRUTH for the build settings, so it is paid for with a
-# fail-closed drift guard: if the canonical script's settings stop matching the ones below, the battery
-# REFUSES rather than quietly measuring a differently-configured build. Reconcile deliberately; do not
-# silence it.
 CANONICAL_SCRIPT = "scripts/xcode-test.sh"
-# The exact token set of the canonical `xcodebuild test` invocation, compared BOTH WAYS. A
-# presence-only check is one-directional and therefore blind in the direction that matters most: if the
-# canonical lane GAINS a build setting, an environment wrapper, or a flag, every fragment it already had
-# is still there, the guard stays green, and the battery quietly measures a differently-configured build
-# than the lane everyone else trusts. Cloud review, PR #2158.
-# FLAGS THIS RUNNER PASSES THAT THE CANONICAL LANE DOES NOT.
-#
-# The drift guard is deliberately two-directional: a battery quietly building
-# something different from the lane everyone trusts is its whole subject. So a
-# flag the runner adds cannot simply be absent from the comparison — it has to
-# be DECLARED, with the reason it is safe, where a reviewer will see it.
-#
-# `-resultBundlePath` qualifies because it changes only what is WRITTEN, never
-# what is built or run: `xcodebuild test` emits an `.xcresult` on every run
-# regardless, and the flag only chooses where. Measured at 4.5s/4.5s with it
-# against 4.6s/4.6s without, 208K per bundle on a 35-test suite.
-#
-# Anything that could alter the BUILD belongs in CANONICAL_TOKENS and in the
-# canonical script, not here. This set is not a general escape hatch.
-RUNNER_ONLY_TOKENS = {"-resultBundlePath"}
-
-CANONICAL_TOKENS = {
-    "-project", "-scheme", "-configuration", "-derivedDataPath", "-destination",
-    "ARCHS=arm64", "VALID_ARCHS=arm64", "ONLY_ACTIVE_ARCH=YES",
-    "-onlyUsePackageVersionsFromResolvedFile",
-}
-# Values that are shell expansions in the invocation and literals here, so they cannot be compared as
-# tokens. Two review rounds each found ONE more of these, so rather than wait for a third the axes were
-# enumerated exhaustively: every input that decides WHAT gets built and WHERE. Each line below is a
-# literal that must appear in the canonical script verbatim.
-#
-#   what project      -> PROJECT
-#   what scheme       -> DEBUG_SCHEME, and the CALL SITE that passes it (a scheme can be right while the
-#                        call passes the other one)
-#   what config       -> the call site again; `Lane.run_suite` hardcodes Debug, so a call site changed to
-#                        Release diverges while `run_lane` itself is untouched
-#   where it lands    -> DERIVED_DATA's default, which this runner reproduces as .derivedData/Test
-#   what destination  -> DEST
-#   how it filters    -> TEST_ARGS
-#   what generates it -> the pinned tuist version, which this runner invokes directly
-CANONICAL_ASSIGNMENTS = [
-    'PROJECT="EnviousWispr.xcodeproj"',
-    'DEBUG_SCHEME="EnviousWispr"',
-    "DEST='platform=macOS,arch=arm64'",
-    'TEST_ARGS=(-only-testing:"$FILTER")',
-    'DERIVED_DATA="${DERIVED_DATA_PATH:-$PROJECT_ROOT/.derivedData/Test}"',
-    # The WHOLE line, not a prefix: `run_lane "$DEBUG_SCHEME" Debug build/... ENABLE_TESTABILITY=YES`
-    # still starts with the prefix, and those trailing positionals reach xcodebuild through `"$@"`,
-    # which the expansion allowlist accepts by name without seeing its contents.
-    'run_lane "$DEBUG_SCHEME" Debug "$LOG_DIR/xcode-test-debug.log"\n',
-    'ew_ensure_generated "$PROJECT_ROOT"',
-]
-# Expansions the runner knows the contents of, because CANONICAL_ASSIGNMENTS pins each one. An
-# expansion NOT in this set hides arguments the runner cannot see, so it is a refusal rather than a
-# token to skip — the difference between "I checked and it matches" and "I could not look".
-# The expansions the canonical invocation must pass, IN ORDER. A set membership test accepted a lane
-# that had DELETED `"${TEST_ARGS[@]}"` — it would stop filtering to one suite and run everything — and
-# accepted `"$scheme"` and `"$config"` swapped, which builds a different configuration. An argument
-# list is defined by its order, so the comparison has to be ordered too. Cloud review, PR #2158.
-CANONICAL_EXPANSION_SEQUENCE = [
-    '"$PROJECT"', '"$scheme"', '"$config"', '"$DERIVED_DATA"', '"$DEST"', '"$@"', '"${TEST_ARGS[@]}"',
-]
-CANONICAL_EXPANSIONS = {
-    '"$PROJECT"', '"$scheme"', '"$config"', '"$DERIVED_DATA"', '"$DEST"',
-    '"$@"', '"${TEST_ARGS[@]}"',
-}
-INVOCATION_RE = re.compile(r"xcodebuild test\s*\\\n(.*?)\|\s*tee", re.DOTALL)
-# Whatever sits between the start of the line and `xcodebuild` — an env prefix, a wrapper, a different
-# toolchain via DEVELOPER_DIR. Required to be EMPTY rather than enumerated: the runner invokes
-# xcodebuild with its ambient environment, so any prefix means the canonical lane and the battery build
-# differently, and there is no list of prefixes worth maintaining.
-INVOCATION_PREFIX_RE = re.compile(r"^([^\n]*?)xcodebuild test\s*\\", re.MULTILINE)
 # WHAT A RECIPE MAY MUTATE — an ALLOW-list, deliberately, and the second attempt at this.
 #
 # Review round 6 found a recipe could target a Tuist input; the fix denied those by name. Round 7 then
@@ -230,30 +150,42 @@ INVOCATION_PREFIX_RE = re.compile(r"^([^\n]*?)xcodebuild test\s*\\", re.MULTILIN
 #                  only that breaking a test breaks it, while the report claims a PRODUCTION mutation
 #                  was detected — a false CAUGHT, the exact vacuity this tool exists to prevent.
 #   Project.swift, Workspace.swift, Tuist.swift, Package.swift, Tuist/**
-#                  the project is generated FROM these and `generate_once` reuses one project for every
-#                  row, so xcodebuild keeps consuming the baseline's `.xcodeproj` and the row reports
-#                  SURVIVED about a mutant the build never saw.
+#                  changing project inputs is outside a production-code mutation's scope; the canonical
+#                  test command owns generation and project configuration.
 #   scripts/**     including this runner: a battery mutating its own harness reports on itself.
 #   workers/**, website/**
 #                  real code, but nothing an `xcodebuild test` lane executes, so every row reports
 #                  SURVIVED regardless of the test's quality.
 MUTABLE_ROOTS = ("Sources/",)
-# One definition, so the drift guard above and the call below cannot disagree about the version.
-# #2178 moved generation into `scripts/lib/ensure-generated.sh`, which skips `tuist generate` unless an
-# input hash changed (6.7s -> 0.06s, project.pbxproj byte-identical). Invoked through the script's own
-# helper rather than reproducing the pin, so the version lives in exactly one place — the duplication
-# this runner is stuck with is the INVOCATION, and it should not grow a second copy of the toolchain
-# pin as well.
-TUIST_GENERATE_ARGV = ["bash", "-c",
-                       'source scripts/lib/ensure-generated.sh && ew_ensure_generated "$PWD"']
-
-
 # A row's restore lives in a `finally`, and Python's DEFAULT action for SIGTERM does not run it: the
 # process dies where it stands, leaving the production file MUTATED and a .mutbak beside it. That is the
 # worst state this tool can leave behind, and an overnight battery is exactly the thing someone cancels
 # — a terminal closing, a session ending, a job being killed. So the restore is also registered here,
 # outside the try/finally, and runs from the signal handler.
 _ACTIVE_RESTORES = {}
+
+
+def _prune_empty_backup_parents(backup: Path, worktree: Path):
+    """Remove only empty backup directories after a verified restore."""
+    root = worktree / "build" / "mutation-battery" / "backups"
+    parent = backup.parent
+    while parent != root:
+        try:
+            parent.rmdir()
+        except OSError:
+            return
+        parent = parent.parent
+    try:
+        root.rmdir()
+    except OSError:
+        pass
+
+
+def backup_path(worktree: Path, tag: str, target: Path) -> Path:
+    """Keep backups outside Sources/ so a mutation cannot change project inputs."""
+    relative_target = target.resolve().relative_to(worktree.resolve())
+    return (worktree / "build" / "mutation-battery" / "backups" / tag
+            / relative_target.with_suffix(relative_target.suffix + ".mutbak"))
 
 
 def _restore_active(reason: str):
@@ -334,9 +266,6 @@ class _RowFailed(Exception):
 # so it leaves a MUTATED TREE behind. The bound is generous: it exists to convert a hang into a row
 # ERROR, not to police a slow suite (validation-discipline.md `hang-guard-vs-latency-bound`).
 LANE_TIMEOUT_SECONDS = 1800
-# Generation is bounded too. It is fast on a warm tree (0.06s when the input hash is unchanged,
-# ~7s cold), so a generous bound still catches a genuine stall without ever firing in normal use.
-GENERATE_TIMEOUT_SECONDS = int(os.environ.get("EW_BATTERY_GENERATE_TIMEOUT", "600"))
 
 
 # The process group of the lane currently running, or None. Registered before the lane starts and
@@ -347,22 +276,38 @@ GENERATE_TIMEOUT_SECONDS = int(os.environ.get("EW_BATTERY_GENERATE_TIMEOUT", "60
 _HANDLED_SIGNALS = (signal.SIGTERM, signal.SIGINT, signal.SIGHUP, signal.SIGQUIT)
 
 _ACTIVE_LANE_PGID = None
+_ACTIVE_LANE_PROC = None
+GRACEFUL_TERMINATION_SECONDS = 10
 
 
 def _reap_active_lane():
-    """Kill the live lane's process group if there is one. Safe to call more than once."""
-    global _ACTIVE_LANE_PGID
-    pgid, _ACTIVE_LANE_PGID = _ACTIVE_LANE_PGID, None
+    """Ask the live canonical lane to exit, then force-kill only if it ignores the request."""
+    global _ACTIVE_LANE_PGID, _ACTIVE_LANE_PROC
+    pgid, proc = _ACTIVE_LANE_PGID, _ACTIVE_LANE_PROC
+    _ACTIVE_LANE_PGID = None
+    _ACTIVE_LANE_PROC = None
     if pgid is None:
         return False
     try:
-        os.killpg(pgid, signal.SIGKILL)
-        return True
+        # xcode-test.sh translates TERM into a normal exit, which runs its EXIT trap and releases any
+        # SwiftPM seed lock. SIGKILL here skips that cleanup and strands every other worktree on a
+        # cache miss, so it is a bounded fallback only.
+        os.killpg(pgid, signal.SIGTERM)
     except (ProcessLookupError, PermissionError):
         return False
+    if proc is None:
+        return True
+    try:
+        proc.wait(timeout=GRACEFUL_TERMINATION_SECONDS)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(pgid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            pass
+    return True
 
 
-def run(cmd, cwd, log_path=None, timeout=None):
+def run(cmd, cwd, log_path=None, timeout=None, env=None):
     """Run a command, optionally teeing to a per-row log. Never the shared fixed log path.
 
     On timeout this kills the whole PROCESS GROUP, not just the direct child. `xcodebuild` spawns the
@@ -371,7 +316,7 @@ def run(cmd, cwd, log_path=None, timeout=None):
     their verdicts long after the source has been restored. The battery would look like it recovered.
     Cloud review, PR #2158.
     """
-    global _ACTIVE_LANE_PGID
+    global _ACTIVE_LANE_PGID, _ACTIVE_LANE_PROC
     # BLOCK the handled signals across spawn-and-register. `Popen` creates the child in its own session
     # BEFORE the pgid is stored, so a signal landing in that window sees `_ACTIVE_LANE_PGID` as None,
     # re-raises, and leaves an isolated tuist/xcodebuild group running after the battery exits. The
@@ -382,7 +327,9 @@ def run(cmd, cwd, log_path=None, timeout=None):
         proc = subprocess.Popen(
             cmd, cwd=str(cwd), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
             start_new_session=True,   # its own process group, so the kills below reach descendants
+            env=env,
         )
+        _ACTIVE_LANE_PROC = proc
         try:
             _ACTIVE_LANE_PGID = os.getpgid(proc.pid)
         except ProcessLookupError:
@@ -394,9 +341,8 @@ def run(cmd, cwd, log_path=None, timeout=None):
         out, _ = proc.communicate(timeout=timeout)
         rc = proc.returncode
     except subprocess.TimeoutExpired:
-        # Kill the GROUP, then re-raise. The raise is the existing contract — the row loop turns it into
-        # a row ERROR with a timeout-specific message — and changing it here would have quietly widened
-        # a bug fix into a behaviour change. Only the cleanup was wrong.
+        # End the GROUP, then re-raise. The canonical script gets a bounded TERM window to release its
+        # seed lock before the fallback kill, while the row keeps the existing timeout-as-ERROR contract.
         if not _reap_active_lane():
             proc.kill()
         try:
@@ -408,10 +354,11 @@ def run(cmd, cwd, log_path=None, timeout=None):
             # only record of which build or test operation hung — on the one path where it matters.
             with open(log_path, "a") as fh:
                 fh.write((out or "")
-                         + f"\n[mutation-battery] timed out after {timeout}s; group killed\n")
+                         + f"\n[mutation-battery] timed out after {timeout}s; group terminated\n")
         raise
     finally:
         _ACTIVE_LANE_PGID = None
+        _ACTIVE_LANE_PROC = None
     if log_path is not None:
         Path(log_path).write_text(out or "")
     return rc, out or ""
@@ -743,111 +690,29 @@ def classify_row(baseline: "SuiteResults", mutated: "SuiteResults", expect_fail:
 
 
 class Lane:
-    """One filtered Debug test run against warm DerivedData."""
+    """One filtered Debug test run through the canonical test entry point."""
 
     def __init__(self, worktree: Path, derived_data: Path, log_dir: Path):
         self.worktree = worktree
         self.derived_data = derived_data
         self.log_dir = log_dir
         self.log_dir.mkdir(parents=True, exist_ok=True)
-        self.generated = False
-
-    def generate_once(self):
-        """`tuist generate` output is byte-identical on a warm tree (measured 6.7s, M5 Max) so it is
-        pure per-row overhead. Generate once.
-
-        Safe ONLY because a mutation changes file CONTENT and never the project's SHAPE. That is a real
-        precondition, not a remark, and `MUTABLE_ROOTS` above is what enforces it: recipes may only
-        target production Swift under Sources/, so the files the project is generated FROM are
-        unreachable by construction rather than by a list someone must remember to extend."""
-        if self.generated:
-            return
-        try:
-            rc, out = run(
-                TUIST_GENERATE_ARGV,
-                cwd=self.worktree,
-                log_path=self.log_dir / "tuist-generate.log",
-                timeout=GENERATE_TIMEOUT_SECONDS,
-            )
-        except subprocess.TimeoutExpired:
-            raise _LaneTimedOut(
-                f"project generation did not finish within {GENERATE_TIMEOUT_SECONDS}s. The lane "
-                "timeout bounds the TEST call; this bounds the setup before it, so an unattended run "
-                "cannot park overnight in either. Its process group was killed; see "
-                f"{self.log_dir / 'tuist-generate.log'}"
-            )
-        if rc != 0:
-            raise Refusal(f"tuist generate failed (rc={rc}); see {self.log_dir/'tuist-generate.log'}")
-        self.generated = True
-        self._prepare_packages()
-
-    def _prepare_packages(self):
-        """Run the canonical lane's package preparation, once, before the first suite.
-
-        `xcode-test.sh:85-96` consumes the SwiftPM seed and then RESOLVES with a fallback that discards
-        a damaged `SourcePackages` and retries unseeded. Skipping it means a seed left by an interrupted
-        run — or one carrying another worktree's absolute paths (#2179) — fails the opening baseline
-        against package state the canonical command recovers from. An overnight battery then produces no
-        results at all until someone clears DerivedData by hand, which is the same wasted night the lane
-        timeout exists to prevent.
-
-        Calls the SAME helpers rather than reproducing them: this runner already carries one duplicated
-        invocation and a guard to police it, and #2165 exists to delete both. Sourcing their library
-        adds no second copy to reconcile.
-        """
-        try:
-            rc, out = self._run_package_prep()
-        except subprocess.TimeoutExpired:
-            raise _LaneTimedOut(
-                f"package preparation did not finish within {GENERATE_TIMEOUT_SECONDS}s. Its process "
-                f"group was killed; see {self.log_dir / 'package-prep.log'}"
-            )
-        if rc != 0:
-            # Not fatal: the canonical fallback already degrades a damaged clone to a slow unseeded
-            # resolve. If even that failed, the baseline is about to say so with a real build error,
-            # which is a better message than anything guessed here.
-            print(f"    note: package preparation exited {rc}; the baseline will report the real "
-                  f"failure if it matters ({self.log_dir / 'package-prep.log'})")
-
-    def _run_package_prep(self):
-        return run(
-            ["bash", "-c",
-             'set -e; source scripts/lib/spm-seed.sh; '
-             'ew_seed_consume "$PWD" "$1"; '
-             'ew_seed_resolve_or_unseed "$1" '
-             '  xcodebuild -resolvePackageDependencies -project EnviousWispr.xcodeproj '
-             '  -scheme EnviousWispr -derivedDataPath "$1"',
-             "_", str(self.derived_data)],
-            cwd=self.worktree,
-            log_path=self.log_dir / "package-prep.log",
-            timeout=GENERATE_TIMEOUT_SECONDS,
-        )
 
     def bundle_path(self, tag: str) -> Path:
-        """Where this row's result bundle lands. `xcodebuild` REFUSES to overwrite an existing
-        bundle, so a re-run of the same tag must start from a clean path."""
-        return self.log_dir / f"{tag}.xcresult"
+        return self.log_dir / tag / "result.xcresult"
 
-    def build_command(self, suite: str, tag: str = "lane"):
-        """The invocation this runner issues. Extracted so the self-test can assert it agrees with
-        CANONICAL_TOKENS — the drift guard compares that constant against the SCRIPT, and nothing
-        compared it against the command actually run, so the two could silently disagree."""
-        return [
-            "xcodebuild", "test",
-            "-project", "EnviousWispr.xcodeproj",
-            "-scheme", "EnviousWispr",
-            "-configuration", "Debug",
-            "-derivedDataPath", str(self.derived_data),
-            "-destination", "platform=macOS,arch=arm64",
-            "-onlyUsePackageVersionsFromResolvedFile",
-            "ARCHS=arm64", "VALID_ARCHS=arm64", "ONLY_ACTIVE_ARCH=YES",
-            # OUR OWN PATH, never the default under `<derivedData>/Logs/Test/`.
-            # That directory accumulates one bundle per run and is shared, so
-            # "newest wins" there carries the same concurrent-writer hazard this
-            # repo already documents for the fixed log path.
-            "-resultBundlePath", str(self.bundle_path(tag)),
-            f"-only-testing:{suite}",
-        ]
+    def debug_log_path(self, tag: str) -> Path:
+        return self.log_dir / tag / "xcode-test-debug.log"
+
+    @staticmethod
+    def _remove_previous(path: Path, label: str):
+        if path.is_dir() and not path.is_symlink():
+            shutil.rmtree(path)
+        else:
+            path.unlink(missing_ok=True)
+        if path.exists() or path.is_symlink():
+            raise _RowFailed(f"the previous {label} at {path} could not be removed. Remove it by hand "
+                             "before re-running; a row must never read another row's receipt.")
 
     def run_suite(self, suite: str, tag: str):
         """-> (count, failures, compiled, log_path, rc, elapsed, results).
@@ -856,37 +721,30 @@ class Lane:
         lane did not compile and so wrote no bundle. Every VERDICT comes from `results`; `count` and
         `compiled` answer only whether the lane reached the test phase at all.
         """
-        self.generate_once()
-        log_path = self.log_dir / f"{tag}.log"
+        row_dir = self.log_dir / tag
+        row_dir.mkdir(parents=True, exist_ok=True)
+        log_path = self.debug_log_path(tag)
         bundle = self.bundle_path(tag)
-        # `xcodebuild` refuses to write into an existing bundle path, and a row
-        # that silently reused a previous row's bundle would grade this mutation
-        # against the LAST one's results — a wrong subject, which is the defect
-        # class this whole change removes.
-        #
-        # SO THE REMOVAL IS PROVEN, NOT ATTEMPTED. `ignore_errors=True` was here
-        # and permitted exactly what the paragraph above forbids: a bundle that
-        # cannot be deleted stays, xcodebuild declines to overwrite it, and the
-        # read returns the PREVIOUS row's results wearing this row's name. A
-        # comment asserting a mechanism the code does not enforce — in the tool
-        # built to catch that.
-        if bundle.exists():
-            shutil.rmtree(bundle, ignore_errors=True)
-        if bundle.exists():
-            raise _RowFailed(
-                f"the previous result bundle at {bundle} could not be removed, so xcodebuild would "
-                f"refuse to overwrite it and this row would be graded against the LAST row's "
-                f"results. Remove it by hand and re-run.")
-        cmd = self.build_command(suite, tag)
+        self._remove_previous(log_path, "canonical Debug log")
+        self._remove_previous(bundle, "result bundle")
+        command_log = row_dir / "invocation.log"
+        self._remove_previous(command_log, "invocation log")
+        cmd = [
+            str(self.worktree / CANONICAL_SCRIPT),
+            "--filter", suite,
+            "--log-dir", str(row_dir),
+            "--result-bundle-path", str(bundle),
+        ]
+        child_env = dict(os.environ, DERIVED_DATA_PATH=str(self.derived_data))
         started = time.monotonic()
         # `monotonic` cannot be compared against a file mtime; a wall clock can.
         started_wall = time.time()
         try:
-            rc, out = run(cmd, cwd=self.worktree, log_path=log_path,
-                          timeout=LANE_TIMEOUT_SECONDS)
+            rc, out = run(cmd, cwd=self.worktree, log_path=command_log,
+                          timeout=LANE_TIMEOUT_SECONDS, env=child_env)
         except subprocess.TimeoutExpired:
             elapsed = time.monotonic() - started
-            Path(log_path).write_text(
+            Path(command_log).write_text(
                 f"lane exceeded {LANE_TIMEOUT_SECONDS}s and was killed after {elapsed:.0f}s\n")
             raise _LaneTimedOut(
                 f"the lane ran past {LANE_TIMEOUT_SECONDS}s and was killed. A mutation that removes a "
@@ -894,19 +752,16 @@ class Lane:
                 f"catch ({log_path})")
         elapsed = time.monotonic() - started
 
+        if not log_path.exists() or log_path.stat().st_mtime < started_wall:
+            raise _RowFailed(
+                f"the canonical Debug log was not created by this lane ({log_path}). The script failed "
+                f"during setup, before there is a test receipt to grade; see {command_log}.")
+
         count, failures = classify_lane_output(out)
         # A red lane with compiler diagnostics and no test summary never ran the tests.
         compiled = not (count is None and COMPILE_ERROR_RE.search(out) is not None)
-        # THE CONSOLE IS STILL PARSED, FOR EXACTLY ONE THING IT CAN ANSWER AND THE
-        # BUNDLE CANNOT: whether the lane REACHED the test phase. A compile failure
-        # writes no bundle, so `compiled` has to come from the diagnostics. Every
-        # VERDICT below comes from the bundle; this is not a fallback.
         results = None
         if compiled:
-            # A bundle predating this lane is the wrong subject, so require one
-            # created after the run began. The removal above should make this
-            # unreachable; it is checked anyway because "should be unreachable"
-            # is what the previous version's comment said too.
             if bundle.exists() and bundle.stat().st_mtime < started_wall:
                 raise _RowFailed(
                     f"the result bundle at {bundle} predates this lane, so it belongs to an earlier "
@@ -915,72 +770,13 @@ class Lane:
         return count, failures, compiled, log_path, rc, elapsed, results
 
 
-def check_canonical_settings(worktree: Path):
-    """Fail closed if scripts/xcode-test.sh has drifted from the flags this runner reproduces."""
+def check_canonical_entrypoint(worktree: Path):
+    """The battery cannot grade a lane unless the canonical entry point is runnable."""
     canonical = worktree / CANONICAL_SCRIPT
-    if not canonical.is_file():
+    if canonical.is_symlink() or not canonical.is_file() or not os.access(canonical, os.X_OK):
         raise Refusal(
-            f"{CANONICAL_SCRIPT} is missing. This runner reproduces its build settings, so it cannot "
-            "confirm it is building the same thing the canonical entry point builds."
-        )
-    text = canonical.read_text()
-
-    missing_assignments = [frag for frag in CANONICAL_ASSIGNMENTS if frag not in text]
-
-    match = INVOCATION_RE.search(text)
-    if not match:
-        raise Refusal(
-            f"could not find the `xcodebuild test ... | tee` invocation in {CANONICAL_SCRIPT}. The "
-            "runner reproduces that command, so it cannot confirm it still matches. Fail closed."
-        )
-    # Literal flags and build settings are compared as tokens, both ways. Shell EXPANSIONS cannot be
-    # compared that way, so they are allowlisted instead: each one in CANONICAL_EXPANSIONS has its
-    # contents pinned by CANONICAL_ASSIGNMENTS above, and an expansion outside that set hides arguments
-    # this runner cannot see. Silently dropping them was the round-3 defect — indirection read as
-    # absence.
-    prefix_match = INVOCATION_PREFIX_RE.search(text)
-    invocation_prefix = (prefix_match.group(1).strip() if prefix_match else "")
-
-    raw_tokens = [tok for tok in match.group(1).split() if tok != "\\"]
-    expansions = [tok for tok in raw_tokens if "$" in tok]
-    unknown_expansions = sorted(set(expansions) - CANONICAL_EXPANSIONS)
-    expansion_sequence = expansions if expansions != CANONICAL_EXPANSION_SEQUENCE else None
-    found = {tok for tok in raw_tokens if "$" not in tok}
-    missing_tokens = sorted(CANONICAL_TOKENS - found)
-    extra_tokens = sorted(found - CANONICAL_TOKENS)
-
-    if (missing_assignments or missing_tokens or extra_tokens or unknown_expansions
-            or invocation_prefix or expansion_sequence is not None):
-        lines = []
-        if missing_assignments:
-            lines.append("  settings the runner expects and the script no longer has:")
-            lines += [f"    - {m}" for m in missing_assignments]
-        if missing_tokens:
-            lines.append("  invocation tokens the runner expects and the script no longer passes:")
-            lines += [f"    - {m}" for m in missing_tokens]
-        if expansion_sequence is not None:
-            lines.append("  the invocation's shell expansions are not the ones this runner "
-                         "reproduces, in order:")
-            lines.append(f"    expected: {CANONICAL_EXPANSION_SEQUENCE}")
-            lines.append(f"    found:    {expansion_sequence}")
-        if extra_tokens:
-            lines.append("  tokens the script now passes and the runner does NOT reproduce:")
-            lines += [f"    + {m}" for m in extra_tokens]
-        if unknown_expansions:
-            lines.append("  shell expansions whose contents this runner cannot see, so it cannot know")
-            lines.append("  whether it reproduces them:")
-            lines += [f"    ? {m}" for m in unknown_expansions]
-        if invocation_prefix:
-            lines.append("  something now runs BEFORE xcodebuild, so the canonical lane may use a")
-            lines.append("  different environment or toolchain than this runner's ambient one:")
-            lines.append(f"    ! {invocation_prefix}")
-        raise Refusal(
-            f"{CANONICAL_SCRIPT} has drifted from what this runner reproduces, so the battery would "
-            "measure a differently-configured build than the canonical lane:\n"
-            + "\n".join(lines)
-            + "\n\nReconcile CANONICAL_TOKENS / CANONICAL_ASSIGNMENTS / CANONICAL_EXPANSIONS and "
-            "the Lane class with the script, deliberately. Do not delete the guard to make this go "
-            "away."
+            f"{CANONICAL_SCRIPT} must be a regular executable file. The battery runs that command "
+            "directly so it cannot make its own copy of the build settings."
         )
 
 
@@ -1034,7 +830,7 @@ def preflight(worktree: Path, *, will_run_tests: bool = True):
     time a peer's UAT app blocked a recipe validation that touches nothing. Scope a guard to the
     situation its reasoning covers; a guard that refuses more than its reason supports trains bypasses.
     """
-    check_canonical_settings(worktree)
+    check_canonical_entrypoint(worktree)
     if will_run_tests:
         check_no_dev_app(worktree)
     # Case-insensitive: the preflight glob is case-SENSITIVE but the default APFS volume is not, so a
@@ -1046,6 +842,15 @@ def preflight(worktree: Path, *, will_run_tests: bool = True):
             "restore. Investigate before mutating anything else:\n  "
             + "\n  ".join(str(p) for p in leftovers)
         )
+    backup_root = worktree / "build" / "mutation-battery" / "backups"
+    if backup_root.exists():
+        backup_leftovers = [p for p in backup_root.rglob("*") if p.is_file() or p.is_symlink()]
+        if backup_leftovers:
+            raise Refusal(
+                "The dedicated backup directory still has files from an earlier battery. Investigate "
+                "before mutating anything else:\n  "
+                + "\n  ".join(str(p) for p in backup_leftovers)
+            )
 
 
 FENCE_RE = re.compile(r"```json\s*\n(.*?)```", re.DOTALL)
@@ -1247,6 +1052,14 @@ def baseline(lane: Lane, suites, phase: str, seen_names: dict = None,
         except _LaneTimedOut as exc:
             problems.append(f"{suite}: {exc}")
             continue
+        except _RowFailed as exc:
+            # The canonical script can fail before Xcode reaches the test lane
+            # (generation, package resolution, or its own setup). In that case it
+            # creates no fresh Debug log, and `run_suite` deliberately refuses to
+            # grade the missing receipt. A clean-tree control must report that as a
+            # baseline problem instead of letting the whole battery traceback.
+            problems.append(f"{suite}: {exc}")
+            continue
         except BundleUnreadable as exc:
             # A NONEXISTENT SUITE ARRIVES HERE, NOT AT THE ZERO-TEST BRANCH BELOW, and
             # that is why this catch matters more than it looks. `xcodebuild` REPORTS
@@ -1314,11 +1127,54 @@ def baseline(lane: Lane, suites, phase: str, seen_names: dict = None,
     return problems
 
 
+_BATTERY_LOCK_FD = None
+
+
+def acquire_battery_lock(worktree: Path):
+    """Refuse a second writer before it can inspect or create mutation state."""
+    global _BATTERY_LOCK_FD
+    lock_path = worktree / "build" / "mutation-battery" / "battery.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = lock_path.open("a+")
+    try:
+        fcntl.flock(fd.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        fd.close()
+        raise Refusal(
+            f"another mutation battery already owns {lock_path}. Wait for that run to finish rather "
+            "than treating its in-flight backup as stale state."
+        )
+    _BATTERY_LOCK_FD = fd
+
+
+def release_battery_lock():
+    global _BATTERY_LOCK_FD
+    if _BATTERY_LOCK_FD is None:
+        return
+    try:
+        fcntl.flock(_BATTERY_LOCK_FD.fileno(), fcntl.LOCK_UN)
+    finally:
+        _BATTERY_LOCK_FD.close()
+        _BATTERY_LOCK_FD = None
+
+
+def release_battery_lock_on_return(fn):
+    """Keep the lock across every normal return and exception from a CLI run."""
+    @functools.wraps(fn)
+    def wrapped(*args, **kwargs):
+        try:
+            return fn(*args, **kwargs)
+        finally:
+            release_battery_lock()
+    return wrapped
+
+
 def main_for_test(recipes: Path, worktree: Path):
     """Entry point for the self-test's stubbed-lane cases. Same code path as the CLI."""
     return main(["--recipes", str(recipes), "--worktree", str(worktree)])
 
 
+@release_battery_lock_on_return
 def main(argv=None):
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     src = ap.add_mutually_exclusive_group(required=True)
@@ -1336,10 +1192,8 @@ def main(argv=None):
                  "silently do less than the other flag promises.")
 
     worktree = (args.worktree or Path(__file__).resolve().parent.parent).resolve()
-    # The canonical lane reads DERIVED_DATA_PATH with the same default (xcode-test.sh:19). The drift
-    # guard only compares that assignment's TEXT, so a battery ignoring the override would run against
-    # the shared warm cache while an operator believed it was isolated — colliding with another lane,
-    # or reusing different incremental artifacts. Cloud review, PR #2158.
+    # Match the canonical lane's DerivedData override so the battery's isolated child lane never falls
+    # back to another checkout's shared cache.
     derived = Path(os.environ.get("DERIVED_DATA_PATH") or (worktree / ".derivedData" / "Test"))
     # NOT created here: --validate-only is documented as running nothing and touching nothing, and an
     # unconditional mkdir both breaks that promise and crashes on a read-only checkout. The Lane makes
@@ -1357,6 +1211,13 @@ def main(argv=None):
               f"the day can be gone. Point it at a checkout that has the code the recipe names.",
               file=sys.stderr)
         return 2
+
+    if not args.validate_only:
+        try:
+            acquire_battery_lock(worktree)
+        except Refusal as exc:
+            print(f"\nREFUSED — the battery did not start.\n\n{exc}", file=sys.stderr)
+            return 2
 
     print(f"worktree: {worktree}")
     rc, branch = run(["git", "branch", "--show-current"], cwd=worktree)
@@ -1452,8 +1313,8 @@ def main(argv=None):
     results = []
     for i, row in enumerate(rows, 1):
         target = Path(row["_resolved"])
-        backup = target.with_suffix(target.suffix + ".mutbak")
         tag = f"row{i:02d}"
+        backup = backup_path(worktree, tag, target)
         verdict, detail = "ERROR", "did not run"
         # Preflight is a SNAPSHOT and a battery is long — an overnight run is the whole point of this
         # tool. A dev app that starts after preflight and stops before the closing baseline corrupts
@@ -1468,6 +1329,7 @@ def main(argv=None):
             print(f"  [ ERR  ] row {i}: {row['label']}\n           {detail}")
             results.append(("ERROR", row["label"], detail))
             continue
+        backup.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(target, backup)
         _ACTIVE_RESTORES[target] = backup
         try:
@@ -1547,6 +1409,7 @@ def main(argv=None):
                 return 1
             else:
                 backup.unlink()   # verified byte-identical; on failure the backup is KEPT (above)
+                _prune_empty_backup_parents(backup, worktree)
             _ACTIVE_RESTORES.pop(target, None)
         # KEYED BY EVERY VERDICT `classify_row` CAN RETURN. A bare dict lookup on a
         # verdict it does not know raises KeyError mid-run, which is the right

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -264,7 +264,7 @@ GRACEFUL_TERMINATION_SECONDS = 10
 
 
 def _reap_active_lane():
-    """Ask the live canonical lane to exit, then force-kill only if it ignores the request."""
+    """Ask the canonical wrapper to clean up, then guarantee its whole process group is gone."""
     global _ACTIVE_LANE_PGID, _ACTIVE_LANE_PROC
     pgid, proc = _ACTIVE_LANE_PGID, _ACTIVE_LANE_PROC
     _ACTIVE_LANE_PGID = None
@@ -283,10 +283,13 @@ def _reap_active_lane():
     try:
         proc.wait(timeout=GRACEFUL_TERMINATION_SECONDS)
     except subprocess.TimeoutExpired:
-        try:
-            os.killpg(pgid, signal.SIGKILL)
-        except (ProcessLookupError, PermissionError):
-            pass
+        pass
+    # The wrapper can exit cleanly while a hung test descendant remains in the group. Always sweep the
+    # group after its cleanup window; ProcessLookupError is the normal proof that nothing survived.
+    try:
+        os.killpg(pgid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):
+        pass
     return True
 
 

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -31,11 +31,9 @@ THE CONTROLS, none of which are optional — each exists because a real run got 
        mutation is registered outside the try/finally and restored from a signal handler.
     7. THE LANE IS BOUNDED. A mutation that removes a completion or cancellation path can hang the
        suite; unbounded, the battery parks all night and never restores. A timeout is a row ERROR.
-    8. NO DEV APP MAY BE RUNNING. Concurrent writes to the app log corrupt the AppLogger tests, and
-       those failures score as mutants CAUGHT when nothing detected the sabotage (#2080) — it fails
-       toward CONFIDENCE, so it is a refusal rather than a warning.
-    9. THE CANONICAL BUILD SETTINGS MUST NOT HAVE DRIFTED. This runner reproduces `xcode-test.sh`'s
-       invocation rather than calling it; the guard is the price, and #2165 is the plan to delete both.
+    8. TEST LOGS ARE PRIVATE TO EACH LANE. The canonical entry point gives the test process its own
+       AppLogger directory, so a running dev app cannot corrupt a test receipt and falsely score a
+       mutant as CAUGHT (#2279).
 
 WHAT IT CANNOT DO, stated so nobody reads a green report as more than it is
     A battery only ever tries the mutations its author imagined. It proves a test fires on the shapes
@@ -92,21 +90,6 @@ import subprocess
 import sys
 import time
 from pathlib import Path
-
-# The dev app writes to ~/Library/Logs/EnviousWispr/app.log. AppLogger tests write a marker there and
-# read it back; a second concurrent writer breaks UTF-8 boundaries, the read returns empty, and ~6
-# tests fail on a diff that touches no logging code (#2080). Inside a battery that scores as a mutant
-# CAUGHT when nothing detected the sabotage — it fails toward CONFIDENCE, which is the direction
-# nothing prompts you to check. So this is a refusal, not a warning.
-# Overridable ONLY so the self-test is not machine-wide. The check is a `pgrep` across the whole box,
-# so without a seam every case in the suite fails whenever ANY session has a dev app open — which
-# happened mid-run the night this was written, and produced a suite that half passed and half refused.
-# The DEFAULT is the real pattern, so an unset environment is the safe one; the override can only make
-# the check look at something else, never skip it, and it announces itself when used. Contrast #2145,
-# where a convenience DEFAULT silently reconnected an injected seam to production — the direction
-# matters more than the presence of a seam.
-DEV_APP_PATTERN = os.environ.get(
-    "EW_BATTERY_DEV_APP_PATTERN", "EnviousWispr Local.app/Contents/MacOS/EnviousWispr")
 
 TEST_COUNT_RE = re.compile(r"Test run with (\d+) test")
 # Swift Testing prints ✘ for a KNOWN issue too, and the lane still exits 0. A test wrapped in
@@ -780,59 +763,8 @@ def check_canonical_entrypoint(worktree: Path):
         )
 
 
-class _ProbeFailed(Exception):
-    """The dev-app probe could not answer. NOT the same as answering 'none running'."""
-
-
-def dev_app_pids(worktree: Path):
-    """Live pids, for the per-row recheck. Preflight raises; a mid-run appearance fails only that row.
-
-    `pgrep` exits 0 for a match, 1 for NO MATCH, and 2 or more when the probe itself failed — a bad
-    pattern, for instance. Folding that third answer into "none running" is fail-OPEN on a guard whose
-    entire job is to stop a corrupted log scoring as a mutant CAUGHT: the battery would proceed
-    believing the machine is clear when it does not know. Three-valued tool, two-valued caller.
-    """
-    rc, out = run(["pgrep", "-f", DEV_APP_PATTERN], cwd=worktree)
-    if rc > 1:
-        raise _ProbeFailed(
-            f"the dev-app probe failed (pgrep exited {rc}). It cannot be read as 'no dev app is "
-            f"running' — that is the probe's third answer, not its second. Pattern: "
-            f"{DEV_APP_PATTERN!r}"
-        )
-    return out.split() if rc == 0 and out.strip() else []
-
-
-def check_no_dev_app(worktree: Path):
-    """Its own function so the self-test can drive it directly rather than through every case."""
-    if DEV_APP_PATTERN != "EnviousWispr Local.app/Contents/MacOS/EnviousWispr":
-        print(f"NOTE: dev-app check is using a non-default pattern: {DEV_APP_PATTERN!r}",
-              file=sys.stderr)
-    try:
-        running = dev_app_pids(worktree)
-    except _ProbeFailed as exc:
-        raise Refusal(str(exc))
-    if running:
-        out = " ".join(running)
-        raise Refusal(
-            "A dev app is running. Its writes to ~/Library/Logs/EnviousWispr/app.log corrupt the\n"
-            "AppLogger tests, and those failures score as mutants CAUGHT when nothing detected the\n"
-            "sabotage (#2080). Stop every dev instance across ALL worktrees and re-run.\n"
-            f"  pids: {' '.join(out.split())}"
-        )
-
-
-def preflight(worktree: Path, *, will_run_tests: bool = True):
-    """`will_run_tests=False` for --validate-only, which runs no lane and mutates nothing.
-
-    The dev-app refusal exists because concurrent app-log writes corrupt the AppLogger tests and score
-    as mutants CAUGHT (#2080). That reasoning is entirely about RUNNING tests, so applying it to a
-    validation pass refuses a read-only check for a condition that cannot affect it — measured the first
-    time a peer's UAT app blocked a recipe validation that touches nothing. Scope a guard to the
-    situation its reasoning covers; a guard that refuses more than its reason supports trains bypasses.
-    """
+def preflight(worktree: Path):
     check_canonical_entrypoint(worktree)
-    if will_run_tests:
-        check_no_dev_app(worktree)
     # Case-insensitive: the preflight glob is case-SENSITIVE but the default APFS volume is not, so a
     # `.MUTBAK` would be invisible here and then silently overwritten and unlinked by a row.
     leftovers = [q for q in worktree.rglob("*") if q.suffix.lower() == ".mutbak"]
@@ -1225,7 +1157,7 @@ def main(argv=None):
     print(f"branch:   {branch.strip()} @ {head.strip()[:12]}")
 
     try:
-        preflight(worktree, will_run_tests=not args.validate_only)
+        preflight(worktree)
         if args.from_issue is not None:
             print(f"recipe:   issue #{args.from_issue}")
             rows = load_recipes(None, worktree, raw=recipes_from_issue(args.from_issue, worktree))
@@ -1316,19 +1248,6 @@ def main(argv=None):
         tag = f"row{i:02d}"
         backup = backup_path(worktree, tag, target)
         verdict, detail = "ERROR", "did not run"
-        # Preflight is a SNAPSHOT and a battery is long — an overnight run is the whole point of this
-        # tool. A dev app that starts after preflight and stops before the closing baseline corrupts
-        # the AppLogger tests only DURING a mutant, producing a false CAUGHT: the sabotage is credited
-        # with a failure something else caused. That fails toward CONFIDENCE, so it is rechecked per
-        # row rather than once. Cloud review, PR #2158.
-        intruders = dev_app_pids(worktree)
-        if intruders:
-            detail = (f"a dev app appeared mid-run (pids {' '.join(intruders)}) — its app.log writes "
-                      f"corrupt the AppLogger tests, which scores as CAUGHT when nothing detected the "
-                      f"sabotage. Stop it and re-run this row.")
-            print(f"  [ ERR  ] row {i}: {row['label']}\n           {detail}")
-            results.append(("ERROR", row["label"], detail))
-            continue
         backup.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(target, backup)
         _ACTIVE_RESTORES[target] = backup

--- a/scripts/xcode-test.sh
+++ b/scripts/xcode-test.sh
@@ -14,6 +14,8 @@ set -euo pipefail
 #   scripts/xcode-test.sh                 # Debug lane (matches the PR gate)
 #   scripts/xcode-test.sh --filter Foo    # -> -only-testing:Foo
 #   scripts/xcode-test.sh --release       # also run the Release-config lane
+#   scripts/xcode-test.sh --filter Foo --result-bundle-path build/foo.xcresult
+#                                         # Debug receipt at an explicit path
 
 PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 # #2157 chunk C: shared owner for conditional project generation.
@@ -36,6 +38,7 @@ RELEASE_SCHEME="EnviousWispr-Release"
 DEST='platform=macOS,arch=arm64'
 FILTER=""
 RUN_RELEASE=0
+RESULT_BUNDLE_PATH=""
 # Default keeps every existing invocation byte-identical: `build/` under the
 # worktree, the two filenames unchanged.
 LOG_DIR=""
@@ -44,6 +47,7 @@ while [ "$#" -gt 0 ]; do
   case "$1" in
     --filter) FILTER="${2:?--filter needs a value}"; shift 2 ;;
     --release) RUN_RELEASE=1; shift ;;
+    --result-bundle-path) RESULT_BUNDLE_PATH="${2:?--result-bundle-path needs a value}"; shift 2 ;;
     # #2165: a per-invocation log directory. `run_lane` SUMS every
     # `Test run with N test` line in its log, so two runs sharing one fixed path
     # inflate the count — 10806 observed against a real 5387 — and the guard
@@ -51,9 +55,14 @@ while [ "$#" -gt 0 ]; do
     # one. A caller running many lanes (a mutation battery, a matrix) needs its
     # own path per row or its counts are not its own.
     --log-dir) LOG_DIR="${2:?--log-dir needs a value}"; shift 2 ;;
-    *) echo "usage: scripts/xcode-test.sh [--filter TEST] [--release] [--log-dir DIR]" >&2; exit 2 ;;
+    *) echo "usage: scripts/xcode-test.sh [--filter TEST] [--release] [--log-dir DIR] [--result-bundle-path PATH]" >&2; exit 2 ;;
   esac
 done
+
+if [ -n "$RESULT_BUNDLE_PATH" ] && [ "$RUN_RELEASE" = "1" ]; then
+  echo "ERROR: --result-bundle-path may only be used for the Debug lane" >&2
+  exit 2
+fi
 
 cd "$PROJECT_ROOT"
 # Owner: scripts/lib/log-dir.sh, which has its own two-way suite. Creating the
@@ -68,6 +77,8 @@ ew_ensure_generated "$PROJECT_ROOT"
 
 TEST_ARGS=()
 [ -n "$FILTER" ] && TEST_ARGS=(-only-testing:"$FILTER")
+RESULT_BUNDLE_ARGS=()
+[ -n "$RESULT_BUNDLE_PATH" ] && RESULT_BUNDLE_ARGS=(-resultBundlePath "$RESULT_BUNDLE_PATH")
 
 # Run one test lane and guard against a silent zero-test run: xcodebuild prints
 # suite-level "passed" even for an empty bundle, so require a positive executed
@@ -87,6 +98,7 @@ run_lane() {  # $1=scheme  $2=config  $3=logfile  $4...=extra build settings
     VALID_ARCHS=arm64 \
     ONLY_ACTIVE_ARCH=YES \
     "$@" \
+    "${RESULT_BUNDLE_ARGS[@]}" \
     "${TEST_ARGS[@]}" | tee "$log"
 
   local n

--- a/scripts/xcode-test.sh
+++ b/scripts/xcode-test.sh
@@ -70,6 +70,8 @@ cd "$PROJECT_ROOT"
 # cannot be tested without one.
 LOG_DIR="$(ew_resolve_log_dir "$PROJECT_ROOT" "$LOG_DIR")"
 mkdir -p "$LOG_DIR"   # absent on a clean checkout
+APP_LOG_DIR="$LOG_DIR/app-logger"
+mkdir -p "$APP_LOG_DIR"
 
 # Generate the Xcode project (gitignored, never committed) — only when a
 # generation input actually changed (#2157 chunk C).
@@ -87,7 +89,10 @@ RESULT_BUNDLE_ARGS=()
 run_lane() {  # $1=scheme  $2=config  $3=logfile  $4...=extra build settings
   local scheme="$1" config="$2" log="$3"; shift 3
   set -o pipefail
-  xcodebuild test \
+  # Xcode forwards TEST_RUNNER_* variables to the test process after removing
+  # the prefix. This keeps AppLogger tests away from the running dev app's
+  # ~/Library/Logs/EnviousWispr/app.log (#2279).
+  TEST_RUNNER_EW_APP_LOG_DIRECTORY="$APP_LOG_DIR" xcodebuild test \
     -project "$PROJECT" \
     -scheme "$scheme" \
     -configuration "$config" \


### PR DESCRIPTION
Closes #2165
Closes #2279

Routes mutation-battery test lanes through the canonical `scripts/xcode-test.sh` command instead of maintaining a second Xcode invocation. Each mutation lane now has isolated logs, AppLogger files, a result bundle, DerivedData, backups, and a worktree lock.

The AppLogger isolation means mutation batteries can run while EnviousWispr Local stays open. Normal app launches still use `~/Library/Logs/EnviousWispr/`; only canonical test processes receive the private override.

Validation:

- `python3 -m py_compile scripts/mutation-battery.py scripts/mutation-battery-test.py`
- `bash -n scripts/xcode-test.sh`
- `python3 scripts/mutation-battery-test.py` — 121/121 passed
- Focused AppLogger suites — 2/2, 5/5, and 1/1 passed while EnviousWispr Local PID 43264 remained open
- Real source mutation while the app was open — baseline 7/7 green before and after; the intended mutation was caught; source restored cleanly
- Private test marker existed in the lane AppLogger file and was absent from the user's live `app.log`
- Full Debug gate — 6,343 tests passed
- Release `build-for-testing` — succeeded
- Independent Codex diff review — no actionable defects; reviewer also re-ran the 121-case harness and a focused AppLogger test

This is developer test tooling, so no native-app UAT applies.
