### PR TITLE
chore(llm): delete supportsReasoning, dead in production since #1831

### DIFF
--- a/Sources/EnviousWisprLLM/ClaudeConnector.swift
+++ b/Sources/EnviousWisprLLM/ClaudeConnector.swift
@@ -3,8 +3,8 @@ import Foundation
 
 /// Anthropic Claude Messages API connector for transcript polishing.
 ///
-/// v1: no extended thinking, ever (`LLMModelCapabilities.supportsReasoning`
-/// is `false` for every Claude model). `temperature`/`top_p`/`top_k` are
+/// v1: no extended thinking, ever (`LLMModelCapabilities.thinkingControl`
+/// is `.unsupported` for every Claude model). `temperature`/`top_p`/`top_k` are
 /// omitted from the request body — Claude generations released after Opus
 /// 4.6 reject a non-default `temperature`, including 0, with an HTTP 400;
 /// omitting them unconditionally is the same shape #1330 established for

--- a/Sources/EnviousWisprLLM/LLMModelCapabilities.swift
+++ b/Sources/EnviousWisprLLM/LLMModelCapabilities.swift
@@ -61,12 +61,15 @@ public struct LLMModelCapabilities: Sendable, Equatable {
     case omit
   }
 
-  public let thinkingControl: ThinkingControl
-  /// Whether this model takes a thinking parameter at all.
+  /// Whether this model takes a thinking parameter, and in which dialect.
   ///
-  /// DERIVED, never stored: two statements about one fact drift when both are
-  /// stored (#1770).
-  public var supportsReasoning: Bool { thinkingControl != .unsupported }
+  /// `.unsupported` IS the "takes no thinking parameter" answer; read it
+  /// directly rather than reintroducing a derived Bool. #1770 added
+  /// `supportsReasoning` for the Deep-reasoning toggle's visibility gate,
+  /// #1831 deleted that gate, and Periphery then reported the property dead in
+  /// production — its only remaining callers were tests, which that scan
+  /// excludes, so they never kept it alive. One fact, one spelling.
+  public let thinkingControl: ThinkingControl
   public let temperaturePolicy: TemperaturePolicy
   /// Primary-endpoint (Chat Completions) eligibility. Meaningful for
   /// `.openAI` only — Responses-API-only families (`-pro`, codex) can never

--- a/Tests/EnviousWisprTests/LLM/LLMProviderCapabilityTests.swift
+++ b/Tests/EnviousWisprTests/LLM/LLMProviderCapabilityTests.swift
@@ -25,7 +25,7 @@ struct LLMProviderCapabilityTests {
   ])
   func reasoningFamilySupportsReasoningAndOmitsTemperature(model: String) {
     let c = caps(model)
-    #expect(c.supportsReasoning)
+    #expect(c.thinkingControl != .unsupported)
     #expect(c.temperaturePolicy == .omit)
     #expect(c.supportsChatCompletions)
   }
