### PR TITLE
fix(post-processing): keep a glued domain suffix through custom-word correction

### DIFF
--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -895,35 +895,43 @@ public struct WordCorrector: Sendable {
         return token
       }
 
-      // Pass 3, tried on the token exactly as ASR emitted it, BEFORE any TLD
-      // peeling. A saved custom word or alias can itself be a domain
-      // ("GitHub.com" canonical, "githab.com" alias), and this is the only
-      // pass safe to try unpeeled: exact string equality can never
-      // coincidentally consume a glued TLD (Codex review, PR for #2281,
-      // finding P1).
-      if let canonical = singleAliasMap[coreLower], core != canonical {
-        appendReplacement(forCanonical: canonical)
-        #if DEBUG
-          Self.logger.debug("WordCorrector: type=alias source='\(core)' target='\(canonical)'")
-        #endif
+      // Step 1: exact match (always) + fuzzy match RESTRICTED to
+      // domain-shaped candidates (`isDomainShaped`), both tried against the
+      // token exactly as ASR emitted it, before any peeling. Exact equality
+      // can never coincidentally consume a glued TLD, so it is always safe
+      // unpeeled (Codex review, PR for #2281, finding P1 round 1). Fuzzy
+      // scoring CAN cross threshold against a glued suffix -- but only when
+      // the CANDIDATE it's compared against is itself bare. A candidate that
+      // is ALSO domain-shaped ("githab.com" alias for canonical
+      // "GitHub.com") makes the comparison apples-to-apples (both sides
+      // carry a TLD), so a near-miss like "githib.com" still needs to try
+      // this unpeeled -- peeling first would strip the TLD from only one
+      // side and lose the match entirely (Codex review, PR for #2281,
+      // finding P1 round 3).
+      if let canonical = matchSingleWordPasses(
+        core: core, coreLower: coreLower, lookups: lookups,
+        appendReplacement: { appendReplacement(forCanonical: $0) }, fuzzyDomainShapedOnly: true)
+      {
         return prefix + canonical + suffix
       }
 
-      // Every other pass (fuzzy Pass 4/5, pack tier) runs on a TLD-peeled core
-      // whenever a recognized TLD is glued to the end -- never on the raw
-      // glued token. Fuzzy SCORING, unlike exact equality, can cross
-      // threshold against the whole glued string too (measured live for
-      // several TLDs while building this fix: trying fuzzy on the unpeeled
-      // token first reproduced the original bug for org/net/ai/me/io/app),
-      // so this is not an optional refinement -- it is what makes the fix
-      // correct for every fuzzy-matched brand, not only exact ones.
+      // Step 2: peel a plausible glued suffix and retry every pass
+      // (exact + fuzzy + pack) against the bare core. The peel trigger is
+      // deliberately NOT limited to `recognizedTLDs` -- fuzzy scoring can
+      // silently swallow any glued suffix that survives edge-punctuation
+      // stripping, not only the ten TLDs that set recognizes as URL
+      // evidence, so narrowing this trigger to that set left ".us"/".uk"/
+      // ".tech" etc. unprotected (Codex review, PR for #2281, finding P1
+      // round 3). If nothing matches the peeled core either, the untouched
+      // original token is returned below, so a permissive trigger costs
+      // nothing when the suffix isn't actually a domain.
       var matchCore = core
-      var peeledTLD = ""
+      var peeledSuffix = ""
       if let lastDot = core.lastIndex(of: "."), lastDot > core.startIndex {
-        let tail = core[core.index(after: lastDot)...].lowercased()
-        if Self.recognizedTLDs.contains(tail) {
+        let tail = core[core.index(after: lastDot)...]
+        if !tail.isEmpty, tail.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "-" }) {
           matchCore = String(core[core.startIndex..<lastDot])
-          peeledTLD = String(core[lastDot...])
+          peeledSuffix = String(core[lastDot...])
         }
       }
       let matchCoreLower = matchCore.lowercased()
@@ -931,18 +939,18 @@ public struct WordCorrector: Sendable {
         return token
       }
       if let canonical = matchSingleWordPasses(
-        core: matchCore, coreLower: matchCoreLower,
-        lookups: lookups, appendReplacement: { appendReplacement(forCanonical: $0) })
+        core: matchCore, coreLower: matchCoreLower, lookups: lookups,
+        appendReplacement: { appendReplacement(forCanonical: $0) }, fuzzyDomainShapedOnly: false)
       {
-        // Codex review, PR for #2281, finding P2 (round 2): a saved
+        // Codex review, PR for #2281, finding P2 (rounds 2 and 3): a saved
         // CANONICAL can itself be a domain ("GitHub.com") even when its
-        // alias is the bare word ("githab") -- blindly re-appending the
-        // peeled TLD to that canonical would produce "GitHub.com.com".
-        // Reattach it only when the matched canonical does not already end
-        // with it.
-        let reattach =
-          peeledTLD.isEmpty || canonical.lowercased().hasSuffix(peeledTLD.lowercased())
-          ? "" : peeledTLD
+        // alias is the bare word ("githab") -- reattaching the peeled
+        // suffix to a canonical that is ALREADY domain-shaped would produce
+        // something like "GitHub.com.org". Suppress the reattach whenever
+        // the matched canonical is domain-shaped AT ALL, not only when it
+        // happens to end with the SAME suffix that was peeled: the
+        // canonical fully specifies its own domain either way.
+        let reattach = peeledSuffix.isEmpty || Self.isDomainShaped(canonical) ? "" : peeledSuffix
         return prefix + canonical + reattach + suffix
       }
 
