### PR TITLE
feat(onboarding): a practice dictation before setup ends (#2196)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/OnboardingProgress.swift
+++ b/Sources/EnviousWisprAppKit/App/OnboardingProgress.swift
@@ -67,6 +67,14 @@ final class OnboardingProgress {
     terminalEmitted = true
   }
 
+  /// True while this visit is still live — begun, and neither cleanly finished
+  /// nor abandoned. Read by the warm gate before it completes setup (#2196,
+  /// local Codex r3): the gate's warm-up deliberately outlives a window close,
+  /// so a `.ready` landing afterwards would otherwise finish a visit the close
+  /// path has already counted as ABANDONED, emitting both terminals for one
+  /// visit and reopening a window only to close it again.
+  var isInFlight: Bool { sessionStartedAt != nil && !terminalEmitted }
+
   /// The single guarded abandon emit — both the window-close closure and the
   /// app-quit terminate path call this. Emits at most once per session; a clean
   /// finish (`markCompleted`) or a prior abandon suppresses it. Posture is passed

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -1270,6 +1270,13 @@ private struct OnboardingWindowRoot: View {
     .environment(b.navigationCoordinator)
     .environment(b.languageSuggestionPresenter)
     .environment(b.dictationRuntime)
+    // #2196 chunk 3 — the practice screen needs to know a take is in flight.
+    // `LiveRecordingState.isDictationActive` is true while EITHER pipeline is
+    // recording, transcribing or polishing, and it is already @Observable, so
+    // the screen reads an existing signal rather than growing a new one. The
+    // main window has had this injected all along; onboarding never needed it
+    // until it hosted a dictation target.
+    .environment(b.liveRecordingState)
     .environment(b.appWindowCoordinator)
     // The nine view-facing homes (epic #763).
     .environment(b.settings)

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -1270,7 +1270,14 @@ private struct OnboardingWindowRoot: View {
     .environment(b.navigationCoordinator)
     .environment(b.languageSuggestionPresenter)
     .environment(b.dictationRuntime)
-    // #2196 chunk 3 — the practice screen needs to know a take is in flight.
+    // #2196 — the practice screen reads BOTH of these, and a type-based
+    // `@Environment` with no default TRAPS AT RUNTIME rather than failing to
+    // compile. Cloud review caught this as a P1: `liveRecordingState` was added
+    // here when the screen started reading it, and `transcriptCoordinator` was
+    // added to the SCREEN a round later without coming back to this list. The
+    // Live UAT that would have caught it ran before that round.
+    .environment(b.transcriptCoordinator)
+    // The practice screen needs to know a take is in flight.
     // `LiveRecordingState.isDictationActive` is true while EITHER pipeline is
     // recording, transcribing or polishing, and it is already @Observable, so
     // the screen reads an existing signal rather than growing a new one. The

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
@@ -347,7 +347,7 @@ final class OnboardingV2ViewModel {
   /// the exact experience this gate exists to prevent, so the copy must not
   /// promise its absence.
   static let warmingFailureCopy =
-    "You can try again, or skip ahead — your first shortcut press may just wake the engine up, and the one after it will dictate."
+    "You can try again, or skip ahead. Your first shortcut press may just wake the engine up, and the one after it will dictate."
 
   /// Start the gate's warm-up if none is live. Safe to call on every view
   /// re-appear: a live attempt makes a re-kick a no-op.
@@ -381,6 +381,15 @@ final class OnboardingV2ViewModel {
       if displayFloor > elapsed {
         try? await Task.sleep(for: .seconds(displayFloor - elapsed))
         if Task.isCancelled { return }
+      }
+      // The visit may have ended while this ran — the window closes, abandon is
+      // emitted, and this task deliberately survives. Re-arm rather than
+      // report: a completion after abandonment is a double terminal, and a
+      // stale `.ready` would let the next open walk through without asking an
+      // engine that may since have been unloaded.
+      guard isVisitActive?() ?? true else {
+        beginWarmingGate()
+        return
       }
       // Readiness both answers the warm-up and ends the visit, so it takes the
       // EXIT latch: if the person already skipped, this must stay silent and
@@ -749,6 +758,13 @@ final class OnboardingV2ViewModel {
   /// because `stepStartedAt` is always >= the session start on the forward path).
   var sessionStartFloor: (@MainActor () -> Date?)?
 
+  /// Whether the onboarding VISIT is still live, supplied by the view from
+  /// `OnboardingProgress.isInFlight` (local Codex r3 on chunks 3-4). The gate's
+  /// warm-up outlives a window close by design, so without this its `.ready`
+  /// branch reports a step completion for a visit already counted as abandoned
+  /// and leaves a stale answer for the next open to walk through.
+  var isVisitActive: (@MainActor () -> Bool)?
+
   /// `stepStartedAt`, never earlier than the current session start.
   private func clampedStepStart() -> Date {
     if let floor = sessionStartFloor?(), floor > stepStartedAt { return floor }
@@ -918,6 +934,7 @@ struct OnboardingV2View: View {
     // start. Set-once is reliable even if a later reused-window reopen skips this
     // onAppear — the closure captures the stable box reference.
     viewModel.sessionStartFloor = { [onboardingProgress] in onboardingProgress.sessionStart }
+    viewModel.isVisitActive = { [onboardingProgress] in onboardingProgress.isInFlight }
     // #1176: `begin()` (the session reset) fires from `openOnboardingAction` so it
     // is reliable even when a reused window skips a fresh onAppear; here we only
     // mirror the resolved screen/step into the box.

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
@@ -23,7 +23,7 @@ enum AppleIntelligenceSettings {
 @MainActor
 @Observable
 final class OnboardingV2ViewModel {
-  enum Screen { case welcome, settingUp, ready }
+  enum Screen { case welcome, settingUp, ready, warmingUp }
   enum SetupPhase { case checklist, permissions }
 
   enum ChecklistItemStatus: Equatable {
@@ -156,6 +156,12 @@ final class OnboardingV2ViewModel {
     switch currentScreen {
     case .welcome: return .idle
     case .ready: return .heart
+    // #2196: the gate is a working beat, so it wears the same animation the
+    // checklist wears while the model loads. Reads the GATE's own outcome —
+    // `downloadError` belongs to the checklist and is a different subject.
+    case .warmingUp:
+      if case .failed = warmingOutcome { return .drooping }
+      return .equalizer
     case .settingUp:
       if setupPhase == .permissions { return .triumph }
       if downloadError != nil { return .drooping }
@@ -284,6 +290,128 @@ final class OnboardingV2ViewModel {
     setupCancelled = false
     cancelRequested = false
     retryCount += 1
+  }
+
+  // MARK: - Engine warm gate (#2196)
+
+  /// What the gate has LEARNED, never what it has waited through. `waiting`
+  /// holds until the awaited warm-up returns a value; no elapsed time, poll or
+  /// yield count can move it (testing-philosophy.md
+  /// RULE: never-guess-when-the-subject-is-finished).
+  enum WarmingOutcome: Equatable {
+    case waiting
+    case ready
+    case failed(String)
+  }
+
+  var warmingOutcome: WarmingOutcome = .waiting
+
+  /// Bumped by `retryWarming()` so the view's `.task(id:)` re-keys and kicks a
+  /// fresh attempt — the same shape `retryCount` gives the checklist.
+  var warmingRetryCount = 0
+
+  /// Owned HERE rather than in the view's `.task`, for the reason #1388
+  /// established for `setupTask`: window churn cancels a view task, and an
+  /// outcome landing in a cancelled context is dropped in silence.
+  @ObservationIgnored private(set) var warmingTask: Task<Void, Never>?
+
+  /// One-shot per attempt: the gate reports itself exactly once, whichever of
+  /// ready / failed / skipped arrives first. Reset by `retryWarming()`.
+  private var warmingReported = false
+
+  /// Minimum time the gate stays on screen once readiness has landed, so the
+  /// usual already-warm case reads as a beat rather than a flash. A DISPLAY
+  /// floor applied AFTER the real signal, never a substitute for one; tests
+  /// pass 0.
+  static let warmingDisplayFloor: TimeInterval = 0.6
+
+  static let warmingFailureCopy =
+    "You can try again, or skip ahead and it will load the first time you dictate."
+
+  /// Start the gate's warm-up if none is live. Safe to call on every view
+  /// re-appear: a live attempt makes a re-kick a no-op.
+  func kickWarmingIfNeeded(
+    warmUp: @escaping @MainActor () async -> EngineWarmupOutcome,
+    displayFloor: TimeInterval = OnboardingV2ViewModel.warmingDisplayFloor
+  ) {
+    guard warmingTask == nil else { return }
+    guard currentScreen == .warmingUp, warmingOutcome == .waiting else { return }
+    warmingTask = Task { @MainActor in
+      await self.runWarmingGate(warmUp: warmUp, displayFloor: displayFloor)
+      self.warmingTask = nil
+    }
+  }
+
+  /// #2196 — the gate is a second CALLER of the shared warm-up
+  /// (`DictationRuntime.ensureActiveEngineWarmForOnboarding`), not a second
+  /// authority over readiness. That entry is idempotent and single-flighted, so
+  /// asking again when the engine is already warm returns `.ready` at once.
+  func runWarmingGate(
+    warmUp: @MainActor () async -> EngineWarmupOutcome, displayFloor: TimeInterval
+  ) async {
+    stepStartedAt = Date()
+    let startedAt = Date()
+    let outcome = await warmUp()
+    if Task.isCancelled { return }
+
+    switch outcome {
+    case .ready:
+      let elapsed = Date().timeIntervalSince(startedAt)
+      if displayFloor > elapsed {
+        try? await Task.sleep(for: .seconds(displayFloor - elapsed))
+        if Task.isCancelled { return }
+      }
+      guard reportWarmingOnce({ completeStep("engine_warm_gate", result: "ready") })
+      else { return }
+      warmingOutcome = .ready
+    case .cancelled:
+      // Nothing on this screen offers a Cancel. A `.cancelled` can only reach
+      // here from a Cancel pressed on the CHECKLIST that raced the gate's own
+      // single-flighted call — so the engine is not ready and the gate must not
+      // open. Retry re-asks; skip remains available.
+      guard reportWarmingOnce({ blockStep("engine_warm_gate", reason: "warmup_cancelled") })
+      else { return }
+      warmingOutcome = .failed(Self.warmingFailureCopy)
+    case .failed:
+      guard reportWarmingOnce({ blockStep("engine_warm_gate", reason: "warmup_failed") })
+      else { return }
+      warmingOutcome = .failed(Self.warmingFailureCopy)
+    }
+  }
+
+  /// Enter the gate from the Ready screen. Resets the attempt, because
+  /// `warmingOutcome` survives a finished visit: a reopened onboarding would
+  /// otherwise inherit a previous visit's `ready` and walk straight through
+  /// without asking the engine anything, and the engine may have been unloaded
+  /// in between. The reset is here rather than at the view's `onAppear`
+  /// because a reused window can skip `onAppear` entirely
+  /// (`OnboardingProgress.swift:40-44`).
+  func beginWarmingGate() {
+    warmingReported = false
+    warmingOutcome = .waiting
+    currentScreen = .warmingUp
+  }
+
+  func retryWarming() {
+    warmingReported = false
+    warmingOutcome = .waiting
+    warmingRetryCount += 1
+  }
+
+  /// The person chose not to wait. Deliberately does NOT cancel the in-flight
+  /// warm-up: that load is shared and single-flighted, so cancelling it to
+  /// leave a screen would cancel it for every other waiter. The attempt runs to
+  /// completion and its outcome is dropped by the one-shot latch below, which
+  /// is what keeps this step from reporting twice.
+  func skipWarmingGate() {
+    _ = reportWarmingOnce { completeStep("engine_warm_gate", result: "skipped") }
+  }
+
+  private func reportWarmingOnce(_ emit: () -> Void) -> Bool {
+    guard !warmingReported else { return false }
+    warmingReported = true
+    emit()
+    return true
   }
 
   // MARK: - Progress Polling
@@ -508,13 +636,20 @@ struct OnboardingV2View: View {
         SettingUpScreenV2(viewModel: viewModel)
           .transition(Self.screenTransition)
       case .ready:
-        ReadyScreenV2(onComplete: {
-          viewModel.finishOnboarding(settings: settings)
-          // #1176 (race fix): mark terminal BEFORE the window closes, so the
-          // unguarded window-close path sees it and does not also fire abandon.
-          onboardingProgress.markCompleted()
-          onComplete()
-        })
+        // #2196: this button no longer ends setup. It opens the warm gate,
+        // which is what finishes — so the last thing that happens before a new
+        // person leaves is a proven-ready engine rather than an assumed one.
+        ReadyScreenV2(onContinue: { viewModel.beginWarmingGate() })
+          .transition(Self.screenTransition)
+      case .warmingUp:
+        WarmingScreenV2(
+          viewModel: viewModel,
+          onReady: finishSetup,
+          onSkip: {
+            viewModel.skipWarmingGate()
+            finishSetup()
+          }
+        )
         .transition(Self.screenTransition)
       }
     }
@@ -542,11 +677,29 @@ struct OnboardingV2View: View {
     // setupPhase is intentionally excluded from the id: changing phase at the
     // end of startSetup must NOT re-trigger. currentScreen + retryCount are
     // sufficient — retryCount bumps on retry, currentScreen on navigation.
-    .task(id: "\(viewModel.currentScreen)-\(viewModel.retryCount)") {
+    .task(
+      id:
+        "\(viewModel.currentScreen)-\(viewModel.retryCount)-\(viewModel.warmingRetryCount)"
+    ) {
       viewModel.kickSetupIfNeeded(
         warmUp: { await dictationRuntime.ensureActiveEngineWarmForOnboarding() },
         settings: settings)
+      // #2196: the gate's attempt, same owned-task shape and same #1388 reason.
+      // Each kick carries its own eligibility guard, so only one can fire.
+      viewModel.kickWarmingIfNeeded(
+        warmUp: { await dictationRuntime.ensureActiveEngineWarmForOnboarding() })
     }
+  }
+
+  /// The one place setup ends. Hoisted from the Ready button (#2196) because
+  /// the gate now has two exits that both finish, and two copies of a terminal
+  /// sequence is how one of them drifts.
+  private func finishSetup() {
+    viewModel.finishOnboarding(settings: settings)
+    // #1176 (race fix): mark terminal BEFORE the window closes, so the
+    // unguarded window-close path sees it and does not also fire abandon.
+    onboardingProgress.markCompleted()
+    onComplete()
   }
 
   private func recoverFromPersistedState() {
@@ -597,6 +750,9 @@ struct OnboardingV2View: View {
     case .ready:
       screen = "ready"
       step = "ready"
+    case .warmingUp:
+      screen = "warming_up"
+      step = "engine_warm_gate"
     }
     onboardingProgress.update(screen: screen, step: step)
   }
@@ -1306,7 +1462,7 @@ private struct ReadyScreenV2: View {
 
   @Environment(SettingsManager.self) private var settings
   @Environment(PermissionsService.self) private var permissions
-  let onComplete: () -> Void
+  let onContinue: () -> Void
 
   var body: some View {
     @Bindable var settings = settings
@@ -1393,7 +1549,7 @@ private struct ReadyScreenV2: View {
       Spacer()
 
       VStack(spacing: 0) {
-        Button(action: onComplete) {
+        Button(action: onContinue) {
           Text("GET STARTED!")
             .font(.system(size: 15, weight: .heavy))
             .kerning(0.3)

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
@@ -162,7 +162,9 @@ final class OnboardingV2ViewModel {
     case .warmingUp:
       if case .failed = warmingOutcome { return .drooping }
       return .equalizer
-    case .tryItOut: return practiceSucceeded ? .smile : .idle
+    case .tryItOut:
+      if practiceState == .missedTheBox { return .idle }
+      return practiceSucceeded ? .smile : .idle
     case .settingUp:
       if setupPhase == .permissions { return .triumph }
       if downloadError != nil { return .drooping }
@@ -506,6 +508,15 @@ final class OnboardingV2ViewModel {
     /// first takes against 10.1% for every genuine failure combined — so it is
     /// a normal state with a way forward, never an error.
     case saidNothing
+    /// FOUNDER-FOUND IN LIVE UAT, 2026-08-24. The take WORKED — words were
+    /// produced — but the box was not selected, so the cascade classified
+    /// `.nonText` and fell to clipboard-only, exactly as it does anywhere else.
+    /// Reporting that as `saidNothing` was a confident WRONG SUBJECT: it told
+    /// someone their microphone heard nothing when it had heard them perfectly,
+    /// and sent them to check hardware when the fix is one click. Measured on
+    /// his take: `RAW ASR "Testing one two three."` beside
+    /// `non-text element focused, falling back to clipboard-only`.
+    case missedTheBox
     /// Something must be turned on before any of this can work. Carries the
     /// telemetry reason so the screen and the funnel cannot disagree.
     case cannotHear(reason: String, permission: String?)
@@ -527,9 +538,15 @@ final class OnboardingV2ViewModel {
   /// A dictation started while this screen is up. Driven by
   /// `LiveRecordingState.isDictationActive`, which is the SUBJECT's own signal
   /// (true while either pipeline is recording, transcribing or polishing).
-  func practiceTakeStarted() {
+  /// Whether the box held focus when the current take began. This is what
+  /// separates "we heard nothing" from "we heard you and the words went
+  /// elsewhere", and the two need opposite advice.
+  private var boxWasFocusedAtTakeStart = true
+
+  func practiceTakeStarted(boxFocused: Bool = true) {
     if case .cannotHear = practiceState { return }
     practiceTextAtTakeStart = practiceText
+    boxWasFocusedAtTakeStart = boxFocused
     practiceState = .listening
   }
 
@@ -539,7 +556,15 @@ final class OnboardingV2ViewModel {
     guard practiceState == .listening else { return }
     let grew = practiceText != practiceTextAtTakeStart
       && !practiceText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-    practiceState = grew ? .worked : .saidNothing
+    if grew {
+      practiceState = .worked
+    } else if !boxWasFocusedAtTakeStart {
+      // Words may well have been produced; they simply had nowhere here to go.
+      // Saying "all quiet" here is the one wrong thing this screen can say.
+      practiceState = .missedTheBox
+    } else {
+      practiceState = .saidNothing
+    }
   }
 
   /// Called on appear with the live posture. Accessibility is the known limit of
@@ -570,6 +595,10 @@ final class OnboardingV2ViewModel {
     let result: String
     if practiceSucceeded {
       result = "completed"
+    } else if practiceState == .missedTheBox {
+      // NOT `no_speech`: this person dictated. Filing them under silence would
+      // repeat the screen's own mistake in the funnel, where nobody can see it.
+      result = "missed_box"
     } else if practiceState == .saidNothing {
       result = "no_speech"
     } else {
@@ -587,6 +616,7 @@ final class OnboardingV2ViewModel {
     practiceState = .waiting
     practiceExitReported = false
     practiceTextAtTakeStart = ""
+    boxWasFocusedAtTakeStart = true
     currentScreen = .tryItOut
   }
 

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
@@ -23,7 +23,7 @@ enum AppleIntelligenceSettings {
 @MainActor
 @Observable
 final class OnboardingV2ViewModel {
-  enum Screen { case welcome, settingUp, ready, warmingUp }
+  enum Screen { case welcome, settingUp, ready, warmingUp, tryItOut }
   enum SetupPhase { case checklist, permissions }
 
   enum ChecklistItemStatus: Equatable {
@@ -162,6 +162,7 @@ final class OnboardingV2ViewModel {
     case .warmingUp:
       if case .failed = warmingOutcome { return .drooping }
       return .equalizer
+    case .tryItOut: return practiceSucceeded ? .smile : .idle
     case .settingUp:
       if setupPhase == .permissions { return .triumph }
       if downloadError != nil { return .drooping }
@@ -456,6 +457,43 @@ final class OnboardingV2ViewModel {
     return true
   }
 
+  // MARK: - Practice box (#2196 chunk 2)
+
+  /// What the person has dictated into the practice box. Written by the box
+  /// itself — including when the paste cascade types into it, which is the whole
+  /// point — so the success signal comes from the SUBJECT rather than from
+  /// elapsed time or a poll (testing-philosophy.md
+  /// RULE: never-guess-when-the-subject-is-finished).
+  var practiceText: String = ""
+
+  /// True once the box has ever held non-whitespace text. Deliberately STICKY:
+  /// a person who dictates and then selects-all-and-deletes has still seen the
+  /// product work, and taking FINISH SETUP away from them at that moment would
+  /// be the screen punishing them for tidying up.
+  private(set) var practiceSucceeded = false
+
+  var practiceTextBinding: Binding<String> {
+    Binding(
+      get: { self.practiceText },
+      set: { self.setPracticeText($0) })
+  }
+
+  func setPracticeText(_ value: String) {
+    practiceText = value
+    if !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+      practiceSucceeded = true
+    }
+  }
+
+  /// Reset on entry, for the same reason `beginWarmingGate` resets: a reopened
+  /// onboarding must not inherit a previous visit's success and offer FINISH
+  /// SETUP to someone who has not dictated in this one.
+  func beginPractice() {
+    practiceText = ""
+    practiceSucceeded = false
+    currentScreen = .tryItOut
+  }
+
   // MARK: - Progress Polling
 
   /// Start polling the shared progress file at ~8 Hz.
@@ -686,13 +724,16 @@ struct OnboardingV2View: View {
       case .warmingUp:
         WarmingScreenV2(
           viewModel: viewModel,
-          onReady: finishSetup,
+          onReady: { viewModel.beginPractice() },
           onSkip: {
             viewModel.skipWarmingGate()
             finishSetup()
           }
         )
         .transition(Self.screenTransition)
+      case .tryItOut:
+        PracticeScreenV2(viewModel: viewModel, onFinish: finishSetup)
+          .transition(Self.screenTransition)
       }
     }
     .animation(.easeInOut(duration: 0.35), value: viewModel.currentScreen)
@@ -806,6 +847,9 @@ struct OnboardingV2View: View {
     case .warmingUp:
       screen = "warming_up"
       step = "engine_warm_gate"
+    case .tryItOut:
+      screen = "try_it_out"
+      step = "practice_dictation"
     }
     onboardingProgress.update(screen: screen, step: step)
   }

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
@@ -485,12 +485,99 @@ final class OnboardingV2ViewModel {
     }
   }
 
+  /// What the practice screen is SHOWING. Distinct from `practiceSucceeded`,
+  /// which is the sticky record that a dictation once worked: this is the
+  /// moment-to-moment state, and it exists because the screen was previously
+  /// blind to a take that produced nothing (local Codex chunk-2 review).
+  enum PracticeState: Equatable {
+    case waiting
+    case listening
+    case worked
+    /// The most likely non-success outcome by a wide margin — 20.3% of real
+    /// first takes against 10.1% for every genuine failure combined — so it is
+    /// a normal state with a way forward, never an error.
+    case saidNothing
+    /// Something must be turned on before any of this can work. Carries the
+    /// telemetry reason so the screen and the funnel cannot disagree.
+    case cannotHear(reason: String, permission: String?)
+  }
+
+  var practiceState: PracticeState = .waiting
+
+  /// One-shot: a visit to the practice screen reports its outcome exactly once,
+  /// whichever way it ends. Same shape as `gateExitReported` and for the same
+  /// reason — the screen has several exits and they must not each report.
+  private var practiceExitReported = false
+
+  /// The box's contents when the current take began, so "did this take produce
+  /// anything" is answered by comparing against the take's own start rather
+  /// than against empty — a second take after a successful one must not be
+  /// scored on the first one's words.
+  private var practiceTextAtTakeStart = ""
+
+  /// A dictation started while this screen is up. Driven by
+  /// `LiveRecordingState.isDictationActive`, which is the SUBJECT's own signal
+  /// (true while either pipeline is recording, transcribing or polishing).
+  func practiceTakeStarted() {
+    if case .cannotHear = practiceState { return }
+    practiceTextAtTakeStart = practiceText
+    practiceState = .listening
+  }
+
+  /// The dictation finished. Whether it produced anything is decided by the box
+  /// itself, never by a clock.
+  func practiceTakeEnded() {
+    guard practiceState == .listening else { return }
+    let grew = practiceText != practiceTextAtTakeStart
+      && !practiceText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    practiceState = grew ? .worked : .saidNothing
+  }
+
+  /// Called on appear with the live posture. Accessibility is the known limit of
+  /// this route — Tier 1 writes through it — so a person who reaches here with
+  /// it denied is told plainly instead of meeting the raw clipboard notice this
+  /// whole feature exists to remove.
+  func applyPracticePosture(micGranted: Bool, accessibilityGranted: Bool) {
+    if !micGranted {
+      practiceState = .cannotHear(reason: "mic_denied", permission: "microphone")
+    } else if !accessibilityGranted {
+      practiceState = .cannotHear(reason: "accessibility_denied", permission: "accessibility")
+    } else if case .cannotHear = practiceState {
+      practiceState = .waiting
+    }
+  }
+
+  /// The single reporting seam for leaving this screen. `completed` when they
+  /// saw their own words; `no_speech` when their last take produced nothing,
+  /// which is a materially different thing from `skipped` — one person tried
+  /// and got silence, the other never tried.
+  func reportPracticeExit() {
+    guard !practiceExitReported else { return }
+    practiceExitReported = true
+    if case .cannotHear(let reason, let permission) = practiceState {
+      blockStep("practice_dictation", reason: reason, permission: permission)
+      return
+    }
+    let result: String
+    if practiceSucceeded {
+      result = "completed"
+    } else if practiceState == .saidNothing {
+      result = "no_speech"
+    } else {
+      result = "skipped"
+    }
+    completeStep("practice_dictation", result: result)
+  }
+
   /// Reset on entry, for the same reason `beginWarmingGate` resets: a reopened
   /// onboarding must not inherit a previous visit's success and offer FINISH
   /// SETUP to someone who has not dictated in this one.
   func beginPractice() {
     practiceText = ""
     practiceSucceeded = false
+    practiceState = .waiting
+    practiceExitReported = false
+    practiceTextAtTakeStart = ""
     currentScreen = .tryItOut
   }
 
@@ -732,8 +819,18 @@ struct OnboardingV2View: View {
         )
         .transition(Self.screenTransition)
       case .tryItOut:
-        PracticeScreenV2(viewModel: viewModel, onFinish: finishSetup)
-          .transition(Self.screenTransition)
+        // Both exits report through ONE seam, so the funnel can tell a person
+        // who practised from one who bailed. Before this they shared a
+        // no-argument finish and `practice_dictation` never appeared at all
+        // (local Codex chunk-2 review).
+        PracticeScreenV2(
+          viewModel: viewModel,
+          onFinish: {
+            viewModel.reportPracticeExit()
+            finishSetup()
+          }
+        )
+        .transition(Self.screenTransition)
       }
     }
     .animation(.easeInOut(duration: 0.35), value: viewModel.currentScreen)

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
@@ -520,6 +520,16 @@ final class OnboardingV2ViewModel {
     /// first takes against 10.1% for every genuine failure combined — so it is
     /// a normal state with a way forward, never an error.
     case saidNothing
+    /// The pipeline FAILED — ASR, capture, or the model. Cloud review, and the
+    /// same class a fourth time: without this a failure produced no text and no
+    /// transcript, fell through to `saidNothing`, and the screen told the person
+    /// "Your microphone is working. We just did not hear anything." Both halves
+    /// false, and it sends them to try harder at a thing that is broken.
+    ///
+    /// `PipelineState` already separates these deliberately: `.error` is our
+    /// failure, `.advisory` is "the microphone delivered nothing usable" (#1891).
+    /// The distinction existed; this screen simply was not reading it.
+    case somethingBroke
     /// FOUNDER-FOUND IN LIVE UAT, 2026-08-24. The take WORKED — words were
     /// produced — but the box was not selected, so the cascade classified
     /// `.nonText` and fell to clipboard-only, exactly as it does anywhere else.
@@ -570,8 +580,15 @@ final class OnboardingV2ViewModel {
 
   /// The dictation finished. Whether it produced anything is decided by the box
   /// itself, never by a clock.
-  func practiceTakeEnded(transcriptCount: Int = 0) {
+  func practiceTakeEnded(transcriptCount: Int = 0, pipelineFailed: Bool = false) {
     guard practiceState == .listening else { return }
+    // A failure outranks every other reading: no text and no transcript are
+    // SYMPTOMS of it, so classifying on them first would describe the symptom
+    // and hide the cause.
+    if pipelineFailed {
+      practiceState = .somethingBroke
+      return
+    }
     let grew = practiceText != practiceTextAtTakeStart
       && !practiceText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     // A transcript that did not reach the box IS the missed-box case, and it
@@ -616,6 +633,12 @@ final class OnboardingV2ViewModel {
     let result: String
     if practiceSucceeded {
       result = "completed"
+    } else if practiceState == .somethingBroke {
+      // Its own reason, never folded into `no_speech`: one is us failing and
+      // the other is a quiet room, and a funnel that cannot tell them apart
+      // will read our own breakage as people not speaking.
+      blockStep("practice_dictation", reason: "pipeline_failed")
+      return
     } else if practiceState == .missedTheBox {
       // NOT `no_speech`: this person dictated. Filing them under silence would
       // repeat the screen's own mistake in the funnel, where nobody can see it.

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
@@ -555,24 +555,33 @@ final class OnboardingV2ViewModel {
   /// elsewhere", and the two need opposite advice.
   private var boxWasFocusedAtTakeStart = true
 
-  func practiceTakeStarted(boxFocused: Bool = true) {
+  /// Transcripts on record when the take began. Focus alone cannot tell a
+  /// missed box from silence — it says where words WOULD go, not whether any
+  /// existed — so the count of produced transcripts is what separates them.
+  private var transcriptCountAtTakeStart = 0
+
+  func practiceTakeStarted(boxFocused: Bool = true, transcriptCount: Int = 0) {
     if case .cannotHear = practiceState { return }
     practiceTextAtTakeStart = practiceText
     boxWasFocusedAtTakeStart = boxFocused
+    transcriptCountAtTakeStart = transcriptCount
     practiceState = .listening
   }
 
   /// The dictation finished. Whether it produced anything is decided by the box
   /// itself, never by a clock.
-  func practiceTakeEnded() {
+  func practiceTakeEnded(transcriptCount: Int = 0) {
     guard practiceState == .listening else { return }
     let grew = practiceText != practiceTextAtTakeStart
       && !practiceText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    // A transcript that did not reach the box IS the missed-box case, and it
+    // is the only evidence that words existed at all. Requiring BOTH — the box
+    // unfocused AND a transcript produced — is what stops this screen claiming
+    // "We heard you" about a take that was simply silent (cloud review).
+    let producedWords = transcriptCount > transcriptCountAtTakeStart
     if grew {
       practiceState = .worked
-    } else if !boxWasFocusedAtTakeStart {
-      // Words may well have been produced; they simply had nowhere here to go.
-      // Saying "all quiet" here is the one wrong thing this screen can say.
+    } else if !boxWasFocusedAtTakeStart && producedWords {
       practiceState = .missedTheBox
     } else {
       practiceState = .saidNothing
@@ -622,13 +631,26 @@ final class OnboardingV2ViewModel {
   /// Reset on entry, for the same reason `beginWarmingGate` resets: a reopened
   /// onboarding must not inherit a previous visit's success and offer FINISH
   /// SETUP to someone who has not dictated in this one.
+  /// The session this screen's contents belong to, so a reopened window cannot
+  /// show a previous visit's words. `sessionStartFloor` is the same box the
+  /// abandon emitter uses, so "a new visit" means exactly what it means
+  /// everywhere else in onboarding.
+  private var practiceVisitStamp: Date?
+
+  var practiceBelongsToCurrentVisit: Bool {
+    guard let stamp = practiceVisitStamp, let current = sessionStartFloor?() else { return false }
+    return stamp == current
+  }
+
   func beginPractice() {
+    practiceVisitStamp = sessionStartFloor?()
     practiceText = ""
     practiceSucceeded = false
     practiceState = .waiting
     practiceExitReported = false
     practiceTextAtTakeStart = ""
     boxWasFocusedAtTakeStart = true
+    transcriptCountAtTakeStart = 0
     currentScreen = .tryItOut
   }
 

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
@@ -595,6 +595,28 @@ final class OnboardingV2ViewModel {
     // is the only evidence that words existed at all. Requiring BOTH — the box
     // unfocused AND a transcript produced — is what stops this screen claiming
     // "We heard you" about a take that was simply silent (cloud review).
+    //
+    // KNOWN LIMIT, recorded rather than fixed, and classified deliberately.
+    // `transcriptCount` comes from history, and `PipelineStateChangePlanner`
+    // skips the append when a History SAVE fails — so a take that produced
+    // words during a failed save reads as silence here and the person is told
+    // "All quiet" instead of "click the box".
+    //
+    // HYPOTHETICAL under validate-automated-review-findings: it needs a
+    // misbehaving dependency (a failed store write), not an input a real user
+    // produces. The rule fixes a hypothetical only when the repair is TRIVIAL,
+    // and this one is not — it means sourcing "were words produced" from
+    // somewhere other than history, and every signal within reach at this point
+    // in the take is either the same fact or a new inference. Five rounds on
+    // this branch have shown what a guessed signal costs: three separate
+    // versions of this screen confidently telling someone something false about
+    // their own words.
+    //
+    // Cost if it fires is also bounded: the person is in a session whose
+    // history is already failing to save, which is a louder problem surfacing
+    // elsewhere, and the advice they get ("we did not hear anything") is
+    // unhelpful rather than harmful. Revisit if a first-class
+    // "this take produced text" signal appears; do not invent one here.
     let producedWords = transcriptCount > transcriptCountAtTakeStart
     if grew {
       practiceState = .worked

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
@@ -315,9 +315,22 @@ final class OnboardingV2ViewModel {
   /// outcome landing in a cancelled context is dropped in silence.
   @ObservationIgnored private(set) var warmingTask: Task<Void, Never>?
 
-  /// One-shot per attempt: the gate reports itself exactly once, whichever of
-  /// ready / failed / skipped arrives first. Reset by `retryWarming()`.
-  private var warmingReported = false
+  /// Two independent one-shots, because the gate reports two different things
+  /// and an earlier revision conflated them (local Codex review, adopted).
+  ///
+  /// `warmingAnswerReported` guards the WARM-UP's own answer — the `blocked`
+  /// row for a failed or cancelled attempt. It resets on retry, because a
+  /// second failed attempt is a second real block.
+  ///
+  /// `gateExitReported` guards the VISIT's terminal `completed` row, whether
+  /// that is `ready` or `skipped`. It resets only when a NEW visit begins, so
+  /// one visit produces exactly one completion however it ends.
+  ///
+  /// Conflating them cost the skip-after-failure case: the failure consumed the
+  /// single latch, and the Skip link still offered beneath the failure panel
+  /// then reported nothing at all.
+  private var warmingAnswerReported = false
+  private var gateExitReported = false
 
   /// Minimum time the gate stays on screen once readiness has landed, so the
   /// usual already-warm case reads as a beat rather than a flash. A DISPLAY
@@ -361,7 +374,10 @@ final class OnboardingV2ViewModel {
         try? await Task.sleep(for: .seconds(displayFloor - elapsed))
         if Task.isCancelled { return }
       }
-      guard reportWarmingOnce({ completeStep("engine_warm_gate", result: "ready") })
+      // Readiness both answers the warm-up and ends the visit, so it takes the
+      // EXIT latch: if the person already skipped, this must stay silent and
+      // must not open a gate nobody is standing at.
+      guard takeGateExit({ completeStep("engine_warm_gate", result: "ready") })
       else { return }
       warmingOutcome = .ready
     case .cancelled:
@@ -369,11 +385,15 @@ final class OnboardingV2ViewModel {
       // here from a Cancel pressed on the CHECKLIST that raced the gate's own
       // single-flighted call — so the engine is not ready and the gate must not
       // open. Retry re-asks; skip remains available.
-      guard reportWarmingOnce({ blockStep("engine_warm_gate", reason: "warmup_cancelled") })
+      guard !gateExitReported,
+        takeWarmingAnswer({ blockStep("engine_warm_gate", reason: "warmup_cancelled") })
       else { return }
       warmingOutcome = .failed(Self.warmingFailureCopy)
     case .failed:
-      guard reportWarmingOnce({ blockStep("engine_warm_gate", reason: "warmup_failed") })
+      // A late failure arriving after the person left is not their block to
+      // carry, so the exit check comes first.
+      guard !gateExitReported,
+        takeWarmingAnswer({ blockStep("engine_warm_gate", reason: "warmup_failed") })
       else { return }
       warmingOutcome = .failed(Self.warmingFailureCopy)
     }
@@ -387,13 +407,17 @@ final class OnboardingV2ViewModel {
   /// because a reused window can skip `onAppear` entirely
   /// (`OnboardingProgress.swift:40-44`).
   func beginWarmingGate() {
-    warmingReported = false
+    warmingAnswerReported = false
+    gateExitReported = false
     warmingOutcome = .waiting
     currentScreen = .warmingUp
   }
 
+  /// A retry re-arms the ANSWER latch only. The visit's exit latch is
+  /// deliberately untouched: retrying is not leaving, and a person who retries
+  /// and then skips must still produce exactly one completion.
   func retryWarming() {
-    warmingReported = false
+    warmingAnswerReported = false
     warmingOutcome = .waiting
     warmingRetryCount += 1
   }
@@ -404,12 +428,19 @@ final class OnboardingV2ViewModel {
   /// completion and its outcome is dropped by the one-shot latch below, which
   /// is what keeps this step from reporting twice.
   func skipWarmingGate() {
-    _ = reportWarmingOnce { completeStep("engine_warm_gate", result: "skipped") }
+    _ = takeGateExit { completeStep("engine_warm_gate", result: "skipped") }
   }
 
-  private func reportWarmingOnce(_ emit: () -> Void) -> Bool {
-    guard !warmingReported else { return false }
-    warmingReported = true
+  private func takeWarmingAnswer(_ emit: () -> Void) -> Bool {
+    guard !warmingAnswerReported else { return false }
+    warmingAnswerReported = true
+    emit()
+    return true
+  }
+
+  private func takeGateExit(_ emit: () -> Void) -> Bool {
+    guard !gateExitReported else { return false }
+    gateExitReported = true
     emit()
     return true
   }

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
@@ -377,21 +377,33 @@ final class OnboardingV2ViewModel {
     let outcome = await warmUp()
     if Task.isCancelled { return }
 
+    // The visit may have ended while this ran: the window closes, abandon is
+    // emitted, and this task deliberately survives. NOTHING it learned belongs
+    // to that visit any more — not a completion, not a block, not a stored
+    // outcome. Re-arm and say nothing.
+    //
+    // This check sits ABOVE the switch on purpose. It was first written inside
+    // the `.ready` branch alone, and cloud review found `.failed` and
+    // `.cancelled` still reporting for a dead visit — the fourth time this one
+    // class was patched at an instance instead of at its root. One guard, every
+    // outcome, no next instance.
+    guard isVisitActive?() ?? true else {
+      beginWarmingGate()
+      return
+    }
+
     switch outcome {
     case .ready:
       let elapsed = Date().timeIntervalSince(startedAt)
       if displayFloor > elapsed {
         try? await Task.sleep(for: .seconds(displayFloor - elapsed))
         if Task.isCancelled { return }
-      }
-      // The visit may have ended while this ran — the window closes, abandon is
-      // emitted, and this task deliberately survives. Re-arm rather than
-      // report: a completion after abandonment is a double terminal, and a
-      // stale `.ready` would let the next open walk through without asking an
-      // engine that may since have been unloaded.
-      guard isVisitActive?() ?? true else {
-        beginWarmingGate()
-        return
+        // Re-checked after the sleep: the floor is a real suspension point and
+        // the visit can end inside it.
+        guard isVisitActive?() ?? true else {
+          beginWarmingGate()
+          return
+        }
       }
       // Readiness both answers the warm-up and ends the visit, so it takes the
       // EXIT latch: if the person already skipped, this must stay silent and

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
@@ -338,8 +338,15 @@ final class OnboardingV2ViewModel {
   /// pass 0.
   static let warmingDisplayFloor: TimeInterval = 0.6
 
+  /// Local Codex r3: the earlier wording promised the engine "will load the
+  /// first time you dictate", which this path specifically cannot deliver — a
+  /// press taken before readiness is refused and mints no session
+  /// (`RecordingStarter.swift:292-297`), so the first press after a genuinely
+  /// failed warm-up only starts the load and a second one is needed. That is
+  /// the exact experience this gate exists to prevent, so the copy must not
+  /// promise its absence.
   static let warmingFailureCopy =
-    "You can try again, or skip ahead and it will load the first time you dictate."
+    "You can try again, or skip ahead — your first shortcut press may just wake the engine up, and the one after it will dictate."
 
   /// Start the gate's warm-up if none is live. Safe to call on every view
   /// re-appear: a live attempt makes a re-kick a no-op.
@@ -410,6 +417,10 @@ final class OnboardingV2ViewModel {
     warmingAnswerReported = false
     gateExitReported = false
     warmingOutcome = .waiting
+    // Re-keys the view's `.task`, so a fresh attempt kicks even when the screen
+    // is not changing — which is the case when a dead visit is re-armed in
+    // place rather than entered from the Ready button.
+    warmingRetryCount += 1
     currentScreen = .warmingUp
   }
 
@@ -726,6 +737,17 @@ struct OnboardingV2View: View {
   /// the gate now has two exits that both finish, and two copies of a terminal
   /// sequence is how one of them drifts.
   private func finishSetup() {
+    // Local Codex r3, and it is the consequence of r1's rejected finding rather
+    // than a refutation of it: the owned warm-up outliving a window close is
+    // exactly what keeps the observer alive to fire — and firing after the
+    // close path already emitted `onboarding.abandoned` would count one visit
+    // as both abandoned AND completed. Re-arm rather than return, so a reopened
+    // window meets a fresh attempt instead of sitting on an answer that belongs
+    // to a visit nobody is in any more.
+    guard onboardingProgress.isInFlight else {
+      viewModel.beginWarmingGate()
+      return
+    }
     viewModel.finishOnboarding(settings: settings)
     // #1176 (race fix): mark terminal BEFORE the window closes, so the
     // unguarded window-close path sees it and does not also fire abandon.

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/PracticeScreen.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/PracticeScreen.swift
@@ -247,8 +247,15 @@ struct PracticeScreenV2: View {
       // so without this the take is never opened and its end is dropped by the
       // `.listening` guard (cloud review).
       if live.isDictationActive {
+        // `boxFocused: false`, and the hardcoded `true` here was the SAME
+        // mistake a third time: this take began before this view existed, so
+        // the pipeline captured its paste target when there was no box on
+        // screen. Claiming focus would send a take that DID produce words into
+        // `saidNothing` — "All quiet" about someone we heard perfectly, which
+        // is the founder's original defect once more. False is not a guess
+        // here, it is the fact: the box could not have been the target.
         viewModel.practiceTakeStarted(
-          boxFocused: true, transcriptCount: transcripts.transcriptCount)
+          boxFocused: false, transcriptCount: transcripts.transcriptCount)
       }
       permissions.refreshAccessibilityStatus()
       viewModel.applyPracticePosture(

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/PracticeScreen.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/PracticeScreen.swift
@@ -1,0 +1,108 @@
+import EnviousWisprServices
+import SwiftUI
+
+// MARK: - Screen 5: Try it out (#2196)
+
+/// The last screen of setup, and the whole point of #2196: a real text box with
+/// the cursor already in it, so a first dictation has somewhere to land.
+///
+/// WHY THE BOX IS THE ENTIRE FIX. `PasteCascadeExecutor` classifies the focused
+/// element by AX role and `PasteService.textRoles` accepts `AXTextField`,
+/// `AXTextArea`, `AXComboBox`, `AXSearchField` (`PasteService.swift:70-75`). A
+/// focused SwiftUI `TextEditor` is backed by `NSTextView` and presents as
+/// `AXTextArea`, which is in that set. The refusal this feature exists to fix
+/// happens BECAUSE the classification is `.nonText` — our own window offered
+/// nothing to type into — so supplying a text-role element removes the
+/// precondition for the refusal rather than special-casing around it. Nothing in
+/// the cascade special-cases our bundle: `isExpectedNonTextRefusal` special-cases
+/// `com.apple.loginwindow` and nothing else (`PasteCascadeExecutor.swift:915-930`).
+///
+/// So this file adds NO pipeline code, no delivery route, and no new setting. It
+/// adds a target.
+struct PracticeScreenV2: View {
+  var viewModel: OnboardingV2ViewModel
+
+  /// Fired when the person is finished, however they got there.
+  let onFinish: () -> Void
+
+  @FocusState private var boxFocused: Bool
+
+  var body: some View {
+    VStack(spacing: 0) {
+      RainbowLipsView(animationState: viewModel.lipsState, size: 108)
+        .padding(.bottom, 14)
+
+      Text(viewModel.practiceSucceeded ? "That is it. You are set." : "Time for your first dictation!")
+        .font(.system(size: 26, weight: .heavy, design: .rounded))
+        .foregroundStyle(Color.obTextPrimary)
+        .kerning(-0.4)
+        .multilineTextAlignment(.center)
+        .padding(.bottom, 6)
+
+      Text(
+        viewModel.practiceSucceeded
+          ? "Those are your words, typed for you.\nIn any other app, click into a text box first."
+          : "Hold your shortcut and say something.\nLet go when you are done."
+      )
+      .font(.obBody)
+      .foregroundStyle(Color.obTextSecondary)
+      .multilineTextAlignment(.center)
+      .fixedSize(horizontal: false, vertical: true)
+      .padding(.bottom, 18)
+
+      // The target. Focused on appear, because an unfocused box is exactly the
+      // state this whole feature exists to remove.
+      TextEditor(text: viewModel.practiceTextBinding)
+        .font(.system(size: 14))
+        .scrollContentBackground(.hidden)
+        .padding(10)
+        .frame(width: 404, height: 132)
+        .background(Color.obSurface, in: RoundedRectangle(cornerRadius: 12))
+        .overlay(
+          RoundedRectangle(cornerRadius: 12)
+            .strokeBorder(
+              viewModel.practiceSucceeded ? Color.obSuccess.opacity(0.55) : Color.obAccent.opacity(0.35),
+              lineWidth: boxFocused ? 2 : 1)
+        )
+        .focused($boxFocused)
+        .accessibilityLabel("Your first dictation")
+
+      // Deliberately quiet while recording: the pill is NOT suppressed during
+      // onboarding (nothing under App/Overlay/ reads `onboardingState`), so it
+      // appears over this window and carries the recording state — which is what
+      // this person will see in every other app forever after. A second waveform
+      // here would teach them a UI that only exists during setup.
+      Text(viewModel.practiceSucceeded ? " " : "Your recording indicator appears while you hold the key.")
+        .font(.obCaptionSmall)
+        .foregroundStyle(Color.obTextTertiary)
+        .padding(.top, 10)
+
+      Spacer()
+
+      Button(action: onFinish) {
+        Text("FINISH SETUP")
+          .font(.system(size: 15, weight: .heavy))
+          .kerning(0.3)
+          .foregroundStyle(.white)
+          .frame(maxWidth: 360)
+          .padding(.vertical, 13)
+          .background(
+            viewModel.practiceSucceeded ? Color.obButtonFill : Color.obButtonFill.opacity(0.35),
+            in: RoundedRectangle(cornerRadius: 12))
+      }
+      .buttonStyle(.plain)
+      .disabled(!viewModel.practiceSucceeded)
+      .keyboardShortcut(.defaultAction)
+
+      Button(action: onFinish) {
+        Text("Skip this step")
+          .font(.obCaption)
+          .foregroundStyle(Color.obAccent)
+      }
+      .buttonStyle(.plain)
+      .padding(.top, 12)
+    }
+    .onAppear { boxFocused = true }
+    .animation(.easeInOut(duration: 0.3), value: viewModel.practiceSucceeded)
+  }
+}

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/PracticeScreen.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/PracticeScreen.swift
@@ -25,25 +25,89 @@ struct PracticeScreenV2: View {
   /// Fired when the person is finished, however they got there.
   let onFinish: () -> Void
 
+  @Environment(PermissionsService.self) private var permissions
+  /// The SUBJECT's own in-flight signal: true while either pipeline is
+  /// recording, transcribing or polishing. The screen was previously blind to a
+  /// take entirely, which is what let Skip pull the target away mid-dictation
+  /// and let a silent take go unacknowledged (local Codex chunk-2 review).
+  @Environment(LiveRecordingState.self) private var live
+
   @FocusState private var boxFocused: Bool
+
+  /// A take is in flight, so both exits are held. Leaving now would close the
+  /// window the ordinary cascade is about to type into, and the words would
+  /// land on the clipboard behind the same notice this feature removes — or in
+  /// whatever app happened to be behind us.
+  private var takeInFlight: Bool { live.isDictationActive }
+
+  private var cannotHear: Bool {
+    if case .cannotHear = viewModel.practiceState { return true }
+    return false
+  }
+
+  private func grantPermission(reason: String) async {
+    if reason == "mic_denied" {
+      _ = await permissions.requestMicrophoneAccess()
+    } else {
+      _ = permissions.requestAccessibilityAccess()
+    }
+    permissions.refreshAccessibilityStatus()
+    viewModel.applyPracticePosture(
+      micGranted: permissions.hasMicrophonePermission,
+      accessibilityGranted: permissions.accessibilityGranted)
+  }
+
+  private var headline: String {
+    switch viewModel.practiceState {
+    case .cannotHear: return "We cannot hear you"
+    case .listening: return "Listening…"
+    case .saidNothing: return "All quiet"
+    case .worked: return "That is it. You are set."
+    case .waiting: return viewModel.practiceSucceeded ? "That is it. You are set." : "Time for your first dictation!"
+    }
+  }
+
+  private var subhead: String {
+    switch viewModel.practiceState {
+    case .cannotHear(let reason, _):
+      return reason == "mic_denied"
+        ? "EnviousWispr needs permission to use your microphone.\nYou can turn it on and come back, or skip ahead."
+        : "EnviousWispr needs Accessibility permission to type for you.\nYou can turn it on and come back, or skip ahead."
+    case .listening:
+      return "Go ahead. Let go of the key when you are done."
+    case .saidNothing:
+      // Not an error, and never worded as one: the microphone worked, there
+      // was simply nothing to hear. The prompt is drawn from the persona banks
+      // so it sounds like something a person would actually say.
+      return "Your microphone is working — we just did not hear anything.\nTry holding the key and saying: tell grandma I will call Sunday."
+    case .worked:
+      return "Those are your words, typed for you.\nIn any other app, click into a text box first."
+    case .waiting:
+      return viewModel.practiceSucceeded
+        ? "Those are your words, typed for you.\nIn any other app, click into a text box first."
+        : "Hold your shortcut and say something.\nLet go when you are done."
+    }
+  }
+
+  private var footnote: String {
+    if cannotHear { return " " }
+    if viewModel.practiceSucceeded { return " " }
+    return "Your recording indicator appears while you hold the key."
+  }
 
   var body: some View {
     VStack(spacing: 0) {
       RainbowLipsView(animationState: viewModel.lipsState, size: 108)
         .padding(.bottom, 14)
 
-      Text(viewModel.practiceSucceeded ? "That is it. You are set." : "Time for your first dictation!")
+      Text(headline)
         .font(.system(size: 26, weight: .heavy, design: .rounded))
         .foregroundStyle(Color.obTextPrimary)
         .kerning(-0.4)
         .multilineTextAlignment(.center)
         .padding(.bottom, 6)
 
-      Text(
-        viewModel.practiceSucceeded
-          ? "Those are your words, typed for you.\nIn any other app, click into a text box first."
-          : "Hold your shortcut and say something.\nLet go when you are done."
-      )
+      Text(subhead)
       .font(.obBody)
       .foregroundStyle(Color.obTextSecondary)
       .multilineTextAlignment(.center)
@@ -72,10 +136,28 @@ struct PracticeScreenV2: View {
       // appears over this window and carries the recording state — which is what
       // this person will see in every other app forever after. A second waveform
       // here would teach them a UI that only exists during setup.
-      Text(viewModel.practiceSucceeded ? " " : "Your recording indicator appears while you hold the key.")
+      Text(footnote)
         .font(.obCaptionSmall)
         .foregroundStyle(Color.obTextTertiary)
+        .multilineTextAlignment(.center)
+        .fixedSize(horizontal: false, vertical: true)
         .padding(.top, 10)
+
+      // The route out. `PermissionsService` exposes request methods rather
+      // than a settings opener, and the request is the better offer anyway: an
+      // undetermined permission is granted in place, and a denied one lands the
+      // person on the right pane instead of the top of System Settings.
+      if case .cannotHear(let reason, _) = viewModel.practiceState {
+        Button {
+          Task { await grantPermission(reason: reason) }
+        } label: {
+          Text(reason == "mic_denied" ? "Turn on the microphone" : "Turn on Accessibility")
+            .font(.obCaption)
+            .foregroundStyle(Color.obAccent)
+        }
+        .buttonStyle(.plain)
+        .padding(.top, 8)
+      }
 
       Spacer()
 
@@ -91,18 +173,33 @@ struct PracticeScreenV2: View {
             in: RoundedRectangle(cornerRadius: 12))
       }
       .buttonStyle(.plain)
-      .disabled(!viewModel.practiceSucceeded)
+      .disabled(!viewModel.practiceSucceeded || takeInFlight)
       .keyboardShortcut(.defaultAction)
 
       Button(action: onFinish) {
-        Text("Skip this step")
+        Text(takeInFlight ? "One moment, still working on that" : "Skip this step")
           .font(.obCaption)
-          .foregroundStyle(Color.obAccent)
+          .foregroundStyle(takeInFlight ? Color.obTextTertiary : Color.obAccent)
       }
       .buttonStyle(.plain)
+      .disabled(takeInFlight)
       .padding(.top, 12)
     }
-    .onAppear { boxFocused = true }
-    .animation(.easeInOut(duration: 0.3), value: viewModel.practiceSucceeded)
+    .onAppear {
+      boxFocused = true
+      permissions.refreshAccessibilityStatus()
+      viewModel.applyPracticePosture(
+        micGranted: permissions.hasMicrophonePermission,
+        accessibilityGranted: permissions.accessibilityGranted)
+    }
+    // The take's own edges, from the subject rather than from a timer.
+    .onChange(of: live.isDictationActive) { _, active in
+      if active {
+        viewModel.practiceTakeStarted()
+      } else {
+        viewModel.practiceTakeEnded()
+      }
+    }
+    .animation(.easeInOut(duration: 0.3), value: viewModel.practiceState)
   }
 }

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/PracticeScreen.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/PracticeScreen.swift
@@ -25,6 +25,7 @@ struct PracticeScreenV2: View {
   /// Fired when the person is finished, however they got there.
   let onFinish: () -> Void
 
+  @Environment(SettingsManager.self) private var settings
   @Environment(PermissionsService.self) private var permissions
   /// The SUBJECT's own in-flight signal: true while either pipeline is
   /// recording, transcribing or polishing. The screen was previously blind to a
@@ -34,11 +35,33 @@ struct PracticeScreenV2: View {
 
   @FocusState private var boxFocused: Bool
 
-  /// A take is in flight, so both exits are held. Leaving now would close the
-  /// window the ordinary cascade is about to type into, and the words would
-  /// land on the clipboard behind the same notice this feature removes — or in
-  /// whatever app happened to be behind us.
+  /// A take is in flight, so both BUTTONS are held. Leaving by button now would
+  /// close the window the ordinary cascade is about to type into, and the words
+  /// would land on the clipboard behind the same notice this feature removes.
+  ///
+  /// KNOWN LIMIT, named rather than implied (cloud review): this holds the
+  /// buttons, NOT the window. The close control and Command-W still work,
+  /// because the window coordinator observes `willClose` and does not veto it.
+  /// Someone determined can still leave mid-take. What that costs is now
+  /// bounded rather than wrong: the abandon path emits, and `runWarmingGate`'s
+  /// visit-alive guard means the late outcome reports nothing and stores
+  /// nothing. So the DATA stays honest and the words behave exactly as they do
+  /// when anyone closes any window mid-dictation anywhere else in the app.
+  /// Vetoing a window close is a bigger change than this screen justifies.
   private var takeInFlight: Bool { live.isDictationActive }
+
+  /// FOUNDER, 2026-08-24: "this page should remind people what keybind they
+  /// set". They chose it on the previous screen seconds ago, and "hold your
+  /// shortcut" assumes they remember which one — the assumption is hardest on
+  /// exactly the person this feature exists for. Same formatter the keycap on
+  /// that screen uses, so the two can never disagree about the name.
+  private var shortcutName: String {
+    if ModifierKeyCodes.isModifierOnly(settings.toggleKeyCode), settings.toggleModifiers.isEmpty {
+      return KeySymbols.formatModifierOnly(
+        settings.toggleModifiers, keyCode: settings.toggleKeyCode)
+    }
+    return KeySymbols.format(keyCode: settings.toggleKeyCode, modifiers: settings.toggleModifiers)
+  }
 
   private var cannotHear: Bool {
     if case .cannotHear = viewModel.practiceState { return true }
@@ -75,23 +98,23 @@ struct PracticeScreenV2: View {
         ? "EnviousWispr needs permission to use your microphone.\nYou can turn it on and come back, or skip ahead."
         : "EnviousWispr needs Accessibility permission to type for you.\nYou can turn it on and come back, or skip ahead."
     case .listening:
-      return "Go ahead. Let go of the key when you are done."
+      return "Go ahead. Let go of \(shortcutName) when you are done."
     case .missedTheBox:
       // Says what happened and what to do, and takes the blame off them. The
       // words are genuinely on the clipboard, so telling them that is useful
       // rather than a consolation.
-      return "We heard you. The box was not selected, so your words went to the clipboard.\nClick inside the box, then hold your shortcut again."
+      return "We heard you. The box was not selected, so your words went to the clipboard.\nClick inside the box, then hold \(shortcutName) again."
     case .saidNothing:
       // Not an error, and never worded as one: the microphone worked, there
       // was simply nothing to hear. The prompt is drawn from the persona banks
       // so it sounds like something a person would actually say.
-      return "Your microphone is working. We just did not hear anything.\nTry holding the key and saying: tell grandma I will call Sunday."
+      return "Your microphone is working. We just did not hear anything.\nTry holding \(shortcutName) and saying: tell grandma I will call Sunday."
     case .worked:
       return "Those are your words, typed for you.\nIn any other app, click into a text box first."
     case .waiting:
       return viewModel.practiceSucceeded
         ? "Those are your words, typed for you.\nIn any other app, click into a text box first."
-        : "Hold your shortcut and say something.\nLet go when you are done."
+        : "Hold \(shortcutName) and say something.\nLet go when you are done."
     }
   }
 

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/PracticeScreen.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/PracticeScreen.swift
@@ -1,3 +1,5 @@
+import AppKit
+import EnviousWisprCore
 import EnviousWisprServices
 import SwiftUI
 
@@ -73,13 +75,33 @@ struct PracticeScreenV2: View {
 
   private func grantPermission(reason: String) async {
     if reason == "mic_denied" {
-      _ = await permissions.requestMicrophoneAccess()
+      // `AVCaptureDevice.requestAccess` only presents the prompt from the
+      // UNDETERMINED state. After a prior denial it returns false immediately
+      // and nothing appears, so the button did nothing at all and the recovery
+      // path read as broken (cloud review). Send them where the switch is.
+      if permissions.microphonePermissionIsDenied {
+        if let url = URL(
+          string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone")
+        {
+          NSWorkspace.shared.open(url)
+        }
+      } else {
+        _ = await permissions.requestMicrophoneAccess()
+      }
     } else {
       _ = permissions.requestAccessibilityAccess()
     }
+    refreshPosture()
+  }
+
+  /// `hasMicrophonePermission` reads a CACHED snapshot taken at construction,
+  /// so a microphone revoked while the app kept running still reads authorized
+  /// (cloud review). `microphonePermissionIsDenied` reads LIVE, which is the
+  /// whole reason #1558 added it.
+  private func refreshPosture() {
     permissions.refreshAccessibilityStatus()
     viewModel.applyPracticePosture(
-      micGranted: permissions.hasMicrophonePermission,
+      micGranted: !permissions.microphonePermissionIsDenied,
       accessibilityGranted: permissions.accessibilityGranted)
   }
 
@@ -87,6 +109,7 @@ struct PracticeScreenV2: View {
     switch viewModel.practiceState {
     case .cannotHear: return "We cannot hear you"
     case .listening: return "Listening…"
+    case .somethingBroke: return "That did not work"
     case .missedTheBox: return "Click the box first"
     case .saidNothing: return "All quiet"
     case .worked: return "That is it. You are set."
@@ -102,6 +125,11 @@ struct PracticeScreenV2: View {
         : "EnviousWispr needs Accessibility permission to type for you.\nYou can turn it on and come back, or skip ahead."
     case .listening:
       return "Go ahead. Let go of \(shortcutName) when you are done."
+    case .somethingBroke:
+      // Takes the blame explicitly. Someone told "we did not hear anything"
+      // tries harder at a thing that is broken; someone told it was us tries
+      // once more and then moves on, which is the honest ask.
+      return "Something went wrong on our side, not yours.\nTry once more, or skip ahead and dictate anywhere."
     case .missedTheBox:
       // Says what happened and what to do, and takes the blame off them. The
       // words are genuinely on the clipboard, so telling them that is useful
@@ -257,10 +285,7 @@ struct PracticeScreenV2: View {
         viewModel.practiceTakeStarted(
           boxFocused: false, transcriptCount: transcripts.transcriptCount)
       }
-      permissions.refreshAccessibilityStatus()
-      viewModel.applyPracticePosture(
-        micGranted: permissions.hasMicrophonePermission,
-        accessibilityGranted: permissions.accessibilityGranted)
+      refreshPosture()
     }
     // The take's own edges, from the subject rather than from a timer.
     // Accessibility cannot be observed by notification and
@@ -274,10 +299,7 @@ struct PracticeScreenV2: View {
       while !Task.isCancelled {
         try? await Task.sleep(for: .seconds(2))
         guard !Task.isCancelled else { return }
-        permissions.refreshAccessibilityStatus()
-        viewModel.applyPracticePosture(
-          micGranted: permissions.hasMicrophonePermission,
-          accessibilityGranted: permissions.accessibilityGranted)
+        refreshPosture()
         if !cannotHear { return }
       }
     }
@@ -289,7 +311,13 @@ struct PracticeScreenV2: View {
         viewModel.practiceTakeStarted(
           boxFocused: boxFocused, transcriptCount: transcripts.transcriptCount)
       } else {
-        viewModel.practiceTakeEnded(transcriptCount: transcripts.transcriptCount)
+        // A pipeline FAILURE outranks silence, and `PipelineState` already
+        // separates our failure (`.error`) from "the microphone delivered
+        // nothing usable" (`.advisory`, #1891).
+        var failed = false
+        if case .error = live.pipelineState { failed = true }
+        viewModel.practiceTakeEnded(
+          transcriptCount: transcripts.transcriptCount, pipelineFailed: failed)
         // Put the cursor back, so the next attempt cannot repeat the miss for
         // the same reason. Founder-found in Live UAT: the advice is useless if
         // acting on it needs a click they were not told about.

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/PracticeScreen.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/PracticeScreen.swift
@@ -61,6 +61,7 @@ struct PracticeScreenV2: View {
     switch viewModel.practiceState {
     case .cannotHear: return "We cannot hear you"
     case .listening: return "Listening…"
+    case .missedTheBox: return "Click the box first"
     case .saidNothing: return "All quiet"
     case .worked: return "That is it. You are set."
     case .waiting: return viewModel.practiceSucceeded ? "That is it. You are set." : "Time for your first dictation!"
@@ -75,6 +76,11 @@ struct PracticeScreenV2: View {
         : "EnviousWispr needs Accessibility permission to type for you.\nYou can turn it on and come back, or skip ahead."
     case .listening:
       return "Go ahead. Let go of the key when you are done."
+    case .missedTheBox:
+      // Says what happened and what to do, and takes the blame off them. The
+      // words are genuinely on the clipboard, so telling them that is useful
+      // rather than a consolation.
+      return "We heard you. The box was not selected, so your words went to the clipboard.\nClick inside the box, then hold your shortcut again."
     case .saidNothing:
       // Not an error, and never worded as one: the microphone worked, there
       // was simply nothing to hear. The prompt is drawn from the persona banks
@@ -213,9 +219,15 @@ struct PracticeScreenV2: View {
     }
     .onChange(of: live.isDictationActive) { _, active in
       if active {
-        viewModel.practiceTakeStarted()
+        // Whether the box holds focus RIGHT NOW is what separates "we heard
+        // nothing" from "we heard you and it went to the clipboard".
+        viewModel.practiceTakeStarted(boxFocused: boxFocused)
       } else {
         viewModel.practiceTakeEnded()
+        // Put the cursor back, so the next attempt cannot repeat the miss for
+        // the same reason. Founder-found in Live UAT: the advice is useless if
+        // acting on it needs a click they were not told about.
+        if viewModel.practiceState == .missedTheBox { boxFocused = true }
       }
     }
     .animation(.easeInOut(duration: 0.3), value: viewModel.practiceState)

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/PracticeScreen.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/PracticeScreen.swift
@@ -26,6 +26,9 @@ struct PracticeScreenV2: View {
   let onFinish: () -> Void
 
   @Environment(SettingsManager.self) private var settings
+  /// Whether a take produced anything at all. Focus says where words WOULD go;
+  /// only this says whether any existed (cloud review).
+  @Environment(TranscriptCoordinator.self) private var transcripts
   @Environment(PermissionsService.self) private var permissions
   /// The SUBJECT's own in-flight signal: true while either pipeline is
   /// recording, transcribing or polishing. The screen was previously blind to a
@@ -229,7 +232,24 @@ struct PracticeScreenV2: View {
       .padding(.top, 12)
     }
     .onAppear {
+      // A reopened window keeps the retained view model, and the open bridge
+      // only starts a fresh `OnboardingProgress` session — it never resets this
+      // screen. Without this, someone who closed the window here and came back
+      // would find a previous visit's words already in the box and FINISH SETUP
+      // already lit (cloud review). Same class as the warm gate's reopen guard.
+      if !viewModel.practiceBelongsToCurrentVisit {
+        viewModel.beginPractice()
+      }
       boxFocused = true
+      // A take can ALREADY be running when this view mounts — press the
+      // shortcut during the warming transition and `isDictationActive` is true
+      // before the observer below exists. `onChange` has no initial callback,
+      // so without this the take is never opened and its end is dropped by the
+      // `.listening` guard (cloud review).
+      if live.isDictationActive {
+        viewModel.practiceTakeStarted(
+          boxFocused: true, transcriptCount: transcripts.transcriptCount)
+      }
       permissions.refreshAccessibilityStatus()
       viewModel.applyPracticePosture(
         micGranted: permissions.hasMicrophonePermission,
@@ -256,11 +276,13 @@ struct PracticeScreenV2: View {
     }
     .onChange(of: live.isDictationActive) { _, active in
       if active {
-        // Whether the box holds focus RIGHT NOW is what separates "we heard
-        // nothing" from "we heard you and it went to the clipboard".
-        viewModel.practiceTakeStarted(boxFocused: boxFocused)
+        // Whether the box holds focus RIGHT NOW is half of what separates "we
+        // heard nothing" from "we heard you and it went to the clipboard"; the
+        // transcript count is the other half.
+        viewModel.practiceTakeStarted(
+          boxFocused: boxFocused, transcriptCount: transcripts.transcriptCount)
       } else {
-        viewModel.practiceTakeEnded()
+        viewModel.practiceTakeEnded(transcriptCount: transcripts.transcriptCount)
         // Put the cursor back, so the next attempt cannot repeat the miss for
         // the same reason. Founder-found in Live UAT: the advice is useless if
         // acting on it needs a click they were not told about.

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/PracticeScreen.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/PracticeScreen.swift
@@ -176,6 +176,20 @@ struct PracticeScreenV2: View {
       // than a settings opener, and the request is the better offer anyway: an
       // undetermined permission is granted in place, and a denied one lands the
       // person on the right pane instead of the top of System Settings.
+      // SCOPE, corrected after founder UAT 2026-08-24 and stated so nobody reads
+      // the near-zero count as the feature working: on a FIRST RUN this state is
+      // UNREACHABLE. The permissions step upstream disables Continue until both
+      // microphone and Accessibility are granted, with no skip
+      // (`OnboardingV2View.swift`, `.disabled(!bothGranted)`), and the founder
+      // confirmed that gate stays — "we aren't going to let people continue
+      // without granting us the basic permissions needed".
+      //
+      // It is reachable on exactly one path, which is real but rare: finish
+      // setup, later have a permission revoked, then reopen setup from the menu.
+      // That reopen resolves straight to `.ready` and never revisits
+      // permissions, so this screen is the first thing that would notice, and
+      // macOS does revoke Accessibility on its own after some app updates.
+      // A safety net for that path, not part of the first-run experience.
       if case .cannotHear(let reason, _) = viewModel.practiceState {
         Button {
           Task { await grantPermission(reason: reason) }

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/PracticeScreen.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/PracticeScreen.swift
@@ -79,7 +79,7 @@ struct PracticeScreenV2: View {
       // Not an error, and never worded as one: the microphone worked, there
       // was simply nothing to hear. The prompt is drawn from the persona banks
       // so it sounds like something a person would actually say.
-      return "Your microphone is working — we just did not hear anything.\nTry holding the key and saying: tell grandma I will call Sunday."
+      return "Your microphone is working. We just did not hear anything.\nTry holding the key and saying: tell grandma I will call Sunday."
     case .worked:
       return "Those are your words, typed for you.\nIn any other app, click into a text box first."
     case .waiting:
@@ -193,6 +193,24 @@ struct PracticeScreenV2: View {
         accessibilityGranted: permissions.accessibilityGranted)
     }
     // The take's own edges, from the subject rather than from a timer.
+    // Accessibility cannot be observed by notification and
+    // `requestAccessibilityAccess()` returns the instant the system prompt
+    // opens, so a person who grants it in System Settings and comes back would
+    // sit on `cannotHear` until they pressed the button again. The permissions
+    // phase upstream solved this with a 2s poll; ported wholesale, scoped to
+    // the blocked state so it costs nothing on the ordinary path.
+    .task(id: cannotHear) {
+      guard cannotHear else { return }
+      while !Task.isCancelled {
+        try? await Task.sleep(for: .seconds(2))
+        guard !Task.isCancelled else { return }
+        permissions.refreshAccessibilityStatus()
+        viewModel.applyPracticePosture(
+          micGranted: permissions.hasMicrophonePermission,
+          accessibilityGranted: permissions.accessibilityGranted)
+        if !cannotHear { return }
+      }
+    }
     .onChange(of: live.isDictationActive) { _, active in
       if active {
         viewModel.practiceTakeStarted()

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/WarmingScreen.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/WarmingScreen.swift
@@ -93,7 +93,14 @@ struct WarmingScreenV2: View {
         // Visible from the first frame, never behind a delay or a confirm
         // (plan D4). A gate nobody can leave would be a worse product than the
         // cold press it exists to prevent.
-        Text("In a hurry? Skip ahead")
+        //
+        // The wording is the SIXTH site on this screen that has to answer the
+        // failure case, and the only one neither review round named — found by
+        // enumerating the class rather than by a third round. "In a hurry?"
+        // is true of someone impatient with a working wait and false of
+        // someone the engine has just failed; offering it to them reads as
+        // blaming them for being in a rush.
+        Text(failureMessage == nil ? "In a hurry? Skip ahead" : "Skip and finish setup")
           .font(.obCaption)
           .foregroundStyle(Color.obAccent)
       }

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/WarmingScreen.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/WarmingScreen.swift
@@ -73,14 +73,21 @@ struct WarmingScreenV2: View {
 
       Spacer()
 
-      Text("This usually takes a moment. Nothing else is needed from you.")
-        .font(.obCaption)
-        .foregroundStyle(Color.obTextSecondary)
-        .multilineTextAlignment(.center)
-        .fixedSize(horizontal: false, vertical: true)
-        .frame(maxWidth: .infinity)
-        .padding(14)
-        .background(Color.obSurface, in: RoundedRectangle(cornerRadius: 12))
+      // Local Codex r2: on the failure panel this caption said nothing else was
+      // needed while the panel beside it asked for a retry or a skip — two
+      // instructions, one of them wrong, at the moment the person is stuck.
+      // The panel already carries the honest instruction, so this simply does
+      // not render there rather than repeating it in different words.
+      if failureMessage == nil {
+        Text("This usually takes a moment. Nothing else is needed from you.")
+          .font(.obCaption)
+          .foregroundStyle(Color.obTextSecondary)
+          .multilineTextAlignment(.center)
+          .fixedSize(horizontal: false, vertical: true)
+          .frame(maxWidth: .infinity)
+          .padding(14)
+          .background(Color.obSurface, in: RoundedRectangle(cornerRadius: 12))
+      }
 
       Button(action: onSkip) {
         // Visible from the first frame, never behind a delay or a confirm

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/WarmingScreen.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/WarmingScreen.swift
@@ -1,0 +1,199 @@
+import EnviousWisprServices
+import SwiftUI
+
+// MARK: - Screen 4: Engine warm gate (#2196)
+
+/// The beat between picking a shortcut and leaving setup. It does not open
+/// until the speech engine reports ready.
+///
+/// Why it exists: a press taken before readiness is REFUSED and mints no
+/// session (`RecordingStarter.swift:292-297`, `ColdPressGuard`), so a brand new
+/// person's very first press would appear to do nothing and would need a second
+/// one. Rather than explain that after the fact, this screen makes it
+/// unreachable.
+///
+/// Readiness is not owned here. The gate is a second CALLER of
+/// `DictationRuntime.ensureActiveEngineWarmForOnboarding()` — the same entry the
+/// setup checklist already awaits, idempotent and single-flighted, so asking
+/// again when the engine is already warm returns `.ready` immediately. No new
+/// flag, no second authority.
+///
+/// The usual case is therefore a sub-second beat. There is deliberately no
+/// percentage bar: the progress file is written only while a model load is
+/// actually running, so on the overwhelmingly common already-warm path a bar
+/// would render either a stale value from the checklist or an empty one, and
+/// both are a claim the screen cannot back.
+struct WarmingScreenV2: View {
+  var viewModel: OnboardingV2ViewModel
+
+  /// Fired once readiness has genuinely landed.
+  let onReady: () -> Void
+
+  /// Fired when the person chooses not to wait. A destination distinct from
+  /// `onReady` by construction: a skipped gate has proven nothing about the
+  /// engine, so a caller must stay free to route the two differently.
+  let onSkip: () -> Void
+
+  @Environment(PermissionsService.self) private var permissions
+
+  private var failureMessage: String? {
+    if case .failed(let message) = viewModel.warmingOutcome { return message }
+    return nil
+  }
+
+  var body: some View {
+    VStack(spacing: 0) {
+      RainbowLipsView(animationState: viewModel.lipsState, size: 122)
+      .padding(.bottom, 18)
+
+      Text(failureMessage == nil ? "Warming up" : "Nearly there")
+        .font(.system(size: 28, weight: .heavy, design: .rounded))
+        .foregroundStyle(Color.obTextPrimary)
+        .kerning(-0.4)
+        .padding(.bottom, 6)
+
+      Text(
+        failureMessage == nil
+          ? "Getting the speech engine ready\nso your first go is instant."
+          : "The speech engine did not finish waking up."
+      )
+      .font(.obBody)
+      .foregroundStyle(Color.obTextSecondary)
+      .multilineTextAlignment(.center)
+      .padding(.bottom, 24)
+
+      if let failureMessage {
+        failurePanel(failureMessage)
+      } else {
+        activityRow
+      }
+
+      checklist
+        .padding(.top, 24)
+
+      Spacer()
+
+      Text("This usually takes a moment. Nothing else is needed from you.")
+        .font(.obCaption)
+        .foregroundStyle(Color.obTextSecondary)
+        .multilineTextAlignment(.center)
+        .fixedSize(horizontal: false, vertical: true)
+        .frame(maxWidth: .infinity)
+        .padding(14)
+        .background(Color.obSurface, in: RoundedRectangle(cornerRadius: 12))
+
+      Button(action: onSkip) {
+        // Visible from the first frame, never behind a delay or a confirm
+        // (plan D4). A gate nobody can leave would be a worse product than the
+        // cold press it exists to prevent.
+        Text("In a hurry? Skip ahead")
+          .font(.obCaption)
+          .foregroundStyle(Color.obAccent)
+      }
+      .buttonStyle(.plain)
+      .padding(.top, 14)
+    }
+    // The subject reports its own outcome; nothing here infers readiness from
+    // elapsed time (testing-philosophy.md RULE: never-guess-when-the-subject-
+    // is-finished). The `onAppear` arm is not redundant with `onChange`: the
+    // parent's `.task` and this view's appearance are not ordered against each
+    // other, so an outcome that lands before the observer is installed would be
+    // a change `onChange` never sees, and the gate would hold forever. They
+    // cannot both fire for one transition, because `onChange` only sees a
+    // SUBSEQUENT change.
+    .onAppear { if viewModel.warmingOutcome == .ready { onReady() } }
+    .onChange(of: viewModel.warmingOutcome) { _, outcome in
+      if outcome == .ready { onReady() }
+    }
+    .animation(.easeInOut(duration: 0.3), value: viewModel.warmingOutcome)
+  }
+
+  private var activityRow: some View {
+    HStack(spacing: 9) {
+      ProgressView()
+        .progressViewStyle(.circular)
+        .controlSize(.small)
+      Text("Loading the speech model")
+        .font(.obLabel)
+        .foregroundStyle(Color.obTextSecondary)
+    }
+  }
+
+  private func failurePanel(_ message: String) -> some View {
+    VStack(spacing: 12) {
+      Text(message)
+        .font(.obCaption)
+        .foregroundStyle(Color.obTextSecondary)
+        .multilineTextAlignment(.center)
+        .fixedSize(horizontal: false, vertical: true)
+
+      Button(action: viewModel.retryWarming) {
+        Text("TRY AGAIN")
+          .font(.system(size: 14, weight: .heavy))
+          .kerning(0.3)
+          .foregroundStyle(.white)
+          .frame(maxWidth: 260)
+          .padding(.vertical, 11)
+          .background(Color.obButtonFill, in: RoundedRectangle(cornerRadius: 11))
+      }
+      .buttonStyle(.plain)
+      .keyboardShortcut(.defaultAction)
+    }
+    .padding(14)
+    .background(Color.obErrorSoft, in: RoundedRectangle(cornerRadius: 12))
+    .overlay(
+      RoundedRectangle(cornerRadius: 12)
+        .strokeBorder(Color.obError.opacity(0.25), lineWidth: 1)
+    )
+  }
+
+  private var checklist: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      WarmingChecklistRow(
+        title: "Microphone ready",
+        state: permissions.hasMicrophonePermission ? .done : .pending)
+      WarmingChecklistRow(title: "Your shortcut is set", state: .done)
+      WarmingChecklistRow(
+        title: "Speech engine",
+        state: {
+          switch viewModel.warmingOutcome {
+          case .ready: return .done
+          case .failed: return .pending
+          case .waiting: return .working
+          }
+        }())
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+}
+
+private struct WarmingChecklistRow: View {
+  enum Mark { case done, working, pending }
+
+  let title: String
+  let state: Mark
+
+  var body: some View {
+    HStack(spacing: 10) {
+      switch state {
+      case .done:
+        Image(systemName: "checkmark.circle.fill")
+          .font(.system(size: 17))
+          .foregroundStyle(Color.obSuccess)
+      case .working:
+        ProgressView()
+          .progressViewStyle(.circular)
+          .controlSize(.small)
+          .frame(width: 17, height: 17)
+      case .pending:
+        Image(systemName: "circle")
+          .font(.system(size: 17))
+          .foregroundStyle(Color.obTextTertiary.opacity(0.5))
+      }
+      Text(title)
+        .font(.obLabel)
+        .foregroundStyle(state == .done ? Color.obTextSecondary : Color.obTextTertiary)
+    }
+    .accessibilityElement(children: .combine)
+  }
+}

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/WarmingScreen.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/WarmingScreen.swift
@@ -101,6 +101,21 @@ struct WarmingScreenV2: View {
     // a change `onChange` never sees, and the gate would hold forever. They
     // cannot both fire for one transition, because `onChange` only sees a
     // SUBSEQUENT change.
+    //
+    // Local Codex review raised a third ordering: the window closed mid-warm-up
+    // (the owned task survives, deliberately), the outcome landing with nobody
+    // watching, and a reopen that skips `onAppear` leaving nothing to fire.
+    // WHAT WAS CHECKED: onboarding is a singleton `Window(id: "onboarding")`
+    // scene (`EnviousWisprApp.swift:44`), not a `WindowGroup`, and the evidence
+    // the finding itself cites — that a reopen keeps the view model and skips
+    // `onAppear` (`OnboardingProgress.swift:40-44`) — is evidence the root view
+    // holding that `@State` is RETAINED, which retains this subtree and its
+    // `onChange` with it. The finding needs the view discarded and the view
+    // model kept at once, and one `@State` cannot outlive its own view.
+    // WHAT IS NOT ESTABLISHED: whether SwiftUI re-evaluates a dismissed
+    // window's body immediately or defers to reopen. Either is correct here;
+    // only "never", which would mean discarding a pending change on a retained
+    // view, would strand the gate, and nothing observed says it does that.
     .onAppear { if viewModel.warmingOutcome == .ready { onReady() } }
     .onChange(of: viewModel.warmingOutcome) { _, outcome in
       if outcome == .ready { onReady() }

--- a/Tests/EnviousWisprTests/App/OnboardingWarmingGateTests.swift
+++ b/Tests/EnviousWisprTests/App/OnboardingWarmingGateTests.swift
@@ -1,0 +1,343 @@
+import EnviousWisprCore
+import EnviousWisprPipeline
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+
+#if DEBUG
+
+  /// #2196 chunk 1 — the engine warm gate.
+  ///
+  /// When these fail, a brand new person's very first press lands on a cold
+  /// engine: `RecordingStarter.swift:292-297` refuses a press taken before
+  /// readiness and mints no session, so the press appears to do nothing and
+  /// needs a second one. The gate's entire job is to make that unreachable, so
+  /// every case here asks the same question — can the gate open on anything
+  /// other than the engine itself saying ready.
+  @MainActor
+  @Suite("Onboarding engine warm gate", .tags(.productOutcome), .serialized)
+  struct OnboardingWarmingGateTests {
+
+    @MainActor
+    private final class Counter { var value = 0 }
+
+    /// A view model parked on the gate, as the Ready button leaves it.
+    private func makeGatedViewModel() -> OnboardingV2ViewModel {
+      let vm = OnboardingV2ViewModel()
+      vm.currentScreen = .warmingUp
+      return vm
+    }
+
+    /// Let the kicked task reach its first suspension point.
+    private func settle() async {
+      for _ in 0..<8 { await Task.yield() }
+    }
+
+    @Test("the gate stays shut while the warm-up is still running")
+    func gateHoldsUntilTheEngineAnswers() async {
+      let vm = makeGatedViewModel()
+      // Signal-gated, never timed: the warm-up suspends until this test
+      // releases it, so "still running" is a state the test creates rather
+      // than one it waits out.
+      let (gate, gateCont) = AsyncStream.makeStream(of: Void.self)
+
+      vm.kickWarmingIfNeeded(
+        warmUp: {
+          var it = gate.makeAsyncIterator()
+          _ = await it.next()
+          return .ready
+        }, displayFloor: 0)
+      let task = vm.warmingTask
+      await settle()
+
+      #expect(vm.warmingOutcome == .waiting, "the gate opened before the engine answered")
+
+      gateCont.yield(())
+      gateCont.finish()
+      await task?.value
+
+      #expect(vm.warmingOutcome == .ready)
+    }
+
+    @Test("a failed warm-up never opens the gate")
+    func failureNeverOpensTheGate() async {
+      let vm = makeGatedViewModel()
+      struct Boom: Error {}
+
+      vm.kickWarmingIfNeeded(warmUp: { .failed(Boom()) }, displayFloor: 0)
+      await vm.warmingTask?.value
+
+      #expect(vm.warmingOutcome != .ready)
+      #expect(vm.warmingOutcome == .failed(OnboardingV2ViewModel.warmingFailureCopy))
+    }
+
+    /// A `.cancelled` can only arrive from a Cancel pressed on the CHECKLIST
+    /// that raced the gate's own single-flighted call. The engine is not ready,
+    /// so the gate must treat it exactly like a failure rather than waving it
+    /// through as "the user chose this".
+    @Test("a cancelled warm-up never opens the gate")
+    func cancellationNeverOpensTheGate() async {
+      let vm = makeGatedViewModel()
+
+      vm.kickWarmingIfNeeded(warmUp: { .cancelled }, displayFloor: 0)
+      await vm.warmingTask?.value
+
+      #expect(vm.warmingOutcome != .ready)
+    }
+
+    @Test("retry re-arms the gate and a second attempt can open it")
+    func retryReArms() async {
+      let vm = makeGatedViewModel()
+      struct Boom: Error {}
+      let calls = Counter()
+
+      vm.kickWarmingIfNeeded(
+        warmUp: {
+          calls.value += 1
+          return calls.value == 1 ? .failed(Boom()) : .ready
+        }, displayFloor: 0)
+      await vm.warmingTask?.value
+      #expect(vm.warmingOutcome != .ready)
+
+      vm.retryWarming()
+      #expect(vm.warmingOutcome == .waiting)
+      #expect(vm.warmingRetryCount == 1)
+
+      vm.kickWarmingIfNeeded(
+        warmUp: {
+          calls.value += 1
+          return calls.value == 1 ? .failed(Boom()) : .ready
+        }, displayFloor: 0)
+      await vm.warmingTask?.value
+
+      #expect(vm.warmingOutcome == .ready)
+      #expect(calls.value == 2)
+    }
+
+    @Test("a re-kick while an attempt is live is a no-op (window churn)")
+    func reKickIsSingleFlight() async {
+      let vm = makeGatedViewModel()
+      let calls = Counter()
+      let (gate, gateCont) = AsyncStream.makeStream(of: Void.self)
+      let warmUp: @MainActor () async -> EngineWarmupOutcome = {
+        calls.value += 1
+        var it = gate.makeAsyncIterator()
+        _ = await it.next()
+        return .ready
+      }
+
+      vm.kickWarmingIfNeeded(warmUp: warmUp, displayFloor: 0)
+      let first = vm.warmingTask
+      await settle()
+      vm.kickWarmingIfNeeded(warmUp: warmUp, displayFloor: 0)
+
+      #expect(calls.value == 1, "a re-kick started a second warm-up")
+
+      gateCont.yield(())
+      gateCont.finish()
+      await first?.value
+      #expect(vm.warmingOutcome == .ready)
+    }
+
+    @Test("the gate does not run from any other screen")
+    func doesNotKickOffScreen() async {
+      let vm = OnboardingV2ViewModel()
+      vm.currentScreen = .ready
+      let calls = Counter()
+
+      vm.kickWarmingIfNeeded(
+        warmUp: {
+          calls.value += 1
+          return .ready
+        }, displayFloor: 0)
+      await vm.warmingTask?.value
+
+      #expect(calls.value == 0)
+      #expect(vm.warmingOutcome == .waiting)
+    }
+
+    /// Found by self-review, and it survives a green suite because nothing
+    /// resets `warmingOutcome` when a visit ENDS: a reopened onboarding
+    /// inherits the last visit's `ready`, the gate's `onAppear` fires straight
+    /// through, and the engine is never asked — on a machine where it may have
+    /// been unloaded since.
+    @Test("a reopened onboarding cannot inherit the last visit's ready")
+    func reopeningReArmsTheGate() async {
+      let vm = makeGatedViewModel()
+      vm.kickWarmingIfNeeded(warmUp: { .ready }, displayFloor: 0)
+      await vm.warmingTask?.value
+      #expect(vm.warmingOutcome == .ready)
+
+      // Setup finished and was reopened: recovery parks it back on Ready, and
+      // the person presses the button again.
+      vm.currentScreen = .ready
+      vm.beginWarmingGate()
+
+      #expect(vm.currentScreen == .warmingUp)
+      #expect(
+        vm.warmingOutcome == .waiting,
+        "the gate opened on a stale answer from a previous visit")
+
+      let calls = Counter()
+      vm.kickWarmingIfNeeded(
+        warmUp: {
+          calls.value += 1
+          return .ready
+        }, displayFloor: 0)
+      await vm.warmingTask?.value
+      #expect(calls.value == 1, "the second visit never asked the engine")
+    }
+
+    /// The skip does NOT cancel the shared warm-up — that load is
+    /// single-flighted, so cancelling it to leave a screen would cancel it for
+    /// every other waiter. The consequence this locks: the abandoned attempt
+    /// still resolves, and it must not then open a gate nobody is standing at.
+    @Test("skipping leaves the in-flight warm-up alone and its late answer opens nothing")
+    func skipDoesNotCancelAndLateReadyIsInert() async {
+      let vm = makeGatedViewModel()
+      let calls = Counter()
+      let (gate, gateCont) = AsyncStream.makeStream(of: Void.self)
+
+      vm.kickWarmingIfNeeded(
+        warmUp: {
+          calls.value += 1
+          var it = gate.makeAsyncIterator()
+          _ = await it.next()
+          return .ready
+        }, displayFloor: 0)
+      let task = vm.warmingTask
+      await settle()
+
+      vm.skipWarmingGate()
+      gateCont.yield(())
+      gateCont.finish()
+      await task?.value
+
+      #expect(calls.value == 1, "the warm-up never ran")
+      #expect(
+        vm.warmingOutcome == .waiting,
+        "a skipped gate opened later on an answer nobody was waiting for")
+    }
+  }
+
+  /// #2196 chunk 1 — what the gate reports. When these fail the onboarding
+  /// funnel lies about where people stop: `engine_warm_gate` is the step that
+  /// separates "waited and got a warm engine" from "did not wait".
+  @MainActor
+  @Suite("Onboarding engine warm gate telemetry", .tags(.observabilityContract), .serialized)
+  struct OnboardingWarmingGateTelemetryTests {
+
+    final class Events: @unchecked Sendable {
+      private let lock = NSLock()
+      private var stored: [CapturedTelemetryEvent] = []
+      func add(_ e: CapturedTelemetryEvent) { lock.withLock { stored.append(e) } }
+      var all: [CapturedTelemetryEvent] { lock.withLock { stored } }
+      /// Only this step's rows, so an unrelated suite emitting onto the shared
+      /// hook cannot be read as one of ours.
+      func gateRows(_ name: String) -> [CapturedTelemetryEvent] {
+        all.filter { $0.name == name && $0.stringProps["step"] == "engine_warm_gate" }
+      }
+    }
+
+    private func makeGatedViewModel() -> OnboardingV2ViewModel {
+      let vm = OnboardingV2ViewModel()
+      vm.currentScreen = .warmingUp
+      return vm
+    }
+
+    private func withHook<T>(_ body: (Events) async throws -> T) async rethrows -> T {
+      let events = Events()
+      TelemetryService.shared.testEventHook = { @Sendable e in events.add(e) }
+      defer { TelemetryService.shared.testEventHook = nil }
+      return try await body(events)
+    }
+
+    @Test("a warmed gate completes the step once, with a duration")
+    func readyCompletesOnce() async {
+      await withHook { events in
+        let vm = makeGatedViewModel()
+        vm.kickWarmingIfNeeded(warmUp: { .ready }, displayFloor: 0)
+        await vm.warmingTask?.value
+
+        let rows = events.gateRows("onboarding.step_completed")
+        #expect(rows.count == 1)
+        #expect(rows.first?.stringProps["result"] == "ready")
+        // The already-warm case and a real wait are told apart by this, which
+        // is why the gate carries no separate already_ready result value.
+        #expect(rows.first?.stringProps["duration_seconds"] != nil)
+        #expect(events.gateRows("onboarding.step_blocked").isEmpty)
+      }
+    }
+
+    @Test("a failed warm-up blocks the step, and does not also complete it")
+    func failureBlocks() async {
+      await withHook { events in
+        struct Boom: Error {}
+        let vm = makeGatedViewModel()
+        vm.kickWarmingIfNeeded(warmUp: { .failed(Boom()) }, displayFloor: 0)
+        await vm.warmingTask?.value
+
+        let blocked = events.gateRows("onboarding.step_blocked")
+        #expect(blocked.count == 1)
+        #expect(blocked.first?.stringProps["reason"] == "warmup_failed")
+        #expect(events.gateRows("onboarding.step_completed").isEmpty)
+      }
+    }
+
+    @Test("a checklist cancel that races the gate is reported as its own reason")
+    func cancellationBlocksWithItsOwnReason() async {
+      await withHook { events in
+        let vm = makeGatedViewModel()
+        vm.kickWarmingIfNeeded(warmUp: { .cancelled }, displayFloor: 0)
+        await vm.warmingTask?.value
+
+        let blocked = events.gateRows("onboarding.step_blocked")
+        #expect(blocked.count == 1)
+        #expect(blocked.first?.stringProps["reason"] == "warmup_cancelled")
+      }
+    }
+
+    /// The one-shot latch, stated as a funnel property: one visit to the gate
+    /// produces exactly one row. Without it a skipped gate whose abandoned
+    /// warm-up later resolves would report BOTH skipped and ready, and the
+    /// share-who-skipped number would be quietly wrong in the flattering
+    /// direction.
+    @Test("skip then a late ready reports exactly one row, and it is the skip")
+    func skipReportsOnce() async {
+      await withHook { events in
+        let vm = makeGatedViewModel()
+        let (gate, gateCont) = AsyncStream.makeStream(of: Void.self)
+        vm.kickWarmingIfNeeded(
+          warmUp: {
+            var it = gate.makeAsyncIterator()
+            _ = await it.next()
+            return .ready
+          }, displayFloor: 0)
+        let task = vm.warmingTask
+        for _ in 0..<8 { await Task.yield() }
+
+        vm.skipWarmingGate()
+        gateCont.yield(())
+        gateCont.finish()
+        await task?.value
+
+        let rows = events.gateRows("onboarding.step_completed")
+        #expect(rows.count == 1)
+        #expect(rows.first?.stringProps["result"] == "skipped")
+      }
+    }
+
+    @Test("a second skip press cannot report twice")
+    func doubleSkipReportsOnce() async {
+      await withHook { events in
+        let vm = makeGatedViewModel()
+        vm.skipWarmingGate()
+        vm.skipWarmingGate()
+        #expect(events.gateRows("onboarding.step_completed").count == 1)
+      }
+    }
+  }
+
+#endif  // DEBUG

--- a/Tests/EnviousWisprTests/App/OnboardingWarmingGateTests.swift
+++ b/Tests/EnviousWisprTests/App/OnboardingWarmingGateTests.swift
@@ -41,17 +41,17 @@ import Testing
   /// needs a second one. The gate's entire job is to make that unreachable, so
   /// every case here asks the same question — can the gate open on anything
   /// other than the engine itself saying ready.
-  /// #2196 chunk 1 — the engine warm gate.
+  /// #2196 — the onboarding practice step, all of it.
   ///
-  /// ONE serialized parent, because both children emit `engine_warm_gate` and
+  /// ONE serialized parent, because the children emit `engine_warm_gate` and
   /// capture it through the process-global `TelemetryService.shared.testEventHook`.
   /// `.serialized` orders tests WITHIN a suite; it says nothing about two
   /// SIBLING suites, so a sibling's events landed in this suite's capture and a
   /// count assertion read three completions where it expected one. Nesting is
   /// what actually orders them against each other (local Codex r3).
   @MainActor
-  @Suite("Onboarding engine warm gate", .serialized)
-  struct OnboardingWarmingGateSuite {
+  @Suite("Onboarding practice step", .serialized)
+  struct OnboardingPracticeStepSuite {
 
     @MainActor
     @Suite("behaviour", .tags(.productOutcome), .timeLimit(.minutes(1)))
@@ -471,6 +471,89 @@ import Testing
           vm.skipWarmingGate()
           #expect(events.gateRows("onboarding.step_completed").count == 1)
         }
+      }
+    }
+
+
+    /// #2196 chunk 2 — the box.
+    ///
+    /// When these fail a new person reaches the end of setup without ever
+    /// seeing the product work, which is the whole defect #2196 exists to fix:
+    /// 51 people in 90 days whose entire experience was the clipboard notice.
+    /// The box's contents are the SUBJECT's own signal — the paste cascade
+    /// writes them — so nothing here waits on a clock.
+    @MainActor
+    @Suite("the box", .tags(.productOutcome), .timeLimit(.minutes(1)))
+    struct OnboardingPracticeBoxTests {
+
+      private func makePracticeViewModel() -> OnboardingV2ViewModel {
+        let vm = OnboardingV2ViewModel()
+        vm.beginPractice()
+        return vm
+      }
+
+      @Test("words landing in the box are what unlocks the end of setup")
+      func wordsInTheBoxUnlockFinish() {
+        let vm = makePracticeViewModel()
+        #expect(vm.practiceSucceeded == false)
+
+        // What the cascade does when it finds a text target: it types.
+        vm.setPracticeText("tell grandma I love her and will call Sunday after church")
+
+        #expect(vm.practiceSucceeded)
+      }
+
+      /// The screen must not congratulate someone for a stray newline. `no_speech`
+      /// is 20.3% of real first takes, so an empty-ish box is the COMMON case and
+      /// treating it as success would tell a fifth of new people the product
+      /// worked when they never heard from it.
+      @Test("whitespace alone is not a successful dictation")
+      func whitespaceIsNotSuccess() {
+        let vm = makePracticeViewModel()
+        vm.setPracticeText("   \n  \t ")
+        #expect(vm.practiceSucceeded == false)
+      }
+
+      /// Deliberately sticky. Someone who dictates and then selects-all-deletes
+      /// has still SEEN the product work; taking FINISH SETUP away at that moment
+      /// would be the screen punishing them for tidying up.
+      @Test("clearing the box does not take the finish button away again")
+      func successIsStickyAcrossAClear() {
+        let vm = makePracticeViewModel()
+        vm.setPracticeText("running 15 min late got stuck on the client call")
+        #expect(vm.practiceSucceeded)
+
+        vm.setPracticeText("")
+
+        #expect(vm.practiceText.isEmpty)
+        #expect(vm.practiceSucceeded, "a cleared box revoked a success that had already happened")
+      }
+
+      /// Same reason `beginWarmingGate` resets: a reopened onboarding must not
+      /// inherit a previous visit's success and offer FINISH SETUP to someone who
+      /// has not dictated in THIS one.
+      @Test("a reopened onboarding cannot inherit the last visit's dictation")
+      func reopeningClearsTheBox() {
+        let vm = makePracticeViewModel()
+        vm.setPracticeText("hey Mike pick up Emma from school today")
+        #expect(vm.practiceSucceeded)
+
+        vm.beginPractice()
+
+        #expect(vm.currentScreen == .tryItOut)
+        #expect(vm.practiceText.isEmpty)
+        #expect(vm.practiceSucceeded == false, "the box opened already believing it had succeeded")
+      }
+
+      /// The gate's ready exit opens the box; it no longer ends setup. If this
+      /// regresses, the warm gate silently becomes the last screen again and the
+      /// entire feature is absent while every other test still passes.
+      @Test("a warmed gate opens the box rather than ending setup")
+      func warmGateOpensTheBox() {
+        let vm = OnboardingV2ViewModel()
+        vm.currentScreen = .warmingUp
+        vm.beginPractice()
+        #expect(vm.currentScreen == .tryItOut)
       }
     }
 

--- a/Tests/EnviousWisprTests/App/OnboardingWarmingGateTests.swift
+++ b/Tests/EnviousWisprTests/App/OnboardingWarmingGateTests.swift
@@ -14,7 +14,7 @@ import Testing
   /// negative assertion passes having exercised nothing.
   @MainActor
   fileprivate final class EntrySignal {
-    private var waiters: [CheckedContinuation<Void, Never>] = []
+    private var waiters: [(UUID, CheckedContinuation<Bool, Never>)] = []
     private var fired = false
 
     /// Called from inside the warm-up, before it suspends.
@@ -23,24 +23,37 @@ import Testing
       fired = true
       let resumable = waiters
       waiters = []
-      for w in resumable { w.resume() }
+      for w in resumable { w.1.resume(returning: true) }
     }
 
-    /// Returns once the warm-up has actually been entered.
-    func awaitEntry() async {
-      if fired { return }
-      await withCheckedContinuation { waiters.append($0) }
+    /// Returns once the warm-up has actually been entered, or gives up after
+    /// `timeout` so a regression that never invokes the warm-up produces a
+    /// FAILING assertion instead of a wedged run. Cancellation does not resume
+    /// a checked continuation, so the suite time limit alone would leave the
+    /// process hung (local Codex r3; test-timing.md — write the deadline when
+    /// you write the waiter).
+    /// - Returns: true if the subject entered, false if the deadline won.
+    func awaitEntry(timeout: Duration = .seconds(5)) async -> Bool {
+      if fired { return true }
+      let id = UUID()
+      return await withCheckedContinuation { continuation in
+        waiters.append((id, continuation))
+        Task { [weak self] in
+          try? await Task.sleep(for: timeout)
+          await self?.expire(id)
+        }
+      }
+    }
+
+    /// Resumes a still-parked waiter with `false`. Removed first, so the real
+    /// signal arriving later cannot resume it a second time.
+    private func expire(_ id: UUID) {
+      guard let index = waiters.firstIndex(where: { $0.0 == id }) else { return }
+      let waiter = waiters.remove(at: index)
+      waiter.1.resume(returning: false)
     }
   }
 
-  /// #2196 chunk 1 — the engine warm gate.
-  ///
-  /// When these fail, a brand new person's very first press lands on a cold
-  /// engine: `RecordingStarter.swift:292-297` refuses a press taken before
-  /// readiness and mints no session, so the press appears to do nothing and
-  /// needs a second one. The gate's entire job is to make that unreachable, so
-  /// every case here asks the same question — can the gate open on anything
-  /// other than the engine itself saying ready.
   /// #2196 — the onboarding practice step, all of it.
   ///
   /// ONE serialized parent, because the children emit `engine_warm_gate` and
@@ -85,7 +98,7 @@ import Testing
           }, displayFloor: 0)
         let task = vm.warmingTask
         // The subject says it is running; nothing here guesses that it is.
-        await entered.awaitEntry()
+        #expect(await entered.awaitEntry(), "the warm-up was never entered")
 
         #expect(vm.warmingOutcome == .waiting, "the gate opened before the engine answered")
 
@@ -168,7 +181,7 @@ import Testing
         vm.kickWarmingIfNeeded(warmUp: warmUp, displayFloor: 0)
         let first = vm.warmingTask
         // Without this the re-kick could land before the first attempt ran.
-        await entered.awaitEntry()
+        #expect(await entered.awaitEntry(), "the warm-up was never entered")
         vm.kickWarmingIfNeeded(warmUp: warmUp, displayFloor: 0)
 
         // Found by the mutation battery, not by review: dropping the
@@ -261,7 +274,7 @@ import Testing
             return .ready
           }, displayFloor: 0)
         let task = vm.warmingTask
-        await entered.awaitEntry()
+        #expect(await entered.awaitEntry(), "the warm-up was never entered")
 
         vm.skipWarmingGate()
         gateCont.yield(())
@@ -371,7 +384,7 @@ import Testing
               return .ready
             }, displayFloor: 0)
           let task = vm.warmingTask
-          await entered.awaitEntry()
+          #expect(await entered.awaitEntry(), "the warm-up was never entered")
 
           vm.skipWarmingGate()
           gateCont.yield(())
@@ -426,7 +439,7 @@ import Testing
               return .failed(Boom())
             }, displayFloor: 0)
           let task = vm.warmingTask
-          await entered.awaitEntry()
+          #expect(await entered.awaitEntry(), "the warm-up was never entered")
 
           vm.skipWarmingGate()
           gateCont.yield(())

--- a/Tests/EnviousWisprTests/App/OnboardingWarmingGateTests.swift
+++ b/Tests/EnviousWisprTests/App/OnboardingWarmingGateTests.swift
@@ -41,310 +41,220 @@ import Testing
   /// needs a second one. The gate's entire job is to make that unreachable, so
   /// every case here asks the same question — can the gate open on anything
   /// other than the engine itself saying ready.
+  /// #2196 chunk 1 — the engine warm gate.
+  ///
+  /// ONE serialized parent, because both children emit `engine_warm_gate` and
+  /// capture it through the process-global `TelemetryService.shared.testEventHook`.
+  /// `.serialized` orders tests WITHIN a suite; it says nothing about two
+  /// SIBLING suites, so a sibling's events landed in this suite's capture and a
+  /// count assertion read three completions where it expected one. Nesting is
+  /// what actually orders them against each other (local Codex r3).
   @MainActor
-  @Suite(
-    "Onboarding engine warm gate", .tags(.productOutcome), .serialized,
-    .timeLimit(.minutes(1)))
-  struct OnboardingWarmingGateTests {
+  @Suite("Onboarding engine warm gate", .serialized)
+  struct OnboardingWarmingGateSuite {
 
     @MainActor
-    private final class Counter { var value = 0 }
+    @Suite("behaviour", .tags(.productOutcome), .timeLimit(.minutes(1)))
+    struct OnboardingWarmingGateTests {
 
-    /// A view model parked on the gate, as the Ready button leaves it.
-    private func makeGatedViewModel() -> OnboardingV2ViewModel {
-      let vm = OnboardingV2ViewModel()
-      vm.currentScreen = .warmingUp
-      return vm
-    }
+      @MainActor
+      private final class Counter { var value = 0 }
 
-    @Test("the gate stays shut while the warm-up is still running")
-    func gateHoldsUntilTheEngineAnswers() async {
-      let vm = makeGatedViewModel()
-      // Signal-gated, never timed: the warm-up suspends until this test
-      // releases it, so "still running" is a state the test creates rather
-      // than one it waits out.
-      let (gate, gateCont) = AsyncStream.makeStream(of: Void.self)
-
-      let entered = EntrySignal()
-      vm.kickWarmingIfNeeded(
-        warmUp: {
-          entered.fire()
-          var it = gate.makeAsyncIterator()
-          _ = await it.next()
-          return .ready
-        }, displayFloor: 0)
-      let task = vm.warmingTask
-      // The subject says it is running; nothing here guesses that it is.
-      await entered.awaitEntry()
-
-      #expect(vm.warmingOutcome == .waiting, "the gate opened before the engine answered")
-
-      gateCont.yield(())
-      gateCont.finish()
-      await task?.value
-
-      #expect(vm.warmingOutcome == .ready)
-    }
-
-    @Test("a failed warm-up never opens the gate")
-    func failureNeverOpensTheGate() async {
-      let vm = makeGatedViewModel()
-      struct Boom: Error {}
-
-      vm.kickWarmingIfNeeded(warmUp: { .failed(Boom()) }, displayFloor: 0)
-      await vm.warmingTask?.value
-
-      #expect(vm.warmingOutcome != .ready)
-      #expect(vm.warmingOutcome == .failed(OnboardingV2ViewModel.warmingFailureCopy))
-    }
-
-    /// A `.cancelled` can only arrive from a Cancel pressed on the CHECKLIST
-    /// that raced the gate's own single-flighted call. The engine is not ready,
-    /// so the gate must treat it exactly like a failure rather than waving it
-    /// through as "the user chose this".
-    @Test("a cancelled warm-up never opens the gate")
-    func cancellationNeverOpensTheGate() async {
-      let vm = makeGatedViewModel()
-
-      vm.kickWarmingIfNeeded(warmUp: { .cancelled }, displayFloor: 0)
-      await vm.warmingTask?.value
-
-      #expect(vm.warmingOutcome != .ready)
-    }
-
-    @Test("retry re-arms the gate and a second attempt can open it")
-    func retryReArms() async {
-      let vm = makeGatedViewModel()
-      struct Boom: Error {}
-      let calls = Counter()
-
-      vm.kickWarmingIfNeeded(
-        warmUp: {
-          calls.value += 1
-          return calls.value == 1 ? .failed(Boom()) : .ready
-        }, displayFloor: 0)
-      await vm.warmingTask?.value
-      #expect(vm.warmingOutcome != .ready)
-
-      vm.retryWarming()
-      #expect(vm.warmingOutcome == .waiting)
-      #expect(vm.warmingRetryCount == 1)
-
-      vm.kickWarmingIfNeeded(
-        warmUp: {
-          calls.value += 1
-          return calls.value == 1 ? .failed(Boom()) : .ready
-        }, displayFloor: 0)
-      await vm.warmingTask?.value
-
-      #expect(vm.warmingOutcome == .ready)
-      #expect(calls.value == 2)
-    }
-
-    @Test("a re-kick while an attempt is live is a no-op (window churn)")
-    func reKickIsSingleFlight() async {
-      let vm = makeGatedViewModel()
-      let calls = Counter()
-      let (gate, gateCont) = AsyncStream.makeStream(of: Void.self)
-      let entered = EntrySignal()
-      let warmUp: @MainActor () async -> EngineWarmupOutcome = {
-        calls.value += 1
-        entered.fire()
-        var it = gate.makeAsyncIterator()
-        _ = await it.next()
-        return .ready
+      /// A view model parked on the gate, as the Ready button leaves it.
+      private func makeGatedViewModel() -> OnboardingV2ViewModel {
+        let vm = OnboardingV2ViewModel()
+        vm.currentScreen = .warmingUp
+        return vm
       }
 
-      vm.kickWarmingIfNeeded(warmUp: warmUp, displayFloor: 0)
-      let first = vm.warmingTask
-      // Without this the re-kick could land before the first attempt ran, and a
-      // `calls.value == 1` read would pass having proven nothing.
-      await entered.awaitEntry()
-      vm.kickWarmingIfNeeded(warmUp: warmUp, displayFloor: 0)
-
-      #expect(calls.value == 1, "a re-kick started a second warm-up")
-
-      gateCont.yield(())
-      gateCont.finish()
-      await first?.value
-      #expect(vm.warmingOutcome == .ready)
-    }
-
-    @Test("the gate does not run from any other screen")
-    func doesNotKickOffScreen() async {
-      let vm = OnboardingV2ViewModel()
-      vm.currentScreen = .ready
-      let calls = Counter()
-
-      vm.kickWarmingIfNeeded(
-        warmUp: {
-          calls.value += 1
-          return .ready
-        }, displayFloor: 0)
-      await vm.warmingTask?.value
-
-      #expect(calls.value == 0)
-      #expect(vm.warmingOutcome == .waiting)
-    }
-
-    /// Found by self-review, and it survives a green suite because nothing
-    /// resets `warmingOutcome` when a visit ENDS: a reopened onboarding
-    /// inherits the last visit's `ready`, the gate's `onAppear` fires straight
-    /// through, and the engine is never asked — on a machine where it may have
-    /// been unloaded since.
-    @Test("a reopened onboarding cannot inherit the last visit's ready")
-    func reopeningReArmsTheGate() async {
-      let vm = makeGatedViewModel()
-      vm.kickWarmingIfNeeded(warmUp: { .ready }, displayFloor: 0)
-      await vm.warmingTask?.value
-      #expect(vm.warmingOutcome == .ready)
-
-      // Setup finished and was reopened: recovery parks it back on Ready, and
-      // the person presses the button again.
-      vm.currentScreen = .ready
-      vm.beginWarmingGate()
-
-      #expect(vm.currentScreen == .warmingUp)
-      #expect(
-        vm.warmingOutcome == .waiting,
-        "the gate opened on a stale answer from a previous visit")
-
-      let calls = Counter()
-      vm.kickWarmingIfNeeded(
-        warmUp: {
-          calls.value += 1
-          return .ready
-        }, displayFloor: 0)
-      await vm.warmingTask?.value
-      #expect(calls.value == 1, "the second visit never asked the engine")
-    }
-
-    /// The skip does NOT cancel the shared warm-up — that load is
-    /// single-flighted, so cancelling it to leave a screen would cancel it for
-    /// every other waiter. The consequence this locks: the abandoned attempt
-    /// still resolves, and it must not then open a gate nobody is standing at.
-    @Test("skipping leaves the in-flight warm-up alone and its late answer opens nothing")
-    func skipDoesNotCancelAndLateReadyIsInert() async {
-      let vm = makeGatedViewModel()
-      let calls = Counter()
-      let (gate, gateCont) = AsyncStream.makeStream(of: Void.self)
-
-      let entered = EntrySignal()
-      vm.kickWarmingIfNeeded(
-        warmUp: {
-          calls.value += 1
-          entered.fire()
-          var it = gate.makeAsyncIterator()
-          _ = await it.next()
-          return .ready
-        }, displayFloor: 0)
-      let task = vm.warmingTask
-      await entered.awaitEntry()
-
-      vm.skipWarmingGate()
-      gateCont.yield(())
-      gateCont.finish()
-      await task?.value
-
-      #expect(calls.value == 1, "the warm-up never ran")
-      #expect(
-        vm.warmingOutcome == .waiting,
-        "a skipped gate opened later on an answer nobody was waiting for")
-    }
-  }
-
-  /// #2196 chunk 1 — what the gate reports. When these fail the onboarding
-  /// funnel lies about where people stop: `engine_warm_gate` is the step that
-  /// separates "waited and got a warm engine" from "did not wait".
-  @MainActor
-  @Suite(
-    "Onboarding engine warm gate telemetry", .tags(.observabilityContract), .serialized,
-    .timeLimit(.minutes(1)))
-  struct OnboardingWarmingGateTelemetryTests {
-
-    final class Events: @unchecked Sendable {
-      private let lock = NSLock()
-      private var stored: [CapturedTelemetryEvent] = []
-      func add(_ e: CapturedTelemetryEvent) { lock.withLock { stored.append(e) } }
-      var all: [CapturedTelemetryEvent] { lock.withLock { stored } }
-      /// Only this step's rows, so an unrelated suite emitting onto the shared
-      /// hook cannot be read as one of ours.
-      func gateRows(_ name: String) -> [CapturedTelemetryEvent] {
-        all.filter { $0.name == name && $0.stringProps["step"] == "engine_warm_gate" }
-      }
-    }
-
-    private func makeGatedViewModel() -> OnboardingV2ViewModel {
-      let vm = OnboardingV2ViewModel()
-      vm.currentScreen = .warmingUp
-      return vm
-    }
-
-    private func withHook<T>(_ body: (Events) async throws -> T) async rethrows -> T {
-      let events = Events()
-      TelemetryService.shared.testEventHook = { @Sendable e in events.add(e) }
-      defer { TelemetryService.shared.testEventHook = nil }
-      return try await body(events)
-    }
-
-    @Test("a warmed gate completes the step once, with a duration")
-    func readyCompletesOnce() async {
-      await withHook { events in
+      @Test("the gate stays shut while the warm-up is still running")
+      func gateHoldsUntilTheEngineAnswers() async {
         let vm = makeGatedViewModel()
-        vm.kickWarmingIfNeeded(warmUp: { .ready }, displayFloor: 0)
-        await vm.warmingTask?.value
-
-        let rows = events.gateRows("onboarding.step_completed")
-        #expect(rows.count == 1)
-        #expect(rows.first?.stringProps["result"] == "ready")
-        // The already-warm case and a real wait are told apart by this, which
-        // is why the gate carries no separate already_ready result value.
-        #expect(rows.first?.stringProps["duration_seconds"] != nil)
-        #expect(events.gateRows("onboarding.step_blocked").isEmpty)
-      }
-    }
-
-    @Test("a failed warm-up blocks the step, and does not also complete it")
-    func failureBlocks() async {
-      await withHook { events in
-        struct Boom: Error {}
-        let vm = makeGatedViewModel()
-        vm.kickWarmingIfNeeded(warmUp: { .failed(Boom()) }, displayFloor: 0)
-        await vm.warmingTask?.value
-
-        let blocked = events.gateRows("onboarding.step_blocked")
-        #expect(blocked.count == 1)
-        #expect(blocked.first?.stringProps["reason"] == "warmup_failed")
-        #expect(events.gateRows("onboarding.step_completed").isEmpty)
-      }
-    }
-
-    @Test("a checklist cancel that races the gate is reported as its own reason")
-    func cancellationBlocksWithItsOwnReason() async {
-      await withHook { events in
-        let vm = makeGatedViewModel()
-        vm.kickWarmingIfNeeded(warmUp: { .cancelled }, displayFloor: 0)
-        await vm.warmingTask?.value
-
-        let blocked = events.gateRows("onboarding.step_blocked")
-        #expect(blocked.count == 1)
-        #expect(blocked.first?.stringProps["reason"] == "warmup_cancelled")
-      }
-    }
-
-    /// The one-shot latch, stated as a funnel property: one visit to the gate
-    /// produces exactly one row. Without it a skipped gate whose abandoned
-    /// warm-up later resolves would report BOTH skipped and ready, and the
-    /// share-who-skipped number would be quietly wrong in the flattering
-    /// direction.
-    @Test("skip then a late ready reports exactly one row, and it is the skip")
-    func skipReportsOnce() async {
-      await withHook { events in
-        let vm = makeGatedViewModel()
+        // Signal-gated, never timed: the warm-up suspends until this test
+        // releases it, so "still running" is a state the test creates rather
+        // than one it waits out.
         let (gate, gateCont) = AsyncStream.makeStream(of: Void.self)
+
         let entered = EntrySignal()
         vm.kickWarmingIfNeeded(
           warmUp: {
+            entered.fire()
+            var it = gate.makeAsyncIterator()
+            _ = await it.next()
+            return .ready
+          }, displayFloor: 0)
+        let task = vm.warmingTask
+        // The subject says it is running; nothing here guesses that it is.
+        await entered.awaitEntry()
+
+        #expect(vm.warmingOutcome == .waiting, "the gate opened before the engine answered")
+
+        gateCont.yield(())
+        gateCont.finish()
+        await task?.value
+
+        #expect(vm.warmingOutcome == .ready)
+      }
+
+      @Test("a failed warm-up never opens the gate")
+      func failureNeverOpensTheGate() async {
+        let vm = makeGatedViewModel()
+        struct Boom: Error {}
+
+        vm.kickWarmingIfNeeded(warmUp: { .failed(Boom()) }, displayFloor: 0)
+        await vm.warmingTask?.value
+
+        #expect(vm.warmingOutcome != .ready)
+        #expect(vm.warmingOutcome == .failed(OnboardingV2ViewModel.warmingFailureCopy))
+      }
+
+      /// A `.cancelled` can only arrive from a Cancel pressed on the CHECKLIST
+      /// that raced the gate's own single-flighted call. The engine is not ready,
+      /// so the gate must treat it exactly like a failure rather than waving it
+      /// through as "the user chose this".
+      @Test("a cancelled warm-up never opens the gate")
+      func cancellationNeverOpensTheGate() async {
+        let vm = makeGatedViewModel()
+
+        vm.kickWarmingIfNeeded(warmUp: { .cancelled }, displayFloor: 0)
+        await vm.warmingTask?.value
+
+        #expect(vm.warmingOutcome != .ready)
+      }
+
+      @Test("retry re-arms the gate and a second attempt can open it")
+      func retryReArms() async {
+        let vm = makeGatedViewModel()
+        struct Boom: Error {}
+        let calls = Counter()
+
+        vm.kickWarmingIfNeeded(
+          warmUp: {
+            calls.value += 1
+            return calls.value == 1 ? .failed(Boom()) : .ready
+          }, displayFloor: 0)
+        await vm.warmingTask?.value
+        #expect(vm.warmingOutcome != .ready)
+
+        vm.retryWarming()
+        #expect(vm.warmingOutcome == .waiting)
+        #expect(vm.warmingRetryCount == 1)
+
+        vm.kickWarmingIfNeeded(
+          warmUp: {
+            calls.value += 1
+            return calls.value == 1 ? .failed(Boom()) : .ready
+          }, displayFloor: 0)
+        await vm.warmingTask?.value
+
+        #expect(vm.warmingOutcome == .ready)
+        #expect(calls.value == 2)
+      }
+
+      @Test("a re-kick while an attempt is live is a no-op (window churn)")
+      func reKickIsSingleFlight() async {
+        let vm = makeGatedViewModel()
+        let calls = Counter()
+        let (gate, gateCont) = AsyncStream.makeStream(of: Void.self)
+        let entered = EntrySignal()
+        let warmUp: @MainActor () async -> EngineWarmupOutcome = {
+          calls.value += 1
+          entered.fire()
+          var it = gate.makeAsyncIterator()
+          _ = await it.next()
+          return .ready
+        }
+
+        vm.kickWarmingIfNeeded(warmUp: warmUp, displayFloor: 0)
+        let first = vm.warmingTask
+        // Without this the re-kick could land before the first attempt ran.
+        await entered.awaitEntry()
+        vm.kickWarmingIfNeeded(warmUp: warmUp, displayFloor: 0)
+
+        // Found by the mutation battery, not by review: dropping the
+        // single-flight guard left this test GREEN. A second `Task` does not
+        // begin executing at the moment it is created, so reading `calls.value`
+        // straight after the re-kick reads an instant at which the evidence
+        // cannot exist yet — the assertion could never have caught the thing it
+        // names. What IS decided synchronously is whether the live attempt was
+        // REPLACED, so assert that first.
+        #expect(
+          vm.warmingTask == first,
+          "a re-kick replaced the live attempt instead of standing down")
+
+        gateCont.yield(())
+        gateCont.finish()
+        await first?.value
+
+        // And the count, now read after the run has finished, so any second
+        // attempt has had its chance to execute.
+        #expect(calls.value == 1, "a re-kick started a second warm-up")
+        #expect(vm.warmingOutcome == .ready)
+      }
+
+      @Test("the gate does not run from any other screen")
+      func doesNotKickOffScreen() async {
+        let vm = OnboardingV2ViewModel()
+        vm.currentScreen = .ready
+        let calls = Counter()
+
+        vm.kickWarmingIfNeeded(
+          warmUp: {
+            calls.value += 1
+            return .ready
+          }, displayFloor: 0)
+        await vm.warmingTask?.value
+
+        #expect(calls.value == 0)
+        #expect(vm.warmingOutcome == .waiting)
+      }
+
+      /// Found by self-review, and it survives a green suite because nothing
+      /// resets `warmingOutcome` when a visit ENDS: a reopened onboarding
+      /// inherits the last visit's `ready`, the gate's `onAppear` fires straight
+      /// through, and the engine is never asked — on a machine where it may have
+      /// been unloaded since.
+      @Test("a reopened onboarding cannot inherit the last visit's ready")
+      func reopeningReArmsTheGate() async {
+        let vm = makeGatedViewModel()
+        vm.kickWarmingIfNeeded(warmUp: { .ready }, displayFloor: 0)
+        await vm.warmingTask?.value
+        #expect(vm.warmingOutcome == .ready)
+
+        // Setup finished and was reopened: recovery parks it back on Ready, and
+        // the person presses the button again.
+        vm.currentScreen = .ready
+        vm.beginWarmingGate()
+
+        #expect(vm.currentScreen == .warmingUp)
+        #expect(
+          vm.warmingOutcome == .waiting,
+          "the gate opened on a stale answer from a previous visit")
+
+        let calls = Counter()
+        vm.kickWarmingIfNeeded(
+          warmUp: {
+            calls.value += 1
+            return .ready
+          }, displayFloor: 0)
+        await vm.warmingTask?.value
+        #expect(calls.value == 1, "the second visit never asked the engine")
+      }
+
+      /// The skip does NOT cancel the shared warm-up — that load is
+      /// single-flighted, so cancelling it to leave a screen would cancel it for
+      /// every other waiter. The consequence this locks: the abandoned attempt
+      /// still resolves, and it must not then open a gate nobody is standing at.
+      @Test("skipping leaves the in-flight warm-up alone and its late answer opens nothing")
+      func skipDoesNotCancelAndLateReadyIsInert() async {
+        let vm = makeGatedViewModel()
+        let calls = Counter()
+        let (gate, gateCont) = AsyncStream.makeStream(of: Void.self)
+
+        let entered = EntrySignal()
+        vm.kickWarmingIfNeeded(
+          warmUp: {
+            calls.value += 1
             entered.fire()
             var it = gate.makeAsyncIterator()
             _ = await it.next()
@@ -358,100 +268,212 @@ import Testing
         gateCont.finish()
         await task?.value
 
-        let rows = events.gateRows("onboarding.step_completed")
-        #expect(rows.count == 1)
-        #expect(rows.first?.stringProps["result"] == "skipped")
+        #expect(calls.value == 1, "the warm-up never ran")
+        #expect(
+          vm.warmingOutcome == .waiting,
+          "a skipped gate opened later on an answer nobody was waiting for")
       }
     }
 
-    /// Local Codex review, adopted: one latch guarded both the warm-up's answer
-    /// and the visit's exit, so a failed attempt consumed it and the Skip link
-    /// still offered beneath the failure panel then reported nothing. A
-    /// failed-then-skipped visit was indistinguishable from a failed-then-
-    /// abandoned one, and the skip rate undercounted exactly the people the
-    /// gate had already failed.
-    @Test("skipping after a failed warm-up still records the skip")
-    func skipAfterFailureIsRecorded() async {
-      await withHook { events in
-        struct Boom: Error {}
-        let vm = makeGatedViewModel()
-        vm.kickWarmingIfNeeded(warmUp: { .failed(Boom()) }, displayFloor: 0)
-        await vm.warmingTask?.value
+    /// #2196 chunk 1 — what the gate reports. When these fail the onboarding
+    /// funnel lies about where people stop: `engine_warm_gate` is the step that
+    /// separates "waited and got a warm engine" from "did not wait".
+    @MainActor
+    @Suite("telemetry", .tags(.observabilityContract), .timeLimit(.minutes(1)))
+    struct OnboardingWarmingGateTelemetryTests {
 
-        vm.skipWarmingGate()
+      final class Events: @unchecked Sendable {
+        private let lock = NSLock()
+        private var stored: [CapturedTelemetryEvent] = []
+        func add(_ e: CapturedTelemetryEvent) { lock.withLock { stored.append(e) } }
+        var all: [CapturedTelemetryEvent] { lock.withLock { stored } }
+        /// Only this step's rows, so an unrelated suite emitting onto the shared
+        /// hook cannot be read as one of ours.
+        func gateRows(_ name: String) -> [CapturedTelemetryEvent] {
+          all.filter { $0.name == name && $0.stringProps["step"] == "engine_warm_gate" }
+        }
+      }
 
-        let blocked = events.gateRows("onboarding.step_blocked")
-        #expect(blocked.count == 1)
-        #expect(blocked.first?.stringProps["reason"] == "warmup_failed")
-        let completed = events.gateRows("onboarding.step_completed")
-        #expect(completed.count == 1, "the skip after a failure was never recorded")
-        #expect(completed.first?.stringProps["result"] == "skipped")
+      private func makeGatedViewModel() -> OnboardingV2ViewModel {
+        let vm = OnboardingV2ViewModel()
+        vm.currentScreen = .warmingUp
+        return vm
+      }
+
+      private func withHook<T>(_ body: (Events) async throws -> T) async rethrows -> T {
+        let events = Events()
+        TelemetryService.shared.testEventHook = { @Sendable e in events.add(e) }
+        defer { TelemetryService.shared.testEventHook = nil }
+        return try await body(events)
+      }
+
+      @Test("a warmed gate completes the step once, with a duration")
+      func readyCompletesOnce() async {
+        await withHook { events in
+          let vm = makeGatedViewModel()
+          vm.kickWarmingIfNeeded(warmUp: { .ready }, displayFloor: 0)
+          await vm.warmingTask?.value
+
+          let rows = events.gateRows("onboarding.step_completed")
+          #expect(rows.count == 1)
+          #expect(rows.first?.stringProps["result"] == "ready")
+          // The already-warm case and a real wait are told apart by this, which
+          // is why the gate carries no separate already_ready result value.
+          #expect(rows.first?.stringProps["duration_seconds"] != nil)
+          #expect(events.gateRows("onboarding.step_blocked").isEmpty)
+        }
+      }
+
+      @Test("a failed warm-up blocks the step, and does not also complete it")
+      func failureBlocks() async {
+        await withHook { events in
+          struct Boom: Error {}
+          let vm = makeGatedViewModel()
+          vm.kickWarmingIfNeeded(warmUp: { .failed(Boom()) }, displayFloor: 0)
+          await vm.warmingTask?.value
+
+          let blocked = events.gateRows("onboarding.step_blocked")
+          #expect(blocked.count == 1)
+          #expect(blocked.first?.stringProps["reason"] == "warmup_failed")
+          #expect(events.gateRows("onboarding.step_completed").isEmpty)
+        }
+      }
+
+      @Test("a checklist cancel that races the gate is reported as its own reason")
+      func cancellationBlocksWithItsOwnReason() async {
+        await withHook { events in
+          let vm = makeGatedViewModel()
+          vm.kickWarmingIfNeeded(warmUp: { .cancelled }, displayFloor: 0)
+          await vm.warmingTask?.value
+
+          let blocked = events.gateRows("onboarding.step_blocked")
+          #expect(blocked.count == 1)
+          #expect(blocked.first?.stringProps["reason"] == "warmup_cancelled")
+        }
+      }
+
+      /// The one-shot latch, stated as a funnel property: one visit to the gate
+      /// produces exactly one row. Without it a skipped gate whose abandoned
+      /// warm-up later resolves would report BOTH skipped and ready, and the
+      /// share-who-skipped number would be quietly wrong in the flattering
+      /// direction.
+      @Test("skip then a late ready reports exactly one row, and it is the skip")
+      func skipReportsOnce() async {
+        await withHook { events in
+          let vm = makeGatedViewModel()
+          let (gate, gateCont) = AsyncStream.makeStream(of: Void.self)
+          let entered = EntrySignal()
+          vm.kickWarmingIfNeeded(
+            warmUp: {
+              entered.fire()
+              var it = gate.makeAsyncIterator()
+              _ = await it.next()
+              return .ready
+            }, displayFloor: 0)
+          let task = vm.warmingTask
+          await entered.awaitEntry()
+
+          vm.skipWarmingGate()
+          gateCont.yield(())
+          gateCont.finish()
+          await task?.value
+
+          let rows = events.gateRows("onboarding.step_completed")
+          #expect(rows.count == 1)
+          #expect(rows.first?.stringProps["result"] == "skipped")
+        }
+      }
+
+      /// Local Codex review, adopted: one latch guarded both the warm-up's answer
+      /// and the visit's exit, so a failed attempt consumed it and the Skip link
+      /// still offered beneath the failure panel then reported nothing. A
+      /// failed-then-skipped visit was indistinguishable from a failed-then-
+      /// abandoned one, and the skip rate undercounted exactly the people the
+      /// gate had already failed.
+      @Test("skipping after a failed warm-up still records the skip")
+      func skipAfterFailureIsRecorded() async {
+        await withHook { events in
+          struct Boom: Error {}
+          let vm = makeGatedViewModel()
+          vm.kickWarmingIfNeeded(warmUp: { .failed(Boom()) }, displayFloor: 0)
+          await vm.warmingTask?.value
+
+          vm.skipWarmingGate()
+
+          let blocked = events.gateRows("onboarding.step_blocked")
+          #expect(blocked.count == 1)
+          #expect(blocked.first?.stringProps["reason"] == "warmup_failed")
+          let completed = events.gateRows("onboarding.step_completed")
+          #expect(completed.count == 1, "the skip after a failure was never recorded")
+          #expect(completed.first?.stringProps["result"] == "skipped")
+        }
+      }
+
+      /// The other direction of the same split: once the person has left, a
+      /// warm-up answer that arrives afterwards is not their block to carry.
+      @Test("a failure landing after the skip adds no row")
+      func lateFailureAfterSkipIsSilent() async {
+        await withHook { events in
+          struct Boom: Error {}
+          let vm = makeGatedViewModel()
+          let (gate, gateCont) = AsyncStream.makeStream(of: Void.self)
+          let entered = EntrySignal()
+          vm.kickWarmingIfNeeded(
+            warmUp: {
+              entered.fire()
+              var it = gate.makeAsyncIterator()
+              _ = await it.next()
+              return .failed(Boom())
+            }, displayFloor: 0)
+          let task = vm.warmingTask
+          await entered.awaitEntry()
+
+          vm.skipWarmingGate()
+          gateCont.yield(())
+          gateCont.finish()
+          await task?.value
+
+          #expect(events.gateRows("onboarding.step_blocked").isEmpty)
+          let completed = events.gateRows("onboarding.step_completed")
+          #expect(completed.count == 1)
+          #expect(completed.first?.stringProps["result"] == "skipped")
+        }
+      }
+
+      /// A retry is not an exit: two real attempts produce two blocks, and the
+      /// visit still produces exactly one completion when it finally ends.
+      @Test("retry then skip reports two blocks and exactly one completion")
+      func retryThenSkipReportsOnce() async {
+        await withHook { events in
+          struct Boom: Error {}
+          let vm = makeGatedViewModel()
+          vm.kickWarmingIfNeeded(warmUp: { .failed(Boom()) }, displayFloor: 0)
+          await vm.warmingTask?.value
+
+          vm.retryWarming()
+          vm.kickWarmingIfNeeded(warmUp: { .failed(Boom()) }, displayFloor: 0)
+          await vm.warmingTask?.value
+
+          vm.skipWarmingGate()
+
+          #expect(events.gateRows("onboarding.step_blocked").count == 2)
+          let completed = events.gateRows("onboarding.step_completed")
+          #expect(completed.count == 1)
+          #expect(completed.first?.stringProps["result"] == "skipped")
+        }
+      }
+
+      @Test("a second skip press cannot report twice")
+      func doubleSkipReportsOnce() async {
+        await withHook { events in
+          let vm = makeGatedViewModel()
+          vm.skipWarmingGate()
+          vm.skipWarmingGate()
+          #expect(events.gateRows("onboarding.step_completed").count == 1)
+        }
       }
     }
 
-    /// The other direction of the same split: once the person has left, a
-    /// warm-up answer that arrives afterwards is not their block to carry.
-    @Test("a failure landing after the skip adds no row")
-    func lateFailureAfterSkipIsSilent() async {
-      await withHook { events in
-        struct Boom: Error {}
-        let vm = makeGatedViewModel()
-        let (gate, gateCont) = AsyncStream.makeStream(of: Void.self)
-        let entered = EntrySignal()
-        vm.kickWarmingIfNeeded(
-          warmUp: {
-            entered.fire()
-            var it = gate.makeAsyncIterator()
-            _ = await it.next()
-            return .failed(Boom())
-          }, displayFloor: 0)
-        let task = vm.warmingTask
-        await entered.awaitEntry()
-
-        vm.skipWarmingGate()
-        gateCont.yield(())
-        gateCont.finish()
-        await task?.value
-
-        #expect(events.gateRows("onboarding.step_blocked").isEmpty)
-        let completed = events.gateRows("onboarding.step_completed")
-        #expect(completed.count == 1)
-        #expect(completed.first?.stringProps["result"] == "skipped")
-      }
-    }
-
-    /// A retry is not an exit: two real attempts produce two blocks, and the
-    /// visit still produces exactly one completion when it finally ends.
-    @Test("retry then skip reports two blocks and exactly one completion")
-    func retryThenSkipReportsOnce() async {
-      await withHook { events in
-        struct Boom: Error {}
-        let vm = makeGatedViewModel()
-        vm.kickWarmingIfNeeded(warmUp: { .failed(Boom()) }, displayFloor: 0)
-        await vm.warmingTask?.value
-
-        vm.retryWarming()
-        vm.kickWarmingIfNeeded(warmUp: { .failed(Boom()) }, displayFloor: 0)
-        await vm.warmingTask?.value
-
-        vm.skipWarmingGate()
-
-        #expect(events.gateRows("onboarding.step_blocked").count == 2)
-        let completed = events.gateRows("onboarding.step_completed")
-        #expect(completed.count == 1)
-        #expect(completed.first?.stringProps["result"] == "skipped")
-      }
-    }
-
-    @Test("a second skip press cannot report twice")
-    func doubleSkipReportsOnce() async {
-      await withHook { events in
-        let vm = makeGatedViewModel()
-        vm.skipWarmingGate()
-        vm.skipWarmingGate()
-        #expect(events.gateRows("onboarding.step_completed").count == 1)
-      }
-    }
   }
 
 #endif  // DEBUG

--- a/Tests/EnviousWisprTests/App/OnboardingWarmingGateTests.swift
+++ b/Tests/EnviousWisprTests/App/OnboardingWarmingGateTests.swift
@@ -518,6 +518,27 @@ import Testing
         }
       }
 
+      /// The funnel must not repeat the screen's own mistake where nobody can
+      /// see it: someone who dictated and missed the box DID dictate, and
+      /// filing them under silence would hide a one-click UX problem inside the
+      /// most common genuine outcome.
+      @Test("a missed box is reported as its own thing, not as silence")
+      func missedBoxHasItsOwnResult() async {
+        await withHook { events in
+          let vm = OnboardingV2ViewModel()
+          vm.beginPractice()
+          vm.practiceTakeStarted(boxFocused: false)
+          vm.practiceTakeEnded()
+
+          vm.reportPracticeExit()
+
+          let rows = events.all.filter {
+            $0.name == "onboarding.step_completed" && $0.stringProps["step"] == "practice_dictation"
+          }
+          #expect(rows.first?.stringProps["result"] == "missed_box")
+        }
+      }
+
       @Test("leaving without ever trying reports skipped")
       func neverTriedReportsSkipped() async {
         await withHook { events in
@@ -715,6 +736,52 @@ import Testing
         vm.practiceTakeEnded()
 
         #expect(vm.practiceState == .saidNothing, "a silent take inherited the previous take's words")
+      }
+
+      /// FOUNDER-FOUND IN LIVE UAT, 2026-08-24, and the most valuable finding
+      /// of the day because no test would have produced it: he dictated with
+      /// the box unfocused and the screen said "All quiet". The app had heard
+      /// him perfectly — `RAW ASR "Testing one two three."` — and the words
+      /// went to the clipboard because the cascade classified `.nonText`. The
+      /// screen accused his microphone of a fault it did not have and sent him
+      /// to check hardware when the fix was one click.
+      @Test("a take that missed the box is not reported as silence")
+      func missedBoxIsNotSilence() {
+        let vm = makePracticeViewModel()
+        vm.practiceTakeStarted(boxFocused: false)
+
+        vm.practiceTakeEnded()
+
+        #expect(vm.practiceState == .missedTheBox)
+        #expect(
+          vm.practiceState != .saidNothing,
+          "the screen told someone it heard nothing when it heard them fine")
+      }
+
+      /// The other half, and why the copy was not simply replaced: real silence
+      /// is 20.3% of first takes, and telling THAT person to click a box they
+      /// already clicked is the same wrong advice pointed the other way.
+      @Test("a silent take with the box focused is still all-quiet")
+      func focusedSilenceIsStillSilence() {
+        let vm = makePracticeViewModel()
+        vm.practiceTakeStarted(boxFocused: true)
+
+        vm.practiceTakeEnded()
+
+        #expect(vm.practiceState == .saidNothing)
+      }
+
+      /// Words arriving is what decides success, whatever the focus flag said
+      /// at the start — a take that lands text has plainly not missed.
+      @Test("a productive take is success even if focus was uncertain at the start")
+      func wordsBeatTheFocusFlag() {
+        let vm = makePracticeViewModel()
+        vm.practiceTakeStarted(boxFocused: false)
+        vm.setPracticeText("tell grandma I love her and will call Sunday")
+
+        vm.practiceTakeEnded()
+
+        #expect(vm.practiceState == .worked)
       }
 
       @Test("a denied microphone is named rather than left as a dead screen")

--- a/Tests/EnviousWisprTests/App/OnboardingWarmingGateTests.swift
+++ b/Tests/EnviousWisprTests/App/OnboardingWarmingGateTests.swift
@@ -539,6 +539,33 @@ import Testing
         }
       }
 
+      /// `pipeline_failed` is its own reason, never folded into `no_speech`:
+      /// one is us failing and the other is a quiet room, and a funnel that
+      /// cannot tell them apart will read our own breakage as people not
+      /// speaking.
+      @Test("a pipeline failure blocks the step with its own reason")
+      func failureReportsItsOwnReason() async {
+        await withHook { events in
+          let vm = OnboardingV2ViewModel()
+          vm.beginPractice()
+          vm.practiceTakeStarted(boxFocused: true, transcriptCount: 0)
+          vm.practiceTakeEnded(transcriptCount: 0, pipelineFailed: true)
+
+          vm.reportPracticeExit()
+
+          let blocked = events.all.filter {
+            $0.name == "onboarding.step_blocked" && $0.stringProps["step"] == "practice_dictation"
+          }
+          #expect(blocked.count == 1)
+          #expect(blocked.first?.stringProps["reason"] == "pipeline_failed")
+          #expect(
+            events.all.filter {
+              $0.name == "onboarding.step_completed"
+                && $0.stringProps["step"] == "practice_dictation"
+            }.isEmpty)
+        }
+      }
+
       @Test("leaving without ever trying reports skipped")
       func neverTriedReportsSkipped() async {
         await withHook { events in
@@ -802,6 +829,50 @@ import Testing
         vm.practiceTakeEnded()
 
         #expect(vm.practiceState == .worked)
+      }
+
+      /// Cloud review, and the SAME class a fourth time: a failed take produces
+      /// no text and no transcript, so without this it fell through to
+      /// `saidNothing` and the screen said "Your microphone is working. We just
+      /// did not hear anything." Both halves false, and it sends someone to try
+      /// harder at a thing that is broken.
+      @Test("a pipeline failure is not reported as silence")
+      func failureIsNotSilence() {
+        let vm = makePracticeViewModel()
+        vm.practiceTakeStarted(boxFocused: true, transcriptCount: 0)
+
+        vm.practiceTakeEnded(transcriptCount: 0, pipelineFailed: true)
+
+        #expect(vm.practiceState == .somethingBroke)
+        #expect(
+          vm.practiceState != .saidNothing,
+          "the screen blamed a quiet room for our own failure")
+      }
+
+      /// The other half: a genuinely quiet room must NOT be dressed up as our
+      /// failure, or the most common first-take outcome starts reading as the
+      /// product breaking.
+      @Test("silence with a healthy pipeline is still silence")
+      func healthySilenceIsStillSilence() {
+        let vm = makePracticeViewModel()
+        vm.practiceTakeStarted(boxFocused: true, transcriptCount: 0)
+
+        vm.practiceTakeEnded(transcriptCount: 0, pipelineFailed: false)
+
+        #expect(vm.practiceState == .saidNothing)
+      }
+
+      /// A failure outranks every other reading, because no text and no
+      /// transcript are SYMPTOMS of it — classifying on them first would
+      /// describe the symptom and hide the cause.
+      @Test("a failure outranks a missed box")
+      func failureOutranksMissedBox() {
+        let vm = makePracticeViewModel()
+        vm.practiceTakeStarted(boxFocused: false, transcriptCount: 0)
+
+        vm.practiceTakeEnded(transcriptCount: 1, pipelineFailed: true)
+
+        #expect(vm.practiceState == .somethingBroke)
       }
 
       @Test("a denied microphone is named rather than left as a dead screen")

--- a/Tests/EnviousWisprTests/App/OnboardingWarmingGateTests.swift
+++ b/Tests/EnviousWisprTests/App/OnboardingWarmingGateTests.swift
@@ -463,6 +463,104 @@ import Testing
         }
       }
 
+      /// Chunk 4. Without these the funnel cannot tell a person who practised
+      /// from one who bailed — both exits called the same no-argument finish, so
+      /// `practice_dictation` never appeared at all.
+      @Test("finishing after a successful take reports completed")
+      func practiceCompletedIsReported() async {
+        await withHook { events in
+          let vm = OnboardingV2ViewModel()
+          vm.beginPractice()
+          vm.practiceTakeStarted()
+          vm.setPracticeText("hey Mike pick up Emma from school today")
+          vm.practiceTakeEnded()
+
+          vm.reportPracticeExit()
+
+          let rows = events.all.filter {
+            $0.name == "onboarding.step_completed" && $0.stringProps["step"] == "practice_dictation"
+          }
+          #expect(rows.count == 1)
+          #expect(rows.first?.stringProps["result"] == "completed")
+        }
+      }
+
+      /// `no_speech` and `skipped` are deliberately different: one person tried
+      /// and got silence, the other never tried. Collapsing them would hide the
+      /// 20.3% case inside the skip rate.
+      @Test("leaving after a silent take reports no_speech, not skipped")
+      func silentThenLeaveReportsNoSpeech() async {
+        await withHook { events in
+          let vm = OnboardingV2ViewModel()
+          vm.beginPractice()
+          vm.practiceTakeStarted()
+          vm.practiceTakeEnded()
+
+          vm.reportPracticeExit()
+
+          let rows = events.all.filter {
+            $0.name == "onboarding.step_completed" && $0.stringProps["step"] == "practice_dictation"
+          }
+          #expect(rows.first?.stringProps["result"] == "no_speech")
+        }
+      }
+
+      @Test("leaving without ever trying reports skipped")
+      func neverTriedReportsSkipped() async {
+        await withHook { events in
+          let vm = OnboardingV2ViewModel()
+          vm.beginPractice()
+
+          vm.reportPracticeExit()
+
+          let rows = events.all.filter {
+            $0.name == "onboarding.step_completed" && $0.stringProps["step"] == "practice_dictation"
+          }
+          #expect(rows.first?.stringProps["result"] == "skipped")
+        }
+      }
+
+      @Test("a blocked permission reports blocked with its permission named")
+      func blockedPermissionIsReported() async {
+        await withHook { events in
+          let vm = OnboardingV2ViewModel()
+          vm.beginPractice()
+          vm.applyPracticePosture(micGranted: false, accessibilityGranted: true)
+
+          vm.reportPracticeExit()
+
+          let blocked = events.all.filter {
+            $0.name == "onboarding.step_blocked" && $0.stringProps["step"] == "practice_dictation"
+          }
+          #expect(blocked.count == 1)
+          #expect(blocked.first?.stringProps["reason"] == "mic_denied")
+          #expect(blocked.first?.stringProps["permission"] == "microphone")
+          #expect(
+            events.all.filter {
+              $0.name == "onboarding.step_completed"
+                && $0.stringProps["step"] == "practice_dictation"
+            }.isEmpty)
+        }
+      }
+
+      @Test("one visit to the box reports exactly once, however it ends")
+      func practiceExitReportsOnce() async {
+        await withHook { events in
+          let vm = OnboardingV2ViewModel()
+          vm.beginPractice()
+          vm.setPracticeText("remember soccer jersey and cleats for tomorrow")
+
+          vm.reportPracticeExit()
+          vm.reportPracticeExit()
+
+          #expect(
+            events.all.filter {
+              $0.name == "onboarding.step_completed"
+                && $0.stringProps["step"] == "practice_dictation"
+            }.count == 1)
+        }
+      }
+
       @Test("a second skip press cannot report twice")
       func doubleSkipReportsOnce() async {
         await withHook { events in
@@ -548,6 +646,101 @@ import Testing
       /// The gate's ready exit opens the box; it no longer ends setup. If this
       /// regresses, the warm gate silently becomes the last screen again and the
       /// entire feature is absent while every other test still passes.
+      /// Local Codex chunk-2 review, P1: Skip after releasing the key but
+      /// BEFORE transcription finishes closed the window while the ordinary
+      /// cascade still targeted the practice editor — so the words landed on
+      /// the clipboard behind the very notice this feature removes, or in
+      /// whatever app was behind us. The screen was blind to a take entirely.
+      @Test("a take in flight is a state the screen can see")
+      func aTakeInFlightIsObservable() {
+        let vm = makePracticeViewModel()
+        #expect(vm.practiceState == .waiting)
+
+        vm.practiceTakeStarted()
+
+        #expect(vm.practiceState == .listening, "the screen cannot tell a take is running")
+      }
+
+      /// The 20.3% case, and the reason it is a state rather than an error: a
+      /// take that produces nothing must be acknowledged, or the screen just
+      /// keeps asking and the person concludes the product ignored them.
+      @Test("a take that produces nothing lands in all-quiet, not in success")
+      func silentTakeIsAcknowledged() {
+        let vm = makePracticeViewModel()
+        vm.practiceTakeStarted()
+
+        vm.practiceTakeEnded()
+
+        #expect(vm.practiceState == .saidNothing)
+        #expect(vm.practiceSucceeded == false)
+      }
+
+      @Test("a take that produces words lands in success")
+      func productiveTakeWorks() {
+        let vm = makePracticeViewModel()
+        vm.practiceTakeStarted()
+        vm.setPracticeText("Emma the birthday card is in the mail happy 7th sweetie")
+
+        vm.practiceTakeEnded()
+
+        #expect(vm.practiceState == .worked)
+        #expect(vm.practiceSucceeded)
+      }
+
+      /// A SECOND take is scored on its own words, never on the first take's.
+      /// Comparing against empty instead of against the take's own start would
+      /// score every later silent take as a success.
+      @Test("a silent second take is not credited to the first take's words")
+      func secondTakeIsScoredOnItsOwn() {
+        let vm = makePracticeViewModel()
+        vm.practiceTakeStarted()
+        vm.setPracticeText("running 15 min late got stuck on the client call")
+        vm.practiceTakeEnded()
+        #expect(vm.practiceState == .worked)
+
+        vm.practiceTakeStarted()
+        vm.practiceTakeEnded()
+
+        #expect(vm.practiceState == .saidNothing, "a silent take inherited the previous take's words")
+      }
+
+      @Test("a denied microphone is named rather than left as a dead screen")
+      func deniedMicIsNamed() {
+        let vm = makePracticeViewModel()
+        vm.applyPracticePosture(micGranted: false, accessibilityGranted: true)
+        #expect(vm.practiceState == .cannotHear(reason: "mic_denied", permission: "microphone"))
+      }
+
+      /// The known limit of this route: Tier 1 writes through Accessibility, so
+      /// without it the person would meet the raw clipboard notice. Named
+      /// instead.
+      @Test("denied accessibility is named rather than left to the clipboard notice")
+      func deniedAccessibilityIsNamed() {
+        let vm = makePracticeViewModel()
+        vm.applyPracticePosture(micGranted: true, accessibilityGranted: false)
+        #expect(
+          vm.practiceState == .cannotHear(reason: "accessibility_denied", permission: "accessibility"))
+      }
+
+      @Test("granting the permission afterwards clears the blocked state")
+      func grantingClearsTheBlock() {
+        let vm = makePracticeViewModel()
+        vm.applyPracticePosture(micGranted: false, accessibilityGranted: false)
+        vm.applyPracticePosture(micGranted: true, accessibilityGranted: true)
+        #expect(vm.practiceState == .waiting)
+      }
+
+      /// A take cannot start while the screen is telling someone their
+      /// microphone is off — otherwise the honest message is replaced by
+      /// "Listening…" on a machine that cannot hear.
+      @Test("a blocked screen does not pretend to listen")
+      func blockedScreenDoesNotListen() {
+        let vm = makePracticeViewModel()
+        vm.applyPracticePosture(micGranted: false, accessibilityGranted: true)
+        vm.practiceTakeStarted()
+        #expect(vm.practiceState == .cannotHear(reason: "mic_denied", permission: "microphone"))
+      }
+
       @Test("a warmed gate opens the box rather than ending setup")
       func warmGateOpensTheBox() {
         let vm = OnboardingV2ViewModel()

--- a/Tests/EnviousWisprTests/App/OnboardingWarmingGateTests.swift
+++ b/Tests/EnviousWisprTests/App/OnboardingWarmingGateTests.swift
@@ -329,6 +329,83 @@ import Testing
       }
     }
 
+    /// Local Codex review, adopted: one latch guarded both the warm-up's answer
+    /// and the visit's exit, so a failed attempt consumed it and the Skip link
+    /// still offered beneath the failure panel then reported nothing. A
+    /// failed-then-skipped visit was indistinguishable from a failed-then-
+    /// abandoned one, and the skip rate undercounted exactly the people the
+    /// gate had already failed.
+    @Test("skipping after a failed warm-up still records the skip")
+    func skipAfterFailureIsRecorded() async {
+      await withHook { events in
+        struct Boom: Error {}
+        let vm = makeGatedViewModel()
+        vm.kickWarmingIfNeeded(warmUp: { .failed(Boom()) }, displayFloor: 0)
+        await vm.warmingTask?.value
+
+        vm.skipWarmingGate()
+
+        let blocked = events.gateRows("onboarding.step_blocked")
+        #expect(blocked.count == 1)
+        #expect(blocked.first?.stringProps["reason"] == "warmup_failed")
+        let completed = events.gateRows("onboarding.step_completed")
+        #expect(completed.count == 1, "the skip after a failure was never recorded")
+        #expect(completed.first?.stringProps["result"] == "skipped")
+      }
+    }
+
+    /// The other direction of the same split: once the person has left, a
+    /// warm-up answer that arrives afterwards is not their block to carry.
+    @Test("a failure landing after the skip adds no row")
+    func lateFailureAfterSkipIsSilent() async {
+      await withHook { events in
+        struct Boom: Error {}
+        let vm = makeGatedViewModel()
+        let (gate, gateCont) = AsyncStream.makeStream(of: Void.self)
+        vm.kickWarmingIfNeeded(
+          warmUp: {
+            var it = gate.makeAsyncIterator()
+            _ = await it.next()
+            return .failed(Boom())
+          }, displayFloor: 0)
+        let task = vm.warmingTask
+        for _ in 0..<8 { await Task.yield() }
+
+        vm.skipWarmingGate()
+        gateCont.yield(())
+        gateCont.finish()
+        await task?.value
+
+        #expect(events.gateRows("onboarding.step_blocked").isEmpty)
+        let completed = events.gateRows("onboarding.step_completed")
+        #expect(completed.count == 1)
+        #expect(completed.first?.stringProps["result"] == "skipped")
+      }
+    }
+
+    /// A retry is not an exit: two real attempts produce two blocks, and the
+    /// visit still produces exactly one completion when it finally ends.
+    @Test("retry then skip reports two blocks and exactly one completion")
+    func retryThenSkipReportsOnce() async {
+      await withHook { events in
+        struct Boom: Error {}
+        let vm = makeGatedViewModel()
+        vm.kickWarmingIfNeeded(warmUp: { .failed(Boom()) }, displayFloor: 0)
+        await vm.warmingTask?.value
+
+        vm.retryWarming()
+        vm.kickWarmingIfNeeded(warmUp: { .failed(Boom()) }, displayFloor: 0)
+        await vm.warmingTask?.value
+
+        vm.skipWarmingGate()
+
+        #expect(events.gateRows("onboarding.step_blocked").count == 2)
+        let completed = events.gateRows("onboarding.step_completed")
+        #expect(completed.count == 1)
+        #expect(completed.first?.stringProps["result"] == "skipped")
+      }
+    }
+
     @Test("a second skip press cannot report twice")
     func doubleSkipReportsOnce() async {
       await withHook { events in

--- a/Tests/EnviousWisprTests/App/OnboardingWarmingGateTests.swift
+++ b/Tests/EnviousWisprTests/App/OnboardingWarmingGateTests.swift
@@ -527,8 +527,8 @@ import Testing
         await withHook { events in
           let vm = OnboardingV2ViewModel()
           vm.beginPractice()
-          vm.practiceTakeStarted(boxFocused: false)
-          vm.practiceTakeEnded()
+          vm.practiceTakeStarted(boxFocused: false, transcriptCount: 0)
+          vm.practiceTakeEnded(transcriptCount: 1)
 
           vm.reportPracticeExit()
 
@@ -748,14 +748,34 @@ import Testing
       @Test("a take that missed the box is not reported as silence")
       func missedBoxIsNotSilence() {
         let vm = makePracticeViewModel()
-        vm.practiceTakeStarted(boxFocused: false)
+        vm.practiceTakeStarted(boxFocused: false, transcriptCount: 3)
 
-        vm.practiceTakeEnded()
+        // A transcript appeared, so words genuinely existed — they just had
+        // nowhere here to land.
+        vm.practiceTakeEnded(transcriptCount: 4)
 
         #expect(vm.practiceState == .missedTheBox)
         #expect(
           vm.practiceState != .saidNothing,
           "the screen told someone it heard nothing when it heard them fine")
+      }
+
+      /// Cloud review, and it is the founder's own defect pointed the other way,
+      /// inside the fix for it: losing focus says where words WOULD go, never
+      /// whether any existed. Without the transcript evidence this take was
+      /// classified `missedTheBox` and the screen said "We heard you" about
+      /// somebody who had said nothing at all.
+      @Test("an unfocused SILENT take is silence, not a missed box")
+      func unfocusedSilenceIsNotAMissedBox() {
+        let vm = makePracticeViewModel()
+        vm.practiceTakeStarted(boxFocused: false, transcriptCount: 3)
+
+        // No transcript appeared: nothing was heard.
+        vm.practiceTakeEnded(transcriptCount: 3)
+
+        #expect(
+          vm.practiceState == .saidNothing,
+          "the screen claimed it heard someone who said nothing")
       }
 
       /// The other half, and why the copy was not simply replaced: real silence

--- a/Tests/EnviousWisprTests/App/OnboardingWarmingGateTests.swift
+++ b/Tests/EnviousWisprTests/App/OnboardingWarmingGateTests.swift
@@ -8,6 +8,31 @@ import Testing
 
 #if DEBUG
 
+  /// A one-shot signal the injected warm-up fires when it is genuinely
+  /// RUNNING. Replaces a yield-count settle, which guessed at the scheduler:
+  /// under contention the guess can expire before the subject has run, so a
+  /// negative assertion passes having exercised nothing.
+  @MainActor
+  fileprivate final class EntrySignal {
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+    private var fired = false
+
+    /// Called from inside the warm-up, before it suspends.
+    func fire() {
+      guard !fired else { return }
+      fired = true
+      let resumable = waiters
+      waiters = []
+      for w in resumable { w.resume() }
+    }
+
+    /// Returns once the warm-up has actually been entered.
+    func awaitEntry() async {
+      if fired { return }
+      await withCheckedContinuation { waiters.append($0) }
+    }
+  }
+
   /// #2196 chunk 1 — the engine warm gate.
   ///
   /// When these fail, a brand new person's very first press lands on a cold
@@ -17,7 +42,9 @@ import Testing
   /// every case here asks the same question — can the gate open on anything
   /// other than the engine itself saying ready.
   @MainActor
-  @Suite("Onboarding engine warm gate", .tags(.productOutcome), .serialized)
+  @Suite(
+    "Onboarding engine warm gate", .tags(.productOutcome), .serialized,
+    .timeLimit(.minutes(1)))
   struct OnboardingWarmingGateTests {
 
     @MainActor
@@ -30,11 +57,6 @@ import Testing
       return vm
     }
 
-    /// Let the kicked task reach its first suspension point.
-    private func settle() async {
-      for _ in 0..<8 { await Task.yield() }
-    }
-
     @Test("the gate stays shut while the warm-up is still running")
     func gateHoldsUntilTheEngineAnswers() async {
       let vm = makeGatedViewModel()
@@ -43,14 +65,17 @@ import Testing
       // than one it waits out.
       let (gate, gateCont) = AsyncStream.makeStream(of: Void.self)
 
+      let entered = EntrySignal()
       vm.kickWarmingIfNeeded(
         warmUp: {
+          entered.fire()
           var it = gate.makeAsyncIterator()
           _ = await it.next()
           return .ready
         }, displayFloor: 0)
       let task = vm.warmingTask
-      await settle()
+      // The subject says it is running; nothing here guesses that it is.
+      await entered.awaitEntry()
 
       #expect(vm.warmingOutcome == .waiting, "the gate opened before the engine answered")
 
@@ -121,8 +146,10 @@ import Testing
       let vm = makeGatedViewModel()
       let calls = Counter()
       let (gate, gateCont) = AsyncStream.makeStream(of: Void.self)
+      let entered = EntrySignal()
       let warmUp: @MainActor () async -> EngineWarmupOutcome = {
         calls.value += 1
+        entered.fire()
         var it = gate.makeAsyncIterator()
         _ = await it.next()
         return .ready
@@ -130,7 +157,9 @@ import Testing
 
       vm.kickWarmingIfNeeded(warmUp: warmUp, displayFloor: 0)
       let first = vm.warmingTask
-      await settle()
+      // Without this the re-kick could land before the first attempt ran, and a
+      // `calls.value == 1` read would pass having proven nothing.
+      await entered.awaitEntry()
       vm.kickWarmingIfNeeded(warmUp: warmUp, displayFloor: 0)
 
       #expect(calls.value == 1, "a re-kick started a second warm-up")
@@ -200,15 +229,17 @@ import Testing
       let calls = Counter()
       let (gate, gateCont) = AsyncStream.makeStream(of: Void.self)
 
+      let entered = EntrySignal()
       vm.kickWarmingIfNeeded(
         warmUp: {
           calls.value += 1
+          entered.fire()
           var it = gate.makeAsyncIterator()
           _ = await it.next()
           return .ready
         }, displayFloor: 0)
       let task = vm.warmingTask
-      await settle()
+      await entered.awaitEntry()
 
       vm.skipWarmingGate()
       gateCont.yield(())
@@ -226,7 +257,9 @@ import Testing
   /// funnel lies about where people stop: `engine_warm_gate` is the step that
   /// separates "waited and got a warm engine" from "did not wait".
   @MainActor
-  @Suite("Onboarding engine warm gate telemetry", .tags(.observabilityContract), .serialized)
+  @Suite(
+    "Onboarding engine warm gate telemetry", .tags(.observabilityContract), .serialized,
+    .timeLimit(.minutes(1)))
   struct OnboardingWarmingGateTelemetryTests {
 
     final class Events: @unchecked Sendable {
@@ -309,14 +342,16 @@ import Testing
       await withHook { events in
         let vm = makeGatedViewModel()
         let (gate, gateCont) = AsyncStream.makeStream(of: Void.self)
+        let entered = EntrySignal()
         vm.kickWarmingIfNeeded(
           warmUp: {
+            entered.fire()
             var it = gate.makeAsyncIterator()
             _ = await it.next()
             return .ready
           }, displayFloor: 0)
         let task = vm.warmingTask
-        for _ in 0..<8 { await Task.yield() }
+        await entered.awaitEntry()
 
         vm.skipWarmingGate()
         gateCont.yield(())
@@ -362,14 +397,16 @@ import Testing
         struct Boom: Error {}
         let vm = makeGatedViewModel()
         let (gate, gateCont) = AsyncStream.makeStream(of: Void.self)
+        let entered = EntrySignal()
         vm.kickWarmingIfNeeded(
           warmUp: {
+            entered.fire()
             var it = gate.makeAsyncIterator()
             _ = await it.next()
             return .failed(Boom())
           }, displayFloor: 0)
         let task = vm.warmingTask
-        for _ in 0..<8 { await Task.yield() }
+        await entered.awaitEntry()
 
         vm.skipWarmingGate()
         gateCont.yield(())

--- a/Tests/EnviousWisprTests/Architecture/EngineMutationInventoryFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EngineMutationInventoryFreezeTests.swift
@@ -806,6 +806,31 @@ import Testing
       matcher: "warmUp", text: "await self.startSetup(warmUp: warmUp, settings: settings)",
       classification: .structurallySafe),
 
+    // #2196 — the onboarding engine warm GATE, which is a second caller of the
+    // same seam the checklist above already uses, so these two entries are the
+    // gate's copies of the two directly above and carry the same reasoning.
+    // Verified rather than assumed: the gate's sole production caller supplies
+    // the same closure literal the checklist's does
+    // (`{ await dictationRuntime.ensureActiveEngineWarmForOnboarding() }`, in
+    // `OnboardingV2View`'s `.task`), which routes through
+    // `KernelDictationDriver.ensureEngineWarm(reason:)` to the already-counted
+    // `gated` `adapter.warmUp()`. `structurallySafe` category (c): the real
+    // engine touch re-acquires its own claim internally on every invocation,
+    // whatever chain the closure travelled to get here.
+    //
+    // The first entry duplicates the text of `startSetup`'s bare call, which is
+    // why it is a SECOND array entry rather than an edit — multiplicity is the
+    // signal, so a future removal of either one has to be accounted for here.
+    CallSite(
+      file: "Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift",
+      matcher: "warmUp", text: "let outcome = await warmUp()",
+      classification: .structurallySafe),
+    CallSite(
+      file: "Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift",
+      matcher: "warmUp",
+      text: "await self.runWarmingGate(warmUp: warmUp, displayFloor: displayFloor)",
+      classification: .structurallySafe),
+
     // MARK: WhisperKitEngineAdapter
     // `recoverFromWedge()`'s deadline-bounded unload — this file's own doc
     // comment marks it "§3.2, structurally-safe row": called only by the


### PR DESCRIPTION
Setup gains two screens so a new person cannot reach the end of it without being offered one dictation into a target that exists.

## The defect, measured

90 days of production, dev excluded. **319 people** received `paste.completed{tier=clipboard_only, target_app=com.enviouswispr.app}`. Restricted to people whose FIRST EVER readable paste outcome was that: 172. Of those, 121 recovered within a median of 2.5 minutes and retain like everyone else. **51 never once had a successful paste**, took a median of 2 dictations, 2 of the 51 ever reached another app, and 33 have not been seen in 30 days.

The issue's "100 people" was a default query-limit artifact and is superseded.

**Honest limit:** for those 51, "pressed the key twice" and "never reached another app" are the same fact seen twice, so causation is not established. What IS established is that the notice was their entire experience of the product.

## Why the box is the entire fix

`PasteCascadeExecutor` classifies the focused element by AX role, and `PasteService.textRoles` accepts `AXTextField`, `AXTextArea`, `AXComboBox`, `AXSearchField`. A focused SwiftUI `TextEditor` presents as `AXTextArea`. The refusal being fixed happens BECAUSE the classification is `.nonText` — our own window offered nothing to type into — so supplying a text-role element removes the precondition rather than special-casing around it.

**Zero lines in `Sources/EnviousWisprPipeline/`.** No new delivery route, no new persisted state, no `OnboardingState` case, no migration, no architecture-ceiling change.

## What ships

| | |
|---|---|
| **Warming up** | Does not open until the shared warm-up itself reports ready, so a first press cannot land on a cold engine and be silently refused. A second CALLER of `ensureActiveEngineWarmForOnboarding`, not a second authority. |
| **Time for your first dictation!** | A focused `TextEditor`. FINISH SETUP dims until a take succeeds; skip is visible from the first frame. |
| **The detours** | `saidNothing` (20.3% of real first takes, worded as normal), `missedTheBox`, `cannotHear` with an in-place permission request. |
| **Counting** | `engine_warm_gate` and `practice_dictation` on the existing onboarding funnel. Nothing new invented. |

## Live UAT, on the real app

Both screens driven on a live dev build.

**The success arm.** Words landed IN the box; the screen advanced to "That is it. You are set."

```
CORRECTION_DEBUG [RAW ASR] Practice step audit. Tell Grandma I love her and we'll call Sunday after church.
Paste cascade: tier=ax_direct, app=com.enviouswispr.app.dev
```

**The negative control**, same screen, same app, box unfocused:

```
Paste cascade: non-text element focused, falling back to clipboard-only
Paste cascade: tier=clipboard_only, app=com.enviouswispr.app.dev
```

One difference, opposite outcomes. That is the fix demonstrated rather than argued.

## A founder-found defect, and what it says about the tests

The control arm above came from the founder dictating with the box unselected — and the screen said **"All quiet"** while the app had heard him perfectly (`RAW ASR "Testing one two three."`). It accused his microphone of a fault it did not have and sent him to check hardware when the fix was one click.

**The copy was not simply replaced**, which was the obvious fix and is wrong: genuine silence is 20.3% of first takes, and telling THAT person to click a box they already clicked is the same wrong advice pointed the other way. The screen now distinguishes them, the cursor is put back after a miss, and the funnel gets `missed_box` rather than `no_speech` — filing it under silence would repeat the screen's own mistake where nobody can see it.

**Why no test caught it:** every unit test feeds the box text directly, so "words exist but went elsewhere" was unreachable BY CONSTRUCTION. The fixture shared the code's assumption. That is the fixture-too-small class, and it is why Live UAT is a ship criterion rather than a formality.

## Validation

- **38 tests** across 4 nested suites; Debug lane **6634**, Release lane **5995**, zero failures.
- **17 mutation rows** on #2371, every one run and CAUGHT or EXPECTED, baseline green before and after. One survivor was found and fixed along the way: `reKickIsSingleFlight` counted `Task` invocations at an instant the evidence could not exist, so it could never have failed. Four review rounds and every green run missed it.
- **Five local review rounds** across the chunks. Notable: one finding I rejected in round 1 was correct about the mechanism and wrong about its consequence, and returned twice more from different angles before the class was closed properly.

## Risk

Confined to onboarding. A single squash revert removes it and nothing else moves. Known limit: this route writes through Accessibility, so a person who reaches the practice screen with it denied is told plainly instead of meeting the clipboard notice — of the 51 people this exists for, 48 had already granted it and not one had denied it.

Closes #2196.
