### PR TITLE
fix(scripts): judge microphone stop budget from marker mtimes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,6 +168,9 @@ scripts/lib/*
 # who already knows it exists, which is precisely the person who does not need it.
 !scripts/check-preview-engine-resources.sh
 !scripts/xcode-test.sh
+# #2335: end-to-end fake-swift driver for the receipt watchdog. Tracked for the same reason as
+# the checks above — a gitignored regression driver only runs for someone who already knows it.
+!scripts/test-real-microphone.test.sh
 # #2141: the grandfather list the test-inventory gate checks against. Tracked for the same reason as
 # the two checks above — a gitignored baseline can only be read by someone who already knows the split
 # is wrong, which is exactly the person who does not need it. The gate itself is a Swift test

--- a/scripts/test-real-microphone.sh
+++ b/scripts/test-real-microphone.sh
@@ -81,6 +81,7 @@ with tempfile.TemporaryDirectory(prefix="ew-microphone-watchdog-") as marker_dir
         relay = threading.Thread(target=relay_output, daemon=True)
         relay.start()
         stop_deadline = None
+        started_at = None
         timed_out = False
         def group_exists():
             try:
@@ -109,21 +110,36 @@ with tempfile.TemporaryDirectory(prefix="ew-microphone-watchdog-") as marker_dir
                 signal_group(signal.SIGKILL)
                 process.wait()
 
+        stop_error = "ERROR: stopCapture and stream completion exceeded two seconds.\n"
         try:
             while True:
                 if received_signal[0] is not None:
                     reap_group()
                     break
+                # Read the markers before the exit poll: they live in the
+                # watchdog's own directory and outlive the Swift process, so an
+                # iteration that wakes after a long shutdown would otherwise see
+                # only the exit and report a clean receipt.
+                if started.exists() and started_at is None:
+                    started_at = started.stat().st_mtime
+                    stop_deadline = time.monotonic() + 2.0
+                if started_at is not None and finished.exists():
+                    # Judge the shutdown by the markers' own timestamps, not by
+                    # when this loop happened to look. Both mtimes come from the
+                    # same filesystem clock, so the difference is meaningful.
+                    if finished.stat().st_mtime - started_at > 2.0:
+                        sys.stderr.write(stop_error)
+                        log.write(stop_error)
+                        log.flush()
+                        timed_out = True
+                        reap_group()
+                        break
+                    stop_deadline = None
                 if process.poll() is not None:
                     break
-                if started.exists() and stop_deadline is None:
-                    stop_deadline = time.monotonic() + 2.0
-                if finished.exists():
-                    stop_deadline = None
                 if stop_deadline is not None and time.monotonic() >= stop_deadline:
-                    message = "ERROR: stopCapture and stream completion exceeded two seconds.\n"
-                    sys.stderr.write(message)
-                    log.write(message)
+                    sys.stderr.write(stop_error)
+                    log.write(stop_error)
                     log.flush()
                     timed_out = True
                     reap_group()

--- a/scripts/test-real-microphone.test.sh
+++ b/scripts/test-real-microphone.test.sh
@@ -36,11 +36,14 @@ EOF
 FAKE_SWIFT_B=$(cat <<EOF
 #!/usr/bin/env bash
 sleep 3
-touch "\$EW_MICROPHONE_STOP_STARTED"
-started_epoch=\$(stat -c %Y "\$EW_MICROPHONE_STOP_STARTED")
-touch -d "@\$((started_epoch + 3))" "\$EW_MICROPHONE_STOP_FINISHED"
+python3 -c "
+import os,sys,time
+now=time.time()
+s,f=sys.argv[1],sys.argv[2]
+open(s,'w').close(); open(f,'w').close()
+os.utime(s,(now-3.0,now-3.0)); os.utime(f,(now,now))
+" "\$EW_MICROPHONE_STOP_STARTED" "\$EW_MICROPHONE_STOP_FINISHED"
 printf '%s\n' '$PASS_LINE'
-sleep 0.5
 EOF
 )
 

--- a/scripts/test-real-microphone.test.sh
+++ b/scripts/test-real-microphone.test.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# End-to-end driver for the stop watchdog in scripts/test-real-microphone.sh.
+#
+# `swift` is not present on this machine, and is not needed: each arm creates
+# its own temp dir holding a fake `swift` that speaks the marker protocol the
+# real test binary performs (touching $EW_MICROPHONE_STOP_STARTED and
+# $EW_MICROPHONE_STOP_FINISHED), and the real shipped script is executed
+# end to end with that dir prepended to PATH.
+#
+# Arms:
+#   A (in budget)                        started -> 0.1 s -> finished    expect 0
+#   B (over budget, markers at once)     started + finished, 3 s apart   expect 124
+#   C (over budget, never finishes)      started, no finished            expect 124
+#
+# Arm B is the regression for the clear-before-expiry bug; arm C guards the
+# already-working wall-clock expiry path; arm A guards against a fix that
+# fails everything. The test exits non-zero if any arm fails.
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/test-real-microphone.sh"
+
+PASS_LINE='Test "the built-in microphone produces non-zero 16 kHz mono samples and stops cleanly" passed after 0.1 seconds'
+
+# Unquoted heredocs: $PASS_LINE expands now; \$EW_* stay literal in the fake.
+FAKE_SWIFT_A=$(cat <<EOF
+#!/usr/bin/env bash
+touch "\$EW_MICROPHONE_STOP_STARTED"
+sleep 0.1
+touch "\$EW_MICROPHONE_STOP_FINISHED"
+printf '%s\n' '$PASS_LINE'
+EOF
+)
+
+FAKE_SWIFT_B=$(cat <<EOF
+#!/usr/bin/env bash
+sleep 3
+touch "\$EW_MICROPHONE_STOP_STARTED"
+started_epoch=\$(stat -c %Y "\$EW_MICROPHONE_STOP_STARTED")
+touch -d "@\$((started_epoch + 3))" "\$EW_MICROPHONE_STOP_FINISHED"
+printf '%s\n' '$PASS_LINE'
+sleep 0.5
+EOF
+)
+
+FAKE_SWIFT_C=$(cat <<EOF
+#!/usr/bin/env bash
+touch "\$EW_MICROPHONE_STOP_STARTED"
+sleep 5
+printf '%s\n' '$PASS_LINE'
+EOF
+)
+
+failures=0
+
+run_arm() {
+  local name="$1" expected="$2" body="$3"
+  local dir status
+  dir="$(mktemp -d)"
+  printf '%s\n' "$body" >"$dir/swift"
+  chmod +x "$dir/swift"
+  status=0
+  PATH="$dir:$PATH" bash "$SCRIPT" >/dev/null 2>&1 || status=$?
+  rm -rf "$dir"
+  if [ "$status" -ne "$expected" ]; then
+    echo "arm $name: expected exit $expected, got $status" >&2
+    failures=$((failures + 1))
+    return 0
+  fi
+  echo "arm $name: exit $status, as required"
+}
+
+run_arm "A (in budget)" 0 "$FAKE_SWIFT_A"
+run_arm "B (over budget, both markers observed together)" 124 "$FAKE_SWIFT_B"
+run_arm "C (over budget, never finishes)" 124 "$FAKE_SWIFT_C"
+
+if [ "$failures" -gt 0 ]; then
+  echo "test-real-microphone.test: $failures of 3 arms failed" >&2
+  exit 1
+fi
+echo "test-real-microphone.test: all 3 arms passed"


### PR DESCRIPTION
## What changed

The watchdog in `scripts/test-real-microphone.sh` cleared its 2 s stop deadline on `finished.exists()` **before** the expiry check, and derived the deadline from when the poll loop happened to notice `started` rather than when the shutdown actually began. Any iteration that observed both markers together (deterministic when both markers land between two polls, and whenever the loop is descheduled across the shutdown) set and wiped the deadline in the same iteration, so the over-budget branch could never fire and a 10 s shutdown reported a clean receipt.

The watchdog now judges the shutdown by the markers' own timestamps:

- first observation of `started` records `started_at = started.stat().st_mtime`
- observation of `finished` computes `finished.stat().st_mtime - started_at`; if that exceeds the 2 s budget it takes the **same** failure branch the timeout takes (same message, same `timed_out` flag, same `reap_group()`, exit 124). The deadline is cleared only when the interval is within budget
- the existing wall-clock expiry branch is kept, so a shutdown that never finishes at all still fails
- marker reads moved ahead of the exit poll: the marker files live in the watchdog's own temp dir and outlive the Swift process, so a loop iteration that wakes after a long shutdown would otherwise see only the exit

Both mtimes come from the same filesystem clock; no mtime is mixed with a `time.monotonic()` value. The 2 s budget is unchanged, nothing under `Sources/` or `Tests/` was touched, no tolerance knob or escape hatch was added, and `set -euo pipefail` stays.

One mechanical addition: `.gitignore` gets a `!scripts/test-real-microphone.test.sh` exception. The repo ignores `scripts/*` by default and requires an explicit per-script exception for anything that should ship (documented in the file); without it the new test driver below could not be tracked.

## Proof: this ran on Linux with a fake `swift`

**This ran on Linux with a fake `swift` earlier on PATH. NO Swift build or Xcode test ran.** `swift` does not exist on this machine. The fake `swift` scripts only perform the marker-file protocol (touching `$EW_MICROPHONE_STOP_STARTED` / `$EW_MICROPHONE_STOP_FINISHED` on the schedule each arm controls) and print the exact line the receipt greps for. `scripts/test-real-microphone.test.sh` (new, executable, no arguments) runs the **real shipped script** end to end, three arms, each in its own temp dir:

| Arm | Fake swift behaviour | Required exit | Observed exit |
|---|---|---|---|
| A in budget | touch `started`, sleep 0.1, touch `finished`, print the pass line | 0 | **0** |
| B over budget, both markers observed together | sleep 3, touch `started` AND `finished` with `finished` mtime 3 s after `started`, print the pass line | 124 | **124** |
| C over budget, never finishes | touch `started`, sleep 5, print the pass line, never touch `finished` | 124 | **124** |

Arms A–C observed: **0, 124, 124** — all pass, repeated across three consecutive full runs.

## Two-way control (pre-fix copy)

Non-destructive, on copies: the script was copied to a scratch path with **only the watchdog change reverted** (i.e. the pre-fix loop), a copy of the test was pointed at that copy, and all three arms were run against it:

```
arm A (in budget): exit 0, as required
arm B (over budget, both markers observed together): expected exit 124, got 0
arm C (over budget, never finishes): exit 124, as required
test-real-microphone.test: 1 of 3 arms failed   (exit 1)
```

So the test **fails on arm B against the pre-fix code** (the over-budget shutdown reports a clean receipt, exit 0) while arms A and C pass — the test is observed failing before the fix, and green after it. The real file was never modified by the control; it ran on copies only.

Closes #2335
