### PR TITLE
fix(worker): the daily report's release lookup names what failed, and stops retrying what a retry cannot fix (#2411)

### DIFF
--- a/workers/daily-report/src/version-scorecard.js
+++ b/workers/daily-report/src/version-scorecard.js
@@ -221,7 +221,12 @@ function retryAfterMs(res) {
   const raw = res.headers?.get?.("retry-after");
   if (typeof raw !== "string" || !/^\d+$/.test(raw.trim())) return null;
   const ms = Number(raw.trim()) * 1000;
-  if (!Number.isSafeInteger(ms) || ms <= 0) return null;
+  // `>= 0`, not `> 0`. **`Retry-After: 0` IS A VALID DELTA-SECONDS VALUE** and it
+  // means "you may retry immediately" (#2415 review r4). Rejecting it threw away
+  // the CHEAPEST recovery available - no wait at all - and reported the section
+  // unavailable instead. The negative branch is unreachable given the `^\d+$`
+  // above and is kept as a floor, not as live logic.
+  if (!Number.isSafeInteger(ms) || ms < 0) return null;
   return ms;
 }
 

--- a/workers/daily-report/src/version-scorecard.js
+++ b/workers/daily-report/src/version-scorecard.js
@@ -185,6 +185,33 @@ function classifyGitHubStatus(res) {
   return res.headers?.get?.("x-ratelimit-remaining") === "0" ? "rate-limited" : "fatal";
 }
 