@@ -35,7 +35,7 @@ struct LLMProviderCapabilityTests {
   @Test(arguments: ["gpt-4o", "gpt-4o-mini", "gpt-4.1", "gpt-4.1-nano", "chatgpt-4o-latest"])
   func classicFamilyIncludesTemperatureWithoutReasoning(model: String) {
     let c = caps(model)
-    #expect(!c.supportsReasoning)
+    #expect(c.thinkingControl == .unsupported)
     #expect(c.temperaturePolicy == .include)
     #expect(c.supportsChatCompletions)
   }
@@ -44,7 +44,7 @@ struct LLMProviderCapabilityTests {
 
   @Test func gpt5ChatVariantIsNotReasoning() {
     let c = caps("gpt-5-chat-latest")
-    #expect(!c.supportsReasoning)
+    #expect(c.thinkingControl == .unsupported)
     #expect(c.temperaturePolicy == .include)
     #expect(c.supportsChatCompletions)
   }
@@ -59,7 +59,7 @@ struct LLMProviderCapabilityTests {
   // MARK: - Case-insensitive matching (persisted strings may vary)
 
   @Test func matchingIsCaseInsensitive() {
-    #expect(caps("GPT-5.6-Sol").supportsReasoning)
+    #expect(caps("GPT-5.6-Sol").thinkingControl != .unsupported)
     #expect(!caps("GPT-5-Pro").supportsChatCompletions)
   }
 
@@ -68,7 +68,7 @@ struct LLMProviderCapabilityTests {
   @Test func emptyAndUnknownIdsAreClassicShaped() {
     for model in ["", "some-future-model"] {
       let c = caps(model)
-      #expect(!c.supportsReasoning)
+      #expect(c.thinkingControl == .unsupported)
       #expect(c.temperaturePolicy == .include)
     }
   }
@@ -118,7 +118,7 @@ struct LLMProviderCapabilityTests {
       #expect(
         LLMProvider.gemini.modelCapabilities(model: unknown).thinkingControl == .unsupported,
         "\(unknown) must fall through to .unsupported, not inherit an untested value")
-      #expect(LLMProvider.gemini.modelCapabilities(model: unknown).supportsReasoning == false)
+      #expect(LLMProvider.gemini.modelCapabilities(model: unknown).thinkingControl == .unsupported)
     }
 
     // Gemini models always keep temperature.
@@ -129,7 +129,7 @@ struct LLMProviderCapabilityTests {
   @Test func localProvidersNeverReasonAndKeepTemperature() {
     for provider in [LLMProvider.ollama, .appleIntelligence, .egOne, .none] {
       let c = provider.modelCapabilities(model: "anything")
-      #expect(!c.supportsReasoning)
+      #expect(c.thinkingControl == .unsupported)
       #expect(c.temperaturePolicy == .include)
     }
   }
@@ -142,7 +142,7 @@ struct LLMProviderCapabilityTests {
   ])
   func claudeNeverReasonsAndOmitsTemperature(model: String) {
     let c = LLMProvider.claude.modelCapabilities(model: model)
-    #expect(!c.supportsReasoning)
+    #expect(c.thinkingControl == .unsupported)
     #expect(c.temperaturePolicy == .omit)
     #expect(!c.supportsChatCompletions)
   }

--- a/Tests/EnviousWisprTests/LLM/OpenAILiveSweepTests.swift
+++ b/Tests/EnviousWisprTests/LLM/OpenAILiveSweepTests.swift
@@ -41,7 +41,7 @@ struct OpenAILiveSweepTests {
         apiKeyKeychainId: KeychainManager.openAIKeyID,
         outputTokens: .providerDefault,
         temperature: 0,
-        thinking: capabilities.supportsReasoning ? .effort("low") : nil
+        thinking: capabilities.thinkingControl != .unsupported ? .effort("low") : nil
       )
 
       let start = ContinuousClock.now


### PR DESCRIPTION
Follow-up to #1831. Deletes `LLMModelCapabilities.supportsReasoning`, dead in production since that change.

`Tier: SMALL | Test: required (LLM) | Lane: Code`

## Why

Periphery on merged main (`46f416b0`) reported it unused. It is the **only** finding in that scan attributable to #1831 — the other ten in the files that change touched are all in the baseline or pre-date it.

#1770 added the property for exactly one job: the Deep-reasoning toggle's visibility gate in `AIPolishSettingsView.isReasoningModel`. #1831 deleted that gate, so nothing in production reads it.

**I flagged this in #1831 C3 and kept it anyway**, arguing it answers a question about the MODEL rather than about the removed UI. That reasoning was about what the property MEANS and never addressed whether anything reads it. Periphery measured the second question. Its only remaining callers were tests, and that scan excludes tests precisely so test references cannot make production code look alive.

## What changed

`.unsupported` already IS the "takes no thinking parameter" answer, so the nine test sites now ask the authority directly (`thinkingControl != .unsupported`) instead of going through a derived Bool. Same DERIVED-never-stored argument #1770 used to ADD it, applied one level up now that the deriving is the redundant part.

`ClaudeConnector`'s doc comment cited the property by name and would have become a reference to a symbol that does not exist. Repointed to `thinkingControl` / `.unsupported` — same claim about Claude, still true.

11 sites, swept across `Sources/ Tests/ scripts/ workers/ website/`. The single surviving mention of the old name is inside the comment explaining the removal.

## Evidence

```
scripts/xcode-test.sh --filter EnviousWisprTests/LLMProviderCapabilityTests
  -> Test run with 9 tests passed, EXIT=0

scripts/xcode-test.sh --release   (on the rebased tree)
  -> Debug   lane executed 6562 tests  ** TEST SUCCEEDED **
  -> Release lane executed 5907 tests  ** TEST SUCCEEDED **
  -> 0 failing-test verdict marks
```

Local `codex review`: clean — "a derived alias with no remaining production callers; all repository references updated to the equivalent `thinkingControl` comparison, preserving runtime behavior."

**Count note**, because +1 per lane against #1831's 6561/5906 has an innocent cause and an unexplained delta should not be waved through: #2347 (`test(clipboard)`) merged between that measurement and this base. Not from this change, which adds no tests and only rewrites assertions.

## One process note worth recording

The scan that found this could not be run the obvious way. `scripts/periphery.sh` is gitignored (`.gitignore:139`), derives `PROJECT_ROOT` from its own location, and has no override — and the root checkout, the only place it exists, is currently on another session's feature branch without #1831 in it. Running it there would have scanned that branch and reported plausible findings about someone else's work. `periphery.md` RULE: `periphery-sh-cannot-scan-a-feature-worktree` names this exact failure. Scanned a detached worktree pinned to `46f416b0` with the script placed alongside it instead.
