### PR TITLE
fix(recovery): retain XPC model-not-loaded takes

### DIFF
--- a/Sources/EnviousWisprASR/RecoveryFailureClassification.swift
+++ b/Sources/EnviousWisprASR/RecoveryFailureClassification.swift
@@ -27,7 +27,13 @@ package func recoveryFailureClass(for error: any Error) -> RecoveryFailureClass?
   // stops being produced. Pinned by "transcribe failure on good audio is a Camp B
   // candidate with a failure class" in RecoverySpoolReplayerTests.
   if let transport = error as? XPCASRTransportError {
-    return transport.isServiceUnreachable ? .xpcUnreachable : .xpcTransport
+    switch transport {
+    case .serviceUnreachable: return .xpcUnreachable
+    case .modelNotLoaded: return .xpcModelNotLoaded
+    case .requestEncodingFailed, .invalidSamplePayload, .requestDecodingFailed,
+      .responseEncodingFailed, .responseDecodingFailed:
+      return .xpcTransport
+    }
   }
   // Three cancellation vehicles, one actionable class. `KernelDictationDriver`
   // already groups the latter two exactly this way.

--- a/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
@@ -340,7 +340,7 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
       if case .classified(.loadReturnedNotReady) = diagnosis {
         return attemptReadinessRetry(
           spoolStore: spoolStore, id: id, diagnosis: diagnosis,
-          reconstructedSampleCount: recovered.samples.count)
+          reconstructedSampleCount: recovered.samples.count, reason: .modelLoadFailed)
       }
       return failUnrecoverable(
         reason: .modelLoadFailed, diagnosis: diagnosis,
@@ -356,6 +356,15 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
       // here as a throw — treat it as an abort (the user discarded), not a failure.
       if isAborted() { return .aborted }
       let diagnosis = Self.diagnose(error, operation: .transcription)
+      // #2221: the helper accepted the request but had no model, so it never
+      // decoded this recovered audio. Give the take the same durable, ONE-time
+      // readiness retry as the post-load race rather than deleting it as a
+      // generic transport failure. The retry marker prevents forever deferral.
+      if case .classified(.xpcModelNotLoaded) = diagnosis {
+        return attemptReadinessRetry(
+          spoolStore: spoolStore, id: id, diagnosis: diagnosis,
+          reconstructedSampleCount: recovered.samples.count, reason: .transcribeError)
+      }
       if Self.engineWasNeverAvailable(diagnosis) {
         return deferForUnavailableEngine(
           spoolStore: spoolStore, id: id, reason: .transcribeError, diagnosis: diagnosis,
@@ -776,6 +785,11 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
       // explicitly because this switch is the build-time gate that forces the
       // choice rather than letting a new case inherit one.
       case .loadReturnedNotReady: return true
+      // #2221. Also not reachable here: the transcription catch routes this
+      // through the bounded retry before asking this broader helper. Returning
+      // false prevents an accidental future fall-through into the unbounded
+      // unavailable-engine deferral.
+      case .xpcModelNotLoaded: return false
       case .xpcUnreachable, .cancelled, .transcriptionFailed, .whisperKitModelLoad,
         .parakeetModelLoad, .parakeetTranscription, .xpcTransport, .other:
         return false
@@ -795,12 +809,12 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
   /// re-opening what the bound exists to close.
   private func attemptReadinessRetry(
     spoolStore: RecoverySpoolStore, id: String, diagnosis: RecoveryFailureDiagnosis,
-    reconstructedSampleCount: Int
+    reconstructedSampleCount: Int, reason: RecoveryTelemetryReason
   ) -> RecoveryReplayOutcome {
     // Already spent: terminal. This is the bound working, NOT a regression.
     guard !spoolStore.hasReadinessRetryMarker(for: id) else {
       return failUnrecoverable(
-        reason: .modelLoadFailed, diagnosis: diagnosis,
+        reason: reason, diagnosis: diagnosis,
         reconstructedSampleCount: reconstructedSampleCount, retryDisposition: .exhausted)
     }
     let spoolSeconds = Int(
@@ -839,9 +853,9 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
     // cannot, which is the wrong direction for a limb.
     try? spoolStore.syncSpoolDirectory()
     RecoveryLog.line(
-      "replay deferred: model_load_failed class=\(diagnosis.failureClass.rawValue) "
-        + "— the load returned but the engine was not ready; one retry granted")
-    emitDeferred(reason: .modelLoadFailed, disposition: .granted)
+      "replay deferred: \(reason.rawValue) class=\(diagnosis.failureClass.rawValue) "
+        + "— the engine was unavailable; one readiness retry granted")
+    emitDeferred(reason: reason, disposition: .granted)
     return .deferred
   }
 

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -164,6 +164,11 @@ public enum RecoveryFailureClass: String, Sendable {
   case parakeetModelLoad = "parakeet_model_load"
   case parakeetTranscription = "parakeet_transcription"
   case xpcTransport = "xpc_transport"
+  /// #2221: the helper received the request but had no admitted model, so it
+  /// never decoded the recovered audio. This gets the same bounded readiness
+  /// retry as `loadReturnedNotReady`, while genuine transport failures remain
+  /// terminal.
+  case xpcModelNotLoaded = "xpc_model_not_loaded"
   /// #2207: the engine's load returned NORMALLY and its readiness projection was
   /// still false. Distinct from `notReady`, which is a DETERMINISTIC refusal at
   /// the load site with no model admitted — conflating the two restores the #2132

--- a/Tests/EnviousWisprTests/Recovery/ReadinessRetryTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/ReadinessRetryTests.swift
@@ -136,6 +136,14 @@ struct ReadinessRetryTelemetryContractTests {
     #expect(classified == .loadReturnedNotReady)
     #expect(classified != .cancelled, "cancelled is terminal — this is the #2132 trap")
   }
+
+  @Test("model-not-loaded is distinct from terminal XPC transport failures")
+  func modelNotLoadedHasItsOwnRecoveryClass() {
+    #expect(recoveryFailureClass(for: XPCASRTransportError.modelNotLoaded) == .xpcModelNotLoaded)
+    #expect(
+      recoveryFailureClass(for: XPCASRTransportError.requestDecodingFailed("x"))
+        == .xpcTransport)
+  }
 }
 
 // MARK: - The recovery outcome
@@ -311,6 +319,51 @@ struct ReadinessRetryRecoveryTests {
     #expect(e.stringProps["outcome"] == "failed")
     #expect(e.stringProps["retry_disposition"] == "exhausted")
     #expect(e.stringProps["failure_class"] == "load_returned_not_ready")
+  }
+
+  /// #2221. The XPC helper accepted the request but had no model, so the audio
+  /// was never decoded and must survive one bounded retry.
+  @Test("the first XPC model-not-loaded refusal keeps the recording")
+  func firstXPCModelNotLoadedRefusalGetsOneRetry() async throws {
+    let h = try Fixture.make()
+    h.asr.transcribeError = XPCASRTransportError.modelNotLoaded
+
+    var outcome: RecoveryReplayOutcome?
+    let box = await Fixture.capturingTelemetry {
+      outcome = await h.replayer.replay(recoverySessionID: h.id, isAborted: { false })
+    }
+
+    #expect(outcome == .deferred)
+    #expect(h.store.hasReadinessRetryMarker(for: h.id), "the one retry is durably spent")
+    #expect(!h.store.hasAttemptMarker(for: h.id), "a later pass may use the recorded retry")
+    #expect(h.spoolExists, "the user's recording remains on disk")
+    #expect(h.asr.transcribeCallCount == 1, "the helper refused this request")
+
+    let e = try #require(box.recoveryEvents().first)
+    #expect(e.stringProps["outcome"] == "deferred")
+    #expect(e.stringProps["reason"] == "transcribe_error")
+    #expect(e.stringProps["failure_class"] == "xpc_model_not_loaded")
+    #expect(e.stringProps["retry_disposition"] == "granted")
+    #expect(e.boolProps["audio_decrypted"] == true)
+    #expect(e.boolProps["camp_b_candidate"] == true)
+  }
+
+  @Test("a second XPC model-not-loaded refusal is terminal")
+  func repeatedXPCModelNotLoadedRefusalTerminates() async throws {
+    let h = try Fixture.make()
+    h.asr.transcribeError = XPCASRTransportError.modelNotLoaded
+    try h.store.writeReadinessRetryMarker(for: h.id)
+
+    var outcome: RecoveryReplayOutcome?
+    let box = await Fixture.capturingTelemetry {
+      outcome = await h.replayer.replay(recoverySessionID: h.id, isAborted: { false })
+    }
+
+    #expect(outcome == .failed(.unrecoverable), "one retry, then the bound stops")
+    let e = try #require(box.recoveryEvents().first)
+    #expect(e.stringProps["reason"] == "transcribe_error")
+    #expect(e.stringProps["failure_class"] == "xpc_model_not_loaded")
+    #expect(e.stringProps["retry_disposition"] == "exhausted")
   }
 
   /// THE TRAP, specified so it cannot be satisfied trivially. Two independent

--- a/Tests/EnviousWisprTests/Recovery/RecoverySpoolReplayerTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoverySpoolReplayerTests.swift
@@ -780,14 +780,14 @@ struct RecoverySpoolReplayerTests {
       #expect(e.stringProps.values.allSatisfy { !$0.contains("serviceUnreachable") })
     }
 
-    /// #1525 PR I-B narrowing-regression: `XPCASRTransportError`'s 6 new
+    /// #1525 PR I-B narrowing-regression: `XPCASRTransportError`'s 5 generic
     /// codec/transport cases are NOT "XPC unreachable" — a bare `is
     /// XPCASRTransportError` type-check would have misclassified them,
     /// corrupting recovery telemetry.
     /// #2132 UPDATE: these now classify as `.xpc_transport` rather than
     /// `.other`. The protection this test exists for is UNCHANGED and is the
     /// reason it must not be deleted: a bare `is XPCASRTransportError` check
-    /// would call all six "unreachable", and the assertion below still fails if
+    /// would call all five "unreachable", and the assertion below still fails if
     /// anyone reintroduces that. The expected label is simply more specific now.
     @Test(
       "the new XPCASRTransportError cases are transport, never .xpcUnreachable",
@@ -795,7 +795,6 @@ struct RecoverySpoolReplayerTests {
         XPCASRTransportError.requestEncodingFailed("x"),
         .invalidSamplePayload("x"),
         .requestDecodingFailed("x"),
-        .modelNotLoaded,
         .responseEncodingFailed("x"),
         .responseDecodingFailed("x"),
       ]


### PR DESCRIPTION
## Summary

- classify `XPCASRTransportError.modelNotLoaded` separately from terminal transport failures
- retain the recovered recording and grant one durable readiness retry
- make a repeated refusal terminal so the helper cannot defer forever
- preserve `transcribe_error` telemetry and add a precise failure class

**Lane:** Code

## Validation

- Debug telemetry contract: 7/7
- Debug readiness recovery outcomes: 11/11
- Debug recovery spool replayer: 25/25
- Release telemetry contract: 7/7
- pinned Codex review: clean; reviewer independently ran 20/20 relevant tests
- `git diff --check`: clean

No Live UAT: reproducing this requires the XPC helper to lose its model between successful load and transcription; the real production route is bound at the error classifier and recovery outcome seams.

Closes #2221