### PR TITLE
fix(website): remove FAQ markup from two pages that render no FAQ

### DIFF
--- a/website/src/pages/how-it-works.astro
+++ b/website/src/pages/how-it-works.astro
@@ -35,68 +35,6 @@ const breadcrumbJsonLd = JSON.stringify({
   ],
 });
 
-const faqJsonLd = JSON.stringify({
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  "mainEntity": [
-    {
-      "@type": "Question",
-      "name": "Does EnviousWispr work without internet?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Yes. All speech recognition runs on-device using Apple Silicon and the Parakeet or WhisperKit model. Your audio never leaves your Mac. AI polish can also run on-device with EG-1, Apple Intelligence on supported systems, or a downloaded Ollama model. If you choose cloud polish, the transcript, cleanup instructions, custom words, target app name, and your account credential go directly to that provider."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "What Mac do I need to run EnviousWispr?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "EnviousWispr requires macOS 14 Sonoma or later, running on an Apple Silicon Mac (M1, M2, M3, M4 or newer). It does not run on Intel Macs. The Neural Engine on Apple Silicon is what makes on-device transcription fast enough to feel instant."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "How fast is voice-to-text with EnviousWispr?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Typical dictation completes in under two seconds from the moment you stop speaking to the moment polished text pastes into your active app. Recording, transcription, and AI polish run in parallel rather than in sequence, which is why the perceived latency is sub-second on warm runs."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "What is the difference between push-to-talk and hands-free mode?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Push-to-talk means you hold a keybind while speaking and release to transcribe. It is the default mode. Hands-free mode listens continuously and transcribes when you pause. It is useful when typing is not an option, for example during accessibility-driven dictation or when both hands are occupied."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Does EnviousWispr send my voice or text anywhere?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Audio never leaves your Mac. Transcription is fully on-device. Local AI polish can keep the request there too. If you choose cloud polish, the transcript, cleanup instructions, custom words, target app name, and your account credential go directly to the provider. No raw audio is ever uploaded."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Which languages does EnviousWispr support?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "The default Parakeet engine covers 25 European languages. Switching the backend to WhisperKit supports 90+ languages. Both run on-device on Apple Silicon."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Does EnviousWispr work in every app?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "EnviousWispr pastes into any macOS app that accepts text input. That includes Slack, VS Code, Gmail, Notion, Google Docs, Terminal, Messages, browser forms, and any other text field. There is no per-app configuration."
-      }
-    },
-  ],
-});
 ---
 
 <BaseLayout
@@ -108,7 +46,6 @@ const faqJsonLd = JSON.stringify({
   <Fragment slot="head">
     <script type="application/ld+json" set:html={webPageJsonLd}></script>
     <script type="application/ld+json" set:html={breadcrumbJsonLd}></script>
-    <script type="application/ld+json" set:html={faqJsonLd}></script>
   </Fragment>
 
 <style>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -87,76 +87,6 @@ const jsonLdWebSite = JSON.stringify({
   }
 });
 
-const jsonLdFaq = JSON.stringify({
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  "mainEntity": [
-    {
-      "@type": "Question",
-      "name": "Is EnviousWispr free?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Yes. EnviousWispr is completely free to download and use. No subscription, no account required."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Does EnviousWispr work offline?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Yes. All speech recognition runs on-device using Apple Silicon. Your audio never leaves your Mac."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "What makes EnviousWispr different from WisprFlow?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "EnviousWispr is free and processes everything on-device. WisprFlow costs $15/month and sends audio to cloud servers. EnviousWispr requires no account signup."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Which macOS versions does EnviousWispr support?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "EnviousWispr requires macOS 14 (Sonoma) or later running on Apple Silicon (M1 or newer)."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Does EnviousWispr support multiple languages?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "The default Parakeet engine covers 25 European languages. The WhisperKit backend supports 90+ languages for wider multi-language dictation."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Can I see EnviousWispr's source code?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Yes. EnviousWispr is open source under the GNU General Public License v3 (GPLv3), an OSI-approved license. The full codebase is on GitHub. You can read every line, build from source, and verify every privacy claim."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Which apps does EnviousWispr work with?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "EnviousWispr works with any app that accepts text input. It pastes directly into your active text field, whether that is Slack, VS Code, Gmail, Notion, Google Docs, Terminal, or any other app."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Does EnviousWispr run Whisper locally?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Yes. The WhisperKit backend runs OpenAI Whisper models locally via Apple Core ML. The default Parakeet engine uses NVIDIA's Parakeet TDT model, also running on-device. Both use Apple Silicon's Neural Engine for fast inference."
-      }
-    }
-  ]
-});
 ---
 
 <BaseLayout title={title} description={description} activePage="home" canonicalPath="/">
@@ -165,7 +95,6 @@ const jsonLdFaq = JSON.stringify({
     <script type="application/ld+json" set:html={jsonLdOrg}></script>
     <script type="application/ld+json" set:html={jsonLdPerson}></script>
     <script type="application/ld+json" set:html={jsonLdWebSite}></script>
-    <script type="application/ld+json" set:html={jsonLdFaq}></script>
   </Fragment>
 
   <!-- ═══════════════════════════════════════════════════════


### PR DESCRIPTION
## What

The homepage declared `FAQPage` structured data with 8 questions. How-it-works declared 7. Neither page renders a single one of them, and neither has an FAQ heading or accordion at all.

Both blocks removed. Nothing else touched.

## Evidence

Verified against **production**, not a local build, by parsing every `application/ld+json` block, collecting `mainEntity[].name`, stripping scripts and tags from the served HTML, then exact-matching:

| Page | Questions in schema | Found in visible text |
|---|---|---|
| `/` | 8 | **0** |
| `/how-it-works/` | 7 | **0** |
| `/compare/voiceink/` (control) | 10 | 9 |

The comparison page matching 9 of 10 (the tenth a quote-character difference) is what a correct page looks like, and it is why this is scoped to two pages rather than treated as a template problem. All 18 comparison pages are correct and are untouched.

## Why delete rather than render

The ticket originally recommended rendering a real FAQ on the homepage. Reading the source changed that: the homepage has no FAQ section of any kind, so adding one is a **design change to our primary conversion page**, not a defect fix, and it does not belong inside a correctness PR.

Deleting removes the policy violation completely and is reversible in one commit. FAQ rich results were retired for all sites in May 2026, so no search real estate is lost. The 15 questions are recorded on #2360 so rendering them later costs nothing, along with three factual claims inside them that would need verifying first (an unsourced competitor price, and two language-count claims that sit against the brand pack's own wording).

## Verification

Two-way control against the built output:

```
index.html            FAQPage occurrences: 8 -> 0
how-it-works/index.html                    7 -> 0
compare/voiceink/index.html                1 -> 1   (unchanged, as intended)
```

Every other schema type on both pages survives, confirmed in the built HTML: `SoftwareApplication`, `Organization`, `Person`, `WebSite` on the homepage; `WebPage`, `BreadcrumbList`, `WebSite` on how-it-works.

Site build clean, 132 pages. All three help checks run **explicitly**, because `npm run build` only runs the first one:

```
help content: 55 articles, 0 error(s), 6 warning(s)
help routes:  expected 68, built 68, in sitemap 68, internal links 9551 (0 dead)
help search:  42 passed, 0 failed
```

A drift baseline was captured for both pages before the edit, so the change is diffable rather than re-derived.

## Lane

Content (`website/**`).

Part of #2359
Closes #2360
