### PR TITLE
test(architecture): close ceiling classification gaps

### DIFF
--- a/Tests/EnviousWisprTests/Architecture/ASREventRouterCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/ASREventRouterCeilingsTests.swift
@@ -28,6 +28,18 @@ import Testing
       """)
   }
 
+  /// The two buckets are individually useful, but an alias can change buckets
+  /// without changing the dependency. Freeze their measured total as well.
+  @Test func totalStoredDependencyCount() throws {
+    let body = try RouterCeilingParser.classBody(named: "ASREventRouter", at: Self.sourcePath)
+    let collaborators = RouterCeilingParser.collaboratorCount(in: body)
+    let closures = RouterCeilingParser.closureInjectedCount(in: body)
+    let total = RouterCeilingParser.storedDependencyCount(in: body)
+    #expect(
+      total <= 3,
+      "ASREventRouter total stored-dependency ceiling exceeded: \(total) > 3 (\(collaborators) collaborators + \(closures) closures).")
+  }
+
   @Test func nonPrivateMethodCount() throws {
     let body = try RouterCeilingParser.classBody(named: "ASREventRouter", at: Self.sourcePath)
     let count = RouterCeilingParser.nonPrivateMethodCount(in: body)

--- a/Tests/EnviousWisprTests/Architecture/AudioEventRouterCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/AudioEventRouterCeilingsTests.swift
@@ -41,6 +41,16 @@ import Testing
       """)
   }
 
