### PR TITLE
test(audio): add real microphone boundary receipt

### DIFF
--- a/Tests/EnviousWisprTests/Audio/AudioCaptureManagerLiveInputTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioCaptureManagerLiveInputTests.swift
@@ -36,6 +36,11 @@ struct AudioCaptureManagerLiveInputTests {
     }
   }
 
+  private struct StopReceipt: Sendable {
+    let capture: CaptureResult
+    let receipt: Receipt
+  }
+
   /// `.enabled(if:)` is evaluated outside actor isolation during discovery.
   /// Read only existing system facts: do not request permission or mutate the
   /// user's selected input device merely to decide whether this receipt runs.
@@ -88,12 +93,18 @@ struct AudioCaptureManagerLiveInputTests {
     // CoreAudio can legitimately emit a silent startup buffer. Observe a short
     // live window so this receipt measures the device rather than that transient.
     try await Task.sleep(for: .seconds(1))
-    let capture = await manager.stopCapture(sessionID: sessionID)
-    guard let receipt = await Self.waitForReceipt(from: collector) else {
+    let stopAndCollect = Task { @MainActor in
+      let capture = await manager.stopCapture(sessionID: sessionID)
+      return StopReceipt(capture: capture, receipt: await collector.value)
+    }
+    guard let stopped = await Self.waitForStopReceipt(from: stopAndCollect) else {
+      stopAndCollect.cancel()
       collector.cancel()
-      Issue.record("stopCapture did not finish the live microphone stream within two seconds")
+      Issue.record("stopCapture and stream completion exceeded two seconds")
       return
     }
+    let capture = stopped.capture
+    let receipt = stopped.receipt
 
     #expect(receipt.bufferCount > 0, "the real microphone produced no buffer within one second")
     #expect(receipt.frameCount > 0)
@@ -109,15 +120,17 @@ struct AudioCaptureManagerLiveInputTests {
     #expect(!manager.isCapturing, "stopCapture must end the live session")
   }
 
-  private static func waitForReceipt(from collector: Task<Receipt, Never>) async -> Receipt? {
+  private static func waitForStopReceipt(
+    from operation: Task<StopReceipt, Never>
+  ) async -> StopReceipt? {
     let (receipts, continuation) = AsyncStream.makeStream(
-      of: Receipt.self, bufferingPolicy: .bufferingNewest(1))
+      of: StopReceipt.self, bufferingPolicy: .bufferingNewest(1))
     let relay = Task {
-      continuation.yield(await collector.value)
+      continuation.yield(await operation.value)
       continuation.finish()
     }
 
-    let result = await withTaskGroup(of: Receipt?.self) { group in
+    let result = await withTaskGroup(of: StopReceipt?.self) { group in
       group.addTask {
         for await receipt in receipts { return receipt }
         return nil

--- a/Tests/EnviousWisprTests/Audio/AudioCaptureManagerLiveInputTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioCaptureManagerLiveInputTests.swift
@@ -1,0 +1,137 @@
+@preconcurrency import AVFoundation
+import CoreAudio
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprAudio
+
+/// #2142 — a receipt across the real microphone boundary.
+///
+/// Unit tests can prove routing and buffering with stand-ins, but they cannot
+/// prove that CoreAudio opens the built-in microphone and delivers live samples
+/// through the production manager. This suite is gated on both the device and
+/// an existing TCC grant. The release receipt runs through
+/// `scripts/test-real-microphone.sh`, which rejects a skipped test.
+@Suite("Live microphone capture", .tags(.productOutcome), .serialized)
+@MainActor
+struct AudioCaptureManagerLiveInputTests {
+
+  private struct Receipt: Sendable {
+    var bufferCount = 0
+    var frameCount = 0
+    var maximumMagnitude: Float = 0
+    var sampleRate: Double?
+    var channelCount: UInt32?
+
+    mutating func observe(_ buffer: AVAudioPCMBuffer) {
+      bufferCount += 1
+      frameCount += Int(buffer.frameLength)
+      sampleRate = sampleRate ?? buffer.format.sampleRate
+      channelCount = channelCount ?? buffer.format.channelCount
+      guard let channel = buffer.floatChannelData?.pointee else { return }
+      for index in 0..<Int(buffer.frameLength) {
+        maximumMagnitude = max(maximumMagnitude, abs(channel[index]))
+      }
+    }
+  }
+
+  /// `.enabled(if:)` is evaluated outside actor isolation during discovery.
+  /// Read only existing system facts: do not request permission or mutate the
+  /// user's selected input device merely to decide whether this receipt runs.
+  nonisolated private static func authorizedBuiltInMicrophoneUID() -> String? {
+    guard AVCaptureDevice.authorizationStatus(for: .audio) == .authorized else { return nil }
+    guard case .success(let candidates, _) = AudioDeviceEnumerator.inputDeviceSnapshot()
+    else { return nil }
+    return candidates.first {
+      $0.rawTransport == kAudioDeviceTransportTypeBuiltIn && !$0.uid.isEmpty
+    }?.uid
+  }
+
+  @Test(
+    "the built-in microphone produces non-zero 16 kHz mono samples and stops cleanly",
+    .tags(.realBoundary),
+    .enabled(if: AudioCaptureManagerLiveInputTests.authorizedBuiltInMicrophoneUID() != nil),
+    .timeLimit(.minutes(1)))
+  func builtInMicrophoneProducesNonZeroSamplesAndCleanStop() async throws {
+    let microphoneUID = try #require(
+      Self.authorizedBuiltInMicrophoneUID(),
+      "requires microphone permission and a built-in input device")
+    let microphoneID = try #require(AudioDeviceEnumerator.deviceID(forUID: microphoneUID))
+    #expect(
+      CoreAudioDeviceLiveness.classify(deviceID: microphoneID) == .alive,
+      "the built-in microphone must be alive before the capture receipt runs")
+    #expect(
+      CoreAudioDeviceMute.classify(deviceID: microphoneID) == .unmuted,
+      "the built-in microphone must be unmuted before the capture receipt runs")
+    let manager = AudioCaptureManager()
+    manager.preferredInputDeviceIDOverride = microphoneUID
+    manager.warmEnginePolicy = .off
+
+    let stream = try await manager.startCapture()
+    let sessionID = manager.currentCaptureSessionID
+    #expect(sessionID > 0, "a live capture must mint a real session identity")
+    guard manager.zeroSignalDiscriminatorDevice?.deviceUID == microphoneUID else {
+      _ = await manager.stopCapture(sessionID: sessionID)
+      Issue.record("capture fell back instead of binding the requested built-in microphone")
+      return
+    }
+
+    let collector = Task { @MainActor in
+      var receipt = Receipt()
+      for await buffer in stream {
+        receipt.observe(buffer)
+      }
+      return receipt
+    }
+
+    // CoreAudio can legitimately emit a silent startup buffer. Observe a short
+    // live window so this receipt measures the device rather than that transient.
+    try await Task.sleep(for: .seconds(1))
+    let capture = await manager.stopCapture(sessionID: sessionID)
+    guard let receipt = await Self.waitForReceipt(from: collector) else {
+      collector.cancel()
+      Issue.record("stopCapture did not finish the live microphone stream within two seconds")
+      return
+    }
+
+    #expect(receipt.bufferCount > 0, "the real microphone produced no buffer within one second")
+    #expect(receipt.frameCount > 0)
+    #expect(receipt.sampleRate == AudioCaptureManager.targetSampleRate)
+    #expect(receipt.channelCount == 1)
+    #expect(
+      receipt.maximumMagnitude > 0.000_001,
+      "the built-in microphone delivered only digital zero")
+    #expect(!capture.samples.isEmpty, "the manager must retain the live samples for transcription")
+    #expect(
+      capture.samples.contains { abs($0) > 0.000_001 },
+      "the manager retained only digital zero")
+    #expect(!manager.isCapturing, "stopCapture must end the live session")
+  }
+
+  private static func waitForReceipt(from collector: Task<Receipt, Never>) async -> Receipt? {
+    let (receipts, continuation) = AsyncStream.makeStream(
+      of: Receipt.self, bufferingPolicy: .bufferingNewest(1))
+    let relay = Task {
+      continuation.yield(await collector.value)
+      continuation.finish()
+    }
+
+    let result = await withTaskGroup(of: Receipt?.self) { group in
+      group.addTask {
+        for await receipt in receipts { return receipt }
+        return nil
+      }
+      group.addTask {
+        try? await Task.sleep(for: .seconds(2))
+        return nil
+      }
+      let first = await group.next() ?? nil
+      group.cancelAll()
+      return first
+    }
+
+    relay.cancel()
+    return result
+  }
+}

--- a/Tests/EnviousWisprTests/Audio/AudioCaptureManagerLiveInputTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioCaptureManagerLiveInputTests.swift
@@ -36,11 +36,6 @@ struct AudioCaptureManagerLiveInputTests {
     }
   }
 
