### PR TITLE
feat(website): answer the VoiceInk buying question, and stop the compare index outranking its own children

### DIFF
--- a/website/src/pages/compare/index.astro
+++ b/website/src/pages/compare/index.astro
@@ -64,8 +64,8 @@ const itemListJsonLd = JSON.stringify({
 ---
 
 <BaseLayout
-  title="Compare 17 Mac Dictation Apps with Free EnviousWispr"
-  description="Browse 17 head-to-head comparisons of free EnviousWispr and Mac dictation apps. Compare price, privacy, offline use, languages, and everyday workflow."
+  title="EnviousWispr Comparisons: Pick a Mac Dictation App"
+  description="Choose which Mac dictation app to compare against free EnviousWispr. Seventeen head-to-head breakdowns. For a recommendation, read our picks by use case."
   activePage="compare"
   canonicalPath="/compare/"
 >
@@ -183,6 +183,28 @@ const itemListJsonLd = JSON.stringify({
   transition: background 0.15s;
 }
 .compare-cta .btn-primary:hover { background: var(--accent-hover); }
+
+  /* Signpost to the recommendation page (#2340). The index is a directory; this is the
+     visible route to the page that answers "which one should I use". */
+  .compare-signpost { display: grid; grid-template-columns: 1.4fr 1fr; gap: 14px; margin-top: 22px; }
+  .compare-signpost a {
+    display: flex; flex-direction: column; gap: 6px; padding: 20px 22px;
+    border: 1px solid var(--border-hover); border-radius: var(--radius-card);
+    background: rgba(255,255,255,.72); text-decoration: none;
+    transition: transform .2s, border-color .2s, box-shadow .2s;
+  }
+  .compare-signpost a:hover {
+    transform: translateY(-2px); border-color: rgba(124,58,237,.26);
+    box-shadow: 0 14px 34px rgba(62,34,107,.08);
+  }
+  .compare-signpost-label {
+    color: var(--text-3); font-family: var(--font-mono); font-size: 10.5px;
+    letter-spacing: .06em; text-transform: uppercase;
+  }
+  .compare-signpost-title { color: var(--text); font-size: 16px; font-weight: 700; letter-spacing: -.4px; }
+  .compare-signpost-primary { background: linear-gradient(135deg, rgba(255,255,255,.9), rgba(240,236,249,.7)); }
+  .compare-signpost-primary .compare-signpost-title { color: var(--accent); }
+  @media (max-width: 760px) { .compare-signpost { grid-template-columns: 1fr; } }
 </style>
 
 <div class="compare-hero">
@@ -195,7 +217,16 @@ const itemListJsonLd = JSON.stringify({
     </a>
     <span class="compare-hero-cta-sub">macOS 14+, Apple Silicon. No account. Works offline.</span>
     <p class="compare-intro">Mac dictation tools split into three groups: cloud-based services that send your audio to a server (<a href="/compare/wisprflow/">WisprFlow</a>, <a href="/compare/otter-ai/">Otter.ai</a>, <a href="/compare/notta/">Notta</a>, <a href="/compare/google-docs-voice-typing/">Google Docs Voice Typing</a>), apps that offer local or mixed processing (<a href="/compare/superwhisper/">Superwhisper</a>, <a href="/compare/macwhisper/">MacWhisper</a>, <a href="/compare/voiceink/">VoiceInk</a>, <a href="/compare/willow-voice/">Willow Voice</a>, <a href="/compare/handy/">Handy</a>, <a href="/compare/fluidvoice/">FluidVoice</a>, <a href="/compare/juno/">Juno</a>, <a href="/compare/typewhisper/">TypeWhisper</a>, <a href="/compare/spokenly/">Spokenly</a>, <a href="/compare/vox/">Vox</a>), and legacy or developer-focused tools (<a href="/compare/dragon/">Dragon</a>, <a href="/compare/apple-dictation/">Apple Dictation</a>, <a href="/compare/whisper-cpp/">whisper.cpp</a>). Each comparison covers price, privacy, offline use, language support, and the workflow each tool fits best, so you can narrow the list without installing all 17.</p>
-    <p class="compare-intro" style="margin-top: 16px;">Want a recommendation rather than a directory? See our guide to the <a href="/compare/best-dictation-apps-for-mac/">best dictation apps for Mac by use case</a>. If you are specifically replacing WisprFlow without a subscription, start with our <a href="/compare/wisprflow-alternatives/">free WisprFlow alternatives for Mac</a>.</p>
+    <div class="compare-signpost">
+      <a href="/compare/best-dictation-apps-for-mac/" class="compare-signpost-primary">
+        <span class="compare-signpost-label">Want a recommendation, not a directory?</span>
+        <span class="compare-signpost-title">Best dictation apps for Mac, picked by use case &rarr;</span>
+      </a>
+      <a href="/compare/wisprflow-alternatives/" class="compare-signpost-secondary">
+        <span class="compare-signpost-label">Replacing WisprFlow?</span>
+        <span class="compare-signpost-title">Free WisprFlow alternatives for Mac &rarr;</span>
+      </a>
+    </div>
   </div>
 </div>
 

--- a/website/src/pages/compare/voiceink.astro
+++ b/website/src/pages/compare/voiceink.astro
@@ -392,7 +392,7 @@ const faqJsonLd = JSON.stringify({
     <div class="vi-answer reveal">
       <p class="vi-answer-kicker">The short answer</p>
       <h2 id="voiceink-answer-heading">Is VoiceInk free, and is it open source?</h2>
-      <p class="vi-answer-lead">VoiceInk is a Mac dictation app that transcribes on your Mac. It is open source under GPL v3, and the app is paid: one-time pricing of $29 for one Mac, $49 for two, or $69 for three, with no subscription.</p>
+      <p class="vi-answer-lead">VoiceInk is a Mac dictation app that can transcribe on your Mac, depending on which of its three engines you pick. It is open source under GPL v3, and the app is paid: one-time pricing of $29 for one Mac, $49 for two, or $69 for three, with no subscription.</p>
       <dl class="vi-facts">
         <div>
           <dt>What it costs</dt>
@@ -408,10 +408,10 @@ const faqJsonLd = JSON.stringify({
         </div>
         <div>
           <dt>Where audio goes</dt>
-          <dd>Stays on your Mac. Both apps transcribe on device.</dd>
+          <dd>On device with whisper.cpp or Parakeet. Its third engine, Cohere Transcribe, is a cloud option, so that one sends audio out.</dd>
         </div>
       </dl>
-      <p class="vi-answer-foot">If you want the same on-device privacy without buying a licence, EnviousWispr is free and GPL v3. The full comparison is below. Pricing re-verified from tryvoiceink.com on 21 August 2026.</p>
+      <p class="vi-answer-foot">EnviousWispr is free, GPL v3, and always transcribes on your Mac, with no engine that sends audio anywhere. The full comparison is below. Pricing and engines re-verified from tryvoiceink.com and the VoiceInk GitHub repository on 21 August 2026.</p>
     </div>
   </div>
 </section>

--- a/website/src/pages/compare/voiceink.astro
+++ b/website/src/pages/compare/voiceink.astro
@@ -145,7 +145,7 @@ const faqJsonLd = JSON.stringify({
 
 <BaseLayout
   title="VoiceInk vs EnviousWispr: Free, Open-Source Dictation"
-  description="VoiceInk is on-device and open source with a paid app after a free trial. EnviousWispr is completely free, GPLv3, and needs no account. Compared."
+  description="VoiceInk is open source under GPL v3 and the app is paid, from $29 one-time. EnviousWispr is free, GPLv3, on-device, and needs no account. Compared."
   activePage="compare"
   ogImage="/images/og/voiceink.png"
   ogType="article"
@@ -316,6 +316,40 @@ const faqJsonLd = JSON.stringify({
   .page-header h1 { font-size: 34px; letter-spacing: -1px; }
   .compare-table-wrap { margin: 0 -20px; border-radius: 0; border-left: none; border-right: none; }
 }
+
+  /* Direct answer block (#2340): the buying question, above the comparison. */
+  .vi-answer-section { padding-top: 0; }
+  .vi-answer {
+    position: relative; max-width: 900px; padding: 34px 38px 30px;
+    border: 1px solid var(--border-hover); border-left: 0; border-radius: 0 20px 20px 0;
+    background: rgba(255,255,255,.86); box-shadow: 0 16px 44px rgba(62,34,107,.07);
+  }
+  .vi-answer::before {
+    content: ''; position: absolute; left: 0; top: 0; bottom: 0; width: 4px;
+    border-radius: 4px 0 0 4px; background: linear-gradient(180deg, var(--accent), var(--cyan));
+  }
+  .vi-answer-kicker {
+    margin-bottom: 8px; color: var(--accent); font-family: var(--font-mono);
+    font-size: 11px; font-weight: 600; letter-spacing: .09em; text-transform: uppercase;
+  }
+  .vi-answer h2 { margin-bottom: 16px; font-size: 30px; letter-spacing: -1.2px; }
+  .vi-answer-lead { color: var(--text); font-size: 19px; line-height: 1.62; letter-spacing: -.3px; }
+  .vi-facts {
+    display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px 40px;
+    margin-top: 22px; padding-top: 20px; border-top: 1px solid var(--border);
+  }
+  .vi-facts dt {
+    margin-bottom: 5px; color: var(--text-3); font-family: var(--font-mono);
+    font-size: 10.5px; letter-spacing: .06em; text-transform: uppercase;
+  }
+  .vi-facts dd { color: var(--text-2); font-size: 15px; line-height: 1.6; }
+  .vi-answer-foot { margin-top: 22px; color: var(--text-2); font-size: 14.5px; line-height: 1.7; }
+  @media (max-width: 700px) {
+    .vi-answer { padding: 24px 22px; border-radius: 0 16px 16px 0; }
+    .vi-answer h2 { font-size: 24px; }
+    .vi-answer-lead { font-size: 17px; }
+    .vi-facts { grid-template-columns: 1fr; gap: 14px; }
+  }
 </style>
 
 <!-- Page Header -->
@@ -351,6 +385,36 @@ const faqJsonLd = JSON.stringify({
     <p class="hero-meta reveal">By <a href="/authors/saurabh-vaish/" style="color: var(--text-3); text-decoration: underline;">Saurabh Vaish</a> · Last reviewed: August 2026</p>
   </div>
 </header>
+
+<!-- Direct answer: the questions people actually arrive with (#2340) -->
+<section class="section vi-answer-section" aria-labelledby="voiceink-answer-heading">
+  <div class="container">
+    <div class="vi-answer reveal">
+      <p class="vi-answer-kicker">The short answer</p>
+      <h2 id="voiceink-answer-heading">Is VoiceInk free, and is it open source?</h2>
+      <p class="vi-answer-lead">VoiceInk is a Mac dictation app that transcribes on your Mac. It is open source under GPL v3, and the app is paid: one-time pricing of $29 for one Mac, $49 for two, or $69 for three, with no subscription.</p>
+      <dl class="vi-facts">
+        <div>
+          <dt>What it costs</dt>
+          <dd>$29 Solo, $49 Personal, $69 Extended. One-time, not a subscription.</dd>
+        </div>
+        <div>
+          <dt>Is it free?</dt>
+          <dd>The source is public, so you can build it yourself. The packaged app is paid.</dd>
+        </div>
+        <div>
+          <dt>Is it open source?</dt>
+          <dd>Yes, GPL v3 on GitHub. Same licence EnviousWispr uses.</dd>
+        </div>
+        <div>
+          <dt>Where audio goes</dt>
+          <dd>Stays on your Mac. Both apps transcribe on device.</dd>
+        </div>
+      </dl>
+      <p class="vi-answer-foot">If you want the same on-device privacy without buying a licence, EnviousWispr is free and GPL v3. The full comparison is below. Pricing re-verified from tryvoiceink.com on 21 August 2026.</p>
+    </div>
+  </div>
+</section>
 
 <!-- Side-by-Side Table -->
 <section class="section" aria-label="Feature Comparison">


### PR DESCRIPTION
Two measured problems from #2340, both in the comparison cluster.

## 1. VoiceInk is the biggest winnable term on the site

`voiceink` is **306 impressions at position 11.4** — one push off page one, and the largest single opportunity we have. The modifiers tell us exactly what those searchers want, and we already rank for all of them:

| Query | Impressions | Position |
|---|---|---|
| voiceink | 306 | 11.4 |
| voiceink pricing | 48 | 5.6 |
| voiceink free | 23 | 9.3 |
| voice ink purchase. | 17 | 11.4 |
| voiceink open source | 11 | 9.2 |

Every one is a buying question. The page opened straight into a feature comparison and answered none of them above the fold.

Added a direct-answer block ahead of the comparison: what VoiceInk is, what it costs, whether it is free, whether it is open source, where audio goes. **Every figure comes from this page's own sourced evidence block**, re-verified from tryvoiceink.com on 2026-08-21, and the block says so on the page.

### A real defect found while writing it

`a paid app after a free trial` existed **only in the meta description**. It appears nowhere in the page's sourced evidence block, so an unverified claim about a competitor was shipping in our search snippet. The brand pack requires source, date and confidence for competitor claims; this had none of the three. Replaced with the sourced pricing fact.

## 2. The compare index is outranking its own children

The bare `/compare/` index, a directory of 17 cards, takes the majority impression share for category queries at positions 73 to 88 and earns zero clicks:

| Query | `/compare/` | The page built for it |
|---|---|---|
| mac dictation vs dragon | 100 imp, pos 88.4 | `/compare/dragon/` 26 imp, pos 73.0 |
| dictation software for mac | 75 imp, pos 73.5 | best-apps 18 imp, pos 74.3 |
| apple dictation vs dragon | 57 imp, pos 75.9 | `/compare/dragon/` 8 imp, pos 66.1 |
| dictation program for mac | 54 imp, pos 74.7 | best-apps 11 imp, pos 76.0 |

The description was the bait: it promised the category answer ("Compare price, privacy, offline use, languages") on a page that is a directory. Retitled and rewritten to read as a directory and hand the recommendation intent to the page that answers it. The recommendation link was one clause buried in a second prose paragraph; it is now a visible signpost carrying both it and the WisprFlow-alternatives route.

**This is a hypothesis about which page Google should choose, not a ranking promise.** Both pages sit in the 60s to 80s today, so there are no clicks to lose. #2340 carries the re-measure date.

## Validation

| Check | Result |
|---|---|
| `npm run build` | 132 pages, help content 56 articles 0 errors |
| `npm run check:help` | routes 69/69, 0 dead internal links, search 42/42 |
| Signpost targets resolve in `dist` | both ✓ |
| em/en dashes added | none |
| `trial` in rendered VoiceInk page | 0 |
| Browser review | both pages, desktop |

Lane: Content. Tier: SMALL.

Refs #2340.