### PR TITLE
fix(pipeline): stop deleting real German/Dutch/Danish/Norwegian words as filler

### DIFF
--- a/Sources/EnviousWisprCore/DictationSessionConfig.swift
+++ b/Sources/EnviousWisprCore/DictationSessionConfig.swift
@@ -188,4 +188,13 @@ public struct DictationSessionConfig: Sendable {
     self.recoveryPayload = recoveryPayload
     self.escapeRecoveryEnabled = escapeRecoveryEnabled
   }
+
+  /// The user's locked dictation language, or nil on Auto-detect. Single authority
+  /// for "what language is THIS dictation locked to" — every reader of
+  /// `languageMode` that wants the locked code, not the mode itself, uses this
+  /// so the extraction cannot drift between call sites (issue #2259).
+  public var lockedLanguageCode: String? {
+    if case .locked(let code) = languageMode { return code }
+    return nil
+  }
 }

--- a/Sources/EnviousWisprPipeline/FillerRemovalStep.swift
+++ b/Sources/EnviousWisprPipeline/FillerRemovalStep.swift
@@ -28,21 +28,50 @@ public final class FillerRemovalStep: TextProcessingStep {
     }
   }()
 
+  /// Filler tokens that collide with real, common words in specific languages and
+  /// must never be stripped when the user has locked that language. Keyed by
+  /// `LanguageNormalizer.baseCode`. Confirmed by native-word meaning, not by corpus
+  /// measurement — scope approved by founder 2026-08-20 to these four languages;
+  /// extending to another language is adding one line here, not new logic.
+  private static let languageProtectedTokens: [String: Set<String>] = [
+    "de": ["er", "um"],  // "er" = he, "um" = at [time] / in order to (issue #2259)
+    "nl": ["er"],  // "er" = there (existential "er is...")
+    "da": ["er"],  // "er" = is
+    "no": ["er"],  // "er" = is (nb/nn collapse to "no" via LanguageNormalizer)
+  ]
+
+  private static func protectedTokens(forLanguage language: String?) -> Set<String> {
+    guard let base = LanguageNormalizer.baseCode(language) else { return [] }
+    return languageProtectedTokens[base] ?? []
+  }
+
   public init() {}
 
-  /// The single filler-stripping transform (#1358): regex replace + `\s{2,}`
-  /// collapse + whitespace/newline trim, applied exactly once. Returns the input
-  /// UNCHANGED when the regex is unavailable. This is the one authority for
-  /// "what does removing fillers leave"; `process()` and
+  /// The single filler-stripping transform (#1358): regex match + selective
+  /// removal + `\s{2,}` collapse + whitespace/newline trim, applied exactly once.
+  /// Returns the input UNCHANGED when the regex is unavailable. This is the one
+  /// authority for "what does removing fillers leave"; `process()` and
   /// `TextLexicalContent.hasLexicalContentAfterRemovingFillers` both call it so
   /// there is never a second filler algorithm.
