### PR TITLE
content(compare): optimize refreshed pages for search

### DIFF
--- a/website/src/components/CompareDecisionSummary.astro
+++ b/website/src/components/CompareDecisionSummary.astro
@@ -1,0 +1,85 @@
+---
+interface Props {
+  id: string;
+  heading: string;
+}
+
+const { id, heading } = Astro.props;
+---
+
+<section class="decision-summary" aria-labelledby={id}>
+  <div class="container">
+    <div class="decision-card reveal">
+      <p class="decision-label">Quick answer</p>
+      <h2 id={id}>{heading}</h2>
+      <div class="decision-copy"><slot /></div>
+      <p class="decision-links">
+        Still deciding? See the <a href="/compare/best-dictation-apps-for-mac/">best Mac dictation apps by use case</a>
+        {' '}or browse <a href="/compare/">all 17 dictation app comparisons</a>.
+      </p>
+    </div>
+  </div>
+</section>
+
+<style>
+  .decision-summary {
+    padding: 0 0 48px;
+    position: relative;
+    z-index: 1;
+  }
+
+  .decision-card {
+    max-width: 920px;
+    margin: 0 auto;
+    padding: 28px 32px;
+    background: linear-gradient(135deg, rgba(124, 58, 237, 0.06), rgba(255, 255, 255, 0.94));
+    border: 1px solid rgba(124, 58, 237, 0.16);
+    border-radius: var(--radius-card);
+  }
+
+  .decision-label {
+    margin: 0 0 8px;
+    color: var(--accent);
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+  }
+
+  h2 {
+    margin: 0 0 12px;
+    color: var(--text);
+    font-size: 24px;
+    line-height: 1.25;
+    letter-spacing: -0.6px;
+  }
+
+  .decision-copy,
+  .decision-links {
+    color: var(--text-2);
+    font-size: 16px;
+    line-height: 1.7;
+  }
+
+  .decision-copy :global(p) {
+    margin: 0;
+  }
+
+  .decision-links {
+    margin: 14px 0 0;
+    font-size: 14px;
+  }
+
+  a {
+    color: var(--accent);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+
+  @media (max-width: 600px) {
+    .decision-summary { padding-bottom: 32px; }
+    .decision-card { padding: 22px 20px; }
+    h2 { font-size: 21px; }
+    .decision-copy { font-size: 15px; }
+  }
+</style>

--- a/website/src/pages/compare/best-dictation-apps-for-mac.astro
+++ b/website/src/pages/compare/best-dictation-apps-for-mac.astro
@@ -82,7 +82,7 @@ const tableCols = ["WisprFlow", "SuperWhisper", "MacWhisper", "Otter.ai", "Apple
 
 <BaseLayout
   title="Best Dictation App for Mac in 2026: Honest Picks by Use Case"
-  description="An honest, by-use-case guide to the best Mac dictation apps in 2026. Free and private, built-in, file transcription, cross-device, and meetings, compared by the EnviousWispr team."
+  description="Compare the best dictation apps for Mac in 2026 by use case, including free, private, built-in, file transcription, cross-device, and meeting options."
   activePage="compare"
   canonicalPath="/compare/best-dictation-apps-for-mac/"
   ogType="article"

--- a/website/src/pages/compare/fluidvoice.astro
+++ b/website/src/pages/compare/fluidvoice.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import CompareDecisionSummary from '../../components/CompareDecisionSummary.astro';
 
 const siteUrl = 'https://enviouswispr.com';
 
@@ -144,7 +145,7 @@ const faqJsonLd = JSON.stringify({
 
 <BaseLayout
   title="FluidVoice vs EnviousWispr: Free Mac Dictation, Both GPLv3"
-  description="Compare FluidVoice and EnviousWispr, two free, GPLv3, on-device Mac dictation apps, each with a custom-tuned AI polish model. See where the real differences are."
+  description="Compare FluidVoice and EnviousWispr, two free, GPLv3, on-device Mac dictation apps with custom AI polish. See which fits your Mac and workflow today."
   activePage="compare"
   ogImage="/og-image.png"
   canonicalPath="/compare/fluidvoice/"
@@ -352,6 +353,10 @@ const faqJsonLd = JSON.stringify({
     <p class="hero-meta reveal">By <a href="/authors/saurabh-vaish/" style="color: var(--text-3); text-decoration: underline;">Saurabh Vaish</a> · Last reviewed: August 2026</p>
   </div>
 </header>
+
+<CompareDecisionSummary id="fluidvoice-vs-enviouswispr-answer" heading="FluidVoice or EnviousWispr: which should you choose?">
+  <p>Both apps are free, GPLv3, and can transcribe and polish speech on your Mac. Choose FluidVoice if you want fourteen speech-model choices, an Intel or Windows route, file transcription, or deeper prompt routing. Choose EnviousWispr if you want a smaller setup on macOS 14 or later, direct paste with Escape Recovery, and a built-in polish model whose base model and license are published. FluidVoice is the more configurable toolkit; EnviousWispr is the more guided default. Neither choice requires a subscription or account, so the practical decision is flexibility versus simplicity rather than price. If you dictate mainly on a newer Mac, both cover the core job well. The stronger reason to switch is a missing workflow or compatibility feature, not a basic difference in transcription privacy.</p>
+</CompareDecisionSummary>
 
 <!-- Side-by-Side Table -->
 <section class="section" aria-label="Feature Comparison">
@@ -700,7 +705,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">How is EnviousWispr different from FluidVoice?</div>
-        <p class="faq-a">Both are Mac-native, on-device, GPLv3, and ship a custom AI model tuned specifically for cleaning up dictation. EnviousWispr supports macOS 14 Sonoma and later; FluidVoice needs macOS 15 Sequoia or later. FluidVoice 1.6.9 showed fourteen speech-model choices across Apple Speech, Cohere, Nemotron, Parakeet, and Whisper. It also has deeper prompt routing, spoken formatting, file transcription, and Command Mode. EnviousWispr keeps setup smaller and adds Escape Recovery.</p>
+        <p class="faq-a">Both are Mac-native, on-device, GPLv3, and ship a custom AI model tuned specifically for cleaning up dictation. EnviousWispr supports macOS 14 Sonoma and later; FluidVoice needs macOS 15 Sequoia or later. FluidVoice 1.6.9 showed 14 speech-model choices across Apple Speech, Cohere, Nemotron, Parakeet, and Whisper; EnviousWispr offers Parakeet TDT and WhisperKit. FluidVoice also has deeper prompt routing, spoken formatting, file transcription, and Command Mode. EnviousWispr keeps setup smaller and adds Escape Recovery for a dictation cancelled by accident.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Does FluidVoice have AI polish like EnviousWispr's EG-1?</div>
@@ -724,7 +729,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Which speech engines does each app use?</div>
-        <p class="faq-a">EnviousWispr runs NVIDIA Parakeet TDT v3 for 25 European languages and WhisperKit for 99 languages. FluidVoice 1.6.9 showed fourteen choices: two Apple speech options, one Cohere model, three Parakeet models, two Nemotron models, and six Whisper sizes.</p>
+        <p class="faq-a">EnviousWispr runs NVIDIA Parakeet TDT v3 for 25 European languages and WhisperKit for 99 languages, switched manually under Settings, Transcription. FluidVoice 1.6.9 showed 14 choices: two Apple speech options, one Cohere model, three Parakeet models, two Nemotron models, and six Whisper sizes.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Does FluidVoice run on Windows or iOS?</div>

--- a/website/src/pages/compare/handy.astro
+++ b/website/src/pages/compare/handy.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import CompareDecisionSummary from '../../components/CompareDecisionSummary.astro';
 
 const siteUrl = 'https://enviouswispr.com';
 
@@ -144,7 +145,7 @@ const faqJsonLd = JSON.stringify({
 
 <BaseLayout
   title="Handy vs EnviousWispr: Free Mac Dictation, AI Polish Built In"
-  description="Compare Handy and EnviousWispr, two free, open source, on-device Mac dictation apps. Both offer AI cleanup; EnviousWispr's is a built-in model that needs no provider or prompt setup."
+  description="Compare Handy and EnviousWispr, two free, open-source, on-device dictation apps. See how AI polish, platforms, setup, and paste recovery differ on Mac."
   activePage="compare"
   ogImage="/og-image.png"
   canonicalPath="/compare/handy/"
@@ -352,6 +353,10 @@ const faqJsonLd = JSON.stringify({
     <p class="hero-meta reveal">By <a href="/authors/saurabh-vaish/" style="color: var(--text-3); text-decoration: underline;">Saurabh Vaish</a> · Last reviewed: August 2026</p>
   </div>
 </header>
+
+<CompareDecisionSummary id="handy-vs-enviouswispr-answer" heading="Handy or EnviousWispr: which should you choose?">
+  <p>Both apps are free, open source, and can keep dictation on your device. Choose Handy if you need Windows or Linux, want a large model catalog, prefer its permissive MIT license, or need to replay saved audio. Choose EnviousWispr if you want a curated Mac setup where one hotkey records, transcribes, polishes, and pastes, with Escape Recovery when a dictation is canceled by mistake. Handy is the better fit for people who enjoy choosing engines and hardware settings. EnviousWispr is the better fit for people who want local AI polish built into a simpler daily workflow. Both are credible choices for private speech-to-text. The deciding question is whether you want broad control across operating systems or a Mac-first flow with fewer switches.</p>
+</CompareDecisionSummary>
 
 <!-- Side-by-Side Table -->
 <section class="section" aria-label="Feature Comparison">

--- a/website/src/pages/compare/juno.astro
+++ b/website/src/pages/compare/juno.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import CompareDecisionSummary from '../../components/CompareDecisionSummary.astro';
 
 const siteUrl = 'https://enviouswispr.com';
 
@@ -144,7 +145,7 @@ const faqJsonLd = JSON.stringify({
 
 <BaseLayout
   title="Juno vs EnviousWispr: Free Mac Dictation on More Macs"
-  description="Compare Juno and EnviousWispr, two free, open source, on-device Mac dictation tools. Juno needs an M2 Mac with 24GB RAM; EnviousWispr runs on any M1 Mac and up."
+  description="Compare Juno and EnviousWispr, two free, open-source, on-device Mac dictation apps. See which fits your Mac, memory, and voice workflow day to day."
   activePage="compare"
   ogImage="/og-image.png"
   canonicalPath="/compare/juno/"
@@ -352,6 +353,10 @@ const faqJsonLd = JSON.stringify({
     <p class="hero-meta reveal">By <a href="/authors/saurabh-vaish/" style="color: var(--text-3); text-decoration: underline;">Saurabh Vaish</a> · Last reviewed: August 2026</p>
   </div>
 </header>
+
+<CompareDecisionSummary id="juno-vs-enviouswispr-answer" heading="Juno or EnviousWispr: which should you choose?">
+  <p>Both Juno and EnviousWispr are free, open source, and run speech processing on your Mac. Choose Juno if you have an M2 or newer Mac with at least 24GB of RAM and want voice-triggered Notes, Reminders, alarms, or spoken rewrites of selected text. Choose EnviousWispr if you have an M1 Mac, 16GB of RAM, or macOS 14, or if you want focused system-wide dictation with a smaller setup. Juno reaches beyond dictation into voice actions. EnviousWispr supports more existing Apple Silicon Macs and keeps the product centered on reliable speech-to-text, polish, and paste. The decision is unusually hardware-specific: on a supported high-memory Mac, compare the extra actions; on older or lower-memory models, EnviousWispr is the practical option.</p>
+</CompareDecisionSummary>
 
 <!-- Side-by-Side Table -->
 <section class="section" aria-label="Feature Comparison">

--- a/website/src/pages/compare/spokenly.astro
+++ b/website/src/pages/compare/spokenly.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import CompareDecisionSummary from '../../components/CompareDecisionSummary.astro';
 
 const siteUrl = 'https://enviouswispr.com';
 
@@ -344,6 +345,10 @@ const faqJsonLd = JSON.stringify({
     <p class="hero-meta reveal">By <a href="/authors/saurabh-vaish/" style="color: var(--text-3); text-decoration: underline;">Saurabh Vaish</a> · Last reviewed: August 2026</p>
   </div>
 </header>
+
+<CompareDecisionSummary id="spokenly-vs-enviouswispr-answer" heading="Spokenly or EnviousWispr: which should you choose?">
+  <p>Both can provide free local dictation, but they make different tradeoffs. Choose Spokenly if you need Windows, Linux, or iOS, want per-app AI profiles, or need Agentic Actions and coding-agent dictation. Choose EnviousWispr if you want a Mac-only app whose source code is public under GPLv3, with local speech, local polish, direct paste, and Escape Recovery in one workflow. Spokenly is broader and more automation-heavy; EnviousWispr is narrower and inspectable. Spokenly also offers a paid managed-cloud tier, while EnviousWispr has no paid tier or account requirement. For someone who wants dictation on several devices or inside agent workflows, Spokenly offers more reach. For someone who wants to inspect the app and avoid a service relationship, EnviousWispr is the clearer fit.</p>
+</CompareDecisionSummary>
 
 <!-- Side-by-Side Table -->
 <section class="section" aria-label="Feature Comparison">
@@ -709,7 +714,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">What is Spokenly's MCP integration for?</div>
-        <p class="faq-a">Spokenly exposes an MCP tool named <code>ask_user_dictation</code>. Claude Code or Codex can call it when the agent needs an answer, and you can respond by voice through Spokenly. This is a voice-response path for agent questions, not a replacement for ordinary system-wide dictation.</p>
+        <p class="faq-a">Spokenly exposes an MCP tool named <code>ask_user_dictation</code>. Claude Code or Codex can call it when the agent needs an answer, and the person can respond by voice through Spokenly. This is a voice-response path for agent questions, not a replacement for ordinary system-wide dictation.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Can I switch from Spokenly to EnviousWispr easily?</div>

--- a/website/src/pages/compare/superwhisper.astro
+++ b/website/src/pages/compare/superwhisper.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import CompareDecisionSummary from '../../components/CompareDecisionSummary.astro';
 
 const siteUrl = 'https://enviouswispr.com';
 
@@ -353,6 +354,10 @@ const faqJsonLd = JSON.stringify({
     <p class="hero-meta reveal">By <a href="/authors/saurabh-vaish/" style="color: var(--text-3); text-decoration: underline;">Saurabh Vaish</a> · Last reviewed: August 2026</p>
   </div>
 </header>
+
+<CompareDecisionSummary id="superwhisper-vs-enviouswispr-answer" heading="Superwhisper or EnviousWispr: which should you choose?">
+  <p>Choose Superwhisper if you need meeting notes, audio or video file transcription, iPhone or Windows support, a large speech and writing model library, or custom writing modes. Choose EnviousWispr if your priority is free, open-source Mac dictation with no account or subscription, local speech processing, and a smaller set of built-in defaults. Both can run transcription locally, but Superwhisper is the broader paid product and EnviousWispr is the focused free alternative. For everyday speech-to-text on an Apple Silicon Mac, the decision mainly comes down to whether you value Superwhisper's wider feature set or EnviousWispr's cost, inspectability, and simpler setup. If meetings or file work are central, Superwhisper's paid features matter. If your main job is live dictation into Mac apps, EnviousWispr covers that narrower path without a purchase.</p>
+</CompareDecisionSummary>
 
 <!-- Side-by-Side Table -->
 <section class="section" aria-label="Feature Comparison">

--- a/website/src/pages/compare/typewhisper.astro
+++ b/website/src/pages/compare/typewhisper.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import CompareDecisionSummary from '../../components/CompareDecisionSummary.astro';
 
 const siteUrl = 'https://enviouswispr.com';
 
@@ -136,7 +137,7 @@ const faqJsonLd = JSON.stringify({
 
 <BaseLayout
   title="TypeWhisper vs EnviousWispr: Free Mac Dictation, Both GPLv3"
-  description="Compare TypeWhisper and EnviousWispr, two free, GPLv3, on-device Mac dictation apps. TypeWhisper offers seven engine options across Mac and Windows; EnviousWispr ships a measured, purpose-built polish model."
+  description="Compare TypeWhisper and EnviousWispr, two free, GPLv3 Mac dictation apps. We compare local engines, file transcription, workflows, and setup side by side."
   activePage="compare"
   ogImage="/og-image.png"
   canonicalPath="/compare/typewhisper/"
@@ -344,6 +345,10 @@ const faqJsonLd = JSON.stringify({
     <p class="hero-meta reveal">By <a href="/authors/saurabh-vaish/" style="color: var(--text-3); text-decoration: underline;">Saurabh Vaish</a> · Last reviewed: August 2026</p>
   </div>
 </header>
+
+<CompareDecisionSummary id="typewhisper-vs-enviouswispr-answer" heading="TypeWhisper or EnviousWispr: which should you choose?">
+  <p>Both apps have free GPLv3 cores and can run Mac dictation locally. Choose TypeWhisper if you want seven speech engines, Windows support, file transcription, or Workflows that connect your own prompts, providers, translation, and automation steps. Choose EnviousWispr if you want two curated speech engines plus a purpose-built polish model that works without building a workflow. TypeWhisper is the stronger toolkit for people who want to configure the pipeline. EnviousWispr is the simpler option for people who want to install the app, choose a hotkey, and get polished text at the cursor with fewer decisions. The meaningful difference is control: TypeWhisper exposes more of the system, while EnviousWispr makes more choices for you. Both can keep ordinary dictation on the Mac.</p>
+</CompareDecisionSummary>
 
 <!-- Side-by-Side Table -->
 <section class="section" aria-label="Feature Comparison">

--- a/website/src/pages/compare/vox.astro
+++ b/website/src/pages/compare/vox.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import CompareDecisionSummary from '../../components/CompareDecisionSummary.astro';
 
 const siteUrl = 'https://enviouswispr.com';
 
@@ -49,18 +50,18 @@ const faqJsonLd = JSON.stringify({
     },
     {
       "@type": "Question",
-      "name": "What is VoxNotch?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "It is a local task list that sits at the top of the Mac screen. You can add, finish, remove, reorder, and reprioritize tasks by speaking naturally."
-      }
-    },
-    {
-      "@type": "Question",
       "name": "Does Vox have AI cleanup like EnviousWispr's EG-1?",
       "acceptedAnswer": {
         "@type": "Answer",
         "text": "Yes. Vox can clean up text locally with a downloaded Gemma 4 model. It also offers Apple Intelligence, which may route text through Apple's Private Cloud Compute. Vox's built-in and custom Voice Modes control how cleanup behaves. EnviousWispr offers EG-1, Apple Intelligence, or a downloaded Ollama model locally, plus optional cloud providers with your own key."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is VoxNotch?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "It is a local task list that sits at the top of the Mac screen. You can add, finish, remove, reorder, and reprioritize tasks by speaking naturally."
       }
     },
     {
@@ -85,7 +86,7 @@ const faqJsonLd = JSON.stringify({
 
 <BaseLayout
   title="Vox vs EnviousWispr: Two Local Dictation Apps Compared"
-  description="Compare Vox and EnviousWispr on local transcription, AI cleanup, Voice Modes, pricing, platforms, and everyday paste behavior."
+  description="Compare Vox and EnviousWispr for local Mac dictation, AI cleanup, Voice Modes, pricing, Windows support, and everyday paste behavior side by side."
   activePage="compare"
   ogImage="/og-image.png"
   canonicalPath="/compare/vox/"
@@ -281,6 +282,10 @@ const faqJsonLd = JSON.stringify({
     <p class="hero-meta reveal">By <a href="/authors/saurabh-vaish/" style="color: var(--text-3); text-decoration: underline;">Saurabh Vaish</a> · Last reviewed: August 2026</p>
   </div>
 </header>
+
+<CompareDecisionSummary id="vox-vs-enviouswispr-answer" heading="Vox or EnviousWispr: which should you choose?">
+  <p>Both Vox and EnviousWispr can transcribe speech and clean up text locally on Apple Silicon Macs. Choose Vox if you want editable Voice Modes, automatic app-based mode suggestions, Windows support, or the VoxNotch voice-controlled task list. Choose EnviousWispr if you want free personal and work use, GPLv3 source code, direct paste, Escape Recovery, and the option to use local models or your own cloud provider. Vox is the more mode-driven product; EnviousWispr is the smaller open workflow. For personal use both are free, but Vox requires a paid license for work at companies with more than one person. Choose based on the workflow you will actually use: Vox rewards people who create multiple modes and use tasks, while EnviousWispr keeps dictation and polish in one path.</p>
+</CompareDecisionSummary>
 
 <section class="section" aria-label="Feature Comparison">
   <div class="container">

--- a/website/src/pages/compare/wisprflow.astro
+++ b/website/src/pages/compare/wisprflow.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import CompareDecisionSummary from '../../components/CompareDecisionSummary.astro';
 
 const siteUrl = 'https://enviouswispr.com';
 
@@ -361,6 +362,10 @@ const faqJsonLd = JSON.stringify({
     <p class="hero-meta reveal">By <a href="/authors/saurabh-vaish/" style="color: var(--text-3); text-decoration: underline;">Saurabh Vaish</a> · Last reviewed: August 2026</p>
   </div>
 </header>
+
+<CompareDecisionSummary id="wisprflow-vs-enviouswispr-answer" heading="WisprFlow or EnviousWispr: which should you choose?">
+  <p>Choose WisprFlow if you need dictation across Mac, Windows, iPhone, and Android, or want its broader set of snippets, shared dictionaries, app styles, backtrack, meeting, team, and enterprise controls. Choose EnviousWispr if you want free, open-source Mac dictation where audio is always transcribed on your device and no account or subscription is required. WisprFlow is the more mature cross-device service. EnviousWispr is the private, Mac-focused alternative with local speech, optional local polish, direct paste, and Escape Recovery. The key tradeoff is breadth and sync versus local control, price, and source-code transparency. If you move between devices or administer a team, WisprFlow's service model is useful. If you work on one Mac and want fewer external dependencies, EnviousWispr fits that constraint.</p>
+</CompareDecisionSummary>
 
 <!-- Side-by-Side Table -->
 <section class="section" aria-label="Feature Comparison">


### PR DESCRIPTION
## Summary

- add a unique, direct choice answer to eight refreshed comparison pages
- link each answer to the use-case roundup and the full comparison directory
- tighten new-page search descriptions while preserving the existing data-backed WisprFlow and Superwhisper titles
- restore exact FAQ/schema parity found during validation on FluidVoice, Spokenly, and Vox

## Why

Current results for Mac dictation and competitor alternatives favor pages that answer the choice directly. These additions make each page easier for people and AI answer engines to extract without turning the pages into repetitive templates or undoing the hub-versus-roundup query split from #2248.

## Validation

- production Astro build: 132 pages
- 20 compare pages: unique titles and descriptions
- 8 answer blocks: 134 to 167 words, pairwise uniqueness check passed
- canonical, Article, BreadcrumbList, FAQPage, FAQ parity, internal route, and local-link checks passed
- compare sitemap coverage: 20 of 20 pages
- AI crawler rules verified for GPTBot, ChatGPT-User, OAI-SearchBot, ClaudeBot, PerplexityBot, and Google-Extended
- desktop browser review at 1440px passed
- mobile browser review at 390px passed with no horizontal overflow
- independent committed-diff review found one shared spacing defect; fixed and confirming review passed

Closes #2308
