### PR TITLE
fix(delivery): the Parakeet Resume door ignored the delivery kill switch (#2139)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/ModelDeliveryHome.swift
+++ b/Sources/EnviousWisprAppKit/App/ModelDeliveryHome.swift
@@ -71,6 +71,16 @@ public final class ModelDeliveryHome {
   /// a deleted one or one filtered on the wrong identity.
   package private(set) var previewStateUpdatesForTests = 0
   package private(set) var parakeetStateUpdatesForTests = 0
+
+  /// How many times the Parakeet Resume door has REFUSED on the family kill
+  /// switch. A test seam, and specifically a POSITIVE one: the refusal path
+  /// returns before any `Task` is created, so this is incremented synchronously
+  /// on the main actor and is already true when `resumeParakeetDownload()`
+  /// returns. Without it the flag-OFF arm could only assert two absences — no
+  /// claim taken, no delivery reached — and an absence cannot distinguish "the
+  /// guard refused" from "the door has not run yet", which is the vacuity this
+  /// counter exists to remove.
+  package private(set) var parakeetResumeRefusalsForTests = 0
   /// Monotonic apply guard (EG-1 `installStateSeqApplied` precedent, made
   /// REAL per exhaustive r7 finding 7): the sequence is minted at observer-
   /// receive time (controller actor, in publish order) and a MainActor hop
@@ -141,7 +151,14 @@ public final class ModelDeliveryHome {
       parakeetRegistration = registration
       // #2119: reclaim staging abandoned by a superseded revision of THIS model.
       Task { await controller.sweepSupersededStaging(registration) }
-      parakeetHandle = ParakeetDeliveryHandle(controller: controller, registration: registration)
+      // The kill-switch store is INJECTED, exactly as its two siblings below
+      // are (`:whisperKitHandle`, `:whisperPreviewHandle`). Omitting it made
+      // this handle resolve `nil` to the real operational suite, so no test
+      // could exercise the family flag without writing a live delivery kill
+      // switch onto a developer's machine (#2139). Production is unchanged:
+      // the only caller that passes a non-nil value is the test suite.
+      parakeetHandle = ParakeetDeliveryHandle(
+        controller: controller, registration: registration, defaults: deliveryFlagDefaults)
       wireObservers(identity: identity)
     } catch {
       Task {
@@ -355,8 +372,6 @@ public final class ModelDeliveryHome {
     }
   }
 
-  /// Settings-row Resume / Try Again: re-enters the single door (resume-aware
-  /// by construction — staged partials survive a cancel).
   // MARK: - #2123: the preview model's own controls
 
   /// Start, resume or retry the preview model's download — one method, because
@@ -539,8 +554,67 @@ public final class ModelDeliveryHome {
     Task { await handle.cancelActiveFetch() }
   }
 
+  /// Settings-row Resume / Try Again: re-enters the single door (resume-aware
+  /// by construction — staged partials survive a cancel).
+  ///
+  /// **Honours the parakeet family kill switch** (#2139). `ensureAvailable()` does
+  /// NOT enforce the flag — it is a straight pass-through to
+  /// `ModelDeliveryController.ensureModelAvailable`, and the controller's flag
+  /// snapshot drives revalidation, source selection and telemetry, never a
+  /// refusal. So for FETCH the enforcement is caller-owned, and a door that omits
+  /// the check does not weaken the flag, it ignores it. (Deletion is different and
+  /// is guarded centrally inside `sweepSupersededStaging` — do not read this
+  /// comment as a claim about the whole controller.)
+  ///
+  /// **Three delivery-managed doors reach a Parakeet fetch, and this was the only
+  /// unguarded one.** Automatic warm-up checks `isEnabled()` immediately before
+  /// its own `ensureAvailable()`; the one-shot load-miss `repair()` in the same
+  /// warm-up runs under that call's own already-taken answer, deliberately, so it
+  /// is not re-checked here or there; this door checked nothing at all, so an
+  /// operator who had frozen delivery could still start a multi-gigabyte fetch
+  /// from Settings.
+  ///
+  /// **What the flag does NOT do**, so nobody reads this guard as more than it is:
+  /// it stands owned delivery down and hands Parakeet back to the legacy
+  /// FluidAudio path, which fetches on its own (`parakeetCacheOnly = false`). It
+  /// also does not stop an attempt already in flight — the controller snapshots
+  /// flags once per attempt — so flipping it mid-download leaves the Settings row
+  /// showing progress and Cancel, exactly as before.
+  ///
+  /// **Before the mutation claim, not inside it.** Taking
+  /// `engineMutationScope.withClaim` and then refusing would serialise a refused
+  /// download against a dictation's engine switch — the limb interfering with the
+  /// heart — for work that was never going to happen.
+  ///
+  /// `cancelParakeetDownload` is deliberately NOT gated, and must stay that way: a
+  /// delivery kill switch must never strand someone mid-download with no way to
+  /// stop it, and cancelling starts no network work. Same shape as
+  /// `WhisperKitDeliveryHandle.cancelActiveFetch()`
+  /// (`WhisperKitModelDelivery.swift:111`), which is ungated for that stated reason.
   public func resumeParakeetDownload() {
     guard let handle = parakeetHandle else { return }
+    guard handle.isEnabled() else {
+      parakeetResumeRefusalsForTests += 1
+      // A DEBUG diagnostic, and it is worth being exact about that rather than
+      // calling it "logging the refusal": `AppLogger.log` compiles to a no-op in
+      // release, so this reaches a developer reproducing the report and never a
+      // shipping user. It earns its place anyway — the flag is set remotely, so
+      // whoever debugs this would otherwise have no way to tell a refused Resume
+      // from a broken one.
+      //
+      // KNOWN LIMIT, deliberately not fixed here: in a shipping build the row
+      // still offers Resume and pressing it now does nothing visible. Giving the
+      // row a disabled state would be a user-facing change to a surface whose
+      // whole point is that the flag ships absent, so it belongs to whoever
+      // decides that, not to this internal rollback fix.
+      Task {
+        await AppLogger.shared.log(
+          "Parakeet resume refused: the parakeet delivery kill switch is off "
+            + "(modelDelivery.parakeet.enabled = false)",
+          level: .info, category: "Delivery")
+      }
+      return
+    }
     Task { [weak self] in
       guard let self else { return }
       // #1707 Phase 3 (§3.2, row 17): hold a mutation claim for the FULL

--- a/Sources/EnviousWisprAppKit/App/ModelDeliveryHome.swift
+++ b/Sources/EnviousWisprAppKit/App/ModelDeliveryHome.swift
@@ -73,13 +73,17 @@ public final class ModelDeliveryHome {
   package private(set) var parakeetStateUpdatesForTests = 0
 
   /// How many times the Parakeet Resume door has REFUSED on the family kill
-  /// switch. A test seam, and specifically a POSITIVE one: the refusal path
-  /// returns before any `Task` is created, so this is incremented synchronously
-  /// on the main actor and is already true when `resumeParakeetDownload()`
-  /// returns. Without it the flag-OFF arm could only assert two absences — no
-  /// claim taken, no delivery reached — and an absence cannot distinguish "the
-  /// guard refused" from "the door has not run yet", which is the vacuity this
-  /// counter exists to remove.
+  /// switch, from EITHER of its two checks. A test seam, and specifically a
+  /// POSITIVE one: without it the flag-OFF arm could only assert two absences —
+  /// no claim taken, no delivery reached — and an absence cannot distinguish
+  /// "the guard refused" from "the door has not run yet", which is the vacuity
+  /// this counter exists to remove.
+  ///
+  /// A flag that is off when the button is pressed takes the SYNCHRONOUS check,
+  /// which returns before any `Task` is created, so the count is already correct
+  /// when `resumeParakeetDownload()` returns and the flag-OFF arm needs no wait.
+  /// The second check can only fire on a flag that flipped inside the window
+  /// between the two, which no test stages today.
   package private(set) var parakeetResumeRefusalsForTests = 0
   /// Monotonic apply guard (EG-1 `installStateSeqApplied` precedent, made
   /// REAL per exhaustive r7 finding 7): the sequence is minted at observer-
@@ -581,10 +585,22 @@ public final class ModelDeliveryHome {
   /// flags once per attempt — so flipping it mid-download leaves the Settings row
   /// showing progress and Cancel, exactly as before.
   ///
-  /// **Before the mutation claim, not inside it.** Taking
-  /// `engineMutationScope.withClaim` and then refusing would serialise a refused
-  /// download against a dictation's engine switch — the limb interfering with the
-  /// heart — for work that was never going to happen.
+  /// **Checked TWICE, and the pair is deliberate.**
+  ///
+  /// The synchronous check is the one that matters for the ordinary case: it
+  /// refuses before any `Task` exists, so a refused download never takes an
+  /// engine mutation claim and never serialises against a dictation's engine
+  /// switch — the limb interfering with the heart, for work that was never going
+  /// to happen.
+  ///
+  /// The re-read inside the `Task`, immediately before the claim, closes what the
+  /// synchronous check alone leaves open: the flag is read on the main actor and
+  /// the `Task` runs later, so an operator flip landing in that window would
+  /// otherwise start the fetch on a stale answer. It NARROWS rather than closes —
+  /// the controller snapshots flags once per attempt, so some window always
+  /// remains between the last read and the bytes moving, and there is no site
+  /// that removes it. It is here because it is three lines and the failure is
+  /// SILENT: a fetch begins that an operator asked to stop, and nothing says so.
   ///
   /// `cancelParakeetDownload` is deliberately NOT gated, and must stay that way: a
   /// delivery kill switch must never strand someone mid-download with no way to
@@ -617,6 +633,17 @@ public final class ModelDeliveryHome {
     }
     Task { [weak self] in
       guard let self else { return }
+      // The re-read (see the doc comment above). Still BEFORE the claim, for the
+      // same reason the synchronous one is: a refusal must not take the claim.
+      guard handle.isEnabled() else {
+        self.parakeetResumeRefusalsForTests += 1
+        await AppLogger.shared.log(
+          "Parakeet resume refused: the parakeet delivery kill switch went off "
+            + "between the button and the download starting "
+            + "(modelDelivery.parakeet.enabled = false)",
+          level: .info, category: "Delivery")
+        return
+      }
       // #1707 Phase 3 (§3.2, row 17): hold a mutation claim for the FULL
       // download.
       _ = await self.engineMutationScope.withClaim(site: "parakeetResumeDownload") {

--- a/Tests/EnviousWisprTests/App/ModelDeliveryHomeTests.swift
+++ b/Tests/EnviousWisprTests/App/ModelDeliveryHomeTests.swift
@@ -77,6 +77,13 @@ struct ModelDeliveryHomeTests {
     #expect(box.wakeCalls == 0, "a refused claim never owes a wake")
   }
 
+  /// The flag store is INJECTED and explicitly ENABLED, which this test did not
+  /// need before #2139 and does now. `resumeParakeetDownload` reads the parakeet
+  /// family kill switch, so without an injected suite it reads the real
+  /// operational one — and on a machine where a developer has that switch set
+  /// false the door refuses before the claim and this test fails on MACHINE
+  /// STATE rather than on code. Found by cloud review; the omission was harmless
+  /// only for as long as this door read no flag.
   @Test("a gate-refused resume reports the site and never releases or wakes")
   func aGateRefusedResumeReportsTheSiteAndNeverReleasesOrWakes() async throws {
     final class Box: @unchecked Sendable {
@@ -85,6 +92,8 @@ struct ModelDeliveryHomeTests {
       var refusedSites: [String] = []
     }
     let box = Box()
+    let suite = try #require(UserDefaults(suiteName: "ew-2139-resume-\(UUID().uuidString)"))
+    suite.set(true, forKey: "modelDelivery.parakeet.enabled")
     let home = ModelDeliveryHome(
       engineMutationScope: .live(
         tryBegin: { false },
@@ -95,7 +104,8 @@ struct ModelDeliveryHomeTests {
         wake: { box.wakeCalls += 1 },
         onRefused: { box.refusedSites.append($0) }),
       manifestBundle: try Self.manifestBundle(),
-      appSupportOverride: try Self.tempAppSupport())
+      appSupportOverride: try Self.tempAppSupport(),
+      deliveryFlagDefaults: suite)
 
     home.resumeParakeetDownload()
     // Signal, not clock: wait for the gate's own refusal telemetry, proving

--- a/Tests/EnviousWisprTests/App/ModelDeliveryHomeTests.swift
+++ b/Tests/EnviousWisprTests/App/ModelDeliveryHomeTests.swift
@@ -415,6 +415,84 @@ struct ModelDeliveryHomeTests {
     )
   }
 
+  /// The Parakeet Resume door honours `modelDelivery.parakeet.enabled` (#2139).
+  ///
+  /// The flag is enforced per FETCH door by the caller — the controller's own
+  /// snapshot drives revalidation, source order and telemetry, never a refusal —
+  /// so a door that omits the check ignores the flag rather than weakening it.
+  /// Automatic warm-up checks it; this door did not, so an operator who had frozen
+  /// delivery could still start a multi-gigabyte fetch from Settings.
+  ///
+  /// **Both directions in one case**, because either half alone is satisfiable by
+  /// the opposite bug: flag-off must not reach the mutation claim, and flag-on
+  /// must still reach it. A one-way test passes against a door welded shut, which
+  /// breaks Resume for every user in order to honour a flag almost nobody sets.
+  ///
+  /// **The claim is the observable, and the gate is deliberately set to REFUSE.**
+  /// `withClaim` calls `tryBegin` before anything else and reports the site
+  /// through `onRefused`, so a refused claim proves control reached the claim —
+  /// which is the statement immediately after the guard — while `ensureAvailable()`
+  /// is never called. That last part is not a convenience: unlike its two
+  /// siblings, Parakeet's install directory is deliberately NOT rerouted by
+  /// `appSupportOverride` (it comes from `AsrModels.defaultCacheDirectory`), so a
+  /// flag-on arm that reached real delivery would validate or fetch against the
+  /// developer's own model cache and the network.
+  ///
+  /// **The flag-off arm asserts a POSITIVE.** `parakeetResumeRefusalsForTests` is
+  /// incremented synchronously inside the guard, on the main actor, before any
+  /// `Task` exists — so it is already true when the call returns and there is
+  /// nothing to wait for. The companion `refusedSites` assertion is a genuine
+  /// absence and is safe for the same structural reason: the refusal path creates
+  /// no `Task`, so nothing could ever append to it later.
+  ///
+  /// The flag store is injected. Reading the real one would mean writing an
+  /// operational delivery kill switch onto a developer's machine.
+  @Test("the Parakeet Resume door honours the parakeet kill switch, both ways")
+  func parakeetResumeHonoursTheKillSwitch() async throws {
+    final class Box: @unchecked Sendable {
+      var refusedSites: [String] = []
+    }
+
+    func makeHome(enabled: Bool, box: Box) throws -> ModelDeliveryHome {
+      let suite = try #require(UserDefaults(suiteName: "ew-2139-killswitch-\(UUID().uuidString)"))
+      suite.set(enabled, forKey: "modelDelivery.parakeet.enabled")
+      return ModelDeliveryHome(
+        engineMutationScope: .live(
+          tryBegin: { false },
+          end: { false },
+          wake: {},
+          onRefused: { box.refusedSites.append($0) }),
+        manifestBundle: try Self.manifestBundle(),
+        appSupportOverride: try Self.tempAppSupport(),
+        deliveryFlagDefaults: suite)
+    }
+
+    let offBox = Box()
+    let off = try makeHome(enabled: false, box: offBox)
+    off.resumeParakeetDownload()
+    #expect(
+      off.parakeetResumeRefusalsForTests == 1,
+      "with the kill switch off the door must refuse synchronously, before any Task exists")
+    #expect(
+      offBox.refusedSites.isEmpty,
+      "a refused door must not reach the mutation claim: a download that is never going to happen must not serialise against a dictation's engine switch"
+    )
+
+    let onBox = Box()
+    let on = try makeHome(enabled: true, box: onBox)
+    on.resumeParakeetDownload()
+    // Signal, not clock: wait for the gate's own refusal telemetry, which the
+    // subject fires from inside the door's Task.
+    for _ in 0..<400 where onBox.refusedSites.isEmpty { await Task.yield() }
+    #expect(
+      on.parakeetResumeRefusalsForTests == 0,
+      "with the flag ON nothing may refuse on the kill switch")
+    #expect(
+      onBox.refusedSites == ["parakeetResumeDownload"],
+      "with the flag ON the door must still reach delivery; a welded-shut door would pass the assertions above"
+    )
+  }
+
   /// A refused removal must still END the removal, or Live Preview dies for the
   /// rest of the launch.
   ///


### PR DESCRIPTION
Closes #2139.

## What was wrong

`modelDelivery.parakeet.enabled` is an operator rollback: it stands model delivery down without shipping a build. The Settings-row **Resume / Try Again** button never consulted it, so with delivery frozen that button could still start a multi-gigabyte fetch.

The flag is enforced per FETCH door, by the caller. `ensureAvailable()` is a straight pass-through to `ModelDeliveryController.ensureModelAvailable`, and the controller's flag snapshot drives revalidation, source order and telemetry — never a refusal. So a door that omits the check does not weaken the flag, it ignores it. Automatic warm-up checks it (`ParakeetEngineAdapter.swift:334`); this door did not.

## Two changes, and the second is upstream of the first

**The guard**, placed before `engineMutationScope.withClaim`. Taking the engine mutation claim and then refusing would serialise a download that is never going to happen against a dictation's engine switch — a limb interfering with the heart.

**`deliveryFlagDefaults` threaded into the Parakeet handle's construction.** Both sibling handles already pass it; this one did not, so it resolved `nil` to the real operational suite. A guard added to the door alone would have read the live shared kill-switch store, and the only way to exercise it would have been writing an operational delivery flag onto a developer's machine — exactly what that injection point exists to prevent. Production behaviour is unchanged by construction: the only caller passing a non-nil value is the test suite.

Plus a doc comment that had drifted 185 lines from the method it describes, where it sat above the preview door's `MARK` and documented the wrong method. Moved verbatim.

## Test

One case, both directions, because either half alone is satisfiable by the opposite bug — a one-way test passes against a door welded shut, which breaks Resume for every user to honour a flag almost nobody sets.

**The observable is the mutation claim, and the gate is deliberately set to REFUSE.** `withClaim` calls `tryBegin` first and reports the site through `onRefused`, so flag-ON proves control reached the claim — the statement immediately after the guard — while `ensureAvailable()` is never called.

That last part is not a convenience, and it is the one thing here that does not generalise from the sibling test: **Parakeet's install directory is deliberately NOT rerouted by `appSupportOverride`** (`ModelDeliveryHome.swift:136`, and the init's own doc comment says so). An arm that reached real delivery would validate or fetch against the developer's actual model cache and the network. The preview test is safe from that only because its install directory IS rerouted.

**Flag-OFF asserts a POSITIVE**, via a synchronous refusal counter incremented inside the guard before any `Task` exists. Without it that arm could assert only absences, and an absence cannot separate "the guard refused" from "the door has not run yet". Its companion absence assertion (`refusedSites.isEmpty`) is safe for a structural reason rather than a timing one: the refusal path creates no `Task`, so nothing can append later.

## From the Codex grounded review

Full adjudication, adopted and rejected alike, in `docs/audits/2026-08-24-2139-adjudication-r1.md`.

**Adopted.** The plan's sweep was not a closed world — a third delivery-managed door exists. The refusal is a DEBUG-only diagnostic, not operator-visible feedback: `AppLogger.log` compiles to a no-op in release. And the flag neither stops an in-flight attempt (flags are snapshotted once per attempt) nor covers the legacy FluidAudio path it rolls back TO. All three are now stated at the code rather than left implied.

**Rejected, with evidence: re-reading the flag at the load-miss `repair()` door.** It is reachable only from a warm-up that already answered `isEnabled()` at its top (`deliveryActive`, `ParakeetEngineAdapter.swift:378-386`); the controller snapshots flags once per attempt, so no other step has stop-button behaviour either; and the proposed edit throws *after* `parakeetCacheOnly` is already `true`, which would convert a recoverable load-miss into a failed warm-up on the dictation path with the legacy fallback never taken. Classified HYPOTHETICAL. **Not silently dropped** — that door is now named in the shipped doc comment with the reason it is deliberately not re-checked, so the next person sweeping these doors does not re-derive it.

**Rejected: an `ensureParakeetAvailableOverrideForTests` production seam.** The problem it solved is real and is adopted above; a seam whose only consumer is a test is how a test comes to prove the caller honours a stub while the production body never runs. Refusing the injected gate costs nothing and reuses a pattern this same file already uses twice.

## Known limit, named rather than omitted

In a shipping build the Settings row still offers Resume, and pressing it with the flag off now does nothing visible. Giving the row a disabled state is a user-facing change to a surface whose whole premise is that the flag ships absent, so it belongs to whoever decides that, not to this internal rollback fix. Recorded at the code.

## Validation

- Filtered `ModelDeliveryHomeTests`: 13 tests green, and the new case's display name is present in the log — it ran, not merely compiled.
- Full lane, Debug + Release.
- No mutants run: no mutation battery in the founder's day. The recipe is frozen at filing in **#2389**, with multi-line anchors because both obvious one-line anchors are ambiguous in this file (the preview door carries an identical guard line, and all three handles carry an identical `defaults:` line).
- The parent-commit control is unavailable by construction: the test reads a seam the fix introduces, so it cannot compile against the parent. Stated rather than skipped.
- Live UAT not required: the flag ships absent, the flag-ON behaviour is unchanged, and both directions are asserted at the seam.

Lane: `Code`. Tier: MEDIUM.

## Round 2 — the Codex diff review, both P2s adopted

Adjudication: `docs/audits/2026-08-24-2139-adjudication-r2.md`.

**A regression this branch introduced, and it is the more important of the two.** `aGateRefusedResumeReportsTheSiteAndNeverReleasesOrWakes` constructs `ModelDeliveryHome` with no `deliveryFlagDefaults`. That was harmless for as long as this door read no flag — **the guard is what made it matter.** On a machine where a developer has `modelDelivery.parakeet.enabled` set false, the door now refuses before the claim and a test about the *mutation gate* fails on machine state. Given an explicitly enabled injected suite, with the reason recorded at the test.

The class is worth naming because neither reading the diff nor a green suite can show it: **adding a read to a shared door retroactively makes every existing CALLER of that door sensitive to the thing being read, and none of those callers appear in the diff.** I had swept for the new identifier and for `ensureAvailable`, and never asked "who else calls this door". Swept mechanically now rather than by eye — every test reaching any flag-reading door either injects a suite or bypasses the flag through `deletePreviewModelOverrideForTests`. Six such tests, all accounted for, none left on machine state.

**The flag is re-read inside the task, immediately before the claim.** It is read synchronously and the task runs later, so an operator flip in that window would start the fetch on a stale answer. Classified HYPOTHETICAL and fixed anyway, because the rule fixes a hypothetical when the fix is trivial AND the failure is silent — and a multi-gigabyte fetch beginning after an operator asked delivery to stop announces itself nowhere.

The review proposed MOVING the check. **Kept both instead**, because moving it loses two things: every refused press would then allocate and schedule a `Task`, and the refusal counter would go behind an `await`, turning the flag-OFF arm's positive assertion back into a waited-on absence — the exact vacuity that counter was added to remove.

Stated at the code: this **narrows, it does not close.** The controller snapshots flags once per attempt, so a window always remains between the last read and the bytes moving, and no site removes it. Saying so is what stops a later reader believing the flag is a stop button.

## Final validation

- Debug lane **6,640** (6,434 + 206), Release lane **5,996** (5,790 + 206) — both green, both reconciling exactly against their per-bundle lines, so no second writer inflated either count.
- Filtered `ModelDeliveryHomeTests` 13/13, new case's display name present in the log.
- `check-cited-symbols.py` clean: 19 symbols, 1 `file:line` citation. It caught one fabricated symbol during self-review — a comment citing `WhisperKitModelDelivery.cancelActiveFetch()`, which is a FILE name used as a type name; the type is `WhisperKitDeliveryHandle`.
