### PR TITLE
feat(test): express mutation outcome sets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,6 +206,7 @@ scripts/lib/*
 # battery becomes a rubber stamp.
 !scripts/mutation-battery.py
 !scripts/mutation-battery-test.py
+!scripts/validate-mutation-recipe.py
 # UAT helpers (per-PR Swift CLIs invoked during Live UAT, e.g. issue #845 keychain verifier)
 !scripts/uat/
 !scripts/uat/**

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -17,6 +17,7 @@ import tempfile
 from pathlib import Path
 
 BATTERY = Path(__file__).resolve().parent / "mutation-battery.py"
+VALIDATOR = Path(__file__).resolve().parent / "validate-mutation-recipe.py"
 
 VALID_ROW = {
     "label": "a representative mutation",
@@ -135,10 +136,38 @@ check("suite_default supplies a missing per-row suite",
       expect_exit=0, top={"suite_default": "EnviousWisprTests/ThingTests"})
 
 # --- each rejection, paired against the accepted case above ---------------------------------------
-for field in ("label", "file", "anchor", "replacement", "expect_fail"):
+for field in ("label", "file", "anchor", "replacement"):
     check(f"missing '{field}' is refused",
           [{k: v for k, v in VALID_ROW.items() if k != field}],
           expect_exit=2, expect_text=f"missing required field '{field}'")
+
+SET_ROW = {
+    k: v for k, v in VALID_ROW.items() if k != "expect_fail"
+}
+SET_ROW["must_fire"] = []
+SET_ROW["must_not_fire"] = [VALID_ROW["expect_fail"]]
+
+check("must_fire may be empty to declare an expected survivor",
+      [dict(SET_ROW)], expect_exit=0, expect_text="1 row(s) well-formed")
+check("a row with neither expectation form is refused",
+      [{k: v for k, v in VALID_ROW.items() if k != "expect_fail"}],
+      expect_exit=2, expect_text="exactly one of 'expect_fail' or 'must_fire'")
+check("a row with both expectation forms is refused",
+      [dict(VALID_ROW, must_fire=[VALID_ROW["expect_fail"]])],
+      expect_exit=2, expect_text="exactly one of 'expect_fail' or 'must_fire'")
+check("must_fire must be a list of test names",
+      [dict(SET_ROW, must_fire=VALID_ROW["expect_fail"])],
+      expect_exit=2, expect_text="must be a list of non-empty test-name strings")
+check("must_not_fire rejects duplicate test names",
+      [dict(SET_ROW, must_not_fire=[VALID_ROW["expect_fail"], VALID_ROW["expect_fail"]])],
+      expect_exit=2, expect_text="contains duplicate test names")
+check("must_fire and must_not_fire cannot contradict each other",
+      [dict(SET_ROW, must_fire=[VALID_ROW["expect_fail"]],
+            must_not_fire=[VALID_ROW["expect_fail"]])],
+      expect_exit=2, expect_text="both must_fire and must_not_fire")
+check("legacy expect_fail cannot silently absorb must_not_fire",
+      [dict(VALID_ROW, must_not_fire=["some other case"])],
+      expect_exit=2, expect_text="cannot also declare 'must_not_fire'")
 
 check("a bare suite name is refused as not target-qualified",
       [dict(VALID_ROW, suite="ThingTests")],
@@ -454,14 +483,14 @@ import contextlib  # noqa: E402
 ORIGINAL = "let guarded = true\n"
 
 
-def drive_row(lane_result, *, expect_verdict, expect_detail, raise_instead=None):
+def drive_row(lane_result, *, expect_verdict, expect_detail, raise_instead=None, recipe_row=None):
     """Run one row with a stubbed lane; return (verdict, detail, file_bytes_after)."""
     import tempfile as _t
     with _t.TemporaryDirectory() as td:
         tmp = make_tree(Path(td))
         target = tmp / "Sources" / "Thing.swift"
         recipes = tmp / "r.json"
-        recipes.write_text(json.dumps({"rows": [dict(VALID_ROW)]}))
+        recipes.write_text(json.dumps({"rows": [dict(recipe_row or VALID_ROW)]}))
 
         seen = {}
 
@@ -492,12 +521,12 @@ def drive_row(lane_result, *, expect_verdict, expect_detail, raise_instead=None)
         return rc, buf.getvalue(), target.read_text(), seen.get("content_during_run")
 
 
-def check_row(name, lane_result, *, expect_marker, expect_rc, raise_instead=None):
+def check_row(name, lane_result, *, expect_marker, expect_rc, raise_instead=None, recipe_row=None):
     global ran, failures
     ran += 1
     try:
         rc, out, after, during = drive_row(lane_result, expect_verdict=None, expect_detail=None,
-                                           raise_instead=raise_instead)
+                                           raise_instead=raise_instead, recipe_row=recipe_row)
     except Exception as exc:
         failures.append(f"{name}: driver raised {type(exc).__name__}: {exc}")
         return
@@ -522,6 +551,30 @@ check_row("the named test failing scores CAUGHT",
           (5, [], True, "log", 65, 3.0,
            mk_results({VALID_ROW["expect_fail"]: "Failed", "some other case": "Passed"})),
           expect_marker="CAUGHT", expect_rc=0)
+
+_joint_row = dict(SET_ROW, must_fire=[VALID_ROW["expect_fail"]],
+                  must_not_fire=["some other case"])
+check_row("joint fire and silence expectations can both match",
+          (5, [], True, "log", 65, 3.0,
+           mk_results({VALID_ROW["expect_fail"]: "Failed", "some other case": "Passed"})),
+          expect_marker="EXPECTED", expect_rc=0, recipe_row=_joint_row)
+
+_survivor_row = dict(SET_ROW, must_fire=[], must_not_fire=[VALID_ROW["expect_fail"]])
+check_row("an expected survivor is a successful result, not a weak-test warning",
+          (5, [], True, "log", 0, 3.0,
+           mk_results({VALID_ROW["expect_fail"]: "Passed", "some other case": "Passed"})),
+          expect_marker="expected survivor matched", expect_rc=0, recipe_row=_survivor_row)
+
+check_row("an expected survivor fails closed when any test fires",
+          (5, [], True, "log", 65, 3.0,
+           mk_results({VALID_ROW["expect_fail"]: "Passed", "some other case": "Failed"})),
+          expect_marker="EXPECTATION-MISMATCH", expect_rc=1, recipe_row=_survivor_row)
+
+check_row("an expected survivor refuses a red lane with a partial green bundle",
+          (5, [], True, "log", 65, 3.0,
+           mk_results({VALID_ROW["expect_fail"]: "Passed", "some other case": "Passed"})),
+          expect_marker="expected-survivor lane exited 65", expect_rc=1,
+          recipe_row=_survivor_row)
 
 # THE STATE THE CONSOLE COULD NOT EXPRESS. Nothing changed status, so the mutation
 # never reached anything the suite observes — today that scored identically to a
@@ -693,6 +746,56 @@ if _problems:
                     + "; ".join(_problems))
 else:
     print("  ok  an unchanged test set names BOTH causes and asserts neither")
+
+# #2224 gap 5: a row may declare a joint expectation instead of pretending every
+# SURVIVED result means a weak test. The fire set is exact, and named silent
+# controls must remain status-identical to their clean baseline.
+ran += 1
+_set_base = mk_results({"guard": "Passed", "independent": "Passed", "sibling": "Passed"})
+_set_mut = mk_results({"guard": "Failed", "independent": "Passed", "sibling": "Passed"})
+_v_set, _d_set = battery.classify_expectations(
+    _set_base, _set_mut, ["guard"], ["independent"])
+if _v_set != battery.VERDICT_EXPECTED:
+    failures.append(f"an exact fire set plus a silent control can match — got {_v_set}: {_d_set}")
+else:
+    print("  ok  an exact fire set plus a silent control can match")
+
+ran += 1
+_v_extra, _d_extra = battery.classify_expectations(
+    _set_base,
+    mk_results({"guard": "Failed", "independent": "Passed", "sibling": "Failed"}),
+    ["guard"], ["independent"])
+if _v_extra != battery.VERDICT_MISMATCH or "unexpected test(s) fired" not in _d_extra:
+    failures.append("an extra red outside must_fire is an expectation mismatch")
+else:
+    print("  ok  an extra red outside must_fire is an expectation mismatch")
+
+ran += 1
+_v_silent, _d_silent = battery.classify_expectations(
+    _set_base,
+    mk_results({"guard": "Failed", "independent": "Skipped", "sibling": "Passed"}),
+    ["guard"], ["independent"])
+if _v_silent != battery.VERDICT_MISMATCH or "changed status" not in _d_silent:
+    failures.append("must_not_fire requires status silence, not merely absence from the failed set")
+else:
+    print("  ok  must_not_fire requires status silence")
+
+ran += 1
+_v_overlap, _d_overlap = battery.classify_expectations(
+    _set_base, _set_mut, ["guard"], ["guard"])
+if _v_overlap != battery.VERDICT_INVALID or "both must_fire and must_not_fire" not in _d_overlap:
+    failures.append("a test declared in both expectation sets must invalidate the row")
+else:
+    print("  ok  overlapping fire and silence sets invalidate the row")
+
+ran += 1
+_v_incomplete, _d_incomplete = battery.classify_expectations(
+    _set_base, mk_results({"guard": "Failed"}), ["guard"], [])
+if (_v_incomplete != battery.VERDICT_MISMATCH
+        or "omitted 2 baseline test(s)" not in _d_incomplete):
+    failures.append("an incomplete mutated bundle cannot satisfy an exact fire set")
+else:
+    print("  ok  an incomplete mutated bundle cannot satisfy an exact fire set")
 
 # P1a: the row gate is fed from the BUNDLE, so a parameterized identifier resolves.
 # The console has no addressable name for one, so a console-derived gate refused
@@ -1856,6 +1959,178 @@ if _mismatch:
     failures.append("a documented return shape matches the code — it does not: " + "; ".join(_mismatch))
 else:
     print("  ok  a documented return shape matches the code")
+
+# --- filing-time validator accepts exactly the schemas the runner accepts ------------------------
+def check_validator(name, row=None, *, document=None, expected_rc, expected_text):
+    global ran
+    ran += 1
+    with tempfile.TemporaryDirectory() as td:
+        recipe = Path(td) / "recipe.json"
+        recipe.write_text(json.dumps(document if document is not None else {"rows": [row]}))
+        result = subprocess.run(
+            [sys.executable, str(VALIDATOR), "--recipes", str(recipe),
+             "--checkout", str(BATTERY.parent.parent)],
+            capture_output=True, text=True,
+        )
+    output = result.stdout + result.stderr
+    if result.returncode != expected_rc or expected_text not in output:
+        failures.append(
+            f"{name}: exit {result.returncode}, wanted {expected_rc}; "
+            f"missing {expected_text!r} in {output[:300]!r}")
+    else:
+        print(f"  ok  {name}")
+
+
+_validator_base = {
+    "label": "validator schema control",
+    "file": "Sources/EnviousWisprAppKit/Views/Settings/AIPolishProviderRail.swift",
+    "anchor": "  // progress is kept, so this is a setup state, never an error.",
+    "replacement": "  // progress remains, so this is a setup state, never an error.",
+    "suite": "EnviousWisprTests/ProviderStatusMappingTests",
+}
+_guard_name = "EG-1 not installed → Not installed / needs-setup"
+_silent_name = "EG-1 paused → Paused / needs-setup"
+
+check_validator("the filing validator still accepts the legacy expect_fail schema",
+                dict(_validator_base, expect_fail=_guard_name),
+                expected_rc=0, expected_text="1/1 rows runnable")
+check_validator("the filing validator accepts fire and silence expectation sets",
+                dict(_validator_base, must_fire=[_guard_name], must_not_fire=[_silent_name]),
+                expected_rc=0, expected_text="1/1 rows runnable")
+check_validator("the filing validator rejects cross-set aliases for the same test",
+                dict(_validator_base, must_fire=[_guard_name],
+                     must_not_fire=["ProviderStatusMappingTests/egOneNotInstalled()"]),
+                expected_rc=1, expected_text="resolve to the same test")
+check_validator("the filing validator checks every name in both expectation sets",
+                dict(_validator_base, must_fire=[_guard_name],
+                     must_not_fire=["this test does not exist"]),
+                expected_rc=1, expected_text="DOES NOT EXIST")
+check_validator("the filing validator refuses a row carrying both schemas",
+                dict(_validator_base, expect_fail=_guard_name, must_fire=[_guard_name]),
+                expected_rc=1, expected_text="must declare exactly one of")
+check_validator("the filing validator rejects a recipe containing zero rows",
+                document={"rows": []}, expected_rc=1, expected_text="declares no rows")
+check_validator("the filing validator checks names inside the selected suite",
+                dict(_validator_base, expect_fail=_guard_name,
+                     suite="EnviousWisprTests/TerminalProcessScannerTests"),
+                expected_rc=1, expected_text="DOES NOT EXIST")
+check_validator("the filing validator decodes escaped Swift display names",
+                dict(_validator_base,
+                     expect_fail='hardware class is real, never "unknown"',
+                     suite="EnviousWisprTests/LaunchAvailabilitySnapshotTests"),
+                expected_rc=0, expected_text="1/1 rows runnable")
+check_validator("the filing validator keeps later tests in their enclosing suite",
+                dict(_validator_base, expect_fail="proxyErrorRecyclesConnection()",
+                     suite="EnviousWisprASRTests/ParakeetDeliveryModeTests"),
+                expected_rc=0, expected_text="1/1 rows runnable")
+check_validator("the filing validator does not invent a parameter suffix",
+                dict(_validator_base, expect_fail="egOnePaused(_:)"),
+                expected_rc=1, expected_text="DOES NOT EXIST")
+check_validator("the filing validator derives a real parameter suffix",
+                dict(_validator_base,
+                     expect_fail="egOneUpdatePausedReadsAsNeedingAttention(_:)"),
+                expected_rc=0, expected_text="1/1 rows runnable")
+check_validator("the filing validator does not accept a raw function name",
+                dict(_validator_base, expect_fail="egOnePaused"),
+                expected_rc=1, expected_text="PREFIX, not a full test name")
+check_validator("the filing validator does not treat an arguments value as a display name",
+                dict(_validator_base, expect_fail="gpt-5.6-sol",
+                     suite="EnviousWisprTests/OpenAIRequestBodyTests"),
+                expected_rc=1, expected_text="DOES NOT EXIST")
+check_validator("the filing validator validates the test target as well as the suite",
+                dict(_validator_base, expect_fail=_guard_name,
+                     suite="BogusTarget/ProviderStatusMappingTests"),
+                expected_rc=1, expected_text="NOT FOUND in Tests")
+check_validator("the filing validator accepts a test active in the Debug lane",
+                dict(_validator_base,
+                     expect_fail="Debug build: log() emits the marker into the file sink",
+                     suite="EnviousWisprTests/AppLoggerCompileOutTests"),
+                expected_rc=0, expected_text="1/1 rows runnable")
+check_validator("the filing validator excludes a release-only test from the Debug lane",
+                dict(_validator_base,
+                     expect_fail="Release build: log() does NOT emit the marker (sink is dead code)",
+                     suite="EnviousWisprTests/AppLoggerCompileOutTests"),
+                expected_rc=1, expected_text="DOES NOT EXIST")
+check_validator("the filing validator does not parse Swift inside a raw multiline fixture",
+                dict(_validator_base, expect_fail="notReal()",
+                     suite="EnviousWisprTests/NotReal"),
+                expected_rc=1, expected_text="DOES NOT EXIST")
+check_validator("the filing validator rejects a test in an environment-gated suite",
+                dict(_validator_base,
+                     expect_fail="everyOfferedModelPolishesSuccessfully()",
+                     suite="EnviousWisprTests/OpenAILiveSweepTests"),
+                expected_rc=1, expected_text="DOES NOT EXIST")
+check_validator("the filing validator rejects a runtime-gated individual test",
+                dict(_validator_base,
+                     expect_fail="filteredSweepFindsWhatTheFullSweepFinds()",
+                     suite="EnviousWisprTests/TerminalProcessScannerTests"),
+                expected_rc=1, expected_text="DOES NOT EXIST")
+
+_validator_spec = importlib.util.spec_from_file_location("mutation_validator", VALIDATOR)
+validator = importlib.util.module_from_spec(_validator_spec)
+_validator_spec.loader.exec_module(validator)
+ran += 1
+_real_read_text = Path.read_text
+
+
+def _fail_one_test_source(path, *args, **kwargs):
+    if path.name == "ProviderStatusMappingTests.swift":
+        raise OSError("simulated unreadable test source")
+    return _real_read_text(path, *args, **kwargs)
+
+
+Path.read_text = _fail_one_test_source
+try:
+    try:
+        validator.test_oracle(BATTERY.parent.parent)
+        failures.append("an unreadable test source refuses the entire filing-time oracle")
+    except RuntimeError as error:
+        if "cannot read test source" not in str(error):
+            failures.append(f"an unreadable test source refused for the wrong reason: {error}")
+        else:
+            print("  ok  an unreadable test source refuses the entire filing-time oracle")
+finally:
+    Path.read_text = _real_read_text
+
+ran += 1
+result = subprocess.run(
+    [sys.executable, str(VALIDATOR), "--issue", "0",
+     "--checkout", str(BATTERY.parent.parent)],
+    capture_output=True, text=True,
+)
+_zero_issue_output = result.stdout + result.stderr
+if (result.returncode != 2 or "issue number must be positive" not in _zero_issue_output
+        or "Traceback" in _zero_issue_output):
+    failures.append(
+        "the filing validator refuses --issue 0 cleanly — "
+        f"exit {result.returncode}: {_zero_issue_output[:250]!r}")
+else:
+    print("  ok  the filing validator refuses --issue 0 cleanly")
+
+ran += 1
+with tempfile.TemporaryDirectory() as td:
+    fake_bin = Path(td) / "bin"
+    fake_bin.mkdir()
+    fake_gh = fake_bin / "gh"
+    fake_gh.write_text(
+        "#!/bin/sh\n"
+        "printf '%s\\n' '```json' '{\"rows\": []}' '```' "
+        "'```json' '{\"rows\": []}' '```'\n")
+    fake_gh.chmod(0o755)
+    env = dict(NEUTRAL_ENV)
+    env["PATH"] = str(fake_bin) + ":" + env.get("PATH", "")
+    result = subprocess.run(
+        [sys.executable, str(VALIDATOR), "--issue", "1",
+         "--checkout", str(BATTERY.parent.parent)],
+        capture_output=True, text=True, env=env,
+    )
+_issue_output = result.stdout + result.stderr
+if result.returncode != 2 or "carries 2 ```json blocks" not in _issue_output:
+    failures.append(
+        "the filing validator shares the runner's single-recipe issue contract — "
+        f"exit {result.returncode}: {_issue_output[:250]!r}")
+else:
+    print("  ok  the filing validator shares the runner's single-recipe issue contract")
 
 print()
 if failures:

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -345,6 +345,61 @@ check_fence("two json blocks are both seen, so the caller can refuse",
             "```json\n{}\n```\ntext\n```json\n{}\n```\n", expect_blocks=2)
 
 
+MARKDOWN_RECIPE = """```mutation-recipe
+| mode | label | file | anchor | replacement | suite | must_fire | must_not_fire | instruction |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| mechanical | invert the gate | `Sources/Thing.swift` | `let guarded = true` | `let guarded = false` | `EnviousWisprTests/ThingTests` | `the guard fires`<br>`the second guard fires` | `the control stays green` | |
+| human | restore the semantic route | | | | `EnviousWisprTests/ThingTests` | `the semantic guard fires` | `the independent control stays green` | Route the refusal through the old public outcome. |
+```"""
+
+ran += 1
+try:
+    _markdown_doc = battery.issue_recipe_document(2156, MARKDOWN_RECIPE)
+    _mechanical, _human = _markdown_doc["rows"]
+    assert _mechanical["must_fire"] == ["the guard fires", "the second guard fires"]
+    assert _mechanical["must_not_fire"] == ["the control stays green"]
+    assert _human["mode"] == "human"
+    assert _human["must_fire"] == ["the semantic guard fires"]
+    assert _human["must_not_fire"] == ["the independent control stays green"]
+    assert "old public outcome" in _human["instruction"]
+    assert battery.select_recipe_row(_markdown_doc["rows"], 1)[0]["mode"] == "mechanical"
+    assert battery.select_recipe_row(_markdown_doc["rows"], 2)[0]["mode"] == "human"
+    assert battery.select_recipe_row([_human, _mechanical], 2)[0]["label"] == "invert the gate"
+    import tempfile as _markdown_tf
+    with _markdown_tf.TemporaryDirectory() as _markdown_td:
+        _markdown_tree = make_tree(Path(_markdown_td))
+        _normalized_mixed = battery.load_recipes(
+            None, _markdown_tree, raw=json.dumps({"rows": [_human, _mechanical]}))
+        assert _normalized_mixed[0]["_recipe_index"] == 1
+        assert _normalized_mixed[1]["_recipe_index"] == 2
+        assert _normalized_mixed[0]["must_fire"] == ["the semantic guard fires"]
+    print("  ok  a strict Markdown table preserves mechanical sets and human instructions")
+except Exception as exc:
+    failures.append(f"a valid Markdown recipe was not parsed faithfully: {exc}")
+
+ran += 1
+try:
+    battery.issue_recipe_document(2156, MARKDOWN_RECIPE + '\n```json\n{"rows": []}\n```')
+except battery.Refusal as exc:
+    if "2 explicit recipe blocks" in str(exc):
+        print("  ok  mixed JSON and Markdown blocks are refused as ambiguous")
+    else:
+        failures.append(f"mixed recipe blocks refused for the wrong reason: {exc}")
+else:
+    failures.append("mixed JSON and Markdown blocks were accepted — the runner could pick the wrong one")
+
+ran += 1
+try:
+    battery.issue_recipe_document(2156, "prose only")
+except battery.Refusal as exc:
+    if "Free-form prose is never guessed" in str(exc):
+        print("  ok  free-form English is refused rather than guessed into source code")
+    else:
+        failures.append(f"free-form prose refused for the wrong reason: {exc}")
+else:
+    failures.append("free-form prose was guessed into a source mutation")
+
+
 def check_raw(name, raw, *, expect_text):
     global ran, failures
     ran += 1
@@ -464,10 +519,12 @@ else:
 check_issue("an issue with exactly one recipe block is accepted",
             rc=0, body='prose\n```json\n{"rows": [1]}\n```\n', expect_ok=True)
 check_issue("an issue carrying NO recipe block is refused",
-            rc=0, body="prose with no recipe at all\n", expect_text="carries no ```json recipe block")
+            rc=0, body="prose with no recipe at all\n", expect_text="Free-form prose is never guessed")
 check_issue("an issue carrying TWO recipe blocks is refused rather than picking the first",
             rc=0, body='```json\n{"a":1}\n```\n```json\n{"b":2}\n```\n',
-            expect_text="carries 2 ```json blocks")
+            expect_text="carries 2 explicit recipe blocks")
+check_issue("an issue with one strict Markdown recipe block is accepted",
+            rc=0, body=MARKDOWN_RECIPE, expect_ok=True)
 check_issue("a failed `gh` call is refused, never treated as an empty issue",
             rc=1, body="could not resolve to an Issue", expect_text="could not read issue #2156")
 
@@ -569,6 +626,12 @@ check_row("an expected survivor fails closed when any test fires",
           (5, [], True, "log", 65, 3.0,
            mk_results({VALID_ROW["expect_fail"]: "Passed", "some other case": "Failed"})),
           expect_marker="EXPECTATION-MISMATCH", expect_rc=1, recipe_row=_survivor_row)
+
+check_row("an expected survivor fails closed when a test is skipped",
+          (5, [], True, "log", 0, 3.0,
+           mk_results({VALID_ROW["expect_fail"]: "Passed", "some other case": "Skipped"})),
+          expect_marker="changed status without failing", expect_rc=1,
+          recipe_row=_survivor_row)
 
 check_row("an expected survivor refuses a red lane with a partial green bundle",
           (5, [], True, "log", 65, 3.0,
@@ -787,6 +850,22 @@ if _v_overlap != battery.VERDICT_INVALID or "both must_fire and must_not_fire" n
     failures.append("a test declared in both expectation sets must invalidate the row")
 else:
     print("  ok  overlapping fire and silence sets invalidate the row")
+
+ran += 1
+_alias_base = battery.SuiteResults(
+    {"Suite/guard()": "Passed"},
+    {"guard": {"Suite/guard()"}, "display guard": {"Suite/guard()"}},
+    {})
+_alias_mutated = battery.SuiteResults(
+    {"Suite/guard()": "Failed"},
+    {"guard": {"Suite/guard()"}, "display guard": {"Suite/guard()"}},
+    {})
+_v_alias, _d_alias = battery.classify_expectations(
+    _alias_base, _alias_mutated, ["guard", "display guard"], [])
+if _v_alias != battery.VERDICT_INVALID or "multiple aliases" not in _d_alias:
+    failures.append("two aliases for one test cannot satisfy a two-entry must_fire set")
+else:
+    print("  ok  duplicate aliases inside one expectation set are rejected")
 
 ran += 1
 _v_incomplete, _d_incomplete = battery.classify_expectations(
@@ -1997,10 +2076,25 @@ check_validator("the filing validator still accepts the legacy expect_fail schem
 check_validator("the filing validator accepts fire and silence expectation sets",
                 dict(_validator_base, must_fire=[_guard_name], must_not_fire=[_silent_name]),
                 expected_rc=0, expected_text="1/1 rows runnable")
+check_validator("the filing validator rejects same-set aliases for one test",
+                dict(_validator_base,
+                     must_fire=[_guard_name, "ProviderStatusMappingTests/egOneNotInstalled()"],
+                     must_not_fire=[]),
+                expected_rc=1, expected_text="multiple aliases")
 check_validator("the filing validator rejects cross-set aliases for the same test",
                 dict(_validator_base, must_fire=[_guard_name],
                      must_not_fire=["ProviderStatusMappingTests/egOneNotInstalled()"]),
                 expected_rc=1, expected_text="resolve to the same test")
+check_validator("the filing validator validates human-row expectations",
+                {"mode": "human", "label": "semantic route", "instruction": "restore it",
+                 "suite": "EnviousWisprTests/ProviderStatusMappingTests",
+                 "must_fire": [_guard_name], "must_not_fire": [_silent_name]},
+                expected_rc=0, expected_text="DEFERRED")
+check_validator("the filing validator rejects a human row with an unknown test",
+                {"mode": "human", "label": "semantic route", "instruction": "restore it",
+                 "suite": "EnviousWisprTests/ProviderStatusMappingTests",
+                 "must_fire": ["this test does not exist"], "must_not_fire": []},
+                expected_rc=1, expected_text="DOES NOT EXIST")
 check_validator("the filing validator checks every name in both expectation sets",
                 dict(_validator_base, must_fire=[_guard_name],
                      must_not_fire=["this test does not exist"]),
@@ -2125,7 +2219,7 @@ with tempfile.TemporaryDirectory() as td:
         capture_output=True, text=True, env=env,
     )
 _issue_output = result.stdout + result.stderr
-if result.returncode != 2 or "carries 2 ```json blocks" not in _issue_output:
+if result.returncode != 2 or "carries 2 explicit recipe blocks" not in _issue_output:
     failures.append(
         "the filing validator shares the runner's single-recipe issue contract — "
         f"exit {result.returncode}: {_issue_output[:250]!r}")

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -58,6 +58,17 @@ RECIPE FORMAT (JSON; the same block that goes in the `test-hardening` issue body
       ]
     }
 
+    `expect_fail` is the backward-compatible single-guard form. A row that needs to
+    describe a JOINT expectation uses these fields instead:
+
+        "must_fire": ["theGuard()"],
+        "must_not_fire": ["theIndependentControl()"]
+
+    `must_fire` is the EXACT set of tests that must newly fail. An empty set is an
+    expected survivor: no test in the suite may newly fail. `must_not_fire` names
+    important silent controls and requires their status to stay unchanged. A row
+    supplies either `expect_fail` or `must_fire`, never both.
+
     `expect_fail` NAMES A TEST AND IS MATCHED EXACTLY — it is not a substring of the
     failure line. Any one of the three spellings the result bundle carries will do:
     the `Suite/function()` identifier, the bare `function()`, or the display name in
@@ -72,8 +83,8 @@ USAGE
     scripts/mutation-battery.py --recipes recipes.json --validate-only  # no xcodebuild at all
 
 EXIT CODES
-    0  every row CAUGHT, baseline green before and after, every file byte-identical
-    1  at least one SURVIVED, ERRORED, or a restore failed
+    0  every row matched its expectation, baseline green before and after, every file byte-identical
+    1  at least one expectation missed, SURVIVED, ERRORED, or a restore failed
     2  usage / preflight refusal (the battery never started)
 """
 
@@ -562,6 +573,8 @@ VERDICT_SURVIVED = "SURVIVED"
 # recipe precisely when the TEST was at fault.
 VERDICT_NOOP = "SURVIVED-UNOBSERVED"
 VERDICT_INVALID = "INVALID-ROW"
+VERDICT_EXPECTED = "EXPECTED"
+VERDICT_MISMATCH = "EXPECTATION-MISMATCH"
 
 
 # WHAT TO DO ABOUT A ROW DEPENDS ON WHY IT IS NOT A CATCH, and the old report
@@ -578,10 +591,12 @@ VERDICT_INVALID = "INVALID-ROW"
 # REMEDIATION HERE. `classify_row` owns that judgement; a second sentence of guidance
 # is a second owner, and it is the one that drifted.
 WHAT_IT_MEANS = {
+    VERDICT_EXPECTED: "the declared fire and silence sets matched",
     VERDICT_NOOP: "no test changed status; the two causes, and how to tell them apart, are below",
     VERDICT_CAUGHT_ELSEWHERE: "a different test caught it; this row says nothing about its own guard",
     VERDICT_INVALID: "the row cannot prove anything as written",
     VERDICT_SURVIVED: "the test did not detect the mutation",
+    VERDICT_MISMATCH: "the suite did not match the row's declared fire and silence sets",
     "ERROR": "the row did not produce a verdict",
 }
 
@@ -673,6 +688,77 @@ def classify_row(baseline: "SuiteResults", mutated: "SuiteResults", expect_fail:
         f"changed status ({', '.join(sorted(changed)[:5])}) — skipped, or absent from the mutated "
         f"run. No guard went red, so the mutation was not detected; check whether the run was cut "
         f"short before reading this as a weak test.")
+
+
+def _resolve_expectation_names(baseline, mutated, names):
+    """Resolve recipe spellings once, failing closed on missing or ambiguous names."""
+    resolved = {}
+    for name in names:
+        targets = mutated.resolve(name) | baseline.resolve(name)
+        if not targets:
+            return None, f"`{name}` names no test in this suite."
+        if len(targets) > 1:
+            return None, (
+                f"`{name}` is ambiguous: it names {len(targets)} tests "
+                f"({', '.join(sorted(targets))}). Use the `Suite/function()` identifier.")
+        target = next(iter(targets))
+        base_result = baseline.by_id.get(target)
+        if base_result not in ("Passed", "Expected Failure"):
+            return None, (
+                f"`{target}` was {base_result or 'absent'} BEFORE the mutation, so its expectation "
+                "has no clean baseline.")
+        resolved[name] = target
+    return resolved, None
+
+
+def classify_expectations(baseline: "SuiteResults", mutated: "SuiteResults",
+                          must_fire, must_not_fire):
+    """Grade an exact newly-failing set plus named controls that must stay unchanged."""
+    fire, error = _resolve_expectation_names(baseline, mutated, must_fire)
+    if error:
+        return VERDICT_INVALID, error
+    silent, error = _resolve_expectation_names(baseline, mutated, must_not_fire)
+    if error:
+        return VERDICT_INVALID, error
+
+    required = set(fire.values())
+    forbidden = set(silent.values())
+    overlap = required & forbidden
+    if overlap:
+        return VERDICT_INVALID, (
+            "the same test is declared in both must_fire and must_not_fire: "
+            + ", ".join(sorted(overlap)))
+
+    newly_failed = mutated.failed() - baseline.failed()
+    missing = required - newly_failed
+    unexpected = newly_failed - required
+    omitted = set(baseline.by_id) - set(mutated.by_id)
+    silent_changed = {
+        test_id for test_id in forbidden
+        if baseline.by_id.get(test_id) != mutated.by_id.get(test_id)
+    }
+    if not missing and not unexpected and not silent_changed and not omitted:
+        if required:
+            return VERDICT_EXPECTED, (
+                f"exact must_fire set matched ({', '.join(sorted(required))}); "
+                f"{len(forbidden)} named silent control(s) stayed unchanged")
+        return VERDICT_EXPECTED, (
+            "expected survivor matched: no test newly failed; "
+            f"{len(forbidden)} named silent control(s) stayed unchanged")
+
+    parts = []
+    if missing:
+        parts.append("required test(s) did not fire: " + ", ".join(sorted(missing)))
+    if unexpected:
+        parts.append("unexpected test(s) fired: " + ", ".join(sorted(unexpected)))
+    if silent_changed:
+        parts.append("must_not_fire control(s) changed status: "
+                     + ", ".join(sorted(silent_changed)))
+    if omitted:
+        parts.append(
+            f"mutated result bundle omitted {len(omitted)} baseline test(s): "
+            + ", ".join(sorted(omitted)[:5]))
+    return VERDICT_MISMATCH, "; ".join(parts)
 
 
 class Lane:
@@ -857,7 +943,7 @@ def load_recipes(path: Path, worktree: Path, raw: str = None):
     for i, row in enumerate(rows, 1):
         if not isinstance(row, dict):
             raise Refusal(f"row {i} is a {type(row).__name__}, not an object.")
-        for field in ("label", "file", "anchor", "replacement", "expect_fail"):
+        for field in ("label", "file", "anchor", "replacement"):
             if field not in row or row[field] is None:
                 raise Refusal(f"row {i} is missing required field '{field}'.")
             if not isinstance(row[field], str):
@@ -868,6 +954,40 @@ def load_recipes(path: Path, worktree: Path, raw: str = None):
             # typed value as missing. Every other field empty is still a mistake.
             if field != "replacement" and not row[field]:
                 raise Refusal(f"row {i} is missing required field '{field}'.")
+        has_legacy = "expect_fail" in row
+        has_sets = "must_fire" in row
+        if has_legacy == has_sets:
+            raise Refusal(
+                f"row {i} must declare exactly one of 'expect_fail' or 'must_fire'.")
+        if has_legacy:
+            if not isinstance(row["expect_fail"], str) or not row["expect_fail"]:
+                raise Refusal(f"row {i} field 'expect_fail' must be a non-empty string.")
+            if "must_not_fire" in row:
+                raise Refusal(
+                    f"row {i} uses legacy 'expect_fail' and cannot also declare 'must_not_fire'. "
+                    "Use must_fire for a joint expectation.")
+            row["_expectation_mode"] = "legacy"
+            row["_must_fire"] = [row["expect_fail"]]
+            row["_must_not_fire"] = []
+        else:
+            for field in ("must_fire", "must_not_fire"):
+                value = row.get(field, [])
+                if not isinstance(value, list) or any(
+                    not isinstance(name, str) or not name for name in value
+                ):
+                    raise Refusal(
+                        f"row {i} field '{field}' must be a list of non-empty test-name strings.")
+                if len(value) != len(set(value)):
+                    raise Refusal(f"row {i} field '{field}' contains duplicate test names.")
+            row.setdefault("must_not_fire", [])
+            overlap = sorted(set(row["must_fire"]) & set(row["must_not_fire"]))
+            if overlap:
+                raise Refusal(
+                    f"row {i} names test(s) in both must_fire and must_not_fire: "
+                    f"{', '.join(overlap)}.")
+            row["_expectation_mode"] = "sets"
+            row["_must_fire"] = row["must_fire"]
+            row["_must_not_fire"] = row["must_not_fire"]
         row.setdefault("suite", default_suite)
         if not row["suite"]:
             raise Refusal(f"row {i} has no suite and no suite_default is set.")
@@ -1207,35 +1327,37 @@ def main(argv=None):
             print(f"  - {p}", file=sys.stderr)
         return 1
 
-    # Refuse a recipe whose expect_fail names no test the clean baseline ran. The answer is already in
+    # Refuse a recipe whose expectation names no test the clean baseline ran. The answer is already in
     # hand at this point, and the alternative is discovering it as a SURVIVED verdict that blames the
     # test. A PREFIX is the common case and the message says so, because that is what an author who
     # wrote against the old substring contract will have.
     unknown = []
     for i, row in enumerate(rows, 1):
         known = baseline_names.get(row["suite"])
+        names = row["_must_fire"] + row["_must_not_fire"]
         # An EMPTY identity set is not a pass. It means the log was unreadable, or Swift Testing's
         # output no longer matches the pattern — in both cases we have no evidence the named test
         # exists, and skipping the check restores exactly the false-SURVIVED this was added to stop.
         # A suite that ran at least one test always prints identity lines, so empty means the reader
         # broke, not that the suite is empty. Fail closed: the whole point of this check.
-        if not known:
+        if not known and names:
             unknown.append(
                 f"row {i}: could not read any test names from {row['suite']}'s baseline run, so "
-                f"{row['expect_fail']!r} cannot be verified. The suite passed, which means it printed "
+                f"{names!r} cannot be verified. The suite passed, which means it printed "
                 "test lines and the reader failed — not that the suite is empty."
             )
             continue
-        if row["expect_fail"] in known:
-            continue
-        near = sorted(n for n in known if row["expect_fail"] in n or n in row["expect_fail"])
-        hint = f"\n      did you mean: {near[0]!r}" if near else ""
-        unknown.append(f"row {i}: no test named {row['expect_fail']!r} ran in {row['suite']}{hint}")
+        for name in names:
+            if name in known:
+                continue
+            near = sorted(n for n in known if name in n or n in name)
+            hint = f"\n      did you mean: {near[0]!r}" if near else ""
+            unknown.append(f"row {i}: no test named {name!r} ran in {row['suite']}{hint}")
     if unknown:
         print("\nREFUSED — nothing was mutated.\n", file=sys.stderr)
-        print("A recipe names the test that must go red, and these name a test the clean baseline did "
-              "not run. Matching is on the FULL test name, not a prefix — a recipe written when this "
-              "matched substrings will look like this.\n", file=sys.stderr)
+        print("A recipe expectation names a test the clean baseline did not run. Matching is on the "
+              "FULL test name, not a prefix — a recipe written when this matched substrings will look "
+              "like this.\n", file=sys.stderr)
         for u in unknown:
             print(f"  - {u}", file=sys.stderr)
         return 2
@@ -1286,11 +1408,23 @@ def main(argv=None):
                         detail = (
                             f"no unmutated baseline was recorded for {row['suite']}, so this row has "
                             f"nothing to differ from ({log})")
+                    elif (row["_expectation_mode"] == "sets"
+                          and not row["_must_fire"] and rc_run != 0
+                          and not (row_results.failed()
+                                   - baseline_results[row["suite"]].failed())):
+                        detail = (
+                            f"expected-survivor lane exited {rc_run}, so a partial result bundle cannot "
+                            f"be graded as success even though no test was recorded failing ({log})")
                     else:
                         # THE VERDICT IS A DIFF, NOT A RED/GREEN READ. See classify_row for why, and
                         # for the limit it does NOT close.
-                        verdict, detail = classify_row(
-                            baseline_results[row["suite"]], row_results, row["expect_fail"])
+                        if row["_expectation_mode"] == "legacy":
+                            verdict, detail = classify_row(
+                                baseline_results[row["suite"]], row_results, row["expect_fail"])
+                        else:
+                            verdict, detail = classify_expectations(
+                                baseline_results[row["suite"]], row_results,
+                                row["_must_fire"], row["_must_not_fire"])
                         detail = f"{detail} — {elapsed:.0f}s ({log})"
         except (_RowFailed, Refusal) as exc:
             detail = str(exc)
@@ -1344,6 +1478,8 @@ def main(argv=None):
             VERDICT_SURVIVED: " SURV ",
             VERDICT_NOOP: " NOOP ",
             VERDICT_INVALID: " BADR ",
+            VERDICT_EXPECTED: " EXP  ",
+            VERDICT_MISMATCH: " MISS ",
             "ERROR": " ERR  ",
         }[verdict]
         print(f"  [{marker}] row {i}: {row['label']}\n           {detail}")
@@ -1357,18 +1493,19 @@ def main(argv=None):
             print(f"  - {p}", file=sys.stderr)
         return 1
 
-    caught = [r for r in results if r[0] == VERDICT_CAUGHT]
-    bad = [r for r in results if r[0] != VERDICT_CAUGHT]
-    print(f"\n{'=' * 72}\n{len(caught)}/{len(results)} CAUGHT, baseline green before and after.")
+    successful = [r for r in results if r[0] in (VERDICT_CAUGHT, VERDICT_EXPECTED)]
+    bad = [r for r in results if r[0] not in (VERDICT_CAUGHT, VERDICT_EXPECTED)]
+    print(f"\n{'=' * 72}\n{len(successful)}/{len(results)} expectations matched "
+          "(CAUGHT or EXPECTED), baseline green before and after.")
     if bad:
         print(f"\n{len(bad)} row(s) need work:")
         for verdict, label, detail in bad:
             print(f"  {verdict}: {label}\n    {explain_verdict(verdict)}\n    {detail}")
         return 1
-    print("\nEvery mutation was detected by the test that claimed to guard it.")
-    print("This proves the tests fire on the mutations written here. It does NOT prove they are")
-    print("binding — a guard over identifier names or source text still needs an independent")
-    print("attempt to evade it, by someone other than its author.")
+    print("\nEvery mutation matched its declared fire and silence expectations.")
+    print("This proves the declared fire/silence pattern holds for the mutations written here.")
+    print("It does NOT prove a guard is binding — identifier-name or source-text guards still need")
+    print("an independent attempt to evade them, by someone other than their author.")
     return 0
 
 

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -69,6 +69,12 @@ RECIPE FORMAT (JSON; the same block that goes in the `test-hardening` issue body
     important silent controls and requires their status to stay unchanged. A row
     supplies either `expect_fail` or `must_fire`, never both.
 
+    A mixed mechanical/human issue may instead carry one fenced `mutation-recipe`
+    Markdown table. Run `scripts/mutation-battery.py --print-markdown-template` for
+    the exact header. Mechanical rows use `<br>` between test names and `&#124;` for
+    a literal pipe. A semantic instruction that cannot be an anchor/replacement pair
+    is mode `human`; it is reported as DEFERRED and is never guessed into source code.
+
     `expect_fail` NAMES A TEST AND IS MATCHED EXACTLY — it is not a substring of the
     failure line. Any one of the three spellings the result bundle carries will do:
     the `Suite/function()` identifier, the bare `function()`, or the display name in
@@ -92,6 +98,7 @@ import argparse
 import filecmp
 import fcntl
 import functools
+import html
 import json
 import os
 import re
@@ -721,6 +728,20 @@ def classify_expectations(baseline: "SuiteResults", mutated: "SuiteResults",
     if error:
         return VERDICT_INVALID, error
 
+    for label, resolved in (("must_fire", fire), ("must_not_fire", silent)):
+        aliases_by_test = {}
+        for alias, test_id in resolved.items():
+            aliases_by_test.setdefault(test_id, []).append(alias)
+        duplicates = {
+            test_id: aliases for test_id, aliases in aliases_by_test.items() if len(aliases) > 1
+        }
+        if duplicates:
+            detail = "; ".join(
+                f"{test_id}: {', '.join(repr(alias) for alias in aliases)}"
+                for test_id, aliases in sorted(duplicates.items())
+            )
+            return VERDICT_INVALID, f"{label} names the same test through multiple aliases: {detail}"
+
     required = set(fire.values())
     forbidden = set(silent.values())
     overlap = required & forbidden
@@ -730,6 +751,11 @@ def classify_expectations(baseline: "SuiteResults", mutated: "SuiteResults",
             + ", ".join(sorted(overlap)))
 
     newly_failed = mutated.failed() - baseline.failed()
+    status_changed_without_failure = {
+        test_id for test_id in set(baseline.by_id) & set(mutated.by_id)
+        if baseline.by_id[test_id] != mutated.by_id[test_id]
+        and test_id not in newly_failed
+    }
     missing = required - newly_failed
     unexpected = newly_failed - required
     omitted = set(baseline.by_id) - set(mutated.by_id)
@@ -737,7 +763,8 @@ def classify_expectations(baseline: "SuiteResults", mutated: "SuiteResults",
         test_id for test_id in forbidden
         if baseline.by_id.get(test_id) != mutated.by_id.get(test_id)
     }
-    if not missing and not unexpected and not silent_changed and not omitted:
+    if (not missing and not unexpected and not silent_changed and not omitted
+            and not status_changed_without_failure):
         if required:
             return VERDICT_EXPECTED, (
                 f"exact must_fire set matched ({', '.join(sorted(required))}); "
@@ -754,6 +781,10 @@ def classify_expectations(baseline: "SuiteResults", mutated: "SuiteResults",
     if silent_changed:
         parts.append("must_not_fire control(s) changed status: "
                      + ", ".join(sorted(silent_changed)))
+    if status_changed_without_failure:
+        parts.append(
+            "test(s) changed status without failing: "
+            + ", ".join(sorted(status_changed_without_failure)))
     if omitted:
         parts.append(
             f"mutated result bundle omitted {len(omitted)} baseline test(s): "
@@ -875,6 +906,110 @@ def preflight(worktree: Path):
 
 
 FENCE_RE = re.compile(r"```json\s*\n(.*?)```", re.DOTALL)
+MARKDOWN_FENCE_RE = re.compile(r"```mutation-recipe\s*\n(.*?)```", re.DOTALL)
+MARKDOWN_RECIPE_COLUMNS = (
+    "mode", "label", "file", "anchor", "replacement", "suite", "must_fire",
+    "must_not_fire", "instruction",
+)
+
+
+def _markdown_cells(line: str):
+    """Split one pipe-table row; literal pipes must be escaped or written as `&#124;`."""
+    text = line.strip()
+    if not text.startswith("|") or not text.endswith("|"):
+        raise Refusal("each mutation-recipe table row must start and end with '|'.")
+    cells = re.split(r"(?<!\\)\|", text[1:-1])
+    return [cell.replace(r"\|", "|").strip() for cell in cells]
+
+
+def _markdown_value(cell: str):
+    """Decode the deliberately small Markdown subset accepted inside recipe cells."""
+    value = html.unescape(cell.strip())
+    if len(value) >= 2 and value.startswith("`") and value.endswith("`"):
+        value = value[1:-1]
+    return re.sub(r"<br\s*/?>", "\n", value, flags=re.IGNORECASE).strip()
+
+
+def markdown_recipe_document(raw: str):
+    """Turn one explicit Markdown recipe table into the same document JSON recipes use.
+
+    This does not parse arbitrary issue prose. A confident guess at English is worse than a refusal in
+    an unattended source-rewrite tool, so only the documented table is executable. Semantic mutations
+    remain useful: mark them `human`, give them an instruction, and the runner reports them as deferred.
+    """
+    lines = [line for line in raw.splitlines() if line.strip()]
+    if len(lines) < 3:
+        raise Refusal("the mutation-recipe block must contain a header, separator, and at least one row.")
+    header = tuple(re.sub(r"[ -]+", "_", cell.lower()) for cell in _markdown_cells(lines[0]))
+    if header != MARKDOWN_RECIPE_COLUMNS:
+        raise Refusal(
+            "the mutation-recipe table header must be exactly: "
+            + " | ".join(MARKDOWN_RECIPE_COLUMNS)
+        )
+    separator = _markdown_cells(lines[1])
+    if len(separator) != len(header) or any(not re.fullmatch(r":?-{3,}:?", cell) for cell in separator):
+        raise Refusal("the mutation-recipe table needs one Markdown separator cell per header.")
+
+    rows = []
+    for index, line in enumerate(lines[2:], 1):
+        cells = _markdown_cells(line)
+        if len(cells) != len(header):
+            raise Refusal(
+                f"Markdown recipe row {index} has {len(cells)} cells; expected {len(header)}. "
+                "Escape a literal pipe as \\| or &#124;."
+            )
+        values = {name: _markdown_value(cell) for name, cell in zip(header, cells)}
+        mode = values["mode"].lower()
+        must_fire = [name.strip(" `") for name in values["must_fire"].splitlines() if name.strip(" `")]
+        must_not_fire = [
+            name.strip(" `") for name in values["must_not_fire"].splitlines() if name.strip(" `")
+        ]
+        if mode == "human":
+            rows.append({
+                "mode": "human",
+                "label": values["label"],
+                "suite": values["suite"],
+                "must_fire": must_fire,
+                "must_not_fire": must_not_fire,
+                "instruction": values["instruction"],
+            })
+            continue
+        if mode != "mechanical":
+            raise Refusal(
+                f"Markdown recipe row {index} mode must be 'mechanical' or 'human', got "
+                f"{values['mode']!r}."
+            )
+        rows.append({
+            "mode": "mechanical",
+            "label": values["label"],
+            "file": values["file"],
+            "anchor": values["anchor"],
+            "replacement": values["replacement"],
+            "suite": values["suite"],
+            "must_fire": must_fire,
+            "must_not_fire": must_not_fire,
+        })
+    return {"rows": rows}
+
+
+def issue_recipe_document(number: int, text: str):
+    """Select exactly one explicit recipe representation from an issue and its comments."""
+    json_blocks = FENCE_RE.findall(text)
+    markdown_blocks = MARKDOWN_FENCE_RE.findall(text)
+    total = len(json_blocks) + len(markdown_blocks)
+    if total == 0:
+        raise Refusal(
+            f"issue #{number} carries neither a ```json nor a ```mutation-recipe block in its body "
+            "or comments. Free-form prose is never guessed into source mutations."
+        )
+    if total > 1:
+        raise Refusal(
+            f"issue #{number} carries {total} explicit recipe blocks across its body and comments. "
+            "Exactly one is allowed, or the run and the issue disagree about what was tested."
+        )
+    if json_blocks:
+        return json.loads(json_blocks[0])
+    return markdown_recipe_document(markdown_blocks[0])
 
 
 def recipes_from_issue(number: int, worktree: Path):
