### PR TITLE
feat: Quick Add — capture a misheard word from anywhere on macOS (#2381)

### DIFF
--- a/Sources/EnviousWispr/Resources/Info.plist
+++ b/Sources/EnviousWispr/Resources/Info.plist
@@ -38,6 +38,24 @@
 	<string>EnviousWispr needs microphone access for speech-to-text dictation.</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSServices</key>
+	<array>
+		<dict>
+			<key>NSMenuItem</key>
+			<dict>
+				<key>default</key>
+				<string>Add to EnviousWispr Words</string>
+			</dict>
+			<key>NSMessage</key>
+			<string>quickAddWord</string>
+			<key>NSPortName</key>
+			<string>EnviousWispr</string>
+			<key>NSSendTypes</key>
+			<array>
+				<string>public.utf8-plain-text</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSSpeechRecognitionUsageDescription</key>
 	<string>EnviousWispr uses on-device speech recognition to show your words in the recording pill while you speak. This preview stays on your Mac and is never the text that gets pasted.</string>
 	<key>PostHogAPIKey</key>

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/HotkeyController.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/HotkeyController.swift
@@ -53,6 +53,11 @@ final class HotkeyController {
     hotkeyService.recordingMode = settings.recordingMode
     hotkeyService.cancelKeyCode = settings.cancelKeyCode
     hotkeyService.cancelModifiers = settings.cancelModifiers
+    // #2381. Pushed here as well as through `PipelineSettingsSync`, for the same reason the other
+    // two are: the sync path carries CHANGES, and without an initial push the service would
+    // register its own compiled-in default until the user happened to edit the shortcut.
+    hotkeyService.quickAddKeyCode = settings.quickAddKeyCode
+    hotkeyService.quickAddModifiers = settings.quickAddModifiers
     hotkeyService.toggleKeyCode = settings.toggleKeyCode
     hotkeyService.toggleModifiers = settings.toggleModifiers
     hotkeyService.onToggleRecording = { [weak starter] in

--- a/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
+++ b/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
@@ -181,6 +181,12 @@ final class PipelineSettingsSync {
     case .cancelKeyCode:
       hotkeyService.cancelKeyCode = settings.cancelKeyCode
       hotkeyService.reapplyCancelBinding()
+    case .quickAddKeyCode:
+      hotkeyService.quickAddKeyCode = settings.quickAddKeyCode
+      hotkeyService.reapplyQuickAddBinding()
+    case .quickAddModifiers:
+      hotkeyService.quickAddModifiers = settings.quickAddModifiers
+      hotkeyService.reapplyQuickAddBinding()
     case .cancelModifiers:
       hotkeyService.cancelModifiers = settings.cancelModifiers
       hotkeyService.reapplyCancelBinding()

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddCoordinator.swift
@@ -82,8 +82,13 @@ final class QuickAddCoordinator {
     var refreshWords: () -> Bool
     var userWords: () -> [CustomWord]
     var packTerms: () -> [CustomWord]
-    /// Persist a word. Returns nil on success, or a user-facing message.
-    var saveWord: (CustomWord) -> String?
+    /// Persist a word and CONFIRM the spelling is on it afterwards. Returns nil only when both
+    /// happened, or a user-facing message.
+    ///
+    /// The spelling is a separate parameter rather than read off `word.aliases.last`, because the
+    /// postcondition would then depend on the caller having appended last — a fact no signature
+    /// states and one edit could change without anything failing.
+    var saveWord: (CustomWord, String) -> String?
     /// Open the existing edit sheet on a new word carrying the heard spelling as its first alias.
     var presentNewWordSheet: (String) -> Void
     var emit: (QuickAddEvent) -> Void
@@ -217,7 +222,7 @@ final class QuickAddCoordinator {
     var word = candidate.word.ownedByUser()
     word.aliases.append(model.spellingToWrite)
 
-    if let message = environment.saveWord(word) {
+    if let message = environment.saveWord(word, model.spellingToWrite) {
       // `reason` stays a fixed token, never the message: the message is authored for a human and
       // can quote what they selected, which is the one thing telemetry may not carry.
       environment.emit(.failed(stage: "save", reason: "refused"))

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddCoordinator.swift
@@ -216,6 +216,55 @@ final class QuickAddCoordinator {
     environment.emit(.failed(stage: "present", reason: "unmeasurable_panel"))
   }
 
+  /// What an accept should write INTO, decided against the library as it is NOW.
+  enum MergeTarget: Equatable {
+    /// A pack term, converted to a user-owned override. Nothing in the user library to merge into.
+    case override(CustomWord)
+    /// A user word still in the library. Carries the CURRENT entry, never the snapshot.
+    case live(CustomWord)
+    /// It was in the library when the panel was ranked and is not there now.
+    case gone
+  }
+
+  /// Resolve the merge target from the LIVE library rather than the ranking's snapshot.
+  ///
+  /// **`candidate.word` is a snapshot taken when the panel was ranked, and the panel is now
+  /// persistent.** `windowDidResignKey` is deliberately a no-op — because treating focus loss as a
+  /// dismissal cancelled the panel 339 ms after opening — so it can sit open across a visit to
+  /// Settings. Appending an alias to that snapshot and handing it to `CustomWordsManager.update`
+  /// replaces the WHOLE stored entry, so a canonical, alias, category, strictness or usage change
+  /// made in between is silently reverted: a write that reports success while undoing the user's own
+  /// edit.
+  ///
+  /// A third instance of two correct fixes composing into a defect neither had alone. Persistence
+  /// was the fix for self-cancellation, and persistence is what gives the snapshot time to go stale.
+  ///
+  /// `.gone` is the same defect pointing the other way and is why this returns three cases rather
+  /// than an optional: writing the snapshot back for a word deleted while the panel sat open would
+  /// RESURRECT it, which is a silent undo of a deletion rather than of an edit.
+  ///
+  /// Scope, stated rather than implied: this reads the in-memory library, which is the one the
+  /// editor writes through, so it covers every edit made inside this app. It is not a cross-process
+  /// claim, and the app does not support a second instance.
+  static func mergeTarget(
+    for candidate: QuickAddRanker.Candidate, in userWords: [CustomWord]
+  ) -> MergeTarget {
+    // ASKED BEFORE THE PACK BRANCH, and the order is the whole point. `ownedByUser()` PRESERVES the
+    // id, so a pack term the user overrode while this panel sat open is now a real user entry under
+    // that same id — and converting the snapshot again would overwrite the override they just made.
+    // A pack candidate that has not been overridden cannot be here: `packTermsNotOverridden` filters
+    // the ranking by exactly this id set, so a pack row reaching this line has no live twin.
+    if let current = userWords.first(where: { $0.id == candidate.word.id }) {
+      return .live(current)
+    }
+    // A PACK term cannot be written through the words coordinator: `CustomWordsManager.update` looks
+    // the id up in the user library, does not find it, and returns having written NOTHING. Convert
+    // to a user-owned override first. The resulting override reaches the polish lane as well as the
+    // corrector lane, which the underlying pack term never did.
+    guard !candidate.isPackTerm else { return .override(candidate.word.ownedByUser()) }
+    return .gone
+  }
+
   /// The user accepted a row.
   ///
   /// **Returns the refusal message when the library would not take the word, and nil otherwise.**
@@ -237,11 +286,27 @@ final class QuickAddCoordinator {
       return nil
     }
 
-    // A PACK term cannot be written through the words coordinator: `CustomWordsManager.update` looks
-    // the id up in the user library, does not find it, and returns having written NOTHING. Convert
-    // to a user-owned override first. The resulting override reaches the polish lane as well as the
-    // corrector lane, which the underlying pack term never did.
-    var word = candidate.word.ownedByUser()
+    var word: CustomWord
+    switch Self.mergeTarget(for: candidate, in: environment.userWords()) {
+    case .override(let converted): word = converted
+    case .live(let current): word = current
+    case .gone:
+      environment.emit(.failed(stage: "save", reason: "target_gone"))
+      return QuickAddPanelCopy.wordNoLongerExists
+    }
+
+    // The guard above answers this from the ranking taken when the panel OPENED. The library can
+    // have gained the spelling since — added in Settings, or by a sibling accept while this panel
+    // sat open — and appending it again would store it twice and report success. One outcome, two
+    // sources, and the live source is the one that decides.
+    guard
+      !word.aliases.contains(where: {
+        $0.caseInsensitiveCompare(model.spellingToWrite) == .orderedSame
+      })
+    else {
+      finish(.alreadySaved, usedSearch: usedSearch, rank: rank, kind: kind)
+      return nil
+    }
     word.aliases.append(model.spellingToWrite)
 
     if let message = environment.saveWord(word, model.spellingToWrite) {

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddCoordinator.swift
@@ -47,8 +47,6 @@ enum QuickAddOutcome: String, Equatable, Sendable, CaseIterable {
   case createdNew = "created_new"
   /// Escape, clicking away, or closing the panel.
   case cancelled
-  /// The user accepted, and the write was refused.
-  case writeFailed = "write_failed"
   /// The word already carried this spelling, so there was nothing to write.
   case alreadySaved = "already_saved"
 }
@@ -250,7 +248,12 @@ final class QuickAddCoordinator {
       // `reason` stays a fixed token, never the message: the message is authored for a human and
       // can quote what they selected, which is the one thing telemetry may not carry.
       environment.emit(.failed(stage: "save", reason: "refused"))
-      finish(.writeFailed, usedSearch: usedSearch, rank: rank, kind: kind)
+      // **DELIBERATELY NOT A RESOLUTION, and the outcome member it used to emit is gone.** A refused
+      // write leaves the panel OPEN — that is the whole point of the fix that introduced it — so the
+      // invocation has not ended and the user can still succeed or give up. Resolving here emitted
+      // `write_failed` and then a second `resolved` when they did either, which is two terminal
+      // events for one open. `resolved` means ENDED; the refusal is reported by the `failed` event
+      // above, which is what that channel is for.
       return message
     }
     finish(
@@ -293,7 +296,16 @@ final class QuickAddCoordinator {
   private func finish(
     _ outcome: QuickAddOutcome, usedSearch: Bool, rank: Int?, kind: QuickAddTargetKind?
   ) {
-    let started = startedAt ?? environment.now()
+    // **A SECOND RESOLUTION IS REFUSED, LOUDLY, rather than substituted for.** The old
+    // `startedAt ?? environment.now()` invented a start time for an invocation that had already
+    // ended, which is what let one open produce two terminal events with plausible elapsed times on
+    // both. Removing the reason (above) and removing the possibility are different jobs: this is the
+    // second, and it reports rather than swallows, because a silent drop is how the funnel would
+    // come to disagree with reality without anyone learning why.
+    guard let started = startedAt else {
+      environment.emit(.failed(stage: "resolve", reason: "double_resolution"))
+      return
+    }
     startedAt = nil
     environment.emit(
       .resolved(

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddCoordinator.swift
@@ -226,7 +226,7 @@ final class QuickAddCoordinator {
   /// already had this shape; this one did not.
   @discardableResult
   func accept(_ candidate: QuickAddRanker.Candidate, from model: QuickAddPanelModel) -> String? {
-    let usedSearch = !model.query.isEmpty
+    let usedSearch = model.isSearching
     let rank = model.ranking.candidates.firstIndex { $0.id == candidate.id }
     let kind: QuickAddTargetKind = candidate.isPackTerm ? .packTerm : .userWord
 
@@ -283,7 +283,7 @@ final class QuickAddCoordinator {
 
   /// Escape, clicking away, or the panel closing.
   func cancel(from model: QuickAddPanelModel) {
-    finish(.cancelled, usedSearch: !model.query.isEmpty, rank: nil, kind: nil)
+    finish(.cancelled, usedSearch: model.isSearching, rank: nil, kind: nil)
   }
 
   // MARK: - Internals

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddCoordinator.swift
@@ -153,10 +153,16 @@ final class QuickAddCoordinator {
       refusal = nil
     case .noSelection:
       heard = ""
-      // No selection is not an error and not a success. It reaches the panel as the one refusal
-      // meaning "you have not told me anything yet"; the panel then states it and offers the
-      // by-hand route, which is the only control that can do anything without a heard word.
-      refusal = .selectionUnavailable
+      // No selection is not an error and not a success: the read SUCCEEDED and there was nothing to
+      // read. It reaches the panel as the refusal meaning "you have not told me anything yet", the
+      // panel states it, and the by-hand route is the only control that can do anything without a
+      // heard word.
+      //
+      // **This used to be `.selectionUnavailable`, whose sentence names TERMINALS and accuses the
+      // frontmost app of withholding a selection.** Pressing the shortcut having highlighted nothing
+      // is the likeliest way to reach a refusal at all, so the commonest case got a confident
+      // diagnosis of an app that had done nothing wrong instead of "select a word first".
+      refusal = .nothingSelected
     case .refused(let reason):
       heard = ""
       refusal = reason
@@ -256,6 +262,27 @@ final class QuickAddCoordinator {
     // the ranking by exactly this id set, so a pack row reaching this line has no live twin.
     if let current = userWords.first(where: { $0.id == candidate.word.id }) {
       return .live(current)
+    }
+    // **A pack row whose CANONICAL the user already owns under a different id.** `ownedByUser()`
+    // keeps the pack's id, and `packTermsNotOverridden` filters the ranking by ID, so a user word
+    // called "Codec" and an enabled pack term called "Codec" are two rows with two ids and one name.
+    // Converting the pack snapshot then hands `CustomWordsManager.add` a colliding canonical, which
+    // it refuses SILENTLY (`guard !words.contains(sameCanonical) else { return }`) — and the
+    // post-write confirmation then finds the spelling on the USER word and reports success for an
+    // override that was never created.
+    //
+    // Merging into the user's own entry is not a consolation prize, it is the only action that can
+    // succeed: while that canonical is taken, no override under it is writable, and the end state
+    // the user asked for — this spelling maps to that word — is exactly what this produces.
+    //
+    // Scoped to pack rows deliberately. A USER candidate missing by id is `.gone`, which is a
+    // deletion the panel must not paper over by matching on a name that happens to be reused.
+    if candidate.isPackTerm,
+      let sameName = userWords.first(where: {
+        $0.canonical.caseInsensitiveCompare(candidate.word.canonical) == .orderedSame
+      })
+    {
+      return .live(sameName)
     }
     // A PACK term cannot be written through the words coordinator: `CustomWordsManager.update` looks
     // the id up in the user library, does not find it, and returns having written NOTHING. Convert

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddCoordinator.swift
@@ -178,7 +178,11 @@ final class QuickAddCoordinator {
           packTerms: environment.packTerms())
       })
 
-    environment.emit(
+    // HELD, not emitted. `opened` names an event the user can see, so it fires when a panel is
+    // actually on screen — see `didOpen()`. Emitting it here made presentation failure the one
+    // remaining way to leave an open with nothing to resolve it, and it is the only such path that
+    // cannot report a reason of its own.
+    pendingOpen =
       .opened(
         door: door,
         refusal: refusal,
@@ -188,10 +192,30 @@ final class QuickAddCoordinator {
         heardScalarCount: heard.unicodeScalars.count,
         candidateCount: model.ranking.candidates.count,
         preselected: model.ranking.preselectedID != nil,
-        topScore: model.ranking.topScore))
+        topScore: model.ranking.topScore)
 
     self.startedAt = startedAt
     return model
+  }
+
+  /// The panel is on screen. Emits the held `opened` event.
+  ///
+  /// Split from `begin` so the funnel counts panels rather than attempts: one `opened`, one
+  /// `resolved`, and no way to have the first without the second.
+  func didOpen() {
+    guard let event = pendingOpen else { return }
+    pendingOpen = nil
+    environment.emit(event)
+  }
+
+  /// The panel could NOT be shown. Discards the held `opened` and reports why.
+  ///
+  /// Never a `resolved`: nothing opened, so there is nothing to resolve, and inventing an outcome
+  /// here would put a phantom row in the denominator of every rate computed from this funnel.
+  func failedToOpen() {
+    pendingOpen = nil
+    startedAt = nil
+    environment.emit(.failed(stage: "present", reason: "unmeasurable_panel"))
   }
 
   /// The user accepted a row.
@@ -246,8 +270,12 @@ final class QuickAddCoordinator {
   }
 
   /// The sheet saved, and the word is confirmed present. Called by the caller that checked.
-  func didCreateNew(from model: QuickAddPanelModel) {
-    finish(.createdNew, usedSearch: !model.query.isEmpty, rank: nil, kind: nil)
+  ///
+  /// Takes `usedSearch` rather than a model because the panel may already be gone — the sheet
+  /// outlives it in at least one ordering — and an `if let model` at the call site made a CONFIRMED
+  /// save emit nothing at all, which is the funnel hole this whole split exists to close.
+  func didCreateNew(usedSearch: Bool) {
+    finish(.createdNew, usedSearch: usedSearch, rank: nil, kind: nil)
   }
 
   /// Escape, clicking away, or the panel closing.
@@ -258,6 +286,9 @@ final class QuickAddCoordinator {
   // MARK: - Internals
 
   private var startedAt: Date?
+
+  /// The `opened` event for a panel that has been built and not yet shown.
+  private var pendingOpen: QuickAddEvent?
 
   private func finish(
     _ outcome: QuickAddOutcome, usedSearch: Bool, rank: Int?, kind: QuickAddTargetKind?

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddCoordinator.swift
@@ -1,0 +1,234 @@
+import EnviousWisprCore
+import EnviousWisprPostProcessing
+import EnviousWisprServices
+import Foundation
+
+/// What happened during one Quick Add, as facts rather than as telemetry (#2381).
+///
+/// **Deliberately knows no vendor.** The coordinator emits these; a bridge maps them onto PostHog and
+/// Sentry. Deleting that bridge leaves this feature working, silently, which is the test of whether
+/// observability was bolted on or wired in.
+enum QuickAddEvent: Equatable, Sendable {
+  /// The panel opened. `refusal` nil means a selection was read.
+  case opened(
+    door: QuickAddDoor,
+    refusal: SelectionReader.Refusal?,
+    sourceBundleID: String?,
+    heardScalarCount: Int,
+    candidateCount: Int,
+    preselected: Bool,
+    topScore: Double?)
+
+  /// The panel closed, one way or another.
+  case resolved(
+    outcome: QuickAddOutcome,
+    usedSearch: Bool,
+    candidateRank: Int?,
+    targetKind: QuickAddTargetKind?,
+    elapsedMilliseconds: Int)
+
+  /// Something failed in a way support would need to see. Never user content.
+  case failed(stage: String, reason: String)
+}
+
+/// Which door the user came through.
+enum QuickAddDoor: String, Equatable, Sendable, CaseIterable {
+  case hotkey
+  case service
+}
+
+/// How the panel ended. A closed set, so a new ending cannot inherit another's name.
+enum QuickAddOutcome: String, Equatable, Sendable, CaseIterable {
+  /// The user accepted a ranked row.
+  case accepted
+  /// The user accepted a row they had searched for.
+  case acceptedAfterSearch = "accepted_after_search"
+  /// The user chose to create a new word.
+  case createdNew = "created_new"
+  /// Escape, clicking away, or closing the panel.
+  case cancelled
+  /// The user accepted, and the write was refused.
+  case writeFailed = "write_failed"
+  /// The word already carried this spelling, so there was nothing to write.
+  case alreadySaved = "already_saved"
+}
+
+/// What kind of library entry the user accepted onto.
+enum QuickAddTargetKind: String, Equatable, Sendable, CaseIterable {
+  case userWord = "user_word"
+  /// A shipped pack term, which is CONVERTED to a user-owned override before writing.
+  case packTerm = "pack_term"
+}
+
+/// Drives one Quick Add from a keypress to a written word (#2381).
+///
+/// **Orchestration only.** It does not own the window, does not rank, does not read Accessibility, and
+/// does not know what PostHog is. Every one of those is a collaborator, which is what makes this the
+/// piece you can read to find out what the feature DOES.
+@MainActor
+final class QuickAddCoordinator {
+
+  /// Everything this needs from the rest of the app, as functions rather than objects.
+  ///
+  /// Not ceremony: the alternative is a coordinator holding the words coordinator, the pack manager,
+  /// the ranker and the panel host, which is four objects' worth of API surface reachable from a limb
+  /// and the shape `keep-central-types-thin` refuses. It also makes every branch below testable
+  /// without a window, a words file, or a real selection.
+  struct Environment {
+    var readSelection: () -> SelectionReader.Result
+    var frontmostBundleID: () -> String?
+    /// Returns false when the words file could not be re-read. The panel then says so rather than
+    /// ranking a stale snapshot.
+    var refreshWords: () -> Bool
+    var userWords: () -> [CustomWord]
+    var packTerms: () -> [CustomWord]
+    /// Persist a word. Returns nil on success, or a user-facing message.
+    var saveWord: (CustomWord) -> String?
+    /// Open the existing edit sheet on a new word carrying the heard spelling as its first alias.
+    var presentNewWordSheet: (String) -> Void
+    var emit: (QuickAddEvent) -> Void
+    /// Injected so elapsed time is measurable without waiting.
+    var now: () -> Date = Date.init
+  }
+
+  private let environment: Environment
+  private let ranker = QuickAddRanker()
+
+  init(environment: Environment) {
+    self.environment = environment
+  }
+
+  /// One Quick Add invocation, from either door.
+  ///
+  /// Returns the panel model to present, or nil when there is nothing to present at all. **nil is
+  /// never silence:** the only path that returns it has already emitted a `failed` event, and the
+  /// caller shows nothing because there is genuinely nothing to show.
+  func begin(door: QuickAddDoor, selectionOverride: String? = nil) -> QuickAddPanelModel? {
+    let startedAt = environment.now()
+    let bundleID = environment.frontmostBundleID()
+
+    // Read BEFORE anything activates our app — by the time a panel exists, the frontmost application
+    // is us and the answer would be about our own window.
+    let selection: SelectionReader.Result =
+      selectionOverride.map { .text($0) } ?? environment.readSelection()
+
+    // Refresh before ranking, every invocation. A sibling instance or the Settings window can have
+    // changed the library since launch, and ranking a stale snapshot offers words that no longer
+    // exist and hides ones that do.
+    guard environment.refreshWords() else {
+      environment.emit(
+        .failed(stage: "refresh", reason: "words_unreadable"))
+      environment.emit(
+        .resolved(
+          outcome: .writeFailed, usedSearch: false, candidateRank: nil, targetKind: nil,
+          elapsedMilliseconds: elapsed(since: startedAt)))
+      return nil
+    }
+
+    let heard: String
+    let refusal: SelectionReader.Refusal?
+    switch selection {
+    case .text(let text):
+      heard = text
+      refusal = nil
+    case .noSelection:
+      heard = ""
+      // No selection is not an error and not a success. It reaches the panel as the one refusal that
+      // means "you have not told me anything yet", and the search field is the way forward.
+      refusal = .selectionUnavailable
+    case .refused(let reason):
+      heard = ""
+      refusal = reason
+    }
+
+    let model = QuickAddPanelModel(
+      heard: heard,
+      refusal: refusal,
+      rankHeard: { [ranker, environment] heardString in
+        ranker.rank(
+          heard: heardString, userWords: environment.userWords(),
+          packTerms: environment.packTerms())
+      },
+      searchLibrary: { [ranker, environment] query, heardString in
+        ranker.search(
+          query: query, heard: heardString, userWords: environment.userWords(),
+          packTerms: environment.packTerms())
+      })
+
+    environment.emit(
+      .opened(
+        door: door,
+        refusal: refusal,
+        sourceBundleID: bundleID,
+        // The LENGTH, never the text. `CLAUDE.md` puts the privacy boundary at the network and the
+        // test is whether user content crosses it; a character count is shape.
+        heardScalarCount: heard.unicodeScalars.count,
+        candidateCount: model.ranking.candidates.count,
+        preselected: model.ranking.preselectedID != nil,
+        topScore: model.ranking.topScore))
+
+    self.startedAt = startedAt
+    return model
+  }
+
+  /// The user accepted a row.
+  func accept(_ candidate: QuickAddRanker.Candidate, from model: QuickAddPanelModel) {
+    let usedSearch = !model.query.isEmpty
+    let rank = model.ranking.candidates.firstIndex { $0.id == candidate.id }
+    let kind: QuickAddTargetKind = candidate.isPackTerm ? .packTerm : .userWord
+
+    guard !candidate.alreadyHasHeardSpelling else {
+      // Writing again would add a duplicate and report success. Saying so is the honest outcome, and
+      // it is a distinct one from a refusal because nothing went wrong.
+      finish(.alreadySaved, usedSearch: usedSearch, rank: rank, kind: kind)
+      return
+    }
+
+    // A PACK term cannot be written through the words coordinator: `CustomWordsManager.update` looks
+    // the id up in the user library, does not find it, and returns having written NOTHING. Convert
+    // to a user-owned override first. The resulting override reaches the polish lane as well as the
+    // corrector lane, which the underlying pack term never did.
+    var word = candidate.word.ownedByUser()
+    word.aliases.append(model.spellingToWrite)
+
+    if let message = environment.saveWord(word) {
+      environment.emit(.failed(stage: "save", reason: "refused"))
+      _ = message
+      finish(.writeFailed, usedSearch: usedSearch, rank: rank, kind: kind)
+      return
+    }
+    finish(
+      usedSearch ? .acceptedAfterSearch : .accepted,
+      usedSearch: usedSearch, rank: rank, kind: kind)
+  }
+
+  /// The user chose to create a new word.
+  func createNew(from model: QuickAddPanelModel) {
+    environment.presentNewWordSheet(model.spellingToWrite)
+    finish(.createdNew, usedSearch: !model.query.isEmpty, rank: nil, kind: nil)
+  }
+
+  /// Escape, clicking away, or the panel closing.
+  func cancel(from model: QuickAddPanelModel) {
+    finish(.cancelled, usedSearch: !model.query.isEmpty, rank: nil, kind: nil)
+  }
+
+  // MARK: - Internals
+
+  private var startedAt: Date?
+
+  private func finish(
+    _ outcome: QuickAddOutcome, usedSearch: Bool, rank: Int?, kind: QuickAddTargetKind?
+  ) {
+    let started = startedAt ?? environment.now()
+    startedAt = nil
+    environment.emit(
+      .resolved(
+        outcome: outcome, usedSearch: usedSearch, candidateRank: rank, targetKind: kind,
+        elapsedMilliseconds: elapsed(since: started)))
+  }
+
+  private func elapsed(since start: Date) -> Int {
+    Int((environment.now().timeIntervalSince(start) * 1000).rounded())
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddCoordinator.swift
@@ -91,11 +91,21 @@ final class QuickAddCoordinator {
     var now: () -> Date = Date.init
   }
 
-  private let environment: Environment
+  private var environment: Environment
   private let ranker = QuickAddRanker()
 
   init(environment: Environment) {
     self.environment = environment
+  }
+
+  /// Supply the create-new presenter after construction.
+  ///
+  /// Needed because the object that presents the sheet is the one that BUILDS this coordinator, so
+  /// it cannot capture itself while doing so. Kept to this one seam rather than making the whole
+  /// environment mutable: everything else is known at construction, and a settable environment is an
+  /// invitation to change the rules at runtime.
+  func setPresentNewWordSheet(_ present: @escaping (String) -> Void) {
+    environment.presentNewWordSheet = present
   }
 
   /// One Quick Add invocation, from either door.

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddCoordinator.swift
@@ -110,29 +110,36 @@ final class QuickAddCoordinator {
 
   /// One Quick Add invocation, from either door.
   ///
-  /// Returns the panel model to present, or nil when there is nothing to present at all. **nil is
-  /// never silence:** the only path that returns it has already emitted a `failed` event, and the
-  /// caller shows nothing because there is genuinely nothing to show.
+  /// Returns the panel model to present. **It no longer returns nil for a refusal, and the
+  /// distinction is the whole point:** a `failed` event is a fact about a dashboard, and the review
+  /// that caught the accept path reporting success without telling anyone caught this one branch
+  /// over. A shortcut that emits telemetry and shows nothing is indistinguishable from a shortcut
+  /// that is not registered.
   func begin(door: QuickAddDoor, selectionOverride: String? = nil) -> QuickAddPanelModel? {
     let startedAt = environment.now()
     let bundleID = environment.frontmostBundleID()
 
     // Read BEFORE anything activates our app — by the time a panel exists, the frontmost application
     // is us and the answer would be about our own window.
-    let selection: SelectionReader.Result =
-      selectionOverride.map { .text($0) } ?? environment.readSelection()
+    //
+    // Door B's text goes through `SelectionReader.classify` rather than straight into `.text`. The
+    // Services system hands us whatever was on the pasteboard, and treating that as already-valid
+    // is what let a whitespace-only selection open a panel on an empty string and an oversized one
+    // reach the scorer — the ceiling and the empty check are properties of a SELECTION, not of the
+    // door it arrived through.
+    var selection: SelectionReader.Result =
+      selectionOverride.map { SelectionReader.classify($0) } ?? environment.readSelection()
 
     // Refresh before ranking, every invocation. A sibling instance or the Settings window can have
     // changed the library since launch, and ranking a stale snapshot offers words that no longer
     // exist and hides ones that do.
-    guard environment.refreshWords() else {
-      environment.emit(
-        .failed(stage: "refresh", reason: "words_unreadable"))
-      environment.emit(
-        .resolved(
-          outcome: .writeFailed, usedSearch: false, candidateRank: nil, targetKind: nil,
-          elapsedMilliseconds: elapsed(since: startedAt)))
-      return nil
+    //
+    // A failure REPLACES the selection rather than returning nil. Whatever was selected is now
+    // unrankable, so the panel opens on the stated reason like any other refusal — which is what
+    // §3 requires and what returning nil silently did not do.
+    if !environment.refreshWords() {
+      environment.emit(.failed(stage: "refresh", reason: "words_unreadable"))
+      selection = .refused(.wordsUnavailable)
     }
 
     let heard: String
@@ -143,8 +150,9 @@ final class QuickAddCoordinator {
       refusal = nil
     case .noSelection:
       heard = ""
-      // No selection is not an error and not a success. It reaches the panel as the one refusal that
-      // means "you have not told me anything yet", and the search field is the way forward.
+      // No selection is not an error and not a success. It reaches the panel as the one refusal
+      // meaning "you have not told me anything yet"; the panel then states it and offers the
+      // by-hand route, which is the only control that can do anything without a heard word.
       refusal = .selectionUnavailable
     case .refused(let reason):
       heard = ""
@@ -222,9 +230,18 @@ final class QuickAddCoordinator {
     return nil
   }
 
-  /// The user chose to create a new word.
+  /// The user chose to create a new word. **Opens the sheet and resolves NOTHING.**
+  ///
+  /// Emitting `createdNew` here counted an intention as an outcome: cancelling the sheet left the
+  /// panel up, and cancelling the panel then emitted a SECOND resolved event for one open. The
+  /// funnel is one `opened` and one `resolved`, and a rate computed over a denominator that
+  /// double-counts is worse than no rate.
   func createNew(from model: QuickAddPanelModel) {
     environment.presentNewWordSheet(model.spellingToWrite)
+  }
+
+  /// The sheet saved, and the word is confirmed present. Called by the caller that checked.
+  func didCreateNew(from model: QuickAddPanelModel) {
     finish(.createdNew, usedSearch: !model.query.isEmpty, rank: nil, kind: nil)
   }
 

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddCoordinator.swift
@@ -279,13 +279,6 @@ final class QuickAddCoordinator {
     let rank = model.ranking.candidates.firstIndex { $0.id == candidate.id }
     let kind: QuickAddTargetKind = candidate.isPackTerm ? .packTerm : .userWord
 
-    guard !candidate.alreadyHasHeardSpelling else {
-      // Writing again would add a duplicate and report success. Saying so is the honest outcome, and
-      // it is a distinct one from a refusal because nothing went wrong.
-      finish(.alreadySaved, usedSearch: usedSearch, rank: rank, kind: kind)
-      return nil
-    }
-
     var word: CustomWord
     switch Self.mergeTarget(for: candidate, in: environment.userWords()) {
     case .override(let converted): word = converted
@@ -295,10 +288,21 @@ final class QuickAddCoordinator {
       return QuickAddPanelCopy.wordNoLongerExists
     }
 
-    // The guard above answers this from the ranking taken when the panel OPENED. The library can
-    // have gained the spelling since — added in Settings, or by a sibling accept while this panel
-    // sat open — and appending it again would store it twice and report success. One outcome, two
-    // sources, and the live source is the one that decides.
+    // **ONE already-has question, asked of the LIVE word, and it replaces a guard that ran BEFORE
+    // the resolver on `candidate.alreadyHasHeardSpelling`.** That flag is a fact about the ranking
+    // taken when the panel opened, and the panel is persistent, so it is wrong in BOTH directions by
+    // the time Return is pressed: the library can have GAINED the spelling (appending again stores
+    // it twice and reports success) or LOST it (the user removed that alias in Settings, and the
+    // panel then reports "already saved" about a spelling that is no longer there, having written
+    // nothing).
+    //
+    // The first version of this fix kept the snapshot guard and added a live check below it, which
+    // closed only the gained direction — the snapshot guard runs FIRST, so `alreadyHasHeardSpelling
+    // == true` returned before the resolver could ever load the current entry. `fix-the-path-that-
+    // runs-first`, inside the fix for a defect of the same family, one round later.
+    //
+    // The flag stays on `Candidate` and the VIEW still reads it: dimming a row and choosing a header
+    // are display, and display from the ranking is what the user is looking at. The DECISION is live.
     guard
       !word.aliases.contains(where: {
         $0.caseInsensitiveCompare(model.spellingToWrite) == .orderedSame

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddCoordinator.swift
@@ -182,7 +182,15 @@ final class QuickAddCoordinator {
   }
 
   /// The user accepted a row.
-  func accept(_ candidate: QuickAddRanker.Candidate, from model: QuickAddPanelModel) {
+  ///
+  /// **Returns the refusal message when the library would not take the word, and nil otherwise.**
+  /// The return value is what tells the caller whether it may dismiss: `saveWord` can refuse for
+  /// reasons that have nothing to do with this feature — the stored-value character policy, the
+  /// 512-scalar ceiling, a words file that will not write — and dismissing regardless is a panel
+  /// reporting success for a word that was never saved. The sibling path through the edit sheet
+  /// already had this shape; this one did not.
+  @discardableResult
+  func accept(_ candidate: QuickAddRanker.Candidate, from model: QuickAddPanelModel) -> String? {
     let usedSearch = !model.query.isEmpty
     let rank = model.ranking.candidates.firstIndex { $0.id == candidate.id }
     let kind: QuickAddTargetKind = candidate.isPackTerm ? .packTerm : .userWord
@@ -191,7 +199,7 @@ final class QuickAddCoordinator {
       // Writing again would add a duplicate and report success. Saying so is the honest outcome, and
       // it is a distinct one from a refusal because nothing went wrong.
       finish(.alreadySaved, usedSearch: usedSearch, rank: rank, kind: kind)
-      return
+      return nil
     }
 
     // A PACK term cannot be written through the words coordinator: `CustomWordsManager.update` looks
@@ -202,14 +210,16 @@ final class QuickAddCoordinator {
     word.aliases.append(model.spellingToWrite)
 
     if let message = environment.saveWord(word) {
+      // `reason` stays a fixed token, never the message: the message is authored for a human and
+      // can quote what they selected, which is the one thing telemetry may not carry.
       environment.emit(.failed(stage: "save", reason: "refused"))
-      _ = message
       finish(.writeFailed, usedSearch: usedSearch, rank: rank, kind: kind)
-      return
+      return message
     }
     finish(
       usedSearch ? .acceptedAfterSearch : .accepted,
       usedSearch: usedSearch, rank: rank, kind: kind)
+    return nil
   }
 
   /// The user chose to create a new word.

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddCoordinator.swift
@@ -346,6 +346,17 @@ final class QuickAddCoordinator {
     finish(.createdNew, usedSearch: usedSearch, rank: nil, kind: nil)
   }
 
+  /// The sheet's canonical was already in the library and already carried every spelling the user
+  /// kept, so `CustomWordsManager.add` wrote nothing and nothing needed writing.
+  ///
+  /// A separate entry point rather than a flag on `didCreateNew`, because the two differ in the one
+  /// way the funnel cares about: whether a word was created. `alreadySaved` is not new vocabulary
+  /// for this — it already means "the word carried this spelling, so there was nothing to write",
+  /// and it is the same fact arriving through the other door.
+  func didFindAlreadySaved(usedSearch: Bool) {
+    finish(.alreadySaved, usedSearch: usedSearch, rank: nil, kind: nil)
+  }
+
   /// Escape, clicking away, or the panel closing.
   func cancel(from model: QuickAddPanelModel) {
     finish(.cancelled, usedSearch: model.isSearching, rank: nil, kind: nil)

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddCoordinator.swift
@@ -277,12 +277,26 @@ final class QuickAddCoordinator {
   func accept(_ candidate: QuickAddRanker.Candidate, from model: QuickAddPanelModel) -> String? {
     let usedSearch = model.isSearching
     let rank = model.ranking.candidates.firstIndex { $0.id == candidate.id }
-    let kind: QuickAddTargetKind = candidate.isPackTerm ? .packTerm : .userWord
 
+    // **`kind` comes from the RESOLVED target, not from `candidate.isPackTerm`**, and this is the
+    // third and last member of the class rounds four and six each found one of: a decision in this
+    // function reading a value captured when the panel was RANKED rather than when Return was
+    // pressed. Enumerated rather than waited for — `model.isSearching` is live, `rank` is a fact
+    // about the ranking shown and is correctly a snapshot, and `spellingToWrite` is the user's
+    // selection rather than library state and must NOT be re-read. That leaves this one.
+    //
+    // A pack term the user overrode while the panel sat open resolves to `.live`, so a USER word is
+    // written while the snapshot still says pack. `pack_term` is a claim about what was written, so
+    // reporting it there is a metric asserting the opposite of what happened.
     var word: CustomWord
+    let kind: QuickAddTargetKind
     switch Self.mergeTarget(for: candidate, in: environment.userWords()) {
-    case .override(let converted): word = converted
-    case .live(let current): word = current
+    case .override(let converted):
+      word = converted
+      kind = .packTerm
+    case .live(let current):
+      word = current
+      kind = .userWord
     case .gone:
       environment.emit(.failed(stage: "save", reason: "target_gone"))
       return QuickAddPanelCopy.wordNoLongerExists

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
@@ -39,7 +39,12 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
   /// **Reuse, not a second panel.** Pressing the shortcut again while the panel is open is an
   /// ordinary thing to do — the user is not sure it fired — and opening a second identical panel on
   /// top of the first looks exactly like nothing happening while leaving a window nobody can reach.
-  func present(_ content: some View) {
+  /// - Returns: whether a panel is now on screen. **The caller MUST read it.** A refusal here used
+  ///   to be invisible: the coordinator had already emitted `opened`, nothing resolved it, and the
+  ///   user got no window — the same shape as the refresh failure that returned no panel, reached
+  ///   through the one path that cannot report a reason.
+  @discardableResult
+  func present(_ content: some View) -> Bool {
     let panel = ensurePanel()
     let host = NSHostingView(rootView: AnyView(content))
     panel.contentView = host
@@ -50,7 +55,7 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
       // caller gets no panel and the user gets nothing, rather than a window that is up, focused,
       // swallowing Return, and blank.
       panel.contentView = nil
-      return
+      return false
     }
     panel.setContentSize(size)
     panel.center()
@@ -59,6 +64,7 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
     // still frontmost, which is the whole reason this happens here rather than at capture time.
     NSApp.activate(ignoringOtherApps: true)
     panel.makeKeyAndOrderFront(nil)
+    return true
   }
 
   /// Take the panel down. Idempotent.

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
@@ -127,11 +127,16 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
       defer: false)
     p.titleVisibility = .hidden
     p.titlebarAppearsTransparent = true
-    // **VISIBLE, and it was hidden until the founder said "there's no way to close out the window".**
-    // The bet was that Escape plus click-away made a close control redundant; both were broken, and
-    // even working they are invisible. A control where the eye already looks for one is a stronger
-    // answer than any amount of hint text.
-    p.standardWindowButton(.closeButton)?.isHidden = false
+    // **STILL HIDDEN, and unhiding it is a change that LOOKS like a fix and is not.** Measured:
+    // setting `isHidden = false` produced no visible control, because `.fullSizeContentView` puts
+    // the hosting view over the titlebar area and the standard buttons sit behind it. A screenshot
+    // of the running panel shows no close control at all.
+    //
+    // So the answer to the founder's "there's no way to close out the window" cannot come from the
+    // window at all — it has to be drawn IN the content, which is what the chosen design does with
+    // its own chrome. Left hidden deliberately rather than left `false` as a line that reads as a
+    // fix and does nothing.
+    p.standardWindowButton(.closeButton)?.isHidden = true
     p.standardWindowButton(.miniaturizeButton)?.isHidden = true
     p.standardWindowButton(.zoomButton)?.isHidden = true
     p.isMovableByWindowBackground = true

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
@@ -1,0 +1,138 @@
+import AppKit
+import SwiftUI
+
+/// The Quick Add panel's window, and nothing else (#2381).
+///
+/// **Sole owner of the `NSPanel`.** The #2292 overlay work had to extract window lifetime out of a
+/// coordinator after the fact; this starts where that ended up. The coordinator below it decides
+/// WHAT to show and never touches a window.
+///
+/// **This panel is key-capable, and that is the one way it must differ from the dictation overlay.**
+/// `OverlayWindowHost` builds `[.borderless, .nonactivatingPanel]`, and a non-activating panel can
+/// never become key — so it could never receive the Return keypress this whole feature is built
+/// around. The shape here follows `RelocationCardPanel` instead, which is the app's existing
+/// key-capable card: `.titled` + `.fullSizeContentView` with the title bar hidden, which also buys
+/// native rounding and shadow rather than hand-drawn ones.
+///
+/// Nonmodal on purpose. A modal panel would trap the user in a limb: Quick Add is something you
+/// abandon by pressing Escape or clicking away, and a run loop that refuses to let you is worse than
+/// the misheard word.
+@MainActor
+final class QuickAddPanelHost: NSObject, NSWindowDelegate {
+
+  /// Fired when the panel goes away for any reason the host can see — Escape, clicking away, or the
+  /// window closing under it. The coordinator treats all three as "the user is done".
+  var onDismiss: (() -> Void)?
+
+  private var panel: NSPanel?
+
+  #if DEBUG
+    /// How many panels this host has built. A second one means the reuse path broke, which is
+    /// invisible on screen: two identical panels stack and the user sees one.
+    private(set) var panelConstructionCount = 0
+  #endif
+
+  var isVisible: Bool { panel?.isVisible ?? false }
+
+  /// Show `content`, reusing the existing panel if one is already up.
+  ///
+  /// **Reuse, not a second panel.** Pressing the shortcut again while the panel is open is an
+  /// ordinary thing to do — the user is not sure it fired — and opening a second identical panel on
+  /// top of the first looks exactly like nothing happening while leaving a window nobody can reach.
+  func present(_ content: some View) {
+    let panel = ensurePanel()
+    let host = NSHostingView(rootView: AnyView(content))
+    panel.contentView = host
+
+    guard let size = resolvedSize(of: host) else {
+      // **A zero fitting size is an INVISIBLE panel that reports success**, which the overlay work
+      // found by fixture rather than by review. Refusing to present is the honest outcome: the
+      // caller gets no panel and the user gets nothing, rather than a window that is up, focused,
+      // swallowing Return, and blank.
+      panel.contentView = nil
+      return
+    }
+    panel.setContentSize(size)
+    panel.center()
+
+    // Activate BEFORE making key, and only now — the selection was read while the other app was
+    // still frontmost, which is the whole reason this happens here rather than at capture time.
+    NSApp.activate(ignoringOtherApps: true)
+    panel.makeKeyAndOrderFront(nil)
+  }
+
+  /// Take the panel down. Idempotent.
+  ///
+  /// `orderOut`, never `close`: closing is what forces a rebuild, and this panel is reused.
+  func dismiss() {
+    guard let panel, panel.isVisible else { return }
+    panel.orderOut(nil)
+    panel.contentView = nil
+  }
+
+  // MARK: - NSWindowDelegate
+
+  func windowDidResignKey(_ notification: Notification) {
+    // Clicking away is a dismissal. The panel holds no unsaved state the user could lose — the word
+    // is written on Return and not before — so there is nothing to confirm.
+    guard panel?.isVisible == true else { return }
+    dismiss()
+    onDismiss?()
+  }
+
+  func windowWillClose(_ notification: Notification) {
+    panel?.contentView = nil
+    onDismiss?()
+  }
+
+  // MARK: - Ownership
+
+  private func ensurePanel() -> NSPanel {
+    if let panel { return panel }
+    #if DEBUG
+      panelConstructionCount += 1
+    #endif
+    let p = KeyCapablePanel(
+      contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
+      styleMask: [.titled, .fullSizeContentView],
+      backing: .buffered,
+      defer: false)
+    p.titleVisibility = .hidden
+    p.titlebarAppearsTransparent = true
+    p.standardWindowButton(.closeButton)?.isHidden = true
+    p.standardWindowButton(.miniaturizeButton)?.isHidden = true
+    p.standardWindowButton(.zoomButton)?.isHidden = true
+    p.isMovableByWindowBackground = true
+    // Survives being ordered out, which is what makes reuse possible at all.
+    p.isReleasedWhenClosed = false
+    p.level = .floating
+    p.hidesOnDeactivate = false
+    p.delegate = self
+    panel = p
+    return p
+  }
+
+  /// The presented size, or nil when the content could not be measured.
+  ///
+  /// nil means DO NOT PRESENT. Never a plausible default: a literal fallback here is how an
+  /// unmeasurable panel becomes a confidently wrong-sized one, and the caller cannot tell the two
+  /// apart afterwards.
+  private func resolvedSize(of view: NSView) -> CGSize? {
+    let fitting = view.fittingSize
+    if fitting.width > 0, fitting.height > 0 { return fitting }
+    let frame = view.frame.size
+    if frame.width > 0, frame.height > 0 { return frame }
+    return nil
+  }
+}
+
+/// A borderless-looking panel that can take keyboard focus.
+///
+/// `canBecomeKey` is `false` by default for a panel without a real title bar, and without it Return
+/// never arrives — the panel would render perfectly and ignore the only key the feature needs.
+private final class KeyCapablePanel: NSPanel {
+  override var canBecomeKey: Bool { true }
+  /// Not main: this is an accessory over whatever the user was working in, and taking main status
+  /// would reorder their windows behind it.
+  override var canBecomeMain: Bool { false }
+}

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
@@ -78,21 +78,36 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
 
   // MARK: - NSWindowDelegate
 
-  func windowDidResignKey(_ notification: Notification) {
-    // **A SHEET TAKING KEY IS NOT THE USER CLICKING AWAY, and treating it as one made "Create a new
-    // word" tear down its own editor.** A SwiftUI `.sheet` on this panel is a real attached window;
-    // presenting it makes the sheet key and sends this to the parent, which is still visible — so
-    // the visibility guard below passes and the panel orders itself out, taking the hosting view and
-    // the sheet with it. The route the feature offers for a word you do not have yet ended in an
-    // empty screen.
-    guard panel?.attachedSheet == nil else { return }
-    // Clicking away is a dismissal. The panel holds no unsaved state the user could lose — the word
-    // is written on Return and not before — so there is nothing to confirm.
-    guard panel?.isVisible == true else { return }
-    dismiss()
-    onDismiss?()
-  }
+  /// **DELIBERATELY EMPTY. Losing key focus is not the user saying they are done.**
+  ///
+  /// This used to dismiss, and Live UAT measured what that costs: the panel cancelled itself after
+  /// 339 ms on one run and 19.7 seconds on the next, both times because an unrelated process took
+  /// key — a terminal reclaiming focus, then a screenshot tool. Neither was a user decision. On a
+  /// real machine the same list includes a notification, Spotlight, a background app waking, and the
+  /// Services system handing focus back to the app the selection came from. The user's selected word
+  /// was discarded and the panel evaporated, which from their side is indistinguishable from the
+  /// shortcut doing nothing.
+  ///
+  /// **The two arrival times looked like variance and were not.** Each panel died at the FIRST focus
+  /// event after opening; only when that arrived differed. So there is nothing to tune here — no
+  /// grace period, no debounce. The signal was wrong, not slow, and a timing-shaped fix would have
+  /// been tuned to whichever arm got measured.
+  ///
+  /// The founder's complaint arrived from the opposite direction — "there's no way to close out the
+  /// window" — and it is the SAME mistake: key state was chosen as the done-signal because it was
+  /// available, so it fires when the user is not done and it is the only exit when it does not fire.
+  /// Leaving is now something the user does on purpose: Escape (`cancelOperation`, below) or the
+  /// close control.
+  ///
+  /// Kept as an explicit no-op rather than deleted, because an absent delegate method is
+  /// indistinguishable from one nobody thought about.
+  func windowDidResignKey(_ notification: Notification) {}
 
+  /// The close control, and anything else that genuinely closes the window.
+  ///
+  /// Reachable for the first time now that the close button is visible. `isReleasedWhenClosed` is
+  /// false, so the panel survives to be reused; clearing the hosting view is what stops the old
+  /// content being handed back on the next present.
   func windowWillClose(_ notification: Notification) {
     panel?.contentView = nil
     onDismiss?()
@@ -112,7 +127,11 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
       defer: false)
     p.titleVisibility = .hidden
     p.titlebarAppearsTransparent = true
-    p.standardWindowButton(.closeButton)?.isHidden = true
+    // **VISIBLE, and it was hidden until the founder said "there's no way to close out the window".**
+    // The bet was that Escape plus click-away made a close control redundant; both were broken, and
+    // even working they are invisible. A control where the eye already looks for one is a stronger
+    // answer than any amount of hint text.
+    p.standardWindowButton(.closeButton)?.isHidden = false
     p.standardWindowButton(.miniaturizeButton)?.isHidden = true
     p.standardWindowButton(.zoomButton)?.isHidden = true
     p.isMovableByWindowBackground = true
@@ -121,6 +140,11 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
     p.level = .floating
     p.hidesOnDeactivate = false
     p.delegate = self
+    p.onCancelOperation = { [weak self] in
+      guard let self, self.isVisible else { return }
+      self.dismiss()
+      self.onDismiss?()
+    }
     panel = p
     return p
   }
@@ -148,4 +172,17 @@ private final class KeyCapablePanel: NSPanel {
   /// Not main: this is an accessory over whatever the user was working in, and taking main status
   /// would reorder their windows behind it.
   override var canBecomeMain: Bool { false }
+
+  /// What Escape should do, handled HERE rather than in the view.
+  ///
+  /// The view had `.onExitCommand`, and the search field takes focus the moment the panel opens. An
+  /// `NSTextField`'s field editor claims `cancelOperation(_:)` first and treats Escape as "cancel
+  /// field editing", so the SwiftUI modifier only ever saw what the responder chain handed back —
+  /// which is why the panel's one documented keyboard exit did not work.
+  ///
+  /// A window-level override cannot be intercepted by a field editor, and it keeps working whatever
+  /// gains focus later. That last part is the reason to prefer it even after the field is fixed: a
+  /// future control that also swallows Escape would silently break the view-level version again.
+  var onCancelOperation: (() -> Void)?
+  override func cancelOperation(_ sender: Any?) { onCancelOperation?() }
 }

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
@@ -73,6 +73,13 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
   // MARK: - NSWindowDelegate
 
   func windowDidResignKey(_ notification: Notification) {
+    // **A SHEET TAKING KEY IS NOT THE USER CLICKING AWAY, and treating it as one made "Create a new
+    // word" tear down its own editor.** A SwiftUI `.sheet` on this panel is a real attached window;
+    // presenting it makes the sheet key and sends this to the parent, which is still visible — so
+    // the visibility guard below passes and the panel orders itself out, taking the hosting view and
+    // the sheet with it. The route the feature offers for a word you do not have yet ended in an
+    // empty screen.
+    guard panel?.attachedSheet == nil else { return }
     // Clicking away is a dismissal. The panel holds no unsaved state the user could lose — the word
     // is written on Return and not before — so there is nothing to confirm.
     guard panel?.isVisible == true else { return }

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
@@ -67,6 +67,18 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
     return true
   }
 
+  /// Bring an already-visible panel back to the front and give it key focus.
+  ///
+  /// Needed because `windowDidResignKey` is now a no-op, so a panel can be visible and unfocused —
+  /// a state that did not exist while focus loss dismissed it. A second shortcut press in that state
+  /// should answer "I am not sure that fired" by SHOWING the panel, not by silently doing nothing
+  /// and not by throwing away the selection it already holds.
+  func raise() {
+    guard let panel, panel.isVisible else { return }
+    NSApp.activate(ignoringOtherApps: true)
+    panel.makeKeyAndOrderFront(nil)
+  }
+
   /// Take the panel down. Idempotent.
   ///
   /// `orderOut`, never `close`: closing is what forces a rebuild, and this panel is reused.

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddServiceProvider.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddServiceProvider.swift
@@ -1,0 +1,77 @@
+import AppKit
+import Foundation
+
+/// Door B: the right-click and app-menu Services entry (#2381).
+///
+/// **Registered on `NSApp.servicesProvider`, declared by `NSServices` in the app's Info.plist.**
+/// Measured on this machine with a throwaway bundle: a Service registers and is ENABLED with no user
+/// setup — absent from `pbs -dump_pboard` at t+0.0s, present at t+2.1s, and `defaults read pbs
+/// NSServicesStatus` does not exist, so nothing was hand-enabled. It also cold-launches the provider
+/// if the app is not running.
+///
+/// **It carries no `NSKeyEquivalent`, deliberately.** The keyboard is door A's job. Declaring a chord
+/// here as well would put two registrations on one key — a Carbon first-come-first-served collision
+/// with our own hotkey — and a Service key equivalent does not reach a terminal anyway: Ghostty routes
+/// them through its own binding table, which is one of the two measurements that put terminals out of
+/// scope.
+///
+/// The provider takes the text it is HANDED. It does not also read Accessibility: that would ask a
+/// second question about whatever is frontmost NOW, which by the time this runs may be us.
+@MainActor
+final class QuickAddServiceProvider: NSObject {
+
+  /// The Services message name. **Must match `NSMessage` in the Info.plist exactly**, and the ObjC
+  /// selector AppKit looks up is this plus `:userData:error:`. A mismatch is silent: the menu item
+  /// appears, the click does nothing, and no error surfaces anywhere.
+  nonisolated static let messageName = "quickAddWord"
+
+  /// The one send type declared. Anything the user can select as text arrives as this.
+  nonisolated static let sendType = NSPasteboard.PasteboardType.string
+
+  private let begin: (String) -> Void
+
+  /// - Parameter begin: hands the selected text to the coordinator. Non-escaping ownership stays
+  ///   with the composition root, which is what keeps this type free of everything else.
+  init(begin: @escaping (String) -> Void) {
+    self.begin = begin
+    super.init()
+  }
+
+  /// Install this provider. Call after launch: `NSApp.servicesProvider` before the app finishes
+  /// launching is registered against an app that cannot yet answer.
+  func install() {
+    NSApp.servicesProvider = self
+    // Tells the Services system to re-read our declaration now rather than at its own leisure.
+    // Without it a freshly installed build can take minutes to show the menu item, which reads as
+    // the feature not working.
+    NSUpdateDynamicServices()
+  }
+
+  @objc(quickAddWord:userData:error:)
+  func quickAddWord(
+    _ pasteboard: NSPasteboard,
+    userData: String?,
+    error: AutoreleasingUnsafeMutablePointer<NSString>
+  ) {
+    guard let text = Self.text(from: pasteboard) else {
+      // A Service invoked with nothing readable is not an error the user needs a dialog about — the
+      // panel opens on its own stated reason, the same as the hotkey door with no selection. Setting
+      // `error` here would put a modal in front of someone who just right-clicked.
+      begin("")
+      return
+    }
+    begin(text)
+  }
+
+  /// The pasteboard's text, or nil when there is none.
+  ///
+  /// Separated and non-private so the mapping is testable without a Services round trip: a real
+  /// invocation needs the Services system, a launched app, and a user gesture, none of which belong
+  /// in a unit test. What CAN be tested is what we make of a pasteboard, which is where the defect
+  /// would be.
+  nonisolated static func text(from pasteboard: NSPasteboard) -> String? {
+    guard let raw = pasteboard.string(forType: sendType) else { return nil }
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddTelemetryBridge.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddTelemetryBridge.swift
@@ -11,8 +11,15 @@ import Foundation
 ///
 /// **THE ROUTING IS THE DECISION, and the three destinations answer different questions.** PostHog
 /// gets the two shape-only events, because they are about how the feature performs across users.
-/// Sentry gets FAILURES only, because they are about something being broken. The local log gets a
-/// support line — and the heard word is NOT in it, including under Debug Mode.
+/// Sentry gets a BREADCRUMB TRAIL — open, resolve and failure — because its job is to explain a crash
+/// that happens next, and a trail with only the failures in it cannot say how the user got there. It
+/// gets no Sentry EVENT and no `ErrorCategory`, which is the part that stays true. The local log gets
+/// a support line — and the heard word is NOT in it, including under Debug Mode.
+///
+/// That distinction was wrong in this comment until the confirming review round: it read "Sentry gets
+/// FAILURES only", which described the code and contradicted §3e, and the code was the thing that was
+/// wrong. A comment agreeing with defective code is the shape that retires the check instead of
+/// failing it.
 ///
 /// That last one was argued the other way first: `CORRECTION_DEBUG` already writes full transcripts
 /// to `app.log` behind the Debug Mode gate, so a heard word there looked like it widened nothing.
@@ -38,10 +45,28 @@ enum QuickAddTelemetryBridge {
           topScore: topScore,
           sourceBundleID: bundleID,
           heardLength: heardScalarCount)
+        // §3e: "Breadcrumbs on open and resolve so a crash inside the panel arrives with the door,
+        // the candidate count, and the outcome attached." Only `failed` was leaving a breadcrumb, so
+        // a crash while the panel was up arrived with no trail of how it got there.
+        SentryBreadcrumb.add(
+          stage: "quick_add",
+          message: "quick_add opened",
+          data: [
+            "door": door.rawValue, "candidate_count": candidateCount,
+            "refuse_reason": refusal?.rawValue ?? "none",
+          ])
+        // `top=` and `reason=` are BOTH required by §3e's own sample line, and both were missing.
+        // Without the score a wrong-preselection report cannot show whether the confidence bar was
+        // crossed, which is the single number this feature will be tuned on; without the reason a
+        // support reader sees `selection=no` and cannot tell a terminal apart from a missing
+        // permission. Vendor telemetry carried both all along — this is the artifact for ONE
+        // person's report, which is a different job.
         log(
           "opened door=\(door.rawValue) app=\(bundleID ?? "unknown") "
-            + "selection=\(refusal == nil ? "yes" : "no") len=\(heardScalarCount) "
-            + "candidates=\(candidateCount) preselect=\(preselected ? "yes" : "no")")
+            + "selection=\(refusal == nil ? "yes" : "no") reason=\(refusal?.rawValue ?? "none") "
+            + "len=\(heardScalarCount) candidates=\(candidateCount) "
+            + "top=\(topScore.map { String(format: "%.2f", $0) } ?? "none") "
+            + "preselect=\(preselected ? "yes" : "no")")
 
       case .resolved(
         let outcome, let usedSearch, let candidateRank, let targetKind, let elapsed):
@@ -51,6 +76,10 @@ enum QuickAddTelemetryBridge {
           candidateRank: candidateRank,
           targetKind: targetKind?.rawValue,
           elapsedMilliseconds: elapsed)
+        SentryBreadcrumb.add(
+          stage: "quick_add",
+          message: "quick_add resolved",
+          data: ["outcome": outcome.rawValue, "used_search": usedSearch])
         log(
           "resolved outcome=\(outcome.rawValue) search=\(usedSearch ? "yes" : "no") "
             + "rank=\(candidateRank.map(String.init) ?? "none") "

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddTelemetryBridge.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddTelemetryBridge.swift
@@ -1,0 +1,86 @@
+import EnviousWisprCore
+import EnviousWisprServices
+import Foundation
+
+/// Maps `QuickAddEvent` onto the telemetry vendors (#2381).
+///
+/// **Deleting this file leaves Quick Add working, silently.** That is the point, and it is the test
+/// of whether observability was wired in or bolted on: the coordinator emits facts and names no
+/// vendor, so nothing about the feature's behaviour depends on anyone listening. Modelled on
+/// `EGOneTelemetryBridge`, which exists for the same reason one module over.
+///
+/// **THE ROUTING IS THE DECISION, and the three destinations answer different questions.** PostHog
+/// gets the two shape-only events, because they are about how the feature performs across users.
+/// Sentry gets FAILURES only, because they are about something being broken. The local log gets a
+/// support line — and the heard word is NOT in it, including under Debug Mode.
+///
+/// That last one was argued the other way first: `CORRECTION_DEBUG` already writes full transcripts
+/// to `app.log` behind the Debug Mode gate, so a heard word there looked like it widened nothing.
+/// Review overruled it — `observability-operations.md` says local lines carry never user content with
+/// NO Debug Mode exception, and the precedent was UNCHECKED. The support cost is real and accepted:
+/// a user reporting "it added the wrong word" cannot be answered from their log alone.
+enum QuickAddTelemetryBridge {
+
+  /// The handler the composition root installs on the coordinator.
+  @MainActor
+  static var handler: (QuickAddEvent) -> Void {
+    { event in
+      switch event {
+      case .opened(
+        let door, let refusal, let bundleID, let heardScalarCount, let candidateCount,
+        let preselected, let topScore):
+        TelemetryService.shared.quickAddOpened(
+          door: door.rawValue,
+          hadSelection: refusal == nil,
+          refuseReason: refusal?.rawValue,
+          candidateCount: candidateCount,
+          preselected: preselected,
+          topScore: topScore,
+          sourceBundleID: bundleID,
+          heardLength: heardScalarCount)
+        log(
+          "opened door=\(door.rawValue) app=\(bundleID ?? "unknown") "
+            + "selection=\(refusal == nil ? "yes" : "no") len=\(heardScalarCount) "
+            + "candidates=\(candidateCount) preselect=\(preselected ? "yes" : "no")")
+
+      case .resolved(
+        let outcome, let usedSearch, let candidateRank, let targetKind, let elapsed):
+        TelemetryService.shared.quickAddResolved(
+          outcome: outcome.rawValue,
+          usedSearch: usedSearch,
+          candidateRank: candidateRank,
+          targetKind: targetKind?.rawValue,
+          elapsedMilliseconds: elapsed)
+        log(
+          "resolved outcome=\(outcome.rawValue) search=\(usedSearch ? "yes" : "no") "
+            + "rank=\(candidateRank.map(String.init) ?? "none") "
+            + "target=\(targetKind?.rawValue ?? "none") elapsed=\(elapsed)ms")
+
+      case .failed(let stage, let reason):
+        // Sentry gets failures and nothing else. A BREADCRUMB, not a captured error: this is a limb,
+        // so a Quick Add that cannot write is worth having in the trail of whatever the user reports
+        // next, and is not worth an issue of its own.
+        //
+        // Deliberately NOT a new `SentryBreadcrumb.ErrorCategory`. That enum is read by
+        // `workers/reporting/sentry-section.js`, which classifies every raw value into
+        // lost-vs-degraded and has a test enumerating the Swift cases against its table — so adding
+        // one turns `worker-tests` red while every Swift test passes. There is no classification this
+        // failure needs that the breadcrumb trail does not already give.
+        SentryBreadcrumb.add(
+          stage: "quick_add",
+          message: "quick_add failed at \(stage)",
+          data: ["stage": stage, "reason": reason])
+        log("failed stage=\(stage) reason=\(reason)")
+      }
+    }
+  }
+
+  /// One line per event in the debug log.
+  ///
+  /// **`len=` is a CHARACTER COUNT and the word itself never appears here.** Every value on these
+  /// lines is a closed-set token, a number, or an app's bundle id. If you are ever tempted to add the
+  /// word to make a support case easier, that is the exact trade this was decided against.
+  private static func log(_ line: String) {
+    Task { await AppLogger.shared.log("[QuickAdd] \(line)", level: .info, category: "QuickAdd") }
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddTelemetryBridge.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddTelemetryBridge.swift
@@ -109,7 +109,30 @@ enum QuickAddTelemetryBridge {
   /// **`len=` is a CHARACTER COUNT and the word itself never appears here.** Every value on these
   /// lines is a closed-set token, a number, or an app's bundle id. If you are ever tempted to add the
   /// word to make a support case easier, that is the exact trade this was decided against.
-  private static func log(_ line: String) {
-    Task { await AppLogger.shared.log("[QuickAdd] \(line)", level: .info, category: "QuickAdd") }
+  ///
+  /// **`#if DEBUG` HERE, not only inside `AppLogger`, and the difference is not stylistic.**
+  /// `AppLogger.log`'s BODY is `#if DEBUG` — its own doc says call sites compile unchanged and
+  /// produce no output — so a release build discards these lines. But discarding them happens AFTER
+  /// the caller has already interpolated the string and spawned a Task to hand it over. Every panel
+  /// open in a shipped build would format `top=%.2f`, build a sentence and hop actors for a sink that
+  /// cannot exist.
+  ///
+  /// The cost is small; the absurdity is the argument. And it corrects a premise worth stating,
+  /// because it is the kind that gets inherited and restated: a RELEASE build writes no
+  /// `~/Library/Logs/EnviousWispr/app.log` at all. These lines are for us reproducing locally and for
+  /// the founder on a dev build during UAT — never something a shipped user can send in. Any support
+  /// workflow written around them is a workflow around an artifact that does not exist.
+  /// (Owed to a peer session finding the same inherited premise under #2135.)
+  /// **`@autoclosure`, and without it the `#if DEBUG` below is a fix that reads as a fix and is not.**
+  /// The interpolation happens at the CALL SITE — `log("opened door=\(door) top=\(score)")` builds
+  /// its string before `log` is entered — so guarding only the body would still format every sentence
+  /// in a release build and then throw it away. Deferring the expression is what actually removes the
+  /// work. Non-escaping and evaluated synchronously inside the guard, so the Task captures a rendered
+  /// String rather than a closure.
+  private static func log(_ line: @autoclosure () -> String) {
+    #if DEBUG
+      let rendered = "[QuickAdd] \(line())"
+      Task { await AppLogger.shared.log(rendered, level: .info, category: "QuickAdd") }
+    #endif
   }
 }

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
@@ -111,8 +111,13 @@ final class QuickAddWiring {
 
   // MARK: - Outcomes
 
+  /// Dismiss only when the word was actually saved. The same rule `saveNewWord` below already
+  /// followed — a refused write leaves the panel up, carrying the reason.
   private func accept(_ candidate: QuickAddRanker.Candidate, model: QuickAddPanelModel) {
-    coordinator.accept(candidate, from: model)
+    if let message = coordinator.accept(candidate, from: model) {
+      model.noteWriteFailure(message)
+      return
+    }
     dismiss()
   }
 

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
@@ -117,7 +117,13 @@ final class QuickAddWiring {
         newWord: Binding(
           get: { [weak self] in self?.pendingNewWord },
           set: { [weak self] in self?.pendingNewWord = $0 }),
-        onSaveNewWord: { [weak self] word in self?.saveNewWord(word) }))
+        // `usedSearch` is captured HERE, from the model this panel was built with, rather than
+        // read back off `activeModel` at save time. The sheet outlives the panel in at least one
+        // ordering, and a nil lookup defaulting to false would report a search-assisted save as an
+        // unassisted one — quietly, and in the direction that flatters the ranking.
+        onSaveNewWord: { [weak self] word in
+          self?.saveNewWord(word, usedSearch: !model.query.isEmpty)
+        }))
 
     // The host refuses to present a panel it could not measure, because an unmeasurable panel is an
     // invisible window that reports success. Clearing `activeModel` matters as much as the event:
@@ -177,7 +183,7 @@ final class QuickAddWiring {
   /// So this asserts the OUTCOME rather than the call's return value — the word is there and it
   /// carries the spellings the user kept — which is the one check that covers both branches and any
   /// third one nobody has found yet.
-  private func saveNewWord(_ word: CustomWord) -> String? {
+  private func saveNewWord(_ word: CustomWord, usedSearch: Bool) -> String? {
     if let message = customWords.add(word) { return message }
     // Compare against the TRIMMED canonical, because that is what `add` stores. Comparing the raw
     // one reports a correct save as a failure whenever the user typed a leading space.
@@ -198,7 +204,7 @@ final class QuickAddWiring {
     guard missing.isEmpty else {
       return QuickAddPanelCopy.newWordAlreadyExists(canonical: stored.canonical)
     }
-    coordinator.didCreateNew(usedSearch: !(activeModel?.query.isEmpty ?? true))
+    coordinator.didCreateNew(usedSearch: usedSearch)
     dismiss()
     return nil
   }

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
@@ -96,11 +96,25 @@ final class QuickAddWiring {
   /// replaced by a refusal, the first `opened` event never resolves, and the funnel gains an open it
   /// can never close.
   ///
-  /// Doing nothing is the whole behaviour, and it is correct rather than lazy: the panel dismisses
-  /// itself when it resigns key, so a visible panel is a FOCUSED panel and there is nothing to raise.
-  /// The guard is on both doors because either can be fired while the other's panel is up — naming
-  /// only the one review pointed at would leave the twin.
-  private func notAlreadyOpen() -> Bool { !panelHost.isVisible }
+  /// **The "doing nothing is correct" half of this rested on a premise that a later fix removed.**
+  /// It read: the panel dismisses itself when it resigns key, so a visible panel is a FOCUSED panel
+  /// and there is nothing to raise. `windowDidResignKey` is now deliberately a no-op — because
+  /// treating focus loss as a dismissal cancelled the panel 339 ms after opening — so a panel can now
+  /// be visible and NOT key. In that state every later hotkey and Services invocation returned false
+  /// here and did nothing at all: no raise, no new capture, no reason given.
+  ///
+  /// Two correct fixes composing into a defect neither had alone, which is why the reason is written
+  /// down beside the code rather than in the commit that changed the other one.
+  ///
+  /// Raising rather than re-capturing is deliberate. The panel already holds a selection the user
+  /// made; a second press is "I am not sure that fired", and answering it by throwing away their
+  /// word to read whatever is frontmost NOW — which is our own panel — is the defect this guard was
+  /// added to prevent in the first place.
+  private func notAlreadyOpen() -> Bool {
+    guard panelHost.isVisible else { return true }
+    panelHost.raise()
+    return false
+  }
 
   private func present(_ model: QuickAddPanelModel?) {
     guard let model else {
@@ -184,6 +198,12 @@ final class QuickAddWiring {
   /// carries the spellings the user kept — which is the one check that covers both branches and any
   /// third one nobody has found yet.
   private func saveNewWord(_ word: CustomWord, usedSearch: Bool) -> String? {
+    // Snapshotted BEFORE the write, because it is the only way to tell "created" from "was already
+    // there". See the vacuity note on the guard below.
+    let canonicalExistedBefore = customWords.customWords.contains {
+      $0.canonical.caseInsensitiveCompare(
+        word.canonical.trimmingCharacters(in: .whitespacesAndNewlines)) == .orderedSame
+    }
     if let message = customWords.add(word) { return message }
     // Compare against the TRIMMED canonical, because that is what `add` stores. Comparing the raw
     // one reports a correct save as a failure whenever the user typed a leading space.
@@ -204,9 +224,49 @@ final class QuickAddWiring {
     guard missing.isEmpty else {
       return QuickAddPanelCopy.newWordAlreadyExists(canonical: stored.canonical)
     }
+    // **AND THE GUARD ABOVE IS VACUOUS WHEN THERE IS NOTHING TO CONFIRM.** Quick Add opened without
+    // a readable selection has no heard spelling, so the sheet starts with one BLANK alias, `kept`
+    // is empty, and `missing.isEmpty` is trivially true. A canonical that already existed then took
+    // the success path: `add` silently no-ops on a duplicate, the word the user typed was never
+    // created, and the panel closed saying nothing.
+    //
+    // Seventh instance of this feature's one class, and it arrived INSIDE the fix for the fifth —
+    // the postcondition was written for the case where a spelling exists to look for, and the state
+    // with no spelling is exactly the state it cannot see. So the existence question is asked
+    // separately: with nothing to confirm, "was this canonical already here before I wrote" is the
+    // only evidence available.
+    guard
+      Self.newWordLanded(
+        keptSpellings: kept, missingSpellings: missing,
+        canonicalExistedBefore: canonicalExistedBefore)
+    else {
+      return QuickAddPanelCopy.newWordAlreadyExists(canonical: stored.canonical)
+    }
     coordinator.didCreateNew(usedSearch: usedSearch)
     dismiss()
     return nil
+  }
+
+  /// Whether the sheet's save actually produced the word the user asked for.
+  ///
+  /// **Split out because the version inline could not be tested, and it was wrong in exactly the
+  /// state no test could reach.** The postcondition asks "did the spellings the user kept land on
+  /// the word", which is the right question whenever there ARE spellings. Quick Add opened without a
+  /// readable selection has none — the sheet starts with one blank alias — so the check passed
+  /// trivially, and a canonical that already existed took the success path while `add` silently
+  /// no-oped. Nothing was created and the panel closed saying nothing.
+  ///
+  /// So there are two questions, not one, and which applies depends on whether there is anything to
+  /// confirm. With spellings: did they land. Without: was this canonical already here before the
+  /// write, because that is then the only evidence available.
+  ///
+  /// Seventh instance of this feature's one class, and it arrived INSIDE the fix for the fifth.
+  package static func newWordLanded(
+    keptSpellings: [String], missingSpellings: [String], canonicalExistedBefore: Bool
+  ) -> Bool {
+    guard missingSpellings.isEmpty else { return false }
+    guard keptSpellings.isEmpty else { return true }
+    return !canonicalExistedBefore
   }
 
   /// Write a word and PROVE the spelling is on it afterwards.

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
@@ -208,9 +208,11 @@ final class QuickAddWiring {
     // Compare against the TRIMMED canonical, because that is what `add` stores. Comparing the raw
     // one reports a correct save as a failure whenever the user typed a leading space.
     let canonical = word.canonical.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard let stored = customWords.customWords.first(where: {
-      $0.canonical.caseInsensitiveCompare(canonical) == .orderedSame
-    }) else {
+    guard
+      let stored = customWords.customWords.first(where: {
+        $0.canonical.caseInsensitiveCompare(canonical) == .orderedSame
+      })
+    else {
       return QuickAddPanelCopy.newWordNotSaved
     }
     // Blank rows are ordinary trimming, not a lost edit — the editor leaves them behind. A NON-blank
@@ -235,14 +237,20 @@ final class QuickAddWiring {
     // with no spelling is exactly the state it cannot see. So the existence question is asked
     // separately: with nothing to confirm, "was this canonical already here before I wrote" is the
     // only evidence available.
-    guard
-      Self.newWordLanded(
-        keptSpellings: kept, missingSpellings: missing,
-        canonicalExistedBefore: canonicalExistedBefore)
-    else {
+    switch Self.newWordOutcome(
+      keptSpellings: kept, missingSpellings: missing,
+      canonicalExistedBefore: canonicalExistedBefore)
+    {
+    case .created:
+      coordinator.didCreateNew(usedSearch: usedSearch)
+    case .alreadyComplete:
+      // NOT `didCreateNew`. Nothing was created, so counting one puts a write that did not happen in
+      // the numerator of every rate computed off this funnel — and `alreadySaved` already means
+      // exactly this, on the accept route, for exactly this reason.
+      coordinator.didFindAlreadySaved(usedSearch: usedSearch)
+    case .refused:
       return QuickAddPanelCopy.newWordAlreadyExists(canonical: stored.canonical)
     }
-    coordinator.didCreateNew(usedSearch: usedSearch)
     dismiss()
     return nil
   }
@@ -260,13 +268,41 @@ final class QuickAddWiring {
   /// confirm. With spellings: did they land. Without: was this canonical already here before the
   /// write, because that is then the only evidence available.
   ///
-  /// Seventh instance of this feature's one class, and it arrived INSIDE the fix for the fifth.
-  package static func newWordLanded(
+  /// **AND A BOOL WAS THE WRONG RETURN TYPE, which round five found.** The first version answered
+  /// true for "the canonical already existed and already carried the spelling", on the stated
+  /// reasoning that adding a spelling to a word you already have is the feature's main path. That
+  /// reasoning is about the ACCEPT route and is false here: through Create New, an existing
+  /// canonical means `CustomWordsManager.add` silently wrote NOTHING, always. So the panel reported
+  /// a creation, and the funnel counted a `created_new`, for a write that did not happen.
+  ///
+  /// The desired end state was nonetheless already true, which is why the answer is not `false`
+  /// either — refusing would hand the user a message telling them to go and add a spelling the word
+  /// already has. Three states, and the third is the one a Bool cannot hold: this is the same
+  /// three-valued shape as `QuickAddCoordinator.mergeTarget`, which is what `validation-discipline`
+  /// means by an unhandled input still landing somewhere, usually in the permissive branch.
+  package enum NewWordOutcome: Equatable {
+    /// The write produced the word the user asked for.
+    case created
+    /// The canonical was already there and already carried every spelling the user kept. Nothing was
+    /// written and nothing needed to be: report it as already saved rather than as a creation.
+    case alreadyComplete
+    /// Nothing was written and the user did not get what they asked for. Say so, keep the panel up.
+    case refused
+  }
+
+  package static func newWordOutcome(
     keptSpellings: [String], missingSpellings: [String], canonicalExistedBefore: Bool
-  ) -> Bool {
-    guard missingSpellings.isEmpty else { return false }
-    guard keptSpellings.isEmpty else { return true }
-    return !canonicalExistedBefore
+  ) -> NewWordOutcome {
+    // Outranks everything below: a spelling the user typed that is not on the word is a lost edit,
+    // whatever else is true.
+    guard missingSpellings.isEmpty else { return .refused }
+    // Through this route `add` no-ops on a duplicate canonical, so a canonical that was NOT there
+    // before is the only evidence a creation happened.
+    guard canonicalExistedBefore else { return .created }
+    // It was already there. With a spelling to confirm, and nothing missing, the end state the user
+    // asked for holds — nothing to do. With NO spelling, nothing was created and nothing was added,
+    // so there is nothing to report as done.
+    return keptSpellings.isEmpty ? .refused : .alreadyComplete
   }
 
   /// Write a word and PROVE the spelling is on it afterwards.

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
@@ -136,7 +136,7 @@ final class QuickAddWiring {
         // ordering, and a nil lookup defaulting to false would report a search-assisted save as an
         // unassisted one — quietly, and in the direction that flatters the ranking.
         onSaveNewWord: { [weak self] word in
-          self?.saveNewWord(word, usedSearch: !model.query.isEmpty)
+          self?.saveNewWord(word, usedSearch: model.isSearching)
         }))
 
     // The host refuses to present a panel it could not measure, because an unmeasurable panel is an

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
@@ -108,7 +108,7 @@ final class QuickAddWiring {
       return
     }
     activeModel = model
-    panelHost.present(
+    let shown = panelHost.present(
       QuickAddRoot(
         model: model,
         onAccept: { [weak self] candidate in self?.accept(candidate, model: model) },
@@ -118,6 +118,17 @@ final class QuickAddWiring {
           get: { [weak self] in self?.pendingNewWord },
           set: { [weak self] in self?.pendingNewWord = $0 }),
         onSaveNewWord: { [weak self] word in self?.saveNewWord(word) }))
+
+    // The host refuses to present a panel it could not measure, because an unmeasurable panel is an
+    // invisible window that reports success. Clearing `activeModel` matters as much as the event:
+    // a stale model here is what a later dismiss would resolve, attributing a cancel to an open that
+    // never happened.
+    guard shown else {
+      activeModel = nil
+      coordinator.failedToOpen()
+      return
+    }
+    coordinator.didOpen()
   }
 
   // MARK: - Outcomes
@@ -187,7 +198,7 @@ final class QuickAddWiring {
     guard missing.isEmpty else {
       return QuickAddPanelCopy.newWordAlreadyExists(canonical: stored.canonical)
     }
-    if let model = activeModel { coordinator.didCreateNew(from: model) }
+    coordinator.didCreateNew(usedSearch: !(activeModel?.query.isEmpty ?? true))
     dismiss()
     return nil
   }

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
@@ -47,13 +47,8 @@ final class QuickAddWiring {
         refreshWords: { customWords.refreshFromDiskIfPossible() },
         userWords: { customWords.customWords },
         packTerms: { packManager.enabledPackTerms() },
-        saveWord: { word in
-          // `add` when the word is new to the user library, `update` when it is already there. A
-          // converted pack term is NEW here even though its id is the pack's, which is why the
-          // decision is by membership rather than by `source`.
-          customWords.customWords.contains { $0.id == word.id }
-            ? customWords.update(word)
-            : customWords.add(word)
+        saveWord: { word, spelling in
+          Self.saveAndConfirm(word, carrying: spelling, through: customWords)
         },
         presentNewWordSheet: { _ in },
         emit: QuickAddTelemetryBridge.handler))
@@ -83,13 +78,29 @@ final class QuickAddWiring {
   // MARK: - The two doors
 
   private func beginFromHotkey() {
+    guard notAlreadyOpen() else { return }
     present(coordinator.begin(door: .hotkey))
   }
 
   /// Door B. Separate from the hotkey path only because the Service is HANDED its text.
   func beginFromService(text: String) {
+    guard notAlreadyOpen() else { return }
     present(coordinator.begin(door: .service, selectionOverride: text))
   }
+
+  /// Whether a new capture may start at all.
+  ///
+  /// **Pressing the shortcut again while the panel is up is an ordinary thing to do** — the user is
+  /// not sure it fired — and without this it started a SECOND capture whose frontmost application is
+  /// our own panel. The new read finds no selection, so the word the user actually selected is
+  /// replaced by a refusal, the first `opened` event never resolves, and the funnel gains an open it
+  /// can never close.
+  ///
+  /// Doing nothing is the whole behaviour, and it is correct rather than lazy: the panel dismisses
+  /// itself when it resigns key, so a visible panel is a FOCUSED panel and there is nothing to raise.
+  /// The guard is on both doors because either can be fired while the other's panel is up — naming
+  /// only the one review pointed at would leave the twin.
+  private func notAlreadyOpen() -> Bool { !panelHost.isVisible }
 
   private func present(_ model: QuickAddPanelModel?) {
     guard let model else {
@@ -179,6 +190,36 @@ final class QuickAddWiring {
     if let model = activeModel { coordinator.didCreateNew(from: model) }
     dismiss()
     return nil
+  }
+
+  /// Write a word and PROVE the spelling is on it afterwards.
+  ///
+  /// **A nil return from the words coordinator is not evidence the write happened**, and this is the
+  /// third distinct way that has been true in this feature. `add` returns silently for a duplicate
+  /// canonical and for a deleted-built-in restore; `update` opens
+  /// `guard let index = words.firstIndex(where: { $0.id == word.id }) else { return }`, so a word
+  /// another instance removed while this panel was open is written NOWHERE and reported as saved.
+  /// The panel then closes on a spelling that was never stored.
+  ///
+  /// Every one of those is invisible to the caller and all of them have one observable: is the
+  /// spelling on the word now. So that is what this asks, instead of asking three questions about
+  /// how the write was routed.
+  ///
+  /// `add` when the word is new to the user library, `update` when it is already there. A converted
+  /// pack term is NEW here even though its id is the pack's, which is why the decision is by
+  /// membership rather than by `source`.
+  private static func saveAndConfirm(
+    _ word: CustomWord, carrying spelling: String, through customWords: CustomWordsCoordinator
+  ) -> String? {
+    let existing = customWords.customWords.contains { $0.id == word.id }
+    if let message = existing ? customWords.update(word) : customWords.add(word) { return message }
+
+    let wanted = spelling.trimmingCharacters(in: .whitespacesAndNewlines)
+    let landed = customWords.customWords.contains { stored in
+      stored.canonical.caseInsensitiveCompare(word.canonical) == .orderedSame
+        && stored.aliases.contains { $0.caseInsensitiveCompare(wanted) == .orderedSame }
+    }
+    return landed ? nil : QuickAddPanelCopy.newWordNotSaved
   }
 
   private func dismiss() {

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
@@ -1,0 +1,176 @@
+import AppKit
+import EnviousWisprCore
+import EnviousWisprPostProcessing
+import EnviousWisprServices
+import SwiftUI
+
+/// Everything Quick Add needs to actually run, in ONE object (#2381).
+///
+/// **One stored property in the composition root, not four.** `EnviousWisprAppCeilingsTests` caps
+/// what `WisprBootstrapper` may hold, and the documented way to spend one slot on a group of
+/// collaborators is a nested type — the same pattern `RecordingLockedAccess` and
+/// `SparkleUpdaterFactory` use. It is also what keeps the deletability property honest: removing this
+/// feature is three directories, one property, and one call.
+///
+/// This is composition, not behaviour. Every decision lives in the coordinator; this decides only who
+/// holds whom and who is told about what.
+@MainActor
+final class QuickAddWiring {
+
+  private let coordinator: QuickAddCoordinator
+  private let panelHost = QuickAddPanelHost()
+  /// Built in `install()`, not here: its whole job is to call back into this object, and `self` does
+  /// not exist yet during init. Constructing it early with a placeholder closure is how a door ships
+  /// registered, enabled, and wired to nothing.
+  private var serviceProvider: QuickAddServiceProvider?
+  private let hotkeyService: HotkeyService
+  private let customWords: CustomWordsCoordinator
+
+  /// The panel currently up, if any. Held because the coordinator's outcome calls need the model the
+  /// user was actually looking at, and a second invocation must reuse rather than stack.
+  private var activeModel: QuickAddPanelModel?
+
+  /// A new word the user asked to create, which drives the edit sheet's presentation.
+  private var pendingNewWord: CustomWord?
+
+  init(
+    hotkeyService: HotkeyService,
+    customWords: CustomWordsCoordinator,
+    packManager: VocabularyPackManager
+  ) {
+    self.hotkeyService = hotkeyService
+    self.customWords = customWords
+    self.coordinator = QuickAddCoordinator(
+      environment: QuickAddCoordinator.Environment(
+        readSelection: { SelectionReader.read() },
+        frontmostBundleID: { NSWorkspace.shared.frontmostApplication?.bundleIdentifier },
+        refreshWords: { customWords.refreshFromDiskIfPossible() },
+        userWords: { customWords.customWords },
+        packTerms: { packManager.enabledPackTerms() },
+        saveWord: { word in
+          // `add` when the word is new to the user library, `update` when it is already there. A
+          // converted pack term is NEW here even though its id is the pack's, which is why the
+          // decision is by membership rather than by `source`.
+          customWords.customWords.contains { $0.id == word.id }
+            ? customWords.update(word)
+            : customWords.add(word)
+        },
+        presentNewWordSheet: { _ in },
+        emit: QuickAddTelemetryBridge.handler))
+
+    // Assigned AFTER init rather than captured during it. `self` does not exist while the
+    // coordinator is being built, and Swift says so; a placeholder that stayed would be a
+    // Create-a-new-word button that renders, records its outcome, and opens nothing.
+    //
+    // Canonical EMPTY and focused: the user knows the misspelling, because they selected it. What
+    // they have to supply is the correct form.
+    coordinator.setPresentNewWordSheet { [weak self] spelling in
+      self?.pendingNewWord = CustomWord(canonical: "", aliases: [spelling])
+    }
+  }
+
+  /// Install both doors. Call after launch: `NSApp.servicesProvider` set before the app has finished
+  /// launching is registered against an app that cannot yet answer.
+  func install() {
+    hotkeyService.onQuickAdd = { [weak self] in self?.beginFromHotkey() }
+    let provider = QuickAddServiceProvider(
+      begin: { [weak self] text in self?.beginFromService(text: text) })
+    provider.install()
+    serviceProvider = provider
+    panelHost.onDismiss = { [weak self] in self?.panelDismissed() }
+  }
+
+  // MARK: - The two doors
+
+  private func beginFromHotkey() {
+    present(coordinator.begin(door: .hotkey))
+  }
+
+  /// Door B. Separate from the hotkey path only because the Service is HANDED its text.
+  func beginFromService(text: String) {
+    present(coordinator.begin(door: .service, selectionOverride: text))
+  }
+
+  private func present(_ model: QuickAddPanelModel?) {
+    guard let model else {
+      // The coordinator already reported why. Nothing to show is not silence.
+      return
+    }
+    activeModel = model
+    panelHost.present(
+      QuickAddRoot(
+        model: model,
+        onAccept: { [weak self] candidate in self?.accept(candidate, model: model) },
+        onCreateNew: { [weak self] in self?.createNew(model: model) },
+        onCancel: { [weak self] in self?.cancel(model: model) },
+        newWord: Binding(
+          get: { [weak self] in self?.pendingNewWord },
+          set: { [weak self] in self?.pendingNewWord = $0 }),
+        onSaveNewWord: { [weak self] word in self?.saveNewWord(word) }))
+  }
+
+  // MARK: - Outcomes
+
+  private func accept(_ candidate: QuickAddRanker.Candidate, model: QuickAddPanelModel) {
+    coordinator.accept(candidate, from: model)
+    dismiss()
+  }
+
+  private func createNew(model: QuickAddPanelModel) {
+    // NOT dismissed: the edit sheet presents OVER this panel, and tearing the panel down would take
+    // its presenter with it.
+    coordinator.createNew(from: model)
+  }
+
+  private func cancel(model: QuickAddPanelModel) {
+    coordinator.cancel(from: model)
+    dismiss()
+  }
+
+  /// The panel went away on its own — Escape, or the user clicking elsewhere.
+  private func panelDismissed() {
+    guard let model = activeModel else { return }
+    activeModel = nil
+    coordinator.cancel(from: model)
+  }
+
+  /// The edit sheet's Save. Routed through the SAME authority every other write uses, so its
+  /// validation, its error message and its change notification are the ones the rest of the app
+  /// already relies on — a second write path here would be a second set of rules.
+  ///
+  /// Returns nil on success or a user-facing message, which is the sheet's own contract.
+  private func saveNewWord(_ word: CustomWord) -> String? {
+    let message = customWords.add(word)
+    if message == nil { dismiss() }
+    return message
+  }
+
+  private func dismiss() {
+    activeModel = nil
+    pendingNewWord = nil
+    panelHost.dismiss()
+  }
+}
+
+/// The panel's content plus the edit sheet it can present over itself.
+///
+/// A real SwiftUI `.sheet`, not the edit view hosted directly: `CustomWordEditSheet` dismisses itself
+/// through `@Environment(\.dismiss)`, which is supplied by a presenting context. Hosted bare in a
+/// panel there is no such context, so its Cancel button would render, be clickable, and do nothing.
+private struct QuickAddRoot: View {
+  @Bindable var model: QuickAddPanelModel
+  let onAccept: (QuickAddRanker.Candidate) -> Void
+  let onCreateNew: () -> Void
+  let onCancel: () -> Void
+  @Binding var newWord: CustomWord?
+  let onSaveNewWord: (CustomWord) -> String?
+
+  var body: some View {
+    QuickAddPanelView(
+      model: model, onAccept: onAccept, onCreateNew: onCreateNew, onCancel: onCancel
+    )
+    .sheet(item: $newWord) { word in
+      CustomWordEditSheet(word: word, onSave: onSaveNewWord)
+    }
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
@@ -144,10 +144,41 @@ final class QuickAddWiring {
   /// already relies on — a second write path here would be a second set of rules.
   ///
   /// Returns nil on success or a user-facing message, which is the sheet's own contract.
+  ///
+  /// **A nil return from `add` is not proof the word was saved, and this is the second time that
+  /// assumption cost this feature a false success.** `CustomWordsManager.add` RETURNS silently,
+  /// without throwing, when the canonical already exists case-insensitively — three lines below its
+  /// own comment explaining that it throws precisely so a silent return cannot dismiss a sheet on a
+  /// nil error. It also has a branch that restores a deleted built-in, which discards the aliases
+  /// the user typed. Both end as: sheet closes, panel closes, nothing saved.
+  ///
+  /// So this asserts the OUTCOME rather than the call's return value — the word is there and it
+  /// carries the spellings the user kept — which is the one check that covers both branches and any
+  /// third one nobody has found yet.
   private func saveNewWord(_ word: CustomWord) -> String? {
-    let message = customWords.add(word)
-    if message == nil { dismiss() }
-    return message
+    if let message = customWords.add(word) { return message }
+    // Compare against the TRIMMED canonical, because that is what `add` stores. Comparing the raw
+    // one reports a correct save as a failure whenever the user typed a leading space.
+    let canonical = word.canonical.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard let stored = customWords.customWords.first(where: {
+      $0.canonical.caseInsensitiveCompare(canonical) == .orderedSame
+    }) else {
+      return QuickAddPanelCopy.newWordNotSaved
+    }
+    // Blank rows are ordinary trimming, not a lost edit — the editor leaves them behind. A NON-blank
+    // spelling that vanished is the lie worth catching.
+    let kept = word.aliases
+      .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+      .filter { !$0.isEmpty }
+    let missing = kept.filter { alias in
+      !stored.aliases.contains { $0.caseInsensitiveCompare(alias) == .orderedSame }
+    }
+    guard missing.isEmpty else {
+      return QuickAddPanelCopy.newWordAlreadyExists(canonical: stored.canonical)
+    }
+    if let model = activeModel { coordinator.didCreateNew(from: model) }
+    dismiss()
+    return nil
   }
 
   private func dismiss() {

--- a/Sources/EnviousWisprAppKit/App/SettingsChangeTelemetry.swift
+++ b/Sources/EnviousWisprAppKit/App/SettingsChangeTelemetry.swift
@@ -59,6 +59,9 @@ enum SettingsProjection {
     case toggleHotkeyIdentity = "toggle_hotkey_identity"
     case pushToTalkHotkeyShape = "push_to_talk_hotkey_shape"
     case cancelHotkeyShape = "cancel_hotkey_shape"
+    /// #2381. Shape only — `chord` or `modifier_only` — never the key code, which would say
+    /// which physical key a named user pressed.
+    case quickAddHotkeyShape = "quick_add_hotkey_shape"
     case playRecordingSounds = "play_recording_sounds"
     case recordingSoundPairing = "recording_sound_pairing"
   }
@@ -113,6 +116,7 @@ enum SettingsProjection {
     case .toggleKeyCode, .toggleModifiers: return [.toggleHotkeyShape, .toggleHotkeyIdentity]
     case .pushToTalkKeyCode, .pushToTalkModifiers: return [.pushToTalkHotkeyShape]
     case .cancelKeyCode, .cancelModifiers: return [.cancelHotkeyShape]
+    case .quickAddKeyCode, .quickAddModifiers: return [.quickAddHotkeyShape]
     case .playRecordingSounds: return [.playRecordingSounds]
     case .recordingSoundPairing: return [.recordingSoundPairing]
     // Not instrumented.
@@ -165,6 +169,7 @@ enum SettingsProjection {
       return HotkeyKeyIdentity.classify(keyCode: settings.toggleKeyCode).rawValue
     case .pushToTalkHotkeyShape: return hotkeyShape(settings.pushToTalkKeyCode)
     case .cancelHotkeyShape: return hotkeyShape(settings.cancelKeyCode)
+    case .quickAddHotkeyShape: return hotkeyShape(settings.quickAddKeyCode)
     case .playRecordingSounds: return onOff(settings.playRecordingSounds)
     case .recordingSoundPairing: return settings.recordingSoundPairing.rawValue
     }

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -80,6 +80,14 @@ public final class WisprBootstrapper {
   let llmDiscovery: LLMModelDiscoveryCoordinator
   let vocabularyPackManager: VocabularyPackManager
 
+  /// Quick Add (#2381), as ONE slot rather than four.
+  ///
+  /// The coordinator, the panel host and the Services provider all live inside it. That is the
+  /// documented way to spend one stored-property slot on a group of collaborators here, and it is
+  /// what keeps the feature's deletability honest: removing Quick Add is three directories, this
+  /// property, and the one `install()` call below.
+  let quickAdd: QuickAddWiring
+
   /// App-owned output-safety classifier holder (#832/#913 PR8). The classifier
   /// is loaded asynchronously off the heart path at prewarm; the holder lets the
   /// live-dictation `LLMPolishStep`s pick it up once ready.
@@ -1040,6 +1048,12 @@ public final class WisprBootstrapper {
     self.keychainManager = keychainManager
     self.llmDiscovery = llmDiscovery
     self.vocabularyPackManager = vocabularyPackManager
+    // #2381. Built from three collaborators this root already holds; it adds no new dependency of
+    // its own and reaches nothing the root did not already have.
+    self.quickAdd = QuickAddWiring(
+      hotkeyService: hotkeyService,
+      customWords: customWordsCoordinator,
+      packManager: vocabularyPackManager)
 
     // #832/#913 PR8: App-owned output-safety classifier holder.
     self.outputClassifierHolder = outputClassifierHolder
@@ -1149,6 +1163,10 @@ public final class WisprBootstrapper {
 
   public func applicationDidFinishLaunching() {
     appLifecycleCoordinator.runDidFinishLaunching()
+    // #2381. AFTER launch, not during: `NSApp.servicesProvider` set before the app has finished
+    // launching is registered against an app that cannot yet answer, and the menu item is then
+    // present and inert.
+    quickAdd.install()
     // #1063 PR2: recover orphan crash-recovery spools behind the blocking
     // "recovering" pill. Strict limb, single-flight, one attempt per orphan.
     Task { await recoveryCoordinator.scanAndRecover() }

--- a/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelModel.swift
+++ b/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelModel.swift
@@ -1,0 +1,97 @@
+import EnviousWisprCore
+import EnviousWisprPostProcessing
+import EnviousWisprServices
+import Foundation
+
+/// The Quick Add panel's state machine (#2381).
+///
+/// **Everything about which row owns the Return key lives here, and nothing about windows does.**
+/// A focused search field and a preselected row both want Return, and the collision is invisible
+/// until someone types — so the rule is one place, written down, and unit-tested without a panel.
+///
+/// The two ranking calls are injected rather than reached for. That is not ceremony: it keeps this
+/// type free of the word library and lets every keyboard rule be exercised against candidate lists
+/// chosen to make the rule visible, instead of whatever the real scorer happens to return.
+@MainActor
+@Observable
+final class QuickAddPanelModel {
+
+  /// What the user selected. **Immutable for the panel's lifetime** — typing in the search field
+  /// changes which candidates are SHOWN and never what would be written.
+  let heard: String
+
+  /// Why there is no selection, or nil when there is one. The panel opens either way; it never
+  /// silently does nothing.
+  let refusal: SelectionReader.Refusal?
+
+  /// What the user has typed. Navigation only.
+  private(set) var query: String = ""
+
+  /// The rows on screen, and which one Return would accept.
+  private(set) var ranking: QuickAddRanker.Ranking
+
+  private let rankHeard: (String) -> QuickAddRanker.Ranking
+  private let searchLibrary: (String, String) -> QuickAddRanker.Ranking
+
+  init(
+    heard: String,
+    refusal: SelectionReader.Refusal? = nil,
+    rankHeard: @escaping (String) -> QuickAddRanker.Ranking,
+    searchLibrary: @escaping (String, String) -> QuickAddRanker.Ranking
+  ) {
+    self.heard = heard
+    self.refusal = refusal
+    self.rankHeard = rankHeard
+    self.searchLibrary = searchLibrary
+    // A refusal has no heard string to rank, so the panel opens on an empty list and a stated
+    // reason rather than on a ranking of nothing.
+    self.ranking = refusal == nil ? rankHeard(heard) : .empty
+  }
+
+  // MARK: - The search field
+
+  /// Re-rank for what the user has typed.
+  ///
+  /// Clearing the field restores the HEARD ranking, including its confidence-based preselection —
+  /// not an empty list, and not the last search's results.
+  func updateQuery(_ newQuery: String) {
+    query = newQuery
+    guard refusal == nil else { return }
+    let trimmed = newQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+    ranking =
+      trimmed.isEmpty
+      ? rankHeard(heard)
+      : searchLibrary(newQuery, heard)
+  }
+
+  // MARK: - The keyboard contract
+
+  /// Move the highlight without leaving the search field.
+  ///
+  /// Clamped rather than wrapping: wrapping from the last row to the first is a surprise when the
+  /// list is short and the user is holding the key, and this list is at most a handful of rows.
+  func moveHighlight(by offset: Int) {
+    guard !ranking.candidates.isEmpty else { return }
+    let current = ranking.candidates.firstIndex { $0.id == ranking.preselectedID }
+    // No highlight yet means the bar was not cleared, so an arrow press is the user OPTING IN to a
+    // row. Down starts at the top; up starts at the bottom.
+    let next: Int
+    if let current {
+      next = min(max(current + offset, 0), ranking.candidates.count - 1)
+    } else {
+      next = offset >= 0 ? 0 : ranking.candidates.count - 1
+    }
+    ranking = QuickAddRanker.Ranking(
+      candidates: ranking.candidates, preselectedID: ranking.candidates[next].id)
+  }
+
+  /// The row Return would accept, or nil when Return must write nothing.
+  var acceptTarget: QuickAddRanker.Candidate? { ranking.preselected }
+
+  /// What gets written if the user accepts. **Always the original selection, never the query.**
+  ///
+  /// The distinction is the whole safety property of the search field: accepting a searched-for row
+  /// must save what the user SELECTED, not what they typed to find it. Without this the escape
+  /// hatch built to recover from a wrong ranking becomes a way to write an arbitrary string.
+  var spellingToWrite: String { heard }
+}

--- a/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelModel.swift
+++ b/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelModel.swift
@@ -93,6 +93,20 @@ final class QuickAddPanelModel {
       candidates: ranking.candidates, preselectedID: ranking.candidates[next].id)
   }
 
+  /// Whether the user is actually filtering, as opposed to having pressed the space bar.
+  ///
+  /// **`!query.isEmpty` was the test at four call sites and it is wrong for whitespace.**
+  /// `updateQuery` trims before deciding whether to re-rank — correctly, since a field holding two
+  /// spaces should show the heard ranking rather than an empty filter — but it stores the RAW text,
+  /// because that is what the field renders. So a whitespace-only field restored the heard ranking
+  /// while every downstream reader still believed a search was in progress: the group header
+  /// switched to its searching sentence under a user who had typed nothing, and `used_search=true`
+  /// went out on the resulting accept, which is a telemetry claim that the ranking needed rescuing
+  /// when it did not.
+  ///
+  /// One owner, derived, rather than four call sites each remembering to trim.
+  var isSearching: Bool { !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+
   /// The row Return would accept, or nil when Return must write nothing.
   var acceptTarget: QuickAddRanker.Candidate? { ranking.preselected }
 

--- a/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelModel.swift
+++ b/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelModel.swift
@@ -27,6 +27,12 @@ final class QuickAddPanelModel {
   /// What the user has typed. Navigation only.
   private(set) var query: String = ""
 
+  /// Why the last accept did not save, or nil. **The panel stays open when this is set**, which is
+  /// the whole point: the write path can refuse (the character policy, the 512-scalar ceiling, a
+  /// words file that will not write) and a panel that dismissed on refusal reported success for a
+  /// word that was never saved.
+  private(set) var writeFailure: String?
+
   /// The rows on screen, and which one Return would accept.
   private(set) var ranking: QuickAddRanker.Ranking
 
@@ -56,6 +62,8 @@ final class QuickAddPanelModel {
   /// not an empty list, and not the last search's results.
   func updateQuery(_ newQuery: String) {
     query = newQuery
+    // A refusal describes the LAST accept. Typing is the user moving on from it.
+    writeFailure = nil
     guard refusal == nil else { return }
     let trimmed = newQuery.trimmingCharacters(in: .whitespacesAndNewlines)
     ranking =
@@ -87,6 +95,10 @@ final class QuickAddPanelModel {
 
   /// The row Return would accept, or nil when Return must write nothing.
   var acceptTarget: QuickAddRanker.Candidate? { ranking.preselected }
+
+  /// Record that the library refused the write. Set by the coordinator's caller, never here: the
+  /// model does not know what a words file is and must not learn.
+  func noteWriteFailure(_ message: String) { writeFailure = message }
 
   /// What gets written if the user accepts. **Always the original selection, never the query.**
   ///

--- a/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelView.swift
+++ b/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelView.swift
@@ -40,6 +40,20 @@ enum QuickAddPanelCopy {
     return "add as a new spelling · \(spellingCount) \(noun) \(alreadySaved)"
   }
 
+  /// The subtitle for a word that ALREADY carries the heard spelling.
+  ///
+  /// **The row promised an add it could not make.** `QuickAddRanker.Candidate` has carried
+  /// `alreadyHasHeardSpelling` since the first chunk and the coordinator branches on it — accepting
+  /// such a row writes NOTHING and resolves `alreadySaved` — but the view never read the flag, so the
+  /// row said "add as a new spelling", the user pressed Return, and the panel closed having done
+  /// nothing and said nothing. Reported success, one file away from the code that refuses to report
+  /// it, and reachable on the very first thing a user tries: any word they have already corrected
+  /// once scores 1.00 and lands here.
+  static func rowSubtitleAlreadyHas(spellingCount: Int) -> String {
+    let noun = spellingCount == 1 ? "spelling" : "spellings"
+    return "already has this spelling · \(spellingCount) \(noun) saved"
+  }
+
   /// The one line shown instead of a ranking when we could not read a selection.
   ///
   /// Every refusal gets its own sentence. A single "could not read your selection" would be
@@ -123,7 +137,10 @@ struct QuickAddPanelView: View {
     // The field takes focus on open, so typing is always the immediate alternative to accepting —
     // which is what makes a wrong-but-confident ranking recoverable without reaching for the mouse.
     .onAppear { searchFocused = true }
-    .onExitCommand(perform: onCancel)
+    // NO `.onExitCommand`. It sat here and never fired: the search field takes focus on open and its
+    // field editor claims `cancelOperation(_:)` first. Escape is handled on the panel itself, where
+    // nothing can intercept it — and leaving it here as well would give one keypress two dismissal
+    // paths, which the coordinator's double-resolution guard would then report as a defect.
   }
 
   // MARK: - Regions
@@ -188,7 +205,7 @@ struct QuickAddPanelView: View {
           Text(candidate.word.canonical)
             .font(.stRowLabel)
             .foregroundStyle(.stTextPrimary)
-          Text(QuickAddPanelCopy.rowSubtitle(spellingCount: candidate.word.aliases.count))
+          Text(Self.subtitle(for: candidate))
             .font(.stHelper)
             .foregroundStyle(.stTextSecondary)
         }
@@ -207,9 +224,15 @@ struct QuickAddPanelView: View {
     }
     .buttonStyle(.plain)
     .contentShape(Rectangle())
-    .accessibilityLabel(
-      "\(candidate.word.canonical), \(QuickAddPanelCopy.rowSubtitle(spellingCount: candidate.word.aliases.count))"
-    )
+    .accessibilityLabel("\(candidate.word.canonical), \(Self.subtitle(for: candidate))")
+  }
+
+  /// One owner for what a row says about itself, read by the visible label AND the accessibility
+  /// one. Two call sites computing this independently is how they came to disagree elsewhere.
+  static func subtitle(for candidate: QuickAddRanker.Candidate) -> String {
+    candidate.alreadyHasHeardSpelling
+      ? QuickAddPanelCopy.rowSubtitleAlreadyHas(spellingCount: candidate.word.aliases.count)
+      : QuickAddPanelCopy.rowSubtitle(spellingCount: candidate.word.aliases.count)
   }
 
   private var createNewRow: some View {

--- a/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelView.swift
+++ b/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelView.swift
@@ -14,6 +14,12 @@ enum QuickAddPanelCopy {
   static let returnHint = "Return"
   static let alreadySaved = "already saved"
 
+  /// Shown when the library refused the write, above the rows so the panel that stayed open says
+  /// why. The message comes from the words authority itself rather than being reworded here: it is
+  /// the same sentence the editor shows for the same refusal, and a second wording would be a
+  /// second set of rules for the user to reconcile.
+  static func writeFailure(_ message: String) -> String { "Not saved. \(message)" }
+
   /// The subtitle under a candidate: what accepting it would do, then how much that word already
   /// carries. Singular matters — "1 spellings already saved" is the kind of thing users screenshot.
   static func rowSubtitle(spellingCount: Int) -> String {
@@ -25,6 +31,13 @@ enum QuickAddPanelCopy {
   ///
   /// Every refusal gets its own sentence. A single "could not read your selection" would be
   /// technically true for all of them and useless for the only one the user can act on.
+  ///
+  /// **Every sentence points at a control that actually works in this state, and three of them
+  /// used to point at one that does not.** With no heard spelling there is nothing to rank and
+  /// nothing to add a spelling TO, so `QuickAddPanelModel.updateQuery` deliberately does not
+  /// re-rank and the view hides the field — and the earlier wording, "You can search for the word
+  /// below", sent the user to a field that would not have answered. The one thing that does work
+  /// here is authoring the word by hand, which is the row below the divider.
   static func refusalMessage(_ refusal: SelectionReader.Refusal) -> String {
     switch refusal {
     case .accessibilityNotTrusted:
@@ -35,12 +48,13 @@ enum QuickAddPanelCopy {
     case .noFocusedElement:
       "That app did not tell us where the cursor is. Click into the text and try again."
     case .selectionUnsupported:
-      "That app does not share its selection with other apps. You can search for the word below."
+      "That app does not share its selection with other apps. You can still add the word by hand "
+        + "below."
     case .selectionUnavailable:
-      "That app reports a selection it will not share. Terminals do this. You can search for the "
-        + "word below."
+      "That app reports a selection it will not share. Terminals do this. You can still add the "
+        + "word by hand below."
     case .unreadable:
-      "Your selection could not be read. You can search for the word below."
+      "Your selection could not be read. You can still add the word by hand below."
     case .selectionTooLong:
       "That selection is too long to be a word. Select just the word and try again."
     }
@@ -67,11 +81,20 @@ struct QuickAddPanelView: View {
   var body: some View {
     VStack(alignment: .leading, spacing: 14) {
       heardHeader
-      searchField
+      // Hidden on a refusal rather than rendered dead. `updateQuery` does not re-rank without a
+      // heard string — correctly, since there would be nothing to add a spelling to — so a field
+      // shown here is a control the user can type into and watch do nothing.
+      if model.refusal == nil { searchField }
       if let refusal = model.refusal {
         Text(QuickAddPanelCopy.refusalMessage(refusal))
           .font(.stBody)
           .foregroundStyle(.stTextSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+      if let failure = model.writeFailure {
+        Text(QuickAddPanelCopy.writeFailure(failure))
+          .font(.stBody)
+          .foregroundStyle(.stError)
           .fixedSize(horizontal: false, vertical: true)
       }
       candidateRows

--- a/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelView.swift
+++ b/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelView.swift
@@ -8,11 +8,8 @@ import SwiftUI
 /// 2026-08-24 design review can be asserted without rendering anything. Every separator here is a
 /// MIDDLE DOT, never a dash.
 enum QuickAddPanelCopy {
-  static let heardLabel = "Heard"
   static let searchPlaceholder = "Search your words"
   static let createNewWord = "Create a new word"
-  static let returnHint = "Return"
-  static let alreadySaved = "already saved"
 
   /// Shown when the library refused the write, above the rows so the panel that stayed open says
   /// why. The message comes from the words authority itself rather than being reworded here: it is
@@ -33,26 +30,63 @@ enum QuickAddPanelCopy {
       + "add this spelling."
   }
 
-  /// The subtitle under a candidate: what accepting it would do, then how much that word already
-  /// carries. Singular matters — "1 spellings already saved" is the kind of thing users screenshot.
-  static func rowSubtitle(spellingCount: Int) -> String {
-    let noun = spellingCount == 1 ? "spelling" : "spellings"
-    return "add as a new spelling · \(spellingCount) \(noun) \(alreadySaved)"
+  /// The one line above the list, which is the sentence every row completes.
+  ///
+  /// **This is what buys the compactness.** The old design repeated "add as a new spelling" on every
+  /// row, so five candidates cost ten lines and four of the five subtitles wrapped. The verb is
+  /// stated ONCE here and the rows carry only a name and a count, which is five lines for the same
+  /// five candidates.
+  ///
+  /// It is also the panel's confidence signal in words rather than in styling. Below the bar nothing
+  /// is preselected, and a list that looks identical either way leaves the user to infer the
+  /// difference from a missing tint.
+  static func groupHeader(_ state: GroupHeaderState, heard: String) -> String {
+    switch state {
+    case .confident: "Add \"\(heard)\" to"
+    case .lowConfidence: "No close match · pick one or keep typing"
+    case .alreadySaved: "Already knows \"\(heard)\" · nothing to add"
+    case .searching: "Add \"\(heard)\" to"
+    }
   }
 
-  /// The subtitle for a word that ALREADY carries the heard spelling.
+  /// What the list is currently saying. Four cases, closed, so a new one forces every consumer to
+  /// say what it does with it rather than falling into whichever branch is nearest.
+  enum GroupHeaderState: Equatable, Sendable, CaseIterable {
+    /// A row is preselected: the bar was cleared and Return will write.
+    case confident
+    /// Rows exist and none is preselected. Return writes nothing, deliberately.
+    case lowConfidence
+    /// The top match already carries this spelling, so there is nothing to add.
+    case alreadySaved
+    /// The user is filtering. Same verb as `confident`; the header must not change under them
+    /// mid-keystroke, which is the one thing a header that also carries state can get wrong.
+    case searching
+  }
+
+  /// The right-hand meta on a row. A count, not a sentence.
+  static func spellingCount(_ count: Int) -> String {
+    "\(count) \(count == 1 ? "spelling" : "spellings")"
+  }
+
+  /// The meta on a row that already carries the heard spelling, in place of the count.
   ///
   /// **The row promised an add it could not make.** `QuickAddRanker.Candidate` has carried
   /// `alreadyHasHeardSpelling` since the first chunk and the coordinator branches on it — accepting
-  /// such a row writes NOTHING and resolves `alreadySaved` — but the view never read the flag, so the
-  /// row said "add as a new spelling", the user pressed Return, and the panel closed having done
-  /// nothing and said nothing. Reported success, one file away from the code that refuses to report
-  /// it, and reachable on the very first thing a user tries: any word they have already corrected
-  /// once scores 1.00 and lands here.
-  static func rowSubtitleAlreadyHas(spellingCount: Int) -> String {
-    let noun = spellingCount == 1 ? "spelling" : "spellings"
-    return "already has this spelling · \(spellingCount) \(noun) saved"
-  }
+  /// such a row writes NOTHING and resolves `alreadySaved` — but the view never read the flag, so
+  /// every row said "add as a new spelling", the user pressed Return, and the panel closed having
+  /// done nothing and said nothing. Reachable on the first thing anyone tries: a word corrected once
+  /// scores 1.00 and lands here.
+  static let alreadyHasThisSpelling = "already has this"
+
+  /// The keyboard legend along the bottom.
+  ///
+  /// Not chrome. It is the contract made visible, and it is the cheapest teaching surface a feature
+  /// whose whole value is keyboard speed can have. Its CONTENTS are derived rather than fixed: if
+  /// Return does nothing in this state, Return is not listed, so the legend can never promise a key
+  /// that will not answer.
+  static let legendAccept = "add spelling"
+  static let legendMove = "move"
+  static let legendClose = "close"
 
   /// The one line shown instead of a ranking when we could not read a selection.
   ///
@@ -110,29 +144,38 @@ struct QuickAddPanelView: View {
   @FocusState private var searchFocused: Bool
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 14) {
-      heardHeader
-      // Hidden on a refusal rather than rendered dead. `updateQuery` does not re-rank without a
-      // heard string — correctly, since there would be nothing to add a spelling to — so a field
-      // shown here is a control the user can type into and watch do nothing.
-      if model.refusal == nil { searchField }
+    VStack(alignment: .leading, spacing: 0) {
+      searchWell
       if let refusal = model.refusal {
         Text(QuickAddPanelCopy.refusalMessage(refusal))
           .font(.stBody)
           .foregroundStyle(.stTextSecondary)
           .fixedSize(horizontal: false, vertical: true)
+          .padding(.horizontal, 16)
+          .padding(.top, 14)
       }
       if let failure = model.writeFailure {
         Text(QuickAddPanelCopy.writeFailure(failure))
           .font(.stBody)
           .foregroundStyle(.stError)
           .fixedSize(horizontal: false, vertical: true)
+          .padding(.horizontal, 16)
+          .padding(.top, 14)
       }
-      candidateRows
-      Divider().overlay(Color.stDivider)
+      if !model.ranking.candidates.isEmpty {
+        Text(QuickAddPanelCopy.groupHeader(headerState, heard: model.heard))
+          .font(.stSectionHeader)
+          .tracking(0.5)
+          .foregroundStyle(headerState == .lowConfidence ? .stTextTertiary : .stAccent)
+          .padding(.horizontal, 16)
+          .padding(.top, 14)
+          .padding(.bottom, 6)
+        candidateRows
+      }
+      Divider().overlay(Color.stDivider).padding(.top, 10)
       createNewRow
+      legend
     }
-    .padding(18)
     .frame(width: 360)
     // The field takes focus on open, so typing is always the immediate alternative to accepting —
     // which is what makes a wrong-but-confident ranking recoverable without reaching for the mouse.
@@ -143,96 +186,175 @@ struct QuickAddPanelView: View {
     // paths, which the coordinator's double-resolution guard would then report as a defect.
   }
 
-  // MARK: - Regions
-
-  private var heardHeader: some View {
-    VStack(alignment: .leading, spacing: 2) {
-      Text(QuickAddPanelCopy.heardLabel)
-        .font(.stSectionHeader)
-        .tracking(0.6)
-        .foregroundStyle(.stAccent)
-      Text(model.heard)
-        .font(.stRowTitle)
-        .foregroundStyle(.stTextPrimary)
-        .textSelection(.enabled)
-    }
+  /// Which sentence the group header is saying. Derived, never stored: a second copy of this on the
+  /// model is a second thing to keep in step with the ranking.
+  var headerState: QuickAddPanelCopy.GroupHeaderState {
+    if model.ranking.preselected?.alreadyHasHeardSpelling == true { return .alreadySaved }
+    if !model.query.isEmpty { return .searching }
+    return model.ranking.preselectedID == nil ? .lowConfidence : .confident
   }
 
-  private var searchField: some View {
-    TextField(
-      QuickAddPanelCopy.searchPlaceholder,
-      // `set: { model.updateQuery($0) }`, NOT `set: model.updateQuery`. The bare method reference
-      // makes the compiler build a reabstraction thunk from a `@MainActor` method to `Binding`'s
-      // non-isolated setter, and Swift 6.3.3 CRASHES emitting it — swift-frontend aborts in IR
-      // generation with no source diagnostic, so the build fails with zero `error:` lines and names
-      // only this file. The explicit closure is the same behaviour and compiles. Do not tidy it back.
-      text: Binding(get: { model.query }, set: { model.updateQuery($0) })
-    )
-    .textFieldStyle(.roundedBorder)
-    .focused($searchFocused)
-    // Arrows move the highlight WITHOUT leaving the field, which is what lets the user keep typing
-    // after correcting the selection.
-    .onMoveCommand { direction in
-      switch direction {
-      case .down: model.moveHighlight(by: 1)
-      case .up: model.moveHighlight(by: -1)
-      default: break
+  // MARK: - Regions
+
+  /// The search field, and the reason it is a WELL rather than a strip.
+  ///
+  /// **It was already the widest, topmost element and still did not read as typable.** The old one
+  /// was a full-bleed strip on a panel made of full-bleed strips, so nothing distinguished it from a
+  /// title area — and size could not fix that, because size was never the variable. A field is
+  /// recognised by its EDGES: a border, a recessed fill, a radius, a caret, and the magnifier that
+  /// makes Spotlight unmistakable at a glance.
+  ///
+  /// The selected word used to ride in here as a pill, which occupied exactly the slot the magnifier
+  /// needs. Moving it to the group header is what made room for the one glyph that does the work,
+  /// and it retired the only genuinely fiddly piece of SwiftUI in the design.
+  private var searchWell: some View {
+    HStack(spacing: 8) {
+      Image(systemName: "magnifyingglass")
+        .font(.system(size: 13, weight: .medium))
+        .foregroundStyle(.stTextTertiary)
+      TextField(
+        QuickAddPanelCopy.searchPlaceholder,
+        // `set: { model.updateQuery($0) }`, NOT `set: model.updateQuery`. The bare method reference
+        // makes the compiler build a reabstraction thunk from a `@MainActor` method to `Binding`'s
+        // non-isolated setter, and Swift 6.3.3 CRASHES emitting it — swift-frontend aborts in IR
+        // generation with no source diagnostic, so the build fails with zero `error:` lines and names
+        // only this file. The explicit closure is the same behaviour and compiles. Do not tidy it back.
+        text: Binding(get: { model.query }, set: { model.updateQuery($0) })
+      )
+      .textFieldStyle(.plain)
+      .font(.system(size: 15))
+      .foregroundStyle(.stTextPrimary)
+      .focused($searchFocused)
+      .disabled(model.refusal != nil)
+      // Arrows move the highlight WITHOUT leaving the field, which is what lets the user keep typing
+      // after correcting the selection.
+      .onMoveCommand { direction in
+        switch direction {
+        case .down: model.moveHighlight(by: 1)
+        case .up: model.moveHighlight(by: -1)
+        default: break
+        }
+      }
+      // **Return writes only when a highlighted row exists.** Below the confidence bar, and on zero
+      // results, there is no highlight and this does nothing — which is the bar doing its job rather
+      // than a dead key.
+      .onSubmit {
+        guard let target = model.acceptTarget else { return }
+        onAccept(target)
       }
     }
-    // **Return writes only when a highlighted row exists.** Below the confidence bar, and on zero
-    // results, there is no highlight and this does nothing — which is the bar doing its job rather
-    // than a dead key.
-    .onSubmit {
-      guard let target = model.acceptTarget else { return }
-      onAccept(target)
-    }
+    .padding(.horizontal, 12)
+    .frame(height: 38)
+    .background(
+      RoundedRectangle(cornerRadius: 8).fill(Color.stSectionBg)
+    )
+    .overlay(
+      RoundedRectangle(cornerRadius: 8)
+        .strokeBorder(searchFocused ? Color.stAccentSolid : Color.stDivider, lineWidth: 1)
+    )
+    .padding(.horizontal, 12)
+    .padding(.top, 12)
   }
 
   private var candidateRows: some View {
-    VStack(alignment: .leading, spacing: 6) {
+    VStack(alignment: .leading, spacing: 1) {
       ForEach(model.ranking.candidates) { candidate in
         row(for: candidate, isHighlighted: candidate.id == model.ranking.preselectedID)
       }
     }
   }
 
+  /// One row: a name, and a count. No verb.
+  ///
+  /// The verb lives in the group header, said once. That is the whole reason five candidates fit in
+  /// five lines rather than the ten that a wrapped per-row subtitle costs.
   private func row(for candidate: QuickAddRanker.Candidate, isHighlighted: Bool) -> some View {
     Button {
       onAccept(candidate)
     } label: {
-      HStack(alignment: .firstTextBaseline, spacing: 10) {
-        VStack(alignment: .leading, spacing: 2) {
-          Text(candidate.word.canonical)
-            .font(.stRowLabel)
-            .foregroundStyle(.stTextPrimary)
-          Text(Self.subtitle(for: candidate))
-            .font(.stHelper)
-            .foregroundStyle(.stTextSecondary)
-        }
+      HStack(spacing: 10) {
+        Text(candidate.word.canonical)
+          .font(.stRowLabel)
+          .foregroundStyle(.stTextPrimary)
+          .lineLimit(1)
         Spacer(minLength: 8)
+        Text(
+          candidate.alreadyHasHeardSpelling
+            ? QuickAddPanelCopy.alreadyHasThisSpelling
+            : QuickAddPanelCopy.spellingCount(candidate.word.aliases.count)
+        )
+        .font(.stHelper)
+        .foregroundStyle(.stTextTertiary)
+        .lineLimit(1)
         if isHighlighted {
-          Text(QuickAddPanelCopy.returnHint)
+          Text("\u{23CE}")
             .font(.stHelper)
             .foregroundStyle(.stTextSecondary)
         }
       }
-      .padding(.vertical, 6)
-      .padding(.horizontal, 8)
+      .padding(.vertical, 7)
+      .padding(.horizontal, 10)
       .frame(maxWidth: .infinity, alignment: .leading)
       .background(isHighlighted ? Color.stAccent.opacity(0.14) : .clear)
       .clipShape(RoundedRectangle(cornerRadius: 6))
+      // A row that cannot add anything is shown, because hiding it would answer "is this word
+      // already handled" by saying nothing, but it is visibly not the live option.
+      .opacity(candidate.alreadyHasHeardSpelling ? 0.55 : 1)
     }
     .buttonStyle(.plain)
     .contentShape(Rectangle())
-    .accessibilityLabel("\(candidate.word.canonical), \(Self.subtitle(for: candidate))")
+    .accessibilityLabel(Self.accessibilityLabel(for: candidate))
+    .padding(.horizontal, 6)
   }
 
-  /// One owner for what a row says about itself, read by the visible label AND the accessibility
-  /// one. Two call sites computing this independently is how they came to disagree elsewhere.
-  static func subtitle(for candidate: QuickAddRanker.Candidate) -> String {
-    candidate.alreadyHasHeardSpelling
-      ? QuickAddPanelCopy.rowSubtitleAlreadyHas(spellingCount: candidate.word.aliases.count)
-      : QuickAddPanelCopy.rowSubtitle(spellingCount: candidate.word.aliases.count)
+  /// One owner for what a row says about itself, read by the accessibility label and derived from
+  /// the same two strings the visible row uses. Two call sites computing this independently is how
+  /// they came to disagree elsewhere.
+  static func accessibilityLabel(for candidate: QuickAddRanker.Candidate) -> String {
+    let meta =
+      candidate.alreadyHasHeardSpelling
+      ? QuickAddPanelCopy.alreadyHasThisSpelling
+      : QuickAddPanelCopy.spellingCount(candidate.word.aliases.count)
+    return "\(candidate.word.canonical), \(meta)"
+  }
+
+  /// The keyboard contract, made visible.
+  ///
+  /// **Its contents are derived, so it can never promise a key that will not answer.** The Return
+  /// cap appears only when a row is actually preselected — below the confidence bar it is absent,
+  /// which is the same fact the group header states in words. It also teaches arrow navigation to a
+  /// user who would otherwise have to discover it by accident.
+  private var legend: some View {
+    HStack(spacing: 14) {
+      if model.acceptTarget != nil {
+        legendItem("\u{23CE}", QuickAddPanelCopy.legendAccept)
+      }
+      if !model.ranking.candidates.isEmpty {
+        legendItem("\u{2191}\u{2193}", QuickAddPanelCopy.legendMove)
+      }
+      legendItem("esc", QuickAddPanelCopy.legendClose)
+      Spacer(minLength: 0)
+    }
+    .padding(.horizontal, 16)
+    .padding(.vertical, 9)
+    .background(Color.stSectionBg)
+  }
+
+  private func legendItem(_ cap: String, _ label: String) -> some View {
+    HStack(spacing: 5) {
+      Text(cap)
+        .font(.system(size: 10, weight: .medium, design: .rounded))
+        .foregroundStyle(.stTextSecondary)
+        .padding(.horizontal, 5)
+        .padding(.vertical, 2)
+        .background(
+          RoundedRectangle(cornerRadius: 4).fill(Color.stDivider.opacity(0.5))
+        )
+      Text(label)
+        .font(.stHelper)
+        .foregroundStyle(.stTextTertiary)
+    }
+    .accessibilityElement(children: .combine)
   }
 
   private var createNewRow: some View {

--- a/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelView.swift
+++ b/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelView.swift
@@ -332,7 +332,20 @@ struct QuickAddPanelView: View {
       if !model.ranking.candidates.isEmpty {
         legendItem("\u{2191}\u{2193}", QuickAddPanelCopy.legendMove)
       }
-      legendItem("esc", QuickAddPanelCopy.legendClose)
+      // **A BUTTON, and it is the only mouse path off this panel.** The standard close control is
+      // hidden because `.fullSizeContentView` puts the hosting view over the titlebar, so unhiding
+      // it produces nothing — measured. And `windowDidResignKey` is deliberately a no-op now, so
+      // clicking away no longer dismisses either. That left Escape as the sole exit, which is
+      // exactly the founder's original complaint arriving through a different door: a keyboard-only
+      // way out is invisible to anyone who does not already know it, and unusable for anyone who
+      // cannot reach that key.
+      //
+      // The legend is where it belongs rather than in new chrome: it already names this key, so a
+      // user reading "esc close" and clicking it is doing the obvious thing.
+      Button(action: onCancel) { legendItem("esc", QuickAddPanelCopy.legendClose) }
+        .buttonStyle(.plain)
+        .contentShape(Rectangle())
+        .accessibilityLabel(QuickAddPanelCopy.legendClose)
       Spacer(minLength: 0)
     }
     .padding(.horizontal, 16)

--- a/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelView.swift
+++ b/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelView.swift
@@ -1,0 +1,191 @@
+import EnviousWisprPostProcessing
+import EnviousWisprServices
+import SwiftUI
+
+/// The Quick Add panel's copy, frozen.
+///
+/// A named table rather than strings inline in the view, so the founder-approved wording from the
+/// 2026-08-24 design review can be asserted without rendering anything. Every separator here is a
+/// MIDDLE DOT, never a dash.
+enum QuickAddPanelCopy {
+  static let heardLabel = "Heard"
+  static let searchPlaceholder = "Search your words"
+  static let createNewWord = "Create a new word"
+  static let returnHint = "Return"
+  static let alreadySaved = "already saved"
+
+  /// The subtitle under a candidate: what accepting it would do, then how much that word already
+  /// carries. Singular matters — "1 spellings already saved" is the kind of thing users screenshot.
+  static func rowSubtitle(spellingCount: Int) -> String {
+    let noun = spellingCount == 1 ? "spelling" : "spellings"
+    return "add as a new spelling · \(spellingCount) \(noun) \(alreadySaved)"
+  }
+
+  /// The one line shown instead of a ranking when we could not read a selection.
+  ///
+  /// Every refusal gets its own sentence. A single "could not read your selection" would be
+  /// technically true for all of them and useless for the only one the user can act on.
+  static func refusalMessage(_ refusal: SelectionReader.Refusal) -> String {
+    switch refusal {
+    case .accessibilityNotTrusted:
+      "EnviousWispr needs Accessibility permission to read your selection. Turn it on in System "
+        + "Settings, then try again."
+    case .noFrontmostApplication:
+      "No app was in front, so there was nothing to read."
+    case .noFocusedElement:
+      "That app did not tell us where the cursor is. Click into the text and try again."
+    case .selectionUnsupported:
+      "That app does not share its selection with other apps. You can search for the word below."
+    case .selectionUnavailable:
+      "That app reports a selection it will not share. Terminals do this. You can search for the "
+        + "word below."
+    case .unreadable:
+      "Your selection could not be read. You can search for the word below."
+    case .selectionTooLong:
+      "That selection is too long to be a word. Select just the word and try again."
+    }
+  }
+}
+
+/// Renders the Quick Add panel and owns its key handling (#2381).
+///
+/// **Rendering and keys, nothing else.** No ranking, no word library, no window: the model beside it
+/// decides which row Return accepts, and the coordinator above it decides what happens when it does.
+struct QuickAddPanelView: View {
+
+  @Bindable var model: QuickAddPanelModel
+
+  /// Accept a candidate: add the heard spelling to that word.
+  let onAccept: (QuickAddRanker.Candidate) -> Void
+  /// Create a new word carrying the heard spelling as its first alias.
+  let onCreateNew: () -> Void
+  /// Escape, or anything else that means "never mind".
+  let onCancel: () -> Void
+
+  @FocusState private var searchFocused: Bool
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 14) {
+      heardHeader
+      searchField
+      if let refusal = model.refusal {
+        Text(QuickAddPanelCopy.refusalMessage(refusal))
+          .font(.stBody)
+          .foregroundStyle(.stTextSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+      candidateRows
+      Divider().overlay(Color.stDivider)
+      createNewRow
+    }
+    .padding(18)
+    .frame(width: 360)
+    // The field takes focus on open, so typing is always the immediate alternative to accepting —
+    // which is what makes a wrong-but-confident ranking recoverable without reaching for the mouse.
+    .onAppear { searchFocused = true }
+    .onExitCommand(perform: onCancel)
+  }
+
+  // MARK: - Regions
+
+  private var heardHeader: some View {
+    VStack(alignment: .leading, spacing: 2) {
+      Text(QuickAddPanelCopy.heardLabel)
+        .font(.stSectionHeader)
+        .tracking(0.6)
+        .foregroundStyle(.stAccent)
+      Text(model.heard)
+        .font(.stRowTitle)
+        .foregroundStyle(.stTextPrimary)
+        .textSelection(.enabled)
+    }
+  }
+
+  private var searchField: some View {
+    TextField(
+      QuickAddPanelCopy.searchPlaceholder,
+      // `set: { model.updateQuery($0) }`, NOT `set: model.updateQuery`. The bare method reference
+      // makes the compiler build a reabstraction thunk from a `@MainActor` method to `Binding`'s
+      // non-isolated setter, and Swift 6.3.3 CRASHES emitting it — swift-frontend aborts in IR
+      // generation with no source diagnostic, so the build fails with zero `error:` lines and names
+      // only this file. The explicit closure is the same behaviour and compiles. Do not tidy it back.
+      text: Binding(get: { model.query }, set: { model.updateQuery($0) })
+    )
+    .textFieldStyle(.roundedBorder)
+    .focused($searchFocused)
+    // Arrows move the highlight WITHOUT leaving the field, which is what lets the user keep typing
+    // after correcting the selection.
+    .onMoveCommand { direction in
+      switch direction {
+      case .down: model.moveHighlight(by: 1)
+      case .up: model.moveHighlight(by: -1)
+      default: break
+      }
+    }
+    // **Return writes only when a highlighted row exists.** Below the confidence bar, and on zero
+    // results, there is no highlight and this does nothing — which is the bar doing its job rather
+    // than a dead key.
+    .onSubmit {
+      guard let target = model.acceptTarget else { return }
+      onAccept(target)
+    }
+  }
+
+  private var candidateRows: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      ForEach(model.ranking.candidates) { candidate in
+        row(for: candidate, isHighlighted: candidate.id == model.ranking.preselectedID)
+      }
+    }
+  }
+
+  private func row(for candidate: QuickAddRanker.Candidate, isHighlighted: Bool) -> some View {
+    Button {
+      onAccept(candidate)
+    } label: {
+      HStack(alignment: .firstTextBaseline, spacing: 10) {
+        VStack(alignment: .leading, spacing: 2) {
+          Text(candidate.word.canonical)
+            .font(.stRowLabel)
+            .foregroundStyle(.stTextPrimary)
+          Text(QuickAddPanelCopy.rowSubtitle(spellingCount: candidate.word.aliases.count))
+            .font(.stHelper)
+            .foregroundStyle(.stTextSecondary)
+        }
+        Spacer(minLength: 8)
+        if isHighlighted {
+          Text(QuickAddPanelCopy.returnHint)
+            .font(.stHelper)
+            .foregroundStyle(.stTextSecondary)
+        }
+      }
+      .padding(.vertical, 6)
+      .padding(.horizontal, 8)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .background(isHighlighted ? Color.stAccent.opacity(0.14) : .clear)
+      .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+    .buttonStyle(.plain)
+    .contentShape(Rectangle())
+    .accessibilityLabel(
+      "\(candidate.word.canonical), \(QuickAddPanelCopy.rowSubtitle(spellingCount: candidate.word.aliases.count))"
+    )
+  }
+
+  private var createNewRow: some View {
+    Button(action: onCreateNew) {
+      HStack(spacing: 8) {
+        Image(systemName: "plus")
+        Text(QuickAddPanelCopy.createNewWord)
+      }
+      .font(.stRowLabel)
+      .foregroundStyle(.stTextPrimary)
+      .padding(.vertical, 6)
+      .padding(.horizontal, 8)
+      .frame(maxWidth: .infinity, alignment: .leading)
+    }
+    .buttonStyle(.plain)
+    .contentShape(Rectangle())
+    .accessibilityLabel(QuickAddPanelCopy.createNewWord)
+  }
+}

--- a/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelView.swift
+++ b/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelView.swift
@@ -23,6 +23,16 @@ enum QuickAddPanelCopy {
   static let newWordNotSaved =
     "That word could not be saved. Check it does not already exist in your words."
 
+  /// The row's word was in the library when the panel was ranked and is not there now, because the
+  /// panel stays open and the user deleted it in Settings in between.
+  ///
+  /// **Written to sit UNDER `writeFailure`'s "Not saved." prefix**, which is the channel it travels
+  /// through: `accept` returns it, the wiring hands it to `noteWriteFailure`, and the view renders
+  /// that prefix. So it does not repeat "was not added" — reusing a refusal path means inheriting
+  /// its sentence, and a copy written as though it stood alone reads as a stutter once rendered.
+  static let wordNoLongerExists =
+    "That word is no longer in your words. Create it as a new word instead."
+
   /// The canonical already existed, so the library kept what it had and the spelling was not added.
   /// Names the surviving word, because the way forward is to pick it from the list.
   static func newWordAlreadyExists(canonical: String) -> String {

--- a/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelView.swift
+++ b/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelView.swift
@@ -132,6 +132,15 @@ enum QuickAddPanelCopy {
       // The plan's exact wording (§3, "Refresh before ranking"). Capital W on Words because that is
       // what the feature is called in Settings, and a user reading this has to find it there.
       "Your Words could not be refreshed, so there is nothing to match against yet. Try again."
+    case .nothingSelected:
+      // The likeliest refusal of the eight, and the only one where NOTHING went wrong. It used to
+      // borrow `selectionUnavailable`'s sentence, which names terminals and blames the frontmost
+      // app — a confident diagnosis handed to someone whose only mistake was not highlighting a
+      // word. So this one names no app, assigns no fault, and says the single thing that fixes it.
+      // No route named ("press the shortcut again"), because BOTH doors reach here: the hotkey with
+      // nothing highlighted, and the Services menu handed whitespace. A sentence naming one of them
+      // is wrong half the time it is shown.
+      "Nothing was selected. Highlight the word you want and try again, or add it by hand below."
     }
   }
 }

--- a/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelView.swift
+++ b/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelView.swift
@@ -20,6 +20,19 @@ enum QuickAddPanelCopy {
   /// second set of rules for the user to reconcile.
   static func writeFailure(_ message: String) -> String { "Not saved. \(message)" }
 
+  /// The edit sheet saved and the word is not in the library afterwards. Rare, and deliberately not
+  /// specific: the reasons `CustomWordsManager.add` can return silently are not distinguishable from
+  /// the caller, so naming one would be a guess presented as a fact.
+  static let newWordNotSaved =
+    "That word could not be saved. Check it does not already exist in your words."
+
+  /// The canonical already existed, so the library kept what it had and the spelling was not added.
+  /// Names the surviving word, because the way forward is to pick it from the list.
+  static func newWordAlreadyExists(canonical: String) -> String {
+    "\"\(canonical)\" already exists and was left as it is. Choose it from the list instead to "
+      + "add this spelling."
+  }
+
   /// The subtitle under a candidate: what accepting it would do, then how much that word already
   /// carries. Singular matters — "1 spellings already saved" is the kind of thing users screenshot.
   static func rowSubtitle(spellingCount: Int) -> String {
@@ -57,6 +70,10 @@ enum QuickAddPanelCopy {
       "Your selection could not be read. You can still add the word by hand below."
     case .selectionTooLong:
       "That selection is too long to be a word. Select just the word and try again."
+    case .wordsUnavailable:
+      // The plan's exact wording (§3, "Refresh before ranking"). Capital W on Words because that is
+      // what the feature is called in Settings, and a user reading this has to find it there.
+      "Your Words could not be refreshed, so there is nothing to match against yet. Try again."
     }
   }
 }

--- a/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelView.swift
+++ b/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelView.swift
@@ -190,7 +190,7 @@ struct QuickAddPanelView: View {
   /// model is a second thing to keep in step with the ranking.
   var headerState: QuickAddPanelCopy.GroupHeaderState {
     if model.ranking.preselected?.alreadyHasHeardSpelling == true { return .alreadySaved }
-    if !model.query.isEmpty { return .searching }
+    if model.isSearching { return .searching }
     return model.ranking.preselectedID == nil ? .lowConfidence : .confident
   }
 

--- a/Sources/EnviousWisprAppKit/Views/Settings/KeybindsSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/KeybindsSettingsView.swift
@@ -179,6 +179,34 @@ struct KeybindsSettingsView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .modifier(SettingsCardSurface())
       }
+
+      // ── Quick Add (#2381) ────────────────────────────────────────────
+      VStack(alignment: .leading, spacing: 10) {
+        eyebrow("Add a Word")
+
+        VStack(alignment: .leading, spacing: 14) {
+          ProminentHotkeyRow(
+            title: "Add-a-word keybind",
+            // Says what the user DOES and what they get, in that order, and names
+            // the one place it will not work rather than letting them discover it.
+            // Terminals are out of scope because a highlight drawn by a terminal
+            // program is not a selection anything outside it can read — a fact
+            // about the terminal, not a limitation we chose, and one a user who
+            // dictates into a terminal will otherwise hit and assume is a bug.
+            description:
+              "Select a misheard word anywhere, then press this to add it to Your Words. "
+              + "Terminal windows do not share their selection, so it will not work there.",
+            keyCode: $settings.quickAddKeyCode,
+            modifiers: $settings.quickAddModifiers,
+            defaultKeyCode: 13,
+            defaultModifiers: [.control, .option],
+            accessibilityLabel: "Add-a-word keybind"
+          )
+        }
+        .padding(18)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .modifier(SettingsCardSurface())
+      }
     }
   }
 

--- a/Sources/EnviousWisprAppKit/Views/Settings/KeybindsSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/KeybindsSettingsView.swift
@@ -73,8 +73,8 @@ struct KeybindsSettingsView: View {
             description: "This keybind starts and stops recording.",
             keyCode: $settings.toggleKeyCode,
             modifiers: $settings.toggleModifiers,
-            defaultKeyCode: ModifierKeyCodes.rightOption,
-            defaultModifiers: [],
+            defaultKeyCode: ShortcutRole.record.defaultKeyCode,
+            defaultModifiers: ShortcutRole.record.defaultModifiers,
             accessibilityLabel: "Recording keybind",
             onBindingAccepted: { code, _ in
               // The claim is owned by SettingsManager, not by this view: onboarding
@@ -129,8 +129,8 @@ struct KeybindsSettingsView: View {
               + "from the next recording you start.",
             keyCode: $settings.cancelKeyCode,
             modifiers: $settings.cancelModifiers,
-            defaultKeyCode: 53,
-            defaultModifiers: [],
+            defaultKeyCode: ShortcutRole.cancel.defaultKeyCode,
+            defaultModifiers: ShortcutRole.cancel.defaultModifiers,
             accessibilityLabel: "Cancel keybind"
           )
 
@@ -198,8 +198,8 @@ struct KeybindsSettingsView: View {
               + "Terminal windows do not share their selection, so it will not work there.",
             keyCode: $settings.quickAddKeyCode,
             modifiers: $settings.quickAddModifiers,
-            defaultKeyCode: 13,
-            defaultModifiers: [.control, .option],
+            defaultKeyCode: ShortcutRole.quickAdd.defaultKeyCode,
+            defaultModifiers: ShortcutRole.quickAdd.defaultModifiers,
             accessibilityLabel: "Add-a-word keybind"
           )
         }

--- a/Sources/EnviousWisprAppKit/Views/Settings/KeybindsSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/KeybindsSettingsView.swift
@@ -73,8 +73,7 @@ struct KeybindsSettingsView: View {
             description: "This keybind starts and stops recording.",
             keyCode: $settings.toggleKeyCode,
             modifiers: $settings.toggleModifiers,
-            defaultKeyCode: ShortcutRole.record.defaultKeyCode,
-            defaultModifiers: ShortcutRole.record.defaultModifiers,
+            role: .record,
             accessibilityLabel: "Recording keybind",
             onBindingAccepted: { code, _ in
               // The claim is owned by SettingsManager, not by this view: onboarding
@@ -129,8 +128,7 @@ struct KeybindsSettingsView: View {
               + "from the next recording you start.",
             keyCode: $settings.cancelKeyCode,
             modifiers: $settings.cancelModifiers,
-            defaultKeyCode: ShortcutRole.cancel.defaultKeyCode,
-            defaultModifiers: ShortcutRole.cancel.defaultModifiers,
+            role: .cancel,
             accessibilityLabel: "Cancel keybind"
           )
 
@@ -198,8 +196,7 @@ struct KeybindsSettingsView: View {
               + "Terminal windows do not share their selection, so it will not work there.",
             keyCode: $settings.quickAddKeyCode,
             modifiers: $settings.quickAddModifiers,
-            defaultKeyCode: ShortcutRole.quickAdd.defaultKeyCode,
-            defaultModifiers: ShortcutRole.quickAdd.defaultModifiers,
+            role: .quickAdd,
             accessibilityLabel: "Add-a-word keybind"
           )
         }
@@ -325,9 +322,22 @@ private struct ProminentHotkeyRow: View {
   let description: String
   @Binding var keyCode: UInt16
   @Binding var modifiers: NSEvent.ModifierFlags
-  let defaultKeyCode: UInt16
-  let defaultModifiers: NSEvent.ModifierFlags
+  /// Which shortcut this row edits. **The row derives its Reset default from this rather than being
+  /// handed one**, so no call site has a default to get wrong.
+  ///
+  /// Three review rounds found the same defect one member at a time — a hard-coded number, then the
+  /// same number surviving in a full-line comment, then in a trailing one — because a guard over
+  /// source text is a DESCRIPTION of a set and the next counterexample always exists.
+  ///
+  /// Precisely what this buys, since "unwriteable" would be an overclaim: a literal is still
+  /// writeable HERE, in the two accessors below. What is gone is a literal at each of three CALL
+  /// SITES, where it applies to one row, reads as ordinary, and drifts alone. One here would apply
+  /// to every row at once, which is the difference between a quiet wrong default and an obvious one.
+  let role: ShortcutRole
   let accessibilityLabel: String
+
+  private var defaultKeyCode: UInt16 { role.defaultKeyCode }
+  private var defaultModifiers: NSEvent.ModifierFlags { role.defaultModifiers }
   /// #1987 — nil on rows that are not the recording keybind, so only the toggle
   /// row can ever present the Globe guidance.
   var onBindingAccepted: ((UInt16, NSEvent.ModifierFlags) -> Void)?

--- a/Sources/EnviousWisprPostProcessing/QuickAdd/QuickAddRanker.swift
+++ b/Sources/EnviousWisprPostProcessing/QuickAdd/QuickAddRanker.swift
@@ -1,0 +1,268 @@
+import EnviousWisprCore
+import Foundation
+
+/// Ranks a misheard spelling against the saved word library for Quick Add (#2381).
+///
+/// Pure policy: no UI, no Accessibility, no I/O, no clock. It is handed the two candidate
+/// populations already loaded by its caller and returns an ordered list plus the one safety
+/// decision the panel turns on — whether the top row may be accepted with a single Return.
+///
+/// **Two questions, two entry points, and they are not the same question.**
+/// `rank(heard:)` answers "which saved word does this mishearing belong to", and carries the
+/// measured policy below. `search(query:)` answers "find me this word", which is the panel's
+/// escape hatch for a wrong ranking and must be able to reach ANY term — so it ranks the two
+/// populations together with no bar-gated suppression. Collapsing them would make the escape
+/// hatch unable to reach the words the ranking suppressed, which is precisely when it is needed.
+///
+/// **The policy is measured, not chosen by feel.** 1,648 real mishearings drawn from the stored
+/// spellings themselves (111 user + 1,537 pack), scored with the shipped `WordCorrector.score`,
+/// two arms per scope: WARM hides one spelling and leaves the word's others in place, COLD strips
+/// every spelling so only the canonical remains. On the user's own words at `confidenceBar`:
+/// 91.9% one-keypress-correct and 0% confident-and-wrong warm, 74.8% / 0% cold. Enabling the
+/// shipped packs alongside took confident-and-wrong from 0 to 4 (`codecs`→`codec`,
+/// `sarag`→`Suarez`, `dot md`→`dotnet`); preferring user words restored 91.9% and dropped wrong
+/// to 1. Method and raw output on #2381.
+public struct QuickAddRanker: Sendable {
+
+  /// The score at or above which the top match may be preselected for a one-keypress accept.
+  ///
+  /// The lowest value at which confident-and-wrong is zero on the user's own words in BOTH the
+  /// warm and cold arms. Below it the identical panel renders with nothing highlighted, which
+  /// costs keystrokes and never writes a wrong alias. Raising it costs one-keypress accepts;
+  /// lowering it re-admits confident-and-wrong, so a change here needs the sweep re-run, not an
+  /// argument.
+  public static let confidenceBar: Double = 0.55
+
+  /// How many rows the panel shows by default. A presentation bound, passed by the caller and
+  /// never consulted by the ranking itself — the escape hatch is `search`, which re-ranks by the
+  /// query and lifts the wanted term to the top rather than needing a longer list.
+  public static let defaultLimit: Int = 5
+
+  /// One ranked row.
+  public struct Candidate: Sendable, Equatable, Identifiable {
+    /// The library word this row would receive the heard spelling.
+    public let word: CustomWord
+    /// Best `WordCorrector.score` of the ranked string against this word's canonical or any of
+    /// its spellings. Raw, not rounded or bucketed.
+    public let score: Double
+    /// True when this word ALREADY carries the heard spelling, so accepting it would add a
+    /// duplicate. The panel says "already saved" rather than writing again (#2381 §14.3).
+    /// Compared on the same normalization the scoring uses.
+    public let alreadyHasHeardSpelling: Bool
+
+    public var id: UUID { word.id }
+    /// A shipped pack term rather than something the user saved. Accepting one converts it to a
+    /// user-owned override first (`CustomWord.ownedByUser()`), because `CustomWordsManager.update`
+    /// looks the id up in the user library and returns silently when it is absent.
+    public var isPackTerm: Bool { word.source == .pack }
+
+    public init(word: CustomWord, score: Double, alreadyHasHeardSpelling: Bool) {
+      self.word = word
+      self.score = score
+      self.alreadyHasHeardSpelling = alreadyHasHeardSpelling
+    }
+  }
+
+  /// An ordered list plus the row that owns the Return key.
+  public struct Ranking: Sendable, Equatable {
+    /// Best first. Empty when there was nothing to rank or nothing matched.
+    public let candidates: [Candidate]
+    /// The row a bare Return accepts, or nil when Return must write nothing. Always the id of a
+    /// member of `candidates`, so a highlight can never accept a row that is not on screen.
+    public let preselectedID: UUID?
+
+    public var preselected: Candidate? {
+      guard let preselectedID else { return nil }
+      return candidates.first { $0.id == preselectedID }
+    }
+
+    /// The top row's score, or nil when there are no candidates. Telemetry reports this raw.
+    public var topScore: Double? { candidates.first?.score }
+
+    public init(candidates: [Candidate], preselectedID: UUID?) {
+      self.candidates = candidates
+      self.preselectedID = preselectedID
+    }
+
+    public static let empty = Ranking(candidates: [], preselectedID: nil)
+  }
+
+  private let corrector = WordCorrector()
+
+  public init() {}
+
+  // MARK: - The heard spelling
+
+  /// Rank a misheard spelling against the library.
+  ///
+  /// User words are ranked first and pack terms are consulted ONLY when no user word clears
+  /// `confidenceBar` — the measured rule. A pack term then wins only by outscoring the best user
+  /// word, so a weak pack match never displaces a weak-but-better user word.
+  ///
+  /// Preselection is the safety decision and the only thing that varies: the top row owns Return
+  /// only when its score clears the bar. Below it the same list renders with nothing highlighted.
+  public func rank(
+    heard: String,
+    userWords: [CustomWord],
+    packTerms: [CustomWord],
+    limit: Int = QuickAddRanker.defaultLimit
+  ) -> Ranking {
+    let needle = Self.normalize(heard)
+    guard !needle.isEmpty else { return .empty }
+
+    let user = score(needle: needle, against: userWords, heardNeedle: needle)
+    let bestUserScore = user.first?.score ?? 0
+
+    var ordered = user
+    if bestUserScore < Self.confidenceBar {
+      // Only now do packs enter, and only ahead of the user list if they actually beat it.
+      let stillPack = Self.packTermsNotOverridden(by: userWords, in: packTerms)
+      let pack = score(needle: needle, against: stillPack, heardNeedle: needle)
+      if let bestPack = pack.first, bestPack.score > bestUserScore {
+        ordered = (user + pack).sorted(by: Self.betterFirst)
+      }
+    }
+
+    let shown = Array(ordered.prefix(max(0, limit)))
+    guard let top = shown.first, top.score >= Self.confidenceBar else {
+      return Ranking(candidates: shown, preselectedID: nil)
+    }
+    return Ranking(candidates: shown, preselectedID: top.id)
+  }
+
+  // MARK: - The search field
+
+  /// Filter the whole library by what the user typed.
+  ///
+  /// **This FILTERS, it does not fuzzy-rank, and the difference is a safety property.** Fuzzy
+  /// scoring assigns every word in the library some score, so it can never return an empty list —
+  /// a query matching nothing would still render five unrelated rows with the first one owning
+  /// Return, and one keypress would write the heard spelling onto a word the user never looked
+  /// for. The design requires a real zero-results state, and only a filter can produce one.
+  /// It is also what a search field is for: typing `kub` must reach `Kubernetes`, which scores
+  /// poorly under an edit-distance measure precisely because it is a fragment.
+  ///
+  /// A word matches when its canonical or any of its spellings CONTAINS the query. Order is a
+  /// tier — exact, then canonical prefix, then spelling prefix, then substring — and inside a tier
+  /// the user's own words come before pack terms, then alphabetically. Deterministic, so a redraw
+  /// cannot move a row under the highlight.
+  ///
+  /// `heard` is used only for `alreadyHasHeardSpelling` and for each row's `score`, which reports
+  /// how well the row matches WHAT WILL BE WRITTEN rather than what was typed. The query never
+  /// becomes an alias: accepting a searched row saves the ORIGINAL heard spelling, which is the
+  /// difference between an escape hatch and a way to write whatever was typed.
+  ///
+  /// An empty query returns nothing rather than the whole library: clearing the field restores
+  /// the heard ranking, so the caller switches back to `rank` rather than rendering this.
+  public func search(
+    query: String,
+    heard: String,
+    userWords: [CustomWord],
+    packTerms: [CustomWord],
+    limit: Int = QuickAddRanker.defaultLimit
+  ) -> Ranking {
+    let needle = Self.normalize(query)
+    guard !needle.isEmpty else { return .empty }
+    let heardNeedle = Self.normalize(heard)
+
+    let population = userWords + Self.packTermsNotOverridden(by: userWords, in: packTerms)
+
+    let matched =
+      population
+      .compactMap { word -> (tier: Int, candidate: Candidate)? in
+        guard let tier = Self.matchTier(needle: needle, word: word) else { return nil }
+        return (tier, candidate(for: word, rankedAgainst: heardNeedle, heardNeedle: heardNeedle))
+      }
+      .sorted { a, b in
+        if a.tier != b.tier { return a.tier < b.tier }
+        if a.candidate.isPackTerm != b.candidate.isPackTerm { return !a.candidate.isPackTerm }
+        return a.candidate.word.canonical.lowercased() < b.candidate.word.canonical.lowercased()
+      }
+      .map(\.candidate)
+
+    let shown = Array(matched.prefix(max(0, limit)))
+    // Every row here is one the user's own query selected, so the first owns Return whatever it
+    // scored against the heard string. The confidence bar governs the ranking the user did NOT
+    // ask for; a list they typed is one they chose. No matches means no highlight and no write.
+    return Ranking(candidates: shown, preselectedID: shown.first?.id)
+  }
+
+  /// How well `word` matches `needle`, as a tier — lower is better, nil means it does not match.
+  ///
+  /// 0 exact · 1 canonical prefix · 2 spelling prefix · 3 substring anywhere.
+  static func matchTier(needle: String, word: CustomWord) -> Int? {
+    let canonical = normalize(word.canonical)
+    let spellings = word.aliases.map(normalize)
+
+    if canonical == needle || spellings.contains(needle) { return 0 }
+    if canonical.hasPrefix(needle) { return 1 }
+    if spellings.contains(where: { $0.hasPrefix(needle) }) { return 2 }
+    if canonical.contains(needle) || spellings.contains(where: { $0.contains(needle) }) { return 3 }
+    return nil
+  }
+
+  // MARK: - Internals
+
+  /// Lowercase and strip surrounding whitespace, which is what the sweep scored and what a real
+  /// selection needs — dragging across a word routinely picks up a trailing space. Trimming a
+  /// clean token is identity, so the measured figures carry over unchanged.
+  static func normalize(_ raw: String) -> String {
+    raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+  }
+
+  private func score(
+    needle: String,
+    against words: [CustomWord],
+    heardNeedle: String
+  ) -> [Candidate] {
+    words
+      .map { candidate(for: $0, rankedAgainst: needle, heardNeedle: heardNeedle) }
+      .sorted(by: Self.betterFirst)
+  }
+
+  /// One row: the best score of `needle` against any spelling of `word`, plus whether `word`
+  /// already carries the heard spelling.
+  private func candidate(
+    for word: CustomWord,
+    rankedAgainst needle: String,
+    heardNeedle: String
+  ) -> Candidate {
+    var best = corrector.score(needle, against: Self.normalize(word.canonical))
+    var carriesHeard = !heardNeedle.isEmpty && Self.normalize(word.canonical) == heardNeedle
+    for alias in word.aliases {
+      let lowered = Self.normalize(alias)
+      best = max(best, corrector.score(needle, against: lowered))
+      if !heardNeedle.isEmpty && lowered == heardNeedle { carriesHeard = true }
+    }
+    return Candidate(word: word, score: best, alreadyHasHeardSpelling: carriesHeard)
+  }
+
+  /// One ordering, used by every list this type produces.
+  ///
+  /// `Array.sorted` gives no stability guarantee, so ties need an explicit total order or a
+  /// redraw can shuffle rows under a highlight — the one state where a reorder changes what
+  /// Return accepts. User words break a tie ahead of pack terms; canonical breaks the rest.
+  private static func betterFirst(_ a: Candidate, _ b: Candidate) -> Bool {
+    if a.score != b.score { return a.score > b.score }
+    if a.isPackTerm != b.isPackTerm { return !a.isPackTerm }
+    return a.word.canonical < b.word.canonical
+  }
+
+  /// The pack terms the user has NOT already taken ownership of.
+  ///
+  /// The collision is real rather than defensive: `CustomWord.ownedByUser()` PRESERVES the id, so
+  /// the moment this feature converts a pack term the same id exists in both populations with
+  /// different spellings. Rendering both would give SwiftUI duplicate `Identifiable` ids and make a
+  /// preselected id ambiguous, and the user's copy is the one that can actually be written —
+  /// `CustomWordsManager.update` looks an id up in the user library and returns silently when it is
+  /// absent.
+  ///
+  /// One answer, used by both entry points: two copies of this predicate is how they drift apart.
+  static func packTermsNotOverridden(
+    by userWords: [CustomWord],
+    in packTerms: [CustomWord]
+  ) -> [CustomWord] {
+    let userIDs = Set(userWords.map(\.id))
+    return packTerms.filter { !userIDs.contains($0.id) }
+  }
+}

--- a/Sources/EnviousWisprPostProcessing/QuickAdd/QuickAddRanker.swift
+++ b/Sources/EnviousWisprPostProcessing/QuickAdd/QuickAddRanker.swift
@@ -79,9 +79,14 @@ public struct QuickAddRanker: Sendable {
     /// The top row's score, or nil when there are no candidates. Telemetry reports this raw.
     public var topScore: Double? { candidates.first?.score }
 
+    /// An id naming no visible row is dropped, so the documented invariant above is carried by
+    /// this branch rather than by the sentence. A highlight on a row nobody can see is the one
+    /// state in which Return writes something the user was never shown.
     public init(candidates: [Candidate], preselectedID: UUID?) {
       self.candidates = candidates
-      self.preselectedID = preselectedID
+      self.preselectedID = preselectedID.flatMap { id in
+        candidates.contains { $0.id == id } ? id : nil
+      }
     }
 
     public static let empty = Ranking(candidates: [], preselectedID: nil)
@@ -114,17 +119,20 @@ public struct QuickAddRanker: Sendable {
     let bestUserScore = user.first?.score ?? 0
 
     var ordered = user
-    if bestUserScore < Self.confidenceBar {
+    if !Self.clearsConfidenceBar(bestUserScore) {
       // Only now do packs enter, and only ahead of the user list if they actually beat it.
       let stillPack = Self.packTermsNotOverridden(by: userWords, in: packTerms)
       let pack = score(needle: needle, against: stillPack, heardNeedle: needle)
-      if let bestPack = pack.first, bestPack.score > bestUserScore {
+      // `user.isEmpty` is not a special case, it repairs an incoherence: with user words present
+      // even zero-scoring rows render, so a user with ONLY packs saw an empty panel while everyone
+      // else saw a list. A strictly-greater test alone cannot beat a best user score of zero.
+      if let bestPack = pack.first, user.isEmpty || bestPack.score > bestUserScore {
         ordered = (user + pack).sorted(by: Self.betterFirst)
       }
     }
 
     let shown = Array(ordered.prefix(max(0, limit)))
-    guard let top = shown.first, top.score >= Self.confidenceBar else {
+    guard let top = shown.first, Self.clearsConfidenceBar(top.score) else {
       return Ranking(candidates: shown, preselectedID: nil)
     }
     return Ranking(candidates: shown, preselectedID: top.id)
@@ -176,7 +184,11 @@ public struct QuickAddRanker: Sendable {
       .sorted { a, b in
         if a.tier != b.tier { return a.tier < b.tier }
         if a.candidate.isPackTerm != b.candidate.isPackTerm { return !a.candidate.isPackTerm }
-        return a.candidate.word.canonical.lowercased() < b.candidate.word.canonical.lowercased()
+        let left = Self.normalize(a.candidate.word.canonical)
+        let right = Self.normalize(b.candidate.word.canonical)
+        if left != right { return left < right }
+        // Same last resort as `betterFirst`, and for the same reason.
+        return a.candidate.id.uuidString < b.candidate.id.uuidString
       }
       .map(\.candidate)
 
@@ -237,6 +249,14 @@ public struct QuickAddRanker: Sendable {
     return Candidate(word: word, score: best, alreadyHasHeardSpelling: carriesHeard)
   }
 
+  /// Does this score earn a one-keypress accept?
+  ///
+  /// The boundary lives here rather than inline at its two call sites so it can be asserted AT its
+  /// own value. No real string reaches exactly `confidenceBar` — 400,000 random pairs and every
+  /// shipped pack spelling against every pack canonical produced none — so a fixture-based test can
+  /// only ever straddle the boundary, never sit on it. The comparison itself has no such limit.
+  static func clearsConfidenceBar(_ score: Double) -> Bool { score >= confidenceBar }
+
   /// One ordering, used by every list this type produces.
   ///
   /// `Array.sorted` gives no stability guarantee, so ties need an explicit total order or a
@@ -245,7 +265,12 @@ public struct QuickAddRanker: Sendable {
   private static func betterFirst(_ a: Candidate, _ b: Candidate) -> Bool {
     if a.score != b.score { return a.score > b.score }
     if a.isPackTerm != b.isPackTerm { return !a.isPackTerm }
-    return a.word.canonical < b.word.canonical
+    if a.word.canonical != b.word.canonical { return a.word.canonical < b.word.canonical }
+    // Two library entries can share a canonical — a pack term and the user's override of a
+    // different one, or a duplicate the store never rejected. Without this last step their order
+    // is whatever `Array.sorted` happens to do with the input order, and a row that moves between
+    // two identical calls changes what Return accepts with no user action.
+    return a.id.uuidString < b.id.uuidString
   }
 
   /// The pack terms the user has NOT already taken ownership of.

--- a/Sources/EnviousWisprServices/HotkeyService.swift
+++ b/Sources/EnviousWisprServices/HotkeyService.swift
@@ -187,17 +187,26 @@ public final class HotkeyService {
 
   public var recordingMode: RecordingMode = .toggle
 
-  /// Toggle-mode hotkey key code (default: Right Option = 61, modifier-only).
-  public var toggleKeyCode: UInt16 = ModifierKeyCodes.rightOption
+  // Every fallback below reads `ShortcutRole.defaultBinding`, the one owner of what a shortcut ships
+  // as. These are the value a service carries before `HotkeyController` pushes the user's settings,
+  // so a hard-coded one here does not show up as a wrong default anywhere a test looks — it shows up
+  // as a newly constructed service holding a stale binding until synchronisation runs.
+  //
+  // Converting Quick Add and leaving these two was the first attempt, which is the partial migration
+  // this repo's own rule refuses: old code removed and new code wired in the SAME change, never a
+  // shim and a follow-up.
 
-  /// Toggle-mode required modifiers (default: none — modifier-only hotkey).
-  public var toggleModifiers: NSEvent.ModifierFlags = []
+  /// Toggle-mode hotkey key code. Right Option, a bare modifier.
+  public var toggleKeyCode: UInt16 = ShortcutRole.record.defaultKeyCode
 
-  /// Key code for the cancel hotkey. Default: Escape (53).
-  public var cancelKeyCode: UInt16 = 53
+  /// Toggle-mode required modifiers — none, because a bare modifier stores empty modifiers.
+  public var toggleModifiers: NSEvent.ModifierFlags = ShortcutRole.record.defaultModifiers
 
-  /// Required modifiers for cancel hotkey. Default: none (bare Escape).
-  public var cancelModifiers: NSEvent.ModifierFlags = []
+  /// Key code for the cancel hotkey. Escape.
+  public var cancelKeyCode: UInt16 = ShortcutRole.cancel.defaultKeyCode
+
+  /// Required modifiers for cancel hotkey — none, bare Escape.
+  public var cancelModifiers: NSEvent.ModifierFlags = ShortcutRole.cancel.defaultModifiers
 
   /// Key code for the Quick Add hotkey (#2381). The shipped value, read from its one owner.
   public var quickAddKeyCode: UInt16 = ShortcutRole.quickAdd.defaultKeyCode

--- a/Sources/EnviousWisprServices/HotkeyService.swift
+++ b/Sources/EnviousWisprServices/HotkeyService.swift
@@ -199,12 +199,11 @@ public final class HotkeyService {
   /// Required modifiers for cancel hotkey. Default: none (bare Escape).
   public var cancelModifiers: NSEvent.ModifierFlags = []
 
-  /// Key code for the Quick Add hotkey (#2381). Default: W (13).
-  public var quickAddKeyCode: UInt16 = 13
+  /// Key code for the Quick Add hotkey (#2381). The shipped value, read from its one owner.
+  public var quickAddKeyCode: UInt16 = ShortcutRole.quickAdd.defaultKeyCode
 
-  /// Required modifiers for the Quick Add hotkey. Default: Control-Option, which is awkward enough
-  /// that nobody reaches it by accident and reachable one-handed.
-  public var quickAddModifiers: NSEvent.ModifierFlags = [.control, .option]
+  /// Required modifiers for the Quick Add hotkey, read from the same owner.
+  public var quickAddModifiers: NSEvent.ModifierFlags = ShortcutRole.quickAdd.defaultModifiers
 
   // MARK: - Lifecycle
 

--- a/Sources/EnviousWisprServices/HotkeyService.swift
+++ b/Sources/EnviousWisprServices/HotkeyService.swift
@@ -862,6 +862,20 @@ public final class HotkeyService {
   /// drives on `.recording` entry and exit. The Carbon path gets this for free —
   /// an unregistered hotkey delivers no event — but the modifier monitors stay
   /// installed the whole time, so the modifier path has to ask.
+  /// The bare-modifier keyCode whose press cancel consumed, until its aggregate flag drops.
+  ///
+  /// Exists because `isPress` is derived from a device-INDEPENDENT flag: with Left Option held,
+  /// releasing Right Option leaves `.option` set, so the release is indistinguishable from a press
+  /// at this layer. Cancel closes its own double-fire by disarming, which is correct and is exactly
+  /// what lets a second role claim the re-entry — see the note at the disarm.
+  ///
+  /// **Deliberately NOT cleared by `unregisterCancelHotkey()`, and that is load-bearing rather than
+  /// an omission.** That teardown runs on the way out of a cancel, which is inside the window this
+  /// marker exists to cover, so clearing it there would make the whole thing dead code that still
+  /// reads as a fix. The aggregate flag dropping is the only signal that the gesture is actually
+  /// over, so it is the only thing that clears this.
+  private var keyCodeConsumedByCancel: UInt16?
+
   private var armedRoles: Set<ShortcutRole> {
     // Quick Add is unconditional: it belongs to the app, not to a recording.
     isCancelArmed ? [.record, .cancel, .quickAdd] : [.record, .quickAdd]
@@ -1167,6 +1181,20 @@ public final class HotkeyService {
     // Determine press vs. release by checking whether the flag is present
     let isPress = currentFlags.contains(flag)
 
+    // **Swallow the tail of a gesture cancel already consumed.** With the opposite-side modifier
+    // held, `isPress` stays true through this key's physical release (the mask is aggregate and
+    // device-independent), so the release re-enters looking exactly like a press — and cancel has
+    // disarmed itself by then, so the matcher hands the same key to the next role that claims it.
+    //
+    // Cleared when the aggregate flag finally drops, which is the only signal available that the
+    // whole gesture is over. Swallowing a genuine second tap of this key while the other side is
+    // still held is the accepted cost and it is the safe direction: the recording is already gone,
+    // and the alternative is opening a panel the user did not ask for on the way out of losing it.
+    if keyCodeConsumedByCancel == keyCode {
+      if !isPress { keyCodeConsumedByCancel = nil }
+      return
+    }
+
     // #1991, blocker 1. This was `guard keyCode == toggleKeyCode`, which asked
     // "is this the RECORD key" and returned early for everything else — so a
     // bare modifier bound to CANCEL reached here and was dropped on the floor.
@@ -1223,6 +1251,17 @@ public final class HotkeyService {
       // dependent left/right masks and would change heart-path dispatch, so it
       // is not folded into a cancel-key fix.
       isCancelArmed = false
+      // **AND DISARMING IS WHAT MAKES THE STRAY RELEASE DANGEROUS RATHER THAN HARMLESS, once a
+      // SECOND role can claim this key.** The comment above is right that the release "finds nothing
+      // to cancel" — it then falls through to the `.quickAdd` arm, which #2381 added, matches the
+      // same bare modifier when the user has bound both to it, and fires on `isPress`. So one cancel
+      // gesture discarded the recording AND opened the panel.
+      //
+      // Not a pre-existing residual: this branch introduced the second claimant. Marking the key is
+      // what lets the TAIL of a consumed gesture be swallowed instead of reinterpreted as a
+      // lower-priority role, and it is per-key rather than a flag because the aggregate mask cannot
+      // tell us which physical key came up.
+      keyCodeConsumedByCancel = keyCode
       performCleanup()
       Task { await onCancelRecording?() }
       emitHotkeyPressed(.cancel, trigger: .cancel)

--- a/Sources/EnviousWisprServices/HotkeyService.swift
+++ b/Sources/EnviousWisprServices/HotkeyService.swift
@@ -64,6 +64,16 @@ public final class HotkeyService {
     /// #2381. Takes 4, not the free slot at 2: that gap is a RETIRED id whose meaning nobody wrote
     /// down, and a stale Carbon registration or an old log line could still carry it.
     case quickAdd = 4
+
+    /// Which role this Carbon registration belongs to. A switch, so a new id must declare one
+    /// rather than borrowing a neighbour's telemetry name.
+    var role: ShortcutRole {
+      switch self {
+      case .toggle: .record
+      case .cancel: .cancel
+      case .quickAdd: .quickAdd
+      }
+    }
   }
 
   // MARK: - Carbon State
@@ -776,8 +786,36 @@ public final class HotkeyService {
   /// `package` so the install condition is testable directly. Testing it through
   /// `installModifierMonitors()` would assert on `NSEvent` monitor objects, which
   /// says nothing about the decision being made here.
+  /// #2381 reproduced #1991's blocker 2 before this was written. The condition was
+  /// `recordBinding.isBareModifier || cancelBinding.isBareModifier` — a hand-written disjunction over
+  /// the roles that existed when it was authored — so a user pairing a bare-modifier QUICK ADD with a
+  /// chord record key and a chord cancel key got no monitor at all, and their shortcut was stored,
+  /// displayed, and completely inert. Exactly the defect the comment above describes, one role over,
+  /// added by the change that quotes it.
+  ///
+  /// It now asks the CLOSED SET rather than a list of the roles someone remembered, so a fourth role
+  /// is included by construction instead of by whoever adds it noticing this line.
   package var shouldInstallModifierMonitors: Bool {
-    recordBinding.isBareModifier || cancelBinding.isBareModifier
+    bareModifierRoleAtRisk != nil
+  }
+
+  /// Which role loses its dispatch if the modifier monitors are missing, or nil when none is a bare
+  /// modifier and the monitors are not needed at all.
+  ///
+  /// One value, so the most SEVERE loss wins — `ShortcutRole`'s declaration order is that severity
+  /// order and its doc comment says so. Read by both the install decision and the failure label, so
+  /// the two cannot come to disagree about which roles matter.
+  package var bareModifierRoleAtRisk: ShortcutRole? {
+    ShortcutRole.allCases.first { binding(for: $0).isBareModifier }
+  }
+
+  /// The binding a role is currently bound to. A switch, so a new role must be given one.
+  package func binding(for role: ShortcutRole) -> ShortcutBinding {
+    switch role {
+    case .record: recordBinding
+    case .cancel: cancelBinding
+    case .quickAdd: quickAddBinding
+    }
   }
 
   /// The current record binding, as one value.
@@ -859,10 +897,15 @@ public final class HotkeyService {
       // as a toggle failure — mislabelling the telemetry for exactly the users
       // this change is for, in the one signal that would tell us it broke.
       //
-      // Record wins when both are bare modifiers: it is armed for the whole
+      // Record wins when several are bare modifiers: it is armed for the whole
       // session while cancel is armed only during a recording, so it is the
       // more severe loss and the field holds one value.
-      let kind = recordBinding.isBareModifier ? "toggle" : "cancel"
+      //
+      // #2381: this was `recordBinding.isBareModifier ? "toggle" : "cancel"`, a THIRD two-role
+      // ternary alongside the two the switch repairs elsewhere in this file, and it reported a dead
+      // bare-modifier Quick Add as a dead CANCEL shortcut. It now reads the same closed enumeration
+      // the install decision does.
+      let kind = bareModifierRoleAtRisk?.telemetryKind ?? "unknown"
       telemetry.registrationFailed("nsevent_\(scope)", kind, nil, "modifier_only")
     }
     return monitor
@@ -965,17 +1008,13 @@ public final class HotkeyService {
     )
     guard status == noErr else {
       // #1175: the noErr-but-silent trap means success can't confirm delivery, so
-      // we only report FAILURE. This is the single Carbon chokepoint — both the
-      // toggle and cancel registrations route through here.
-      // A `switch`, not a ternary (#2381). The old `id == cancel ? "cancel" : "toggle"` reported a
-      // quick-add registration failure as a TOGGLE failure — the telemetry naming the wrong subject,
-      // on the one signal that says a user's shortcut is inert.
-      let kind =
-        switch HotkeyID(rawValue: id) {
-        case .cancel: "cancel"
-        case .quickAdd: "quick_add"
-        case .toggle, nil: "toggle"
-        }
+      // we only report FAILURE. This is the single Carbon chokepoint — every registration routes
+      // through here.
+      // #2381: this was `id == cancel ? "cancel" : "toggle"`, which reported a quick-add
+      // registration failure as a TOGGLE failure. It now resolves the id to a ROLE and asks the role
+      // for its wire name, so the Carbon path and the monitor path below cannot disagree about what
+      // a role is called — one owner, `ShortcutRole.telemetryKind`.
+      let kind = (HotkeyID(rawValue: id)?.role ?? .record).telemetryKind
       let keyShape = ModifierKeyCodes.isModifierOnly(keyCode) ? "modifier_only" : "chord"
       telemetry.registrationFailed("carbon", kind, status, keyShape)
       return nil

--- a/Sources/EnviousWisprServices/HotkeyService.swift
+++ b/Sources/EnviousWisprServices/HotkeyService.swift
@@ -61,6 +61,9 @@ public final class HotkeyService {
   private enum HotkeyID: UInt32 {
     case toggle = 1
     case cancel = 3
+    /// #2381. Takes 4, not the free slot at 2: that gap is a RETIRED id whose meaning nobody wrote
+    /// down, and a stale Carbon registration or an old log line could still carry it.
+    case quickAdd = 4
   }
 
   // MARK: - Carbon State
@@ -68,6 +71,7 @@ public final class HotkeyService {
   private var eventHandlerRef: EventHandlerRef?
   private var toggleHotkeyRef: EventHotKeyRef?
   private var cancelHotkeyRef: EventHotKeyRef?
+  private var quickAddHotkeyRef: EventHotKeyRef?
 
   /// Whether the cancel role is currently armed.
   ///
@@ -165,6 +169,10 @@ public final class HotkeyService {
   /// Used by the processing state gate to block new recordings during processing.
   public var onIsProcessing: (@MainActor () -> Bool)?
 
+  /// Quick Add fired (#2381). Deliberately NOT gated on `onIsProcessing`: it never touches the
+  /// recording path, so refusing it mid-transcription would block a limb for a heart-path reason.
+  public var onQuickAdd: (@MainActor () async -> Void)?
+
   // MARK: - Configuration
 
   public var recordingMode: RecordingMode = .toggle
@@ -180,6 +188,13 @@ public final class HotkeyService {
 
   /// Required modifiers for cancel hotkey. Default: none (bare Escape).
   public var cancelModifiers: NSEvent.ModifierFlags = []
+
+  /// Key code for the Quick Add hotkey (#2381). Default: W (13).
+  public var quickAddKeyCode: UInt16 = 13
+
+  /// Required modifiers for the Quick Add hotkey. Default: Control-Option, which is awkward enough
+  /// that nobody reaches it by accident and reachable one-handed.
+  public var quickAddModifiers: NSEvent.ModifierFlags = [.control, .option]
 
   // MARK: - Lifecycle
 
@@ -227,6 +242,7 @@ public final class HotkeyService {
   /// cancel hotkey and a PTT triple-press cancel (told apart by `trigger`).
   private enum PressAction: String {
     case start, toggle, cancel, lock, stop
+    case quickAdd = "quick_add"
     case ignoredProcessing = "ignored_processing"
     case ignoredCooldown = "ignored_cooldown"
   }
@@ -236,6 +252,7 @@ public final class HotkeyService {
     case ptt = "ptt_hotkey"
     case toggle = "toggle_hotkey"
     case cancel = "cancel_hotkey"
+    case quickAdd = "quick_add_hotkey"
   }
 
   /// Injected clock for the 500ms double-press window and the lock cooldown.
@@ -267,7 +284,15 @@ public final class HotkeyService {
     // key_shape reflects the TRIGGERING hotkey: the cancel hotkey (Escape, a chord
     // by default) vs the toggle/PTT hotkey (modifier-only by default). The PTT
     // hands-free actions all ride the toggle key. (Codex code-diff #1.)
-    let keyCode = trigger == .cancel ? cancelKeyCode : toggleKeyCode
+    // A `switch`, not a ternary (#2381). The old `trigger == .cancel ? cancel : toggle` silently
+    // absorbed any new member into the toggle branch, so a Quick Add press would have reported the
+    // RECORD key's shape and identity — a telemetry field asserting the wrong subject.
+    let keyCode: UInt16 =
+      switch trigger {
+      case .cancel: cancelKeyCode
+      case .quickAdd: quickAddKeyCode
+      case .toggle, .ptt: toggleKeyCode
+      }
     let keyShape = ModifierKeyCodes.isModifierOnly(keyCode) ? "modifier_only" : "chord"
     // #1987: same key as key_shape, one level finer. `key_shape` cannot separate
     // Globe from Right Option because both are modifier-only. Content-free class,
@@ -280,6 +305,7 @@ public final class HotkeyService {
     guard !isEnabled else { return }
     installCarbonEventHandler()
     registerToggleHotkey()
+    registerQuickAddHotkey()
     installModifierMonitors()
     // Cancel hotkey is NOT registered here — only during recording
     isEnabled = true
@@ -287,6 +313,7 @@ public final class HotkeyService {
 
   public func stop() {
     unregisterCancelHotkey()
+    unregisterQuickAddHotkey()
     unregisterToggleHotkey()
     removeCarbonEventHandler()
     removeModifierMonitors()
@@ -311,6 +338,7 @@ public final class HotkeyService {
     let wasArmed = isCancelArmed
     unregisterCancelHotkey()
     cancelArmedBeforeSuspend = wasArmed
+    unregisterQuickAddHotkey()
     unregisterToggleHotkey()
     removeModifierMonitors()
     isSuspended = true
@@ -322,6 +350,9 @@ public final class HotkeyService {
     isModifierHeld = false
     performCleanup()
     registerToggleHotkey()
+    // No armed-state snapshot, unlike cancel: Quick Add is armed whenever the service is, so
+    // restoring it is unconditional and there is nothing that could outlive its own recording.
+    registerQuickAddHotkey()
     installModifierMonitors()
     isSuspended = false
     if cancelArmedBeforeSuspend { registerCancelHotkey() }
@@ -759,6 +790,11 @@ public final class HotkeyService {
     .keyboard(keyCode: cancelKeyCode, modifiers: cancelModifiers)
   }
 
+  /// The current Quick Add binding, as one value.
+  package var quickAddBinding: ShortcutBinding {
+    .keyboard(keyCode: quickAddKeyCode, modifiers: quickAddModifiers)
+  }
+
   /// Which roles a press may currently trigger.
   ///
   /// Record is live whenever the service is; cancel only between
@@ -767,7 +803,8 @@ public final class HotkeyService {
   /// an unregistered hotkey delivers no event — but the modifier monitors stay
   /// installed the whole time, so the modifier path has to ask.
   private var armedRoles: Set<ShortcutRole> {
-    isCancelArmed ? [.record, .cancel] : [.record]
+    // Quick Add is unconditional: it belongs to the app, not to a recording.
+    isCancelArmed ? [.record, .cancel, .quickAdd] : [.record, .quickAdd]
   }
 
   private func installModifierMonitors() {
@@ -880,6 +917,41 @@ public final class HotkeyService {
     }
   }
 
+  /// Register the Quick Add hotkey (#2381).
+  ///
+  /// Asked through the BINDING, exactly as the toggle and cancel paths ask it — a bare modifier
+  /// cannot go to Carbon, and for that shape the already-installed `NSEvent` monitors observe it
+  /// instead. Two spellings of that question is how the record and cancel paths drifted apart.
+  private func registerQuickAddHotkey() {
+    guard quickAddBinding.isCarbonRegistrable else { return }
+    guard quickAddHotkeyRef == nil else { return }
+    quickAddHotkeyRef = registerHotkey(
+      id: HotkeyID.quickAdd.rawValue,
+      keyCode: quickAddKeyCode,
+      modifiers: carbonModifiers(from: quickAddModifiers)
+    )
+  }
+
+  private func unregisterQuickAddHotkey() {
+    if let ref = quickAddHotkeyRef {
+      UnregisterEventHotKey(ref)
+      quickAddHotkeyRef = nil
+    }
+  }
+
+  /// Re-apply the Quick Add binding after the user changes it.
+  ///
+  /// Both halves, because the binding can change SHAPE — chord to bare modifier or back — which
+  /// moves it between Carbon and the monitors. Re-registering without re-installing the monitors
+  /// would leave the new shape unobserved, which is #1991's exact failure: a shortcut that is
+  /// stored, displayed, and inert.
+  public func reapplyQuickAddBinding() {
+    unregisterQuickAddHotkey()
+    guard isEnabled, !isSuspended else { return }
+    registerQuickAddHotkey()
+    installModifierMonitors()
+  }
+
   private func registerHotkey(id: UInt32, keyCode: UInt16, modifiers: UInt32) -> EventHotKeyRef? {
     let hotkeyID = EventHotKeyID(signature: hotkeySignature, id: id)
     var ref: EventHotKeyRef?
@@ -895,7 +967,15 @@ public final class HotkeyService {
       // #1175: the noErr-but-silent trap means success can't confirm delivery, so
       // we only report FAILURE. This is the single Carbon chokepoint — both the
       // toggle and cancel registrations route through here.
-      let kind = id == HotkeyID.cancel.rawValue ? "cancel" : "toggle"
+      // A `switch`, not a ternary (#2381). The old `id == cancel ? "cancel" : "toggle"` reported a
+      // quick-add registration failure as a TOGGLE failure — the telemetry naming the wrong subject,
+      // on the one signal that says a user's shortcut is inert.
+      let kind =
+        switch HotkeyID(rawValue: id) {
+        case .cancel: "cancel"
+        case .quickAdd: "quick_add"
+        case .toggle, nil: "toggle"
+        }
       let keyShape = ModifierKeyCodes.isModifierOnly(keyCode) ? "modifier_only" : "chord"
       telemetry.registrationFailed("carbon", kind, status, keyShape)
       return nil
@@ -929,6 +1009,13 @@ public final class HotkeyService {
       performCleanup()
       Task { await onCancelRecording?() }
       emitHotkeyPressed(.cancel, trigger: .cancel)
+
+    case HotkeyID.quickAdd.rawValue:
+      guard !isRelease else { return }
+      // No `performCleanup()`: Quick Add does not touch the recording path, so tearing down
+      // press-tracking state here would disturb an in-flight dictation for a limb's sake.
+      Task { await onQuickAdd?() }
+      emitHotkeyPressed(.quickAdd, trigger: .quickAdd)
 
     default:
       break
@@ -988,10 +1075,27 @@ public final class HotkeyService {
         forBareModifierKeyCode: keyCode,
         record: recordBinding,
         cancel: cancelBinding,
+        quickAdd: quickAddBinding,
         armed: armedRoles)
     else { return }
 
-    if role == .cancel {
+    // #2381. This was `if role == .cancel { … return }` followed by the record path, so a role the
+    // matcher resolved and this site did not name FELL THROUGH AND STARTED A RECORDING — and it
+    // compiled perfectly, because an `if` over an enum asserts nothing about the members it omits.
+    // A bare-modifier Quick Add would have begun dictating instead of opening the panel. The switch
+    // below is what makes the compiler name every member, which is the entire reason `ShortcutRole`
+    // was made a closed set.
+    switch role {
+    case .quickAdd:
+      // Press only: a modifier RELEASE is not a gesture. Quick Add carries none of cancel's
+      // aggregate-flag hazard, because it disarms nothing and destroys nothing — a stray second
+      // fire opens the panel twice, and the panel reuses its own window.
+      guard isPress else { return }
+      Task { await onQuickAdd?() }
+      emitHotkeyPressed(.quickAdd, trigger: .quickAdd)
+      return
+
+    case .cancel:
       // A modifier RELEASE is not a press, on the common path.
       guard isPress else { return }
 
@@ -1020,6 +1124,9 @@ public final class HotkeyService {
       Task { await onCancelRecording?() }
       emitHotkeyPressed(.cancel, trigger: .cancel)
       return
+
+    case .record:
+      break
     }
 
     if recordingMode == .toggle {

--- a/Sources/EnviousWisprServices/HotkeyService.swift
+++ b/Sources/EnviousWisprServices/HotkeyService.swift
@@ -323,10 +323,13 @@ public final class HotkeyService {
     guard !isEnabled else { return }
     installCarbonEventHandler()
     registerToggleHotkey()
-    registerQuickAddHotkey()
+    // `isEnabled` is set BEFORE the reconciler, which reads it: the rule it enforces is "not while
+    // stopped or suspended", and a reconciler run against a service that has not yet admitted it is
+    // running would refuse the registration it was called to make.
+    isEnabled = true
+    reconcileQuickAddRegistration()
     installModifierMonitors()
     // Cancel hotkey is NOT registered here — only during recording
-    isEnabled = true
   }
 
   public func stop() {
@@ -370,9 +373,11 @@ public final class HotkeyService {
     registerToggleHotkey()
     // No armed-state snapshot, unlike cancel: Quick Add is armed whenever the service is, so
     // restoring it is unconditional and there is nothing that could outlive its own recording.
-    registerQuickAddHotkey()
-    installModifierMonitors()
+    // WHETHER it may hold its chord is still the reconciler's call, because a recording can be in
+    // flight and cancel may own that chord — `resume()` re-arms cancel two lines below.
     isSuspended = false
+    reconcileQuickAddRegistration()
+    installModifierMonitors()
     if cancelArmedBeforeSuspend { registerCancelHotkey() }
     cancelArmedBeforeSuspend = false
   }
@@ -388,6 +393,11 @@ public final class HotkeyService {
   /// stored, displayed, and inert.
   public func registerCancelHotkey() {
     isCancelArmed = true
+    // Quick Add yields FIRST, before cancel asks Carbon. `RegisterEventHotKey` refuses a duplicate
+    // chord, and Quick Add is registered at `start()` and holds its registration for the whole
+    // session — so with both bound to one chord, cancel arrives second, is refused, and the user's
+    // cancel key opens the Quick Add panel while the recording keeps running.
+    reconcileQuickAddRegistration()
     guard cancelBinding.isCarbonRegistrable else { return }
     guard cancelHotkeyRef == nil else { return }
     cancelHotkeyRef = registerHotkey(
@@ -412,6 +422,10 @@ public final class HotkeyService {
       UnregisterEventHotKey(ref)
       cancelHotkeyRef = nil
     }
+    // Cancel has released the chord, so Quick Add may have it back. Unconditional rather than
+    // guarded on a collision: the reconciler decides, and asking the question here as well would be
+    // the same rule written twice.
+    reconcileQuickAddRegistration()
   }
 
   /// Arm or disarm the cancel hotkey from a single decision (#2087).
@@ -973,6 +987,45 @@ public final class HotkeyService {
   /// Asked through the BINDING, exactly as the toggle and cancel paths ask it — a bare modifier
   /// cannot go to Carbon, and for that shape the already-installed `NSEvent` monitors observe it
   /// instead. Two spellings of that question is how the record and cancel paths drifted apart.
+  /// The ONE place that decides whether Quick Add may hold its Carbon chord.
+  ///
+  /// **A shared chord is a policy question, and the event-tap path already answered it while the
+  /// Carbon path had no answer at all.** `ShortcutMatcher.role(forBareModifierKeyCode:...)` checks
+  /// Quick Add LAST precisely because it is the least severe of the three roles
+  /// (`ShortcutRole`'s declaration order is severity order, and load-bearing). This is the same
+  /// ruling for the other dispatch mechanism: cancel outranks Quick Add on a chord they share, for
+  /// as long as cancel is armed.
+  ///
+  /// Every caller that used to call `registerQuickAddHotkey()` calls this instead, so the rule lives
+  /// in one function rather than being asked again at each site — which is how the three shortcut
+  /// defaults came to disagree in the first place (#1991 blocker 2, reproduced during this build).
+  private func reconcileQuickAddRegistration() {
+    if Self.quickAddMayHoldItsChord(
+      isEnabled: isEnabled, isSuspended: isSuspended,
+      quickAdd: quickAddBinding, cancel: cancelBinding, isCancelArmed: isCancelArmed)
+    {
+      registerQuickAddHotkey()
+    } else {
+      unregisterQuickAddHotkey()
+    }
+  }
+
+  /// The decision itself, pure.
+  ///
+  /// Split out for the same reason `SelectionReader.refusalBeforeReading` is: the surrounding
+  /// function talks to Carbon, and a rule reachable only through `RegisterEventHotKey` is a rule no
+  /// test can state. Every branch here is one a user can produce by rebinding a shortcut.
+  package static func quickAddMayHoldItsChord(
+    isEnabled: Bool, isSuspended: Bool,
+    quickAdd: ShortcutBinding, cancel: ShortcutBinding, isCancelArmed: Bool
+  ) -> Bool {
+    guard isEnabled, !isSuspended else { return false }
+    // Cancel outranks Quick Add on a shared chord, for as long as cancel is armed — the same
+    // severity order `ShortcutRole` declares and the bare-modifier matcher already applies.
+    return !(quickAdd == cancel && isCancelArmed)
+  }
+
+  /// Pure mechanism, no policy: `reconcileQuickAddRegistration` above decides whether to call it.
   private func registerQuickAddHotkey() {
     guard quickAddBinding.isCarbonRegistrable else { return }
     guard quickAddHotkeyRef == nil else { return }
@@ -998,8 +1051,11 @@ public final class HotkeyService {
   /// stored, displayed, and inert.
   public func reapplyQuickAddBinding() {
     unregisterQuickAddHotkey()
+    // The reconciler owns both questions the two guards below used to ask separately — may we
+    // register at all, and may we hold THIS chord. Rebinding Quick Add onto the cancel chord during
+    // a recording is exactly the case a bare `registerQuickAddHotkey()` here would get wrong.
+    reconcileQuickAddRegistration()
     guard isEnabled, !isSuspended else { return }
-    registerQuickAddHotkey()
     installModifierMonitors()
   }
 

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -809,9 +809,14 @@ public enum PasteService {
   /// a usable pid, the messaging timeout bound, CF type validation before the
   /// cast, and confirming the returned element actually belongs to the
   /// process that was asked, not one AX resolved to on its own.
-  private static func focusedElementQuery(
+  ///
+  /// Module-internal rather than private since #2381: `SelectionReader` asks the same question of
+  /// the frontmost app and a second implementation of it would be the parallel machine this repo's
+  /// adopt-before-inventing rule exists to prevent. Every defensive check above is exactly what a
+  /// second copy would have had to reproduce and would eventually have drifted on.
+  static func focusedElementQuery(
     pid: pid_t,
-    messagingTimeout: Double
+    messagingTimeout: Double = axMessagingTimeoutSeconds
   ) -> AXUIElement? {
     guard AXIsProcessTrusted(), pid > 0 else { return nil }
 

--- a/Sources/EnviousWisprServices/SelectionReader.swift
+++ b/Sources/EnviousWisprServices/SelectionReader.swift
@@ -60,6 +60,20 @@ public enum SelectionReader {
     /// asserted instead of assumed: `noReadOutcomeIsWordsUnavailable` requires every reader path to
     /// stay out of this case.
     case wordsUnavailable = "words_unavailable"
+    /// The read SUCCEEDED and the user had selected nothing. The ordinary case, not a fault.
+    ///
+    /// **The second member `SelectionReader` never produces, for the same reason as the one above**
+    /// — this set is the panel's reason line and the telemetry `refuse_reason`, and there is one of
+    /// each — but it is worth its own entry because of what it replaced. `.noSelection` used to be
+    /// mapped onto `selectionUnavailable`, whose sentence names TERMINALS and accuses the frontmost
+    /// app of withholding a selection. Pressing the shortcut in TextEdit having highlighted nothing
+    /// is the most likely way to reach a refusal at all, and it got a confident diagnosis of an app
+    /// that had done nothing wrong, instead of "select a word first".
+    ///
+    /// Two states, one slot, and the collapse pointed at the accusatory member: exactly the
+    /// three-valued shape `validation-discipline` describes, where the unhandled input lands in a
+    /// neighbouring branch and inherits a claim that was never about it.
+    case nothingSelected = "nothing_selected"
   }
 
   /// The longest selection worth reading, in Unicode scalars.
@@ -69,7 +83,9 @@ public enum SelectionReader {
   /// saved and a panel offering it would be confidently wrong. It is also a real bound on work —
   /// the scorer's edit distance builds an (m+1)x(n+1) matrix PER CANDIDATE, so a document-sized
   /// selection against a few hundred words is not a slow ranking, it is a frozen app.
-  public static var maximumSelectionScalars: Int { CustomWordsImportLimits.maximumStoredValueScalars }
+  public static var maximumSelectionScalars: Int {
+    CustomWordsImportLimits.maximumStoredValueScalars
+  }
 
   // MARK: - The live read
 
@@ -89,7 +105,8 @@ public enum SelectionReader {
     // is not a state this entry point can be called from.
     let frontmost = NSWorkspace.shared.frontmostApplication?.processIdentifier
 
-    if let refusal = refusalBeforeReading(isTrusted: AXIsProcessTrusted(), frontmostPID: frontmost) {
+    if let refusal = refusalBeforeReading(isTrusted: AXIsProcessTrusted(), frontmostPID: frontmost)
+    {
       return .refused(refusal)
     }
     // Safe: `refusalBeforeReading` returns non-nil for a nil or non-positive pid.

--- a/Sources/EnviousWisprServices/SelectionReader.swift
+++ b/Sources/EnviousWisprServices/SelectionReader.swift
@@ -51,6 +51,15 @@ public enum SelectionReader {
     case unreadable = "unreadable"
     /// A selection too long to be stored as a word, so reading it further cannot help.
     case selectionTooLong = "selection_too_long"
+    /// The saved words could not be re-read, so there is nothing trustworthy to rank against.
+    ///
+    /// **The one member `SelectionReader` itself never produces**, and that is deliberate rather
+    /// than sloppy. This set is the panel's one reason line AND the telemetry `refuse_reason`, and
+    /// there is one of each — so the set is "why the panel has nothing to rank", which has two
+    /// producers. Splitting it would give the same slot two enums to reconcile. The boundary is
+    /// asserted instead of assumed: `noReadOutcomeIsWordsUnavailable` requires every reader path to
+    /// stay out of this case.
+    case wordsUnavailable = "words_unavailable"
   }
 
   /// The longest selection worth reading, in Unicode scalars.
@@ -139,10 +148,23 @@ public enum SelectionReader {
       return .refused(.unreadable)
     }
 
-    // TRIM FIRST, then measure. The ceiling exists to bound what gets STORED, and what gets stored
-    // is the trimmed string — so measuring the untrimmed one refuses a short word that happened to
-    // be dragged with a lot of surrounding space, and reports whitespace-only text as "too long"
-    // when the honest answer is "nothing selected".
+    return classify(text)
+  }
+
+  /// What a candidate selection IS, independent of where it came from.
+  ///
+  /// **Extracted so the two doors cannot disagree, which they did.** Door A arrives here through
+  /// `resolve`; door B is HANDED text by the Services system and reached the coordinator as
+  /// `.text(raw)` with none of this applied — so a whitespace-only Service selection opened a panel
+  /// on an empty string with no stated reason, and an oversized one bypassed the ceiling entirely
+  /// and went to the scorer. Anything one door validates and the other does not is a defect by
+  /// construction; the fix is one function, not a second copy of three checks.
+  ///
+  /// TRIM FIRST, then measure. The ceiling exists to bound what gets STORED, and what gets stored is
+  /// the trimmed string — so measuring the untrimmed one refuses a short word that happened to be
+  /// dragged with a lot of surrounding space, and reports whitespace-only text as "too long" when
+  /// the honest answer is "nothing selected".
+  public static func classify(_ text: String) -> Result {
     let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else { return .noSelection }
 

--- a/Sources/EnviousWisprServices/SelectionReader.swift
+++ b/Sources/EnviousWisprServices/SelectionReader.swift
@@ -92,7 +92,10 @@ public enum SelectionReader {
     let error = AXUIElementCopyAttributeValue(
       focused, kAXSelectedTextAttribute as CFString, &valueRef)
 
-    return resolve(error: error, value: valueRef as? String)
+    // The raw CF value is handed on UNERASED. `valueRef as? String` here would turn "the attribute
+    // answered with something that is not a string" into `nil`, which reads as "nothing selected" —
+    // and it would do it in the one function no test can reach.
+    return resolve(error: error, value: valueRef)
   }
 
   // MARK: - The decisions, which are pure
@@ -113,7 +116,7 @@ public enum SelectionReader {
   /// Separated from the round trip so every branch is reachable from a test without fabricating an
   /// `AXUIElement`. Only `noFocusedElement` stays untested by construction: it is one guard over a
   /// live AX call whose result cannot be produced without a real element, and Live UAT covers it.
-  static func resolve(error: AXError, value: String?) -> Result {
+  static func resolve(error: AXError, value: CFTypeRef?) -> Result {
     switch error {
     case .success:
       break
@@ -125,15 +128,27 @@ public enum SelectionReader {
       return .refused(.unreadable)
     }
 
-    // A successful read with no string is the same fact as `noValue` from the user's side: nothing
+    // A successful read with no value is the same fact as `noValue` from the user's side: nothing
     // was selected. It reaches here rather than the refusal branch because the attribute answered.
     guard let value else { return .noSelection }
 
-    guard value.unicodeScalars.count <= maximumSelectionScalars else {
-      return .refused(.selectionTooLong)
+    // Type-checked before the cast, the same way `PasteService.focusedElementQuery` validates the
+    // element it is handed. An attribute answering with a number or a boolean is a broken element,
+    // not an empty selection, and `as? String` alone would collapse the two into `noSelection`.
+    guard CFGetTypeID(value) == CFStringGetTypeID(), let text = value as? String else {
+      return .refused(.unreadable)
     }
 
-    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-    return trimmed.isEmpty ? .noSelection : .text(trimmed)
+    // TRIM FIRST, then measure. The ceiling exists to bound what gets STORED, and what gets stored
+    // is the trimmed string — so measuring the untrimmed one refuses a short word that happened to
+    // be dragged with a lot of surrounding space, and reports whitespace-only text as "too long"
+    // when the honest answer is "nothing selected".
+    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return .noSelection }
+
+    guard trimmed.unicodeScalars.count <= maximumSelectionScalars else {
+      return .refused(.selectionTooLong)
+    }
+    return .text(trimmed)
   }
 }

--- a/Sources/EnviousWisprServices/SelectionReader.swift
+++ b/Sources/EnviousWisprServices/SelectionReader.swift
@@ -1,0 +1,139 @@
+import AppKit
+import ApplicationServices
+import EnviousWisprCore
+import Foundation
+
+/// Reads the text the user has selected in whatever app is in front (#2381).
+///
+/// **One Accessibility round trip, on an explicit user gesture, and nothing else.** It does not
+/// observe, poll, cache, or write. The string it returns is held in memory by its caller, shown to
+/// the user, and either saved to the local word library or discarded — it is never logged and never
+/// leaves the machine.
+///
+/// The decision is split in two on purpose. `resolve` is pure and carries every branch, so the
+/// mapping from what Accessibility said to what the user is told is unit-tested. `read()` performs
+/// the live round trip and is proven by Live UAT, because a fabricated `AXUIElement` would test our
+/// idea of Accessibility rather than Accessibility — the same split `PasteService` keeps.
+public enum SelectionReader {
+
+  /// What the user selected, or why we could not tell.
+  public enum Result: Equatable, Sendable {
+    /// A usable selection, already trimmed.
+    case text(String)
+    /// The read succeeded and there was nothing selected.
+    case noSelection
+    /// We could not read a selection, and the panel says which of these it was.
+    case refused(Refusal)
+  }
+
+  /// Every reason a read can fail, as a closed set.
+  ///
+  /// Closed because it is BOTH the user-facing copy key and the telemetry `refuse_reason`, and a
+  /// reason that exists in one and not the other is how a dashboard comes to disagree with what the
+  /// user was told. Adding a member forces every consumer to say what it does with it.
+  public enum Refusal: String, Equatable, Sendable, CaseIterable {
+    /// The user has not granted Accessibility. The only refusal they can act on.
+    case accessibilityNotTrusted = "accessibility_not_trusted"
+    /// No application was frontmost, or it had no process to ask.
+    case noFrontmostApplication = "no_frontmost_application"
+    /// The frontmost application reported no focused element.
+    case noFocusedElement = "no_focused_element"
+    /// The focused element does not expose selected text at all (`kAXErrorAttributeUnsupported`).
+    case selectionUnsupported = "selection_unsupported"
+    /// The attribute is advertised but answered with no value (`kAXErrorNoValue`).
+    ///
+    /// Kept apart from `selectionUnsupported` because it is the TERMINAL case and it lies: measured
+    /// in Ghostty with text visibly highlighted, the attribute is listed in the element's attribute
+    /// names and still answers `-25212` with a zero-length range. Collapsing the two would hide
+    /// that a whole class of app reports a selection it will not hand over.
+    case selectionUnavailable = "selection_unavailable"
+    /// Any other Accessibility error.
+    case unreadable = "unreadable"
+    /// A selection too long to be stored as a word, so reading it further cannot help.
+    case selectionTooLong = "selection_too_long"
+  }
+
+  /// The longest selection worth reading, in Unicode scalars.
+  ///
+  /// Not a number invented here: it is the store's own ceiling
+  /// (`CustomWordsImportLimits.maximumStoredValueScalars`), so anything past it could never be
+  /// saved and a panel offering it would be confidently wrong. It is also a real bound on work —
+  /// the scorer's edit distance builds an (m+1)x(n+1) matrix PER CANDIDATE, so a document-sized
+  /// selection against a few hundred words is not a slow ranking, it is a frozen app.
+  public static var maximumSelectionScalars: Int { CustomWordsImportLimits.maximumStoredValueScalars }
+
+  // MARK: - The live read
+
+  /// Read the selection from the frontmost application.
+  ///
+  /// **Call this BEFORE activating our own app**, or the frontmost application is us and the answer
+  /// is about our own window.
+  ///
+  /// Per-application, never system-wide: `AXUIElementCreateSystemWide()` can answer for a different
+  /// process than the one the user is looking at, and the whole point here is to read the app they
+  /// just made a selection in.
+  @MainActor
+  public static func read() -> Result {
+    // Frontmost is read here rather than inside the check because it is the LIVE half. Current
+    // because this runs on the main run loop from a hotkey or a Service, with events flowing;
+    // `NSWorkspace.frontmostApplication` is stale only where nothing is pumping the run loop, which
+    // is not a state this entry point can be called from.
+    let frontmost = NSWorkspace.shared.frontmostApplication?.processIdentifier
+
+    if let refusal = refusalBeforeReading(isTrusted: AXIsProcessTrusted(), frontmostPID: frontmost) {
+      return .refused(refusal)
+    }
+    // Safe: `refusalBeforeReading` returns non-nil for a nil or non-positive pid.
+    guard let pid = frontmost, let focused = PasteService.focusedElementQuery(pid: pid) else {
+      return .refused(.noFocusedElement)
+    }
+
+    var valueRef: CFTypeRef?
+    let error = AXUIElementCopyAttributeValue(
+      focused, kAXSelectedTextAttribute as CFString, &valueRef)
+
+    return resolve(error: error, value: valueRef as? String)
+  }
+
+  // MARK: - The decisions, which are pure
+
+  /// Why a read cannot even be attempted, or nil to go ahead.
+  ///
+  /// Split from `read()` so both refusals are reachable from a test. Trust and frontmost are asked
+  /// together because they are the two questions with no Accessibility round trip behind them; the
+  /// element read has its own function below rather than four optionals in one.
+  static func refusalBeforeReading(isTrusted: Bool, frontmostPID: pid_t?) -> Refusal? {
+    guard isTrusted else { return .accessibilityNotTrusted }
+    guard let frontmostPID, frontmostPID > 0 else { return .noFrontmostApplication }
+    return nil
+  }
+
+  /// Map one Accessibility answer onto what the user is told.
+  ///
+  /// Separated from the round trip so every branch is reachable from a test without fabricating an
+  /// `AXUIElement`. Only `noFocusedElement` stays untested by construction: it is one guard over a
+  /// live AX call whose result cannot be produced without a real element, and Live UAT covers it.
+  static func resolve(error: AXError, value: String?) -> Result {
+    switch error {
+    case .success:
+      break
+    case .attributeUnsupported:
+      return .refused(.selectionUnsupported)
+    case .noValue:
+      return .refused(.selectionUnavailable)
+    default:
+      return .refused(.unreadable)
+    }
+
+    // A successful read with no string is the same fact as `noValue` from the user's side: nothing
+    // was selected. It reaches here rather than the refusal branch because the attribute answered.
+    guard let value else { return .noSelection }
+
+    guard value.unicodeScalars.count <= maximumSelectionScalars else {
+      return .refused(.selectionTooLong)
+    }
+
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? .noSelection : .text(trimmed)
+  }
+}

--- a/Sources/EnviousWisprServices/SettingsDefaultValues.swift
+++ b/Sources/EnviousWisprServices/SettingsDefaultValues.swift
@@ -43,6 +43,12 @@ enum SettingsDefaultValues {
 
   static let cancelKeyCode: Int = 53  // Escape
   static let cancelModifiersRaw: UInt = 0
+  /// Quick Add (#2381): Control-Option-W. Awkward enough that nobody reaches it by accident —
+  /// the persona review's hard requirement is that a user who has never heard of this feature
+  /// never triggers it — and still reachable with one hand.
+  static let quickAddKeyCode: Int = 13  // W
+  static let quickAddModifiersRaw: UInt =
+    NSEvent.ModifierFlags([.control, .option]).rawValue
   static let toggleKeyCode: Int = Int(ModifierKeyCodes.rightOption)
   static let toggleModifiersRaw: UInt = 0
   static let pushToTalkKeyCode: Int = 49  // Space

--- a/Sources/EnviousWisprServices/SettingsDefaultValues.swift
+++ b/Sources/EnviousWisprServices/SettingsDefaultValues.swift
@@ -41,16 +41,16 @@ enum SettingsDefaultValues {
   static let vadSensitivity: Float = 0.5
   static let vadEnergyGate = true
 
-  static let cancelKeyCode: Int = 53  // Escape
-  static let cancelModifiersRaw: UInt = 0
-  /// Quick Add (#2381): Control-Option-W. Awkward enough that nobody reaches it by accident —
-  /// the persona review's hard requirement is that a user who has never heard of this feature
-  /// never triggers it — and still reachable with one hand.
-  static let quickAddKeyCode: Int = 13  // W
-  static let quickAddModifiersRaw: UInt =
-    NSEvent.ModifierFlags([.control, .option]).rawValue
-  static let toggleKeyCode: Int = Int(ModifierKeyCodes.rightOption)
-  static let toggleModifiersRaw: UInt = 0
+  // The three shortcut defaults are OWNED by `ShortcutRole.defaultBinding` and read here, rather
+  // than written here and repeated in the service and in each Settings row. See that extension for
+  // why: three unlinked copies of one value, whose drift symptom is a Reset button that takes the
+  // user somewhere no fresh install goes.
+  static let cancelKeyCode: Int = Int(ShortcutRole.cancel.defaultKeyCode)
+  static let cancelModifiersRaw: UInt = ShortcutRole.cancel.defaultModifiers.rawValue
+  static let quickAddKeyCode: Int = Int(ShortcutRole.quickAdd.defaultKeyCode)
+  static let quickAddModifiersRaw: UInt = ShortcutRole.quickAdd.defaultModifiers.rawValue
+  static let toggleKeyCode: Int = Int(ShortcutRole.record.defaultKeyCode)
+  static let toggleModifiersRaw: UInt = ShortcutRole.record.defaultModifiers.rawValue
   static let pushToTalkKeyCode: Int = 49  // Space
   static let pushToTalkModifiersRaw: UInt = NSEvent.ModifierFlags.option.rawValue
 

--- a/Sources/EnviousWisprServices/SettingsManager.swift
+++ b/Sources/EnviousWisprServices/SettingsManager.swift
@@ -20,6 +20,8 @@ public final class SettingsManager {
     case hasCompletedOnboarding  // Legacy — kept for backward-compat writes only
     case cancelKeyCode
     case cancelModifiers
+    case quickAddKeyCode
+    case quickAddModifiers
     case toggleKeyCode
     case toggleModifiers
     case pushToTalkKeyCode
@@ -78,6 +80,7 @@ public final class SettingsManager {
     "autoCopyToClipboard", "hotkeyEnabled", "vadAutoStop", "vadSilenceTimeout",
     "vadSensitivity", "vadEnergyGate", "onboardingState", "hasCompletedOnboarding",
     "cancelKeyCode", "cancelModifiersRaw", "toggleKeyCode", "toggleModifiersRaw",
+    "quickAddKeyCode", "quickAddModifiersRaw",
     "pushToTalkKeyCode", "pushToTalkModifiersRaw", "modelUnloadPolicy",
     "restoreClipboardAfterPaste", "smartInsertion", "escapeRecoveryEnabled",
     "wordCorrectionEnabled",
@@ -318,6 +321,23 @@ public final class SettingsManager {
     didSet {
       defaults.set(cancelModifiers.rawValue, forKey: "cancelModifiersRaw")
       onChange?(.cancelModifiers)
+    }
+  }
+
+  /// Quick Add's key code (#2381). Same shape as its two siblings above: the `didSet` is the ONLY
+  /// writer, so a change cannot reach defaults without also notifying, which is what stops an edit
+  /// that persists and never registers.
+  public var quickAddKeyCode: UInt16 {
+    didSet {
+      defaults.set(Int(quickAddKeyCode), forKey: "quickAddKeyCode")
+      onChange?(.quickAddKeyCode)
+    }
+  }
+
+  public var quickAddModifiers: NSEvent.ModifierFlags {
+    didSet {
+      defaults.set(quickAddModifiers.rawValue, forKey: "quickAddModifiersRaw")
+      onChange?(.quickAddModifiers)
     }
   }
 
@@ -737,6 +757,13 @@ public final class SettingsManager {
     let savedCancelModRaw = defaults.object(forKey: "cancelModifiersRaw") as? UInt
     cancelModifiers = NSEvent.ModifierFlags(
       rawValue: savedCancelModRaw ?? SettingsDefaultValues.cancelModifiersRaw)
+
+    let savedQuickAddKeyCode = defaults.object(forKey: "quickAddKeyCode") as? Int
+    quickAddKeyCode = UInt16(savedQuickAddKeyCode ?? SettingsDefaultValues.quickAddKeyCode)
+
+    let savedQuickAddModRaw = defaults.object(forKey: "quickAddModifiersRaw") as? UInt
+    quickAddModifiers = NSEvent.ModifierFlags(
+      rawValue: savedQuickAddModRaw ?? SettingsDefaultValues.quickAddModifiersRaw)
 
     let savedToggleKeyCode = defaults.object(forKey: "toggleKeyCode") as? Int
     toggleKeyCode = UInt16(savedToggleKeyCode ?? SettingsDefaultValues.toggleKeyCode)

--- a/Sources/EnviousWisprServices/ShortcutBinding.swift
+++ b/Sources/EnviousWisprServices/ShortcutBinding.swift
@@ -5,14 +5,32 @@ import AppKit
 /// A closed set, deliberately: the #1991 defect was possible because "record"
 /// and "cancel" were never named as members of one thing, so a dispatch path
 /// could handle one and silently omit the other and nothing said so.
+/// **Declaration order is SEVERITY order, and it is load-bearing.** `allCases` is iterated to answer
+/// "which role dies if the modifier monitors are missing", and the field holds one value, so the most
+/// severe loss must come first: record kills dictation entirely, cancel kills the ability to abort one,
+/// Quick Add is a limb. `ShortcutRoleOrderTests` pins it — reordering these cases silently mislabels
+/// that telemetry rather than failing to compile.
 package enum ShortcutRole: String, Sendable, CaseIterable {
   case record
   case cancel
   /// Quick Add (#2381): capture the selected word into the library.
   ///
   /// Unlike the other two this one is armed WHENEVER THE SERVICE IS, because it
-  /// does not belong to a recording. That is why it sorts last below.
+  /// does not belong to a recording. That is why it sorts last in the matcher.
   case quickAdd
+
+  /// The wire name this role uses in hotkey telemetry.
+  ///
+  /// `record` is `"toggle"` because that is the string production has been sending since #1175 and a
+  /// rename would split every existing breakdown. A switch, so a fourth role cannot inherit a
+  /// neighbour's name by omission.
+  package var telemetryKind: String {
+    switch self {
+    case .record: "toggle"
+    case .cancel: "cancel"
+    case .quickAdd: "quick_add"
+    }
+  }
 }
 
 /// One shortcut, whatever kind it is.

--- a/Sources/EnviousWisprServices/ShortcutBinding.swift
+++ b/Sources/EnviousWisprServices/ShortcutBinding.swift
@@ -8,8 +8,8 @@ import AppKit
 /// **Declaration order is SEVERITY order, and it is load-bearing.** `allCases` is iterated to answer
 /// "which role dies if the modifier monitors are missing", and the field holds one value, so the most
 /// severe loss must come first: record kills dictation entirely, cancel kills the ability to abort one,
-/// Quick Add is a limb. `ShortcutRoleOrderTests` pins it — reordering these cases silently mislabels
-/// that telemetry rather than failing to compile.
+/// Quick Add is a limb. `roleOrderIsSeverityOrder` in `HotkeyQuickAddShortcutTests` pins it —
+/// reordering these cases silently mislabels that telemetry rather than failing to compile.
 package enum ShortcutRole: String, Sendable, CaseIterable {
   case record
   case cancel

--- a/Sources/EnviousWisprServices/ShortcutBinding.swift
+++ b/Sources/EnviousWisprServices/ShortcutBinding.swift
@@ -33,6 +33,48 @@ package enum ShortcutRole: String, Sendable, CaseIterable {
   }
 }
 
+/// What each shortcut is bound to on a fresh install.
+///
+/// **One owner, because this value was previously written in three places that nothing linked.**
+/// `SettingsDefaultValues` decides what a fresh install stores, `HotkeyService` carries a
+/// compiled-in fallback, and each Settings row hard-codes what its Reset button offers. Any one of
+/// them could move without the others, and the visible symptom is the worst kind: Reset takes the
+/// user to a shortcut no fresh install has, so their "back to how it shipped" stops matching a
+/// colleague's, every screenshot, and every support answer. Nothing fails, nothing is red.
+///
+/// A guard over those three literals was written first and then deleted in favour of this. A guard
+/// fires after the mistake is made; one constant makes it unwriteable.
+extension ShortcutRole {
+  /// The shipped binding for this role. A switch, so a new role must declare one.
+  package var defaultBinding: ShortcutBinding {
+    switch self {
+    // Right Option, a bare modifier: the record key is held or tapped constantly, so it earns the
+    // one shape that needs no chord.
+    case .record: .keyboard(keyCode: ModifierKeyCodes.rightOption, modifiers: [])
+    // Escape, bare.
+    case .cancel: .keyboard(keyCode: 53, modifiers: [])
+    // Control-Option-W (#2381). A CHORD deliberately: it takes the Carbon path, and the persona
+    // review's hard requirement is that a user who has never heard of this feature never triggers
+    // it by accident. Still reachable with one hand.
+    case .quickAdd: .keyboard(keyCode: 13, modifiers: [.control, .option])
+    }
+  }
+
+  /// The shipped key code, for callers that store the two halves separately.
+  package var defaultKeyCode: UInt16 {
+    switch defaultBinding {
+    case .keyboard(let keyCode, _): keyCode
+    }
+  }
+
+  /// The shipped modifiers, for callers that store the two halves separately.
+  package var defaultModifiers: NSEvent.ModifierFlags {
+    switch defaultBinding {
+    case .keyboard(_, let modifiers): modifiers
+    }
+  }
+}
+
 /// One shortcut, whatever kind it is.
 ///
 /// Today this is keyboard-only. It exists as an enum rather than a struct

--- a/Sources/EnviousWisprServices/ShortcutBinding.swift
+++ b/Sources/EnviousWisprServices/ShortcutBinding.swift
@@ -8,6 +8,11 @@ import AppKit
 package enum ShortcutRole: String, Sendable, CaseIterable {
   case record
   case cancel
+  /// Quick Add (#2381): capture the selected word into the library.
+  ///
+  /// Unlike the other two this one is armed WHENEVER THE SERVICE IS, because it
+  /// does not belong to a recording. That is why it sorts last below.
+  case quickAdd
 }
 
 /// One shortcut, whatever kind it is.
@@ -66,10 +71,17 @@ package enum ShortcutMatcher {
 
   /// Which armed role a bare-modifier key press belongs to, if any.
   ///
-  /// `armed` is passed in rather than inferred because the two roles are not
-  /// symmetric: record is live whenever the service is running, while cancel is
-  /// armed only for the duration of a recording. A matcher that assumed both
-  /// were always live would cancel recordings that had not started.
+  /// `armed` is passed in rather than inferred because the roles are not
+  /// symmetric: record and Quick Add are live whenever the service is running,
+  /// while cancel is armed only for the duration of a recording. A matcher that
+  /// assumed all were always live would cancel recordings that had not started.
+  ///
+  /// **Quick Add is checked LAST, and the order is a safety decision rather than
+  /// an arbitrary one.** It is the only role armed at all times, so putting it
+  /// ahead of cancel would shadow cancel for the entire duration of every
+  /// recording — silently taking away the key that stops one. Behind cancel, a
+  /// shared binding gives Quick Add every moment cancel is not armed, and costs
+  /// the user nothing they had before.
   ///
   /// **Record wins a tie, and nothing currently prevents the tie.** No conflict
   /// check has ever existed at either capture surface, so a user can already
@@ -87,6 +99,7 @@ package enum ShortcutMatcher {
     forBareModifierKeyCode keyCode: UInt16,
     record: ShortcutBinding,
     cancel: ShortcutBinding,
+    quickAdd: ShortcutBinding,
     armed: Set<ShortcutRole>
   ) -> ShortcutRole? {
     if armed.contains(.record), record == .keyboard(keyCode: keyCode, modifiers: []) {
@@ -118,6 +131,21 @@ package enum ShortcutMatcher {
         return nil
       }
       return .cancel
+    }
+    if armed.contains(.quickAdd), quickAdd == .keyboard(keyCode: keyCode, modifiers: []) {
+      // The SAME refusal as cancel's, for the same reason one step over. With the
+      // record chord needing this modifier, a bare press of it is genuinely
+      // ambiguous, and accepting it opens a panel that TAKES KEY FOCUS — so the
+      // rest of the chord lands in the panel and the recording the user was
+      // starting never happens. Cancel refuses because accepting destroys text
+      // already spoken; this refuses because accepting prevents text being spoken
+      // at all. Neither is recoverable by waiting.
+      if let flag = ModifierKeyCodes.flag(for: keyCode),
+        record.requiredModifiers.contains(flag)
+      {
+        return nil
+      }
+      return .quickAdd
     }
     return nil
   }

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -742,6 +742,69 @@ public final class TelemetryService {
     PostHogSDK.shared.capture("hotkey.pressed", properties: props)
   }
 
+  /// Quick Add opened (#2381). Shape only.
+  ///
+  /// **The selected word is NEVER a property here, and this is the event where it would be easiest
+  /// to add.** `CLAUDE.md` puts the privacy boundary at the network and the test is whether USER
+  /// CONTENT crosses it: `heard_length` is a scalar count, `top_score` is a number about a match, and
+  /// the bundle id names an APP rather than anything the user wrote. The word itself never leaves the
+  /// machine, and it is not in the local log either.
+  ///
+  /// `top_score` ships RAW rather than bucketed. It is a similarity between two strings, not a
+  /// property of either; bucketing it would destroy the only signal that says whether the confidence
+  /// bar is set right, which is the number this feature will actually be tuned on.
+  public func quickAddOpened(
+    door: String, hadSelection: Bool, refuseReason: String?, candidateCount: Int,
+    preselected: Bool, topScore: Double?, sourceBundleID: String?, heardLength: Int
+  ) {
+    var props: [String: Any] = [
+      "door": door, "had_selection": hadSelection, "candidate_count": candidateCount,
+      "preselected": preselected, "heard_length": heardLength,
+      "refuse_reason": refuseReason ?? "none",
+      "source_bundle_id": sourceBundleID ?? "unknown",
+    ]
+    if let topScore { props["top_score"] = (topScore * 100).rounded() / 100 }
+    #if DEBUG
+      // DERIVED from `props`, never re-listed — the #1987 lesson. A projection built independently
+      // of the real payload lets a test assert a property the shipped event does not carry, and it
+      // also hides a leak: an added non-String value would reach PostHog while a string-only hook
+      // dropped it, leaving a privacy test green.
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "quick_add.opened",
+          stringProps: props.compactMapValues { $0 as? String },
+          intProps: props.compactMapValues { $0 as? Int },
+          doubleProps: props.compactMapValues { $0 as? Double },
+          boolProps: props.compactMapValues { $0 as? Bool }))
+    #endif
+    PostHogSDK.shared.capture("quick_add.opened", properties: props)
+  }
+
+  /// Quick Add ended (#2381). Shape only; the same privacy boundary as `quick_add.opened`.
+  ///
+  /// `candidate_rank` is the POSITION the user accepted, which is what says whether the ranking is
+  /// earning its place: rank 0 is the guess landing, anything else is the user correcting it.
+  public func quickAddResolved(
+    outcome: String, usedSearch: Bool, candidateRank: Int?, targetKind: String?,
+    elapsedMilliseconds: Int
+  ) {
+    var props: [String: Any] = [
+      "outcome": outcome, "used_search": usedSearch, "elapsed_ms": elapsedMilliseconds,
+      "target_kind": targetKind ?? "none",
+    ]
+    if let candidateRank { props["candidate_rank"] = candidateRank }
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "quick_add.resolved",
+          stringProps: props.compactMapValues { $0 as? String },
+          intProps: props.compactMapValues { $0 as? Int },
+          doubleProps: props.compactMapValues { $0 as? Double },
+          boolProps: props.compactMapValues { $0 as? Bool }))
+    #endif
+    PostHogSDK.shared.capture("quick_add.resolved", properties: props)
+  }
+
   /// #1631: a recorded hands-free intent reached a publication decision. Sibling
   /// of `hotkey.pressed`, NOT a replacement — `hotkey.pressed` keeps meaning "a
   /// press was received" and every one of its values is unchanged. This event

--- a/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
@@ -40,6 +40,20 @@ struct QuickAddCoordinatorTests {
     CustomWord(canonical: canonical, aliases: aliases, source: source)
   }
 
+  /// `begin` plus the presentation callback, which is what the wiring does and what a test asserting
+  /// an `opened` event must reproduce.
+  ///
+  /// The two are separate in production on purpose: `opened` names an event the user can SEE, so it
+  /// fires when a panel is on screen. Emitting it from `begin` made a panel that could not be
+  /// measured leave an open with nothing to resolve it.
+  private func beginAndShow(
+    _ coordinator: QuickAddCoordinator, door: QuickAddDoor = .hotkey, selectionOverride: String? = nil
+  ) -> QuickAddPanelModel? {
+    let model = coordinator.begin(door: door, selectionOverride: selectionOverride)
+    if model != nil { coordinator.didOpen() }
+    return model
+  }
+
   private func makeCoordinator(
     selection: SelectionReader.Result = .text("codecs"),
     refreshSucceeds: Bool = true,
@@ -84,7 +98,7 @@ struct QuickAddCoordinatorTests {
     // snapshot offers words that no longer exist and hides ones that do.
     let (coordinator, recorder) = makeCoordinator(userWords: [word("Codex")])
 
-    _ = coordinator.begin(door: .hotkey)
+    _ = beginAndShow(coordinator)
 
     #expect(recorder.refreshCalls == 1)
   }
@@ -98,7 +112,7 @@ struct QuickAddCoordinatorTests {
     let (coordinator, recorder) = makeCoordinator(
       refreshSucceeds: false, userWords: [word("Codex")])
 
-    let model = try #require(coordinator.begin(door: .hotkey))
+    let model = try #require(beginAndShow(coordinator))
 
     #expect(model.refusal == .wordsUnavailable)
     // The stale snapshot half of the name is the part that was always right.
@@ -114,7 +128,7 @@ struct QuickAddCoordinatorTests {
     // count is shape; the string is not.
     let (coordinator, recorder) = makeCoordinator(userWords: [word("Codex")])
 
-    _ = coordinator.begin(door: .hotkey)
+    _ = beginAndShow(coordinator)
     let opened = try #require(recorder.opened)
 
     guard case .opened(let door, let refusal, let bundle, let count, _, _, _) = opened else {
@@ -131,7 +145,7 @@ struct QuickAddCoordinatorTests {
   func aRefusalStillOpens() throws {
     let (coordinator, recorder) = makeCoordinator(selection: .refused(.accessibilityNotTrusted))
 
-    let model = try #require(coordinator.begin(door: .hotkey))
+    let model = try #require(beginAndShow(coordinator))
 
     #expect(model.refusal == .accessibilityNotTrusted)
     #expect(recorder.opened != nil, "the panel opens on a stated reason, never a silent no-op")
@@ -141,7 +155,7 @@ struct QuickAddCoordinatorTests {
   func noSelectionIsAReason() throws {
     let (coordinator, _) = makeCoordinator(selection: .noSelection)
 
-    let model = try #require(coordinator.begin(door: .hotkey))
+    let model = try #require(beginAndShow(coordinator))
 
     #expect(model.refusal != nil, "the search field is the way forward, and the panel says so")
     #expect(model.heard.isEmpty)
@@ -153,7 +167,7 @@ struct QuickAddCoordinatorTests {
   func acceptingWritesTheHeardSpelling() throws {
     let codex = word("Codex", aliases: ["codeks"])
     let (coordinator, recorder) = makeCoordinator(userWords: [codex])
-    let model = try #require(coordinator.begin(door: .hotkey))
+    let model = try #require(beginAndShow(coordinator))
     let target = try #require(model.ranking.candidates.first)
 
     coordinator.accept(target, from: model)
@@ -171,7 +185,7 @@ struct QuickAddCoordinatorTests {
     // the call returns having written nothing and reporting success — a save that silently does not.
     let pack = word("codec", source: .pack)
     let (coordinator, recorder) = makeCoordinator(userWords: [], packTerms: [pack])
-    let model = try #require(coordinator.begin(door: .hotkey))
+    let model = try #require(beginAndShow(coordinator))
     let target = try #require(model.ranking.candidates.first)
     #expect(target.isPackTerm)
 
@@ -187,7 +201,7 @@ struct QuickAddCoordinatorTests {
   func anAlreadySavedWordIsNotWrittenAgain() throws {
     let codex = word("Codex", aliases: ["codecs"])
     let (coordinator, recorder) = makeCoordinator(userWords: [codex])
-    let model = try #require(coordinator.begin(door: .hotkey))
+    let model = try #require(beginAndShow(coordinator))
     let target = try #require(model.ranking.candidates.first)
 
     coordinator.accept(target, from: model)
@@ -202,7 +216,7 @@ struct QuickAddCoordinatorTests {
     // override passes the reader and is refused here. The user must be told.
     let (coordinator, recorder) = makeCoordinator(
       userWords: [word("Codex")], saveFailure: "That word cannot be saved.")
-    let model = try #require(coordinator.begin(door: .hotkey))
+    let model = try #require(beginAndShow(coordinator))
     let target = try #require(model.ranking.candidates.first)
 
     let message = coordinator.accept(target, from: model)
@@ -221,7 +235,7 @@ struct QuickAddCoordinatorTests {
     // The paired accepted case for the refusal above. Without it the caller could dismiss on any
     // non-nil-ness rule and still pass, and a check that never classifies anything looks clean.
     let (coordinator, recorder) = makeCoordinator(userWords: [word("Codex")])
-    let model = try #require(coordinator.begin(door: .hotkey))
+    let model = try #require(beginAndShow(coordinator))
     let target = try #require(model.ranking.candidates.first)
 
     #expect(coordinator.accept(target, from: model) == nil)
@@ -234,7 +248,7 @@ struct QuickAddCoordinatorTests {
     // refusal above only by the return value, which is why both are asserted.
     let (coordinator, recorder) = makeCoordinator(
       selection: .text("codecs"), userWords: [word("Codex", aliases: ["codecs"])])
-    let model = try #require(coordinator.begin(door: .hotkey))
+    let model = try #require(beginAndShow(coordinator))
     let target = try #require(model.ranking.candidates.first)
 
     #expect(coordinator.accept(target, from: model) == nil)
@@ -247,7 +261,7 @@ struct QuickAddCoordinatorTests {
     // user rescuing it. A single `accepted` would hide how often the ranking is wrong.
     let (coordinator, recorder) = makeCoordinator(
       userWords: [word("Codex"), word("Claude Code")])
-    let model = try #require(coordinator.begin(door: .hotkey))
+    let model = try #require(beginAndShow(coordinator))
     model.updateQuery("claude")
     let target = try #require(model.ranking.candidates.first)
 
@@ -260,7 +274,7 @@ struct QuickAddCoordinatorTests {
   func searchingNeverChangesWhatIsWritten() throws {
     let (coordinator, recorder) = makeCoordinator(
       userWords: [word("Codex"), word("Claude Code")])
-    let model = try #require(coordinator.begin(door: .hotkey))
+    let model = try #require(beginAndShow(coordinator))
     model.updateQuery("claude")
     let target = try #require(model.ranking.candidates.first)
 
@@ -277,7 +291,7 @@ struct QuickAddCoordinatorTests {
   @Test("Create-new opens the edit sheet on the heard spelling")
   func createNewOpensTheSheet() throws {
     let (coordinator, recorder) = makeCoordinator()
-    let model = try #require(coordinator.begin(door: .hotkey))
+    let model = try #require(beginAndShow(coordinator))
 
     coordinator.createNew(from: model)
 
@@ -292,7 +306,7 @@ struct QuickAddCoordinatorTests {
   @Test("Cancelling writes nothing and says so")
   func cancellingWritesNothing() throws {
     let (coordinator, recorder) = makeCoordinator(userWords: [word("Codex")])
-    let model = try #require(coordinator.begin(door: .hotkey))
+    let model = try #require(beginAndShow(coordinator))
 
     coordinator.cancel(from: model)
 
@@ -304,7 +318,7 @@ struct QuickAddCoordinatorTests {
   func bothDoorsAreReported() throws {
     let (coordinator, recorder) = makeCoordinator()
 
-    _ = coordinator.begin(door: .service, selectionOverride: "codecs")
+    _ = beginAndShow(coordinator, door: .service, selectionOverride: "codecs")
     guard case .opened(let door, _, _, _, _, _, _) = try #require(recorder.opened) else { return }
 
     #expect(door == .service)
@@ -317,7 +331,7 @@ struct QuickAddCoordinatorTests {
     // whose answer is about whatever is frontmost now, which by then may be us.
     let (coordinator, _) = makeCoordinator(selection: .refused(.accessibilityNotTrusted))
 
-    let model = try #require(coordinator.begin(door: .service, selectionOverride: "sarag"))
+    let model = try #require(beginAndShow(coordinator, door: .service, selectionOverride: "sarag"))
 
     #expect(model.heard == "sarag")
     #expect(model.refusal == nil, "the AX refusal is irrelevant when the text was handed to us")
@@ -339,7 +353,7 @@ struct QuickAddCoordinatorTests {
     // opened a panel reading `Heard: ` with the search field up, from which Return could write an
     // alias the store then stripped while reporting success.
     let (coordinator, recorder) = makeCoordinator(userWords: [word("Codex")])
-    let model = try #require(coordinator.begin(door: .service, selectionOverride: "   "))
+    let model = try #require(beginAndShow(coordinator, door: .service, selectionOverride: "   "))
 
     #expect(model.heard.isEmpty)
     #expect(model.refusal == .selectionUnavailable)
@@ -353,7 +367,7 @@ struct QuickAddCoordinatorTests {
     // and sent to the scorer through the other — where edit distance builds a matrix per candidate.
     let huge = String(repeating: "a", count: SelectionReader.maximumSelectionScalars + 1)
     let (coordinator, _) = makeCoordinator(userWords: [word("Codex")])
-    let model = try #require(coordinator.begin(door: .service, selectionOverride: huge))
+    let model = try #require(beginAndShow(coordinator, door: .service, selectionOverride: huge))
 
     #expect(model.refusal == .selectionTooLong)
     #expect(model.ranking.candidates.isEmpty)
@@ -364,7 +378,7 @@ struct QuickAddCoordinatorTests {
     // The paired accepted case. Without it every assertion above passes against a door that refuses
     // everything, which is a check that never classifies anything.
     let (coordinator, _) = makeCoordinator(userWords: [word("Codex")])
-    let model = try #require(coordinator.begin(door: .service, selectionOverride: "  codecs  "))
+    let model = try #require(beginAndShow(coordinator, door: .service, selectionOverride: "  codecs  "))
 
     #expect(model.heard == "codecs")
     #expect(model.refusal == nil)
@@ -376,7 +390,7 @@ struct QuickAddCoordinatorTests {
     // Emitting createdNew on the click counted opening a sheet as a save: cancelling the sheet left
     // the panel up, and cancelling the panel then emitted a SECOND resolved event for one open.
     let (coordinator, recorder) = makeCoordinator(userWords: [word("Codex")])
-    let model = try #require(coordinator.begin(door: .hotkey))
+    let model = try #require(beginAndShow(coordinator))
 
     coordinator.createNew(from: model)
 
@@ -387,7 +401,7 @@ struct QuickAddCoordinatorTests {
   @Test("Cancelling after opening the sheet resolves exactly once, as cancelled")
   func cancellingAfterTheSheetResolvesOnce() throws {
     let (coordinator, recorder) = makeCoordinator(userWords: [word("Codex")])
-    let model = try #require(coordinator.begin(door: .hotkey))
+    let model = try #require(beginAndShow(coordinator))
 
     coordinator.createNew(from: model)
     coordinator.cancel(from: model)
@@ -400,10 +414,52 @@ struct QuickAddCoordinatorTests {
     // The paired positive: the outcome still exists and is still reachable. Moving the emission
     // without this would be indistinguishable from deleting it.
     let (coordinator, recorder) = makeCoordinator(userWords: [word("Codex")])
-    let model = try #require(coordinator.begin(door: .hotkey))
+    let model = try #require(beginAndShow(coordinator))
 
     coordinator.createNew(from: model)
-    coordinator.didCreateNew(from: model)
+    coordinator.didCreateNew(usedSearch: false)
+
+    #expect(recorder.outcomes == [.createdNew])
+  }
+
+  @Test("A panel that could not be shown leaves no open event behind")
+  func aPanelThatCannotBeShownEmitsNoOpen() throws {
+    // Found by ENUMERATING the ways a Quick Add can end, not by a review round. The host refuses to
+    // present a panel it could not measure — an unmeasurable panel is an invisible window reporting
+    // success — and `opened` used to fire before that, so the one path that cannot report a reason
+    // of its own left an open with nothing to resolve it.
+    let (coordinator, recorder) = makeCoordinator(userWords: [word("Codex")])
+
+    _ = try #require(coordinator.begin(door: .hotkey))
+    coordinator.failedToOpen()
+
+    #expect(recorder.opened == nil)
+    // And NOT a resolved either: nothing opened, so there is nothing to resolve, and inventing an
+    // outcome would put a phantom row in the denominator of every rate built on this funnel.
+    #expect(recorder.outcomes.isEmpty)
+    #expect(recorder.events.contains { if case .failed = $0 { true } else { false } })
+  }
+
+  @Test("A panel that IS shown emits exactly one open")
+  func aPanelThatIsShownEmitsOneOpen() throws {
+    // The paired positive. Deferring the emission is indistinguishable from deleting it without
+    // something that still requires it to arrive, exactly once.
+    let (coordinator, recorder) = makeCoordinator(userWords: [word("Codex")])
+
+    _ = try #require(beginAndShow(coordinator))
+
+    #expect(recorder.events.filter { if case .opened = $0 { true } else { false } }.count == 1)
+  }
+
+  @Test("A confirmed new word resolves even when the panel has already gone")
+  func createdNewResolvesWithoutAModel() throws {
+    // The sheet outlives the panel in at least one ordering, and the call site used to read
+    // `if let model = activeModel`, so a CONFIRMED save emitted nothing at all.
+    let (coordinator, recorder) = makeCoordinator(userWords: [word("Codex")])
+    let model = try #require(beginAndShow(coordinator))
+    coordinator.createNew(from: model)
+
+    coordinator.didCreateNew(usedSearch: false)
 
     #expect(recorder.outcomes == [.createdNew])
   }
@@ -415,7 +471,7 @@ struct QuickAddCoordinatorTests {
     // search field exists precisely to let the user type something else.
     let (coordinator, recorder) = makeCoordinator(
       selection: .text("codecs"), userWords: [word("Codex"), word("Kubernetes")])
-    let model = try #require(coordinator.begin(door: .hotkey))
+    let model = try #require(beginAndShow(coordinator))
     model.updateQuery("kub")
     let target = try #require(model.ranking.candidates.first)
 

--- a/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
@@ -36,6 +36,14 @@ struct QuickAddCoordinatorTests {
         return nil
       }
     }
+    /// The `targetKind` of every resolution, which is a claim about WHAT WAS WRITTEN rather than
+    /// about what the ranking showed — so it has to be asserted separately from the outcome.
+    var targetKinds: [QuickAddTargetKind] {
+      events.compactMap {
+        if case .resolved(_, _, _, let kind, _) = $0 { return kind }
+        return nil
+      }
+    }
     var opened: QuickAddEvent? { events.first { if case .opened = $0 { true } else { false } } }
   }
 
@@ -291,6 +299,9 @@ struct QuickAddCoordinatorTests {
     #expect(saved.canonical == "Codec", "their edit to the override survived")
     #expect(saved.aliases.contains("kodek"), "and so did the spelling they put on it")
     #expect(saved.aliases.contains("codecs"))
+    // And the funnel says what was WRITTEN. The snapshot still calls this a pack term; a user word
+    // is what landed, so reporting `pack_term` would be a metric asserting the opposite.
+    #expect(recorder.targetKinds == [.userWord])
   }
 
   @Test("A word deleted while the panel sat open is not resurrected by accepting its row")

--- a/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
@@ -633,47 +633,64 @@ struct QuickAddCoordinatorTests {
   }
   // MARK: - Did the sheet's save actually produce a word (#2381, cloud review)
 
-  @Test("A blank-alias save onto an existing canonical is NOT a success")
-  func blankAliasOntoExistingCanonicalIsNotASuccess() {
+  @Test("A blank-alias save onto an existing canonical is refused")
+  func blankAliasOntoExistingCanonicalIsRefused() {
     // The state the inline version could not see. Quick Add opened without a readable selection has
     // no heard spelling, so the sheet starts with one BLANK alias and there is nothing to confirm.
     // The postcondition asked "did the kept spellings land", which is vacuously true of none — so a
     // canonical that already existed took the success path while `add` silently no-oped. Nothing was
     // created and the panel closed saying nothing.
     #expect(
-      !QuickAddWiring.newWordLanded(
-        keptSpellings: [], missingSpellings: [], canonicalExistedBefore: true))
+      QuickAddWiring.newWordOutcome(
+        keptSpellings: [], missingSpellings: [], canonicalExistedBefore: true) == .refused)
   }
 
-  @Test("A blank-alias save of a genuinely new canonical IS a success")
-  func blankAliasOntoNewCanonicalIsASuccess() {
+  @Test("A blank-alias save of a genuinely new canonical IS a creation")
+  func blankAliasOntoNewCanonicalIsACreation() {
     // The paired positive, and without it the fix reads as "refuse every blank-alias save", which
     // would break creating a word by hand from a panel that could not read a selection — the one
     // route that state has.
     #expect(
-      QuickAddWiring.newWordLanded(
-        keptSpellings: [], missingSpellings: [], canonicalExistedBefore: false))
+      QuickAddWiring.newWordOutcome(
+        keptSpellings: [], missingSpellings: [], canonicalExistedBefore: false) == .created)
   }
 
-  @Test("A spelling that landed is a success whether or not the canonical existed before")
-  func aLandedSpellingIsASuccessEitherWay() {
-    // With something to confirm, the confirmation is the whole answer. A canonical that already
-    // existed is not evidence of anything here: adding a spelling to a word you already have is the
-    // feature's main path, not a duplicate.
+  @Test("A spelling landing on a NEW canonical is a creation")
+  func aLandedSpellingOnANewCanonicalIsACreation() {
     #expect(
-      QuickAddWiring.newWordLanded(
-        keptSpellings: ["codecs"], missingSpellings: [], canonicalExistedBefore: true))
-    #expect(
-      QuickAddWiring.newWordLanded(
-        keptSpellings: ["codecs"], missingSpellings: [], canonicalExistedBefore: false))
+      QuickAddWiring.newWordOutcome(
+        keptSpellings: ["codecs"], missingSpellings: [], canonicalExistedBefore: false) == .created)
   }
 
-  @Test("A spelling that vanished is never a success")
-  func aMissingSpellingIsNeverASuccess() {
+  @Test("A spelling already on an EXISTING canonical is already-saved, never a creation")
+  func aSpellingAlreadyOnAnExistingCanonicalIsAlreadySaved() {
+    // REWRITTEN in round five, and the previous version is why. It asserted this as a success, on a
+    // comment reading "adding a spelling to a word you already have is the feature's main path, not
+    // a duplicate". That is true of the ACCEPT route and false here: through Create New, `add`
+    // no-ops on a duplicate canonical, so an existing canonical means NOTHING was written. The panel
+    // reported a creation and the funnel counted a `created_new` for a write that never happened.
+    //
+    // Not `.refused` either, which is the half that makes this three states rather than a flipped
+    // Bool: the end state the user asked for already holds, so refusing would hand them a message
+    // telling them to go and add a spelling the word already has.
+    #expect(
+      QuickAddWiring.newWordOutcome(
+        keptSpellings: ["codecs"], missingSpellings: [], canonicalExistedBefore: true)
+        == .alreadyComplete)
+  }
+
+  @Test("A spelling that vanished is refused however new the canonical is")
+  func aMissingSpellingIsAlwaysRefused() {
     // Outranks both other questions: if the user typed a spelling and it is not on the word, no
-    // amount of the canonical being new makes that a save.
+    // amount of the canonical being new makes that a save. Asserted BOTH ways, because a guard that
+    // only ever sees one value of the thing it is said to outrank has not been shown to outrank it.
     #expect(
-      !QuickAddWiring.newWordLanded(
-        keptSpellings: ["codecs"], missingSpellings: ["codecs"], canonicalExistedBefore: false))
+      QuickAddWiring.newWordOutcome(
+        keptSpellings: ["codecs"], missingSpellings: ["codecs"], canonicalExistedBefore: false)
+        == .refused)
+    #expect(
+      QuickAddWiring.newWordOutcome(
+        keptSpellings: ["codecs"], missingSpellings: ["codecs"], canonicalExistedBefore: true)
+        == .refused)
   }
 }

--- a/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
@@ -520,4 +520,49 @@ struct QuickAddCoordinatorTests {
     #expect(recorder.savedSpellings == ["codecs"])
     #expect(recorder.saved.first?.aliases.contains("codecs") == true)
   }
+  // MARK: - Did the sheet's save actually produce a word (#2381, cloud review)
+
+  @Test("A blank-alias save onto an existing canonical is NOT a success")
+  func blankAliasOntoExistingCanonicalIsNotASuccess() {
+    // The state the inline version could not see. Quick Add opened without a readable selection has
+    // no heard spelling, so the sheet starts with one BLANK alias and there is nothing to confirm.
+    // The postcondition asked "did the kept spellings land", which is vacuously true of none — so a
+    // canonical that already existed took the success path while `add` silently no-oped. Nothing was
+    // created and the panel closed saying nothing.
+    #expect(
+      !QuickAddWiring.newWordLanded(
+        keptSpellings: [], missingSpellings: [], canonicalExistedBefore: true))
+  }
+
+  @Test("A blank-alias save of a genuinely new canonical IS a success")
+  func blankAliasOntoNewCanonicalIsASuccess() {
+    // The paired positive, and without it the fix reads as "refuse every blank-alias save", which
+    // would break creating a word by hand from a panel that could not read a selection — the one
+    // route that state has.
+    #expect(
+      QuickAddWiring.newWordLanded(
+        keptSpellings: [], missingSpellings: [], canonicalExistedBefore: false))
+  }
+
+  @Test("A spelling that landed is a success whether or not the canonical existed before")
+  func aLandedSpellingIsASuccessEitherWay() {
+    // With something to confirm, the confirmation is the whole answer. A canonical that already
+    // existed is not evidence of anything here: adding a spelling to a word you already have is the
+    // feature's main path, not a duplicate.
+    #expect(
+      QuickAddWiring.newWordLanded(
+        keptSpellings: ["codecs"], missingSpellings: [], canonicalExistedBefore: true))
+    #expect(
+      QuickAddWiring.newWordLanded(
+        keptSpellings: ["codecs"], missingSpellings: [], canonicalExistedBefore: false))
+  }
+
+  @Test("A spelling that vanished is never a success")
+  func aMissingSpellingIsNeverASuccess() {
+    // Outranks both other questions: if the user typed a spelling and it is not on the word, no
+    // amount of the canonical being new makes that a save.
+    #expect(
+      !QuickAddWiring.newWordLanded(
+        keptSpellings: ["codecs"], missingSpellings: ["codecs"], canonicalExistedBefore: false))
+  }
 }

--- a/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
@@ -25,6 +25,11 @@ struct QuickAddCoordinatorTests {
     var sheetsFor: [String] = []
     var refreshCalls = 0
 
+    /// The user library, LIVE. Held here rather than captured by value so a test can change it
+    /// between opening the panel and accepting a row — which is the whole shape of the staleness
+    /// this suite has to reach, and is not reproducible against a frozen array.
+    var userWords: [CustomWord] = []
+
     var outcomes: [QuickAddOutcome] {
       events.compactMap {
         if case .resolved(let outcome, _, _, _, _) = $0 { return outcome }
@@ -47,7 +52,8 @@ struct QuickAddCoordinatorTests {
   /// fires when a panel is on screen. Emitting it from `begin` made a panel that could not be
   /// measured leave an open with nothing to resolve it.
   private func beginAndShow(
-    _ coordinator: QuickAddCoordinator, door: QuickAddDoor = .hotkey, selectionOverride: String? = nil
+    _ coordinator: QuickAddCoordinator, door: QuickAddDoor = .hotkey,
+    selectionOverride: String? = nil
   ) -> QuickAddPanelModel? {
     let model = coordinator.begin(door: door, selectionOverride: selectionOverride)
     if model != nil { coordinator.didOpen() }
@@ -62,6 +68,7 @@ struct QuickAddCoordinatorTests {
     saveFailure: String? = nil
   ) -> (QuickAddCoordinator, Recorder) {
     let recorder = Recorder()
+    recorder.userWords = userWords
     var clock = Date(timeIntervalSince1970: 0)
     let environment = QuickAddCoordinator.Environment(
       readSelection: { selection },
@@ -70,7 +77,7 @@ struct QuickAddCoordinatorTests {
         recorder.refreshCalls += 1
         return refreshSucceeds
       },
-      userWords: { userWords },
+      userWords: { recorder.userWords },
       packTerms: { packTerms },
       saveWord: { candidate, spelling in
         if let saveFailure { return saveFailure }
@@ -210,6 +217,103 @@ struct QuickAddCoordinatorTests {
     #expect(recorder.outcomes == [.alreadySaved], "a distinct outcome: nothing went wrong")
   }
 
+  @Test("Accepting merges into the word as it is NOW, not the snapshot the panel was ranked from")
+  func acceptingMergesIntoTheLiveWord() throws {
+    // The panel is deliberately persistent — it survives losing focus — so the user can open it,
+    // go and edit the word in Settings, and come back to it. Appending an alias to the SNAPSHOT and
+    // handing that to `update` replaces the whole stored entry, so their edit is reverted by a write
+    // that reports success. Silent data loss, and the panel says it worked.
+    let opened = word("Codex", aliases: ["codeks"])
+    let (coordinator, recorder) = makeCoordinator(userWords: [opened])
+    let model = try #require(beginAndShow(coordinator))
+    let target = try #require(model.ranking.candidates.first)
+
+    // What the user did in Settings while the panel sat open.
+    var edited = opened
+    edited.canonical = "Codex CLI"
+    edited.aliases = ["codeks", "kodex"]
+    edited.category = .domain
+    recorder.userWords = [edited]
+
+    coordinator.accept(target, from: model)
+
+    let saved = try #require(recorder.saved.first)
+    #expect(saved.id == opened.id, "still the same entry")
+    #expect(saved.canonical == "Codex CLI", "the rename survived")
+    #expect(saved.category == .domain, "and so did every other field on it")
+    #expect(saved.aliases.contains("kodex"), "the spelling they added in Settings survived")
+    #expect(saved.aliases.contains("codecs"), "and the one Quick Add was for landed")
+  }
+
+  @Test("A pack term overridden while the panel sat open merges into the override, not over it")
+  func aPackTermOverriddenInBetweenIsNotOverwritten() throws {
+    // `ownedByUser()` PRESERVES the id, so once the user takes ownership of a pack term the same id
+    // names a real entry. Converting the pack snapshot a second time would write over the override
+    // they just made — which is why the live lookup runs BEFORE the pack branch rather than after.
+    let pack = word("codec", source: .pack)
+    let (coordinator, recorder) = makeCoordinator(userWords: [], packTerms: [pack])
+    let model = try #require(beginAndShow(coordinator))
+    let target = try #require(model.ranking.candidates.first)
+    #expect(target.isPackTerm)
+
+    var override = pack.ownedByUser()
+    override.canonical = "Codec"
+    override.aliases = ["kodek"]
+    recorder.userWords = [override]
+
+    coordinator.accept(target, from: model)
+
+    let saved = try #require(recorder.saved.first)
+    #expect(saved.canonical == "Codec", "their edit to the override survived")
+    #expect(saved.aliases.contains("kodek"), "and so did the spelling they put on it")
+    #expect(saved.aliases.contains("codecs"))
+  }
+
+  @Test("A word deleted while the panel sat open is not resurrected by accepting its row")
+  func aDeletedWordIsNotResurrected() throws {
+    // The same staleness pointing the other way, and it is why the resolver returns three cases
+    // rather than an optional: writing the snapshot back would silently undo a DELETION.
+    let codex = word("Codex", aliases: ["codeks"])
+    let (coordinator, recorder) = makeCoordinator(userWords: [codex])
+    let model = try #require(beginAndShow(coordinator))
+    let target = try #require(model.ranking.candidates.first)
+
+    recorder.userWords = []
+
+    let message = coordinator.accept(target, from: model)
+
+    #expect(message == QuickAddPanelCopy.wordNoLongerExists)
+    #expect(recorder.saved.isEmpty, "nothing may be written for a word that is gone")
+    #expect(
+      recorder.outcomes.isEmpty,
+      "a refusal leaves the panel open, so the invocation has not ended and nothing resolves")
+    #expect(
+      recorder.events.contains {
+        if case .failed(_, let reason) = $0 { reason == "target_gone" } else { false }
+      })
+  }
+
+  @Test("A spelling that arrived from elsewhere is not appended a second time")
+  func aSpellingAddedElsewhereIsNotAppendedAgain() throws {
+    // The snapshot guard answers this from the ranking taken when the panel opened. The library can
+    // gain the spelling AFTER that, and appending it again stores it twice and reports success.
+    let codex = word("Codex", aliases: ["codeks"])
+    let (coordinator, recorder) = makeCoordinator(userWords: [codex])
+    let model = try #require(beginAndShow(coordinator))
+    let target = try #require(model.ranking.candidates.first)
+    #expect(!target.alreadyHasHeardSpelling, "the snapshot says there is work to do")
+
+    var edited = codex
+    // Case differs, which is still the same spelling — matching exactly would store both.
+    edited.aliases = ["codeks", "Codecs"]
+    recorder.userWords = [edited]
+
+    coordinator.accept(target, from: model)
+
+    #expect(recorder.saved.isEmpty, "storing it twice would report success for a duplicate")
+    #expect(recorder.outcomes == [.alreadySaved], "one outcome, two sources, same answer")
+  }
+
   @Test("A refused write is reported as a failure, not as a save")
   func aRefusedWriteIsReported() throws {
     // The reader reuses only the LENGTH half of the store's policy, so a selection carrying a bidi
@@ -248,7 +352,10 @@ struct QuickAddCoordinatorTests {
     coordinator.cancel(from: model)
 
     #expect(recorder.outcomes == [.cancelled])
-    #expect(!recorder.events.contains { if case .failed(let stage, _) = $0 { stage == "resolve" } else { false } })
+    #expect(
+      !recorder.events.contains {
+        if case .failed(let stage, _) = $0 { stage == "resolve" } else { false }
+      })
   }
 
   @Test("A second resolution is refused loudly rather than invented")
@@ -265,8 +372,11 @@ struct QuickAddCoordinatorTests {
     #expect(recorder.outcomes == [.cancelled])
     #expect(
       recorder.events.contains {
-        if case .failed(let stage, let reason) = $0 { stage == "resolve" && reason == "double_resolution" }
-        else { false }
+        if case .failed(let stage, let reason) = $0 {
+          stage == "resolve" && reason == "double_resolution"
+        } else {
+          false
+        }
       })
   }
 
@@ -418,7 +528,8 @@ struct QuickAddCoordinatorTests {
     // The paired accepted case. Without it every assertion above passes against a door that refuses
     // everything, which is a check that never classifies anything.
     let (coordinator, _) = makeCoordinator(userWords: [word("Codex")])
-    let model = try #require(beginAndShow(coordinator, door: .service, selectionOverride: "  codecs  "))
+    let model = try #require(
+      beginAndShow(coordinator, door: .service, selectionOverride: "  codecs  "))
 
     #expect(model.heard == "codecs")
     #expect(model.refusal == nil)

--- a/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
@@ -222,12 +222,52 @@ struct QuickAddCoordinatorTests {
     let message = coordinator.accept(target, from: model)
 
     // The RETURNED message is the assertion that matters, and the first version of this test did
-    // not make it. Telemetry going out under `writeFailed` is a fact about a dashboard; what the
+    // not make it. It asserted the TELEMETRY outcome, which is a fact about a dashboard; what the
     // comment above promises — "the user must be told" — is only true if the caller is handed
     // something to show, and the caller dismissed the panel regardless until this was added.
     #expect(message == "That word cannot be saved.")
-    #expect(recorder.outcomes == [.writeFailed])
     #expect(recorder.events.contains { if case .failed = $0 { true } else { false } })
+    // NOT resolved. The panel is still open, so the invocation has not ended — `resolved` means
+    // ENDED, and the second version of this test asserted `[.writeFailed]` here, which was the
+    // defect written down as a contract one layer up from the first version's.
+    #expect(recorder.outcomes.isEmpty)
+  }
+
+  @Test("A refused write then a cancel is ONE resolution, not two")
+  func aRefusedWriteThenCancelResolvesOnce() throws {
+    // The axis-A member the enumeration missed, and the reason it missed it: I enumerated which
+    // ENDINGS exist and checked each in isolation, when the generating dimension is which ordered
+    // PAIRS are reachable in one open. Only a refused write leaves the panel up, so only it can be
+    // followed by a second ending.
+    let (coordinator, recorder) = makeCoordinator(
+      userWords: [word("Codex")], saveFailure: "That word cannot be saved.")
+    let model = try #require(beginAndShow(coordinator))
+    let target = try #require(model.ranking.candidates.first)
+
+    _ = coordinator.accept(target, from: model)
+    coordinator.cancel(from: model)
+
+    #expect(recorder.outcomes == [.cancelled])
+    #expect(!recorder.events.contains { if case .failed(let stage, _) = $0 { stage == "resolve" } else { false } })
+  }
+
+  @Test("A second resolution is refused loudly rather than invented")
+  func aSecondResolutionIsRefused() throws {
+    // Removing the REASON and removing the POSSIBILITY are different jobs. `finish` used to
+    // substitute `environment.now()` for a cleared start time, which gave a second terminal event a
+    // plausible elapsed time and no way to tell it apart from a real one.
+    let (coordinator, recorder) = makeCoordinator(userWords: [word("Codex")])
+    let model = try #require(beginAndShow(coordinator))
+
+    coordinator.cancel(from: model)
+    coordinator.cancel(from: model)
+
+    #expect(recorder.outcomes == [.cancelled])
+    #expect(
+      recorder.events.contains {
+        if case .failed(let stage, let reason) = $0 { stage == "resolve" && reason == "double_resolution" }
+        else { false }
+      })
   }
 
   @Test("A save that succeeds returns nothing to show, which is what licenses the dismiss")

--- a/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
@@ -1,0 +1,290 @@
+import EnviousWisprCore
+import EnviousWisprPostProcessing
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #2381 — what one Quick Add actually does, from keypress to written word.
+///
+/// When this fails the user presses their shortcut and the wrong thing lands in their library: a word
+/// gains a spelling twice, a pack term is "saved" and silently written nowhere, or a stale snapshot is
+/// ranked so the panel offers words that no longer exist. Every one of those reports success.
+///
+/// Every collaborator is a function, so each branch is reachable without a window, a words file, or a
+/// real selection — and so the assertions are about the DECISION rather than about a stub's shape.
+@MainActor
+@Suite("Quick Add orchestration — #2381", .tags(.productOutcome))
+struct QuickAddCoordinatorTests {
+
+  private final class Recorder {
+    var events: [QuickAddEvent] = []
+    var saved: [CustomWord] = []
+    var sheetsFor: [String] = []
+    var refreshCalls = 0
+
+    var outcomes: [QuickAddOutcome] {
+      events.compactMap {
+        if case .resolved(let outcome, _, _, _, _) = $0 { return outcome }
+        return nil
+      }
+    }
+    var opened: QuickAddEvent? { events.first { if case .opened = $0 { true } else { false } } }
+  }
+
+  private func word(_ canonical: String, aliases: [String] = [], source: WordSource = .user)
+    -> CustomWord
+  {
+    CustomWord(canonical: canonical, aliases: aliases, source: source)
+  }
+
+  private func makeCoordinator(
+    selection: SelectionReader.Result = .text("codecs"),
+    refreshSucceeds: Bool = true,
+    userWords: [CustomWord] = [],
+    packTerms: [CustomWord] = [],
+    saveFailure: String? = nil
+  ) -> (QuickAddCoordinator, Recorder) {
+    let recorder = Recorder()
+    var clock = Date(timeIntervalSince1970: 0)
+    let environment = QuickAddCoordinator.Environment(
+      readSelection: { selection },
+      frontmostBundleID: { "com.apple.TextEdit" },
+      refreshWords: {
+        recorder.refreshCalls += 1
+        return refreshSucceeds
+      },
+      userWords: { userWords },
+      packTerms: { packTerms },
+      saveWord: { candidate in
+        if let saveFailure { return saveFailure }
+        recorder.saved.append(candidate)
+        return nil
+      },
+      presentNewWordSheet: { recorder.sheetsFor.append($0) },
+      emit: { recorder.events.append($0) },
+      now: {
+        clock.addTimeInterval(0.01)
+        return clock
+      })
+    return (QuickAddCoordinator(environment: environment), recorder)
+  }
+
+  // MARK: - Opening
+
+  @Test("The library is re-read before anything is ranked")
+  func refreshHappensBeforeRanking() throws {
+    // A sibling instance or the Settings window can change the library after launch. Ranking a stale
+    // snapshot offers words that no longer exist and hides ones that do.
+    let (coordinator, recorder) = makeCoordinator(userWords: [word("Codex")])
+
+    _ = coordinator.begin(door: .hotkey)
+
+    #expect(recorder.refreshCalls == 1)
+  }
+
+  @Test("An unreadable library presents nothing rather than ranking a stale snapshot")
+  func anUnreadableLibraryPresentsNothing() {
+    let (coordinator, recorder) = makeCoordinator(
+      refreshSucceeds: false, userWords: [word("Codex")])
+
+    let model = coordinator.begin(door: .hotkey)
+
+    #expect(model == nil)
+    // nil is never silence: the failure is reported before the caller is told to show nothing.
+    #expect(recorder.events.contains { if case .failed = $0 { true } else { false } })
+    #expect(recorder.outcomes == [.writeFailed])
+  }
+
+  @Test("Opening reports SHAPE, never the word itself")
+  func openingReportsShapeOnly() throws {
+    // The privacy boundary is the network and the test is whether user content crosses it. A scalar
+    // count is shape; the string is not.
+    let (coordinator, recorder) = makeCoordinator(userWords: [word("Codex")])
+
+    _ = coordinator.begin(door: .hotkey)
+    let opened = try #require(recorder.opened)
+
+    guard case .opened(let door, let refusal, let bundle, let count, _, _, _) = opened else {
+      Issue.record("not an opened event")
+      return
+    }
+    #expect(door == .hotkey)
+    #expect(refusal == nil)
+    #expect(bundle == "com.apple.TextEdit")
+    #expect(count == "codecs".unicodeScalars.count)
+  }
+
+  @Test("A refusal still opens the panel, carrying its reason")
+  func aRefusalStillOpens() throws {
+    let (coordinator, recorder) = makeCoordinator(selection: .refused(.accessibilityNotTrusted))
+
+    let model = try #require(coordinator.begin(door: .hotkey))
+
+    #expect(model.refusal == .accessibilityNotTrusted)
+    #expect(recorder.opened != nil, "the panel opens on a stated reason, never a silent no-op")
+  }
+
+  @Test("No selection is a reason, not an error")
+  func noSelectionIsAReason() throws {
+    let (coordinator, _) = makeCoordinator(selection: .noSelection)
+
+    let model = try #require(coordinator.begin(door: .hotkey))
+
+    #expect(model.refusal != nil, "the search field is the way forward, and the panel says so")
+    #expect(model.heard.isEmpty)
+  }
+
+  // MARK: - Accepting
+
+  @Test("Accepting writes the heard spelling onto the chosen word")
+  func acceptingWritesTheHeardSpelling() throws {
+    let codex = word("Codex", aliases: ["codeks"])
+    let (coordinator, recorder) = makeCoordinator(userWords: [codex])
+    let model = try #require(coordinator.begin(door: .hotkey))
+    let target = try #require(model.ranking.candidates.first)
+
+    coordinator.accept(target, from: model)
+
+    #expect(recorder.saved.count == 1)
+    #expect(recorder.saved.first?.canonical == "Codex")
+    #expect(recorder.saved.first?.aliases.contains("codecs") == true)
+    #expect(recorder.saved.first?.aliases.contains("codeks") == true, "existing spellings survive")
+    #expect(recorder.outcomes == [.accepted])
+  }
+
+  @Test("A pack term is converted to a user-owned word before it is written")
+  func aPackTermIsConvertedBeforeWriting() throws {
+    // `CustomWordsManager.update` looks an id up in the USER library. A pack term is not there, so
+    // the call returns having written nothing and reporting success — a save that silently does not.
+    let pack = word("codec", source: .pack)
+    let (coordinator, recorder) = makeCoordinator(userWords: [], packTerms: [pack])
+    let model = try #require(coordinator.begin(door: .hotkey))
+    let target = try #require(model.ranking.candidates.first)
+    #expect(target.isPackTerm)
+
+    coordinator.accept(target, from: model)
+
+    let saved = try #require(recorder.saved.first)
+    #expect(saved.source == .user, "written as a pack term, it would have gone nowhere")
+    #expect(saved.id == pack.id, "the override keeps the pack term's identity")
+    #expect(saved.aliases.contains("codecs"))
+  }
+
+  @Test("A word that already carries the spelling is not written again")
+  func anAlreadySavedWordIsNotWrittenAgain() throws {
+    let codex = word("Codex", aliases: ["codecs"])
+    let (coordinator, recorder) = makeCoordinator(userWords: [codex])
+    let model = try #require(coordinator.begin(door: .hotkey))
+    let target = try #require(model.ranking.candidates.first)
+
+    coordinator.accept(target, from: model)
+
+    #expect(recorder.saved.isEmpty, "writing again adds a duplicate and reports success")
+    #expect(recorder.outcomes == [.alreadySaved], "a distinct outcome: nothing went wrong")
+  }
+
+  @Test("A refused write is reported as a failure, not as a save")
+  func aRefusedWriteIsReported() throws {
+    // The reader reuses only the LENGTH half of the store's policy, so a selection carrying a bidi
+    // override passes the reader and is refused here. The user must be told.
+    let (coordinator, recorder) = makeCoordinator(
+      userWords: [word("Codex")], saveFailure: "That word cannot be saved.")
+    let model = try #require(coordinator.begin(door: .hotkey))
+    let target = try #require(model.ranking.candidates.first)
+
+    coordinator.accept(target, from: model)
+
+    #expect(recorder.outcomes == [.writeFailed])
+    #expect(recorder.events.contains { if case .failed = $0 { true } else { false } })
+  }
+
+  @Test("Accepting after searching is a distinct outcome from accepting the top row")
+  func acceptingAfterSearchIsDistinct() throws {
+    // The two say different things about the ranking: one is the guess landing, the other is the
+    // user rescuing it. A single `accepted` would hide how often the ranking is wrong.
+    let (coordinator, recorder) = makeCoordinator(
+      userWords: [word("Codex"), word("Claude Code")])
+    let model = try #require(coordinator.begin(door: .hotkey))
+    model.updateQuery("claude")
+    let target = try #require(model.ranking.candidates.first)
+
+    coordinator.accept(target, from: model)
+
+    #expect(recorder.outcomes == [.acceptedAfterSearch])
+  }
+
+  @Test("Searching never changes what gets written")
+  func searchingNeverChangesWhatIsWritten() throws {
+    let (coordinator, recorder) = makeCoordinator(
+      userWords: [word("Codex"), word("Claude Code")])
+    let model = try #require(coordinator.begin(door: .hotkey))
+    model.updateQuery("claude")
+    let target = try #require(model.ranking.candidates.first)
+
+    coordinator.accept(target, from: model)
+
+    #expect(recorder.saved.first?.aliases.contains("codecs") == true)
+    #expect(
+      recorder.saved.first?.aliases.contains("claude") == false,
+      "the query must never become the spelling")
+  }
+
+  // MARK: - The other two endings
+
+  @Test("Create-new opens the edit sheet on the heard spelling")
+  func createNewOpensTheSheet() throws {
+    let (coordinator, recorder) = makeCoordinator()
+    let model = try #require(coordinator.begin(door: .hotkey))
+
+    coordinator.createNew(from: model)
+
+    #expect(recorder.sheetsFor == ["codecs"])
+    #expect(recorder.outcomes == [.createdNew])
+    #expect(recorder.saved.isEmpty, "the sheet writes, not this")
+  }
+
+  @Test("Cancelling writes nothing and says so")
+  func cancellingWritesNothing() throws {
+    let (coordinator, recorder) = makeCoordinator(userWords: [word("Codex")])
+    let model = try #require(coordinator.begin(door: .hotkey))
+
+    coordinator.cancel(from: model)
+
+    #expect(recorder.saved.isEmpty)
+    #expect(recorder.outcomes == [.cancelled])
+  }
+
+  @Test("Both doors are reported, and they are the only two")
+  func bothDoorsAreReported() throws {
+    let (coordinator, recorder) = makeCoordinator()
+
+    _ = coordinator.begin(door: .service, selectionOverride: "codecs")
+    guard case .opened(let door, _, _, _, _, _, _) = try #require(recorder.opened) else { return }
+
+    #expect(door == .service)
+    #expect(QuickAddDoor.allCases.count == 2)
+  }
+
+  @Test("The Service door uses the pasteboard text and does not read Accessibility")
+  func theServiceDoorUsesItsOwnText() throws {
+    // A Service is HANDED the selection. Reading Accessibility as well would ask a second question
+    // whose answer is about whatever is frontmost now, which by then may be us.
+    let (coordinator, _) = makeCoordinator(selection: .refused(.accessibilityNotTrusted))
+
+    let model = try #require(coordinator.begin(door: .service, selectionOverride: "sarag"))
+
+    #expect(model.heard == "sarag")
+    #expect(model.refusal == nil, "the AX refusal is irrelevant when the text was handed to us")
+  }
+
+  @Test("Every outcome name is distinct")
+  func outcomeNamesAreDistinct() {
+    // The raw values are the telemetry values. Two outcomes sharing one makes a dashboard unable to
+    // tell a cancel from a failed write.
+    let names = QuickAddOutcome.allCases.map(\.rawValue)
+    #expect(Set(names).count == names.count)
+    #expect(names.allSatisfy { !$0.isEmpty })
+  }
+}

--- a/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
@@ -84,17 +84,23 @@ struct QuickAddCoordinatorTests {
     #expect(recorder.refreshCalls == 1)
   }
 
-  @Test("An unreadable library presents nothing rather than ranking a stale snapshot")
-  func anUnreadableLibraryPresentsNothing() {
+  @Test("An unreadable library states a reason rather than ranking a stale snapshot")
+  func anUnreadableLibraryStatesAReason() throws {
+    // REWRITTEN in review round 1, and the previous version is why: it asserted `model == nil` plus
+    // a resolved event, which is the defect written down as a contract. Reporting the failure to
+    // telemetry is a fact about a dashboard; the user got a shortcut that did nothing visible,
+    // which is indistinguishable from one that was never registered.
     let (coordinator, recorder) = makeCoordinator(
       refreshSucceeds: false, userWords: [word("Codex")])
 
-    let model = coordinator.begin(door: .hotkey)
+    let model = try #require(coordinator.begin(door: .hotkey))
 
-    #expect(model == nil)
-    // nil is never silence: the failure is reported before the caller is told to show nothing.
+    #expect(model.refusal == .wordsUnavailable)
+    // The stale snapshot half of the name is the part that was always right.
+    #expect(model.ranking.candidates.isEmpty)
     #expect(recorder.events.contains { if case .failed = $0 { true } else { false } })
-    #expect(recorder.outcomes == [.writeFailed])
+    // Opening is not resolving. A resolved event here closes a funnel the user is still inside.
+    #expect(recorder.outcomes.isEmpty)
   }
 
   @Test("Opening reports SHAPE, never the word itself")
@@ -271,7 +277,10 @@ struct QuickAddCoordinatorTests {
     coordinator.createNew(from: model)
 
     #expect(recorder.sheetsFor == ["codecs"])
-    #expect(recorder.outcomes == [.createdNew])
+    // `createdNew` deliberately does NOT fire here any more — opening a sheet is an intention, and
+    // emitting on the click double-counted every open where the user then cancelled. The outcome is
+    // asserted in `didCreateNewResolvesOnce`, after the save is confirmed.
+    #expect(recorder.outcomes.isEmpty)
     #expect(recorder.saved.isEmpty, "the sheet writes, not this")
   }
 
@@ -317,4 +326,81 @@ struct QuickAddCoordinatorTests {
     #expect(Set(names).count == names.count)
     #expect(names.allSatisfy { !$0.isEmpty })
   }
+  // MARK: - Round 1 of the whole-diff review (#2381)
+
+  @Test("A Service handing over whitespace opens on a stated reason, not on an empty word")
+  func serviceWhitespaceIsARefusal() throws {
+    // The Services system hands us whatever was on the pasteboard. Treating that as already-valid
+    // opened a panel reading `Heard: ` with the search field up, from which Return could write an
+    // alias the store then stripped while reporting success.
+    let (coordinator, recorder) = makeCoordinator(userWords: [word("Codex")])
+    let model = try #require(coordinator.begin(door: .service, selectionOverride: "   "))
+
+    #expect(model.heard.isEmpty)
+    #expect(model.refusal == .selectionUnavailable)
+    #expect(model.ranking.candidates.isEmpty)
+    #expect(recorder.outcomes.isEmpty)
+  }
+
+  @Test("A Service handing over an oversized selection is refused at the store's own ceiling")
+  func serviceOversizedIsRefused() throws {
+    // Door A bounded this and door B did not, so the same selection was refused through one door
+    // and sent to the scorer through the other — where edit distance builds a matrix per candidate.
+    let huge = String(repeating: "a", count: SelectionReader.maximumSelectionScalars + 1)
+    let (coordinator, _) = makeCoordinator(userWords: [word("Codex")])
+    let model = try #require(coordinator.begin(door: .service, selectionOverride: huge))
+
+    #expect(model.refusal == .selectionTooLong)
+    #expect(model.ranking.candidates.isEmpty)
+  }
+
+  @Test("A Service handing over a real word still ranks it, so the guard is not blanket refusal")
+  func serviceOrdinaryWordStillRanks() throws {
+    // The paired accepted case. Without it every assertion above passes against a door that refuses
+    // everything, which is a check that never classifies anything.
+    let (coordinator, _) = makeCoordinator(userWords: [word("Codex")])
+    let model = try #require(coordinator.begin(door: .service, selectionOverride: "  codecs  "))
+
+    #expect(model.heard == "codecs")
+    #expect(model.refusal == nil)
+    #expect(!model.ranking.candidates.isEmpty)
+  }
+
+  @Test("Opening the new-word sheet resolves nothing, because an intention is not an outcome")
+  func createNewDoesNotResolve() throws {
+    // Emitting createdNew on the click counted opening a sheet as a save: cancelling the sheet left
+    // the panel up, and cancelling the panel then emitted a SECOND resolved event for one open.
+    let (coordinator, recorder) = makeCoordinator(userWords: [word("Codex")])
+    let model = try #require(coordinator.begin(door: .hotkey))
+
+    coordinator.createNew(from: model)
+
+    #expect(recorder.sheetsFor == ["codecs"])
+    #expect(recorder.outcomes.isEmpty)
+  }
+
+  @Test("Cancelling after opening the sheet resolves exactly once, as cancelled")
+  func cancellingAfterTheSheetResolvesOnce() throws {
+    let (coordinator, recorder) = makeCoordinator(userWords: [word("Codex")])
+    let model = try #require(coordinator.begin(door: .hotkey))
+
+    coordinator.createNew(from: model)
+    coordinator.cancel(from: model)
+
+    #expect(recorder.outcomes == [.cancelled])
+  }
+
+  @Test("A confirmed save resolves as createdNew, once")
+  func didCreateNewResolvesOnce() throws {
+    // The paired positive: the outcome still exists and is still reachable. Moving the emission
+    // without this would be indistinguishable from deleting it.
+    let (coordinator, recorder) = makeCoordinator(userWords: [word("Codex")])
+    let model = try #require(coordinator.begin(door: .hotkey))
+
+    coordinator.createNew(from: model)
+    coordinator.didCreateNew(from: model)
+
+    #expect(recorder.outcomes == [.createdNew])
+  }
+
 }

--- a/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
@@ -217,6 +217,30 @@ struct QuickAddCoordinatorTests {
     #expect(recorder.outcomes == [.alreadySaved], "a distinct outcome: nothing went wrong")
   }
 
+  @Test("A spelling removed while the panel sat open is written again, not reported as saved")
+  func aSpellingRemovedInBetweenIsWrittenAgain() throws {
+    // The MIRROR of the de-dup below, and the direction the first version of this fix missed. The
+    // snapshot's `alreadyHasHeardSpelling` was consulted BEFORE the live lookup, so a spelling the
+    // user removed in Settings while the panel sat open still short-circuited to "already saved" —
+    // the panel reporting a spelling was there, having written nothing, about a word that no longer
+    // had it. Same family as the P1, arriving through the guard that runs first.
+    let codex = word("Codex", aliases: ["codecs"])
+    let (coordinator, recorder) = makeCoordinator(userWords: [codex])
+    let model = try #require(beginAndShow(coordinator))
+    let target = try #require(model.ranking.candidates.first)
+    #expect(target.alreadyHasHeardSpelling, "the snapshot says it is already there")
+
+    var edited = codex
+    edited.aliases = []
+    recorder.userWords = [edited]
+
+    coordinator.accept(target, from: model)
+
+    let saved = try #require(recorder.saved.first)
+    #expect(saved.aliases.contains("codecs"), "it is not there any more, so it gets written")
+    #expect(recorder.outcomes == [.accepted], "never alreadySaved for a spelling that is absent")
+  }
+
   @Test("Accepting merges into the word as it is NOW, not the snapshot the panel was ranked from")
   func acceptingMergesIntoTheLiveWord() throws {
     // The panel is deliberately persistent — it survives losing focus — so the user can open it,

--- a/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
@@ -194,10 +194,40 @@ struct QuickAddCoordinatorTests {
     let model = try #require(coordinator.begin(door: .hotkey))
     let target = try #require(model.ranking.candidates.first)
 
-    coordinator.accept(target, from: model)
+    let message = coordinator.accept(target, from: model)
 
+    // The RETURNED message is the assertion that matters, and the first version of this test did
+    // not make it. Telemetry going out under `writeFailed` is a fact about a dashboard; what the
+    // comment above promises — "the user must be told" — is only true if the caller is handed
+    // something to show, and the caller dismissed the panel regardless until this was added.
+    #expect(message == "That word cannot be saved.")
     #expect(recorder.outcomes == [.writeFailed])
     #expect(recorder.events.contains { if case .failed = $0 { true } else { false } })
+  }
+
+  @Test("A save that succeeds returns nothing to show, which is what licenses the dismiss")
+  func aSuccessfulWriteReturnsNil() throws {
+    // The paired accepted case for the refusal above. Without it the caller could dismiss on any
+    // non-nil-ness rule and still pass, and a check that never classifies anything looks clean.
+    let (coordinator, recorder) = makeCoordinator(userWords: [word("Codex")])
+    let model = try #require(coordinator.begin(door: .hotkey))
+    let target = try #require(model.ranking.candidates.first)
+
+    #expect(coordinator.accept(target, from: model) == nil)
+    #expect(recorder.outcomes == [.accepted])
+  }
+
+  @Test("A word that already carries the spelling returns nothing to show")
+  func alreadySavedReturnsNil() throws {
+    // Nothing went wrong, so there is nothing to keep the panel open for. Distinguished from the
+    // refusal above only by the return value, which is why both are asserted.
+    let (coordinator, recorder) = makeCoordinator(
+      selection: .text("codecs"), userWords: [word("Codex", aliases: ["codecs"])])
+    let model = try #require(coordinator.begin(door: .hotkey))
+    let target = try #require(model.ranking.candidates.first)
+
+    #expect(coordinator.accept(target, from: model) == nil)
+    #expect(recorder.outcomes == [.alreadySaved])
   }
 
   @Test("Accepting after searching is a distinct outcome from accepting the top row")

--- a/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
@@ -21,6 +21,7 @@ struct QuickAddCoordinatorTests {
   private final class Recorder {
     var events: [QuickAddEvent] = []
     var saved: [CustomWord] = []
+    var savedSpellings: [String] = []
     var sheetsFor: [String] = []
     var refreshCalls = 0
 
@@ -57,9 +58,13 @@ struct QuickAddCoordinatorTests {
       },
       userWords: { userWords },
       packTerms: { packTerms },
-      saveWord: { candidate in
+      saveWord: { candidate, spelling in
         if let saveFailure { return saveFailure }
         recorder.saved.append(candidate)
+        // Recorded so a test can assert the coordinator hands over the SELECTION, never the query.
+        // The postcondition the real one checks lives in the wiring; what is checkable here is that
+        // the spelling it would check is the right string.
+        recorder.savedSpellings.append(spelling)
         return nil
       },
       presentNewWordSheet: { recorder.sheetsFor.append($0) },
@@ -403,4 +408,20 @@ struct QuickAddCoordinatorTests {
     #expect(recorder.outcomes == [.createdNew])
   }
 
+  @Test("The spelling handed to the write path is the SELECTION, never the search query")
+  func theWritePathIsGivenTheSelection() throws {
+    // The write path now takes the spelling as its own parameter so it can prove that spelling
+    // landed. That check is only worth anything if the string it is given is the right one — and the
+    // search field exists precisely to let the user type something else.
+    let (coordinator, recorder) = makeCoordinator(
+      selection: .text("codecs"), userWords: [word("Codex"), word("Kubernetes")])
+    let model = try #require(coordinator.begin(door: .hotkey))
+    model.updateQuery("kub")
+    let target = try #require(model.ranking.candidates.first)
+
+    coordinator.accept(target, from: model)
+
+    #expect(recorder.savedSpellings == ["codecs"])
+    #expect(recorder.saved.first?.aliases.contains("codecs") == true)
+  }
 }

--- a/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
@@ -166,13 +166,18 @@ struct QuickAddCoordinatorTests {
     #expect(recorder.opened != nil, "the panel opens on a stated reason, never a silent no-op")
   }
 
-  @Test("No selection is a reason, not an error")
-  func noSelectionIsAReason() throws {
+  @Test("No selection gets its OWN reason, never the one that blames the app")
+  func noSelectionGetsItsOwnReason() throws {
+    // This used to map onto `selectionUnavailable`, whose sentence names terminals and accuses the
+    // frontmost app of withholding a selection. Pressing the shortcut having highlighted nothing is
+    // the likeliest way to reach a refusal at all, so the commonest case got a confident diagnosis
+    // of an app that had done nothing wrong. The old test asserted `refusal != nil`, which is true
+    // of every member and so could not see it.
     let (coordinator, _) = makeCoordinator(selection: .noSelection)
 
     let model = try #require(beginAndShow(coordinator))
 
-    #expect(model.refusal != nil, "the search field is the way forward, and the panel says so")
+    #expect(model.refusal == .nothingSelected)
     #expect(model.heard.isEmpty)
   }
 
@@ -302,6 +307,35 @@ struct QuickAddCoordinatorTests {
     // And the funnel says what was WRITTEN. The snapshot still calls this a pack term; a user word
     // is what landed, so reporting `pack_term` would be a metric asserting the opposite.
     #expect(recorder.targetKinds == [.userWord])
+  }
+
+  @Test("A pack row whose NAME the user already owns merges into their word, not a doomed override")
+  func aPackRowCollidingByNameMergesIntoTheUserWord() throws {
+    // `ownedByUser()` keeps the pack term's id and `packTermsNotOverridden` filters the ranking by
+    // ID, so a user word and an enabled pack term can share a canonical and differ by id — two rows,
+    // one name. Converting the pack snapshot hands `add` a colliding canonical, which it refuses
+    // SILENTLY, and the post-write confirmation then finds the spelling on the USER word and reports
+    // success for an override that was never created.
+    let pack = word("Codec", source: .pack)
+    let mine = word("Codec", aliases: ["kodek"])
+    #expect(pack.id != mine.id, "the whole case is one name under two identities")
+
+    let (coordinator, recorder) = makeCoordinator(userWords: [mine], packTerms: [pack])
+    let model = try #require(beginAndShow(coordinator))
+    // Reached through SEARCH, not the heard ranking, and the difference is load-bearing. Pack terms
+    // enter the heard list only when the user's best score misses the confidence bar, so a strong
+    // user match hides them; the search population is `userWords + packTermsNotOverridden`
+    // unconditionally, so both rows are on screen the moment the user types the shared name.
+    model.updateQuery("Codec")
+    let packRow = try #require(model.ranking.candidates.first { $0.isPackTerm })
+
+    coordinator.accept(packRow, from: model)
+
+    let saved = try #require(recorder.saved.first)
+    #expect(saved.id == mine.id, "written to the entry that can actually take it")
+    #expect(saved.aliases.contains("kodek"), "and their own spelling survived the merge")
+    #expect(saved.aliases.contains("codecs"))
+    #expect(recorder.targetKinds == [.userWord], "a user word is what was written, so say so")
   }
 
   @Test("A word deleted while the panel sat open is not resurrected by accepting its row")
@@ -541,7 +575,11 @@ struct QuickAddCoordinatorTests {
     let model = try #require(beginAndShow(coordinator, door: .service, selectionOverride: "   "))
 
     #expect(model.heard.isEmpty)
-    #expect(model.refusal == .selectionUnavailable)
+    // The TWIN of the hotkey case, and it moved with it: whitespace classifies as no selection, so
+    // both doors now land on the reason that blames nobody rather than on the one naming terminals.
+    // Its sentence deliberately names no route, because a message telling a Services user to "press
+    // the shortcut again" is wrong about how they got here.
+    #expect(model.refusal == .nothingSelected)
     #expect(model.ranking.candidates.isEmpty)
     #expect(recorder.outcomes.isEmpty)
   }

--- a/Tests/EnviousWisprTests/App/QuickAddServiceDeclarationTests.swift
+++ b/Tests/EnviousWisprTests/App/QuickAddServiceDeclarationTests.swift
@@ -1,0 +1,117 @@
+import AppKit
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #2381 — the Services declaration and the code that answers it agree.
+///
+/// When this fails the right-click menu item appears and clicking it does NOTHING. There is no error,
+/// no log line, and no crash: AppKit looks up a selector built from the plist's `NSMessage`, does not
+/// find it, and stops. The user right-clicks, chooses the item, and nothing happens — twice, then they
+/// stop trying.
+///
+/// **This is a drift guard, and it guards a JOIN.** Neither half is wrong on its own; they are wrong
+/// together, and nothing in Swift or in the build connects a string in a plist to an `@objc` selector.
+@Suite("Quick Add Services declaration — #2381", .tags(.driftGuard))
+struct QuickAddServiceDeclarationTests {
+
+  private static func declaration() throws -> [String: Any] {
+    let url = RepoRoot.sourceURL("Sources/EnviousWispr/Resources/Info.plist")
+    let data = try Data(contentsOf: url)
+    let plist =
+      try PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any] ?? [:]
+    let services = plist["NSServices"] as? [[String: Any]] ?? []
+    guard let ours = services.first(where: { $0["NSMessage"] as? String == QuickAddServiceProvider.messageName })
+    else {
+      Issue.record(
+        Comment(
+          rawValue:
+            "no NSServices entry with NSMessage '\(QuickAddServiceProvider.messageName)' — the menu "
+            + "item would never appear"))
+      return [:]
+    }
+    return ours
+  }
+
+  @Test("The declared message is the one the provider answers")
+  func theDeclaredMessageMatchesTheProvider() throws {
+    let ours = try Self.declaration()
+
+    #expect(ours["NSMessage"] as? String == QuickAddServiceProvider.messageName)
+  }
+
+  @Test("The provider actually responds to the selector AppKit will build")
+  func theProviderRespondsToTheSelector() async throws {
+    // The join this suite exists for. AppKit builds `<NSMessage>:userData:error:` and calls it; a
+    // rename on either side leaves a menu item that silently does nothing.
+    let ours = try Self.declaration()
+    let message = try #require(ours["NSMessage"] as? String)
+    let selector = Selector("\(message):userData:error:")
+
+    let provider = await MainActor.run { QuickAddServiceProvider(begin: { _ in }) }
+
+    #expect(
+      provider.responds(to: selector),
+      "the plist promises \(message); the provider does not implement it")
+  }
+
+  @Test("It accepts plain text, which is what a selection is")
+  func itAcceptsPlainText() throws {
+    let ours = try Self.declaration()
+    let sendTypes = ours["NSSendTypes"] as? [String] ?? []
+
+    #expect(sendTypes.contains("public.utf8-plain-text"))
+  }
+
+  @Test("It declares NO key equivalent")
+  func itDeclaresNoKeyEquivalent() throws {
+    // The keyboard is door A's job. A chord here as well puts two registrations on one key — a Carbon
+    // first-come-first-served collision with our own hotkey — and a Service key equivalent does not
+    // reach a terminal anyway, which is one of the measurements that put terminals out of scope.
+    let ours = try Self.declaration()
+
+    #expect(ours["NSKeyEquivalent"] == nil)
+  }
+
+  @Test("The menu item says what it does, in the user's words")
+  func theMenuItemNamesTheAction() throws {
+    let ours = try Self.declaration()
+    let item = ours["NSMenuItem"] as? [String: Any] ?? [:]
+    let title = try #require(item["default"] as? String)
+
+    #expect(title == "Add to EnviousWispr Words")
+    #expect(!title.contains("\u{2014}"), "GR-NO-DASHES")
+    #expect(!title.contains("\u{2013}"), "GR-NO-DASHES")
+  }
+
+  // MARK: - What we make of a pasteboard
+
+  @Test("Selected text arrives trimmed")
+  func selectedTextArrivesTrimmed() {
+    let pasteboard = NSPasteboard(name: .init(rawValue: "ew.quickAddTest.\(UUID().uuidString)"))
+    pasteboard.clearContents()
+    pasteboard.setString("  codecs \n", forType: .string)
+
+    #expect(QuickAddServiceProvider.text(from: pasteboard) == "codecs")
+  }
+
+  @Test("An empty or whitespace-only pasteboard reads as nothing, not as a selection of spaces")
+  func whitespaceOnlyReadsAsNothing() {
+    for raw in ["", "   ", "\n\t"] {
+      let pasteboard = NSPasteboard(name: .init(rawValue: "ew.quickAddTest.\(UUID().uuidString)"))
+      pasteboard.clearContents()
+      pasteboard.setString(raw, forType: .string)
+
+      #expect(QuickAddServiceProvider.text(from: pasteboard) == nil, "'\(raw)' is not a word")
+    }
+  }
+
+  @Test("A pasteboard with no string at all reads as nothing rather than trapping")
+  func noStringReadsAsNothing() {
+    let pasteboard = NSPasteboard(name: .init(rawValue: "ew.quickAddTest.\(UUID().uuidString)"))
+    pasteboard.clearContents()
+
+    #expect(QuickAddServiceProvider.text(from: pasteboard) == nil)
+  }
+}

--- a/Tests/EnviousWisprTests/App/QuickAddTelemetryPrivacyTests.swift
+++ b/Tests/EnviousWisprTests/App/QuickAddTelemetryPrivacyTests.swift
@@ -1,0 +1,141 @@
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #2381 — the selected word never reaches a vendor.
+///
+/// When this fails, a word someone dictated leaves their Mac. `CLAUDE.md` puts the privacy boundary
+/// at the NETWORK and the test is whether USER CONTENT crosses it — so this asserts on the payload
+/// that would actually be sent, not on the code that builds it.
+///
+/// **The hook is DERIVED from the real property dictionary, not rebuilt beside it.** That is the
+/// #1987 lesson and it is load-bearing here: a projection assembled independently lets a test assert
+/// a property the shipped event does not carry, and worse, an added non-String value would reach
+/// PostHog while a string-only hook silently dropped it — leaving a test named "no raw word" green.
+/// Every typed bucket is checked below for that reason.
+#if DEBUG
+
+  @MainActor
+  @Suite("Quick Add telemetry carries shape, never content — #2381", .tags(.observabilityContract))
+  struct QuickAddTelemetryPrivacyTests {
+
+    /// The word a user selected. Distinctive on purpose: a substring search for it must be able to
+    /// fail loudly rather than collide with an ordinary token.
+    private static let secret = "zzsecretwordzz"
+
+    /// A reference box, because `testEventHook` is `@Sendable` and cannot mutate a captured local.
+    /// It fires synchronously on the emitting actor.
+    private final class EventBox: @unchecked Sendable {
+      var events: [CapturedTelemetryEvent] = []
+    }
+
+    private func captureEvents(_ body: () -> Void) -> [CapturedTelemetryEvent] {
+      let box = EventBox()
+      TelemetryService.shared.testEventHook = { box.events.append($0) }
+      defer { TelemetryService.shared.testEventHook = nil }
+      body()
+      return box.events
+    }
+
+    /// Every value in an event, across all four typed buckets, as strings.
+    ///
+    /// Projecting only `stringProps` is how a leak becomes invisible: a word smuggled in as any other
+    /// type would pass a string-only sweep while still reaching the vendor.
+    private func allValues(_ event: CapturedTelemetryEvent) -> [String] {
+      event.stringProps.values.map { $0 }
+        + event.intProps.values.map { "\($0)" }
+        + event.doubleProps.values.map { "\($0)" }
+        + event.boolProps.values.map { "\($0)" }
+    }
+
+    @Test("The opened event carries the word's LENGTH and never the word")
+    func openedCarriesLengthNotContent() throws {
+      let events = captureEvents {
+        TelemetryService.shared.quickAddOpened(
+          door: "hotkey", hadSelection: true, refuseReason: nil, candidateCount: 3,
+          preselected: true, topScore: 0.8631, sourceBundleID: "com.apple.TextEdit",
+          heardLength: Self.secret.unicodeScalars.count)
+      }
+
+      let event = try #require(events.first { $0.name == "quick_add.opened" })
+      for value in allValues(event) {
+        #expect(!value.contains(Self.secret), "the selected word reached PostHog in: \(value)")
+      }
+      #expect(event.intProps["heard_length"] == Self.secret.unicodeScalars.count)
+    }
+
+    @Test("The resolved event carries no content either")
+    func resolvedCarriesNoContent() throws {
+      let events = captureEvents {
+        TelemetryService.shared.quickAddResolved(
+          outcome: "accepted", usedSearch: true, candidateRank: 0, targetKind: "user_word",
+          elapsedMilliseconds: 1200)
+      }
+
+      let event = try #require(events.first { $0.name == "quick_add.resolved" })
+      for value in allValues(event) {
+        #expect(!value.contains(Self.secret))
+      }
+    }
+
+    @Test("The source app's bundle id IS sent, and that is the decision not an oversight")
+    func theBundleIDIsSent() throws {
+      // Resolved against the rules rather than escalated: the boundary is the network and the test is
+      // whether USER CONTENT crosses it. A bundle id names an APP, not anything the user wrote, and the
+      // delivery path already sends one. Without it, "which apps is this used in" is unanswerable, and
+      // that is the question that decides whether terminals are worth revisiting.
+      let events = captureEvents {
+        TelemetryService.shared.quickAddOpened(
+          door: "service", hadSelection: true, refuseReason: nil, candidateCount: 1,
+          preselected: false, topScore: 0.4, sourceBundleID: "com.apple.TextEdit", heardLength: 6)
+      }
+
+      let event = try #require(events.first)
+      #expect(event.stringProps["source_bundle_id"] == "com.apple.TextEdit")
+    }
+
+    @Test("An unknown app and an absent score are named, not omitted")
+    func absentValuesAreNamed() throws {
+      // A missing property and a property meaning "none" are different facts, and a consumer cannot
+      // tell them apart after the fact. `top_score` is genuinely absent when nothing was ranked.
+      let events = captureEvents {
+        TelemetryService.shared.quickAddOpened(
+          door: "hotkey", hadSelection: false, refuseReason: "selection_unavailable",
+          candidateCount: 0, preselected: false, topScore: nil, sourceBundleID: nil, heardLength: 0)
+      }
+
+      let event = try #require(events.first)
+      #expect(event.stringProps["source_bundle_id"] == "unknown")
+      #expect(event.stringProps["refuse_reason"] == "selection_unavailable")
+      #expect(event.doubleProps["top_score"] == nil, "nothing was ranked, so there is no score")
+    }
+
+    @Test("A successful read reports no refusal reason rather than omitting the field")
+    func aSuccessfulReadNamesNoReason() throws {
+      let events = captureEvents {
+        TelemetryService.shared.quickAddOpened(
+          door: "hotkey", hadSelection: true, refuseReason: nil, candidateCount: 2,
+          preselected: true, topScore: 0.9, sourceBundleID: "com.apple.TextEdit", heardLength: 6)
+      }
+
+      #expect(try #require(events.first).stringProps["refuse_reason"] == "none")
+    }
+
+    @Test("The score ships as a real number, rounded but not bucketed")
+    func theScoreShipsRaw() throws {
+      // Bucketing would destroy the only signal that says whether the confidence bar is set right,
+      // which is the number this feature will actually be tuned on. Two decimals is the resolution the
+      // sweep was reported at.
+      let events = captureEvents {
+        TelemetryService.shared.quickAddOpened(
+          door: "hotkey", hadSelection: true, refuseReason: nil, candidateCount: 3,
+          preselected: true, topScore: 0.8631, sourceBundleID: "com.apple.TextEdit", heardLength: 6)
+      }
+
+      #expect(try #require(events.first).doubleProps["top_score"] == 0.86)
+    }
+  }
+
+#endif

--- a/Tests/EnviousWisprTests/PostProcessing/QuickAddRankerTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/QuickAddRankerTests.swift
@@ -1,0 +1,344 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPostProcessing
+
+/// #2381 — the ranking policy behind Quick Add's one-keypress accept.
+///
+/// When this fails the user selects a misheard word, presses Return once, and the spelling lands
+/// on the wrong entry — or lands nowhere while the panel looked confident. Both are silent: the
+/// library is written correctly-shaped, and the next dictation comes out wrong.
+///
+/// **Every score asserted here was measured with the shipped scorer**, canonical-only so each
+/// fixture reproduces exactly (`WordCorrector.score`, weights 0.40/0.40/0.20). No number in this
+/// file was estimated.
+///
+/// **The bar itself cannot be tested AT its boundary with real words.** 400,000 random pairs and
+/// every shipped pack spelling against every pack canonical (1,928 x 391)
+/// produced ZERO pairs scoring exactly 0.55, so the `>=` case is unreachable by a value test. The
+/// two sides are tested instead, against the named constant rather than a literal, so moving the
+/// bar moves the test with it.
+@Suite("QuickAddRanker — #2381 which saved word does this mishearing belong to", .tags(.productOutcome))
+struct QuickAddRankerTests {
+
+  let ranker = QuickAddRanker()
+  let corrector = WordCorrector()
+
+  /// `Codex` as the user saved it, with the `codecs` spelling NOT yet on it — which is the only
+  /// state a user is ever in when they reach for Quick Add.
+  static let codex = CustomWord(canonical: "Codex")
+  /// The shipped pack term that outscores it: `codecs` vs `codec` = 0.8889, vs `Codex` = 0.7333.
+  static let codecPack = CustomWord(canonical: "codec", source: .pack)
+
+  // MARK: - The user's own words outrank the packs
+
+  @Test("A user's own word wins even when a pack term scores higher — the #2381 ship-blocker")
+  func userWordOutranksAHigherScoringPackTerm() {
+    let ranking = ranker.rank(
+      heard: "codecs", userWords: [Self.codex], packTerms: [Self.codecPack])
+
+    #expect(ranking.candidates.first?.word.canonical == "Codex")
+    #expect(ranking.preselected?.word.canonical == "Codex")
+
+    // The assertion that makes this discriminate: the pack term really does score HIGHER, so a
+    // ranker that merged one pool would preselect `codec` and this test would go red.
+    let userScore = corrector.score("codecs", against: "codex")
+    let packScore = corrector.score("codecs", against: "codec")
+    #expect(packScore > userScore, "fixture no longer reproduces the case it was built for")
+    #expect(!ranking.candidates.contains { $0.isPackTerm })
+  }
+
+  @Test("A pack term is consulted only when no user word clears the bar")
+  func packTermsEnterOnlyBelowTheBar() {
+    // `dkr` vs `Docker` = 0.4000, below the bar; the pack's `Docker` copy carries the spelling and
+    // so scores 1.0. With the user word below the bar, the pack is allowed to win.
+    let userWord = CustomWord(canonical: "Docker")
+    let packWord = CustomWord(canonical: "Dockerfile", aliases: ["dkr"], source: .pack)
+
+    let ranking = ranker.rank(heard: "dkr", userWords: [userWord], packTerms: [packWord])
+
+    #expect(corrector.score("dkr", against: "docker") < QuickAddRanker.confidenceBar)
+    #expect(ranking.candidates.first?.word.canonical == "Dockerfile")
+    #expect(ranking.candidates.first?.isPackTerm == true)
+  }
+
+  @Test("A pack term below the best user word does not displace it")
+  func aWeakerPackTermNeverDisplacesTheUserWord() {
+    // Both below the bar, user word higher. Packs are consulted and must lose.
+    let userWord = CustomWord(canonical: "Docker")
+    let packWord = CustomWord(canonical: "Zocor", source: .pack)
+
+    let ranking = ranker.rank(heard: "dkr", userWords: [userWord], packTerms: [packWord])
+
+    let userScore = corrector.score("dkr", against: "docker")
+    let packScore = corrector.score("dkr", against: "zocor")
+    #expect(userScore < QuickAddRanker.confidenceBar, "fixture must sit below the bar")
+    #expect(packScore < userScore, "fixture must have the pack losing on raw score")
+    #expect(ranking.candidates.first?.word.canonical == "Docker")
+    #expect(ranking.preselectedID == nil, "nothing clears the bar, so Return must write nothing")
+  }
+
+  // MARK: - The confidence bar
+
+  @Test("Below the bar the list still renders and NOTHING owns Return")
+  func belowTheBarNothingIsPreselected() {
+    let ranking = ranker.rank(
+      heard: "dkr", userWords: [CustomWord(canonical: "Docker")], packTerms: [])
+
+    #expect(corrector.score("dkr", against: "docker") < QuickAddRanker.confidenceBar)
+    #expect(!ranking.candidates.isEmpty, "the user still gets a list to pick from")
+    #expect(ranking.preselectedID == nil)
+    #expect(ranking.preselected == nil)
+  }
+
+  @Test("Above the bar the top row owns Return")
+  func aboveTheBarTheTopRowIsPreselected() {
+    // `mongo` vs `MongoDB` = 0.6057.
+    let ranking = ranker.rank(
+      heard: "mongo", userWords: [CustomWord(canonical: "MongoDB")], packTerms: [])
+
+    #expect(corrector.score("mongo", against: "mongodb") >= QuickAddRanker.confidenceBar)
+    #expect(ranking.preselected?.word.canonical == "MongoDB")
+  }
+
+  @Test("An exact match is preselected")
+  func anExactMatchIsPreselected() {
+    let ranking = ranker.rank(
+      heard: "codex", userWords: [Self.codex], packTerms: [])
+
+    #expect(ranking.topScore == 1.0)
+    #expect(ranking.preselected?.word.canonical == "Codex")
+  }
+
+  // MARK: - Nothing to rank
+
+  @Test("An empty library ranks nothing and preselects nothing")
+  func anEmptyLibraryRanksNothing() {
+    let ranking = ranker.rank(heard: "codecs", userWords: [], packTerms: [])
+
+    #expect(ranking.candidates.isEmpty)
+    #expect(ranking.preselectedID == nil)
+    #expect(ranking.topScore == nil)
+  }
+
+  @Test("A heard string matching nothing preselects nothing")
+  func noMatchPreselectsNothing() {
+    // `banana` vs `Docker` = 0.0000.
+    let ranking = ranker.rank(
+      heard: "banana", userWords: [CustomWord(canonical: "Docker")], packTerms: [])
+
+    #expect(ranking.topScore == 0)
+    #expect(ranking.preselectedID == nil)
+  }
+
+  @Test("An empty or whitespace-only selection ranks nothing rather than everything")
+  func whitespaceOnlySelectionRanksNothing() {
+    for heard in ["", "   ", "\n\t "] {
+      let ranking = ranker.rank(heard: heard, userWords: [Self.codex], packTerms: [])
+      #expect(ranking.candidates.isEmpty, "'\(heard)' must rank nothing")
+      #expect(ranking.preselectedID == nil)
+    }
+  }
+
+  @Test("Case and surrounding whitespace do not change the ranking")
+  func selectionNormalizationIsIdempotent() {
+    // A drag-select routinely picks up a trailing space; it must not cost a match.
+    let plain = ranker.rank(heard: "codecs", userWords: [Self.codex], packTerms: [])
+    let messy = ranker.rank(heard: "  Codecs\n", userWords: [Self.codex], packTerms: [])
+
+    #expect(messy == plain)
+  }
+
+  // MARK: - Already saved
+
+  @Test("A word that already carries the heard spelling is flagged rather than written again")
+  func alreadySavedIsFlagged() {
+    let saved = CustomWord(canonical: "Codex", aliases: ["codecs"])
+    let other = CustomWord(canonical: "Claude Code")
+
+    let ranking = ranker.rank(heard: "codecs", userWords: [saved, other], packTerms: [])
+
+    #expect(ranking.candidates.first?.word.canonical == "Codex")
+    #expect(ranking.candidates.first?.alreadyHasHeardSpelling == true)
+    #expect(ranking.candidates.last?.alreadyHasHeardSpelling == false)
+  }
+
+  @Test("The flag reads the canonical too, not only the spellings")
+  func alreadySavedMatchesTheCanonical() {
+    let ranking = ranker.rank(heard: "Codex", userWords: [Self.codex], packTerms: [])
+
+    #expect(ranking.candidates.first?.alreadyHasHeardSpelling == true)
+  }
+
+  // MARK: - The search field, which is the escape hatch
+
+  @Test("Search reaches a term the heard ranking suppressed")
+  func searchReachesASuppressedTerm() {
+    // `rank` hides `codec` entirely, because a user word cleared the bar. If search inherited that
+    // suppression the escape hatch would be shut in exactly the case it exists for.
+    let ranked = ranker.rank(heard: "codecs", userWords: [Self.codex], packTerms: [Self.codecPack])
+    #expect(!ranked.candidates.contains { $0.word.canonical == "codec" })
+
+    let found = ranker.search(
+      query: "codec", heard: "codecs", userWords: [Self.codex], packTerms: [Self.codecPack])
+    #expect(found.candidates.contains { $0.word.canonical == "codec" })
+  }
+
+  @Test("Search ranks by the query and flags 'already saved' against the HEARD spelling")
+  func searchSeparatesTheQueryFromTheHeardSpelling() throws {
+    // The panel writes the heard spelling, never the query. The two strings differ here so a
+    // ranker that conflated them would flag the wrong row.
+    let saved = CustomWord(canonical: "Codex", aliases: ["codecs"])
+
+    let found = ranker.search(
+      query: "codex", heard: "codecs", userWords: [saved], packTerms: [])
+
+    let row = try #require(found.candidates.first)
+    #expect(row.word.canonical == "Codex")
+    #expect(row.alreadyHasHeardSpelling == true, "flagged for 'codecs', which is what gets written")
+  }
+
+  @Test("An empty search query returns nothing, so the caller falls back to the heard ranking")
+  func anEmptySearchQueryReturnsNothing() {
+    let found = ranker.search(
+      query: "  ", heard: "codecs", userWords: [Self.codex], packTerms: [Self.codecPack])
+
+    #expect(found.candidates.isEmpty)
+    #expect(found.preselectedID == nil)
+  }
+
+  @Test("The first search result owns Return even when it scores below the bar")
+  func searchResultsAreAlwaysAcceptable() {
+    // The bar governs a ranking the user did not ask for. A list they typed is one they chose, so
+    // the row is acceptable even though `dkr` scores 0.4000 against `Docker`.
+    let found = ranker.search(
+      query: "dock", heard: "dkr", userWords: [CustomWord(canonical: "Docker")], packTerms: [])
+
+    #expect(corrector.score("dkr", against: "docker") < QuickAddRanker.confidenceBar)
+    #expect(found.preselected?.word.canonical == "Docker")
+    #expect(found.topScore == corrector.score("dkr", against: "docker"),
+            "a search row scores against what gets WRITTEN, not against what was typed")
+  }
+
+  @Test("A query matching nothing returns no rows, so Return writes nothing")
+  func aQueryMatchingNothingReturnsNothing() {
+    // The reason search filters instead of fuzzy-ranking. Fuzzy scoring gives EVERY word some
+    // score, so it can never be empty: a query matching nothing would still render rows with the
+    // first owning Return, and one keypress would write onto a word nobody looked for.
+    let found = ranker.search(
+      query: "xylophone",
+      heard: "codecs",
+      userWords: [Self.codex, CustomWord(canonical: "Docker")],
+      packTerms: [Self.codecPack])
+
+    #expect(found.candidates.isEmpty)
+    #expect(found.preselectedID == nil)
+  }
+
+  @Test("A fragment reaches a longer word, which is what a search field is for")
+  func aFragmentReachesALongerWord() {
+    // `kub` scores poorly against `Kubernetes` under edit distance precisely because it is a
+    // fragment, so a fuzzy search would bury the one word the user is typing towards.
+    let kubernetes = CustomWord(canonical: "Kubernetes")
+    let found = ranker.search(
+      query: "kub", heard: "kubernetties", userWords: [kubernetes], packTerms: [])
+
+    #expect(found.candidates.first?.word.canonical == "Kubernetes")
+    #expect(corrector.score("kub", against: "kubernetes") < QuickAddRanker.confidenceBar,
+            "fixture must be one a fuzzy search would have missed")
+  }
+
+  @Test("Search matches a saved spelling, not only the canonical")
+  func searchMatchesSpellings() {
+    let word = CustomWord(canonical: "Kubernetes", aliases: ["kates"])
+    let found = ranker.search(query: "kate", heard: "kubernetties", userWords: [word], packTerms: [])
+
+    #expect(found.candidates.first?.word.canonical == "Kubernetes")
+  }
+
+  @Test("Exact beats a canonical prefix, which beats a spelling prefix, which beats a substring")
+  func matchTiersAreOrdered() {
+    let exact = CustomWord(canonical: "code")
+    let canonicalPrefix = CustomWord(canonical: "codex")
+    let spellingPrefix = CustomWord(canonical: "Zulu", aliases: ["coder"])
+    let substring = CustomWord(canonical: "barcode")
+
+    let found = ranker.search(
+      query: "code",
+      heard: "codecs",
+      userWords: [substring, spellingPrefix, canonicalPrefix, exact],
+      packTerms: [],
+      limit: 10)
+
+    #expect(found.candidates.map(\.word.canonical) == ["code", "codex", "Zulu", "barcode"])
+  }
+
+  // MARK: - Structure
+
+  @Test("A user override of a pack term is rendered once, as the user's copy")
+  func aUserOverrideOfAPackTermIsNotRenderedTwice() {
+    // `CustomWord.ownedByUser()` PRESERVES the id, so the moment Quick Add converts a pack term
+    // the same id sits in both populations. Two rows with one id give SwiftUI duplicate
+    // `Identifiable` ids and make a preselected id ambiguous.
+    let packTerm = CustomWord(canonical: "codec", source: .pack)
+    var override = packTerm.ownedByUser()
+    override.aliases = ["codecs"]
+    #expect(override.id == packTerm.id, "the collision this test exists for must still be real")
+
+    let found = ranker.search(
+      query: "codec", heard: "codecs", userWords: [override], packTerms: [packTerm])
+
+    #expect(found.candidates.filter { $0.id == packTerm.id }.count == 1)
+    #expect(found.candidates.first { $0.id == packTerm.id }?.isPackTerm == false)
+  }
+
+  @Test("The limit bounds the rows shown without changing which row wins")
+  func theLimitBoundsTheRowsShown() {
+    let library = (0..<20).map { CustomWord(canonical: "Docker\($0)") }
+
+    let short = ranker.rank(heard: "docker0", userWords: library, packTerms: [], limit: 3)
+    let long = ranker.rank(heard: "docker0", userWords: library, packTerms: [], limit: 10)
+
+    #expect(short.candidates.count == 3)
+    #expect(long.candidates.count == 10)
+    #expect(short.candidates.first?.id == long.candidates.first?.id)
+    #expect(short.preselectedID == long.preselectedID)
+  }
+
+  @Test("A zero or negative limit shows nothing rather than trapping")
+  func aNonPositiveLimitShowsNothing() {
+    for limit in [0, -1] {
+      let ranking = ranker.rank(
+        heard: "codecs", userWords: [Self.codex], packTerms: [], limit: limit)
+      #expect(ranking.candidates.isEmpty)
+      #expect(ranking.preselectedID == nil, "no row is on screen, so Return must write nothing")
+    }
+  }
+
+  @Test("Equal scores order the user's word first and stay put across calls")
+  func tiesAreOrderedAndStable() {
+    // Two words scoring identically must not swap between redraws: a reorder under a highlight
+    // changes what Return accepts without the user touching anything.
+    let userWord = CustomWord(canonical: "codec")
+    let packWord = CustomWord(canonical: "codec", source: .pack)
+
+    let first = ranker.search(
+      query: "codec", heard: "codecs", userWords: [userWord], packTerms: [packWord])
+    let second = ranker.search(
+      query: "codec", heard: "codecs", userWords: [userWord], packTerms: [packWord])
+
+    #expect(first.candidates.map(\.id) == second.candidates.map(\.id))
+    #expect(first.candidates.first?.isPackTerm == false, "the user's own word leads a tie")
+  }
+
+  @Test("The preselected id is always a row that is on screen")
+  func thePreselectedRowIsAlwaysVisible() {
+    let library = (0..<20).map { CustomWord(canonical: "Docker\($0)") }
+    let ranking = ranker.rank(heard: "docker0", userWords: library, packTerms: [], limit: 2)
+
+    guard let id = ranking.preselectedID else { return }
+    #expect(ranking.candidates.contains { $0.id == id })
+    #expect(ranking.preselected != nil)
+  }
+}

--- a/Tests/EnviousWisprTests/PostProcessing/QuickAddRankerTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/QuickAddRankerTests.swift
@@ -14,11 +14,12 @@ import Testing
 /// fixture reproduces exactly (`WordCorrector.score`, weights 0.40/0.40/0.20). No number in this
 /// file was estimated.
 ///
-/// **The bar itself cannot be tested AT its boundary with real words.** 400,000 random pairs and
-/// every shipped pack spelling against every pack canonical (1,928 x 391)
-/// produced ZERO pairs scoring exactly 0.55, so the `>=` case is unreachable by a value test. The
-/// two sides are tested instead, against the named constant rather than a literal, so moving the
-/// bar moves the test with it.
+/// **No real string SCORES exactly 0.55** — 400,000 random pairs and every shipped pack spelling
+/// against every pack canonical (1,928 x 391) produced none — so no fixture can sit on the
+/// boundary. That is a fact about the scorer's reachable values, not about the boundary, which is a
+/// property of the comparison and is asserted directly through `clearsConfidenceBar`. The measured
+/// VALUE is pinned separately, because tests written against the named constant move with it and
+/// would not notice the bar being changed.
 @Suite("QuickAddRanker — #2381 which saved word does this mishearing belong to", .tags(.productOutcome))
 struct QuickAddRankerTests {
 
@@ -332,13 +333,86 @@ struct QuickAddRankerTests {
     #expect(first.candidates.first?.isPackTerm == false, "the user's own word leads a tie")
   }
 
+  @Test("Two entries alike on every ordering key keep their order when the input is reversed")
+  func tiesSurviveAReversedInput() {
+    // Same score, same source, same canonical — the case the comparator used to leave to
+    // `Array.sorted`. Repeating one input order cannot observe it; reversing the input can.
+    let a = CustomWord(canonical: "codec")
+    let b = CustomWord(canonical: "codec")
+
+    let forward = ranker.search(query: "codec", heard: "codecs", userWords: [a, b], packTerms: [])
+    let reversed = ranker.search(query: "codec", heard: "codecs", userWords: [b, a], packTerms: [])
+
+    #expect(forward.candidates.count == 2)
+    #expect(forward.candidates.map(\.id) == reversed.candidates.map(\.id))
+    #expect(forward.preselectedID == reversed.preselectedID)
+  }
+
+  @Test("The heard ranking resolves the same tie the same way in both input orders")
+  func rankedTiesSurviveAReversedInput() {
+    let a = CustomWord(canonical: "codec")
+    let b = CustomWord(canonical: "codec")
+
+    let forward = ranker.rank(heard: "codecs", userWords: [a, b], packTerms: [])
+    let reversed = ranker.rank(heard: "codecs", userWords: [b, a], packTerms: [])
+
+    #expect(forward.candidates.map(\.id) == reversed.candidates.map(\.id))
+    #expect(forward.preselectedID == reversed.preselectedID)
+  }
+
   @Test("The preselected id is always a row that is on screen")
-  func thePreselectedRowIsAlwaysVisible() {
+  func thePreselectedRowIsAlwaysVisible() throws {
     let library = (0..<20).map { CustomWord(canonical: "Docker\($0)") }
     let ranking = ranker.rank(heard: "docker0", userWords: library, packTerms: [], limit: 2)
 
-    guard let id = ranking.preselectedID else { return }
+    // `try #require`, never a `guard ... else { return }`: the early return made this pass against
+    // a ranker that preselected NOTHING, which is the one break it exists to catch.
+    let id = try #require(ranking.preselectedID)
     #expect(ranking.candidates.contains { $0.id == id })
     #expect(ranking.preselected != nil)
+  }
+
+  @Test("A ranking cannot carry a highlight on a row that is not on screen")
+  func anIdNamingNoVisibleRowIsDropped() {
+    let visible = QuickAddRanker.Candidate(
+      word: Self.codex, score: 1, alreadyHasHeardSpelling: false)
+
+    let ranking = QuickAddRanker.Ranking(candidates: [visible], preselectedID: UUID())
+
+    #expect(ranking.preselectedID == nil, "a highlight nobody can see would still accept on Return")
+    #expect(ranking.preselected == nil)
+  }
+
+  // MARK: - The bar's value and its boundary
+
+  @Test("The confidence bar is the measured value, not whatever the constant currently says")
+  func theConfidenceBarIsTheMeasuredValue() {
+    // Every other bar test compares against the named constant, so all of them move with it. This
+    // is the one that does not: 0.55 is the lowest value at which confident-and-wrong is zero on
+    // the user's own words in BOTH the warm and cold arms of the 1,648-mishearing sweep. Changing
+    // it needs that sweep re-run, and this line is what makes the change say so.
+    #expect(QuickAddRanker.confidenceBar == 0.55)
+  }
+
+  @Test("A score exactly AT the bar clears it")
+  func theBoundaryIsInclusive() {
+    // No fixture can reach 0.55 through the scorer, so the boundary is asserted where it lives.
+    #expect(QuickAddRanker.clearsConfidenceBar(QuickAddRanker.confidenceBar))
+    #expect(!QuickAddRanker.clearsConfidenceBar(QuickAddRanker.confidenceBar.nextDown))
+    #expect(QuickAddRanker.clearsConfidenceBar(QuickAddRanker.confidenceBar.nextUp))
+  }
+
+  @Test("A library of only pack terms still renders a list")
+  func aPackOnlyLibraryStillRenders() {
+    // A brand-new user has no saved words. With `banana` scoring 0.0000 against `Docker`, a
+    // strictly-greater test against a best user score of zero admitted nothing, so this user saw an
+    // empty panel while everyone else saw their own zero-scoring rows.
+    let ranking = ranker.rank(
+      heard: "banana", userWords: [], packTerms: [CustomWord(canonical: "Docker", source: .pack)])
+
+    #expect(corrector.score("banana", against: "docker") == 0)
+    #expect(ranking.candidates.count == 1)
+    #expect(ranking.candidates.first?.isPackTerm == true)
+    #expect(ranking.preselectedID == nil, "nothing scored, so Return must still write nothing")
   }
 }

--- a/Tests/EnviousWisprTests/Services/HotkeyQuickAddShortcutTests.swift
+++ b/Tests/EnviousWisprTests/Services/HotkeyQuickAddShortcutTests.swift
@@ -188,6 +188,36 @@ struct HotkeyQuickAddShortcutTests {
     #expect(sink.cancels == 0)
   }
 
+  @Test("One cancel gesture does not also open Quick Add when the other side is held")
+  func aConsumedCancelGestureDoesNotFallThroughToQuickAdd() async {
+    // `.command` is AGGREGATE and device-independent: with Left Command held, releasing Right
+    // Command leaves it set, so the release re-enters reading exactly like a press. Cancel closes
+    // its own double-fire by disarming — correct, and precisely what lets the NEXT claimant of this
+    // key take the re-entry. With both bound to it, one cancel gesture discarded the recording and
+    // opened the panel on the way out.
+    let (service, sink, quickAdd, cancel, _) = makeService(
+      recordKey: chordKeyCode, cancelKey: rightCommand, quickAddKey: rightCommand)
+    service.registerCancelHotkey()
+
+    service.handleFlagsChangedValues(keyCode: rightCommand, flags: .command)
+    await cancel.wait()
+    #expect(sink.cancels == 1)
+
+    // Right Command physically UP, Left still down, so the flag survives.
+    service.handleFlagsChangedValues(keyCode: rightCommand, flags: .command)
+
+    #expect(sink.quickAdds == 0, "the tail of a consumed cancel is not a Quick Add gesture")
+    #expect(sink.cancels == 1, "and it is not a second cancel either")
+
+    // PAIRED POSITIVE, and without it "swallow this key forever" passes everything above. The
+    // aggregate flag dropping is the only evidence the gesture is over; after that the key is live.
+    service.handleFlagsChangedValues(keyCode: rightCommand, flags: [])
+    service.handleFlagsChangedValues(keyCode: rightCommand, flags: .command)
+    await quickAdd.wait()
+
+    #expect(sink.quickAdds == 1, "swallowing is bounded to the one gesture, not to the key")
+  }
+
   @Test("A Quick Add modifier that is part of the record chord is refused, not accepted")
   func quickAddSharingTheRecordChordIsRefused() async {
     // Accepting would open a panel that TAKES KEY FOCUS the instant the user pressed the first
@@ -348,7 +378,8 @@ struct HotkeyQuickAddShortcutTests {
     // if it ever collided", which is a different defect.
     #expect(
       HotkeyService.quickAddMayHoldItsChord(
-        isEnabled: true, isSuspended: false, quickAdd: shared, cancel: shared, isCancelArmed: false))
+        isEnabled: true, isSuspended: false, quickAdd: shared, cancel: shared, isCancelArmed: false)
+    )
   }
 
   @Test("A chord cancel does not share is Quick Add's whether or not a recording is running")
@@ -360,7 +391,8 @@ struct HotkeyQuickAddShortcutTests {
 
     #expect(
       HotkeyService.quickAddMayHoldItsChord(
-        isEnabled: true, isSuspended: false, quickAdd: quickAdd, cancel: cancel, isCancelArmed: true))
+        isEnabled: true, isSuspended: false, quickAdd: quickAdd, cancel: cancel, isCancelArmed: true
+      ))
   }
 
   @Test("A stopped or suspended service holds no Quick Add chord, collision or not")

--- a/Tests/EnviousWisprTests/Services/HotkeyQuickAddShortcutTests.swift
+++ b/Tests/EnviousWisprTests/Services/HotkeyQuickAddShortcutTests.swift
@@ -330,4 +330,53 @@ struct HotkeyQuickAddShortcutTests {
     #expect(sink.presses.last?.trigger == "toggle_hotkey")
     #expect(sink.presses.last?.keyShape == "modifier_only")
   }
+  // MARK: - A chord two roles share (#2381 review r2)
+
+  @Test("Cancel outranks Quick Add on a shared chord, for as long as cancel is armed")
+  func cancelWinsASharedChord() {
+    // `RegisterEventHotKey` REFUSES a duplicate chord, and Quick Add registers at start() and holds
+    // it for the whole session — so with both bound to one chord, cancel arrives second during a
+    // recording, is refused, and the user's cancel key opens the Quick Add panel while the recording
+    // keeps running. The bare-modifier matcher already refused this by checking Quick Add last; the
+    // Carbon path had no answer at all.
+    let shared = ShortcutBinding.keyboard(keyCode: 53, modifiers: [])
+
+    #expect(
+      !HotkeyService.quickAddMayHoldItsChord(
+        isEnabled: true, isSuspended: false, quickAdd: shared, cancel: shared, isCancelArmed: true))
+    // Disarmed, the chord is Quick Add's again. Without this the fix would be "Quick Add never works
+    // if it ever collided", which is a different defect.
+    #expect(
+      HotkeyService.quickAddMayHoldItsChord(
+        isEnabled: true, isSuspended: false, quickAdd: shared, cancel: shared, isCancelArmed: false))
+  }
+
+  @Test("A chord cancel does not share is Quick Add's whether or not a recording is running")
+  func differentChordsDoNotContend() {
+    // The paired accepted case. A rule that refused whenever cancel was armed would pass the test
+    // above and break Quick Add for every user who never rebound anything.
+    let quickAdd = ShortcutBinding.keyboard(keyCode: 13, modifiers: [.control, .option])
+    let cancel = ShortcutBinding.keyboard(keyCode: 53, modifiers: [])
+
+    #expect(
+      HotkeyService.quickAddMayHoldItsChord(
+        isEnabled: true, isSuspended: false, quickAdd: quickAdd, cancel: cancel, isCancelArmed: true))
+  }
+
+  @Test("A stopped or suspended service holds no Quick Add chord, collision or not")
+  func stoppedOrSuspendedHoldsNothing() {
+    let quickAdd = ShortcutBinding.keyboard(keyCode: 13, modifiers: [.control, .option])
+    let cancel = ShortcutBinding.keyboard(keyCode: 53, modifiers: [])
+
+    #expect(
+      !HotkeyService.quickAddMayHoldItsChord(
+        isEnabled: false, isSuspended: false, quickAdd: quickAdd, cancel: cancel,
+        isCancelArmed: false))
+    // Suspended is the shortcut recorder being open. Holding a chord then is what makes a rebind
+    // capture our own hotkey instead of the user's keypress.
+    #expect(
+      !HotkeyService.quickAddMayHoldItsChord(
+        isEnabled: true, isSuspended: true, quickAdd: quickAdd, cancel: cancel,
+        isCancelArmed: false))
+  }
 }

--- a/Tests/EnviousWisprTests/Services/HotkeyQuickAddShortcutTests.swift
+++ b/Tests/EnviousWisprTests/Services/HotkeyQuickAddShortcutTests.swift
@@ -223,6 +223,80 @@ struct HotkeyQuickAddShortcutTests {
     #expect(sink.cancels == 0)
   }
 
+  // MARK: - Installation, which every dispatch test above is blind to
+
+  @Test("A bare-modifier Quick Add installs the modifier monitors")
+  func bareModifierQuickAddInstallsMonitors() {
+    // #1991 BLOCKER 2, REPRODUCED BY #2381 AND CAUGHT HERE. The install condition was a hand-written
+    // disjunction over record and cancel, so this exact configuration — a bare-modifier Quick Add
+    // paired with a chord record key and a chord cancel key, which is the DEFAULT shape for both —
+    // installed no monitor at all and left the shortcut stored, displayed, and completely inert.
+    //
+    // Every dispatch case in this suite drives `handleFlagsChangedValues` directly and so passes
+    // against that build, which is precisely why #1991's original tests could not see it either.
+    // This asserts the DECISION, not the `NSEvent` objects: the monitor objects say nothing about
+    // whether the right question was asked.
+    let (service, _, _, _, _) = makeService(
+      recordKey: chordKeyCode, recordModifiers: [.command],
+      cancelKey: 53, quickAddKey: rightCommand)
+
+    #expect(service.recordBinding.isBareModifier == false)
+    #expect(service.cancelBinding.isBareModifier == false)
+    #expect(service.quickAddBinding.isBareModifier == true)
+    #expect(service.shouldInstallModifierMonitors, "no monitor means the shortcut is inert")
+  }
+
+  @Test("Chords everywhere install no monitors")
+  func chordsEverywhereInstallNoMonitors() {
+    // The paired negative. Without it, a condition returning true for everything would look clean.
+    let (service, _, _, _, _) = makeService(
+      recordKey: chordKeyCode, recordModifiers: [.command],
+      cancelKey: 53, quickAddKey: wKeyCode, quickAddModifiers: [.control, .option])
+
+    #expect(service.shouldInstallModifierMonitors == false)
+    #expect(service.bareModifierRoleAtRisk == nil)
+  }
+
+  @Test("The role that dies without monitors is the most severe one bound to a bare modifier")
+  func theRoleAtRiskIsTheMostSevereOne() {
+    // The field holds ONE value and it labels the failure telemetry, so the answer must be the
+    // biggest loss: record kills dictation, cancel kills aborting one, Quick Add is a limb.
+    let (allThree, _, _, _, _) = makeService(
+      recordKey: rightOption, cancelKey: rightCommand, quickAddKey: ModifierKeyCodes.rightShift)
+    #expect(allThree.bareModifierRoleAtRisk == .record)
+
+    let (cancelAndQuickAdd, _, _, _, _) = makeService(
+      recordKey: chordKeyCode, recordModifiers: [.command],
+      cancelKey: rightCommand, quickAddKey: ModifierKeyCodes.rightShift)
+    #expect(cancelAndQuickAdd.bareModifierRoleAtRisk == .cancel)
+
+    let (quickAddOnly, _, _, _, _) = makeService(
+      recordKey: chordKeyCode, recordModifiers: [.command],
+      cancelKey: 53, quickAddKey: rightCommand)
+    #expect(
+      quickAddOnly.bareModifierRoleAtRisk == .quickAdd,
+      "a dead Quick Add reported as a dead cancel shortcut names the wrong subject")
+  }
+
+  @Test("Every role has its own telemetry name, and record keeps the one production sends")
+  func telemetryKindsAreDistinctAndStable() {
+    // `record` is "toggle" on the wire since #1175. Renaming it would split every existing
+    // breakdown, so this pins it rather than leaving it to look like an inconsistency worth tidying.
+    #expect(ShortcutRole.record.telemetryKind == "toggle")
+    #expect(ShortcutRole.cancel.telemetryKind == "cancel")
+    #expect(ShortcutRole.quickAdd.telemetryKind == "quick_add")
+
+    let names = ShortcutRole.allCases.map(\.telemetryKind)
+    #expect(Set(names).count == names.count, "two roles sharing a name make the field ambiguous")
+  }
+
+  @Test("Role declaration order is severity order, which the risk answer depends on")
+  func roleOrderIsSeverityOrder() {
+    // `bareModifierRoleAtRisk` takes the FIRST matching case, so reordering this enum silently
+    // relabels that telemetry instead of failing to compile. Pinned here so it cannot.
+    #expect(ShortcutRole.allCases == [.record, .cancel, .quickAdd])
+  }
+
   // MARK: - Telemetry names the right subject
 
   @Test("A Quick Add press reports ITS OWN key shape, not the record key's")

--- a/Tests/EnviousWisprTests/Services/HotkeyQuickAddShortcutTests.swift
+++ b/Tests/EnviousWisprTests/Services/HotkeyQuickAddShortcutTests.swift
@@ -1,0 +1,259 @@
+import AppKit
+import EnviousWisprCore
+import EnviousWisprServices
+import Foundation
+import Testing
+
+/// #2381 — the Quick Add shortcut, on both mechanisms.
+///
+/// When this fails the user presses their Quick Add key and one of three things happens, all of
+/// them silent: nothing at all, a RECORDING STARTS instead of the panel opening, or the shortcut is
+/// stored and displayed while being completely inert. The third is #1991 verbatim, which is why
+/// this suite exercises a bare modifier at all — the default is a chord, and a suite that only
+/// tested the default would pass a build that is dead for anyone who rebinds.
+///
+/// **The dangerous shape is the fall-through.** Before this change the bare-modifier dispatch read
+/// `if role == .cancel { … return }` and then ran the record path, so a role the matcher resolved
+/// and the dispatch did not name started a recording. An `if` over an enum asserts nothing about
+/// the members it omits, and it compiles perfectly.
+@MainActor
+@Suite("Quick Add shortcut — #2381", .tags(.productOutcome))
+struct HotkeyQuickAddShortcutTests {
+
+  private let rightCommand = ModifierKeyCodes.rightCommand
+  private let rightOption = ModifierKeyCodes.rightOption
+  /// `kVK_ANSI_D` — a plain chord record key, the shape that hid #1991's second blocker.
+  private let chordKeyCode: UInt16 = 2
+  /// `kVK_ANSI_W`, the Quick Add default.
+  private let wKeyCode: UInt16 = 13
+
+  /// The Carbon id Quick Add registers under.
+  ///
+  /// A literal because `handleCarbonHotkey(id:isRelease:)` takes a raw `UInt32` — the id IS the
+  /// wire contract with Carbon, not an internal detail, so a test that could not name it would be
+  /// testing something other than what the OS delivers.
+  private let quickAddCarbonID: UInt32 = 4
+
+  @MainActor final class Sink {
+    var quickAdds = 0
+    var cancels = 0
+    var toggles = 0
+    var presses: [(trigger: String, keyShape: String, action: String)] = []
+  }
+
+  /// Signal-based wait: the callback IS the signal, with a deadline only so a regression fails with
+  /// a test name instead of hanging. A test that hangs on the defect it exists to catch reports
+  /// nothing at all.
+  @MainActor final class Waiter {
+    private var fired = false
+    private var pending: (id: UUID, continuation: CheckedContinuation<Void, Never>)?
+
+    func note() {
+      fired = true
+      guard let pending else { return }
+      self.pending = nil
+      pending.continuation.resume()
+    }
+
+    func wait(timeout: Duration = .seconds(5)) async {
+      if fired { return }
+      let id = UUID()
+      let timeoutTask = Task { @MainActor [weak self] in
+        // settle: deadline fallback around the callback signal; the callback cancels this
+        try? await Task.sleep(for: timeout)
+        self?.expire(id: id)
+      }
+      await withCheckedContinuation { continuation in pending = (id, continuation) }
+      timeoutTask.cancel()
+    }
+
+    private func expire(id: UUID) {
+      guard let pending, pending.id == id else { return }
+      self.pending = nil
+      Issue.record(Comment(rawValue: "timed out waiting for the callback"))
+      pending.continuation.resume()
+    }
+  }
+
+  private func makeService(
+    recordKey: UInt16,
+    recordModifiers: NSEvent.ModifierFlags = [],
+    cancelKey: UInt16,
+    quickAddKey: UInt16,
+    quickAddModifiers: NSEvent.ModifierFlags = []
+  ) -> (HotkeyService, Sink, Waiter, Waiter, Waiter) {
+    let sink = Sink()
+    let quickAddWaiter = Waiter()
+    let cancelWaiter = Waiter()
+    let toggleWaiter = Waiter()
+    let service = HotkeyService(
+      telemetry: HotkeyTelemetrySink(
+        registrationFailed: { _, _, _, _ in },
+        pressed: { trigger, _, keyShape, _, action in
+          sink.presses.append((trigger, keyShape, action))
+        }))
+    service.recordingMode = .toggle
+    service.toggleKeyCode = recordKey
+    service.toggleModifiers = recordModifiers
+    service.cancelKeyCode = cancelKey
+    service.cancelModifiers = []
+    service.quickAddKeyCode = quickAddKey
+    service.quickAddModifiers = quickAddModifiers
+    service.onQuickAdd = {
+      sink.quickAdds += 1
+      quickAddWaiter.note()
+    }
+    service.onCancelRecording = {
+      sink.cancels += 1
+      cancelWaiter.note()
+    }
+    service.onToggleRecording = {
+      sink.toggles += 1
+      toggleWaiter.note()
+    }
+    return (service, sink, quickAddWaiter, cancelWaiter, toggleWaiter)
+  }
+
+  /// A modifier press: the flag is PRESENT on press and ABSENT on release, the shape real hardware
+  /// produces (measured for #1987). Asserting on set membership instead would prove the key is
+  /// accepted and nothing about what pressing it does.
+  private func press(_ service: HotkeyService, _ keyCode: UInt16) {
+    guard let flag = ModifierKeyCodes.flag(for: keyCode) else {
+      Issue.record("\(keyCode) is not a modifier key code")
+      return
+    }
+    service.handleFlagsChangedValues(keyCode: keyCode, flags: flag)
+  }
+
+  private func release(_ service: HotkeyService, _ keyCode: UInt16) {
+    service.handleFlagsChangedValues(keyCode: keyCode, flags: [])
+  }
+
+  // MARK: - The fall-through
+
+  @Test("A bare-modifier Quick Add opens Quick Add and does NOT start a recording")
+  func bareModifierQuickAddDoesNotStartARecording() async {
+    // The defect this suite exists for. With the dispatch written as `if role == .cancel`, this
+    // press fell through to the record path and began dictating.
+    let (service, sink, quickAdd, _, _) = makeService(
+      recordKey: chordKeyCode, cancelKey: 53, quickAddKey: rightCommand)
+
+    press(service, rightCommand)
+    await quickAdd.wait()
+
+    #expect(sink.quickAdds == 1)
+    #expect(sink.toggles == 0, "a Quick Add press must never start a recording")
+    #expect(sink.cancels == 0)
+  }
+
+  @Test("A modifier RELEASE is not a Quick Add gesture")
+  func releaseDoesNotFireQuickAdd() async {
+    let (service, sink, _, _, _) = makeService(
+      recordKey: chordKeyCode, cancelKey: 53, quickAddKey: rightCommand)
+
+    release(service, rightCommand)
+    await Task.yield()
+
+    #expect(sink.quickAdds == 0)
+  }
+
+  // MARK: - Ordering against cancel
+
+  @Test("While a recording is running, a shared binding cancels rather than opening Quick Add")
+  func cancelOutranksQuickAddWhileArmed() async {
+    // Quick Add is armed at ALL times and cancel only during a recording, so ordering Quick Add
+    // first would take the stop key away for the whole of every recording.
+    let (service, sink, _, cancel, _) = makeService(
+      recordKey: chordKeyCode, cancelKey: rightCommand, quickAddKey: rightCommand)
+    service.registerCancelHotkey()
+
+    press(service, rightCommand)
+    await cancel.wait()
+
+    #expect(sink.cancels == 1)
+    #expect(sink.quickAdds == 0, "cancel must win while it is armed")
+  }
+
+  @Test("With no recording running, the same shared binding opens Quick Add")
+  func quickAddWinsWhenCancelIsNotArmed() async {
+    // The other half of the ordering: behind cancel, Quick Add still gets every moment cancel is
+    // not armed, so a shared binding costs the user nothing they had before.
+    let (service, sink, quickAdd, _, _) = makeService(
+      recordKey: chordKeyCode, cancelKey: rightCommand, quickAddKey: rightCommand)
+
+    press(service, rightCommand)
+    await quickAdd.wait()
+
+    #expect(sink.quickAdds == 1)
+    #expect(sink.cancels == 0)
+  }
+
+  @Test("A Quick Add modifier that is part of the record chord is refused, not accepted")
+  func quickAddSharingTheRecordChordIsRefused() async {
+    // Accepting would open a panel that TAKES KEY FOCUS the instant the user pressed the first
+    // half of their record chord, so the rest of the chord lands in the panel and the recording
+    // never happens. The same refusal cancel makes, for the same reason one step over.
+    let (service, sink, _, _, _) = makeService(
+      recordKey: chordKeyCode, recordModifiers: [.command], cancelKey: 53,
+      quickAddKey: rightCommand)
+
+    press(service, rightCommand)
+    await Task.yield()
+
+    #expect(sink.quickAdds == 0, "ambiguous with starting the record chord")
+    #expect(sink.toggles == 0)
+  }
+
+  // MARK: - The Carbon path, which the DEFAULT chord takes
+
+  @Test("The Carbon hotkey fires Quick Add on press and not on release")
+  func carbonDispatchFiresQuickAdd() async {
+    let (service, sink, quickAdd, _, _) = makeService(
+      recordKey: rightOption, cancelKey: 53, quickAddKey: wKeyCode,
+      quickAddModifiers: [.control, .option])
+
+    service.handleCarbonHotkey(id: quickAddCarbonID, isRelease: true)
+    await Task.yield()
+    #expect(sink.quickAdds == 0, "a key release is not a gesture")
+
+    service.handleCarbonHotkey(id: quickAddCarbonID, isRelease: false)
+    await quickAdd.wait()
+    #expect(sink.quickAdds == 1)
+    #expect(sink.toggles == 0)
+    #expect(sink.cancels == 0)
+  }
+
+  // MARK: - Telemetry names the right subject
+
+  @Test("A Quick Add press reports ITS OWN key shape, not the record key's")
+  func telemetryReportsTheQuickAddKeyShape() async {
+    // The binary collapse this change removed: `trigger == .cancel ? cancelKeyCode : toggleKeyCode`
+    // absorbed any new member into the toggle branch, so a Quick Add press reported the RECORD
+    // key's shape. Record is modifier-only here and Quick Add is a chord, so the two disagree.
+    let (service, sink, quickAdd, _, _) = makeService(
+      recordKey: rightOption, cancelKey: 53, quickAddKey: wKeyCode,
+      quickAddModifiers: [.control, .option])
+
+    service.handleCarbonHotkey(id: quickAddCarbonID, isRelease: false)
+    await quickAdd.wait()
+
+    let press = sink.presses.last
+    #expect(press?.trigger == "quick_add_hotkey")
+    #expect(press?.action == "quick_add")
+    #expect(press?.keyShape == "chord", "reported the record key's modifier_only shape")
+  }
+
+  @Test("A record press still reports the record key's shape")
+  func telemetryStillReportsTheRecordKeyShape() async {
+    // The paired case. A switch that answered "chord" for everything would satisfy the test above.
+    let (service, sink, _, _, toggle) = makeService(
+      recordKey: rightOption, cancelKey: 53, quickAddKey: wKeyCode,
+      quickAddModifiers: [.control, .option])
+
+    press(service, rightOption)
+    await toggle.wait()
+
+    #expect(sink.presses.last?.trigger == "toggle_hotkey")
+    #expect(sink.presses.last?.keyShape == "modifier_only")
+  }
+}

--- a/Tests/EnviousWisprTests/Services/SelectionReaderTests.swift
+++ b/Tests/EnviousWisprTests/Services/SelectionReaderTests.swift
@@ -64,25 +64,65 @@ struct SelectionReaderTests {
 
   @Test("A selection comes back as text")
   func aSelectionIsReturned() {
-    #expect(SelectionReader.resolve(error: .success, value: "codecs") == .text("codecs"))
+    #expect(SelectionReader.resolve(error: .success, value: "codecs" as CFString) == .text("codecs"))
   }
 
   @Test("A selection is trimmed, because a drag routinely picks up the surrounding space")
   func aSelectionIsTrimmed() {
-    #expect(SelectionReader.resolve(error: .success, value: "  codecs \n") == .text("codecs"))
+    #expect(SelectionReader.resolve(error: .success, value: "  codecs \n" as CFString) == .text("codecs"))
   }
 
   @Test("Whitespace only is nothing selected, not a selection of spaces")
   func whitespaceOnlyIsNoSelection() {
     for value in ["", " ", "\n", "\t  \n"] {
-      #expect(SelectionReader.resolve(error: .success, value: value) == .noSelection)
+      #expect(SelectionReader.resolve(error: .success, value: value as CFString) == .noSelection)
     }
   }
 
-  @Test("A successful read with no string is nothing selected")
+  @Test("A lot of whitespace is still nothing selected, not a selection that is too long")
+  func longWhitespaceIsNoSelectionNotTooLong() {
+    // Measuring before trimming reported this as `selectionTooLong`, which tells the user their
+    // selection was too big when they had not selected anything at all.
+    let padding = String(repeating: " ", count: SelectionReader.maximumSelectionScalars * 2)
+
+    #expect(SelectionReader.resolve(error: .success, value: padding as CFString) == .noSelection)
+  }
+
+  @Test("A short word dragged with a lot of surrounding space is accepted, not refused for length")
+  func aPaddedShortSelectionIsAccepted() {
+    // The ceiling bounds what gets STORED, and what gets stored is the trimmed string. Measuring
+    // the untrimmed one refuses a word that would have fitted easily.
+    let padding = String(repeating: " ", count: SelectionReader.maximumSelectionScalars)
+    let padded = padding + "codecs" + padding
+
+    #expect(padded.unicodeScalars.count > SelectionReader.maximumSelectionScalars)
+    #expect(SelectionReader.resolve(error: .success, value: padded as CFString) == .text("codecs"))
+  }
+
+  @Test("A successful read with no value at all is nothing selected")
   func successWithNoStringIsNoSelection() {
     // The attribute answered; it just had nothing in it. Distinct from `noValue`, which did not.
     #expect(SelectionReader.resolve(error: .success, value: nil) == .noSelection)
+  }
+
+  @Test("An attribute that answers with something other than text is unreadable, not empty")
+  func aNonStringAnswerIsUnreadable() {
+    // `as? String` alone would turn every one of these into nil, and nil reads as "nothing
+    // selected" — a broken element reported to the user as an empty selection.
+    let notStrings: [CFTypeRef] = [
+      NSNumber(value: 42), kCFBooleanTrue, [1, 2, 3] as CFArray, Data() as CFData,
+    ]
+    for value in notStrings {
+      #expect(
+        SelectionReader.resolve(error: .success, value: value) == .refused(.unreadable),
+        "a \(CFCopyTypeIDDescription(CFGetTypeID(value)) as String? ?? "?") answer must not read as an empty selection")
+    }
+
+    // The paired ACCEPTED case, in the same test rather than a duplicate of `aSelectionIsReturned`:
+    // a type check that refused everything would satisfy the loop above and look clean.
+    #expect(
+      SelectionReader.resolve(error: .success, value: "codecs" as CFString) == .text("codecs"),
+      "the type check must not be refusing every answer")
   }
 
   @Test("An element that does not expose selected text says so")
@@ -114,7 +154,7 @@ struct SelectionReaderTests {
   @Test("An error wins over a value, so a stale string cannot be offered as a selection")
   func anErrorIsNotOverriddenByAValue() {
     #expect(
-      SelectionReader.resolve(error: .cannotComplete, value: "codecs") == .refused(.unreadable))
+      SelectionReader.resolve(error: .cannotComplete, value: "codecs" as CFString) == .refused(.unreadable))
   }
 
   // MARK: - Too long to be a word
@@ -125,14 +165,14 @@ struct SelectionReaderTests {
     let tooLong = String(repeating: "a", count: SelectionReader.maximumSelectionScalars + 1)
 
     #expect(
-      SelectionReader.resolve(error: .success, value: tooLong) == .refused(.selectionTooLong))
+      SelectionReader.resolve(error: .success, value: tooLong as CFString) == .refused(.selectionTooLong))
   }
 
   @Test("A selection exactly at the store's ceiling is accepted")
   func aSelectionAtTheCeilingIsAccepted() {
     let atLimit = String(repeating: "a", count: SelectionReader.maximumSelectionScalars)
 
-    #expect(SelectionReader.resolve(error: .success, value: atLimit) == .text(atLimit))
+    #expect(SelectionReader.resolve(error: .success, value: atLimit as CFString) == .text(atLimit))
   }
 
   @Test("The ceiling is the store's own, not a number invented here")
@@ -155,12 +195,12 @@ struct SelectionReaderTests {
 
     let underCeiling = String(repeating: family, count: SelectionReader.maximumSelectionScalars / 5)
     #expect(underCeiling.unicodeScalars.count <= SelectionReader.maximumSelectionScalars)
-    #expect(SelectionReader.resolve(error: .success, value: underCeiling) == .text(underCeiling))
+    #expect(SelectionReader.resolve(error: .success, value: underCeiling as CFString) == .text(underCeiling))
 
     let overCeiling = underCeiling + family
     #expect(overCeiling.unicodeScalars.count > SelectionReader.maximumSelectionScalars)
     #expect(
-      SelectionReader.resolve(error: .success, value: overCeiling) == .refused(.selectionTooLong),
+      SelectionReader.resolve(error: .success, value: overCeiling as CFString) == .refused(.selectionTooLong),
       "the ceiling counted characters rather than scalars")
   }
 

--- a/Tests/EnviousWisprTests/Services/SelectionReaderTests.swift
+++ b/Tests/EnviousWisprTests/Services/SelectionReaderTests.swift
@@ -215,4 +215,55 @@ struct SelectionReaderTests {
     #expect(Set(names).count == names.count)
     #expect(names.allSatisfy { !$0.isEmpty })
   }
+  // MARK: - One owner for what a selection IS (#2381 review r1)
+
+  @Test("Whitespace-only text is nothing selected, whichever door handed it over")
+  func classifyTreatsWhitespaceAsNoSelection() {
+    // Door B reached the coordinator with raw pasteboard text and none of this applied, so a
+    // whitespace-only Service selection opened a panel on an empty string with no stated reason.
+    #expect(SelectionReader.classify("   ") == .noSelection)
+    #expect(SelectionReader.classify("\n\t ") == .noSelection)
+    #expect(SelectionReader.classify("") == .noSelection)
+  }
+
+  @Test("The store's ceiling applies to handed text too, and it is measured after trimming")
+  func classifyAppliesTheCeiling() {
+    let atCeiling = String(repeating: "a", count: SelectionReader.maximumSelectionScalars)
+    let overCeiling = atCeiling + "a"
+
+    #expect(SelectionReader.classify(atCeiling) == .text(atCeiling))
+    #expect(SelectionReader.classify(overCeiling) == .refused(.selectionTooLong))
+    // Padded but short: trimming first is what stops surrounding space refusing a real word.
+    #expect(SelectionReader.classify("   codecs   ") == .text("codecs"))
+  }
+
+  @Test("No reader outcome is wordsUnavailable — that member has a different producer")
+  func noReadOutcomeIsWordsUnavailable() {
+    // `Refusal` is the panel's one reason line AND the telemetry refuse_reason, so it holds a case
+    // the reader cannot produce. Asserting the boundary is what keeps that from decaying into "the
+    // reader might return anything in here".
+    var seen: [SelectionReader.Result] = [
+      SelectionReader.classify(""),
+      SelectionReader.classify("codecs"),
+      SelectionReader.classify(String(repeating: "a", count: 9999)),
+      SelectionReader.resolve(error: .attributeUnsupported, value: nil),
+      SelectionReader.resolve(error: .noValue, value: nil),
+      SelectionReader.resolve(error: .cannotComplete, value: nil),
+      SelectionReader.resolve(error: .success, value: nil),
+      SelectionReader.resolve(error: .success, value: NSNumber(value: 7)),
+      SelectionReader.resolve(error: .success, value: "codecs" as CFString),
+    ]
+    for refusal in [
+      SelectionReader.refusalBeforeReading(isTrusted: false, frontmostPID: 1),
+      SelectionReader.refusalBeforeReading(isTrusted: true, frontmostPID: nil),
+      SelectionReader.refusalBeforeReading(isTrusted: true, frontmostPID: 0),
+    ] {
+      if let refusal { seen.append(.refused(refusal)) }
+    }
+
+    #expect(!seen.contains(.refused(.wordsUnavailable)))
+    // Paired positive: a sweep that produced no refusals at all would pass the line above.
+    #expect(seen.contains { if case .refused = $0 { true } else { false } })
+  }
+
 }

--- a/Tests/EnviousWisprTests/Services/SelectionReaderTests.swift
+++ b/Tests/EnviousWisprTests/Services/SelectionReaderTests.swift
@@ -1,0 +1,178 @@
+import ApplicationServices
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprServices
+
+/// #2381 — how one Accessibility answer becomes what the user is told.
+///
+/// When this fails the user presses the shortcut and the panel says the wrong thing: it claims a
+/// selection that is not there, silently does nothing where it should name a reason, or offers a
+/// string the word library will refuse to store. The panel opening on a stated reason instead of a
+/// silent no-op is the whole failure contract of this feature.
+///
+/// **No `AXUIElement` is fabricated anywhere here**, deliberately. `PasteService` keeps live AX
+/// round trips out of unit tests and asserts on pure decisions, and a hand-built element would test
+/// our idea of Accessibility rather than Accessibility. The error values are the REAL ones —
+/// `AXError` cases, not integers copied from a header — so a renamed case fails to compile rather
+/// than passing against the wrong branch.
+@Suite("SelectionReader — #2381 reading the user's selection", .tags(.productOutcome))
+struct SelectionReaderTests {
+
+  // MARK: - Before any read is attempted
+
+  @Test("Without Accessibility the reason is the one the user can act on")
+  func untrustedIsNamed() {
+    #expect(
+      SelectionReader.refusalBeforeReading(isTrusted: false, frontmostPID: 501)
+        == .accessibilityNotTrusted)
+  }
+
+  @Test("Trust is checked before the frontmost app, because it is the one the user can fix")
+  func untrustedOutranksAMissingFrontmostApp() {
+    // Both wrong at once. Reporting "no frontmost application" to someone who simply has not
+    // granted permission sends them looking at the wrong thing.
+    #expect(
+      SelectionReader.refusalBeforeReading(isTrusted: false, frontmostPID: nil)
+        == .accessibilityNotTrusted)
+  }
+
+  @Test("No frontmost application is its own reason")
+  func noFrontmostApplicationIsNamed() {
+    #expect(
+      SelectionReader.refusalBeforeReading(isTrusted: true, frontmostPID: nil)
+        == .noFrontmostApplication)
+  }
+
+  @Test("A non-positive pid is refused rather than passed to Accessibility")
+  func aNonPositivePIDIsRefused() {
+    for pid: pid_t in [0, -1] {
+      #expect(
+        SelectionReader.refusalBeforeReading(isTrusted: true, frontmostPID: pid)
+          == .noFrontmostApplication,
+        "pid \(pid) must not reach Accessibility")
+    }
+  }
+
+  @Test("Trusted with a live application goes ahead")
+  func trustedAndFrontmostProceeds() {
+    #expect(SelectionReader.refusalBeforeReading(isTrusted: true, frontmostPID: 501) == nil)
+  }
+
+  // MARK: - What Accessibility answered
+
+  @Test("A selection comes back as text")
+  func aSelectionIsReturned() {
+    #expect(SelectionReader.resolve(error: .success, value: "codecs") == .text("codecs"))
+  }
+
+  @Test("A selection is trimmed, because a drag routinely picks up the surrounding space")
+  func aSelectionIsTrimmed() {
+    #expect(SelectionReader.resolve(error: .success, value: "  codecs \n") == .text("codecs"))
+  }
+
+  @Test("Whitespace only is nothing selected, not a selection of spaces")
+  func whitespaceOnlyIsNoSelection() {
+    for value in ["", " ", "\n", "\t  \n"] {
+      #expect(SelectionReader.resolve(error: .success, value: value) == .noSelection)
+    }
+  }
+
+  @Test("A successful read with no string is nothing selected")
+  func successWithNoStringIsNoSelection() {
+    // The attribute answered; it just had nothing in it. Distinct from `noValue`, which did not.
+    #expect(SelectionReader.resolve(error: .success, value: nil) == .noSelection)
+  }
+
+  @Test("An element that does not expose selected text says so")
+  func unsupportedIsNamed() {
+    #expect(
+      SelectionReader.resolve(error: .attributeUnsupported, value: nil)
+        == .refused(.selectionUnsupported))
+  }
+
+  @Test("The terminal case is kept apart from the unsupported one")
+  func noValueIsItsOwnRefusal() {
+    // Measured in Ghostty with text visibly highlighted: the attribute IS advertised in the
+    // element's attribute names and still answers `noValue` with a zero-length range. Collapsing
+    // this into `selectionUnsupported` would hide a whole class of app that reports a selection it
+    // will not hand over — which is why terminals are out of scope rather than merely unlucky.
+    #expect(
+      SelectionReader.resolve(error: .noValue, value: nil) == .refused(.selectionUnavailable))
+  }
+
+  @Test("Any other Accessibility error is unreadable rather than silently nothing")
+  func otherErrorsAreUnreadable() {
+    for error: AXError in [.invalidUIElement, .cannotComplete, .failure, .notImplemented] {
+      #expect(
+        SelectionReader.resolve(error: error, value: nil) == .refused(.unreadable),
+        "\(error) must not read as an empty selection")
+    }
+  }
+
+  @Test("An error wins over a value, so a stale string cannot be offered as a selection")
+  func anErrorIsNotOverriddenByAValue() {
+    #expect(
+      SelectionReader.resolve(error: .cannotComplete, value: "codecs") == .refused(.unreadable))
+  }
+
+  // MARK: - Too long to be a word
+
+  @Test("A selection longer than the store will accept is refused, not truncated")
+  func anOverlongSelectionIsRefused() {
+    // Truncating would silently save a different word than the user selected. Refusing says so.
+    let tooLong = String(repeating: "a", count: SelectionReader.maximumSelectionScalars + 1)
+
+    #expect(
+      SelectionReader.resolve(error: .success, value: tooLong) == .refused(.selectionTooLong))
+  }
+
+  @Test("A selection exactly at the store's ceiling is accepted")
+  func aSelectionAtTheCeilingIsAccepted() {
+    let atLimit = String(repeating: "a", count: SelectionReader.maximumSelectionScalars)
+
+    #expect(SelectionReader.resolve(error: .success, value: atLimit) == .text(atLimit))
+  }
+
+  @Test("The ceiling is the store's own, not a number invented here")
+  func theCeilingIsTheStoresOwn() {
+    // Pinning the SOURCE, not the value: a selection the reader accepts and the store refuses
+    // would open a confident panel over a word that cannot be saved.
+    #expect(
+      SelectionReader.maximumSelectionScalars
+        == CustomWordsImportLimits.maximumStoredValueScalars)
+  }
+
+  @Test("The ceiling counts scalars, which is neither characters nor bytes")
+  func lengthIsMeasuredInScalars() {
+    // One family emoji is a SINGLE Character, five scalars, and twenty-five UTF-8 bytes, so the
+    // three counts disagree by a lot. Counting characters would let a selection through that the
+    // store then refuses; counting bytes would refuse selections a user can legitimately save.
+    let family = "👨‍👩‍👧"
+    #expect(family.count == 1)
+    #expect(family.unicodeScalars.count == 5)
+
+    let underCeiling = String(repeating: family, count: SelectionReader.maximumSelectionScalars / 5)
+    #expect(underCeiling.unicodeScalars.count <= SelectionReader.maximumSelectionScalars)
+    #expect(SelectionReader.resolve(error: .success, value: underCeiling) == .text(underCeiling))
+
+    let overCeiling = underCeiling + family
+    #expect(overCeiling.unicodeScalars.count > SelectionReader.maximumSelectionScalars)
+    #expect(
+      SelectionReader.resolve(error: .success, value: overCeiling) == .refused(.selectionTooLong),
+      "the ceiling counted characters rather than scalars")
+  }
+
+  // MARK: - The closed set
+
+  @Test("Every refusal has a distinct telemetry name")
+  func refusalNamesAreUnique() {
+    // The raw values are BOTH the copy key and the telemetry `refuse_reason`. Two reasons sharing
+    // a name makes a dashboard disagree with what the user was told, silently.
+    let names = SelectionReader.Refusal.allCases.map(\.rawValue)
+
+    #expect(Set(names).count == names.count)
+    #expect(names.allSatisfy { !$0.isEmpty })
+  }
+}

--- a/Tests/EnviousWisprTests/Services/SelectionReaderTests.swift
+++ b/Tests/EnviousWisprTests/Services/SelectionReaderTests.swift
@@ -64,12 +64,14 @@ struct SelectionReaderTests {
 
   @Test("A selection comes back as text")
   func aSelectionIsReturned() {
-    #expect(SelectionReader.resolve(error: .success, value: "codecs" as CFString) == .text("codecs"))
+    #expect(
+      SelectionReader.resolve(error: .success, value: "codecs" as CFString) == .text("codecs"))
   }
 
   @Test("A selection is trimmed, because a drag routinely picks up the surrounding space")
   func aSelectionIsTrimmed() {
-    #expect(SelectionReader.resolve(error: .success, value: "  codecs \n" as CFString) == .text("codecs"))
+    #expect(
+      SelectionReader.resolve(error: .success, value: "  codecs \n" as CFString) == .text("codecs"))
   }
 
   @Test("Whitespace only is nothing selected, not a selection of spaces")
@@ -115,7 +117,8 @@ struct SelectionReaderTests {
     for value in notStrings {
       #expect(
         SelectionReader.resolve(error: .success, value: value) == .refused(.unreadable),
-        "a \(CFCopyTypeIDDescription(CFGetTypeID(value)) as String? ?? "?") answer must not read as an empty selection")
+        "a \(CFCopyTypeIDDescription(CFGetTypeID(value)) as String? ?? "?") answer must not read as an empty selection"
+      )
     }
 
     // The paired ACCEPTED case, in the same test rather than a duplicate of `aSelectionIsReturned`:
@@ -154,7 +157,8 @@ struct SelectionReaderTests {
   @Test("An error wins over a value, so a stale string cannot be offered as a selection")
   func anErrorIsNotOverriddenByAValue() {
     #expect(
-      SelectionReader.resolve(error: .cannotComplete, value: "codecs" as CFString) == .refused(.unreadable))
+      SelectionReader.resolve(error: .cannotComplete, value: "codecs" as CFString)
+        == .refused(.unreadable))
   }
 
   // MARK: - Too long to be a word
@@ -165,7 +169,8 @@ struct SelectionReaderTests {
     let tooLong = String(repeating: "a", count: SelectionReader.maximumSelectionScalars + 1)
 
     #expect(
-      SelectionReader.resolve(error: .success, value: tooLong as CFString) == .refused(.selectionTooLong))
+      SelectionReader.resolve(error: .success, value: tooLong as CFString)
+        == .refused(.selectionTooLong))
   }
 
   @Test("A selection exactly at the store's ceiling is accepted")
@@ -195,12 +200,15 @@ struct SelectionReaderTests {
 
     let underCeiling = String(repeating: family, count: SelectionReader.maximumSelectionScalars / 5)
     #expect(underCeiling.unicodeScalars.count <= SelectionReader.maximumSelectionScalars)
-    #expect(SelectionReader.resolve(error: .success, value: underCeiling as CFString) == .text(underCeiling))
+    #expect(
+      SelectionReader.resolve(error: .success, value: underCeiling as CFString)
+        == .text(underCeiling))
 
     let overCeiling = underCeiling + family
     #expect(overCeiling.unicodeScalars.count > SelectionReader.maximumSelectionScalars)
     #expect(
-      SelectionReader.resolve(error: .success, value: overCeiling as CFString) == .refused(.selectionTooLong),
+      SelectionReader.resolve(error: .success, value: overCeiling as CFString)
+        == .refused(.selectionTooLong),
       "the ceiling counted characters rather than scalars")
   }
 
@@ -237,11 +245,17 @@ struct SelectionReaderTests {
     #expect(SelectionReader.classify("   codecs   ") == .text("codecs"))
   }
 
-  @Test("No reader outcome is wordsUnavailable — that member has a different producer")
-  func noReadOutcomeIsWordsUnavailable() {
-    // `Refusal` is the panel's one reason line AND the telemetry refuse_reason, so it holds a case
+  @Test("No reader outcome is a coordinator-owned refusal — those members have other producers")
+  func noReadOutcomeIsCoordinatorOwned() {
+    // `Refusal` is the panel's one reason line AND the telemetry refuse_reason, so it holds cases
     // the reader cannot produce. Asserting the boundary is what keeps that from decaying into "the
     // reader might return anything in here".
+    //
+    // TWO members now, and the second is why this asserts a SET rather than a name. `nothingSelected`
+    // is minted by the coordinator from `.noSelection`, exactly as `wordsUnavailable` is minted from
+    // a failed refresh — and it exists because mapping `.noSelection` onto `selectionUnavailable`
+    // handed the commonest refusal a sentence blaming the frontmost app for withholding a selection.
+    let coordinatorOwned: [SelectionReader.Refusal] = [.wordsUnavailable, .nothingSelected]
     var seen: [SelectionReader.Result] = [
       SelectionReader.classify(""),
       SelectionReader.classify("codecs"),
@@ -261,8 +275,10 @@ struct SelectionReaderTests {
       if let refusal { seen.append(.refused(refusal)) }
     }
 
-    #expect(!seen.contains(.refused(.wordsUnavailable)))
-    // Paired positive: a sweep that produced no refusals at all would pass the line above.
+    for owned in coordinatorOwned {
+      #expect(!seen.contains(.refused(owned)), "the reader minted \(owned), which it does not own")
+    }
+    // Paired positive: a sweep that produced no refusals at all would pass every line above.
     #expect(seen.contains { if case .refused = $0 { true } else { false } })
   }
 

--- a/Tests/EnviousWisprTests/Services/SettingsDefaultsRoutingTests.swift
+++ b/Tests/EnviousWisprTests/Services/SettingsDefaultsRoutingTests.swift
@@ -121,6 +121,60 @@ struct SettingsDefaultsRoutingTests {
     #expect(matchingChanges == 1)
   }
 
+  // MARK: - Quick Add's shortcut (#2381)
+
+  @Test("Quick Add ships on Control-Option-W and belongs to unified defaults")
+  func quickAddShortcutDefaults() {
+    let suite = Self.freshSuite()
+    let settings = SettingsManager(defaults: suite)
+
+    // W (13), not a modifier: the default is deliberately a CHORD, so it takes the Carbon path and
+    // nobody who has never heard of the feature reaches it by accident.
+    #expect(settings.quickAddKeyCode == 13)
+    #expect(settings.quickAddModifiers == [.control, .option])
+    #expect(
+      SettingsManager.unifiedDefaultsKeys.filter { $0 == "quickAddKeyCode" }.count == 1,
+      "missing from unified keys means it never migrates to the shared suite (#923)")
+    #expect(
+      SettingsManager.unifiedDefaultsKeys.filter { $0 == "quickAddModifiersRaw" }.count == 1)
+  }
+
+  @Test("A rebound Quick Add shortcut survives a relaunch")
+  func quickAddShortcutPersists() {
+    // The requirement nothing else covers: rebinding is the whole point for a one-handed user, and
+    // a binding that works until quit is indistinguishable from one that works.
+    let suite = Self.freshSuite()
+    let settings = SettingsManager(defaults: suite)
+
+    settings.quickAddKeyCode = 2  // D
+    settings.quickAddModifiers = [.command, .shift]
+
+    #expect(suite.object(forKey: "quickAddKeyCode") as? Int == 2)
+    let reloaded = SettingsManager(defaults: suite)
+    #expect(reloaded.quickAddKeyCode == 2)
+    #expect(reloaded.quickAddModifiers == [.command, .shift])
+  }
+
+  @Test("Each half of the Quick Add binding emits its own SettingKey exactly once")
+  func quickAddShortcutNotifies() {
+    // Without the notification the value persists and never reaches registration — a shortcut that
+    // is stored, displayed, and inert (#1991).
+    let settings = SettingsManager(defaults: Self.freshSuite())
+    var keyCodeChanges = 0
+    var modifierChanges = 0
+
+    settings.onChange = { key in
+      if case .quickAddKeyCode = key { keyCodeChanges += 1 }
+      if case .quickAddModifiers = key { modifierChanges += 1 }
+    }
+
+    settings.quickAddKeyCode = 2
+    settings.quickAddModifiers = [.command]
+
+    #expect(keyCodeChanges == 1)
+    #expect(modifierChanges == 1)
+  }
+
   @Test("Smart insertion change emits its SettingKey exactly once")
   func smartInsertionNotifies() {
     let settings = SettingsManager(defaults: Self.freshSuite())

--- a/Tests/EnviousWisprTests/Views/KeybindRowDefaultsTests.swift
+++ b/Tests/EnviousWisprTests/Views/KeybindRowDefaultsTests.swift
@@ -81,6 +81,20 @@ struct KeybindRowDefaultsTests {
     #expect(settings.quickAddModifiers == ShortcutRole.quickAdd.defaultModifiers)
   }
 
+  @MainActor
+  @Test("A newly constructed service carries the shipped shortcuts, before any settings arrive")
+  func serviceFallbacksMatchTheOwner() {
+    // The gap that hid an incomplete migration: converting one fallback and leaving two produced no
+    // failure anywhere, because no case built a service. A hard-coded fallback is invisible in every
+    // other assertion here — it shows up only as a fresh service holding a stale binding until
+    // `HotkeyController` pushes settings over it.
+    let service = HotkeyService()
+
+    #expect(service.recordBinding == ShortcutRole.record.defaultBinding)
+    #expect(service.cancelBinding == ShortcutRole.cancel.defaultBinding)
+    #expect(service.quickAddBinding == ShortcutRole.quickAdd.defaultBinding)
+  }
+
   // MARK: - No literal creeps back into a row
 
   /// Each row's own source block, keyed by its accessibility label.
@@ -97,7 +111,15 @@ struct KeybindRowDefaultsTests {
       Issue.record(Comment(rawValue: "no ProminentHotkeyRow labelled '\(label)'"))
       return ""
     }
-    return block
+    // COMMENTS STRIPPED, and that is not tidiness. These rows are heavily commented, and a comment
+    // MENTIONING `ShortcutRole.quickAdd.defaultKeyCode` would satisfy every assertion below while
+    // the executable line beneath it held a literal — a guard passing on prose about the thing it
+    // is meant to check. Line comments only; this file has no block comments inside a row.
+    return
+      block
+      .split(separator: "\n", omittingEmptySubsequences: false)
+      .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+      .joined(separator: "\n")
   }
 
   @Test(

--- a/Tests/EnviousWisprTests/Views/KeybindRowDefaultsTests.swift
+++ b/Tests/EnviousWisprTests/Views/KeybindRowDefaultsTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import Testing
 
@@ -6,77 +7,122 @@ import Testing
 /// #2381 — every keybind row's Reset offers the value a fresh install actually gets.
 ///
 /// When this fails the user presses Reset on a shortcut row and lands on a chord that is NOT the
-/// default, so their "back to how it shipped" differs from a colleague's fresh install and from
-/// every screenshot and support answer. It compiles, it looks right, and nothing else notices.
+/// default, so their "back to how it shipped" stops matching a colleague's fresh install, every
+/// screenshot, and every support answer. It compiles, it looks right, and nothing goes red.
 ///
-/// **The row's default is a LITERAL in the view and the real default is a constant in Services**,
-/// with nothing linking the two. That is the shape of a claim that decays without anyone touching
-/// the line: `SettingsDefaultValues` is where a default is CHANGED, and the view is where it is
-/// OFFERED. This is a drift guard, not product coverage — it protects a property of the source,
-/// so it reads the source.
+/// **The first version of this suite was a guard over three hard-coded literals in the view.** It
+/// worked, and it was the wrong shape: a guard fires after the mistake is made, and it left three
+/// unlinked copies of one value in place. `ShortcutRole.defaultBinding` now owns the value and the
+/// view, the service and `SettingsDefaultValues` all read it, so the drift is unwriteable rather
+/// than detected. What survives here is what a constant cannot do for itself: pin the VALUES so
+/// changing one is a conscious act, and keep a literal from creeping back into a row.
 ///
-/// Swept over all THREE rows rather than only the new one: the new row's author is the one person
-/// certain to have checked theirs, and an entity sweep finds wrong statements while a member sweep
-/// finds omissions.
-@Suite("Keybind row defaults match the shipped defaults (#2381)", .tags(.driftGuard))
+/// Swept over all THREE rows, not just the new one — an entity sweep finds wrong statements, a
+/// member sweep finds omissions, and the new row is the one its author is certain to have checked.
+@Suite("Keybind defaults have one owner (#2381)", .tags(.driftGuard))
 struct KeybindRowDefaultsTests {
 
-  private static func viewSource() throws -> String {
+  // MARK: - The values themselves
+
+  @Test("The shipped shortcut for each role is the founder-ratified one")
+  func shippedShortcutsAreTheRatifiedOnes() {
+    #expect(
+      ShortcutRole.record.defaultBinding
+        == .keyboard(keyCode: ModifierKeyCodes.rightOption, modifiers: []))
+    #expect(ShortcutRole.cancel.defaultBinding == .keyboard(keyCode: 53, modifiers: []))
+    #expect(
+      ShortcutRole.quickAdd.defaultBinding
+        == .keyboard(keyCode: 13, modifiers: [.control, .option]))
+  }
+
+  @Test("Quick Add ships as a CHORD, which is what keeps it out of an unsuspecting user's way")
+  func quickAddShipsAsAChord() {
+    // Not a property of the number: a bare modifier would take the NSEvent path AND be reachable by
+    // anyone who rests a finger on it. The persona review's hard requirement is that someone who
+    // has never heard of this feature never triggers it.
+    #expect(ShortcutRole.quickAdd.defaultBinding.isBareModifier == false)
+    #expect(ShortcutRole.quickAdd.defaultBinding.isCarbonRegistrable)
+    // The paired case: record ships as a bare modifier, so this is not a check that passes for
+    // every role.
+    #expect(ShortcutRole.record.defaultBinding.isBareModifier)
+  }
+
+  // MARK: - Everyone reads the owner
+
+  @Test("What a fresh install stores is what the owner says, for all three roles")
+  func storedDefaultsMatchTheOwner() {
+    // True by construction now. Pinned because "by construction" is a property of today's code, and
+    // a future edit that re-inlines a number here would be silent.
+    #expect(SettingsDefaultValues.toggleKeyCode == Int(ShortcutRole.record.defaultKeyCode))
+    #expect(SettingsDefaultValues.toggleModifiersRaw == ShortcutRole.record.defaultModifiers.rawValue)
+    #expect(SettingsDefaultValues.cancelKeyCode == Int(ShortcutRole.cancel.defaultKeyCode))
+    #expect(SettingsDefaultValues.cancelModifiersRaw == ShortcutRole.cancel.defaultModifiers.rawValue)
+    #expect(SettingsDefaultValues.quickAddKeyCode == Int(ShortcutRole.quickAdd.defaultKeyCode))
+    #expect(
+      SettingsDefaultValues.quickAddModifiersRaw == ShortcutRole.quickAdd.defaultModifiers.rawValue)
+  }
+
+  // `@MainActor` on this case alone rather than the suite: `SettingsManager` is main-actor isolated
+  // and the source-reading cases below are not, so hoisting it would isolate tests that do not need
+  // it.
+  @MainActor
+  @Test("A fresh install's live settings are the shipped shortcuts")
+  func aFreshInstallGetsTheShippedShortcuts() {
+    // The end-to-end version of the above, through the object the app actually reads. Ephemeral
+    // suite so nothing touches the host process.
+    let name = "ew.keybindDefaultsTest." + UUID().uuidString
+    let suite = UserDefaults(suiteName: name)!
+    suite.removePersistentDomain(forName: name)
+    let settings = SettingsManager(defaults: suite)
+
+    #expect(settings.toggleKeyCode == ShortcutRole.record.defaultKeyCode)
+    #expect(settings.cancelKeyCode == ShortcutRole.cancel.defaultKeyCode)
+    #expect(settings.quickAddKeyCode == ShortcutRole.quickAdd.defaultKeyCode)
+    #expect(settings.quickAddModifiers == ShortcutRole.quickAdd.defaultModifiers)
+  }
+
+  // MARK: - No literal creeps back into a row
+
+  /// Each row's own source block, keyed by its accessibility label.
+  ///
+  /// Scoped per ROW rather than searched whole-file: a whole-file `contains` passes when a token
+  /// moves to the WRONG row, which is the defect a location-insensitive guard is least able to see
+  /// and the one that puts the wrong Reset on the wrong shortcut.
+  private static func rowBlock(labelled label: String) throws -> String {
     let url = RepoRoot.sourceURL(
       "Sources/EnviousWisprAppKit/Views/Settings/KeybindsSettingsView.swift")
-    return try String(contentsOf: url, encoding: .utf8)
-  }
-
-  @Test("The Quick Add row binds the Quick Add setting, not a neighbour's")
-  func quickAddRowBindsItsOwnSetting() throws {
-    let source = try Self.viewSource()
-
-    #expect(source.contains("keyCode: $settings.quickAddKeyCode"))
-    #expect(source.contains("modifiers: $settings.quickAddModifiers"))
-  }
-
-  @Test("The Quick Add row's Reset offers the value a fresh install gets")
-  func quickAddRowResetMatchesTheShippedDefault() throws {
-    let source = try Self.viewSource()
-
-    #expect(
-      SettingsDefaultValues.quickAddKeyCode == 13,
-      "the shipped default moved; the view literal below must move with it")
-    #expect(
-      source.contains("defaultKeyCode: 13"),
-      "the row would reset to a chord no fresh install has")
-    #expect(source.contains("defaultModifiers: [.control, .option]"))
-  }
-
-  @Test("Every keybind row appears exactly once, so no shortcut is edited from two places")
-  func eachRowAppearsOnce() throws {
-    let source = try Self.viewSource()
-
-    for binding in ["$settings.toggleKeyCode", "$settings.cancelKeyCode", "$settings.quickAddKeyCode"] {
-      #expect(
-        source.components(separatedBy: "keyCode: \(binding)").count - 1 == 1,
-        "\(binding) is bound by more than one row")
+    let source = try String(contentsOf: url, encoding: .utf8)
+    let blocks = source.components(separatedBy: "ProminentHotkeyRow(").dropFirst()
+    guard let block = blocks.first(where: { $0.contains("accessibilityLabel: \"\(label)\"") }) else {
+      Issue.record(Comment(rawValue: "no ProminentHotkeyRow labelled '\(label)'"))
+      return ""
     }
+    return block
   }
 
-  @Test("The cancel row's Reset also matches its shipped default")
-  func cancelRowResetMatchesTheShippedDefault() throws {
-    // The paired existing case. Without it this suite would only ever have checked the row its
-    // author wrote, which is the row least likely to be wrong.
-    let source = try Self.viewSource()
+  @Test(
+    "Every row reads its role's default rather than repeating the number",
+    arguments: [
+      ("Recording keybind", "record"),
+      ("Cancel keybind", "cancel"),
+      ("Add-a-word keybind", "quickAdd"),
+    ])
+  func everyRowReadsTheOwner(label: String, role: String) throws {
+    let block = try Self.rowBlock(labelled: label)
 
-    #expect(SettingsDefaultValues.cancelKeyCode == 53)
-    #expect(source.contains("defaultKeyCode: 53"))
+    #expect(block.contains("defaultKeyCode: ShortcutRole.\(role).defaultKeyCode"))
+    #expect(block.contains("defaultModifiers: ShortcutRole.\(role).defaultModifiers"))
   }
 
-  @Test("The record row's Reset reads the constant rather than repeating its number")
-  func recordRowResetReadsTheConstant() throws {
-    // The record row is the one shape that CANNOT drift, because it names the symbol instead of a
-    // literal. Asserted so the pattern is visible as the better one, and so a later edit replacing
-    // it with a number is a conscious act.
-    let source = try Self.viewSource()
-
-    #expect(source.contains("defaultKeyCode: ModifierKeyCodes.rightOption"))
-    #expect(SettingsDefaultValues.toggleKeyCode == Int(ModifierKeyCodes.rightOption))
+  @Test("Every row binds its own setting, so no shortcut is edited from two rows")
+  func everyRowBindsItsOwnSetting() throws {
+    for (label, setting) in [
+      ("Recording keybind", "toggle"), ("Cancel keybind", "cancel"),
+      ("Add-a-word keybind", "quickAdd"),
+    ] {
+      let block = try Self.rowBlock(labelled: label)
+      #expect(block.contains("keyCode: $settings.\(setting)KeyCode"))
+      #expect(block.contains("modifiers: $settings.\(setting)Modifiers"))
+    }
   }
 }

--- a/Tests/EnviousWisprTests/Views/KeybindRowDefaultsTests.swift
+++ b/Tests/EnviousWisprTests/Views/KeybindRowDefaultsTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprServices
+
+/// #2381 — every keybind row's Reset offers the value a fresh install actually gets.
+///
+/// When this fails the user presses Reset on a shortcut row and lands on a chord that is NOT the
+/// default, so their "back to how it shipped" differs from a colleague's fresh install and from
+/// every screenshot and support answer. It compiles, it looks right, and nothing else notices.
+///
+/// **The row's default is a LITERAL in the view and the real default is a constant in Services**,
+/// with nothing linking the two. That is the shape of a claim that decays without anyone touching
+/// the line: `SettingsDefaultValues` is where a default is CHANGED, and the view is where it is
+/// OFFERED. This is a drift guard, not product coverage — it protects a property of the source,
+/// so it reads the source.
+///
+/// Swept over all THREE rows rather than only the new one: the new row's author is the one person
+/// certain to have checked theirs, and an entity sweep finds wrong statements while a member sweep
+/// finds omissions.
+@Suite("Keybind row defaults match the shipped defaults (#2381)", .tags(.driftGuard))
+struct KeybindRowDefaultsTests {
+
+  private static func viewSource() throws -> String {
+    let url = RepoRoot.sourceURL(
+      "Sources/EnviousWisprAppKit/Views/Settings/KeybindsSettingsView.swift")
+    return try String(contentsOf: url, encoding: .utf8)
+  }
+
+  @Test("The Quick Add row binds the Quick Add setting, not a neighbour's")
+  func quickAddRowBindsItsOwnSetting() throws {
+    let source = try Self.viewSource()
+
+    #expect(source.contains("keyCode: $settings.quickAddKeyCode"))
+    #expect(source.contains("modifiers: $settings.quickAddModifiers"))
+  }
+
+  @Test("The Quick Add row's Reset offers the value a fresh install gets")
+  func quickAddRowResetMatchesTheShippedDefault() throws {
+    let source = try Self.viewSource()
+
+    #expect(
+      SettingsDefaultValues.quickAddKeyCode == 13,
+      "the shipped default moved; the view literal below must move with it")
+    #expect(
+      source.contains("defaultKeyCode: 13"),
+      "the row would reset to a chord no fresh install has")
+    #expect(source.contains("defaultModifiers: [.control, .option]"))
+  }
+
+  @Test("Every keybind row appears exactly once, so no shortcut is edited from two places")
+  func eachRowAppearsOnce() throws {
+    let source = try Self.viewSource()
+
+    for binding in ["$settings.toggleKeyCode", "$settings.cancelKeyCode", "$settings.quickAddKeyCode"] {
+      #expect(
+        source.components(separatedBy: "keyCode: \(binding)").count - 1 == 1,
+        "\(binding) is bound by more than one row")
+    }
+  }
+
+  @Test("The cancel row's Reset also matches its shipped default")
+  func cancelRowResetMatchesTheShippedDefault() throws {
+    // The paired existing case. Without it this suite would only ever have checked the row its
+    // author wrote, which is the row least likely to be wrong.
+    let source = try Self.viewSource()
+
+    #expect(SettingsDefaultValues.cancelKeyCode == 53)
+    #expect(source.contains("defaultKeyCode: 53"))
+  }
+
+  @Test("The record row's Reset reads the constant rather than repeating its number")
+  func recordRowResetReadsTheConstant() throws {
+    // The record row is the one shape that CANNOT drift, because it names the symbol instead of a
+    // literal. Asserted so the pattern is visible as the better one, and so a later edit replacing
+    // it with a number is a conscious act.
+    let source = try Self.viewSource()
+
+    #expect(source.contains("defaultKeyCode: ModifierKeyCodes.rightOption"))
+    #expect(SettingsDefaultValues.toggleKeyCode == Int(ModifierKeyCodes.rightOption))
+  }
+}

--- a/Tests/EnviousWisprTests/Views/KeybindRowDefaultsTests.swift
+++ b/Tests/EnviousWisprTests/Views/KeybindRowDefaultsTests.swift
@@ -1,5 +1,7 @@
 import AppKit
 import Foundation
+import SwiftParser
+import SwiftSyntax
 import Testing
 
 @testable import EnviousWisprServices
@@ -95,56 +97,86 @@ struct KeybindRowDefaultsTests {
     #expect(service.quickAddBinding == ShortcutRole.quickAdd.defaultBinding)
   }
 
-  // MARK: - No literal creeps back into a row
+  // MARK: - The one source question left
 
-  /// Each row's own source block, keyed by its accessibility label.
+  /// Comment-free source, from a real parse.
   ///
-  /// Scoped per ROW rather than searched whole-file: a whole-file `contains` passes when a token
-  /// moves to the WRONG row, which is the defect a location-insensitive guard is least able to see
-  /// and the one that puts the wrong Reset on the wrong shortcut.
-  private static func rowBlock(labelled label: String) throws -> String {
+  /// **A hand-rolled comment strip was tried twice and found wanting twice** — first it handled only
+  /// full-line comments, then a trailing `// ...` walked past it, and block selection happened before
+  /// stripping so a commented label could pick the wrong row. That is a DESCRIPTION of Swift's
+  /// comment grammar, and a description always has a next counterexample.
+  ///
+  /// `swift-patterns.md` RULE: scan-swift-source-with-swiftparser-never-a-hand-rolled-lexer settles
+  /// it: `swift-syntax` is already a test-target dependency, comments are TRIVIA, and dropping
+  /// trivia removes every spelling of a comment at once rather than one at a time.
+  private static func executableSource() throws -> String {
     let url = RepoRoot.sourceURL(
       "Sources/EnviousWisprAppKit/Views/Settings/KeybindsSettingsView.swift")
-    let source = try String(contentsOf: url, encoding: .utf8)
-    let blocks = source.components(separatedBy: "ProminentHotkeyRow(").dropFirst()
+    let parsed = Parser.parse(source: try String(contentsOf: url, encoding: .utf8))
+    return CommentStripper().rewrite(parsed).description
+  }
+
+  /// Each row's own source block, keyed by its accessibility label, comments already gone.
+  ///
+  /// Scoped per ROW rather than searched whole-file: a whole-file `contains` passes when a token
+  /// moves to the WRONG row, which is the defect that puts one shortcut's controls on another's.
+  private static func rowBlock(labelled label: String) throws -> String {
+    let blocks = try executableSource().components(separatedBy: "ProminentHotkeyRow(").dropFirst()
     guard let block = blocks.first(where: { $0.contains("accessibilityLabel: \"\(label)\"") }) else {
       Issue.record(Comment(rawValue: "no ProminentHotkeyRow labelled '\(label)'"))
       return ""
     }
-    // COMMENTS STRIPPED, and that is not tidiness. These rows are heavily commented, and a comment
-    // MENTIONING `ShortcutRole.quickAdd.defaultKeyCode` would satisfy every assertion below while
-    // the executable line beneath it held a literal — a guard passing on prose about the thing it
-    // is meant to check. Line comments only; this file has no block comments inside a row.
-    return
-      block
-      .split(separator: "\n", omittingEmptySubsequences: false)
-      .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
-      .joined(separator: "\n")
-  }
-
-  @Test(
-    "Every row reads its role's default rather than repeating the number",
-    arguments: [
-      ("Recording keybind", "record"),
-      ("Cancel keybind", "cancel"),
-      ("Add-a-word keybind", "quickAdd"),
-    ])
-  func everyRowReadsTheOwner(label: String, role: String) throws {
-    let block = try Self.rowBlock(labelled: label)
-
-    #expect(block.contains("defaultKeyCode: ShortcutRole.\(role).defaultKeyCode"))
-    #expect(block.contains("defaultModifiers: ShortcutRole.\(role).defaultModifiers"))
+    return block
   }
 
   @Test("Every row binds its own setting, so no shortcut is edited from two rows")
   func everyRowBindsItsOwnSetting() throws {
-    for (label, setting) in [
-      ("Recording keybind", "toggle"), ("Cancel keybind", "cancel"),
-      ("Add-a-word keybind", "quickAdd"),
+    // The one property the type system does not carry. A row's ROLE now decides its Reset default,
+    // but nothing links that role to the settings binding beside it, so a row can still be given
+    // `.quickAdd` and wired to `$settings.cancelKeyCode`.
+    for (label, role, setting) in [
+      ("Recording keybind", "record", "toggle"), ("Cancel keybind", "cancel", "cancel"),
+      ("Add-a-word keybind", "quickAdd", "quickAdd"),
     ] {
       let block = try Self.rowBlock(labelled: label)
+      #expect(block.contains("role: .\(role)"))
       #expect(block.contains("keyCode: $settings.\(setting)KeyCode"))
       #expect(block.contains("modifiers: $settings.\(setting)Modifiers"))
     }
+  }
+
+  @Test("A comment cannot satisfy the row check")
+  func commentsCannotSatisfyTheRowCheck() throws {
+    // The control for the parser above, asserted rather than assumed: the file HAS comments inside
+    // its rows, and none of them survives into what the check reads. Without this, a stripper that
+    // silently did nothing would look identical to one that works.
+    let block = try Self.rowBlock(labelled: "Add-a-word keybind")
+
+    #expect(!block.contains("//"))
+    #expect(block.contains("role: .quickAdd"), "the strip must not have eaten the code too")
+  }
+}
+
+/// Drops every COMMENT and nothing else.
+///
+/// Comments are trivia in SwiftSyntax, so filtering the comment PIECES removes all of their
+/// spellings at once — line, block, doc, and trailing — while spaces and newlines survive untouched.
+/// Dropping trivia wholesale was tried first and is wrong for this job: it collapses the spacing the
+/// assertions read, so `accessibilityLabel: "x"` comes back as `accessibilityLabel : "x"` and every
+/// match fails. The failure was loud, which is the only reason that draft cost minutes.
+private final class CommentStripper: SyntaxRewriter {
+  private func withoutComments(_ trivia: Trivia) -> Trivia {
+    Trivia(pieces: trivia.filter { piece in
+      switch piece {
+      case .lineComment, .blockComment, .docLineComment, .docBlockComment: false
+      default: true
+      }
+    })
+  }
+
+  override func visit(_ token: TokenSyntax) -> TokenSyntax {
+    token
+      .with(\.leadingTrivia, withoutComments(token.leadingTrivia))
+      .with(\.trailingTrivia, withoutComments(token.trailingTrivia))
   }
 }

--- a/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelCopyTests.swift
+++ b/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelCopyTests.swift
@@ -66,6 +66,20 @@ struct QuickAddPanelCopyTests {
         == QuickAddPanelCopy.groupHeader(.confident, heard: "codecs"))
   }
 
+  @Test("A refusal reads correctly once its channel's prefix is on it")
+  func aRefusalReadsCorrectlyUnderThePrefix() {
+    // `wordNoLongerExists` reaches the user through `writeFailure`, which prefixes "Not saved.".
+    // Written as though it stood alone it said "was not added" as well, which renders as a stutter.
+    // The cost of REUSING a refusal path is inheriting its sentence, and nothing about the constant
+    // says which path it travels — only the composed form shows it.
+    let rendered = QuickAddPanelCopy.writeFailure(QuickAddPanelCopy.wordNoLongerExists)
+
+    #expect(rendered.hasPrefix("Not saved."))
+    #expect(!rendered.lowercased().contains("not added"), "the prefix already said it")
+    #expect(
+      rendered.contains("Create it as a new word"), "the way forward the open panel still has")
+  }
+
   @Test("Every refusal has its own sentence")
   func everyRefusalHasItsOwnSentence() {
     // A single "could not read your selection" would be technically true for all of them and useless

--- a/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelCopyTests.swift
+++ b/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelCopyTests.swift
@@ -94,11 +94,27 @@ struct QuickAddPanelCopyTests {
     // The field is hidden on a refusal because `updateQuery` will not re-rank without a heard
     // string. Three messages used to say "You can search for the word below", which named a
     // control that is not on screen and would not have answered if it were.
+    //
+    // **WIDENED past the literal word "search", and the reason generalises past this guard.** The
+    // first version matched `contains("search")` only, so "you can look for the word below" or
+    // "type the word below" would have passed while being the identical defect. A pattern narrower
+    // than the LANGUAGE reports clean on a synonym, and that is a guard returning empty and having
+    // empty read as an answer. The question to ask of any text guard is not what a scanner might
+    // mis-lex but what a WRITER could legitimately say instead.
+    //
+    // Two-way controlled before shipping the widening, because "no new false positives" is a claim
+    // about the whole copy table that costs one command to check and is otherwise optimism: the
+    // term set below matches ZERO of today's seven messages and still catches the exact wording
+    // that was removed. (Framing owed to a peer session hitting the same shape in
+    // `check-language-count.mjs`, where "99-lang" slipped a pattern requiring "language".)
+    let pointsAtTheField = ["search", "look for", "find", "filter", "type"]
     for refusal in SelectionReader.Refusal.allCases {
-      let message = QuickAddPanelCopy.refusalMessage(refusal)
-      #expect(
-        !message.lowercased().contains("search"),
-        "\(refusal.rawValue) points at a control that does nothing in this state")
+      let message = QuickAddPanelCopy.refusalMessage(refusal).lowercased()
+      for term in pointsAtTheField {
+        #expect(
+          !message.contains(term),
+          "\(refusal.rawValue) says \"\(term)\", pointing at a control that is not on screen")
+      }
       #expect(!message.isEmpty)
     }
   }
@@ -122,5 +138,30 @@ struct QuickAddPanelCopyTests {
     // the reason here would give the user two vocabularies for one refusal.
     #expect(rendered.hasPrefix("Not saved."))
     #expect(rendered.contains("That word cannot be saved."))
+  }
+  @Test("A word that already has the spelling does not promise to add it")
+  func aWordThatAlreadyHasItSaysSo() {
+    // The live defect the design pass found by reading the view against the model: the flag existed,
+    // the coordinator branched on it, and the view never read it — so the row said "add as a new
+    // spelling", Return wrote nothing, and the panel closed silently. Reachable on the first thing a
+    // user tries, because any word they have corrected once scores 1.00 and lands here.
+    let promises = QuickAddPanelCopy.rowSubtitle(spellingCount: 3)
+    let states = QuickAddPanelCopy.rowSubtitleAlreadyHas(spellingCount: 3)
+
+    #expect(promises.contains("add as a new spelling"))
+    #expect(!states.contains("add"), "a row that cannot add must not use the verb")
+    #expect(states.contains("already has this spelling"))
+    // Both still carry the count, which is the half that was always true.
+    #expect(promises.contains("3 spellings"))
+    #expect(states.contains("3 spellings"))
+  }
+
+  @Test("Singular and plural are right in both subtitles")
+  func bothSubtitlesCountCorrectly() {
+    // "1 spellings already saved" is the kind of thing users screenshot.
+    #expect(QuickAddPanelCopy.rowSubtitle(spellingCount: 1).contains("1 spelling "))
+    #expect(QuickAddPanelCopy.rowSubtitleAlreadyHas(spellingCount: 1).contains("1 spelling "))
+    #expect(QuickAddPanelCopy.rowSubtitle(spellingCount: 2).contains("2 spellings"))
+    #expect(QuickAddPanelCopy.rowSubtitleAlreadyHas(spellingCount: 2).contains("2 spellings"))
   }
 }

--- a/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelCopyTests.swift
+++ b/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelCopyTests.swift
@@ -79,11 +79,48 @@ struct QuickAddPanelCopyTests {
         QuickAddPanelCopy.heardLabel, QuickAddPanelCopy.searchPlaceholder,
         QuickAddPanelCopy.createNewWord, QuickAddPanelCopy.returnHint,
         QuickAddPanelCopy.rowSubtitle(spellingCount: 3),
+        // A member of the copy set like any other. Sweeping the SET rather than the strings that
+        // existed when this was written is what makes a later addition visible here.
+        QuickAddPanelCopy.writeFailure("That word cannot be saved."),
       ]
 
     for text in all {
       #expect(!text.contains("\u{2014}"), "em-dash in: \(text)")
       #expect(!text.contains("\u{2013}"), "en-dash in: \(text)")
     }
+  }
+  @Test("No refusal sends the user to the search field, which is hidden in exactly that state")
+  func noRefusalPointsAtTheSearchField() {
+    // The field is hidden on a refusal because `updateQuery` will not re-rank without a heard
+    // string. Three messages used to say "You can search for the word below", which named a
+    // control that is not on screen and would not have answered if it were.
+    for refusal in SelectionReader.Refusal.allCases {
+      let message = QuickAddPanelCopy.refusalMessage(refusal)
+      #expect(
+        !message.lowercased().contains("search"),
+        "\(refusal.rawValue) points at a control that does nothing in this state")
+      #expect(!message.isEmpty)
+    }
+  }
+
+  @Test("Three refusals point at authoring the word by hand, which is the control that does work")
+  func unreadableRefusalsPointAtCreatingAWord() {
+    // The paired positive case for the assertion above: a check that only ever refuses a word
+    // would pass just as happily against messages that name no way forward at all.
+    for refusal in [
+      SelectionReader.Refusal.selectionUnsupported, .selectionUnavailable, .unreadable,
+    ] {
+      #expect(QuickAddPanelCopy.refusalMessage(refusal).contains("add the word by hand"))
+    }
+  }
+
+  @Test("A write failure is presented as not-saved, carrying the library's own sentence")
+  func writeFailureCarriesTheLibrarysMessage() {
+    let rendered = QuickAddPanelCopy.writeFailure("That word cannot be saved.")
+
+    // Both halves matter: the verdict is ours, the reason is the words authority's, and rewording
+    // the reason here would give the user two vocabularies for one refusal.
+    #expect(rendered.hasPrefix("Not saved."))
+    #expect(rendered.contains("That word cannot be saved."))
   }
 }

--- a/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelCopyTests.swift
+++ b/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelCopyTests.swift
@@ -14,23 +14,56 @@ import Testing
 @Suite("Quick Add panel copy — #2381", .tags(.driftGuard))
 struct QuickAddPanelCopyTests {
 
-  @Test("The row subtitle says what accepting does, then how much that word already carries")
-  func rowSubtitleShape() {
-    #expect(
-      QuickAddPanelCopy.rowSubtitle(spellingCount: 4)
-        == "add as a new spelling · 4 spellings already saved")
+  @Test("A row's meta is a count, and the verb is not on the row")
+  func rowMetaIsACount() {
+    // The verb moved to the group header, said once. That structural difference is what makes five
+    // candidates cost five lines instead of the ten that four wrapped subtitles cost.
+    #expect(QuickAddPanelCopy.spellingCount(4) == "4 spellings")
+    #expect(!QuickAddPanelCopy.spellingCount(4).contains("add"))
   }
 
   @Test("One spelling is singular")
-  func rowSubtitleIsSingularForOne() {
-    // "1 spellings already saved" is the kind of thing users screenshot.
-    #expect(QuickAddPanelCopy.rowSubtitle(spellingCount: 1).contains("1 spelling already saved"))
-    #expect(!QuickAddPanelCopy.rowSubtitle(spellingCount: 1).contains("spellings"))
+  func countIsSingularForOne() {
+    // "1 spellings" is the kind of thing users screenshot.
+    #expect(QuickAddPanelCopy.spellingCount(1) == "1 spelling")
+    #expect(QuickAddPanelCopy.spellingCount(0) == "0 spellings")
   }
 
-  @Test("A word with no spellings yet reads as plural, which is correct for zero")
-  func rowSubtitleIsPluralForZero() {
-    #expect(QuickAddPanelCopy.rowSubtitle(spellingCount: 0).contains("0 spellings already saved"))
+  @Test("The group header names the selected word and states the verb once")
+  func groupHeaderCarriesTheVerb() {
+    let confident = QuickAddPanelCopy.groupHeader(.confident, heard: "codecs")
+    #expect(confident.contains("codecs"))
+    #expect(confident.contains("Add"))
+  }
+
+  @Test("Low confidence says so in words, not only by withholding a highlight")
+  func lowConfidenceHeaderSaysSo() {
+    // Below the bar nothing is preselected. A list that looks identical either way leaves the user
+    // inferring the difference from a missing tint, which nobody reads.
+    let low = QuickAddPanelCopy.groupHeader(.lowConfidence, heard: "kubernets")
+    #expect(!low.contains("Add"), "there is nothing to add yet, so do not use the verb")
+    #expect(low.lowercased().contains("no close match"))
+  }
+
+  @Test("The already-saved header states the outcome and offers no verb")
+  func alreadySavedHeaderOffersNothing() {
+    let already = QuickAddPanelCopy.groupHeader(.alreadySaved, heard: "codecs")
+    #expect(already.contains("codecs"))
+    #expect(already.lowercased().contains("nothing to add"))
+  }
+
+  @Test("Searching keeps the confident sentence, so the header cannot change mid-keystroke")
+  func searchingKeepsTheVerb() {
+    // Four states, three distinct sentences, and the collision is deliberate: a header that also
+    // carries state must not rewrite itself under someone who is typing.
+    let all = QuickAddPanelCopy.GroupHeaderState.allCases.map {
+      QuickAddPanelCopy.groupHeader($0, heard: "codecs")
+    }
+    #expect(Set(all).count == 3)
+    #expect(all.allSatisfy { !$0.isEmpty })
+    #expect(
+      QuickAddPanelCopy.groupHeader(.searching, heard: "codecs")
+        == QuickAddPanelCopy.groupHeader(.confident, heard: "codecs"))
   }
 
   @Test("Every refusal has its own sentence")
@@ -76,9 +109,13 @@ struct QuickAddPanelCopyTests {
     let all =
       SelectionReader.Refusal.allCases.map(QuickAddPanelCopy.refusalMessage)
       + [
-        QuickAddPanelCopy.heardLabel, QuickAddPanelCopy.searchPlaceholder,
-        QuickAddPanelCopy.createNewWord, QuickAddPanelCopy.returnHint,
-        QuickAddPanelCopy.rowSubtitle(spellingCount: 3),
+        QuickAddPanelCopy.searchPlaceholder, QuickAddPanelCopy.createNewWord,
+        QuickAddPanelCopy.spellingCount(3), QuickAddPanelCopy.alreadyHasThisSpelling,
+        QuickAddPanelCopy.legendAccept, QuickAddPanelCopy.legendMove,
+        QuickAddPanelCopy.legendClose,
+        QuickAddPanelCopy.groupHeader(.confident, heard: "codecs"),
+        QuickAddPanelCopy.groupHeader(.lowConfidence, heard: "codecs"),
+        QuickAddPanelCopy.groupHeader(.alreadySaved, heard: "codecs"),
         // A member of the copy set like any other. Sweeping the SET rather than the strings that
         // existed when this was written is what makes a later addition visible here.
         QuickAddPanelCopy.writeFailure("That word cannot be saved."),
@@ -142,26 +179,10 @@ struct QuickAddPanelCopyTests {
   @Test("A word that already has the spelling does not promise to add it")
   func aWordThatAlreadyHasItSaysSo() {
     // The live defect the design pass found by reading the view against the model: the flag existed,
-    // the coordinator branched on it, and the view never read it — so the row said "add as a new
+    // the coordinator branched on it, and the view never read it — so every row said "add as a new
     // spelling", Return wrote nothing, and the panel closed silently. Reachable on the first thing a
-    // user tries, because any word they have corrected once scores 1.00 and lands here.
-    let promises = QuickAddPanelCopy.rowSubtitle(spellingCount: 3)
-    let states = QuickAddPanelCopy.rowSubtitleAlreadyHas(spellingCount: 3)
-
-    #expect(promises.contains("add as a new spelling"))
-    #expect(!states.contains("add"), "a row that cannot add must not use the verb")
-    #expect(states.contains("already has this spelling"))
-    // Both still carry the count, which is the half that was always true.
-    #expect(promises.contains("3 spellings"))
-    #expect(states.contains("3 spellings"))
-  }
-
-  @Test("Singular and plural are right in both subtitles")
-  func bothSubtitlesCountCorrectly() {
-    // "1 spellings already saved" is the kind of thing users screenshot.
-    #expect(QuickAddPanelCopy.rowSubtitle(spellingCount: 1).contains("1 spelling "))
-    #expect(QuickAddPanelCopy.rowSubtitleAlreadyHas(spellingCount: 1).contains("1 spelling "))
-    #expect(QuickAddPanelCopy.rowSubtitle(spellingCount: 2).contains("2 spellings"))
-    #expect(QuickAddPanelCopy.rowSubtitleAlreadyHas(spellingCount: 2).contains("2 spellings"))
+    // user tries, because any word corrected once scores 1.00 and lands here.
+    #expect(!QuickAddPanelCopy.alreadyHasThisSpelling.contains("add"))
+    #expect(QuickAddPanelCopy.alreadyHasThisSpelling.contains("already has"))
   }
 }

--- a/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelCopyTests.swift
+++ b/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelCopyTests.swift
@@ -1,0 +1,89 @@
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #2381 — the panel's copy, and the promise each refusal line makes.
+///
+/// When this fails the user is told the wrong thing about why their selection could not be read, and
+/// goes looking in the wrong place. The one refusal they can ACT on is the Accessibility permission;
+/// every other line has to be honest enough that they stop rather than retry forever.
+///
+/// A frozen copy table rather than strings inline in the view, so this asserts without rendering.
+@Suite("Quick Add panel copy — #2381", .tags(.driftGuard))
+struct QuickAddPanelCopyTests {
+
+  @Test("The row subtitle says what accepting does, then how much that word already carries")
+  func rowSubtitleShape() {
+    #expect(
+      QuickAddPanelCopy.rowSubtitle(spellingCount: 4)
+        == "add as a new spelling · 4 spellings already saved")
+  }
+
+  @Test("One spelling is singular")
+  func rowSubtitleIsSingularForOne() {
+    // "1 spellings already saved" is the kind of thing users screenshot.
+    #expect(QuickAddPanelCopy.rowSubtitle(spellingCount: 1).contains("1 spelling already saved"))
+    #expect(!QuickAddPanelCopy.rowSubtitle(spellingCount: 1).contains("spellings"))
+  }
+
+  @Test("A word with no spellings yet reads as plural, which is correct for zero")
+  func rowSubtitleIsPluralForZero() {
+    #expect(QuickAddPanelCopy.rowSubtitle(spellingCount: 0).contains("0 spellings already saved"))
+  }
+
+  @Test("Every refusal has its own sentence")
+  func everyRefusalHasItsOwnSentence() {
+    // A single "could not read your selection" would be technically true for all of them and useless
+    // for the only one the user can do anything about.
+    let messages = SelectionReader.Refusal.allCases.map(QuickAddPanelCopy.refusalMessage)
+
+    #expect(Set(messages).count == messages.count, "two refusals share a sentence")
+    #expect(messages.allSatisfy { !$0.isEmpty })
+  }
+
+  @Test("The Accessibility refusal names the fix, because it is the only one the user can act on")
+  func theAccessibilityRefusalNamesTheFix() {
+    let message = QuickAddPanelCopy.refusalMessage(.accessibilityNotTrusted)
+
+    #expect(message.contains("System Settings"))
+    #expect(message.contains("Accessibility"))
+  }
+
+  @Test("The terminal refusal says WHY rather than blaming the user's aim")
+  func theTerminalRefusalExplains() {
+    // Measured: a terminal advertises the attribute and then answers with nothing, so "select the
+    // word again" would send the user round a loop that cannot end.
+    let message = QuickAddPanelCopy.refusalMessage(.selectionUnavailable)
+
+    #expect(message.lowercased().contains("terminal"))
+    #expect(!message.lowercased().contains("try again"))
+  }
+
+  @Test("The too-long refusal DOES tell the user to try again, because retrying works there")
+  func theTooLongRefusalAsksForARetry() {
+    // The paired case for the one above: the difference between the two is whether a retry can
+    // succeed, and the copy has to reflect that rather than being uniformly apologetic.
+    let message = QuickAddPanelCopy.refusalMessage(.selectionTooLong)
+
+    #expect(message.lowercased().contains("try again"))
+  }
+
+  @Test("No panel copy contains an em-dash or en-dash")
+  func noDashesInUserFacingCopy() {
+    // GR-NO-DASHES. The row subtitle's separator is a MIDDLE DOT, which is not one of these.
+    let all =
+      SelectionReader.Refusal.allCases.map(QuickAddPanelCopy.refusalMessage)
+      + [
+        QuickAddPanelCopy.heardLabel, QuickAddPanelCopy.searchPlaceholder,
+        QuickAddPanelCopy.createNewWord, QuickAddPanelCopy.returnHint,
+        QuickAddPanelCopy.rowSubtitle(spellingCount: 3),
+      ]
+
+    for text in all {
+      #expect(!text.contains("\u{2014}"), "em-dash in: \(text)")
+      #expect(!text.contains("\u{2013}"), "en-dash in: \(text)")
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelCopyTests.swift
+++ b/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelCopyTests.swift
@@ -80,6 +80,21 @@ struct QuickAddPanelCopyTests {
       rendered.contains("Create it as a new word"), "the way forward the open panel still has")
   }
 
+  @Test("The commonest refusal blames nobody and names the one thing that fixes it")
+  func nothingSelectedBlamesNobody() {
+    // Highlighting nothing is the likeliest way to reach a refusal at all, and it is the only one
+    // where NOTHING went wrong. It used to borrow `selectionUnavailable`'s sentence, which names
+    // terminals and accuses the frontmost app of withholding a selection — a confident diagnosis
+    // handed to someone whose only mistake was not selecting a word.
+    let message = QuickAddPanelCopy.refusalMessage(.nothingSelected)
+    let accusatory = QuickAddPanelCopy.refusalMessage(.selectionUnavailable)
+
+    #expect(message != accusatory, "the whole point is that these two are different sentences")
+    #expect(!message.lowercased().contains("terminal"), "no app is at fault here")
+    #expect(!message.lowercased().contains("will not share"), "nothing was withheld")
+    #expect(message.lowercased().contains("select"), "and the way out is stated, not implied")
+  }
+
   @Test("Every refusal has its own sentence")
   func everyRefusalHasItsOwnSentence() {
     // A single "could not read your selection" would be technically true for all of them and useless

--- a/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelModelTests.swift
+++ b/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelModelTests.swift
@@ -156,6 +156,27 @@ struct QuickAddPanelModelTests {
     #expect(model.heard == "codecs")
   }
 
+  @Test("A refused write is held on the model, so the panel that stayed open can say why")
+  func aRefusedWriteIsHeld() {
+    let (model, _) = makeModel(heardRanking: ranking(["Codex"], preselecting: 0))
+
+    #expect(model.writeFailure == nil)
+    model.noteWriteFailure("That word cannot be saved.")
+    #expect(model.writeFailure == "That word cannot be saved.")
+  }
+
+  @Test("Typing clears a write failure, because it describes the accept the user has moved on from")
+  func typingClearsAWriteFailure() {
+    let (model, _) = makeModel(
+      heardRanking: ranking(["Codex"], preselecting: 0),
+      searchRanking: ranking(["Codex"], preselecting: nil))
+    model.noteWriteFailure("That word cannot be saved.")
+
+    model.updateQuery("cod")
+
+    #expect(model.writeFailure == nil)
+  }
+
   @Test("A refusal leaves the search field inert rather than ranking an empty selection")
   func searchIsInertUnderARefusal() {
     let (model, calls) = makeModel(

--- a/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelModelTests.swift
+++ b/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelModelTests.swift
@@ -309,4 +309,46 @@ struct QuickAddPanelModelTests {
 
     #expect(headerState(heardRanking: r, query: "cod") == .alreadySaved)
   }
+  @Test("Whitespace is not a search, at every reader")
+  func whitespaceIsNotASearch() {
+    // `updateQuery` trims before deciding whether to re-rank and stores the RAW text, because that
+    // is what the field renders. So the heard ranking came back while four downstream readers still
+    // believed a search was running: the header switched sentence under a user who typed nothing,
+    // and `used_search=true` went out on the accept — a claim that the ranking needed rescuing when
+    // it did not.
+    let (model, _) = makeModel(
+      heardRanking: ranking(["Codex"], preselecting: 0),
+      searchRanking: ranking(["Codex"], preselecting: nil))
+
+    model.updateQuery("   ")
+
+    #expect(!model.isSearching)
+    #expect(model.ranking.preselectedID != nil, "the heard ranking, including its preselection")
+  }
+
+  @Test("Real text IS a search")
+  func realTextIsASearch() {
+    // The paired positive. Without it, `isSearching` could return false always and the case above
+    // would pass while the search field stopped being observable at all.
+    let (model, _) = makeModel(
+      heardRanking: ranking(["Codex"], preselecting: 0),
+      searchRanking: ranking(["Codex"], preselecting: nil))
+
+    model.updateQuery("cod")
+
+    #expect(model.isSearching)
+  }
+
+  @Test("Text with surrounding whitespace is still a search")
+  func paddedTextIsStillASearch() {
+    // Trimming decides whether there is anything to search FOR; it must not decide that a padded
+    // query is no query. A user who typed a space before their word is searching.
+    let (model, _) = makeModel(
+      heardRanking: ranking(["Codex"], preselecting: 0),
+      searchRanking: ranking(["Codex"], preselecting: nil))
+
+    model.updateQuery("  cod  ")
+
+    #expect(model.isSearching)
+  }
 }

--- a/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelModelTests.swift
+++ b/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelModelTests.swift
@@ -1,0 +1,232 @@
+import EnviousWisprCore
+import EnviousWisprPostProcessing
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #2381 — which row the Return key accepts, and what accepting writes.
+///
+/// When this fails the user presses Return once and the wrong thing happens: a word they never chose
+/// gains a spelling, or the spelling saved is what they TYPED to find the word rather than what they
+/// selected. Both are silent — the library is written correctly-shaped, and only the next dictation
+/// shows it.
+///
+/// **A focused search field and a preselected row both want Return, and the collision is invisible
+/// until someone types.** That is the whole reason this state machine exists apart from the view: it
+/// can be driven through every keyboard state without a window, a run loop, or the real library.
+///
+/// The two ranking calls are injected so each case can hand the model exactly the list that makes a
+/// rule visible, rather than whatever the real scorer returns for a fixture chosen to be realistic.
+@MainActor
+@Suite("Quick Add panel keyboard contract — #2381", .tags(.productOutcome))
+struct QuickAddPanelModelTests {
+
+  private func candidate(_ canonical: String, aliases: [String] = []) -> QuickAddRanker.Candidate {
+    QuickAddRanker.Candidate(
+      word: CustomWord(canonical: canonical, aliases: aliases),
+      score: 0.9,
+      alreadyHasHeardSpelling: false)
+  }
+
+  private func ranking(_ names: [String], preselecting index: Int?) -> QuickAddRanker.Ranking {
+    let rows = names.map { candidate($0) }
+    return QuickAddRanker.Ranking(
+      candidates: rows, preselectedID: index.map { rows[$0].id })
+  }
+
+  /// A model whose two ranking calls are recorded, so a case can assert WHICH question was asked.
+  private final class Calls {
+    var heard: [String] = []
+    var searches: [(query: String, heard: String)] = []
+  }
+
+  private func makeModel(
+    heard: String = "codecs",
+    refusal: SelectionReader.Refusal? = nil,
+    heardRanking: QuickAddRanker.Ranking,
+    searchRanking: QuickAddRanker.Ranking = .empty
+  ) -> (QuickAddPanelModel, Calls) {
+    let calls = Calls()
+    let model = QuickAddPanelModel(
+      heard: heard,
+      refusal: refusal,
+      rankHeard: { heardString in
+        calls.heard.append(heardString)
+        return heardRanking
+      },
+      searchLibrary: { query, heardString in
+        calls.searches.append((query, heardString))
+        return searchRanking
+      })
+    return (model, calls)
+  }
+
+  // MARK: - Opening
+
+  @Test("Opening ranks the heard word and nothing else")
+  func openingRanksTheHeardWord() {
+    let (model, calls) = makeModel(heardRanking: ranking(["Codex", "Claude Code"], preselecting: 0))
+
+    #expect(calls.heard == ["codecs"])
+    #expect(calls.searches.isEmpty)
+    #expect(model.ranking.candidates.count == 2)
+    #expect(model.acceptTarget?.word.canonical == "Codex")
+  }
+
+  @Test("A refusal opens the panel with no ranking, and does not rank nothing")
+  func aRefusalRanksNothing() {
+    // The panel still opens — it never silently does nothing — but there is no selection to rank, so
+    // asking the ranker would be asking about an empty string.
+    let (model, calls) = makeModel(
+      heard: "",
+      refusal: .selectionUnavailable,
+      heardRanking: ranking(["Codex"], preselecting: 0))
+
+    #expect(calls.heard.isEmpty)
+    #expect(model.ranking.candidates.isEmpty)
+    #expect(model.acceptTarget == nil)
+    #expect(model.refusal == .selectionUnavailable)
+  }
+
+  @Test("Below the bar nothing is highlighted, so Return writes nothing")
+  func belowTheBarReturnWritesNothing() {
+    let (model, _) = makeModel(heardRanking: ranking(["Codex", "Claude Code"], preselecting: nil))
+
+    #expect(!model.ranking.candidates.isEmpty, "the user still gets a list")
+    #expect(model.acceptTarget == nil)
+  }
+
+  // MARK: - The search field
+
+  @Test("Typing asks the search question, with the heard word carried alongside")
+  func typingSearches() {
+    let (model, calls) = makeModel(
+      heardRanking: ranking(["Codex"], preselecting: 0),
+      searchRanking: ranking(["codec"], preselecting: 0))
+
+    model.updateQuery("codec")
+
+    #expect(calls.searches.count == 1)
+    #expect(calls.searches.first?.query == "codec")
+    #expect(calls.searches.first?.heard == "codecs", "the search must know what will be written")
+    #expect(model.ranking.candidates.first?.word.canonical == "codec")
+  }
+
+  @Test("Clearing the field restores the heard ranking, not an empty list")
+  func clearingRestoresTheHeardRanking() {
+    // The panel must not become a dead end when the user deletes what they typed.
+    let (model, calls) = makeModel(
+      heardRanking: ranking(["Codex"], preselecting: 0),
+      searchRanking: ranking(["codec"], preselecting: 0))
+
+    model.updateQuery("codec")
+    model.updateQuery("")
+
+    #expect(model.ranking.candidates.first?.word.canonical == "Codex")
+    #expect(model.acceptTarget?.word.canonical == "Codex", "the confidence preselection comes back")
+    #expect(calls.heard.count == 2, "re-ranked, not restored from a stale copy")
+  }
+
+  @Test("A whitespace-only query is a cleared field, not a search for spaces")
+  func whitespaceQueryRestoresTheHeardRanking() {
+    let (model, calls) = makeModel(
+      heardRanking: ranking(["Codex"], preselecting: 0),
+      searchRanking: ranking(["codec"], preselecting: 0))
+
+    model.updateQuery("   ")
+
+    #expect(calls.searches.isEmpty)
+    #expect(model.ranking.candidates.first?.word.canonical == "Codex")
+  }
+
+  @Test("Typing never changes what would be written")
+  func typingNeverChangesWhatIsWritten() {
+    // The sharpest hazard the search field introduces: accepting a searched-for row must save the
+    // ORIGINAL selection, not the query used to find it. Otherwise the escape hatch built to recover
+    // from a wrong ranking becomes a way to write an arbitrary string.
+    let (model, _) = makeModel(
+      heardRanking: ranking(["Codex"], preselecting: 0),
+      searchRanking: ranking(["codec"], preselecting: 0))
+
+    model.updateQuery("something else entirely")
+
+    #expect(model.spellingToWrite == "codecs")
+    #expect(model.heard == "codecs")
+  }
+
+  @Test("A refusal leaves the search field inert rather than ranking an empty selection")
+  func searchIsInertUnderARefusal() {
+    let (model, calls) = makeModel(
+      heard: "",
+      refusal: .accessibilityNotTrusted,
+      heardRanking: ranking(["Codex"], preselecting: 0),
+      searchRanking: ranking(["codec"], preselecting: 0))
+
+    model.updateQuery("codec")
+
+    #expect(calls.searches.isEmpty)
+    #expect(model.query == "codec", "the text still shows; only the ranking is withheld")
+    #expect(model.acceptTarget == nil)
+  }
+
+  // MARK: - Arrows
+
+  @Test("Down from no highlight opts into the FIRST row")
+  func downFromNoHighlightTakesTheFirst() {
+    // Below the bar nothing is highlighted. An arrow press is the user deliberately opting in, which
+    // is a different act from Return and is allowed to select where Return was not.
+    let (model, _) = makeModel(heardRanking: ranking(["Codex", "Claude Code"], preselecting: nil))
+
+    model.moveHighlight(by: 1)
+
+    #expect(model.acceptTarget?.word.canonical == "Codex")
+  }
+
+  @Test("Up from no highlight opts into the LAST row")
+  func upFromNoHighlightTakesTheLast() {
+    let (model, _) = makeModel(heardRanking: ranking(["Codex", "Claude Code"], preselecting: nil))
+
+    model.moveHighlight(by: -1)
+
+    #expect(model.acceptTarget?.word.canonical == "Claude Code")
+  }
+
+  @Test("The highlight clamps at both ends rather than wrapping")
+  func theHighlightClamps() {
+    // Wrapping from the last row to the first is a surprise when the list is short and the user is
+    // holding the key — and this list is at most a handful of rows.
+    let (model, _) = makeModel(
+      heardRanking: ranking(["Codex", "Claude Code", "Claude.md"], preselecting: 0))
+
+    model.moveHighlight(by: -1)
+    #expect(model.acceptTarget?.word.canonical == "Codex", "already at the top")
+
+    model.moveHighlight(by: 1)
+    model.moveHighlight(by: 1)
+    model.moveHighlight(by: 1)
+    #expect(model.acceptTarget?.word.canonical == "Claude.md", "already at the bottom")
+  }
+
+  @Test("Arrows on an empty list do nothing rather than trapping")
+  func arrowsOnAnEmptyListDoNothing() {
+    let (model, _) = makeModel(heardRanking: .empty)
+
+    model.moveHighlight(by: 1)
+    model.moveHighlight(by: -1)
+
+    #expect(model.acceptTarget == nil)
+    #expect(model.ranking.candidates.isEmpty)
+  }
+
+  @Test("The highlight is always a row that is on screen")
+  func theHighlightIsAlwaysVisible() throws {
+    let (model, _) = makeModel(heardRanking: ranking(["Codex", "Claude Code"], preselecting: nil))
+
+    model.moveHighlight(by: 1)
+    let id = try #require(model.ranking.preselectedID)
+
+    #expect(model.ranking.candidates.contains { $0.id == id })
+  }
+}

--- a/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelModelTests.swift
+++ b/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelModelTests.swift
@@ -250,4 +250,63 @@ struct QuickAddPanelModelTests {
 
     #expect(model.ranking.candidates.contains { $0.id == id })
   }
+  // MARK: - Which sentence the group header says (#2381, the command-bar layout)
+
+  private func headerState(
+    heard: String = "codecs",
+    refusal: SelectionReader.Refusal? = nil,
+    heardRanking: QuickAddRanker.Ranking,
+    query: String = ""
+  ) -> QuickAddPanelCopy.GroupHeaderState {
+    let (model, _) = makeModel(
+      heard: heard, refusal: refusal, heardRanking: heardRanking, searchRanking: heardRanking)
+    if !query.isEmpty { model.updateQuery(query) }
+    let view = QuickAddPanelView(
+      model: model, onAccept: { _ in }, onCreateNew: {}, onCancel: {})
+    return view.headerState
+  }
+
+  @Test("A preselected row means the header states the verb")
+  func headerIsConfidentWhenARowIsPreselected() {
+    #expect(headerState(heardRanking: ranking(["Codex"], preselecting: 0)) == .confident)
+  }
+
+  @Test("No preselection means the header says there is no close match")
+  func headerIsLowConfidenceWithNoPreselection() {
+    // The confidence bar's whole job, said in words. Without this the two states look identical
+    // apart from a missing tint, which is not a signal anyone reads.
+    #expect(headerState(heardRanking: ranking(["Codex"], preselecting: nil)) == .lowConfidence)
+  }
+
+  @Test("Typing keeps the verb, so the header cannot rewrite itself mid-keystroke")
+  func headerStaysConfidentWhileSearching() {
+    #expect(
+      headerState(heardRanking: ranking(["Codex"], preselecting: 0), query: "cod") == .searching)
+  }
+
+  @Test("A preselected row that already has the spelling changes what the header says")
+  func headerIsAlreadySavedWhenTheTopRowHasIt() {
+    // The state the view never used to read at all. It outranks the others deliberately: if the
+    // preselected row cannot add anything, a header promising an add is the defect this closes.
+    let owned = QuickAddRanker.Candidate(
+      word: CustomWord(canonical: "Codex", aliases: ["codecs"]),
+      score: 1.0,
+      alreadyHasHeardSpelling: true)
+    let r = QuickAddRanker.Ranking(candidates: [owned], preselectedID: owned.id)
+
+    #expect(headerState(heardRanking: r) == .alreadySaved)
+  }
+
+  @Test("Already-saved outranks searching, because typing does not make the row addable")
+  func alreadySavedOutranksSearching() {
+    // The paired ordering case. Without it the four-way `if` could be written in any order and
+    // still pass every test above.
+    let owned = QuickAddRanker.Candidate(
+      word: CustomWord(canonical: "Codex", aliases: ["codecs"]),
+      score: 1.0,
+      alreadyHasHeardSpelling: true)
+    let r = QuickAddRanker.Ranking(candidates: [owned], preselectedID: owned.id)
+
+    #expect(headerState(heardRanking: r, query: "cod") == .alreadySaved)
+  }
 }

--- a/Tests/RuntimeUAT/ptt_binding.py
+++ b/Tests/RuntimeUAT/ptt_binding.py
@@ -436,20 +436,52 @@ def assert_canonical_defaults_match_swift() -> None:
 
     raw_keycode = swift.get("toggleKeyCode", "")
     match = re.fullmatch(r"Int\(ModifierKeyCodes\.(\w+)\)", raw_keycode)
-    if match is None:
-        raise AssertionError(
-            f"toggleKeyCode default is no longer Int(ModifierKeyCodes.x): {raw_keycode!r}"
+    if match is not None:
+        symbol = match.group(1)
+    else:
+        # #2381 moved every shortcut default onto ONE owner, `ShortcutRole`, because three files
+        # each holding their own copy is what shipped a stored, displayed, inert Quick Add binding
+        # (#1991 blocker 2, reproduced during that build). So `SettingsDefaultValues.toggleKeyCode`
+        # is now `Int(ShortcutRole.record.defaultKeyCode)` and this check has one more hop to make.
+        #
+        # FOLLOWED, not relaxed. Widening the regex to accept any expression would keep this case
+        # green while it stopped checking anything, which is the shape it exists to prevent one
+        # module over — a guard that runs, matches, and has matching read as agreement. The hop is
+        # resolved to a real `ModifierKeyCodes` symbol or this still fails.
+        role_match = re.fullmatch(r"Int\(ShortcutRole\.(\w+)\.defaultKeyCode\)", raw_keycode)
+        if role_match is None:
+            raise AssertionError(
+                "toggleKeyCode default is neither Int(ModifierKeyCodes.x) nor "
+                f"Int(ShortcutRole.<role>.defaultKeyCode): {raw_keycode!r}"
+            )
+        symbol = _shortcut_role_default_key_symbol(
+            root / "Sources/EnviousWisprServices/ShortcutBinding.swift", role_match.group(1)
         )
-    expected = modifier_codes.get(match.group(1))
+    expected = modifier_codes.get(symbol)
     if expected != DEFAULT_TOGGLE_KEY_CODE:
         raise AssertionError(
             f"DEFAULT_TOGGLE_KEY_CODE={DEFAULT_TOGGLE_KEY_CODE} but Swift ships "
-            f"{match.group(1)}={expected}"
+            f"{symbol}={expected}"
         )
-    if swift.get("toggleModifiersRaw") != str(DEFAULT_TOGGLE_MODIFIERS_RAW):
+    raw_modifiers = swift.get("toggleModifiersRaw", "")
+    role_modifiers = re.fullmatch(
+        r"ShortcutRole\.(\w+)\.defaultModifiers\.rawValue", raw_modifiers
+    )
+    if role_modifiers is not None:
+        # Same #2381 indirection as the key code above, and followed the same way: resolved to the
+        # actual modifier LIST in `defaultBinding`, never accepted as "some expression".
+        shipped_modifiers = _shortcut_role_default_modifier_names(
+            root / "Sources/EnviousWisprServices/ShortcutBinding.swift", role_modifiers.group(1)
+        )
+        if shipped_modifiers:
+            raise AssertionError(
+                f"DEFAULT_TOGGLE_MODIFIERS_RAW={DEFAULT_TOGGLE_MODIFIERS_RAW} means NO modifiers, "
+                f"but Swift ships {shipped_modifiers}"
+            )
+    elif raw_modifiers != str(DEFAULT_TOGGLE_MODIFIERS_RAW):
         raise AssertionError(
             f"DEFAULT_TOGGLE_MODIFIERS_RAW={DEFAULT_TOGGLE_MODIFIERS_RAW} but Swift "
-            f"ships {swift.get('toggleModifiersRaw')!r}"
+            f"ships {raw_modifiers!r}"
         )
     if swift.get("recordingMode") != f".{DEFAULT_RECORDING_MODE}":
         raise AssertionError(
@@ -684,6 +716,58 @@ def _case_domain_export_is_read_once() -> None:
 
 def _case_swift_python_modifier_parity() -> None:
     assert_modifier_table_parity()
+
+
+def _shortcut_role_default_key_symbol(path: Path, role: str) -> str:
+    """The `ModifierKeyCodes` symbol a `ShortcutRole` case resolves to.
+
+    Reads `defaultBinding`'s switch, which is the ONE place a shortcut default is written since
+    #2381. Refuses rather than guesses: a case that ships a bare integer, or a role this cannot
+    find, raises — because the caller's whole job is to prove Python and Swift agree on a number,
+    and a resolver that shrugs turns that proof into a formality.
+    """
+    source = path.read_text(encoding="utf-8")
+    body = re.search(
+        r"var defaultBinding: ShortcutBinding \{(.*?)\n  \}", source, re.S
+    )
+    if body is None:
+        raise AssertionError("ShortcutRole.defaultBinding not found in ShortcutBinding.swift")
+    case_match = re.search(
+        rf"case \.{re.escape(role)}:\s*\.keyboard\(keyCode:\s*([^,]+),", body.group(1)
+    )
+    if case_match is None:
+        raise AssertionError(f"ShortcutRole.{role} has no .keyboard default in defaultBinding")
+    expression = case_match.group(1).strip()
+    symbol = re.fullmatch(r"ModifierKeyCodes\.(\w+)", expression)
+    if symbol is None:
+        raise AssertionError(
+            f"ShortcutRole.{role} ships {expression!r}, not a ModifierKeyCodes symbol, so this "
+            "check cannot resolve it to a key code"
+        )
+    return symbol.group(1)
+
+
+def _shortcut_role_default_modifier_names(path: Path, role: str) -> list[str]:
+    """The modifier names a `ShortcutRole` case ships, or [] for a bare key.
+
+    Returns names rather than a raw value on purpose: this file cannot evaluate
+    `NSEvent.ModifierFlags`, and inventing an arithmetic model of it here would be a second
+    implementation of a thing Swift already owns. The caller only needs to know whether the set is
+    EMPTY, which is a question the source answers directly.
+    """
+    source = path.read_text(encoding="utf-8")
+    body = re.search(
+        r"var defaultBinding: ShortcutBinding \{(.*?)\n  \}", source, re.S
+    )
+    if body is None:
+        raise AssertionError("ShortcutRole.defaultBinding not found in ShortcutBinding.swift")
+    case_match = re.search(
+        rf"case \.{re.escape(role)}:\s*\.keyboard\([^)]*modifiers:\s*\[([^\]]*)\]",
+        body.group(1),
+    )
+    if case_match is None:
+        raise AssertionError(f"ShortcutRole.{role} has no modifiers list in defaultBinding")
+    return [m.strip() for m in case_match.group(1).split(",") if m.strip()]
 
 
 def _case_canonical_defaults_match_swift() -> None:


### PR DESCRIPTION
Closes #2381

Select a misheard word anywhere on macOS, press a shortcut or use the right-click Services item, and a small panel ranks that spelling against your saved custom words so one Return adds it as an alias.

Nobody else does this. A sweep of the competitor audits on disk found four rivals with PASSIVE auto-learn (Wispr Flow, Juno, FluidVoice, TypeWhisper) and **zero with active capture** — no selection-plus-shortcut, no Services entry, no right-click, no URL scheme, no Shortcuts action, no clipboard watching.

## Two doors, one panel

**Door A, the shortcut.** Control-Option-W by default. Reads `AXSelectedText` from the frontmost app's focused element, holds it in memory, and never writes it anywhere.

**Door B, right-click → Services.** The provider takes the text it is HANDED rather than asking Accessibility a second question about whatever is frontmost by then, which by that point may be us.

## What the panel looks like, and why it was rebuilt

The founder saw the first build and said the UX was not good enough. Three directions went to review; he chose the command bar, with one change: *"we should make the search bar more obvious"*.

**The field did not read as typable, and it was not size.** It was already the widest, topmost element — size was never the variable. It had no EDGES: a full-bleed strip on a panel made of full-bleed strips looks like a title area. Now a 38pt well with a magnifier, a focus ring and a visible caret.

**The pill is gone.** The selected word used to ride inside the field, occupying exactly the slot the magnifier needs. Moving it to the group header made room for the glyph that does the work AND retired the only genuinely fiddly piece of SwiftUI in the design.

**353pt, down from 565.** Not by trimming: the verb is stated once in a group header instead of repeated on every row, so five candidates cost five lines rather than the ten that four wrapped subtitles cost.

**The header is also the confidence signal, in words.** Below the bar nothing is preselected, and the two states used to differ only by a missing tint. It now says "No close match · pick one or keep typing".

**The keyboard legend is derived, not fixed.** The Return cap appears only when a row is actually preselected, so it can never promise a key that will not answer.

## Ranking, measured rather than asserted

Confidence bar 0.55, from a sweep. User words are preferred over shipped pack terms: without that rule the sweep produced wrong-word wins (`sarag`→`Suarez`, `dot md`→`dotnet`); with it, 91.9% correct.

The search field FILTERS by containment rather than fuzzy-ranking, so it can return nothing — and accepting any row always writes the ORIGINAL selection, never the query used to find it. Without that, the escape hatch built to recover from a wrong ranking becomes a way to write an arbitrary string into the library.

## What this ships as a limb

Removing `App/QuickAdd/`, `Views/QuickAdd/`, `PostProcessing/QuickAdd/`, `SelectionReader.swift`, the two `TelemetryService` methods, the `NSServices` block and the composition-root wiring leaves the app compiling with **zero surviving mentions of the feature anywhere in `Sources` or `Tests`**. Measured in a detached worktree and two-way controlled: 839 compile lines prove the build ran, a surviving file appears in the log, and the deleted code appears zero times.

## The defect class this branch spent the night on

**One thing, over and over: the app doing something other than what it told the user it did.** Every row below is that, and each was found by a DIFFERENT instrument — which is the part worth recording, and the reason no count is given here. The table is the measurement; a number in the sentence above it would have to be edited every time a row lands, and has not been.

| Found by | Defect |
|---|---|
| whole-diff self-review | a refused write closed the panel as if it had worked |
| review round 1 | the Services door validated nothing; create-new with an existing name saved nothing and closed; an unreadable words file showed no panel at all |
| review round 2 | the edit sheet closed the panel that presents it; two Carbon hotkeys could collide so Quick Add stole Cancel's key; `update` could no-op and report success |
| enumeration | an unmeasurable panel left an `opened` with nothing to resolve it; a confirmed save emitted nothing |
| review round 3 | a refused write then a cancel produced two terminal events for one open |
| **Live UAT** | **the panel cancelled itself on any focus change — measured at 339 ms and 19.7 s, both from an unrelated process taking key** |
| **design pass** | **the view never read `alreadyHasHeardSpelling`, so a row promised an add it could not make** |
| review round 4 | an accept merged into the SNAPSHOT taken when the panel opened, so an edit made in Settings while it sat open was reverted by a write that reported success |
| **review round 5** | **Create New onto a name that already exists and already has the spelling wrote nothing and reported a creation — and a test of mine asserted that cell as correct, with a justification, which is why three rounds read past it** |
| review round 6 | the already-saved guard ran BEFORE the live lookup, so a spelling REMOVED in Settings while the panel sat open still reported "already saved" and wrote nothing — the mirror of round 4's defect, inside round 4's fix |
| **my own enumeration** | **`targetKind` was taken from the ranking, so overriding a pack term mid-panel wrote a user word and filed it as a pack term. Found by sweeping the class after two rounds shared a root, not by a seventh review** |
| review round 7 | pressing the shortcut with nothing selected showed a message blaming the frontmost app for withholding a selection, naming terminals — the likeliest refusal there is; a pack row sharing a canonical with a user word saved nothing and reported success; and a shared cancel/Quick Add modifier let one cancel gesture also open the panel |

The last two are the argument for doing both. Three review rounds, a four-axis enumeration and 6,800 tests found neither: no test can observe window key state, and the `alreadyHasHeardSpelling` miss is an OMISSION between the view and the model rather than a wrong line in a diff.

**A session gate refused a third review round** on the rule that N rounds of one finding per round means the self-audit was too shallow. The enumeration it forced found two defects three rounds had missed; the confirming round then found four the enumeration had missed. Neither instrument dominates. §10k and §10l in the plan record both, including where the enumeration's own stated property was falsified.

## Receipts

- Debug 6,817 / Release 6,167, both green. Nine full lane runs across the branch, and **every delta equalled the tests written, in both lanes** — the reconciliation is the check, not the total.
- Nine new suites: ranker 31, selection reader 24, shortcut 16, keybind row defaults 7, panel keyboard contract 20, panel copy 15, coordinator 30, Services declaration 8, telemetry privacy 6.
- **Every pre-existing behaviour test passed against the rebuilt layout unchanged.** The keyboard contract, the highlight rules and the write-the-selection guarantee survived a full visual rebuild with no edits.
- Live UAT: door B registered and reachable, ranking correct, the selected word absent from the log on every run, and the self-dismissal fix proven with the exact gesture that used to trigger it.

## Privacy

The selected word is held in memory, never transmitted, and never written to the local log — including under Debug Mode. Telemetry carries a character count, a similarity score, a closed-set outcome token and the source app's bundle id, which is metadata about an APP.

Note for anyone planning support around this: a RELEASE build writes no `app.log` at all, so those lines are for local reproduction and dev-build UAT, never something a shipped user can send in.

## Not in this change

The approved design also has a confirmation pill after a save and an inline one-field create flow. Both reach into the dictation overlay's state machine, rebuilt from a 1,448-line file in #2292, and one has a trap already identified: `reduceImportStatus` silently returns `.noChange` when another pill owns the slot, so reusing it for "it worked" would reintroduce the exact class this branch closed. Filed as #2391 with the reasoning and both decisions.

## Overnight hardening

Mutation recipes are filed rather than run inline, per the founder's rule that no mutant runs in his day: #2383, #2384, #2385, #2386, #2387, #2388, #2397, #2403. Between them they declare five expected survivors with the reason each is unreachable, so an overnight session cannot quietly report them caught.




