### PR TITLE
SEO: add solutions hub and developer landing page

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -682,6 +682,11 @@ jobs:
         working-directory: website
         run: npm run check:help
 
+      - name: Solution checker tests
+        if: steps.changes.outputs.needs_website == 'true'
+        working-directory: website
+        run: npm run test:solutions
+
   # Required aggregate gate. This is the ONLY required status check on main
   # (ruleset main-protection, context "build-check"); keeping the job id
   # "build-check" preserves that context so no ruleset change is needed (#906).

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -103,6 +103,13 @@ function sourceForUrl(url) {
     const slug = p.replace('/compare/', '');
     return path.join(__dirname, `src/pages/compare/${slug}.astro`);
   }
+  // /solutions/ index → src/pages/solutions/index.astro
+  if (p === '/solutions') return path.join(__dirname, 'src/pages/solutions/index.astro');
+  // /solutions/<slug>/ → src/pages/solutions/<slug>.astro
+  if (p.startsWith('/solutions/')) {
+    const slug = p.replace('/solutions/', '');
+    return path.join(__dirname, `src/pages/solutions/${slug}.astro`);
+  }
   // /index → src/pages/index.astro
   if (p === '/index') return path.join(__dirname, 'src/pages/index.astro');
   // /<page>/ → src/pages/<page>.astro

--- a/website/package.json
+++ b/website/package.json
@@ -8,10 +8,13 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
+    "postbuild": "node scripts/check-solutions.mjs",
     "preview": "astro preview",
     "astro": "astro",
     "prebuild": "node scripts/check-help-content.mjs",
