### PR TITLE
Pill refactor Phase 4: leaves obey explicit models, and the recording pill becomes the user's choice (#2376)

### DIFF
--- a/.github/workflows/main-post-merge.yml
+++ b/.github/workflows/main-post-merge.yml
@@ -49,6 +49,15 @@ env:
   XCODE_PROJECT: EnviousWispr.xcodeproj
   XCODE_SCHEME: EnviousWispr
   XCODE_RELEASE_SCHEME: EnviousWispr-Release
+  # Xcode forwards TEST_RUNNER_* into the test process, stripping the prefix; an
+  # INHERITED variable does not arrive at all, so a suite cannot answer "am I on a
+  # hosted runner" by reading the runner's own CI. Measured both ways (#2376).
+  #
+  # What this gates: rows that freeze RENDERED TEXT GEOMETRY. Those numbers are a
+  # reading of one Mac's font metrics — eleven of twelve failed here while all
+  # twelve passed on the development machine, same commit. The claims that travel
+  # are asserted separately and run in both places.
+  TEST_RUNNER_CI: "true"
 
 # Job layout (#1994). This ran as ONE job until 2026-08-12 and grew into its
 # 45-minute cap: eleven completed runs measured 34.7 min (min) / 40.4 (median) /

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -15,6 +15,15 @@ env:
   XCODE_PROJECT: EnviousWispr.xcodeproj
   XCODE_SCHEME: EnviousWispr
   XCODE_RELEASE_SCHEME: EnviousWispr-Release
+  # Xcode forwards TEST_RUNNER_* into the test process, stripping the prefix; an
+  # INHERITED variable does not arrive at all, so a suite cannot answer "am I on a
+  # hosted runner" by reading the runner's own CI. Measured both ways (#2376).
+  #
+  # What this gates: rows that freeze RENDERED TEXT GEOMETRY. Those numbers are a
+  # reading of one Mac's font metrics — eleven of twelve failed here while all
+  # twelve passed on the development machine, same commit. The claims that travel
+  # are asserted separately and run in both places.
+  TEST_RUNNER_CI: "true"
 
 jobs:
   # Debug lane: Xcode debug build + XPC hygiene self-tests + debug-config logic

