### PR TITLE
refactor(overlay): PillCatalog as the sole definition and design-resolution authority (#2375 Phase 3)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/Overlay/OverlayDirector.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/OverlayDirector.swift
@@ -1389,8 +1389,25 @@ extension OverlayDirector: OverlayPresenting {
     // Recording is the exception and it is not a refusal: a recording morph
     // keeps the identity it was created with, so the incumbent id IS the id this
     // request now owns.
+    //
+    // **BUT THE EXCEPTION IS ABOUT A MORPH, AND THE ID ALONE CANNOT TELL A MORPH
+    // FROM A REQUEST THAT NEVER COMMITTED.** Three recording paths reach here
+    // having installed nothing: a refusal because a feature holds the slot, a
+    // discard because a newer event won between PREPARE and COMMIT, and the
+    // catalog returning no definition. On all three the occupant is somebody
+    // else's pill, so an unconditional receipt hands the recording caller an
+    // error or a Bluetooth card to call `isCurrent` about and dismiss — which is
+    // the exact harm the paragraph above describes, arriving through the one
+    // branch written to skip it.
+    //
+    // Ask what the slot HOLDS rather than which request asked. A morph and a
+    // fresh commit both leave a recording current; nothing that failed to commit
+    // does.
     guard let current = reducer.state.current else { return nil }
-    if case .recording = request { return PillReceipt(presentationID: current.id) }
+    if case .recording = request {
+      guard case .recording = current.content else { return nil }
+      return PillReceipt(presentationID: current.id)
+    }
     guard current.id != incumbentID else { return nil }
     return PillReceipt(presentationID: current.id)
   }

--- a/Sources/EnviousWisprAppKit/App/Overlay/OverlayDirector.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/OverlayDirector.swift
@@ -250,10 +250,9 @@ final class OverlayDirector {
   /// this is required, so forgetting it does not compile.
   ///
   /// Atomicity is untouched, and it never depended on how these arrived:
-  /// `presentRecording` still RESOLVES the layout by calling
-  /// `livePreview.isEnabledForGeometry()` at present time, so the geometry comes
-  /// from the setting at the moment the pill appears. That is a property of WHEN
-  /// the closure is called.
+  /// `presentRecording` reads capability and selections at presentation time and
+  /// resolves them once into a design, so the definition's geometry comes from
+  /// that captured pair.
   private let livePreview: LivePreviewBridge
 
   /// What the accessibility notice's Grant button does.
@@ -361,38 +360,35 @@ final class OverlayDirector {
     _ event: OverlayEvent, binding: BindingInput, relay: PresentationRelay? = nil
   ) {
     if case .pipeline(.recording) = event {
-      // **The wrong ORDER is what this refuses, not the wrong event.** A caller
-      // that sends first and installs providers afterwards renders one frame
-      // from whatever the model last held — the previous dictation's layout, or
-      // the `.compact(.top)` default on the first recording of the session — and
-      // a later mutation of the model is not published, so the wrong frame is
-      // also the final one.
+      // **The wrong ORDER is what this refuses, not the wrong event.** A bare
+      // event carries no providers and resolves no design or position.
       //
       // `assertionFailure` rather than a precondition: this is a programming
       // invariant, caught in Debug and in CI, and trapping a user's Release build
       // over a first-frame defect is worse than the defect.
       //
-      // **In Release this does NOT refuse.** `assertionFailure` compiles away and
-      // the call falls through to render with the layout the model already holds
-      // — correct for a morph, stale-but-plausible for a fresh recording. The
-      // step-4 caller sweep must therefore leave no such call; the assertion
-      // catches one during development, it does not defend against one shipping.
+      // In Release the assertion compiles away. A live recording may still morph
+      // using its preserved design, captured position and already-installed
+      // providers; a fresh recording is refused by the reducer and shows nothing.
+      // The caller sweep remains load-bearing because the assertion is
+      // diagnostic, not a Release defence.
       assertionFailure(
-        "use presentRecording(...) — a recording's providers and layout must be "
-          + "installed in the same operation that presents it")
+        "use presentRecording(...) — a recording's providers and its resolved design "
+          + "must be installed in the same operation that presents it")
     }
     apply(reducer.reduce(event), binding: binding, relay: relay)
   }
 
-  /// Present the recording pill with its providers and its layout installed in
-  /// ONE operation.
+  /// Present the recording pill with its providers and its resolved design
+  /// installed in ONE operation.
   ///
-  /// **Five things travel together and the shipped code installs them together.**
-  /// See `OverlayRecordingLayout`. Splitting them across `setRecordingProviders`
+  /// **The accepted definition, captured position and recording providers are
+  /// installed together.**
+  /// Splitting them across `setRecordingProviders`
   /// and `send` made a wrong first frame expressible, so this is the only way to
   /// express the right one.
   ///
-  /// A MORPH keeps the layout it was created with. The shipped panel reads the
+  /// A MORPH keeps the design it was created with. The shipped panel reads the
   /// preview setting once at creation and its width is fixed for that panel's
   /// life, because an `NSPanel` cannot grow mid-recording without a rebuild and a
   /// rebuild is the #930 flicker. Re-resolving here on every audio tick would
@@ -434,8 +430,14 @@ final class OverlayDirector {
         apply(plan, binding: .none, effectsAlreadyDelivered: true, relay: relay)
         return
       }
+      // A morph keeps the live pill's design and position: nothing was resolved,
+      // so there is nothing new to install.
+      guard let design = presentation.recordingDesign else {
+        assertionFailure("a morphed recording carries no design")
+        return
+      }
       installRecordingProviders(
-        for: presentation, layout: model.recordingLayout,
+        for: presentation, design: design, position: model.recordingPosition,
         audioLevelProvider: audioLevelProvider,
         recordingElapsedProvider: recordingElapsedProvider)
       apply(plan, binding: .none, effectsAlreadyDelivered: true, relay: relay)
@@ -486,14 +488,11 @@ final class OverlayDirector {
         return
       }
 
-      // **From the ACCEPTED definition's design, never from `resolution`.** They
-      // are equal today, which is exactly why the difference matters: the
-      // constraint is that the adapter can only ever describe the pill that
-      // actually committed, so it cannot drift into computing its own answer. An
-      // adapter that can compute its own answer is not an adapter.
-      let layout = OverlayRecordingLayout(design: acceptedDesign, position: at)
+      // **From the ACCEPTED definition's design, never from `resolution`.**
+      // They are equal today, but passing `resolution.design` would reintroduce a
+      // second answer beside the definition that actually committed.
       installRecordingProviders(
-        for: definition, layout: layout,
+        for: definition, design: acceptedDesign, position: at,
         audioLevelProvider: audioLevelProvider,
         recordingElapsedProvider: recordingElapsedProvider)
       apply(plan, binding: .none, effectsAlreadyDelivered: true, relay: relay)
@@ -504,7 +503,8 @@ final class OverlayDirector {
   /// drift in what they hand the render model.
   private func installRecordingProviders(
     for presentation: PillDefinition,
-    layout: OverlayRecordingLayout,
+    design: RecordingPillDesign,
+    position: OverlayPillPosition,
     audioLevelProvider: @escaping () -> Float,
     recordingElapsedProvider: @escaping () -> TimeInterval?
   ) {
@@ -512,23 +512,20 @@ final class OverlayDirector {
       audioLevel: audioLevelProvider,
       recordingElapsed: recordingElapsedProvider,
       livePreview: livePreview.display,
-      layout: layout,
+      design: design,
+      position: position,
       onContentHeightChange: { [weak self] height in
         // The preview pill grows a line at a time as words wrap. Keyed to the
         // presentation it was installed for, so a late callback from a finished
         // dictation cannot resize the pill that replaced it.
         //
-        // **STILL READS THE RETAINED ADAPTER, and that is C3a's boundary rather
-        // than an oversight.** This callback is one of the three replacements
-        // §3.5 names, and all three land together in C3b because they are one
-        // value being taken apart — a partial landing leaves a consumer reading a
-        // deleted field. Moving it early would make C3b's deletion the visual
-        // change this chunk is supposed not to be.
-        guard let self, self.presentedID == presentation.id,
-          self.model.recordingLayout.usesPreview
+        // **Width comes from the design CAPTURED in this transaction, never
+        // re-read** (#2375 C3b). Reading it back off the render model is what
+        // made this a second consumer of the geometry override, so a change to
+        // that override silently moved a live pill's growth width.
+        guard let self, self.presentedID == presentation.id, design.canHoldWords
         else { return }
-        self.host.resizeCurrentPresentation(
-          to: CGSize(width: self.model.recordingLayout.width, height: height))
+        self.host.resizeCurrentPresentation(to: CGSize(width: design.width, height: height))
       })
   }
 
@@ -906,26 +903,20 @@ final class OverlayDirector {
   private func geometry(
     for presentation: PillDefinition
   ) -> (width: OverlayWidth, fixedHeight: CGFloat?) {
-    guard case .recording = presentation.content else {
-      return (presentation.requestedWidth, presentation.reservesFixedHeight)
-    }
-    // **THIS OVERRIDE IS NOW A NO-OP, AND C3B DELETES IT** (#2375 C3a).
+    // **THE RECORDING SPECIAL CASE IS GONE, AND THAT IS G3 CLOSED** (#2375 C3b).
     //
-    // Its old comment said the reducer's 185/92 was "the compact answer and is
-    // deliberately ignored here: the reducer cannot know which layout is in
-    // force". That was true and it was the whole of G3 — two authorities for one
-    // geometry, the correct-looking one ignored, with the arrangement documented
-    // as though it were a design.
+    // It substituted the layout bundle's width and height for the definition's,
+    // and its own comment said why: the reducer "cannot know which layout is in
+    // force", so its 185/92 was ignored. Two authorities for one geometry, the
+    // correct-looking one discarded, documented as though it were a design.
     //
-    // The definition now carries the RESOLVED design and its own width and
-    // height, and `model.recordingLayout` is derived from that same design, so
-    // both sides of this function agree by construction. It is kept for exactly
-    // one chunk so C3a stays a structural change rather than a visual one, and
-    // `recordingAdapterMatchesTheAcceptedDefinition` asserts the agreement for
-    // both designs — which is what makes C3b's deletion provably a no-op rather
-    // than argued to be one.
-    let layout = model.recordingLayout
-    return (.fixed(layout.width), layout.fixedHeight)
+    // A recording definition now carries its RESOLVED design's own width and
+    // height, so there is one answer and this function returns it like every
+    // other pill's. C3a proved the deletion was a no-op by asserting the adapter
+    // and the definition agreed for both designs; that assertion is deleted with
+    // the adapter, because once there is nothing to disagree with it asserts
+    // nothing.
+    return (presentation.requestedWidth, presentation.reservesFixedHeight)
   }
 
   /// Push the model's new occupant to the window.
@@ -1075,13 +1066,11 @@ final class OverlayDirector {
     presentedID = presentation.id
     let recordingGeometry = geometry(for: presentation)
     // **One position per presentation, not two reads of a provider.** The
-    // recording layout captured the anchored edge when the pill was composed;
-    // re-reading here lets a setting changed in between compose against one edge
-    // and place against another, which is the same assembled-from-two-instants
-    // defect the layout value exists to close.
+    // recording position was captured when the pill was composed; re-reading here
+    // could compose against one edge and place against another.
     let anchor: OverlayPillPosition
     if case .recording = presentation.content {
-      anchor = model.recordingLayout.position
+      anchor = model.recordingPosition
     } else {
       anchor = position()
     }

--- a/Sources/EnviousWisprAppKit/App/Overlay/OverlayDirector.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/OverlayDirector.swift
@@ -725,7 +725,7 @@ final class OverlayDirector {
   /// its events. Every other presentation takes its own width and reserved height
   /// unchanged.
   private func geometry(
-    for presentation: OverlayPresentation
+    for presentation: PillDefinition
   ) -> (width: OverlayWidth, fixedHeight: CGFloat?) {
     guard case .recording = presentation.content else {
       return (presentation.requestedWidth, presentation.reservesFixedHeight)
@@ -759,7 +759,7 @@ final class OverlayDirector {
   /// Returns `false` ONLY when the host refused a presentation it was asked to
   /// show. Emptying the slot always succeeds, so the caller reads a `false` as
   /// "the occupant this plan installed is not on screen and never will be".
-  private static func isRecording(_ presentation: OverlayPresentation) -> Bool {
+  private static func isRecording(_ presentation: PillDefinition) -> Bool {
     if case .recording = presentation.content { return true }
     return false
   }
@@ -772,7 +772,7 @@ final class OverlayDirector {
 
   @discardableResult
   private func render(
-    _ presentation: OverlayPresentation?, onPresented: @escaping () -> Void = {},
+    _ presentation: PillDefinition?, onPresented: @escaping () -> Void = {},
     relay: PresentationRelay? = nil
   ) -> RenderOutcome {
     guard let presentation else {
@@ -851,7 +851,7 @@ final class OverlayDirector {
 
   /// The synchronous half, so the deferred first call and every later one run
   /// exactly the same code rather than two copies that can drift.
-  private func performRender(_ presentation: OverlayPresentation) -> Bool {
+  private func performRender(_ presentation: PillDefinition) -> Bool {
     // **`isFresh` means NOTHING IS SHOWING, not "a different occupant".** The
     // comment here used to say the opposite and the code matched it, which made
     // every recording -> processing -> warning step a fresh presentation: the

--- a/Sources/EnviousWisprAppKit/App/Overlay/OverlayDirector.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/OverlayDirector.swift
@@ -30,6 +30,33 @@ final class OverlayDirector {
   private let model: OverlayRenderModel
   private let schedule: OverlayScheduler
 
+  /// **Which recording pill the user has chosen, read fresh per recording.**
+  ///
+  /// A CLOSURE and not a stored value: the director is constructed once and lives
+  /// for the application's lifetime, so an immutable pair would freeze the choice
+  /// at launch — Phase 4's picker would appear to work, change nothing, and only
+  /// take effect after a relaunch. That is a seam that looks correct and is not,
+  /// which is worse than an obviously missing one.
+  ///
+  /// Read ONCE PER FRESH RECORDING and never on a same-id morph, matching the
+  /// discipline capability already follows and for the same reason: an `NSPanel`
+  /// cannot grow mid-recording without a rebuild, and a rebuild is the #930
+  /// flicker. A live pill must not change design because the user opened Settings
+  /// mid-dictation.
+  private let selections: @MainActor () -> PillDesignSelections
+
+  /// How a bounded bridge reconciliation reaches the next run-loop turn.
+  private let scheduleReconciliation: (@escaping () -> Void) -> Void
+
+  /// **A closed state machine, not a latch.** It means "a continuation chain is
+  /// queued OR EXECUTING": true from the moment the first continuation is queued,
+  /// true throughout that chain including while a queued closure runs and the
+  /// queue is empty, and false only after a pass observes an unchanged slot
+  /// revision. A flag that only ever gets set is
+  /// a permanent mute wearing coalescing's name — the same shape this whole phase
+  /// exists to remove, one layer down.
+  private var reconciliationPending = false
+
   /// The ONE armed expiry. Replacing it cancels whatever was armed, which is
   /// what makes a stale dismissal structurally impossible rather than merely
   /// guarded against.
@@ -253,12 +280,27 @@ final class OverlayDirector {
     // about neither; choosing one is now visible in the source.
     livePreview: LivePreviewBridge,
     grantAccessibility: @escaping () -> Void,
+    // **No default either, for the reason directly above** (#2375 C3a). This is
+    // the seam Phase 4 replaces: a settings-backed snapshot at this same
+    // construction point, changing this closure's BODY and nothing else. A
+    // default would let a caller silently inherit the constant, so Phase 4 would
+    // end up editing the default instead of the seam — a seam that looks
+    // installed and is not.
+    selections: @escaping @MainActor () -> PillDesignSelections,
     makeID: @escaping () -> PresentationID = { PresentationID() },
     deferFirstRender: @escaping (@escaping () -> Void) -> Void = { work in
+      DispatchQueue.main.async(execute: work)
+    },
+    // A MECHANISM default, unlike the two above: production always wants the next
+    // main-run-loop turn, and a test wants to execute the queued continuation
+    // itself so the bound is asserted without a sleep.
+    scheduleReconciliation: @escaping (@escaping () -> Void) -> Void = { work in
       DispatchQueue.main.async(execute: work)
     }
   ) {
     self.deferFirstRender = deferFirstRender
+    self.selections = selections
+    self.scheduleReconciliation = scheduleReconciliation
     self.host = host
     self.announce = announce
     self.accessibilityEligibility = accessibilityEligibility
@@ -377,35 +419,95 @@ final class OverlayDirector {
     // morph that the recording plan below supersedes. What matters is the STATE
     // it sets, which the born-locked rule and the morph path both read.
     _ = reducer.reduce(.lockStateChanged(isRecordingLocked))
-    let plan = reducer.reduce(.pipeline(.recording(audioLevel: audioLevel)))
 
-    // **The effect goes out BEFORE the layout is resolved, not merely before the
-    // render.** Moving effects to the top of `apply` was half the fix: this
-    // method reads `livePreview.isEnabledForGeometry()` on its way to a layout, and
-    // happens before `apply` is ever called. `LivePreviewCoordinator` applies its
-    // model-removal suppression inside `setRecording`, so a geometry read that
-    // beats the effect can pick the 400-point preview layout for a pill whose
-    // preview is about to resolve DISABLED — a preview-sized window with no
-    // preview in it.
-    for effect in plan.effects {
-      route(effect)
-    }
-
-    guard let presentation = plan.presentation else {
-      // The reducer refused — a feature holds the slot, or nothing changed.
+    switch reducer.prepareRecording(audioLevel: audioLevel) {
+    case .refused(let plan):
+      // A feature holds the slot, or nothing changed.
       apply(plan, binding: .none, effectsAlreadyDelivered: true, relay: relay)
-      return
-    }
 
-    let layout: OverlayRecordingLayout
-    if presentedID == presentation.id {
-      layout = model.recordingLayout
-    } else {
+    case .morphed(let plan):
+      // **A same-id morph skips RESOLVE ENTIRELY.** The live pill keeps its
+      // design, so there is nothing to read and nothing that could change: no
+      // capability read, no selections read, no position read. This is the
+      // shipped `presentedID == presentation.id` branch keeping its meaning.
+      guard let presentation = plan.presentation else {
+        apply(plan, binding: .none, effectsAlreadyDelivered: true, relay: relay)
+        return
+      }
+      installRecordingProviders(
+        for: presentation, layout: model.recordingLayout,
+        audioLevelProvider: audioLevelProvider,
+        recordingElapsedProvider: recordingElapsedProvider)
+      apply(plan, binding: .none, effectsAlreadyDelivered: true, relay: relay)
+
+    case .prepared(let token):
+      // ---- RESOLVE ----------------------------------------------------------
+      // **The effect goes out BEFORE capability is read, not merely before the
+      // render**, and that ordering is the reason this whole boundary exists.
+      // `LivePreviewCoordinator` applies its model-removal suppression inside
+      // `setRecording`, so a capability read that beats the effect can pick the
+      // 400-point design for a pill whose preview is about to resolve DISABLED —
+      // a preview-sized window with no preview in it.
+      for effect in token.effects {
+        route(effect)
+      }
+
+      // Capability, selections and position: read ONCE, here, together.
+      let capabilityHasWords = livePreview.isEnabledForGeometry()
+      let resolution = selections().resolve(capabilityHasWords: capabilityHasWords)
       let at = position()
-      layout = livePreview.isEnabledForGeometry() ? .preview(position: at) : .compact(position: at)
-      // Read HERE, at present time — see the `livePreview` note.
-    }
 
+      let entry = PillCatalog.entry(
+        for: .recording(audioLevel: token.audioLevel, design: resolution.design), id: token.id)
+      // **Both guards run BEFORE COMMIT.** An earlier version validated the
+      // accepted design AFTER committing, so on failure the corrupt state had
+      // already landed and the guard could only report it. Reconciling the bridge
+      // here also covers the nil-definition case, which previously returned
+      // leaving Live Preview told a recording had started.
+      guard let definition = entry.definition,
+        let acceptedDesign = definition.recordingDesign
+      else {
+        assertionFailure("the catalog's recording arm returned no recording definition")
+        reconcileRecordingBridge()
+        return
+      }
+
+      // ---- COMMIT -----------------------------------------------------------
+      guard let plan = reducer.commitRecording(token, definition: definition) else {
+        // **DISCARDED, and the discard is not an error.** A newer overlay event
+        // reentered synchronously between PREPARE and COMMIT and is already
+        // authoritative, so retrying would install an older pill over a newer
+        // one. Nothing is committed, rendered, announced or armed.
+        //
+        // But RESOLVE already routed `.recordingStateChanged(true)`, so Live
+        // Preview has been told a recording started with nothing behind it. That
+        // is the leak this reconciliation closes, and it retries only the BRIDGE.
+        reconcileRecordingBridge()
+        return
+      }
+
+      // **From the ACCEPTED definition's design, never from `resolution`.** They
+      // are equal today, which is exactly why the difference matters: the
+      // constraint is that the adapter can only ever describe the pill that
+      // actually committed, so it cannot drift into computing its own answer. An
+      // adapter that can compute its own answer is not an adapter.
+      let layout = OverlayRecordingLayout(design: acceptedDesign, position: at)
+      installRecordingProviders(
+        for: definition, layout: layout,
+        audioLevelProvider: audioLevelProvider,
+        recordingElapsedProvider: recordingElapsedProvider)
+      apply(plan, binding: .none, effectsAlreadyDelivered: true, relay: relay)
+    }
+  }
+
+  /// The provider install, shared by the morph and commit paths so the two cannot
+  /// drift in what they hand the render model.
+  private func installRecordingProviders(
+    for presentation: PillDefinition,
+    layout: OverlayRecordingLayout,
+    audioLevelProvider: @escaping () -> Float,
+    recordingElapsedProvider: @escaping () -> TimeInterval?
+  ) {
     model.setRecordingProviders(
       audioLevel: audioLevelProvider,
       recordingElapsed: recordingElapsedProvider,
@@ -415,14 +517,91 @@ final class OverlayDirector {
         // The preview pill grows a line at a time as words wrap. Keyed to the
         // presentation it was installed for, so a late callback from a finished
         // dictation cannot resize the pill that replaced it.
+        //
+        // **STILL READS THE RETAINED ADAPTER, and that is C3a's boundary rather
+        // than an oversight.** This callback is one of the three replacements
+        // §3.5 names, and all three land together in C3b because they are one
+        // value being taken apart — a partial landing leaves a consumer reading a
+        // deleted field. Moving it early would make C3b's deletion the visual
+        // change this chunk is supposed not to be.
         guard let self, self.presentedID == presentation.id,
           self.model.recordingLayout.usesPreview
         else { return }
         self.host.resizeCurrentPresentation(
           to: CGSize(width: self.model.recordingLayout.width, height: height))
       })
+  }
 
-    apply(plan, binding: .none, effectsAlreadyDelivered: true, relay: relay)
+  /// Tell Live Preview what the reducer now says, and keep telling it until the
+  /// slot stops moving (#2375 C3a).
+  ///
+  /// **Bounded, and the bound is the point.** Routing calls back into the same
+  /// boundary that created the prepare/commit hazard, so reading the answer
+  /// before the call proves nothing about the answer after it — but "repeat until
+  /// stable" is a proof obligation dressed as an algorithm, and an unbounded
+  /// synchronous loop would spin on the RECORDING path, which `CLAUDE.md` says
+  /// must work every time it physically can.
+  ///
+  /// Neither escape is acceptable here: a silent give-up leaves Live Preview
+  /// wrong with nothing reporting it, and a `fatalError` turns a rare reentrancy
+  /// into a crash mid-dictation. So: at most TWO synchronous attempts, then
+  /// exactly one continuation onto the next turn, which schedules its own
+  /// successor only if the world moved again. It yields under sustained churn
+  /// rather than spinning, and it never abandons reconciliation.
+  ///
+  /// Every attempt is mint-free, render-free, announcement-free and expiry-free.
+  private func reconcileRecordingBridge() {
+    var attempts = 0
+    while attempts < 2 {
+      attempts += 1
+      let before = reducer.recordingReconciliationSnapshot
+      route(.recordingStateChanged(before.isRecording))
+      // **Converged. The flag is NOT touched here, and that is deliberate.** It
+      // means "a continuation chain is queued or executing", and this synchronous
+      // pass may be
+      // running while one already is — a second discard can arrive inside a
+      // route. Clearing a flag this pass did not set would let the next caller
+      // enqueue a duplicate, which is the one thing the flag exists to prevent.
+      if reducer.recordingReconciliationSnapshot.revision == before.revision { return }
+    }
+    scheduleReconciliationContinuation()
+  }
+
+  /// One continuation, coalesced. A call arriving while one is pending does not
+  /// enqueue another; the pending one reads the LATEST snapshot when it runs, so
+  /// a late continuation is harmless by construction — the danger is never a
+  /// wrong value, only a suppressed one.
+  ///
+  /// **`reconciliationPending` means a continuation chain is queued or executing.**
+  /// While a queued closure runs, the queue is empty and the flag is still true —
+  /// "queued" alone would be a claim the implementation does not make. One place
+  /// sets it and one place clears it. An earlier version had three sites
+  /// touching it, two of which could clear a flag they had not set: the
+  /// synchronous pass above, and the continuation clearing it before recursing
+  /// into that pass — which can route, reenter, discard, and reach here again
+  /// with the guard open.
+  private func scheduleReconciliationContinuation() {
+    guard !reconciliationPending else { return }
+    reconciliationPending = true
+    enqueueReconciliationPass()
+  }
+
+  /// The chain re-enqueues through here rather than through the guard above, so
+  /// the flag stays true for the whole chain and is cleared only by the pass that
+  /// finds the world has stopped moving.
+  private func enqueueReconciliationPass() {
+    // **Weak capture**, so teardown cancels the remaining work rather than having
+    // a pending reconciliation extend the director's lifetime.
+    scheduleReconciliation { [weak self] in
+      guard let self else { return }
+      let before = self.reducer.recordingReconciliationSnapshot
+      self.route(.recordingStateChanged(before.isRecording))
+      if self.reducer.recordingReconciliationSnapshot.revision == before.revision {
+        self.reconciliationPending = false
+        return
+      }
+      self.enqueueReconciliationPass()
+    }
   }
 
   /// Present the accessibility notice, showing the toast or falling back to the
@@ -730,12 +909,21 @@ final class OverlayDirector {
     guard case .recording = presentation.content else {
       return (presentation.requestedWidth, presentation.reservesFixedHeight)
     }
-    // **BOTH axes come from the layout, and the width is the one that is easy to
-    // miss.** The shipped site reads `showsPreview ? previewPillWidth : 185` —
-    // 400 against 185 — before it picks the sizing branch, so carrying only the
-    // height still renders a preview pill at under half its intended width. The
-    // reducer's own 185/92 is the compact answer and is deliberately ignored
-    // here: the reducer cannot know which layout is in force.
+    // **THIS OVERRIDE IS NOW A NO-OP, AND C3B DELETES IT** (#2375 C3a).
+    //
+    // Its old comment said the reducer's 185/92 was "the compact answer and is
+    // deliberately ignored here: the reducer cannot know which layout is in
+    // force". That was true and it was the whole of G3 — two authorities for one
+    // geometry, the correct-looking one ignored, with the arrangement documented
+    // as though it were a design.
+    //
+    // The definition now carries the RESOLVED design and its own width and
+    // height, and `model.recordingLayout` is derived from that same design, so
+    // both sides of this function agree by construction. It is kept for exactly
+    // one chunk so C3a stays a structural change rather than a visual one, and
+    // `recordingAdapterMatchesTheAcceptedDefinition` asserts the agreement for
+    // both designs — which is what makes C3b's deletion provably a no-op rather
+    // than argued to be one.
     let layout = model.recordingLayout
     return (.fixed(layout.width), layout.fixedHeight)
   }

--- a/Sources/EnviousWisprAppKit/App/Overlay/OverlayPlacementState.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/OverlayPlacementState.swift
@@ -206,3 +206,52 @@ struct OverlayPlacementState: Equatable {
     min(requestedY, screen.visibleFrame.maxY - height - topClampMargin)
   }
 }
+
+// MARK: - Screens and geometry
+
+/// A screen's stable identity, so placement can say "the same screen" without
+/// holding an `NSScreen` and without AppKit being present in a test.
+struct ScreenID: Hashable, Sendable {
+  let rawValue: Int
+  init(rawValue: Int) { self.rawValue = rawValue }
+}
+
+/// Everything placement needs to know about a screen. A value, so the geometry
+/// rules are exercisable against invented screens — including the ones that are
+/// awkward to obtain on the dev machine, such as a display whose `visibleFrame`
+/// is inset by a notch or by a full-screen space.
+struct ScreenGeometry: Equatable, Sendable {
+  let id: ScreenID
+  /// Full display bounds.
+  let frame: CGRect
+  /// Bounds excluding menu bar and Dock.
+  let visibleFrame: CGRect
+  /// True when the screen currently shows a full-screen space, which is the
+  /// condition the Bottom rule keys off.
+  let hasFullScreenSpace: Bool
+
+  init(id: ScreenID, frame: CGRect, visibleFrame: CGRect, hasFullScreenSpace: Bool = false) {
+    self.id = id
+    self.frame = frame
+    self.visibleFrame = visibleFrame
+    self.hasFullScreenSpace = hasFullScreenSpace
+  }
+}
+
+/// Whether a presentation is arriving into an empty slot or replacing a live one.
+///
+/// **`continuing` carries the COMPLETE current frame, both axes.** That is the
+/// whole of the #2195 fix: the shipped path inherits only `y` and always
+/// recentres `x`, so a pill the user dragged horizontally jumps back to centre
+/// the moment its content changes. A single value carrying the whole rect makes
+/// the half-inheritance unrepresentable rather than merely discouraged.
+enum OverlayContinuity: Equatable, Sendable {
+  case fresh(position: OverlayPillPosition, screen: ScreenID)
+  /// `outgoingWasContentSized` is required, not optional: the shipped Top rule
+  /// re-anchors a content-sized outgoing panel by its TOP edge and a
+  /// fixed-frame one by its CENTRE, and getting that wrong moves the pill
+  /// vertically on an ordinary recording-to-polishing hand-off.
+  case continuing(
+    currentFrame: CGRect, anchoredScreen: ScreenID, outgoingWasContentSized: Bool)
+}
+

--- a/Sources/EnviousWisprAppKit/App/Overlay/OverlayReducer.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/OverlayReducer.swift
@@ -79,7 +79,7 @@ enum OverlayExpiryCommand: Equatable {
 /// window server, a run loop, or a clock.
 struct OverlayPlan: Equatable {
   /// What should occupy the slot now. `nil` means the slot is empty.
-  let presentation: OverlayPresentation?
+  let presentation: PillDefinition?
   /// True when the host must apply `presentation`.
   ///
   /// False leaves the window's content unchanged; it does NOT mean the plan is
@@ -117,7 +117,7 @@ struct OverlayPlan: Equatable {
   static let noChange = OverlayPlan(presentation: nil, didChange: false)
 
   init(
-    presentation: OverlayPresentation?, didChange: Bool,
+    presentation: PillDefinition?, didChange: Bool,
     expiryCommand: OverlayExpiryCommand = .unchanged,
     deliverAction: PillAction? = nil,
     effects: [PillEffect] = [],
@@ -136,7 +136,7 @@ struct OverlayPlan: Equatable {
 /// collection it has become the thing it replaced.
 struct OverlayState: Equatable {
   /// What occupies the slot, or nil.
-  private(set) var current: OverlayPresentation?
+  private(set) var current: PillDefinition?
   /// The last pipeline intent seen. A feature may take the slot only while this
   /// is `.hidden`, which is the arbitration rule the shipped code spells out
   /// separately at every feature.
@@ -176,7 +176,7 @@ struct OverlayState: Equatable {
   }
 
   fileprivate mutating func set(
-    current: OverlayPresentation?, pipelineIntent: OverlayIntent? = nil, isHovered: Bool? = nil,
+    current: PillDefinition?, pipelineIntent: OverlayIntent? = nil, isHovered: Bool? = nil,
     isLocked: Bool? = nil
   ) {
     self.current = current
@@ -255,7 +255,7 @@ struct OverlayReducer {
       let current = state.current,
       case .recording(_, let isLocked, let notice) = current.content
     {
-      let updated = OverlayPresentation(
+      let updated = PillDefinition(
         id: current.id,
         content: .recording(audioLevel: level, isLocked: isLocked, notice: notice),
         expiry: current.expiry,
@@ -283,7 +283,7 @@ struct OverlayReducer {
     // exists precisely so this is applied in the SAME transaction rather than
     // rendered unlocked and morphed a frame later.
     if case .recording(let level, _, let notice) = presentation.content, state.isLocked {
-      presentation = OverlayPresentation(
+      presentation = PillDefinition(
         id: presentation.id,
         content: .recording(audioLevel: level, isLocked: true, notice: notice),
         expiry: presentation.expiry, requestedWidth: presentation.requestedWidth,
@@ -359,7 +359,7 @@ struct OverlayReducer {
       }
     }
     return admit(
-      OverlayPresentation(
+      PillDefinition(
         id: makeID(),
         content: .notice(NoticeModel(kind: .importStatus, text: message, isMultiline: true)),
         // `ImportStatusOverlayView` uses `.frame(maxWidth: 280)` — a BOUND, not a
@@ -378,7 +378,7 @@ struct OverlayReducer {
   private mutating func reduceBluetoothAwareness() -> OverlayPlan {
     guard state.featureSlotIsAvailable else { return .noChange }
     return admit(
-      OverlayPresentation(
+      PillDefinition(
         id: makeID(), content: .bluetoothAwareness, expiry: .untilReplaced,
         requestedWidth: .fixed(320)),  // :1790 — persistent
       announcement: Self.announcement(for: .bluetoothAwareness))
@@ -386,7 +386,7 @@ struct OverlayReducer {
 
   /// The tail every feature shares: take the slot, arm the expiry, speak.
   private mutating func admit(
-    _ presentation: OverlayPresentation, announcement: OverlayAnnouncement?
+    _ presentation: PillDefinition, announcement: OverlayAnnouncement?
   ) -> OverlayPlan {
     state.set(current: presentation, isHovered: false)
     return OverlayPlan(
@@ -404,7 +404,7 @@ struct OverlayReducer {
   // there is no overload to resolve wrongly, and each feature names its own
   // sentence at the point it takes the slot.
 
-  private static func isRecording(_ p: OverlayPresentation?) -> Bool {
+  private static func isRecording(_ p: PillDefinition?) -> Bool {
     if case .recording? = p?.content { return true }
     return false
   }
@@ -427,7 +427,7 @@ struct OverlayReducer {
       return .noChange
     }
 
-    let updated = OverlayPresentation(
+    let updated = PillDefinition(
       id: current.id,
       content: .recording(audioLevel: level, isLocked: locked, notice: notice),
       expiry: current.expiry, requestedWidth: current.requestedWidth,
@@ -449,7 +449,7 @@ struct OverlayReducer {
       case .recording(let level, let isLocked, _) = current.content
     else { return .noChange }
 
-    let updated = OverlayPresentation(
+    let updated = PillDefinition(
       id: current.id,
       content: .recording(
         audioLevel: level, isLocked: isLocked,
@@ -475,7 +475,7 @@ struct OverlayReducer {
       case .recording(let level, let isLocked, let notice) = current.content, notice != nil
     else { return .noChange }
 
-    let updated = OverlayPresentation(
+    let updated = PillDefinition(
       id: current.id,
       content: .recording(audioLevel: level, isLocked: isLocked, notice: nil),
       expiry: current.expiry,
@@ -568,7 +568,7 @@ struct OverlayReducer {
   /// dwell, `.cancel` when it is persistent. Never `.unchanged` — leaving the
   /// previous occupant's timer running is how a stale dismissal reaches a live
   /// pill, which is the whole defect `PresentationID` exists to close.
-  private static func command(for p: OverlayPresentation) -> OverlayExpiryCommand {
+  private static func command(for p: PillDefinition) -> OverlayExpiryCommand {
     guard case .after(let seconds, _) = p.expiry else { return .cancel }
     return .arm(id: p.id, seconds: seconds, target: .presentation)
   }
@@ -582,7 +582,7 @@ struct OverlayReducer {
   /// opening the panel and reading them. The sites are cited per row so the next
   /// reader can re-check rather than trust this sentence.
   private static func presentation(for intent: OverlayIntent, id: PresentationID)
-    -> OverlayPresentation?
+    -> PillDefinition?
   {
     switch intent {
     case .hidden:
@@ -600,7 +600,7 @@ struct OverlayReducer {
       // the reducer cannot decide it here, and it does not: the 92 below is the
       // NON-preview answer, and `OverlayDirector.fixedHeight(for:)` overrides it
       // to content-sized when the render model says preview is on.
-      return OverlayPresentation(
+      return PillDefinition(
         id: id, content: .recording(audioLevel: level, isLocked: false, notice: nil),
         expiry: .untilReplaced, requestedWidth: .fixed(185), reservesFixedHeight: 92)
 
@@ -662,7 +662,7 @@ struct OverlayReducer {
         expiry: .after(seconds: 2), severity: .distress)  // NotificationStyle 2.0
 
     case .passiveChip(let payload):
-      return OverlayPresentation(
+      return PillDefinition(
         id: id, content: .languageChip(payload: payload),
         expiry: .after(seconds: 6, pausesOnHover: true),
         requestedWidth: .fixed(340), reservesFixedHeight: 56)  // :1410
@@ -703,7 +703,7 @@ struct OverlayReducer {
         expiry: .after(seconds: 3))  // :675
 
     case .bluetoothAwareness:
-      return OverlayPresentation(
+      return PillDefinition(
         // that site calls `showPanel` with NO `scheduleAutoDismiss`: the card is
         // PERSISTENT until something replaces it. The first version gave it a
         // 6-second dwell, which would have made it vanish on its own.
@@ -711,7 +711,7 @@ struct OverlayReducer {
         requestedWidth: .fixed(320))
 
     case .escapeRecovery(let transcriptID):
-      return OverlayPresentation(
+      return PillDefinition(
         // **THIS expiry is the only one. The director owns it; the view draws
         // it.** Three seconds, hover-pausable, exactly like any other dwell.
         //
@@ -779,8 +779,8 @@ struct OverlayReducer {
     width: OverlayWidth, fixedHeight: CGFloat? = nil,
     expiry: OverlayExpiry = .untilReplaced, severity: NoticeModel.Severity = .neutral,
     isMultiline: Bool = false, action: (label: String, action: PillAction)? = nil
-  ) -> OverlayPresentation {
-    OverlayPresentation(
+  ) -> PillDefinition {
+    PillDefinition(
       id: id,
       content: .notice(
         NoticeModel(

--- a/Sources/EnviousWisprAppKit/App/Overlay/OverlayReducer.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/OverlayReducer.swift
@@ -235,7 +235,7 @@ struct OverlayReducer {
     // and re-announcing a recording that never stopped is not behaviour worth
     // porting.
     let isNewIntent = state.pipelineIntent != intent
-    let announcement = isNewIntent ? Self.announcement(for: intent) : nil
+    let announcement = isNewIntent ? PillCatalog.announcement(for: intent) : nil
 
     // **The shipped dedup DROPS a repeated intent, it does not merely silence
     // it.** The first version returned a fresh presentation with a new ID and
@@ -325,7 +325,13 @@ struct OverlayReducer {
     let showToast = showingToast()
     let toast = reducePipeline(.accessibilityToast)
     guard !showToast, let shown = toast.presentation,
-      let fallback = Self.presentation(for: .clipboardFallback, id: shown.id)
+      // The SECOND catalog request of this transition, with the SAME id.
+      // Stated rather than left to be rediscovered: this path substitutes the
+      // clipboard DEFINITION while retaining the accessibility entry's
+      // ANNOUNCEMENT, which is the one place the two halves of an entry
+      // legitimately come from different requests. Neither request carries or
+      // resolves a recording design.
+      let fallback = PillCatalog.entry(for: .clipboardFallback, id: shown.id).definition
     else {
       return toast
     }
@@ -353,19 +359,25 @@ struct OverlayReducer {
   /// switch had no arm for it. A sentence here would be inventing a notice.
   private mutating func reduceImportStatus(message: String) -> OverlayPlan {
     guard state.featureSlotIsAvailable else { return .noChange }
+    // **REDUNDANT TODAY, and deliberately kept.** `featureSlotIsAvailable`
+    // already refuses whenever the pipeline is not idle, and the only occupants a
+    // feature route can install while it IS idle are the Bluetooth card, which
+    // that guard also refuses, and an import-status notice, which this one
+    // admits. So no reachable state distinguishes the two, and deleting either
+    // line alone changes nothing observable — a single-line mutant here survives
+    // by construction rather than for want of a test.
+    //
+    // Written down because that is exactly how a later tidy-up removes half of a
+    // pair: run one mutation, see green, delete the line. The pair states a rule
+    // the arbitration guard does not — a status pill may replace ITSELF and
+    // nothing else — and it becomes load-bearing the moment a third feature route
+    // installs a non-notice occupant.
     if let current = state.current {
       guard case .notice(let notice) = current.content, notice.kind == .importStatus else {
         return .noChange
       }
     }
-    return admit(
-      PillDefinition(
-        id: makeID(),
-        content: .notice(NoticeModel(kind: .importStatus, text: message, isMultiline: true)),
-        // `ImportStatusOverlayView` uses `.frame(maxWidth: 280)` — a BOUND, not a
-        // width — under `fitToContent`, so this is measured too.
-        expiry: .after(seconds: 3), requestedWidth: .measured),  // :1105, :1148
-      announcement: nil)
+    return admitEntry(PillCatalog.entry(for: .importStatus(message: message), id: makeID()))
   }
 
   /// **The card is announced at MEDIUM priority, read off the shipped switch.**
@@ -377,11 +389,23 @@ struct OverlayReducer {
   /// dismissed rather than expiring on its own.
   private mutating func reduceBluetoothAwareness() -> OverlayPlan {
     guard state.featureSlotIsAvailable else { return .noChange }
-    return admit(
-      PillDefinition(
-        id: makeID(), content: .bluetoothAwareness, expiry: .untilReplaced,
-        requestedWidth: .fixed(320)),  // :1790 — persistent
-      announcement: Self.announcement(for: .bluetoothAwareness))
+    return admitEntry(PillCatalog.entry(for: .bluetoothAwareness, id: makeID()))
+  }
+
+  /// Admit a catalog entry.
+  ///
+  /// **The `nil` branch cannot be reached and is loud rather than silent.**
+  /// `.hidden` is the only request whose entry carries no definition, and no
+  /// feature path asks for it — but a `return .noChange` alone would turn a
+  /// future mistake into a pill that quietly never appears, which is the hardest
+  /// overlay defect to notice. Debug builds trap; release leaves the slot as it
+  /// was.
+  private mutating func admitEntry(_ entry: PillCatalogEntry) -> OverlayPlan {
+    guard let definition = entry.definition else {
+      assertionFailure("a feature request resolved to no definition")
+      return .noChange
+    }
+    return admit(definition, announcement: entry.announcement)
   }
 
   /// The tail every feature shares: take the slot, arm the expiry, speak.
@@ -573,20 +597,33 @@ struct OverlayReducer {
     return .arm(id: p.id, seconds: seconds, target: .presentation)
   }
 
-  /// The shipped widths and dwells, gathered.
+  /// What a pipeline intent occupies the slot with.
   ///
-  /// **Every value here was MEASURED at its shipped call site, and the first
-  /// version of this table was not.** It was written from the design and
-  /// described in the commit as "carried over", which was false: eleven of the
-  /// fifteen widths and six of the dwells were wrong. Cloud review caught it by
-  /// opening the panel and reading them. The sites are cited per row so the next
-  /// reader can re-check rather than trust this sentence.
+  /// **The table this used to hold now lives in `PillCatalog`**, moved byte for
+  /// byte with the comments citing the call sites each value was read off.
+  ///
+  /// **`.recording` is the ONE arm still minted here.** The catalog's recording
+  /// arm needs a RESOLVED design and no production caller can supply one until
+  /// C3a builds the recording transaction; a placeholder would make a
+  /// preview-capable definition disagree with its own rendered layout, which is
+  /// a wrong value that type-checks. C3a moves this arm and its comment together.
+  ///
+  /// Listing the other fifteen rather than writing `default` is deliberate: a new
+  /// pipeline intent must fail to compile here as well as in the catalog.
   private static func presentation(for intent: OverlayIntent, id: PresentationID)
     -> PillDefinition?
   {
     switch intent {
-    case .hidden:
-      return nil
+    case .hidden, .processing, .clipboardFallback, .accessibilityToast, .warning,
+      .error, .advisory, .interruption, .passiveChip, .cachingModel, .engineReady,
+      .recoveringLastRecording, .recoverySucceeded, .bluetoothAwareness, .escapeRecovery:
+      guard let request = PillCatalogRequest(pipeline: intent) else {
+        // Unreachable: the initialiser refuses `.recording` only, and that arm
+        // returns below without reaching here.
+        assertionFailure("PillCatalogRequest(pipeline:) refused a non-recording intent")
+        return nil
+      }
+      return PillCatalog.entry(for: request, id: id).definition
 
     case .recording(let level):
       // that site — the NON-PREVIEW recording pill, and only it, reserves a fixed
@@ -603,189 +640,23 @@ struct OverlayReducer {
       return PillDefinition(
         id: id, content: .recording(audioLevel: level, isLocked: false, notice: nil),
         expiry: .untilReplaced, requestedWidth: .fixed(185), reservesFixedHeight: 92)
-
-    case .processing(let phase):
-      // `PolishingOverlayView` pins no width and that site passes `fitToContent: true`,
-      // so the `230` at that call site is DISCARDED and the real width is the
-      // view's `fittingSize`. Carrying the literal would have looked right.
-      return notice(
-        id: id, kind: .processing, text: DictationNarrator.copy(for: phase),
-        width: .measured)
-
-    case .clipboardFallback:
-      // that site via transitionToPolishingNow, dwell from
-      // `scheduleAutoDismiss`'s own default.
-      return notice(
-        // Routes through the same `PolishingOverlayView` path, so also measured.
-        id: id, kind: .processing, text: DictationNarrator.clipboardFallbackText, width: .measured,
-        expiry: .after(seconds: 2.5))
-
-    case .accessibilityToast:
-      return notice(
-        id: id, kind: .accessibilityToast, text: DictationNarrator.accessibilityToastText,
-        width: .fixed(300), fixedHeight: 56,  // :859 and :1118 both pass height: 56
-        expiry: .after(seconds: 6), isMultiline: true,
-        action: (label: "Grant", action: .grantAccessibility))
-
-    case .warning(let reason):
-      return notice(
-        id: id, kind: .notification, text: DictationNarrator.copy(for: reason),
-        // A single-line notification is NOT `fitToContent`, so it takes
-        // `showPanel`'s own `height: 44` default and keeps the 280x44 box.
-        width: .fixed(280), fixedHeight: 44,
-        expiry: .after(seconds: 2.5), severity: .warning)  // NotificationStyle 2.5
-
-    case .error(let reason):
-      return notice(
-        id: id, kind: .notification, text: DictationNarrator.copy(for: reason),
-        width: .fixed(280), fixedHeight: 44,
-        expiry: .after(seconds: 3), severity: .error)  // NotificationStyle 3.0
-
-    case .advisory(let reason):
-      // #1891. A user-setup advisory draws the mic-slash glyph in the secondary
-      // colour, not the red failure treatment, and `NotificationStyle` owns both
-      // — so it needs a severity of its own rather than inheriting the helper's
-      // `.neutral`, which `OverlayRootView.style(for:)` paints as a warning.
-      //
-      // **The ONLY notification that is content-sized**, because `showPanel` is
-      // called with `fitToContent: style.isMultiline` and this is the one style
-      // where that is true. No `fixedHeight` here is deliberate, not an omission.
-      return notice(
-        id: id, kind: .notification, text: DictationNarrator.copy(for: reason),
-        width: .fixed(360),  // RecordingOverlayPanel.advisoryWidth
-        expiry: .after(seconds: 8), severity: .advisory, isMultiline: true)
-
-    case .interruption(let reason):
-      return notice(
-        id: id, kind: .notification, text: DictationNarrator.copy(for: reason),
-        width: .fixed(280), fixedHeight: 44,
-        expiry: .after(seconds: 2), severity: .distress)  // NotificationStyle 2.0
-
-    case .passiveChip(let payload):
-      return PillDefinition(
-        id: id, content: .languageChip(payload: payload),
-        expiry: .after(seconds: 6, pausesOnHover: true),
-        requestedWidth: .fixed(340), reservesFixedHeight: 56)  // :1410
-
-    case .cachingModel(let engineLabel):
-      return notice(
-        id: id, kind: .warmingUp, text: DictationNarrator.coldStartTitle,
-        secondary: DictationNarrator.coldStartSubtitle(engineLabel: engineLabel),
-        width: .fixed(300), fixedHeight: 56,  // :483
-        expiry: .after(seconds: 2))  // :642
-
-    case .engineReady:
-      return notice(
-        id: id, kind: .ready, text: DictationNarrator.readyTitle,
-        width: .fixed(240), fixedHeight: 44,  // :498
-        expiry: .after(seconds: 1.5))  // :657
-
-    case .recoveringLastRecording:
-      return notice(
-        id: id, kind: .recovery, text: DictationNarrator.recoveryTitle,
-        secondary: DictationNarrator.recoverySubtitle,
-        width: .fixed(320), fixedHeight: 56,  // :530
-        // that site gives it a 6-second dwell. The first version said `.untilReplaced`,
-        // which would have left the recovery pill on screen forever.
-        expiry: .after(seconds: 6), isMultiline: true,
-        action: (label: "Discard", action: .discardRecovery))
-
-    case .recoverySucceeded:
-      // `.ready`, NOT `.notification`. The shipped site draws
-      // `ColdStartNoticeView(title:subtitle:icon: .ready)` — the same green
-      // success mark `.engineReady` uses — and routing it through
-      // `NotificationOverlayView` would have painted a success message as a
-      // warning, which is the exact failure this whole mapping exists to stop.
-      return notice(
-        id: id, kind: .ready, text: DictationNarrator.recoverySucceededTitle,
-        secondary: DictationNarrator.recoverySucceededSubtitle,
-        width: .fixed(300), fixedHeight: 56,  // :516
-        expiry: .after(seconds: 3))  // :675
-
-    case .bluetoothAwareness:
-      return PillDefinition(
-        // that site calls `showPanel` with NO `scheduleAutoDismiss`: the card is
-        // PERSISTENT until something replaces it. The first version gave it a
-        // 6-second dwell, which would have made it vanish on its own.
-        id: id, content: .bluetoothAwareness, expiry: .untilReplaced,
-        requestedWidth: .fixed(320))
-
-    case .escapeRecovery(let transcriptID):
-      return PillDefinition(
-        // **THIS expiry is the only one. The director owns it; the view draws
-        // it.** Three seconds, hover-pausable, exactly like any other dwell.
-        //
-        // The shipped panel could not do that -- it had no single owner of
-        // expiry, so a panel-level timer could not be paused by a hover only the
-        // view sees and the view kept its own. That reason died with the
-        // retained window, and this comment used to LEAD with it as though it
-        // were still true, correcting itself only at the end.
-        //
-        // It cost two independent three-second timers running side by side from
-        // the cutover until cloud review found the rail finishing while the pill
-        // was still on screen. The trap worth naming: a comment asserting a
-        // FUTURE state ("a later chunk removes the view's task") is invisible to
-        // every diff review, because nothing in a diff can contradict a promise.
-        // C4 was recorded as doing it and did not; C18 did.
-        id: id, content: .escapeRecovery(transcriptID: transcriptID),
-        expiry: .after(seconds: 3, pausesOnHover: true), requestedWidth: .measured)
     }
   }
 
   // **`presentation(for request:id:)` was DELETED with `OverlayRequest`**
-  // (#2292 C5c). Its four arms are now: import status and Bluetooth inline in
-  // their own reducers above, and `.passiveChip` / `.accessibilityToast` gone
-  // entirely — those were unreachable duplicates of the pipeline presentations
-  // `presentation(for intent:)` already builds, since the chip travels as
-  // `.pipeline(.passiveChip)` and the toast through `reduceAccessibilityNotice`.
-
-  /// `fixedHeight` is the shipped `showPanel(height:)` for this notice, and
-  /// omitting it means CONTENT-SIZED, which is what `fitToContent: true` does at
-  /// the shipped site.
-  ///
-  /// **It defaults to nil and that default is a trap worth naming.** Every
-  /// notice in the first port took it, so eight pills that reserve a fixed box
-  /// became content-sized — a geometry change with no compiler error, no test
-  /// failure and no mention in any diff. `noticeGeometryIsPinned` sweeps the
-  /// closed set against the shipped call sites so a new row cannot inherit the
-  /// default silently.
-  /// The spoken announcement for a pipeline intent, and its priority.
-  ///
-  /// **Both halves come from the shipped `apply(intent:)` switch, read one arm
-  /// at a time.** The TEXT is `DictationNarrator.announcement(for:)`, which is
-  /// already the sole author (#1569 E4). The PRIORITY is the panel's own choice
-  /// per case — nine `.high` and seven `.medium` — and it is not derivable from
-  /// severity: `.recording` and `.engineReady` are high while `.warning` is
-  /// medium, so it is enumerated rather than computed.
-  static func announcement(for intent: OverlayIntent) -> OverlayAnnouncement {
-    let text = DictationNarrator.announcement(for: intent)
-    switch intent {
-    case .recording, .clipboardFallback, .accessibilityToast, .error, .advisory,
-      .interruption, .engineReady, .recoverySucceeded, .recoveringLastRecording:
-      return .high(text)
-    case .hidden, .processing, .warning, .passiveChip, .cachingModel,
-      .bluetoothAwareness, .escapeRecovery:
-      return .medium(text)
-    }
-  }
+  // (#2292 C5c). Two of its four arms — `.passiveChip` and `.accessibilityToast`
+  // — went entirely, as unreachable duplicates of the pipeline presentations this
+  // reducer already built: the chip travels as `.pipeline(.passiveChip)` and the
+  // toast through `reduceAccessibilityNotice`.
+  //
+  // The other two, import status and Bluetooth, were minted INLINE in their own
+  // reducers until #2375 C2 moved them into `PillCatalog` with everything else.
+  // Stated in the past tense on purpose: this note is history, and an earlier
+  // revision of it said "inline in their own reducers above", which C2 made false
+  // on the same day it stopped being true.
 
   private static func isRecordingIntent(_ intent: OverlayIntent) -> Bool {
     if case .recording = intent { return true }
     return false
-  }
-
-  private static func notice(
-    id: PresentationID, kind: NoticeModel.Kind, text: String, secondary: String? = nil,
-    width: OverlayWidth, fixedHeight: CGFloat? = nil,
-    expiry: OverlayExpiry = .untilReplaced, severity: NoticeModel.Severity = .neutral,
-    isMultiline: Bool = false, action: (label: String, action: PillAction)? = nil
-  ) -> PillDefinition {
-    PillDefinition(
-      id: id,
-      content: .notice(
-        NoticeModel(
-          kind: kind, text: text, secondaryText: secondary, severity: severity,
-          isMultiline: isMultiline, action: action)),
-      expiry: expiry, requestedWidth: width, reservesFixedHeight: fixedHeight)
   }
 }

--- a/Sources/EnviousWisprAppKit/App/Overlay/OverlayReducer.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/OverlayReducer.swift
@@ -175,10 +175,33 @@ struct OverlayState: Equatable {
     }
   }
 
+  /// How many times the SLOT has changed hands (#2375 C3a).
+  ///
+  /// **A slot revision, not a whole-state one, and the narrowing is a product
+  /// decision rather than an optimisation.** A prepared recording is discarded
+  /// when this moves between PREPARE and COMMIT. Two of `set`'s eleven callers
+  /// are a hover change and a lock-only change with no presentation; neither can
+  /// conflict with committing a fresh recording, and discarding on either means a
+  /// recording pill that never appears. `CLAUDE.md` puts "dictation works 100% of
+  /// the time it physically can" above every other audio decision, so an
+  /// over-eager invalidation is the more expensive error here.
+  ///
+  /// A lock morph on a LIVE recording changes `current` and therefore does
+  /// advance this, so no real slot conflict is missed.
+  private(set) var slotRevision: UInt64 = 0
+
   fileprivate mutating func set(
     current: PillDefinition?, pipelineIntent: OverlayIntent? = nil, isHovered: Bool? = nil,
     isLocked: Bool? = nil
   ) {
+    // **Compare VALUES, never "was a parameter supplied".** `set(current:isHovered:)`
+    // passes the EXISTING current straight through on a hover change, and
+    // `set(current:isLocked:)` does the same on a lock-only change, so an
+    // increment keyed on the presence of an argument would advance on every hover
+    // and silently undo the narrowing above.
+    if current != self.current || (pipelineIntent != nil && pipelineIntent != self.pipelineIntent) {
+      slotRevision &+= 1
+    }
     self.current = current
     if let pipelineIntent { self.pipelineIntent = pipelineIntent }
     if let isHovered { self.isHovered = isHovered }
@@ -219,6 +242,138 @@ struct OverlayReducer {
     }
   }
 
+  // MARK: - The recording transaction
+
+  /// What PREPARE decided, when it decided a fresh recording should start.
+  ///
+  /// **One-shot, and it publishes NO definition.** It carries only what RESOLVE
+  /// and COMMIT need: the identity the pill will have, the effects the director
+  /// must route before it may read capability, the sentence to speak, and the
+  /// slot revision PREPARE observed. Nothing here has been applied to reducer
+  /// state — that is the point of the split.
+  struct PreparedRecordingTransition: Equatable, Sendable {
+    let id: PresentationID
+    let audioLevel: Float
+    let effects: [PillEffect]
+    let announcement: OverlayAnnouncement?
+    /// The slot revision at PREPARE time. COMMIT refuses if it has moved.
+    let observedSlotRevision: UInt64
+  }
+
+  /// The three things PREPARE can conclude.
+  enum RecordingPreparation {
+    /// The slot already holds a recording, so this is a same-id morph: the design
+    /// is preserved from the live pill, RESOLVE is skipped entirely, and the plan
+    /// is final and already applied.
+    case morphed(OverlayPlan)
+    /// Nothing to do.
+    case refused(OverlayPlan)
+    /// A fresh recording. Route `effects`, resolve a design, then COMMIT.
+    case prepared(PreparedRecordingTransition)
+  }
+
+  /// PREPARE: decide admission, identity and effects for a recording WITHOUT
+  /// minting a definition (#2375 C3a).
+  ///
+  /// **This exists because recording composition is not one transaction.** The
+  /// shipped ordering routes the recording effect BEFORE reading whether Live
+  /// Preview is on, and that ordering is load-bearing: `LivePreviewCoordinator`
+  /// applies its model-removal suppression inside `setRecording`, so a capability
+  /// read that beats the effect can pick the wide layout for a pill whose preview
+  /// is about to resolve disabled — a preview-sized window with nothing in it.
+  /// The catalog needs the resolved design as an INPUT to minting, so the mint
+  /// has to happen after the effect, which means it cannot happen here.
+  ///
+  /// **Mutates nothing on the `prepared` path.** A caller that prepares and never
+  /// commits leaves the reducer exactly as it found it.
+  mutating func prepareRecording(audioLevel: Float) -> RecordingPreparation {
+    let intent = OverlayIntent.recording(audioLevel: audioLevel)
+    let isNewIntent = state.pipelineIntent != intent
+    let announcement = isNewIntent ? PillCatalog.announcement(for: intent) : nil
+
+    // A live recording keeps its identity across audio-level updates, and keeps
+    // its DESIGN with it. An `NSPanel` cannot grow mid-recording without a
+    // rebuild and a rebuild is the #930 flicker, so re-resolving here would
+    // resize a live pill the moment the user changed the setting.
+    if let current = state.current,
+      case .recording(_, let isLocked, let notice, let design) = current.content
+    {
+      let updated = PillDefinition(
+        id: current.id,
+        content: .recording(
+          audioLevel: audioLevel, isLocked: isLocked, notice: notice, design: design),
+        expiry: current.expiry,
+        requestedWidth: current.requestedWidth,
+        reservesFixedHeight: current.reservesFixedHeight)
+      state.set(current: updated, pipelineIntent: intent)
+      return .morphed(
+        OverlayPlan(presentation: updated, didChange: true, announcement: announcement))
+    }
+
+    // Fresh. `.recordingStateChanged(true)` is emitted here and routed by the
+    // director BEFORE it reads capability; COMMIT emits no effects of its own.
+    let wasRecording = Self.isRecording(state.current)
+    return .prepared(
+      PreparedRecordingTransition(
+        id: makeID(), audioLevel: audioLevel,
+        effects: wasRecording ? [] : [.recordingStateChanged(true)],
+        announcement: announcement,
+        observedSlotRevision: state.slotRevision))
+  }
+
+  /// COMMIT: install the definition the director obtained from the catalog.
+  ///
+  /// Returns `nil` when the token is stale, which means a newer overlay event
+  /// reentered synchronously between PREPARE and COMMIT and is already
+  /// authoritative. **A discarded transition is not an error and must not be
+  /// retried** — retrying it would install an older pill over a newer one, which
+  /// is the stale-first-presentation defect this phase must not introduce.
+  ///
+  /// **The born-locked rule reads the reducer's CURRENT lock, never one captured
+  /// at PREPARE.** That is what makes the narrowed slot revision safe rather than
+  /// merely defensible: a lock-only event arriving inside the window does not
+  /// advance the slot revision, so it does not invalidate the transition — and
+  /// because the lock is read here, its effect is preserved in the pill that
+  /// commits rather than lost.
+  mutating func commitRecording(
+    _ token: PreparedRecordingTransition, definition: PillDefinition
+  ) -> OverlayPlan? {
+    guard state.slotRevision == token.observedSlotRevision else { return nil }
+
+    var committed = definition
+    if state.isLocked,
+      case .recording(let level, _, let notice, let design) = definition.content
+    {
+      committed = PillDefinition(
+        id: definition.id,
+        content: .recording(audioLevel: level, isLocked: true, notice: notice, design: design),
+        expiry: definition.expiry, requestedWidth: definition.requestedWidth,
+        reservesFixedHeight: definition.reservesFixedHeight)
+    }
+
+    state.set(
+      current: committed, pipelineIntent: .recording(audioLevel: token.audioLevel),
+      isHovered: false)
+    return OverlayPlan(
+      presentation: committed, didChange: true,
+      expiryCommand: Self.command(for: committed),
+      // The effects went out at RESOLVE, before the capability read. Emitting
+      // them again here would tell Live Preview a recording started twice.
+      effects: [],
+      announcement: token.announcement)
+  }
+
+  /// What the bridge reconciliation reads.
+  ///
+  /// **A snapshot rather than a bare boolean, because the exit condition is "did
+  /// the world move", which a boolean cannot answer.** Reconciliation routes
+  /// `.recordingStateChanged`, and routing calls back into the same boundary that
+  /// created the prepare/commit hazard, so reading the answer before the call
+  /// proves nothing about the answer after it.
+  var recordingReconciliationSnapshot: (revision: UInt64, isRecording: Bool) {
+    (state.slotRevision, Self.isRecording(state.current))
+  }
+
   // MARK: - Pipeline
 
   private mutating func reducePipeline(_ intent: OverlayIntent) -> OverlayPlan {
@@ -248,21 +403,42 @@ struct OverlayReducer {
       return .noChange
     }
 
+    // **A bare `.pipeline(.recording)` may MORPH a live recording and may not
+    // START one.** The morph below preserves the current pill's design, so it
+    // needs nothing resolved. Starting one does, and `presentation(for:)` returns
+    // nil for `.recording`, so a fresh recording arriving here empties the slot
+    // rather than minting — which is why the guard after the morph refuses it
+    // loudly instead. Production never sends one: `OverlayDirector` uses
+    // `prepareRecording`.
+    //
     // A live recording pill must keep its identity across audio-level updates,
     // or every metering tick would look like a new presentation and re-arm
     // expiry, re-measure the frame and reset the in-panel notice.
     if case .recording(let level) = intent,
       let current = state.current,
-      case .recording(_, let isLocked, let notice) = current.content
+      case .recording(_, let isLocked, let notice, let design) = current.content
     {
       let updated = PillDefinition(
         id: current.id,
-        content: .recording(audioLevel: level, isLocked: isLocked, notice: notice),
+        content: .recording(
+          audioLevel: level, isLocked: isLocked, notice: notice, design: design),
         expiry: current.expiry,
         requestedWidth: current.requestedWidth,
         reservesFixedHeight: current.reservesFixedHeight)
       state.set(current: updated, pipelineIntent: intent)
       return OverlayPlan(presentation: updated, didChange: true, announcement: announcement)
+    }
+
+    if Self.isRecordingIntent(intent) {
+      // Reached only when the slot does not already hold a recording, i.e. a
+      // FRESH one. Refusing loudly beats emptying the slot, which is what falling
+      // through to the nil branch below would do — a dictation that starts and
+      // shows nothing, on the one path `CLAUDE.md` says must work every time it
+      // physically can.
+      assertionFailure(
+        "a fresh recording cannot be started through reduce(.pipeline(.recording)); "
+          + "use prepareRecording(audioLevel:) so a design can be resolved")
+      return .noChange
     }
 
     guard var presentation = Self.presentation(for: intent, id: makeID()) else {
@@ -282,10 +458,10 @@ struct OverlayReducer {
     // Born locked if the lock is on. `show(...isRecordingLocked:)`
     // exists precisely so this is applied in the SAME transaction rather than
     // rendered unlocked and morphed a frame later.
-    if case .recording(let level, _, let notice) = presentation.content, state.isLocked {
+    if case .recording(let level, _, let notice, let design) = presentation.content, state.isLocked {
       presentation = PillDefinition(
         id: presentation.id,
-        content: .recording(audioLevel: level, isLocked: true, notice: notice),
+        content: .recording(audioLevel: level, isLocked: true, notice: notice, design: design),
         expiry: presentation.expiry, requestedWidth: presentation.requestedWidth,
         reservesFixedHeight: presentation.reservesFixedHeight)
     }
@@ -445,7 +621,7 @@ struct OverlayReducer {
   private mutating func reduceLockState(_ locked: Bool) -> OverlayPlan {
     guard state.isLocked != locked else { return .noChange }
     guard let current = state.current,
-      case .recording(let level, _, let notice) = current.content
+      case .recording(let level, _, let notice, let design) = current.content
     else {
       state.set(current: state.current, isLocked: locked)
       return .noChange
@@ -453,7 +629,7 @@ struct OverlayReducer {
 
     let updated = PillDefinition(
       id: current.id,
-      content: .recording(audioLevel: level, isLocked: locked, notice: notice),
+      content: .recording(audioLevel: level, isLocked: locked, notice: notice, design: design),
       expiry: current.expiry, requestedWidth: current.requestedWidth,
       reservesFixedHeight: current.reservesFixedHeight)
     state.set(current: updated, isLocked: locked)
@@ -470,14 +646,14 @@ struct OverlayReducer {
     // would have torn the panel down; with the panel retained, this is a field
     // on the presentation that owns it.
     guard let current = state.current,
-      case .recording(let level, let isLocked, _) = current.content
+      case .recording(let level, let isLocked, _, let design) = current.content
     else { return .noChange }
 
     let updated = PillDefinition(
       id: current.id,
       content: .recording(
         audioLevel: level, isLocked: isLocked,
-        notice: InPanelNotice(reason: reason, dismissAfter: dismissAfter)),
+        notice: InPanelNotice(reason: reason, dismissAfter: dismissAfter), design: design),
       expiry: current.expiry,
       requestedWidth: current.requestedWidth,
       reservesFixedHeight: current.reservesFixedHeight)
@@ -496,12 +672,13 @@ struct OverlayReducer {
   /// outlives its banner.
   mutating func reduceInPanelNoticeExpiry(_ id: PresentationID) -> OverlayPlan {
     guard isCurrent(id), let current = state.current,
-      case .recording(let level, let isLocked, let notice) = current.content, notice != nil
+      case .recording(let level, let isLocked, let notice, let design) = current.content,
+      notice != nil
     else { return .noChange }
 
     let updated = PillDefinition(
       id: current.id,
-      content: .recording(audioLevel: level, isLocked: isLocked, notice: nil),
+      content: .recording(audioLevel: level, isLocked: isLocked, notice: nil, design: design),
       expiry: current.expiry,
       requestedWidth: current.requestedWidth,
       reservesFixedHeight: current.reservesFixedHeight)
@@ -602,11 +779,6 @@ struct OverlayReducer {
   /// **The table this used to hold now lives in `PillCatalog`**, moved byte for
   /// byte with the comments citing the call sites each value was read off.
   ///
-  /// **`.recording` is the ONE arm still minted here.** The catalog's recording
-  /// arm needs a RESOLVED design and no production caller can supply one until
-  /// C3a builds the recording transaction; a placeholder would make a
-  /// preview-capable definition disagree with its own rendered layout, which is
-  /// a wrong value that type-checks. C3a moves this arm and its comment together.
   ///
   /// Listing the other fifteen rather than writing `default` is deliberate: a new
   /// pipeline intent must fail to compile here as well as in the catalog.
@@ -617,29 +789,28 @@ struct OverlayReducer {
     case .hidden, .processing, .clipboardFallback, .accessibilityToast, .warning,
       .error, .advisory, .interruption, .passiveChip, .cachingModel, .engineReady,
       .recoveringLastRecording, .recoverySucceeded, .bluetoothAwareness, .escapeRecovery:
-      guard let request = PillCatalogRequest(pipeline: intent) else {
+      guard let request = PillCatalogRequest(nonRecording: intent) else {
         // Unreachable: the initialiser refuses `.recording` only, and that arm
-        // returns below without reaching here.
-        assertionFailure("PillCatalogRequest(pipeline:) refused a non-recording intent")
+        // returns above without reaching here.
+        assertionFailure("PillCatalogRequest(nonRecording:) refused a non-recording intent")
         return nil
       }
       return PillCatalog.entry(for: request, id: id).definition
 
-    case .recording(let level):
-      // that site — the NON-PREVIEW recording pill, and only it, reserves a fixed
-      // 92-point interaction frame: it holds the normal 185x44, the locked
-      // 120x64 and the #1060 notice expansion without resizing on every morph.
+    case .recording:
+      // **The reducer no longer mints a recording pill, and this is the whole of
+      // G3 closing.** The old arm here emitted 185x92 and said so in its own
+      // comment: "the 92 below is the NON-preview answer, and the director
+      // overrides it to content-sized when the render model says preview is on".
+      // Two authorities for one geometry, one of them ignored, documented as
+      // though it were a design.
       //
-      // **This is NOT universal, and the first version of this table claimed it
-      // was.** With Live Preview on, that site takes a different branch —
-      // `fitToContent: true`, content-sized from the first frame so it does not
-      // visibly snap. Whether preview is on is a provider the DIRECTOR owns, so
-      // the reducer cannot decide it here, and it does not: the 92 below is the
-      // NON-preview answer, and `OverlayDirector.fixedHeight(for:)` overrides it
-      // to content-sized when the render model says preview is on.
-      return PillDefinition(
-        id: id, content: .recording(audioLevel: level, isLocked: false, notice: nil),
-        expiry: .untilReplaced, requestedWidth: .fixed(185), reservesFixedHeight: 92)
+      // **`.recording` is deliberately not minted here.** C3a moved its factory
+      // into `PillCatalog`, and a fresh recording goes through
+      // `prepareRecording(audioLevel:)` — it needs a RESOLVED design, which needs
+      // a capability read, which must happen after the recording effect is
+      // routed. Nothing holding only an intent has resolved one.
+      return nil
     }
   }
 

--- a/Sources/EnviousWisprAppKit/App/Overlay/OverlayRenderModel.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/OverlayRenderModel.swift
@@ -1,4 +1,5 @@
 import CoreGraphics
+import EnviousWisprCore
 import Foundation
 import SwiftUI
 
@@ -56,8 +57,14 @@ final class OverlayRenderModel: ObservableObject {
   /// The capsule reports its measured height so the window can follow it. A
   /// callback rather than a value: it flows the other way.
   private(set) var onContentHeightChange: (CGFloat) -> Void = { _ in }
-  /// How the current recording pill is composed. See `OverlayRecordingLayout`
-  /// for the five decisions it carries and why they cannot be installed apart.
+  /// Where the current recording pill is anchored (#2375 C3b).
+  ///
+  /// **A POSITION, not a layout bundle.** It used to be an
+  /// OverlayRecordingLayout carrying position, width, height and preview
+  /// eligibility together — and the geometry half of that was a SECOND authority
+  /// that disagreed with the definition and won. The definition now carries its
+  /// own width and height; only the position needs a home here, because it is
+  /// resolved by the director and read by the placement anchor.
   ///
   /// **Resolved once per FRESH recording and then held, rather than re-read.**
   /// The shipped site reads the setting once at panel creation and the width is
@@ -65,24 +72,27 @@ final class OverlayRenderModel: ObservableObject {
   /// without a rebuild, and a rebuild is the #930 flicker. So a mid-dictation
   /// settings change must NOT resize the live pill, which is what re-reading a
   /// provider on every morph would do.
-  private(set) var recordingLayout: OverlayRecordingLayout = .compact(position: .top)
+  private(set) var recordingPosition: OverlayPillPosition = .top
 
   func setRecordingProviders(
     audioLevel: @escaping () -> Float,
     recordingElapsed: @escaping () -> TimeInterval?,
     livePreview: @escaping () -> LivePreviewDisplay,
-    layout: OverlayRecordingLayout,
+    design: RecordingPillDesign,
+    position: OverlayPillPosition,
     onContentHeightChange: @escaping (CGFloat) -> Void
   ) {
     audioLevelProvider = audioLevel
     recordingElapsedProvider = recordingElapsed
-    // **Gated exactly as the shipped site gates it.** With preview off it passes
-    // `{ .off }` rather than the live display provider, so a pill that shows no
-    // preview cannot be reading one.
-    livePreviewProvider = layout.usesPreview ? livePreview : { .off }
-    recordingLayout = layout
-    // Likewise `{ _ in }` off-preview: only the preview pill grows to its text.
-    self.onContentHeightChange = layout.usesPreview ? onContentHeightChange : { _ in }
+    // **Gated exactly as the shipped site gates it, off the DESIGN.** With a pill
+    // that cannot hold words it passes `{ .off }` rather than the live display
+    // provider, so a pill that shows no preview cannot be reading one. The gate
+    // used to key off a geometry bundle's preview flag, which is how one
+    // authority came to disagree with another about what was on screen.
+    livePreviewProvider = design.canHoldWords ? livePreview : { .off }
+    recordingPosition = position
+    // Likewise `{ _ in }` for a pill that holds no words: only that one grows.
+    self.onContentHeightChange = design.canHoldWords ? onContentHeightChange : { _ in }
   }
 
   /// Dropped when the recording pill goes, so a stale closure cannot outlive the
@@ -94,6 +104,6 @@ final class OverlayRenderModel: ObservableObject {
     recordingElapsedProvider = { nil }
     livePreviewProvider = { .off }
     onContentHeightChange = { _ in }
-    recordingLayout = .compact(position: .top)
+    recordingPosition = .top
   }
 }

--- a/Sources/EnviousWisprAppKit/App/Overlay/OverlayRenderModel.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/OverlayRenderModel.swift
@@ -17,7 +17,7 @@ import SwiftUI
 final class OverlayRenderModel: ObservableObject {
 
   /// What the retained root should render, or `nil` for an empty slot.
-  @Published var presentation: OverlayPresentation?
+  @Published var presentation: PillDefinition?
 
   /// **The dwell a countdown is drawing**, published so a view starts from the
   /// same instant the director armed the real dismissal. `nil` while nothing is

--- a/Sources/EnviousWisprAppKit/App/Overlay/OverlayRootView.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/OverlayRootView.swift
@@ -81,7 +81,7 @@ struct OverlayRootView: View {
   @ViewBuilder
   private func content(for presentation: PillDefinition) -> some View {
     switch presentation.content {
-    case .recording:
+    case .recording(_, _, _, let design):
       // The LEVEL on the presentation is a snapshot the reducer carries for
       // identity and morph decisions; the view reads the live provider instead,
       // which is why it is not bound here.
@@ -92,8 +92,9 @@ struct OverlayRootView: View {
       // size itself inside a 92-point window: the #1341 Bottom case in
       // particular depends on the ALIGNMENT here, because bottom-aligning the
       // content is what makes the panel's Y origin the capsule's visible bottom
-      // edge. `OverlayRecordingLayout` owns all of it.
-      recording(model.recordingLayout)
+      // edge. The DESIGN owns the size and the captured position owns the
+      // alignment; nothing bundles them together any more.
+      recording(design: design, position: model.recordingPosition)
 
     case .notice(let notice):
       notices(notice, on: presentation)
@@ -121,28 +122,41 @@ struct OverlayRootView: View {
     }
   }
 
+  /// **`usesPreviewLayout` SURVIVES this chunk, and that is the boundary rather
+  /// than an oversight** (#2375 C3b). Two adapters existed and only one is
+  /// deleted: the layout bundle is gone, and this boolean is still handed to
+  /// `RecordingOverlayView` with its internal uses untouched. It is DERIVED —
+  /// its only input is the captured design — so it cannot disagree with the
+  /// catalog independently. Phase 4 replaces it with the design itself.
+  ///
+  /// **The design is NON-OPTIONAL, and an earlier version of this took an
+  /// optional and fell back to `.classic`.** The definition's own recording case
+  /// carries the design, so the caller binds it there and nothing here can
+  /// substitute a second answer — which is exactly the arrangement this chunk
+  /// deletes, and I had rebuilt a small one inside the fix for it.
   @ViewBuilder
-  private func recording(_ layout: OverlayRecordingLayout) -> some View {
+  private func recording(
+    design: RecordingPillDesign, position: OverlayPillPosition
+  ) -> some View {
     let view = RecordingOverlayView(
       audioLevelProvider: model.audioLevelProvider,
       recordingElapsedProvider: model.recordingElapsedProvider,
       livePreviewProvider: model.livePreviewProvider,
       onContentHeightChange: model.onContentHeightChange,
-      usesPreviewLayout: layout.usesPreview,
+      usesPreviewLayout: design.canHoldWords,
       lockState: lockState.value,
       noticeState: noticeState.value)
 
-    switch layout {
-    case .preview(_):
+    if design.canHoldWords {
       // Width only. The height is content-driven so the pill earns its size a
       // line at a time rather than snapping once the real height is measured.
-      view.frame(width: layout.width)
-    case .compact(let position):
+      view.frame(width: design.width)
+    } else {
       // #1341: Bottom bottom-aligns, Top centres. Centring in Bottom leaves ~24
       // points of invisible space under a ~44-point capsule, which mutes the
       // Bottom offset and visibly misaligns the polishing pill that replaces it.
       view.frame(
-        width: layout.width, height: layout.fixedHeight,
+        width: design.width, height: design.reservedHeight,
         alignment: position == .bottom ? .bottom : .center)
     }
   }

--- a/Sources/EnviousWisprAppKit/App/Overlay/OverlayRootView.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/OverlayRootView.swift
@@ -5,7 +5,7 @@ import SwiftUI
 ///
 /// **View construction lives HERE, not in the render model and not in the
 /// director.** The model holds values and providers; the director decides; this
-/// switches over `OverlayPresentation.content` and builds the EXISTING leaf
+/// switches over `PillDefinition.content` and builds the EXISTING leaf
 /// views. Putting the `switch` in the model would make the model know about
 /// SwiftUI, and putting it in the director would make the director know about
 /// pixels — both are the god-object shape this migration is removing, relocated.
@@ -62,7 +62,7 @@ struct OverlayRootView: View {
     .onChange(of: model.presentation) { _, new in sync(new) }
   }
 
-  private func sync(_ presentation: OverlayPresentation?) {
+  private func sync(_ presentation: PillDefinition?) {
     guard case .recording(_, let isLocked, let notice)? = presentation?.content else {
       lockState.value.isLocked = false
       noticeState.value.message = nil
@@ -74,12 +74,12 @@ struct OverlayRootView: View {
 
   /// Every leaf callback goes through here, so the presentation's own ID travels
   /// with the press instead of being looked up afterwards.
-  private func press(_ action: PillAction, on presentation: OverlayPresentation) {
+  private func press(_ action: PillAction, on presentation: PillDefinition) {
     sendEvent(.action(presentation.id, action))
   }
 
   @ViewBuilder
-  private func content(for presentation: OverlayPresentation) -> some View {
+  private func content(for presentation: PillDefinition) -> some View {
     switch presentation.content {
     case .recording:
       // The LEVEL on the presentation is a snapshot the reducer carries for
@@ -151,7 +151,7 @@ struct OverlayRootView: View {
   /// keeps their appearance intact — the model says what to say, the kind says
   /// which pill says it.
   @ViewBuilder
-  private func notices(_ notice: NoticeModel, on presentation: OverlayPresentation) -> some View {
+  private func notices(_ notice: NoticeModel, on presentation: PillDefinition) -> some View {
     switch notice.kind {
     case .processing:
       PolishingOverlayView(label: notice.text)

--- a/Sources/EnviousWisprAppKit/App/Overlay/OverlayRootView.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/OverlayRootView.swift
@@ -63,7 +63,7 @@ struct OverlayRootView: View {
   }
 
   private func sync(_ presentation: PillDefinition?) {
-    guard case .recording(_, let isLocked, let notice)? = presentation?.content else {
+    guard case .recording(_, let isLocked, let notice, _)? = presentation?.content else {
       lockState.value.isLocked = false
       noticeState.value.message = nil
       return

--- a/Sources/EnviousWisprAppKit/App/Overlay/PillCatalog.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/PillCatalog.swift
@@ -1,0 +1,374 @@
+import CoreGraphics
+import EnviousWisprCore
+import EnviousWisprPipeline
+import Foundation
+
+/// The sole authority on what a pill IS: given a request and an identity, the
+/// definition that occupies the slot and the sentence a screen reader speaks.
+///
+/// **AppKit-free and stateless, deliberately.** Everything here is a pure
+/// function of its arguments, so the whole catalog is testable with no
+/// windowing, no clock and no director present — the same property
+/// `OverlayReducer` has and for the same reason.
+///
+/// **What it does NOT own, and the boundary is the point.** Admission,
+/// arbitration, identity, staleness and the five same-id morphs stay on the
+/// reducer: those are functions of `OverlayState`, not of a request. Geometry
+/// overrides and capability stay on the director. This type answers one
+/// question — what does this request look like and what does it say.
+///
+/// **Every value below was MEASURED at its shipped call site**, and was moved
+/// here byte for byte rather than retyped. The comments citing those sites moved
+/// with them, so the next reader can re-check rather than trust a summary. An
+/// earlier port of this same table wrote it from the design instead and got
+/// eleven of fifteen widths and six dwells wrong.
+enum PillCatalogRequest: Equatable, Sendable {
+  case hidden
+  case processing(phase: ProcessingPhase)
+  case clipboardFallback
+  case accessibilityToast
+  case warning(reason: RecordingWarningReason)
+  case error(reason: TerminalNoticeReason)
+  case advisory(reason: TerminalAdvisoryReason)
+  case interruption(reason: TerminalNoticeReason)
+  case passiveChip(payload: LanguageChipPayload)
+  case cachingModel(engineLabel: String)
+  case engineReady
+  case recoveringLastRecording
+  case recoverySucceeded
+  case bluetoothAwareness
+  case escapeRecovery(transcriptID: UUID)
+
+  /// The one request with no matching `OverlayIntent`. It is minted by a feature
+  /// path rather than by the pipeline, which is why it announces nothing.
+  case importStatus(message: String)
+
+  // **SIXTEEN cases, and `.recording` is deliberately absent until C3a.** The
+  // catalog's recording arm needs a RESOLVED design, and no production caller
+  // can supply one before the recording transaction exists. A `.recording` case
+  // landing here early would need either an unimplemented arm or a placeholder
+  // design, and a placeholder would make a preview-capable definition disagree
+  // with its own rendered layout — a wrong value that type-checks, in the chunk
+  // whose entire receipt is parity.
+  //
+  // **The count is sixteen, not seventeen, and the difference is G2 itself.**
+  // `bluetoothAwareness` is a pipeline intent AND is minted a second time by
+  // `reduceBluetoothAwareness`; those are two ROUTES to one VALUE, not two
+  // requests. C0 froze both routes as separate rows and they are identical field
+  // for field, which is the measurement that settles it. A seventeenth
+  // non-recording case here could only be a second Bluetooth arm — G2's
+  // duplicate, reappearing inside the type built to remove it.
+}
+
+/// What one request resolves to.
+///
+/// **An ENTRY rather than a definition, because `.hidden` has neither.** It
+/// empties the slot and still says "Recording complete", so a definition-only
+/// return could not carry it — and `announcement(for:)` would have had to stay a
+/// SECOND intent-to-value mapping on the reducer, which would make this type's
+/// central claim false.
+struct PillCatalogEntry: Equatable, Sendable {
+  /// `nil` empties the slot.
+  let definition: PillDefinition?
+  /// `nil` says nothing. Only import status is silent.
+  let announcement: OverlayAnnouncement?
+}
+
+enum PillCatalog {
+
+  /// The one entry point.
+  static func entry(for request: PillCatalogRequest, id: PresentationID) -> PillCatalogEntry {
+    PillCatalogEntry(
+      definition: definition(for: request, id: id),
+      announcement: announcement(for: request))
+  }
+
+  /// The announcement alone, for the ONE caller that needs it before it has an
+  /// identity to spend.
+  ///
+  /// **This is not a second entry point and must not be folded into `entry`.**
+  /// The reducer decides whether to announce BEFORE its dedup guard and before
+  /// the same-id morph path, and only allocates an id further down. Calling
+  /// `entry` at the earlier site would burn a `PresentationID` on two paths that
+  /// consume none today — invisible in production, where ids are UUIDs, and
+  /// immediately wrong for every test that injects a deterministic id factory to
+  /// assert on identity. There is still exactly one implementation: `entry`
+  /// calls this.
+  static func announcement(for request: PillCatalogRequest) -> OverlayAnnouncement? {
+    guard let intent = request.matchingIntent else {
+      // **Import status announces NOTHING, and that is preserved rather than
+      // omitted.** It is the one presentation with no matching `OverlayIntent`,
+      // so the shipped switch had no arm for it. A sentence here would be
+      // inventing a notice.
+      return nil
+    }
+    return announcement(for: intent)
+  }
+
+
+  /// The spoken announcement for a pipeline intent, and its priority.
+  ///
+  /// **Both halves come from the shipped `apply(intent:)` switch, read one arm
+  /// at a time.** The TEXT is `DictationNarrator.announcement(for:)`, which is
+  /// already the sole author (#1569 E4). The PRIORITY is the panel's own choice
+  /// per case — nine `.high` and seven `.medium` — and it is not derivable from
+  /// severity: `.recording` and `.engineReady` are high while `.warning` is
+  /// medium, so it is enumerated rather than computed.
+  static func announcement(for intent: OverlayIntent) -> OverlayAnnouncement {
+    let text = DictationNarrator.announcement(for: intent)
+    switch intent {
+    case .recording, .clipboardFallback, .accessibilityToast, .error, .advisory,
+      .interruption, .engineReady, .recoverySucceeded, .recoveringLastRecording:
+      return .high(text)
+    case .hidden, .processing, .warning, .passiveChip, .cachingModel,
+      .bluetoothAwareness, .escapeRecovery:
+      return .medium(text)
+    }
+  }
+
+  // MARK: - The shipped table
+
+  /// The shipped widths and dwells, gathered.
+  ///
+  /// **Every value here was MEASURED at its shipped call site, and the first
+  /// version of this table was not.** It was written from the design and
+  /// described in the commit as "carried over", which was false: eleven of the
+  /// fifteen widths and six of the dwells were wrong. Cloud review caught it by
+  /// opening the panel and reading them. The sites are cited per row so the next
+  /// reader can re-check rather than trust this sentence.
+  private static func definition(for request: PillCatalogRequest, id: PresentationID)
+    -> PillDefinition?
+  {
+    switch request {
+
+    case .hidden:
+      return nil
+
+    case .processing(let phase):
+      // `PolishingOverlayView` pins no width and that site passes `fitToContent: true`,
+      // so the `230` at that call site is DISCARDED and the real width is the
+      // view's `fittingSize`. Carrying the literal would have looked right.
+      return notice(
+        id: id, kind: .processing, text: DictationNarrator.copy(for: phase),
+        width: .measured)
+
+    case .clipboardFallback:
+      // that site via transitionToPolishingNow, dwell from
+      // `scheduleAutoDismiss`'s own default.
+      return notice(
+        // Routes through the same `PolishingOverlayView` path, so also measured.
+        id: id, kind: .processing, text: DictationNarrator.clipboardFallbackText, width: .measured,
+        expiry: .after(seconds: 2.5))
+
+    case .accessibilityToast:
+      return notice(
+        id: id, kind: .accessibilityToast, text: DictationNarrator.accessibilityToastText,
+        width: .fixed(300), fixedHeight: 56,  // :859 and :1118 both pass height: 56
+        expiry: .after(seconds: 6), isMultiline: true,
+        action: (label: "Grant", action: .grantAccessibility))
+
+    case .warning(let reason):
+      return notice(
+        id: id, kind: .notification, text: DictationNarrator.copy(for: reason),
+        // A single-line notification is NOT `fitToContent`, so it takes
+        // `showPanel`'s own `height: 44` default and keeps the 280x44 box.
+        width: .fixed(280), fixedHeight: 44,
+        expiry: .after(seconds: 2.5), severity: .warning)  // NotificationStyle 2.5
+
+    case .error(let reason):
+      return notice(
+        id: id, kind: .notification, text: DictationNarrator.copy(for: reason),
+        width: .fixed(280), fixedHeight: 44,
+        expiry: .after(seconds: 3), severity: .error)  // NotificationStyle 3.0
+
+    case .advisory(let reason):
+      // #1891. A user-setup advisory draws the mic-slash glyph in the secondary
+      // colour, not the red failure treatment, and `NotificationStyle` owns both
+      // — so it needs a severity of its own rather than inheriting the helper's
+      // `.neutral`, which `OverlayRootView.style(for:)` paints as a warning.
+      //
+      // **The ONLY notification that is content-sized**, because `showPanel` is
+      // called with `fitToContent: style.isMultiline` and this is the one style
+      // where that is true. No `fixedHeight` here is deliberate, not an omission.
+      return notice(
+        id: id, kind: .notification, text: DictationNarrator.copy(for: reason),
+        width: .fixed(360),  // RecordingOverlayPanel.advisoryWidth
+        expiry: .after(seconds: 8), severity: .advisory, isMultiline: true)
+
+    case .interruption(let reason):
+      return notice(
+        id: id, kind: .notification, text: DictationNarrator.copy(for: reason),
+        width: .fixed(280), fixedHeight: 44,
+        expiry: .after(seconds: 2), severity: .distress)  // NotificationStyle 2.0
+
+    case .passiveChip(let payload):
+      return PillDefinition(
+        id: id, content: .languageChip(payload: payload),
+        expiry: .after(seconds: 6, pausesOnHover: true),
+        requestedWidth: .fixed(340), reservesFixedHeight: 56)  // :1410
+
+    case .cachingModel(let engineLabel):
+      return notice(
+        id: id, kind: .warmingUp, text: DictationNarrator.coldStartTitle,
+        secondary: DictationNarrator.coldStartSubtitle(engineLabel: engineLabel),
+        width: .fixed(300), fixedHeight: 56,  // :483
+        expiry: .after(seconds: 2))  // :642
+
+    case .engineReady:
+      return notice(
+        id: id, kind: .ready, text: DictationNarrator.readyTitle,
+        width: .fixed(240), fixedHeight: 44,  // :498
+        expiry: .after(seconds: 1.5))  // :657
+
+    case .recoveringLastRecording:
+      return notice(
+        id: id, kind: .recovery, text: DictationNarrator.recoveryTitle,
+        secondary: DictationNarrator.recoverySubtitle,
+        width: .fixed(320), fixedHeight: 56,  // :530
+        // that site gives it a 6-second dwell. The first version said `.untilReplaced`,
+        // which would have left the recovery pill on screen forever.
+        expiry: .after(seconds: 6), isMultiline: true,
+        action: (label: "Discard", action: .discardRecovery))
+
+    case .recoverySucceeded:
+      // `.ready`, NOT `.notification`. The shipped site draws
+      // `ColdStartNoticeView(title:subtitle:icon: .ready)` — the same green
+      // success mark `.engineReady` uses — and routing it through
+      // `NotificationOverlayView` would have painted a success message as a
+      // warning, which is the exact failure this whole mapping exists to stop.
+      return notice(
+        id: id, kind: .ready, text: DictationNarrator.recoverySucceededTitle,
+        secondary: DictationNarrator.recoverySucceededSubtitle,
+        width: .fixed(300), fixedHeight: 56,  // :516
+        expiry: .after(seconds: 3))  // :675
+
+    case .bluetoothAwareness:
+      return PillDefinition(
+        // that site calls `showPanel` with NO `scheduleAutoDismiss`: the card is
+        // PERSISTENT until something replaces it. The first version gave it a
+        // 6-second dwell, which would have made it vanish on its own.
+        id: id, content: .bluetoothAwareness, expiry: .untilReplaced,
+        requestedWidth: .fixed(320))
+
+    case .escapeRecovery(let transcriptID):
+      return PillDefinition(
+        // **THIS expiry is the only one. The director owns it; the view draws
+        // it.** Three seconds, hover-pausable, exactly like any other dwell.
+        //
+        // The shipped panel could not do that -- it had no single owner of
+        // expiry, so a panel-level timer could not be paused by a hover only the
+        // view sees and the view kept its own. That reason died with the
+        // retained window, and this comment used to LEAD with it as though it
+        // were still true, correcting itself only at the end.
+        //
+        // It cost two independent three-second timers running side by side from
+        // the cutover until cloud review found the rail finishing while the pill
+        // was still on screen. The trap worth naming: a comment asserting a
+        // FUTURE state ("a later chunk removes the view's task") is invisible to
+        // every diff review, because nothing in a diff can contradict a promise.
+        // C4 was recorded as doing it and did not; C18 did.
+        id: id, content: .escapeRecovery(transcriptID: transcriptID),
+        expiry: .after(seconds: 3, pausesOnHover: true), requestedWidth: .measured)
+
+    case .importStatus(let message):
+      // Lifted from `reduceImportStatus`, where it was minted inline. The
+      // ADMISSION rule around it — that a status pill may only replace itself —
+      // stays on the reducer, because admission is a function of `OverlayState`
+      // and not of this value.
+      return PillDefinition(
+        id: id,
+        content: .notice(NoticeModel(kind: .importStatus, text: message, isMultiline: true)),
+        // `ImportStatusOverlayView` uses `.frame(maxWidth: 280)` — a BOUND, not a
+        // width — under `fitToContent`, so this is measured too.
+        expiry: .after(seconds: 3), requestedWidth: .measured)  // :1105, :1148
+
+    }
+  }
+
+
+  // MARK: - Shared shape
+
+  /// `fixedHeight` is the shipped `showPanel(height:)` for this notice, and
+  /// omitting it means CONTENT-SIZED, which is what `fitToContent: true` does at
+  /// the shipped site.
+  ///
+  /// **It defaults to nil and that default is a trap worth naming.** Every
+  /// notice in the first port took it, so eight pills that reserve a fixed box
+  /// became content-sized — a geometry change with no compiler error, no test
+  /// failure and no mention in any diff. `noticeGeometryIsPinned` sweeps the
+  /// closed set against the shipped call sites so a new row cannot inherit the
+  /// default silently.
+  private static func notice(
+    id: PresentationID, kind: NoticeModel.Kind, text: String, secondary: String? = nil,
+    width: OverlayWidth, fixedHeight: CGFloat? = nil,
+    expiry: OverlayExpiry = .untilReplaced, severity: NoticeModel.Severity = .neutral,
+    isMultiline: Bool = false, action: (label: String, action: PillAction)? = nil
+  ) -> PillDefinition {
+    PillDefinition(
+      id: id,
+      content: .notice(
+        NoticeModel(
+          kind: kind, text: text, secondaryText: secondary, severity: severity,
+          isMultiline: isMultiline, action: action)),
+      expiry: expiry, requestedWidth: width, reservesFixedHeight: fixedHeight)
+  }
+}
+
+/// The pipeline intent a request mirrors, where one exists.
+///
+/// **This and `PillCatalogRequest(pipeline:)` are one bijection written twice,
+/// which is a duplicate-authority risk and is therefore CHECKED rather than
+/// intended.** `PillCatalogRoundTripTests` walks every `OverlayIntent` arm and
+/// every `PillCatalogRequest` case and requires both directions to agree, so a
+/// case added to one side and forgotten on the other fails a test rather than
+/// silently resolving to the wrong pill.
+extension PillCatalogRequest {
+  var matchingIntent: OverlayIntent? {
+    switch self {
+    case .hidden: return .hidden
+    case .processing(let phase): return .processing(phase: phase)
+    case .clipboardFallback: return .clipboardFallback
+    case .accessibilityToast: return .accessibilityToast
+    case .warning(let reason): return .warning(reason: reason)
+    case .error(let reason): return .error(reason: reason)
+    case .advisory(let reason): return .advisory(reason: reason)
+    case .interruption(let reason): return .interruption(reason: reason)
+    case .passiveChip(let payload): return .passiveChip(payload: payload)
+    case .cachingModel(let engineLabel): return .cachingModel(engineLabel: engineLabel)
+    case .engineReady: return .engineReady
+    case .recoveringLastRecording: return .recoveringLastRecording
+    case .recoverySucceeded: return .recoverySucceeded
+    case .bluetoothAwareness: return .bluetoothAwareness
+    case .escapeRecovery(let transcriptID): return .escapeRecovery(transcriptID: transcriptID)
+    case .importStatus: return nil
+    }
+  }
+
+  /// The request a pipeline intent resolves to.
+  ///
+  /// **`nil` for `.recording` ONLY, and that is a staging fact rather than a
+  /// silent fallthrough.** C3a adds `.recording(audioLevel:design:)` with its
+  /// first production caller and this initialiser stops being failable. The
+  /// reducer handles `.recording` in its own arm above this call, so the `nil`
+  /// is never observed there.
+  init?(pipeline intent: OverlayIntent) {
+    switch intent {
+    case .recording: return nil
+    case .hidden: self = .hidden
+    case .processing(let phase): self = .processing(phase: phase)
+    case .clipboardFallback: self = .clipboardFallback
+    case .accessibilityToast: self = .accessibilityToast
+    case .warning(let reason): self = .warning(reason: reason)
+    case .error(let reason): self = .error(reason: reason)
+    case .advisory(let reason): self = .advisory(reason: reason)
+    case .interruption(let reason): self = .interruption(reason: reason)
+    case .passiveChip(let payload): self = .passiveChip(payload: payload)
+    case .cachingModel(let engineLabel): self = .cachingModel(engineLabel: engineLabel)
+    case .engineReady: self = .engineReady
+    case .recoveringLastRecording: self = .recoveringLastRecording
+    case .recoverySucceeded: self = .recoverySucceeded
+    case .bluetoothAwareness: self = .bluetoothAwareness
+    case .escapeRecovery(let transcriptID): self = .escapeRecovery(transcriptID: transcriptID)
+    }
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/Overlay/PillCatalog.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/PillCatalog.swift
@@ -23,6 +23,12 @@ import Foundation
 /// earlier port of this same table wrote it from the design instead and got
 /// eleven of fifteen widths and six dwells wrong.
 enum PillCatalogRequest: Equatable, Sendable {
+  /// **The design rides on THIS case and no other.** A `design:` parameter on
+  /// `entry` would force every import, Bluetooth, notice, language, recovery and
+  /// `.hidden` lookup to supply a recording design that means nothing to them —
+  /// an argument whose only correct value is "ignore me", which is the shape that
+  /// later gets read by accident. Here the illegal call is unrepresentable.
+  case recording(audioLevel: Float, design: RecordingPillDesign)
   case hidden
   case processing(phase: ProcessingPhase)
   case clipboardFallback
@@ -43,15 +49,15 @@ enum PillCatalogRequest: Equatable, Sendable {
   /// path rather than by the pipeline, which is why it announces nothing.
   case importStatus(message: String)
 
-  // **SIXTEEN cases, and `.recording` is deliberately absent until C3a.** The
-  // catalog's recording arm needs a RESOLVED design, and no production caller
-  // can supply one before the recording transaction exists. A `.recording` case
-  // landing here early would need either an unimplemented arm or a placeholder
-  // design, and a placeholder would make a preview-capable definition disagree
-  // with its own rendered layout — a wrong value that type-checks, in the chunk
-  // whose entire receipt is parity.
+  // **SEVENTEEN cases: `.recording` plus sixteen non-recording.** C2 staged
+  // `.recording` out because the catalog's recording arm needs a RESOLVED design
+  // and no production caller could supply one before the recording transaction
+  // existed. C3a builds that transaction, so the arm and its first caller land
+  // together — no chunk ever contained an unimplemented case or a placeholder
+  // design.
   //
-  // **The count is sixteen, not seventeen, and the difference is G2 itself.**
+  // **The non-recording count is sixteen, not seventeen, and the difference is
+  // G2 itself.**
   // `bluetoothAwareness` is a pipeline intent AND is minted a second time by
   // `reduceBluetoothAwareness`; those are two ROUTES to one VALUE, not two
   // requests. C0 froze both routes as separate rows and they are identical field
@@ -270,6 +276,27 @@ enum PillCatalog {
         id: id, content: .escapeRecovery(transcriptID: transcriptID),
         expiry: .after(seconds: 3, pausesOnHover: true), requestedWidth: .measured)
 
+    case .recording(let level, let design):
+      // Moved from `OverlayReducer.presentation(for:id:)` in C3a with its own
+      // comment, which is repaired rather than carried: the reducer's version
+      // said the 92 was "the NON-preview answer" and that the DIRECTOR overrode
+      // it to content-sized when preview was on. That was true and was the whole
+      // of G3 — two authorities for one geometry, one of them ignored. There is
+      // now one. The definition carries the RESOLVED design's own width and
+      // height, so nothing downstream has anything left to override.
+      //
+      // The values are unchanged: classic is 185 wide with a fixed 92-point
+      // interaction frame that holds the normal capsule, the locked state and the
+      // #1060 notice expansion without resizing on every morph; the reading well
+      // is 400 wide and content-sized from the first frame so it does not visibly
+      // snap. Both are properties of `RecordingPillDesign`, measured at the sites
+      // its own doc comments cite.
+      return PillDefinition(
+        id: id,
+        content: .recording(audioLevel: level, isLocked: false, notice: nil, design: design),
+        expiry: .untilReplaced, requestedWidth: .fixed(design.width),
+        reservesFixedHeight: design.reservedHeight)
+
     case .importStatus(let message):
       // Lifted from `reduceImportStatus`, where it was minted inline. The
       // ADMISSION rule around it — that a status pill may only replace itself —
@@ -325,6 +352,7 @@ enum PillCatalog {
 extension PillCatalogRequest {
   var matchingIntent: OverlayIntent? {
     switch self {
+    case .recording(let level, _): return .recording(audioLevel: level)
     case .hidden: return .hidden
     case .processing(let phase): return .processing(phase: phase)
     case .clipboardFallback: return .clipboardFallback
@@ -344,14 +372,18 @@ extension PillCatalogRequest {
     }
   }
 
-  /// The request a pipeline intent resolves to.
+  /// The request a NON-RECORDING pipeline intent resolves to.
   ///
-  /// **`nil` for `.recording` ONLY, and that is a staging fact rather than a
-  /// silent fallthrough.** C3a adds `.recording(audioLevel:design:)` with its
-  /// first production caller and this initialiser stops being failable. The
-  /// reducer handles `.recording` in its own arm above this call, so the `nil`
-  /// is never observed there.
-  init?(pipeline intent: OverlayIntent) {
+  /// **`nil` for `.recording` and only for `.recording`, and since C3a that is a
+  /// permanent fact rather than a staging one.** A recording pill cannot be
+  /// requested without a resolved design; a caller holding only an intent has not
+  /// resolved one and has no business minting one. The recording request is built
+  /// from its case directly, at the one site that has a design to give it.
+  ///
+  /// The name says `nonRecording` rather than `pipeline` so the refusal is
+  /// legible at the call site instead of looking like a failure that might mean
+  /// something else.
+  init?(nonRecording intent: OverlayIntent) {
     switch intent {
     case .recording: return nil
     case .hidden: self = .hidden

--- a/Sources/EnviousWisprAppKit/App/Overlay/PillDefinition.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/PillDefinition.swift
@@ -230,7 +230,7 @@ struct InPanelNotice: Equatable, Sendable {
 /// One occupancy of the overlay slot: what to show, how it is identified, and
 /// when it goes away. The director never holds a per-kind field collection —
 /// this value IS the state.
-struct OverlayPresentation: Equatable, Sendable {
+struct PillDefinition: Equatable, Sendable {
   let id: PresentationID
   let content: OverlayContent
   let expiry: OverlayExpiry

--- a/Sources/EnviousWisprAppKit/App/Overlay/PillDefinition.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/PillDefinition.swift
@@ -30,6 +30,121 @@ struct PresentationID: Hashable, Sendable {
   init(rawValue: UUID) { self.rawValue = rawValue }
 }
 
+// MARK: - The recording pill's design
+
+/// Which recording pill the user gets (#2375 Phase 3, chunk C3a).
+///
+/// **A DESIGN, not a capability.** Whether the machine can show words as you
+/// speak is a capability the director reads; which pill is drawn is a choice.
+/// Until Phase 4 the two are locked together by a constant, and separating the
+/// vocabulary now is what lets Phase 4 change one without touching the other.
+///
+/// **`.readingWell`, deliberately not `.livePreview`.** Naming a design after
+/// the capability that enables it makes the settings group label and the card
+/// label the same word, and forecloses a second with-words design before one
+/// exists. The capability keeps its own name.
+enum RecordingPillDesign: Equatable, Sendable, CaseIterable {
+  /// The rainbow-lips capsule: a fixed 185x92 interaction frame that holds the
+  /// normal capsule, the locked state and the #1060 notice expansion without
+  /// resizing on every morph.
+  case classic
+  /// The wide panel that shows words as you speak. Content-sized from the first
+  /// frame so it does not visibly snap as lines wrap.
+  case readingWell
+
+  /// Whether this design can display transcribed words while recording.
+  ///
+  /// **This is the semantic authority for provider gating.** During C3a the
+  /// retained layout derives `usesPreview` from it; C3b removes that adapter and
+  /// keys the consumers directly from `canHoldWords`. The shipped code keyed off
+  /// a layout value that also carried geometry and position, which is why one
+  /// authority could disagree with another about what is on screen.
+  var canHoldWords: Bool {
+    switch self {
+    case .classic: return false
+    case .readingWell: return true
+    }
+  }
+
+  /// The width the window is sized to. Measured from
+  /// `RecordingOverlayPanel`: `showsPreview ? previewPillWidth : 185`.
+  var width: CGFloat {
+    switch self {
+    case .classic: return 185
+    case .readingWell: return 400
+    }
+  }
+
+  /// `nil` means content-sized, which is `fitToContent: true` at the shipped
+  /// site. The classic pill reserves a fixed box; the reading well does not.
+  var reservedHeight: CGFloat? {
+    switch self {
+    case .classic: return 92
+    case .readingWell: return nil
+    }
+  }
+}
+
+/// Which design the user has chosen for each capability state.
+///
+/// **Two selections, not one, because the two states are genuinely different
+/// products.** Without words the choice is cosmetic; with words the pill has to
+/// be able to hold them, which is why `resolve` may substitute.
+struct PillDesignSelections: Equatable, Sendable {
+  /// The design to use when the machine cannot show words as you speak.
+  let withoutWords: RecordingPillDesign
+  /// The design to use when it can.
+  let withWords: RecordingPillDesign
+
+  init(withoutWords: RecordingPillDesign, withWords: RecordingPillDesign) {
+    self.withoutWords = withoutWords
+    self.withWords = withWords
+  }
+
+  /// The pair the shipped code produces, and what Phase 3 injects everywhere.
+  ///
+  /// Phase 4 replaces the CLOSURE that returns this, never this constant's
+  /// meaning — it is the current behaviour written down, so a Phase 4 regression
+  /// is measurable against it.
+  static let shipped = PillDesignSelections(withoutWords: .classic, withWords: .readingWell)
+
+  /// Resolve the selection for a capability state, FAIL-CLOSED.
+  ///
+  /// **The fallback is a RETURNED VALUE rather than a promise.** An earlier
+  /// draft of this design said a mismatch "is recorded", which named no owner, no
+  /// event and no seam — a claim about observability that nothing would have made
+  /// true. `DesignResolution` cannot lie about which of the two happened, and a
+  /// caller may assert on it, log it, or ignore it.
+  ///
+  /// **No production caller can produce a mismatch this phase**, because
+  /// selections are constructed from `shipped`. That branch is covered by unit
+  /// tests only and ships no logging, telemetry or composition wiring. Phase 4
+  /// introduces the first real producer of an incompatible value and owns the
+  /// decision about what `substituted` should then cause.
+  func resolve(capabilityHasWords: Bool) -> DesignResolution {
+    let chosen = capabilityHasWords ? withWords : withoutWords
+    // Written as an `if` rather than a `guard`, because the mismatch is the
+    // EXCEPTIONAL case and a guard whose success path is the exception reads
+    // backwards to everyone after the author.
+    if capabilityHasWords, !chosen.canHoldWords {
+      // The capability can show words and the chosen design cannot hold them.
+      // Substituting the canonical with-words design is the fail-closed answer:
+      // the alternative is a pill that silently drops the feature it was enabled
+      // for.
+      return DesignResolution(design: .readingWell, substituted: true)
+    }
+    return DesignResolution(design: chosen, substituted: false)
+  }
+}
+
+/// What `PillDesignSelections.resolve` decided, and whether it had to override.
+struct DesignResolution: Equatable, Sendable {
+  let design: RecordingPillDesign
+  /// True when the group's selection could not hold the capability's content and
+  /// the canonical default was substituted.
+  let substituted: Bool
+}
+
 // MARK: - What ends up on screen
 
 /// What a screen reader says when a presentation arrives, and how loudly.
@@ -77,6 +192,22 @@ struct OverlayAnnouncement: Equatable, Sendable {
 enum OverlayRecordingLayout: Equatable, Sendable {
   case compact(position: OverlayPillPosition)
   case preview(position: OverlayPillPosition)
+
+  /// **A DERIVED adapter, and C3b deletes it** (#2375 C3a).
+  ///
+  /// Its only inputs are the accepted definition's resolved design and the
+  /// position captured in the same transaction. It never rereads capability,
+  /// never rereads selections, and has no default — an adapter that can compute
+  /// its own answer is not an adapter, it is the second authority coming back
+  /// wearing a local variable's name.
+  ///
+  /// It survives C3a only so geometry is unchanged and that chunk stays a
+  /// structural change rather than a visual one. C3b deletes it together with all
+  /// three of its replacements, because they are one value being taken apart and
+  /// a partial landing leaves a consumer reading a deleted field.
+  init(design: RecordingPillDesign, position: OverlayPillPosition) {
+    self = design.canHoldWords ? .preview(position: position) : .compact(position: position)
+  }
 
   var usesPreview: Bool {
     if case .preview = self { return true }
@@ -207,7 +338,17 @@ enum OverlayContent: Equatable, Sendable {
   /// rendered recording's lifetime. `recordingElapsedProvider` has no
   /// representation in this vocabulary at all and must not be forgotten because nothing
   /// here names it — which is precisely why it is named here.
-  case recording(audioLevel: Float, isLocked: Bool, notice: InPanelNotice?)
+  /// **The resolved design rides HERE, on the one content case that has one.**
+  /// Putting it on `PillDefinition` instead would let a notice carry a recording
+  /// design — representable, meaningless, and eventually read by accident. Here
+  /// the illegal state cannot be constructed.
+  ///
+  /// It also makes morph preservation a COMPILER obligation rather than a test
+  /// one: every same-id reconstruction has to bind and pass it, so a morph that
+  /// drops the design fails to build instead of silently dropping the pill back
+  /// to the other design's geometry mid-recording.
+  case recording(
+    audioLevel: Float, isLocked: Bool, notice: InPanelNotice?, design: RecordingPillDesign)
   case notice(NoticeModel)
   case languageChip(payload: LanguageChipPayload)
   case bluetoothAwareness
@@ -233,6 +374,18 @@ struct InPanelNotice: Equatable, Sendable {
 struct PillDefinition: Equatable, Sendable {
   let id: PresentationID
   let content: OverlayContent
+
+  /// The resolved recording design, or nil for every pill that is not a
+  /// recording.
+  ///
+  /// **This is the authority initial host sizing reads.** Before #2375 the
+  /// reducer emitted one geometry and `OverlayDirector.geometry(for:)`
+  /// substituted another for the preview case, so two values described one pill
+  /// and the reducer's was ignored. There is now one, and it is this.
+  var recordingDesign: RecordingPillDesign? {
+    guard case .recording(_, _, _, let design) = content else { return nil }
+    return design
+  }
   let expiry: OverlayExpiry
   /// How the presentation's width is decided.
   ///

--- a/Sources/EnviousWisprAppKit/App/Overlay/PillDefinition.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/PillDefinition.swift
@@ -54,11 +54,11 @@ enum RecordingPillDesign: Equatable, Sendable, CaseIterable {
 
   /// Whether this design can display transcribed words while recording.
   ///
-  /// **This is the semantic authority for provider gating.** During C3a the
-  /// retained layout derives `usesPreview` from it; C3b removes that adapter and
-  /// keys the consumers directly from `canHoldWords`. The shipped code keyed off
-  /// a layout value that also carried geometry and position, which is why one
-  /// authority could disagree with another about what is on screen.
+  /// **This is the authority for provider gating, and since C3b it is the only
+  /// one.** The consumers key directly off `canHoldWords`. Before that the
+  /// shipped code keyed off a layout value that also carried geometry and
+  /// position, which is why one authority could disagree with another about what
+  /// is on screen; C3a derived that value from this one and C3b deleted it.
   var canHoldWords: Bool {
     switch self {
     case .classic: return false
@@ -169,73 +169,6 @@ struct OverlayAnnouncement: Equatable, Sendable {
   }
 }
 
-/// How the recording pill is composed, which is FIVE decisions and not one.
-///
-/// The shipped site takes them together from a single showsPreview read, and
-/// porting them one at a time is how four of them went missing: the pill was
-/// carrying the compact width at the preview's content height, with no frame, no
-/// alignment, and the preview's own providers live in a pill that does not show a
-/// preview. They travel together here so a caller cannot install half of them.
-///
-/// - **width** 400 with preview, 185 without.
-/// - **height** content-driven with preview so the pill earns its size a line at
-///   a time; a reserved 92 without, which holds the normal 185x44, the locked
-///   120x64 and the #1060 notice expansion without resizing on every morph.
-/// - **alignment** #1341. In Bottom position the compact content is BOTTOM-
-///   aligned so the panel's Y origin is the capsule's visible bottom edge.
-///   Centred, the 92-point frame leaves ~24 points of invisible space below a
-///   ~44-point capsule, which mutes the Bottom offset and visibly misaligns the
-///   polishing pill that replaces it. Top keeps centring.
-/// - **the preview display provider**, which the shipped site replaces with
-///   `{ .off }` when preview is off rather than passing the live one.
-/// - **the content-height callback**, likewise `{ _ in }` when preview is off.
-enum OverlayRecordingLayout: Equatable, Sendable {
-  case compact(position: OverlayPillPosition)
-  case preview(position: OverlayPillPosition)
-
-  /// **A DERIVED adapter, and C3b deletes it** (#2375 C3a).
-  ///
-  /// Its only inputs are the accepted definition's resolved design and the
-  /// position captured in the same transaction. It never rereads capability,
-  /// never rereads selections, and has no default — an adapter that can compute
-  /// its own answer is not an adapter, it is the second authority coming back
-  /// wearing a local variable's name.
-  ///
-  /// It survives C3a only so geometry is unchanged and that chunk stays a
-  /// structural change rather than a visual one. C3b deletes it together with all
-  /// three of its replacements, because they are one value being taken apart and
-  /// a partial landing leaves a consumer reading a deleted field.
-  init(design: RecordingPillDesign, position: OverlayPillPosition) {
-    self = design.canHoldWords ? .preview(position: position) : .compact(position: position)
-  }
-
-  var usesPreview: Bool {
-    if case .preview = self { return true }
-    return false
-  }
-
-  var position: OverlayPillPosition {
-    switch self {
-    case .compact(let position), .preview(let position): return position
-    }
-  }
-
-  /// `RecordingOverlayPanel`: `showsPreview ? previewPillWidth : 185`.
-  var width: CGFloat {
-    switch self {
-    case .compact: return 185
-    case .preview: return 400
-    }
-  }
-
-  /// nil means content-sized, which is `fitToContent: true` at the shipped site.
-  var fixedHeight: CGFloat? {
-    switch self {
-    case .compact: return 92
-    case .preview: return nil
-    }
-  }
-}
 
 /// How a presentation's width is decided. `.measured` means the render model
 /// computes it; nothing may substitute a default for it.

--- a/Sources/EnviousWisprAppKit/App/Overlay/PillDefinition.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/PillDefinition.swift
@@ -7,7 +7,6 @@ import Foundation
 // AppKit: everything here is a value, so the reducer and the placement state
 // are testable with no windowing present, which is the property `OverlayReducer`
 // exists to have.
-
 // MARK: - Identity
 
 /// Identity for one presentation of the overlay slot.
@@ -29,54 +28,6 @@ struct PresentationID: Hashable, Sendable {
   /// Test seam only: a deterministic id, so a suite can assert on identity
   /// without threading a UUID factory through every call site.
   init(rawValue: UUID) { self.rawValue = rawValue }
-}
-
-// MARK: - Screens and geometry
-
-/// A screen's stable identity, so placement can say "the same screen" without
-/// holding an `NSScreen` and without AppKit being present in a test.
-struct ScreenID: Hashable, Sendable {
-  let rawValue: Int
-  init(rawValue: Int) { self.rawValue = rawValue }
-}
-
-/// Everything placement needs to know about a screen. A value, so the geometry
-/// rules are exercisable against invented screens — including the ones that are
-/// awkward to obtain on the dev machine, such as a display whose `visibleFrame`
-/// is inset by a notch or by a full-screen space.
-struct ScreenGeometry: Equatable, Sendable {
-  let id: ScreenID
-  /// Full display bounds.
-  let frame: CGRect
-  /// Bounds excluding menu bar and Dock.
-  let visibleFrame: CGRect
-  /// True when the screen currently shows a full-screen space, which is the
-  /// condition the Bottom rule keys off.
-  let hasFullScreenSpace: Bool
-
-  init(id: ScreenID, frame: CGRect, visibleFrame: CGRect, hasFullScreenSpace: Bool = false) {
-    self.id = id
-    self.frame = frame
-    self.visibleFrame = visibleFrame
-    self.hasFullScreenSpace = hasFullScreenSpace
-  }
-}
-
-/// Whether a presentation is arriving into an empty slot or replacing a live one.
-///
-/// **`continuing` carries the COMPLETE current frame, both axes.** That is the
-/// whole of the #2195 fix: the shipped path inherits only `y` and always
-/// recentres `x`, so a pill the user dragged horizontally jumps back to centre
-/// the moment its content changes. A single value carrying the whole rect makes
-/// the half-inheritance unrepresentable rather than merely discouraged.
-enum OverlayContinuity: Equatable, Sendable {
-  case fresh(position: OverlayPillPosition, screen: ScreenID)
-  /// `outgoingWasContentSized` is required, not optional: the shipped Top rule
-  /// re-anchors a content-sized outgoing panel by its TOP edge and a
-  /// fixed-frame one by its CENTRE, and getting that wrong moves the pill
-  /// vertically on an ordinary recording-to-polishing hand-off.
-  case continuing(
-    currentFrame: CGRect, anchoredScreen: ScreenID, outgoingWasContentSized: Bool)
 }
 
 // MARK: - What ends up on screen
@@ -160,18 +111,6 @@ enum OverlayRecordingLayout: Equatable, Sendable {
 enum OverlayWidth: Equatable, Sendable {
   case fixed(CGFloat)
   case measured
-}
-
-/// How long a presentation lives without further input.
-enum OverlayExpiry: Equatable, Sendable {
-  /// Stays until something replaces it. Recording and processing are persistent.
-  case untilReplaced
-  /// Dismisses itself after an interval, unless the user is hovering it.
-  case after(seconds: Double, pausesOnHover: Bool)
-
-  static func after(seconds: Double) -> OverlayExpiry {
-    .after(seconds: seconds, pausesOnHover: false)
-  }
 }
 
 /// The collapsed notice. Processing, clipboard fallback, warning, error,
@@ -335,38 +274,5 @@ struct OverlayPresentation: Equatable, Sendable {
     self.expiry = expiry
     self.requestedWidth = requestedWidth
     self.reservesFixedHeight = reservesFixedHeight
-  }
-}
-
-
-/// The dwell a countdown is drawing, as a WINDOW rather than a start signal
-/// (#2292, C20b).
-///
-/// **Publishing an identity and treating its delivery as the start is wrong, and
-/// subtly so.** SwiftUI processes a published change on a later render
-/// transaction -- normally the next one, arbitrarily later while the UI is busy.
-/// The director's timer is already running by then, so a rail that starts when
-/// the signal ARRIVES lags the clock it draws and gets cut off before its end.
-///
-/// Carrying `startedAt` lets a late reader compute how much of the dwell it has
-/// already missed and draw the REMAINDER, which is correct whenever it runs.
-///
-/// It also fixes a second case the identity form could not express: a hover-exit
-/// re-arms the same presentation, so an id-only signal does not change and the
-/// rail never restarts.
-struct OverlayDwellWindow: Equatable, Sendable {
-  let id: PresentationID
-  let startedAt: Date
-  let seconds: Double
-
-  /// What fraction has already elapsed at `now`, clamped to 0...1.
-  func elapsedFraction(at now: Date) -> Double {
-    guard seconds > 0 else { return 1 }
-    return min(1, max(0, now.timeIntervalSince(startedAt) / seconds))
-  }
-
-  /// How long is left to animate at `now`, never negative.
-  func remaining(at now: Date) -> Double {
-    max(0, seconds - now.timeIntervalSince(startedAt))
   }
 }

--- a/Sources/EnviousWisprAppKit/App/Overlay/PillExpiry.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/PillExpiry.swift
@@ -1,0 +1,46 @@
+import CoreGraphics
+import Foundation
+
+/// How long a presentation lives without further input.
+enum OverlayExpiry: Equatable, Sendable {
+  /// Stays until something replaces it. Recording and processing are persistent.
+  case untilReplaced
+  /// Dismisses itself after an interval, unless the user is hovering it.
+  case after(seconds: Double, pausesOnHover: Bool)
+
+  static func after(seconds: Double) -> OverlayExpiry {
+    .after(seconds: seconds, pausesOnHover: false)
+  }
+}
+
+/// The dwell a countdown is drawing, as a WINDOW rather than a start signal
+/// (#2292, C20b).
+///
+/// **Publishing an identity and treating its delivery as the start is wrong, and
+/// subtly so.** SwiftUI processes a published change on a later render
+/// transaction -- normally the next one, arbitrarily later while the UI is busy.
+/// The director's timer is already running by then, so a rail that starts when
+/// the signal ARRIVES lags the clock it draws and gets cut off before its end.
+///
+/// Carrying `startedAt` lets a late reader compute how much of the dwell it has
+/// already missed and draw the REMAINDER, which is correct whenever it runs.
+///
+/// It also fixes a second case the identity form could not express: a hover-exit
+/// re-arms the same presentation, so an id-only signal does not change and the
+/// rail never restarts.
+struct OverlayDwellWindow: Equatable, Sendable {
+  let id: PresentationID
+  let startedAt: Date
+  let seconds: Double
+
+  /// What fraction has already elapsed at `now`, clamped to 0...1.
+  func elapsedFraction(at now: Date) -> Double {
+    guard seconds > 0 else { return 1 }
+    return min(1, max(0, now.timeIntervalSince(startedAt) / seconds))
+  }
+
+  /// How long is left to animate at `now`, never negative.
+  func remaining(at now: Date) -> Double {
+    max(0, seconds - now.timeIntervalSince(startedAt))
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/Overlay/PillRequest.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/PillRequest.swift
@@ -9,7 +9,10 @@ import Foundation
 // screen with a control bound to nobody.
 //
 // Chunk C1 was a semantic no-op port: `PillAction` and `PillEffect` moved here
-// from `OverlayVocabulary.swift` under new names with their behavior unchanged.
+// from the overlay's shared vocabulary file under new names with their behavior
+// unchanged. That file was itself split and deleted by #2375 Phase 3; what
+// remained of it now lives in `PillDefinition.swift`, `PillExpiry.swift` and
+// `OverlayPlacementState.swift`.
 // `OverlayRequest` stayed behind until C5c, which deleted it — the reducer now
 // speaks one vocabulary rather than a pipeline enum and a feature enum that both
 // declared `passiveChip` and `bluetoothAwareness`.

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -489,7 +489,19 @@ public final class WisprBootstrapper {
       // Its one callback has a single assignment (`MenuBarController.swift:76`)
       // and that captures weakly. `WisprBootstrapper` owns the service for the
       // app's lifetime regardless.
-      grantAccessibility: { _ = permissions.requestAccessibilityAccess() })
+      grantAccessibility: { _ = permissions.requestAccessibilityAccess() },
+      // **THE SEAM PHASE 4 REPLACES, and it is a closure so that it can be.**
+      // The director lives for the app's lifetime, so a stored pair would freeze
+      // the user's choice at launch: a picker would appear to work, change
+      // nothing, and only take effect after a relaunch.
+      //
+      // Phase 3 returns the constant the current code already produces — the
+      // classic capsule without words, the reading well with them. Phase 4
+      // replaces this closure's BODY with a settings-backed snapshot and nothing
+      // else: not `PillCatalog.entry`, not `DesignResolution`, not the call site,
+      // not where the director resolves capability. If Phase 4 finds itself
+      // changing any of those, this seam was wrong.
+      selections: { .shipped })
 
     // #1701 Chunk 2: bulk-import-enrichment producer, a sibling of
     // `contactsImportCoordinator` on the same alias-suggester permit lane.

--- a/Tests/EnviousWisprTests/App/LivePreviewPackCopyTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewPackCopyTests.swift
@@ -14,8 +14,8 @@ import Testing
 @MainActor
 struct LivePreviewPackCopyTests {
 
-  /// The pill's real numbers, read from `OverlayRecordingLayout`: 400 pt wide with 14 pt of
-  /// horizontal padding each side, text at system 12.
+  /// The pill's real numbers, read from `RecordingPillDesign.readingWell`: 400 pt wide with
+  /// 14 pt of horizontal padding each side, text at system 12.
   private static let availableWidth: CGFloat = 400 - (14 * 2)
   private static let font = NSFont.systemFont(ofSize: 12)
 
@@ -60,7 +60,7 @@ struct LivePreviewPackCopyTests {
       overflowing.isEmpty,
       """
       These languages overflow the pill's 2-line cap for the unavailable state. \
-      Either shorten the copy or raise the cap in OverlayRecordingLayout deliberately: \
+      Either shorten the copy or raise the cap in RecordingPillDesign deliberately: \
       \(overflowing.map { "\($0.0)=\($0.1) lines" }.joined(separator: ", "))
       """)
   }

--- a/Tests/EnviousWisprTests/App/Overlay/FrozenPillParityFixture.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/FrozenPillParityFixture.swift
@@ -1,0 +1,341 @@
+import CoreGraphics
+import Foundation
+
+// The frozen parity oracle for the #2375 Phase 3 catalog migration (chunk C0).
+//
+// **Every value here was RUN, not read.** A characterization pass drove each
+// request through the shipped reducer at `main` `da103706` and printed what it
+// observed; these rows are that output transcribed. The distinction is the whole
+// point of the chunk: the values Phase 3 must preserve do not come from one
+// owner today — the definition fields come from `OverlayReducer` and both
+// recording geometries come from the director's own substitution — so no single
+// file can be read to produce "the base revision's answer".
+//
+// **THE SCHEMA IS DELIBERATELY RENAME-NEUTRAL and must stay that way.** It names
+// none of C0's forbidden MIGRATION types anywhere, including in comments — a
+// narrower claim than "no production type", which this comment used to make and
+// which its own line 10 falsifies. Kinds and severities are
+// Strings, widths and expiries are fixture-local enums, and the recording rows
+// key on a fixture-local capability.
+//
+// The reason comments count: C1b's proof is that the renamed type's occurrence
+// population is exactly the count measured before the work began, and that count
+// comes from a plain text search — which cannot tell a comment from code. A
+// mention here would enlarge the population silently, so the oracle would break
+// the other proof that depends on it. The forbidden list is enumerated once, in
+// `FrozenPillParityFixtureTests`, and enforced there rather than restated here.
+//
+// Nothing in this file is derived from any post-refactor implementation. A table
+// that reads its expectations from the code under test proves only
+// self-consistency.
+
+// MARK: - Fixture-local value types
+
+enum FrozenWidth: Equatable, Sendable {
+  case fixed(CGFloat)
+  /// The view pins its own width, so the call site's number is discarded.
+  case measured
+}
+
+enum FrozenExpiry: Equatable, Sendable {
+  case untilReplaced
+  case after(seconds: Double, pausesOnHover: Bool)
+}
+
+struct FrozenAnnouncement: Equatable, Sendable {
+  let text: String
+  let isHighPriority: Bool
+}
+
+/// The notice fields, as Strings so the schema names no production enum.
+struct FrozenNotice: Equatable, Sendable {
+  let kind: String
+  let text: String
+  let secondary: String?
+  let severity: String
+  let isMultiline: Bool
+  let actionLabel: String?
+  let actionCase: String?
+}
+
+struct FrozenRow: Equatable, Sendable {
+  let label: String
+  /// False for `hidden`, which produces no definition and still announces.
+  let hasDefinition: Bool
+  /// `notice` for a notice-backed pill; otherwise the content's own tag.
+  let contentTag: String
+  let notice: FrozenNotice?
+  let width: FrozenWidth?
+  let fixedHeight: CGFloat?
+  let expiry: FrozenExpiry?
+  let announcement: FrozenAnnouncement?
+}
+
+/// Which capability state the recording pill was composed under. **A capability,
+/// never a design** — these keys describe what the base revision could observe,
+/// and the base revision has no notion of a user-chosen design.
+enum FrozenRecordingCapability: String, Sendable {
+  case withoutWords
+  case withWords
+}
+
+struct FrozenRecordingRow: Equatable, Sendable {
+  let capability: FrozenRecordingCapability
+  /// What the director actually sizes the window to, which is NOT what the
+  /// reducer returns for the with-words case.
+  let effectiveWidth: CGFloat
+  let fixedHeight: CGFloat?
+  /// Captured so the surviving leaf adapter's equivalence is a measured row
+  /// rather than an argument. It outlives C3b: C3b deletes the layout value,
+  /// not the boolean the leaf still receives.
+  let usesPreviewLayout: Bool
+}
+
+// MARK: - The frozen rows
+
+enum FrozenPillParity {
+
+  /// Definition parity for every request, keyed by label.
+  ///
+  /// Eighteen canonical request rows — the sixteen pipeline intents plus the two
+  /// feature routes — and the two route-dependent outcomes of
+  /// `reduceAccessibilityNotice`. **The eighteen already include BOTH Bluetooth
+  /// routes**, which is what makes the duplicate observable; an earlier draft of
+  /// this comment counted that second route again and described 21 rows against
+  /// a table of 20.
+  static let rows: [FrozenRow] = [
+    // **Captured from a RECORDING, not from a fresh reducer.** A fresh reducer
+    // already sits at `hidden`, so the dedup guard makes the request a no-op and
+    // it announces nothing. That is a true measurement of the wrong transition.
+    // The observed dictation-ending transition is recording -> hidden.
+    //
+    // Deliberately NOT claiming that production never sends hidden from an idle
+    // state. The capture establishes which transition matters here, and says
+    // nothing about which requests production can emit.
+    //
+    // Only this row is affected: every other intent differs from a fresh
+    // reducer's starting intent, so each of them is new and announces normally.
+    //
+    // The same transition also cancels the armed expiry and emits
+    // `recordingStateChanged(false)`, which is how Live Preview learns the
+    // dictation ended. Those observations are OUTSIDE this fixture's
+    // definition-parity schema and are recorded here purely as capture
+    // provenance — so the next reader knows this row is a slice of a larger
+    // observation. This comment does NOT claim another table asserts them.
+    FrozenRow(
+      label: "hidden", hasDefinition: false, contentTag: "none", notice: nil,
+      width: nil, fixedHeight: nil, expiry: nil,
+      announcement: FrozenAnnouncement(text: "Recording complete", isHighPriority: false)),
+
+    FrozenRow(
+      label: "recording", hasDefinition: true, contentTag: "recording", notice: nil,
+      width: .fixed(185), fixedHeight: 92, expiry: .untilReplaced,
+      announcement: FrozenAnnouncement(text: "Recording started", isHighPriority: true)),
+
+    FrozenRow(
+      label: "processing.transcribing", hasDefinition: true, contentTag: "notice",
+      notice: FrozenNotice(
+        kind: "processing", text: "Transcribing...", secondary: nil, severity: "neutral",
+        isMultiline: false, actionLabel: nil, actionCase: nil),
+      width: .measured, fixedHeight: nil, expiry: .untilReplaced,
+      announcement: FrozenAnnouncement(text: "Processing transcription", isHighPriority: false)),
+
+    FrozenRow(
+      label: "clipboardFallback", hasDefinition: true, contentTag: "notice",
+      notice: FrozenNotice(
+        kind: "processing", text: "Copied. Press ⌘V to paste", secondary: nil,
+        severity: "neutral", isMultiline: false, actionLabel: nil, actionCase: nil),
+      width: .measured, fixedHeight: nil,
+      expiry: .after(seconds: 2.5, pausesOnHover: false),
+      announcement: FrozenAnnouncement(text: "Text copied to clipboard", isHighPriority: true)),
+
+    FrozenRow(
+      label: "accessibilityToast", hasDefinition: true, contentTag: "notice",
+      notice: FrozenNotice(
+        kind: "accessibilityToast", text: "Auto-paste needs Accessibility", secondary: nil,
+        severity: "neutral", isMultiline: true, actionLabel: "Grant",
+        actionCase: "grantAccessibility"),
+      width: .fixed(300), fixedHeight: 56,
+      expiry: .after(seconds: 6, pausesOnHover: false),
+      announcement: FrozenAnnouncement(
+        text: "Accessibility permission needed for auto-paste", isHighPriority: true)),
+
+    FrozenRow(
+      label: "warning.polishFailed", hasDefinition: true, contentTag: "notice",
+      notice: FrozenNotice(
+        kind: "notification", text: "Polish failed. Using raw text.", secondary: nil,
+        severity: "warning", isMultiline: false, actionLabel: nil, actionCase: nil),
+      width: .fixed(280), fixedHeight: 44,
+      expiry: .after(seconds: 2.5, pausesOnHover: false),
+      announcement: FrozenAnnouncement(
+        text: "Warning: Polish failed. Using raw text.", isHighPriority: false)),
+
+    FrozenRow(
+      label: "error.asrFailed", hasDefinition: true, contentTag: "notice",
+      notice: FrozenNotice(
+        kind: "notification", text: "Transcription error. Try again.", secondary: nil,
+        severity: "error", isMultiline: false, actionLabel: nil, actionCase: nil),
+      width: .fixed(280), fixedHeight: 44,
+      expiry: .after(seconds: 3, pausesOnHover: false),
+      announcement: FrozenAnnouncement(
+        text: "Error: Transcription error. Try again.", isHighPriority: true)),
+
+    // The ONLY content-sized notification: `fitToContent:` is passed
+    // `style.isMultiline`, and advisory is the one style where that is true.
+    FrozenRow(
+      label: "advisory.zeroSignal", hasDefinition: true, contentTag: "notice",
+      notice: FrozenNotice(
+        kind: "notification",
+        text:
+          "Audio isn't capturing. Your lid may be closed, your headset muted, or there may be a hardware issue. Please check your microphone settings.",
+        secondary: nil, severity: "advisory", isMultiline: true, actionLabel: nil,
+        actionCase: nil),
+      width: .fixed(360), fixedHeight: nil,
+      expiry: .after(seconds: 8, pausesOnHover: false),
+      announcement: FrozenAnnouncement(
+        text:
+          "Audio isn't capturing. Your lid may be closed, your headset muted, or there may be a hardware issue. Please check your microphone settings.",
+        isHighPriority: true)),
+
+    FrozenRow(
+      label: "interruption.deviceRemoved", hasDefinition: true, contentTag: "notice",
+      notice: FrozenNotice(
+        kind: "notification", text: "Microphone disconnected.", secondary: nil,
+        severity: "distress", isMultiline: false, actionLabel: nil, actionCase: nil),
+      width: .fixed(280), fixedHeight: 44,
+      expiry: .after(seconds: 2, pausesOnHover: false),
+      announcement: FrozenAnnouncement(
+        text: "Interruption: Microphone disconnected.", isHighPriority: true)),
+
+    FrozenRow(
+      label: "passiveChip", hasDefinition: true, contentTag: "languageChip", notice: nil,
+      width: .fixed(340), fixedHeight: 56,
+      expiry: .after(seconds: 6, pausesOnHover: true),
+      announcement: FrozenAnnouncement(text: "Detected Spanish", isHighPriority: false)),
+
+    FrozenRow(
+      label: "cachingModel", hasDefinition: true, contentTag: "notice",
+      notice: FrozenNotice(
+        kind: "warmingUp", text: "Getting dictation ready…",
+        secondary: "Parakeet is warming up after a restart", severity: "neutral",
+        isMultiline: false, actionLabel: nil, actionCase: nil),
+      width: .fixed(300), fixedHeight: 56,
+      expiry: .after(seconds: 2, pausesOnHover: false),
+      announcement: FrozenAnnouncement(
+        text: "Getting dictation ready, one moment", isHighPriority: false)),
+
+    FrozenRow(
+      label: "engineReady", hasDefinition: true, contentTag: "notice",
+      notice: FrozenNotice(
+        kind: "ready", text: "Ready — press to dictate", secondary: nil, severity: "neutral",
+        isMultiline: false, actionLabel: nil, actionCase: nil),
+      width: .fixed(240), fixedHeight: 44,
+      expiry: .after(seconds: 1.5, pausesOnHover: false),
+      announcement: FrozenAnnouncement(
+        text: "Dictation ready. Press to start.", isHighPriority: true)),
+
+    FrozenRow(
+      label: "recoveringLastRecording", hasDefinition: true, contentTag: "notice",
+      notice: FrozenNotice(
+        kind: "recovery", text: "Recovering your last recording…",
+        secondary: "Anything saved lands in History", severity: "neutral", isMultiline: true,
+        actionLabel: "Discard", actionCase: "discardRecovery"),
+      width: .fixed(320), fixedHeight: 56,
+      expiry: .after(seconds: 6, pausesOnHover: false),
+      announcement: FrozenAnnouncement(
+        text: "Recovering your last recording. Press Discard to skip.", isHighPriority: true)),
+
+    // `ready`, NOT `notification`: routing a success through the notification
+    // leaf would paint it as a warning, which is the mis-kind this mapping
+    // exists to stop.
+    FrozenRow(
+      label: "recoverySucceeded", hasDefinition: true, contentTag: "notice",
+      notice: FrozenNotice(
+        kind: "ready", text: "Recovered your last recording", secondary: "Saved to History",
+        severity: "neutral", isMultiline: false, actionLabel: nil, actionCase: nil),
+      width: .fixed(300), fixedHeight: 56,
+      expiry: .after(seconds: 3, pausesOnHover: false),
+      announcement: FrozenAnnouncement(
+        text: "Recovered your last recording. Saved to History.", isHighPriority: true)),
+
+    // THE DUPLICATE, both routes. These two rows are byte-identical in the base
+    // revision, which is the measured form of the defect: they agree today and
+    // nothing holds them to it.
+    FrozenRow(
+      label: "bluetoothAwareness.pipelineRoute", hasDefinition: true,
+      contentTag: "bluetoothAwareness", notice: nil,
+      width: .fixed(320), fixedHeight: nil, expiry: .untilReplaced,
+      announcement: FrozenAnnouncement(
+        text:
+          "Bluetooth microphone detected. Wait a moment before speaking on a cold start.",
+        isHighPriority: false)),
+
+    FrozenRow(
+      label: "bluetoothAwareness.featureRoute", hasDefinition: true,
+      contentTag: "bluetoothAwareness", notice: nil,
+      width: .fixed(320), fixedHeight: nil, expiry: .untilReplaced,
+      announcement: FrozenAnnouncement(
+        text:
+          "Bluetooth microphone detected. Wait a moment before speaking on a cold start.",
+        isHighPriority: false)),
+
+    FrozenRow(
+      label: "escapeRecovery", hasDefinition: true, contentTag: "escapeRecovery", notice: nil,
+      width: .measured, fixedHeight: nil,
+      expiry: .after(seconds: 3, pausesOnHover: true),
+      announcement: FrozenAnnouncement(
+        text: "Transcript cancelled. Press Undo to get it back, or find it in History.",
+        isHighPriority: false)),
+
+    // The one presentation with no matching intent, so the shipped announcement
+    // switch has no arm for it. `nil` is asserted rather than the row omitted.
+    FrozenRow(
+      label: "importStatus.featureRoute", hasDefinition: true, contentTag: "notice",
+      notice: FrozenNotice(
+        kind: "importStatus", text: "Imported 12 words", secondary: nil, severity: "neutral",
+        isMultiline: true, actionLabel: nil, actionCase: nil),
+      width: .measured, fixedHeight: nil,
+      expiry: .after(seconds: 3, pausesOnHover: false),
+      announcement: nil),
+
+    // The accessibility path's two outcomes. The refused case is the one that
+    // matters: it draws the CLIPBOARD definition while retaining the
+    // ACCESSIBILITY announcement — the only place a definition and an
+    // announcement legitimately come from different requests.
+    FrozenRow(
+      label: "accessibilityNotice.toastRefused", hasDefinition: true, contentTag: "notice",
+      notice: FrozenNotice(
+        kind: "processing", text: "Copied. Press ⌘V to paste", secondary: nil,
+        severity: "neutral", isMultiline: false, actionLabel: nil, actionCase: nil),
+      width: .measured, fixedHeight: nil,
+      expiry: .after(seconds: 2.5, pausesOnHover: false),
+      announcement: FrozenAnnouncement(
+        text: "Accessibility permission needed for auto-paste", isHighPriority: true)),
+
+    FrozenRow(
+      label: "accessibilityNotice.toastShown", hasDefinition: true, contentTag: "notice",
+      notice: FrozenNotice(
+        kind: "accessibilityToast", text: "Auto-paste needs Accessibility", secondary: nil,
+        severity: "neutral", isMultiline: true, actionLabel: "Grant",
+        actionCase: "grantAccessibility"),
+      width: .fixed(300), fixedHeight: 56,
+      expiry: .after(seconds: 6, pausesOnHover: false),
+      announcement: FrozenAnnouncement(
+        text: "Accessibility permission needed for auto-paste", isHighPriority: true)),
+  ]
+
+  /// The two recording geometries the DIRECTOR substitutes.
+  ///
+  /// **Compare `withWords.effectiveWidth` (400) against the `recording` row's
+  /// `width` (185) above: that is the dead-literal defect, measured rather than
+  /// argued.** The reducer's 185/92 is the without-words answer and is discarded
+  /// for the with-words case.
+  static let recordingRows: [FrozenRecordingRow] = [
+    FrozenRecordingRow(
+      capability: .withoutWords, effectiveWidth: 185, fixedHeight: 92,
+      usesPreviewLayout: false),
+    FrozenRecordingRow(
+      capability: .withWords, effectiveWidth: 400, fixedHeight: nil,
+      usesPreviewLayout: true),
+  ]
+}

--- a/Tests/EnviousWisprTests/App/Overlay/FrozenPillParityFixtureTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/FrozenPillParityFixtureTests.swift
@@ -1,0 +1,184 @@
+import CoreGraphics
+import Foundation
+import Testing
+
+/// Guards on the frozen oracle itself (#2375 Phase 3, chunk C0).
+///
+/// **Drift Guard, not Product Outcome.** These do not test the product; they
+/// test that the oracle every later chunk is measured against is intact and
+/// still usable. Declaring the class matters here more than usual: a suite that
+/// looks like parity coverage and is really a fixture check is exactly the
+/// arithmetic this repo's test inventory exists to expose.
+///
+/// The rename-neutrality check is the one that earns its place. C1b's proof is
+/// that the renamed type's occurrence population is exactly the count measured
+/// before the work began, and a fixture naming that type would enlarge it
+/// silently — so the oracle would break the other proof that depends on it. The
+/// plan calls for that check to be mechanical rather than intended.
+///
+/// **No sweep exclusion is needed, and an earlier draft of this file wrongly
+/// asked for one.** Only ONE of the forbidden names is renamed by C1b, and a
+/// guard's list is data rather than prose — so that single entry is assembled
+/// from fragments at the point of use. The guard stays readable, C1b's sweep
+/// stays a plain search with a zero-reference endpoint, and the plan needs no
+/// permanent carve-out. The other entries are not renamed by C1b, so spelling
+/// them costs nothing.
+@Suite(.tags(.driftGuard))
+struct FrozenPillParityFixtureTests {
+
+  private static let fixturePath =
+    "Tests/EnviousWisprTests/App/Overlay/FrozenPillParityFixture.swift"
+
+  /// MIGRATION types the fixture must never name. Naming any of them either
+  /// enlarges C1b's rename population or ties the oracle to the code under test.
+  ///
+  /// Deliberately NOT "every production type": the fixture legitimately names
+  /// `OverlayReducer` in its provenance comment, and a list that does not forbid
+  /// that name cannot support a claim that it forbids all of them.
+  private static let forbidden = [
+    // Assembled, not spelled: this is the one name C1b renames, and a literal
+    // here would enlarge the very population C1b's sweep must drive to zero.
+    "Overlay" + "Presentation",
+    "PillDefinition",
+    "OverlayRecordingLayout",
+    "RecordingPillDesign",
+    "PillCatalog",
+    "NoticeModel",
+    "OverlayWidth",
+    "OverlayExpiry",
+    "OverlayAnnouncement",
+  ]
+
+  @Test("the frozen fixture names no forbidden migration type")
+  func fixtureIsRenameNeutral() throws {
+    let url = RepoRoot.url.appending(path: Self.fixturePath)
+    let source = try String(contentsOf: url, encoding: .utf8)
+
+    // Two-way control: a token that IS present, so an empty result cannot pass
+    // for "nothing forbidden found" when the read itself failed.
+    #expect(
+      source.contains("FrozenRecordingCapability"),
+      "positive control failed — the fixture source was not read")
+
+    for name in Self.forbidden {
+      #expect(
+        source.contains(name) == false,
+        "the frozen fixture names forbidden migration type \(name), which ties the oracle to the code under test or enlarges C1b's rename population"
+      )
+    }
+  }
+
+  @Test("every row has a distinct label")
+  func labelsAreUnique() {
+    let labels = FrozenPillParity.rows.map(\.label)
+    #expect(Set(labels).count == labels.count, "duplicate labels make a row unaddressable")
+  }
+
+  /// The transcription's own floor. A row silently dropped during transcription
+  /// is invisible to every later chunk, because a missing expectation cannot
+  /// fail.
+  @Test("the capture's full row set survived transcription")
+  func rowCountIsFrozen() {
+    #expect(FrozenPillParity.rows.count == 20)
+    #expect(FrozenPillParity.recordingRows.count == 2)
+  }
+
+  /// `hidden` is the row that forced the catalog to return an ENTRY rather than
+  /// a definition: no definition, and it still announces.
+  ///
+  /// **The announcement assertion is the point of this test**, not an extra.
+  /// An earlier draft said "it still announces" in prose and checked only the
+  /// absent definition — so it passed against a row frozen with `nil`, which is
+  /// exactly what a fresh-reducer capture produces. A test whose name claims a
+  /// property its assertions do not require is worse than no test, because it is
+  /// cited as covering that property.
+  @Test("hidden carries no definition and still announces the end of the dictation")
+  func hiddenHasNoDefinitionAndStillAnnounces() throws {
+    let row = try #require(FrozenPillParity.rows.first { $0.label == "hidden" })
+    #expect(row.hasDefinition == false)
+    #expect(row.width == nil)
+    #expect(row.expiry == nil)
+    #expect(
+      row.announcement
+        == FrozenAnnouncement(text: "Recording complete", isHighPriority: false),
+      "the end of a dictation is spoken even though no pill is shown, which is the case that forced the catalog's return type to be an entry rather than a definition"
+    )
+  }
+
+  /// Import status is the one presentation with no matching intent, so the
+  /// shipped announcement switch has no arm for it. Asserted as nil rather than
+  /// left out, because an omitted row proves nothing.
+  @Test("import status announces nothing")
+  func importStatusIsSilent() throws {
+    let row = try #require(
+      FrozenPillParity.rows.first { $0.label == "importStatus.featureRoute" })
+    #expect(row.hasDefinition)
+    #expect(row.announcement == nil)
+  }
+
+  /// **The duplicate, measured.** Both routes produce identical values in the
+  /// base revision. This is what C2's de-duplication must preserve, and having
+  /// it as a checked property means the agreement is a fact rather than a
+  /// recollection.
+  @Test("both Bluetooth routes are identical in the base revision")
+  func bluetoothRoutesAgree() throws {
+    let pipeline = try #require(
+      FrozenPillParity.rows.first { $0.label == "bluetoothAwareness.pipelineRoute" })
+    let feature = try #require(
+      FrozenPillParity.rows.first { $0.label == "bluetoothAwareness.featureRoute" })
+
+    #expect(pipeline.hasDefinition == feature.hasDefinition)
+    #expect(pipeline.notice == feature.notice)
+    #expect(pipeline.contentTag == feature.contentTag)
+    #expect(pipeline.width == feature.width)
+    #expect(pipeline.fixedHeight == feature.fixedHeight)
+    #expect(pipeline.expiry == feature.expiry)
+    #expect(pipeline.announcement == feature.announcement)
+  }
+
+  /// **The dead literal, measured.** The reducer answers 185/92 for a recording;
+  /// the director substitutes 400/content-sized when words can be shown. If
+  /// these two ever agree, the defect Phase 3 exists to close has already been
+  /// closed by something else and this fixture is describing a tree that no
+  /// longer exists.
+  @Test("the reducer's recording width is the without-words answer only")
+  func recordingGeometryDisagreesWithTheReducer() throws {
+    let reducerRow = try #require(FrozenPillParity.rows.first { $0.label == "recording" })
+    let withoutWords = try #require(
+      FrozenPillParity.recordingRows.first { $0.capability == .withoutWords })
+    let withWords = try #require(
+      FrozenPillParity.recordingRows.first { $0.capability == .withWords })
+
+    #expect(reducerRow.width == .fixed(withoutWords.effectiveWidth))
+    #expect(reducerRow.fixedHeight == withoutWords.fixedHeight)
+
+    #expect(
+      withWords.effectiveWidth != withoutWords.effectiveWidth,
+      "the two capability states must differ, or there is no substitution to close")
+    #expect(withWords.fixedHeight == nil, "the with-words pill is content-sized")
+    #expect(withWords.usesPreviewLayout != withoutWords.usesPreviewLayout)
+  }
+
+  /// The accessibility refusal draws one request's definition under another
+  /// request's announcement. It is the only row where that is legitimate, and
+  /// C2 has to reproduce it exactly.
+  @Test("a refused accessibility toast draws the clipboard pill and keeps its own sentence")
+  func accessibilityRefusalMixesTwoRequests() throws {
+    let refused = try #require(
+      FrozenPillParity.rows.first { $0.label == "accessibilityNotice.toastRefused" })
+    let clipboard = try #require(
+      FrozenPillParity.rows.first { $0.label == "clipboardFallback" })
+    let shown = try #require(
+      FrozenPillParity.rows.first { $0.label == "accessibilityNotice.toastShown" })
+
+    #expect(refused.notice == clipboard.notice, "the drawn pill is the clipboard fallback")
+    #expect(refused.hasDefinition == clipboard.hasDefinition)
+    #expect(refused.contentTag == clipboard.contentTag)
+    #expect(refused.fixedHeight == clipboard.fixedHeight)
+    #expect(refused.width == clipboard.width)
+    #expect(refused.expiry == clipboard.expiry)
+    #expect(
+      refused.announcement == shown.announcement,
+      "the spoken sentence stays the accessibility one")
+  }
+}

--- a/Tests/EnviousWisprTests/App/Overlay/FrozenPillParityFixtureTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/FrozenPillParityFixtureTests.swift
@@ -40,6 +40,9 @@ struct FrozenPillParityFixtureTests {
     // here would enlarge the very population C1b's sweep must drive to zero.
     "Overlay" + "Presentation",
     "PillDefinition",
+    // Retired by C3b, and kept on this list deliberately. A forbidden name for a
+    // type that no longer exists costs nothing and still stops the fixture
+    // resurrecting it — removing it as dead would reopen the hole.
     "OverlayRecordingLayout",
     "RecordingPillDesign",
     "PillCatalog",

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayDirectorTestSupport.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayDirectorTestSupport.swift
@@ -34,7 +34,7 @@ enum OverlayTestDouble {
       host: WindowlessOverlayHost(),
       // Announcements go nowhere: a test that has not asked for a screen has not
       // asked for VoiceOver either, and the real post reaches the system.
-      announce: { _ in }, livePreview: .disabled, grantAccessibility: {},
+      announce: { _ in }, livePreview: .disabled, grantAccessibility: {}, selections: { .shipped },
       deferFirstRender: { $0() })
   }
 
@@ -45,7 +45,7 @@ enum OverlayTestDouble {
     return (
       OverlayDirector(
         host: host, announce: { _ in },
-        livePreview: .disabled, grantAccessibility: {}, deferFirstRender: { $0() }),
+        livePreview: .disabled, grantAccessibility: {}, selections: { .shipped }, deferFirstRender: { $0() }),
       host
     )
   }

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayDirectorTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayDirectorTests.swift
@@ -90,6 +90,7 @@
           isEnabledForGeometry: { preview.isEnabled },
           display: { preview.display() }),
         grantAccessibility: { sink.appActions.append(.grantAccessibility) },
+        selections: { .shipped },
         deferFirstRender: { $0() })
       return (d, host, sink)
     }
@@ -160,7 +161,7 @@
         scheduler: .manual { _ in },
         announce: { _ in },
         livePreview: .disabled,
-        grantAccessibility: {},
+        grantAccessibility: {}, selections: { .shipped },
         deferFirstRender: { deferral.block = $0 })
     }
 
@@ -249,6 +250,7 @@
           isEnabledForGeometry: { preview.isEnabled },
           display: { preview.display() }),
         grantAccessibility: { sink.appActions.append(.grantAccessibility) },
+        selections: { .shipped },
         deferFirstRender: { $0() })
       hosts.append(host)
       return (d, armed, sink)
@@ -873,7 +875,7 @@
           recordingDidChange: { if $0 { recordingStarted = true } },
           isEnabledForGeometry: { recordingStarted },
           display: { .off }),
-        grantAccessibility: {}, deferFirstRender: { $0() })
+        grantAccessibility: {}, selections: { .shipped }, deferFirstRender: { $0() })
       Self.hosts.append(host)
       defer { Self.closeAllWindows() }
 
@@ -952,7 +954,7 @@
 
       Self.record(d, locked: true)
 
-      guard case .recording(_, let locked, _)? = d.renderModel.presentation?.content else {
+      guard case .recording(_, let locked, _, _)? = d.renderModel.presentation?.content else {
         Issue.record("expected a recording presentation")
         return
       }
@@ -1300,7 +1302,7 @@
       // The production `deferFirstRender` — the default — is the subject here.
       let d = OverlayDirector(
         host: host, announce: { _ in },
-        livePreview: .disabled, grantAccessibility: {})
+        livePreview: .disabled, grantAccessibility: {}, selections: { .shipped })
 
       d.present(.warning(reason: .polishFailed))
       #expect(
@@ -1326,7 +1328,7 @@
       let host = WindowlessOverlayHost()
       let d = OverlayDirector(
         host: host, announce: { _ in },
-        livePreview: .disabled, grantAccessibility: {})
+        livePreview: .disabled, grantAccessibility: {}, selections: { .shipped })
 
       // First request, deferred. A second replaces it before the run loop turns,
       // so the first drops on its identity gate and builds nothing.
@@ -1350,7 +1352,7 @@
       let host = WindowlessOverlayHost()
       let d = OverlayDirector(
         host: host, announce: { _ in },
-        livePreview: .disabled, grantAccessibility: {})
+        livePreview: .disabled, grantAccessibility: {}, selections: { .shipped })
       d.present(.warning(reason: .polishFailed))
       await withCheckedContinuation { c in DispatchQueue.main.async { c.resume() } }
 
@@ -1532,6 +1534,7 @@
         announce: { sink.announcements.append($0) },
         livePreview: .disabled,
         grantAccessibility: { sink.appActions.append(.grantAccessibility) },
+        selections: { .shipped },
         deferFirstRender: { $0() })
       hosts.append(host)
       return (d, sink, armed)

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayDirectorTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayDirectorTests.swift
@@ -43,10 +43,10 @@
     /// hand each test its own host instead of registering it here.
     private static nonisolated(unsafe) var hosts: [OverlayWindowHost] = []
 
-    /// Recordings go through `presentRecording`, never `send`, because providers
-    /// and layout must be installed in the SAME operation that presents the pill.
-    /// The director asserts on the wrong order, so this helper is what keeps the
-    /// suite expressing the right one.
+    /// Recordings go through `presentRecording`, never `send`, because providers,
+    /// the resolved design and captured position must be installed in the same
+    /// operation that presents the pill. The director asserts on the wrong order,
+    /// so this helper is what keeps the suite expressing the right one.
     private static func record(
       _ d: OverlayDirector, level: Float = 0.2, preview: Bool = false,
       locked: Bool = false,
@@ -503,7 +503,7 @@
       defer { Self.closeAllWindows() }
       d.renderModel.setRecordingProviders(
         audioLevel: { 0.9 }, recordingElapsed: { 12 }, livePreview: { .off },
-        layout: .compact(position: .top), onContentHeightChange: { _ in })
+        design: .classic, position: .top, onContentHeightChange: { _ in })
       Self.record(d, level: 0.2)
 
       d.dismissCurrent(.announced)
@@ -524,7 +524,7 @@
       defer { Self.closeAllWindows() }
       d.renderModel.setRecordingProviders(
         audioLevel: { 0.9 }, recordingElapsed: { 12 }, livePreview: { .off },
-        layout: .compact(position: .top), onContentHeightChange: { _ in })
+        design: .classic, position: .top, onContentHeightChange: { _ in })
       Self.record(d, level: 0.2)
 
       d.present(.processing(phase: .transcribing))
@@ -565,14 +565,14 @@
         "an audio tick dropped the elapsed clock it was handed")
     }
 
-    /// **A morph keeps the LAYOUT it was created with, whatever the setting now
+    /// **A morph keeps the DESIGN it was created with, whatever the setting now
     /// says.** The shipped panel reads the preview setting once at creation and
     /// its width is fixed for that panel's life, because an `NSPanel` cannot grow
     /// mid-recording without a rebuild and a rebuild is the #930 flicker. So a
     /// user toggling Live Preview mid-dictation must not resize the live pill —
-    /// which re-resolving the layout on every tick would do.
+    /// which re-resolving the design on every tick would do.
     @Test("toggling Live Preview mid-dictation does not resize the live pill")
-    func morphKeepsTheLayoutItWasCreatedWith() {
+    func morphKeepsTheDesignItWasCreatedWith() {
       let setting = PreviewSetting()
       let (d, host, _) = Self.pressableDirector(preview: setting)
       Self.record(d, level: 0.2, preview: false, previewSetting: setting)
@@ -581,10 +581,10 @@
       Self.record(d, level: 0.6, preview: true, previewSetting: setting)
 
       // **Asserted on what the director ASKED FOR, not on the panel it got**
-      // (#2292 C6). The claim is about the director's arithmetic — it must not
-      // re-resolve the layout on a tick — and reading an `NSPanel` frame to check
-      // that tested it through AppKit, which is why this case could only run in
-      // the Debug lane. Whether a panel then honours the width it is handed is
+      // (#2292 C6). The claim is about the director's arithmetic — it must
+      // preserve the accepted design on a tick. Reading an `NSPanel` frame to
+      // check that tested it through AppKit, which is why this case could only
+      // run in the Debug lane. Whether a panel honours the width it is handed is
       // `OverlayWindowHostTests`' question.
       #expect(
         host.presented.map(\.width) == [.fixed(185), .fixed(185)],
@@ -842,22 +842,21 @@
 
     /// **The effect must beat the GEOMETRY READ, not merely the render.**
     ///
-    /// `presentRecording` reads `livePreviewEnabled()` on its way to a layout,
-    /// and that read happens before `apply` is entered — so moving effects to the
-    /// top of `apply` fixed only half of it. `LivePreviewCoordinator` applies its
-    /// model-removal suppression inside `setRecording`, so a geometry read that
-    /// beats the effect picks the 400-point preview layout for a pill whose
-    /// preview is about to resolve DISABLED: a preview-sized window with no
-    /// preview in it.
+    /// `presentRecording` reads capability on its way to resolving a design, and
+    /// that read happens before `apply` is entered — so moving effects to the top
+    /// of `apply` fixed only half of it. `LivePreviewCoordinator` applies its
+    /// model-removal suppression inside `setRecording`, so a read that beats the
+    /// effect can select `.readingWell` for a pill whose preview is about to
+    /// resolve DISABLED: a preview-sized window with no preview in it.
     ///
     /// The probe is the provider itself. It answers true only AFTER the effect
-    /// has been delivered, so `usesPreview` is true if and only if the ordering
+    /// has been delivered, so `canHoldWords` is true if and only if the ordering
     /// is right. Asserting the ORDER directly would need a clock; this needs none.
     ///
     /// **The host must PRESENT for this probe to survive**, and it did not have
     /// to before C7. The first version resolved no screen, so the presentation
-    /// was refused -- and the layout it asserts on outlived the refusal only
-    /// because a refused presentation used to leave its owner behind. Reading
+    /// was refused -- and the presentation asserted below outlived the refusal
+    /// only because refused presentations previously left their owner behind. Reading
     /// state that should not exist is not a weaker test, it is a test of the
     /// defect; with the rollback in place the same probe needs a real screen.
     @Test("a recording's effect is delivered before its geometry is resolved")
@@ -887,8 +886,11 @@
             recordingElapsedProvider: { nil },
             isLocked: false)))
 
+      // **Reads the DESIGN since #2375 C3b**, which is the same question one
+      // authority later: the layout bundle it used to read is gone, and what the
+      // pill can hold is now a property of the design the transaction captured.
       #expect(
-        d.renderModel.recordingLayout.usesPreview,
+        d.renderModel.presentation?.recordingDesign?.canHoldWords == true,
         "geometry was resolved before the effect that freezes its input")
     }
 
@@ -961,10 +963,10 @@
       #expect(locked, "the recording rendered unlocked before a later lock morph")
     }
 
-    /// **One position per presentation, not two reads of a provider.** The layout
-    /// captures the anchored edge when the pill is composed; the host used to
-    /// re-read it, so a setting changed in between would compose against one edge
-    /// and place against another.
+    /// **One position per presentation, not two reads of a provider.** The
+    /// recording transaction captures the anchored edge when the pill is composed;
+    /// the host used to re-read it, allowing composition and placement against
+    /// different edges.
     ///
     /// Counting READS rather than comparing edges, because the defect is the
     /// second read itself — a test that compared two positions would pass
@@ -980,7 +982,9 @@
 
       Self.record(d)
 
-      #expect(reads == 1, "the host re-read a position already captured by the recording layout")
+      #expect(
+        reads == 1,
+        "the host re-read a position already captured by the recording transaction")
     }
 
     /// **The obligation `OverlayContent.recording` recorded, discharged.** The

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayHostingContractTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayHostingContractTests.swift
@@ -48,7 +48,7 @@ struct OverlayHostingContractTests {
   func theFakeNeverRefuses() {
     let host = WindowlessOverlayHost()
     let d = OverlayDirector(
-      host: host,       announce: { _ in }, livePreview: .disabled, grantAccessibility: {},
+      host: host,       announce: { _ in }, livePreview: .disabled, grantAccessibility: {}, selections: { .shipped },
       deferFirstRender: { $0() })
 
     d.present(.warning(reason: .polishFailed))
@@ -97,7 +97,7 @@ struct OverlayHostingParityTests {
 
   private static func director(on host: any OverlayWindowHosting) -> OverlayDirector {
     OverlayDirector(
-      host: host,         announce: { _ in }, livePreview: .disabled, grantAccessibility: {},
+      host: host,         announce: { _ in }, livePreview: .disabled, grantAccessibility: {}, selections: { .shipped },
       deferFirstRender: { $0() })
   }
 

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayReducerRecordingSupport.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayReducerRecordingSupport.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprCore
+@testable import EnviousWisprPipeline
+
+extension OverlayReducer {
+
+  /// Start a recording the way `OverlayDirector` does: PREPARE, route, COMMIT
+  /// (#2375 Phase 3, chunk C3a).
+  ///
+  /// **Not a shortcut around the two-stage boundary — it IS the boundary.** A
+  /// bare `reduce(.pipeline(.recording(_:)))` can morph a live recording and can
+  /// no longer start one, because starting one needs a resolved design and a
+  /// reducer holding only an intent has not resolved anything. This helper is the
+  /// smallest honest way for a reducer test to obtain a recording occupant.
+  ///
+  /// **It resolves nothing.** The design is a parameter, so this helper is not a
+  /// second authority on which pill the user gets: it never reads capability,
+  /// never reads selections, and has no opinion. That decision belongs to the
+  /// director, and `OverlayDirectorTests` is where it is asserted.
+  ///
+  /// **Effects are re-attached to the returned plan, deliberately.** They travel
+  /// on the PREPARE token now, because the director must route them BEFORE it
+  /// reads capability — so `commitRecording` returns a plan with none. Handing
+  /// back the set the director would have routed keeps existing assertions about
+  /// `plan.effects` reading the same OBSERVABLE fact rather than an artefact of
+  /// where the value is carried.
+  ///
+  /// Lives in the test target rather than behind `#if DEBUG` in `Sources`: a
+  /// DEBUG-only seam would take every test that uses it out of the Release lane,
+  /// and a whole subsystem silently absent from Release is how a green Release
+  /// count comes to mean less than it looks like.
+  @discardableResult
+  mutating func startRecordingForTests(
+    audioLevel: Float,
+    design: RecordingPillDesign = .classic,
+    routeEffects: ([PillEffect]) -> Void = { _ in }
+  ) -> OverlayPlan {
+    switch prepareRecording(audioLevel: audioLevel) {
+    case .morphed(let plan), .refused(let plan):
+      return plan
+
+    case .prepared(let token):
+      routeEffects(token.effects)
+      let entry = PillCatalog.entry(
+        for: .recording(audioLevel: token.audioLevel, design: design), id: token.id)
+      guard let definition = entry.definition else {
+        Issue.record("the catalog's recording arm resolved to no definition")
+        return .noChange
+      }
+      guard let plan = commitRecording(token, definition: definition) else {
+        // Discarded. A test that wants this outcome should drive prepare and
+        // commit itself so it can assert on the discard rather than infer it.
+        return .noChange
+      }
+      return OverlayPlan(
+        presentation: plan.presentation, didChange: plan.didChange,
+        expiryCommand: plan.expiryCommand, deliverAction: plan.deliverAction,
+        effects: token.effects, announcement: plan.announcement)
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayReducerTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayReducerTests.swift
@@ -40,7 +40,7 @@ struct OverlayReducerTests {
   @Test("a feature cannot take the slot while the pipeline is recording")
   func featureIsRefusedDuringRecording() {
     var r = Self.makeReducer()
-    _ = r.reduce(.pipeline(.recording(audioLevel: 0.4)))
+    _ = r.startRecordingForTests(audioLevel: 0.4)
 
     let plan = r.reduce(.importStatus(message: "Imported 12 words"))
 
@@ -85,7 +85,7 @@ struct OverlayReducerTests {
     // The defect this guards is not one feature getting it wrong; it is the
     // features DISAGREEING, which is what separate ownership flags produce.
     var busy = Self.makeReducer()
-    _ = busy.reduce(.pipeline(.recording(audioLevel: 0.1)))
+    _ = busy.startRecordingForTests(audioLevel: 0.1)
     #expect(busy.reduce(request).didChange == false)
 
     var idle = Self.makeReducer()
@@ -97,17 +97,17 @@ struct OverlayReducerTests {
   @Test("audio-level updates keep the recording pill's identity")
   func meteringDoesNotChurnIdentity() {
     var r = Self.makeReducer()
-    _ = r.reduce(.pipeline(.recording(audioLevel: 0.1)))
+    _ = r.startRecordingForTests(audioLevel: 0.1)
     let first = r.state.current?.id
 
     for level in [Float(0.2), 0.3, 0.9, 0.0] {
-      _ = r.reduce(.pipeline(.recording(audioLevel: level)))
+      _ = r.startRecordingForTests(audioLevel: level)
     }
 
     #expect(r.state.current?.id == first)
     // A new id per metering tick would re-arm expiry and re-measure the frame on
     // every audio callback, which is many times a second.
-    guard case .recording(let level, _, _)? = r.state.current?.content else {
+    guard case .recording(let level, _, _, _)? = r.state.current?.content else {
       Issue.record("expected a recording pill")
       return
     }
@@ -121,7 +121,7 @@ struct OverlayReducerTests {
     let stale = try! #require(r.state.current?.id)
 
     // A newer presentation takes the slot before the old timer fires.
-    _ = r.reduce(.pipeline(.recording(audioLevel: 0.5)))
+    _ = r.startRecordingForTests(audioLevel: 0.5)
     let live = try! #require(r.state.current?.id)
     #expect(stale != live)
 
@@ -151,7 +151,7 @@ struct OverlayReducerTests {
     var r = Self.makeReducer()
     _ = r.reduce(.pipeline(.accessibilityToast))
     let stale = try! #require(r.state.current?.id)
-    _ = r.reduce(.pipeline(.recording(audioLevel: 0.2)))
+    _ = r.startRecordingForTests(audioLevel: 0.2)
 
     let plan = r.reduce(.action(stale, .grantAccessibility))
 
@@ -172,14 +172,14 @@ struct OverlayReducerTests {
   @Test("an in-panel notice morphs the live recording pill rather than replacing it")
   func inPanelNoticeMorphsRatherThanReplaces() {
     var r = Self.makeReducer()
-    _ = r.reduce(.pipeline(.recording(audioLevel: 0.3)))
+    _ = r.startRecordingForTests(audioLevel: 0.3)
     let id = try! #require(r.state.current?.id)
 
     let plan = r.reduce(.inPanelNotice(.approachingCap, dismissAfter: nil))
 
     #expect(plan.didChange)
     #expect(plan.presentation?.id == id, "the notice replaced the pill instead of morphing it")
-    guard case .recording(let level, _, let notice)? = plan.presentation?.content else {
+    guard case .recording(let level, _, let notice, _)? = plan.presentation?.content else {
       Issue.record("expected the recording pill to survive")
       return
     }
@@ -227,7 +227,7 @@ struct OverlayReducerTests {
   @Test("hiding an occupied slot is a change")
   func hidingAnOccupiedSlotIsAChange() {
     var r = Self.makeReducer()
-    _ = r.reduce(.pipeline(.recording(audioLevel: 0.1)))
+    _ = r.startRecordingForTests(audioLevel: 0.1)
     let plan = r.reduce(.pipeline(.hidden))
     #expect(plan.didChange)
     #expect(plan.presentation == nil)
@@ -249,7 +249,7 @@ struct OverlayReducerTests {
     // yet tell the two apart — the preview flag is a provider the director owns
     // — so C3 adds that branch and this test gains its pair.
     var r = Self.makeReducer()
-    _ = r.reduce(.pipeline(.recording(audioLevel: 0.1)))
+    _ = r.startRecordingForTests(audioLevel: 0.1)
     #expect(r.state.current?.reservesFixedHeight == 92)
     #expect(r.state.current?.requestedWidth == .fixed(185))
 
@@ -285,7 +285,7 @@ struct OverlayReducerTests {
   @Test("an expiry cannot dismiss a presentation that has no timer")
   func expiryCannotDismissAPersistentPresentation() {
     var r = Self.makeReducer()
-    _ = r.reduce(.pipeline(.recording(audioLevel: 0.4)))
+    _ = r.startRecordingForTests(audioLevel: 0.4)
     let id = try! #require(r.state.current?.id)
 
     let plan = r.reduce(.expiryFired(id))
@@ -347,7 +347,7 @@ struct OverlayReducerTests {
   func persistentPresentationCancelsTheArmedTimer() {
     var r = Self.makeReducer()
     _ = r.reduce(.pipeline(.warning(reason: .polishFailed)))
-    let plan = r.reduce(.pipeline(.recording(audioLevel: 0.3)))
+    let plan = r.startRecordingForTests(audioLevel: 0.3)
     #expect(plan.expiryCommand == .cancel)
   }
 
@@ -394,10 +394,10 @@ struct OverlayReducerTests {
   func recordingIntentIsObservable() {
     var r = Self.makeReducer()
     #expect(
-      r.reduce(.pipeline(.recording(audioLevel: 0.2))).effects
+      r.startRecordingForTests(audioLevel: 0.2).effects
         == [.recordingStateChanged(true)])
     // A metering update is not a start: it must not re-notify.
-    #expect(r.reduce(.pipeline(.recording(audioLevel: 0.9))).effects.isEmpty)
+    #expect(r.startRecordingForTests(audioLevel: 0.9).effects.isEmpty)
     #expect(r.reduce(.pipeline(.hidden)).effects == [.recordingStateChanged(false)])
   }
 
@@ -406,14 +406,14 @@ struct OverlayReducerTests {
   @Test("hands-free lock morphs the live recording pill")
   func lockMorphsTheRecordingPill() {
     var r = Self.makeReducer()
-    _ = r.reduce(.pipeline(.recording(audioLevel: 0.5)))
+    _ = r.startRecordingForTests(audioLevel: 0.5)
     let id = try! #require(r.state.current?.id)
 
     let plan = r.reduce(.lockStateChanged(true))
 
     #expect(plan.didChange)
     #expect(plan.presentation?.id == id, "locking replaced the pill instead of morphing it")
-    guard case .recording(let level, let locked, _)? = plan.presentation?.content else {
+    guard case .recording(let level, let locked, _, _)? = plan.presentation?.content else {
       Issue.record("expected the recording pill to survive locking")
       return
     }
@@ -439,9 +439,9 @@ struct OverlayReducerTests {
     var r = Self.makeReducer()
     _ = r.reduce(.lockStateChanged(true))
 
-    let plan = r.reduce(.pipeline(.recording(audioLevel: 0.3)))
+    let plan = r.startRecordingForTests(audioLevel: 0.3)
 
-    guard case .recording(_, let locked, _)? = plan.presentation?.content else {
+    guard case .recording(_, let locked, _, _)? = plan.presentation?.content else {
       Issue.record("expected a recording pill")
       return
     }
@@ -451,8 +451,8 @@ struct OverlayReducerTests {
   @Test("a recording pill that starts unlocked is not born locked")
   func recordingIsNotBornLockedByDefault() {
     var r = Self.makeReducer()
-    let plan = r.reduce(.pipeline(.recording(audioLevel: 0.3)))
-    guard case .recording(_, let locked, _)? = plan.presentation?.content else {
+    let plan = r.startRecordingForTests(audioLevel: 0.3)
+    guard case .recording(_, let locked, _, _)? = plan.presentation?.content else {
       Issue.record("expected a recording pill")
       return
     }
@@ -704,7 +704,16 @@ struct OverlayReducerTests {
     // is primed with something else — the priming is what makes it a change, not
     // a workaround for a defect.
     if case .hidden = row.intent { _ = r.reduce(.pipeline(.engineReady)) }
-    let plan = r.reduce(.pipeline(row.intent))
+    // **Recording goes through the two-stage path since #2375 C3a**, because a
+    // fresh one needs a resolved design. The announcement is unchanged and still
+    // travels on the plan — it is carried on the PREPARE token and re-attached,
+    // so this row asserts the same observable fact as the other fifteen.
+    let plan: OverlayPlan
+    if case .recording(let level) = row.intent {
+      plan = r.startRecordingForTests(audioLevel: level)
+    } else {
+      plan = r.reduce(.pipeline(row.intent))
+    }
     guard let announcement = plan.announcement else {
       Issue.record("\(row.intent) announced nothing — a VoiceOver user hears silence")
       return
@@ -723,9 +732,9 @@ struct OverlayReducerTests {
   @Test("a repeated intent does not announce again")
   func repeatedIntentIsSilent() {
     var r = Self.makeReducer()
-    _ = r.reduce(.pipeline(.recording(audioLevel: 0)))
+    _ = r.startRecordingForTests(audioLevel: 0)
 
-    let second = r.reduce(.pipeline(.recording(audioLevel: 0)))
+    let second = r.startRecordingForTests(audioLevel: 0)
 
     #expect(
       second.announcement == nil,
@@ -779,7 +788,7 @@ struct OverlayReducerTests {
   @Test("a timed in-panel notice arms its own dwell and clears itself")
   func timedInPanelNoticeClears() {
     var r = Self.makeReducer()
-    _ = r.reduce(.pipeline(.recording(audioLevel: 0.2)))
+    _ = r.startRecordingForTests(audioLevel: 0.2)
     let id = try! #require(r.state.current?.id)
 
     let armed = r.reduce(.inPanelNotice(.autoStopUnavailable, dismissAfter: 4.0))
@@ -789,7 +798,7 @@ struct OverlayReducerTests {
 
     let fired = r.reduce(.inPanelNoticeExpiryFired(id))
 
-    guard case .recording(_, _, let notice)? = r.state.current?.content else {
+    guard case .recording(_, _, let notice, _)? = r.state.current?.content else {
       Issue.record("the expiry ended the whole recording instead of the banner")
       return
     }
@@ -804,7 +813,7 @@ struct OverlayReducerTests {
   @Test("an untimed in-panel notice arms nothing")
   func untimedInPanelNoticeIsPersistent() {
     var r = Self.makeReducer()
-    _ = r.reduce(.pipeline(.recording(audioLevel: 0.2)))
+    _ = r.startRecordingForTests(audioLevel: 0.2)
 
     let plan = r.reduce(.inPanelNotice(.approachingCap, dismissAfter: nil))
 

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayRetainedWindowTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayRetainedWindowTests.swift
@@ -230,7 +230,7 @@ struct OverlayRetainedWindowTests {
     func transitionsReuseTheRetainedWindow() async {
       let host = OverlayWindowHost()
       let d = OverlayDirector(
-        host: host,         announce: { _ in }, livePreview: .disabled, grantAccessibility: {},
+        host: host,         announce: { _ in }, livePreview: .disabled, grantAccessibility: {}, selections: { .shipped },
         deferFirstRender: { $0() })
       defer { host.panelForTesting?.orderOut(nil) }
 
@@ -259,7 +259,7 @@ struct OverlayRetainedWindowTests {
     func hideThenShowReusesTheWindow() async {
       let host = OverlayWindowHost()
       let d = OverlayDirector(
-        host: host,         announce: { _ in }, livePreview: .disabled, grantAccessibility: {},
+        host: host,         announce: { _ in }, livePreview: .disabled, grantAccessibility: {}, selections: { .shipped },
         deferFirstRender: { $0() })
       defer { host.panelForTesting?.orderOut(nil) }
 

--- a/Tests/EnviousWisprTests/App/Overlay/PillCatalogAdmissionTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/PillCatalogAdmissionTests.swift
@@ -39,7 +39,9 @@ struct PillCatalogAdmissionTests {
     case .emptySlot:
       break
     case .pipelineBusy:
-      _ = reducer.reduce(.pipeline(.recording(audioLevel: 0)))
+      // The real two-stage path: a fresh recording cannot be started through
+      // `reduce`, because starting one needs a resolved design.
+      reducer.startRecordingForTests(audioLevel: 0)
     case .featureHoldsSlot:
       _ = reducer.reduce(.bluetoothAwareness)
     }
@@ -49,10 +51,19 @@ struct PillCatalogAdmissionTests {
   private static let chip = LanguageChipPayload(
     lang: "es", displayName: "Spanish", state: .askToLock, generation: 1)
 
-  /// Every request a caller can make of the slot, feature routes included.
+  /// Every request a caller can make of the slot THROUGH `reduce`, feature routes
+  /// included.
+  ///
+  /// **Starting a recording is deliberately absent since C3a, and its absence is
+  /// a fact about the API rather than a gap in this table.** A fresh recording
+  /// needs a resolved design, so it goes through `prepareRecording` and
+  /// `commitRecording`; `reduce(.pipeline(.recording(_:)))` can now only morph a
+  /// live one. Admission for a fresh recording is asserted where it happens, in
+  /// the director's transaction tests — and the `pipelineBusy` starting state
+  /// below is built with the real two-stage path, so every row here is still run
+  /// against a slot a recording occupies.
   private static let events: [(label: String, event: OverlayEvent)] = [
     ("hidden", .pipeline(.hidden)),
-    ("recording", .pipeline(.recording(audioLevel: 0))),
     ("processing", .pipeline(.processing(phase: .transcribing))),
     ("clipboardFallback", .pipeline(.clipboardFallback)),
     ("accessibilityToast", .pipeline(.accessibilityToast)),
@@ -142,18 +153,13 @@ struct PillCatalogAdmissionTests {
           #expect(
             reducer.state.current == plan.presentation,
             "\(label) in \(state.rawValue) reported a presentation without committing it")
-          if state == .pipelineBusy, case .pipeline(.recording) = event {
-            // The one legitimate no-change admission: a repeated recording push
-            // at the same audio level rebuilds an EQUAL definition and must keep
-            // its identity, or every metering tick would look like a new pill.
-            #expect(
-              reducer.state.current == before,
-              "the repeated recording morph lost its identity")
-          } else {
-            #expect(
-              reducer.state.current != before,
-              "\(label) in \(state.rawValue) reported admission without replacing the prior occupant")
-          }
+          // **The repeated-recording carve-out is GONE with the row it existed
+          // for.** It read: an identical recording push rebuilds an EQUAL
+          // definition and must keep its identity. That is still true and is now
+          // asserted where the morph lives, not here.
+          #expect(
+            reducer.state.current != before,
+            "\(label) in \(state.rawValue) reported admission without replacing the prior occupant")
         }
       }
     }
@@ -161,12 +167,13 @@ struct PillCatalogAdmissionTests {
     // **The sweep must prove it generated something.** Every branch above is a
     // conditional, so a mis-specified axis — one state, one event, a predicate
     // that never fires — leaves this test green while asserting nothing. The
-    // three counts are arithmetic over the axes: 18 requests x 3 states = 54
-    // cells, of which the 2 feature routes are refused in the 2 non-empty states
-    // (4), `.hidden` empties in all 3, and the remaining 47 are admitted.
+    // three counts are arithmetic over the axes.
+    // 17 requests x 3 states = 51 cells: the 2 feature routes refused in the 2
+    // non-empty states (4), `.hidden` emptying in all 3, and the remaining 44
+    // admitted.
     #expect(refused == 4, "the refusal half of this sweep is not being exercised")
     #expect(emptied == 3, "the emptying half of this sweep is not being exercised")
-    #expect(admitted == 47, "the admission half of this sweep is not being exercised")
+    #expect(admitted == 44, "the admission half of this sweep is not being exercised")
     #expect(refused + emptied + admitted == StartingState.allCases.count * Self.events.count)
   }
 
@@ -229,7 +236,7 @@ struct PillCatalogAdmissionTests {
   func requestAxisIsComplete() {
     let labels = Self.events.map(\.label)
     let expected: Set<String> = [
-      "hidden", "recording", "processing", "clipboardFallback", "accessibilityToast",
+      "hidden", "processing", "clipboardFallback", "accessibilityToast",
       "warning", "error", "advisory", "interruption", "passiveChip", "cachingModel",
       "engineReady", "recoveringLastRecording", "recoverySucceeded",
       "bluetoothAwareness.pipelineRoute", "escapeRecovery",
@@ -249,7 +256,6 @@ struct PillCatalogAdmissionTests {
     for (label, event) in Self.events {
       switch (label, event) {
       case ("hidden", .pipeline(.hidden)),
-        ("recording", .pipeline(.recording(audioLevel: _))),
         ("processing", .pipeline(.processing(phase: _))),
         ("clipboardFallback", .pipeline(.clipboardFallback)),
         ("accessibilityToast", .pipeline(.accessibilityToast)),

--- a/Tests/EnviousWisprTests/App/Overlay/PillCatalogAdmissionTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/PillCatalogAdmissionTests.swift
@@ -1,0 +1,289 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprCore
+@testable import EnviousWisprPipeline
+
+/// **Table 2 — admission, through the reducer** (#2375 Phase 3, chunk C2).
+///
+/// Admission is a function of `OverlayState`, never of a catalog entry, so it
+/// cannot be observed from `PillCatalog` at all. This suite drives real events
+/// through a real reducer.
+///
+/// **The cross-product is GENERATED, not hand-picked.** Hand-written rows cover
+/// the cells the author thought of, which is the same blind spot the table exists
+/// to cover for. Every request is run against every starting state.
+///
+/// **The clause a naive admission test omits is the third one**: a refusal must
+/// leave the incumbent UNTOUCHED. Without it, a feature stealing another
+/// feature's slot passes — the refusal is reported, and the slot has already
+/// changed hands.
+@Suite(.tags(.productOutcome))
+struct PillCatalogAdmissionTests {
+
+  // MARK: - Axes
+
+  private enum StartingState: String, CaseIterable {
+    /// Nothing on screen, pipeline idle.
+    case emptySlot
+    /// A dictation is running, so the pipeline owns the slot.
+    case pipelineBusy
+    /// A feature card already holds the slot while the pipeline is idle.
+    case featureHoldsSlot
+  }
+
+  private static func reducer(in state: StartingState) -> OverlayReducer {
+    var reducer = OverlayReducer()
+    switch state {
+    case .emptySlot:
+      break
+    case .pipelineBusy:
+      _ = reducer.reduce(.pipeline(.recording(audioLevel: 0)))
+    case .featureHoldsSlot:
+      _ = reducer.reduce(.bluetoothAwareness)
+    }
+    return reducer
+  }
+
+  private static let chip = LanguageChipPayload(
+    lang: "es", displayName: "Spanish", state: .askToLock, generation: 1)
+
+  /// Every request a caller can make of the slot, feature routes included.
+  private static let events: [(label: String, event: OverlayEvent)] = [
+    ("hidden", .pipeline(.hidden)),
+    ("recording", .pipeline(.recording(audioLevel: 0))),
+    ("processing", .pipeline(.processing(phase: .transcribing))),
+    ("clipboardFallback", .pipeline(.clipboardFallback)),
+    ("accessibilityToast", .pipeline(.accessibilityToast)),
+    ("warning", .pipeline(.warning(reason: .polishFailed))),
+    ("error", .pipeline(.error(reason: .asrFailed))),
+    ("advisory", .pipeline(.advisory(reason: .zeroSignal))),
+    ("interruption", .pipeline(.interruption(reason: .deviceRemoved))),
+    ("passiveChip", .pipeline(.passiveChip(payload: chip))),
+    ("cachingModel", .pipeline(.cachingModel(engineLabel: "Parakeet"))),
+    ("engineReady", .pipeline(.engineReady)),
+    ("recoveringLastRecording", .pipeline(.recoveringLastRecording)),
+    ("recoverySucceeded", .pipeline(.recoverySucceeded)),
+    ("bluetoothAwareness.pipelineRoute", .pipeline(.bluetoothAwareness)),
+    ("escapeRecovery", .pipeline(.escapeRecovery(transcriptID: UUID()))),
+    ("bluetoothAwareness.featureRoute", .bluetoothAwareness),
+    ("importStatus.featureRoute", .importStatus(message: "Imported 12 words")),
+  ]
+
+  // MARK: - The sweep
+
+  /// **A pipeline request is never refused; a feature request is refused unless
+  /// the slot is free.** That is the shipped arbitration rule, and running every
+  /// request against every state is what proves the rule rather than a sample of
+  /// it.
+  @Test("every request against every starting state obeys the arbitration rule")
+  func admissionCrossProduct() {
+    var refused = 0
+    var admitted = 0
+    var emptied = 0
+
+    for state in StartingState.allCases {
+      for (label, event) in Self.events {
+        var reducer = Self.reducer(in: state)
+        let before = reducer.state.current
+        let plan = reducer.reduce(event)
+
+        let isFeatureRoute = Self.isFeatureRoute(event)
+        let shouldBeRefused = isFeatureRoute && state != .emptySlot
+
+        if shouldBeRefused {
+          refused += 1
+          #expect(
+            plan.didChange == false,
+            "\(label) in \(state.rawValue) was admitted and should have been refused")
+          // The clause that catches a feature stealing another feature's slot.
+          #expect(
+            reducer.state.current == before,
+            "\(label) in \(state.rawValue) was refused and still disturbed the incumbent")
+          #expect(
+            plan.presentation == nil,
+            "\(label) in \(state.rawValue) was refused and still produced a presentation")
+          #expect(
+            plan.announcement == nil,
+            "\(label) in \(state.rawValue) was refused and still spoke")
+        } else if Self.isEmptying(event) {
+          emptied += 1
+          // `.hidden` empties the slot. From an EMPTY slot that is a genuine
+          // no-op with its own accounting; from an occupied one it is a change,
+          // and it evicts a feature card as well as a pipeline pill.
+          #expect(
+            plan.presentation == nil,
+            "\(label) in \(state.rawValue) emptied the slot and still produced a pill")
+          #expect(
+            reducer.state.current == nil,
+            "\(label) in \(state.rawValue) did not empty the slot")
+          #expect(
+            plan.didChange == (before != nil),
+            "\(label) in \(state.rawValue) mis-reported whether emptying changed anything")
+        } else {
+          admitted += 1
+          // **Acceptance is `didChange`, NOT "the value differs".** An earlier
+          // draft asserted the occupant changed, which fails on a repeated
+          // recording push: the same audio level rebuilds an EQUAL definition, so
+          // a correctly admitted request looks like a no-op to an equality check.
+          // The sweep caught it, which is the argument for generating the
+          // cross-product rather than picking rows.
+          #expect(
+            plan.didChange,
+            "\(label) in \(state.rawValue) was refused and should have been admitted")
+          #expect(
+            plan.presentation != nil,
+            "\(label) in \(state.rawValue) was admitted with nothing to show")
+          // **The binding clause: the plan's occupant is the one that landed.**
+          // `didChange` plus a non-nil plan plus a non-nil incumbent can all be
+          // true of a reducer that reports a presentation and commits something
+          // else (review r1 finding 2).
+          #expect(
+            reducer.state.current == plan.presentation,
+            "\(label) in \(state.rawValue) reported a presentation without committing it")
+          if state == .pipelineBusy, case .pipeline(.recording) = event {
+            // The one legitimate no-change admission: a repeated recording push
+            // at the same audio level rebuilds an EQUAL definition and must keep
+            // its identity, or every metering tick would look like a new pill.
+            #expect(
+              reducer.state.current == before,
+              "the repeated recording morph lost its identity")
+          } else {
+            #expect(
+              reducer.state.current != before,
+              "\(label) in \(state.rawValue) reported admission without replacing the prior occupant")
+          }
+        }
+      }
+    }
+
+    // **The sweep must prove it generated something.** Every branch above is a
+    // conditional, so a mis-specified axis — one state, one event, a predicate
+    // that never fires — leaves this test green while asserting nothing. The
+    // three counts are arithmetic over the axes: 18 requests x 3 states = 54
+    // cells, of which the 2 feature routes are refused in the 2 non-empty states
+    // (4), `.hidden` empties in all 3, and the remaining 47 are admitted.
+    #expect(refused == 4, "the refusal half of this sweep is not being exercised")
+    #expect(emptied == 3, "the emptying half of this sweep is not being exercised")
+    #expect(admitted == 47, "the admission half of this sweep is not being exercised")
+    #expect(refused + emptied + admitted == StartingState.allCases.count * Self.events.count)
+  }
+
+  /// The sweep above would still pass against a reducer that refused EVERYTHING,
+  /// because a refusal is easy to satisfy. This pins the other direction: from an
+  /// empty slot, both feature routes are admitted and occupy it.
+  @Test("both feature routes are admitted from an empty slot")
+  func featuresAreAdmittedWhenTheSlotIsFree() {
+    for (label, event) in Self.events where Self.isFeatureRoute(event) {
+      var reducer = Self.reducer(in: .emptySlot)
+      let plan = reducer.reduce(event)
+      #expect(plan.didChange, "\(label) was refused from an empty slot")
+      #expect(plan.presentation != nil, "\(label) was admitted with nothing to show")
+      #expect(reducer.state.current != nil, "\(label) did not take the slot")
+    }
+  }
+
+  /// The one feature that may replace itself, which is the shipped rule and is
+  /// narrower than "the slot is free".
+  @Test("import status may replace itself and nothing else")
+  func importStatusReplacesOnlyItself() {
+    var reducer = OverlayReducer()
+    #expect(reducer.reduce(.importStatus(message: "Imported 12 words")).didChange)
+    let first = reducer.state.current
+
+    let second = reducer.reduce(.importStatus(message: "Imported 40 words"))
+    #expect(second.didChange, "a status pill must be replaceable by the next status")
+    #expect(reducer.state.current != first, "the message did not update")
+
+    // ...but it may not take the slot from another feature.
+    var other = OverlayReducer()
+    _ = other.reduce(.bluetoothAwareness)
+    let held = other.state.current
+    let refused = other.reduce(.importStatus(message: "Imported 12 words"))
+    #expect(refused.didChange == false, "import status took the Bluetooth card's slot")
+    #expect(other.state.current == held, "the Bluetooth card was disturbed by a refusal")
+  }
+
+  /// The Bluetooth card reaches the slot by two routes and both must produce the
+  /// same occupant, now that one catalog arm serves them.
+  @Test("both Bluetooth routes install the same occupant")
+  func bothBluetoothRoutesAgree() {
+    var viaPipeline = OverlayReducer()
+    var viaFeature = OverlayReducer()
+    let a = viaPipeline.reduce(.pipeline(.bluetoothAwareness))
+    let b = viaFeature.reduce(.bluetoothAwareness)
+
+    #expect(a.presentation?.content == b.presentation?.content)
+    #expect(a.presentation?.requestedWidth == b.presentation?.requestedWidth)
+    #expect(a.presentation?.reservesFixedHeight == b.presentation?.reservesFixedHeight)
+    #expect(a.presentation?.expiry == b.presentation?.expiry)
+    #expect(a.announcement == b.announcement)
+  }
+
+  /// The same class one suite over: the sweep's axes are hand-written lists, and
+  /// the coverage floor above counts CELLS. Fifty-four cells is equally true of
+  /// eighteen distinct requests and of seventeen with one duplicated, so the
+  /// floor cannot tell a complete axis from a short one. Name the axis.
+  @Test("the request axis is the whole set, not merely eighteen entries")
+  func requestAxisIsComplete() {
+    let labels = Self.events.map(\.label)
+    let expected: Set<String> = [
+      "hidden", "recording", "processing", "clipboardFallback", "accessibilityToast",
+      "warning", "error", "advisory", "interruption", "passiveChip", "cachingModel",
+      "engineReady", "recoveringLastRecording", "recoverySucceeded",
+      "bluetoothAwareness.pipelineRoute", "escapeRecovery",
+      "bluetoothAwareness.featureRoute", "importStatus.featureRoute",
+    ]
+    #expect(Set(labels) == expected, "a request is missing from the sweep's axis")
+    #expect(labels.count == expected.count, "the sweep's axis contains a duplicate")
+    #expect(
+      Self.events.filter { Self.isFeatureRoute($0.event) }.count == 2,
+      "both feature routes must be on the axis — they are where a refusal is observable")
+
+    // **A LABEL IS NOT AN EVENT, and the set check above only proves the labels.**
+    // A row labelled "warning" carrying `.error` satisfies every assertion in this
+    // suite: the label set matches, the cell counts match, and both requests are
+    // admitted identically — so the sweep would report full coverage of an axis
+    // that never exercises one of its members. Pin each label to its request.
+    for (label, event) in Self.events {
+      switch (label, event) {
+      case ("hidden", .pipeline(.hidden)),
+        ("recording", .pipeline(.recording(audioLevel: _))),
+        ("processing", .pipeline(.processing(phase: _))),
+        ("clipboardFallback", .pipeline(.clipboardFallback)),
+        ("accessibilityToast", .pipeline(.accessibilityToast)),
+        ("warning", .pipeline(.warning(reason: _))),
+        ("error", .pipeline(.error(reason: _))),
+        ("advisory", .pipeline(.advisory(reason: _))),
+        ("interruption", .pipeline(.interruption(reason: _))),
+        ("passiveChip", .pipeline(.passiveChip(payload: _))),
+        ("cachingModel", .pipeline(.cachingModel(engineLabel: _))),
+        ("engineReady", .pipeline(.engineReady)),
+        ("recoveringLastRecording", .pipeline(.recoveringLastRecording)),
+        ("recoverySucceeded", .pipeline(.recoverySucceeded)),
+        ("bluetoothAwareness.pipelineRoute", .pipeline(.bluetoothAwareness)),
+        ("escapeRecovery", .pipeline(.escapeRecovery(transcriptID: _))),
+        ("bluetoothAwareness.featureRoute", .bluetoothAwareness),
+        ("importStatus.featureRoute", .importStatus(message: _)):
+        break
+      default:
+        Issue.record("\(label) is paired with the wrong request")
+      }
+    }
+  }
+
+  private static func isFeatureRoute(_ event: OverlayEvent) -> Bool {
+    switch event {
+    case .importStatus, .bluetoothAwareness: return true
+    default: return false
+    }
+  }
+
+  /// `.hidden` from an empty slot is a genuine no-op, so "admitted and changed
+  /// nothing" is the correct outcome there rather than a failure.
+  private static func isEmptying(_ event: OverlayEvent) -> Bool {
+    if case .pipeline(.hidden) = event { return true }
+    return false
+  }
+}

--- a/Tests/EnviousWisprTests/App/Overlay/PillCatalogParityTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/PillCatalogParityTests.swift
@@ -1,0 +1,315 @@
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprCore
+@testable import EnviousWisprPipeline
+
+/// **Table 1 — definition parity, read from the catalog and checked against the
+/// FROZEN oracle** (#2375 Phase 3, chunk C2).
+///
+/// Every expectation here comes from `FrozenPillParity.rows`, captured by running
+/// the shipped reducer at `main` `da103706` before any catalog code existed.
+/// Nothing is derived from `PillCatalog`, and that is the whole point: a table
+/// that reads its expectations from the code under test proves only
+/// self-consistency.
+///
+/// **Recording is absent, deliberately.** The catalog has no `.recording` case
+/// until C3a supplies a resolved design, so its two frozen geometry rows are
+/// C3a's and C3b's receipt rather than this chunk's. This suite covers the
+/// sixteen non-recording requests.
+@Suite(.tags(.productOutcome))
+struct PillCatalogParityTests {
+
+  // MARK: - Projection
+
+  /// Project a catalog entry into the fixture's rename-neutral schema.
+  ///
+  /// **The projection is the risky part of this suite and it fails CLOSED.**
+  /// A projection that quietly reported "no notice" for a notice-backed pill
+  /// would make several rows pass while asserting nothing, so every enum it
+  /// crosses is switched exhaustively and every unknown is a distinct string a
+  /// comparison cannot match by accident.
+  private static func project(_ entry: PillCatalogEntry, label: String) -> FrozenRow {
+    guard let definition = entry.definition else {
+      return FrozenRow(
+        label: label, hasDefinition: false, contentTag: "none", notice: nil,
+        width: nil, fixedHeight: nil, expiry: nil,
+        announcement: entry.announcement.map(frozen))
+    }
+    return FrozenRow(
+      label: label, hasDefinition: true,
+      contentTag: tag(definition.content),
+      notice: frozenNotice(definition.content),
+      width: frozen(definition.requestedWidth),
+      fixedHeight: definition.reservesFixedHeight,
+      expiry: frozen(definition.expiry),
+      announcement: entry.announcement.map(frozen))
+  }
+
+  private static func tag(_ content: OverlayContent) -> String {
+    switch content {
+    case .recording: return "recording"
+    case .notice: return "notice"
+    case .languageChip: return "languageChip"
+    case .bluetoothAwareness: return "bluetoothAwareness"
+    case .escapeRecovery: return "escapeRecovery"
+    }
+  }
+
+  private static func frozenNotice(_ content: OverlayContent) -> FrozenNotice? {
+    guard case .notice(let notice) = content else { return nil }
+    return FrozenNotice(
+      kind: name(notice.kind), text: notice.text, secondary: notice.secondaryText,
+      severity: name(notice.severity), isMultiline: notice.isMultiline,
+      actionLabel: notice.action?.label, actionCase: notice.action.map { name($0.action) })
+  }
+
+  private static func name(_ kind: NoticeModel.Kind) -> String {
+    switch kind {
+    case .processing: return "processing"
+    case .notification: return "notification"
+    case .accessibilityToast: return "accessibilityToast"
+    case .warmingUp: return "warmingUp"
+    case .ready: return "ready"
+    case .recovery: return "recovery"
+    case .importStatus: return "importStatus"
+    }
+  }
+
+  private static func name(_ severity: NoticeModel.Severity) -> String {
+    switch severity {
+    case .neutral: return "neutral"
+    case .warning: return "warning"
+    case .error: return "error"
+    case .advisory: return "advisory"
+    case .distress: return "distress"
+    }
+  }
+
+  private static func name(_ action: PillAction) -> String {
+    switch action {
+    case .grantAccessibility: return "grantAccessibility"
+    case .discardRecovery: return "discardRecovery"
+    case .pasteEscapeRecovery: return "pasteEscapeRecovery"
+    case .lockLanguage: return "lockLanguage"
+    case .dismissChip: return "dismissChip"
+    case .acknowledgeBluetoothAwareness: return "acknowledgeBluetoothAwareness"
+    case .closeBluetoothAwareness: return "closeBluetoothAwareness"
+    case .openBluetoothSettings: return "openBluetoothSettings"
+    }
+  }
+
+  private static func frozen(_ width: OverlayWidth) -> FrozenWidth {
+    switch width {
+    case .fixed(let value): return .fixed(value)
+    case .measured: return .measured
+    }
+  }
+
+  private static func frozen(_ expiry: OverlayExpiry) -> FrozenExpiry {
+    switch expiry {
+    case .untilReplaced: return .untilReplaced
+    case .after(let seconds, let pausesOnHover):
+      return .after(seconds: seconds, pausesOnHover: pausesOnHover)
+    }
+  }
+
+  private static func frozen(_ announcement: OverlayAnnouncement) -> FrozenAnnouncement {
+    FrozenAnnouncement(text: announcement.text, isHighPriority: announcement.isHighPriority)
+  }
+
+  // MARK: - The requests, and the inputs each frozen row was captured with
+
+  /// The sixteen non-recording requests, paired with the frozen row each must
+  /// reproduce.
+  ///
+  /// **The payloads are RECONSTRUCTED from the row labels, and a wrong
+  /// reconstruction cannot pass quietly.** The capture recorded which reason it
+  /// drove each row with in the label — `warning.polishFailed`,
+  /// `interruption.deviceRemoved` — and every reason produces different copy, so
+  /// a mis-picked payload fails on the notice text and the announcement rather
+  /// than silently matching.
+  private static let cases: [(label: String, request: PillCatalogRequest)] = [
+    ("hidden", .hidden),
+    ("processing.transcribing", .processing(phase: .transcribing)),
+    ("clipboardFallback", .clipboardFallback),
+    ("accessibilityToast", .accessibilityToast),
+    ("warning.polishFailed", .warning(reason: .polishFailed)),
+    ("error.asrFailed", .error(reason: .asrFailed)),
+    ("advisory.zeroSignal", .advisory(reason: .zeroSignal)),
+    ("interruption.deviceRemoved", .interruption(reason: .deviceRemoved)),
+    ("passiveChip", .passiveChip(payload: spanishChip)),
+    ("cachingModel", .cachingModel(engineLabel: "Parakeet")),
+    ("engineReady", .engineReady),
+    ("recoveringLastRecording", .recoveringLastRecording),
+    ("recoverySucceeded", .recoverySucceeded),
+    ("bluetoothAwareness.pipelineRoute", .bluetoothAwareness),
+    ("escapeRecovery", .escapeRecovery(transcriptID: UUID())),
+    ("importStatus.featureRoute", .importStatus(message: "Imported 12 words")),
+  ]
+
+  /// The inputs the accessibility composition check drives, and the row label the
+  /// Bluetooth duplicate check reads.
+  ///
+  /// **These exist so the accounting test and the checks consume the SAME data.**
+  /// Round 4's finding: a partition built from its own string literals is a copy
+  /// of the check's inputs rather than a reference to them, so the two can drift
+  /// and the accounting would still report a clean partition over rows nothing
+  /// reads. I had recorded that as unclosable without a runtime registry or
+  /// source parsing. It is closable with a shared constant.
+  private static let accessibilityCompositionCases: [(label: String, showsToast: Bool)] = [
+    ("accessibilityNotice.toastShown", true),
+    ("accessibilityNotice.toastRefused", false),
+  ]
+
+  private static let bluetoothFeatureRowLabel = "bluetoothAwareness.featureRoute"
+
+  // MARK: - Table 1
+
+  @Test("every non-recording request reproduces its frozen definition and announcement")
+  func nonRecordingParity() throws {
+    for (label, request) in Self.cases {
+      guard let expected = FrozenPillParity.rows.first(where: { $0.label == label }) else {
+        Issue.record("no frozen row labelled \(label) — the oracle and this table disagree")
+        continue
+      }
+      let observed = Self.project(
+        PillCatalog.entry(for: request, id: PresentationID()), label: label)
+      #expect(observed == expected, "\(label) drifted from the frozen capture")
+    }
+  }
+
+  /// **Every row in `FrozenPillParity.rows` is accounted for exactly once: either
+  /// covered by this suite or explicitly deferred to C3a.**
+  ///
+  /// "Spent" was the earlier wording and it over-claimed — `recording` is
+  /// deferred, not covered, and a partition that calls a deferral a check is the
+  /// same defect one level up from the ones this suite exists to catch.
+  ///
+  /// This is the strongest completeness claim available here, and it replaces a
+  /// bare `rows.count == 20`. A count cannot tell a complete oracle from one with
+  /// a duplicate row and a missing one, and — worse — it says nothing at all about
+  /// whether this suite USES what C0 froze. Twenty rows could sit in the fixture
+  /// with four of them asserted nowhere, which is exactly what round 1 found for
+  /// the two accessibility rows.
+  ///
+  /// Read the partition as the suite's own map: sixteen non-recording requests in
+  /// the parity sweep, the second Bluetooth route in the duplicate check, both
+  /// composition outcomes in the accessibility check, and recording deferred to
+  /// C3a because the catalog cannot answer it yet.
+  @Test("every table row is either covered exactly once or explicitly deferred")
+  func theOracleIsFullyAccountedFor() {
+    let frozen = Set(FrozenPillParity.rows.map(\.label))
+    #expect(
+      frozen.count == FrozenPillParity.rows.count,
+      "the oracle has a duplicate label, so a row is unaddressable")
+
+    let sweep = Set(Self.cases.map(\.label))
+    #expect(sweep.count == Self.cases.count, "this suite's request list has a duplicate label")
+
+    let duplicateCheck: Set<String> = [Self.bluetoothFeatureRowLabel]
+    let compositionCheck = Set(Self.accessibilityCompositionCases.map(\.label))
+    // Deferred, with its reason: the catalog has no `.recording` case until C3a
+    // supplies a resolved design, so its row is C3a's receipt.
+    let deferredToC3a: Set<String> = ["recording"]
+
+    let partitions = [sweep, duplicateCheck, compositionCheck, deferredToC3a]
+    let accounted = partitions.reduce(into: Set<String>()) { $0.formUnion($1) }
+
+    // ONE literal, never a concatenation: a `Comment` is built from a string
+    // literal, so `"a" + "b"` does not type-check as an expectation message.
+    #expect(
+      accounted == frozen,
+      "orphaned frozen rows: \(frozen.subtracting(accounted).sorted()) — claims with no frozen row: \(accounted.subtracting(frozen).sorted())"
+    )
+    // **Disjointness over ALL FOUR, not just `sweep` against each other one.**
+    // Comparing one partition to the rest leaves the rest free to overlap, which
+    // is how the earlier version let the Bluetooth pipeline route be counted by
+    // two checks while reading as a partition. Summing counts and comparing to
+    // the union tests every pair at once.
+    #expect(
+      partitions.reduce(0) { $0 + $1.count } == accounted.count,
+      "a frozen row is assigned to more than one partition")
+  }
+
+  /// The two frozen rows an entry-by-entry table cannot reach (review r1 finding 1).
+  ///
+  /// **`reduceAccessibilityNotice` is a COMPOSITION of two catalog requests, and
+  /// its whole point is that the halves come from different ones.** When
+  /// eligibility refuses the toast it draws the CLIPBOARD definition and retains
+  /// the ACCESSIBILITY announcement — the only place in the system where that is
+  /// legitimate. Asserting the toast entry and the clipboard entry separately
+  /// proves each is right and says nothing about the substitution, so C0 froze
+  /// the composed outcome in both eligibility states and this is where those two
+  /// rows are spent.
+  @Test("both accessibility outcomes reproduce their frozen rows")
+  func accessibilityCompositionParity() throws {
+    for (label, showsToast) in Self.accessibilityCompositionCases {
+      var reducer = OverlayReducer()
+      let plan = reducer.reduceAccessibilityNotice(showingToast: { showsToast })
+      let expected = try #require(
+        FrozenPillParity.rows.first { $0.label == label },
+        "no frozen row labelled \(label)")
+      let observed = Self.project(
+        PillCatalogEntry(definition: plan.presentation, announcement: plan.announcement),
+        label: label)
+      #expect(observed == expected, "\(label) drifted from the frozen capture")
+    }
+  }
+
+  /// The duplicate G2 removes, asserted as an OUTCOME rather than as an absence.
+  ///
+  /// C0 froze the Bluetooth card twice because the base revision minted it twice —
+  /// once through the pipeline switch and once inline in the feature reducer.
+  /// After C2 there is one arm, so the single catalog request must reproduce both
+  /// frozen rows. A test asserting only that the inline mint is gone would pass
+  /// against an arm that returns the wrong card.
+  ///
+  /// **This test covers the FEATURE route only, and that is not a weakening.**
+  /// The pipeline route is already covered by the parity sweep, which issues the
+  /// same `.bluetoothAwareness` request. Checking both here made the row covered
+  /// twice, so the accounting above could call itself a partition while it was
+  /// not one. Both frozen rows are still reproduced by the single arm; the claim
+  /// is distributed across two checks instead of overlapping in one.
+  @Test("the single catalog arm reproduces the frozen feature Bluetooth route")
+  func bluetoothDuplicateIsGone() throws {
+    let row = try #require(
+      FrozenPillParity.rows.first { $0.label == Self.bluetoothFeatureRowLabel },
+      "the oracle lost the second base-revision route, which is where the duplicate was visible")
+    let observed = Self.project(
+      PillCatalog.entry(for: .bluetoothAwareness, id: PresentationID()), label: row.label)
+    #expect(observed == row, "the feature route is not what the single catalog arm produces")
+  }
+
+  /// `.hidden` is the shape a definition-only return could not have carried.
+  @Test("hidden empties the slot and still announces")
+  func hiddenAnnouncesWithoutDefinition() {
+    let entry = PillCatalog.entry(for: .hidden, id: PresentationID())
+    #expect(entry.definition == nil, "hidden must empty the slot")
+    #expect(entry.announcement?.text == "Recording complete")
+    #expect(entry.announcement?.isHighPriority == false)
+  }
+
+  /// Import status is the one silent request, and the fixture asserts nil rather
+  /// than omitting the row.
+  @Test("import status has a definition and says nothing")
+  func importStatusIsSilent() {
+    let entry = PillCatalog.entry(
+      for: .importStatus(message: "Imported 12 words"), id: PresentationID())
+    #expect(entry.definition != nil, "import status must occupy the slot")
+    #expect(entry.announcement == nil, "import status announces nothing")
+  }
+
+  /// The id travels onto the definition rather than being looked up afterwards.
+  @Test("the catalog stamps the identity it was given")
+  func identityTravels() {
+    let id = PresentationID(rawValue: UUID())
+    let entry = PillCatalog.entry(for: .engineReady, id: id)
+    #expect(entry.definition?.id == id)
+  }
+
+  private static let spanishChip = LanguageChipPayload(
+    lang: "es", displayName: "Spanish", state: .askToLock, generation: 1)
+}

--- a/Tests/EnviousWisprTests/App/Overlay/PillCatalogRecordingParityTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/PillCatalogRecordingParityTests.swift
@@ -1,0 +1,155 @@
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprCore
+@testable import EnviousWisprPipeline
+
+/// **Table 1's recording rows, and the measurement that makes G3 legible**
+/// (#2375 Phase 3, chunk C3a).
+///
+/// C0 froze the recording pill twice: once as an ordinary definition row, which
+/// records what the REDUCER emitted, and once per capability state as a
+/// `FrozenRecordingRow`, which records what the window was actually sized to.
+/// Those two disagree for the with-words case — 185 against 400 — and that
+/// disagreement IS the defect: two authorities for one geometry, the
+/// correct-looking one ignored.
+///
+/// After C3a there is one authority. Both frozen recording rows must now come
+/// from the definition itself.
+@Suite(.tags(.productOutcome))
+struct PillCatalogRecordingParityTests {
+
+  /// Which design each frozen capability state resolves to under the shipped
+  /// selections. Not hardcoded per row: `PillDesignSelections.shipped` is the
+  /// pair the base revision produced, so the mapping is derived from the thing
+  /// under test's own input rather than restated.
+  private static func design(for capability: FrozenRecordingCapability) -> RecordingPillDesign {
+    PillDesignSelections.shipped
+      .resolve(capabilityHasWords: capability == .withWords)
+      .design
+  }
+
+  @Test("both frozen recording geometries come from the definition alone")
+  func recordingGeometryParity() throws {
+    #expect(FrozenPillParity.recordingRows.count == 2, "the oracle lost a capability state")
+
+    for row in FrozenPillParity.recordingRows {
+      let design = Self.design(for: row.capability)
+      let entry = PillCatalog.entry(
+        for: .recording(audioLevel: 0, design: design), id: PresentationID())
+      let definition = try #require(entry.definition, "\(row.capability) produced no definition")
+
+      #expect(
+        definition.requestedWidth == .fixed(row.effectiveWidth),
+        "\(row.capability): the definition's own width is not the width the base revision sized to")
+      #expect(
+        definition.reservesFixedHeight == row.fixedHeight,
+        "\(row.capability): the definition's own height is not what the base revision reserved")
+      #expect(
+        definition.recordingDesign?.canHoldWords == row.usesPreviewLayout,
+        "\(row.capability): the leaf would be told the wrong thing about showing words")
+    }
+  }
+
+  /// The dead literal, asserted as a difference rather than described.
+  ///
+  /// **This is the one row that would have passed before C3a and did not mean
+  /// anything.** The reducer emitted 185 for both capability states; the director
+  /// substituted 400 for one of them. A test reading the reducer saw 185 twice
+  /// and agreed with itself.
+  @Test("the two designs produce genuinely different geometry")
+  func theTwoDesignsDiffer() throws {
+    let classic = try #require(
+      PillCatalog.entry(for: .recording(audioLevel: 0, design: .classic), id: PresentationID())
+        .definition)
+    let readingWell = try #require(
+      PillCatalog.entry(
+        for: .recording(audioLevel: 0, design: .readingWell), id: PresentationID()
+      ).definition)
+
+    #expect(classic.requestedWidth == .fixed(185))
+    #expect(readingWell.requestedWidth == .fixed(400))
+    #expect(classic.reservesFixedHeight == 92)
+    #expect(readingWell.reservesFixedHeight == nil)
+    #expect(classic.requestedWidth != readingWell.requestedWidth)
+  }
+
+  /// The recording pill still announces, and still says the same sentence
+  /// whichever design it wears — the design is a look, not a different event.
+  @Test("both designs announce the frozen recording sentence")
+  func recordingAnnouncementIsDesignIndependent() throws {
+    let frozen = try #require(
+      FrozenPillParity.rows.first { $0.label == "recording" }?.announcement,
+      "the oracle lost the recording announcement")
+
+    for design in RecordingPillDesign.allCases {
+      let entry = PillCatalog.entry(
+        for: .recording(audioLevel: 0, design: design), id: PresentationID())
+      #expect(entry.announcement?.text == frozen.text, "\(design) said something else")
+      #expect(
+        entry.announcement?.isHighPriority == frozen.isHighPriority,
+        "\(design) announced at the wrong priority")
+    }
+  }
+
+  /// The frozen `recording` definition row, which is the classic design's.
+  ///
+  /// It is asserted here rather than in the main parity sweep because that sweep
+  /// is keyed by request and this row needs a design argument the other sixteen
+  /// do not have.
+  @Test("the classic design reproduces the frozen recording definition row")
+  func classicMatchesTheFrozenDefinitionRow() throws {
+    let row = try #require(FrozenPillParity.rows.first { $0.label == "recording" })
+    let entry = PillCatalog.entry(
+      for: .recording(audioLevel: 0, design: .classic), id: PresentationID())
+    let definition = try #require(entry.definition)
+
+    #expect(row.hasDefinition)
+    #expect(row.contentTag == "recording")
+    #expect(row.notice == nil)
+    #expect(definition.requestedWidth == .fixed(185))
+    #expect(definition.reservesFixedHeight == row.fixedHeight)
+    #expect(definition.expiry == .untilReplaced)
+  }
+
+  // MARK: - The selection seam
+
+  /// `resolve` is fail-closed, and the fallback is a value rather than a promise.
+  @Test("a selection that cannot hold words is substituted, and says so")
+  func resolveIsFailClosed() {
+    let bad = PillDesignSelections(withoutWords: .classic, withWords: .classic)
+
+    let withWords = bad.resolve(capabilityHasWords: true)
+    #expect(withWords.design == .readingWell, "a design that cannot hold words was accepted")
+    #expect(withWords.substituted, "the substitution was silent")
+
+    // The same bad pair is FINE without words: nothing is being dropped.
+    let withoutWords = bad.resolve(capabilityHasWords: false)
+    #expect(withoutWords.design == .classic)
+    #expect(withoutWords.substituted == false, "an unnecessary substitution was reported")
+  }
+
+  /// The shipped pair never substitutes, in either state. If it ever does, the
+  /// constant and the designs have drifted apart.
+  @Test("the shipped selections resolve cleanly in both capability states")
+  func shippedSelectionsNeverSubstitute() {
+    for hasWords in [true, false] {
+      let resolution = PillDesignSelections.shipped.resolve(capabilityHasWords: hasWords)
+      #expect(
+        resolution.substituted == false, "the shipped pair substituted at hasWords=\(hasWords)")
+      #expect(resolution.design.canHoldWords == hasWords, "the shipped pair resolved the wrong way")
+    }
+  }
+
+  /// **`canHoldWords` is what provider gating keys off, so it is pinned per
+  /// design rather than inferred.** Reading it off the resolution would make this
+  /// agree with itself.
+  @Test("each design's word capability is what its name promises")
+  func designCapabilities() {
+    #expect(RecordingPillDesign.classic.canHoldWords == false)
+    #expect(RecordingPillDesign.readingWell.canHoldWords)
+    #expect(RecordingPillDesign.allCases.count == 2, "a design was added without a frozen row")
+  }
+}

--- a/Tests/EnviousWisprTests/App/Overlay/PillCatalogRoundTripTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/PillCatalogRoundTripTests.swift
@@ -8,7 +8,7 @@ import Testing
 /// The bijection between `OverlayIntent` and `PillCatalogRequest`, checked
 /// rather than intended (#2375 Phase 3, chunk C2).
 ///
-/// **Two mappings exist and they must agree.** `PillCatalogRequest(pipeline:)`
+/// **Two mappings exist and they must agree.** `PillCatalogRequest(nonRecording:)`
 /// converts an intent into a request; `matchingIntent` converts it back so the
 /// catalog can ask `DictationNarrator` — still the sole author of announcement
 /// TEXT — for the sentence. Written twice, they are a duplicate-authority risk of
@@ -53,11 +53,13 @@ struct PillCatalogRoundTripTests {
   @Test("every intent except recording round-trips through a catalog request")
   func intentRoundTrip() {
     for intent in Self.intents {
-      guard let request = PillCatalogRequest(pipeline: intent) else {
-        // The ONE legal refusal. C3a removes it along with the failability.
+      guard let request = PillCatalogRequest(nonRecording: intent) else {
+        // The ONE legal refusal: recording is permanently outside this
+        // initialiser's domain, because a recording request needs a resolved
+        // design and an intent alone has not resolved one.
         #expect(
           Self.isRecording(intent),
-          "PillCatalogRequest(pipeline:) refused a non-recording intent")
+          "PillCatalogRequest(nonRecording:) refused a non-recording intent")
         continue
       }
       #expect(
@@ -70,7 +72,7 @@ struct PillCatalogRoundTripTests {
   func onlyImportStatusHasNoIntent() {
     #expect(PillCatalogRequest.importStatus(message: "x").matchingIntent == nil)
     for intent in Self.intents where !Self.isRecording(intent) {
-      let request = PillCatalogRequest(pipeline: intent)
+      let request = PillCatalogRequest(nonRecording: intent)
       #expect(request?.matchingIntent != nil, "a pipeline-derived request lost its intent")
     }
   }
@@ -96,7 +98,7 @@ struct PillCatalogRoundTripTests {
     #expect(Set(names) == expected, "an OverlayIntent arm is missing or duplicated")
     #expect(names.count == expected.count, "the intent list contains a duplicate")
 
-    let converted = Self.intents.compactMap { PillCatalogRequest(pipeline: $0) }
+    let converted = Self.intents.compactMap { PillCatalogRequest(nonRecording: $0) }
     #expect(converted.count == 15, "exactly one arm — recording — may refuse conversion")
     #expect(Self.intents.filter(Self.isRecording).count == 1)
   }
@@ -135,7 +137,7 @@ struct PillCatalogRoundTripTests {
   @Test("the staged catalog covers sixteen non-recording requests")
   func stagedCaseCount() {
     let requests: [PillCatalogRequest] =
-      Self.intents.compactMap { PillCatalogRequest(pipeline: $0) } + [.importStatus(message: "x")]
+      Self.intents.compactMap { PillCatalogRequest(nonRecording: $0) } + [.importStatus(message: "x")]
     #expect(requests.count == 16)
 
     // Every one of them resolves, and only `.hidden` empties the slot.
@@ -173,13 +175,18 @@ struct PillCatalogRoundTripTests {
       guard text.hasPrefix("case ") else { return nil }
       return String(text.dropFirst(5).prefix { $0.isLetter || $0.isNumber || $0 == "_" })
     }
+    // **Updated DELIBERATELY by C3a, which is what this guard is for.** It went
+    // red the moment `.recording` was added, which is the designed behaviour: the
+    // set is frozen so a case cannot arrive unnoticed, and unfreezing it is an
+    // edit someone has to make on purpose.
     let expected: Set<String> = [
+      "recording",
       "hidden", "processing", "clipboardFallback", "accessibilityToast", "warning",
       "error", "advisory", "interruption", "passiveChip", "cachingModel",
       "engineReady", "recoveringLastRecording", "recoverySucceeded",
       "bluetoothAwareness", "escapeRecovery", "importStatus",
     ]
-    #expect(Set(names) == expected, "the staged case set changed")
+    #expect(Set(names) == expected, "the catalog case set changed")
     #expect(names.count == expected.count, "a catalog case is duplicated")
   }
 

--- a/Tests/EnviousWisprTests/App/Overlay/PillCatalogRoundTripTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/PillCatalogRoundTripTests.swift
@@ -1,0 +1,190 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprCore
+@testable import EnviousWisprPipeline
+
+/// The bijection between `OverlayIntent` and `PillCatalogRequest`, checked
+/// rather than intended (#2375 Phase 3, chunk C2).
+///
+/// **Two mappings exist and they must agree.** `PillCatalogRequest(pipeline:)`
+/// converts an intent into a request; `matchingIntent` converts it back so the
+/// catalog can ask `DictationNarrator` — still the sole author of announcement
+/// TEXT — for the sentence. Written twice, they are a duplicate-authority risk of
+/// exactly the kind this phase exists to remove, so the agreement is a test
+/// rather than a comment.
+///
+/// **Drift Guard, not Product Outcome.** A failure here means our own two
+/// mappings disagree, which is a fact about the code and not about what a user
+/// sees. The user-facing consequence — the wrong pill, or the wrong sentence — is
+/// `PillCatalogParityTests`.
+@Suite(.tags(.driftGuard))
+struct PillCatalogRoundTripTests {
+
+  /// Every `OverlayIntent` arm, with a payload where it takes one.
+  ///
+  /// **Hand-written and therefore checked for completeness below.** `OverlayIntent`
+  /// is not `CaseIterable` — several arms carry payloads that have no canonical
+  /// value — so this list cannot be derived. An array literal is not exhaustive
+  /// over an enum, and a new arm silently missing from it would leave the whole
+  /// suite passing while covering nothing, so `everyIntentArmIsListed` counts.
+  private static let intents: [OverlayIntent] = [
+    .hidden,
+    .recording(audioLevel: 0),
+    .processing(phase: .transcribing),
+    .clipboardFallback,
+    .accessibilityToast,
+    .warning(reason: .polishFailed),
+    .error(reason: .asrFailed),
+    .advisory(reason: .zeroSignal),
+    .interruption(reason: .deviceRemoved),
+    .passiveChip(
+      payload: LanguageChipPayload(
+        lang: "es", displayName: "Spanish", state: .askToLock, generation: 1)),
+    .cachingModel(engineLabel: "Parakeet"),
+    .engineReady,
+    .recoveringLastRecording,
+    .recoverySucceeded,
+    .bluetoothAwareness,
+    .escapeRecovery(transcriptID: UUID()),
+  ]
+
+  @Test("every intent except recording round-trips through a catalog request")
+  func intentRoundTrip() {
+    for intent in Self.intents {
+      guard let request = PillCatalogRequest(pipeline: intent) else {
+        // The ONE legal refusal. C3a removes it along with the failability.
+        #expect(
+          Self.isRecording(intent),
+          "PillCatalogRequest(pipeline:) refused a non-recording intent")
+        continue
+      }
+      #expect(
+        request.matchingIntent == intent,
+        "the two mappings disagree about this intent")
+    }
+  }
+
+  @Test("import status is the only request with no matching intent")
+  func onlyImportStatusHasNoIntent() {
+    #expect(PillCatalogRequest.importStatus(message: "x").matchingIntent == nil)
+    for intent in Self.intents where !Self.isRecording(intent) {
+      let request = PillCatalogRequest(pipeline: intent)
+      #expect(request?.matchingIntent != nil, "a pipeline-derived request lost its intent")
+    }
+  }
+
+  /// The completeness floor for the hand-written list above.
+  ///
+  /// **Sixteen is a measured count, not a guess**: `PipelineVocabulary.swift`
+  /// declares sixteen `OverlayIntent` arms. Fifteen of them convert to a request;
+  /// the sixteenth is `.recording`, staged out until C3a. Adding an arm to the
+  /// enum without adding it here leaves this red.
+  @Test("all sixteen intent arms are exercised, and fifteen convert")
+  func everyIntentArmIsListed() {
+    // **A COUNT IS NOT A SET, and a count was what this asserted.** Sixteen
+    // entries can contain a duplicate while omitting another arm, so the list
+    // would read complete while covering fifteen. Name them.
+    let names = Self.intents.map(Self.caseName)
+    let expected: Set<String> = [
+      "hidden", "recording", "processing", "clipboardFallback",
+      "accessibilityToast", "warning", "error", "advisory", "interruption",
+      "passiveChip", "cachingModel", "engineReady", "recoveringLastRecording",
+      "recoverySucceeded", "bluetoothAwareness", "escapeRecovery",
+    ]
+    #expect(Set(names) == expected, "an OverlayIntent arm is missing or duplicated")
+    #expect(names.count == expected.count, "the intent list contains a duplicate")
+
+    let converted = Self.intents.compactMap { PillCatalogRequest(pipeline: $0) }
+    #expect(converted.count == 15, "exactly one arm — recording — may refuse conversion")
+    #expect(Self.intents.filter(Self.isRecording).count == 1)
+  }
+
+  /// Exhaustive over `OverlayIntent`, so a new arm fails to compile here as well
+  /// as in the catalog.
+  private static func caseName(_ intent: OverlayIntent) -> String {
+    switch intent {
+    case .hidden: return "hidden"
+    case .recording: return "recording"
+    case .processing: return "processing"
+    case .clipboardFallback: return "clipboardFallback"
+    case .accessibilityToast: return "accessibilityToast"
+    case .warning: return "warning"
+    case .error: return "error"
+    case .advisory: return "advisory"
+    case .interruption: return "interruption"
+    case .passiveChip: return "passiveChip"
+    case .cachingModel: return "cachingModel"
+    case .engineReady: return "engineReady"
+    case .recoveringLastRecording: return "recoveringLastRecording"
+    case .recoverySucceeded: return "recoverySucceeded"
+    case .bluetoothAwareness: return "bluetoothAwareness"
+    case .escapeRecovery: return "escapeRecovery"
+    }
+  }
+
+  /// The catalog's own case count, asserted through a value each case produces
+  /// rather than through a comment claiming a number.
+  ///
+  /// **Sixteen non-recording cases, not seventeen.** `bluetoothAwareness` is a
+  /// pipeline intent AND was minted a second time by the feature reducer; those
+  /// are two routes to one value, and C0 froze both and found them identical. A
+  /// seventeenth non-recording case could only be a second Bluetooth arm, which
+  /// is the duplicate this chunk deletes.
+  @Test("the staged catalog covers sixteen non-recording requests")
+  func stagedCaseCount() {
+    let requests: [PillCatalogRequest] =
+      Self.intents.compactMap { PillCatalogRequest(pipeline: $0) } + [.importStatus(message: "x")]
+    #expect(requests.count == 16)
+
+    // Every one of them resolves, and only `.hidden` empties the slot.
+    let withoutDefinition = requests.filter {
+      PillCatalog.entry(for: $0, id: PresentationID()).definition == nil
+    }
+    #expect(withoutDefinition.count == 1, "only hidden may resolve to no definition")
+    #expect(withoutDefinition.first == .hidden)
+  }
+
+  /// What `stagedCaseCount` cannot see (review r1 finding 3).
+  ///
+  /// **That test counts a list this file builds, so it is a claim about the list
+  /// and not about the enum.** A seventeenth case could be declared in
+  /// `PillCatalogRequest` and every other test here would stay green: nothing in
+  /// the round-trip reaches a case no intent maps to, and the count would still
+  /// read sixteen. Reading the declaration is the only way to ask the enum
+  /// itself.
+  ///
+  /// **Update this set DELIBERATELY.** C3a adds `recording` and this test must go
+  /// red first — that is the point of a freeze. It is a lexical read of a small
+  /// enum this phase owns, and it fails LOUDLY on a mis-parse (an empty or short
+  /// name set cannot equal the expected one), so it has no silent direction.
+  @Test("the staged enum declares exactly the expected cases")
+  func stagedDeclarationSetIsFrozen() throws {
+    let path = "Sources/EnviousWisprAppKit/App/Overlay/PillCatalog.swift"
+    let source = try String(contentsOf: RepoRoot.url.appending(path: path), encoding: .utf8)
+    let start = try #require(
+      source.range(of: "enum PillCatalogRequest: Equatable, Sendable {"),
+      "the request enum was renamed or reshaped")
+    let tail = source[start.upperBound...]
+    let end = try #require(tail.range(of: "\n}"), "the request enum has no closing brace")
+    let names = tail[..<end.lowerBound].split(separator: "\n").compactMap { line -> String? in
+      let text = line.trimmingCharacters(in: .whitespaces)
+      guard text.hasPrefix("case ") else { return nil }
+      return String(text.dropFirst(5).prefix { $0.isLetter || $0.isNumber || $0 == "_" })
+    }
+    let expected: Set<String> = [
+      "hidden", "processing", "clipboardFallback", "accessibilityToast", "warning",
+      "error", "advisory", "interruption", "passiveChip", "cachingModel",
+      "engineReady", "recoveringLastRecording", "recoverySucceeded",
+      "bluetoothAwareness", "escapeRecovery", "importStatus",
+    ]
+    #expect(Set(names) == expected, "the staged case set changed")
+    #expect(names.count == expected.count, "a catalog case is duplicated")
+  }
+
+  private static func isRecording(_ intent: OverlayIntent) -> Bool {
+    if case .recording = intent { return true }
+    return false
+  }
+}

--- a/Tests/EnviousWisprTests/App/Overlay/PillRequestParityTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/PillRequestParityTests.swift
@@ -84,6 +84,7 @@ struct PillRequestParityTests {
           appActions.append(.grantAccessibility)
           grantSawPresentation = director.renderModel.presentation != nil
         },
+        selections: { .shipped },
         deferFirstRender: { $0() })
     }
 

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingDirectorCaptureTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingDirectorCaptureTests.swift
@@ -6,8 +6,8 @@ import Testing
 @testable import EnviousWisprCore
 @testable import EnviousWisprPipeline
 
-/// **Table 3b: what the director captures, and the adapter equivalence that
-/// makes C3b's deletion provable** (#2375 Phase 3, chunk C3a).
+/// **Table 3b: what the director captures and what the resulting composition
+/// drives** (#2375 Phase 3).
 ///
 /// Capability, selections and position are read through callbacks, so "read
 /// once" is a countable fact rather than an argument. Provider gating and the
@@ -35,13 +35,19 @@ struct RecordingDirectorCaptureTests {
     capabilityHasWords: Bool,
     selections: PillDesignSelections = .shipped,
     host: any OverlayWindowHosting = WindowlessOverlayHost(),
+    // **`.bottom`, not `.top`, and that is the whole point of the parameter.**
+    // `.top` is `OverlayRenderModel.recordingPosition`'s own default, so a
+    // director that ignored the captured position entirely would still leave the
+    // model reading `.top` and every assertion would pass. The fixture has to sit
+    // somewhere the default is not.
+    position: OverlayPillPosition = .bottom,
     scheduleReconciliation: @escaping (@escaping () -> Void) -> Void = { $0() }
   ) -> OverlayDirector {
     OverlayDirector(
       host: host,
       position: {
         counts.position += 1
-        return .top
+        return position
       },
       announce: { _ in },
       livePreview: LivePreviewBridge(
@@ -110,53 +116,65 @@ struct RecordingDirectorCaptureTests {
     #expect(counts.position == afterFirst.2, "a morph re-read position")
   }
 
-  // MARK: - Adapter equivalence
+  // MARK: - The frozen geometries, straight from the definition
 
-  /// **The assertion that makes C3b's deletion provably a no-op rather than
-  /// argued to be one.**
+  /// **recordingAdapterMatchesTheAcceptedDefinition was DELETED here** (#2375
+  /// C3b), and the deletion is the plan's own instruction rather than a
+  /// convenience.
   ///
-  /// `OverlayRecordingLayout` survives C3a as a derived adapter. If every field
-  /// it exposes already equals the accepted definition's own, deleting it changes
-  /// nothing — and this is deleted with it.
+  /// It existed to prove that OverlayRecordingLayout said exactly what the
+  /// accepted definition said, so that deleting the layout could be shown to be a
+  /// no-op instead of argued to be one. The layout is now gone. A test comparing
+  /// a value against itself asserts nothing, and keeping it would leave a green
+  /// row that reads as coverage.
+  ///
+  /// What it was really protecting — that the geometry on screen is the FROZEN
+  /// geometry — survives here, now read from the one authority.
   @Test(
-    "the surviving layout adapter agrees with the accepted definition, both designs",
+    "the composed recording carries the frozen geometry for its capability",
     arguments: [false, true])
-  func recordingAdapterMatchesTheAcceptedDefinition(capabilityHasWords: Bool) throws {
+  func composedRecordingMatchesTheFrozenGeometry(capabilityHasWords: Bool) throws {
     let counts = Counts()
-    let d = Self.makeDirector(counts, capabilityHasWords: capabilityHasWords)
+    let host = WindowlessOverlayHost()
+    let d = Self.makeDirector(counts, capabilityHasWords: capabilityHasWords, host: host)
 
     Self.record(d)
 
     let definition = try #require(d.renderModel.presentation, "no recording is showing")
     let design = try #require(definition.recordingDesign, "the accepted pill carries no design")
-    let layout = d.renderModel.recordingLayout
-
-    #expect(
-      definition.requestedWidth == .fixed(layout.width),
-      "the adapter's width disagrees with the definition's")
-    #expect(
-      definition.reservesFixedHeight == layout.fixedHeight,
-      "the adapter's height disagrees with the definition's")
-    #expect(
-      design.canHoldWords == layout.usesPreview,
-      "provider gating and the adapter disagree about showing words")
-    #expect(layout.position == .top, "the adapter did not use the captured position")
-
-    // And the frozen row for this capability is what both of them say.
     let frozen = try #require(
       FrozenPillParity.recordingRows.first {
         $0.capability == (capabilityHasWords ? .withWords : .withoutWords)
       })
+
     #expect(definition.requestedWidth == .fixed(frozen.effectiveWidth))
     #expect(definition.reservesFixedHeight == frozen.fixedHeight)
     #expect(design.canHoldWords == frozen.usesPreviewLayout)
+    // `.bottom` is not the model's default, so this fails against a director that
+    // never installed the captured position at all.
+    #expect(
+      d.renderModel.recordingPosition == .bottom,
+      "the render model did not keep the captured position")
+    // **And the WINDOW was asked for that geometry, which is the thing the user
+    // sees.** The definition carrying the right numbers is necessary and not
+    // sufficient: `geometry(for:)` sits between the definition and the host, and
+    // it is exactly where the deleted override used to substitute its own answer.
+    // Without this the override could come back and every assertion above would
+    // still pass.
+    let asked = try #require(host.presented.last, "the host was never asked to present")
+    #expect(
+      asked.width == .fixed(frozen.effectiveWidth),
+      "the window was sized to something other than the frozen width")
+    #expect(
+      asked.fixedHeight == frozen.fixedHeight,
+      "the window reserved something other than the frozen height")
   }
 
-  /// **Table 3b's actual subject: the CONSUMERS, not the adapter beside them.**
+  /// **Table 3b's actual subject: the CONSUMERS, not field agreement alone.**
   ///
-  /// The equivalence check above compares fields. This drives the two things
-  /// those fields feed — the provider gate and the preview-growth callback — and
-  /// asserts what they do. A pill that cannot hold words must not be reading a
+  /// The geometry check above compares fields. This drives the two things those
+  /// fields feed — the provider gate and the preview-growth callback — and asserts
+  /// what they do. A pill that cannot hold words must not be reading a
   /// live preview at all, and must not resize itself when the content reports a
   /// height.
   @Test(

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingDirectorCaptureTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingDirectorCaptureTests.swift
@@ -1,0 +1,240 @@
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprCore
+@testable import EnviousWisprPipeline
+
+/// **Table 3b: what the director captures, and the adapter equivalence that
+/// makes C3b's deletion provable** (#2375 Phase 3, chunk C3a).
+///
+/// Capability, selections and position are read through callbacks, so "read
+/// once" is a countable fact rather than an argument. Provider gating and the
+/// captured position live on the director and the render model, which is why
+/// this cannot be a reducer test.
+@MainActor
+@Suite(.tags(.productOutcome))
+struct RecordingDirectorCaptureTests {
+
+  /// A counting rig. Every input the transaction reads is a closure that records
+  /// having been asked.
+  private final class Counts {
+    var capability = 0
+    var selections = 0
+    var position = 0
+    var bridge: [Bool] = []
+    /// How many times the live preview DISPLAY provider was actually asked. The
+    /// render model swaps in `{ .off }` when the pill cannot hold words, so this
+    /// counts the real gate rather than a field beside it.
+    var displayReads = 0
+  }
+
+  private static func makeDirector(
+    _ counts: Counts,
+    capabilityHasWords: Bool,
+    selections: PillDesignSelections = .shipped,
+    host: any OverlayWindowHosting = WindowlessOverlayHost(),
+    scheduleReconciliation: @escaping (@escaping () -> Void) -> Void = { $0() }
+  ) -> OverlayDirector {
+    OverlayDirector(
+      host: host,
+      position: {
+        counts.position += 1
+        return .top
+      },
+      announce: { _ in },
+      livePreview: LivePreviewBridge(
+        recordingDidChange: { counts.bridge.append($0) },
+        isEnabledForGeometry: {
+          counts.capability += 1
+          return capabilityHasWords
+        },
+        display: {
+          counts.displayReads += 1
+          return .off
+        }),
+      grantAccessibility: {},
+      selections: {
+        counts.selections += 1
+        return selections
+      },
+      deferFirstRender: { $0() },
+      scheduleReconciliation: scheduleReconciliation)
+  }
+
+  private static func record(_ d: OverlayDirector, level: Float = 0, locked: Bool = false) {
+    d.present(
+      .recording(
+        RecordingPillInput(
+          audioLevel: level,
+          audioLevelProvider: { level },
+          recordingElapsedProvider: { nil },
+          isLocked: locked)))
+  }
+
+  // MARK: - Read once
+
+  @Test(
+    "a fresh recording reads capability, selections and position exactly once",
+    arguments: [false, true])
+  func freshRecordingReadsEachInputOnce(capabilityHasWords: Bool) {
+    let counts = Counts()
+    let d = Self.makeDirector(counts, capabilityHasWords: capabilityHasWords)
+
+    Self.record(d)
+
+    #expect(counts.capability == 1, "capability was read \(counts.capability) times, not once")
+    #expect(counts.selections == 1, "selections were read \(counts.selections) times, not once")
+    #expect(counts.position == 1, "position was read \(counts.position) times, not once")
+  }
+
+  /// **A same-id morph performs no second read**, which is the discipline that
+  /// keeps a live pill from changing design because the user opened Settings
+  /// mid-dictation. An `NSPanel` cannot grow mid-recording without a rebuild, and
+  /// a rebuild is the #930 flicker.
+  @Test("audio-level morphs read nothing at all")
+  func morphsReadNothing() {
+    let counts = Counts()
+    let d = Self.makeDirector(counts, capabilityHasWords: true)
+
+    Self.record(d)
+    let afterFirst = (counts.capability, counts.selections, counts.position)
+
+    for level in [Float(0.2), 0.5, 0.9] {
+      Self.record(d, level: level)
+    }
+
+    #expect(counts.capability == afterFirst.0, "a morph re-read capability")
+    #expect(counts.selections == afterFirst.1, "a morph re-read selections")
+    #expect(counts.position == afterFirst.2, "a morph re-read position")
+  }
+
+  // MARK: - Adapter equivalence
+
+  /// **The assertion that makes C3b's deletion provably a no-op rather than
+  /// argued to be one.**
+  ///
+  /// `OverlayRecordingLayout` survives C3a as a derived adapter. If every field
+  /// it exposes already equals the accepted definition's own, deleting it changes
+  /// nothing — and this is deleted with it.
+  @Test(
+    "the surviving layout adapter agrees with the accepted definition, both designs",
+    arguments: [false, true])
+  func recordingAdapterMatchesTheAcceptedDefinition(capabilityHasWords: Bool) throws {
+    let counts = Counts()
+    let d = Self.makeDirector(counts, capabilityHasWords: capabilityHasWords)
+
+    Self.record(d)
+
+    let definition = try #require(d.renderModel.presentation, "no recording is showing")
+    let design = try #require(definition.recordingDesign, "the accepted pill carries no design")
+    let layout = d.renderModel.recordingLayout
+
+    #expect(
+      definition.requestedWidth == .fixed(layout.width),
+      "the adapter's width disagrees with the definition's")
+    #expect(
+      definition.reservesFixedHeight == layout.fixedHeight,
+      "the adapter's height disagrees with the definition's")
+    #expect(
+      design.canHoldWords == layout.usesPreview,
+      "provider gating and the adapter disagree about showing words")
+    #expect(layout.position == .top, "the adapter did not use the captured position")
+
+    // And the frozen row for this capability is what both of them say.
+    let frozen = try #require(
+      FrozenPillParity.recordingRows.first {
+        $0.capability == (capabilityHasWords ? .withWords : .withoutWords)
+      })
+    #expect(definition.requestedWidth == .fixed(frozen.effectiveWidth))
+    #expect(definition.reservesFixedHeight == frozen.fixedHeight)
+    #expect(design.canHoldWords == frozen.usesPreviewLayout)
+  }
+
+  /// **Table 3b's actual subject: the CONSUMERS, not the adapter beside them.**
+  ///
+  /// The equivalence check above compares fields. This drives the two things
+  /// those fields feed — the provider gate and the preview-growth callback — and
+  /// asserts what they do. A pill that cannot hold words must not be reading a
+  /// live preview at all, and must not resize itself when the content reports a
+  /// height.
+  @Test(
+    "provider gating and preview growth follow the captured design",
+    arguments: [false, true])
+  func providersFollowTheCapturedDesign(capabilityHasWords: Bool) {
+    let counts = Counts()
+    let host = WindowlessOverlayHost()
+    let d = Self.makeDirector(counts, capabilityHasWords: capabilityHasWords, host: host)
+
+    Self.record(d)
+    _ = d.renderModel.livePreviewProvider()
+    d.renderModel.onContentHeightChange(123)
+
+    #expect(
+      counts.displayReads == (capabilityHasWords ? 1 : 0),
+      "a pill that cannot hold words was still reading the live preview")
+    #expect(
+      host.resizes == (capabilityHasWords ? [CGSize(width: 400, height: 123)] : []),
+      "preview growth did not follow the captured design")
+  }
+
+  /// **The discriminating pairing: a with-words DESIGN under a without-words
+  /// CAPABILITY.**
+  ///
+  /// The case above uses the shipped selections, where design and capability move
+  /// together — so it passes just as well against consumers that gate directly on
+  /// capability, which is the arrangement this whole phase exists to remove.
+  /// Separating them is the only way to tell which one the consumers actually
+  /// follow.
+  @Test("reading well drives its consumers even without word capability")
+  func consumersFollowDesignRatherThanCapability() {
+    let counts = Counts()
+    let host = WindowlessOverlayHost()
+    let selections = PillDesignSelections(withoutWords: .readingWell, withWords: .readingWell)
+    let d = Self.makeDirector(
+      counts, capabilityHasWords: false, selections: selections, host: host)
+
+    Self.record(d)
+    #expect(d.renderModel.presentation?.recordingDesign == .readingWell)
+    _ = d.renderModel.livePreviewProvider()
+    d.renderModel.onContentHeightChange(123)
+
+    #expect(counts.displayReads == 1, "the consumers gated on capability, not on the design")
+    #expect(
+      host.resizes == [CGSize(width: 400, height: 123)],
+      "preview growth followed capability rather than the captured design")
+  }
+
+  // MARK: - The bridge
+
+  /// The effect reaches Live Preview BEFORE capability is read. That ordering is
+  /// the reason the transaction exists, and reading the counter at the moment the
+  /// capability closure runs is the only way to observe it.
+  @Test("the recording effect is routed before capability is read")
+  func effectPrecedesTheCapabilityRead() {
+    let counts = Counts()
+    var bridgeAtCapabilityRead: [Bool] = []
+    let d = OverlayDirector(
+      host: WindowlessOverlayHost(),
+      position: { .top },
+      announce: { _ in },
+      livePreview: LivePreviewBridge(
+        recordingDidChange: { counts.bridge.append($0) },
+        isEnabledForGeometry: {
+          bridgeAtCapabilityRead = counts.bridge
+          return true
+        },
+        display: { .off }),
+      grantAccessibility: {},
+      selections: { .shipped },
+      deferFirstRender: { $0() })
+
+    Self.record(d)
+
+    #expect(
+      bridgeAtCapabilityRead == [true],
+      "capability was read before the bridge was told a recording started — the ordering that gives a preview-sized window with no preview in it"
+    )
+  }
+}

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingReconciliationTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingReconciliationTests.swift
@@ -1,0 +1,405 @@
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprCore
+@testable import EnviousWisprPipeline
+
+/// **The bounded bridge reconciliation** (#2375 Phase 3, chunk C3a).
+///
+/// RESOLVE routes `.recordingStateChanged(true)` before COMMIT, because the
+/// effect must precede the capability read. If COMMIT then discards the token,
+/// Live Preview has been told a recording started and no recording definition
+/// ever became current — the bridge is left active with nothing behind it.
+///
+/// The fix has to converge without spinning: routing calls back into the same
+/// boundary that created the hazard, so reading the answer before the call proves
+/// nothing about the answer after it, while an unbounded synchronous loop would
+/// spin on the RECORDING path.
+@MainActor
+@Suite(.tags(.productOutcome))
+struct RecordingReconciliationTests {
+
+  /// A scheduler that queues rather than running, so the BOUND is observable
+  /// before anything drains it.
+  private final class Queue {
+    var pending: [() -> Void] = []
+    var enqueued = 0
+
+    func schedule(_ work: @escaping () -> Void) {
+      enqueued += 1
+      pending.append(work)
+    }
+
+    /// Run everything currently queued, once. Work scheduled BY that work lands
+    /// back in `pending` for the next drain, which is what lets a test watch the
+    /// chain advance one turn at a time.
+    @discardableResult
+    func drainOnce() -> Int {
+      let batch = pending
+      pending = []
+      batch.forEach { $0() }
+      return batch.count
+    }
+  }
+
+  /// Drives a fresh recording whose COMMIT is guaranteed to be discarded, by
+  /// reentering a winning event from inside the capability read — the exact
+  /// window §3.4 opens.
+  private static func makeDirector(
+    queue: Queue,
+    bridge: @escaping (Bool) -> Void,
+    host: any OverlayWindowHosting = WindowlessOverlayHost(),
+    announce: @escaping @MainActor (OverlayAnnouncement) -> Void = { _ in },
+    selections: @escaping @MainActor () -> PillDesignSelections = { .shipped },
+    onCapabilityRead: @escaping () -> Void
+  ) -> OverlayDirector {
+    OverlayDirector(
+      host: host,
+      position: { .top },
+      announce: announce,
+      livePreview: LivePreviewBridge(
+        recordingDidChange: bridge,
+        isEnabledForGeometry: {
+          onCapabilityRead()
+          return false
+        },
+        display: { .off }),
+      grantAccessibility: {},
+      selections: selections,
+      deferFirstRender: { $0() },
+      scheduleReconciliation: { queue.schedule($0) })
+  }
+
+  /// **Each churn step must present something DIFFERENT.** The reducer's dedup
+  /// guard drops a repeated intent, so presenting the same warning twice moves
+  /// the slot once and the loop converges on the second attempt — the churn stops
+  /// churning and the bound is never reached. A row that cannot exercise the
+  /// behaviour it names is worse than no row: it passes, and reads as coverage.
+  private static let churnEvents: [PillRequest] = [
+    .warning(reason: .polishFailed),
+    .error(reason: .asrFailed),
+    .interruption(reason: .deviceRemoved),
+    .advisory(reason: .zeroSignal),
+    .warning(reason: .historySaveFailed(reason: "x")),
+    .engineReady,
+  ]
+
+  private static func record(_ d: OverlayDirector) {
+    d.present(
+      .recording(
+        RecordingPillInput(
+          audioLevel: 0, audioLevelProvider: { 0 },
+          recordingElapsedProvider: { nil }, isLocked: false)))
+  }
+
+  // MARK: - A discarded transition still tells the bridge the truth
+
+  /// **Assert the BRIDGE, not only the reducer.** A test that checks reducer and
+  /// host state alone passes while Live Preview is left running behind nothing.
+  @Test("a discarded recording followed by a non-recording winner ends with the bridge told false")
+  func discardedTransitionReconcilesTheBridgeToFalse() {
+    let queue = Queue()
+    var bridge: [Bool] = []
+    var announcements: [OverlayAnnouncement] = []
+    var capabilityReads = 0
+    let host = WindowlessOverlayHost()
+    var director: OverlayDirector?
+    // A local rather than a static: a `static var` here is shared mutable state
+    // across every run of the suite, so a second run would find it already
+    // spent and the reentrant winner would never fire.
+    var winnerFired = false
+
+    let d = Self.makeDirector(
+      queue: queue,
+      bridge: { bridge.append($0) },
+      host: host,
+      announce: { announcements.append($0) },
+      onCapabilityRead: {
+        capabilityReads += 1
+        // The reentrant winner: a terminal notice takes the slot while the
+        // recording is still resolving. Fired ONCE, so the reconciliation
+        // converges rather than churning.
+        guard let director, !winnerFired else { return }
+        winnerFired = true
+        _ = director.present(.error(reason: .asrFailed))
+      })
+    director = d
+
+    Self.record(d)
+
+    // **The whole SEQUENCE, not just its last element.** `bridge.last == false`
+    // is also true of a discard that skipped reconciliation entirely and simply
+    // never told the bridge anything after the winner took the slot. The sequence
+    // names what happened: the prepared recording's effect, then exactly one
+    // reconciliation route to the winner — which also binds the stable-path rule
+    // that reconciliation stops after its first unchanged read-route-reread pass.
+    #expect(
+      bridge == [true, false],
+      "expected the prepared recording effect followed by one reconciliation to the winner")
+    #expect(
+      d.renderModel.presentation?.recordingDesign == nil,
+      "the stale recording reached the screen")
+
+    // **The discarded definition is commit-free, render-free, announcement-free
+    // and retry-free**, and each of those is a claim the plan makes that nothing
+    // was binding. Not "mint-free": RESOLVE already asked the catalog for the
+    // definition, which is what makes the discard cheap rather than absent. A
+    // discard that quietly retried, or that spoke, would have passed the three
+    // assertions above.
+    #expect(capabilityReads == 1, "the stale transaction was retried")
+    #expect(host.presented.count == 1, "the stale recording reached the host")
+    #expect(
+      announcements.map(\.text) == ["Error: Transcription error. Try again."],
+      "the discarded recording announced, or displaced the winner's announcement")
+  }
+
+  /// **The other direction, and a suite with only the first half is half a
+  /// claim.** A discarded transition followed by a newer NON-RECORDING winner must
+  /// end with the bridge told false; followed by a newer RECORDING winner it must
+  /// end told true. A reconciliation that simply always said false would pass the
+  /// case above and leave Live Preview dark through a live dictation.
+  @Test("a discarded recording followed by a newer recording leaves the bridge true")
+  func newerRecordingWins() {
+    let queue = Queue()
+    var bridge: [Bool] = []
+    var director: OverlayDirector?
+    var reentered = false
+    var selectionReads = 0
+
+    // **The two transitions must be DISTINGUISHABLE, and an earlier version made
+    // them identical.** Both were fresh recordings under the shipped selections,
+    // so both resolved to the same design — and if the stale outer transition
+    // overwrote the newer inner one the test still saw a recording and a `true`
+    // bridge. It could not tell which one survived, which is the only thing it
+    // exists to say.
+    //
+    // The INNER transition resolves first, to reading well; the stale outer one
+    // resolves second, to classic. The design on screen names the winner.
+    let d = Self.makeDirector(
+      queue: queue,
+      bridge: { bridge.append($0) },
+      selections: {
+        selectionReads += 1
+        return selectionReads == 1
+          ? PillDesignSelections(withoutWords: .readingWell, withWords: .readingWell)
+          : .shipped
+      },
+      onCapabilityRead: {
+        // The reentrant winner is another RECORDING, so the slot ends up holding
+        // one even though the first transition was discarded.
+        guard let director, !reentered else { return }
+        reentered = true
+        Self.record(director)
+      })
+    director = d
+
+    Self.record(d)
+
+    // Both recording effects, then the discriminating reconciliation route. The
+    // THIRD element is the one that proves reconciliation ran at all: without it
+    // the first two alone already leave `bridge.last == true`, so a discard that
+    // skipped reconciliation entirely would have passed.
+    #expect(
+      bridge == [true, true, true],
+      "expected both recording effects followed by reconciliation to the newer recording")
+    #expect(selectionReads == 2, "both transitions were not resolved")
+    #expect(
+      d.renderModel.presentation?.recordingDesign == .readingWell,
+      "the stale outer recording overwrote the newer recording")
+  }
+
+  // MARK: - The bound
+
+  /// **The counts are asserted BEFORE the queue is drained, and that ordering is
+  /// what makes the case discriminating.** Drained first, a bounded and an
+  /// unbounded implementation both end up converged and both pass; checked first,
+  /// the unbounded one has already run the third route synchronously while the
+  /// bounded one shows two attempts and one queued continuation.
+  @Test("sustained churn yields after two synchronous attempts with exactly one continuation")
+  func theLoopIsBounded() {
+    let queue = Queue()
+    var routes = 0
+    var bridge: [Bool] = []
+    var director: OverlayDirector?
+    var churnBudget = 4
+
+    let d = Self.makeDirector(
+      queue: queue,
+      bridge: { value in
+        routes += 1
+        bridge.append(value)
+        // **The FIRST bridge call is the recording effect itself, not a
+        // reconciliation route, and it must not spend a churn step.** It did, so
+        // only two churn steps survived: the loop hit its bound, queued one
+        // continuation, and that continuation found the world already still. The
+        // unstable-continuation path — the one that re-enqueues — was never
+        // executed, and the test passed.
+        //
+        // Every route after that changes the slot again, each with a DIFFERENT
+        // request, or the dedup guard drops the repeat and the churn stops before
+        // the bound is reached.
+        guard routes > 1, let director, churnBudget > 0 else { return }
+        _ = director.present(Self.churnEvents[churnBudget % Self.churnEvents.count])
+        churnBudget -= 1
+      },
+      onCapabilityRead: {
+        guard let director else { return }
+        _ = director.present(.error(reason: .asrFailed))
+      })
+    director = d
+
+    Self.record(d)
+
+    // BEFORE draining.
+    #expect(
+      routes == 3,
+      "expected the initial effect plus two synchronous attempts, saw \(routes) routes")
+    #expect(
+      queue.enqueued == 1,
+      "expected exactly one queued continuation, saw \(queue.enqueued) — an unbounded loop would have run them all synchronously and queued none")
+    #expect(queue.pending.count == 1, "a duplicate continuation was enqueued")
+
+    // **The FIRST drain must leave another continuation queued**, which is what
+    // proves the unstable path re-enqueues rather than giving up. Without this
+    // the chain's own recursion is never executed.
+    queue.drainOnce()
+    #expect(
+      queue.pending.count == 1,
+      "the continuation found the world still moving and did not schedule a successor")
+
+    var turns = 0
+    while !queue.pending.isEmpty, turns < 8 {
+      queue.drainOnce()
+      turns += 1
+    }
+    #expect(queue.pending.isEmpty, "the reconciliation never converged")
+    // And the last thing the bridge heard matches what is actually on screen.
+    #expect(
+      bridge.last == (d.renderModel.presentation?.recordingDesign != nil),
+      "the bridge and the screen disagree about whether a recording is up")
+  }
+
+  /// **A pass that CONVERGES must not reopen the gate while a continuation is
+  /// still queued**, which is the one thing the coalescing flag exists to
+  /// prevent.
+  ///
+  /// Three discards, and the THIRD is the discriminating one: the first queues a
+  /// continuation, the second converges synchronously — which is where the old
+  /// implementation wrongly cleared the flag — and the third is what observes
+  /// whether the gate was reopened.
+  ///
+  /// This case exists because the review that found the flag defect could not be
+  /// bound by anything already here: every other case stages ONE discard, and the
+  /// defect needs a second one arriving inside the window where a continuation is
+  /// pending. A fix nothing can fail is a fix nobody can keep.
+  ///
+  /// The defect it pins: the synchronous pass used to clear the flag on
+  /// convergence even when it had not set it, and the continuation used to clear
+  /// it before recursing — either leaves the guard open with work still queued.
+  @Test("a converged reconciliation cannot reopen the gate while a continuation is queued")
+  func aConvergedPassDoesNotReopenTheGate() {
+    let queue = Queue()
+    var routes = 0
+    var director: OverlayDirector?
+    var churnBudget = 4
+
+    let d = Self.makeDirector(
+      queue: queue,
+      bridge: { _ in
+        routes += 1
+        guard routes > 1, let director, churnBudget > 0 else { return }
+        _ = director.present(Self.churnEvents[churnBudget % Self.churnEvents.count])
+        churnBudget -= 1
+      },
+      onCapabilityRead: {
+        // Every fresh recording is overtaken, so every one of them discards.
+        guard let director else { return }
+        _ = director.present(.error(reason: .asrFailed))
+      })
+    director = d
+
+    Self.record(d)
+    #expect(queue.pending.count == 1, "the first discard did not queue a continuation")
+    let afterFirst = queue.enqueued
+
+    // **A SECOND discard that CONVERGES synchronously, and the convergence is the
+    // whole point.** My first version made this one churn too, so the old
+    // implementation never reached the line that wrongly cleared the flag — the
+    // case passed against the very defect it was written to bind. The old
+    // synchronous pass cleared on convergence, so this is where it opened the
+    // gate while the first continuation was still queued.
+    churnBudget = 0
+    routes = 0
+    Self.record(d)
+
+    // A THIRD discard, which would find the gate open if the second reopened it.
+    _ = d.present(.engineReady)
+    churnBudget = 4
+    routes = 0
+    Self.record(d)
+
+    #expect(
+      queue.pending.count == 1,
+      "a duplicate continuation was enqueued while one was already pending")
+    #expect(
+      queue.enqueued == afterFirst,
+      "the third discard enqueued again — the converged second reconciliation reopened the gate")
+
+    var turns = 0
+    while !queue.pending.isEmpty, turns < 12 {
+      queue.drainOnce()
+      turns += 1
+    }
+    #expect(queue.pending.isEmpty, "the chain never converged")
+  }
+
+  /// **Then close the flag.** Without this the suite passes against a flag that is
+  /// set once and never cleared — precisely the permanent mute the state machine
+  /// exists to prevent. Asserted as an OUTCOME: a second, independent
+  /// reconciliation must be able to enqueue and complete.
+  @Test("after convergence a second reconciliation can still enqueue and complete")
+  func theFlagClosesAfterConvergence() {
+    let queue = Queue()
+    var director: OverlayDirector?
+    var churnBudget = 3
+
+    let d = Self.makeDirector(
+      queue: queue,
+      bridge: { _ in
+        guard let director, churnBudget > 0 else { return }
+        _ = director.present(Self.churnEvents[churnBudget % Self.churnEvents.count])
+        churnBudget -= 1
+      },
+      onCapabilityRead: {
+        guard let director else { return }
+        _ = director.present(.error(reason: .asrFailed))
+      })
+    director = d
+
+    Self.record(d)
+    var turns = 0
+    while !queue.pending.isEmpty, turns < 8 {
+      queue.drainOnce()
+      turns += 1
+    }
+    let afterFirst = queue.enqueued
+    #expect(queue.pending.isEmpty, "the first reconciliation never converged")
+
+    // A SECOND, independent churn.
+    churnBudget = 3
+    Self.record(d)
+
+    #expect(
+      queue.enqueued > afterFirst,
+      "a second reconciliation could not enqueue — the coalescing flag was never cleared, so it is a permanent mute rather than coalescing")
+
+    turns = 0
+    while !queue.pending.isEmpty, turns < 8 {
+      queue.drainOnce()
+      turns += 1
+    }
+    #expect(queue.pending.isEmpty, "the second reconciliation never converged")
+  }
+}

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingReconciliationTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingReconciliationTests.swift
@@ -402,4 +402,93 @@ struct RecordingReconciliationTests {
     }
     #expect(queue.pending.isEmpty, "the second reconciliation never converged")
   }
+
+  // MARK: - The receipt names what the slot holds
+
+  /// **A discarded recording must not be handed the winner's receipt**
+  /// (#2404 cloud review, P2).
+  ///
+  /// `admit` refuses to return the incumbent's receipt for a stated reason: a
+  /// caller holding a receipt calls `isCurrent` about it and dismisses it, so
+  /// naming somebody else's pill lets one presenter dismiss another's. The
+  /// recording arm was written as an exception to that guard, justified by a
+  /// same-id MORPH keeping the identity it was created with. That is true of a
+  /// morph and false of a recording that never committed — and the discard staged
+  /// by the rest of this suite is exactly such a recording.
+  ///
+  /// The assertion is on WHICH pill the receipt names. A receipt naming the
+  /// recording would be correct; the defect is a receipt naming the terminal
+  /// notice that won the slot, which the recording caller can then dismiss.
+  @Test("a discarded recording is not handed the winner's receipt")
+  func discardedRecordingDoesNotInheritTheWinnersReceipt() throws {
+    let queue = Queue()
+    var director: OverlayDirector?
+    var winnerFired = false
+    var winnerReceipt: PillReceipt?
+
+    let d = Self.makeDirector(
+      queue: queue,
+      bridge: { _ in },
+      onCapabilityRead: {
+        guard let director, !winnerFired else { return }
+        winnerFired = true
+        winnerReceipt = director.present(.error(reason: .asrFailed))
+      })
+    director = d
+
+    var results: [PillPresentationResult] = []
+    let recordingReceipt = d.present(
+      .recording(
+        RecordingPillInput(
+          audioLevel: 0, audioLevelProvider: { 0 },
+          recordingElapsedProvider: { nil }, isLocked: false)),
+      onResult: { results.append($0) })
+
+    // **The fixture asserts it reached its subject before the claim is read.**
+    // A recording that quietly committed would leave a recording pill current,
+    // and every assertion below would then be about the wrong scenario.
+    #expect(winnerFired, "the reentrant winner never fired, so nothing was discarded")
+    // A terminal notice renders as `.notice`; a committed recording would render
+    // as `.recording`. This is the line that separates "the recording was
+    // discarded" from "the recording quietly won", and every claim below is
+    // about the wrong scenario without it.
+    guard case .notice? = d.renderModel.presentation?.content else {
+      Issue.record(
+        "the winner did not take the slot, so the recording was never discarded: \(String(describing: d.renderModel.presentation?.content))")
+      return
+    }
+    let winner = try #require(winnerReceipt, "the winner was itself refused, so it owns no receipt to inherit")
+    #expect(
+      d.renderModel.presentation?.id == winner.presentationID,
+      "the pill on screen is not the winner, so this fixture is staging something else")
+
+    #expect(
+      recordingReceipt == nil,
+      "the discarded recording was handed a receipt naming \(String(describing: recordingReceipt?.presentationID))")
+    #expect(results == [.notPresented], "the discarded recording was told it was presented")
+  }
+
+  /// The paired accepted case, in the same rig with the winner disarmed. Without
+  /// it, a director that returned nil for every recording receipt would satisfy
+  /// the case above.
+  @Test("an accepted recording still receives its own receipt")
+  func acceptedRecordingStillReceivesItsOwnReceipt() throws {
+    let queue = Queue()
+    let d = Self.makeDirector(queue: queue, bridge: { _ in }, onCapabilityRead: {})
+
+    var results: [PillPresentationResult] = []
+    let receipt = try #require(
+      d.present(
+        .recording(
+          RecordingPillInput(
+            audioLevel: 0, audioLevelProvider: { 0 },
+            recordingElapsedProvider: { nil }, isLocked: false)),
+        onResult: { results.append($0) }))
+
+    guard case .recording? = d.renderModel.presentation?.content else {
+      Issue.record("no recording pill reached the screen, so the receipt names something else")
+      return
+    }
+    #expect(results == [.presented(receipt)], "an accepted recording was not reported presented")
+  }
 }

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingTransactionTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingTransactionTests.swift
@@ -1,0 +1,274 @@
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprCore
+@testable import EnviousWisprPipeline
+
+/// **Table 3a and Table 3ab: the recording transaction** (#2375 Phase 3, chunk
+/// C3a).
+///
+/// Two properties, and they pull in opposite directions. A prepared transition
+/// must survive events that cannot conflict with it, or a rare reentrancy becomes
+/// a dictation that shows nothing — and `CLAUDE.md` puts "dictation works 100% of
+/// the time it physically can" above every other audio decision. It must be
+/// discarded by events that CAN conflict, or an older pill overwrites a newer
+/// one.
+@Suite(.tags(.productOutcome))
+struct RecordingTransactionTests {
+
+  private static func reducerWithLiveRecording(
+    design: RecordingPillDesign = .classic
+  ) -> OverlayReducer {
+    var r = OverlayReducer()
+    r.startRecordingForTests(audioLevel: 0.3, design: design)
+    return r
+  }
+
+  // MARK: - Table 3a — morph preservation
+
+  /// **Every same-id morph preserves the resolved design.** Without this a
+  /// hands-free lock could silently drop a live pill back to the other design's
+  /// geometry mid-recording, which is a visible resize the user did not ask for.
+  ///
+  /// The design is part of the recording content case, so a morph that dropped it
+  /// would not compile — this asserts the OUTCOME anyway, because "it compiles"
+  /// is a claim about the code and this is a claim about the pill.
+  @Test(
+    "all five morphs preserve identity, design and geometry",
+    arguments: RecordingPillDesign.allCases)
+  func morphsPreserveDesign(design: RecordingPillDesign) throws {
+    var r = Self.reducerWithLiveRecording(design: design)
+    let original = try #require(r.state.current)
+
+    func check(_ plan: OverlayPlan, _ what: String) throws {
+      let after = try #require(plan.presentation, "\(what) produced no presentation")
+      #expect(after.id == original.id, "\(what) changed the presentation id")
+      #expect(after.recordingDesign == design, "\(what) dropped the resolved design")
+      #expect(after.requestedWidth == original.requestedWidth, "\(what) changed the width")
+      #expect(
+        after.reservesFixedHeight == original.reservesFixedHeight,
+        "\(what) changed the reserved height")
+    }
+
+    // 1. audio level
+    try check(r.startRecordingForTests(audioLevel: 0.9, design: design), "an audio-level morph")
+    // 2. hands-free lock on
+    try check(r.reduce(.lockStateChanged(true)), "locking")
+    // 3. lock off
+    try check(r.reduce(.lockStateChanged(false)), "unlocking")
+    // 4. in-panel notice arriving
+    try check(
+      r.reduce(.inPanelNotice(.approachingCap, dismissAfter: nil)), "an in-panel notice")
+    // 5. that notice clearing
+    let id = try #require(r.state.current?.id)
+    try check(r.reduce(.inPanelNoticeExpiryFired(id)), "an in-panel notice clearing")
+  }
+
+  /// The morph path reads NOTHING: no capability, no selections, no position. It
+  /// cannot, because it never reaches RESOLVE.
+  @Test("a morph is reported as a morph, never as a fresh preparation")
+  func morphSkipsPrepare() {
+    var r = Self.reducerWithLiveRecording()
+    switch r.prepareRecording(audioLevel: 0.7) {
+    case .morphed(let plan):
+      #expect(plan.presentation?.recordingDesign == .classic)
+    case .prepared:
+      Issue.record(
+        "a live recording was treated as a fresh one, so its design would be re-resolved")
+    case .refused:
+      Issue.record("a live recording refused its own audio-level update")
+    }
+  }
+
+  // MARK: - PREPARE mutates nothing
+
+  /// **A caller that prepares and never commits leaves the reducer as it found
+  /// it.** That is what makes a discard safe rather than merely tidy.
+  @Test("preparing a fresh recording publishes nothing and mutates nothing")
+  func prepareIsPure() throws {
+    var r = OverlayReducer()
+    _ = r.reduce(.pipeline(.engineReady))
+    let before = r.state.current
+    let revisionBefore = r.recordingReconciliationSnapshot.revision
+
+    guard case .prepared(let token) = r.prepareRecording(audioLevel: 0.4) else {
+      Issue.record("expected a fresh preparation")
+      return
+    }
+
+    #expect(r.state.current == before, "PREPARE changed the slot")
+    #expect(
+      r.recordingReconciliationSnapshot.revision == revisionBefore,
+      "PREPARE advanced the slot revision, so it would invalidate its own token")
+    #expect(
+      token.effects.contains(.recordingStateChanged(true)),
+      "the bridge would never be told the recording started")
+  }
+
+  // MARK: - Table 3ab — the invalidated transition
+
+  /// **Assert the OUTCOME — which definition is current — never a flag saying the
+  /// token was invalidated.** A flag is satisfied by a token that was marked and
+  /// committed anyway.
+  @Test("a newer event between PREPARE and COMMIT discards the older transition")
+  func reentrantEventDiscardsTheStaleTransition() throws {
+    var r = OverlayReducer()
+    guard case .prepared(let token) = r.prepareRecording(audioLevel: 0.4) else {
+      Issue.record("expected a fresh preparation")
+      return
+    }
+
+    // The reentrant winner: a terminal notice takes the slot while the recording
+    // is still being resolved.
+    let winner = r.reduce(.pipeline(.error(reason: .asrFailed)))
+    let winningDefinition = try #require(winner.presentation)
+
+    let entry = PillCatalog.entry(
+      for: .recording(audioLevel: token.audioLevel, design: .classic), id: token.id)
+    let committed = r.commitRecording(token, definition: try #require(entry.definition))
+
+    #expect(committed == nil, "the stale transition was committed over a newer event")
+    #expect(
+      r.state.current == winningDefinition,
+      "the newer event's pill is not the one on screen")
+    #expect(r.state.current?.id != token.id, "the stale token's identity reached the slot")
+  }
+
+  /// **The narrowing, asserted from the surviving side.** A lock-only change
+  /// cannot conflict with a fresh recording, so it may not discard one — the
+  /// alternative is a recording pill that never appears.
+  ///
+  /// Hover is tested separately, against an incumbent retained during PREPARE.
+  ///
+  /// **An earlier version of this comment claimed hover could not occur in this
+  /// window at all, on the reasoning that a PREPARED transition has published no
+  /// presentation to hover over.** That is false and `prepareIsPure` above
+  /// disproves it in the same file: PREPARE mutates nothing, so whatever occupied
+  /// the slot is still there and still hoverable.
+  @Test("a lock-only change does NOT invalidate a prepared recording")
+  func lockOnlyChangeDoesNotInvalidate() throws {
+    var r = OverlayReducer()
+    guard case .prepared(let token) = r.prepareRecording(audioLevel: 0.4) else {
+      Issue.record("expected a fresh preparation")
+      return
+    }
+    _ = r.reduce(.lockStateChanged(true))
+
+    let entry = PillCatalog.entry(
+      for: .recording(audioLevel: token.audioLevel, design: .classic), id: token.id)
+    let plan = r.commitRecording(token, definition: try #require(entry.definition))
+    #expect(plan != nil, "a lock-only change discarded a recording it cannot conflict with")
+    #expect(r.state.current?.id == token.id, "a lock-only change cost the user their pill")
+  }
+
+  /// The other half of the narrowing, against the incumbent PREPARE leaves in
+  /// place.
+  @Test("hovering the incumbent does not invalidate a prepared recording")
+  func incumbentHoverDoesNotInvalidate() throws {
+    var r = OverlayReducer()
+    // **A HOVER-PAUSABLE incumbent, and that is the whole fixture.** `.engineReady`
+    // has `pausesOnHover: false`, so `reduceHover` returns `.noChange` and the
+    // hover never happens — this case passed with hover handling entirely broken.
+    // Escape Recovery pauses on hover, so the event is genuinely accepted.
+    let incumbent = try #require(
+      r.reduce(.pipeline(.escapeRecovery(transcriptID: UUID()))).presentation)
+    guard case .prepared(let token) = r.prepareRecording(audioLevel: 0.4) else {
+      Issue.record("expected a fresh preparation")
+      return
+    }
+
+    let hover = r.reduce(.hoverChanged(incumbent.id, true))
+    #expect(r.state.isHovered, "the fixture never entered the hovered state")
+    #expect(hover.expiryCommand == .cancel, "the hover event was not accepted")
+
+    let definition = try #require(
+      PillCatalog.entry(
+        for: .recording(audioLevel: token.audioLevel, design: .classic), id: token.id
+      ).definition)
+
+    #expect(
+      r.commitRecording(token, definition: definition) != nil,
+      "a hover on the incumbent discarded a recording it cannot conflict with")
+    #expect(r.state.current?.id == token.id, "the hover cost the user their recording pill")
+  }
+
+  /// **COMMIT reads the CURRENT lock, not one captured at PREPARE.** That is what
+  /// makes the narrowing above safe rather than merely defensible: a lock arriving
+  /// inside the window is preserved in the pill that commits.
+  @Test("a lock arriving inside the window is applied to the committed pill")
+  func lockInsideTheWindowIsPreserved() throws {
+    var r = OverlayReducer()
+    guard case .prepared(let token) = r.prepareRecording(audioLevel: 0.4) else {
+      Issue.record("expected a fresh preparation")
+      return
+    }
+    _ = r.reduce(.lockStateChanged(true))
+
+    let entry = PillCatalog.entry(
+      for: .recording(audioLevel: token.audioLevel, design: .classic), id: token.id)
+    _ = r.commitRecording(token, definition: try #require(entry.definition))
+
+    guard case .recording(_, let isLocked, _, _)? = r.state.current?.content else {
+      Issue.record("no recording is current")
+      return
+    }
+    #expect(isLocked, "hands-free lock was lost by the transaction that raced it")
+  }
+
+  /// A slot change DOES invalidate, and this is the paired half of the narrowing.
+  @Test("a slot change between PREPARE and COMMIT does invalidate")
+  func slotChangeInvalidates() throws {
+    var r = OverlayReducer()
+    guard case .prepared(let token) = r.prepareRecording(audioLevel: 0.4) else {
+      Issue.record("expected a fresh preparation")
+      return
+    }
+    _ = r.reduce(.pipeline(.engineReady))
+
+    let entry = PillCatalog.entry(
+      for: .recording(audioLevel: token.audioLevel, design: .classic), id: token.id)
+    #expect(
+      r.commitRecording(token, definition: try #require(entry.definition)) == nil,
+      "a real slot conflict was committed over")
+  }
+
+  // MARK: - The reconciliation snapshot
+
+  /// The snapshot is what the bounded loop reads, so it must actually track the
+  /// two things the loop compares.
+  @Test("the reconciliation snapshot tracks the slot and whether a recording is up")
+  func snapshotTracksTheWorld() {
+    var r = OverlayReducer()
+    let idle = r.recordingReconciliationSnapshot
+    #expect(idle.isRecording == false)
+
+    r.startRecordingForTests(audioLevel: 0.2)
+    let recording = r.recordingReconciliationSnapshot
+    #expect(recording.isRecording, "a live recording is not reported as one")
+    #expect(recording.revision != idle.revision, "taking the slot did not move the revision")
+
+    _ = r.reduce(.pipeline(.hidden))
+    let after = r.recordingReconciliationSnapshot
+    #expect(after.isRecording == false, "an emptied slot still reports a recording")
+    #expect(after.revision != recording.revision, "emptying the slot did not move the revision")
+  }
+
+  /// **The narrowing, at the level the loop reads it.** A hover must not move the
+  /// slot revision, or every hover would invalidate a prepared recording.
+  @Test("a hover does not move the slot revision")
+  func hoverDoesNotMoveTheSlotRevision() throws {
+    var r = Self.reducerWithLiveRecording()
+    let id = try #require(r.state.current?.id)
+    let before = r.recordingReconciliationSnapshot.revision
+
+    _ = r.reduce(.hoverChanged(id, true))
+    #expect(
+      r.recordingReconciliationSnapshot.revision == before,
+      "a hover advanced the slot revision, which would discard prepared recordings")
+
+    _ = r.reduce(.hoverChanged(id, false))
+    #expect(r.recordingReconciliationSnapshot.revision == before)
+  }
+}

--- a/Tests/EnviousWisprTests/App/RecordingFinalizerCancelPathTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingFinalizerCancelPathTests.swift
@@ -283,7 +283,7 @@
     /// no recording is showing, which is the honest answer to "is the user
     /// looking at a locked pill".
     private static func pillShowsLocked(_ overlay: OverlayDirector) -> Bool {
-      guard case .recording(_, let isLocked, _)? = overlay.renderModel.presentation?.content
+      guard case .recording(_, let isLocked, _, _)? = overlay.renderModel.presentation?.content
       else { return false }
       return isLocked
     }

--- a/Tests/EnviousWisprTests/App/RecordingOverlayPreviewSizingTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingOverlayPreviewSizingTests.swift
@@ -40,7 +40,7 @@ struct RecordingOverlayPreviewSizingTests {
 
   init() { _ = NSApplication.shared }
 
-  /// Width the preview pill is created at (`OverlayRecordingLayout.preview`).
+  /// Width the preview pill is created at (`RecordingPillDesign.readingWell`).
   private static let previewWidth: CGFloat = 400
 
   /// Collects every height the view reports. The LAST value is what the panel

--- a/scripts/verify-declaration-move.py
+++ b/scripts/verify-declaration-move.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Prove that declarations moved between files rather than changing.
+
+**Why this exists rather than `verify-view-split.py`.** That tool reconstructs the
+original by CONCATENATING destination files in declaration order, which requires
+each destination to hold a CONTIGUOUS run of declarations and to have been empty
+before the move. #2375 C1a satisfies neither, measured before this file was
+written:
+
+  - the three destinations interleave — `PillDefinition` occupies three separate
+    runs in declaration order and `PillExpiry` two, because placement and expiry
+    declarations sit between the presentation ones;
+  - `OverlayPlacementState.swift` is a pre-existing 208-line file with its own
+    declaration, so concatenating it would feed the reconstruction content the
+    original never had.
+
+Either alone defeats concatenation. So this tool asks an ORDER-INDEPENDENT
+question instead, which is the right question for a move that regroups rather
+than merely splits:
+
+  1. **Line conservation.** The multiset of non-blank, non-import lines ADDED to
+     the destinations equals the multiset of non-blank, non-import lines in the
+     original at `--base`. Every line moved; none was added, lost, or edited.
+  2. **Supported declaration accounting.** Every top-level class, struct, enum,
+     actor, extension or protocol declaration in the original appears in exactly
+     ONE destination, exactly once, and no destination gained a supported
+     declaration the original did not have.
+
+     **"Supported" is load-bearing, not hedging.** The parser reads those six
+     forms and no others, so a top-level `typealias`, `func`, `var` or `macro`
+     is invisible to check 2 — it would still be caught by check 1, which counts
+     lines, but it would not be ACCOUNTED to a declaration. Measured for #2375
+     C1a before relying on this: the original and all three destinations contain
+     ZERO such forms. A file that has them needs the parser widened, not this
+     comment reread.
+  3. **Per-declaration ownership and order.** Each declaration's SIGNIFICANT
+     lines, including its leading comment and attribute run, stay attached to
+     that declaration and occur in their base order. Blank lines and imports are
+     excluded and declared access widenings are normalised first, so this is not
+     a byte-identity claim — an earlier version of this sentence said "byte-
+     identical", which overclaims in the direction that matters.
+  4. **Pre-existing declarations in a destination are untouched**, checked the
+     same way. A reorder inside one adds and removes nothing, so every count
+     above stays green and only this catches it.
+  5. **No survivor.** The original path is gone from the working tree.
+
+**Check 3 exists because checks 1 and 2 are not sufficient, and this is measured
+rather than anticipated.** The first run of this chunk moved two `// MARK:`
+section headers onto the wrong neighbouring declaration: every line was still
+present exactly once, every declaration had exactly one home, and the verdict was
+MOVE-ONLY while `Screens and geometry` labelled the presentation types. A
+whole-file multiset cannot see WHICH declaration a line belongs to. Review caught
+it; check 3 is what makes it catchable.
+
+So the tool is blind to the ORDER OF DECLARATIONS, deliberately — regrouping is
+what this chunk does — and NOT blind to which declaration a line belongs to, nor
+to content.
+
+FAILS CLOSED. A missing file, an unreadable revision, a destination whose base
+version cannot be read, or a zero-declaration parse exits nonzero. A measurement
+authority that prints a number after a half-failed read looks exactly like a real
+result.
+
+Usage:
+  scripts/verify-declaration-move.py \
+      --base <sha> --original Sources/.../OverlayVocabulary.swift \
+      --dest Sources/.../PillDefinition.swift \
+      --dest Sources/.../PillExpiry.swift \
+      --dest Sources/.../OverlayPlacementState.swift \
+      [--allow-widen TypeName] [--json out.json]
+
+The oracle is `git show <base>:<path>`, never a working-tree path: a path pins a
+LOCATION and a revision pins CONTENT.
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import pathlib
+import re
+import subprocess
+import sys
+
+DECL = re.compile(
+    r"^(?:public |internal |private |fileprivate |package )?"
+    r"(?:final class|class|struct|enum|actor|extension|protocol) +([A-Za-z_][A-Za-z0-9_]*)",
+)
+
+
+def die(msg: str) -> None:
+    print(f"BLOCKED: {msg}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def git_show(base: str, path: str) -> str | None:
+    proc = subprocess.run(
+        ["git", "show", f"{base}:{path}"], capture_output=True, text=True)
+    if proc.returncode != 0:
+        return None
+    return proc.stdout
+
+
+def significant(text: str, widened: list[str]) -> list[str]:
+    """Non-blank, non-import lines, with permitted access widenings undone."""
+    for name in widened:
+        # Must stay in step with DECL's form list above. Adding a form to one and
+        # not the other makes an allowed widening on that form fail the check it
+        # was explicitly permitted by — which is the shape review caught when
+        # `actor` was added to DECL alone.
+        for kind in ("struct", "class", "enum", "actor", "extension", "protocol"):
+            text = text.replace(f"private {kind} {name}", f"{kind} {name}")
+    out = []
+    for line in text.split("\n"):
+        s = line.strip()
+        if not s:
+            continue
+        if s.startswith("import ") or s.startswith("@testable import "):
+            continue
+        out.append(line)
+    return out
+
+
+def declarations(text: str) -> list[str]:
+    return [m.group(1) for line in text.split("\n") if (m := DECL.match(line))]
+
+
+def declaration_chunks(text: str, widened: list[str]) -> dict[str, tuple[str, ...]]:
+    """Each declaration's ordered significant lines, including its leading comment/attribute run.
+
+    **This is what a line multiset alone cannot see.** Comparing multisets across
+    whole files is blind to WHICH declaration a line belongs to, so a section
+    header attached to the wrong neighbour, or two properties swapped between two
+    types, keeps every line present exactly once and passes. Measured on this
+    chunk's first attempt: two `// MARK:` headers travelled with the wrong block
+    and the multiset check reported MOVE-ONLY.
+
+    Comparing per declaration closes that, because a line that changed owner is
+    now missing from one chunk and extra in another.
+    """
+    lines = text.split("\n")
+    starts = [(i, m.group(1)) for i, line in enumerate(lines) if (m := DECL.match(line))]
+    prefixes: list[int] = []
+    for i, _ in starts:
+        j = i
+        while j > 0:
+            prev = lines[j - 1].strip()
+            if prev.startswith("//") or prev.startswith("@"):
+                j -= 1
+            elif not prev and j - 2 >= 0 and lines[j - 2].strip().startswith("//"):
+                # a blank line INSIDE a comment run still belongs to that run
+                j -= 1
+            else:
+                break
+        prefixes.append(j)
+    out: dict[str, tuple[str, ...]] = {}
+    for n, (_, name) in enumerate(starts):
+        end = prefixes[n + 1] if n + 1 < len(prefixes) else len(lines)
+        out[name] = tuple(significant("\n".join(lines[prefixes[n]:end]), widened))
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base", required=True)
+    ap.add_argument("--original", required=True)
+    ap.add_argument("--dest", action="append", required=True)
+    ap.add_argument("--allow-widen", action="append", default=[])
+    ap.add_argument("--json")
+    args = ap.parse_args()
+
+    original_raw = git_show(args.base, args.original)
+    if original_raw is None or not original_raw.strip():
+        die(f"{args.base}:{args.original} is missing or empty — "
+            "refusing to compare against nothing")
+
+    if pathlib.Path(args.original).exists():
+        die(f"{args.original} still exists in the working tree — "
+            "a move that leaves the original behind is a copy")
+
+    original_lines = significant(original_raw, args.allow_widen)
+    original_decls = declarations(original_raw)
+    if not original_decls:
+        die(f"{args.base}:{args.original} parsed to ZERO declarations — "
+            "the parse is wrong, not the file")
+
+    added_lines: list[str] = []
+    added_decls: list[str] = []
+    gained_chunks: dict[str, tuple[str, ...]] = {}
+    per_dest: dict[str, dict] = {}
+
+    for rel in args.dest:
+        p = pathlib.Path(rel)
+        if not p.is_file():
+            die(f"{rel} does not exist — the destination list is wrong")
+        now = p.read_text(encoding="utf-8")
+        # `git_show(...) or ""` would treat an unreadable revision as a NEW file,
+        # which is the permissive direction and contradicts this tool's own
+        # fail-closed claim. Ask whether the path EXISTS at base first, so
+        # "absent" and "could not be read" stop being the same answer.
+        listed = subprocess.run(
+            ["git", "ls-tree", "--name-only", args.base, "--", rel],
+            capture_output=True, text=True)
+        if listed.returncode != 0:
+            die(f"git ls-tree {args.base} -- {rel} failed: {listed.stderr.strip()}")
+        exists_at_base = listed.stdout.strip() != ""
+        before = git_show(args.base, rel) if exists_at_base else ""
+        if exists_at_base and before is None:
+            die(f"{args.base}:{rel} exists but could not be read")
+
+        now_lines = significant(now, args.allow_widen)
+        before_lines = significant(before, args.allow_widen)
+
+        delta = list((collections.Counter(now_lines)
+                      - collections.Counter(before_lines)).elements())
+        removed = list((collections.Counter(before_lines)
+                        - collections.Counter(now_lines)).elements())
+        if removed:
+            die(f"{rel} LOST {len(removed)} pre-existing line(s); a move must only "
+                f"add. First: {removed[0].strip()!r}")
+
+        d_now = set(declarations(now))
+        d_before = set(declarations(before))
+        gained = sorted(d_now - d_before)
+
+        now_chunks = declaration_chunks(now, args.allow_widen)
+        for name in gained:
+            gained_chunks[name] = now_chunks[name]
+
+        # A destination's PRE-EXISTING declarations must be untouched too. The
+        # whole-file multiset cannot see a reorder inside one of them: no line is
+        # added and none removed, so both the LOST check and the conservation
+        # check stay green. Only comparing that declaration's own ordered lines
+        # against its base version catches it.
+        before_chunks = declaration_chunks(before, args.allow_widen)
+        changed_existing = sorted(
+            name for name, body in before_chunks.items()
+            if now_chunks.get(name) != body)
+        if changed_existing:
+            die(f"{rel} changed pre-existing declaration(s): "
+                f"{', '.join(changed_existing)}")
+
+        added_lines.extend(delta)
+        added_decls.extend(gained)
+        per_dest[rel] = {"added_lines": len(delta), "gained_declarations": gained}
+
+    # --- 1. line conservation -------------------------------------------------
+    orig_c = collections.Counter(original_lines)
+    add_c = collections.Counter(added_lines)
+    only_original = list((orig_c - add_c).elements())
+    only_added = list((add_c - orig_c).elements())
+
+    # --- 2. declaration accounting -------------------------------------------
+    dup = [n for n, k in collections.Counter(added_decls).items() if k > 1]
+    missing = sorted(set(original_decls) - set(added_decls))
+    extra = sorted(set(added_decls) - set(original_decls))
+
+    # Per-declaration comparison: a line that changed OWNER is invisible to the
+    # multiset above and visible here.
+    original_chunks = declaration_chunks(original_raw, args.allow_widen)
+    reassigned = sorted(
+        name for name, body in original_chunks.items()
+        if name in gained_chunks and gained_chunks[name] != body)
+
+    ok = not (only_original or only_added or dup or missing or extra or reassigned)
+
+    receipt = {
+        "base": args.base,
+        "original": args.original,
+        "original_significant_lines": len(original_lines),
+        "added_significant_lines": len(added_lines),
+        "original_declarations": original_decls,
+        "destinations": per_dest,
+        "lines_only_in_original": len(only_original),
+        "lines_only_in_destinations": len(only_added),
+        "declarations_in_two_destinations": dup,
+        "declarations_missing": missing,
+        "declarations_not_in_original": extra,
+        "declarations_whose_lines_changed_owner": reassigned,
+        "allowed_widenings": args.allow_widen,
+        "verdict": "MOVE-ONLY" if ok else "CONTENT CHANGED",
+    }
+    if args.json:
+        pathlib.Path(args.json).write_text(json.dumps(receipt, indent=2) + "\n")
+
+    print(f"base                     {args.base}")
+    print(f"original                 {args.original} ({len(original_lines)} significant lines,"
+          f" {len(original_decls)} declarations)")
+    for rel, info in per_dest.items():
+        print(f"  -> {rel}: +{info['added_lines']} lines, "
+              f"{', '.join(info['gained_declarations']) or 'no new declarations'}")
+    print(f"allowed widenings        {args.allow_widen or 'none'}")
+    print(f"lines only in original   {len(only_original)}")
+    print(f"lines only in new files  {len(only_added)}")
+    print(f"declarations missing     {missing or 'none'}")
+    print(f"declarations duplicated  {dup or 'none'}")
+    print(f"declarations unexpected  {extra or 'none'}")
+    print(f"declarations reassigned  {reassigned or 'none'}")
+    print()
+    print(f"VERDICT: {receipt['verdict']}")
+
+    if not ok:
+        for line in only_original[:5]:
+            print(f"  only in original:  {line.strip()[:100]}")
+        for line in only_added[:5]:
+            print(f"  only in new files: {line.strip()[:100]}")
+        for name in reassigned[:5]:
+            was = set(original_chunks[name])
+            now_ = set(gained_chunks[name])
+            for line in sorted(was - now_)[:2]:
+                print(f"  {name} LOST:   {line.strip()[:90]}")
+            for line in sorted(now_ - was)[:2]:
+                print(f"  {name} GAINED: {line.strip()[:90]}")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify-declaration-move.test.sh
+++ b/scripts/verify-declaration-move.test.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# Two-way control for verify-declaration-move.py.
+#
+# A verifier that merely stops complaining is indistinguishable from one that was
+# deleted. So every arm declares its own expectation in its own name:
+#
+#   - an arm whose name says the input is CLEAN must exit 0 with empty stderr;
+#   - an arm whose name says a defect is CAUGHT must fail for its NAMED reason,
+#     asserted on the message, never on the exit status alone. A generic failure
+#     would pass a tool that rejects everything.
+#
+# **This header deliberately does NOT enumerate arm numbers.** It listed them
+# twice and went stale both times, once per arm added — a count in prose that has
+# to track code decays the moment someone appends. The rule above cannot.
+#
+# Asserts stderr is empty on every arm that should be silent, because a harness
+# that does not read its own stderr reports a green it cannot see.
+set -uo pipefail
+
+TOOL="$(cd "$(dirname "$0")" && pwd)/verify-declaration-move.py"
+PASS=0; FAIL=0
+note() { printf '%s  %s\n' "$1" "$2"; }
+ok()   { PASS=$((PASS+1)); note "PASS" "$1"; }
+bad()  { FAIL=$((FAIL+1)); note "FAIL" "$1"; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+setup() {
+  rm -rf "$WORK/repo"; mkdir -p "$WORK/repo/src"; cd "$WORK/repo"
+  git init -q .; git config user.email t@t; git config user.name t
+  cat > src/Original.swift <<'SWIFT'
+import Foundation
+
+/// Alpha does a thing.
+struct Alpha: Equatable {
+  let a: Int
+}
+
+/// Beta does another.
+enum Beta {
+  case one
+}
+
+/// Gamma is third.
+struct Gamma {
+  let g: String
+}
+SWIFT
+  cat > src/Existing.swift <<'SWIFT'
+import Foundation
+
+struct AlreadyHere {
+  let x: Int
+  let y: String
+}
+SWIFT
+  git add -A; git commit -qm base
+  BASE="$(git rev-parse HEAD)"
+}
+
+# A correct move: Alpha+Gamma into a NEW file, Beta appended to an EXISTING file.
+# Deliberately interleaved and into a non-empty destination — the two shapes the
+# concatenation tool cannot handle.
+do_clean_move() {
+  cat > src/NewHome.swift <<'SWIFT'
+import Foundation
+
+/// Alpha does a thing.
+struct Alpha: Equatable {
+  let a: Int
+}
+
+/// Gamma is third.
+struct Gamma {
+  let g: String
+}
+SWIFT
+  cat >> src/Existing.swift <<'SWIFT'
+
+/// Beta does another.
+enum Beta {
+  case one
+}
+SWIFT
+  rm src/Original.swift
+}
+
+run() { python3 "$TOOL" --base "$BASE" --original src/Original.swift \
+          --dest src/NewHome.swift --dest src/Existing.swift 2>"$WORK/err"; }
+
+# --- arm 1: the clean move passes ------------------------------------------
+setup; do_clean_move
+out="$(run)"; rc=$?
+[ $rc -eq 0 ] && grep -q "VERDICT: MOVE-ONLY" <<<"$out" \
+  && ok "arm 1 clean interleaved move into a non-empty destination -> MOVE-ONLY" \
+  || bad "arm 1 expected MOVE-ONLY, rc=$rc"
+[ -s "$WORK/err" ] && bad "arm 1 wrote to stderr: $(head -1 "$WORK/err")" || ok "arm 1 stderr empty"
+
+# --- arm 2: an EDITED line is caught ---------------------------------------
+setup; do_clean_move
+/usr/bin/sed -i '' 's/let a: Int/let a: Int64/' src/NewHome.swift
+out="$(run)"; rc=$?
+[ $rc -eq 1 ] && [ ! -s "$WORK/err" ] && grep -q "VERDICT: CONTENT CHANGED" <<<"$out" \
+  && ok "arm 2 edited line -> CONTENT CHANGED" || bad "arm 2 expected CONTENT CHANGED, rc=$rc"
+
+# --- arm 3: a DROPPED declaration is caught --------------------------------
+setup; do_clean_move
+python3 - <<'PY'
+import pathlib
+p = pathlib.Path("src/NewHome.swift"); t = p.read_text()
+p.write_text(t.split("/// Gamma is third.")[0])
+PY
+out="$(run)"; rc=$?
+[ $rc -eq 1 ] && [ ! -s "$WORK/err" ] && grep -q "declarations missing     \['Gamma'\]" <<<"$out" \
+  && ok "arm 3 dropped declaration -> named as missing" || bad "arm 3 expected Gamma missing, rc=$rc"
+
+# --- arm 4: a DUPLICATED declaration is caught -----------------------------
+setup; do_clean_move
+cat >> src/Existing.swift <<'SWIFT'
+
+/// Gamma is third.
+struct Gamma {
+  let g: String
+}
+SWIFT
+out="$(run)"; rc=$?
+[ $rc -eq 1 ] && [ ! -s "$WORK/err" ] && grep -q "declarations duplicated  \['Gamma'\]" <<<"$out" \
+  && ok "arm 4 declaration in two destinations -> named as duplicated" || bad "arm 4 rc=$rc"
+
+# --- arm 5: an ADDED line is caught ----------------------------------------
+setup; do_clean_move
+printf '\n/// smuggled in\n' >> src/NewHome.swift
+out="$(run)"; rc=$?
+[ $rc -eq 1 ] && [ ! -s "$WORK/err" ] && grep -q "lines only in new files  1" <<<"$out" \
+  && ok "arm 5 added comment line -> reported as only in new files" || bad "arm 5 rc=$rc"
+
+# --- arm 6: a SURVIVING original is caught ---------------------------------
+setup; do_clean_move
+git checkout -q -- src/Original.swift
+run >/dev/null 2>"$WORK/err"; rc=$?
+[ $rc -eq 2 ] && grep -q "still exists in the working tree" "$WORK/err" \
+  && ok "arm 6 original left behind -> refuses (a move that leaves a copy)" || bad "arm 6 rc=$rc"
+
+# --- arm 7: a destination that LOST a pre-existing line is caught -----------
+setup; do_clean_move
+/usr/bin/sed -i '' '/let x: Int/d' src/Existing.swift
+run >/dev/null 2>"$WORK/err"; rc=$?
+[ $rc -eq 2 ] && grep -q "LOST 1 pre-existing line" "$WORK/err" \
+  && ok "arm 7 destination lost its own content -> refuses" || bad "arm 7 rc=$rc"
+
+# --- arm 8: blank-line churn is DELIBERATELY tolerated ----------------------
+setup; do_clean_move
+printf '\n\n' >> src/NewHome.swift
+out="$(run)"; rc=$?
+[ $rc -eq 0 ] && [ ! -s "$WORK/err" ] && grep -q "VERDICT: MOVE-ONLY" <<<"$out" \
+  && ok "arm 8 blank lines tolerated -> MOVE-ONLY, stderr empty (stated limit)" \
+  || bad "arm 8 blank lines should not fail, rc=$rc"
+
+# --- arm 9: a line that changed OWNER is caught ------------------------------
+# The defect review found in #2375 C1a: a section header travelled with the wrong
+# neighbour. Every line is still present exactly once, so checks 1 and 2 pass and
+# ONLY the per-declaration comparison can see it.
+setup; do_clean_move
+python3 - <<'PY2'
+import pathlib
+p = pathlib.Path("src/NewHome.swift"); t = p.read_text()
+# move Alpha's doc comment onto Gamma: no line added, none lost, owner changed
+t = t.replace("/// Alpha does a thing.\n", "", 1)
+t = t.replace("/// Gamma is third.\n", "/// Alpha does a thing.\n/// Gamma is third.\n", 1)
+p.write_text(t)
+PY2
+out="$(run)"; rc=$?
+[ $rc -eq 1 ] && [ ! -s "$WORK/err" ] && grep -q "declarations reassigned" <<<"$out" && grep -qE "reassigned  \['(Alpha|Gamma)'" <<<"$out" \
+  && ok "arm 9 comment line changed OWNER -> reassigned (multiset alone cannot see this)" \
+  || bad "arm 9 expected a reassignment finding, rc=$rc"
+
+# --- arm 10: a pre-existing destination is never silently treated as NEW ------
+# `git show base:path or ""` would have called a failed read a new file, which is
+# the permissive direction. This arm points a destination at a path that was a
+# TREE at base and is a FILE now, and requires a fail-closed refusal.
+#
+# **Stated limit, because a faked control is worse than a named gap:** `git show`
+# on a tree SUCCEEDS and returns a listing, so this arm exercises the
+# pre-existing-content branch, NOT the `exists but could not be read` branch. That
+# branch guards a corrupt or unreadable object and is not exercised by any arm
+# here. It is one line and it fails closed by construction; nothing in this suite
+# proves it fires.
+rm -rf "$WORK/repo"; mkdir -p "$WORK/repo/src/thing"; cd "$WORK/repo"
+git init -q .; git config user.email t@t; git config user.name t
+cat > src/Original.swift <<'SWIFT'
+import Foundation
+
+/// Alpha does a thing.
+struct Alpha {
+  let a: Int
+}
+SWIFT
+echo "// placeholder" > src/thing/keep.swift
+git add -A; git commit -qm base
+BASE="$(git rev-parse HEAD)"
+rm -rf src/thing
+cat > src/thing <<'SWIFT'
+import Foundation
+
+/// Alpha does a thing.
+struct Alpha {
+  let a: Int
+}
+SWIFT
+rm src/Original.swift
+python3 "$TOOL" --base "$BASE" --original src/Original.swift --dest src/thing \
+  >/dev/null 2>"$WORK/err"; rc=$?
+[ $rc -eq 2 ] && grep -qE "LOST [0-9]+ pre-existing line" "$WORK/err" \
+  && ok "arm 10 pre-existing destination refused fail-closed, never treated as new" \
+  || bad "arm 10 expected a fail-closed refusal, rc=$rc, err=$(head -1 "$WORK/err")"
+
+# --- arm 11: a REORDER inside a PRE-EXISTING declaration is caught ------------
+# Adds nothing and removes nothing, so line conservation, the LOST check and the
+# gained-declaration comparison all stay green. Only comparing the pre-existing
+# declaration's own ordered lines against base can see it.
+setup; do_clean_move
+python3 - <<'PY3'
+import pathlib
+p = pathlib.Path("src/Existing.swift"); t = p.read_text()
+t = t.replace("  let x: Int\n  let y: String\n", "  let y: String\n  let x: Int\n", 1)
+p.write_text(t)
+PY3
+run >/dev/null 2>"$WORK/err"; rc=$?
+[ $rc -eq 2 ] && grep -q "changed pre-existing declaration(s): AlreadyHere" "$WORK/err" \
+  && ok "arm 11 reorder inside a pre-existing declaration -> refuses" \
+  || bad "arm 11 expected a pre-existing-declaration refusal, rc=$rc, err=$(head -1 "$WORK/err")"
+
+# --- arms 12-13: --allow-widen, which NO arm exercised until review said so ----
+# A file split forces a file-private type to widen to internal, which is the one
+# difference this tool is allowed to forgive. Both arms are needed: the permitted
+# widening must PASS, and an UNLISTED one must still fail, or "forgive" would mean
+# "ignore".
+widen_setup() {
+  rm -rf "$WORK/repo"; mkdir -p "$WORK/repo/src"; cd "$WORK/repo"
+  git init -q .; git config user.email t@t; git config user.name t
+  cat > src/Original.swift <<'SWIFT'
+import Foundation
+
+private struct Helper {
+  let h: Int
+}
+
+private actor Worker {
+  var n = 0
+}
+SWIFT
+  git add -A; git commit -qm base
+  BASE="$(git rev-parse HEAD)"
+  cat > src/Moved.swift <<'SWIFT'
+import Foundation
+
+struct Helper {
+  let h: Int
+}
+
+actor Worker {
+  var n = 0
+}
+SWIFT
+  rm src/Original.swift
+}
+
+widen_setup
+python3 "$TOOL" --base "$BASE" --original src/Original.swift --dest src/Moved.swift \
+  --allow-widen Helper --allow-widen Worker >"$WORK/out" 2>"$WORK/err"; rc=$?
+[ $rc -eq 0 ] && [ ! -s "$WORK/err" ] && grep -q "VERDICT: MOVE-ONLY" "$WORK/out" \
+  && ok "arm 12 permitted widening on a struct AND an actor -> MOVE-ONLY, stderr empty" \
+  || bad "arm 12 expected MOVE-ONLY, rc=$rc, $(head -1 "$WORK/err")"
+
+widen_setup
+python3 "$TOOL" --base "$BASE" --original src/Original.swift --dest src/Moved.swift \
+  --allow-widen Helper >"$WORK/out" 2>"$WORK/err"; rc=$?
+[ $rc -eq 1 ] && [ ! -s "$WORK/err" ] && grep -q "VERDICT: CONTENT CHANGED" "$WORK/out" \
+  && grep -q "only in original:  private actor Worker" "$WORK/out" \
+  && grep -q "only in new files: actor Worker" "$WORK/out" \
+  && ok "arm 13 UNLISTED actor widening fails NAMING the actor -> forgive is not ignore" \
+  || bad "arm 13 expected CONTENT CHANGED, rc=$rc"
+
+echo
+echo "passed $PASS, failed $FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Phase 3 of the pill-system refactor. **`PillCatalog` is now the sole definition and design-resolution authority**, and the recording pill's geometry has one owner instead of two.

## What the user gets

Nothing changes on screen. Every pill looks and sounds exactly as it did, and that is the receipt rather than the caveat: eighteen frozen rows captured by running the shipped code at `da103706`, before any of this existed, and asserted against ever since.

What changes is that **which recording pill you see is now a decision the code can express.** It is resolved once, travels with the pill, and is read from one place. Phase 4's appearance picker replaces one closure body and nothing else.

## The defect this closes

Two authorities described one geometry and the correct-looking one was ignored.

The reducer emitted `185 x 92` for a recording pill. The director then substituted `400` and content-sizing when Live Preview was on. The override's own comment explained why — the reducer "cannot know which layout is in force" — so the arrangement was documented as though it were a design.

C0 froze both, which is what makes this a measurement rather than an argument: the definition row says 185, the with-words geometry row says 400.

## Chunks

| | Commit | Rounds | What |
|---|---|---|---|
| C0 | `6005ca15` | 5 | The frozen oracle. Twenty rows plus both recording geometries, RUN against `main` rather than read from source. No production code. |
| C1a | `e75254d8` | 6 | `OverlayVocabulary.swift` split three ways. Proven move-only against the base blob. |
| C1b | `a5da3f39` | 1 | `OverlayPresentation` → `PillDefinition`. Proven substitution-only. |
| C2 | `6d3379d1` | 5 | The catalog becomes the sole authority for all sixteen non-recording pills. G2's duplicate Bluetooth mint deleted. |
| C3a | `0c592088` | 8 | The recording transaction: prepare → resolve → commit, the selection seam, and a bounded bridge reconciliation. |
| C3b | (this) | 6 | `OverlayRecordingLayout` deleted with all three replacements at once. G3 closed. |

There is no C4. The plan had one and it was unbuildable — its selection types were needed by the chunk before it — so they land with their first consumer in C3a.

## Two corrections to the plan, both measured

**The catalog needs sixteen non-recording cases, not seventeen.** The plan's §3.2 described the enum as the sixteen pipeline intents unioned with "two feature requests", one of which is already among the sixteen. Followed literally, the only seventeenth case available is a second Bluetooth arm — G2's duplicate, reappearing inside the type built to delete it. C0's two Bluetooth rows are identical field for field, which settles it.

**The stated proof for C1a could not verify C1a.** `verify-view-split.py` rebuilds an original by concatenating destinations in declaration order, which needs each to hold one contiguous run and to have started empty; two destinations hold several runs and one was a pre-existing 208-line file. Replaced with `scripts/verify-declaration-move.py`, which asks an order-independent question, plus a 14-arm two-way control.

## Design decisions worth knowing

**The resolved design rides on the recording content case, not on the definition.** A notice cannot then carry a recording design, and every same-id morph must bind and pass it — so a morph that drops the design fails to *compile* rather than silently dropping a live pill back to the other geometry mid-recording.

**Recording composition is not one transaction, and that is the phase's real structural change.** The recording effect must reach Live Preview *before* capability is read, or a pill can be sized wide for a preview that resolves disabled. The catalog needs the resolved design as an *input* to minting. So minting moved after the effect, behind an explicit prepare/resolve/commit boundary with a one-shot token.

**The slot revision is narrowed deliberately.** A prepared recording is discarded when the slot changes under it — but a hover or a lock-only change cannot conflict with one, and discarding on either means a recording pill that never appears. `CLAUDE.md` ranks that above every other audio consideration.

**`reduce(.pipeline(.recording))` may morph a live recording and may not start one.** Starting one needs a resolved design; anything holding only an intent has not resolved anything. Accepting a placeholder to keep that path alive is what the plan forbids, because a preview-capable definition would then disagree with its own rendered layout.

## Tests

**Twenty-eight new cases across five suites, and all nine new test files run in BOTH configurations.** That is not luck: the recording test helper went in the test target rather than behind a `#if DEBUG` seam, because a debug-only helper takes every test that touches it out of the Release lane — and two overlay suites already sit in that hole.

Table 1 asserts every non-recording request and both accessibility composition outcomes against the frozen capture. Table 2 is a generated cross-product with its own coverage floor. Table 3a covers morph preservation for both designs; 3ab covers the invalidated transition asserted as *which definition is current* rather than as a flag; 3b covers what the director captures and what the resulting composition drives.

## Thirty-one review rounds, and one root

Every test-side finding across the phase was **an assertion satisfied by something other than the thing it names**, at four grains that are not derivable from one another:

- the fixture cannot *reach* the behaviour — the same request repeated, so the dedup guard dropped it;
- the fixture sits where the property is *degenerate* — a hover test on a pill that does not respond to hover; a design test under settings where design and capability always agree;
- the two things compared are *indistinguishable* — both transitions resolving to the same design, so a stale one overwriting a newer one was unobservable;
- the assertion is satisfied by an *earlier element* — reading the last bridge value, which the earlier values already made true.

Where a fixture must reach a state it now asserts it reached it before the claim is read. Two lines that would have caught three of the five.

## Two tooling defects found and filed

- **#2396** — the lane log path is shared by default, so two concurrent runs corrupt each other's count. Observed reporting 2379 tests against a real 6664.
- **#2401** — a crashed test bundle reports `TEST SUCCEEDED` and exit 0 with two thirds of the suite never run. Zero failure marks, and the count guard only rejects zero.

Both were hit in this phase. Every count cited here is reconciled against its own per-bundle sum, compared to the previous baseline, and checked for crash lines.

## Ship criteria

- Debug lane green, reconciled — **6692**, seven consecutive clean runs
- Release lane — see the checklist comment
- Zero live declarations or references to `OverlayVocabulary`, `OverlayPresentation`, `OverlayRecordingLayout` — **measured**
- `geometry(for:)` has no recording special case — **measured**
- Live UAT rows 1-10 — see the checklist comment
- `test-hardening` issues filed with frozen recipes — **#2393** and **#2402**, both re-validated after their review rounds

Part of #2375. Board #2373. Phase 4 is #2376.
