### PR TITLE
chore(ci): scheduled main validation with fail-closed skip guard

### DIFF
--- a/.github/workflows/main-post-merge.yml
+++ b/.github/workflows/main-post-merge.yml
@@ -13,8 +13,27 @@ on:
       - '.github/workflows/main-post-merge.yml'
       - '.github/actions/xcode-ci-setup/action.yml'
       - 'scripts/ci/verify-checked-out-revision.sh'
+      - 'scripts/ci/post-merge-should-run.sh'
+  schedule:
+    # Hourly re-validation of main HEAD (#2334): during a merge train,
+    # cancel-in-progress cancels every push run before it completes, so main
+    # can sit unverified for hours. The schedule guarantees a green signal
+    # exists within an hour even then. The minute is offset from :00 because
+    # GitHub flags top-of-hour as a high-load window where scheduled runs are
+    # delayed or dropped (#1131). The schedule-guard job skips the macOS
+    # matrix when this HEAD already has a green full-matrix run, so an idle
+    # main costs no macOS minutes.
+    - cron: '7 * * * *'
   workflow_dispatch:
 
+# Concurrency group per event (#2334): push runs group as
+# `main-post-merge-push-refs/heads/main`, scheduled runs as
+# `main-post-merge-schedule-refs/heads/main`, PR runs as
+# `main-post-merge-pull_request-<number>`. The event_name segment isolates
+# the schedule from push: a newer push can still cancel an in-flight push
+# run, but it can never cancel an in-flight scheduled run — which is what
+# lets the hourly validation survive a merge train. Do not "simplify" this
+# group: the push path's per-ref isolation is load-bearing.
 concurrency:
   group: main-post-merge-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -96,17 +115,60 @@ jobs:
               echo "needs_build=true" >> "$GITHUB_OUTPUT"
               echo "==> Manual diagnostic dispatch requires the full Xcode matrix"
               ;;
+            schedule)
+              echo "needs_build=true" >> "$GITHUB_OUTPUT"
+              echo "==> Scheduled main-HEAD validation always runs the full Xcode matrix (#2334)"
+              ;;
             *)
               echo "::error::Unsupported event: $EVENT_NAME"
               exit 1
               ;;
           esac
 