-  public static func removingFillers(from text: String) -> String {
+  ///
+  /// `language` gates per-token removal via `protectedTokens(forLanguage:)`
+  /// (issue #2259) — a token that collides with a real word in the locked
+  /// language is left in place; every other match is removed exactly as before.
+  public static func removingFillers(from text: String, language: String?) -> String {
     guard let pattern = fillerPattern else { return text }
+    let protected = protectedTokens(forLanguage: language)
     let range = NSRange(text.startIndex..., in: text)
-    let cleaned = pattern.stringByReplacingMatches(
-      in: text, range: range, withTemplate: ""
-    )
-    return cleaned.replacingOccurrences(
+    var result = text
+    // Walk matches in REVERSE so ranges computed against the ORIGINAL string
+    // stay valid as earlier matches are removed from `result` — removing a
+    // later range never shifts the offsets of an earlier one.
+    for match in pattern.matches(in: text, range: range).reversed() {
+      guard let wordRange = Range(match.range(at: 1), in: text) else { continue }
+      if protected.contains(text[wordRange].lowercased()) { continue }
+      guard let fullRange = Range(match.range, in: text) else { continue }
+      result.removeSubrange(fullRange)
+    }
+    return result.replacingOccurrences(
       of: #"\s{2,}"#, with: " ", options: .regularExpression
     ).trimmingCharacters(in: .whitespacesAndNewlines)
   }
@@ -58,7 +87,7 @@ public final class FillerRemovalStep: TextProcessingStep {
       }
       return context
     }
-    let result = Self.removingFillers(from: text)
+    let result = Self.removingFillers(from: text, language: context.language)
 
     let removedCount = (text.count - result.count)
     if removedCount > 0 {

--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -357,10 +357,7 @@ struct KernelFinalizationWiring {
       // wire above.
       steps.inverseTextNormalization.backendSupportsLID =
         adapter.capabilities.supportsLanguageDetection
-      let language: String? = {
-        if case .locked(let code) = context.config?.languageMode { return code }
-        return nil
-      }()
+      let language: String? = context.config?.lockedLanguageCode
       let start = CFAbsoluteTimeGetCurrent()
       // #145: ITN runs BEFORE polish so it doubles as the raw-fallback floor —
       // polish-rejected/disabled both deliver the post-ITN text.
@@ -440,7 +437,8 @@ struct KernelFinalizationWiring {
       if !(ctx.polishedText ?? ctx.text).trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
         return ctx.polishedText ?? ctx.text  // unchanged happy path
       }
-      let floor = Self.emptyOutputRecoveryFloor(deterministicText: ctx.text, rawASR: raw)
+      let floor = Self.emptyOutputRecoveryFloor(
+        deterministicText: ctx.text, rawASR: raw, language: language)
       if !floor.isEmpty {
         outcome.rawText = floor
         outcome.polishedText = nil  // the "" polish never persists; History == clipboard
@@ -676,10 +674,7 @@ struct KernelFinalizationWiring {
         // built to prevent (cloud review, PR #1802).
         // Every `@MainActor` input, snapshotted BEFORE the `@Sendable` deadline
         // operation, which cannot reach a `@MainActor` seam.
-        let lockedLanguageCode: String? = {
-          if case .locked(let code) = context.config?.languageMode { return code }
-          return nil
-        }()
+        let lockedLanguageCode: String? = context.config?.lockedLanguageCode
         let engineDetectsLanguage = adapter.capabilities.supportsLanguageDetection
         let engineReportedLanguage = adapter.lastResult?.language
         // The caret windows we already read. A short mid-sentence continuation
@@ -1070,10 +1065,12 @@ struct KernelFinalizationWiring {
   /// floor is never desired (founder directive 2026-07-11). Pure + `@MainActor`
   /// (the filler classifier reads the shared regex). Tested parametrically.
   @MainActor
-  static func emptyOutputRecoveryFloor(deterministicText: String, rawASR: String) -> String {
+  static func emptyOutputRecoveryFloor(
+    deterministicText: String, rawASR: String, language: String?
+  ) -> String {
     let deterministicFloor = deterministicText.trimmingCharacters(in: .whitespacesAndNewlines)
     if !deterministicFloor.isEmpty { return deterministicFloor }
-    if TextLexicalContent.hasLexicalContentAfterRemovingFillers(rawASR) {
+    if TextLexicalContent.hasLexicalContentAfterRemovingFillers(rawASR, language: language) {
       return rawASR.trimmingCharacters(in: .whitespacesAndNewlines)
     }
     return ""

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -3063,7 +3063,8 @@ final class RecordingSessionKernel {
       telemetryState.transcriptionFailureError = error
       processed = KernelFinalizationWiring.emptyOutputRecoveryFloor(
         deterministicText: "",
-        rawASR: asrText
+        rawASR: asrText,
+        language: sessionConfig?.lockedLanguageCode
       )
     }
     guard isCurrent(sid) else { return }
@@ -4345,12 +4346,7 @@ final class RecordingSessionKernel {
     -> TranscriptionOptions
   {
     var options = TranscriptionOptions()
-    switch config.languageMode {
-    case .auto:
-      options.language = nil
-    case .locked(let code):
-      options.language = code
-    }
+    options.language = config.lockedLanguageCode
     return options
   }
 

--- a/Sources/EnviousWisprPipeline/TextLexicalContent.swift
+++ b/Sources/EnviousWisprPipeline/TextLexicalContent.swift
@@ -17,8 +17,10 @@ public enum TextLexicalContent {
   /// scalar (a letter or digit). "uh" → false; "OK" / "1988" / "I" → true;
   /// "..." → false; "uh OK" → true.
   @MainActor
-  public static func hasLexicalContentAfterRemovingFillers(_ text: String) -> Bool {
-    let stripped = FillerRemovalStep.removingFillers(from: text)
+  public static func hasLexicalContentAfterRemovingFillers(_ text: String, language: String?)
+    -> Bool
+  {
+    let stripped = FillerRemovalStep.removingFillers(from: text, language: language)
     return stripped.unicodeScalars.contains { CharacterSet.alphanumerics.contains($0) }
   }
 }

--- a/Sources/EnviousWisprPipeline/TextProcessingStep.swift
+++ b/Sources/EnviousWisprPipeline/TextProcessingStep.swift
@@ -7,7 +7,10 @@ public struct TextProcessingContext: Sendable {
   public var text: String
   /// Optional polished/enhanced version of the text.
   public var polishedText: String?
-  /// Detected language from ASR.
+  /// The user's locked dictation language, or nil on Auto-detect. NOT a
+  /// per-utterance ASR detection — populated from the frozen session config's
+  /// locked language code (or nil), the same source
+  /// `InverseTextNormalizationStep`'s language gate reads (issue #2259).
   public let language: String?
   /// #1846: which dictation this text belongs to, frozen by `TextProcessingRunner`
   /// at the start of the chain. Observation-only: never persisted, never `Codable`,

--- a/Tests/EnviousWisprTests/Pipeline/DictationSessionConfigTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/DictationSessionConfigTests.swift
@@ -69,4 +69,14 @@ struct DictationSessionConfigTests {
     sourceFlag = false
     #expect(config.autoCopyToClipboard == true)
   }
+
+  @Test(
+    "lockedLanguageCode: locked returns the code, auto returns nil (issue #2259 shared authority)"
+  )
+  func testLockedLanguageCode() {
+    let locked = DictationSessionConfig.testDefault(languageMode: .locked("de"))
+    #expect(locked.lockedLanguageCode == "de")
+    let auto = DictationSessionConfig.testDefault(languageMode: .auto)
+    #expect(auto.lockedLanguageCode == nil)
+  }
 }

--- a/Tests/EnviousWisprTests/Pipeline/FillerRemovalLanguageProtectionTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/FillerRemovalLanguageProtectionTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+/// Issue #2259: `FillerRemovalStep` unconditionally stripped `um|umm|uh|uhh|hmm|mm|mhm|mmm|ah|er`
+/// with no language awareness. "er" (he) and "um" (at [time] / in order to) are real, common
+/// words in German; "er" is also real in Dutch (there), Danish and Norwegian (is). These tests
+/// bind that a LOCKED language in that set protects only the colliding tokens, every other
+/// language and every other token keep today's exact behavior, and the fix reaches every step
+/// that reads `TextProcessingContext.language`.
+@MainActor
+@Suite(.tags(.productOutcome))
+struct FillerRemovalLanguageProtectionTests {
+
+  private func makeContext(text: String, language: String?) -> TextProcessingContext {
+    TextProcessingContext(text: text, language: language)
+  }
+
+  private func process(_ text: String, language: String?) async throws -> String {
+    let step = FillerRemovalStep()
+    step.fillerRemovalEnabled = true
+    let result = try await step.process(makeContext(text: text, language: language))
+    return result.text
+  }
+
+  // MARK: German
+
+  @Test("German: \"er\" (he) survives mid-sentence")
+  func germanErSurvivesMidSentence() async throws {
+    let out = try await process("Ich glaube er kommt morgen", language: "de")
+    #expect(out == "Ich glaube er kommt morgen")
+  }
+
+  @Test("German: \"um\" (at [time]) survives")
+  func germanUmSurvivesTime() async throws {
+    let out = try await process("Wir treffen uns um drei Uhr", language: "de")
+    #expect(out == "Wir treffen uns um drei Uhr")
+  }
+
+  @Test("German: \"um\" (in order to) survives")
+  func germanUmSurvivesPurpose() async throws {
+    let out = try await process("Ich rufe an um zu fragen", language: "de")
+    #expect(out == "Ich rufe an um zu fragen")
+  }
+
+  @Test("German: both \"um\" and \"er\" survive in one sentence")
+  func germanBothTokensSurvive() async throws {
+    let out = try await process(
+      "Wir treffen uns um drei Uhr er kommt auch", language: "de")
+    #expect(out == "Wir treffen uns um drei Uhr er kommt auch")
+  }
+
+  @Test("German: a genuine filler is still stripped, proving this is per-token, not a step skip")
+  func germanGenuineFillerStillStripped() async throws {
+    let out = try await process("Ah, ich glaube er kommt", language: "de")
+    #expect(out == "ich glaube er kommt")
+  }
+
+  // MARK: Dutch, Danish, Norwegian — "er"
+
+  @Test("Dutch: \"er\" (there) survives")
+  func dutchErSurvives() async throws {
+    let out = try await process("Er is een probleem", language: "nl")
+    #expect(out == "Er is een probleem")
+  }
+
+  @Test("Danish: \"er\" (is) survives")
+  func danishErSurvives() async throws {
+    let out = try await process("Han er glad", language: "da")
+    #expect(out == "Han er glad")
+  }
+
+  @Test(
+    "Norwegian: \"er\" (is) survives under the settings-exposed codes, not just the Apple alias",
+    arguments: ["no", "nn", "nb"])
+  func norwegianErSurvives(code: String) async throws {
+    let out = try await process("Han er glad", language: code)
+    #expect(out == "Han er glad")
+  }
+
+  // MARK: Non-protected languages and Auto-detect are unaffected
+
+  @Test("Untabled language: \"ah\" and \"er\" both removed exactly as before")
+  func untabledLanguageUnaffected() async throws {
+    let out = try await process("Ah, er kommt", language: "fr")
+    #expect(out == "kommt")
+  }
+
+  @Test("Auto-detect (nil language): \"ah\" and \"er\" both removed exactly as before")
+  func autoDetectUnaffected() async throws {
+    let out = try await process("Ah, er kommt", language: nil)
+    #expect(out == "kommt")
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/Issue1358EmptyRecoveryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Issue1358EmptyRecoveryTests.swift
@@ -49,7 +49,20 @@ struct Issue1358EmptyRecoveryTests {
       ("1988", true), ("8", true), ("uh OK", true), ("hello there", true),
     ])
   func lexicalClassifier(input: String, expected: Bool) {
-    #expect(TextLexicalContent.hasLexicalContentAfterRemovingFillers(input) == expected)
+    #expect(
+      TextLexicalContent.hasLexicalContentAfterRemovingFillers(input, language: nil) == expected)
+  }
+
+  @Test(
+    "hasLexicalContentAfterRemovingFillers: a lone German pronoun is lexical content, not pure filler (#2259)"
+  )
+  func lexicalClassifierGermanLoneWord() {
+    // Pre-fix, "Er" alone would have been classified as no lexical content
+    // (the unconditional filler regex strips it) and dropped to `.noSpeech`.
+    #expect(TextLexicalContent.hasLexicalContentAfterRemovingFillers("Er", language: "de") == true)
+    #expect(TextLexicalContent.hasLexicalContentAfterRemovingFillers("Um", language: "de") == true)
+    // Untabled language: unchanged behavior, still pure filler.
+    #expect(TextLexicalContent.hasLexicalContentAfterRemovingFillers("Er", language: "fr") == false)
   }
 
   // MARK: emptyOutputRecoveryFloor (the pure floor decision)
@@ -70,7 +83,7 @@ struct Issue1358EmptyRecoveryTests {
   func recoveryFloor(deterministicText: String, rawASR: String, expectedFloor: String) {
     #expect(
       KernelFinalizationWiring.emptyOutputRecoveryFloor(
-        deterministicText: deterministicText, rawASR: rawASR) == expectedFloor)
+        deterministicText: deterministicText, rawASR: rawASR, language: nil) == expectedFloor)
   }
 
   @Test(
@@ -79,12 +92,27 @@ struct Issue1358EmptyRecoveryTests {
     // The classifier never reads `fillerRemovalEnabled`; a bare filler is never
     // floored even when a NON-filler step emptied the deterministic text.
     #expect(
-      KernelFinalizationWiring.emptyOutputRecoveryFloor(deterministicText: "", rawASR: "uh") == ""
+      KernelFinalizationWiring.emptyOutputRecoveryFloor(
+        deterministicText: "", rawASR: "uh", language: nil) == ""
     )
     // A real word emptied by a step IS recovered.
     #expect(
-      KernelFinalizationWiring.emptyOutputRecoveryFloor(deterministicText: "", rawASR: "hello")
+      KernelFinalizationWiring.emptyOutputRecoveryFloor(
+        deterministicText: "", rawASR: "hello", language: nil)
         == "hello")
+  }
+
+  @Test(
+    "the raw floor is language-aware: a German pronoun is not floored away as filler (#2259)")
+  func rawFloorGermanLoneWordRecovered() {
+    #expect(
+      KernelFinalizationWiring.emptyOutputRecoveryFloor(
+        deterministicText: "", rawASR: "Er", language: "de") == "Er"
+    )
+    #expect(
+      KernelFinalizationWiring.emptyOutputRecoveryFloor(
+        deterministicText: "", rawASR: "Er", language: nil) == ""
+    )
   }
 
   // MARK: Wiring integration — polish returns empty (finding 3)
@@ -103,7 +131,8 @@ struct Issue1358EmptyRecoveryTests {
     steps.llmPolish.llmProvider = .openAI
     steps.llmPolish.llmModel = "gpt-4o-mini"
     steps.llmPolish.makePolisher = { _, _, _ in EmptyPolisher() }
-    let wiring = makeWiring(outcome: outcome, steps: steps, save: { transcript, _ in saved.transcript = transcript })
+    let wiring = makeWiring(
+      outcome: outcome, steps: steps, save: { transcript, _ in saved.transcript = transcript })
 
     let input = "please clean up this sentence now"
     let result = try await wiring.processText(input) {}

--- a/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelSalvageTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelSalvageTests.swift
@@ -48,7 +48,8 @@ struct ExhaustedRetrySpoolDeletionTests {
     #expect(deletesRecoverySpool(.failed(.asrFailed)))
   }
 
-  @Test("a retry left at .attempted (timeout/cancel) deletes as plain .failed (#1755 founder override)")
+  @Test(
+    "a retry left at .attempted (timeout/cancel) deletes as plain .failed (#1755 founder override)")
   func attemptedOnlyRetryDeletesAsFailed() {
     // `.attempted` remains the honest diagnostic that no decode conclusion
     // was accepted; the founder's Gate 2 decision makes it delete anyway —
@@ -218,6 +219,30 @@ struct ExhaustedRetrySpoolDeletionTests {
       }
     }
 
+    /// Issue #2259: the SAME throw path, locked to German, with raw ASR that is
+    /// a bare filler token in English but a real German pronoun. Pre-fix this
+    /// caller passed no language to `emptyOutputRecoveryFloor`, so "Er" would
+    /// have been misread as pure filler and dropped to `.noSpeech` exactly like
+    /// the English "uh" case above. Fixed, it must behave like the LEXICAL
+    /// case: stored and delivered once.
+    @Test("a processText throw with German raw ASR (\"Er\") stores and delivers it, not no-speech")
+    func processTextThrowGermanLoneWordDelivers() async {
+      let (context, wrapper) = makeWrapper(behavior: .batchSuccess(text: "Er"))
+      wrapper.sessionConfigForTesting = .testDefault(languageMode: .locked("de"))
+      wrapper.testProcessTextThrows()
+      let kernel = wrapper.testKernel
+
+      await startRecording(context)
+      await context.sut.apply(.stop)
+      await wrapper.drainUntilConcluded()
+
+      #expect(wrapper.storedTexts == ["Er"], "storage receives the German raw ASR, not dropped")
+      #expect(context.paste.pasteAttempts == ["Er"])
+      #expect(kernel.deliveredTranscript == "Er")
+      #expect(kernel.recordingOutcome == .completed)
+      #expect(kernel.recordingOutcome != .noSpeech(.emptyAfterProcessing))
+    }
+
     // MARK: 1c. #1755 chunk 4 — #1709 salvage-cancelled breadcrumb (exact cell only)
 
     /// ONE synchronous MainActor test with no suspension points: the
@@ -227,7 +252,9 @@ struct ExhaustedRetrySpoolDeletionTests {
     /// real protection — a previously installed delegate survives; a truly
     /// concurrent writer to the same global could still race it, which this
     /// test cannot prevent.
-    @Test("the .asr + .cancelled floor cell emits exactly one asr_salvage_cancelled breadcrumb; siblings stay silent")
+    @Test(
+      "the .asr + .cancelled floor cell emits exactly one asr_salvage_cancelled breadcrumb; siblings stay silent"
+    )
     func asrSalvageCancelledBreadcrumbExactCellOnly() {
       nonisolated(unsafe) var matches: [[String: String]] = []
       let prior = SentryBreadcrumb.breadcrumbDelegate


### PR DESCRIPTION
## Summary

- `FillerRemovalStep` stripped a fixed English-shaped token list (`um|umm|uh|uhh|hmm|mm|mhm|mmm|ah|er`) unconditionally, deleting real, common words in German ("er" = he, "um" = at [time] / in order to), Dutch, Danish, and Norwegian ("er"). Filler stripping now reads the locked dictation language and exempts only the colliding tokens for German/Dutch/Danish/Norwegian; every other token and language is unchanged.
- Threaded through both production callers of the empty-output recovery floor, including a throwing-path caller the first review pass missed.
- Consolidated three duplicated "locked language code, or nil" extractions onto one shared `DictationSessionConfig.lockedLanguageCode` property.
- Verified the AI polish layer (Apple Intelligence and three local models) already preserves these words correctly when the language is locked, using the real production prompts against real German sentences — no polish-layer change needed.

## Test plan

- [x] New suite `FillerRemovalLanguageProtectionTests` (10 cases) — German/Dutch/Danish/Norwegian tokens survive, untabled languages and Auto-detect unaffected, genuine fillers still stripped
- [x] `Issue1358EmptyRecoveryTests` extended — the floor path no longer misreads a lone German pronoun as pure filler
- [x] `RecordingSessionKernelSalvageTests` extended — the previously-missed throwing-path caller now protects German raw ASR
- [x] `DictationSessionConfigTests` extended — the new shared `lockedLanguageCode` property
- [x] Full Debug (6318 tests) + Release (5751 tests) lanes green
- [x] Codex diff review: clean, no actionable findings
- [x] Live UAT: real German audio ("Wir treffen uns um drei Uhr, er kommt auch.") dictated through the running dev app with German locked — `app.log` confirms `RAW ASR` captured both "um" and "Er" and `Filler Removal: no change`, twice, end to end

Closes #2259.
