### PR TITLE
feat(delivery): every delivery event reaches the local log, through one switch (#2135)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/ModelDeliveryHome.swift
+++ b/Sources/EnviousWisprAppKit/App/ModelDeliveryHome.swift
@@ -721,7 +721,10 @@ enum ModelDeliveryTelemetryBridge {
         props["source_id"] = failingSourceID
       }
       if let detail { props["detail"] = detail }
-    case .sourceFailover(let reason):
+    // The two source ids are LOCAL-LOG ONLY (#2135) and are deliberately
+    // dropped here: adding them would change this event's PostHog shape,
+    // which this issue's subject is not.
+    case .sourceFailover(let reason, _, _):
       name = "source_failover"
       props["reason"] = reason.rawValue
     case .validationRepair(let componentsCount, let trigger):

--- a/Sources/EnviousWisprModelDelivery/DeliveryTypes.swift
+++ b/Sources/EnviousWisprModelDelivery/DeliveryTypes.swift
@@ -86,7 +86,14 @@ public enum DeliveryEvent: Sendable, Equatable {
     durationBucket: String, bytesDownloadedBucket: String, sourcesUsed: Int,
     finalSourceID: String, repairedComponentsCount: Int)
   case attemptFailed(reason: DeliveryFailureClass, failingSourceID: String?, detail: String?)
-  case sourceFailover(reason: DeliveryFailureClass)
+  /// `fromSourceID`/`toSourceID` exist for the LOCAL log and nothing else
+  /// (#2135). `reason` alone cannot say which mirror fell over or which took
+  /// over, and "a mirror fell over" is the whole diagnostic value of this
+  /// event — the values are discarded inside `ManifestFetchTask` before the
+  /// event is built, so `emit` cannot recover them. The telemetry bridge
+  /// deliberately ignores both, so no PostHog name or property changes.
+  case sourceFailover(
+    reason: DeliveryFailureClass, fromSourceID: String, toSourceID: String)
   case validationRepair(componentsCount: Int, trigger: ValidationTrigger)
   case cancel(phaseAtCancel: String, resumable: Bool)
   case flagActive(flag: String, value: String)

--- a/Sources/EnviousWisprModelDelivery/ManifestFetchTask.swift
+++ b/Sources/EnviousWisprModelDelivery/ManifestFetchTask.swift
@@ -32,7 +32,9 @@ struct ManifestFetchTask {
   /// denominator baseline so the UI fraction covers the WHOLE set honestly.
   let verifiedInPlaceBytes: Int64
   let onProgress: @Sendable (_ bytesWritten: Int64, _ totalBytes: Int64) -> Void
-  let onSourceFailover: @Sendable (DeliveryFailureClass) -> Void
+  let onSourceFailover:
+    @Sendable (_ reason: DeliveryFailureClass, _ fromSourceID: String, _ toSourceID: String)
+      -> Void
 
   /// Phase 2 (#1405): the inter-attempt backoff sleep, injectable so tests
   /// advance it without wall-clock waits (`swift-patterns` timing-seam-shapes;
@@ -233,12 +235,15 @@ struct ManifestFetchTask {
             }
             throw failure
           }
+          let fromSourceID = sources[sourceIndex].id
           sourceIndex += 1
           sourcesUsed = 2
           // Retry budget is PER SOURCE (#1405 §6): the backup gets its own N
           // transient retries, so reset the counter on failover (Codex r1 P2).
           networkRetriesUsed = 0
-          onSourceFailover(failure.reason)
+          // In bounds: the guard above returns unless `sourceIndex + 1` is a
+          // valid index, so reading AFTER the increment is safe (#2135).
+          onSourceFailover(failure.reason, fromSourceID, sources[sourceIndex].id)
         }
       }
     }

--- a/Sources/EnviousWisprModelDelivery/ManifestFetchTask.swift
+++ b/Sources/EnviousWisprModelDelivery/ManifestFetchTask.swift
@@ -32,9 +32,17 @@ struct ManifestFetchTask {
   /// denominator baseline so the UI fraction covers the WHOLE set honestly.
   let verifiedInPlaceBytes: Int64
   let onProgress: @Sendable (_ bytesWritten: Int64, _ totalBytes: Int64) -> Void
+  /// AWAITED, not fire-and-forget (#2135 cloud review P2). Emitting this from
+  /// an unstructured `Task` leaves it unordered against the continuation the
+  /// controller is awaiting here, so a fast backup or a cancel could publish a
+  /// TERMINAL event first — and a cancel that bumps the generation first makes
+  /// the controller's own guard drop the failover entirely. Awaiting makes the
+  /// notification part of the fetch path, which is where it already belonged:
+  /// this is the slow branch by construction, since it runs only when a mirror
+  /// has already failed and another is about to be tried.
   let onSourceFailover:
     @Sendable (_ reason: DeliveryFailureClass, _ fromSourceID: String, _ toSourceID: String)
-      -> Void
+      async -> Void
 
   /// Phase 2 (#1405): the inter-attempt backoff sleep, injectable so tests
   /// advance it without wall-clock waits (`swift-patterns` timing-seam-shapes;
@@ -243,7 +251,7 @@ struct ManifestFetchTask {
           networkRetriesUsed = 0
           // In bounds: the guard above returns unless `sourceIndex + 1` is a
           // valid index, so reading AFTER the increment is safe (#2135).
-          onSourceFailover(failure.reason, fromSourceID, sources[sourceIndex].id)
+          await onSourceFailover(failure.reason, fromSourceID, sources[sourceIndex].id)
         }
       }
     }