-  private struct StopReceipt: Sendable {
-    let capture: CaptureResult
-    let receipt: Receipt
-  }
-
   /// `.enabled(if:)` is evaluated outside actor isolation during discovery.
   /// Read only existing system facts: do not request permission or mutate the
   /// user's selected input device merely to decide whether this receipt runs.
@@ -93,18 +88,10 @@ struct AudioCaptureManagerLiveInputTests {
     // CoreAudio can legitimately emit a silent startup buffer. Observe a short
     // live window so this receipt measures the device rather than that transient.
     try await Task.sleep(for: .seconds(1))
-    let stopAndCollect = Task { @MainActor in
-      let capture = await manager.stopCapture(sessionID: sessionID)
-      return StopReceipt(capture: capture, receipt: await collector.value)
-    }
-    guard let stopped = await Self.waitForStopReceipt(from: stopAndCollect) else {
-      stopAndCollect.cancel()
-      collector.cancel()
-      Issue.record("stopCapture and stream completion exceeded two seconds")
-      return
-    }
-    let capture = stopped.capture
-    let receipt = stopped.receipt
+    try Self.writeWatchdogMarker(named: "EW_MICROPHONE_STOP_STARTED")
+    let capture = await manager.stopCapture(sessionID: sessionID)
+    let receipt = await collector.value
+    try Self.writeWatchdogMarker(named: "EW_MICROPHONE_STOP_FINISHED")
 
     #expect(receipt.bufferCount > 0, "the real microphone produced no buffer within one second")
     #expect(receipt.frameCount > 0)
@@ -120,31 +107,8 @@ struct AudioCaptureManagerLiveInputTests {
     #expect(!manager.isCapturing, "stopCapture must end the live session")
   }
 
-  private static func waitForStopReceipt(
-    from operation: Task<StopReceipt, Never>
-  ) async -> StopReceipt? {
-    let (receipts, continuation) = AsyncStream.makeStream(
-      of: StopReceipt.self, bufferingPolicy: .bufferingNewest(1))
-    let relay = Task {
-      continuation.yield(await operation.value)
-      continuation.finish()
-    }
-
-    let result = await withTaskGroup(of: StopReceipt?.self) { group in
-      group.addTask {
-        for await receipt in receipts { return receipt }
-        return nil
-      }
-      group.addTask {
-        try? await Task.sleep(for: .seconds(2))
-        return nil
-      }
-      let first = await group.next() ?? nil
-      group.cancelAll()
-      return first
-    }
-
-    relay.cancel()
-    return result
+  private static func writeWatchdogMarker(named environmentKey: String) throws {
+    guard let path = ProcessInfo.processInfo.environment[environmentKey] else { return }
+    try Data().write(to: URL(filePath: path), options: .atomic)
   }
 }

--- a/scripts/test-real-microphone.sh
+++ b/scripts/test-real-microphone.sh
@@ -50,6 +50,15 @@ with tempfile.TemporaryDirectory(prefix="ew-microphone-watchdog-") as marker_dir
     environment["EW_MICROPHONE_STOP_FINISHED"] = str(finished)
 
     with open(log_file, "w", encoding="utf-8") as log:
+        received_signal = [None]
+
+        def request_shutdown(signum, _frame):
+            received_signal[0] = signum
+
+        # Install handlers before Popen so no signal can strand the new Swift session.
+        for handled_signal in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP):
+            signal.signal(handled_signal, request_shutdown)
+
         process = subprocess.Popen(
             ["swift", *swift_args],
             cwd=project_root,
@@ -73,19 +82,17 @@ with tempfile.TemporaryDirectory(prefix="ew-microphone-watchdog-") as marker_dir
         relay.start()
         stop_deadline = None
         timed_out = False
-        received_signal = [None]
-
         def group_exists():
             try:
                 os.killpg(process.pid, 0)
                 return True
-            except ProcessLookupError:
+            except (ProcessLookupError, PermissionError):
                 return False
 
         def signal_group(sig):
             try:
                 os.killpg(process.pid, sig)
-            except ProcessLookupError:
+            except (ProcessLookupError, PermissionError):
                 pass
 
         def reap_group():
@@ -101,12 +108,6 @@ with tempfile.TemporaryDirectory(prefix="ew-microphone-watchdog-") as marker_dir
             except subprocess.TimeoutExpired:
                 signal_group(signal.SIGKILL)
                 process.wait()
-
-        def request_shutdown(signum, _frame):
-            received_signal[0] = signum
-
-        for handled_signal in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP):
-            signal.signal(handled_signal, request_shutdown)
 
         try:
             while True:

