### PR TITLE
content(compare): refresh pages from live app audit

### DIFF
--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -5,13 +5,13 @@
 Maker: Envious Labs LLC (Connecticut, USA). Founder: Saurabh Vaish.
 License: GNU General Public License v3 (GPLv3, open source on GitHub).
 Platform: macOS 14 (Sonoma) or later, Apple Silicon only.
-Last-updated: 2026-08-05
+Last-updated: 2026-08-21
 
 ## Product
 
 - [How it works](https://enviouswispr.com/how-it-works/): The end-to-end pipeline: keybind hold, audio capture, on-device ASR, optional LLM polish, clipboard or paste-to-app delivery.
 - [Homepage](https://enviouswispr.com/): Download, screenshots, core value proposition, system requirements (Apple Silicon, macOS 14+).
-- [Best dictation apps for Mac](https://enviouswispr.com/compare/best-dictation-apps-for-mac/): A practical 2026 guide to six Mac dictation options, with honest picks by workflow.
+- [Best dictation apps for Mac](https://enviouswispr.com/compare/best-dictation-apps-for-mac/): A practical 2026 guide to seven Mac dictation options, with honest picks by workflow.
 - [Compare to alternatives](https://enviouswispr.com/compare/): Index of comparison pages vs WisprFlow, Superwhisper, Apple Dictation, Dragon, MacWhisper, Otter.ai, and others.
 
 ## Help

--- a/website/src/pages/compare/best-dictation-apps-for-mac.astro
+++ b/website/src/pages/compare/best-dictation-apps-for-mac.astro
@@ -44,40 +44,40 @@ const tableRows = [
   {
     feature: "Price",
     ew: "Free",
-    cells: ["$12-15/mo Pro (free 2k words/wk)", "$8.49/mo (unlimited free tier)", "~$69 (Gumroad) or $99.99 (App Store lifetime)", "$8.33/mo Pro (free 300 min/mo)", "Free (built in)"],
+    cells: ["$12-15/mo Pro (free 2k words/wk)", "$8.49/mo (unlimited free tier)", "~$69 (Gumroad) or $99.99 (App Store lifetime)", "$8.33/mo Pro (free 300 min/mo)", "Free (built in)", "Free for personal and one-person-company work; larger companies pay $12/seat monthly or $120 yearly ($10/mo)"],
   },
   {
     feature: "Audio stays on your Mac",
     ew: "Yes, fully on-device",
-    cells: ["No, cloud", "Yes", "Yes", "No, cloud only", "Mostly (enhanced uses cloud)"],
+    cells: ["No, cloud", "Yes with local models", "Yes", "No, cloud only", "Mostly (enhanced uses cloud)", "Yes"],
   },
   {
     feature: "Works offline",
     ew: "Yes",
-    cells: ["No", "Yes", "Yes", "No", "Partial (enhanced needs internet)"],
+    cells: ["No", "Yes with local models", "Yes", "No", "Partial (enhanced needs internet)", "Yes with downloaded Gemma; Apple Intelligence may use Private Cloud Compute"],
   },
   {
     feature: "Account",
     ew: "No account for core use",
-    cells: ["Email signup required", "No", "No", "Account required", "No"],
+    cells: ["Email signup required", "No", "No", "Account required", "No", "No for personal use"],
   },
   {
     feature: "Polish / cleanup",
     ew: "Yes, on-device with EG-1, Ollama, or Apple Intelligence (macOS 26+); optional cloud via your own key",
-    cells: ["Yes, cloud", "Optional, your own key", "Optional add-on", "AI summaries (cloud)", "No"],
+    cells: ["Yes, cloud", "Local S1-mini or cloud writing models", "Optional add-on", "AI summaries (cloud)", "No", "Downloaded Gemma 4 for strictly local cleanup; Apple Intelligence also offered"],
   },
   {
     feature: "Languages",
     ew: "25 European (Parakeet) + 99 (WhisperKit)",
-    cells: ["100+", "100+", "100+", "~100", "~60"],
+    cells: ["100+", "100+", "100+", "~100", "~60", "25 languages via Parakeet TDT v3; additional multilingual Whisper options"],
   },
   {
     feature: "Best for",
     ew: "Free, private, on-device dictation",
-    cells: ["Polished cross-device dictation", "Customisable on-device modes", "Transcribing existing audio files", "Meetings and long transcripts", "Built-in, zero-install short bursts"],
+    cells: ["Cross-device dictation, meetings, and teams", "Large speech and writing model library", "Transcribing existing audio files", "Meetings and long transcripts", "Built-in, zero-install short bursts", "Editable local modes and a voice task list"],
   },
 ];
-const tableCols = ["WisprFlow", "SuperWhisper", "MacWhisper", "Otter.ai", "Apple Dictation"];
+const tableCols = ["WisprFlow", "SuperWhisper", "MacWhisper", "Otter.ai", "Apple Dictation", "Vox"];
 ---
 
 <BaseLayout
@@ -179,10 +179,10 @@ const tableCols = ["WisprFlow", "SuperWhisper", "MacWhisper", "Otter.ai", "Apple
 
       <div class="method reveal">
         <h2>How we chose</h2>
-        <p>We compared the main Mac dictation and transcription tools on the things that actually change the decision: Mac support, whether your audio stays on your device, offline support, price, whether an account is required, built-in cleanup or AI polish, and whether the app is built for live dictation or for transcribing recorded files. Picks are by use case, not a single universal ranking. Competitor prices and features are verified from each tool's official site (dates in the table note below) and reflect public documentation rather than a hands-on test of every product.</p>
+        <p>We compared the main Mac dictation and transcription tools on the things that actually change the decision: Mac support, whether your audio stays on your device, offline support, price, account requirements, cleanup, and whether the app is built for live dictation, meetings, or recorded files. Picks are by use case, not a single universal ranking. We checked official sources and opened the current installed versions of the local apps where available.</p>
       </div>
 
-      <p class="short-answer reveal">The best Mac dictation app depends on what you need. For <strong>free, fully private, on-device dictation</strong>, EnviousWispr is the pick. For <strong>built-in, zero-install</strong> use, Apple Dictation. For <strong>transcribing existing audio files</strong>, MacWhisper. For <strong>customisable on-device modes</strong>, SuperWhisper. For a <strong>polished cross-device</strong> experience, WisprFlow. For <strong>meetings and long transcripts</strong>, Otter.ai.</p>
+      <p class="short-answer reveal">The best Mac dictation app depends on what you need. For <strong>free, fully private, on-device dictation</strong>, EnviousWispr is the pick. For <strong>built-in, zero-install</strong> use, Apple Dictation. For <strong>recorded audio files</strong>, MacWhisper. For the <strong>broadest speech and writing model library</strong>, SuperWhisper. For <strong>editable local modes and a voice task list</strong>, Vox. For a <strong>cross-device service with meetings and teams</strong>, WisprFlow. For <strong>meetings and long transcripts</strong>, Otter.ai.</p>
     </div>
   </div>
 </section>
@@ -211,7 +211,7 @@ const tableCols = ["WisprFlow", "SuperWhisper", "MacWhisper", "Otter.ai", "Apple
       </table>
     </div>
     <p class="scroll-hint">Scroll the table sideways to see every app.</p>
-    <p class="table-note">Competitor prices and features verified from each tool's official site, April 2026 and re-verified August 2026. EnviousWispr details reflect the current app. Claims are source-verified from public documentation, not a hands-on test of every product.</p>
+    <p class="table-note">Competitor prices and features were re-verified in August 2026 from official sources and current installed apps where available. Exact testing notes live on each head-to-head page.</p>
   </div>
 </section>
 
@@ -248,18 +248,27 @@ const tableCols = ["WisprFlow", "SuperWhisper", "MacWhisper", "Otter.ai", "Apple
     </div>
 
     <div class="pick reveal" id="best-customisable-on-device">
-      <div class="pick-label">Best for customisable on-device modes</div>
+      <div class="pick-label">Best for a large speech and writing model library</div>
       <h2>SuperWhisper</h2>
-      <p>SuperWhisper is the closest on-device alternative to EnviousWispr, and the better fit if you want to tune how the output is formatted per context. It runs Whisper models locally, so audio stays on your Mac and it works offline, and its standout feature is custom modes: pre-built workflows that format the result differently for an email, a code comment, meeting notes, and so on. You can pick from several model sizes to trade speed against accuracy, and connect a cloud model for cleanup if you bring your own key. Its free tier is unlimited but restricted to smaller AI models; Pro runs about $8.49 a month, with a lifetime option, for the full model lineup. If per-context formatting and model choice are worth paying for, SuperWhisper is the right pick. If you mainly want free, fast, private dictation without the configuration, EnviousWispr covers that.</p>
+      <p>SuperWhisper is the better fit if choosing models is part of the experience you want. Its searchable library includes local and cloud speech models, several writing-model families, provider filters, and per-app or per-site Modes. The current app also supports system-audio capture, speaker identification, file transcription, and Claude Code or Codex plugins. Local Cohere Transcribe and S1-mini can keep speech and basic cleanup on your Mac; richer cloud modes use online providers. Its free tier is unlimited but restricted to smaller AI models, while Pro runs about $8.49 a month with a lifetime option.</p>
       <div class="pick-links">
         <a href="/compare/superwhisper/">Full EnviousWispr vs SuperWhisper comparison</a>
+      </div>
+    </div>
+
+    <div class="pick reveal" id="best-local-modes-and-tasks">
+      <div class="pick-label">Best for editable local modes and a voice task list</div>
+      <h2>Vox</h2>
+      <p>Vox keeps transcription on your device and can keep cleanup local with a downloaded Gemma 4 model, then lets you shape the result with editable Voice Modes for chat, email, notes, code comments, summaries, and your own prompts. Its Mac-only VoxNotch surface can add, finish, reorder, reprioritize, and remove tasks by natural voice. The core dictation experience also runs on Windows. Vox is free for personal use; work use at a company with more than one person costs $12 per seat monthly or $120 per seat yearly, equivalent to $10 per month.</p>
+      <div class="pick-links">
+        <a href="/compare/vox/">Full EnviousWispr vs Vox comparison</a>
       </div>
     </div>
 
     <div class="pick reveal" id="best-cross-device">
       <div class="pick-label">Best polished cross-device dictation</div>
       <h2>WisprFlow</h2>
-      <p>WisprFlow is the most polished commercial dictation tool, and the right choice if you work across more than just a Mac. It runs on Mac, Windows, iOS, and Android, so your setup follows you across devices, and it is more feature-rich than the free options today: snippets, backtrack, per-app tones, command mode, and syntax awareness. The trade-off is architecture and cost: transcription happens in the cloud, so your audio is uploaded to its servers, it needs an internet connection, and it is a subscription ($15 a month, or $12 a month billed annually, after a limited free tier, with an email account required). If cross-device support and the deepest feature set matter more to you than keeping audio on your machine or avoiding a subscription, WisprFlow earns the pick. If privacy and price are the priorities, the free on-device options close most of the everyday gap.</p>
+      <p>WisprFlow is the most complete service in this group if you work across devices, meetings, and a team. It runs on Mac, Windows, iOS, and Android, and the current Mac app includes Notetaker, shared dictionary and snippets, Transforms, Scratchpad, Insights, app-category Styles, coding-editor awareness, and enterprise controls. The trade-off is architecture and cost: transcription happens in the cloud, it needs an internet connection and account, and Pro costs $15 a month or $12 a month billed annually after a limited free tier. Choose it when the service layer matters more than local audio processing or avoiding a subscription.</p>
       <div class="pick-links">
         <a href="/compare/wisprflow/">Full EnviousWispr vs WisprFlow comparison</a>
       </div>
@@ -287,7 +296,8 @@ const tableCols = ["WisprFlow", "SuperWhisper", "MacWhisper", "Otter.ai", "Apple
         <ul>
           <li>You need snippets, backtrack, per-app tones, cross-platform support, or command-mode features today: choose <a href="/compare/wisprflow/">WisprFlow</a>.</li>
           <li>You record and summarise meetings with multiple speakers: choose <a href="/compare/otter-ai/">Otter.ai</a> or <a href="/compare/notta/">Notta</a>.</li>
-          <li>You want per-context output modes and do not mind a subscription: choose <a href="/compare/superwhisper/">SuperWhisper</a>.</li>
+          <li>You want the broadest speech and writing model library: choose <a href="/compare/superwhisper/">SuperWhisper</a>.</li>
+          <li>You want editable local modes, Windows support, or a voice-controlled Mac task list: choose <a href="/compare/vox/">Vox</a>.</li>
           <li>You mainly transcribe already-recorded audio or video files: choose <a href="/compare/macwhisper/">MacWhisper</a>.</li>
           <li>You need hands-free Mac control or system commands, not just text dictation: start with Apple's built-in Voice Control accessibility tools.</li>
         </ul>
@@ -307,7 +317,7 @@ const tableCols = ["WisprFlow", "SuperWhisper", "MacWhisper", "Otter.ai", "Apple
         Download EnviousWispr Free
       </a>
     </div>
-    <p class="directory-line reveal" style="margin-top: 28px;">Want every head-to-head? See all <a href="/compare/">16 Mac dictation app comparisons</a>.</p>
+    <p class="directory-line reveal" style="margin-top: 28px;">Want every head-to-head? See all <a href="/compare/">17 Mac dictation app comparisons</a>.</p>
   </div>
 </section>
 

--- a/website/src/pages/compare/fluidvoice.astro
+++ b/website/src/pages/compare/fluidvoice.astro
@@ -71,7 +71,7 @@ const faqJsonLd = JSON.stringify({
       "name": "How is EnviousWispr different from FluidVoice?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Both are Mac-native, on-device, GPLv3, and ship a custom AI model tuned specifically for cleaning up dictation, so this is not a case where one app has polish and the other does not. The differences are elsewhere. EnviousWispr supports macOS 14 Sonoma and later; FluidVoice needs macOS 15 Sequoia or later. FluidVoice offers a choice of five transcription engines (Nemotron, Parakeet, Cohere, Whisper, and Apple Speech); EnviousWispr offers two, Parakeet TDT and WhisperKit, switched manually in Settings. EnviousWispr adds Escape Recovery, which can keep a dictation you cancel by accident, something not documented on FluidVoice's side."
+        "text": "Both are Mac-native, on-device, GPLv3, and ship a custom AI model tuned specifically for cleaning up dictation. EnviousWispr supports macOS 14 Sonoma and later; FluidVoice needs macOS 15 Sequoia or later. FluidVoice 1.6.9 showed 14 speech-model choices across Apple Speech, Cohere, Nemotron, Parakeet, and Whisper; EnviousWispr offers Parakeet TDT and WhisperKit. FluidVoice also has deeper prompt routing, spoken formatting, file transcription, and Command Mode. EnviousWispr keeps setup smaller and adds Escape Recovery for a dictation cancelled by accident."
       }
     },
     {
@@ -79,7 +79,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Does FluidVoice have AI polish like EnviousWispr's EG-1?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes. FluidVoice ships its own model, called Fluid Intelligence or Fluid-1, fine-tuned specifically for cleaning up dictation, the same way our EG-1 is. Neither app asks you to write your own prompt; both ship a working default. The main difference is disclosure: EG-1's license and its base model (a fine-tune of Qwen3-4B-Instruct-2507) are published in our repository. FluidVoice's Fluid-1 runtime and model are not part of its GPLv3 app code and are not publicly documented in the same way."
+        "text": "Yes. FluidVoice ships Fluid Intelligence, also called Fluid-1, and a working default prompt. It also supports OpenAI, Anthropic, xAI, Groq, Cerebras, Google, OpenRouter, Ollama, LM Studio, and custom OpenAI-compatible endpoints, with reusable prompt profiles and app overrides. EnviousWispr offers a smaller provider list and its own EG-1 model with published license and base-model details."
       }
     },
     {
@@ -119,7 +119,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Which speech engines does each app use?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "EnviousWispr runs NVIDIA Parakeet TDT v3 for 25 European languages and WhisperKit for 99 languages, switched manually under Settings, Transcription. FluidVoice offers a choice of five: Nemotron (40 languages), Parakeet (25 languages), Cohere (14 languages), Whisper (99 languages), and Apple Speech (your Mac's installed languages), and you choose which one to use."
+        "text": "EnviousWispr runs NVIDIA Parakeet TDT v3 for 25 European languages and WhisperKit for 99 languages, switched manually under Settings, Transcription. FluidVoice 1.6.9 showed 14 choices: two Apple speech options, one Cohere model, three Parakeet models, two Nemotron models, and six Whisper sizes."
       }
     },
     {
@@ -391,7 +391,9 @@ const faqJsonLd = JSON.stringify({
                  downloads a real local model (~1.54GB, Apple Silicon tag, no API key) rather than calling a
                  cloud API, so the existing "on-device" claim for it holds.
              Confidence: source-verified from FluidVoice's own GitHub repo, prior internal teardown, and the
-             installed app opened directly. Last verified: 2026-08-21. -->
+             installed app opened directly. The live app exposed 14 speech choices, 10 named AI providers
+             plus a custom endpoint, editable prompt profiles, spoken formatting, Train by Voice,
+             Command Mode, and configurable direct or clipboard insertion. Last verified: 2026-08-21. -->
         <tbody>
           <tr>
             <td>Price</td>
@@ -416,17 +418,17 @@ const faqJsonLd = JSON.stringify({
           <tr>
             <td>Speech engines</td>
             <td><span class="table-highlight">Parakeet TDT v3 + WhisperKit</span>, switch in Settings</td>
-            <td><span class="table-check">Choice of five</span>: Nemotron, Parakeet, Cohere, Whisper, or Apple Speech</td>
+            <td><span class="table-check">14 visible choices</span> across Apple Speech, Cohere, Nemotron, Parakeet, and Whisper</td>
           </tr>
           <tr>
             <td>AI polish (cleanup after transcription)</td>
             <td><span class="table-highlight">EG-1</span> (our own tuned model), Apple Intelligence, Ollama, or your own OpenAI, Claude, or Gemini key</td>
-            <td><span class="table-check">Fluid-1</span> (their own tuned model), included at no cost, about 3.5GB download</td>
+            <td><span class="table-check">Fluid-1 plus broad provider choice</span>: OpenAI, Anthropic, xAI, Groq, Cerebras, Google, OpenRouter, Ollama, LM Studio, or a custom endpoint</td>
           </tr>
           <tr>
             <td>Needs a prompt to be written</td>
             <td><span class="table-check">No</span>: EG-1 and Apple Intelligence ship with a working default</td>
-            <td><span class="table-check">No</span>: Fluid-1 ships with its own fixed prompt too</td>
+            <td><span class="table-check">No</span>: a working default ships with the app, and prompt profiles can be edited or routed by app</td>
           </tr>
           <tr>
             <td>AI polish model's license disclosed</td>
@@ -446,7 +448,7 @@ const faqJsonLd = JSON.stringify({
           <tr>
             <td>Custom vocabulary</td>
             <td><span class="table-check">Yes</span> (names, terms, jargon; imports from 8 other apps, FluidVoice included)</td>
-            <td><span class="table-check">Yes</span> (custom vocabulary file, with alias support per term)</td>
+            <td><span class="table-check">Yes</span> (aliases, import/export, auto-learning, and Train by Voice)</td>
           </tr>
           <tr>
             <td>Transcription latency</td>
@@ -466,7 +468,7 @@ const faqJsonLd = JSON.stringify({
           <tr>
             <td>Text lands in the right app</td>
             <td><span class="table-check">Yes</span> (target app reactivation via Accessibility API, three-tier paste fallback)</td>
-            <td>Not specified</td>
+            <td><span class="table-check">Yes</span> (direct insertion or clipboard paste, configurable)</td>
           </tr>
         </tbody>
       </table>
@@ -570,7 +572,7 @@ const faqJsonLd = JSON.stringify({
         </div>
         <div class="privacy-step">
           <div class="privacy-step-num">3</div>
-          <div>Fluid-1, their own tuned model, runs the polish pass on-device, using a fixed prompt they ship rather than one you write.</div>
+          <div>Fluid-1, their own tuned model, can run the polish pass on-device with the working default prompt or an editable prompt profile.</div>
         </div>
         <div class="privacy-step">
           <div class="privacy-step-num">4</div>
@@ -621,12 +623,12 @@ const faqJsonLd = JSON.stringify({
     <div class="deep-dive-grid">
       <div class="deep-dive-card reveal">
         <div class="deep-dive-icon">🔀</div>
-        <div class="deep-dive-title">Two engines to switch between, or five to choose from</div>
+        <div class="deep-dive-title">Two engines to switch between, or fourteen models to choose from</div>
         <div class="deep-dive-body">
-          <p>FluidVoice gives you a real menu: Nemotron, Parakeet, Cohere, Whisper, or Apple Speech, each with its own language coverage and speed profile. If you want to hand-tune which engine handles which language, that flexibility is real and it is one of the clearest reasons to pick FluidVoice.</p>
+          <p>FluidVoice 1.6.9 showed fourteen choices across Apple Speech, Cohere, Nemotron, Parakeet, and Whisper. The list includes streaming, multilingual, small, and large options with different speed and language trade-offs.</p>
           <p>EnviousWispr keeps it to two: Parakeet TDT v3 for the 25 languages it covers best, and WhisperKit filling in the other 74, switched manually under Settings, Transcription. There is no larger menu; the app is built around this one pairing.</p>
           <div class="deep-dive-detail">
-            <strong>Why it matters:</strong> Power users who want to compare engines directly, or who need a specific one of FluidVoice's five, get more choice there today. Anyone who wants one setup that already works gets that from EnviousWispr.
+            <strong>Why it matters:</strong> Power users who want to compare engines directly get much more choice in FluidVoice. Anyone who wants a smaller setup gets that from EnviousWispr.
           </div>
         </div>
       </div>
@@ -657,7 +659,7 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">🎚️</div>
         <div class="advantage-title">You want a wider menu of transcription engines</div>
-        <p class="advantage-desc">Nemotron, Parakeet, Cohere, Whisper, or Apple Speech, FluidVoice lets you pick from five. EnviousWispr offers two, Parakeet and WhisperKit, switched manually in Settings, which is simpler but leaves less to tune.</p>
+        <p class="advantage-desc">FluidVoice 1.6.9 showed fourteen speech-model choices across five families. EnviousWispr offers Parakeet and WhisperKit, which is simpler but leaves much less to tune.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">💻</div>
@@ -680,7 +682,7 @@ const faqJsonLd = JSON.stringify({
         <p class="advantage-desc">FluidVoice can transcribe an existing audio or video file you drag in, WAV, MP3, M4A, OGG, MP4, and more, useful for a meeting recording made elsewhere. EnviousWispr only transcribes what you dictate live; it has no file-upload transcription today.</p>
       </div>
     </div>
-    <p style="font-size: 15px; color: var(--text-2); text-align: center; margin-top: 24px;">If you want a choice of five transcription engines, run an Intel Mac, want to follow a project expanding across platforms, or need to transcribe an existing recording, FluidVoice is a strong pick. If you want the same idea, a model tuned for dictation with no prompt to write, on a wider range of macOS versions, <a href="/#download" style="color: var(--accent); text-decoration: underline;">give EnviousWispr a try</a>. You can always use both.</p>
+    <p style="font-size: 15px; color: var(--text-2); text-align: center; margin-top: 24px;">If you want fourteen speech-model choices, deep prompt routing, an Intel Mac path, or file transcription, FluidVoice is a strong pick. If you want a smaller setup with a tuned default model on more macOS versions, <a href="/#download" style="color: var(--accent); text-decoration: underline;">give EnviousWispr a try</a>. You can always use both.</p>
   </div>
 </section>
 
@@ -698,11 +700,11 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">How is EnviousWispr different from FluidVoice?</div>
-        <p class="faq-a">Both are Mac-native, on-device, GPLv3, and ship a custom AI model tuned specifically for cleaning up dictation, so this is not a case where one app has polish and the other does not. The differences are elsewhere. EnviousWispr supports macOS 14 Sonoma and later; FluidVoice needs macOS 15 Sequoia or later. FluidVoice offers a choice of five transcription engines (Nemotron, Parakeet, Cohere, Whisper, and Apple Speech); EnviousWispr offers two, Parakeet TDT and WhisperKit, switched manually in Settings. EnviousWispr adds Escape Recovery, which can keep a dictation you cancel by accident, something not documented on FluidVoice's side.</p>
+        <p class="faq-a">Both are Mac-native, on-device, GPLv3, and ship a custom AI model tuned specifically for cleaning up dictation. EnviousWispr supports macOS 14 Sonoma and later; FluidVoice needs macOS 15 Sequoia or later. FluidVoice 1.6.9 showed fourteen speech-model choices across Apple Speech, Cohere, Nemotron, Parakeet, and Whisper. It also has deeper prompt routing, spoken formatting, file transcription, and Command Mode. EnviousWispr keeps setup smaller and adds Escape Recovery.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Does FluidVoice have AI polish like EnviousWispr's EG-1?</div>
-        <p class="faq-a">Yes. FluidVoice ships its own model, called Fluid Intelligence or Fluid-1, fine-tuned specifically for cleaning up dictation, the same way our EG-1 is. Neither app asks you to write your own prompt; both ship a working default. The main difference is disclosure: EG-1's license and its base model (a fine-tune of Qwen3-4B-Instruct-2507) are published in our repository. FluidVoice's Fluid-1 runtime and model are not part of its GPLv3 app code and are not publicly documented in the same way.</p>
+        <p class="faq-a">Yes. FluidVoice ships Fluid Intelligence, also called Fluid-1, and a working default prompt. It also supports OpenAI, Anthropic, xAI, Groq, Cerebras, Google, OpenRouter, Ollama, LM Studio, and custom OpenAI-compatible endpoints, with reusable prompt profiles and app overrides. EnviousWispr offers a smaller provider list and its own EG-1 model with published license and base-model details.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Can I use EnviousWispr completely offline?</div>
@@ -722,7 +724,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Which speech engines does each app use?</div>
-        <p class="faq-a">EnviousWispr runs NVIDIA Parakeet TDT v3 for 25 European languages and WhisperKit for 99 languages, switched manually under Settings, Transcription. FluidVoice offers a choice of five: Nemotron (40 languages), Parakeet (25 languages), Cohere (14 languages), Whisper (99 languages), and Apple Speech (your Mac's installed languages), and you choose which one to use.</p>
+        <p class="faq-a">EnviousWispr runs NVIDIA Parakeet TDT v3 for 25 European languages and WhisperKit for 99 languages. FluidVoice 1.6.9 showed fourteen choices: two Apple speech options, one Cohere model, three Parakeet models, two Nemotron models, and six Whisper sizes.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Does FluidVoice run on Windows or iOS?</div>

--- a/website/src/pages/compare/handy.astro
+++ b/website/src/pages/compare/handy.astro
@@ -127,7 +127,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Which speech engines does each app use?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "EnviousWispr runs NVIDIA Parakeet TDT v3 for 25 European languages and WhisperKit for 99 languages. Handy offers a choice of engines: OpenAI Whisper in several sizes (Small, Medium, Turbo, Large) with GPU acceleration, plus Parakeet V2 and V3. Handy's Whisper option lets you trade speed for accuracy on capable hardware; EnviousWispr defaults to Parakeet for speed, and switching to WhisperKit for a language it doesn't cover is one setting away, under Settings, Transcription."
+        "text": "EnviousWispr runs NVIDIA Parakeet TDT v3 and WhisperKit. Handy 0.9.5 showed dozens of downloadable choices across Parakeet, Nemotron, Canary, Cohere, Whisper, Voxtral, Qwen3 ASR, FunASR, Granite, Moonshine, SenseVoice, GigaAM, Breeze, and MedASR."
       }
     },
     {
@@ -376,14 +376,14 @@ const faqJsonLd = JSON.stringify({
              Sources:
                - github.com/cjpais/Handy (accessed 2026-08-21): MIT license, 30,050 stars, latest release
                  v0.9.5 (2026-08-08), platforms (macOS Intel+Apple Silicon, Windows x64, Linux x64),
-                 engines (Whisper Small/Medium/Turbo/Large with GPU acceleration; Parakeet V2/V3, CPU-optimized,
-                 automatic language detection), custom dictionary via Raycast integration, no cloud
-                 transcription engine.
+                 cross-platform support and local transcription. The live 0.9.5 model catalog was materially
+                 broader than the older README list.
                - handy.computer/docs/post-processing (accessed 2026-08-21): a Post-Processing feature exists,
                  triggered by a SEPARATE dedicated hotkey from plain transcription (the regular hotkey always
                  gives plain output). Providers: OpenAI, Anthropic, OpenRouter, Groq, Cerebras, Z.AI (all
                  cloud, bring your own API key), Apple Intelligence (on-device, Apple Silicon, macOS 26+), and
-                 any OpenAI-compatible local server.
+                 any OpenAI-compatible local server. The installed app also exposed Custom and AWS Bedrock
+                 through Mantle.
                - Handy v0.9.5, opened directly on 2026-08-21: Post-Processing is off by default
                  (src-tauri/src/settings.rs, default_post_process_enabled() = false) and its provider defaults
                  to OpenAI, not Apple Intelligence. It ships one ready-made prompt out of the box, named
@@ -396,7 +396,9 @@ const faqJsonLd = JSON.stringify({
                  with Parakeet, which does not support streaming.
              Confidence: source-verified from Handy's own site, GitHub repo and source code, and confirmed
              by opening the installed app directly. Features marked "Not published" or "Not documented" were
-             not found in Handy's public documentation as of 2026-08-21. Last verified: 2026-08-21. -->
+             not found in Handy's public documentation as of 2026-08-21. The live app also confirmed built-in
+             custom words, explicit clipboard behavior, model unloading, and CPU/Apple GPU controls.
+             Last verified: 2026-08-21. -->
         <tbody>
           <tr>
             <td>Price</td>
@@ -416,12 +418,12 @@ const faqJsonLd = JSON.stringify({
           <tr>
             <td>Speech engines</td>
             <td><span class="table-highlight"><a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3" style="color: var(--accent); text-decoration: underline;">Parakeet TDT v3</a> + WhisperKit</span> (dual engines, on-device)</td>
-            <td>Whisper (Small/Medium/Turbo/Large, GPU accelerated) + Parakeet V2/V3</td>
+            <td><span class="table-check">Dozens of local choices</span> across Parakeet, Nemotron, Canary, Cohere, Whisper, Voxtral, Qwen3 ASR, FunASR, Granite, Moonshine, SenseVoice, GigaAM, Breeze, and MedASR</td>
           </tr>
           <tr>
             <td>Model choice</td>
             <td>Parakeet by default; switch to WhisperKit in Settings for other languages</td>
-            <td><span class="table-check">Yes</span>: pick a Whisper size to trade speed for accuracy</td>
+            <td><span class="table-check">Extensive</span>: filter the downloadable catalog by language, streaming, translation, and model family</td>
           </tr>
           <tr>
             <td>Audio leaves your Mac</td>
@@ -436,7 +438,7 @@ const faqJsonLd = JSON.stringify({
           <tr>
             <td>AI polish (cleanup after transcription)</td>
             <td><span class="table-highlight">EG-1, Apple Intelligence, or a local Ollama model on-device;</span> OpenAI, Claude, or Gemini with your own key, or Ollama's hosted models with your Ollama sign-in</td>
-            <td><span class="table-check">Yes</span>: OpenAI, Anthropic, OpenRouter, Groq, Cerebras, or Z.AI with your own key, Apple Intelligence on-device, or a local server</td>
+            <td><span class="table-check">Yes</span>: OpenAI, OpenRouter, Anthropic, Groq, Cerebras, Apple Intelligence, Custom, Z.AI, or AWS Bedrock through Mantle</td>
           </tr>
           <tr>
             <td>Default provider needs a download or an API key</td>
@@ -456,12 +458,12 @@ const faqJsonLd = JSON.stringify({
           <tr>
             <td>Filler word removal</td>
             <td><span class="table-check">Yes</span> (built-in, automatic, language-aware, runs before AI polish)</td>
-            <td><span class="table-check">Yes</span>: strips a fixed list of words you configure yourself, not automatic detection</td>
+            <td>Handled by the shipped Post Process prompt when that separate workflow is used</td>
           </tr>
           <tr>
             <td>Turns a spoken list into a real list, no prompt needed</td>
             <td><span class="table-check">Yes</span> (EG-1, 83% of the time in our own testing)</td>
-            <td>Possible if you write a prompt for it; not a built-in behavior</td>
+            <td>Depends on the selected prompt and provider; custom prompts are supported</td>
           </tr>
           <tr>
             <td>Live preview while speaking</td>
@@ -476,7 +478,7 @@ const faqJsonLd = JSON.stringify({
           <tr>
             <td>Custom vocabulary</td>
             <td><span class="table-check">Yes</span> (names, terms, jargon; imports from 8 other apps, Handy included)</td>
-            <td><span class="table-check">Yes</span> (dictionary management via Raycast integration)</td>
+            <td><span class="table-check">Yes</span> (built into Advanced settings; Raycast integration also exists)</td>
           </tr>
           <tr>
             <td>Transcription latency</td>
@@ -486,7 +488,7 @@ const faqJsonLd = JSON.stringify({
           <tr>
             <td>Clipboard preservation</td>
             <td><span class="table-check">Yes</span> (clipboard saved before paste, restored after)</td>
-            <td>Not specified</td>
+            <td><span class="table-check">Configurable</span>: leave the clipboard untouched or keep a transcript copy; paste with Command-V or choose no paste</td>
           </tr>
           <tr>
             <td>Where transcription runs</td>
@@ -708,7 +710,7 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">🎚️</div>
         <div class="advantage-title">You want to choose your own model</div>
-        <p class="advantage-desc">Handy lets you pick among several Whisper sizes to trade speed for accuracy, and it can load custom GGUF models from Hugging Face. EnviousWispr offers just two, Parakeet or WhisperKit, switched manually in Settings, which is simpler but leaves less to tune.</p>
+        <p class="advantage-desc">Handy's live catalog covered more than a dozen model families, with filters for language, streaming, and translation. EnviousWispr offers Parakeet or WhisperKit, which is simpler but leaves far less to tune.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">🪪</div>
@@ -723,7 +725,7 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">🎯</div>
         <div class="advantage-title">You want more cloud providers to choose from</div>
-        <p class="advantage-desc">Handy's Post-Processing supports OpenAI, Anthropic, OpenRouter, Groq, Cerebras, and Z.AI, six cloud options beside Apple Intelligence and a local server. EnviousWispr's cloud polish covers OpenAI, Claude, and Gemini. If the specific model you want to plug in is not one of our three, Handy's list is longer.</p>
+        <p class="advantage-desc">Handy's Post Process list includes OpenAI, OpenRouter, Anthropic, Groq, Cerebras, Apple Intelligence, Custom, Z.AI, and AWS Bedrock through Mantle. EnviousWispr's cloud polish covers OpenAI, Claude, Gemini, and hosted Ollama. Handy's provider menu is wider.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">🎧</div>
@@ -731,7 +733,7 @@ const faqJsonLd = JSON.stringify({
         <p class="advantage-desc">Handy's History keeps an audio player alongside every saved entry, so you can play back what you actually said. EnviousWispr discards audio after every dictation by design, even in History, so this is not something we offer.</p>
       </div>
     </div>
-    <p style="font-size: 15px; color: var(--text-2); text-align: center; margin-top: 24px;">If you want to customize your own cleanup prompt and pick from a wider list of cloud providers, or you need Windows or Linux support, Handy is a strong pick. If you want cleanup that works the moment you turn it on, no provider or prompt required, <a href="/#download" style="color: var(--accent); text-decoration: underline;">give EnviousWispr a try</a>. You can always use both.</p>
+    <p style="font-size: 15px; color: var(--text-2); text-align: center; margin-top: 24px;">If you want a large local model catalog, detailed hardware controls, or Windows and Linux support, Handy is a strong pick. If you want a smaller curated setup with one hotkey for dictation and cleanup, <a href="/#download" style="color: var(--accent); text-decoration: underline;">give EnviousWispr a try</a>. You can always use both.</p>
   </div>
 </section>
 
@@ -777,7 +779,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Which speech engines does each app use?</div>
-        <p class="faq-a">EnviousWispr runs NVIDIA Parakeet TDT v3 for 25 European languages and WhisperKit for 99 languages. Handy offers a choice of engines: OpenAI Whisper in several sizes (Small, Medium, Turbo, Large) with GPU acceleration, plus Parakeet V2 and V3. Handy's Whisper option lets you trade speed for accuracy on capable hardware; EnviousWispr defaults to Parakeet for speed, and switching to WhisperKit for a language it doesn't cover is one setting away, under Settings, Transcription.</p>
+        <p class="faq-a">EnviousWispr runs NVIDIA Parakeet TDT v3 and WhisperKit. Handy 0.9.5 showed dozens of downloadable choices across Parakeet, Nemotron, Canary, Cohere, Whisper, Voxtral, Qwen3 ASR, FunASR, Granite, Moonshine, SenseVoice, GigaAM, Breeze, and MedASR.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Can I switch from Handy to EnviousWispr easily?</div>

--- a/website/src/pages/compare/index.astro
+++ b/website/src/pages/compare/index.astro
@@ -30,15 +30,16 @@ const cloudTools = [
 ];
 
 const onDeviceApps = [
-  { name: "Superwhisper", slug: "superwhisper", angle: "Two on-device Mac apps, different trade-offs on price and speed" },
+  { name: "Superwhisper", slug: "superwhisper", angle: "Local or cloud model choice vs two curated on-device engines" },
   { name: "MacWhisper", slug: "macwhisper", angle: "File transcription app vs live dictation tool" },
   { name: "VoiceInk", slug: "voiceink", angle: "Two whisper-based Mac apps, head to head on features" },
   { name: "Willow Voice", slug: "willow-voice", angle: "Cloud-first subscription vs free on-device alternative" },
-  { name: "Handy", slug: "handy", angle: "Both free and open source; ours needs no prompt to write" },
+  { name: "Handy", slug: "handy", angle: "Both free and open source; curated defaults vs broad model choice" },
   { name: "FluidVoice", slug: "fluidvoice", angle: "Both GPLv3 with a tuned AI model; different macOS support" },
   { name: "Juno", slug: "juno", angle: "Free and open source; ours runs on older, lighter Macs" },
   { name: "TypeWhisper", slug: "typewhisper", angle: "Both GPLv3; theirs is a toolkit, ours works with no setup" },
-  { name: "Spokenly", slug: "spokenly", angle: "Both free; ours is the one you can actually read" },
+  { name: "Spokenly", slug: "spokenly", angle: "Open-source simplicity vs flexible modes and providers" },
+  { name: "Vox", slug: "vox", angle: "Two local apps; simple polish vs editable modes and VoxNotch" },
 ];
 
 const legacyDev = [
@@ -51,7 +52,7 @@ const allComparisons = [...cloudTools, ...onDeviceApps, ...legacyDev];
 const itemListJsonLd = JSON.stringify({
   "@context": "https://schema.org",
   "@type": "ItemList",
-  "name": "Compare 16 Mac Dictation Apps with Free EnviousWispr",
+  "name": "Compare 17 Mac Dictation Apps with Free EnviousWispr",
   "description": "Side-by-side comparisons of EnviousWispr against the major Mac dictation apps.",
   "itemListElement": allComparisons.map((tool, idx) => ({
     "@type": "ListItem",
@@ -63,8 +64,8 @@ const itemListJsonLd = JSON.stringify({
 ---
 
 <BaseLayout
-  title="Compare 16 Mac Dictation Apps with Free EnviousWispr"
-  description="Browse 16 head-to-head comparisons of free EnviousWispr and Mac dictation apps. Compare price, privacy, offline use, languages, and everyday workflow."
+  title="Compare 17 Mac Dictation Apps with Free EnviousWispr"
+  description="Browse 17 head-to-head comparisons of free EnviousWispr and Mac dictation apps. Compare price, privacy, offline use, languages, and everyday workflow."
   activePage="compare"
   canonicalPath="/compare/"
 >
@@ -186,14 +187,14 @@ const itemListJsonLd = JSON.stringify({
 
 <div class="compare-hero">
   <div class="container">
-    <h1>Compare free EnviousWispr with 16 Mac dictation apps</h1>
-    <p>Honest, side-by-side breakdowns of EnviousWispr against the 16 major Mac dictation apps people actually use.</p>
+    <h1>Compare free EnviousWispr with 17 Mac dictation apps</h1>
+    <p>Honest, side-by-side breakdowns of EnviousWispr against 17 Mac dictation apps people actually use.</p>
     <a href="https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg" class="compare-hero-cta" data-download-source="compare-hero">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="14" height="14" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
       Download EnviousWispr Free
     </a>
     <span class="compare-hero-cta-sub">macOS 14+, Apple Silicon. No account. Works offline.</span>
-    <p class="compare-intro">Mac dictation tools split into three groups: cloud-based services that send your audio to a server (<a href="/compare/wisprflow/">WisprFlow</a>, <a href="/compare/otter-ai/">Otter.ai</a>, <a href="/compare/notta/">Notta</a>, <a href="/compare/google-docs-voice-typing/">Google Docs Voice Typing</a>), on-device apps that keep audio local (<a href="/compare/superwhisper/">Superwhisper</a>, <a href="/compare/macwhisper/">MacWhisper</a>, <a href="/compare/voiceink/">VoiceInk</a>, <a href="/compare/willow-voice/">Willow Voice</a>, <a href="/compare/handy/">Handy</a>, <a href="/compare/fluidvoice/">FluidVoice</a>, <a href="/compare/juno/">Juno</a>, <a href="/compare/typewhisper/">TypeWhisper</a>, <a href="/compare/spokenly/">Spokenly</a>), and legacy or developer-focused tools (<a href="/compare/dragon/">Dragon</a>, <a href="/compare/apple-dictation/">Apple Dictation</a>, <a href="/compare/whisper-cpp/">whisper.cpp</a>). Pricing ranges from free to $144 a year. Each comparison below covers price, accuracy, latency, privacy architecture, and the specific use case the tool fits best, so you can pick the right one without trying all 16.</p>
+    <p class="compare-intro">Mac dictation tools split into three groups: cloud-based services that send your audio to a server (<a href="/compare/wisprflow/">WisprFlow</a>, <a href="/compare/otter-ai/">Otter.ai</a>, <a href="/compare/notta/">Notta</a>, <a href="/compare/google-docs-voice-typing/">Google Docs Voice Typing</a>), apps that offer local or mixed processing (<a href="/compare/superwhisper/">Superwhisper</a>, <a href="/compare/macwhisper/">MacWhisper</a>, <a href="/compare/voiceink/">VoiceInk</a>, <a href="/compare/willow-voice/">Willow Voice</a>, <a href="/compare/handy/">Handy</a>, <a href="/compare/fluidvoice/">FluidVoice</a>, <a href="/compare/juno/">Juno</a>, <a href="/compare/typewhisper/">TypeWhisper</a>, <a href="/compare/spokenly/">Spokenly</a>, <a href="/compare/vox/">Vox</a>), and legacy or developer-focused tools (<a href="/compare/dragon/">Dragon</a>, <a href="/compare/apple-dictation/">Apple Dictation</a>, <a href="/compare/whisper-cpp/">whisper.cpp</a>). Each comparison covers price, privacy, offline use, language support, and the workflow each tool fits best, so you can narrow the list without installing all 17.</p>
     <p class="compare-intro" style="margin-top: 16px;">Want a recommendation rather than a directory? See our guide to the <a href="/compare/best-dictation-apps-for-mac/">best dictation apps for Mac by use case</a>.</p>
   </div>
 </div>
@@ -229,7 +230,7 @@ const itemListJsonLd = JSON.stringify({
             <td>Audio stays on Mac</td>
             <td class="col-ew"><span class="yes">Yes, fully on-device</span></td>
             <td><span class="no">No, cloud transcription</span></td>
-            <td><span class="yes">Yes</span></td>
+            <td><span class="partial">With local speech models; cloud speech models send audio to the provider</span></td>
             <td><span class="yes">Yes</span></td>
             <td><span class="partial">Mostly (enhanced uses cloud)</span></td>
             <td><span class="yes">Yes</span></td>
@@ -274,7 +275,7 @@ const itemListJsonLd = JSON.stringify({
             <td>AI polish (cleanup)</td>
             <td class="col-ew"><span class="yes">Yes, on-device EG-1, Ollama, or Apple Intelligence (macOS 26+); BYOK cloud optional</span></td>
             <td><span class="yes">Yes, cloud</span></td>
-            <td><span class="partial">Optional GPT cleanup, BYOK</span></td>
+            <td><span class="partial">S1-mini for local basic cleanup; Pro cloud writing modes also available</span></td>
             <td><span class="no">No</span></td>
             <td><span class="no">No</span></td>
             <td><span class="no">No</span></td>
@@ -300,7 +301,7 @@ const itemListJsonLd = JSON.stringify({
         </tbody>
       </table>
     </div>
-    <p class="compare-table-foot">Detailed breakdowns of each comparison live below. Sources verified 2026-04 and re-checked 2026-05-15.</p>
+    <p class="compare-table-foot">Detailed breakdowns of each comparison live below. Core table sources re-checked August 2026.</p>
   </div>
 </section>
 
@@ -319,7 +320,7 @@ const itemListJsonLd = JSON.stringify({
   </div>
 
   <div class="compare-group">
-    <div class="compare-group-label">On-device Mac apps</div>
+    <div class="compare-group-label">Local and mixed processing</div>
     <div class="compare-grid">
       {onDeviceApps.map(tool => (
         <a href={`/compare/${tool.slug}/`} class="compare-card">

--- a/website/src/pages/compare/juno.astro
+++ b/website/src/pages/compare/juno.astro
@@ -79,7 +79,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Is Juno just a dictation app, or something more?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Something more. Juno can create Apple Notes, Reminders, and Calendar entries from a spoken command like \"Hey Juno, remind me tomorrow at 9 to send the deck,\" and it can rewrite selected or recent text on request, such as \"make this warmer\" or \"shorter bullets.\" EnviousWispr is a dictation tool: it turns your speech into clean text wherever your cursor is, and does not create Notes, Reminders, or Calendar entries on its own."
+        "text": "Something more. Juno can create Notes, Reminders, and one-shot alarms from Voice Actions after you say Hey Juno. Its separate Voice Commands for rewriting text do not need a wake phrase while dictating. It can also learn from clear corrections, expand snippets, and apply a different Style per app. EnviousWispr focuses on turning speech into clean text wherever your cursor is."
       }
     },
     {
@@ -135,7 +135,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Can I switch from Juno to EnviousWispr easily?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes. Download EnviousWispr, set your keybind, and Smart Import can bring your Juno custom words across in one pass. There is no other data to migrate for dictation purposes, though Juno's Notes, Reminders, and Calendar actions have no equivalent in EnviousWispr, since we are a dictation tool rather than a voice assistant. Both apps work in any text field on macOS."
+        "text": "Yes. Download EnviousWispr, set your keybind, and Smart Import can bring your Juno custom words across in one pass. There is no other data to migrate for dictation purposes, though Juno's Notes, Reminders, and alarm actions have no equivalent in EnviousWispr, since we are a dictation tool rather than a voice assistant. Both apps work in any text field on macOS."
       }
     }
   ]
@@ -377,20 +377,20 @@ const faqJsonLd = JSON.stringify({
                - usejuno.co (accessed 2026-08-21): "Built for M2 or newer Apple Silicon Macs on macOS 15
                  Sequoia or newer with at least 24 GB RAM." Free forever, no paid tier, no usage cap, no
                  account. Live HUD transcript while dictating (live preview). On-device processing;
-                 network only for model downloads/updates. Voice-triggered actions for Apple Notes,
-                 Reminders, and Calendar via a "Hey Juno" command phrase spoken during an active session,
-                 not an always-on wake word by default. No cancelled-dictation recovery documented.
+                 network only for model downloads/updates. No cancelled-dictation recovery documented.
                - github.com/Cassini-Research/Juno (GitHub API, accessed 2026-08-21): MIT license, 68 stars,
                  no published releases found via the API.
-               - Local Info.plist (accessed 2026-08-21): confirms Accessibility permission use, an
-                 OPTIONAL "Listen for Juno" wake-mode setting distinct from the default session-based
-                 activation described on the marketing site, and Calendar/Reminders/Notes automation
-                 permissions matching the site's description.
+               - Local Info.plist (accessed 2026-08-21): confirms Accessibility permission use and local
+                 automation permissions.
                - Juno opened directly on 2026-08-21: its Settings model manager names four downloadable
                  models by role: Live captions and High-quality transcription both use Whisper Large V3
                  Turbo, Live correction uses Qwen3 0.6B (4-bit), Smart formatting uses Qwen3 4B Instruct
                  2507 (4-bit). The two cleanup models are separate downloads from the transcription models
-                 and were not installed by default on this machine.
+                 and were not installed by default on this machine. The live app also showed Voice Actions
+                 for Notes, Reminders, and alarms that start with "Hey Juno"; separate Voice Commands that
+                 need no wake phrase during dictation;
+                 selected-text Writer commands; correction learning; snippets and replacements; Styles;
+                 and per-app writing rules.
              Confidence: source-verified from Juno's own site, GitHub repo, a local install's Info.plist,
              and the installed app opened directly. Last verified: 2026-08-21. -->
         <tbody>
@@ -435,9 +435,9 @@ const faqJsonLd = JSON.stringify({
             <td><span class="table-check">No</span></td>
           </tr>
           <tr>
-            <td>Creates Notes, Reminders, or Calendar entries by voice</td>
+            <td>Creates Notes, Reminders, or alarms by voice</td>
             <td><span class="table-cross">No</span>, dictation only</td>
-            <td><span class="table-check">Yes</span>, via a "Hey Juno" command during a session</td>
+            <td><span class="table-check">Yes</span>; start the Voice Action with "Hey Juno" after dictation begins</td>
           </tr>
           <tr>
             <td>Live preview while speaking</td>
@@ -452,7 +452,22 @@ const faqJsonLd = JSON.stringify({
           <tr>
             <td>Custom vocabulary</td>
             <td><span class="table-check">Yes</span> (imports from 8 other apps, Juno included)</td>
-            <td><span class="table-check">Yes</span>, ships with roughly 400 seed terms of its own</td>
+            <td><span class="table-check">Yes</span>, with automatic learning from clear edits</td>
+          </tr>
+          <tr>
+            <td>Snippets and direct replacements</td>
+            <td><span class="table-cross">No snippet expansion</span></td>
+            <td><span class="table-check">Yes</span>, both are built in</td>
+          </tr>
+          <tr>
+            <td>Selected-text writing commands</td>
+            <td><span class="table-cross">No</span></td>
+            <td><span class="table-check">Yes</span>, including shorter, longer, clearer, formal, casual, lists, translation, and replace</td>
+          </tr>
+          <tr>
+            <td>Per-app writing behavior</td>
+            <td>App context helps polish the current dictation</td>
+            <td><span class="table-check">Yes</span>, choose a Style and privacy behavior for each app</td>
           </tr>
           <tr>
             <td>Transcription latency</td>
@@ -566,7 +581,7 @@ const faqJsonLd = JSON.stringify({
         </div>
         <div class="privacy-step">
           <div class="privacy-step-num">3</div>
-          <div>Cleanup and any voice-triggered action (a Note, a Reminder, a Calendar entry) run on-device.</div>
+          <div>Cleanup and voice actions for Notes, Reminders, and alarms run on-device.</div>
         </div>
         <div class="privacy-step">
           <div class="privacy-step-num">4</div>
@@ -630,8 +645,8 @@ const faqJsonLd = JSON.stringify({
         <div class="deep-dive-icon">🎙️</div>
         <div class="deep-dive-title">Dictation vs a voice layer for your Mac</div>
         <div class="deep-dive-body">
-          <p>Juno describes itself as a voice layer for writing, rewriting, and taking actions. Say "Hey Juno" during a session and it can create a Note, set a Reminder, or add a Calendar entry, on top of cleaning up ordinary dictation.</p>
-          <p>EnviousWispr does not create Notes, Reminders, or Calendar entries. It dictates: speech becomes text, cleaned up and pasted where you were working, every time, the same way. If you want a broader assistant, Juno covers ground we do not. If you want a dictation tool and nothing more to learn, that is what EnviousWispr is built to be.</p>
+          <p>Juno is a local voice layer for writing, rewriting, and taking actions. After dictation begins, Voice Actions for creating a Note, setting a Reminder, or adding a one-shot alarm start with "Hey Juno." Its separate Voice Commands and Writer commands can rewrite text without a wake phrase.</p>
+          <p>EnviousWispr does not create Notes, Reminders, or alarms. It turns speech into text and pastes it where you were working. If you want a broader local assistant, Juno covers ground we do not.</p>
           <div class="deep-dive-detail">
             <strong>How it works:</strong> Deterministic filler and number cleanup runs first and always. AI polish (EG-1, Apple Intelligence, Ollama, or your own cloud key) runs after, with output-length validation to catch fabrication. If any step fails, you still get the last successful text, never nothing.
           </div>
@@ -653,7 +668,7 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">📝</div>
         <div class="advantage-title">You want voice-triggered actions</div>
-        <p class="advantage-desc">Creating a Note, Reminder, or Calendar entry by saying "Hey Juno" is a real capability EnviousWispr does not have. If you want your voice to do more than produce text, Juno covers that ground.</p>
+        <p class="advantage-desc">Creating a Note, Reminder, or alarm during dictation is a real capability EnviousWispr does not have. Start those Voice Actions with "Hey Juno" after dictation begins.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">✏️</div>
@@ -693,7 +708,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Is Juno just a dictation app, or something more?</div>
-        <p class="faq-a">Something more. Juno can create Apple Notes, Reminders, and Calendar entries from a spoken command like "Hey Juno, remind me tomorrow at 9 to send the deck," and it can rewrite selected or recent text on request, such as "make this warmer" or "shorter bullets." EnviousWispr is a dictation tool: it turns your speech into clean text wherever your cursor is, and does not create Notes, Reminders, or Calendar entries on its own.</p>
+        <p class="faq-a">Something more. Juno can create Notes, Reminders, and one-shot alarms from Voice Actions after you say Hey Juno. Its separate Voice Commands for rewriting text do not need a wake phrase while dictating. It can also learn from clear corrections, expand snippets, and apply a different Style per app. EnviousWispr focuses on turning speech into clean text wherever your cursor is.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Does Juno have AI cleanup like EnviousWispr's EG-1?</div>
@@ -721,7 +736,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Can I switch from Juno to EnviousWispr easily?</div>
-        <p class="faq-a">Yes. Download EnviousWispr, set your keybind, and Smart Import can bring your Juno custom words across in one pass. There is no other data to migrate for dictation purposes, though Juno's Notes, Reminders, and Calendar actions have no equivalent in EnviousWispr, since we are a dictation tool rather than a voice assistant. Both apps work in any text field on macOS.</p>
+        <p class="faq-a">Yes. Download EnviousWispr, set your keybind, and Smart Import can bring your Juno custom words across in one pass. There is no other data to migrate for dictation purposes, though Juno's Notes, Reminders, and alarm actions have no equivalent in EnviousWispr, since we are a dictation tool rather than a voice assistant. Both apps work in any text field on macOS.</p>
       </div>
     </div>
   </div>

--- a/website/src/pages/compare/spokenly.astro
+++ b/website/src/pages/compare/spokenly.astro
@@ -119,7 +119,7 @@ const faqJsonLd = JSON.stringify({
       "name": "What is Spokenly's MCP integration for?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Spokenly includes an MCP server that lets developer tools like Claude Code, Cursor, and Codex use it as a voice input tool. EnviousWispr does not offer an MCP integration; it works as an ordinary system-wide dictation tool in any text field, including a terminal running one of those same coding agents."
+        "text": "Spokenly exposes an MCP tool named ask_user_dictation. Claude Code or Codex can call it when the agent needs an answer, and the person can respond by voice through Spokenly. This is a voice-response path for agent questions, not a replacement for ordinary system-wide dictation."
       }
     },
     {
@@ -378,10 +378,12 @@ const faqJsonLd = JSON.stringify({
                  or quit apps, or run a Shortcut after transcribing.
                - spokenly.app/docs (accessed 2026-08-21): mentions an MCP integration for developer tools
                  (Claude Code, Cursor, Codex) to use Spokenly as a voice input tool.
-             Confidence: source-verified from Spokenly's own site and docs. We could NOT confirm whether
-             Spokenly's default Mode ships with cleanup AI Instructions pre-configured, or whether it has a
-             live/streaming preview or cancelled-dictation recovery; this page does not assert either way
-             where unconfirmed. Spokenly was not tested firsthand. Last verified: 2026-08-21. -->
+             - Spokenly 2.26.0 (507), opened directly on 2026-08-21: confirmed six local speech choices,
+               sixteen bring-your-own API providers, managed online models, file transcription, Local Only
+               Mode, advanced context inputs, per-mode model controls, and coding-agent setup pages exposing
+               the ask_user_dictation MCP tool.
+             Confidence: source-verified and firsthand-tested. Cancelled-dictation recovery was not found.
+             Last verified: 2026-08-21. -->
         <tbody>
           <tr>
             <td>Price</td>
@@ -401,7 +403,7 @@ const faqJsonLd = JSON.stringify({
           <tr>
             <td>Speech engines</td>
             <td><span class="table-highlight">Parakeet TDT v3 + WhisperKit</span>, switch in Settings</td>
-            <td>Parakeet, Whisper, and Apple Speech Analyzer options</td>
+            <td><span class="table-check">Broad choice</span>: six local options, sixteen bring-your-own API providers, plus managed online models</td>
           </tr>
           <tr>
             <td>AI cleanup (after transcription)</td>
@@ -421,7 +423,22 @@ const faqJsonLd = JSON.stringify({
           <tr>
             <td>Developer tool integration (MCP)</td>
             <td><span class="table-cross">No</span></td>
-            <td><span class="table-check">Yes</span>, for Claude Code, Cursor, and Codex</td>
+            <td><span class="table-check">Yes</span>: Claude Code or Codex can call <code>ask_user_dictation</code> and receive a spoken answer</td>
+          </tr>
+          <tr>
+            <td>Advanced context for a Mode</td>
+            <td>Current app and custom words inform polish</td>
+            <td><span class="table-check">Screen text, clipboard, app, selection, browser URL, and scripts</span>, with per-mode model, reasoning, and temperature controls</td>
+          </tr>
+          <tr>
+            <td>File transcription</td>
+            <td><span class="table-cross">No</span>, live dictation only</td>
+            <td><span class="table-check">Yes</span>, common audio and video formats plus direct recording</td>
+          </tr>
+          <tr>
+            <td>Local-only lock</td>
+            <td>Choose local transcription and local polish</td>
+            <td><span class="table-check">Yes</span>, Local Only Mode blocks network requests</td>
           </tr>
           <tr>
             <td>Recover a cancelled dictation</td>
@@ -446,7 +463,7 @@ const faqJsonLd = JSON.stringify({
         </tbody>
       </table>
     </div>
-    <p style="font-size: 12px; color: var(--text-3); margin-top: 12px; text-align: center;">Spokenly claims sourced from spokenly.app, spokenly.app/open-source, and spokenly.app/docs. Spokenly was not tested firsthand. EnviousWispr latency from production PostHog data on Apple Silicon Macs. Competitor claims last verified: 2026-08-21.</p>
+    <p style="font-size: 12px; color: var(--text-3); margin-top: 12px; text-align: center;">Spokenly claims sourced from spokenly.app, spokenly.app/open-source, spokenly.app/docs, and Spokenly 2.26.0 opened directly. EnviousWispr latency from production PostHog data on Apple Silicon Macs. Competitor claims last verified: 2026-08-21.</p>
     <div style="text-align: center; margin-top: 28px;">
       <a href="/#download" class="btn-primary">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
@@ -609,7 +626,7 @@ const faqJsonLd = JSON.stringify({
         <div class="deep-dive-icon">🧩</div>
         <div class="deep-dive-title">A dictation tool, or a voice-driven automation layer</div>
         <div class="deep-dive-body">
-          <p>Spokenly's Modes and Agentic Actions turn it into more than dictation: switch profiles per app, and let a spoken command search the web, open an app, or run a Shortcut. Its MCP integration lets coding agents like Claude Code or Cursor use it as a voice input tool directly.</p>
+          <p>Spokenly's Modes and Agentic Actions turn it into more than dictation: switch profiles per app, and let a spoken command search the web, open an app, or run a Shortcut. Its MCP tool gives Claude Code or Codex a specific way to ask a question and receive your spoken answer.</p>
           <p>EnviousWispr does one thing: it turns your speech into clean, finished text wherever your cursor is, every time, the same way. If you want the broader automation layer, Spokenly covers ground we do not attempt.</p>
           <div class="deep-dive-detail">
             <strong>How it works:</strong> Deterministic filler and number cleanup runs first and always. AI polish (EG-1, Apple Intelligence, Ollama, or your own cloud key) runs after, with output-length validation to catch fabrication. If any step fails, you still get the last successful text, never nothing.
@@ -642,7 +659,7 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">💻</div>
         <div class="advantage-title">You want it wired into a coding agent</div>
-        <p class="advantage-desc">Spokenly's MCP integration lets Claude Code, Cursor, and Codex use it directly as a voice tool. If that specific developer workflow matters to you, Spokenly has it and we do not.</p>
+        <p class="advantage-desc">Spokenly exposes <code>ask_user_dictation</code>, so Claude Code or Codex can ask you a question and receive your spoken answer. If that agent-response workflow matters to you, Spokenly has it and we do not.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">🎚️</div>
@@ -692,7 +709,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">What is Spokenly's MCP integration for?</div>
-        <p class="faq-a">Spokenly includes an MCP server that lets developer tools like Claude Code, Cursor, and Codex use it as a voice input tool. EnviousWispr does not offer an MCP integration; it works as an ordinary system-wide dictation tool in any text field, including a terminal running one of those same coding agents.</p>
+        <p class="faq-a">Spokenly exposes an MCP tool named <code>ask_user_dictation</code>. Claude Code or Codex can call it when the agent needs an answer, and you can respond by voice through Spokenly. This is a voice-response path for agent questions, not a replacement for ordinary system-wide dictation.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Can I switch from Spokenly to EnviousWispr easily?</div>

--- a/website/src/pages/compare/superwhisper.astro
+++ b/website/src/pages/compare/superwhisper.astro
@@ -71,7 +71,7 @@ const faqJsonLd = JSON.stringify({
       "name": "How is EnviousWispr different from Superwhisper?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Both are Mac-native and run on-device. The key differences: EnviousWispr is free (Superwhisper Pro costs ~$8.49/mo), uses dual ASR engines (Parakeet TDT for speed and English accuracy, WhisperKit for wider language coverage), and is open source (GPLv3) on GitHub. Superwhisper has meeting transcription, an iOS app, Windows support, and more writing modes that EnviousWispr does not offer yet."
+        "text": "Both are Mac-native and offer on-device transcription. EnviousWispr is free, uses two curated local engines, and is open source under GPLv3. Superwhisper offers a much larger library of local and cloud speech models, plus meeting transcription, an iOS app, Windows support, and more writing modes. Superwhisper Pro costs about $8.49 per month."
       }
     },
     {
@@ -79,7 +79,7 @@ const faqJsonLd = JSON.stringify({
       "name": "How does EnviousWispr compare to Superwhisper for accuracy?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "EnviousWispr uses NVIDIA Parakeet TDT v3, which covers 25 European languages at roughly 110x real-time on the Neural Engine. For languages outside those 25, both apps use Whisper-based engines with comparable accuracy. Superwhisper offers more Whisper model size choices, which lets you trade speed for accuracy on older hardware."
+        "text": "EnviousWispr uses NVIDIA Parakeet TDT v3 for 25 European languages and WhisperKit for wider language coverage. Superwhisper offers a large searchable library of local and cloud speech models, including Cohere Transcribe, Parakeet realtime, and its Nano, Fast, Standard, Pro, and Ultra choices. Superwhisper gives you more models to compare, while EnviousWispr keeps the choice to two curated local engines."
       }
     },
     {
@@ -95,7 +95,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Does Superwhisper have offline AI polish?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Superwhisper's transcription works offline via Whisper, and it now has an on-device polish option too: a Local mode powered by S1-mini, their own 0.6B open-weights model that cleans up fillers, punctuation, and numbers without sending anything off your Mac. It is a newer, experimental addition, and it is a lighter cleanup pass than their cloud writing modes (Formal, Casual, Legal, Chat), which still need GPT, Claude, or Llama. EnviousWispr's EG-1 and Ollama integrations run entirely on your Mac, and so does Apple Intelligence on macOS 26+."
+        "text": "Superwhisper can transcribe offline with a downloaded local speech model, and it now has an on-device polish option too: a Local mode powered by S1-mini, its own 0.6B open-weights model that cleans up fillers, punctuation, and numbers without sending anything off your Mac. It is a newer, experimental addition and a lighter cleanup pass than the cloud writing modes, which still need an internet connection. EnviousWispr's EG-1 and Ollama integrations run entirely on your Mac, and so does Apple Intelligence on macOS 26+."
       }
     },
     {
@@ -329,7 +329,7 @@ const faqJsonLd = JSON.stringify({
       <span class="vs-brand">Superwhisper</span>
     </div>
     <h1 class="reveal">The free Superwhisper alternative for Mac</h1>
-    <p class="page-header-sub reveal">Both are Mac-native and on-device. The difference: EnviousWispr is free, and uses Parakeet TDT for better English accuracy alongside WhisperKit.</p>
+    <p class="page-header-sub reveal">Both are Mac-native and offer on-device transcription. EnviousWispr is free with two curated local engines; Superwhisper offers a much larger library of local and cloud speech models.</p>
     <div class="hero-pills reveal">
       <span class="hero-pill">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg>
@@ -382,7 +382,11 @@ const faqJsonLd = JSON.stringify({
                  MarkTechPost, both accessed 2026-08-21): S1-mini is a real, newly released 0.6B open-weights
                  on-device model, ~462MB quantized, that cleans fillers/punctuation/numbers from a transcript;
                  described as experimental, and narrower than the cloud-backed writing modes (Formal, Casual,
-                 Legal, Chat), which still route through GPT/Claude/Llama.
+                 Legal, Chat), which still route through GPT/Claude/Llama. The live Models library also showed
+                 Cohere Transcribe, Parakeet realtime, Superwhisper Nano/Fast/Standard/Pro/Ultra speech choices,
+                 multiple writing-model families, provider filters, favorites, and local/cloud attributes.
+                 Mode settings exposed system-audio capture and speaker identification. Advanced Configuration
+                 exposed Claude Code and Codex agent plugins.
              Confidence: source-verified from the public website, the installed app opened directly, and an
              independent public source for S1-mini. Features marked "Not specified" were not found on
              superwhisper.com or in the app as of 2026-08-21.
@@ -402,22 +406,22 @@ const faqJsonLd = JSON.stringify({
           <tr>
             <td>Speech engines</td>
             <td><span class="table-highlight"><a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> + <a href="https://github.com/argmaxinc/argmax-oss-swift" style="color: var(--accent); text-decoration: underline;">WhisperKit</a></span> (dual engines, on-device)</td>
-            <td>Whisper (on-device, multiple model sizes)</td>
+            <td><span class="table-check">Large searchable library</span>: local and cloud speech choices including Cohere Transcribe, Parakeet realtime, and Superwhisper Nano/Fast/Standard/Pro/Ultra variants</td>
           </tr>
           <tr>
             <td>Audio processing</td>
             <td><span class="table-highlight">On-device</span> (Apple Neural Engine)</td>
-            <td>On-device (Whisper); optional cloud AI for polish</td>
+            <td>Local or cloud speech model by Mode; local choices keep audio on the Mac</td>
           </tr>
           <tr>
             <td>Audio leaves your Mac</td>
             <td><span class="table-check">Never.</span> Audio stays on your Mac. If you enable cloud AI polish, only the text transcript is sent.</td>
-            <td>Not for transcription. Cloud AI features send text to third-party APIs.</td>
+            <td>Not with a local speech model. Choosing a cloud speech model sends audio to that provider; cloud writing models send transcript text.</td>
           </tr>
           <tr>
             <td>Works offline</td>
             <td><span class="table-check">Yes</span> (after models download)</td>
-            <td><span class="table-check">Yes</span> (on-device Whisper mode)</td>
+            <td><span class="table-check">Yes</span> with a downloaded local speech model</td>
           </tr>
           <tr>
             <td>AI polish</td>
@@ -480,6 +484,16 @@ const faqJsonLd = JSON.stringify({
             <td><span class="table-check">Yes</span> (live meeting recording with automatic notes)</td>
           </tr>
           <tr>
+            <td>System audio and speaker identification</td>
+            <td><span class="table-cross">No</span></td>
+            <td><span class="table-check">Yes</span>, configurable per Mode</td>
+          </tr>
+          <tr>
+            <td>Coding-agent plugins</td>
+            <td><span class="table-cross">No dedicated plugin</span></td>
+            <td><span class="table-check">Claude Code and Codex plugins</span> in Advanced Configuration</td>
+          </tr>
+          <tr>
             <td>Multi-language</td>
             <td>25 European (Parakeet), 99 languages via WhisperKit</td>
             <td>100+ languages with translation to English</td>
@@ -538,8 +552,8 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">🧠</div>
-        <div class="advantage-title">Parakeet TDT, not just Whisper</div>
-        <p class="advantage-desc">Superwhisper uses Whisper for on-device transcription. EnviousWispr runs <a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3" style="color: var(--accent); text-decoration: underline;">NVIDIA Parakeet TDT</a> as its primary engine, covering 25 European languages with strong accuracy on English dictation. WhisperKit is available as a fallback for 99 languages. See <a href="/how-it-works/" style="color: var(--accent); text-decoration: underline;">how the pipeline works</a>.</p>
+        <div class="advantage-title">Two curated local engines</div>
+        <p class="advantage-desc">EnviousWispr uses <a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3" style="color: var(--accent); text-decoration: underline;">NVIDIA Parakeet TDT</a> for 25 European languages and WhisperKit for wider coverage. Superwhisper gives you a much larger library of local and cloud models to compare. EnviousWispr keeps the choice smaller and entirely local. See <a href="/how-it-works/" style="color: var(--accent); text-decoration: underline;">how the pipeline works</a>.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">⚡</div>
@@ -571,7 +585,7 @@ const faqJsonLd = JSON.stringify({
     <div class="section-head reveal">
       <div class="section-label-pill cyan">Privacy</div>
       <h2 class="section-title">Where does your voice go?</h2>
-      <p class="section-sub">Both apps transcribe on-device. The difference is what happens next. For a deeper dive, read <a href="/blog/on-device-vs-cloud-dictation-privacy/" style="color: var(--accent); text-decoration: underline;">on-device vs cloud dictation privacy</a>.</p>
+      <p class="section-sub">EnviousWispr always transcribes on-device. Superwhisper can use a local or cloud speech model depending on the selected Mode, and both apps offer local and optional cloud cleanup paths. For a deeper dive, read <a href="/blog/on-device-vs-cloud-dictation-privacy/" style="color: var(--accent); text-decoration: underline;">on-device vs cloud dictation privacy</a>.</p>
     </div>
     <div class="privacy-split">
       <div class="privacy-card ew reveal">
@@ -607,7 +621,7 @@ const faqJsonLd = JSON.stringify({
         </div>
         <div class="privacy-step">
           <div class="privacy-step-num">2</div>
-          <div>Audio is transcribed on-device via Whisper. So far, similar to EnviousWispr.</div>
+          <div>With a local speech model, audio is transcribed on-device. Choosing a cloud speech model sends audio to that provider for transcription.</div>
         </div>
         <div class="privacy-step">
           <div class="privacy-step-num">3</div>
@@ -657,18 +671,18 @@ const faqJsonLd = JSON.stringify({
     <div class="section-head reveal">
       <div class="section-label-pill">Under the Hood</div>
       <h2 class="section-title">What the feature table does not show</h2>
-      <p class="section-sub">Both apps do on-device Whisper transcription. The technical differences are in the engines and the post-processing pipeline.</p>
+      <p class="section-sub">Both apps can run speech and cleanup locally. Superwhisper offers a much larger model library; EnviousWispr keeps a curated two-engine setup.</p>
     </div>
     <div class="deep-dive-grid">
       <div class="deep-dive-card reveal">
         <div class="deep-dive-icon">🔀</div>
-        <div class="deep-dive-title">Dual ASR engines vs. Whisper alone</div>
+        <div class="deep-dive-title">Two curated engines vs. a model marketplace</div>
         <div class="deep-dive-body">
-          <p>Superwhisper uses OpenAI Whisper with multiple model sizes (likely tiny through large). It is a proven, broadly capable model that handles 100+ languages well. For multilingual dictation, it is excellent.</p>
+          <p>Superwhisper 2.18.1 has a searchable speech and writing model library. The live app showed local Cohere Transcribe, Parakeet realtime, and Superwhisper-branded Nano, Fast, Standard, Pro, and Ultra choices alongside cloud models.</p>
           <p>EnviousWispr takes a different approach: NVIDIA Parakeet TDT v3, a CTC/TDT hybrid model that runs at ~110x real-time on the Apple Neural Engine. It covers 25 European languages and is tuned for fast, accurate dictation. For languages outside those 25, EnviousWispr falls back to WhisperKit (an Apple Silicon-optimized Whisper implementation).</p>
-          <p>The result is two engines chosen for their strengths: Parakeet for English speed and accuracy, WhisperKit for language breadth. Superwhisper uses one engine for everything.</p>
+          <p>EnviousWispr uses Parakeet TDT v3 for the languages it covers and WhisperKit for broader language support. Superwhisper gives you much more room to compare models, providers, and local or cloud trade-offs.</p>
           <div class="deep-dive-detail">
-            <strong>Why it matters:</strong> Parakeet TDT's ~110x real-time factor means a 30-second dictation transcribes in under 300ms. Whisper large-v3 is accurate but slower. By using the right engine for the right language, EnviousWispr gets both speed and accuracy without compromise.
+            <strong>Why it matters:</strong> Choose Superwhisper if model selection is part of the experience you want. Choose EnviousWispr if you prefer a smaller set of defaults.
           </div>
         </div>
       </div>
@@ -746,11 +760,11 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">How is EnviousWispr different from Superwhisper?</div>
-        <p class="faq-a">Both are Mac-native and run on-device. The key differences: EnviousWispr is free (Superwhisper Pro costs ~$8.49/mo), uses dual ASR engines (Parakeet TDT for speed and English accuracy, WhisperKit for wider language coverage), and is open source (GPLv3) on GitHub. Superwhisper has meeting transcription, an iOS app, Windows support, and more writing modes that EnviousWispr does not offer yet.</p>
+        <p class="faq-a">Both are Mac-native and offer on-device transcription. EnviousWispr is free, uses two curated local engines, and is open source under GPLv3. Superwhisper offers a much larger library of local and cloud speech models, plus meeting transcription, an iOS app, Windows support, and more writing modes. Superwhisper Pro costs about $8.49 per month.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">How does EnviousWispr compare to Superwhisper for accuracy?</div>
-        <p class="faq-a">EnviousWispr uses NVIDIA Parakeet TDT v3, which covers 25 European languages at roughly 110x real-time on the Neural Engine. For languages outside those 25, both apps use Whisper-based engines with comparable accuracy. Superwhisper offers more Whisper model size choices, which lets you trade speed for accuracy on older hardware.</p>
+        <p class="faq-a">EnviousWispr uses NVIDIA Parakeet TDT v3 for 25 European languages and WhisperKit for wider language coverage. Superwhisper offers a large searchable library of local and cloud speech models, including Cohere Transcribe, Parakeet realtime, and its Nano, Fast, Standard, Pro, and Ultra choices. Superwhisper gives you more models to compare, while EnviousWispr keeps the choice to two curated local engines.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Can I use EnviousWispr completely offline?</div>
@@ -758,7 +772,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Does Superwhisper have offline AI polish?</div>
-        <p class="faq-a">Superwhisper's transcription works offline via Whisper, and it now has an on-device polish option too: a Local mode powered by S1-mini, their own 0.6B open-weights model that cleans up fillers, punctuation, and numbers without sending anything off your Mac. It is a newer, experimental addition, and it is a lighter cleanup pass than their cloud writing modes (Formal, Casual, Legal, Chat), which still need GPT, Claude, or Llama. EnviousWispr's EG-1 and Ollama integrations run entirely on your Mac, and so does Apple Intelligence on macOS 26+.</p>
+        <p class="faq-a">Superwhisper can transcribe offline with a downloaded local speech model, and it now has an on-device polish option too: a Local mode powered by S1-mini, its own 0.6B open-weights model that cleans up fillers, punctuation, and numbers without sending anything off your Mac. It is a newer, experimental addition and a lighter cleanup pass than the cloud writing modes, which still need an internet connection. EnviousWispr's EG-1 and Ollama integrations run entirely on your Mac, and so does Apple Intelligence on macOS 26+.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Is EnviousWispr really free?</div>

--- a/website/src/pages/compare/typewhisper.astro
+++ b/website/src/pages/compare/typewhisper.astro
@@ -71,7 +71,7 @@ const faqJsonLd = JSON.stringify({
       "name": "How is EnviousWispr different from TypeWhisper?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Both are GPLv3, free at the core, and run on-device. TypeWhisper offers the widest engine choice we found in any competitor: WhisperKit, Parakeet TDT, Voxtral, Qwen3 ASR, IBM Granite Speech, Apple Speech, and ONNX-based engines on Windows, plus a Workflows system for building your own cleanup, translation, and formatting steps. EnviousWispr runs two engines, Parakeet TDT and WhisperKit, switched manually in Settings, and EG-1, a model built and measured specifically for cleaning up dictation, with no setup required. TypeWhisper also runs on Windows in addition to Mac; EnviousWispr is Mac only."
+        "text": "Both are GPLv3, free at the core, and run on-device. TypeWhisper offers seven engine options across Mac and Windows: WhisperKit, Parakeet TDT, Voxtral, Qwen3 ASR, IBM Granite Speech, Apple Speech, and ONNX-based engines, plus a Workflows system for building your own cleanup, translation, and formatting steps. EnviousWispr runs two engines, Parakeet TDT and WhisperKit, switched manually in Settings, and EG-1, a model built and measured specifically for cleaning up dictation, with no setup required. TypeWhisper also runs on Windows in addition to Mac; EnviousWispr is Mac only."
       }
     },
     {
@@ -79,7 +79,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Does TypeWhisper have AI cleanup like EnviousWispr's EG-1?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "TypeWhisper's equivalent is called Workflows, a configurable system that can send your transcript through an LLM (its changelog references OpenAI and Groq) for cleanup, translation, or formatting, plus a separate Dictionary Autocorrection feature reserved for its paid Commercial license. We could not confirm from TypeWhisper's public documentation whether a working cleanup workflow is pre-configured out of the box or needs to be set up. EG-1 is purpose-built for dictation cleanup, ships with the app, and needs no setup or prompt writing."
+        "text": "TypeWhisper's equivalent is called Workflows, a configurable system that can send your transcript through an LLM for cleanup, translation, or formatting. The installed 1.6.0 build also contains ready-made actions for lists, email, meeting notes, translation, JSON, and more. A separate Dictionary Autocorrection feature for paid Commercial licenses learns from confident edits. EG-1 is purpose-built for dictation cleanup and ships ready inside EnviousWispr."
       }
     },
     {
@@ -136,7 +136,7 @@ const faqJsonLd = JSON.stringify({
 
 <BaseLayout
   title="TypeWhisper vs EnviousWispr: Free Mac Dictation, Both GPLv3"
-  description="Compare TypeWhisper and EnviousWispr, two free, GPLv3, on-device Mac dictation apps. TypeWhisper offers the widest engine choice; EnviousWispr ships a measured, purpose-built polish model."
+  description="Compare TypeWhisper and EnviousWispr, two free, GPLv3, on-device Mac dictation apps. TypeWhisper offers seven engine options across Mac and Windows; EnviousWispr ships a measured, purpose-built polish model."
   activePage="compare"
   ogImage="/og-image.png"
   canonicalPath="/compare/typewhisper/"
@@ -378,10 +378,12 @@ const faqJsonLd = JSON.stringify({
                  non-GPL terms, up to 3 devices); Team from EUR 19/mo; Enterprise from EUR 99/mo.
                - github.com/TypeWhisper/typewhisper-mac (GitHub API, accessed 2026-08-21): GPLv3 license,
                  1,717 stars.
-             Confidence: source-verified from TypeWhisper's own site, pricing page, changelog, and GitHub
-             repo. We could NOT confirm from public documentation whether a Workflow ships pre-configured
-             for cleanup out of the box, or requires the user to build one; this page does not assert
-             either way. TypeWhisper was not tested firsthand. Last verified: 2026-08-21. -->
+             - Installed TypeWhisper 1.6.0 bundle inspected on 2026-08-21: confirmed preset actions for
+               Action Items, Create Table, email drafting, list formatting, JSON, Meeting Notes, Reply, and
+               Translate, plus Recorder, Watch Folder, meeting automation, plugins, snippets, and user-owned
+               iCloud or folder sync surfaces. The live window could not be captured, so exact labels and
+               defaults remain source-verified rather than firsthand-tested.
+             Confidence: source-verified plus installed-bundle-inspected. Last verified: 2026-08-21. -->
         <tbody>
           <tr>
             <td>Price (core app)</td>
@@ -411,7 +413,7 @@ const faqJsonLd = JSON.stringify({
           <tr>
             <td>Needs a prompt to be written</td>
             <td><span class="table-check">No</span></td>
-            <td>Not confirmed either way from public documentation</td>
+            <td><span class="table-check">No for common tasks</span>: the installed build includes presets for lists, email, meeting notes, translation, JSON, and more; custom Workflows remain configurable</td>
           </tr>
           <tr>
             <td>Learns your corrections automatically</td>
@@ -443,10 +445,30 @@ const faqJsonLd = JSON.stringify({
             <td>macOS (Apple Silicon only)</td>
             <td><span class="table-check">macOS and Windows</span>, dedicated builds for each</td>
           </tr>
+          <tr>
+            <td>System-audio recorder</td>
+            <td><span class="table-cross">No</span></td>
+            <td><span class="table-check">Yes</span>, microphone, system audio, or both, with mixed or separate tracks</td>
+          </tr>
+          <tr>
+            <td>Watched-folder transcription</td>
+            <td><span class="table-cross">No</span></td>
+            <td><span class="table-check">Yes</span>, automatic transcription and text or subtitle export</td>
+          </tr>
+          <tr>
+            <td>Meeting automation</td>
+            <td><span class="table-cross">No</span></td>
+            <td><span class="table-check">Yes</span>, calendar reminders or automatic recording when a matching meeting starts</td>
+          </tr>
+          <tr>
+            <td>Dictionary and snippet sync</td>
+            <td><span class="table-cross">No</span></td>
+            <td><span class="table-check">Yes</span>, with a Commercial license, through a private iCloud container or a user-chosen synced folder</td>
+          </tr>
         </tbody>
       </table>
     </div>
-    <p style="font-size: 12px; color: var(--text-3); margin-top: 12px; text-align: center;">TypeWhisper claims sourced from typewhisper.com, its pricing page, its changelog, and the GitHub API. TypeWhisper was not tested firsthand. EnviousWispr latency from production PostHog data on Apple Silicon Macs. Competitor claims last verified: 2026-08-21.</p>
+    <p style="font-size: 12px; color: var(--text-3); margin-top: 12px; text-align: center;">TypeWhisper claims sourced from typewhisper.com, its pricing page, its changelog, the GitHub API, and the installed TypeWhisper 1.6.0 bundle. The live window could not be captured, so exact UI labels were not firsthand-tested. EnviousWispr latency from production PostHog data on Apple Silicon Macs. Competitor claims last verified: 2026-08-21.</p>
     <div style="text-align: center; margin-top: 28px;">
       <a href="/#download" class="btn-primary">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
@@ -468,7 +490,7 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">🧹</div>
         <div class="advantage-title">Nothing to configure</div>
-        <p class="advantage-desc">EG-1 ships fine-tuned specifically for dictation cleanup and runs on the same hotkey as transcription, with no prompt to write. TypeWhisper's Workflows are genuinely flexible, and can send your transcript through a provider like OpenAI or Groq; we could not confirm from public documentation whether a working cleanup Workflow ships pre-configured or needs to be built.</p>
+        <p class="advantage-desc">EG-1 is fine-tuned specifically for dictation cleanup and runs on the same hotkey as transcription. TypeWhisper's Workflows are more flexible, and the installed build includes ready-made actions for common writing tasks alongside custom workflows.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">📊</div>
@@ -598,7 +620,7 @@ const faqJsonLd = JSON.stringify({
         <div class="deep-dive-icon">🔀</div>
         <div class="deep-dive-title">Seven engines, or two you switch between</div>
         <div class="deep-dive-body">
-          <p>TypeWhisper's engine list is the widest we found in any dictation app: WhisperKit, Parakeet TDT, Voxtral, Qwen3 ASR, IBM Granite Speech, and Apple Speech on Mac, with ONNX-based engines added on Windows. If you want to compare engines directly, or you have a strong preference for one, that choice is real.</p>
+          <p>TypeWhisper offers seven engine options across Mac and Windows: WhisperKit, Parakeet TDT, Voxtral, Qwen3 ASR, IBM Granite Speech, Apple Speech, and ONNX-based engines. If you want to compare these engines directly, or you have a strong preference for one, that choice is real.</p>
           <p>EnviousWispr runs two: Parakeet TDT v3 for the 25 languages it covers best, WhisperKit for the rest. There is no larger menu; you switch between the two in Settings, Transcription.</p>
           <div class="deep-dive-detail">
             <strong>Why it matters:</strong> Power users and anyone who wants a specific model, or Windows support, get more from TypeWhisper today. Anyone who wants one setup that already works gets that from EnviousWispr.
@@ -609,7 +631,7 @@ const faqJsonLd = JSON.stringify({
         <div class="deep-dive-icon">🧩</div>
         <div class="deep-dive-title">A configurable automation system, versus a model we tuned</div>
         <div class="deep-dive-body">
-          <p>TypeWhisper's Workflows are a genuine automation system: cleanup, translation, extraction, and formatting steps, referencing providers like OpenAI and Groq in its own changelog, included free. That flexibility is real. We could not confirm from public documentation whether a working cleanup Workflow is ready by default or needs to be configured first.</p>
+          <p>TypeWhisper's Workflows are a genuine automation system: cleanup, translation, extraction, and formatting steps, referencing providers like OpenAI and Groq in its own changelog. The installed build also includes presets for Action Items, Create Table, email drafting, lists, JSON, Meeting Notes, Reply, and Translate.</p>
           <p>EG-1 is a single model, fine-tuned by us specifically for the problem of turning spoken dictation into clean text, shipped with the app, with results we measure and publish. It runs on the same hotkey as transcription with nothing to configure.</p>
           <div class="deep-dive-detail">
             <strong>How it works:</strong> Deterministic filler and number cleanup runs first and always. AI polish (EG-1, Apple Intelligence, Ollama, or your own cloud key) runs after, with output-length validation to catch fabrication. If any step fails, you still get the last successful text, never nothing.
@@ -650,7 +672,7 @@ const faqJsonLd = JSON.stringify({
         <p class="advantage-desc">Workflows let you wire up your own provider, prompt, and automation steps, including translation and app-specific behavior. If that flexibility is what you are after, EG-1's single tuned model will not give it to you.</p>
       </div>
     </div>
-    <p style="font-size: 15px; color: var(--text-2); text-align: center; margin-top: 24px;">If you want the widest engine choice, need Windows, or want the flexibility to build your own cleanup workflow, TypeWhisper is a strong pick. If you want a purpose-built polish model with a published, measured track record, <a href="/#download" style="color: var(--accent); text-decoration: underline;">give EnviousWispr a try</a>. You can always use both.</p>
+    <p style="font-size: 15px; color: var(--text-2); text-align: center; margin-top: 24px;">If you want TypeWhisper's seven engine options, need Windows, or want the flexibility to build your own cleanup workflow, TypeWhisper is a strong pick. If you want a purpose-built polish model with a published, measured track record, <a href="/#download" style="color: var(--accent); text-decoration: underline;">give EnviousWispr a try</a>. You can always use both.</p>
   </div>
 </section>
 
@@ -668,11 +690,11 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">How is EnviousWispr different from TypeWhisper?</div>
-        <p class="faq-a">Both are GPLv3, free at the core, and run on-device. TypeWhisper offers the widest engine choice we found in any competitor: WhisperKit, Parakeet TDT, Voxtral, Qwen3 ASR, IBM Granite Speech, Apple Speech, and ONNX-based engines on Windows, plus a Workflows system for building your own cleanup, translation, and formatting steps. EnviousWispr runs two engines, Parakeet TDT and WhisperKit, switched manually in Settings, and EG-1, a model built and measured specifically for cleaning up dictation, with no setup required. TypeWhisper also runs on Windows in addition to Mac; EnviousWispr is Mac only.</p>
+        <p class="faq-a">Both are GPLv3, free at the core, and run on-device. TypeWhisper offers seven engine options across Mac and Windows: WhisperKit, Parakeet TDT, Voxtral, Qwen3 ASR, IBM Granite Speech, Apple Speech, and ONNX-based engines, plus a Workflows system for building your own cleanup, translation, and formatting steps. EnviousWispr runs two engines, Parakeet TDT and WhisperKit, switched manually in Settings, and EG-1, a model built and measured specifically for cleaning up dictation, with no setup required. TypeWhisper also runs on Windows in addition to Mac; EnviousWispr is Mac only.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Does TypeWhisper have AI cleanup like EnviousWispr's EG-1?</div>
-        <p class="faq-a">TypeWhisper's equivalent is called Workflows, a configurable system that can send your transcript through an LLM (its changelog references OpenAI and Groq) for cleanup, translation, or formatting, plus a separate Dictionary Autocorrection feature reserved for its paid Commercial license. We could not confirm from TypeWhisper's public documentation whether a working cleanup workflow is pre-configured out of the box or needs to be set up. EG-1 is purpose-built for dictation cleanup, ships with the app, and needs no setup or prompt writing.</p>
+        <p class="faq-a">TypeWhisper's equivalent is called Workflows, a configurable system that can send your transcript through an LLM for cleanup, translation, or formatting. The installed 1.6.0 build also contains ready-made actions for lists, email, meeting notes, translation, JSON, and more. A separate Dictionary Autocorrection feature for paid Commercial licenses learns from confident edits. EG-1 is purpose-built for dictation cleanup and ships ready inside EnviousWispr.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Can I use EnviousWispr completely offline?</div>

--- a/website/src/pages/compare/vox.astro
+++ b/website/src/pages/compare/vox.astro
@@ -1,0 +1,471 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+const siteUrl = 'https://enviouswispr.com';
+
+const articleJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "EnviousWispr vs Vox: Two Local Dictation Apps Compared",
+  "description": "Compare EnviousWispr and Vox on local transcription, AI cleanup, Voice Modes, pricing, platforms, and everyday paste behavior.",
+  "url": `${siteUrl}/compare/vox/`,
+  "image": `${siteUrl}/og-image.png`,
+  "datePublished": "2026-08-21T19:00:00Z",
+  "dateModified": "2026-08-21T19:00:00Z",
+  "author": { "@type": "Person", "name": "Saurabh Vaish", "url": `${siteUrl}/authors/saurabh-vaish/` },
+  "publisher": { "@type": "Organization", "name": "Envious Labs", "url": siteUrl },
+  "isPartOf": { "@type": "WebSite", "url": siteUrl, "name": "EnviousWispr" },
+});
+
+const breadcrumbJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": siteUrl },
+    { "@type": "ListItem", "position": 2, "name": "Comparisons", "item": `${siteUrl}/compare/` },
+    { "@type": "ListItem", "position": 3, "name": "EnviousWispr vs Vox", "item": `${siteUrl}/compare/vox/` },
+  ],
+});
+
+const faqJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Is EnviousWispr free, like Vox?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "EnviousWispr is free for personal and work use under GPLv3. Vox is free for personal use, while work use at a company with more than one person requires a commercial license at $12 per seat monthly or $120 per seat yearly, equivalent to $10 per month. Neither app requires an account for personal dictation."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do EnviousWispr and Vox both work offline?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes, when using downloaded local models. Vox can transcribe locally and use downloaded Gemma 4 for local cleanup. Vox also offers Apple Intelligence, which may route text through Apple's Private Cloud Compute. EnviousWispr can use local EG-1, Apple Intelligence, or downloaded Ollama models, plus optional cloud providers with your own key."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is VoxNotch?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "It is a local task list that sits at the top of the Mac screen. You can add, finish, remove, reorder, and reprioritize tasks by speaking naturally."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does Vox have AI cleanup like EnviousWispr's EG-1?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Vox can clean up text locally with a downloaded Gemma 4 model. It also offers Apple Intelligence, which may route text through Apple's Private Cloud Compute. Vox's built-in and custom Voice Modes control how cleanup behaves. EnviousWispr offers EG-1, Apple Intelligence, or a downloaded Ollama model locally, plus optional cloud providers with your own key."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Vox open source?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Vox's official FAQ says the team is considering open-sourcing its modes engine. EnviousWispr is open source under GPLv3."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Which Macs do EnviousWispr and Vox support?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Both support Apple Silicon Macs starting with M1 on macOS 14 or later. Neither supports Intel Macs. Vox also supports 64-bit Windows 10 and 11, while EnviousWispr is Mac only."
+      }
+    }
+  ]
+});
+---
+
+<BaseLayout
+  title="Vox vs EnviousWispr: Two Local Dictation Apps Compared"
+  description="Compare Vox and EnviousWispr on local transcription, AI cleanup, Voice Modes, pricing, platforms, and everyday paste behavior."
+  activePage="compare"
+  ogImage="/og-image.png"
+  canonicalPath="/compare/vox/"
+  ogType="article"
+>
+  <Fragment slot="head">
+    <script type="application/ld+json" set:html={articleJsonLd}></script>
+    <script type="application/ld+json" set:html={breadcrumbJsonLd}></script>
+    <script type="application/ld+json" set:html={faqJsonLd}></script>
+  </Fragment>
+
+<style>
+/* ── Page Header ── */
+.page-header { padding: 100px 0 48px; text-align: center; position: relative; z-index: 1; }
+.vs-badge {
+  display: inline-flex; align-items: center; gap: 14px; margin-bottom: 20px;
+  font-size: 14px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; color: var(--text-3);
+}
+.vs-brand { font-size: 18px; font-weight: 800; letter-spacing: -0.5px; color: var(--text); }
+.vs-brand.accent { color: var(--accent); }
+.vs-circle {
+  width: 36px; height: 36px; border-radius: 50%; border: 2px solid var(--border-hover);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 11px; font-weight: 800; color: var(--text-3); background: #fff;
+}
+.page-header h1 { font-size: 48px; font-weight: 800; letter-spacing: -2.5px; line-height: 1.1; color: var(--text); margin-bottom: 14px; max-width: 700px; margin-left: auto; margin-right: auto; }
+.page-header-sub { font-size: 18px; font-weight: 400; color: var(--text-2); max-width: 560px; margin: 0 auto; line-height: 1.6; }
+.hero-pills { display: flex; align-items: center; justify-content: center; gap: 10px; flex-wrap: wrap; margin-top: 20px; }
+.hero-pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 14px; border-radius: 100px; font-size: 13px; font-weight: 600;
+  background: rgba(124,58,237,0.06); color: var(--accent); border: 1px solid rgba(124,58,237,0.12);
+}
+.hero-pill svg { flex-shrink: 0; }
+.hero-cta { margin-top: 28px; }
+.hero-meta { font-size: 12px; color: var(--text-3); margin-top: 16px; }
+
+/* ── Comparison Table ── */
+.compare-table-wrap {
+  overflow-x: auto; -webkit-overflow-scrolling: touch;
+  border-radius: var(--radius-card); border: 1px solid var(--border-hover);
+  background: #fff;
+}
+/* Table rules live in global.css (.compare-table--duo) so this page shares the
+   same desktop and phone layout as every other head-to-head comparison. */
+.table-check { color: var(--green); font-weight: 700; }
+.table-cross { color: var(--text-3); }
+.table-highlight { color: var(--accent); font-weight: 600; }
+
+/* ── Advantage Cards ── */
+.advantages-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+.advantage-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 28px 24px;
+  position: relative; overflow: hidden;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+.advantage-card:hover { transform: translateY(-3px); box-shadow: 0 12px 40px rgba(124,58,237,0.10); }
+.advantage-card::before {
+  content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px;
+  background: var(--rainbow-full);
+}
+.advantage-icon { font-size: 28px; margin-bottom: 14px; line-height: 1; }
+.advantage-title { font-size: 18px; font-weight: 700; letter-spacing: -0.5px; margin-bottom: 8px; color: var(--text); }
+.advantage-desc { font-size: 14px; color: var(--text-2); line-height: 1.65; }
+
+/* ── Privacy Section ── */
+.privacy-split { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+.privacy-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 32px 28px;
+}
+.privacy-card.ew {
+  border-color: rgba(0,200,128,0.25);
+  background: linear-gradient(135deg, rgba(0,200,128,0.03), rgba(248,245,255,0.5));
+}
+.privacy-card.wf {
+  border-color: rgba(230,37,58,0.15);
+  background: linear-gradient(135deg, rgba(230,37,58,0.02), rgba(248,245,255,0.5));
+}
+.privacy-card-label {
+  font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 1px;
+  margin-bottom: 16px; display: flex; align-items: center; gap: 8px;
+}
+.privacy-card.ew .privacy-card-label { color: var(--green); }
+.privacy-card.wf .privacy-card-label { color: var(--red); }
+.privacy-step {
+  display: flex; align-items: flex-start; gap: 12px;
+  padding: 10px 0; border-bottom: 1px solid var(--border);
+  font-size: 14px; color: var(--text-2); line-height: 1.55;
+}
+.privacy-step:last-child { border-bottom: none; }
+.privacy-step-num {
+  flex-shrink: 0; width: 22px; height: 22px; border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 11px; font-weight: 700;
+}
+.privacy-card.ew .privacy-step-num { background: rgba(0,200,128,0.12); color: var(--green); }
+.privacy-card.wf .privacy-step-num { background: rgba(230,37,58,0.08); color: var(--red); }
+
+/* ── Speed Stats ── */
+.speed-stats { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+.speed-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 28px 20px; text-align: center;
+}
+.speed-value {
+  font-size: 42px; font-weight: 800; letter-spacing: -2px; line-height: 1; margin-bottom: 6px;
+  background: var(--rainbow-full);
+  -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;
+}
+.speed-label { font-size: 14px; color: var(--text-2); font-weight: 500; }
+.speed-detail { font-size: 11px; color: var(--text-3); margin-top: 4px; }
+
+/* ── Deep Dive ── */
+.deep-dive-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 28px; }
+.deep-dive-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 36px 32px;
+  position: relative; overflow: hidden;
+}
+.deep-dive-card::before {
+  content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px;
+  background: var(--rainbow-full);
+}
+.deep-dive-icon { font-size: 32px; margin-bottom: 16px; line-height: 1; }
+.deep-dive-title { font-size: 22px; font-weight: 800; letter-spacing: -0.8px; margin-bottom: 12px; color: var(--text); }
+.deep-dive-body { font-size: 15px; color: var(--text-2); line-height: 1.7; }
+.deep-dive-body p { margin-bottom: 12px; }
+.deep-dive-body p:last-child { margin-bottom: 0; }
+.deep-dive-detail {
+  margin-top: 16px; padding: 14px 18px; border-radius: 10px;
+  background: rgba(124,58,237,0.04); border: 1px solid rgba(124,58,237,0.08);
+  font-size: 13px; color: var(--text-2); line-height: 1.6;
+}
+.deep-dive-detail strong { color: var(--text); }
+@media (max-width: 900px) {
+  .deep-dive-grid { grid-template-columns: 1fr; }
+}
+
+/* ── FAQ ── */
+.faq-list { max-width: 720px; margin: 0 auto; }
+.faq-item {
+  border-bottom: 1px solid var(--border-hover); padding: 24px 0;
+}
+.faq-item:last-child { border-bottom: none; }
+.faq-q {
+  font-size: 17px; font-weight: 700; color: var(--text); margin-bottom: 8px; letter-spacing: -0.3px;
+}
+.faq-a { font-size: 15px; color: var(--text-2); line-height: 1.65; }
+
+/* ── CTA ── */
+.cta-section { padding: var(--section-pad) 0; text-align: center; position: relative; z-index: 1; }
+.cta-section h2 { font-size: 40px; font-weight: 800; letter-spacing: -2px; margin-bottom: 12px; }
+.cta-section p { font-size: 17px; color: var(--text-2); margin-bottom: 36px; }
+.cta-actions { display: flex; align-items: center; justify-content: center; gap: 16px; flex-wrap: wrap; }
+.back-link { font-size: 15px; font-weight: 500; color: var(--text-3); text-decoration: none; transition: color 0.2s; }
+.back-link:hover { color: var(--accent); }
+
+/* ── Responsive ── */
+@media (max-width: 900px) {
+  .advantages-grid { grid-template-columns: repeat(2, 1fr); }
+  .privacy-split { grid-template-columns: 1fr; }
+  .speed-stats { grid-template-columns: repeat(3, 1fr); }
+  .page-header h1 { font-size: 42px; letter-spacing: -2px; }
+}
+@media (max-width: 600px) {
+  .advantages-grid { grid-template-columns: 1fr; }
+  .speed-stats { grid-template-columns: 1fr; }
+  .page-header h1 { font-size: 34px; letter-spacing: -1px; }
+  .compare-table-wrap { margin: 0 -20px; border-radius: 0; border-left: none; border-right: none; }
+}
+</style>
+
+<!-- Page Header -->
+<header class="page-header">
+  <div class="container">
+    <div class="vs-badge reveal">
+      <span class="vs-brand accent">EnviousWispr</span>
+      <span class="vs-circle">VS</span>
+      <span class="vs-brand">Vox</span>
+    </div>
+    <h1 class="reveal">Two private dictation apps with different ideas about polish.</h1>
+    <p class="page-header-sub reveal">Both can keep speech and cleanup on your device. EnviousWispr is free and open source for personal or work use. Vox adds editable Voice Modes, Windows support, and a voice-controlled task list; paid work licenses begin at companies with more than one person.</p>
+    <div class="hero-pills reveal">
+      <span class="hero-pill">Both can work offline</span>
+      <span class="hero-pill">Both support M1 and newer</span>
+      <span class="hero-pill">No account for personal use</span>
+    </div>
+    <div class="hero-cta reveal">
+      <a href="/#download" class="btn-primary">Download EnviousWispr Free</a>
+    </div>
+    <p class="hero-meta reveal">By <a href="/authors/saurabh-vaish/" style="color: var(--text-3); text-decoration: underline;">Saurabh Vaish</a> · Last reviewed: August 2026</p>
+  </div>
+</header>
+
+<section class="section" aria-label="Feature Comparison">
+  <div class="container">
+    <div class="section-head reveal">
+      <h2 class="section-title">Feature comparison</h2>
+      <p class="section-sub">The short version: both keep speech recognition local. Cleanup privacy, licensing, modes, platforms, and how the finished text reaches your app are where the choice changes.</p>
+    </div>
+    <div class="compare-table-wrap reveal">
+      <table class="compare-table compare-table--duo">
+        <thead>
+          <tr><th>Feature</th><th>EnviousWispr</th><th>Vox</th></tr>
+        </thead>
+        <tbody>
+          <!-- Evidence: Vox 1.10.0 was inspected directly on 2026-08-21. Public claims were verified
+               against https://vox.rizenhq.com/ and https://vox.rizenhq.com/teams on 2026-08-21.
+               The installed app, local mode files, and settings file confirmed editable modes, Gemma 4
+               cleanup choices, Parakeet/Whisper speech models, suggested modes, and VoxNotch controls.
+               Confidence: firsthand-tested plus source-verified. -->
+          <tr>
+            <td>Price and license</td>
+            <td><span class="table-highlight">Free for personal and work use</span>; open source under GPLv3</td>
+            <td>Free for personal use and work at a one-person company; larger-company work is $12 per seat monthly or $120 yearly ($10 per month); closed source</td>
+          </tr>
+          <tr>
+            <td>Platforms</td>
+            <td>Apple Silicon Mac, macOS 14+</td>
+            <td><span class="table-check">Mac and Windows</span>; Apple Silicon Mac with macOS 14+, or Windows 10/11</td>
+          </tr>
+          <tr>
+            <td>Speech engines</td>
+            <td>Parakeet TDT v3 and WhisperKit</td>
+            <td>Parakeet and Whisper, with several local model choices</td>
+          </tr>
+          <tr>
+            <td>Audio sent to a server</td>
+            <td><span class="table-check">Never</span></td>
+            <td><span class="table-check">Never</span></td>
+          </tr>
+          <tr>
+            <td>AI cleanup</td>
+            <td>EG-1, Apple Intelligence, or a downloaded Ollama model</td>
+            <td>Downloaded Gemma 4 stays local; Apple Intelligence may use Apple's Private Cloud Compute</td>
+          </tr>
+          <tr>
+            <td>Cloud cleanup</td>
+            <td>Optional OpenAI, Gemini, Claude, or hosted Ollama with your own account or key</td>
+            <td>No third-party provider option; Apple Intelligence may use Apple's Private Cloud Compute</td>
+          </tr>
+          <tr>
+            <td>Writing modes</td>
+            <td>One cleanup pipeline that preserves the dictated tone</td>
+            <td><span class="table-check">Editable Voice Modes</span> for chat, email, notes, code comments, summaries, and custom styles</td>
+          </tr>
+          <tr>
+            <td>App-aware behavior</td>
+            <td>App context helps polish the transcript</td>
+            <td><span class="table-check">Suggested and automatic modes</span> based on the current app</td>
+          </tr>
+          <tr>
+            <td>Finished text</td>
+            <td>Can paste directly or copy to the clipboard</td>
+            <td>Copies to the clipboard by default; the installed settings also expose automatic paste</td>
+          </tr>
+          <tr>
+            <td>Voice task list</td>
+            <td><span class="table-cross">No</span></td>
+            <td><span class="table-check">VoxNotch</span> can add, finish, reorder, reprioritize, and remove local tasks by voice on Mac</td>
+          </tr>
+          <tr>
+            <td>Custom vocabulary</td>
+            <td><span class="table-check">Yes</span>, with aliases and Smart Import from other apps</td>
+            <td><span class="table-check">Yes</span>, a local personal dictionary</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <p style="font-size: 12px; color: var(--text-3); margin-top: 12px; text-align: center;">Vox claims were checked in Vox 1.10.0 and on <a href="https://vox.rizenhq.com/" target="_blank" rel="noopener" style="color: var(--text-3); text-decoration: underline;">Vox's official site</a>. Pricing was checked on its <a href="https://vox.rizenhq.com/teams" target="_blank" rel="noopener" style="color: var(--text-3); text-decoration: underline;">official Teams page</a>. Competitor claims last verified: 2026-08-21.</p>
+  </div>
+</section>
+
+<section class="section" style="padding-top: 24px;">
+  <div class="container">
+    <div class="section-head reveal">
+      <h2 class="section-title">What both apps get right</h2>
+      <p class="section-sub">Choosing local dictation no longer means giving up cleaned-up text.</p>
+    </div>
+    <div class="advantages-grid">
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🔒</div>
+        <div class="advantage-title">Speech stays local</div>
+        <p class="advantage-desc">Both transcribe on your device. Neither needs to upload your recording for ordinary dictation.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">✨</div>
+        <div class="advantage-title">Cleanup can stay local</div>
+        <p class="advantage-desc">Both can remove fillers, fix punctuation, and shape the result with an on-device writing model.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">✈️</div>
+        <div class="advantage-title">Works without internet</div>
+        <p class="advantage-desc">After model downloads finish, either app can handle the full dictation path offline when a local cleanup model is selected.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="section" aria-label="Where each app fits">
+  <div class="container">
+    <div class="section-head reveal">
+      <h2 class="section-title">The clearest reasons to choose each one</h2>
+    </div>
+    <div class="deep-dive-grid">
+      <div class="deep-dive-card reveal">
+        <div class="deep-dive-icon">🟣</div>
+        <div class="deep-dive-title">Choose EnviousWispr for a smaller, open workflow</div>
+        <div class="deep-dive-body">
+          <p>EnviousWispr is free for personal and work use, and the app is open source under GPLv3. It can paste directly where you were writing, recover an accidental cancellation, and import custom words from other dictation apps.</p>
+          <p>You can keep polish local or bring your own cloud provider. That gives you a simple default without closing off model choice later.</p>
+        </div>
+      </div>
+      <div class="deep-dive-card reveal">
+        <div class="deep-dive-icon">🎛️</div>
+        <div class="deep-dive-title">Choose Vox for modes, Windows, and VoxNotch</div>
+        <div class="deep-dive-body">
+          <p>Vox gives each writing context its own editable prompt. It can suggest a mode for the current app, and its built-in choices cover chat, email, notes, code comments, summaries, and more.</p>
+          <p>VoxNotch is a separate local task surface controlled by natural speech. Vox also runs on Windows, which EnviousWispr does not.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="section" aria-label="Frequently Asked Questions">
+  <div class="container">
+    <div class="section-head reveal"><h2 class="section-title">Frequently asked questions</h2></div>
+    <div class="faq-list">
+      <div class="faq-item reveal">
+        <div class="faq-q">Is EnviousWispr free, like Vox?</div>
+        <p class="faq-a">EnviousWispr is free for personal and work use under GPLv3. Vox is free for personal use, while work use at a company with more than one person requires a commercial license at $12 per seat monthly or $120 per seat yearly, equivalent to $10 per month. Neither app requires an account for personal dictation.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Do EnviousWispr and Vox both work offline?</div>
+        <p class="faq-a">Yes, when using downloaded local models. Vox can transcribe locally and use downloaded Gemma 4 for local cleanup. Vox also offers Apple Intelligence, which may route text through Apple's Private Cloud Compute. EnviousWispr can use local EG-1, Apple Intelligence, or downloaded Ollama models, plus optional cloud providers with your own key.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Does Vox have AI cleanup like EnviousWispr's EG-1?</div>
+        <p class="faq-a">Yes. Vox can clean up text locally with a downloaded Gemma 4 model. It also offers Apple Intelligence, which may route text through Apple's Private Cloud Compute. Vox's built-in and custom Voice Modes control how cleanup behaves. EnviousWispr offers EG-1, Apple Intelligence, or a downloaded Ollama model locally, plus optional cloud providers with your own key.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">What is VoxNotch?</div>
+        <p class="faq-a">It is a local task list that sits at the top of the Mac screen. You can add, finish, remove, reorder, and reprioritize tasks by speaking naturally.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Is Vox open source?</div>
+        <p class="faq-a">No. Vox's official FAQ says the team is considering open-sourcing its modes engine. EnviousWispr is open source under GPLv3.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Which Macs do EnviousWispr and Vox support?</div>
+        <p class="faq-a">Both support Apple Silicon Macs starting with M1 on macOS 14 or later. Neither supports Intel Macs. Vox also supports 64-bit Windows 10 and 11, while EnviousWispr is Mac only.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="section" aria-label="Related Comparisons" style="padding-top: 0;">
+  <div class="container" style="text-align: center;">
+    <p style="font-size: 13px; color: var(--text-3); margin-bottom: 14px;">Compare more on-device dictation apps:</p>
+    <div style="display: flex; flex-wrap: wrap; gap: 10px; justify-content: center;">
+      <a href="/compare/superwhisper/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Superwhisper</a>
+      <a href="/compare/fluidvoice/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs FluidVoice</a>
+      <a href="/compare/juno/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Juno</a>
+      <a href="/compare/handy/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Handy</a>
+    </div>
+  </div>
+</section>
+
+<section class="cta-section" aria-label="Download CTA">
+  <div class="container">
+    <h2 class="reveal">Want the free, open-source option?</h2>
+    <p class="reveal">No account. No subscription. Your audio stays on your Mac.</p>
+    <div class="cta-actions reveal">
+      <a href="https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg" class="btn-primary" data-download-source="compare">Download EnviousWispr Free</a>
+      <a href="/compare/" class="back-link">See all comparisons</a>
+    </div>
+  </div>
+</section>
+
+</BaseLayout>

--- a/website/src/pages/compare/wisprflow.astro
+++ b/website/src/pages/compare/wisprflow.astro
@@ -392,9 +392,10 @@ const faqJsonLd = JSON.stringify({
                - App opened directly (2026-08-21): Settings confirms a "Vibe coding" section: variable
                  recognition for VS Code/Cursor/Windsurf and automatic file tagging in Cursor/Windsurf chat
                  (e.g. `index.tsx`). Confirmed the dictionary is genuinely auto-learning with team sharing,
-                 as already stated on this page. Connectors/MCP tabs are exclusively for the separate
-                 Notetaker meeting-notes feature, explicitly not dictation ("The Wispr MCP does not have
-                 access to your dictations"), so they are out of scope for this page.
+                 as already stated on this page. The live app also showed Notetaker, Insights, personal and
+                 team snippets, category Styles, three Auto Cleanup levels, Transforms, Scratchpad, Calendar
+                 and Slack connectors, and an MCP surface for meeting notes. The MCP page explicitly excludes
+                 ordinary dictations.
              Word-limit words-remaining counter and free-tier cap independently confirmed live in-app.
              EnviousWispr latency (0.61s / 1.65s) re-measured from production PostHog data, 30-day trailing median, 2026-08-21.
              All claims are source-verified from official pages and the installed app. -->
@@ -475,6 +476,26 @@ const faqJsonLd = JSON.stringify({
             <td><span class="table-check">Yes</span> (Pro only). Edit and rewrite with voice commands.</td>
           </tr>
           <tr>
+            <td>Meeting notetaker</td>
+            <td><span class="table-cross">No</span></td>
+            <td><span class="table-check">Yes</span>, with live transcript, speaker labels, shared notes, imports, and questions over meetings</td>
+          </tr>
+          <tr>
+            <td>Post-dictation transforms and scratchpad</td>
+            <td><span class="table-cross">No dedicated workspace</span></td>
+            <td><span class="table-check">Yes</span>, reusable Transforms plus a multi-tab rich-text Scratchpad</td>
+          </tr>
+          <tr>
+            <td>Usage insights</td>
+            <td>Basic word and time-saved statistics</td>
+            <td><span class="table-check">Detailed</span>: speed, words, corrections, dictionary fixes, app/task breakdown, streaks, and a local Voice Profile</td>
+          </tr>
+          <tr>
+            <td>MCP and connectors</td>
+            <td><span class="table-cross">No</span></td>
+            <td><span class="table-check">Meeting notes only</span>: MCP excludes ordinary dictations; Google Calendar and Slack connectors support Notetaker workflows</td>
+          </tr>
+          <tr>
             <td>First-word capture</td>
             <td><span class="table-check">Yes,</span> while the mic is warm. A 500ms pre-roll buffer captures audio before recording officially starts; a cold start can still clip.</td>
             <td>Not specified</td>
@@ -517,7 +538,7 @@ const faqJsonLd = JSON.stringify({
         </tbody>
       </table>
     </div>
-    <p style="font-size: 12px; color: var(--text-3); margin-top: 12px; text-align: center;">*WisprFlow pricing and features verified from wisprflow.ai/pricing and wisprflow.ai/features, last checked August 2026. Pro is $15/mo billed monthly or $12/mo billed annually. EnviousWispr latency from production PostHog data on Apple Silicon Macs, 30-day trailing median. WisprFlow was not firsthand-tested. "Not specified" means the feature is not documented on WisprFlow's public pages. Competitor claims last verified: 2026-08-21.</p>
+    <p style="font-size: 12px; color: var(--text-3); margin-top: 12px; text-align: center;">*WisprFlow pricing and features verified from wisprflow.ai/pricing, wisprflow.ai/features, and Wispr Flow 1.6.606 opened directly. Pro is $15/mo billed monthly or $12/mo billed annually. EnviousWispr latency comes from production PostHog data on Apple Silicon Macs. Competitor claims last verified: 2026-08-21.</p>
     <div style="text-align: center; margin-top: 28px;">
       <a href="/#download" class="btn-primary">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
@@ -710,7 +731,7 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">🎨</div>
         <div class="advantage-title">You want more features today</div>
-        <p class="advantage-desc">WisprFlow has a broader feature set: voice command mode for editing, snippet shortcuts, per-app tone adjustment, whisper mode, backtrack correction, team collaboration tools, and coding-editor awareness that recognizes variable names in VS Code, Cursor, or Windsurf and auto-tags files in Cursor and Windsurf chat. EnviousWispr is catching up, but WisprFlow is ahead on features right now.</p>
+        <p class="advantage-desc">WisprFlow has a broader feature set: Notetaker, shared dictionary and snippets, Transforms, Scratchpad, Insights, app-category Styles, voice command editing, backtrack, team tools, and coding-editor awareness. EnviousWispr is catching up, but WisprFlow is ahead on features right now.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">🏢</div>


### PR DESCRIPTION
## Summary

- refreshes FluidVoice, Handy, Juno, Spokenly, Superwhisper, TypeWhisper, and Wispr Flow from the August 21 live app audit
- adds a new Vox comparison page and updates the comparison hub to 17 apps
- adds Vox to the 2026 roundup and updates the AI-readable site index
- keeps public claims explicit about firsthand, source-verified, and installed-bundle evidence

## Important corrections

- distinguishes local and cloud speech or cleanup paths for Vox and Superwhisper
- separates Juno Voice Actions that require "Hey Juno" from rewrite commands that do not
- reflects current model catalogs, integrations, settings, licensing boundaries, and paid-tier limits
- keeps visible FAQs and FAQ structured data synchronized

## Responsive verification

- desktop verified at 1440 x 1000 with the standard three-column head-to-head table
- mobile verified at 390 x 844 with the shared label-band layout and no sideways page overflow
- rebased onto #2289 so Vox uses the same responsive table owner as the other head-to-head pages

## Validation

- `npm run build`: pass, 132 pages including `/compare/vox/`
- internal static-link scan: pass
- browser console: no warnings or errors
- independent GPT-5.6 Codex review: clean after all findings were fixed
- Content-lane validation record: pass

Closes #2290
