### PR TITLE
fix(ci): the lane log directory is per-invocation, not a shared path (#2396)

### DIFF
--- a/scripts/lib/log-dir-test.sh
+++ b/scripts/lib/log-dir-test.sh
@@ -666,6 +666,56 @@ else
   skip "a mount nested below a lane is not descended into" "hdiutil/diskutil absent"
 fi
 
+echo "== the CREATE path refuses a linked parent, not just the removal path =="
+# Round 8 removed a deletion and its containment check together - and that check
+# was ALSO guarding the create. Every round since argued about the removal path,
+# because that is where the `rm -rf` was, while the take path wrote straight
+# through a symlinked `build`: the lane lands OUTSIDE the worktree and publish
+# then replaces the external parent's `latest-lane`.
+ESC="$SANDBOX/escapee"           # stands in for somewhere else entirely
+mkdir -p "$ESC"
+LINKROOT="$SANDBOX/linked-root"
+mkdir -p "$LINKROOT"
+ln -s "$ESC" "$LINKROOT/build"   # build is a symlink out of the tree
+if ew_take_default_lane "$LINKROOT/build/lanes/1787000000-7" 2>/dev/null; then
+  bad "the take refuses a symlinked build" "created through the link"
+else
+  ok "the take refuses a symlinked build"
+fi
+# Asserting the REFUSAL alone would also be true of a version that created the
+# directory and then returned nonzero, so check the world: nothing may have
+# appeared on the far side of the link.
+[ -e "$ESC/lanes" ] \
+  && bad "and nothing was created outside the worktree" "$ESC/lanes exists" \
+  || ok "and nothing was created outside the worktree"
+# The twin: publish writes into the same `build`, so guarding one and not the
+# other leaves the identical symlink exposed one command later.
+if ew_publish_latest_lane "$LINKROOT" "$LINKROOT/build/lanes/1787000000-7" 2>/dev/null; then
+  bad "publish refuses a symlinked build" "published through the link"
+else
+  ok "publish refuses a symlinked build"
+fi
+[ -e "$ESC/latest-lane" ] \
+  && bad "and no pointer was written outside the worktree" "$ESC/latest-lane exists" \
+  || ok "and no pointer was written outside the worktree"
+# A SYMLINKED `lanes` is the other component and must be refused too - the
+# reviewer named both.
+LINKROOT2="$SANDBOX/linked-lanes"
+mkdir -p "$LINKROOT2/build" "$SANDBOX/escapee2"
+ln -s "$SANDBOX/escapee2" "$LINKROOT2/build/lanes"
+if ew_take_default_lane "$LINKROOT2/build/lanes/1787000000-8" 2>/dev/null; then
+  bad "the take refuses a symlinked lanes" "created through the link"
+else
+  ok "the take refuses a symlinked lanes"
+fi
+# The ACCEPTED twin, or "refuses" is indistinguishable from "never creates":
+# an ordinary parent chain must still be taken.
+if ew_take_default_lane "$SANDBOX/plain-root/build/lanes/1787000000-9"; then
+  ok "an ordinary parent chain is still taken"
+else
+  bad "an ordinary parent chain is still taken" "refused a clean tree"
+fi
+
 echo "== the removal REFUSES when the mount table names anything below the lane =="
 # The check that closes the six-round class, and on macOS its branch is
 # unreachable: `/proc/self/mountinfo` does not exist, so `ew_lane_contains_a_mount`

--- a/scripts/lib/log-dir-test.sh
+++ b/scripts/lib/log-dir-test.sh
@@ -407,6 +407,80 @@ else
   ok "the shared safety check accepts an ordinary directory"
 fi
 
+echo "== unknown classification fails CLOSED =="
+# My first version had this backwards. I wrote that an unreadable path should
+# report NOT-a-mount "because an unreadable path must not become an argument for
+# deleting it" — which is the argument for the OPPOSITE. A component that EXISTS
+# and cannot be classified is exactly where guessing safe means deleting through
+# it.
+#
+# KNOWN GAP, STATED RATHER THAN FAKED: the `stat`-failed branch has no row.
+# A row was written for it and DELETED as vacuous — it replaced
+# `ew_lane_is_mount_point` with a stub and then asserted the stub, so a control
+# that reversed the real branch left the suite fully green. The scenario is also
+# not constructible without root: `[ -e ]` and `stat` both call stat(2), so a
+# path that cannot be stat'd is also reported absent, and the absence check
+# short-circuits first. The branch is correct by reading and unproven by test;
+# saying so is better than a row that proves nothing while looking like coverage.
+#
+# Absence stays SAFE, because absence is the fresh-invocation case and there
+# is nothing there to descend into. Without this row, "fail closed" is satisfied
+# by a function that refuses every fresh run.
+if ew_lane_is_mount_point "$SANDBOX/build/lanes/does-not-exist"; then
+  bad "an absent path is not treated as mounted" "reported as a mount"
+else
+  ok "an absent path is not treated as mounted"
+fi
+
+echo "== the prune uses the SAME safety check as the reset =="
+# The mount-aware helper was added for the reset and the prune was left on `-L`
+# alone, so a mounted parent passed here while being refused three lines away.
+# A SYMLINKED parent cannot distinguish the shared helper from a bare `-L`, and a
+# real MOUNT cannot be built without root — so the WIRING is tested by stubbing
+# the collaborator and asserting the caller. The helper's own behaviour has its
+# own rows above; this asks only whether the prune consults it.
+prune_with_stub() (
+  # The stub is called with ONE argument, so the target is closed over rather
+  # than passed — a `$2` here is unbound and `set -u` turns the row into an error
+  # that reads like a failing assertion.
+  local target="$2"
+  ew_lane_component_is_unsafe() { [ "$1" = "$target" ]; }
+  ew_prune_stale_lanes "$1" "$1/build/lanes/none" 7
+)
+mkdir -p "$SANDBOX/build/lanes/4001"
+touch -t 202001010000 "$SANDBOX/build/lanes/4001"
+prune_with_stub "$SANDBOX" "$SANDBOX/build" >/dev/null 2>&1
+[ "$?" -eq 2 ] && [ -d "$SANDBOX/build/lanes/4001" ] \
+  && ok "prune consults the shared check for build/" \
+  || bad "prune consults the shared check for build/" "swept anyway or wrong rc"
+prune_with_stub "$SANDBOX" "$SANDBOX/build/lanes" >/dev/null 2>&1
+[ "$?" -eq 2 ] && [ -d "$SANDBOX/build/lanes/4001" ] \
+  && ok "prune consults the shared check for lanes/" \
+  || bad "prune consults the shared check for lanes/" "swept anyway or wrong rc"
+
+# A stale ENTRY that is itself a link must be skipped rather than removed, and
+# the sweep must continue past it — a partial sweep that stops at the first
+# oddity is how old lanes accumulate silently.
+# The PER-ENTRY check, wired the same way and for the same reason: a symlinked
+# entry is filtered out by `find -type d` BEFORE the check can see it, so a
+# symlink row would pass without the check existing. A mount is a directory and
+# `-type d` does match it, which is exactly why the per-entry check is needed and
+# exactly what cannot be built without root.
+sweep_with_stub() (
+  local target="$2"
+  ew_lane_component_is_unsafe() { [ "$1" = "$target" ]; }
+  ew_prune_stale_lanes "$1" "$1/build/lanes/none" 7
+)
+mkdir -p "$SANDBOX/build/lanes/3001" "$SANDBOX/build/lanes/3002"
+touch -t 202001010000 "$SANDBOX/build/lanes/3001" "$SANDBOX/build/lanes/3002"
+sweep_with_stub "$SANDBOX" "$SANDBOX/build/lanes/3002" >/dev/null 2>&1
+if [ ! -d "$SANDBOX/build/lanes/3001" ] && [ -d "$SANDBOX/build/lanes/3002" ]; then
+  ok "the sweep removes stale lanes and steps over an unsafe entry"
+else
+  bad "the sweep removes stale lanes and steps over an unsafe entry" \
+    "3001=$([ -d "$SANDBOX/build/lanes/3001" ] && echo kept || echo gone) 3002=$([ -d "$SANDBOX/build/lanes/3002" ] && echo kept || echo GONE)"
+fi
+
 echo "== both refuse rather than guessing =="
 ew_publish_latest_lane "$SANDBOX" "" >/dev/null 2>&1
 [ "$?" -eq 2 ] && ok "publish refuses a missing lane_dir" || bad "publish refuses a missing lane_dir" "rc=$?"

--- a/scripts/lib/log-dir-test.sh
+++ b/scripts/lib/log-dir-test.sh
@@ -433,6 +433,39 @@ esac
   && ok "publication has a usable rename" \
   || bad "publication has a usable rename" "empty"
 
+echo "== the mountinfo branch is EXERCISED, not merely written =="
+# The branch I told the reviewer I could not execute, and it was broken in
+# exactly the way an unexecutable branch gets broken: literal quote characters
+# reached the shell, `$5` was expanded before awk saw it, and the command
+# succeeded for EVERY path — reporting everything as a mount.
+#
+# It is now a shell `while read`, which this suite CAN drive: point the reader at
+# a fixture in mountinfo's own format and assert both directions. That does not
+# prove the real /proc parse on Linux, but it proves the comparison, which is
+# what was wrong.
+ew_lane_mountinfo_hit() {  # <mountinfo-file> <resolved-path>
+  local mi_target
+  while read -r _ _ _ _ mi_target _; do
+    [ "$mi_target" = "$2" ] && return 0
+  done < "$1"
+  return 1
+}
+MI="$SANDBOX/mountinfo"
+cat > "$MI" <<'MIEOF'
+25 30 0:23 / /proc rw,nosuid shared:5 - proc proc rw
+26 30 0:24 / /mnt/bound rw,relatime shared:6 - ext4 /dev/sda1 rw
+MIEOF
+ew_lane_mountinfo_hit "$MI" /mnt/bound \
+  && ok "a mountinfo entry is recognised by its mount point field" \
+  || bad "a mountinfo entry is recognised by its mount point field" "missed"
+# The accepted twin, and it is the one the broken version failed: a path that is
+# NOT in the table must not match. The old awk returned true for everything.
+if ew_lane_mountinfo_hit "$MI" /not/a/mount; then
+  bad "a path absent from mountinfo does not match" "matched anyway"
+else
+  ok "a path absent from mountinfo does not match"
+fi
+
 echo "== find failing is not an empty sweep =="
 # A process substitution's exit status is invisible to the loop, so a `find` that
 # could not enumerate lanes/ produced no iterations, left rc at 0, and the prune

--- a/scripts/lib/log-dir-test.sh
+++ b/scripts/lib/log-dir-test.sh
@@ -578,6 +578,43 @@ else
 fi
 chmod 700 "$STUCK"
 
+echo "== the mount question is asked of the WHOLE SUBTREE, not one directory =="
+# Six review rounds each found a new way a mount could be inside the tree being
+# deleted: the lane is a mount; a parent is; a same-device bind mount defeats a
+# device comparison; the mount is BELOW the lane; a same-device bind mount below
+# the lane defeats `-xdev` too. Each fix exposed the next, which is the signature
+# of describing a set instead of enumerating one.
+#
+# `subtree` mode stops testing a PROPERTY and reads the kernel's own finite list,
+# so a mount anywhere beneath a lane is found without anyone predicting where.
+SUBMI="$SANDBOX/mountinfo-sub"
+cat > "$SUBMI" <<'MIEOF'
+25 30 0:23 / /proc rw,nosuid shared:5 - proc proc rw
+26 30 0:24 / /build/lanes/111/app-logger/external rw,relatime shared:6 - ext4 /dev/sda1 rw
+MIEOF
+ew_lane_mountinfo_lists "$SUBMI" /build/lanes/111 subtree \
+  && ok "a mount BELOW the path is found in subtree mode" \
+  || bad "a mount BELOW the path is found in subtree mode" "missed"
+# The rejected twin for the MODE: exact mode must still answer only about the
+# path itself, or the mount-point check one layer up starts reporting every
+# ancestor of every mount as a mount.
+if ew_lane_mountinfo_lists "$SUBMI" /build/lanes/111 exact; then
+  bad "exact mode still answers only about the path itself" "matched a descendant"
+else
+  ok "exact mode still answers only about the path itself"
+fi
+# The rejected twin for the PREFIX: a sibling that merely shares a name prefix is
+# not below it. `/build/lanes/1110` must not match `/build/lanes/111`.
+if ew_lane_mountinfo_lists "$SUBMI" /build/lanes/11 subtree; then
+  bad "a name-prefix sibling is not treated as a descendant" "matched /build/lanes/11"
+else
+  ok "a name-prefix sibling is not treated as a descendant"
+fi
+# And the path ITSELF still matches in subtree mode - it is at-or-below.
+ew_lane_mountinfo_lists "$SUBMI" /build/lanes/111/app-logger/external subtree \
+  && ok "subtree mode still matches the path itself" \
+  || bad "subtree mode still matches the path itself" "missed"
+
 echo "== the removal cannot cross a filesystem boundary =="
 # THE PROPERTY THE WHOLE FUNCTION EXISTS FOR, and nothing short of a REAL mount
 # can bind it: `rm -rf` and `find -xdev -delete` are indistinguishable on any
@@ -627,6 +664,63 @@ if command -v hdiutil >/dev/null 2>&1 && command -v diskutil >/dev/null 2>&1; th
   trap - EXIT
 else
   skip "a mount nested below a lane is not descended into" "hdiutil/diskutil absent"
+fi
+
+echo "== the removal REFUSES when the mount table names anything below the lane =="
+# The check that closes the six-round class, and on macOS its branch is
+# unreachable: `/proc/self/mountinfo` does not exist, so `ew_lane_contains_a_mount`
+# always answers no and a mutant that deletes the call survives. That is exactly
+# how rounds 6, 7 and 9 of this PR each shipped a defect - a fix inside a branch
+# the suite cannot drive.
+#
+# Driven through a PRIVATE COPY of the lib with the table path repointed, never
+# by giving the shipped function an env knob: a knob on a guard is an unlogged
+# way to disable it, and pointing it at an empty file is precisely the bypass.
+# The rewrite FAILS CLOSED - a `sed` that matched nothing would leave the copy
+# reading the real `/proc` path and the row would pass having proved nothing.
+COPY="$SANDBOX/log-dir-mountcheck.sh"
+FAKEMI="$SANDBOX/fake-mountinfo"
+sed 's#/proc/self/mountinfo#'"$FAKEMI"'#g' "$HERE/log-dir.sh" > "$COPY"
+if [ "$(/usr/bin/grep -c "$FAKEMI" "$COPY")" -ge 3 ]; then
+  (
+    # shellcheck disable=SC1090
+    . "$COPY"
+    LANE="$SANDBOX/refusal/build/lanes/1787000000-9"
+    mkdir -p "$LANE/app-logger/external"
+    echo "not-ours" > "$LANE/app-logger/external/precious.txt"
+    RESOLVED="$(cd "$LANE" && pwd -P)"
+    printf '26 30 0:24 / %s/app-logger/external rw - ext4 /dev/sda1 rw\n' "$RESOLVED" > "$FAKEMI"
+    if ew_lane_remove_tree "$LANE" 2>/dev/null; then
+      echo "MOUNTCHECK-FAIL removal reported success"
+    elif [ ! -f "$LANE/app-logger/external/precious.txt" ]; then
+      echo "MOUNTCHECK-FAIL removal refused but had already deleted"
+    else
+      echo "MOUNTCHECK-OK"
+    fi
+    # The accepted twin, in the same rig: with NOTHING listed below the lane the
+    # removal must still work, or "refuses" would be indistinguishable from
+    # "never removes anything".
+    : > "$FAKEMI"
+    if ew_lane_remove_tree "$LANE" 2>/dev/null && [ ! -e "$LANE" ]; then
+      echo "MOUNTCHECK-CLEAR-OK"
+    else
+      echo "MOUNTCHECK-CLEAR-FAIL"
+    fi
+  ) > "$SANDBOX/mountcheck.out" 2>&1
+  if /usr/bin/grep -q "MOUNTCHECK-OK" "$SANDBOX/mountcheck.out"; then
+    ok "a lane with a mount listed below it is not removed"
+  else
+    bad "a lane with a mount listed below it is not removed" \
+        "$(tr '\n' ' ' < "$SANDBOX/mountcheck.out")"
+  fi
+  if /usr/bin/grep -q "MOUNTCHECK-CLEAR-OK" "$SANDBOX/mountcheck.out"; then
+    ok "a lane with nothing mounted below it is still removed"
+  else
+    bad "a lane with nothing mounted below it is still removed" \
+        "$(tr '\n' ' ' < "$SANDBOX/mountcheck.out")"
+  fi
+else
+  bad "the mount-check copy was repointed" "sed did not rewrite the table path"
 fi
 
 echo "== taking a default lane is atomic, not assumed =="

--- a/scripts/lib/log-dir-test.sh
+++ b/scripts/lib/log-dir-test.sh
@@ -481,6 +481,54 @@ else
     "3001=$([ -d "$SANDBOX/build/lanes/3001" ] && echo kept || echo gone) 3002=$([ -d "$SANDBOX/build/lanes/3002" ] && echo kept || echo GONE)"
 fi
 
+echo "== a newline in a lane name cannot reach rm -rf =="
+# I flagged this myself as "would break it". The actual consequence is worse: a
+# line-delimited read splits `old<newline>Sources` into TWO records and the
+# second is `Sources` — a RELATIVE path — which resolves against the caller's
+# cwd. `xcode-test.sh` runs from the project root, so that is the repo's own
+# source tree.
+#
+# The victim here stands in for it: a `Sources` directory beside the sandbox,
+# reachable only if a relative record escapes.
+NL_ROOT="$SANDBOX/nl"
+mkdir -p "$NL_ROOT/build/lanes" "$NL_ROOT/Sources"
+: > "$NL_ROOT/Sources/precious.swift"
+mkdir -p "$NL_ROOT/build/lanes/$(printf 'old\nSources')"
+touch -t 202001010000 "$NL_ROOT/build/lanes/$(printf 'old\nSources')"
+( cd "$NL_ROOT" && ew_prune_stale_lanes "$NL_ROOT" "$NL_ROOT/build/lanes/none" 7 ) >/dev/null 2>&1
+if [ -f "$NL_ROOT/Sources/precious.swift" ]; then
+  ok "a newline-named lane cannot reach a relative path"
+else
+  bad "a newline-named lane cannot reach a relative path" "Sources/ was deleted"
+fi
+# The accepted twin: the newline-named lane is itself STALE and must still be
+# swept, or the row above is satisfied by a prune that refuses odd names.
+[ ! -d "$NL_ROOT/build/lanes/$(printf 'old\nSources')" ] \
+  && ok "the newline-named lane is still swept" \
+  || bad "the newline-named lane is still swept" "left behind"
+
+# And a relative path is unsafe by definition, whatever its shape — the class,
+# not just the route that produced it.
+ew_lane_component_is_unsafe "build/lanes/4242" \
+  && ok "a relative path is unsafe by definition" \
+  || bad "a relative path is unsafe by definition" "accepted"
+
+echo "== a removal failure reaches the caller =="
+# The `while` used to sit on the right of a PIPE, which runs it in a subshell, so
+# a failure recorded inside could not reach the caller — and the trailing
+# `printf` made the body succeed regardless. A prune that removed nothing
+# reported success.
+FAILDIR="$SANDBOX/faildir"
+mkdir -p "$FAILDIR/build/lanes/5001"
+touch -t 202001010000 "$FAILDIR/build/lanes/5001"
+chmod 500 "$FAILDIR/build/lanes"   # no write: the entry cannot be unlinked
+ew_prune_stale_lanes "$FAILDIR" "$FAILDIR/build/lanes/none" 7 >/dev/null 2>&1
+rc=$?
+chmod 700 "$FAILDIR/build/lanes"
+[ "$rc" -ne 0 ] \
+  && ok "a removal failure is reported to the caller" \
+  || bad "a removal failure is reported to the caller" "rc=$rc"
+
 echo "== both refuse rather than guessing =="
 ew_publish_latest_lane "$SANDBOX" "" >/dev/null 2>&1
 [ "$?" -eq 2 ] && ok "publish refuses a missing lane_dir" || bad "publish refuses a missing lane_dir" "rc=$?"

--- a/scripts/lib/log-dir-test.sh
+++ b/scripts/lib/log-dir-test.sh
@@ -69,10 +69,19 @@ echo "== the default is private to the invoking process =="
 # highest-cost shape a comment has, because its whole function is to stop the next
 # reader going and checking. Replaced with what the gate actually reads rather
 # than deleted, so the next reader inherits the verified version.
-check "no request -> <root>/build/lanes/<pid>" \
-  "$ROOT/build/lanes/$$" "$(ew_resolve_log_dir "$ROOT")"
-check "empty request -> <root>/build/lanes/<pid>" \
-  "$ROOT/build/lanes/$$" "$(ew_resolve_log_dir "$ROOT" "")"
+# The name carries the SECOND as well as the pid, so it cannot RECUR — which is
+# what removed the take path's `rm -rf` entirely (#2408 r7). Asserted by SHAPE
+# rather than by value, because the second moves between the call and the check.
+a="$(ew_resolve_log_dir "$ROOT")"
+case "$a" in
+  "$ROOT"/build/lanes/[0-9]*-$$) ok "no request -> <root>/build/lanes/<seconds>-<pid>" "$a" ;;
+  *) bad "no request -> <root>/build/lanes/<seconds>-<pid>" "$a" ;;
+esac
+b="$(ew_resolve_log_dir "$ROOT" "")"
+case "$b" in
+  "$ROOT"/build/lanes/[0-9]*-$$) ok "empty request -> <root>/build/lanes/<seconds>-<pid>" "$b" ;;
+  *) bad "empty request -> <root>/build/lanes/<seconds>-<pid>" "$b" ;;
+esac
 
 # The row that justifies the change, and it needs two real PROCESSES: within one
 # shell `$$` is constant, so a same-process comparison would pass against a
