### PR TITLE
fix(website): correct four snippets and name carpal tunnel on the RSI post

### DIFF
--- a/website/src/content/blog/voice-input-rsi-keyboard-free-workflow.md
+++ b/website/src/content/blog/voice-input-rsi-keyboard-free-workflow.md
@@ -10,7 +10,7 @@ author: "Saurabh Vaish"
 
 By some estimates, knowledge workers produce somewhere between 5,000 and 10,000 words per day across emails, messages, documents, and tickets. That's roughly 125,000 to 250,000 keystrokes. Every single workday, five days a week, for years. The human wrist was not designed for this.
 
-Repetitive strain injury doesn't announce itself with a single dramatic moment. It builds quietly, one email, one Slack thread, one commit message at a time, until typing becomes something you ration instead of something you do without thinking. You start making calculations: can I afford to type this reply, or should I save my keystrokes for the report due at five?
+Repetitive strain injury, whether that is carpal tunnel syndrome, tendinitis, or something a doctor has not yet put a name to, doesn't announce itself with a single dramatic moment. It builds quietly, one email, one Slack thread, one commit message at a time, until typing becomes something you ration instead of something you do without thinking. You start making calculations: can I afford to type this reply, or should I save my keystrokes for the report due at five?
 
 Voice input changes that math entirely. Not as a novelty, but as a genuine reduction in the repetitive motion that causes the damage.
 

--- a/website/src/content/help/what-is-enviouswispr.md
+++ b/website/src/content/help/what-is-enviouswispr.md
@@ -1,6 +1,6 @@
 ---
 title: "What Is EnviousWispr?"
-description: "What EnviousWispr does, and what you get for free."
+description: "EnviousWispr is a free, open-source dictation app for macOS. Hold a keybind, speak, and your words appear as text in whatever app you are using."
 category: "getting-started"
 section: "Basics"
 order: 1