--- a/scripts/test-real-microphone.sh
+++ b/scripts/test-real-microphone.sh
@@ -73,27 +73,69 @@ with tempfile.TemporaryDirectory(prefix="ew-microphone-watchdog-") as marker_dir
         relay.start()
         stop_deadline = None
         timed_out = False
-        while process.poll() is None:
-            if started.exists() and stop_deadline is None:
-                stop_deadline = time.monotonic() + 2.0
-            if finished.exists():
-                stop_deadline = None
-            if stop_deadline is not None and time.monotonic() >= stop_deadline:
-                message = "ERROR: stopCapture and stream completion exceeded two seconds.\n"
-                sys.stderr.write(message)
-                log.write(message)
-                log.flush()
-                timed_out = True
-                os.killpg(process.pid, signal.SIGTERM)
-                try:
-                    process.wait(timeout=2)
-                except subprocess.TimeoutExpired:
-                    os.killpg(process.pid, signal.SIGKILL)
-                break
-            time.sleep(0.025)
+        received_signal = [None]
+
+        def group_exists():
+            try:
+                os.killpg(process.pid, 0)
+                return True
+            except ProcessLookupError:
+                return False
+
+        def signal_group(sig):
+            try:
+                os.killpg(process.pid, sig)
+            except ProcessLookupError:
+                pass
+
+        def reap_group():
+            signal_group(signal.SIGTERM)
+            grace_deadline = time.monotonic() + 2.0
+            while group_exists() and time.monotonic() < grace_deadline:
+                time.sleep(0.025)
+            # Sweep the process group even if its original leader already exited.
+            if group_exists():
+                signal_group(signal.SIGKILL)
+            try:
+                process.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                signal_group(signal.SIGKILL)
+                process.wait()
+
+        def request_shutdown(signum, _frame):
+            received_signal[0] = signum
+
+        for handled_signal in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP):
+            signal.signal(handled_signal, request_shutdown)
+
+        try:
+            while True:
+                if received_signal[0] is not None:
+                    reap_group()
+                    break
+                if process.poll() is not None:
+                    break
+                if started.exists() and stop_deadline is None:
+                    stop_deadline = time.monotonic() + 2.0
+                if finished.exists():
+                    stop_deadline = None
+                if stop_deadline is not None and time.monotonic() >= stop_deadline:
+                    message = "ERROR: stopCapture and stream completion exceeded two seconds.\n"
+                    sys.stderr.write(message)
+                    log.write(message)
+                    log.flush()
+                    timed_out = True
+                    reap_group()
+                    break
+                time.sleep(0.025)
+        finally:
+            if group_exists():
+                reap_group()
 
         return_code = process.wait()
         relay.join(timeout=2)