@@ -901,20 +1036,10 @@ def recipes_from_issue(number: int, worktree: Path):
     )
     if rc != 0:
         raise Refusal(f"could not read issue #{number}: {out.strip()[:300]}")
-    blocks = FENCE_RE.findall(out)
-    if not blocks:
-        raise Refusal(
-            f"issue #{number} carries no ```json recipe block in its body or any comment. A "
-            "test-hardening issue without its recipe cannot be acted on cold, which is the whole "
-            "reason the recipe is written into the issue."
-        )
-    if len(blocks) > 1:
-        raise Refusal(
-            f"issue #{number} carries {len(blocks)} ```json blocks across its body and comments. "
-            "Exactly one, or the run and the issue disagree about what was tested — edit the "
-            "superseded one out rather than adding a newer block beside it."
-        )
-    return blocks[0]
+    try:
+        return json.dumps(issue_recipe_document(number, out))
+    except json.JSONDecodeError as exc:
+        raise Refusal(f"the JSON recipe in issue #{number} is not valid JSON: {exc}") from exc
 
 
 def load_recipes(path: Path, worktree: Path, raw: str = None):
@@ -943,6 +1068,41 @@ def load_recipes(path: Path, worktree: Path, raw: str = None):
     for i, row in enumerate(rows, 1):
         if not isinstance(row, dict):
             raise Refusal(f"row {i} is a {type(row).__name__}, not an object.")