+  @Test func totalStoredDependencyCount() throws {
+    let body = try RouterCeilingParser.classBody(named: "AudioEventRouter", at: Self.sourcePath)
+    let collaborators = RouterCeilingParser.collaboratorCount(in: body)
+    let closures = RouterCeilingParser.closureInjectedCount(in: body)
+    let total = RouterCeilingParser.storedDependencyCount(in: body)
+    #expect(
+      total <= 4,
+      "AudioEventRouter total stored-dependency ceiling exceeded: \(total) > 4 (\(collaborators) collaborators + \(closures) closures).")
+  }
+
   @Test func nonPrivateMethodCount() throws {
     let body = try RouterCeilingParser.classBody(named: "AudioEventRouter", at: Self.sourcePath)
     let count = RouterCeilingParser.nonPrivateMethodCount(in: body)

--- a/Tests/EnviousWisprTests/Architecture/CeilingsTestSupport.swift
+++ b/Tests/EnviousWisprTests/Architecture/CeilingsTestSupport.swift
@@ -71,25 +71,7 @@ enum CeilingsTestSupport {
   }
 
   static func countTopLevelLetCollaborators(in body: String) -> Int {
-    var depth = 0
-    var collaborators = 0
-
-    for line in body.split(separator: "\n", omittingEmptySubsequences: false) {
-      let opens = line.filter { $0 == "{" }.count
-      let closes = line.filter { $0 == "}" }.count
-      let depthForThisLine = depth - max(0, closes - opens)
-
-      if depthForThisLine == 0 {
-        let s = String(line)
-        if isCollaboratorLetDeclaration(s) && !isPrimitiveTyped(s) {
-          collaborators += 1
-        }
-      }
-
-      depth += opens - closes
-    }
-
-    return collaborators
+    RouterCeilingParser.storedDependencyCount(in: body)
   }
 
   static func countNonPrivateMethods(in body: String) -> Int {
@@ -133,9 +115,6 @@ enum CeilingsTestSupport {
 
   private static let attrs = #"(@[A-Za-z_][A-Za-z0-9_]*(\([^)]*\))?[[:space:]]+)*"#
 
-  private static let collaboratorLetPattern =
-    #"^[[:space:]]*\#(attrs)(public|internal|private|fileprivate|package|open)?[[:space:]]*let[[:space:]]+[A-Za-z_]"#
-
   private static let privateMethodPattern =
     #"^[[:space:]]*\#(attrs)(private|fileprivate)[[:space:]]+(static[[:space:]]+)?(class[[:space:]]+)?func[[:space:]]+[A-Za-z_]"#
 
@@ -149,23 +128,11 @@ enum CeilingsTestSupport {
   private static let importPattern =
     #"^[[:space:]]*\#(attrs)import[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)\b"#
 
-  private static func isCollaboratorLetDeclaration(_ line: String) -> Bool {
-    line.range(of: collaboratorLetPattern, options: .regularExpression) != nil
-  }
-
   private static func isNonPrivateMethodDeclaration(_ line: String) -> Bool {
     if line.range(of: privateMethodPattern, options: .regularExpression) != nil {
       return false
     }
     return line.range(of: nonPrivateMethodPattern, options: .regularExpression) != nil
-  }
-
-  private static func isPrimitiveTyped(_ line: String) -> Bool {
-    let primitives = [
-      ": Bool", ": Int", ": String", ": Double", ": Float",
-      "Task<", ": ((", "= false", "= true",
-    ]
-    return primitives.contains { line.contains($0) }
   }
 
   private static func firstCapture(in line: String, pattern: String) -> String? {

--- a/Tests/EnviousWisprTests/Architecture/DictationRuntimeCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/DictationRuntimeCeilingsTests.swift
@@ -69,6 +69,17 @@ import Testing
       """)
   }
 
+  @Test func totalStoredDependencyCount() throws {
+    let body = try RouterCeilingParser.classBody(
+      named: "DictationRuntime", at: Self.sourcePath)
+    let collaborators = RouterCeilingParser.collaboratorCount(in: body)
+    let closures = RouterCeilingParser.closureInjectedCount(in: body)
+    let total = RouterCeilingParser.storedDependencyCount(in: body)
+    #expect(
+      total <= 7,
+      "DictationRuntime total stored-dependency ceiling exceeded: \(total) > 7 (\(collaborators) collaborators + \(closures) closures).")
+  }
+
   @Test func nonPrivateMethodCount() throws {
     let body = try RouterCeilingParser.classBody(
       named: "DictationRuntime", at: Self.sourcePath)

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -563,42 +563,7 @@ private func structBodyOfEnviousWisprApp() throws -> String {
 /// Stored properties include those marked with SwiftUI property wrappers
 /// (`@State`, `@NSApplicationDelegateAdaptor`).
 private func countTopLevelStoredProperties(in body: String) -> Int {
-  var depth = 0
-  var count = 0
-  for line in body.split(separator: "\n", omittingEmptySubsequences: false) {
-    let opens = line.filter { $0 == "{" }.count
-    let closes = line.filter { $0 == "}" }.count
-    let depthForThisLine = depth - max(0, closes - opens)
-    if depthForThisLine == 0 {
-      let s = String(line)
-      if isStoredPropertyDeclaration(s) {
-        count += 1
-      }
-    }
-    depth += opens - closes
-  }
-  return count
-}
-
-private let storedPropertyPattern: String = {
-  // Match `let|var <ident>` at the top level, allowing property wrappers
-  // (with optional parenthesized args) and access modifiers in any order
-  // before the declaration keyword.
-  let attrs = #"(@[A-Za-z_][A-Za-z0-9_]*(\([^)]*\))?[[:space:]]+)*"#
-  let access = #"(public|internal|private|fileprivate|package|open)?"#
-  return "^[[:space:]]*\(attrs)\(access)[[:space:]]*(let|var)[[:space:]]+[A-Za-z_]"
-}()
-
-private func isStoredPropertyDeclaration(_ line: String) -> Bool {
-  guard line.range(of: storedPropertyPattern, options: .regularExpression) != nil
-  else { return false }
-  // Exclude computed properties — these have an opening `{` on the same line
-  // as the declaration (e.g. `var body: some Scene {`). Stored properties
-  // never have a trailing `{` on the declaration line.
-  if line.range(of: #"\{[[:space:]]*$"#, options: .regularExpression) != nil {
-    return false
-  }
-  return true
+  RouterCeilingParser.storedPropertyCount(in: body)
 }
 
 /// Counts top-level non-private `func` declarations. The `body` computed

--- a/Tests/EnviousWisprTests/Architecture/HotkeyControllerCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/HotkeyControllerCeilingsTests.swift
@@ -41,6 +41,17 @@ import Testing
       """)
   }
 
+  @Test func totalStoredDependencyCount() throws {
+    let body = try RouterCeilingParser.classBody(
+      named: "HotkeyController", at: Self.sourcePath)
+    let collaborators = RouterCeilingParser.collaboratorCount(in: body)
+    let closures = RouterCeilingParser.closureInjectedCount(in: body)
+    let total = RouterCeilingParser.storedDependencyCount(in: body)
+    #expect(
+      total <= 4,
+      "HotkeyController total stored-dependency ceiling exceeded: \(total) > 4 (\(collaborators) collaborators + \(closures) closures).")
+  }
+
   @Test func nonPrivateMethodCount() throws {
     let body = try RouterCeilingParser.classBody(
       named: "HotkeyController", at: Self.sourcePath)

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
@@ -105,6 +105,21 @@ enum RouterCeilingParser {
     }.count
   }
 
+  /// The classification-independent count used by architecture ceilings. An
+  /// alias can look like a collaborator while spelling a closure, but it still
+  /// consumes exactly one dependency slot here.
+  static func storedDependencyCount(in body: String) -> Int {
+    collaboratorCount(in: body) + closureInjectedCount(in: body)
+  }
+
+  /// Every parser-visible instance stored property, whether declared with `let`
+  /// or `var`. This is the right counter for a composition-root state ceiling:
+  /// unlike collaborator ceilings, owned mutable state is part of that home's
+  /// size and must consume a slot too.
+  static func storedPropertyCount(in body: String) -> Int {
+    storedBindings(in: body, includeVars: true).count
+  }
+
   /// Non-private `func` declarations declared directly in the class body.
   static func nonPrivateMethodCount(in body: String) -> Int {
     members(in: body).compactMap { $0.as(FunctionDeclSyntax.self) }
@@ -284,13 +299,20 @@ enum RouterCeilingParser {
   /// what the ceiling means rather than a fact about Swift: a type property is
   /// not an injected instance collaborator.
   private static func storedLetBindings(in body: String) -> [StoredLet] {
+    storedBindings(in: body, includeVars: false)
+  }
+
+  private static func storedBindings(in body: String, includeVars: Bool) -> [StoredLet] {
     var result: [StoredLet] = []
     for member in members(in: body) {
       guard let variable = member.as(VariableDeclSyntax.self) else { continue }
-      guard variable.bindingSpecifier.tokenKind == .keyword(.let) else { continue }
+      guard
+        variable.bindingSpecifier.tokenKind == .keyword(.let)
+          || (includeVars && variable.bindingSpecifier.tokenKind == .keyword(.var))
+      else { continue }
       guard !isTypeProperty(variable.modifiers) else { continue }
       for binding in variable.bindings {
-        guard binding.accessorBlock == nil else { continue }
+        guard isStoredProperty(binding) else { continue }
         let isBool = binding.initializer.map { isBooleanLiteral($0.value) } ?? false
         expand(
           pattern: binding.pattern, type: binding.typeAnnotation?.type,
@@ -298,6 +320,17 @@ enum RouterCeilingParser {
       }
     }
     return result
+  }
+
+  private static func isStoredProperty(_ binding: PatternBindingSyntax) -> Bool {
+    guard let accessorBlock = binding.accessorBlock else { return true }
+    guard case .accessors(let accessors) = accessorBlock.accessors else { return false }
+    // `didSet`/`willSet` observe a backing slot; a getter or setter computes the
+    // value instead. Count only the former so a state ceiling cannot be walked
+    // around by adding an observed `var`.
+    return accessors.allSatisfy { accessor in
+      ["didSet", "willSet"].contains(accessor.accessorSpecifier.text)
+    }
   }
 
   /// One `StoredLet` per property a binding actually declares.

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
@@ -283,6 +283,46 @@ import Testing
     #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
   }
 
+  @Test func storedPropertyCount_countsLetsAndVarsButExcludesComputedAndTypeProperties() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let alpha: AlphaDep
+          var state: State
+          var observed: ObservedState = .init() { didSet {} }
+          let (first, second): (FirstDep, SecondDep)
+          var computed: AlphaDep { alpha }
+          static let shared: Registry
+        }
+        """)
+    #expect(RouterCeilingParser.storedPropertyCount(in: body) == 5)
+  }
+
+  @Test func storedDependencyCount_includesBothClassificationBuckets() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let collaborator: Collaborator
+          let callback: () -> Void
+          let aliasedCallback: ProgressCallback
+        }
+        """)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 2)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 1)
+    #expect(RouterCeilingParser.storedDependencyCount(in: body) == 3)
+  }
+
+  @Test func sharedCeilingSupportCountsDirectClosureDependencies() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let collaborator: Collaborator
+          let callback: () -> Void
+        }
+        """)
+    #expect(CeilingsTestSupport.countTopLevelLetCollaborators(in: body) == 2)
+  }
+
   @Test func collaboratorCount_excludesPrimitiveLet() throws {
     let body = try classBody(
       of: """

