### PR TITLE
fix(ci): a crashed test bundle can no longer report a green lane (#2401)

### DIFF
--- a/.github/workflows/main-post-merge.yml
+++ b/.github/workflows/main-post-merge.yml
@@ -14,6 +14,11 @@ on:
       - '.github/actions/xcode-ci-setup/action.yml'
       - 'scripts/ci/verify-checked-out-revision.sh'
       - 'scripts/ci/post-merge-should-run.sh'
+      # #2401: both lanes below decide their verdict through this owner, so a
+      # change to it alters every job here while leaving the workflow untouched —
+      # the same reason the composite action and the revision guard are listed.
+      - 'scripts/lib/lane-verdict.sh'
+      - 'scripts/lib/lane-verdict.py'
   schedule:
     # Hourly re-validation of main HEAD (#2334): during a merge train,
     # cancel-in-progress cancels every push run before it completes, so main
@@ -267,13 +272,16 @@ jobs:
             ENABLE_TESTABILITY=YES 2>&1 | tee xcode-test-release.log
 
           # Require a positive executed-test count (see pr-check.yml rationale):
-          # a presence-grep would green a zero-test run.
-          TESTS_RUN=$(grep -oE "Test run with [0-9]+ test" xcode-test-release.log | grep -oE "[0-9]+" | awk '{s+=$1} END{print s+0}')
-          if [ "$TESTS_RUN" -lt 1 ]; then
-            echo "::error::Xcode executed 0 release tests (empty/misconfigured bundle) — failing"
-            exit 1
-          fi
-          echo "==> Xcode executed $TESTS_RUN tests (release)"
+          # a presence-grep would green a zero-test run. #2401: that guard is
+          # complete about the EMPTY case and is kept unchanged inside the shared
+          # owner, which additionally reads the named .xcresult so a TRUNCATED
+          # run cannot pass — a crashed bundle prints zero failure marks and
+          # concludes SUCCEEDED.
+          . "$GITHUB_WORKSPACE/scripts/lib/lane-verdict.sh"
+          ew_lane_verdict \
+            "xcode-test-release.log" \
+            "$GITHUB_WORKSPACE/xcode-test-release.xcresult" \
+            "Post-merge Release lane"
 
       - name: Summarize release-test failure
         if: failure() && steps.release-tests.outcome == 'failure'
@@ -405,13 +413,16 @@ jobs:
             VALID_ARCHS=arm64 2>&1 | tee xcode-test-debug.log
 
           # Require a positive executed-test count (see pr-check.yml rationale):
-          # a presence-grep would green a zero-test run.
-          TESTS_RUN=$(grep -oE "Test run with [0-9]+ test" xcode-test-debug.log | grep -oE "[0-9]+" | awk '{s+=$1} END{print s+0}')
-          if [ "$TESTS_RUN" -lt 1 ]; then
-            echo "::error::Xcode executed 0 debug tests (empty/misconfigured bundle) — failing"
-            exit 1
-          fi
-          echo "==> Xcode executed $TESTS_RUN tests (debug)"
+          # a presence-grep would green a zero-test run. #2401: that guard is
+          # complete about the EMPTY case and is kept unchanged inside the shared
+          # owner, which additionally reads the named .xcresult so a TRUNCATED
+          # run cannot pass — a crashed bundle prints zero failure marks and
+          # concludes SUCCEEDED.
+          . "$GITHUB_WORKSPACE/scripts/lib/lane-verdict.sh"
+          ew_lane_verdict \
+            "xcode-test-debug.log" \
+            "$GITHUB_WORKSPACE/xcode-test-debug.xcresult" \
+            "Post-merge Debug lane"
 
       # #1600, MOVED here from pr-check.yml's build-debug lane in the CI-speed
       # pass. It was always informational — no percentage gate, because coverage

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -203,12 +203,20 @@ jobs:
           # "passed" text even for an empty bundle, so a presence-grep would
           # green a run where nothing executed. Require a positive executed
           # count (summed across the Swift Testing per-target run summaries).
-          TESTS_RUN=$(grep -oE "Test run with [0-9]+ test" xcode-test-debug.log | grep -oE "[0-9]+" | awk '{s+=$1} END{print s+0}')
-          if [ "$TESTS_RUN" -lt 1 ]; then
-            echo "::error::Xcode executed 0 tests (empty/misconfigured bundle) — failing the gate"
-            exit 1
-          fi
-          echo "==> Xcode executed $TESTS_RUN tests (debug)"
+          #
+          # #2401: that reasoning is complete about the EMPTY case and is kept
+          # unchanged inside the shared owner. What it cannot see is a TRUNCATED
+          # one — a crashed bundle was measured reporting `** TEST SUCCEEDED **`
+          # at 2,557 of 6,664 tests with exit 0, and a crash prints zero failure
+          # marks, so every signal a reader checks agreed and every one was
+          # wrong. `ew_lane_verdict` keeps the count guard and additionally reads
+          # the named .xcresult, where a crashed case carries a typed `Failed`
+          # result that no amount of test output can forge.
+          . "$GITHUB_WORKSPACE/scripts/lib/lane-verdict.sh"
+          ew_lane_verdict \
+            "xcode-test-debug.log" \
+            "$GITHUB_WORKSPACE/xcode-test-debug.xcresult" \
+            "PR Debug lane"
 
       # #2162: a red `build-debug` was undiagnosable from CI BY CONSTRUCTION, and both halves of that
       # had to be true at once. This lane writes `xcode-test-debug.log` and an `.xcresult` and then
@@ -703,6 +711,22 @@ jobs:
           set -euo pipefail
           scripts/ci/classify-changes.sh --self-test
           scripts/ci/check-pr-check-fetch-depth.sh
+
+      - name: Lane verdict self-test (#2401)
+        run: |
+          set -euo pipefail
+          # The owner that decides whether a test lane counts as passing is
+          # itself only as good as its own suite, and a suite nothing invokes
+          # first fires in someone else's run. It lives HERE, inside the
+          # required aggregator, because that is the gate this owner protects.
+          #
+          # Runs on Linux deliberately: every case either drives the judge
+          # directly on a JSON payload or exercises a shell path that
+          # short-circuits before `xcrun`, so it needs no Xcode. The sibling
+          # scripts/lib suites are NOT wired in yet — a real gap, stated rather
+          # than papered over by adding suites whose macOS assumptions have not
+          # been checked on this runner.
+          bash scripts/lib/lane-verdict-test.sh
 
       - name: Download-link lint (doorway tagging + on-site /#download)
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -170,6 +170,9 @@ scripts/lib/*
 !scripts/lib/spm-seed-test.sh
 !scripts/lib/log-dir.sh
 !scripts/lib/log-dir-test.sh
+!scripts/lib/lane-verdict.sh
+!scripts/lib/lane-verdict.py
+!scripts/lib/lane-verdict-test.sh
 # #1951: catalog ids are pull targets, so a wrong one ships a dead Download
 # button. Tracked deliberately — a gitignored validator can only be run by
 # someone who remembers it exists, which is how the false green happens.

--- a/scripts/lib/lane-verdict-test.sh
+++ b/scripts/lib/lane-verdict-test.sh
@@ -214,6 +214,28 @@ else
   bad "a non-numeric expected-count warns and is ignored" "rc=$jrc out=$junk"
 fi
 
+echo "== a refusal still REPORTS under errexit =="
+# The row this suite could not previously express. Its own harness runs
+# `set -uo pipefail` with no `errexit`, so nothing in it could see that all three
+# workflow steps run under `set -e` and call the function as a simple command —
+# where a bare judge invocation aborts the shell the instant it rejects, before
+# the verdict line is printed and before the payload is cleaned up. CI still goes
+# red, which is why it is easy to miss; it goes red with no reason attached.
+#
+# Driven in a SUBSHELL with errexit genuinely on, because asserting this any
+# other way asserts something else.
+errexit_out=$(
+  set -e
+  . "$HERE/lane-verdict.sh"
+  ew_lane_verdict "$TMP/zero.log" "$TMP/bundle" "errexit probe" 2>&1
+  echo "REACHED-END"
+)
+if printf '%s' "$errexit_out" | /usr/bin/grep -q "verdict: FAIL"; then
+  ok "a refusal prints its verdict even under errexit"
+else
+  bad "a refusal prints its verdict even under errexit" "out=$errexit_out"
+fi
+
 echo
 printf "PASS=%d FAIL=%d\n" "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/scripts/lib/lane-verdict-test.sh
+++ b/scripts/lib/lane-verdict-test.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# Two-way suite for scripts/lib/lane-verdict.sh and lane-verdict.py (#2401).
+#
+# The point of the change is that a CRASHED lane can no longer report a green
+# verdict, so this asserts BOTH halves: a healthy lane still passes, AND a
+# crashed one is refused. A gate that refuses everything would satisfy a
+# refusal-only suite while making the lane unusable, and a gate that refuses
+# nothing is the defect being fixed — so every rejected case here is paired with
+# an accepted twin that differs only in the field under test.
+#
+# The two files have different contracts and are tested at their own boundaries:
+# the shell owns arguments, the count guard and the verdict lines; the judge owns
+# classifying a result payload, and its documented interface already takes a file
+# path, so it needs no seam to be driven. Nothing here gives the gate a test-only
+# knob (`validation-discipline.md` RULE: a-test-seam-on-a-GUARD-is-a-bypass).
+#
+# Run: bash scripts/lib/lane-verdict-test.sh
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/lane-verdict.sh
+. "$HERE/lane-verdict.sh"
+
+PASS=0
+FAIL=0
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/ew-lane-verdict-test.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+# Every failure LEADS with the same name its pass prints, so a mutation control
+# reading this output can tell WHICH case fired rather than only that one did
+# (validation-discipline.md, the unreadable-control entry).
+ok() { PASS=$((PASS + 1)); printf "  ok    %s\n" "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf "  FAIL  %s — %s\n" "$1" "$2"; }
+
+# ---------------------------------------------------------------- the judge --
+# `nodeType` nesting mirrors a real bundle: Test Plan > Unit test bundle >
+# Test Suite > Test Case, with Failure Message as a child of the case.
+node() {  # <name> <result> [failure message]
+  local name="$1" result="$2" message="${3:-}"
+  if [ -n "$message" ]; then
+    printf '{"nodeType":"Test Case","nodeIdentifier":"%s","result":"%s","children":[{"nodeType":"Failure Message","name":"%s"}]}' \
+      "$name" "$result" "$message"
+  else
+    printf '{"nodeType":"Test Case","nodeIdentifier":"%s","result":"%s"}' "$name" "$result"
+  fi
+}
+
+payload() {  # <file> <case json>...
+  local out="$1"; shift
+  local joined="" sep=""
+  local c
+  for c in "$@"; do joined="$joined$sep$c"; sep=","; done
+  printf '{"testNodes":[{"nodeType":"Test Plan","children":[{"nodeType":"Unit test bundle","children":[{"nodeType":"Test Suite","children":[%s]}]}]}]}' \
+    "$joined" > "$out"
+}
+
+judge() {  # <file> -> rc, stderr captured to $TMP/err
+  EW_LANE_LABEL="probe" python3 "$HERE/lane-verdict.py" "$1" >"$TMP/out" 2>"$TMP/err"
+}
+
+echo "== the three results a healthy lane produces are accepted =="
+# Measured on a real 6,829-case lane: Passed 6815, Skipped 12, Expected Failure 2.
+# Exactly three distinct values, which is why the allowlist is these three and
+# why anything else must fail rather than be assumed benign.
+payload "$TMP/healthy.json" \
+  "$(node 'S/passes()' 'Passed')" \
+  "$(node 'S/hardwareGated()' 'Skipped')" \
+  "$(node 'S/knownIssue()' 'Expected Failure')"
+if judge "$TMP/healthy.json"; then ok "a healthy lane passes"; else bad "a healthy lane passes" "rc=$? stderr=$(cat "$TMP/err")"; fi
+
+echo "== a crashed case is refused, and NAMED =="
+payload "$TMP/crashed.json" \
+  "$(node 'S/passes()' 'Passed')" \
+  "$(node 'S/dies()' 'Failed' 'Test crashed with signal trap.')"
+if judge "$TMP/crashed.json"; then
+  bad "a crashed case is refused" "the judge accepted it"
+elif ! /usr/bin/grep -q "S/dies()" "$TMP/err"; then
+  bad "a crashed case is refused" "refused without naming the case: $(cat "$TMP/err")"
+elif ! /usr/bin/grep -q "Test crashed with signal trap" "$TMP/err"; then
+  bad "a crashed case is refused" "refused without the failure message: $(cat "$TMP/err")"
+else
+  ok "a crashed case is refused, and NAMED"
+fi
+
+echo "== crash text as DATA does not fire the gate =="
+# This is the whole reason the oracle is the typed result rather than the
+# console. A build log for a suite containing a literal fatalError(...) call
+# echoed that source line 24 times as compiler diagnostics, so on an untyped
+# stream a crash and a quotation of a crash are the same bytes. Here the crash
+# wording sits in a PASSING case's identifier and must change nothing.
+payload "$TMP/data.json" \
+  "$(node 'S/testCrashedWithSignalTrapIsReportedLoudly()' 'Passed')" \
+  "$(node 'S/fatalErrorMessageIsRendered()' 'Passed')"
+if judge "$TMP/data.json"; then ok "crash text as data does not fire the gate"; else bad "crash text as data does not fire the gate" "rc=$? stderr=$(cat "$TMP/err")"; fi
+
+echo "== an unknown result value fails CLOSED =="
+# A future Xcode may invent a value. Refusing what we do not recognise is the
+# only direction that cannot silently green a lane.
+payload "$TMP/unknown.json" "$(node 'S/x()' 'Interrupted')"
+if judge "$TMP/unknown.json"; then
+  bad "an unknown result value fails closed" "the judge accepted 'Interrupted'"
+else
+  ok "an unknown result value fails closed"
+fi
+
+echo "== a payload with no cases, or no shape, is refused =="
+payload "$TMP/empty.json"
+if judge "$TMP/empty.json"; then bad "zero test cases is refused" "accepted"; else ok "zero test cases is refused"; fi
+
+printf '{"testNodes":"not-an-array"}' > "$TMP/shape.json"
+if judge "$TMP/shape.json"; then bad "a malformed testNodes is refused" "accepted"; else ok "a malformed testNodes is refused"; fi
+
+printf 'not json at all' > "$TMP/broken.json"
+if judge "$TMP/broken.json"; then bad "unparseable JSON is refused" "accepted"; else ok "unparseable JSON is refused"; fi
+
+if judge "$TMP/does-not-exist.json"; then bad "a missing payload is refused" "accepted"; else ok "a missing payload is refused"; fi
+
+echo "== the judge is found from ANY cwd =="
+# The case that was missing: every judge row above drives lane-verdict.py
+# directly, so none of them exercises how `ew_lane_verdict` FINDS it. That is a
+# fixture too small to express the question — the rows share the harness's own
+# `$HERE` and so cannot disagree with it.
+#
+# Under bash the resolution is correct however the file is sourced, and these
+# rows are green before and after the hardening. They exist because the value is
+# consumed by a path lookup that nothing else asserts, and because this suite
+# runs on Linux CI where a real bundle is unavailable — so the resolution is the
+# one part of the shell's bundle path that CAN be checked there.
+if [ -f "$EW_LANE_JUDGE" ]; then
+  ok "the judge path resolves to an existing file"
+else
+  bad "the judge path resolves to an existing file" "EW_LANE_JUDGE=$EW_LANE_JUDGE"
+fi
+case "$EW_LANE_JUDGE" in
+  /*) ok "the judge path is absolute, not cwd-relative" ;;
+  *) bad "the judge path is absolute, not cwd-relative" "EW_LANE_JUDGE=$EW_LANE_JUDGE" ;;
+esac
+# Two-way: source it from an unrelated cwd, by a relative path, and require the
+# same answer. A resolver that happened to work from the repo root only would
+# pass both rows above.
+resolved=$(cd "$HERE/../.." && cd scripts && bash -c '. lib/lane-verdict.sh; printf "%s" "$EW_LANE_JUDGE"')
+if [ "$resolved" = "$EW_LANE_JUDGE" ]; then
+  ok "sourcing from another cwd resolves the same judge"
+else
+  bad "sourcing from another cwd resolves the same judge" "got '$resolved', want '$EW_LANE_JUDGE'"
+fi
+
+echo "== the shell contract =="
+LOG="$TMP/lane.log"
+printf 'Test run with 6623 tests in 578 suites passed\nTest run with 206 tests in 21 suites passed\n' > "$LOG"
+
+out=$(ew_lane_verdict "$LOG" 2>&1); rc=$?
+if [ "$rc" -eq 2 ]; then ok "too few arguments is a usage error, not a verdict"; else bad "too few arguments is a usage error, not a verdict" "rc=$rc out=$out"; fi
+
+out=$(ew_lane_verdict "$TMP/no-such.log" "$TMP/bundle" "probe" 2>&1); rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | /usr/bin/grep -q "verdict: FAIL"; then
+  ok "a missing log is a FAIL verdict"
+else
+  bad "a missing log is a FAIL verdict" "rc=$rc out=$out"
+fi
+
+# The empty-run guard this change PRESERVES rather than replaces.
+: > "$TMP/zero.log"
+out=$(ew_lane_verdict "$TMP/zero.log" "$TMP/bundle" "probe" 2>&1); rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | /usr/bin/grep -q "executed 0 tests"; then
+  ok "the empty-run guard still refuses a zero count"
+else
+  bad "the empty-run guard still refuses a zero count" "rc=$rc out=$out"
+fi
+
+# A positive count is no longer sufficient — the truncated-run half of the fix.
+out=$(ew_lane_verdict "$LOG" "$TMP/no-such-bundle" "probe" 2>&1); rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | /usr/bin/grep -q "no result bundle"; then
+  ok "a positive count alone does NOT green a lane"
+else
+  bad "a positive count alone does NOT green a lane" "rc=$rc out=$out"
+fi
+
+# The count is summed across per-target summaries, unchanged.
+out=$(ew_lane_verdict "$LOG" "$TMP/no-such-bundle" "probe" 2>&1)
+if printf '%s' "$out" | /usr/bin/grep -q "executed 6829 tests"; then
+  ok "the count sums every per-target run summary"
+else
+  bad "the count sums every per-target run summary" "out=$out"
+fi
+
+echo "== the expected count FLAGS and never GATES =="
+# tools-and-apps.md FACT: ew-watcher-classification — a count is a parameter, a
+# parameter can be borrowed from the wrong workflow, and a count-GATED check
+# fails toward silence. Both rows below must reach the SAME verdict path; only
+# the warning differs.
+mismatch=$(ew_lane_verdict "$LOG" "$TMP/no-such-bundle" "probe" 9999 2>&1); mrc=$?
+matched=$(ew_lane_verdict "$LOG" "$TMP/no-such-bundle" "probe" 6829 2>&1); yrc=$?
+if [ "$mrc" -eq "$yrc" ]; then
+  ok "an expected-count mismatch does not change the verdict"
+else
+  bad "an expected-count mismatch does not change the verdict" "mismatch rc=$mrc, match rc=$yrc"
+fi
+if printf '%s' "$mismatch" | /usr/bin/grep -q "expected 9999"; then
+  ok "an expected-count mismatch is reported LOUDLY"
+else
+  bad "an expected-count mismatch is reported LOUDLY" "out=$mismatch"
+fi
+if printf '%s' "$matched" | /usr/bin/grep -q "expected"; then
+  bad "a matching expected-count says nothing" "out=$matched"
+else
+  ok "a matching expected-count says nothing"
+fi
+# A borrowed or malformed parameter must be loud and inert, never a verdict.
+junk=$(ew_lane_verdict "$LOG" "$TMP/no-such-bundle" "probe" "not-a-number" 2>&1); jrc=$?
+if [ "$jrc" -eq "$mrc" ] && printf '%s' "$junk" | /usr/bin/grep -q "not a number"; then
+  ok "a non-numeric expected-count warns and is ignored"
+else
+  bad "a non-numeric expected-count warns and is ignored" "rc=$jrc out=$junk"
+fi
+
+echo
+printf "PASS=%d FAIL=%d\n" "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/scripts/lib/lane-verdict.py
+++ b/scripts/lib/lane-verdict.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Judge one Xcode test lane from its result bundle (#2401).
+
+Owner for the STRUCTURED half of `ew_lane_verdict`; `lane-verdict.sh` owns the
+count guard and the contract, and its header owns the reasoning. This file is
+separate for one reason: an inline heredoc inside a shell function cannot be
+imported by a test, so it could only be exercised by running a whole lane, and
+in practice would never be exercised at all.
+
+Input is the JSON from `xcrun xcresulttool get test-results tests --path <bundle>`
+on stdin's named file. Exits 0 when every Test Case carries an accepted result,
+1 otherwise, and 1 on any malformed input — a measurement authority fails CLOSED,
+because a half-failed judge that prints a verdict looks like a real one.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+# Passed to us so the shell file stays the single place the accepted set is
+# stated. Split on newlines, not spaces: "Expected Failure" contains one.
+DEFAULT_ACCEPTED = ("Passed", "Skipped", "Expected Failure")
+
+
+def _accepted() -> frozenset[str]:
+    raw = os.environ.get("EW_LANE_ACCEPTED", "")
+    # The shell passes a space-joined string for readability at the call site.
+    # Reconstruct rather than split, because one member contains a space and a
+    # naive split would silently accept the token "Expected" on its own.
+    known = {value for value in DEFAULT_ACCEPTED if value in raw}
+    return frozenset(known) if known else frozenset(DEFAULT_ACCEPTED)
+
+
+def _test_cases(node: object, out: list[dict]) -> None:
+    if not isinstance(node, dict):
+        return
+    if node.get("nodeType") == "Test Case":
+        out.append(node)
+        return
+    for child in node.get("children") or []:
+        _test_cases(child, out)
+
+
+def _failure_messages(node: object, out: list[str]) -> None:
+    if not isinstance(node, dict):
+        return
+    if node.get("nodeType") == "Failure Message":
+        name = node.get("name")
+        if name:
+            out.append(str(name))
+    for child in node.get("children") or []:
+        _failure_messages(child, out)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: lane-verdict.py <results.json>", file=sys.stderr)
+        return 1
+
+    label = os.environ.get("EW_LANE_LABEL", "lane")
+    accepted = _accepted()
+
+    try:
+        with open(argv[1], encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"ERROR: {label} result payload is unreadable: {exc}", file=sys.stderr)
+        return 1
+
+    roots = payload.get("testNodes")
+    if not isinstance(roots, list):
+        print(f"ERROR: {label} result payload has no testNodes array", file=sys.stderr)
+        return 1
+
+    cases: list[dict] = []
+    for root in roots:
+        _test_cases(root, cases)
+
+    # Zero cases is the same refusal the count guard makes, arrived at from the
+    # other side. Both are kept: they can disagree, and a disagreement is itself
+    # worth failing on.
+    if not cases:
+        print(f"ERROR: {label} result bundle contains ZERO test cases", file=sys.stderr)
+        return 1
+
+    bad: list[tuple[str, object]] = []
+    for case in cases:
+        identity = case.get("nodeIdentifier") or case.get("name") or "<unnamed test>"
+        if case.get("result") not in accepted:
+            bad.append((str(identity), case.get("result")))
+
+    if bad:
+        # Lead every line with the label, so a mutation control reading this
+        # output can tell WHICH check fired rather than only that something did.
+        for identity, result in bad[:20]:
+            messages: list[str] = []
+            for case in cases:
+                if (case.get("nodeIdentifier") or case.get("name")) == identity:
+                    _failure_messages(case, messages)
+                    break
+            detail = f" — {messages[0]}" if messages else ""
+            print(f"ERROR: {label} result is {result!r}: {identity}{detail}", file=sys.stderr)
+        if len(bad) > 20:
+            print(f"ERROR: {label} and {len(bad) - 20} more", file=sys.stderr)
+        return 1
+
+    print(f"==> {label} result bundle: {len(cases)} test cases, all accepted")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/lib/lane-verdict.sh
+++ b/scripts/lib/lane-verdict.sh
@@ -105,10 +105,28 @@ ew_lane_verdict() {
     return 1
   fi
 
-  # Unchanged from the guard this replaces: sum the Swift Testing per-target run
-  # summaries. Kept as the empty-run detector, not as the verdict.
-  n=$(/usr/bin/grep -oE "Test run with [0-9]+ test" "$log" \
-    | /usr/bin/grep -oE "[0-9]+" | awk '{s+=$1} END{print s+0}')
+  # Sum the Swift Testing per-target run summaries — the same quantity the guard
+  # this replaces computed, kept as the empty-run detector rather than the verdict.
+  #
+  # ONE awk PASS, not the original `grep | grep | awk`. Under `errexit` — which
+  # all three workflow steps set — a no-match `grep` exits 1, the pipeline fails,
+  # and the assignment ABORTS THE SHELL. On an empty lane, which is precisely the
+  # case the count exists to catch, so the guard would die instead of reporting.
+  # Found by this file's own new errexit row, not by review; awk exits 0 whether
+  # or not it matches, so the failure has nowhere to come from.
+  n=$(LC_ALL=C awk '
+    {
+      rest = $0
+      while (match(rest, /Test run with [0-9]+ test/)) {
+        hit = substr(rest, RSTART, RLENGTH)
+        sub(/^Test run with /, "", hit)
+        sub(/ test$/, "", hit)
+        total += hit + 0
+        rest = substr(rest, RSTART + RLENGTH)
+      }
+    }
+    END { print total + 0 }
+  ' "$log")
 
   # Reported before any refusal, because a reader diagnosing a FAIL wants the
   # number as much as a reader confirming a PASS does.
@@ -149,8 +167,17 @@ ew_lane_verdict() {
 
   # `get test-results tests` is the MODERN subcommand. The one most sessions
   # reach for first, `get test-report tests`, is deprecated and refuses outright.
-  if ! xcrun xcresulttool get test-results tests --path "$bundle" >"$payload" 2>/dev/null; then
+  #
+  # NOT `if ! cmd; then rc=$?`: inside that branch `$?` is the status of the `!`
+  # EXPRESSION, which is 0 exactly when the command failed. The message would
+  # have read "exited 0" for every real failure — a diagnostic that is wrong
+  # precisely when it is read (#2407 review r2).
+  if xcrun xcresulttool get test-results tests --path "$bundle" >"$payload" 2>/dev/null; then
+    rc=0
+  else
     rc=$?
+  fi
+  if [ "$rc" -ne 0 ]; then
     rm -f "$payload"
     echo "ERROR: $label could not read the result bundle at $bundle (xcresulttool exited $rc)" >&2
     echo "==> $label verdict: FAIL"
@@ -166,9 +193,25 @@ ew_lane_verdict() {
     return 1
   fi
 
-  EW_LANE_LABEL="$label" EW_LANE_ACCEPTED="$EW_LANE_ACCEPTED_RESULTS" \
+  # RUN IT AS AN `if` CONDITION, which suppresses `errexit` for this command.
+  #
+  # All three workflow steps run under `set -e` and call this as a simple
+  # command, so a bare invocation would abort the shell THE INSTANT the judge
+  # rejected — before the temp file is removed and before the `verdict: FAIL`
+  # line is printed. CI would still go red, which is why this is easy to miss,
+  # but red with no verdict, no reason and a leaked payload: the failure mode is
+  # a MISSING EXPLANATION exactly when someone needs one (#2407 review r2).
+  #
+  # Invisible to this file's own suite by construction — that harness runs
+  # `set -uo pipefail` with no `errexit`, so no row it contains could express the
+  # question. The suite now sets it explicitly for one row.
+  if EW_LANE_LABEL="$label" EW_LANE_ACCEPTED="$EW_LANE_ACCEPTED_RESULTS" \
     python3 "$EW_LANE_JUDGE" "$payload"
-  rc=$?
+  then
+    rc=0
+  else
+    rc=$?
+  fi
   rm -f "$payload"
 
   if [ "$rc" -ne 0 ]; then

--- a/scripts/lib/lane-verdict.sh
+++ b/scripts/lib/lane-verdict.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# scripts/lib/lane-verdict.sh — one verdict owner for every Xcode test lane (#2401).
+#
+# THE EMPTY RUN, AND THIS REASONING IS PRESERVED RATHER THAN REPLACED
+# `xcodebuild` prints suite-level "passed" text even for an empty bundle, so a
+# presence-grep would green a run where nothing executed. A positive executed
+# count is therefore required. That guard is not a mistake and this file keeps
+# it verbatim — it is correct and complete about the EMPTY case, and it is the
+# only record of why a presence-grep was rejected.
+#
+# THE TRUNCATED RUN, WHICH THAT GUARD CANNOT SEE
+# A positive count does not prove the lane finished. A test bundle that CRASHES
+# mid-run was measured reporting `** TEST SUCCEEDED **` with a lane total of
+# 2,557 against a baseline of 6,664 — roughly 4,100 tests never run, exit 0.
+# Every signal a reader checks agreed and every one was wrong: a crash prints
+# ZERO `✘` marks so the failure count is honestly zero, `xcodebuild` concluded
+# SUCCEEDED, and `n < 1` is comfortably satisfied by 2,557. The guard catches an
+# EMPTY run and passes a TRUNCATED one.
+#
+# WHY THE CONSOLE IS NOT THE ORACLE, MEASURED RATHER THAN ARGUED
+# The obvious fix is to grep the log for `Fatal error:`. Three measurements say
+# no, all taken 2026-08-25 against this repo:
+#   1. THE LOG CARRIES TEST SOURCE. A build log for a suite containing a literal
+#      `fatalError(...)` call echoed that source line 24 times as compiler
+#      diagnostics. Console text is an untyped stream in which a crash and a
+#      quotation of a crash are the same bytes, and a gate that fires on data is
+#      the shape `validation-discipline.md` RULE: false-positives-not-gates-
+#      trains-evasion measures the cost of.
+#   2. THE STRING IS NOT OURS. Its wording belongs to the Swift runtime and to
+#      Xcode, so a set of console signatures is a DESCRIPTION with a next
+#      counterexample forever, not an enumeration.
+#   3. THE CONSOLE SEES LESS THAN THE BUNDLE. On the crashed run the console's
+#      final `Test run with N tests` read 3, because `xcodebuild` restarts after
+#      a crash and that line reports only the last launch. The result bundle
+#      held all SIX cases, including the two that ran before the crash and the
+#      one that died.
+#
+# WHAT IS ASKED INSTEAD, AND WHY IT IS A CLOSED QUESTION
+#   "Does the named result bundle hold at least one test case, and is every case
+#    result one this repo accepts?"
+# The bundle is structured, so the answer comes from a typed field rather than
+# from matching text, and no amount of test output can forge one. The accepted
+# set is MEASURED, not guessed — a healthy full lane of 6,829 cases produced
+# exactly three distinct values:
+#       Passed 6815 · Skipped 12 · Expected Failure 2
+# `Skipped` is what a hardware-gated `@Test(.enabled(if:))` reports; `Expected
+# Failure` is what a `withKnownIssue` case reports. Anything else — including a
+# value a future Xcode invents — is refused, so this fails CLOSED.
+#
+# Deliberately NOT matched: the crash's own failure text. The crashed run's
+# `Failure Message` child read `Test crashed with signal trap.`, which is not the
+# `Crash: xctest at ...` a reader of the older note would expect. Keying on that
+# prefix would have shipped a check that misses the case it was written for. The
+# typed `Failed` result catches it with no string involved.
+#
+# THE EXPECTED COUNT IS A FLAG, NEVER A GATE
+# `tools-and-apps.md` FACT: ew-watcher-classification is explicit: a count is a
+# PARAMETER, a parameter can be borrowed from the wrong workflow, and a
+# count-GATED check fails toward silence — it prints progress forever and says
+# nothing. So a mismatch is reported loudly beside a verdict and never licenses
+# or withholds one.
+#
+# CONTRACT
+#   ew_lane_verdict <log> <result_bundle> <label> [expected_count]
+# Echoes the executed count and a PASS/FAIL verdict. Returns 0 only when the
+# count is positive AND every case in the bundle carries an accepted result.
+
+# The three results a healthy lane is allowed to produce. Anything else fails.
+EW_LANE_ACCEPTED_RESULTS="Passed Skipped Expected Failure"
+
+# Resolved ONCE, at source time, to an ABSOLUTE path, with a loud branch below
+# when the judge is not where this says it is.
+#
+# NOT because the old form was broken for any shipped consumer — it was not.
+# Every consumer runs bash (`xcode-test.sh` and all three workflow steps), and
+# under bash `${BASH_SOURCE[0]}` resolves correctly however the file is sourced.
+#
+# The reason is what happens OUTSIDE bash. `BASH_SOURCE` does not exist in zsh,
+# so it expands to empty, `dirname ""` is `.`, and the judge is looked for beside
+# the caller's cwd. Measured two-way, same command, same cwd:
+#     zsh  -> <root>/lane-verdict.py             (wrong, and the file is absent)
+#     bash -> <root>/scripts/lib/lane-verdict.py (right)
+# This machine's interactive shell is zsh, so anyone driving the function by hand
+# to diagnose a lane hits it — while every automated path is fine. That is a bad
+# failure to own: it fires only for the person already debugging something else.
+#
+# Fail-closed either way, so this was never a false green. What the explicit
+# branch buys is a NAMED failure: "cannot find its result judge" instead of a
+# python traceback, so a missing judge and a crashed lane cannot be confused.
+EW_LANE_VERDICT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EW_LANE_JUDGE="$EW_LANE_VERDICT_DIR/lane-verdict.py"
+
+ew_lane_verdict() {
+  if [ "$#" -lt 3 ] || [ "$#" -gt 4 ]; then
+    echo "ew_lane_verdict: expected <log> <result_bundle> <label> [expected_count]" >&2
+    return 2
+  fi
+
+  local log="$1" bundle="$2" label="$3" expected="${4:-}"
+  local n payload rc
+
+  if [ ! -f "$log" ]; then
+    echo "ERROR: $label has no test log at $log" >&2
+    echo "==> $label verdict: FAIL"
+    return 1
+  fi
+
+  # Unchanged from the guard this replaces: sum the Swift Testing per-target run
+  # summaries. Kept as the empty-run detector, not as the verdict.
+  n=$(/usr/bin/grep -oE "Test run with [0-9]+ test" "$log" \
+    | /usr/bin/grep -oE "[0-9]+" | awk '{s+=$1} END{print s+0}')
+
+  # Reported before any refusal, because a reader diagnosing a FAIL wants the
+  # number as much as a reader confirming a PASS does.
+  echo "==> $label executed $n tests"
+
+  if [ -n "$expected" ]; then
+    case "$expected" in
+      "" | *[!0-9]*)
+        # A malformed parameter is loud and harmless: it must not be able to
+        # decide a lane either way.
+        echo "WARNING: $label expected-count is not a number: '$expected' (ignored)" >&2
+        ;;
+      *)
+        if [ "$n" -ne "$expected" ]; then
+          echo "WARNING: $label executed $n tests, expected $expected — NOT a verdict, see the verdict line" >&2
+        fi
+        ;;
+    esac
+  fi
+
+  if [ "$n" -lt 1 ]; then
+    echo "ERROR: $label executed 0 tests (empty/misconfigured bundle)" >&2
+    echo "==> $label verdict: FAIL"
+    return 1
+  fi
+
+  if [ ! -d "$bundle" ]; then
+    echo "ERROR: $label has no result bundle at $bundle" >&2
+    echo "==> $label verdict: FAIL"
+    return 1
+  fi
+
+  payload="$(mktemp "${TMPDIR:-/tmp}/ew-lane-verdict.XXXXXX")" || {
+    echo "ERROR: $label could not create a temporary file for the result payload" >&2
+    echo "==> $label verdict: FAIL"
+    return 1
+  }
+
+  # `get test-results tests` is the MODERN subcommand. The one most sessions
+  # reach for first, `get test-report tests`, is deprecated and refuses outright.
+  if ! xcrun xcresulttool get test-results tests --path "$bundle" >"$payload" 2>/dev/null; then
+    rc=$?
+    rm -f "$payload"
+    echo "ERROR: $label could not read the result bundle at $bundle (xcresulttool exited $rc)" >&2
+    echo "==> $label verdict: FAIL"
+    return 1
+  fi
+
+  if [ ! -f "$EW_LANE_JUDGE" ]; then
+    # Loud and specific: "the judge is missing" and "the lane crashed" are
+    # different situations and must not print the same thing.
+    rm -f "$payload"
+    echo "ERROR: $label cannot find its result judge at $EW_LANE_JUDGE" >&2
+    echo "==> $label verdict: FAIL"
+    return 1
+  fi
+
+  EW_LANE_LABEL="$label" EW_LANE_ACCEPTED="$EW_LANE_ACCEPTED_RESULTS" \
+    python3 "$EW_LANE_JUDGE" "$payload"
+  rc=$?
+  rm -f "$payload"
+
+  if [ "$rc" -ne 0 ]; then
+    echo "==> $label verdict: FAIL"
+    return 1
+  fi
+
+  echo "==> $label verdict: PASS"
+  return 0
+}

--- a/scripts/xcode-test.sh
+++ b/scripts/xcode-test.sh
@@ -25,6 +25,8 @@ PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 . "$PROJECT_ROOT/scripts/lib/spm-seed.sh"
 # shellcheck source=scripts/lib/log-dir.sh
 . "$PROJECT_ROOT/scripts/lib/log-dir.sh"
+# shellcheck source=scripts/lib/lane-verdict.sh
+. "$PROJECT_ROOT/scripts/lib/lane-verdict.sh"
 trap 'ew_seed_release_all' EXIT
 # bash exits on a signal WITHOUT running the EXIT trap, which would strand a
 # seed lock. Converting each signal into a normal exit makes EXIT run.
@@ -79,15 +81,36 @@ ew_ensure_generated "$PROJECT_ROOT"
 
 TEST_ARGS=()
 [ -n "$FILTER" ] && TEST_ARGS=(-only-testing:"$FILTER")
-RESULT_BUNDLE_ARGS=()
-[ -n "$RESULT_BUNDLE_PATH" ] && RESULT_BUNDLE_ARGS=(-resultBundlePath "$RESULT_BUNDLE_PATH")
+# EVERY lane now names its result bundle, because the verdict is read from it
+# (#2401). `-resultBundlePath` does not CREATE the artifact — `xcodebuild test`
+# writes one into `<derivedData>/Logs/Test/` on every run regardless, measured at
+# 4.5s against 4.6s without the flag — it only puts it somewhere addressable.
+# Naming it also avoids that directory's "newest wins" hazard, which is the same
+# shared-path problem `--log-dir` exists for one artifact over.
+DEBUG_RESULT_BUNDLE="${RESULT_BUNDLE_PATH:-$LOG_DIR/xcode-test-debug.xcresult}"
+RELEASE_RESULT_BUNDLE="$LOG_DIR/xcode-test-release.xcresult"
 
-# Run one test lane and guard against a silent zero-test run: xcodebuild prints
-# suite-level "passed" even for an empty bundle, so require a positive executed
-# count (summed across the Swift Testing per-target run summaries) — same guard
-# CI uses (pr-check.yml / main-post-merge.yml).
-run_lane() {  # $1=scheme  $2=config  $3=logfile  $4...=extra build settings
-  local scheme="$1" config="$2" log="$3"; shift 3
+# Run one test lane and hand its verdict to the shared owner.
+#
+# The zero-test guard this used to inline is PRESERVED inside
+# `ew_lane_verdict` and its reasoning is unchanged: xcodebuild prints
+# suite-level "passed" even for an empty bundle, so a presence-grep would green
+# a run where nothing executed and a positive executed count is required.
+#
+# What is ADDED beside it is the truncated-run refusal, because a positive count
+# cannot prove the lane finished — a crashed bundle was measured reporting
+# `** TEST SUCCEEDED **` at 2,557 of 6,664 tests with exit 0. That owner is
+# shared with the three CI steps (pr-check.yml / main-post-merge.yml) so the
+# rule cannot hold in one place and lapse in another.
+run_lane() {  # $1=scheme $2=config $3=logfile $4=bundle $5...=extra build settings
+  local scheme="$1" config="$2" log="$3" bundle="$4"; shift 4
+  # xcodebuild refuses to overwrite an existing bundle. Scoped to a path that
+  # actually names one: `--result-bundle-path` is caller-supplied, and an
+  # unscoped `rm -rf` on a caller-supplied path is a sharp edge nobody needs.
+  case "$bundle" in
+    *.xcresult) rm -rf "$bundle" ;;
+    *) echo "ERROR: result bundle path must end in .xcresult: $bundle" >&2; exit 2 ;;
+  esac
   set -o pipefail
   # Xcode forwards TEST_RUNNER_* variables to the test process after removing
   # the prefix. This keeps AppLogger tests away from the running dev app's
@@ -103,16 +126,17 @@ run_lane() {  # $1=scheme  $2=config  $3=logfile  $4...=extra build settings
     VALID_ARCHS=arm64 \
     ONLY_ACTIVE_ARCH=YES \
     "$@" \
-    "${RESULT_BUNDLE_ARGS[@]}" \
+    -resultBundlePath "$bundle" \
     "${TEST_ARGS[@]}" | tee "$log"
 
-  local n
-  n=$(grep -oE "Test run with [0-9]+ test" "$log" | grep -oE "[0-9]+" | awk '{s+=$1} END{print s+0}')
-  if [ "$n" -lt 1 ]; then
-    echo "ERROR: $config lane executed 0 tests (empty/misconfigured bundle)" >&2
-    exit 1
-  fi
-  echo "==> $config lane executed $n tests"
+  # The expected count is a FLAG, never a gate: it warns on a mismatch and
+  # cannot decide the lane either way. Unset by default, because a count is a
+  # parameter and a borrowed parameter builds a check that cannot fire.
+  local expected=""
+  [ "$config" = "Debug" ] && expected="${EW_EXPECTED_DEBUG_TESTS:-}"
+  [ "$config" = "Release" ] && expected="${EW_EXPECTED_RELEASE_TESTS:-}"
+
+  ew_lane_verdict "$log" "$bundle" "$config lane" "$expected" || exit 1
 }
 
 # #2157 chunk A: seed before the first lane resolves anything.
@@ -126,8 +150,9 @@ ew_seed_resolve_or_unseed "$DERIVED_DATA" \
     -scheme "$DEBUG_SCHEME" \
     -derivedDataPath "$DERIVED_DATA"
 
-run_lane "$DEBUG_SCHEME" Debug "$LOG_DIR/xcode-test-debug.log"
+run_lane "$DEBUG_SCHEME" Debug "$LOG_DIR/xcode-test-debug.log" "$DEBUG_RESULT_BUNDLE"
 ew_seed_publish "$PROJECT_ROOT" "$DERIVED_DATA"
 if [ "$RUN_RELEASE" = "1" ]; then
-  run_lane "$RELEASE_SCHEME" Release "$LOG_DIR/xcode-test-release.log" ENABLE_TESTABILITY=YES
+  run_lane "$RELEASE_SCHEME" Release "$LOG_DIR/xcode-test-release.log" \
+    "$RELEASE_RESULT_BUNDLE" ENABLE_TESTABILITY=YES
 fi


### PR DESCRIPTION
Closes #2401.

## What was wrong

A test bundle that CRASHES mid-run reported `** TEST SUCCEEDED **`, printed a lane total, and exited **0** — with roughly **4,100 of 6,664 tests never executed** and nothing saying so.

Every signal a reader checks agreed, and every one was wrong:

- a crash prints **zero** failure marks, so `failed=0` is accurate and useless;
- `xcodebuild` concluded SUCCEEDED;
- the guard rejects only `n < 1`, which 2,557 satisfies comfortably.

It catches an EMPTY run and passes a TRUNCATED one.

## The issue understated the blast radius: four sites, three of them CI

```
scripts/xcode-test.sh:110
.github/workflows/pr-check.yml:206          <- inside build-debug
.github/workflows/main-post-merge.yml:271   <- release lane
.github/workflows/main-post-merge.yml:409   <- debug lane
```

Identical three lines, identical blind spot. `build-debug` is one of five jobs `build-check` requires, and `build-check` is the only **required** status — so this was never a local lane lying to one session. **A crashed bundle greened the merge gate**, and main could merge with most of the suite never run. Independently re-verified by the issue's author before I built on it.

## The console is not the oracle, and that is measured rather than argued

The obvious fix is to grep the log for `Fatal error:`. Three measurements refuse it:

1. **The log carries test SOURCE.** A build log for a suite containing a literal `fatalError(...)` call echoed that line **24 times** as compiler diagnostics. On an untyped stream a crash and a *quotation* of a crash are the same bytes.
2. **The string is not ours.** Its wording belongs to the Swift runtime and to Xcode, so a set of console signatures is a description with a next counterexample forever, not an enumeration.
3. **The console sees LESS than the bundle.** On the crashed run the final `Test run with N tests` read **3**, because xcodebuild restarts after a crash and that line reports only the last launch. The bundle held all **six** cases, including the two that ran before the crash and the one that died.

So the question asked is closed and typed: *does the named `.xcresult` hold at least one test case, and is every case result one this repo accepts?*

The accepted set is **measured**, not guessed — a healthy 6,829-case lane produced exactly three values:

```
Passed 6815 · Skipped 12 · Expected Failure 2
```

`Skipped` is a hardware-gated `@Test(.enabled(if:))`; `Expected Failure` is a `withKnownIssue` case. Anything else — including a value a future Xcode invents — is refused. Fails closed.

**Deliberately not matched: the crash's own failure text.** The crashed run's `Failure Message` read `Test crashed with signal trap.`, not the `Crash: xctest at ...` the older note predicts. Keying on that prefix would have shipped a check that misses the case it was written for.

## The empty-run reasoning is preserved, not replaced

The original comment — *a presence-grep would green a run where nothing executed* — is correct and complete about the EMPTY case, and is the only record of why a presence-grep was rejected. It is carried into the new owner verbatim, so the next reader does not read the old guard as carelessness and re-propose the thing it ruled out.

## The expected count is a FLAG, never a gate

A count is a parameter, a parameter can be borrowed from the wrong workflow, and a count-gated check fails toward silence. A mismatch prints loudly beside a verdict and never licenses or withholds one.

## Evidence

**The decisive control, built from two REAL artifacts rather than a simulation** — a log whose count reads 6,829 (positive, healthy-looking) paired with the genuine crashed result bundle:

```
==> Debug lane executed 6829 tests
ERROR: Debug lane result is 'Failed': CustomWordsExportNoticeTests/nothingToExportIsInfo()
       — Test crashed with signal trap.
==> Debug lane verdict: FAIL
```

The old guard passes that input. Both directions verified end to end through the finished script: a healthy filtered lane returns `verdict: PASS`, exit 0.

**A control I ran that proved nothing, recorded so nobody repeats it.** Injecting a `fatalError` into a filtered suite returns exit 65 — xcodebuild attributed the crash to a named test and failed the lane itself, so `set -e` aborts before the verdict owner runs. That *looks* like the new gate working and is not. The dangerous variant is the one where xcodebuild exits 0, which could not be manufactured on demand; hence the composed control above.

## Tests

20 cases, two-way, mutation-controlled: disabling the allowlist reddens exactly the two refusal rows and nothing else. Every rejected case is paired with an accepted twin differing only in the field under test — including one where the crash wording sits in a **passing** case's identifier and must change nothing.

Wired into `build-check` itself, because a suite nothing invokes first fires in someone else's run. It runs on Linux: every row either drives the judge on a JSON payload or takes a shell path that short-circuits before `xcrun`.

## Two Codex findings I did not take on faith

- It predicted the crash message would read `Crash: xctest at ...`. On this Xcode it reads `Test crashed with signal trap.`, so that clause is dropped — the typed `Failed` result catches it with no string involved.
- It claimed crash output bypasses the `tee`. Measured: the tee'd log carried 2 `Fatal error` lines and the restart line. Neither changes the conclusion, but the stated reasons were wrong.

## Known gaps, stated

- **Slot for the sibling suites:** the other `scripts/lib/*-test.sh` files are wired into no CI job. Not fixed here rather than adding suites whose macOS assumptions have not been checked on the Linux runner.
- `scripts/lib/*` is gitignored by default, so the three new files carry explicit exceptions — verified with `git add --dry-run`, not by reading the pattern. Without them this works locally and ships as nothing.

Sibling of #2396, which is the other way a lane count lies and which I am taking next.

Lane: `Code` + `CI/workflow`, `mixed_pr: true`. Tier: MEDIUM — it changes what the required check accepts.