--- a/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
+++ b/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
@@ -623,8 +623,12 @@ public actor ModelDeliveryController {
             identity, bytes: bytes, total: total, generation: generation)
         }
       },
-      onSourceFailover: { reason in
-        Task { await controller.noteFailover(identity, reason: reason, generation: generation) }
+      onSourceFailover: { reason, fromSourceID, toSourceID in
+        Task {
+          await controller.noteFailover(
+            identity, reason: reason, fromSourceID: fromSourceID, toSourceID: toSourceID,
+            generation: generation)
+        }
       })
 
     do {
@@ -662,8 +666,10 @@ public actor ModelDeliveryController {
       // abandoned before this launch; this one catches anything superseded by
       // the admission that just happened.
       sweepSupersededStaging(registration)
-      await AppLogger.shared.log(
-        "Model delivery admitted \(identity.cacheKey)", level: .info, category: "Delivery")
+      // The local line is written by the `.attemptCompleted` arm of
+      // `deliveryLogLine` (#2135). An ad-hoc call here as well would print TWO
+      // lines for one admission, and a doubled line invites reading one
+      // occurrence as two — the misreading this issue exists to prevent.
       return .admitted
     } catch let failure as DeliveryFailure where failure.reason == .cancelled {
       return finishCancelled(identity, generation: generation)
@@ -700,10 +706,9 @@ public actor ModelDeliveryController {
       identity,
       .attemptFailed(
         reason: failure.reason, failingSourceID: failure.failingSourceID, detail: failure.detail))
-    let detailSuffix = failure.detail.map { " (\($0))" } ?? ""
-    await AppLogger.shared.log(
-      "Model delivery failed \(identity.cacheKey): \(failure.reason.rawValue)\(detailSuffix)",
-      level: .info, category: "Delivery")
+    // The local line is written by the `.attemptFailed` arm of
+    // `deliveryLogLine` (#2135), from the emit two statements above. It carries
+    // the failing source id as well, which this call could not.
     return .failed(failure)
   }
 
@@ -752,10 +757,13 @@ public actor ModelDeliveryController {
   }
 
   private func noteFailover(
-    _ identity: ModelIdentity, reason: DeliveryFailureClass, generation: Int
+    _ identity: ModelIdentity, reason: DeliveryFailureClass, fromSourceID: String,
+    toSourceID: String, generation: Int
   ) {
     guard entries[identity]?.generation == generation else { return }
-    emit(identity, .sourceFailover(reason: reason))
+    emit(
+      identity,
+      .sourceFailover(reason: reason, fromSourceID: fromSourceID, toSourceID: toSourceID))
   }
 
   private func setState(
@@ -782,6 +790,9 @@ public actor ModelDeliveryController {
   }
 
   private func emit(_ identity: ModelIdentity, _ event: DeliveryEvent) {
+    #if DEBUG
+      enqueueDeliveryLog(identity, event)
+    #endif
     guard !eventObservers.isEmpty else {
       // Pre-attach buffer (drained by the first `addEventObserver`). Bounded:
       // a launch window emits a handful of events; if something pathological
@@ -792,6 +803,116 @@ public actor ModelDeliveryController {
     }
     for observer in eventObservers { observer(identity, event) }
   }
+
+  // MARK: - Local log (#2135)
+
+  #if DEBUG
+
+    /// Emit order, minted on this actor. Present in every line so a reader can
+    /// see a gap, and so a residual reordering is legible rather than silently
+    /// wrong.
+    private var deliveryLogSequence: UInt64 = 0
+
+    /// The tail of a chain of writes. Each write awaits its predecessor, so the
+    /// FILE order matches emit order. Separate unstructured `Task`s are not
+    /// FIFO, and this log's whole value is that a sequence can be read top to
+    /// bottom — a sequence number alone would make disorder auditable, never
+    /// readable.
+    ///
+    /// Best-effort at process termination, stated rather than hidden:
+    /// `applicationWillTerminate` is synchronous and cannot await this tail, so
+    /// a rapid quit or a `kill -9` can discard unwritten lines. Guaranteeing a
+    /// drain needs a wider asynchronous-termination design, which is not
+    /// justified for a debug diagnostic.
+    private var deliveryLogTail: Task<Void, Never>?
+
+    /// Test seam. A recorder installed HERE observes the production enqueue
+    /// path — the same rendering, the same chain, the same call site — rather
+    /// than a substitute renderer, which would prove a stub instead of the
+    /// production body.
+    private var deliveryLogSinkForTesting: (@Sendable (String) async -> Void)?
+
+    package func setDeliveryLogSinkForTesting(_ sink: (@Sendable (String) async -> Void)?) {
+      deliveryLogSinkForTesting = sink
+    }
+
+    /// Await the write chain. Tests need this because the assertion is about
+    /// what LANDED, and the chain is the thing that decides when that is true.
+    package func flushDeliveryLogsForTesting() async {
+      await deliveryLogTail?.value
+    }
+
+    /// Render on the actor, in emit order, then hand the finished string off.
+    /// The string is therefore correct whatever the writer does.
+    private func enqueueDeliveryLog(_ identity: ModelIdentity, _ event: DeliveryEvent) {
+      deliveryLogSequence &+= 1
+      let line = Self.deliveryLogLine(
+        identity: identity, event: event, sequence: deliveryLogSequence)
+      let previous = deliveryLogTail
+      let sink = deliveryLogSinkForTesting
+      deliveryLogTail = Task {
+        await previous?.value
+        if let sink {
+          await sink(line)
+        } else {
+          await AppLogger.shared.log(line, level: .info, category: "Delivery")
+        }
+      }
+    }
+
+    /// The ONE place a `DeliveryEvent` becomes a local log line.
+    ///
+    /// A `switch` rather than a list of call sites, and that is the mechanism
+    /// rather than a preference: the compiler owns exhaustiveness, so a ninth
+    /// event fails to BUILD here until someone decides its line. A hand-written
+    /// list is a convention, and a convention with a comment claiming it is
+    /// exhaustive is how a new enum member gets silently dropped (#2207).
+    ///
+    /// `Model delivery admitted` and `Model delivery failed` reproduce the
+    /// wording of the two ad-hoc lines this replaces, verbatim, because those
+    /// are what someone greps for today.
+    package static func deliveryLogLine(
+      identity: ModelIdentity, event: DeliveryEvent, sequence: UInt64
+    ) -> String {
+      let prefix = "[delivery #\(sequence)]"
+      let key = identity.cacheKey
+      switch event {
+      case .attemptStarted(let resumed):
+        return "\(prefix) Model delivery attempt started \(key): resumed=\(resumed)"
+      case .attemptCompleted(
+        let durationBucket, let bytesDownloadedBucket, let sourcesUsed, let finalSourceID,
+        let repairedComponentsCount):
+        return
+          "\(prefix) Model delivery admitted \(key): duration=\(durationBucket) "
+          + "bytes=\(bytesDownloadedBucket) sources=\(sourcesUsed) "
+          + "final_source=\(finalSourceID) repaired=\(repairedComponentsCount)"
+      case .attemptFailed(let reason, let failingSourceID, let detail):
+        let detailSuffix = detail.map { " (\($0))" } ?? ""
+        let sourceSuffix = failingSourceID.map { " source=\($0)" } ?? ""
+        return
+          "\(prefix) Model delivery failed \(key): \(reason.rawValue)\(detailSuffix)"
+          + sourceSuffix
+      case .sourceFailover(let reason, let fromSourceID, let toSourceID):
+        return
+          "\(prefix) Model delivery source failover \(key): \(fromSourceID) -> "
+          + "\(toSourceID), reason=\(reason.rawValue)"
+      case .validationRepair(let componentsCount, let trigger):
+        return
+          "\(prefix) Model delivery validation repair \(key): "
+          + "components=\(componentsCount) trigger=\(trigger.rawValue)"
+      case .cancel(let phaseAtCancel, let resumable):
+        return
+          "\(prefix) Model delivery cancelled \(key): phase=\(phaseAtCancel) "
+          + "resumable=\(resumable)"
+      case .flagActive(let flag, let value):
+        return "\(prefix) Model delivery flag active \(key): \(flag)=\(value)"
+      case .admittedWithoutFetch(let reason):
+        return
+          "\(prefix) Model delivery admitted \(key) without fetch: reason=\(reason.rawValue)"
+      }
+    }
+
+  #endif
 
   // MARK: - Paths + disk
 

--- a/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
+++ b/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
@@ -760,14 +760,41 @@ public actor ModelDeliveryController {
     setState(identity, .preparing(validatingExistingCache: true))
   }
 
+  /// **The local log and telemetry legitimately disagree here, and only here.**
+  ///
+  /// Awaiting this call orders it against the `fetchTask.run()` continuation. It
+  /// does NOT order it against a concurrent `cancel()`: both enter this actor,
+  /// and a cancel serviced first bumps the generation, after which the guard
+  /// below discards the event (#2135 cloud review, round 2).
+  ///
+  /// Dropping it is CORRECT for telemetry and WRONG for the log, because the two
+  /// answer different questions. **A telemetry event is a claim about an
+  /// attempt**, so an event belonging to a superseded generation must not be
+  /// attributed to the live one — that is exactly what the guard is for.
+  /// **A log line is a record of an occurrence**, and the failover genuinely
+  /// happened, before the cancel, whatever the generation did afterwards.
+  /// Suppressing it makes the log lie by omission about a real event — and a
+  /// missing line reads as "it did not happen", which is the direction that
+  /// produces confidently wrong conclusions.
+  ///
+  /// So the line is written unconditionally and the EMIT stays guarded. This is
+  /// the one place these two channels diverge; everywhere else the switch inside
+  /// `emit` serves both. Do not "tidy" this by moving the log back below the
+  /// guard, and do not fix it by relaxing the guard — the guard is right about
+  /// its own question.
   private func noteFailover(
     _ identity: ModelIdentity, reason: DeliveryFailureClass, fromSourceID: String,
     toSourceID: String, generation: Int
   ) {
-    guard entries[identity]?.generation == generation else { return }
-    emit(
-      identity,
-      .sourceFailover(reason: reason, fromSourceID: fromSourceID, toSourceID: toSourceID))
+    let event = DeliveryEvent.sourceFailover(
+      reason: reason, fromSourceID: fromSourceID, toSourceID: toSourceID)
+    guard entries[identity]?.generation == generation else {
+      #if DEBUG
+        enqueueDeliveryLog(identity, event)
+      #endif
+      return
+    }
+    emit(identity, event)
   }
 
   private func setState(

--- a/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
+++ b/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
@@ -624,11 +624,15 @@ public actor ModelDeliveryController {
         }
       },
       onSourceFailover: { reason, fromSourceID, toSourceID in
-        Task {
-          await controller.noteFailover(
-            identity, reason: reason, fromSourceID: fromSourceID, toSourceID: toSourceID,
-            generation: generation)
-        }
+        // Awaited rather than spawned. See `onSourceFailover`'s own doc: a
+        // detached Task here is unordered against the `fetchTask.run()`
+        // continuation below, which can publish a terminal event first or let a
+        // cancel bump the generation so this call's guard drops the failover.
+        // Re-entering the actor is safe: the controller is SUSPENDED at that
+        // await, so it is not held.
+        await controller.noteFailover(
+          identity, reason: reason, fromSourceID: fromSourceID, toSourceID: toSourceID,
+          generation: generation)
       })
 
     do {

--- a/Tests/EnviousWisprTests/ModelDelivery/DeliveryLocalLogTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/DeliveryLocalLogTests.swift
@@ -1,0 +1,184 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprModelDelivery
+
+/// #2135 — every `DeliveryEvent` reaches the LOCAL log.
+///
+/// **Observability Contract, not product coverage.** When these fail, no user
+/// sees anything; what breaks is our ability to explain a download from a log
+/// someone sends us. Declared so the count is never cited as product safety.
+///
+/// The whole surface is `#if DEBUG`, because the renderer and its writer are:
+/// `AppLogger` compiles to a no-op in release, so building the string and
+/// scheduling the write there would be cost paid for a sink that is not present.
+#if DEBUG
+
+  @Suite(.tags(.observabilityContract))
+  struct DeliveryLocalLogTests {
+
+    private static let identity = ModelIdentity(
+      family: .parakeet, name: "test-model", revision: "v1", variant: "unit",
+      runtimeABI: "test")
+
+    /// This suite's OWN defaults suite, never the shared one. A controller
+    /// reading the real store would make these assertions depend on whatever
+    /// delivery flags a developer happens to have set.
+    private func testDefaults() -> UserDefaults {
+      UserDefaults(suiteName: "ew-2135-local-log-\(UUID().uuidString)") ?? .standard
+    }
+
+    /// Pins the EXACT line for every case the enum currently has.
+    ///
+    /// **Deliberately not "distinct and non-empty".** Eight garbage strings
+    /// satisfy that, and so does any renderer that silently drops a field. The
+    /// fields ARE the diagnostic — "a failover happened" without naming which
+    /// mirror fell over is the shape this issue exists to remove.
+    ///
+    /// This is SEMANTIC coverage and makes no claim to enumerate the enum: the
+    /// exhaustiveness mechanism is the `switch` in `deliveryLogLine`, which the
+    /// compiler owns. A ninth case fails to BUILD there; it does not fail here,
+    /// and a test that counted cases would be a number that must track code.
+    ///
+    /// `Model delivery admitted` and `Model delivery failed` are asserted
+    /// verbatim because two ad-hoc call sites used to print exactly those words
+    /// and someone greps for them today.
+    @Test("every delivery event renders its own line, with its own fields")
+    func everyEventRendersItsFields() {
+      let key = Self.identity.cacheKey
+      func line(_ event: DeliveryEvent, _ sequence: UInt64 = 1) -> String {
+        ModelDeliveryController.deliveryLogLine(
+          identity: Self.identity, event: event, sequence: sequence)
+      }
+
+      #expect(
+        line(.attemptStarted(resumed: true))
+          == "[delivery #1] Model delivery attempt started \(key): resumed=true")
+
+      #expect(
+        line(
+          .attemptCompleted(
+            durationBucket: "10_30s", bytesDownloadedBucket: "100_500mb", sourcesUsed: 2,
+            finalSourceID: "backup", repairedComponentsCount: 1))
+          == "[delivery #1] Model delivery admitted \(key): duration=10_30s "
+            + "bytes=100_500mb sources=2 final_source=backup repaired=1")
+
+      #expect(
+        line(
+          .attemptFailed(
+            reason: .sourceTimeout, failingSourceID: "primary", detail: "read_timeout"))
+          == "[delivery #1] Model delivery failed \(key): source_timeout (read_timeout) "
+            + "source=primary")
+
+      #expect(
+        line(.attemptFailed(reason: .insufficientDisk, failingSourceID: nil, detail: nil))
+          == "[delivery #1] Model delivery failed \(key): insufficient_disk",
+        "an absent source and detail must add nothing, not empty parentheses")
+
+      #expect(
+        line(
+          .sourceFailover(reason: .source5xx, fromSourceID: "primary", toSourceID: "backup"))
+          == "[delivery #1] Model delivery source failover \(key): primary -> backup, "
+            + "reason=source_5xx",
+        "naming the transition IS the diagnostic: reason alone cannot say which mirror fell over")
+
+      #expect(
+        line(.validationRepair(componentsCount: 3, trigger: .loadMiss))
+          == "[delivery #1] Model delivery validation repair \(key): components=3 "
+            + "trigger=load_miss")
+
+      #expect(
+        line(.cancel(phaseAtCancel: "downloading", resumable: true))
+          == "[delivery #1] Model delivery cancelled \(key): phase=downloading resumable=true")
+
+      #expect(
+        line(.flagActive(flag: "modelDelivery.parakeet.sourceOrder", value: "backup_first"))
+          == "[delivery #1] Model delivery flag active \(key): "
+            + "modelDelivery.parakeet.sourceOrder=backup_first")
+
+      #expect(
+        line(.admittedWithoutFetch(reason: .markerFastPath))
+          == "[delivery #1] Model delivery admitted \(key) without fetch: "
+            + "reason=marker_fast_path")
+
+      #expect(
+        line(.attemptStarted(resumed: false), 42).hasPrefix("[delivery #42] "),
+        "the sequence is the line's own, not a constant")
+    }
+
+    /// The local log is written ABOVE the telemetry observer guard, and in order.
+    ///
+    /// **Both halves are load-bearing and the case is built to prove them
+    /// together, because either alone is satisfiable by the wrong code.**
+    ///
+    /// NO event observer is attached. `emit` returns early into a bounded
+    /// 64-entry buffer in that state, so a log call placed below that guard —
+    /// or hung off an observer — would produce NOTHING here. That is the
+    /// failure this case exists to catch, and it is exactly the state a
+    /// launch-window delivery problem happens in.
+    ///
+    /// **100 events, not 8, and the number is chosen rather than round.** It
+    /// exceeds the 64-entry buffer, which keeps its FIRST 64 and discards the
+    /// rest. So an implementation that logged from the buffer instead of at the
+    /// door would deliver 64 lines and pass any assertion that only counted
+    /// "some". Asserting all 100 arrive proves the local path is independent of
+    /// that bound rather than merely appearing to be.
+    ///
+    /// Order is asserted, not just arrival: the sequence is minted on the
+    /// controller actor in emit order, and the writer chains each write behind
+    /// its predecessor. Separate unstructured Tasks are not FIFO, so without the
+    /// chain this arrives shuffled — a log whose whole value is being readable
+    /// top to bottom.
+    ///
+    /// The recorder is installed at the PRODUCTION enqueue path, so this drives
+    /// the real renderer and the real chain. It never reads the shared
+    /// `app.log`, which two processes write with no rotation lock (#2159).
+    @Test("100 events reach the local log in order, with no telemetry observer attached")
+    func localLogIsIndependentOfTelemetryAndOrdered() async {
+      let controller = ModelDeliveryController(defaults: testDefaults())
+
+      actor Recorder {
+        var lines: [String] = []
+        func record(_ line: String) { lines.append(line) }
+      }
+      let recorder = Recorder()
+      await controller.setDeliveryLogSinkForTesting { line in await recorder.record(line) }
+
+      let total = 100
+      for index in 0..<total {
+        await controller.noteFlagActive(
+          identity: Self.identity, flag: "probe", value: String(index))
+      }
+      await controller.flushDeliveryLogsForTesting()
+
+      let lines = await recorder.lines
+      #expect(
+        lines.count == total,
+        """
+        expected \(total) lines with NO observer attached; got \(lines.count). Fewer than 100 \
+        (and 64 in particular) means the local log is riding the bounded telemetry buffer \
+        instead of sitting above it
+        """)
+
+      let values = lines.compactMap { line -> Int? in
+        guard let equals = line.lastIndex(of: "=") else { return nil }
+        return Int(line[line.index(after: equals)...])
+      }
+      #expect(
+        values == Array(0..<total),
+        "lines must land in emit order; a shuffled result means the writes are not chained")
+
+      let sequences = lines.compactMap { line -> UInt64? in
+        guard let hash = line.firstIndex(of: "#"), let close = line.firstIndex(of: "]") else {
+          return nil
+        }
+        return UInt64(line[line.index(after: hash)..<close])
+      }
+      #expect(
+        sequences == Array(1...UInt64(total)),
+        "the sequence must be dense and monotonic, so a reader can see a gap")
+    }
+  }
+
+#endif