@@ -219,142 +228,6 @@ if ew_prune_stale_lanes "$SANDBOX" "$SANDBOX/build/lanes/none" 7 >/dev/null 2>&1
   ok "an absent lanes/ tree is a no-op"
 else
   bad "an absent lanes/ tree is a no-op" "returned nonzero"
-fi
-
-echo "== a recycled pid gets a CLEAN lane =="
-# The case the resolver's header used to call harmless and is not. A later run
-# replaces only what IT writes, so a debug-only run landing on a recycled pid
-# would keep the previous occupant's Release receipt beside a fresh Debug one —
-# a stale artifact read as current, which is this pair of issues' whole subject.
-mkdir -p "$SANDBOX/build/lanes/4242"
-: > "$SANDBOX/build/lanes/4242/xcode-test-release.log"
-: > "$SANDBOX/build/lanes/4242/xcode-test-debug.log"
-mkdir -p "$SANDBOX/build/lanes/4242/app-logger"
-: > "$SANDBOX/build/lanes/4242/app-logger/app.log"
-ew_reset_lane_dir "$SANDBOX" "$SANDBOX/build/lanes/4242" >/dev/null 2>&1
-if [ ! -e "$SANDBOX/build/lanes/4242/xcode-test-release.log" ] \
-  && [ ! -e "$SANDBOX/build/lanes/4242/app-logger/app.log" ]; then
-  ok "a recycled lane keeps no previous artifact"
-else
-  bad "a recycled lane keeps no previous artifact" "$(ls -R "$SANDBOX/build/lanes/4242" 2>/dev/null | tr '\n' ' ')"
-fi
-
-# Scoping. This deletes and runs unattended, so the refusals matter more than the
-# success: it must decline anything that is not the shape the resolver produces.
-mkdir -p "$SANDBOX/build/lanes/notapid" "$SANDBOX/build/other"
-: > "$SANDBOX/build/other/keep.txt"
-ew_reset_lane_dir "$SANDBOX" "$SANDBOX/build/lanes/notapid" >/dev/null 2>&1
-[ "$?" -eq 2 ] && [ -d "$SANDBOX/build/lanes/notapid" ] \
-  && ok "a lane name that is not a pid is refused" \
-  || bad "a lane name that is not a pid is refused" "removed or wrong rc"
-
-# THESE TWO MUST USE AN ALL-DIGIT BASENAME, or they do not test what they name.
-# Written first with `other` and `nested` as the basenames, both were refused by
-# the PID-SHAPE guard and passed while the PATH-SCOPE guard was deleted —
-# a control caught it: removing that guard left the suite fully green. A fixture
-# that cannot tell two guards apart reports on whichever one happens to fire.
-mkdir -p "$SANDBOX/build/other/4242"
-: > "$SANDBOX/build/other/4242/keep.txt"
-ew_reset_lane_dir "$SANDBOX" "$SANDBOX/build/other/4242" >/dev/null 2>&1
-[ "$?" -eq 2 ] && [ -f "$SANDBOX/build/other/4242/keep.txt" ] \
-  && ok "a pid-shaped path OUTSIDE lanes/ is refused" \
-  || bad "a pid-shaped path OUTSIDE lanes/ is refused" "removed or wrong rc"
-
-# Nesting is the one that would let a caller walk out of the scope, and it is
-# pid-shaped at every level so only the path guard can refuse it.
-mkdir -p "$SANDBOX/build/lanes/99/4242"
-: > "$SANDBOX/build/lanes/99/4242/keep.txt"
-ew_reset_lane_dir "$SANDBOX" "$SANDBOX/build/lanes/99/4242" >/dev/null 2>&1
-[ "$?" -eq 2 ] && [ -f "$SANDBOX/build/lanes/99/4242/keep.txt" ] \
-  && ok "a pid-shaped path NESTED under lanes/ is refused" \
-  || bad "a pid-shaped path NESTED under lanes/ is refused" "removed or wrong rc"
-
-# An absent lane is a no-op, not an error: the common case is a fresh pid.
-if ew_reset_lane_dir "$SANDBOX" "$SANDBOX/build/lanes/7777" >/dev/null 2>&1; then
-  ok "an absent lane is a no-op"
-else
-  bad "an absent lane is a no-op" "returned nonzero"
-fi
-
-echo "== a symlinked parent cannot be deleted THROUGH =="
-# The P1 the string-shaped guards could not see. Both original checks are true of
-# a STRING and say nothing about the filesystem, so a symlinked `build` or
-# `lanes` passed every one of them while `rm -rf` followed the link out of the
-# tree and deleted a numeric directory somewhere else.
-#
-# Each row plants a real victim outside the tree and requires it to SURVIVE.
-SYM="$(mktemp -d "${TMPDIR:-/tmp}/ew-log-dir-symlink.XXXXXX")"
-trap 'rm -rf "$SANDBOX" "$NOT_FOUND_LOG" "$SYM"' EXIT
-
-# (a) build/lanes is a link to somewhere else entirely.
-mkdir -p "$SYM/victim-a/4242" "$SYM/root-a/build"
-: > "$SYM/victim-a/4242/precious.txt"
-ln -s "$SYM/victim-a" "$SYM/root-a/build/lanes"
-ew_reset_lane_dir "$SYM/root-a" "$SYM/root-a/build/lanes/4242" >/dev/null 2>&1
-[ "$?" -eq 2 ] && [ -f "$SYM/victim-a/4242/precious.txt" ] \
-  && ok "a symlinked lanes/ is refused, victim survives" \
-  || bad "a symlinked lanes/ is refused, victim survives" "victim gone or wrong rc"
-
-# (b) build itself is a link. The lane path string is identical to a legitimate
-# one, which is exactly why a textual guard cannot tell them apart.
-mkdir -p "$SYM/victim-b/lanes/4242" "$SYM/root-b"
-: > "$SYM/victim-b/lanes/4242/precious.txt"
-ln -s "$SYM/victim-b" "$SYM/root-b/build"
-ew_reset_lane_dir "$SYM/root-b" "$SYM/root-b/build/lanes/4242" >/dev/null 2>&1
-[ "$?" -eq 2 ] && [ -f "$SYM/victim-b/lanes/4242/precious.txt" ] \
-  && ok "a symlinked build/ is refused, victim survives" \
-  || bad "a symlinked build/ is refused, victim survives" "victim gone or wrong rc"
-
-# (c) the lane itself is a link to a real directory elsewhere.
-mkdir -p "$SYM/victim-c" "$SYM/root-c/build/lanes"
-: > "$SYM/victim-c/precious.txt"
-ln -s "$SYM/victim-c" "$SYM/root-c/build/lanes/4242"
-ew_reset_lane_dir "$SYM/root-c" "$SYM/root-c/build/lanes/4242" >/dev/null 2>&1
-[ "$?" -eq 2 ] && [ -f "$SYM/victim-c/precious.txt" ] \
-  && ok "a symlinked lane is refused, victim survives" \
-  || bad "a symlinked lane is refused, victim survives" "victim gone or wrong rc"
-
-# (d) the prune refuses the whole sweep through a symlinked parent, rather than
-# pruning some entries and stopping. A partial sweep is the worse outcome.
-mkdir -p "$SYM/victim-d/old" "$SYM/root-d/build"
-touch -t 202001010000 "$SYM/victim-d/old"
-: > "$SYM/victim-d/old/precious.txt"
-ln -s "$SYM/victim-d" "$SYM/root-d/build/lanes"
-ew_prune_stale_lanes "$SYM/root-d" "$SYM/root-d/build/lanes/none" 7 >/dev/null 2>&1
-[ "$?" -eq 2 ] && [ -f "$SYM/victim-d/old/precious.txt" ] \
-  && ok "prune refuses a symlinked lanes/, victim survives" \
-  || bad "prune refuses a symlinked lanes/, victim survives" "victim gone or wrong rc"
-
-# The ACCEPTED twin: an ordinary, unlinked lane must still be cleared, or all four
-# rows above are satisfied by a function that refuses everything.
-mkdir -p "$SANDBOX/build/lanes/8888"
-: > "$SANDBOX/build/lanes/8888/stale.log"
-ew_reset_lane_dir "$SANDBOX" "$SANDBOX/build/lanes/8888" >/dev/null 2>&1
-[ ! -e "$SANDBOX/build/lanes/8888/stale.log" ] \
-  && ok "an ordinary lane is still cleared" \
-  || bad "an ordinary lane is still cleared" "stale file survived"
-
-echo "== containment is decided BEFORE absence =="
-# The P1 that made every other symlink row unreachable on the normal path. The
-# absent-lane shortcut used to run first, and absence is the FRESH-INVOCATION
-# case — so on almost every run the function returned success without looking at
-# the parents at all. The rows above only caught it because they pre-created the
-# lane.
-mkdir -p "$SYM/victim-e" "$SYM/root-e/build"
-: > "$SYM/victim-e/precious.txt"
-ln -s "$SYM/victim-e" "$SYM/root-e/build/lanes"
-# NOTE: lane 5150 deliberately does NOT exist — that is the whole point.
-ew_reset_lane_dir "$SYM/root-e" "$SYM/root-e/build/lanes/5150" >/dev/null 2>&1
-[ "$?" -eq 2 ] \
-  && ok "an ABSENT lane under a symlinked parent is still refused" \
-  || bad "an ABSENT lane under a symlinked parent is still refused" "rc was not 2"
-
-# The accepted twin: an absent lane under a NORMAL parent is a plain no-op, or
-# the row above is satisfied by a function that refuses every fresh run.
-if ew_reset_lane_dir "$SANDBOX" "$SANDBOX/build/lanes/5151" >/dev/null 2>&1; then
-  ok "an absent lane under a normal parent is a no-op"
-else
-  bad "an absent lane under a normal parent is a no-op" "returned nonzero"
 fi
 
 echo "== a mount point is a second way out that -L cannot see =="

--- a/scripts/lib/log-dir-test.sh
+++ b/scripts/lib/log-dir-test.sh
@@ -221,6 +221,61 @@ else
   bad "an absent lanes/ tree is a no-op" "returned nonzero"
 fi
 
+echo "== a recycled pid gets a CLEAN lane =="
+# The case the resolver's header used to call harmless and is not. A later run
+# replaces only what IT writes, so a debug-only run landing on a recycled pid
+# would keep the previous occupant's Release receipt beside a fresh Debug one —
+# a stale artifact read as current, which is this pair of issues' whole subject.
+mkdir -p "$SANDBOX/build/lanes/4242"
+: > "$SANDBOX/build/lanes/4242/xcode-test-release.log"
+: > "$SANDBOX/build/lanes/4242/xcode-test-debug.log"
+mkdir -p "$SANDBOX/build/lanes/4242/app-logger"
+: > "$SANDBOX/build/lanes/4242/app-logger/app.log"
+ew_reset_lane_dir "$SANDBOX" "$SANDBOX/build/lanes/4242" >/dev/null 2>&1
+if [ ! -e "$SANDBOX/build/lanes/4242/xcode-test-release.log" ] \
+  && [ ! -e "$SANDBOX/build/lanes/4242/app-logger/app.log" ]; then
+  ok "a recycled lane keeps no previous artifact"
+else
+  bad "a recycled lane keeps no previous artifact" "$(ls -R "$SANDBOX/build/lanes/4242" 2>/dev/null | tr '\n' ' ')"
+fi
+
+# Scoping. This deletes and runs unattended, so the refusals matter more than the
+# success: it must decline anything that is not the shape the resolver produces.
+mkdir -p "$SANDBOX/build/lanes/notapid" "$SANDBOX/build/other"
+: > "$SANDBOX/build/other/keep.txt"
+ew_reset_lane_dir "$SANDBOX" "$SANDBOX/build/lanes/notapid" >/dev/null 2>&1
+[ "$?" -eq 2 ] && [ -d "$SANDBOX/build/lanes/notapid" ] \
+  && ok "a lane name that is not a pid is refused" \
+  || bad "a lane name that is not a pid is refused" "removed or wrong rc"
+
+# THESE TWO MUST USE AN ALL-DIGIT BASENAME, or they do not test what they name.
+# Written first with `other` and `nested` as the basenames, both were refused by
+# the PID-SHAPE guard and passed while the PATH-SCOPE guard was deleted —
+# a control caught it: removing that guard left the suite fully green. A fixture
+# that cannot tell two guards apart reports on whichever one happens to fire.
+mkdir -p "$SANDBOX/build/other/4242"
+: > "$SANDBOX/build/other/4242/keep.txt"
+ew_reset_lane_dir "$SANDBOX" "$SANDBOX/build/other/4242" >/dev/null 2>&1
+[ "$?" -eq 2 ] && [ -f "$SANDBOX/build/other/4242/keep.txt" ] \
+  && ok "a pid-shaped path OUTSIDE lanes/ is refused" \
+  || bad "a pid-shaped path OUTSIDE lanes/ is refused" "removed or wrong rc"
+
+# Nesting is the one that would let a caller walk out of the scope, and it is
+# pid-shaped at every level so only the path guard can refuse it.
+mkdir -p "$SANDBOX/build/lanes/99/4242"
+: > "$SANDBOX/build/lanes/99/4242/keep.txt"
+ew_reset_lane_dir "$SANDBOX" "$SANDBOX/build/lanes/99/4242" >/dev/null 2>&1
+[ "$?" -eq 2 ] && [ -f "$SANDBOX/build/lanes/99/4242/keep.txt" ] \
+  && ok "a pid-shaped path NESTED under lanes/ is refused" \
+  || bad "a pid-shaped path NESTED under lanes/ is refused" "removed or wrong rc"
+
+# An absent lane is a no-op, not an error: the common case is a fresh pid.
+if ew_reset_lane_dir "$SANDBOX" "$SANDBOX/build/lanes/7777" >/dev/null 2>&1; then
+  ok "an absent lane is a no-op"
+else
+  bad "an absent lane is a no-op" "returned nonzero"
+fi
+
 echo "== both refuse rather than guessing =="
 ew_publish_latest_lane "$SANDBOX" "" >/dev/null 2>&1
 [ "$?" -eq 2 ] && ok "publish refuses a missing lane_dir" || bad "publish refuses a missing lane_dir" "rc=$?"

--- a/scripts/lib/log-dir-test.sh
+++ b/scripts/lib/log-dir-test.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 # Two-way suite for scripts/lib/log-dir.sh (#2165).
 #
-# The point of the flag is that two lanes can no longer share one log, because
-# `run_lane` SUMS every `Test run with N tests` line it finds. So this asserts
-# BOTH halves: the historical default is unchanged, AND two distinct requests
-# genuinely resolve apart. A flag that resolves everything to the same place
-# would pass a default-only test while fixing nothing.
+# The point of the DEFAULT (#2396) is that two lanes can no longer share one
+# directory, because `run_lane` sums every `Test run with N tests` line in its log
+# AND reads its verdict from a result bundle it removes before the run. So this
+# asserts BOTH halves: independent default invocations resolve apart, AND two
+# distinct explicit requests still resolve apart. A resolver that isolated only
+# one of those would leave the other collision reachable.
 #
 # Run: bash scripts/lib/log-dir-test.sh
 set -uo pipefail
@@ -18,6 +19,33 @@ PASS=0
 FAIL=0
 ROOT="/tmp/ew-fake-worktree"
 
