### PR TITLE
SEO: add open-source and writer solution pages

### DIFF
--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -15,6 +15,8 @@ Last-updated: 2026-08-22
 - [Dictation for developers](https://enviouswispr.com/solutions/developers/): On-device voice input for PR descriptions, code reviews, issues, documentation, commit messages, and prompts.
 - [AI dictation polish](https://enviouswispr.com/solutions/ai-polish/): Deterministic cleanup, local AI models, and bring-your-own-key cloud polish with a clear privacy boundary.
 - [Offline dictation](https://enviouswispr.com/solutions/offline-dictation/): Local speech recognition and text cleanup for Apple Silicon Macs after required model downloads.
+- [Open source Mac dictation](https://enviouswispr.com/solutions/open-source/): GPLv3 app source, public development history, documented build path, and a separate license for EG-1 model weights.
+- [Dictation for writers](https://enviouswispr.com/solutions/writers/): Voice input for outlines, first drafts, essays, scripts, and revision notes with local transcription.
 - [Best dictation apps for Mac](https://enviouswispr.com/compare/best-dictation-apps-for-mac/): A practical 2026 guide to seven Mac dictation options, with honest picks by workflow.
 - [Compare to alternatives](https://enviouswispr.com/compare/): Index of comparison pages vs WisprFlow, Superwhisper, Apple Dictation, Dragon, MacWhisper, Otter.ai, and others.
 

--- a/website/src/content/blog/dictation-for-developers-code-reviews.md
+++ b/website/src/content/blog/dictation-for-developers-code-reviews.md
@@ -1,8 +1,8 @@
 ---
-title: "macOS Dictation for Developers: Code Reviews and PRs"
+title: "How to Dictate Code Reviews and PR Descriptions on Mac"
 description: "How developers use macOS voice dictation to write PR descriptions, code review comments, and documentation, faster and without breaking flow state."
 pubDate: 2026-03-12
-updatedDate: 2026-04-04
+updatedDate: 2026-08-22
 tags: ["developers", "dictation", "productivity", "code-review"]
 draft: false
 author: "Saurabh Vaish"
@@ -10,7 +10,7 @@ author: "Saurabh Vaish"
 
 The biggest time sink in software development isn't writing code. It's everything around the code. PR descriptions, review comments, Slack threads, postmortems, design docs, README updates. Developers often spend a surprising share of their workday writing prose, not code, and most of that prose gets typed in the cracks between implementation work, breaking flow state every time.
 
-That context-switch cost is what makes voice input valuable for developers. Hold a keybind, speak, release. Your words get transcribed on-device, cleaned up by optional AI polish, and pasted into whatever app has focus. The whole cycle takes a second or two on Apple Silicon. No cloud API, no uploaded audio.
+That context-switch cost is what makes voice input valuable for developers. Hold a keybind, speak, release. Your words get transcribed on-device, cleaned up by the local or cloud polish route you choose, and pasted into whatever app has focus. Audio is not uploaded for transcription, and cloud text polish is optional.
 
 Here's how that fits into a developer's actual day.
 
@@ -28,9 +28,9 @@ Not all developer writing sounds the same. A commit message is terse. A PR descr
 
 For most developer writing (review comments, ticket updates, README sections, Slack threads), the default polish handles the cleanup without over-formalizing or stripping your voice. You speak naturally and the output reads naturally.
 
-For more specialized output, the way you talk steers the shape, and Ollama, OpenAI, or Gemini polish turns those cues into formatting. A few patterns that work well for developer workflows:
+For more specialized output, the way you talk steers the shape, and supported local or cloud AI polish can turn those cues into formatting. A few patterns that work well for developer workflows:
 
-- Call out a list ("first... then... finally," "the changes were") and, with Ollama, OpenAI, or Gemini polish on, changelog entries or release notes come back as a clean markdown bullet list.
+- Call out a list ("first... then... finally," "the changes were") and, with a supported AI polish route on, changelog entries or release notes can come back as a clean markdown bullet list.
 - Walk a postmortem timeline in order and the polish keeps that sequence the way you narrate it.
 - Name the parts of an API doc as you speak (the parameters, what each returns) and the output lands organized.
 
@@ -74,7 +74,7 @@ This works especially well for longer review comments, the kind where you need t
 
 Technical documentation has the highest typing-to-thinking ratio of anything developers write. You know what the system does. You just need to get it into words. Dictation makes this almost trivial.
 
-For documentation, the polish step produces clean prose with proper punctuation and clear paragraphs. You talk through the architecture the way you'd explain it to a new team member, and the output lands polished and ready to commit. Walk through it in sections, and with Ollama, OpenAI, or Gemini polish on those headers and lists carry into the output as markdown.
+For documentation, the polish step can produce clean prose with proper punctuation and clear paragraphs. You talk through the architecture the way you'd explain it to a new team member, then review the output before committing it. Walk through it in sections, and a supported AI polish route can carry those headers and lists into the output as markdown.
 
 This is particularly useful for the kind of documentation that always gets skipped: the "how does this subsystem actually work" docs that everyone wishes existed but nobody wants to sit down and type out. Speaking is lower friction than typing for this kind of knowledge dump, and the difference is enough to make it actually happen.
 
@@ -82,9 +82,9 @@ This is particularly useful for the kind of documentation that always gets skipp
 
 Developer conversations are sensitive. PR descriptions mention internal architecture. Code review comments reference proprietary logic. Slack threads discuss unreleased features, customer issues, and security concerns.
 
-EnviousWispr processes everything on-device. Your audio is transcribed locally using either Parakeet or WhisperKit, both running natively via Core ML. Post-processing runs through your local LLM. From microphone to clipboard, nothing leaves your Mac unless you explicitly configure an external API.
+EnviousWispr always transcribes audio on-device using Parakeet or WhisperKit. Deterministic cleanup, EG-1, supported Apple Intelligence, and downloaded Ollama models can keep the text path local too. OpenAI, Gemini, Claude, and Ollama-hosted polish send the transcript and supporting context to the provider you select.
 
-This isn't a privacy policy; it's architecture. There's no server to send data to. For a detailed breakdown of how on-device processing differs from cloud alternatives, see [On-Device vs Cloud Dictation: What Stays Private](/blog/macos-dictation-offline-private/). The processing happens on your hardware, using models that run on your Apple Silicon Neural Engine.
+The choice is explicit: audio and transcription stay on your Mac, while text leaves only when you select a cloud polish route. For a detailed breakdown, see [On-Device vs Cloud Dictation: What Stays Private](/blog/macos-dictation-offline-private/).
 
 For developers working on proprietary codebases, under NDA, or at companies with strict data handling policies, this is the difference between "tool I can actually use at work" and "tool that's blocked by security review."
 
@@ -92,11 +92,13 @@ For developers working on proprietary codebases, under NDA, or at companies with
 
 [Download EnviousWispr free](/#download) or browse the source [on GitHub](https://github.com/saurabhav88/EnviousWispr). On first launch, grant microphone and accessibility permissions. The speech model downloads automatically.
 
+See the focused guide to [dictation for developers on Mac](/solutions/developers/) for the workflow, privacy choices, and setup in one place.
+
 To set up for developer use:
 
 1. **Pick your keybind.** Choose something that doesn't collide with your IDE shortcuts.
 2. **Leave polish on.** The polish handles most developer writing (review comments, ticket updates, README sections) without over-formalizing.
-3. **Speak the structure for the niches.** API docs, changelog entries, structured postmortems: name the sections and lists out loud, and with Ollama, OpenAI, or Gemini polish on the output comes back formatted.
+3. **Speak the structure for the niches.** API docs, changelog entries, structured postmortems: name the sections and lists out loud, and a supported AI polish route can format the output.
 
 Hold the keybind in GitHub, talk through your PR description, and the polished text lands ready to paste. Move to Slack and the same workflow handles a quick reply.
 

--- a/website/src/content/blog/dictation-for-writers-skip-blank-page.md
+++ b/website/src/content/blog/dictation-for-writers-skip-blank-page.md
@@ -1,8 +1,8 @@
 ---
-title: "macOS Dictation for Writers: Skip the Blank Page"
+title: "How to Dictate a First Draft on Mac Without Losing Your Voice"
 description: "Voice writing bypasses the blank page entirely. Learn how dictation fits a writer's workflow and why speaking your first draft changes everything."
 pubDate: 2026-03-14
-updatedDate: 2026-04-04
+updatedDate: 2026-08-22
 tags: ["writing", "dictation", "workflow", "creativity"]
 draft: false
 author: "Saurabh Vaish"
@@ -36,15 +36,15 @@ The shift is psychological as much as practical. When you dictate, you give your
 
 Most dictation tools were built for business users dictating emails and memos. Writers need something different. You need output that sounds like writing, not like a transcribed meeting. And you need it to land in your writing app, formatted the way you work.
 
-EnviousWispr handles this with on-device LLM post-processing tuned specifically for writers.
+EnviousWispr handles this with deterministic cleanup plus optional local or cloud AI polish.
 
 ### Polish That Keeps Your Voice
 
-After EnviousWispr transcribes your speech, it runs the text through a local LLM for post-processing. The default polish removes filler words, fixes punctuation, and tightens structure without flattening your phrasing into corporate prose. The result is a clean first draft that sounds like you, not like a robot or a memo.
+After EnviousWispr transcribes your speech, deterministic cleanup can remove filler and fix punctuation locally. Optional AI polish can tighten structure, but model edits can also change phrasing. Treat the result as a first draft and compare it with what you intended to say.
 
-That processing can run fully on-device with Apple Intelligence, EG-1, or Ollama, without sending your words anywhere.
+That processing can stay on-device with deterministic cleanup, EG-1, supported Apple Intelligence, or a downloaded Ollama model. OpenAI, Gemini, Claude, and Ollama-hosted polish require a connection and send text to that provider.
 
-For writers who want their voice preserved, the polish is built to edit, not reword. It keeps your meaning, tone, and phrasing intact, so your em dashes, your parentheticals, and your intentional fragments survive the cleanup. Keep a passage as loose stream of consciousness and the polish leaves your flow alone; the output always sounds like you, not a template.
+For writers who want their voice preserved, polish should be a starting point rather than the final editor. Read every passage against your meaning, tone, and phrasing. Restore intentional fragments or rhythms when the model makes a choice you would not.
 
 For a step-by-step look at how this works in a real writing session, see [Voice to Prose: A Realistic Writing Workflow](/blog/voice-to-prose-writing-workflow/).
 
@@ -70,7 +70,7 @@ Don't try to "write out loud." Instead, imagine you're explaining the piece to a
 
 ### Don't Correct Yourself Mid-Stream
 
-If you stumble or say something awkward, keep going. The post-processing step will clean up filler words and false starts. Stopping to correct yourself breaks the flow, which is the whole thing you're trying to protect.
+If you stumble or say something awkward, keep going. Cleanup can remove filler words and some false starts, and you can fix anything it misses during the edit. Stopping to correct every sentence breaks the flow you're trying to protect.
 
 ### Pace Around
 
@@ -82,7 +82,7 @@ Instead of aiming for 500 words, aim for 10 minutes of continuous dictation. You
 
 ### Use Hands-Free Mode for Long Sessions
 
-For anything longer than a quick paragraph, use hands-free mode. Double-press your keybind to lock recording instead of holding it the entire time. You can pace, pause to think, and keep going without worrying about key presses. It turns your MacBook Air or Mac Mini into a dictation station.
+For anything longer than a quick paragraph, use a hands-free recording route. In Push-to-Talk mode, double-press your keybind to start and press once to finish. In Toggle mode, press once to start and once to finish. You can pace, pause to think, and keep going without holding a key.
 
 ### Edit in a Separate Pass
 
@@ -105,9 +105,11 @@ The draft won't be perfect. That's the point. It doesn't need to be perfect; it 
 
 If you're dictating early drafts, unpublished ideas, or sensitive client work, where that audio goes matters. Most cloud dictation tools send your recordings to external servers for processing. That means your unfinished novel, your half-formed article, your notes about a source. All of it passes through someone else's infrastructure.
 
-EnviousWispr runs entirely on your Mac. Transcription happens locally using on-device speech recognition via Core ML. Post-processing can run fully on-device with Apple Intelligence, EG-1, or Ollama. Your recordings never leave your device. For writers working on anything unpublished or confidential, that's not a minor detail.
+EnviousWispr always transcribes on your Mac. Deterministic cleanup, EG-1, supported Apple Intelligence, and downloaded Ollama models can keep manuscript text there too. If you choose OpenAI, Gemini, Claude, or Ollama-hosted polish, the transcript and supporting context go to that provider. Audio remains local in either case.
 
 You can read more about [how the pipeline works](/how-it-works/), from microphone input through transcription and AI cleanup to final output. For a detailed comparison of on-device and cloud-based dictation, see [On-Device vs Cloud Dictation: What Stays Private](/blog/macos-dictation-offline-private/).
+
+See the focused guide to [dictation for writers on Mac](/solutions/writers/) for the first-draft workflow, hands-free controls, and privacy choices in one place.
 
 ## Related Posts
 
@@ -117,7 +119,7 @@ You can read more about [how the pipeline works](/how-it-works/), from microphon
 
 ## Getting Started
 
-EnviousWispr is free. You don't need an account, a subscription, or an API key.
+EnviousWispr is free. Core dictation and local cleanup do not need an EnviousWispr account, a subscription, or a cloud API key.
 
 [Download EnviousWispr free](/#download) or browse the source [on GitHub](https://github.com/saurabhav88/EnviousWispr). Install it, grant microphone and accessibility permissions, and you're dictating within a few minutes. The speech model downloads automatically. Try dictating your next first draft instead of typing it, and let the polish keep it in your voice.
 

--- a/website/src/content/blog/macos-dictation-offline-private.md
+++ b/website/src/content/blog/macos-dictation-offline-private.md
@@ -159,6 +159,8 @@ The core promise of offline, private dictation is simple: local transcription wo
 
 For people who rely on voice input as their primary way of writing, those aren't bonus features. They're baseline requirements. EnviousWispr is built around them.
 
+See the focused guide to [free offline dictation for Mac](/solutions/offline-dictation/) for the local data path, model-download checklist, and a Wi-Fi-off test you can repeat.
+
 ## Related Posts
 
 - [Voice Input for RSI: A Keyboard-Free Workflow](/blog/voice-input-rsi-keyboard-free-workflow/). A practical guide for people whose hands need a break from typing.

--- a/website/src/data/solutions.ts
+++ b/website/src/data/solutions.ts
@@ -32,4 +32,20 @@ export const solutions: SolutionCard[] = [
     outcome: 'Reliable voice input on planes, trains, and quiet networks',
     accent: 'green',
   },
+  {
+    href: '/solutions/open-source/',
+    eyebrow: 'Open source',
+    title: 'Inspect the app behind the privacy claims',
+    description: 'Read the GPLv3 app source, review the local processing path, build it yourself, or follow active development on GitHub.',
+    outcome: 'Trust based on code you can inspect',
+    accent: 'orange',
+  },
+  {
+    href: '/solutions/writers/',
+    eyebrow: 'For writers',
+    title: 'Speak the first draft before the editor wakes up',
+    description: 'Turn outlines, rough prose, essays, and scripts into editable text while keeping the original thought and your revision pass separate.',
+    outcome: 'More raw material and less time facing a blank page',
+    accent: 'cyan',
+  },
 ];

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -226,7 +226,7 @@ const jsonLdFaq = JSON.stringify({
         <span class="trust-item"><span class="trust-dot" aria-hidden="true"></span>Free download</span>
         <span class="trust-item"><span class="trust-dot" aria-hidden="true"></span>No account needed</span>
         <span class="trust-item"><span class="trust-dot" aria-hidden="true"></span>Works offline</span>
-        <a href="https://github.com/saurabhav88/EnviousWispr" target="_blank" rel="noopener" class="trust-item trust-link"><span class="trust-dot" aria-hidden="true"></span>GPLv3 open source, view the code</a>
+        <a href="/solutions/open-source/" class="trust-item trust-link"><span class="trust-dot" aria-hidden="true"></span>GPLv3 open source, inspect the app</a>
       </div>
 
       <p class="hero-brew reveal" style="--i:4.5">Prefer the terminal? <code>brew install --cask saurabhav88/tap/enviouswispr</code></p>
@@ -309,11 +309,11 @@ const jsonLdFaq = JSON.stringify({
           <span class="uc-cta">See developer dictation</span>
         </a>
 
-        <a href="/blog/dictation-for-writers-skip-blank-page/" class="uc-card reveal" style="--i:1">
+        <a href="/solutions/writers/" class="uc-card reveal" style="--i:1">
           <span class="uc-badge"><span class="uc-badge-icon" aria-hidden="true">✍️</span>For Writers</span>
           <h3 class="uc-headline">Draft at the speed of thought.</h3>
           <p class="uc-tasks">First drafts, outlines, blog posts, essays. Beat the blank page by talking it out.</p>
-          <span class="uc-cta">Read the workflow</span>
+          <span class="uc-cta">See writer dictation</span>
         </a>
 
         <a href="/blog/meeting-notes-polished-summaries/" class="uc-card tint-purple reveal" style="--i:2">

--- a/website/src/pages/solutions/index.astro
+++ b/website/src/pages/solutions/index.astro
@@ -4,7 +4,7 @@ import { solutions } from '../../data/solutions';
 
 const siteUrl = 'https://enviouswispr.com';
 const title = 'Mac Dictation Solutions for Real Work | EnviousWispr';
-const description = 'Find a free Mac dictation workflow for coding, private offline work, and clean AI-polished text. Compare local and cloud routes, then download free.';
+const description = 'Find a free Mac dictation workflow for coding, writing, private offline work, and clean AI-polished text. Explore EnviousWispr and download free.';
 
 const collectionJsonLd = JSON.stringify({
   '@context': 'https://schema.org',
@@ -48,7 +48,7 @@ const breadcrumbJsonLd = JSON.stringify({
           <h1>Less typing.<br/><span class="rainbow-text">More finished work.</span></h1>
         </div>
         <div class="hub-intro">
-          <p>EnviousWispr is a free dictation app for Apple Silicon Macs. Explore developer dictation, AI cleanup choices, and a fully offline workflow.</p>
+          <p>EnviousWispr is a free dictation app for Apple Silicon Macs. Choose the workflow closest to the work you do, then see exactly where voice fits.</p>
           <a href="/how-it-works/">See how on-device dictation works</a>
         </div>
       </header>

--- a/website/src/pages/solutions/open-source.astro
+++ b/website/src/pages/solutions/open-source.astro
@@ -1,0 +1,108 @@
+---
+import SolutionLayout from '../../layouts/SolutionLayout.astro';
+
+const repoUrl = 'https://github.com/saurabhav88/EnviousWispr';
+
+const faqs = [
+  {
+    question: 'Is EnviousWispr open source?',
+    answer: 'Yes. The app source is published on GitHub under the GNU General Public License version 3. You can read it, build it, modify it, and redistribute covered code under the terms of that license.',
+  },
+  {
+    question: 'Is the EG-1 model open source too?',
+    answer: 'No. EG-1 model weights are distributed separately under the EG-1 Community Model License. The app code is GPLv3, but that license does not apply to the EG-1 weights. The separate model license is included in the repository.',
+  },
+  {
+    question: 'Can I build the Mac app from source?',
+    answer: 'Yes. Swift Package Manager can compile the packages. The runnable app bundle uses the Xcode build engine through Tuist. The repository documents the development and release commands, including the additional tools needed for a distributable build.',
+  },
+  {
+    question: 'Does open source guarantee that the app is secure?',
+    answer: 'No. Public code makes independent inspection and testing possible, but it is not a security guarantee. Review the source, release history, permissions, and network behavior according to the risk of the material you plan to dictate.',
+  },
+];
+
+const relatedLinks = [
+  {
+    href: repoUrl,
+    title: 'Read the repository',
+    description: 'Inspect the Swift source, issue tracker, releases, build scripts, and licenses on GitHub.',
+  },
+  {
+    href: '/help/source-code-and-contributing/',
+    title: 'Source and contribution guide',
+    description: 'Find the project links and the supported way to report an issue or contribute.',
+  },
+  {
+    href: '/solutions/offline-dictation/',
+    title: 'Test the local data path',
+    description: 'Use an offline workflow to verify how speech recognition behaves without a network.',
+  },
+];
+
+const directAnswer = `An open source dictation app publishes the code that records, transcribes, cleans, and delivers speech as text, so people can inspect how its claims are implemented. EnviousWispr's Mac app source is available on GitHub under GPLv3. You can read the Swift packages, follow issues and releases, compile the packages with Swift Package Manager, or assemble the runnable app through the documented Xcode and Tuist path. That visibility makes privacy and reliability claims testable, but it does not guarantee security or eliminate the need to review permissions and network behavior. The license boundary also matters. GPLv3 covers the app code. EG-1, Envious Labs' downloadable dictation-polish model, has a separate Community Model License and its weights are not open source. Other bundled dependencies and speech models retain their own licenses, listed in the repository notices. If you prefer a signed build, the same repository publishes releases. If you prefer direct inspection, the source, build scripts, release history, model license, and issue tracker are public.`;
+---
+
+<SolutionLayout
+  title="Free Open Source Dictation App for Mac | EnviousWispr"
+  description="Inspect the GPLv3 source for a free Mac dictation app, follow development on GitHub, or build it yourself. EG-1 model weights use a separate license."
+  canonicalPath="/solutions/open-source/"
+  eyebrow="Open source"
+  heading="Do not stop at the privacy promise. Read the implementation."
+  intro="The app source, build path, issue history, and releases are public. Inspect the local speech pipeline yourself and keep the app license separate from the EG-1 model license."
+  answerHeading="What is an open source dictation app for Mac?"
+  directAnswer={directAnswer}
+  downloadSource="solution-open-source"
+  trustItems={['App source under GPLv3', 'Public issues and releases', 'Separate EG-1 model license']}
+  faqs={faqs}
+  relatedLinks={relatedLinks}
+>
+  <div slot="proof" class="proof-window">
+    <div class="proof-window-bar"><i></i><i></i><i></i>enviouswispr</div>
+    <div class="proof-body">
+      <div class="proof-row">
+        <span class="proof-row-label">App code · GPLv3</span>
+        <p>Sources / Tests / scripts / Package.swift / Project.swift / LICENSE</p>
+      </div>
+      <div class="proof-row output">
+        <span class="proof-row-label">Separate model terms</span>
+        <p>EG-1-MODEL-LICENSE.txt keeps the downloadable model-weight boundary explicit.</p>
+      </div>
+      <div class="proof-rail" aria-hidden="true"><span>Inspect</span><span>Build</span><span>Test</span><span>Contribute</span></div>
+    </div>
+  </div>
+
+  <section class="solution-section" aria-labelledby="source-visible-heading">
+    <div>
+      <p class="solution-kicker">What is visible</p>
+      <h2 id="source-visible-heading">The useful evidence lives deeper than a badge.</h2>
+    </div>
+    <div class="solution-card-grid">
+      <article class="solution-card"><h3>Processing code</h3><p>Trace microphone capture, on-device speech engines, deterministic cleanup, model polish, and paste behavior through the source packages.</p></article>
+      <article class="solution-card"><h3>Tests and build scripts</h3><p>Read the automated coverage and the commands used to compile packages, assemble the app, and produce a release build.</p></article>
+      <article class="solution-card"><h3>Issues and pull requests</h3><p>See active defects, product decisions, proposed fixes, and the history behind reliability work.</p></article>
+      <article class="solution-card"><h3>Licenses and notices</h3><p>Review GPLv3 for the app, separate EG-1 terms for model weights, and third-party notices for dependencies.</p></article>
+    </div>
+  </section>
+
+  <section class="solution-section" aria-labelledby="source-build-heading">
+    <div>
+      <p class="solution-kicker">Build path</p>
+      <h2 id="source-build-heading">Compile the packages or assemble the Mac app.</h2>
+    </div>
+    <div>
+      <p class="solution-section-lead"><code>swift build</code> compiles the Swift packages after dependencies resolve. The runnable app bundle is assembled with the Xcode build engine through Tuist. The repository's development script creates a local app build, while the release script adds the packaging path for a distributable DMG.</p>
+      <div class="solution-callout" style="margin-top:20px"><strong>A public repository is evidence, not a guarantee</strong><p>Open source lets you inspect and test the implementation. It does not promise that every defect is known or that the software is appropriate for every security policy.</p></div>
+    </div>
+  </section>
+
+  <section class="solution-section" aria-labelledby="source-license-heading">
+    <div>
+      <p class="solution-kicker">License boundary</p>
+      <h2 id="source-license-heading">The app and EG-1 are not licensed the same way.</h2>
+    </div>
+    <div>
+      <p class="solution-section-lead">EnviousWispr's app code is GPLv3. EG-1 model weights are a separate artifact under the EG-1 Community Model License, which permits specific personal, educational, research, and evaluation uses and includes restrictions. Read both files before redistributing code or using the model outside the published app.</p>
+    </div>
+  </section>
+</SolutionLayout>

--- a/website/src/pages/solutions/writers.astro
+++ b/website/src/pages/solutions/writers.astro
@@ -1,0 +1,106 @@
+---
+import SolutionLayout from '../../layouts/SolutionLayout.astro';
+
+const faqs = [
+  {
+    question: 'Is dictation useful for writing a first draft?',
+    answer: 'Yes. Dictation can separate idea generation from line editing. Speak an outline, scene, essay section, or script into your writing app, then revise the resulting text with the same judgment you would use on a typed first draft.',
+  },
+  {
+    question: 'Will AI polish preserve my writing voice?',
+    answer: 'Polish is designed to clean filler, punctuation, and structure while retaining meaning, but generated edits can still change phrasing. Treat the result as a draft, compare it with what you intended, and revise deliberately before publication.',
+  },
+  {
+    question: 'Can writers dictate without holding a key?',
+    answer: 'Yes. In Push-to-Talk mode, double-press the configured keybind to start a hands-free recording, then press once to finish. In Toggle mode, press once to start and once to finish. Either route lets you dictate a longer passage without holding a key.',
+  },
+  {
+    question: 'Does my unpublished manuscript stay private?',
+    answer: 'Audio and speech recognition stay on your Mac. Local cleanup can keep the polish request there too. If you choose cloud polish, the transcript, instructions, custom words, target app name, and your account credential go to that provider under its terms.',
+  },
+];
+
+const relatedLinks = [
+  {
+    href: '/blog/dictation-for-writers-skip-blank-page/',
+    title: 'Skip the blank page',
+    description: 'A practical guide to moving from an empty document to editable material by speaking.',
+  },
+  {
+    href: '/blog/voice-to-prose-writing-workflow/',
+    title: 'Build a voice-to-prose workflow',
+    description: 'See an honest first-draft process with examples, limits, and revision steps.',
+  },
+  {
+    href: '/blog/dictate-first-drafts-sound-like-you/',
+    title: 'Keep the draft in your voice',
+    description: 'Learn how to review cleanup without handing creative decisions to the model.',
+  },
+];
+
+const directAnswer = `Dictation for writers on Mac turns spoken ideas into editable text before sentence-level revision takes over. EnviousWispr records your voice, transcribes it on your Apple Silicon Mac, runs the cleanup route you choose, and pastes the result into a compatible text field. It can help with outlines, first drafts, essays, blog posts, scripts, scene notes, and long passages through hands-free mode. The value is not automatic publication-ready prose. It is getting material onto the page so editorial work can begin. Deterministic cleanup handles predictable formatting, while local or cloud AI polish can remove filler and improve structure. Model edits can still alter phrasing, so compare the result with your intention and revise it. Audio and speech recognition stay on the Mac. Local polish can keep manuscript text there too. With cloud polish, the transcript, instructions, custom words, target app name, and your account credential go to the selected provider under its terms. EnviousWispr is free and requires macOS 14 or later on Apple Silicon.`;
+---
+
+<SolutionLayout
+  title="Free Dictation for Writers and First Drafts | EnviousWispr"
+  description="Dictate outlines, essays, scripts, and first drafts on Mac. EnviousWispr keeps audio on-device, supports hands-free writing, and gives you text to edit."
+  canonicalPath="/solutions/writers/"
+  eyebrow="For writers"
+  heading="Get the rough draft moving. Save judgment for the edit."
+  intro="Speak the outline, paragraph, scene, or script while the idea is alive. Let the words land in your writing app, then shape them with a writer's eye."
+  answerHeading="How does dictation help writers on Mac?"
+  directAnswer={directAnswer}
+  downloadSource="solution-writers"
+  trustItems={['Audio stays on your Mac', 'Hands-free for long passages', 'Your edit remains the final say']}
+  faqs={faqs}
+  relatedLinks={relatedLinks}
+>
+  <div slot="proof" class="proof-window">
+    <div class="proof-window-bar"><i></i><i></i><i></i>first-draft.txt</div>
+    <div class="proof-body">
+      <div class="proof-row">
+        <span class="proof-row-label">Spoken idea</span>
+        <p>I keep thinking the empty train station should feel familiar before the character realizes every clock has stopped.</p>
+      </div>
+      <div class="proof-row output">
+        <span class="proof-row-label">Editable draft</span>
+        <p>The empty station felt familiar at first. Then she noticed that every clock had stopped.</p>
+      </div>
+      <div class="proof-rail" aria-hidden="true"><span>Idea</span><span>Local ASR</span><span>Draft</span><span>Your edit</span></div>
+    </div>
+  </div>
+
+  <section class="solution-section" aria-labelledby="writer-work-heading">
+    <div>
+      <p class="solution-kicker">Where voice fits</p>
+      <h2 id="writer-work-heading">Generate material first. Make it good second.</h2>
+    </div>
+    <div class="solution-card-grid">
+      <article class="solution-card"><h3>Outlines</h3><p>Talk through the argument, sequence, or scene order, then turn the useful beats into a structure you can see.</p></article>
+      <article class="solution-card"><h3>First drafts</h3><p>Move past the empty document with paragraphs that already contain your core idea, examples, and natural rhythm.</p></article>
+      <article class="solution-card"><h3>Scripts and dialogue</h3><p>Speak conversational passages aloud and hear whether the line works before refining it on the page.</p></article>
+      <article class="solution-card"><h3>Revision notes</h3><p>Capture what a section needs while reading it, without interrupting the editorial pass to type every observation.</p></article>
+    </div>
+  </section>
+
+  <section class="solution-section" aria-labelledby="writer-voice-heading">
+    <div>
+      <p class="solution-kicker">Keep authorship visible</p>
+      <h2 id="writer-voice-heading">Polish can help. It should not get the last word.</h2>
+    </div>
+    <div>
+      <p class="solution-section-lead">Cleanup can remove filler, fix punctuation, and give a rambling thought a readable shape. It can also choose a word or rhythm you would not. Treat polished output as draft material, read it against what you meant, and keep the final phrasing yours.</p>
+      <div class="solution-callout" style="margin-top:20px"><strong>Hands-free does not mean hands-off</strong><p>In Push-to-Talk mode, double-press to start a longer passage without holding a key. In Toggle mode, press once to start and once to finish. When the text lands, edit it with the attention the piece deserves.</p></div>
+    </div>
+  </section>
+
+  <section class="solution-section" aria-labelledby="writer-privacy-heading">
+    <div>
+      <p class="solution-kicker">Unpublished stays local when you choose local</p>
+      <h2 id="writer-privacy-heading">Know where the manuscript text goes.</h2>
+    </div>
+    <div>
+      <p class="solution-section-lead">Audio and transcription remain on your Mac. Deterministic cleanup, EG-1, supported Apple Intelligence, and downloaded Ollama models can keep text polish there too. If you select cloud polish, the transcript, cleanup instructions, custom words, target app name, and your account credential go directly to that provider.</p>
+    </div>
+  </section>
+</SolutionLayout>


### PR DESCRIPTION
## Summary

- add `/solutions/open-source/`
- add `/solutions/writers/`
- complete the five-page solutions hub and final cross-linking
- retarget developer and writer articles while preserving their URLs
- update article modification dates so visible and structured metadata reflect the changes

## Validation

- `npm run build`
- `npm run test:solutions`
- `npm run check:help`
- desktop and mobile browser review of all six solution routes
- Codex diff review: initial metadata finding fixed, final review found no actionable defects

Stack 3 of 3 for #2326. Base: `seo/solutions-ai-polish-offline`. Updates #2329.

