### PR TITLE
fix(logger): append every app log write atomically

### DIFF
--- a/Sources/EnviousWisprCore/AppLogger.swift
+++ b/Sources/EnviousWisprCore/AppLogger.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import OSLog
 
@@ -170,10 +171,23 @@ public actor AppLogger {
       let dir = logDirectory
       try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
       if !FileManager.default.fileExists(atPath: currentLogURL.path) {
-        FileManager.default.createFile(atPath: currentLogURL.path, contents: nil)
+        _ = FileManager.default.createFile(atPath: currentLogURL.path, contents: nil)
       }
-      fileHandle = try? FileHandle(forWritingTo: currentLogURL)
-      fileHandle?.seekToEndOfFile()
+      fileHandle = Self.openAppendFileHandle(at: currentLogURL)
+    }
+
+    /// Open every process's handle with kernel-enforced append semantics.
+    ///
+    /// `FileHandle(forWritingTo:)` plus one `seekToEndOfFile()` leaves each
+    /// process with an independent offset. Later writes can overwrite bytes a
+    /// different process appended in the meantime. `O_APPEND` moves the offset
+    /// to the current end atomically for every write, so main-app and XPC lines
+    /// cannot silently replace one another (#2159). Rotation still needs the
+    /// separate cross-process lock tracked by that issue.
+    package static func openAppendFileHandle(at url: URL) -> FileHandle? {
+      let descriptor = Darwin.open(url.path, O_WRONLY | O_APPEND | O_CLOEXEC)
+      guard descriptor >= 0 else { return nil }
+      return FileHandle(fileDescriptor: descriptor, closeOnDealloc: true)
     }
 
     /// Single renderer for both the live path and the #1361 flush, so a format

--- a/Tests/EnviousWisprTests/Core/AppLoggerCompileOutTests.swift
+++ b/Tests/EnviousWisprTests/Core/AppLoggerCompileOutTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import Testing
 
@@ -52,6 +53,44 @@ struct AppLoggerCompileOutTests {
         environment: ["EW_APP_LOG_DIRECTORY": "relative/logger"],
         libraryDirectory: fallback)
       #expect(rejected == fallback.appendingPathComponent("Logs/EnviousWispr", isDirectory: true))
+    }
+
+    @Test("every file handle appends at write time instead of keeping a stale offset")
+    func everyFileHandleUsesAppendSemantics() throws {
+      let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("ew-2159-\(UUID().uuidString)", isDirectory: true)
+      try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+      defer { try? FileManager.default.removeItem(at: directory) }
+
+      let url = directory.appendingPathComponent("app.log")
+      _ = FileManager.default.createFile(atPath: url.path, contents: nil)
+      let first = try #require(AppLogger.openAppendFileHandle(at: url))
+      let second = try #require(AppLogger.openAppendFileHandle(at: url))
+      defer {
+        try? first.close()
+        try? second.close()
+      }
+
+      let flags = fcntl(first.fileDescriptor, F_GETFL)
+      #expect(flags >= 0)
+      #expect(flags & O_APPEND == O_APPEND, "the AppLogger handle must carry O_APPEND")
+
+      // Both handles opened while the file was empty. Without O_APPEND each
+      // keeps offset zero and these alternating writes overwrite one another.
+      // With O_APPEND, the kernel resolves the current end for every write.
+      for (handle, line) in [
+        (first, "main-1\n"),
+        (second, "xpc-1-longer\n"),
+        (first, "main-2-even-longer\n"),
+        (second, "xpc-2\n"),
+      ] {
+        try handle.write(contentsOf: Data(line.utf8))
+      }
+      try first.synchronize()
+      try second.synchronize()
+
+      let contents = try String(contentsOf: url, encoding: .utf8)
+      #expect(contents == "main-1\nxpc-1-longer\nmain-2-even-longer\nxpc-2\n")
     }
 
     @Test("Debug build: log() emits the marker into the file sink")


### PR DESCRIPTION
Part of #2159.

## What changed

- open `app.log` descriptors with `O_APPEND` and `O_CLOEXEC`
- remove the one-time seek whose per-process offset allowed later writes to overwrite another process
- add a two-handle regression test that checks the real descriptor flag and exact bytes on disk

## Mutation proof

Removing `O_APPEND` from production makes the new test fail twice: the descriptor flag is absent and alternating app/XPC-shaped writes overwrite each other. Restoring it returns the suite to green.

## Validation

- focused Debug: 3/3
- focused Release: 1/1
- full Debug: 6,356
- Release `EnviousWisprCore` build: pass
- pinned Codex review: clean

## Remaining #2159 work

This stops the dominant silent line-loss path. #2159 stays open by design: rotation still needs the existing stable companion-file `flock`, which requires the founder-reviewed `RotatingFileSink` module move. No merge performed.
