### PR TITLE
fix(seo): guard the language-count consumer the guard could not read (#2368)

### DIFF
--- a/Sources/EnviousWisprServices/SettingsManager.swift
+++ b/Sources/EnviousWisprServices/SettingsManager.swift
@@ -835,7 +835,7 @@ public final class SettingsManager {
       defaults.string(forKey: "whisperKitLanguage") ?? SettingsDefaultValues.whisperKitLanguage
     // Load languageMode, or migrate from whisperKitLanguage on first launch
     // (Multilingual v1). Both paths normalize (lowercase) and validate against
-    // the Whisper-supported 99-lang set; unsupported, empty, or case-variant
+    // the accepted-code set in `LanguageTypes`; unsupported, empty, or case-variant
     // codes fall back to .auto so a stale or bogus persisted value cannot
     // lock the user into a non-existent language.
     let resolvedLanguageMode: LanguageMode = {

--- a/website/scripts/check-language-count.mjs
+++ b/website/scripts/check-language-count.mjs
@@ -99,19 +99,38 @@ const SITES = [
 // deliberately kept narrow (see ANCHORS below) after broad scanning produced
 // three false positives on correct prose, and a guard that cries wolf on correct
 // code trains people to skip it. This does not reopen that trade.
-// The leading `(?<![-\d])` excludes ISO designators: in "ISO 639-1 lang code"
-// the `1` is part of the standard's name, not a count, and without this the
-// guard fails the website prebuild on correct prose (#2368 cloud review P2).
+// TWO checks, and the split is the point (#2368 cloud review, rounds 1-3).
 //
-// That hole predates the `langs?` branch — "ISO 639-1 language code" matched the
-// ORIGINAL pattern too. It was unreachable only because no anchored block
-// contained an ISO reference; anchoring a third file is what made it reachable.
+// Rounds 1 and 2 both found a new ISO SPELLING the pattern mis-read as a count:
+// first "ISO 639-1 lang code" matching `1 lang`, then "ISO 639 lang code"
+// matching `639 lang` once the hyphenated form was excluded. That is review
+// finding a new MEMBER of a set each round, which means the defect is that the
+// set is being DESCRIBED rather than enumerated — and a description always has a
+// next counterexample.
 //
-// Paired accept/reject table, all verified, because a check that stopped
+// So the question was inverted. Enumerating "every way prose can spell a count"
+// is open and unbounded. Enumerating "which numbers are LEGITIMATE here" is
+// CLOSED: the ISO 639 family has a fixed, externally-defined part list, and it is
+// the only numeric vocabulary the guarded blocks legitimately carry — verified by
+// reading all three, which contain `ISO 639-1` and `ISO 639-3` and nothing else
+// numeric.
+//
+// Allowed designators are removed FIRST, then what remains is checked for a
+// count. A genuine count in the same sentence as an ISO reference still fires,
+// which is what stops this being a blanket exemption.
+//
+// Paired accept/reject table, all verified, because a check that quietly stopped
 // classifying anything also reports clean:
 //   MATCH:  "99-lang set" · "(99 languages)" · "99-language set"
 //           "All 99 Whisper-supported languages" · "25 European languages"
-//   REJECT: "ISO 639-1 lang code" · "ISO 639-1 language code"
+//           "a 54-language list" · "ISO 639-3 entries and 99 languages"
+//   REJECT: "ISO 639-1 lang code" · "ISO 639 lang code" · "ISO 639 language code"
+//           "Accepted language codes: ISO 639-1, plus the ISO 639-3 entries"
+//
+// A FOURTH finding here would have to be a number that is neither an ISO 639
+// designator nor a count. Stating that so the closure is falsifiable rather than
+// hopeful.
+const ISO_DESIGNATOR = /\bISO[\s ]*639(?:-[1-5])?\b/gi;
 const COUNT_IN_PROSE = /(?<![-\d])\d{1,3}\+?[\s-]*([A-Za-z-]+\s+){0,2}(languages?|langs?)\b/i;
 
 // The two declarations where the count used to live. The doc block directly
@@ -204,7 +223,7 @@ for (const { file, label, declRe, commentRe } of ANCHORS) {
     failures.push(`${file}:${idx + 1}: no doc comment directly above "${label}" — restore the explanation; this guard verifies it carries no count`);
     continue;
   }
-  const m = block.join('\n').match(COUNT_IN_PROSE);
+  const m = block.join('\n').replace(ISO_DESIGNATOR, 'ISO-STD').match(COUNT_IN_PROSE);
   if (m) {
     failures.push(`${file}:${idx + 1 - block.length}..${idx}: doc block above "${label}" carries a language count ("${m[0]}") — the set's size is not a marketed figure (#2368); describe what it is, with no number`);
   }

--- a/website/scripts/check-language-count.mjs
+++ b/website/scripts/check-language-count.mjs
@@ -99,7 +99,20 @@ const SITES = [
 // deliberately kept narrow (see ANCHORS below) after broad scanning produced
 // three false positives on correct prose, and a guard that cries wolf on correct
 // code trains people to skip it. This does not reopen that trade.
-const COUNT_IN_PROSE = /\b\d{1,3}\+?[\s-]*([A-Za-z-]+\s+){0,2}(languages?|langs?)\b/i;
+// The leading `(?<![-\d])` excludes ISO designators: in "ISO 639-1 lang code"
+// the `1` is part of the standard's name, not a count, and without this the
+// guard fails the website prebuild on correct prose (#2368 cloud review P2).
+//
+// That hole predates the `langs?` branch — "ISO 639-1 language code" matched the
+// ORIGINAL pattern too. It was unreachable only because no anchored block
+// contained an ISO reference; anchoring a third file is what made it reachable.
+//
+// Paired accept/reject table, all verified, because a check that stopped
+// classifying anything also reports clean:
+//   MATCH:  "99-lang set" · "(99 languages)" · "99-language set"
+//           "All 99 Whisper-supported languages" · "25 European languages"
+//   REJECT: "ISO 639-1 lang code" · "ISO 639-1 language code"
+const COUNT_IN_PROSE = /(?<![-\d])\d{1,3}\+?[\s-]*([A-Za-z-]+\s+){0,2}(languages?|langs?)\b/i;
 
 // The two declarations where the count used to live. The doc block directly
 // above each must carry no count. Deliberately NARROW: the other seven

--- a/website/scripts/check-language-count.mjs
+++ b/website/scripts/check-language-count.mjs
@@ -82,10 +82,24 @@ const SITES = [
 ];
 
 // A language count in prose: a 1-3 digit number (optionally +) within two
-// words of "language/languages". Catches "(99 languages)", "All 99
-// Whisper-supported languages", "99-language set"; does not catch ISO designators
-// like "639-1" (a digit cannot continue the match past "-1").
-const COUNT_IN_PROSE = /\b\d{1,3}\+?[\s-]*([A-Za-z-]+\s+){0,2}languages?\b/i;
+// words of "language/languages" OR its abbreviation "lang/langs". Catches
+// "(99 languages)", "All 99 Whisper-supported languages", "99-language set",
+// and "99-lang set"; does not catch ISO designators like "639-1" (a digit
+// cannot continue the match past "-1").
+//
+// The abbreviation was added by #2368's follow-up, and the omission is why the
+// guard could scan a file and report it clean: the stale comment read
+// "the Whisper-supported 99-lang set", so a pattern requiring the whole word
+// matched nothing and empty read as an answer. Adding the file to ANCHORS
+// without this would have changed nothing.
+//
+// Widening was two-way controlled before shipping rather than assumed safe: run
+// over every `//` comment in `Sources/`, the wider alternation newly matches
+// EXACTLY ONE line — the defect itself. That matters because this guard was
+// deliberately kept narrow (see ANCHORS below) after broad scanning produced
+// three false positives on correct prose, and a guard that cries wolf on correct
+// code trains people to skip it. This does not reopen that trade.
+const COUNT_IN_PROSE = /\b\d{1,3}\+?[\s-]*([A-Za-z-]+\s+){0,2}(languages?|langs?)\b/i;
 
 // The two declarations where the count used to live. The doc block directly
 // above each must carry no count. Deliberately NARROW: the other seven
@@ -107,6 +121,22 @@ const ANCHORS = [
     file: 'Sources/EnviousWisprAppKit/Views/Settings/LanguageCatalog.swift',
     label: 'all:',
     declRe: /static let all: \[Entry\]/,
+  },
+  // The CONSUMER, added by #2368's follow-up (Codex post-merge review on #2372).
+  //
+  // `SettingsManager` describes the same `LanguageTypes.isSupported` validation
+  // and had drifted to "the Whisper-supported 99-lang set" — the stale count this
+  // issue set out to remove, in a file the guard did not read.
+  //
+  // Its comment is a `//` block INSIDE a function body rather than a `///` doc
+  // block above a declaration, which is why this entry carries its own
+  // `commentRe`. Anchoring on the `let` the block introduces keeps the guard
+  // narrow: it reads that block and nothing else in a 1,000-line file.
+  {
+    file: 'Sources/EnviousWisprServices/SettingsManager.swift',
+    label: 'resolvedLanguageMode',
+    declRe: /let resolvedLanguageMode: LanguageMode = \{/,
+    commentRe: /^\s*\/\//,
   },
 ];
 
@@ -141,7 +171,9 @@ if (readableSites === 0) {
   failures.push(`no claim-site files could be read under ${ROOT} — the guard cannot see its subject, refusing to pass`);
 }
 
-for (const { file, label, declRe } of ANCHORS) {
+for (const { file, label, declRe, commentRe } of ANCHORS) {
+  // `///` unless the entry says otherwise — see the SettingsManager entry.
+  const commentLine = commentRe ?? /^\s*\/\/\//;
   const text = read(file);
   if (text === null) {
     failures.push(`${file}: file not found — anchor "${label}" cannot be verified`);
@@ -154,7 +186,7 @@ for (const { file, label, declRe } of ANCHORS) {
     continue;
   }
   const block = [];
-  for (let i = idx - 1; i >= 0 && /^\s*\/\/\//.test(lines[i]); i--) block.unshift(lines[i]);
+  for (let i = idx - 1; i >= 0 && commentLine.test(lines[i]); i--) block.unshift(lines[i]);
   if (block.length === 0) {
     failures.push(`${file}:${idx + 1}: no doc comment directly above "${label}" — restore the explanation; this guard verifies it carries no count`);
     continue;

--- a/website/scripts/check-language-count.mjs
+++ b/website/scripts/check-language-count.mjs
@@ -99,39 +99,65 @@ const SITES = [
 // deliberately kept narrow (see ANCHORS below) after broad scanning produced
 // three false positives on correct prose, and a guard that cries wolf on correct
 // code trains people to skip it. This does not reopen that trade.
-// TWO checks, and the split is the point (#2368 cloud review, rounds 1-3).
+// The guard asks whether a block restates the SIZE OF THE SET, and it derives
+// that size by COUNTING the set rather than by describing prose (#2368 cloud
+// review, rounds 1-4).
 //
-// Rounds 1 and 2 both found a new ISO SPELLING the pattern mis-read as a count:
-// first "ISO 639-1 lang code" matching `1 lang`, then "ISO 639 lang code"
-// matching `639 lang` once the hyphenated form was excluded. That is review
-// finding a new MEMBER of a set each round, which means the defect is that the
-// set is being DESCRIBED rather than enumerated — and a description always has a
-// next counterexample.
+// Four rounds each found a different numeric idiom the pattern mis-read as a
+// count: `ISO 639-1`, then bare `ISO 639`, then `2-letter language code` and
+// `BCP 47 language tag`. Each round I extended an exclusion list. **That is
+// describing a set, and a description always has a next member** — round 3's
+// comment even wrote down what a fourth finding would have to look like, and
+// round 4 produced exactly that on the first try. The prediction was falsifiable
+// and it was falsified, so the answer is not a fifth exclusion.
 //
-// So the question was inverted. Enumerating "every way prose can spell a count"
-// is open and unbounded. Enumerating "which numbers are LEGITIMATE here" is
-// CLOSED: the ISO 639 family has a fixed, externally-defined part list, and it is
-// the only numeric vocabulary the guarded blocks legitimately carry — verified by
-// reading all three, which contain `ISO 639-1` and `ISO 639-3` and nothing else
-// numeric.
+// The closed question was in the DATA. These blocks may not restate how big the
+// accepted-code set is; that size is countable from the set itself, so a number
+// is suspicious only when it is NEAR it. `639`, `47`, `2` and `1` are not, and
+// fall out with no exemption list at all.
 //
-// Allowed designators are removed FIRST, then what remains is checked for a
-// count. A genuine count in the same sentence as an ISO reference still fires,
-// which is what stops this being a blanket exemption.
+// Self-updating by construction: the band is computed from the live set, so if
+// the set grows the guard follows it. A hardcoded 100 would be one more number
+// that must track code and would go stale silently.
 //
-// Paired accept/reject table, all verified, because a check that quietly stopped
-// classifying anything also reports clean:
-//   MATCH:  "99-lang set" · "(99 languages)" · "99-language set"
-//           "All 99 Whisper-supported languages" · "25 European languages"
-//           "a 54-language list" · "ISO 639-3 entries and 99 languages"
-//   REJECT: "ISO 639-1 lang code" · "ISO 639 lang code" · "ISO 639 language code"
-//           "Accepted language codes: ISO 639-1, plus the ISO 639-3 entries"
+// STATED TRADE, because narrowing a guard deserves saying out loud: a wrong count
+// FAR from the set size — "the 25-language set" inside a block about the Whisper
+// set — is no longer caught. That is a real gap and it is the deliberate price of
+// never crying wolf on correct prose describing a code format, which this guard's
+// own header says trains people to skip it. The blocks are about THIS set, so a
+// drifted count in them lands near its size.
 //
-// A FOURTH finding here would have to be a number that is neither an ISO 639
-// designator nor a count. Stating that so the closure is falsifiable rather than
-// hopeful.
-const ISO_DESIGNATOR = /\bISO[\s ]*639(?:-[1-5])?\b/gi;
-const COUNT_IN_PROSE = /(?<![-\d])\d{1,3}\+?[\s-]*([A-Za-z-]+\s+){0,2}(languages?|langs?)\b/i;
+// Paired accept/reject, all verified:
+//   MATCH:  "99 languages" · "99-lang set" · "100+ languages" · "99+ languages"
+//           "All 99 Whisper-supported languages"
+//   REJECT: "ISO 639-1 lang code" · "ISO 639 lang code" · "2-letter language code"
+//           "BCP 47 language tag" · "ISO 639-3 entries"
+const ACCEPTED_SET_FILE = 'Sources/EnviousWisprCore/LanguageTypes.swift';
+
+function acceptedSetSize() {
+  const text = read(ACCEPTED_SET_FILE);
+  if (text === null) return null;
+  const open = text.indexOf('whisperSupportedLanguages: Set<String> = [');
+  if (open === -1) return null;
+  const close = text.indexOf(']', open);
+  if (close === -1) return null;
+  const codes = text.slice(open, close).match(/"[a-z]{2,3}"/g) || [];
+  return codes.length || null;
+}
+
+// +/- 2 around the live size: wide enough to catch the four numbers this issue
+// found in the wild (98, 99, 100, and their `+` forms), narrow enough to exclude
+// every identifier idiom above.
+function countInProseFor(size) {
+  const lo = size - 2;
+  const hi = size + 2;
+  const alts = [];
+  for (let n = lo; n <= hi; n++) alts.push(String(n));
+  return new RegExp(
+    String.raw`(?<![-\d])(?:${alts.join('|')})\+?[\s-]*([A-Za-z-]+\s+){0,2}(languages?|langs?)\b`,
+    'i'
+  );
+}
 
 // The two declarations where the count used to live. The doc block directly
 // above each must carry no count. Deliberately NARROW: the other seven
@@ -203,6 +229,17 @@ if (readableSites === 0) {
   failures.push(`no claim-site files could be read under ${ROOT} — the guard cannot see its subject, refusing to pass`);
 }
 
+const setSize = acceptedSetSize();
+if (setSize === null) {
+  // Fail CLOSED: if the set cannot be counted the guard cannot know what a wrong
+  // number looks like, and reporting clean would be an answer it has not earned.
+  failures.push(
+    `${ACCEPTED_SET_FILE}: could not count whisperSupportedLanguages — the guard derives its ` +
+      `suspicious range from that set and cannot run without it`
+  );
+}
+const countPattern = setSize === null ? null : countInProseFor(setSize);
+
 for (const { file, label, declRe, commentRe } of ANCHORS) {
   // `///` unless the entry says otherwise — see the SettingsManager entry.
   const commentLine = commentRe ?? /^\s*\/\/\//;
@@ -223,7 +260,7 @@ for (const { file, label, declRe, commentRe } of ANCHORS) {
     failures.push(`${file}:${idx + 1}: no doc comment directly above "${label}" — restore the explanation; this guard verifies it carries no count`);
     continue;
   }
-  const m = block.join('\n').replace(ISO_DESIGNATOR, 'ISO-STD').match(COUNT_IN_PROSE);
+  const m = countPattern === null ? null : block.join('\n').match(countPattern);
   if (m) {
     failures.push(`${file}:${idx + 1 - block.length}..${idx}: doc block above "${label}" carries a language count ("${m[0]}") — the set's size is not a marketed figure (#2368); describe what it is, with no number`);
   }


### PR DESCRIPTION
Closes #2368.

## What was left

Codex's post-merge review on #2372 flagged that `SettingsManager` still described the `LanguageTypes.isSupported` validation as *"the Whisper-supported 99-lang set"* — the stale count this issue set out to eliminate — and asked for that file to be added to `check-language-count.mjs`'s `ANCHORS`.

## That is correct, and it would not have worked

**Adding the file alone changes nothing, and the reason is one word wide.** The guard's `COUNT_IN_PROSE` requires `language`/`languages`; the stale comment is **abbreviated**. The guard would have scanned the file, matched nothing, and reported clean — a guard that runs, returns empty, and has empty read as an answer.

So the file's absence was the less interesting of two defects:

**1. The pattern.** Now accepts `lang`/`langs` alongside the full word.

**Two-way controlled before shipping rather than assumed safe:** run over every `//` comment in `Sources/`, the wider alternation newly matches **exactly one line** — the defect itself. That matters because this guard was deliberately kept narrow after broad scanning produced three false positives on correct prose, and its own header says a guard that cries wolf on correct code trains people to skip it. Measured, so the widening demonstrably does not reopen that trade.

**2. The comment shape.** The two existing anchors walk `///` doc blocks above a declaration. This comment is a `//` block **inside a function body**, so the new anchor carries its own `commentRe`. Anchoring on the `let` that the block introduces keeps it narrow — it reads that block and nothing else in a 1,000-line file.

## Verified both ways

A guard that merely stops firing is indistinguishable from one that was deleted, so:

```
defect restored:  FAIL: …:836..840: doc block above "resolvedLanguageMode"
                  carries a language count ("99-lang") …
fix in place:     language count: 42 claim sites carry "99+", 0 failure(s)
```

Without that control the new anchor could have been inert and reported clean — the same defect one level up from the one being fixed.

## The comment itself

Now names what the set **is** rather than how big it is: "the accepted-code set in `LanguageTypes`". That is the disposition #2368 already chose for the other nine comments — the set is a validation allowlist for persisted session priors, including ISO 639-3 codes, not a marketed language count. Welding the two is how four different numbers were born in the first place.

## Validation

- Debug lane **6,820**, Release lane **6,168**, both green, both reconciling exactly against their own per-bundle sums.
- **Both** crash detectors clean (`Fatal error` 0, `Crash:` 0). Running the pair is deliberate: reconciliation catches a concurrently-corrupted log by construction, and structurally *cannot* catch a crashed one, because a crash truncates the run and both numbers then come from the same truncated log and agree perfectly while agreeing about the wrong thing. Each is blind to the other's case.
- The guard run directly, both directions, as above.
- Lane logs copied to `docs/audits/lane-logs-2368/` before merge, because `PROJECT_ROOT` is the worktree — so the fetch that completes a merge deletes the evidence that justified it.

Lane: `Code` (primary), mixed with `Content`. `mixed_pr: true`. Tier: SMALL.
