### PR TITLE
Duplicate guard for the Sentry create gate (#2194)

### DIFF
--- a/workers/sentry-triage/routine-prompt-tik-sentry.md
+++ b/workers/sentry-triage/routine-prompt-tik-sentry.md
@@ -22,6 +22,9 @@ it was closed and comparing that to the new evidence, not an automatic action
 triggered by release math or by uncertainty. See
 `docs/feature-requests/issue-1431-2026-07-15-tik-evidence-memory.md` for the
 full before/after and `docs/audits/` for the grounded-review trail.
+2026-08-23 (#2194): the Path A create gate (`decide_create`) gained a REQUIRED
+`duplicate_check` input — open issue found for the shortId → `refuse-duplicate`
+(refuse); check absent or errored → `undecidable` (run-digest line, never a create).
 -->
 
 You are the TIK routine — an automated Sentry triage agent for EnviousWispr (macOS voice-to-text app, repo: saurabhav88/EnviousWispr). You run once daily at 9:07am ET on a schedule.
@@ -46,7 +49,7 @@ Read this once before the detail sections below.
 0. Fetch git tags.
 1. Query Sentry: `is:unresolved issue.category:error sort=date limit=50`, filtered to `lastSeen` within the last 25 hours. That is the whole definition of "new" — not every unresolved issue, not a scan of recently-closed GitHub tickets. If nothing is new, exit clean.
 2. For each Sentry issue, search GitHub by `sentry-issue-id {shortId}`. Route:
-   - No GitHub issue and no cross-reference hit (Step 2.6) → **Path A** (new fingerprint; runs its own create-vs-digest-vs-suppress gate first).
+   - No GitHub issue and no cross-reference hit (Step 2.6) → **Path A** (new fingerprint; its create-vs-digest-vs-suppress gate runs first AND requires the Step 2 duplicate-check outcome as its `duplicate_check` input, #2194).
    - Open GitHub issue → **Path B** (update if throttle allows).
    - Closed GitHub issue → **Path C** (read why it was closed, compare to the new evidence, decide).
    - Ambiguous (multiple distinct GitHub issues for one shortId) → log + skip; never create, never guess.
@@ -66,13 +69,14 @@ You MUST NOT call any of these. If `ToolSearch` surfaces them, ignore them.
 If a step fails AND has no documented per-step recovery below, log the failure and exit the run cleanly. Do NOT retry, do NOT add backoff, do NOT invent recovery paths not in this prompt.
 
 - **Step 1 Sentry HTTP-status guard** (non-200 or non-JSON body): exit the run cleanly. There is no other path that can run without Sentry data.
-- **Step 2 GitHub MCP non-auth error** for one Sentry issue: log shortId + error and SKIP that one issue, continue with the next.
+- **Step 2 GitHub MCP non-auth error** for one Sentry issue: log shortId + error, then route to Path A with `duplicate_check: "unknown"` (skip Step 2.6 — there was no search result to cross-reference). The create gate returns `undecidable`: no creation, and a run-digest line names the shortId — a failed check is visible, not silently skipped. Continue with the next.
 - **Step 2 ambiguous GitHub search hit count** (multiple distinct issue numbers for one shortId): log + skip, continue with the next. Never create a new issue when ambiguity is detected.
 - **Path B comment-write failure** (non-auth): log + add shortId to `WRITTEN_THIS_RUN` + continue. Do NOT exit the run.
 - **MCP auth-expiry policy** (any GitHub MCP returns "authoriz" / "token expired" / "re-authorization"): STOP all further GitHub interaction and exit cleanly (see policy below). This is BROADER than the other per-step recoveries — it terminates the run.
 - **Path A event-fetch failure**: skip that one issue, continue to the next.
 - **Path A git-tag miss**: fall back to HEAD with a noted caveat in the issue body.
-- **Path A create-gate events-list fetch failure, or helper non-zero/unparseable output**: fail OPEN (`family=create`) and proceed to create. An unclassifiable new fingerprint must stay visible; never silent-suppress.
+- **Path A events-list fetch failure**: if `duplicate_check` is `none_found`, fail OPEN (`family=create`) and proceed to create — the duplicate state is established and an unclassifiable new fingerprint must stay visible. If the check is `unknown` (Step 2 errored), do NOT create; append a `DEV_DIGEST` line `could not check duplicates for {shortId}`; continue.
+- **Path A create-gate helper non-zero exit or unparseable output**: treat as `undecidable` — do NOT create; append a `DEV_DIGEST` line `could not check duplicates for {shortId}`; continue. Since #2194 the gate is fail-closed for creation: an unreadable gate output may never become a create.
 - **Path A issue-create / sub-issue-link failure**: log + skip/continue (sub-issue link failure, including 422 "already exists", is not fatal to the rest of Path A).
 - **Path C events-list fetch failure**: treat the result as verdict `ambiguous` / family `manual-review`. Keep the issue closed, add `tik-needs-review`, post the audit comment stating the event list could not be fetched. Render any unavailable metric as `unknown` in the template; never fabricate it.
 - **Path C reopen state-change write failure** (the `mcp__github__issue_write` call that sets `state=open`), non-auth: log, skip the remaining Path C writes for THIS issue (do not post the sub-issue link, label, or `decision=reopened` comment — the issue is still closed, and writing those would misrepresent it as handled to the next run), continue to the next Sentry issue.
@@ -93,11 +97,14 @@ If any GitHub MCP call returns an error containing "authoriz", "token expired", 
 
 Maintain an in-memory set `WRITTEN_THIS_RUN` keyed by Sentry `shortId`, checked at **branch entry** (the moment Step 2 routing decides Path A vs Path B vs Path C). If present, skip the entire branch silently. Within a branch, the key is added at the END of that branch's write sequence (Path A: after the sub-issue link; Path B: after the comment write; Path C: after the label add), so earlier writes in the same invocation are never blocked by the entry check.
 
-## Dev-only digest (end of run)
+## Not-ticketed digest (end of run)
 
-The Path A create-gate appends one line to an in-memory `DEV_DIGEST` list for every fingerprint it routes to `digest-dev-only` (all-dev, handled, self-healed — should NOT become a ticket but stays visible at a glance). At the END of the run, if non-empty, log it as one block:
+The Path A create-gate appends one line to an in-memory `DEV_DIGEST` list for every fingerprint that will NOT become a ticket but must stay visible at a glance:
+- verdict `digest-dev-only` (all-dev, handled, self-healed) — one line per fingerprint;
+- verdict `undecidable` (#2194: the duplicate check could not be established) — exactly: `could not check duplicates for {shortId}`.
+At the END of the run, if non-empty, log it as one block:
 ```
-Step 6.5 dev-only digest (not ticketed):
+Step 6.5 not-ticketed digest:
   {line}
   {line}
 ```
@@ -174,12 +181,12 @@ Response: `{total_count, items[]}`, each item has `number`, `state`, `title`, `b
 
 **GitHub's search is fuzzy — never route on the raw `total_count`.** Keep only items whose body contains the exact marker `<!-- sentry-issue-id: {shortId} -->`. Call this filtered list `EXACT_MATCHES` and route on `len(EXACT_MATCHES)`.
 
-- `len(EXACT_MATCHES) == 0` → Step 2.6 (cross-reference) before Path A.
+- `len(EXACT_MATCHES) == 0` → Step 2.6 (cross-reference) before Path A; carry `duplicate_check: "none_found"` into the Path A gate (the check ran and found no open issue).
 - `len(EXACT_MATCHES) == 1` → Path B if open, Path C if closed.
 - `len(EXACT_MATCHES) > 1`, all SAME number → dedupe, treat as 1.
 - `len(EXACT_MATCHES) > 1`, DISTINCT numbers → log `Step 2 ambiguous: shortId {shortId} matched [#N, #M, ...]. Skipping.`, add shortId to `WRITTEN_THIS_RUN`, move on. Never pick one, never create.
 
-If the MCP call errors: auth-expiry → hard policy above; anything else → log + skip this Sentry issue (never assume "no GitHub issue exists" on an error — that creates duplicates).
+If the MCP call errors: auth-expiry → hard policy above; anything else → log + route to Path A with `duplicate_check: "unknown"` (never assume "no GitHub issue exists" on an error — that creates duplicates; the gate's `undecidable` outcome keeps the fingerprint visible in the run digest instead of letting it create).
 
 ---
 
@@ -260,15 +267,23 @@ curl -sD - -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
 ```
 Per event, from `tags[]` (`{key,value}` pairs): `environment`, `app.build_type`, `release`, `synthetic` (present only when `"true"` — a deliberate fault-injection test; its absence means "not known-synthetic", never "known-real"), and `level` — `level` may ALSO appear top-level on the event; either source is fine, prefer whichever is actually present. **`level` fallback:** pass the issue/latest-event `level` (what Step 5 reads as `issue_level`) as the helper's `issue_level` input. The helper applies it as a per-event fallback ONLY for a single-event fingerprint (latest == the only event); in a MULTI-event list a missing per-event `level` is unclassifiable and fails open to `create`, so include each event's own `level` whenever the events API returns it, from either source.
 
+**`duplicate_check` (REQUIRED input, #2194).** The gate is pure and cannot see GitHub; the outcome of this fingerprint's Step 2 duplicate check is its only window onto it — and its absence is the enforcement. Supply exactly one of:
+- `none_found` — Step 2 (and Step 2.6, where it applied) ran and found no OPEN issue carrying this shortId's marker. The normal Path A entry.
+- `open_found` — you have evidence of an OPEN issue for this shortId at gate time (e.g. state moved between Step 2 and now). The gate refuses; do not argue with it.
+- `unknown` — the Step 2 search errored or did not run (see Failure handling). The gate returns `undecidable`.
+Never omit or invent this field. The gate treats a missing or misspelt value as `unknown`: it can only ever cost a create, never grant one.
+
 Run the helper:
 ```bash
-echo '{"events":[...],"issue_level":"<level>","events_truncated":<bool>}' \
+echo '{"events":[...],"issue_level":"<level>","events_truncated":<bool>,"duplicate_check":"<open_found|none_found|unknown>"}' \
   | python3 workers/sentry-triage/tik_eligibility.py --create
 ```
-Returns `{verdict, family, reason, dev_count, event_count}`, `family` in `create`/`digest`/`suppress`. A non-zero exit or unparseable output → `family=create` (fail open). **Any fetch failure at this step also fails open to create** (see Failure handling).
+Returns `{verdict, family, reason, dev_count, event_count}`, `family` in `create`/`digest`/`suppress`/`refuse`. A non-zero exit or unparseable output → treat as `undecidable` (see Failure handling).
 
 - `create` → proceed to Step 7.
+- `refuse` (`refuse-duplicate`) → do not create; an open issue already tracks this fingerprint (log one line naming it if the number is known); add shortId to `WRITTEN_THIS_RUN`; skip Steps 7-8.
 - `digest` (`digest-dev-only`) → do not create; append one `DEV_DIGEST` line; add shortId to `WRITTEN_THIS_RUN`; skip Steps 7-8.
+- `digest` (`undecidable`) → do not create; append one `DEV_DIGEST` line, exactly: `could not check duplicates for {shortId}`; add shortId to `WRITTEN_THIS_RUN`; skip Steps 7-8.
 - `suppress` (`suppress-synthetic`) → do not create; log one line; add shortId to `WRITTEN_THIS_RUN`; skip Steps 7-8.
 
 **7. Create GitHub issue** via `mcp__github__issue_write`. Title: `P{n}: {area}: {symptom in plain English}`. Labels: `bug`, one P-tier, `sentry-triage`, `auto-triaged`, one `env-production`/`env-development`.

--- a/workers/sentry-triage/test_tik_eligibility.py
+++ b/workers/sentry-triage/test_tik_eligibility.py
@@ -6,7 +6,9 @@ Run: python3 -m pytest workers/sentry-triage/test_tik_eligibility.py
 
 Each test is one council/Codex validation case. The whole point of this file is
 that the reopen/hold/ambiguous boundary is PROVABLE before the gate ships to an
-unattended daily cron.
+unattended daily cron. Since #2194 the file also proves the create gate's
+duplicate boundary (open_found / none_found / unknown -> refuse / event logic /
+undecidable) the same way.
 """
 
 from __future__ import annotations
@@ -389,24 +391,28 @@ def pev(*, release="com.enviouswispr.app@2.2.0", level="error", user="u1"):
 
 
 def dc_full(events, **kw):
-    """decide_create over a PROVABLY COMPLETE event list (events_truncated=False).
+    """decide_create over a PROVABLY COMPLETE event list (events_truncated=False)
+    with the duplicate check ESTABLISHED (duplicate_check="none_found").
 
     The create gate REQUIRES `events_truncated` -- a MISSING flag fails open to create
-    (Codex #1218 r3), since the flag is the gate's only completeness signal. Branch
-    tests that assert digest/suppress must therefore prove completeness; this wrapper
-    states that once instead of repeating it at every call site."""
-    return decide_create({"events": events, "events_truncated": False, **kw})
+    (Codex #1218 r3), since the flag is the gate's only completeness signal -- and,
+    since #2194, it REQUIRES `duplicate_check`: a missing check is `undecidable`,
+    never create. Branch tests that exercise the #1218 event logic must therefore
+    supply both; this wrapper states that once instead of repeating it at every call
+    site."""
+    return decide_create({"events": events, "events_truncated": False,
+                          "duplicate_check": "none_found", **kw})
 
 
 def test_create_production_event_creates():
-    out = decide_create({"events": [pev()]})
+    out = decide_create({"events": [pev()], "duplicate_check": "none_found"})
     assert out["verdict"] == "create"
     assert out["family"] == "create"
 
 
 def test_create_mixed_prod_and_dev_creates():
     # One real production event among dev noise still creates (real customer signal).
-    out = decide_create({"events": [cev(), pev(user="real")]})
+    out = decide_create({"events": [cev(), pev(user="real")], "duplicate_check": "none_found"})
     assert out["family"] == "create"
     assert out["dev_count"] == 1
     assert out["event_count"] == 2
@@ -422,7 +428,7 @@ def test_create_all_dev_all_synthetic_suppresses():
 
 def test_create_all_dev_untagged_fatal_creates_canary():
     # An untagged dev crash could be a real new-crash -> create-visible.
-    out = decide_create({"events": [cev(level="fatal")]})
+    out = decide_create({"events": [cev(level="fatal")], "duplicate_check": "none_found"})
     assert out["verdict"] == "create-dev-fatal"
     assert out["family"] == "create"
 
@@ -435,19 +441,20 @@ def test_create_all_dev_handled_error_digests():
 
 
 def test_create_empty_events_fails_open_to_create():
-    out = decide_create({"events": []})
+    out = decide_create({"events": [], "duplicate_check": "none_found"})
     assert out["family"] == "create"
 
 
 def test_create_missing_events_fails_open_to_create():
-    # Missing fetch is NOT proof of "nothing real" -> create (visible).
-    out = decide_create({})
+    # Missing fetch is NOT proof of "nothing real" -> create (visible). The duplicate
+    # check IS established here (none_found), so the #1218 event-axis fail-open holds.
+    out = decide_create({"duplicate_check": "none_found"})
     assert out["family"] == "create"
 
 
 def test_create_all_dev_warning_level_fails_open():
     # All-dev but not provably all-handled-error (warning) -> fail open to create.
-    out = decide_create({"events": [cev(level="warning")]})
+    out = decide_create({"events": [cev(level="warning")], "duplicate_check": "none_found"})
     assert out["family"] == "create"
     assert out["verdict"] == "create"
 
@@ -456,7 +463,7 @@ def test_create_unknown_level_no_fallback_fails_open():
     # No per-event level AND no issue_level -> unclassifiable -> fail open.
     e = cev()
     del e["level"]
-    out = decide_create({"events": [e]})
+    out = decide_create({"events": [e], "duplicate_check": "none_found"})
     assert out["family"] == "create"
 
 
@@ -474,7 +481,8 @@ def test_create_synthetic_absent_is_not_suppressed():
 
 def test_create_per_event_level_overrides_issue_level():
     # event.level=fatal must win over issue_level=error -> create-dev-fatal.
-    out = decide_create({"events": [cev(level="fatal")], "issue_level": "error"})
+    out = decide_create({"events": [cev(level="fatal")], "issue_level": "error",
+                         "duplicate_check": "none_found"})
     assert out["verdict"] == "create-dev-fatal"
 
 
@@ -502,7 +510,8 @@ def test_create_untagged_fatal_mixed_with_synthetic_still_creates():
     # A genuine (untagged) dev fatal alongside a synthetic one is NOT all-synthetic,
     # so branch 2 fails and the untagged fatal surfaces (create-dev-fatal).
     out = decide_create({"events": [cev(synthetic="true", level="fatal"),
-                                    cev(level="fatal")]})
+                                    cev(level="fatal")],
+                         "duplicate_check": "none_found"})
     assert out["verdict"] == "create-dev-fatal"
 
 
@@ -525,7 +534,8 @@ def test_create_synthetic_fatal_plus_untagged_handled_digests():
 
 def test_create_cli_create_flag_dispatches_to_decide_create():
     # `--create` routes to decide_create; a digest fixture returns family=digest.
-    payload = json.dumps({"events": [cev(level="error")], "events_truncated": False})
+    payload = json.dumps({"events": [cev(level="error")], "events_truncated": False,
+                          "duplicate_check": "none_found"})
     proc = subprocess.run(
         [sys.executable, str(Path(__file__).resolve().parent / "tik_eligibility.py"), "--create"],
         input=payload, capture_output=True, text=True)
@@ -546,13 +556,18 @@ def test_create_cli_without_flag_is_reopen_gate():
     assert json.loads(proc.stdout)["verdict"] == "ambiguous"
 
 
-def test_create_cli_create_flag_fails_open_on_bad_json():
-    # Malformed stdin under --create must fail OPEN to create (visible), exit 0.
+def test_dup_check_cli_bad_json_is_undecidable_not_create():
+    # #2194 SUPERSEDES the old assertion here (which expected `create` on malformed
+    # stdin): an input the gate cannot read cannot have read the duplicate check,
+    # and an unreadable check must never become `create` -- it is `undecidable`
+    # (run-digest line) instead. Still visible, still exit 0; just no duplicate.
     proc = subprocess.run(
         [sys.executable, str(Path(__file__).resolve().parent / "tik_eligibility.py"), "--create"],
         input="not json", capture_output=True, text=True)
     assert proc.returncode == 0
-    assert json.loads(proc.stdout)["family"] == "create"
+    out = json.loads(proc.stdout)
+    assert out["verdict"] == "undecidable"
+    assert out["family"] != "create"
 
 
 def test_create_8_fingerprint_regression_zero_creates():
@@ -571,20 +586,23 @@ def test_create_missing_events_truncated_fails_open_on_suppress():
     # Codex P2 (#1218 review r3): events_truncated is REQUIRED. A digest/suppress with
     # NO events_truncated key cannot prove the list is complete -> fail open to create.
     # (Same events that digest/suppress WITH events_truncated=False, per dc_full above.)
-    assert decide_create({"events": [cev(level="error")]})["family"] == "create"
-    assert decide_create({"events": [cev(synthetic="true")]})["family"] == "create"
+    # The duplicate check is established (none_found), so the #1218 logic is reachable.
+    assert decide_create({"events": [cev(level="error")],
+                          "duplicate_check": "none_found"})["family"] == "create"
+    assert decide_create({"events": [cev(synthetic="true")],
+                          "duplicate_check": "none_found"})["family"] == "create"
 
 
 def test_create_truncated_downgrades_digest_to_create():
     # Codex P2 (#1218 review r2): a digest on a TRUNCATED list is unsafe — an unread
     # page could hold a production/fatal event -> fail open to create.
-    base = {"events": [cev(level="error")]}
+    base = {"events": [cev(level="error")], "duplicate_check": "none_found"}
     assert decide_create({**base, "events_truncated": False})["family"] == "digest"
     assert decide_create({**base, "events_truncated": True})["family"] == "create"
 
 
 def test_create_truncated_downgrades_suppress_to_create():
-    base = {"events": [cev(synthetic="true")]}
+    base = {"events": [cev(synthetic="true")], "duplicate_check": "none_found"}
     assert decide_create({**base, "events_truncated": False})["family"] == "suppress"
     assert decide_create({**base, "events_truncated": True})["family"] == "create"
 
@@ -592,14 +610,128 @@ def test_create_truncated_downgrades_suppress_to_create():
 def test_create_truncated_does_not_change_create():
     # A create verdict is already visible -> truncation is irrelevant (like the reopen
     # gate's test_truncated_does_not_downgrade_reopen).
-    base = {"events": [cev(level="fatal")]}  # create-dev-fatal
+    base = {"events": [cev(level="fatal")], "duplicate_check": "none_found"}  # create-dev-fatal
     assert decide_create({**base, "events_truncated": True})["verdict"] == "create-dev-fatal"
 
 
 def test_create_truncated_string_true_is_coerced():
     # Shell-built JSON passes "true"/"false" as strings; only a real true downgrades.
-    out = decide_create({"events": [cev(level="error")], "events_truncated": "true"})
+    out = decide_create({"events": [cev(level="error")], "events_truncated": "true",
+                         "duplicate_check": "none_found"})
     assert out["family"] == "create"
+
+
+# ---- decide_create: duplicate guard (issue #2194) ---------------------------
+#
+# The create gate takes a REQUIRED `duplicate_check` input -- the outcome of the
+# routine's Step 2 marker search for the shortId. Three states, three outcomes:
+#   "open_found"  -> refuse-duplicate (family refuse): never create a second issue
+#   "none_found"  -> the #1218 event logic decides (create / digest / suppress)
+#   absent / errored / skipped ("unknown") -> undecidable (family digest): neither
+#     create nor suppress; the run digest says "could not check duplicates for X".
+# The enforcement is the REQUIRED input, not an instruction: a caller that supplies
+# nothing can never reach `create`.
+
+def test_dup_check_open_found_refuses_create():
+    # A production event that would otherwise create, plus a known open issue:
+    # the gate refuses. The open ticket already makes the fingerprint visible.
+    out = decide_create({"events": [pev()], "duplicate_check": "open_found"})
+    assert out["verdict"] == "refuse-duplicate"
+    assert out["family"] == "refuse"
+    assert out["family"] != "create"
+
+
+def test_dup_check_open_found_refuses_dev_fatal_too():
+    # The duplicate state dominates the event logic: even an untagged dev fatal
+    # (create-dev-fatal without the check) is refused when an open issue exists.
+    out = decide_create({"events": [cev(level="fatal")], "duplicate_check": "open_found"})
+    assert out["verdict"] == "refuse-duplicate"
+    assert out["family"] == "refuse"
+
+
+def test_dup_check_open_found_ignores_events_truncated():
+    # refuse-duplicate does not rest on the event list, so the truncation downgrade
+    # (which only upgrades suppressing verdicts to create) cannot reach it.
+    out = decide_create({"events": [cev(level="error")], "duplicate_check": "open_found",
+                         "events_truncated": True})
+    assert out["verdict"] == "refuse-duplicate"
+    assert out["family"] == "refuse"
+
+
+def test_dup_check_none_found_reaches_event_logic():
+    # "checked, none found" is the ONLY state that lets the #1218 event logic decide.
+    out = decide_create({"events": [pev()], "duplicate_check": "none_found"})
+    assert out["verdict"] == "create"
+    assert dc_full([cev(level="error")])["verdict"] == "digest-dev-only"
+
+
+def test_dup_check_missing_input_is_undecidable_never_create():
+    # The enforcement (REQUIRED input): a caller that supplies nothing to read gets
+    # the undecidable outcome, NOT the fail-open create default -- even when the
+    # events would create.
+    out = decide_create({"events": [pev()]})
+    assert out["verdict"] == "undecidable"
+    assert out["family"] == "digest"
+    assert out["family"] != "create"
+
+
+def test_dup_check_missing_everything_is_undecidable():
+    # The empty caller (the 2026-08-16/17 shape: Step 2 skipped, gate reached with
+    # nothing) must not create.
+    out = decide_create({})
+    assert out["verdict"] == "undecidable"
+    assert out["family"] != "create"
+
+
+def test_dup_check_unknown_value_is_undecidable():
+    # The search errored -> the routine says "unknown" -> neither create nor suppress.
+    out = decide_create({"events": [pev()], "duplicate_check": "unknown"})
+    assert out["verdict"] == "undecidable"
+    assert out["family"] != "create"
+
+
+def test_dup_check_unrecognised_values_are_undecidable():
+    # A typo or mis-pipe must land in the only state that cannot create.
+    for bad in ("openfound", "none", "no duplicates", "", None, 1, ["none_found"]):
+        out = decide_create({"events": [pev()], "duplicate_check": bad})
+        assert out["verdict"] == "undecidable", f"{bad!r} -> {out}"
+        assert out["family"] != "create"
+
+
+def test_dup_check_strip_and_case_normalised():
+    # strip/lower match the close_class leniency; the recognised spellings are the
+    # exact three states, so normalisation can only ever produce the documented
+    # outcomes (refuse / event logic), never a create the caller did not send.
+    assert decide_create({"events": [pev()], "duplicate_check": " OPEN_FOUND "})["family"] == "refuse"
+    assert decide_create({"events": [pev()], "duplicate_check": "None_Found"})["family"] == "create"
+    assert decide_create({"events": [pev()], "duplicate_check": "None_fond"})["family"] != "create"
+
+
+def test_dup_check_cli_missing_field_is_undecidable():
+    # Valid JSON without the REQUIRED field: the GATE (not the routine's compliance)
+    # returns undecidable. This is the enforcement end-to-end over the CLI the
+    # routine actually uses.
+    payload = json.dumps({"events": [pev()], "issue_level": "error",
+                          "events_truncated": False})
+    proc = subprocess.run(
+        [sys.executable, str(Path(__file__).resolve().parent / "tik_eligibility.py"), "--create"],
+        input=payload, capture_output=True, text=True)
+    assert proc.returncode == 0
+    out = json.loads(proc.stdout)
+    assert out["verdict"] == "undecidable"
+    assert out["family"] != "create"
+
+
+def test_dup_check_cli_open_found_refuses():
+    payload = json.dumps({"events": [pev()], "issue_level": "error",
+                          "events_truncated": False, "duplicate_check": "open_found"})
+    proc = subprocess.run(
+        [sys.executable, str(Path(__file__).resolve().parent / "tik_eligibility.py"), "--create"],
+        input=payload, capture_output=True, text=True)
+    assert proc.returncode == 0
+    out = json.loads(proc.stdout)
+    assert out["verdict"] == "refuse-duplicate"
+    assert out["family"] == "refuse"
 
 
 # ---- self-runner (no pytest dependency in the routine sandbox) --------------

--- a/workers/sentry-triage/tik_eligibility.py
+++ b/workers/sentry-triage/tik_eligibility.py
@@ -17,10 +17,13 @@ Two pure decision functions for the TIK Sentry-triage routine, sharing the
     already proven benign (#980, three times), and a mechanical auto-reopen on
     `ambiguous` (unprovable release relation) caused a second false reopen
     (#1332, 2026-07-12) by mutating a closed issue's state on pure uncertainty.
-  - `decide_create()` (#1218) -- the CREATE gate. Given the event list for a NEW
-    fingerprint that has no GitHub issue, decide whether it becomes a ticket (create),
-    is deliberate fault-injection noise (suppress), or is a dev-only self-healed error
-    to list in the run digest (digest). See its own docstring for the branch order.
+  - `decide_create()` (#1218, duplicate guard #2194) -- the CREATE gate. Given the
+    event list for a NEW fingerprint that has no GitHub issue, decide whether it becomes
+    a ticket (create), is deliberate fault-injection noise (suppress), or is a dev-only
+    self-healed error to list in the run digest (digest). Since #2194 it ALSO takes the
+    routine's duplicate-check outcome as a REQUIRED input and can refuse (an open issue
+    already tracks the fingerprint) or report that it could not decide (check absent or
+    errored) -- neither of which is the fail-open `create` default. See its docstring.
 
 DESIGN INVARIANTS (council 2026-06-21, 2 rounds; Codex grounded review 3 rounds;
 family semantics revised #1431, 2026-07-15):
@@ -38,6 +41,17 @@ family semantics revised #1431, 2026-07-15):
   - This module does NO network and NO git. The routine resolves the fix boundary
     (stamp or local-git-only derivation) and the event list, then pipes JSON here.
     Keeping it pure is what makes the gate unit-testable before it ships.
+  - CREATE-GATE DUPLICATE AXIS (#2194, 2026-08): `decide_create` takes a REQUIRED
+    `duplicate_check` input ("open_found" | "none_found" | "unknown"; anything else
+    is "unknown"). "open_found" returns `refuse-duplicate` (family `refuse`): the
+    fingerprint already has an open, visible ticket, so the refusal costs no
+    visibility. "unknown" (absent / errored / skipped check) returns a distinct
+    `undecidable` outcome -- NEITHER create nor suppress -- which the routine lists
+    in the run digest. This is the one place the create gate does NOT fail open to
+    `create`: failing open to create on a missing duplicate check is the mechanism
+    of #2194 itself (the 2026-08-16/17 duplicate batches). Same invariant, different
+    axis -- nothing is silently suppressed, and an unprovable duplicate state never
+    mutates GitHub state.
 
 Input (JSON on stdin): see EXPECTED_INPUT_SHAPE below.
 Output (JSON on stdout): {"verdict", "family", "reason", "eligible_user_count",
@@ -45,7 +59,10 @@ Output (JSON on stdout): {"verdict", "family", "reason", "eligible_user_count",
   "dev_canary"}.
 On any internal error: prints an `ambiguous` verdict (family `manual-review`,
 fail open to visible-but-non-mutating) and exits 0, so a helper bug can never
-become a silent hold NOR a silent reopen.
+become a silent hold NOR a silent reopen. Under `--create` the helper-error
+verdict is `undecidable` instead (#2194): an input the gate cannot read cannot
+have read the duplicate check, and an unreadable check must never become
+`create` -- so a helper bug can never become a silent drop NOR a duplicate create.
 """
 
 from __future__ import annotations
@@ -405,6 +422,12 @@ def _out(verdict, reason, eligible_user_count=0, eligible_count=0,
 # dev-detector -- the single authority for "is this dev" -- and the same fail-open
 # philosophy: anything we cannot PROVE is dev-only-and-self-healed becomes a VISIBLE
 # create, never a silent drop.
+#
+# The #2194 duplicate gate is the documented exception, on a different axis
+# (see decide_create): an unprovable DUPLICATE STATE never fails open to create --
+# refusing a duplicate costs no visibility (the open ticket is already on the
+# board), and an unverifiable check returns `undecidable` (run-digest line),
+# which is neither a create nor a silent suppression.
 
 # Create-path verdict -> action family. The routine Path A branches on `family`.
 #   create  : file the GitHub issue (real production signal, untagged dev fatal, or
@@ -417,13 +440,51 @@ CREATE_VERDICT_FAMILY = {
     "create-dev-fatal": "create",
     "suppress-synthetic": "suppress",
     "digest-dev-only": "digest",
+    # #2194 duplicate axis. `refuse`: an open issue already tracks this
+    # fingerprint -- creating a second one IS the bug. `undecidable`: the
+    # duplicate state was not established (check absent/errored/skipped) --
+    # neither create nor suppress; surfaced in the run digest like every other
+    # non-ticketed outcome, so a human sees it.
+    "refuse-duplicate": "refuse",
+    "undecidable": "digest",
 }
 
 # Create-path verdicts that SUPPRESS a ticket (do not create). On a truncated event
 # list (the fetch hit the page cap with more pages pending) a hidden later page could
 # carry a real production/fatal event, so any of these must fail OPEN (downgrade to
 # create) when `events_truncated` is set -- mirrors the reopen gate's `_HOLD_VERDICTS`.
+# The #2194 duplicate-axis verdicts are deliberately ABSENT from this set: they do
+# not rest on the event list at all (decided before it is read), so `events_truncated`
+# has no upgrade path into them -- in particular `undecidable` can never become
+# `create`, by construction.
 _CREATE_SUPPRESSING_VERDICTS = {"suppress-synthetic", "digest-dev-only"}
+
+# Duplicate-check states (issue #2194) -- the REQUIRED `duplicate_check` input to
+# `decide_create`, i.e. the outcome of the routine's Step 2 marker search for the
+# shortId. This gate is pure and cannot see GitHub; the routine ran the search and
+# must hand it the result. A skipped check is indistinguishable from an absent
+# one, and both must be treated as "could not verify" -- never as "none found".
+_DUP_CHECK_OPEN = "open_found"
+_DUP_CHECK_NONE = "none_found"
+_DUP_CHECK_UNKNOWN = "unknown"
+
+
+def _duplicate_check_state(data: dict) -> str:
+    """Normalise the REQUIRED `duplicate_check` input (#2194) to a state string.
+
+    Only the three documented spellings are recognised, after strip().lower()
+    (the same leniency `close_class` gets). Anything else -- absent, null,
+    non-string, or a typo -- returns "unknown". That direction is deliberate:
+    "unknown" is the one state that can never become `create`, so a broken,
+    misspelt, or skipped check always lands in the safe direction.
+    """
+    v = data.get("duplicate_check")
+    if not isinstance(v, str):
+        return _DUP_CHECK_UNKNOWN
+    v = v.strip().lower()
+    if v in (_DUP_CHECK_OPEN, _DUP_CHECK_NONE, _DUP_CHECK_UNKNOWN):
+        return v
+    return _DUP_CHECK_UNKNOWN
 
 
 def _effective_level(event: dict, issue_level) -> str | None:
@@ -438,16 +499,73 @@ def _effective_level(event: dict, issue_level) -> str | None:
 
 
 def decide_create(data: dict) -> dict:
-    """Create-path eligibility gate (#1218): should a NEW fingerprint become a ticket?
+    """Create-path eligibility gate (#1218; duplicate guard #2194).
 
     Input (JSON): {events: [{environment, build_type, release, level, synthetic,
-    user_id, dateCreated}], issue_level, events_truncated}. `issue_level` is the
-    aggregate/latest-event level Path A severity already reads -- the per-event `level`
-    fallback. Operates over the event LIST (not a scalar) so a multi-event fingerprint
-    partitions correctly. Output: {verdict, family, reason, dev_count, event_count};
-    family in {create, suppress, digest}. Fails OPEN (create) on empty/unclassifiable
-    input AND on a truncated event list (unread pages could hide a real event).
+    user_id, dateCreated}], issue_level, events_truncated, duplicate_check}.
+    `issue_level` is the aggregate/latest-event level Path A severity already reads --
+    the per-event `level` fallback. Operates over the event LIST (not a scalar) so a
+    multi-event fingerprint partitions correctly. `events_truncated` is the event-list
+    completeness flag (REQUIRED by the #1218 logic).
+
+    `duplicate_check` is REQUIRED since #2194 -- the outcome of the routine's Step 2
+    marker search for this shortId, because this gate is pure and cannot see GitHub:
+      "open_found"  an OPEN issue carrying the shortId's marker exists
+      "none_found"  the check ran and found no open issue for this shortId
+      "unknown"     the check errored or was not run (a skipped check is absent,
+                    and an absent check must be treated like an errored one, because
+                    both are "I could not verify")
+    Anything else -- missing, null, non-string, a typo -- is treated as "unknown";
+    that is the only state a mis-piped input can land in, and it never creates.
+
+    Output: {verdict, family, reason, dev_count, event_count};
+    family in {create, suppress, digest, refuse}. Fails OPEN (create) on
+    empty/unclassifiable input AND on a truncated event list (unread pages could hide
+    a real event) -- but only AFTER the duplicate check above has passed: the
+    event-axis fail-open default is `create`, the duplicate-axis one is
+    `undecidable`.
     """
+    events = data.get("events") if isinstance(data.get("events"), list) else []
+    dev_count = sum(1 for e in events if isinstance(e, dict) and is_development(e))
+
+    # ---- duplicate gate (#2194) -- decided before, and independent of, the events --
+    #
+    # This module's invariant is "anything unprovable stays visible, never silently
+    # suppressed", and every fail-open branch in this file protects VISIBILITY.
+    # The two outcomes below do not contradict it -- they are a different axis:
+    #
+    #   open_found -> refuse. Refusing a duplicate COSTS NO VISIBILITY: the
+    #   fingerprint already has an open, visible ticket; a second issue only buries
+    #   the first (#2194: eight duplicates in two days, seven P0-labelled, read as
+    #   seven emergencies when it was three fingerprints).
+    #
+    #   unknown -> undecidable. NEITHER create NOR suppress. Failing open to create
+    #   here would reproduce #2194 exactly -- an agent that skips Step 2 supplies
+    #   nothing and gets the fail-open default. Failing closed to suppress would
+    #   silently swallow a genuinely new fingerprint, the one outcome this module
+    #   exists to prevent. So it is listed in the run digest ("could not check
+    #   duplicates for {shortId}"): nothing hidden, a person told. Fail open to
+    #   VISIBILITY, literally.
+    #
+    # The field is REQUIRED precisely so the enforcement does not depend on the
+    # routine choosing to comply: a skipped Step 2 reaches this gate with nothing to
+    # read and gets `undecidable`, not `create`. The prompt already said "never
+    # assume 'no GitHub issue exists' on an error"; the 2026-08-16/17 runs show that
+    # an instruction is not self-enforcing while a required input is.
+    check = _duplicate_check_state(data)
+    if check == _DUP_CHECK_OPEN:
+        return _out_create("refuse-duplicate",
+                           "open GitHub issue already exists for this shortId; refusing "
+                           "to create a duplicate (the fingerprint is already visible "
+                           "on the board)",
+                           dev_count=dev_count, event_count=len(events))
+    if check != _DUP_CHECK_NONE:
+        return _out_create("undecidable",
+                           "could not check duplicates (duplicate_check absent or "
+                           "errored); neither create nor suppress -- run digest: "
+                           "could not check duplicates for this shortId",
+                           dev_count=dev_count, event_count=len(events))
+
     result = _decide_create_inner(data)
     # A digest/suppress decision is only valid on a PROVABLY COMPLETE event list. The
     # `events_truncated` flag is REQUIRED on the input and is this gate's ONLY
@@ -548,11 +666,17 @@ def main(argv=None) -> int:
         raw = sys.stdin.read()
         data = json.loads(raw)
         result = decide_create(data) if create_mode else decide(data)
-    except Exception as exc:  # noqa: BLE001 -- fail OPEN on any helper error
-        # Fail-open shape differs per gate: reopen-gate -> ambiguous (family
-        # manual-review: visible flag, closed issue stays closed, #1431),
-        # create -> create (visible new ticket). Neither can become a silent drop.
-        result = (_out_create("create", f"helper error: {type(exc).__name__}: {exc}")
+    except Exception as exc:  # noqa: BLE001 -- fail CLOSED-to-VISIBLE on helper error
+        # Helper-error shape differs per gate: reopen-gate -> ambiguous (family
+        # manual-review: visible flag, closed issue stays closed, #1431); create ->
+        # undecidable (#2194: an input the gate cannot read cannot have read the
+        # duplicate check, and an unreadable check must never become `create`; the
+        # run digest surfaces it). Neither can become a silent drop.
+        result = (_out_create(
+                      "undecidable",
+                      f"helper error: {type(exc).__name__}: {exc} -- the duplicate "
+                      f"check could not be read, so neither create nor suppress; "
+                      f"run digest: could not check duplicates")
                   if create_mode
                   else _out("ambiguous", f"helper error: {type(exc).__name__}: {exc}"))
     print(json.dumps(result))


### PR DESCRIPTION
# Duplicate guard for the Sentry create gate (#2194)

`decide_create()` in `workers/sentry-triage/tik_eligibility.py` now takes the routine's Step 2 duplicate-check outcome as a **REQUIRED** input. A caller that skips the check reaches the gate with nothing to read and gets the undecidable outcome — it cannot accidentally get `create`. Per the design fork resolved in the issue thread: the third state (absent / errored check) is a distinct outcome, not a collapse into either neighbour, and the "refusing a duplicate costs no visibility" argument lives at the new code, not only in the commit message.

## The three states, as implemented

Function: `decide_create(data)` — new input `data["duplicate_check"]`, normalised by `_duplicate_check_state()` (strip/lower; anything unrecognised — missing, null, non-string, typo — is `unknown`, the only state that cannot create).

| routine supplies (`duplicate_check`) | meaning | verdict | family | routine does |
|---|---|---|---|---|
| `"open_found"` | open issue found for this shortId | `refuse-duplicate` | `refuse` | do not create; log one line; skip create steps |
| `"none_found"` | checked, none found | (event logic) `create` / `create-dev-fatal` / `digest-dev-only` / `suppress-synthetic` | `create`/`digest`/`suppress` | unchanged #1218 behaviour, incl. the `events_truncated` downgrade |
| `"unknown"`, missing, or the search errored | could not decide | `undecidable` | `digest` | do not create; run-digest line: `could not check duplicates for {shortId}` |

- The duplicate gate runs **before** and independently of the event logic; `refuse-duplicate` and `undecidable` are deliberately absent from `_CREATE_SUPPRESSING_VERDICTS`, so `events_truncated` has no upgrade path into them — `undecidable` can never become `create`, by construction.
- The CLI helper-error path (`--create`, unparseable stdin / internal exception) now returns `undecidable` instead of `create`: an input the gate cannot read cannot have read the check. The reopen gate (`decide()`) is unchanged.
- No bypass, no force flag, no env-var escape. No existing fail-open branch was removed: the event-axis fail-opens (empty/unclassifiable events, truncation downgrade) are intact, scoped to the `none_found` state.
- The header's `DESIGN INVARIANTS` block was updated in the same commit with the new duplicate-axis invariant ("same invariant, different axis").

## Tests (Python suite, run on this machine)

- Before: **67/67 passed** (green baseline recorded before any change).
- After: **78/78 passed** (11 new cases + the rewritten bad-JSON case below).
- Worker JS lane (CI `worker-tests` runs `node --test`): **87/87 passed** locally.
- **NOT RUN — requires Mac validation:** Swift/Xcode build and `Tests/` suites (no Swift changes in this PR; the repo's required `build-check` lanes run on macOS CI only).

### New cases (all in `test_tik_eligibility.py`, section "duplicate guard (issue #2194)")

| test | pins |
|---|---|
| `test_dup_check_open_found_refuses_create` | open_found → `refuse-duplicate`, even for a production event that would otherwise create |
| `test_dup_check_open_found_refuses_dev_fatal_too` | the check dominates the event logic (untagged dev fatal still refused) |
| `test_dup_check_open_found_ignores_events_truncated` | refuse is not reachable via the truncation upgrade path |
| `test_dup_check_none_found_reaches_event_logic` | `none_found` is the only state that reaches the #1218 logic (create and digest both observed) |
| `test_dup_check_missing_input_is_undecidable_never_create` | **the enforcement**: a caller supplying nothing to read gets `undecidable`, never `create` |
| `test_dup_check_missing_everything_is_undecidable` | the empty caller (the 2026-08-16/17 shape) does not create |
| `test_dup_check_unknown_value_is_undecidable` | explicit `"unknown"` (search errored) → undecidable |
| `test_dup_check_unrecognised_values_are_undecidable` | typos / non-strings / null / numbers all land in the state that cannot create |
| `test_dup_check_strip_and_case_normalised` | normalisation is lenient only toward the documented spellings |
| `test_dup_check_cli_missing_field_is_undecidable` | enforcement end-to-end over the real `--create` CLI |
| `test_dup_check_cli_open_found_refuses` | refuse end-to-end over the real `--create` CLI |

### Existing tests — one contract change, disclosed

The new input is REQUIRED, so existing create-gate fixtures now supply `duplicate_check: "none_found"` (mechanical fixture update; every event-logic assertion is unchanged and all still pass for the same reason — including the 8-fingerprint regression metric). One test asserts the exact behaviour #2194 supersedes and was rewritten, flagged here as a semantic change, not a fixture update:

- `test_create_cli_create_flag_fails_open_on_bad_json` → `test_dup_check_cli_bad_json_is_undecidable_not_create`. It previously asserted malformed stdin under `--create` yields `family=create`. Under the new contract an unreadable input cannot have read the check, so it yields `undecidable` (still visible via the run digest, still exit 0) — failing open to `create` on unreadable input is the mechanism of #2194 itself.

## Mutation control (per case, on the exact file the tests import)

Each new case: the guarded production line was broken in place, that specific test was run and confirmed red **for the intended reason** (the mutant's actual verdict is shown), then the file was restored byte-identical (sha256-verified). Full suite re-confirmed 78/78 after restore.

| test | mutation | mutant's actual verdict (why red) |
|---|---|---|
| `…_open_found_refuses_create` | `if check == _DUP_CHECK_OPEN:` → `if check == "openfound":` | `undecidable` (expected `refuse-duplicate`) |
| `…_open_found_refuses_dev_fatal_too` | the two early-return blocks swapped wholesale (undecidable branch first) | `undecidable` — i.e. `open_found` collapsed into its neighbour (expected `refuse-duplicate`) |
| `…_open_found_ignores_events_truncated` | refuse conditioned on `not events_truncated` | `undecidable` with `events_truncated=true` (expected `refuse-duplicate`) |
| `…_none_found_reaches_event_logic` | `"none_found"` removed from the recognised set | `undecidable` (expected `create`) |
| `…_missing_input_is_undecidable_never_create` | fallback condition inverted: `!=` → `==` `_DUP_CHECK_NONE` | `create` (expected `undecidable`) — the bug's shape |
| `…_missing_everything_is_undecidable` | same | `create` (expected `undecidable`) |
| `…_unknown_value_is_undecidable` | `"unknown"` unrecognised **and** helper fallback returns `none_found` | `create` (expected `undecidable`) |
| `…_unrecognised_values_are_undecidable` | helper fallback returns `none_found` | `create` (expected `undecidable`) |
| `…_strip_and_case_normalised` | `v = v.strip().lower()` → `v = v` | `undecidable` for `" OPEN_FOUND "` (expected `refuse`) |
| `…_cli_missing_field_is_undecidable` | fallback condition inverted, over the CLI | `create` (expected `undecidable`) |
| `…_cli_open_found_refuses` | open_found condition → unrecognised literal, over the CLI | `undecidable` (expected `refuse-duplicate`) |
| `…_cli_bad_json_is_undecidable_not_create` | `main()` except path reverted to return `create` | `create` (expected `undecidable`) |

Note on case 2: the first mutation attempt (swapping only the two `if` conditions, bodies kept) did **not** go red for this test — the mutant did change behaviour (a *missing* check then returned `refuse` instead of `undecidable`) but not the behaviour this test pins. Per the control's rule, that was established before concluding, and the mutation was replaced with the wholesale block swap above. Also note cases 1, 2 and 11 guard the same production line (the `open_found` branch) from three angles (direct, dominance-over-event-logic, and over the CLI).

## Routine prompt changes (required collateral)

`workers/sentry-triage/routine-prompt-tik-sentry.md` (reference copy of the live TIK routine; the live Routine config must be re-synced from this file):

1. **Path A step 6.5** documents the new REQUIRED `duplicate_check` input with its three values, adds it to the helper invocation, and branches on the two new outcomes (`refuse` → log + skip; `undecidable` → run-digest line, exactly `could not check duplicates for {shortId}`).
2. **Step 2 + Failure handling:** on a Step 2 search error the routine previously did "log + skip" (the duplicate state silently unknown). It now routes to Path A with `duplicate_check: "unknown"` — the gate returns `undecidable`, so a failed check is visible in the run digest instead of silently skipped. Normal routing carries `duplicate_check: "none_found"`.
3. **Failure handling, create-gate bullet split:** events-list fetch failure fails open to `create` only when the check is `none_found`; a helper non-zero exit / unparseable output is now treated as `undecidable` (the gate itself is the fail-closed default for creation).
4. **"Dev-only digest" → "Not-ticketed digest":** the end-of-run digest block now covers both `digest-dev-only` and `undecidable` lines.

`routine-prompt-tok-codex.md` needs nothing (TOK owns PR triage and never runs the Sentry create gate); `routine-prompt-v3.1-backup-2026-05-02.md` is a historical backup and was not touched.

## Scope

`git diff --name-status origin/main...HEAD`:

```
M	workers/sentry-triage/routine-prompt-tik-sentry.md
M	workers/sentry-triage/test_tik_eligibility.py
M	workers/sentry-triage/tik_eligibility.py
```

Nothing under `Sources/`, `Tests/`, `website/`, or `.github/`.

Closes #2194