+        mode = row.get("mode", "mechanical")
+        row["_recipe_index"] = i
+        if mode == "human":
+            for field in ("label", "instruction"):
+                if not isinstance(row.get(field), str) or not row[field]:
+                    raise Refusal(f"human row {i} field '{field}' must be a non-empty string.")
+            for field in ("must_fire", "must_not_fire"):
+                value = row.get(field, [])
+                if not isinstance(value, list) or any(
+                    not isinstance(name, str) or not name for name in value
+                ):
+                    raise Refusal(
+                        f"human row {i} field '{field}' must be a list of non-empty test-name strings.")
+                if len(value) != len(set(value)):
+                    raise Refusal(f"human row {i} field '{field}' contains duplicate test names.")
+            overlap = sorted(set(row.get("must_fire", [])) & set(row.get("must_not_fire", [])))
+            if overlap:
+                raise Refusal(
+                    f"human row {i} names test(s) in both must_fire and must_not_fire: "
+                    f"{', '.join(overlap)}.")
+            row.setdefault("must_fire", [])
+            row.setdefault("must_not_fire", [])
+            row.setdefault("suite", default_suite)
+            if not row["suite"]:
+                raise Refusal(f"human row {i} has no suite and no suite_default is set.")
+            if not isinstance(row["suite"], str) or "/" not in row["suite"]:
+                raise Refusal(
+                    f"human row {i} suite must be a target-qualified string, got {row['suite']!r}.")
+            row["_must_fire"] = row["must_fire"]
+            row["_must_not_fire"] = row["must_not_fire"]
+            row["_mode"] = "human"
+            continue
+        if mode != "mechanical":
+            raise Refusal(f"row {i} mode must be 'mechanical' or 'human', got {mode!r}.")
+        row["_mode"] = "mechanical"
         for field in ("label", "file", "anchor", "replacement"):
             if field not in row or row[field] is None:
                 raise Refusal(f"row {i} is missing required field '{field}'.")