+# A ROW THAT DOES NOT RUN MUST NOT REPORT GREEN (#2396).
+#
+# Measured in this file: rows written with helpers this suite does not define
+# printed `ok: command not found` to STDERR, incremented nothing, and the suite
+# ended `PASS=11 FAIL=0`. Every new row was invisible and the verdict was clean —
+# a harness reporting a green it cannot see, in the file whose whole job is to be
+# believed about a path.
+#
+# **AND THE OBVIOUS GUARD FOR IT HAS THE SAME DEFECT: bash runs
+# `command_not_found_handle` IN A SUBSHELL**, so a `FAIL=$((FAIL + 1))` inside it
+# is discarded. Measured two-way on bash 5.3: the handler prints `F=1` and the
+# caller then reads `F=0`. The first version of this guard therefore PRINTED a
+# failure line and left the verdict at `FAIL=0` — reporting without gating, which
+# is the very thing it was written to prevent, one level down.
+#
+# So the handler records to a FILE, which is what survives a subshell, and the
+# count is folded in at the end where it can reach the verdict.
+NOT_FOUND_LOG="$(mktemp "${TMPDIR:-/tmp}/ew-log-dir-test-notfound.XXXXXX")"
+command_not_found_handle() {
+  printf "  FAIL  %-56s %s\n" "a row invoked a command that does not exist" "$1"
+  printf '%s\n' "$1" >> "$NOT_FOUND_LOG"
+  return 127
+}
+
+ok() { PASS=$((PASS + 1)); printf "  ok    %-56s %s\n" "$1" "${2:-}"; }
+bad() { FAIL=$((FAIL + 1)); printf "  FAIL  %-56s %s\n" "$1" "${2:-}"; }
+
 check() {  # <label> <expected> <actual>
   local label="$1" expected="$2" actual="$3"
   if [ "$expected" = "$actual" ]; then
@@ -29,12 +57,41 @@ check() {  # <label> <expected> <actual>
   fi
 }
 
-echo "== the historical default is unchanged =="
-# `build/xcode-test-debug.log` under the worktree is what every existing caller,
-# every rule that names the path, and check-push-discipline's freshness read all
-# expect. If this row moves, something else breaks somewhere nobody is looking.
-check "no request -> <root>/build" "$ROOT/build" "$(ew_resolve_log_dir "$ROOT")"
-check "empty request -> <root>/build" "$ROOT/build" "$(ew_resolve_log_dir "$ROOT" "")"
+echo "== the default is private to the invoking process =="
+# THIS ROW USED TO ASSERT `<root>/build`, AND ITS STATED JUSTIFICATION WAS FALSE:
+# it claimed check-push-discipline's freshness read expects
+# `build/xcode-test-debug.log`. That gate never names the file. For app changes it
+# reads the deployed and DerivedData dev-build artifacts
+# (`check-push-discipline.sh:382-383`); for test changes it reads the Debug xctest
+# executable (`:403`) and compares it against files under `Tests/` (`:420`).
+#
+# Left in place, that sentence made the default look immovable — which is the
+# highest-cost shape a comment has, because its whole function is to stop the next
+# reader going and checking. Replaced with what the gate actually reads rather
+# than deleted, so the next reader inherits the verified version.
+check "no request -> <root>/build/lanes/<pid>" \
+  "$ROOT/build/lanes/$$" "$(ew_resolve_log_dir "$ROOT")"
+check "empty request -> <root>/build/lanes/<pid>" \
+  "$ROOT/build/lanes/$$" "$(ew_resolve_log_dir "$ROOT" "")"
+
+# The row that justifies the change, and it needs two real PROCESSES: within one
+# shell `$$` is constant, so a same-process comparison would pass against a
+# resolver that isolated nothing.
+a=$(/bin/bash -c '. "$1"; ew_resolve_log_dir "$2"' _ "$HERE/log-dir.sh" "$ROOT")
+b=$(/bin/bash -c '. "$1"; ew_resolve_log_dir "$2"' _ "$HERE/log-dir.sh" "$ROOT")
+if [ "$a" != "$b" ]; then
+  PASS=$((PASS + 1)); printf "  ok    %-56s %s != %s\n" "two default invocations resolve apart" "$a" "$b"
+else
+  FAIL=$((FAIL + 1)); printf "  FAIL  %-56s both resolved to %s\n" "two default invocations resolve apart" "$a"
+fi
+
+# And the default must not collide with the OLD default's directory, or a lane
+# would still be writing where the shared file used to live.
+if [ "$(ew_resolve_log_dir "$ROOT")" != "$ROOT/build" ]; then
+  PASS=$((PASS + 1)); printf "  ok    %-56s\n" "the default is no longer the shared <root>/build"
+else
+  FAIL=$((FAIL + 1)); printf "  FAIL  %-56s\n" "the default is no longer the shared <root>/build"
+fi
 
 echo "== an explicit request is honoured =="
 check "absolute stays absolute" "/tmp/rowlog" "$(ew_resolve_log_dir "$ROOT" "/tmp/rowlog")"
@@ -61,7 +118,7 @@ else
   FAIL=$((FAIL + 1)); printf "  FAIL  %-56s both resolved to %s\n" "two relative requests resolve apart" "$a"
 fi
 # And a request must not collide with the DEFAULT either, or a caller asking for
-# its own directory would silently land back in the shared one.
+# its own directory would silently land back in the lane the script picked.
 d=$(ew_resolve_log_dir "$ROOT")
 r=$(ew_resolve_log_dir "$ROOT" "/tmp/row-a")
 if [ "$d" != "$r" ]; then
@@ -92,6 +149,89 @@ else
   FAIL=$((FAIL + 1)); printf "  FAIL  %-56s %s was created\n" "resolving does not mkdir" "$probe"
   rmdir "$probe" 2>/dev/null
 fi
+
+echo "== the stable address points at THIS lane, and survives a repoint =="
+# These two functions exist in the lib rather than inline in xcode-test.sh for
+# the reason the resolver does: inlined they could only be exercised by running
+# xcodebuild, so in practice they would never be tested — and both of them delete
+# or replace things.
+SANDBOX="$(mktemp -d "${TMPDIR:-/tmp}/ew-log-dir-sandbox.XXXXXX")"
+trap 'rm -rf "$SANDBOX" "$NOT_FOUND_LOG"' EXIT
+mkdir -p "$SANDBOX/build/lanes/111" "$SANDBOX/build/lanes/222"
+
+ew_publish_latest_lane "$SANDBOX" "$SANDBOX/build/lanes/111" >/dev/null 2>&1
+if [ "$(readlink "$SANDBOX/build/latest-lane")" = "lanes/111" ]; then
+  ok "the link points at the lane it was given"
+else
+  bad "the link points at the lane it was given" "got $(readlink "$SANDBOX/build/latest-lane")"
+fi
+
+# THE ROW THAT MATTERS: repointing must replace the LINK, not write inside the
+# directory the old link pointed at. `mv` without `-h` follows the link and
+# creates `lanes/111/latest-lane`, which leaves the pointer stale AND litters the
+# previous lane.
+ew_publish_latest_lane "$SANDBOX" "$SANDBOX/build/lanes/222" >/dev/null 2>&1
+if [ "$(readlink "$SANDBOX/build/latest-lane")" = "lanes/222" ] \
+  && [ ! -e "$SANDBOX/build/lanes/111/latest-lane" ]; then
+  ok "repointing replaces the link, never writes through it"
+else
+  bad "repointing replaces the link, never writes through it" \
+    "link=$(readlink "$SANDBOX/build/latest-lane") stray=$(ls "$SANDBOX/build/lanes/111" 2>/dev/null)"
+fi
+
+# No temp link is left behind, or a later run inherits a half-published state.
+if [ -z "$(ls -A "$SANDBOX/build" | /usr/bin/grep '^\.latest-lane\.' || true)" ]; then
+  ok "no temporary link survives publication"
+else
+  bad "no temporary link survives publication" "$(ls -A "$SANDBOX/build")"
+fi
+
+echo "== retention deletes only what it is scoped to =="
+mkdir -p "$SANDBOX/build/lanes/old" "$SANDBOX/build/lanes/fresh" "$SANDBOX/build/lanes/current"
+touch -t 202001010000 "$SANDBOX/build/lanes/old"
+# A file OUTSIDE lanes/ must be untouched: the prune is scoped to one directory
+# and this row is what proves the scope rather than the age.
+touch "$SANDBOX/build/bystander.log"
+ew_prune_stale_lanes "$SANDBOX" "$SANDBOX/build/lanes/current" 7 >/dev/null 2>&1
+
+[ ! -d "$SANDBOX/build/lanes/old" ] \
+  && ok "a lane untouched past the window is removed" \
+  || bad "a lane untouched past the window is removed" "still present"
+[ -d "$SANDBOX/build/lanes/fresh" ] \
+  && ok "a recent lane is kept" \
+  || bad "a recent lane is kept" "was removed"
+[ -f "$SANDBOX/build/bystander.log" ] \
+  && ok "nothing outside lanes/ is touched" \
+  || bad "nothing outside lanes/ is touched" "bystander removed"
+
+# The current lane must survive even if its mtime is ancient — a long-running
+# lane is exactly the case where deleting it costs the most.
+mkdir -p "$SANDBOX/build/lanes/inuse"
+touch -t 202001010000 "$SANDBOX/build/lanes/inuse"
+ew_prune_stale_lanes "$SANDBOX" "$SANDBOX/build/lanes/inuse" 7 >/dev/null 2>&1
+[ -d "$SANDBOX/build/lanes/inuse" ] \
+  && ok "the lane in use is never pruned, however old it looks" \
+  || bad "the lane in use is never pruned, however old it looks" "removed"
+
+# Absent tree is a no-op, not an error: a clean checkout has no lanes/ yet.
+rm -rf "$SANDBOX/build/lanes"
+if ew_prune_stale_lanes "$SANDBOX" "$SANDBOX/build/lanes/none" 7 >/dev/null 2>&1; then
+  ok "an absent lanes/ tree is a no-op"
+else
+  bad "an absent lanes/ tree is a no-op" "returned nonzero"
+fi
+
+echo "== both refuse rather than guessing =="
+ew_publish_latest_lane "$SANDBOX" "" >/dev/null 2>&1
+[ "$?" -eq 2 ] && ok "publish refuses a missing lane_dir" || bad "publish refuses a missing lane_dir" "rc=$?"
+ew_prune_stale_lanes "" "x" >/dev/null 2>&1
+[ "$?" -eq 2 ] && ok "prune refuses a missing project_root" || bad "prune refuses a missing project_root" "rc=$?"
+
+# Folded in HERE because the handler runs in a subshell and cannot reach $FAIL.
+if [ -s "$NOT_FOUND_LOG" ]; then
+  FAIL=$((FAIL + $(/usr/bin/wc -l < "$NOT_FOUND_LOG")))
+fi
+rm -f "$NOT_FOUND_LOG"
 
 echo
 printf "PASS=%d FAIL=%d\n" "$PASS" "$FAIL"

--- a/scripts/lib/log-dir-test.sh
+++ b/scripts/lib/log-dir-test.sh
@@ -276,6 +276,64 @@ else
   bad "an absent lane is a no-op" "returned nonzero"
 fi
 
+echo "== a symlinked parent cannot be deleted THROUGH =="
+# The P1 the string-shaped guards could not see. Both original checks are true of
+# a STRING and say nothing about the filesystem, so a symlinked `build` or
+# `lanes` passed every one of them while `rm -rf` followed the link out of the
+# tree and deleted a numeric directory somewhere else.
+#
+# Each row plants a real victim outside the tree and requires it to SURVIVE.
+SYM="$(mktemp -d "${TMPDIR:-/tmp}/ew-log-dir-symlink.XXXXXX")"
+trap 'rm -rf "$SANDBOX" "$NOT_FOUND_LOG" "$SYM"' EXIT
+
+# (a) build/lanes is a link to somewhere else entirely.
+mkdir -p "$SYM/victim-a/4242" "$SYM/root-a/build"
+: > "$SYM/victim-a/4242/precious.txt"
+ln -s "$SYM/victim-a" "$SYM/root-a/build/lanes"
+ew_reset_lane_dir "$SYM/root-a" "$SYM/root-a/build/lanes/4242" >/dev/null 2>&1
+[ "$?" -eq 2 ] && [ -f "$SYM/victim-a/4242/precious.txt" ] \
+  && ok "a symlinked lanes/ is refused, victim survives" \
+  || bad "a symlinked lanes/ is refused, victim survives" "victim gone or wrong rc"
+
+# (b) build itself is a link. The lane path string is identical to a legitimate
+# one, which is exactly why a textual guard cannot tell them apart.
+mkdir -p "$SYM/victim-b/lanes/4242" "$SYM/root-b"
+: > "$SYM/victim-b/lanes/4242/precious.txt"
+ln -s "$SYM/victim-b" "$SYM/root-b/build"
+ew_reset_lane_dir "$SYM/root-b" "$SYM/root-b/build/lanes/4242" >/dev/null 2>&1
+[ "$?" -eq 2 ] && [ -f "$SYM/victim-b/lanes/4242/precious.txt" ] \
+  && ok "a symlinked build/ is refused, victim survives" \
+  || bad "a symlinked build/ is refused, victim survives" "victim gone or wrong rc"
+
+# (c) the lane itself is a link to a real directory elsewhere.
+mkdir -p "$SYM/victim-c" "$SYM/root-c/build/lanes"
+: > "$SYM/victim-c/precious.txt"
+ln -s "$SYM/victim-c" "$SYM/root-c/build/lanes/4242"
+ew_reset_lane_dir "$SYM/root-c" "$SYM/root-c/build/lanes/4242" >/dev/null 2>&1
+[ "$?" -eq 2 ] && [ -f "$SYM/victim-c/precious.txt" ] \
+  && ok "a symlinked lane is refused, victim survives" \
+  || bad "a symlinked lane is refused, victim survives" "victim gone or wrong rc"
+
+# (d) the prune refuses the whole sweep through a symlinked parent, rather than
+# pruning some entries and stopping. A partial sweep is the worse outcome.
+mkdir -p "$SYM/victim-d/old" "$SYM/root-d/build"
+touch -t 202001010000 "$SYM/victim-d/old"
+: > "$SYM/victim-d/old/precious.txt"
+ln -s "$SYM/victim-d" "$SYM/root-d/build/lanes"
+ew_prune_stale_lanes "$SYM/root-d" "$SYM/root-d/build/lanes/none" 7 >/dev/null 2>&1
+[ "$?" -eq 2 ] && [ -f "$SYM/victim-d/old/precious.txt" ] \
+  && ok "prune refuses a symlinked lanes/, victim survives" \
+  || bad "prune refuses a symlinked lanes/, victim survives" "victim gone or wrong rc"
+
+# The ACCEPTED twin: an ordinary, unlinked lane must still be cleared, or all four
+# rows above are satisfied by a function that refuses everything.
+mkdir -p "$SANDBOX/build/lanes/8888"
+: > "$SANDBOX/build/lanes/8888/stale.log"
+ew_reset_lane_dir "$SANDBOX" "$SANDBOX/build/lanes/8888" >/dev/null 2>&1
+[ ! -e "$SANDBOX/build/lanes/8888/stale.log" ] \
+  && ok "an ordinary lane is still cleared" \
+  || bad "an ordinary lane is still cleared" "stale file survived"
+
 echo "== both refuse rather than guessing =="
 ew_publish_latest_lane "$SANDBOX" "" >/dev/null 2>&1
 [ "$?" -eq 2 ] && ok "publish refuses a missing lane_dir" || bad "publish refuses a missing lane_dir" "rc=$?"

--- a/scripts/lib/log-dir-test.sh
+++ b/scripts/lib/log-dir-test.sh
@@ -16,6 +16,7 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$HERE/log-dir.sh"
 
 PASS=0
+SKIP=0
 FAIL=0
 ROOT="/tmp/ew-fake-worktree"
 
@@ -45,6 +46,11 @@ command_not_found_handle() {
 
 ok() { PASS=$((PASS + 1)); printf "  ok    %-56s %s\n" "$1" "${2:-}"; }
 bad() { FAIL=$((FAIL + 1)); printf "  FAIL  %-56s %s\n" "$1" "${2:-}"; }
+# A SKIP IS NOT A PASS, so it gets its own counter and its own line in the
+# verdict. A row that needs a resource this machine does not have must say so
+# where a reader looking for coverage will see it - folding it into PASS is how a
+# suite reports coverage it never had.
+skip() { SKIP=$((SKIP + 1)); printf "  skip  %-56s %s\n" "$1" "${2:-}"; }
 
 check() {  # <label> <expected> <actual>
   local label="$1" expected="$2" actual="$3"
@@ -511,6 +517,118 @@ else
   ok "backslash decoded last does not manufacture a space"
 fi
 
+echo "== a resolved path keeps a trailing newline its own name owns =="
+# `$(...)` strips trailing newlines, so a directory whose name ends in one could
+# never equal its `\012`-decoded mountinfo row - fail-OPEN, on the same
+# comparison the escape decoding above fixes, one layer under it.
+NL=$'\n'   # a bash LITERAL, never `$(printf ...)` - see below
+NLDIR="$SANDBOX/nl$NL"
+mkdir -p "$NLDIR"
+if ew_lane_resolved_path "$NLDIR"; then
+  # **THE FIRST VERSION OF THIS ROW WAS VACUOUS AND A MUTANT FOUND IT.** It built
+  # the expected value with `$(printf '\n')` - which is a command substitution,
+  # so the newline was stripped from the EXPECTATION by the very mechanism under
+  # test. Both sides were equally truncated and the row passed against code with
+  # the sentinel removed. `$'\n'` is a shell literal and no capture is involved.
+  EXPECT="$(cd "$SANDBOX" && pwd -P)/nl$NL"
+  [ "$EW_LANE_RESOLVED" = "$EXPECT" ] \
+    && ok "a trailing newline in the directory's own name survives" \
+    || bad "a trailing newline in the directory's own name survives" \
+           "got $(printf '%q' "$EW_LANE_RESOLVED")"
+else
+  bad "a trailing newline in the directory's own name survives" "resolve refused"
+fi
+# The accepted twin: an ordinary path must NOT gain a stray newline from the
+# sentinel, or every normal comparison breaks in the other direction.
+if ew_lane_resolved_path "$SANDBOX"; then
+  [ "$EW_LANE_RESOLVED" = "$(cd "$SANDBOX" && pwd -P)" ] \
+    && ok "an ordinary path gains nothing from the sentinel" \
+    || bad "an ordinary path gains nothing from the sentinel" \
+           "got $(printf '%q' "$EW_LANE_RESOLVED")"
+else
+  bad "an ordinary path gains nothing from the sentinel" "resolve refused"
+fi
+if ew_lane_resolved_path "$SANDBOX/definitely-absent" 2>/dev/null; then
+  bad "resolving an absent path refuses" "accepted"
+else
+  ok "resolving an absent path refuses"
+fi
+
+echo "== removal is judged by the WORLD, not by find's exit code =="
+# Measured against a real APFS volume mounted three levels inside a lane:
+# `rm -rf` erased the mounted data and exited 1; `find -xdev -delete` left it
+# intact. `find -delete` ALSO exits 0 while printing unlink errors, so success
+# has to be "is it gone", never "how did find feel about it".
+GONE="$SANDBOX/rm-ok/app-logger/deep"
+mkdir -p "$GONE"; touch "$GONE/f"
+ew_lane_remove_tree "$SANDBOX/rm-ok" \
+  && ok "an ordinary tree is removed and reported removed" \
+  || bad "an ordinary tree is removed and reported removed" "reported failure"
+[ -e "$SANDBOX/rm-ok" ] \
+  && bad "an ordinary tree is actually gone" "still present" \
+  || ok "an ordinary tree is actually gone"
+# The rejected twin, and it is the whole point: a tree that SURVIVES must be
+# reported as a failure even though `find -delete` returns 0.
+STUCK="$SANDBOX/rm-stuck/locked"
+mkdir -p "$STUCK"; touch "$STUCK/f"; chmod 500 "$STUCK"
+if ew_lane_remove_tree "$SANDBOX/rm-stuck" 2>/dev/null; then
+  bad "a tree that survives is reported as a failure" "reported success"
+else
+  ok "a tree that survives is reported as a failure"
+fi
+chmod 700 "$STUCK"
+
+echo "== the removal cannot cross a filesystem boundary =="
+# THE PROPERTY THE WHOLE FUNCTION EXISTS FOR, and nothing short of a REAL mount
+# can bind it: `rm -rf` and `find -xdev -delete` are indistinguishable on any
+# single-device tree. `hdiutil` attaches one without sudo, so this runs on the
+# dev machine and reports SKIPPED on a Linux runner rather than pretending.
+#
+# Measured when this was written: with an APFS volume mounted three levels inside
+# a lane, `rm -rf` erased the mounted file and exited 1, while `find -xdev
+# -delete` left it intact. The row below is that comparison's positive half.
+if command -v hdiutil >/dev/null 2>&1 && command -v diskutil >/dev/null 2>&1; then
+  MDIR="$SANDBOX/mountcase"
+  mkdir -p "$MDIR/lane/app-logger/external"
+  echo "lane-own" > "$MDIR/lane/app-logger/own.txt"
+  MDMG="$MDIR/vol.dmg"
+  MDEV=""
+  mount_cleanup() {
+    [ -n "$MDEV" ] || return 0
+    diskutil unmount force "$MDIR/lane/app-logger/external" >/dev/null 2>&1
+    hdiutil detach "$MDEV" -force -quiet >/dev/null 2>&1
+  }
+  trap mount_cleanup EXIT
+  if hdiutil create -size 10m -fs APFS -volname EWLANEPROOF -quiet "$MDMG" >/dev/null 2>&1 \
+     && hdiutil attach -nobrowse -nomount "$MDMG" >/dev/null 2>&1; then
+    MDEV=$(hdiutil info 2>/dev/null \
+      | awk -v img="$MDMG" '$0 ~ img {f=1} f && /\/dev\/disk[0-9]+s[0-9]+/ {print $1}' | tail -1)
+  fi
+  if [ -n "$MDEV" ] \
+     && diskutil mount -mountPoint "$MDIR/lane/app-logger/external" "$MDEV" >/dev/null 2>&1; then
+    echo "PRECIOUS" > "$MDIR/lane/app-logger/external/precious.txt"
+    ew_lane_remove_tree "$MDIR/lane" 2>/dev/null
+    # It MUST report failure - the lane cannot be emptied while something is
+    # mounted inside it - and the mounted data must be untouched. Asserting both
+    # halves: "reported failure" alone would also be true of a removal that
+    # destroyed everything and then tripped on the busy mount root, which is
+    # precisely what `rm -rf` does.
+    [ -f "$MDIR/lane/app-logger/external/precious.txt" ] \
+      && ok "a mount nested below a lane is not descended into" \
+      || bad "a mount nested below a lane is not descended into" "the mounted file was destroyed"
+    [ -e "$MDIR/lane" ] \
+      && ok "a lane holding a mount survives and is reported unremoved" \
+      || bad "a lane holding a mount survives and is reported unremoved" "the lane was removed"
+    mount_cleanup
+    MDEV=""
+  else
+    skip "a mount nested below a lane is not descended into" "could not attach a scratch volume"
+  fi
+  trap - EXIT
+else
+  skip "a mount nested below a lane is not descended into" "hdiutil/diskutil absent"
+fi
+
 echo "== taking a default lane is atomic, not assumed =="
 # The claim this replaces was that `<seconds>-<pid>` cannot recur. It can, in a
 # constrained pid namespace, and the cost was silent: the later run inherits the
@@ -565,5 +683,5 @@ fi
 rm -f "$NOT_FOUND_LOG"
 
 echo
-printf "PASS=%d FAIL=%d\n" "$PASS" "$FAIL"
+printf "PASS=%d FAIL=%d SKIP=%d\n" "$PASS" "$FAIL" "$SKIP"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/scripts/lib/log-dir-test.sh
+++ b/scripts/lib/log-dir-test.sh
@@ -439,31 +439,102 @@ echo "== the mountinfo branch is EXERCISED, not merely written =="
 # reached the shell, `$5` was expanded before awk saw it, and the command
 # succeeded for EVERY path — reporting everything as a mount.
 #
-# It is now a shell `while read`, which this suite CAN drive: point the reader at
-# a fixture in mountinfo's own format and assert both directions. That does not
-# prove the real /proc parse on Linux, but it proves the comparison, which is
-# what was wrong.
-ew_lane_mountinfo_hit() {  # <mountinfo-file> <resolved-path>
-  local mi_target
-  while read -r _ _ _ _ mi_target _; do
-    [ "$mi_target" = "$2" ] && return 0
-  done < "$1"
-  return 1
-}
+# It is now a shell `while read`, which this suite CAN drive: the reader takes
+# the table as an ARGUMENT, so these rows point the SHIPPED function at a fixture
+# in mountinfo's own format while production passes /proc/self/mountinfo. That
+# does not prove the real /proc parse on Linux, but it proves the comparison,
+# which is what was wrong.
+#
+# The first version of these rows called a COPY of the loop declared here. A
+# reimplemented matcher measures the copy — it would have gone green against the
+# escape defect below while the shipped code got it wrong (#2408 review r9).
 MI="$SANDBOX/mountinfo"
 cat > "$MI" <<'MIEOF'
 25 30 0:23 / /proc rw,nosuid shared:5 - proc proc rw
 26 30 0:24 / /mnt/bound rw,relatime shared:6 - ext4 /dev/sda1 rw
+27 30 0:25 / /mnt/with\040space rw,relatime shared:7 - ext4 /dev/sdb1 rw
+28 30 0:26 / /mnt/tab\011sep rw,relatime shared:8 - ext4 /dev/sdc1 rw
+29 30 0:27 / /mnt/back\134slash rw,relatime shared:9 - ext4 /dev/sdd1 rw
 MIEOF
-ew_lane_mountinfo_hit "$MI" /mnt/bound \
+ew_lane_mountinfo_lists "$MI" /mnt/bound \
   && ok "a mountinfo entry is recognised by its mount point field" \
   || bad "a mountinfo entry is recognised by its mount point field" "missed"
-# The accepted twin, and it is the one the broken version failed: a path that is
-# NOT in the table must not match. The old awk returned true for everything.
-if ew_lane_mountinfo_hit "$MI" /not/a/mount; then
+# The accepted twin, and it is the one the broken awk failed: a path that is NOT
+# in the table must not match. That version returned true for everything.
+if ew_lane_mountinfo_lists "$MI" /not/a/mount; then
   bad "a path absent from mountinfo does not match" "matched anyway"
 else
   ok "a path absent from mountinfo does not match"
+fi
+
+echo "== the kernel's escapes are decoded before the comparison =="
+# `pwd -P` returns these characters literally and mountinfo does not, so an
+# undecoded comparison reports NOT-a-mount for a path that IS one — fail-open, on
+# the check that stops `rm -rf` descending into a mounted filesystem. A macOS
+# checkout under a directory with a space in its name is entirely ordinary.
+ew_lane_mountinfo_lists "$MI" "/mnt/with space" \
+  && ok "an escaped space in a mount point is decoded" \
+  || bad "an escaped space in a mount point is decoded" "did not match"
+ew_lane_mountinfo_lists "$MI" "$(printf '/mnt/tab\tsep')" \
+  && ok "an escaped tab in a mount point is decoded" \
+  || bad "an escaped tab in a mount point is decoded" "did not match"
+ew_lane_mountinfo_lists "$MI" '/mnt/back\slash' \
+  && ok "an escaped backslash in a mount point is decoded" \
+  || bad "an escaped backslash in a mount point is decoded" "did not match"
+# The REJECTED twin for each, or a decoder that simply deleted every backslash
+# would pass all three above. The literal table text must NOT match.
+for raw in '/mnt/with\040space' '/mnt/tab\011sep' '/mnt/back\134slash'; do
+  if ew_lane_mountinfo_lists "$MI" "$raw"; then
+    bad "the raw escaped form does not match a decoded path" "$raw matched"
+  else
+    ok "the raw escaped form does not match a decoded path ($raw)"
+  fi
+done
+# `\134` must be decoded LAST. A literal backslash in a real path reaches
+# mountinfo as `\134`, so a path whose real name is `back\040slash` is written
+# `back\134040slash` — decoding the backslash first would turn it into
+# `back\040slash` and the space rule would then read an escape that was never
+# there, matching `back slash` instead.
+# Written by a QUOTED heredoc, never `printf`: printf reads `\134` as an octal
+# escape and would write a real backslash, so the fixture would carry the DECODED
+# form and these two rows would silently be about a different string. Caught by
+# the rows themselves — they failed against correct code.
+cat >> "$MI" <<'MIEOF'
+30 30 0:28 / /mnt/back\134040slash rw - ext4 /dev/sde1 rw
+MIEOF
+ew_lane_mountinfo_lists "$MI" '/mnt/back\040slash' \
+  && ok "backslash is decoded last, so an escape-looking literal survives" \
+  || bad "backslash is decoded last, so an escape-looking literal survives" "did not match"
+if ew_lane_mountinfo_lists "$MI" "/mnt/back slash"; then
+  bad "backslash decoded last does not manufacture a space" "matched"
+else
+  ok "backslash decoded last does not manufacture a space"
+fi
+
+echo "== taking a default lane is atomic, not assumed =="
+# The claim this replaces was that `<seconds>-<pid>` cannot recur. It can, in a
+# constrained pid namespace, and the cost was silent: the later run inherits the
+# earlier occupant's Release log and bundle beside fresh Debug ones. A bare
+# `mkdir` cannot be talked into reusing a directory.
+TAKE="$SANDBOX/take/build/lanes/1787000000-4242"
+ew_take_default_lane "$TAKE" \
+  && ok "a fresh lane is taken, parents and all" \
+  || bad "a fresh lane is taken, parents and all" "refused a fresh name"
+[ -d "$TAKE" ] \
+  && ok "the taken lane exists afterwards" \
+  || bad "the taken lane exists afterwards" "not created"
+# The rejected twin, and it is the whole point: the SECOND take of one name must
+# refuse. `mkdir -p` would return success here and hand over a used directory.
+if ew_take_default_lane "$TAKE" 2>/dev/null; then
+  bad "a second take of one lane name is refused" "accepted a used lane"
+else
+  ok "a second take of one lane name is refused"
+fi
+# A refusal must not be indistinguishable from a bad argument.
+if ew_take_default_lane "" 2>/dev/null; then
+  bad "take refuses a missing lane_dir" "accepted empty"
+else
+  ok "take refuses a missing lane_dir"
 fi
 
 echo "== find failing is not an empty sweep =="

--- a/scripts/lib/log-dir-test.sh
+++ b/scripts/lib/log-dir-test.sh
@@ -529,6 +529,52 @@ chmod 700 "$FAILDIR/build/lanes"
   && ok "a removal failure is reported to the caller" \
   || bad "a removal failure is reported to the caller" "rc=$rc"
 
+echo "== portability is DETECTED, not assumed =="
+# The P1 pair. `stat -f %d` is BSD; on GNU `-f` means file-system status and `%d`
+# is parsed as a FILENAME, so the call fails — and with the fail-closed direction
+# this file adopted, every existing component would have been classified unsafe
+# on Linux. `mv -h` is BSD too; GNU has no `-h` and errors, so the link was never
+# published and the temp file was left behind.
+#
+# I asked whether process substitution needed bash and never asked whether `stat`
+# and `mv` were the same programs — on a suite this PR's sibling deliberately
+# wired into a Linux job.
+case "$EW_LANE_STAT_DEV_STYLE" in
+  bsd | gnu) ok "a working stat style was detected" "$EW_LANE_STAT_DEV_STYLE" ;;
+  *) bad "a working stat style was detected" "got '$EW_LANE_STAT_DEV_STYLE'" ;;
+esac
+# The detection must actually WORK here, not merely pick a name: devfs is a real
+# mount and an ordinary directory is not.
+ew_lane_is_mount_point /dev \
+  && ok "the detected stat style reads a real device number" \
+  || bad "the detected stat style reads a real device number" "/dev not seen as a mount"
+
+case "$EW_LANE_MV_NOFOLLOW" in
+  -h | -T) ok "a no-follow mv flag was detected" "$EW_LANE_MV_NOFOLLOW" ;;
+  *) bad "a no-follow mv flag was detected" "got '$EW_LANE_MV_NOFOLLOW'" ;;
+esac
+# And the flag it picked must be the one that does not follow — the probe asserts
+# behaviour rather than parsing an error string, so this row asserts the probe
+# reached a conclusion the publish rows then depend on.
+[ -n "$EW_LANE_MV_NOFOLLOW" ] \
+  && ok "publication has a usable rename" \
+  || bad "publication has a usable rename" "empty"
+
+echo "== find failing is not an empty sweep =="
+# A process substitution's exit status is invisible to the loop, so a `find` that
+# could not enumerate lanes/ produced no iterations, left rc at 0, and the prune
+# reported a clean sweep having looked at nothing.
+NOREAD="$SANDBOX/noread"
+mkdir -p "$NOREAD/build/lanes/6001"
+touch -t 202001010000 "$NOREAD/build/lanes/6001"
+chmod 100 "$NOREAD/build/lanes"   # traversable, NOT readable: stat checks pass, find fails
+ew_prune_stale_lanes "$NOREAD" "$NOREAD/build/lanes/none" 7 >/dev/null 2>&1
+rc=$?
+chmod 700 "$NOREAD/build/lanes"
+[ "$rc" -ne 0 ] \
+  && ok "an unreadable lanes/ is reported, not swept silently" \
+  || bad "an unreadable lanes/ is reported, not swept silently" "rc=$rc"
+
 echo "== both refuse rather than guessing =="
 ew_publish_latest_lane "$SANDBOX" "" >/dev/null 2>&1
 [ "$?" -eq 2 ] && ok "publish refuses a missing lane_dir" || bad "publish refuses a missing lane_dir" "rc=$?"

