### PR TITLE
fix(compare): give head-to-head tables a phone layout, one owner for all 16

### DIFF
--- a/website/src/components/CompareTableMobile.astro
+++ b/website/src/components/CompareTableMobile.astro
@@ -79,7 +79,19 @@
     apply();
   }
 
-  // Rotating a phone can cross the breakpoint; rows already handled are
-  // skipped by the duoReady guard.
-  PHONE.addEventListener('change', apply);
+  // Leaving the breakpoint has to UNDO the work, not just stop doing it.
+  // The desktop table is a real <table> again and the clamp CSS is inside the
+  // media query, so a leftover toggle would render as an unstyled button in
+  // the middle of a cell. Rotating a phone crosses this boundary (390 -> 844).
+  function teardown() {
+    document.querySelectorAll<HTMLElement>('.compare-table--duo tbody tr').forEach((row) => {
+      row.querySelectorAll('.duo-toggle').forEach((button) => button.remove());
+      row.classList.remove('duo-clamped', 'duo-open');
+      delete row.dataset.duoReady;
+    });
+    // The .duo-text wrappers stay. They are inert outside the media query and
+    // wrapContents reuses them, so re-entering the breakpoint does not rewrap.
+  }
+
+  PHONE.addEventListener('change', () => (PHONE.matches ? apply() : teardown()));
 </script>

--- a/website/src/components/CompareTableMobile.astro
+++ b/website/src/components/CompareTableMobile.astro
@@ -18,6 +18,9 @@
   const LABEL_CLOSED = 'What that means';
   const LABEL_OPEN = 'Show less';
 
+  const rows = () =>
+    Array.from(document.querySelectorAll<HTMLElement>('.compare-table--duo tbody tr'));
+
   // A `td` in this layout is a grid item, and grid items are blockified:
   // `display: -webkit-box` computes to `flow-root`, so -webkit-line-clamp is
   // silently dropped. Clamping an inner element sidesteps that.
@@ -31,24 +34,30 @@
     return span;
   }
 