+        if received_signal[0] is not None:
+            sys.exit(128 + received_signal[0])
         if timed_out:
             sys.exit(124)
         sys.exit(return_code)

--- a/scripts/test-real-microphone.sh
+++ b/scripts/test-real-microphone.sh
@@ -25,14 +25,85 @@ LOG_DIR="$PROJECT_ROOT/build/real-boundary"
 LOG_FILE="$LOG_DIR/microphone-$CONFIGURATION.log"
 mkdir -p "$LOG_DIR"
 
-SWIFT_ARGS=(test --filter AudioCaptureManagerLiveInputTests)
-if [ "$CONFIGURATION" = "release" ]; then
-  SWIFT_ARGS=(test -c release --filter AudioCaptureManagerLiveInputTests)
-fi
-
 cd "$PROJECT_ROOT"
-set -o pipefail
-swift "${SWIFT_ARGS[@]}" 2>&1 | tee "$LOG_FILE"
+set +e
+python3 - "$PROJECT_ROOT" "$LOG_FILE" "$CONFIGURATION" <<'PY'
+import os
+from pathlib import Path
+import signal
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+
+project_root, log_file, configuration = sys.argv[1:]
+swift_args = ["test", "--filter", "AudioCaptureManagerLiveInputTests"]
+if configuration == "release":
+    swift_args = ["test", "-c", "release", "--filter", "AudioCaptureManagerLiveInputTests"]
+
+with tempfile.TemporaryDirectory(prefix="ew-microphone-watchdog-") as marker_dir:
+    started = Path(marker_dir) / "stop-started"
+    finished = Path(marker_dir) / "stop-finished"
+    environment = os.environ.copy()
+    environment["EW_MICROPHONE_STOP_STARTED"] = str(started)
+    environment["EW_MICROPHONE_STOP_FINISHED"] = str(finished)
+
+    with open(log_file, "w", encoding="utf-8") as log:
+        process = subprocess.Popen(
+            ["swift", *swift_args],
+            cwd=project_root,
+            env=environment,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+            start_new_session=True,
+        )
+
+        def relay_output():
+            assert process.stdout is not None
+            for line in process.stdout:
+                sys.stdout.write(line)
+                sys.stdout.flush()
+                log.write(line)
+                log.flush()
+
+        relay = threading.Thread(target=relay_output, daemon=True)
+        relay.start()
+        stop_deadline = None
+        timed_out = False
+        while process.poll() is None:
+            if started.exists() and stop_deadline is None:
+                stop_deadline = time.monotonic() + 2.0
+            if finished.exists():
+                stop_deadline = None
+            if stop_deadline is not None and time.monotonic() >= stop_deadline:
+                message = "ERROR: stopCapture and stream completion exceeded two seconds.\n"
+                sys.stderr.write(message)
+                log.write(message)
+                log.flush()
+                timed_out = True
+                os.killpg(process.pid, signal.SIGTERM)
+                try:
+                    process.wait(timeout=2)
+                except subprocess.TimeoutExpired:
+                    os.killpg(process.pid, signal.SIGKILL)
+                break
+            time.sleep(0.025)
+
+        return_code = process.wait()
+        relay.join(timeout=2)
+        if timed_out:
+            sys.exit(124)
+        sys.exit(return_code)
+PY
+TEST_STATUS=$?
+set -e
+
+if [ "$TEST_STATUS" -ne 0 ]; then
+  exit "$TEST_STATUS"
+fi
 
 PASS_TEXT='Test "the built-in microphone produces non-zero 16 kHz mono samples and stops cleanly" passed after'
 if ! grep -Fq "$PASS_TEXT" "$LOG_FILE"; then

