### PR TITLE
test(audio): classify every stop metadata field

### DIFF
--- a/Tests/EnviousWisprTests/Audio/HALFormatStabilizationTests.swift
+++ b/Tests/EnviousWisprTests/Audio/HALFormatStabilizationTests.swift
@@ -220,6 +220,33 @@ struct CaptureStopMetadataGapTests {
     #expect(clean.inputTimelineGapCount == 0)
   }
 
+  @Test("#1810: every stop field is classified before it can affect gap accounting")
+  func everyStopFieldIsClassified() {
+    // `drainedPreRollSampleCount` deliberately lives on AudioInputSource, not this
+    // metadata. Drained samples were delivered; counting them as a gap would turn
+    // every healthy warm start into a degraded timeline. Freeze the complete field
+    // set so any future stop fact must be reviewed as either a gap addend or a
+    // documented non-addend instead of entering the calculation unnoticed.
+    let metadata = CaptureStopMetadata(nativeRateHz: 24000)
+    let fields = Set(Mirror(reflecting: metadata).children.compactMap { $0.label })
+
+    #expect(
+      fields
+        == Set([
+          "nativeRateHz",
+          "ringDropCount",
+          "converterErrorCount",
+          "zeroOutputCount",
+          "renderFailureCount",
+          "oversizedSliceCount",
+          "preRollGapCount",
+          "lostChunkCount",
+          "rateDivergenceDetected",
+          "nativeChannelCount",
+        ]))
+    #expect(!fields.contains("drainedPreRollSampleCount"))
+  }
+
   @Test("each lossy edge contributes exactly one gap")
   func everyLossyEdgeCounts() {
     #expect(


### PR DESCRIPTION
## Summary

- replace #2199's two impossible `CaptureStopMetadata` mutation rows with a real structural contract
- freeze the complete set of stored stop-metadata fields so every future field must be classified as a gap or a documented non-gap
- explicitly keep delivered `drainedPreRollSampleCount` outside gap metadata

## Mutation proof

Added the defect the stale recipe intended to model: a stored `drainedPreRollSampleCount` field that contributes to `inputTimelineGapCount`. The new test failed on both the unexpected field and the forbidden delivered-sample field, then passed again after the production mutation was restored.

Together with the issue's recorded results, the battery is now:

- filed runnable rows: 4/4 caught
- prior independent mutants: 2/2 caught
- replacement structural mutant: 1/1 caught

The separate real-microphone HAL receipt remains tracked by #2142.

## Validation

- focused Debug suite: 9 tests passed
- focused Release suite: 9 tests passed
- full Debug lane: 6,356 tests passed
- pinned Codex 5.6 review: no actionable defects
- `git diff --check`: clean

Closes #2199
