### PR TITLE
fix(website): publish 99+ WhisperKit language count and guard it (#2368)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Press keybind -->  Record  -->  Transcribe  -->  Polish (optional)  -->  Paste
 
 1. **Press your keybind** from any app. Push-to-talk, toggle, or hands-free (double-press to lock for long-form), your choice.
 2. **Speak naturally.** Silero VAD detects when you stop talking and ends recording automatically.
-3. **On-device transcription.** Choose Parakeet v3 (fastest, 25 European languages) or WhisperKit (99 languages, with automatic language detection).
+3. **On-device transcription.** Choose Parakeet v3 (fastest, 25 European languages) or WhisperKit (99+ languages, with automatic language detection).
 4. **AI polish** (optional). Clean up grammar, punctuation, and formatting. Runs fully on-device with EG-1 (our own custom model), Apple Intelligence (macOS 26+), or Ollama, or in the cloud via OpenAI or Gemini with your own API key.
 5. **Text lands in your clipboard** and optionally auto-pastes into the active app.
 
@@ -82,7 +82,7 @@ Dictation is only useful if you can trust it mid-sentence, every time. EnviousWi
 | Model | Best for | Languages | Disk space | Runs on |
 |---|---|---|---|---|
 | **Parakeet TDT v3** | Fastest dictation (default) | 25 European languages | ~460 MB | Apple Neural Engine |
-| **WhisperKit** (Whisper Large v3 Turbo) | Broadest language coverage and automatic language detection | 99 languages | ~1.6 GB | Apple GPU |
+| **WhisperKit** (Whisper Large v3 Turbo) | Broadest language coverage and automatic language detection | 99+ languages | ~1.6 GB | Apple GPU |
 
 Both models run entirely on-device on Apple Silicon using CoreML. Parakeet runs on the Apple Neural Engine, which is what makes the default engine near-instant; WhisperKit runs on the GPU for broad-language accuracy. First launch downloads and compiles the model; subsequent launches are instant.
 

--- a/Sources/EnviousWisprASR/LanguageDetector.swift
+++ b/Sources/EnviousWisprASR/LanguageDetector.swift
@@ -788,7 +788,7 @@ public actor LanguageDetector {
     else {
       return SessionLanguageMemory()
     }
-    // Defensive: strip any langs that are not in the 99-language set.
+    // Defensive: strip any langs that are not accepted Whisper codes.
     decoded.usage24h = decoded.usage24h.filter { LanguageTypes.isSupported($0.key) }
     decoded.accepted = decoded.accepted.filter { LanguageTypes.isSupported($0.lang) }
     if let p = decoded.sessionPreferred, !LanguageTypes.isSupported(p) {

--- a/Sources/EnviousWisprAppKit/Views/Settings/LanguageCatalog.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LanguageCatalog.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Display metadata for the 99 Whisper-supported languages.
+/// Display metadata for the languages accepted by the Whisper path.
 ///
 /// Keyed by ISO 639-1 (and one ISO 639-3-style code, `haw`, plus `yue` for
 /// Cantonese) matching `LanguageTypes.whisperSupportedLanguages`. Each entry
@@ -26,13 +26,14 @@ enum LanguageCatalog {
     return Entry(code: code, nativeName: code.uppercased(), englishName: code.uppercased())
   }
 
-  /// All 99 languages, sorted alphabetically by English name for catalog display.
+  /// Every accepted Whisper language, sorted alphabetically by English name
+  /// for catalog display.
   static let sortedByEnglishName: [Entry] = all.sorted { lhs, rhs in
     lhs.englishName.localizedCaseInsensitiveCompare(rhs.englishName) == .orderedAscending
   }
 
-  /// All 99 Whisper-supported languages. Order here is not significant; the
-  /// UI sorts via `sortedByEnglishName`.
+  /// Every language accepted by the Whisper path. Order here is not
+  /// significant; the UI sorts via `sortedByEnglishName`.
   static let all: [Entry] = [
     Entry(code: "af", nativeName: "Afrikaans", englishName: "Afrikaans"),
     Entry(code: "am", nativeName: "አማርኛ", englishName: "Amharic"),

--- a/Sources/EnviousWisprAppKit/Views/Settings/LanguageLockOptions.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LanguageLockOptions.swift
@@ -157,7 +157,7 @@ enum LanguageLockOptions {
   static func lockableCodes(for backend: ASRBackendType) -> Set<String>? {
     switch backend {
     case .whisperKit:
-      // All 99. The engine claims no restriction, so the app must not invent one.
+      // The engine's full catalogue. It claims no restriction, so the app must not invent one.
       return nil
     case .parakeet:
       // Owned by the backend, derived from the vendor enum minus the cases its

--- a/Sources/EnviousWisprAppKit/Views/Settings/LanguageLockSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LanguageLockSheet.swift
@@ -15,7 +15,7 @@ struct LanguageLockSheet: View {
   @Environment(\.dismiss) private var dismiss
 
   /// Codes this engine may be locked to, or nil for "no restriction" (the
-  /// multilingual engine's 99).
+  /// multilingual engine's full catalogue).
   ///
   /// #1678: the fast engine claims 25 European languages, so the sheet must not
   /// offer the rest. A code outside the engine's set is a SILENT failure — it
@@ -105,7 +105,7 @@ struct LanguageLockSheet: View {
   /// strands the people who trusted it.
   ///
   /// Placed FIRST rather than in the list: it is not a language, and sorting it
-  /// among them would hide the escape route in a scroll of 99 rows. Hidden while
+  /// among them would hide the escape route in a long scroll. Hidden while
   /// searching for the same reason recents are — typing means looking for a
   /// specific language.
   @ViewBuilder

--- a/Sources/EnviousWisprAppKit/Views/Settings/SpeechEngineSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SpeechEngineSettingsView.swift
@@ -74,7 +74,7 @@ struct SpeechEngineSettingsView: View {
         tagline: "Pick this for other languages or the toughest audio.",
         specs: [
           ("Model", "Whisper Large v3 Turbo"),
-          ("Languages", "99 languages"),
+          ("Languages", "99+ languages"),
           ("Runs on", "Apple GPU"),
           ("Transcribe time", "Usually 1-2s after you speak"),
         ],
@@ -446,7 +446,7 @@ struct SpeechEngineSettingsView: View {
     switch settings.selectedBackend {
     case .whisperKit:
       return
-        "Auto-detect your language, or lock to a specific one. WhisperKit supports 99 languages."
+        "Auto-detect your language, or lock to a specific one. WhisperKit supports 99+ languages."
     case .parakeet:
       return """
         Auto-detect your language, or lock to one of 25 European languages. \

--- a/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
@@ -1092,7 +1092,7 @@ enum WhatsNewContent {
     Entry(
       id: "multilingual-auto-detect",
       icon: "globe",
-      title: "Dictate in 99 languages",
+      title: "Dictate in 99+ languages",
       description:
         "EnviousWispr now auto-detects the language you are speaking and transcribes accordingly. German, Japanese, Arabic, Tamil, Mandarin and 95 others work out of the box with no setting change needed.",
       version: "1.9.2"

--- a/Sources/EnviousWisprCore/LanguageTypes.swift
+++ b/Sources/EnviousWisprCore/LanguageTypes.swift
@@ -359,8 +359,9 @@ public enum LanguageTypes {
     LanguageScriptGuardrail.isUnsegmentedScript(lang)
   }
 
-  /// Full set of Whisper-supported ISO 639-1 codes (99 languages).
-  /// Used for defensive validation when reading persisted session priors.
+  /// Accepted language codes for the Whisper path: ISO 639-1, plus the ISO
+  /// 639-3 entries `haw` and `yue`. A validation set for persisted session
+  /// priors, not a count of languages the vendor claims to support.
   public static let whisperSupportedLanguages: Set<String> = [
     "af", "am", "ar", "as", "az", "ba", "be", "bg", "bn", "bo", "br",
     "bs", "ca", "cs", "cy", "da", "de", "el", "en", "es", "et", "eu",
@@ -373,7 +374,7 @@ public enum LanguageTypes {
     "tk", "tl", "tr", "tt", "uk", "ur", "uz", "vi", "yi", "yo", "yue", "zh",
   ]
 
-  /// True if `lang` is in the 99-language Whisper set. Used to defensively skip
+  /// True if `lang` is an accepted Whisper code. Used to defensively skip
   /// stale/unrecognized session priors rather than crashing.
   public static func isSupported(_ lang: String) -> Bool {
     whisperSupportedLanguages.contains(lang.lowercased())

--- a/website/package.json
+++ b/website/package.json
@@ -10,7 +10,7 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "prebuild": "node scripts/check-help-content.mjs",
+    "prebuild": "node scripts/check-help-content.mjs && node scripts/check-language-count.mjs",
     "check:help": "node scripts/check-help-routes.mjs && node scripts/check-help-search.mjs"
   },
   "overrides": {

--- a/website/scripts/check-language-count.mjs
+++ b/website/scripts/check-language-count.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+// The published language count for EnviousWispr's WhisperKit path, enforced.
+// Runs from `npm run build` via prebuild (beside check-help-content.mjs), so
+// it executes in CI on every deploy — the website-check job in pr-check.yml.
+//
+// WHY 99+ (mirror the vendor — not "99+ forever"):
+// We ship openai_whisper-large-v3-v20240930_turbo through WhisperKit
+// (argmaxinc/argmax-oss-swift, see Package.swift). Argmax publishes 99 to 101
+// languages for large-v3 / large-v3-turbo, and the founder's 2026-08-24
+// direction settled this repo on "99+ for wisprkit". 99+ is true against
+// WhisperKit's 99-101, true against our own accepted-code set, and overstates
+// nothing. If a future reader finds Argmax publishing a DIFFERENT figure for
+// the weights we ship, that number wins: change COUNT below and every site in
+// SITES in the same commit. The OpenAI hosted-API figure (98) is NOT our
+// vendor — we do not ship that API (#2368).
+//
+// Two things are checked. Never a whole-site regex over "<number> languages":
+// such a pattern cannot tell our claim from a competitor's, which is the exact
+// defect #2368 nearly shipped (seventeen sourced competitor "100+" claims).
+//   1. Every claim site below — enumerated explicitly — carries COUNT.
+//   2. The doc block directly above the two declarations where the count used
+//      to live carries no count at all: the set's size is a validation-set
+//      size, not a marketed number, and welding the two is how four numbers
+//      were born.
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Resolved from THIS file's location, not the cwd, so the guard inspects the
+// tree it lives in — including a scratch copy of the repo.
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+const COUNT = '99+';
+
+// [file, phrase] — phrase is a single-line substring of the claim and carries
+// COUNT exactly once. Pairs where the same sentence ships twice in one file
+// (FAQ JSON + rendered FAQ) are listed once per copy, with the wrapper that
+// distinguishes the two.
+const SITES = [
+  ['README.md', 'WhisperKit (99+ languages, with automatic language detection)'],
+  ['README.md', 'Broadest language coverage and automatic language detection | 99+ languages | ~1.6 GB'],
+  ['Sources/EnviousWisprAppKit/Views/Settings/SpeechEngineSettingsView.swift', '("Languages", "99+ languages")'],
+  ['Sources/EnviousWisprAppKit/Views/Settings/SpeechEngineSettingsView.swift', 'WhisperKit supports 99+ languages.'],
+  ['Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift', 'title: "Dictate in 99+ languages"'],
+  ['website/src/content/blog/live-transcription-that-keeps-up-with-you.md', 'the one that covers 99+ languages and the toughest audio'],
+  ['website/src/content/blog/on-device-dictation-polishing-small-models.md', 'with WhisperKit available for 99+ languages.'],
+  ['website/src/content/blog/getting-started-enviouswispr-under-2-minutes.md', 'A secondary engine is available for 99+ languages.'],
+  ['website/src/content/blog/welcome-to-enviouswispr.md', 'A secondary engine covers 99+ languages.'],
+  ['website/src/content/help/choosing-a-speech-engine-parakeet-vs-whisperkit.md', '| Languages | 25 European | 99+ |'],
+  ['website/src/content/help/multi-language-dictation.md', 'switch to the WhisperKit engine, which supports 99+ languages.'],
+  ['website/src/pages/compare/apple-dictation.astro', '25 European (Parakeet), 99+ languages via WhisperKit'],
+  ['website/src/pages/compare/best-dictation-apps-for-mac.astro', 'ew: "25 European (Parakeet) + 99+ (WhisperKit)"'],
+  ['website/src/pages/compare/best-dictation-apps-for-mac.astro', 'you can switch to WhisperKit for 99+ languages.'],
+  ['website/src/pages/compare/fluidvoice.astro', '"text": "EnviousWispr runs NVIDIA Parakeet TDT v3 for 25 European languages and WhisperKit for 99+ languages, switched manually under Settings, Transcription.'],
+  ['website/src/pages/compare/fluidvoice.astro', '<td>25 European (Parakeet), 99+ via WhisperKit</td>'],
+  ['website/src/pages/compare/fluidvoice.astro', '<p class="faq-a">EnviousWispr runs NVIDIA Parakeet TDT v3 for 25 European languages and WhisperKit for 99+ languages, switched manually under Settings, Transcription.'],
+  ['website/src/pages/compare/google-docs-voice-typing.astro', '<td>25 European (Parakeet), 99+ languages via WhisperKit</td>'],
+  ['website/src/pages/compare/google-docs-voice-typing.astro', 'WhisperKit supports 99+ but with varying accuracy'],
+  ['website/src/pages/compare/handy.astro', '<td>25 European (Parakeet), 99+ via WhisperKit</td>'],
+  ['website/src/pages/compare/index.astro', '25 European (Parakeet) + 99+ via WhisperKit'],
+  ['website/src/pages/compare/notta.astro', '<td>25 European (Parakeet), 99+ languages via WhisperKit</td>'],
+  ['website/src/pages/compare/superwhisper.astro', '"text": "Yes. EnviousWispr offers on-device transcription on Apple Silicon Macs, completely free, with no account or subscription required. It uses Parakeet TDT for 25 European languages and WhisperKit for 99+."'],
+  ['website/src/pages/compare/superwhisper.astro', 'language count (99+ via WhisperKit) re-measured 2026-08-21'],
+  ['website/src/pages/compare/superwhisper.astro', '<td>25 European (Parakeet), 99+ languages via WhisperKit</td>'],
+  ['website/src/pages/compare/superwhisper.astro', '<p class="faq-a">Yes. EnviousWispr offers on-device transcription on Apple Silicon Macs, completely free, with no account or subscription required. It uses Parakeet TDT for 25 European languages and WhisperKit for 99+.</p>'],
+  ['website/src/pages/compare/typewhisper.astro', '"text": "EnviousWispr runs NVIDIA Parakeet TDT v3 for 25 European languages and WhisperKit for 99+ languages, switched manually in Settings.'],
+  ['website/src/pages/compare/typewhisper.astro', '<p class="faq-a">EnviousWispr runs NVIDIA Parakeet TDT v3 for 25 European languages and WhisperKit for 99+ languages, switched manually in Settings.'],
+  ['website/src/pages/compare/voiceink.astro', '"text": "Yes. Parakeet TDT covers 25 European languages. For wider coverage, EnviousWispr switches to WhisperKit, which supports 99+ languages. VoiceInk supports 100+ languages through whisper.cpp."'],
+  ['website/src/pages/compare/voiceink.astro', 'EnviousWispr supports 99+ languages via WhisperKit. For English specifically'],
+  ['website/src/pages/compare/voiceink.astro', '<td>25 European (Parakeet), 99+ languages via WhisperKit</td>'],
+  ['website/src/pages/compare/voiceink.astro', 'WhisperKit handles 99+ languages when you need wider coverage'],
+  ['website/src/pages/compare/voiceink.astro', 'EnviousWispr supports 99+ via WhisperKit, and Parakeet TDT (the fast engine)'],
+  ['website/src/pages/compare/voiceink.astro', '<p class="faq-a">Yes. Parakeet TDT covers 25 European languages. For wider coverage, EnviousWispr switches to WhisperKit, which supports 99+ languages. VoiceInk supports 100+ languages through whisper.cpp.</p>'],
+  ['website/src/pages/compare/voiceink.astro', 'EnviousWispr supports 99+ via WhisperKit, and its fastest engine (Parakeet TDT)'],
+  ['website/src/pages/compare/whisper-cpp.astro', '<td>25 European (Parakeet), 99+ via WhisperKit</td>'],
+  ['website/src/pages/compare/whisper-cpp.astro', 'with 99+ languages via WhisperKit as a secondary option'],
+  ['website/src/pages/compare/willow-voice.astro', 'language count (99+ via WhisperKit) re-measured 2026-08-21'],
+  ['website/src/pages/compare/willow-voice.astro', '<td>25 European (Parakeet), 99+ languages via WhisperKit</td>'],
+  ['website/src/pages/compare/willow-voice.astro', 'WhisperKit covers 99+ but with higher latency on less common ones'],
+  ['website/src/pages/compare/wisprflow.astro', '<td>25 European (Parakeet), 99+ languages via WhisperKit</td>'],
+  ['website/src/pages/speech-to-text-mac.astro', 'Runs on the GPU. Slower than Parakeet, covers 99+ languages, and this is the one'],
+];
+
+// A language count in prose: a 1-3 digit number (optionally +) within two
+// words of "language/languages". Catches "(99 languages)", "All 99
+// Whisper-supported languages", "99-language set"; does not catch ISO designators
+// like "639-1" (a digit cannot continue the match past "-1").
+const COUNT_IN_PROSE = /\b\d{1,3}\+?[\s-]*([A-Za-z-]+\s+){0,2}languages?\b/i;
+
+// The two declarations where the count used to live. The doc block directly
+// above each must carry no count. Deliberately NARROW: the other seven
+// cleaned comments from #2368 (LanguageCatalog's enum and sortedByEnglishName
+// docs, LanguageLockOptions, LanguageLockSheet x2, LanguageDetector) are fixed
+// but NOT guarded — scanning every comment in those files produced three false
+// positives on correct prose (a "last 10 accepted languages" recents ring
+// buffer, a "10 minutes" timeout, Parakeet's correct "25 European languages").
+// A guard that cries wolf on correct code trains people to skip it. If one of
+// the seven regrows a count, the residue grep from the #2368 PR body is the
+// manual net.
+const ANCHORS = [
+  {
+    file: 'Sources/EnviousWisprCore/LanguageTypes.swift',
+    label: 'whisperSupportedLanguages',
+    declRe: /public static let whisperSupportedLanguages\b/,
+  },
+  {
+    file: 'Sources/EnviousWisprAppKit/Views/Settings/LanguageCatalog.swift',
+    label: 'all:',
+    declRe: /static let all: \[Entry\]/,
+  },
+];
+
+const failures = [];
+const esc = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const read = (rel) => {
+  const p = path.join(ROOT, rel);
+  return fs.existsSync(p) ? fs.readFileSync(p, 'utf8') : null;
+};
+
+let readableSites = 0;
+for (const [rel, phrase] of SITES) {
+  const text = read(rel);
+  if (text === null) {
+    failures.push(`${rel}: file not found — claim site cannot be verified`);
+    continue;
+  }
+  readableSites++;
+  if (text.includes(phrase)) continue;
+  // What does the site carry instead? Same phrase, any number in COUNT's place.
+  const variant = esc(phrase).split(esc(COUNT)).join('([0-9]+\\+?)');
+  const m = text.match(new RegExp(variant, 'm'));
+  if (m) {
+    const lineNo = text.slice(0, m.index).split('\n').length;
+    failures.push(`${rel}:${lineNo}: expected "${COUNT}" — site carries "${m[1]}" instead`);
+  } else {
+    failures.push(`${rel}: claim site no longer reads "${phrase.slice(0, 70)}…" — restore the claim or update this list`);
+  }
+}
+// Fail closed: a check that cannot see a single subject is not a pass.
+if (readableSites === 0) {
+  failures.push(`no claim-site files could be read under ${ROOT} — the guard cannot see its subject, refusing to pass`);
+}
+
+for (const { file, label, declRe } of ANCHORS) {
+  const text = read(file);
+  if (text === null) {
+    failures.push(`${file}: file not found — anchor "${label}" cannot be verified`);
+    continue;
+  }
+  const lines = text.split('\n');
+  const idx = lines.findIndex((l) => declRe.test(l));
+  if (idx === -1) {
+    failures.push(`${file}: anchor declaration "${label}" not found — the guard cannot verify the doc block above it`);
+    continue;
+  }
+  const block = [];
+  for (let i = idx - 1; i >= 0 && /^\s*\/\/\//.test(lines[i]); i--) block.unshift(lines[i]);
+  if (block.length === 0) {
+    failures.push(`${file}:${idx + 1}: no doc comment directly above "${label}" — restore the explanation; this guard verifies it carries no count`);
+    continue;
+  }
+  const m = block.join('\n').match(COUNT_IN_PROSE);
+  if (m) {
+    failures.push(`${file}:${idx + 1 - block.length}..${idx}: doc block above "${label}" carries a language count ("${m[0]}") — the set's size is not a marketed figure (#2368); describe what it is, with no number`);
+  }
+}
+
+for (const f of failures) console.error(`FAIL: ${f}`);
+console.log(
+  `language count: ${SITES.length} claim sites carry "${COUNT}" (vendor: Argmax/WhisperKit), ${failures.length} failure(s)`
+);
+process.exit(failures.length ? 1 : 0);

--- a/website/src/content/blog/getting-started-enviouswispr-under-2-minutes.md
+++ b/website/src/content/blog/getting-started-enviouswispr-under-2-minutes.md
@@ -83,7 +83,7 @@ EnviousWispr works well with zero configuration, but if you want to tune it to y
 
 ### Speech engine
 
-EnviousWispr downloads its speech recognition model automatically on first launch. The primary engine handles English with streaming transcription that overlaps with recording. A secondary engine is available for 100+ languages. The download takes a minute or two, and the model is cached locally from then on.
+EnviousWispr downloads its speech recognition model automatically on first launch. The primary engine handles English with streaming transcription that overlaps with recording. A secondary engine is available for 99+ languages. The download takes a minute or two, and the model is cached locally from then on.
 
 ### AI polish
 

--- a/website/src/content/blog/live-transcription-that-keeps-up-with-you.md
+++ b/website/src/content/blog/live-transcription-that-keeps-up-with-you.md
@@ -17,7 +17,7 @@ faqs:
   - question: "Why does live transcription turn off when Auto-detect language is on?"
     answer: "Live transcription has to commit to one language within the first second or two of your recording, which is not enough audio to detect a language reliably. With Auto-detect on, EnviousWispr waits until you stop and decides the language from more of your opening audio instead, which is far more accurate. Pick a specific language in Settings to stream live."
   - question: "Does live transcription work with the Fast engine too?"
-    answer: "Yes. The Fast engine has transcribed live for a while. What is new is that the All Languages engine, the one that covers 99 languages and the toughest audio, now does it too."
+    answer: "Yes. The Fast engine has transcribed live for a while. What is new is that the All Languages engine, the one that covers 99+ languages and the toughest audio, now does it too."
   - question: "Is live transcription less accurate?"
     answer: "For most dictation it produces the same text. A word is only committed once two consecutive passes over the audio agree on it. On very long recordings, transcribing everything at the end can still read slightly cleaner, which is why the toggle is there."
 ---

--- a/website/src/content/blog/on-device-dictation-polishing-small-models.md
+++ b/website/src/content/blog/on-device-dictation-polishing-small-models.md
@@ -27,7 +27,7 @@ Critically, the 91.0 percent result was not a first attempt. It is the product o
 
 ## 2. System under study
 
-The system under study is EnviousWispr, an application providing free, fully on-device dictation for macOS on Apple Silicon. When the user holds a keybind and speaks, cleaned text is inserted at the cursor in under a second. Speech-to-text processing occurs entirely on-device using Parakeet as the default fast engine for 25 languages, with WhisperKit available for 99 languages. An active-by-default polish stage rewrites raw transcription into finished text using Apple's on-device foundation model. This polish stage can be switched to cloud providers like OpenAI and Gemini or local Ollama models. The system is open source on GitHub under GPLv3, and nothing leaves the device by default.
+The system under study is EnviousWispr, an application providing free, fully on-device dictation for macOS on Apple Silicon. When the user holds a keybind and speaks, cleaned text is inserted at the cursor in under a second. Speech-to-text processing occurs entirely on-device using Parakeet as the default fast engine for 25 languages, with WhisperKit available for 99+ languages. An active-by-default polish stage rewrites raw transcription into finished text using Apple's on-device foundation model. This polish stage can be switched to cloud providers like OpenAI and Gemini or local Ollama models. The system is open source on GitHub under GPLv3, and nothing leaves the device by default.
 
 ## 3. Task and evaluation
 

--- a/website/src/content/blog/welcome-to-enviouswispr.md
+++ b/website/src/content/blog/welcome-to-enviouswispr.md
@@ -61,7 +61,7 @@ For a full breakdown, read [how on-device dictation compares to cloud services](
 The pipeline has four steps, and they run in parallel on Apple Silicon, which is what makes the end-to-end time roughly two seconds:
 
 1. **Record.** Hold the global keybind (configurable), speak, release. EnviousWispr captures audio from your microphone with a pre-roll buffer so your first words are never clipped.
-2. **Transcribe.** On-device speech recognition runs natively via Core ML on Apple Silicon. The primary engine handles English with streaming transcription that overlaps with recording. A secondary engine covers 100+ languages.
+2. **Transcribe.** On-device speech recognition runs natively via Core ML on Apple Silicon. The primary engine handles English with streaming transcription that overlaps with recording. A secondary engine covers 99+ languages.
 3. **Polish.** Your choice of AI provider (OpenAI, Gemini, Ollama, Apple Intelligence, or none) removes filler words, fixes punctuation, and shapes the output to match how you speak.
 4. **Paste.** The polished text pastes directly into whatever app has keyboard focus. Your previous clipboard contents are preserved and restored automatically.
 

--- a/website/src/content/help/choosing-a-speech-engine-parakeet-vs-whisperkit.md
+++ b/website/src/content/help/choosing-a-speech-engine-parakeet-vs-whisperkit.md
@@ -14,7 +14,7 @@ You can choose between two speech engines for transcription, Parakeet or Whisper
 
 | Feature | Parakeet | WhisperKit |
 | --- | --- | --- |
-| Languages | 25 European | 99 |
+| Languages | 25 European | 99+ |
 | Speed | Faster | Slower |
 | Setup | Downloaded for you during setup | You download it, about 1.5 GB |
 | Best for | Everyday dictation | Languages Parakeet does not cover |

--- a/website/src/content/help/multi-language-dictation.md
+++ b/website/src/content/help/multi-language-dictation.md
@@ -12,7 +12,7 @@ EnviousWispr handles dozens of languages without asking you to change a setting 
 
 ### Switching to WhisperKit for more languages
 
-If your spoken language is not among the 25 Parakeet covers, switch to the WhisperKit engine, which supports 99 languages.
+If your spoken language is not among the 25 Parakeet covers, switch to the WhisperKit engine, which supports 99+ languages.
 
 **Open settings.** Click the EnviousWispr icon in your menu bar, choose **Settings**, and go to **Transcription**.
 

--- a/website/src/pages/compare/apple-dictation.astro
+++ b/website/src/pages/compare/apple-dictation.astro
@@ -479,7 +479,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Language support</td>
-            <td>25 European (Parakeet), 99 languages via WhisperKit</td>
+            <td>25 European (Parakeet), 99+ languages via WhisperKit</td>
             <td>Dozens of locales</td>
           </tr>
           <tr>

--- a/website/src/pages/compare/best-dictation-apps-for-mac.astro
+++ b/website/src/pages/compare/best-dictation-apps-for-mac.astro
@@ -68,7 +68,7 @@ const tableRows = [
   },
   {
     feature: "Languages",
-    ew: "25 European (Parakeet) + 99 (WhisperKit)",
+    ew: "25 European (Parakeet) + 99+ (WhisperKit)",
     cells: ["Broad via Whisper; auto-detect on Parakeet V3", "Up to 99 via Whisper, 40 via Nemotron, 25 via Parakeet", "100+", "100+", "100+", "~100", "~60", "25 languages via Parakeet TDT v3; additional multilingual Whisper options"],
   },
   {
@@ -222,7 +222,7 @@ const tableCols = ["Handy", "FluidVoice", "WisprFlow", "SuperWhisper", "MacWhisp
     <div class="pick reveal" id="best-free-private-mac-dictation">
       <div class="pick-label">Best for free, private, on-device dictation</div>
       <h2>EnviousWispr</h2>
-      <p>If you want to dictate into any Mac app without paying, signing in, or sending your voice to the cloud, EnviousWispr is the pick. Hold a keybind, speak, and transcription lands in well under a second; polished text follows shortly after, with the wait scaling to how much you said. Transcription runs entirely on your Mac's Apple Silicon, so your audio never leaves the device, and it works offline on a plane or in a basement. Cleanup runs on-device with EG-1, our own model, or Apple Intelligence (macOS 26+), so even the polish step can stay local; you can bring your own OpenAI, Gemini, or Claude key if you prefer a cloud model. Twenty-five European languages run on the fast Parakeet engine by default, and you can switch to WhisperKit for 99 languages. The honest catch: it is macOS 14 and later on Apple Silicon only, with no Windows, Intel, or mobile version, and it is younger than the paid options.</p>
+      <p>If you want to dictate into any Mac app without paying, signing in, or sending your voice to the cloud, EnviousWispr is the pick. Hold a keybind, speak, and transcription lands in well under a second; polished text follows shortly after, with the wait scaling to how much you said. Transcription runs entirely on your Mac's Apple Silicon, so your audio never leaves the device, and it works offline on a plane or in a basement. Cleanup runs on-device with EG-1, our own model, or Apple Intelligence (macOS 26+), so even the polish step can stay local; you can bring your own OpenAI, Gemini, or Claude key if you prefer a cloud model. Twenty-five European languages run on the fast Parakeet engine by default, and you can switch to WhisperKit for 99+ languages. The honest catch: it is macOS 14 and later on Apple Silicon only, with no Windows, Intel, or mobile version, and it is younger than the paid options.</p>
       <div class="pick-links">
         <a href="https://www.youtube.com/watch?v=srS5OgTj3O4" target="_blank" rel="noopener">Watch the 30-second demo</a>
         <a href="/compare/wisprflow/">Full EnviousWispr vs WisprFlow comparison</a>

--- a/website/src/pages/compare/fluidvoice.astro
+++ b/website/src/pages/compare/fluidvoice.astro
@@ -120,7 +120,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Which speech engines does each app use?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "EnviousWispr runs NVIDIA Parakeet TDT v3 for 25 European languages and WhisperKit for 99 languages, switched manually under Settings, Transcription. FluidVoice 1.6.9 showed 14 choices: two Apple speech options, one Cohere model, three Parakeet models, two Nemotron models, and six Whisper sizes."
+        "text": "EnviousWispr runs NVIDIA Parakeet TDT v3 for 25 European languages and WhisperKit for 99+ languages, switched manually under Settings, Transcription. FluidVoice 1.6.9 showed 14 choices: two Apple speech options, one Cohere model, three Parakeet models, two Nemotron models, and six Whisper sizes."
       }
     },
     {
@@ -467,7 +467,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Multi-language</td>
-            <td>25 European (Parakeet), 99 via WhisperKit</td>
+            <td>25 European (Parakeet), 99+ via WhisperKit</td>
             <td>Up to 99 via Whisper; 40 via Nemotron, 25 via Parakeet, 14 via Cohere, depending on engine chosen</td>
           </tr>
           <tr>
@@ -729,7 +729,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Which speech engines does each app use?</div>
-        <p class="faq-a">EnviousWispr runs NVIDIA Parakeet TDT v3 for 25 European languages and WhisperKit for 99 languages, switched manually under Settings, Transcription. FluidVoice 1.6.9 showed 14 choices: two Apple speech options, one Cohere model, three Parakeet models, two Nemotron models, and six Whisper sizes.</p>
+        <p class="faq-a">EnviousWispr runs NVIDIA Parakeet TDT v3 for 25 European languages and WhisperKit for 99+ languages, switched manually under Settings, Transcription. FluidVoice 1.6.9 showed 14 choices: two Apple speech options, one Cohere model, three Parakeet models, two Nemotron models, and six Whisper sizes.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Does FluidVoice run on Windows or iOS?</div>

--- a/website/src/pages/compare/google-docs-voice-typing.astro
+++ b/website/src/pages/compare/google-docs-voice-typing.astro
@@ -385,7 +385,7 @@ const breadcrumbJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Languages</td>
-            <td>25 European (Parakeet), 99 languages via WhisperKit</td>
+            <td>25 European (Parakeet), 99+ languages via WhisperKit</td>
             <td>100+ languages and regional variants</td>
           </tr>
           <tr>
@@ -629,7 +629,7 @@ const breadcrumbJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">🌐</div>
         <div class="advantage-title">100+ languages out of the box</div>
-        <p class="advantage-desc">Google supports over 100 languages and regional variants for voice typing with no extra configuration. EnviousWispr's primary engine (Parakeet) covers 25 European languages; WhisperKit supports 99 but with varying accuracy.</p>
+        <p class="advantage-desc">Google supports over 100 languages and regional variants for voice typing with no extra configuration. EnviousWispr's primary engine (Parakeet) covers 25 European languages; WhisperKit supports 99+ but with varying accuracy.</p>
       </div>
     </div>
     <p style="font-size: 15px; color: var(--text-2); text-align: center; margin-top: 24px;">If your workflow lives entirely inside Google Docs, their voice typing is a solid choice. If you need dictation across your whole Mac, in any app, with AI polish and privacy, <a href="/#download" style="color: var(--accent); text-decoration: underline;">give EnviousWispr a try</a>.</p>

--- a/website/src/pages/compare/handy.astro
+++ b/website/src/pages/compare/handy.astro
@@ -507,7 +507,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Multi-language</td>
-            <td>25 European (Parakeet), 99 via WhisperKit</td>
+            <td>25 European (Parakeet), 99+ via WhisperKit</td>
             <td>Broad via Whisper; automatic detection on Parakeet V3</td>
           </tr>
           <tr>

--- a/website/src/pages/compare/index.astro
+++ b/website/src/pages/compare/index.astro
@@ -286,7 +286,7 @@ const itemListJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Languages</td>
-            <td class="col-ew">25 European (Parakeet) + 99 via WhisperKit</td>
+            <td class="col-ew">25 European (Parakeet) + 99+ via WhisperKit</td>
             <td>100+ languages</td>
             <td>100+ via Whisper</td>
             <td>100+ via Whisper</td>

--- a/website/src/pages/compare/notta.astro
+++ b/website/src/pages/compare/notta.astro
@@ -468,7 +468,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Languages</td>
-            <td>25 European (Parakeet), 99 languages via WhisperKit</td>
+            <td>25 European (Parakeet), 99+ languages via WhisperKit</td>
             <td>58 languages, transcript translation</td>
           </tr>
           <tr>

--- a/website/src/pages/compare/superwhisper.astro
+++ b/website/src/pages/compare/superwhisper.astro
@@ -64,7 +64,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Is there a free alternative to Superwhisper?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes. EnviousWispr offers on-device transcription on Apple Silicon Macs, completely free, with no account or subscription required. It uses Parakeet TDT for 25 European languages and WhisperKit for 99."
+        "text": "Yes. EnviousWispr offers on-device transcription on Apple Silicon Macs, completely free, with no account or subscription required. It uses Parakeet TDT for 25 European languages and WhisperKit for 99+."
       }
     },
     {
@@ -395,7 +395,7 @@ const faqJsonLd = JSON.stringify({
              Confidence: source-verified from the public website, the installed app opened directly, and an
              independent public source for S1-mini. Features marked "Not specified" were not found on
              superwhisper.com or in the app as of 2026-08-21.
-             EnviousWispr latency (0.61s / 1.65s) and language count (99 via WhisperKit) re-measured 2026-08-21.
+             EnviousWispr latency (0.61s / 1.65s) and language count (99+ via WhisperKit) re-measured 2026-08-21.
              Last verified: 2026-08-21. -->
         <tbody>
           <tr>
@@ -500,7 +500,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Multi-language</td>
-            <td>25 European (Parakeet), 99 languages via WhisperKit</td>
+            <td>25 European (Parakeet), 99+ languages via WhisperKit</td>
             <td>100+ languages with translation to English</td>
           </tr>
           <tr>
@@ -761,7 +761,7 @@ const faqJsonLd = JSON.stringify({
     <div class="faq-list">
       <div class="faq-item reveal">
         <div class="faq-q">Is there a free alternative to Superwhisper?</div>
-        <p class="faq-a">Yes. EnviousWispr offers on-device transcription on Apple Silicon Macs, completely free, with no account or subscription required. It uses Parakeet TDT for 25 European languages and WhisperKit for 99.</p>
+        <p class="faq-a">Yes. EnviousWispr offers on-device transcription on Apple Silicon Macs, completely free, with no account or subscription required. It uses Parakeet TDT for 25 European languages and WhisperKit for 99+.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">How is EnviousWispr different from Superwhisper?</div>

--- a/website/src/pages/compare/typewhisper.astro
+++ b/website/src/pages/compare/typewhisper.astro
@@ -120,7 +120,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Which speech engines does each app use?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "EnviousWispr runs NVIDIA Parakeet TDT v3 for 25 European languages and WhisperKit for 99 languages, switched manually in Settings. TypeWhisper offers a much wider menu: WhisperKit, Parakeet TDT, Voxtral, Qwen3 ASR, IBM Granite Speech, and Apple Speech on Mac, plus ONNX-based engines on Windows, with cloud engines available through add-ons."
+        "text": "EnviousWispr runs NVIDIA Parakeet TDT v3 for 25 European languages and WhisperKit for 99+ languages, switched manually in Settings. TypeWhisper offers a much wider menu: WhisperKit, Parakeet TDT, Voxtral, Qwen3 ASR, IBM Granite Speech, and Apple Speech on Mac, plus ONNX-based engines on Windows, with cloud engines available through add-ons."
       }
     },
     {
@@ -719,7 +719,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Which speech engines does each app use?</div>
-        <p class="faq-a">EnviousWispr runs NVIDIA Parakeet TDT v3 for 25 European languages and WhisperKit for 99 languages, switched manually in Settings. TypeWhisper offers a much wider menu: WhisperKit, Parakeet TDT, Voxtral, Qwen3 ASR, IBM Granite Speech, and Apple Speech on Mac, plus ONNX-based engines on Windows, with cloud engines available through add-ons.</p>
+        <p class="faq-a">EnviousWispr runs NVIDIA Parakeet TDT v3 for 25 European languages and WhisperKit for 99+ languages, switched manually in Settings. TypeWhisper offers a much wider menu: WhisperKit, Parakeet TDT, Voxtral, Qwen3 ASR, IBM Granite Speech, and Apple Speech on Mac, plus ONNX-based engines on Windows, with cloud engines available through add-ons.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Can I switch from TypeWhisper to EnviousWispr easily?</div>

--- a/website/src/pages/compare/voiceink.astro
+++ b/website/src/pages/compare/voiceink.astro
@@ -79,7 +79,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Does EnviousWispr support languages other than English?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes. Parakeet TDT covers 25 European languages. For wider coverage, EnviousWispr switches to WhisperKit, which supports 99 languages. VoiceInk supports 100+ languages through whisper.cpp."
+        "text": "Yes. Parakeet TDT covers 25 European languages. For wider coverage, EnviousWispr switches to WhisperKit, which supports 99+ languages. VoiceInk supports 100+ languages through whisper.cpp."
       }
     },
     {
@@ -103,7 +103,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Which app is better for non-English languages?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "VoiceInk supports 100+ languages through whisper.cpp and may have an edge in multilingual breadth. EnviousWispr supports 99 languages via WhisperKit. For English specifically, EnviousWispr is faster thanks to Parakeet TDT."
+        "text": "VoiceInk supports 100+ languages through whisper.cpp and may have an edge in multilingual breadth. EnviousWispr supports 99+ languages via WhisperKit. For English specifically, EnviousWispr is faster thanks to Parakeet TDT."
       }
     },
     {
@@ -536,7 +536,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Multi-language</td>
-            <td>25 European (Parakeet), 99 languages via WhisperKit</td>
+            <td>25 European (Parakeet), 99+ languages via WhisperKit</td>
             <td>100+ languages</td>
           </tr>
           <tr>
@@ -599,7 +599,7 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">&#9889;</div>
         <div class="advantage-title">Faster English transcription</div>
-        <p class="advantage-desc">Parakeet TDT covers 25 European languages and runs on Apple's Neural Engine. 0.61s median latency. WhisperKit handles 99 languages when you need wider coverage.</p>
+        <p class="advantage-desc">Parakeet TDT covers 25 European languages and runs on Apple's Neural Engine. 0.61s median latency. WhisperKit handles 99+ languages when you need wider coverage.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">&#129504;</div>
@@ -780,7 +780,7 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">&#127758;</div>
         <div class="advantage-title">Broader multilingual support</div>
-        <p class="advantage-desc">VoiceInk supports 100+ languages through whisper.cpp and has been tuned for multilingual workflows. EnviousWispr supports 99 via WhisperKit, and Parakeet TDT (the fast engine) covers 25 European languages. If you dictate heavily in non-European languages, VoiceInk may be more polished for that use case.</p>
+        <p class="advantage-desc">VoiceInk supports 100+ languages through whisper.cpp and has been tuned for multilingual workflows. EnviousWispr supports 99+ via WhisperKit, and Parakeet TDT (the fast engine) covers 25 European languages. If you dictate heavily in non-European languages, VoiceInk may be more polished for that use case.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">&#9201;</div>
@@ -810,7 +810,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Does EnviousWispr support languages other than English?</div>
-        <p class="faq-a">Yes. Parakeet TDT covers 25 European languages. For wider coverage, EnviousWispr switches to WhisperKit, which supports 99 languages. VoiceInk supports 100+ languages through whisper.cpp.</p>
+        <p class="faq-a">Yes. Parakeet TDT covers 25 European languages. For wider coverage, EnviousWispr switches to WhisperKit, which supports 99+ languages. VoiceInk supports 100+ languages through whisper.cpp.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">How does custom vocabulary compare between the two apps?</div>
@@ -822,7 +822,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Which app is better for non-English languages?</div>
-        <p class="faq-a">VoiceInk supports 100+ languages through whisper.cpp and has been optimized for multilingual use. EnviousWispr supports 99 via WhisperKit, and its fastest engine (Parakeet TDT) covers 25 European languages. For languages outside those, VoiceInk may have an edge in breadth and tuning.</p>
+        <p class="faq-a">VoiceInk supports 100+ languages through whisper.cpp and has been optimized for multilingual use. EnviousWispr supports 99+ via WhisperKit, and its fastest engine (Parakeet TDT) covers 25 European languages. For languages outside those, VoiceInk may have an edge in breadth and tuning.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Does VoiceInk have AI text enhancement?</div>

--- a/website/src/pages/compare/whisper-cpp.astro
+++ b/website/src/pages/compare/whisper-cpp.astro
@@ -380,7 +380,7 @@ const breadcrumbJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Multi-language</td>
-            <td>25 European (Parakeet), 99 via WhisperKit</td>
+            <td>25 European (Parakeet), 99+ via WhisperKit</td>
             <td>90+ (OpenAI Whisper models)</td>
           </tr>
           <tr>
@@ -612,7 +612,7 @@ const breadcrumbJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">🌍</div>
         <div class="advantage-title">You need deep multilingual support</div>
-        <p class="advantage-desc">whisper.cpp supports 90+ languages natively with any Whisper model. EnviousWispr's primary engine (Parakeet) covers 25 European languages, with 99 languages via WhisperKit as a secondary option.</p>
+        <p class="advantage-desc">whisper.cpp supports 90+ languages natively with any Whisper model. EnviousWispr's primary engine (Parakeet) covers 25 European languages, with 99+ languages via WhisperKit as a secondary option.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">🌐</div>

--- a/website/src/pages/compare/willow-voice.astro
+++ b/website/src/pages/compare/willow-voice.astro
@@ -311,7 +311,7 @@ const breadcrumbJsonLd = JSON.stringify({
                - Security: willowvoice.com - SOC 2, HIPAA, zero data retention, privacy mode (Business/Enterprise tiers)
                - Backing: YC-backed
              Firsthand testing: Willow Voice was not tested firsthand for this comparison.
-             EnviousWispr latency (0.61s / 1.65s) and language count (99 via WhisperKit) re-measured 2026-08-21.
+             EnviousWispr latency (0.61s / 1.65s) and language count (99+ via WhisperKit) re-measured 2026-08-21.
              "Not specified" is used for any feature not explicitly documented on their site. -->
         <tbody>
           <tr>
@@ -396,7 +396,7 @@ const breadcrumbJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Multi-language</td>
-            <td>25 European (Parakeet), 99 languages via WhisperKit</td>
+            <td>25 European (Parakeet), 99+ languages via WhisperKit</td>
             <td>100+ languages</td>
           </tr>
           <tr>
@@ -613,7 +613,7 @@ const breadcrumbJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">🌍</div>
         <div class="advantage-title">You dictate in many languages daily</div>
-        <p class="advantage-desc">Willow Voice supports 100+ languages through its cloud engine with automatic grammar and formatting. EnviousWispr's fast engine (Parakeet) covers 25 European languages with no language setting to pick, and WhisperKit covers 99 but with higher latency on less common ones.</p>
+        <p class="advantage-desc">Willow Voice supports 100+ languages through its cloud engine with automatic grammar and formatting. EnviousWispr's fast engine (Parakeet) covers 25 European languages with no language setting to pick, and WhisperKit covers 99+ but with higher latency on less common ones.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">🔊</div>

--- a/website/src/pages/compare/wisprflow.astro
+++ b/website/src/pages/compare/wisprflow.astro
@@ -438,7 +438,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Multi-language</td>
-            <td>25 European (Parakeet), 99 languages via WhisperKit</td>
+            <td>25 European (Parakeet), 99+ languages via WhisperKit</td>
             <td>100+ languages with auto-detection</td>
           </tr>
           <tr>

--- a/website/src/pages/speech-to-text-mac.astro
+++ b/website/src/pages/speech-to-text-mac.astro
@@ -144,7 +144,7 @@ const faqJsonLd = JSON.stringify({
         <div class="split-card reveal">
           <h3>WhisperKit</h3>
           <p>
-            Runs on the GPU. Slower than Parakeet, covers 99 languages, and this is the one that detects the language automatically. Switch to it in settings when you need a language Parakeet does not carry, or when you move between languages without wanting to set one.
+            Runs on the GPU. Slower than Parakeet, covers 99+ languages, and this is the one that detects the language automatically. Switch to it in settings when you need a language Parakeet does not carry, or when you move between languages without wanting to set one.
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Decision: publish `99+`, mirroring the vendor we actually ship

We ship `openai_whisper-large-v3-v20240930_turbo` through **WhisperKit** (`argmaxinc/argmax-oss-swift`, see `Package.swift`; `WhisperKitBackend.swift:196`). Argmax is the vendor for our transcription path, and their published range for `large-v3` / `large-v3-turbo` is **99 to 101** languages. Founder direction 2026-08-24: *"I think saying 99+ is my preference for wisprkit."*

`99+` is true against WhisperKit's 99-101, true against our own accepted-code set, and overstates nothing.

**Why 98 was superseded:** the issue's first comment standardised on 98 by quoting OpenAI's *hosted API* documentation. We do not ship that API, so 98 mirrored the wrong vendor. The principle is *mirror the vendor*, not "98 forever" (or "99+ forever"): if a future reader finds Argmax publishing a different figure for the weights we ship, that number wins. The new check says exactly that in its header comment.

**Correction to the issue's premise:** the issue says the site "overstates in 19 places" with `100+ languages`. **Seventeen of the nineteen describe competitors** — Google Docs, superwhisper, VoiceInk, Willow Voice, WisprFlow, Spokenly, whisper.cpp — each carrying its own source URL and access date, on six comparison pages. Changing them would publish false claims about named rivals with the contradicting source sitting beside them. Only two of the nineteen are ours (blog prose). **The seventeen are untouched in this PR** and are asserted untouched by the residue check below.

## Three categories (the shipped spec files: CAT-A.txt, CAT-B.txt, KEEP-LIST.txt)

Baseline verified against `origin/main` (`912a446a`) before editing: **64** bare-`99` hits across the residue scope, **19** occurrences of `100+ languages`, and 64 = 40 + 9 + 15 exactly, nothing unclassified.

- **Category A — 42 lines: our own published claims; `99` becomes `99+` (digits only).** The 40 lines named in CAT-A.txt, plus the only two places we overstate ourselves, `100+` becoming `99+`:
  - `website/src/content/blog/getting-started-enviouswispr-under-2-minutes.md:86` — "available for 100+ languages"
  - `website/src/content/blog/welcome-to-enviouswispr.md:64` — "covers 100+ languages"
- **Category B — 9 comments: the count is REMOVED, not changed.** These describe `whisperSupportedLanguages`, which is a **validation set for persisted session priors** (ISO codes including the 639-3 entries `haw` and `yue`). Its size is not a count of languages any vendor claims to support — treating it as one is how we ended up with four numbers. Each comment now describes what the set is and carries no number (not `99+` either). Files: `LanguageTypes.swift` (2), `LanguageCatalog.swift` (3), `LanguageDetector.swift` (1), `LanguageLockOptions.swift` (1), `LanguageLockSheet.swift` (2).
- **Category C — untouched:** the 15 KEEP-LIST lines (hex colour `5cc99a` x2, `global.css:99` reference, four polish-accuracy percentages, six competitor prices, three genuine competitor language counts) survive byte-identical, plus the seventeen competitor `100+` rows.

No global find-and-replace was run. No competitor row, price, citation, or access date was touched.

## The recurring guard: `website/scripts/check-language-count.mjs`

Wired into `prebuild` beside the existing content check, so it runs inside `npm run build` and therefore inside the required `website-check` CI job on every deploy. **No new/renamed PR job** — `build-check.needs` and its result checks are unchanged.

- **Not derived from `whisperSupportedLanguages`.** Counting the validation set would weld the marketing figure to it and guarantee the drift this issue exists to end. The number is a vendor-sourced constant in the script.
- **Check 1 — every claim site carries the constant.** All 42 sites are enumerated explicitly as (file, phrase) pairs — no whole-site regex over `<number> languages`, which cannot tell our claim from a competitor's (the exact defect this issue nearly shipped). On a mismatch it names the file, the line, and what the site carries instead.
- **Check 2 — the durable half.** The doc block directly above the two declarations where the number used to live must carry no count: `whisperSupportedLanguages` in `LanguageTypes.swift` and `all:` in `LanguageCatalog.swift`. Scope is deliberately two anchors: scanning every comment in the five Category-B files produced three false positives on correct prose (a "last 10 accepted languages" recents ring buffer, a "10 minutes" timeout, Parakeet's correct "25 European languages"). The resulting hole is stated in the script: the other seven cleaned comments are fixed but not guarded.
- **Fail closed.** A missing anchor declaration, a declaration with no doc block, an unreadable claim-site file, or a site list that resolves to nothing all exit nonzero. Disagreements found along the way are printed, not masked.

The script is **tracked**: `git check-ignore -q website/scripts/check-language-count.mjs` exits 1 (not ignored), `git status --short` shows `?? website/scripts/check-language-count.mjs` before staging, and `git add --dry-run` adds it. It is committed in this PR. (The root `scripts/*` ignore does not reach `website/scripts/`, whose existing checks are already tracked.)

## Checks, before vs after (all run on this machine)

| Check | Before | After |
|---|---|---|
| content (`npm run build` prebuild) | `help content: 55 articles, 0 error(s), 6 warning(s)` | `help content: 55 articles, 0 error(s), 6 warning(s)` |
| language count (new) | — (script did not exist) | `language count: 42 claim sites carry "99+" (vendor: Argmax/WhisperKit), 0 failure(s)` |
| routes (`npm run check:help`) | `help routes: expected 68, built 68, in sitemap 68, internal links 9551 (0 dead)` | `help routes: expected 68, built 68, in sitemap 68, internal links 9551 (0 dead)` |
| search (`npm run check:help`) | `help search: 42 passed, 0 failed` | `help search: 42 passed, 0 failed` |

`npm run build` (astro, 132 pages) completes in all runs.

## Residue check (fail-closed proof), real output

```console
$ grep -rnE '(^|[^0-9.])99([^0-9%+]|$)' website/src Sources/EnviousWisprAppKit \
    Sources/EnviousWisprCore/LanguageTypes.swift Sources/EnviousWisprASR/LanguageDetector.swift README.md \
    | cut -d: -f1,2 | sort -u > /tmp/after.txt
$ grep -v '^#' KEEP-LIST.txt | awk '{print $1}' | sort -u > /tmp/keep.txt
$ diff /tmp/keep.txt /tmp/after.txt && echo "RESIDUE CLEAN"
RESIDUE CLEAN
$ grep -rc '100+ languages' website/src README.md | grep -v ':0$' | awk -F: '{s+=$2} END {print "competitor 100+ rows surviving:", s, "(expect 17)"}'
competitor 100+ rows surviving: 17 (expect 17)
```

Every surviving bare `99` is on the keep list and nothing else; all seventeen competitor `100+` rows survive.

## Break-and-restore, three ways (scratch copy, restored after each)

The guard resolves paths from its own location, so the scratch copy's guard inspects the scratch tree. A canary mutation first proved this: mutating the scratch `README.md` while the real tree stayed clean produced `FAIL: README.md:59: expected "99+" — site carries "98" instead` (exit 1), and restoring it passed.

1. **Revert one claim site to `99`** (`superwhisper.astro:503`):
   `FAIL: website/src/pages/compare/superwhisper.astro:503: expected "99+" — site carries "99" instead` — exit 1, naming the site. Restored: pass.
2. **Write a count back into the doc block above `whisperSupportedLanguages`**:
   `FAIL: Sources/EnviousWisprCore/LanguageTypes.swift:362..364: doc block above "whisperSupportedLanguages" carries a language count ("99 languages") — the set's size is not a marketed figure (#2368); describe what it is, with no number` — exit 1, naming it. Restored: pass.
3. **Rename the declaration so the anchor is genuinely absent** (`whisperSupportedLanguages` → `whisperAcceptedLanguageCodes`, a true rename, not an append):
   `FAIL: Sources/EnviousWisprCore/LanguageTypes.swift: anchor declaration "whisperSupportedLanguages" not found — the guard cannot verify the doc block above it` — exit 1 (nonzero, not a pass). Restored: pass.

**No no-op mutant occurred.** The prior run's mutant failed to arrive because it renamed by *appending* to the name, leaving the anchor string present as a substring; arm 3 here is a full rename, and before drawing any conclusion I verified the mutant had actually landed (`grep -cE 'public static let whisperSupportedLanguages\b'` → 0). Each arm went red for the intended reason, and each restore went green.

## Section-5 text-guard search (guards that parse the edited files as text)

Searched `Tests`, `scripts`, `.github` for text-parsing guards over the edited files:

- `website/scripts/check-help-content.mjs` (the prebuild content check) parses `website/src/content/help/*.md` — the two edited help articles are in scope. Green before and after (summary lines above).
- `website/scripts/check-help-routes.mjs` / `check-help-search.mjs` parse `src/data/help-categories.ts` and the built `dist/` — route-set equality and pinned search queries; unaffected by digit/comment edits. Green before and after.
- `scripts/ci/check-download-link-utms.sh` parses `README.md` and `website/src/content/blog/*` as text (download-link attribution rules) and runs in `pr-check.yml` and `deploy-blog.yml`. Ran `--self-test` and the real run after editing: both pass (`download-link lint passed: README doorway tagged; blog prose uses /#download.`). No link was touched.
- `scripts/ci/classify-changes.sh` is path-based only; these changes hit `website/`, `Sources/`, and `README.md`, so `needs_website=true` and the Xcode lanes trigger as expected.
- `.github/workflows/ci-drift-check.yml` scans `.sh` scripts referenced by workflows; the new file is a `.mjs` in `website/scripts/`, not workflow-referenced. Unaffected.
- `XcodeBuildTopologyFreezeTests.swift` and `check-pr-check-fetch-depth.sh` parse workflow files, which are untouched here.
- `TestInventoryFreezeTests` / `scripts/test-inventory-baseline.txt`: no new Swift test suite was added, so no class tag is required and nothing was added to the grandfather list.

Nothing in `Tests`, `scripts`, or `.github` pins the literal `99 languages` text or the line numbers of the edited files, so no textual guard needed updating.

## Scope and validation status

- Changed files: the 24 files carrying the 42 Category-A lines (2 README, 3 Swift UI strings, 19 website content), the 5 files carrying the 9 Category-B comments (3 of them overlapping the list above), `website/package.json` (prebuild wiring), and the new `website/scripts/check-language-count.mjs`. 30 files total in the commit; every file is named above or is one of the spec-named lines.
- The six touched Swift files carry comment/string-literal edits only; no code structure changed. `swift-format` could not be run: **NOT RUN — requires Mac validation** (no Swift toolchain on this machine).
- Swift builds and the app test suite: **NOT RUN — requires Mac validation.** No outcome is claimed for them.
- Website checks (content, language count, routes, search) and `npm run build`: run here, results above.

Closes #2368