--- a/scripts/test-real-microphone.sh
+++ b/scripts/test-real-microphone.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Developer-machine receipt for #2142. The canonical Xcode unit-test bundle has
+# its own TCC identity and therefore skips the microphone test. SwiftPM inherits
+# the invoking terminal's existing microphone grant. This runner turns that
+# environment-specific route into an honest gate: a skipped test is a failure.
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CONFIGURATION="release"
+
+if [ "$#" -gt 1 ]; then
+  echo "usage: scripts/test-real-microphone.sh [--debug]" >&2
+  exit 2
+fi
+if [ "$#" -eq 1 ]; then
+  if [ "$1" != "--debug" ]; then
+    echo "usage: scripts/test-real-microphone.sh [--debug]" >&2
+    exit 2
+  fi
+  CONFIGURATION="debug"
+fi
+
+LOG_DIR="$PROJECT_ROOT/build/real-boundary"
+LOG_FILE="$LOG_DIR/microphone-$CONFIGURATION.log"
+mkdir -p "$LOG_DIR"
+
+SWIFT_ARGS=(test --filter AudioCaptureManagerLiveInputTests)
+if [ "$CONFIGURATION" = "release" ]; then
+  SWIFT_ARGS=(test -c release --filter AudioCaptureManagerLiveInputTests)
+fi
+
+cd "$PROJECT_ROOT"
+set -o pipefail
+swift "${SWIFT_ARGS[@]}" 2>&1 | tee "$LOG_FILE"
+
+PASS_TEXT='Test "the built-in microphone produces non-zero 16 kHz mono samples and stops cleanly" passed after'
+if ! grep -Fq "$PASS_TEXT" "$LOG_FILE"; then
+  echo "ERROR: the real microphone receipt did not PASS." >&2
+  echo "A skipped or zero-test run is not proof. Grant microphone access to this terminal and rerun." >&2
+  exit 1
+fi
+
+echo "==> Real microphone receipt passed ($CONFIGURATION)"


### PR DESCRIPTION
Part of #2142.

## What changed
- adds a real built-in microphone receipt through production `AudioCaptureManager`
- proves the requested built-in UID actually bound (no silent fallback)
- requires live non-zero 16 kHz mono audio and retained transcription samples
- requires stream shutdown within two seconds
- adds `scripts/test-real-microphone.sh`, a developer-machine Release gate that rejects skips and zero-test runs

## Proof
- Release real-microphone runner: 1/1 passed (1.106s on final reviewed commit)
- Debug real-microphone runner: 1/1 passed; five consecutive live runs passed after startup-window hardening
- test inventory: `REAL-BOUNDARY receipts 1` on this branch
- production audio-drop mutation: receipt failed with zero buffers/samples
- production stream-finish mutation: receipt failed in 3.09s with the bounded shutdown error
- swift-format lint, shellcheck, and diff checks passed
- pinned Codex review: four rounds; final round clean

## Environment behavior
The canonical unhosted Xcode test bundle has a separate microphone TCC identity and skips this hardware receipt. The dedicated SwiftPM runner uses the invoking developer terminal’s existing microphone permission and fails if the test skips. Hosted CI has no built-in microphone and is expected to skip the hardware test.

Not merged.