+  // One writer for the open/closed state, so the class, the label and the
+  // ARIA state cannot drift apart.
+  function setOpen(row: HTMLElement, open: boolean) {
+    row.classList.toggle('duo-open', open);
+    const button = row.querySelector<HTMLButtonElement>('.duo-toggle');
+    if (!button) return;
+    button.setAttribute('aria-expanded', String(open));
+    button.textContent = open ? LABEL_OPEN : LABEL_CLOSED;
+  }
+
   function toggleFor(row: HTMLElement): HTMLButtonElement {
     const button = document.createElement('button');
     button.type = 'button';
     button.className = 'duo-toggle';
     button.textContent = LABEL_CLOSED;
     button.setAttribute('aria-expanded', 'false');
-    button.addEventListener('click', () => {
-      const open = row.classList.toggle('duo-open');
-      button.setAttribute('aria-expanded', String(open));
-      button.textContent = open ? LABEL_OPEN : LABEL_CLOSED;
-    });
+    button.addEventListener('click', () => setOpen(row, !row.classList.contains('duo-open')));
     return button;
   }
 
   function apply() {
     if (!PHONE.matches) return;
 
-    document.querySelectorAll<HTMLElement>('.compare-table--duo tbody tr').forEach((row) => {
+    rows().forEach((row) => {
       if (row.dataset.duoReady) return;
       row.dataset.duoReady = '1';
 
@@ -71,6 +80,48 @@
     });
   }
 
+  function teardown() {
+    rows().forEach((row) => {
+      row.querySelectorAll('.duo-toggle').forEach((button) => button.remove());
+      row.classList.remove('duo-clamped', 'duo-open');
+      delete row.dataset.duoReady;
+    });
+    // The .duo-text wrappers stay. They are inert outside the media query and
+    // wrapContents reuses them, so re-measuring does not rewrap.
+  }
+
+  // Whether a row overflows is a function of COLUMN WIDTH, so the trigger has
+  // to be width itself. A breakpoint event is not enough in either direction:
+  // widening past 700 needs a teardown rather than an early return, and two
+  // widths can both be under 700 — an iPhone SE is 375 portrait and 667
+  // landscape, and rotating between them fires no `change` at all while
+  // halving the column width. Rows measured in landscape would stay unclamped
+  // in portrait, which is exactly the case this component exists for.
+  function remeasure() {
+    if (!PHONE.matches) {
+      teardown();
+      return;
+    }
+    const reopen = new Set(rows().filter((row) => row.classList.contains('duo-open')));
+    teardown();
+    apply();
+    reopen.forEach((row) => {
+      if (row.classList.contains('duo-clamped')) setOpen(row, true);
+    });
+  }
+
+  // Width only. iOS fires `resize` when the URL bar collapses during a scroll,
+  // which changes height and nothing else; re-measuring on that would be pure
+  // churn on the one platform this feature is for.
+  let lastWidth = window.innerWidth;
+  let pending = 0;
+  window.addEventListener('resize', () => {
+    if (window.innerWidth === lastWidth) return;
+    lastWidth = window.innerWidth;
+    cancelAnimationFrame(pending);
+    pending = requestAnimationFrame(remeasure);
+  });
+
   // Fonts change line height, and line height decides what counts as
   // truncated. Measuring before they load would clamp the wrong rows.
   if (document.fonts && document.fonts.status !== 'loaded') {
@@ -78,20 +129,4 @@
   } else {
     apply();
   }
-
-  // Leaving the breakpoint has to UNDO the work, not just stop doing it.
-  // The desktop table is a real <table> again and the clamp CSS is inside the
-  // media query, so a leftover toggle would render as an unstyled button in
-  // the middle of a cell. Rotating a phone crosses this boundary (390 -> 844).
-  function teardown() {
-    document.querySelectorAll<HTMLElement>('.compare-table--duo tbody tr').forEach((row) => {
-      row.querySelectorAll('.duo-toggle').forEach((button) => button.remove());
-      row.classList.remove('duo-clamped', 'duo-open');
-      delete row.dataset.duoReady;
-    });
-    // The .duo-text wrappers stay. They are inert outside the media query and
-    // wrapContents reuses them, so re-entering the breakpoint does not rewrap.
-  }
-
-  PHONE.addEventListener('change', () => (PHONE.matches ? apply() : teardown()));
 </script>

--- a/website/src/components/CompareTableMobile.astro
+++ b/website/src/components/CompareTableMobile.astro
@@ -1,0 +1,85 @@
+---
+// Phone-only progressive disclosure for two-product comparison tables.
+//
+// A `.compare-table--duo` row shows both products side by side. Where an
+// answer runs long, the pair is clamped to a few lines and the row's label
+// band gains a toggle, so 23 rows stay scannable and the detail is one tap
+// away. Rows whose answers already fit are left alone.
+//
+// Layout is CSS (global.css, "Compare tables on phones"). This file does the
+// two things a stylesheet cannot: wrap each answer so the clamp has a
+// non-grid-item to act on, and decide WHICH rows overflow, which depends on
+// rendered height. With JS off nothing is wrapped, nothing is clamped, and
+// the full text shows — the behaviour these pages had before.
+---
+
+<script>
+  const PHONE = window.matchMedia('(max-width: 700px)');
+  const LABEL_CLOSED = 'What that means';
+  const LABEL_OPEN = 'Show less';
+
+  // A `td` in this layout is a grid item, and grid items are blockified:
+  // `display: -webkit-box` computes to `flow-root`, so -webkit-line-clamp is
+  // silently dropped. Clamping an inner element sidesteps that.
+  function wrapContents(cell: HTMLElement): HTMLElement {
+    const existing = cell.querySelector<HTMLElement>(':scope > .duo-text');
+    if (existing) return existing;
+    const span = document.createElement('span');
+    span.className = 'duo-text';
+    span.append(...cell.childNodes);
+    cell.appendChild(span);
+    return span;
+  }
+
+  function toggleFor(row: HTMLElement): HTMLButtonElement {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'duo-toggle';
+    button.textContent = LABEL_CLOSED;
+    button.setAttribute('aria-expanded', 'false');
+    button.addEventListener('click', () => {
+      const open = row.classList.toggle('duo-open');
+      button.setAttribute('aria-expanded', String(open));
+      button.textContent = open ? LABEL_OPEN : LABEL_CLOSED;
+    });
+    return button;
+  }
+
+  function apply() {
+    if (!PHONE.matches) return;
+
+    document.querySelectorAll<HTMLElement>('.compare-table--duo tbody tr').forEach((row) => {
+      if (row.dataset.duoReady) return;
+      row.dataset.duoReady = '1';
+
+      const label = row.querySelector<HTMLElement>('td:first-child');
+      const values = Array.from(row.querySelectorAll<HTMLElement>('td')).slice(1);
+      if (!label || values.length === 0) return;
+
+      const texts = values.map(wrapContents);
+
+      // Clamp first, then MEASURE whether anything was actually cut off.
+      // A character-count threshold would guess; this asks the layout.
+      row.classList.add('duo-clamped');
+      const truncated = texts.some((text) => text.scrollHeight > text.clientHeight + 1);
+      if (!truncated) {
+        row.classList.remove('duo-clamped');
+        return;
+      }
+
+      label.appendChild(toggleFor(row));
+    });
+  }
+
+  // Fonts change line height, and line height decides what counts as
+  // truncated. Measuring before they load would clamp the wrong rows.
+  if (document.fonts && document.fonts.status !== 'loaded') {
+    document.fonts.ready.then(apply);
+  } else {
+    apply();
+  }
+
+  // Rotating a phone can cross the breakpoint; rows already handled are
+  // skipped by the duoReady guard.
+  PHONE.addEventListener('change', apply);
+</script>

--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -2,6 +2,7 @@
 import Nav from '../components/Nav.astro';
 import Footer from '../components/Footer.astro';
 import ScrollReveal from '../components/ScrollReveal.astro';
+import CompareTableMobile from '../components/CompareTableMobile.astro';
 import '../styles/global.css';
 
 interface Props {
@@ -70,6 +71,7 @@ const ogImageUrl = ogImage.startsWith('http') ? ogImage : `${siteUrl}${ogImage}`
   </main>
   <Footer />
   <ScrollReveal />
+  <CompareTableMobile />
   <!-- PostHog Analytics (deferred until after LCP to avoid contention) -->
   <script>
     let postHogLoaded = false;

--- a/website/src/pages/compare/apple-dictation.astro
+++ b/website/src/pages/compare/apple-dictation.astro
@@ -197,34 +197,8 @@ const faqJsonLd = JSON.stringify({
   border-radius: var(--radius-card); border: 1px solid var(--border-hover);
   background: #fff;
 }
-.compare-table {
-  width: 100%; border-collapse: collapse; font-size: 15px;
-  min-width: 640px;
-}
-.compare-table thead th {
-  padding: 20px 24px; font-size: 16px; font-weight: 700;
-  text-align: left; border-bottom: 2px solid var(--border-hover);
-  background: rgba(248,245,255,0.5);
-}
-.compare-table thead th:first-child { width: 34%; }
-.compare-table thead th:nth-child(2) {
-  background: rgba(124,58,237,0.06);
-  color: var(--accent);
-}
-.compare-table tbody td {
-  padding: 16px 24px; border-bottom: 1px solid var(--border);
-  vertical-align: top; line-height: 1.55;
-}
-.compare-table tbody tr:last-child td { border-bottom: none; }
-.compare-table tbody td:first-child {
-  font-weight: 600; color: var(--text);
-}
-.compare-table tbody td:nth-child(2) {
-  background: rgba(124,58,237,0.02);
-}
-.compare-table tbody td:nth-child(3) {
-  color: var(--text-2);
-}
+/* Table rules moved to global.css (.compare-table--duo) so one owner serves all
+   head-to-head pages and the phone layout there is not fighting 16 scoped copies. */
 .table-check { color: var(--green); font-weight: 700; }
 .table-cross { color: var(--text-3); }
 .table-highlight { color: var(--accent); font-weight: 600; }
@@ -395,7 +369,7 @@ const faqJsonLd = JSON.stringify({
       <p class="section-sub">Apple Dictation is a solid default. Here is where a dedicated dictation app pulls ahead.</p>
     </div>
     <div class="compare-table-wrap reveal">
-      <table class="compare-table">
+      <table class="compare-table compare-table--duo">
         <thead>
           <tr>
             <th scope="col"></th>

--- a/website/src/pages/compare/dragon.astro
+++ b/website/src/pages/compare/dragon.astro
@@ -205,34 +205,8 @@ const faqJsonLd = JSON.stringify({
   border-radius: var(--radius-card); border: 1px solid var(--border-hover);
   background: #fff;
 }
-.compare-table {
-  width: 100%; border-collapse: collapse; font-size: 15px;
-  min-width: 640px;
-}
-.compare-table thead th {
-  padding: 20px 24px; font-size: 16px; font-weight: 700;
-  text-align: left; border-bottom: 2px solid var(--border-hover);
-  background: rgba(248,245,255,0.5);
-}
-.compare-table thead th:first-child { width: 34%; }
-.compare-table thead th:nth-child(2) {
-  background: rgba(124,58,237,0.06);
-  color: var(--accent);
-}
-.compare-table tbody td {
-  padding: 16px 24px; border-bottom: 1px solid var(--border);
-  vertical-align: top; line-height: 1.55;
-}
-.compare-table tbody tr:last-child td { border-bottom: none; }
-.compare-table tbody td:first-child {
-  font-weight: 600; color: var(--text);
-}
-.compare-table tbody td:nth-child(2) {
-  background: rgba(124,58,237,0.02);
-}
-.compare-table tbody td:nth-child(3) {
-  color: var(--text-2);
-}
+/* Table rules moved to global.css (.compare-table--duo) so one owner serves all
+   head-to-head pages and the phone layout there is not fighting 16 scoped copies. */
 .table-check { color: var(--green); font-weight: 700; }
 .table-cross { color: var(--text-3); }
 .table-highlight { color: var(--accent); font-weight: 600; }
@@ -405,7 +379,7 @@ const faqJsonLd = JSON.stringify({
       <p class="section-sub">Dragon NaturallySpeaking set the standard for dictation software. Here is how it compares to EnviousWispr in 2026.</p>
     </div>
     <div class="compare-table-wrap reveal">
-      <table class="compare-table">
+      <table class="compare-table compare-table--duo">
         <thead>
           <tr>
             <th scope="col"></th>

--- a/website/src/pages/compare/fluidvoice.astro
+++ b/website/src/pages/compare/fluidvoice.astro
@@ -188,34 +188,8 @@ const faqJsonLd = JSON.stringify({
   border-radius: var(--radius-card); border: 1px solid var(--border-hover);
   background: #fff;
 }
-.compare-table {
-  width: 100%; border-collapse: collapse; font-size: 15px;
-  min-width: 640px;
-}
-.compare-table thead th {
-  padding: 20px 24px; font-size: 16px; font-weight: 700;
-  text-align: left; border-bottom: 2px solid var(--border-hover);
-  background: rgba(248,245,255,0.5);
-}
-.compare-table thead th:first-child { width: 34%; }
-.compare-table thead th:nth-child(2) {
-  background: rgba(124,58,237,0.06);
-  color: var(--accent);
-}
-.compare-table tbody td {
-  padding: 16px 24px; border-bottom: 1px solid var(--border);
-  vertical-align: top; line-height: 1.55;
-}
-.compare-table tbody tr:last-child td { border-bottom: none; }
-.compare-table tbody td:first-child {
-  font-weight: 600; color: var(--text);
-}
-.compare-table tbody td:nth-child(2) {
-  background: rgba(124,58,237,0.02);
-}
-.compare-table tbody td:nth-child(3) {
-  color: var(--text-2);
-}
+/* Table rules moved to global.css (.compare-table--duo) so one owner serves all
+   head-to-head pages and the phone layout there is not fighting 16 scoped copies. */
 .table-check { color: var(--green); font-weight: 700; }
 .table-cross { color: var(--text-3); }
 .table-highlight { color: var(--accent); font-weight: 600; }
@@ -388,7 +362,7 @@ const faqJsonLd = JSON.stringify({
       <p class="section-sub">An honest look at how the two tools stack up across the dimensions that matter most.</p>
     </div>
     <div class="compare-table-wrap reveal">
-      <table class="compare-table">
+      <table class="compare-table compare-table--duo">
         <thead>
           <tr>
             <th scope="col"></th>

--- a/website/src/pages/compare/google-docs-voice-typing.astro
+++ b/website/src/pages/compare/google-docs-voice-typing.astro
@@ -120,34 +120,8 @@ const breadcrumbJsonLd = JSON.stringify({
   border-radius: var(--radius-card); border: 1px solid var(--border-hover);
   background: #fff;
 }
-.compare-table {
-  width: 100%; border-collapse: collapse; font-size: 15px;
-  min-width: 640px;
-}
-.compare-table thead th {
-  padding: 20px 24px; font-size: 16px; font-weight: 700;
-  text-align: left; border-bottom: 2px solid var(--border-hover);
-  background: rgba(248,245,255,0.5);
-}
-.compare-table thead th:first-child { width: 34%; }
-.compare-table thead th:nth-child(2) {
-  background: rgba(124,58,237,0.06);
-  color: var(--accent);
-}
-.compare-table tbody td {
-  padding: 16px 24px; border-bottom: 1px solid var(--border);
-  vertical-align: top; line-height: 1.55;
-}
-.compare-table tbody tr:last-child td { border-bottom: none; }
-.compare-table tbody td:first-child {
-  font-weight: 600; color: var(--text);
-}
-.compare-table tbody td:nth-child(2) {
-  background: rgba(124,58,237,0.02);
-}
-.compare-table tbody td:nth-child(3) {
-  color: var(--text-2);
-}
+/* Table rules moved to global.css (.compare-table--duo) so one owner serves all
+   head-to-head pages and the phone layout there is not fighting 16 scoped copies. */
 .table-check { color: var(--green); font-weight: 700; }
 .table-cross { color: var(--text-3); }
 .table-highlight { color: var(--accent); font-weight: 600; }
@@ -320,7 +294,7 @@ const breadcrumbJsonLd = JSON.stringify({
       <p class="section-sub">An honest look at how the two tools stack up across the dimensions that matter most.</p>
     </div>
     <div class="compare-table-wrap reveal">
-      <table class="compare-table">
+      <table class="compare-table compare-table--duo">
         <thead>
           <tr>
             <th scope="col"></th>

--- a/website/src/pages/compare/handy.astro
+++ b/website/src/pages/compare/handy.astro
@@ -188,34 +188,8 @@ const faqJsonLd = JSON.stringify({
   border-radius: var(--radius-card); border: 1px solid var(--border-hover);
   background: #fff;
 }
-.compare-table {
-  width: 100%; border-collapse: collapse; font-size: 15px;
-  min-width: 640px;
-}
-.compare-table thead th {
-  padding: 20px 24px; font-size: 16px; font-weight: 700;
-  text-align: left; border-bottom: 2px solid var(--border-hover);
-  background: rgba(248,245,255,0.5);
-}
-.compare-table thead th:first-child { width: 34%; }
-.compare-table thead th:nth-child(2) {
-  background: rgba(124,58,237,0.06);
-  color: var(--accent);
-}
-.compare-table tbody td {
-  padding: 16px 24px; border-bottom: 1px solid var(--border);
-  vertical-align: top; line-height: 1.55;
-}
-.compare-table tbody tr:last-child td { border-bottom: none; }
-.compare-table tbody td:first-child {
-  font-weight: 600; color: var(--text);
-}
-.compare-table tbody td:nth-child(2) {
-  background: rgba(124,58,237,0.02);
-}
-.compare-table tbody td:nth-child(3) {
-  color: var(--text-2);
-}
+/* Table rules moved to global.css (.compare-table--duo) so one owner serves all
+   head-to-head pages and the phone layout there is not fighting 16 scoped copies. */
 .table-check { color: var(--green); font-weight: 700; }
 .table-cross { color: var(--text-3); }
 .table-highlight { color: var(--accent); font-weight: 600; }
@@ -388,7 +362,7 @@ const faqJsonLd = JSON.stringify({
       <p class="section-sub">An honest look at how the two tools stack up across the dimensions that matter most.</p>
     </div>
     <div class="compare-table-wrap reveal">
-      <table class="compare-table">
+      <table class="compare-table compare-table--duo">
         <thead>
           <tr>
             <th scope="col"></th>

--- a/website/src/pages/compare/juno.astro
+++ b/website/src/pages/compare/juno.astro
@@ -188,34 +188,8 @@ const faqJsonLd = JSON.stringify({
   border-radius: var(--radius-card); border: 1px solid var(--border-hover);
   background: #fff;
 }
-.compare-table {
-  width: 100%; border-collapse: collapse; font-size: 15px;
-  min-width: 640px;
-}
-.compare-table thead th {
-  padding: 20px 24px; font-size: 16px; font-weight: 700;
-  text-align: left; border-bottom: 2px solid var(--border-hover);
-  background: rgba(248,245,255,0.5);
-}
-.compare-table thead th:first-child { width: 34%; }
-.compare-table thead th:nth-child(2) {
-  background: rgba(124,58,237,0.06);
-  color: var(--accent);
-}
-.compare-table tbody td {
-  padding: 16px 24px; border-bottom: 1px solid var(--border);
-  vertical-align: top; line-height: 1.55;
-}
-.compare-table tbody tr:last-child td { border-bottom: none; }
-.compare-table tbody td:first-child {
-  font-weight: 600; color: var(--text);
-}
-.compare-table tbody td:nth-child(2) {
-  background: rgba(124,58,237,0.02);
-}
-.compare-table tbody td:nth-child(3) {
-  color: var(--text-2);
-}
+/* Table rules moved to global.css (.compare-table--duo) so one owner serves all
+   head-to-head pages and the phone layout there is not fighting 16 scoped copies. */
 .table-check { color: var(--green); font-weight: 700; }
 .table-cross { color: var(--text-3); }
 .table-highlight { color: var(--accent); font-weight: 600; }
@@ -388,7 +362,7 @@ const faqJsonLd = JSON.stringify({
       <p class="section-sub">An honest look at how the two tools stack up across the dimensions that matter most.</p>
     </div>
     <div class="compare-table-wrap reveal">
-      <table class="compare-table">
+      <table class="compare-table compare-table--duo">
         <thead>
           <tr>
             <th scope="col"></th>

--- a/website/src/pages/compare/macwhisper.astro
+++ b/website/src/pages/compare/macwhisper.astro
@@ -197,34 +197,8 @@ const faqJsonLd = JSON.stringify({
   border-radius: var(--radius-card); border: 1px solid var(--border-hover);
   background: #fff;
 }
-.compare-table {
-  width: 100%; border-collapse: collapse; font-size: 15px;
-  min-width: 640px;
-}
-.compare-table thead th {
-  padding: 20px 24px; font-size: 16px; font-weight: 700;
-  text-align: left; border-bottom: 2px solid var(--border-hover);
-  background: rgba(248,245,255,0.5);
-}
-.compare-table thead th:first-child { width: 34%; }
-.compare-table thead th:nth-child(2) {
-  background: rgba(124,58,237,0.06);
-  color: var(--accent);
-}
-.compare-table tbody td {
-  padding: 16px 24px; border-bottom: 1px solid var(--border);
-  vertical-align: top; line-height: 1.55;
-}
-.compare-table tbody tr:last-child td { border-bottom: none; }
-.compare-table tbody td:first-child {
-  font-weight: 600; color: var(--text);
-}
-.compare-table tbody td:nth-child(2) {
-  background: rgba(124,58,237,0.02);
-}
-.compare-table tbody td:nth-child(3) {
-  color: var(--text-2);
-}
+/* Table rules moved to global.css (.compare-table--duo) so one owner serves all
+   head-to-head pages and the phone layout there is not fighting 16 scoped copies. */
 .table-check { color: var(--green); font-weight: 700; }
 .table-cross { color: var(--text-3); }
 .table-highlight { color: var(--accent); font-weight: 600; }
@@ -395,7 +369,7 @@ const faqJsonLd = JSON.stringify({
       <p class="section-sub">MacWhisper and EnviousWispr both run Whisper-family models on your Mac. They solve different problems.</p>
     </div>
     <div class="compare-table-wrap reveal">
-      <table class="compare-table">
+      <table class="compare-table compare-table--duo">
         <thead>
           <tr>
             <th scope="col"></th>

--- a/website/src/pages/compare/notta.astro
+++ b/website/src/pages/compare/notta.astro
@@ -197,34 +197,8 @@ const faqJsonLd = JSON.stringify({
   border-radius: var(--radius-card); border: 1px solid var(--border-hover);
   background: #fff;
 }
-.compare-table {
-  width: 100%; border-collapse: collapse; font-size: 15px;
-  min-width: 640px;
-}
-.compare-table thead th {
-  padding: 20px 24px; font-size: 16px; font-weight: 700;
-  text-align: left; border-bottom: 2px solid var(--border-hover);
-  background: rgba(248,245,255,0.5);
-}
-.compare-table thead th:first-child { width: 34%; }
-.compare-table thead th:nth-child(2) {
-  background: rgba(124,58,237,0.06);
-  color: var(--accent);
-}
-.compare-table tbody td {
-  padding: 16px 24px; border-bottom: 1px solid var(--border);
-  vertical-align: top; line-height: 1.55;
-}
-.compare-table tbody tr:last-child td { border-bottom: none; }
-.compare-table tbody td:first-child {
-  font-weight: 600; color: var(--text);
-}
-.compare-table tbody td:nth-child(2) {
-  background: rgba(124,58,237,0.02);
-}
-.compare-table tbody td:nth-child(3) {
-  color: var(--text-2);
-}
+/* Table rules moved to global.css (.compare-table--duo) so one owner serves all
+   head-to-head pages and the phone layout there is not fighting 16 scoped copies. */
 .table-check { color: var(--green); font-weight: 700; }
 .table-cross { color: var(--text-3); }
 .table-highlight { color: var(--accent); font-weight: 600; }
@@ -384,7 +358,7 @@ const faqJsonLd = JSON.stringify({
       <p class="section-sub">These are fundamentally different tools. This table shows where they overlap and where they diverge.</p>
     </div>
     <div class="compare-table-wrap reveal">
-      <table class="compare-table">
+      <table class="compare-table compare-table--duo">
         <thead>
           <tr>
             <th scope="col"></th>

--- a/website/src/pages/compare/otter-ai.astro
+++ b/website/src/pages/compare/otter-ai.astro
@@ -197,34 +197,8 @@ const faqJsonLd = JSON.stringify({
   border-radius: var(--radius-card); border: 1px solid var(--border-hover);
   background: #fff;
 }
-.compare-table {
-  width: 100%; border-collapse: collapse; font-size: 15px;
-  min-width: 640px;
-}
-.compare-table thead th {
-  padding: 20px 24px; font-size: 16px; font-weight: 700;
-  text-align: left; border-bottom: 2px solid var(--border-hover);
-  background: rgba(248,245,255,0.5);
-}
-.compare-table thead th:first-child { width: 34%; }
-.compare-table thead th:nth-child(2) {
-  background: rgba(124,58,237,0.06);
-  color: var(--accent);
-}
-.compare-table tbody td {
-  padding: 16px 24px; border-bottom: 1px solid var(--border);
-  vertical-align: top; line-height: 1.55;
-}
-.compare-table tbody tr:last-child td { border-bottom: none; }
-.compare-table tbody td:first-child {
-  font-weight: 600; color: var(--text);
-}
-.compare-table tbody td:nth-child(2) {
-  background: rgba(124,58,237,0.02);
-}
-.compare-table tbody td:nth-child(3) {
-  color: var(--text-2);
-}
+/* Table rules moved to global.css (.compare-table--duo) so one owner serves all
+   head-to-head pages and the phone layout there is not fighting 16 scoped copies. */
 .table-check { color: var(--green); font-weight: 700; }
 .table-cross { color: var(--text-3); }
 .table-highlight { color: var(--accent); font-weight: 600; }
@@ -395,7 +369,7 @@ const faqJsonLd = JSON.stringify({
       <p class="section-sub">Otter.ai and EnviousWispr solve fundamentally different problems. This table highlights where they overlap and where they diverge.</p>
     </div>
     <div class="compare-table-wrap reveal">
-      <table class="compare-table">
+      <table class="compare-table compare-table--duo">
         <thead>
           <tr>
             <th scope="col"></th>

--- a/website/src/pages/compare/spokenly.astro
+++ b/website/src/pages/compare/spokenly.astro
@@ -180,34 +180,8 @@ const faqJsonLd = JSON.stringify({
   border-radius: var(--radius-card); border: 1px solid var(--border-hover);
   background: #fff;
 }
-.compare-table {
-  width: 100%; border-collapse: collapse; font-size: 15px;
-  min-width: 640px;
-}
-.compare-table thead th {
-  padding: 20px 24px; font-size: 16px; font-weight: 700;
-  text-align: left; border-bottom: 2px solid var(--border-hover);
-  background: rgba(248,245,255,0.5);
-}
-.compare-table thead th:first-child { width: 34%; }
-.compare-table thead th:nth-child(2) {
-  background: rgba(124,58,237,0.06);
-  color: var(--accent);
-}
-.compare-table tbody td {
-  padding: 16px 24px; border-bottom: 1px solid var(--border);
-  vertical-align: top; line-height: 1.55;
-}
-.compare-table tbody tr:last-child td { border-bottom: none; }
-.compare-table tbody td:first-child {
-  font-weight: 600; color: var(--text);
-}
-.compare-table tbody td:nth-child(2) {
-  background: rgba(124,58,237,0.02);
-}
-.compare-table tbody td:nth-child(3) {
-  color: var(--text-2);
-}
+/* Table rules moved to global.css (.compare-table--duo) so one owner serves all
+   head-to-head pages and the phone layout there is not fighting 16 scoped copies. */
 .table-check { color: var(--green); font-weight: 700; }
 .table-cross { color: var(--text-3); }
 .table-highlight { color: var(--accent); font-weight: 600; }
@@ -380,7 +354,7 @@ const faqJsonLd = JSON.stringify({
       <p class="section-sub">An honest look at how the two tools stack up across the dimensions that matter most.</p>
     </div>
     <div class="compare-table-wrap reveal">
-      <table class="compare-table">
+      <table class="compare-table compare-table--duo">
         <thead>
           <tr>
             <th scope="col"></th>

--- a/website/src/pages/compare/superwhisper.astro
+++ b/website/src/pages/compare/superwhisper.astro
@@ -189,34 +189,8 @@ const faqJsonLd = JSON.stringify({
   border-radius: var(--radius-card); border: 1px solid var(--border-hover);
   background: #fff;
 }
-.compare-table {
-  width: 100%; border-collapse: collapse; font-size: 15px;
-  min-width: 640px;
-}
-.compare-table thead th {
-  padding: 20px 24px; font-size: 16px; font-weight: 700;
-  text-align: left; border-bottom: 2px solid var(--border-hover);
-  background: rgba(248,245,255,0.5);
-}
-.compare-table thead th:first-child { width: 34%; }
-.compare-table thead th:nth-child(2) {
-  background: rgba(124,58,237,0.06);
-  color: var(--accent);
-}
-.compare-table tbody td {
-  padding: 16px 24px; border-bottom: 1px solid var(--border);
-  vertical-align: top; line-height: 1.55;
-}
-.compare-table tbody tr:last-child td { border-bottom: none; }
-.compare-table tbody td:first-child {
-  font-weight: 600; color: var(--text);
-}
-.compare-table tbody td:nth-child(2) {
-  background: rgba(124,58,237,0.02);
-}
-.compare-table tbody td:nth-child(3) {
-  color: var(--text-2);
-}
+/* Table rules moved to global.css (.compare-table--duo) so one owner serves all
+   head-to-head pages and the phone layout there is not fighting 16 scoped copies. */
 .table-check { color: var(--green); font-weight: 700; }
 .table-cross { color: var(--text-3); }
 .table-highlight { color: var(--accent); font-weight: 600; }
@@ -389,7 +363,7 @@ const faqJsonLd = JSON.stringify({
       <p class="section-sub">An honest look at how the two tools stack up across the dimensions that matter most.</p>
     </div>
     <div class="compare-table-wrap reveal">
-      <table class="compare-table">
+      <table class="compare-table compare-table--duo">
         <thead>
           <tr>
             <th scope="col"></th>

--- a/website/src/pages/compare/typewhisper.astro
+++ b/website/src/pages/compare/typewhisper.astro
@@ -180,34 +180,8 @@ const faqJsonLd = JSON.stringify({
   border-radius: var(--radius-card); border: 1px solid var(--border-hover);
   background: #fff;
 }
-.compare-table {
-  width: 100%; border-collapse: collapse; font-size: 15px;
-  min-width: 640px;
-}
-.compare-table thead th {
-  padding: 20px 24px; font-size: 16px; font-weight: 700;
-  text-align: left; border-bottom: 2px solid var(--border-hover);
-  background: rgba(248,245,255,0.5);
-}
-.compare-table thead th:first-child { width: 34%; }
-.compare-table thead th:nth-child(2) {
-  background: rgba(124,58,237,0.06);
-  color: var(--accent);
-}
-.compare-table tbody td {
-  padding: 16px 24px; border-bottom: 1px solid var(--border);
-  vertical-align: top; line-height: 1.55;
-}
-.compare-table tbody tr:last-child td { border-bottom: none; }
-.compare-table tbody td:first-child {
-  font-weight: 600; color: var(--text);
-}
-.compare-table tbody td:nth-child(2) {
-  background: rgba(124,58,237,0.02);
-}
-.compare-table tbody td:nth-child(3) {
-  color: var(--text-2);
-}
+/* Table rules moved to global.css (.compare-table--duo) so one owner serves all
+   head-to-head pages and the phone layout there is not fighting 16 scoped copies. */
 .table-check { color: var(--green); font-weight: 700; }
 .table-cross { color: var(--text-3); }
 .table-highlight { color: var(--accent); font-weight: 600; }
@@ -380,7 +354,7 @@ const faqJsonLd = JSON.stringify({
       <p class="section-sub">An honest look at how the two tools stack up across the dimensions that matter most.</p>
     </div>
     <div class="compare-table-wrap reveal">
-      <table class="compare-table">
+      <table class="compare-table compare-table--duo">
         <thead>
           <tr>
             <th scope="col"></th>

--- a/website/src/pages/compare/voiceink.astro
+++ b/website/src/pages/compare/voiceink.astro
@@ -189,34 +189,8 @@ const faqJsonLd = JSON.stringify({
   border-radius: var(--radius-card); border: 1px solid var(--border-hover);
   background: #fff;
 }
-.compare-table {
-  width: 100%; border-collapse: collapse; font-size: 15px;
-  min-width: 640px;
-}
-.compare-table thead th {
-  padding: 20px 24px; font-size: 16px; font-weight: 700;
-  text-align: left; border-bottom: 2px solid var(--border-hover);
-  background: rgba(248,245,255,0.5);
-}
-.compare-table thead th:first-child { width: 34%; }
-.compare-table thead th:nth-child(2) {
-  background: rgba(124,58,237,0.06);
-  color: var(--accent);
-}
-.compare-table tbody td {
-  padding: 16px 24px; border-bottom: 1px solid var(--border);
-  vertical-align: top; line-height: 1.55;
-}
-.compare-table tbody tr:last-child td { border-bottom: none; }
-.compare-table tbody td:first-child {
-  font-weight: 600; color: var(--text);
-}
-.compare-table tbody td:nth-child(2) {
-  background: rgba(124,58,237,0.02);
-}
-.compare-table tbody td:nth-child(3) {
-  color: var(--text-2);
-}
+/* Table rules moved to global.css (.compare-table--duo) so one owner serves all
+   head-to-head pages and the phone layout there is not fighting 16 scoped copies. */
 .table-check { color: var(--green); font-weight: 700; }
 .table-cross { color: var(--text-3); }
 .table-highlight { color: var(--accent); font-weight: 600; }
@@ -387,7 +361,7 @@ const faqJsonLd = JSON.stringify({
       <p class="section-sub">An honest look at how the two on-device dictation apps compare across pricing, speed, engines, and features.</p>
     </div>
     <div class="compare-table-wrap reveal">
-      <table class="compare-table">
+      <table class="compare-table compare-table--duo">
         <thead>
           <tr>
             <th scope="col"></th>

--- a/website/src/pages/compare/whisper-cpp.astro
+++ b/website/src/pages/compare/whisper-cpp.astro
@@ -119,34 +119,8 @@ const breadcrumbJsonLd = JSON.stringify({
   border-radius: var(--radius-card); border: 1px solid var(--border-hover);
   background: #fff;
 }
-.compare-table {
-  width: 100%; border-collapse: collapse; font-size: 15px;
-  min-width: 640px;
-}
-.compare-table thead th {
-  padding: 20px 24px; font-size: 16px; font-weight: 700;
-  text-align: left; border-bottom: 2px solid var(--border-hover);
-  background: rgba(248,245,255,0.5);
-}
-.compare-table thead th:first-child { width: 34%; }
-.compare-table thead th:nth-child(2) {
-  background: rgba(124,58,237,0.06);
-  color: var(--accent);
-}
-.compare-table tbody td {
-  padding: 16px 24px; border-bottom: 1px solid var(--border);
-  vertical-align: top; line-height: 1.55;
-}
-.compare-table tbody tr:last-child td { border-bottom: none; }
-.compare-table tbody td:first-child {
-  font-weight: 600; color: var(--text);
-}
-.compare-table tbody td:nth-child(2) {
-  background: rgba(124,58,237,0.02);
-}
-.compare-table tbody td:nth-child(3) {
-  color: var(--text-2);
-}
+/* Table rules moved to global.css (.compare-table--duo) so one owner serves all
+   head-to-head pages and the phone layout there is not fighting 16 scoped copies. */
 .table-check { color: var(--green); font-weight: 700; }
 .table-cross { color: var(--text-3); }
 .table-highlight { color: var(--accent); font-weight: 600; }
@@ -306,7 +280,7 @@ const breadcrumbJsonLd = JSON.stringify({
       <p class="section-sub">whisper.cpp is a developer library. EnviousWispr is a finished Mac app. Here is how they compare for daily dictation use.</p>
     </div>
     <div class="compare-table-wrap reveal">
-      <table class="compare-table">
+      <table class="compare-table compare-table--duo">
         <thead>
           <tr>
             <th scope="col"></th>

--- a/website/src/pages/compare/willow-voice.astro
+++ b/website/src/pages/compare/willow-voice.astro
@@ -120,34 +120,8 @@ const breadcrumbJsonLd = JSON.stringify({
   border-radius: var(--radius-card); border: 1px solid var(--border-hover);
   background: #fff;
 }
-.compare-table {
-  width: 100%; border-collapse: collapse; font-size: 15px;
-  min-width: 640px;
-}
-.compare-table thead th {
-  padding: 20px 24px; font-size: 16px; font-weight: 700;
-  text-align: left; border-bottom: 2px solid var(--border-hover);
-  background: rgba(248,245,255,0.5);
-}
-.compare-table thead th:first-child { width: 34%; }
-.compare-table thead th:nth-child(2) {
-  background: rgba(124,58,237,0.06);
-  color: var(--accent);
-}
-.compare-table tbody td {
-  padding: 16px 24px; border-bottom: 1px solid var(--border);
-  vertical-align: top; line-height: 1.55;
-}
-.compare-table tbody tr:last-child td { border-bottom: none; }
-.compare-table tbody td:first-child {
-  font-weight: 600; color: var(--text);
-}
-.compare-table tbody td:nth-child(2) {
-  background: rgba(124,58,237,0.02);
-}
-.compare-table tbody td:nth-child(3) {
-  color: var(--text-2);
-}
+/* Table rules moved to global.css (.compare-table--duo) so one owner serves all
+   head-to-head pages and the phone layout there is not fighting 16 scoped copies. */
 .table-check { color: var(--green); font-weight: 700; }
 .table-cross { color: var(--text-3); }
 .table-highlight { color: var(--accent); font-weight: 600; }
@@ -319,7 +293,7 @@ const breadcrumbJsonLd = JSON.stringify({
       <p class="section-sub">An honest look at how the two tools stack up across the dimensions that matter most.</p>
     </div>
     <div class="compare-table-wrap reveal">
-      <table class="compare-table">
+      <table class="compare-table compare-table--duo">
         <thead>
           <tr>
             <th scope="col"></th>

--- a/website/src/pages/compare/wisprflow.astro
+++ b/website/src/pages/compare/wisprflow.astro
@@ -197,34 +197,8 @@ const faqJsonLd = JSON.stringify({
   border-radius: var(--radius-card); border: 1px solid var(--border-hover);
   background: #fff;
 }
-.compare-table {
-  width: 100%; border-collapse: collapse; font-size: 15px;
-  min-width: 640px;
-}
-.compare-table thead th {
-  padding: 20px 24px; font-size: 16px; font-weight: 700;
-  text-align: left; border-bottom: 2px solid var(--border-hover);
-  background: rgba(248,245,255,0.5);
-}
-.compare-table thead th:first-child { width: 34%; }
-.compare-table thead th:nth-child(2) {
-  background: rgba(124,58,237,0.06);
-  color: var(--accent);
-}
-.compare-table tbody td {
-  padding: 16px 24px; border-bottom: 1px solid var(--border);
-  vertical-align: top; line-height: 1.55;
-}
-.compare-table tbody tr:last-child td { border-bottom: none; }
-.compare-table tbody td:first-child {
-  font-weight: 600; color: var(--text);
-}
-.compare-table tbody td:nth-child(2) {
-  background: rgba(124,58,237,0.02);
-}
-.compare-table tbody td:nth-child(3) {
-  color: var(--text-2);
-}
+/* Table rules moved to global.css (.compare-table--duo) so one owner serves all
+   head-to-head pages and the phone layout there is not fighting 16 scoped copies. */
 .table-check { color: var(--green); font-weight: 700; }
 .table-cross { color: var(--text-3); }
 .table-highlight { color: var(--accent); font-weight: 600; }
@@ -397,7 +371,7 @@ const faqJsonLd = JSON.stringify({
       <p class="section-sub">An honest look at how the two tools stack up across the dimensions that matter most.</p>
     </div>
     <div class="compare-table-wrap reveal">
-      <table class="compare-table">
+      <table class="compare-table compare-table--duo">
         <thead>
           <tr>
             <th scope="col"></th>

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -218,22 +218,195 @@ body::after {
   .reveal { opacity: 1; transform: none; }
 }
 
-/* #538 on-page SEO: pin the first (feature-label) column of compare tables on phones
-   so labels stay visible while swiping to the competitor column. Adds only NEW sticky
-   properties on the first cell; does not override the per-page scoped wrapper rules.
-   Applies to all .compare-table users (11 /compare/<competitor>/ pages + the /compare/ hub). */
+/* ── Head-to-head comparison table ──────────────────────────────────────────
+   One owner for every two-product /compare/ page. These rules used to be
+   pasted into each page's scoped <style>, where Astro compiled them to
+   `.compare-table[data-astro-cid-…]` and they outranked anything global.css
+   could say, which is why the phone layout below could not take effect.
+   The multi-column hub and roundup keep their own scoped tables.
+   ───────────────────────────────────────────────────────────────────────── */
+.compare-table--duo {
+  width: 100%; border-collapse: collapse; font-size: 15px;
+  min-width: 640px;
+}
+.compare-table--duo thead th {
+  padding: 20px 24px; font-size: 16px; font-weight: 700;
+  text-align: left; border-bottom: 2px solid var(--border-hover);
+  background: rgba(248,245,255,0.5);
+}
+.compare-table--duo thead th:first-child { width: 34%; }
+.compare-table--duo thead th:nth-child(2) {
+  background: rgba(124,58,237,0.06);
+  color: var(--accent);
+}
+.compare-table--duo tbody td {
+  padding: 16px 24px; border-bottom: 1px solid var(--border);
+  vertical-align: top; line-height: 1.55;
+}
+.compare-table--duo tbody tr:last-child td { border-bottom: none; }
+.compare-table--duo tbody td:first-child {
+  font-weight: 600; color: var(--text);
+}
+.compare-table--duo tbody td:nth-child(2) {
+  background: rgba(124,58,237,0.02);
+}
+.compare-table--duo tbody td:nth-child(3) {
+  color: var(--text-2);
+}
+
+/* ── Compare tables on phones ─────────────────────────────────────────────
+   Two shapes of compare table exist and they need opposite treatments.
+
+   TWO-PRODUCT tables (`.compare-table--duo`) switch to a label-band layout:
+   the row label moves ABOVE its two value cells instead of holding a third
+   column, so each product gets half the width instead of the label taking
+   most of it. Nothing scrolls sideways, and the two product names pin below
+   the nav so the reader never loses which side they are reading.
+
+   MULTI-COLUMN tables (the /compare/ hub, the roundup) cannot fit their
+   columns on a phone at any density, so they keep the frozen first column
+   and horizontal scroll from #538. The label band does not generalise to
+   them: it assumes exactly two value cells per row.
+
+   Which pages are which is a property of the markup, not of a list kept
+   here — read it off the tree:
+     grep -rl 'compare-table--duo' src/pages/
+   ───────────────────────────────────────────────────────────────────────── */
+
+/* Multi-column only. A duo table has no scrolling column to pin a label
+   against, and this rule's opaque background would paint over the band. */
 @media (max-width: 600px) {
-  .compare-table thead th:first-child,
-  .compare-table tbody td:first-child {
+  .compare-table:not(.compare-table--duo) thead th:first-child,
+  .compare-table:not(.compare-table--duo) tbody td:first-child {
     position: sticky;
     left: 0;
     z-index: 2;
-    /* Opaque so the scrolling competitor column doesn't ghost through the pinned
-       first column. Some pages set a translucent scoped bg on these first cells
-       (header `thead th` on competitor pages; body `td:first-child` on the /compare/ hub),
-       and Astro boosts scoped-selector specificity, so a targeted !important is the
-       correct tool to keep a sticky-overlay background opaque everywhere. */
+    /* Opaque so the scrolling competitor columns do not ghost through the
+       pinned first column. Some pages set a translucent scoped background on
+       these first cells, so a targeted !important keeps the overlay opaque
+       everywhere. */
     background: #fff !important;
   }
-  .compare-table thead th:first-child { z-index: 3; }
+  .compare-table:not(.compare-table--duo) thead th:first-child { z-index: 3; }
+}
+
+@media (max-width: 700px) {
+  /* The wrapper is a horizontal scroll container, which also makes it the
+     scrollport for position:sticky. A duo table has nothing to scroll to, so
+     releasing it here is what lets the header stick to the viewport. */
+  .compare-table-wrap:has(.compare-table.compare-table--duo) { overflow: visible; }
+
+  .compare-table.compare-table--duo { min-width: 0; display: block; }
+  .compare-table.compare-table--duo thead,
+  .compare-table.compare-table--duo tbody { display: block; }
+
+  /* Product names, pinned. 64px is .nav-inner's height. */
+  .compare-table.compare-table--duo thead tr {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    position: sticky;
+    top: 64px;
+    z-index: 2;
+    background: #fff;
+  }
+  .compare-table.compare-table--duo thead th {
+    width: auto;
+    padding: 12px 14px;
+    font-size: 14px;
+  }
+  /* The label column's header is empty by design; it has no band to name. */
+  .compare-table.compare-table--duo thead th:first-child { display: none; }
+
+  .compare-table.compare-table--duo tbody tr {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    /* Cells size to their own content. Stretching them would make a clamped
+       cell as tall as its unclamped neighbour, and the extra height shows a
+       sliced fourth line below the ellipsis. */
+    align-items: start;
+    border-bottom: 1px solid var(--border-hover);
+    /* Ours-tint and the column divider are painted on the ROW, not the cell,
+       so they still span the full row height once the cells stop stretching. */
+    background: linear-gradient(
+      to right,
+      rgba(124,58,237,0.035) 0 calc(50% - 0.5px),
+      var(--border-hover) calc(50% - 0.5px) calc(50% + 0.5px),
+      transparent calc(50% + 0.5px)
+    );
+  }
+  .compare-table.compare-table--duo tbody tr:last-child { border-bottom: none; }
+
+  .compare-table.compare-table--duo tbody td {
+    padding: 10px 14px 12px;
+    border-bottom: none;
+    font-size: 14.5px;
+  }
+
+  /* The label band: full width, above the pair. */
+  .compare-table.compare-table--duo tbody td:first-child {
+    grid-column: 1 / -1;
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 9px 14px 7px;
+    font-size: 12px;
+    font-weight: 700;
+    line-height: 1.35;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--text-3);
+    background: var(--surface);
+  }
+
+  /* Desktop paints these on the cell; on the row grid that is the row's job. */
+  .compare-table.compare-table--duo tbody td:nth-child(2) {
+    background: none;
+    border-right: none;
+  }
+
+  /* Progressive disclosure. `.duo-clamped` is applied by CompareTableMobile
+     only to rows it MEASURED as overflowing, so a row whose answers already
+     fit is never given a toggle. With JS off nothing is wrapped or clamped
+     and the full text shows, which is the pre-existing behaviour.
+
+     The clamp is on the inner `.duo-text`, never on the cell: a `td` here is
+     a grid item, grid items are blockified, and blockification turns
+     `-webkit-box` into `flow-root` — which silently drops the clamp while
+     leaving `overflow: hidden` to slice the next line through the padding. */
+  .compare-table.compare-table--duo tbody tr.duo-clamped .duo-text {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    line-clamp: 3;
+    overflow: hidden;
+  }
+  .compare-table.compare-table--duo tbody tr.duo-open .duo-text {
+    display: block;
+    -webkit-line-clamp: none;
+    line-clamp: none;
+    overflow: visible;
+  }
+
+  .compare-table.compare-table--duo .duo-toggle {
+    flex: none;
+    font-family: inherit;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--accent);
+    background: none;
+    border: 0;
+    padding: 2px 0 2px 10px;
+    margin: -2px 0;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+  .compare-table.compare-table--duo .duo-toggle:hover { color: var(--accent-hover); }
+  .compare-table.compare-table--duo .duo-toggle:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    border-radius: 3px;
+  }
 }

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -297,17 +297,24 @@ body::after {
   .compare-table-wrap:has(.compare-table.compare-table--duo) { overflow: visible; }
 
   .compare-table.compare-table--duo { min-width: 0; display: block; }
-  .compare-table.compare-table--duo thead,
   .compare-table.compare-table--duo tbody { display: block; }
 
-  /* Product names, pinned. 64px is .nav-inner's height. */
-  .compare-table.compare-table--duo thead tr {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
+  /* Product names, pinned. 64px is .nav-inner's height.
+     The sticky element must be the THEAD, not the header row: a sticky box
+     cannot leave its containing block, and the row's containing block is the
+     thead, which is exactly one row tall — so sticking the row pins it to a
+     box it already fills and it scrolls away with the table. The thead's own
+     containing block is the (display: block) table, which spans every row. */
+  .compare-table.compare-table--duo thead {
+    display: block;
     position: sticky;
     top: 64px;
     z-index: 2;
     background: #fff;
+  }
+  .compare-table.compare-table--duo thead tr {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
   }
   .compare-table.compare-table--duo thead th {
     width: auto;


### PR DESCRIPTION
## Why

Founder review on a phone: the head-to-head compare pages read as one-sided. You see the price, then EnviousWispr, and the competitor column is cut off.

Measured on `/compare/wisprflow/` at 390×844 — the table is pinned to a 640pt minimum, so **250pt sits off the right edge**, and the label column's `width: 34%` lands at 218pt, **56% of the visible screen**. Our own answers clip mid-word; the competitor is not visible at all until the reader thinks to swipe. Nothing cues the swipe, and swiping scrolls the product names away.

Research backing the chosen layout: [NN/g, Mobile Tables](https://www.nngroup.com/articles/mobile-tables/) (dual-axis scrolling raises confusion and task time; freeze labels and headers if you must scroll) and [UX Patterns, Comparison Table](https://uxpatterns.dev/patterns/data-display/comparison-table) (shipping the desktop density model is the named anti-pattern; stacked cards or progressive disclosure are the fallbacks). Only ~2 wordy columns stay legible on a phone — and we have exactly two products, so nothing needs to scroll once the label stops occupying a column.

Founder picked this layout from three mocked options.

## What changed

Below 700pt, two-product tables get a **label band above the pair** instead of a label column beside it:

- Attribute name in a thin full-width band; both products get half the width each.
- Product names pin under the nav so the reader never loses which side they are reading.
- Long answers clamp to three lines with a **"What that means"** toggle — applied only to rows *measured* as overflowing, never a character-count guess.

## Before → after, `/compare/wisprflow/` at 390×844

| | before | after |
|---|---|---|
| table width | 640pt | 390pt |
| hidden off-screen | 250pt | 0pt |
| value cell widths | 213 / 210 (one off-screen) | 195 / 195 |
| horizontal scroll | yes | no |
| clamped rows | n/a | 11 of 23 |

Spot-checked `/compare/dragon/`: same result, 5 of 23 clamped, 0 sliced lines.

**Desktop is unchanged** — verified at 1280px: `display: table`, 34% label column, 16px/24px cell padding, 15px text, 20px/24px header padding, no clamping, no toggles.

## The deduplication, and why it was required rather than tidy-up

All 16 head-to-head pages carried a **byte-identical** copy of the table CSS (one md5 across all 16). Astro compiles a page-scoped rule to `.compare-table[data-astro-cid-…]`, which outranks anything `global.css` can say — so **no phone layout could have taken effect while those copies existed**. This is not a refactor bolted onto the fix; it is the fix's precondition. Confirmed by reading the built CSS, not by assuming.

The copies are removed and replaced by one owner in `global.css`, keyed on a new `.compare-table--duo` class. Net **-241 lines**. After the move, no `.compare-table` rule remains in any duo page's scoped style, so nothing can newly win on specificity — swept, not assumed.

## What was deliberately left alone

The `/compare/` hub (7 columns) and the roundup (variable columns) genuinely cannot fit on a phone at any density, so they keep #538's frozen first column and horizontal scroll. That rule is now scoped `:not(.compare-table--duo)` so it stops painting an opaque background over the new band. Verified both still scroll with a sticky opaque first column and gain no toggles.

## Two implementation notes worth reviewing closely

- **The clamp is on an inner `.duo-text`, not on the cell.** A `td` here is a grid item, grid items are blockified, and blockification turns `display: -webkit-box` into `flow-root` — which silently drops `-webkit-line-clamp` while leaving `overflow: hidden` to slice the next line through the cell's padding. The first fix measured the *cell* and reported clean while the screenshot showed the slice; the probe was asserting a mechanism instead of the outcome.
- **Row cells use `align-items: start`,** so the ours-tint and column divider are painted on the row via a gradient rather than on the cell. Stretched cells made a clamped cell as tall as its unclamped neighbour, which is what exposed the sliced line.

## Degradation

With JS off nothing is wrapped, nothing is clamped, and the full text shows — the behaviour these pages had before. The `:has()` used to release the wrapper's scroll container is the one modern-CSS dependency; without it the header simply stops sticking.

## Validation

- `npm run build` → 131 pages, exit 0
- `npm run check:help` → routes: expected 69, built 69, 0 dead; search: 42 passed, 0 failed
- Rendered measurement at 390×844 on `/compare/wisprflow/` and `/compare/dragon/`; multi-column control on `/compare/` and `/compare/best-dictation-apps-for-mac/`
- Toggle behaviour asserted: label flips, `aria-expanded` flips, row grows, all text visible when open, height restores on close

Lane: Content. No product claims were edited — this is layout only.

Part of the mobile-readability work; no issue number.