--- a/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewBridge.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewBridge.swift
@@ -39,6 +39,12 @@ struct LivePreviewBridge {
   /// Whether to SIZE a pill for preview text.
   let isEnabledForGeometry: () -> Bool
 
+  /// The same answer with its REASON, for the surface that has to explain itself
+  /// (#2376 Phase 4, C4). The director reads the verdict above; the appearance
+  /// picker reads this, because greying out a group of designs without saying why
+  /// is the shape this repo already records as "visible and inaudible".
+  let wordsCapability: () -> PillWordsCapability
+
   /// What to render in it.
   let display: () -> LivePreviewDisplay
 
@@ -53,16 +59,24 @@ struct LivePreviewBridge {
     self.init(
       recordingDidChange: { coordinator.setRecording($0) },
       isEnabledForGeometry: { coordinator.isEnabledForGeometry },
+      wordsCapability: { coordinator.wordsCapability },
       display: { coordinator.display })
   }
 
   init(
     recordingDidChange: @escaping (Bool) -> Void,
     isEnabledForGeometry: @escaping () -> Bool,
+    // **NO DEFAULT, for the reason this file already states about the bridge as a
+    // whole.** A defaulted parameter leaves no token at the call site, so a caller
+    // that meant to supply a real capability and did not compiles and silently
+    // reports `.previewOff` — which a picker would render as "turn the preview on"
+    // to a user whose engine cannot run here at all.
+    wordsCapability: @escaping () -> PillWordsCapability,
     display: @escaping () -> LivePreviewDisplay
   ) {
     self.recordingDidChange = recordingDidChange
     self.isEnabledForGeometry = isEnabledForGeometry
+    self.wordsCapability = wordsCapability
     self.display = display
   }
 
@@ -81,6 +95,7 @@ struct LivePreviewBridge {
   static let disabled = LivePreviewBridge(
     recordingDidChange: { _ in },
     isEnabledForGeometry: { false },
+    wordsCapability: { .previewOff },
     display: { .off })
 }
 

--- a/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
@@ -268,6 +268,36 @@ final class LivePreviewCoordinator: CorrectorVocabularyConsumer {
     return selectedRoute().isSupportedOnThisSystem() && isPreviewOn()
   }
 
+  /// The same question with its REASON attached (#2376 Phase 4, C4).
+  ///
+  /// **A SIBLING of `isEnabledForGeometry`, not a replacement for it.** Phase 3's
+  /// seam comment states that Phase 4 must not change where the director resolves
+  /// capability, so that property is untouched and this reads the same two inputs
+  /// and honours the same per-recording freeze. The appearance picker needs a
+  /// reason a `Bool` cannot carry: a user whose engine cannot run here must not be
+  /// told to turn a switch on.
+  ///
+  /// **The two are bound by a test rather than by intention.**
+  /// `wordsCapabilityAgreesWithTheGeometryVerdict` sweeps the cross-product of
+  /// route support, preview setting and snapshot presence and requires
+  /// `.available` if and only if `isEnabledForGeometry`.
+  ///
+  /// KNOWN LIMIT, recorded rather than discovered later: a recording frozen by the
+  /// model-removal path carries `enabled: false` with a route that may well be
+  /// supported and a preview that may well be on, so during THAT recording this
+  /// reports `.previewOff` for a third reason it has no case for. The picker reads
+  /// this from Settings, outside a recording, where no snapshot exists — and
+  /// adding a `.modelRemoval` case would put a transient engine state in front of
+  /// a user choosing how a pill looks.
+  var wordsCapability: PillWordsCapability {
+    if let snapshot = recordingSnapshot {
+      if snapshot.enabled { return .available }
+      return snapshot.route.isSupportedOnThisSystem() ? .previewOff : .engineUnsupported
+    }
+    guard selectedRoute().isSupportedOnThisSystem() else { return .engineUnsupported }
+    return isPreviewOn() ? .available : .previewOff
+  }
+
   // MARK: - Lifecycle
 
   /// Start or stop the preview for the current recording.

--- a/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
@@ -297,7 +297,16 @@ final class LivePreviewCoordinator: CorrectorVocabularyConsumer {
   /// So the two properties AGREE outside a recording and may DIVERGE during one,
   /// which is asserted in both directions by
   /// `PillWordsCapabilityTests` rather than left to intention.
+  /// **The claim this makes is exact and is what the tests hold it to: this is
+  /// what `setRecording(true)` WOULD freeze if a recording started right now.**
+  /// Stated that way rather than as "the live settings" because the first
+  /// correction here fixed the liveness and still missed a condition — the
+  /// suppression below — and a property described by its INPUTS invites exactly
+  /// that, while one described by the decision it mirrors names its own
+  /// completeness criterion. The order matches the freeze's, so removal outranks
+  /// the rest here for the same reason it does there.
   var wordsCapability: PillWordsCapability {
+    guard !isRemovingModel else { return .modelBeingRemoved }
     guard selectedRoute().isSupportedOnThisSystem() else { return .engineUnsupported }
     return isPreviewOn() ? .available : .previewOff
   }

--- a/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
@@ -268,32 +268,36 @@ final class LivePreviewCoordinator: CorrectorVocabularyConsumer {
     return selectedRoute().isSupportedOnThisSystem() && isPreviewOn()
   }
 
-  /// The same question with its REASON attached (#2376 Phase 4, C4).
+  /// Why the NEXT recording can or cannot show words, with its reason attached
+  /// (#2376 Phase 4, C4; corrected by cloud review on C7).
   ///
-  /// **A SIBLING of `isEnabledForGeometry`, not a replacement for it.** Phase 3's
-  /// seam comment states that Phase 4 must not change where the director resolves
-  /// capability, so that property is untouched and this reads the same two inputs
-  /// and honours the same per-recording freeze. The appearance picker needs a
-  /// reason a `Bool` cannot carry: a user whose engine cannot run here must not be
-  /// told to turn a switch on.
+  /// **This answers a DIFFERENT QUESTION from `isEnabledForGeometry`, and the
+  /// difference is the whole point.** That property answers "what is THIS
+  /// recording doing", so it reads the frozen snapshot — a pill already on screen
+  /// must not resize because a setting moved underneath it. This answers "what
+  /// will the NEXT recording do", which is what a settings page has to say, and
+  /// so it reads LIVE and ignores the snapshot entirely.
   ///
-  /// **The two are bound by a test rather than by intention.**
-  /// `wordsCapabilityAgreesWithTheGeometryVerdict` sweeps the cross-product of
-  /// route support, preview setting and snapshot presence and requires
-  /// `.available` if and only if `isEnabledForGeometry`.
+  /// **An earlier version honoured the snapshot and that was a user-visible
+  /// defect, found by cloud review rather than by the equivalence test that was
+  /// supposed to protect this.** Settings is reachable while recording — the menu
+  /// item carries no recording gate, and the Live Preview toggle is disabled only
+  /// when no engine is available — so a user could start a take, switch Live
+  /// Preview off, open Appearance, and be told "Live Preview is on, so the pill
+  /// shows your words" about a next recording where it will not be. That
+  /// contradicts the panel's own promise that changes apply the next time you
+  /// record.
   ///
-  /// KNOWN LIMIT, recorded rather than discovered later: a recording frozen by the
-  /// model-removal path carries `enabled: false` with a route that may well be
-  /// supported and a preview that may well be on, so during THAT recording this
-  /// reports `.previewOff` for a third reason it has no case for. The picker reads
-  /// this from Settings, outside a recording, where no snapshot exists — and
-  /// adding a `.modelRemoval` case would put a transient engine state in front of
-  /// a user choosing how a pill looks.
+  /// **The comment that made it survive is worth naming, because it is the shape
+  /// this repo ranks worst.** The known-limit note here used to say the picker
+  /// "reads this from Settings, outside a recording, where no snapshot exists".
+  /// That sentence asserted a premise nobody checked and told the next reader the
+  /// question was closed. It was false: Settings is available during a recording.
+  ///
+  /// So the two properties AGREE outside a recording and may DIVERGE during one,
+  /// which is asserted in both directions by
+  /// `PillWordsCapabilityTests` rather than left to intention.
   var wordsCapability: PillWordsCapability {
-    if let snapshot = recordingSnapshot {
-      if snapshot.enabled { return .available }
-      return snapshot.route.isSupportedOnThisSystem() ? .previewOff : .engineUnsupported
-    }
     guard selectedRoute().isSupportedOnThisSystem() else { return .engineUnsupported }
     return isPreviewOn() ? .available : .previewOff
   }

--- a/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
@@ -244,6 +244,24 @@ final class LivePreviewCoordinator: CorrectorVocabularyConsumer {
   /// starting a competing one.
   private var removalDrain: Task<Void, Never>?
 
+  /// **Called when `wordsCapability` may have changed for a reason no observable
+  /// setting records** (#2376 Phase 4, round 4).
+  ///
+  /// Every other input to that property is settings-backed, so a SwiftUI page
+  /// reading it registers a dependency and refreshes by itself. Removal
+  /// suppression is the exception: it is a private field on a class that is not
+  /// `@Observable`, and the capability's guard returns on it BEFORE any settings
+  /// read — so during a drain the page has no dependency on anything at all, and
+  /// `endRemovalSuppression()` cannot invalidate it. The Appearance picker would
+  /// keep the with-words designs greyed with the removal sentence until some
+  /// unrelated redraw, and the inverse stale state is reachable too.
+  ///
+  /// A callback rather than making this class `@Observable`: the whole heart path
+  /// reads it at 20 Hz, and changing its invalidation semantics to publish one
+  /// settings page is a blast radius nobody asked for. Weak at the call site, so
+  /// a settings page can never be what keeps the limb alive.
+  var onWordsCapabilityMayHaveChanged: (@MainActor () -> Void)?
+
   /// `selectedRoute` answers "which engine is chosen right now" and is read once
   /// per recording. `isPreviewOn` is the user's toggle ALONE — support is the
   /// route's own answer (`isSupportedOnThisSystem`), so combining them here is
@@ -684,6 +702,9 @@ final class LivePreviewCoordinator: CorrectorVocabularyConsumer {
     }
 
     isRemovingModel = true
+    // The suppression BEGINS here, so a page already on screen stops offering
+    // what the next recording will not deliver.
+    onWordsCapabilityMayHaveChanged?()
 
     // **CAPTURE EVERY HOLDER BEFORE RELEASING ANYTHING.** The shared teardown
     // clears `preparationTask` on its way through, so reading it afterwards
@@ -718,6 +739,10 @@ final class LivePreviewCoordinator: CorrectorVocabularyConsumer {
   /// Removal is over: previews may run again.
   func endRemovalSuppression() {
     isRemovingModel = false
+    // And it ENDS here. Without this the picker keeps the removal sentence up
+    // after the files are gone, which is the direction a user actually meets:
+    // the drain finishes while they are looking at the page.
+    onWordsCapabilityMayHaveChanged?()
   }
 
   /// The shared teardown: stop the live session, then drop the cached engine.

--- a/Sources/EnviousWisprAppKit/App/Overlay/OverlayRootView.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/OverlayRootView.swift
@@ -179,7 +179,11 @@ struct OverlayRootView: View {
       // Width only. The height is content-driven so the pill earns its size a
       // line at a time rather than snapping once the real height is measured.
       view.frame(width: design.width)
-    case .classic:
+    case .classic, .levelRail:
+      // The shared without-words arm: both reserve a fixed interaction frame, and
+      // both do it for the same reason — the #1060 banner has to fit a box neither
+      // can grow out of.
+      //
       // #1341: Bottom bottom-aligns, Top centres. Centring in Bottom leaves ~24
       // points of invisible space under a ~44-point capsule, which mutes the
       // Bottom offset and visibly misaligns the polishing pill that replaces it.

--- a/Sources/EnviousWisprAppKit/App/Overlay/OverlayRootView.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/OverlayRootView.swift
@@ -122,18 +122,25 @@ struct OverlayRootView: View {
     }
   }
 
-  /// **`usesPreviewLayout` SURVIVES this chunk, and that is the boundary rather
-  /// than an oversight** (#2375 C3b). Two adapters existed and only one is
-  /// deleted: the layout bundle is gone, and this boolean is still handed to
-  /// `RecordingOverlayView` with its internal uses untouched. It is DERIVED —
-  /// its only input is the captured design — so it cannot disagree with the
-  /// catalog independently. Phase 4 replaces it with the design itself.
+  /// **`usesPreviewLayout` IS GONE, and the design itself is what the leaf gets**
+  /// (#2376 Phase 4, C2). #2375 C3b deleted the layout bundle and left this
+  /// boolean as the declared boundary; it is now replaced by
+  /// `RecordingPillChrome`, a value carrying what the pill DRAWS. `canHoldWords`
+  /// survives untouched as a CAPABILITY fact, read by
+  /// `OverlayRenderModel.setRecordingProviders` to decide whether a live-preview
+  /// provider is installed at all. It never reaches a view.
   ///
   /// **The design is NON-OPTIONAL, and an earlier version of this took an
   /// optional and fell back to `.classic`.** The definition's own recording case
   /// carries the design, so the caller binds it there and nothing here can
-  /// substitute a second answer — which is exactly the arrangement this chunk
-  /// deletes, and I had rebuilt a small one inside the fix for it.
+  /// substitute a second answer — which is exactly the arrangement #2375 C3b
+  /// deleted, and a small one had been rebuilt inside the fix for it.
+  ///
+  /// **The framing switch is EXHAUSTIVE over `RecordingPillDesign` and carries no
+  /// `default:`.** A default would let a design added later render inside a
+  /// neighbour's frame — correct model data with the wrong geometry, which is
+  /// this phase's named regression arriving through the one construct that hides
+  /// it from the compiler.
   @ViewBuilder
   private func recording(
     design: RecordingPillDesign, position: OverlayPillPosition
@@ -143,15 +150,16 @@ struct OverlayRootView: View {
       recordingElapsedProvider: model.recordingElapsedProvider,
       livePreviewProvider: model.livePreviewProvider,
       onContentHeightChange: model.onContentHeightChange,
-      usesPreviewLayout: design.canHoldWords,
+      chrome: design.chrome,
       lockState: lockState.value,
       noticeState: noticeState.value)
 
-    if design.canHoldWords {
+    switch design {
+    case .readingWell:
       // Width only. The height is content-driven so the pill earns its size a
       // line at a time rather than snapping once the real height is measured.
       view.frame(width: design.width)
-    } else {
+    case .classic:
       // #1341: Bottom bottom-aligns, Top centres. Centring in Bottom leaves ~24
       // points of invisible space under a ~44-point capsule, which mutes the
       // Bottom offset and visibly misaligns the polishing pill that replaces it.

--- a/Sources/EnviousWisprAppKit/App/Overlay/OverlayRootView.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/OverlayRootView.swift
@@ -78,6 +78,26 @@ struct OverlayRootView: View {
     sendEvent(.action(presentation.id, action))
   }
 
+  /// Send a NOTICE's own action (#2376 Phase 4, C3).
+  ///
+  /// **The literal is gone, and that is the point.** This site used to dispatch
+  /// `.discardRecovery` and `.grantAccessibility` by name while `PillCatalog`
+  /// carried the same two values on the model, so `NoticeModel.action` had no
+  /// production reader at all — a field set by two rows and read by nothing but
+  /// the model's own `==`.
+  ///
+  /// **There is no `??` fallback to the old literal, deliberately.** A fallback
+  /// would reinstate exactly the duplicate authority this deletes, and would do
+  /// it silently: a row that lost its action would keep working and nothing would
+  /// say so. A button with no action does not render at all
+  /// (`RecoveryNoticeView` and `AccessibilityToastView` both bind `if let
+  /// action`), and `noticeActionsAreCarriedByEveryKindThatDrawsAButton` sweeps the
+  /// catalog's closed set so a row cannot lose one unnoticed.
+  private func dispatch(_ action: NoticeAction?, on presentation: PillDefinition) {
+    guard let action else { return }
+    press(action.action, on: presentation)
+  }
+
   @ViewBuilder
   private func content(for presentation: PillDefinition) -> some View {
     switch presentation.content {
@@ -182,13 +202,21 @@ struct OverlayRootView: View {
     case .ready:
       ColdStartNoticeView(title: notice.text, subtitle: notice.secondaryText, icon: .ready)
     case .notification:
-      NotificationOverlayView(message: notice.text, style: Self.style(for: notice.severity))
+      NotificationOverlayView(
+        message: notice.text, style: Self.style(for: notice.severity),
+        isMultiline: notice.isMultiline)
     case .importStatus:
       ImportStatusOverlayView(message: notice.text)
     case .recovery:
-      RecoveryNoticeView(onDiscard: { press(.discardRecovery, on: presentation) })
+      RecoveryNoticeView(
+        title: notice.text, subtitle: notice.secondaryText,
+        accessibilityLabel: notice.accessibilityLabel ?? notice.text,
+        action: notice.action,
+        onAction: { dispatch(notice.action, on: presentation) })
     case .accessibilityToast:
-      AccessibilityToastView(onGrant: { press(.grantAccessibility, on: presentation) })
+      AccessibilityToastView(
+        text: notice.text, action: notice.action,
+        onAction: { dispatch(notice.action, on: presentation) })
     }
   }
 

--- a/Sources/EnviousWisprAppKit/App/Overlay/PillCatalog.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/PillCatalog.swift
@@ -82,6 +82,31 @@ struct PillCatalogEntry: Equatable, Sendable {
 
 enum PillCatalog {
 
+  // MARK: - Which designs may be offered
+
+  /// Whether a design may be OFFERED for a capability state (#2376 Phase 4, C4).
+  ///
+  /// **Defined in terms of `resolve`, and that definition IS the anti-drift
+  /// mechanism.** A design the picker greys out is exactly a design `resolve`
+  /// would substitute, so the two cannot disagree without `resolve` disagreeing
+  /// with itself. The plan names catalog-versus-Settings drift as the risk to
+  /// watch, and a parallel `allCases.filter { $0.canHoldWords == x }` would be a
+  /// second derivation of the same rule even while it happened to agree.
+  static func offers(_ design: RecordingPillDesign, capabilityHasWords: Bool) -> Bool {
+    PillDesignSelections(withoutWords: design, withWords: design)
+      .resolve(capabilityHasWords: capabilityHasWords)
+      .substituted == false
+  }
+
+  /// The designs in one compatibility group, for the picker's ORDER only.
+  ///
+  /// **Every enabled-or-greyed decision goes through `offers`, never through
+  /// this.** Grouping is presentation; offerability is policy, and keeping them
+  /// separate is what stops the group list quietly becoming a second answer.
+  static func designs(holdingWords: Bool) -> [RecordingPillDesign] {
+    RecordingPillDesign.allCases.filter { $0.canHoldWords == holdingWords }
+  }
+
   /// The one entry point.
   static func entry(for request: PillCatalogRequest, id: PresentationID) -> PillCatalogEntry {
     PillCatalogEntry(

--- a/Sources/EnviousWisprAppKit/App/Overlay/PillCatalog.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/PillCatalog.swift
@@ -171,7 +171,7 @@ enum PillCatalog {
         id: id, kind: .accessibilityToast, text: DictationNarrator.accessibilityToastText,
         width: .fixed(300), fixedHeight: 56,  // :859 and :1118 both pass height: 56
         expiry: .after(seconds: 6), isMultiline: true,
-        action: (label: "Grant", action: .grantAccessibility))
+        action: NoticeAction(label: "Grant", action: .grantAccessibility))
 
     case .warning(let reason):
       return notice(
@@ -199,6 +199,13 @@ enum PillCatalog {
       return notice(
         id: id, kind: .notification, text: DictationNarrator.copy(for: reason),
         width: .fixed(360),  // RecordingOverlayPanel.advisoryWidth
+        // **The 8 seconds is READING TIME, and the reason moved here from the
+        // dead table it used to live in** (#2376 C3). `NotificationStyle`
+        // carried an `autoDismissSeconds` table with no reader at all, and its
+        // #1891 note is the only place this number was ever justified: the
+        // advisory sentence is ~23 words, which at roughly 200 wpm needs about
+        // seven seconds to read, so the 3-second error dwell would show a
+        // message the user physically cannot finish.
         expiry: .after(seconds: 8), severity: .advisory, isMultiline: true)
 
     case .interruption(let reason):
@@ -230,11 +237,22 @@ enum PillCatalog {
       return notice(
         id: id, kind: .recovery, text: DictationNarrator.recoveryTitle,
         secondary: DictationNarrator.recoverySubtitle,
+        // Deliberately NOT the title. The spoken label drops the title's
+        // ellipsis, and `DictationNarratorTests` pins the two as different
+        // strings — the leaf used to read this constant itself, which is the
+        // duplication this chunk removes.
+        accessibilityLabel: DictationNarrator.recoveryAccessibilityLabel,
         width: .fixed(320), fixedHeight: 56,  // :530
         // that site gives it a 6-second dwell. The first version said `.untilReplaced`,
         // which would have left the recovery pill on screen forever.
         expiry: .after(seconds: 6), isMultiline: true,
-        action: (label: "Discard", action: .discardRecovery))
+        action: NoticeAction(
+          label: "Discard",
+          // The button's own spoken label, which the leaf used to spell as a bare
+          // literal with no model field behind it. "Discard" alone is ambiguous
+          // out of context; this says what is being discarded.
+          accessibilityLabel: "Discard recovering recording",
+          action: .discardRecovery))
 
     case .recoverySucceeded:
       // `.ready`, NOT `.notification`. The shipped site draws
@@ -327,15 +345,17 @@ enum PillCatalog {
   /// default silently.
   private static func notice(
     id: PresentationID, kind: NoticeModel.Kind, text: String, secondary: String? = nil,
+    accessibilityLabel: String? = nil,
     width: OverlayWidth, fixedHeight: CGFloat? = nil,
     expiry: OverlayExpiry = .untilReplaced, severity: NoticeModel.Severity = .neutral,
-    isMultiline: Bool = false, action: (label: String, action: PillAction)? = nil
+    isMultiline: Bool = false, action: NoticeAction? = nil
   ) -> PillDefinition {
     PillDefinition(
       id: id,
       content: .notice(
         NoticeModel(
-          kind: kind, text: text, secondaryText: secondary, severity: severity,
+          kind: kind, text: text, secondaryText: secondary,
+          accessibilityLabel: accessibilityLabel, severity: severity,
           isMultiline: isMultiline, action: action)),
       expiry: expiry, requestedWidth: width, reservesFixedHeight: fixedHeight)
   }

--- a/Sources/EnviousWisprAppKit/App/Overlay/PillDefinition.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/PillDefinition.swift
@@ -123,10 +123,18 @@ extension RecordingPillDesign {
 ///
 /// **Additive, and the verdict it sits beside is untouched.** Phase 3's seam
 /// comment forbids Phase 4 from changing where the director resolves capability,
-/// so this reads the same two inputs and honours the same per-recording freeze
-/// rather than replacing the property the director reads.
-/// `wordsCapabilityAgreesWithTheGeometryVerdict` binds the two in both directions
-/// so they cannot drift.
+/// so this is produced alongside the property the director reads rather than
+/// replacing it.
+///
+/// **It reads LIVE while that verdict reads a frozen snapshot, and the difference
+/// is deliberate** (corrected by cloud review). The verdict answers "what is THIS
+/// recording doing", so a pill on screen keeps the geometry it was sized for.
+/// This answers "what will the NEXT recording do", which is the only question a
+/// settings page can honestly answer — and Settings is reachable DURING a
+/// recording, so a snapshot-backed answer would tell a user who just switched
+/// Live Preview off that their words will still be shown.
+/// `PillWordsCapabilityTests` asserts the agreement outside a recording and the
+/// divergence during one.
 enum PillWordsCapability: Equatable, Sendable {
   /// Words are available: an engine that runs here, and the preview turned on.
   case available

--- a/Sources/EnviousWisprAppKit/App/Overlay/PillDefinition.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/PillDefinition.swift
@@ -177,6 +177,39 @@ enum OverlayWidth: Equatable, Sendable {
   case measured
 }
 
+/// The one button a notice may carry.
+///
+/// **A struct rather than the tuple it replaces, because the button needs a
+/// THIRD value and a tuple cannot grow one** (#2376 Phase 4, C3). The shipped
+/// recovery pill spells its button's accessibility label as a bare literal
+/// inside the view — "Discard recovering recording" — with no field behind it, so
+/// nothing could read it, nothing could check it, and it was invisible to the
+/// catalog that owns every other word on that pill. A tuple's third element would
+/// have had to be restated positionally at every site; a struct names it once.
+///
+/// It is also what lets `NoticeModel`'s hand-written `==` shrink rather than
+/// grow: the tuple is why that operator had to compare two members by hand.
+struct NoticeAction: Equatable, Sendable {
+  /// What is printed on the button.
+  let label: String
+  /// What a screen reader says instead, where the printed label is too terse to
+  /// stand alone. `nil` means the label speaks for itself.
+  let accessibilityLabel: String?
+  /// What pressing it sends.
+  let action: PillAction
+
+  init(label: String, accessibilityLabel: String? = nil, action: PillAction) {
+    self.label = label
+    self.accessibilityLabel = accessibilityLabel
+    self.action = action
+  }
+
+  /// What VoiceOver should read: the explicit label where one is given, and the
+  /// printed one otherwise. Resolved HERE rather than at each leaf, so two leaves
+  /// cannot answer it differently.
+  var spokenLabel: String { accessibilityLabel ?? label }
+}
+
 /// The collapsed notice. Processing, clipboard fallback, warning, error,
 /// advisory, interruption, caching, ready, recovery-success, the accessibility
 /// toast and import status are all THIS — a sentence, a visual severity, and
@@ -228,27 +261,50 @@ struct NoticeModel: Equatable, Sendable {
   let kind: Kind
   let text: String
   let secondaryText: String?
+  /// What VoiceOver reads for the pill AS A WHOLE, where that is deliberately
+  /// different from what is printed on it.
+  ///
+  /// **Required rather than tidy, and exactly one pill needs it.**
+  /// `DictationNarrator.recoveryAccessibilityLabel` is pinned as deliberately
+  /// DIFFERENT from `recoveryTitle` — the title carries an ellipsis and the
+  /// spoken label does not — so folding it into `text` would ship an ellipsis
+  /// into VoiceOver and break a test that exists to keep them apart. `nil` means
+  /// the pill's own contents are what a screen reader should compose.
+  let accessibilityLabel: String?
   let severity: Severity
   /// A notice long enough to need wrapping renders multiline with a
   /// content-driven height. `.advisory` is the shipped case and its dwell is
   /// deliberately long enough to read (#1891).
+  ///
+  /// **Read by `NotificationOverlayView`, which is the leaf whose wrapping it
+  /// decides** (#2376 Phase 4, C3). That leaf used to re-derive the same fact
+  /// from its own style table as `self == .advisory`, so one pill's wrapping was
+  /// stated twice and the model's copy was the one nobody read; the style's copy
+  /// is deleted and this is the survivor.
+  ///
+  /// `.importStatus` also sets it, and its leaf pins a two-line CAP of its own.
+  /// Those are not the same question — this says the text wraps rather than being
+  /// clipped to one line, and the cap says how far — so the row is accurate and
+  /// the leaf is not duplicating it.
   let isMultiline: Bool
-  let action: (label: String, action: PillAction)?
+  let action: NoticeAction?
 
   static func == (a: NoticeModel, b: NoticeModel) -> Bool {
     a.kind == b.kind && a.text == b.text && a.secondaryText == b.secondaryText
+      && a.accessibilityLabel == b.accessibilityLabel
       && a.severity == b.severity
-      && a.isMultiline == b.isMultiline && a.action?.label == b.action?.label
-      && a.action?.action == b.action?.action
+      && a.isMultiline == b.isMultiline && a.action == b.action
   }
 
   init(
-    kind: Kind, text: String, secondaryText: String? = nil, severity: Severity = .neutral,
-    isMultiline: Bool = false, action: (label: String, action: PillAction)? = nil
+    kind: Kind, text: String, secondaryText: String? = nil, accessibilityLabel: String? = nil,
+    severity: Severity = .neutral,
+    isMultiline: Bool = false, action: NoticeAction? = nil
   ) {
     self.kind = kind
     self.text = text
     self.secondaryText = secondaryText
+    self.accessibilityLabel = accessibilityLabel
     self.severity = severity
     self.isMultiline = isMultiline
     self.action = action

--- a/Sources/EnviousWisprAppKit/App/Overlay/PillDefinition.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/PillDefinition.swift
@@ -32,45 +32,10 @@ struct PresentationID: Hashable, Sendable {
 
 // MARK: - The recording pill's design
 
-/// Which recording pill the user gets (#2375 Phase 3, chunk C3a).
-///
-/// **A DESIGN, not a capability.** Whether the machine can show words as you
-/// speak is a capability the director reads; which pill is drawn is a choice.
-/// Until Phase 4 the two are locked together by a constant, and separating the
-/// vocabulary now is what lets Phase 4 change one without touching the other.
-///
-/// **`.readingWell`, deliberately not `.livePreview`.** Naming a design after
-/// the capability that enables it makes the settings group label and the card
-/// label the same word, and forecloses a second with-words design before one
-/// exists. The capability keeps its own name.
-enum RecordingPillDesign: Equatable, Sendable, CaseIterable {
-  /// The rainbow-lips capsule: a fixed 185x92 interaction frame that holds the
-  /// normal capsule, the locked state and the #1060 notice expansion without
-  /// resizing on every morph.
-  case classic
-  /// The wide panel that shows words as you speak. Content-sized from the first
-  /// frame so it does not visibly snap as lines wrap.
-  case readingWell
-  /// A wider capsule carrying the clock beside a live rainbow level rail, and no
-  /// lips mark (#2376 Phase 4, C5).
-  ///
-  /// **Named for what it DRAWS, following `.readingWell`'s own reasoning.** A
-  /// design named for a capability makes the settings group label and the card
-  /// label the same word; `.levelRail` says nothing about words, preview or live
-  /// anything, so it survives a capability rename and can never be read as the
-  /// with-words option. `.compact` or `.minimal` would name what it LACKS, and
-  /// `.waveform` collides with the ASR vocabulary already in the tree.
-  ///
-  /// **It closes a real gap rather than adding a variation.**
-  /// `RainbowLevelMeter` has exactly one production construction site — inside the
-  /// reading well's header — so the meter shipped in #2216 is reachable only by
-  /// users who can and do run live preview. This offers it to everyone else.
-  ///
-  /// It cannot hold words BY CONSTRUCTION rather than by policy: `canHoldWords`
-  /// is false, so `OverlayRenderModel` installs `{ .off }` and the leaf renders
-  /// no well at all, and its chrome carries no well insets and no fade — there is
-  /// nowhere for text to go even if a provider were installed.
-  case levelRail
+/// The PIXELS of a recording design. Its identity lives in `EnviousWisprCore`,
+/// because a setting persists it and `SettingsManager` is in Services; everything
+/// here is what AppKit knows and Core must not.
+extension RecordingPillDesign {
 
   /// Whether this design can display transcribed words while recording.
   ///
@@ -97,6 +62,33 @@ enum RecordingPillDesign: Equatable, Sendable, CaseIterable {
     // not a measured one — there is no mockup in the tree — and the one value in
     // this design a founder should move before it ships.
     case .levelRail: return 260
+    }
+  }
+
+  /// What the Appearance picker calls this design.
+  ///
+  /// **On the design rather than in the picker, deliberately.** A per-design
+  /// table in the view would be a second one on day one — the drift shape this
+  /// phase exists to remove, one field over — and a design added later would
+  /// render with a blank card until somebody remembered the other list.
+  var displayName: String {
+    switch self {
+    case .classic: return "Capsule"
+    case .readingWell: return "Reading Well"
+    case .levelRail: return "Level Rail"
+    }
+  }
+
+  /// One sentence on the card, in the user's terms rather than ours. No em or en
+  /// dashes (GR-NO-DASHES).
+  var summary: String {
+    switch self {
+    case .classic:
+      return "A small capsule with the rainbow mark and a timer. The pill EnviousWispr has always shown."
+    case .readingWell:
+      return "A wide panel that shows your words as you speak, growing a line at a time."
+    case .levelRail:
+      return "A wider capsule with a live rainbow meter of your voice beside the timer."
     }
   }
 

--- a/Sources/EnviousWisprAppKit/App/Overlay/PillDefinition.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/PillDefinition.swift
@@ -85,6 +85,32 @@ enum RecordingPillDesign: Equatable, Sendable, CaseIterable {
   }
 }
 
+/// Why the recording pill can or cannot show words as you speak (#2376 Phase 4).
+///
+/// **A REASON, where `LivePreviewBridge.isEnabledForGeometry` is a verdict.** The
+/// director only needs to know whether to size a pill for words; a settings page
+/// that greys out a whole group of designs has to say WHY, and a `Bool` cannot
+/// carry that. One sentence for both causes would be worse than none: it would
+/// tell a user on an unsupported machine to turn on a setting that would not help
+/// them.
+///
+/// **Additive, and the verdict it sits beside is untouched.** Phase 3's seam
+/// comment forbids Phase 4 from changing where the director resolves capability,
+/// so this reads the same two inputs and honours the same per-recording freeze
+/// rather than replacing the property the director reads.
+/// `wordsCapabilityAgreesWithTheGeometryVerdict` binds the two in both directions
+/// so they cannot drift.
+enum PillWordsCapability: Equatable, Sendable {
+  /// Words are available: an engine that runs here, and the preview turned on.
+  case available
+  /// The engine would run here; the user has the preview switched off.
+  case previewOff
+  /// The selected engine cannot run on this machine, so the switch would not help.
+  case engineUnsupported
+
+  var hasWords: Bool { self == .available }
+}
+
 /// Which design the user has chosen for each capability state.
 ///
 /// **Two selections, not one, because the two states are genuinely different
@@ -101,12 +127,23 @@ struct PillDesignSelections: Equatable, Sendable {
     self.withWords = withWords
   }
 
-  /// The pair the shipped code produces, and what Phase 3 injects everywhere.
+  /// The pair the shipped code produces, and the FROZEN REFERENCE tests measure
+  /// against.
   ///
-  /// Phase 4 replaces the CLOSURE that returns this, never this constant's
-  /// meaning — it is the current behaviour written down, so a Phase 4 regression
-  /// is measurable against it.
+  /// **Production no longer reads it** (#2376 Phase 4). The bootstrapper's
+  /// selections closure is settings-backed, and this constant's job is to be the
+  /// thing those defaults are asserted to equal — one production authority, one
+  /// frozen reference, and a test saying they agree. It is kept rather than
+  /// deleted because 22 test call sites across 8 files use it as the neutral pair
+  /// for a director that is not about design selection.
   static let shipped = PillDesignSelections(withoutWords: .classic, withWords: .readingWell)
+
+  /// The design substituted when the chosen one cannot hold the capability's
+  /// content. Stated ONCE each rather than spelled at the branch that needs it.
+  static let canonicalWithWords: RecordingPillDesign = .readingWell
+  /// The design substituted when a with-words design is chosen for a pill that
+  /// will show no words.
+  static let canonicalWithoutWords: RecordingPillDesign = .classic
 
   /// Resolve the selection for a capability state, FAIL-CLOSED.
   ///
@@ -116,22 +153,40 @@ struct PillDesignSelections: Equatable, Sendable {
   /// true. `DesignResolution` cannot lie about which of the two happened, and a
   /// caller may assert on it, log it, or ignore it.
   ///
-  /// **No production caller can produce a mismatch this phase**, because
-  /// selections are constructed from `shipped`. That branch is covered by unit
-  /// tests only and ships no logging, telemetry or composition wiring. Phase 4
-  /// introduces the first real producer of an incompatible value and owns the
-  /// decision about what `substituted` should then cause.
+  /// **What `substituted` CAUSES is nothing, and that is the decision rather than
+  /// an omission** (#2376 Phase 4). Phase 3 recorded that Phase 4 introduces the
+  /// first real producer and owns this call. It does: two independently persisted
+  /// selections. But the picker cannot OFFER an incompatible design — it asks
+  /// `PillCatalog.offers`, which is defined in terms of this very function — so a
+  /// substitution is reachable only from a hand-edited plist or a downgrade. It
+  /// stays a returned value with no logging and no telemetry, and its
+  /// unreachability is asserted by the picker's cross-product rather than watched
+  /// for at runtime.
   func resolve(capabilityHasWords: Bool) -> DesignResolution {
     let chosen = capabilityHasWords ? withWords : withoutWords
-    // Written as an `if` rather than a `guard`, because the mismatch is the
-    // EXCEPTIONAL case and a guard whose success path is the exception reads
+    // Written as `if`s rather than `guard`s, because the mismatches are the
+    // EXCEPTIONAL cases and a guard whose success path is the exception reads
     // backwards to everyone after the author.
     if capabilityHasWords, !chosen.canHoldWords {
       // The capability can show words and the chosen design cannot hold them.
       // Substituting the canonical with-words design is the fail-closed answer:
       // the alternative is a pill that silently drops the feature it was enabled
       // for.
-      return DesignResolution(design: .readingWell, substituted: true)
+      return DesignResolution(design: Self.canonicalWithWords, substituted: true)
+    }
+    // **THE MIRROR DIRECTION, CLOSED IN #2376 C4, AND IT WAS NOT HYPOTHETICAL.**
+    // Phase 3 guarded only the case above, so a with-words design sitting in the
+    // without-words slot was accepted with `substituted: false` —
+    // `RecordingDirectorCaptureTests` MEASURES that combination installing a live
+    // display provider and resizing the window to 400x123 on a machine with no
+    // preview: a wide empty panel with nothing to put in it.
+    //
+    // C6 introduces the first producer that can reach this — two independently
+    // persisted selections, either of which a hand-edited plist or a downgrade
+    // can cross — so the guard lands one chunk BEFORE the thing that can trip it
+    // rather than one chunk after.
+    if !capabilityHasWords, chosen.canHoldWords {
+      return DesignResolution(design: Self.canonicalWithoutWords, substituted: true)
     }
     return DesignResolution(design: chosen, substituted: false)
   }

--- a/Sources/EnviousWisprAppKit/App/Overlay/PillDefinition.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/PillDefinition.swift
@@ -135,13 +135,17 @@ extension RecordingPillDesign {
 /// Live Preview off that their words will still be shown.
 /// `PillWordsCapabilityTests` asserts the agreement outside a recording and the
 /// divergence during one.
-enum PillWordsCapability: Equatable, Sendable {
+enum PillWordsCapability: Equatable, Sendable, CaseIterable {
   /// Words are available: an engine that runs here, and the preview turned on.
   case available
   /// The engine would run here; the user has the preview switched off.
   case previewOff
   /// The selected engine cannot run on this machine, so the switch would not help.
   case engineUnsupported
+  /// The selected model is being removed, so the next recording is frozen wordless
+  /// however the switch is set. Transient, and the only cause here that resolves
+  /// itself: it lasts as long as the removal drain.
+  case modelBeingRemoved
 
   var hasWords: Bool { self == .available }
 }

--- a/Sources/EnviousWisprAppKit/App/Overlay/PillDefinition.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/PillDefinition.swift
@@ -61,7 +61,21 @@ extension RecordingPillDesign {
     // beside the clock, and unmistakably not 185 at a glance. A CHOSEN number,
     // not a measured one — there is no mockup in the tree — and the one value in
     // this design a founder should move before it ships.
-    case .levelRail: return 260
+    // 288, not the 260 this design was drawn at, and the 28 is MEASURED rather
+    // than chosen (#2376 Phase 4, round 5). The hands-free badge is inline —
+    // the reserved-box guard refused it a row of its own — and the locked row
+    // then wants 279pt: a ~45pt clock, 24 bars at 3pt with 2pt gaps, and a
+    // ~90pt badge. At 260 the badge or the rail is CLIPPED with nothing
+    // reporting it, and the thing being clipped is the only confirmation that
+    // the microphone stays open after the key is released.
+    //
+    // Three alternatives were measured and refused: shortening the label splits
+    // one mode across two names, since the reading well already says
+    // "Hands-free"; cutting the rail to 20 bars takes 20pt out of the audio
+    // history that is this design's whole point, and `barCount` is shared with
+    // the reading well; dropping the clock contradicts the 2026-08-19 founder
+    // decision that hands-free is the mode that needs one.
+    case .levelRail: return 288
     }
   }
 

--- a/Sources/EnviousWisprAppKit/App/Overlay/PillDefinition.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/PillDefinition.swift
@@ -51,6 +51,26 @@ enum RecordingPillDesign: Equatable, Sendable, CaseIterable {
   /// The wide panel that shows words as you speak. Content-sized from the first
   /// frame so it does not visibly snap as lines wrap.
   case readingWell
+  /// A wider capsule carrying the clock beside a live rainbow level rail, and no
+  /// lips mark (#2376 Phase 4, C5).
+  ///
+  /// **Named for what it DRAWS, following `.readingWell`'s own reasoning.** A
+  /// design named for a capability makes the settings group label and the card
+  /// label the same word; `.levelRail` says nothing about words, preview or live
+  /// anything, so it survives a capability rename and can never be read as the
+  /// with-words option. `.compact` or `.minimal` would name what it LACKS, and
+  /// `.waveform` collides with the ASR vocabulary already in the tree.
+  ///
+  /// **It closes a real gap rather than adding a variation.**
+  /// `RainbowLevelMeter` has exactly one production construction site — inside the
+  /// reading well's header — so the meter shipped in #2216 is reachable only by
+  /// users who can and do run live preview. This offers it to everyone else.
+  ///
+  /// It cannot hold words BY CONSTRUCTION rather than by policy: `canHoldWords`
+  /// is false, so `OverlayRenderModel` installs `{ .off }` and the leaf renders
+  /// no well at all, and its chrome carries no well insets and no fade — there is
+  /// nowhere for text to go even if a provider were installed.
+  case levelRail
 
   /// Whether this design can display transcribed words while recording.
   ///
@@ -61,7 +81,7 @@ enum RecordingPillDesign: Equatable, Sendable, CaseIterable {
   /// is on screen; C3a derived that value from this one and C3b deleted it.
   var canHoldWords: Bool {
     switch self {
-    case .classic: return false
+    case .classic, .levelRail: return false
     case .readingWell: return true
     }
   }
@@ -72,6 +92,11 @@ enum RecordingPillDesign: Equatable, Sendable, CaseIterable {
     switch self {
     case .classic: return 185
     case .readingWell: return 400
+    // Wide enough that the rail is the pill's subject rather than an ornament
+    // beside the clock, and unmistakably not 185 at a glance. A CHOSEN number,
+    // not a measured one — there is no mockup in the tree — and the one value in
+    // this design a founder should move before it ships.
+    case .levelRail: return 260
     }
   }
 
@@ -79,7 +104,17 @@ enum RecordingPillDesign: Equatable, Sendable, CaseIterable {
   /// site. The classic pill reserves a fixed box; the reading well does not.
   var reservedHeight: CGFloat? {
     switch self {
-    case .classic: return 92
+    // **92 IS THE WITHOUT-WORDS NOTICE BUDGET, and it is inherited rather than
+    // chosen.** The #1060 in-panel banner is rendered by every layout from one
+    // `Text` inside the root stack, and a design that cannot hold words is handed
+    // a no-op growth callback by `OverlayRenderModel` — so it CANNOT resize its
+    // window when the banner arrives mid-recording. Measured 2026-08-25: the
+    // longest shipped banner fills this box EXACTLY, with zero headroom, and a
+    // three-line sentence measures 120 and would be clipped in silence. A 40 or
+    // 44-point box would clip the graceful-cap warning on a shipping path with no
+    // test able to see it, which is why `.levelRail` takes the same number as
+    // `.classic` rather than one sized to its own contents.
+    case .classic, .levelRail: return 92
     case .readingWell: return nil
     }
   }

--- a/Sources/EnviousWisprAppKit/App/Overlay/Views/AccessibilityToastView.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/Views/AccessibilityToastView.swift
@@ -5,27 +5,37 @@ import SwiftUI
 
 // MARK: - AccessibilityToastView
 
+/// **It renders the model it is handed and reads no copy of its own** (#2376
+/// Phase 4, C3). It used to take only a closure, read
+/// `DictationNarrator.accessibilityToastText` itself and hardcode its button
+/// label, both of which `PillCatalog` already carried on the model.
 struct AccessibilityToastView: View {
-  let onGrant: () -> Void
+  let text: String
+  let action: NoticeAction?
+  let onAction: () -> Void
 
   var body: some View {
     HStack(spacing: 10) {
       Image(systemName: "lock.shield.fill")
         .foregroundStyle(.orange)
         .font(.system(size: 16))
-      Text(DictationNarrator.accessibilityToastText)
+      Text(text)
         .font(.system(size: 13, weight: .medium))
         .foregroundStyle(.white)
       Spacer(minLength: 8)
-      Button(action: onGrant) {
-        Text("Grant")
-          .font(.system(size: 12, weight: .semibold))
-          .foregroundStyle(.white)
-          .padding(.horizontal, 12)
-          .padding(.vertical, 4)
-          .background(Capsule().fill(Color.orange.opacity(0.85)))
+      if let action {
+        Button(action: onAction) {
+          Text(action.label)
+            .font(.system(size: 12, weight: .semibold))
+            .foregroundStyle(.white)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 4)
+            .contentShape(Rectangle())
+            .background(Capsule().fill(Color.orange.opacity(0.85)))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(action.spokenLabel)
       }
-      .buttonStyle(.plain)
     }
     .padding(.horizontal, 14)
     .padding(.vertical, 10)

--- a/Sources/EnviousWisprAppKit/App/Overlay/Views/NotificationOverlayView.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/Views/NotificationOverlayView.swift
@@ -35,24 +35,6 @@ enum NotificationStyle {
     }
   }
 
-  var autoDismissSeconds: Double {
-    switch self {
-    case .error: 3.0
-    case .warning: 2.5
-    case .interruption: 2.0
-    // #1891: the advisory sentence is ~23 words. At roughly 200 wpm that needs
-    // about 7 seconds to read, so the 3.0s error dwell would show a message
-    // the user physically cannot finish. 8s, confirmed by reading UAT.
-    case .advisory: 8.0
-    }
-  }
-
-  /// #1891: only the advisory wraps and sizes to its content. Every other
-  /// notice is a short single line in a fixed 280x44 box and stays that way.
-  var isMultiline: Bool {
-    self == .advisory
-  }
-
   var usesDistressLips: Bool {
     self == .interruption
   }
@@ -64,6 +46,15 @@ enum NotificationStyle {
 struct NotificationOverlayView: View {
   let message: String
   let style: NotificationStyle
+  /// #1891: only the advisory wraps and sizes to its content; every other notice
+  /// is a short single line in a fixed 280x44 box.
+  ///
+  /// **Taken from the MODEL rather than re-derived from the style** (#2376 Phase
+  /// 4, C3). `NotificationStyle` carried its own `isMultiline` computed from
+  /// `self == .advisory` while `PillCatalog` set the same fact on every notice
+  /// row, so one pill's wrapping was stated twice and the model's copy was
+  /// ignored. The style's copy is deleted; this is the survivor.
+  let isMultiline: Bool
 
   var body: some View {
     HStack(spacing: 8) {
@@ -81,8 +72,8 @@ struct NotificationOverlayView: View {
         // #1891: `.lineLimit(1)` in a 280pt box truncates the advisory sentence
         // to a fragment. Only the advisory wraps; every other notice keeps its
         // single-line shape exactly as before.
-        .lineLimit(style.isMultiline ? nil : 1)
-        .fixedSize(horizontal: false, vertical: style.isMultiline)
+        .lineLimit(isMultiline ? nil : 1)
+        .fixedSize(horizontal: false, vertical: isMultiline)
         .multilineTextAlignment(.leading)
     }
     .padding(.horizontal, 14)

--- a/Sources/EnviousWisprAppKit/App/Overlay/Views/RecordingOverlayView.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/Views/RecordingOverlayView.swift
@@ -91,6 +91,11 @@ struct RecordingPillChrome: Equatable, Sendable {
     case mark
     /// The ruled strip: clock, live meter, mode badge (#2202).
     case meterStrip
+    /// The clock beside a full-width level rail, with the clock visible in BOTH
+    /// lock states (#2376 C5). That is the founder call already recorded for the
+    /// reading well's header: hands-free is the mode that runs for minutes, so it
+    /// is the one that needs a clock.
+    case clockAndRail
   }
 
   let header: Header
@@ -157,6 +162,30 @@ extension RecordingPillDesign {
         showsListeningSentence: true,
         noticeInk: .capsuleWhite,
         noticeMaxWidth: 170,
+        noticeInsets: EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0),
+        wellInsets: EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0),
+        wellInk: .capsuleWhite,
+        fadesWhenWellIsFull: false,
+        isContentSizedVertically: reservedHeight == nil)
+
+    case .levelRail:
+      // Every value here is `.classic`'s, except the header and the notice cap.
+      // That is deliberate rather than lazy: this is a without-words capsule, so
+      // it inherits the group's insets, corner, ink, animation and notice budget,
+      // and differs only in what it DRAWS. A design that also moved its paddings
+      // would be changing two things at once with one of them unmotivated.
+      return RecordingPillChrome(
+        header: .clockAndRail,
+        stackSpacing: 6,
+        rootInsets: EdgeInsets(top: 10, leading: 14, bottom: 10, trailing: 14),
+        cornerStyle: .capsule,
+        levelAnimation: .none,
+        showsListeningSentence: false,
+        noticeInk: .capsuleWhite,
+        // 260 less the 14pt root inset either side. Stated as the arithmetic it
+        // is, because a bare 232 beside a 260-wide design reads as a second
+        // measurement nobody took.
+        noticeMaxWidth: 232,
         noticeInsets: EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0),
         wellInsets: EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0),
         wellInk: .capsuleWhite,
@@ -343,6 +372,21 @@ struct RecordingOverlayView: View {
       switch chrome.header {
       case .meterStrip:
         previewHeader
+      case .clockAndRail:
+        HStack(spacing: 10) {
+          // The clock in BOTH lock states, unlike the capsule which hides it when
+          // locked. Same treatment as the capsule's own clock so the two designs
+          // are not gratuitously different where they agree.
+          Text(FormattingConstants.formatDuration(elapsed))
+            .font(.system(size: 13, weight: .semibold, design: .monospaced))
+            .foregroundStyle(.white)
+          // Taller and wider-barred than the reading well's, so the rail rather
+          // than the clock is what the eye lands on. No lips mark: the rail IS
+          // the audio-reactive element, and two of them would compete.
+          RainbowLevelMeter(
+            audioLevel: audioLevel, tick: audioTick, height: 24, barWidth: 3, spacing: 2)
+        }
+
       case .mark:
         HStack(spacing: 10) {
           // Rainbow lips icon — audio-reactive during recording.

--- a/Sources/EnviousWisprAppKit/App/Overlay/Views/RecordingOverlayView.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/Views/RecordingOverlayView.swift
@@ -3,6 +3,185 @@ import EnviousWisprCore
 import EnviousWisprPipeline
 import SwiftUI
 
+// MARK: - What a design tells the recording leaf to draw
+
+/// Which ink a piece of the recording pill is painted in (#2376 Phase 4, C2).
+///
+/// **An enum, not a `Color`, and the reason is that ONE INK HAS TWO ROLES.** An
+/// earlier version of this comment said a `Color` would leave the treatment
+/// unassertable; that is false and worth stating plainly, because SwiftUI's
+/// `Color` is both `Equatable` and `Sendable` and a stored one would compare
+/// fine. The real reason is structural: a design's ink has to answer for the
+/// #1060 notice AND for the reading well's text in two dimming states, so a
+/// `Color` field could not carry it without two or three fields that are free to
+/// disagree about which palette this pill is in. A case names the palette once.
+///
+/// Resolved to a `Color` here, once per case, so the capsule's frozen notice
+/// literal keeps its single occurrence across the two files
+/// `CapsuleBackgroundFreezeTests.capsuleSourcePaths` names.
+enum PillInk: Equatable, Sendable {
+  /// The capsule's own white, as every without-words pill has always drawn it.
+  case capsuleWhite
+  /// The light reading-well palette (#2204).
+  case previewPalette
+
+  /// The #1060 in-panel notice's colour.
+  var notice: Color {
+    switch self {
+    case .capsuleWhite: return Color.white.opacity(0.95)
+    case .previewPalette: return PreviewPillPalette.notice
+    }
+  }
+
+  /// The reading well's text colour, which has a dimmed variant for the
+  /// "listening" and "unavailable" states.
+  func well(dimmed: Bool) -> Color {
+    switch self {
+    case .capsuleWhite: return .white.opacity(dimmed ? 0.5 : 0.92)
+    case .previewPalette: return dimmed ? PreviewPillPalette.textDimmed : PreviewPillPalette.text
+    }
+  }
+}
+
+/// Whether the container animates when the audio level ticks.
+///
+/// **A case rather than an `Animation?`, and NOT because `Animation` cannot be
+/// compared — it is `Equatable` and `Sendable`.** The reason is that a stored
+/// `nil` says nothing: it records that this design animates nothing and loses
+/// WHY, which here is a measured constraint rather than a taste. A case carries
+/// the policy and its reason to every design that selects it.
+enum PillLevelAnimation: Equatable, Sendable {
+  /// No container animation on the level. The reading well selects this: the
+  /// level is repolled every 50 ms, so a container animation fires ~20 times a
+  /// second and animates whatever else changed in the same update — including
+  /// the preview text, and therefore the pill's HEIGHT (#2201).
+  case none
+  /// The capsule's shipped 80 ms ease-out.
+  case capsuleEaseOut
+
+  var resolved: Animation? {
+    switch self {
+    case .none: return nil
+    case .capsuleEaseOut: return .easeOut(duration: 0.08)
+    }
+  }
+}
+
+/// Everything about the recording pill's appearance that varies by DESIGN.
+///
+/// **This replaces eighteen reads of a `usesPreviewLayout` boolean**, which
+/// expressed exactly two designs and would have needed a branch per design for a
+/// third — and every one of those branches is a place where one design can be
+/// wrong in isolation while the others look fine. The leaf is now HANDED what to
+/// draw and reads no capability of its own.
+///
+/// **`canHoldWords` is NOT here and must never be.** It is a capability fact the
+/// director reads to decide whether to install a live-preview provider at all
+/// (`OverlayRenderModel.setRecordingProviders`); it is not a look. Whether the
+/// well has any words in it is decided upstream, and this value only says what
+/// the well looks like when it does.
+///
+/// Every field is a per-design literal except `isContentSizedVertically`, whose
+/// derivation is documented at its own declaration.
+struct RecordingPillChrome: Equatable, Sendable {
+
+  /// What sits above the preview area.
+  enum Header: Equatable, Sendable {
+    /// The rainbow-lips mark beside the clock, the clock hidden when locked.
+    case mark
+    /// The ruled strip: clock, live meter, mode badge (#2202).
+    case meterStrip
+  }
+
+  let header: Header
+  /// #2202 row 1 of the shared-root table: the capsule wants 6pt between its
+  /// stacked pieces; the preview puts a ruled header directly against its
+  /// reading well and supplies its own spacing inside each section.
+  let stackSpacing: CGFloat
+  /// #2202 row 8. The capsule keeps its uniform inset; the preview zeroes it and
+  /// each section supplies its own, because a header strip over a reading well
+  /// does not want one rectangle of padding wrapped around both.
+  let rootInsets: EdgeInsets
+  let cornerStyle: OverlayCapsuleBackground.CornerStyle
+  let levelAnimation: PillLevelAnimation
+  /// #2202: the preview layout's header already says `Listening`, so repeating
+  /// the sentence in the well would greet a first-time user with the same word
+  /// twice in one small box. The capsule has no header, so it keeps it.
+  let showsListeningSentence: Bool
+  /// #2204: the notice is rendered by every layout from one `Text`, and white is
+  /// invisible on a light pill.
+  let noticeInk: PillInk
+  /// `nil` means the notice may use the pill's full width. 170pt suits the 185pt
+  /// capsule; the reading well is 400pt wide, so the same cap would wrap a
+  /// one-line warning into three inside a box with room to spare.
+  let noticeMaxWidth: CGFloat?
+  /// #2202 row 4. The notice's ONLY inset came from the shared root padding,
+  /// which the preview zeroes — without a replacement it sits flush against the
+  /// pill's bottom edge.
+  let noticeInsets: EdgeInsets
+  /// #2202: the well's own inset, replacing what the shared root padding used to
+  /// give it.
+  let wellInsets: EdgeInsets
+  let wellInk: PillInk
+  /// #2203: fade the well's top edge when something is scrolling off it.
+  let fadesWhenWellIsFull: Bool
+  /// #2201: whether the root stack reports its IDEAL height whatever it is
+  /// offered, so the pill's height is a function of what it is SHOWING rather
+  /// than of how tall it happens to be already.
+  ///
+  /// **DERIVED from the design's own `reservedHeight`, never typed twice.** A
+  /// design that reserves a fixed box is not content-sized by definition, and the
+  /// two answers disagreeing is how a pill comes to be measured inside the panel
+  /// that is being sized from that measurement — the loop #2201 settled.
+  let isContentSizedVertically: Bool
+}
+
+extension RecordingPillDesign {
+
+  /// What this design tells the leaf to draw.
+  ///
+  /// **Every value was read off the base revision's own branches, not designed
+  /// here.** `.classic` is the `false` side of all eighteen `usesPreviewLayout`
+  /// reads and `.readingWell` the `true` side, so this table is the shipped
+  /// behaviour written down — which is what makes the C1 frozen rows a real
+  /// receipt rather than an agreement between two things I wrote today.
+  var chrome: RecordingPillChrome {
+    switch self {
+    case .classic:
+      return RecordingPillChrome(
+        header: .mark,
+        stackSpacing: 6,
+        rootInsets: EdgeInsets(top: 10, leading: 14, bottom: 10, trailing: 14),
+        cornerStyle: .capsule,
+        levelAnimation: .capsuleEaseOut,
+        showsListeningSentence: true,
+        noticeInk: .capsuleWhite,
+        noticeMaxWidth: 170,
+        noticeInsets: EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0),
+        wellInsets: EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0),
+        wellInk: .capsuleWhite,
+        fadesWhenWellIsFull: false,
+        isContentSizedVertically: reservedHeight == nil)
+
+    case .readingWell:
+      return RecordingPillChrome(
+        header: .meterStrip,
+        stackSpacing: 0,
+        rootInsets: EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0),
+        cornerStyle: .rounded,
+        levelAnimation: .none,
+        showsListeningSentence: false,
+        noticeInk: .previewPalette,
+        noticeMaxWidth: nil,
+        noticeInsets: EdgeInsets(top: 0, leading: 16, bottom: 12, trailing: 16),
+        wellInsets: EdgeInsets(top: 12, leading: 16, bottom: 15, trailing: 16),
+        wellInk: .previewPalette,
+        fadesWhenWellIsFull: true,
+        isContentSizedVertically: reservedHeight == nil)
+    }
+  }
+}
+
 // MARK: - RecordingOverlayView
 
 /// Compact recording indicator overlay.
@@ -19,16 +198,25 @@ struct RecordingOverlayView: View {
   /// showing anything more.
   let livePreviewProvider: () -> LivePreviewDisplay
   /// #1988: reports the capsule's measured height so the panel can follow it as the
-  /// preview grows. No-op when the preview is off.
-  var onContentHeightChange: (CGFloat) -> Void = { _ in }
-  /// #1988: whether this pill is the tall preview layout. Passed in rather than
-  /// derived from the display state, which remains `.off` until the polling task
-  /// first runs and would flash the capsule shape before that first read.
+  /// preview grows.
   ///
-  /// #2201: the previous wording said "for one 50 ms poll", which names a duration
-  /// the code does not have — the task reads its providers BEFORE its first sleep,
-  /// so the window is until it is first scheduled, not a fixed 50 ms.
-  var usesPreviewLayout: Bool = false
+  /// **No default, deliberately** (#2376 C2). A property default plus an init
+  /// default leaves NO TOKEN at the call site, so a caller that meant to pass one
+  /// and did not compiles and ships a pill whose window never follows its
+  /// content. `OverlayRenderModel` already substitutes a no-op for a design that
+  /// cannot grow, which is the one place that decision belongs.
+  let onContentHeightChange: (CGFloat) -> Void
+  /// What this pill DRAWS, handed in by the root from the resolved design.
+  ///
+  /// **This replaces `usesPreviewLayout`, and the replacement is a value rather
+  /// than a wider boolean** (#2376 C2). The old flag was read eighteen times and
+  /// branched on nearly all of them; a third design would have made every one of
+  /// those a place where one design could be wrong while the others looked right. It was
+  /// also passed in rather than derived from the display state — which remains
+  /// `.off` until the polling task first runs and would flash the capsule shape
+  /// before that first read — and that reasoning transfers unchanged: the chrome
+  /// is decided upstream and this view never asks what the pill is capable of.
+  let chrome: RecordingPillChrome
   var lockState: OverlayLockState
   /// #1060: transient notice banner shown inside the recording capsule.
   var noticeState: OverlayNoticeState
@@ -57,8 +245,8 @@ struct RecordingOverlayView: View {
     audioLevelProvider: @escaping () -> Float,
     recordingElapsedProvider: @escaping () -> TimeInterval? = { nil },
     livePreviewProvider: @escaping () -> LivePreviewDisplay,
-    onContentHeightChange: @escaping (CGFloat) -> Void = { _ in },
-    usesPreviewLayout: Bool = false,
+    onContentHeightChange: @escaping (CGFloat) -> Void,
+    chrome: RecordingPillChrome,
     lockState: OverlayLockState,
     noticeState: OverlayNoticeState,
     initialPreview: LivePreviewDisplay = .off
@@ -67,7 +255,7 @@ struct RecordingOverlayView: View {
     self.recordingElapsedProvider = recordingElapsedProvider
     self.livePreviewProvider = livePreviewProvider
     self.onContentHeightChange = onContentHeightChange
-    self.usesPreviewLayout = usesPreviewLayout
+    self.chrome = chrome
     self.lockState = lockState
     self.noticeState = noticeState
     _preview = State(initialValue: initialPreview)
@@ -147,10 +335,15 @@ struct RecordingOverlayView: View {
     // #2202 row 1 of the shared-root table: the capsule wants 6pt between its
     // stacked pieces; the preview puts a ruled header directly against its
     // reading well and supplies its own spacing inside each section.
-    VStack(spacing: usesPreviewLayout ? 0 : 6) {
-      if usesPreviewLayout {
+    VStack(spacing: chrome.stackSpacing) {
+      // EXHAUSTIVE over the chrome's header, with no `default:`. A default here
+      // would let a header added later render as whichever neighbour the compiler
+      // happened to fall through to, which is this phase's named regression
+      // wearing a new case.
+      switch chrome.header {
+      case .meterStrip:
         previewHeader
-      } else {
+      case .mark:
         HStack(spacing: 10) {
           // Rainbow lips icon — audio-reactive during recording.
           // Scales to 2x in hands-free (locked) mode.
@@ -178,22 +371,19 @@ struct RecordingOverlayView: View {
           // #2204: the notice is rendered by BOTH layouts from this one `Text`,
           // and white is invisible on a light pill. Gated rather than made
           // dynamic, so the capsule's paint is unchanged to the byte.
-          .foregroundStyle(
-            usesPreviewLayout ? PreviewPillPalette.notice : Color.white.opacity(0.95)
-          )
+          .foregroundStyle(chrome.noticeInk.notice)
           .multilineTextAlignment(.center)
           .fixedSize(horizontal: false, vertical: true)
           // 170pt suits the 185pt capsule. The preview pill is 400pt wide, so the
           // same cap would wrap a one-line warning into three inside a box with
           // room to spare.
-          .frame(maxWidth: usesPreviewLayout ? .infinity : 170)
+          .frame(maxWidth: chrome.noticeMaxWidth ?? .infinity)
           // #2202 row 4 of the shared-root table. The notice is rendered by BOTH
           // layouts and its ONLY inset came from the shared root padding, which
           // the preview now zeroes — so without this it sits flush against the
           // pill's bottom edge. The header and the reading well each received
           // replacement padding; this is the third section and it was missed.
-          .padding(.horizontal, usesPreviewLayout ? 16 : 0)
-          .padding(.bottom, usesPreviewLayout ? 12 : 0)
+          .padding(chrome.noticeInsets)
           .transition(.opacity)
       }
     }
@@ -207,18 +397,17 @@ struct RecordingOverlayView: View {
     // preview text, and therefore the capsule's HEIGHT. That turned each genuine
     // resize into a smoothly animated one and drove `setFrame` once per frame.
     //
-    // The trigger VALUE is kept rather than deleted, so the non-preview capsule's
-    // animation is visibly untouched in the diff and the two branches sit side by
-    // side. Audio-reactive PAINT is unaffected in both: `RainbowLipsIcon` reads
-    // `audioLevel` directly and redraws without needing this.
+    // The trigger VALUE is kept rather than deleted, so the capsule's animation is
+    // visibly untouched. **There is no branch here any more** (#2376 C2): the
+    // policy is a field on the design's chrome, so each design states its own
+    // answer once instead of both answers sitting inline. Audio-reactive PAINT is
+    // unaffected either way: `RainbowLipsIcon` reads `audioLevel` directly and
+    // redraws without needing this.
     //
     // Not a violation of swift-patterns.md RULE: animate-the-container-not-children
     // — that forbids per-child `.animation(value:)`, and this adds none. The
     // container keeps its `lockState` and `noticeState` triggers in both layouts.
-    .animation(
-      usesPreviewLayout ? nil : .easeOut(duration: 0.08),
-      value: audioLevel
-    )
+    .animation(chrome.levelAnimation.resolved, value: audioLevel)
     .animation(.easeInOut(duration: 0.25), value: noticeState.message)
     // #2202 row 8 of the shared-root table. The capsule keeps its uniform inset;
     // the preview zeroes it and each section supplies its own, because a header
@@ -226,8 +415,7 @@ struct RecordingOverlayView: View {
     // around both. Migrated ATOMICALLY with the section padding above and below:
     // split across two commits, whatever shipped in between would have had no
     // insets at all.
-    .padding(.horizontal, usesPreviewLayout ? 0 : 14)
-    .padding(.vertical, usesPreviewLayout ? 0 : 10)
+    .padding(chrome.rootInsets)
     // #2201: the preview pill's height must be a function of what it is SHOWING,
     // never of how tall it happens to be already.
     //
@@ -250,11 +438,14 @@ struct RecordingOverlayView: View {
     // The 185pt capsule sits inside a fixed 92pt frame and is out of scope for
     // #2198; `vertical: false` leaves it exactly as it was.
     //
-    // **Order is load-bearing:** after both paddings, before both backgrounds. The
+    // **Order is load-bearing:** after the root inset, before both backgrounds.
+    // (It was "after both paddings" while the root applied a horizontal and a
+    // vertical modifier separately; #2376 C2 collapsed those into one
+    // `EdgeInsets`, and the ordering constraint is unchanged.) The
     // measurement is taken on the padded stack, so moving this either side of it
     // measures a different view than the one that was proven.
-    .fixedSize(horizontal: false, vertical: usesPreviewLayout)
-    .background(OverlayCapsuleBackground(cornerStyle: usesPreviewLayout ? .rounded : .capsule))
+    .fixedSize(horizontal: false, vertical: chrome.isContentSizedVertically)
+    .background(OverlayCapsuleBackground(cornerStyle: chrome.cornerStyle))
     // #1988: report the capsule's real height so the panel can follow it. Measured
     // on the capsule rather than computed from a line count, because only the text
     // engine knows how many lines a sentence wraps to at this width in this script.
@@ -314,10 +505,10 @@ struct RecordingOverlayView: View {
       // HAS a well; the defect was asking for a well to hold nothing. Fixed at the
       // call site rather than by making the shared padding conditional, which would
       // put an emptiness test inside a view that should not care.
-      if usesPreviewLayout {
-        EmptyView()
-      } else {
+      if chrome.showsListeningSentence {
         previewText(LivePreviewCopy.listening, dimmed: true, lines: 1)
+      } else {
+        EmptyView()
       }
     case .unavailable(let reason):
       // Say why rather than sitting blank. A blank preview reads as "it did not
@@ -353,7 +544,9 @@ struct RecordingOverlayView: View {
   /// measurement.
   private func previewText(_ message: String, dimmed: Bool, lines: Int) -> some View {
     PreviewWellText(
-      message: message, dimmed: dimmed, lines: lines, usesPreviewLayout: usesPreviewLayout)
+      message: message, dimmed: dimmed, lines: lines,
+      insets: chrome.wellInsets, ink: chrome.wellInk,
+      fadesWhenFull: chrome.fadesWhenWellIsFull)
   }
 
   /// #2203: ONE authority for preview typography. The `Text` and the cap both read
@@ -406,7 +599,13 @@ struct PreviewWellText: View {
   let message: String
   let dimmed: Bool
   let lines: Int
-  let usesPreviewLayout: Bool
+  /// The three chrome values this view needs, handed down rather than a copy of
+  /// the whole thing. **It used to carry `usesPreviewLayout` itself**, which made
+  /// it a second style authority one level below the leaf: the same boolean, read
+  /// again, free to disagree.
+  let insets: EdgeInsets
+  let ink: PillInk
+  let fadesWhenFull: Bool
 
   /// Whether the well is at its cap, and so whether anything is scrolling off the
   /// top. Written from a `GeometryReader` in the BACKGROUND of the capped frame,
@@ -422,11 +621,7 @@ struct PreviewWellText: View {
     Text(message)
       .font(.system(size: RecordingOverlayView.previewFontSize))
       .lineSpacing(RecordingOverlayView.previewLineSpacing)
-      .foregroundStyle(
-        usesPreviewLayout
-          ? (dimmed ? PreviewPillPalette.textDimmed : PreviewPillPalette.text)
-          : .white.opacity(dimmed ? 0.5 : 0.92)
-      )
+      .foregroundStyle(ink.well(dimmed: dimmed))
       .multilineTextAlignment(.leading)
       .fixedSize(horizontal: false, vertical: true)
       .frame(maxWidth: .infinity, alignment: .leading)
@@ -468,14 +663,12 @@ struct PreviewWellText: View {
       // box would clip at four-and-a-bit lines and the founder's five-line rule
       // would quietly stop holding — a number that looks like it means lines
       // while meaning something else.
-      .padding(.horizontal, usesPreviewLayout ? 16 : 0)
-      .padding(.top, usesPreviewLayout ? 12 : 0)
-      .padding(.bottom, usesPreviewLayout ? 15 : 0)
+      .padding(insets)
   }
 
   @ViewBuilder
   private var fadeMask: some View {
-    if usesPreviewLayout && wellIsFull {
+    if fadesWhenFull && wellIsFull {
       LinearGradient(
         stops: [
           .init(color: .clear, location: 0),

--- a/Sources/EnviousWisprAppKit/App/Overlay/Views/RecordingOverlayView.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/Views/RecordingOverlayView.swift
@@ -182,10 +182,16 @@ extension RecordingPillDesign {
         levelAnimation: .none,
         showsListeningSentence: false,
         noticeInk: .capsuleWhite,
-        // 260 less the 14pt root inset either side. Stated as the arithmetic it
-        // is, because a bare 232 beside a 260-wide design reads as a second
+        // 288 less the 14pt root inset either side. Stated as the arithmetic it
+        // is, because a bare 260 beside a 288-wide design reads as a second
         // measurement nobody took.
-        noticeMaxWidth: 232,
+        //
+        // **This is the site the round-5 width change nearly missed.** Nothing
+        // fails if it keeps the old 232 — notices would just wrap 28pt early,
+        // for ever, with no test red anywhere. It was found by grepping the
+        // VALUE rather than the symbol, which is the only thing that reaches a
+        // number carrying someone else's arithmetic.
+        noticeMaxWidth: 260,
         noticeInsets: EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0),
         wellInsets: EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0),
         wellInk: .capsuleWhite,
@@ -385,6 +391,40 @@ struct RecordingOverlayView: View {
           // the audio-reactive element, and two of them would compete.
           RainbowLevelMeter(
             audioLevel: audioLevel, tick: audioTick, height: 24, barWidth: 3, spacing: 2)
+
+          // **The hands-free badge, and without it this design was the one that
+          // never said the microphone stays open** (#2376 Phase 4, cloud review
+          // round 5, P1). Every other visual property here is independent of
+          // `lockState.isLocked`, so the container's animation had nothing to
+          // animate and the locked pill was pixel-identical to the unlocked one.
+          // The cost is not cosmetic: hands-free keeps recording after the key is
+          // released, so a user with no confirmation can leave a capture running.
+          //
+          // Treatment is the reading well's, verbatim, for the reason recorded
+          // there: a filled badge because the mode PERSISTS, where a size change
+          // is only legible to someone who saw the other size a second earlier.
+          //
+          // **INLINE rather than on a row of its own, and the reserved-box guard is
+          // what decided that.** A second row put the pill at 104pt with a #1060
+          // banner also showing, against the 92pt box this design reserves — and a
+          // without-words pill is handed a no-op growth callback, so that overflow
+          // is CLIPPED with nothing reporting it. The box is the inherited notice
+          // budget rather than a number this phase gets to pick, so the badge
+          // gives up the row instead.
+          //
+          // No leading dot, unlike the reading well's: this row is a ~45pt clock
+          // plus 24 bars at 3pt-and-2pt, and the dot is 11pt of the margin that
+          // keeps the rail from being squeezed. Measured locked: 279pt of content,
+          // which is what moved this design's width to 288.
+          if lockState.isLocked {
+            Text(LivePreviewCopy.handsFreeMode)
+              .font(.system(size: 11, weight: .semibold))
+              .foregroundStyle(PreviewPillPalette.badgeText)
+              .padding(.horizontal, 9)
+              .padding(.vertical, 3)
+              .background(Capsule().fill(PreviewPillPalette.badgeFill))
+              .transition(.opacity)
+          }
         }
 
       case .mark:

--- a/Sources/EnviousWisprAppKit/App/Overlay/Views/RecoveryNoticeView.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/Views/RecoveryNoticeView.swift
@@ -10,8 +10,21 @@ import SwiftUI
 /// notice shape (spinner + plain-English copy) and adds a Discard affordance for
 /// "I don't want to wait." Icon + text (never color-only); the Discard button is
 /// keyboard-activatable for VoiceOver.
+/// **It renders the model it is handed and reads no copy of its own** (#2376
+/// Phase 4, C3). It used to take only a closure and reach for
+/// `DictationNarrator.recoveryTitle`, `.recoverySubtitle` and
+/// `.recoveryAccessibilityLabel` itself, and to hardcode both button strings —
+/// while `PillCatalog` was already carrying every one of those values on the
+/// model. Two sources for one sentence, and the leaf's copy was the one on
+/// screen.
 struct RecoveryNoticeView: View {
-  let onDiscard: () -> Void
+  let title: String
+  let subtitle: String?
+  /// What VoiceOver reads for the pill as a whole. Distinct from `title` by
+  /// design: the title carries an ellipsis and the spoken label does not.
+  let accessibilityLabel: String
+  let action: NoticeAction?
+  let onAction: () -> Void
 
   var body: some View {
     HStack(spacing: 10) {
@@ -19,30 +32,34 @@ struct RecoveryNoticeView: View {
         .controlSize(.small)
         .accessibilityHidden(true)
       VStack(alignment: .leading, spacing: 1) {
-        Text(DictationNarrator.recoveryTitle)
+        Text(title)
           .font(.system(size: 13, weight: .medium))
           .foregroundStyle(.white)
-        Text(DictationNarrator.recoverySubtitle)
-          .font(.system(size: 11))
-          .foregroundStyle(.white.opacity(0.7))
+        if let subtitle {
+          Text(subtitle)
+            .font(.system(size: 11))
+            .foregroundStyle(.white.opacity(0.7))
+        }
       }
       Spacer(minLength: 8)
-      Button(action: onDiscard) {
-        Text("Discard")
-          .font(.system(size: 12, weight: .semibold))
-          .foregroundStyle(.white)
-          .padding(.horizontal, 12)
-          .padding(.vertical, 4)
-          .contentShape(Rectangle())
-          .background(Capsule().fill(Color.white.opacity(0.18)))
+      if let action {
+        Button(action: onAction) {
+          Text(action.label)
+            .font(.system(size: 12, weight: .semibold))
+            .foregroundStyle(.white)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 4)
+            .contentShape(Rectangle())
+            .background(Capsule().fill(Color.white.opacity(0.18)))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(action.spokenLabel)
       }
-      .buttonStyle(.plain)
-      .accessibilityLabel("Discard recovering recording")
     }
     .padding(.horizontal, 14)
     .padding(.vertical, 10)
     .background(OverlayCapsuleBackground())
     .accessibilityElement(children: .contain)
-    .accessibilityLabel(DictationNarrator.recoveryAccessibilityLabel)
+    .accessibilityLabel(accessibilityLabel)
   }
 }

--- a/Sources/EnviousWisprAppKit/App/PillAppearanceModel.swift
+++ b/Sources/EnviousWisprAppKit/App/PillAppearanceModel.swift
@@ -1,0 +1,63 @@
+import EnviousWisprCore
+import EnviousWisprServices
+import Observation
+
+/// The Appearance page's window onto the recording pill (#2376 Phase 4, C7).
+///
+/// **One narrow home rather than a second derivation.** The picker needs two
+/// things the settings store cannot give it: whether this machine can show words
+/// as you speak, and WHY not when it cannot. Both come from the live-preview
+/// coordinator through `LivePreviewBridge`, so this holds that one closure and
+/// the settings object, and computes nothing of its own.
+///
+/// **It deliberately does NOT re-derive capability from the engine resolver**,
+/// which is what `LivePreviewSettingsView` does for its own page. That page asks
+/// "is any engine available here" — a different question from the coordinator's
+/// "will the engine I am configured to use actually run, and is the preview
+/// switched on" — and shipping both would put two answers to one question in
+/// front of the same user on two pages.
+@MainActor
+@Observable
+final class PillAppearanceModel {
+
+  private let settings: SettingsManager
+  private let capability: () -> PillWordsCapability
+
+  init(settings: SettingsManager, capability: @escaping () -> PillWordsCapability) {
+    self.settings = settings
+    self.capability = capability
+  }
+
+  /// Why words are or are not available right now.
+  var wordsCapability: PillWordsCapability { capability() }
+
+  /// The designs in one group, in the catalog's own order.
+  func designs(holdingWords: Bool) -> [RecordingPillDesign] {
+    PillCatalog.designs(holdingWords: holdingWords)
+  }
+
+  /// **Whether this design may be chosen, asked of the CATALOG.** The picker
+  /// decides nothing: a design it greys out is exactly a design the pill would
+  /// refuse, because `PillCatalog.offers` is defined in terms of the same
+  /// `resolve` the director calls.
+  func offers(_ design: RecordingPillDesign, holdingWords: Bool) -> Bool {
+    PillCatalog.offers(design, capabilityHasWords: holdingWords)
+  }
+
+  /// The design currently chosen for a group.
+  func selection(holdingWords: Bool) -> RecordingPillDesign {
+    holdingWords
+      ? settings.recordingPillDesignWithWords
+      : settings.recordingPillDesignWithoutWords
+  }
+
+  /// Choose a design for ONE group. Writing only that group's key is what
+  /// preserves the other side's memory across a capability flip.
+  func choose(_ design: RecordingPillDesign, holdingWords: Bool) {
+    if holdingWords {
+      settings.recordingPillDesignWithWords = design
+    } else {
+      settings.recordingPillDesignWithoutWords = design
+    }
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/PillAppearanceModel.swift
+++ b/Sources/EnviousWisprAppKit/App/PillAppearanceModel.swift
@@ -28,8 +28,28 @@ final class PillAppearanceModel {
     self.capability = capability
   }
 
+  /// Bumped whenever the coordinator reports that capability may have moved for
+  /// a reason no settings key records. Observed rather than merely stored: it is
+  /// READ by `wordsCapability` below, which is what puts a SwiftUI page reading
+  /// that property into this object's dependency graph.
+  private var capabilityGeneration = 0
+
   /// Why words are or are not available right now.
-  var wordsCapability: PillWordsCapability { capability() }
+  ///
+  /// **The discard is load-bearing, not tidying.** Reading `capabilityGeneration`
+  /// is what registers the dependency; the closure behind `capability` reaches a
+  /// class that is not `@Observable`, so a page that read only its result would
+  /// never be invalidated when removal suppression begins or ends.
+  var wordsCapability: PillWordsCapability {
+    _ = capabilityGeneration
+    return capability()
+  }
+
+  /// The coordinator reporting a change no settings key can announce.
+  func capabilityDidChange() {
+    capabilityGeneration &+= 1
+  }
+
 
   /// The designs in one group, in the catalog's own order.
   func designs(holdingWords: Bool) -> [RecordingPillDesign] {

--- a/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
+++ b/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
@@ -269,6 +269,8 @@ final class PipelineSettingsSync {
       break  // UI-only; applied to NSApp.appearance by the app shell (#1047).
     case .overlayPillPosition:
       break  // #1341: UI-only; read at fresh panel creation.
+    case .recordingPillDesignWithoutWords, .recordingPillDesignWithWords:
+      break  // #2376: UI-only; read at the start of the next fresh recording.
     case .showBluetoothTips:
       break  // #1480: UI-only; read by BluetoothAwarenessPresenter, no pipeline sync.
     case .playRecordingSounds, .recordingSoundPairing:

--- a/Sources/EnviousWisprAppKit/App/PreviewPillPalette.swift
+++ b/Sources/EnviousWisprAppKit/App/PreviewPillPalette.swift
@@ -113,10 +113,16 @@ enum PreviewPillPalette {
 
   /// The #1060 notice banner.
   ///
-  /// **This one is why the palette exists.** The notice is rendered by BOTH
-  /// layouts from one `Text`, and its colour was a hardcoded white — invisible on
-  /// a light pill. It has to be selected on `usesPreviewLayout` at the call site,
-  /// with the capsule keeping `.white.opacity(0.95)` exactly.
+  /// **This one is why the palette exists.** The notice is rendered by EVERY
+  /// recording layout from one `Text`, and its colour was a hardcoded white —
+  /// invisible on a light pill.
+  ///
+  /// **It is selected by the DESIGN's chrome, not at the call site** (#2376
+  /// Phase 4, C2). `RecordingPillChrome.noticeInk` names an ink case and
+  /// `PillInk.notice` resolves it, so a design says which ink it wants and the
+  /// call site chooses nothing. The capsule keeps `.white.opacity(0.95)` exactly,
+  /// which `CapsuleBackgroundFreezeTests` pins by counting that literal's single
+  /// occurrence.
   static let notice = Color.stDynamic(
     lightRGB: (0.059, 0.039, 0.102, 0.88),
     darkRGB: (1.0, 1.0, 1.0, 0.95))

--- a/Sources/EnviousWisprAppKit/App/SettingsChangeTelemetry.swift
+++ b/Sources/EnviousWisprAppKit/App/SettingsChangeTelemetry.swift
@@ -125,7 +125,14 @@ enum SettingsProjection {
       .selectedInputDeviceUID, .preferredInputDeviceIDOverride,
       // #1480: the popover's own lifecycle telemetry (`bt_awareness.*`) owns this
       // signal, incl. `suppressed_by_setting`; no separate settings.changed delta.
-      .showBluetoothTips:
+      .showBluetoothTips,
+      // #2376: which recording pill a user picked. NOT instrumented, and that is
+      // a decision rather than an omission. Adding a `Logical` would auto-emit the
+      // value into the `settings.snapshot` config block, which iterates
+      // `Logical.allCases`, and no consumer exists for it. A closed enum value is
+      // shape rather than content, so `CLAUDE.md`'s privacy test permits it
+      // whenever a consumer appears; it simply has not.
+      .recordingPillDesignWithoutWords, .recordingPillDesignWithWords:
       return []
     }
   }

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -527,6 +527,12 @@ public final class WisprBootstrapper {
     // same capability the director does rather than re-deriving one.
     let pillAppearance = PillAppearanceModel(
       settings: settings, capability: livePreviewInstallation.bridge.wordsCapability)
+    // Removal suppression is the one capability input no settings key records, so
+    // it has to be pushed. Weak, for the reason every other hook into this limb is
+    // weak: a settings page must never be what keeps it alive.
+    livePreview.onWordsCapabilityMayHaveChanged = { [weak pillAppearance] in
+      pillAppearance?.capabilityDidChange()
+    }
 
     // #1701 Chunk 2: bulk-import-enrichment producer, a sibling of
     // `contactsImportCoordinator` on the same alias-suggester permit lane.

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -74,6 +74,10 @@ public final class WisprBootstrapper {
   /// lives as long as the app — which is what "runs on every launch" requires.
   let whisperKitRetirement: WhisperKitLegacyUpgradeCoordinator?
   let audioDeviceList: AudioDeviceList
+  /// #2376 C7: the Appearance page's window onto the recording pill. A
+  /// view-facing home like the nine beside it, injected into every window root
+  /// that hosts Settings.
+  let pillAppearance: PillAppearanceModel
   let inputDevicePreferenceReconciler: InputDevicePreferenceReconciler
   let aiAvailability: AIAvailabilityCoordinator
   let keychainManager: KeychainManager
@@ -498,18 +502,31 @@ public final class WisprBootstrapper {
       // and that captures weakly. `WisprBootstrapper` owns the service for the
       // app's lifetime regardless.
       grantAccessibility: { _ = permissions.requestAccessibilityAccess() },
-      // **THE SEAM PHASE 4 REPLACES, and it is a closure so that it can be.**
-      // The director lives for the app's lifetime, so a stored pair would freeze
-      // the user's choice at launch: a picker would appear to work, change
-      // nothing, and only take effect after a relaunch.
+      // **THE SEAM PHASE 3 LEFT, NOW SPENT** (#2376 Phase 4, C6). It is a closure
+      // so that it can be: the director lives for the app's lifetime, so a stored
+      // pair would freeze the user's choice at launch — a picker would appear to
+      // work, change nothing, and only take effect after a relaunch.
       //
-      // Phase 3 returns the constant the current code already produces — the
-      // classic capsule without words, the reading well with them. Phase 4
-      // replaces this closure's BODY with a settings-backed snapshot and nothing
-      // else: not `PillCatalog.entry`, not `DesignResolution`, not the call site,
-      // not where the director resolves capability. If Phase 4 finds itself
-      // changing any of those, this seam was wrong.
-      selections: { .shipped })
+      // Phase 3 returned a constant and predicted that Phase 4 would replace this
+      // closure's BODY and nothing else: not `PillCatalog.entry`, not
+      // `DesignResolution`, not the call site, not where the director resolves
+      // capability. That held — this is the only line of composition that moved.
+      //
+      // `settings` is captured strongly, exactly as `position:` above captures it,
+      // and the bootstrapper owns both for the app's lifetime so there is no
+      // cycle. Every party is already `@MainActor`, so there is no hop and nothing
+      // to make `Sendable`.
+      selections: {
+        PillDesignSelections(
+          withoutWords: settings.recordingPillDesignWithoutWords,
+          withWords: settings.recordingPillDesignWithWords)
+      })
+
+    // #2376 C7: the Appearance page's window onto the pill. Built HERE because
+    // this is where the live-preview bridge already is, so the picker reads the
+    // same capability the director does rather than re-deriving one.
+    let pillAppearance = PillAppearanceModel(
+      settings: settings, capability: livePreviewInstallation.bridge.wordsCapability)
 
     // #1701 Chunk 2: bulk-import-enrichment producer, a sibling of
     // `contactsImportCoordinator` on the same alias-suggester permit lane.
@@ -1055,6 +1072,7 @@ public final class WisprBootstrapper {
     self.egOneRuntime = egOneRuntime
     self.modelDelivery = modelDelivery
     self.audioDeviceList = audioDeviceList
+    self.pillAppearance = pillAppearance
     self.inputDevicePreferenceReconciler = inputDevicePreferenceReconciler
     self.aiAvailability = aiAvailability
     self.keychainManager = keychainManager
@@ -1264,6 +1282,7 @@ private struct MainWindowRoot: View {
       .environment(b.appWindowCoordinator)
       // The nine view-facing homes (epic #763).
       .environment(b.settings)
+      .environment(b.pillAppearance)
       .environment(b.permissions)
       .environment(b.customWordsCoordinator)
       .environment(b.contactsImportCoordinator)

--- a/Sources/EnviousWisprAppKit/Views/Settings/AppearanceSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AppearanceSettingsView.swift
@@ -19,9 +19,14 @@ struct AppearanceSettingsView: View {
 
     SettingsContentView {
       // No section eyebrow or restated description here: the page-header card
-      // already introduces the page ("Appearance — Choose how EnviousWispr looks
-      // in light and dark") and each card describes its own mode. Say it once,
-      // then show the choices (founder, 2026-07-03).
+      // already introduces the page and each card describes its own mode. Say it
+      // once, then show the choices (founder, 2026-07-03).
+      //
+      // **#2376: that header no longer tells the whole truth and was revised with
+      // this change.** It read "Choose how EnviousWispr looks in light and dark",
+      // which was complete while theme and pill position were the only settings
+      // here; a pill-design picker on the same page makes it a description of one
+      // section rather than of the page.
       LazyVGrid(columns: columns, spacing: 12) {
         ForEach(AppearancePreference.allCases, id: \.self) { preference in
           AppearanceCard(
@@ -48,6 +53,9 @@ struct AppearanceSettingsView: View {
           selection: $settings.overlayPillPosition
         )
       }
+
+      // #2376: which pill is drawn while dictating, per capability group.
+      RecordingPillAppearancePanel()
     }
   }
 }

--- a/Sources/EnviousWisprAppKit/Views/Settings/RecordingPillAppearancePanel.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/RecordingPillAppearancePanel.swift
@@ -87,6 +87,8 @@ struct RecordingPillAppearancePanel: View {
           "These need Live Preview, which is currently off. Turn it on in Live Preview settings."
       case .engineUnsupported:
         return "These need Live Preview, which the engine you have selected cannot run on this Mac."
+      case .modelBeingRemoved:
+        return "These need Live Preview, which is unavailable while the model you removed finishes clearing."
       }
     }
     // The wordless group is inactive exactly when words ARE available.

--- a/Sources/EnviousWisprAppKit/Views/Settings/RecordingPillAppearancePanel.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/RecordingPillAppearancePanel.swift
@@ -1,0 +1,165 @@
+import EnviousWisprCore
+import SwiftUI
+
+/// Choose the recording pill's design, per capability group (#2376 Phase 4, C7).
+///
+/// **Two groups, and the one that does not apply is GREYED WITH ITS REASON
+/// rather than hidden.** Hiding it would leave a user who turns Live Preview on
+/// wondering where the other pills went, and would give no clue to a user whose
+/// engine cannot run here that the switch is not the thing standing in their way.
+///
+/// **The groups and their offerability come from `PillCatalog`, never from this
+/// view.** A design this page greys out is exactly a design the pill would
+/// refuse, because `offers` is defined in terms of the same `resolve` the
+/// director calls. A local `allCases.filter { $0.canHoldWords == x }` would be a
+/// second derivation of that rule even on the day it agreed.
+///
+/// **The reason is stated ONCE, at group level.** Two precedents were considered
+/// and both rejected: `EngineCard` puts a reason inside a card that stays
+/// selectable, and `LivePreviewSettingsView` deliberately moved its reason OUT of
+/// the disabled control onto another card, on the recorded grounds that two
+/// places saying why is how they come to disagree. Here the requirement is the
+/// reason WITH the greyed group, so it is rendered once in that group's header
+/// and nowhere else.
+struct RecordingPillAppearancePanel: View {
+
+  @Environment(PillAppearanceModel.self) private var model
+
+  private let columns = [GridItem(.adaptive(minimum: 210, maximum: .infinity), spacing: 12)]
+
+  var body: some View {
+    BrandedPanel(
+      icon: "waveform.badge.mic",
+      header: "Recording Pill",
+      description:
+        "Choose how the pill looks while you are dictating. Changes apply the next time you record."
+    ) {
+      VStack(alignment: .leading, spacing: 18) {
+        group(holdingWords: false)
+        group(holdingWords: true)
+      }
+    }
+  }
+
+  private var hasWords: Bool { model.wordsCapability.hasWords }
+
+  @ViewBuilder
+  private func group(holdingWords: Bool) -> some View {
+    let isActive = holdingWords == hasWords
+    VStack(alignment: .leading, spacing: 8) {
+      Text(holdingWords ? "Shows your words as you speak" : "Without live words")
+        .font(.stRowTitle)
+        .foregroundStyle(isActive ? .stTextPrimary : .stTextSecondary)
+
+      // The reason, rendered ONLY on the inactive group and only once.
+      if !isActive,
+        let reason = Self.reason(for: model.wordsCapability, groupHoldsWords: holdingWords)
+      {
+        Text(reason)
+          .settingsReadingCopy()
+      }
+
+      LazyVGrid(columns: columns, spacing: 12) {
+        ForEach(model.designs(holdingWords: holdingWords), id: \.self) { design in
+          RecordingPillDesignCard(
+            design: design,
+            isSelected: model.selection(holdingWords: holdingWords) == design,
+            isEnabled: model.offers(design, holdingWords: holdingWords) && isActive,
+            onSelect: { model.choose(design, holdingWords: holdingWords) })
+        }
+      }
+    }
+    // One animation on the container, never per `ForEach` child.
+    .animation(.easeInOut(duration: 0.15), value: isActive)
+  }
+
+  /// Why the inactive group is inactive, in that user's terms.
+  ///
+  /// **Two refusals, two sentences, and that is the whole reason the capability
+  /// carries a reason at all.** One sentence for both would tell a user whose
+  /// engine cannot run on this Mac to turn on a setting that would not help them.
+  static func reason(for capability: PillWordsCapability, groupHoldsWords: Bool) -> String? {
+    if groupHoldsWords {
+      switch capability {
+      case .available: return nil
+      case .previewOff:
+        return
+          "These need Live Preview, which is currently off. Turn it on in Live Preview settings."
+      case .engineUnsupported:
+        return "These need Live Preview, which the engine you have selected cannot run on this Mac."
+      }
+    }
+    // The wordless group is inactive exactly when words ARE available.
+    return capability.hasWords
+      ? "Live Preview is on, so the pill shows your words. These become available if you turn it off."
+      : nil
+  }
+}
+
+/// One selectable pill design.
+///
+/// A new card rather than a generalised `AppearanceCard`: that one is private to
+/// the light/dark grid this phase must leave untouched, and widening it would
+/// mean editing the very control the page already ships.
+private struct RecordingPillDesignCard: View {
+  let design: RecordingPillDesign
+  let isSelected: Bool
+  let isEnabled: Bool
+  let onSelect: () -> Void
+
+  var body: some View {
+    Button(action: onSelect) {
+      VStack(alignment: .leading, spacing: 6) {
+        HStack(spacing: 8) {
+          Image(systemName: iconName)
+            .font(.system(size: 16, weight: .medium))
+            .foregroundStyle(isSelected && isEnabled ? .stAccent : .stTextSecondary)
+            .frame(width: 22, alignment: .center)
+          Text(design.displayName)
+            .font(.stRowTitle)
+            .foregroundStyle(isSelected && isEnabled ? .stAccent : .stTextPrimary)
+          Spacer(minLength: 0)
+          if isSelected {
+            Image(systemName: "checkmark.circle.fill")
+              .font(.system(size: 15, weight: .semibold))
+              .foregroundStyle(isEnabled ? Color.stAccent : Color.stTextSecondary)
+          }
+        }
+        Text(design.summary)
+          .settingsReadingCopy()
+          .frame(maxWidth: .infinity, minHeight: 40, alignment: .topLeading)
+      }
+      .padding(14)
+      // Before `.buttonStyle(.plain)`, so the whole card is the hit target rather
+      // than the label's glyphs.
+      .contentShape(Rectangle())
+      .background(Color.stSectionBg)
+      .clipShape(RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius))
+      .overlay(
+        RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius)
+          .strokeBorder(
+            isSelected && isEnabled ? Color.stAccent : Color.stDivider,
+            lineWidth: isSelected && isEnabled ? 2 : 1)
+      )
+    }
+    .buttonStyle(.plain)
+    .disabled(!isEnabled)
+    .opacity(isEnabled ? 1 : 0.45)
+    // **Addressed by role and title, never by an accessibility identifier**
+    // (swift-patterns). A greyed card must REPORT as disabled rather than merely
+    // look it: the mistake `EngineCard` records for itself is a control that is
+    // visible and inaudible.
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(design.displayName)
+    .accessibilityValue(isSelected ? "Selected" : "")
+    .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
+  }
+
+  private var iconName: String {
+    switch design {
+    case .classic: return "capsule"
+    case .readingWell: return "text.alignleft"
+    case .levelRail: return "waveform"
+    }
+  }
+}

--- a/Sources/EnviousWisprAppKit/Views/Settings/SettingsSection.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SettingsSection.swift
@@ -85,7 +85,9 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     switch self {
     case .history: return "Your past dictations, searchable and ready to reuse."
     case .whatsNew: return "The latest improvements and fixes in this release."
-    case .appearance: return "Choose how EnviousWispr looks in light and dark."
+    // #2376: widened from "in light and dark" when the recording-pill picker
+    // joined this page. The old line described one section rather than the page.
+    case .appearance: return "Choose how EnviousWispr looks, and which pill you see while dictating."
     case .speechEngine: return "The speech engine that turns your voice into text."
     case .livePreview: return "See your words on screen while you are still speaking."
     case .audio: return "Choose your input source and readiness behavior."

--- a/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
@@ -20,6 +20,39 @@ enum WhatsNewContent {
   static let entries: [Entry] = [
     // MARK: - v2.4.6
 
+    // #2376. FIRST in the 2.4.6 group because order is the hierarchy
+    // (whats-new-protocol.md RULE: whats-new-content-rules): headline feature,
+    // then supporting features, then fixes. This is the feature; the entry below
+    // is a removal.
+    //
+    // The 2.4.6 group is already open and already matches
+    // `WhatsNewConstants.currentContentVersion`, so this needs no Core edit —
+    // bumping it here would invent a release.
+    //
+    // **The copy names what a user GAINS, not what moved underneath.** Most of
+    // this phase is a refactor nobody should be able to see, and saying so would
+    // be talking about our code on a page about their app. What is genuinely new
+    // is a choice they did not have and a meter most of them have never seen: it
+    // has shipped since #2216 with exactly one construction site, inside the live
+    // preview pill, so only users who can and do run that feature have ever laid
+    // eyes on it.
+    //
+    // It deliberately does NOT promise the meter to everyone: it is one of two
+    // options, and the capsule stays the default so nobody's pill changes on
+    // upgrade. No dash characters, per GR-NO-DASHES.
+    //
+    // TITLE NOT YET FOUNDER-EDITED. He read and edited every title in the 2.4.5
+    // group by hand on 2026-08-20; this one was written without him and is the
+    // obvious thing for him to change.
+    Entry(
+      id: "recording-pill-designs",
+      icon: "waveform.badge.mic",
+      title: "Choose how your recording pill looks",
+      description:
+        "The pill that appears while you dictate now comes in more than one shape, and you pick which one you see. Appearance settings has a new Recording Pill section with two groups: pills that show your words as you speak, and pills that do not. Alongside the capsule you already know there is a new Level Rail, a wider pill carrying your timer beside a live rainbow meter of your voice. That meter has been in the app for a while, but until now only people running Live Preview ever saw it. Each group remembers its own choice, so if you switch Live Preview off and on again you get back the pill you picked for each. The group that does not apply to you right now stays visible and greyed, and tells you why rather than leaving you to guess.",
+      version: "2.4.6"
+    ),
+
     // #1831. OPENS THE 2.4.6 GROUP, and that placement is load-bearing.
     //
     // v2.4.5 shipped 2026-08-20. Anyone who has opened What's New since

--- a/Sources/EnviousWisprCore/SettingsEnums.swift
+++ b/Sources/EnviousWisprCore/SettingsEnums.swift
@@ -35,6 +35,46 @@ public enum LivePreviewEngineChoice: String, CaseIterable, Sendable {
   case universal
 }
 
+/// Which recording pill the user gets (#2375 Phase 3; moved here by #2376 C4/C6).
+///
+/// **A DESIGN, not a capability.** Whether the machine can show words as you
+/// speak is a capability the director reads; which pill is drawn is a choice the
+/// user makes. Keeping those two vocabularies apart is what lets one change
+/// without touching the other.
+///
+/// **It lives in Core because a SETTING persists it**, and `SettingsManager` is
+/// in Services. Only the identity is here: `canHoldWords`, `width`,
+/// `reservedHeight` and `chrome` are an AppKit extension, because Core has no
+/// business knowing a pill's pixels. Persisted by rawValue, which derives from
+/// the case NAMES — `recordingPillDesignRawValuesAreStable` pins them, because a
+/// rename would silently orphan every saved selection to the fallback.
+///
+/// **`package`, not `public`, and it is forced rather than stylistic.** A public
+/// non-frozen enum from another module makes every switch over it demand
+/// `@unknown default`, which would destroy this phase's exhaustive-routing
+/// requirement — a design added later could then render as a neighbour by falling
+/// through. `package` keeps the compiler's exhaustiveness and is already used
+/// cross-module in this build.
+package enum RecordingPillDesign: String, Equatable, Sendable, CaseIterable {
+  /// The rainbow-lips capsule: a fixed 185x92 interaction frame that holds the
+  /// normal capsule, the locked state and the #1060 notice expansion without
+  /// resizing on every morph.
+  case classic
+  /// The wide panel that shows words as you speak. Content-sized from the first
+  /// frame so it does not visibly snap as lines wrap.
+  ///
+  /// **`.readingWell`, deliberately not `.livePreview`.** Naming a design after
+  /// the capability that enables it makes the settings group label and the card
+  /// label the same word, and forecloses a second with-words design before one
+  /// exists. The capability keeps its own name.
+  case readingWell
+  /// A wider capsule carrying the clock beside a live rainbow level rail, and no
+  /// lips mark (#2376 Phase 4, C5). Named for what it DRAWS, following
+  /// `.readingWell`'s reasoning; it says nothing about words or preview, so it
+  /// survives a capability rename.
+  case levelRail
+}
+
 /// Where the recording pill (and every transient overlay sharing its window —
 /// polishing, warnings, cold-start notices, the Bluetooth card) appears on
 /// screen. Persisted by rawValue; unknown/missing values resolve to `.top`.

--- a/Sources/EnviousWisprServices/SettingsDefaultValues.swift
+++ b/Sources/EnviousWisprServices/SettingsDefaultValues.swift
@@ -19,6 +19,16 @@ enum SettingsDefaultValues {
   // #1341: recording pill / status notices default to the top of the screen,
   // matching the fixed position every existing install already sees.
   static let overlayPillPosition: OverlayPillPosition = .top
+  /// #2376: which recording pill a user sees when the machine cannot show words
+  /// as they speak. The shipped capsule, so nobody's pill changes on upgrade.
+  static let recordingPillDesignWithoutWords: RecordingPillDesign = .classic
+  /// #2376: and when it can. The reading well, likewise unchanged.
+  ///
+  /// **These two are asserted to equal `PillDesignSelections.shipped`**, which is
+  /// the frozen pair every overlay test measures against. One production
+  /// authority, one frozen reference, and a test saying they agree — rather than
+  /// two constants that happen to match on the day they were written.
+  static let recordingPillDesignWithWords: RecordingPillDesign = .readingWell
 
   // #923: AI polish is ON by default, Apple Intelligence. Previously the cold
   // fallback was `.none` and onboarding wrote `.appleIntelligence` separately,

--- a/Sources/EnviousWisprServices/SettingsManager.swift
+++ b/Sources/EnviousWisprServices/SettingsManager.swift
@@ -49,6 +49,8 @@ public final class SettingsManager {
     case warmEnginePolicy
     case appearance
     case overlayPillPosition
+    case recordingPillDesignWithoutWords
+    case recordingPillDesignWithWords
     case showBluetoothTips
     case playRecordingSounds
     case recordingSoundPairing
@@ -92,6 +94,7 @@ public final class SettingsManager {
     "useStreamingASR", "livePreviewEnabled", "livePreviewEngine",
     "warmEnginePolicy", "appearancePreference",
     "overlayPillPosition",
+    "recordingPillDesignWithoutWords", "recordingPillDesignWithWords",
     "showBluetoothTips", "playRecordingSounds", "recordingSoundPairing",
     WhatsNewConstants.lastSeenVersionDefaultsKey,
     globeGuidanceClaimKey,
@@ -534,6 +537,37 @@ public final class SettingsManager {
     }
   }
 
+  /// #2376: which recording pill is drawn when the machine cannot show words as
+  /// you speak, and when it can.
+  ///
+  /// **TWO keys rather than one, and that is the feature rather than an
+  /// implementation detail.** Without words the choice is cosmetic; with words the
+  /// pill has to be able to hold them, so the two states are genuinely different
+  /// products. Persisting them separately is what lets a user turn Live Preview
+  /// off and back on and get the pill they last chose on that side, instead of
+  /// whichever one a single shared key happened to hold.
+  ///
+  /// Nothing is written on a capability flip: `PillCatalog` reads whichever side
+  /// the capability selects. A value that has somehow crossed groups — a
+  /// hand-edited plist, a downgrade — cannot render wrong, because
+  /// `PillDesignSelections.resolve` fails closed in both directions.
+  ///
+  /// UI-only: read at the start of each FRESH recording through the director's
+  /// selections closure, never live-patched into a pill already on screen.
+  package var recordingPillDesignWithoutWords: RecordingPillDesign {
+    didSet {
+      defaults.set(recordingPillDesignWithoutWords.rawValue, forKey: "recordingPillDesignWithoutWords")
+      onChange?(.recordingPillDesignWithoutWords)
+    }
+  }
+
+  package var recordingPillDesignWithWords: RecordingPillDesign {
+    didSet {
+      defaults.set(recordingPillDesignWithWords.rawValue, forKey: "recordingPillDesignWithWords")
+      onChange?(.recordingPillDesignWithWords)
+    }
+  }
+
   /// #1480: show the once-per-launch Bluetooth cold-start education popover.
   /// UI-only — no pipeline sync; `BluetoothAwarenessPresenter` reads it via the
   /// injected `tipsEnabled` closure and reconciles a visible card off when it
@@ -927,6 +961,16 @@ public final class SettingsManager {
       OverlayPillPosition(
         rawValue: defaults.string(forKey: "overlayPillPosition") ?? ""
       ) ?? SettingsDefaultValues.overlayPillPosition
+
+    recordingPillDesignWithoutWords =
+      RecordingPillDesign(
+        rawValue: defaults.string(forKey: "recordingPillDesignWithoutWords") ?? ""
+      ) ?? SettingsDefaultValues.recordingPillDesignWithoutWords
+
+    recordingPillDesignWithWords =
+      RecordingPillDesign(
+        rawValue: defaults.string(forKey: "recordingPillDesignWithWords") ?? ""
+      ) ?? SettingsDefaultValues.recordingPillDesignWithWords
 
     showBluetoothTips =
       defaults.object(forKey: "showBluetoothTips") as? Bool

--- a/Tests/EnviousWisprTests/App/CapsuleBackgroundFreezeTests.swift
+++ b/Tests/EnviousWisprTests/App/CapsuleBackgroundFreezeTests.swift
@@ -148,8 +148,8 @@ struct CapsuleBackgroundFreezeTests {
   /// **The first version of this checked for a gate keyword within six lines of
   /// each palette reference, and it was wrong in the way this repo keeps
   /// recording: a comparison narrower than the language.** `previewHeader` is
-  /// reached only from `if usesPreviewLayout`, so every line in it is gated and
-  /// none of them says so. Lexical proximity is not the property; reachability is,
+  /// reached only from the chrome's `.meterStrip` header case, so every line in it
+  /// is gated and none of them says so. Lexical proximity is not the property; reachability is,
   /// and the honest way to check reachability cheaply is to scope the check to the
   /// one type where a leak is possible.
   ///

--- a/Tests/EnviousWisprTests/App/LivePreview/PillWordsCapabilityTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreview/PillWordsCapabilityTests.swift
@@ -50,9 +50,13 @@ struct PillWordsCapabilityTests {
   /// **Generated over the cross-product**, so a third input added later is swept
   /// with no edit here, and both directions are asserted: `.available` if and only
   /// if the geometry verdict is true.
-  /// **Scoped to OUTSIDE a recording, which is the only place the two answer the
-  /// same question.** During one they deliberately diverge; that is the case
-  /// below.
+  /// **Scoped to OUTSIDE a recording and to NO REMOVAL IN FLIGHT**, which is where
+  /// the two answer the same question. Both exclusions are real divergences with a
+  /// case of their own below, not conditions swept under the rug: during a
+  /// recording the verdict is frozen and this is not, and during a removal drain
+  /// this refuses while the verdict's live branch does not read the suppression at
+  /// all. Fresh coordinators are never mid-removal, so every row here is inside
+  /// the scope by construction.
   @Test(
     "outside a recording, the reason says available exactly when the verdict says enabled",
     arguments: [true, false], [true, false])
@@ -122,7 +126,7 @@ struct PillWordsCapabilityTests {
   /// **The reason must actually DISCRIMINATE**, or it is a `Bool` in a costume and
   /// the picker would show one sentence to two different users. A machine that
   /// cannot run the engine must not be told to turn a switch on.
-  @Test("the two unavailable reasons are told apart")
+  @Test("the two settings-shaped causes are told apart")
   func unavailableReasonsAreDistinct() {
     let engineCannotRun = Self.coordinator(supported: false, previewOn: true)
     let userTurnedItOff = Self.coordinator(supported: true, previewOn: false)
@@ -135,6 +139,53 @@ struct PillWordsCapabilityTests {
       both unavailable states report the same reason, so the picker would tell a \
       user whose engine cannot run here to switch a preview on.
       """)
+  }
+
+  /// **THIS PROPERTY'S COMPLETENESS CRITERION, asserted rather than described:
+  /// what it reports is what `setRecording(true)` would freeze right now.**
+  ///
+  /// Cloud review's THIRD finding on this one property, and the first two are why
+  /// it is written this way. The original read a frozen snapshot, which made it
+  /// answer the wrong recording. The correction made it read live and still missed
+  /// a condition, because "read the live settings" names the INPUTS and a
+  /// condition absent from that list is invisible to it. Mirroring a decision
+  /// names the decision instead, so the test can hold the two side by side.
+  ///
+  /// The user's sequence is real: press Remove on the selected model, and while
+  /// the drain is still running start another recording. That recording is frozen
+  /// wordless by `setRecording`. Appearance said the with-words designs were
+  /// available.
+  @Test("mid-removal, the picker reports what the next recording would actually get")
+  func removalSuppressionReachesThePicker() async {
+    let c = Self.coordinator(supported: true, previewOn: true)
+    #expect(c.wordsCapability == .available, "control: words are available before the removal")
+
+    await c.releaseAndDrainForRemoval()
+
+    #expect(
+      c.wordsCapability == .modelBeingRemoved,
+      """
+      the picker still offers the with-words designs during a removal drain, so a \
+      user starting a recording now gets a wordless pill while Appearance says \
+      otherwise.
+      """)
+    #expect(!c.wordsCapability.hasWords)
+
+    // The mirror claim itself: what the picker reports is what the freeze does.
+    c.setRecording(true)
+    #expect(
+      !c.isEnabledForGeometry,
+      """
+      the recording started during a removal drain was NOT frozen wordless, so the \
+      premise this property mirrors is false and its reason is the wrong one.
+      """)
+    c.setRecording(false)
+
+    // And the suppression lifts, so the reason is transient rather than sticky.
+    c.endRemovalSuppression()
+    #expect(
+      c.wordsCapability == .available,
+      "the removal reason outlived the removal, so the picker stays wrong afterwards")
   }
 
   /// The paired positive, so the case above cannot pass by reporting a reason for

--- a/Tests/EnviousWisprTests/App/LivePreview/PillWordsCapabilityTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreview/PillWordsCapabilityTests.swift
@@ -1,0 +1,142 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprLivePreview
+
+/// The capability's REASON agrees with the capability's VERDICT (#2376 Phase 4, C4).
+///
+/// **Two properties answering one question, bound in both directions by this
+/// suite rather than by intention.** `isEnabledForGeometry` is what the director
+/// reads to decide whether to size a pill for words; `wordsCapability` is what
+/// the appearance picker reads, because greying out a group of designs without
+/// saying WHY is the shape this repo already records as "visible and inaudible",
+/// and a `Bool` cannot carry a reason.
+///
+/// Phase 3's seam comment forbids Phase 4 from changing where the director
+/// resolves capability, so the verdict is untouched and the reason is additive.
+/// The cost of additive is a second authority, and this is what pays it.
+///
+/// **Product Outcome.** When these fail, a settings page tells a user to turn on
+/// a switch that cannot help them, or greys out designs their machine can render.
+@MainActor
+@Suite(.tags(.productOutcome))
+struct PillWordsCapabilityTests {
+
+  private static func coordinator(
+    supported: Bool, previewOn: Bool
+  ) -> LivePreviewCoordinator {
+    LivePreviewCoordinator(
+      readSamples: { _ in ([], 0) },
+      isPreviewOn: { previewOn },
+      languageMode: { .locked("en") },
+      selectedRoute: {
+        LivePreviewEngineRoute(
+          telemetryEngineID: "universal",
+          isSupportedOnThisSystem: { supported },
+          resolve: { _ in .blocked(.unsupportedSystem) })
+      })
+  }
+
+  /// **Generated over the cross-product**, so a third input added later is swept
+  /// with no edit here, and both directions are asserted: `.available` if and only
+  /// if the geometry verdict is true.
+  @Test(
+    "the reason says available exactly when the verdict says enabled",
+    arguments: [true, false], [true, false])
+  func wordsCapabilityAgreesWithTheGeometryVerdict(supported: Bool, previewOn: Bool) {
+    let c = Self.coordinator(supported: supported, previewOn: previewOn)
+    #expect(
+      c.wordsCapability.hasWords == c.isEnabledForGeometry,
+      """
+      supported=\(supported) previewOn=\(previewOn): the reason said \
+      \(c.wordsCapability) while the verdict said \(c.isEnabledForGeometry). These \
+      are one question; if they can disagree, the picker and the pill will.
+      """)
+  }
+
+  /// The same equivalence DURING a recording, where the verdict reads a frozen
+  /// snapshot rather than the live setting. A reason that answered live here would
+  /// agree outside a recording and diverge inside one, which is the window a
+  /// cross-product over live inputs alone cannot see.
+  @Test(
+    "the reason honours the recording freeze the verdict honours",
+    arguments: [true, false], [true, false])
+  func wordsCapabilityHonoursTheRecordingFreeze(supported: Bool, previewOn: Bool) {
+    let c = Self.coordinator(supported: supported, previewOn: previewOn)
+    c.setRecording(true)
+    #expect(
+      c.wordsCapability.hasWords == c.isEnabledForGeometry,
+      "supported=\(supported) previewOn=\(previewOn) mid-recording: \(c.wordsCapability)")
+  }
+
+  /// **The reason must actually DISCRIMINATE**, or it is a `Bool` in a costume and
+  /// the picker would show one sentence to two different users. A machine that
+  /// cannot run the engine must not be told to turn a switch on.
+  @Test("the two unavailable reasons are told apart")
+  func unavailableReasonsAreDistinct() {
+    let engineCannotRun = Self.coordinator(supported: false, previewOn: true)
+    let userTurnedItOff = Self.coordinator(supported: true, previewOn: false)
+
+    #expect(engineCannotRun.wordsCapability == .engineUnsupported)
+    #expect(userTurnedItOff.wordsCapability == .previewOff)
+    #expect(
+      engineCannotRun.wordsCapability != userTurnedItOff.wordsCapability,
+      """
+      both unavailable states report the same reason, so the picker would tell a \
+      user whose engine cannot run here to switch a preview on.
+      """)
+  }
+
+  /// The paired positive, so the case above cannot pass by reporting a reason for
+  /// everything: the available state is reachable and is not one of the refusals.
+  @Test("the available state is reachable and distinct from both refusals")
+  func availableIsReachable() {
+    let c = Self.coordinator(supported: true, previewOn: true)
+    #expect(c.wordsCapability == .available)
+    #expect(c.wordsCapability.hasWords)
+  }
+
+  /// **Where an engine is unsupported, the preview switch is irrelevant**, and
+  /// that is the asymmetry the picker's copy depends on. Both rows report the same
+  /// reason for the same cause, so the sentence a user sees is stable.
+  @Test(
+    "an unsupported engine reports the same reason whatever the switch says",
+    arguments: [true, false])
+  func unsupportedOutranksTheSwitch(previewOn: Bool) {
+    let c = Self.coordinator(supported: false, previewOn: previewOn)
+    #expect(
+      c.wordsCapability == .engineUnsupported,
+      "previewOn=\(previewOn) changed the reason on a machine that cannot run the engine")
+  }
+
+  /// The bridge carries the reason to its one consumer, and carries the REAL one.
+  /// Every other overlay suite builds its own bridge from test closures, so
+  /// nothing else can see the production mapping — the same gap
+  /// `LivePreviewBridge.init(coordinator:)` was created to close for the other
+  /// three seams.
+  @Test("the production bridge maps the reason to the coordinator")
+  func productionBridgeMapsTheReason() {
+    let c = Self.coordinator(supported: true, previewOn: false)
+    let bridge = LivePreviewBridge(coordinator: c)
+    #expect(
+      bridge.wordsCapability() == .previewOff,
+      "the bridge's reason did not reach the coordinator")
+    #expect(
+      bridge.wordsCapability().hasWords == bridge.isEnabledForGeometry(),
+      "the bridge's two answers disagree, so it maps one of them to the wrong seam")
+  }
+
+  /// The no-preview bridge answers honestly rather than plausibly. `.disabled`
+  /// exists for a director nobody wired a preview to, and reporting `.available`
+  /// there would offer word-holding designs on a build that has no preview at all.
+  @Test("the disabled bridge reports no words, with a reason")
+  func disabledBridgeReportsNoWords() {
+    #expect(LivePreviewBridge.disabled.wordsCapability() == .previewOff)
+    #expect(LivePreviewBridge.disabled.wordsCapability().hasWords == false)
+    #expect(
+      LivePreviewBridge.disabled.wordsCapability().hasWords
+        == LivePreviewBridge.disabled.isEnabledForGeometry())
+  }
+}

--- a/Tests/EnviousWisprTests/App/LivePreview/PillWordsCapabilityTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreview/PillWordsCapabilityTests.swift
@@ -210,6 +210,45 @@ struct PillWordsCapabilityTests {
       "previewOn=\(previewOn) changed the reason on a machine that cannot run the engine")
   }
 
+  /// **A CAPABILITY NOBODY IS TOLD ABOUT IS A STALE PAGE, and this is the input
+  /// that has no settings key to announce it** (cloud review round 4).
+  ///
+  /// Every other input to `wordsCapability` is settings-backed, so a page reading
+  /// it registers a dependency and refreshes on its own. Removal suppression is a
+  /// private field on a class that is not `@Observable`, and the capability's
+  /// guard returns on it BEFORE any settings read — so during a drain the page
+  /// depends on nothing, and the end of the drain cannot invalidate it.
+  ///
+  /// Both transitions are asserted because the user meets them in both
+  /// directions: removal starting while the page is open, and finishing while
+  /// they are looking at it.
+  @Test("both ends of a removal are announced to whoever is watching")
+  func removalTransitionsAreAnnounced() async {
+    let c = Self.coordinator(supported: true, previewOn: true)
+    var announcements = 0
+    c.onWordsCapabilityMayHaveChanged = { announcements += 1 }
+
+    await c.releaseAndDrainForRemoval()
+    #expect(
+      announcements >= 1,
+      """
+      the removal began and nothing was announced, so a page already showing the \
+      with-words designs keeps offering what the next recording will not deliver.
+      """)
+    #expect(c.wordsCapability == .modelBeingRemoved, "control: the state did change")
+
+    let afterBegin = announcements
+    c.endRemovalSuppression()
+    #expect(
+      announcements > afterBegin,
+      """
+      the removal ENDED and nothing was announced. This is the direction a user \
+      actually meets: the drain finishes while they are on the page, and the \
+      removal sentence stays up over designs that are available again.
+      """)
+    #expect(c.wordsCapability == .available, "control: the state changed back")
+  }
+
   /// The bridge carries the reason to its one consumer, and carries the REAL one.
   /// Every other overlay suite builds its own bridge from test closures, so
   /// nothing else can see the production mapping — the same gap

--- a/Tests/EnviousWisprTests/App/LivePreview/PillWordsCapabilityTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreview/PillWordsCapabilityTests.swift
@@ -5,18 +5,26 @@ import Testing
 @testable import EnviousWisprAppKit
 @testable import EnviousWisprLivePreview
 
-/// The capability's REASON agrees with the capability's VERDICT (#2376 Phase 4, C4).
+/// The pill's VERDICT and the picker's REASON, and where they must part company
+/// (#2376 Phase 4, C4; scope corrected by cloud review on C7).
 ///
-/// **Two properties answering one question, bound in both directions by this
-/// suite rather than by intention.** `isEnabledForGeometry` is what the director
-/// reads to decide whether to size a pill for words; `wordsCapability` is what
-/// the appearance picker reads, because greying out a group of designs without
-/// saying WHY is the shape this repo already records as "visible and inaudible",
-/// and a `Bool` cannot carry a reason.
+/// **TWO PROPERTIES ANSWERING TWO QUESTIONS, and an earlier version of this suite
+/// asserted they were one.** `isEnabledForGeometry` answers "what is THIS
+/// recording doing" and reads a frozen snapshot, so a pill on screen cannot
+/// resize when a setting moves underneath it. `wordsCapability` answers "what
+/// will the NEXT recording do", which is what the Appearance picker has to say,
+/// and reads live.
 ///
-/// Phase 3's seam comment forbids Phase 4 from changing where the director
-/// resolves capability, so the verdict is untouched and the reason is additive.
-/// The cost of additive is a second authority, and this is what pays it.
+/// They agree outside a recording and DIVERGE during one. Both directions are
+/// asserted here, because the agreement was the easy half to write and the
+/// divergence is the half a user can be lied to by.
+///
+/// The picker needs a reason at all because greying out a group of designs
+/// without saying WHY is the shape this repo already records as "visible and
+/// inaudible", and a `Bool` cannot carry one. Phase 3's seam comment forbids
+/// Phase 4 from changing where the DIRECTOR resolves capability, so the verdict
+/// is untouched and the reason is additive; the cost of additive is a second
+/// authority, and this suite is what pays it.
 ///
 /// **Product Outcome.** When these fail, a settings page tells a user to turn on
 /// a switch that cannot help them, or greys out designs their machine can render.
@@ -42,8 +50,11 @@ struct PillWordsCapabilityTests {
   /// **Generated over the cross-product**, so a third input added later is swept
   /// with no edit here, and both directions are asserted: `.available` if and only
   /// if the geometry verdict is true.
+  /// **Scoped to OUTSIDE a recording, which is the only place the two answer the
+  /// same question.** During one they deliberately diverge; that is the case
+  /// below.
   @Test(
-    "the reason says available exactly when the verdict says enabled",
+    "outside a recording, the reason says available exactly when the verdict says enabled",
     arguments: [true, false], [true, false])
   func wordsCapabilityAgreesWithTheGeometryVerdict(supported: Bool, previewOn: Bool) {
     let c = Self.coordinator(supported: supported, previewOn: previewOn)
@@ -56,19 +67,56 @@ struct PillWordsCapabilityTests {
       """)
   }
 
-  /// The same equivalence DURING a recording, where the verdict reads a frozen
-  /// snapshot rather than the live setting. A reason that answered live here would
-  /// agree outside a recording and diverge inside one, which is the window a
-  /// cross-product over live inputs alone cannot see.
-  @Test(
-    "the reason honours the recording freeze the verdict honours",
-    arguments: [true, false], [true, false])
-  func wordsCapabilityHonoursTheRecordingFreeze(supported: Bool, previewOn: Bool) {
-    let c = Self.coordinator(supported: supported, previewOn: previewOn)
+  /// **THE TWO DELIBERATELY DIVERGE DURING A RECORDING, and this is the case
+  /// cloud review's second P2 exists as.**
+  ///
+  /// `isEnabledForGeometry` answers "what is THIS recording doing" and reads the
+  /// frozen snapshot, because a pill already on screen must not resize when a
+  /// setting moves underneath it. `wordsCapability` answers "what will the NEXT
+  /// recording do", which is what the Appearance picker has to say.
+  ///
+  /// Settings is reachable WHILE recording — the menu item carries no recording
+  /// gate and the Live Preview toggle is disabled only when no engine is
+  /// available — so this sequence is a real user's, not a contrived one: start a
+  /// take, switch Live Preview off, open Appearance. An earlier version honoured
+  /// the snapshot here and would have told that user "Live Preview is on, so the
+  /// pill shows your words" about a recording where it will not be, contradicting
+  /// the panel's own promise that changes apply the next time you record.
+  @Test("mid-recording, the pill keeps its frozen verdict and the picker does not")
+  func thePickerAnswersTheNextRecordingNotThisOne() {
+    var previewOn = true
+    let c = LivePreviewCoordinator(
+      readSamples: { _ in ([], 0) },
+      isPreviewOn: { previewOn },
+      languageMode: { .locked("en") },
+      selectedRoute: {
+        LivePreviewEngineRoute(
+          telemetryEngineID: "universal",
+          isSupportedOnThisSystem: { true },
+          resolve: { _ in .blocked(.unsupportedSystem) })
+      })
+
     c.setRecording(true)
+    #expect(c.isEnabledForGeometry, "control: this recording began with words available")
+    #expect(c.wordsCapability == .available, "control: so does the next one, so far")
+
+    // The user opens Settings mid-take and switches Live Preview off.
+    previewOn = false
+
     #expect(
-      c.wordsCapability.hasWords == c.isEnabledForGeometry,
-      "supported=\(supported) previewOn=\(previewOn) mid-recording: \(c.wordsCapability)")
+      c.isEnabledForGeometry,
+      """
+      the LIVE pill's verdict moved when the setting did. A recording already on \
+      screen must keep the geometry it was sized for; re-reading here is what makes \
+      a pill resize mid-dictation.
+      """)
+    #expect(
+      c.wordsCapability == .previewOff,
+      """
+      the picker still reports words available for the NEXT recording after the user \
+      turned Live Preview off. It would enable the wrong group and print a reason \
+      that is false by the time the user records again.
+      """)
   }
 
   /// **The reason must actually DISCRIMINATE**, or it is a `Bool` in a costume and

--- a/Tests/EnviousWisprTests/App/LivePreviewPackCopyTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewPackCopyTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import EnviousWisprCore
 import Foundation
 import Testing
 

--- a/Tests/EnviousWisprTests/App/Overlay/AppearancePillPickerTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/AppearancePillPickerTests.swift
@@ -1,0 +1,161 @@
+import AppKit
+import EnviousWisprCore
+import Testing
+
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprServices
+
+/// The grouped pill picker gets its rules from the catalog (#2376 Phase 4, C7).
+///
+/// **The risk this suite exists for is DRIFT, and the plan names it outright:**
+/// the picker and the pill each deciding which designs are compatible, agreeing
+/// on the day they are written and diverging the day a design is added. Every row
+/// here is generated over the cross-product, so a fourth design is swept with no
+/// edit.
+///
+/// **Product Outcome.** When these fail, a user is offered a pill their machine
+/// cannot draw, or is refused one it can.
+@MainActor
+@Suite(.tags(.productOutcome))
+struct AppearancePillPickerTests {
+
+  init() { _ = NSApplication.shared }
+
+  private static func model(_ capability: PillWordsCapability) -> PillAppearanceModel {
+    let name = "ew.pillPickerTest." + UUID().uuidString
+    let suite = UserDefaults(suiteName: name)!
+    suite.removePersistentDomain(forName: name)
+    return PillAppearanceModel(
+      settings: SettingsManager(defaults: suite), capability: { capability })
+  }
+
+  // MARK: - Offerability comes from the catalog, in both directions
+
+  @Test(
+    "what the picker offers is what the pill would accept",
+    arguments: RecordingPillDesign.allCases, [true, false])
+  func offerabilityAgreesWithTheCatalog(design: RecordingPillDesign, holdingWords: Bool) {
+    let m = Self.model(holdingWords ? .available : .previewOff)
+    let offered = m.offers(design, holdingWords: holdingWords)
+    let resolution = PillDesignSelections(withoutWords: design, withWords: design)
+      .resolve(capabilityHasWords: holdingWords)
+
+    #expect(
+      offered == (resolution.substituted == false),
+      """
+      the picker said offered=\(offered) for \(design) at holdingWords=\
+      \(holdingWords) while the pill would have substituted=\(resolution.substituted). \
+      The picker has grown an opinion of its own, which is the drift this phase \
+      was told to watch for.
+      """)
+  }
+
+  /// **Group completeness**, so a design added later cannot be silently
+  /// unofferable: the union of the two rendered groups is every design.
+  @Test("the two groups between them offer every design")
+  func groupsCoverEveryDesign() {
+    let m = Self.model(.available)
+    let all = Set(m.designs(holdingWords: true) + m.designs(holdingWords: false))
+    #expect(
+      all == Set(RecordingPillDesign.allCases),
+      "the picker lays out \(all.count) of \(RecordingPillDesign.allCases.count) designs")
+  }
+
+  // MARK: - The reason is stated, differs by cause, and only when it applies
+
+  /// **Two refusals must not share a sentence.** Telling a user whose engine
+  /// cannot run here to switch a preview on is worse than saying nothing: it
+  /// sends them to a control that will not help.
+  @Test("the two unavailable causes give different reasons")
+  func reasonsDifferByCause() throws {
+    let off = try #require(
+      RecordingPillAppearancePanel.reason(for: .previewOff, groupHoldsWords: true))
+    let unsupported = try #require(
+      RecordingPillAppearancePanel.reason(for: .engineUnsupported, groupHoldsWords: true))
+
+    #expect(off != unsupported, "both causes give one sentence: \(off)")
+    #expect(!off.isEmpty && !unsupported.isEmpty)
+  }
+
+  /// The paired negative: an ACTIVE group carries no reason at all, so the
+  /// sentence appears exactly once in the rendered page rather than twice.
+  @Test(
+    "an applicable group is given no reason",
+    arguments: [
+      (PillWordsCapability.available, true),
+      (.previewOff, false),
+      (.engineUnsupported, false),
+    ])
+  func anApplicableGroupHasNoReason(row: (PillWordsCapability, Bool)) {
+    #expect(
+      RecordingPillAppearancePanel.reason(for: row.0, groupHoldsWords: row.1) == nil,
+      """
+      the \(row.1 ? "with-words" : "wordless") group is applicable at \(row.0) and \
+      still carries a reason, so the page would explain a restriction that is not \
+      in force.
+      """)
+  }
+
+  /// And the INAPPLICABLE group always carries one, in every capability state.
+  /// Without this, greying a group with no explanation would pass every row above.
+  @Test(
+    "an inapplicable group always says why",
+    arguments: [
+      (PillWordsCapability.available, false),
+      (.previewOff, true),
+      (.engineUnsupported, true),
+    ])
+  func anInapplicableGroupAlwaysSaysWhy(row: (PillWordsCapability, Bool)) {
+    let reason = RecordingPillAppearancePanel.reason(for: row.0, groupHoldsWords: row.1)
+    #expect(reason != nil, "a greyed group at \(row.0) explains nothing")
+    #expect(reason?.isEmpty == false)
+  }
+
+  /// House style: no em or en dashes in anything a user reads.
+  @Test("no user-facing string carries a dash")
+  func copyCarriesNoDashes() {
+    var strings = RecordingPillDesign.allCases.flatMap { [$0.displayName, $0.summary] }
+    for capability in [PillWordsCapability.available, .previewOff, .engineUnsupported] {
+      for holdsWords in [true, false] {
+        if let r = RecordingPillAppearancePanel.reason(
+          for: capability, groupHoldsWords: holdsWords)
+        {
+          strings.append(r)
+        }
+      }
+    }
+    for s in strings {
+      #expect(!s.contains("\u{2014}"), "em dash in: \(s)")
+      #expect(!s.contains("\u{2013}"), "en dash in: \(s)")
+    }
+  }
+
+  // MARK: - Choosing writes one group and only one
+
+  @Test("choosing a design writes its own group and leaves the other alone")
+  func choosingWritesOneGroup() {
+    let m = Self.model(.previewOff)
+    let otherBefore = m.selection(holdingWords: true)
+
+    m.choose(.levelRail, holdingWords: false)
+
+    #expect(m.selection(holdingWords: false) == .levelRail)
+    #expect(
+      m.selection(holdingWords: true) == otherBefore,
+      "choosing a wordless design changed the with-words group's selection")
+  }
+
+  /// Every design carries a name and a sentence, so a design added later cannot
+  /// render as a blank card.
+  @Test("every design has copy", arguments: RecordingPillDesign.allCases)
+  func everyDesignHasCopy(design: RecordingPillDesign) {
+    #expect(!design.displayName.isEmpty, "\(design) has no name")
+    #expect(!design.summary.isEmpty, "\(design) has no description")
+  }
+
+  @Test("no two designs share a name")
+  func namesAreDistinct() {
+    let names = RecordingPillDesign.allCases.map(\.displayName)
+    #expect(Set(names).count == names.count, "two designs share a card title: \(names)")
+  }
+}

--- a/Tests/EnviousWisprTests/App/Overlay/AppearancePillPickerTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/AppearancePillPickerTests.swift
@@ -63,59 +63,79 @@ struct AppearancePillPickerTests {
 
   // MARK: - The reason is stated, differs by cause, and only when it applies
 
-  /// **Two refusals must not share a sentence.** Telling a user whose engine
-  /// cannot run here to switch a preview on is worse than saying nothing: it
-  /// sends them to a control that will not help.
-  @Test("the two unavailable causes give different reasons")
-  func reasonsDifferByCause() throws {
-    let off = try #require(
-      RecordingPillAppearancePanel.reason(for: .previewOff, groupHoldsWords: true))
-    let unsupported = try #require(
-      RecordingPillAppearancePanel.reason(for: .engineUnsupported, groupHoldsWords: true))
+  /// **No two refusals may share a sentence.** Telling a user whose engine cannot
+  /// run here to switch a preview on is worse than saying nothing: it sends them
+  /// to a control that will not help.
+  ///
+  /// **Swept over `allCases` rather than over a written-out pair, and the fourth
+  /// cause is why.** This suite used to name its causes in array literals. An
+  /// array literal is not exhaustive over an enum, so adding `.modelBeingRemoved`
+  /// compiled and left it unswept in four places at once: the compiler cannot see
+  /// an omission from a list, only from a `switch`. Reading the authority instead
+  /// means the next cause is swept by every case here on the day it is added.
+  @Test("no two refusals give the same reason")
+  func refusalsAreDistinguishable() throws {
+    let refusals = PillWordsCapability.allCases.filter { !$0.hasWords }
+    #expect(refusals.count >= 2, "control: there is more than one way to be refused")
 
-    #expect(off != unsupported, "both causes give one sentence: \(off)")
-    #expect(!off.isEmpty && !unsupported.isEmpty)
-  }
+    var sentences: [PillWordsCapability: String] = [:]
+    for cause in refusals {
+      let sentence = try #require(
+        RecordingPillAppearancePanel.reason(for: cause, groupHoldsWords: true),
+        "\(cause) greys the with-words group and explains nothing")
+      #expect(!sentence.isEmpty)
+      sentences[cause] = sentence
+    }
 
-  /// The paired negative: an ACTIVE group carries no reason at all, so the
-  /// sentence appears exactly once in the rendered page rather than twice.
-  @Test(
-    "an applicable group is given no reason",
-    arguments: [
-      (PillWordsCapability.available, true),
-      (.previewOff, false),
-      (.engineUnsupported, false),
-    ])
-  func anApplicableGroupHasNoReason(row: (PillWordsCapability, Bool)) {
     #expect(
-      RecordingPillAppearancePanel.reason(for: row.0, groupHoldsWords: row.1) == nil,
+      Set(sentences.values).count == refusals.count,
       """
-      the \(row.1 ? "with-words" : "wordless") group is applicable at \(row.0) and \
-      still carries a reason, so the page would explain a restriction that is not \
-      in force.
+      \(refusals.count) causes share \(Set(sentences.values).count) sentences, so at \
+      least one user is told the wrong thing about why their designs are greyed: \
+      \(sentences)
       """)
   }
 
-  /// And the INAPPLICABLE group always carries one, in every capability state.
-  /// Without this, greying a group with no explanation would pass every row above.
+  /// **One property replacing two row tables, and it is a closed question: a group
+  /// carries a reason EXACTLY when it is inapplicable.** The applicable group must
+  /// carry none, so the sentence appears once on the page rather than twice; the
+  /// inapplicable one must always carry one, so nothing is greyed in silence.
+  /// Written as an if-and-only-if over the full cross-product because the two
+  /// halves were separate hand-written tables that could each be extended without
+  /// the other.
   @Test(
-    "an inapplicable group always says why",
-    arguments: [
-      (PillWordsCapability.available, false),
-      (.previewOff, true),
-      (.engineUnsupported, true),
-    ])
-  func anInapplicableGroupAlwaysSaysWhy(row: (PillWordsCapability, Bool)) {
-    let reason = RecordingPillAppearancePanel.reason(for: row.0, groupHoldsWords: row.1)
-    #expect(reason != nil, "a greyed group at \(row.0) explains nothing")
-    #expect(reason?.isEmpty == false)
+    "a group explains itself exactly when it is inapplicable",
+    arguments: PillWordsCapability.allCases, [true, false])
+  func onlyTheInapplicableGroupCarriesAReason(
+    capability: PillWordsCapability, groupHoldsWords: Bool
+  ) {
+    // The with-words group applies when words are available; the wordless group
+    // applies when they are not. So applicability IS this equality.
+    let isApplicable = (groupHoldsWords == capability.hasWords)
+    let reason = RecordingPillAppearancePanel.reason(
+      for: capability, groupHoldsWords: groupHoldsWords)
+
+    if isApplicable {
+      #expect(
+        reason == nil,
+        """
+        the \(groupHoldsWords ? "with-words" : "wordless") group applies at \
+        \(capability) and still explains a restriction that is not in force: \(reason!)
+        """)
+    } else {
+      #expect(
+        reason != nil,
+        "the \(groupHoldsWords ? "with-words" : "wordless") group is greyed at \(capability) and says nothing")
+      #expect(reason?.isEmpty == false, "\(capability) explains itself with an empty string")
+    }
   }
 
-  /// House style: no em or en dashes in anything a user reads.
+  /// House style: no em or en dashes in anything a user reads. Swept over the
+  /// authority for the same reason as above.
   @Test("no user-facing string carries a dash")
   func copyCarriesNoDashes() {
     var strings = RecordingPillDesign.allCases.flatMap { [$0.displayName, $0.summary] }
-    for capability in [PillWordsCapability.available, .previewOff, .engineUnsupported] {
+    for capability in PillWordsCapability.allCases {
       for holdsWords in [true, false] {
         if let r = RecordingPillAppearancePanel.reason(
           for: capability, groupHoldsWords: holdsWords)
@@ -124,13 +144,12 @@ struct AppearancePillPickerTests {
         }
       }
     }
+    #expect(strings.count > RecordingPillDesign.allCases.count, "control: reasons were collected")
     for s in strings {
       #expect(!s.contains("\u{2014}"), "em dash in: \(s)")
       #expect(!s.contains("\u{2013}"), "en dash in: \(s)")
     }
   }
-
-  // MARK: - Choosing writes one group and only one
 
   @Test("choosing a design writes its own group and leaves the other alone")
   func choosingWritesOneGroup() {

--- a/Tests/EnviousWisprTests/App/Overlay/AppearancePillPickerTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/AppearancePillPickerTests.swift
@@ -151,6 +151,50 @@ struct AppearancePillPickerTests {
     }
   }
 
+  /// **THE PAGE MUST BE INVALIDATED, not merely able to compute the right answer
+  /// if something else happens to ask it again** (cloud review round 4).
+  ///
+  /// Every other input to `wordsCapability` is settings-backed, so a page reading
+  /// it registers a dependency and refreshes on its own. Model-removal
+  /// suppression is the exception: a private field on a coordinator that is not
+  /// `@Observable`, which the capability's guard returns on BEFORE any settings
+  /// read. During a drain the page therefore depends on nothing at all, and the
+  /// end of the drain cannot invalidate it — the removal sentence stays over
+  /// designs that are available again.
+  ///
+  /// Asserted with `withObservationTracking`, the mechanism SwiftUI itself uses,
+  /// so this fails if `wordsCapability` ever stops consuming the generation. That
+  /// discard in its body reads like tidying and IS the registration.
+  ///
+  /// Lives here rather than beside the coordinator because this suite already
+  /// builds a model with its own defaults suite; the capability suite has a
+  /// coordinator rig and no settings rig, and a second fixture for a state one
+  /// already stages is the cost worth not paying.
+  @Test("a reader of the capability is invalidated when the coordinator announces")
+  func aCapabilityReaderIsInvalidated() {
+    let model = Self.model(.available)
+
+    // A reference box because `onChange` is `@Sendable`. It fires synchronously on
+    // the mutating thread, which here is the main actor throughout.
+    final class Flag: @unchecked Sendable { var fired = false }
+    let flag = Flag()
+    withObservationTracking {
+      _ = model.wordsCapability
+    } onChange: {
+      flag.fired = true
+    }
+
+    #expect(!flag.fired, "control: nothing has changed yet")
+    model.capabilityDidChange()
+    #expect(
+      flag.fired,
+      """
+      a reader of wordsCapability was not invalidated by an announced change, so \
+      the Appearance page renders whatever it computed last and corrects itself \
+      only on an unrelated redraw.
+      """)
+  }
+
   @Test("choosing a design writes its own group and leaves the other alone")
   func choosingWritesOneGroup() {
     let m = Self.model(.previewOff)

--- a/Tests/EnviousWisprTests/App/Overlay/EnvironmentInjectionFreezeTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/EnvironmentInjectionFreezeTests.swift
@@ -1,0 +1,84 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// The pill-appearance home is injected wherever Settings is (#2376 Phase 4, C7).
+///
+/// **A type-based `@Environment` read has NO DEFAULT, so a window root that hosts
+/// the Appearance page without injecting this home TRAPS AT RUNTIME with every
+/// test green.** That is a measured failure mode in this repo, not a theory: a
+/// missing injection has previously shipped with 6,635 tests passing and a crash
+/// on a screen every new user reaches.
+///
+/// So the guard is a MECHANISM rather than a reminder. It reads the composition
+/// root as SOURCE and requires that every builder block injecting `settings` also
+/// injects `pillAppearance` — because the two are needed by the same page, and a
+/// root that has one and not the other is exactly the half-an-edit this catches.
+///
+/// **A Drift Guard.** It fails when we change our own composition, which is the
+/// point; it is not evidence about anything a user sees.
+@Suite(.tags(.driftGuard))
+struct EnvironmentInjectionFreezeTests {
+
+  private static let bootstrapperPath = "Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift"
+
+  @Test("the window root that hosts Settings injects the pill-appearance home")
+  func pillAppearanceIsInjectedWhereSettingsIsHosted() throws {
+    let url = RepoRoot.url.appending(path: Self.bootstrapperPath)
+    let source = try String(contentsOf: url, encoding: .utf8)
+
+    // Fails CLOSED on an unreadable or empty read: a zero-length source would
+    // otherwise satisfy every search below and read as a clean pass.
+    try #require(
+      source.count > 1000,
+      "\(Self.bootstrapperPath) read \(source.count) bytes — this guard is pointed at nothing")
+
+    // **Scoped to the root that HOSTS the page, not to every root that injects
+    // `settings`.** The broader rule was written first and is wrong: the
+    // onboarding root injects `settings` and hosts `OnboardingV2View`, which has
+    // no Appearance page, so requiring the pill home there would demand an
+    // injection nothing reads. A guard that fires on correct code is the
+    // false-positive shape this repo's own precision tally argues against, and it
+    // trains the next person to widen the guard rather than fix the wiring.
+    let host = "UnifiedWindowView()"
+    let start = try #require(
+      source.range(of: host), "positive control failed — \(host) is not in the composition root")
+
+    // The builder block ends at the next type declaration.
+    let rest = source[start.upperBound...]
+    let blockEnd = rest.range(of: "\nprivate struct ") ?? rest.range(of: "\nstruct ")
+    let block = blockEnd.map { String(rest[..<$0.lowerBound]) } ?? String(rest)
+
+    try #require(
+      block.contains(".environment(b.settings)"),
+      "positive control failed — the Settings host block does not inject settings")
+
+    #expect(
+      block.contains(".environment(b.pillAppearance)"),
+      """
+      the window root hosting Settings injects `settings` but not `pillAppearance`. \
+      The Appearance page reads the pill home through a type-based @Environment, \
+      which has NO DEFAULT — so this traps at runtime on a screen a user reaches \
+      from the menu bar, with every unit test still green. That exact failure has \
+      shipped from this file before (#2196, caught as a P1 in cloud review).
+      """)
+  }
+
+  /// The home must actually be constructed from the live-preview bridge rather
+  /// than from a second derivation of capability. Checked as source because the
+  /// wiring itself is what is being claimed, and the closure it captures is not
+  /// observable from outside.
+  @Test("the pill-appearance home reads the same capability the director does")
+  func pillAppearanceReadsTheBridge() throws {
+    let url = RepoRoot.url.appending(path: Self.bootstrapperPath)
+    let source = try String(contentsOf: url, encoding: .utf8)
+    #expect(
+      source.contains("PillAppearanceModel(") && source.contains("bridge.wordsCapability"),
+      """
+      the pill-appearance home is not built from the live-preview bridge's own \
+      capability. Re-deriving it — from the engine resolver, say — puts two answers \
+      to one question in front of the same user on two settings pages.
+      """)
+  }
+}

--- a/Tests/EnviousWisprTests/App/Overlay/FrozenPillParityFixture.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/FrozenPillParityFixture.swift
@@ -85,9 +85,16 @@ struct FrozenRecordingRow: Equatable, Sendable {
   /// reducer returns for the with-words case.
   let effectiveWidth: CGFloat
   let fixedHeight: CGFloat?
-  /// Captured so the surviving leaf adapter's equivalence is a measured row
-  /// rather than an argument. It outlives C3b: C3b deletes the layout value,
-  /// not the boolean the leaf still receives.
+  /// Captured so the design-versus-capability equivalence is a measured row
+  /// rather than an argument.
+  ///
+  /// **The NAME is base-revision vocabulary and is deliberately not renamed**: it
+  /// records what the base revision observed, and editing a frozen capture to
+  /// match today's names destroys the evidence it exists to be. What it means is
+  /// the CAPABILITY — whether that pill showed words — which is what
+  /// `RecordingPillDesign.canHoldWords` answers today. #2376 C2 deleted the leaf
+  /// API of the same name, so no leaf receives a boolean any more; this row is
+  /// unaffected because it never described the leaf.
   let usesPreviewLayout: Bool
 }
 

--- a/Tests/EnviousWisprTests/App/Overlay/FrozenPillParityFixture.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/FrozenPillParityFixture.swift
@@ -91,10 +91,14 @@ struct FrozenRecordingRow: Equatable, Sendable {
   /// **The NAME is base-revision vocabulary and is deliberately not renamed**: it
   /// records what the base revision observed, and editing a frozen capture to
   /// match today's names destroys the evidence it exists to be. What it means is
-  /// the CAPABILITY — whether that pill showed words — which is what
-  /// `RecordingPillDesign.canHoldWords` answers today. #2376 C2 deleted the leaf
-  /// API of the same name, so no leaf receives a boolean any more; this row is
-  /// unaffected because it never described the leaf.
+  /// the CAPABILITY — whether that pill showed words as you speak — which is a
+  /// question the shipped code still answers, under a different name. #2376 C2
+  /// deleted the leaf parameter this shares a spelling with, so no leaf receives
+  /// a boolean any more; this row is unaffected because it never described a leaf.
+  ///
+  /// **Deliberately naming no current type**, because `fixtureIsRenameNeutral`
+  /// forbids it: an oracle that cites the code under test is tied to it, and this
+  /// file's whole value is being independent of it.
   let usesPreviewLayout: Bool
 }
 

--- a/Tests/EnviousWisprTests/App/Overlay/FrozenPillParityFixtureTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/FrozenPillParityFixtureTests.swift
@@ -1,4 +1,5 @@
 import CoreGraphics
+import EnviousWisprCore
 import Foundation
 import Testing
 

--- a/Tests/EnviousWisprTests/App/Overlay/LevelRailDesignTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/LevelRailDesignTests.swift
@@ -1,0 +1,173 @@
+import AppKit
+import EnviousWisprCore
+import SwiftUI
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// The second without-words design (#2376 Phase 4, C5).
+///
+/// **What this suite has to establish is that `.levelRail` is a DESIGN and not a
+/// near-copy.** Phase 4's named likeliest regression is correct model data
+/// rendered with the wrong visual treatment, and a new design that measures like
+/// its neighbour is that regression arriving as a feature. So every row here is a
+/// difference from something, or a bound it must respect.
+///
+/// **Product Outcome.** When these fail a user who picked one pill gets another
+/// one, or gets a warning banner clipped off the bottom of it.
+@MainActor
+@Suite(.tags(.productOutcome))
+struct LevelRailDesignTests {
+
+  init() { _ = NSApplication.shared }
+
+  // MARK: - It is genuinely a different pill
+
+  @Test("the level rail measures like neither of its neighbours")
+  func levelRailIsDistinctFromBothShippedDesigns() throws {
+    let rail = RenderedPillHarness.recordingRootSize(design: .levelRail)
+    let classic = RenderedPillHarness.recordingRootSize(design: .classic)
+    let well = RenderedPillHarness.recordingRootSize(design: .readingWell)
+
+    try #require(rail.width > 0 && rail.height > 0, "the level rail measured \(rail)")
+    #expect(
+      rail != classic,
+      """
+      the level rail measures \(rail) and the classic capsule \(classic) — the same. \
+      A design that renders identically to its neighbour is this phase's named \
+      regression shipped as a feature.
+      """)
+    #expect(rail != well, "the level rail measures the same as the reading well: \(rail)")
+    #expect(rail.width == 260, "the level rail is \(rail.width)pt wide, not the 260 it declares")
+    #expect(rail.height == 92, "the level rail reserved \(rail.height)pt, not 92")
+  }
+
+  /// The clock is present in BOTH lock states, where the capsule hides it when
+  /// locked. Read as GEOMETRY rather than as text, because the harness cannot see
+  /// glyphs: the two designs' unlocked sizes must differ, and the rail's own two
+  /// lock states must not.
+  @Test("the level rail is the same size locked and unlocked")
+  func lockNeutrality() {
+    let unlocked = RenderedPillHarness.recordingRootSize(design: .levelRail, locked: false)
+    let locked = RenderedPillHarness.recordingRootSize(design: .levelRail, locked: true)
+    #expect(
+      unlocked == locked,
+      """
+      the level rail measured \(unlocked) unlocked and \(locked) locked. Hands-free \
+      is the mode that runs for minutes, so the clock stays — and a pill that \
+      twitches when you double-press is the class of thing #2201 removed.
+      """)
+  }
+
+  // MARK: - The notice budget it inherits
+
+  /// **The assertion the design's 92 exists for.** The #1060 banner is the only
+  /// thing that makes a without-words pill grow, and such a pill is handed a no-op
+  /// growth callback — so if the content exceeds the reserved box it is clipped on
+  /// screen with nothing reporting it.
+  @Test(
+    "the shipped in-panel notices fit the box the level rail reserves",
+    arguments: [RecordingNoticeReason.approachingCap, .autoStopUnavailable])
+  func inPanelNoticesFitTheReservedBox(reason: RecordingNoticeReason) throws {
+    let budget = try #require(RecordingPillDesign.levelRail.reservedHeight)
+    for locked in [false, true] {
+      let height = try RenderedPillHarness.recordingContentHeight(
+        design: .levelRail, locked: locked,
+        notice: DictationNarrator.copy(for: reason),
+        width: RecordingPillDesign.levelRail.width)
+      #expect(
+        height <= budget,
+        """
+        the \(reason) banner made the level rail \(height)pt tall (locked: \(locked)) \
+        against the \(budget)pt box it reserves. It cannot grow — a without-words \
+        design is handed a no-op growth callback — so the overflow is CLIPPED with \
+        nothing reporting it. Shorten the copy or raise the reserved height; do not \
+        raise this expectation.
+        """)
+    }
+  }
+
+  /// The paired case, so the budget row cannot pass by measuring nothing.
+  @Test("a notice grows the level rail at all")
+  func aNoticeGrowsTheRail() throws {
+    let bare = try RenderedPillHarness.recordingContentHeight(
+      design: .levelRail, width: 260)
+    let withNotice = try RenderedPillHarness.recordingContentHeight(
+      design: .levelRail, notice: DictationNarrator.copy(for: .approachingCap), width: 260)
+    #expect(withNotice > bare, "a notice measured \(withNotice)pt against a bare \(bare)pt")
+  }
+
+  // MARK: - It cannot hold words, proven through the real gate
+
+  /// **Driven through `OverlayRenderModel`, never through the leaf's
+  /// `initialPreview:` seam.** That seam bypasses the `canHoldWords` gate
+  /// entirely, so seeding it would measure the leaf's willingness to draw words
+  /// rather than whether the gate let any through — which is the thing that makes
+  /// this design wordless by construction rather than by policy.
+  @Test("the level rail is handed no words even when a provider offers them")
+  func theGateRefusesWordsForTheRail() {
+    let model = OverlayRenderModel()
+    var displayReads = 0
+    var growthReports: [CGFloat] = []
+
+    model.setRecordingProviders(
+      audioLevel: { 0.4 },
+      recordingElapsed: { 127 },
+      livePreview: {
+        displayReads += 1
+        return .text("the quarterly numbers came in ahead of plan")
+      },
+      design: .levelRail,
+      position: .top,
+      onContentHeightChange: { growthReports.append($0) })
+
+    #expect(model.livePreviewProvider() == .off, "the level rail was handed a live display")
+    model.onContentHeightChange(123)
+
+    #expect(displayReads == 0, "the live provider was read for a pill that shows no words")
+    #expect(growthReports.isEmpty, "a pill that cannot grow reported a height to its window")
+  }
+
+  /// And it measures the same whether or not a provider was offered, which is the
+  /// rendered consequence of the row above.
+  @Test("offering the level rail words does not change what it draws")
+  func wordsDoNotChangeTheRail() {
+    let silent = RenderedPillHarness.recordingRootSize(design: .levelRail, display: .off)
+    let offered = RenderedPillHarness.recordingRootSize(
+      design: .levelRail,
+      display: .text("the quarterly numbers came in ahead of plan and the board was pleased"))
+    #expect(
+      silent == offered,
+      "the level rail measured \(silent) with no words and \(offered) with words offered")
+  }
+
+  // MARK: - It perturbed nothing
+
+  /// The two shipped designs are byte-identical to what `RenderedPillFreezeTests`
+  /// froze before this design existed. Asserted here as well as there because the
+  /// frozen suite proves they did not move; this proves adding a CASE did not move
+  /// them, which is the specific risk of widening a switch.
+  @Test(
+    "adding a design left the shipped two exactly as they were",
+    arguments: [
+      (RecordingPillDesign.classic, CGSize(width: 185, height: 92)),
+      (RecordingPillDesign.readingWell, CGSize(width: 400, height: 34)),
+    ])
+  func shippedDesignsAreUnmoved(row: (RecordingPillDesign, CGSize)) {
+    let measured = RenderedPillHarness.recordingRootSize(design: row.0)
+    #expect(measured == row.1, "\(row.0) measured \(measured), frozen at \(row.1)")
+  }
+
+  /// The catalog's own geometry for the new design, so a wrong number is caught
+  /// without rendering anything.
+  @Test("the catalog gives the level rail its declared geometry")
+  func catalogGeometry() throws {
+    let definition = try #require(
+      PillCatalog.entry(
+        for: .recording(audioLevel: 0, design: .levelRail), id: RenderedPillHarness.id()
+      ).definition)
+    #expect(definition.requestedWidth == .fixed(260))
+    #expect(definition.reservesFixedHeight == 92)
+    #expect(definition.recordingDesign == .levelRail)
+  }
+}

--- a/Tests/EnviousWisprTests/App/Overlay/LevelRailDesignTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/LevelRailDesignTests.swift
@@ -38,7 +38,11 @@ struct LevelRailDesignTests {
       regression shipped as a feature.
       """)
     #expect(rail != well, "the level rail measures the same as the reading well: \(rail)")
-    #expect(rail.width == 260, "the level rail is \(rail.width)pt wide, not the 260 it declares")
+    // 288 since round 5: the hands-free badge is inline and the locked row
+    // measured 279pt of content, so 260 clipped the one thing that says the
+    // microphone is still open. Pinned rather than derived, deliberately — a pin
+    // that reads `design.width` would agree with any future value.
+    #expect(rail.width == 288, "the level rail is \(rail.width)pt wide, not the 288 it declares")
     #expect(rail.height == 92, "the level rail reserved \(rail.height)pt, not 92")
   }
 
@@ -91,9 +95,10 @@ struct LevelRailDesignTests {
   @Test("a notice grows the level rail at all")
   func aNoticeGrowsTheRail() throws {
     let bare = try RenderedPillHarness.recordingContentHeight(
-      design: .levelRail, width: 260)
+      design: .levelRail, width: RecordingPillDesign.levelRail.width)
     let withNotice = try RenderedPillHarness.recordingContentHeight(
-      design: .levelRail, notice: DictationNarrator.copy(for: .approachingCap), width: 260)
+      design: .levelRail, notice: DictationNarrator.copy(for: .approachingCap),
+      width: RecordingPillDesign.levelRail.width)
     #expect(withNotice > bare, "a notice measured \(withNotice)pt against a bare \(bare)pt")
   }
 
@@ -166,7 +171,7 @@ struct LevelRailDesignTests {
       PillCatalog.entry(
         for: .recording(audioLevel: 0, design: .levelRail), id: RenderedPillHarness.id()
       ).definition)
-    #expect(definition.requestedWidth == .fixed(260))
+    #expect(definition.requestedWidth == .fixed(288))
     #expect(definition.reservesFixedHeight == 92)
     #expect(definition.recordingDesign == .levelRail)
   }

--- a/Tests/EnviousWisprTests/App/Overlay/NoticeLeafModelTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/NoticeLeafModelTests.swift
@@ -1,0 +1,230 @@
+import AppKit
+import SwiftUI
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// Every notice leaf renders the MODEL it is handed (#2376 Phase 4, C3).
+///
+/// **The axis-differential proof, and it is red before this chunk and green
+/// after.** Render one kind twice through the ROOT with models differing in
+/// exactly ONE field, and require the measured size to move on the axis that
+/// field controls. That answers two questions at once, and the second is the one
+/// a simpler proof misses: did the value reach the render at all, and did it
+/// reach the RIGHT SLOT. A longer sentence on a single-line row changes WIDTH; a
+/// secondary line on a two-line stack changes HEIGHT; a longer button label
+/// changes WIDTH by the button's own delta.
+///
+/// Against the base revision `.recovery` and `.accessibilityToast` measure
+/// IDENTICALLY under every model, because they took no model at all — they read
+/// `DictationNarrator` themselves and hardcoded both button strings. So these
+/// rows fail before the change, which is the parent-commit-equivalent control
+/// this repo licenses inline, with no mutant run.
+///
+/// **Product Outcome.** When one of these fails the user is shown a pill whose
+/// words are not the words the app decided to say.
+@MainActor
+@Suite(.tags(.productOutcome))
+struct NoticeLeafModelTests {
+
+  init() { _ = NSApplication.shared }
+
+  private static func size(_ model: NoticeModel) -> CGSize {
+    RenderedPillHarness.rootSize(
+      for: PillDefinition(
+        id: RenderedPillHarness.id(), content: .notice(model),
+        expiry: .untilReplaced, requestedWidth: .measured))
+  }
+
+  /// The base model per kind, deliberately minimal so each row below changes one
+  /// thing and nothing else.
+  private static func base(_ kind: NoticeModel.Kind) -> NoticeModel {
+    switch kind {
+    case .recovery:
+      return NoticeModel(
+        kind: .recovery, text: "Recovering", accessibilityLabel: "Recovering",
+        action: NoticeAction(label: "Discard", action: .discardRecovery))
+    case .accessibilityToast:
+      return NoticeModel(
+        kind: .accessibilityToast, text: "Needs access",
+        action: NoticeAction(label: "Grant", action: .grantAccessibility))
+    default:
+      return NoticeModel(kind: kind, text: "Notice")
+    }
+  }
+
+  private static func with(
+    _ base: NoticeModel, text: String? = nil, secondary: String?? = nil,
+    action: NoticeAction?? = nil
+  ) -> NoticeModel {
+    NoticeModel(
+      kind: base.kind, text: text ?? base.text,
+      secondaryText: secondary ?? base.secondaryText,
+      accessibilityLabel: base.accessibilityLabel, severity: base.severity,
+      isMultiline: base.isMultiline, action: action ?? base.action)
+  }
+
+  nonisolated static let allKinds: [NoticeModel.Kind] = [
+    .processing, .warmingUp, .ready, .notification, .importStatus, .recovery,
+    .accessibilityToast,
+  ]
+
+  // MARK: - The text reaches the render, on the width axis
+
+  @Test(
+    "a longer sentence makes its pill wider, whichever leaf draws it",
+    arguments: NoticeLeafModelTests.allKinds)
+  func textReachesTheRender(kind: NoticeModel.Kind) throws {
+    let short = Self.base(kind)
+    let long = Self.with(short, text: String(repeating: "wider ", count: 8))
+
+    let a = Self.size(short)
+    let b = Self.size(long)
+    try #require(a.width > 0 && b.width > 0, "\(kind) measured nothing: \(a) / \(b)")
+    #expect(
+      b.width > a.width,
+      """
+      \(kind) measured \(a.width)pt for a short sentence and \(b.width)pt for a long \
+      one. The leaf is not rendering the model's text — it is drawing something it \
+      chose itself, so a copy change made in the catalog never reaches the screen.
+      """)
+  }
+
+  // MARK: - The secondary line reaches the render, on the HEIGHT axis
+
+  /// The three kinds whose leaves draw a second line. The others have no slot for
+  /// one, and asserting they grow would be asserting a defect.
+  @Test(
+    "a secondary line makes its pill taller",
+    arguments: [NoticeModel.Kind.warmingUp, .ready, .recovery])
+  func secondaryTextReachesTheRender(kind: NoticeModel.Kind) throws {
+    let without = Self.with(Self.base(kind), secondary: .some(nil))
+    let with = Self.with(Self.base(kind), secondary: "and a second line")
+
+    let a = Self.size(without)
+    let b = Self.size(with)
+    try #require(a.height > 0 && b.height > 0, "\(kind) measured nothing")
+    #expect(
+      b.height > a.height,
+      """
+      \(kind) measured \(a.height)pt without a secondary line and \(b.height)pt with \
+      one. The model's secondaryText is being ignored, which is how the recovery pill \
+      came to carry its own copy of a sentence the catalog already owns.
+      """)
+  }
+
+  // MARK: - The button's label reaches the render
+
+  @Test(
+    "a longer button label makes its pill wider",
+    arguments: [NoticeModel.Kind.recovery, .accessibilityToast])
+  func actionLabelReachesTheRender(kind: NoticeModel.Kind) throws {
+    let short = Self.base(kind)
+    let long = Self.with(
+      short,
+      action: .some(
+        NoticeAction(
+          label: "Discard this recovering recording now",
+          action: short.action!.action)))
+
+    let a = Self.size(short)
+    let b = Self.size(long)
+    #expect(
+      b.width > a.width,
+      """
+      \(kind) measured \(a.width)pt with a short button label and \(b.width)pt with a \
+      long one. The leaf is drawing a hardcoded label, so the catalog's is dead.
+      """)
+  }
+
+  /// The paired negative: with no action the button is not drawn at all, so the
+  /// pill is narrower. Without this, the row above could pass on a leaf that
+  /// always draws a button and merely happens to read the label.
+  @Test(
+    "a notice with no action draws no button",
+    arguments: [NoticeModel.Kind.recovery, .accessibilityToast])
+  func noActionDrawsNoButton(kind: NoticeModel.Kind) throws {
+    let withButton = Self.size(Self.base(kind))
+    let without = Self.size(Self.with(Self.base(kind), action: .some(nil)))
+    #expect(
+      without.width < withButton.width,
+      """
+      \(kind) measured \(without.width)pt with no action and \(withButton.width)pt \
+      with one. A button is being drawn for a notice that carries no action, which \
+      means its label came from somewhere other than the model.
+      """)
+  }
+
+  // MARK: - The catalog's closed set
+
+  /// **The guard that lets the root dispatch with no `??` fallback.**
+  ///
+  /// `NoticeModel.action` is optional because most notices carry no button, but
+  /// `.recovery` and `.accessibilityToast` structurally require one — their whole
+  /// purpose is the affordance. The root refuses to substitute a literal when it
+  /// is missing, which is only safe because this sweeps the catalog's own closed
+  /// set of requests and fails if a row ever loses its action.
+  @Test(
+    "every request that draws an action pill carries its action",
+    arguments: [
+      PillCatalogRequest.recoveringLastRecording, .accessibilityToast,
+    ])
+  func noticeActionsAreCarriedByEveryKindThatDrawsAButton(request: PillCatalogRequest) throws {
+    let definition = try #require(
+      PillCatalog.entry(for: request, id: RenderedPillHarness.id()).definition)
+    guard case .notice(let notice) = definition.content else {
+      Issue.record("\(request) is not a notice")
+      return
+    }
+    let action = try #require(
+      notice.action,
+      """
+      \(request) carries no action. `OverlayRootView.dispatch` has no fallback to a \
+      literal by design, so this pill would render without its button and the user \
+      would have no way to act on it.
+      """)
+    #expect(!action.label.isEmpty, "\(request)'s button has no label")
+    #expect(!action.spokenLabel.isEmpty, "\(request)'s button says nothing to VoiceOver")
+  }
+
+  /// And the recovery pill's spoken label is deliberately NOT its printed one.
+  /// `DictationNarratorTests` pins the title and the element label as different
+  /// strings; this pins that the BUTTON has its own too, which is the value that
+  /// used to be a bare literal inside the view with no field behind it.
+  @Test("the recovery pill's button says more to VoiceOver than it prints")
+  func recoveryButtonHasItsOwnSpokenLabel() throws {
+    let definition = try #require(
+      PillCatalog.entry(for: .recoveringLastRecording, id: RenderedPillHarness.id())
+        .definition)
+    guard case .notice(let notice) = definition.content else {
+      Issue.record("recovery is not a notice")
+      return
+    }
+    let action = try #require(notice.action)
+    #expect(
+      action.spokenLabel != action.label,
+      """
+      the recovery button prints \(action.label) and speaks the same, so a VoiceOver \
+      user hears a bare verb with nothing naming what it acts on.
+      """)
+  }
+
+  /// The pill's own element label is likewise distinct from its title, and the
+  /// catalog is where that distinction now lives rather than inside the view.
+  @Test("the recovery pill's element label is not its title")
+  func recoveryElementLabelIsNotTheTitle() throws {
+    let definition = try #require(
+      PillCatalog.entry(for: .recoveringLastRecording, id: RenderedPillHarness.id())
+        .definition)
+    guard case .notice(let notice) = definition.content else {
+      Issue.record("recovery is not a notice")
+      return
+    }
+    let spoken = try #require(notice.accessibilityLabel)
+    #expect(
+      spoken != notice.text,
+      "the spoken label equals the title, so VoiceOver reads the title's ellipsis aloud")
+    #expect(spoken == DictationNarrator.recoveryAccessibilityLabel)
+    #expect(notice.text == DictationNarrator.recoveryTitle)
+  }
+}

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayDirectorTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayDirectorTests.swift
@@ -88,6 +88,10 @@
         livePreview: LivePreviewBridge(
           recordingDidChange: { sink.recordingStates.append($0) },
           isEnabledForGeometry: { preview.isEnabled },
+          // Derived from this fixture's own verdict, never typed beside it: a
+          // fixture stating both independently can contradict itself, and no
+          // assertion would catch it.
+          wordsCapability: { preview.isEnabled ? .available : .previewOff },
           display: { preview.display() }),
         grantAccessibility: { sink.appActions.append(.grantAccessibility) },
         selections: { .shipped },
@@ -248,6 +252,10 @@
             sink.order.append("effect")
           },
           isEnabledForGeometry: { preview.isEnabled },
+          // Derived from this fixture's own verdict, never typed beside it: a
+          // fixture stating both independently can contradict itself, and no
+          // assertion would catch it.
+          wordsCapability: { preview.isEnabled ? .available : .previewOff },
           display: { preview.display() }),
         grantAccessibility: { sink.appActions.append(.grantAccessibility) },
         selections: { .shipped },
@@ -873,6 +881,7 @@
         livePreview: LivePreviewBridge(
           recordingDidChange: { if $0 { recordingStarted = true } },
           isEnabledForGeometry: { recordingStarted },
+          wordsCapability: { recordingStarted ? .available : .previewOff },
           display: { .off }),
         grantAccessibility: {}, selections: { .shipped }, deferFirstRender: { $0() })
       Self.hosts.append(host)

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayReducerRecordingSupport.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayReducerRecordingSupport.swift
@@ -1,3 +1,4 @@
+import EnviousWisprCore
 import Foundation
 import Testing
 

--- a/Tests/EnviousWisprTests/App/Overlay/PillCatalogRecordingParityTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/PillCatalogRecordingParityTests.swift
@@ -76,7 +76,11 @@ struct PillCatalogRecordingParityTests {
 
     #expect(classic.requestedWidth == .fixed(185))
     #expect(readingWell.requestedWidth == .fixed(400))
-    #expect(levelRail.requestedWidth == .fixed(260))
+    // 288 since #2376 round 5, measured from 279pt of locked content rather than
+    // chosen. LITERAL on purpose: this suite is the guard ON the number, so a pin
+    // that read `RecordingPillDesign.levelRail.width` would agree with whatever
+    // that becomes and guard nothing.
+    #expect(levelRail.requestedWidth == .fixed(288))
     #expect(classic.reservesFixedHeight == 92)
     #expect(readingWell.reservesFixedHeight == nil)
     // **The same 92 as the capsule, and that is inherited rather than repeated.**

--- a/Tests/EnviousWisprTests/App/Overlay/PillCatalogRecordingParityTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/PillCatalogRecordingParityTests.swift
@@ -69,11 +69,28 @@ struct PillCatalogRecordingParityTests {
         for: .recording(audioLevel: 0, design: .readingWell), id: PresentationID()
       ).definition)
 
+    let levelRail = try #require(
+      PillCatalog.entry(for: .recording(audioLevel: 0, design: .levelRail), id: PresentationID())
+        .definition)
+
     #expect(classic.requestedWidth == .fixed(185))
     #expect(readingWell.requestedWidth == .fixed(400))
+    #expect(levelRail.requestedWidth == .fixed(260))
     #expect(classic.reservesFixedHeight == 92)
     #expect(readingWell.reservesFixedHeight == nil)
-    #expect(classic.requestedWidth != readingWell.requestedWidth)
+    // **The same 92 as the capsule, and that is inherited rather than repeated.**
+    // It is the without-words NOTICE BUDGET: the #1060 banner is the only thing
+    // that grows such a pill, and a design that cannot hold words is handed a
+    // no-op growth callback, so anything over the reserved box is clipped in
+    // silence.
+    #expect(levelRail.reservesFixedHeight == 92)
+
+    // **Every PAIR must differ, not just the original two.** Asserting only that
+    // classic and readingWell disagree would stay green with a third design that
+    // rendered as a copy of either — which is this phase's named regression
+    // arriving as a feature.
+    let widths = [classic, readingWell, levelRail].map(\.requestedWidth)
+    #expect(Set(widths.map(String.init(describing:))).count == widths.count, "\(widths)")
   }
 
   /// The recording pill still announces, and still says the same sentence
@@ -150,6 +167,11 @@ struct PillCatalogRecordingParityTests {
   func designCapabilities() {
     #expect(RecordingPillDesign.classic.canHoldWords == false)
     #expect(RecordingPillDesign.readingWell.canHoldWords)
-    #expect(RecordingPillDesign.allCases.count == 2, "a design was added without a frozen row")
+    #expect(RecordingPillDesign.levelRail.canHoldWords == false)
+    // Raised from 2 to 3 by #2376 C5, which added `.levelRail` WITH its frozen
+    // geometry row below and its own suite. The tripwire is doing its job: it
+    // fired, and the response was to add the rows a new design owes rather than
+    // to widen the number.
+    #expect(RecordingPillDesign.allCases.count == 3, "a design was added without a frozen row")
   }
 }

--- a/Tests/EnviousWisprTests/App/Overlay/PillCatalogRecordingParityTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/PillCatalogRecordingParityTests.swift
@@ -1,4 +1,5 @@
 import CoreGraphics
+import EnviousWisprCore
 import Foundation
 import Testing
 

--- a/Tests/EnviousWisprTests/App/Overlay/PillOfferabilityTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/PillOfferabilityTests.swift
@@ -1,0 +1,144 @@
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// One authority decides which designs may be offered (#2376 Phase 4, C4).
+///
+/// **The picker does not get its own opinion, and this suite is what says so.**
+/// The plan names catalog-versus-Settings drift as the risk to watch for the
+/// appearance picker: two places deciding which designs are compatible, agreeing
+/// on the day they are written and diverging the day a design is added.
+/// `PillCatalog.offers` is defined in terms of `PillDesignSelections.resolve`, so
+/// the two cannot disagree without `resolve` disagreeing with itself — and every
+/// row here is generated over the cross-product, so a design added later is swept
+/// with no edit.
+///
+/// **Product Outcome.** When these fail a user is offered a pill design that
+/// cannot show the words their machine can produce, or is refused one that can.
+@Suite(.tags(.productOutcome))
+struct PillOfferabilityTests {
+
+  // MARK: - resolve fails closed in BOTH directions
+
+  /// **The mirror direction, which Phase 3 left open.** It guarded only "the
+  /// capability has words and the design cannot hold them". The other way round —
+  /// a with-words design selected for a pill that will show none — was accepted
+  /// with `substituted: false`, and `RecordingDirectorCaptureTests` measures what
+  /// that produces: a live display provider installed and a 400-point window on a
+  /// machine with no preview, which is a wide empty panel.
+  @Test(
+    "a design that cannot hold the words the capability has is refused",
+    arguments: RecordingPillDesign.allCases)
+  func withWordsMismatchSubstitutes(chosen: RecordingPillDesign) {
+    let resolution = PillDesignSelections(withoutWords: chosen, withWords: chosen)
+      .resolve(capabilityHasWords: true)
+    if chosen.canHoldWords {
+      #expect(resolution.substituted == false, "\(chosen) can hold words and was substituted")
+      #expect(resolution.design == chosen)
+    } else {
+      #expect(resolution.substituted, "\(chosen) cannot hold words and was accepted anyway")
+      #expect(resolution.design == PillDesignSelections.canonicalWithWords)
+      #expect(resolution.design.canHoldWords, "the substitute cannot hold words either")
+    }
+  }
+
+  @Test(
+    "a design that holds words is refused for a pill that will show none",
+    arguments: RecordingPillDesign.allCases)
+  func withoutWordsMismatchSubstitutes(chosen: RecordingPillDesign) {
+    let resolution = PillDesignSelections(withoutWords: chosen, withWords: chosen)
+      .resolve(capabilityHasWords: false)
+    if chosen.canHoldWords {
+      #expect(
+        resolution.substituted,
+        """
+        \(chosen) holds words and was accepted for a pill with none. That is the \
+        combination measured to install a live display provider and size a 400-point \
+        window on a machine with no preview.
+        """)
+      #expect(resolution.design == PillDesignSelections.canonicalWithoutWords)
+      #expect(resolution.design.canHoldWords == false, "the substitute holds words")
+    } else {
+      #expect(resolution.substituted == false, "\(chosen) holds no words and was substituted")
+      #expect(resolution.design == chosen)
+    }
+  }
+
+  /// The canonical substitutes must themselves be compatible, or a substitution
+  /// hands back a value the next `resolve` would substitute again.
+  @Test("the canonical substitutes are compatible with the group they serve")
+  func canonicalSubstitutesAreCompatible() {
+    #expect(PillDesignSelections.canonicalWithWords.canHoldWords)
+    #expect(PillDesignSelections.canonicalWithoutWords.canHoldWords == false)
+  }
+
+  // MARK: - offers is resolve, and cannot drift from it
+
+  /// **Generated over the whole cross-product**, so this sweeps a design added
+  /// later with no edit here. Hand-picked rows cover the cells the author thought
+  /// of, which is the same blind spot the check exists to cover for.
+  @Test(
+    "offers agrees with resolve, in both directions, for every design",
+    arguments: RecordingPillDesign.allCases, [true, false])
+  func offersIsDefinedByResolve(design: RecordingPillDesign, hasWords: Bool) {
+    let offered = PillCatalog.offers(design, capabilityHasWords: hasWords)
+    let resolution = PillDesignSelections(withoutWords: design, withWords: design)
+      .resolve(capabilityHasWords: hasWords)
+    #expect(
+      offered == (resolution.substituted == false),
+      """
+      offers(\(design), hasWords: \(hasWords)) said \(offered) while resolve \
+      substituted=\(resolution.substituted). These are one rule; if they can \
+      disagree, the picker has an opinion of its own and will drift from the pill.
+      """)
+  }
+
+  /// The paired positive and negative, so the sweep cannot pass by answering the
+  /// same thing everywhere: every design is offerable in exactly one group.
+  @Test(
+    "each design is offered in exactly one capability state",
+    arguments: RecordingPillDesign.allCases)
+  func eachDesignBelongsToOneGroup(design: RecordingPillDesign) {
+    let inWords = PillCatalog.offers(design, capabilityHasWords: true)
+    let inSilence = PillCatalog.offers(design, capabilityHasWords: false)
+    #expect(
+      inWords != inSilence,
+      """
+      \(design) is offered in \(inWords && inSilence ? "both" : "neither") capability \
+      state. A design offered in both is one the picker would show twice; a design \
+      offered in neither can never be chosen at all.
+      """)
+  }
+
+  // MARK: - The groups partition, so no design is unreachable
+
+  @Test("the two groups partition every design exactly once")
+  func groupsPartitionAllDesigns() {
+    let withWords = PillCatalog.designs(holdingWords: true)
+    let without = PillCatalog.designs(holdingWords: false)
+    #expect(Set(withWords).isDisjoint(with: Set(without)))
+    #expect(
+      Set(withWords).union(without) == Set(RecordingPillDesign.allCases),
+      """
+      the groups cover \(withWords.count + without.count) of \
+      \(RecordingPillDesign.allCases.count) designs, so one is offerable nowhere and \
+      the picker cannot show it.
+      """)
+    #expect(!withWords.isEmpty, "no design can hold words, so the with-words group is empty")
+    #expect(!without.isEmpty, "every design holds words, so the without-words group is empty")
+  }
+
+  /// Group membership and offerability must agree, or the picker lays a design
+  /// out under a heading it is then greyed out beneath.
+  @Test(
+    "a design's group is the state it is offered in",
+    arguments: RecordingPillDesign.allCases)
+  func groupMembershipMatchesOfferability(design: RecordingPillDesign) {
+    for hasWords in [true, false] {
+      let inGroup = PillCatalog.designs(holdingWords: hasWords).contains(design)
+      #expect(
+        inGroup == PillCatalog.offers(design, capabilityHasWords: hasWords),
+        "\(design) is grouped and offered differently at hasWords=\(hasWords)")
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/App/Overlay/PillOfferabilityTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/PillOfferabilityTests.swift
@@ -1,3 +1,4 @@
+import EnviousWisprCore
 import Testing
 
 @testable import EnviousWisprAppKit

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingDirectorCaptureTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingDirectorCaptureTests.swift
@@ -56,6 +56,8 @@ struct RecordingDirectorCaptureTests {
           counts.capability += 1
           return capabilityHasWords
         },
+        // Derived from this fixture's own verdict, never typed beside it.
+        wordsCapability: { capabilityHasWords ? .available : .previewOff },
         display: {
           counts.displayReads += 1
           return .off
@@ -205,23 +207,72 @@ struct RecordingDirectorCaptureTests {
   /// capability, which is the arrangement this whole phase exists to remove.
   /// Separating them is the only way to tell which one the consumers actually
   /// follow.
-  @Test("reading well drives its consumers even without word capability")
+  ///
+  /// **REWRITTEN IN #2376 C4, AND THE REASON IS THAT ITS OLD ROUTE STOPPED
+  /// EXISTING.** It used to drive the DIRECTOR with a selections pair of
+  /// `.readingWell` / `.readingWell` at `capabilityHasWords: false`, and what it
+  /// measured was real: one display read and a resize to 400x123, on a machine
+  /// with no preview — a wide panel with nothing to put in it. C4 closed that
+  /// direction of `PillDesignSelections.resolve`, so the director now substitutes
+  /// `.classic` and the mismatch is no longer reachable through it.
+  ///
+  /// The PROPERTY is worth keeping and is not about the director: the render
+  /// model's consumers must follow the DESIGN they were handed rather than
+  /// re-deriving capability for themselves. So it is driven at
+  /// `setRecordingProviders` directly, which takes the design as an argument and
+  /// is the type under test. Losing the production route to the mismatch is the
+  /// point of C4; losing the observation would have been an accident of it.
+  @Test("the render model's consumers follow the design they are handed")
   func consumersFollowDesignRatherThanCapability() {
     let counts = Counts()
     let host = WindowlessOverlayHost()
-    let selections = PillDesignSelections(withoutWords: .readingWell, withWords: .readingWell)
-    let d = Self.makeDirector(
-      counts, capabilityHasWords: false, selections: selections, host: host)
+    let model = OverlayRenderModel()
 
-    Self.record(d)
-    #expect(d.renderModel.presentation?.recordingDesign == .readingWell)
-    _ = d.renderModel.livePreviewProvider()
-    d.renderModel.onContentHeightChange(123)
+    model.setRecordingProviders(
+      audioLevel: { 0 },
+      recordingElapsed: { nil },
+      livePreview: {
+        counts.displayReads += 1
+        return .text("words")
+      },
+      design: .readingWell,
+      position: .top,
+      onContentHeightChange: { host.resizeCurrentPresentation(to: CGSize(width: 400, height: $0)) })
+
+    _ = model.livePreviewProvider()
+    model.onContentHeightChange(123)
 
     #expect(counts.displayReads == 1, "the consumers gated on capability, not on the design")
     #expect(
       host.resizes == [CGSize(width: 400, height: 123)],
       "preview growth followed capability rather than the captured design")
+  }
+
+  /// The paired negative, which is what makes the case above a discriminator
+  /// rather than a demonstration: a design that cannot hold words is handed a
+  /// live provider and a growth callback, and must reach neither.
+  @Test("a design that holds no words reaches neither consumer")
+  func aWordlessDesignReachesNeitherConsumer() {
+    let counts = Counts()
+    let host = WindowlessOverlayHost()
+    let model = OverlayRenderModel()
+
+    model.setRecordingProviders(
+      audioLevel: { 0 },
+      recordingElapsed: { nil },
+      livePreview: {
+        counts.displayReads += 1
+        return .text("words")
+      },
+      design: .classic,
+      position: .top,
+      onContentHeightChange: { host.resizeCurrentPresentation(to: CGSize(width: 185, height: $0)) })
+
+    #expect(model.livePreviewProvider() == .off, "a wordless design was handed a live display")
+    model.onContentHeightChange(123)
+
+    #expect(counts.displayReads == 0, "the live provider was read for a pill that shows no words")
+    #expect(host.resizes.isEmpty, "a pill that cannot grow asked its window to resize")
   }
 
   // MARK: - The bridge
@@ -243,6 +294,7 @@ struct RecordingDirectorCaptureTests {
           bridgeAtCapabilityRead = counts.bridge
           return true
         },
+        wordsCapability: { .available },
         display: { .off }),
       grantAccessibility: {},
       selections: { .shipped },

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingPillChromeTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingPillChromeTests.swift
@@ -1,0 +1,160 @@
+import AppKit
+import SwiftUI
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// What each recording design tells the leaf to draw (#2376 Phase 4, C2).
+///
+/// **The first assertion in this repo that can fail when two designs are painted
+/// the same.** Before `RecordingPillChrome` the pill's appearance was a boolean
+/// read eighteen times inside one view body, so "these two designs look
+/// different" was not a question any test could ask — it was a property of
+/// scattered ternaries. As a value it is comparable, and comparing it is what
+/// this suite does.
+///
+/// **A Drift Guard.** When a row here fails the user sees nothing yet: it says we
+/// changed our own appearance table. Whether the table reached the pixels is a
+/// Live UAT row, because `fittingSize` is blind to icon, colour and corner shape.
+@MainActor
+@Suite(.tags(.driftGuard))
+struct RecordingPillChromeTests {
+
+  /// **Generated over the cross-product rather than hand-picked**, so a design
+  /// added later is swept with no edit here. Hand-written pairs cover the cells
+  /// the author thought of, which is the same blind spot the check exists to
+  /// cover for.
+  @Test("no two designs are painted the same")
+  func chromeIsInjectiveOverDesigns() {
+    let designs = RecordingPillDesign.allCases
+    for a in designs {
+      for b in designs where a != b {
+        #expect(
+          a.chrome != b.chrome,
+          """
+          \(a) and \(b) carry identical chrome, so one of them renders as the \
+          other. That is this phase's named regression — correct model data with \
+          the wrong visual treatment — and it is the one thing this value exists \
+          to make observable.
+          """)
+      }
+    }
+  }
+
+  /// The paired case that stops the sweep above passing vacuously: a design must
+  /// equal ITSELF, or `Equatable` is comparing nothing and every pair differs.
+  @Test("chrome is stable and self-equal", arguments: RecordingPillDesign.allCases)
+  func chromeIsSelfEqual(design: RecordingPillDesign) {
+    #expect(
+      design.chrome == design.chrome,
+      "\(design)'s chrome does not equal itself, so the injectivity sweep proves nothing")
+  }
+
+  /// **Pinned per design, read off the base revision's own branches.**
+  ///
+  /// `.classic` was the `false` side of every `usesPreviewLayout` read and
+  /// `.readingWell` the `true` side. A wrong value here is a wrong pill, and the
+  /// C1 frozen rows are what say these values reached the render — this suite
+  /// says WHICH values, that one says they draw the same as before.
+  @Test("the classic capsule's chrome is what the boolean's false side said")
+  func classicChromeIsPinned() {
+    let chrome = RecordingPillDesign.classic.chrome
+    #expect(chrome.header == .mark)
+    #expect(chrome.stackSpacing == 6)
+    #expect(chrome.rootInsets == EdgeInsets(top: 10, leading: 14, bottom: 10, trailing: 14))
+    #expect(chrome.cornerStyle == .capsule)
+    #expect(chrome.levelAnimation == .capsuleEaseOut)
+    #expect(chrome.showsListeningSentence)
+    #expect(chrome.noticeInk == .capsuleWhite)
+    #expect(chrome.noticeMaxWidth == 170)
+    #expect(chrome.noticeInsets == EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
+    #expect(chrome.wellInsets == EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
+    #expect(chrome.wellInk == .capsuleWhite)
+    #expect(chrome.fadesWhenWellIsFull == false)
+    #expect(chrome.isContentSizedVertically == false)
+  }
+
+  @Test("the reading well's chrome is what the boolean's true side said")
+  func readingWellChromeIsPinned() {
+    let chrome = RecordingPillDesign.readingWell.chrome
+    #expect(chrome.header == .meterStrip)
+    #expect(chrome.stackSpacing == 0)
+    #expect(chrome.rootInsets == EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
+    #expect(chrome.cornerStyle == .rounded)
+    #expect(chrome.levelAnimation == .none)
+    #expect(chrome.showsListeningSentence == false)
+    #expect(chrome.noticeInk == .previewPalette)
+    #expect(chrome.noticeMaxWidth == nil)
+    #expect(chrome.noticeInsets == EdgeInsets(top: 0, leading: 16, bottom: 12, trailing: 16))
+    #expect(chrome.wellInsets == EdgeInsets(top: 12, leading: 16, bottom: 15, trailing: 16))
+    #expect(chrome.wellInk == .previewPalette)
+    #expect(chrome.fadesWhenWellIsFull)
+    #expect(chrome.isContentSizedVertically)
+  }
+
+  /// **The one field that must never be typed, only derived.** A design that
+  /// reserves a fixed box is not content-sized, by definition; two independent
+  /// answers to that is how a pill comes to be measured inside the panel being
+  /// sized from that measurement, which is the loop #2201 settled.
+  @Test(
+    "content sizing follows the design's reserved height",
+    arguments: RecordingPillDesign.allCases)
+  func contentSizingIsDerivedFromTheReservedHeight(design: RecordingPillDesign) {
+    #expect(
+      design.chrome.isContentSizedVertically == (design.reservedHeight == nil),
+      """
+      \(design) reserves \(String(describing: design.reservedHeight)) and reports \
+      isContentSizedVertically = \(design.chrome.isContentSizedVertically). These are \
+      one fact; if they can disagree, one of them is typed rather than derived.
+      """)
+  }
+
+  /// The two inks must resolve to different colours, or the enum is a label with
+  /// no consequence and every notice paints the same whatever a design asks for.
+  @Test("the two inks are actually different paint")
+  func inksResolveDifferently() {
+    #expect(PillInk.capsuleWhite.notice != PillInk.previewPalette.notice)
+    for dimmed in [true, false] {
+      #expect(
+        PillInk.capsuleWhite.well(dimmed: dimmed) != PillInk.previewPalette.well(dimmed: dimmed),
+        "the two inks resolve to one colour at dimmed=\(dimmed)")
+    }
+  }
+
+  /// And the dimmed variant must differ from the normal one within an ink, or
+  /// "listening" and real words are painted identically.
+  @Test("each ink dims", arguments: [PillInk.capsuleWhite, .previewPalette])
+  func eachInkDims(ink: PillInk) {
+    #expect(ink.well(dimmed: true) != ink.well(dimmed: false), "\(ink) does not dim")
+  }
+
+  /// The animation case must resolve to an actual absence and an actual
+  /// animation, or #2201's whole fix is a renamed constant.
+  @Test("the level animation cases resolve to what they promise")
+  func levelAnimationResolves() {
+    #expect(PillLevelAnimation.none.resolved == nil)
+    #expect(PillLevelAnimation.capsuleEaseOut.resolved != nil)
+  }
+
+  /// **The RESOLVED values, not just the cases.** Every assertion above compares
+  /// one case to another, which stays green if a case is quietly repointed at a
+  /// different colour or duration — the enum would still be injective and the
+  /// chrome table would still read correctly while the pill changed. These pin
+  /// what the cases actually produce, at the shipped values.
+  ///
+  /// `Color.white.opacity(0.95)` is also counted by
+  /// `CapsuleBackgroundFreezeTests.frozenCapsuleLiterals`, which is a tripwire on
+  /// the FILE. This is the same fact asserted on the VALUE, and the two fail for
+  /// different reasons: that one catches the literal being edited, this one
+  /// catches the ink being pointed somewhere else.
+  @Test("the shipped ink and animation values are what they have always been")
+  func resolvedValuesAreShipped() {
+    #expect(PillInk.capsuleWhite.notice == Color.white.opacity(0.95))
+    #expect(PillInk.capsuleWhite.well(dimmed: false) == .white.opacity(0.92))
+    #expect(PillInk.capsuleWhite.well(dimmed: true) == .white.opacity(0.5))
+    #expect(PillInk.previewPalette.notice == PreviewPillPalette.notice)
+    #expect(PillInk.previewPalette.well(dimmed: false) == PreviewPillPalette.text)
+    #expect(PillInk.previewPalette.well(dimmed: true) == PreviewPillPalette.textDimmed)
+    #expect(PillLevelAnimation.capsuleEaseOut.resolved == .easeOut(duration: 0.08))
+  }
+}

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingPillChromeTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingPillChromeTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import EnviousWisprCore
 import SwiftUI
 import Testing
 

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingPillSelectionTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingPillSelectionTests.swift
@@ -1,0 +1,194 @@
+import AppKit
+import EnviousWisprCore
+import Testing
+
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprServices
+
+/// Two persisted selections, one per capability group (#2376 Phase 4, C6).
+///
+/// **The criterion is a RENDERED WIDTH, not a value read back out of the store.**
+/// Reading a key back proves the store works; what has to be true is that a
+/// choice reaches the pill, and that the OTHER group's choice is still there when
+/// the capability flips back. So every row here drives
+/// `PillDesignSelections.resolve` — the same function the director calls — from
+/// values loaded by a real `SettingsManager` over an ephemeral store, and asserts
+/// on the design that comes out.
+///
+/// **Product Outcome.** When these fail a user's chosen pill silently reverts, or
+/// choosing one pill forgets the other.
+@MainActor
+@Suite(.tags(.productOutcome))
+struct RecordingPillSelectionTests {
+
+  init() { _ = NSApplication.shared }
+
+  private static func freshSuite() -> UserDefaults {
+    let name = "ew.pillDesignTest." + UUID().uuidString
+    let d = UserDefaults(suiteName: name)!
+    d.removePersistentDomain(forName: name)
+    return d
+  }
+
+  /// The selections a settings-backed director would build, which is the exact
+  /// expression the bootstrapper's seam evaluates.
+  private static func selections(_ s: SettingsManager) -> PillDesignSelections {
+    PillDesignSelections(
+      withoutWords: s.recordingPillDesignWithoutWords,
+      withWords: s.recordingPillDesignWithWords)
+  }
+
+  private static func width(_ s: SettingsManager, hasWords: Bool) -> CGFloat {
+    selections(s).resolve(capabilityHasWords: hasWords).design.width
+  }
+
+  // MARK: - The criterion nothing else produces
+
+  /// **FOUR WIDTHS FROM ONE RUN, and the fourth is the whole point.** A key read
+  /// back would fake the first three: the memory claim is that flipping the
+  /// capability away and back returns the design last chosen on THAT side, and
+  /// only a second reading of the without-words group after a round trip can say
+  /// so.
+  @Test("each group remembers its own choice across a capability flip")
+  func perGroupMemorySurvivesACapabilityFlip() {
+    let suite = Self.freshSuite()
+    let settings = SettingsManager(defaults: suite)
+
+    // 1. Fresh install, no words: the shipped capsule.
+    #expect(Self.width(settings, hasWords: false) == 185)
+
+    // 2. Choose the level rail for the wordless side.
+    settings.recordingPillDesignWithoutWords = .levelRail
+    #expect(
+      Self.width(settings, hasWords: false) == 260,
+      "the chosen design did not reach the pill")
+
+    // 3. Words become available: the OTHER group's choice decides, untouched.
+    #expect(
+      Self.width(settings, hasWords: true) == 400,
+      "choosing a wordless design changed what the with-words group renders")
+
+    // 4. Words go away again. THIS is the memory claim: 260, not the 185 a
+    //    single shared key or a reset would give back.
+    #expect(
+      Self.width(settings, hasWords: false) == 260,
+      """
+      the wordless group came back at a different width after a capability flip, \
+      so the user's choice on that side was lost or overwritten by the other \
+      group's.
+      """)
+  }
+
+  /// The mirror: choosing on the with-words side leaves the wordless side alone.
+  /// Without this the row above passes on an implementation that simply never
+  /// writes the with-words key.
+  @Test("choosing a with-words design leaves the wordless choice alone")
+  func theTwoGroupsAreIndependent() {
+    let suite = Self.freshSuite()
+    let settings = SettingsManager(defaults: suite)
+    settings.recordingPillDesignWithoutWords = .levelRail
+    settings.recordingPillDesignWithWords = .readingWell
+
+    #expect(Self.width(settings, hasWords: true) == 400)
+    #expect(Self.width(settings, hasWords: false) == 260)
+    #expect(
+      suite.string(forKey: "recordingPillDesignWithoutWords") == "levelRail",
+      "the with-words write reached the wordless key")
+  }
+
+  // MARK: - Fail-closed, observed through the first path that can reach it
+
+  /// **C4's guard, seen through persistence.** A cross-group value is only
+  /// reachable from a hand-edited plist or a downgrade, and this is the first
+  /// path in the product that can carry one. It must render the wordless design,
+  /// not a 400-point panel with nothing to put in it.
+  @Test("a with-words design stored in the wordless key renders the wordless pill")
+  func aCrossGroupValueFailsClosed() {
+    let suite = Self.freshSuite()
+    suite.set("readingWell", forKey: "recordingPillDesignWithoutWords")
+    let settings = SettingsManager(defaults: suite)
+
+    #expect(
+      settings.recordingPillDesignWithoutWords == .readingWell,
+      "control: the store really does hold the crossed value")
+    let resolution = Self.selections(settings).resolve(capabilityHasWords: false)
+    #expect(resolution.substituted, "the crossed value was accepted")
+    #expect(
+      resolution.design.width == 185,
+      "a wordless pill rendered at \(resolution.design.width)pt — the empty wide panel")
+  }
+
+  // MARK: - The defaults are the frozen pair, and stay so
+
+  /// **The binding the canonical-defaults doc requires.** `PillDesignSelections.
+  /// shipped` is what every overlay test measures against; these two constants
+  /// are what production loads. Asserting they agree is what makes the frozen
+  /// reference a reference rather than a second opinion.
+  @Test("the shipped defaults are the frozen pair")
+  func defaultsEqualTheFrozenPair() {
+    #expect(
+      SettingsDefaultValues.recordingPillDesignWithoutWords
+        == PillDesignSelections.shipped.withoutWords)
+    #expect(
+      SettingsDefaultValues.recordingPillDesignWithWords
+        == PillDesignSelections.shipped.withWords)
+  }
+
+  @Test("a fresh install renders exactly what it rendered before this phase")
+  func freshInstallIsUnchanged() {
+    let settings = SettingsManager(defaults: Self.freshSuite())
+    #expect(Self.selections(settings) == PillDesignSelections.shipped)
+    #expect(Self.width(settings, hasWords: false) == 185)
+    #expect(Self.width(settings, hasWords: true) == 400)
+  }
+
+  // MARK: - The three-test pattern, per key
+
+  @Test(
+    "each key persists to the injected store and is in the unified key set",
+    arguments: [
+      ("recordingPillDesignWithoutWords", RecordingPillDesign.levelRail),
+      ("recordingPillDesignWithWords", RecordingPillDesign.readingWell),
+    ])
+  func keysPersistAndAreUnified(row: (String, RecordingPillDesign)) {
+    let suite = Self.freshSuite()
+    let settings = SettingsManager(defaults: suite)
+    if row.0.hasSuffix("WithoutWords") {
+      settings.recordingPillDesignWithoutWords = row.1
+    } else {
+      settings.recordingPillDesignWithWords = row.1
+    }
+    #expect(suite.string(forKey: row.0) == row.1.rawValue)
+    #expect(
+      SettingsManager.unifiedDefaultsKeys.contains(row.0),
+      """
+      \(row.0) is missing from unifiedDefaultsKeys, so the build-unification
+      migration will not carry it and a user's choice is lost between builds. That
+      array is hand-written with no derivation, so nothing but this catches it.
+      """)
+  }
+
+  @Test(
+    "an unparseable stored design falls back to its shipped default",
+    arguments: ["recordingPillDesignWithoutWords", "recordingPillDesignWithWords"])
+  func unparseableFallsBack(key: String) {
+    let suite = Self.freshSuite()
+    suite.set("sideways", forKey: key)
+    let settings = SettingsManager(defaults: suite)
+    #expect(Self.selections(settings) == PillDesignSelections.shipped)
+  }
+
+  /// **Raw values derive from case NAMES, so a rename orphans every saved
+  /// selection to the fallback — silently, on every machine.** Pinned explicitly
+  /// rather than trusted, because nothing else in the build would notice.
+  @Test("the persisted spellings are stable")
+  func rawValuesAreStable() {
+    #expect(RecordingPillDesign.classic.rawValue == "classic")
+    #expect(RecordingPillDesign.readingWell.rawValue == "readingWell")
+    #expect(RecordingPillDesign.levelRail.rawValue == "levelRail")
+    #expect(
+      Set(RecordingPillDesign.allCases.map(\.rawValue)).count
+        == RecordingPillDesign.allCases.count,
+      "two designs share a persisted spelling, so one silently loads as the other")
+  }
+}

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingPillSelectionTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingPillSelectionTests.swift
@@ -59,8 +59,12 @@ struct RecordingPillSelectionTests {
 
     // 2. Choose the level rail for the wordless side.
     settings.recordingPillDesignWithoutWords = .levelRail
+    // Reads the design rather than repeating its width: this suite's claim is
+     // WHICH DESIGN reached the pill, and the number was only ever a stand-in for
+     // identity. Written as a literal it broke when the level rail widened for a
+     // reason that has nothing to do with selection memory.
     #expect(
-      Self.width(settings, hasWords: false) == 260,
+      Self.width(settings, hasWords: false) == RecordingPillDesign.levelRail.width,
       "the chosen design did not reach the pill")
 
     // 3. Words become available: the OTHER group's choice decides, untouched.
@@ -68,10 +72,10 @@ struct RecordingPillSelectionTests {
       Self.width(settings, hasWords: true) == 400,
       "choosing a wordless design changed what the with-words group renders")
 
-    // 4. Words go away again. THIS is the memory claim: 260, not the 185 a
-    //    single shared key or a reset would give back.
+    // 4. Words go away again. THIS is the memory claim: the level rail's own
+     //    width, not the 185 a single shared key or a reset would give back.
     #expect(
-      Self.width(settings, hasWords: false) == 260,
+      Self.width(settings, hasWords: false) == RecordingPillDesign.levelRail.width,
       """
       the wordless group came back at a different width after a capability flip, \
       so the user's choice on that side was lost or overwritten by the other \
@@ -90,7 +94,7 @@ struct RecordingPillSelectionTests {
     settings.recordingPillDesignWithWords = .readingWell
 
     #expect(Self.width(settings, hasWords: true) == 400)
-    #expect(Self.width(settings, hasWords: false) == 260)
+    #expect(Self.width(settings, hasWords: false) == RecordingPillDesign.levelRail.width)
     #expect(
       suite.string(forKey: "recordingPillDesignWithoutWords") == "levelRail",
       "the with-words write reached the wordless key")

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingReconciliationTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingReconciliationTests.swift
@@ -53,6 +53,13 @@ struct RecordingReconciliationTests {
     host: any OverlayWindowHosting = WindowlessOverlayHost(),
     announce: @escaping @MainActor (OverlayAnnouncement) -> Void = { _ in },
     selections: @escaping @MainActor () -> PillDesignSelections = { .shipped },
+    // **The capability is a parameter because #2376 C4 made it the only way two
+    // transitions can resolve to different designs.** Before that a fixture could
+    // hand out mismatched selections — a with-words design under a without-words
+    // capability — and the director would install it, which is precisely the
+    // combination C4 now refuses. A test that still did it would be asserting on
+    // a state the product cannot reach.
+    capability: @escaping () -> Bool = { false },
     onCapabilityRead: @escaping () -> Void
   ) -> OverlayDirector {
     OverlayDirector(
@@ -63,8 +70,10 @@ struct RecordingReconciliationTests {
         recordingDidChange: bridge,
         isEnabledForGeometry: {
           onCapabilityRead()
-          return false
+          return capability()
         },
+        // Derived from this fixture's own verdict, never stated beside it.
+        wordsCapability: { capability() ? .available : .previewOff },
         display: { .off }),
       grantAccessibility: {},
       selections: selections,
@@ -166,7 +175,7 @@ struct RecordingReconciliationTests {
     var bridge: [Bool] = []
     var director: OverlayDirector?
     var reentered = false
-    var selectionReads = 0
+    var capabilityReads = 0
 
     // **The two transitions must be DISTINGUISHABLE, and an earlier version made
     // them identical.** Both were fresh recordings under the shipped selections,
@@ -177,14 +186,23 @@ struct RecordingReconciliationTests {
     //
     // The INNER transition resolves first, to reading well; the stale outer one
     // resolves second, to classic. The design on screen names the winner.
+    //
+    // **The two are told apart by the CAPABILITY, not by mismatched selections**
+    // (#2376 C4). An earlier version handed the first read a with-words design
+    // under a without-words capability, which C4 now refuses and substitutes — so
+    // both transitions resolved to classic and the discriminator quietly
+    // vanished. Varying the capability keeps the shipped pair on both reads and
+    // asks for two legal answers.
+    //
+    // The counter increments on RETURN rather than on entry, which is what makes
+    // the inner transition read `1`: the outer call is the one that triggers
+    // reentrancy, so it starts first and returns last.
     let d = Self.makeDirector(
       queue: queue,
       bridge: { bridge.append($0) },
-      selections: {
-        selectionReads += 1
-        return selectionReads == 1
-          ? PillDesignSelections(withoutWords: .readingWell, withWords: .readingWell)
-          : .shipped
+      capability: {
+        capabilityReads += 1
+        return capabilityReads == 1
       },
       onCapabilityRead: {
         // The reentrant winner is another RECORDING, so the slot ends up holding
@@ -204,7 +222,7 @@ struct RecordingReconciliationTests {
     #expect(
       bridge == [true, true, true],
       "expected both recording effects followed by reconciliation to the newer recording")
-    #expect(selectionReads == 2, "both transitions were not resolved")
+    #expect(capabilityReads == 2, "both transitions were not resolved")
     #expect(
       d.renderModel.presentation?.recordingDesign == .readingWell,
       "the stale outer recording overwrote the newer recording")

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingTransactionTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingTransactionTests.swift
@@ -1,4 +1,5 @@
 import CoreGraphics
+import EnviousWisprCore
 import Foundation
 import Testing
 

--- a/Tests/EnviousWisprTests/App/Overlay/RenderedPillFreezeTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RenderedPillFreezeTests.swift
@@ -185,6 +185,88 @@ struct RenderedPillFreezeTests {
       """)
   }
 
+  /// **THE LEVEL RAIL MUST NOT LOOK THE SAME WHEN THE MICROPHONE STAYS OPEN**
+  /// (#2376 Phase 4, cloud review round 5, P1).
+  ///
+  /// Hands-free keeps recording after the key is released, so a design that renders
+  /// identically in both states lets a user walk away from a live capture believing
+  /// it ended. `.levelRail` shipped exactly that way: every visual property in its
+  /// branch was independent of `lockState.isLocked`, so the container's animation
+  /// had nothing to animate.
+  ///
+  /// **Nothing caught it because `levelRail` appears NOWHERE in the frozen
+  /// recording table** — the design this phase ADDED is the one the fixture never
+  /// grew a row for. Ask of any fixture what it makes impossible, not what it
+  /// covers.
+  ///
+  /// A relation between two measurements in one process, so it is portable.
+  @Test("the level rail announces hands-free by asking for more room")
+  func theLevelRailAnnouncesHandsFree() throws {
+    // WIDTH, not height, and that is forced rather than chosen: the badge is
+    // INLINE — the reserved-box guard refused a second row — so it adds no height
+    // at all. Width is the observable the inline form preserves.
+    let unlocked = RenderedPillHarness.recordingContentNaturalWidth(
+      design: .levelRail, locked: false)
+    let locked = RenderedPillHarness.recordingContentNaturalWidth(
+      design: .levelRail, locked: true)
+
+    try #require(
+      unlocked > 0 && locked > 0,
+      "measured \(unlocked)/\(locked) — the harness returned nothing, which is not a pass")
+
+    #expect(
+      locked > unlocked,
+      """
+      the level rail wants \(locked)pt locked and \(unlocked)pt unlocked, so it looks \
+      IDENTICAL in hands-free. That mode keeps the microphone open after the key is \
+      released, and this design would give the user nothing to read it from. Add a \
+      treatment; do not relax this.
+      """)
+
+    // And it must still FIT, or the badge is announced into a clipped region. The
+    // pill's width is fixed, so content wider than it is silently cut.
+    #expect(
+      locked <= RecordingPillDesign.levelRail.width,
+      """
+      locked content wants \(locked)pt inside a \(RecordingPillDesign.levelRail.width)pt \
+      pill, so the badge or the rail is CLIPPED with nothing reporting it. Shorten the \
+      copy or widen the design; do not relax this.
+      """)
+  }
+
+  /// **KNOWN LIMIT, STATED SO THE NEXT READER DOES NOT REDISCOVER IT BY WRITING THE
+  /// TEST ABOVE FOR ALL THREE DESIGNS.** The obvious generalisation — every design
+  /// renders differently when locked — goes RED on `.classic` and `.readingWell`,
+  /// and BOTH of them have a treatment:
+  ///
+  /// | design | treatment | why height cannot see it |
+  /// |---|---|---|
+  /// | `.classic` | lips icon `.scaleEffect(2.0)`, clock hidden | a scale is a RENDER transform, not a layout change; 44pt either way |
+  /// | `.readingWell` | filled badge replaces the quiet mode text | same font, same row; 34pt either way |
+  /// | `.levelRail` | badge on a NEW row | genuinely taller, which is what the case above reads |
+  ///
+  /// `RenderedPillHarness` already records why there is no better probe here:
+  /// `fittingSize` is blind to paint and `scaleEffect`, and the accessibility tree
+  /// is not readable from a hosted view. So "the pill LOOKS different" has no
+  /// complete in-process observer, and a version of the case above that passed for
+  /// all three would be binding nothing. Those two are Live UAT rows.
+  ///
+  /// This case is the CONTROL for that claim rather than prose about it: it holds
+  /// lock CONSTANT and requires the same answer twice, so a harness returning a
+  /// different number per call could not have produced the table above.
+  @Test(
+    "the same design at the same lock state measures the same twice",
+    arguments: RecordingPillDesign.allCases)
+  func contentHeightIsStable(design: RecordingPillDesign) throws {
+    let first = try RenderedPillHarness.recordingContentHeight(
+      design: design, locked: true, width: design.width)
+    let second = try RenderedPillHarness.recordingContentHeight(
+      design: design, locked: true, width: design.width)
+    #expect(
+      first == second,
+      "\(design) measured \(first) then \(second) with nothing changed between them")
+  }
+
   // MARK: - The instrument's own controls
 
   /// **An empty slot must be distinguishable from every pill**, or a harness

--- a/Tests/EnviousWisprTests/App/Overlay/RenderedPillFreezeTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RenderedPillFreezeTests.swift
@@ -28,6 +28,18 @@ struct RenderedPillFreezeTests {
 
   // MARK: - The frozen table
 
+  /// **Is this a machine whose text metrics the frozen tables were taken on?**
+  ///
+  /// `scripts/xcode-test.sh` forwards `CI` as `TEST_RUNNER_CI`, because an
+  /// inherited variable does not reach the test process — measured both ways, and
+  /// the direction is what matters: a gate reading the runner's own `CI` fails
+  /// OPEN, so it runs the machine-dependent rows on the machine it meant to
+  /// exclude. An EMPTY value is a local run, since the script forwards the
+  /// variable unconditionally and it is unset here.
+  nonisolated static var isDeveloperMachine: Bool {
+    (ProcessInfo.processInfo.environment["CI"] ?? "").isEmpty
+  }
+
   /// Sizes of the routed content, measured 2026-08-25 on `e062ab4d`.
   ///
   /// Read `RenderedPillHarness`'s own doc for what a row means: it is the
@@ -54,8 +66,28 @@ struct RenderedPillFreezeTests {
       ("importStatus", .importStatus(message: "Imported 12 words"), 170, 38),
     ]
 
+  /// **TEXT LAYOUT IS A PROPERTY OF THE MACHINE, so the exact-size half of this
+  /// suite runs on a development Mac and reports SKIPPED on a hosted runner.**
+  ///
+  /// Measured, and this is the whole justification rather than a precaution: this
+  /// table passed locally at 6,958 tests and failed on CI at ELEVEN of its twelve
+  /// rows, on the same commit, with every other suite in the run agreeing. Font
+  /// metrics, system version and rendering defaults all differ, and a freeze over
+  /// absolute point sizes cannot survive that by construction — the numbers are a
+  /// reading of one Mac on one day.
+  ///
+  /// **What that costs is stated rather than hidden: on CI this row proves
+  /// nothing, and a skipped receipt is not a passed receipt.** The claim that
+  /// travels is the companion below, which asserts the RELATIONS these numbers
+  /// happen to satisfy and holds on any machine. Two tests because there are two
+  /// claims, and only one of them is portable.
+  ///
+  /// The frozen values keep their evidential job either way: they are the
+  /// pre-Phase-4 reading, and the parity they were written to prove was
+  /// established on the machine that took them.
   @Test(
     "every notice pill renders exactly what it rendered before Phase 4",
+    .enabled(if: RenderedPillFreezeTests.isDeveloperMachine),
     arguments: RenderedPillFreezeTests.frozenNotices)
   func noticeRowsAreFrozen(
     row: (label: String, request: PillCatalogRequest, width: CGFloat, height: CGFloat)
@@ -72,9 +104,53 @@ struct RenderedPillFreezeTests {
       """
       \(row.label) measured \(size.width) x \(size.height), frozen at \
       \(row.width) x \(row.height). Either this pill is routed through a different \
-      leaf now, or its treatment changed. Phase 4 changes where a leaf's WORDS come \
-      from and must not change what any of them draws.
+      leaf now, or its treatment changed, or this is not the Mac the table was \
+      measured on. Phase 4 changes where a leaf's WORDS come from and must not \
+      change what any of them draws.
       """)
+  }
+
+  /// **The portable half, and the one CI actually runs.** Every claim here is a
+  /// RELATION between measurements taken in the same process, so it holds
+  /// whatever that process's font metrics are.
+  ///
+  /// Two properties, each of which a real regression would break, and NEITHER of
+  /// them a size: every notice is drawn at all, and a notice whose definition
+  /// asks for a FIXED width is given that width rather than its unwrapped ideal.
+  ///
+  /// **Deliberately NOT asserted here: that a notice fits the recording pill's
+  /// reserved box.** These are standalone pills with their own windows, not
+  /// content inside the capsule, so that budget is not theirs and asserting it
+  /// would be a claim about the wrong subject that happens to hold today. The
+  /// in-panel notices, which DO inherit that box and have no headroom in it, are
+  /// covered by `inPanelNoticesFitTheReservedBox` below.
+  @Test(
+    "every notice pill is drawn, and a fixed width is honoured",
+    arguments: RenderedPillFreezeTests.frozenNotices)
+  func noticeRowsSatisfyTheirPortableRelations(
+    row: (label: String, request: PillCatalogRequest, width: CGFloat, height: CGFloat)
+  ) throws {
+    let definition = try #require(
+      PillCatalog.entry(for: row.request, id: RenderedPillHarness.id()).definition,
+      "\(row.label) produced no definition at all, so nothing below is about a pill")
+    let size = RenderedPillHarness.rootSize(for: definition)
+    try #require(
+      size.width > 0 && size.height > 0,
+      "\(row.label) measured \(size) — the harness returned nothing, which is not a pass")
+
+    // The advisory is the one such row today, and it is the row two capture
+    // rounds got wrong by reading its unwrapped 927 instead of its real 360.
+    if case .fixed(let requested) = definition.requestedWidth,
+      definition.reservesFixedHeight == nil, requested > 0
+    {
+      #expect(
+        size.width == requested,
+        """
+        \(row.label) asked for a fixed \(requested) and measured \(size.width). \
+        A width that is not the one requested means the proposal never reached the \
+        content, so its height is the height of some other layout entirely.
+        """)
+    }
   }
 
   // MARK: - The instrument's own controls
@@ -105,31 +181,61 @@ struct RenderedPillFreezeTests {
   /// Holding the sentence fixed and varying only the severity makes a collapsed
   /// mapping fail: the four would then measure identically.
   ///
-  /// Measured 2026-08-25 with one sentence at a fixed 280pt: warning 37,
-  /// error 38, distress 44, advisory 52. The error-versus-warning gap is ONE
-  /// point, from the two SF Symbols' differing heights — real, small, and the
-  /// reason this suite claims discrimination rather than claiming to see paint.
+  /// **The first correction held the MESSAGE constant and left a second axis
+  /// varying, which cloud review then refuted on the same case.** `isMultiline`
+  /// was set for `.advisory` alone, so that row wrapped where the others did not
+  /// and could measure differently even under a collapsed mapping — the same
+  /// defect the first fix was for, one axis over. A control varies ONE thing;
+  /// "the message is now constant" is not that claim, and only enumerating what
+  /// else the definition carries gets there.
+  ///
+  /// Re-measured 2026-08-25 with one sentence, `isMultiline: false` throughout,
+  /// at a fixed 280pt: **warning 37, error 38, distress 44, advisory 39** (the
+  /// advisory's 52 in the previous revision was its wrapping, not its style).
+  /// Three of the four gaps are ONE point, from the SF Symbols' differing
+  /// heights — real, small, and the reason this suite claims discrimination
+  /// rather than claiming to see paint. The heights are pinned below as well as
+  /// compared, because at a one-point spread a mapping could collapse two styles
+  /// onto a third and still produce four distinct numbers.
   @Test("the notification severities are told apart by the instrument")
   func severitiesAreDiscriminated() {
     let text = "Something went wrong while polishing your text."
-    let sizes = [NoticeModel.Severity.warning, .error, .distress, .advisory].map {
-      severity in
+    // EVERY field but `severity` is held fixed. That is the claim.
+    let expected: [(NoticeModel.Severity, CGFloat)] = [
+      (.warning, 37), (.error, 38), (.distress, 44), (.advisory, 39),
+    ]
+    let sizes = expected.map { severity, _ in
       RenderedPillHarness.rootSize(
         for: PillDefinition(
           id: RenderedPillHarness.id(),
           content: .notice(
             NoticeModel(
               kind: .notification, text: text, severity: severity,
-              isMultiline: severity == .advisory)),
+              isMultiline: false)),
           expiry: .untilReplaced, requestedWidth: .fixed(280)))
     }
     #expect(
       Set(sizes.map { "\($0.width)x\($0.height)" }).count == sizes.count,
       """
-      two or more notification severities measured identically on ONE sentence: \
-      \(sizes). Either the severity-to-style mapping has collapsed, or this \
-      instrument cannot tell the treatments apart — and every frozen row above is a \
-      claim it cannot support.
+      two or more notification severities measured identically on ONE sentence with \
+      one wrapping mode: \(sizes). Either the severity-to-style mapping has \
+      collapsed, or this instrument cannot tell the treatments apart — and every \
+      frozen row above is a claim it cannot support.
+      """)
+    // **The exact heights are NOT asserted here, and that is deliberate.** They
+    // are a reading of one Mac (recorded above as evidence), and the row that
+    // pins absolute sizes is skipped on CI for exactly that reason. What travels
+    // is the ORDER, which is a relation between measurements in one process: the
+    // distress style is the tallest treatment, and it is the one whose height
+    // comes from its own chrome rather than from the sentence.
+    let tallest = zip(expected, sizes).max(by: { $0.1.height < $1.1.height })
+    #expect(
+      tallest?.0.0 == .distress,
+      """
+      \(String(describing: tallest?.0.0)) measured tallest, not .distress. \
+      Distinctness alone would not have caught this: with the four barely a point \
+      apart, two styles can collapse onto a third and still give four different \
+      numbers, so the ordering is the part that says WHICH treatment each got.
       """)
   }
 

--- a/Tests/EnviousWisprTests/App/Overlay/RenderedPillFreezeTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RenderedPillFreezeTests.swift
@@ -120,7 +120,7 @@ struct RenderedPillFreezeTests {
   @Test("the classic capsule measures what its own suite already pins")
   func classicAgreesWithTheIndependentPin() throws {
     let contentHeight = try RenderedPillHarness.recordingContentHeight(
-      usesPreviewLayout: false, width: 185)
+      design: .classic, width: 185)
     #expect(
       contentHeight == 44,
       """
@@ -192,7 +192,7 @@ struct RenderedPillFreezeTests {
     let budget = try #require(RecordingPillDesign.classic.reservedHeight)
     for locked in [false, true] {
       let height = try RenderedPillHarness.recordingContentHeight(
-        usesPreviewLayout: false, locked: locked,
+        design: .classic, locked: locked,
         notice: DictationNarrator.copy(for: reason), width: RecordingPillDesign.classic.width)
       #expect(
         height <= budget,
@@ -211,9 +211,9 @@ struct RenderedPillFreezeTests {
   @Test("a notice is what makes the capsule grow at all")
   func aNoticeGrowsTheCapsule() throws {
     let bare = try RenderedPillHarness.recordingContentHeight(
-      usesPreviewLayout: false, width: 185)
+      design: .classic, width: 185)
     let withNotice = try RenderedPillHarness.recordingContentHeight(
-      usesPreviewLayout: false,
+      design: .classic,
       notice: DictationNarrator.copy(for: .approachingCap), width: 185)
     #expect(
       withNotice > bare,

--- a/Tests/EnviousWisprTests/App/Overlay/RenderedPillFreezeTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RenderedPillFreezeTests.swift
@@ -1,0 +1,222 @@
+import AppKit
+import EnviousWisprCore
+import SwiftUI
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// What every pill measures on `main` at `e062ab4d`, before Phase 4 moves a line
+/// (#2376 C1).
+///
+/// **Every number here was RUN and TRANSCRIBED, never computed from the code it
+/// freezes.** A table derived from the implementation agrees with every future
+/// version of that implementation, which is the one thing a freeze must not do.
+/// The capture that produced them is in the commit message; re-take them by
+/// printing `RenderedPillHarness.rootSize` per row rather than by reading the
+/// views.
+///
+/// **A Drift Guard, deliberately, and not a Product Outcome test.** When a row
+/// here fails the user sees nothing yet — it says WE changed our own rendering,
+/// which is exactly what Phase 4 does on purpose in some chunks and must not do
+/// by accident in others. The sentence "when this fails the user sees ___" has
+/// no ending, so it is not product coverage and is not counted as any.
+@MainActor
+@Suite(.tags(.driftGuard))
+struct RenderedPillFreezeTests {
+
+  init() { _ = NSApplication.shared }
+
+  // MARK: - The frozen table
+
+  /// Sizes of the routed content, measured 2026-08-25 on `e062ab4d`.
+  ///
+  /// Read `RenderedPillHarness`'s own doc for what a row means: it is the
+  /// content at the width the definition asks for, which is not the window's
+  /// size, and it is blind to paint.
+  nonisolated static let frozenNotices:
+    [(label: String, request: PillCatalogRequest, width: CGFloat, height: CGFloat)] = [
+      ("processing.transcribing", .processing(phase: .transcribing), 151.5, 44),
+      ("clipboardFallback", .clipboardFallback, 226.5, 44),
+      ("accessibilityToast", .accessibilityToast, 332.5, 43),
+      ("warning.polishFailed", .warning(reason: .polishFailed), 231, 37),
+      ("error.asrFailed", .error(reason: .asrFailed), 239, 38),
+      // The one row whose width is a PROPOSAL rather than an ideal, because it
+      // is the one pill asking for a fixed width and a content height. At its
+      // real 360 it wraps to 68pt; unproposed it reports 927 x 39, a single
+      // unwrapped line — which is the reading two earlier capture rounds took
+      // and the reason the harness proposes a width at all.
+      ("advisory.zeroSignal", .advisory(reason: .zeroSignal), 360, 68),
+      ("interruption.deviceRemoved", .interruption(reason: .deviceRemoved), 225.5, 44),
+      ("cachingModel", .cachingModel(engineLabel: "Parakeet"), 259.5, 51),
+      ("engineReady", .engineReady, 213, 40),
+      ("recoveringLastRecording", .recoveringLastRecording, 352, 51),
+      ("recoverySucceeded", .recoverySucceeded, 245, 51),
+      ("importStatus", .importStatus(message: "Imported 12 words"), 170, 38),
+    ]
+
+  @Test(
+    "every notice pill renders exactly what it rendered before Phase 4",
+    arguments: RenderedPillFreezeTests.frozenNotices)
+  func noticeRowsAreFrozen(
+    row: (label: String, request: PillCatalogRequest, width: CGFloat, height: CGFloat)
+  ) throws {
+    let size = RenderedPillHarness.rootSize(for: row.request)
+    // The instrument control comes FIRST and is a `#require`: a hosting view
+    // measured before layout reports `.zero`, and a table of zeroes would freeze
+    // perfectly for ever.
+    try #require(
+      size.width > 0 && size.height > 0,
+      "\(row.label) measured \(size) — the harness returned nothing, which is not a pass")
+    #expect(
+      size.width == row.width && size.height == row.height,
+      """
+      \(row.label) measured \(size.width) x \(size.height), frozen at \
+      \(row.width) x \(row.height). Either this pill is routed through a different \
+      leaf now, or its treatment changed. Phase 4 changes where a leaf's WORDS come \
+      from and must not change what any of them draws.
+      """)
+  }
+
+  // MARK: - The instrument's own controls
+
+  /// **An empty slot must be distinguishable from every pill**, or a harness
+  /// that silently measured nothing would agree with a table of the right shape.
+  @Test("an empty slot measures nothing, and nothing measures like a pill")
+  func emptySlotIsDistinguishable() {
+    let empty = RenderedPillHarness.rootSize(for: nil as PillDefinition?)
+    #expect(empty == .zero, "an empty slot measured \(empty)")
+    for row in Self.frozenNotices {
+      #expect(
+        !(row.width == empty.width && row.height == empty.height),
+        "\(row.label) is frozen at the empty-slot size, so its row proves nothing")
+    }
+  }
+
+  /// **The four notification severities must not all measure the same.** They
+  /// share one leaf and one model shape and differ only in style, so a harness
+  /// returning one number for everything would pass every row above while seeing
+  /// nothing. `.interruption` swaps an SF Symbol for the distress lips and its
+  /// own background, and `.advisory` wraps where the others do not.
+  @Test("the notification severities are told apart by the instrument")
+  func severitiesAreDiscriminated() {
+    let sizes = [
+      RenderedPillHarness.rootSize(for: .warning(reason: .polishFailed)),
+      RenderedPillHarness.rootSize(for: .error(reason: .asrFailed)),
+      RenderedPillHarness.rootSize(for: .advisory(reason: .zeroSignal)),
+      RenderedPillHarness.rootSize(for: .interruption(reason: .deviceRemoved)),
+    ]
+    #expect(
+      Set(sizes.map { "\($0.width)x\($0.height)" }).count == sizes.count,
+      """
+      two or more notification severities measured identically: \(sizes). This \
+      instrument cannot tell them apart, so every frozen row above is a claim it \
+      cannot support.
+      """)
+  }
+
+  /// Reconciles this instrument against a number pinned independently, by a
+  /// different rig, before this suite existed. A disagreement here indicts the
+  /// harness rather than the app.
+  @Test("the classic capsule measures what its own suite already pins")
+  func classicAgreesWithTheIndependentPin() throws {
+    let contentHeight = try RenderedPillHarness.recordingContentHeight(
+      usesPreviewLayout: false, width: 185)
+    #expect(
+      contentHeight == 44,
+      """
+      the capsule's content measured \(contentHeight)pt, against the 44pt \
+      `RecordingOverlayPreviewChromeTests.capsuleHeightIsPinned` has pinned since \
+      #2202. Two rigs disagreeing about one pill means one of them is wrong, and \
+      this is the newer one.
+      """)
+  }
+
+  // MARK: - Recording pills
+
+  nonisolated static let frozenRecording:
+    [(label: String, design: RecordingPillDesign, locked: Bool, width: CGFloat, height: CGFloat)] =
+      [
+        ("classic.unlocked", .classic, false, 185, 92),
+        ("classic.locked", .classic, true, 185, 92),
+        ("readingWell.unlocked", .readingWell, false, 400, 34),
+        ("readingWell.locked", .readingWell, true, 400, 34),
+      ]
+
+  @Test(
+    "every recording pill renders exactly what it rendered before Phase 4",
+    arguments: RenderedPillFreezeTests.frozenRecording)
+  func recordingRowsAreFrozen(
+    row: (
+      label: String, design: RecordingPillDesign, locked: Bool, width: CGFloat, height: CGFloat
+    )
+  ) throws {
+    let size = RenderedPillHarness.recordingRootSize(design: row.design, locked: row.locked)
+    try #require(size.width > 0 && size.height > 0, "\(row.label) measured \(size)")
+    #expect(
+      size.width == row.width && size.height == row.height,
+      "\(row.label) measured \(size.width) x \(size.height), frozen at \(row.width) x \(row.height)"
+    )
+  }
+
+  /// The reading well earns its height a line at a time, and that growth is the
+  /// feature. Frozen as a specific measurement rather than as "taller", because
+  /// "taller" also passes if it grows to the wrong size.
+  @Test("the reading well grows for words, and by exactly as much as it did")
+  func readingWellGrowsForWords() {
+    let words = RenderedPillHarness.recordingRootSize(
+      design: .readingWell,
+      display: .text("the quarterly numbers came in ahead of plan and the board was pleased"))
+    #expect(words.width == 400 && words.height == 99, "the reading well measured \(words)")
+  }
+
+  // MARK: - The measurement nobody had taken
+
+  /// **The classic pill's reserved box has ZERO headroom for its own longest
+  /// notice, and that is measured rather than asserted.**
+  ///
+  /// The #1060 banner is the only thing that makes a without-words pill grow.
+  /// The root frames such a pill to `RecordingPillDesign.reservedHeight`, and a
+  /// without-words design is handed a no-op growth callback by
+  /// `OverlayRenderModel`, so nothing in production and nothing in this tree
+  /// could previously observe the content exceeding the box.
+  ///
+  /// Measured 2026-08-25: `approachingCap` fills the 92-point box EXACTLY, and
+  /// `autoStopUnavailable` uses 78. A three-line sentence measures 120 and would
+  /// be silently cut off. So this is not a defect today and is one word of copy
+  /// away from being one — which is precisely why the budget is pinned here
+  /// rather than left as a number in a doc comment.
+  @Test(
+    "the shipped in-panel notices fit the box the classic pill reserves",
+    arguments: [RecordingNoticeReason.approachingCap, .autoStopUnavailable])
+  func inPanelNoticesFitTheReservedBox(reason: RecordingNoticeReason) throws {
+    let budget = try #require(RecordingPillDesign.classic.reservedHeight)
+    for locked in [false, true] {
+      let height = try RenderedPillHarness.recordingContentHeight(
+        usesPreviewLayout: false, locked: locked,
+        notice: DictationNarrator.copy(for: reason), width: RecordingPillDesign.classic.width)
+      #expect(
+        height <= budget,
+        """
+        the \(reason) banner made the capsule \(height)pt tall (locked: \(locked)) \
+        against the \(budget)pt box the classic design reserves. The pill cannot \
+        grow — a without-words design is handed a no-op growth callback — so the \
+        overflow is CLIPPED on screen with nothing reporting it. Shorten the copy \
+        or raise the reserved height; do not raise this expectation.
+        """)
+    }
+  }
+
+  /// The paired case, so the row above cannot pass by measuring nothing. A
+  /// notice must make the pill genuinely taller than a bare one.
+  @Test("a notice is what makes the capsule grow at all")
+  func aNoticeGrowsTheCapsule() throws {
+    let bare = try RenderedPillHarness.recordingContentHeight(
+      usesPreviewLayout: false, width: 185)
+    let withNotice = try RenderedPillHarness.recordingContentHeight(
+      usesPreviewLayout: false,
+      notice: DictationNarrator.copy(for: .approachingCap), width: 185)
+    #expect(
+      withNotice > bare,
+      "a notice measured \(withNotice)pt against a bare \(bare)pt — the banner never rendered")
+  }
+}

--- a/Tests/EnviousWisprTests/App/Overlay/RenderedPillFreezeTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RenderedPillFreezeTests.swift
@@ -153,6 +153,38 @@ struct RenderedPillFreezeTests {
     }
   }
 
+  /// **The one product CONSTANT the frozen table was silently carrying, pinned
+  /// where a hosted runner can see it** (#2376 Phase 4, round 4).
+  ///
+  /// Gating `noticeRowsAreFrozen` to a development Mac was right — its numbers are
+  /// rendered measurements — but it took a real guard with it. That table was the
+  /// only thing binding the advisory's 360pt REQUEST, and a request is not a
+  /// measurement: it is a value in the catalog, identical on every machine. So it
+  /// belongs in an always-enabled case, and narrowing it is caught everywhere
+  /// rather than only here.
+  ///
+  /// Note what the portable relations case CANNOT do instead: it asserts the
+  /// rendered width equals the REQUESTED one, so moving the request moves both
+  /// sides and it stays green. A test that follows the value it is checking binds
+  /// nothing.
+  @Test("the advisory asks for the width the panel reserves for it")
+  func advisoryWidthIsPinned() throws {
+    let definition = try #require(
+      PillCatalog.entry(for: .advisory(reason: .zeroSignal), id: RenderedPillHarness.id())
+        .definition)
+    guard case .fixed(let requested) = definition.requestedWidth else {
+      Issue.record("the advisory no longer asks for a fixed width at all")
+      return
+    }
+    #expect(
+      requested == 360,
+      """
+      the advisory asks for \(requested)pt, not the 360 the overlay panel reserves. \
+      #1891: unconstrained it measures 927 and wraps to nothing sensible, so this \
+      number is what makes the pill legible rather than a style choice.
+      """)
+  }
+
   // MARK: - The instrument's own controls
 
   /// **An empty slot must be distinguishable from every pill**, or a harness

--- a/Tests/EnviousWisprTests/App/Overlay/RenderedPillFreezeTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RenderedPillFreezeTests.swift
@@ -92,25 +92,68 @@ struct RenderedPillFreezeTests {
     }
   }
 
-  /// **The four notification severities must not all measure the same.** They
-  /// share one leaf and one model shape and differ only in style, so a harness
-  /// returning one number for everything would pass every row above while seeing
-  /// nothing. `.interruption` swaps an SF Symbol for the distress lips and its
-  /// own background, and `.advisory` wraps where the others do not.
+  /// **The four notification severities must not all measure the same, and the
+  /// TEXT is held constant so that claim is about the severity.**
+  ///
+  /// An earlier version drove four different catalog requests — `.warning`,
+  /// `.error`, `.advisory`, `.interruption` — each carrying its own copy. Cloud
+  /// review refuted it: those four measure differently because their MESSAGES
+  /// differ, so the control passes just as well against a build that routes every
+  /// severity through one style, while claiming to prove the opposite. A control
+  /// that cannot fail for the reason it names buys confidence without cover.
+  ///
+  /// Holding the sentence fixed and varying only the severity makes a collapsed
+  /// mapping fail: the four would then measure identically.
+  ///
+  /// Measured 2026-08-25 with one sentence at a fixed 280pt: warning 37,
+  /// error 38, distress 44, advisory 52. The error-versus-warning gap is ONE
+  /// point, from the two SF Symbols' differing heights — real, small, and the
+  /// reason this suite claims discrimination rather than claiming to see paint.
   @Test("the notification severities are told apart by the instrument")
   func severitiesAreDiscriminated() {
-    let sizes = [
-      RenderedPillHarness.rootSize(for: .warning(reason: .polishFailed)),
-      RenderedPillHarness.rootSize(for: .error(reason: .asrFailed)),
-      RenderedPillHarness.rootSize(for: .advisory(reason: .zeroSignal)),
-      RenderedPillHarness.rootSize(for: .interruption(reason: .deviceRemoved)),
-    ]
+    let text = "Something went wrong while polishing your text."
+    let sizes = [NoticeModel.Severity.warning, .error, .distress, .advisory].map {
+      severity in
+      RenderedPillHarness.rootSize(
+        for: PillDefinition(
+          id: RenderedPillHarness.id(),
+          content: .notice(
+            NoticeModel(
+              kind: .notification, text: text, severity: severity,
+              isMultiline: severity == .advisory)),
+          expiry: .untilReplaced, requestedWidth: .fixed(280)))
+    }
     #expect(
       Set(sizes.map { "\($0.width)x\($0.height)" }).count == sizes.count,
       """
-      two or more notification severities measured identically: \(sizes). This \
-      instrument cannot tell them apart, so every frozen row above is a claim it \
-      cannot support.
+      two or more notification severities measured identically on ONE sentence: \
+      \(sizes). Either the severity-to-style mapping has collapsed, or this \
+      instrument cannot tell the treatments apart — and every frozen row above is a \
+      claim it cannot support.
+      """)
+  }
+
+  /// The paired case, so the row above cannot pass merely because five inputs
+  /// give five answers: `.neutral` has no style of its own and maps to
+  /// `.warning`, so it must measure IDENTICALLY to it. A harness that returned a
+  /// different number for every input would fail here.
+  @Test("the styleless severity measures as the style it maps to")
+  func neutralMeasuresAsWarning() {
+    let text = "Something went wrong while polishing your text."
+    func size(_ severity: NoticeModel.Severity) -> CGSize {
+      RenderedPillHarness.rootSize(
+        for: PillDefinition(
+          id: RenderedPillHarness.id(),
+          content: .notice(NoticeModel(kind: .notification, text: text, severity: severity)),
+          expiry: .untilReplaced, requestedWidth: .fixed(280)))
+    }
+    #expect(
+      size(.neutral) == size(.warning),
+      """
+      `.neutral` measured \(size(.neutral)) against `.warning`'s \(size(.warning)). \
+      `OverlayRootView.style(for:)` maps the styleless severity to `.warning` \
+      deliberately, so a row landing there is styled-wrong-but-VISIBLE rather than \
+      unstyled; if these differ, that mapping moved.
       """)
   }
 

--- a/Tests/EnviousWisprTests/App/Overlay/RenderedPillHarness.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RenderedPillHarness.swift
@@ -164,7 +164,7 @@ enum RenderedPillHarness {
   /// without-words design is also handed `onContentHeightChange = { _ in }` by
   /// `OverlayRenderModel`, so nothing in production reports this either.
   static func recordingContentHeight(
-    usesPreviewLayout: Bool,
+    design: RecordingPillDesign,
     locked: Bool = false,
     notice: String? = nil,
     display: LivePreviewDisplay = .off,
@@ -181,7 +181,7 @@ enum RenderedPillHarness {
       recordingElapsedProvider: { 127 },
       livePreviewProvider: { display },
       onContentHeightChange: { log.record($0) },
-      usesPreviewLayout: usesPreviewLayout,
+      chrome: design.chrome,
       lockState: lockState,
       noticeState: noticeState,
       initialPreview: display)

--- a/Tests/EnviousWisprTests/App/Overlay/RenderedPillHarness.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RenderedPillHarness.swift
@@ -1,0 +1,202 @@
+import AppKit
+import EnviousWisprCore
+import SwiftUI
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// Hosts `OverlayRootView` and measures what it actually renders (#2376 Phase 4, C1).
+///
+/// **It hosts the ROOT, never a leaf, and that is the whole reason it exists.**
+/// Phase 4's named likeliest regression is correct model data rendered with the
+/// WRONG visual treatment. `OverlayRootView.content(for:)` and `.notices(_:on:)`
+/// are both private, so a fixture that constructs `RecoveryNoticeView` itself
+/// bypasses the routing switch entirely and can never observe which leaf was
+/// chosen — it would only prove that the leaf it already named draws what it
+/// draws. Driving `model.presentation` with real `PillCatalog.entry` output
+/// exercises the routing by construction, so a row routed through the wrong leaf
+/// measures differently.
+///
+/// **What it measures is the ROUTED CONTENT at the width the definition asks
+/// for, which is not the same thing as the window's size.** The width constraint
+/// mirrors `OverlayWindowHost.resolvedSize`'s own first step — a pill asking for
+/// a fixed width and a content height is asking "how tall is this at that
+/// width", and an unconstrained measurement answers a different question (the
+/// #1891 advisory measures 927 points wide unconstrained and 360 on screen).
+/// What this deliberately does NOT reproduce is the host's `fixedHeight`
+/// substitution: that is the host's arithmetic, the host's suite owns it, and
+/// copying it here would put a second authority for window geometry in the test
+/// target.
+///
+/// **What it cannot see at all, stated rather than discovered later: PAINT.**
+/// Icon, icon colour, corner shape and button fill do not participate in layout,
+/// and `scaleEffect` is a rendering transform `fittingSize` is blind to — the 2x
+/// hands-free mark measures identically to the 1x one, recorded at
+/// `RecordingOverlayPreviewChromeTests.swift:105`. This instrument proves which
+/// leaf ran and what it measured. Whether the chosen treatment reached the
+/// pixels is a Live UAT row and is claimed nowhere else.
+///
+/// **The accessibility tree is NOT readable this way, measured 2026-08-25 and
+/// recorded so nobody spends the afternoon again.** A recursive
+/// `accessibilityChildren()` walk over the hosted root returns exactly one
+/// element — the root `AXGroup`, with an empty label and no children — for both
+/// action pills, because SwiftUI populates its accessibility tree lazily under a
+/// real accessibility client rather than at layout. Element labels and button
+/// enablement are therefore proven by Live UAT against the running app, and by
+/// the axis-differential size proof below, and by nothing else.
+@MainActor
+enum RenderedPillHarness {
+
+  /// A deterministic id, so a row's identity cannot vary between runs.
+  static func id() -> PresentationID { PresentationID(rawValue: UUID()) }
+
+  /// Records what a rendered root sent back, so an action row can assert on the
+  /// EVENT rather than on a closure having been called.
+  final class EventRecorder: @unchecked Sendable {
+    private(set) var events: [OverlayEvent] = []
+    func record(_ event: OverlayEvent) { events.append(event) }
+    var actions: [PillAction] {
+      events.compactMap { if case .action(_, let a) = $0 { return a } else { return nil } }
+    }
+  }
+
+  /// Height reported by a recording leaf's own geometry background.
+  final class HeightLog: @unchecked Sendable {
+    private(set) var reported: [CGFloat] = []
+    func record(_ h: CGFloat) { reported.append(h) }
+  }
+
+  // MARK: - Rendering the root
+
+  /// Measure the routed content for one definition.
+  static func rootSize(
+    for definition: PillDefinition?,
+    model: OverlayRenderModel = OverlayRenderModel(),
+    recorder: EventRecorder = EventRecorder()
+  ) -> CGSize {
+    model.presentation = definition
+    let root = OverlayRootView(model: model, sendEvent: { recorder.record($0) })
+
+    // **The constraint is a SwiftUI WIDTH PROPOSAL, and it took two capture
+    // rounds to establish that nothing else is one.** `NSHostingView.fittingSize`
+    // reports the ideal size for an UNSPECIFIED width proposal, so neither
+    // narrowing the hosting view's frame nor narrowing the window it sits in
+    // reaches it — both were measured, and both left the #1891 advisory
+    // reporting 927 x 39, one unwrapped line, for a pill that renders at 360 and
+    // wraps to three. The deleted panel constrained the advisory the same way,
+    // with `.frame(width: 360)` inside the SwiftUI hierarchy, which is what this
+    // reproduces.
+    //
+    // Applied ONLY to a fixed width with a CONTENT height, which is the one
+    // combination `OverlayWindowHost.resolvedSize` constrains for the same
+    // reason. A `.measured` width stays unproposed, or the measurement it exists
+    // for becomes the constraint we just imposed.
+    var proposal: CGFloat?
+    if let definition, case .fixed(let constrained) = definition.requestedWidth,
+      definition.reservesFixedHeight == nil, constrained > 0
+    {
+      proposal = constrained
+    }
+
+    let host: NSHostingView<AnyView> =
+      proposal.map { NSHostingView(rootView: AnyView(root.frame(width: $0))) }
+      ?? NSHostingView(rootView: AnyView(root))
+
+    let frame = NSRect(x: 0, y: 0, width: proposal ?? 1000, height: 600)
+    let window = NSWindow(
+      contentRect: frame, styleMask: [.borderless], backing: .buffered, defer: false)
+    window.contentView = host
+    host.frame = frame
+    host.layoutSubtreeIfNeeded()
+    window.displayIfNeeded()
+    return host.fittingSize
+  }
+
+  /// Measure the routed content for a non-recording request, taken from the real
+  /// catalog rather than from a hand-built definition.
+  static func rootSize(for request: PillCatalogRequest) -> CGSize {
+    rootSize(for: PillCatalog.entry(for: request, id: id()).definition)
+  }
+
+  /// Measure a recording pill at a given design, driving the providers through
+  /// `OverlayRenderModel` exactly as the director does.
+  ///
+  /// **The preview display goes through `setRecordingProviders`, never through
+  /// the leaf's `initialPreview:` seam.** That seam bypasses
+  /// `OverlayRenderModel`'s `canHoldWords` gate, so seeding it would measure the
+  /// leaf's willingness to draw words rather than whether the gate let any
+  /// through.
+  static func recordingRootSize(
+    design: RecordingPillDesign,
+    locked: Bool = false,
+    display: LivePreviewDisplay = .off,
+    audioLevel: Float = 0.4,
+    elapsed: TimeInterval = 127,
+    position: OverlayPillPosition = .top
+  ) -> CGSize {
+    let model = OverlayRenderModel()
+    model.setRecordingProviders(
+      audioLevel: { audioLevel },
+      recordingElapsed: { elapsed },
+      livePreview: { display },
+      design: design,
+      position: position,
+      onContentHeightChange: { _ in })
+    let definition = PillDefinition(
+      id: id(),
+      content: .recording(
+        audioLevel: audioLevel, isLocked: locked, notice: nil, design: design),
+      expiry: .untilReplaced,
+      requestedWidth: .fixed(design.width),
+      reservesFixedHeight: design.reservedHeight)
+    return rootSize(for: definition, model: model)
+  }
+
+  // MARK: - The measurement the root's fixed frame hides
+
+  /// The CONTENT height a recording leaf reports for itself, with an optional
+  /// #1060 in-panel notice set.
+  ///
+  /// **A different question from `recordingRootSize`, and the root cannot answer
+  /// it.** The root frames a without-words recording pill to its design's
+  /// reserved box, so it measures 185x92 whatever the content does — which is
+  /// exactly the measurement that cannot see a notice overflowing its budget. A
+  /// without-words design is also handed `onContentHeightChange = { _ in }` by
+  /// `OverlayRenderModel`, so nothing in production reports this either.
+  static func recordingContentHeight(
+    usesPreviewLayout: Bool,
+    locked: Bool = false,
+    notice: String? = nil,
+    display: LivePreviewDisplay = .off,
+    width: CGFloat
+  ) throws -> CGFloat {
+    let log = HeightLog()
+    let lockState = OverlayLockState()
+    lockState.isLocked = locked
+    let noticeState = OverlayNoticeState()
+    noticeState.message = notice
+
+    let view = RecordingOverlayView(
+      audioLevelProvider: { 0.4 },
+      recordingElapsedProvider: { 127 },
+      livePreviewProvider: { display },
+      onContentHeightChange: { log.record($0) },
+      usesPreviewLayout: usesPreviewLayout,
+      lockState: lockState,
+      noticeState: noticeState,
+      initialPreview: display)
+
+    let host = NSHostingView(rootView: view.frame(width: width))
+    let frame = NSRect(x: 0, y: 0, width: width, height: 400)
+    let window = NSWindow(
+      contentRect: frame, styleMask: [.borderless], backing: .buffered, defer: false)
+    window.contentView = host
+    host.frame = frame
+    host.layoutSubtreeIfNeeded()
+    window.displayIfNeeded()
+
+    return try #require(
+      log.reported.last,
+      "the recording leaf never reported a height — the measurement is missing, not failing")
+  }
+}

--- a/Tests/EnviousWisprTests/App/Overlay/RenderedPillHarness.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RenderedPillHarness.swift
@@ -199,4 +199,51 @@ enum RenderedPillHarness {
       log.reported.last,
       "the recording leaf never reported a height — the measurement is missing, not failing")
   }
+
+  /// What the recording leaf's content WOULD take if nothing constrained it.
+  ///
+  /// **`recordingRootSize` cannot answer this and that is the reason this exists.**
+  /// It proposes the design's own fixed width, so it returns 185 or 288 whatever
+  /// the content wants — pinned by construction, and therefore blind to anything
+  /// that changes how much room the content needs.
+  ///
+  /// Written for the hands-free treatment (#2376 Phase 4, round 5): the badge sits
+  /// INLINE, so it adds no height, and height is what every other recording probe
+  /// here reads. Width is the observable the inline form preserves.
+  ///
+  /// Same blindness as the rest of this harness, restated so it is not assumed
+  /// away: this measures LAYOUT, never paint. A treatment that recolours or scales
+  /// without changing what the content needs is invisible to it.
+  static func recordingContentNaturalWidth(
+    design: RecordingPillDesign,
+    locked: Bool = false,
+    notice: String? = nil,
+    display: LivePreviewDisplay = .off
+  ) -> CGFloat {
+    let lockState = OverlayLockState()
+    lockState.isLocked = locked
+    let noticeState = OverlayNoticeState()
+    noticeState.message = notice
+
+    let view = RecordingOverlayView(
+      audioLevelProvider: { 0.4 },
+      recordingElapsedProvider: { 127 },
+      livePreviewProvider: { display },
+      onContentHeightChange: { _ in },
+      chrome: design.chrome,
+      lockState: lockState,
+      noticeState: noticeState,
+      initialPreview: display)
+
+    // No `.frame(width:)`, which is the whole point — an unproposed hosting view
+    // reports what the content ideally wants.
+    let host = NSHostingView(rootView: view)
+    let window = NSWindow(
+      contentRect: NSRect(x: 0, y: 0, width: 2000, height: 400),
+      styleMask: [.borderless], backing: .buffered, defer: false)
+    window.contentView = host
+    host.layoutSubtreeIfNeeded()
+    window.displayIfNeeded()
+    return host.fittingSize.width
+  }
 }

--- a/Tests/EnviousWisprTests/App/RecordingOverlayPreviewChromeTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingOverlayPreviewChromeTests.swift
@@ -31,7 +31,7 @@ struct RecordingOverlayPreviewChromeTests {
   private func pillHeight(
     locked: Bool,
     showing display: LivePreviewDisplay,
-    usesPreviewLayout: Bool = true
+    design: RecordingPillDesign = .readingWell
   ) throws -> CGFloat {
     let log = HeightLog()
     let lockState = OverlayLockState()
@@ -42,7 +42,7 @@ struct RecordingOverlayPreviewChromeTests {
       recordingElapsedProvider: { 127 },
       livePreviewProvider: { display },
       onContentHeightChange: { log.record($0) },
-      usesPreviewLayout: usesPreviewLayout,
+      chrome: design.chrome,
       lockState: lockState,
       noticeState: OverlayNoticeState(),
       initialPreview: display
@@ -118,13 +118,13 @@ struct RecordingOverlayPreviewChromeTests {
     "the capsule's height is untouched by this chunk, in both modes",
     arguments: [false, true])
   func capsuleHeightIsPinned(locked: Bool) throws {
-    let height = try pillHeight(locked: locked, showing: .off, usesPreviewLayout: false)
+    let height = try pillHeight(locked: locked, showing: .off, design: .classic)
     #expect(
       height == Self.capsuleContentHeight,
       """
       the capsule measured \(height)pt (locked: \(locked)), not the \
       \(Self.capsuleContentHeight)pt it has always been. This chunk is gated on \
-      usesPreviewLayout and must not reach the layout the founder reserved.
+      its own chrome and must not reach the layout the founder reserved.
       """)
   }
 
@@ -154,7 +154,7 @@ struct RecordingOverlayPreviewChromeTests {
       recordingElapsedProvider: { 127 },
       livePreviewProvider: { text },
       onContentHeightChange: { log.record($0) },
-      usesPreviewLayout: true,
+      chrome: RecordingPillDesign.readingWell.chrome,
       lockState: OverlayLockState(),
       noticeState: noticeState,
       initialPreview: text
@@ -230,8 +230,8 @@ struct RecordingOverlayPreviewChromeTests {
   /// would report clean after silently deleting it.
   @Test("the capsule still says something while waiting, because it has no header")
   func capsuleWaitingKeepsItsSentence() throws {
-    let waiting = try pillHeight(locked: false, showing: .waiting, usesPreviewLayout: false)
-    let off = try pillHeight(locked: false, showing: .off, usesPreviewLayout: false)
+    let waiting = try pillHeight(locked: false, showing: .waiting, design: .classic)
+    let off = try pillHeight(locked: false, showing: .off, design: .classic)
 
     #expect(
       waiting > off,

--- a/Tests/EnviousWisprTests/App/RecordingOverlayPreviewChromeTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingOverlayPreviewChromeTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import EnviousWisprCore
 import SwiftUI
 import Testing
 

--- a/Tests/EnviousWisprTests/App/RecordingOverlayPreviewSizingTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingOverlayPreviewSizingTests.swift
@@ -60,7 +60,7 @@ struct RecordingOverlayPreviewSizingTests {
     inPanelOfHeight startingHeight: CGFloat,
     notice: String? = nil,
     locked: Bool = false,
-    usesPreviewLayout: Bool = true
+    design: RecordingPillDesign = .readingWell
   ) throws -> CGFloat {
     let log = HeightLog()
     let lockState = OverlayLockState()
@@ -73,7 +73,7 @@ struct RecordingOverlayPreviewSizingTests {
       recordingElapsedProvider: { 41 },
       livePreviewProvider: { display },
       onContentHeightChange: { log.record($0) },
-      usesPreviewLayout: usesPreviewLayout,
+      chrome: design.chrome,
       lockState: lockState,
       noticeState: noticeState,
       initialPreview: display
@@ -217,7 +217,7 @@ struct RecordingOverlayPreviewSizingTests {
       recordingElapsedProvider: { 41 },
       livePreviewProvider: { display },
       onContentHeightChange: { log.record($0) },
-      usesPreviewLayout: true,
+      chrome: RecordingPillDesign.readingWell.chrome,
       lockState: OverlayLockState(),
       noticeState: noticeState,
       initialPreview: display
@@ -265,7 +265,7 @@ struct RecordingOverlayPreviewSizingTests {
       recordingElapsedProvider: { 41 },
       livePreviewProvider: { .text(Self.threeLines) },
       onContentHeightChange: { log.record($0) },
-      usesPreviewLayout: true,
+      chrome: RecordingPillDesign.readingWell.chrome,
       lockState: OverlayLockState(),
       noticeState: OverlayNoticeState(),
       initialPreview: .text(Self.threeLines)
@@ -312,7 +312,7 @@ struct RecordingOverlayPreviewSizingTests {
       recordingElapsedProvider: { 41 },
       livePreviewProvider: { .off },
       onContentHeightChange: { log.record($0) },
-      usesPreviewLayout: false,
+      chrome: RecordingPillDesign.classic.chrome,
       lockState: OverlayLockState(),
       noticeState: OverlayNoticeState(),
       initialPreview: .off

--- a/Tests/EnviousWisprTests/App/RecordingOverlayPreviewSizingTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingOverlayPreviewSizingTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import EnviousWisprCore
 import SwiftUI
 import Testing
 

--- a/Tests/EnviousWisprTests/App/RecordingOverlayPreviewTypographyTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingOverlayPreviewTypographyTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import EnviousWisprCore
 import SwiftUI
 import Testing
 

--- a/Tests/EnviousWisprTests/App/RecordingOverlayPreviewTypographyTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingOverlayPreviewTypographyTests.swift
@@ -36,7 +36,7 @@ struct RecordingOverlayPreviewTypographyTests {
       recordingElapsedProvider: { 41 },
       livePreviewProvider: { display },
       onContentHeightChange: { log.record($0) },
-      usesPreviewLayout: true,
+      chrome: RecordingPillDesign.readingWell.chrome,
       lockState: OverlayLockState(),
       noticeState: OverlayNoticeState(),
       initialPreview: display

--- a/scripts/xcode-test.sh
+++ b/scripts/xcode-test.sh
@@ -115,7 +115,16 @@ run_lane() {  # $1=scheme $2=config $3=logfile $4=bundle $5...=extra build setti
   # Xcode forwards TEST_RUNNER_* variables to the test process after removing
   # the prefix. This keeps AppLogger tests away from the running dev app's
   # ~/Library/Logs/EnviousWispr/app.log (#2279).
-  TEST_RUNNER_EW_APP_LOG_DIRECTORY="$APP_LOG_DIR" xcodebuild test \
+  #
+  # `CI` is forwarded the same way and for the same reason: an INHERITED variable
+  # does not reach the test process at all. Measured 2026-08-25 two ways on one
+  # suite — with `CI=true` exported into this script a gate reading it still ran,
+  # and with `TEST_RUNNER_CI=true` the same gate skipped. So a suite asking "am I
+  # on a hosted runner" cannot read the runner's own variable, and a gate written
+  # against it fails OPEN, which is how a machine-dependent assertion reaches CI
+  # while its author believes it is gated (#2376 Phase 4).
+  TEST_RUNNER_EW_APP_LOG_DIRECTORY="$APP_LOG_DIR" \
+  TEST_RUNNER_CI="${CI:-}" xcodebuild test \
     -project "$PROJECT" \
     -scheme "$scheme" \
     -configuration "$config" \


### PR DESCRIPTION
Phase 4 of the six-phase pill-system refactor. Board: #2373. Plan authority: `docs/plans/pill-system-refactor-plan.md` § "Phase 4 — make leaves obey explicit models and ship recording appearances". Part of #2376.

## What a user gets

A **Recording Pill** picker on the Appearance page, in two groups: designs that show your words as you speak, and designs that do not. Each group remembers its own choice, so turning Live Preview off and back on returns the pill you last chose on that side. The group that does not apply is greyed out **with its reason** — and the reason distinguishes "Live Preview is off" from "the engine you selected cannot run on this Mac", because those send a user to two different places.

A **second without-words design**, `.levelRail`: a wider capsule carrying the elapsed clock beside a live rainbow level meter. It reuses `RainbowLevelMeter`, which today has exactly one production construction site — inside the reading well's header — so the meter shipped in #2216 is reachable only by users who can and do run Live Preview. This offers it to everyone else.

Everything else in the phase is invisible by design: `.classic` and `.readingWell` render byte-identically to `main`.

## Seven chunks

| | |
|---|---|
| **C1** `b900b799` | A rendered-ROOT instrument and the freeze of what every pill measures today. Tests only. |
| **C2** `a7266c6d` | `usesPreviewLayout` dies as a leaf API; `RecordingPillChrome` replaces eighteen reads of it. Semantic no-op. |
| **C3** `44645841` | The notice leaves render their models and stop inventing copy, labels and actions. |
| **C4** `57e2737a` | `resolve` fails closed in BOTH directions; one offerability predicate; the capability gains a reason. |
| **C5** `aabe91fc` | `.levelRail` ships, unreachable until C6. |
| **C6** `75bfb5cf` | Per-group selection persisted; the bootstrapper seam stops being a constant. |
| **C7** `78c53f9c` | The grouped picker. |

## The three things worth a reviewer's attention

**1. The instrument, because every no-op claim in this PR rests on it.** Nothing in the tree could previously observe Phase 4's named likeliest regression — correct model data rendered with the WRONG visual treatment. Every existing pill test either builds a leaf directly, which bypasses the private routing switch and so cannot observe which leaf was chosen, or reads a value off the catalog without rendering it. `RenderedPillHarness` hosts the ROOT with real `PillCatalog.entry` output, so routing is exercised by construction. Its numbers were RUN and TRANSCRIBED, and it carries three controls: a positive measurement per row, an empty slot distinguishable from every frozen row, and the four notification severities required not to measure the same — plus a reconciliation against the 44pt capsule height a different rig has pinned independently since #2202.

**2. A live tripwire it found on the way.** The #1060 in-panel banner is the only thing that grows a without-words pill, and such a pill is handed a no-op growth callback, so nothing in production or in the tree could see it overflow its box. Measured: the longest shipped banner fills `.classic`'s 92-point box EXACTLY, with zero headroom; a three-line sentence measures 120 and would be clipped in silence. Not a defect today, one word of copy from being one, and now pinned. It also settles `.levelRail`'s reserved height: 92 is the group's NOTICE BUDGET, not a number chosen for its contents. Every draft plan gave the new design 40 or 44 and would have clipped the graceful-cap warning.

**3. Drift is closed structurally, not by care.** `PillCatalog.offers` is defined in terms of the same `resolve` the director calls, so a design the picker greys out is exactly a design the pill would refuse. The design enum MOVED to Core rather than being mirrored by a string with an AppKit-side mapping: the move failed loudly (ten test files, one import each), the mapping would have compiled in silence and left two lists to diverge.

## Verification

- **Debug lane 6,957 tests, verdict PASS**, per-bundle lines reconciling exactly against the lane total (6,751 + 206), zero crash lines. Every C1 frozen row re-measures byte-identical across C2 through C7.
- **Release lane**: see the comment below.
- Three `test-hardening` issues carry mutation recipes in their bodies — #2416, #2417, #2418 — twelve rows, all validated runnable against this branch.

## What is NOT claimed, stated rather than left to be assumed

`fittingSize` is blind to icon, icon colour, corner shape and button fill, and `scaleEffect` is a rendering transform it cannot see. **The accessibility tree is not readable from a hosted view at all** — measured in C1, where a recursive `accessibilityChildren()` walk returned exactly one empty `AXGroup` for both action pills, because SwiftUI populates that tree lazily under a real accessibility client.

So three things are Live UAT rows and are asserted nowhere else: that each design's chrome reached the pixels, that a greyed card REPORTS as disabled to VoiceOver rather than merely looking it, and that the recovery pill speaks its own element label rather than its title.

## Two founder-visible calls

1. `.levelRail`'s **260-point width** and its meter's **24-point height** are CHOSEN, not measured — there is no mockup in the tree. Both are easy to move. The 92 is not a choice.
2. `ImportStatusOverlayView` pins a two-line cap while the catalog row says the text wraps. Read as two different questions (does it wrap / how far), so neither was changed and no pixel moved. If the intent was ever an unbounded import message, this preserves the opposite.