@@ -1072,6 +1232,15 @@ def load_recipes(path: Path, worktree: Path, raw: str = None):
                 "the mutation lands somewhere you did not choose."
             )
     return rows
+
+
+def select_recipe_row(rows, number):
+    """Apply `--row` to the authored order, before human rows are separated."""
+    if number is None:
+        return rows
+    if not 1 <= number <= len(rows):
+        raise Refusal(f"--row {number} out of range (1..{len(rows)})")
+    return [rows[number - 1]]
 
 
 def suite_test_names(log_path) -> set:
@@ -1232,16 +1401,30 @@ def main_for_test(recipes: Path, worktree: Path):
 @release_battery_lock_on_return
 def main(argv=None):
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    src = ap.add_mutually_exclusive_group(required=True)
+    ap.add_argument("--print-markdown-template", action="store_true",
+                    help="print the strict mixed mechanical/human recipe table and exit")
+    src = ap.add_mutually_exclusive_group(required=False)
     src.add_argument("--recipes", type=Path, help="a recipe JSON file")
     src.add_argument("--from-issue", type=int, metavar="N",
-                     help="read the recipe from the ```json block in test-hardening issue #N")
+                     help="read the explicit JSON or Markdown recipe in test-hardening issue #N")
     ap.add_argument("--worktree", type=Path, default=None)
     ap.add_argument("--row", type=int, default=None, help="run a single 1-indexed row")
     ap.add_argument("--dry-run", action="store_true", help="validate recipes and baseline, mutate nothing")
     ap.add_argument("--validate-only", action="store_true",
                     help="preflight and recipe validation only — no xcodebuild, no baseline, no mutations")
     args = ap.parse_args(argv)
