### PR TITLE
test(uat): prove TextEdit delivery exactly once

### DIFF
--- a/Tests/RuntimeUAT/README.md
+++ b/Tests/RuntimeUAT/README.md
@@ -53,6 +53,18 @@ python3 -c "import sys; sys.path.insert(0, 'Tests/RuntimeUAT'); from wispr_eyes 
 python3 Tests/RuntimeUAT/uat_runner.py run --suite recording
 ```
 
+**Real microphone -> shipped ASR -> TextEdit, exactly once:**
+```bash
+scripts/test-heart-path-delivery.sh
+```
+
+This receipt rebuilds and launches the current worktree's dev app, then takes
+control while it exercises both shipped backends. Run it as a background task
+because it posts CGEvents. It first checks the speaker route and performs the
+canonical silent-room probe; an occupied room stops the run before acoustic
+testing. It has no hosted-runner skip path: unreadable Accessibility state,
+unavailable models, or a missing real delivery fails the run.
+
 The `uat_runner.py run` command **must** be invoked with `run_in_background: true` from Claude Code's Bash tool — foreground execution silently fails. `list` works fine in foreground.
 
 ## How this fits the workflow

--- a/Tests/RuntimeUAT/simulate_input.py
+++ b/Tests/RuntimeUAT/simulate_input.py
@@ -293,8 +293,10 @@ def modifier_up(keycode):
 def hold_modifier(keycode, duration=2.0):
     """Press a modifier key, hold for *duration* seconds, then release."""
     modifier_down(keycode)
-    time.sleep(duration)
-    modifier_up(keycode)
+    try:
+        time.sleep(duration)
+    finally:
+        modifier_up(keycode)
 
 
 def scroll(dx=0, dy=0, x=None, y=None):
@@ -343,13 +345,14 @@ def hold_key(key_name, duration=2.0, cmd=False, shift=False, alt=False, ctrl=Fal
     down_event = CGEventCreateKeyboardEvent(None, keycode, True)
     CGEventSetFlags(down_event, flags)
     CGEventPost(kCGHIDEventTap, down_event)
-
-    time.sleep(duration)
-
-    # Key up
-    up_event = CGEventCreateKeyboardEvent(None, keycode, False)
-    CGEventSetFlags(up_event, flags)
-    CGEventPost(kCGHIDEventTap, up_event)
+    try:
+        time.sleep(duration)
+    finally:
+        # Key up must survive an interrupted wait; leaving modifiers or ordinary
+        # keys held changes the user's input after a failed UAT run.
+        up_event = CGEventCreateKeyboardEvent(None, keycode, False)
+        CGEventSetFlags(up_event, flags)
+        CGEventPost(kCGHIDEventTap, up_event)
     time.sleep(DEFAULT_DELAY)
 
 

--- a/Tests/RuntimeUAT/test_heart_path_delivery.py
+++ b/Tests/RuntimeUAT/test_heart_path_delivery.py
@@ -1,0 +1,841 @@
+#!/usr/bin/env python3
+"""Real-boundary receipt for capture -> shipped ASR -> TextEdit delivery (#2142).
+
+Run through ``scripts/test-heart-path-delivery.sh``. That runner rebuilds and
+launches this worktree's dev app before this file drives it. The receipt uses a
+real microphone capture (the committed speech clip is played through the Mac's
+speakers), each shipped ASR backend, the production PTT path, and a real
+foreground TextEdit document.
+
+This is intentionally fail-closed. An unreadable TextEdit field, a missing
+pipeline signal, an unverified backend selection, or a skipped backend is a
+failed receipt rather than a pass with weaker evidence.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import plistlib
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parents[1]
+sys.path.insert(0, str(HERE))
+
+import simulate_input as si  # noqa: E402
+import ui_helpers  # noqa: E402
+import wispr_eyes as w  # noqa: E402
+from capture_bakeoff import (  # noqa: E402
+    EXPECTED_BACKEND as EXPECTED_CAPTURE_BACKEND,
+    _bt_route_line_count,
+    read_new_evidence,
+)
+from ptt_binding import PTTBindingError, resolve  # noqa: E402
+from ui_helpers import (  # noqa: E402
+    activate_app,
+    find_app_pid,
+    find_element,
+    get_attr,
+    get_ax_app,
+    perform_action,
+    set_attr,
+)
+
+APP = ROOT / "build" / "EnviousWispr Local.app"
+APP_EXECUTABLE = APP / "Contents" / "MacOS" / "EnviousWispr"
+FIXTURE = ROOT / "scripts" / "freeze-suite" / "clips" / "normal-speech.wav"
+LOG = Path.home() / "Library" / "Logs" / "EnviousWispr" / "app.log"
+SHARED_DOMAIN = "com.enviouswispr.app"
+EXPECTED_PHRASE = "quick brown fox"
+BACKENDS = ("parakeet", "whisperkit")
+BUILT_IN_MICROPHONE_UID = "BuiltInMicrophoneDevice"
+
+
+class ReceiptFailure(RuntimeError):
+    """The run did not prove the real product outcome."""
+
+
+def wait_for(description, predicate, deadline=60.0, poll=0.2):
+    end = time.monotonic() + deadline
+    while time.monotonic() < end:
+        value = predicate()
+        if value:
+            return value
+        time.sleep(poll)
+    raise ReceiptFailure(f"no signal for {description} within {deadline:.0f}s")
+
+
+def screen_is_locked():
+    import Quartz
+
+    session = Quartz.CGSessionCopyCurrentDictionary()
+    return bool(session.get("CGSSessionScreenIsLocked", 0)) if session else False
+
+
+def audio_output_state():
+    settings = subprocess.run(
+        ["osascript", "-e", "get volume settings"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if settings.returncode != 0:
+        raise ReceiptFailure("cannot read the Mac's output volume and mute state")
+    volume_match = re.search(r"output volume:(\d+)", settings.stdout)
+    mute_match = re.search(r"output muted:(true|false)", settings.stdout)
+    if not volume_match or not mute_match:
+        raise ReceiptFailure(f"cannot parse output settings: {settings.stdout.strip()!r}")
+    route = subprocess.run(
+        ["SwitchAudioSource", "-c", "-t", "output"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if route.returncode != 0 or not route.stdout.strip():
+        raise ReceiptFailure("cannot verify the current audio output route")
+    return int(volume_match.group(1)), mute_match.group(1) == "true", route.stdout.strip()
+
+
+def log_lines():
+    if not LOG.exists():
+        raise ReceiptFailure(f"debug app log is missing: {LOG}")
+    return LOG.read_text(errors="replace").splitlines()
+
+
+def log_since(snapshot):
+    """Read this take's log window without assuming app.log kept its inode."""
+    lines, _ = w._read_new_log_lines(snapshot)
+    return "".join(lines)
+
+
+def in_flight(text):
+    last = None
+    for line in text.splitlines():
+        if "Recording started" in line:
+            last = "start"
+        elif "dictation_terminal" in line:
+            last = "terminal"
+    return last == "start"
+
+
+def running_enviouswispr_executables():
+    """Return every process that can receive EnviousWispr's global PTT event."""
+    result = subprocess.run(
+        ["pgrep", "-x", "EnviousWispr"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    matches = []
+    for raw_pid in result.stdout.split():
+        command = subprocess.run(
+            ["ps", "-p", raw_pid, "-o", "comm="],
+            capture_output=True,
+            text=True,
+            check=False,
+        ).stdout.strip()
+        if command:
+            matches.append((int(raw_pid), Path(command).resolve()))
+    return matches
+
+
+def refuse_competing_apps(allow_subject):
+    """Reject production or another dev app before posting a global PTT event."""
+    subject = APP_EXECUTABLE.resolve()
+    competing = [
+        (pid, executable)
+        for pid, executable in running_enviouswispr_executables()
+        if not allow_subject or executable != subject
+    ]
+    if competing:
+        detail = ", ".join(f"PID {pid}: {path}" for pid, path in competing)
+        raise ReceiptFailure(
+            f"another EnviousWispr app is running and could receive PTT: {detail}"
+        )
+
+
+def running_dev_executable():
+    result = subprocess.run(
+        ["pgrep", "-f", "EnviousWispr Local.app/Contents/MacOS/EnviousWispr"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    matches = []
+    for raw_pid in result.stdout.split():
+        command = subprocess.run(
+            ["ps", "-p", raw_pid, "-o", "comm="],
+            capture_output=True,
+            text=True,
+            check=False,
+        ).stdout.strip()
+        if command:
+            matches.append(command)
+    return unique_running_executable(matches, allow_absent=False)
+
+
+def unique_running_executable(matches, allow_absent):
+    if not matches and allow_absent:
+        return None
+    if len(matches) != 1:
+        raise ReceiptFailure(
+            f"expected exactly one running dev app, found {len(matches)}: {matches}"
+        )
+    return Path(matches[0]).resolve()
+
+
+def running_dev_executable_or_none():
+    result = subprocess.run(
+        ["pgrep", "-f", "EnviousWispr Local.app/Contents/MacOS/EnviousWispr"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    matches = []
+    for raw_pid in result.stdout.split():
+        command = subprocess.run(
+            ["ps", "-p", raw_pid, "-o", "comm="],
+            capture_output=True,
+            text=True,
+            check=False,
+        ).stdout.strip()
+        if command:
+            matches.append(command)
+    return unique_running_executable(matches, allow_absent=True)
+
+
+def subject_pid_for_executable():
+    result = subprocess.run(
+        ["pgrep", "-f", str(APP_EXECUTABLE)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    matching = []
+    for raw_pid in result.stdout.split():
+        command = subprocess.run(
+            ["ps", "-p", raw_pid, "-o", "comm="],
+            capture_output=True,
+            text=True,
+            check=False,
+        ).stdout.strip()
+        if command and Path(command).resolve() == APP_EXECUTABLE.resolve():
+            matching.append(int(raw_pid))
+    if len(matching) != 1:
+        raise ReceiptFailure(f"expected one verified worktree app PID, found {matching}")
+    return matching[0]
+
+
+def process_still_matches_subject(pid):
+    command = subprocess.run(
+        ["ps", "-p", str(pid), "-o", "comm="],
+        capture_output=True,
+        text=True,
+        check=False,
+    ).stdout.strip()
+    return bool(command) and Path(command).resolve() == APP_EXECUTABLE.resolve()
+
+
+def pin_wispr_eyes_to_subject():
+    """Keep every high-level UAT call on this worktree's verified process."""
+    pid = subject_pid_for_executable()
+    fallback = w.find_app_pid
+
+    def pinned_finder(name="EnviousWispr"):
+        if name != "EnviousWispr":
+            return fallback(name)
+        return pid if process_still_matches_subject(pid) else None
+
+    w.find_app_pid = pinned_finder
+    ui_helpers.find_app_pid = pinned_finder
+    return pid
+
+
+def verify_subject():
+    refuse_competing_apps(allow_subject=True)
+    if screen_is_locked():
+        raise ReceiptFailure("screen is locked; TextEdit cannot be a real foreground target")
+    if not APP_EXECUTABLE.exists():
+        raise ReceiptFailure(f"rebuilt app is missing: {APP_EXECUTABLE}")
+    running = running_dev_executable()
+    expected = APP_EXECUTABLE.resolve()
+    if running != expected:
+        raise ReceiptFailure(f"wrong dev app is running: {running}; expected {expected}")
+    current = log_lines()
+    if in_flight("\n".join(current[-400:])):
+        raise ReceiptFailure("a recording is already live; refusing to stop someone else's take")
+    volume, muted, route = audio_output_state()
+    if volume <= 50 or muted:
+        raise ReceiptFailure(
+            f"speaker preflight failed: volume={volume}, muted={str(muted).lower()}"
+        )
+    if route != "MacBook Pro Speakers":
+        raise ReceiptFailure(f"speaker preflight failed: output route is {route!r}")
+
+
+def refuse_active_recording_before_build():
+    """Fail before build-dev-app can terminate a live dev-app recording."""
+    refuse_competing_apps(allow_subject=True)
+    running = subprocess.run(
+        ["pgrep", "-f", "EnviousWispr Local.app/Contents/MacOS/EnviousWispr"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if running.returncode != 0:
+        return
+    for raw_pid in running.stdout.split():
+        state = ax_recording_state(int(raw_pid))
+        if state == "recording":
+            raise ReceiptFailure("a recording is active; refusing the rebuild")
+        if state != "idle":
+            raise ReceiptFailure(
+                f"cannot verify recording state for dev-app PID {raw_pid}; refusing the rebuild"
+            )
+
+
+def ax_recording_state(pid):
+    """Return live menu state without relying on Debug Mode or app.log."""
+    app = ui_helpers.get_ax_app(pid)
+    items = ui_helpers.find_all_elements(app, role="AXMenuItem")
+    start_items = [
+        item
+        for item in items
+        if str(ui_helpers.get_attr(item, "AXTitle") or "") == "Start Recording"
+    ]
+    has_stop = any(
+        str(ui_helpers.get_attr(item, "AXTitle") or "") == "Stop Recording"
+        for item in items
+    )
+    has_start = bool(start_items)
+    if has_stop and not has_start:
+        return "recording"
+    if has_start and not has_stop:
+        enabled_values = [ui_helpers.get_attr(item, "AXEnabled") for item in start_items]
+        if any(value is None for value in enabled_values):
+            return "unknown"
+        return "idle" if all(bool(value) for value in enabled_values) else "processing"
+    return "unknown"
+
+
+def selected_backend_snapshot():
+    result = subprocess.run(
+        ["defaults", "export", SHARED_DOMAIN, "-"],
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise ReceiptFailure("cannot snapshot selectedBackend before the receipt")
+    try:
+        domain = plistlib.loads(result.stdout)
+    except Exception as error:
+        raise ReceiptFailure(f"cannot parse the shared settings domain: {error}") from error
+    present = "selectedBackend" in domain
+    value = domain.get("selectedBackend", "parakeet")
+    return present, preserved_backend_value(value)
+
+
+def preserved_backend_value(value):
+    if not isinstance(value, str):
+        raise ReceiptFailure(f"selectedBackend is not a string: {value!r}")
+    if value in ("whisperKit", "parakeet"):
+        return value
+    raise ReceiptFailure(f"cannot preserve unknown selectedBackend value: {value!r}")
+
+
+def textedit_value(path):
+    pid = find_app_pid("TextEdit")
+    if pid is None:
+        return None
+    wanted = path.name
+    app = get_ax_app(pid)
+    for window in get_attr(app, "AXWindows") or []:
+        if str(get_attr(window, "AXTitle") or "") != wanted:
+            continue
+        area = find_element(window, role="AXTextArea")
+        if area is None:
+            return None
+        return str(get_attr(area, "AXValue") or "")
+    return None
+
+
+def focus_document(path):
+    subprocess.run(["open", "-a", "TextEdit", str(path)], check=True)
+    wait_for(
+        f"TextEdit document {path.name} to become accessibility-readable",
+        lambda: textedit_area(path) is not None,
+        deadline=10.0,
+    )
+    area = textedit_area(path)
+    if area is None:
+        raise ReceiptFailure(f"TextEdit area disappeared for {path.name}")
+
+    def activate_target():
+        pid = find_app_pid("TextEdit")
+        if pid is None:
+            return False
+        app = get_ax_app(pid)
+        wanted = path.name
+        window = next(
+            (
+                candidate
+                for candidate in (get_attr(app, "AXWindows") or [])
+                if str(get_attr(candidate, "AXTitle") or "") == wanted
+            ),
+            None,
+        )
+        if window is None:
+            return False
+        # ``open -a`` can open a document without activating TextEdit when the
+        # menu-bar dev app is still settling. Target the exact PID and window;
+        # never post the later PTT event until both report focused.
+        activate_app(pid)
+        set_attr(app, "AXFrontmost", True)
+        perform_action(window, "AXRaise")
+        set_attr(window, "AXMain", True)
+        set_attr(area, "AXFocused", True)
+        return (
+            frontmost_bundle_id() == "com.apple.TextEdit"
+            and bool(get_attr(area, "AXFocused"))
+        )
+
+    wait_for(
+        f"TextEdit document {path.name} to become the foreground target",
+        activate_target,
+        deadline=10.0,
+    )
+
+
+def frontmost_bundle_id():
+    """Read live focus through System Events (NSWorkspace is stale without a run loop)."""
+    result = subprocess.run(
+        [
+            "osascript",
+            "-e",
+            'tell application "System Events" to get bundle identifier of first process whose frontmost is true',
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def textedit_area(path):
+    pid = find_app_pid("TextEdit")
+    if pid is None:
+        return None
+    wanted = path.name
+    app = get_ax_app(pid)
+    for window in get_attr(app, "AXWindows") or []:
+        if str(get_attr(window, "AXTitle") or "") == wanted:
+            return find_element(window, role="AXTextArea")
+    return None
+
+
+def verify_textedit_oracle(path):
+    marker = "ew-delivery-oracle-check"
+    focus_document(path)
+    si.type_text(marker)
+    wait_for(
+        "TextEdit oracle control text",
+        lambda: marker in (textedit_value(path) or ""),
+        deadline=10.0,
+    )
+    w.connect()
+    w.press_key("a", cmd=True)
+    w.press_key("delete")
+    wait_for("TextEdit oracle clear", lambda: textedit_value(path) == "", deadline=5.0)
+
+
+def fixture_duration():
+    result = subprocess.run(
+        ["afinfo", str(FIXTURE)], capture_output=True, text=True, check=True
+    )
+    for line in result.stdout.splitlines():
+        if "estimated duration" in line.lower():
+            return float(line.split()[-2])
+    raise ReceiptFailure(f"could not read fixture duration: {FIXTURE}")
+
+
+def count_phrase(text):
+    return text.lower().count(EXPECTED_PHRASE)
+
+
+def raw_asr_word_count(evidence):
+    raw = ""
+    found = False
+    for line in evidence.splitlines():
+        if "CORRECTION_DEBUG [RAW ASR]" in line:
+            found = True
+            raw = line.split("CORRECTION_DEBUG [RAW ASR]", 1)[1].strip()
+    return len(re.findall(r"[A-Za-z0-9']+", raw)) if found else None
+
+
+def silent_probe_word_count(evidence):
+    words = raw_asr_word_count(evidence)
+    if words is not None:
+        return words
+    if "dictation_terminal result=no_speech" in evidence:
+        return 0
+    raise ReceiptFailure("silent probe has neither raw ASR nor an explicit no-speech result")
+
+
+def assert_builtin_microphone_evidence(evidence):
+    """Prove this take bound the Mac's physical built-in microphone."""
+    source = [record for record in evidence if record.get("_kind") == "source"]
+    if len(source) != 1:
+        raise ReceiptFailure(
+            f"expected one source-side capture record for this take, found {len(source)}"
+        )
+    record = source[0]
+    expected = {
+        "backend": EXPECTED_CAPTURE_BACKEND,
+        "boundUID": BUILT_IN_MICROPHONE_UID,
+        "boundTransport": "built_in",
+        "bindOK": "true",
+    }
+    mismatches = [
+        f"{key}={record.get(key)!r}"
+        for key, value in expected.items()
+        if record.get(key) != value
+    ]
+    if mismatches:
+        raise ReceiptFailure(
+            "capture did not prove the built-in microphone: " + ", ".join(mismatches)
+        )
+    requested = record.get("requestedUID")
+    if requested not in (BUILT_IN_MICROPHONE_UID, "system_default"):
+        raise ReceiptFailure(
+            f"capture requested an unexpected input device: requestedUID={requested!r}"
+        )
+
+
+def whisperkit_warm_completed(evidence):
+    return "WhisperKit warm-up: completed(" in evidence
+
+
+def run_silent_probe(path):
+    """Refuse acoustic UAT when a six-second silent capture hears the room."""
+    print("\n[control] checking that the room is quiet")
+    refuse_competing_apps(allow_subject=True)
+    w.switch_backend("parakeet", wait=0.0)
+    w.close_window()
+    focus_document(path)
+    baseline = w._snapshot_log_state()
+    if baseline is None:
+        raise ReceiptFailure("silent probe cannot snapshot app.log")
+    capture_baseline = _bt_route_line_count()
+    # The canonical probe intentionally returns False because its sentinel can
+    # never match. Hide its transcript-bearing report and score raw word count.
+    report = io.StringIO()
+    with contextlib.redirect_stdout(report), contextlib.redirect_stderr(report):
+        w.test_recording(
+            audio=None,
+            sentence=" ",
+            hold=6.0,
+            expect="\x00nomatch",
+        )
+    evidence = log_since(baseline)
+    if not evidence.strip() or "dictation_terminal" not in evidence:
+        raise ReceiptFailure("silent probe produced no complete log evidence")
+    assert_take_lifecycle("parakeet", evidence)
+    assert_builtin_microphone_evidence(read_new_evidence(capture_baseline))
+    words = silent_probe_word_count(evidence)
+    if words:
+        raise ReceiptFailure(
+            f"silent probe heard {words} words; room is occupied, so acoustic UAT stopped"
+        )
+    print("PASS control: silent probe heard no words")
+
+
+def assert_backend_evidence(backend, evidence):
+    expected = "whisperKit" if backend == "whisperkit" else "parakeet"
+    assert_take_lifecycle(expected, evidence)
+    if "Paste cascade:" not in evidence or "app=com.apple.TextEdit" not in evidence:
+        raise ReceiptFailure(f"{backend}: production paste did not report a TextEdit target")
+
+
+def assert_take_lifecycle(expected_backend, evidence):
+    starts = [line for line in evidence.splitlines() if "dictation_started" in line]
+    if len(starts) != 1 or f"backend={expected_backend}" not in starts[0]:
+        raise ReceiptFailure(
+            f"{expected_backend}: expected one matching dictation start, got {starts}"
+        )
+    take_match = re.search(r"\btake=([^\s]+)", starts[0])
+    if take_match is None:
+        raise ReceiptFailure(
+            f"{expected_backend}: dictation start has no take identifier"
+        )
+    take_marker = take_match.group(1)
+    terminals = [line for line in evidence.splitlines() if "dictation_terminal" in line]
+    if len(terminals) != 1 or f"take={take_marker}" not in terminals[0]:
+        raise ReceiptFailure(
+            f"{expected_backend}: expected one terminal for take {take_marker}, got {terminals}"
+        )
+    return take_marker
+
+
+def run_backend(backend, path):
+    print(f"\n[{backend}] switching shipped backend")
+    switch_snapshot = w._snapshot_log_state()
+    if switch_snapshot is None:
+        raise ReceiptFailure(f"{backend}: app.log disappeared before engine switch")
+    w.switch_backend(backend, wait=0.0)
+    if backend == "whisperkit":
+        warm_evidence = wait_for(
+            "WhisperKit's production warm-up completion",
+            lambda: (
+                evidence
+                if "WhisperKit warm-up:" in (evidence := log_since(switch_snapshot))
+                else None
+            ),
+            deadline=35.0,
+        )
+        if not whisperkit_warm_completed(warm_evidence):
+            raise ReceiptFailure("whisperkit: production warm-up did not complete cleanly")
+    w.close_window()
+    focus_document(path)
+    if textedit_value(path) != "":
+        raise ReceiptFailure(f"{backend}: unique TextEdit document did not start empty")
+
+    baseline = w._snapshot_log_state()
+    if baseline is None:
+        raise ReceiptFailure(f"{backend}: app.log disappeared before recording")
+    refuse_competing_apps(allow_subject=True)
+    capture_baseline = _bt_route_line_count()
+    # Use Whisper Eyes' canonical PTT driver. It resolves the configured key,
+    # keeps playback inside the key-down window, and owns bounded key release.
+    if not w.test_ptt(audio=str(FIXTURE), expect=EXPECTED_PHRASE, timeout=90.0):
+        raise ReceiptFailure(f"{backend}: canonical Whisper Eyes PTT run failed")
+
+    wait_for(
+        f"{backend} pipeline terminal",
+        lambda: "dictation_terminal" in log_since(baseline),
+        deadline=90.0,
+    )
+    wait_for(
+        f"{backend} production TextEdit paste receipt",
+        lambda: (
+            "Paste cascade:" in log_since(baseline)
+            and "app=com.apple.TextEdit" in log_since(baseline)
+        ),
+        deadline=10.0,
+    )
+    first_value = wait_for(
+        f"{backend} text arrival in TextEdit",
+        lambda: (
+            value
+            if (value := textedit_value(path)) is not None
+            and count_phrase(value) > 0
+            else None
+        ),
+        deadline=15.0,
+    )
+    final_value = stable_exact_once_value(path, first_value)
+    evidence = log_since(baseline)
+    if not evidence.strip():
+        raise ReceiptFailure(f"{backend}: app.log produced no evidence for this take")
+    assert_backend_evidence(backend, evidence)
+    assert_builtin_microphone_evidence(read_new_evidence(capture_baseline))
+    occurrences = count_phrase(final_value)
+    if occurrences != 1:
+        raise ReceiptFailure(
+            f"{backend}: expected {EXPECTED_PHRASE!r} exactly once in TextEdit, "
+            f"found {occurrences}; value={final_value!r}"
+        )
+    print(f"PASS {backend}: real capture reached TextEdit exactly once")
+    return final_value
+
+
+def stable_exact_once_value(path, initial_value, stability_seconds=2.0):
+    """Require the TextEdit value to stay exactly-once after the first arrival."""
+    value = initial_value
+    stable_since = time.monotonic()
+    deadline = stable_since + stability_seconds + 5.0
+    while time.monotonic() < deadline:
+        current = textedit_value(path)
+        if current is None:
+            raise ReceiptFailure("TextEdit document disappeared during stability check")
+        occurrences = count_phrase(current)
+        if occurrences != 1:
+            raise ReceiptFailure(
+                f"delivery changed during stability check; expected once, found {occurrences}"
+            )
+        if current != value:
+            value = current
+            stable_since = time.monotonic()
+        elif time.monotonic() - stable_since >= stability_seconds:
+            return value
+        time.sleep(0.1)
+    raise ReceiptFailure("TextEdit delivery did not stabilize within the bounded window")
+
+
+def close_document(path):
+    # TextEdit may group documents as tabs. Reopening the owned path activates
+    # its tab so its title and value become AX-visible before cleanup decides.
+    focus_document(path)
+    value = textedit_value(path)
+    if value is None:
+        raise ReceiptFailure(f"cannot activate owned TextEdit document {path.name}")
+    if value:
+        w.press_key("s", cmd=True)
+        wait_for(
+            "TextEdit save",
+            lambda: path.read_text(errors="replace") == value,
+            deadline=5.0,
+        )
+    w.press_key("w", cmd=True)
+    wait_for("TextEdit window close", lambda: textedit_value(path) is None, deadline=5.0)
+
+
+def stop_leaked_recording():
+    recent = "\n".join(log_lines()[-400:])
+    if not in_flight(recent):
+        return
+    print("CLEANUP: cancelling a recording started by this receipt", file=sys.stderr)
+    si.press_key("escape")
+    try:
+        wait_for(
+            "receipt recording to stop",
+            lambda: not in_flight("\n".join(log_lines()[-400:])),
+            deadline=15.0,
+        )
+    except ReceiptFailure:
+        subprocess.run(["pkill", "-f", str(APP_EXECUTABLE)], check=False)
+
+
+def stop_subject_app():
+    subprocess.run(["pkill", "-f", str(APP_EXECUTABLE)], check=False)
+    wait_for(
+        "receipt app to exit",
+        lambda: subprocess.run(
+            ["pgrep", "-f", str(APP_EXECUTABLE)], capture_output=True, check=False
+        ).returncode
+        != 0,
+        deadline=15.0,
+    )
+
+
+def restore_backend(snapshot):
+    present, backend = snapshot
+    stop_subject_app()
+    if present:
+        subprocess.run(
+            ["defaults", "write", SHARED_DOMAIN, "selectedBackend", "-string", backend],
+            check=True,
+        )
+    else:
+        subprocess.run(
+            ["defaults", "delete", SHARED_DOMAIN, "selectedBackend"],
+            capture_output=True,
+            check=False,
+        )
+    if selected_backend_snapshot() != snapshot:
+        raise ReceiptFailure("selectedBackend did not restore to its exact prior state")
+    subprocess.run(["open", str(APP)], check=True)
+    wait_for(
+        "restored receipt app to relaunch",
+        lambda: running_dev_executable_or_none() == APP_EXECUTABLE.resolve(),
+        deadline=30.0,
+    )
+
+
+def run_receipt():
+    verify_subject()
+    subject_pid = pin_wispr_eyes_to_subject()
+    if not FIXTURE.exists() or FIXTURE.stat().st_size < 8192:
+        raise ReceiptFailure(f"committed speech fixture is missing or too small: {FIXTURE}")
+    try:
+        binding = resolve()
+    except PTTBindingError as error:
+        raise ReceiptFailure(f"cannot resolve the real PTT binding: {error}") from error
+    if binding.recording_mode != "pushToTalk":
+        raise ReceiptFailure(
+            f"configured recording mode is {binding.recording_mode!r}, not pushToTalk"
+        )
+
+    original_backend = selected_backend_snapshot()
+    frontmost = frontmost_bundle_id()
+    duration = fixture_duration()
+    workspace = Path(tempfile.mkdtemp(prefix="ew-heart-path-delivery-"))
+    documents = {
+        name: workspace / f"{workspace.name}-{name}-delivery.txt"
+        for name in ("control", *BACKENDS)
+    }
+    for path in documents.values():
+        path.write_text("")
+
+    print("=== Heart Path TextEdit Delivery Receipt (#2142) ===")
+    print(f"subject: {APP_EXECUTABLE}")
+    print(f"subject PID: {subject_pid} (pinned for every Whisper Eyes call)")
+    print(f"instrument: wispr_eyes={Path(w.__file__).resolve()}")
+    print(f"instrument: simulate_input={Path(si.__file__).resolve()}")
+    print(f"PTT: {binding.key_name}; fixture: {FIXTURE.name} ({duration:.2f}s)")
+    results = {}
+    backend_restored = False
+    try:
+        verify_textedit_oracle(documents["control"])
+        print("PASS control: TextEdit field is readable and writable through Accessibility")
+        run_silent_probe(documents["control"])
+        for backend in BACKENDS:
+            results[backend] = run_backend(backend, documents[backend])
+    finally:
+        try:
+            stop_leaked_recording()
+        except Exception as error:
+            print(f"CLEANUP WARNING: could not stop recording: {error}", file=sys.stderr)
+        try:
+            restore_backend(original_backend)
+            backend_restored = True
+        except Exception as error:
+            print(f"RESTORE FAILURE: selected backend was not restored: {error}", file=sys.stderr)
+        for path in documents.values():
+            try:
+                close_document(path)
+            except Exception as error:
+                print(f"CLEANUP WARNING: could not close {path.name}: {error}", file=sys.stderr)
+        shutil.rmtree(workspace, ignore_errors=True)
+        if frontmost and frontmost not in ("com.apple.TextEdit", "com.enviouswispr.app.dev"):
+            subprocess.run(["open", "-b", frontmost], check=False)
+
+    if set(results) != set(BACKENDS):
+        raise ReceiptFailure(f"not every shipped backend ran: {sorted(results)}")
+    if not backend_restored:
+        raise ReceiptFailure("the receipt passed but selectedBackend was not restored")
+    print("\nPASS: both shipped backends delivered real captured speech exactly once")
+
+
+def main():
+    if sys.argv[1:] == ["--refuse-active-recording"]:
+        try:
+            refuse_active_recording_before_build()
+        except ReceiptFailure as error:
+            print(f"FAIL: {error}", file=sys.stderr)
+            return 1
+        print("PASS: no active dev-app recording")
+        return 0
+    if sys.argv[1:]:
+        print(
+            "Usage: test_heart_path_delivery.py [--refuse-active-recording]",
+            file=sys.stderr,
+        )
+        return 2
+    try:
+        run_receipt()
+    except (ReceiptFailure, subprocess.SubprocessError, OSError) as error:
+        print(f"\nFAIL: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Tests/RuntimeUAT/test_heart_path_delivery_harness.py
+++ b/Tests/RuntimeUAT/test_heart_path_delivery_harness.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Deterministic guard tests for the #2142 real-delivery receipt."""
+
+import importlib.util
+import pathlib
+import sys
+
+SUBJECT_PATH = pathlib.Path(__file__).with_name("test_heart_path_delivery.py")
+SPEC = importlib.util.spec_from_file_location("heart_path_delivery", SUBJECT_PATH)
+subject = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(subject)
+
+failures = []
+
+
+def check(name, condition):
+    print(f"{'PASS' if condition else 'FAIL'} {name}")
+    if not condition:
+        failures.append(name)
+
+
+check("one expected phrase is accepted", subject.count_phrase("The quick brown fox arrived.") == 1)
+check(
+    "duplicate delivery is visible",
+    subject.count_phrase("quick brown fox / QUICK BROWN FOX") == 2,
+)
+check("missing delivery is visible", subject.count_phrase("something else") == 0)
+check(
+    "silent transcript counts words without exposing content",
+    subject.raw_asr_word_count(
+        "CORRECTION_DEBUG [RAW ASR] three private words\n"
+    )
+    == 3,
+)
+check(
+    "absent raw transcript is unavailable",
+    subject.raw_asr_word_count("dictation_terminal result=no_speech") is None,
+)
+check(
+    "explicit no-speech terminal proves silence",
+    subject.silent_probe_word_count("dictation_terminal result=no_speech") == 0,
+)
+try:
+    subject.silent_probe_word_count("dictation_terminal result=completed")
+    check("missing silence evidence is refused", False)
+except subject.ReceiptFailure:
+    check("missing silence evidence is refused", True)
+
+check(
+    "blank silent probe does not generate TTS",
+    not subject.w._recording_should_generate_tts(" "),
+)
+check(
+    "default recording still generates TTS",
+    subject.w._recording_should_generate_tts(None),
+)
+check(
+    "spoken fixture still generates TTS",
+    subject.w._recording_should_generate_tts("hello"),
+)
+check(
+    "WhisperKit preference keeps its case-sensitive raw value",
+    subject.preserved_backend_value("whisperKit") == "whisperKit",
+)
+try:
+    subject.preserved_backend_value("whisperkit")
+    check("invalid lowercase WhisperKit preference is refused", False)
+except subject.ReceiptFailure:
+    check("invalid lowercase WhisperKit preference is refused", True)
+check(
+    "active recording state is detected",
+    subject.in_flight("Recording started\nother log line"),
+)
+check(
+    "terminal recording state is idle",
+    not subject.in_flight("Recording started\ndictation_terminal result=completed"),
+)
+check(
+    "relaunch polling tolerates no process yet",
+    subject.unique_running_executable([], allow_absent=True) is None,
+)
+try:
+    subject.unique_running_executable([], allow_absent=False)
+    check("subject verification refuses no process", False)
+except subject.ReceiptFailure:
+    check("subject verification refuses no process", True)
+
+original_running_apps = subject.running_enviouswispr_executables
+subject.running_enviouswispr_executables = lambda: [
+    (10, subject.APP_EXECUTABLE.resolve())
+]
+try:
+    subject.refuse_competing_apps(allow_subject=True)
+    check("the verified worktree app is allowed", True)
+except subject.ReceiptFailure:
+    check("the verified worktree app is allowed", False)
+subject.running_enviouswispr_executables = lambda: [
+    (10, subject.APP_EXECUTABLE.resolve()),
+    (11, pathlib.Path("/Applications/EnviousWispr.app/Contents/MacOS/EnviousWispr")),
+]
+try:
+    subject.refuse_competing_apps(allow_subject=True)
+    check("a production app competing for PTT is refused", False)
+except subject.ReceiptFailure:
+    check("a production app competing for PTT is refused", True)
+finally:
+    subject.running_enviouswispr_executables = original_running_apps
+
+valid_capture = [{
+    "_kind": "source",
+    "backend": "hal_device_input",
+    "boundUID": "BuiltInMicrophoneDevice",
+    "boundTransport": "built_in",
+    "bindOK": "true",
+    "requestedUID": "BuiltInMicrophoneDevice",
+}]
+try:
+    subject.assert_builtin_microphone_evidence(valid_capture)
+    check("actual built-in microphone binding is accepted", True)
+except subject.ReceiptFailure:
+    check("actual built-in microphone binding is accepted", False)
+try:
+    subject.assert_builtin_microphone_evidence(
+        [{**valid_capture[0], "requestedUID": "system_default"}]
+    )
+    check("Auto input with actual built-in binding is accepted", True)
+except subject.ReceiptFailure:
+    check("Auto input with actual built-in binding is accepted", False)
+
+for name, evidence in (
+    ("missing actual microphone evidence is refused", []),
+    ("duplicate source evidence is refused", valid_capture * 2),
+    (
+        "virtual microphone binding is refused",
+        [{**valid_capture[0], "boundUID": "BlackHole2ch_UID", "boundTransport": "virtual"}],
+    ),
+    ("failed microphone binding is refused", [{**valid_capture[0], "bindOK": "false"}]),
+    (
+        "another explicitly requested input is refused",
+        [{**valid_capture[0], "requestedUID": "BlackHole2ch_UID"}],
+    ),
+):
+    try:
+        subject.assert_builtin_microphone_evidence(evidence)
+        check(name, False)
+    except subject.ReceiptFailure:
+        check(name, True)
+
+original_get_ax_app = subject.ui_helpers.get_ax_app
+original_find_all = subject.ui_helpers.find_all_elements
+original_ui_get_attr = subject.ui_helpers.get_attr
+subject.ui_helpers.get_ax_app = lambda _pid: "app"
+subject.ui_helpers.find_all_elements = lambda _app, role: [
+    {"AXTitle": "Start Recording", "AXEnabled": True}
+]
+subject.ui_helpers.get_attr = lambda item, attribute: item.get(attribute)
+try:
+    check("live AX Start Recording menu means idle", subject.ax_recording_state(42) == "idle")
+    subject.ui_helpers.find_all_elements = lambda _app, role: [
+        {"AXTitle": "Start Recording", "AXEnabled": True},
+        {"AXTitle": "Start Recording", "AXEnabled": True},
+    ]
+    check(
+        "duplicate AX traversal of enabled Start remains idle",
+        subject.ax_recording_state(42) == "idle",
+    )
+    subject.ui_helpers.find_all_elements = lambda _app, role: [
+        {"AXTitle": "Start Recording", "AXEnabled": False}
+    ]
+    check(
+        "disabled Start Recording menu means processing",
+        subject.ax_recording_state(42) == "processing",
+    )
+    subject.ui_helpers.find_all_elements = lambda _app, role: [
+        {"AXTitle": "Stop Recording", "AXEnabled": True}
+    ]
+    check(
+        "live AX Stop Recording menu means active",
+        subject.ax_recording_state(42) == "recording",
+    )
+    subject.ui_helpers.find_all_elements = lambda _app, role: []
+    check("missing live menu state is unknown", subject.ax_recording_state(42) == "unknown")
+finally:
+    subject.ui_helpers.get_ax_app = original_get_ax_app
+    subject.ui_helpers.find_all_elements = original_find_all
+    subject.ui_helpers.get_attr = original_ui_get_attr
+
+original_subject_pid = subject.subject_pid_for_executable
+original_process_match = subject.process_still_matches_subject
+original_w_finder = subject.w.find_app_pid
+original_ui_finder = subject.ui_helpers.find_app_pid
+subject.subject_pid_for_executable = lambda: 4242
+subject.process_still_matches_subject = lambda pid: pid == 4242
+try:
+    pinned_pid = subject.pin_wispr_eyes_to_subject()
+    check(
+        "both Whisper Eyes lookup layers pin the verified PID",
+        pinned_pid == 4242
+        and subject.w.find_app_pid("EnviousWispr") == 4242
+        and subject.ui_helpers.find_app_pid("EnviousWispr") == 4242,
+    )
+finally:
+    subject.subject_pid_for_executable = original_subject_pid
+    subject.process_still_matches_subject = original_process_match
+    subject.w.find_app_pid = original_w_finder
+    subject.ui_helpers.find_app_pid = original_ui_finder
+check(
+    "clean WhisperKit warm-up is accepted",
+    subject.whisperkit_warm_completed("WhisperKit warm-up: completed(2069ms)"),
+)
+check(
+    "failed WhisperKit warm-up is refused",
+    not subject.whisperkit_warm_completed("WhisperKit warm-up: timed_out"),
+)
+
+original_post_ptt = subject.w._post_ptt_key_event
+ptt_edges = []
+subject.w._post_ptt_key_event = lambda key, is_down: ptt_edges.append((key, is_down))
+try:
+    with subject.w._held_ptt_key("rcmd"):
+        raise RuntimeError("synthetic playback failure")
+except RuntimeError:
+    pass
+finally:
+    subject.w._post_ptt_key_event = original_post_ptt
+check(
+    "exceptional PTT path releases the key",
+    ptt_edges == [("rcmd", True), ("rcmd", False)],
+)
+
+original_modifier_down = subject.si.modifier_down
+original_modifier_up = subject.si.modifier_up
+original_input_sleep = subject.si.time.sleep
+modifier_edges = []
+subject.si.modifier_down = lambda keycode: modifier_edges.append((keycode, True))
+subject.si.modifier_up = lambda keycode: modifier_edges.append((keycode, False))
+subject.si.time.sleep = lambda _seconds: (_ for _ in ()).throw(
+    RuntimeError("interrupted hold")
+)
+try:
+    subject.si.hold_modifier(54, 1.0)
+except RuntimeError:
+    pass
+finally:
+    subject.si.modifier_down = original_modifier_down
+    subject.si.modifier_up = original_modifier_up
+    subject.si.time.sleep = original_input_sleep
+check(
+    "interrupted generic modifier hold releases the key",
+    modifier_edges == [(54, True), (54, False)],
+)
+
+original_textedit_value = subject.textedit_value
+original_monotonic = subject.time.monotonic
+original_sleep = subject.time.sleep
+ticks = iter((0.0, 0.1))
+values = iter(("quick brown fox quick brown fox",))
+subject.time.monotonic = lambda: next(ticks)
+subject.time.sleep = lambda _seconds: None
+subject.textedit_value = lambda _path: next(values)
+try:
+    subject.stable_exact_once_value(pathlib.Path("unused"), "quick brown fox")
+    check("delayed duplicate delivery is refused", False)
+except subject.ReceiptFailure:
+    check("delayed duplicate delivery is refused", True)
+finally:
+    subject.textedit_value = original_textedit_value
+    subject.time.monotonic = original_monotonic
+    subject.time.sleep = original_sleep
+
+original_focus_document = subject.focus_document
+original_textedit_value = subject.textedit_value
+original_press_key = subject.w.press_key
+original_wait_for = subject.wait_for
+cleanup_calls = []
+cleanup_values = iter(("", None))
+subject.focus_document = lambda path: cleanup_calls.append(("focus", path.name))
+subject.textedit_value = lambda _path: next(cleanup_values)
+subject.w.press_key = lambda key, **kwargs: cleanup_calls.append(("press", key, kwargs))
+subject.wait_for = lambda _description, predicate, **_kwargs: predicate()
+try:
+    subject.close_document(pathlib.Path("hidden-tab.txt"))
+finally:
+    subject.focus_document = original_focus_document
+    subject.textedit_value = original_textedit_value
+    subject.w.press_key = original_press_key
+    subject.wait_for = original_wait_for
+check(
+    "cleanup activates a hidden TextEdit tab before closing",
+    cleanup_calls[0] == ("focus", "hidden-tab.txt")
+    and cleanup_calls[1][0:2] == ("press", "w"),
+)
+
+valid = """
+dictation_started take=1 backend=parakeet
+Paste cascade: tier=ax_direct, app=com.apple.TextEdit
+dictation_terminal result=completed take=1 backend=parakeet
+"""
+try:
+    subject.assert_backend_evidence("parakeet", valid)
+    check("complete production evidence is accepted", True)
+except subject.ReceiptFailure:
+    check("complete production evidence is accepted", False)
+
+for name, evidence in (
+    ("wrong backend is refused", valid.replace("parakeet", "whisperKit")),
+    ("missing terminal is refused", valid.replace("dictation_terminal", "other")),
+    ("wrong target is refused", valid.replace("com.apple.TextEdit", "com.apple.Terminal")),
+    ("missing take id is refused", valid.replace("take=1", "session=1", 1)),
+    ("duplicate start is refused", valid + "dictation_started take=2 backend=parakeet\n"),
+):
+    try:
+        subject.assert_backend_evidence("parakeet", evidence)
+        check(name, False)
+    except subject.ReceiptFailure:
+        check(name, True)
+
+sys.exit(1 if failures else 0)

--- a/Tests/RuntimeUAT/wispr_eyes.py
+++ b/Tests/RuntimeUAT/wispr_eyes.py
@@ -2,7 +2,7 @@
 Usage:  python3 -c "from wispr_eyes import *; connect(); see()"
         python3 -c "from wispr_eyes import *; connect(); tap('AI Polish')"
 """
-import os, sys, subprocess, time
+import contextlib, os, sys, subprocess, time
 sys.path.insert(0, os.path.dirname(__file__))
 from ui_helpers import (find_app_pid, get_ax_app, get_attr, set_attr, perform_action,
     find_element, find_all_elements, find_control_for_label, wait_for_condition,
@@ -28,6 +28,35 @@ def _resolve_ptt_key():
     rather than guessing; see that module's header for why no fallback exists.
     """
     return resolve().key_name
+
+
+def _post_ptt_key_event(key, is_down):
+    """Post one configured PTT edge, or refuse before posting anything."""
+    import simulate_input as _si
+
+    key_lower = key.lower()
+    if key_lower in _si.MODIFIER_KEYS:
+        if is_down:
+            _si.modifier_down(_si.MODIFIER_KEYS[key_lower])
+        else:
+            _si.modifier_up(_si.MODIFIER_KEYS[key_lower])
+        return
+    if key_lower in _si.KEY_CODES:
+        from Quartz import CGEventCreateKeyboardEvent, CGEventPost, kCGHIDEventTap
+        event = CGEventCreateKeyboardEvent(None, _si.KEY_CODES[key_lower], is_down)
+        CGEventPost(kCGHIDEventTap, event)
+        return
+    raise PTTBindingError(f"Unknown PTT key '{key}'")
+
+
+@contextlib.contextmanager
+def _held_ptt_key(key):
+    """Guarantee the matching key-up even when playback or waiting raises."""
+    _post_ptt_key_event(key, True)
+    try:
+        yield
+    finally:
+        _post_ptt_key_event(key, False)
 
 
 def _ptt_binding_diagnostic(pressed_key):
@@ -1269,6 +1298,11 @@ def _engine_button(label):
     return None
 
 
+def _recording_should_generate_tts(sentence):
+    """A deliberate blank sentence is the no-playback ambient-room probe."""
+    return sentence is None or bool(sentence.strip())
+
+
 def test_recording(audio=None, sentence=None, hold=3.0, expect=None, timeout=30.0):
     """End-to-end recording test: menu start -> TTS/audio playback -> menu stop -> verify pipeline.
 
@@ -1288,13 +1322,17 @@ def test_recording(audio=None, sentence=None, hold=3.0, expect=None, timeout=30.
     """
     connect()
 
-    # Generate TTS audio if no explicit audio file provided
+    # Generate TTS audio if no explicit audio file provided. A blank sentence
+    # deliberately means silence: the canonical ambient-room probe records for
+    # the caller's exact hold without playing or auto-sizing a TTS clip.
     if audio is None:
+        should_generate_tts = _recording_should_generate_tts(sentence)
         if sentence is None:
             sentence = "The quick brown fox jumps over the lazy dog"
-        audio = tts(sentence)
-        if expect is None:
-            expect = "fox" if "fox" in sentence.lower() else sentence.split()[len(sentence.split())//2].lower()
+        if should_generate_tts:
+            audio = tts(sentence)
+            if expect is None:
+                expect = "fox" if "fox" in sentence.lower() else sentence.split()[len(sentence.split())//2].lower()
 
     begin_test(f"recording{' +audio' if audio else ''}")
 
@@ -1664,47 +1702,30 @@ def test_ptt(key=None, audio=None, sentence=None, expect=None, timeout=10.0):
     clip_before = get_clipboard_text() or ""
 
     # Phase 1: Key down (recording starts)
-    import simulate_input as _si
     print(f"\n--- KEY DOWN ({key}) ---")
     _chime()
 
-    key_lower = key.lower()
-    if key_lower in _si.MODIFIER_KEYS:
-        _si.modifier_down(_si.MODIFIER_KEYS[key_lower])
-    elif key_lower in _si.KEY_CODES:
-        from Quartz import CGEventCreateKeyboardEvent, CGEventPost, kCGHIDEventTap
-        kc = _si.KEY_CODES[key_lower]
-        down = CGEventCreateKeyboardEvent(None, kc, True)
-        CGEventPost(kCGHIDEventTap, down)
-    else:
-        print(f"BLOCKED: Unknown key '{key}'")
-        end_test()
-        return False
-
-    time.sleep(0.8)  # let recording engage + model warm
-
-    # Phase 2: Play audio
-    print(f"Playing audio ({audio_dur:.2f}s)...")
-    audio_proc = subprocess.Popen(
-        ["afplay", audio], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
-    )
-
-    # Phase 3: Wait for audio + buffer
     hold_audio = audio_dur + 0.8
-    time.sleep(hold_audio)
-    if audio_proc.poll() is None:
-        audio_proc.terminate()
-
-    # Phase 4: Key up (recording stops)
     total_hold = 0.8 + hold_audio
+    with _held_ptt_key(key):
+        time.sleep(0.8)  # let recording engage + model warm
+
+        # Phase 2: Play audio
+        print(f"Playing audio ({audio_dur:.2f}s)...")
+        audio_proc = None
+        try:
+            audio_proc = subprocess.Popen(
+                ["afplay", audio], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+            )
+
+            # Phase 3: Wait for audio + buffer
+            time.sleep(hold_audio)
+        finally:
+            if audio_proc is not None and audio_proc.poll() is None:
+                audio_proc.terminate()
+
+    # Phase 4: Key up has completed (recording stops)
     print(f"\n--- KEY UP ({key}) after {total_hold:.1f}s hold ---")
-    if key_lower in _si.MODIFIER_KEYS:
-        _si.modifier_up(_si.MODIFIER_KEYS[key_lower])
-    else:
-        from Quartz import CGEventCreateKeyboardEvent, CGEventPost, kCGHIDEventTap
-        kc = _si.KEY_CODES[key_lower]
-        up = CGEventCreateKeyboardEvent(None, kc, False)
-        CGEventPost(kCGHIDEventTap, up)
 
     # Phase 5: Wait for completion (log-based with clipboard fallback)
     t_stop = time.time()

--- a/scripts/test-heart-path-delivery.sh
+++ b/scripts/test-heart-path-delivery.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Developer-machine real-boundary receipt for #2142. This is deliberately
+# disruptive: build-dev-app stops any running dev app, then the Python receipt
+# drives PTT and TextEdit. Invoke this runner as a background task because it
+# posts CGEvents. Hosted CI must not treat a skip as a pass, so there is no
+# resource-skip path here.
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Run the pure policy/parser guards on every receipt invocation.
+python3 "$PROJECT_ROOT/Tests/RuntimeUAT/test_heart_path_delivery_harness.py"
+
+# build-dev-app terminates dev bundles. Refuse before that destructive step if
+# any running bundle currently owns an in-flight recording.
+python3 "$PROJECT_ROOT/Tests/RuntimeUAT/test_heart_path_delivery.py" \
+  --refuse-active-recording
+
+case "${1:-}" in
+  "") "$PROJECT_ROOT/scripts/build-dev-app.sh" ;;
+  --no-build) ;;
+  *) echo "Usage: $0 [--no-build]" >&2; exit 2 ;;
+esac
+
+exec python3 "$PROJECT_ROOT/Tests/RuntimeUAT/test_heart_path_delivery.py"


### PR DESCRIPTION
Part of #2142.

## What this adds
- a developer-machine real-boundary receipt for capture through each shipped ASR backend into a real foreground TextEdit document
- exact-once AX-value proof with a stability window
- fail-closed guards for the exact worktree app, competing EnviousWispr processes, real PTT configuration, WhisperKit warm-up, a quiet room, MacBook Pro speaker output, and actual built-in-microphone binding
- bounded cleanup and exact restoration of the prior backend setting
- deterministic coverage for the receipt policy and exceptional key-release paths

## Safe validation
- receipt harness: 43/43 passed
- PTT binding self-test: 19/19 passed
- Python compile, shellcheck, and diff check passed
- live pre-build active-recording refusal passed
- pinned Codex review: no actionable correctness issues

## Live UAT status
Parakeet reached TextEdit exactly once before the final harness hardening. The canonical six-second silent probe then detected ambient speech, so the run stopped as required. WhisperKit and the final hardened two-backend receipt remain pending a quiet-room run. No acoustic result is claimed from the invalid attempt.

This PR is intentionally draft until that real quiet-room receipt passes. Do not merge yet.