--- a/Tests/EnviousWisprTests/Architecture/WedgeRecoveryRouterCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/WedgeRecoveryRouterCeilingsTests.swift
@@ -30,6 +30,17 @@ import Testing
       """)
   }
 
+  @Test func totalStoredDependencyCount() throws {
+    let body = try RouterCeilingParser.classBody(
+      named: "WedgeRecoveryRouter", at: Self.sourcePath)
+    let collaborators = RouterCeilingParser.collaboratorCount(in: body)
+    let closures = RouterCeilingParser.closureInjectedCount(in: body)
+    let total = RouterCeilingParser.storedDependencyCount(in: body)
+    #expect(
+      total <= 5,
+      "WedgeRecoveryRouter total stored-dependency ceiling exceeded: \(total) > 5 (\(collaborators) collaborators + \(closures) closures).")
+  }
+
   @Test func nonPrivateMethodCount() throws {
     let body = try RouterCeilingParser.classBody(
       named: "WedgeRecoveryRouter", at: Self.sourcePath)


### PR DESCRIPTION
## Summary

- Adds total stored-dependency ceilings to the five remaining router homes, so a dependency cannot evade a cap by changing classification.
- Replaces the two remaining line-based stored-property counters with the shared SwiftSyntax parser.
- Counts direct closures and observed `var` state correctly, while keeping computed and type properties out.

Closes #2082
Closes #2267

## Verification

- Focused `RouterCeilingParserTests` and `EnviousWisprAppCeilingsTests` passed.
- The ASR, Audio, Dictation Runtime, Hotkey Controller, Wedge Recovery, and Sparkle ceiling suites passed.
- Four deliberate mutations were caught: dropping the closure bucket, skipping mutable state, excluding shared direct closures, and excluding observed vars.
- Independent review against `origin/main` — clean.

## Scope

Architecture test tooling only; no shipped app behavior changes or live-app UAT apply.