+    if args.print_markdown_template:
+        if args.recipes is not None or args.from_issue is not None:
+            ap.error("--print-markdown-template does not take a recipe source.")
+        print("""```mutation-recipe
+| mode | label | file | anchor | replacement | suite | must_fire | must_not_fire | instruction |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| mechanical | drop the guard | `Sources/Module/Foo.swift` | `guard ready else { return }` | `if false { return }` | `EnviousWisprTests/FooTests` | `the guard blocks work` | `the independent control stays green` | |
+| human | re-route the semantic branch | | | | `EnviousWisprTests/FooTests` | | | Reintroduce the old deferral through the public outcome, then grade the named suite. |
+```""")
+        return 0
+    if args.recipes is None and args.from_issue is None:
+        ap.error("one of --recipes or --from-issue is required")
     if args.validate_only and (args.dry_run or args.row is not None):
         ap.error("--validate-only stops before any run; combining it with --dry-run or --row would "
                  "silently do less than the other flag promises.")
@@ -1286,19 +1469,32 @@ def main(argv=None):
             rows = load_recipes(None, worktree, raw=recipes_from_issue(args.from_issue, worktree))
         else:
             rows = load_recipes(args.recipes.resolve(), worktree)
+        rows = select_recipe_row(rows, args.row)
     except Refusal as exc:
         print(f"\nREFUSED — the battery did not start.\n\n{exc}", file=sys.stderr)
         return 2
 