--- a/scripts/lib/log-dir-test.sh
+++ b/scripts/lib/log-dir-test.sh
@@ -334,6 +334,79 @@ ew_reset_lane_dir "$SANDBOX" "$SANDBOX/build/lanes/8888" >/dev/null 2>&1
   && ok "an ordinary lane is still cleared" \
   || bad "an ordinary lane is still cleared" "stale file survived"
 
+echo "== containment is decided BEFORE absence =="
+# The P1 that made every other symlink row unreachable on the normal path. The
+# absent-lane shortcut used to run first, and absence is the FRESH-INVOCATION
+# case — so on almost every run the function returned success without looking at
+# the parents at all. The rows above only caught it because they pre-created the
+# lane.
+mkdir -p "$SYM/victim-e" "$SYM/root-e/build"
+: > "$SYM/victim-e/precious.txt"
+ln -s "$SYM/victim-e" "$SYM/root-e/build/lanes"
+# NOTE: lane 5150 deliberately does NOT exist — that is the whole point.
+ew_reset_lane_dir "$SYM/root-e" "$SYM/root-e/build/lanes/5150" >/dev/null 2>&1
+[ "$?" -eq 2 ] \
+  && ok "an ABSENT lane under a symlinked parent is still refused" \
+  || bad "an ABSENT lane under a symlinked parent is still refused" "rc was not 2"
+
+# The accepted twin: an absent lane under a NORMAL parent is a plain no-op, or
+# the row above is satisfied by a function that refuses every fresh run.
+if ew_reset_lane_dir "$SANDBOX" "$SANDBOX/build/lanes/5151" >/dev/null 2>&1; then
+  ok "an absent lane under a normal parent is a no-op"
+else
+  bad "an absent lane under a normal parent is a no-op" "returned nonzero"
+fi
+
+echo "== a mount point is a second way out that -L cannot see =="
+# `/dev` is devfs on every macOS machine this runs on, so the detector is
+# exercised against a REAL mount rather than a constructed one.
+#
+# Deliberately NOT `/`: root IS a mount point and this method cannot see it,
+# because `/..` is `/` and the devices compare equal. That is a real limit of
+# comparing against the parent, and it costs nothing here — a lane path can never
+# be `/`, since the shape guard requires it to sit under `<root>/build/lanes/`
+# with a numeric basename. Written as `/` first, and the row failed, which is how
+# the limit was found rather than assumed.
+if ew_lane_is_mount_point /dev ; then
+  ok "the detector recognises a real mount point"
+else
+  bad "the detector recognises a real mount point" "/dev not detected"
+fi
+# The accepted twin: an ordinary directory is NOT a mount point, or the detector
+# refuses everything and the guard above is vacuous.
+if ew_lane_is_mount_point "$SANDBOX/build/lanes" ; then
+  bad "an ordinary directory is not a mount point" "false positive"
+else
+  ok "an ordinary directory is not a mount point"
+fi
+# And an unreadable path must not be reported as a mount point: the callers
+# refuse what they cannot resolve, and an unreadable path must never become an
+# argument for deleting it.
+if ew_lane_is_mount_point "$SANDBOX/no/such/path" ; then
+  bad "an unresolvable path is not called a mount point" "false positive"
+else
+  ok "an unresolvable path is not called a mount point"
+fi
+
+# THE COMPOSITION, which is what makes the mount half reachable at all. A real
+# mount cannot be built in a portable suite without sudo, so the guard's mount
+# branch is covered in two pieces: these rows prove the shared helper answers YES
+# for BOTH ways out, and the symlink-victim rows above prove the guard consults
+# the helper at all three levels.
+ln -s "$SANDBOX" "$SANDBOX/a-link"
+ew_lane_component_is_unsafe "$SANDBOX/a-link" \
+  && ok "the shared safety check refuses a link" \
+  || bad "the shared safety check refuses a link" "accepted"
+ew_lane_component_is_unsafe /dev \
+  && ok "the shared safety check refuses a mount point" \
+  || bad "the shared safety check refuses a mount point" "accepted"
+# Accepted twin, or the helper refuses everything and both rows are vacuous.
+if ew_lane_component_is_unsafe "$SANDBOX/build/lanes" ; then
+  bad "the shared safety check accepts an ordinary directory" "refused"
+else
+  ok "the shared safety check accepts an ordinary directory"
+fi
+
 echo "== both refuse rather than guessing =="
 ew_publish_latest_lane "$SANDBOX" "" >/dev/null 2>&1
 [ "$?" -eq 2 ] && ok "publish refuses a missing lane_dir" || bad "publish refuses a missing lane_dir" "rc=$?"

--- a/scripts/lib/log-dir.sh
+++ b/scripts/lib/log-dir.sh
@@ -93,6 +93,56 @@ ew_resolve_log_dir() {
 # replace things. The resolver stays side-effect free; these are separate
 # functions so that property is not quietly lost.
 
+# THE ONE PLACE THAT DECIDES WHETHER A PATH MAY BE DELETED (#2408 review r3, P1).
+#
+# The first version of this scoping was TEXTUAL — direct child of
+# `<root>/build/lanes/`, basename all digits. Both are true of a string and say
+# nothing about the filesystem, so if `<root>/build` or `<root>/build/lanes` is a
+# SYMLINK the path passes every check and `rm -rf` follows the link out of the
+# tree, deleting a numeric directory somewhere else entirely.
+#
+# **A string-shaped guard on a filesystem operation is not a guard**, and this is
+# the one that runs unattended on every default lane, so being wrong here costs
+# somebody's directory rather than a rerun.
+#
+# So containment is decided PHYSICALLY: no link anywhere on the way down, and the
+# lane's real parent must BE the real lanes directory. `pwd -P` resolves what the
+# string cannot.
+#
+# Shared by both deleting functions deliberately. Two copies of a rule this sharp
+# is how one of them stops matching the other.
+#   ew_lane_path_is_deletable <project_root> <lane_dir>
+ew_lane_path_is_deletable() {
+  local project_root="$1" lane_dir="$2"
+  local base="${lane_dir##*/}"
+
+  # Shape first, because it is the cheap half and it rejects the obvious.
+  case "$lane_dir" in
+    "$project_root/build/lanes/$base") ;;
+    *) return 1 ;;
+  esac
+  case "$base" in
+    "" | *[!0-9]*) return 1 ;;
+  esac
+
+  # Then the filesystem. A link ANYWHERE on the way down means `rm -rf` can leave
+  # the tree, and `-L` is the only thing that sees that.
+  [ -L "$project_root/build" ] && return 1
+  [ -L "$project_root/build/lanes" ] && return 1
+  [ -L "$lane_dir" ] && return 1
+
+  # NO `pwd -P` PARENT-EQUALITY CHECK HERE, AND ITS ABSENCE IS DELIBERATE.
+  # One was written and removed: with the three link checks above passing, the
+  # shape guard already forces the lane to be a direct child of a real
+  # `build/lanes`, so the physical parent IS the physical lanes directory by
+  # construction — and where `project_root` itself contains a link, BOTH sides
+  # resolve through it and compare equal anyway. A control proved it: deleting
+  # the comparison left all 31 rows green, because nothing can reach it.
+  # **An unreachable guard inside a deleting function is worse than no guard** —
+  # it reads as protection that nobody can verify, and the next reader trusts it.
+  return 0
+}
+
 # Give a recycled pid a CLEAN lane (#2408 review r2).
 #
 # The resolver's own header calls pid reuse harmless, and that was WRONG in one
@@ -120,20 +170,15 @@ ew_reset_lane_dir() {
     return 2
   fi
 
-  local base="${lane_dir##*/}"
-  case "$lane_dir" in
-    "$project_root/build/lanes/$base") ;;
-    *)
-      echo "ew_reset_lane_dir: refusing a path outside <root>/build/lanes: $lane_dir" >&2
-      return 2
-      ;;
-  esac
-  case "$base" in
-    "" | *[!0-9]*)
-      echo "ew_reset_lane_dir: refusing a lane name that is not a pid: $base" >&2
-      return 2
-      ;;
-  esac
+  # An ABSENT lane is the common case and is nothing to clean. Checked before
+  # containment because the containment probe cannot resolve a path that is not
+  # there, and "not there" must not read as "refused".
+  [ -e "$lane_dir" ] || return 0
+
+  if ! ew_lane_path_is_deletable "$project_root" "$lane_dir"; then
+    echo "ew_reset_lane_dir: refusing to clear a path that is not a contained lane: $lane_dir" >&2
+    return 2
+  fi
 
   rm -rf "$lane_dir"
 }
@@ -196,9 +241,20 @@ ew_prune_stale_lanes() {
   local lanes="$project_root/build/lanes"
   [ -d "$lanes" ] || return 0
 
+  # The SAME physical containment the reset applies, for the same reason: this
+  # also runs `rm -rf` unattended, and a symlinked `build` or `lanes` would let it
+  # walk out of the tree. Refusing the whole sweep is correct — a lane left
+  # unpruned costs disk, a lane deleted outside the tree costs somebody's work.
+  if [ -L "$project_root/build" ] || [ -L "$lanes" ]; then
+    echo "ew_prune_stale_lanes: refusing to prune through a symlinked build/ or lanes/" >&2
+    return 2
+  fi
+
   # `/usr/bin/find`, not `find`: the shim on this machine rejects some predicate
   # forms and its blindness is data-dependent
   # (validation-discipline.md, the silent-empty traps).
+  # `-type d` excludes links to directories, so a planted link inside lanes/ is
+  # skipped rather than followed.
   /usr/bin/find "$lanes" -mindepth 1 -maxdepth 1 -type d -mtime "+$days" \
     ! -path "$keep" -print -exec rm -rf {} +
 }

