### PR TITLE
fix(test): wait for A13 clock registration

### DIFF
--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeClock.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeClock.swift
@@ -50,10 +50,11 @@ final class FakeClock {
   /// it rather than absorbed by it.
   ///
   /// So it is a signal a future drain COULD consume, kept because the window is
-  /// real and nothing else names it. What it is not is evidence that any window
-  /// is currently guarded, and A13 in particular is not: that flake is lost
-  /// between `spawn` and the sleep REGISTERING, where this counter reads zero.
-  /// `registeredWaiterCount` below is the signal that window needs.
+  /// real and nothing else names it. What it is not is evidence that the A13
+  /// window is guarded: that flake is lost between `spawn` and the sleep
+  /// REGISTERING, where this counter reads zero. A13 now uses
+  /// `triggerAwaitingClockRegistration`, which waits on `registeredWaiterCount`
+  /// below before advancing the logical clock.
   ///
   /// Incremented at BOTH resume sites and decremented by the resumed task
   /// itself, on the first line that runs after its `await`. `sleep(ticks:)`

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
@@ -471,8 +471,9 @@ final class KernelRecordingSession: RecordingSessionDriving {
   ///
   /// Scope: this gate covers ONLY the recording-exit hand-off, behind the
   /// recurring `interleavingSweep` `got recording` failure. It is not the only
-  /// observed window — A13 below is another, and is not covered. The same
-  /// bump-absorption shape exists at other continuations resumed inside a step's
+  /// observed window — A13 below is another, and is not covered by THIS drain.
+  /// `ScenarioRunner` waits for A13's clock registration before advancing. The
+  /// same bump-absorption shape exists at other continuations resumed inside a step's
   /// `apply` — `FakeClock.advance(by:)` resuming a sleep, a VAD
   /// `AsyncStream.yield` — and neither is gated here.
   ///
@@ -491,8 +492,8 @@ final class KernelRecordingSession: RecordingSessionDriving {
   /// preceded it — A13 is itself a stale-state-after-`advanceClock` failure that
   /// the counter cannot see, so "it followed an advance" does not pick the fix. A
   /// case that deliberately opens the resume-to-run window wants the counter
-  /// clause added HERE; A13 wants registration tracked, a different mechanism,
-  /// recorded on #1868.
+  /// clause added HERE; A13 uses the separate registration mechanism encoded by
+  /// `triggerAwaitingClockRegistration` in its scenario script (#1868).
   func drainReadyWork() async {
     var last = kernel.workEpoch
     var stable = 0

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/Scenario.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/Scenario.swift
@@ -110,6 +110,12 @@ enum VADDirective: Sendable {
 /// One step in a scenario's ordered script.
 enum ScenarioStep: Sendable {
   case trigger(SessionTrigger)
+  /// Apply a trigger that is known to spawn one new logical-clock sleeper,
+  /// then wait for that sleeper's real registration signal before allowing
+  /// the next scenario step to run. This is intentionally explicit: most
+  /// triggers schedule no clock work, so a blanket registration wait would
+  /// strand ordinary scenarios.
+  case triggerAwaitingClockRegistration(SessionTrigger)
   case advanceClock(ticks: Int)
   case engine(EngineDirective)
   case capture(CaptureDirective)

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioInventory.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioInventory.swift
@@ -171,12 +171,14 @@ enum ScenarioInventory {
     Scenario(
       // .wedgeOnFinalize emits a few finalize-progress ticks then goes silent;
       // the kernel's finalize wedge watcher arms on the first tick and fires
-      // after a stall window of logical time (PR-3 plan §3.7). The advanceClock
-      // step supplies that window; the trailing cancel hits a terminal state.
+      // after a stall window of logical time (PR-3 plan §3.7). STOP waits for
+      // the watcher's real clock registration before advanceClock supplies that
+      // window; the trailing cancel then hits an already-terminal state (#1868).
       id: "A13", name: "adapter wedge on finalize",
       steps: [
         .engine(.setBehavior(.wedgeOnFinalize)),
-        .trigger(.start), .capture(.deliverBuffer), .trigger(.stop),
+        .trigger(.start), .capture(.deliverBuffer),
+        .triggerAwaitingClockRegistration(.stop),
         .advanceClock(ticks: 4), .trigger(.cancel),
       ],
       expected: ExpectedOutcome(

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioRunner.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioRunner.swift
@@ -104,6 +104,19 @@ struct ScenarioRunner {
     case .trigger(let trigger):
       await context.sut.apply(trigger)
 
+    case .triggerAwaitingClockRegistration(let trigger):
+      // #1868: A13's finalize-progress consumer spawns its wedge watcher, but
+      // the watcher may not have reached `FakeClock.sleep` yet. Advancing in
+      // that spawn-to-register window moves an empty clock and makes the
+      // watcher's deadline four ticks late, so the following cancel wins.
+      // Capture the monotonic count BEFORE the trigger, then wait for the
+      // clock's own registration event. A bounded fall-through would recreate
+      // the bug; this step is used only where a new sleeper is part of the
+      // scenario's declared meaning.
+      let requiredRegistration = context.clock.registeredWaiterCount + 1
+      await context.sut.apply(trigger)
+      await context.clock.waitForRegistrations(requiredRegistration)
+
     case .advanceClock(let ticks):
       context.clock.advance(by: ticks)
 

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioRunnerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioRunnerTests.swift
@@ -34,8 +34,10 @@ struct ScenarioRunnerTests {
     return makeContext(sut: stub)
   }
 
-  private func makeContext(sut: RecordingSessionDriving) -> SimulatorContext {
-    let clock = FakeClock()
+  private func makeContext(
+    sut: RecordingSessionDriving,
+    clock: FakeClock = FakeClock()
+  ) -> SimulatorContext {
     return SimulatorContext(
       sut: sut,
       engine: FakeEngine(behavior: .batchSuccess(text: "hello"), clock: clock),
@@ -187,5 +189,63 @@ struct ScenarioRunnerTests {
       spy.concludedCalls == 0,
       "#1868: `.idle` is not terminal, so A16 and its kin must keep the plain drain.")
     #expect(spy.readyWorkCalls > 0, "the plain drain must still run")
+  }
+
+  @Test("a clock-gated trigger waits for its sleeper to register before the next step")
+  func clockGatedTriggerWaitsForRegistration() async {
+    let clock = FakeClock()
+    var sleeper: Task<Void, Never>?
+    let stub = StubRecordingSession { trigger, _ in
+      guard trigger == .stop else { return }
+      sleeper = Task { @MainActor in await clock.sleep(ticks: 1) }
+    }
+    let scenario = Scenario(
+      id: "SELFTEST-1868-CLOCK-REGISTRATION",
+      name: "clock advance waits for the sleeper it is meant to drive",
+      steps: [
+        .triggerAwaitingClockRegistration(.stop),
+        .advanceClock(ticks: 1),
+      ],
+      expected: ExpectedOutcome(
+        terminalState: .idle, pasteCount: 0, pasteOutcome: .none, transcript: .none))
+
+    _ = await ScenarioRunner().run(
+      scenario,
+      context: makeContext(sut: stub, clock: clock))
+
+    let registrationsBeforeCleanup = clock.registeredWaiterCount
+    #expect(
+      registrationsBeforeCleanup == 1,
+      """
+      #1868: the runner must not advance to the next step until the trigger's \
+      sleeper has actually registered. Without that wait, this deterministic \
+      stub leaves the count at zero when the runner returns.
+      """)
+
+    // Keep the negative mutation non-hanging: if the runner returned early,
+    // let the orphaned sleeper register, then release it before this test exits.
+    if registrationsBeforeCleanup == 0 {
+      await clock.waitForRegistrations(1)
+      clock.drainPending()
+    }
+    if let sleeper { await sleeper.value }
+  }
+
+  @Test("A13 binds STOP to registration before it advances the wedge clock")
+  func a13WaitsForWedgeWatcherRegistration() {
+    let a13 = ScenarioInventory.all.first { $0.id == "A13" }
+    let hasBoundStop = a13?.steps.indices.dropLast().contains { index in
+      guard case .triggerAwaitingClockRegistration(.stop) = a13?.steps[index],
+            case .advanceClock = a13?.steps[index + 1]
+      else { return false }
+      return true
+    } ?? false
+
+    #expect(
+      hasBoundStop,
+      """
+      A13 must wait for the finalize wedge watcher to register before advancing \
+      the logical clock; a plain STOP reopens the CI-only spawn-to-register race.
+      """)
   }
 }


### PR DESCRIPTION
Closes #1868

## What changed

- adds an explicit simulator step for triggers that must register a new logical-clock sleeper
- makes A13 wait for the STOP wedge watcher to register before advancing the fake clock
- adds runner and scenario-binding guards for the spawn-to-registration race
- updates harness comments to match the new ownership boundary

This changes test infrastructure only; production behavior is unchanged. It uses a real registration signal instead of widening yields or adding a timing window.

## Validation

- ScenarioRunnerTests: 9/9 green
- RecordingSessionKernelScenarioTests: both top-level tests green, including 38 inventory cases and the 64-schedule contention sweep
- Debug lane: 6,357 tests green
- mutation 1: removing the registration wait failed the new runner guard
- mutation 2: reverting A13 to a plain STOP trigger failed the A13 binding guard
- pinned Codex review: clean