+    deferred = [row for row in rows if row.get("_mode") == "human"]
+    rows = [row for row in rows if row.get("_mode") == "mechanical"]
+    if deferred:
+        print(f"\n{len(deferred)} human-adversary row(s) DEFERRED — no source rewrite was guessed:")
+        for row in deferred:
+            suite = f" [{row.get('suite')}]" if row.get("suite") else ""
+            fire = f"; must fire: {row['must_fire']}" if row["must_fire"] else ""
+            silent = f"; must not fire: {row['must_not_fire']}" if row["must_not_fire"] else ""
+            print(
+                f"  - row {row['_recipe_index']}: {row['label']}{suite}: "
+                f"{row['instruction']}{fire}{silent}"
+            )
+
     if args.validate_only:
-        print(f"\n--validate-only: preflight clean, {len(rows)} row(s) well-formed. Nothing was run.")
+        print(f"\n--validate-only: preflight clean, {len(rows)} row(s) well-formed (mechanical); "
+              f"{len(deferred)} human row(s) deferred. Nothing was run.")
         return 0
 
-    if args.row is not None:
-        if not 1 <= args.row <= len(rows):
-            print(f"--row {args.row} out of range (1..{len(rows)})", file=sys.stderr)
-            return 2
-        rows = [rows[args.row - 1]]
+    if not rows:
+        print("\nNo mechanical rows can run unattended. Human-adversary work remains.", file=sys.stderr)
+        return 1
 
     lane = Lane(worktree, derived, log_dir)
     suites = {row["suite"] for row in rows}
