### PR TITLE
test(recovery): cover production retarget failure guards

### DIFF
--- a/Sources/EnviousWisprAppKit/App/EscapeRecoveryPasteAction.swift
+++ b/Sources/EnviousWisprAppKit/App/EscapeRecoveryPasteAction.swift
@@ -39,7 +39,7 @@ enum EscapeRecoveryPasteAction {
     payload: CancelUndoPayload,
     restorable: (UUID) -> (text: String, stampedAt: Date, takeID: String?)?,
     report: (_ ageMs: Int, _ result: EscapeRecoveryPasteResult, _ takeID: String) -> Void,
-    retarget: @MainActor (CancelUndoPayload) -> Bool = Self.retargetWithAccessibility,
+    retarget: @MainActor (CancelUndoPayload) -> Bool = Self.defaultRetarget,
     targetHasQuit: (CancelUndoPayload) -> Bool = { $0.targetApp?.isTerminated == true }
   ) {
     guard let row = restorable(payload.transcriptID) else {
@@ -202,16 +202,25 @@ enum EscapeRecoveryPasteAction {
   /// was right about History and wrong about the pill: History activates
   /// nothing, so it promises nothing, while returning to the target app is the
   /// entire reason this pill exists.
+  private static func defaultRetarget(_ payload: CancelUndoPayload) -> Bool {
+    retargetWithAccessibility(payload)
+  }
+
   @MainActor
-  static func retargetWithAccessibility(_ payload: CancelUndoPayload) -> Bool {
+  static func retargetWithAccessibility(
+    _ payload: CancelUndoPayload,
+    forceActivate: (pid_t) -> Bool = PasteService.forceActivateApp,
+    activateFallback: (NSRunningApplication) -> Bool = { $0.activate() },
+    focusElement: (AXUIElement) -> Bool = PasteService.focusElement
+  ) -> Bool {
     guard let app = payload.targetApp else { return true }
     // Both routes report. `forceActivateApp` is the AX path macOS 14+ needs for
     // a background process; `activate()` is the fallback when Accessibility is
     // refused, in which case the paste was never going to work anyway.
-    guard PasteService.forceActivateApp(pid: app.processIdentifier) || app.activate() else {
+    guard forceActivate(app.processIdentifier) || activateFallback(app) else {
       return false
     }
     guard let element = payload.targetElement else { return true }
-    return PasteService.focusElement(element)
+    return focusElement(element)
   }
 }

--- a/Tests/EnviousWisprTests/App/EscapeRecoveryRestoreTests.swift
+++ b/Tests/EnviousWisprTests/App/EscapeRecoveryRestoreTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import EnviousWisprCore
 import EnviousWisprServices
 import EnviousWisprStorage
@@ -183,6 +184,88 @@ struct EscapeRecoveryRestoreTests {
     #expect(
       spy.reports.first?.result == .clipboardOnly,
       "the words stay on the clipboard rather than landing in the wrong field")
+  }
+
+  /// The production retarget has two activation routes because macOS may refuse
+  /// the Accessibility route while the ordinary AppKit activation still works.
+  /// If both fail, it must report failure so `paste` leaves the words safely on
+  /// the clipboard instead of sending Cmd-V to whichever app is frontmost.
+  @Test("the production retarget refuses a captured app when both activation routes fail")
+  func productionRetargetRefusesFailedActivation() {
+    let app = NSRunningApplication.current
+    let payload = CancelUndoPayload(
+      transcriptID: UUID(), targetApp: app, targetElement: nil)
+    var forcedPIDs: [pid_t] = []
+    var fallbackCalls = 0
+
+    let retargeted = EscapeRecoveryPasteAction.retargetWithAccessibility(
+      payload,
+      forceActivate: {
+        forcedPIDs.append($0)
+        return false
+      },
+      activateFallback: { _ in
+        fallbackCalls += 1
+        return false
+      })
+
+    #expect(forcedPIDs == [app.processIdentifier], "the Accessibility route is tried first")
+    #expect(fallbackCalls == 1, "the AppKit fallback is tried when Accessibility is unavailable")
+    #expect(
+      retargeted == false,
+      "a captured app that cannot be reached must not be followed by a paste into another app")
+  }
+
+  /// No target was captured, so Escape Recovery intentionally preserves
+  /// History's behavior and pastes into the user's current focus. This is not
+  /// an activation failure: there is simply no app to return to.
+  @Test("the production retarget permits a restore with no recorded target")
+  func productionRetargetPermitsNoTarget() {
+    let payload = CancelUndoPayload(
+      transcriptID: UUID(), targetApp: nil, targetElement: nil)
+    var activationAttempted = false
+
+    let retargeted = EscapeRecoveryPasteAction.retargetWithAccessibility(
+      payload,
+      forceActivate: { _ in
+        activationAttempted = true
+        return false
+      },
+      activateFallback: { _ in
+        activationAttempted = true
+        return false
+      })
+
+    #expect(activationAttempted == false, "there is no app to activate")
+    #expect(retargeted == true, "the existing no-target behavior is intentional and preserved")
+  }
+
+  @Test("the production retarget refuses a captured field that cannot be focused")
+  func productionRetargetRefusesFailedFieldFocus() {
+    let app = NSRunningApplication.current
+    let element = AXUIElementCreateApplication(app.processIdentifier)
+    let payload = CancelUndoPayload(
+      transcriptID: UUID(), targetApp: app, targetElement: element)
+    var fallbackCalls = 0
+    var focusedElements: [AXUIElement] = []
+
+    let retargeted = EscapeRecoveryPasteAction.retargetWithAccessibility(
+      payload,
+      forceActivate: { _ in true },
+      activateFallback: { _ in
+        fallbackCalls += 1
+        return true
+      },
+      focusElement: {
+        focusedElements.append($0)
+        return false
+      })
+
+    #expect(fallbackCalls == 0, "a successful Accessibility activation does not need AppKit")
+    #expect(focusedElements.count == 1, "the captured field is the decision point after activation")
+    #expect(
+      retargeted == false,
+      "a field that rejects focus must keep the recovery on the clipboard")
   }
 
   // MARK: History's door


### PR DESCRIPTION
## Summary

- exercise `retargetWithAccessibility` itself, rather than only an injected sibling closure
- prove both activation routes failing and a captured field rejecting focus refuse the paste
- pin the deliberate no-target behavior: preserve the user’s current focus without attempting activation

Closes #2229

## Validation

- `scripts/xcode-test.sh --filter EnviousWisprTests/EscapeRecoveryRestoreTests` — 12/12 green
- independent Codex review — no actionable regression
- #2269 mutation hardening while EnviousWispr Local stayed open — 3/3 production mutations caught by the named tests; 12-test baseline green before and after; source restored cleanly
