### PR TITLE
test(paste): freeze clipboard cleanup routes

### DIFF
--- a/Sources/EnviousWisprPipeline/ClipboardCleanup.swift
+++ b/Sources/EnviousWisprPipeline/ClipboardCleanup.swift
@@ -65,6 +65,13 @@ import EnviousWisprServices
 /// neither should be deleted on the grounds that a test still passes without
 /// it. That is what defence in depth looks like from inside a mutation run, and
 /// it is easy to misread as a vacuous test.
+///
+/// The same is true of both production `task.cancel()` calls below. Removing
+/// either one also leaves the suite green because the identity check refuses the
+/// stale task when it wakes. Cancellation still matters: it abandons superseded
+/// work immediately instead of retaining and waking it later. A green
+/// single-line mutant is evidence of the backstop, not evidence that either
+/// cancellation is dead code (#2215).
 @MainActor
 public enum ClipboardCleanup {
 

--- a/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
+++ b/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
@@ -477,7 +477,7 @@ internal final class PasteCascadeExecutor {
         // proven gap — taken because it costs one moved line.
         let snapshot: ClipboardSnapshot? =
           request.restoreClipboardAfterPaste
-          ? ClipboardCleanup.snapshotForDelivery()
+          ? ClipboardCleanup.snapshotForDelivery(from: pasteboard)
           : nil
         submittedKind = payload.kind
         let dispatchResult = PasteService.pasteToActiveApp(
@@ -529,7 +529,7 @@ internal final class PasteCascadeExecutor {
         // Same ordering as Tier 2: snapshot after the re-check, before the write.
         let snapshot: ClipboardSnapshot? =
           request.restoreClipboardAfterPaste
-          ? ClipboardCleanup.snapshotForDelivery()
+          ? ClipboardCleanup.snapshotForDelivery(from: pasteboard)
           : nil
         submittedKind = payload.kind
         let changeCount = PasteService.copyToClipboardReturningChangeCount(
@@ -568,7 +568,9 @@ internal final class PasteCascadeExecutor {
         // Put our text on the clipboard BEFORE probing enabled-state: apps grey
         // out Paste when the clipboard is empty/incompatible (#729 Codex r1).
         let snapshot: ClipboardSnapshot? =
-          request.restoreClipboardAfterPaste ? ClipboardCleanup.snapshotForDelivery() : nil
+          request.restoreClipboardAfterPaste
+          ? ClipboardCleanup.snapshotForDelivery(from: pasteboard)
+          : nil
         // Selected through the same owner as every other route. A container
         // target should never HAVE a candidate — the context reader refuses any
         // role that is not a text role — but this route asks the same question

--- a/Tests/EnviousWisprTests/Architecture/ClipboardIsolationFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/ClipboardIsolationFreezeTests.swift
@@ -355,7 +355,8 @@ struct ClipboardIsolationFreezeTests {
       // Unwrap here too. The rule is "what does the compiler treat as transparent", and it has to hold
       // at EVERY expression this visitor inspects — `(executor.deliver)(request)` is the same call, and
       // applying the rule at three sites and not the other two is how the class comes back.
-      guard let callee = Self.unwrapped(node.calledExpression).as(MemberAccessExprSyntax.self) else {
+      guard let callee = Self.unwrapped(node.calledExpression).as(MemberAccessExprSyntax.self)
+      else {
         return .visitChildren
       }
       let baseName = Self.trailingName(of: callee.base)
@@ -462,21 +463,77 @@ struct ClipboardIsolationFreezeTests {
   private final class SnapshotRoutingVisitor: SyntaxVisitor {
     private(set) var snapshotCalls = 0
     private(set) var callsUsingExecutorBoard = 0
+    private(set) var automaticRouteWrites: [(block: Int?, usesExecutorBoard: Bool)] = []
+    private(set) var clipboardFallbackWrites: [(insideFallback: Bool, usesExecutorBoard: Bool)] = []
+    private var snapshotsByBlock: [Int: Int] = [:]
+
+    var automaticRoutesHaveSnapshots: [Bool] {
+      automaticRouteWrites.map { route in
+        guard let block = route.block else { return false }
+        return snapshotsByBlock[block] == 1
+      }
+    }
 
     override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
-      guard let member = node.calledExpression.as(MemberAccessExprSyntax.self),
-        member.declName.baseName.text == "snapshotForDelivery",
-        member.base?.trimmedDescription == "ClipboardCleanup"
-      else { return .visitChildren }
+      guard let member = node.calledExpression.as(MemberAccessExprSyntax.self) else {
+        return .visitChildren
+      }
+      let functionName = member.declName.baseName.text
+      let base = member.base?.trimmedDescription
 
-      snapshotCalls += 1
-      if node.arguments.count == 1, let argument = node.arguments.first,
-        argument.label?.text == "from",
-        argument.expression.trimmedDescription == "pasteboard"
+      if functionName == "snapshotForDelivery", base == "ClipboardCleanup" {
+        snapshotCalls += 1
+        if let block = enclosingCodeBlockStart(node) {
+          snapshotsByBlock[block, default: 0] += 1
+        }
+        if node.arguments.count == 1, let argument = node.arguments.first,
+          argument.label?.text == "from",
+          argument.expression.trimmedDescription == "pasteboard"
+        {
+          callsUsingExecutorBoard += 1
+        }
+      }
+
+      guard base == "PasteService" else { return .visitChildren }
+      let usesExecutorBoard = node.arguments.contains { argument in
+        argument.label?.text == "to" && argument.expression.trimmedDescription == "pasteboard"
+      }
+      if functionName == "pasteToActiveApp"
+        || functionName == "copyToClipboardReturningChangeCount"
       {
-        callsUsingExecutorBoard += 1
+        automaticRouteWrites.append(
+          (block: enclosingCodeBlockStart(node), usesExecutorBoard: usesExecutorBoard))
+      } else if functionName == "copyToClipboard" {
+        clipboardFallbackWrites.append(
+          (insideFallback: isInsideClipboardFallback(node), usesExecutorBoard: usesExecutorBoard))
       }
       return .visitChildren
+    }
+
+    private func enclosingCodeBlockStart(_ node: some SyntaxProtocol) -> Int? {
+      var ancestor = Syntax(node).parent
+      while let current = ancestor {
+        if let block = current.as(CodeBlockSyntax.self) {
+          return block.positionAfterSkippingLeadingTrivia.utf8Offset
+        }
+        ancestor = current.parent
+      }
+      return nil
+    }
+
+    private func isInsideClipboardFallback(_ node: some SyntaxProtocol) -> Bool {
+      var ancestor = Syntax(node).parent
+      while let current = ancestor {
+        if let branch = current.as(IfExprSyntax.self),
+          Array(branch.conditions.tokens(viewMode: .sourceAccurate).map(\.text))
+            == ["tier", "==", ".", "clipboardOnly"]
+        {
+          return true
+        }
+        if current.is(FunctionDeclSyntax.self) { return false }
+        ancestor = current.parent
+      }
+      return false
     }
   }
 
@@ -555,6 +612,41 @@ struct ClipboardIsolationFreezeTests {
     #expect(
       visitor.callsUsingExecutorBoard == visitor.snapshotCalls,
       "a paste route bypasses cleanup inheritance or silently defaults to the real clipboard")
+    #expect(
+      visitor.automaticRouteWrites.count == 3,
+      "expected the Cmd+V, AppleScript, and menu-paste clipboard writes")
+    #expect(
+      visitor.automaticRouteWrites.allSatisfy { $0.usesExecutorBoard },
+      "every automatic paste route must write to the executor's board")
+    #expect(
+      visitor.automaticRoutesHaveSnapshots == [true, true, true],
+      "every automatic paste route must take its cleanup snapshot in the same scope")
+    #expect(
+      visitor.clipboardFallbackWrites.count == 1
+        && visitor.clipboardFallbackWrites.allSatisfy {
+          $0.insideFallback && $0.usesExecutorBoard
+        },
+      "the one manual clipboard fallback must stay explicit and use the executor's board")
+  }
+
+  @Test("a new automatic paste route cannot omit its cleanup snapshot")
+  func automaticRouteWithoutSnapshotIsCaught() {
+    let tree = Parser.parse(
+      source: """
+        func deliver() {
+          if firstRoute {
+            let snapshot = ClipboardCleanup.snapshotForDelivery(from: pasteboard)
+            PasteService.pasteToActiveApp("one", to: pasteboard)
+          }
+          if secondRoute {
+            PasteService.copyToClipboardReturningChangeCount("two", to: pasteboard)
+          }
+        }
+        """)
+    let visitor = SnapshotRoutingVisitor(viewMode: .sourceAccurate)
+    visitor.walk(tree)
+
+    #expect(visitor.automaticRoutesHaveSnapshots == [true, false])
   }
 
   // MARK: Two-way controls

--- a/Tests/EnviousWisprTests/Architecture/ClipboardIsolationFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/ClipboardIsolationFreezeTests.swift
@@ -463,14 +463,16 @@ struct ClipboardIsolationFreezeTests {
   private final class SnapshotRoutingVisitor: SyntaxVisitor {
     private(set) var snapshotCalls = 0
     private(set) var callsUsingExecutorBoard = 0
-    private(set) var automaticRouteWrites: [(block: Int?, usesExecutorBoard: Bool)] = []
+    private(set) var automaticRouteWrites: [(block: Int?, position: Int, usesExecutorBoard: Bool)] =
+      []
     private(set) var clipboardFallbackWrites: [(insideFallback: Bool, usesExecutorBoard: Bool)] = []
-    private var snapshotsByBlock: [Int: Int] = [:]
+    private var snapshotsByBlock: [Int: [Int]] = [:]
 
     var automaticRoutesHaveSnapshots: [Bool] {
       automaticRouteWrites.map { route in
         guard let block = route.block else { return false }
-        return snapshotsByBlock[block] == 1
+        guard let snapshots = snapshotsByBlock[block], snapshots.count == 1 else { return false }
+        return snapshots[0] < route.position
       }
     }
 
@@ -484,7 +486,8 @@ struct ClipboardIsolationFreezeTests {
       if functionName == "snapshotForDelivery", base == "ClipboardCleanup" {
         snapshotCalls += 1
         if let block = enclosingCodeBlockStart(node) {
-          snapshotsByBlock[block, default: 0] += 1
+          snapshotsByBlock[block, default: []].append(
+            node.positionAfterSkippingLeadingTrivia.utf8Offset)
         }
         if node.arguments.count == 1, let argument = node.arguments.first,
           argument.label?.text == "from",
@@ -494,7 +497,9 @@ struct ClipboardIsolationFreezeTests {
         }
       }
 
-      guard base == "PasteService" else { return .visitChildren }
+      guard trailingName(of: member.base) == "PasteService" else {
+        return .visitChildren
+      }
       let usesExecutorBoard = node.arguments.contains { argument in
         argument.label?.text == "to" && argument.expression.trimmedDescription == "pasteboard"
       }
@@ -502,12 +507,26 @@ struct ClipboardIsolationFreezeTests {
         || functionName == "copyToClipboardReturningChangeCount"
       {
         automaticRouteWrites.append(
-          (block: enclosingCodeBlockStart(node), usesExecutorBoard: usesExecutorBoard))
+          (
+            block: enclosingCodeBlockStart(node),
+            position: node.positionAfterSkippingLeadingTrivia.utf8Offset,
+            usesExecutorBoard: usesExecutorBoard
+          ))
       } else if functionName == "copyToClipboard" {
         clipboardFallbackWrites.append(
           (insideFallback: isInsideClipboardFallback(node), usesExecutorBoard: usesExecutorBoard))
       }
       return .visitChildren
+    }
+
+    private func trailingName(of expression: ExprSyntax?) -> String? {
+      if let reference = expression?.as(DeclReferenceExprSyntax.self) {
+        return reference.baseName.text
+      }
+      if let member = expression?.as(MemberAccessExprSyntax.self) {
+        return member.declName.baseName.text
+      }
+      return nil
     }
 
     private func enclosingCodeBlockStart(_ node: some SyntaxProtocol) -> Int? {
@@ -647,6 +666,36 @@ struct ClipboardIsolationFreezeTests {
     visitor.walk(tree)
 
     #expect(visitor.automaticRoutesHaveSnapshots == [true, false])
+  }
+
+  @Test("a cleanup snapshot must precede its automatic route write")
+  func automaticRouteRejectsLateSnapshot() {
+    let tree = Parser.parse(
+      source: """
+        func deliver() {
+          PasteService.pasteToActiveApp("one", to: pasteboard)
+          let snapshot = ClipboardCleanup.snapshotForDelivery(from: pasteboard)
+        }
+        """)
+    let visitor = SnapshotRoutingVisitor(viewMode: .sourceAccurate)
+    visitor.walk(tree)
+
+    #expect(visitor.automaticRoutesHaveSnapshots == [false])
+  }
+
+  @Test("module-qualified route writes stay in the cleanup inventory")
+  func moduleQualifiedAutomaticRouteIsCaught() {
+    let tree = Parser.parse(
+      source: """
+        func deliver() {
+          EnviousWisprServices.PasteService.copyToClipboardReturningChangeCount(
+            "one", to: pasteboard)
+        }
+        """)
+    let visitor = SnapshotRoutingVisitor(viewMode: .sourceAccurate)
+    visitor.walk(tree)
+
+    #expect(visitor.automaticRoutesHaveSnapshots == [false])
   }
 
   // MARK: Two-way controls

--- a/Tests/EnviousWisprTests/Architecture/ClipboardIsolationFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/ClipboardIsolationFreezeTests.swift
@@ -459,6 +459,27 @@ struct ClipboardIsolationFreezeTests {
     return visitor.violations
   }
 
+  private final class SnapshotRoutingVisitor: SyntaxVisitor {
+    private(set) var snapshotCalls = 0
+    private(set) var callsUsingExecutorBoard = 0
+
+    override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+      guard let member = node.calledExpression.as(MemberAccessExprSyntax.self),
+        member.declName.baseName.text == "snapshotForDelivery",
+        member.base?.trimmedDescription == "ClipboardCleanup"
+      else { return .visitChildren }
+
+      snapshotCalls += 1
+      if node.arguments.count == 1, let argument = node.arguments.first,
+        argument.label?.text == "from",
+        argument.expression.trimmedDescription == "pasteboard"
+      {
+        callsUsingExecutorBoard += 1
+      }
+      return .visitChildren
+    }
+  }
+
   private static func scanTests() throws -> (violations: [Violation], filesScanned: Int) {
     let root = RepoRoot.sourceURL("Tests")
     var found: [Violation] = []
@@ -518,6 +539,22 @@ struct ClipboardIsolationFreezeTests {
         - PasteService tests: use `NSPasteboard.withUniqueName()` and pass it
           explicitly via `to:` / `from:` / `on:`.
       """)
+  }
+
+  @Test("every paste route inherits cleanup through the executor's board")
+  func pasteRoutesUseCleanupSnapshot() throws {
+    let url = RepoRoot.sourceURL("Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift")
+    let source = try String(contentsOf: url, encoding: .utf8)
+    let tree = Parser.parse(source: source)
+    let visitor = SnapshotRoutingVisitor(viewMode: .sourceAccurate)
+    visitor.walk(tree)
+
+    #expect(
+      visitor.snapshotCalls == 3,
+      "expected the three clipboard paste routes, found \(visitor.snapshotCalls)")
+    #expect(
+      visitor.callsUsingExecutorBoard == visitor.snapshotCalls,
+      "a paste route bypasses cleanup inheritance or silently defaults to the real clipboard")
   }
 
   // MARK: Two-way controls


### PR DESCRIPTION
## Summary

- closes the remaining #2215 route-level coverage gap
- makes the executor pasteboard explicit at all three cleanup snapshot sites
- adds a Swift parser inventory that fails if any route bypasses cleanup inheritance or silently defaults to the real clipboard
- records why the two surviving cancellation mutants are defense in depth, not dead code

## Mutation proof

- replacing one Tier 2 `ClipboardCleanup.snapshotForDelivery` call with `PasteService.saveClipboard` fails `pasteRoutesUseCleanupSnapshot`
- dropping the clipboard-cleanup clause from `UpdateCoordinator.installRefusedNow` fails `refusedWhileClipboardCleanupPending`
- the prior battery results remain: rows 1, 2, 3, 4, 8 and the own mutant caught; rows 5 and 6 are the documented redundant protections

## Validation

- `ClipboardIsolationFreezeTests`: 20/20 passed
- `UpdateCoordinatorProactiveCheckTests`: 25/25 passed
- `ClipboardCleanupTests`: 10/10 passed
- full Debug: 6,343 tests passed
- post-rebase architecture suite: 20/20 passed
- independent Codex review: no actionable defects

Closes #2215