--- a/Tests/EnviousWisprTests/ModelDelivery/ManifestFetchTaskTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/ManifestFetchTaskTests.swift
@@ -127,7 +127,9 @@ final class DeliveryStubProtocol: URLProtocol {
     manifest: DeliveryManifest, staging: URL, components: Set<String>? = nil,
     backoffSleep: @escaping @Sendable (TimeInterval) async throws -> Void = { _ in },
     jitter: @escaping @Sendable () -> Double = { 1.0 },
-    onFailover: @escaping @Sendable (DeliveryFailureClass) -> Void = { _ in }
+    onFailover: @escaping @Sendable (DeliveryFailureClass, String, String) -> Void = {
+      _, _, _ in
+    }
   ) -> ManifestFetchTask {
     ManifestFetchTask(
       manifest: manifest, stagingDirectory: staging, sources: manifest.sources,
@@ -177,24 +179,39 @@ final class DeliveryStubProtocol: URLProtocol {
           .init(
             status: 200, headers: ["Content-Length": String(f.content.count)], body: f.content))
       }
+      /// Records the whole failover, not just its reason (#2135). The source
+      /// transition is the diagnostic — "a failover happened" cannot say which
+      /// mirror fell over — and a value no test reads is a value that can be
+      /// wrong without anything noticing.
       final class FailoverLog: @unchecked Sendable {
-        private let lock = NSLock()
-        private var reasons: [DeliveryFailureClass] = []
-        func record(_ reason: DeliveryFailureClass) {
-          lock.withLock { reasons.append(reason) }
+        struct Entry: Equatable {
+          let reason: DeliveryFailureClass
+          let from: String
+          let to: String
         }
-        var all: [DeliveryFailureClass] { lock.withLock { reasons } }
+        private let lock = NSLock()
+        private var entries: [Entry] = []
+        func record(_ reason: DeliveryFailureClass, _ from: String, _ to: String) {
+          lock.withLock { entries.append(Entry(reason: reason, from: from, to: to)) }
+        }
+        var all: [Entry] { lock.withLock { entries } }
+        var reasons: [DeliveryFailureClass] { all.map(\.reason) }
       }
       let failovers = FailoverLog()
       let fetchTask = ManifestFetchTask(
         manifest: manifest, stagingDirectory: staging, sources: manifest.sources,
         componentsToFetch: Set(manifest.files.map(\.component)), verifiedInPlaceBytes: 0,
         onProgress: { _, _ in },
-        onSourceFailover: { failovers.record($0) })
+        onSourceFailover: { failovers.record($0, $1, $2) })
       let outcome = try await fetchTask.run()
       #expect(outcome.sourcesUsed == 2)
       #expect(outcome.finalSourceID == "backup")
-      #expect(failovers.all == [.source4xx])
+      #expect(failovers.reasons == [.source4xx])
+      #expect(
+        failovers.all == [
+          FailoverLog.Entry(reason: .source4xx, from: "our_copy", to: "backup")
+        ],
+        "the failover must name the mirror it left and the one it moved to")
     }
   }
 