-    "check:help": "node scripts/check-help-routes.mjs && node scripts/check-help-search.mjs"
+    "check:help": "node scripts/check-help-routes.mjs && node scripts/check-help-search.mjs",
+    "check:solutions": "node scripts/check-solutions.mjs",
+    "test:solutions": "node --test scripts/check-solutions.test.mjs"
   },
   "overrides": {
     "devalue": ">=5.8.1",

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -5,12 +5,14 @@
 Maker: Envious Labs LLC (Connecticut, USA). Founder: Saurabh Vaish.
 License: GNU General Public License v3 (GPLv3, open source on GitHub).
 Platform: macOS 14 (Sonoma) or later, Apple Silicon only.
-Last-updated: 2026-08-21
+Last-updated: 2026-08-22
 
 ## Product
 
 - [How it works](https://enviouswispr.com/how-it-works/): The end-to-end pipeline: keybind hold, audio capture, on-device ASR, optional LLM polish, clipboard or paste-to-app delivery.
 - [Homepage](https://enviouswispr.com/): Download, screenshots, core value proposition, system requirements (Apple Silicon, macOS 14+).
+- [Solutions](https://enviouswispr.com/solutions/): Focused dictation workflows for the work people do on a Mac.
+- [Dictation for developers](https://enviouswispr.com/solutions/developers/): On-device voice input for PR descriptions, code reviews, issues, documentation, commit messages, and prompts.
 - [Best dictation apps for Mac](https://enviouswispr.com/compare/best-dictation-apps-for-mac/): A practical 2026 guide to seven Mac dictation options, with honest picks by workflow.
 - [Compare to alternatives](https://enviouswispr.com/compare/): Index of comparison pages vs WisprFlow, Superwhisper, Apple Dictation, Dragon, MacWhisper, Otter.ai, and others.
 

--- a/website/scripts/check-solutions.mjs
+++ b/website/scripts/check-solutions.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const SITE = 'https://enviouswispr.com';
+
+function textContent(html) {
+  return html
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&#39;|&apos;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function wordCount(value) {
+  const text = textContent(value);
+  return text ? text.split(/\s+/).length : 0;
+}
+
+function matches(html, pattern) {
+  return pattern.test(html);
+}
+
+export function validateSolutionDocument({ html, route, kind, knownRoutes }) {
+  const errors = [];
+  const h1Count = (html.match(/<h1\b/gi) ?? []).length;
+  const title = html.match(/<title>([\s\S]*?)<\/title>/i)?.[1]?.trim() ?? '';
+  const description = html.match(/<meta\s+name="description"\s+content="([^"]*)"/i)?.[1]?.trim() ?? '';
+  const canonical = html.match(/<link\s+rel="canonical"\s+href="([^"]+)"/i)?.[1] ?? '';
+  const sources = [...html.matchAll(/data-download-source="([^"]+)"/g)].map((match) => match[1]);
+
+  if (h1Count !== 1) errors.push(`${route}: expected exactly one H1, found ${h1Count}`);
+  if (!title) errors.push(`${route}: missing title`);
+  if (!description) errors.push(`${route}: missing meta description`);
+  if (title && (title.length < 50 || title.length > 60)) errors.push(`${route}: title has ${title.length} characters, expected 50 to 60`);
+  if (description && (description.length < 145 || description.length > 155)) errors.push(`${route}: meta description has ${description.length} characters, expected 145 to 155`);
+  if (canonical !== `${SITE}${route}`) errors.push(`${route}: canonical is ${canonical || '<missing>'}`);
+  if (!matches(html, /"@type":"BreadcrumbList"/)) errors.push(`${route}: missing BreadcrumbList schema`);
+  if (/[—–]/.test(textContent(html))) errors.push(`${route}: rendered copy contains an em or en dash`);
+
+  if (kind === 'hub') {
+    if (!matches(html, /"@type":"CollectionPage"/)) errors.push(`${route}: missing CollectionPage schema`);
+    if (!matches(html, /"@type":"ItemList"/)) errors.push(`${route}: missing ItemList schema`);
+  } else {
+    if (!matches(html, /"@type":"WebPage"/)) errors.push(`${route}: missing WebPage schema`);
+    if (!matches(html, /<details\b/)) errors.push(`${route}: missing visible FAQ details`);
+    if (!matches(html, /href="\/solutions\/"/)) errors.push(`${route}: missing link back to the solutions hub`);
+    if (!matches(html, /href="[^"]*EnviousWispr\.dmg"/)) errors.push(`${route}: missing direct download action`);
+    if (sources.length < 2) errors.push(`${route}: expected distinct hero and bottom download sources`);
+
+    const answerBlock = html.match(/<section\b[^>]*data-answer-block[^>]*>([\s\S]*?)<\/section>/i)?.[1] ?? '';
+    const answerParagraphs = [...answerBlock.matchAll(/<p(?:\s[^>]*)?>([\s\S]*?)<\/p>/gi)];
+    const answerParagraph = answerParagraphs.at(-1)?.[1] ?? '';
+    const answerWords = wordCount(answerParagraph);
+    if (answerWords < 134 || answerWords > 167) {
+      errors.push(`${route}: direct answer has ${answerWords} words, expected 134 to 167`);
+    }
+  }
+
+  for (const match of html.matchAll(/href="(\/solutions\/[a-z0-9-]*\/)"/g)) {
+    if (!knownRoutes.has(match[1])) errors.push(`${route}: solution link points nowhere: ${match[1]}`);
+  }
+
+  return { errors, title, description, sources };
+}
+
+export function validateSolutionCluster({ documents, sitemapXml }) {
+  const errors = [];
+  const knownRoutes = new Set(documents.map((document) => document.route));
+  const titles = new Map();
+  const descriptions = new Map();
+  const downloadSources = new Map();
+
+  for (const document of documents) {
+    const result = validateSolutionDocument({ ...document, knownRoutes });
+    errors.push(...result.errors);
+    for (const [value, map, label] of [
+      [result.title, titles, 'title'],
+      [result.description, descriptions, 'meta description'],
+    ]) {
+      if (!value) continue;
+      if (map.has(value)) errors.push(`${document.route}: duplicate ${label} also used by ${map.get(value)}`);
+      else map.set(value, document.route);
+    }
+    for (const source of result.sources) {
+      if (downloadSources.has(source)) errors.push(`${document.route}: duplicate download source also used by ${downloadSources.get(source)}: ${source}`);
+      else downloadSources.set(source, document.route);
+    }
+    const sitemapMatches = [...sitemapXml.matchAll(new RegExp(`<loc>${SITE}${document.route.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}</loc>`, 'g'))];
+    if (sitemapMatches.length !== 1) errors.push(`${document.route}: expected once in sitemap, found ${sitemapMatches.length}`);
+  }
+
+  return errors;
+}
+
+function routeFromSource(filename) {
+  return filename === 'index.astro' ? '/solutions/' : `/solutions/${filename.replace(/\.astro$/, '')}/`;
+}
+
+export function run(root = process.cwd()) {
+  const sourceDir = path.join(root, 'src/pages/solutions');
+  const distDir = path.join(root, 'dist');
+  if (!fs.existsSync(sourceDir) || !fs.existsSync(distDir)) {
+    console.error('FAIL: solutions source or dist directory is missing. Run `npm run build` from website/.');
+    return 1;
+  }
+
+  const sourceRoutes = fs.readdirSync(sourceDir).filter((file) => file.endsWith('.astro')).map(routeFromSource).sort();
+  const documents = sourceRoutes.map((route) => {
+    const file = path.join(distDir, route.replace(/^\//, ''), 'index.html');
+    if (!fs.existsSync(file)) return { route, kind: route === '/solutions/' ? 'hub' : 'landing', html: '' };
+    return { route, kind: route === '/solutions/' ? 'hub' : 'landing', html: fs.readFileSync(file, 'utf8') };
+  });
+  const builtRoutes = fs.existsSync(path.join(distDir, 'solutions'))
+    ? fs.readdirSync(path.join(distDir, 'solutions'), { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => `/solutions/${entry.name}/`)
+      .concat('/solutions/')
+      .sort()
+    : [];
+
+  const routeProblems = [
+    ...sourceRoutes.filter((route) => !builtRoutes.includes(route)).map((route) => `${route}: source route missing from build`),
+    ...builtRoutes.filter((route) => !sourceRoutes.includes(route)).map((route) => `${route}: built route has no static source page`),
+  ];
+  const sitemapXml = fs.readdirSync(distDir)
+    .filter((file) => /^sitemap.*\.xml$/.test(file))
+    .map((file) => fs.readFileSync(path.join(distDir, file), 'utf8'))
+    .join('\n');
+  const errors = [...routeProblems, ...validateSolutionCluster({ documents, sitemapXml })];
+
+  console.log(`solutions: ${sourceRoutes.length} source route(s), ${builtRoutes.length} built route(s), ${errors.length} error(s)`);
+  for (const error of errors) console.error(`FAIL: ${error}`);
+  return errors.length ? 1 : 0;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exit(run());
+}

--- a/website/scripts/check-solutions.test.mjs
+++ b/website/scripts/check-solutions.test.mjs
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { validateSolutionCluster } from './check-solutions.mjs';
+
+const answer = Array.from({ length: 140 }, (_, index) => `word${index + 1}`).join(' ');
+
+function page({ route = '/solutions/developers/', title = 'Free Dictation for Developers on Mac | EnviousWispr', description = 'Dictate pull requests, reviews, documentation, and prompts on Mac with free, private, on-device voice input designed for technical vocabulary every day.', source = 'solution-developers', body = answer, target = '/solutions/' } = {}) {
+  return {
+    route,
+    kind: 'landing',
+    html: `<!doctype html><html><head><title>${title}</title><meta name="description" content="${description}"><link rel="canonical" href="https://enviouswispr.com${route}"><script type="application/ld+json">{"@type":"WebPage"}</script><script type="application/ld+json">{"@type":"BreadcrumbList"}</script></head><body><h1>One heading</h1><a href="${target}">Solutions</a><a href="https://example.com/EnviousWispr.dmg" data-download-source="${source}">Download</a><section data-answer-block><p>Label</p><h2>Answer</h2><p>${body}</p></section><details><summary>Question</summary><p>Answer</p></details><a href="https://example.com/EnviousWispr.dmg" data-download-source="${source}-bottom">Download</a></body></html>`,
+  };
+}
+
+function hub() {
+  return {
+    route: '/solutions/',
+    kind: 'hub',
+    html: '<!doctype html><html><head><title>Mac Dictation Solutions for Real Work | EnviousWispr</title><meta name="description" content="Find a free Mac dictation workflow for coding, writing, private offline work, and clean AI-polished text. Explore EnviousWispr and download free."><link rel="canonical" href="https://enviouswispr.com/solutions/"><script type="application/ld+json">{"@type":"CollectionPage","mainEntity":{"@type":"ItemList"}}</script><script type="application/ld+json">{"@type":"BreadcrumbList"}</script></head><body><h1>One heading</h1><a href="/solutions/developers/">Developers</a></body></html>',
+  };
+}
+
+function sitemap(...routes) {
+  return routes.map((route) => `<loc>https://enviouswispr.com${route}</loc>`).join('');
+}
+
+test('accepts a complete hub and landing page', () => {
+  const documents = [hub(), page()];
+  assert.deepEqual(validateSolutionCluster({ documents, sitemapXml: sitemap(...documents.map((item) => item.route)) }), []);
+});
+
+test('rejects a direct answer outside the extraction window', () => {
+  const documents = [hub(), page({ body: 'too short' })];
+  const errors = validateSolutionCluster({ documents, sitemapXml: sitemap(...documents.map((item) => item.route)) });
+  assert.ok(errors.some((error) => error.includes('direct answer has 2 words')));
+});
+
+test('rejects a solution link with no built route', () => {
+  const documents = [hub(), page({ target: '/solutions/missing/' })];
+  const errors = validateSolutionCluster({ documents, sitemapXml: sitemap(...documents.map((item) => item.route)) });
+  assert.ok(errors.some((error) => error.includes('solution link points nowhere')));
+});
+
+test('rejects duplicate metadata and download attribution', () => {
+  const first = page();
+  const second = page({ route: '/solutions/writers/', source: 'solution-developers' });
+  const documents = [hub(), first, second];
+  const errors = validateSolutionCluster({ documents, sitemapXml: sitemap(...documents.map((item) => item.route)) });
+  assert.ok(errors.some((error) => error.includes('duplicate title')));
+  assert.ok(errors.some((error) => error.includes('duplicate meta description')));
+  assert.ok(errors.some((error) => error.includes('duplicate download source')));
+});

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -42,6 +42,7 @@ const year = new Date().getFullYear();
       <div class="footer-right">
         <nav class="footer-links" aria-label="Footer Navigation">
           <a href="/how-it-works/">Under the Hood</a>
+          <a href="/solutions/">Solutions</a>
           <a href="/compare/">Compare</a>
           <a href="/blog/">Blog</a>
           <a href="/help/">Help</a>

--- a/website/src/components/Nav.astro
+++ b/website/src/components/Nav.astro
@@ -40,6 +40,7 @@ const { activePage = 'home' } = Astro.props;
     </a>
     <ul class="nav-links" id="navLinks" role="list">
       <li><a href="/how-it-works/" class:list={[{ active: activePage === 'how-it-works' }]}>Under the Hood</a></li>
+      <li><a href="/solutions/" class:list={[{ active: activePage === 'solutions' }]}>Solutions</a></li>
       <li><a href="/compare/" class:list={[{ active: activePage === 'compare' }]}>Compare</a></li>
       <li><a href="/blog/">Blog</a></li>
       <li><a href="/help/" class:list={[{ active: activePage === 'help' }]}>Help</a></li>

--- a/website/src/data/solutions.ts
+++ b/website/src/data/solutions.ts
@@ -1,0 +1,19 @@
+export interface SolutionCard {
+  href: string;
+  eyebrow: string;
+  title: string;
+  description: string;
+  outcome: string;
+  accent: 'blue' | 'violet' | 'green' | 'orange' | 'cyan';
+}
+
+export const solutions: SolutionCard[] = [
+  {
+    href: '/solutions/developers/',
+    eyebrow: 'For developers',
+    title: 'Dictate the work around the code',
+    description: 'Turn spoken context into PR descriptions, review comments, issue notes, and technical documentation without sending your audio away.',
+    outcome: 'Less typing between thinking and shipping',
+    accent: 'blue',
+  },
+];

--- a/website/src/layouts/SolutionLayout.astro
+++ b/website/src/layouts/SolutionLayout.astro
@@ -1,0 +1,248 @@
+---
+import BaseLayout from './BaseLayout.astro';
+
+interface FAQ {
+  question: string;
+  answer: string;
+}
+
+interface RelatedLink {
+  href: string;
+  title: string;
+  description: string;
+}
+
+interface Props {
+  title: string;
+  description: string;
+  canonicalPath: string;
+  eyebrow: string;
+  heading: string;
+  intro: string;
+  answerHeading: string;
+  directAnswer: string;
+  downloadSource: string;
+  trustItems: string[];
+  faqs: FAQ[];
+  relatedLinks: RelatedLink[];
+}
+
+const {
+  title,
+  description,
+  canonicalPath,
+  eyebrow,
+  heading,
+  intro,
+  answerHeading,
+  directAnswer,
+  downloadSource,
+  trustItems,
+  faqs,
+  relatedLinks,
+} = Astro.props;
+
+const siteUrl = 'https://enviouswispr.com';
+const pageUrl = `${siteUrl}${canonicalPath}`;
+const downloadUrl = 'https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg';
+
+const webPageJsonLd = JSON.stringify({
+  '@context': 'https://schema.org',
+  '@type': 'WebPage',
+  name: title,
+  description,
+  url: pageUrl,
+  isPartOf: {
+    '@type': 'WebSite',
+    name: 'EnviousWispr',
+    url: siteUrl,
+  },
+});
+
+const breadcrumbJsonLd = JSON.stringify({
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: siteUrl },
+    { '@type': 'ListItem', position: 2, name: 'Solutions', item: `${siteUrl}/solutions/` },
+    { '@type': 'ListItem', position: 3, name: eyebrow, item: pageUrl },
+  ],
+});
+
+---
+
+<BaseLayout
+  title={title}
+  description={description}
+  activePage="solutions"
+  canonicalPath={canonicalPath}
+>
+  <Fragment slot="head">
+    <script type="application/ld+json" set:html={webPageJsonLd}></script>
+    <script type="application/ld+json" set:html={breadcrumbJsonLd}></script>
+  </Fragment>
+
+  <article class="solution-page">
+    <div class="container">
+      <nav class="solution-breadcrumb" aria-label="Breadcrumb">
+        <a href="/">Home</a><span aria-hidden="true">/</span>
+        <a href="/solutions/">Solutions</a><span aria-hidden="true">/</span>
+        <span aria-current="page">{eyebrow}</span>
+      </nav>
+
+      <header class="solution-hero">
+        <div class="solution-hero-copy">
+          <div class="section-label-pill accent">{eyebrow}</div>
+          <h1>{heading}</h1>
+          <p class="solution-intro">{intro}</p>
+          <div class="solution-actions">
+            <a href={downloadUrl} class="solution-primary" data-download-source={downloadSource}>Download free</a>
+            <a href="#how-it-fits" class="solution-secondary">See how it fits</a>
+          </div>
+          <ul class="solution-trust" role="list">
+            {trustItems.map((item) => <li>{item}</li>)}
+          </ul>
+        </div>
+        <div class="solution-proof" aria-label={`${eyebrow} workflow example`}>
+          <slot name="proof" />
+        </div>
+      </header>
+
+      <section class="solution-answer" aria-labelledby="direct-answer-heading" data-answer-block>
+        <p class="solution-answer-label">The short answer</p>
+        <h2 id="direct-answer-heading">{answerHeading}</h2>
+        <p>{directAnswer}</p>
+      </section>
+
+      <div id="how-it-fits" class="solution-content">
+        <slot />
+      </div>
+
+      <section class="solution-faq" aria-labelledby="faq-heading">
+        <div class="solution-section-heading">
+          <p class="solution-kicker">Common questions</p>
+          <h2 id="faq-heading">What to know before you download</h2>
+        </div>
+        <div class="solution-faq-list">
+          {faqs.map((faq) => (
+            <details>
+              <summary>{faq.question}</summary>
+              <p>{faq.answer}</p>
+            </details>
+          ))}
+        </div>
+      </section>
+
+      <section class="solution-related" aria-labelledby="related-heading">
+        <div class="solution-section-heading">
+          <p class="solution-kicker">Keep exploring</p>
+          <h2 id="related-heading">Related guides and workflows</h2>
+        </div>
+        <div class="solution-related-grid">
+          {relatedLinks.map((link) => (
+            <a href={link.href}>
+              <h3>{link.title}</h3>
+              <p>{link.description}</p>
+              <span>Explore this guide</span>
+            </a>
+          ))}
+        </div>
+      </section>
+
+      <section class="solution-bottom-cta cta-section" aria-labelledby="solution-cta-heading">
+        <div>
+          <p class="solution-kicker">Free, private, Mac native</p>
+          <h2 id="solution-cta-heading">Give your keyboard a quieter day.</h2>
+          <p>No account and no subscription. Requires macOS 14 or later on Apple Silicon.</p>
+        </div>
+        <a href={downloadUrl} class="solution-primary" data-download-source={`${downloadSource}-bottom`}>Download EnviousWispr</a>
+      </section>
+    </div>
+  </article>
+</BaseLayout>
+
+<style is:global>
+  .solution-page { padding: 92px 0 80px; }
+  .solution-breadcrumb { display: flex; align-items: center; gap: 9px; margin: 10px 0 34px; font-size: 13px; color: var(--text-3); }
+  .solution-breadcrumb a { color: var(--text-3); text-decoration: none; }
+  .solution-breadcrumb a:hover { color: var(--accent); }
+  .solution-hero { display: grid; grid-template-columns: minmax(0, 1.02fr) minmax(420px, 0.98fr); gap: 64px; align-items: center; min-height: 570px; }
+  .solution-hero-copy h1 { max-width: 720px; margin-bottom: 22px; font-size: clamp(46px, 5.4vw, 72px); line-height: 1.02; letter-spacing: -3.5px; }
+  .solution-intro { max-width: 650px; color: var(--text-2); font-size: 19px; line-height: 1.72; }
+  .solution-actions { display: flex; align-items: center; gap: 14px; margin-top: 30px; flex-wrap: wrap; }
+  .solution-primary, .solution-secondary { display: inline-flex; align-items: center; justify-content: center; min-height: 48px; padding: 13px 21px; border-radius: var(--radius-btn); font-size: 14px; font-weight: 700; text-decoration: none; transition: transform .2s, box-shadow .2s, background .2s; }
+  .solution-primary { color: #fff; background: var(--text); box-shadow: 0 10px 28px rgba(15,10,26,.14); }
+  .solution-primary:hover { transform: translateY(-2px); box-shadow: 0 14px 34px rgba(15,10,26,.2); }
+  .solution-secondary { color: var(--accent); border: 1px solid rgba(124,58,237,.2); background: rgba(255,255,255,.7); }
+  .solution-secondary:hover { background: #fff; }
+  .solution-trust { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 24px; list-style: none; }
+  .solution-trust li { padding: 7px 11px; border: 1px solid var(--border-hover); border-radius: var(--radius-pill); background: rgba(255,255,255,.72); color: var(--text-2); font-family: var(--font-mono); font-size: 11px; }
+  .solution-proof { position: relative; min-height: 440px; padding: 18px; border: 1px solid rgba(124,58,237,.14); border-radius: 28px; background: linear-gradient(145deg,rgba(255,255,255,.94),rgba(240,236,249,.82)); box-shadow: 0 32px 80px rgba(62,34,107,.13); overflow: hidden; }
+  .solution-proof::before { content: ''; position: absolute; inset: 0; background: radial-gradient(circle at 85% 10%,rgba(0,204,221,.16),transparent 34%),radial-gradient(circle at 6% 92%,rgba(124,58,237,.14),transparent 38%); pointer-events: none; }
+  .proof-window { position: relative; height: 100%; min-height: 404px; display: flex; flex-direction: column; border: 1px solid rgba(138,43,226,.11); border-radius: 18px; background: rgba(15,10,26,.96); color: #f8f5ff; overflow: hidden; }
+  .proof-window-bar { display: flex; align-items: center; gap: 7px; padding: 14px 16px; border-bottom: 1px solid rgba(255,255,255,.09); color: rgba(248,245,255,.55); font-family: var(--font-mono); font-size: 10px; text-transform: uppercase; letter-spacing: .08em; }
+  .proof-window-bar i { width: 8px; height: 8px; border-radius: 50%; background: #ff6258; }
+  .proof-window-bar i:nth-child(2) { background: #ffbd2e; }
+  .proof-window-bar i:nth-child(3) { background: #29c940; margin-right: 5px; }
+  .proof-body { display: grid; gap: 14px; padding: 22px; flex: 1; }
+  .proof-row { padding: 15px 16px; border: 1px solid rgba(255,255,255,.08); border-radius: 12px; background: rgba(255,255,255,.04); }
+  .proof-row-label { display: block; margin-bottom: 7px; color: #8de8f1; font-family: var(--font-mono); font-size: 10px; text-transform: uppercase; letter-spacing: .1em; }
+  .proof-row p { color: rgba(248,245,255,.86); font-size: 13px; line-height: 1.65; }
+  .proof-row.output { border-color: rgba(0,250,154,.25); background: rgba(0,200,128,.08); }
+  .proof-row.output .proof-row-label { color: #55e0a8; }
+  .proof-rail { display: grid; grid-template-columns: repeat(4,1fr); gap: 8px; margin-top: auto; }
+  .proof-rail span { position: relative; padding-top: 16px; color: rgba(248,245,255,.48); font-family: var(--font-mono); font-size: 9px; text-align: center; }
+  .proof-rail span::before { content: ''; position: absolute; top: 3px; left: 0; right: 0; height: 3px; border-radius: 3px; background: linear-gradient(90deg,#8a2be2,#00ccdd); }
+  .solution-answer { margin: 68px auto; max-width: 920px; padding: 34px 38px; border-left: 4px solid var(--accent); border-radius: 0 18px 18px 0; background: rgba(255,255,255,.78); box-shadow: 0 14px 40px rgba(62,34,107,.07); }
+  .solution-answer-label, .solution-kicker { margin-bottom: 8px; color: var(--accent); font-family: var(--font-mono); font-size: 11px; font-weight: 600; letter-spacing: .09em; text-transform: uppercase; }
+  .solution-answer h2 { margin-bottom: 14px; font-size: 30px; letter-spacing: -1px; }
+  .solution-answer p:last-child { color: var(--text-2); font-size: 17px; line-height: 1.8; }
+  .solution-content { display: grid; gap: 72px; scroll-margin-top: 88px; }
+  .solution-section { display: grid; grid-template-columns: .72fr 1.28fr; gap: 60px; align-items: start; }
+  .solution-section h2, .solution-section-heading h2 { font-size: clamp(30px,3.4vw,44px); line-height: 1.12; letter-spacing: -1.8px; }
+  .solution-section-lead { color: var(--text-2); font-size: 17px; line-height: 1.75; }
+  .solution-card-grid { display: grid; grid-template-columns: repeat(2,1fr); gap: 16px; }
+  .solution-card { padding: 24px; border: 1px solid var(--border-hover); border-radius: var(--radius-card); background: rgba(255,255,255,.76); }
+  .solution-card h3 { margin-bottom: 9px; font-size: 17px; letter-spacing: -.4px; }
+  .solution-card p { color: var(--text-2); font-size: 14px; line-height: 1.65; }
+  .solution-callout { padding: 26px 28px; border: 1px solid rgba(0,204,221,.22); border-radius: 18px; background: linear-gradient(135deg,rgba(0,204,221,.08),rgba(124,58,237,.06)); }
+  .solution-callout strong { display: block; margin-bottom: 8px; font-size: 17px; }
+  .solution-callout p { color: var(--text-2); }
+  .solution-faq, .solution-related { margin-top: 92px; }
+  .solution-section-heading { max-width: 680px; margin-bottom: 32px; }
+  .solution-faq-list { display: grid; gap: 12px; }
+  .solution-faq details { border: 1px solid var(--border-hover); border-radius: 14px; background: rgba(255,255,255,.75); }
+  .solution-faq summary { padding: 20px 22px; cursor: pointer; font-size: 16px; font-weight: 700; }
+  .solution-faq details p { padding: 0 22px 22px; color: var(--text-2); line-height: 1.72; }
+  .solution-related-grid { display: grid; grid-template-columns: repeat(3,1fr); gap: 16px; }
+  .solution-related-grid a { display: block; padding: 24px; border: 1px solid var(--border-hover); border-radius: var(--radius-card); background: rgba(255,255,255,.72); color: var(--text); text-decoration: none; transition: transform .2s, border-color .2s; }
+  .solution-related-grid a:hover { transform: translateY(-3px); border-color: rgba(124,58,237,.25); }
+  .solution-related-grid h3 { margin-bottom: 8px; font-size: 17px; }
+  .solution-related-grid p { margin-bottom: 18px; color: var(--text-2); font-size: 13px; line-height: 1.65; }
+  .solution-related-grid span { color: var(--accent); font-size: 12px; font-weight: 700; }
+  .solution-bottom-cta { display: flex; align-items: center; justify-content: space-between; gap: 32px; margin-top: 92px; padding: 38px; border-radius: 24px; background: var(--text); color: #fff; }
+  .solution-bottom-cta h2 { margin-bottom: 7px; font-size: 32px; letter-spacing: -1.2px; }
+  .solution-bottom-cta p:not(.solution-kicker) { color: rgba(255,255,255,.67); }
+  .solution-bottom-cta .solution-primary { color: var(--text); background: #fff; white-space: nowrap; }
+  .solution-bottom-cta .solution-kicker { color: #8de8f1; }
+  @media (max-width: 980px) {
+    .solution-hero { grid-template-columns: 1fr; gap: 38px; min-height: 0; }
+    .solution-proof { min-height: 390px; }
+    .solution-section { grid-template-columns: 1fr; gap: 26px; }
+  }
+  @media (max-width: 700px) {
+    .solution-page { padding-top: 78px; }
+    .solution-breadcrumb { margin-bottom: 24px; }
+    .solution-hero-copy h1 { font-size: 43px; letter-spacing: -2.2px; }
+    .solution-intro { font-size: 17px; }
+    .solution-proof { min-height: 0; padding: 10px; border-radius: 20px; }
+    .proof-window { min-height: 390px; }
+    .proof-body { padding: 16px; }
+    .proof-rail { grid-template-columns: repeat(2,1fr); }
+    .solution-answer { margin: 48px 0; padding: 26px 24px; }
+    .solution-answer h2 { font-size: 26px; }
+    .solution-card-grid, .solution-related-grid { grid-template-columns: 1fr; }
+    .solution-faq, .solution-related { margin-top: 68px; }
+    .solution-bottom-cta { align-items: flex-start; flex-direction: column; margin-top: 68px; padding: 28px 24px; }
+  }
+</style>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -302,11 +302,11 @@ const jsonLdFaq = JSON.stringify({
       </div>
 
       <div class="uc-grid reveal-stagger">
-        <a href="/blog/dictation-for-developers-code-reviews/" class="uc-card tint-blue reveal" style="--i:0">
+        <a href="/solutions/developers/" class="uc-card tint-blue reveal" style="--i:0">
           <span class="uc-badge"><span class="uc-badge-icon" aria-hidden="true">💻</span>For Developers</span>
           <h3 class="uc-headline">Ship code without leaving flow.</h3>
           <p class="uc-tasks">PR descriptions, commit messages, code comments. Narrate while you work.</p>
-          <span class="uc-cta">Read the workflow</span>
+          <span class="uc-cta">See developer dictation</span>
         </a>
 
         <a href="/blog/dictation-for-writers-skip-blank-page/" class="uc-card reveal" style="--i:1">

--- a/website/src/pages/solutions/developers.astro
+++ b/website/src/pages/solutions/developers.astro
@@ -1,0 +1,106 @@
+---
+import SolutionLayout from '../../layouts/SolutionLayout.astro';
+
+const faqs = [
+  {
+    question: 'Can EnviousWispr dictate source code?',
+    answer: 'EnviousWispr is best for the language around code: PR descriptions, code-review comments, issue notes, documentation, commit messages, and prompts. It does not generate source code or execute terminal commands for you.',
+  },
+  {
+    question: 'Does developer dictation work offline?',
+    answer: 'Yes. Speech recognition runs on your Apple Silicon Mac after the speech model is downloaded. Deterministic cleanup also stays local. If you choose a local polish provider, the full text workflow can remain offline.',
+  },
+  {
+    question: 'How does EnviousWispr handle technical words?',
+    answer: 'It includes built-in technology vocabulary and lets you add custom words for project names, APIs, teammates, libraries, and internal terms. Custom-word correction runs on your Mac.',
+  },
+  {
+    question: 'Will it run commands when I dictate in Terminal?',
+    answer: 'No. EnviousWispr inserts text into text-entry surfaces. It does not automatically execute shell commands or press Return for you. You stay in control of what runs.',
+  },
+];
+
+const relatedLinks = [
+  {
+    href: '/blog/dictation-for-developers-code-reviews/',
+    title: 'Code reviews and PR descriptions',
+    description: 'A practical voice workflow for the writing that surrounds a pull request.',
+  },
+  {
+    href: '/blog/voice-coding-macos-without-cloud/',
+    title: 'Voice coding without the cloud',
+    description: 'See how local transcription changes the privacy boundary for developer work.',
+  },
+  {
+    href: '/blog/switched-typing-to-dictating-git-commits/',
+    title: 'Dictating git commit messages',
+    description: 'A focused workflow for explaining a change while the context is still fresh.',
+  },
+];
+
+const directAnswer = `Dictation for developers on Mac is voice input for the writing that surrounds software work: pull request descriptions, review comments, issue updates, documentation, prompts, and commit messages. EnviousWispr records your speech, transcribes it on your Apple Silicon Mac, cleans common filler and formatting, then pastes the result into the text field you are using. It is not a source-code generator and it does not execute commands. The useful part is keeping your reasoning moving when the keyboard becomes the bottleneck. Built-in technology vocabulary and custom words help with library names, APIs, teammates, and project terms. Audio always stays on your Mac. You can keep text cleanup local with deterministic rules, EG-1, Apple Intelligence on supported systems, or a downloaded Ollama model. If you choose cloud polish, the transcript, cleanup instructions, custom words, target app name, and your key go directly to that provider. The core app is free, open source, and requires macOS 14 or later on Apple Silicon.`;
+---
+
+<SolutionLayout
+  title="Free Dictation for Developers on Mac | EnviousWispr"
+  description="Dictate PR descriptions, code reviews, docs, and prompts on Mac. EnviousWispr is free, private, on-device, fast, and built for technical vocabulary."
+  canonicalPath="/solutions/developers/"
+  eyebrow="For developers"
+  heading="Think through the change. Dictate the context."
+  intro="The code may need a keyboard. The explanation around it does not. Turn spoken reasoning into clean PR descriptions, reviews, docs, issues, and prompts without uploading your voice."
+  answerHeading="What is dictation for developers on Mac?"
+  directAnswer={directAnswer}
+  downloadSource="solution-developers"
+  trustItems={['Audio stays on your Mac', 'Tech vocabulary + custom words', 'macOS 14+ · Apple Silicon']}
+  faqs={faqs}
+  relatedLinks={relatedLinks}
+>
+  <div slot="proof" class="proof-window">
+    <div class="proof-window-bar"><i></i><i></i><i></i>pull-request.md</div>
+    <div class="proof-body">
+      <div class="proof-row">
+        <span class="proof-row-label">Spoken</span>
+        <p>Okay so this changes the auth retry because the old path could lose the refresh result, and I also added coverage for the fallback.</p>
+      </div>
+      <div class="proof-row output">
+        <span class="proof-row-label">Ready for review</span>
+        <p>This changes the authentication retry so the refresh result is preserved. It also adds coverage for the fallback path.</p>
+      </div>
+      <div class="proof-rail" aria-hidden="true"><span>Voice</span><span>Local ASR</span><span>Cleanup</span><span>Paste</span></div>
+    </div>
+  </div>
+
+  <section class="solution-section" aria-labelledby="developer-work-heading">
+    <div>
+      <p class="solution-kicker">Where it helps</p>
+      <h2 id="developer-work-heading">Use voice where context matters more than syntax.</h2>
+    </div>
+    <div class="solution-card-grid">
+      <article class="solution-card"><h3>Pull request descriptions</h3><p>Explain the why, the trade-off, and the test evidence while the change is still in your head.</p></article>
+      <article class="solution-card"><h3>Code-review comments</h3><p>Talk through a concern in full sentences, then paste a calmer and clearer review note.</p></article>
+      <article class="solution-card"><h3>Issues and handoffs</h3><p>Capture reproduction steps, constraints, and the next decision without turning note-taking into a second task.</p></article>
+      <article class="solution-card"><h3>Documentation and prompts</h3><p>Draft READMEs, implementation notes, and detailed AI prompts in the editor or browser you already use.</p></article>
+    </div>
+  </section>
+
+  <section class="solution-section" aria-labelledby="developer-control-heading">
+    <div>
+      <p class="solution-kicker">Your terminal stays yours</p>
+      <h2 id="developer-control-heading">Text goes in. Nothing runs by itself.</h2>
+    </div>
+    <div>
+      <p class="solution-section-lead">EnviousWispr is an input tool, not an autonomous coding agent. It can place dictated text into compatible text fields, including terminal input, but it does not press Return, execute shell commands, change files, or make repository decisions for you.</p>
+      <div class="solution-callout" style="margin-top:20px"><strong>Best fit</strong><p>Use it for natural-language work around code. Keep precise syntax, structural edits, and command execution under direct control.</p></div>
+    </div>
+  </section>
+
+  <section class="solution-section" aria-labelledby="developer-privacy-heading">
+    <div>
+      <p class="solution-kicker">A concrete privacy boundary</p>
+      <h2 id="developer-privacy-heading">Your voice never becomes somebody else's audio file.</h2>
+    </div>
+    <div>
+      <p class="solution-section-lead">Transcription runs on your Mac, so spoken project context is not uploaded for speech recognition. Local polish can keep the resulting text there too. If you turn on a cloud provider, the transcript, cleanup instructions, custom words, target app name, and your account credential go directly to it. Envious Labs does not relay the request.</p>
+    </div>
+  </section>
+</SolutionLayout>

--- a/website/src/pages/solutions/index.astro
+++ b/website/src/pages/solutions/index.astro
@@ -1,0 +1,120 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import { solutions } from '../../data/solutions';
+
+const siteUrl = 'https://enviouswispr.com';
+const title = 'Mac Dictation Solutions for Real Work | EnviousWispr';
+const description = 'Explore a free Mac dictation workflow for developers. Turn spoken context into PR descriptions, code reviews, docs, issues, commits, and prompts locally.';
+
+const collectionJsonLd = JSON.stringify({
+  '@context': 'https://schema.org',
+  '@type': 'CollectionPage',
+  name: title,
+  description,
+  url: `${siteUrl}/solutions/`,
+  mainEntity: {
+    '@type': 'ItemList',
+    itemListElement: solutions.map((solution, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: solution.title,
+      url: `${siteUrl}${solution.href}`,
+    })),
+  },
+});
+
+const breadcrumbJsonLd = JSON.stringify({
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: siteUrl },
+    { '@type': 'ListItem', position: 2, name: 'Solutions', item: `${siteUrl}/solutions/` },
+  ],
+});
+---
+
+<BaseLayout title={title} description={description} activePage="solutions" canonicalPath="/solutions/">
+  <Fragment slot="head">
+    <script type="application/ld+json" set:html={collectionJsonLd}></script>
+    <script type="application/ld+json" set:html={breadcrumbJsonLd}></script>
+  </Fragment>
+
+  <div class="solutions-hub">
+    <div class="container">
+      <nav class="hub-breadcrumb" aria-label="Breadcrumb"><a href="/">Home</a><span aria-hidden="true">/</span><span aria-current="page">Solutions</span></nav>
+      <header class="hub-hero">
+        <div>
+          <div class="section-label-pill accent">Solutions</div>
+          <h1>Less typing.<br/><span class="rainbow-text">More finished work.</span></h1>
+        </div>
+        <div class="hub-intro">
+          <p>EnviousWispr is a free dictation app for Apple Silicon Macs. Start with the developer workflow and see exactly where voice fits around code.</p>
+          <a href="/how-it-works/">See how on-device dictation works</a>
+        </div>
+      </header>
+
+      <section class="hub-grid" aria-label="Dictation solutions">
+        {solutions.map((solution, index) => (
+          <a href={solution.href} class={`hub-card ${solution.accent}`}>
+            <div class="hub-card-number">0{index + 1}</div>
+            <p class="hub-card-eyebrow">{solution.eyebrow}</p>
+            <h2>{solution.title}</h2>
+            <p class="hub-card-description">{solution.description}</p>
+            <div class="hub-card-outcome"><span aria-hidden="true"></span>{solution.outcome}</div>
+            <div class="hub-card-link">Explore the workflow <span aria-hidden="true">→</span></div>
+          </a>
+        ))}
+      </section>
+
+      <section class="hub-principles" aria-labelledby="principles-heading">
+        <div>
+          <p class="hub-kicker">One foundation</p>
+          <h2 id="principles-heading">Every workflow starts with the same three promises.</h2>
+        </div>
+        <div class="hub-principle-list">
+          <article><strong>Audio stays local</strong><p>Speech recognition runs on your Mac. Your voice is never uploaded.</p></article>
+          <article><strong>You choose the polish path</strong><p>Keep cleanup on-device, use deterministic cleanup only, or bring your own cloud provider key.</p></article>
+          <article><strong>The app stays free</strong><p>No EnviousWispr account, subscription, or locked core dictation feature.</p></article>
+        </div>
+      </section>
+    </div>
+  </div>
+</BaseLayout>
+
+<style>
+  .solutions-hub { padding: 96px 0 96px; }
+  .hub-breadcrumb { display:flex; gap:9px; margin:10px 0 42px; color:var(--text-3); font-size:13px; }
+  .hub-breadcrumb a { color:var(--text-3); text-decoration:none; }
+  .hub-hero { display:grid; grid-template-columns:1.25fr .75fr; gap:80px; align-items:end; margin-bottom:58px; }
+  .hub-hero h1 { max-width:760px; font-size:clamp(52px,7vw,88px); line-height:.98; letter-spacing:-5px; }
+  .hub-intro { padding-bottom:8px; }
+  .hub-intro p { margin-bottom:18px; color:var(--text-2); font-size:18px; line-height:1.75; }
+  .hub-intro a { color:var(--accent); font-size:14px; font-weight:700; text-underline-offset:4px; }
+  .hub-grid { display:grid; grid-template-columns:repeat(2,1fr); gap:20px; }
+  .hub-card { position:relative; min-height:390px; display:flex; flex-direction:column; padding:34px; border:1px solid var(--border-hover); border-radius:22px; background:rgba(255,255,255,.8); color:var(--text); text-decoration:none; overflow:hidden; transition:transform .22s,box-shadow .22s; }
+  .hub-card::before { content:''; position:absolute; inset:0 auto auto 0; width:100%; height:5px; background:var(--card-accent); }
+  .hub-card::after { content:''; position:absolute; right:-70px; top:-70px; width:210px; height:210px; border-radius:50%; background:var(--card-glow); filter:blur(4px); }
+  .hub-card:hover { transform:translateY(-5px); box-shadow:0 22px 55px rgba(62,34,107,.11); }
+  .hub-card.blue { --card-accent:linear-gradient(90deg,#1e90ff,#00ccdd); --card-glow:rgba(30,144,255,.12); }
+  .hub-card.violet { --card-accent:linear-gradient(90deg,#8a2be2,#d45a90); --card-glow:rgba(138,43,226,.12); }
+  .hub-card.green { --card-accent:linear-gradient(90deg,#00c880,#adff2f); --card-glow:rgba(0,200,128,.12); }
+  .hub-card.orange { --card-accent:linear-gradient(90deg,#ff8c00,#ffd700); --card-glow:rgba(255,140,0,.12); }
+  .hub-card.cyan { --card-accent:linear-gradient(90deg,#00ccdd,#7c3aed); --card-glow:rgba(0,204,221,.12); }
+  .hub-card-number { position:relative; z-index:1; margin-bottom:45px; color:var(--text-3); font-family:var(--font-mono); font-size:11px; }
+  .hub-card-eyebrow,.hub-kicker { margin-bottom:10px; color:var(--accent); font-family:var(--font-mono); font-size:11px; font-weight:600; letter-spacing:.09em; text-transform:uppercase; }
+  .hub-card h2 { position:relative; z-index:1; max-width:520px; margin-bottom:14px; font-size:32px; line-height:1.12; letter-spacing:-1.3px; }
+  .hub-card-description { max-width:560px; color:var(--text-2); line-height:1.7; }
+  .hub-card-outcome { display:flex; gap:9px; align-items:center; margin-top:24px; color:var(--text-2); font-size:12px; font-weight:600; }
+  .hub-card-outcome span { width:7px; height:7px; border-radius:50%; background:#00c880; box-shadow:0 0 0 4px rgba(0,200,128,.1); }
+  .hub-card-link { margin-top:auto; padding-top:30px; color:var(--accent); font-size:13px; font-weight:700; }
+  .hub-principles { display:grid; grid-template-columns:.8fr 1.2fr; gap:68px; margin-top:82px; padding:48px; border-radius:24px; background:var(--text); color:#fff; }
+  .hub-principles h2 { font-size:36px; line-height:1.18; letter-spacing:-1.5px; }
+  .hub-kicker { color:#8de8f1; }
+  .hub-principle-list { display:grid; gap:20px; }
+  .hub-principle-list article { padding-bottom:20px; border-bottom:1px solid rgba(255,255,255,.1); }
+  .hub-principle-list article:last-child { padding-bottom:0; border-bottom:0; }
+  .hub-principle-list strong { display:block; margin-bottom:5px; font-size:16px; }
+  .hub-principle-list p { color:rgba(255,255,255,.63); font-size:14px; line-height:1.65; }
+  @media(max-width:850px){.hub-hero,.hub-principles{grid-template-columns:1fr;gap:32px}.hub-grid{grid-template-columns:1fr}.hub-hero h1{letter-spacing:-3px}.hub-card{min-height:350px}.hub-principles{padding:32px}}
+  @media(max-width:600px){.solutions-hub{padding-top:80px}.hub-hero h1{font-size:48px;letter-spacing:-2.7px}.hub-card{padding:26px}.hub-card h2{font-size:28px}.hub-principles{padding:28px 24px}}
+</style>


### PR DESCRIPTION
## Summary

- add the `/solutions/` hub and `/solutions/developers/`
- add a reusable, responsive solution-page layout with accessible visible FAQs
- add canonical, breadcrumb, WebPage, CollectionPage, and ItemList metadata
- add solution-route validation to build and pull-request checks
- connect the new hub from navigation, footer, homepage, sitemap, and `llms.txt`

## Validation

- `npm run build`
- `npm run test:solutions`
- `npm run check:help`
- `actionlint .github/workflows/pr-check.yml`
- desktop and mobile browser review with zero horizontal overflow
- Codex diff review: no actionable regressions

Stack 1 of 3 for #2326. Updates #2327.

