### PR TITLE
docs(asr): point recovery ordering at its real test

### DIFF
--- a/Sources/EnviousWisprASR/RecoveryFailureClassification.swift
+++ b/Sources/EnviousWisprASR/RecoveryFailureClassification.swift
@@ -24,7 +24,8 @@ import EnviousWisprServices
 package func recoveryFailureClass(for error: any Error) -> RecoveryFailureClass? {
   // ORDER IS LOAD-BEARING: the unreachable-service case must be tested before
   // the general transport case or the shipped `xpc_unreachable` series silently
-  // stops being produced. Pinned by `serviceUnreachableOutranksGeneralTransport`.
+  // stops being produced. Pinned by "transcribe failure on good audio is a Camp B
+  // candidate with a failure class" in RecoverySpoolReplayerTests.
   if let transport = error as? XPCASRTransportError {
     return transport.isServiceUnreachable ? .xpcUnreachable : .xpcTransport
   }


### PR DESCRIPTION
## Summary

- completes the #2206 recovery-deferral mutation battery
- replaces a stale reference to a nonexistent test with the real regression test
- makes no runtime behavior change

## Mutation proof

All six controls were caught:

- recovery deletion guard recipe 1
- load-time not-ready deferral recipe 2
- recovery deletion guard recipe 3
- XPC classification ordering mutation
- removed `audio_decrypted` from engine deferral telemetry
- removed `camp_b_candidate` and `spool_seconds_bucket` from engine deferral telemetry

The load-time mutant failed `loadTimeNotReadyStaysUnrecoverable`. Each telemetry mutant failed `notReadyEngineDefersInsteadOfDeletingTheRecording`.

## Validation

- `RecoverySpoolReplayerTests`: 25/25 passed after restoring source
- isolated worktree used for all source mutations
- independent Codex review: no actionable defects

Closes #2206