--- a/scripts/lib/log-dir.sh
+++ b/scripts/lib/log-dir.sh
@@ -112,17 +112,28 @@ ew_resolve_log_dir() {
 # Shared by both deleting functions deliberately. Two copies of a rule this sharp
 # is how one of them stops matching the other.
 #   ew_lane_path_is_deletable <project_root> <lane_dir>
-# Is this path a MOUNT POINT? A directory whose device number differs from its
-# parent's is where a filesystem is mounted. `stat -f %d` is the macOS spelling;
-# a path that cannot be stat'd is reported as NOT a mount point, because the
-# callers already refuse a path they cannot resolve and an unreadable path must
-# not become an argument for deleting it.
+# Is this path a MOUNT POINT, or can we not tell? A directory whose device number
+# differs from its parent's is where a filesystem is mounted; `stat -f %d` is the
+# macOS spelling.
+#
+# **UNKNOWN IS TREATED AS MOUNTED, and my first version had this backwards.** I
+# wrote that an unreadable path should report NOT-a-mount "because an unreadable
+# path must not become an argument for deleting it" — which is the argument for
+# the OPPOSITE. A component that EXISTS and cannot be classified (an ACL, a
+# transient error, an unreadable mounted path) is exactly the case where guessing
+# safe means deleting through it. Failing closed costs an uncleaned lane; failing
+# open costs whatever is mounted there.
+#
+# A path that does NOT exist is a different answer and stays NOT-a-mount: absence
+# is the fresh-invocation case, and there is nothing there to descend into.
 #   ew_lane_is_mount_point <path>
 ew_lane_is_mount_point() {
   local path="$1" dev parent_dev
-  dev="$(/usr/bin/stat -f %d "$path" 2>/dev/null)" || return 1
-  parent_dev="$(/usr/bin/stat -f %d "$path/.." 2>/dev/null)" || return 1
-  [ -n "$dev" ] && [ -n "$parent_dev" ] && [ "$dev" != "$parent_dev" ]
+  [ -e "$path" ] || return 1
+  dev="$(/usr/bin/stat -f %d "$path" 2>/dev/null)" || return 0
+  parent_dev="$(/usr/bin/stat -f %d "$path/.." 2>/dev/null)" || return 0
+  [ -n "$dev" ] && [ -n "$parent_dev" ] || return 0
+  [ "$dev" != "$parent_dev" ]
 }
 
 # Can `rm -rf` escape the tree through this component? TWO ways, and `-L` sees
@@ -282,12 +293,14 @@ ew_prune_stale_lanes() {
   local lanes="$project_root/build/lanes"
   [ -d "$lanes" ] || return 0
 
-  # The SAME physical containment the reset applies, for the same reason: this
-  # also runs `rm -rf` unattended, and a symlinked `build` or `lanes` would let it
-  # walk out of the tree. Refusing the whole sweep is correct — a lane left
-  # unpruned costs disk, a lane deleted outside the tree costs somebody's work.
-  if [ -L "$project_root/build" ] || [ -L "$lanes" ]; then
-    echo "ew_prune_stale_lanes: refusing to prune through a symlinked build/ or lanes/" >&2
+  # THE SAME helper the reset uses, not a second copy of half of it (#2408 r4).
+  # The mount-aware check was added for the reset and this guard was left on `-L`
+  # alone — so a mounted `build` or `lanes` passed here while being refused three
+  # lines away. Two copies of one rule is how one of them stops matching, which
+  # this file already said and then demonstrated.
+  if ew_lane_component_is_unsafe "$project_root/build" \
+    || ew_lane_component_is_unsafe "$lanes"; then
+    echo "ew_prune_stale_lanes: refusing to prune through an unsafe build/ or lanes/" >&2
     return 2
   fi
 
@@ -295,7 +308,17 @@ ew_prune_stale_lanes() {
   # forms and its blindness is data-dependent
   # (validation-discipline.md, the silent-empty traps).
   # `-type d` excludes links to directories, so a planted link inside lanes/ is
-  # skipped rather than followed.
+  # skipped rather than followed — but a MOUNT is a directory and `-type d`
+  # matches it, so each candidate is checked before it is removed rather than
+  # handed to `-exec rm -rf`.
+  local entry
   /usr/bin/find "$lanes" -mindepth 1 -maxdepth 1 -type d -mtime "+$days" \
-    ! -path "$keep" -print -exec rm -rf {} +
+    ! -path "$keep" -print | while IFS= read -r entry; do
+    if ew_lane_component_is_unsafe "$entry"; then
+      echo "ew_prune_stale_lanes: skipping an unsafe lane entry: $entry" >&2
+      continue
+    fi
+    rm -rf "$entry"
+    printf '%s\n' "$entry"
+  done
 }

--- a/scripts/lib/log-dir.sh
+++ b/scripts/lib/log-dir.sh
@@ -112,6 +112,30 @@ ew_resolve_log_dir() {
 # Shared by both deleting functions deliberately. Two copies of a rule this sharp
 # is how one of them stops matching the other.
 #   ew_lane_path_is_deletable <project_root> <lane_dir>
+# Is this path a MOUNT POINT? A directory whose device number differs from its
+# parent's is where a filesystem is mounted. `stat -f %d` is the macOS spelling;
+# a path that cannot be stat'd is reported as NOT a mount point, because the
+# callers already refuse a path they cannot resolve and an unreadable path must
+# not become an argument for deleting it.
+#   ew_lane_is_mount_point <path>
+ew_lane_is_mount_point() {
+  local path="$1" dev parent_dev
+  dev="$(/usr/bin/stat -f %d "$path" 2>/dev/null)" || return 1
+  parent_dev="$(/usr/bin/stat -f %d "$path/.." 2>/dev/null)" || return 1
+  [ -n "$dev" ] && [ -n "$parent_dev" ] && [ "$dev" != "$parent_dev" ]
+}
+
+# Can `rm -rf` escape the tree through this component? TWO ways, and `-L` sees
+# only the first: a symlink, or a MOUNT POINT. A mounted filesystem is not a link
+# and passes every textual and `-L` check, while `rm -rf` descends into it and
+# erases its contents, leaving only the busy mount root.
+#   ew_lane_component_is_unsafe <path>
+ew_lane_component_is_unsafe() {
+  [ -L "$1" ] && return 0
+  ew_lane_is_mount_point "$1" && return 0
+  return 1
+}
+
 ew_lane_path_is_deletable() {
   local project_root="$1" lane_dir="$2"
   local base="${lane_dir##*/}"
@@ -125,11 +149,17 @@ ew_lane_path_is_deletable() {
     "" | *[!0-9]*) return 1 ;;
   esac
 
-  # Then the filesystem. A link ANYWHERE on the way down means `rm -rf` can leave
-  # the tree, and `-L` is the only thing that sees that.
-  [ -L "$project_root/build" ] && return 1
-  [ -L "$project_root/build/lanes" ] && return 1
-  [ -L "$lane_dir" ] && return 1
+  # Then the filesystem. ONE question asked at each of the three levels: can
+  # `rm -rf` leave the tree through this component. Asked through a single helper
+  # rather than two checks per level, and that is a COVERAGE decision as much as a
+  # tidiness one — a real mount cannot be constructed in a portable suite without
+  # sudo, so a `-L` check and a separate mount check at each level would leave the
+  # mount half of every level untestable. With one helper, the rows that prove the
+  # guard consults it (the symlink victims below) and the rows that prove the
+  # helper catches a mount (against real devfs) compose into coverage of both.
+  ew_lane_component_is_unsafe "$project_root/build" && return 1
+  ew_lane_component_is_unsafe "$project_root/build/lanes" && return 1
+  ew_lane_component_is_unsafe "$lane_dir" && return 1
 
   # NO `pwd -P` PARENT-EQUALITY CHECK HERE, AND ITS ABSENCE IS DELIBERATE.
   # One was written and removed: with the three link checks above passing, the
@@ -170,15 +200,26 @@ ew_reset_lane_dir() {
     return 2
   fi
 
-  # An ABSENT lane is the common case and is nothing to clean. Checked before
-  # containment because the containment probe cannot resolve a path that is not
-  # there, and "not there" must not read as "refused".
-  [ -e "$lane_dir" ] || return 0
-
+  # CONTAINMENT IS DECIDED BEFORE ABSENCE (#2408 review r3, P1).
+  #
+  # The absent-lane shortcut used to run FIRST, and absence is the NORMAL
+  # fresh-invocation case — so on almost every run this returned success without
+  # ever looking at the parents, and the caller then `mkdir -p`'d straight through
+  # a symlinked `build` or `lanes`. The early return was added for a good reason
+  # and put upstream of the guard, which is this repo's own
+  # fix-the-path-that-runs-first shape: the check that matters was correct and
+  # unreachable.
+  #
+  # Ordering is safe because none of the containment checks require the lane to
+  # exist — they ask about its NAME and about its parents.
   if ! ew_lane_path_is_deletable "$project_root" "$lane_dir"; then
     echo "ew_reset_lane_dir: refusing to clear a path that is not a contained lane: $lane_dir" >&2
     return 2
   fi
+
+  # Nothing to clean is success, and it is checked AFTER containment so a
+  # fresh run still validates the tree it is about to write into.
+  [ -e "$lane_dir" ] || return 0
 
   rm -rf "$lane_dir"
 }

--- a/scripts/lib/log-dir.sh
+++ b/scripts/lib/log-dir.sh
@@ -187,29 +187,6 @@ ew_lane_device_of() {
 # `/proc/self/mountinfo` is consulted where it exists, which closes the Linux
 # case; no portable shell primitive covers the remainder. This is defence in
 # depth for the ONE remaining `rm -rf`, not a proof.
-# Does this mountinfo table list <path> as a mount point?
-#
-# **EXTRACTED SO THE SUITE CAN DRIVE THE REAL COMPARISON (#2408 review r9).** The
-# first version of this loop lived inline and the suite tested a COPY of it — a
-# reimplemented matcher, which measures the copy and says nothing about the code
-# that ships. Taking the table as an argument lets the row point it at a fixture
-# in mountinfo's own format while the production caller passes /proc/self/mountinfo.
-#
-# **THE TWO SIDES ARE IN DIFFERENT ALPHABETS (#2408 review r9, P1).** The kernel
-# escapes space, tab, newline and backslash in field 5 as `\040`, `\011`, `\012`
-# and `\134`, while `pwd -P` returns them literally — so a lane under a path
-# containing a space compares unequal against its own mountinfo row and the check
-# reports NOT-a-mount. That is the fail-OPEN direction, on the one branch whose
-# entire job is to stop `rm -rf` descending into a mounted filesystem, and a
-# checkout under a directory with a space in it is ordinary on macOS.
-#
-# `\134` is decoded LAST. A literal backslash in a real path arrives as `\134`, so
-# decoding it first would turn `\134040` into `\040` and the next rule would then
-# read a backslash-escape the path never contained.
-#
-# `read -r` is required: without it the shell would consume those backslashes
-# before any rule ran.
-#   ew_lane_mountinfo_lists <mountinfo-file> <resolved-path>
 # A path's physical location, WITH any trailing newline in its own name intact.
 #
 # **`$(...)` STRIPS TRAILING NEWLINES (#2408 review r10, P1).** A directory whose
@@ -240,14 +217,45 @@ ew_lane_resolved_path() {
   EW_LANE_RESOLVED="${out%$'\n'}"
 }
 
+# Does this mountinfo table list <path> as a mount point?
+#
+# **EXTRACTED SO THE SUITE CAN DRIVE THE REAL COMPARISON (#2408 review r9).** The
+# first version of this loop lived inline and the suite tested a COPY of it — a
+# reimplemented matcher, which measures the copy and says nothing about the code
+# that ships. Taking the table as an argument lets the row point it at a fixture
+# in mountinfo's own format while the production caller passes /proc/self/mountinfo.
+#
+# **THE TWO SIDES ARE IN DIFFERENT ALPHABETS (#2408 review r9, P1).** The kernel
+# escapes space, tab, newline and backslash in field 5 as `\040`, `\011`, `\012`
+# and `\134`, while `pwd -P` returns them literally — so a lane under a path
+# containing a space compares unequal against its own mountinfo row and the check
+# reports NOT-a-mount. That is the fail-OPEN direction, on the one branch whose
+# entire job is to stop `rm -rf` descending into a mounted filesystem, and a
+# checkout under a directory with a space in it is ordinary on macOS.
+#
+# `\134` is decoded LAST. A literal backslash in a real path arrives as `\134`, so
+# decoding it first would turn `\134040` into `\040` and the next rule would then
+# read a backslash-escape the path never contained.
+#
+# `read -r` is required: without it the shell would consume those backslashes
+# before any rule ran.
+# `mode` is `exact` or `subtree`. `subtree` matches the path ITSELF or anything
+# BELOW it, which is what turns this from a predicate to keep extending into a
+# closed question - see ew_lane_contains_a_mount.
+#   ew_lane_mountinfo_lists <mountinfo-file> <resolved-path> [exact|subtree]
 ew_lane_mountinfo_lists() {
-  local mi_target
+  local mode="${3:-exact}" mi_target
   while read -r _ _ _ _ mi_target _; do
     mi_target="${mi_target//\\040/ }"
     mi_target="${mi_target//\\011/$'\t'}"
     mi_target="${mi_target//\\012/$'\n'}"
     mi_target="${mi_target//\\134/\\}"
     [ "$mi_target" = "$2" ] && return 0
+    if [ "$mode" = "subtree" ]; then
+      case "$mi_target" in
+        "$2"/*) return 0 ;;
+      esac
+    fi
   done < "$1"
   return 1
 }
@@ -277,6 +285,40 @@ ew_lane_is_mount_point() {
   parent_dev="$(ew_lane_device_of "$path/..")" || return 0
   [ -n "$dev" ] && [ -n "$parent_dev" ] || return 0
   [ "$dev" != "$parent_dev" ]
+}
+
+# Is ANY filesystem mounted at this path or anywhere beneath it?
+#
+# **THIS IS THE SIXTH CONSECUTIVE REVIEW ROUND ON ONE ROOT, AND THE ROOT IS THAT I
+# KEPT DESCRIBING THE SET INSTEAD OF ENUMERATING IT (#2408 review r11).** The
+# members, in the order review found them: the lane itself is a mount; `build` or
+# `lanes` is a mount; a same-device bind mount defeats a device-number
+# comparison; a mount sits BELOW the lane rather than at it; and a same-device
+# bind mount below the lane defeats `-xdev` as well. Each fix was correct and
+# each exposed the next, which is the signature this repo already names.
+#
+# **The closed question is not "is this directory a mount", which is a property I
+# have to keep testing better. It is "what does the kernel say is mounted", which
+# is a FINITE LIST I can read.** One pass over that table answers every member
+# above and every member nobody has thought of yet, because it does not test a
+# property at all.
+#
+# `-xdev` stays on the removal and is NOT redundant: it is the only protection
+# where this table cannot be read.
+#
+# PLATFORM BOUNDARY, stated rather than implied. `/proc/self/mountinfo` is Linux,
+# and Linux is where `mount --bind` exists - so the case this closes and the means
+# of closing it arrive together. macOS has no same-device bind mount in the
+# ordinary configuration, and there `-xdev` plus the entry check carry it.
+# `/sbin/mount` is deliberately NOT parsed as a fallback: its output is
+# `dev on /path (fs, opts)`, which cannot be split unambiguously for a path
+# containing " on " or " (", and a mount check that is WRONG about a path is
+# worse than one that is honest about its scope.
+#   ew_lane_contains_a_mount <path>
+ew_lane_contains_a_mount() {
+  [ -r /proc/self/mountinfo ] || return 1
+  ew_lane_resolved_path "$1" || return 1
+  ew_lane_mountinfo_lists /proc/self/mountinfo "$EW_LANE_RESOLVED" subtree
 }
 
 # Can `rm -rf` escape the tree through this component? TWO ways, and `-L` sees
@@ -361,6 +403,13 @@ ew_take_default_lane() {
 ew_lane_remove_tree() {
   local entry="$1"
   [ -n "$entry" ] || return 2
+  # ASK THE KERNEL WHAT IS MOUNTED UNDER HERE BEFORE REMOVING ANYTHING. This is
+  # the check that closes the class; `-xdev` below is the floor for where the
+  # table cannot be read.
+  if ew_lane_contains_a_mount "$entry"; then
+    echo "ew_lane_remove_tree: something is mounted at or below $entry - refusing" >&2
+    return 1
+  fi
   /usr/bin/find "$entry" -xdev -delete
   [ ! -e "$entry" ]
 }

--- a/scripts/lib/log-dir.sh
+++ b/scripts/lib/log-dir.sh
@@ -186,6 +186,41 @@ ew_lane_device_of() {
 # `/proc/self/mountinfo` is consulted where it exists, which closes the Linux
 # case; no portable shell primitive covers the remainder. This is defence in
 # depth for the ONE remaining `rm -rf`, not a proof.
+# Does this mountinfo table list <path> as a mount point?
+#
+# **EXTRACTED SO THE SUITE CAN DRIVE THE REAL COMPARISON (#2408 review r9).** The
+# first version of this loop lived inline and the suite tested a COPY of it — a
+# reimplemented matcher, which measures the copy and says nothing about the code
+# that ships. Taking the table as an argument lets the row point it at a fixture
+# in mountinfo's own format while the production caller passes /proc/self/mountinfo.
+#
+# **THE TWO SIDES ARE IN DIFFERENT ALPHABETS (#2408 review r9, P1).** The kernel
+# escapes space, tab, newline and backslash in field 5 as `\040`, `\011`, `\012`
+# and `\134`, while `pwd -P` returns them literally — so a lane under a path
+# containing a space compares unequal against its own mountinfo row and the check
+# reports NOT-a-mount. That is the fail-OPEN direction, on the one branch whose
+# entire job is to stop `rm -rf` descending into a mounted filesystem, and a
+# checkout under a directory with a space in it is ordinary on macOS.
+#
+# `\134` is decoded LAST. A literal backslash in a real path arrives as `\134`, so
+# decoding it first would turn `\134040` into `\040` and the next rule would then
+# read a backslash-escape the path never contained.
+#
+# `read -r` is required: without it the shell would consume those backslashes
+# before any rule ran.
+#   ew_lane_mountinfo_lists <mountinfo-file> <resolved-path>
+ew_lane_mountinfo_lists() {
+  local mi_target
+  while read -r _ _ _ _ mi_target _; do
+    mi_target="${mi_target//\\040/ }"
+    mi_target="${mi_target//\\011/$'\t'}"
+    mi_target="${mi_target//\\012/$'\n'}"
+    mi_target="${mi_target//\\134/\\}"
+    [ "$mi_target" = "$2" ] && return 0
+  done < "$1"
+  return 1
+}
+
 ew_lane_is_mount_point() {
   local path="$1" dev parent_dev resolved
   [ -e "$path" ] || return 1
@@ -204,10 +239,7 @@ ew_lane_is_mount_point() {
   # the shell's own `=` on a variable this function already holds.
   if [ -r /proc/self/mountinfo ]; then
     resolved="$(cd "$path" 2>/dev/null && pwd -P)" || return 0
-    local mi_target
-    while read -r _ _ _ _ mi_target _; do
-      [ "$mi_target" = "$resolved" ] && return 0
-    done < /proc/self/mountinfo
+    ew_lane_mountinfo_lists /proc/self/mountinfo "$resolved" && return 0
   fi
   dev="$(ew_lane_device_of "$path")" || return 0
   parent_dev="$(ew_lane_device_of "$path/..")" || return 0
@@ -233,6 +265,40 @@ ew_lane_component_is_unsafe() {
   ew_lane_is_mount_point "$1" && return 0
   return 1
 }
+# Take a DEFAULT lane, atomically (#2408 review r9, P2).
+#
+# The note this replaces claimed `<seconds>-<pid>` "cannot recur — two runs
+# sharing both are the same process". Review found the case that is false in: a
+# pid recycled INSIDE one second, which a constrained pid namespace allows. The
+# old answer to reuse was an `rm -rf` at take time, and five review rounds went
+# into arranging guards around it.
+#
+# So this claims nothing about uniqueness. A bare `mkdir` — no `-p` — is atomic
+# and refuses an existing directory, the same primitive this repo settled on for
+# the seed cache after measuring that a check-then-act window fires 2-5 times in
+# 24 attempts. Reuse becomes IMPOSSIBLE rather than improbable, and a collision
+# fails loud instead of inheriting the previous occupant's Release receipt in
+# silence.
+#
+# In the LIB rather than inline in `xcode-test.sh` for the reason this file's
+# header already gives about the other two: inline, it could only be exercised by
+# running `xcodebuild`, so in practice it would never be exercised at all — and
+# this one is what stands between a recycled name and a stale receipt.
+#   ew_take_default_lane <lane_dir>
+ew_take_default_lane() {
+  local lane_dir="$1"
+  if [ -z "$lane_dir" ]; then
+    echo "ew_take_default_lane: lane_dir is required" >&2
+    return 2
+  fi
+  mkdir -p "${lane_dir%/*}" || return 2   # build/lanes is absent on a clean checkout
+  if ! mkdir "$lane_dir" 2>/dev/null; then
+    echo "ew_take_default_lane: $lane_dir already exists — refusing to inherit it" >&2
+    echo "  Two runs reached one lane name. Re-run; a new second gives a new lane." >&2
+    return 2
+  fi
+}
+
 # Publish "the last lane I ran" at a stable address (#2396).
 #
 # The default log directory is no longer predictable, so a human needs one place

--- a/scripts/lib/log-dir.sh
+++ b/scripts/lib/log-dir.sh
@@ -128,7 +128,8 @@ ew_resolve_log_dir() {
 # WHY THIS FILE STILL CARRIES CONTAINMENT CHECKS AT ALL, now that the take path
 # does not delete (#2408 review r7).
 #
-# One `rm -rf` remains: the retention sweep. It runs unattended on every default
+# One RECURSIVE REMOVAL remains: the retention sweep, and since r10 it is
+# `find -xdev -delete` rather than `rm -rf`. It runs unattended on every default
 # lane, so the same reasoning applies to it — **a string-shaped guard on a
 # filesystem operation is not a guard**, and being wrong there costs somebody's
 # directory rather than a rerun.
@@ -209,6 +210,36 @@ ew_lane_device_of() {
 # `read -r` is required: without it the shell would consume those backslashes
 # before any rule ran.
 #   ew_lane_mountinfo_lists <mountinfo-file> <resolved-path>
+# A path's physical location, WITH any trailing newline in its own name intact.
+#
+# **`$(...)` STRIPS TRAILING NEWLINES (#2408 review r10, P1).** A directory whose
+# name ends in a newline is written `\012` in mountinfo and decodes back to a
+# trailing newline, so it would never equal a `pwd -P` result that had it removed
+# - the fail-OPEN direction again, one layer under the escape fix, on the same
+# comparison.
+#
+# The `printf x` sentinel is the portable way to keep them: strip the `x`, then
+# strip exactly the ONE newline `pwd` itself adds. Everything the path owns
+# survives.
+#
+# **IT SETS A GLOBAL RATHER THAN ECHOING, and that is part of the fix rather than
+# a style choice.** The whole defect is that `$(...)` eats trailing newlines, so
+# handing the answer back through a command substitution would reintroduce it at
+# the call site - a correct function whose only caller undoes it.
+#
+# Split out rather than left inline so the suite can drive it on macOS,
+# where `/proc/self/mountinfo` does not exist and its caller's whole branch is
+# unreachable - a fix inside an unexecutable branch is how rounds 6, 7 and 9 of
+# this PR each shipped a defect.
+#   ew_lane_resolved_path <path>
+EW_LANE_RESOLVED=""
+ew_lane_resolved_path() {
+  local out
+  out="$(cd "$1" 2>/dev/null && pwd -P && printf x)" || return 1
+  out="${out%x}"
+  EW_LANE_RESOLVED="${out%$'\n'}"
+}
+
 ew_lane_mountinfo_lists() {
   local mi_target
   while read -r _ _ _ _ mi_target _; do
@@ -238,7 +269,8 @@ ew_lane_is_mount_point() {
   # awk so there is no second language to quote through, and so the comparison is
   # the shell's own `=` on a variable this function already holds.
   if [ -r /proc/self/mountinfo ]; then
-    resolved="$(cd "$path" 2>/dev/null && pwd -P)" || return 0
+    ew_lane_resolved_path "$path" || return 0
+    resolved="$EW_LANE_RESOLVED"
     ew_lane_mountinfo_lists /proc/self/mountinfo "$resolved" && return 0
   fi
   dev="$(ew_lane_device_of "$path")" || return 0
@@ -297,6 +329,40 @@ ew_take_default_lane() {
     echo "  Two runs reached one lane name. Re-run; a new second gives a new lane." >&2
     return 2
   fi
+}
+
+# Remove ONE stale lane, with no ability to cross a filesystem boundary.
+#
+# **THIS REPLACES `rm -rf`, AND THE DIFFERENCE IS MEASURED RATHER THAN REASONED
+# (#2408 review r10, P1).** The containment checks above inspect `build`, `lanes`
+# and the lane ENTRY. A mount nested BELOW an entry - `<lane>/app-logger/external`
+# - passes all of them, because the entry is an ordinary directory, and `rm -rf`
+# then descends into the mounted filesystem and erases its contents.
+#
+# Two-way, against a real APFS volume attached with `hdiutil` and mounted three
+# levels down (devices 16777231 vs 16777239):
+#
+#   rm -rf              precious.txt GONE, "Directory not empty", exit 1
+#   find -xdev -delete  precious.txt INTACT, lane survives, own files removed
+#
+# So the current code destroys the data and THEN reports a failure. `-xdev` is
+# the closed answer rather than a sixth guard: it refuses to descend past a
+# device boundary at ANY depth, so it does not need to be told where the mount
+# is. That is the same move as removing the take-path deletion in round 8 -
+# a question whose answer set is closed, one level down.
+#
+# **THE EXIT CODE IS NOT THE ORACLE, and this is the half that would have gone
+# unnoticed.** Measured: `find -delete` prints
+# `rmdir(...): Resource busy` to stderr and STILL EXITS 0. So success is decided
+# by asking the world whether the directory is gone, not by asking find how it
+# felt about the attempt. stderr is deliberately not suppressed - it names WHICH
+# path refused, which the caller's own message cannot.
+#   ew_lane_remove_tree <entry>
+ew_lane_remove_tree() {
+  local entry="$1"
+  [ -n "$entry" ] || return 2
+  /usr/bin/find "$entry" -xdev -delete
+  [ ! -e "$entry" ]
 }
 
 # Publish "the last lane I ran" at a stable address (#2396).
@@ -387,17 +453,19 @@ ew_prune_stale_lanes() {
   # `-type d` excludes links to directories, so a planted link inside lanes/ is
   # skipped rather than followed — but a MOUNT is a directory and `-type d`
   # matches it, so each candidate is checked before it is removed rather than
-  # handed to `-exec rm -rf`.
+  # handed straight to a removal. That check covers the ENTRY; a mount nested
+  # BELOW one is covered by the removal itself refusing to cross a device
+  # boundary (ew_lane_remove_tree).
   # NUL-DELIMITED, AND THE NEWLINE CASE IS NOT MERELY "BROKEN" (#2408 review r5).
   # A line-delimited read splits a directory named `old<newline>Sources` into TWO
   # records, and the second is `Sources` — a RELATIVE path. `xcode-test.sh` runs
   # from the project root, so that resolves to the repo's own `Sources/` and
-  # reaches `rm -rf`. I flagged this myself as "would break it"; the actual
+  # reaches the removal. I flagged this myself as "would break it"; the actual
   # consequence is deleting the source tree.
   #
   # PROCESS SUBSTITUTION, not a pipe: a `while` on the right of a pipe runs in a
   # SUBSHELL, so a failure recorded inside it cannot reach the caller — which is
-  # the second half of the same finding. `rm -rf` failing on one entry (a
+  # the second half of the same finding. A removal failing on one entry (a
   # permission, an ACL) was swallowed and the trailing `printf` made the body
   # succeed, so the whole prune reported success having removed nothing.
   local entry rc=0 find_failed=0
@@ -410,7 +478,7 @@ ew_prune_stale_lanes() {
       echo "ew_prune_stale_lanes: skipping an unsafe lane entry: $entry" >&2
       continue
     fi
-    if rm -rf "$entry"; then
+    if ew_lane_remove_tree "$entry"; then
       printf '%s\n' "$entry"
     else
       echo "ew_prune_stale_lanes: could not remove $entry" >&2

--- a/scripts/lib/log-dir.sh
+++ b/scripts/lib/log-dir.sh
@@ -395,7 +395,7 @@ ew_take_default_lane() {
     echo "ew_take_default_lane: lane_dir is required" >&2
     return 2
   fi
-  if false; then
+  if ew_lane_parents_are_unsafe "$lane_dir"; then
     echo "ew_take_default_lane: refusing to create $lane_dir through a linked parent" >&2
     return 2
   fi

--- a/scripts/lib/log-dir.sh
+++ b/scripts/lib/log-dir.sh
@@ -49,9 +49,13 @@
 # Echoes an ABSOLUTE directory path. An empty `requested` yields a
 # CONCURRENCY-ISOLATED directory, `<project_root>/build/lanes/$$`. That is the
 # honest name for it: two concurrent processes cannot share a pid, which is the
-# whole defect, while a LATER run can revisit a recycled pid — harmless, because
-# `tee` replaces the lane log and the bundle is deliberately replaced. It is not
-# globally unique and no timestamp is needed to make it so.
+# whole defect, while a LATER run can revisit a recycled pid. It is not globally
+# unique and no timestamp is needed to make it so — the caller CLEARS the
+# directory instead, via `ew_reset_lane_dir`.
+# An earlier version of this comment called reuse HARMLESS. It is not: a
+# debug-only run replaces only the debug artifacts, so a recycled lane keeps the
+# previous occupant's Release log and bundle beside fresh Debug ones, and
+# `app-logger` appends. Clearing is part of taking the directory.
 # A relative `requested` is taken as relative to the project root, never to the
 # caller's cwd — a lane's log belongs to the WORKTREE being tested, and cwd is
 # not a stable identity on a machine running five of them
@@ -88,6 +92,51 @@ ew_resolve_log_dir() {
 # in practice they would never be tested at all — and both of them delete or
 # replace things. The resolver stays side-effect free; these are separate
 # functions so that property is not quietly lost.
+
+# Give a recycled pid a CLEAN lane (#2408 review r2).
+#
+# The resolver's own header calls pid reuse harmless, and that was WRONG in one
+# case I asked about and answered badly. A later run replaces only what it
+# writes: a DEBUG-only invocation landing on a recycled pid overwrites the debug
+# log and bundle and leaves the previous occupant's `xcode-test-release.log` and
+# release `.xcresult` sitting beside them, while `app-logger` appends rather than
+# replaces. So a reader of `latest-lane` would find a stale Release receipt next
+# to a fresh Debug one and no way to tell — which is this pair of issues' whole
+# subject, arriving through the fix for it.
+#
+# Clearing is therefore part of taking the directory, not an optimisation.
+#
+# SCOPED HARD, because this deletes and it runs unattended: the path must sit
+# directly under `<project_root>/build/lanes/` and its basename must be all
+# digits, which is the shape the resolver produces and nothing a caller can talk
+# it into. Anything else is refused rather than cleaned — a wrong refusal costs a
+# stale file, a wrong delete costs someone's work.
+#   ew_reset_lane_dir <project_root> <lane_dir>
+ew_reset_lane_dir() {
+  local project_root="$1" lane_dir="$2"
+
+  if [ -z "$project_root" ] || [ -z "$lane_dir" ]; then
+    echo "ew_reset_lane_dir: project_root and lane_dir are required" >&2
+    return 2
+  fi
+
+  local base="${lane_dir##*/}"
+  case "$lane_dir" in
+    "$project_root/build/lanes/$base") ;;
+    *)
+      echo "ew_reset_lane_dir: refusing a path outside <root>/build/lanes: $lane_dir" >&2
+      return 2
+      ;;
+  esac
+  case "$base" in
+    "" | *[!0-9]*)
+      echo "ew_reset_lane_dir: refusing a lane name that is not a pid: $base" >&2
+      return 2
+      ;;
+  esac
+
+  rm -rf "$lane_dir"
+}
 
 # Publish "the last lane I ran" at a stable address (#2396).
 #

--- a/scripts/lib/log-dir.sh
+++ b/scripts/lib/log-dir.sh
@@ -20,11 +20,39 @@
 # `xcodebuild`, so in practice it would never be tested at all, and a path bug
 # surfaces as a lane writing somewhere nobody reads.
 #
+# THE DEFAULT IS NOW PER-INVOCATION (#2396)
+# It used to be `<project_root>/build`, so every invocation that omitted
+# `--log-dir` wrote the same file and the flag was a thing every caller had to
+# REMEMBER — which fails on the run you most want to cite. Measured: a lane
+# reporting 2379 against its own log's 6458 + 206.
+#
+# WHAT MADE IT LOOK IMMOVABLE WAS A FALSE SENTENCE, and it sat in this file's own
+# suite. It claimed `check-push-discipline.sh`'s freshness read expects
+# `build/xcode-test-debug.log`. That gate never names the file: for app changes
+# it reads the deployed and DerivedData dev-build artifacts (`:382-383`), and for
+# test changes the Debug xctest executable (`:403`), compared against `Tests/`
+# (`:420`). Swept for real consumers rather than recalled — the writer, this
+# resolver, and two lines of prose were the only namers, and the mutation battery
+# already passes its own `--log-dir` per row.
+#
+# AND #2401 CHANGED THE FAILURE CLASS, NOT MERELY ITS SEVERITY. `run_lane` now
+# derives the RESULT BUNDLE from this directory too and removes it before the run,
+# because xcodebuild refuses to overwrite one. Two concurrent same-worktree lanes
+# are therefore destructive on either schedule: one may delete a bundle the other
+# is still writing, or both may race to create the same path. **Before, they
+# produced a wrong NUMBER, and reconciliation catches a wrong number. A missing
+# bundle is not a number to reconcile**, so the detector this repo already
+# prescribes does not reach the new mode at all.
+#
 # CONTRACT
 #   ew_resolve_log_dir <project_root> [requested]
-# Echoes an ABSOLUTE directory path. An empty `requested` yields the historical
-# default, `<project_root>/build`, so every existing invocation is unchanged. A
-# relative `requested` is taken as relative to the project root, never to the
+# Echoes an ABSOLUTE directory path. An empty `requested` yields a
+# CONCURRENCY-ISOLATED directory, `<project_root>/build/lanes/$$`. That is the
+# honest name for it: two concurrent processes cannot share a pid, which is the
+# whole defect, while a LATER run can revisit a recycled pid — harmless, because
+# `tee` replaces the lane log and the bundle is deliberately replaced. It is not
+# globally unique and no timestamp is needed to make it so.
+# A relative `requested` is taken as relative to the project root, never to the
 # caller's cwd — a lane's log belongs to the WORKTREE being tested, and cwd is
 # not a stable identity on a machine running five of them
 # (`tools-and-apps.md` RULE: cwd-is-sticky-never-cd-for-a-one-off).
@@ -40,7 +68,7 @@ ew_resolve_log_dir() {
   fi
 
   if [ -z "$requested" ]; then
-    printf '%s\n' "$project_root/build"
+    printf '%s\n' "$project_root/build/lanes/$$"
     return 0
   fi
 
@@ -52,4 +80,76 @@ ew_resolve_log_dir() {
   fi
 
   printf '%s\n' "$project_root/$requested"
+}
+
+# The two SIDE-EFFECTING halves of the same subject. They live here rather than
+# inline in `xcode-test.sh` for the reason this file's header already gives about
+# the resolver: inlined, they could only be exercised by running `xcodebuild`, so
+# in practice they would never be tested at all — and both of them delete or
+# replace things. The resolver stays side-effect free; these are separate
+# functions so that property is not quietly lost.
+
+# Publish "the last lane I ran" at a stable address (#2396).
+#
+# The default log directory is no longer predictable, so a human needs one place
+# to look: `build/latest-lane/xcode-test-debug.log`. Deliberately ONE directory
+# link rather than per-file links at the old names — those would keep an obsolete
+# contract alive and would need four of them (two logs, two bundles) plus
+# `app-logger`.
+#
+# BUILT BESIDE THE DESTINATION AND RENAMED, because `ln -sfn` is not atomic: it
+# unlinks and recreates, so a concurrent lane can observe no link at all. `mv -h`
+# replaces the LINK rather than following it into the previous lane's directory,
+# which is the difference between repointing the pointer and writing inside the
+# thing it points at.
+# KNOWN LIMIT, stated rather than hidden: with two lanes started at once the link
+# points at whichever PUBLISHED last, which is a coin flip. That is inherent to a
+# single shared pointer and is not what this fix is for — the lanes themselves no
+# longer collide, which is the defect. A caller that needs a specific address
+# should pass `--log-dir`, and this function is deliberately not called for one.
+#   ew_publish_latest_lane <project_root> <lane_dir>
+ew_publish_latest_lane() {
+  local project_root="$1" lane_dir="$2"
+
+  if [ -z "$project_root" ] || [ -z "$lane_dir" ]; then
+    echo "ew_publish_latest_lane: project_root and lane_dir are required" >&2
+    return 2
+  fi
+
+  local link="$project_root/build/latest-lane"
+  local tmp="$project_root/build/.latest-lane.$$"
+  mkdir -p "$project_root/build" || return 1
+  rm -f "$tmp"
+  ln -s "lanes/${lane_dir##*/}" "$tmp" || return 1
+  /bin/mv -fh "$tmp" "$link"
+}
+
+# Bounded retention for lane directories (#2396).
+#
+# Each lane now holds two logs AND up to two `.xcresult` bundles, so an unbounded
+# per-invocation default would be a defect this change INTRODUCES rather than one
+# it inherits.
+#
+# Scoped as narrowly as it can be, because this deletes: only directories
+# directly under one worktree's own `build/lanes/`, only ones untouched for
+# `days`, never the lane currently in use, and never by following a link. A lane
+# still running after a week does not exist; a lane a human still wants after a
+# week is one they should have given `--log-dir`.
+#   ew_prune_stale_lanes <project_root> <keep_dir> [days]
+ew_prune_stale_lanes() {
+  local project_root="$1" keep="$2" days="${3:-7}"
+
+  if [ -z "$project_root" ]; then
+    echo "ew_prune_stale_lanes: project_root is required" >&2
+    return 2
+  fi
+
+  local lanes="$project_root/build/lanes"
+  [ -d "$lanes" ] || return 0
+
+  # `/usr/bin/find`, not `find`: the shim on this machine rejects some predicate
+  # forms and its blindness is data-dependent
+  # (validation-discipline.md, the silent-empty traps).
+  /usr/bin/find "$lanes" -mindepth 1 -maxdepth 1 -type d -mtime "+$days" \
+    ! -path "$keep" -print -exec rm -rf {} +
 }

--- a/scripts/lib/log-dir.sh
+++ b/scripts/lib/log-dir.sh
@@ -47,15 +47,25 @@
 # CONTRACT
 #   ew_resolve_log_dir <project_root> [requested]
 # Echoes an ABSOLUTE directory path. An empty `requested` yields a
-# CONCURRENCY-ISOLATED directory, `<project_root>/build/lanes/$$`. That is the
-# honest name for it: two concurrent processes cannot share a pid, which is the
-# whole defect, while a LATER run can revisit a recycled pid. It is not globally
-# unique and no timestamp is needed to make it so — the caller CLEARS the
-# directory instead, via `ew_reset_lane_dir`.
-# An earlier version of this comment called reuse HARMLESS. It is not: a
-# debug-only run replaces only the debug artifacts, so a recycled lane keeps the
-# previous occupant's Release log and bundle beside fresh Debug ones, and
-# `app-logger` appends. Clearing is part of taking the directory.
+# directory named `<seconds>-<pid>`, which cannot recur.
+#
+# **THIS WAS `$$` ALONE, AND EVERY DELETION THE TAKE PATH ONCE PERFORMED EXISTED
+# TO COMPENSATE FOR THAT CHOICE (#2408 review r7).** Two concurrent processes
+# cannot share a pid — that is the defect — but pids RECYCLE, and a later run
+# replaces only what IT writes, so a debug-only run landing on a recycled lane
+# kept the previous occupant's Release log and bundle beside fresh Debug ones
+# while `app-logger` appended. The answer was an `rm -rf` at take time, guarded by
+# shape, by three link checks, by mount detection and by an absoluteness check —
+# five guards, and review found a defect in that arrangement on FOUR CONSECUTIVE
+# ROUNDS, the last of which was a bind mount no device comparison can see.
+#
+# Adding the SECOND removes the need for all of it: two runs cannot share both a
+# pid and a second, because that is the same process. No reuse, no stale receipt,
+# nothing to clear. **The take path no longer deletes at all**, and one of the two
+# `rm -rf` sites in this file is gone rather than better guarded.
+#
+# The paved road rather than a sixth guard: a guard fires after the mistake is
+# possible; a name that cannot recur makes it impossible.
 # A relative `requested` is taken as relative to the project root, never to the
 # caller's cwd — a lane's log belongs to the WORKTREE being tested, and cwd is
 # not a stable identity on a machine running five of them
@@ -86,7 +96,12 @@ ew_lane_probe_mv_flag() {
   done
   rm -rf "$d"
 }
-ew_lane_probe_mv_flag
+# `|| true`: this runs at SOURCE time and `xcode-test.sh` sets `set -e` BEFORE
+# sourcing, so a probe that cannot create its temp directory — a missing,
+# unwritable or full `TMPDIR` — would abort the whole lane before `xcodebuild`
+# (#2408 review r7). A failed probe leaves the flag empty, which publication
+# already refuses on; that degradation must be allowed to happen.
+ew_lane_probe_mv_flag || true
 
 ew_resolve_log_dir() {
   local project_root="$1" requested="${2:-}"
@@ -97,7 +112,7 @@ ew_resolve_log_dir() {
   fi
 
   if [ -z "$requested" ]; then
-    printf '%s\n' "$project_root/build/lanes/$$"
+    printf '%s\n' "$project_root/build/lanes/$(date +%s)-$$"
     return 0
   fi
 
@@ -110,33 +125,19 @@ ew_resolve_log_dir() {
 
   printf '%s\n' "$project_root/$requested"
 }
+# WHY THIS FILE STILL CARRIES CONTAINMENT CHECKS AT ALL, now that the take path
+# does not delete (#2408 review r7).
+#
+# One `rm -rf` remains: the retention sweep. It runs unattended on every default
+# lane, so the same reasoning applies to it — **a string-shaped guard on a
+# filesystem operation is not a guard**, and being wrong there costs somebody's
+# directory rather than a rerun.
+#
+# The guard that decided a whole PATH was deletable is gone with the function it
+# served: it had no other caller, and dead code inside a safety file reads as
+# protection nobody can verify — which is the argument this PR already made for
+# deleting an unreachable check rather than keeping it with a note.
 
-# The two SIDE-EFFECTING halves of the same subject. They live here rather than
-# inline in `xcode-test.sh` for the reason this file's header already gives about
-# the resolver: inlined, they could only be exercised by running `xcodebuild`, so
-# in practice they would never be tested at all — and both of them delete or
-# replace things. The resolver stays side-effect free; these are separate
-# functions so that property is not quietly lost.
-
-# THE ONE PLACE THAT DECIDES WHETHER A PATH MAY BE DELETED (#2408 review r3, P1).
-#
-# The first version of this scoping was TEXTUAL — direct child of
-# `<root>/build/lanes/`, basename all digits. Both are true of a string and say
-# nothing about the filesystem, so if `<root>/build` or `<root>/build/lanes` is a
-# SYMLINK the path passes every check and `rm -rf` follows the link out of the
-# tree, deleting a numeric directory somewhere else entirely.
-#
-# **A string-shaped guard on a filesystem operation is not a guard**, and this is
-# the one that runs unattended on every default lane, so being wrong here costs
-# somebody's directory rather than a rerun.
-#
-# So containment is decided PHYSICALLY: no link anywhere on the way down, and the
-# lane's real parent must BE the real lanes directory. `pwd -P` resolves what the
-# string cannot.
-#
-# Shared by both deleting functions deliberately. Two copies of a rule this sharp
-# is how one of them stops matching the other.
-#   ew_lane_path_is_deletable <project_root> <lane_dir>
 # Is this path a MOUNT POINT, or can we not tell? A directory whose device number
 # differs from its parent's is where a filesystem is mounted; `stat -f %d` is the
 # macOS spelling.
@@ -180,9 +181,23 @@ ew_lane_device_of() {
   esac
 }
 
+# KNOWN LIMIT and the reason the take path stopped deleting: a device-number
+# comparison cannot see a SAME-DEVICE bind mount, which Linux allows.
+# `/proc/self/mountinfo` is consulted where it exists, which closes the Linux
+# case; no portable shell primitive covers the remainder. This is defence in
+# depth for the ONE remaining `rm -rf`, not a proof.
 ew_lane_is_mount_point() {
-  local path="$1" dev parent_dev
+  local path="$1" dev parent_dev resolved
   [ -e "$path" ] || return 1
+
+  # Linux: the authoritative list, which sees a bind mount whatever its device.
+  if [ -r /proc/self/mountinfo ]; then
+    resolved="$(cd "$path" 2>/dev/null && pwd -P)" || return 0
+    if /usr/bin/awk -v p="$resolved" '"'"'$5 == p { f = 1 } END { exit !f }'"'"' \
+      /proc/self/mountinfo 2>/dev/null; then
+      return 0
+    fi
+  fi
   dev="$(ew_lane_device_of "$path")" || return 0
   parent_dev="$(ew_lane_device_of "$path/..")" || return 0
   [ -n "$dev" ] && [ -n "$parent_dev" ] || return 0
@@ -207,95 +222,6 @@ ew_lane_component_is_unsafe() {
   ew_lane_is_mount_point "$1" && return 0
   return 1
 }
-
-ew_lane_path_is_deletable() {
-  local project_root="$1" lane_dir="$2"
-  local base="${lane_dir##*/}"
-
-  # Shape first, because it is the cheap half and it rejects the obvious.
-  case "$lane_dir" in
-    "$project_root/build/lanes/$base") ;;
-    *) return 1 ;;
-  esac
-  case "$base" in
-    "" | *[!0-9]*) return 1 ;;
-  esac
-
-  # Then the filesystem. ONE question asked at each of the three levels: can
-  # `rm -rf` leave the tree through this component. Asked through a single helper
-  # rather than two checks per level, and that is a COVERAGE decision as much as a
-  # tidiness one — a real mount cannot be constructed in a portable suite without
-  # sudo, so a `-L` check and a separate mount check at each level would leave the
-  # mount half of every level untestable. With one helper, the rows that prove the
-  # guard consults it (the symlink victims below) and the rows that prove the
-  # helper catches a mount (against real devfs) compose into coverage of both.
-  ew_lane_component_is_unsafe "$project_root/build" && return 1
-  ew_lane_component_is_unsafe "$project_root/build/lanes" && return 1
-  ew_lane_component_is_unsafe "$lane_dir" && return 1
-
-  # NO `pwd -P` PARENT-EQUALITY CHECK HERE, AND ITS ABSENCE IS DELIBERATE.
-  # One was written and removed: with the three link checks above passing, the
-  # shape guard already forces the lane to be a direct child of a real
-  # `build/lanes`, so the physical parent IS the physical lanes directory by
-  # construction — and where `project_root` itself contains a link, BOTH sides
-  # resolve through it and compare equal anyway. A control proved it: deleting
-  # the comparison left all 31 rows green, because nothing can reach it.
-  # **An unreachable guard inside a deleting function is worse than no guard** —
-  # it reads as protection that nobody can verify, and the next reader trusts it.
-  return 0
-}
-
-# Give a recycled pid a CLEAN lane (#2408 review r2).
-#
-# The resolver's own header calls pid reuse harmless, and that was WRONG in one
-# case I asked about and answered badly. A later run replaces only what it
-# writes: a DEBUG-only invocation landing on a recycled pid overwrites the debug
-# log and bundle and leaves the previous occupant's `xcode-test-release.log` and
-# release `.xcresult` sitting beside them, while `app-logger` appends rather than
-# replaces. So a reader of `latest-lane` would find a stale Release receipt next
-# to a fresh Debug one and no way to tell — which is this pair of issues' whole
-# subject, arriving through the fix for it.
-#
-# Clearing is therefore part of taking the directory, not an optimisation.
-#
-# SCOPED HARD, because this deletes and it runs unattended: the path must sit
-# directly under `<project_root>/build/lanes/` and its basename must be all
-# digits, which is the shape the resolver produces and nothing a caller can talk
-# it into. Anything else is refused rather than cleaned — a wrong refusal costs a
-# stale file, a wrong delete costs someone's work.
-#   ew_reset_lane_dir <project_root> <lane_dir>
-ew_reset_lane_dir() {
-  local project_root="$1" lane_dir="$2"
-
-  if [ -z "$project_root" ] || [ -z "$lane_dir" ]; then
-    echo "ew_reset_lane_dir: project_root and lane_dir are required" >&2
-    return 2
-  fi
-
-  # CONTAINMENT IS DECIDED BEFORE ABSENCE (#2408 review r3, P1).
-  #
-  # The absent-lane shortcut used to run FIRST, and absence is the NORMAL
-  # fresh-invocation case — so on almost every run this returned success without
-  # ever looking at the parents, and the caller then `mkdir -p`'d straight through
-  # a symlinked `build` or `lanes`. The early return was added for a good reason
-  # and put upstream of the guard, which is this repo's own
-  # fix-the-path-that-runs-first shape: the check that matters was correct and
-  # unreachable.
-  #
-  # Ordering is safe because none of the containment checks require the lane to
-  # exist — they ask about its NAME and about its parents.
-  if ! ew_lane_path_is_deletable "$project_root" "$lane_dir"; then
-    echo "ew_reset_lane_dir: refusing to clear a path that is not a contained lane: $lane_dir" >&2
-    return 2
-  fi
-
-  # Nothing to clean is success, and it is checked AFTER containment so a
-  # fresh run still validates the tree it is about to write into.
-  [ -e "$lane_dir" ] || return 0
-
-  rm -rf "$lane_dir"
-}
-
 # Publish "the last lane I ran" at a stable address (#2396).
 #
 # The default log directory is no longer predictable, so a human needs one place

--- a/scripts/lib/log-dir.sh
+++ b/scripts/lib/log-dir.sh
@@ -142,6 +142,14 @@ ew_lane_is_mount_point() {
 # erases its contents, leaving only the busy mount root.
 #   ew_lane_component_is_unsafe <path>
 ew_lane_component_is_unsafe() {
+  # A RELATIVE path is unsafe by definition: it resolves against whatever the
+  # caller's cwd happens to be, and `xcode-test.sh` runs from the project root.
+  # Defence that does not depend on the delimiter — the NUL read above closes the
+  # route that produced one, this closes the CLASS.
+  case "$1" in
+    /*) ;;
+    *) return 0 ;;
+  esac
   [ -L "$1" ] && return 0
   ew_lane_is_mount_point "$1" && return 0
   return 1
@@ -311,14 +319,32 @@ ew_prune_stale_lanes() {
   # skipped rather than followed — but a MOUNT is a directory and `-type d`
   # matches it, so each candidate is checked before it is removed rather than
   # handed to `-exec rm -rf`.
-  local entry
-  /usr/bin/find "$lanes" -mindepth 1 -maxdepth 1 -type d -mtime "+$days" \
-    ! -path "$keep" -print | while IFS= read -r entry; do
+  # NUL-DELIMITED, AND THE NEWLINE CASE IS NOT MERELY "BROKEN" (#2408 review r5).
+  # A line-delimited read splits a directory named `old<newline>Sources` into TWO
+  # records, and the second is `Sources` — a RELATIVE path. `xcode-test.sh` runs
+  # from the project root, so that resolves to the repo's own `Sources/` and
+  # reaches `rm -rf`. I flagged this myself as "would break it"; the actual
+  # consequence is deleting the source tree.
+  #
+  # PROCESS SUBSTITUTION, not a pipe: a `while` on the right of a pipe runs in a
+  # SUBSHELL, so a failure recorded inside it cannot reach the caller — which is
+  # the second half of the same finding. `rm -rf` failing on one entry (a
+  # permission, an ACL) was swallowed and the trailing `printf` made the body
+  # succeed, so the whole prune reported success having removed nothing.
+  local entry rc=0
+  while IFS= read -r -d '' entry; do
     if ew_lane_component_is_unsafe "$entry"; then
       echo "ew_prune_stale_lanes: skipping an unsafe lane entry: $entry" >&2
       continue
     fi
-    rm -rf "$entry"
-    printf '%s\n' "$entry"
-  done
+    if rm -rf "$entry"; then
+      printf '%s\n' "$entry"
+    else
+      echo "ew_prune_stale_lanes: could not remove $entry" >&2
+      rc=1
+    fi
+  done < <(/usr/bin/find "$lanes" -mindepth 1 -maxdepth 1 -type d -mtime "+$days" \
+    ! -path "$keep" -print0)
+
+  return "$rc"
 }

--- a/scripts/lib/log-dir.sh
+++ b/scripts/lib/log-dir.sh
@@ -191,12 +191,23 @@ ew_lane_is_mount_point() {
   [ -e "$path" ] || return 1
 
   # Linux: the authoritative list, which sees a bind mount whatever its device.
+  #
+  # THE AWK PROGRAM MUST REACH AWK. A previous version carried literal quote
+  # characters from the tool that generated it, so BASH expanded `$5` before awk
+  # ever saw it and awk received a constant expression — which is true for every
+  # line, so the command succeeded for EVERY path and reported everything as a
+  # mount. Exactly the branch I told the reviewer I could not execute, broken in
+  # exactly the way an unexecutable branch gets broken (#2408 review r8).
+  #
+  # Field 5 of mountinfo is the mount point. Read with `while read` rather than
+  # awk so there is no second language to quote through, and so the comparison is
+  # the shell's own `=` on a variable this function already holds.
   if [ -r /proc/self/mountinfo ]; then
     resolved="$(cd "$path" 2>/dev/null && pwd -P)" || return 0
-    if /usr/bin/awk -v p="$resolved" '"'"'$5 == p { f = 1 } END { exit !f }'"'"' \
-      /proc/self/mountinfo 2>/dev/null; then
-      return 0
-    fi
+    local mi_target
+    while read -r _ _ _ _ mi_target _; do
+      [ "$mi_target" = "$resolved" ] && return 0
+    done < /proc/self/mountinfo
   fi
   dev="$(ew_lane_device_of "$path")" || return 0
   parent_dev="$(ew_lane_device_of "$path/..")" || return 0

--- a/scripts/lib/log-dir.sh
+++ b/scripts/lib/log-dir.sh
@@ -359,10 +359,44 @@ ew_lane_component_is_unsafe() {
 # running `xcodebuild`, so in practice it would never be exercised at all — and
 # this one is what stands between a recycled name and a stale receipt.
 #   ew_take_default_lane <lane_dir>
+# Are `build` and `build/lanes` safe to CREATE THROUGH?
+#
+# **ROUND 8 REMOVED A DELETION AND ITS CONTAINMENT CHECK TOGETHER, AND THAT CHECK
+# WAS ALSO GUARDING THE CREATE (#2408 review r13, P1, reproduced by the
+# reviewer).** Every round since has argued about the removal path, because that
+# is where the `rm -rf` was - and the take path was quietly writing through a
+# symlinked `build` the whole time, putting the lane outside the worktree and
+# then letting `ew_publish_latest_lane` replace the EXTERNAL parent's
+# `latest-lane`.
+#
+# The general shape, and it is the one I got wrong: when you delete a mechanism,
+# ask what ELSE it was protecting. A guard that sat in front of a deletion is not
+# necessarily a guard ABOUT deletion.
+#
+# A component that does not exist is SAFE - that is the fresh-checkout case, and
+# `ew_lane_component_is_unsafe` already answers it that way.
+#   ew_lane_parents_are_unsafe <lane_dir>
+ew_lane_parents_are_unsafe() {
+  local lanes="${1%/*}" build
+  build="${lanes%/*}"
+  local c
+  for c in "$build" "$lanes"; do
+    if ew_lane_component_is_unsafe "$c"; then
+      echo "ew_lane_parents_are_unsafe: $c is a symlink or a mount point" >&2
+      return 0
+    fi
+  done
+  return 1
+}
+
 ew_take_default_lane() {
   local lane_dir="$1"
   if [ -z "$lane_dir" ]; then
     echo "ew_take_default_lane: lane_dir is required" >&2
+    return 2
+  fi
+  if false; then
+    echo "ew_take_default_lane: refusing to create $lane_dir through a linked parent" >&2
     return 2
   fi
   mkdir -p "${lane_dir%/*}" || return 2   # build/lanes is absent on a clean checkout
@@ -453,6 +487,16 @@ ew_publish_latest_lane() {
   if [ -z "$project_root" ] || [ -z "$lane_dir" ]; then
     echo "ew_publish_latest_lane: project_root and lane_dir are required" >&2
     return 2
+  fi
+
+  # THE TWIN OF THE TAKE PATH, and naming it is the point: this writes into the
+  # same `build` the take path was refusing to write through, so guarding one and
+  # not the other leaves the same symlink exposed one command later (#2408 review
+  # r13). `latest-lane` lives beside `lanes/`, so the component to check is
+  # `build` itself - passed as a lane-shaped path so the one owner answers.
+  if ew_lane_parents_are_unsafe "$project_root/build/lanes/x"; then
+    echo "ew_publish_latest_lane: refusing to publish through a linked parent" >&2
+    return 1
   fi
 
   local link="$project_root/build/latest-lane"

--- a/scripts/lib/log-dir.sh
+++ b/scripts/lib/log-dir.sh
@@ -63,6 +63,31 @@
 # The directory is NOT created here; creating it is the caller's business, and a
 # resolver with a side effect cannot be tested cheaply.
 
+# Which flag makes `mv` replace a SYMLINK rather than FOLLOW it: `-h` on BSD,
+# `-T` on GNU. Probed against a real link in a temp directory rather than by
+# parsing an error message, because an error string is a different thing to be
+# wrong about than a behaviour. An unrecognised `mv` leaves this empty and
+# publication refuses rather than writing through the old link.
+EW_LANE_MV_NOFOLLOW=""
+ew_lane_probe_mv_flag() {
+  local d f
+  d="$(mktemp -d "${TMPDIR:-/tmp}/ew-mvprobe.XXXXXX")" || return 1
+  mkdir -p "$d/target"
+  ln -s target "$d/link"
+  ln -s elsewhere "$d/tmp"
+  for f in -h -T; do
+    if /bin/mv -f "$f" "$d/tmp" "$d/link" 2>/dev/null; then
+      # It must have replaced the LINK, not written inside `target/`.
+      if [ ! -e "$d/target/link" ] && [ "$(readlink "$d/link")" = "elsewhere" ]; then
+        EW_LANE_MV_NOFOLLOW="$f"
+      fi
+      break
+    fi
+  done
+  rm -rf "$d"
+}
+ew_lane_probe_mv_flag
+
 ew_resolve_log_dir() {
   local project_root="$1" requested="${2:-}"
 
@@ -127,11 +152,39 @@ ew_resolve_log_dir() {
 # A path that does NOT exist is a different answer and stays NOT-a-mount: absence
 # is the fresh-invocation case, and there is nothing there to descend into.
 #   ew_lane_is_mount_point <path>
+# Read a path's DEVICE NUMBER, on either stat (#2408 review r6).
+#
+# `stat -f %d` is BSD. On GNU `-f` means "display file system status" and `%d` is
+# parsed as another FILENAME, so the call fails — and with the fail-closed
+# direction this file adopted last round, every existing component would have
+# been classified unsafe on Linux. **I asked whether process substitution needed
+# bash and never asked whether `stat` was the same program**, on a suite this PR's
+# sibling deliberately wired into a Linux job.
+#
+# Detected ONCE at source time against `/`, which exists everywhere, rather than
+# per call. An unrecognised `stat` yields an empty command, and the caller fails
+# closed on that — unknown stays unsafe.
+if /usr/bin/stat -f %d / >/dev/null 2>&1; then
+  EW_LANE_STAT_DEV_STYLE=bsd
+elif stat -c %d / >/dev/null 2>&1; then
+  EW_LANE_STAT_DEV_STYLE=gnu
+else
+  EW_LANE_STAT_DEV_STYLE=unknown
+fi
+
+ew_lane_device_of() {
+  case "$EW_LANE_STAT_DEV_STYLE" in
+    bsd) /usr/bin/stat -f %d "$1" 2>/dev/null ;;
+    gnu) stat -c %d "$1" 2>/dev/null ;;
+    *) return 1 ;;
+  esac
+}
+
 ew_lane_is_mount_point() {
   local path="$1" dev parent_dev
   [ -e "$path" ] || return 1
-  dev="$(/usr/bin/stat -f %d "$path" 2>/dev/null)" || return 0
-  parent_dev="$(/usr/bin/stat -f %d "$path/.." 2>/dev/null)" || return 0
+  dev="$(ew_lane_device_of "$path")" || return 0
+  parent_dev="$(ew_lane_device_of "$path/..")" || return 0
   [ -n "$dev" ] && [ -n "$parent_dev" ] || return 0
   [ "$dev" != "$parent_dev" ]
 }
@@ -275,7 +328,20 @@ ew_publish_latest_lane() {
   mkdir -p "$project_root/build" || return 1
   rm -f "$tmp"
   ln -s "lanes/${lane_dir##*/}" "$tmp" || return 1
-  /bin/mv -fh "$tmp" "$link"
+
+  # `-h` is BSD, `-T` is GNU, and both mean the same thing here: replace the LINK
+  # rather than following it into the directory it points at. `mv -f` alone
+  # follows on both, which writes `latest-lane` INSIDE the previous lane and
+  # leaves the pointer stale (#2408 review r6 — `-fh` simply errors on GNU, so the
+  # link was never published at all and the temp file was left behind).
+  case "$EW_LANE_MV_NOFOLLOW" in
+    -h | -T) /bin/mv -f "$EW_LANE_MV_NOFOLLOW" "$tmp" "$link" ;;
+    *)
+      rm -f "$tmp"
+      echo "ew_publish_latest_lane: no no-follow rename available on this mv" >&2
+      return 1
+      ;;
+  esac
 }
 
 # Bounded retention for lane directories (#2396).
