### PR TITLE
test(clipboard): unwrap route callees before classifying them (#2215)

### DIFF
--- a/Tests/EnviousWisprTests/Architecture/ClipboardIsolationFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/ClipboardIsolationFreezeTests.swift
@@ -842,7 +842,8 @@ struct ClipboardIsolationFreezeTests {
     }
 
     override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
-      guard let member = node.calledExpression.as(MemberAccessExprSyntax.self) else {
+      guard let member = ClipboardVisitor.unwrapped(
+        node.calledExpression).as(MemberAccessExprSyntax.self) else {
         return .visitChildren
       }
       let functionName = member.declName.baseName.text
@@ -894,10 +895,11 @@ struct ClipboardIsolationFreezeTests {
     }
 
     private func trailingName(of expression: ExprSyntax?) -> String? {
-      if let reference = expression?.as(DeclReferenceExprSyntax.self) {
+      let unwrappedExpression = expression.map { ClipboardVisitor.unwrapped($0) }
+      if let reference = unwrappedExpression?.as(DeclReferenceExprSyntax.self) {
         return reference.baseName.text
       }
-      if let member = expression?.as(MemberAccessExprSyntax.self) {
+      if let member = unwrappedExpression?.as(MemberAccessExprSyntax.self) {
         return member.declName.baseName.text
       }
       return nil
@@ -1064,6 +1066,20 @@ struct ClipboardIsolationFreezeTests {
         func deliver() {
           EnviousWisprServices.PasteService.copyToClipboardReturningChangeCount(
             "one", to: pasteboard)
+        }
+        """)
+    let visitor = SnapshotRoutingVisitor(viewMode: .sourceAccurate)
+    visitor.walk(tree)
+
+    #expect(visitor.automaticRoutesHaveSnapshots == [false])
+  }
+
+  @Test("a parenthesized route callee is still classified")
+  func parenthesizedCalleeIsCaught() {
+    let tree = Parser.parse(
+      source: """
+        func deliver() {
+          (PasteService.copyToClipboardReturningChangeCount)("one", to: pasteboard)
         }
         """)
     let visitor = SnapshotRoutingVisitor(viewMode: .sourceAccurate)


### PR DESCRIPTION
Closes #2215

`SnapshotRoutingVisitor` classified paste routes by casting the callee straight to `MemberAccessExprSyntax`, so a valid parenthesized spelling — `(PasteService.copyToClipboardReturningChangeCount)("one", to: pasteboard)` — walked past the guard and left a real route out of the cleanup inventory. Both classification sites now go through the existing `ClipboardVisitor.unwrapped` helper, which strips spellings that change syntax but not value (parentheses, a one-element tuple, an `as` coercion):

- `visit(_ node: FunctionCallExprSyntax)`: unwrap `node.calledExpression` before the `MemberAccessExprSyntax` cast.
- `trailingName(of:)`: unwrap `expression` once at the top and run both existing casts against the unwrapped value, mirroring `ClipboardVisitor.trailingName(of:)`. The call site `guard trailingName(of: member.base) == "PasteService"` is unchanged.
- New regression test `parenthesizedCalleeIsCaught`: a parenthesized route callee is classified and reported as missing its cleanup snapshot.

Unwrapping is a no-op on an expression that needs no unwrapping, so the three real, unparenthesized routes in `PasteCascadeExecutor.swift` are counted exactly as before and `pasteRoutesUseCleanupSnapshot` still expects three.

**Not built or tested on the authoring machine.** This machine has no macOS toolchain or Xcode, so no Swift build and no test run was performed here. The change is a careful, minimal, test-only edit and needs the real build and test suite on a Mac to verify it.

posted by pi (local qwen3.8-27b on aliensv) at 2026-08-23T15:25:44Z