@@ -1332,7 +1528,8 @@ def main(argv=None):
     # test. A PREFIX is the common case and the message says so, because that is what an author who
     # wrote against the old substring contract will have.
     unknown = []
-    for i, row in enumerate(rows, 1):
+    for row in rows:
+        i = row["_recipe_index"]
         known = baseline_names.get(row["suite"])
         names = row["_must_fire"] + row["_must_not_fire"]
         # An EMPTY identity set is not a pass. It means the log was unreadable, or Swift Testing's
@@ -1364,11 +1561,12 @@ def main(argv=None):
 
     if args.dry_run:
         print("\n--dry-run: recipes validated, baseline green, nothing mutated.")
-        return 0
+        return 1 if deferred else 0
 
     print(f"\n[2/3] {len(rows)} mutation(s), one at a time")
     results = []
-    for i, row in enumerate(rows, 1):
+    for row in rows:
+        i = row["_recipe_index"]
         target = Path(row["_resolved"])
         tag = f"row{i:02d}"
         backup = backup_path(worktree, tag, target)
@@ -1501,6 +1699,9 @@ def main(argv=None):
         print(f"\n{len(bad)} row(s) need work:")
         for verdict, label, detail in bad:
             print(f"  {verdict}: {label}\n    {explain_verdict(verdict)}\n    {detail}")
+        return 1
+    if deferred:
+        print(f"\n{len(deferred)} human-adversary row(s) still require a thinking operator.")
         return 1
     print("\nEvery mutation matched its declared fire and silence expectations.")
     print("This proves the declared fire/silence pattern holds for the mutations written here.")

--- a/scripts/validate-mutation-recipe.py
+++ b/scripts/validate-mutation-recipe.py
@@ -331,6 +331,22 @@ def validate(recipes, root, label):
                 problems.append(
                     "must_fire and must_not_fire resolve to the same test(s): "
                     + ", ".join(alias_overlap))
+            for field in ("_must_fire", "_must_not_fire"):
+                aliases_by_test = {}
+                for name in normalized.get(field, []):
+                    for test_id in suite_names.get(name, set()):
+                        aliases_by_test.setdefault(test_id, []).append(name)
+                duplicates = {
+                    test_id: aliases for test_id, aliases in aliases_by_test.items()
+                    if len(aliases) > 1
+                }
+                if duplicates:
+                    problems.append(
+                        f"{field.removeprefix('_')} names the same test through multiple aliases: "
+                        + "; ".join(
+                            f"{test_id}: {', '.join(aliases)}"
+                            for test_id, aliases in sorted(duplicates.items())
+                        ))
 
             if suite and suite not in names_by_suite:
                 problems.append(f"suite {suite} NOT FOUND in Tests/")
@@ -341,7 +357,8 @@ def validate(recipes, root, label):
                 row_label = row.get("label", "(no label)") if isinstance(row, dict) else "(no label)"
                 print(f"        {str(row_label)[:90]}")
             else:
-                print(f"row {index}: runnable   | {str(normalized.get('label', ''))[:70]}")
+                status = "DEFERRED" if normalized.get("_mode") == "human" else "runnable"
+                print(f"row {index}: {status:<10} | {str(normalized.get('label', ''))[:70]}")
 
     print(f"\n{label}: {total - bad}/{total} rows runnable"
           + (f", {bad} UNRUNNABLE" if bad else ""))

