### PR TITLE
fix(paste): skip the trailing space in a browser's URL bar

### DIFF
--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -659,7 +659,11 @@ struct KernelFinalizationWiring {
             // ONE rendered row, so a payload carrying a line break is refused
             // rather than reasoned about — in a terminal a newline can submit
             // the command.
-            isScreenDerived: $0.isScreenDerived)
+            isScreenDerived: $0.isScreenDerived,
+            // #2258: a space anywhere in a browser's address bar blocks
+            // pressing Enter to navigate. Services already did the AX work;
+            // this is the same policy-fact-only handoff as `isScreenDerived`.
+            isURLBarField: $0.isBrowserAddressBar)
         }
 
         // Resolved from positive evidence, NOT read off the result.
@@ -715,6 +719,8 @@ struct KernelFinalizationWiring {
               // single-claim rule; it exists to leave the closure, not to be read.
               // #1946: named for the DEADLINE, not the oracle — nothing here has
               // consulted one, and the old `.oracleTimedOut` asserted otherwise.
+              // #2258: deliberately plain, never URL-bar-aware — see
+              // `CursorInsertionRepair.legacyPayload`'s own doc comment for why.
               return (
                 CursorInsertionRepair.legacyOnly(text: text, reason: .repairDeadlineMissed),
                 resolution

--- a/Sources/EnviousWisprPostProcessing/CursorInsertionRepair.swift
+++ b/Sources/EnviousWisprPostProcessing/CursorInsertionRepair.swift
@@ -46,14 +46,21 @@ public enum CursorInsertionRepair {
     /// the refusal in `prepare`.
     public let isScreenDerived: Bool
 
+    /// Whether the caret sits in a recognized browser's URL/address bar
+    /// (#2258). The narrow POLICY fact this repair needs — a space anywhere
+    /// in that field blocks pressing Enter to navigate — never the
+    /// accessibility evidence behind it, which stays in Services.
+    public let isURLBarField: Bool
+
     public init(
       left: String, right: String, leftReachesDocumentStart: Bool = false,
-      isScreenDerived: Bool = false
+      isScreenDerived: Bool = false, isURLBarField: Bool = false
     ) {
       self.left = left
       self.right = right
       self.leftReachesDocumentStart = leftReachesDocumentStart
       self.isScreenDerived = isScreenDerived
+      self.isURLBarField = isURLBarField
     }
   }
 
@@ -141,6 +148,10 @@ public enum CursorInsertionRepair {
     /// Thai, Lao, Burmese, Khmer). A space at either end of the insertion is a
     /// visible defect in those scripts, not a separator.
     case unsegmentedScript = "unsegmented_script"
+    /// A recognized browser's URL/address bar (#2258). A space anywhere in
+    /// that field blocks pressing Enter to navigate, so this is checked
+    /// before what follows the caret rather than as one more case of it.
+    case browserAddressBar = "browser_address_bar"
   }
 
   /// One decision the repair took, for tests and privacy-safe telemetry.
@@ -492,6 +503,16 @@ public enum CursorInsertionRepair {
   /// Today's delivery-stage rule, absorbed verbatim from
   /// the retired `PasteService.appendTrailingSpace`, which is now deleted — this
   /// is the single owner of the rule.
+  ///
+  /// Deliberately CONTEXT-FREE, including for a URL bar (#2258, cloud review
+  /// r3): this is the fallback `payloadAtCommitBoundary`/`accessibilityWritePayload`
+  /// reach for when a revalidation at the FINAL commit boundary finds the
+  /// destination may no longer be what it was when `repair` ran — trusting a
+  /// space omitted for a URL bar that has since scrolled out of focus would
+  /// silently corrupt an ordinary field's text instead. The URL-bar exception
+  /// lives ONLY in the candidate `repair` offers (`.trailingSpaceSkipped` in
+  /// `contextualPayload`), which Services re-verifies is still the live
+  /// destination before ever committing it.
   static func legacyPayload(_ text: String) -> String {
     text.hasSuffix(" ") ? text : text + " "
   }
@@ -507,7 +528,9 @@ public enum CursorInsertionRepair {
   ) -> (String, [AppliedRule]) {
     var out = text
     var rules: [AppliedRule] = []
-    guard !text.isEmpty else { return (legacyPayload(text), rules) }
+    guard !text.isEmpty else {
+      return (legacyPayload(text), rules)
+    }
 
     let left = leftAnchor(of: context.left)
     let right = rightAnchor(of: context.right)
@@ -530,6 +553,19 @@ public enum CursorInsertionRepair {
     // not typing a space, then dictating — is user-controlled and already how
     // the app behaves next to a period, which users understand because they
     // caused it.
+    // Rule 1 is DELIBERATELY untouched by the URL-bar flag (#2258, and this
+    // is the settled answer after two review rounds pulled in opposite
+    // directions). Round 1 asked for a leading-space exception too, reasoning
+    // from a URL continuation ("github.com/|" then "issues" should join with
+    // no space). Round 2 then found that suppressing it unconditionally
+    // corrupts an address bar SEARCH query the same way: "best|" then
+    // "restaurants" becomes "bestrestaurants" rather than "best restaurants"
+    // — a browser's address bar is both a URL field and a search field, and
+    // plain left-context text cannot tell which one a continuation is
+    // extending. Merging two dictated words with no separator is worse than
+    // leaving one avoidable space in the narrower URL-continuation case,
+    // which is not a regression — it is exactly today's pre-#2258 behavior.
+    // Scoped to the TRAILING space only, matching the issue's own "Ask".
     if !context.isScreenDerived, language.usesWordSpacing, let anchor = left.character,
       !left.crossedSpace, !left.isOpener,
       let firstCharacter = out.first, !firstCharacter.isWhitespace
@@ -628,7 +664,15 @@ public enum CursorInsertionRepair {
     }
 
     // Rule 3: a trailing space, unless what follows makes it wrong.
-    if !language.usesWordSpacing {
+    //
+    // The URL-bar check comes FIRST and unconditionally, ahead of the
+    // right-anchor checks below (#2258): a space anywhere in a browser's
+    // address bar blocks pressing Enter to navigate, whatever character
+    // happens to sit to the right of the caret. `legacyPayload` carries the
+    // same exception, since a refusal earlier in `repair` falls back to it.
+    if context.isURLBarField {
+      rules.append(.trailingSpaceSkipped(.browserAddressBar))
+    } else if !language.usesWordSpacing {
       rules.append(.trailingSpaceSkipped(.unsegmentedScript))
     } else if let anchor = right {
       if anchor.isWhitespace {

--- a/Sources/EnviousWisprServices/BrowserAddressBarDetector.swift
+++ b/Sources/EnviousWisprServices/BrowserAddressBarDetector.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+/// Whether the focused element is a browser's URL/address bar, never merely
+/// "is a text field inside a browser". #2258.
+///
+/// Two conditions, both required, in the same veto-first shape as
+/// `TerminalSurface`: the owning app must be one of the handful of browsers
+/// actually measured, and the element's OWN signature must match that
+/// browser's address field. `AXRole`/`AXSubrole` alone cannot tell an address
+/// bar from an ordinary field — both Chrome and Safari expose a bare
+/// `AXTextField` with no subrole (measured live 2026-08-21) — so a browser not
+/// in the allowlist never reaches the signature check at all, and an ordinary
+/// web page text field inside a recognized browser (its `AXDOMClassList` is
+/// whatever the page's own DOM renders, never the omnibox's) is refused by the
+/// signature rather than by the app gate.
+///
+/// The app gate is deliberately checkable WITHOUT an accessibility call
+/// (`family(forBundleIdentifier:)`, below), so a caller can reject an
+/// unrecognized app before spending a cross-process AX round trip on it
+/// (Codex review r1, #2258): every AX attribute read carries up to the
+/// element's 0.5-second messaging timeout on failure, and this feature runs
+/// on every smart-insertion paste, not only in a browser.
+package enum BrowserAddressBarDetector {
+  /// Which family of browser owns the focused element, and therefore which
+  /// AX attribute is worth reading — never both, since each family exposes
+  /// only its own signal. `nil` for anything not recognized at all.
+  package enum Family: Sendable {
+    case safari
+    case chromium
+  }
+
+  /// Safari/WebKit's fixed accessibility identifier for the field, measured
+  /// 2026-08-21 live on Safari. AX identifiers are code constants, not
+  /// translated strings.
+  static let safariAddressBarIdentifier = "WEB_BROWSER_ADDRESS_AND_SEARCH_FIELD"
+
+  private static let safariBundleIdentifiers: Set<String> = ["com.apple.safari"]
+
+  /// Chromium's own view-class name for its address bar, measured 2026-08-21
+  /// live on Chrome (`OmniboxViewViews`) and Brave (`BraveOmniboxViewViews`)
+  /// via `AXDOMClassList`. A C++ class name from Chromium's shared views
+  /// toolkit, not a translated string — unlike `AXDescription`
+  /// ("Address and search bar" on both, measured identical), which IS a
+  /// translated accessibility label and would silently disable this feature
+  /// for every non-English system locale. Matched as a SUFFIX, not exact, so
+  /// a vendor subclass (Brave's `Brave` prefix) still matches.
+  static let chromiumOmniboxDOMClassSuffix = "OmniboxViewViews"
+
+  /// Bundle identifiers measured, or confidently inferred, to expose the
+  /// Chromium signature above.
+  ///
+  /// Chrome was measured directly. Brave was measured to confirm the
+  /// signature generalizes to a vendor subclass rather than being
+  /// Chrome-specific. Edge is included unmeasured: it is a Chromium fork
+  /// with a strong track record of keeping upstream view-class names, and
+  /// the suffix check already tolerates a renamed subclass — a false
+  /// negative here costs nothing beyond today's behavior.
+  ///
+  /// Arc and Firefox are deliberately absent. Arc's address affordance is a
+  /// materially different UI (a floating command bar, not a persistent
+  /// field), and Firefox uses Gecko's accessibility layer, not Chromium's —
+  /// neither is safe to assume from a Chromium measurement, and neither was
+  /// installed on the measuring machine. Adding either needs its own live
+  /// measurement, not an extension of this list by inference (#2258).
+  private static let chromiumBundleIdentifiers: Set<String> = [
+    "com.google.chrome",
+    "com.brave.browser",
+    "com.microsoft.edgemac",
+  ]
+
+  /// Every recognized bundle identifier, lowercased, across both families —
+  /// for callers that only need "is this app worth asking at all", such as
+  /// tests pinning what is deliberately absent.
+  package static var recognizedBundleIdentifiers: Set<String> {
+    safariBundleIdentifiers.union(chromiumBundleIdentifiers)
+  }
+
+  /// Which family owns `bundleIdentifier`, with NO accessibility call — the
+  /// cheap half of the two-factor check, meant to run before any AX read.
+  package static func family(forBundleIdentifier bundleIdentifier: String?) -> Family? {
+    guard let bundleIdentifier else { return nil }
+    let normalized = bundleIdentifier.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    guard !normalized.isEmpty else { return nil }
+    if safariBundleIdentifiers.contains(normalized) { return .safari }
+    if chromiumBundleIdentifiers.contains(normalized) { return .chromium }
+    return nil
+  }
+
+  /// - Parameters:
+  ///   - bundleIdentifier: the bundle identifier of the app OWNING the
+  ///     focused element — never the system's frontmost app, which can
+  ///     differ from it (a focused element captured moments earlier, or a
+  ///     system-wide read proxying to the wrong window).
+  ///   - axIdentifier: `AXIdentifier` of the focused element, if readable.
+  ///   - axDOMClassList: `AXDOMClassList` of the focused element, if the app
+  ///     exposes it at all — Chromium browsers only; Safari and non-browser
+  ///     apps report `nil`.
+  package static func matches(
+    bundleIdentifier: String?,
+    axIdentifier: String?,
+    axDOMClassList: [String]?
+  ) -> Bool {
+    switch family(forBundleIdentifier: bundleIdentifier) {
+    case .safari:
+      return axIdentifier == safariAddressBarIdentifier
+    case .chromium:
+      guard let axDOMClassList else { return false }
+      return axDOMClassList.contains(where: { $0.hasSuffix(chromiumOmniboxDOMClassSuffix) })
+    case nil:
+      return false
+    }
+  }
+}

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -606,7 +606,16 @@ public enum PasteService {
       caretUnchanged
   ) -> (text: String, kind: PastePayloadKind) {
     guard let repaired, let context, let element else { return (legacy, .legacy) }
-    guard candidateDeletesDictatedText || requireCaretUnchanged else {
+    // A URL-bar candidate is ALSO forced through revalidation (#2258, cloud
+    // review r3), even though it never deletes dictated text: activating the
+    // target app can move focus (the comment at every call site of this
+    // function already says so), and a space omitted for a URL bar that is no
+    // longer the destination would silently reach an ordinary field missing
+    // the separator it was dictated with. `legacy` is safe either way — it
+    // is deliberately never URL-bar-aware (see `legacyPayload`'s own doc
+    // comment) — so falling back to it here costs nothing extra to guard.
+    guard candidateDeletesDictatedText || requireCaretUnchanged || context.isBrowserAddressBar
+    else {
       return (repaired, .repaired)
     }
     guard caretUnchangedCheck(element, context, terminalBudget)
@@ -683,12 +692,18 @@ public enum PasteService {
     /// DELETES a dictated word.
     package let leftReachesDocumentStart: Bool
 
+    /// Whether the focused element is a recognized browser's URL/address bar
+    /// (#2258), per `BrowserAddressBarDetector`. Always `false` for a
+    /// terminal-derived context — a terminal is never a browser.
+    package let isBrowserAddressBar: Bool
+
     /// Whether this context was derived from a terminal screen.
     package var isScreenDerived: Bool { terminalEvidence != nil }
 
     package init(
       leftWindow: String, rightWindow: String, selectionLocation: Int, selectionLength: Int,
-      leftReachesDocumentStart: Bool, terminalEvidence: TerminalEvidence? = nil
+      leftReachesDocumentStart: Bool, terminalEvidence: TerminalEvidence? = nil,
+      isBrowserAddressBar: Bool = false
     ) {
       self.leftWindow = leftWindow
       self.rightWindow = rightWindow
@@ -696,6 +711,7 @@ public enum PasteService {
       self.selectionLength = selectionLength
       self.leftReachesDocumentStart = leftReachesDocumentStart
       self.terminalEvidence = terminalEvidence
+      self.isBrowserAddressBar = isBrowserAddressBar
     }
   }
 
@@ -1201,14 +1217,136 @@ public enum PasteService {
 
     guard let range = bounded("range", { selectedRange(of: fresh) }) else { return nil }
 
-    return assembleCaretContext(
-      characterCount: characterCount,
-      selectionLocation: range.location,
-      selectionLength: range.length,
-      window: window,
-      readRange: { location, length in
-        bounded("range_read", { string(of: fresh, at: location, length: length) })
-      })
+    guard
+      let assembled = assembleCaretContext(
+        characterCount: characterCount,
+        selectionLocation: range.location,
+        selectionLength: range.length,
+        window: window,
+        readRange: { location, length in
+          bounded("range_read", { string(of: fresh, at: location, length: length) })
+        })
+    else { return nil }
+
+    let isBrowserAddressBar = bounded(
+      "browser_address_bar", { browserAddressBarSignature(of: fresh) })
+    guard isBrowserAddressBar else { return assembled }
+    return CaretContext(
+      leftWindow: assembled.leftWindow, rightWindow: assembled.rightWindow,
+      selectionLocation: assembled.selectionLocation, selectionLength: assembled.selectionLength,
+      leftReachesDocumentStart: assembled.leftReachesDocumentStart,
+      terminalEvidence: assembled.terminalEvidence, isBrowserAddressBar: true)
+  }
+
+  /// A PID→bundle-ID lookup on the SAME element already in hand (never a
+  /// second focused-element round trip), THEN — only for a recognized
+  /// browser — exactly one AX attribute read, the one that browser's own
+  /// family actually exposes. #2258; signature owned by
+  /// `BrowserAddressBarDetector`.
+  ///
+  /// The bundle-ID check costs no accessibility call at all, so it runs
+  /// FIRST (Codex review r1): every AX attribute read here can carry up to
+  /// the element's 0.5-second messaging timeout on failure, and this runs on
+  /// every smart-insertion paste, in every app, not only in a browser — an
+  /// unrecognized app must never pay for a read whose answer cannot matter.
+  ///
+  /// The signature ALONE is not enough (cloud review, PR #2272): `AXDOMClassList`
+  /// mirrors the rendered page's own HTML `class` attribute for a DOM element, so
+  /// an ordinary — or deliberately adversarial — web page could name one of its
+  /// own fields `OmniboxViewViews` and pass the suffix check outright. Measured
+  /// live 2026-08-21: a real page field's AX ancestor chain reaches `AXWebArea`
+  /// (Google's search box, depth 7); the real omnibox's chain never does, because
+  /// it is native browser chrome, never rendered page content — page HTML cannot
+  /// remove a wrapper Chromium itself inserts around everything it renders. So a
+  /// signature match is trusted only once the ancestor chain is POSITIVELY
+  /// verified clean of `AXWebArea`.
+  private static func browserAddressBarSignature(of element: AXUIElement) -> Bool {
+    var pid: pid_t = 0
+    guard AXUIElementGetPid(element, &pid) == .success else { return false }
+    let bundleIdentifier = NSRunningApplication(processIdentifier: pid)?.bundleIdentifier
+    guard let family = BrowserAddressBarDetector.family(forBundleIdentifier: bundleIdentifier)
+    else { return false }
+
+    let signatureMatches: Bool
+    switch family {
+    case .safari:
+      var identifierRef: CFTypeRef?
+      let axIdentifier: String? =
+        AXUIElementCopyAttributeValue(element, kAXIdentifierAttribute as CFString, &identifierRef)
+          == .success
+        ? identifierRef as? String : nil
+      signatureMatches = BrowserAddressBarDetector.matches(
+        bundleIdentifier: bundleIdentifier, axIdentifier: axIdentifier, axDOMClassList: nil)
+    case .chromium:
+      var domClassRef: CFTypeRef?
+      let axDOMClassList: [String]? =
+        AXUIElementCopyAttributeValue(element, "AXDOMClassList" as CFString, &domClassRef)
+          == .success
+        ? domClassRef as? [String] : nil
+      signatureMatches = BrowserAddressBarDetector.matches(
+        bundleIdentifier: bundleIdentifier, axIdentifier: nil, axDOMClassList: axDOMClassList)
+    }
+    guard signatureMatches else { return false }
+    return ancestorChainVerifiedFreeOfWebArea(element)
+  }
+
+  /// Whether `element`'s AX ancestor chain can be POSITIVELY VERIFIED clean of
+  /// any `AXWebArea` — the wrapper both Chromium and WebKit insert around every
+  /// rendered page. Its presence means the element is PAGE CONTENT, never
+  /// native browser chrome, whatever its own reported signature claims.
+  ///
+  /// FAILS CLOSED, deliberately positive-framed rather than the inverted
+  /// `hasWebAreaAncestor` this replaced (cloud review r2, PR #2272): that
+  /// version returned `false` on BOTH "found a web area" and "a read failed
+  /// partway up the chain", and the caller NEGATED it — so an incomplete walk
+  /// was silently TRUSTED, exactly backwards from the fail-closed design the
+  /// comment claimed. This version returns `true` in exactly one case: every
+  /// read up the chain succeeded, none was `AXWebArea`, and the chain reached
+  /// a REAL, verified end. Every other outcome — a role read failing, a
+  /// parent read failing for any reason other than "this object genuinely has
+  /// no parent", or the bound running out before reaching a verified end — is
+  /// UNVERIFIED and returns `false`, refusing the match.
+  ///
+  /// "Genuinely has no parent" is `.attributeUnsupported` specifically, not
+  /// any failure — measured live 2026-08-21 walking the real omnibox's whole
+  /// chain to `AXApplication`, where `AXParent` fails with exactly that code
+  /// (`-25205`). Any OTHER error (a stale element, a timed-out IPC call) means
+  /// the walk was cut short, not that it reached the top, and must not be
+  /// read as verification — the existing `.attributeUnsupported`/`.noValue`
+  /// idiom in `firstPasteItem` above draws the same distinction one type over.
+  private static func ancestorChainVerifiedFreeOfWebArea(
+    _ element: AXUIElement, maxDepth: Int = 10
+  ) -> Bool {
+    var current = element
+    var depth = 0
+    while depth < maxDepth {
+      var roleRef: CFTypeRef?
+      guard
+        AXUIElementCopyAttributeValue(current, kAXRoleAttribute as CFString, &roleRef) == .success,
+        let role = roleRef as? String
+      else { return false }
+      if role == "AXWebArea" { return false }
+
+      var parentRef: CFTypeRef?
+      let parentRead = AXUIElementCopyAttributeValue(
+        current, kAXParentAttribute as CFString, &parentRef)
+      if parentRead == .attributeUnsupported || parentRead == .noValue {
+        // A missing parent is only proof of reaching the TOP when the current
+        // element genuinely IS the application root (cloud review r3, PR
+        // #2272): otherwise an intermediate element reporting the same two
+        // codes — for whatever reason, including a page-content quirk — would
+        // be read as "verified clean" without ever having been checked past
+        // this point. `role` is already in hand from this same iteration.
+        return role == "AXApplication"
+      }
+      guard parentRead == .success, let parentRef,
+        CFGetTypeID(parentRef) == AXUIElementGetTypeID()
+      else { return false }
+      // swift-format-ignore: NeverForceUnwrap — guarded by the CFGetTypeID check above.
+      current = (parentRef as! AXUIElement)
+      depth += 1
+    }
+    return false
   }
 
   /// Exact UTF-16 code-unit identity.

--- a/Tests/EnviousWisprTests/PostProcessing/CursorInsertionRepairTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CursorInsertionRepairTests.swift
@@ -1722,4 +1722,130 @@ struct CursorInsertionRepairTests {
         left: left, right: "", leftReachesDocumentStart: reaches, isScreenDerived: true),
       protectedWords: [], language: "en", oracle: Self.prototypeOracle)
   }
+
+  // MARK: - #2258 URL bar: Rule 1 (leading space) is deliberately UNCHANGED
+
+  @Test(
+    "A URL-bar continuation still gains a leading space — the settled answer after two review rounds"
+  )
+  func urlBarContinuationStillGainsLeadingSpace() {
+    // Round 1 asked for a leading-space exception too, reasoning from a URL
+    // continuation ("github.com/|" then "issues" should join with no space).
+    // Round 2 found that unconditional suppression corrupts a SEARCH
+    // continuation the same way ("best|" then "restaurants" becomes
+    // "bestrestaurants"), because the address bar is both a URL field and a
+    // search field and plain text cannot tell which one is being continued.
+    // Merging two dictated words is worse than one avoidable space, and
+    // leaving Rule 1 alone here is not a regression — it is exactly the
+    // behavior that existed before #2258.
+    let payloads = CursorInsertionRepair.repair(
+      text: "issues",
+      context: CursorInsertionRepair.CaretText(left: "github.com/", right: "", isURLBarField: true),
+      protectedWords: [], language: "en", oracle: Self.prototypeOracle)
+    #expect(payloads.repairedText == " issues")
+    #expect(payloads.candidateRules.contains(.leadingSpace))
+  }
+
+  @Test("A URL-bar search-query continuation is not corrupted — the case round 2 caught")
+  func urlBarSearchContinuationIsNotMerged() {
+    let payloads = CursorInsertionRepair.repair(
+      text: "restaurants",
+      context: CursorInsertionRepair.CaretText(left: "best", right: "", isURLBarField: true),
+      protectedWords: [], language: "en", oracle: Self.prototypeOracle)
+    // The separator survives — never "bestrestaurants".
+    #expect(payloads.repairedText == " restaurants")
+    #expect(payloads.candidateRules.contains(.leadingSpace))
+  }
+
+  // MARK: - #2258 URL bar: no trailing space on the CANDIDATE, legacy stays context-free
+
+  @Test("A URL bar's contextual candidate carries no trailing space, empty caret")
+  func urlBarCandidateHasNoTrailingSpace() {
+    let payloads = CursorInsertionRepair.repair(
+      text: "github.com",
+      context: CursorInsertionRepair.CaretText(left: "", right: "", isURLBarField: true),
+      protectedWords: [], language: "en", oracle: Self.prototypeOracle)
+    #expect(payloads.repairedText == "github.com")
+    #expect(payloads.candidateRules.contains(.trailingSpaceSkipped(.browserAddressBar)))
+    // `legacyText` is DELIBERATELY context-free (cloud review r3, PR #2272):
+    // it is the safe fallback Services reaches for when a commit-boundary
+    // revalidation finds the destination may no longer be the URL bar this
+    // candidate was computed for, so it must never itself carry the
+    // suppression — see `legacyPayload`'s own doc comment.
+    #expect(payloads.legacyText == "github.com ")
+  }
+
+  @Test(
+    "A URL bar suppresses the trailing space regardless of what follows the caret",
+    arguments: ["", " ", ".", "x"])
+  func urlBarSuppressesTrailingSpaceForEveryRightContext(_ right: String) {
+    // The guard must be UNCONDITIONAL — checked ahead of the right-anchor
+    // rules, not merely added as one more case of them. An ordinary field
+    // would append a space for the last two arguments here. `left` ends in a
+    // non-word character (a slash, as after a URL path segment) so a
+    // word-character `right` cannot instead trip the separate mid-word
+    // refusal — that refusal is its own case, in `CursorInsertionRepairTests`
+    // generally, and is orthogonal to this guard.
+    let payloads = CursorInsertionRepair.repair(
+      text: "github.com",
+      context: CursorInsertionRepair.CaretText(left: "/", right: right, isURLBarField: true),
+      protectedWords: [], language: "en", oracle: Self.prototypeOracle)
+    #expect(payloads.repairedText?.hasSuffix(" ") == false)
+    #expect(payloads.candidateRules.contains(.trailingSpaceSkipped(.browserAddressBar)))
+  }
+
+  @Test(
+    "A URL bar with residual right-side text and no left anchor refuses; legacy is unaffected",
+    arguments: [".", "x"])
+  func urlBarNoLeftAnchorRefusesAndLegacyIsPlain(_ right: String) {
+    // Caret at the very start of the field with existing text after it (e.g.
+    // an autocomplete suggestion) is refused by an earlier, URL-bar-agnostic
+    // guard — `repair`'s own "nothing real to the left, something real to the
+    // right" rule — before Rule 3 is ever reached. There is no candidate to
+    // revalidate here, so `legacyText` is exactly what it always is.
+    let payloads = CursorInsertionRepair.repair(
+      text: "github.com",
+      context: CursorInsertionRepair.CaretText(left: "", right: right, isURLBarField: true),
+      protectedWords: [], language: "en", oracle: Self.prototypeOracle)
+    #expect(payloads.candidateRules == [.refusedNoLeftAnchor])
+    #expect(payloads.repairedText == nil)
+    #expect(payloads.legacyText == "github.com ")
+  }
+
+  @Test("A URL bar's legacy fallback is plain when the contextual candidate is refused")
+  func urlBarLegacyFallbackIsPlainOnRefusal() {
+    // Caret sits inside a word ("gith|ub.com", both sides real word
+    // characters) — the contextual candidate is refused, so the caller falls
+    // back to `legacyText`, which never carries the URL-bar exception. The
+    // narrower cost this accepts (mid-word caret in a URL bar keeps its
+    // space, same as before #2258) is deliberate — see `legacyPayload`.
+    let payloads = CursorInsertionRepair.repair(
+      text: "-",
+      context: CursorInsertionRepair.CaretText(left: "gith", right: "ub.com", isURLBarField: true),
+      protectedWords: [], language: "en", oracle: Self.prototypeOracle)
+    #expect(payloads.candidateRules == [.refusedInsideWord])
+    #expect(payloads.repairedText == nil)
+    #expect(payloads.legacyText == "- ")
+  }
+
+  @Test("A non-URL-bar field is unaffected — regression pin")
+  func nonURLBarFieldStillGetsTrailingSpace() {
+    let payloads = CursorInsertionRepair.repair(
+      text: "github.com",
+      context: CursorInsertionRepair.CaretText(left: "", right: "", isURLBarField: false),
+      protectedWords: [], language: "en", oracle: Self.prototypeOracle)
+    #expect(payloads.repairedText == "github.com ")
+    #expect(payloads.candidateRules.contains(.trailingSpace))
+    #expect(payloads.legacyText == "github.com ")
+  }
+
+  @Test("legacyOnly is always context-free, even for a URL-bar caller")
+  func legacyOnlyIsAlwaysPlain() {
+    // The deadline-bypass path (#1946) bypasses `repair` entirely and has no
+    // revalidation opportunity of its own — it inherits the same
+    // context-free contract every other `legacyText` carries.
+    let payloads = CursorInsertionRepair.legacyOnly(
+      text: "github.com", reason: .languageNotSupported)
+    #expect(payloads.legacyText == "github.com ")
+  }
 }

--- a/Tests/EnviousWisprTests/Services/BrowserAddressBarDetectorTests.swift
+++ b/Tests/EnviousWisprTests/Services/BrowserAddressBarDetectorTests.swift
@@ -1,0 +1,126 @@
+import Testing
+
+@testable import EnviousWisprServices
+
+// #2258: whether the focused element is a browser's URL/address bar. Product
+// outcome — when this misses, the user gets a trailing space that blocks
+// pressing Enter to navigate; when it misfires on an ordinary web field, the
+// user silently loses a space they dictated.
+@Suite("BrowserAddressBarDetector", .tags(.productOutcome))
+struct BrowserAddressBarDetectorTests {
+
+  @Test("Safari's fixed AXIdentifier matches")
+  func safariIdentifierMatches() {
+    #expect(
+      BrowserAddressBarDetector.matches(
+        bundleIdentifier: "com.apple.Safari",
+        axIdentifier: "WEB_BROWSER_ADDRESS_AND_SEARCH_FIELD",
+        axDOMClassList: nil))
+  }
+
+  @Test("Chrome's exact Chromium DOM class matches")
+  func chromeDOMClassMatches() {
+    #expect(
+      BrowserAddressBarDetector.matches(
+        bundleIdentifier: "com.google.Chrome",
+        axIdentifier: nil,
+        axDOMClassList: ["OmniboxViewViews"]))
+  }
+
+  @Test("Brave's vendor-subclassed DOM class matches via suffix")
+  func braveVendorSubclassMatches() {
+    #expect(
+      BrowserAddressBarDetector.matches(
+        bundleIdentifier: "com.brave.Browser",
+        axIdentifier: nil,
+        axDOMClassList: ["BraveOmniboxViewViews"]))
+  }
+
+  @Test("bundle identifier comparison is case-insensitive")
+  func bundleIdentifierIsCaseInsensitive() {
+    #expect(
+      BrowserAddressBarDetector.matches(
+        bundleIdentifier: "COM.GOOGLE.CHROME",
+        axIdentifier: nil,
+        axDOMClassList: ["OmniboxViewViews"]))
+  }
+
+  @Test("an unrecognized app never reaches the signature check, even with a matching signature")
+  func unrecognizedBundleRefusesDespiteMatchingSignature() {
+    // The veto: some unrelated third-party app coincidentally exposing an
+    // identically-named view must not be trusted just because the string
+    // matches. This is the case the two-factor design exists for.
+    #expect(
+      !BrowserAddressBarDetector.matches(
+        bundleIdentifier: "com.example.SomeOtherApp",
+        axIdentifier: "WEB_BROWSER_ADDRESS_AND_SEARCH_FIELD",
+        axDOMClassList: ["OmniboxViewViews"]))
+  }
+
+  @Test("a recognized browser with no matching signature refuses — an ordinary web field")
+  func recognizedBrowserWithoutSignatureRefuses() {
+    // A Gmail compose box inside Chrome: same app, same AXRole family, but
+    // its own DOM class list, not the omnibox's.
+    #expect(
+      !BrowserAddressBarDetector.matches(
+        bundleIdentifier: "com.google.Chrome",
+        axIdentifier: nil,
+        axDOMClassList: ["gmail-compose-textarea", "editable"]))
+  }
+
+  @Test("all-nil inputs refuse")
+  func allNilInputsRefuse() {
+    #expect(
+      !BrowserAddressBarDetector.matches(
+        bundleIdentifier: nil, axIdentifier: nil, axDOMClassList: nil))
+  }
+
+  @Test("Firefox and Arc are not recognized — not measured, per #2258")
+  func unmeasuredBrowsersAreNotRecognized() {
+    #expect(!BrowserAddressBarDetector.recognizedBundleIdentifiers.contains("org.mozilla.firefox"))
+    #expect(
+      !BrowserAddressBarDetector.recognizedBundleIdentifiers.contains("company.thebrowser.browser"))
+  }
+
+  // MARK: - family(forBundleIdentifier:) — the cheap, no-AX-call half (Codex review r1)
+
+  @Test("Safari's bundle resolves to the .safari family")
+  func safariResolvesToSafariFamily() {
+    #expect(BrowserAddressBarDetector.family(forBundleIdentifier: "com.apple.Safari") == .safari)
+  }
+
+  @Test(
+    "Every Chromium bundle resolves to the .chromium family",
+    arguments: ["com.google.Chrome", "com.brave.Browser", "com.microsoft.edgemac"])
+  func chromiumBundlesResolveToChromiumFamily(_ bundleIdentifier: String) {
+    #expect(BrowserAddressBarDetector.family(forBundleIdentifier: bundleIdentifier) == .chromium)
+  }
+
+  @Test("An unrecognized or nil bundle resolves to no family at all")
+  func unrecognizedBundleResolvesToNoFamily() {
+    #expect(
+      BrowserAddressBarDetector.family(forBundleIdentifier: "com.example.SomeOtherApp") == nil)
+    #expect(BrowserAddressBarDetector.family(forBundleIdentifier: nil) == nil)
+  }
+
+  @Test("A Safari-family match ignores an incidentally-supplied DOM class list")
+  func safariFamilyIgnoresDOMClassList() {
+    // Family gates which SIGNAL is even consulted, not merely which one is
+    // checked first — Safari's own process should never expose Chromium's
+    // internal view-class list, so a stray one must not be trusted.
+    #expect(
+      !BrowserAddressBarDetector.matches(
+        bundleIdentifier: "com.apple.Safari",
+        axIdentifier: nil,
+        axDOMClassList: ["OmniboxViewViews"]))
+  }
+
+  @Test("A Chromium-family match ignores an incidentally-supplied AXIdentifier")
+  func chromiumFamilyIgnoresAXIdentifier() {
+    #expect(
+      !BrowserAddressBarDetector.matches(
+        bundleIdentifier: "com.google.Chrome",
+        axIdentifier: "WEB_BROWSER_ADDRESS_AND_SEARCH_FIELD",
+        axDOMClassList: nil))
+  }
+}