+  # #2334. The schedule's only reason to exist is a merge train, where every
+  # push run of this workflow is cancelled before it completes. The guard
+  # answers whether the current main HEAD already has a green full-matrix
+  # run; if so the expensive macOS jobs skip and an idle main costs no macOS
+  # minutes. It runs on schedule events ONLY: the push path must stay
+  # unconditional and never consults it. Anything the guard cannot determine
+  # answers "run" — a guard that failed closed toward skipping would silently
+  # restore the exact hole #2334 is about.
+  schedule-guard:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      should_run: ${{ steps.guard.outputs.should_run }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+
+      - name: Verify checked-out revision
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: scripts/ci/verify-checked-out-revision.sh
+
+      - name: Decide whether main HEAD is already validated
+        id: guard
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: scripts/ci/post-merge-should-run.sh --sha "${{ github.sha }}"
+
   # The long pole, and the cache WRITER. Builds both configurations (the cache
   # shape pr-check.yml restores) but runs only the release suite.
   release-validation:
-    needs: classify
-    if: needs.classify.outputs.needs_build == 'true'
+    needs: [classify, schedule-guard]
+    # #2334: the schedule path additionally requires the guard to answer
+    # "run". On every other event the guard is skipped and this reduces to
+    # the original condition — the push path is unconditional by design.
+    if: >-
+      needs.classify.outputs.needs_build == 'true' &&
+      (github.event_name != 'schedule' || needs.schedule-guard.outputs.should_run == 'yes')
     runs-on: macos-26
     # Worst observed critical path for this job's steps is ~36 min (44.0 min
     # whole-run max, less the 8.0 min debug suite that run executed). 45 leaves
@@ -258,8 +320,11 @@ jobs:
   # Runs in parallel with release-validation. Restore-only: it never writes the
   # cache, so the writer contract with pr-check.yml has exactly one owner.
   debug-validation:
-    needs: classify
-    if: needs.classify.outputs.needs_build == 'true'
+    needs: [classify, schedule-guard]
+    # #2334: same schedule guard as release-validation (see above).
+    if: >-
+      needs.classify.outputs.needs_build == 'true' &&
+      (github.event_name != 'schedule' || needs.schedule-guard.outputs.should_run == 'yes')
     runs-on: macos-26
     # Whole-job duration over the 20 most recent successful runs: 666-1008s
     # (11.1-16.8 min), median ~850s. The CI-speed pass added coverage
@@ -408,7 +473,7 @@ jobs:
   # One place that says whether main is green. Without this, a reader has to
   # combine three job results by eye, and a SKIPPED job looks like a failure.
   post-merge-result:
-    needs: [classify, release-validation, debug-validation]
+    needs: [classify, release-validation, debug-validation, schedule-guard]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -416,6 +481,9 @@ jobs:
     steps:
       - name: Post result
         env:
+          EVENT_NAME: ${{ github.event_name }}
+          SCHEDULE_GUARD_RESULT: ${{ needs.schedule-guard.result }}
+          SCHEDULE_GUARD: ${{ needs.schedule-guard.outputs.should_run }}
           NEEDS_BUILD: ${{ needs.classify.outputs.needs_build }}
           CLASSIFY_RESULT: ${{ needs.classify.result }}
           RELEASE_RESULT: ${{ needs.release-validation.result }}
@@ -427,6 +495,21 @@ jobs:
           if [ "$CLASSIFY_RESULT" != "success" ]; then
             echo "::error::Change classification did not complete (result=$CLASSIFY_RESULT) — main is UNVERIFIED"
             exit 1
+          fi
+
+          # #2334: the scheduled path consults the skip guard; the push path
+          # does not. A guard that answered "no" is an INTENDED skip — the
+          # full matrix already ran green on this HEAD — and must not fall
+          # into the skipped-while-needs_build defect below.
+          if [ "$EVENT_NAME" = "schedule" ]; then
+            if [ "$SCHEDULE_GUARD_RESULT" != "success" ]; then
+              echo "::error::Schedule guard did not complete (result=$SCHEDULE_GUARD_RESULT) — cannot confirm main HEAD is validated — main is UNVERIFIED"
+              exit 1
+            fi
+            if [ "$SCHEDULE_GUARD" = "no" ]; then
+              echo "Scheduled validation skipped: main HEAD already has a green full-matrix run"
+              exit 0
+            fi
           fi
 
           if [ "$NEEDS_BUILD" != "true" ]; then

--- a/.github/workflows/main-post-merge.yml
+++ b/.github/workflows/main-post-merge.yml
@@ -166,7 +166,18 @@ jobs:
     # #2334: the schedule path additionally requires the guard to answer
     # "run". On every other event the guard is skipped and this reduces to
     # the original condition — the push path is unconditional by design.
+    #
+    # `!cancelled()` is a status check function, so it removes the implicit
+    # success() that otherwise skips a job whenever a `needs` dependency is
+    # skipped — and schedule-guard skips on every non-schedule event, which
+    # was silently dragging both macOS suites into the skip (run 32653384491).
+    # With the implicit success() gone, the classify dependency is enforced
+    # explicitly. It is `!cancelled()`, not `always()`: the latter would run
+    # the suites even while the run is being cancelled, which is the
+    # merge-train waste #2334 exists to reduce.
     if: >-
+      !cancelled() &&
+      needs.classify.result == 'success' &&
       needs.classify.outputs.needs_build == 'true' &&
       (github.event_name != 'schedule' || needs.schedule-guard.outputs.should_run == 'yes')
     runs-on: macos-26
@@ -321,8 +332,11 @@ jobs:
   # cache, so the writer contract with pr-check.yml has exactly one owner.
   debug-validation:
     needs: [classify, schedule-guard]
-    # #2334: same schedule guard as release-validation (see above).
+    # #2334: same schedule guard and status-function rationale as
+    # release-validation (see above).
     if: >-
+      !cancelled() &&
+      needs.classify.result == 'success' &&
       needs.classify.outputs.needs_build == 'true' &&
       (github.event_name != 'schedule' || needs.schedule-guard.outputs.should_run == 'yes')
     runs-on: macos-26

--- a/scripts/ci/post-merge-should-run.sh
+++ b/scripts/ci/post-merge-should-run.sh
@@ -1,0 +1,328 @@
+#!/usr/bin/env bash
+# scripts/ci/post-merge-should-run.sh
+# Decide whether a scheduled main-post-merge validation run is needed for a
+# given main HEAD sha (issue #2334). The hourly schedule in
+# main-post-merge.yml re-validates main HEAD so a green signal exists even
+# during a merge train, where cancel-in-progress cancels every push run
+# before it completes; without this guard an idle main would burn a macOS
+# run every hour.
+#
+# Verdict:
+#   should_run=no   only when main-post-merge.yml already has a completed
+#                   run with conclusion success, headSha == the target sha,
+#                   and BOTH the release-validation and debug-validation
+#                   jobs concluded success — the full Xcode matrix actually
+#                   ran green on that exact sha.
+#   should_run=yes  (fail closed) for everything else, including: no such
+#                   run; a success whose matrix jobs were skipped (a
+#                   non-code-change run validated nothing, and its parent
+#                   may be the unverified commit); a run in the pre-#1994
+#                   single-job shape (unknown job names); any API error,
+#                   timeout, or malformed response; a missing tool.
+# A guard that fails closed toward skipping would silently restore the exact
+# hole #2334 is about: main that is unverified but looks green because the
+# run that would catch it was never started.
+#
+# The push path never consults this script. main-post-merge.yml wires it
+# into the schedule path only, and the push path stays unconditional.
+#
+# Reads from the workflow environment:
+#   GH_TOKEN           gh auth (set by the calling step)
+#   GITHUB_REPOSITORY  owner/name (default for --repo; set by Actions)
+#   GITHUB_OUTPUT      receives should_run=yes|no when set
+#
+# Usage:
+#   post-merge-should-run.sh --sha <main-head-sha> [--repo <owner/name>]
+#   post-merge-should-run.sh --self-test
+#
+# The self-test stubs the GitHub API with mock `gh`/`timeout` executables on
+# PATH (the appcast-delivery.sh pattern); it never calls GitHub.
+set -euo pipefail
+
+WORKFLOW_FILE="main-post-merge.yml"
+API_TIMEOUT_SECONDS=30
+SELFTEST_FAILS=0
+
+usage() {
+  cat <<'EOF'
+Usage:
+  post-merge-should-run.sh --sha <main-head-sha> [--repo <owner/name>]
+      Answer whether a main-post-merge validation run is needed for <sha>.
+      Writes should_run=yes|no to $GITHUB_OUTPUT when set. Every determinate
+      answer (yes or no) exits 0 — yes is also the fail-closed answer for
+      anything indeterminate. Usage errors exit 2.
+  post-merge-should-run.sh --self-test
+      Run the verdict matrix against a stubbed GitHub API.
+EOF
+}
+
+# emit <yes|no> <reason>: record a determinate verdict and exit 0. The
+# workflow branches on the GITHUB_OUTPUT value, not on the exit code.
+emit() {
+  local verdict="$1" reason="$2"
+  echo "==> post-merge-should-run: should_run=$verdict — $reason"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    printf 'should_run=%s\n' "$verdict" >>"$GITHUB_OUTPUT"
+  fi
+  exit 0
+}
+
+# fail_closed <reason>: the verdict could not be established, so answer
+# "run" (never "no") and still exit 0. An indeterminate guard must cost one
+# macOS run, not a silent green skip.
+fail_closed() {
+  echo "::warning title=post-merge-should-run::$1 — failing closed to a full run"
+  emit yes "indeterminate ($1)"
+}
+
+# run_api <gh args...>: one GitHub API call with a hard timeout, the
+# appcast-delivery.sh pattern. A non-zero return (API error or timeout)
+# leaves the caller to fail closed.
+run_api() {
+  timeout --signal=TERM "${API_TIMEOUT_SECONDS}s" gh "$@"
+}
+
+decide() {
+  local sha="$1" repo="$2"
+  local tool
+  for tool in gh jq timeout; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+      fail_closed "required tool '$tool' is missing"
+    fi
+  done
+
+  local runs_json
+  if ! runs_json="$(run_api run list \
+      --repo "$repo" \
+      --workflow "$WORKFLOW_FILE" \
+      --commit "$sha" \
+      --limit 100 \
+      --json databaseId,headSha,event,conclusion)"; then
+    fail_closed "gh run list failed or timed out"
+  fi
+  if ! jq -e 'type == "array"' >/dev/null 2>&1 <<<"$runs_json"; then
+    fail_closed "run-list response is not a JSON array"
+  fi
+
+  # Completed-successful runs of THIS workflow on THIS exact sha. The local
+  # headSha/conclusion filter (not just the --commit flag) is what the
+  # verdict rests on, mirroring classify_deploy_runs in appcast-delivery.sh.
+  local candidates id
+  if ! candidates="$(jq -r --arg sha "$sha" '
+      [ .[]
+        | select((.conclusion // "") == "success")
+        | select(((.headSha // "") | ascii_downcase) == ($sha | ascii_downcase))
+        | .databaseId ] | .[]' <<<"$runs_json" 2>/dev/null)"; then
+    fail_closed "could not parse the run-list JSON"
+  fi
+  if [ -z "$candidates" ]; then
+    emit yes "no successful run of $WORKFLOW_FILE exists for this sha — it has never been validated"
+  fi
+
+  for id in $candidates; do
+    local jobs_json
+    if ! jobs_json="$(run_api run view "$id" --repo "$repo" --json jobs)"; then
+      fail_closed "gh run view failed or timed out for run $id"
+    fi
+    if ! jq -e 'type == "array"' >/dev/null 2>&1 <<<"$jobs_json"; then
+      fail_closed "jobs response for run $id is not a JSON array"
+    fi
+    # A run only counts when BOTH validation jobs actually ran and passed.
+    # post-merge-result turns any other combination (failure, cancelled,
+    # skipped) into a non-success workflow conclusion, so a success without
+    # both jobs green is a non-code-change run that validated nothing —
+    # counting it would skip a main whose last code commit was cancelled.
+    if jq -e '
+        ( [ .[] | select(.name == "release-validation") | .conclusion ] | any(. == "success") )
+        and
+        ( [ .[] | select(.name == "debug-validation")   | .conclusion ] | any(. == "success") )
+      ' >/dev/null 2>&1 <<<"$jobs_json"; then
+      emit no "run $id already validated this sha with a green full matrix (release-validation + debug-validation)"
+    fi
+  done
+
+  # Candidates existed but none carried a green full matrix.
+  emit yes "successful run(s) for this sha did not execute the full matrix — validating it now"
+}
+
+# ---------------------------------------------------------------------------
+# Self-test. Stubs the GitHub API with mock `gh`/`timeout` executables on
+# PATH (the appcast-delivery.sh pattern) and runs the REAL script against
+# them; it never calls GitHub.
+# ---------------------------------------------------------------------------
+
+# write_mock_executables <bin-dir>
+write_mock_executables() {
+  local bin_dir="$1"
+  mkdir -p "$bin_dir"
+
+  cat >"$bin_dir/gh" <<'MOCK_GH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "run" && "${2:-}" == "list" ]]; then
+  [[ "${MOCK_GH_FAIL:-0}" == "1" ]] && exit "${MOCK_GH_FAIL_RC:-1}"
+  if [[ -n "${MOCK_RUNS_FILE:-}" && -f "${MOCK_RUNS_FILE}" ]]; then
+    cat "$MOCK_RUNS_FILE"
+  else
+    printf '[]\n'
+  fi
+  exit 0
+fi
+if [[ "${1:-}" == "run" && "${2:-}" == "view" ]]; then
+  [[ "${MOCK_GH_FAIL:-0}" == "1" ]] && exit 1
+  id="${3:-}"
+  f="${MOCK_JOBS_DIR:?MOCK_JOBS_DIR unset}/jobs-${id}.json"
+  [[ -f "$f" ]] || exit 1
+  cat "$f"
+  exit 0
+fi
+echo "mock gh: unsupported call: $*" >&2
+exit 1
+MOCK_GH
+
+  cat >"$bin_dir/timeout" <<'MOCK_TIMEOUT'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "${MOCK_TIMEOUT_FAIL:-0}" == "1" ]] && exit 124
+# Drop the flag options and the duration, then exec the command.
+while [[ "${1:-}" == --* ]]; do shift; done
+shift
+exec "$@"
+MOCK_TIMEOUT
+
+  chmod +x "$bin_dir/gh" "$bin_dir/timeout"
+}
+
+self_test() {
+  local root bin sha repo
+  root="$(mktemp -d)"
+  bin="$root/bin"
+  sha="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  repo="saurabhav88/EnviousWispr"
+
+  write_mock_executables "$bin"
+  mkdir -p "$root/jobs"
+  export MOCK_JOBS_DIR="$root/jobs"
+  export MOCK_RUNS_FILE=""
+  unset MOCK_GH_FAIL MOCK_GH_FAIL_RC MOCK_TIMEOUT_FAIL 2>/dev/null || true
+
+  # _expect <label> <expected:yes|no>: run the REAL script with the current
+  # MOCK_* state; require rc=0 and the expected should_run in GITHUB_OUTPUT.
+  # rc=0 is asserted too: a determinate verdict — yes or no — always exits 0,
+  # so a crash or a missing output is a test failure, not a "run".
+  _expect() {
+    local label="$1" expected="$2"
+    local out rc verdict
+    out="$(mktemp)"
+    rc=0
+    ( PATH="$bin:$PATH" GITHUB_OUTPUT="$out" "$0" --sha "$sha" --repo "$repo" ) >/dev/null 2>&1 || rc=$?
+    verdict="$(grep -oE 'should_run=(yes|no)' "$out" | tail -n1 | cut -d= -f2 || true)"
+    rm -f "$out"
+    if [ "$rc" -eq 0 ] && [ "$verdict" = "$expected" ]; then
+      echo "ok   [$label] should_run=$verdict rc=0"
+    else
+      echo "FAIL [$label] expected should_run=$expected rc=0; got should_run='$verdict' rc=$rc"
+      SELFTEST_FAILS=$((SELFTEST_FAILS + 1))
+    fi
+  }
+
+  echo "== post-merge-should-run self-test =="
+
+  # --- should_run=yes (run): the sha was not validated, or is indeterminate ---
+
+  # No successful run for this sha: it was never validated.
+  printf '[]\n' >"$root/runs.json"
+  MOCK_RUNS_FILE="$root/runs.json"
+  _expect "no successful run for sha -> run" yes
+
+  # A success whose matrix jobs were skipped (a non-code-change run): it
+  # validated nothing, so this sha still needs the full matrix.
+  printf '[{"databaseId":201,"headSha":"%s","event":"push","conclusion":"success"}]\n' "$sha" >"$root/runs.json"
+  printf '[{"databaseId":1,"name":"classify","conclusion":"success"},{"databaseId":2,"name":"release-validation","conclusion":"skipped"},{"databaseId":3,"name":"debug-validation","conclusion":"skipped"},{"databaseId":4,"name":"post-merge-result","conclusion":"success"}]\n' >"$MOCK_JOBS_DIR/jobs-201.json"
+  MOCK_RUNS_FILE="$root/runs.json"
+  _expect "success with skipped matrix jobs -> run" yes
+
+  # An API error (run list unreachable) must fail closed to run.
+  export MOCK_GH_FAIL=1
+  _expect "gh run list failure -> run" yes
+  unset MOCK_GH_FAIL
+
+  # A malformed run-list response must fail closed to run.
+  printf 'not-json{this is not the API}\n' >"$root/bad.json"
+  MOCK_RUNS_FILE="$root/bad.json"
+  _expect "malformed run-list response -> run" yes
+
+  # A candidate whose jobs cannot be read must fail closed to run.
+  printf '[{"databaseId":301,"headSha":"%s","event":"push","conclusion":"success"}]\n' "$sha" >"$root/runs.json"
+  rm -f "$MOCK_JOBS_DIR/jobs-301.json"
+  MOCK_RUNS_FILE="$root/runs.json"
+  _expect "unreadable jobs for candidate run -> run" yes
+
+  # A timed-out API call must fail closed to run.
+  printf '[{"databaseId":401,"headSha":"%s","event":"push","conclusion":"success"}]\n' "$sha" >"$root/runs.json"
+  printf '[{"databaseId":1,"name":"release-validation","conclusion":"success"},{"databaseId":2,"name":"debug-validation","conclusion":"success"}]\n' >"$MOCK_JOBS_DIR/jobs-401.json"
+  export MOCK_TIMEOUT_FAIL=1
+  _expect "API timeout -> run" yes
+  unset MOCK_TIMEOUT_FAIL
+
+  # --- should_run=no (skip): a green full-matrix run exists for this sha ---
+
+  # The validating run is NOT the first entry in the list: the script must
+  # scan past the unrelated sha and skip. (If it queried the unrelated run's
+  # jobs, the mock has no fixture for it and fails, which would read "run".)
+  printf '[{"databaseId":900,"headSha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","event":"push","conclusion":"success"},{"databaseId":101,"headSha":"%s","event":"push","conclusion":"success"}]\n' "$sha" >"$root/runs.json"
+  printf '[{"databaseId":1,"name":"classify","conclusion":"success"},{"databaseId":2,"name":"release-validation","conclusion":"success"},{"databaseId":3,"name":"debug-validation","conclusion":"success"},{"databaseId":4,"name":"post-merge-result","conclusion":"success"}]\n' >"$MOCK_JOBS_DIR/jobs-101.json"
+  MOCK_RUNS_FILE="$root/runs.json"
+  _expect "green full-matrix run for sha (not first in list) -> skip" no
+
+  # The sha match is case-insensitive: the API returns lowercase, and a
+  # fixture in another case must still be recognized.
+  printf '[{"databaseId":101,"headSha":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","event":"schedule","conclusion":"success"}]\n' >"$root/runs.json"
+  MOCK_RUNS_FILE="$root/runs.json"
+  _expect "uppercase headSha fixture still matches -> skip" no
+
+  rm -rf "$root"
+
+  if [ "$SELFTEST_FAILS" -eq 0 ]; then
+    echo "== post-merge-should-run self-test PASS =="
+  else
+    echo "== post-merge-should-run self-test FAIL ($SELFTEST_FAILS) =="
+    return 1
+  fi
+}
+
+main() {
+  case "${1:-}" in
+    --self-test)
+      self_test
+      ;;
+    --sha)
+      local sha="${2:-}" repo=""
+      if [ -z "$sha" ]; then
+        echo "::error title=post-merge-should-run::--sha requires a 40-character commit sha" >&2
+        usage >&2
+        exit 2
+      fi
+      if ! printf '%s' "$sha" | grep -qE '^[0-9a-fA-F]{40}$'; then
+        echo "::error title=post-merge-should-run::--sha must be a 40-character commit sha, got '$sha'" >&2
+        exit 2
+      fi
+      if [ "${3:-}" = "--repo" ]; then
+        repo="${4:-}"
+      fi
+      if [ -z "$repo" ]; then
+        repo="${GITHUB_REPOSITORY:-}"
+      fi
+      if [ -z "$repo" ]; then
+        fail_closed "no repository supplied (--repo or GITHUB_REPOSITORY)"
+      fi
+      decide "$sha" "$repo"
+      ;;
+    *)
+      usage >&2
+      exit 2
+      ;;
+  esac
+}
+
+main "$@"

--- a/scripts/ci/verify-checked-out-revision.sh
+++ b/scripts/ci/verify-checked-out-revision.sh
@@ -2,10 +2,11 @@
 # Assert the working tree is at the revision the workflow intended to test.
 #
 # Why it is a script and not an inline step (#1994): main-post-merge.yml runs
-# three jobs that each check out independently, so this guard would otherwise
-# exist as three hand-mirrored copies. Two copies of one decision is the shape
-# that drifts — .claude/rules/workflow-process.md RULE: port-proven-patterns-wholesale
-# records two cases in this repo where exactly that happened. One owner, three
+# four jobs that each check out independently (the fourth is the #2334
+# schedule guard), so this guard would otherwise exist as four hand-mirrored
+# copies. Two copies of one decision is the shape that drifts —
+# .claude/rules/workflow-process.md RULE: port-proven-patterns-wholesale
+# records two cases in this repo where exactly that happened. One owner, four
 # callers.
 #
 # Reads (all from the workflow environment):


### PR DESCRIPTION
Implements **option 2** from the issue (keep `cancel-in-progress`, add a scheduled validation of `main` HEAD). I agree with the recorded reasoning and see no objection to register: in the measured window, option 1 would have queued ~7 hours of macOS runner time for a signal that is still hours stale, and option 3 changes how every PR merges. Implementing option 2 as chosen.

## Files changed

- `.github/workflows/main-post-merge.yml`: hourly `schedule:` trigger (offset minute per #1131); new `schedule-guard` job (schedule events only); `classify` gains a `schedule` branch (`needs_build=true` — the old `case` errored on the unknown event); both macOS jobs gain `needs.schedule-guard` and a guard-gated `if:` that degrades to the original condition on every non-schedule event; `post-merge-result` reports an intentional guard skip as a pass and a guard failure as unverified; the new script joins the `pull_request` paths list so a PR touching the guard re-runs this workflow against itself.
- `scripts/ci/post-merge-should-run.sh` (new): answers, for a given `main` HEAD sha, whether a validation run is needed. `should_run=no` only when this workflow has a completed run with `conclusion: success`, `headSha` == the target, **and both** `release-validation` and `debug-validation` jobs concluded `success` — i.e. the full matrix actually ran green on that exact sha. A success whose matrix jobs were skipped (a non-code-change run) does **not** count: counting it could skip a `main` whose last code commit was cancelled, which is the exact hole #2334 is about. Everything else — no such run, pre-#1994 single-job run shape, API error, timeout, malformed JSON, missing tool — answers `should_run=yes`. The push path never consults the script.
- `scripts/ci/verify-checked-out-revision.sh`: header comment only — "three jobs / three callers" → "four jobs / four callers" (the guard is a fourth independent checkout).

## Step 2 — concurrency-group verification (no change needed)

Group template: `main-post-merge-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}`

- **push** (to `main`): `github.event.pull_request.number` is empty, so the group is the event name + `github.ref`:
  → **`main-post-merge-push-refs/heads/main`**
- **schedule**: `github.event.pull_request.number` is also empty (not a PR), and for schedule events `github.ref` is the repository default branch:
  → **`main-post-merge-schedule-refs/heads/main`**

The two strings **differ** (the `push` vs `schedule` segment), so a push can never cancel an in-flight scheduled run, and vice versa — the scheduled run is already isolated. **No change to the concurrency block was made.** (PR runs remain `main-post-merge-pull_request-<number>`, isolated as before.) A comment now records both strings and the load-bearing property in the workflow.

Known residual, deliberately unchanged: two *scheduled* runs share a group, so a new hourly firing can cancel a still-running previous hourly firing. Worst-case wall time is ~46 min (45-min release cap + setup) against a 60-min cadence, so overlap requires ~15+ min of runner queue delay; if it happens, the new run re-validates the same HEAD and still completes green, so the guarantee holds.

## The guard

- Queries `gh run list --workflow main-post-merge.yml --commit <sha>` (the `appcast-delivery.sh` query pattern), filters locally with `jq` on `headSha`/`conclusion`, then for each candidate run fetches its jobs and requires `release-validation` **and** `debug-validation` to have concluded `success`.
- All `gh` calls are wrapped in `timeout --signal=TERM 30s`; any failure (API error, timeout, malformed response, missing `gh`/`jq`/`timeout`) fails closed to `should_run=yes`, exit 0. Usage errors (bad/missing sha, unknown flag) exit 2 so a wiring bug is visible, never a silent skip.
- Self-test follows the `appcast-delivery.sh` mock pattern: mock `gh`/`timeout` executables on PATH, driven by `MOCK_*` state; it never calls GitHub.
- The two-way control proved itself while authoring: the first draft of the candidate filter had a jq precedence bug (`select(X | f) == Y` parses as `(select(X | f)) == Y`, always false). The self-test's skip rows went red, the bug was fixed, and the rows passed. A self-test written after the guard has not been observed failing; this one has.

## Self-test output (`scripts/ci/post-merge-should-run.sh --self-test`)

```
== post-merge-should-run self-test ==
ok   [no successful run for sha -> run] should_run=yes rc=0
ok   [success with skipped matrix jobs -> run] should_run=yes rc=0
ok   [gh run list failure -> run] should_run=yes rc=0
ok   [malformed run-list response -> run] should_run=yes rc=0
ok   [unreadable jobs for candidate run -> run] should_run=yes rc=0
ok   [API timeout -> run] should_run=yes rc=0
ok   [green full-matrix run for sha (not first in list) -> skip] should_run=no rc=0
ok   [uppercase headSha fixture still matches -> skip] should_run=no rc=0
== post-merge-should-run self-test PASS ==
```

Two-way: six "run" cases and two "skip" cases, including unreadable (`gh` failure, missing jobs fixture, timeout) and malformed (non-JSON) API responses, all answering "run".

## Two-way control (broken scratch copy)

Copied the guard to a scratch file (outside the repo), changed the never-validated branch to answer `skip` (`emit no "BROKEN-CONTROL: never-validated sha answered skip"` — a sha that was never validated now skips), and ran the copy's own self-test:

```
FAIL [no successful run for sha -> run] expected should_run=yes rc=0; got should_run='no' rc=0
ok   [success with skipped matrix jobs -> run] should_run=yes rc=0
ok   [gh run list failure -> run] should_run=yes rc=0
ok   [malformed run-list response -> run] should_run=yes rc=0
ok   [unreadable jobs for candidate run -> run] should_run=yes rc=0
ok   [API timeout -> run] should_run=yes rc=0
ok   [green full-matrix run for sha (not first in list) -> skip] should_run=no rc=0
ok   [uppercase headSha fixture still matches -> skip] should_run=no rc=0
== post-merge-should-run self-test FAIL (1) ==
exit code: 1
```

The self-test goes red exactly on the row the break targets. Non-destructive, on a copy; the real file was verified unmodified afterwards (still passes, row 1 `ok`).

## Checks run

- `bash -n` on every touched shell file: pass
- `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/main-post-merge.yml'))"` (PyYAML 6.0.1): pass
- yamllint with the exact config of the CI drift-check (`extends: default`, line-length/truthy/document-start/comments/brackets/comments-indentation disabled): pass
- `shellcheck` 0.9.0 on both touched shell files: clean
- `verify-checked-out-revision.sh --self-test`: pass (unchanged logic, comment-only edit)

**No macOS run, no Xcode build, and no Swift test ran on the authoring machine** (Linux box, no Xcode/macOS available); all proof above is shell-level: syntax, YAML, self-tests, and the broken-guard control.

## `.gitignore` disclosure

`scripts/*` is gitignored by default, but `scripts/ci/` is **already excepted** (`.gitignore` lines: `!scripts/ci/` / `!scripts/ci/**`, added for #1151), so the new script ships with **no `.gitignore` change**. Verified with `git check-ignore -v` (deciding pattern is the negation) and `git add --dry-run` (the file stages).

Closes #2334
