### PR TITLE
fix(delivery): a cancel of a download we merely JOINED must not decline the upgrade (#2110)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/ModelDeliveryHome.swift
+++ b/Sources/EnviousWisprAppKit/App/ModelDeliveryHome.swift
@@ -72,6 +72,21 @@ public final class ModelDeliveryHome {
   package private(set) var previewStateUpdatesForTests = 0
   package private(set) var parakeetStateUpdatesForTests = 0
 
+  /// The launch probe above has RUN TO COMPLETION.
+  ///
+  /// A test seam, and the only honest one for this question. A test that needs a
+  /// baseline of `previewStateUpdatesForTests` must know the probe is finished,
+  /// because the probe is what moves that counter — and it runs in an
+  /// unstructured `Task` whose publish can land at any yield.
+  ///
+  /// **A quiet period is not a completion signal, which is what the first fix for
+  /// this got wrong.** Waiting for the counter to stop changing looks like
+  /// stability and is still a count: the counter is equally quiet when the task
+  /// has not STARTED, or is suspended inside `attachPreviewObserver` or
+  /// `recordFirstRunBaseline`, neither of which touches it. Set on the probe's
+  /// exit path, this is a claim by the SUBJECT about the subject.
+  package private(set) var previewLaunchProbeDidFinishForTests = false
+
   /// How many times the Parakeet Resume door has REFUSED on the family kill
   /// switch, from EITHER of its two checks. A test seam, and specifically a
   /// POSITIVE one: without it the flag-OFF arm could only assert two absences —
@@ -265,6 +280,7 @@ public final class ModelDeliveryHome {
         await previewHome.attachPreviewObserver(identity: previewIdentity)
         await previewHome.recordFirstRunBaseline(for: registration)
         _ = await previewHome.controller.admitIfComplete(registration)
+        previewHome.previewLaunchProbeDidFinishForTests = true
       }
     } catch {
       Task {

--- a/Sources/EnviousWisprLLM/EGOne/EGOneDeliveryAdapter.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneDeliveryAdapter.swift
@@ -94,7 +94,10 @@ public final class EGOneDeliveryAdapter {
   /// existing cache is already admitted (the server may use trusted bytes),
   /// else a limb-not-ready failure (dictation raw-fallbacks). The bypass fires
   /// `flag_active` from its one taking site (D5 §1).
-  public func ensureAvailable() async -> ModelDeliveryController.DeliveryOutcome {
+  public func ensureAvailable(
+    onFetchDecision:
+      (@MainActor @Sendable (ModelDeliveryController.FetchDecision) -> Void)? = nil
+  ) async -> ModelDeliveryController.DeliveryOutcome {
     if !isEnabled() {
       controllerNoteDisabled()
       if await controller.isAdmitted(registration) { return .admitted }
@@ -109,7 +112,14 @@ public final class EGOneDeliveryAdapter {
         DeliveryFailure(reason: .cacheRepairFailed, detail: "legacy_retirement"))
     }
 
-    let outcome = await controller.ensureModelAvailable(registration)
+    let outcome = await controller.ensureModelAvailable(registration) { decision in
+      guard let onFetchDecision else { return }
+      // The controller fires this on its own actor; the coordinator is
+      // @MainActor. The hop is why the coordinator has a `.pending` state at all
+      // — it is not bounded, so the coordinator refuses to attribute a Cancel
+      // until the answer lands rather than guessing (#2110).
+      Task { @MainActor in onFetchDecision(decision) }
+    }
     if case .admitted = outcome {
       legacyDidAdmit?()
     }

--- a/Sources/EnviousWisprLLM/EGOne/EGOneDeliveryAdapter.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneDeliveryAdapter.swift
@@ -94,7 +94,17 @@ public final class EGOneDeliveryAdapter {
   /// existing cache is already admitted (the server may use trusted bytes),
   /// else a limb-not-ready failure (dictation raw-fallbacks). The bypass fires
   /// `flag_active` from its one taking site (D5 §1).
+  /// - Parameters:
+  ///   - onWillRequestFetch: fired immediately before this call enters the
+  ///     controller, and AFTER retirement preparation. A caller attributing a
+  ///     Cancel needs the two separated, because preparation can hash a 2.9 GB
+  ///     monolith: treating that window as "we might have joined" would refuse a
+  ///     user's cancel of their OWN unrelated download for the whole hash, when
+  ///     in fact this call had not touched the controller yet (#2110 cloud
+  ///     review). Before this fires, nothing here can have joined anything.
+  ///   - onFetchDecision: the controller's start-vs-join answer, once it lands.
   public func ensureAvailable(
+    onWillRequestFetch: (@MainActor @Sendable () -> Void)? = nil,
     onFetchDecision:
       (@MainActor @Sendable (ModelDeliveryController.FetchDecision) -> Void)? = nil
   ) async -> ModelDeliveryController.DeliveryOutcome {
@@ -111,6 +121,12 @@ public final class EGOneDeliveryAdapter {
       return .failed(
         DeliveryFailure(reason: .cacheRepairFailed, detail: "legacy_retirement"))
     }
+
+    // Preparation is done; the next statement enters the controller. Awaited,
+    // not spawned, so the coordinator is registered BEFORE any decision can be
+    // reported — a `.pending` that arrived after its own resolution would be a
+    // stuck attempt nothing ever clears.
+    if let onWillRequestFetch { await MainActor.run { onWillRequestFetch() } }
 
     let outcome = await controller.ensureModelAvailable(registration) { decision in
       guard let onFetchDecision else { return }

--- a/Sources/EnviousWisprLLM/EGOne/EGOneUpgradeCoordinator.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneUpgradeCoordinator.swift
@@ -148,7 +148,21 @@ public final class EGOneUpgradeCoordinator {
   /// same fail-closed direction C14 already takes when a decline cannot be
   /// persisted.
   private enum AutomaticFetchDecision {
-    /// The start-vs-join answer has not reached the main actor yet.
+    /// Registered, but the ensure has NOT reached the controller yet — it is
+    /// still in retirement preparation, which can hash a 2.9 GB monolith.
+    ///
+    /// **Present but not attributable, and the two are different questions.**
+    /// Presence is what stops `prepareForEnsure()` clearing a decline another
+    /// attempt recorded durably while this one was suspended in preparation
+    /// (#2110 cloud review, round 3). Attribution is what a Cancel asks, and the
+    /// honest answer here is "not ours": nothing has been joined or started yet,
+    /// so the user's own cancel must go through.
+    ///
+    /// Round 2 of this change collapsed the two by leaving the attempt absent
+    /// during preparation. That fixed attribution and broke presence.
+    case preparing
+    /// Inside the controller; the start-vs-join answer has not reached the main
+    /// actor yet.
     case pending
     /// This automatic attempt STARTED the shared fetch. A Cancel is ours.
     case started
@@ -426,6 +440,11 @@ public final class EGOneUpgradeCoordinator {
     // started. `.pending` covers only the genuine unknown, between entering the
     // controller and its answer landing here.
     let attemptID = UUID()
+    // Registered as `.preparing` from HERE, so presence is true across the whole
+    // ensure — including retirement preparation — and `prepareForEnsure()` will
+    // not clear a decline recorded meanwhile. Attribution starts later, at the
+    // controller boundary, because only then can anything have been joined.
+    automaticFetchDecisions[attemptID] = .preparing
     let outcome = await ensureCurrentModel(
       { [weak self] in self?.automaticFetchDecisions[attemptID] = .pending },
       { [weak self] decision in
@@ -695,6 +714,8 @@ public final class EGOneUpgradeCoordinator {
       if automaticFetchDecisions.values.contains(.started) {
         declinesRevision = true
       } else if automaticFetchDecisions.values.contains(.pending) {
+        // NOTE `.preparing` deliberately does NOT reach here: it is present for
+        // the presence question and not attributable for this one.
         // Fail closed. The start-vs-join answer has not landed, and both guesses
         // are wrong in a way the user would notice. Returning false blocks the
         // action, exactly as a failed decline WRITE does (C14) — the caller sees

--- a/Sources/EnviousWisprLLM/EGOne/EGOneUpgradeCoordinator.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneUpgradeCoordinator.swift
@@ -107,6 +107,10 @@ public final class EGOneUpgradeCoordinator {
   package typealias FetchDecisionHandler =
     @MainActor @Sendable (ModelDeliveryController.FetchDecision) -> Void
 
+  /// Fired when an ensure is about to enter the controller — after preparation,
+  /// before any join can happen. See `runLaunch` for why the two are separate.
+  package typealias WillRequestFetchHandler = @MainActor @Sendable () -> Void
+
   /// What each in-flight automatic ensure turned out to BE, keyed per attempt.
   ///
   /// **A dictionary rather than a count, because the count could not express the
@@ -168,8 +172,8 @@ public final class EGOneUpgradeCoordinator {
   private var deferredForOnboarding = false
 
   private let ensureCurrentModel:
-    @MainActor @Sendable (@escaping FetchDecisionHandler) async ->
-      ModelDeliveryController.DeliveryOutcome
+    @MainActor @Sendable (@escaping WillRequestFetchHandler, @escaping FetchDecisionHandler)
+      async -> ModelDeliveryController.DeliveryOutcome
   private let currentModelIsAdmitted: @MainActor @Sendable () async -> Bool
 
   /// nil in production: `LegacyRetirement` then hashes the descriptor it verified, so the
@@ -199,11 +203,12 @@ public final class EGOneUpgradeCoordinator {
         ?? .standard,
       trustedArtifact: trustedArtifact,
       isOnboardingComplete: isOnboardingComplete,
-      ensureCurrentModel: { [weak adapter] onFetchDecision in
+      ensureCurrentModel: { [weak adapter] onWillRequestFetch, onFetchDecision in
         guard let adapter else {
           return .failed(DeliveryFailure(reason: .unknown, detail: "adapter_released"))
         }
-        return await adapter.ensureAvailable(onFetchDecision: onFetchDecision)
+        return await adapter.ensureAvailable(
+          onWillRequestFetch: onWillRequestFetch, onFetchDecision: onFetchDecision)
       },
       currentModelIsAdmitted: { [weak adapter] in
         guard let adapter else { return false }
@@ -229,8 +234,9 @@ public final class EGOneUpgradeCoordinator {
     trustedArtifact: TrustedArtifact,
     isOnboardingComplete: @escaping @MainActor @Sendable () -> Bool = { true },
     ensureCurrentModel:
-      @escaping @MainActor @Sendable (@escaping FetchDecisionHandler) async ->
-        ModelDeliveryController.DeliveryOutcome,
+      @escaping @MainActor @Sendable (
+        @escaping WillRequestFetchHandler, @escaping FetchDecisionHandler
+      ) async -> ModelDeliveryController.DeliveryOutcome,
     currentModelIsAdmitted: @escaping @MainActor @Sendable () async -> Bool,
     hashFile: (@Sendable (URL) async throws -> String)? = nil,
     writeMarker: (@MainActor @Sendable (URL) -> Bool)? = nil,
@@ -409,17 +415,26 @@ public final class EGOneUpgradeCoordinator {
     //
     // Marked in-flight across the fetch so a Cancel arriving through the adapter's shared
     // decline hook is attributable to US rather than to the settings row.
-    // Registered as `.pending` BEFORE the call, so a Cancel arriving in the gap
-    // is refused rather than attributed by guess (#2110).
+    // Registered as `.pending` when the call ENTERS the controller, never before
+    // (#2110 cloud review). The adapter first awaits retirement preparation,
+    // which can hash a 2.9 GB monolith; registering ahead of that would refuse a
+    // user's cancel of their OWN unrelated download for the whole hash, on the
+    // strength of a join that had not happened and could not yet have happened.
+    //
+    // Before the signal arrives this attempt is simply absent, which reads as
+    // "not ours" — correct, because it is not: nothing has been joined or
+    // started. `.pending` covers only the genuine unknown, between entering the
+    // controller and its answer landing here.
     let attemptID = UUID()
-    automaticFetchDecisions[attemptID] = .pending
-    let outcome = await ensureCurrentModel { [weak self] decision in
-      guard let self, self.automaticFetchDecisions[attemptID] != nil else { return }
-      switch decision {
-      case .started: self.automaticFetchDecisions[attemptID] = .started
-      case .joined: self.automaticFetchDecisions[attemptID] = .joined
-      }
-    }
+    let outcome = await ensureCurrentModel(
+      { [weak self] in self?.automaticFetchDecisions[attemptID] = .pending },
+      { [weak self] decision in
+        guard let self, self.automaticFetchDecisions[attemptID] != nil else { return }
+        switch decision {
+        case .started: self.automaticFetchDecisions[attemptID] = .started
+        case .joined: self.automaticFetchDecisions[attemptID] = .joined
+        }
+      })
     automaticFetchDecisions.removeValue(forKey: attemptID)
 
     if case .admitted = outcome {

--- a/Sources/EnviousWisprLLM/EGOne/EGOneUpgradeCoordinator.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneUpgradeCoordinator.swift
@@ -102,12 +102,61 @@ public final class EGOneUpgradeCoordinator {
   /// automatic upgrade from a download the user began in settings — the two reach the same
   /// adapter hooks and must not mean the same thing on cancel.
   ///
-  /// A COUNT, not a flag. `runLaunch()` runs once at bootstrap today, but it is re-entered within
-  /// the same session when onboarding completes, so two automatic attempts can overlap. With a
-  /// plain Boolean the first to finish would clear it while the second was still fetching, and a
-  /// Cancel belonging to that second attempt would be misread as the user's own.
-  private var automaticUpgradeInFlightCount = 0
-  private var automaticUpgradeInFlight: Bool { automaticUpgradeInFlightCount > 0 }
+  /// How the controller reports its start-vs-join decision back to this type.
+  /// `@MainActor` because the coordinator is, and the adapter hops it here.
+  package typealias FetchDecisionHandler =
+    @MainActor @Sendable (ModelDeliveryController.FetchDecision) -> Void
+
+  /// What each in-flight automatic ensure turned out to BE, keyed per attempt.
+  ///
+  /// **A dictionary rather than a count, because the count could not express the
+  /// question (#2110).** A count answers "is one of ours running", and a Cancel
+  /// needs "is the download being cancelled ONE OF OURS". Those differ exactly
+  /// when the controller single-flights: our ensure JOINS a download the user
+  /// started, the count goes up, and their Cancel is recorded as us declining an
+  /// automatic upgrade we never started.
+  ///
+  /// Keyed per attempt for the reason the count was keyed at all: `runLaunch()`
+  /// is `public`, so concurrent calls are possible and a shared slot would let
+  /// one attempt's decision overwrite another's.
+  ///
+  /// **Correcting the reason the old comment gave**, because it was wrong and a
+  /// wrong reason at the code stops the next reader checking: it said the count
+  /// existed because `runLaunch` is re-entered when onboarding completes, so two
+  /// automatic attempts can overlap. They cannot, by that route.
+  /// `onboardingDidComplete()` guards on `deferredForOnboarding`, which is set
+  /// only when `runLaunch` returned at the onboarding gate — BEFORE fetching. The
+  /// real reason is the `public` entry point above.
+  private var automaticFetchDecisions: [UUID: AutomaticFetchDecision] = [:]
+
+  /// Three states, and the third is the point.
+  ///
+  /// The controller reports start-vs-join on its own actor and the answer reaches
+  /// this @MainActor type through a hop that is NOT bounded — during launch the
+  /// main actor is running bootstrap composition, settings observation, runtime
+  /// activation and UI. A Cancel already queued can arrive while the answer is
+  /// still in flight.
+  ///
+  /// `.pending` refuses the Cancel rather than guessing. Both guesses are wrong:
+  /// assuming ours writes a decline the user never made and suppresses future
+  /// upgrades; assuming theirs drops a real decline and re-fetches up to 2.9 GB
+  /// on the next launch, contradicting the Cancel just pressed. Refusing is the
+  /// same fail-closed direction C14 already takes when a decline cannot be
+  /// persisted.
+  private enum AutomaticFetchDecision {
+    /// The start-vs-join answer has not reached the main actor yet.
+    case pending
+    /// This automatic attempt STARTED the shared fetch. A Cancel is ours.
+    case started
+    /// It joined a download someone else started. A Cancel is not ours.
+    case joined
+  }
+
+  /// Whether any automatic ensure is running, in ANY of the three states.
+  ///
+  /// Deliberately separate from the decision itself: `prepareForEnsure()` must not
+  /// clear a decline merely because attribution has not arrived yet.
+  private var automaticEnsureInProgress: Bool { !automaticFetchDecisions.isEmpty }
 
   /// Whether first-run setup has finished. EG-1 polish is a LIMB; during onboarding the HEART's
   /// model (Parakeet or WhisperKit) is downloading, and dictation does not work at all until it
@@ -119,7 +168,8 @@ public final class EGOneUpgradeCoordinator {
   private var deferredForOnboarding = false
 
   private let ensureCurrentModel:
-    @MainActor @Sendable () async -> ModelDeliveryController.DeliveryOutcome
+    @MainActor @Sendable (@escaping FetchDecisionHandler) async ->
+      ModelDeliveryController.DeliveryOutcome
   private let currentModelIsAdmitted: @MainActor @Sendable () async -> Bool
 
   /// nil in production: `LegacyRetirement` then hashes the descriptor it verified, so the
@@ -149,11 +199,11 @@ public final class EGOneUpgradeCoordinator {
         ?? .standard,
       trustedArtifact: trustedArtifact,
       isOnboardingComplete: isOnboardingComplete,
-      ensureCurrentModel: { [weak adapter] in
+      ensureCurrentModel: { [weak adapter] onFetchDecision in
         guard let adapter else {
           return .failed(DeliveryFailure(reason: .unknown, detail: "adapter_released"))
         }
-        return await adapter.ensureAvailable()
+        return await adapter.ensureAvailable(onFetchDecision: onFetchDecision)
       },
       currentModelIsAdmitted: { [weak adapter] in
         guard let adapter else { return false }
@@ -179,7 +229,8 @@ public final class EGOneUpgradeCoordinator {
     trustedArtifact: TrustedArtifact,
     isOnboardingComplete: @escaping @MainActor @Sendable () -> Bool = { true },
     ensureCurrentModel:
-      @escaping @MainActor @Sendable () async -> ModelDeliveryController.DeliveryOutcome,
+      @escaping @MainActor @Sendable (@escaping FetchDecisionHandler) async ->
+        ModelDeliveryController.DeliveryOutcome,
     currentModelIsAdmitted: @escaping @MainActor @Sendable () async -> Bool,
     hashFile: (@Sendable (URL) async throws -> String)? = nil,
     writeMarker: (@MainActor @Sendable (URL) -> Bool)? = nil,
@@ -358,9 +409,18 @@ public final class EGOneUpgradeCoordinator {
     //
     // Marked in-flight across the fetch so a Cancel arriving through the adapter's shared
     // decline hook is attributable to US rather than to the settings row.
-    automaticUpgradeInFlightCount += 1
-    let outcome = await ensureCurrentModel()
-    automaticUpgradeInFlightCount -= 1
+    // Registered as `.pending` BEFORE the call, so a Cancel arriving in the gap
+    // is refused rather than attributed by guess (#2110).
+    let attemptID = UUID()
+    automaticFetchDecisions[attemptID] = .pending
+    let outcome = await ensureCurrentModel { [weak self] decision in
+      guard let self, self.automaticFetchDecisions[attemptID] != nil else { return }
+      switch decision {
+      case .started: self.automaticFetchDecisions[attemptID] = .started
+      case .joined: self.automaticFetchDecisions[attemptID] = .joined
+      }
+    }
+    automaticFetchDecisions.removeValue(forKey: attemptID)
 
     if case .admitted = outcome {
       handleAdmission()
@@ -397,7 +457,7 @@ public final class EGOneUpgradeCoordinator {
   /// This lives on the coordinator rather than inside the composition root's closure so it is
   /// reachable from the test seam; logic that only exists in a wiring closure cannot be tested.
   func prepareForEnsure() async -> Bool {
-    if !automaticUpgradeInFlight { clearRevisionDecline() }
+    if !automaticEnsureInProgress { clearRevisionDecline() }
     return await prepareForDownload()
   }
 
@@ -602,8 +662,33 @@ public final class EGOneUpgradeCoordinator {
   // just declined — the failure being silent is precisely what makes it worth failing closed.
   // Written before the owed marker is cleared, so a failure leaves BOTH markers in their
   // pre-decline state rather than a half-applied one.
+  // C16 (#2110) - A Cancel declines the REVISION only when one of OUR automatic
+  // attempts started the download being cancelled. The controller single-flights,
+  // so an automatic ensure can JOIN a download the user started themselves; before
+  // this, that user's Cancel wrote a revision decline and suppressed the next
+  // automatic upgrade they had never refused.
+  //
+  // `.remove` is unaffected and deliberately still reads `isRevisionUpgradeOwed`:
+  // it is a refusal of the MODEL, from durable admission state, not a statement
+  // about whichever task happens to be running.
   func recordUserDecline(source: DeclineSource) -> Bool {
-    let declinesRevision = source == .remove ? isRevisionUpgradeOwed : automaticUpgradeInFlight
+    let declinesRevision: Bool
+    switch source {
+    case .remove:
+      declinesRevision = isRevisionUpgradeOwed
+    case .cancel:
+      if automaticFetchDecisions.values.contains(.started) {
+        declinesRevision = true
+      } else if automaticFetchDecisions.values.contains(.pending) {
+        // Fail closed. The start-vs-join answer has not landed, and both guesses
+        // are wrong in a way the user would notice. Returning false blocks the
+        // action, exactly as a failed decline WRITE does (C14) — the caller sees
+        // "could not record your decision", not a silent mis-attribution.
+        return false
+      } else {
+        declinesRevision = false
+      }
+    }
     guard !declinesRevision || writeRevisionDecline() else { return false }
     // Emitted only after the decline is DURABLE. An event for a refusal that failed to persist
     // would report an outcome the next launch is about to contradict.

--- a/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
+++ b/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
@@ -209,8 +209,33 @@ public actor ModelDeliveryController {
   /// Ensure the model's cache is admitted, fetching/repairing as needed.
   /// Single-flight JOIN: a second caller while one runs awaits the SAME
   /// task's outcome (D4 §2 — two windows, onboarding + cold-press).
-  public func ensureModelAvailable(_ registration: DeliveryRegistration) async -> DeliveryOutcome {
-    await joinOrStartFetch(registration, trigger: nil)
+  /// - Parameter onFetchDecision: reports START-vs-JOIN at the instant this
+  ///   controller decides it, which is the only instant the answer exists and is
+  ///   still useful (#2110). A caller that needs to know whether the download
+  ///   running is ITS OWN cannot learn it from the outcome: by then the download
+  ///   is over, and the question is asked while it runs, when Cancel arrives.
+  ///
+  ///   Deliberately a callback rather than a return value or an owner the
+  ///   controller stores. An owner field would let a caller ASK later, which
+  ///   reads as the safer design and is not: between the question and the cancel
+  ///   the observed task can finish and another can start, so the answer is
+  ///   stale exactly when it matters. Reporting the decision leaves ownership
+  ///   where it belongs — with the caller who made the call.
+  ///
+  ///   Fired synchronously on this actor, so it must not block; every caller
+  ///   hops it onward itself.
+  public func ensureModelAvailable(
+    _ registration: DeliveryRegistration,
+    onFetchDecision: (@Sendable (FetchDecision) -> Void)? = nil
+  ) async -> DeliveryOutcome {
+    await joinOrStartFetch(registration, trigger: nil, onFetchDecision: onFetchDecision)
+  }
+
+  /// Whether a call to an explicit-fetch door STARTED the shared fetch or JOINED
+  /// one already running.
+  public enum FetchDecision: Sendable, Equatable {
+    case started
+    case joined
   }
 
   /// Shared join logic for the two EXPLICIT-fetch doors (`ensureModelAvailable`,
@@ -226,12 +251,14 @@ public actor ModelDeliveryController {
   /// A second fetch caller in the same wave sees the fetch task installed
   /// synchronously by `startAttempt` and joins it (no double-start, no spin).
   private func joinOrStartFetch(
-    _ registration: DeliveryRegistration, trigger: DeliveryEvent.ValidationTrigger?
+    _ registration: DeliveryRegistration, trigger: DeliveryEvent.ValidationTrigger?,
+    onFetchDecision: (@Sendable (FetchDecision) -> Void)? = nil
   ) async -> DeliveryOutcome {
     let identity = registration.manifest.identity
     if let active = entries[identity, default: Entry()].activeTask,
       entries[identity]?.activeTaskFetches == true
     {
+      onFetchDecision?(.joined)
       return await active.value
     }
     if let probe = entries[identity]?.activeTask {
@@ -242,6 +269,8 @@ public actor ModelDeliveryController {
       entries[identity]?.activeTask = nil
       probe.cancel()
     }
+    // Superseding a no-fetch probe still STARTS this caller's fetch.
+    onFetchDecision?(.started)
     return await startAttempt(registration, trigger: trigger)
   }
 

--- a/Tests/EnviousWisprTests/App/ModelDeliveryHomeTests.swift
+++ b/Tests/EnviousWisprTests/App/ModelDeliveryHomeTests.swift
@@ -405,9 +405,38 @@ struct ModelDeliveryHomeTests {
         deliveryFlagDefaults: suite)
     }
 
+    /// Wait for the mirror to STOP changing, rather than yielding a fixed number
+    /// of times and hoping.
+    ///
+    /// Construction runs a launch probe (`admitIfComplete`) in an unstructured
+    /// `Task`, and its state publish can land at ANY yield. A fixed budget makes
+    /// the baseline a race: if the probe publishes at yield 401, the baseline is
+    /// stale and the assertion below fails `2 == 1` — reporting that the refused
+    /// door reached delivery, which is a confident wrong subject.
+    ///
+    /// It failed exactly that way on CI (`build-debug`, #2400) while passing
+    /// locally, and the trigger was #2135 adding a task per delivery event, which
+    /// pushed the probe past 400 yields on a slower, contended runner. The race
+    /// was always there; that change only made it likely.
+    ///
+    /// Stability has no budget to get wrong: it asks the world to stop moving
+    /// rather than asserting how long that takes.
+    func settledPreviewUpdates(_ home: ModelDeliveryHome) async -> Int {
+      var last = -1
+      var stableFor = 0
+      for _ in 0..<5_000 {
+        let now = home.previewStateUpdatesForTests
+        stableFor = (now == last) ? stableFor + 1 : 0
+        last = now
+        if stableFor >= 50 { return now }
+        await Task.yield()
+      }
+      Issue.record("the preview mirror never settled; baseline would be a guess")
+      return last
+    }
+
     let off = try home(enabled: false)
-    for _ in 0..<400 { await Task.yield() }
-    let offBaseline = off.previewStateUpdatesForTests
+    let offBaseline = await settledPreviewUpdates(off)
     off.startPreviewDownload()
     for _ in 0..<2000 { await Task.yield() }
     #expect(
@@ -415,8 +444,7 @@ struct ModelDeliveryHomeTests {
       "the kill switch is off but the download door still reached delivery")
 
     let on = try home(enabled: true)
-    for _ in 0..<400 { await Task.yield() }
-    let onBaseline = on.previewStateUpdatesForTests
+    let onBaseline = await settledPreviewUpdates(on)
     on.startPreviewDownload()
     for _ in 0..<4000 where on.previewStateUpdatesForTests == onBaseline { await Task.yield() }
     #expect(

--- a/Tests/EnviousWisprTests/App/ModelDeliveryHomeTests.swift
+++ b/Tests/EnviousWisprTests/App/ModelDeliveryHomeTests.swift
@@ -404,39 +404,40 @@ struct ModelDeliveryHomeTests {
         appSupportOverride: try Self.tempAppSupport(),
         deliveryFlagDefaults: suite)
     }
-
-    /// Wait for the mirror to STOP changing, rather than yielding a fixed number
-    /// of times and hoping.
+    /// Take the baseline once the SUBJECT says its launch probe has finished.
     ///
-    /// Construction runs a launch probe (`admitIfComplete`) in an unstructured
-    /// `Task`, and its state publish can land at ANY yield. A fixed budget makes
-    /// the baseline a race: if the probe publishes at yield 401, the baseline is
-    /// stale and the assertion below fails `2 == 1` — reporting that the refused
-    /// door reached delivery, which is a confident wrong subject.
+    /// Construction runs that probe in an unstructured `Task`, and it is what
+    /// moves `previewStateUpdatesForTests`. A baseline read before it completes is
+    /// stale, and the assertion below then fails `2 == 1` — a confident accusation
+    /// against production code that is correct.
     ///
     /// It failed exactly that way on CI (`build-debug`, #2400) while passing
-    /// locally, and the trigger was #2135 adding a task per delivery event, which
-    /// pushed the probe past 400 yields on a slower, contended runner. The race
-    /// was always there; that change only made it likely.
+    /// locally twice, after #2135 added a task per delivery event and pushed the
+    /// probe past the old fixed 400-yield wait on a contended runner.
     ///
-    /// Stability has no budget to get wrong: it asks the world to stop moving
-    /// rather than asserting how long that takes.
-    func settledPreviewUpdates(_ home: ModelDeliveryHome) async -> Int {
-      var last = -1
-      var stableFor = 0
-      for _ in 0..<5_000 {
-        let now = home.previewStateUpdatesForTests
-        stableFor = (now == last) ? stableFor + 1 : 0
-        last = now
-        if stableFor >= 50 { return now }
+    /// **The first fix was also wrong, and wrong in the interesting way:** it
+    /// waited for the counter to stop changing across 50 yields and called that
+    /// stability. Still a COUNT — the counter is equally quiet when the task has
+    /// not started, or is suspended inside `attachPreviewObserver` or
+    /// `recordFirstRunBaseline`, neither of which touches it. And 50 is SHORTER
+    /// than the 400 it replaced, so it widened the race it was meant to close.
+    /// Cloud review caught that on the fix rather than on the original.
+    ///
+    /// The bound below is a HANG GUARD, not a settle budget: it can only fire when
+    /// the subject never reports, and it says so instead of returning a guess.
+    func baselineAfterLaunchProbe(_ home: ModelDeliveryHome) async -> Int {
+      for _ in 0..<100_000 where !home.previewLaunchProbeDidFinishForTests {
         await Task.yield()
       }
-      Issue.record("the preview mirror never settled; baseline would be a guess")
-      return last
+      if !home.previewLaunchProbeDidFinishForTests {
+        Issue.record(
+          "the preview launch probe never reported completion; any baseline is a guess")
+      }
+      return home.previewStateUpdatesForTests
     }
 
     let off = try home(enabled: false)
-    let offBaseline = await settledPreviewUpdates(off)
+    let offBaseline = await baselineAfterLaunchProbe(off)
     off.startPreviewDownload()
     for _ in 0..<2000 { await Task.yield() }
     #expect(
@@ -444,7 +445,7 @@ struct ModelDeliveryHomeTests {
       "the kill switch is off but the download door still reached delivery")
 
     let on = try home(enabled: true)
-    let onBaseline = await settledPreviewUpdates(on)
+    let onBaseline = await baselineAfterLaunchProbe(on)
     on.startPreviewDownload()
     for _ in 0..<4000 where on.previewStateUpdatesForTests == onBaseline { await Task.yield() }
     #expect(

--- a/Tests/EnviousWisprTests/LLM/EGOneRevisionUpgradeTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneRevisionUpgradeTests.swift
@@ -106,8 +106,13 @@ import Testing
       defaults: defaults,
       trustedArtifact: .init(name: "eg-1-v1.gguf", sizeBytes: 11, sha256: "unused-here"),
       isOnboardingComplete: isOnboardingComplete,
-      ensureCurrentModel: {
+      ensureCurrentModel: { onFetchDecision in
         probe.ensureCount += 1
+        // Report STARTED, as the real controller does the moment it decides
+        // (#2110). A closure reporting nothing would leave the attempt
+        // `.pending`, which now REFUSES a cancel — correct behaviour, and not
+        // what these cases are about.
+        onFetchDecision(.started)
         return probe.ensureOutcome
       },
       currentModelIsAdmitted: { probe.admitted },
@@ -627,15 +632,12 @@ import Testing
   /// with NOTHING in flight. The settings row's own Cancel reaches the same hook as ours, so a
   /// cancel that is not attributable to us must not switch off the automatic path.
   ///
-  /// **SCOPE — the NAME is broader than the coverage, and than the code (#2110).** A cancel of a
-  /// download the user started while the coordinator has JOINED it does still write a decline:
-  /// `ModelDeliveryController` single-flights, so `ensureCurrentModel()` joins the user's fetch
-  /// while `automaticUpgradeInFlightCount` is positive, and `.cancel` reads that counter. This
-  /// test does not reach that case and passes today either way. The plan carries the same
-  /// correction (issue-2096 §3.2, amended 2026-08-16); this comment is its twin, and the twin was
-  /// missed. Do not read a green run here as evidence for the joined case, and do not write that
-  /// case against today's behaviour — #2110 has two candidate designs and the test belongs with
-  /// whichever lands.
+  /// **SCOPE — this case stages a cancel with NOTHING in flight, and that is all it proves.**
+  /// It used to carry a note saying the JOINED case was uncovered and must not be written against
+  /// then-current behaviour, because #2110 had two candidate designs. That is now settled and the
+  /// joined case is covered by `joinedCancelDoesNotDeclineAndPendingAttributionRefuses` below.
+  /// This case is kept as the third arm — no attempt registered at all — which neither of the
+  /// other two reaches.
   @MainActor
   @Test func userInitiatedCancelDoesNotRecordDecline() async throws {
     let root = try makeRoot()
@@ -677,8 +679,13 @@ import Testing
       installDirectory: installDirectory(root),
       defaults: store,
       trustedArtifact: .init(name: "eg-1-v1.gguf", sizeBytes: 11, sha256: "unused-here"),
-      ensureCurrentModel: {
+      ensureCurrentModel: { onFetchDecision in
         probe.ensureCount += 1
+        // STARTED first, then the cancel — the real order. The controller reports
+        // its decision when it decides, and Cancel arrives later, during the
+        // fetch. Reporting it is what makes this case about ATTRIBUTION rather
+        // than about the `.pending` refusal (#2110).
+        onFetchDecision(.started)
         _ = box.coordinator?.recordUserDecline(source: .cancel)
         return .failed(DeliveryFailure(reason: .unknown, detail: "cancelled"))
       },
@@ -691,6 +698,82 @@ import Testing
     #expect(
       FileManager.default.fileExists(atPath: declineMarker(root).path),
       "a cancel during OUR upgrade is a decline of the upgrade")
+  }
+
+  /// The defect this issue names, and the fail-closed state that replaced the guess (#2110).
+  ///
+  /// `ModelDeliveryController` single-flights per identity, so an automatic ensure can JOIN a
+  /// download the user started from the settings row. Before this, that made the user's own Cancel
+  /// write a revision decline — suppressing the next automatic upgrade they had never refused.
+  ///
+  /// **Three arms, because each is satisfiable by the opposite bug.**
+  ///
+  /// - JOINED must write NO decline. Alone, this passes against a coordinator that never records
+  ///   anything, which would break the feature to fix the bug.
+  /// - STARTED must still write one. That arm lives in
+  ///   `cancelDuringAutomaticUpgradeRecordsDecline` and is the reason this case does not repeat it.
+  /// - PENDING — the decision has not reached the main actor — must REFUSE, returning `false` so
+  ///   the caller blocks rather than guessing. Both guesses are wrong in a way the user notices:
+  ///   assuming ours suppresses upgrades never refused; assuming theirs drops a real refusal and
+  ///   re-fetches on the next launch, contradicting the Cancel just pressed. Refusing is the same
+  ///   fail-closed direction C14 takes when a decline cannot be persisted.
+  ///
+  /// **Attribution is driven through the production seam**, the decision handler the controller
+  /// invokes at the instant it decides start-vs-join. That the controller actually reports
+  /// `.joined` on its join branch is a property of the controller, not of this coordinator, and is
+  /// asserted separately — see the recipe filed with this change.
+  @MainActor
+  @Test func joinedCancelDoesNotDeclineAndPendingAttributionRefuses() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    try stagePriorAdmission(root: root)
+    let probe = Probe()
+    let box = CancelBox()
+
+    // Records what `recordUserDecline` ANSWERED, not merely whether a marker exists:
+    // a refusal and a permitted-but-not-declining cancel both leave no marker, and
+    // only the return value separates them.
+    final class Answers: @unchecked Sendable {
+      var whileJoined: Bool?
+      var whilePending: Bool?
+    }
+    let answers = Answers()
+
+    let subject = EGOneUpgradeCoordinator(
+      appSupportDirectory: root,
+      identity: Self.identity(),
+      installDirectory: installDirectory(root),
+      defaults: store,
+      trustedArtifact: .init(name: "eg-1-v1.gguf", sizeBytes: 11, sha256: "unused-here"),
+      ensureCurrentModel: { onFetchDecision in
+        probe.ensureCount += 1
+        // BEFORE any decision lands, the attempt is `.pending`.
+        answers.whilePending = box.coordinator?.recordUserDecline(source: .cancel)
+        // Now the controller's answer arrives: we joined someone else's download.
+        onFetchDecision(.joined)
+        answers.whileJoined = box.coordinator?.recordUserDecline(source: .cancel)
+        return .failed(DeliveryFailure(reason: .unknown, detail: "cancelled"))
+      },
+      currentModelIsAdmitted: { probe.admitted })
+    box.coordinator = subject
+
+    await subject.runLaunch()
+
+    #expect(probe.ensureCount == 1, "the ensure must actually have run, or the arms prove nothing")
+
+    #expect(
+      answers.whilePending == false,
+      "with attribution still pending a cancel must be REFUSED, not guessed either way")
+
+    #expect(
+      answers.whileJoined == true,
+      "a joined cancel is permitted; it simply does not decline the revision")
+    #expect(
+      !FileManager.default.fileExists(atPath: declineMarker(root).path),
+      "cancelling a download WE joined is the user cancelling THEIRS, and declines nothing")
   }
 
   @MainActor
@@ -822,8 +905,9 @@ import Testing
       installDirectory: installDirectory(root),
       defaults: store,
       trustedArtifact: .init(name: "eg-1-v1.gguf", sizeBytes: 11, sha256: "unused-here"),
-      ensureCurrentModel: {
+      ensureCurrentModel: { onFetchDecision in
         probe.ensureCount += 1
+        onFetchDecision(.started)
         if probe.ensureCount == 1 {
           // Re-enter while THIS attempt is still in flight, and let the inner one finish.
           await box.coordinator?.runLaunch()

--- a/Tests/EnviousWisprTests/LLM/EGOneRevisionUpgradeTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneRevisionUpgradeTests.swift
@@ -106,8 +106,9 @@ import Testing
       defaults: defaults,
       trustedArtifact: .init(name: "eg-1-v1.gguf", sizeBytes: 11, sha256: "unused-here"),
       isOnboardingComplete: isOnboardingComplete,
-      ensureCurrentModel: { onFetchDecision in
+      ensureCurrentModel: { onWillRequestFetch, onFetchDecision in
         probe.ensureCount += 1
+        onWillRequestFetch()
         // Report STARTED, as the real controller does the moment it decides
         // (#2110). A closure reporting nothing would leave the attempt
         // `.pending`, which now REFUSES a cancel — correct behaviour, and not
@@ -679,8 +680,9 @@ import Testing
       installDirectory: installDirectory(root),
       defaults: store,
       trustedArtifact: .init(name: "eg-1-v1.gguf", sizeBytes: 11, sha256: "unused-here"),
-      ensureCurrentModel: { onFetchDecision in
+      ensureCurrentModel: { onWillRequestFetch, onFetchDecision in
         probe.ensureCount += 1
+        onWillRequestFetch()
         // STARTED first, then the cancel — the real order. The controller reports
         // its decision when it decides, and Cancel arrives later, during the
         // fetch. Reporting it is what makes this case about ATTRIBUTION rather
@@ -739,6 +741,7 @@ import Testing
     final class Answers: @unchecked Sendable {
       var whileJoined: Bool?
       var whilePending: Bool?
+      var beforeEnteringController: Bool?
     }
     let answers = Answers()
 
@@ -748,9 +751,16 @@ import Testing
       installDirectory: installDirectory(root),
       defaults: store,
       trustedArtifact: .init(name: "eg-1-v1.gguf", sizeBytes: 11, sha256: "unused-here"),
-      ensureCurrentModel: { onFetchDecision in
+      ensureCurrentModel: { onWillRequestFetch, onFetchDecision in
         probe.ensureCount += 1
-        // BEFORE any decision lands, the attempt is `.pending`.
+        // BEFORE entering the controller — this is the retirement-preparation
+        // window, which can hash a 2.9 GB monolith. Nothing has been joined or
+        // started, so a cancel here is the user's own and must be PERMITTED.
+        // Registering `.pending` ahead of this refused it for the whole hash
+        // (#2110 cloud review P2).
+        answers.beforeEnteringController = box.coordinator?.recordUserDecline(source: .cancel)
+        onWillRequestFetch()
+        // Now inside the controller, decision not yet back: genuinely `.pending`.
         answers.whilePending = box.coordinator?.recordUserDecline(source: .cancel)
         // Now the controller's answer arrives: we joined someone else's download.
         onFetchDecision(.joined)
@@ -764,6 +774,9 @@ import Testing
 
     #expect(probe.ensureCount == 1, "the ensure must actually have run, or the arms prove nothing")
 
+    #expect(
+      answers.beforeEnteringController == true,
+      "before the ensure enters the controller nothing can have been joined, so the user's own cancel must be permitted, not refused while we hash a 2.9 GB file")
     #expect(
       answers.whilePending == false,
       "with attribution still pending a cancel must be REFUSED, not guessed either way")
@@ -905,8 +918,9 @@ import Testing
       installDirectory: installDirectory(root),
       defaults: store,
       trustedArtifact: .init(name: "eg-1-v1.gguf", sizeBytes: 11, sha256: "unused-here"),
-      ensureCurrentModel: { onFetchDecision in
+      ensureCurrentModel: { onWillRequestFetch, onFetchDecision in
         probe.ensureCount += 1
+        onWillRequestFetch()
         onFetchDecision(.started)
         if probe.ensureCount == 1 {
           // Re-enter while THIS attempt is still in flight, and let the inner one finish.

--- a/Tests/EnviousWisprTests/LLM/EGOneUpgradeCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneUpgradeCoordinatorTests.swift
@@ -98,8 +98,9 @@ import Testing
         sizeBytes: Int64(bytes.count),
         sha256: digest(bytes)
       ),
-      ensureCurrentModel: { onFetchDecision in
+      ensureCurrentModel: { onWillRequestFetch, onFetchDecision in
         probe.ensureCount += 1
+        onWillRequestFetch()
         // Report STARTED, as the real controller does the moment it decides
         // (#2110). A closure reporting nothing would leave the attempt
         // `.pending`, which now REFUSES a cancel — correct behaviour, and not

--- a/Tests/EnviousWisprTests/LLM/EGOneUpgradeCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneUpgradeCoordinatorTests.swift
@@ -98,8 +98,13 @@ import Testing
         sizeBytes: Int64(bytes.count),
         sha256: digest(bytes)
       ),
-      ensureCurrentModel: {
+      ensureCurrentModel: { onFetchDecision in
         probe.ensureCount += 1
+        // Report STARTED, as the real controller does the moment it decides
+        // (#2110). A closure reporting nothing would leave the attempt
+        // `.pending`, which now REFUSES a cancel — correct behaviour, and not
+        // what these cases are about.
+        onFetchDecision(.started)
         return probe.ensureOutcome
       },
       currentModelIsAdmitted: {


### PR DESCRIPTION
Closes #2110.

## What was wrong

`ModelDeliveryController` single-flights per identity, so an automatic EG-1 upgrade can **JOIN** a download the user started from the settings row. The coordinator marked itself in-flight across that ensure, and `.cancel` read that mark — so a user cancelling **their own** download wrote a revision decline and suppressed the next automatic upgrade they had never refused.

Narrow and recoverable — nothing is deleted, pressing Download clears it — but what is lost is the automatic retry, and the user did nothing to deserve that.

## The count could not express the question

A count answers *"is one of ours running"*. A Cancel asks *"is the download being cancelled **one of ours**"*. Those differ precisely when the controller single-flights, which is the defect.

Replaced with a per-attempt decision: `.started`, `.joined`, or `.pending`.

## `.pending` is the part that is in neither of the issue's two designs

The controller reports start-vs-join on its own actor; the coordinator is `@MainActor`, and that hop is **not bounded** — during launch the main actor is running bootstrap composition, settings observation, runtime activation and UI. A Cancel already queued can arrive while the answer is still travelling.

So an unattributed cancel is **refused**, not guessed. Both guesses are wrong in a way the user notices:

- assume it is ours → a decline they never made, suppressing future upgrades;
- assume it is theirs → a real refusal dropped, re-fetching up to 2.9 GB on the next launch, contradicting the Cancel just pressed.

Refusing is the **same fail-closed direction C14 already takes** when a decline cannot be persisted: `recordUserDecline` returns `false`, which both call sites already treat as blocking the action. No new branch at the caller, and no user-visible outcome that did not already exist.

## The issue's own recommendation was overturned, and correctly

I recommended the controller record an owner and the decline path ask it, on the strength of "no window". **That premise is false.** Asking who owns the active fetch and *then* cancelling is check-then-act: the observed task can finish and a different one start in the gap. Closing that honestly needs a cancellation reservation tied to the generation — materially more than an owner field and two `await`s. Adjudication in `docs/audits/2026-08-25-2110-plan-review-r1.md` and on the issue.

Reporting the decision rather than storing an owner also keeps caller identity out of the shared delivery layer: the controller says what it **did**, and the caller who made the call keeps the meaning.

## A false justification in a comment, corrected

The old comment said the count was a COUNT because `runLaunch` is re-entered when onboarding completes, so two automatic attempts can overlap. **Verified: they cannot, by that route.** `onboardingDidComplete()` guards on `deferredForOnboarding`, which is set only when `runLaunch` returned at the onboarding gate — *before* fetching.

Per-attempt keying is still right, for the reason the comment did not give: `runLaunch()` is `public`, so concurrent calls are possible. Correct code, wrong reason — and a wrong reason at the code stops the next reader checking, which is the expensive half.

## `.remove` is deliberately untouched

It reads `isRevisionUpgradeOwed` — durable admission state — so it refuses the **model**, not whichever task happens to be running. Joined-fetch confusion cannot reach it. This is also an argument for the shape chosen: the alternative design's shared async hook would have dragged Remove through a suspension it has no use for.

## Test

Three arms, because each is satisfiable by the opposite bug:

- **JOINED** writes no decline — alone, passes against a coordinator that records nothing, breaking the feature to fix the bug;
- **PENDING** refuses;
- **STARTED** still declines — that arm is the existing `cancelDuringAutomaticUpgradeRecordsDecline`, which now reports `.started` first. That is the real order (the controller decides, the download runs, Cancel arrives during it) and it is what makes that case about *attribution* rather than accidentally exercising the refusal.

The new case asserts **what `recordUserDecline` answered**, not merely that no marker exists. A refusal and a permitted-but-non-declining cancel both leave no marker; only the return value separates them — and one mutation row in #2398 exists precisely to prove that assertion is load-bearing.

Retired a scope note on the neighbouring test saying the joined case was uncovered and must not be written against then-current behaviour. Correct when written; misleading now.

## Known gap, named rather than implied

The new case drives attribution through the production seam, so it proves the **coordinator** handles each answer correctly. It does **not** prove the **controller** reports `.joined` when it joins — a controller that never fired the callback would leave everything `.pending` and refuse every cancel: safe, and wrong.

Closing it needs a controller-level case holding a fetch at a barrier, calling `ensureModelAvailable` twice, and asserting `.started` / `.joined` with exactly one underlying fetch. Filed as an expected-survivor row in **#2398** with that shape written out, rather than closed by asserting the coordinator harder — the gap is one layer up and no coordinator-level assertion reaches it.

## Validation

- Debug lane **6,641**, Release lane **5,997** — **+1 each** against `6509b2cd`, exactly the one new case, present in both configurations.
- `EGOneRevisionUpgradeTests` 29/29 (was 28), new case's name present in the log.
- Every removed line in this diff is nameable: 33, all traced to a named edit.
- Live UAT not required: the surface is decline bookkeeping with no UI, asserted at the seam in three directions.

Lane: `Code`. Tier: MEDIUM.

## Round 2 — the cloud review's P2, and it was a regression in my own fix

**I widened a refusal window from one scheduling hop to seconds of disk work, in the name of safety.**

`runLaunch` registered `.pending` before calling `ensureCurrentModel`. But the adapter awaits `legacyPrepareBeforeEnsure` — retirement preparation, which can hash a 2.9 GB monolith — **before** it reaches the controller. So a user cancelling their OWN, unrelated download was refused for that entire hash, on the strength of a join that had not happened and could not yet have happened.

That is worse than the defect `.pending` exists to prevent, and user-visible in a way the original never was: the Cancel button stops working.

**The invariant `.pending` should express is "our attempt MIGHT have joined or started, and we do not yet know which".** Before the controller is entered we definitively have not, so the honest state during preparation is *not registered* — which reads as "not ours" and leaves the user's cancel alone, correctly.

Fixed by splitting the signal: the adapter announces `onWillRequestFetch` immediately before entering the controller, after preparation, and the coordinator registers `.pending` on that rather than at launch. Two callbacks instead of one enum carrying a phase, so each says exactly one thing and the adapter needs no coordinator-shaped type to say it.

`onWillRequestFetch` is **awaited rather than spawned**, deliberately: a `.pending` landing after its own resolution would be a stuck attempt nothing clears, and that failure mode refuses every subsequent cancel for the life of the process.

**Fourth test arm, binding exactly this:** a cancel BEFORE the ensure enters the controller must be PERMITTED. That is the direction nothing was checking, and it is the direction this round's defect went. The arms are now before-entering (permitted), pending (refused), joined (permitted, declines nothing), and started (declines — its own case).

Final validation: Debug **6,641**, Release **5,997**, both green; `EGOneRevisionUpgradeTests` 29/29.