--- a/Tests/EnviousWisprTests/Services/TerminalInsertionPolicyTests.swift
+++ b/Tests/EnviousWisprTests/Services/TerminalInsertionPolicyTests.swift
@@ -461,4 +461,72 @@ struct TerminalInsertionPolicyTests {
     #expect(!seamCalled, "requireCaretUnchanged defaults to false and must not invoke the seam")
   }
 
+  // MARK: - #2258 URL bar: forced revalidation at the commit boundary
+
+  private func browserAddressBarContext(left: String, right: String = "")
+    -> PasteService.CaretContext
+  {
+    PasteService.CaretContext(
+      leftWindow: left, rightWindow: right,
+      selectionLocation: left.utf16.count, selectionLength: 0,
+      leftReachesDocumentStart: true,
+      isBrowserAddressBar: true)
+  }
+
+  @Test("A URL-bar candidate IS forced through revalidation, even though it deletes no text")
+  func urlBarCandidateIsForcedThroughRevalidation() {
+    // Cloud review, PR #2272: activating the target app (Tier 2) can move
+    // focus away from the URL bar `repair` read, and `legacy` is
+    // deliberately never URL-bar-aware — so trusting a spacing-only
+    // candidate here without revalidation risks a stale suppression landing
+    // in a field that is no longer the address bar.
+    let payload = PasteService.payloadAtCommitBoundary(
+      legacy: "github.com ",
+      repaired: "github.com",
+      context: browserAddressBarContext(left: ""),
+      element: AXUIElementCreateSystemWide(),
+      candidateDeletesDictatedText: false,
+      caretUnchangedCheck: { _, _, _ in false })
+
+    #expect(payload.kind == .legacy, "a URL-bar candidate must be re-verified before commit")
+    #expect(payload.text == "github.com ", "the safe fallback keeps its trailing space")
+  }
+
+  @Test("A URL-bar candidate commits once revalidation confirms the caret is unchanged")
+  func urlBarCandidateCommitsWhenConfirmedUnchanged() {
+    let payload = PasteService.payloadAtCommitBoundary(
+      legacy: "github.com ",
+      repaired: "github.com",
+      context: browserAddressBarContext(left: ""),
+      element: AXUIElementCreateSystemWide(),
+      candidateDeletesDictatedText: false,
+      caretUnchangedCheck: { _, _, _ in true })
+
+    #expect(payload.kind == .repaired)
+    #expect(payload.text == "github.com")
+  }
+
+  @Test("An ordinary, non-URL-bar spacing-only candidate is NOT forced through revalidation")
+  func ordinaryCandidateSkipsForcedRevalidation() {
+    // Two-way control: the new trigger is scoped to `isBrowserAddressBar`,
+    // not to every spacing decision. Same shape as
+    // `casingCandidateSkipsTheReread` above, with the seam instrumented to
+    // prove it is never even called (the real check would refuse in a test
+    // process, which would make this pass for the wrong reason).
+    var seamCalled = false
+    let payload = PasteService.payloadAtCommitBoundary(
+      legacy: "github.com ",
+      repaired: "github.com",
+      context: terminalContext(line: "typing a plain sentence"),
+      element: AXUIElementCreateSystemWide(),
+      candidateDeletesDictatedText: false,
+      caretUnchangedCheck: { _, _, _ in
+        seamCalled = true
+        return false
+      })
+
+    #expect(payload.kind == .repaired)
+    #expect(!seamCalled, "an ordinary candidate must not pay for the URL-bar revalidation")
+  }
+
 }


