### PR TITLE
test(ui): bind meter updates to poll ticks

### DIFF
--- a/Sources/EnviousWisprAppKit/App/Overlay/Views/OverlayLegacyViews.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/Views/OverlayLegacyViews.swift
@@ -164,6 +164,11 @@ struct RainbowLevelMeter: View {
   var barWidth: CGFloat = 2
   var spacing: CGFloat = 1.5
 
+  /// Outcome observer for the rendered history update. Production uses the
+  /// no-op default; host-view tests use it to prove the SwiftUI trigger feeds
+  /// identical samples on successive poll ticks.
+  var onHistoryChange: ([CGFloat]) -> Void = { _ in }
+
   /// #2216: the last `barCount` levels, oldest first. Bar `i` is a MOMENT, not a
   /// position on a shape.
   ///
@@ -276,7 +281,9 @@ struct RainbowLevelMeter: View {
     }
     .frame(width: Self.width(barWidth: barWidth, spacing: spacing), height: height)
     .onChange(of: tick) { _, _ in
-      history = Self.pushed(history, level: CGFloat(audioLevel))
+      let next = Self.pushed(history, level: CGFloat(audioLevel))
+      history = next
+      onHistoryChange(next)
     }
     .accessibilityHidden(true)
   }

--- a/Tests/EnviousWisprTests/App/RainbowLevelMeterTests.swift
+++ b/Tests/EnviousWisprTests/App/RainbowLevelMeterTests.swift
@@ -22,6 +22,23 @@ import Testing
 @Suite(.tags(.productOutcome))
 struct RainbowLevelMeterTests {
 
+  private final class MeterDriver: ObservableObject {
+    @Published var tick = 0
+    @Published var audioLevel: Float = 0
+  }
+
+  private struct MeterHarness: View {
+    @ObservedObject var driver: MeterDriver
+    let onHistoryChange: ([CGFloat]) -> Void
+
+    var body: some View {
+      RainbowLevelMeter(
+        audioLevel: driver.audioLevel,
+        tick: driver.tick,
+        onHistoryChange: onHistoryChange)
+    }
+  }
+
   init() { _ = NSApplication.shared }
 
   // MARK: - The history is a record
@@ -107,6 +124,36 @@ struct RainbowLevelMeterTests {
       \(heights). The loud passage never scrolled off, so the waveform is frozen \
       rather than draining.
       """)
+  }
+
+  @Test("identical silence samples enter history on every poll tick")
+  func identicalSilenceSamplesFollowTheTick() async {
+    let driver = MeterDriver()
+    var observed: [[CGFloat]] = []
+    let host = NSHostingView(
+      rootView: MeterHarness(driver: driver) { observed.append($0) }
+        .frame(width: 100, height: 20))
+    let frame = NSRect(x: 0, y: 0, width: 100, height: 20)
+    let window = NSWindow(
+      contentRect: frame, styleMask: [.borderless], backing: .buffered, defer: false)
+    window.contentView = host
+    host.frame = frame
+    host.layoutSubtreeIfNeeded()
+    window.displayIfNeeded()
+    #expect(observed.isEmpty, "mounting the meter must not invent a sample")
+
+    driver.tick = 1
+    await Task.yield()
+    host.layoutSubtreeIfNeeded()
+    window.displayIfNeeded()
+
+    driver.tick = 2
+    await Task.yield()
+    host.layoutSubtreeIfNeeded()
+    window.displayIfNeeded()
+
+    #expect(observed.count == 2, "two poll ticks delivered \(observed.count) samples")
+    #expect(observed.last == [0, 0], "identical silence did not advance the rendered history")
   }
 
   // MARK: - Turning the buffer into bars


### PR DESCRIPTION
## Summary

- add an inert production-default history observer to the Live Preview meter
- host the real SwiftUI view in a test and prove identical silence samples advance on every poll tick
- finish the formerly blocked parameterized clamp mutation using the repaired result-bundle runner

## Mutation proof

- changing the view trigger from `tick` back to `audioLevel` failed the new hosted-view test on both expected samples
- removing the entry clamp failed the named parameterized test through the canonical mutation runner; baseline was green before and after and the source was restored byte-identically
- the issue's remaining filed rows were already caught or documented as an intentional redundant pair; all nine filed protections are now accounted for

## Validation

- focused Debug suite: 20 tests passed
- focused Release suite: 20 tests passed
- full Debug lane: 6,356 tests passed
- hosted wiring test stress run: 30/30 passed
- pinned Codex 5.6 review: no actionable defects
- `git diff --check`: clean

Closes #2220
