### PR TITLE
fix(recovery): identify pending shadows by decoded identity

### DIFF
--- a/Sources/EnviousWisprStorage/TranscriptStore.swift
+++ b/Sources/EnviousWisprStorage/TranscriptStore.swift
@@ -329,6 +329,24 @@ public final class TranscriptStore {
     return transcript.recoverySessionID
   }
 
+  /// A pending row is a shadow only when the permanent row names the same
+  /// transcript and the same recovery session. A matching filename alone is
+  /// not identity: a corrupt pending filename can collide with an unrelated
+  /// permanent row, and deleting it would discard the de-dup proof for its
+  /// still-live spool (#2256).
+  private nonisolated static func hasPermanentTwin(
+    for candidate: PendingCandidate, in permanentDir: URL
+  ) -> Bool {
+    guard
+      let pendingData = try? Data(contentsOf: candidate.url),
+      let pending = try? JSONDecoder().decode(Transcript.self, from: pendingData),
+      let permanentData = try? Data(
+        contentsOf: permanentDir.appendingPathComponent(candidate.url.lastPathComponent)),
+      let permanent = try? JSONDecoder().decode(Transcript.self, from: permanentData)
+    else { return false }
+    return pending.id == permanent.id && pending.recoverySessionID == permanent.recoverySessionID
+  }
+
   private nonisolated static func spoolIDsFromDisk() -> Set<String>? {
     guard let ids = try? RecoverySpoolStore().listSpoolSessionIDs() else { return nil }
     return Set(ids)
@@ -376,20 +394,31 @@ public final class TranscriptStore {
     // proof precisely when we cannot see what it protects. Rows carrying no
     // recovery id are unaffected either way — nothing can replay them.
 
-    let liveCandidates = candidates.filter(\.isLive)
+    // A successful Keep writes the permanent row before it best-effort removes
+    // the pending one. Clear any true shadows before taking the live count: a
+    // leftover live copy must neither be re-offered nor keep the pulse walking
+    // the directory until its original deadline (#2256).
+    var sweepCandidates: [PendingCandidate] = []
+    var survivingLiveShadows: [PendingCandidate] = []
+    for candidate in candidates {
+      guard hasPermanentTwin(for: candidate, in: permanentDir) else {
+        sweepCandidates.append(candidate)
+        continue
+      }
+      try? fm.removeItem(at: candidate.url)
+      if fm.fileExists(atPath: candidate.url.path) {
+        unremovable += 1
+        if candidate.isLive { survivingLiveShadows.append(candidate) }
+      } else if let id = UUID(uuidString: candidate.url.deletingPathExtension().lastPathComponent) {
+        deleted.insert(id)
+      }
+    }
+    var liveCandidates = sweepCandidates.filter(\.isLive)
+    liveCandidates.append(contentsOf: survivingLiveShadows)
     let remainingLive = liveCandidates.count
     let nextLiveDeadline = liveCandidates.compactMap { $0.deadline(retention: retention) }.min()
     var retainedForSpool = 0
-    for candidate in candidates where !candidate.isLive {
-      // A permanent twin answers BOTH questions below, so it is asked first.
-      // Local review, P2: with the spool guard ahead of it, a Keep whose shadow
-      // removal failed AND whose spool survived was retained forever — the
-      // permanent row already carries the de-dup key, so the shadow protects
-      // nothing and the pulse walks the directory every minute for the life of
-      // the app. Checked by FILE rather than by loading the row: this runs off
-      // the main actor, and existence is the whole question.
-      let hasPermanentTwin = FileManager.default.fileExists(
-        atPath: permanentDir.appendingPathComponent(candidate.url.lastPathComponent).path)
+    for candidate in sweepCandidates where !candidate.isLive {
       // #2186: this row is the only proof its spool was already recovered.
       // Delete it while the spool survives and the next scan replays that spool
       // as a fresh dictation — handing back the take the user CANCELLED. Retain
@@ -398,32 +427,10 @@ public final class TranscriptStore {
       // The enum answers for `.live`/`.expired`; `.invalid` carries no
       // transcript by design, so ask the FILE with the de-dup reader's own
       // permissive decode. Anything that reader would count, this must protect.
-      if !hasPermanentTwin,
-        let session = candidate.recoverySessionID ?? recoverySessionID(of: candidate.url),
+      if let session = candidate.recoverySessionID ?? recoverySessionID(of: candidate.url),
         spoolIDs.map({ $0.contains(session) }) ?? true
       {
         retainedForSpool += 1
-        continue
-      }
-      // A SHADOW, not an expiry (cloud review). `promotePending` writes the
-      // permanent row first and removes the pending file second, so a crash or a
-      // failed removal in between leaves the stamped copy beside its permanent
-      // twin. Twenty-four hours later this loop would see a stamped row past its
-      // window and emit `escape_recovery.expired` for a dictation the user
-      // pressed KEEP on — the text is safe either way, but the kept-versus-
-      // expired ratio is the one number this funnel exists to produce, and it
-      // would be wrong in the direction that makes the feature look worse.
-      //
-      // Deleted (it is litter) and NOT reported (nothing expired).
-      if hasPermanentTwin {
-        try? fm.removeItem(at: candidate.url)
-        if fm.fileExists(atPath: candidate.url.path) {
-          unremovable += 1
-        } else if let id = UUID(
-          uuidString: candidate.url.deletingPathExtension().lastPathComponent)
-        {
-          deleted.insert(id)
-        }
         continue
       }
       // `removeItem`, NOT `unlink`. A corrupt entry can be a DIRECTORY named

--- a/Sources/EnviousWisprStorage/TranscriptStore.swift
+++ b/Sources/EnviousWisprStorage/TranscriptStore.swift
@@ -359,6 +359,7 @@ public final class TranscriptStore {
     let fm = FileManager.default
     var reported: [ExpiredPendingRow] = []
     var deleted: Set<UUID> = []
+    var clearedShadows = 0
     var unremovable = 0
     // An unreadable directory is reported as an INCOMPLETE walk, never as an
     // empty one. Swallowing it into `[]` produced `unremovable == 0`, which the
@@ -409,8 +410,12 @@ public final class TranscriptStore {
       if fm.fileExists(atPath: candidate.url.path) {
         unremovable += 1
         if candidate.isLive { survivingLiveShadows.append(candidate) }
-      } else if let id = UUID(uuidString: candidate.url.deletingPathExtension().lastPathComponent) {
-        deleted.insert(id)
+      } else {
+        // This file disappeared, but its transcript did not: the permanent
+        // twin is the surviving record. `deletedIDs` is consumed as an
+        // in-memory eviction channel, so putting the shared id there removes
+        // the row the user just kept from History until the next load.
+        clearedShadows += 1
       }
     }
     var liveCandidates = sweepCandidates.filter(\.isLive)
@@ -498,7 +503,7 @@ public final class TranscriptStore {
     return PendingSweepResult(
       deletedIDs: deleted, expired: reported, unremovable: unremovable,
       remainingLive: remainingLive, retainedForSpool: retainedForSpool,
-      nextLiveDeadline: nextLiveDeadline)
+      nextLiveDeadline: nextLiveDeadline, clearedShadows: clearedShadows)
   }
 
   /// Why a pending file is or is not still offered.
@@ -804,9 +809,11 @@ public final class TranscriptStore {
 
 /// What one sweep did (#2087).
 ///
-/// Four fields because they answer four different questions. `deletedIDs` is
+/// The fields answer different questions. `deletedIDs` is
 /// every file the sweep removed — expired AND invalid — and is what a caller
-/// evicts from memory on. `expired` is only the rows a user genuinely let lapse,
+/// evicts from memory on. It deliberately excludes cleared pending shadows,
+/// because their permanent twin is still the user's live record. `expired` is
+/// only the rows a user genuinely let lapse,
 /// and is what telemetry reports: a corrupt file is not a user letting a
 /// recovery go, so it is a strict subset.
 /// `unremovable` is the third: how many files this sweep decided must go and
@@ -868,10 +875,15 @@ public struct PendingSweepResult: Sendable {
   /// counting down.
   public let nextLiveDeadline: Date?
 
+  /// Pending copies removed because the same transcript already survives in
+  /// the permanent store. A count rather than ids because callers must never
+  /// evict the shared transcript identity; this is cleanup evidence only.
+  public let clearedShadows: Int
+
   public init(
     deletedIDs: Set<UUID>, expired: [ExpiredPendingRow], unremovable: Int = 0,
     walkComplete: Bool = true, remainingLive: Int = 0, retainedForSpool: Int = 0,
-    nextLiveDeadline: Date? = nil
+    nextLiveDeadline: Date? = nil, clearedShadows: Int = 0
   ) {
     self.deletedIDs = deletedIDs
     self.expired = expired
@@ -880,6 +892,7 @@ public struct PendingSweepResult: Sendable {
     self.remainingLive = remainingLive
     self.retainedForSpool = retainedForSpool
     self.nextLiveDeadline = nextLiveDeadline
+    self.clearedShadows = clearedShadows
   }
 }
 

--- a/Tests/EnviousWisprTests/App/EscapeRecoveryDiskExpiryTests.swift
+++ b/Tests/EnviousWisprTests/App/EscapeRecoveryDiskExpiryTests.swift
@@ -57,7 +57,8 @@ struct EscapeRecoveryDiskExpiryTests {
       .appendingPathComponent("ew-2186-\(UUID().uuidString)", isDirectory: true)
     return (
       TranscriptStore(directory: directory, liveSpoolIDs: spools),
-      directory)
+      directory
+    )
   }
 
   /// Written from the detached walk and read on the main actor, so it carries
@@ -208,13 +209,40 @@ struct EscapeRecoveryDiskExpiryTests {
         kept row already carries that proof, so this one is litter that is never collected — and \
         the countdown keeps running against it forever.
         """)
-      #expect(swept.deletedIDs.contains(id), "it must be swept as the litter it is")
+      #expect(swept.clearedShadows == 1, "the leftover pending copy was cleared")
+      #expect(
+        !swept.deletedIDs.contains(id),
+        "the shared id still names the permanent row and must not be reported for eviction")
       #expect(
         swept.remainingLive == 0 && swept.nextLiveDeadline == nil,
         "a kept live shadow must not be re-offered or keep the expiry pulse armed")
       #expect(
         swept.expired.isEmpty,
         "and NOT reported as expired — the user kept this dictation, nothing lapsed")
+    }
+
+    @Test("clearing a kept shadow does not evict its permanent History row")
+    func keptLiveShadowPreservesPermanentRowInMemory() async throws {
+      let store = makeStore(spools: { ["session-kept-history"] })
+      let coordinator = makeCoordinator(EventLog(), store: store)
+      let pending = Transcript(
+        id: UUID(), text: "the kept row must stay visible",
+        recoverySessionID: "session-kept-history",
+        escapeRecoveredAt: Date().addingTimeInterval(-60),
+        escapeRecoveryTakeID: "take-kept-history")
+      let permanent = pending.promotedFromPending()
+      try store.savePending(pending)
+      try store.save(permanent)
+      coordinator.setTranscriptsForTesting([permanent])
+
+      await coordinator.sweepExpiredPending()
+
+      #expect(
+        coordinator.visibleTranscripts.map(\.id) == [permanent.id],
+        "clearing the pending shadow must not make the user's kept row disappear from History")
+      #expect(
+        try await store.loadPending().isEmpty,
+        "control: the pending shadow itself was actually removed")
     }
 
     @Test("the recovery folder is never read on the main thread")

--- a/Tests/EnviousWisprTests/App/EscapeRecoveryDiskExpiryTests.swift
+++ b/Tests/EnviousWisprTests/App/EscapeRecoveryDiskExpiryTests.swift
@@ -47,10 +47,17 @@ struct EscapeRecoveryDiskExpiryTests {
   private func makeStore(spools: @escaping @Sendable () -> Set<String>? = { [] })
     -> TranscriptStore
   {
-    TranscriptStore(
-      directory: FileManager.default.temporaryDirectory
-        .appendingPathComponent("ew-2186-\(UUID().uuidString)", isDirectory: true),
-      liveSpoolIDs: spools)
+    makeStoreWithDirectory(spools: spools).store
+  }
+
+  private func makeStoreWithDirectory(
+    spools: @escaping @Sendable () -> Set<String>? = { [] }
+  ) -> (store: TranscriptStore, directory: URL) {
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ew-2186-\(UUID().uuidString)", isDirectory: true)
+    return (
+      TranscriptStore(directory: directory, liveSpoolIDs: spools),
+      directory)
   }
 
   /// Written from the detached walk and read on the main actor, so it carries
@@ -172,8 +179,8 @@ struct EscapeRecoveryDiskExpiryTests {
         """)
     }
 
-    @Test("a kept dictation's leftover copy is deleted even when its audio survives")
-    func keptShadowIsDeletedDespiteSurvivingSpool() async throws {
+    @Test("a kept live dictation's leftover copy is deleted before it can re-arm the pulse")
+    func keptLiveShadowIsDeletedDespiteSurvivingSpool() async throws {
       let store = makeStore(spools: { ["session-kept"] })
 
       // The state a half-failed Keep leaves behind: the permanent row written,
@@ -182,7 +189,7 @@ struct EscapeRecoveryDiskExpiryTests {
       let id = UUID()
       let row = Transcript(
         id: id, text: "the user pressed Keep on this", recoverySessionID: "session-kept",
-        escapeRecoveredAt: Date().addingTimeInterval(-48 * 3600),
+        escapeRecoveredAt: Date().addingTimeInterval(-60),
         escapeRecoveryTakeID: "take-kept")
       try store.savePending(row)
       try store.save(row.promotedFromPending())
@@ -202,6 +209,9 @@ struct EscapeRecoveryDiskExpiryTests {
         the countdown keeps running against it forever.
         """)
       #expect(swept.deletedIDs.contains(id), "it must be swept as the litter it is")
+      #expect(
+        swept.remainingLive == 0 && swept.nextLiveDeadline == nil,
+        "a kept live shadow must not be re-offered or keep the expiry pulse armed")
       #expect(
         swept.expired.isEmpty,
         "and NOT reported as expired — the user kept this dictation, nothing lapsed")
@@ -504,6 +514,46 @@ struct EscapeRecoveryDiskExpiryTests {
       #2186: the sweep deleted an INVALID pending row whose spool is still on disk. Its \
       recoverySessionID is de-dup proof that `allRecoveredSessionIDs()` honours, so removing \
       the file makes the next scan replay that spool and hand back a cancelled dictation.
+      """)
+  }
+
+  @Test("a filename collision with an unrelated permanent row keeps the invalid row's spool proof")
+  func invalidFilenameCollisionDoesNotBypassSpoolGuard() async throws {
+    let session = UUID().uuidString
+    let fixture = makeStoreWithDirectory(spools: { [session] })
+    let store = fixture.store
+    let pendingID = UUID()
+    let unrelatedPermanentID = UUID()
+    let pending = Transcript(
+      id: pendingID,
+      text: "cancelled audio still needs its de-dup proof",
+      recoverySessionID: session,
+      escapeRecoveredAt: Date().addingTimeInterval(
+        -(AppConstants.pendingTranscriptRetention + 3600)),
+      escapeRecoveryTakeID: "take-filename-collision")
+    try store.savePending(pending)
+    try store.save(
+      Transcript(
+        id: unrelatedPermanentID,
+        text: "a different dictation that happened to take this filename",
+        recoverySessionID: UUID().uuidString))
+
+    // Pending file A decodes as transcript B. A permanent A exists, but it is
+    // unrelated: treating filename equality as a permanent twin would skip the
+    // spool guard and delete B's recovery-session de-dup proof.
+    let pendingDir = fixture.directory.appendingPathComponent(AppConstants.pendingTranscriptsDir)
+    let original = pendingDir.appendingPathComponent("\(pendingID.uuidString).json")
+    let collidingName = pendingDir.appendingPathComponent("\(unrelatedPermanentID.uuidString).json")
+    try FileManager.default.moveItem(at: original, to: collidingName)
+
+    let swept = try await store.deleteExpiredPending()
+
+    #expect(swept.retainedForSpool == 1)
+    #expect(
+      try await store.pendingRecoverySessionIDs().contains(session),
+      """
+      #2256: a filename collision must not erase the invalid row's recovery-session key. The next \
+      scan would otherwise replay the surviving cancelled-audio spool as a duplicate dictation.
       """)
   }
 

--- a/Tests/EnviousWisprTests/Storage/PendingTranscriptStoreTests.swift
+++ b/Tests/EnviousWisprTests/Storage/PendingTranscriptStoreTests.swift
@@ -507,8 +507,11 @@ import Testing
       swept.expired.isEmpty,
       "the user pressed Keep; reporting an expiry would understate the one ratio")
     #expect(
-      swept.deletedIDs.contains(row.id),
+      swept.clearedShadows == 1,
       "the shadow is still litter and must be cleared, receipt or no receipt")
+    #expect(
+      !swept.deletedIDs.contains(row.id),
+      "the permanent twin shares this id, so it must not be reported for eviction")
     let shadow = dir.appendingPathComponent("pending/\(row.id.uuidString).json")
     #expect(!FileManager.default.fileExists(atPath: shadow.path))
   }


### PR DESCRIPTION
Closes #2256

This removes a false recovery-dedup path: a pending file is now a permanent shadow only when its decoded transcript identity and recovery session match the permanent row. Live shadows are removed before the next-live count is calculated.

Validation:

- `scripts/test-validation.sh` — 3/3 passed
- `scripts/xcode-test.sh --filter EnviousWisprTests/EscapeRecoveryDiskExpiryTests` — 13 tests passed after rebase
- Full Debug and Release suite before rebase — 205 tests in 20 suites passed
- Independent Codex review — no actionable regressions
- #2275 mutation hardening while EnviousWispr Local stayed open — 3/3 mutations caught by the named tests; 13-test baseline green before and after; source restored cleanly