### PR DESCRIPTION
## Summary
- Dictating into a recognized browser's address bar (Safari, Chrome, Brave, Edge) no longer gets the trailing space every other field gets, so a dictated URL can be entered immediately without a manual edit first.
- Two-factor detection: the owning app must be a recognized browser AND the focused element's own signature must match that browser's address field (Safari's fixed AXIdentifier, or Chromium's `OmniboxViewViews` DOM class, matched by suffix). Live-measured against Safari, Chrome, and Brave. The bundle-ID check runs first with no accessibility call, so an unrecognized app never pays for the AX read that follows.
- Leading-space suppression was tried and deliberately reverted — see the plan doc §8 for why (it corrupts an address-bar search-query continuation like "best" + "restaurants").

Closes #2258.

## Test plan
- [x] `BrowserAddressBarDetectorTests` (new) — signature matching, the app-recognition veto, the cheap `family(forBundleIdentifier:)` gate.
- [x] `CursorInsertionRepairTests` additions — trailing-space suppression (contextual + legacy fallback + deadline-bypass paths), Rule 1 deliberately unaffected (with a search-continuation regression pin).
- [x] Full Xcode Debug (6340 tests) + Release (5773 tests) lane, green.
- [x] Three rounds of local Codex diff review — two real findings fixed (leading-space gap found in r1, then reverted after r2 showed it corrupts search continuations; AX-read-ordering perf), r3 confirming clean.
- [ ] Cloud Codex review.
- [ ] Live UAT on the rebuilt app (Safari/Chrome address bar, dictate a URL, confirm no trailing space and Enter navigates).

Plan: `docs/feature-requests/issue-2258-2026-08-21-url-bar-space.md` (gitignored, lives in the main checkout).
