### PR TITLE
fix(ui): keep custom word actions visible

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordEditSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordEditSheet.swift
@@ -44,6 +44,11 @@ struct CustomWordEditSheet: View {
     )
   }
 
+  private var aliasCountLabel: String {
+    let count = word.aliases.count
+    return "\(count) \(count == 1 ? "alias" : "aliases")"
+  }
+
   var body: some View {
     VStack(alignment: .leading, spacing: 14) {
       Text(word.canonical.isEmpty ? "Add Custom Word" : "Edit Custom Word")
@@ -74,9 +79,15 @@ struct CustomWordEditSheet: View {
 
       // Aliases
       VStack(alignment: .leading, spacing: 4) {
-        Text("Aliases (spoken variants the ASR produces)")
-          .font(.stHelper)
-          .foregroundStyle(.stTextSecondary)
+        HStack {
+          Text("Aliases (spoken variants the ASR produces)")
+            .font(.stHelper)
+            .foregroundStyle(.stTextSecondary)
+          Spacer()
+          Text(aliasCountLabel)
+            .font(.stHelper)
+            .foregroundStyle(.stTextSecondary)
+        }
 
         HStack {
           TextField("Add alias (e.g. clawed)", text: $newAlias)
@@ -86,28 +97,50 @@ struct CustomWordEditSheet: View {
             .disabled(newAlias.trimmingCharacters(in: .whitespaces).isEmpty)
         }
 
-        if !word.aliases.isEmpty {
-          WrappingHStack(spacing: 6) {
-            ForEach(word.aliases, id: \.self) { alias in
-              HStack(spacing: 3) {
-                Text(alias)
-                  .font(.stHelper)
-                Button {
-                  word.aliases.removeAll { $0 == alias }
-                } label: {
-                  Image(systemName: "xmark")
-                    .font(.system(size: 8, weight: .bold))
+        ScrollView(.vertical) {
+          if word.aliases.isEmpty {
+            Text("No aliases yet")
+              .font(.stHelper)
+              .foregroundStyle(.stTextSecondary)
+              .frame(maxWidth: .infinity, alignment: .leading)
+              .padding(8)
+          } else {
+            WrappingHStack(spacing: 6) {
+              ForEach(word.aliases, id: \.self) { alias in
+                HStack(spacing: 3) {
+                  Text(alias)
+                    .font(.stHelper)
+                    .fixedSize(horizontal: false, vertical: true)
+                  Button {
+                    word.aliases.removeAll { $0 == alias }
+                  } label: {
+                    Image(systemName: "xmark")
+                      .font(.system(size: 8, weight: .bold))
+                  }
+                  .buttonStyle(.plain)
+                  .fixedSize()
+                  .accessibilityLabel("Remove alias \(alias)")
                 }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Remove alias \(alias)")
+                .padding(.horizontal, 6)
+                .padding(.vertical, 3)
+                .background(Color.stAccentLight)
+                .clipShape(RoundedRectangle(cornerRadius: 4))
               }
-              .padding(.horizontal, 6)
-              .padding(.vertical, 3)
-              .background(Color.stAccentLight)
-              .clipShape(RoundedRectangle(cornerRadius: 4))
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(8)
           }
         }
+        .frame(maxWidth: .infinity)
+        .frame(height: 150)
+        .background(Color.stPageBg)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .overlay(
+          RoundedRectangle(cornerRadius: 8)
+            .strokeBorder(Color.stDivider, lineWidth: 1)
+        )
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Aliases")
       }
 
       // Match strictness (Phase 2a override surface)
@@ -161,6 +194,9 @@ struct CustomWordEditSheet: View {
       .frame(maxWidth: .infinity, alignment: .leading)
       .accessibilityElement(children: .combine)
 
+      Divider()
+        .overlay(Color.stDivider)
+
       // Actions
       HStack {
         if onDelete != nil {
@@ -199,7 +235,7 @@ struct CustomWordEditSheet: View {
       Text("Removes this word and its aliases. Can't be undone.")
     }
     .padding(20)
-    .frame(width: 400, height: 480)
+    .frame(width: 480, height: 600)
     // Phase 1 (#637) + Phase 4 (#634) + Codex P2 fix: keyed task that restarts
     // when canonical changes. Empty-canonical guard prevents the AFM call from
     // running on the blank "+ Add term" sheet open. After the user types into

--- a/Sources/EnviousWisprAppKit/Views/Settings/SettingsComponents.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SettingsComponents.swift
@@ -590,9 +590,10 @@ struct WrappingHStack: Layout {
       subviews: subviews
     )
     for (index, position) in result.positions.enumerated() {
+      let size = result.sizes[index]
       subviews[index].place(
         at: CGPoint(x: bounds.minX + position.x, y: bounds.minY + position.y),
-        proposal: .unspecified
+        proposal: ProposedViewSize(width: size.width, height: size.height)
       )
     }
   }
@@ -600,28 +601,32 @@ struct WrappingHStack: Layout {
   private func layout(
     proposal: ProposedViewSize,
     subviews: Subviews
-  ) -> (size: CGSize, positions: [CGPoint]) {
+  ) -> (size: CGSize, positions: [CGPoint], sizes: [CGSize]) {
     let maxWidth = proposal.width ?? .infinity
+    let subviewProposal =
+      proposal.width.map { ProposedViewSize(width: $0, height: nil) } ?? .unspecified
     var positions: [CGPoint] = []
+    var sizes: [CGSize] = []
     var x: CGFloat = 0
     var y: CGFloat = 0
     var rowHeight: CGFloat = 0
     var totalWidth: CGFloat = 0
 
     for subview in subviews {
-      let size = subview.sizeThatFits(.unspecified)
+      let size = subview.sizeThatFits(subviewProposal)
       if x + size.width > maxWidth, x > 0 {
         x = 0
         y += rowHeight + spacing
         rowHeight = 0
       }
       positions.append(CGPoint(x: x, y: y))
+      sizes.append(size)
       rowHeight = max(rowHeight, size.height)
       x += size.width + spacing
       totalWidth = max(totalWidth, x - spacing)
     }
 
-    return (CGSize(width: totalWidth, height: y + rowHeight), positions)
+    return (CGSize(width: totalWidth, height: y + rowHeight), positions, sizes)
   }
 }
 


### PR DESCRIPTION
## Summary

- keep the custom-word sheet at a stable size
- put alias chips in a bounded, independently scrollable area
- keep Delete, Cancel, and Save permanently visible
- show a live alias count and wrap very long aliases safely

## Validation

- independent Codex diff review: clean
- debug suite: 6,398 tests passed
- release suite: 5,830 tests passed
- signed dev build and strict Code-lane validation passed
- real app UAT passed with 17 aliases, including a long wrapped alias
- verified dark and light appearance
- verified the shared vocabulary-pack chip layout still renders correctly

Closes #2317