@@ -955,13 +963,22 @@ public struct WordCorrector: Sendable {
   /// Passes 3-5 (plus the pack tier), factored out of `correct(using:)` so the
   /// single-word matcher can be run TWICE per token: once against the token as
   /// ASR emitted it, and -- only if that produced no match -- once more
-  /// against a TLD-peeled core (see the call site in `correct(using:)`).
+  /// against a peeled core (see the two call sites in `correct(using:)`).
   /// Returns the bare matched CANONICAL, never prefix/suffix-assembled --
   /// the caller reattaches those, since only the caller knows whether a
-  /// peeled TLD needs deduplicating against the canonical it matched.
+  /// peeled suffix needs deduplicating against the canonical it matched.
+  ///
+  /// `fuzzyDomainShapedOnly` gates ONLY the fuzzy passes (4/5 + pack): Pass 3
+  /// (exact) always considers every alias, domain-shaped or not, because
+  /// exact equality can never coincidentally consume a glued suffix the way
+  /// fuzzy scoring can. The unpeeled call site passes `true` (fuzzy is only
+  /// safe unpeeled when comparing against an equally domain-shaped
+  /// candidate); the peeled call site passes `false` (the ordinary,
+  /// unrestricted pool, exactly as before this parameter existed).
   private func matchSingleWordPasses(
     core: String, coreLower: String,
-    lookups: Lookups, appendReplacement: (String) -> Void
+    lookups: Lookups, appendReplacement: (String) -> Void,
+    fuzzyDomainShapedOnly: Bool
   ) -> String? {
     let singleAliasMap = lookups.singleAliasMap
     let singleFuzzyCandidates = lookups.singleFuzzyCandidates
@@ -1000,6 +1017,9 @@ public struct WordCorrector: Sendable {
     for entry in singleFuzzyCandidates {
       let surface = entry.surface
       let canonical = entry.canonical
+      if fuzzyDomainShapedOnly, !Self.isDomainShaped(surface), !Self.isDomainShaped(canonical) {
+        continue
+      }
       // Length-ratio pruning: skip if lengths differ too much for threshold
       let surfLen = surface.count
       let lenRatio = Double(min(coreLen, surfLen)) / Double(max(coreLen, surfLen))
@@ -1056,6 +1076,7 @@ public struct WordCorrector: Sendable {
     bestMatch = ""
 
     for (idx, targetLower) in lowercasedCanonicals.enumerated() {
+      if fuzzyDomainShapedOnly, !Self.isDomainShaped(targetLower) { continue }
       let targetLen = targetLower.count
       let lenRatio = Double(min(coreLen, targetLen)) / Double(max(coreLen, targetLen))
       if lenRatio < 0.5 { continue }
@@ -1127,6 +1148,11 @@ public struct WordCorrector: Sendable {
       var pSecond = 0.0
       var pMatch = ""
       for entry in packSingleFuzzyCandidates {
+        if fuzzyDomainShapedOnly, !Self.isDomainShaped(entry.surface),
+          !Self.isDomainShaped(entry.canonical)
+        {
+          continue
+        }
         let surfLen = entry.surface.count
         let lenRatio = Double(min(coreLen, surfLen)) / Double(max(coreLen, surfLen))
         if lenRatio < 0.5 { continue }
@@ -1169,6 +1195,7 @@ public struct WordCorrector: Sendable {
       var pSecond = 0.0
       var pMatch = ""
       for (idx, targetLower) in packLowercasedCanonicals.enumerated() {
+        if fuzzyDomainShapedOnly, !Self.isDomainShaped(targetLower) { continue }
         let targetLen = targetLower.count
         let lenRatio = Double(min(coreLen, targetLen)) / Double(max(coreLen, targetLen))
         if lenRatio < 0.5 { continue }
@@ -1293,14 +1320,38 @@ public struct WordCorrector: Sendable {
   /// (`lowerRiskURLTLDAlt` + `commonWordURLTLDAlt`), reused rather than
   /// redefined so both parts of the pipeline agree on what "looks like a
   /// domain" means — a closed, already-vetted set, never a fresh guess
-  /// (`matcher-set-adversarial-tests`). Read only by the single-word retry in
-  /// `correct(using:)` -- NOT by `splitPunctuation` itself, so Pass 0/1/2
-  /// compound matching still treats a glued domain as one opaque unit, exactly
-  /// as before this fix (Codex review, PR for #2281, finding P2: peeling a TLD
-  /// inside the shared helper let an internal token's ".com" get silently
-  /// consumed by an accidental cross-token compound match).
+  /// (`matcher-set-adversarial-tests`).
+  ///
+  /// Scope, narrowed by Codex review round 3: this set decides whether a
+  /// saved ALIAS/CANONICAL counts as domain-shaped (`isDomainShaped(_:)`
+  /// below) -- a controlled, curated surface where reusing the vetted TLD
+  /// list is correct. It does NOT decide whether a dotted suffix on the
+  /// INPUT is worth trying to peel: that trigger is deliberately broader
+  /// (see the single-word retry in `correct(using:)`), because fuzzy scoring
+  /// can silently swallow ANY glued suffix, not only the ten TLDs here --
+  /// `Enviousvisper.us` was still corrected to `EnviousWispr` (dropping
+  /// ".us") when the peel trigger was this same narrow list.
+  /// Read only by the single-word retry -- NOT by `splitPunctuation` itself,
+  /// so Pass 0/1/2 compound matching still treats a glued domain as one
+  /// opaque unit, exactly as before this fix (Codex review, PR for #2281,
+  /// finding P2: peeling inside the shared helper let an internal token's
+  /// ".com" get silently consumed by an accidental cross-token compound
+  /// match).
   private static let recognizedTLDs: Set<String> = Set(
     InverseTextNormalizer.urlTLDAlt.components(separatedBy: "|"))
+
+  /// True when `s` itself ends in a recognized TLD -- used to decide whether
+  /// a saved alias/canonical is a domain in its own right, in which case a
+  /// peeled suffix must never be appended to it a second time (Codex review,
+  /// PR for #2281, finding P2 round 3: a bare alias "githab" mapped to
+  /// canonical "GitHub.com" turned input "githab.org" into "GitHub.com.org"
+  /// when the dedup check only compared against the SAME TLD that was
+  /// peeled, rather than asking whether the canonical is a domain at all).
+  private static func isDomainShaped(_ s: String) -> Bool {
+    guard let lastDot = s.lastIndex(of: "."), lastDot > s.startIndex else { return false }
+    let tail = s[s.index(after: lastDot)...].lowercased()
+    return Self.recognizedTLDs.contains(tail)
+  }
 
   private func stripPunctuation(_ token: String) -> String {
     splitPunctuation(token).core

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -906,9 +906,13 @@ public struct WordCorrector: Sendable {
       // when the suffix isn't actually a domain.
       var matchCore = core
       var peeledSuffix = ""
+      let hasPeelableSuffix: Bool
       if let split = Self.splitDomainSuffix(core) {
         matchCore = split.bare
         peeledSuffix = split.suffix
+        hasPeelableSuffix = true
+      } else {
+        hasPeelableSuffix = false
       }
       let matchCoreLower = matchCore.lowercased()
       let matchCoreEligible =
@@ -957,9 +961,19 @@ public struct WordCorrector: Sendable {
       // is ALSO domain-shaped makes the raw comparison apples-to-apples, so
       // a near-miss like "githib.com" needs to try this unpeeled (finding
       // P1 round 3).
-      if let canonical = nonPackFuzzySingleWordMatch(
-        core: core, coreLower: coreLower, lookups: lookups,
-        appendReplacement: { appendReplacement(forCanonical: $0) }, domainShapedOnly: true)
+      //
+      // Step 3 only runs when the token ITSELF has a peelable suffix (Codex
+      // review round 5, P1): without that guard it ran even for an ordinary
+      // no-dot word, comparing it against domain-shaped candidates it has
+      // no business being compared against and letting a weaker
+      // domain-shaped match preempt the correct bare candidate reachable
+      // only at step 4 -- "enviouswhisper" scoring against
+      // "enviouswhisper.com" purely because the strings share a long
+      // prefix, with no dot in the input at all.
+      if hasPeelableSuffix,
+        let canonical = nonPackFuzzySingleWordMatch(
+          core: core, coreLower: coreLower, lookups: lookups,
+          appendReplacement: { appendReplacement(forCanonical: $0) }, domainShapedOnly: true)
       {
         return prefix + canonical + suffix
       }
@@ -971,13 +985,15 @@ public struct WordCorrector: Sendable {
         return reattached(canonical)
       }
 
-      // Step 5 + 6: pack fuzzy, the same unpeeled-then-peeled shape, only
+      // Step 5 + 6: pack fuzzy, the same unpeeled-then-peeled shape (step 5
+      // gated on `hasPeelableSuffix` for the same reason step 3 is), only
       // reached once every higher-authority attempt above has missed. Step
       // 4's peeled non-pack fuzzy fixes the originally reported bug for a
       // bare (non-domain-shaped) alias.
-      if let canonical = packFuzzySingleWordMatch(
-        core: core, coreLower: coreLower, lookups: lookups,
-        appendReplacement: { appendReplacement(forCanonical: $0) }, domainShapedOnly: true)
+      if hasPeelableSuffix,
+        let canonical = packFuzzySingleWordMatch(
+          core: core, coreLower: coreLower, lookups: lookups,
+          appendReplacement: { appendReplacement(forCanonical: $0) }, domainShapedOnly: true)
       {
         return prefix + canonical + suffix
       }
@@ -1409,16 +1425,30 @@ public struct WordCorrector: Sendable {
   /// `urlTLDAlt` asserts semantic meaning ("this specific string IS a
   /// TLD"), which is the right bar for a POSITIVE identification (deciding
   /// spoken text represents a real URL). Here the bar is lower and
-  /// symmetric: "is this worth trying as a suffix", never asserted as fact
-  /// -- if peeling produces no match on either side, the untouched original
-  /// token is returned, so a wrong guess costs nothing. A purely structural
-  /// check generalizes to every user's vocabulary rather than the ten TLDs
-  /// this app happens to vet for URL recognition elsewhere.
+  /// symmetric: "is this worth trying as a suffix", never asserted as fact.
+  /// It is not free to be wrong, though (Codex review round 5, P2 --
+  /// correcting an earlier version of this comment that claimed it was): a
+  /// peeled bare form can coincidentally EXACT-match a real, unrelated
+  /// alias, so an over-permissive trigger produces a real wrong correction,
+  /// not merely a harmless miss -- alias "v1" turned input "v1.2" into
+  /// "VersionOne.2" before this guard existed. The one exclusion this
+  /// function makes is therefore load-bearing: a real TLD label is never
+  /// purely numeric (ICANN requires at least one non-digit character), so
+  /// an all-digit final label marks a version number, decimal, or IP-like
+  /// token rather than a domain. A purely structural check otherwise
+  /// generalizes to every user's vocabulary rather than the ten TLDs this
+  /// app happens to vet for URL recognition elsewhere.
   private static func splitDomainSuffix(_ s: String) -> (bare: String, suffix: String)? {
     guard let firstDot = s.firstIndex(of: "."), firstDot > s.startIndex else { return nil }
     let tail = s[s.index(after: firstDot)...]
     guard !tail.isEmpty, tail.first != ".", tail.last != ".",
       tail.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "-" || $0 == "." })
+    else {
+      return nil
+    }
+    let labels = tail.split(separator: ".", omittingEmptySubsequences: false)
+    guard labels.allSatisfy({ !$0.isEmpty }), let lastLabel = labels.last,
+      !lastLabel.allSatisfy({ $0.isNumber })
     else {
       return nil
     }

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -1502,13 +1502,29 @@ public struct WordCorrector: Sendable {
   /// domain) from "Node.js" (a product name that happens to end in a
   /// dot-suffix): both are ALL-LETTERS after the dot, so no structural rule
   /// -- however tightened -- can separate them.
+  /// KNOWN LIMIT, accepted rather than chased further (founder call,
+  /// Codex review round 7, P2): this list is CURATED, not exhaustive --
+  /// ICANN's real root zone has 1,500+ entries, and any hand-picked subset
+  /// will always be missing one (round 7 named "GitHub.academy" as a real
+  /// gTLD this list omits). `matcher-set-adversarial-tests`'s
+  /// generalisation gate is right that a hand-authored set is a prediction
+  /// about users we haven't met -- the two mechanisms that would actually
+  /// close it are bundling a maintained public-suffix authority, or letting
+  /// a word's OWNER mark it as a domain explicitly rather than the app
+  /// guessing from its text -- and both are real feature-sized additions,
+  /// not a fix for this bug. The failure mode this list still has is
+  /// narrow: it needs BOTH a saved word shaped like a domain that ISN'T one
+  /// AND a separately-dictated real domain suffix glued onto its bare
+  /// alias, and (measured against the shipped pack and this founder's own
+  /// live vocabulary while building this fix) zero words anywhere in this
+  /// app are shaped like a domain at all today.
   private static let knownDedupTLDs: Set<String> = [
     "com", "org", "net", "edu", "gov", "mil", "int", "info", "biz", "name",
     "pro", "coop", "museum", "aero", "jobs", "mobi", "travel", "tel", "asia", "cat", "xxx",
     "io", "co", "dev", "app", "xyz", "me", "tv", "cc", "ai", "tech",
     "online", "site", "store", "shop", "cloud", "live", "life", "world", "media", "news",
     "agency", "studio", "design", "digital", "email", "expert", "guide", "help",
-    "network", "software", "systems", "tools", "works", "so",
+    "network", "software", "systems", "tools", "works", "so", "academy",
     "us", "uk", "ca", "au", "de", "fr", "jp", "cn", "in", "br",
     "ru", "es", "it", "nl", "se", "no", "dk", "fi", "pl", "ch",
     "at", "be", "pt", "gr", "ie", "nz", "sg", "hk", "tw", "kr",

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -1049,7 +1049,17 @@ public struct WordCorrector: Sendable {
     core: String, coreLower: String, lookups: Lookups
   ) -> (canonical: String, isPack: Bool)? {
     guard let canonical = lookups.singleAliasMap[coreLower], core != canonical else { return nil }
-    let isPack = lookups.canonicalToWord[canonical.lowercased()]?.source == .pack
+    // Authority comes from the matched KEY (`coreLower`), never from the
+    // resulting canonical TEXT (Codex review, PR for #2281, finding P2
+    // round 8): `canonicalToWord[canonical]` answers "who owns this
+    // canonical STRING", which breaks when a pack alias and a user word
+    // happen to share the same canonical text -- a pack alias "githib.com"
+    // -> "Shared" would then be misattributed to the USER'S "Shared" word
+    // and wrongly treated as non-pack. `singleAliasMap` is constructed so
+    // non-pack always wins on a KEY collision, so `nonPackExactKeys`
+    // (already the authority for exactly that construction) tells us
+    // whether THIS key's mapping came from a non-pack term, unambiguously.
+    let isPack = !lookups.nonPackExactKeys.contains(coreLower)
     return (canonical, isPack)
   }
 
@@ -1475,11 +1485,29 @@ public struct WordCorrector: Sendable {
     }
     let labels = tail.split(separator: ".", omittingEmptySubsequences: false)
     guard labels.allSatisfy({ !$0.isEmpty }), let lastLabel = labels.last,
-      lastLabel.allSatisfy({ $0.isLetter })
+      Self.isPlausibleTLDLabel(lastLabel)
     else {
       return nil
     }
     return (String(s[s.startIndex..<firstDot]), String(s[firstDot...]))
+  }
+
+  /// True for an all-letters label (the ordinary case), OR a punycode
+  /// A-label -- the ASCII-only form DNS actually carries for an
+  /// internationalized TLD, always written as `xn--` followed by
+  /// alphanumerics and hyphens (Russia's `.рф` is `.xn--p1ai`, e.g.). Real
+  /// TLDs are never purely numeric or mixed-alphanumeric OUTSIDE this one
+  /// prefixed shape, so accepting punycode here does not reopen the
+  /// version-string/IP exclusions (Codex review, PR for #2281, finding P2
+  /// round 8): "xn--p1ai" and "v1" are structurally distinguishable by the
+  /// `xn--` prefix alone, and nothing that isn't real punycode happens to
+  /// start with it.
+  private static func isPlausibleTLDLabel(_ label: Substring) -> Bool {
+    if label.allSatisfy({ $0.isLetter }) { return true }
+    let lower = label.lowercased()
+    guard lower.hasPrefix("xn--") else { return false }
+    let rest = lower.dropFirst(4)
+    return !rest.isEmpty && rest.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "-" })
   }
 
   /// A curated (not exhaustive) set of real TLDs, deliberately much broader

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -937,75 +937,57 @@ public struct WordCorrector: Sendable {
       // "githib") -- accepting the unpeeled pack match immediately would
       // preempt the higher-authority user match one step away (Codex
       // review, PR for #2281, finding P1 round 7). So both attempts are
-      // computed first, with non-pack results checked before either pack
-      // result is accepted.
+      // computed first, and priority runs across all FOUR (attempt x
+      // authority) slots in a fixed order: unpeeled non-pack, peeled
+      // non-pack, unpeeled pack, peeled pack.
       let unpeeledExact = exactSingleWordMatch(core: core, coreLower: coreLower, lookups: lookups)
-      // The token already IS a registered canonical, byte-for-byte -- the
-      // strongest "leave this alone" signal available. Stop the whole
-      // single-word retry here rather than falling through to the peeled
-      // attempt, which could otherwise replace already-correct text with an
-      // unrelated match (Codex review, PR for #2281, finding P2 round 9).
-      if case .alreadyCorrect = unpeeledExact { return token }
-
-      var unpeeledMatch: (canonical: String, isPack: Bool)?
-      if case .replace(let canonical, let isPack) = unpeeledExact {
-        unpeeledMatch = (canonical, isPack)
-      }
-
-      func acceptExact(unpeeled: Bool, _ match: (canonical: String, isPack: Bool)) -> String {
-        appendReplacement(forCanonical: match.canonical)
-        #if DEBUG
-          Self.logger.debug(
-            "WordCorrector: type=alias source='\(unpeeled ? core : matchCore)' target='\(match.canonical)'"
-          )
-        #endif
-        return unpeeled ? prefix + match.canonical + suffix : reattached(match.canonical)
-      }
-
-      // An UNPEELED non-pack exact replace is the single highest-priority
-      // outcome in this whole retry -- a deliberate, complete registration
-      // for the token exactly as typed -- so it must win before anything
-      // peeled is even consulted, including a peeled `.alreadyCorrect`
-      // (Codex cloud review, PR #2298, round 11): canonical "GitHub" (a
-      // self-entry the peeled bare form matches exactly) does not get to
-      // override a SEPARATE, deliberately-registered alias "GitHub.com" ->
-      // "Company Portal" just because the peeled half also happens to
-      // resolve to something.
-      if let match = unpeeledMatch, !match.isPack {
-        return acceptExact(unpeeled: true, match)
-      }
-
       let peeledExact =
         matchCoreEligible
         ? exactSingleWordMatch(core: matchCore, coreLower: matchCoreLower, lookups: lookups)
         : ExactSingleWordOutcome.noMatch
-      var peeledMatch: (canonical: String, isPack: Bool)?
-      if case .replace(let canonical, let isPack) = peeledExact {
-        peeledMatch = (canonical, isPack)
-      }
-      // `.alreadyCorrect` on the PEELED form means the bare part was
-      // already spelled right, so the untouched original token (bare part
-      // + its existing suffix) is already the correct output -- but that
-      // conclusion is only valid if nothing HIGHER-priority already claimed
-      // this token, which the unpeeled non-pack check just above already
-      // ruled out. Without a signal of its own, `peeledMatch` staying nil
-      // here would be indistinguishable from `.noMatch`, letting a
-      // LOWER-authority pack exact match (or even a fuzzy match) found
-      // afterward win and replace text that was already correct (local
-      // Codex sweep of PR #2298's cloud findings: canonical "GitHub" + pack
-      // alias "github.com" -> "Wrong" turned input "GitHub.com" into
-      // "Wrong" instead of leaving it alone). Stop here, exactly like the
-      // unpeeled case above -- just one priority level later.
-      if case .alreadyCorrect = peeledExact { return token }
 
-      if let match = peeledMatch, !match.isPack {
-        return acceptExact(unpeeled: false, match)
+      func acceptExact(unpeeled: Bool, canonical: String) -> String {
+        appendReplacement(forCanonical: canonical)
+        #if DEBUG
+          Self.logger.debug(
+            "WordCorrector: type=alias source='\(unpeeled ? core : matchCore)' target='\(canonical)'"
+          )
+        #endif
+        return unpeeled ? prefix + canonical + suffix : reattached(canonical)
       }
-      if let match = unpeeledMatch {
-        return acceptExact(unpeeled: true, match)
+
+      // `.alreadyCorrect` carries its own isPack, exactly like `.replace`,
+      // so it participates in the SAME four-slot priority order rather than
+      // short-circuiting unconditionally the instant either attempt hits
+      // it. A PACK's own self-alias (canonical "GitHub.com", alias
+      // "GitHub.com") being byte-for-byte correct on the unpeeled attempt
+      // does not get to outrank a higher-authority NON-PACK alias reachable
+      // only by peeling ("github" -> "Other") -- "non-pack always wins over
+      // pack" is exactly as absolute for "leave it alone" as it is for
+      // "replace it" (Codex cloud review, PR #2298, round 13). Only a
+      // NON-PACK `.alreadyCorrect` is the unconditional "stop here" signal:
+      // a deliberate user registration confirming the token is already
+      // correct outranks everything else in this retry by construction.
+      //
+      // Slot 1: unpeeled, non-pack.
+      if case .alreadyCorrect(false) = unpeeledExact { return token }
+      if case .replace(let canonical, false) = unpeeledExact {
+        return acceptExact(unpeeled: true, canonical: canonical)
       }
-      if let match = peeledMatch {
-        return acceptExact(unpeeled: false, match)
+      // Slot 2: peeled, non-pack.
+      if case .alreadyCorrect(false) = peeledExact { return token }
+      if case .replace(let canonical, false) = peeledExact {
+        return acceptExact(unpeeled: false, canonical: canonical)
+      }
+      // Slot 3: unpeeled, pack.
+      if case .alreadyCorrect = unpeeledExact { return token }
+      if case .replace(let canonical, _) = unpeeledExact {
+        return acceptExact(unpeeled: true, canonical: canonical)
+      }
+      // Slot 4: peeled, pack.
+      if case .alreadyCorrect = peeledExact { return token }
+      if case .replace(let canonical, _) = peeledExact {
+        return acceptExact(unpeeled: false, canonical: canonical)
       }
 
       // Step 3 + 4: non-pack FUZZY to completion -- unpeeled (restricted to
@@ -1098,7 +1080,12 @@ public struct WordCorrector: Sendable {
   /// the whole single-word retry, not merely this one attempt.
   private enum ExactSingleWordOutcome {
     case replace(canonical: String, isPack: Bool)
-    case alreadyCorrect
+    // Carries isPack too (Codex cloud review, PR #2298, round 13): a pack's
+    // own self-alias being byte-for-byte correct must not outrank a
+    // higher-authority non-pack alias reachable at a lower-priority slot --
+    // "leave it alone" needs the same authority tag "replace it" already
+    // has, or the caller has no way to arbitrate the two.
+    case alreadyCorrect(isPack: Bool)
     case noMatch
   }
 
@@ -1106,7 +1093,6 @@ public struct WordCorrector: Sendable {
     core: String, coreLower: String, lookups: Lookups
   ) -> ExactSingleWordOutcome {
     guard let canonical = lookups.singleAliasMap[coreLower] else { return .noMatch }
-    guard core != canonical else { return .alreadyCorrect }
     // Authority comes from the matched KEY (`coreLower`), never from the
     // resulting canonical TEXT (Codex review, PR for #2281, finding P2
     // round 8): `canonicalToWord[canonical]` answers "who owns this
@@ -1117,7 +1103,10 @@ public struct WordCorrector: Sendable {
     // non-pack always wins on a KEY collision, so `nonPackExactKeys`
     // (already the authority for exactly that construction) tells us
     // whether THIS key's mapping came from a non-pack term, unambiguously.
+    // Computed before the already-correct check too (round 13): "already
+    // correct" needs the same authority tag "replace" gets.
     let isPack = !lookups.nonPackExactKeys.contains(coreLower)
+    guard core != canonical else { return .alreadyCorrect(isPack: isPack) }
     return .replace(canonical: canonical, isPack: isPack)
   }
 

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -1010,19 +1010,69 @@ public struct WordCorrector: Sendable {
       // only at step 4 -- "enviouswhisper" scoring against
       // "enviouswhisper.com" purely because the strings share a long
       // prefix, with no dot in the input at all.
-      if hasPeelableSuffix,
-        let canonical = nonPackFuzzySingleWordMatch(
-          core: core, coreLower: coreLower, lookups: lookups,
-          appendReplacement: { appendReplacement(forCanonical: $0) }, domainShapedOnly: true)
-      {
-        return prefix + canonical + suffix
+      // Clearing threshold on the unpeeled (domain-restricted) attempt does
+      // not mean it is the STRONGER match: the peeled attempt can score
+      // higher against the user's actual saved alias while the unpeeled
+      // attempt merely clears the bar against an unrelated domain-shaped
+      // distractor. Compute both before accepting either, and take the
+      // higher score -- a raw candidate scoring 0.91 must not preempt a
+      // peeled candidate scoring 0.97 (Codex cloud review, PR #2298, round
+      // 14). Ties favor unpeeled, consistent with the exact-match tier's
+      // own unpeeled-before-peeled precedence.
+      func acceptFuzzy(unpeeled: Bool, canonical: String) -> String {
+        appendReplacement(forCanonical: canonical)
+        return unpeeled ? prefix + canonical + suffix : reattached(canonical)
       }
-      if matchCoreEligible,
-        let canonical = nonPackFuzzySingleWordMatch(
-          core: matchCore, coreLower: matchCoreLower, lookups: lookups,
-          appendReplacement: { appendReplacement(forCanonical: $0) }, domainShapedOnly: false)
-      {
-        return reattached(canonical)
+      func strongerOf(
+        _ unpeeled: (canonical: String, score: Double)?,
+        _ peeled: (canonical: String, score: Double)?
+      ) -> String? {
+        switch (unpeeled, peeled) {
+        case let (.some(u), .some(p)):
+          return u.score >= p.score
+            ? acceptFuzzy(unpeeled: true, canonical: u.canonical)
+            : acceptFuzzy(unpeeled: false, canonical: p.canonical)
+        case let (.some(u), nil):
+          return acceptFuzzy(unpeeled: true, canonical: u.canonical)
+        case let (nil, .some(p)):
+          return acceptFuzzy(unpeeled: false, canonical: p.canonical)
+        case (nil, nil):
+          return nil
+        }
+      }
+
+      // Step 3 + 4: non-pack FUZZY to completion -- unpeeled (restricted to
+      // domain-shaped candidates), then peeled (unrestricted) -- before the
+      // pack tier gets a turn at all, so "non-pack always wins over pack"
+      // holds across the peel boundary too, not only within one attempt
+      // (Codex review, PR for #2281; same shape as finding P1 round 4, one
+      // tier down). Step 3's domain restriction is necessary because fuzzy
+      // scoring CAN cross threshold against a glued suffix, but only when
+      // the CANDIDATE compared against is itself bare -- a candidate that
+      // is ALSO domain-shaped makes the raw comparison apples-to-apples, so
+      // a near-miss like "githib.com" needs to try this unpeeled (finding
+      // P1 round 3).
+      //
+      // Step 3 only runs when the token ITSELF has a peelable suffix (Codex
+      // review round 5, P1): without that guard it ran even for an ordinary
+      // no-dot word, comparing it against domain-shaped candidates it has
+      // no business being compared against and letting a weaker
+      // domain-shaped match preempt the correct bare candidate reachable
+      // only at step 4 -- "enviouswhisper" scoring against
+      // "enviouswhisper.com" purely because the strings share a long
+      // prefix, with no dot in the input at all.
+      let unpeeledNonPackFuzzy =
+        hasPeelableSuffix
+        ? nonPackFuzzySingleWordMatch(
+          core: core, coreLower: coreLower, lookups: lookups, domainShapedOnly: true)
+        : nil
+      let peeledNonPackFuzzy =
+        matchCoreEligible
+        ? nonPackFuzzySingleWordMatch(
+          core: matchCore, coreLower: matchCoreLower, lookups: lookups, domainShapedOnly: false)
+        : nil
+      if let result = strongerOf(unpeeledNonPackFuzzy, peeledNonPackFuzzy) {
+        return result
       }
 
       // Step 5 + 6: pack fuzzy, the same unpeeled-then-peeled shape (step 5
@@ -1030,19 +1080,18 @@ public struct WordCorrector: Sendable {
       // reached once every higher-authority attempt above has missed. Step
       // 4's peeled non-pack fuzzy fixes the originally reported bug for a
       // bare (non-domain-shaped) alias.
-      if hasPeelableSuffix,
-        let canonical = packFuzzySingleWordMatch(
-          core: core, coreLower: coreLower, lookups: lookups,
-          appendReplacement: { appendReplacement(forCanonical: $0) }, domainShapedOnly: true)
-      {
-        return prefix + canonical + suffix
-      }
-      if matchCoreEligible,
-        let canonical = packFuzzySingleWordMatch(
-          core: matchCore, coreLower: matchCoreLower, lookups: lookups,
-          appendReplacement: { appendReplacement(forCanonical: $0) }, domainShapedOnly: false)
-      {
-        return reattached(canonical)
+      let unpeeledPackFuzzy =
+        hasPeelableSuffix
+        ? packFuzzySingleWordMatch(
+          core: core, coreLower: coreLower, lookups: lookups, domainShapedOnly: true)
+        : nil
+      let peeledPackFuzzy =
+        matchCoreEligible
+        ? packFuzzySingleWordMatch(
+          core: matchCore, coreLower: matchCoreLower, lookups: lookups, domainShapedOnly: false)
+        : nil
+      if let result = strongerOf(unpeeledPackFuzzy, peeledPackFuzzy) {
+        return result
       }
 
       return token
@@ -1129,9 +1178,9 @@ public struct WordCorrector: Sendable {
   /// ordinary, unrestricted pool).
   private func nonPackFuzzySingleWordMatch(
     core: String, coreLower: String,
-    lookups: Lookups, appendReplacement: (String) -> Void,
+    lookups: Lookups,
     domainShapedOnly: Bool
-  ) -> String? {
+  ) -> (canonical: String, score: Double)? {
     let singleFuzzyCandidates = lookups.singleFuzzyCandidates
     let canonicalToWord = lookups.canonicalToWord
     let lowercasedCanonicals = lookups.lowercasedCanonicals
@@ -1192,13 +1241,12 @@ public struct WordCorrector: Sendable {
       bestScore - secondBest >= Self.ambiguityMargin,
       core != bestMatch
     {
-      appendReplacement(bestMatch)
       #if DEBUG
         Self.logger.debug(
           "WordCorrector: type=alias-fuzzy source='\(core)' target='\(bestMatch)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(bestScore - secondBest, format: .fixed(precision: 3)) threshold=\(pass4Threshold, format: .fixed(precision: 3))"
         )
       #endif
-      return bestMatch
+      return (bestMatch, bestScore)
     } else if bestScore > 0 {
       #if DEBUG
         let pass4Margin = bestScore - secondBest
@@ -1247,13 +1295,12 @@ public struct WordCorrector: Sendable {
       bestScore - secondBest >= Self.ambiguityMargin,
       core != bestMatch
     {
-      appendReplacement(bestMatch)
       #if DEBUG
         Self.logger.debug(
           "WordCorrector: type=canonical-fuzzy source='\(core)' target='\(bestMatch)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(bestScore - secondBest, format: .fixed(precision: 3)) threshold=\(pass5Threshold, format: .fixed(precision: 3))"
         )
       #endif
-      return bestMatch
+      return (bestMatch, bestScore)
     } else if bestScore > 0 {
       #if DEBUG
         let pass5Margin = bestScore - secondBest
@@ -1285,9 +1332,9 @@ public struct WordCorrector: Sendable {
   /// lowercase pack canonicals).
   private func packFuzzySingleWordMatch(
     core: String, coreLower: String,
-    lookups: Lookups, appendReplacement: (String) -> Void,
+    lookups: Lookups,
     domainShapedOnly: Bool
-  ) -> String? {
+  ) -> (canonical: String, score: Double)? {
     let packSingleFuzzyCandidates = lookups.packSingleFuzzyCandidates
     let packCanonicals = lookups.packCanonicals
     let packLowercasedCanonicals = lookups.packLowercasedCanonicals
@@ -1345,13 +1392,12 @@ public struct WordCorrector: Sendable {
             )
           #endif
         } else {
-          appendReplacement(pMatch)
           #if DEBUG
             Self.logger.debug(
               "WordCorrector: type=pack-alias-fuzzy source='\(core)' target='\(pMatch)' score=\(pBest, format: .fixed(precision: 3)) margin=\(pBest - pSecond, format: .fixed(precision: 3)) threshold=\(packThreshold, format: .fixed(precision: 3))"
             )
           #endif
-          return pMatch
+          return (pMatch, pBest)
         }
       }
     }
@@ -1387,13 +1433,12 @@ public struct WordCorrector: Sendable {
             )
           #endif
         } else {
-          appendReplacement(pMatch)
           #if DEBUG
             Self.logger.debug(
               "WordCorrector: type=pack-canonical-fuzzy source='\(core)' target='\(pMatch)' score=\(pBest, format: .fixed(precision: 3)) margin=\(pBest - pSecond, format: .fixed(precision: 3)) threshold=\(packThreshold, format: .fixed(precision: 3))"
             )
           #endif
-          return pMatch
+          return (pMatch, pBest)
         }
       }
     }

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -1648,6 +1648,37 @@ public struct WordCorrector: Sendable {
   /// IP-like token rather than a domain. A purely structural check
   /// otherwise generalizes to every user's vocabulary rather than the ten
   /// TLDs this app happens to vet for URL recognition elsewhere.
+  ///
+  /// KNOWN LIMIT, third face of the same tradeoff `knownDedupTLDs`'s own
+  /// doc comment names (founder call, Codex cloud review round 17): an
+  /// ALL-LETTERS suffix that is NOT a version number still passes this
+  /// trigger even when it is an ordinary file extension or dotted
+  /// identifier rather than a domain -- ".swift", ".py", ".js" are all
+  /// structurally indistinguishable from a real TLD by this check alone.
+  /// If a saved word's bare text coincidentally equals a dictated
+  /// filename's stem, the peeled match can fire and silently reattach the
+  /// extension to the wrong replacement ("config.swift" -- a saved
+  /// "config" -> "Configuration" alias -- becomes "Configuration.swift").
+  /// TRIED AND REJECTED: gating this trigger on `knownDedupTLDs`
+  /// (mirroring `isDomainShaped`'s bar) closes that gap but empirically
+  /// breaks real, already-shipped behavior this exact suite tests for --
+  /// ".zzz" (round 3's own test, proving the trigger deliberately works
+  /// OUTSIDE any curated list), ".technology" (round 12, a real TLD this
+  /// list simply does not carry), and native-script IDN dedup
+  /// suppression (".рф", non-ASCII and therefore uncurated by
+  /// construction) all regressed when tried. The permissiveness this
+  /// function documents above as necessary for THOSE cases is the same
+  /// permissiveness that makes this one possible -- there is no purely
+  /// structural or curated-list rule that admits one and excludes the
+  /// other, because both are "an all-letters string after a dot" and
+  /// nothing about the TEXT distinguishes a domain suffix from a file
+  /// extension -- the same irreducible ambiguity `knownDedupTLDs` already
+  /// accepts for dedup-suppression and fuzzy admission, surfacing at a
+  /// THIRD site through a different signal (structural shape here, a
+  /// curated word list there). Closing it needs the same two
+  /// real, feature-sized mechanisms named there: a maintained
+  /// public-suffix authority, or letting a word's OWNER mark it as a
+  /// domain explicitly.
   private static func splitDomainSuffix(_ s: String) -> (bare: String, suffix: String)? {
     guard let firstDot = s.firstIndex(of: "."), firstDot > s.startIndex else { return nil }
     let tail = s[s.index(after: firstDot)...]

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -918,23 +918,32 @@ public struct WordCorrector: Sendable {
       // so this is not an optional refinement -- it is what makes the fix
       // correct for every fuzzy-matched brand, not only exact ones.
       var matchCore = core
-      var matchSuffix = suffix
+      var peeledTLD = ""
       if let lastDot = core.lastIndex(of: "."), lastDot > core.startIndex {
         let tail = core[core.index(after: lastDot)...].lowercased()
         if Self.recognizedTLDs.contains(tail) {
           matchCore = String(core[core.startIndex..<lastDot])
-          matchSuffix = String(core[lastDot...]) + suffix
+          peeledTLD = String(core[lastDot...])
         }
       }
       let matchCoreLower = matchCore.lowercased()
       guard !Self.emojiTriggerReservedWords.contains(matchCoreLower), matchCore.count >= 2 else {
         return token
       }
-      if let matched = matchSingleWordPasses(
-        prefix: prefix, core: matchCore, coreLower: matchCoreLower, suffix: matchSuffix,
+      if let canonical = matchSingleWordPasses(
+        core: matchCore, coreLower: matchCoreLower,
         lookups: lookups, appendReplacement: { appendReplacement(forCanonical: $0) })
       {
-        return matched
+        // Codex review, PR for #2281, finding P2 (round 2): a saved
+        // CANONICAL can itself be a domain ("GitHub.com") even when its
+        // alias is the bare word ("githab") -- blindly re-appending the
+        // peeled TLD to that canonical would produce "GitHub.com.com".
+        // Reattach it only when the matched canonical does not already end
+        // with it.
+        let reattach =
+          peeledTLD.isEmpty || canonical.lowercased().hasSuffix(peeledTLD.lowercased())
+          ? "" : peeledTLD
+        return prefix + canonical + reattach + suffix
       }
 
       return token
@@ -947,10 +956,11 @@ public struct WordCorrector: Sendable {
   /// single-word matcher can be run TWICE per token: once against the token as
   /// ASR emitted it, and -- only if that produced no match -- once more
   /// against a TLD-peeled core (see the call site in `correct(using:)`).
-  /// `nil` means "no pass matched"; every accept path returns the final
-  /// `prefix + canonical + suffix` string, exactly as the inline closure did.
+  /// Returns the bare matched CANONICAL, never prefix/suffix-assembled --
+  /// the caller reattaches those, since only the caller knows whether a
+  /// peeled TLD needs deduplicating against the canonical it matched.
   private func matchSingleWordPasses(
-    prefix: String, core: String, coreLower: String, suffix: String,
+    core: String, coreLower: String,
     lookups: Lookups, appendReplacement: (String) -> Void
   ) -> String? {
     let singleAliasMap = lookups.singleAliasMap
@@ -969,7 +979,7 @@ public struct WordCorrector: Sendable {
       #if DEBUG
         Self.logger.debug("WordCorrector: type=alias source='\(core)' target='\(canonical)'")
       #endif
-      return prefix + canonical + suffix
+      return canonical
     }
 
     // Skip fuzzy for very short tokens
@@ -1022,7 +1032,7 @@ public struct WordCorrector: Sendable {
           "WordCorrector: type=alias-fuzzy source='\(core)' target='\(bestMatch)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(bestScore - secondBest, format: .fixed(precision: 3)) threshold=\(pass4Threshold, format: .fixed(precision: 3))"
         )
       #endif
-      return prefix + bestMatch + suffix
+      return bestMatch
     } else if bestScore > 0 {
       #if DEBUG
         let pass4Margin = bestScore - secondBest
@@ -1076,7 +1086,7 @@ public struct WordCorrector: Sendable {
           "WordCorrector: type=canonical-fuzzy source='\(core)' target='\(bestMatch)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(bestScore - secondBest, format: .fixed(precision: 3)) threshold=\(pass5Threshold, format: .fixed(precision: 3))"
         )
       #endif
-      return prefix + bestMatch + suffix
+      return bestMatch
     } else if bestScore > 0 {
       #if DEBUG
         let pass5Margin = bestScore - secondBest
@@ -1148,7 +1158,7 @@ public struct WordCorrector: Sendable {
               "WordCorrector: type=pack-alias-fuzzy source='\(core)' target='\(pMatch)' score=\(pBest, format: .fixed(precision: 3)) margin=\(pBest - pSecond, format: .fixed(precision: 3)) threshold=\(packThreshold, format: .fixed(precision: 3))"
             )
           #endif
-          return prefix + pMatch + suffix
+          return pMatch
         }
       }
     }
@@ -1189,7 +1199,7 @@ public struct WordCorrector: Sendable {
               "WordCorrector: type=pack-canonical-fuzzy source='\(core)' target='\(pMatch)' score=\(pBest, format: .fixed(precision: 3)) margin=\(pBest - pSecond, format: .fixed(precision: 3)) threshold=\(packThreshold, format: .fixed(precision: 3))"
             )
           #endif
-          return prefix + pMatch + suffix
+          return pMatch
         }
       }
     }

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -1214,6 +1214,14 @@ public struct WordCorrector: Sendable {
 
   // MARK: - Helpers
 
+  /// The exact TLD set `InverseTextNormalizer.urls(_:)` treats as URL evidence
+  /// (`lowerRiskURLTLDAlt` + `commonWordURLTLDAlt`), reused rather than
+  /// redefined so both parts of the pipeline agree on what "looks like a
+  /// domain" means — a closed, already-vetted set, never a fresh guess
+  /// (`matcher-set-adversarial-tests`).
+  private static let recognizedTLDs: Set<String> = Set(
+    InverseTextNormalizer.urlTLDAlt.components(separatedBy: "|"))
+
   private func stripPunctuation(_ token: String) -> String {
     splitPunctuation(token).core
   }
@@ -1229,6 +1237,24 @@ public struct WordCorrector: Sendable {
     while let last = core.last, !last.isLetter && !last.isNumber {
       suffix = String(last) + suffix
       core = String(core.dropLast())
+    }
+    // A glued domain suffix ("EnviousWispr.com") is CONTENT, not punctuation
+    // to discard. `InverseTextNormalizer.urls(_:)` already made "word.tld" a
+    // routine, CORRECT shape for a dictated domain (#2257/#2258), so every
+    // matching pass below must not treat the whole glued token as fair game
+    // and silently swallow the TLD along with a fuzzy/exact word match.
+    // Measured live (Saurabh's own dictation, 2026-08-21): "Enviousvisper.com"
+    // corrected to "EnviousWispr" with the ".com" gone entirely, because the
+    // trailing "m" is a letter, so the edge-stripping loops above never even
+    // looked at the "." three characters earlier. Peeling a RECOGNIZED TLD off
+    // into `suffix` here, before any caller ever sees `core`, fixes it at the
+    // one shared root every pass already reads through.
+    if let lastDot = core.lastIndex(of: "."), lastDot > core.startIndex {
+      let tail = core[core.index(after: lastDot)...].lowercased()
+      if Self.recognizedTLDs.contains(tail) {
+        suffix = String(core[lastDot...]) + suffix
+        core = String(core[core.startIndex..<lastDot])
+      }
     }
     return (prefix, core, suffix)
   }

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -918,36 +918,54 @@ public struct WordCorrector: Sendable {
       let matchCoreEligible =
         !Self.emojiTriggerReservedWords.contains(matchCoreLower) && matchCore.count >= 2
 
-      // Step 1 + 2: EXACT match to completion -- unpeeled, then peeled --
-      // before any fuzzy pass runs at all. Exact equality always outranks
-      // fuzzy scoring and always respects the user/pack tiering baked into
-      // `singleAliasMap`, and that must hold even for a domain-shaped
-      // token: a fuzzy match found via the unpeeled domain-restricted pass
-      // (step 3) could otherwise preempt the user's OWN exact alias,
-      // reachable only by peeling first (Codex review, PR for #2281,
-      // finding P1 round 4).
-      if let canonical = exactSingleWordMatch(
-        core: core, coreLower: coreLower, lookups: lookups,
-        appendReplacement: { appendReplacement(forCanonical: $0) })
-      {
-        return prefix + canonical + suffix
-      }
-      if matchCoreEligible,
-        let canonical = exactSingleWordMatch(
-          core: matchCore, coreLower: matchCoreLower, lookups: lookups,
-          appendReplacement: { appendReplacement(forCanonical: $0) })
-      {
-        let reattach = peeledSuffix.isEmpty || Self.isDomainShaped(canonical) ? "" : peeledSuffix
-        return prefix + canonical + reattach + suffix
-      }
-
-      // A peeled suffix, once a fuzzy match is found, is reattached UNLESS
-      // the matched canonical is itself domain-shaped -- it already fully
+      // A peeled suffix, once a match is found, is reattached UNLESS the
+      // matched canonical is itself domain-shaped -- it already fully
       // specifies its own domain, whatever suffix the user actually said
       // (Codex review, PR for #2281, finding P2, rounds 2-4).
       func reattached(_ canonical: String) -> String {
         let reattach = peeledSuffix.isEmpty || Self.isDomainShaped(canonical) ? "" : peeledSuffix
         return prefix + canonical + reattach + suffix
+      }
+
+      // Step 1 + 2: EXACT match to completion -- unpeeled, then peeled --
+      // before any fuzzy pass runs at all, AND non-pack outranks pack
+      // across that same boundary. Exact equality always outranks fuzzy
+      // scoring (finding P1 round 4). Within exact itself, "non-pack always
+      // wins over pack" must ALSO hold across the peel boundary: an
+      // unpeeled key can resolve to a pack alias while the peeled key
+      // resolves to the user's own alias (pack "githib.com", user
+      // "githib") -- accepting the unpeeled pack match immediately would
+      // preempt the higher-authority user match one step away (Codex
+      // review, PR for #2281, finding P1 round 7). So both attempts are
+      // computed first, with non-pack results checked before either pack
+      // result is accepted.
+      let unpeeledExact = exactSingleWordMatch(core: core, coreLower: coreLower, lookups: lookups)
+      let peeledExact =
+        matchCoreEligible
+        ? exactSingleWordMatch(core: matchCore, coreLower: matchCoreLower, lookups: lookups)
+        : nil
+
+      func acceptExact(unpeeled: Bool, _ match: (canonical: String, isPack: Bool)) -> String {
+        appendReplacement(forCanonical: match.canonical)
+        #if DEBUG
+          Self.logger.debug(
+            "WordCorrector: type=alias source='\(unpeeled ? core : matchCore)' target='\(match.canonical)'"
+          )
+        #endif
+        return unpeeled ? prefix + match.canonical + suffix : reattached(match.canonical)
+      }
+
+      if let match = unpeeledExact, !match.isPack {
+        return acceptExact(unpeeled: true, match)
+      }
+      if let match = peeledExact, !match.isPack {
+        return acceptExact(unpeeled: false, match)
+      }
+      if let match = unpeeledExact {
+        return acceptExact(unpeeled: true, match)
+      }
+      if let match = peeledExact {
+        return acceptExact(unpeeled: false, match)
       }
 
       // Step 3 + 4: non-pack FUZZY to completion -- unpeeled (restricted to
@@ -1020,16 +1038,19 @@ public struct WordCorrector: Sendable {
   /// found via the unpeeled domain-restricted pass could otherwise preempt
   /// the user's own exact alias, reachable only by peeling first (Codex
   /// review, PR for #2281, finding P1 round 4).
+  /// Returns the matched canonical AND whether it came from a pack term,
+  /// but does NOT call `appendReplacement` or log -- the caller decides
+  /// which of potentially several candidate exact matches (unpeeled vs
+  /// peeled) actually wins before committing that side effect (Codex
+  /// review, PR for #2281, finding P1 round 7: see the call site in
+  /// `correct(using:)` for why the caller needs to see both before
+  /// choosing).
   private func exactSingleWordMatch(
-    core: String, coreLower: String,
-    lookups: Lookups, appendReplacement: (String) -> Void
-  ) -> String? {
+    core: String, coreLower: String, lookups: Lookups
+  ) -> (canonical: String, isPack: Bool)? {
     guard let canonical = lookups.singleAliasMap[coreLower], core != canonical else { return nil }
-    appendReplacement(canonical)
-    #if DEBUG
-      Self.logger.debug("WordCorrector: type=alias source='\(core)' target='\(canonical)'")
-    #endif
-    return canonical
+    let isPack = lookups.canonicalToWord[canonical.lowercased()]?.source == .pack
+    return (canonical, isPack)
   }
 
   /// Pass 4-5 alone (non-pack fuzzy: aliases + canonical self-entries, then

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -895,54 +895,74 @@ public struct WordCorrector: Sendable {
         return token
       }
 
-      // Step 1: exact match (always) + fuzzy match RESTRICTED to
-      // domain-shaped candidates (`isDomainShaped`), both tried against the
-      // token exactly as ASR emitted it, before any peeling. Exact equality
-      // can never coincidentally consume a glued TLD, so it is always safe
-      // unpeeled (Codex review, PR for #2281, finding P1 round 1). Fuzzy
-      // scoring CAN cross threshold against a glued suffix -- but only when
-      // the CANDIDATE it's compared against is itself bare. A candidate that
-      // is ALSO domain-shaped ("githab.com" alias for canonical
-      // "GitHub.com") makes the comparison apples-to-apples (both sides
-      // carry a TLD), so a near-miss like "githib.com" still needs to try
-      // this unpeeled -- peeling first would strip the TLD from only one
-      // side and lose the match entirely (Codex review, PR for #2281,
-      // finding P1 round 3).
-      if let canonical = matchSingleWordPasses(
+      // Compute the peeled form up front (used by steps 2 and 4 below).
+      // The trigger is purely structural -- a dot followed by a non-empty
+      // run of letters/digits/hyphens -- deliberately not limited to any
+      // curated TLD list: fuzzy scoring can silently swallow ANY glued
+      // suffix that survives edge-punctuation stripping, not only a
+      // hand-picked set (Codex review, PR for #2281, finding P1 round 3).
+      // If nothing ever matches the peeled core, the untouched original
+      // token is returned below, so a permissive trigger costs nothing
+      // when the suffix isn't actually a domain.
+      var matchCore = core
+      var peeledSuffix = ""
+      if let split = Self.splitDomainSuffix(core) {
+        matchCore = split.bare
+        peeledSuffix = split.suffix
+      }
+      let matchCoreLower = matchCore.lowercased()
+      let matchCoreEligible =
+        !Self.emojiTriggerReservedWords.contains(matchCoreLower) && matchCore.count >= 2
+
+      // Step 1 + 2: EXACT match to completion -- unpeeled, then peeled --
+      // before any fuzzy pass runs at all. Exact equality always outranks
+      // fuzzy scoring and always respects the user/pack tiering baked into
+      // `singleAliasMap`, and that must hold even for a domain-shaped
+      // token: a fuzzy match found via the unpeeled domain-restricted pass
+      // (step 3) could otherwise preempt the user's OWN exact alias,
+      // reachable only by peeling first (Codex review, PR for #2281,
+      // finding P1 round 4).
+      if let canonical = exactSingleWordMatch(
         core: core, coreLower: coreLower, lookups: lookups,
-        appendReplacement: { appendReplacement(forCanonical: $0) }, fuzzyDomainShapedOnly: true)
+        appendReplacement: { appendReplacement(forCanonical: $0) })
+      {
+        return prefix + canonical + suffix
+      }
+      if matchCoreEligible,
+        let canonical = exactSingleWordMatch(
+          core: matchCore, coreLower: matchCoreLower, lookups: lookups,
+          appendReplacement: { appendReplacement(forCanonical: $0) })
+      {
+        let reattach = peeledSuffix.isEmpty || Self.isDomainShaped(canonical) ? "" : peeledSuffix
+        return prefix + canonical + reattach + suffix
+      }
+
+      // Step 3: fuzzy match RESTRICTED to domain-shaped candidates
+      // (`isDomainShaped`), tried against the token exactly as ASR emitted
+      // it, before peeling. Fuzzy scoring CAN cross threshold against a
+      // glued suffix -- but only when the CANDIDATE it's compared against
+      // is itself bare. A candidate that is ALSO domain-shaped ("githab.com"
+      // alias for canonical "GitHub.com") makes the comparison
+      // apples-to-apples (both sides carry a suffix), so a near-miss like
+      // "githib.com" still needs to try this unpeeled -- peeling first
+      // would strip the suffix from only one side and lose the match
+      // entirely (Codex review, PR for #2281, finding P1 round 3).
+      if let canonical = fuzzySingleWordPasses(
+        core: core, coreLower: coreLower, lookups: lookups,
+        appendReplacement: { appendReplacement(forCanonical: $0) }, domainShapedOnly: true)
       {
         return prefix + canonical + suffix
       }
 
-      // Step 2: peel a plausible glued suffix and retry every pass
-      // (exact + fuzzy + pack) against the bare core. The peel trigger is
-      // deliberately NOT limited to `recognizedTLDs` -- fuzzy scoring can
-      // silently swallow any glued suffix that survives edge-punctuation
-      // stripping, not only the ten TLDs that set recognizes as URL
-      // evidence, so narrowing this trigger to that set left ".us"/".uk"/
-      // ".tech" etc. unprotected (Codex review, PR for #2281, finding P1
-      // round 3). If nothing matches the peeled core either, the untouched
-      // original token is returned below, so a permissive trigger costs
-      // nothing when the suffix isn't actually a domain.
-      var matchCore = core
-      var peeledSuffix = ""
-      if let lastDot = core.lastIndex(of: "."), lastDot > core.startIndex {
-        let tail = core[core.index(after: lastDot)...]
-        if !tail.isEmpty, tail.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "-" }) {
-          matchCore = String(core[core.startIndex..<lastDot])
-          peeledSuffix = String(core[lastDot...])
-        }
-      }
-      let matchCoreLower = matchCore.lowercased()
-      guard !Self.emojiTriggerReservedWords.contains(matchCoreLower), matchCore.count >= 2 else {
-        return token
-      }
-      if let canonical = matchSingleWordPasses(
-        core: matchCore, coreLower: matchCoreLower, lookups: lookups,
-        appendReplacement: { appendReplacement(forCanonical: $0) }, fuzzyDomainShapedOnly: false)
+      // Step 4: fuzzy (+ pack) against the peeled core, the ordinary
+      // unrestricted pool -- the fallback that fixes the originally
+      // reported bug for a bare (non-domain-shaped) alias.
+      if matchCoreEligible,
+        let canonical = fuzzySingleWordPasses(
+          core: matchCore, coreLower: matchCoreLower, lookups: lookups,
+          appendReplacement: { appendReplacement(forCanonical: $0) }, domainShapedOnly: false)
       {
-        // Codex review, PR for #2281, finding P2 (rounds 2 and 3): a saved
+        // Codex review, PR for #2281, finding P2 (rounds 2, 3, 4): a saved
         // CANONICAL can itself be a domain ("GitHub.com") even when its
         // alias is the bare word ("githab") -- reattaching the peeled
         // suffix to a canonical that is ALREADY domain-shaped would produce
@@ -960,27 +980,46 @@ public struct WordCorrector: Sendable {
     return (corrected.joined(separator: " "), replacements)
   }
 
-  /// Passes 3-5 (plus the pack tier), factored out of `correct(using:)` so the
+  /// Pass 3 alone: exact single-word alias (includes canonical self-entries).
+  /// Factored out so the outer single-word retry in `correct(using:)` can run
+  /// EXACT matching to completion -- unpeeled, then peeled -- before trying
+  /// any fuzzy pass. Exact equality always outranks fuzzy scoring and always
+  /// respects the user/pack tiering baked into `singleAliasMap`, and that
+  /// must hold even when a domain-shaped token is involved: a fuzzy match
+  /// found via the unpeeled domain-restricted pass could otherwise preempt
+  /// the user's own exact alias, reachable only by peeling first (Codex
+  /// review, PR for #2281, finding P1 round 4).
+  private func exactSingleWordMatch(
+    core: String, coreLower: String,
+    lookups: Lookups, appendReplacement: (String) -> Void
+  ) -> String? {
+    guard let canonical = lookups.singleAliasMap[coreLower], core != canonical else { return nil }
+    appendReplacement(canonical)
+    #if DEBUG
+      Self.logger.debug("WordCorrector: type=alias source='\(core)' target='\(canonical)'")
+    #endif
+    return canonical
+  }
+
+  /// Passes 4-5 (plus the pack tier), factored out of `correct(using:)` so the
   /// single-word matcher can be run TWICE per token: once against the token as
-  /// ASR emitted it, and -- only if that produced no match -- once more
-  /// against a peeled core (see the two call sites in `correct(using:)`).
-  /// Returns the bare matched CANONICAL, never prefix/suffix-assembled --
-  /// the caller reattaches those, since only the caller knows whether a
-  /// peeled suffix needs deduplicating against the canonical it matched.
+  /// ASR emitted it, and -- only if exact matching (both unpeeled and peeled)
+  /// produced no match -- once more against a peeled core (see the call
+  /// sites in `correct(using:)`). Returns the bare matched CANONICAL, never
+  /// prefix/suffix-assembled -- the caller reattaches those, since only the
+  /// caller knows whether a peeled suffix needs deduplicating against the
+  /// canonical it matched.
   ///
-  /// `fuzzyDomainShapedOnly` gates ONLY the fuzzy passes (4/5 + pack): Pass 3
-  /// (exact) always considers every alias, domain-shaped or not, because
-  /// exact equality can never coincidentally consume a glued suffix the way
-  /// fuzzy scoring can. The unpeeled call site passes `true` (fuzzy is only
-  /// safe unpeeled when comparing against an equally domain-shaped
-  /// candidate); the peeled call site passes `false` (the ordinary,
-  /// unrestricted pool, exactly as before this parameter existed).
-  private func matchSingleWordPasses(
+  /// `domainShapedOnly` gates every fuzzy loop here: the unpeeled call site
+  /// passes `true` (fuzzy is only safe unpeeled when comparing against an
+  /// equally domain-shaped candidate -- both sides then carry a suffix, so
+  /// nothing is silently swallowed); the peeled call site passes `false`
+  /// (the ordinary, unrestricted pool).
+  private func fuzzySingleWordPasses(
     core: String, coreLower: String,
     lookups: Lookups, appendReplacement: (String) -> Void,
-    fuzzyDomainShapedOnly: Bool
+    domainShapedOnly: Bool
   ) -> String? {
-    let singleAliasMap = lookups.singleAliasMap
     let singleFuzzyCandidates = lookups.singleFuzzyCandidates
     let canonicalToWord = lookups.canonicalToWord
     let lowercasedCanonicals = lookups.lowercasedCanonicals
@@ -989,15 +1028,6 @@ public struct WordCorrector: Sendable {
     let packCanonicals = lookups.packCanonicals
     let packLowercasedCanonicals = lookups.packLowercasedCanonicals
     let nonPackExactKeys = lookups.nonPackExactKeys
-
-    // Pass 3: exact single-word alias (includes canonical self-entries)
-    if let canonical = singleAliasMap[coreLower], core != canonical {
-      appendReplacement(canonical)
-      #if DEBUG
-        Self.logger.debug("WordCorrector: type=alias source='\(core)' target='\(canonical)'")
-      #endif
-      return canonical
-    }
 
     // Skip fuzzy for very short tokens
     guard core.count >= 3 else { return nil }
@@ -1017,7 +1047,7 @@ public struct WordCorrector: Sendable {
     for entry in singleFuzzyCandidates {
       let surface = entry.surface
       let canonical = entry.canonical
-      if fuzzyDomainShapedOnly, !Self.isDomainShaped(surface), !Self.isDomainShaped(canonical) {
+      if domainShapedOnly, !Self.isDomainShaped(surface), !Self.isDomainShaped(canonical) {
         continue
       }
       // Length-ratio pruning: skip if lengths differ too much for threshold
@@ -1076,7 +1106,7 @@ public struct WordCorrector: Sendable {
     bestMatch = ""
 
     for (idx, targetLower) in lowercasedCanonicals.enumerated() {
-      if fuzzyDomainShapedOnly, !Self.isDomainShaped(targetLower) { continue }
+      if domainShapedOnly, !Self.isDomainShaped(targetLower) { continue }
       let targetLen = targetLower.count
       let lenRatio = Double(min(coreLen, targetLen)) / Double(max(coreLen, targetLen))
       if lenRatio < 0.5 { continue }
@@ -1148,7 +1178,7 @@ public struct WordCorrector: Sendable {
       var pSecond = 0.0
       var pMatch = ""
       for entry in packSingleFuzzyCandidates {
-        if fuzzyDomainShapedOnly, !Self.isDomainShaped(entry.surface),
+        if domainShapedOnly, !Self.isDomainShaped(entry.surface),
           !Self.isDomainShaped(entry.canonical)
         {
           continue
@@ -1195,7 +1225,7 @@ public struct WordCorrector: Sendable {
       var pSecond = 0.0
       var pMatch = ""
       for (idx, targetLower) in packLowercasedCanonicals.enumerated() {
-        if fuzzyDomainShapedOnly, !Self.isDomainShaped(targetLower) { continue }
+        if domainShapedOnly, !Self.isDomainShaped(targetLower) { continue }
         let targetLen = targetLower.count
         let lenRatio = Double(min(coreLen, targetLen)) / Double(max(coreLen, targetLen))
         if lenRatio < 0.5 { continue }
@@ -1316,41 +1346,43 @@ public struct WordCorrector: Sendable {
 
   // MARK: - Helpers
 
-  /// The exact TLD set `InverseTextNormalizer.urls(_:)` treats as URL evidence
-  /// (`lowerRiskURLTLDAlt` + `commonWordURLTLDAlt`), reused rather than
-  /// redefined so both parts of the pipeline agree on what "looks like a
-  /// domain" means — a closed, already-vetted set, never a fresh guess
-  /// (`matcher-set-adversarial-tests`).
+  /// Splits `s` at its LAST dot into (bare, suffix) when everything after
+  /// that dot is a non-empty run of letters/digits/hyphens -- a purely
+  /// STRUCTURAL definition of "looks like it ends in a domain suffix",
+  /// deliberately not limited to any curated TLD list. One shared
+  /// definition, used for BOTH questions this fix has to ask: is an INPUT
+  /// token worth peeling, and is a saved ALIAS/CANONICAL domain-shaped.
   ///
-  /// Scope, narrowed by Codex review round 3: this set decides whether a
-  /// saved ALIAS/CANONICAL counts as domain-shaped (`isDomainShaped(_:)`
-  /// below) -- a controlled, curated surface where reusing the vetted TLD
-  /// list is correct. It does NOT decide whether a dotted suffix on the
-  /// INPUT is worth trying to peel: that trigger is deliberately broader
-  /// (see the single-word retry in `correct(using:)`), because fuzzy scoring
-  /// can silently swallow ANY glued suffix, not only the ten TLDs here --
-  /// `Enviousvisper.us` was still corrected to `EnviousWispr` (dropping
-  /// ".us") when the peel trigger was this same narrow list.
-  /// Read only by the single-word retry -- NOT by `splitPunctuation` itself,
-  /// so Pass 0/1/2 compound matching still treats a glued domain as one
-  /// opaque unit, exactly as before this fix (Codex review, PR for #2281,
-  /// finding P2: peeling inside the shared helper let an internal token's
-  /// ".com" get silently consumed by an accidental cross-token compound
-  /// match).
-  private static let recognizedTLDs: Set<String> = Set(
-    InverseTextNormalizer.urlTLDAlt.components(separatedBy: "|"))
+  /// Codex review, PR for #2281, rounds 3-4: an earlier version reused
+  /// `InverseTextNormalizer.urlTLDAlt` (the closed, ten-item TLD set
+  /// `matcher-set-adversarial-tests` argues for reusing elsewhere) for BOTH
+  /// questions, then for only ONE of them, and each split answer left a
+  /// suffix outside that list unprotected somewhere -- `Enviousvisper.us`
+  /// dropped its ".us" when the list gated the peel trigger; "GitHub.us"
+  /// grew a duplicate suffix when the list gated only the dedup check.
+  /// `urlTLDAlt` asserts semantic meaning ("this specific string IS a
+  /// TLD"), which is the right bar for a POSITIVE identification (deciding
+  /// spoken text represents a real URL). Here the bar is lower and
+  /// symmetric: "is this worth trying as a suffix", never asserted as fact
+  /// -- if peeling produces no match on either side, the untouched original
+  /// token is returned, so a wrong guess costs nothing. A purely structural
+  /// check generalizes to every user's vocabulary rather than the ten TLDs
+  /// this app happens to vet for URL recognition elsewhere.
+  private static func splitDomainSuffix(_ s: String) -> (bare: String, suffix: String)? {
+    guard let lastDot = s.lastIndex(of: "."), lastDot > s.startIndex else { return nil }
+    let tail = s[s.index(after: lastDot)...]
+    guard !tail.isEmpty, tail.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "-" }) else {
+      return nil
+    }
+    return (String(s[s.startIndex..<lastDot]), String(s[lastDot...]))
+  }
 
-  /// True when `s` itself ends in a recognized TLD -- used to decide whether
-  /// a saved alias/canonical is a domain in its own right, in which case a
-  /// peeled suffix must never be appended to it a second time (Codex review,
-  /// PR for #2281, finding P2 round 3: a bare alias "githab" mapped to
-  /// canonical "GitHub.com" turned input "githab.org" into "GitHub.com.org"
-  /// when the dedup check only compared against the SAME TLD that was
-  /// peeled, rather than asking whether the canonical is a domain at all).
+  /// True when `s` itself ends in a domain-shaped suffix -- used to decide
+  /// whether a saved alias/canonical is a domain in its own right, in which
+  /// case a peeled suffix must never be appended to it a second time (Codex
+  /// review, PR for #2281, finding P2 rounds 2-4).
   private static func isDomainShaped(_ s: String) -> Bool {
-    guard let lastDot = s.lastIndex(of: "."), lastDot > s.startIndex else { return false }
-    let tail = s[s.index(after: lastDot)...].lowercased()
-    return Self.recognizedTLDs.contains(tail)
+    Self.splitDomainSuffix(s) != nil
   }
 
   private func stripPunctuation(_ token: String) -> String {

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -1431,13 +1431,19 @@ public struct WordCorrector: Sendable {
   /// peeled bare form can coincidentally EXACT-match a real, unrelated
   /// alias, so an over-permissive trigger produces a real wrong correction,
   /// not merely a harmless miss -- alias "v1" turned input "v1.2" into
-  /// "VersionOne.2" before this guard existed. The one exclusion this
-  /// function makes is therefore load-bearing: a real TLD label is never
-  /// purely numeric (ICANN requires at least one non-digit character), so
-  /// an all-digit final label marks a version number, decimal, or IP-like
-  /// token rather than a domain. A purely structural check otherwise
-  /// generalizes to every user's vocabulary rather than the ten TLDs this
-  /// app happens to vet for URL recognition elsewhere.
+  /// "VersionOne.2" before a first guard existed, and a looser
+  /// "not all-digit" version of that guard still let "v1.2beta" and
+  /// "v1.2.3rc1" through (Codex review round 6, P2: a rejected label needs
+  /// to catch ALPHANUMERIC version/build tails, not only purely-numeric
+  /// ones). The exclusion this function makes is therefore the strictest
+  /// one that still matches real DNS policy rather than an arbitrary
+  /// tightening: a real TLD label is ALL LETTERS -- current ICANN policy
+  /// bars digits and hyphens from the TLD position entirely (unlike an
+  /// ordinary hostname label, which permits both) -- so a final label
+  /// carrying so much as one digit marks a version number, decimal, or
+  /// IP-like token rather than a domain. A purely structural check
+  /// otherwise generalizes to every user's vocabulary rather than the ten
+  /// TLDs this app happens to vet for URL recognition elsewhere.
   private static func splitDomainSuffix(_ s: String) -> (bare: String, suffix: String)? {
     guard let firstDot = s.firstIndex(of: "."), firstDot > s.startIndex else { return nil }
     let tail = s[s.index(after: firstDot)...]
@@ -1448,19 +1454,55 @@ public struct WordCorrector: Sendable {
     }
     let labels = tail.split(separator: ".", omittingEmptySubsequences: false)
     guard labels.allSatisfy({ !$0.isEmpty }), let lastLabel = labels.last,
-      !lastLabel.allSatisfy({ $0.isNumber })
+      lastLabel.allSatisfy({ $0.isLetter })
     else {
       return nil
     }
     return (String(s[s.startIndex..<firstDot]), String(s[firstDot...]))
   }
 
-  /// True when `s` itself ends in a domain-shaped suffix -- used to decide
-  /// whether a saved alias/canonical is a domain in its own right, in which
-  /// case a peeled suffix must never be appended to it a second time (Codex
-  /// review, PR for #2281, finding P2 rounds 2-4).
+  /// A curated (not exhaustive) set of real TLDs, deliberately much broader
+  /// than `InverseTextNormalizer.urlTLDAlt`'s original ten entries so common
+  /// ccTLDs (`.us`, `.uk`, `.jp`, ...) are covered, but still a REAL,
+  /// vetted list rather than "any letters after a dot". Read ONLY by
+  /// `isDomainShaped` -- never by `splitDomainSuffix`'s peel trigger, which
+  /// stays purely structural on purpose (see that function's doc comment).
+  ///
+  /// Why two different bars for what looks like the same question (Codex
+  /// review round 6, P1): "is this worth TRYING to peel" tolerates being
+  /// wrong for free -- nothing matches, the untouched token comes back.
+  /// "Should a peeled suffix be SUPPRESSED because the matched canonical is
+  /// already a domain" does not: a purely structural check here means any
+  /// dotted brand name with a plausible-looking suffix -- "Node.js",
+  /// "D3.js", "Vue.js", "Chart.js" are all real, common product names in
+  /// exactly this shape -- gets misclassified as a domain and silently
+  /// swallows a suffix the user actually said ("nodejs.com" -> "Node.js").
+  /// A real TLD list is the only mechanical way to tell "GitHub.com" (a
+  /// domain) from "Node.js" (a product name that happens to end in a
+  /// dot-suffix): both are ALL-LETTERS after the dot, so no structural rule
+  /// -- however tightened -- can separate them.
+  private static let knownDedupTLDs: Set<String> = [
+    "com", "org", "net", "edu", "gov", "mil", "int", "info", "biz", "name",
+    "pro", "coop", "museum", "aero", "jobs", "mobi", "travel", "tel", "asia", "cat", "xxx",
+    "io", "co", "dev", "app", "xyz", "me", "tv", "cc", "ai", "tech",
+    "online", "site", "store", "shop", "cloud", "live", "life", "world", "media", "news",
+    "agency", "studio", "design", "digital", "email", "expert", "guide", "help",
+    "network", "software", "systems", "tools", "works", "so",
+    "us", "uk", "ca", "au", "de", "fr", "jp", "cn", "in", "br",
+    "ru", "es", "it", "nl", "se", "no", "dk", "fi", "pl", "ch",
+    "at", "be", "pt", "gr", "ie", "nz", "sg", "hk", "tw", "kr",
+    "mx", "ar", "za", "il", "ae", "sa", "tr", "id", "my", "th",
+    "ph", "vn", "eu", "uy", "cl", "pe", "ec", "ve", "cr",
+  ]
+
+  /// True when `s` itself ends in a REAL domain-shaped suffix -- used to
+  /// decide whether a saved alias/canonical is a domain in its own right,
+  /// in which case a peeled suffix must never be appended to it a second
+  /// time (Codex review, PR for #2281, finding P2 rounds 2-4, 6).
   private static func isDomainShaped(_ s: String) -> Bool {
-    Self.splitDomainSuffix(s) != nil
+    guard let split = Self.splitDomainSuffix(s) else { return false }
+    let lastLabel = split.suffix.split(separator: ".").last?.lowercased() ?? ""
+    return Self.knownDedupTLDs.contains(lastLabel)
   }
 
   private func stripPunctuation(_ token: String) -> String {

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -937,41 +937,56 @@ public struct WordCorrector: Sendable {
         return prefix + canonical + reattach + suffix
       }
 
-      // Step 3: fuzzy match RESTRICTED to domain-shaped candidates
-      // (`isDomainShaped`), tried against the token exactly as ASR emitted
-      // it, before peeling. Fuzzy scoring CAN cross threshold against a
-      // glued suffix -- but only when the CANDIDATE it's compared against
-      // is itself bare. A candidate that is ALSO domain-shaped ("githab.com"
-      // alias for canonical "GitHub.com") makes the comparison
-      // apples-to-apples (both sides carry a suffix), so a near-miss like
-      // "githib.com" still needs to try this unpeeled -- peeling first
-      // would strip the suffix from only one side and lose the match
-      // entirely (Codex review, PR for #2281, finding P1 round 3).
-      if let canonical = fuzzySingleWordPasses(
+      // A peeled suffix, once a fuzzy match is found, is reattached UNLESS
+      // the matched canonical is itself domain-shaped -- it already fully
+      // specifies its own domain, whatever suffix the user actually said
+      // (Codex review, PR for #2281, finding P2, rounds 2-4).
+      func reattached(_ canonical: String) -> String {
+        let reattach = peeledSuffix.isEmpty || Self.isDomainShaped(canonical) ? "" : peeledSuffix
+        return prefix + canonical + reattach + suffix
+      }
+
+      // Step 3 + 4: non-pack FUZZY to completion -- unpeeled (restricted to
+      // domain-shaped candidates), then peeled (unrestricted) -- before the
+      // pack tier gets a turn at all, so "non-pack always wins over pack"
+      // holds across the peel boundary too, not only within one attempt
+      // (Codex review, PR for #2281; same shape as finding P1 round 4, one
+      // tier down). Step 3's domain restriction is necessary because fuzzy
+      // scoring CAN cross threshold against a glued suffix, but only when
+      // the CANDIDATE compared against is itself bare -- a candidate that
+      // is ALSO domain-shaped makes the raw comparison apples-to-apples, so
+      // a near-miss like "githib.com" needs to try this unpeeled (finding
+      // P1 round 3).
+      if let canonical = nonPackFuzzySingleWordMatch(
         core: core, coreLower: coreLower, lookups: lookups,
         appendReplacement: { appendReplacement(forCanonical: $0) }, domainShapedOnly: true)
       {
         return prefix + canonical + suffix
       }
-
-      // Step 4: fuzzy (+ pack) against the peeled core, the ordinary
-      // unrestricted pool -- the fallback that fixes the originally
-      // reported bug for a bare (non-domain-shaped) alias.
       if matchCoreEligible,
-        let canonical = fuzzySingleWordPasses(
+        let canonical = nonPackFuzzySingleWordMatch(
           core: matchCore, coreLower: matchCoreLower, lookups: lookups,
           appendReplacement: { appendReplacement(forCanonical: $0) }, domainShapedOnly: false)
       {
-        // Codex review, PR for #2281, finding P2 (rounds 2, 3, 4): a saved
-        // CANONICAL can itself be a domain ("GitHub.com") even when its
-        // alias is the bare word ("githab") -- reattaching the peeled
-        // suffix to a canonical that is ALREADY domain-shaped would produce
-        // something like "GitHub.com.org". Suppress the reattach whenever
-        // the matched canonical is domain-shaped AT ALL, not only when it
-        // happens to end with the SAME suffix that was peeled: the
-        // canonical fully specifies its own domain either way.
-        let reattach = peeledSuffix.isEmpty || Self.isDomainShaped(canonical) ? "" : peeledSuffix
-        return prefix + canonical + reattach + suffix
+        return reattached(canonical)
+      }
+
+      // Step 5 + 6: pack fuzzy, the same unpeeled-then-peeled shape, only
+      // reached once every higher-authority attempt above has missed. Step
+      // 4's peeled non-pack fuzzy fixes the originally reported bug for a
+      // bare (non-domain-shaped) alias.
+      if let canonical = packFuzzySingleWordMatch(
+        core: core, coreLower: coreLower, lookups: lookups,
+        appendReplacement: { appendReplacement(forCanonical: $0) }, domainShapedOnly: true)
+      {
+        return prefix + canonical + suffix
+      }
+      if matchCoreEligible,
+        let canonical = packFuzzySingleWordMatch(
+          core: matchCore, coreLower: matchCoreLower, lookups: lookups,
+          appendReplacement: { appendReplacement(forCanonical: $0) }, domainShapedOnly: false)
+      {
+        return reattached(canonical)
       }
 
       return token
@@ -1001,21 +1016,24 @@ public struct WordCorrector: Sendable {
     return canonical
   }
 
-  /// Passes 4-5 (plus the pack tier), factored out of `correct(using:)` so the
-  /// single-word matcher can be run TWICE per token: once against the token as
-  /// ASR emitted it, and -- only if exact matching (both unpeeled and peeled)
-  /// produced no match -- once more against a peeled core (see the call
-  /// sites in `correct(using:)`). Returns the bare matched CANONICAL, never
-  /// prefix/suffix-assembled -- the caller reattaches those, since only the
-  /// caller knows whether a peeled suffix needs deduplicating against the
-  /// canonical it matched.
+  /// Pass 4-5 alone (non-pack fuzzy: aliases + canonical self-entries, then
+  /// canonicals as fallback). Split from the pack tier so the outer
+  /// single-word retry can run the FULL non-pack fuzzy tier -- unpeeled,
+  /// then peeled -- before the pack tier gets a turn at all, the same way
+  /// exact already runs to completion before any fuzzy pass. Without this
+  /// split, a pack-tier fuzzy hit reachable unpeeled (domain-restricted)
+  /// could preempt a non-pack fuzzy hit reachable only by peeling -- the
+  /// identical shape of precedence violation Codex review round 4 found one
+  /// tier up (exact vs. fuzzy), and "non-pack always wins over pack" is
+  /// exactly as absolute an invariant in this file as "exact always wins
+  /// over fuzzy" is.
   ///
-  /// `domainShapedOnly` gates every fuzzy loop here: the unpeeled call site
-  /// passes `true` (fuzzy is only safe unpeeled when comparing against an
-  /// equally domain-shaped candidate -- both sides then carry a suffix, so
-  /// nothing is silently swallowed); the peeled call site passes `false`
-  /// (the ordinary, unrestricted pool).
-  private func fuzzySingleWordPasses(
+  /// `domainShapedOnly` gates both loops: the unpeeled call site passes
+  /// `true` (fuzzy is only safe unpeeled when comparing against an equally
+  /// domain-shaped candidate -- both sides then carry a suffix, so nothing
+  /// is silently swallowed); the peeled call site passes `false` (the
+  /// ordinary, unrestricted pool).
+  private func nonPackFuzzySingleWordMatch(
     core: String, coreLower: String,
     lookups: Lookups, appendReplacement: (String) -> Void,
     domainShapedOnly: Bool
@@ -1024,10 +1042,6 @@ public struct WordCorrector: Sendable {
     let canonicalToWord = lookups.canonicalToWord
     let lowercasedCanonicals = lookups.lowercasedCanonicals
     let canonicals = lookups.canonicals
-    let packSingleFuzzyCandidates = lookups.packSingleFuzzyCandidates
-    let packCanonicals = lookups.packCanonicals
-    let packLowercasedCanonicals = lookups.packLowercasedCanonicals
-    let nonPackExactKeys = lookups.nonPackExactKeys
 
     // Skip fuzzy for very short tokens
     guard core.count >= 3 else { return nil }
@@ -1155,18 +1169,38 @@ public struct WordCorrector: Sendable {
       #endif
     }
 
-    // #992 PACK FUZZY TIER — LOWER authority. Reached ONLY here, i.e. after
-    // every non-pack fuzzy pass above missed (each accept returns early). This
-    // ordering is what makes "user/builtin always wins" structurally true: any
-    // user/builtin match (Pass 3/4/5) preempts the entire pack tier. Pack
-    // matches additionally clear a stricter bar (packFuzzyThresholdBump) and a
-    // casing guard (a case-only change is never an improvement for the
-    // lowercase pack canonicals). Source is unambiguous: only pack terms are
-    // scored in this tier.
+    return nil
+  }
+
+  /// #992 PACK FUZZY TIER — LOWER authority. Split from the non-pack fuzzy
+  /// passes so the outer single-word retry can call this ONLY after BOTH
+  /// non-pack fuzzy attempts (unpeeled, then peeled) have already missed --
+  /// see `nonPackFuzzySingleWordMatch`'s doc comment for why that ordering,
+  /// not merely "non-pack pool before pack pool within one call", is what
+  /// this tier's whole reason for existing depends on. Pack matches
+  /// additionally clear a stricter bar (`packFuzzyThresholdBump`) and a
+  /// casing guard (a case-only change is never an improvement for the
+  /// lowercase pack canonicals).
+  private func packFuzzySingleWordMatch(
+    core: String, coreLower: String,
+    lookups: Lookups, appendReplacement: (String) -> Void,
+    domainShapedOnly: Bool
+  ) -> String? {
+    let packSingleFuzzyCandidates = lookups.packSingleFuzzyCandidates
+    let packCanonicals = lookups.packCanonicals
+    let packLowercasedCanonicals = lookups.packLowercasedCanonicals
+    let nonPackExactKeys = lookups.nonPackExactKeys
+
+    guard core.count >= 3 else { return nil }
+    let effectiveThreshold =
+      core.count <= Self.shortTokenMaxLength
+      ? Self.shortTokenThreshold
+      : Self.threshold
+    let coreLen = coreLower.count
 
     // #992 precedence guard: if the token is already a recognized non-pack
     // term (user/builtin canonical or alias), it is correct as-is — packs
-    // must not rewrite it. This covers the case where the non-pack tier above
+    // must not rewrite it. This covers the case where non-pack matching
     // produced no replacement precisely because no fix was needed.
     if nonPackExactKeys.contains(coreLower) {
       return nil
@@ -1346,12 +1380,24 @@ public struct WordCorrector: Sendable {
 
   // MARK: - Helpers
 
-  /// Splits `s` at its LAST dot into (bare, suffix) when everything after
-  /// that dot is a non-empty run of letters/digits/hyphens -- a purely
-  /// STRUCTURAL definition of "looks like it ends in a domain suffix",
-  /// deliberately not limited to any curated TLD list. One shared
-  /// definition, used for BOTH questions this fix has to ask: is an INPUT
-  /// token worth peeling, and is a saved ALIAS/CANONICAL domain-shaped.
+  /// Splits `s` at its FIRST dot into (bare, suffix) when everything after
+  /// that dot is a non-empty run of letters/digits/hyphens/dots (with no
+  /// leading, trailing, or doubled dot) -- a purely STRUCTURAL definition of
+  /// "looks like it ends in a domain suffix", deliberately not limited to
+  /// any curated TLD list. One shared definition, used for BOTH questions
+  /// this fix has to ask: is an INPUT token worth peeling, and is a saved
+  /// ALIAS/CANONICAL domain-shaped.
+  ///
+  /// FIRST dot, not last: many countries' everyday domains are two-part
+  /// suffixes -- ".co.jp", ".co.uk", ".com.au", ".co.in" -- not the single
+  /// ".com" this app's own San-Francisco-built URL vetting was written
+  /// around. Peeling only the LAST label left "GitHub.co.jp" reattaching as
+  /// "GitHub.co" with the ".jp" silently eaten, and a bare alias "githab"
+  /// glued to "githab.co.jp" never matched at all, because the leftover
+  /// ".co" was still noise on the comparison. Peeling from the first dot
+  /// takes the WHOLE suffix as one unit, whatever shape it has, which is
+  /// what makes a brand name recoverable in a domain-suffix style this app
+  /// was not built around by default.
   ///
   /// Codex review, PR for #2281, rounds 3-4: an earlier version reused
   /// `InverseTextNormalizer.urlTLDAlt` (the closed, ten-item TLD set
@@ -1369,12 +1415,14 @@ public struct WordCorrector: Sendable {
   /// check generalizes to every user's vocabulary rather than the ten TLDs
   /// this app happens to vet for URL recognition elsewhere.
   private static func splitDomainSuffix(_ s: String) -> (bare: String, suffix: String)? {
-    guard let lastDot = s.lastIndex(of: "."), lastDot > s.startIndex else { return nil }
-    let tail = s[s.index(after: lastDot)...]
-    guard !tail.isEmpty, tail.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "-" }) else {
+    guard let firstDot = s.firstIndex(of: "."), firstDot > s.startIndex else { return nil }
+    let tail = s[s.index(after: firstDot)...]
+    guard !tail.isEmpty, tail.first != ".", tail.last != ".",
+      tail.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "-" || $0 == "." })
+    else {
       return nil
     }
-    return (String(s[s.startIndex..<lastDot]), String(s[lastDot...]))
+    return (String(s[s.startIndex..<firstDot]), String(s[firstDot...]))
   }
 
   /// True when `s` itself ends in a domain-shaped suffix -- used to decide

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -940,10 +940,40 @@ public struct WordCorrector: Sendable {
       // computed first, with non-pack results checked before either pack
       // result is accepted.
       let unpeeledExact = exactSingleWordMatch(core: core, coreLower: coreLower, lookups: lookups)
+      // The token already IS a registered canonical, byte-for-byte -- the
+      // strongest "leave this alone" signal available. Stop the whole
+      // single-word retry here rather than falling through to the peeled
+      // attempt, which could otherwise replace already-correct text with an
+      // unrelated match (Codex review, PR for #2281, finding P2 round 9).
+      if case .alreadyCorrect = unpeeledExact { return token }
+
+      var unpeeledMatch: (canonical: String, isPack: Bool)?
+      if case .replace(let canonical, let isPack) = unpeeledExact {
+        unpeeledMatch = (canonical, isPack)
+      }
+
       let peeledExact =
         matchCoreEligible
         ? exactSingleWordMatch(core: matchCore, coreLower: matchCoreLower, lookups: lookups)
-        : nil
+        : ExactSingleWordOutcome.noMatch
+      var peeledMatch: (canonical: String, isPack: Bool)?
+      if case .replace(let canonical, let isPack) = peeledExact {
+        peeledMatch = (canonical, isPack)
+      }
+      // `.alreadyCorrect` on the PEELED form means the bare part was
+      // already spelled right, so the untouched original token (bare part
+      // + its existing suffix) is already the correct output -- but that
+      // conclusion is only valid if nothing else is allowed to override it
+      // afterward. An earlier version of this comment claimed the "falls
+      // through to the final `return token`" path made this automatic; it
+      // does not, because `peeledMatch` staying nil here is indistinguishable
+      // from `.noMatch`, so a LOWER-authority pack exact match (or even a
+      // fuzzy match) found afterward could still win and replace text that
+      // was already correct (local Codex sweep of PR #2298's cloud
+      // findings, same day: canonical "GitHub" + pack alias "github.com" ->
+      // "Wrong" turned input "GitHub.com" into "Wrong" instead of leaving
+      // it alone). Stop here, exactly like the unpeeled case above.
+      if case .alreadyCorrect = peeledExact { return token }
 
       func acceptExact(unpeeled: Bool, _ match: (canonical: String, isPack: Bool)) -> String {
         appendReplacement(forCanonical: match.canonical)
@@ -955,16 +985,16 @@ public struct WordCorrector: Sendable {
         return unpeeled ? prefix + match.canonical + suffix : reattached(match.canonical)
       }
 
-      if let match = unpeeledExact, !match.isPack {
+      if let match = unpeeledMatch, !match.isPack {
         return acceptExact(unpeeled: true, match)
       }
-      if let match = peeledExact, !match.isPack {
+      if let match = peeledMatch, !match.isPack {
         return acceptExact(unpeeled: false, match)
       }
-      if let match = unpeeledExact {
+      if let match = unpeeledMatch {
         return acceptExact(unpeeled: true, match)
       }
-      if let match = peeledExact {
+      if let match = peeledMatch {
         return acceptExact(unpeeled: false, match)
       }
 
@@ -1045,10 +1075,28 @@ public struct WordCorrector: Sendable {
   /// review, PR for #2281, finding P1 round 7: see the call site in
   /// `correct(using:)` for why the caller needs to see both before
   /// choosing).
+  /// Three outcomes, not two, because the caller must react differently to
+  /// "nothing registered for this key" than to "something IS registered and
+  /// this token already IS that canonical" (Codex review, PR for #2281,
+  /// finding P2 round 9): collapsing both into `nil` let the peeled attempt
+  /// run even when the UNPEELED token was already letter-for-letter a real
+  /// canonical -- e.g. core exactly equals canonical "GitHub.com", so no
+  /// correction is needed at all, but an unrelated alias "github" (the
+  /// peeled bare form) mapping to some OTHER canonical could still win,
+  /// replacing text that was already correct. Exact self-identity is the
+  /// strongest possible "leave this alone" signal there is; it must stop
+  /// the whole single-word retry, not merely this one attempt.
+  private enum ExactSingleWordOutcome {
+    case replace(canonical: String, isPack: Bool)
+    case alreadyCorrect
+    case noMatch
+  }
+
   private func exactSingleWordMatch(
     core: String, coreLower: String, lookups: Lookups
-  ) -> (canonical: String, isPack: Bool)? {
-    guard let canonical = lookups.singleAliasMap[coreLower], core != canonical else { return nil }
+  ) -> ExactSingleWordOutcome {
+    guard let canonical = lookups.singleAliasMap[coreLower] else { return .noMatch }
+    guard core != canonical else { return .alreadyCorrect }
     // Authority comes from the matched KEY (`coreLower`), never from the
     // resulting canonical TEXT (Codex review, PR for #2281, finding P2
     // round 8): `canonicalToWord[canonical]` answers "who owns this
@@ -1060,7 +1108,7 @@ public struct WordCorrector: Sendable {
     // (already the authority for exactly that construction) tells us
     // whether THIS key's mapping came from a non-pack term, unambiguously.
     let isPack = !lookups.nonPackExactKeys.contains(coreLower)
-    return (canonical, isPack)
+    return .replace(canonical: canonical, isPack: isPack)
   }
 
   /// Pass 4-5 alone (non-pack fuzzy: aliases + canonical self-entries, then
@@ -1503,7 +1551,21 @@ public struct WordCorrector: Sendable {
   /// `xn--` prefix alone, and nothing that isn't real punycode happens to
   /// start with it.
   private static func isPlausibleTLDLabel(_ label: Substring) -> Bool {
-    if label.allSatisfy({ $0.isLetter }) { return true }
+    label.allSatisfy({ $0.isLetter }) || Self.isPunycodeTLDLabel(label)
+  }
+
+  /// The punycode-shape half of `isPlausibleTLDLabel`, factored out so
+  /// `isDomainShaped` can require it WITHOUT also admitting arbitrary
+  /// all-letters labels ("js", "academy", ...) the way the peel trigger
+  /// does -- those two questions need different bars for the reasons
+  /// `knownDedupTLDs`'s own doc comment gives (Codex review, PR for #2281,
+  /// finding P2 round 9: a canonical whose domain is itself an
+  /// internationalized name, written in its ASCII punycode form, was not
+  /// recognized as domain-shaped at all -- `splitDomainSuffix` peeled it
+  /// correctly, but the DEDUP check that decides whether to suppress a
+  /// mismatched reattach only consulted the curated real-word TLD list,
+  /// which can never contain an `xn--...` string).
+  private static func isPunycodeTLDLabel(_ label: Substring) -> Bool {
     let lower = label.lowercased()
     guard lower.hasPrefix("xn--") else { return false }
     let rest = lower.dropFirst(4)
@@ -1563,11 +1625,35 @@ public struct WordCorrector: Sendable {
   /// True when `s` itself ends in a REAL domain-shaped suffix -- used to
   /// decide whether a saved alias/canonical is a domain in its own right,
   /// in which case a peeled suffix must never be appended to it a second
-  /// time (Codex review, PR for #2281, finding P2 rounds 2-4, 6).
+  /// time (Codex review, PR for #2281, finding P2 rounds 2-4, 6, 9). A
+  /// punycode label (an internationalized domain's ASCII form) counts even
+  /// though it can never appear in `knownDedupTLDs` -- that list holds
+  /// real WORDS, and no curated word list can contain every possible
+  /// `xn--...` string, but the `xn--` shape itself is unambiguous evidence
+  /// on its own (round 9).
+  ///
+  /// A NATIVE-SCRIPT internationalized label (a real ccTLD written in its
+  /// own Unicode form, never converted to punycode -- ".рф" as literal
+  /// Cyrillic, not ".xn--p1ai") also counts, for a reason the curated-list
+  /// exclusion for "Node.js" does NOT apply to here (local Codex sweep of
+  /// PR #2298's cloud findings, same day): the false-positive risk that
+  /// keeps this function from accepting "any all-letters label" is
+  /// specifically an ENGLISH product-name risk (".js", ".io" as common
+  /// English computing suffixes on real brand names). No ordinary English
+  /// or Latin-script brand name coincidentally ends in a run of Cyrillic,
+  /// CJK, or Arabic-script characters, so accepting "all-letters AND
+  /// contains at least one non-ASCII character" here carries none of that
+  /// risk while closing the gap for any real IDN this app cannot curate by
+  /// string (there is no bounded list of "real internationalized domains"
+  /// any more than there is of ASCII ones).
   private static func isDomainShaped(_ s: String) -> Bool {
     guard let split = Self.splitDomainSuffix(s) else { return false }
-    let lastLabel = split.suffix.split(separator: ".").last?.lowercased() ?? ""
-    return Self.knownDedupTLDs.contains(lastLabel)
+    guard let lastLabelSub = split.suffix.split(separator: ".").last else { return false }
+    if Self.isPunycodeTLDLabel(lastLabelSub) { return true }
+    if lastLabelSub.allSatisfy({ $0.isLetter }), lastLabelSub.contains(where: { !$0.isASCII }) {
+      return true
+    }
+    return Self.knownDedupTLDs.contains(lastLabelSub.lowercased())
   }
 
   private func stripPunctuation(_ token: String) -> String {

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -1029,9 +1029,21 @@ public struct WordCorrector: Sendable {
       ) -> String? {
         switch (unpeeled, peeled) {
         case let (.some(u), .some(p)):
-          return u.score >= p.score
-            ? acceptFuzzy(unpeeled: true, canonical: u.canonical)
-            : acceptFuzzy(unpeeled: false, canonical: p.canonical)
+          // Each attempt already enforces `ambiguityMargin` WITHIN its own
+          // candidate pool, but that says nothing about the margin BETWEEN
+          // the two attempts' winners -- two different canonicals scoring
+          // 0.956 and 0.959 are each unambiguous alone yet nowhere near
+          // 0.05 apart from each other. Picking the higher score outright
+          // is exactly the "guess when uncertain" this file otherwise never
+          // does (Codex cloud review, PR #2298, round 15). Neither attempt
+          // is confident enough to override the other; fall through rather
+          // than accept either.
+          guard u.canonical != p.canonical, abs(u.score - p.score) < Self.ambiguityMargin else {
+            return u.score >= p.score
+              ? acceptFuzzy(unpeeled: true, canonical: u.canonical)
+              : acceptFuzzy(unpeeled: false, canonical: p.canonical)
+          }
+          return nil
         case let (.some(u), nil):
           return acceptFuzzy(unpeeled: true, canonical: u.canonical)
         case let (nil, .some(p)):

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -895,7 +895,12 @@ public struct WordCorrector: Sendable {
         return token
       }
 
-      // Pass 3: exact single-word alias (includes canonical self-entries)
+      // Pass 3, tried on the token exactly as ASR emitted it, BEFORE any TLD
+      // peeling. A saved custom word or alias can itself be a domain
+      // ("GitHub.com" canonical, "githab.com" alias), and this is the only
+      // pass safe to try unpeeled: exact string equality can never
+      // coincidentally consume a glued TLD (Codex review, PR for #2281,
+      // finding P1).
       if let canonical = singleAliasMap[coreLower], core != canonical {
         appendReplacement(forCanonical: canonical)
         #if DEBUG
@@ -904,232 +909,292 @@ public struct WordCorrector: Sendable {
         return prefix + canonical + suffix
       }
 
-      // Skip fuzzy for very short tokens
-      guard core.count >= 3 else { return token }
-
-      // Determine threshold based on token length
-      let effectiveThreshold =
-        core.count <= Self.shortTokenMaxLength
-        ? Self.shortTokenThreshold
-        : Self.threshold
-
-      // Pass 4: fuzzy single-word against aliases + canonical self-entries
-      let coreLen = coreLower.count
-      var bestScore = 0.0
-      var secondBest = 0.0
-      var bestMatch = ""
-
-      for entry in singleFuzzyCandidates {
-        let surface = entry.surface
-        let canonical = entry.canonical
-        // Length-ratio pruning: skip if lengths differ too much for threshold
-        let surfLen = surface.count
-        let lenRatio = Double(min(coreLen, surfLen)) / Double(max(coreLen, surfLen))
-        if lenRatio < 0.5 { continue }
-
-        let s = score(coreLower, against: surface)
-        if s > bestScore {
-          if bestMatch != canonical { secondBest = bestScore }
-          bestScore = s
-          bestMatch = canonical
-        } else if s > secondBest && canonical != bestMatch {
-          secondBest = s
+      // Every other pass (fuzzy Pass 4/5, pack tier) runs on a TLD-peeled core
+      // whenever a recognized TLD is glued to the end -- never on the raw
+      // glued token. Fuzzy SCORING, unlike exact equality, can cross
+      // threshold against the whole glued string too (measured live for
+      // several TLDs while building this fix: trying fuzzy on the unpeeled
+      // token first reproduced the original bug for org/net/ai/me/io/app),
+      // so this is not an optional refinement -- it is what makes the fix
+      // correct for every fuzzy-matched brand, not only exact ones.
+      var matchCore = core
+      var matchSuffix = suffix
+      if let lastDot = core.lastIndex(of: "."), lastDot > core.startIndex {
+        let tail = core[core.index(after: lastDot)...].lowercased()
+        if Self.recognizedTLDs.contains(tail) {
+          matchCore = String(core[core.startIndex..<lastDot])
+          matchSuffix = String(core[lastDot...]) + suffix
         }
       }
-
-      // Phase 2 (#638) §8.2: vocab-size penalty + length-aware adjustment
-      // applied per-candidate. Per-term override wins absolutely if set.
-      let pass4VocabPenalty = Self.largeVocabPenalty(poolSize: singleFuzzyCandidates.count)
-      let pass4LengthAdj = Self.lengthAwareAdjustment(candidateLength: bestMatch.count)
-      let pass4Override = canonicalToWord[bestMatch.lowercased()]?.minSimilarityOverride
-      let pass4Threshold =
-        pass4Override ?? (effectiveThreshold + pass4VocabPenalty - pass4LengthAdj)
-      if bestScore >= pass4Threshold,
-        bestScore - secondBest >= Self.ambiguityMargin,
-        core != bestMatch
-      {
-        appendReplacement(forCanonical: bestMatch)
-        #if DEBUG
-          Self.logger.debug(
-            "WordCorrector: type=alias-fuzzy source='\(core)' target='\(bestMatch)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(bestScore - secondBest, format: .fixed(precision: 3)) threshold=\(pass4Threshold, format: .fixed(precision: 3))"
-          )
-        #endif
-        return prefix + bestMatch + suffix
-      } else if bestScore > 0 {
-        #if DEBUG
-          let pass4Margin = bestScore - secondBest
-          let reason: String
-          if bestScore < pass4Threshold {
-            reason = "below_threshold"
-          } else if pass4Margin < Self.ambiguityMargin {
-            reason = "below_margin"
-          } else {
-            reason = "same_as_input"
-          }
-          Self.logger.debug(
-            "WordCorrector: REJECT pass=alias-fuzzy source='\(core)' best_target='\(bestMatch)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(pass4Margin, format: .fixed(precision: 3)) threshold=\(pass4Threshold, format: .fixed(precision: 3)) reason=\(reason)"
-          )
-        #endif
-      }
-
-      // Pass 5: fuzzy single-word against canonicals as fallback
-      bestScore = 0.0
-      secondBest = 0.0
-      bestMatch = ""
-
-      for (idx, targetLower) in lowercasedCanonicals.enumerated() {
-        let targetLen = targetLower.count
-        let lenRatio = Double(min(coreLen, targetLen)) / Double(max(coreLen, targetLen))
-        if lenRatio < 0.5 { continue }
-
-        let s = score(coreLower, against: targetLower)
-        if s > bestScore {
-          secondBest = bestScore
-          bestScore = s
-          bestMatch = canonicals[idx]
-        } else if s > secondBest {
-          secondBest = s
-        }
-      }
-
-      // Phase 2 (#638) §8.2: same hardening for Pass 5.
-      let pass5VocabPenalty = Self.largeVocabPenalty(poolSize: lowercasedCanonicals.count)
-      let pass5LengthAdj = Self.lengthAwareAdjustment(candidateLength: bestMatch.count)
-      let pass5Override = canonicalToWord[bestMatch.lowercased()]?.minSimilarityOverride
-      let pass5Threshold =
-        pass5Override ?? (effectiveThreshold + pass5VocabPenalty - pass5LengthAdj)
-      if bestScore >= pass5Threshold,
-        bestScore - secondBest >= Self.ambiguityMargin,
-        core != bestMatch
-      {
-        appendReplacement(forCanonical: bestMatch)
-        #if DEBUG
-          Self.logger.debug(
-            "WordCorrector: type=canonical-fuzzy source='\(core)' target='\(bestMatch)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(bestScore - secondBest, format: .fixed(precision: 3)) threshold=\(pass5Threshold, format: .fixed(precision: 3))"
-          )
-        #endif
-        return prefix + bestMatch + suffix
-      } else if bestScore > 0 {
-        #if DEBUG
-          let pass5Margin = bestScore - secondBest
-          let reason: String
-          if bestScore < pass5Threshold {
-            reason = "below_threshold"
-          } else if pass5Margin < Self.ambiguityMargin {
-            reason = "below_margin"
-          } else {
-            reason = "same_as_input"
-          }
-          Self.logger.debug(
-            "WordCorrector: REJECT pass=canonical-fuzzy source='\(core)' best_target='\(bestMatch)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(pass5Margin, format: .fixed(precision: 3)) threshold=\(pass5Threshold, format: .fixed(precision: 3)) reason=\(reason)"
-          )
-        #endif
-      }
-
-      // #992 PACK FUZZY TIER — LOWER authority. Reached ONLY here, i.e. after
-      // every non-pack fuzzy pass above missed (each accept returns early). This
-      // ordering is what makes "user/builtin always wins" structurally true: any
-      // user/builtin match (Pass 3/4/5) preempts the entire pack tier. Pack
-      // matches additionally clear a stricter bar (packFuzzyThresholdBump) and a
-      // casing guard (a case-only change is never an improvement for the
-      // lowercase pack canonicals). Source is unambiguous: only pack terms are
-      // scored in this tier.
-
-      // #992 precedence guard: if the token is already a recognized non-pack
-      // term (user/builtin canonical or alias), it is correct as-is — packs
-      // must not rewrite it. This covers the case where the non-pack tier above
-      // produced no replacement precisely because no fix was needed.
-      if nonPackExactKeys.contains(coreLower) {
+      let matchCoreLower = matchCore.lowercased()
+      guard !Self.emojiTriggerReservedWords.contains(matchCoreLower), matchCore.count >= 2 else {
         return token
       }
-
-      // Pack Pass 4: single-word pack aliases.
-      if !packSingleFuzzyCandidates.isEmpty {
-        var pBest = 0.0
-        var pSecond = 0.0
-        var pMatch = ""
-        for entry in packSingleFuzzyCandidates {
-          let surfLen = entry.surface.count
-          let lenRatio = Double(min(coreLen, surfLen)) / Double(max(coreLen, surfLen))
-          if lenRatio < 0.5 { continue }
-          let s = score(coreLower, against: entry.surface)
-          if s > pBest {
-            if pMatch != entry.canonical { pSecond = pBest }
-            pBest = s
-            pMatch = entry.canonical
-          } else if s > pSecond && entry.canonical != pMatch {
-            pSecond = s
-          }
-        }
-        let vocabPenalty = Self.largeVocabPenalty(poolSize: packSingleFuzzyCandidates.count)
-        let lengthAdj = Self.lengthAwareAdjustment(candidateLength: pMatch.count)
-        let packThreshold =
-          effectiveThreshold + vocabPenalty - lengthAdj + Self.packFuzzyThresholdBump
-        if pBest >= packThreshold, pBest - pSecond >= Self.ambiguityMargin, core != pMatch {
-          if coreLower == pMatch.lowercased() {
-            // Casing guard: case-only change — suppress, fall through.
-            #if DEBUG
-              Self.logger.debug(
-                "WordCorrector: SUPPRESS pass=pack-alias-fuzzy reason=case_only source='\(core)' target='\(pMatch)'"
-              )
-            #endif
-          } else {
-            appendReplacement(forCanonical: pMatch)
-            #if DEBUG
-              Self.logger.debug(
-                "WordCorrector: type=pack-alias-fuzzy source='\(core)' target='\(pMatch)' score=\(pBest, format: .fixed(precision: 3)) margin=\(pBest - pSecond, format: .fixed(precision: 3)) threshold=\(packThreshold, format: .fixed(precision: 3))"
-              )
-            #endif
-            return prefix + pMatch + suffix
-          }
-        }
-      }
-
-      // Pack Pass 5: single-word pack canonicals.
-      if !packLowercasedCanonicals.isEmpty {
-        var pBest = 0.0
-        var pSecond = 0.0
-        var pMatch = ""
-        for (idx, targetLower) in packLowercasedCanonicals.enumerated() {
-          let targetLen = targetLower.count
-          let lenRatio = Double(min(coreLen, targetLen)) / Double(max(coreLen, targetLen))
-          if lenRatio < 0.5 { continue }
-          let s = score(coreLower, against: targetLower)
-          if s > pBest {
-            pSecond = pBest
-            pBest = s
-            pMatch = packCanonicals[idx]
-          } else if s > pSecond {
-            pSecond = s
-          }
-        }
-        let vocabPenalty = Self.largeVocabPenalty(poolSize: packLowercasedCanonicals.count)
-        let lengthAdj = Self.lengthAwareAdjustment(candidateLength: pMatch.count)
-        let packThreshold =
-          effectiveThreshold + vocabPenalty - lengthAdj + Self.packFuzzyThresholdBump
-        if pBest >= packThreshold, pBest - pSecond >= Self.ambiguityMargin, core != pMatch {
-          if coreLower == pMatch.lowercased() {
-            #if DEBUG
-              Self.logger.debug(
-                "WordCorrector: SUPPRESS pass=pack-canonical-fuzzy reason=case_only source='\(core)' target='\(pMatch)'"
-              )
-            #endif
-          } else {
-            appendReplacement(forCanonical: pMatch)
-            #if DEBUG
-              Self.logger.debug(
-                "WordCorrector: type=pack-canonical-fuzzy source='\(core)' target='\(pMatch)' score=\(pBest, format: .fixed(precision: 3)) margin=\(pBest - pSecond, format: .fixed(precision: 3)) threshold=\(packThreshold, format: .fixed(precision: 3))"
-              )
-            #endif
-            return prefix + pMatch + suffix
-          }
-        }
+      if let matched = matchSingleWordPasses(
+        prefix: prefix, core: matchCore, coreLower: matchCoreLower, suffix: matchSuffix,
+        lookups: lookups, appendReplacement: { appendReplacement(forCanonical: $0) })
+      {
+        return matched
       }
 
       return token
     }
 
     return (corrected.joined(separator: " "), replacements)
+  }
+
+  /// Passes 3-5 (plus the pack tier), factored out of `correct(using:)` so the
+  /// single-word matcher can be run TWICE per token: once against the token as
+  /// ASR emitted it, and -- only if that produced no match -- once more
+  /// against a TLD-peeled core (see the call site in `correct(using:)`).
+  /// `nil` means "no pass matched"; every accept path returns the final
+  /// `prefix + canonical + suffix` string, exactly as the inline closure did.
+  private func matchSingleWordPasses(
+    prefix: String, core: String, coreLower: String, suffix: String,
+    lookups: Lookups, appendReplacement: (String) -> Void
+  ) -> String? {
+    let singleAliasMap = lookups.singleAliasMap
+    let singleFuzzyCandidates = lookups.singleFuzzyCandidates
+    let canonicalToWord = lookups.canonicalToWord
+    let lowercasedCanonicals = lookups.lowercasedCanonicals
+    let canonicals = lookups.canonicals
+    let packSingleFuzzyCandidates = lookups.packSingleFuzzyCandidates
+    let packCanonicals = lookups.packCanonicals
+    let packLowercasedCanonicals = lookups.packLowercasedCanonicals
+    let nonPackExactKeys = lookups.nonPackExactKeys
+
+    // Pass 3: exact single-word alias (includes canonical self-entries)
+    if let canonical = singleAliasMap[coreLower], core != canonical {
+      appendReplacement(canonical)
+      #if DEBUG
+        Self.logger.debug("WordCorrector: type=alias source='\(core)' target='\(canonical)'")
+      #endif
+      return prefix + canonical + suffix
+    }
+
+    // Skip fuzzy for very short tokens
+    guard core.count >= 3 else { return nil }
+
+    // Determine threshold based on token length
+    let effectiveThreshold =
+      core.count <= Self.shortTokenMaxLength
+      ? Self.shortTokenThreshold
+      : Self.threshold
+
+    // Pass 4: fuzzy single-word against aliases + canonical self-entries
+    let coreLen = coreLower.count
+    var bestScore = 0.0
+    var secondBest = 0.0
+    var bestMatch = ""
+
+    for entry in singleFuzzyCandidates {
+      let surface = entry.surface
+      let canonical = entry.canonical
+      // Length-ratio pruning: skip if lengths differ too much for threshold
+      let surfLen = surface.count
+      let lenRatio = Double(min(coreLen, surfLen)) / Double(max(coreLen, surfLen))
+      if lenRatio < 0.5 { continue }
+
+      let s = score(coreLower, against: surface)
+      if s > bestScore {
+        if bestMatch != canonical { secondBest = bestScore }
+        bestScore = s
+        bestMatch = canonical
+      } else if s > secondBest && canonical != bestMatch {
+        secondBest = s
+      }
+    }
+
+    // Phase 2 (#638) §8.2: vocab-size penalty + length-aware adjustment
+    // applied per-candidate. Per-term override wins absolutely if set.
+    let pass4VocabPenalty = Self.largeVocabPenalty(poolSize: singleFuzzyCandidates.count)
+    let pass4LengthAdj = Self.lengthAwareAdjustment(candidateLength: bestMatch.count)
+    let pass4Override = canonicalToWord[bestMatch.lowercased()]?.minSimilarityOverride
+    let pass4Threshold =
+      pass4Override ?? (effectiveThreshold + pass4VocabPenalty - pass4LengthAdj)
+    if bestScore >= pass4Threshold,
+      bestScore - secondBest >= Self.ambiguityMargin,
+      core != bestMatch
+    {
+      appendReplacement(bestMatch)
+      #if DEBUG
+        Self.logger.debug(
+          "WordCorrector: type=alias-fuzzy source='\(core)' target='\(bestMatch)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(bestScore - secondBest, format: .fixed(precision: 3)) threshold=\(pass4Threshold, format: .fixed(precision: 3))"
+        )
+      #endif
+      return prefix + bestMatch + suffix
+    } else if bestScore > 0 {
+      #if DEBUG
+        let pass4Margin = bestScore - secondBest
+        let reason: String
+        if bestScore < pass4Threshold {
+          reason = "below_threshold"
+        } else if pass4Margin < Self.ambiguityMargin {
+          reason = "below_margin"
+        } else {
+          reason = "same_as_input"
+        }
+        Self.logger.debug(
+          "WordCorrector: REJECT pass=alias-fuzzy source='\(core)' best_target='\(bestMatch)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(pass4Margin, format: .fixed(precision: 3)) threshold=\(pass4Threshold, format: .fixed(precision: 3)) reason=\(reason)"
+        )
+      #endif
+    }
+
+    // Pass 5: fuzzy single-word against canonicals as fallback
+    bestScore = 0.0
+    secondBest = 0.0
+    bestMatch = ""
+
+    for (idx, targetLower) in lowercasedCanonicals.enumerated() {
+      let targetLen = targetLower.count
+      let lenRatio = Double(min(coreLen, targetLen)) / Double(max(coreLen, targetLen))
+      if lenRatio < 0.5 { continue }
+
+      let s = score(coreLower, against: targetLower)
+      if s > bestScore {
+        secondBest = bestScore
+        bestScore = s
+        bestMatch = canonicals[idx]
+      } else if s > secondBest {
+        secondBest = s
+      }
+    }
+
+    // Phase 2 (#638) §8.2: same hardening for Pass 5.
+    let pass5VocabPenalty = Self.largeVocabPenalty(poolSize: lowercasedCanonicals.count)
+    let pass5LengthAdj = Self.lengthAwareAdjustment(candidateLength: bestMatch.count)
+    let pass5Override = canonicalToWord[bestMatch.lowercased()]?.minSimilarityOverride
+    let pass5Threshold =
+      pass5Override ?? (effectiveThreshold + pass5VocabPenalty - pass5LengthAdj)
+    if bestScore >= pass5Threshold,
+      bestScore - secondBest >= Self.ambiguityMargin,
+      core != bestMatch
+    {
+      appendReplacement(bestMatch)
+      #if DEBUG
+        Self.logger.debug(
+          "WordCorrector: type=canonical-fuzzy source='\(core)' target='\(bestMatch)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(bestScore - secondBest, format: .fixed(precision: 3)) threshold=\(pass5Threshold, format: .fixed(precision: 3))"
+        )
+      #endif
+      return prefix + bestMatch + suffix
+    } else if bestScore > 0 {
+      #if DEBUG
+        let pass5Margin = bestScore - secondBest
+        let reason: String
+        if bestScore < pass5Threshold {
+          reason = "below_threshold"
+        } else if pass5Margin < Self.ambiguityMargin {
+          reason = "below_margin"
+        } else {
+          reason = "same_as_input"
+        }
+        Self.logger.debug(
+          "WordCorrector: REJECT pass=canonical-fuzzy source='\(core)' best_target='\(bestMatch)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(pass5Margin, format: .fixed(precision: 3)) threshold=\(pass5Threshold, format: .fixed(precision: 3)) reason=\(reason)"
+        )
+      #endif
+    }
+
+    // #992 PACK FUZZY TIER — LOWER authority. Reached ONLY here, i.e. after
+    // every non-pack fuzzy pass above missed (each accept returns early). This
+    // ordering is what makes "user/builtin always wins" structurally true: any
+    // user/builtin match (Pass 3/4/5) preempts the entire pack tier. Pack
+    // matches additionally clear a stricter bar (packFuzzyThresholdBump) and a
+    // casing guard (a case-only change is never an improvement for the
+    // lowercase pack canonicals). Source is unambiguous: only pack terms are
+    // scored in this tier.
+
+    // #992 precedence guard: if the token is already a recognized non-pack
+    // term (user/builtin canonical or alias), it is correct as-is — packs
+    // must not rewrite it. This covers the case where the non-pack tier above
+    // produced no replacement precisely because no fix was needed.
+    if nonPackExactKeys.contains(coreLower) {
+      return nil
+    }
+
+    // Pack Pass 4: single-word pack aliases.
+    if !packSingleFuzzyCandidates.isEmpty {
+      var pBest = 0.0
+      var pSecond = 0.0
+      var pMatch = ""
+      for entry in packSingleFuzzyCandidates {
+        let surfLen = entry.surface.count
+        let lenRatio = Double(min(coreLen, surfLen)) / Double(max(coreLen, surfLen))
+        if lenRatio < 0.5 { continue }
+        let s = score(coreLower, against: entry.surface)
+        if s > pBest {
+          if pMatch != entry.canonical { pSecond = pBest }
+          pBest = s
+          pMatch = entry.canonical
+        } else if s > pSecond && entry.canonical != pMatch {
+          pSecond = s
+        }
+      }
+      let vocabPenalty = Self.largeVocabPenalty(poolSize: packSingleFuzzyCandidates.count)
+      let lengthAdj = Self.lengthAwareAdjustment(candidateLength: pMatch.count)
+      let packThreshold =
+        effectiveThreshold + vocabPenalty - lengthAdj + Self.packFuzzyThresholdBump
+      if pBest >= packThreshold, pBest - pSecond >= Self.ambiguityMargin, core != pMatch {
+        if coreLower == pMatch.lowercased() {
+          // Casing guard: case-only change — suppress, fall through.
+          #if DEBUG
+            Self.logger.debug(
+              "WordCorrector: SUPPRESS pass=pack-alias-fuzzy reason=case_only source='\(core)' target='\(pMatch)'"
+            )
+          #endif
+        } else {
+          appendReplacement(pMatch)
+          #if DEBUG
+            Self.logger.debug(
+              "WordCorrector: type=pack-alias-fuzzy source='\(core)' target='\(pMatch)' score=\(pBest, format: .fixed(precision: 3)) margin=\(pBest - pSecond, format: .fixed(precision: 3)) threshold=\(packThreshold, format: .fixed(precision: 3))"
+            )
+          #endif
+          return prefix + pMatch + suffix
+        }
+      }
+    }
+
+    // Pack Pass 5: single-word pack canonicals.
+    if !packLowercasedCanonicals.isEmpty {
+      var pBest = 0.0
+      var pSecond = 0.0
+      var pMatch = ""
+      for (idx, targetLower) in packLowercasedCanonicals.enumerated() {
+        let targetLen = targetLower.count
+        let lenRatio = Double(min(coreLen, targetLen)) / Double(max(coreLen, targetLen))
+        if lenRatio < 0.5 { continue }
+        let s = score(coreLower, against: targetLower)
+        if s > pBest {
+          pSecond = pBest
+          pBest = s
+          pMatch = packCanonicals[idx]
+        } else if s > pSecond {
+          pSecond = s
+        }
+      }
+      let vocabPenalty = Self.largeVocabPenalty(poolSize: packLowercasedCanonicals.count)
+      let lengthAdj = Self.lengthAwareAdjustment(candidateLength: pMatch.count)
+      let packThreshold =
+        effectiveThreshold + vocabPenalty - lengthAdj + Self.packFuzzyThresholdBump
+      if pBest >= packThreshold, pBest - pSecond >= Self.ambiguityMargin, core != pMatch {
+        if coreLower == pMatch.lowercased() {
+          #if DEBUG
+            Self.logger.debug(
+              "WordCorrector: SUPPRESS pass=pack-canonical-fuzzy reason=case_only source='\(core)' target='\(pMatch)'"
+            )
+          #endif
+        } else {
+          appendReplacement(pMatch)
+          #if DEBUG
+            Self.logger.debug(
+              "WordCorrector: type=pack-canonical-fuzzy source='\(core)' target='\(pMatch)' score=\(pBest, format: .fixed(precision: 3)) margin=\(pBest - pSecond, format: .fixed(precision: 3)) threshold=\(packThreshold, format: .fixed(precision: 3))"
+            )
+          #endif
+          return prefix + pMatch + suffix
+        }
+      }
+    }
+
+    return nil
   }
 
   // MARK: - Scoring
@@ -1218,7 +1283,12 @@ public struct WordCorrector: Sendable {
   /// (`lowerRiskURLTLDAlt` + `commonWordURLTLDAlt`), reused rather than
   /// redefined so both parts of the pipeline agree on what "looks like a
   /// domain" means — a closed, already-vetted set, never a fresh guess
-  /// (`matcher-set-adversarial-tests`).
+  /// (`matcher-set-adversarial-tests`). Read only by the single-word retry in
+  /// `correct(using:)` -- NOT by `splitPunctuation` itself, so Pass 0/1/2
+  /// compound matching still treats a glued domain as one opaque unit, exactly
+  /// as before this fix (Codex review, PR for #2281, finding P2: peeling a TLD
+  /// inside the shared helper let an internal token's ".com" get silently
+  /// consumed by an accidental cross-token compound match).
   private static let recognizedTLDs: Set<String> = Set(
     InverseTextNormalizer.urlTLDAlt.components(separatedBy: "|"))
 
@@ -1237,24 +1307,6 @@ public struct WordCorrector: Sendable {
     while let last = core.last, !last.isLetter && !last.isNumber {
       suffix = String(last) + suffix
       core = String(core.dropLast())
-    }
-    // A glued domain suffix ("EnviousWispr.com") is CONTENT, not punctuation
-    // to discard. `InverseTextNormalizer.urls(_:)` already made "word.tld" a
-    // routine, CORRECT shape for a dictated domain (#2257/#2258), so every
-    // matching pass below must not treat the whole glued token as fair game
-    // and silently swallow the TLD along with a fuzzy/exact word match.
-    // Measured live (Saurabh's own dictation, 2026-08-21): "Enviousvisper.com"
-    // corrected to "EnviousWispr" with the ".com" gone entirely, because the
-    // trailing "m" is a letter, so the edge-stripping loops above never even
-    // looked at the "." three characters earlier. Peeling a RECOGNIZED TLD off
-    // into `suffix` here, before any caller ever sees `core`, fixes it at the
-    // one shared root every pass already reads through.
-    if let lastDot = core.lastIndex(of: "."), lastDot > core.startIndex {
-      let tail = core[core.index(after: lastDot)...].lowercased()
-      if Self.recognizedTLDs.contains(tail) {
-        suffix = String(core[lastDot...]) + suffix
-        core = String(core[core.startIndex..<lastDot])
-      }
     }
     return (prefix, core, suffix)
   }

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -1023,10 +1023,21 @@ public struct WordCorrector: Sendable {
         appendReplacement(forCanonical: canonical)
         return unpeeled ? prefix + canonical + suffix : reattached(canonical)
       }
+      // `.ambiguous` and `.noCandidate` MUST stay distinguishable to the
+      // caller (Codex cloud review, PR #2298, round 16): collapsing both to
+      // `nil` let an ambiguous NON-PACK tie fall through into the
+      // lower-authority PACK tier as if non-pack had found nothing at all,
+      // letting a pack candidate win a token that "non-pack always outranks
+      // pack" says should have been left untouched instead.
+      enum FuzzyTierOutcome {
+        case accepted(String)
+        case ambiguous
+        case noCandidate
+      }
       func strongerOf(
         _ unpeeled: (canonical: String, score: Double)?,
         _ peeled: (canonical: String, score: Double)?
-      ) -> String? {
+      ) -> FuzzyTierOutcome {
         switch (unpeeled, peeled) {
         case let (.some(u), .some(p)):
           // Each attempt already enforces `ambiguityMargin` WITHIN its own
@@ -1036,20 +1047,20 @@ public struct WordCorrector: Sendable {
           // 0.05 apart from each other. Picking the higher score outright
           // is exactly the "guess when uncertain" this file otherwise never
           // does (Codex cloud review, PR #2298, round 15). Neither attempt
-          // is confident enough to override the other; fall through rather
-          // than accept either.
+          // is confident enough to override the other.
           guard u.canonical != p.canonical, abs(u.score - p.score) < Self.ambiguityMargin else {
-            return u.score >= p.score
-              ? acceptFuzzy(unpeeled: true, canonical: u.canonical)
-              : acceptFuzzy(unpeeled: false, canonical: p.canonical)
+            return .accepted(
+              u.score >= p.score
+                ? acceptFuzzy(unpeeled: true, canonical: u.canonical)
+                : acceptFuzzy(unpeeled: false, canonical: p.canonical))
           }
-          return nil
+          return .ambiguous
         case let (.some(u), nil):
-          return acceptFuzzy(unpeeled: true, canonical: u.canonical)
+          return .accepted(acceptFuzzy(unpeeled: true, canonical: u.canonical))
         case let (nil, .some(p)):
-          return acceptFuzzy(unpeeled: false, canonical: p.canonical)
+          return .accepted(acceptFuzzy(unpeeled: false, canonical: p.canonical))
         case (nil, nil):
-          return nil
+          return .noCandidate
         }
       }
 
@@ -1083,8 +1094,16 @@ public struct WordCorrector: Sendable {
         ? nonPackFuzzySingleWordMatch(
           core: matchCore, coreLower: matchCoreLower, lookups: lookups, domainShapedOnly: false)
         : nil
-      if let result = strongerOf(unpeeledNonPackFuzzy, peeledNonPackFuzzy) {
+      // An ambiguous non-pack tie is terminal, not "try pack next": pack is
+      // lower authority and must never get a turn just because non-pack
+      // couldn't confidently pick between two of ITS OWN candidates.
+      switch strongerOf(unpeeledNonPackFuzzy, peeledNonPackFuzzy) {
+      case .accepted(let result):
         return result
+      case .ambiguous:
+        return token
+      case .noCandidate:
+        break
       }
 
       // Step 5 + 6: pack fuzzy, the same unpeeled-then-peeled shape (step 5
@@ -1102,7 +1121,9 @@ public struct WordCorrector: Sendable {
         ? packFuzzySingleWordMatch(
           core: matchCore, coreLower: matchCoreLower, lookups: lookups, domainShapedOnly: false)
         : nil
-      if let result = strongerOf(unpeeledPackFuzzy, peeledPackFuzzy) {
+      // Nothing follows the pack tier, so ambiguous and no-candidate both
+      // resolve to the same "leave it alone" outcome here.
+      if case .accepted(let result) = strongerOf(unpeeledPackFuzzy, peeledPackFuzzy) {
         return result
       }
 
@@ -1658,21 +1679,42 @@ public struct WordCorrector: Sendable {
   /// dot-suffix): both are ALL-LETTERS after the dot, so no structural rule
   /// -- however tightened -- can separate them.
   /// KNOWN LIMIT, accepted rather than chased further (founder call,
-  /// Codex review round 7, P2): this list is CURATED, not exhaustive --
-  /// ICANN's real root zone has 1,500+ entries, and any hand-picked subset
-  /// will always be missing one (round 7 named "GitHub.academy" as a real
-  /// gTLD this list omits). `matcher-set-adversarial-tests`'s
-  /// generalisation gate is right that a hand-authored set is a prediction
-  /// about users we haven't met -- the two mechanisms that would actually
-  /// close it are bundling a maintained public-suffix authority, or letting
-  /// a word's OWNER mark it as a domain explicitly rather than the app
-  /// guessing from its text -- and both are real feature-sized additions,
-  /// not a fix for this bug. The failure mode this list still has is
-  /// narrow: it needs BOTH a saved word shaped like a domain that ISN'T one
-  /// AND a separately-dictated real domain suffix glued onto its bare
-  /// alias, and (measured against the shipped pack and this founder's own
-  /// live vocabulary while building this fix) zero words anywhere in this
-  /// app are shaped like a domain at all today.
+  /// Codex review round 7, P2; reconfirmed round 16 against two MORE
+  /// consequences of the same root cause): this list is CURATED, not
+  /// exhaustive -- ICANN's real root zone has 1,500+ entries, and any
+  /// hand-picked subset will always be missing one (round 7 named
+  /// "GitHub.academy" as a real gTLD this list omits). `isDomainShaped`
+  /// is the ONLY consumer, but it backs TWO different decisions that both
+  /// inherit this same limit:
+  /// - Dedup suppression (this function's own purpose): a saved domain
+  ///   using a real TLD absent from this list is not recognized as
+  ///   already-a-domain, so a peeled suffix can get appended to it a
+  ///   second time.
+  /// - Domain-restricted fuzzy ADMISSION (Pass 4/5 and their pack
+  ///   equivalents' `domainShapedOnly` gate, round 16): a saved alias
+  ///   using a real TLD absent from this list is excluded from the raw
+  ///   (unpeeled) fuzzy scan entirely, so a near-miss like
+  ///   "githib.photography" for a saved "githab.photography" never
+  ///   matches, because ".photography" is not in this set.
+  /// Round 16 also found the CONVERSE failure: a real TLD present in this
+  /// list ("io") is simultaneously a common non-domain product-name
+  /// suffix ("Socket.IO"), so a canonical like "Socket.IO" is
+  /// misclassified as domain-shaped and silently drops a dictated ".com"
+  /// -- the exact ambiguity this comment already names for "Node.js"
+  /// (".js" is NOT curated) now shows up for a curated TLD too. Canonical
+  /// text alone cannot resolve either direction: `matcher-set-adversarial-
+  /// tests`'s generalisation gate is right that a hand-authored set is a
+  /// prediction about users we haven't met -- the two mechanisms that
+  /// would actually close it are bundling a maintained public-suffix
+  /// authority, or letting a word's OWNER mark it as a domain explicitly
+  /// rather than the app guessing from its text -- and both are real
+  /// feature-sized additions, not a fix for this bug. The failure mode
+  /// this list still has is narrow: it needs a saved word shaped like a
+  /// domain (or ambiguously shaped like one) that is missing from, or
+  /// collides with, this curated set, AND a separately-dictated domain
+  /// suffix interacting with it, and (measured against the shipped pack
+  /// and this founder's own live vocabulary while building this fix) zero
+  /// words anywhere in this app are shaped like a domain at all today.
   private static let knownDedupTLDs: Set<String> = [
     "com", "org", "net", "edu", "gov", "mil", "int", "info", "biz", "name",
     "pro", "coop", "museum", "aero", "jobs", "mobi", "travel", "tel", "asia", "cat", "xxx",

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -1255,6 +1255,17 @@ public struct WordCorrector: Sendable {
     var bestScore = 0.0
     var secondBest = 0.0
     var bestMatch = ""
+    // Tracks whether EITHER pass found a genuine ambiguity (score cleared
+    // its own threshold but not its own margin) that neither pass went on
+    // to resolve -- the function's FINAL fallback, not an early exit,
+    // because a confident Pass 5 canonical match must still be able to
+    // override a Pass 4 alias ambiguity (round 19: two Pass 4 aliases
+    // scoring 0.970/0.959 against each other is genuinely ambiguous, but
+    // Pass 5's own candidate pool can independently and confidently
+    // resolve the SAME input at 0.970 with nothing else within 0.05 of
+    // it -- Pass 5 answers a different, unambiguous question and must get
+    // the chance to).
+    var anyPassWasAmbiguous = false
 
     for entry in singleFuzzyCandidates {
       let surface = entry.surface
@@ -1302,16 +1313,20 @@ public struct WordCorrector: Sendable {
       return .candidate(canonical: bestMatch, score: bestScore)
     } else if bestScore >= pass4Threshold, pass4Margin < Self.ambiguityMargin {
       // Score clears the bar but the margin over the runner-up does not --
-      // this is a genuine ambiguity between two DIFFERENT candidates, not
-      // "nothing scored close." Stop here rather than trying Pass 5, whose
-      // canonical pool answers a different question and cannot resolve
-      // THIS ambiguity (round 17).
+      // a genuine ambiguity between two DIFFERENT candidates, not "nothing
+      // scored close." Record it and continue to Pass 5 rather than
+      // returning immediately (round 17 stopped here; round 19 found that
+      // too aggressive): Pass 5's canonical pool answers a DIFFERENT
+      // question, so it may still resolve confidently on its own terms
+      // even though Pass 4 couldn't. Only if Pass 5 ALSO fails to produce
+      // a confident candidate does this ambiguity become the function's
+      // final answer.
       #if DEBUG
         Self.logger.debug(
           "WordCorrector: REJECT pass=alias-fuzzy source='\(core)' best_target='\(bestMatch)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(pass4Margin, format: .fixed(precision: 3)) threshold=\(pass4Threshold, format: .fixed(precision: 3)) reason=below_margin"
         )
       #endif
-      return .ambiguous
+      anyPassWasAmbiguous = true
     } else if bestScore > 0 {
       #if DEBUG
         let reason = bestScore < pass4Threshold ? "below_threshold" : "same_as_input"
@@ -1362,7 +1377,7 @@ public struct WordCorrector: Sendable {
           "WordCorrector: REJECT pass=canonical-fuzzy source='\(core)' best_target='\(bestMatch)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(pass5Margin, format: .fixed(precision: 3)) threshold=\(pass5Threshold, format: .fixed(precision: 3)) reason=below_margin"
         )
       #endif
-      return .ambiguous
+      anyPassWasAmbiguous = true
     } else if bestScore > 0 {
       #if DEBUG
         let reason = bestScore < pass5Threshold ? "below_threshold" : "same_as_input"
@@ -1372,7 +1387,13 @@ public struct WordCorrector: Sendable {
       #endif
     }
 
-    return .noCandidate
+    // Neither pass produced a confident candidate. If either was
+    // genuinely ambiguous (rather than simply empty), that ambiguity is
+    // this attempt's answer, not "no candidate" -- preserves round 16/17's
+    // invariant that an unresolved ambiguity blocks the pack tier, now
+    // correctly scoped to "unresolved by EITHER pass" instead of
+    // "Pass 4 alone" (round 19).
+    return anyPassWasAmbiguous ? .ambiguous : .noCandidate
   }
 
   /// #992 PACK FUZZY TIER — LOWER authority. Split from the non-pack fuzzy
@@ -1408,6 +1429,11 @@ public struct WordCorrector: Sendable {
     if nonPackExactKeys.contains(coreLower) {
       return .noCandidate
     }
+
+    // Same "final answer, not an early exit" tracking as the non-pack
+    // twin above (round 19): a Pack Pass 4 ambiguity must still let Pack
+    // Pass 5 try to resolve confidently on its own terms.
+    var anyPassWasAmbiguous = false
 
     // Pack Pass 4: single-word pack aliases.
     if !packSingleFuzzyCandidates.isEmpty {
@@ -1455,14 +1481,15 @@ public struct WordCorrector: Sendable {
           return .candidate(canonical: pMatch, score: pBest)
         }
       } else if pBest >= packThreshold, pMargin < Self.ambiguityMargin {
-        // Same "genuinely ambiguous, not merely absent" distinction as the
-        // non-pack Pass 4 above (round 17).
+        // Genuinely ambiguous, not merely absent (round 17) -- but record
+        // and continue rather than return, so Pack Pass 5 still gets its
+        // chance (round 19).
         #if DEBUG
           Self.logger.debug(
             "WordCorrector: REJECT pass=pack-alias-fuzzy source='\(core)' best_target='\(pMatch)' score=\(pBest, format: .fixed(precision: 3)) margin=\(pMargin, format: .fixed(precision: 3)) threshold=\(packThreshold, format: .fixed(precision: 3)) reason=below_margin"
           )
         #endif
-        return .ambiguous
+        anyPassWasAmbiguous = true
       }
     }
 
@@ -1511,11 +1538,11 @@ public struct WordCorrector: Sendable {
             "WordCorrector: REJECT pass=pack-canonical-fuzzy source='\(core)' best_target='\(pMatch)' score=\(pBest, format: .fixed(precision: 3)) margin=\(pMargin, format: .fixed(precision: 3)) threshold=\(packThreshold, format: .fixed(precision: 3)) reason=below_margin"
           )
         #endif
-        return .ambiguous
+        anyPassWasAmbiguous = true
       }
     }
 
-    return .noCandidate
+    return anyPassWasAmbiguous ? .ambiguous : .noCandidate
   }
 
   // MARK: - Scoring

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -1035,11 +1035,18 @@ public struct WordCorrector: Sendable {
         case noCandidate
       }
       func strongerOf(
-        _ unpeeled: (canonical: String, score: Double)?,
-        _ peeled: (canonical: String, score: Double)?
+        _ unpeeled: SingleAttemptFuzzyOutcome,
+        _ peeled: SingleAttemptFuzzyOutcome
       ) -> FuzzyTierOutcome {
         switch (unpeeled, peeled) {
-        case let (.some(u), .some(p)):
+        // Either attempt being ambiguous ON ITS OWN (two different
+        // candidates too close together WITHIN that attempt's scan) is
+        // just as terminal as the two attempts' winners being too close to
+        // EACH OTHER below -- round 17 extends round 15's cross-attempt
+        // margin check down into the attempts themselves.
+        case (.ambiguous, _), (_, .ambiguous):
+          return .ambiguous
+        case let (.candidate(uc, us), .candidate(pc, ps)):
           // Each attempt already enforces `ambiguityMargin` WITHIN its own
           // candidate pool, but that says nothing about the margin BETWEEN
           // the two attempts' winners -- two different canonicals scoring
@@ -1048,18 +1055,18 @@ public struct WordCorrector: Sendable {
           // is exactly the "guess when uncertain" this file otherwise never
           // does (Codex cloud review, PR #2298, round 15). Neither attempt
           // is confident enough to override the other.
-          guard u.canonical != p.canonical, abs(u.score - p.score) < Self.ambiguityMargin else {
+          guard uc != pc, abs(us - ps) < Self.ambiguityMargin else {
             return .accepted(
-              u.score >= p.score
-                ? acceptFuzzy(unpeeled: true, canonical: u.canonical)
-                : acceptFuzzy(unpeeled: false, canonical: p.canonical))
+              us >= ps
+                ? acceptFuzzy(unpeeled: true, canonical: uc)
+                : acceptFuzzy(unpeeled: false, canonical: pc))
           }
           return .ambiguous
-        case let (.some(u), nil):
-          return .accepted(acceptFuzzy(unpeeled: true, canonical: u.canonical))
-        case let (nil, .some(p)):
-          return .accepted(acceptFuzzy(unpeeled: false, canonical: p.canonical))
-        case (nil, nil):
+        case let (.candidate(uc, _), .noCandidate):
+          return .accepted(acceptFuzzy(unpeeled: true, canonical: uc))
+        case let (.noCandidate, .candidate(pc, _)):
+          return .accepted(acceptFuzzy(unpeeled: false, canonical: pc))
+        case (.noCandidate, .noCandidate):
           return .noCandidate
         }
       }
@@ -1088,12 +1095,12 @@ public struct WordCorrector: Sendable {
         hasPeelableSuffix
         ? nonPackFuzzySingleWordMatch(
           core: core, coreLower: coreLower, lookups: lookups, domainShapedOnly: true)
-        : nil
+        : .noCandidate
       let peeledNonPackFuzzy =
         matchCoreEligible
         ? nonPackFuzzySingleWordMatch(
           core: matchCore, coreLower: matchCoreLower, lookups: lookups, domainShapedOnly: false)
-        : nil
+        : .noCandidate
       // An ambiguous non-pack tie is terminal, not "try pack next": pack is
       // lower authority and must never get a turn just because non-pack
       // couldn't confidently pick between two of ITS OWN candidates.
@@ -1115,12 +1122,12 @@ public struct WordCorrector: Sendable {
         hasPeelableSuffix
         ? packFuzzySingleWordMatch(
           core: core, coreLower: coreLower, lookups: lookups, domainShapedOnly: true)
-        : nil
+        : .noCandidate
       let peeledPackFuzzy =
         matchCoreEligible
         ? packFuzzySingleWordMatch(
           core: matchCore, coreLower: matchCoreLower, lookups: lookups, domainShapedOnly: false)
-        : nil
+        : .noCandidate
       // Nothing follows the pack tier, so ambiguous and no-candidate both
       // resolve to the same "leave it alone" outcome here.
       if case .accepted(let result) = strongerOf(unpeeledPackFuzzy, peeledPackFuzzy) {
@@ -1209,18 +1216,33 @@ public struct WordCorrector: Sendable {
   /// domain-shaped candidate -- both sides then carry a suffix, so nothing
   /// is silently swallowed); the peeled call site passes `false` (the
   /// ordinary, unrestricted pool).
+  /// A single attempt's fuzzy result must distinguish "genuinely ambiguous"
+  /// from "no candidate scored close at all" (Codex cloud review, PR #2298,
+  /// round 17): collapsing both to the same `nil` let an in-pass ambiguity
+  /// (two DIFFERENT candidates within `ambiguityMargin` of each other) read
+  /// as "this attempt found nothing," which let a lower-authority pack
+  /// match decide a token the non-pack tier had already found genuinely
+  /// uncertain -- the identical shape round 16 fixed one layer up, for the
+  /// cross-attempt (unpeeled vs. peeled) comparison instead of this
+  /// within-attempt one.
+  private enum SingleAttemptFuzzyOutcome {
+    case candidate(canonical: String, score: Double)
+    case ambiguous
+    case noCandidate
+  }
+
   private func nonPackFuzzySingleWordMatch(
     core: String, coreLower: String,
     lookups: Lookups,
     domainShapedOnly: Bool
-  ) -> (canonical: String, score: Double)? {
+  ) -> SingleAttemptFuzzyOutcome {
     let singleFuzzyCandidates = lookups.singleFuzzyCandidates
     let canonicalToWord = lookups.canonicalToWord
     let lowercasedCanonicals = lookups.lowercasedCanonicals
     let canonicals = lookups.canonicals
 
     // Skip fuzzy for very short tokens
-    guard core.count >= 3 else { return nil }
+    guard core.count >= 3 else { return .noCandidate }
 
     // Determine threshold based on token length
     let effectiveThreshold =
@@ -1270,27 +1292,29 @@ public struct WordCorrector: Sendable {
     let pass4Override = canonicalToWord[bestMatch.lowercased()]?.minSimilarityOverride
     let pass4Threshold =
       pass4Override ?? (effectiveThreshold + pass4VocabPenalty - pass4LengthAdj)
-    if bestScore >= pass4Threshold,
-      bestScore - secondBest >= Self.ambiguityMargin,
-      core != bestMatch
-    {
+    let pass4Margin = bestScore - secondBest
+    if bestScore >= pass4Threshold, pass4Margin >= Self.ambiguityMargin, core != bestMatch {
       #if DEBUG
         Self.logger.debug(
-          "WordCorrector: type=alias-fuzzy source='\(core)' target='\(bestMatch)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(bestScore - secondBest, format: .fixed(precision: 3)) threshold=\(pass4Threshold, format: .fixed(precision: 3))"
+          "WordCorrector: type=alias-fuzzy source='\(core)' target='\(bestMatch)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(pass4Margin, format: .fixed(precision: 3)) threshold=\(pass4Threshold, format: .fixed(precision: 3))"
         )
       #endif
-      return (bestMatch, bestScore)
+      return .candidate(canonical: bestMatch, score: bestScore)
+    } else if bestScore >= pass4Threshold, pass4Margin < Self.ambiguityMargin {
+      // Score clears the bar but the margin over the runner-up does not --
+      // this is a genuine ambiguity between two DIFFERENT candidates, not
+      // "nothing scored close." Stop here rather than trying Pass 5, whose
+      // canonical pool answers a different question and cannot resolve
+      // THIS ambiguity (round 17).
+      #if DEBUG
+        Self.logger.debug(
+          "WordCorrector: REJECT pass=alias-fuzzy source='\(core)' best_target='\(bestMatch)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(pass4Margin, format: .fixed(precision: 3)) threshold=\(pass4Threshold, format: .fixed(precision: 3)) reason=below_margin"
+        )
+      #endif
+      return .ambiguous
     } else if bestScore > 0 {
       #if DEBUG
-        let pass4Margin = bestScore - secondBest
-        let reason: String
-        if bestScore < pass4Threshold {
-          reason = "below_threshold"
-        } else if pass4Margin < Self.ambiguityMargin {
-          reason = "below_margin"
-        } else {
-          reason = "same_as_input"
-        }
+        let reason = bestScore < pass4Threshold ? "below_threshold" : "same_as_input"
         Self.logger.debug(
           "WordCorrector: REJECT pass=alias-fuzzy source='\(core)' best_target='\(bestMatch)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(pass4Margin, format: .fixed(precision: 3)) threshold=\(pass4Threshold, format: .fixed(precision: 3)) reason=\(reason)"
         )
@@ -1324,34 +1348,31 @@ public struct WordCorrector: Sendable {
     let pass5Override = canonicalToWord[bestMatch.lowercased()]?.minSimilarityOverride
     let pass5Threshold =
       pass5Override ?? (effectiveThreshold + pass5VocabPenalty - pass5LengthAdj)
-    if bestScore >= pass5Threshold,
-      bestScore - secondBest >= Self.ambiguityMargin,
-      core != bestMatch
-    {
+    let pass5Margin = bestScore - secondBest
+    if bestScore >= pass5Threshold, pass5Margin >= Self.ambiguityMargin, core != bestMatch {
       #if DEBUG
         Self.logger.debug(
-          "WordCorrector: type=canonical-fuzzy source='\(core)' target='\(bestMatch)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(bestScore - secondBest, format: .fixed(precision: 3)) threshold=\(pass5Threshold, format: .fixed(precision: 3))"
+          "WordCorrector: type=canonical-fuzzy source='\(core)' target='\(bestMatch)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(pass5Margin, format: .fixed(precision: 3)) threshold=\(pass5Threshold, format: .fixed(precision: 3))"
         )
       #endif
-      return (bestMatch, bestScore)
+      return .candidate(canonical: bestMatch, score: bestScore)
+    } else if bestScore >= pass5Threshold, pass5Margin < Self.ambiguityMargin {
+      #if DEBUG
+        Self.logger.debug(
+          "WordCorrector: REJECT pass=canonical-fuzzy source='\(core)' best_target='\(bestMatch)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(pass5Margin, format: .fixed(precision: 3)) threshold=\(pass5Threshold, format: .fixed(precision: 3)) reason=below_margin"
+        )
+      #endif
+      return .ambiguous
     } else if bestScore > 0 {
       #if DEBUG
-        let pass5Margin = bestScore - secondBest
-        let reason: String
-        if bestScore < pass5Threshold {
-          reason = "below_threshold"
-        } else if pass5Margin < Self.ambiguityMargin {
-          reason = "below_margin"
-        } else {
-          reason = "same_as_input"
-        }
+        let reason = bestScore < pass5Threshold ? "below_threshold" : "same_as_input"
         Self.logger.debug(
           "WordCorrector: REJECT pass=canonical-fuzzy source='\(core)' best_target='\(bestMatch)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(pass5Margin, format: .fixed(precision: 3)) threshold=\(pass5Threshold, format: .fixed(precision: 3)) reason=\(reason)"
         )
       #endif
     }
 
-    return nil
+    return .noCandidate
   }
 
   /// #992 PACK FUZZY TIER — LOWER authority. Split from the non-pack fuzzy
@@ -1367,13 +1388,13 @@ public struct WordCorrector: Sendable {
     core: String, coreLower: String,
     lookups: Lookups,
     domainShapedOnly: Bool
-  ) -> (canonical: String, score: Double)? {
+  ) -> SingleAttemptFuzzyOutcome {
     let packSingleFuzzyCandidates = lookups.packSingleFuzzyCandidates
     let packCanonicals = lookups.packCanonicals
     let packLowercasedCanonicals = lookups.packLowercasedCanonicals
     let nonPackExactKeys = lookups.nonPackExactKeys
 
-    guard core.count >= 3 else { return nil }
+    guard core.count >= 3 else { return .noCandidate }
     let effectiveThreshold =
       core.count <= Self.shortTokenMaxLength
       ? Self.shortTokenThreshold
@@ -1385,7 +1406,7 @@ public struct WordCorrector: Sendable {
     // must not rewrite it. This covers the case where non-pack matching
     // produced no replacement precisely because no fix was needed.
     if nonPackExactKeys.contains(coreLower) {
-      return nil
+      return .noCandidate
     }
 
     // Pack Pass 4: single-word pack aliases.
@@ -1416,7 +1437,8 @@ public struct WordCorrector: Sendable {
       let lengthAdj = Self.lengthAwareAdjustment(candidateLength: pMatch.count)
       let packThreshold =
         effectiveThreshold + vocabPenalty - lengthAdj + Self.packFuzzyThresholdBump
-      if pBest >= packThreshold, pBest - pSecond >= Self.ambiguityMargin, core != pMatch {
+      let pMargin = pBest - pSecond
+      if pBest >= packThreshold, pMargin >= Self.ambiguityMargin, core != pMatch {
         if coreLower == pMatch.lowercased() {
           // Casing guard: case-only change — suppress, fall through.
           #if DEBUG
@@ -1427,11 +1449,20 @@ public struct WordCorrector: Sendable {
         } else {
           #if DEBUG
             Self.logger.debug(
-              "WordCorrector: type=pack-alias-fuzzy source='\(core)' target='\(pMatch)' score=\(pBest, format: .fixed(precision: 3)) margin=\(pBest - pSecond, format: .fixed(precision: 3)) threshold=\(packThreshold, format: .fixed(precision: 3))"
+              "WordCorrector: type=pack-alias-fuzzy source='\(core)' target='\(pMatch)' score=\(pBest, format: .fixed(precision: 3)) margin=\(pMargin, format: .fixed(precision: 3)) threshold=\(packThreshold, format: .fixed(precision: 3))"
             )
           #endif
-          return (pMatch, pBest)
+          return .candidate(canonical: pMatch, score: pBest)
         }
+      } else if pBest >= packThreshold, pMargin < Self.ambiguityMargin {
+        // Same "genuinely ambiguous, not merely absent" distinction as the
+        // non-pack Pass 4 above (round 17).
+        #if DEBUG
+          Self.logger.debug(
+            "WordCorrector: REJECT pass=pack-alias-fuzzy source='\(core)' best_target='\(pMatch)' score=\(pBest, format: .fixed(precision: 3)) margin=\(pMargin, format: .fixed(precision: 3)) threshold=\(packThreshold, format: .fixed(precision: 3)) reason=below_margin"
+          )
+        #endif
+        return .ambiguous
       }
     }
 
@@ -1458,7 +1489,8 @@ public struct WordCorrector: Sendable {
       let lengthAdj = Self.lengthAwareAdjustment(candidateLength: pMatch.count)
       let packThreshold =
         effectiveThreshold + vocabPenalty - lengthAdj + Self.packFuzzyThresholdBump
-      if pBest >= packThreshold, pBest - pSecond >= Self.ambiguityMargin, core != pMatch {
+      let pMargin = pBest - pSecond
+      if pBest >= packThreshold, pMargin >= Self.ambiguityMargin, core != pMatch {
         if coreLower == pMatch.lowercased() {
           #if DEBUG
             Self.logger.debug(
@@ -1468,15 +1500,22 @@ public struct WordCorrector: Sendable {
         } else {
           #if DEBUG
             Self.logger.debug(
-              "WordCorrector: type=pack-canonical-fuzzy source='\(core)' target='\(pMatch)' score=\(pBest, format: .fixed(precision: 3)) margin=\(pBest - pSecond, format: .fixed(precision: 3)) threshold=\(packThreshold, format: .fixed(precision: 3))"
+              "WordCorrector: type=pack-canonical-fuzzy source='\(core)' target='\(pMatch)' score=\(pBest, format: .fixed(precision: 3)) margin=\(pMargin, format: .fixed(precision: 3)) threshold=\(packThreshold, format: .fixed(precision: 3))"
             )
           #endif
-          return (pMatch, pBest)
+          return .candidate(canonical: pMatch, score: pBest)
         }
+      } else if pBest >= packThreshold, pMargin < Self.ambiguityMargin {
+        #if DEBUG
+          Self.logger.debug(
+            "WordCorrector: REJECT pass=pack-canonical-fuzzy source='\(core)' best_target='\(pMatch)' score=\(pBest, format: .fixed(precision: 3)) margin=\(pMargin, format: .fixed(precision: 3)) threshold=\(packThreshold, format: .fixed(precision: 3)) reason=below_margin"
+          )
+        #endif
+        return .ambiguous
       }
     }
 
-    return nil
+    return .noCandidate
   }
 
   // MARK: - Scoring

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -952,6 +952,29 @@ public struct WordCorrector: Sendable {
         unpeeledMatch = (canonical, isPack)
       }
 
+      func acceptExact(unpeeled: Bool, _ match: (canonical: String, isPack: Bool)) -> String {
+        appendReplacement(forCanonical: match.canonical)
+        #if DEBUG
+          Self.logger.debug(
+            "WordCorrector: type=alias source='\(unpeeled ? core : matchCore)' target='\(match.canonical)'"
+          )
+        #endif
+        return unpeeled ? prefix + match.canonical + suffix : reattached(match.canonical)
+      }
+
+      // An UNPEELED non-pack exact replace is the single highest-priority
+      // outcome in this whole retry -- a deliberate, complete registration
+      // for the token exactly as typed -- so it must win before anything
+      // peeled is even consulted, including a peeled `.alreadyCorrect`
+      // (Codex cloud review, PR #2298, round 11): canonical "GitHub" (a
+      // self-entry the peeled bare form matches exactly) does not get to
+      // override a SEPARATE, deliberately-registered alias "GitHub.com" ->
+      // "Company Portal" just because the peeled half also happens to
+      // resolve to something.
+      if let match = unpeeledMatch, !match.isPack {
+        return acceptExact(unpeeled: true, match)
+      }
+
       let peeledExact =
         matchCoreEligible
         ? exactSingleWordMatch(core: matchCore, coreLower: matchCoreLower, lookups: lookups)
@@ -963,31 +986,18 @@ public struct WordCorrector: Sendable {
       // `.alreadyCorrect` on the PEELED form means the bare part was
       // already spelled right, so the untouched original token (bare part
       // + its existing suffix) is already the correct output -- but that
-      // conclusion is only valid if nothing else is allowed to override it
-      // afterward. An earlier version of this comment claimed the "falls
-      // through to the final `return token`" path made this automatic; it
-      // does not, because `peeledMatch` staying nil here is indistinguishable
-      // from `.noMatch`, so a LOWER-authority pack exact match (or even a
-      // fuzzy match) found afterward could still win and replace text that
-      // was already correct (local Codex sweep of PR #2298's cloud
-      // findings, same day: canonical "GitHub" + pack alias "github.com" ->
-      // "Wrong" turned input "GitHub.com" into "Wrong" instead of leaving
-      // it alone). Stop here, exactly like the unpeeled case above.
+      // conclusion is only valid if nothing HIGHER-priority already claimed
+      // this token, which the unpeeled non-pack check just above already
+      // ruled out. Without a signal of its own, `peeledMatch` staying nil
+      // here would be indistinguishable from `.noMatch`, letting a
+      // LOWER-authority pack exact match (or even a fuzzy match) found
+      // afterward win and replace text that was already correct (local
+      // Codex sweep of PR #2298's cloud findings: canonical "GitHub" + pack
+      // alias "github.com" -> "Wrong" turned input "GitHub.com" into
+      // "Wrong" instead of leaving it alone). Stop here, exactly like the
+      // unpeeled case above -- just one priority level later.
       if case .alreadyCorrect = peeledExact { return token }
 
-      func acceptExact(unpeeled: Bool, _ match: (canonical: String, isPack: Bool)) -> String {
-        appendReplacement(forCanonical: match.canonical)
-        #if DEBUG
-          Self.logger.debug(
-            "WordCorrector: type=alias source='\(unpeeled ? core : matchCore)' target='\(match.canonical)'"
-          )
-        #endif
-        return unpeeled ? prefix + match.canonical + suffix : reattached(match.canonical)
-      }
-
-      if let match = unpeeledMatch, !match.isPack {
-        return acceptExact(unpeeled: true, match)
-      }
       if let match = peeledMatch, !match.isPack {
         return acceptExact(unpeeled: false, match)
       }
@@ -1156,7 +1166,15 @@ public struct WordCorrector: Sendable {
     for entry in singleFuzzyCandidates {
       let surface = entry.surface
       let canonical = entry.canonical
-      if domainShapedOnly, !Self.isDomainShaped(surface), !Self.isDomainShaped(canonical) {
+      // Admission must key off `surface` alone, never `canonical` too: the
+      // comparison two lines below is `coreLower` (the raw, unpeeled input)
+      // against `surface` -- the apples-to-apples reasoning that makes raw
+      // comparison safe only holds when the SURFACE being scored is itself
+      // domain-shaped. Admitting on a domain-shaped CANONICAL with a bare
+      // surface let a long bare alias absorb the glued suffix as scoring
+      // noise, reproducing the original bug through this pass instead
+      // (Codex cloud review, PR #2298, round 11).
+      if domainShapedOnly, !Self.isDomainShaped(surface) {
         continue
       }
       // Length-ratio pruning: skip if lengths differ too much for threshold
@@ -1307,9 +1325,10 @@ public struct WordCorrector: Sendable {
       var pSecond = 0.0
       var pMatch = ""
       for entry in packSingleFuzzyCandidates {
-        if domainShapedOnly, !Self.isDomainShaped(entry.surface),
-          !Self.isDomainShaped(entry.canonical)
-        {
+        // Same fix as the non-pack Pass 4 above: admission keys off the
+        // SURFACE alone, since that is what's actually scored against
+        // `coreLower` below (Codex cloud review, PR #2298, round 11).
+        if domainShapedOnly, !Self.isDomainShaped(entry.surface) {
           continue
         }
         let surfLen = entry.surface.count

--- a/Tests/EnviousWisprTests/PostProcessing/WordCorrectorGluedDomainSuffixTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/WordCorrectorGluedDomainSuffixTests.swift
@@ -512,4 +512,47 @@ struct WordCorrectorGluedDomainSuffixTests {
     #expect(result.text == "пример.рф")
     #expect(result.replacements == 1)
   }
+
+  // MARK: Cloud Codex review, round 2 (PR #2298) -- an unpeeled non-pack
+  // exact replace must beat a peeled already-correct match, and the
+  // domain-restricted raw fuzzy pass must key admission off what it
+  // actually scores (the alias SURFACE), not the canonical.
+
+  @Test("An unpeeled non-pack exact replace outranks a peeled already-correct match")
+  func unpeeledReplaceOutranksPeeledAlreadyCorrect() {
+    // Cloud review round 2: canonical "GitHub" is a self-entry the peeled
+    // bare form "GitHub" matches exactly (already correct) -- but a
+    // SEPARATE, deliberately registered alias "GitHub.com" -> "Company
+    // Portal" names the whole glued string directly. The deliberate,
+    // complete registration must win; the peeled self-match must not be
+    // allowed to short-circuit ahead of it.
+    let bareCanonical = CustomWord(canonical: "GitHub", aliases: [])
+    let domainAlias = CustomWord(canonical: "Company Portal", aliases: ["GitHub.com"])
+    let result = corrected("GitHub.com", [bareCanonical, domainAlias])
+    #expect(result.text == "Company Portal")
+    #expect(result.replacements == 1)
+  }
+
+  @Test("The domain-restricted raw fuzzy pass admits candidates by SURFACE, not canonical")
+  func domainRestrictedFuzzyAdmitsBySurfaceNotCanonical() {
+    // Cloud review round 2: the raw (unpeeled) domain-restricted pass
+    // scores `coreLower` against each candidate's SURFACE, but the
+    // admission check used to also let a candidate in when only its
+    // CANONICAL was domain-shaped -- a mismatch between what's admitted
+    // and what's actually compared. Structural fix verified by reading
+    // the code (grep for "domainShapedOnly, !Self.isDomainShaped" shows
+    // both Pass 4 sites now check surface alone); this pins the intended
+    // end-to-end behavior for the shape the review named. Note: this
+    // specific input does not observably distinguish the fixed admission
+    // from the old one, because a domain-shaped matched canonical already
+    // suppresses reattach either way (round 3/4's dedup design) -- the old
+    // bug is only reachable by winning against a DIFFERENT, correct
+    // candidate under raw-vs-peeled scoring noise, which this test does
+    // not attempt to reconstruct.
+    let word = CustomWord(
+      canonical: "SomeLongBrandName.com", aliases: ["someverylongbarealiasnameindeed"])
+    let result = corrected("someverylongbarealiasnameindeed.org", [word])
+    #expect(result.text == "SomeLongBrandName.com")
+    #expect(result.replacements == 1)
+  }
 }

--- a/Tests/EnviousWisprTests/PostProcessing/WordCorrectorGluedDomainSuffixTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/WordCorrectorGluedDomainSuffixTests.swift
@@ -52,13 +52,19 @@ struct WordCorrectorGluedDomainSuffixTests {
     #expect(result.replacements == 1)
   }
 
-  @Test("An UNRECOGNIZED trailing suffix is left as part of the match, unchanged shape")
-  func unrecognizedSuffixIsNotTreatedAsATLD() {
-    // ".zzz" is not in the closed TLD list this fix reuses, so the token is
-    // handled exactly as before this fix -- no special-casing invented for
-    // strings that merely look domain-shaped.
+  @Test("A suffix outside the recognized-TLD list ALSO survives (Codex round 3)")
+  func suffixOutsideTheAllowlistAlsoSurvives() {
+    // Superseded by Codex review round 3, P1: the peel trigger used to be
+    // `recognizedTLDs` itself, so ".zzz" -- not in that ten-item list --
+    // stayed unpeeled and fuzzy matching swallowed it exactly like the
+    // original bug. The trigger is now any letter/digit/hyphen run after a
+    // dot, so this survives too. `suffixOutsideAllowlistStillSurvives`
+    // below covers the same shape for real-looking TLDs; this pins a
+    // clearly-not-a-TLD string to prove the trigger isn't secretly still an
+    // allowlist under a different name.
     let result = corrected("Enviousvisper.zzz")
-    #expect(result.text != "EnviousWispr.zzz")
+    #expect(result.text == "EnviousWispr.zzz")
+    #expect(result.replacements == 1)
   }
 
   @Test("A fuzzy (near-miss spelling) match ALSO keeps a glued TLD")
@@ -151,6 +157,52 @@ struct WordCorrectorGluedDomainSuffixTests {
     // retry path, where "githab" DOES exact-match. Blindly reattaching the
     // peeled ".com" would produce "GitHub.com.com".
     let result = corrected("githab.com", [Self.gitHubBareAlias])
+    #expect(result.text == "GitHub.com")
+    #expect(result.replacements == 1)
+  }
+
+  // MARK: Codex review round 3 findings -- the peel trigger, the reattach
+  // dedup, and the domain-shaped fuzzy path all needed to widen past the
+  // narrow ten-TLD allowlist.
+
+  @Test("A glued suffix OUTSIDE the recognized-TLD allowlist still survives correction")
+  func suffixOutsideAllowlistStillSurvives() {
+    // Codex review round 3, P1: the peel trigger was `recognizedTLDs`
+    // itself, so a suffix like ".us" (not in that ten-item list) left the
+    // token unpeeled, and fuzzy matching swallowed it exactly like the
+    // original bug. The trigger no longer depends on that allowlist.
+    for tld in ["us", "uk", "tech", "info"] {
+      let result = corrected("Enviousvisper.\(tld)")
+      #expect(result.text == "EnviousWispr.\(tld)", "'.\(tld)' should survive, allowlist or not")
+      #expect(result.replacements == 1)
+    }
+  }
+
+  private static let gitHubDomainAliasNearMiss = CustomWord(
+    canonical: "GitHub.com", aliases: ["githab.com"], category: .brand)
+
+  @Test("A near-miss (fuzzy) spelling of a domain-shaped alias still matches unpeeled")
+  func fuzzyMatchOnDomainShapedAliasStillWorks() {
+    // Codex review round 3, P1: peeling ALWAYS before matching broke fuzzy
+    // correction for a domain-valued alias. "githib.com" is a one-letter
+    // near miss of the alias "githab.com" -- comparing the whole glued
+    // strings (both carrying ".com") scores high; peeling first strips the
+    // TLD from only the INPUT side and the match is lost.
+    let result = corrected("githib.com", [Self.gitHubDomainAliasNearMiss])
+    #expect(result.text == "GitHub.com")
+    #expect(result.replacements == 1)
+  }
+
+  @Test(
+    "A peeled suffix that DIFFERS from the matched canonical's own TLD is still dropped, not appended"
+  )
+  func mismatchedPeeledSuffixStillDroppedNotAppended() {
+    // Codex review round 3, P2: the dedup check only compared the peeled
+    // suffix against the SAME suffix on the canonical. Canonical
+    // "GitHub.com" matched via bare alias "githab", with input carrying a
+    // DIFFERENT recognized TLD (".org"), still produced "GitHub.com.org".
+    // The canonical is domain-shaped at all, so its own TLD wins outright.
+    let result = corrected("githab.org", [Self.gitHubBareAlias])
     #expect(result.text == "GitHub.com")
     #expect(result.replacements == 1)
   }

--- a/Tests/EnviousWisprTests/PostProcessing/WordCorrectorGluedDomainSuffixTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/WordCorrectorGluedDomainSuffixTests.swift
@@ -450,4 +450,66 @@ struct WordCorrectorGluedDomainSuffixTests {
     #expect(result.text == "EnviousWispr.xn--p1ai")
     #expect(result.replacements == 1)
   }
+
+  // MARK: Cloud Codex review (PR #2298) findings -- an already-correct
+  // unpeeled exact match must stop the whole retry, and the dedup check
+  // must recognize punycode canonicals it did not curate by string.
+
+  @Test("An already-correct unpeeled exact match is never overridden by an unrelated peeled match")
+  func alreadyCorrectUnpeeledNeverOverriddenByPeeled() {
+    // Cloud review, P2: core "GitHub.com" is ALREADY exactly a registered
+    // canonical, so no correction is needed -- but an unrelated alias
+    // "github" (the peeled bare form) mapping to a DIFFERENT canonical
+    // ("Other") could still win if the peeled attempt were tried anyway.
+    let githubDomain = CustomWord(canonical: "GitHub.com", aliases: [])
+    let githubBare = CustomWord(canonical: "Other", aliases: ["github"])
+    let result = corrected("GitHub.com", [githubDomain, githubBare])
+    #expect(result.text == "GitHub.com")
+    #expect(result.replacements == 0)
+  }
+
+  @Test("A canonical that IS a punycode domain suppresses a mismatched reattach")
+  func punycodeCanonicalSuppressesMismatchedReattach() {
+    // Cloud review, P2: `isDomainShaped` only checked the curated real-word
+    // TLD list, which can never contain an "xn--..." string, so a bare
+    // alias whose canonical is an internationalized domain in its ASCII
+    // form ("xn--e1afmkfd.xn--p1ai") was never recognized as domain-shaped
+    // -- "primer.org" would have produced a duplicated suffix.
+    let word = CustomWord(canonical: "xn--e1afmkfd.xn--p1ai", aliases: ["primer"])
+    let result = corrected("primer.org", [word])
+    #expect(result.text == "xn--e1afmkfd.xn--p1ai")
+    #expect(result.replacements == 1)
+  }
+
+  // MARK: Local Codex sweep (same day, same PR) of the cloud review's own
+  // findings -- a peeled already-correct exact match needed the same
+  // short-circuit as the unpeeled one, and a NATIVE-script (not punycode)
+  // internationalized TLD needed dedup recognition too.
+
+  @Test("A peeled already-correct exact match is never overridden by a pack exact match")
+  func peeledAlreadyCorrectExactNeverOverriddenByPack() {
+    // Local Codex sweep: the peeled bare form "GitHub" is already exactly
+    // the user's own canonical -- no correction needed at all -- but a
+    // pack alias "github.com" -> "Wrong" (a lower-authority, unrelated
+    // match) could still win if peeled .alreadyCorrect were silently
+    // dropped the way it originally was.
+    let userCanonical = CustomWord(canonical: "GitHub", aliases: [])
+    let packDomain = CustomWord(canonical: "Wrong", aliases: ["github.com"], source: .pack)
+    let result = corrected("GitHub.com", [userCanonical, packDomain])
+    #expect(result.text == "GitHub.com")
+    #expect(result.replacements == 0)
+  }
+
+  @Test("A canonical that IS a native-script (non-punycode) IDN suppresses a mismatched reattach")
+  func nativeScriptIDNCanonicalSuppressesMismatchedReattach() {
+    // Local Codex sweep: `isDomainShaped`'s punycode fix (round 9) only
+    // covered the ASCII "xn--..." encoding. A canonical that is itself an
+    // internationalized domain written in its OWN native Unicode script
+    // (".рф" as literal Cyrillic, never converted to punycode) still
+    // failed dedup and would have produced "пример.рф.org".
+    let word = CustomWord(canonical: "пример.рф", aliases: ["primer"])
+    let result = corrected("primer.org", [word])
+    #expect(result.text == "пример.рф")
+    #expect(result.replacements == 1)
+  }
 }

--- a/Tests/EnviousWisprTests/PostProcessing/WordCorrectorGluedDomainSuffixTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/WordCorrectorGluedDomainSuffixTests.swift
@@ -415,4 +415,39 @@ struct WordCorrectorGluedDomainSuffixTests {
     #expect(result.text == "UserChoice.com")
     #expect(result.replacements == 1)
   }
+
+  // MARK: Codex review round 8 findings -- exact-match authority must key
+  // off the matched KEY, not the resulting canonical TEXT, and a punycode
+  // TLD label is a real, valid domain suffix despite containing digits
+  // and hyphens.
+
+  @Test("Non-pack exact still outranks pack exact when both happen to share a canonical")
+  func nonPackExactOutranksPackExactEvenWithSharedCanonical() {
+    // Codex review round 8, P1: attributing authority via
+    // canonicalToWord[canonical] breaks when a pack alias and an unrelated
+    // user word happen to share the same canonical TEXT ("Shared") -- the
+    // pack-owned exact match gets misattributed as non-pack because the
+    // user's OTHER word claimed that canonical string first. The user's
+    // real "githib" -> "UserChoice" alias must still win.
+    let packWord = CustomWord(
+      canonical: "Shared", aliases: ["githib.com"], category: .brand, source: .pack)
+    let userSharedCanonical = CustomWord(
+      canonical: "Shared", aliases: [], category: .brand, source: .user)
+    let userChoice = CustomWord(
+      canonical: "UserChoice", aliases: ["githib"], category: .brand, source: .user)
+    let result = corrected("githib.com", [packWord, userSharedCanonical, userChoice])
+    #expect(result.text == "UserChoice.com")
+    #expect(result.replacements == 1)
+  }
+
+  @Test("A punycode (internationalized) TLD is peeled and reattached correctly")
+  func punycodeTLDIsPeeledAndReattachedCorrectly() {
+    // Codex review round 8, P2: an internationalized domain's ASCII form
+    // always carries its TLD as "xn--" + alphanumerics/hyphens (Russia's
+    // .рф is .xn--p1ai). The all-letters-only rule that excludes version
+    // numbers and IPs also excluded this real, valid domain suffix.
+    let result = corrected("Enviousvisper.xn--p1ai")
+    #expect(result.text == "EnviousWispr.xn--p1ai")
+    #expect(result.replacements == 1)
+  }
 }

--- a/Tests/EnviousWisprTests/PostProcessing/WordCorrectorGluedDomainSuffixTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/WordCorrectorGluedDomainSuffixTests.swift
@@ -395,4 +395,24 @@ struct WordCorrectorGluedDomainSuffixTests {
       #expect(result.replacements == 0)
     }
   }
+
+  // MARK: Codex review round 7, P1 -- non-pack exact must outrank pack
+  // exact even across the peel boundary, not only within one attempt.
+
+  @Test(
+    "A user's own bare exact alias, reachable only by peeling, still outranks a pack exact domain match"
+  )
+  func userBareExactOutranksPackExactDomainAcrossPeelBoundary() {
+    // "githib.com" is registered as a PACK-sourced exact alias; "githib"
+    // (bare) is registered as the USER's own exact alias. Accepting the
+    // unpeeled pack match immediately -- before even trying the peeled
+    // form -- would preempt the higher-authority user match one step away.
+    let packWord = CustomWord(
+      canonical: "PackDomain.com", aliases: ["githib.com"], category: .brand, source: .pack)
+    let userWord = CustomWord(
+      canonical: "UserChoice", aliases: ["githib"], category: .brand, source: .user)
+    let result = corrected("githib.com", [packWord, userWord])
+    #expect(result.text == "UserChoice.com")
+    #expect(result.replacements == 1)
+  }
 }

--- a/Tests/EnviousWisprTests/PostProcessing/WordCorrectorGluedDomainSuffixTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/WordCorrectorGluedDomainSuffixTests.swift
@@ -256,4 +256,55 @@ struct WordCorrectorGluedDomainSuffixTests {
     #expect(result.text == "GitHub.us")
     #expect(result.replacements == 1)
   }
+
+  // MARK: Not a US-only fix. Founder correction (2026-08-21): this app is
+  // used internationally, so the domain-suffix shape has to work for
+  // accented, non-Latin-script, and multi-part (ccTLD + SLD) domains too --
+  // not only plain ASCII words glued to ".com".
+
+  @Test("A single-word ACCENTED brand keeps a glued TLD")
+  func accentedSingleWordBrandKeepsGluedTLD() {
+    let word = CustomWord(canonical: "Café", aliases: ["cafeh"], category: .brand)
+    let result = corrected("cafeh.com", [word])
+    #expect(result.text == "Café.com")
+    #expect(result.replacements == 1)
+  }
+
+  @Test("A CYRILLIC brand corrects a near-miss and keeps a glued TLD")
+  func cyrillicBrandCorrectsFuzzyMissAndKeepsGluedTLD() {
+    let word = CustomWord(canonical: "Привет", aliases: ["привет"], category: .brand)
+    let result = corrected("привед.com", [word])
+    #expect(result.text == "Привет.com")
+    #expect(result.replacements == 1)
+  }
+
+  @Test(
+    "A two-part ccTLD (.co.jp, .co.uk, .com.au) is peeled and reattached whole, not just its last label"
+  )
+  func twoPartCcTLDPeeledAsOneUnit() {
+    // Common everyday domain shape outside the US -- Japan (.co.jp), the UK
+    // (.co.uk), Australia (.com.au). Peeling only the LAST label (the
+    // original design) left "GitHub.co" behind and lost ".jp" outright, or
+    // failed to match a bare alias at all because the leftover ".co" was
+    // still noise on the comparison.
+    let jp = CustomWord(canonical: "任天堂", aliases: ["にんてんどう"], category: .brand)
+    #expect(corrected("にんてんどう.co.jp", [jp]).text == "任天堂.co.jp")
+
+    let uk = CustomWord(canonical: "GitHub", aliases: ["githab"], category: .brand)
+    #expect(corrected("githab.co.uk", [uk]).text == "GitHub.co.uk")
+
+    let au = CustomWord(canonical: "EnviousWispr", aliases: ["Enviousvisper"], category: .brand)
+    #expect(corrected("Enviousvisper.com.au", [au]).text == "EnviousWispr.com.au")
+  }
+
+  @Test("A canonical that is ITSELF a two-part ccTLD domain suppresses reattach correctly")
+  func canonicalItselfTwoPartCcTLDSuppressesReattach() {
+    // The dedup check (finding P2) must recognize "GitHub.co.uk" as
+    // domain-shaped just as readily as "GitHub.com", so a mismatched
+    // peeled suffix is still dropped rather than appended.
+    let word = CustomWord(canonical: "GitHub.co.uk", aliases: ["githab"], category: .brand)
+    let result = corrected("githab.org", [word])
+    #expect(result.text == "GitHub.co.uk")
+    #expect(result.replacements == 1)
+  }
 }

--- a/Tests/EnviousWisprTests/PostProcessing/WordCorrectorGluedDomainSuffixTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/WordCorrectorGluedDomainSuffixTests.swift
@@ -206,4 +206,54 @@ struct WordCorrectorGluedDomainSuffixTests {
     #expect(result.text == "GitHub.com")
     #expect(result.replacements == 1)
   }
+
+  // MARK: Codex review round 4 findings -- exact/user precedence over a
+  // fuzzy/pack match reachable only by peeling, and the same narrow-
+  // allowlist inconsistency in the dedup check itself.
+
+  private static let githibExactUserAlias = CustomWord(
+    canonical: "GitHub Issue Board", aliases: ["githib"], category: .brand, source: .user)
+  private static let githabDomainPackAlias = CustomWord(
+    canonical: "GitHub.com", aliases: ["githab.com"], category: .brand, source: .pack)
+
+  @Test("A user's own exact alias, reachable only by peeling, still outranks a fuzzy pack match")
+  func exactUserAliasOutranksFuzzyPackMatch() {
+    // Codex review round 4, P1: the unpeeled domain-restricted FUZZY pass
+    // ran before the PEELED exact pass, so a fuzzy pack-tier hit on the raw
+    // token ("githib.com" scored against pack alias "githab.com") could
+    // preempt the user's own exact alias "githib", which only becomes
+    // reachable once the ".com" is peeled off. Exact always beats fuzzy,
+    // and user always beats pack -- both must hold regardless of whether
+    // peeling is involved.
+    let result = corrected(
+      "githib.com", [Self.githibExactUserAlias, Self.githabDomainPackAlias])
+    #expect(result.text == "GitHub Issue Board.com")
+    #expect(result.replacements == 1)
+  }
+
+  private static let gitHubUnusualTLDBareAlias = CustomWord(
+    canonical: "GitHub.us", aliases: ["githab"], category: .brand)
+
+  @Test("Dedup recognizes a saved domain using a TLD outside the old allowlist too")
+  func dedupRecognizesDomainCanonicalOutsideAllowlist() {
+    // Codex review round 4, P2: `isDomainShaped` still used the narrow
+    // ten-item TLD list even after the PEEL trigger was widened past it, so
+    // a saved canonical like "GitHub.us" (".us" not in that list) was not
+    // recognized as domain-shaped -- "githab.org" through this alias
+    // produced "GitHub.us.org" instead of trusting the canonical's own TLD.
+    let result = corrected("githab.org", [Self.gitHubUnusualTLDBareAlias])
+    #expect(result.text == "GitHub.us")
+    #expect(result.replacements == 1)
+  }
+
+  @Test("A near-miss of a domain-shaped alias using a TLD outside the old allowlist still matches")
+  func fuzzyDomainMatchOutsideAllowlistStillWorks() {
+    // Codex review round 4, P2, other half: the raw domain-restricted fuzzy
+    // pass (round 3, P1) is gated by the same `isDomainShaped` check, so a
+    // domain-shaped alias using an unusual TLD was invisible to it too.
+    let alias = CustomWord(canonical: "GitHub.us", aliases: ["githab.us"], category: .brand)
+    let result = corrected("githib.us", [alias])
+    #expect(result.text == "GitHub.us")
+    #expect(result.replacements == 1)
+  }
 }

--- a/Tests/EnviousWisprTests/PostProcessing/WordCorrectorGluedDomainSuffixTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/WordCorrectorGluedDomainSuffixTests.swift
@@ -139,4 +139,19 @@ struct WordCorrectorGluedDomainSuffixTests {
       #expect(result.replacements == 1, "TLD '\(tld)' should still count as one replacement")
     }
   }
+
+  private static let gitHubBareAlias = CustomWord(
+    canonical: "GitHub.com", aliases: ["githab"], category: .brand)
+
+  @Test("A peeled TLD is not duplicated when the matched canonical already carries it")
+  func peeledTLDNotDuplicatedWhenCanonicalAlreadyHasIt() {
+    // Codex review round 2: canonical "GitHub.com" already IS a domain, but
+    // its alias "githab" is bare. "githab.com" misses the (unpeeled) exact
+    // Pass 3 -- the alias has no ".com" -- so it falls into the peel-and-
+    // retry path, where "githab" DOES exact-match. Blindly reattaching the
+    // peeled ".com" would produce "GitHub.com.com".
+    let result = corrected("githab.com", [Self.gitHubBareAlias])
+    #expect(result.text == "GitHub.com")
+    #expect(result.replacements == 1)
+  }
 }

--- a/Tests/EnviousWisprTests/PostProcessing/WordCorrectorGluedDomainSuffixTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/WordCorrectorGluedDomainSuffixTests.swift
@@ -560,4 +560,24 @@ struct WordCorrectorGluedDomainSuffixTests {
     #expect(result.text == "EnviousWispr.technology")
     #expect(result.replacements == 1)
   }
+
+  // MARK: Cloud Codex review, round 13 (PR #2298) -- an unpeeled PACK
+  // already-correct match must not outrank a higher-authority PEELED
+  // non-pack replace; "non-pack always wins over pack" applies to "leave it
+  // alone" exactly as it applies to "replace it".
+
+  @Test("A peeled non-pack alias outranks an unpeeled pack self-alias that is already correct")
+  func peeledNonPackReplaceOutranksUnpeeledPackAlreadyCorrect() {
+    // A pack explicitly includes a domain-shaped alias identical to its own
+    // canonical, so the unpeeled attempt on "GitHub.com" resolves to
+    // `.alreadyCorrect(isPack: true)`. A SEPARATE, higher-authority
+    // non-pack alias "github" -> "Other" is only reachable by peeling. The
+    // pack's own "no change needed" answer must not silently outrank it.
+    let packSelfAlias = CustomWord(
+      canonical: "GitHub.com", aliases: ["GitHub.com"], category: .brand, source: .pack)
+    let userAlias = CustomWord(canonical: "Other", aliases: ["github"])
+    let result = corrected("GitHub.com", [packSelfAlias, userAlias])
+    #expect(result.text == "Other.com")
+    #expect(result.replacements == 1)
+  }
 }

--- a/Tests/EnviousWisprTests/PostProcessing/WordCorrectorGluedDomainSuffixTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/WordCorrectorGluedDomainSuffixTests.swift
@@ -1,0 +1,99 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprCore
+@testable import EnviousWisprPostProcessing
+
+/// A custom word's own alias, glued to a recognized TLD with no space
+/// ("EnviousWispr.com" as one ASR token), must correct the word AND keep the
+/// domain suffix — never silently drop it.
+///
+/// Measured live from the founder's own dictation, 2026-08-21: "Enviousvisper.com"
+/// corrected to "EnviousWispr" with the ".com" gone entirely. Root cause:
+/// `WordCorrector.splitPunctuation` only strips LEADING/TRAILING characters
+/// that are not letters or numbers, so a token ending in a letter ("...com")
+/// never gets its internal "." recognized as a boundary at all — the whole
+/// glued string, TLD included, was handed to the matching passes as one
+/// "core", and a match replaced the entire thing.
+@Suite("WordCorrector — a glued domain suffix survives correction", .tags(.productOutcome))
+struct WordCorrectorGluedDomainSuffixTests {
+
+  private static let enviousWispr = CustomWord(
+    canonical: "EnviousWispr",
+    aliases: [
+      "envious visper", "envious whisper", "envious wisper",
+      "mbs cisper", "envious cisper", "envious wispr",
+      "in vious wispr", "envy us wispr", "NVS Visper", "NBS Vesper",
+      "Enviousvisper",
+    ],
+    category: .brand)
+
+  private func corrected(_ input: String, _ terms: [CustomWord] = [enviousWispr]) -> (
+    text: String, replacements: Int
+  ) {
+    let result = WordCorrector().correct(input, against: terms)
+    return (result.corrected, result.replacements.count)
+  }
+
+  @Test("A no-space alias glued directly to a recognized TLD keeps the TLD")
+  func gluedAliasKeepsTLD() {
+    // The founder's own reproduction, exactly. Regression pin for #2258-adjacent.
+    let result = corrected("Enviousvisper.com")
+    #expect(result.text == "EnviousWispr.com")
+    #expect(result.replacements == 1)
+  }
+
+  @Test(
+    "Every recognized TLD is preserved, not only .com",
+    arguments: ["com", "org", "io", "co", "dev", "me", "net", "ai", "app", "xyz"])
+  func everyRecognizedTLDIsPreserved(_ tld: String) {
+    let result = corrected("Enviousvisper.\(tld)")
+    #expect(result.text == "EnviousWispr.\(tld)")
+    #expect(result.replacements == 1)
+  }
+
+  @Test("An UNRECOGNIZED trailing suffix is left as part of the match, unchanged shape")
+  func unrecognizedSuffixIsNotTreatedAsATLD() {
+    // ".zzz" is not in the closed TLD list this fix reuses, so the token is
+    // handled exactly as before this fix -- no special-casing invented for
+    // strings that merely look domain-shaped.
+    let result = corrected("Enviousvisper.zzz")
+    #expect(result.text != "EnviousWispr.zzz")
+  }
+
+  @Test("A fuzzy (near-miss spelling) match ALSO keeps a glued TLD")
+  func fuzzyMatchAlsoKeepsGluedTLD() {
+    // "EnviousWhisper" is not a registered alias verbatim, so this exercises
+    // the SIMILARITY-scored passes, not the exact/no-space passes above --
+    // previously this input corrected NOTHING (the ".com" noise pulled the
+    // similarity score below threshold), matching the founder's third
+    // dictation ("EnviousWhisper.com" -> "no change").
+    let result = corrected("EnviousWhisper.com")
+    #expect(result.text == "EnviousWispr.com")
+    #expect(result.replacements == 1)
+  }
+
+  @Test("A glued TLD inside a full sentence still corrects and keeps the domain")
+  func gluedTLDInsideASentenceStillWorks() {
+    let result = corrected("Hey, I keep trying to say Enviousvisper.com but it never works")
+    #expect(result.text == "Hey, I keep trying to say EnviousWispr.com but it never works")
+    #expect(result.replacements == 1)
+  }
+
+  @Test("The spaced alias form is unaffected — regression pin")
+  func spacedAliasFormUnaffected() {
+    let result = corrected("envious visper dot com")
+    // No TLD glued to a single token here ("dot com" is two ordinary spoken
+    // words) -- this fix's new branch never engages, and the alias still
+    // corrects exactly as it always has.
+    #expect(result.text == "EnviousWispr dot com")
+    #expect(result.replacements == 1)
+  }
+
+  @Test("A TLD-shaped suffix on a word that matches NOTHING is left alone")
+  func noMatchLeavesTheTokenAlone() {
+    let result = corrected("totallyunrelatedword.com")
+    #expect(result.text == "totallyunrelatedword.com")
+    #expect(result.replacements == 0)
+  }
+}

--- a/Tests/EnviousWisprTests/PostProcessing/WordCorrectorGluedDomainSuffixTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/WordCorrectorGluedDomainSuffixTests.swift
@@ -580,4 +580,23 @@ struct WordCorrectorGluedDomainSuffixTests {
     #expect(result.text == "Other.com")
     #expect(result.replacements == 1)
   }
+
+  // MARK: Cloud Codex review, round 14 (PR #2298) -- the unpeeled
+  // domain-restricted fuzzy pass must not accept the first candidate that
+  // clears threshold; it must be compared against the peeled attempt's
+  // best candidate, and the STRONGER of the two wins.
+
+  @Test("A stronger peeled fuzzy match outranks a weaker unpeeled domain-shaped match")
+  func strongerPeeledFuzzyOutranksWeakerUnpeeledDomainMatch() {
+    // Cloud review's own construction: a domain-shaped distractor scores
+    // ~0.91 against the raw (unpeeled) input, which used to be accepted
+    // outright the instant it cleared threshold. The peeled input scores
+    // ~0.97 against the intended alias -- objectively closer -- but was
+    // never even consulted because the unpeeled attempt already returned.
+    let distractor = CustomWord(canonical: "Wrong.com", aliases: ["internationalplatfozz.com"])
+    let correct = CustomWord(canonical: "Right", aliases: ["internationalplatforn"])
+    let result = corrected("internationalplatform.com", [distractor, correct])
+    #expect(result.text == "Right.com")
+    #expect(result.replacements == 1)
+  }
 }

--- a/Tests/EnviousWisprTests/PostProcessing/WordCorrectorGluedDomainSuffixTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/WordCorrectorGluedDomainSuffixTests.swift
@@ -361,4 +361,38 @@ struct WordCorrectorGluedDomainSuffixTests {
     #expect(result.text == "192.168.1.1")
     #expect(result.replacements == 0)
   }
+
+  // MARK: Codex review round 6 findings -- a dotted PRODUCT name is not a
+  // domain even though it structurally looks like one, and an alphanumeric
+  // version/build tail is not a domain suffix either.
+
+  private static let nodeJSAlias = CustomWord(canonical: "Node.js", aliases: ["nodejs"])
+
+  @Test("A dotted product-name canonical does NOT suppress a real glued TLD")
+  func dottedProductNameCanonicalDoesNotSuppressGluedTLD() {
+    // Codex review round 6, P1: "Node.js" is a real, common product name
+    // that happens to end in a dot-suffix ("D3.js", "Vue.js", "Chart.js"
+    // are the same shape), but it is not a domain. The old purely
+    // structural `isDomainShaped` treated any all-letters tail as a domain
+    // and suppressed the user's own glued ".com", producing "Node.js"
+    // instead of "Node.js.com". Only a REAL TLD suppresses the reattach.
+    let result = corrected("nodejs.com", [Self.nodeJSAlias])
+    #expect(result.text == "Node.js.com")
+    #expect(result.replacements == 1)
+  }
+
+  @Test("An alphanumeric version/build tail is never treated as a domain suffix")
+  func alphanumericVersionTailIsNeverADomainSuffix() {
+    // Codex review round 6, P2: the round-5 fix excluded only PURELY
+    // numeric tails, so "v1.2beta" and "v1.2.3rc1" -- ordinary version/
+    // build strings with letters mixed in -- still slipped through and
+    // rewrote to "VersionOne.2beta" / "VersionOne.2.3rc1". A real TLD
+    // label is ALL LETTERS (current ICANN policy bars digits from the TLD
+    // position entirely), so any digit in the final label now excludes it.
+    for input in ["v1.2beta", "v1.2.3rc1", "v1.0", "v1.2rc"] {
+      let result = corrected(input, [Self.versionOneAlias])
+      #expect(result.text == input, "'\(input)' must stay unchanged, got '\(result.text)'")
+      #expect(result.replacements == 0)
+    }
+  }
 }

--- a/Tests/EnviousWisprTests/PostProcessing/WordCorrectorGluedDomainSuffixTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/WordCorrectorGluedDomainSuffixTests.swift
@@ -96,4 +96,47 @@ struct WordCorrectorGluedDomainSuffixTests {
     #expect(result.text == "totallyunrelatedword.com")
     #expect(result.replacements == 0)
   }
+
+  // MARK: Codex review findings (PR for #2281) — a saved alias that IS itself
+  // a domain must not have its TLD peeled off before the exact lookup runs,
+  // and a domain-shaped token must never feed the COMPOUND (multi-token)
+  // passes and lose its TLD there instead.
+
+  private static let gitHubDomainAlias = CustomWord(
+    canonical: "GitHub.com", aliases: ["githab.com"], category: .brand)
+
+  @Test("An exact alias that is ITSELF a domain still matches whole, unpeeled")
+  func exactDomainShapedAliasStillMatches() {
+    let result = corrected("githab.com", [Self.gitHubDomainAlias])
+    #expect(result.text == "GitHub.com")
+    #expect(result.replacements == 1)
+  }
+
+  private static let fooBar = CustomWord(
+    canonical: "FooBar", aliases: ["foobar"], category: .brand)
+
+  @Test(
+    "A domain-shaped token before another word does not feed compound matching and lose its TLD")
+  func domainTokenDoesNotFeedCompoundMatch() {
+    // "foo.com" + "bar" superficially concatenates to "foobar" -- an accident
+    // compound Pass 0 must not act on. Domain-bearing tokens stay opaque to
+    // the compound passes exactly as they were before this fix.
+    let result = corrected("foo.com bar", [Self.fooBar])
+    #expect(result.text == "foo.com bar")
+    #expect(result.replacements == 0)
+  }
+
+  @Test("Every recognized TLD survives a FUZZY (not just exact) single-word match")
+  func everyRecognizedTLDSurvivesFuzzyMatch() {
+    // Regression for the fix's own false start: trying the fuzzy passes on
+    // the unpeeled token FIRST let several TLD lengths cross threshold and
+    // get silently swallowed (org/net/ai/me/io/app all failed before this
+    // was caught and corrected). Re-assert every TLD through the fuzzy path
+    // specifically, using a near-miss spelling rather than the exact alias.
+    for tld in ["com", "org", "io", "co", "dev", "me", "net", "ai", "app", "xyz"] {
+      let result = corrected("EnviousWhisper.\(tld)")
+      #expect(result.text == "EnviousWispr.\(tld)", "TLD '\(tld)' should survive a fuzzy match")
+      #expect(result.replacements == 1, "TLD '\(tld)' should still count as one replacement")
+    }
+  }
 }

--- a/Tests/EnviousWisprTests/PostProcessing/WordCorrectorGluedDomainSuffixTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/WordCorrectorGluedDomainSuffixTests.swift
@@ -621,4 +621,25 @@ struct WordCorrectorGluedDomainSuffixTests {
     #expect(result.text == "internationalplatform.com")
     #expect(result.replacements == 0)
   }
+
+  // MARK: Cloud Codex review, round 16 (PR #2298) -- an ambiguous non-pack
+  // result must be TERMINAL, not "no non-pack candidate, try pack next": a
+  // lower-authority pack candidate must never win a token that non-pack
+  // itself couldn't confidently resolve.
+
+  @Test("An ambiguous non-pack tie is terminal and never falls through to a pack candidate")
+  func ambiguousNonPackTieDoesNotFallThroughToPack() {
+    // Same near-tied non-pack pair as round 15, plus a pack alias that
+    // WOULD clear its own threshold if given a turn. The non-pack tier's
+    // ambiguity must stop the retry outright rather than reading as "no
+    // non-pack candidate" and letting the pack tier decide instead.
+    let distractor = CustomWord(canonical: "Wrong.com", aliases: ["internationalplatforn.com"])
+    let correct = CustomWord(canonical: "Right", aliases: ["internationalplatforx"])
+    let packDistractor = CustomWord(
+      canonical: "PackWrong", aliases: ["internationalplatforq.com"], source: .pack)
+    let result = corrected(
+      "internationalplatform.com", [distractor, correct, packDistractor])
+    #expect(result.text == "internationalplatform.com")
+    #expect(result.replacements == 0)
+  }
 }

--- a/Tests/EnviousWisprTests/PostProcessing/WordCorrectorGluedDomainSuffixTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/WordCorrectorGluedDomainSuffixTests.swift
@@ -599,4 +599,26 @@ struct WordCorrectorGluedDomainSuffixTests {
     #expect(result.text == "Right.com")
     #expect(result.replacements == 1)
   }
+
+  // MARK: Cloud Codex review, round 15 (PR #2298) -- round 14's cross-pass
+  // score comparison must apply the SAME ambiguity margin used within each
+  // individual pass; two different canonicals that are each unambiguous
+  // alone can still be too close to each other to pick between confidently.
+
+  @Test(
+    "Near-tied unpeeled and peeled fuzzy candidates for DIFFERENT canonicals are left unresolved"
+  )
+  func nearTiedCrossPassFuzzyCandidatesAreNotResolved() {
+    // Cloud review's own construction: the unpeeled attempt scores ~0.956
+    // for "Wrong.com" and the peeled attempt scores ~0.959 for "Right" --
+    // each is the clear winner within its own scan, but the two scores are
+    // only 0.003 apart, far inside the 0.05 ambiguity margin this file
+    // otherwise always enforces before accepting a replacement. Neither
+    // wins; the original token is left untouched.
+    let distractor = CustomWord(canonical: "Wrong.com", aliases: ["internationalplatforn.com"])
+    let correct = CustomWord(canonical: "Right", aliases: ["internationalplatforx"])
+    let result = corrected("internationalplatform.com", [distractor, correct])
+    #expect(result.text == "internationalplatform.com")
+    #expect(result.replacements == 0)
+  }
 }

--- a/Tests/EnviousWisprTests/PostProcessing/WordCorrectorGluedDomainSuffixTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/WordCorrectorGluedDomainSuffixTests.swift
@@ -667,4 +667,38 @@ struct WordCorrectorGluedDomainSuffixTests {
     #expect(result.text == "internationalplatform.com")
     #expect(result.replacements == 0)
   }
+
+  // MARK: Cloud Codex review, round 19 (PR #2298) -- a Pass 4 (alias)
+  // ambiguity must still let Pass 5 (canonicals) try to resolve
+  // confidently on its own terms, rather than blocking Pass 5 outright the
+  // way round 17 did. Pass 5 answers a DIFFERENT question over a DIFFERENT
+  // candidate pool, so its own margin can clear even when Pass 4's cannot.
+
+  @Test("A confident Pass 5 canonical match resolves a Pass 4 alias ambiguity")
+  func confidentPass5ResolvesPass4Ambiguity() {
+    // Cloud review's own construction, real scores measured: two Pass 4
+    // aliases score 0.970/0.959 against each other (ambiguous, only 0.011
+    // apart) -- but Pass 5's canonical pool scores the SAME top candidate
+    // at 0.970 against an unrelated ~0.09 for the other canonicals, a
+    // margin of ~0.88, nowhere near ambiguous. Pass 5's confident answer
+    // must win rather than the whole attempt staying silent.
+    let right = CustomWord(canonical: "internationalplatforn", aliases: [])
+    let wrong1 = CustomWord(canonical: "Wrong1", aliases: ["internationalplatforn"])
+    let wrong2 = CustomWord(canonical: "Wrong2", aliases: ["internationalplatforx"])
+    let result = corrected("internationalplatform", [right, wrong1, wrong2])
+    #expect(result.text == "internationalplatforn")
+    #expect(result.replacements == 1)
+  }
+
+  @Test("A confident pack Pass 5 canonical match resolves a pack Pass 4 alias ambiguity")
+  func confidentPackPass5ResolvesPackPass4Ambiguity() {
+    // Same construction as above, at the lower-authority pack tier -- the
+    // twin site round 16/17/18 each needed a matching fix for.
+    let right = CustomWord(canonical: "internationalplatforn", aliases: [], source: .pack)
+    let wrong1 = CustomWord(canonical: "Wrong1", aliases: ["internationalplatforn"], source: .pack)
+    let wrong2 = CustomWord(canonical: "Wrong2", aliases: ["internationalplatforx"], source: .pack)
+    let result = corrected("internationalplatform", [right, wrong1, wrong2])
+    #expect(result.text == "internationalplatforn")
+    #expect(result.replacements == 1)
+  }
 }

--- a/Tests/EnviousWisprTests/PostProcessing/WordCorrectorGluedDomainSuffixTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/WordCorrectorGluedDomainSuffixTests.swift
@@ -535,24 +535,29 @@ struct WordCorrectorGluedDomainSuffixTests {
 
   @Test("The domain-restricted raw fuzzy pass admits candidates by SURFACE, not canonical")
   func domainRestrictedFuzzyAdmitsBySurfaceNotCanonical() {
-    // Cloud review round 2: the raw (unpeeled) domain-restricted pass
-    // scores `coreLower` against each candidate's SURFACE, but the
-    // admission check used to also let a candidate in when only its
-    // CANONICAL was domain-shaped -- a mismatch between what's admitted
-    // and what's actually compared. Structural fix verified by reading
-    // the code (grep for "domainShapedOnly, !Self.isDomainShaped" shows
-    // both Pass 4 sites now check surface alone); this pins the intended
-    // end-to-end behavior for the shape the review named. Note: this
-    // specific input does not observably distinguish the fixed admission
-    // from the old one, because a domain-shaped matched canonical already
-    // suppresses reattach either way (round 3/4's dedup design) -- the old
-    // bug is only reachable by winning against a DIFFERENT, correct
-    // candidate under raw-vs-peeled scoring noise, which this test does
-    // not attempt to reconstruct.
-    let word = CustomWord(
-      canonical: "SomeLongBrandName.com", aliases: ["someverylongbarealiasnameindeed"])
-    let result = corrected("someverylongbarealiasnameindeed.org", [word])
-    #expect(result.text == "SomeLongBrandName.com")
+    // Round 12 (confirming local sweep): the earlier version of this test
+    // could not distinguish the fixed admission from the old one. This
+    // construction can: a WRONG distractor's own surface is domain-shaped
+    // (via "&.com"), so the old (surface-OR-canonical) admission let it into
+    // the raw pass, where it scores close enough to the raw input to win
+    // outright and print the WRONG canonical. The fixed (surface-only)
+    // admission rejects it, so the peeled attempt runs and correctly favors
+    // the RIGHT candidate.
+    let correct = CustomWord(canonical: "EnviousWispr", aliases: [])
+    let distractor = CustomWord(canonical: "WrongBrand.com", aliases: ["enviouswispertechnology"])
+    let result = corrected("enviouswisper.technology", [correct, distractor])
+    #expect(result.text == "EnviousWispr.technology")
+    #expect(result.replacements == 1)
+  }
+
+  @Test("The domain-restricted raw fuzzy pass admits PACK candidates by SURFACE, not canonical")
+  func domainRestrictedPackFuzzyAdmitsBySurfaceNotCanonical() {
+    // Same construction as above, at the lower-authority pack Pass 4 site.
+    let correct = CustomWord(canonical: "EnviousWispr", aliases: [], source: .pack)
+    let distractor = CustomWord(
+      canonical: "WrongBrand.com", aliases: ["enviouswispertechnology"], source: .pack)
+    let result = corrected("enviouswisper.technology", [correct, distractor])
+    #expect(result.text == "EnviousWispr.technology")
     #expect(result.replacements == 1)
   }
 }

--- a/Tests/EnviousWisprTests/PostProcessing/WordCorrectorGluedDomainSuffixTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/WordCorrectorGluedDomainSuffixTests.swift
@@ -307,4 +307,58 @@ struct WordCorrectorGluedDomainSuffixTests {
     #expect(result.text == "GitHub.co.uk")
     #expect(result.replacements == 1)
   }
+
+  // MARK: Codex review round 5 findings -- the domain-restricted fuzzy pass
+  // must not run at all for a token with no dot, and a numeric-only tail is
+  // never a domain suffix.
+
+  private static let enviousWisprCloseNeighbors = CustomWord(
+    canonical: "Right",
+    aliases: ["enviouswhispr"],
+    category: .brand)
+  private static let enviousWisprDomainDistractor = CustomWord(
+    canonical: "Wrong.com",
+    aliases: ["enviouswhisper.com"],
+    category: .brand)
+
+  @Test("An ordinary no-dot token never runs the domain-restricted fuzzy pass at all")
+  func ordinaryNoDotTokenSkipsDomainRestrictedFuzzy() {
+    // Codex review round 5, P1: the domain-restricted fuzzy pass used to run
+    // unconditionally, even for a token with no dot at all -- comparing it
+    // against domain-shaped candidates it has no business being compared
+    // against. "enviouswhisper" (no dot) could score against the
+    // domain-shaped "enviouswhisper.com" candidate purely on shared prefix
+    // length, preempting the correct bare candidate "enviouswhispr" that
+    // only step 4 (peeled, unrestricted -- a no-op here since there's
+    // nothing to peel) would otherwise have found.
+    let result = corrected(
+      "enviouswhisper",
+      [Self.enviousWisprCloseNeighbors, Self.enviousWisprDomainDistractor])
+    #expect(result.text == "Right")
+    #expect(result.replacements == 1)
+  }
+
+  private static let versionOneAlias = CustomWord(canonical: "VersionOne", aliases: ["v1"])
+
+  @Test("A numeric-only tail is never treated as a domain suffix")
+  func numericOnlyTailIsNeverADomainSuffix() {
+    // Codex review round 5, P2: a real TLD label is never purely numeric.
+    // Without this exclusion, "v1.2" (an ordinary version number) peeled to
+    // bare "v1", exact-matched an unrelated alias "v1", and produced
+    // "VersionOne.2" -- correcting text that was never a domain at all.
+    let result = corrected("v1.2", [Self.versionOneAlias])
+    #expect(result.text == "v1.2")
+    #expect(result.replacements == 0)
+  }
+
+  @Test("An IP-shaped token is never treated as a domain suffix")
+  func ipShapedTokenIsNeverADomainSuffix() {
+    // Same root as the version-number case: every label of an IPv4-style
+    // token is numeric, so the LAST label check alone is what excludes it
+    // (an IP is not glued to a real custom word in practice, but nothing
+    // here should coincidentally rewrite one).
+    let result = corrected("192.168.1.1", [Self.versionOneAlias])
+    #expect(result.text == "192.168.1.1")
+    #expect(result.replacements == 0)
+  }
 }

--- a/Tests/EnviousWisprTests/PostProcessing/WordCorrectorGluedDomainSuffixTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/WordCorrectorGluedDomainSuffixTests.swift
@@ -642,4 +642,29 @@ struct WordCorrectorGluedDomainSuffixTests {
     #expect(result.text == "internationalplatform.com")
     #expect(result.replacements == 0)
   }
+
+  // MARK: Cloud Codex review, round 17 (PR #2298) -- ambiguity WITHIN a
+  // single attempt's own Pass 4 scan must be distinguishable from "no
+  // candidate at all," the same way round 16 fixed it ACROSS the two
+  // attempts. Both are needed: an ambiguous single attempt must stay
+  // terminal too, never silently falling through to Pass 5 or the pack tier
+  // as if nothing had been found.
+
+  @Test("An in-pass ambiguity within one attempt is terminal and never falls through to pack")
+  func inPassAmbiguityDoesNotFallThroughToPack() {
+    // Cloud review's own construction: two DIFFERENT non-pack aliases both
+    // domain-shaped, both close enough to the unpeeled input to be each
+    // other's near-tied competitors within the SAME Pass 4 scan -- not a
+    // cross-attempt tie, an in-attempt one. A pack alias that would win if
+    // given a turn proves the tier stayed terminal rather than reading the
+    // in-pass ambiguity as "nothing scored."
+    let distractor1 = CustomWord(canonical: "Wrong1", aliases: ["internationalplatforn.com"])
+    let distractor2 = CustomWord(canonical: "Wrong2", aliases: ["internationalplatforx.com"])
+    let packDistractor = CustomWord(
+      canonical: "PackWrong", aliases: ["internationalplatforq.com"], source: .pack)
+    let result = corrected(
+      "internationalplatform.com", [distractor1, distractor2, packDistractor])
+    #expect(result.text == "internationalplatform.com")
+    #expect(result.replacements == 0)
+  }
 }


### PR DESCRIPTION
## Summary
- Fixes #2281: a custom-word correction ("Enviousvisper" -> "EnviousWispr" etc.) glued directly onto a domain suffix with no space ("Enviousvisper.com") was silently dropping the ".com" -- or, in the fuzzy-match case, failing to correct at all.
- Root cause: `WordCorrector.splitPunctuation` only stripped leading/trailing characters that are not letters or numbers, so a token ending in a letter (`...com`) never had its internal "." recognized as a boundary -- the whole glued string, TLD included, was handed to every matching pass as one opaque "core".
- Fix, scoped to the single-word matching pass: try an exact match against the token exactly as ASR emitted it first (so a saved alias that is itself a domain still matches whole), then peel a domain-shaped suffix (structural, not limited to a fixed TLD list -- covers international two-part suffixes like `.co.uk`/`.co.jp`/`.com.au` and punycode IDN TLDs) and retry every pass on the bare core. Exact-over-fuzzy and non-pack-over-pack precedence hold across that peel boundary. The multi-word/compound passes are untouched, so a domain-shaped token can never feed a cross-token compound match and lose its TLD there.
- Eight rounds of local Codex review, each catching a real edge case (precedence across the peel boundary, international TLD shapes, version-number/IP false positives, punycode, authority attribution) -- every finding fixed with a dedicated, mutation-verified regression test. One remaining known limit (the curated real-TLD list used for one specific decision is not exhaustive against ICANN's full ~1,500-entry root zone) is documented in the code as an accepted, founder-confirmed scope boundary rather than chased further.
- Live UAT: dictated real domain suffixes (US `.com`, UK `.co.uk`) into Chrome, Safari, and Brave's actual address bars using the founder's own live custom word. Confirmed the corrected text lands intact in all three, and confirmed full end-to-end navigation in Safari (`https://enviouswispr.com`) and Chrome after typed input, isolating a separate, pre-existing, unrelated issue (Chrome/Brave not accepting Enter-to-navigate after an AX-direct paste) -- filed separately as #2297, not part of this PR's scope.

## Test plan
- [x] `swift test --filter WordCorrect` (85 tests) -- pass
- [x] `swift test --filter "BrandApostropheTests|InverseTextNormalizer|CustomWords"` (324 tests) -- pass, no regressions
- [x] Full `scripts/xcode-test.sh --release`: Debug 6384 / Release 5816, both green (re-run fresh before push)
- [x] 8 rounds of local Codex review, all findings fixed with regression tests; several guards mutation-verified by reverting them and confirming the test goes red
- [x] Live UAT: real dictation into Chrome/Safari/Brave address bars, US and UK domain shapes, using the founder's live registered custom word
- [x] Founder decision recorded in-code for the one remaining known limit (curated TLD list, not exhaustive)

Fast-follow filed: #2297 (Chrome/Brave Enter-to-navigate, unrelated pre-existing issue found during this PR's Live UAT).