@@ -331,8 +397,12 @@ ew_prune_stale_lanes() {
   # the second half of the same finding. `rm -rf` failing on one entry (a
   # permission, an ACL) was swallowed and the trailing `printf` made the body
   # succeed, so the whole prune reported success having removed nothing.
-  local entry rc=0
+  local entry rc=0 find_failed=0
   while IFS= read -r -d '' entry; do
+    if [ "$entry" = "FIND-FAILED" ]; then
+      find_failed=1
+      continue
+    fi
     if ew_lane_component_is_unsafe "$entry"; then
       echo "ew_prune_stale_lanes: skipping an unsafe lane entry: $entry" >&2
       continue
@@ -344,7 +414,18 @@ ew_prune_stale_lanes() {
       rc=1
     fi
   done < <(/usr/bin/find "$lanes" -mindepth 1 -maxdepth 1 -type d -mtime "+$days" \
-    ! -path "$keep" -print0)
+    ! -path "$keep" -print0 || printf 'FIND-FAILED\0')
+
+  # `find` FAILING IS NOT AN EMPTY SWEEP (#2408 review r6). A process
+  # substitution's exit status is not visible to the loop, so a `find` that could
+  # not enumerate `lanes` — a permission or an ACL that allows the stat checks and
+  # denies the directory read — produced no iterations, left `rc` at 0, and the
+  # prune reported a clean sweep having looked at nothing. The sentinel is the
+  # only channel that survives the substitution.
+  if [ "$find_failed" = "1" ]; then
+    echo "ew_prune_stale_lanes: could not enumerate $lanes" >&2
+    return 1
+  fi
 
   return "$rc"
 }

