### PR TITLE
feat(website): repaint the solutions hub and shared workflow template

### DIFF
--- a/website/scripts/check-solutions.mjs
+++ b/website/scripts/check-solutions.mjs
@@ -54,12 +54,23 @@ export function validateSolutionDocument({ html, route, kind, knownRoutes }) {
     if (!matches(html, /href="[^"]*EnviousWispr\.dmg"/)) errors.push(`${route}: missing direct download action`);
     if (sources.length < 2) errors.push(`${route}: expected distinct hero and bottom download sources`);
 
+    // The answer prose is rendered as a lead sentence plus balanced columns, so its word
+    // count is the SUM of the paragraphs inside [data-answer-prose] rather than any single
+    // one. Scoping to that container excludes the block's label and heading. Fail closed:
+    // a missing container is a broken template, not a zero-word answer.
     const answerBlock = html.match(/<section\b[^>]*data-answer-block[^>]*>([\s\S]*?)<\/section>/i)?.[1] ?? '';
-    const answerParagraphs = [...answerBlock.matchAll(/<p(?:\s[^>]*)?>([\s\S]*?)<\/p>/gi)];
-    const answerParagraph = answerParagraphs.at(-1)?.[1] ?? '';
-    const answerWords = wordCount(answerParagraph);
-    if (answerWords < 134 || answerWords > 167) {
-      errors.push(`${route}: direct answer has ${answerWords} words, expected 134 to 167`);
+    const answerProse = answerBlock.match(/<div\b[^>]*data-answer-prose[^>]*>([\s\S]*)$/i)?.[1] ?? null;
+    if (answerProse === null) {
+      errors.push(`${route}: answer block has no [data-answer-prose] container`);
+    } else {
+      const answerParagraphs = [...answerProse.matchAll(/<p(?:\s[^>]*)?>([\s\S]*?)<\/p>/gi)];
+      const answerWords = answerParagraphs.reduce((total, match) => total + wordCount(match[1]), 0);
+      if (answerParagraphs.length < 2) {
+        errors.push(`${route}: direct answer is ${answerParagraphs.length} paragraph(s), expected it to be broken up`);
+      }
+      if (answerWords < 134 || answerWords > 167) {
+        errors.push(`${route}: direct answer has ${answerWords} words, expected 134 to 167`);
+      }
     }
   }
 

--- a/website/scripts/check-solutions.test.mjs
+++ b/website/scripts/check-solutions.test.mjs
@@ -2,13 +2,25 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { validateSolutionCluster } from './check-solutions.mjs';
 
-const answer = Array.from({ length: 140 }, (_, index) => `word${index + 1}`).join(' ');
+function words(count, offset = 0) {
+  return Array.from({ length: count }, (_, index) => `word${index + 1 + offset}`).join(' ');
+}
 
-function page({ route = '/solutions/developers/', title = 'Free Dictation for Developers on Mac | EnviousWispr', description = 'Dictate pull requests, reviews, documentation, and prompts on Mac with free, private, on-device voice input designed for technical vocabulary every day.', source = 'solution-developers', body = answer, target = '/solutions/' } = {}) {
+// The shipped layout splits the answer into a lead sentence plus balanced columns, so the
+// default fixture is multi-paragraph and the checked count is their SUM.
+const answerParagraphs = [words(20), words(60, 20), words(60, 80)];
+
+function prose(paragraphs) {
+  return paragraphs === null
+    ? '<p>No prose container</p>'
+    : `<div data-answer-prose>${paragraphs.map((text) => `<p>${text}</p>`).join('')}</div>`;
+}
+
+function page({ route = '/solutions/developers/', title = 'Free Dictation for Developers on Mac | EnviousWispr', description = 'Dictate pull requests, reviews, documentation, and prompts on Mac with free, private, on-device voice input designed for technical vocabulary every day.', source = 'solution-developers', body = answerParagraphs, target = '/solutions/' } = {}) {
   return {
     route,
     kind: 'landing',
-    html: `<!doctype html><html><head><title>${title}</title><meta name="description" content="${description}"><link rel="canonical" href="https://enviouswispr.com${route}"><script type="application/ld+json">{"@type":"WebPage"}</script><script type="application/ld+json">{"@type":"BreadcrumbList"}</script></head><body><h1>One heading</h1><a href="${target}">Solutions</a><a href="https://example.com/EnviousWispr.dmg" data-download-source="${source}">Download</a><section data-answer-block><p>Label</p><h2>Answer</h2><p>${body}</p></section><details><summary>Question</summary><p>Answer</p></details><a href="https://example.com/EnviousWispr.dmg" data-download-source="${source}-bottom">Download</a></body></html>`,
+    html: `<!doctype html><html><head><title>${title}</title><meta name="description" content="${description}"><link rel="canonical" href="https://enviouswispr.com${route}"><script type="application/ld+json">{"@type":"WebPage"}</script><script type="application/ld+json">{"@type":"BreadcrumbList"}</script></head><body><h1>One heading</h1><a href="${target}">Solutions</a><a href="https://example.com/EnviousWispr.dmg" data-download-source="${source}">Download</a><section data-answer-block><p>Label</p><h2>Answer</h2>${prose(body)}</section><details><summary>Question</summary><p>Answer</p></details><a href="https://example.com/EnviousWispr.dmg" data-download-source="${source}-bottom">Download</a></body></html>`,
   };
 }
 
@@ -30,9 +42,29 @@ test('accepts a complete hub and landing page', () => {
 });
 
 test('rejects a direct answer outside the extraction window', () => {
-  const documents = [hub(), page({ body: 'too short' })];
+  const documents = [hub(), page({ body: ['too short', 'still short'] })];
   const errors = validateSolutionCluster({ documents, sitemapXml: sitemap(...documents.map((item) => item.route)) });
-  assert.ok(errors.some((error) => error.includes('direct answer has 2 words')));
+  assert.ok(errors.some((error) => error.includes('direct answer has 4 words')));
+});
+
+test('counts every answer paragraph, not just the last one', () => {
+  // The last paragraph alone is 60 words, well under the floor. Only summing clears it,
+  // so this fails against a checker that reads a single paragraph.
+  const documents = [hub(), page()];
+  const errors = validateSolutionCluster({ documents, sitemapXml: sitemap(...documents.map((item) => item.route)) });
+  assert.deepEqual(errors.filter((error) => error.includes('direct answer')), []);
+});
+
+test('rejects an answer that was never broken up', () => {
+  const documents = [hub(), page({ body: [words(140)] })];
+  const errors = validateSolutionCluster({ documents, sitemapXml: sitemap(...documents.map((item) => item.route)) });
+  assert.ok(errors.some((error) => error.includes('direct answer is 1 paragraph(s)')));
+});
+
+test('rejects an answer block with no prose container', () => {
+  const documents = [hub(), page({ body: null })];
+  const errors = validateSolutionCluster({ documents, sitemapXml: sitemap(...documents.map((item) => item.route)) });
+  assert.ok(errors.some((error) => error.includes('no [data-answer-prose] container')));
 });
 
 test('rejects a solution link with no built route', () => {

--- a/website/src/data/solutions.ts
+++ b/website/src/data/solutions.ts
@@ -1,3 +1,5 @@
+export type SolutionIcon = 'code' | 'polish' | 'offline' | 'source' | 'draft';
+
 export interface SolutionCard {
   href: string;
   eyebrow: string;
@@ -5,6 +7,10 @@ export interface SolutionCard {
   description: string;
   outcome: string;
   accent: 'blue' | 'violet' | 'green' | 'orange' | 'cyan';
+  icon: SolutionIcon;
+  /** The featured card leads the hub grid at full width with a product panel. At most one;
+   *  the hub page throws at build time if a second is added. */
+  featured?: boolean;
 }
 
 export const solutions: SolutionCard[] = [
@@ -15,6 +21,8 @@ export const solutions: SolutionCard[] = [
     description: 'Turn spoken context into PR descriptions, review comments, issue notes, and technical documentation without sending your audio away.',
     outcome: 'Less typing between thinking and shipping',
     accent: 'blue',
+    icon: 'code',
+    featured: true,
   },
   {
     href: '/solutions/ai-polish/',
@@ -23,6 +31,7 @@ export const solutions: SolutionCard[] = [
     description: 'Compare deterministic cleanup, local AI models, and bring-your-own-key cloud polish without blurring their privacy boundaries.',
     outcome: 'The cleanup you want with the boundary you choose',
     accent: 'violet',
+    icon: 'polish',
   },
   {
     href: '/solutions/offline-dictation/',
@@ -31,6 +40,7 @@ export const solutions: SolutionCard[] = [
     description: 'Run speech recognition and text cleanup on your Apple Silicon Mac after the required models have been downloaded.',
     outcome: 'Reliable voice input on planes, trains, and quiet networks',
     accent: 'green',
+    icon: 'offline',
   },
   {
     href: '/solutions/open-source/',
@@ -39,6 +49,7 @@ export const solutions: SolutionCard[] = [
     description: 'Read the GPLv3 app source, review the local processing path, build it yourself, or follow active development on GitHub.',
     outcome: 'Trust based on code you can inspect',
     accent: 'orange',
+    icon: 'source',
   },
   {
     href: '/solutions/writers/',
@@ -47,5 +58,6 @@ export const solutions: SolutionCard[] = [
     description: 'Turn outlines, rough prose, essays, and scripts into editable text while keeping the original thought and your revision pass separate.',
     outcome: 'More raw material and less time facing a blank page',
     accent: 'cyan',
+    icon: 'draft',
   },
 ];

--- a/website/src/layouts/SolutionLayout.astro
+++ b/website/src/layouts/SolutionLayout.astro
@@ -46,6 +46,38 @@ const siteUrl = 'https://enviouswispr.com';
 const pageUrl = `${siteUrl}${canonicalPath}`;
 const downloadUrl = 'https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg';
 
+// The direct answer is a single ~160-word paragraph on every solution page, which is
+// unreadable as one block. Split it for layout ONLY: the lead sentence is promoted, the
+// remainder is grouped into paragraphs and dealt into two balanced columns. Every word and
+// the original word order are preserved, so the indexed text is unchanged.
+const answerSentences = directAnswer.split(/(?<=[.!?])\s+/).map((s) => s.trim()).filter(Boolean);
+const answerLead = answerSentences[0] ?? directAnswer;
+const answerRest = answerSentences.slice(1);
+
+const SENTENCES_PER_PARAGRAPH = 2;
+const answerParagraphs: string[] = [];
+for (let i = 0; i < answerRest.length; i += SENTENCES_PER_PARAGRAPH) {
+  answerParagraphs.push(answerRest.slice(i, i + SENTENCES_PER_PARAGRAPH).join(' '));
+}
+
+// Deal paragraphs into two columns at whichever split leaves the columns closest in length.
+// Taking the first cut past the halfway mark instead overshoots and leaves the two columns
+// visibly lopsided when the middle paragraph is the long one.
+const answerTotal = answerParagraphs.reduce((sum, paragraph) => sum + paragraph.length, 0);
+let cutAt = answerParagraphs.length;
+let bestImbalance = Number.POSITIVE_INFINITY;
+let running = 0;
+for (let i = 0; i < answerParagraphs.length; i += 1) {
+  running += answerParagraphs[i].length;
+  const imbalance = Math.abs(running - (answerTotal - running));
+  if (imbalance < bestImbalance) {
+    bestImbalance = imbalance;
+    cutAt = i + 1;
+  }
+}
+const answerColumnA = answerParagraphs.slice(0, cutAt);
+const answerColumnB = answerParagraphs.slice(cutAt);
+
 const webPageJsonLd = JSON.stringify({
   '@context': 'https://schema.org',
   '@type': 'WebPage',
@@ -96,11 +128,19 @@ const breadcrumbJsonLd = JSON.stringify({
           <h1>{heading}</h1>
           <p class="solution-intro">{intro}</p>
           <div class="solution-actions">
-            <a href={downloadUrl} class="solution-primary" data-download-source={downloadSource}>Download free</a>
+            <a href={downloadUrl} class="solution-primary" data-download-source={downloadSource}>
+              <svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M8 2v8m0 0 3-3m-3 3L5 7M2.5 12.5h11"/></svg>
+              Download free
+            </a>
             <a href="#how-it-fits" class="solution-secondary">See how it fits</a>
           </div>
           <ul class="solution-trust" role="list">
-            {trustItems.map((item) => <li>{item}</li>)}
+            {trustItems.map((item) => (
+              <li>
+                <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="#00c880" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m2.8 8.4 3 3 7.4-7.4"/></svg>
+                {item}
+              </li>
+            ))}
           </ul>
         </div>
         <div class="solution-proof" aria-label={`${eyebrow} workflow example`}>
@@ -111,7 +151,21 @@ const breadcrumbJsonLd = JSON.stringify({
       <section class="solution-answer" aria-labelledby="direct-answer-heading" data-answer-block>
         <p class="solution-answer-label">The short answer</p>
         <h2 id="direct-answer-heading">{answerHeading}</h2>
-        <p>{directAnswer}</p>
+        <div class="solution-answer-prose" data-answer-prose>
+          <p class="solution-answer-lead">{answerLead}</p>
+          {answerParagraphs.length > 0 && (
+            <div class="solution-answer-body">
+              <div class="solution-answer-column">
+                {answerColumnA.map((paragraph) => <p>{paragraph}</p>)}
+              </div>
+              {answerColumnB.length > 0 && (
+                <div class="solution-answer-column">
+                  {answerColumnB.map((paragraph) => <p>{paragraph}</p>)}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
       </section>
 
       <div id="how-it-fits" class="solution-content">
@@ -124,9 +178,13 @@ const breadcrumbJsonLd = JSON.stringify({
           <h2 id="faq-heading">What to know before you download</h2>
         </div>
         <div class="solution-faq-list">
-          {faqs.map((faq) => (
-            <details>
-              <summary>{faq.question}</summary>
+          {faqs.map((faq, index) => (
+            <details open={index === 0}>
+              <summary>
+                <span class="solution-faq-number">{String(index + 1).padStart(2, '0')}</span>
+                <span class="solution-faq-question">{faq.question}</span>
+                <span class="solution-faq-mark" aria-hidden="true"></span>
+              </summary>
               <p>{faq.answer}</p>
             </details>
           ))}
@@ -141,9 +199,10 @@ const breadcrumbJsonLd = JSON.stringify({
         <div class="solution-related-grid">
           {relatedLinks.map((link) => (
             <a href={link.href}>
+              <span class="solution-related-tag">Guide</span>
               <h3>{link.title}</h3>
               <p>{link.description}</p>
-              <span>Explore this guide</span>
+              <span class="solution-related-go">Explore this guide <span aria-hidden="true">&rarr;</span></span>
             </a>
           ))}
         </div>
@@ -155,7 +214,13 @@ const breadcrumbJsonLd = JSON.stringify({
           <h2 id="solution-cta-heading">Give your keyboard a quieter day.</h2>
           <p>No account and no subscription. Requires macOS 14 or later on Apple Silicon.</p>
         </div>
-        <a href={downloadUrl} class="solution-primary" data-download-source={`${downloadSource}-bottom`}>Download EnviousWispr</a>
+        <div class="solution-bottom-cta-actions">
+          <a href={downloadUrl} class="solution-primary" data-download-source={`${downloadSource}-bottom`}>
+            <svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M8 2v8m0 0 3-3m-3 3L5 7M2.5 12.5h11"/></svg>
+            Download EnviousWispr
+          </a>
+          <code>brew install --cask saurabhav88/tap/enviouswispr</code>
+        </div>
       </section>
     </div>
   </article>
@@ -166,17 +231,18 @@ const breadcrumbJsonLd = JSON.stringify({
   .solution-breadcrumb { display: flex; align-items: center; gap: 9px; margin: 10px 0 34px; font-size: 13px; color: var(--text-3); }
   .solution-breadcrumb a { color: var(--text-3); text-decoration: none; }
   .solution-breadcrumb a:hover { color: var(--accent); }
-  .solution-hero { display: grid; grid-template-columns: minmax(0, 1.02fr) minmax(420px, 0.98fr); gap: 64px; align-items: center; min-height: 570px; }
+  .solution-hero { display: grid; grid-template-columns: minmax(0, 1.02fr) minmax(420px, 0.98fr); gap: 60px; align-items: center; min-height: 570px; }
   .solution-hero-copy h1 { max-width: 720px; margin-bottom: 22px; font-size: clamp(46px, 5.4vw, 72px); line-height: 1.02; letter-spacing: -3.5px; }
   .solution-intro { max-width: 650px; color: var(--text-2); font-size: 19px; line-height: 1.72; }
   .solution-actions { display: flex; align-items: center; gap: 14px; margin-top: 30px; flex-wrap: wrap; }
-  .solution-primary, .solution-secondary { display: inline-flex; align-items: center; justify-content: center; min-height: 48px; padding: 13px 21px; border-radius: var(--radius-btn); font-size: 14px; font-weight: 700; text-decoration: none; transition: transform .2s, box-shadow .2s, background .2s; }
+  .solution-primary, .solution-secondary { display: inline-flex; align-items: center; justify-content: center; gap: 8px; min-height: 48px; padding: 13px 21px; border-radius: var(--radius-btn); font-size: 14px; font-weight: 700; text-decoration: none; transition: transform .2s, box-shadow .2s, background .2s; }
   .solution-primary { color: #fff; background: var(--text); box-shadow: 0 10px 28px rgba(15,10,26,.14); }
   .solution-primary:hover { transform: translateY(-2px); box-shadow: 0 14px 34px rgba(15,10,26,.2); }
   .solution-secondary { color: var(--accent); border: 1px solid rgba(124,58,237,.2); background: rgba(255,255,255,.7); }
   .solution-secondary:hover { background: #fff; }
-  .solution-trust { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 24px; list-style: none; }
-  .solution-trust li { padding: 7px 11px; border: 1px solid var(--border-hover); border-radius: var(--radius-pill); background: rgba(255,255,255,.72); color: var(--text-2); font-family: var(--font-mono); font-size: 11px; }
+  .solution-trust { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 24px; list-style: none; }
+  .solution-trust li { display: flex; align-items: center; gap: 6px; padding: 6px 11px; border: 1px solid var(--border-hover); border-radius: var(--radius-pill); background: rgba(255,255,255,.72); color: var(--text-2); font-family: var(--font-mono); font-size: 10.5px; white-space: nowrap; }
+  .solution-trust li svg { flex: none; }
   .solution-proof { position: relative; min-height: 440px; padding: 18px; border: 1px solid rgba(124,58,237,.14); border-radius: 28px; background: linear-gradient(145deg,rgba(255,255,255,.94),rgba(240,236,249,.82)); box-shadow: 0 32px 80px rgba(62,34,107,.13); overflow: hidden; }
   .solution-proof::before { content: ''; position: absolute; inset: 0; background: radial-gradient(circle at 85% 10%,rgba(0,204,221,.16),transparent 34%),radial-gradient(circle at 6% 92%,rgba(124,58,237,.14),transparent 38%); pointer-events: none; }
   .proof-window { position: relative; height: 100%; min-height: 404px; display: flex; flex-direction: column; border: 1px solid rgba(138,43,226,.11); border-radius: 18px; background: rgba(15,10,26,.96); color: #f8f5ff; overflow: hidden; }
@@ -186,49 +252,113 @@ const breadcrumbJsonLd = JSON.stringify({
   .proof-window-bar i:nth-child(3) { background: #29c940; margin-right: 5px; }
   .proof-body { display: grid; gap: 14px; padding: 22px; flex: 1; }
   .proof-row { padding: 15px 16px; border: 1px solid rgba(255,255,255,.08); border-radius: 12px; background: rgba(255,255,255,.04); }
-  .proof-row-label { display: block; margin-bottom: 7px; color: #8de8f1; font-family: var(--font-mono); font-size: 10px; text-transform: uppercase; letter-spacing: .1em; }
+  .proof-row-label { display: flex; align-items: center; gap: 8px; margin-bottom: 7px; color: #8de8f1; font-family: var(--font-mono); font-size: 10px; text-transform: uppercase; letter-spacing: .1em; }
   .proof-row p { color: rgba(248,245,255,.86); font-size: 13px; line-height: 1.65; }
   .proof-row.output { border-color: rgba(0,250,154,.25); background: rgba(0,200,128,.08); }
   .proof-row.output .proof-row-label { color: #55e0a8; }
+  .proof-wave { display: flex; align-items: flex-end; gap: 2px; height: 11px; margin-left: auto; }
+  .proof-wave span { width: 2px; border-radius: 1px; background: linear-gradient(180deg,#8a2be2,#00ccdd); }
   .proof-rail { display: grid; grid-template-columns: repeat(4,1fr); gap: 8px; margin-top: auto; }
   .proof-rail span { position: relative; padding-top: 16px; color: rgba(248,245,255,.48); font-family: var(--font-mono); font-size: 9px; text-align: center; }
   .proof-rail span::before { content: ''; position: absolute; top: 3px; left: 0; right: 0; height: 3px; border-radius: 3px; background: linear-gradient(90deg,#8a2be2,#00ccdd); }
-  .solution-answer { margin: 68px auto; max-width: 920px; padding: 34px 38px; border-left: 4px solid var(--accent); border-radius: 0 18px 18px 0; background: rgba(255,255,255,.78); box-shadow: 0 14px 40px rgba(62,34,107,.07); }
+
+  /* ── The short answer ── */
+  .solution-answer { position: relative; margin: 72px 0 0; padding: 38px 44px 36px; border: 1px solid var(--border-hover); border-left: 0; border-radius: 0 20px 20px 0; background: rgba(255,255,255,.86); box-shadow: 0 16px 44px rgba(62,34,107,.07); }
+  .solution-answer::before { content: ''; position: absolute; left: 0; top: 0; bottom: 0; width: 4px; border-radius: 4px 0 0 4px; background: linear-gradient(180deg,var(--accent),var(--cyan)); }
   .solution-answer-label, .solution-kicker { margin-bottom: 8px; color: var(--accent); font-family: var(--font-mono); font-size: 11px; font-weight: 600; letter-spacing: .09em; text-transform: uppercase; }
-  .solution-answer h2 { margin-bottom: 14px; font-size: 30px; letter-spacing: -1px; }
-  .solution-answer p:last-child { color: var(--text-2); font-size: 17px; line-height: 1.8; }
-  .solution-content { display: grid; gap: 72px; scroll-margin-top: 88px; }
-  .solution-section { display: grid; grid-template-columns: .72fr 1.28fr; gap: 60px; align-items: start; }
-  .solution-section h2, .solution-section-heading h2 { font-size: clamp(30px,3.4vw,44px); line-height: 1.12; letter-spacing: -1.8px; }
-  .solution-section-lead { color: var(--text-2); font-size: 17px; line-height: 1.75; }
+  .solution-answer h2 { margin-bottom: 18px; font-size: 32px; letter-spacing: -1.3px; }
+  .solution-answer-lead { max-width: 900px; color: var(--text); font-size: 21px; line-height: 1.6; letter-spacing: -.4px; }
+  .solution-answer-body { display: grid; grid-template-columns: repeat(2,1fr); gap: 14px 52px; align-items: start; margin-top: 20px; padding-top: 20px; border-top: 1px solid var(--border); }
+  .solution-answer-column { display: grid; gap: 13px; align-content: start; }
+  .solution-answer-body p { color: var(--text-2); font-size: 15.5px; line-height: 1.78; }
+
+  /* ── Body sections ── */
+  .solution-content { display: grid; gap: 80px; scroll-margin-top: 88px; }
+  .solution-content { margin-top: 84px; }
+  .solution-section { display: grid; grid-template-columns: .68fr 1.32fr; gap: 56px; align-items: start; }
+  .solution-section h2, .solution-section-heading h2 { font-size: clamp(30px,3.4vw,38px); line-height: 1.1; letter-spacing: -1.7px; }
+  .solution-section-lead { color: var(--text-2); font-size: 16.5px; line-height: 1.78; }
+  /* A section that is a heading plus one paragraph reads as unfinished in the two-column
+     grid. `.solution-statement` gives that shape its own contained treatment instead. */
+  .solution-statement { grid-template-columns: 1fr; gap: 20px; max-width: 900px; padding: 40px 44px; border: 1px solid var(--border-hover); border-radius: 22px; background: linear-gradient(135deg,rgba(255,255,255,.9),rgba(240,236,249,.7)); }
+  .solution-statement h2 { max-width: 720px; }
+  .solution-statement .solution-section-lead { max-width: 760px; }
   .solution-card-grid { display: grid; grid-template-columns: repeat(2,1fr); gap: 16px; }
-  .solution-card { padding: 24px; border: 1px solid var(--border-hover); border-radius: var(--radius-card); background: rgba(255,255,255,.76); }
-  .solution-card h3 { margin-bottom: 9px; font-size: 17px; letter-spacing: -.4px; }
-  .solution-card p { color: var(--text-2); font-size: 14px; line-height: 1.65; }
-  .solution-callout { padding: 26px 28px; border: 1px solid rgba(0,204,221,.22); border-radius: 18px; background: linear-gradient(135deg,rgba(0,204,221,.08),rgba(124,58,237,.06)); }
-  .solution-callout strong { display: block; margin-bottom: 8px; font-size: 17px; }
-  .solution-callout p { color: var(--text-2); }
-  .solution-faq, .solution-related { margin-top: 92px; }
-  .solution-section-heading { max-width: 680px; margin-bottom: 32px; }
-  .solution-faq-list { display: grid; gap: 12px; }
-  .solution-faq details { border: 1px solid var(--border-hover); border-radius: 14px; background: rgba(255,255,255,.75); }
-  .solution-faq summary { padding: 20px 22px; cursor: pointer; font-size: 16px; font-weight: 700; }
-  .solution-faq details p { padding: 0 22px 22px; color: var(--text-2); line-height: 1.72; }
-  .solution-related-grid { display: grid; grid-template-columns: repeat(3,1fr); gap: 16px; }
-  .solution-related-grid a { display: block; padding: 24px; border: 1px solid var(--border-hover); border-radius: var(--radius-card); background: rgba(255,255,255,.72); color: var(--text); text-decoration: none; transition: transform .2s, border-color .2s; }
-  .solution-related-grid a:hover { transform: translateY(-3px); border-color: rgba(124,58,237,.25); }
-  .solution-related-grid h3 { margin-bottom: 8px; font-size: 17px; }
-  .solution-related-grid p { margin-bottom: 18px; color: var(--text-2); font-size: 13px; line-height: 1.65; }
-  .solution-related-grid span { color: var(--accent); font-size: 12px; font-weight: 700; }
-  .solution-bottom-cta { display: flex; align-items: center; justify-content: space-between; gap: 32px; margin-top: 92px; padding: 38px; border-radius: 24px; background: var(--text); color: #fff; }
-  .solution-bottom-cta h2 { margin-bottom: 7px; font-size: 32px; letter-spacing: -1.2px; }
-  .solution-bottom-cta p:not(.solution-kicker) { color: rgba(255,255,255,.67); }
-  .solution-bottom-cta .solution-primary { color: var(--text); background: #fff; white-space: nowrap; }
+  .solution-card { padding: 24px; border: 1px solid var(--border-hover); border-radius: var(--radius-card); background: rgba(255,255,255,.8); }
+  .solution-card h3 { margin-bottom: 9px; font-size: 16.5px; letter-spacing: -.4px; }
+  .solution-card p { color: var(--text-2); font-size: 14px; line-height: 1.68; }
+  .solution-callout { display: grid; grid-template-columns: 34px 1fr; gap: 16px; padding: 24px 26px; border: 1px solid rgba(0,204,221,.24); border-radius: 16px; background: linear-gradient(135deg,rgba(0,204,221,.08),rgba(124,58,237,.06)); }
+  .solution-callout-icon { display: flex; align-items: center; justify-content: center; width: 34px; height: 34px; border-radius: 9px; background: rgba(0,204,221,.16); color: #00808c; }
+  .solution-callout strong { display: block; margin-bottom: 6px; font-size: 16px; letter-spacing: -.3px; }
+  .solution-callout p { color: var(--text-2); font-size: 14px; line-height: 1.7; }
+
+  /* ── Where the data goes: local lane / network / remote lane ── */
+  .solution-lanes { border: 1px solid var(--border-hover); border-radius: 20px; background: rgba(255,255,255,.82); overflow: hidden; }
+  .solution-lane { padding: 24px 26px; }
+  .solution-lane + .solution-lane { border-top: 1px solid var(--border-hover); }
+  .solution-lane-head { display: flex; align-items: center; gap: 11px; }
+  .solution-lane-dot { width: 9px; height: 9px; border-radius: 50%; flex: none; }
+  .solution-lane-title { font-size: 16px; letter-spacing: -.4px; }
+  .solution-lane-note { margin-left: auto; font-family: var(--font-mono); font-size: 10px; letter-spacing: .05em; text-transform: uppercase; }
+  .solution-lane-items { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 15px; list-style: none; }
+  .solution-lane-items li { padding: 7px 12px; border-radius: var(--radius-pill); font-size: 12.5px; font-weight: 600; }
+  .solution-lane.local .solution-lane-dot { background: var(--green); box-shadow: 0 0 0 4px rgba(0,200,128,.13); }
+  .solution-lane.local .solution-lane-note { color: #05815a; }
+  .solution-lane.local .solution-lane-items li { border: 1px solid rgba(0,200,128,.26); background: rgba(0,200,128,.08); color: #04613f; }
+  .solution-lane.remote .solution-lane-dot { background: var(--orange); box-shadow: 0 0 0 4px rgba(230,126,0,.13); }
+  .solution-lane.remote .solution-lane-note { color: #a85a00; }
+  .solution-lane.remote .solution-lane-items li { border: 1px solid rgba(230,126,0,.26); background: rgba(230,126,0,.08); color: #8a4c00; }
+  .solution-lane-sub { margin-top: 12px; color: var(--text-2); font-size: 13.5px; line-height: 1.7; }
+  .solution-lane-boundary { display: flex; align-items: center; gap: 14px; padding: 13px 26px; background: var(--text); color: rgba(255,255,255,.62); font-family: var(--font-mono); font-size: 10.5px; letter-spacing: .09em; text-transform: uppercase; }
+  .solution-lane-boundary::before, .solution-lane-boundary::after { content: ''; flex: 1; height: 1px; background: rgba(255,255,255,.16); }
+  .solution-lane-never { display: flex; align-items: center; gap: 10px; padding: 16px 26px; border-top: 1px solid var(--border-hover); background: var(--surface); color: var(--text-2); font-size: 13.5px; }
+  .solution-lane-never svg { flex: none; }
+  .solution-lane-never strong { color: var(--text); }
+
+  /* ── Questions ── */
+  .solution-faq, .solution-related { margin-top: 96px; }
+  .solution-section-heading { max-width: 700px; margin-bottom: 28px; }
+  .solution-faq-list { display: grid; gap: 10px; max-width: 940px; }
+  .solution-faq details { border: 1px solid var(--border-hover); border-radius: 14px; background: rgba(255,255,255,.8); transition: border-color .2s, box-shadow .2s; }
+  .solution-faq details:hover { border-color: rgba(124,58,237,.22); }
+  .solution-faq details[open] { border-color: rgba(124,58,237,.26); box-shadow: 0 10px 30px rgba(62,34,107,.06); }
+  .solution-faq summary { display: flex; align-items: center; gap: 14px; padding: 21px 24px; cursor: pointer; font-size: 16.5px; font-weight: 700; letter-spacing: -.35px; list-style: none; }
+  .solution-faq summary::-webkit-details-marker { display: none; }
+  .solution-faq summary::marker { content: ''; }
+  .solution-faq summary:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 14px; }
+  .solution-faq-number { flex: none; color: var(--text-3); font-family: var(--font-mono); font-size: 11px; font-weight: 500; }
+  .solution-faq-question { flex: 1; }
+  .solution-faq-mark { position: relative; flex: none; width: 26px; height: 26px; border-radius: 8px; background: var(--accent-soft); }
+  .solution-faq-mark::before, .solution-faq-mark::after { content: ''; position: absolute; top: 50%; left: 50%; width: 12px; height: 2px; border-radius: 1px; background: var(--accent); transform: translate(-50%,-50%); transition: transform .2s; }
+  .solution-faq-mark::after { transform: translate(-50%,-50%) rotate(90deg); }
+  .solution-faq details[open] .solution-faq-mark::after { transform: translate(-50%,-50%) rotate(0deg); }
+  .solution-faq details p { padding: 0 24px 22px 52px; max-width: 720px; color: var(--text-2); font-size: 14.5px; line-height: 1.75; }
+
+  /* ── Related ── */
+  .solution-related-grid { display: grid; grid-template-columns: repeat(3,1fr); gap: 18px; }
+  .solution-related-grid a { display: flex; flex-direction: column; min-height: 196px; padding: 26px; border: 1px solid var(--border-hover); border-radius: 18px; background: rgba(255,255,255,.8); color: var(--text); text-decoration: none; transition: transform .2s, border-color .2s, box-shadow .2s; }
+  .solution-related-grid a:hover { transform: translateY(-3px); border-color: rgba(124,58,237,.25); box-shadow: 0 16px 40px rgba(62,34,107,.07); }
+  .solution-related-tag { align-self: flex-start; padding: 4px 10px; border-radius: 6px; background: var(--surface); color: var(--text-3); font-family: var(--font-mono); font-size: 10px; letter-spacing: .05em; text-transform: uppercase; }
+  .solution-related-grid h3 { margin-top: 16px; margin-bottom: 9px; font-size: 18px; line-height: 1.24; letter-spacing: -.5px; }
+  .solution-related-grid p { margin-bottom: 20px; color: var(--text-2); font-size: 13.5px; line-height: 1.66; }
+  .solution-related-go { display: flex; align-items: center; justify-content: space-between; margin-top: auto; color: var(--accent); font-size: 12.5px; font-weight: 700; }
+
+  /* ── Closing band ── */
+  .solution-bottom-cta { position: relative; display: flex; align-items: center; justify-content: space-between; gap: 44px; margin-top: 92px; padding: 44px 46px; border-radius: 24px; background: var(--text); color: #fff; overflow: hidden; }
+  .solution-bottom-cta::before { content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px; background: var(--rainbow-full); }
+  .solution-bottom-cta h2 { margin: 10px 0 9px; font-size: 34px; letter-spacing: -1.5px; }
+  .solution-bottom-cta p:not(.solution-kicker) { color: rgba(255,255,255,.66); font-size: 14.5px; }
   .solution-bottom-cta .solution-kicker { color: #8de8f1; }
+  .solution-bottom-cta-actions { display: flex; flex-direction: column; align-items: flex-end; gap: 11px; flex: none; }
+  .solution-bottom-cta .solution-primary { color: var(--text); background: #fff; white-space: nowrap; box-shadow: none; }
+  .solution-bottom-cta code { color: rgba(255,255,255,.44); font-family: var(--font-mono); font-size: 10.5px; }
+
   @media (max-width: 980px) {
     .solution-hero { grid-template-columns: 1fr; gap: 38px; min-height: 0; }
     .solution-proof { min-height: 390px; }
     .solution-section { grid-template-columns: 1fr; gap: 26px; }
+    .solution-answer-body { grid-template-columns: 1fr; gap: 13px; }
+    .solution-content { gap: 60px; }
   }
   @media (max-width: 700px) {
     .solution-page { padding-top: 78px; }
@@ -239,10 +369,21 @@ const breadcrumbJsonLd = JSON.stringify({
     .proof-window { min-height: 390px; }
     .proof-body { padding: 16px; }
     .proof-rail { grid-template-columns: repeat(2,1fr); }
-    .solution-answer { margin: 48px 0; padding: 26px 24px; }
+    .solution-answer { margin-top: 52px; padding: 26px 24px 24px; }
     .solution-answer h2 { font-size: 26px; }
+    .solution-answer-lead { font-size: 18px; }
+    .solution-content { margin-top: 60px; }
+    .solution-statement { padding: 28px 24px; }
     .solution-card-grid, .solution-related-grid { grid-template-columns: 1fr; }
+    .solution-lane, .solution-lane-boundary, .solution-lane-never { padding-left: 20px; padding-right: 20px; }
+    .solution-lane-head { flex-wrap: wrap; }
+    .solution-lane-note { margin-left: 0; width: 100%; }
     .solution-faq, .solution-related { margin-top: 68px; }
-    .solution-bottom-cta { align-items: flex-start; flex-direction: column; margin-top: 68px; padding: 28px 24px; }
+    .solution-faq summary { padding: 18px 20px; font-size: 15.5px; }
+    .solution-faq details p { padding: 0 20px 20px 46px; }
+    .solution-bottom-cta { align-items: flex-start; flex-direction: column; margin-top: 68px; padding: 30px 24px; }
+    .solution-bottom-cta h2 { font-size: 28px; }
+    .solution-bottom-cta-actions { align-items: flex-start; width: 100%; }
+    .solution-bottom-cta code { font-size: 9.5px; word-break: break-all; }
   }
 </style>

--- a/website/src/pages/solutions/ai-polish.astro
+++ b/website/src/pages/solutions/ai-polish.astro
@@ -59,7 +59,7 @@ const directAnswer = `AI polish for dictation turns a spoken transcript into cle
     <div class="proof-window-bar"><i></i><i></i><i></i>polish-route</div>
     <div class="proof-body">
       <div class="proof-row">
-        <span class="proof-row-label">Spoken transcript</span>
+        <span class="proof-row-label">Spoken transcript<span class="proof-wave" aria-hidden="true"><span style="height:4px"></span><span style="height:9px"></span><span style="height:6px"></span><span style="height:11px"></span><span style="height:5px"></span><span style="height:8px"></span><span style="height:3px"></span><span style="height:7px"></span></span></span>
         <p>Um send Maya the revised outline on Tuesday at about three thirty and ask if the second section is clear.</p>
       </div>
       <div class="proof-row output">
@@ -90,11 +90,11 @@ const directAnswer = `AI polish for dictation turns a spoken transcript into cle
     </div>
     <div>
       <p class="solution-section-lead">Speech recognition finishes on your Mac before polish begins. A local route keeps the request there. A cloud route sends the transcript, cleanup instructions, custom words, target app name, and your account credential directly to the selected provider. Envious Labs does not operate a transcription or polish relay.</p>
-      <div class="solution-callout" style="margin-top:20px"><strong>One Ollama detail worth checking</strong><p>Ollama supports both downloaded local models and hosted models. A hosted model runs on Ollama's servers, even though you selected Ollama in the app.</p></div>
+      <div class="solution-callout" style="margin-top:22px"><span class="solution-callout-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2.6 20 6v5.4c0 4.3-3.2 7.4-8 8.6-4.8-1.2-8-4.3-8-8.6V6Z"/><path d="m9 12 2.2 2.2L15.4 10"/></svg></span><div><strong>One Ollama detail worth checking</strong><p>Ollama supports both downloaded local models and hosted models. A hosted model runs on Ollama's servers, even though you selected Ollama in the app.</p></div></div>
     </div>
   </section>
 
-  <section class="solution-section" aria-labelledby="polish-failure-heading">
+  <section class="solution-section solution-statement" aria-labelledby="polish-failure-heading">
     <div>
       <p class="solution-kicker">Fail soft</p>
       <h2 id="polish-failure-heading">A polish problem should not swallow your thought.</h2>

--- a/website/src/pages/solutions/developers.astro
+++ b/website/src/pages/solutions/developers.astro
@@ -59,7 +59,7 @@ const directAnswer = `Dictation for developers on Mac is voice input for the wri
     <div class="proof-window-bar"><i></i><i></i><i></i>pull-request.md</div>
     <div class="proof-body">
       <div class="proof-row">
-        <span class="proof-row-label">Spoken</span>
+        <span class="proof-row-label">Spoken<span class="proof-wave" aria-hidden="true"><span style="height:4px"></span><span style="height:9px"></span><span style="height:6px"></span><span style="height:11px"></span><span style="height:5px"></span><span style="height:8px"></span><span style="height:3px"></span><span style="height:7px"></span></span></span>
         <p>Okay so this changes the auth retry because the old path could lose the refresh result, and I also added coverage for the fallback.</p>
       </div>
       <div class="proof-row output">
@@ -90,7 +90,7 @@ const directAnswer = `Dictation for developers on Mac is voice input for the wri
     </div>
     <div>
       <p class="solution-section-lead">EnviousWispr is an input tool, not an autonomous coding agent. It can place dictated text into compatible text fields, including terminal input, but it does not press Return, execute shell commands, change files, or make repository decisions for you.</p>
-      <div class="solution-callout" style="margin-top:20px"><strong>Best fit</strong><p>Use it for natural-language work around code. Keep precise syntax, structural edits, and command execution under direct control.</p></div>
+      <div class="solution-callout" style="margin-top:22px"><span class="solution-callout-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2.6 20 6v5.4c0 4.3-3.2 7.4-8 8.6-4.8-1.2-8-4.3-8-8.6V6Z"/><path d="m9 12 2.2 2.2L15.4 10"/></svg></span><div><strong>Best fit</strong><p>Use it for natural-language work around code. Keep precise syntax, structural edits, and command execution under direct control.</p></div></div>
     </div>
   </section>
 
@@ -98,9 +98,49 @@ const directAnswer = `Dictation for developers on Mac is voice input for the wri
     <div>
       <p class="solution-kicker">A concrete privacy boundary</p>
       <h2 id="developer-privacy-heading">Your voice never becomes somebody else's audio file.</h2>
+      <p class="solution-section-lead" style="margin-top:18px;font-size:15.5px">Transcription runs on your Mac, so spoken project context is not uploaded for speech recognition. Everything below is what can cross the line, and what never does.</p>
     </div>
-    <div>
-      <p class="solution-section-lead">Transcription runs on your Mac, so spoken project context is not uploaded for speech recognition. Local polish can keep the resulting text there too. If you turn on a cloud provider, the transcript, cleanup instructions, custom words, target app name, and your account credential go directly to it. Envious Labs does not relay the request.</p>
+    <div class="solution-lanes">
+      <div class="solution-lane local">
+        <div class="solution-lane-head">
+          <span class="solution-lane-dot" aria-hidden="true"></span>
+          <h3 class="solution-lane-title">Stays on your Mac</h3>
+          <span class="solution-lane-note">Always</span>
+        </div>
+        <ul class="solution-lane-items" role="list">
+          <li>Your voice</li>
+          <li>The recording</li>
+          <li>Speech recognition</li>
+          <li>Deterministic cleanup</li>
+          <li>EG-1 polish</li>
+          <li>Apple Intelligence polish</li>
+          <li>Downloaded Ollama polish</li>
+        </ul>
+        <p class="solution-lane-sub">No EnviousWispr account and no upload. This half is the same whether you are online or not.</p>
+      </div>
+
+      <p class="solution-lane-boundary">The network</p>
+
+      <div class="solution-lane remote">
+        <div class="solution-lane-head">
+          <span class="solution-lane-dot" aria-hidden="true"></span>
+          <h3 class="solution-lane-title">Leaves your Mac, only if you turn cloud polish on</h3>
+          <span class="solution-lane-note">Your choice</span>
+        </div>
+        <ul class="solution-lane-items" role="list">
+          <li>The transcript</li>
+          <li>Cleanup instructions</li>
+          <li>Your custom words</li>
+          <li>Target app name</li>
+          <li>Your own provider credential</li>
+        </ul>
+        <p class="solution-lane-sub">These go from your Mac straight to the provider you chose, under your own account. Envious Labs does not relay the request.</p>
+      </div>
+
+      <p class="solution-lane-never">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="#e6253a" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="8" cy="8" r="6.2"/><path d="M4.2 4.2l7.6 7.6"/></svg>
+        <span><strong>Audio is never in the second lane.</strong> There is no setting that sends your recording anywhere.</span>
+      </p>
     </div>
   </section>
 </SolutionLayout>

--- a/website/src/pages/solutions/index.astro
+++ b/website/src/pages/solutions/index.astro
@@ -1,10 +1,37 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
-import { solutions } from '../../data/solutions';
+import { solutions, type SolutionIcon } from '../../data/solutions';
 
 const siteUrl = 'https://enviouswispr.com';
+const downloadUrl = 'https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg';
 const title = 'Mac Dictation Solutions for Real Work | EnviousWispr';
 const description = 'Find a free Mac dictation workflow for coding, writing, private offline work, and clean AI-polished text. Explore EnviousWispr and download free.';
+
+// Stroke-only glyphs on a 24px grid, one per workflow. Kept here rather than in the data
+// module so the data stays copy and routing.
+const icons: Record<SolutionIcon, string> = {
+  code: '<path d="m8 17-5-5 5-5m8 10 5-5-5-5m-2-3-4 16"/>',
+  polish: '<path d="M12 3v3m0 12v3M5.6 5.6l2.1 2.1m8.6 8.6 2.1 2.1M3 12h3m12 0h3M5.6 18.4l2.1-2.1m8.6-8.6 2.1-2.1"/><circle cx="12" cy="12" r="3.2"/>',
+  offline: '<path d="M3 3l18 18M8.5 6.2A6 6 0 0 1 18 10.5a3.8 3.8 0 0 1 2.5 6.3M17 18H7a4 4 0 0 1-.9-7.9"/>',
+  source: '<circle cx="6.5" cy="6" r="2.6"/><circle cx="6.5" cy="18" r="2.6"/><circle cx="17.5" cy="12" r="2.6"/><path d="M6.5 8.6v6.8M8.9 7.1l6.3 3.6M8.9 16.9l6.3-3.6"/>',
+  draft: '<path d="M11.5 3.5 20 12l-8.5 8.5H4v-3.4Z"/><path d="m14.2 6.2 3.6 3.6M6 21h14"/>',
+};
+
+// Enforced rather than asserted in prose: a second featured card would silently render as
+// an ordinary one, leaving the grid a card short of the row it was laid out for.
+const featuredCards = solutions.filter((solution) => solution.featured);
+if (featuredCards.length > 1) {
+  throw new Error(`solutions: expected at most one featured card, found ${featuredCards.length}`);
+}
+const featured = featuredCards[0] ?? solutions[0];
+const rest = solutions.filter((solution) => solution !== featured);
+
+const glance = [
+  { label: 'Price', value: 'Free, no account' },
+  { label: 'Transcription', value: 'On your Mac' },
+  { label: 'Requires', value: 'macOS 14+, Apple Silicon' },
+  { label: 'Licence', value: 'GPLv3, open source' },
+];
 
 const collectionJsonLd = JSON.stringify({
   '@context': 'https://schema.org',
@@ -42,27 +69,73 @@ const breadcrumbJsonLd = JSON.stringify({
   <div class="solutions-hub">
     <div class="container">
       <nav class="hub-breadcrumb" aria-label="Breadcrumb"><a href="/">Home</a><span aria-hidden="true">/</span><span aria-current="page">Solutions</span></nav>
+
       <header class="hub-hero">
-        <div>
-          <div class="section-label-pill accent">Solutions</div>
-          <h1>Less typing.<br/><span class="rainbow-text">More finished work.</span></h1>
+        <div class="section-label-pill accent">Solutions</div>
+        <h1>Less typing.<br/><span class="rainbow-text">More finished work.</span></h1>
+        <div class="hub-hero-row">
+          <p>Five workflows, one app. Pick the one closest to the work you already do, and see exactly where your voice fits into it.</p>
+          <a href="/how-it-works/">See how on-device dictation works <span aria-hidden="true">&rarr;</span></a>
         </div>
-        <div class="hub-intro">
-          <p>EnviousWispr is a free dictation app for Apple Silicon Macs. Choose the workflow closest to the work you do, then see exactly where voice fits.</p>
-          <a href="/how-it-works/">See how on-device dictation works</a>
-        </div>
+        <dl class="hub-glance">
+          {glance.map((item) => (
+            <div><dt>{item.label}</dt><dd>{item.value}</dd></div>
+          ))}
+        </dl>
       </header>
 
       <section class="hub-grid" aria-label="Dictation solutions">
-        {solutions.map((solution, index) => (
-          <a href={solution.href} class={`hub-card ${solution.accent}`}>
-            <div class="hub-card-number">0{index + 1}</div>
-            <p class="hub-card-eyebrow">{solution.eyebrow}</p>
-            <h2>{solution.title}</h2>
+        <a href={featured.href} class={`hub-featured ${featured.accent}`}>
+          <div>
+            <div class="hub-card-head">
+              <span class="hub-tile" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" set:html={icons[featured.icon]}></svg>
+              </span>
+              <p class="hub-card-eyebrow">{featured.eyebrow}</p>
+            </div>
+            <h2>{featured.title}</h2>
+            <p class="hub-card-description">{featured.description}</p>
+            <div class="hub-card-foot">
+              <span class="hub-card-link">Explore the workflow <span aria-hidden="true">&rarr;</span></span>
+              <span class="hub-card-outcome"><span aria-hidden="true"></span>{featured.outcome}</span>
+            </div>
+          </div>
+
+          <div class="hub-proof" aria-hidden="true">
+            <div class="hub-proof-bar"><i></i><i></i><i></i>pull-request.md</div>
+            <div class="hub-proof-body">
+              <div class="hub-proof-row">
+                <span class="hub-proof-label">Spoken
+                  <span class="hub-proof-wave">
+                    <span style="height:4px"></span><span style="height:9px"></span><span style="height:6px"></span><span style="height:11px"></span><span style="height:5px"></span><span style="height:8px"></span><span style="height:3px"></span>
+                  </span>
+                </span>
+                <p>Okay so this changes the auth retry because the old path could lose the refresh result, and I also added coverage for the fallback.</p>
+              </div>
+              <div class="hub-proof-row output">
+                <span class="hub-proof-label">Ready for review</span>
+                <p>This changes the authentication retry so the refresh result is preserved. It also adds coverage for the fallback path.</p>
+              </div>
+            </div>
+            <div class="hub-proof-rail"><span>Voice</span><span>Local ASR</span><span>Cleanup</span><span>Paste</span></div>
+          </div>
+        </a>
+
+        {rest.map((solution) => (
+          <article class={`hub-card ${solution.accent}`}>
+            <div class="hub-card-head">
+              <span class="hub-tile" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" set:html={icons[solution.icon]}></svg>
+              </span>
+              <p class="hub-card-eyebrow">{solution.eyebrow}</p>
+            </div>
+            <h2><a href={solution.href}>{solution.title}</a></h2>
             <p class="hub-card-description">{solution.description}</p>
-            <div class="hub-card-outcome"><span aria-hidden="true"></span>{solution.outcome}</div>
-            <div class="hub-card-link">Explore the workflow <span aria-hidden="true">→</span></div>
-          </a>
+            <div class="hub-card-foot">
+              <span class="hub-card-link">Explore <span aria-hidden="true">&rarr;</span></span>
+              <span class="hub-card-outcome"><span aria-hidden="true"></span>{solution.outcome}</span>
+            </div>
+          </article>
         ))}
       </section>
 
@@ -72,9 +145,39 @@ const breadcrumbJsonLd = JSON.stringify({
           <h2 id="principles-heading">Every workflow starts with the same three promises.</h2>
         </div>
         <div class="hub-principle-list">
-          <article><strong>Audio stays local</strong><p>Speech recognition runs on your Mac. Your voice is never uploaded.</p></article>
-          <article><strong>You choose the polish path</strong><p>Keep cleanup on-device, use deterministic cleanup only, or bring your own cloud provider key.</p></article>
-          <article><strong>The app stays free</strong><p>No EnviousWispr account, subscription, or locked core dictation feature.</p></article>
+          <article>
+            <span class="hub-principle-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="3" width="16" height="13" rx="1.6"/><path d="M2 20h20M9.5 8v3m2.5-5v7m2.5-4.5v2"/></svg>
+            </span>
+            <div><strong>Audio stays local</strong><p>Speech recognition runs on your Mac. Your voice is never uploaded.</p></div>
+          </article>
+          <article>
+            <span class="hub-principle-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M4 8h8m4 0h4M4 16h4m4 0h8"/><circle cx="14" cy="8" r="2.4"/><circle cx="10" cy="16" r="2.4"/></svg>
+            </span>
+            <div><strong>You choose the polish path</strong><p>Keep cleanup on-device, use deterministic cleanup only, or bring your own cloud provider key.</p></div>
+          </article>
+          <article>
+            <span class="hub-principle-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M7 10V7.5a5 5 0 0 1 10 0V10"/><rect x="4.5" y="10" width="15" height="10" rx="2"/><path d="M12 14v2.5"/></svg>
+            </span>
+            <div><strong>The app stays free</strong><p>No EnviousWispr account, subscription, or locked core dictation feature.</p></div>
+          </article>
+        </div>
+      </section>
+
+      <section class="hub-cta cta-section" aria-labelledby="hub-cta-heading">
+        <div>
+          <p class="hub-kicker accent">Free, private, Mac native</p>
+          <h2 id="hub-cta-heading">Give your keyboard a quieter day.</h2>
+          <p>No account and no subscription. Requires macOS 14 or later on Apple Silicon.</p>
+        </div>
+        <div class="hub-cta-actions">
+          <a href={downloadUrl} class="hub-download" data-download-source="solution-hub-bottom">
+            <svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M8 2v8m0 0 3-3m-3 3L5 7M2.5 12.5h11"/></svg>
+            Download free
+          </a>
+          <a href="/compare/" class="hub-compare">Compare the alternatives</a>
         </div>
       </section>
     </div>
@@ -83,38 +186,122 @@ const breadcrumbJsonLd = JSON.stringify({
 
 <style>
   .solutions-hub { padding: 96px 0 96px; }
-  .hub-breadcrumb { display:flex; gap:9px; margin:10px 0 42px; color:var(--text-3); font-size:13px; }
+  .hub-breadcrumb { display:flex; gap:9px; margin:10px 0 34px; color:var(--text-3); font-size:13px; }
   .hub-breadcrumb a { color:var(--text-3); text-decoration:none; }
-  .hub-hero { display:grid; grid-template-columns:1.25fr .75fr; gap:80px; align-items:end; margin-bottom:58px; }
-  .hub-hero h1 { max-width:760px; font-size:clamp(52px,7vw,88px); line-height:.98; letter-spacing:-5px; }
-  .hub-intro { padding-bottom:8px; }
-  .hub-intro p { margin-bottom:18px; color:var(--text-2); font-size:18px; line-height:1.75; }
-  .hub-intro a { color:var(--accent); font-size:14px; font-weight:700; text-underline-offset:4px; }
+  .hub-breadcrumb a:hover { color:var(--accent); }
+
+  /* ── hero ── */
+  .hub-hero { margin-bottom:44px; }
+  .hub-hero h1 { margin-top:18px; max-width:900px; font-size:clamp(48px,7vw,82px); line-height:.98; letter-spacing:-4.5px; }
+  .hub-hero-row { display:flex; align-items:flex-end; justify-content:space-between; gap:60px; margin-top:26px; }
+  .hub-hero-row p { max-width:540px; color:var(--text-2); font-size:17.5px; line-height:1.75; }
+  .hub-hero-row a { flex:none; padding-bottom:3px; color:var(--accent); font-size:14px; font-weight:700; text-decoration:none; }
+  .hub-hero-row a:hover { text-decoration:underline; text-underline-offset:4px; }
+  .hub-glance { display:flex; align-items:stretch; margin-top:34px; padding:22px 26px; border:1px solid var(--border-hover); border-radius:var(--radius-card); background:rgba(255,255,255,.72); }
+  .hub-glance > div { flex:1; padding:0 26px; border-left:1px solid var(--border-hover); }
+  .hub-glance > div:first-child { padding-left:0; border-left:0; }
+  .hub-glance dt { color:var(--text-3); font-family:var(--font-mono); font-size:10.5px; letter-spacing:.06em; text-transform:uppercase; }
+  .hub-glance dd { margin-top:7px; font-size:17px; font-weight:700; letter-spacing:-.5px; }
+
+  /* ── grid: one featured workflow, then the rest two-up ── */
   .hub-grid { display:grid; grid-template-columns:repeat(2,1fr); gap:20px; }
-  .hub-card { position:relative; min-height:390px; display:flex; flex-direction:column; padding:34px; border:1px solid var(--border-hover); border-radius:22px; background:rgba(255,255,255,.8); color:var(--text); text-decoration:none; overflow:hidden; transition:transform .22s,box-shadow .22s; }
-  .hub-card::before { content:''; position:absolute; inset:0 auto auto 0; width:100%; height:5px; background:var(--card-accent); }
-  .hub-card::after { content:''; position:absolute; right:-70px; top:-70px; width:210px; height:210px; border-radius:50%; background:var(--card-glow); filter:blur(4px); }
-  .hub-card:hover { transform:translateY(-5px); box-shadow:0 22px 55px rgba(62,34,107,.11); }
-  .hub-card.blue { --card-accent:linear-gradient(90deg,#1e90ff,#00ccdd); --card-glow:rgba(30,144,255,.12); }
-  .hub-card.violet { --card-accent:linear-gradient(90deg,#8a2be2,#d45a90); --card-glow:rgba(138,43,226,.12); }
-  .hub-card.green { --card-accent:linear-gradient(90deg,#00c880,#adff2f); --card-glow:rgba(0,200,128,.12); }
-  .hub-card.orange { --card-accent:linear-gradient(90deg,#ff8c00,#ffd700); --card-glow:rgba(255,140,0,.12); }
-  .hub-card.cyan { --card-accent:linear-gradient(90deg,#00ccdd,#7c3aed); --card-glow:rgba(0,204,221,.12); }
-  .hub-card-number { position:relative; z-index:1; margin-bottom:45px; color:var(--text-3); font-family:var(--font-mono); font-size:11px; }
-  .hub-card-eyebrow,.hub-kicker { margin-bottom:10px; color:var(--accent); font-family:var(--font-mono); font-size:11px; font-weight:600; letter-spacing:.09em; text-transform:uppercase; }
-  .hub-card h2 { position:relative; z-index:1; max-width:520px; margin-bottom:14px; font-size:32px; line-height:1.12; letter-spacing:-1.3px; }
-  .hub-card-description { max-width:560px; color:var(--text-2); line-height:1.7; }
-  .hub-card-outcome { display:flex; gap:9px; align-items:center; margin-top:24px; color:var(--text-2); font-size:12px; font-weight:600; }
-  .hub-card-outcome span { width:7px; height:7px; border-radius:50%; background:#00c880; box-shadow:0 0 0 4px rgba(0,200,128,.1); }
-  .hub-card-link { margin-top:auto; padding-top:30px; color:var(--accent); font-size:13px; font-weight:700; }
-  .hub-principles { display:grid; grid-template-columns:.8fr 1.2fr; gap:68px; margin-top:82px; padding:48px; border-radius:24px; background:var(--text); color:#fff; }
-  .hub-principles h2 { font-size:36px; line-height:1.18; letter-spacing:-1.5px; }
-  .hub-kicker { color:#8de8f1; }
-  .hub-principle-list { display:grid; gap:20px; }
-  .hub-principle-list article { padding-bottom:20px; border-bottom:1px solid rgba(255,255,255,.1); }
+  .hub-featured, .hub-card { position:relative; padding:32px; border:1px solid var(--border-hover); border-radius:20px; background:rgba(255,255,255,.8); color:var(--text); text-decoration:none; transition:transform .22s, border-color .22s, box-shadow .22s; }
+  .hub-featured { grid-column:1 / -1; display:grid; grid-template-columns:1.02fr .98fr; gap:48px; align-items:center; padding:38px; border-radius:22px; background:linear-gradient(140deg,rgba(255,255,255,.92),rgba(240,236,249,.66)); box-shadow:0 20px 54px rgba(62,34,107,.07); }
+  .hub-card { display:flex; flex-direction:column; min-height:236px; padding:28px; border-radius:18px; }
+  .hub-featured:hover, .hub-card:hover { transform:translateY(-4px); border-color:rgba(124,58,237,.24); box-shadow:0 22px 55px rgba(62,34,107,.1); }
+  .hub-card h2 a { color:var(--text); text-decoration:none; }
+  .hub-card h2 a::after { content:''; position:absolute; inset:0; }
+  .hub-card h2 a:focus-visible { outline:2px solid var(--accent); outline-offset:4px; border-radius:4px; }
+
+  .hub-card-head { display:flex; align-items:center; gap:12px; margin-bottom:16px; }
+  .hub-tile { display:inline-flex; align-items:center; justify-content:center; width:40px; height:40px; border-radius:11px; flex:none; }
+  .hub-tile svg { width:20px; height:20px; }
+  .blue .hub-tile { background:rgba(30,144,255,.1); color:#1668c4; }
+  .violet .hub-tile { background:rgba(138,43,226,.1); color:var(--accent); }
+  .green .hub-tile { background:rgba(0,200,128,.12); color:#05815a; }
+  .orange .hub-tile { background:rgba(230,126,0,.12); color:#b35f00; }
+  .cyan .hub-tile { background:rgba(0,204,221,.14); color:#00808c; }
+
+  .hub-card-eyebrow, .hub-kicker { color:var(--accent); font-family:var(--font-mono); font-size:11px; font-weight:600; letter-spacing:.09em; text-transform:uppercase; }
+  .hub-featured h2 { margin-bottom:12px; max-width:460px; font-size:40px; line-height:1.08; letter-spacing:-1.9px; }
+  .hub-card h2 { font-size:23px; line-height:1.16; letter-spacing:-.9px; }
+  .hub-featured .hub-card-description { max-width:470px; }
+  .hub-card-description { margin-top:9px; color:var(--text-2); font-size:14.5px; line-height:1.68; }
+  .hub-featured .hub-card-description { margin-top:0; font-size:15.5px; line-height:1.72; }
+  .hub-card-foot { display:flex; align-items:center; justify-content:space-between; gap:16px; margin-top:auto; padding-top:22px; }
+  .hub-featured .hub-card-foot { justify-content:flex-start; gap:20px; margin-top:26px; padding-top:0; }
+  .hub-card-link { color:var(--accent); font-size:13px; font-weight:700; }
+  .hub-featured .hub-card-link { font-size:14px; }
+  .hub-card-outcome { display:inline-flex; align-items:center; gap:8px; color:var(--text-2); font-size:12.5px; font-weight:600; }
+  .hub-card-outcome span { width:7px; height:7px; border-radius:50%; flex:none; background:#00c880; box-shadow:0 0 0 4px rgba(0,200,128,.12); }
+
+  /* product panel inside the featured card */
+  .hub-proof { border:1px solid rgba(138,43,226,.11); border-radius:16px; background:#0f0a1a; overflow:hidden; }
+  .hub-proof-bar { display:flex; align-items:center; gap:7px; padding:13px 16px; border-bottom:1px solid rgba(255,255,255,.09); color:rgba(248,245,255,.5); font-family:var(--font-mono); font-size:10px; letter-spacing:.08em; text-transform:uppercase; }
+  .hub-proof-bar i { width:8px; height:8px; border-radius:50%; background:#ff6258; }
+  .hub-proof-bar i:nth-child(2) { background:#ffbd2e; }
+  .hub-proof-bar i:nth-child(3) { background:#29c940; margin-right:6px; }
+  .hub-proof-body { display:grid; gap:12px; padding:20px; }
+  .hub-proof-row { padding:14px 16px; border:1px solid rgba(255,255,255,.08); border-radius:12px; background:rgba(255,255,255,.04); }
+  .hub-proof-label { display:flex; align-items:center; gap:8px; margin-bottom:8px; color:#8de8f1; font-family:var(--font-mono); font-size:9.5px; letter-spacing:.1em; text-transform:uppercase; }
+  .hub-proof-row p { color:rgba(248,245,255,.87); font-size:13px; line-height:1.62; }
+  .hub-proof-row.output { border-color:rgba(0,250,154,.24); background:rgba(0,200,128,.08); }
+  .hub-proof-row.output .hub-proof-label { color:#55e0a8; }
+  .hub-proof-wave { display:flex; align-items:flex-end; gap:2px; height:11px; margin-left:auto; }
+  .hub-proof-wave span { width:2px; border-radius:1px; background:linear-gradient(180deg,#8a2be2,#00ccdd); }
+  .hub-proof-rail { display:grid; grid-template-columns:repeat(4,1fr); gap:8px; padding:2px 20px 20px; }
+  .hub-proof-rail span { position:relative; padding-top:15px; color:rgba(248,245,255,.5); font-family:var(--font-mono); font-size:9px; text-align:center; }
+  .hub-proof-rail span::before { content:''; position:absolute; top:2px; left:0; right:0; height:3px; border-radius:3px; background:linear-gradient(90deg,#8a2be2,#00ccdd); }
+
+  /* ── promises ── */
+  .hub-principles { position:relative; display:grid; grid-template-columns:.82fr 1.18fr; gap:64px; margin-top:76px; padding:46px; border-radius:24px; background:var(--text); color:#fff; overflow:hidden; }
+  .hub-principles::before { content:''; position:absolute; top:0; left:0; right:0; height:3px; background:var(--rainbow-full); }
+  .hub-principles h2 { margin-top:11px; font-size:34px; line-height:1.16; letter-spacing:-1.5px; }
+  .hub-principles .hub-kicker { color:#8de8f1; }
+  .hub-principle-list { display:grid; gap:0; }
+  .hub-principle-list article { display:grid; grid-template-columns:34px 1fr; gap:16px; padding:20px 0; border-bottom:1px solid rgba(255,255,255,.1); }
+  .hub-principle-list article:first-child { padding-top:0; }
   .hub-principle-list article:last-child { padding-bottom:0; border-bottom:0; }
-  .hub-principle-list strong { display:block; margin-bottom:5px; font-size:16px; }
-  .hub-principle-list p { color:rgba(255,255,255,.63); font-size:14px; line-height:1.65; }
-  @media(max-width:850px){.hub-hero,.hub-principles{grid-template-columns:1fr;gap:32px}.hub-grid{grid-template-columns:1fr}.hub-hero h1{letter-spacing:-3px}.hub-card{min-height:350px}.hub-principles{padding:32px}}
-  @media(max-width:600px){.solutions-hub{padding-top:80px}.hub-hero h1{font-size:48px;letter-spacing:-2.7px}.hub-card{padding:26px}.hub-card h2{font-size:28px}.hub-principles{padding:28px 24px}}
+  .hub-principle-icon { display:flex; align-items:center; justify-content:center; width:34px; height:34px; border-radius:9px; background:rgba(255,255,255,.07); color:#8de8f1; }
+  .hub-principle-icon svg { width:17px; height:17px; }
+  .hub-principle-list strong { display:block; margin-bottom:5px; font-size:15.5px; letter-spacing:-.3px; }
+  .hub-principle-list p { color:rgba(255,255,255,.64); font-size:13.5px; line-height:1.65; }
+
+  /* ── closing band ── */
+  .hub-cta { display:flex; align-items:center; justify-content:space-between; gap:40px; margin-top:24px; padding:38px 44px; border:1px solid var(--border-hover); border-radius:24px; background:linear-gradient(135deg,rgba(255,255,255,.92),rgba(240,236,249,.72)); }
+  .hub-cta h2 { margin:9px 0 8px; font-size:32px; letter-spacing:-1.4px; }
+  .hub-cta p:not(.hub-kicker) { color:var(--text-2); font-size:14.5px; }
+  .hub-cta-actions { display:flex; align-items:center; gap:14px; flex:none; }
+  .hub-download, .hub-compare { display:inline-flex; align-items:center; justify-content:center; gap:8px; min-height:48px; padding:13px 22px; border-radius:var(--radius-btn); font-size:14px; font-weight:700; text-decoration:none; transition:transform .2s, box-shadow .2s, background .2s; }
+  .hub-download { color:#fff; background:var(--text); box-shadow:0 10px 28px rgba(15,10,26,.14); }
+  .hub-download:hover { transform:translateY(-2px); box-shadow:0 14px 34px rgba(15,10,26,.2); }
+  .hub-compare { color:var(--accent); border:1px solid rgba(124,58,237,.2); background:rgba(255,255,255,.7); }
+  .hub-compare:hover { background:#fff; }
+
+  @media(max-width:900px){
+    .hub-hero-row { flex-direction:column; align-items:flex-start; gap:16px; }
+    .hub-glance { flex-wrap:wrap; gap:20px 0; padding:20px 22px; }
+    .hub-glance > div { flex:1 1 45%; padding:0 20px; }
+    .hub-glance > div:nth-child(odd) { padding-left:0; border-left:0; }
+    .hub-grid { grid-template-columns:1fr; }
+    .hub-featured { grid-template-columns:1fr; gap:26px; padding:28px; }
+    .hub-featured h2 { font-size:32px; letter-spacing:-1.4px; }
+    .hub-featured .hub-card-foot { flex-direction:column; align-items:flex-start; gap:10px; }
+    .hub-principles { grid-template-columns:1fr; gap:32px; padding:32px; }
+    .hub-card { min-height:0; }
+    .hub-cta { flex-direction:column; align-items:flex-start; gap:24px; padding:30px 26px; }
+    .hub-cta-actions { width:100%; }
+  }
+  @media(max-width:600px){
+    .solutions-hub { padding-top:80px; }
+    .hub-hero h1 { letter-spacing:-2.4px; }
+    .hub-hero-row p { font-size:16px; }
+    .hub-glance > div { flex:1 1 100%; padding:0; border-left:0; }
+    .hub-card { padding:24px; }
+    .hub-card h2 { font-size:21px; }
+    .hub-card-foot { flex-direction:column; align-items:flex-start; gap:9px; }
+    .hub-principles { padding:28px 24px; }
+    .hub-cta-actions { flex-direction:column; align-items:stretch; }
+    .hub-cta h2 { font-size:27px; }
+  }
 </style>

--- a/website/src/pages/solutions/offline-dictation.astro
+++ b/website/src/pages/solutions/offline-dictation.astro
@@ -90,11 +90,11 @@ const directAnswer = `Offline dictation on Mac converts speech to text without s
     </div>
     <div>
       <p class="solution-section-lead">The first speech model download needs an internet connection. EG-1 and local Ollama models also need to be downloaded before you rely on them offline. Once the required files are present, core dictation does not need a server.</p>
-      <div class="solution-callout" style="margin-top:20px"><strong>Hosted is not local</strong><p>An Ollama-hosted model still uses Ollama's servers. Choose a model that is downloaded to your Mac when an offline or fully local text path matters.</p></div>
+      <div class="solution-callout" style="margin-top:22px"><span class="solution-callout-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2.6 20 6v5.4c0 4.3-3.2 7.4-8 8.6-4.8-1.2-8-4.3-8-8.6V6Z"/><path d="m9 12 2.2 2.2L15.4 10"/></svg></span><div><strong>Hosted is not local</strong><p>An Ollama-hosted model still uses Ollama's servers. Choose a model that is downloaded to your Mac when an offline or fully local text path matters.</p></div></div>
     </div>
   </section>
 
-  <section class="solution-section" aria-labelledby="offline-test-heading">
+  <section class="solution-section solution-statement" aria-labelledby="offline-test-heading">
     <div>
       <p class="solution-kicker">A test you can repeat</p>
       <h2 id="offline-test-heading">Turn off Wi-Fi and use the real path.</h2>

--- a/website/src/pages/solutions/open-source.astro
+++ b/website/src/pages/solutions/open-source.astro
@@ -92,11 +92,11 @@ const directAnswer = `An open source dictation app publishes the code that recor
     </div>
     <div>
       <p class="solution-section-lead"><code>swift build</code> compiles the Swift packages after dependencies resolve. The runnable app bundle is assembled with the Xcode build engine through Tuist. The repository's development script creates a local app build, while the release script adds the packaging path for a distributable DMG.</p>
-      <div class="solution-callout" style="margin-top:20px"><strong>A public repository is evidence, not a guarantee</strong><p>Open source lets you inspect and test the implementation. It does not promise that every defect is known or that the software is appropriate for every security policy.</p></div>
+      <div class="solution-callout" style="margin-top:22px"><span class="solution-callout-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2.6 20 6v5.4c0 4.3-3.2 7.4-8 8.6-4.8-1.2-8-4.3-8-8.6V6Z"/><path d="m9 12 2.2 2.2L15.4 10"/></svg></span><div><strong>A public repository is evidence, not a guarantee</strong><p>Open source lets you inspect and test the implementation. It does not promise that every defect is known or that the software is appropriate for every security policy.</p></div></div>
     </div>
   </section>
 
-  <section class="solution-section" aria-labelledby="source-license-heading">
+  <section class="solution-section solution-statement" aria-labelledby="source-license-heading">
     <div>
       <p class="solution-kicker">License boundary</p>
       <h2 id="source-license-heading">The app and EG-1 are not licensed the same way.</h2>

--- a/website/src/pages/solutions/writers.astro
+++ b/website/src/pages/solutions/writers.astro
@@ -59,7 +59,7 @@ const directAnswer = `Dictation for writers on Mac turns spoken ideas into edita
     <div class="proof-window-bar"><i></i><i></i><i></i>first-draft.txt</div>
     <div class="proof-body">
       <div class="proof-row">
-        <span class="proof-row-label">Spoken idea</span>
+        <span class="proof-row-label">Spoken idea<span class="proof-wave" aria-hidden="true"><span style="height:4px"></span><span style="height:9px"></span><span style="height:6px"></span><span style="height:11px"></span><span style="height:5px"></span><span style="height:8px"></span><span style="height:3px"></span><span style="height:7px"></span></span></span>
         <p>I keep thinking the empty train station should feel familiar before the character realizes every clock has stopped.</p>
       </div>
       <div class="proof-row output">
@@ -90,11 +90,11 @@ const directAnswer = `Dictation for writers on Mac turns spoken ideas into edita
     </div>
     <div>
       <p class="solution-section-lead">Cleanup can remove filler, fix punctuation, and give a rambling thought a readable shape. It can also choose a word or rhythm you would not. Treat polished output as draft material, read it against what you meant, and keep the final phrasing yours.</p>
-      <div class="solution-callout" style="margin-top:20px"><strong>Hands-free does not mean hands-off</strong><p>In Push-to-Talk mode, double-press to start a longer passage without holding a key. In Toggle mode, press once to start and once to finish. When the text lands, edit it with the attention the piece deserves.</p></div>
+      <div class="solution-callout" style="margin-top:22px"><span class="solution-callout-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2.6 20 6v5.4c0 4.3-3.2 7.4-8 8.6-4.8-1.2-8-4.3-8-8.6V6Z"/><path d="m9 12 2.2 2.2L15.4 10"/></svg></span><div><strong>Hands-free does not mean hands-off</strong><p>In Push-to-Talk mode, double-press to start a longer passage without holding a key. In Toggle mode, press once to start and once to finish. When the text lands, edit it with the attention the piece deserves.</p></div></div>
     </div>
   </section>
 
-  <section class="solution-section" aria-labelledby="writer-privacy-heading">
+  <section class="solution-section solution-statement" aria-labelledby="writer-privacy-heading">
     <div>
       <p class="solution-kicker">Unpublished stays local when you choose local</p>
       <h2 id="writer-privacy-heading">Know where the manuscript text goes.</h2>


### PR DESCRIPTION
## Why

The six pages under `/solutions/` shipped in #2331, #2332 and #2333. They read as templated next to the rest of the site, and the causes are structural rather than cosmetic:

| | Tell |
|---|---|
| 1 | The direct answer is one unbroken paragraph of 159 to 165 words, 9 to 11 sentences, directly under the hero |
| 2 | Five cards in a two-column grid, so the fifth sits alone beside a card-sized hole |
| 3 | The last section of every page is a heading beside one paragraph, nothing on the right |
| 4 | The questions are unstyled `<details>` with the browser's default triangle |
| 5 | The hub never asks for the download |
| 6 | Rainbow top-bar plus blurred corner blob on the hub cards, used nowhere else on the site |

The five workflow pages are one shared template filled in five times, so the fix is two files.

## What changed

**Shared template** (`SolutionLayout.astro`, so all five workflow pages):

- **The direct answer is split for layout only.** The lead sentence is promoted, the remainder is grouped two sentences to a paragraph and dealt into two columns at whichever split leaves them closest in length. Every word and the original word order survive. The built pages measure **159 / 156 / 165 / 162 / 164** words, exactly their source strings, so nothing indexable moved.
- Questions become the house accordion: numbered, custom plus/minus mark, hover and open states, first one open.
- `.solution-statement` gives a heading-plus-one-paragraph section its own contained treatment rather than leaving half the grid empty. Applied to the last section of ai-polish, offline-dictation, open-source and writers.
- `.solution-lanes` renders what stays on the Mac against what crosses the network, audio explicitly outside the second lane. Used on the developers page. **Every item is a claim already made in that page's own copy** — no new product claims.
- Related links, trust chips, download buttons and the closing band move to the site's existing scale and colour.

**Hub** (`solutions/index.astro`):

- One featured workflow at full width with a product panel, then four compact cards. Five items, no orphan row.
- The template signature comes off the cards; tinted icon tiles from the existing palette replace it, one accent per workflow.
- Facts move into a four-cell strip under the hero, and the page now closes with a download band like every other page.
- `featured` is **enforced at build time**, not asserted in a comment: a second featured card throws, because it would silently render as an ordinary card and leave the grid a row short.

## Guard change

`check-solutions.mjs` counted the **last** paragraph in the answer block, which the split makes meaningless. It now:

- sums every paragraph inside a required `[data-answer-prose]` container,
- fails closed when that container is missing,
- additionally rejects an answer that was never broken up.

Its test gains those three cases plus a multi-paragraph fixture. **Mutation control:** against the old single-paragraph checker, 5 of the 7 tests go red and the 2 unrelated ones stay green; restoring the checker returns 7/7 with a byte-identical file. The `featured` guard was mutation-controlled the same way — a second featured card fails the build with its own message.

## Validation

| Check | Result |
|---|---|
| `npm run build` | help content 56 articles, 0 errors · solutions 6/6 routes, 0 errors |
| `npm run check:help` | routes 69/69, 0 dead links · search 42/42 |
| `npm run test:solutions` | 7/7 |
| Horizontal overflow, all six routes at 390px and 768px | none |
| Rendered locally | 1440px and 390px, hub and all five workflow pages |

Lane: Content. Tier: SMALL (UI layout, no copy rewritten).

No tracking issue: founder request in session.
