### PR TITLE
test: prove preview notices trigger live resizing

### DIFF
--- a/Tests/EnviousWisprTests/App/RecordingOverlayPreviewSizingTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingOverlayPreviewSizingTests.swift
@@ -206,6 +206,41 @@ struct RecordingOverlayPreviewSizingTests {
     #expect(atCompact == atTall, "with a notice showing: \(atCompact)pt vs \(atTall)pt")
   }
 
+  @Test("the notice banner contributes to the measured height")
+  func noticeBannerAddsHeight() throws {
+    let log = HeightLog()
+    let noticeState = OverlayNoticeState()
+    let display = LivePreviewDisplay.text(Self.oneLine)
+    let view = RecordingOverlayView(
+      audioLevelProvider: { 0 },
+      recordingElapsedProvider: { 41 },
+      livePreviewProvider: { display },
+      onContentHeightChange: { log.record($0) },
+      usesPreviewLayout: true,
+      lockState: OverlayLockState(),
+      noticeState: noticeState,
+      initialPreview: display
+    )
+    let frame = NSRect(x: 0, y: 0, width: Self.previewWidth, height: 65)
+    let host = NSHostingView(rootView: view.frame(width: Self.previewWidth))
+    let window = NSWindow(
+      contentRect: frame, styleMask: [.borderless], backing: .buffered, defer: false)
+    window.contentView = host
+    host.frame = frame
+    host.layoutSubtreeIfNeeded()
+    window.displayIfNeeded()
+    let withoutNotice = try #require(log.reported.last)
+
+    noticeState.message = "Recording stops in one minute."
+    host.layoutSubtreeIfNeeded()
+    window.displayIfNeeded()
+    let withNotice = try #require(log.reported.last)
+
+    #expect(
+      withNotice > withoutNotice,
+      "the notice was present but the measured height stayed at \(withoutNotice)pt")
+  }
+
   // MARK: - The acceptance criterion, pinned rather than implied
 
   /// The chunk's stated criterion is a NUMBER: while preview text, lock state and


### PR DESCRIPTION
## Summary

- completes #2210 with a valid independent mutation
- adds a production-view test proving a notice added after mount increases the reported pill height
- guards the live geometry-change callback, not only initial layout

## Mutation proof

The original 8-test suite survived when the production notice branch was hidden. After this change:

- hiding the notice fails `noticeBannerAddsHeight`
- removing the geometry reader `onChange` callback fails `noticeBannerAddsHeight`
- removing `@Observable` from `OverlayNoticeState` fails `noticeBannerAddsHeight`

The six filed recipe rows had already produced their expected four caught and two intentional-survivor results.

## Validation

- `RecordingOverlayPreviewSizingTests`: 9/9 passed
- repeated focused suite: 270/270 passed across 30 iterations
- full Debug: 6,343 tests passed
- independent Codex review: no actionable defects after the review fix

Closes #2210