--- a/scripts/lib/log-dir.sh
+++ b/scripts/lib/log-dir.sh
@@ -406,6 +406,20 @@ ew_lane_remove_tree() {
   # ASK THE KERNEL WHAT IS MOUNTED UNDER HERE BEFORE REMOVING ANYTHING. This is
   # the check that closes the class; `-xdev` below is the floor for where the
   # table cannot be read.
+  # KNOWN LIMIT, ACCEPTED RATHER THAN FIXED (#2408 review r12). This reads a
+  # SNAPSHOT of the mount table and the traversal below happens afterwards, so a
+  # mount created in that window is not seen. **No shell primitive closes it** -
+  # the kernel-level answer is an `openat2` walk with `RESOLVE_NO_XDEV`, which
+  # bash cannot express - and inventing a mechanism I cannot execute is precisely
+  # how rounds 6, 7 and 9 of this PR each shipped a defect.
+  #
+  # State the residue precisely rather than as "there is a race", because the
+  # precise version is much smaller: `-xdev` runs DURING the traversal and is
+  # enforced by the kernel at the moment find would cross a device boundary, so a
+  # mount that appears mid-walk on a different device is still refused. What
+  # survives is a SAME-DEVICE bind mount, on Linux, created inside a >7-day-old
+  # lane under a gitignored `build/`, in the window between this read and the
+  # walk reaching that path.
   if ew_lane_contains_a_mount "$entry"; then
     echo "ew_lane_remove_tree: something is mounted at or below $entry - refusing" >&2
     return 1

--- a/scripts/xcode-test.sh
+++ b/scripts/xcode-test.sh
@@ -77,7 +77,18 @@ LOG_DIR="$(ew_resolve_log_dir "$PROJECT_ROOT" "$LOG_DIR")"
 # means clearing it, or a debug-only run inherits the previous occupant's Release
 # receipt (#2408 review r2). Never for an explicit `--log-dir`: that directory
 # belongs to the caller and may be one they are deliberately filling.
-[ "$USING_DEFAULT_LOG_DIR" = "1" ] && ew_reset_lane_dir "$PROJECT_ROOT" "$LOG_DIR"
+# REFUSING TO DELETE MUST NOT REFUSE TO RUN (#2408 review r3, P2).
+#
+# This script runs `set -euo pipefail`, so a bare call returning 2 aborts the
+# lane before `xcodebuild` — turning "I will not delete through a symlink" into
+# "your tests do not run", which is a far worse answer to an unusual but legal
+# layout. An `if` condition suppresses errexit for the call, the same mechanism
+# #2401 needed for its judge.
+if [ "$USING_DEFAULT_LOG_DIR" = "1" ]; then
+  if ! ew_reset_lane_dir "$PROJECT_ROOT" "$LOG_DIR"; then
+    echo "==> not clearing this lane; a recycled pid may leave stale receipts here" >&2
+  fi
+fi
 mkdir -p "$LOG_DIR"   # absent on a clean checkout
 APP_LOG_DIR="$LOG_DIR/app-logger"
 mkdir -p "$APP_LOG_DIR"
@@ -87,8 +98,15 @@ mkdir -p "$APP_LOG_DIR"
 # address it already knows, and moving a shared pointer or pruning on its behalf
 # would make a battery's rows fight over it.
 if [ "$USING_DEFAULT_LOG_DIR" = "1" ]; then
-  ew_publish_latest_lane "$PROJECT_ROOT" "$LOG_DIR"
-  ew_prune_stale_lanes "$PROJECT_ROOT" "$LOG_DIR"
+  # Both are conveniences and neither may abort the lane under `set -e`: a link
+  # that cannot be repointed and a sweep that will not run through a symlink are
+  # both worth saying out loud and neither is worth refusing to test over.
+  if ! ew_publish_latest_lane "$PROJECT_ROOT" "$LOG_DIR"; then
+    echo "==> could not publish build/latest-lane; the lane itself is unaffected" >&2
+  fi
+  if ! ew_prune_stale_lanes "$PROJECT_ROOT" "$LOG_DIR"; then
+    echo "==> not pruning old lanes; build/lanes will grow until this is resolved" >&2
+  fi
 fi
 
 # Generate the Xcode project (gitignored, never committed) — only when a

--- a/scripts/xcode-test.sh
+++ b/scripts/xcode-test.sh
@@ -73,14 +73,16 @@ cd "$PROJECT_ROOT"
 USING_DEFAULT_LOG_DIR=0
 [ -z "$LOG_DIR" ] && USING_DEFAULT_LOG_DIR=1
 LOG_DIR="$(ew_resolve_log_dir "$PROJECT_ROOT" "$LOG_DIR")"
-# A DEFAULT lane is named by pid, and pids recycle — so taking the directory
-# means clearing it, or a debug-only run inherits the previous occupant's Release
-# receipt (#2408 review r2). Never for an explicit `--log-dir`: that directory
-# belongs to the caller and may be one they are deliberately filling.
-# NO RESET HERE ANY MORE (#2408 review r7). The lane name carries the SECOND as
-# well as the pid, so it cannot recur — two runs sharing both are the same
-# process. The take path has nothing to clear and does not delete.
-mkdir -p "$LOG_DIR"   # absent on a clean checkout
+# Owner: scripts/lib/log-dir.sh ew_take_default_lane, which has its own rows. A
+# default lane is TAKEN atomically rather than assumed unique — the reasoning,
+# and the review finding that produced it, live at the function.
+if [ "$USING_DEFAULT_LOG_DIR" = "1" ]; then
+  ew_take_default_lane "$LOG_DIR" || exit 2
+else
+  # `-p` stays right for an explicit `--log-dir`: that directory belongs to the
+  # caller, who may be deliberately filling it across several runs.
+  mkdir -p "$LOG_DIR"
+fi
 APP_LOG_DIR="$LOG_DIR/app-logger"
 mkdir -p "$APP_LOG_DIR"
 

--- a/scripts/xcode-test.sh
+++ b/scripts/xcode-test.sh
@@ -77,16 +77,25 @@ LOG_DIR="$(ew_resolve_log_dir "$PROJECT_ROOT" "$LOG_DIR")"
 # means clearing it, or a debug-only run inherits the previous occupant's Release
 # receipt (#2408 review r2). Never for an explicit `--log-dir`: that directory
 # belongs to the caller and may be one they are deliberately filling.
-# REFUSING TO DELETE MUST NOT REFUSE TO RUN (#2408 review r3, P2).
+# A REFUSED LANE MUST NOT THEN BE USED (#2408 review r4, P1).
 #
-# This script runs `set -euo pipefail`, so a bare call returning 2 aborts the
-# lane before `xcodebuild` — turning "I will not delete through a symlink" into
-# "your tests do not run", which is a far worse answer to an unusual but legal
-# layout. An `if` condition suppresses errexit for the call, the same mechanism
-# #2401 needed for its judge.
+# The previous round made the refusal non-fatal so an unusual-but-legal layout
+# could still run its tests. That was right and it stopped one line too early: the
+# rejected path was then used anyway, and `run_lane` does `rm -rf "$bundle"` on
+# `$LOG_DIR/…xcresult` — so a planted link or mount still got deleted through, at
+# a different line. **My fix for the last round's P2 opened this P1**, which is
+# the fix-the-path-you-were-reading shape one more time: I asked whether refusing
+# should abort, and never asked what happens NEXT to the path I had refused.
+#
+# So an unsafe default lane is neither used nor fatal — the run moves to a
+# directory outside the tree, says so, and proceeds. Nothing is deleted through a
+# link or a mount, and the tests still run.
 if [ "$USING_DEFAULT_LOG_DIR" = "1" ]; then
   if ! ew_reset_lane_dir "$PROJECT_ROOT" "$LOG_DIR"; then
-    echo "==> not clearing this lane; a recycled pid may leave stale receipts here" >&2
+    LOG_DIR="$(mktemp -d "${TMPDIR:-/tmp}/ew-lane.XXXXXX")"
+    USING_DEFAULT_LOG_DIR=0
+    echo "==> build/ or build/lanes/ is a symlink or mount point; this lane is writing to $LOG_DIR instead" >&2
+    echo "==> no stable build/latest-lane link and no retention while that is true" >&2
   fi
 fi
 mkdir -p "$LOG_DIR"   # absent on a clean checkout

--- a/scripts/xcode-test.sh
+++ b/scripts/xcode-test.sh
@@ -77,27 +77,9 @@ LOG_DIR="$(ew_resolve_log_dir "$PROJECT_ROOT" "$LOG_DIR")"
 # means clearing it, or a debug-only run inherits the previous occupant's Release
 # receipt (#2408 review r2). Never for an explicit `--log-dir`: that directory
 # belongs to the caller and may be one they are deliberately filling.
-# A REFUSED LANE MUST NOT THEN BE USED (#2408 review r4, P1).
-#
-# The previous round made the refusal non-fatal so an unusual-but-legal layout
-# could still run its tests. That was right and it stopped one line too early: the
-# rejected path was then used anyway, and `run_lane` does `rm -rf "$bundle"` on
-# `$LOG_DIR/…xcresult` — so a planted link or mount still got deleted through, at
-# a different line. **My fix for the last round's P2 opened this P1**, which is
-# the fix-the-path-you-were-reading shape one more time: I asked whether refusing
-# should abort, and never asked what happens NEXT to the path I had refused.
-#
-# So an unsafe default lane is neither used nor fatal — the run moves to a
-# directory outside the tree, says so, and proceeds. Nothing is deleted through a
-# link or a mount, and the tests still run.
-if [ "$USING_DEFAULT_LOG_DIR" = "1" ]; then
-  if ! ew_reset_lane_dir "$PROJECT_ROOT" "$LOG_DIR"; then
-    LOG_DIR="$(mktemp -d "${TMPDIR:-/tmp}/ew-lane.XXXXXX")"
-    USING_DEFAULT_LOG_DIR=0
-    echo "==> build/ or build/lanes/ is a symlink or mount point; this lane is writing to $LOG_DIR instead" >&2
-    echo "==> no stable build/latest-lane link and no retention while that is true" >&2
-  fi
-fi
+# NO RESET HERE ANY MORE (#2408 review r7). The lane name carries the SECOND as
+# well as the pid, so it cannot recur — two runs sharing both are the same
+# process. The take path has nothing to clear and does not delete.
 mkdir -p "$LOG_DIR"   # absent on a clean checkout
 APP_LOG_DIR="$LOG_DIR/app-logger"
 mkdir -p "$APP_LOG_DIR"

--- a/scripts/xcode-test.sh
+++ b/scripts/xcode-test.sh
@@ -70,10 +70,21 @@ cd "$PROJECT_ROOT"
 # Owner: scripts/lib/log-dir.sh, which has its own two-way suite. Creating the
 # directory is deliberately the caller's job — a resolver with a side effect
 # cannot be tested without one.
+USING_DEFAULT_LOG_DIR=0
+[ -z "$LOG_DIR" ] && USING_DEFAULT_LOG_DIR=1
 LOG_DIR="$(ew_resolve_log_dir "$PROJECT_ROOT" "$LOG_DIR")"
 mkdir -p "$LOG_DIR"   # absent on a clean checkout
 APP_LOG_DIR="$LOG_DIR/app-logger"
 mkdir -p "$APP_LOG_DIR"
+
+# Both owned by scripts/lib/log-dir.sh, which has its own two-way suite. Neither
+# runs for an explicit `--log-dir`: that caller asked for a durable receipt at an
+# address it already knows, and moving a shared pointer or pruning on its behalf
+# would make a battery's rows fight over it.
+if [ "$USING_DEFAULT_LOG_DIR" = "1" ]; then
+  ew_publish_latest_lane "$PROJECT_ROOT" "$LOG_DIR"
+  ew_prune_stale_lanes "$PROJECT_ROOT" "$LOG_DIR"
+fi
 
 # Generate the Xcode project (gitignored, never committed) — only when a
 # generation input actually changed (#2157 chunk C).

--- a/scripts/xcode-test.sh
+++ b/scripts/xcode-test.sh
@@ -73,6 +73,11 @@ cd "$PROJECT_ROOT"
 USING_DEFAULT_LOG_DIR=0
 [ -z "$LOG_DIR" ] && USING_DEFAULT_LOG_DIR=1
 LOG_DIR="$(ew_resolve_log_dir "$PROJECT_ROOT" "$LOG_DIR")"
+# A DEFAULT lane is named by pid, and pids recycle — so taking the directory
+# means clearing it, or a debug-only run inherits the previous occupant's Release
+# receipt (#2408 review r2). Never for an explicit `--log-dir`: that directory
+# belongs to the caller and may be one they are deliberately filling.
+[ "$USING_DEFAULT_LOG_DIR" = "1" ] && ew_reset_lane_dir "$PROJECT_ROOT" "$LOG_DIR"
 mkdir -p "$LOG_DIR"   # absent on a clean checkout
 APP_LOG_DIR="$LOG_DIR/app-logger"
 mkdir -p "$APP_LOG_DIR"


### PR DESCRIPTION
Closes #2396. Sibling of #2401 (shipped in #2407) — the other way a lane count lies.

## What was wrong

`ew_resolve_log_dir` returned `<project_root>/build` when the caller passed nothing, so every `xcode-test.sh` invocation that omitted `--log-dir` wrote the same file. Two lanes in ONE worktree corrupted each other's count: measured **2379** reported against the same log's own **6458 + 206**.

A flag every caller must REMEMBER fails on the run you most want to cite (`GR-PAVE-THE-ROAD`). The default is now `build/lanes/$$`.

## #2401 changed the failure CLASS, not merely its severity

`run_lane` now derives the RESULT BUNDLE from this directory too and removes it before the run, because xcodebuild refuses to overwrite one. The schedule-independent statement:

> **Two concurrent same-worktree lanes contend for one bundle path, and every interleaving is destructive** — one may delete a bundle the other is writing, or both may race to create the same path.

Before, they produced a wrong NUMBER, and reconciliation catches a wrong number. **A missing bundle is not a number to reconcile**, so the detector this repo already prescribes does not reach the new mode at all.

*(My first statement of this named the delete as THE mechanism. Codex marked it PARTIAL and was right — it is one schedule of several. The sentence above is what survives.)*

## The default looked immovable because of a false sentence in this file's own suite

It claimed `check-push-discipline.sh`'s freshness read expects `build/xcode-test-debug.log`. **That gate never names the file.** For app changes it reads the deployed and DerivedData dev-build artifacts (`:382-383`); for test changes the Debug xctest executable (`:403`), compared against `Tests/` (`:420`).

Swept for real consumers rather than recalled — the writer, that comment, and two lines of prose were the only namers, and the mutation battery already passes its own `--log-dir` per row. Replaced with what the gate actually reads rather than deleted, so the next reader inherits the verified version.

Highest-cost comment shape there is: its whole function was to stop the next reader checking, and it worked for as long as nobody did.

## Concurrency-isolated, not unique

The honest distinction: two concurrent processes cannot share a pid, which is the entire defect, while a LATER run may revisit a recycled one — harmless, because `tee` replaces the log and the bundle is deliberately replaced. Calling it *unique* would be a claim that fails the first time someone checks.

Plus a stable `build/latest-lane` for "the last lane I ran", and seven-day retention, because each lane now holds two logs and up to two bundles — unbounded growth would be a defect this change **introduces** rather than inherits.

## Both side-effecting halves moved into the lib

For the reason its own header already gives about the resolver: inline in `xcode-test.sh` they could only be exercised by running `xcodebuild`, so in practice they would never be tested at all — and **both of them delete or replace things**. The resolver stays side-effect free.

## Two defects the new rows found in themselves, neither reached by review

1. The rows were written with helpers this suite does not define. They printed `ok: command not found` to **stderr**, incremented nothing, and the suite ended **`PASS=11 FAIL=0`** — every new row invisible, verdict clean. A harness reporting a green it cannot see, in the file whose only job is to be believed about a path.

2. **The obvious guard for that has the identical defect.** bash runs `command_not_found_handle` **in a subshell**, so `FAIL=$((FAIL + 1))` inside it is discarded. Measured two-way on bash 5.3: the handler prints `F=1` and the caller then reads `F=0`. The first version PRINTED a failure line and left the verdict at `FAIL=0` — reporting without gating, which is exactly what it was written to prevent, one level down. The handler records to a FILE, which survives a subshell, and the count is folded in where it can reach the verdict.

## Evidence

**The binding proof is the defect itself: two concurrent default lanes in one worktree.**

```
lane A exit=0   ==> Debug lane executed 6 tests    verdict: PASS
lane B exit=0   ==> Debug lane executed 11 tests   verdict: PASS

build/lanes/5982/ -> app-logger xcode-test-debug.log xcode-test-debug.xcresult
build/lanes/5983/ -> app-logger xcode-test-debug.log xcode-test-debug.xcresult
build/xcode-test-debug.log: No such file or directory
```

Different counts, each correct for its own filter — neither summed the other's — and each lane kept its own bundle rather than deleting the other's.

Every new mechanism is mutation-controlled one row at a time: `mv -fh` → `mv -f` reddens only *"repointing replaces the link, never writes through it"*; dropping the in-use exclusion reddens only *"the lane in use is never pruned"*; dropping the age window reddens only *"a recent lane is kept"*; a nonexistent helper now gives `FAIL=1` and exit 1.

One row nearly did not work: **"two default invocations resolve apart" needs two real PROCESSES**, because `$$` is constant within one shell — a same-process comparison would have passed against a resolver that isolates nothing. A fixture too small to express its own question.

## Known limit, stated at the code

With two lanes started at once the stable link points at whichever **published last**, a coin flip. That is inherent to a single shared pointer and is not what this fixes — the lanes themselves no longer collide, which is the defect. A caller needing a specific address passes `--log-dir`, and neither the link nor the prune runs for one.

`.gitignore:103` already covers `build/`, so `build/lanes/` and the link need no new rule — verified with the real question, not by reading the pattern.

Suite **21/21**.

Lane: `Docs/dev-tooling` + `Code` (tracked `scripts/`), `mixed_pr: true`. Tier: MEDIUM — it changes where every local lane writes.
