### PR TITLE
fix(website): attribute nav download clicks, which were 68% of all downloads and invisible

### DIFF
--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -45,7 +45,7 @@ const year = new Date().getFullYear();
           <a href="/compare/">Compare</a>
           <a href="/blog/">Blog</a>
           <a href="/help/">Help</a>
-          <a href="https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg">Download</a>
+          <a href="https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg" data-download-source="footer">Download</a>
         </nav>
         <div class="footer-social" aria-label="Social Links">
           <a href="https://x.com/EnviousLabs" target="_blank" rel="noopener" aria-label="X (Twitter)">

--- a/website/src/components/Nav.astro
+++ b/website/src/components/Nav.astro
@@ -53,7 +53,7 @@ const { activePage = 'home' } = Astro.props;
       <a href="https://github.com/saurabhav88/EnviousWispr" class="nav-gh" target="_blank" rel="noopener" aria-label="GitHub">
         <svg viewBox="0 0 24 24" fill="currentColor" width="20" height="20" aria-hidden="true"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
       </a>
-      <a href="https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg" class="nav-cta">
+      <a href="https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg" class="nav-cta" data-download-source="nav">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="14" height="14" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
         Download Free
       </a>

--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -104,7 +104,7 @@ const ogImageUrl = ogImage.startsWith('http') ? ogImage : `${siteUrl}${ogImage}`
       const link = e.target.closest('a[href*="EnviousWispr.dmg"]');
       if (!link || typeof window.posthog === 'undefined') return;
       const source = link.dataset.downloadSource
-        || link.closest('nav')?.classList.contains('nav-bar') && 'nav'
+        || link.closest('nav') && 'nav'
         || link.closest('.hero-section') && 'hero'
         || link.closest('.cta-section') && 'bottom-cta'
         || link.closest('footer') && 'footer'


### PR DESCRIPTION
## The finding

PostHog, last 90 days: **878 download clicks, 594 of them recorded as source `unknown`.** That is 68% of every download click on the site landing in a bucket that tells us nothing.

| Source | Clicks |
|---|---|
| **unknown** | **594** |
| hero | 212 |
| bottom-cta | 29 |
| footer | 12 |
| how-it-works | 12 |
| compare-hero | 12 |
| blog-index-hero | 5 |
| compare | 1 |
| blog-post | 1 |

## The cause

The handler in `BaseLayout.astro` resolved the nav like this:

```js
link.closest('nav')?.classList.contains('nav-bar') && 'nav'
```

The nav element carries `class="nav"`. **`nav-bar` appeared nowhere on the site except that line**, so the branch could never match and every nav click fell through to `unknown`. The nav CTA is on all 132 pages and is the most prominent download button we have, which is why the unknown bucket is so large.

Separately, the nav and footer links were the only 2 of the site's 29 download links with no explicit `data-download-source`. The other 27 all declare one.

## The fix

- Nav and footer CTAs now declare `data-download-source` explicitly, like every other CTA. The footer already resolved correctly via `closest('footer')`, but relying on DOM structure is what produced the nav bug.
- The dead selector is replaced with a working one and kept only as a safety net for a link that forgets the attribute.

## Verified in the browser, not by reading

The first control was **vacuous**: with the new attribute present, `dataset.downloadSource` short-circuits before either selector runs, so old and new agreed by construction. Re-run ignoring the attribute, which is the state the nav was actually in:

```
nav link, selector OLD : "unknown"   <- defect reproduced
nav link, selector NEW : "nav"
nav link, attribute    : "nav"
```

## What to expect

Nothing changes for a visitor. It changes whether we can tell which button earns a download, which is the input to every conversion decision after this.

The unknown bucket should collapse and a `nav` row should appear within a day of deploy. **If unknown stays high afterwards, the remaining source is something this change did not cover** and should be traced before further conversion work.

## Validation

| Check | Result |
|---|---|
| `npm run build` | help content 56 articles, 0 errors |
| `npm run check:help` | routes 69/69, 0 dead links, search 42/42 |
| Download links declaring a source | 29 of 29 |
| `nav-bar` occurrences site-wide | 0 |

Lane: Content. Tier: SMALL.

Refs #2340.