### PR TITLE
test: bind Escape Recovery observability

### DIFF
--- a/Sources/EnviousWisprAppKit/App/EscapeRecoveryPasteAction.swift
+++ b/Sources/EnviousWisprAppKit/App/EscapeRecoveryPasteAction.swift
@@ -25,6 +25,8 @@ enum EscapeRecoveryPasteAction {
   ///     restored. **Inert, not merely harmless**: pasting a cached snapshot
   ///     would hand back text the user was told had gone, which is the one thing
   ///     the 24-hour promise forbids.
+  ///   - copyToClipboard: the clipboard write, injected so tests never touch
+  ///     the developer's real clipboard.
   ///   - report: the restore event, injected so a test can read it.
   ///   - targetHasQuit: whether the app this dictation was aimed at is gone.
   ///     Injected because `NSRunningApplication.isTerminated` cannot be staged
@@ -38,6 +40,7 @@ enum EscapeRecoveryPasteAction {
   static func paste(
     payload: CancelUndoPayload,
     restorable: (UUID) -> (text: String, stampedAt: Date, takeID: String?)?,
+    copyToClipboard: @MainActor (String) -> Void,
     report: (_ ageMs: Int, _ result: EscapeRecoveryPasteResult, _ takeID: String) -> Void,
     retarget: @MainActor (CancelUndoPayload) -> Bool = Self.defaultRetarget,
     targetHasQuit: (CancelUndoPayload) -> Bool = { $0.targetApp?.isTerminated == true },
@@ -52,7 +55,7 @@ enum EscapeRecoveryPasteAction {
       return
     }
 
-    PasteService.copyToClipboard(row.text)
+    copyToClipboard(row.text)
 
     // A TARGET THAT HAS QUIT MUST NOT BE PASTED PAST (cloud review).
     //

--- a/Sources/EnviousWisprAppKit/App/EscapeRecoveryPasteAction.swift
+++ b/Sources/EnviousWisprAppKit/App/EscapeRecoveryPasteAction.swift
@@ -40,14 +40,15 @@ enum EscapeRecoveryPasteAction {
     restorable: (UUID) -> (text: String, stampedAt: Date, takeID: String?)?,
     report: (_ ageMs: Int, _ result: EscapeRecoveryPasteResult, _ takeID: String) -> Void,
     retarget: @MainActor (CancelUndoPayload) -> Bool = Self.defaultRetarget,
-    targetHasQuit: (CancelUndoPayload) -> Bool = { $0.targetApp?.isTerminated == true }
+    targetHasQuit: (CancelUndoPayload) -> Bool = { $0.targetApp?.isTerminated == true },
+    recordLog: @MainActor (_ outcome: String, _ ageMs: Int?, _ takeID: String?) -> Void = Self.log
   ) {
     guard let row = restorable(payload.transcriptID) else {
       // Lapsed between render and press. Silent TO THE USER, whose row is
       // already gone from view and who cannot act on the explanation — but no
       // longer silent to us. A press that produced nothing is the single most
       // likely thing a support conversation is about.
-      Self.log(outcome: "no-row", ageMs: nil, takeID: nil)
+      recordLog("no-row", nil, nil)
       return
     }
 
@@ -75,7 +76,8 @@ enum EscapeRecoveryPasteAction {
     // text went to the clipboard instead. Still a restore."
     if targetHasQuit(payload) {
       Self.finish(
-        .clipboardOnly, stampedAt: row.stampedAt, takeID: row.takeID, report: report)
+        .clipboardOnly, stampedAt: row.stampedAt, takeID: row.takeID, report: report,
+        recordLog: recordLog)
       return
     }
 
@@ -91,7 +93,8 @@ enum EscapeRecoveryPasteAction {
     // pastes it themselves, or takes it from History for the next 24 hours.
     guard retarget(payload) else {
       Self.finish(
-        .clipboardOnly, stampedAt: row.stampedAt, takeID: row.takeID, report: report)
+        .clipboardOnly, stampedAt: row.stampedAt, takeID: row.takeID, report: report,
+        recordLog: recordLog)
       return
     }
     // `NSApp?`, not `NSApp`. It is an implicitly-unwrapped optional and is nil
@@ -112,7 +115,9 @@ enum EscapeRecoveryPasteAction {
     // simulated paste gives no completion signal, so a failure value here would
     // be a guess presented as a measurement.
     //
-    Self.finish(.pasted, stampedAt: row.stampedAt, takeID: row.takeID, report: report)
+    Self.finish(
+      .pasted, stampedAt: row.stampedAt, takeID: row.takeID, report: report,
+      recordLog: recordLog)
   }
 
   /// Record the outcome once, on every path, to BOTH channels.
@@ -135,10 +140,11 @@ enum EscapeRecoveryPasteAction {
     _ result: EscapeRecoveryPasteResult,
     stampedAt: Date,
     takeID: String?,
-    report: (_ ageMs: Int, _ result: EscapeRecoveryPasteResult, _ takeID: String) -> Void
+    report: (_ ageMs: Int, _ result: EscapeRecoveryPasteResult, _ takeID: String) -> Void,
+    recordLog: @MainActor (_ outcome: String, _ ageMs: Int?, _ takeID: String?) -> Void
   ) {
     let ageMs = Int(Date().timeIntervalSince(stampedAt) * 1000)
-    log(outcome: result.rawValue, ageMs: ageMs, takeID: takeID)
+    recordLog(result.rawValue, ageMs, takeID)
     guard let takeID else { return }
     report(ageMs, result, takeID)
   }

--- a/Sources/EnviousWisprAppKit/App/EscapeRecoveryPasteAction.swift
+++ b/Sources/EnviousWisprAppKit/App/EscapeRecoveryPasteAction.swift
@@ -27,6 +27,7 @@ enum EscapeRecoveryPasteAction {
   ///     the 24-hour promise forbids.
   ///   - copyToClipboard: the clipboard write, injected so tests never touch
   ///     the developer's real clipboard.
+  ///   - dispatchPaste: the Cmd-V dispatch, injected for the same reason.
   ///   - report: the restore event, injected so a test can read it.
   ///   - targetHasQuit: whether the app this dictation was aimed at is gone.
   ///     Injected because `NSRunningApplication.isTerminated` cannot be staged
@@ -41,6 +42,7 @@ enum EscapeRecoveryPasteAction {
     payload: CancelUndoPayload,
     restorable: (UUID) -> (text: String, stampedAt: Date, takeID: String?)?,
     copyToClipboard: @MainActor (String) -> Void,
+    dispatchPaste: @escaping @MainActor () -> Void,
     report: (_ ageMs: Int, _ result: EscapeRecoveryPasteResult, _ takeID: String) -> Void,
     retarget: @MainActor (CancelUndoPayload) -> Bool = Self.defaultRetarget,
     targetHasQuit: (CancelUndoPayload) -> Bool = { $0.targetApp?.isTerminated == true },
@@ -110,7 +112,7 @@ enum EscapeRecoveryPasteAction {
     NSApp?.hide(nil)
     Task {
       try? await Task.sleep(for: .milliseconds(TimingConstants.appHideBeforePasteDelayMs))
-      PasteService.simulatePaste()
+      dispatchPaste()
     }
 
     // Reported as `.pasted` because that is what was ATTEMPTED and what the user

--- a/Sources/EnviousWisprAppKit/App/EscapeRecoveryWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/EscapeRecoveryWiring.swift
@@ -69,6 +69,7 @@ enum EscapeRecoveryWiring {
         payload: payload,
         restorable: { coordinator.restorableHeldRow(id: $0) },
         copyToClipboard: { PasteService.copyToClipboard($0) },
+        dispatchPaste: { PasteService.simulatePaste() },
         report: report)
     }
   }

--- a/Sources/EnviousWisprAppKit/App/EscapeRecoveryWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/EscapeRecoveryWiring.swift
@@ -68,6 +68,7 @@ enum EscapeRecoveryWiring {
       EscapeRecoveryPasteAction.paste(
         payload: payload,
         restorable: { coordinator.restorableHeldRow(id: $0) },
+        copyToClipboard: { PasteService.copyToClipboard($0) },
         report: report)
     }
   }

--- a/Sources/EnviousWisprAppKit/App/TranscriptCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/TranscriptCoordinator.swift
@@ -47,6 +47,7 @@ final class TranscriptCoordinator {
   private let emitEscapeRecoveryKept: (_ ageMs: Int, _ takeID: String) -> Void
   private let emitEscapeRecoveryExpired: (_ ageMs: Int, _ takeID: String) -> Void
   private let emitEscapeRecoveryRestoredFromHistory: (_ ageMs: Int, _ takeID: String) -> Void
+  private let recordEscapeRecoveryKeep: @MainActor (_ outcome: String, _ takeID: String?) -> Void
   private var loadTask: Task<Void, Never>?
   private var pulseTask: Task<Void, Never>?
 
@@ -258,7 +259,8 @@ final class TranscriptCoordinator {
     pendingPulseSleep: (@Sendable (Duration) async -> Void)? = nil,
     emitEscapeRecoveryKept: ((_ ageMs: Int, _ takeID: String) -> Void)? = nil,
     emitEscapeRecoveryExpired: ((_ ageMs: Int, _ takeID: String) -> Void)? = nil,
-    emitEscapeRecoveryRestoredFromHistory: ((_ ageMs: Int, _ takeID: String) -> Void)? = nil
+    emitEscapeRecoveryRestoredFromHistory: ((_ ageMs: Int, _ takeID: String) -> Void)? = nil,
+    recordEscapeRecoveryKeep: (@MainActor (_ outcome: String, _ takeID: String?) -> Void)? = nil
   ) {
     self.store = store
     self.pendingPulseInterval = pendingPulseInterval
@@ -279,6 +281,7 @@ final class TranscriptCoordinator {
         TelemetryService.shared.escapeRecoveryRestored(
           source: .history, ageMs: ageMs, pasteResult: .pasted, takeID: takeID)
       }
+    self.recordEscapeRecoveryKeep = recordEscapeRecoveryKeep ?? Self.logKeep
   }
 
   /// Report that a HELD recovery was pasted from History (#2087).
@@ -591,7 +594,7 @@ final class TranscriptCoordinator {
         // user pressed Keep, the row lapsed a moment earlier, and nothing
         // anywhere recorded that the press happened. That is precisely the
         // report a support conversation starts from.
-        Self.logKeep(outcome: "refused-not-offerable", takeID: transcript.escapeRecoveryTakeID)
+        recordEscapeRecoveryKeep("refused-not-offerable", transcript.escapeRecoveryTakeID)
         return
       }
       // #2087: only on a CONFIRMED promotion, and only with the persisted take
@@ -599,12 +602,12 @@ final class TranscriptCoordinator {
       // one ratio this funnel exists to measure.
       if let takeID = transcript.escapeRecoveryTakeID, let stamped = transcript.escapeRecoveredAt {
         emitEscapeRecoveryKept(Int(Date().timeIntervalSince(stamped) * 1000), takeID)
-        Self.logKeep(outcome: "kept", takeID: takeID)
+        recordEscapeRecoveryKeep("kept", takeID)
       } else {
         // Promoted, but with nothing to join it to. The user keeps their text
         // either way — this records the bookkeeping gap rather than letting the
         // Keep disappear from the count it belongs in.
-        Self.logKeep(outcome: "kept-unreported", takeID: nil)
+        recordEscapeRecoveryKeep("kept-unreported", nil)
       }
       guard let index = transcripts.firstIndex(where: { $0.id == transcript.id }) else { return }
       transcripts[index] = transcripts[index].promotedFromPending()

--- a/Tests/EnviousWisprTests/App/EscapeRecoveryObservabilityTests.swift
+++ b/Tests/EnviousWisprTests/App/EscapeRecoveryObservabilityTests.swift
@@ -35,6 +35,7 @@ struct EscapeRecoveryObservabilityTests {
       payload: payload,
       restorable: { _ in ("kept", Date(timeIntervalSinceNow: -1), nil) },
       copyToClipboard: { _ in },
+      dispatchPaste: {},
       report: { _, result, takeID in box.reports.append((result, takeID)) },
       retarget: { _ in
         box.retargetCount += 1
@@ -60,6 +61,7 @@ struct EscapeRecoveryObservabilityTests {
         transcriptID: UUID(), targetApp: nil, targetElement: nil),
       restorable: { _ in nil },
       copyToClipboard: { _ in },
+      dispatchPaste: {},
       report: { _, result, takeID in box.reports.append((result, takeID)) },
       retarget: { _ in
         box.retargetCount += 1

--- a/Tests/EnviousWisprTests/App/EscapeRecoveryObservabilityTests.swift
+++ b/Tests/EnviousWisprTests/App/EscapeRecoveryObservabilityTests.swift
@@ -1,0 +1,143 @@
+import EnviousWisprCore
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprPipeline
+@testable import EnviousWisprStorage
+
+/// The local support trail for Escape Recovery. These cases protect what can be
+/// diagnosed after a press, not whether the user's text was restored.
+@MainActor
+@Suite("Escape Recovery observability (#2087)", .tags(.observabilityContract))
+struct EscapeRecoveryObservabilityTests {
+
+  @MainActor
+  private final class RestoreLogBox {
+    var logs: [(outcome: String, ageMs: Int?, takeID: String?)] = []
+    var reports: [(result: EscapeRecoveryPasteResult, takeID: String)] = []
+    var retargetCount = 0
+  }
+
+  @MainActor
+  private final class KeepLogBox {
+    var logs: [(outcome: String, takeID: String?)] = []
+  }
+
+  @Test("an id-less Undo is logged even though telemetry cannot join it")
+  func idlessUndoStillLogs() {
+    let box = RestoreLogBox()
+    let payload = CancelUndoPayload(
+      transcriptID: UUID(), targetApp: nil, targetElement: nil)
+
+    EscapeRecoveryPasteAction.paste(
+      payload: payload,
+      restorable: { _ in ("kept", Date(timeIntervalSinceNow: -1), nil) },
+      report: { _, result, takeID in box.reports.append((result, takeID)) },
+      retarget: { _ in
+        box.retargetCount += 1
+        return false
+      },
+      targetHasQuit: { _ in false },
+      recordLog: { box.logs.append(($0, $1, $2)) })
+
+    #expect(box.retargetCount == 1, "control: the restore reached its terminal path")
+    #expect(box.reports.isEmpty, "without a take id, telemetry must stay silent")
+    #expect(box.logs.count == 1)
+    #expect(box.logs.first?.outcome == EscapeRecoveryPasteResult.clipboardOnly.rawValue)
+    #expect((box.logs.first?.ageMs ?? -1) >= 1_000)
+    #expect(box.logs.first?.takeID == nil)
+  }
+
+  @Test("an Undo pressed after its row lapses records the refusal")
+  func missingRowLogsTheRefusal() {
+    let box = RestoreLogBox()
+
+    EscapeRecoveryPasteAction.paste(
+      payload: CancelUndoPayload(
+        transcriptID: UUID(), targetApp: nil, targetElement: nil),
+      restorable: { _ in nil },
+      report: { _, result, takeID in box.reports.append((result, takeID)) },
+      retarget: { _ in
+        box.retargetCount += 1
+        return true
+      },
+      targetHasQuit: { _ in false },
+      recordLog: { box.logs.append(($0, $1, $2)) })
+
+    #expect(box.retargetCount == 0)
+    #expect(box.reports.isEmpty)
+    #expect(box.logs.count == 1)
+    #expect(box.logs.first?.outcome == "no-row")
+    #expect(box.logs.first?.ageMs == nil)
+    #expect(box.logs.first?.takeID == nil)
+  }
+
+  @Test("a Keep pressed after its row lapses records the refusal")
+  func refusedKeepStillLogs() {
+    let (store, directory) = makeStore()
+    defer { try? FileManager.default.removeItem(at: directory) }
+    let box = KeepLogBox()
+    let coordinator = TranscriptCoordinator(
+      store: store,
+      recordEscapeRecoveryKeep: { box.logs.append(($0, $1)) })
+    let vanished = held(takeID: "take-late")
+
+    coordinator.keep(vanished)
+
+    #expect(box.logs.count == 1)
+    #expect(box.logs.first?.outcome == "refused-not-offerable")
+    #expect(box.logs.first?.takeID == "take-late")
+  }
+
+  @Test("a successful Keep records its join key")
+  func successfulKeepLogs() throws {
+    let (store, directory) = makeStore()
+    defer { try? FileManager.default.removeItem(at: directory) }
+    let box = KeepLogBox()
+    let row = held(takeID: "take-kept")
+    try store.savePending(row)
+    let coordinator = TranscriptCoordinator(
+      store: store,
+      emitEscapeRecoveryKept: { _, _ in },
+      recordEscapeRecoveryKeep: { box.logs.append(($0, $1)) })
+
+    coordinator.keep(row)
+
+    #expect(box.logs.count == 1)
+    #expect(box.logs.first?.outcome == "kept")
+    #expect(box.logs.first?.takeID == "take-kept")
+  }
+
+  @Test("a successful Keep without a join key records the anomaly")
+  func unreportedKeepLogs() throws {
+    let (store, directory) = makeStore()
+    defer { try? FileManager.default.removeItem(at: directory) }
+    let box = KeepLogBox()
+    let row = held(takeID: nil)
+    try store.savePending(row)
+    let coordinator = TranscriptCoordinator(
+      store: store,
+      recordEscapeRecoveryKeep: { box.logs.append(($0, $1)) })
+
+    coordinator.keep(row)
+
+    #expect(box.logs.count == 1)
+    #expect(box.logs.first?.outcome == "kept-unreported")
+    #expect(box.logs.first?.takeID == nil)
+  }
+
+  private func makeStore() -> (TranscriptStore, URL) {
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ew-2177-observability-\(UUID().uuidString)", isDirectory: true)
+    return (TranscriptStore(directory: directory), directory)
+  }
+
+  private func held(takeID: String?) -> Transcript {
+    Transcript(
+      text: "held", backendType: .parakeet,
+      escapeRecoveredAt: Date(timeIntervalSinceNow: -60),
+      escapeRecoveryTakeID: takeID)
+  }
+}

--- a/Tests/EnviousWisprTests/App/EscapeRecoveryObservabilityTests.swift
+++ b/Tests/EnviousWisprTests/App/EscapeRecoveryObservabilityTests.swift
@@ -34,6 +34,7 @@ struct EscapeRecoveryObservabilityTests {
     EscapeRecoveryPasteAction.paste(
       payload: payload,
       restorable: { _ in ("kept", Date(timeIntervalSinceNow: -1), nil) },
+      copyToClipboard: { _ in },
       report: { _, result, takeID in box.reports.append((result, takeID)) },
       retarget: { _ in
         box.retargetCount += 1
@@ -58,6 +59,7 @@ struct EscapeRecoveryObservabilityTests {
       payload: CancelUndoPayload(
         transcriptID: UUID(), targetApp: nil, targetElement: nil),
       restorable: { _ in nil },
+      copyToClipboard: { _ in },
       report: { _, result, takeID in box.reports.append((result, takeID)) },
       retarget: { _ in
         box.retargetCount += 1

--- a/Tests/EnviousWisprTests/App/EscapeRecoveryRestoreTests.swift
+++ b/Tests/EnviousWisprTests/App/EscapeRecoveryRestoreTests.swift
@@ -34,6 +34,7 @@ struct EscapeRecoveryRestoreTests {
       payload: payload,
       restorable: { _ in row },
       copyToClipboard: { _ in },
+      dispatchPaste: {},
       report: { spy.reports.append((ageMs: $0, result: $1, takeID: $2)) },
       retarget: {
         spy.retargeted.append($0.transcriptID)
@@ -113,6 +114,7 @@ struct EscapeRecoveryRestoreTests {
       payload: payload,
       restorable: { _ in ("kept", Date(), "take-1") },
       copyToClipboard: { _ in },
+      dispatchPaste: {},
       report: { spy.reports.append((ageMs: $0, result: $1, takeID: $2)) },
       retarget: {
         spy.retargeted.append($0.transcriptID)
@@ -145,6 +147,7 @@ struct EscapeRecoveryRestoreTests {
       payload: payload,
       restorable: { _ in ("kept", Date(), "take-1") },
       copyToClipboard: { _ in },
+      dispatchPaste: {},
       report: { spy.reports.append((ageMs: $0, result: $1, takeID: $2)) },
       retarget: {
         spy.retargeted.append($0.transcriptID)
@@ -175,6 +178,7 @@ struct EscapeRecoveryRestoreTests {
       payload: payload,
       restorable: { _ in ("kept", Date(), "take-1") },
       copyToClipboard: { _ in },
+      dispatchPaste: {},
       report: { spy.reports.append((ageMs: $0, result: $1, takeID: $2)) },
       retarget: {
         spy.retargeted.append($0.transcriptID)

--- a/Tests/EnviousWisprTests/App/EscapeRecoveryRestoreTests.swift
+++ b/Tests/EnviousWisprTests/App/EscapeRecoveryRestoreTests.swift
@@ -33,6 +33,7 @@ struct EscapeRecoveryRestoreTests {
     EscapeRecoveryPasteAction.paste(
       payload: payload,
       restorable: { _ in row },
+      copyToClipboard: { _ in },
       report: { spy.reports.append((ageMs: $0, result: $1, takeID: $2)) },
       retarget: {
         spy.retargeted.append($0.transcriptID)
@@ -111,6 +112,7 @@ struct EscapeRecoveryRestoreTests {
     EscapeRecoveryPasteAction.paste(
       payload: payload,
       restorable: { _ in ("kept", Date(), "take-1") },
+      copyToClipboard: { _ in },
       report: { spy.reports.append((ageMs: $0, result: $1, takeID: $2)) },
       retarget: {
         spy.retargeted.append($0.transcriptID)
@@ -142,6 +144,7 @@ struct EscapeRecoveryRestoreTests {
     EscapeRecoveryPasteAction.paste(
       payload: payload,
       restorable: { _ in ("kept", Date(), "take-1") },
+      copyToClipboard: { _ in },
       report: { spy.reports.append((ageMs: $0, result: $1, takeID: $2)) },
       retarget: {
         spy.retargeted.append($0.transcriptID)
@@ -171,6 +174,7 @@ struct EscapeRecoveryRestoreTests {
     EscapeRecoveryPasteAction.paste(
       payload: payload,
       restorable: { _ in ("kept", Date(), "take-1") },
+      copyToClipboard: { _ in },
       report: { spy.reports.append((ageMs: $0, result: $1, takeID: $2)) },
       retarget: {
         spy.retargeted.append($0.transcriptID)

--- a/workers/daily-report/test/report.test.js
+++ b/workers/daily-report/test/report.test.js
@@ -510,6 +510,68 @@ test("adoption section: every recovery column the query asks for reaches the for
   }
 });
 
+test("adoption query: outcome buckets stay aligned with Swift's wire vocabulary", () => {
+  const swift = readFileSync(
+    new URL("../../../Sources/EnviousWisprCore/EscapeRecoveryTerminalOutcome.swift", import.meta.url),
+    "utf8"
+  );
+  const enumBody = swift.match(
+    /public enum EscapeRecoveryTerminalOutcome:[^{]+\{([\s\S]*?)\n\}/
+  )?.[1];
+  assert.ok(enumBody, "expected EscapeRecoveryTerminalOutcome in the Swift source");
+
+  const outcomes = Object.fromEntries(
+    [...enumBody.matchAll(/^\s*case\s+(\w+)(?:\s*=\s*"([^"]+)")?/gm)]
+      .map(([, name, explicitRawValue]) => [name, explicitRawValue || name])
+  );
+  assert.deepEqual(
+    Object.keys(outcomes).sort(),
+    ["abandoned", "empty", "saveFailed", "saved", "transcriptionFailed"],
+    "a new terminal outcome needs an explicit daily-report decision"
+  );
+
+  const adoption = readFileSync(new URL("../src/adoption.js", import.meta.url), "utf8");
+  const totalsQuery = adoption.match(/const totalsSql = `([\s\S]*?)`;/)?.[1];
+  assert.ok(totalsQuery, "expected totalsSql");
+
+  const buckets = new Map();
+  for (const match of totalsQuery.matchAll(
+    /(?:countIf|uniqExactIf)\(([\s\S]*?)\)\s+AS\s+(er_[a-z_]+)/g
+  )) {
+    const literal = match[1].match(/properties\.outcome\s*=\s*'([^']+)'/)?.[1];
+    if (!literal) continue;
+    const aliases = buckets.get(literal) || [];
+    aliases.push(match[2]);
+    buckets.set(literal, aliases);
+  }
+
+  assert.deepEqual(
+    buckets.get(outcomes.saved),
+    ["er_kept", "er_kept_users"],
+    "saved is the only success and owns both its count and unique-user count"
+  );
+  assert.deepEqual(
+    buckets.get(outcomes.transcriptionFailed),
+    ["er_failed_transcription"],
+    "a transcription failure must stay in its own failure bucket"
+  );
+  assert.deepEqual(
+    buckets.get(outcomes.saveFailed),
+    ["er_failed_save"],
+    "a save failure must stay in its own failure bucket"
+  );
+  assert.equal(buckets.has(outcomes.empty), false, "empty audio is not a failure");
+  assert.equal(buckets.has(outcomes.abandoned), false, "a user cancellation is not a failure");
+
+  const knownRawValues = new Set(Object.values(outcomes));
+  for (const literal of totalsQuery.matchAll(/properties\.outcome\s*=\s*'([^']+)'/g)) {
+    assert.ok(
+      knownRawValues.has(literal[1]),
+      `the query uses unknown Escape Recovery outcome '${literal[1]}'`
+    );
+  }
+});
+
 test("adoption section: a report predating the feature renders without it, and without throwing", () => {
   const { escapeRecovery, ...withoutIt } = GOLDEN_DATA;
   const msg = formatAdoption(withoutIt, GOLDEN_BUCKETS).join("\n");


### PR DESCRIPTION
## Summary

- bind Escape Recovery Undo and Keep log outcomes to injectable, production-default sinks
- add five observability-contract tests for id-less, refused, successful, and unreported outcomes
- make the daily-report test read the canonical Swift terminal-outcome enum and verify every SQL bucket against it

## Mutation proof

Seven deliberate defects were caught and restored before commit:

1. Moving the Undo log after the optional take ID guard
2. Deleting the refused Keep log
3. Mapping transcription failures to the save-failure bucket
4. Relabeling an unreported Keep as a normal Keep
5. Treating a missing restore target as success
6. Pointing the recovery announcement to Settings instead of History
7. Changing the recovery pill title

## Validation

- focused Escape Recovery and narrator suites: 40 tests passed
- daily-report worker suite: 178 tests passed
- full Debug lane: 6,365 tests passed
- full Release lane: 5,792 tests passed
- pinned Codex 5.6 review: no actionable defects
- `git diff --check`: clean

Closes #2177