+/** A `Retry-After` we can actually honour, in MILLISECONDS, or null.
+ *
+ * **A SECONDARY RATE LIMIT IS NOT THE SAME ANIMAL AS THE HOURLY ONE (#2415 review
+ * r2).** The primary limit resets at the top of an hour and no request can wait
+ * for it, which is why this change stopped retrying. GitHub's SECONDARY limit is
+ * different: it carries `Retry-After`, and the value can be a second or two - a
+ * wait we can afford, and the only case where a rate limit is recoverable inside
+ * one request. Refusing it threw away a recovery the server had explicitly
+ * offered.
+ *
+ * Two ways this returns null, and they are different situations rather than one:
+ * the header is ABSENT or unparseable, and the wait is LONGER than the budget.
+ * The caller reports which, because "GitHub did not say" and "GitHub said 900
+ * seconds" send a reader to different places.
+ *
+ * Integer seconds only. `Retry-After` also has an HTTP-date form; GitHub sends
+ * seconds here, and a date we half-parsed would be a guess wearing a
+ * measurement's clothes. An unrecognised value is reported as unusable, never
+ * silently treated as absent. */
+function retryAfterMs(res) {
+  const raw = res.headers?.get?.("retry-after");
+  if (typeof raw !== "string" || !/^\d+$/.test(raw.trim())) return null;
+  const ms = Number(raw.trim()) * 1000;
+  if (!Number.isSafeInteger(ms) || ms <= 0) return null;
+  return ms;
+}
+
 /** How long until the rate-limit window resets, in SECONDS FROM NOW.
  *
  * Deliberately not a formatted instant. The first version returned
@@ -206,12 +233,25 @@ function rateLimitResetInSeconds(res, nowFn = Date.now) {
   return delta > 0 ? delta : null;
 }
 
+/** ONE waiting budget for this lookup, and everything that waits derives from it.
+ *
+ * The delays below and the `Retry-After` ceiling started as three separate
+ * numbers I had chosen and nothing had measured (#2415 review r1, my own
+ * question). Reducing them to one leaves one thing to justify: **how long may a
+ * daily report's release lookup block a request somebody is waiting on.** The
+ * ping workflow's `curl` sets no `--max-time` and the job budget is hours, so the
+ * real constraint is that a human reading a failed run should not be waiting on
+ * arithmetic - 2 seconds is beneath notice beside the PostHog, Sentry and Discord
+ * work the same run already does.
+ *
+ * Stated so the next reader can disagree with the number rather than reverse-
+ * engineer it: nothing measured 2000. It is a ceiling chosen to be small.
+ */
+const GITHUB_MAX_WAIT_MS = 2000;
+
 /** Backoff between RETRYABLE attempts. Was `0`, which made the retry loop three
  * requests inside a few milliseconds - the shape of a retry with none of the
- * effect. Deliberately small: the founder's `curl` is waiting on this request,
- * and ~2s total is what a connection reset or a 5xx blip needs. A rate limit
- * needs minutes and is no longer retried at all, so nothing here is trying to
- * outwait one. */
+ * effect. Sums to exactly the budget above. */
 const GITHUB_RETRY_DELAYS_MS = [500, 1500];
 
 /** OPTIONAL authentication, matching what `workers/weekly-digest` already does
@@ -266,6 +306,10 @@ async function fetchPublishedReleases(env, { fetchFn = fetch, sleepFn = sleep, n
   }
 
   let lastStatus = null;
+  // ONCE, not per attempt. A server that keeps answering "wait one second" would
+  // otherwise be obeyed for as many attempts as the loop has, turning a bounded
+  // budget into a multiple of it.
+  let honouredRetryAfter = false;
   for (let attempt = 1; attempt <= GITHUB_MAX_ATTEMPTS; attempt += 1) {
     let res;
     try {
@@ -367,13 +411,37 @@ async function fetchPublishedReleases(env, { fetchFn = fetch, sleepFn = sleep, n
       });
     }
     if (disposition === "rate-limited") {
+      // A SHORT `Retry-After` IS A RECOVERY THE SERVER OFFERED, so take it once
+      // (#2415 review r2). Only once, and only inside the budget: this is the
+      // secondary-limit case, where the wait is seconds. The primary hourly limit
+      // carries no such header and still fails immediately, which is the whole
+      // point of not retrying it.
+      const waitMs = retryAfterMs(res);
+      if (waitMs !== null && waitMs <= GITHUB_MAX_WAIT_MS && !honouredRetryAfter) {
+        honouredRetryAfter = true;
+        lastStatus = res.status;
+        await sleepFn(waitMs);
+        continue;
+      }
       // Reported at once rather than after two more refusals. The reset instant
       // is the fact that decides what to do about it, so it is in the message
       // and not only in a header nobody will see.
       const resetIn = rateLimitResetInSeconds(res, nowFn);
+      // Three facts, each of which sends a reader somewhere different: the
+      // status, when the window reopens, and whether the server offered a wait
+      // we could not afford. A `Retry-After` that was present and too long is
+      // NOT the same situation as one that was absent - the first says GitHub
+      // knows and we declined, the second says nobody knows.
+      const declined =
+        waitMs !== null && waitMs > GITHUB_MAX_WAIT_MS
+          ? `, Retry-After ${waitMs / 1000}s exceeds the ${GITHUB_MAX_WAIT_MS / 1000}s budget`
+          : honouredRetryAfter
+            ? ", already waited once on Retry-After"
+            : "";
       throw new ReleaseResolutionError(
         `GitHub releases rate-limited: HTTP ${lastStatus}` +
           (resetIn === null ? ", reset not reported" : `, resets in ${resetIn}s`) +
+          declined +
           " (not retried: the window is far longer than a request can wait)",
         { transient: true }
       );

--- a/workers/daily-report/src/version-scorecard.js
+++ b/workers/daily-report/src/version-scorecard.js
@@ -162,22 +162,93 @@ export function compareVersions(a, b) {
   return a1 - b1 || a2 - b2 || a3 - b3;
 }
 
-/** A 403 is transient ONLY when GitHub says the rate limit is exhausted.
- * Treating every forbidden response as transient would retry a genuine
- * permission or configuration failure three times and then report it as a
- * temporary blip. */
-function isTransientGitHubStatus(res) {
+/** THREE outcomes, because "transient" was hiding two different things (#2411).
+ *
+ * A 403 is temporary ONLY when GitHub says the rate limit is exhausted; treating
+ * every forbidden response as temporary would retry a genuine permission or
+ * configuration failure and then report it as a blip. That part is unchanged.
+ *
+ * What changed is that a rate limit is no longer RETRIED. Its window resets at
+ * the top of an hour and a Worker cannot wait that long, so the two extra
+ * requests spend more of an already-exhausted budget and fail anyway - three
+ * attempts inside a few milliseconds is arithmetically one attempt against
+ * anything with a recovery time. It stays TEMPORARY, so the section still
+ * degrades rather than killing the run; only the retry is dropped.
+ *
+ * Returns "retry" | "rate-limited" | "fatal".
+ */
+function classifyGitHubStatus(res) {
   const status = res.status;
-  if (status === 429 || status >= 500) return true;
-  if (status !== 403) return false;
-  const remaining = res.headers?.get?.("x-ratelimit-remaining");
-  return remaining === "0";
+  if (status >= 500) return "retry";
+  if (status === 429) return "rate-limited";
+  if (status !== 403) return "fatal";
+  return res.headers?.get?.("x-ratelimit-remaining") === "0" ? "rate-limited" : "fatal";
+}
+
+/** How long until the rate-limit window resets, in SECONDS FROM NOW.
+ *
+ * Deliberately not a formatted instant. The first version returned
+ * `new Date(ms).toISOString()` and the suite's source guardrail refused it -
+ * correctly, because that guard exists to keep `parseGitHubTimestamp` the ONLY
+ * date authority in this file, and a second one would drift. Seconds-from-now
+ * needs no date construction, and it is the more useful number in a log anyway:
+ * an operator reading the failure wants "how long", not a timestamp to subtract.
+ *
+ * `x-ratelimit-reset` is unix SECONDS. Absent, unparseable, or already past
+ * yields null rather than a guess - an invented reset is worse than an unknown
+ * one, because the next reader plans around it. */
+function rateLimitResetInSeconds(res, nowFn = Date.now) {
+  const raw = res.headers?.get?.("x-ratelimit-reset");
+  if (typeof raw !== "string" || !/^\d+$/.test(raw)) return null;
+  const resetSec = Number(raw);
+  if (!Number.isSafeInteger(resetSec) || resetSec <= 0) return null;
+  const delta = resetSec - Math.floor(nowFn() / 1000);
+  return delta > 0 ? delta : null;
+}
+
+/** Backoff between RETRYABLE attempts. Was `0`, which made the retry loop three
+ * requests inside a few milliseconds - the shape of a retry with none of the
+ * effect. Deliberately small: the founder's `curl` is waiting on this request,
+ * and ~2s total is what a connection reset or a 5xx blip needs. A rate limit
+ * needs minutes and is no longer retried at all, so nothing here is trying to
+ * outwait one. */
+const GITHUB_RETRY_DELAYS_MS = [500, 1500];
+
+/** OPTIONAL authentication, matching what `workers/weekly-digest` already does
+ * (`src/index.js`, its `fetchGitHubDownloads`).
+ *
+ * A token is not needed to READ a public repo - authorization was never the
+ * question. It is what raises the RATE LIMIT: unauthenticated GitHub allows 60
+ * requests an hour PER IP (measured, `x-ratelimit-limit: 60`), and a Cloudflare
+ * Worker's outbound requests leave from a shared egress pool, so that ceiling is
+ * shared with every other tenant on the same address. Our own usage is one
+ * request a day, so nothing about our call rate reaches it.
+ *
+ * `wrangler.toml` claimed this lookup "needs no token and no secret - the same
+ * unauthenticated pattern workers/weekly-digest already uses". The second half
+ * was false: the sibling has had this header since it was written. Corrected
+ * there rather than deleted.
+ *
+ * INERT until the secret exists, which is deliberate. This is the code half of
+ * #2411; installing `GITHUB_TOKEN` is a separate, founder-owned action, and the
+ * diagnostic added in this same change is what will say whether it is needed. */
+function githubHeaders(env) {
+  const headers = { "User-Agent": USER_AGENT, Accept: "application/vnd.github+json" };
+  const token = env?.GITHUB_TOKEN;
+  // A blank or whitespace-only secret is ABSENT, not a credential. Sending
+  // `Authorization: token ` makes GitHub answer 401, which classifies fatal and
+  // would turn a missing secret into a whole-run failure - the loud-but-wrong
+  // direction, from a value nobody meant to set.
+  if (typeof token === "string" && token.trim() !== "") {
+    headers.Authorization = `token ${token.trim()}`;
+  }
+  return headers;
 }
 
 /** Fetches published, non-draft, non-prerelease releases. Newest is decided by
  * `published_at`, never by the API's array order (which is creation order and
  * can disagree after a re-publish). */
-async function fetchPublishedReleases(env, { fetchFn = fetch, sleepFn = sleep } = {}) {
+async function fetchPublishedReleases(env, { fetchFn = fetch, sleepFn = sleep, nowFn = Date.now } = {}) {
   // Checked BEFORE any request: configuration is not a blip, and must never
   // consume retries or look transient. Validated as a real owner/repo slug
   // rather than merely truthy - a value like "EnviousWispr" would otherwise
@@ -199,7 +270,7 @@ async function fetchPublishedReleases(env, { fetchFn = fetch, sleepFn = sleep } 
     let res;
     try {
       res = await fetchFn(`${GITHUB_API}/repos/${repo}/releases`, {
-        headers: { "User-Agent": USER_AGENT, Accept: "application/vnd.github+json" },
+        headers: githubHeaders(env),
       });
     } catch (_) {
       // A network-level rejection (DNS, reset, abort) never produces a response
@@ -209,7 +280,7 @@ async function fetchPublishedReleases(env, { fetchFn = fetch, sleepFn = sleep } 
       // original error: it can carry a URL or body.
       lastStatus = "network error";
       if (attempt < GITHUB_MAX_ATTEMPTS) {
-        await sleepFn(0);
+        await sleepFn(GITHUB_RETRY_DELAYS_MS[attempt - 1]);
         continue;
       }
       break;
@@ -289,12 +360,25 @@ async function fetchPublishedReleases(env, { fetchFn = fetch, sleepFn = sleep } 
       }
     }
 
-    if (!isTransientGitHubStatus(res)) {
+    const disposition = classifyGitHubStatus(res);
+    if (disposition === "fatal") {
       throw new ReleaseResolutionError(`GitHub releases request failed: HTTP ${lastStatus}`, {
         transient: false,
       });
     }
-    if (attempt < GITHUB_MAX_ATTEMPTS) await sleepFn(0);
+    if (disposition === "rate-limited") {
+      // Reported at once rather than after two more refusals. The reset instant
+      // is the fact that decides what to do about it, so it is in the message
+      // and not only in a header nobody will see.
+      const resetIn = rateLimitResetInSeconds(res, nowFn);
+      throw new ReleaseResolutionError(
+        `GitHub releases rate-limited: HTTP ${lastStatus}` +
+          (resetIn === null ? ", reset not reported" : `, resets in ${resetIn}s`) +
+          " (not retried: the window is far longer than a request can wait)",
+        { transient: true }
+      );
+    }
+    if (attempt < GITHUB_MAX_ATTEMPTS) await sleepFn(GITHUB_RETRY_DELAYS_MS[attempt - 1]);
   }
 
   throw new ReleaseResolutionError(
@@ -1508,13 +1592,29 @@ const SCORECARD_QUERIES = [
 ];
 
 /** Classification is by TYPE, never by message text: a substring match on an
- * error message is a contract nobody declared and every reword breaks. */
+ * error message is a contract nobody declared and every reword breaks. That is
+ * unchanged and is why the `instanceof` below is the only thing deciding
+ * severity.
+ *
+ * THE MESSAGE NOW CARRIES THE REASON, WHICH IT DID NOT (#2411). The fixed
+ * strings alone cost five days of failures nobody could attribute: the worker
+ * knew the status - `HTTP 403`, `HTTP 503`, `network error` - and this boundary
+ * replaced it with "release resolution exhausted its retries", putting the
+ * original in `cause` where nothing reads it. The fetch handler returns
+ * `err.message` (index.js), the ping workflow prints that body, and the one fact
+ * that decides whether this is rate limiting, an outage or a shape change was
+ * discarded one line before it would have been printed.
+ *
+ * Safe to print: every message these paths produce is built from a status code,
+ * an attempt count, a reset timestamp, the public repo slug or a release tag.
+ * None carries a credential or a URL, and the workflow masks URLs regardless. */
 function releaseFailure(reason) {
   const transient = reason instanceof ReleaseResolutionError && reason.transient === true;
+  const detail = reason instanceof Error && reason.message ? `: ${reason.message}` : "";
   return new ScorecardSectionError(
-    transient
+    (transient
       ? "release resolution exhausted its retries"
-      : "release resolution failed its contract",
+      : "release resolution failed its contract") + detail,
     { wholeRun: !transient, cause: reason }
   );
 }

--- a/workers/daily-report/src/version-scorecard.js
+++ b/workers/daily-report/src/version-scorecard.js
@@ -182,6 +182,19 @@ function classifyGitHubStatus(res) {
   if (status >= 500) return "retry";
   if (status === 429) return "rate-limited";
   if (status !== 403) return "fatal";
+  // A SECONDARY RATE LIMIT CAN ARRIVE AS 403 WITH `x-ratelimit-remaining`
+  // NONZERO (#2415 review r3). Keying only on that header called it FATAL, which
+  // is the worst outcome available here: fatal means `wholeRun`, so the founder
+  // loses the entire report - not just the scorecard - over a condition that
+  // resolves in seconds, and the `Retry-After` recovery never runs.
+  //
+  // `Retry-After` is the precise discriminator rather than a widening: GitHub
+  // sends it for rate limiting and NOT for a genuine permission failure, so a
+  // 403 carrying it is the server saying "slow down", and a 403 without it is
+  // still "you may not" and still fatal. Presence is what is tested, not
+  // usability - an unparseable value degrades to reported-and-not-retried, never
+  // to killing the run.
+  if (typeof res.headers?.get?.("retry-after") === "string") return "rate-limited";
   return res.headers?.get?.("x-ratelimit-remaining") === "0" ? "rate-limited" : "fatal";
 }
 

--- a/workers/daily-report/src/version-scorecard.js
+++ b/workers/daily-report/src/version-scorecard.js
@@ -1611,9 +1611,20 @@ const SCORECARD_QUERIES = [
 function releaseFailure(reason) {
   const transient = reason instanceof ReleaseResolutionError && reason.transient === true;
   const detail = reason instanceof Error && reason.message ? `: ${reason.message}` : "";
+  // THE PREFIX MUST NOT CLAIM A MECHANISM (#2415 review r1). It read "exhausted
+  // its retries", which was true when every temporary failure was retried three
+  // times - and this same change made a rate limit fail after ONE attempt, so the
+  // label started asserting a retry loop that no longer ran. A fixed string
+  // describing behaviour it does not control is the comment-that-retires-a-check
+  // shape wearing an error message.
+  //
+  // Deriving two prefixes from the cause would be a SECOND classifier keyed on
+  // the message, which the note above rejects. So the prefix names only what
+  // failed and how severe it is; the mechanism lives in `detail`, which comes
+  // from the code that actually performed it.
   return new ScorecardSectionError(
     (transient
-      ? "release resolution exhausted its retries"
+      ? "release resolution failed temporarily"
       : "release resolution failed its contract") + detail,
     { wholeRun: !transient, cause: reason }
   );

--- a/workers/daily-report/test/report.test.js
+++ b/workers/daily-report/test/report.test.js
@@ -2211,6 +2211,30 @@ test("resolveReleases: a SHORT Retry-After is honoured once; a long one is decli
     "a fractional Retry-After is not a wait we honour"
   );
   assert.equal(fracCalls, 1, "a fractional Retry-After is not waited on");
+
+  // 6. A SECONDARY LIMIT CAN ARRIVE AS 403 WITH `x-ratelimit-remaining` NONZERO
+  // (#2415 review r3). Keying only on that header called it FATAL - and fatal
+  // means `wholeRun`, so the founder loses the ENTIRE report over a condition
+  // that resolves in seconds. Strictly worse than the defect this PR started on.
+  let secCalls = 0;
+  const secSleeps = [];
+  const secOut = await resolveReleases({ GITHUB_REPO: "o/r" }, [usage("2.4.1", 1)], {
+    windowEndExclusive: "2026-07-29",
+    fetchFn: async () => {
+      secCalls += 1;
+      if (secCalls === 1) {
+        return ghResponse(403, null, {
+          headers: { "retry-after": "1", "x-ratelimit-remaining": "57" },
+        });
+      }
+      return ghResponse(200, [release("v2.4.1", "2026-07-24T00:00:00Z")]);
+    },
+    sleepFn: async (ms) => secSleeps.push(ms),
+    nowFn,
+  });
+  assert.equal(secCalls, 2, "a 403 carrying Retry-After is a rate limit, and recovers");
+  assert.deepEqual(secSleeps, [1000]);
+  assert.ok(secOut.releases.length > 0);
 });
 
 test("resolveReleases: a RATE LIMIT is temporary but NOT retried, and says when it resets", async () => {
@@ -2280,6 +2304,10 @@ test("resolveReleases: a non-transient 4xx fails loud after ONE attempt", async 
     [404, {}],
     // A forbidden response that is NOT rate-limit exhaustion is a real failure,
     // not a blip - retrying it would report a permission problem as temporary.
+    // THE REJECTED TWIN of the Retry-After widening (#2415 review r3): a 403
+    // WITHOUT that header is still "you may not", not "slow down". GitHub does
+    // not send Retry-After for a permission failure, which is what makes the
+    // header a discriminator rather than a loosening.
     [403, { "x-ratelimit-remaining": "57" }],
   ]) {
     let attempts = 0;

--- a/workers/daily-report/test/report.test.js
+++ b/workers/daily-report/test/report.test.js
@@ -2093,6 +2093,126 @@ test("a rate limit's 500 body says WHY, and never claims a retry loop that did n
   }
 });
 
+test("resolveReleases: a SHORT Retry-After is honoured once; a long one is declined out loud", async () => {
+  // #2415 review r2. The primary hourly limit resets at the top of an hour and
+  // no request can wait for it - that is why this change stopped retrying. The
+  // SECONDARY limit is a different animal: it carries `Retry-After`, the value
+  // can be a second, and refusing it threw away a recovery the server offered.
+  const NOW_MS = 1_787_670_000_000;
+  const nowFn = () => NOW_MS;
+  const resetAt = String(Math.floor(NOW_MS / 1000) + 1800);
+
+  // 1. A one-second secondary limit RECOVERS, and the request succeeds.
+  let calls = 0;
+  const sleeps = [];
+  const out = await resolveReleases({ GITHUB_REPO: "o/r" }, [usage("2.4.1", 1)], {
+    windowEndExclusive: "2026-07-29",
+    fetchFn: async () => {
+      calls += 1;
+      if (calls === 1) return ghResponse(429, null, { headers: { "retry-after": "1" } });
+      return ghResponse(200, [release("v2.4.1", "2026-07-24T00:00:00Z")]);
+    },
+    sleepFn: async (ms) => sleeps.push(ms),
+    nowFn,
+  });
+  assert.equal(calls, 2, "the offered wait is taken and the request retried");
+  assert.deepEqual(sleeps, [1000], "it waits exactly what the server asked for");
+  assert.ok(out.releases.length > 0, "and the lookup succeeds");
+
+  // 2. ONCE, not per attempt. A server that keeps answering "wait one second"
+  // would otherwise turn a bounded budget into a multiple of it.
+  let repeat = 0;
+  const repeatSleeps = [];
+  await assert.rejects(
+    () =>
+      resolveReleases({ GITHUB_REPO: "o/r" }, [], {
+        windowEndExclusive: "2026-07-29",
+        fetchFn: async () => {
+          repeat += 1;
+          return ghResponse(429, null, { headers: { "retry-after": "1", "x-ratelimit-reset": resetAt } });
+        },
+        sleepFn: async (ms) => repeatSleeps.push(ms),
+        nowFn,
+      }),
+    (err) =>
+      err instanceof ReleaseResolutionError &&
+      err.transient === true &&
+      /already waited once on Retry-After/.test(err.message),
+    "a repeated Retry-After is obeyed once"
+  );
+  assert.equal(repeat, 2, "two requests: the original and the one honoured wait");
+  assert.deepEqual(repeatSleeps, [1000]);
+
+  // 3. A wait longer than the budget is DECLINED, and the message says so.
+  // "GitHub said 900 seconds" and "GitHub did not say" send a reader to
+  // different places, so they must not collapse into one sentence.
+  let longCalls = 0;
+  await assert.rejects(
+    () =>
+      resolveReleases({ GITHUB_REPO: "o/r" }, [], {
+        windowEndExclusive: "2026-07-29",
+        fetchFn: async () => {
+          longCalls += 1;
+          return ghResponse(429, null, { headers: { "retry-after": "900", "x-ratelimit-reset": resetAt } });
+        },
+        sleepFn: async () => {},
+        nowFn,
+      }),
+    (err) =>
+      err instanceof ReleaseResolutionError &&
+      /Retry-After 900s exceeds the 2s budget/.test(err.message),
+    "a long Retry-After is named, not silently ignored"
+  );
+  assert.equal(longCalls, 1, "and it is not waited on");
+
+  // 4. `Retry-After` also has an HTTP-date form. GitHub sends seconds here, and
+  // a date we half-parsed would be a guess wearing a measurement's clothes - so
+  // it reads as no usable wait rather than as a number.
+  let dateCalls = 0;
+  await assert.rejects(
+    () =>
+      resolveReleases({ GITHUB_REPO: "o/r" }, [], {
+        windowEndExclusive: "2026-07-29",
+        fetchFn: async () => {
+          dateCalls += 1;
+          return ghResponse(429, null, {
+            headers: { "retry-after": "Wed, 21 Oct 2026 07:28:00 GMT", "x-ratelimit-reset": resetAt },
+          });
+        },
+        sleepFn: async () => {},
+        nowFn,
+      }),
+    (err) => err instanceof ReleaseResolutionError && err.transient === true,
+    "an HTTP-date Retry-After is not parsed as a number"
+  );
+  assert.equal(dateCalls, 1, "an unusable Retry-After is not waited on");
+
+  // 5. A FRACTIONAL value, and this row exists because a mutant found that
+  // nothing else needed the digit check: an HTTP-date already dies at
+  // `Number.isSafeInteger`, so dropping the regex changed nothing observable
+  // there - two mechanisms covering one outcome. `1.5` is the input where the
+  // regex does unique work: without it, `Number("1.5") * 1000` is a safe integer
+  // and a fractional header would be honoured as a real wait.
+  let fracCalls = 0;
+  await assert.rejects(
+    () =>
+      resolveReleases({ GITHUB_REPO: "o/r" }, [], {
+        windowEndExclusive: "2026-07-29",
+        fetchFn: async () => {
+          fracCalls += 1;
+          return ghResponse(429, null, {
+            headers: { "retry-after": "1.5", "x-ratelimit-reset": resetAt },
+          });
+        },
+        sleepFn: async () => {},
+        nowFn,
+      }),
+    (err) => err instanceof ReleaseResolutionError && err.transient === true,
+    "a fractional Retry-After is not a wait we honour"
+  );
+  assert.equal(fracCalls, 1, "a fractional Retry-After is not waited on");
+});
+
 test("resolveReleases: a RATE LIMIT is temporary but NOT retried, and says when it resets", async () => {
   // #2411. This used to retry three times like any other transient status. The
   // window resets at the top of an hour and a request cannot wait that long, so

--- a/workers/daily-report/test/report.test.js
+++ b/workers/daily-report/test/report.test.js
@@ -2235,6 +2235,27 @@ test("resolveReleases: a SHORT Retry-After is honoured once; a long one is decli
   assert.equal(secCalls, 2, "a 403 carrying Retry-After is a rate limit, and recovers");
   assert.deepEqual(secSleeps, [1000]);
   assert.ok(secOut.releases.length > 0);
+
+  // 7. `Retry-After: 0` is a VALID delta-seconds value meaning "retry now"
+  // (#2415 review r4). A `> 0` test rejected it and threw away the cheapest
+  // recovery there is - no wait at all - reporting the section unavailable
+  // instead. The row asserts the retry happens AND that the wait is zero, since
+  // "recovered" alone would also be true of a version that slept a default.
+  let zeroCalls = 0;
+  const zeroSleeps = [];
+  const zeroOut = await resolveReleases({ GITHUB_REPO: "o/r" }, [usage("2.4.1", 1)], {
+    windowEndExclusive: "2026-07-29",
+    fetchFn: async () => {
+      zeroCalls += 1;
+      if (zeroCalls === 1) return ghResponse(429, null, { headers: { "retry-after": "0" } });
+      return ghResponse(200, [release("v2.4.1", "2026-07-24T00:00:00Z")]);
+    },
+    sleepFn: async (ms) => zeroSleeps.push(ms),
+    nowFn,
+  });
+  assert.equal(zeroCalls, 2, "Retry-After: 0 is honoured, not discarded");
+  assert.deepEqual(zeroSleeps, [0], "and it waits for exactly no time");
+  assert.ok(zeroOut.releases.length > 0);
 });
 
 test("resolveReleases: a RATE LIMIT is temporary but NOT retried, and says when it resets", async () => {

--- a/workers/daily-report/test/report.test.js
+++ b/workers/daily-report/test/report.test.js
@@ -1889,6 +1889,43 @@ test("malformed tags, versions and usage rows are refused, never silently absorb
   }
 });
 
+test("resolveReleases: GITHUB_TOKEN is optional, and a blank one is ABSENT not a credential", async () => {
+  // #2411. A token is not needed to READ a public repo - it is what raises the
+  // rate limit from 60 requests an hour per shared IP to 5,000. Inert until the
+  // secret exists, which is the point: installing it is a separate action.
+  const sent = async (env) => {
+    let headers = null;
+    await resolveReleases(env, [usage("2.4.1", 1)], {
+      windowEndExclusive: "2026-07-29",
+      fetchFn: async (_url, init) => {
+        headers = init.headers;
+        return ghResponse(200, [release("v2.4.1", "2026-07-24T00:00:00Z")]);
+      },
+      sleepFn: async () => {},
+    });
+    return headers;
+  };
+
+  const none = await sent({ GITHUB_REPO: "o/r" });
+  assert.equal(none.Authorization, undefined, "no secret means no Authorization header");
+  assert.equal(none["User-Agent"], "EnviousWispr-Daily-Report", "the UA is unconditional");
+
+  const withToken = await sent({ GITHUB_REPO: "o/r", GITHUB_TOKEN: "ghp_example" });
+  assert.equal(withToken.Authorization, "token ghp_example");
+
+  // The rejected twin, and it is the one that would hurt: `Authorization: token `
+  // makes GitHub answer 401, which classifies FATAL and fails the whole run. An
+  // unset secret must never turn into a loud failure by way of an empty string.
+  for (const blank of ["", "   ", "\n"]) {
+    const h = await sent({ GITHUB_REPO: "o/r", GITHUB_TOKEN: blank });
+    assert.equal(h.Authorization, undefined, `a blank token (${JSON.stringify(blank)}) is absent`);
+  }
+  // A token with surrounding whitespace is a real secret someone pasted with a
+  // trailing newline - trimmed, not refused.
+  const padded = await sent({ GITHUB_REPO: "o/r", GITHUB_TOKEN: "  ghp_padded\n" });
+  assert.equal(padded.Authorization, "token ghp_padded");
+});
+
 test("resolveReleases: uses GITHUB_REPO + User-Agent, drops draft/prerelease, newest by published_at", async () => {
   let seenUrl = null;
   let seenUA = null;
@@ -1986,10 +2023,11 @@ test("resolveReleases: bad configuration and malformed release data fail loud, n
   );
 });
 
-test("resolveReleases: rate-limited 403, 429 and 5xx retry to exactly 3 attempts then signal transient", async () => {
+test("resolveReleases: a RETRYABLE failure takes 3 attempts with real backoff between them", async () => {
   // A network-level rejection produces no response to inspect, so without
   // explicit handling it escapes unretried AND unclassified.
   let netAttempts = 0;
+  const netSleeps = [];
   await assert.rejects(
     () =>
       resolveReleases({ GITHUB_REPO: "o/r" }, [], {
@@ -1998,33 +2036,97 @@ test("resolveReleases: rate-limited 403, 429 and 5xx retry to exactly 3 attempts
           netAttempts += 1;
           throw new TypeError("network failure");
         },
-        sleepFn: async () => {},
+        sleepFn: async (ms) => netSleeps.push(ms),
       }),
     (err) => err instanceof ReleaseResolutionError && err.transient === true,
     "network rejection"
   );
   assert.equal(netAttempts, 3, "a network rejection must retry to exactly 3 attempts");
+  // THE DELAYS MUST BE REAL AND GROWING (#2411). They were `0`, which is the
+  // shape of a retry with none of the effect: three requests inside a few
+  // milliseconds is arithmetically one attempt against anything with a recovery
+  // time. Asserting the VALUES, not merely that sleep was called - a call with 0
+  // is exactly the defect.
+  assert.deepEqual(netSleeps, [500, 1500], "network retries must back off");
 
-  for (const [status, headers] of [
-    [403, { "x-ratelimit-remaining": "0" }],
-    [429, {}],
-    [503, {}],
+  let attempts = 0;
+  const sleeps = [];
+  await assert.rejects(
+    () =>
+      resolveReleases({ GITHUB_REPO: "o/r" }, [], {
+        windowEndExclusive: "2026-07-29",
+        fetchFn: async () => {
+          attempts += 1;
+          return ghResponse(503, null, { headers: {} });
+        },
+        sleepFn: async (ms) => sleeps.push(ms),
+      }),
+    (err) => err instanceof ReleaseResolutionError && err.transient === true,
+    "status 503"
+  );
+  assert.equal(attempts, 3, "a 5xx must make exactly 3 attempts");
+  assert.deepEqual(sleeps, [500, 1500], "5xx retries must back off");
+});
+
+test("resolveReleases: a RATE LIMIT is temporary but NOT retried, and says when it resets", async () => {
+  // #2411. This used to retry three times like any other transient status. The
+  // window resets at the top of an hour and a request cannot wait that long, so
+  // the two extra attempts only spend more of an already-exhausted budget and
+  // fail anyway. It stays TEMPORARY - the section degrades, the run survives -
+  // and only the retry is dropped.
+  const NOW_MS = 1_787_670_000_000;
+  const nowFn = () => NOW_MS;
+  const resetAt = String(Math.floor(NOW_MS / 1000) + 1800);
+
+  for (const [label, status, headers] of [
+    ["primary limit", 403, { "x-ratelimit-remaining": "0", "x-ratelimit-reset": resetAt }],
+    ["secondary limit", 429, { "x-ratelimit-reset": resetAt }],
   ]) {
     let attempts = 0;
+    const sleeps = [];
     await assert.rejects(
       () =>
         resolveReleases({ GITHUB_REPO: "o/r" }, [], {
           windowEndExclusive: "2026-07-29",
-        fetchFn: async () => {
+          fetchFn: async () => {
             attempts += 1;
             return ghResponse(status, null, { headers });
           },
-          sleepFn: async () => {},
+          sleepFn: async (ms) => sleeps.push(ms),
+          nowFn,
         }),
-      (err) => err instanceof ReleaseResolutionError && err.transient === true,
-      `status ${status}`
+      (err) =>
+        err instanceof ReleaseResolutionError &&
+        err.transient === true &&
+        /rate-limited/.test(err.message) &&
+        /resets in 1800s/.test(err.message),
+      label
     );
-    assert.equal(attempts, 3, `status ${status} must make exactly 3 attempts`);
+    assert.equal(attempts, 1, `${label} must not retry`);
+    assert.deepEqual(sleeps, [], `${label} must not sleep`);
+  }
+
+  // A reset we cannot read is reported as unknown, never guessed: the next
+  // reader plans around whatever this says.
+  for (const [label, headers] of [
+    ["absent", { "x-ratelimit-remaining": "0" }],
+    ["not a number", { "x-ratelimit-remaining": "0", "x-ratelimit-reset": "soon" }],
+    ["already past", { "x-ratelimit-remaining": "0", "x-ratelimit-reset": "1" }],
+  ]) {
+    await assert.rejects(
+      () =>
+        resolveReleases({ GITHUB_REPO: "o/r" }, [], {
+          windowEndExclusive: "2026-07-29",
+          fetchFn: async () => ghResponse(403, null, { headers }),
+          sleepFn: async () => {},
+          nowFn,
+        }),
+      (err) =>
+        err instanceof ReleaseResolutionError &&
+        err.transient === true &&
+        /reset not reported/.test(err.message),
+      `reset ${label}`
+    );
   }
 });
 
@@ -3462,6 +3564,15 @@ test("exhausted TRANSIENT release resolution loses only the scorecard, and never
   try {
     const res = await trigger("&date=2026-07-17");
     assert.equal(res.status, 500);
+    // THE 500 BODY MUST NAME WHAT FAILED (#2411). It read only "release
+    // resolution exhausted its retries" for five days of failures nobody could
+    // attribute: the worker knew the status, and this boundary replaced it with
+    // a fixed string and put the original in `cause`, where nothing reads it.
+    // The trigger's body is the only channel the reason reaches a human through.
+    const body = await res.text();
+    assert.match(body, /release resolution exhausted its retries/,
+      "the classification survives");
+    assert.match(body, /HTTP 503/, "and it now carries the status that caused it");
     assert.equal(mock.requests.filter((u) => u.startsWith(GITHUB_HOST)).length, 3,
       "three attempts, then give up");
     assert.equal(mock.discordPayloads.length, 1);

--- a/workers/daily-report/test/report.test.js
+++ b/workers/daily-report/test/report.test.js
@@ -2068,6 +2068,31 @@ test("resolveReleases: a RETRYABLE failure takes 3 attempts with real backoff be
   assert.deepEqual(sleeps, [500, 1500], "5xx retries must back off");
 });
 
+test("a rate limit's 500 body says WHY, and never claims a retry loop that did not run", async () => {
+  // #2415 review r1. The section prefix used to read "exhausted its retries",
+  // true while every temporary failure was retried three times - and false the
+  // moment a rate limit started failing after ONE attempt, which is what this
+  // same change did. The body a human reads is the only place that shows.
+  const mock = mockPostHog({ github: 429 });
+  try {
+    const res = await trigger("&date=2026-07-17");
+    assert.equal(res.status, 500);
+    const body = await res.text();
+    assert.match(body, /rate-limited/, "the body names the mechanism");
+    assert.doesNotMatch(body, /exhausted its retries/,
+      "and does not claim a retry loop that never ran");
+    assert.equal(mock.requests.filter((u) => u.startsWith(GITHUB_HOST)).length, 1,
+      "one attempt, because retrying a rate limit cannot help");
+    // Still only the SECTION: a rate limit must not cost the adoption numbers.
+    assert.equal(mock.discordPayloads.length, 1);
+    const [adoption, scorecard] = mock.discordPayloads[0].embeds;
+    assert.match(adoption.description, /Total users:/);
+    assert.match(scorecard.title, /unavailable today/);
+  } finally {
+    mock.restore();
+  }
+});
+
 test("resolveReleases: a RATE LIMIT is temporary but NOT retried, and says when it resets", async () => {
   // #2411. This used to retry three times like any other transient status. The
   // window resets at the top of an hour and a request cannot wait that long, so
@@ -3570,8 +3595,14 @@ test("exhausted TRANSIENT release resolution loses only the scorecard, and never
     // a fixed string and put the original in `cause`, where nothing reads it.
     // The trigger's body is the only channel the reason reaches a human through.
     const body = await res.text();
-    assert.match(body, /release resolution exhausted its retries/,
+    assert.match(body, /release resolution failed temporarily/,
       "the classification survives");
+    // The prefix must not claim a MECHANISM. It said "exhausted its retries",
+    // which this same change made false for a rate limit - one attempt, no loop
+    // (#2415 review r1). A label asserting behaviour it does not control drifts
+    // the moment that behaviour changes, and it changed in the same commit.
+    assert.doesNotMatch(body, /exhausted its retries/,
+      "the prefix does not assert a retry loop it does not control");
     assert.match(body, /HTTP 503/, "and it now carries the status that caused it");
     assert.equal(mock.requests.filter((u) => u.startsWith(GITHUB_HOST)).length, 3,
       "three attempts, then give up");

--- a/workers/daily-report/wrangler.toml
+++ b/workers/daily-report/wrangler.toml
@@ -9,8 +9,15 @@ compatibility_date = "2026-07-09"
 
 [vars]
 POSTHOG_PROJECT_ID = "354235"
-# Public repo, so the version scorecard's release lookup needs no token and no
-# secret - the same unauthenticated pattern workers/weekly-digest already uses.
+# The version scorecard's release lookup. Public repo, so no token is needed to
+# READ it; a token is what raises the RATE LIMIT, and the lookup sends one when
+# GITHUB_TOKEN is present (#2411).
+#
+# The line this replaces said the lookup needs no secret, "the same
+# unauthenticated pattern workers/weekly-digest already uses". The second half
+# was false - that worker has sent an optional Authorization header since it was
+# written - and the sentence is why nobody looked at the limit for five days of
+# failures.
 GITHUB_REPO = "saurabhav88/EnviousWispr"
 # Sentry section (#1965). Identifiers only, no credential.
 SENTRY_ORG = "envious-labs-llc"
@@ -23,6 +30,13 @@ SENTRY_PROJECT_SLUG = "enviouswispr"
 #   TRIGGER_SECRET            - gates the public `fetch` trigger; the GitHub Action sends it as
 #                               the `x-trigger-secret` header (the workers.dev URL is public, so
 #                               the trigger fails closed without it)
+#   GITHUB_TOKEN              - OPTIONAL (#2411). Absent, the release lookup is
+#     unauthenticated and shares a 60-request-per-hour ceiling with every other
+#     tenant on the Worker's outbound IP; present, the ceiling is 5,000. Read
+#     access to a PUBLIC repo needs no scopes at all, so a fine-grained token
+#     with none is correct here. The lookup degrades to an unavailable scorecard
+#     either way and never fails the run, so this is a reliability setting rather
+#     than a requirement.
 #   SENTRY_AUTH_TOKEN         - reads the Sentry section's aggregates (#1965).
 #     GCP secret `sentry-workers-readonly-token`, scoped to exactly
 #     `event:read` + `org:read`. Install the SAME token on all three Sentry


### PR DESCRIPTION
Fixes #2411.

## The Daily Report has failed five times in nine days, always saying the same thing

```
2026-08-25 / 24 / 20 / 18 / 17   release resolution exhausted its retries
2026-08-06 / 03 / 02             HTTP 500, body not echoed at that revision
```

The three older ones predate the workflow's `--fail-with-body` change and are recorded as **unread**, not as a different cause.

## First, a correction to the issue's severity

The issue says "the daily numbers are gone on each failed day". **They are not.** The transient branch is `wholeRun: false`, so the payload is built with the scorecard section unavailable, `deliverReport` runs, and only *then* does `if (failed) throw` turn the trigger red.

The founder received the whole report minus the version scorecard on all five days, and the red run is the designed signal that a section stopped working. What is broken is that **the signal says nothing about what broke**.

## Three defects, all established by reading the code

**1. The worker knew the status and threw it away.** The fetch raises `GitHub releases unavailable after 3 attempts: HTTP <status>`. The section boundary replaced that with a fixed string and put the original in `cause`, where nothing reads it; the fetch handler returns `err.message` alone. The one fact that decides whether this is rate limiting, an outage, or a shape change was discarded one line before it would have been printed.

**2. The retries had zero delay.** `await sleepFn(0)`, twice. Three requests inside a few milliseconds is the shape of a retry with none of the effect. Now `500ms` then `1500ms` — small on purpose, because a `curl` is waiting on this request.

**3. A rate limit was classified transient and then retried, which cannot work.** Its window resets at the top of an hour; a request cannot wait that long, so the extra attempts only spend more of an already-exhausted budget. It stays *temporary* — the section degrades, the run survives — and only the retry is dropped. The message now carries the reset delta, or says the reset was not reported rather than guessing one.

## The twin, and a false sentence that is why nobody looked

`wrangler.toml` said this lookup "needs no token and no secret — the same unauthenticated pattern `workers/weekly-digest` already uses". **The second half is false**: that worker has sent an optional `Authorization` header since it was written. Corrected there rather than deleted, and `daily-report` now sends the same header.

Measured rather than assumed:

```
HTTP 200  time=0.40s  size=381663
x-ratelimit-limit: 60          <- unauthenticated, PER IP
entries 30   malformed 0   drafts 0   prereleases 0
```

A token is not needed to *read* a public repo; it raises the *limit* from 60 to 5,000. A Worker's outbound requests leave from a shared egress pool, so that ceiling is shared with every other tenant on the address — our own usage is one request a day and never approaches it.

**The header is inert until the secret exists, and that is deliberate.** This is the code half. Installing `GITHUB_TOKEN` is a separate, founder-owned action, and defect 1 is what will say whether it is needed. **I am not filing rate limiting as the cause** — it is the hypothesis the evidence best fits, and defect 1 is the reason I cannot do better than a hypothesis today.

A blank or whitespace-only secret is treated as absent: `Authorization: token ` makes GitHub answer 401, which classifies fatal and would turn an unset secret into a whole-run failure.

## Ten mutants, each caught by exactly one test

```
M1 backoff returns to 0                 M6  the reason is discarded again
M2 backoff is flat, not growing         M7  every 403 becomes a rate limit
M3 a rate limit is retried again        M8  the token header is never sent
M4 the reset is not reported            M9  a blank token is sent
M5 a stale reset is reported as live    M10 the token is sent untrimmed
```

M7 is caught by a **pre-existing** test — the non-transient 4xx guard still binds, so nothing here weakened it.

## Not in scope

Caching the release list, and installing the secret.

`daily-report` 266/266 · `weekly-digest` 73/73 · `sentry-triage` 87/87.