--- a/scripts/validate-mutation-recipe.py
+++ b/scripts/validate-mutation-recipe.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+"""Validate mutation recipes against a checkout without running Xcode."""
+
+import argparse
+import importlib.util
+import json
+import pathlib
+import re
+import sys
+
+
+def load_battery():
+    path = pathlib.Path(__file__).with_name("mutation-battery.py")
+    spec = importlib.util.spec_from_file_location("mutation_battery", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def mask_noncode(source):
+    """Preserve offsets while blanking comments and string literals."""
+    masked = list(source)
+    index = 0
+    length = len(source)
+
+    def blank(start, end):
+        for position in range(start, end):
+            if masked[position] != "\n":
+                masked[position] = " "
+
+    while index < length:
+        raw_string = re.match(r'(?P<hashes>#+)(?P<quote>"""|")', source[index:])
+        if raw_string:
+            start = index
+            hashes = raw_string.group("hashes")
+            quote = raw_string.group("quote")
+            closing = quote + hashes
+            search_from = index + len(hashes) + len(quote)
+            end = source.find(closing, search_from)
+            index = length if end < 0 else end + len(closing)
+            blank(start, index)
+        elif source.startswith("//", index):
+            end = source.find("\n", index)
+            end = length if end < 0 else end
+            blank(index, end)
+            index = end
+        elif source.startswith("/*", index):
+            start = index
+            depth = 1
+            index += 2
+            while index < length and depth:
+                if source.startswith("/*", index):
+                    depth += 1
+                    index += 2
+                elif source.startswith("*/", index):
+                    depth -= 1
+                    index += 2
+                else:
+                    index += 1
+            blank(start, index)
+        elif source.startswith('"""', index):
+            start = index
+            end = source.find('"""', index + 3)
+            index = length if end < 0 else end + 3
+            blank(start, index)
+        elif source[index] == '"':
+            start = index
+            index += 1
+            while index < length:
+                if source[index] == "\\":
+                    index += 2
+                elif source[index] == '"':
+                    index += 1
+                    break
+                else:
+                    index += 1
+            blank(start, min(index, length))
+        else:
+            index += 1
+    return "".join(masked)
+
+
+def mask_inactive_debug_branches(code):
+    """Blank branches that cannot compile in the canonical Debug lane."""
+    masked = list(code)
+    stack = []
+    active = True
+    offset = 0
+
+    def condition_value(expression):
+        expression = expression.strip()
+        if expression == "DEBUG":
+            return True
+        if expression == "!DEBUG":
+            return False
+        return None
+
+    def blank(start, end):
+        for position in range(start, end):
+            if masked[position] != "\n":
+                masked[position] = " "
+
+    for line in code.splitlines(keepends=True):
+        directive = re.match(r"\s*#(if|elseif|else|endif)\b(.*)", line)
+        line_active = active
+        if directive:
+            kind, expression = directive.groups()
+            if kind == "if":
+                value = condition_value(expression)
+                stack.append({
+                    "parent": active,
+                    "known": value is not None,
+                    "taken": value is True,
+                })
+                active = active and (value if value is not None else True)
+            elif not stack:
+                raise RuntimeError("unbalanced conditional-compilation directive in test corpus")
+            elif kind == "elseif":
+                frame = stack[-1]
+                value = condition_value(expression)
+                if not frame["known"] or value is None:
+                    frame["known"] = False
+                    active = frame["parent"]
+                else:
+                    active = frame["parent"] and not frame["taken"] and value
+                    frame["taken"] = frame["taken"] or value
+            elif kind == "else":
+                frame = stack[-1]
+                active = frame["parent"] if not frame["known"] else (
+                    frame["parent"] and not frame["taken"])
+                frame["taken"] = True
+            else:
+                frame = stack.pop()
+                active = frame["parent"]
+            blank(offset, offset + len(line))
+        elif not line_active:
+            blank(offset, offset + len(line))
+        offset += len(line)
+
+    if stack:
+        raise RuntimeError("unterminated conditional-compilation directive in test corpus")
+    return "".join(masked)
+
+
+def matching_delimiter(code, opening, left, right):
+    depth = 0
+    for index in range(opening, len(code)):
+        if code[index] == left:
+            depth += 1
+        elif code[index] == right:
+            depth -= 1
+            if depth == 0:
+                return index
+    return None
+
+
+def function_suffix(parameters):
+    if not parameters.strip():
+        return "()"
+    pieces = []
+    start = 0
+    depths = {"(": 0, "[": 0, "<": 0}
+    closing = {")": "(", "]": "[", ">": "<"}
+    for index, character in enumerate(parameters):
+        if character in depths:
+            depths[character] += 1
+        elif character in closing and depths[closing[character]]:
+            depths[closing[character]] -= 1
+        elif character == "," and not any(depths.values()):
+            pieces.append(parameters[start:index])
+            start = index + 1
+    pieces.append(parameters[start:])
+
+    labels = []
+    for piece in pieces:
+        head = piece.split(":", 1)[0]
+        tokens = re.findall(r"\b[A-Za-z_]\w*\b|_", head)
+        if not tokens:
+            return None
+        labels.append(tokens[0])
+    return "(" + "".join(f"{label}:" for label in labels) + ")"
+
+
+def has_runtime_gate(attribute_code):
+    return re.search(r"\.(?:enabled|disabled)\s*\(", attribute_code) is not None
+
+
+def test_oracle(root):
+    test_root = root / "Tests"
+    sources = []
+    for path in test_root.rglob("*.swift"):
+        try:
+            sources.append((path, path.read_text(errors="replace")))
+        except OSError as error:
+            raise RuntimeError(f"cannot read test source {path}: {error}") from error
+    tests = "\n".join(source for _, source in sources)
+    if len(sources) < 100 or len(tests) < 100_000:
+        raise RuntimeError(
+            f"test corpus read {len(sources)} files / {len(tests)} bytes — refusing to "
+            "validate against a suspiciously small oracle")
+
+    names_by_suite = {}
+    for path, part in sources:
+        target = path.relative_to(test_root).parts[0]
+        code = mask_inactive_debug_branches(mask_noncode(part))
+        ranges = []
+        for declaration in re.finditer(
+            r"\b(?:struct|final\s+class|class|enum|actor|extension)\s+(\w+)", code
+        ):
+            opening = code.find("{", declaration.end())
+            closing = matching_delimiter(code, opening, "{", "}") if opening >= 0 else None
+            if closing is not None:
+                suite_start = code.rfind("@Suite", max(0, declaration.start() - 2_000),
+                                         declaration.start())
+                suite_attribute = code[suite_start:declaration.start()] if suite_start >= 0 else ""
+                if "{" in suite_attribute or "}" in suite_attribute:
+                    suite_attribute = ""
+                ranges.append((
+                    opening, closing, declaration.group(1), has_runtime_gate(suite_attribute)
+                ))
+
+        for attribute in re.finditer(r"@Test\b", code):
+            function_match = re.search(r"\bfunc\s+(\w+)\s*\(", code[attribute.end():])
+            if not function_match:
+                continue
+            function_start = attribute.end() + function_match.start()
+            next_test = code.find("@Test", attribute.end(), function_start)
+            if next_test >= 0:
+                continue
+            if has_runtime_gate(code[attribute.start():function_start]):
+                continue
+            function = function_match.group(1)
+            opening = code.find("(", function_start)
+            closing = matching_delimiter(code, opening, "(", ")")
+            if closing is None:
+                continue
+            suffix = function_suffix(code[opening + 1:closing])
+            if suffix is None:
+                continue
+            containing = [
+                (end - start, name, gated) for start, end, name, gated in ranges
+                if start < attribute.start() < end
+            ]
+            if not containing:
+                continue
+            _, enclosing, suite_is_gated = min(containing)
+            if suite_is_gated:
+                continue
+            body = part[attribute.end():function_start]
+            display_names = []
+            display = re.match(r'\s*\(\s*"((?:[^"\\]|\\.)*)"', body)
+            if display:
+                literal = display.group(1)
+                try:
+                    display_names.append(json.loads(f'"{literal}"'))
+                except json.JSONDecodeError:
+                    display_names.append(
+                        literal.replace('\\\"', '"').replace('\\\\', '\\'))
+            canonical = f"{enclosing}/{function}{suffix}"
+            aliases = display_names + [f"{function}{suffix}", canonical]
+            suite_names = names_by_suite.setdefault(f"{target}/{enclosing}", {})
+            for alias in aliases:
+                suite_names.setdefault(alias, set()).add(canonical)
+    name_count = sum(len(names) for names in names_by_suite.values())
+    if name_count < 1_000:
+        raise RuntimeError(
+            f"extracted only {name_count} suite-scoped test names — refusing to validate against "
+            "a suspiciously small oracle")
+    return names_by_suite
+
+
+def missing_test_problem(name, known_names):
+    if name in known_names:
+        if len(known_names[name]) > 1:
+            return (
+                f"expectation name is AMBIGUOUS across {len(known_names[name])} tests: {name!r}")
+        return None
+    near = sorted(
+        (candidate for candidate in known_names
+         if candidate and candidate != name and candidate.startswith(name)),
+        key=len,
+    )
+    if near:
+        return (
+            f"expectation name is a PREFIX, not a full test name; "
+            f"did you mean {near[0]!r}")
+    return f"expectation names a test that DOES NOT EXIST: {name!r}"
+
+
+def validate(recipes, root, label):
+    names_by_suite = test_oracle(root)
+    battery = load_battery()
+    root = root.resolve()
+    bad = 0
+    total = 0
+
+    for document in recipes:
+        if not isinstance(document, dict) or not isinstance(document.get("rows"), list):
+            print(f"{label}: UNRUNNABLE — recipe must be an object with a rows list")
+            return 1
+        if not document["rows"]:
+            print(f"{label}: UNRUNNABLE — recipe declares no rows")
+            return 1
+        default_suite = document.get("suite_default")
+        for index, row in enumerate(document["rows"], 1):
+            total += 1
+            problems = []
+            normalized = {}
+            single_row = {"suite_default": default_suite, "rows": [row]}
+            try:
+                normalized = battery.load_recipes(
+                    None, root, raw=json.dumps(single_row))[0]
+            except battery.Refusal as error:
+                problems.append(str(error))
+
+            suite = normalized.get("suite")
+            suite_names = names_by_suite.get(suite, {})
+            for name in normalized.get("_must_fire", []) + normalized.get("_must_not_fire", []):
+                problem = missing_test_problem(name, suite_names)
+                if problem:
+                    problems.append(problem)
+
+            fire_ids = set().union(*(
+                suite_names.get(name, set()) for name in normalized.get("_must_fire", [])
+            ))
+            silent_ids = set().union(*(
+                suite_names.get(name, set()) for name in normalized.get("_must_not_fire", [])
+            ))
+            alias_overlap = sorted(fire_ids & silent_ids)
+            if alias_overlap:
+                problems.append(
+                    "must_fire and must_not_fire resolve to the same test(s): "
+                    + ", ".join(alias_overlap))
+
+            if suite and suite not in names_by_suite:
+                problems.append(f"suite {suite} NOT FOUND in Tests/")
+
+            if problems:
+                bad += 1
+                print(f"row {index}: UNRUNNABLE — {'; '.join(problems)}")
+                row_label = row.get("label", "(no label)") if isinstance(row, dict) else "(no label)"
+                print(f"        {str(row_label)[:90]}")
+            else:
+                print(f"row {index}: runnable   | {str(normalized.get('label', ''))[:70]}")
+
+    print(f"\n{label}: {total - bad}/{total} rows runnable"
+          + (f", {bad} UNRUNNABLE" if bad else ""))
+    return 1 if bad else 0
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--issue", type=int)
+    source.add_argument("--recipes", type=pathlib.Path)
+    parser.add_argument("--checkout", type=pathlib.Path, default=pathlib.Path.cwd())
+    args = parser.parse_args(argv)
+
+    try:
+        battery = load_battery()
+        if args.issue is not None:
+            if args.issue <= 0:
+                raise RuntimeError("issue number must be positive")
+            try:
+                raw = battery.recipes_from_issue(args.issue, args.checkout)
+            except battery.Refusal as error:
+                raise RuntimeError(str(error)) from error
+            recipes = [json.loads(raw)]
+            label = f"#{args.issue}"
+        else:
+            recipes = [json.loads(args.recipes.read_text())]
+            label = str(args.recipes)
+        if not recipes:
+            print(f"{label}: NO PARSEABLE RECIPE — nothing to validate")
+            return 2
+        return validate(recipes, args.checkout, label)
+    except (OSError, json.JSONDecodeError, RuntimeError) as error:
+        print(f"REFUSED — {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Part of #2224

## What changed
- Adds exact `must_fire` and `must_not_fire` expectation sets while preserving legacy `expect_fail` recipes.
- Supports intentional survivor rows and fails closed on extra failures, skips, changed controls, incomplete result bundles, ambiguous aliases, and contradictory sets.
- Adds a tracked filing-time validator that shares the runner parser and rejects unrunnable Debug-lane recipes before Xcode work.
- Adds one strict `mutation-recipe` Markdown table for mixed mechanical and human-adversary rows. Mechanical rows run unattended; semantic rows retain their exact expectations and are reported as deferred rather than guessed into source rewrites.
- Preserves authored row numbers across mixed recipes so `--row N`, logs, and reports always name the same instruction.

## Validation
- `python3 scripts/mutation-battery-test.py` — 167/167 passed
- `python3 -m py_compile` — passed
- `git diff --check` — passed
- Real isolated Xcode mutation battery — 2/2 expectations matched, including one exact failing set and one expected survivor; clean baseline restored before/after.
- Pinned Codex review — clean after correcting five fail-closed edge cases found during review.

## Scope
Tooling only; no production behavior changes. No new source-mutation run was performed for the Markdown addition because EnviousWispr is currently running. The original free-form backlog still needs a one-time transcription into the explicit table; arbitrary English remains deliberately non-executable.