--- a/website/src/pages/compare/dragon.astro
+++ b/website/src/pages/compare/dragon.astro
@@ -160,8 +160,8 @@ const faqJsonLd = JSON.stringify({
 ---
 
 <BaseLayout
-  title="Dragon for Mac Alternative: EnviousWispr (Dragon Mac Discontinued)"
-  description="Dragon for Mac was discontinued, and Nuance's consumer Dragon is now sidelined under Microsoft. EnviousWispr is free, on-device dictation for Apple Silicon Macs. No account required."
+  title="Dragon for Mac Alternative: Free On-Device Dictation"
+  description="Dragon for Mac was discontinued and is no longer sold. EnviousWispr is free on-device dictation for Apple Silicon Macs, with no account or subscription."
   activePage="compare"
   ogImage="/images/og/dragon.png"
   canonicalPath="/compare/dragon/"

--- a/website/src/pages/how-it-works.astro
+++ b/website/src/pages/how-it-works.astro
@@ -7,7 +7,7 @@ const webPageJsonLd = JSON.stringify({
   "@context": "https://schema.org",
   "@type": "WebPage",
   "name": "On-Device Speech to Text on macOS: How EnviousWispr Works",
-  "description": "On-device dictation on Apple Silicon. Zero audio uploaded. About two seconds from voice to paste. See how the EnviousWispr pipeline records, transcribes, polishes, and pastes without sending your voice to a server.",
+  "description": "On-device dictation for Apple Silicon Macs. Your audio never leaves your Mac, and it takes about two seconds from speech to pasted text. See how it works.",
   "url": `${siteUrl}/how-it-works/`,
   "isPartOf": {
     "@type": "WebSite",
@@ -39,7 +39,7 @@ const breadcrumbJsonLd = JSON.stringify({
 
 <BaseLayout
   title="On-Device Speech to Text on macOS: How EnviousWispr Works"
-  description="On-device dictation on Apple Silicon. Zero audio uploaded. About two seconds from voice to paste. See how the EnviousWispr pipeline records, transcribes, polishes, and pastes without sending your voice to a server."
+  description="On-device dictation for Apple Silicon Macs. Your audio never leaves your Mac, and it takes about two seconds from speech to pasted text. See how it works."
   activePage="how-it-works"
   canonicalPath="/how-it-works/"
 >

--- a/website/src/pages/terms-of-service.astro
+++ b/website/src/pages/terms-of-service.astro
@@ -19,6 +19,15 @@ const jsonLd = {
     "url": "https://enviouswispr.com",
   },
 };
+
+const breadcrumbJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://enviouswispr.com" },
+    { "@type": "ListItem", "position": 2, "name": "Terms of Service", "item": "https://enviouswispr.com/terms-of-service/" },
+  ],
+};
 ---
 
 <BaseLayout
@@ -28,6 +37,7 @@ const jsonLd = {
   canonicalPath="/terms-of-service/"
 >
   <script slot="head" type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
+  <script slot="head" type="application/ld+json" set:html={JSON.stringify(breadcrumbJsonLd)} />
 
   <div class="legal-page">
     <a href="/" class="back-link">&larr; Back to home</a>


### PR DESCRIPTION
## What

Five corrections from the 2026-08-23 audit (#2359). Every value below is read back from the **built output**, not the source.

| Page | Field | Before | After |
|---|---|---|---|
| `/help/what-is-enviouswispr/` | description | 50 | **144** |
| `/how-it-works/` | description | 214 | **154** |
| `/compare/dragon/` | title | 66 | **52** |
| `/compare/dragon/` | description | 182 | **152** |
| `/terms-of-service/` | `BreadcrumbList` | absent | **present** |
| `/blog/voice-input-rsi-...` | "carpal tunnel" | 0 occurrences | **1** |

The homepage was left untouched and used as a control; its title and description are unchanged in the built output.

## Notes on individual calls

**The help page is the highest-value item here.** Position 3.3 on 86 impressions with zero clicks, and a 50-character description was surrendering two thirds of the snippet. Its title still repeats the brand twice (`What Is EnviousWispr?: EnviousWispr Help`) because that suffix is built site-wide across all 55 help articles at `src/pages/help/[...slug].astro:91`. Changing it would touch every help page and is not a small correction; flagged for its own decision.

**The Dragon title change was checked, not assumed.** Dropping "(Dragon Mac Discontinued)" costs nothing: `discontinued` appears in **one** query with **one** impression over 28 days, while `dragon for mac` carries 109 and `dragon speaks for mac` 56. The new title leads with the dominant intent. The discontinued fact stays in the description, where it is the actual hook for someone who searches for Dragon and finds it gone.

**`/how-it-works/` needed two sites, not one.** The description is set both in the `BaseLayout` prop and in the page's JSON-LD. A single-site edit would have left the structured data disagreeing with the meta tag. The guard that caught this refused the edit rather than silently changing one of them.

**The RSI wording avoids a medical claim.** The phrase is named once, inside the sentence that already explains what RSI is: *"Repetitive strain injury, whether that is carpal tunnel syndrome, tendinitis, or something a doctor has not yet put a name to, doesn't announce itself..."* Those searches currently land on `/blog/dictation-parents-type-one-handed/` at position 61.4, which is the wrong article.

**The breadcrumb matches this file's idiom.** `terms-of-service.astro` uses a plain object injected with `slot="head"`, not the stringified-const pattern in `privacy-policy.astro`, and has no `siteUrl` binding. Pasting the sibling's pattern would not have compiled.

## Two items deliberately not done

- **The "Seventeen head-to-head breakdowns" copy is correct.** There are exactly 17: 20 files in `src/pages/compare/`, minus the index, minus the roundup, minus the alternatives list. That finding is **withdrawn** on #2364 and corrected in the audit report. The original 19 counted every link to a comparison page, which is a different quantity from what the copy claims.
- **FAQ markup was not added to `/compare/best-dictation-apps-for-mac/`.** That page renders no FAQ, so the markup would recreate exactly the defect #2360 removed two commits ago. Two of the audit's own recommendations were in conflict; this is the resolution.

## Verification

```
help content: 55 articles, 0 error(s), 6 warning(s)
help routes:  expected 68, built 68, in sitemap 68, internal links 9551 (0 dead)
help search:  42 passed, 0 failed
build:        132 page(s), exit 0
```

All three checks run explicitly, because `npm run build` only runs the first. Drift baselines were captured for these pages before the edits, so the change is diffable.

## Lane

Content (`website/**`).

Part of #2359
Closes #2364
