### PR TITLE
test: bind the recovery rail to visible progress

### DIFF
--- a/Tests/EnviousWisprTests/App/EscapeRecoveryPillLayoutTests.swift
+++ b/Tests/EnviousWisprTests/App/EscapeRecoveryPillLayoutTests.swift
@@ -79,9 +79,11 @@ struct EscapeRecoveryPillLayoutTests {
   @Test("The rail is already visible the instant the pill appears")
   func theRailShowsASparkAtZero() {
     // At t=0 an untrimmed rail draws nothing, and the pill arrives looking like
-    // its rim is broken.
+    // its rim is broken. The spark must also stay unmistakably near the start;
+    // a large floor makes a fresh three-second offer look almost expired.
     #expect(SpectralRail.drawnFraction(for: 0) > 0)
     #expect(SpectralRail.drawnFraction(for: 0) == SpectralRail.minimumSpark)
+    #expect(SpectralRail.minimumSpark < 0.1)
   }
 
   @Test("The rail never asks for more path than exists")
@@ -97,7 +99,9 @@ struct EscapeRecoveryPillLayoutTests {
     let samples = stride(from: 0.0, through: 1.0, by: 0.1).map {
       SpectralRail.drawnFraction(for: $0)
     }
-    #expect(zip(samples, samples.dropFirst()).allSatisfy { $0 <= $1 })
+    // Non-strict monotonicity allowed a rail pinned at 95% for almost the whole
+    // dwell. Every tenth of the timer must visibly advance the countdown.
+    #expect(zip(samples, samples.dropFirst()).allSatisfy { $0 < $1 })
   }
 
   // MARK: - Legibility in both themes


### PR DESCRIPTION
## Summary

- cap the initial countdown spark below 10 percent, so a fresh recovery offer cannot appear almost expired
- require visible progress at every sampled tenth of the countdown
- close the surviving 95 percent floor mutation without pinning the shipped 1.5 percent value

## Mutation proof

- `minimumSpark = 0.95`: caught by the new spark bound and strict progress guard
- contrast helper returning `99`: caught by the independent theme-sequence outcome test
- `panelWidth = pillWidth + 12`: caught by the exact panel-to-pill geometry test
- palette alias to the dark spectrum: caught by contrast and theme-sequence tests
- palette helper returning the dark spectrum: caught by contrast and theme-sequence tests
- upstream head/body reconstruction from the dark spectrum: caught by contrast and theme-sequence tests
- the issues previously recorded source recipes 1 through 5 and 7 through 9 remain caught; recipe 6s named margin symbol never existed, and its real behavior is covered by the panel mutation above

One frozen palette-evasion pass was run. All three shapes failed, so no further hand-tuning was performed.

## Validation

- focused `EscapeRecoveryPillLayoutTests`: 13/13 passed after all sources were restored
- full canonical Debug lane: 6,342 tests passed
- post-rebase focused lane: 13/13 passed
- independent Codex review: no actionable findings

Closes #2189