@@ -346,7 +363,7 @@ final class DeliveryStubProtocol: URLProtocol {
     let fetchTask = ManifestFetchTask(
       manifest: manifest, stagingDirectory: FileManager.default.temporaryDirectory,
       sources: manifest.sources, componentsToFetch: [], verifiedInPlaceBytes: 0,
-      onProgress: { _, _ in }, onSourceFailover: { _ in })
+      onProgress: { _, _ in }, onSourceFailover: { _, _, _ in })
     // (recordedETag, recordedLength, headETag, headLength, existing, expected) -> discard?
     let cases: [(String??, Int64??, String?, Int64?, Int64, Int64, Bool, String)] = [
       (nil, nil, "\"e\"", 10, 5, 10, true, "no identity recorded"),
@@ -495,7 +512,7 @@ final class DeliveryStubProtocol: URLProtocol {
       DeliveryStubProtocol.enqueue(url: mirrorURL(file), okStub(file))
       let failovers = FailoverBox()
       let outcome = try await task(
-        manifest: manifest, staging: staging, onFailover: { failovers.record($0) }
+        manifest: manifest, staging: staging, onFailover: { failovers.record($0, $1, $2) }
       ).run()
       #expect(outcome.sourcesUsed == 1)
       #expect(outcome.finalSourceID == "our_copy")
@@ -511,7 +528,7 @@ final class DeliveryStubProtocol: URLProtocol {
       DeliveryStubProtocol.enqueue(url: backupURL(file), okStub(file))
       let failovers = FailoverBox()
       let outcome = try await task(
-        manifest: manifest, staging: staging, onFailover: { failovers.record($0) }
+        manifest: manifest, staging: staging, onFailover: { failovers.record($0, $1, $2) }
       ).run()
       #expect(outcome.sourcesUsed == 2)
       #expect(outcome.finalSourceID == "backup")
@@ -530,7 +547,7 @@ final class DeliveryStubProtocol: URLProtocol {
       DeliveryStubProtocol.enqueue(url: backupURL(file), okStub(file))
       let failovers = FailoverBox()
       let outcome = try await task(
-        manifest: manifest, staging: staging, onFailover: { failovers.record($0) }
+        manifest: manifest, staging: staging, onFailover: { failovers.record($0, $1, $2) }
       ).run()
       #expect(outcome.sourcesUsed == 2)
       #expect(outcome.finalSourceID == "backup")
@@ -553,7 +570,7 @@ final class DeliveryStubProtocol: URLProtocol {
       DeliveryStubProtocol.enqueue(url: backupURL(file), okStub(file))
       let failovers = FailoverBox()
       let outcome = try await task(
-        manifest: manifest, staging: staging, onFailover: { failovers.record($0) }
+        manifest: manifest, staging: staging, onFailover: { failovers.record($0, $1, $2) }
       ).run()
       #expect(outcome.sourcesUsed == 2, "offline must fail over, not retry the mirror")
       #expect(outcome.finalSourceID == "backup")
@@ -650,7 +667,7 @@ final class DeliveryStubProtocol: URLProtocol {
       DeliveryStubProtocol.enqueue(url: url, okStub(file))
       let failovers = FailoverBox()
       let outcome = try await task(
-        manifest: manifest, staging: staging, onFailover: { failovers.record($0) }
+        manifest: manifest, staging: staging, onFailover: { failovers.record($0, $1, $2) }
       ).run()
       #expect(outcome.sourcesUsed == 1, "independent budgets keep it on one source")
       #expect(failovers.all.isEmpty)
@@ -669,7 +686,7 @@ final class DeliveryStubProtocol: URLProtocol {
       let delays = DelayBox()
       let outcome = try await task(
         manifest: manifest, staging: staging, backoffSleep: { delays.record($0) },
-        onFailover: { _ in }
+        onFailover: { _, _, _ in }
       ).run()
       #expect(delays.all.isEmpty, "a long Retry-After must not wait")
       #expect(outcome.sourcesUsed == 2)
@@ -778,10 +795,21 @@ private actor TestSignal {
 
 /// Records source-failover reasons across the concurrent fetch.
 private final class FailoverBox: @unchecked Sendable {
+  /// `all` stays the REASON list so the assertions written against it keep their
+  /// exact meaning; the transition is recorded alongside it for the cases that
+  /// care which mirror was left (#2135).
+  struct Entry: Equatable {
+    let reason: DeliveryFailureClass
+    let from: String
+    let to: String
+  }
   private let lock = NSLock()
-  private var reasons: [DeliveryFailureClass] = []
-  func record(_ reason: DeliveryFailureClass) { lock.withLock { reasons.append(reason) } }
-  var all: [DeliveryFailureClass] { lock.withLock { reasons } }
+  private var entries: [Entry] = []
+  func record(_ reason: DeliveryFailureClass, _ from: String, _ to: String) {
+    lock.withLock { entries.append(Entry(reason: reason, from: from, to: to)) }
+  }
+  var all: [DeliveryFailureClass] { lock.withLock { entries.map(\.reason) } }
+  var transitions: [Entry] { lock.withLock { entries } }
 }
 
 /// Records the backoff delays the retry loop asked the (injected) sleep for.


### PR DESCRIPTION
Closes #2135.

## What was wrong

The local log could say a model ended up **installed** or **failed**, and nothing about HOW. Cancel, resume-versus-restart, mirror failover and component repair are all modelled as events, all reach telemetry, and none reached `app.log`.

The founder's own 2026-08-17 sequence is the proof: three user actions — cancel, resume, completion — produced **one** log line, and that line described none of them.

## One exhaustive switch at the single funnel, not eight call sites

All eight `DeliveryEvent` cases already pass through `ModelDeliveryController.emit`. A `switch` there means **the compiler owns exhaustiveness**: a ninth event fails to BUILD until someone decides its line. Eight scattered `AppLogger` calls would be a convention, and a convention carrying a comment that claims it is exhaustive is exactly how a new enum member gets silently dropped (#2207).

## Above the observer guard, which is the load-bearing detail

`emit` returns early into a bounded 64-entry buffer when no telemetry observer is attached. A log call placed below that guard — or hung off an observer — would be silent **exactly when telemetry is unwired**, which is the launch window, which is when a delivery problem most needs explaining. The two channels are now independent by construction.

## Ordered, because a sequence read out of order invites a wrong causal reading

The line is rendered and its sequence minted on the controller actor in emit order; each write then awaits its predecessor. Separate unstructured `Task`s are not FIFO.

A sequence number **alone** was considered and rejected: it makes disorder *auditable*, never *readable*, and a developer reads a log top to bottom.

Sorting by timestamp was killed by measurement rather than preference. The formatter is a bare `ISO8601DateFormatter` with no fractional-seconds option (`AppLogger.swift:34-40`), so every line is stamped to whole seconds — and a delivery sequence happens inside one second by construction. Sorting would produce a stable-looking order that is arbitrary within each second, which is worse than visibly unordered because it reads as authoritative. The timestamp is also taken at WRITE time (`:146`), so it describes the writer rather than the event.

**Best-effort at termination, stated at the code:** `applicationWillTerminate` is synchronous and cannot await the tail, so a rapid quit or `kill -9` can lose unwritten lines. Guaranteeing a drain needs a wider asynchronous-termination design and is not justified for a debug diagnostic.

## `sourceFailover` gains the source transition

It could say a failover happened and not **which mirror fell over or which took over** — the values are discarded inside `ManifestFetchTask` before the event is built, so `emit` could not recover them. That is the entire diagnostic value of the event: a flaky install usually means a mirror fell over.

The telemetry bridge deliberately drops both new values, so no PostHog name or property changes.

## Two ad-hoc log lines removed, not left beside the switch

The `admitted` and `failed` lines each sat statements away from an `emit` of the same occurrence. Keeping them would print **two lines for one event**, and a doubled line invites reading one occurrence as two — the misreading this issue exists to prevent, arriving through its own fix.

Their exact wording is reproduced inside the switch, because `Model delivery admitted` and `Model delivery failed` are what someone greps for today. The `removed` line stays: nothing in the event vocabulary represents removal, and adding one would change a telemetry surface this issue is not about.

## A premise inherited from the issue body, corrected rather than propagated

The issue says these events are absent from *"the one artifact a user can send us."* **A shipping user has no such artifact.** `AppLogger` is `#if DEBUG` in its entirety — OSLog sink and file sink both — and its own header says "no `~/Library/Logs/EnviousWispr/` files in shipped binaries". There are exactly two build tiers and users get Release.

The real readership is us reproducing locally, and the founder during UAT on a dev build with Debug Mode on. The issue's value is unchanged and the founder's own run is the evidence for it; what it may CLAIM is not. No support workflow should be planned around asking a user for this file.

Corrected here because the sentence arrived from the issue body and reads as settled, which is how a wrong premise gets restated forever.

## From the Codex grounded review

Adjudication: `docs/audits/2026-08-24-2135-adjudication-r1.md`.

**Adopted, and the plan had this one backwards.** The plan claimed no release cost "beyond the existing actor hop". True of the two events that already had a log line, **false of the other six**. Ungated, a release build would pay to build strings and schedule tasks for a sink that is compiled out — and, given the correction above, for a file that cannot exist. The whole render-and-enqueue path is now `#if DEBUG`, not just the write.

**Adopted:** the test was too weak — "distinct and non-empty" is satisfied by eight garbage strings. Also adopted: the serial writer over sequence-number-alone; the wording fix that "exactly three delivery lines" is controller-scoped rather than repo-wide; and that the privacy boundary here is **producer**-enforced rather than type-enforced, since several associated values are unrestricted `String`s and `noteFlagActive` is public.

**Rejected, deliberately.** Its drop-in block also rewrote `sourcesUsed = 2` to `max(sourcesUsed, sourceIndex + 1)`. Nothing in its prose mentioned that, and it changes how a telemetry value is computed. Both expressions yield 2 for today's two-source manifests — which is precisely what makes it easy to paste and impossible to notice later: it would ship correct, sit correct for months, and move a number the day a three-source manifest lands, with nothing connecting the change to a review round nobody remembers.

**The rejection is checkable rather than remembered:** that line is absent from this diff's removed set.

## Tests

Class: **Observability Contract** — when these fail no user sees anything; what breaks is our ability to explain a download. Not counted as product coverage.

- **`everyEventRendersItsFields`** pins the EXACT line for every current case, including the two grep phrases above. The fields ARE the diagnostic, and "distinct and non-empty" would pass a renderer that silently dropped one. Makes no claim to enumerate the enum — that is the `switch`, which the compiler owns.
- **`localLogIsIndependentOfTelemetryAndOrdered`** attaches NO event observer, emits **100** events, and asserts all 100 arrive in order with a dense monotonic sequence. The 100 is chosen, not round: it exceeds the 64-entry buffer, which keeps its *first* 64, so an implementation logging from the buffer would deliver 64 and pass anything that counted "some".

The failover test now **asserts** the transition rather than merely compiling against it — a value nothing reads is a value that can be wrong without anything noticing.

Frozen mutation recipe in **#2392**, filed with the tests. One row is flagged as expected-to-be-flaky with the reason, and one expected survivor is named in advance so it is reported rather than "fixed" by making a test read the shared `app.log`.

## Validation

- Debug lane **6,642** (6,436 + 206), Release lane **5,996** (5,790 + 206), both green and reconciling exactly.
- **Debug +2, Release +0** against `main`, which is the expected signature of a `#if DEBUG` suite and is itself evidence the gating works.
- `ManifestFetchTaskTests` 23/23; `DeliveryLocalLogTests` 2/2, both display names present in the log.
- Worker suites, which CI runs and `xcode-test.sh` does not: daily-report 264, weekly-digest 73, sentry-triage 87 — 424 tests, 0 failures.
- Every removed line in this diff is nameable: 14, all accounted for.
- Live UAT not required: the surface is a debug log line, asserted at the seam in both directions, and the events it renders are already covered by their own suites.

Lane: `Code`. Tier: MEDIUM.
