### PR TITLE
SEO: add AI polish and offline dictation solutions

### DIFF
--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -13,6 +13,8 @@ Last-updated: 2026-08-22
 - [Homepage](https://enviouswispr.com/): Download, screenshots, core value proposition, system requirements (Apple Silicon, macOS 14+).
 - [Solutions](https://enviouswispr.com/solutions/): Focused dictation workflows for the work people do on a Mac.
 - [Dictation for developers](https://enviouswispr.com/solutions/developers/): On-device voice input for PR descriptions, code reviews, issues, documentation, commit messages, and prompts.
+- [AI dictation polish](https://enviouswispr.com/solutions/ai-polish/): Deterministic cleanup, local AI models, and bring-your-own-key cloud polish with a clear privacy boundary.
+- [Offline dictation](https://enviouswispr.com/solutions/offline-dictation/): Local speech recognition and text cleanup for Apple Silicon Macs after required model downloads.
 - [Best dictation apps for Mac](https://enviouswispr.com/compare/best-dictation-apps-for-mac/): A practical 2026 guide to seven Mac dictation options, with honest picks by workflow.
 - [Compare to alternatives](https://enviouswispr.com/compare/): Index of comparison pages vs WisprFlow, Superwhisper, Apple Dictation, Dragon, MacWhisper, Otter.ai, and others.
 

--- a/website/src/content/blog/macos-dictation-offline-private.md
+++ b/website/src/content/blog/macos-dictation-offline-private.md
@@ -1,29 +1,29 @@
 ---
-title: "macOS Dictation That Works Offline and Stays Private"
+title: "How Offline Dictation Works on Mac and What Stays On Device"
 description: "Fully private, on-device dictation for macOS that never sends your voice to the cloud. How EnviousWispr delivers offline speech-to-text you can trust."
 pubDate: 2026-03-11
-updatedDate: 2026-04-28
+updatedDate: 2026-08-22
 tags: ["accessibility", "privacy", "dictation", "offline"]
 draft: false
 author: "Saurabh Vaish"
 faqs:
   - question: "Does macOS have a built-in offline dictation option?"
-    answer: "Yes, but with caveats. Apple Dictation can download an Enhanced Dictation model that runs locally, but the experience is dated, post-processing is minimal, and accuracy on long-form dictation lags purpose-built tools. EnviousWispr runs entirely on-device using newer speech models (Parakeet for 25 European languages, Whisper for wider multilingual coverage) plus optional AI polish, so the transcript you paste is closer to what you actually meant to write."
+    answer: "Yes, but with caveats. Apple Dictation can run locally on supported Macs, but its cleanup and customization options are limited. EnviousWispr always transcribes on-device using Parakeet for 25 European languages or WhisperKit for wider multilingual coverage. You can then use local cleanup, local AI polish, or an optional cloud text-polish provider."
   - question: "Can dictation software really work without an internet connection?"
-    answer: "Yes, when the speech model runs locally. EnviousWispr ships with Core ML models that execute on your Mac's Neural Engine, so the entire transcribe-and-polish pipeline runs offline after the first download. There is no API call out, no server round-trip, and no graceful degradation when the Wi-Fi drops."
+    answer: "Yes, when the speech model runs locally. EnviousWispr transcribes on your Mac, so core dictation works offline after the speech model download. Deterministic cleanup, EG-1, supported Apple Intelligence, and downloaded Ollama models can also stay local. OpenAI, Gemini, Claude, and Ollama-hosted polish need a connection."
   - question: "Is on-device dictation accurate enough for medical or accessibility use?"
-    answer: "On Apple Silicon Macs, on-device speech recognition reaches word error rates competitive with leading cloud APIs for English dictation. For accessibility users who rely on voice input as a primary modality, that accuracy plus the predictability of no network failures is usually the deciding factor. For medical dictation, accuracy matters but the on-device privacy story usually matters more."
+    answer: "Accuracy depends on your microphone, language, speaking style, and chosen speech model. On-device processing removes network failures and keeps audio local, but it does not guarantee perfect text. Always review important output, especially medical terms, names, doses, and instructions."
   - question: "What happens if I dictate while completely offline?"
-    answer: "Everything works the same. EnviousWispr captures audio, runs transcription via Core ML, and pastes polished text into your app. The only feature that needs network is optional cloud AI polish (OpenAI, Gemini); on-device polish via Apple Intelligence, EG-1, or Ollama still works offline once its model is installed, as does raw transcription with no polish at all."
+    answer: "Core dictation works the same after its model is downloaded. EnviousWispr captures audio, transcribes locally, runs your selected local cleanup route, and pastes text into your app. OpenAI, Gemini, Claude, and Ollama-hosted polish need a connection. Apple Intelligence on supported systems, EG-1, downloaded Ollama models, deterministic cleanup, and raw transcription can work offline."
   - question: "Is there a free offline dictation app for Mac?"
-    answer: "Yes. EnviousWispr is free to download, requires no account, and runs entirely on your Mac. There is no usage cap, no trial period, and no subscription tier. You can use it indefinitely without ever creating an account or connecting to a server."
+    answer: "Yes. EnviousWispr is free to download and requires no EnviousWispr account. There is no usage cap, trial period, or subscription tier. Choose transcription with deterministic cleanup or a supported local polish provider to use it without connecting to a cloud text-polish service."
 ---
 
 What happens to your primary input method when the Wi-Fi goes down? If voice input is how you write (because typing hurts, or because it's simply not an option) that's not a hypothetical question. It's the difference between a tool you can depend on and one that fails when you need it most.
 
 Most macOS dictation tools treat offline capability as a nice-to-have. For someone who relies on voice input for accessibility, it's the whole point. And "works offline" shouldn't come with the usual asterisks: reduced accuracy, no post-processing, no customization.
 
-EnviousWispr is a different approach: on-device dictation for macOS that processes everything locally, works without an internet connection, and treats accessibility as a core use case rather than a footnote.
+EnviousWispr is a different approach: macOS dictation that always transcribes on-device, can complete the full workflow locally, and treats accessibility as a core use case rather than a footnote. Cloud text polish is available when you choose it, but it is not required for core dictation.
 
 ## Why Offline Matters for Accessible Voice Input
 
@@ -35,20 +35,22 @@ Offline dictation removes the most common point of failure. Your Mac's processin
 
 Privacy matters here too, and not in the abstract. People dictate medical information, therapy notes, personal health details, financial data. If you're using voice input as your primary way of interacting with your computer, everything flows through it. Sending all of that to a cloud service, even one with a solid privacy policy, is a decision most people would rather not make.
 
-With EnviousWispr, that decision doesn't come up. Your recordings stay on your Mac.
+With EnviousWispr, your recordings stay on your Mac. You still choose what happens to the transcript after that: keep cleanup local, or send text to a cloud polish provider you select.
 
 ## How On-Device Transcription Works
 
-EnviousWispr handles transcription locally using two backends: Parakeet for fast dictation across 25 European languages, and WhisperKit for wider multi-language support. Both run natively through Apple's Core ML framework. The Neural Engine on your Apple Silicon chip does the heavy lifting, not a remote server.
+EnviousWispr handles transcription locally using two backends: Parakeet for fast dictation across 25 European languages, and WhisperKit for wider multi-language support. Both run through local Apple Silicon hardware rather than a remote transcription server.
 
 Here's what the pipeline looks like in practice:
 
 1. **Record.** You speak, and EnviousWispr captures audio from your microphone with a pre-roll buffer so your first words are never clipped.
 2. **Transcribe.** On-device speech recognition converts your speech to text using Core ML.
-3. **Post-process.** Optional AI polish cleans up filler words, fixes punctuation, and formats the output. Choose from on-device providers (Apple Intelligence, EG-1, Ollama) or cloud (OpenAI, Gemini).
+3. **Post-process.** Deterministic cleanup runs locally. Optional AI polish can use EG-1, supported Apple Intelligence, or a downloaded Ollama model locally, or OpenAI, Gemini, Claude, and Ollama-hosted models over the network.
 4. **Deliver.** The polished text pastes directly into the app you're using. Your previous clipboard contents are preserved.
 
-End-to-end, this takes a second or two on Apple Silicon. No network round-trip. No waiting for a server response. For a deeper look at the transcription pipeline, see [how it works](/how-it-works/).
+With a local route, there is no network round-trip or server response to wait for. Cloud polish adds a network step after local transcription. For a deeper look at the transcription pipeline, see [how it works](/how-it-works/).
+
+Audio and transcription remain on your Mac in both cases. When you select cloud polish, the transcript, cleanup instructions, custom words, target app name, and your account credential go directly to that provider.
 
 Here's what on-device dictation looks like in practice, composing an email without touching the keyboard:
 
@@ -58,7 +60,7 @@ Here's what on-device dictation looks like in practice, composing an email witho
 **What gets pasted:**
 > Hi Dr. Martinez, following up on last week's appointment. You mentioned scheduling a follow-up in six weeks. I also need the referral paperwork for the hand specialist. Could you send that to my patient portal and let me know if there's anything I need to fill out beforehand? Thank you.
 
-That message was composed entirely by voice, processed on-device, and never left the Mac. For someone dictating medical or personal health content, that distinction matters.
+With a local polish route, that message can be composed entirely by voice and processed without the transcript leaving the Mac. For someone dictating medical or personal health content, that choice matters.
 
 ## Hands-Free Mode for Extended Dictation
 
@@ -102,7 +104,7 @@ These are paid macOS dictation apps that also focus on quality and speed. Both u
 
 EnviousWispr differs on three axes:
 
-- **Fully on-device.** Transcription and post-processing both run locally, with no cloud dependency.
+- **Local by choice.** Transcription always runs on-device. Deterministic cleanup and supported local polish providers can avoid a cloud dependency.
 - **Free to download.** Zero accounts, zero subscriptions. Available on [GitHub](https://github.com/saurabhav88/EnviousWispr).
 - **Hands-free mode included.** Double-press to lock recording for extended dictation without holding keys.
 
@@ -113,9 +115,9 @@ EnviousWispr differs on three axes:
 | On-device transcription | Yes | Partial | No | No |
 | Post-processing | On-device or cloud (your choice) | None | Cloud | Cloud |
 | Hands-free mode | Yes (double-press lock) | No | Varies | No |
-| Adaptive formatting | Yes (Ollama, OpenAI, or Gemini polish) | No | Varies | Varies |
+| Adaptive formatting | Yes (local or cloud polish) | No | Varies | Varies |
 | Custom word dictionary | Yes | No | No | No |
-| Internet required | No | No | Yes | Yes |
+| Internet required | No for local routes | No | Yes | Yes |
 | Cost | Free | Free | Subscription | Subscription |
 
 No tool wins on every axis. Cloud tools often have the easiest setup. Built-in dictation requires zero installation. EnviousWispr wins on privacy, offline capability, customization, and cost: the axes that matter most when voice input is something you depend on every day.
@@ -141,7 +143,7 @@ Both prompts appear automatically. Click Allow for each.
 
 ### Model Download
 
-EnviousWispr downloads its speech recognition model automatically on first launch. The download happens once, and after that everything runs locally.
+EnviousWispr downloads its speech recognition model on first use. Once that model is present, core dictation can run locally. EG-1 and local Ollama models also need to finish downloading before you depend on them offline.
 
 ### Configure for Hands-Free Use
 
@@ -149,11 +151,11 @@ If you want to avoid holding keys, just double-press your keybind to lock record
 
 ### Let the Polish Adapt
 
-EnviousWispr's polish step cleans up your dictation by default, removing filler words and fixing punctuation without flattening your voice. A quick aside stays a clean line. With Ollama, OpenAI, or Gemini polish on, a longer piece with list cues comes back structured with paragraphs and bullets; on the Apple Intelligence default, the same content stays clean prose.
+EnviousWispr's deterministic cleanup can remove filler words and fix punctuation locally. Optional AI polish can shape longer material with paragraphs and lists. Choose EG-1, supported Apple Intelligence, or a downloaded Ollama model for a local route, or OpenAI, Gemini, Claude, and Ollama-hosted models when you want cloud polish.
 
 ## A Tool That Works When You Need It
 
-The core promise of offline, private dictation is simple: it works when you need it, it doesn't send your words somewhere else, and it doesn't cost anything.
+The core promise of offline, private dictation is simple: local transcription works when you need it, you can keep the text-polish path on your Mac, and the app does not cost anything.
 
 For people who rely on voice input as their primary way of writing, those aren't bonus features. They're baseline requirements. EnviousWispr is built around them.
 

--- a/website/src/data/solutions.ts
+++ b/website/src/data/solutions.ts
@@ -16,4 +16,20 @@ export const solutions: SolutionCard[] = [
     outcome: 'Less typing between thinking and shipping',
     accent: 'blue',
   },
+  {
+    href: '/solutions/ai-polish/',
+    eyebrow: 'AI polish choices',
+    title: 'Choose how rough speech becomes clean text',
+    description: 'Compare deterministic cleanup, local AI models, and bring-your-own-key cloud polish without blurring their privacy boundaries.',
+    outcome: 'The cleanup you want with the boundary you choose',
+    accent: 'violet',
+  },
+  {
+    href: '/solutions/offline-dictation/',
+    eyebrow: 'Offline dictation',
+    title: 'Keep dictating when the internet disappears',
+    description: 'Run speech recognition and text cleanup on your Apple Silicon Mac after the required models have been downloaded.',
+    outcome: 'Reliable voice input on planes, trains, and quiet networks',
+    accent: 'green',
+  },
 ];

--- a/website/src/pages/how-it-works.astro
+++ b/website/src/pages/how-it-works.astro
@@ -44,7 +44,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Does EnviousWispr work without internet?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes. All speech recognition runs on-device using Apple Silicon and the Parakeet or WhisperKit model. Your audio never leaves your Mac. AI polish is optional and can also run fully on-device: EG-1, our own model, on any supported Mac, or Apple Intelligence on macOS 26 and later. If you bring your own OpenAI or Gemini API key, only the transcribed text (not the audio) is sent to that provider for polishing."
+        "text": "Yes. All speech recognition runs on-device using Apple Silicon and the Parakeet or WhisperKit model. Your audio never leaves your Mac. AI polish can also run on-device with EG-1, Apple Intelligence on supported systems, or a downloaded Ollama model. If you choose cloud polish, the transcript, cleanup instructions, custom words, target app name, and your account credential go directly to that provider."
       }
     },
     {
@@ -76,7 +76,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Does EnviousWispr send my voice or text anywhere?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Audio never leaves your Mac. Transcription is fully on-device. AI polish runs on-device by default through Apple Intelligence on supported Macs. If you opt into cloud polish by adding your own OpenAI or Gemini API key, only the transcribed text is sent to the provider you chose. No raw audio is ever uploaded."
+        "text": "Audio never leaves your Mac. Transcription is fully on-device. Local AI polish can keep the request there too. If you choose cloud polish, the transcript, cleanup instructions, custom words, target app name, and your account credential go directly to the provider. No raw audio is ever uploaded."
       }
     },
     {
@@ -497,7 +497,7 @@ const faqJsonLd = JSON.stringify({
       <div class="engine-card reveal" style="--i:3">
         <span class="engine-badge">Your call</span>
         <h3>Your OpenAI or Gemini key</h3>
-        <p>Prefer a cloud model? Add your own key. Only your text is sent, never audio, and we ask the provider not to keep it.</p>
+        <p>Prefer a cloud model? The transcript, cleanup instructions, custom words, target app name, and your account credential go directly to that provider. Audio never does.</p>
         <div class="engine-meta">Cloud &middot; Your own key &middot; Text only</div>
       </div>
     </div>
@@ -599,6 +599,8 @@ const faqJsonLd = JSON.stringify({
       <a href="/compare/" class="back-link">Compare with alternatives</a>
     </div>
     <nav class="how-it-works-links reveal" aria-label="Related content">
+      <a href="/solutions/ai-polish/">Compare AI polish choices</a>
+      <a href="/solutions/offline-dictation/">Set up offline dictation</a>
       <a href="/blog/getting-started-enviouswispr-under-2-minutes/">Get started in under 2 minutes</a>
       <a href="/blog/on-device-vs-cloud-dictation-privacy/">On-device vs cloud dictation</a>
       <a href="/compare/wisprflow/">Compare with WisprFlow</a>

--- a/website/src/pages/solutions/ai-polish.astro
+++ b/website/src/pages/solutions/ai-polish.astro
@@ -1,0 +1,106 @@
+---
+import SolutionLayout from '../../layouts/SolutionLayout.astro';
+
+const faqs = [
+  {
+    question: 'Does AI polish send my audio to a model provider?',
+    answer: 'No. Speech recognition always happens on your Mac. AI polish receives no microphone audio. Local providers keep the request on your Mac. A cloud provider receives the transcript, cleanup instructions, custom words, target app name, and your account credential when you choose it.',
+  },
+  {
+    question: 'Which AI polish options work on-device?',
+    answer: 'EG-1 works on every supported Apple Silicon Mac after its model download. Apple Intelligence requires macOS 26 or later and an eligible Mac. Ollama stays local only when the selected model is downloaded to your Mac. Deterministic cleanup uses no AI model.',
+  },
+  {
+    question: 'Can I use my own cloud AI account?',
+    answer: 'Yes. EnviousWispr supports bring-your-own-key polish with OpenAI, Gemini, and Claude. The request includes the transcript, cleanup instructions, custom words, target app name, and your account credential. It goes directly to the provider under its terms, without an Envious Labs relay.',
+  },
+  {
+    question: 'What happens when AI polish fails?',
+    answer: 'Your dictation is not discarded. EnviousWispr keeps the last usable result from the earlier pipeline, normally the deterministically cleaned transcript, and delivers that text. Some failures also show a plain-language notice so you can fix the selected provider.',
+  },
+];
+
+const relatedLinks = [
+  {
+    href: '/how-it-works/',
+    title: 'See the full dictation pipeline',
+    description: 'Follow audio, transcription, cleanup, polish, and paste from start to finish.',
+  },
+  {
+    href: '/blog/cloud-ai-polish-not-stored/',
+    title: 'Understand cloud polish requests',
+    description: 'See what leaves your Mac when you deliberately choose a cloud provider.',
+  },
+  {
+    href: '/blog/spoken-text-formatting-dates-numbers-emails/',
+    title: 'Cleanup without an AI model',
+    description: 'Learn how predictable formatting still runs when AI polish is off.',
+  },
+];
+
+const directAnswer = `AI polish for dictation turns a spoken transcript into cleaner written text after speech recognition is complete. In EnviousWispr, that is a choice, not one hidden processing path. Deterministic cleanup formats common numbers, dates, money, email addresses, and spoken emoji without an AI model. EG-1, Apple Intelligence, and downloaded Ollama models can polish text on your Mac. EG-1 works across the app's supported macOS 14 and later range after its model download. Apple Intelligence requires macOS 26 or later and an eligible Mac. Ollama can also point to a hosted model, so check where the selected model runs before treating it as local. OpenAI, Gemini, and Claude are bring-your-own-key cloud choices. Those requests include the transcript, cleanup instructions, custom words, target app name, and your account credential; audio never does. If polish cannot finish, EnviousWispr keeps the usable deterministically cleaned transcript instead of losing the dictation. You decide whether cleanup is predictable, local, or cloud based.`;
+---
+
+<SolutionLayout
+  title="AI Dictation Polish on Mac, Local or Cloud | EnviousWispr"
+  description="Compare deterministic cleanup, local AI polish, and bring-your-own-key cloud models for Mac dictation. Your audio always remains on your Mac device."
+  canonicalPath="/solutions/ai-polish/"
+  eyebrow="AI polish choices"
+  heading="Clean up the words. Keep control of the route."
+  intro="Start with a local transcript, then choose predictable cleanup, an on-device model, or a cloud provider you already use. The privacy boundary stays visible."
+  answerHeading="What is AI polish for dictation on Mac?"
+  directAnswer={directAnswer}
+  downloadSource="solution-ai-polish"
+  trustItems={['Audio always stays local', 'Local and cloud choices', 'Usable text survives failures']}
+  faqs={faqs}
+  relatedLinks={relatedLinks}
+>
+  <div slot="proof" class="proof-window">
+    <div class="proof-window-bar"><i></i><i></i><i></i>polish-route</div>
+    <div class="proof-body">
+      <div class="proof-row">
+        <span class="proof-row-label">Spoken transcript</span>
+        <p>Um send Maya the revised outline on Tuesday at about three thirty and ask if the second section is clear.</p>
+      </div>
+      <div class="proof-row output">
+        <span class="proof-row-label">Clean text</span>
+        <p>Send Maya the revised outline on Tuesday at 3:30 PM and ask whether the second section is clear.</p>
+      </div>
+      <div class="proof-rail" aria-hidden="true"><span>Transcript</span><span>Rules</span><span>Your model</span><span>Paste</span></div>
+    </div>
+  </div>
+
+  <section class="solution-section" aria-labelledby="polish-routes-heading">
+    <div>
+      <p class="solution-kicker">Four clear routes</p>
+      <h2 id="polish-routes-heading">Pick the amount of intelligence the text needs.</h2>
+    </div>
+    <div class="solution-card-grid">
+      <article class="solution-card"><h3>Deterministic cleanup</h3><p>Fixed rules format common numbers, dates, money, email addresses, custom words, and spoken emoji. No generative model is involved.</p></article>
+      <article class="solution-card"><h3>EG-1</h3><p>Envious Labs' dictation-polish model runs on-device after a separate model download. Its weights use the EG-1 Community Model License, not the app's GPLv3 license.</p></article>
+      <article class="solution-card"><h3>Apple Intelligence</h3><p>Apple's on-device model can polish supported languages on eligible Macs running macOS 26 or later, with no extra EnviousWispr model download.</p></article>
+      <article class="solution-card"><h3>Ollama or your cloud key</h3><p>Use a downloaded Ollama model locally, a model hosted by Ollama, or your own OpenAI, Gemini, or Claude account. The execution location is part of the choice.</p></article>
+    </div>
+  </section>
+
+  <section class="solution-section" aria-labelledby="polish-boundary-heading">
+    <div>
+      <p class="solution-kicker">The privacy boundary</p>
+      <h2 id="polish-boundary-heading">Audio never enters the polish step.</h2>
+    </div>
+    <div>
+      <p class="solution-section-lead">Speech recognition finishes on your Mac before polish begins. A local route keeps the request there. A cloud route sends the transcript, cleanup instructions, custom words, target app name, and your account credential directly to the selected provider. Envious Labs does not operate a transcription or polish relay.</p>
+      <div class="solution-callout" style="margin-top:20px"><strong>One Ollama detail worth checking</strong><p>Ollama supports both downloaded local models and hosted models. A hosted model runs on Ollama's servers, even though you selected Ollama in the app.</p></div>
+    </div>
+  </section>
+
+  <section class="solution-section" aria-labelledby="polish-failure-heading">
+    <div>
+      <p class="solution-kicker">Fail soft</p>
+      <h2 id="polish-failure-heading">A polish problem should not swallow your thought.</h2>
+    </div>
+    <div>
+      <p class="solution-section-lead">The transcript passes through predictable cleanup before model polish. If the selected model is unavailable, times out, or rejects the request, EnviousWispr keeps the last usable text and continues toward paste. A model problem can reduce cleanup quality, but it does not erase the dictation.</p>
+    </div>
+  </section>
+</SolutionLayout>

--- a/website/src/pages/solutions/index.astro
+++ b/website/src/pages/solutions/index.astro
@@ -4,7 +4,7 @@ import { solutions } from '../../data/solutions';
 
 const siteUrl = 'https://enviouswispr.com';
 const title = 'Mac Dictation Solutions for Real Work | EnviousWispr';
-const description = 'Explore a free Mac dictation workflow for developers. Turn spoken context into PR descriptions, code reviews, docs, issues, commits, and prompts locally.';
+const description = 'Find a free Mac dictation workflow for coding, private offline work, and clean AI-polished text. Compare local and cloud routes, then download free.';
 
 const collectionJsonLd = JSON.stringify({
   '@context': 'https://schema.org',
@@ -48,7 +48,7 @@ const breadcrumbJsonLd = JSON.stringify({
           <h1>Less typing.<br/><span class="rainbow-text">More finished work.</span></h1>
         </div>
         <div class="hub-intro">
-          <p>EnviousWispr is a free dictation app for Apple Silicon Macs. Start with the developer workflow and see exactly where voice fits around code.</p>
+          <p>EnviousWispr is a free dictation app for Apple Silicon Macs. Explore developer dictation, AI cleanup choices, and a fully offline workflow.</p>
           <a href="/how-it-works/">See how on-device dictation works</a>
         </div>
       </header>

--- a/website/src/pages/solutions/offline-dictation.astro
+++ b/website/src/pages/solutions/offline-dictation.astro
@@ -1,0 +1,106 @@
+---
+import SolutionLayout from '../../layouts/SolutionLayout.astro';
+
+const faqs = [
+  {
+    question: 'Does EnviousWispr work without an internet connection?',
+    answer: 'Yes, after the speech model and any local polish model you want have finished downloading. Recording, speech recognition, deterministic cleanup, and paste can all run without a network connection on an Apple Silicon Mac.',
+  },
+  {
+    question: 'Is transcription always on-device?',
+    answer: 'Yes. EnviousWispr does not offer cloud transcription. Parakeet and WhisperKit process microphone audio on your Mac whether you use no polish, local polish, or a cloud text-polish provider afterward.',
+  },
+  {
+    question: 'Which polish choices work offline?',
+    answer: 'Deterministic cleanup, EG-1 after its model download, Apple Intelligence on supported macOS 26 systems, and downloaded Ollama models can work offline. OpenAI, Gemini, Claude, and Ollama-hosted models need a network connection.',
+  },
+  {
+    question: 'How can I test offline dictation myself?',
+    answer: 'Finish all model downloads, open TextEdit, turn off Wi-Fi, and dictate a short sentence. Confirm the text appears, then repeat with your chosen local polish provider. This checks the real workflow instead of relying on a settings label.',
+  },
+];
+
+const relatedLinks = [
+  {
+    href: '/blog/macos-dictation-offline-private/',
+    title: 'How offline dictation works',
+    description: 'Read the longer guide to the local speech and cleanup pipeline.',
+  },
+  {
+    href: '/blog/on-device-vs-cloud-dictation-privacy/',
+    title: 'On-device versus cloud dictation',
+    description: 'Compare the data paths and trade-offs before choosing a workflow.',
+  },
+  {
+    href: '/solutions/ai-polish/',
+    title: 'Choose an AI polish route',
+    description: 'Separate local models, hosted models, and deterministic cleanup clearly.',
+  },
+];
+
+const directAnswer = `Offline dictation on Mac converts speech to text without sending microphone audio to an internet service. EnviousWispr records and transcribes locally with Parakeet or WhisperKit on Apple Silicon, then runs predictable cleanup and pastes the result into the active app. It works offline after the speech model has been downloaded. You can stop there, use deterministic cleanup with no AI model, or keep AI polish local with EG-1, Apple Intelligence on supported macOS 26 systems, or a downloaded Ollama model. Ollama-hosted models are different: they run on Ollama's servers and need a connection. OpenAI, Gemini, and Claude also need the internet because the transcript, cleanup instructions, custom words, target app name, and your account credential go to the provider, though audio stays local. To verify the boundary, finish your model downloads, open TextEdit, turn off Wi-Fi, and dictate a sentence. If the text appears with your selected local route, you have tested the actual offline path. EnviousWispr requires macOS 14 or later and Apple Silicon.`;
+---
+
+<SolutionLayout
+  title="Free Offline Dictation for Apple Silicon Mac | EnviousWispr"
+  description="Use free offline dictation on Apple Silicon Mac. Speech recognition runs on-device, audio stays local, and downloaded polish models work without Wi-Fi."
+  canonicalPath="/solutions/offline-dictation/"
+  eyebrow="Offline dictation"
+  heading="Your connection can drop. Your words do not have to."
+  intro="Record, transcribe, clean, and paste on your Mac after the models you need are downloaded. No transcription server and no account stand between your voice and the page."
+  answerHeading="How does offline dictation work on Mac?"
+  directAnswer={directAnswer}
+  downloadSource="solution-offline-dictation"
+  trustItems={['Transcription always on-device', 'Works after model download', 'macOS 14+ · Apple Silicon']}
+  faqs={faqs}
+  relatedLinks={relatedLinks}
+>
+  <div slot="proof" class="proof-window">
+    <div class="proof-window-bar"><i></i><i></i><i></i>offline-path</div>
+    <div class="proof-body">
+      <div class="proof-row">
+        <span class="proof-row-label">Network</span>
+        <p>Wi-Fi off. No EnviousWispr account. Speech and local models are already downloaded.</p>
+      </div>
+      <div class="proof-row output">
+        <span class="proof-row-label">TextEdit</span>
+        <p>The sentence appears in the document through the same hold, speak, release workflow.</p>
+      </div>
+      <div class="proof-rail" aria-hidden="true"><span>Voice</span><span>Local ASR</span><span>Local cleanup</span><span>Paste</span></div>
+    </div>
+  </div>
+
+  <section class="solution-section" aria-labelledby="offline-path-heading">
+    <div>
+      <p class="solution-kicker">The local path</p>
+      <h2 id="offline-path-heading">Four steps can stay on one machine.</h2>
+    </div>
+    <div class="solution-card-grid">
+      <article class="solution-card"><h3>1. Capture</h3><p>Your microphone records on the Mac. EnviousWispr does not upload audio for transcription.</p></article>
+      <article class="solution-card"><h3>2. Transcribe</h3><p>Parakeet or WhisperKit converts speech to text locally with a model downloaded to your Mac.</p></article>
+      <article class="solution-card"><h3>3. Clean</h3><p>Fixed formatting rules run locally. EG-1, supported Apple Intelligence, or a downloaded Ollama model can add local AI polish.</p></article>
+      <article class="solution-card"><h3>4. Deliver</h3><p>The usable text is copied or pasted into the app you were using, with no network round trip.</p></article>
+    </div>
+  </section>
+
+  <section class="solution-section" aria-labelledby="offline-download-heading">
+    <div>
+      <p class="solution-kicker">Prepare before going offline</p>
+      <h2 id="offline-download-heading">Models need to arrive before the network leaves.</h2>
+    </div>
+    <div>
+      <p class="solution-section-lead">The first speech model download needs an internet connection. EG-1 and local Ollama models also need to be downloaded before you rely on them offline. Once the required files are present, core dictation does not need a server.</p>
+      <div class="solution-callout" style="margin-top:20px"><strong>Hosted is not local</strong><p>An Ollama-hosted model still uses Ollama's servers. Choose a model that is downloaded to your Mac when an offline or fully local text path matters.</p></div>
+    </div>
+  </section>
+
+  <section class="solution-section" aria-labelledby="offline-test-heading">
+    <div>
+      <p class="solution-kicker">A test you can repeat</p>
+      <h2 id="offline-test-heading">Turn off Wi-Fi and use the real path.</h2>
+    </div>
+    <div>
+      <p class="solution-section-lead">Open TextEdit, disable Wi-Fi, then use your normal keybind to dictate one sentence. Confirm the text appears. If you selected local AI polish, first confirm the provider shows ready, then dictate a spoken list and check that the model formats it as a list. Filler removal alone is not proof because deterministic cleanup can remove filler without an AI model.</p>
+    </div>
+  </section>
+</SolutionLayout>


### PR DESCRIPTION
## Summary

- add `/solutions/ai-polish/`
- add `/solutions/offline-dictation/`
- extend the solutions hub and internal links for both search intents
- document local and cloud processing boundaries from the current app implementation
- retarget the existing offline article without changing its URL

## Validation

- `npm run build`
- `npm run test:solutions`
- `npm run check:help`
- Codex diff review: no actionable regressions

Stack 2 of 3 for #2326. Base: `seo/solutions-foundation-developers`. Updates #2328.

