### PR TITLE
test(asr): add shipped Parakeet real-boundary receipt

### DIFF
--- a/Tests/EnviousWisprASRTests/ParakeetDeliveryModeTests.swift
+++ b/Tests/EnviousWisprASRTests/ParakeetDeliveryModeTests.swift
@@ -12,16 +12,15 @@ import Testing
   /// Cache-only arms FluidAudio's own offline switch (`ModelHub.offlineMode`
   /// since #1981); the legacy mode resets it explicitly — flipping the
   /// delivery flag works without a service restart (declared invariant, plan §3).
-  @Test func offlineModeFollowsCacheOnlyDeterministically() {
-    let original = ModelHub.offlineMode
-    defer { ModelHub.offlineMode = original }
+  @Test func offlineModeFollowsCacheOnlyDeterministically() async {
+    await withParakeetOfflineModeExclusion {
+      ParakeetBackend.configureOfflineMode(cacheOnly: true)
+      #expect(ModelHub.offlineMode)
 
-    ParakeetBackend.configureOfflineMode(cacheOnly: true)
-    #expect(ModelHub.offlineMode)
-
-    // Legacy-after-cache-only: the reset is explicit, not leftover state.
-    ParakeetBackend.configureOfflineMode(cacheOnly: false)
-    #expect(!ModelHub.offlineMode)
+      // Legacy-after-cache-only: the reset is explicit, not leftover state.
+      ParakeetBackend.configureOfflineMode(cacheOnly: false)
+      #expect(!ModelHub.offlineMode)
+    }
   }
 
   /// #1981 chunk 2: the vendor-progress → app-callback mapping, exercised

--- a/Tests/EnviousWisprASRTests/ParakeetOfflineModeTestExclusion.swift
+++ b/Tests/EnviousWisprASRTests/ParakeetOfflineModeTestExclusion.swift
@@ -1,0 +1,53 @@
+@preconcurrency import FluidAudio
+
+/// Cross-suite exclusion for FluidAudio's process-wide offline-mode switch.
+///
+/// `.serialized` orders tests only inside one suite. Both the delivery-mode
+/// contract and the real-model receipt change this global, so they share this
+/// fair FIFO guard and return the switch exactly as they found it.
+private actor ParakeetOfflineModeTestExclusion {
+  static let shared = ParakeetOfflineModeTestExclusion()
+
+  private var held = false
+  private var waiters: [CheckedContinuation<Void, Never>] = []
+
+  func acquire() async {
+    if !held {
+      held = true
+      return
+    }
+    await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+      waiters.append(continuation)
+    }
+  }
+
+  func release() {
+    if waiters.isEmpty {
+      held = false
+    } else {
+      waiters.removeFirst().resume()
+    }
+  }
+}
+
+func withParakeetOfflineModeExclusion<T>(
+  isolation: isolated (any Actor)? = #isolation,
+  _ body: () async throws -> T
+) async rethrows -> T {
+  await ParakeetOfflineModeTestExclusion.shared.acquire()
+  let originalOfflineMode = ModelHub.offlineMode
+
+  @Sendable func restoreAndRelease() async {
+    ModelHub.offlineMode = originalOfflineMode
+    await ParakeetOfflineModeTestExclusion.shared.release()
+  }
+
+  do {
+    let value = try await body()
+    await restoreAndRelease()
+    return value
+  } catch {
+    await restoreAndRelease()
+    throw error
+  }
+}

--- a/Tests/EnviousWisprASRTests/ParakeetRealBoundaryTests.swift
+++ b/Tests/EnviousWisprASRTests/ParakeetRealBoundaryTests.swift
@@ -1,0 +1,69 @@
+import EnviousWisprCore
+@preconcurrency import FluidAudio
+import Foundation
+import Testing
+
+@testable import EnviousWisprASR
+
+private enum ParakeetRealBoundaryFixture {
+  static let repoRoot = URL(filePath: #filePath)
+    .deletingLastPathComponent()  // EnviousWisprASRTests
+    .deletingLastPathComponent()  // Tests
+    .deletingLastPathComponent()  // repo root
+
+  static let audioURL = repoRoot.appending(path: "scripts/freeze-suite/clips/normal-speech.wav")
+  static let expectedTranscript =
+    "the quick brown fox jumps over the lazy dog while the morning sun rises slowly above the quiet hills"
+
+  static var shippedModelIsInstalled: Bool {
+    let cache = AsrModels.defaultCacheDirectory(for: .v3)
+    return AsrModels.modelsExist(at: cache, version: .v3)
+  }
+
+  static func normalizedWords(_ text: String) -> String {
+    text.lowercased()
+      .split(whereSeparator: { !$0.isLetter && !$0.isNumber })
+      .joined(separator: " ")
+  }
+}
+
+/// #2142 real-boundary receipt for the default shipped transcription engine.
+///
+/// **What the user sees when this fails:** a normal recording reaches the shipped
+/// Parakeet model but does not come back as the words they spoke.
+///
+/// The resource gate runs this on a developer machine after EnviousWispr has
+/// installed the model and reports it skipped on hosted CI. `cacheOnly: true`
+/// keeps the test read-only: it cannot download, repair, or replace model bytes.
+@Suite("Shipped Parakeet transcription", .serialized, .tags(.productOutcome))
+struct ParakeetRealBoundaryTests {
+
+  @Test(
+    "the shipped model transcribes committed speech",
+    .enabled(if: ParakeetRealBoundaryFixture.shippedModelIsInstalled),
+    .tags(.realBoundary)
+  )
+  func shippedModelTranscribesCommittedSpeech() async throws {
+    let samples = try AudioConverter().resampleAudioFile(
+      path: ParakeetRealBoundaryFixture.audioURL.path)
+    let result: EnviousWisprCore.ASRResult = try await withParakeetOfflineModeExclusion {
+      let backend = ParakeetBackend()
+      do {
+        try await backend.prepare(cacheOnly: true, progressCallback: nil)
+        let result = try await backend.transcribe(audioSamples: samples, options: .default)
+        await backend.unload()
+        return result
+      } catch {
+        await backend.unload()
+        throw error
+      }
+    }
+
+    #expect(result.backendType == .parakeet)
+    #expect(
+      ParakeetRealBoundaryFixture.normalizedWords(result.text)
+        == ParakeetRealBoundaryFixture.expectedTranscript,
+      "Parakeet returned: \(result.text)"
+    )
+  }
+}


### PR DESCRIPTION
## Summary

- add a real-model test that transcribes the committed normal-speech WAV with the shipped cached Parakeet model
- require the exact expected normalized transcript and Parakeet backend identity
- coordinate FluidAudio process-wide offline mode across both test suites with a fair async exclusion
- use cache-only preparation, so the test skips when the model is absent and never downloads or repairs it

Part of #2142

## Validation

- focused Xcode delivery-mode suite: 4/4 passed
- focused Xcode real-boundary suite: 1/1 passed
- SwiftPM focused real-boundary suite: 1/1 passed
- combined suites: 5/5 passed in 10 consecutive reviewer runs
- full Debug Xcode gate: 6,356 executed tests passed
- pinned Codex review: no actionable defects

## Mutation proof

Changing the production Parakeet result text to an empty string made only the new real-boundary receipt fail on its transcript assertion. Production was restored before commit.