### PR TITLE
fix(vocabulary): the multi-word fuzzy pass no longer swallows a glued domain suffix (#2312)

### DIFF
--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -809,68 +809,100 @@ public struct WordCorrector: Sendable {
             }
 
             if let candidates = multiAliasByCount[span] {
-              var bestScore = 0.0
-              var secondBest = 0.0
-              var bestCanonical = ""
-              var bestAlias = ""
+              // #2312: TWO attempts when the span's LAST token carries a glued
+              // domain suffix, mirroring the single-word path's proven shape.
+              //
+              // The bug this fixes is not "the peeled form was never tried" — it
+              // is that the UNPEELED form already scores above threshold and
+              // wins. `international platforn.com` against the alias
+              // `international platform` scores 0.890, clears 0.85, and the
+              // accept branch then rebuilds the span from `lastSuffix`, which is
+              // EMPTY because the token ends in a letter. The dictated `.com` is
+              // destroyed by a correction meant only to fix a spelling.
+              //
+              // So a "try peeled only if unpeeled failed" rule would not fix
+              // anything. Both attempts are scored, then compared.
+              let strippedCores = slice.map { stripPunctuation($0) }
+              let domainSplit = strippedCores.last.flatMap { Self.splitDomainSuffix($0) }
 
-              for entry in candidates {
-                let alias = entry.alias
-                let canonical = entry.canonical
-                let s = score(phrase, against: alias)
-                if s > bestScore {
-                  if bestCanonical != canonical { secondBest = bestScore }
-                  bestScore = s
-                  bestCanonical = canonical
-                  bestAlias = alias
-                } else if s > secondBest && canonical != bestCanonical {
-                  secondBest = s
+              let unpeeledOutcome = multiWordFuzzyAttempt(
+                phrase: phrase, rawPhrase: rawPhrase, candidates: candidates,
+                canonicalToWord: canonicalToWord,
+                // Restricted only when a peel is available: with no suffix to
+                // swallow there is nothing for the restriction to protect, and
+                // narrowing the pool would silently drop today's ordinary matches.
+                domainShapedOnly: domainSplit != nil)
+
+              var peeledRawPhrase: String?
+              var peeledOutcome: MultiWordFuzzyAttemptOutcome = .noCandidate
+
+              if let domainSplit {
+                var peeledCores = strippedCores
+                peeledCores[peeledCores.count - 1] = domainSplit.bare
+                // Peeling can EXPOSE a reserved trigger word the slice guard
+                // above could not see: `emoji.com` is not `emoji` until the
+                // suffix comes off. Re-check what the peel actually produced.
+                let exposesReservedWord = peeledCores.contains {
+                  Self.emojiTriggerReservedWords.contains($0.lowercased())
+                }
+                if !exposesReservedWord {
+                  let peeledRaw = peeledCores.joined(separator: " ")
+                  peeledRawPhrase = peeledRaw
+                  peeledOutcome = multiWordFuzzyAttempt(
+                    phrase: peeledRaw.lowercased(), rawPhrase: peeledRaw,
+                    candidates: candidates, canonicalToWord: canonicalToWord,
+                    domainShapedOnly: false)
                 }
               }
 
-              let margin = bestScore - secondBest
-              // Phase 2 (#638) §8.2 item 1: lift multi-word threshold by +0.05
-              // when the candidate span includes any common stopword. Prevents
-              // "and we said" → "Andre" type degeneration.
-              let phraseTokens = Set(phrase.components(separatedBy: " "))
-              let hasStopword = !phraseTokens.isDisjoint(with: Self.stopwords)
-              let stopwordPenalty = hasStopword ? 0.05 : 0.0
-              // Phase 2 (#638) §8.2 item 4: per-term override for the matched
-              // canonical, if any. Override is the absolute bar.
-              let multiOverride = canonicalToWord[bestCanonical.lowercased()]?
-                .minSimilarityOverride
-              let multiThreshold = multiOverride ?? (Self.multiWordThreshold + stopwordPenalty)
-              if bestScore >= multiThreshold,
-                margin >= Self.ambiguityMargin,
-                rawPhrase != bestCanonical
-              {
-                let (firstPrefix, _, _) = splitPunctuation(tokens[i])
-                let (_, _, lastSuffix) = splitPunctuation(tokens[i + span - 1])
-                tokens.replaceSubrange(
-                  i..<(i + span), with: [firstPrefix + bestCanonical + lastSuffix])
-                appendReplacement(forCanonical: bestCanonical)
-                matched = true
-                #if DEBUG
-                  Self.logger.debug(
-                    "WordCorrector: type=multi-word-fuzzy source='\(rawPhrase)' target='\(bestCanonical)' alias='\(bestAlias)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(margin, format: .fixed(precision: 3)) stopword=\(hasStopword) override=\(multiOverride.map { String($0) } ?? "nil")"
-                  )
-                #endif
-                break
-              } else if bestScore > 0 {
-                #if DEBUG
-                  let reason: String
-                  if bestScore < multiThreshold {
-                    reason = "below_threshold"
-                  } else if margin < Self.ambiguityMargin {
-                    reason = "below_margin"
-                  } else {
-                    reason = "same_as_input"
-                  }
-                  Self.logger.debug(
-                    "WordCorrector: REJECT pass=multi-word-fuzzy source='\(rawPhrase)' best_target='\(bestCanonical)' alias='\(bestAlias)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(margin, format: .fixed(precision: 3)) threshold=\(multiThreshold, format: .fixed(precision: 3)) stopword=\(hasStopword) reason=\(reason)"
-                  )
-                #endif
+              let winner: (candidate: MultiWordFuzzyCandidate, peeled: Bool)
+              switch (unpeeledOutcome, peeledOutcome) {
+              case (.ambiguous, _), (_, .ambiguous):
+                // An ambiguous attempt is NOT "found nothing": letting the other
+                // attempt decide a span this one already judged uncertain is the
+                // defect PR #2298 round 17 fixed one pass over.
+                continue
+              case (.candidate(let unpeeled), .candidate(let peeled)):
+                // Cross-attempt ambiguity, which neither attempt's own margin can
+                // see: two internally-clear winners can still disagree with each
+                // other by less than the margin.
+                if unpeeled.canonical != peeled.canonical,
+                  abs(unpeeled.score - peeled.score) < Self.ambiguityMargin
+                {
+                  continue
+                }
+                winner = unpeeled.score >= peeled.score ? (unpeeled, false) : (peeled, true)
+              case (.candidate(let unpeeled), .noCandidate):
+                winner = (unpeeled, false)
+              case (.noCandidate, .candidate(let peeled)):
+                winner = (peeled, true)
+              case (.noCandidate, .noCandidate):
+                continue
               }
+
+              let (firstPrefix, _, _) = splitPunctuation(tokens[i])
+              let (_, _, lastSuffix) = splitPunctuation(tokens[i + span - 1])
+              // Reattached UNLESS the canonical already specifies its own domain,
+              // the same rule Pass 4 applies — and BEFORE `lastSuffix`, so
+              // `platforn.com!` becomes canonical + `.com` + `!`.
+              let reattachedDomainSuffix =
+                winner.peeled && !Self.isDomainShaped(winner.candidate.canonical)
+                ? (domainSplit?.suffix ?? "") : ""
+
+              tokens.replaceSubrange(
+                i..<(i + span),
+                with: [
+                  firstPrefix + winner.candidate.canonical + reattachedDomainSuffix + lastSuffix
+                ])
+              appendReplacement(forCanonical: winner.candidate.canonical)
+              matched = true
+              #if DEBUG
+                let winningSource = winner.peeled ? (peeledRawPhrase ?? rawPhrase) : rawPhrase
+                Self.logger.debug(
+                  "WordCorrector: type=multi-word-fuzzy source='\(winningSource)' target='\(winner.candidate.canonical)' alias='\(winner.candidate.alias)' score=\(winner.candidate.score, format: .fixed(precision: 3)) margin=\(winner.candidate.margin, format: .fixed(precision: 3)) threshold=\(winner.candidate.threshold, format: .fixed(precision: 3)) stopword=\(winner.candidate.hasStopword) peeled=\(winner.peeled)"
+                )
+              #endif
+              break
             }
           }
         }
@@ -1225,6 +1257,104 @@ public struct WordCorrector: Sendable {
   /// uncertain -- the identical shape round 16 fixed one layer up, for the
   /// cross-attempt (unpeeled vs. peeled) comparison instead of this
   /// within-attempt one.
+  /// One Pass 2 fuzzy attempt's result (#2312).
+  ///
+  /// Mirrors `SingleAttemptFuzzyOutcome` deliberately, including its three-way
+  /// shape: "genuinely ambiguous" must stay distinguishable from "nothing scored
+  /// close", because collapsing them lets an in-attempt ambiguity read as "this
+  /// attempt found nothing" and hands the decision to the other attempt — the
+  /// defect round 17 of PR #2298 fixed one pass over.
+  ///
+  /// Carries more than the single-word version because Pass 2's debug line
+  /// reports alias, margin, threshold and stopword state, and recomputing those
+  /// at the call site would be a second place for them to drift.
+  private struct MultiWordFuzzyCandidate {
+    let canonical: String
+    let alias: String
+    let score: Double
+    let margin: Double
+    let threshold: Double
+    let hasStopword: Bool
+  }
+
+  private enum MultiWordFuzzyAttemptOutcome {
+    case candidate(MultiWordFuzzyCandidate)
+    case ambiguous
+    case noCandidate
+  }
+
+  /// Score one phrase against the Pass 2 pool, applying every gate this pass
+  /// already applied — stopword penalty, per-term override, best-vs-second
+  /// ambiguity margin — to THIS attempt independently (#2312).
+  ///
+  /// `domainShapedOnly` gates the pool exactly as it does for the single-word
+  /// path: the UNPEELED attempt passes `true`, because fuzzy is only safe
+  /// unpeeled when compared against an equally domain-shaped candidate — both
+  /// sides then carry a suffix, so nothing is silently swallowed. The PEELED
+  /// attempt passes `false` and sees the ordinary pool.
+  ///
+  /// The stopword check is recomputed per attempt rather than shared: peeling
+  /// can CHANGE it. `alpha and.com` carries the token `and.com` unpeeled and
+  /// `and` once peeled, and the check is exact token membership — so a shared
+  /// value would apply the wrong threshold to one of the two attempts.
+  private func multiWordFuzzyAttempt(
+    phrase: String,
+    rawPhrase: String,
+    candidates: [Lookups.AliasCanonical],
+    canonicalToWord: [String: CustomWord],
+    domainShapedOnly: Bool
+  ) -> MultiWordFuzzyAttemptOutcome {
+    var bestScore = 0.0
+    var secondBest = 0.0
+    var bestCanonical = ""
+    var bestAlias = ""
+
+    for entry in candidates {
+      if domainShapedOnly, !Self.isDomainShaped(entry.alias) { continue }
+      let candidateScore = score(phrase, against: entry.alias)
+      if candidateScore > bestScore {
+        if bestCanonical != entry.canonical { secondBest = bestScore }
+        bestScore = candidateScore
+        bestCanonical = entry.canonical
+        bestAlias = entry.alias
+      } else if candidateScore > secondBest, entry.canonical != bestCanonical {
+        secondBest = candidateScore
+      }
+    }
+
+    guard bestScore > 0 else { return .noCandidate }
+
+    let phraseTokens = Set(phrase.components(separatedBy: " "))
+    let hasStopword = !phraseTokens.isDisjoint(with: Self.stopwords)
+    let stopwordPenalty = hasStopword ? 0.05 : 0.0
+    let override = canonicalToWord[bestCanonical.lowercased()]?.minSimilarityOverride
+    let threshold = override ?? (Self.multiWordThreshold + stopwordPenalty)
+    let margin = bestScore - secondBest
+
+    guard bestScore >= threshold else {
+      #if DEBUG
+        Self.logger.debug(
+          "WordCorrector: REJECT pass=multi-word-fuzzy source='\(rawPhrase)' best_target='\(bestCanonical)' alias='\(bestAlias)' score=\(bestScore, format: .fixed(precision: 3)) threshold=\(threshold, format: .fixed(precision: 3)) stopword=\(hasStopword) domain_only=\(domainShapedOnly) reason=below_threshold"
+        )
+      #endif
+      return .noCandidate
+    }
+    guard margin >= Self.ambiguityMargin else {
+      #if DEBUG
+        Self.logger.debug(
+          "WordCorrector: REJECT pass=multi-word-fuzzy source='\(rawPhrase)' best_target='\(bestCanonical)' alias='\(bestAlias)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(margin, format: .fixed(precision: 3)) stopword=\(hasStopword) domain_only=\(domainShapedOnly) reason=below_margin"
+        )
+      #endif
+      return .ambiguous
+    }
+    guard rawPhrase != bestCanonical else { return .noCandidate }
+
+    return .candidate(
+      MultiWordFuzzyCandidate(
+        canonical: bestCanonical, alias: bestAlias, score: bestScore,
+        margin: margin, threshold: threshold, hasStopword: hasStopword))
+  }
+
   private enum SingleAttemptFuzzyOutcome {
     case candidate(canonical: String, score: Double)
     case ambiguous

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -857,6 +857,10 @@ public struct WordCorrector: Sendable {
 
               let winner: (candidate: MultiWordFuzzyCandidate, peeled: Bool)
               switch (unpeeledOutcome, peeledOutcome) {
+              case (.alreadyCorrect, _), (_, .alreadyCorrect):
+                // Already right as dictated. Leave the span alone rather than
+                // letting the other attempt replace correct text.
+                continue
               case (.ambiguous, _), (_, .ambiguous):
                 // An ambiguous attempt is NOT "found nothing": letting the other
                 // attempt decide a span this one already judged uncertain is the
@@ -1280,6 +1284,17 @@ public struct WordCorrector: Sendable {
   private enum MultiWordFuzzyAttemptOutcome {
     case candidate(MultiWordFuzzyCandidate)
     case ambiguous
+    /// The phrase ALREADY equals its canonical — correct as dictated, nothing to
+    /// do. TERMINAL for the span, and distinct from `.noCandidate` for the same
+    /// reason `.ambiguous` is (#2406 cloud review).
+    ///
+    /// Collapsing it into `.noCandidate` let the OTHER attempt win and replace
+    /// text that was already right: with `International Platform.com` dictated,
+    /// the peeled attempt matches its canonical perfectly while an unrelated
+    /// domain-shaped distractor can clear the threshold unpeeled — and the
+    /// switch would accept the distractor. A hazard this PR's two-attempt design
+    /// created; the single-attempt version had no other branch to hand it to.
+    case alreadyCorrect
     case noCandidate
   }
 
@@ -1347,7 +1362,7 @@ public struct WordCorrector: Sendable {
       #endif
       return .ambiguous
     }
-    guard rawPhrase != bestCanonical else { return .noCandidate }
+    guard rawPhrase != bestCanonical else { return .alreadyCorrect }
 
     return .candidate(
       MultiWordFuzzyCandidate(

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -770,6 +770,15 @@ public struct WordCorrector: Sendable {
       var i = 0
       while i < tokens.count {
         var matched = false
+        // #2406 review r2: how far to advance when a span is left ALONE.
+        //
+        // A MATCHED span collapses to one token, so `i += 1` steps past it. An
+        // ALREADY-CORRECT span does not — it keeps its N tokens — so advancing by
+        // one lands back INSIDE text just declared protected, where a shorter
+        // overlapping alias can rewrite it. `Alpha Beta Gamma.com` is correct as a
+        // three-token span, and a `beta gamma` alias then rewrote it to
+        // `Alpha Wrong.com`. Reserve the whole span instead.
+        var reservedSpan: Int?
 
         for span in stride(from: min(maxSpan, tokens.count - i), through: 2, by: -1) {
           let slice = tokens[i..<(i + span)]
@@ -798,7 +807,7 @@ public struct WordCorrector: Sendable {
 
         // Pass 2: fuzzy multi-word fallback (only if exact missed for all spans)
         if !matched {
-          for span in stride(from: min(maxSpan, tokens.count - i), through: 2, by: -1) {
+          spanLoop: for span in stride(from: min(maxSpan, tokens.count - i), through: 2, by: -1) {
             let slice = tokens[i..<(i + span)]
             let phrase = slice.map { stripPunctuation($0).lowercased() }.joined(separator: " ")
             let rawPhrase = slice.map { stripPunctuation($0) }.joined(separator: " ")
@@ -858,9 +867,13 @@ public struct WordCorrector: Sendable {
               let winner: (candidate: MultiWordFuzzyCandidate, peeled: Bool)
               switch (unpeeledOutcome, peeledOutcome) {
               case (.alreadyCorrect, _), (_, .alreadyCorrect):
-                // Already right as dictated. Leave the span alone rather than
-                // letting the other attempt replace correct text.
-                continue
+                // Already right as dictated. RESERVE the span — not `continue`,
+                // which only tries a shorter one and then lets the outer loop walk
+                // back into it.
+                reservedSpan = span
+                // Labelled: a bare `break` inside a `switch` exits the SWITCH, falling
+                // through to code that reads an uninitialised `winner`.
+                break spanLoop
               case (.ambiguous, _), (_, .ambiguous):
                 // An ambiguous attempt is NOT "found nothing": letting the other
                 // attempt decide a span this one already judged uncertain is the
@@ -911,7 +924,7 @@ public struct WordCorrector: Sendable {
           }
         }
 
-        i += 1
+        i += reservedSpan ?? 1
       }
     }
 

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -134,6 +134,12 @@ public struct WordCorrector: Sendable {
     public let lowercasedCanonicals: [String]
     public let singleFuzzyCandidates: [SurfaceCanonical]
     public let multiAliasByCount: [Int: [AliasCanonical]]
+    /// #2406 review r6: the NON-pack multi-word alias keys, needed to answer
+    /// "is this exact multi match a pack term" at Pass 1. `nonPackExactKeys`
+    /// cannot answer it — that set is built from SINGLE alias keys and
+    /// canonicals only (see its construction), so a multi-word phrase is absent
+    /// from it whatever its authority.
+    public let nonPackMultiAliasMap: [String: String]
     /// #992 pack fuzzy tier (LOWER authority than the non-pack pools above).
     /// Single-word pack ALIAS surfaces (lowercased, length ≥ packFuzzyMinLength)
     /// for the pack Pass-4 scan; pack CANONICALS (length ≥ packFuzzyMinLength)
@@ -651,6 +657,7 @@ public struct WordCorrector: Sendable {
       lowercasedCanonicals: lowercasedCanonicals,
       singleFuzzyCandidates: singleFuzzyCandidates,
       multiAliasByCount: multiAliasByCount,
+      nonPackMultiAliasMap: nonPackMultiAliasMap,
       packSingleFuzzyCandidates: packSingleFuzzyCandidates,
       packCanonicals: packCanonicals,
       packLowercasedCanonicals: packLowercasedCanonicals,
@@ -690,6 +697,7 @@ public struct WordCorrector: Sendable {
   ) {
     let singleAliasMap = lookups.singleAliasMap
     let multiAliasMap = lookups.multiAliasMap
+    let nonPackMultiAliasMap = lookups.nonPackMultiAliasMap
     let nospaceCanonicalMap = lookups.nospaceCanonicalMap
     let canonicalToID = lookups.canonicalToID
     let canonicalToWord = lookups.canonicalToWord
@@ -790,8 +798,41 @@ public struct WordCorrector: Sendable {
             continue
           }
 
-          // Pass 1: exact multi-word alias
-          if let canonical = multiAliasMap[phrase], rawPhrase != canonical {
+          // Pass 1: exact multi-word alias.
+          //
+          // NON-PACK BEATS PACK ACROSS THE PEEL BOUNDARY (#2406 review r6, P1).
+          //
+          // This map is the WIDE one and includes pack gap-fill entries, so a
+          // pack alias carrying its own domain suffix matches the unpeeled
+          // phrase here and `break`s — before Pass 2 can offer the user's OWN
+          // alias, which matches the same span once the suffix is peeled. The
+          // user's word loses to a pack term, which inverts this repo's
+          // precedence.
+          //
+          // Measured shape: pack `international platform.com` -> Pack Choice,
+          // user `international platform` -> User Choice, dictated
+          // `international platform.com`. Slot 2 must outrank slot 3.
+          //
+          // This is Pass 4's four-slot ladder (#2281 round 7) applied to the
+          // multi-word passes, and only the middle pair needed arbitrating:
+          //   1. unpeeled non-pack   accepted here, unchanged
+          //   2. peeled   non-pack   deferred to Pass 2's exact lookup
+          //   3. unpeeled pack       accepted here ONLY when 2 is absent
+          //   4. peeled   pack       KNOWN LIMIT, see below
+          //
+          // KNOWN LIMIT, stated rather than hidden: slot 4 does not exist.
+          // Pass 2's pool is built solely from `nonPackMultiAliasMap`, so a PACK
+          // alias whose key matches only the PEELED phrase is never matched
+          // exactly and falls through to fuzzy. That is the lowest-authority
+          // slot, so its absence can only under-match, never override a
+          // higher-authority answer — and adding it would mean giving Pass 2 a
+          // pack pool, which is a larger change than this defect requires.
+          if let canonical = multiAliasMap[phrase], rawPhrase != canonical,
+            !Self.nonPackPeeledExactExists(
+              slice: slice, nonPackMultiAliasMap: nonPackMultiAliasMap,
+              isPackMatch: nonPackMultiAliasMap[phrase] == nil,
+              stripPunctuation: stripPunctuation)
+          {
             let (firstPrefix, _, _) = splitPunctuation(tokens[i])
             let (_, _, lastSuffix) = splitPunctuation(tokens[i + span - 1])
             tokens.replaceSubrange(i..<(i + span), with: [firstPrefix + canonical + lastSuffix])
@@ -1453,6 +1494,38 @@ public struct WordCorrector: Sendable {
       MultiWordFuzzyCandidate(
         canonical: bestCanonical, alias: bestAlias, score: bestScore,
         margin: margin, threshold: threshold, hasStopword: hasStopword))
+  }
+
+  /// Does a NON-pack alias match this span's PEELED phrase exactly?
+  ///
+  /// Only asked when Pass 1's own match came from a PACK entry, because that is
+  /// the only case where deferring changes anything: a non-pack unpeeled match
+  /// already outranks everything and must not be delayed. Returning `false` for
+  /// a non-pack match keeps the existing behaviour byte-for-byte rather than
+  /// re-deciding it (#2406 review r6).
+  ///
+  /// The peel is recomputed here rather than threaded in, because Pass 1 runs
+  /// its own span loop before Pass 2 exists and the two loops do not share a
+  /// frame. It is a string split over at most a handful of tokens, and it runs
+  /// only on the pack branch.
+  private static func nonPackPeeledExactExists(
+    slice: ArraySlice<String>,
+    nonPackMultiAliasMap: [String: String],
+    isPackMatch: Bool,
+    stripPunctuation: (String) -> String
+  ) -> Bool {
+    guard isPackMatch else { return false }
+    var cores = slice.map(stripPunctuation)
+    guard let last = cores.last, let split = Self.splitDomainSuffix(last) else { return false }
+    cores[cores.count - 1] = split.bare
+    // Peeling can EXPOSE a reserved trigger word, the same re-check Pass 2 makes
+    // for the same reason: `emoji.com` is not `emoji` until the suffix is off.
+    // If the peel exposes one, Pass 2 will refuse the span, so deferring to it
+    // would leave the span uncorrected rather than better corrected.
+    if cores.contains(where: { Self.emojiTriggerReservedWords.contains($0.lowercased()) }) {
+      return false
+    }
+    return nonPackMultiAliasMap[cores.joined(separator: " ").lowercased()] != nil
   }
 
   private enum SingleAttemptFuzzyOutcome {

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -834,6 +834,78 @@ public struct WordCorrector: Sendable {
               let strippedCores = slice.map { stripPunctuation($0) }
               let domainSplit = strippedCores.last.flatMap { Self.splitDomainSuffix($0) }
 
+              // The peel is computed ONCE, above both the exact lookup and the
+              // fuzzy attempts, because both need it. Peeling can EXPOSE a
+              // reserved trigger word the slice guard above could not see:
+              // `emoji.com` is not `emoji` until the suffix comes off. Re-check
+              // what the peel actually produced.
+              var peeledRawPhrase: String?
+              if let domainSplit {
+                var peeledCores = strippedCores
+                peeledCores[peeledCores.count - 1] = domainSplit.bare
+                let exposesReservedWord = peeledCores.contains {
+                  Self.emojiTriggerReservedWords.contains($0.lowercased())
+                }
+                if !exposesReservedWord { peeledRawPhrase = peeledCores.joined(separator: " ") }
+              }
+
+              // EXACT BEFORE FUZZY, ACROSS THE PEEL BOUNDARY (#2406 review r5,
+              // and the consolidation of r2/r3/r4 — every one of those was this
+              // same root at a different member).
+              //
+              // Pass 1 gives the UNPEELED phrase an exact lookup and has already
+              // missed by the time Pass 2 runs. The PEELED phrase had no exact
+              // lookup at all, so a certainty was being routed through a
+              // competition: `international platform.com`, with the alias
+              // `international platform` scoring 1.0 and a distractor
+              // `international platforma` scoring 0.972, was rejected on the
+              // ambiguity margin and never corrected.
+              //
+              // A COMPETITION IS THE WRONG INSTRUMENT FOR A CERTAINTY. Threshold
+              // and margin exist to adjudicate candidates that only RESEMBLE the
+              // input; an exact member of the pool does not resemble it, it IS
+              // it. This is the rule Pass 4 reached at round 4 of #2281 —
+              // "EXACT match to completion, unpeeled then peeled, before any
+              // fuzzy pass runs at all" — applied to the pass that was built
+              // without it.
+              //
+              // No authority ladder is needed here and one would be wrong: this
+              // pool is built solely from `nonPackMultiAliasMap`, so every entry
+              // carries the same authority, and the dictionary it derives from
+              // makes an alias hit unique by construction. That is what makes
+              // the question CLOSED — "is this phrase a key of the pool" has one
+              // answer, where "does it resemble one" has a next counterexample.
+              if let peeledRaw = peeledRawPhrase,
+                let exactCanonical = candidates.first(where: { $0.alias == peeledRaw.lowercased() })?
+                  .canonical
+              {
+                if peeledRaw == exactCanonical {
+                  // Already right as dictated. Reserve the span, exactly as the
+                  // fuzzy `.alreadyCorrect` branch does — otherwise the outer
+                  // loop walks back into text this pass just declared correct.
+                  reservedSpan = span
+                  break spanLoop
+                }
+                let (firstPrefix, _, _) = splitPunctuation(tokens[i])
+                let (_, _, lastSuffix) = splitPunctuation(tokens[i + span - 1])
+                // Same reattachment rule as the fuzzy accept branch and as
+                // Pass 4: a canonical that already specifies its own domain
+                // keeps its own, whatever suffix was dictated.
+                let reattach =
+                  Self.isDomainShaped(exactCanonical) ? "" : (domainSplit?.suffix ?? "")
+                tokens.replaceSubrange(
+                  i..<(i + span),
+                  with: [firstPrefix + exactCanonical + reattach + lastSuffix])
+                appendReplacement(forCanonical: exactCanonical)
+                matched = true
+                #if DEBUG
+                  Self.logger.debug(
+                    "WordCorrector: type=multi-word-exact-peeled source='\(peeledRaw)' target='\(exactCanonical)'"
+                  )
+                #endif
+                break spanLoop
+              }
+
               let unpeeledOutcome = multiWordFuzzyAttempt(
                 phrase: phrase, rawPhrase: rawPhrase, candidates: candidates,
                 canonicalToWord: canonicalToWord,
@@ -842,26 +914,12 @@ public struct WordCorrector: Sendable {
                 // narrowing the pool would silently drop today's ordinary matches.
                 domainShapedOnly: domainSplit != nil)
 
-              var peeledRawPhrase: String?
               var peeledOutcome: MultiWordFuzzyAttemptOutcome = .noCandidate
-
-              if let domainSplit {
-                var peeledCores = strippedCores
-                peeledCores[peeledCores.count - 1] = domainSplit.bare
-                // Peeling can EXPOSE a reserved trigger word the slice guard
-                // above could not see: `emoji.com` is not `emoji` until the
-                // suffix comes off. Re-check what the peel actually produced.
-                let exposesReservedWord = peeledCores.contains {
-                  Self.emojiTriggerReservedWords.contains($0.lowercased())
-                }
-                if !exposesReservedWord {
-                  let peeledRaw = peeledCores.joined(separator: " ")
-                  peeledRawPhrase = peeledRaw
-                  peeledOutcome = multiWordFuzzyAttempt(
-                    phrase: peeledRaw.lowercased(), rawPhrase: peeledRaw,
-                    candidates: candidates, canonicalToWord: canonicalToWord,
-                    domainShapedOnly: false)
-                }
+              if let peeledRaw = peeledRawPhrase {
+                peeledOutcome = multiWordFuzzyAttempt(
+                  phrase: peeledRaw.lowercased(), rawPhrase: peeledRaw,
+                  candidates: candidates, canonicalToWord: canonicalToWord,
+                  domainShapedOnly: false)
               }
 
               let winner: (candidate: MultiWordFuzzyCandidate, peeled: Bool)

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -1359,6 +1359,21 @@ public struct WordCorrector: Sendable {
     let threshold = override ?? (Self.multiWordThreshold + stopwordPenalty)
     let margin = bestScore - secondBest
 
+    // SELF-IDENTITY FIRST, ahead of both gates (#2406 review r3).
+    //
+    // "This text is already the canonical" is a fact about the INPUT. The
+    // threshold and margin gates describe a COMPETITION between candidates, and a
+    // competition cannot make correct text incorrect.
+    //
+    // Ordered last, the margin gate reached it first: with `Alpha Beta Gamma.com`
+    // dictated and a near-twin alias present, the attempt returned `.ambiguous`
+    // rather than `.alreadyCorrect` — and `.ambiguous` does not reserve the span,
+    // so an overlapping `beta gamma` alias rewrote text that was already right.
+    //
+    // Safe to hoist above the threshold too: an exact self-match scores ~1.0, so
+    // it clears any threshold it could have been measured against.
+    guard rawPhrase != bestCanonical else { return .alreadyCorrect }
+
     guard bestScore >= threshold else {
       #if DEBUG
         Self.logger.debug(
@@ -1375,7 +1390,6 @@ public struct WordCorrector: Sendable {
       #endif
       return .ambiguous
     }
-    guard rawPhrase != bestCanonical else { return .alreadyCorrect }
 
     return .candidate(
       MultiWordFuzzyCandidate(

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -772,6 +772,19 @@ public struct WordCorrector: Sendable {
       }
     }
 
+    // Token ranges the multi-word passes declared ALREADY CORRECT (#2406 r7).
+    //
+    // Reserving a span stopped the multi-word scan walking back into it, and
+    // stopped there: Passes 3-5 map over every token independently and knew
+    // nothing about it, so a single-word alias could rewrite one token of a span
+    // this pass had just certified. Protection that ends at the pass boundary is
+    // not protection — the user sees the same corruption, one pass later.
+    //
+    // Recorded in FINAL array coordinates and safe to do so: a reserved span is
+    // never replaced, so it keeps its N tokens, and every later iteration acts
+    // only at positions at or beyond its end.
+    var reservedTokenRanges: [Range<Int>] = []
+
     // Pass 1 + 2: multi-word (exact then fuzzy)
     if !multiAliasMap.isEmpty {
       let maxSpan = multiAliasMap.keys.reduce(0) { max($0, $1.components(separatedBy: " ").count) }
@@ -827,12 +840,22 @@ public struct WordCorrector: Sendable {
           // slot, so its absence can only under-match, never override a
           // higher-authority answer — and adding it would mean giving Pass 2 a
           // pack pool, which is a larger change than this defect requires.
-          if let canonical = multiAliasMap[phrase], rawPhrase != canonical,
-            !Self.nonPackPeeledExactExists(
+          //
+          // DEFERRING MUST END THE EXACT SCAN FOR THIS POSITION, not fall to a
+          // SHORTER span (#2406 r7). Folded into the `if` condition, a deferral
+          // was indistinguishable from a miss, so Pass 1 simply tried span-1 —
+          // where a SHORTER pack alias at the same position could match and win,
+          // reinstating the inversion this deferral exists to prevent, one span
+          // down. Same shape as r3 one pass over: `continue` only ever tries a
+          // shorter span, and the protection has to stop the scan instead.
+          if let canonical = multiAliasMap[phrase], rawPhrase != canonical {
+            if Self.nonPackPeeledExactExists(
               slice: slice, nonPackMultiAliasMap: nonPackMultiAliasMap,
               isPackMatch: nonPackMultiAliasMap[phrase] == nil,
               stripPunctuation: stripPunctuation)
-          {
+            {
+              break  // hand this position to Pass 2, which owns the peeled exact
+            }
             let (firstPrefix, _, _) = splitPunctuation(tokens[i])
             let (_, _, lastSuffix) = splitPunctuation(tokens[i + span - 1])
             tokens.replaceSubrange(i..<(i + span), with: [firstPrefix + canonical + lastSuffix])
@@ -1023,12 +1046,18 @@ public struct WordCorrector: Sendable {
           }
         }
 
+        if let reservedSpan { reservedTokenRanges.append(i..<(i + reservedSpan)) }
         i += reservedSpan ?? 1
       }
     }
 
     // Passes 3-5: single-word (per token)
-    let corrected = tokens.map { token -> String in
+    let corrected = tokens.enumerated().map { index, token -> String in
+      // A span the multi-word passes certified as already correct is not offered
+      // to the single-word passes at all (#2406 r7). Returning the token
+      // untouched is the whole mechanism: there is no correction to make to text
+      // that is already what the vocabulary says it should be.
+      if reservedTokenRanges.contains(where: { $0.contains(index) }) { return token }
       let (prefix, core, suffix) = splitPunctuation(token)
       guard !core.isEmpty, core.count >= 2 else { return token }
 

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -790,7 +790,17 @@ public struct WordCorrector: Sendable {
       let maxSpan = multiAliasMap.keys.reduce(0) { max($0, $1.components(separatedBy: " ").count) }
       var i = 0
       while i < tokens.count {
-        var matched = false
+        // ONE state answers "is this position settled, and by how far"
+        // (#2406 review r9).
+        //
+        // It was TWO: `matched` for a replacement and `reservedSpan` for an
+        // already-correct span. Both mean Pass 2 must not touch this position,
+        // and Pass 2's gate consulted only the first — so reserving a span left
+        // `matched` false and the fuzzy pass ran on text Pass 1 had just
+        // certified. A settled position expressed as two booleans that must both
+        // be remembered is the shape that produces exactly this omission; a
+        // single value has nothing to forget.
+        //
         // #2406 review r2: how far to advance when a span is left ALONE.
         //
         // A MATCHED span collapses to one token, so `i += 1` steps past it. An
@@ -799,7 +809,20 @@ public struct WordCorrector: Sendable {
         // overlapping alias can rewrite it. `Alpha Beta Gamma.com` is correct as a
         // three-token span, and a `beta gamma` alias then rewrote it to
         // `Alpha Wrong.com`. Reserve the whole span instead.
-        var reservedSpan: Int?
+        // `.replaced` advances by ONE because the span collapsed to a single
+        // token; `.reserved(n)` advances by N because the span kept all of them.
+        enum SpanOutcome {
+          case replaced
+          case reserved(Int)
+
+          var advance: Int {
+            switch self {
+            case .replaced: return 1
+            case .reserved(let span): return span
+            }
+          }
+        }
+        var outcome: SpanOutcome?
 
         for span in stride(from: min(maxSpan, tokens.count - i), through: 2, by: -1) {
           let slice = tokens[i..<(i + span)]
@@ -889,7 +912,7 @@ public struct WordCorrector: Sendable {
             // canonical — round 3's defect, which was fixed in Pass 2 and left
             // standing here because nothing had reached it yet.
             if exactHit.source == exactHit.canonical {
-              reservedSpan = span
+              outcome = .reserved(span)
               break
             }
             let (firstPrefix, _, _) = splitPunctuation(tokens[i])
@@ -903,7 +926,7 @@ public struct WordCorrector: Sendable {
               i..<(i + span),
               with: [firstPrefix + exactHit.canonical + reattach + lastSuffix])
             appendReplacement(forCanonical: exactHit.canonical)
-            matched = true
+            outcome = .replaced
             #if DEBUG
               Self.logger.debug(
                 "WordCorrector: type=multi-word-exact source='\(exactHit.source)' target='\(exactHit.canonical)' peeled=\(exactHit.peeled)"
@@ -914,7 +937,7 @@ public struct WordCorrector: Sendable {
         }
 
         // Pass 2: fuzzy multi-word fallback (only if exact missed for all spans)
-        if !matched {
+        if outcome == nil {
           spanLoop: for span in stride(from: min(maxSpan, tokens.count - i), through: 2, by: -1) {
             let slice = tokens[i..<(i + span)]
             let phrase = slice.map { stripPunctuation($0).lowercased() }.joined(separator: " ")
@@ -982,7 +1005,7 @@ public struct WordCorrector: Sendable {
                 // Already right as dictated. RESERVE the span — not `continue`,
                 // which only tries a shorter one and then lets the outer loop walk
                 // back into it.
-                reservedSpan = span
+                outcome = .reserved(span)
                 // Labelled: a bare `break` inside a `switch` exits the SWITCH, falling
                 // through to code that reads an uninitialised `winner`.
                 break spanLoop
@@ -1024,7 +1047,7 @@ public struct WordCorrector: Sendable {
                   firstPrefix + winner.candidate.canonical + reattachedDomainSuffix + lastSuffix
                 ])
               appendReplacement(forCanonical: winner.candidate.canonical)
-              matched = true
+              outcome = .replaced
               #if DEBUG
                 let winningSource = winner.peeled ? (peeledRawPhrase ?? rawPhrase) : rawPhrase
                 Self.logger.debug(
@@ -1036,8 +1059,10 @@ public struct WordCorrector: Sendable {
           }
         }
 
-        if let reservedSpan { reservedTokenRanges.append(i..<(i + reservedSpan)) }
-        i += reservedSpan ?? 1
+        if case .reserved(let span) = outcome {
+          reservedTokenRanges.append(i..<(i + span))
+        }
+        i += outcome?.advance ?? 1
       }
     }
 

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -811,59 +811,103 @@ public struct WordCorrector: Sendable {
             continue
           }
 
-          // Pass 1: exact multi-word alias.
+          // The peel, computed once for both the unpeeled and peeled slots.
+          // Peeling can EXPOSE a reserved trigger word this guard could not see:
+          // `emoji.com` is not `emoji` until the suffix comes off, so a peel that
+          // exposes one yields no peeled slot rather than a forbidden match.
+          let strippedCores = slice.map { stripPunctuation($0) }
+          let domainSplit = strippedCores.last.flatMap { Self.splitDomainSuffix($0) }
+          var peeledRawPhrase: String?
+          if let domainSplit {
+            var peeledCores = strippedCores
+            peeledCores[peeledCores.count - 1] = domainSplit.bare
+            if !peeledCores.contains(where: {
+              Self.emojiTriggerReservedWords.contains($0.lowercased())
+            }) {
+              peeledRawPhrase = peeledCores.joined(separator: " ")
+            }
+          }
+
+          // PASS 1 IS THE ONE PLACE EXACT MULTI-WORD MATCHING HAPPENS
+          // (#2406 review r8, and the reason rounds 6, 7 and 8 each found a new
+          // leak).
           //
-          // NON-PACK BEATS PACK ACROSS THE PEEL BOUNDARY (#2406 review r6, P1).
+          // Those three rounds were one root, and it was not any of the
+          // individual holes they named. Exact matching had been SPLIT across
+          // two passes — unpeeled here, peeled in Pass 2 — so this pass could
+          // only DECLINE and hope the right thing picked the span up. Every
+          // round found another thing that picked it up first:
           //
-          // This map is the WIDE one and includes pack gap-fill entries, so a
-          // pack alias carrying its own domain suffix matches the unpeeled
-          // phrase here and `break`s — before Pass 2 can offer the user's OWN
-          // alias, which matches the same span once the suffix is peeled. The
-          // user's word loses to a pack term, which inverts this repo's
-          // precedence.
+          //   r6  a pack unpeeled exact accepted before the user's peeled exact
+          //   r7  declining fell through to a SHORTER span in this same loop
+          //   r8  `break` handed off to Pass 2, which restarts at maxSpan, so a
+          //       LONGER fuzzy candidate preempted the deferred exact
           //
-          // Measured shape: pack `international platform.com` -> Pack Choice,
-          // user `international platform` -> User Choice, dictated
-          // `international platform.com`. Slot 2 must outrank slot 3.
+          // Declining is not a decision. A pass that hands work away has to name
+          // the destination, and there is always one more route to it — which is
+          // this repo's own "describing a set instead of enumerating one".
           //
-          // This is Pass 4's four-slot ladder (#2281 round 7) applied to the
-          // multi-word passes, and only the middle pair needed arbitrating:
-          //   1. unpeeled non-pack   accepted here, unchanged
-          //   2. peeled   non-pack   deferred to Pass 2's exact lookup
-          //   3. unpeeled pack       accepted here ONLY when 2 is absent
-          //   4. peeled   pack       KNOWN LIMIT, see below
+          // So the split is removed. All four (attempt x authority) slots are
+          // resolved HERE, in one fixed order, and Pass 2 is fuzzy only:
           //
-          // KNOWN LIMIT, stated rather than hidden: slot 4 does not exist.
-          // Pass 2's pool is built solely from `nonPackMultiAliasMap`, so a PACK
-          // alias whose key matches only the PEELED phrase is never matched
-          // exactly and falls through to fuzzy. That is the lowest-authority
-          // slot, so its absence can only under-match, never override a
-          // higher-authority answer — and adding it would mean giving Pass 2 a
-          // pack pool, which is a larger change than this defect requires.
+          //   1. unpeeled non-pack   the user's own word, as dictated
+          //   2. peeled   non-pack   the user's own word, suffix peeled
+          //   3. unpeeled pack       a pack term, as dictated
+          //   4. peeled   pack       a pack term, suffix peeled
           //
-          // DEFERRING MUST END THE EXACT SCAN FOR THIS POSITION, not fall to a
-          // SHORTER span (#2406 r7). Folded into the `if` condition, a deferral
-          // was indistinguishable from a miss, so Pass 1 simply tried span-1 —
-          // where a SHORTER pack alias at the same position could match and win,
-          // reinstating the inversion this deferral exists to prevent, one span
-          // down. Same shape as r3 one pass over: `continue` only ever tries a
-          // shorter span, and the protection has to stop the scan instead.
-          if let canonical = multiAliasMap[phrase], rawPhrase != canonical {
-            if Self.nonPackPeeledExactExists(
-              slice: slice, nonPackMultiAliasMap: nonPackMultiAliasMap,
-              isPackMatch: nonPackMultiAliasMap[phrase] == nil,
-              stripPunctuation: stripPunctuation)
-            {
-              break  // hand this position to Pass 2, which owns the peeled exact
+          // This is Pass 4's ladder (#2281 round 7) ported wholesale rather than
+          // approximated, which is what the reviewer meant from round 5 on by
+          // "as the single-word path already does". Slot 4 is no longer a known
+          // limit: this pass holds the wide map, so it can be expressed here at
+          // no extra cost, and leaving it out was only ever an artifact of the
+          // split.
+          //
+          // Non-pack membership is decided by `nonPackMultiAliasMap`, not by
+          // `nonPackExactKeys` — that set is built from SINGLE alias keys and
+          // canonicals only, so a multi-word phrase is absent from it whatever
+          // its authority.
+          var exactHit: (canonical: String, source: String, peeled: Bool)?
+          let peeledKey = peeledRawPhrase?.lowercased()
+
+          if let canonical = nonPackMultiAliasMap[phrase] {
+            exactHit = (canonical, rawPhrase, false)
+          } else if let key = peeledKey, let raw = peeledRawPhrase,
+            let canonical = nonPackMultiAliasMap[key]
+          {
+            exactHit = (canonical, raw, true)
+          } else if let canonical = multiAliasMap[phrase] {
+            exactHit = (canonical, rawPhrase, false)
+          } else if let key = peeledKey, let raw = peeledRawPhrase,
+            let canonical = multiAliasMap[key]
+          {
+            exactHit = (canonical, raw, true)
+          }
+
+          if let exactHit {
+            // ALREADY CORRECT RESERVES THE SPAN. Previously this pass fell
+            // through to a shorter span when the text already equalled its
+            // canonical — round 3's defect, which was fixed in Pass 2 and left
+            // standing here because nothing had reached it yet.
+            if exactHit.source == exactHit.canonical {
+              reservedSpan = span
+              break
             }
             let (firstPrefix, _, _) = splitPunctuation(tokens[i])
             let (_, _, lastSuffix) = splitPunctuation(tokens[i + span - 1])
-            tokens.replaceSubrange(i..<(i + span), with: [firstPrefix + canonical + lastSuffix])
-            appendReplacement(forCanonical: canonical)
+            // Reattached UNLESS the canonical already specifies its own domain —
+            // the same rule Pass 4 and Pass 2's accept branch apply.
+            let reattach =
+              exactHit.peeled && !Self.isDomainShaped(exactHit.canonical)
+              ? (domainSplit?.suffix ?? "") : ""
+            tokens.replaceSubrange(
+              i..<(i + span),
+              with: [firstPrefix + exactHit.canonical + reattach + lastSuffix])
+            appendReplacement(forCanonical: exactHit.canonical)
             matched = true
             #if DEBUG
               Self.logger.debug(
-                "WordCorrector: type=multi-word-exact source='\(rawPhrase)' target='\(canonical)'")
+                "WordCorrector: type=multi-word-exact source='\(exactHit.source)' target='\(exactHit.canonical)' peeled=\(exactHit.peeled)"
+              )
             #endif
             break
           }
@@ -913,63 +957,9 @@ public struct WordCorrector: Sendable {
                 if !exposesReservedWord { peeledRawPhrase = peeledCores.joined(separator: " ") }
               }
 
-              // EXACT BEFORE FUZZY, ACROSS THE PEEL BOUNDARY (#2406 review r5,
-              // and the consolidation of r2/r3/r4 — every one of those was this
-              // same root at a different member).
-              //
-              // Pass 1 gives the UNPEELED phrase an exact lookup and has already
-              // missed by the time Pass 2 runs. The PEELED phrase had no exact
-              // lookup at all, so a certainty was being routed through a
-              // competition: `international platform.com`, with the alias
-              // `international platform` scoring 1.0 and a distractor
-              // `international platforma` scoring 0.972, was rejected on the
-              // ambiguity margin and never corrected.
-              //
-              // A COMPETITION IS THE WRONG INSTRUMENT FOR A CERTAINTY. Threshold
-              // and margin exist to adjudicate candidates that only RESEMBLE the
-              // input; an exact member of the pool does not resemble it, it IS
-              // it. This is the rule Pass 4 reached at round 4 of #2281 —
-              // "EXACT match to completion, unpeeled then peeled, before any
-              // fuzzy pass runs at all" — applied to the pass that was built
-              // without it.
-              //
-              // No authority ladder is needed here and one would be wrong: this
-              // pool is built solely from `nonPackMultiAliasMap`, so every entry
-              // carries the same authority, and the dictionary it derives from
-              // makes an alias hit unique by construction. That is what makes
-              // the question CLOSED — "is this phrase a key of the pool" has one
-              // answer, where "does it resemble one" has a next counterexample.
-              if let peeledRaw = peeledRawPhrase,
-                let exactCanonical = candidates.first(where: { $0.alias == peeledRaw.lowercased() })?
-                  .canonical
-              {
-                if peeledRaw == exactCanonical {
-                  // Already right as dictated. Reserve the span, exactly as the
-                  // fuzzy `.alreadyCorrect` branch does — otherwise the outer
-                  // loop walks back into text this pass just declared correct.
-                  reservedSpan = span
-                  break spanLoop
-                }
-                let (firstPrefix, _, _) = splitPunctuation(tokens[i])
-                let (_, _, lastSuffix) = splitPunctuation(tokens[i + span - 1])
-                // Same reattachment rule as the fuzzy accept branch and as
-                // Pass 4: a canonical that already specifies its own domain
-                // keeps its own, whatever suffix was dictated.
-                let reattach =
-                  Self.isDomainShaped(exactCanonical) ? "" : (domainSplit?.suffix ?? "")
-                tokens.replaceSubrange(
-                  i..<(i + span),
-                  with: [firstPrefix + exactCanonical + reattach + lastSuffix])
-                appendReplacement(forCanonical: exactCanonical)
-                matched = true
-                #if DEBUG
-                  Self.logger.debug(
-                    "WordCorrector: type=multi-word-exact-peeled source='\(peeledRaw)' target='\(exactCanonical)'"
-                  )
-                #endif
-                break spanLoop
-              }
-
+              // Exact matching is entirely Pass 1's now (#2406 r8). This pass is
+              // fuzzy only, so there is no exact answer here for a fuzzy
+              // candidate to preempt and no span handed across a pass boundary.
               let unpeeledOutcome = multiWordFuzzyAttempt(
                 phrase: phrase, rawPhrase: rawPhrase, candidates: candidates,
                 canonicalToWord: canonicalToWord,
@@ -1523,38 +1513,6 @@ public struct WordCorrector: Sendable {
       MultiWordFuzzyCandidate(
         canonical: bestCanonical, alias: bestAlias, score: bestScore,
         margin: margin, threshold: threshold, hasStopword: hasStopword))
-  }
-
-  /// Does a NON-pack alias match this span's PEELED phrase exactly?
-  ///
-  /// Only asked when Pass 1's own match came from a PACK entry, because that is
-  /// the only case where deferring changes anything: a non-pack unpeeled match
-  /// already outranks everything and must not be delayed. Returning `false` for
-  /// a non-pack match keeps the existing behaviour byte-for-byte rather than
-  /// re-deciding it (#2406 review r6).
-  ///
-  /// The peel is recomputed here rather than threaded in, because Pass 1 runs
-  /// its own span loop before Pass 2 exists and the two loops do not share a
-  /// frame. It is a string split over at most a handful of tokens, and it runs
-  /// only on the pack branch.
-  private static func nonPackPeeledExactExists(
-    slice: ArraySlice<String>,
-    nonPackMultiAliasMap: [String: String],
-    isPackMatch: Bool,
-    stripPunctuation: (String) -> String
-  ) -> Bool {
-    guard isPackMatch else { return false }
-    var cores = slice.map(stripPunctuation)
-    guard let last = cores.last, let split = Self.splitDomainSuffix(last) else { return false }
-    cores[cores.count - 1] = split.bare
-    // Peeling can EXPOSE a reserved trigger word, the same re-check Pass 2 makes
-    // for the same reason: `emoji.com` is not `emoji` until the suffix is off.
-    // If the peel exposes one, Pass 2 will refuse the span, so deferring to it
-    // would leave the span uncorrected rather than better corrected.
-    if cores.contains(where: { Self.emojiTriggerReservedWords.contains($0.lowercased()) }) {
-      return false
-    }
-    return nonPackMultiAliasMap[cores.joined(separator: " ").lowercased()] != nil
   }
 
   private enum SingleAttemptFuzzyOutcome {

--- a/Tests/EnviousWisprTests/PostProcessing/MultiWordDomainSuffixTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/MultiWordDomainSuffixTests.swift
@@ -153,6 +153,45 @@ struct MultiWordDomainSuffixTests {
       "the canonical already carries its own domain; got: \(result)")
   }
 
+  /// The user's own word outranks a pack term ACROSS the peel boundary
+  /// (#2406 r6, P1).
+  ///
+  /// A pack alias carrying its own domain suffix matches the UNPEELED phrase in
+  /// Pass 1, which reads the wide map and accepts immediately — before Pass 2
+  /// can offer the user's own alias, which matches the same span once the suffix
+  /// comes off. The result is the user's vocabulary losing to a pack term, which
+  /// inverts this repo's precedence.
+  ///
+  /// This is the slot-2-over-slot-3 rule the single-word path settled at round 7
+  /// of #2281, reached in the multi-word passes only because this PR made a
+  /// peeled exact match possible at all.
+  @Test("a user's peeled exact outranks a pack term's unpeeled exact")
+  func nonPackPeeledExactOutranksPackUnpeeledExact() {
+    let packWord = CustomWord(
+      canonical: "Pack Choice", aliases: ["international platform.com"], source: .pack)
+    let userWord = CustomWord(canonical: "User Choice", aliases: ["international platform"])
+    let (result, replacements) = corrector.correct(
+      "visit international platform.com today", against: [packWord, userWord])
+    #expect(
+      result == "visit User Choice.com today",
+      "the user's own word must outrank a pack term across the peel; got: \(result)")
+    #expect(replacements.first?.sourceID == userWord.id)
+  }
+
+  /// The other direction, and it is what stops the case above being satisfiable
+  /// by "always defer to Pass 2": with NO user word competing, the pack term's
+  /// unpeeled exact must still win. Slot 3 is a real slot, not a disabled one.
+  @Test("a pack term's unpeeled exact still wins when no user word competes")
+  func packUnpeeledExactStillWinsUncontested() {
+    let packWord = CustomWord(
+      canonical: "Pack Choice", aliases: ["international platform.com"], source: .pack)
+    let (result, _) = corrector.correct(
+      "visit international platform.com today", against: [packWord])
+    #expect(
+      result == "visit Pack Choice today",
+      "an uncontested pack exact must still be applied; got: \(result)")
+  }
+
   /// A canonical that already specifies its own domain does NOT get the dictated
   /// suffix reattached — otherwise the user sees it twice. Same rule the
   /// single-word path applies.

--- a/Tests/EnviousWisprTests/PostProcessing/MultiWordDomainSuffixTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/MultiWordDomainSuffixTests.swift
@@ -248,6 +248,30 @@ struct MultiWordDomainSuffixTests {
     #expect(replacements.first?.sourceID == user.id)
   }
 
+  /// A LONGER fuzzy candidate must not preempt an exact match (#2406 r8).
+  ///
+  /// While exact matching was split across two passes, the first could only
+  /// DECLINE a span and hand it on — and the fuzzy pass restarts at the longest
+  /// span, so a longer fuzzy candidate reached the tokens before the deferred
+  /// exact match did.
+  ///
+  /// The span here is three tokens and the fuzzy distractor is four, so the
+  /// distractor is offered FIRST by any implementation that lets fuzzy start
+  /// over. Exactness must win regardless of length.
+  @Test("a longer fuzzy candidate does not preempt a shorter exact match")
+  func longerFuzzyCandidateDoesNotPreemptExact() {
+    let packLong = CustomWord(
+      canonical: "Pack Choice", aliases: ["alpha beta gamma.com"], source: .pack)
+    let user = CustomWord(canonical: "User Choice", aliases: ["alpha beta gamma"])
+    let longerFuzzy = CustomWord(canonical: "Fuzzy Winner", aliases: ["alpha beta gamma now"])
+    let (result, replacements) = corrector.correct(
+      "see alpha beta gamma.com now", against: [packLong, user, longerFuzzy])
+    #expect(
+      result == "see User Choice.com now",
+      "an exact match outranks a longer fuzzy candidate; got: \(result)")
+    #expect(replacements.first?.sourceID == user.id)
+  }
+
   /// A canonical that already specifies its own domain does NOT get the dictated
   /// suffix reattached — otherwise the user sees it twice. Same rule the
   /// single-word path applies.

--- a/Tests/EnviousWisprTests/PostProcessing/MultiWordDomainSuffixTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/MultiWordDomainSuffixTests.swift
@@ -272,6 +272,28 @@ struct MultiWordDomainSuffixTests {
     #expect(replacements.first?.sourceID == user.id)
   }
 
+  /// Reserving a span must also stop the FUZZY pass (#2406 r9).
+  ///
+  /// The loop carried two states meaning "this position is settled" — one for a
+  /// replacement, one for an already-correct span — and the fuzzy pass's gate
+  /// consulted only the first. So reserving a span left the position looking
+  /// unsettled and the fuzzy pass ran on text the exact pass had just certified.
+  ///
+  /// Reached here through a PACK already-correct match, because that is the case
+  /// where a non-pack fuzzy alias of the same token count is still waiting.
+  @Test("a reserved span is not rewritten by the fuzzy pass")
+  func reservedSpanStopsTheFuzzyPass() {
+    let packExact = CustomWord(
+      canonical: "Alpha Beta Gamma", aliases: ["alpha beta gamma"], source: .pack)
+    let fuzzyDistractor = CustomWord(
+      canonical: "Fuzzy Wrong", aliases: ["alpha beta gammaa"])
+    let (result, _) = corrector.correct(
+      "see Alpha Beta Gamma now", against: [packExact, fuzzyDistractor])
+    #expect(
+      result == "see Alpha Beta Gamma now",
+      "text certified by the exact pass must be invisible to the fuzzy pass; got: \(result)")
+  }
+
   /// A canonical that already specifies its own domain does NOT get the dictated
   /// suffix reattached — otherwise the user sees it twice. Same rule the
   /// single-word path applies.

--- a/Tests/EnviousWisprTests/PostProcessing/MultiWordDomainSuffixTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/MultiWordDomainSuffixTests.swift
@@ -85,6 +85,23 @@ struct MultiWordDomainSuffixTests {
     #expect(replacements.isEmpty, "nothing should have been replaced")
   }
 
+  /// An already-correct span must be RESERVED, not merely skipped (#2406 r2).
+  ///
+  /// `continue` only tried a shorter span, and the outer loop then advanced one
+  /// token — back INSIDE the protected text — where a shorter overlapping alias
+  /// rewrote it. A matched span collapses to one token so `i += 1` steps past it;
+  /// an already-correct span keeps all N.
+  @Test("an already-correct span is not rewritten by a shorter overlapping alias")
+  func alreadyCorrectSpanIsReservedFromOverlappingAliases() {
+    let full = CustomWord(canonical: "Alpha Beta Gamma", aliases: ["alpha beta gamma"])
+    let overlapping = CustomWord(canonical: "Wrong", aliases: ["beta gamma"])
+    let (result, _) = corrector.correct(
+      "see Alpha Beta Gamma.com now", against: [full, overlapping])
+    #expect(
+      result == "see Alpha Beta Gamma.com now",
+      "the whole already-correct span must be reserved; got: \(result)")
+  }
+
   /// A canonical that already specifies its own domain does NOT get the dictated
   /// suffix reattached — otherwise the user sees it twice. Same rule the
   /// single-word path applies.

--- a/Tests/EnviousWisprTests/PostProcessing/MultiWordDomainSuffixTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/MultiWordDomainSuffixTests.swift
@@ -121,6 +121,38 @@ struct MultiWordDomainSuffixTests {
       "a near-twin must not turn already-correct text into an ambiguous span; got: \(result)")
   }
 
+  /// An EXACT peeled alias is a certainty, not a competitor (#2406 r5).
+  ///
+  /// Pass 1 gives the unpeeled phrase an exact lookup and misses here, because
+  /// the dictated token still carries `.com`. The peeled phrase then had no
+  /// exact lookup at all, so a score of 1.0 was put in a competition against a
+  /// distractor at ~0.972 and lost on the ambiguity margin — a correction the
+  /// vocabulary defines EXACTLY, refused because something else looked similar.
+  @Test("an exact peeled alias wins over a near-twin distractor")
+  func exactPeeledAliasOutranksFuzzyDistractor() {
+    let intended = CustomWord(canonical: "Acme Suite", aliases: ["international platform"])
+    let distractor = CustomWord(canonical: "Other Thing", aliases: ["international platforma"])
+    let (result, replacements) = corrector.correct(
+      "visit international platform.com today", against: [intended, distractor])
+    #expect(
+      result == "visit Acme Suite.com today",
+      "an exact alias for the peeled phrase is the answer, not a candidate; got: \(result)")
+    #expect(replacements.first?.sourceID == intended.id)
+  }
+
+  /// The other direction for the exact-peeled path, and it is what stops the
+  /// case above being satisfiable by "always take the first exact-ish hit": an
+  /// exact peeled alias must still respect the domain-shaped reattachment rule.
+  @Test("an exact peeled alias to a domain-shaped canonical does not double the suffix")
+  func exactPeeledAliasRespectsDomainShapedCanonical() {
+    let word = CustomWord(canonical: "Acme Suite.com", aliases: ["international platform"])
+    let (result, _) = corrector.correct(
+      "visit international platform.com today", against: [word])
+    #expect(
+      result == "visit Acme Suite.com today",
+      "the canonical already carries its own domain; got: \(result)")
+  }
+
   /// A canonical that already specifies its own domain does NOT get the dictated
   /// suffix reattached — otherwise the user sees it twice. Same rule the
   /// single-word path applies.

--- a/Tests/EnviousWisprTests/PostProcessing/MultiWordDomainSuffixTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/MultiWordDomainSuffixTests.swift
@@ -102,6 +102,25 @@ struct MultiWordDomainSuffixTests {
       "the whole already-correct span must be reserved; got: \(result)")
   }
 
+  /// Already-correct text survives even when a NEAR-TWIN alias exists (#2406 r3).
+  ///
+  /// Self-identity is a fact about the input; threshold and margin are about a
+  /// competition between candidates, and a competition cannot make correct text
+  /// incorrect. Checked last, the margin gate reached it first and returned
+  /// `.ambiguous` — which does not reserve the span, so an overlapping alias
+  /// rewrote text that was already right.
+  @Test("already-correct text survives a near-twin distractor and an overlapping alias")
+  func alreadyCorrectSurvivesNearTwinAndOverlap() {
+    let full = CustomWord(canonical: "Alpha Beta Gamma", aliases: ["alpha beta gamma"])
+    let nearTwin = CustomWord(canonical: "Alpha Beta Gammaa", aliases: ["alpha beta gammaa"])
+    let overlapping = CustomWord(canonical: "Wrong", aliases: ["beta gamma"])
+    let (result, _) = corrector.correct(
+      "see Alpha Beta Gamma.com now", against: [full, nearTwin, overlapping])
+    #expect(
+      result == "see Alpha Beta Gamma.com now",
+      "a near-twin must not turn already-correct text into an ambiguous span; got: \(result)")
+  }
+
   /// A canonical that already specifies its own domain does NOT get the dictated
   /// suffix reattached — otherwise the user sees it twice. Same rule the
   /// single-word path applies.

--- a/Tests/EnviousWisprTests/PostProcessing/MultiWordDomainSuffixTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/MultiWordDomainSuffixTests.swift
@@ -61,6 +61,30 @@ struct MultiWordDomainSuffixTests {
     #expect(replacements.count == 1)
   }
 
+  /// Text that is ALREADY correct must survive a competing distractor (#2406).
+  ///
+  /// With `International Platform.com` dictated, the PEELED attempt matches its
+  /// canonical perfectly — nothing to do — while an unrelated domain-shaped
+  /// distractor can clear the threshold on the UNPEELED attempt. Treating
+  /// "already correct" as "found nothing" handed the span to the distractor and
+  /// replaced correct text.
+  ///
+  /// This hazard is specific to the two-attempt design: the single-attempt
+  /// version had no other branch to hand the span to.
+  @Test("already-correct text is not replaced by a competing distractor")
+  func alreadyCorrectTextSurvivesADistractor() {
+    let real = CustomWord(
+      canonical: "International Platform", aliases: ["international platform"])
+    let distractor = CustomWord(
+      canonical: "Unrelated Thing", aliases: ["international plxxform.com"])
+    let (result, replacements) = corrector.correct(
+      "visit International Platform.com today", against: [real, distractor])
+    #expect(
+      result == "visit International Platform.com today",
+      "already-correct text must be left alone, not replaced; got: \(result)")
+    #expect(replacements.isEmpty, "nothing should have been replaced")
+  }
+
   /// A canonical that already specifies its own domain does NOT get the dictated
   /// suffix reattached — otherwise the user sees it twice. Same rule the
   /// single-word path applies.

--- a/Tests/EnviousWisprTests/PostProcessing/MultiWordDomainSuffixTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/MultiWordDomainSuffixTests.swift
@@ -192,6 +192,62 @@ struct MultiWordDomainSuffixTests {
       "an uncontested pack exact must still be applied; got: \(result)")
   }
 
+  /// A reserved span survives into the SINGLE-word passes (#2406 r7).
+  ///
+  /// Reserving the span stopped the multi-word scan walking back into it, and
+  /// stopped there: Passes 3-5 map every token independently and knew nothing
+  /// about the reservation, so a single-word alias could rewrite one token of a
+  /// span the multi-word passes had just certified as already correct.
+  ///
+  /// Protection that ends at a pass boundary is not protection — the user sees
+  /// the same corruption, one pass later.
+  @Test("an already-correct span is not rewritten by a single-word alias either")
+  func reservedSpanSurvivesIntoSingleWordPasses() {
+    let full = CustomWord(canonical: "Alpha Beta Gamma", aliases: ["alpha beta gamma"])
+    let singleWord = CustomWord(canonical: "Wrong", aliases: ["gamma"])
+    let (result, _) = corrector.correct(
+      "see Alpha Beta Gamma.com now", against: [full, singleWord])
+    #expect(
+      result == "see Alpha Beta Gamma.com now",
+      "a reserved span must be invisible to the single-word passes; got: \(result)")
+  }
+
+  /// The other direction: a single-word alias OUTSIDE any reserved span must
+  /// still apply. Alone, the case above is satisfiable by an implementation that
+  /// disabled the single-word passes entirely.
+  @Test("a single-word alias outside a reserved span still applies")
+  func singleWordAliasOutsideReservedSpanStillApplies() {
+    let full = CustomWord(canonical: "Alpha Beta Gamma", aliases: ["alpha beta gamma"])
+    let elsewhere = CustomWord(canonical: "Later", aliases: ["now"])
+    let (result, _) = corrector.correct(
+      "see Alpha Beta Gamma.com now", against: [full, elsewhere])
+    #expect(
+      result == "see Alpha Beta Gamma.com Later",
+      "only the reserved span is protected, not the rest of the line; got: \(result)")
+  }
+
+  /// Deferring to Pass 2 must END the exact scan for this position, not fall to
+  /// a SHORTER Pass 1 span (#2406 r7).
+  ///
+  /// Folded into the accept condition, a deferral was indistinguishable from a
+  /// miss, so Pass 1 simply tried the next span down — where a SHORTER pack
+  /// alias at the same position could match and win, reinstating the very
+  /// authority inversion the deferral exists to prevent, one span lower.
+  @Test("deferring a pack span does not let a shorter pack alias win instead")
+  func deferringDoesNotFallToAShorterPackSpan() {
+    let longPack = CustomWord(
+      canonical: "Long Pack", aliases: ["alpha beta gamma.com"], source: .pack)
+    let shortPack = CustomWord(
+      canonical: "Short Pack", aliases: ["alpha beta"], source: .pack)
+    let user = CustomWord(canonical: "User Choice", aliases: ["alpha beta gamma"])
+    let (result, replacements) = corrector.correct(
+      "see alpha beta gamma.com now", against: [longPack, shortPack, user])
+    #expect(
+      result == "see User Choice.com now",
+      "the deferred span belongs to Pass 2, not to a shorter pack alias; got: \(result)")
+    #expect(replacements.first?.sourceID == user.id)
+  }
+
   /// A canonical that already specifies its own domain does NOT get the dictated
   /// suffix reattached — otherwise the user sees it twice. Same rule the
   /// single-word path applies.

--- a/Tests/EnviousWisprTests/PostProcessing/MultiWordDomainSuffixTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/MultiWordDomainSuffixTests.swift
@@ -1,0 +1,76 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPostProcessing
+
+/// #2312 — the MULTI-WORD fuzzy pass (Pass 2) must not swallow a glued domain
+/// suffix.
+///
+/// **Product Outcome.** When these fail the user dictates `platforn.com`, gets a
+/// spelling correction, and their `.com` is silently gone.
+///
+/// The existing glued-suffix suite covers the SINGLE-word path that #2281 built.
+/// Pass 2 runs first and consumed the tokens before that path could see them, so
+/// none of it was binding here — which is why the defect survived 20 review
+/// rounds one pass over.
+@Suite("WordCorrector — multi-word glued domain suffix (#2312)", .tags(.productOutcome))
+struct MultiWordDomainSuffixTests {
+  let corrector = WordCorrector()
+
+  /// The reported defect.
+  ///
+  /// **Reaches Pass 2's fuzzy branch by construction, which is what stops this
+  /// being vacuous:** `international platforn.com` is not the exact spaced alias
+  /// (so Pass 1 misses) and not its space-free form (so Pass 0 misses), and the
+  /// last token ends in a letter so the suffix survives `stripPunctuation` into
+  /// the scorer. A single-word-only implementation cannot produce this result,
+  /// because Pass 2 replaces the whole two-token span before Pass 4 runs.
+  @Test("a near-miss with a glued suffix keeps the suffix")
+  func multiWordFuzzyKeepsGluedSuffix() {
+    let word = CustomWord(canonical: "International Platform", aliases: ["international platform"])
+    let (result, replacements) = corrector.correct(
+      "visit international platforn.com today", against: [word])
+    #expect(
+      result == "visit International Platform.com today",
+      "the spelling is corrected and the dictated .com survives; got: \(result)")
+    #expect(replacements.count == 1)
+    #expect(replacements.first?.sourceID == word.id)
+  }
+
+  /// Reattachment lands BEFORE the token's ordinary punctuation, mirroring the
+  /// single-word path's `prefix + canonical + reattach + suffix` order.
+  @Test("the peeled suffix is reattached before trailing punctuation")
+  func suffixPrecedesTrailingPunctuation() {
+    let word = CustomWord(canonical: "International Platform", aliases: ["international platform"])
+    let (result, _) = corrector.correct("go to international platforn.com!", against: [word])
+    #expect(
+      result == "go to International Platform.com!",
+      "expected canonical + .com + !; got: \(result)")
+  }
+
+  /// The other direction, and it is load-bearing: a multi-word near-miss with NO
+  /// glued suffix must still correct exactly as before. Alone, the case above is
+  /// satisfiable by an implementation that broke ordinary matching.
+  @Test("a near-miss with no glued suffix still corrects")
+  func multiWordFuzzyStillCorrectsWithoutSuffix() {
+    let word = CustomWord(canonical: "International Platform", aliases: ["international platform"])
+    let (result, replacements) = corrector.correct(
+      "visit international platforn today", against: [word])
+    #expect(result == "visit International Platform today")
+    #expect(replacements.count == 1)
+  }
+
+  /// A canonical that already specifies its own domain does NOT get the dictated
+  /// suffix reattached — otherwise the user sees it twice. Same rule the
+  /// single-word path applies.
+  @Test("a domain-shaped canonical does not get the suffix reattached")
+  func domainShapedCanonicalDoesNotDoubleSuffix() {
+    let word = CustomWord(
+      canonical: "Example Site.com", aliases: ["example site"])
+    let (result, _) = corrector.correct("open example sight.com now", against: [word])
+    #expect(
+      !result.contains(".com.com"),
+      "a domain-shaped canonical already carries its suffix; got: \(result)")
+  }
+}


### PR DESCRIPTION
Closes #2312. Part of epic #2316.

> **This PR changed shape at round 8 and the body has been rewritten to match.** It began as "the multi-word fuzzy pass deletes a dictated `.com`" and ended as "one place decides an exact multi-word match". The rounds are documented below rather than squashed away, because the path is the argument for the final shape.

## What was wrong

Dictating **"international platforn.com"** with a saved phrase "international platform" corrected the spelling and **deleted the `.com`**.

Pass 2 (multi-word fuzzy) consumes the span before Pass 4's peel/reattach logic — built over 20 review rounds for #2281 — ever runs. `stripPunctuation` strips only edge characters, so a token ending in a letter keeps its internal dot and `platforn.com` reaches the scorer intact. The accept branch then rebuilds the span from `lastSuffix`, which is **empty** for a letter-final token, and the dictated domain is gone.

## The plan's own proposal would not have fixed it

I proposed "try the peeled form only if the unpeeled one fails". **The unpeeled phrase scores 0.890 — already above the 0.85 threshold — so it wins and discards the suffix regardless.** A fix that fixes nothing, and only a measurement showed it. Codex's grounded review killed it with the number rather than an argument.

## The fix, as it stands now

**Exact matching happens in exactly one place.** Pass 1 resolves all four (attempt × authority) slots in a fixed order and Pass 2 is fuzzy only:

| slot | meaning |
|---|---|
| 1. unpeeled non-pack | the user's own word, as dictated |
| 2. peeled non-pack | the user's own word, suffix peeled |
| 3. unpeeled pack | a pack term, as dictated |
| 4. peeled pack | a pack term, suffix peeled |

This is Pass 4's ladder (#2281 round 7) ported wholesale, which is what the reviewer meant from round 5 on by *"as the single-word path already does"*.

Pass 2 then scores two fuzzy attempts and compares them: unpeeled against domain-shaped aliases only (Pass 4's restriction, applied only when a peel is available — with no suffix to swallow there is nothing to protect), peeled against the unrestricted pool. Higher score wins, an exact tie favours unpeeled, and different canonicals within `ambiguityMargin` reject the span — as does an internal ambiguity in either attempt, because **an ambiguous attempt is not "found nothing"**.

## Two principles, eight rounds

Every finding after round 1 collapsed into one of two, and the second took three rounds to see.

**A CERTAINTY IS NOT DECIDED BY A COMPETITION** (rounds 2–5). Threshold and margin adjudicate candidates that only *resemble* the input; an exact member of the pool does not resemble the input, it *is* the input. r2 collapsed already-correct into "no candidate"; r3 failed to reserve the span so a shorter overlapping alias walked back in; r4 checked identity after the margin gate; r5 put an exact alias into the competition and lost it on ambiguity.

**A PROTECTION MUST NOT END WHERE THE AUTHOR'S ATTENTION ENDED** (rounds 6–8). r6: a pack unpeeled exact was accepted before the user's peeled exact — the user's own vocabulary losing to a pack term. r7: declining fell through to a *shorter* span, and a reserved span was invisible to the single-word passes. r8: the handoff to Pass 2 let a *longer fuzzy* candidate preempt the deferred exact.

**Rounds 6–8 were one root, and it is none of the holes they named.** Exact matching had been SPLIT across two passes, so Pass 1 could only *decline* a span and hope the right thing picked it up — and each round found another thing that picked it up first. **Declining is not a decision.** Removing the split closed all three at once.

**The tell that this left the loop rather than widening the description is the net deletion**: the deferral helper, the cross-pass handoff, Pass 2's exact lookup, and a KNOWN LIMIT I had documented for the missing fourth slot all go. That limit was never a property of the problem — Pass 1 holds the wide map, so slot 4 costs nothing there; it existed only because the split put the pack pool on the wrong side of the boundary.

Closed on the way, because the unified path reaches it: Pass 1 used to fall through to a shorter span when the text already equalled its canonical — round 3's defect, fixed in Pass 2 and left standing in Pass 1 because nothing had reached it.

## Two cases the plan missed, both from review

- **The stopword penalty must be recomputed per attempt.** Peeling changes it: `alpha and.com` carries the token `and.com` unpeeled and `and` peeled, and the check is exact token membership.
- **Peeling can EXPOSE a reserved trigger word** the slice guard could not see — `emoji.com` is not `emoji` until the suffix comes off.

## A worry the review reversed with numbers

I expected the shorter peeled phrase to score too easily against the same threshold. The opposite is true: Levenshtein divides by the longer string and Dice normalises by both bigram sets, so shortening makes a remaining typo proportionally **more** costly. The peeled score rises here (0.890 → 0.971) because genuine noise was removed. Threshold unchanged.

## Evidence

**Proved against the parent commit** — stronger than a synthetic mutant because the failure is the real one. Round 7's source, round 8's tests:

```
✘ "a longer fuzzy candidate does not preempt a shorter exact match"
    (result → "see Fuzzy Winner") == "see User Choice.com now"
```

The longer fuzzy candidate swallowed the whole four-token span, destroying the exact match, the dictated `.com`, and the trailing word. **Exactly one of fifteen failed** — the other fourteen, every guard rounds 1–7 established, stayed green on the old source. The unification preserves all of them and changes only what it was written to change.

Every case on this PR carries its own control, each isolated by one line. Two are worth naming because they failed first:

- The original control for r7 mutated the deferral to a no-op, which makes Pass 1 accept the pack immediately — **not the pre-fix behaviour** — so it reddened r6's case too and isolated nothing. Re-run with the exact pre-fix shape, only the new case goes red.
- A `git checkout --` used to restore the tree after a control destroyed an uncommitted fix. After a control that mutates the tree, restore by **re-applying** the change, never by reverting to a commit that predates it.

## Tests

15 cases, `.productOutcome`. Every rejected case is paired with an accepted twin differing only in the field under test — an uncontested pack exact must still win; a single-word alias *outside* a reserved span must still apply; a domain-shaped canonical must not double its suffix. Without those, "always defer", "disable the single-word passes" and "always reattach" would each satisfy the binding cases.

## Validation

- `MultiWordDomainSuffixTests` 15/15.
- Both lanes green, both reconciling against their own per-bundle sums, `Fatal error` 0 and `Crash:` 0 in both. Both checks are run because they catch disjoint failures: a concurrent writer fails reconciliation, a crashed bundle reconciles perfectly and only the crash grep sees it.
- Logs and every control preserved in `docs/audits/lane-logs-2312/` in the main checkout, so they survive the fetch that deletes this worktree on merge.

Lane: `Code`. Tier: MEDIUM.
