### PR TITLE
fix(quickadd): the dead Create button, the silent save, and the keyboard that never came back (#2391)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddCoordinator.swift
@@ -298,16 +298,41 @@ final class QuickAddCoordinator {
     return .gone
   }
 
+  /// What accepting a row actually did, which is not always what the row promised.
+  ///
+  /// **Three cases rather than an optional message, because the caller now has to SAY what
+  /// happened.** The panel confirms a save before it leaves (#2391 §1), and the confirmation is a
+  /// claim: `"clawwed" added to Claude` is false when the word already carried that spelling and
+  /// nothing was written.
+  ///
+  /// The caller cannot work this out for itself. `candidate.alreadyHasHeardSpelling` is a fact about
+  /// the ranking taken when the panel OPENED, and the panel is persistent — the whole reason the
+  /// already-has question is asked of the live word below. A confirmation composed from the snapshot
+  /// would be the same stale-read defect the accept path has now produced three times, arriving
+  /// through the sentence written to reassure the user.
+  ///
+  /// The canonical rides along for the same reason: the user can have renamed the word in Settings
+  /// while the panel sat open, and naming the snapshot's spelling would confirm a word that no
+  /// longer exists under that name.
+  enum AcceptResult: Equatable {
+    /// The spelling was written onto this word.
+    case saved(word: String)
+    /// The live word already carried the spelling, so nothing was written and nothing needed to be.
+    case alreadyHad(word: String)
+    /// The library refused. Carries the user-facing reason; the panel stays open.
+    case refused(String)
+  }
+
   /// The user accepted a row.
   ///
-  /// **Returns the refusal message when the library would not take the word, and nil otherwise.**
-  /// The return value is what tells the caller whether it may dismiss: `saveWord` can refuse for
-  /// reasons that have nothing to do with this feature — the stored-value character policy, the
-  /// 512-scalar ceiling, a words file that will not write — and dismissing regardless is a panel
-  /// reporting success for a word that was never saved. The sibling path through the edit sheet
-  /// already had this shape; this one did not.
+  /// **Returns what happened, and `.refused` is what tells the caller it may NOT dismiss.**
+  /// `saveWord` can refuse for reasons that have nothing to do with this feature — the stored-value
+  /// character policy, the 512-scalar ceiling, a words file that will not write — and dismissing
+  /// regardless is a panel reporting success for a word that was never saved. The sibling path
+  /// through Create already had this shape; this one did not.
   @discardableResult
-  func accept(_ candidate: QuickAddRanker.Candidate, from model: QuickAddPanelModel) -> String? {
+  func accept(_ candidate: QuickAddRanker.Candidate, from model: QuickAddPanelModel) -> AcceptResult
+  {
     let usedSearch = model.isSearching
     let rank = model.ranking.candidates.firstIndex { $0.id == candidate.id }
 
@@ -332,7 +357,7 @@ final class QuickAddCoordinator {
       kind = .userWord
     case .gone:
       environment.emit(.failed(stage: "save", reason: "target_gone"))
-      return QuickAddPanelCopy.wordNoLongerExists
+      return .refused(QuickAddPanelCopy.wordNoLongerExists)
     }
 
     // **ONE already-has question, asked of the LIVE word, and it replaces a guard that ran BEFORE
@@ -356,7 +381,7 @@ final class QuickAddCoordinator {
       })
     else {
       finish(.alreadySaved, usedSearch: usedSearch, rank: rank, kind: kind)
-      return nil
+      return .alreadyHad(word: word.canonical)
     }
     word.aliases.append(model.spellingToWrite)
 
@@ -370,12 +395,12 @@ final class QuickAddCoordinator {
       // `write_failed` and then a second `resolved` when they did either, which is two terminal
       // events for one open. `resolved` means ENDED; the refusal is reported by the `failed` event
       // above, which is what that channel is for.
-      return message
+      return .refused(message)
     }
     finish(
       usedSearch ? .acceptedAfterSearch : .accepted,
       usedSearch: usedSearch, rank: rank, kind: kind)
-    return nil
+    return .saved(word: word.canonical)
   }
 
   /// The user chose to create a new word. **Moves the panel to its compose stage and resolves
@@ -403,13 +428,16 @@ final class QuickAddCoordinator {
     finish(.createdNew, usedSearch: usedSearch, rank: nil, kind: nil)
   }
 
-  /// The sheet's canonical was already in the library and already carried every spelling the user
-  /// kept, so `CustomWordsManager.add` wrote nothing and nothing needed writing.
+  /// Nothing was written and nothing needed to be.
+  ///
+  /// **Two callers, one fact.** Create's canonical was already in the library and already carried
+  /// every spelling the user kept, so `CustomWordsManager.add` wrote nothing; or the panel opened
+  /// onto a word that already knows the selection and the user let the notice fade (#2391 §3).
   ///
   /// A separate entry point rather than a flag on `didCreateNew`, because the two differ in the one
   /// way the funnel cares about: whether a word was created. `alreadySaved` is not new vocabulary
   /// for this — it already means "the word carried this spelling, so there was nothing to write",
-  /// and it is the same fact arriving through the other door.
+  /// and it is the same fact arriving through the other doors.
   func didFindAlreadySaved(usedSearch: Bool) {
     finish(.alreadySaved, usedSearch: usedSearch, rank: nil, kind: nil)
   }

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddCoordinator.swift
@@ -87,8 +87,14 @@ final class QuickAddCoordinator {
     /// postcondition would then depend on the caller having appended last — a fact no signature
     /// states and one edit could change without anything failing.
     var saveWord: (CustomWord, String) -> String?
-    /// Open the existing edit sheet on a new word carrying the heard spelling as its first alias.
-    var presentNewWordSheet: (String) -> Void
+    /// Move the panel to its compose stage, where the user authors the word by hand.
+    ///
+    /// **Takes no spelling, and that is the whole shape of the #2391 fix.** It used to present a
+    /// SwiftUI `.sheet` seeded with the heard spelling — which presented NOTHING, because the panel
+    /// refuses main status and AppKit refuses `beginSheet` on such a window, silently. The word is
+    /// now assembled by the panel model, which already holds the heard spelling, so there is no
+    /// second copy of it to hand anywhere and no second place that could disagree about trimming.
+    var beginNewWord: () -> Void
     var emit: (QuickAddEvent) -> Void
     /// Injected so elapsed time is measurable without waiting.
     var now: () -> Date = Date.init
@@ -101,14 +107,14 @@ final class QuickAddCoordinator {
     self.environment = environment
   }
 
-  /// Supply the create-new presenter after construction.
+  /// Supply the create-new entry point after construction.
   ///
-  /// Needed because the object that presents the sheet is the one that BUILDS this coordinator, so
+  /// Needed because the object that owns the live panel is the one that BUILDS this coordinator, so
   /// it cannot capture itself while doing so. Kept to this one seam rather than making the whole
   /// environment mutable: everything else is known at construction, and a settable environment is an
   /// invitation to change the rules at runtime.
-  func setPresentNewWordSheet(_ present: @escaping (String) -> Void) {
-    environment.presentNewWordSheet = present
+  func setBeginNewWord(_ begin: @escaping () -> Void) {
+    environment.beginNewWord = begin
   }
 
   /// One Quick Add invocation, from either door.
@@ -372,14 +378,20 @@ final class QuickAddCoordinator {
     return nil
   }
 
-  /// The user chose to create a new word. **Opens the sheet and resolves NOTHING.**
+  /// The user chose to create a new word. **Moves the panel to its compose stage and resolves
+  /// NOTHING.**
   ///
-  /// Emitting `createdNew` here counted an intention as an outcome: cancelling the sheet left the
-  /// panel up, and cancelling the panel then emitted a SECOND resolved event for one open. The
+  /// Emitting `createdNew` here counted an intention as an outcome: backing out of composing leaves
+  /// the panel up, and cancelling the panel then emitted a SECOND resolved event for one open. The
   /// funnel is one `opened` and one `resolved`, and a rate computed over a denominator that
   /// double-counts is worse than no rate.
+  ///
+  /// Takes the model it does nothing with, deliberately: every other outcome on this type is
+  /// reported against the panel the user was looking at, and a signature that quietly stopped
+  /// naming one would be the only place a reader has to check which panel is meant.
   func createNew(from model: QuickAddPanelModel) {
-    environment.presentNewWordSheet(model.spellingToWrite)
+    _ = model
+    environment.beginNewWord()
   }
 
   /// The sheet saved, and the word is confirmed present. Called by the caller that checked.

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddCoordinator.swift
@@ -375,7 +375,17 @@ final class QuickAddCoordinator {
     //
     // The flag stays on `Candidate` and the VIEW still reads it: dimming a row and choosing a header
     // are display, and display from the ranking is what the user is looking at. The DECISION is live.
+    // **The CANONICAL counts as already covering the spelling, not just the aliases.** A word whose
+    // canonical IS the selected text is covered by it; appending it again stores the canonical as an
+    // alias of itself and reports `"Codex" added to Codex` — a false sentence over a junk write.
+    // Reachable two ways: the word is renamed in Settings while the panel sits open, or the user
+    // types past the already-covered notice, comes back to the list and selects the same row.
+    //
+    // This is the ranker's question (`QuickAddRanker` seeds `alreadyHasHeardSpelling` from the
+    // canonical before reading aliases) and the compose path's rule (`draftWord` drops a
+    // self-alias). Three sites, one rule — it was two out of three.
     guard
+      word.canonical.caseInsensitiveCompare(model.spellingToWrite) != .orderedSame,
       !word.aliases.contains(where: {
         $0.caseInsensitiveCompare(model.spellingToWrite) == .orderedSame
       })

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
@@ -108,6 +108,23 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
     panel.makeKeyAndOrderFront(nil)
   }
 
+  /// Hand keyboard focus back to whatever the user was working in, WITHOUT taking the panel down.
+  ///
+  /// **The one property that made the confirmation safe to put in the panel at all.** This panel is
+  /// key-capable because Return is the whole feature, so a panel that lingers for a beat after
+  /// Return is a panel that owns the keyboard for that beat — and the user has already gone back to
+  /// their sentence. The first letters of their next word would land in our search field. That cost
+  /// nearly sent the confirmation to the dictation overlay instead, which is non-activating by
+  /// construction.
+  ///
+  /// `NSApp.deactivate()` gives focus to the app behind us. The panel stays visible because
+  /// `hidesOnDeactivate` is false and it sits at `.floating` — both set for their own reasons long
+  /// before this needed them.
+  func releaseFocus() {
+    guard let panel, panel.isVisible else { return }
+    NSApp.deactivate()
+  }
+
   /// Take the panel down. Idempotent.
   ///
   /// `orderOut`, never `close`: closing is what forces a rebuild, and this panel is reused.

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
@@ -120,12 +120,31 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
 
     // Activate BEFORE making key, and only now — the selection was read while the other app was
     // still frontmost, which is the whole reason this happens here rather than at capture time.
+    takeFocus(panel)
+    return true
+  }
+
+  /// Take activation and key status, recording what was taken so `releaseFocus` can give back
+  /// exactly that.
+  ///
+  /// **One owner, because there are TWO takers and the second was missed by three review rounds.**
+  /// `present` and `raise` both activate and both call `makeKeyAndOrderFront`; only the first
+  /// recorded it, so after a raise both records described the PREVIOUS presentation. Reachable:
+  /// open from another app, click into our Settings window, press the shortcut again — the raise
+  /// takes key status from Settings while the records still say the app was activated from outside,
+  /// and the release then deactivates, hiding the user's own window.
+  ///
+  /// A third taker cannot be added without coming through here, which is the point of it existing
+  /// rather than the two lines being repeated.
+  private func takeFocus(_ panel: NSPanel) {
     // Both read BEFORE anything is taken, which is the only moment either answer exists.
     activatedForThisPresentation = !NSApp.isActive
-    previousKeyWindow = NSApp.keyWindow
+    let key = NSApp.keyWindow
+    // Never record OUR OWN panel as the window to hand back to: a raise while the panel is already
+    // key would otherwise make `releaseFocus` restore the panel it is trying to release.
+    previousKeyWindow = key === panel ? previousKeyWindow : key
     NSApp.activate(ignoringOtherApps: true)
     panel.makeKeyAndOrderFront(nil)
-    return true
   }
 
   /// Bring an already-visible panel back to the front and give it key focus.
@@ -136,8 +155,7 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
   /// and not by throwing away the selection it already holds.
   func raise() {
     guard let panel, panel.isVisible else { return }
-    NSApp.activate(ignoringOtherApps: true)
-    panel.makeKeyAndOrderFront(nil)
+    takeFocus(panel)
   }
 
   /// Hand keyboard focus back to whatever the user was working in, WITHOUT taking the panel down.

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
@@ -24,6 +24,19 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
   /// window closing under it. The coordinator treats all three as "the user is done".
   var onDismiss: (() -> Void)?
 
+  /// Asked before Escape takes the panel down. Returning true means the CONTENT consumed the
+  /// keypress and the window must not dismiss.
+  ///
+  /// **The window is where Escape arrives and the window is the one place that cannot decide what
+  /// it means.** `cancelOperation` is overridden on the panel because a focused text field's field
+  /// editor claims Escape first, so a view-level handler never sees it — and the panel now has two
+  /// stages where Escape means two different things. Asking the content, rather than teaching the
+  /// window about stages, keeps every keyboard rule in the model that already owns the rest of them.
+  ///
+  /// Defaults to "not consumed", which is the shipped behaviour: an unset seam dismisses, so a
+  /// caller that forgets to wire this loses a feature rather than trapping the user in a panel.
+  var shouldConsumeCancel: () -> Bool = { false }
+
   private var panel: NSPanel?
 
   #if DEBUG
@@ -46,17 +59,33 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
   @discardableResult
   func present(_ content: some View) -> Bool {
     let panel = ensurePanel()
-    let host = NSHostingView(rootView: AnyView(content))
-    panel.contentView = host
+    // **An `NSHostingController` rather than a bare `NSHostingView`, and the reason is that the
+    // content can now change SHAPE while it is on screen.** The panel used to render one thing —
+    // a search field over a ranked list — and its size was decided once, here, at present time.
+    // It now has stages (pick, compose), and a stage change makes the ideal height jump; a window
+    // sized once shows the new stage floating in the old stage's space.
+    //
+    // `sizingOptions = .preferredContentSize` is the mechanism AppKit provides for exactly this:
+    // the controller republishes its ideal size whenever the SwiftUI content's changes, and the
+    // window follows. Doing it by hand would mean the caller re-measuring after every mutation, on
+    // a later run loop pass, which is a race with SwiftUI's own layout.
+    let controller = NSHostingController(rootView: AnyView(content))
+    controller.sizingOptions = [.preferredContentSize]
+    // Force the view to load and lay out BEFORE measuring. `fittingSize` on an unloaded view is
+    // zero, which this method's own guard would then read as an unmeasurable panel.
+    controller.view.layoutSubtreeIfNeeded()
 
-    guard let size = resolvedSize(of: host) else {
+    guard let size = resolvedSize(of: controller.view) else {
       // **A zero fitting size is an INVISIBLE panel that reports success**, which the overlay work
       // found by fixture rather than by review. Refusing to present is the honest outcome: the
       // caller gets no panel and the user gets nothing, rather than a window that is up, focused,
       // swallowing Return, and blank.
-      panel.contentView = nil
+      //
+      // Refused BEFORE the controller is installed, so a failed present leaves the panel exactly as
+      // it was rather than half-swapped.
       return false
     }
+    panel.contentViewController = controller
     panel.setContentSize(size)
     panel.center()
 
@@ -85,7 +114,7 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
   func dismiss() {
     guard let panel, panel.isVisible else { return }
     panel.orderOut(nil)
-    panel.contentView = nil
+    panel.contentViewController = nil
   }
 
   // MARK: - NSWindowDelegate
@@ -121,8 +150,21 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
   /// false, so the panel survives to be reused; clearing the hosting view is what stops the old
   /// content being handed back on the next present.
   func windowWillClose(_ notification: Notification) {
-    panel?.contentView = nil
+    panel?.contentViewController = nil
     onDismiss?()
+  }
+
+  /// Keep the panel centred when its content changes stage.
+  ///
+  /// An `NSWindow` resizes about its BOTTOM-LEFT corner, so a panel that shrinks appears to slide
+  /// down the screen and one that grows appears to climb. That is fine for a window the user is
+  /// dragging and wrong for one that changes height because the user pressed a button: the panel
+  /// opened centred, and it should still look centred after it changes what it is asking.
+  ///
+  /// `center()` moves the origin and never the size, so this cannot recurse.
+  func windowDidResize(_ notification: Notification) {
+    guard let panel, panel.isVisible else { return }
+    panel.center()
   }
 
   // MARK: - Ownership
@@ -159,6 +201,8 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
     p.delegate = self
     p.onCancelOperation = { [weak self] in
       guard let self, self.isVisible else { return }
+      // The content gets first refusal. See `shouldConsumeCancel`.
+      guard !self.shouldConsumeCancel() else { return }
       self.dismiss()
       self.onDismiss?()
     }

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
@@ -1,4 +1,7 @@
 import AppKit
+import EnviousWisprCore
+import EnviousWisprServices
+import Foundation
 import SwiftUI
 
 /// The Quick Add panel's window, and nothing else (#2381).
@@ -45,6 +48,20 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
   /// because a Settings window the user closed during the beat must not be resurrected or retained.
   private var focusOrigin: FocusOriginKind = .unknown
   private weak var originWindow: NSWindow?
+  /// The process id of the application that was frontmost when we took focus.
+  ///
+  /// **Named, because `NSApp.deactivate()` does not hand activation to anyone.** Measured: four
+  /// seconds after the panel closed we were still active with zero windows, and every keystroke was
+  /// being discarded. Activation is cooperative since macOS 14 — resigning is not transferring, and
+  /// with nothing else asking we simply stay in front.
+  ///
+  /// **A pid rather than the `NSRunningApplication`, and the first version got this wrong in a way
+  /// only the log line caught.** Held `weak`, the object returned by `frontmostApplication` is
+  /// deallocated immediately — nothing else retains it — so the release always took the branch with
+  /// nothing to name and behaved exactly like the defect it was fixing. Held STRONG it would pin a
+  /// process object for the life of the host. A pid is neither: it is resolved at release time, and
+  /// if that app has quit the lookup fails, which is the honest answer rather than a stale one.
+  private var originAppPID: pid_t?
 
 
   #if DEBUG
@@ -138,9 +155,13 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
       if NSApp.isActive, let key = NSApp.keyWindow, key !== panel {
         focusOrigin = .ourWindow
         originWindow = key
+        originAppPID = nil
       } else {
         focusOrigin = .otherApp
         originWindow = nil
+        // Read at the same instant as everything else here, and for the same reason: a moment later
+        // the frontmost application is us.
+        originAppPID = NSWorkspace.shared.frontmostApplication?.processIdentifier
       }
     }
     NSApp.activate(ignoringOtherApps: true)
@@ -151,6 +172,20 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
   ///
   /// Holding it already means nothing is being taken, so the standing record — who we took it from
   /// when we did — is still the right answer.
+  /// Which release BRANCH ran, so a Live UAT can read it instead of inferring it.
+  ///
+  /// **Inferring it from which app ends up in front does not work, and two versions of that harness
+  /// were unfailable before this line existed** — our app can legitimately be frontmost either way,
+  /// so the observed value and the defect value were the same string. This names the branch.
+  ///
+  /// `#if DEBUG` and the same category as the funnel: a release build writes no `app.log` at all.
+  /// It carries no word, no spelling and no selection — only which of three paths was taken.
+  private func logFocus(_ line: String) {
+    #if DEBUG
+      Task { await AppLogger.shared.log("[QuickAdd] \(line)", level: .info, category: "QuickAdd") }
+    #endif
+  }
+
   package static func shouldCaptureOrigin(panelIsKey: Bool) -> Bool { !panelIsKey }
 
   /// Whether taking the panel down should hand focus back.
@@ -236,8 +271,23 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
       // be a guess about an app the user may not have come from, so do neither.
       guard let originWindow, originWindow !== panel, originWindow.isVisible else { return }
       originWindow.makeKeyAndOrderFront(nil)
+      logFocus("focus released to our own window")
     case .deactivateApp:
-      NSApp.deactivate()
+      // **Activate the app BY NAME. `NSApp.deactivate()` alone does not hand activation to anyone**
+      // — measured as four seconds still frontmost with zero windows, keystrokes going nowhere.
+      // This mirrors the branch above, which always named its destination and always worked.
+      if let pid = originAppPID,
+        let originApp = NSRunningApplication(processIdentifier: pid),
+        !originApp.isTerminated
+      {
+        originApp.activate()
+        logFocus("focus released to the origin app")
+      } else {
+        // Nothing to name: an origin taken before a frontmost app could be read, or one that has
+        // quit. Worse than naming a destination, better than keeping a keyboard nobody can use.
+        NSApp.deactivate()
+        logFocus("focus released with no origin app to name")
+      }
     }
   }
 

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
@@ -39,25 +39,6 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
 
   private var panel: NSPanel?
 
-  /// Whether THIS presentation is what brought EnviousWispr forward.
-  ///
-  /// The Quick Add shortcut is global, so it fires while our own Settings window is frontmost too.
-  /// There we were already active, took nothing, and handing activation away would push the user's
-  /// own window behind an unrelated app. Set on every presentation, so a reused panel cannot inherit
-  /// the previous invocation's answer.
-  private var activatedForThisPresentation = false
-
-  /// Whoever held key status when this presentation took it.
-  ///
-  /// **`present` takes TWO things and they are independent, which is the whole reason this exists
-  /// beside the flag above.** Activation is taken only when we were not already active;
-  /// `makeKeyAndOrderFront` takes key status ALWAYS, from whatever held it. Releasing only the first
-  /// left the confirmation key for two seconds inside our own app — the keystroke-eating defect the
-  /// flag was added to prevent, in the one case the flag made silent.
-  ///
-  /// Weak on purpose: a Settings window the user closed during the beat must not be resurrected, and
-  /// must not be kept alive by us.
-  private weak var previousKeyWindow: NSWindow?
 
   #if DEBUG
     /// How many panels this host has built. A second one means the reuse path broke, which is
@@ -136,47 +117,35 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
   ///
   /// A third taker cannot be added without coming through here, which is the point of it existing
   /// rather than the two lines being repeated.
+  /// Bring the panel forward and give it the keyboard.
+  ///
+  /// **Records nothing, deliberately.** An earlier revision remembered who focus was taken FROM so
+  /// it could be handed back, and three review rounds each found another way for the panel to gain
+  /// focus without passing through here — a raise, a mouse click, and whatever comes next. That set
+  /// is AppKit's rather than ours. `releaseFocus` now derives its answer from the live world instead,
+  /// so there is no record that can go stale.
   private func takeFocus(_ panel: NSPanel) {
-    // Both read BEFORE anything is taken, which is the only moment either answer exists.
-    let wasActive = NSApp.isActive
-    let key = NSApp.keyWindow
-    switch Self.focusTake(wasActive: wasActive, keyWindowIsThePanel: key === panel) {
-    case .fromAnotherApp:
-      activatedForThisPresentation = true
-      previousKeyWindow = nil
-    case .fromOurOwnWindow:
-      activatedForThisPresentation = false
-      previousKeyWindow = key
-    case .nothing:
-      // **Records untouched, and this is the case a second press lands on.** Recomputing them here
-      // reads a world THIS PANEL already changed: we are active because we activated ourselves, and
-      // key because we took it. The presentation that actually took still owes the debt.
-      break
-    }
     NSApp.activate(ignoringOtherApps: true)
     panel.makeKeyAndOrderFront(nil)
   }
 
-  /// What a focus-taking call is actually taking, which is not always something.
+  /// Where the keyboard should go when this panel gives it up.
   ///
-  /// **The whole decision, extracted so the case that takes NOTHING is statable.** Making `takeFocus`
-  /// the single owner of taking was right and writing it as if every call takes something was not:
-  /// pressing the shortcut while the panel is already key recomputes `!NSApp.isActive` as false, and
-  /// the debt owed to the app the user actually came from is discarded — so the confirmation leaves
-  /// us active and their next keystrokes go nowhere.
-  package enum FocusTake: Equatable, Sendable, CaseIterable {
-    /// Not active: activation and key status both came from outside.
-    case fromAnotherApp
-    /// Active, and another of OUR windows held key. Activation was never ours to take.
-    case fromOurOwnWindow
-    /// Already active and already key. Nothing is taken and the standing debt is unchanged.
-    case nothing
+  /// Two values, and the question is CLOSED because it is about the world as it is now rather than
+  /// about a history of how the panel came to be key.
+  package enum FocusRelease: Equatable, Sendable, CaseIterable {
+    /// Another window of ours is on screen and can take key: the user is inside our app, and
+    /// deactivating would hide their own window.
+    case handToOurOwnWindow
+    /// The panel is our only window, so the user came from another app and that is where the
+    /// keyboard belongs.
+    case deactivateApp
   }
 
-  package static func focusTake(wasActive: Bool, keyWindowIsThePanel: Bool) -> FocusTake {
-    guard wasActive else { return .fromAnotherApp }
-    return keyWindowIsThePanel ? .nothing : .fromOurOwnWindow
+  package static func focusRelease(hasOtherKeyableWindow: Bool) -> FocusRelease {
+    hasOtherKeyableWindow ? .handToOurOwnWindow : .deactivateApp
   }
+
 
   /// Bring an already-visible panel back to the front and give it key focus.
   ///
@@ -208,15 +177,18 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
   /// window is what gets it back — deactivating there would hide the user's own window instead.
   func releaseFocus() {
     guard let panel, panel.isVisible else { return }
-    let previous = previousKeyWindow
-    previousKeyWindow = nil
-    if activatedForThisPresentation {
-      NSApp.deactivate()
-      return
+    // Asked HERE, of the live window list, rather than remembered at take time. `canBecomeKey`
+    // rather than mere visibility: an accessory window that cannot take the keyboard is not somewhere
+    // to leave it.
+    let other = NSApp.windows.first {
+      $0 !== panel && $0.isVisible && $0.canBecomeKey
     }
-    // Already active: activation was never ours to give. Key status was, and it came from here.
-    guard let previous, previous !== panel, previous.isVisible else { return }
-    previous.makeKeyAndOrderFront(nil)
+    switch Self.focusRelease(hasOtherKeyableWindow: other != nil) {
+    case .handToOurOwnWindow:
+      other?.makeKeyAndOrderFront(nil)
+    case .deactivateApp:
+      NSApp.deactivate()
+    }
   }
 
   /// Take the panel down. Idempotent.

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
@@ -41,12 +41,23 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
 
   /// Whether THIS presentation is what brought EnviousWispr forward.
   ///
-  /// `releaseFocus()` reads it, and without it that method is usually right rather than right: the
-  /// Quick Add shortcut is global, so it fires while our own Settings window is frontmost too. There
-  /// we were already active, took nothing, and handing activation away would push the user's own
-  /// window behind an unrelated app. Set on every presentation, so a reused panel cannot inherit the
-  /// previous invocation's answer.
+  /// The Quick Add shortcut is global, so it fires while our own Settings window is frontmost too.
+  /// There we were already active, took nothing, and handing activation away would push the user's
+  /// own window behind an unrelated app. Set on every presentation, so a reused panel cannot inherit
+  /// the previous invocation's answer.
   private var activatedForThisPresentation = false
+
+  /// Whoever held key status when this presentation took it.
+  ///
+  /// **`present` takes TWO things and they are independent, which is the whole reason this exists
+  /// beside the flag above.** Activation is taken only when we were not already active;
+  /// `makeKeyAndOrderFront` takes key status ALWAYS, from whatever held it. Releasing only the first
+  /// left the confirmation key for two seconds inside our own app — the keystroke-eating defect the
+  /// flag was added to prevent, in the one case the flag made silent.
+  ///
+  /// Weak on purpose: a Settings window the user closed during the beat must not be resurrected, and
+  /// must not be kept alive by us.
+  private weak var previousKeyWindow: NSWindow?
 
   #if DEBUG
     /// How many panels this host has built. A second one means the reuse path broke, which is
@@ -109,8 +120,9 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
 
     // Activate BEFORE making key, and only now — the selection was read while the other app was
     // still frontmost, which is the whole reason this happens here rather than at capture time.
-    // Read BEFORE activating, which is the only moment the answer exists.
+    // Both read BEFORE anything is taken, which is the only moment either answer exists.
     activatedForThisPresentation = !NSApp.isActive
+    previousKeyWindow = NSApp.keyWindow
     NSApp.activate(ignoringOtherApps: true)
     panel.makeKeyAndOrderFront(nil)
     return true
@@ -141,12 +153,21 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
   /// `hidesOnDeactivate` is false and it sits at `.floating` — both set for their own reasons long
   /// before this needed them.
   ///
-  /// **Conditional on having TAKEN activation, which is the half that makes it correct rather than
-  /// usually correct.** See `activatedForThisPresentation`: opened from our own Settings window,
-  /// there is nothing to give back and giving it anyway hides the user's own window.
+  /// **Returns exactly what `present` took, which is TWO things rather than one.** Opened from
+  /// another app it took activation, and giving that back returns key status with it. Opened from
+  /// our own Settings window it took activation from nobody and key status from that window, so the
+  /// window is what gets it back — deactivating there would hide the user's own window instead.
   func releaseFocus() {
-    guard let panel, panel.isVisible, activatedForThisPresentation else { return }
-    NSApp.deactivate()
+    guard let panel, panel.isVisible else { return }
+    let previous = previousKeyWindow
+    previousKeyWindow = nil
+    if activatedForThisPresentation {
+      NSApp.deactivate()
+      return
+    }
+    // Already active: activation was never ours to give. Key status was, and it came from here.
+    guard let previous, previous !== panel, previous.isVisible else { return }
+    previous.makeKeyAndOrderFront(nil)
   }
 
   /// Take the panel down. Idempotent.

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
@@ -1,7 +1,4 @@
 import AppKit
-import EnviousWisprCore
-import EnviousWisprServices
-import Foundation
 import SwiftUI
 
 /// The Quick Add panel's window, and nothing else (#2381).
@@ -42,26 +39,6 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
 
   private var panel: NSPanel?
 
-  /// What held the keyboard before the panel took it, and the window if it was ours.
-  ///
-  /// Written by the two observers below and by nothing else, so there is no route to miss. Weak,
-  /// because a Settings window the user closed during the beat must not be resurrected or retained.
-  private var focusOrigin: FocusOriginKind = .unknown
-  private weak var originWindow: NSWindow?
-  /// The process id of the application that was frontmost when we took focus.
-  ///
-  /// **Named, because `NSApp.deactivate()` does not hand activation to anyone.** Measured: four
-  /// seconds after the panel closed we were still active with zero windows, and every keystroke was
-  /// being discarded. Activation is cooperative since macOS 14 — resigning is not transferring, and
-  /// with nothing else asking we simply stay in front.
-  ///
-  /// **A pid rather than the `NSRunningApplication`, and the first version got this wrong in a way
-  /// only the log line caught.** Held `weak`, the object returned by `frontmostApplication` is
-  /// deallocated immediately — nothing else retains it — so the release always took the branch with
-  /// nothing to name and behaved exactly like the defect it was fixing. Held STRONG it would pin a
-  /// process object for the life of the host. A pid is neither: it is resolved at release time, and
-  /// if that app has quit the lookup fails, which is the honest answer rather than a stale one.
-  private var originAppPID: pid_t?
 
 
   #if DEBUG
@@ -129,41 +106,16 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
     return true
   }
 
-  /// Bring the panel forward and give it the keyboard, recording what held it first.
+  /// Bring the panel forward and give it the keyboard.
+  ///
+  /// **Takes focus and does NOT record where it came from.** Seven review rounds went into giving it
+  /// back, and the founder retired the requirement rather than the bug (2026-08-25): after adding a
+  /// word the user is already reaching for the place they want to type, so putting the caret
+  /// somewhere on their behalf competes with the click they were going to make.
   ///
   /// **One owner for both takers.** `present` and `raise` both activate and both call
-  /// `makeKeyAndOrderFront`, so a third taker cannot be added without coming through here — which
-  /// is the point of this existing rather than the two lines being repeated at each site.
-  ///
-  /// **Capture iff we do not already hold focus, and that predicate is the sixth answer to one
-  /// question.** The five before it each described something unbounded. Hooking the ROUTES misses
-  /// routes, because the set of ways a window becomes key is AppKit's rather than ours. Deriving
-  /// from the current window list answers a different question — a visible window of ours is not
-  /// evidence the user came from it. Naming the one uncontaminated INSTANT is a claim about time,
-  /// and `raise` falsifies it: `windowDidResignKey` is a no-op, so the panel can sit visible and
-  /// unfocused while the user works somewhere else, and a second shortcut press is then a genuinely
-  /// new origin rather than a repeat of the first.
-  ///
-  /// `panel.isKeyWindow` is AppKit's own answer, read at the transition, with two values. If we do
-  /// not hold focus we are about to take it from whoever does, so record them; if we already hold
-  /// it, nothing is being taken and the existing record still describes who we took it from.
-  ///
-  /// The read happens BEFORE the activate below, which is the only line here that moves focus —
-  /// `QuickAddCoordinator.begin` depends on the same ordering to read the selection.
+  /// `makeKeyAndOrderFront`, so a third taker cannot be added without coming through here.
   private func takeFocus(_ panel: NSPanel) {
-    if Self.shouldCaptureOrigin(panelIsKey: panel.isKeyWindow) {
-      if NSApp.isActive, let key = NSApp.keyWindow, key !== panel {
-        focusOrigin = .ourWindow
-        originWindow = key
-        originAppPID = nil
-      } else {
-        focusOrigin = .otherApp
-        originWindow = nil
-        // Read at the same instant as everything else here, and for the same reason: a moment later
-        // the frontmost application is us.
-        originAppPID = NSWorkspace.shared.frontmostApplication?.processIdentifier
-      }
-    }
     NSApp.activate(ignoringOtherApps: true)
     panel.makeKeyAndOrderFront(nil)
   }
@@ -172,64 +124,7 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
   ///
   /// Holding it already means nothing is being taken, so the standing record — who we took it from
   /// when we did — is still the right answer.
-  /// Which release BRANCH ran, so a Live UAT can read it instead of inferring it.
-  ///
-  /// **Inferring it from which app ends up in front does not work, and two versions of that harness
-  /// were unfailable before this line existed** — our app can legitimately be frontmost either way,
-  /// so the observed value and the defect value were the same string. This names the branch.
-  ///
-  /// `#if DEBUG` and the same category as the funnel: a release build writes no `app.log` at all.
-  /// It carries no word, no spelling and no selection — only which of three paths was taken.
-  private func logFocus(_ line: String) {
-    #if DEBUG
-      Task { await AppLogger.shared.log("[QuickAdd] \(line)", level: .info, category: "QuickAdd") }
-    #endif
-  }
 
-  package static func shouldCaptureOrigin(panelIsKey: Bool) -> Bool { !panelIsKey }
-
-  /// Whether taking the panel down should hand focus back.
-  ///
-  /// **Gated rather than unconditional, and the gate is load-bearing.** After a confirmation the
-  /// beat has already released, so the panel is not key when the fade fires; releasing again there
-  /// would re-raise a Settings window the user may have left in the meantime. Not holding focus
-  /// means there is nothing to give back.
-  package static func shouldReleaseOnDismiss(panelIsKey: Bool) -> Bool { panelIsKey }
-
-  /// What held the keyboard immediately before this panel took it.
-  ///
-  /// **Provenance, and six review rounds went into where to capture it.** Recording at the ROUTES
-  /// enumerates AppKit's set rather than ours — a raise, a mouse click, command-tab, the Dock — so
-  /// three rounds each found another one. Deriving instead from "do we have another window on
-  /// screen" is closed and WRONG: leave Settings open behind TextEdit, invoke the shortcut from
-  /// TextEdit, and a window-list answer sends the keyboard to Settings.
-  ///
-  /// The closed capture point is not a list of routes, not a derivation from the current world,
-  /// and not an instant. It is the panel's own key status at the transition — see
-  /// `shouldCaptureOrigin(panelIsKey:)`.
-  package enum FocusOriginKind: Equatable, Sendable, CaseIterable {
-    /// Another application was frontmost.
-    case otherApp
-    /// One of OUR windows held key — Settings, reachable because the shortcut is global.
-    case ourWindow
-    /// Nothing observed yet. Reachable only before either notification has fired.
-    case unknown
-  }
-
-  /// Where the keyboard goes when the panel gives it up.
-  package enum FocusRelease: Equatable, Sendable, CaseIterable {
-    /// Hand key to the window of ours that had it. Deactivating would hide the user's own window.
-    case handToOurOwnWindow
-    /// Give the app behind us the keyboard back.
-    case deactivateApp
-  }
-
-  /// **`unknown` deactivates, and the asymmetry is deliberate.** Guessing "our window" when the user
-  /// came from another app eats the keystrokes this whole mechanism exists to protect; guessing
-  /// "deactivate" when they were in our app costs them a click. The second is the cheaper error.
-  package static func focusRelease(origin: FocusOriginKind) -> FocusRelease {
-    origin == .ourWindow ? .handToOurOwnWindow : .deactivateApp
-  }
 
 
   /// Bring an already-visible panel back to the front and give it key focus.
@@ -246,63 +141,11 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
     takeFocus(panel)
   }
 
-  /// Hand keyboard focus back to whatever the user was working in, WITHOUT taking the panel down.
-  ///
-  /// **The one property that made the confirmation safe to put in the panel at all.** This panel is
-  /// key-capable because Return is the whole feature, so a panel that lingers for a beat after
-  /// Return is a panel that owns the keyboard for that beat — and the user has already gone back to
-  /// their sentence. The first letters of their next word would land in our search field. That cost
-  /// nearly sent the confirmation to the dictation overlay instead, which is non-activating by
-  /// construction.
-  ///
-  /// `NSApp.deactivate()` gives focus to the app behind us. The panel stays visible because
-  /// `hidesOnDeactivate` is false and it sits at `.floating` — both set for their own reasons long
-  /// before this needed them.
-  ///
-  /// **Returns exactly what `present` took, which is TWO things rather than one.** Opened from
-  /// another app it took activation, and giving that back returns key status with it. Opened from
-  /// our own Settings window it took activation from nobody and key status from that window, so the
-  /// window is what gets it back — deactivating there would hide the user's own window instead.
-  func releaseFocus() {
-    guard let panel, panel.isVisible else { return }
-    switch Self.focusRelease(origin: focusOrigin) {
-    case .handToOurOwnWindow:
-      // A window that has since been closed leaves nothing to hand to; deactivating instead would
-      // be a guess about an app the user may not have come from, so do neither.
-      guard let originWindow, originWindow !== panel, originWindow.isVisible else { return }
-      originWindow.makeKeyAndOrderFront(nil)
-      logFocus("focus released to our own window")
-    case .deactivateApp:
-      // **Activate the app BY NAME. `NSApp.deactivate()` alone does not hand activation to anyone**
-      // — measured as four seconds still frontmost with zero windows, keystrokes going nowhere.
-      // This mirrors the branch above, which always named its destination and always worked.
-      if let pid = originAppPID,
-        let originApp = NSRunningApplication(processIdentifier: pid),
-        !originApp.isTerminated
-      {
-        originApp.activate()
-        logFocus("focus released to the origin app")
-      } else {
-        // Nothing to name: an origin taken before a frontmost app could be read, or one that has
-        // quit. Worse than naming a destination, better than keeping a keyboard nobody can use.
-        NSApp.deactivate()
-        logFocus("focus released with no origin app to name")
-      }
-    }
-  }
-
-
   /// Take the panel down. Idempotent.
   ///
   /// `orderOut`, never `close`: closing is what forces a rebuild, and this panel is reused.
   func dismiss() {
     guard let panel, panel.isVisible else { return }
-    // **Every dismissal route passes through here, which is why the release lives here rather than
-    // at the routes.** Escape on a notice the user clicked back into does not reach the wiring's
-    // cancel path at all — that invocation already resolved and `activeModel` is nil — so a release
-    // placed at the visible close control left the app active with no key window and the next
-    // characters going nowhere.
-    if Self.shouldReleaseOnDismiss(panelIsKey: panel.isKeyWindow) { releaseFocus() }
     panel.orderOut(nil)
     panel.contentViewController = nil
   }

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
@@ -108,41 +108,33 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
 
     // Activate BEFORE making key, and only now — the selection was read while the other app was
     // still frontmost, which is the whole reason this happens here rather than at capture time.
-    takeFocus(panel, capturingOrigin: true)
+    takeFocus(panel)
     return true
   }
 
-  /// Take activation and key status, recording what was taken so `releaseFocus` can give back
-  /// exactly that.
-  ///
-  /// **One owner, because there are TWO takers and the second was missed by three review rounds.**
-  /// `present` and `raise` both activate and both call `makeKeyAndOrderFront`; only the first
-  /// recorded it, so after a raise both records described the PREVIOUS presentation. Reachable:
-  /// open from another app, click into our Settings window, press the shortcut again — the raise
-  /// takes key status from Settings while the records still say the app was activated from outside,
-  /// and the release then deactivates, hiding the user's own window.
-  ///
-  /// A third taker cannot be added without coming through here, which is the point of it existing
-  /// rather than the two lines being repeated.
   /// Bring the panel forward and give it the keyboard, recording what held it first.
   ///
-  /// **`capturingOrigin` is true exactly once per invocation, and the reason is that there is only
-  /// one uncontaminated instant.** Five review rounds found five ways to get this wrong, and they
-  /// share a cause: every attempt OBSERVED focus from inside a process whose own activation moves it.
-  /// Hooking the routes misses routes (a raise, a mouse click, the Dock). Deriving from the current
-  /// window list answers a different question — a visible window of ours is not evidence the user
-  /// came from it. Watching AppKit's notifications catches our OWN `NSApp.activate` making Settings
-  /// key on its way to activating us.
+  /// **One owner for both takers.** `present` and `raise` both activate and both call
+  /// `makeKeyAndOrderFront`, so a third taker cannot be added without coming through here — which
+  /// is the point of this existing rather than the two lines being repeated at each site.
   ///
-  /// The instant before this invocation touches anything is not contaminated, because nothing has
-  /// happened yet. `QuickAddCoordinator.begin` already depends on exactly that instant to read the
-  /// selection, for exactly this reason.
+  /// **Capture iff we do not already hold focus, and that predicate is the sixth answer to one
+  /// question.** The five before it each described something unbounded. Hooking the ROUTES misses
+  /// routes, because the set of ways a window becomes key is AppKit's rather than ours. Deriving
+  /// from the current window list answers a different question — a visible window of ours is not
+  /// evidence the user came from it. Naming the one uncontaminated INSTANT is a claim about time,
+  /// and `raise` falsifies it: `windowDidResignKey` is a no-op, so the panel can sit visible and
+  /// unfocused while the user works somewhere else, and a second shortcut press is then a genuinely
+  /// new origin rather than a repeat of the first.
   ///
-  /// `raise` passes false: a second shortcut press is the same invocation, and the user has not gone
-  /// anywhere between the two.
-  private func takeFocus(_ panel: NSPanel, capturingOrigin: Bool) {
-    if capturingOrigin {
-      // Read BEFORE the activate below, which is the only line in this method that moves focus.
+  /// `panel.isKeyWindow` is AppKit's own answer, read at the transition, with two values. If we do
+  /// not hold focus we are about to take it from whoever does, so record them; if we already hold
+  /// it, nothing is being taken and the existing record still describes who we took it from.
+  ///
+  /// The read happens BEFORE the activate below, which is the only line here that moves focus —
+  /// `QuickAddCoordinator.begin` depends on the same ordering to read the selection.
+  private func takeFocus(_ panel: NSPanel) {
+    if Self.shouldCaptureOrigin(panelIsKey: panel.isKeyWindow) {
       if NSApp.isActive, let key = NSApp.keyWindow, key !== panel {
         focusOrigin = .ourWindow
         originWindow = key
@@ -155,17 +147,31 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
     panel.makeKeyAndOrderFront(nil)
   }
 
+  /// Whether taking focus should record who held it first.
+  ///
+  /// Holding it already means nothing is being taken, so the standing record — who we took it from
+  /// when we did — is still the right answer.
+  package static func shouldCaptureOrigin(panelIsKey: Bool) -> Bool { !panelIsKey }
+
+  /// Whether taking the panel down should hand focus back.
+  ///
+  /// **Gated rather than unconditional, and the gate is load-bearing.** After a confirmation the
+  /// beat has already released, so the panel is not key when the fade fires; releasing again there
+  /// would re-raise a Settings window the user may have left in the meantime. Not holding focus
+  /// means there is nothing to give back.
+  package static func shouldReleaseOnDismiss(panelIsKey: Bool) -> Bool { panelIsKey }
+
   /// What held the keyboard immediately before this panel took it.
   ///
-  /// **Provenance, and the third attempt at where to capture it.** Recording it in `present` and
-  /// `raise` enumerates ROUTES, and routes are AppKit's set — a raise, a mouse click, command-tab,
-  /// the Dock — so three review rounds each found another one. Deriving it instead from "do we have
-  /// another window on screen" is closed and WRONG: leave Settings open behind TextEdit, invoke the
-  /// shortcut from TextEdit, and a window-list answer sends the keyboard to Settings.
+  /// **Provenance, and six review rounds went into where to capture it.** Recording at the ROUTES
+  /// enumerates AppKit's set rather than ours — a raise, a mouse click, command-tab, the Dock — so
+  /// three rounds each found another one. Deriving instead from "do we have another window on
+  /// screen" is closed and WRONG: leave Settings open behind TextEdit, invoke the shortcut from
+  /// TextEdit, and a window-list answer sends the keyboard to Settings.
   ///
-  /// The closed capture point is not a list of routes and not a derivation from the current world.
-  /// It is the one INSTANT at which this process has provably not touched focus yet — see
-  /// `takeFocus(_:capturingOrigin:)`.
+  /// The closed capture point is not a list of routes, not a derivation from the current world,
+  /// and not an instant. It is the panel's own key status at the transition — see
+  /// `shouldCaptureOrigin(panelIsKey:)`.
   package enum FocusOriginKind: Equatable, Sendable, CaseIterable {
     /// Another application was frontmost.
     case otherApp
@@ -199,8 +205,10 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
   /// and not by throwing away the selection it already holds.
   func raise() {
     guard let panel, panel.isVisible else { return }
-    // NOT recapturing: a second press is the same invocation and the user has not moved.
-    takeFocus(panel, capturingOrigin: false)
+    // Recaptures iff the panel is not key. A press while it IS key is the same invocation and
+    // changes nothing; a press while it is visible-but-unfocused means the user moved, and the
+    // origin has to move with them.
+    takeFocus(panel)
   }
 
   /// Hand keyboard focus back to whatever the user was working in, WITHOUT taking the panel down.
@@ -239,6 +247,12 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
   /// `orderOut`, never `close`: closing is what forces a rebuild, and this panel is reused.
   func dismiss() {
     guard let panel, panel.isVisible else { return }
+    // **Every dismissal route passes through here, which is why the release lives here rather than
+    // at the routes.** Escape on a notice the user clicked back into does not reach the wiring's
+    // cancel path at all — that invocation already resolved and `activeModel` is nil — so a release
+    // placed at the visible close control left the app active with no key window and the next
+    // characters going nowhere.
+    if Self.shouldReleaseOnDismiss(panelIsKey: panel.isKeyWindow) { releaseFocus() }
     panel.orderOut(nil)
     panel.contentViewController = nil
   }

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
@@ -138,13 +138,44 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
   /// rather than the two lines being repeated.
   private func takeFocus(_ panel: NSPanel) {
     // Both read BEFORE anything is taken, which is the only moment either answer exists.
-    activatedForThisPresentation = !NSApp.isActive
+    let wasActive = NSApp.isActive
     let key = NSApp.keyWindow
-    // Never record OUR OWN panel as the window to hand back to: a raise while the panel is already
-    // key would otherwise make `releaseFocus` restore the panel it is trying to release.
-    previousKeyWindow = key === panel ? previousKeyWindow : key
+    switch Self.focusTake(wasActive: wasActive, keyWindowIsThePanel: key === panel) {
+    case .fromAnotherApp:
+      activatedForThisPresentation = true
+      previousKeyWindow = nil
+    case .fromOurOwnWindow:
+      activatedForThisPresentation = false
+      previousKeyWindow = key
+    case .nothing:
+      // **Records untouched, and this is the case a second press lands on.** Recomputing them here
+      // reads a world THIS PANEL already changed: we are active because we activated ourselves, and
+      // key because we took it. The presentation that actually took still owes the debt.
+      break
+    }
     NSApp.activate(ignoringOtherApps: true)
     panel.makeKeyAndOrderFront(nil)
+  }
+
+  /// What a focus-taking call is actually taking, which is not always something.
+  ///
+  /// **The whole decision, extracted so the case that takes NOTHING is statable.** Making `takeFocus`
+  /// the single owner of taking was right and writing it as if every call takes something was not:
+  /// pressing the shortcut while the panel is already key recomputes `!NSApp.isActive` as false, and
+  /// the debt owed to the app the user actually came from is discarded — so the confirmation leaves
+  /// us active and their next keystrokes go nowhere.
+  package enum FocusTake: Equatable, Sendable, CaseIterable {
+    /// Not active: activation and key status both came from outside.
+    case fromAnotherApp
+    /// Active, and another of OUR windows held key. Activation was never ours to take.
+    case fromOurOwnWindow
+    /// Already active and already key. Nothing is taken and the standing debt is unchanged.
+    case nothing
+  }
+
+  package static func focusTake(wasActive: Bool, keyWindowIsThePanel: Bool) -> FocusTake {
+    guard wasActive else { return .fromAnotherApp }
+    return keyWindowIsThePanel ? .nothing : .fromOurOwnWindow
   }
 
   /// Bring an already-visible panel back to the front and give it key focus.

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
@@ -39,6 +39,15 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
 
   private var panel: NSPanel?
 
+  /// Whether THIS presentation is what brought EnviousWispr forward.
+  ///
+  /// `releaseFocus()` reads it, and without it that method is usually right rather than right: the
+  /// Quick Add shortcut is global, so it fires while our own Settings window is frontmost too. There
+  /// we were already active, took nothing, and handing activation away would push the user's own
+  /// window behind an unrelated app. Set on every presentation, so a reused panel cannot inherit the
+  /// previous invocation's answer.
+  private var activatedForThisPresentation = false
+
   #if DEBUG
     /// How many panels this host has built. A second one means the reuse path broke, which is
     /// invisible on screen: two identical panels stack and the user sees one.
@@ -81,8 +90,17 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
       // caller gets no panel and the user gets nothing, rather than a window that is up, focused,
       // swallowing Return, and blank.
       //
-      // Refused BEFORE the controller is installed, so a failed present leaves the panel exactly as
-      // it was rather than half-swapped.
+      // Refused BEFORE the controller is installed, so nothing is ever half-swapped — and then the
+      // panel is TAKEN DOWN, because "leave it exactly as it was" is the wrong answer once the panel
+      // can be reused across invocations.
+      //
+      // **What it would have been left showing is a CONFIRMATION from an invocation that already
+      // resolved.** A fresh capture arriving inside the fade cancels that fade deliberately
+      // (`QuickAddWiring.mayBeginCapture`), so nothing else is coming to clear it: the old
+      // `"clawwed" added to Claude` would sit on screen indefinitely while the caller emits
+      // `failedToOpen`, describing an invocation the user has moved past. A stale sentence is worse
+      // than no window, which is the same reason this method refuses an unmeasurable panel at all.
+      dismiss()
       return false
     }
     panel.contentViewController = controller
@@ -91,6 +109,8 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
 
     // Activate BEFORE making key, and only now — the selection was read while the other app was
     // still frontmost, which is the whole reason this happens here rather than at capture time.
+    // Read BEFORE activating, which is the only moment the answer exists.
+    activatedForThisPresentation = !NSApp.isActive
     NSApp.activate(ignoringOtherApps: true)
     panel.makeKeyAndOrderFront(nil)
     return true
@@ -120,8 +140,12 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
   /// `NSApp.deactivate()` gives focus to the app behind us. The panel stays visible because
   /// `hidesOnDeactivate` is false and it sits at `.floating` — both set for their own reasons long
   /// before this needed them.
+  ///
+  /// **Conditional on having TAKEN activation, which is the half that makes it correct rather than
+  /// usually correct.** See `activatedForThisPresentation`: opened from our own Settings window,
+  /// there is nothing to give back and giving it anyway hides the user's own window.
   func releaseFocus() {
-    guard let panel, panel.isVisible else { return }
+    guard let panel, panel.isVisible, activatedForThisPresentation else { return }
     NSApp.deactivate()
   }
 

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
@@ -45,7 +45,6 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
   /// because a Settings window the user closed during the beat must not be resurrected or retained.
   private var focusOrigin: FocusOriginKind = .unknown
   private weak var originWindow: NSWindow?
-  private var focusObservers: [NSObjectProtocol] = []
 
 
   #if DEBUG
@@ -109,7 +108,7 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
 
     // Activate BEFORE making key, and only now — the selection was read while the other app was
     // still frontmost, which is the whole reason this happens here rather than at capture time.
-    takeFocus(panel)
+    takeFocus(panel, capturingOrigin: true)
     return true
   }
 
@@ -125,14 +124,33 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
   ///
   /// A third taker cannot be added without coming through here, which is the point of it existing
   /// rather than the two lines being repeated.
-  /// Bring the panel forward and give it the keyboard.
+  /// Bring the panel forward and give it the keyboard, recording what held it first.
   ///
-  /// **Records nothing, deliberately.** An earlier revision remembered who focus was taken FROM so
-  /// it could be handed back, and three review rounds each found another way for the panel to gain
-  /// focus without passing through here — a raise, a mouse click, and whatever comes next. That set
-  /// is AppKit's rather than ours. `releaseFocus` now derives its answer from the live world instead,
-  /// so there is no record that can go stale.
-  private func takeFocus(_ panel: NSPanel) {
+  /// **`capturingOrigin` is true exactly once per invocation, and the reason is that there is only
+  /// one uncontaminated instant.** Five review rounds found five ways to get this wrong, and they
+  /// share a cause: every attempt OBSERVED focus from inside a process whose own activation moves it.
+  /// Hooking the routes misses routes (a raise, a mouse click, the Dock). Deriving from the current
+  /// window list answers a different question — a visible window of ours is not evidence the user
+  /// came from it. Watching AppKit's notifications catches our OWN `NSApp.activate` making Settings
+  /// key on its way to activating us.
+  ///
+  /// The instant before this invocation touches anything is not contaminated, because nothing has
+  /// happened yet. `QuickAddCoordinator.begin` already depends on exactly that instant to read the
+  /// selection, for exactly this reason.
+  ///
+  /// `raise` passes false: a second shortcut press is the same invocation, and the user has not gone
+  /// anywhere between the two.
+  private func takeFocus(_ panel: NSPanel, capturingOrigin: Bool) {
+    if capturingOrigin {
+      // Read BEFORE the activate below, which is the only line in this method that moves focus.
+      if NSApp.isActive, let key = NSApp.keyWindow, key !== panel {
+        focusOrigin = .ourWindow
+        originWindow = key
+      } else {
+        focusOrigin = .otherApp
+        originWindow = nil
+      }
+    }
     NSApp.activate(ignoringOtherApps: true)
     panel.makeKeyAndOrderFront(nil)
   }
@@ -145,8 +163,9 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
   /// another window on screen" is closed and WRONG: leave Settings open behind TextEdit, invoke the
   /// shortcut from TextEdit, and a window-list answer sends the keyboard to Settings.
   ///
-  /// The closed capture point is not a list of routes at all. It is the two notifications AppKit
-  /// posts however focus moved, below.
+  /// The closed capture point is not a list of routes and not a derivation from the current world.
+  /// It is the one INSTANT at which this process has provably not touched focus yet — see
+  /// `takeFocus(_:capturingOrigin:)`.
   package enum FocusOriginKind: Equatable, Sendable, CaseIterable {
     /// Another application was frontmost.
     case otherApp
@@ -180,7 +199,8 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
   /// and not by throwing away the selection it already holds.
   func raise() {
     guard let panel, panel.isVisible else { return }
-    takeFocus(panel)
+    // NOT recapturing: a second press is the same invocation and the user has not moved.
+    takeFocus(panel, capturingOrigin: false)
   }
 
   /// Hand keyboard focus back to whatever the user was working in, WITHOUT taking the panel down.
@@ -213,41 +233,6 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
     }
   }
 
-  /// Watch what holds the keyboard, so `releaseFocus` never has to know HOW the panel got it.
-  ///
-  /// **Two notifications, and between them they cover every route** — including the ones three
-  /// review rounds found one at a time. Last writer wins, which orders them without timestamps.
-  ///
-  /// The panel becoming key is deliberately IGNORED rather than recorded: a mouse click on the panel
-  /// activates us, and treating that as "the user is now in our app" is what would send their
-  /// keyboard to the wrong place afterwards. Clicking an accessory panel is not moving into an app.
-  private func installFocusObservers() {
-    guard focusObservers.isEmpty else { return }
-    focusObservers.append(
-      NSWorkspace.shared.notificationCenter.addObserver(
-        forName: NSWorkspace.didActivateApplicationNotification, object: nil, queue: .main
-      ) { [weak self] note in
-        // Extracted BEFORE entering the isolated block: reading `note` inside trips Swift 6's
-        // sending-risks-data-races on a task-isolated capture.
-        let app = note.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication
-        MainActor.assumeIsolated {
-          guard let self, let app, app != NSRunningApplication.current else { return }
-          self.focusOrigin = .otherApp
-          self.originWindow = nil
-        }
-      })
-    focusObservers.append(
-      NotificationCenter.default.addObserver(
-        forName: NSWindow.didBecomeKeyNotification, object: nil, queue: .main
-      ) { [weak self] note in
-        let window = note.object as? NSWindow
-        MainActor.assumeIsolated {
-          guard let self, let window, window !== self.panel else { return }
-          self.focusOrigin = .ourWindow
-          self.originWindow = window
-        }
-      })
-  }
 
   /// Take the panel down. Idempotent.
   ///
@@ -348,7 +333,6 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
       self.onDismiss?()
     }
     panel = p
-    installFocusObservers()
     return p
   }
 

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
@@ -39,6 +39,14 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
 
   private var panel: NSPanel?
 
+  /// What held the keyboard before the panel took it, and the window if it was ours.
+  ///
+  /// Written by the two observers below and by nothing else, so there is no route to miss. Weak,
+  /// because a Settings window the user closed during the beat must not be resurrected or retained.
+  private var focusOrigin: FocusOriginKind = .unknown
+  private weak var originWindow: NSWindow?
+  private var focusObservers: [NSObjectProtocol] = []
+
 
   #if DEBUG
     /// How many panels this host has built. A second one means the reuse path broke, which is
@@ -129,21 +137,38 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
     panel.makeKeyAndOrderFront(nil)
   }
 
-  /// Where the keyboard should go when this panel gives it up.
+  /// What held the keyboard immediately before this panel took it.
   ///
-  /// Two values, and the question is CLOSED because it is about the world as it is now rather than
-  /// about a history of how the panel came to be key.
+  /// **Provenance, and the third attempt at where to capture it.** Recording it in `present` and
+  /// `raise` enumerates ROUTES, and routes are AppKit's set — a raise, a mouse click, command-tab,
+  /// the Dock — so three review rounds each found another one. Deriving it instead from "do we have
+  /// another window on screen" is closed and WRONG: leave Settings open behind TextEdit, invoke the
+  /// shortcut from TextEdit, and a window-list answer sends the keyboard to Settings.
+  ///
+  /// The closed capture point is not a list of routes at all. It is the two notifications AppKit
+  /// posts however focus moved, below.
+  package enum FocusOriginKind: Equatable, Sendable, CaseIterable {
+    /// Another application was frontmost.
+    case otherApp
+    /// One of OUR windows held key — Settings, reachable because the shortcut is global.
+    case ourWindow
+    /// Nothing observed yet. Reachable only before either notification has fired.
+    case unknown
+  }
+
+  /// Where the keyboard goes when the panel gives it up.
   package enum FocusRelease: Equatable, Sendable, CaseIterable {
-    /// Another window of ours is on screen and can take key: the user is inside our app, and
-    /// deactivating would hide their own window.
+    /// Hand key to the window of ours that had it. Deactivating would hide the user's own window.
     case handToOurOwnWindow
-    /// The panel is our only window, so the user came from another app and that is where the
-    /// keyboard belongs.
+    /// Give the app behind us the keyboard back.
     case deactivateApp
   }
 
-  package static func focusRelease(hasOtherKeyableWindow: Bool) -> FocusRelease {
-    hasOtherKeyableWindow ? .handToOurOwnWindow : .deactivateApp
+  /// **`unknown` deactivates, and the asymmetry is deliberate.** Guessing "our window" when the user
+  /// came from another app eats the keystrokes this whole mechanism exists to protect; guessing
+  /// "deactivate" when they were in our app costs them a click. The second is the cheaper error.
+  package static func focusRelease(origin: FocusOriginKind) -> FocusRelease {
+    origin == .ourWindow ? .handToOurOwnWindow : .deactivateApp
   }
 
 
@@ -177,18 +202,51 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
   /// window is what gets it back — deactivating there would hide the user's own window instead.
   func releaseFocus() {
     guard let panel, panel.isVisible else { return }
-    // Asked HERE, of the live window list, rather than remembered at take time. `canBecomeKey`
-    // rather than mere visibility: an accessory window that cannot take the keyboard is not somewhere
-    // to leave it.
-    let other = NSApp.windows.first {
-      $0 !== panel && $0.isVisible && $0.canBecomeKey
-    }
-    switch Self.focusRelease(hasOtherKeyableWindow: other != nil) {
+    switch Self.focusRelease(origin: focusOrigin) {
     case .handToOurOwnWindow:
-      other?.makeKeyAndOrderFront(nil)
+      // A window that has since been closed leaves nothing to hand to; deactivating instead would
+      // be a guess about an app the user may not have come from, so do neither.
+      guard let originWindow, originWindow !== panel, originWindow.isVisible else { return }
+      originWindow.makeKeyAndOrderFront(nil)
     case .deactivateApp:
       NSApp.deactivate()
     }
+  }
+
+  /// Watch what holds the keyboard, so `releaseFocus` never has to know HOW the panel got it.
+  ///
+  /// **Two notifications, and between them they cover every route** — including the ones three
+  /// review rounds found one at a time. Last writer wins, which orders them without timestamps.
+  ///
+  /// The panel becoming key is deliberately IGNORED rather than recorded: a mouse click on the panel
+  /// activates us, and treating that as "the user is now in our app" is what would send their
+  /// keyboard to the wrong place afterwards. Clicking an accessory panel is not moving into an app.
+  private func installFocusObservers() {
+    guard focusObservers.isEmpty else { return }
+    focusObservers.append(
+      NSWorkspace.shared.notificationCenter.addObserver(
+        forName: NSWorkspace.didActivateApplicationNotification, object: nil, queue: .main
+      ) { [weak self] note in
+        // Extracted BEFORE entering the isolated block: reading `note` inside trips Swift 6's
+        // sending-risks-data-races on a task-isolated capture.
+        let app = note.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication
+        MainActor.assumeIsolated {
+          guard let self, let app, app != NSRunningApplication.current else { return }
+          self.focusOrigin = .otherApp
+          self.originWindow = nil
+        }
+      })
+    focusObservers.append(
+      NotificationCenter.default.addObserver(
+        forName: NSWindow.didBecomeKeyNotification, object: nil, queue: .main
+      ) { [weak self] note in
+        let window = note.object as? NSWindow
+        MainActor.assumeIsolated {
+          guard let self, let window, window !== self.panel else { return }
+          self.focusOrigin = .ourWindow
+          self.originWindow = window
+        }
+      })
   }
 
   /// Take the panel down. Idempotent.
@@ -290,6 +348,7 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
       self.onDismiss?()
     }
     panel = p
+    installFocusObservers()
     return p
   }
 

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
@@ -258,6 +258,15 @@ final class QuickAddWiring {
       guard !Task.isCancelled, let self else { return }
       guard self.activeModel === model, model.isShowingSearchableNotice else { return }
       self.coordinator.didFindAlreadySaved(usedSearch: false)
+      // **The keyboard goes back here too, and forgetting it is worse on THIS path than on the
+      // confirmation's.** `present` takes activation with `NSApp.activate(ignoringOtherApps:)`, so
+      // ordering the panel out leaves our app active with no key window and the user's next
+      // keystrokes land nowhere. The confirmation releases at the START of its beat because the user
+      // has already pressed Return and gone back to their sentence; here the user has pressed
+      // nothing — the panel is still theirs to type into, which is the whole point of a SEARCHABLE
+      // notice — so it releases at dismissal instead. Same obligation, opposite moment, and the
+      // asymmetry is why it did not travel with the code that already had it.
+      self.panelHost.releaseFocus()
       self.dismiss()
     }
   }

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
@@ -143,6 +143,35 @@ final class QuickAddWiring {
     return true
   }
 
+  /// What a VoiceOver user must HEAR when the panel changes what it is telling them, or nil when
+  /// the panel is asking rather than telling.
+  ///
+  /// **One derivation, so the two channels cannot disagree.** It returns the string the view
+  /// renders — not a paraphrase — because a spoken confirmation that differs from the visible one is
+  /// two answers to "what happened", and the blind user has no way to notice.
+  ///
+  /// A write failure outranks a notice. They are mutually exclusive today (`showNotice` clears the
+  /// failure), and stating the order closes the case rather than leaving it to that invariant.
+  package static func announcement(
+    notice: QuickAddPanelModel.Notice?, writeFailure: String?
+  ) -> String? {
+    if let writeFailure { return QuickAddPanelCopy.writeFailure(writeFailure) }
+    if let notice { return QuickAddPanelCopy.notice(notice) }
+    return nil
+  }
+
+  /// Speak the panel's current message, if it has one.
+  ///
+  /// **`.accessibilityLabel` is not this.** A label names an element when it is VISITED; every
+  /// message this panel shows is a dynamic status change, and two of the three vanish on a timer
+  /// while focus is somewhere else entirely — the terminal confirmation deliberately releases focus,
+  /// and the searchable notice gives it to the search field rather than to the sentence.
+  private func speak(_ model: QuickAddPanelModel) {
+    guard let text = Self.announcement(notice: model.notice, writeFailure: model.writeFailure)
+    else { return }
+    OverlayDirector.postAnnouncement(.medium(text))
+  }
+
   /// Whether a fresh capture may start.
   ///
   /// **A confirmation fading out is NOT a live panel, and treating it as one costs the user their
@@ -189,7 +218,10 @@ final class QuickAddWiring {
     coordinator.didOpen()
     // Opened onto a word that already knows this spelling: the panel says so and fades, unless the
     // user types (#2391 §3).
-    if model.isShowingSearchableNotice { scheduleSearchableNoticeFade(for: model) }
+    if model.isShowingSearchableNotice {
+      speak(model)
+      scheduleSearchableNoticeFade(for: model)
+    }
   }
 
   // MARK: - Outcomes
@@ -209,6 +241,7 @@ final class QuickAddWiring {
     switch coordinator.accept(candidate, from: model) {
     case .refused(let message):
       model.noteWriteFailure(message)
+      speak(model)
     case .saved(let word):
       conclude(model, .saved, spelling: model.spellingToWrite, word: word)
     case .alreadyHad(let word):
@@ -233,6 +266,9 @@ final class QuickAddWiring {
   ) {
     activeModel = nil
     model.showNotice(kind, spelling: spelling, word: word)
+    // Spoken BEFORE focus is released, because releasing it is what makes the sentence unreachable
+    // by exploration — after this line there is no element for VoiceOver to visit.
+    speak(model)
     panelHost.releaseFocus()
     noticeDismissal?.cancel()
     noticeDismissal = Task { [weak self] in
@@ -288,6 +324,7 @@ final class QuickAddWiring {
     switch saveNewWord(word, usedSearch: model.isSearching) {
     case .refused(let message):
       model.noteWriteFailure(message)
+      speak(model)
     case .created(let canonical):
       let spelling = model.spellingToWrite.trimmingCharacters(in: .whitespacesAndNewlines)
       // With no readable selection there is no mishearing to name, and a confirmation quoting an

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
@@ -266,10 +266,7 @@ final class QuickAddWiring {
   ) {
     activeModel = nil
     model.showNotice(kind, spelling: spelling, word: word)
-    // Spoken BEFORE focus is released, because releasing it is what makes the sentence unreachable
-    // by exploration — after this line there is no element for VoiceOver to visit.
     speak(model)
-    panelHost.releaseFocus()
     noticeDismissal?.cancel()
     noticeDismissal = Task { [weak self] in
       try? await Task.sleep(for: .seconds(Self.noticeSeconds))
@@ -294,15 +291,6 @@ final class QuickAddWiring {
       guard !Task.isCancelled, let self else { return }
       guard self.activeModel === model, model.isShowingSearchableNotice else { return }
       self.coordinator.didFindAlreadySaved(usedSearch: false)
-      // **The keyboard goes back here too, and forgetting it is worse on THIS path than on the
-      // confirmation's.** `present` takes activation with `NSApp.activate(ignoringOtherApps:)`, so
-      // ordering the panel out leaves our app active with no key window and the user's next
-      // keystrokes land nowhere. The confirmation releases at the START of its beat because the user
-      // has already pressed Return and gone back to their sentence; here the user has pressed
-      // nothing — the panel is still theirs to type into, which is the whole point of a SEARCHABLE
-      // notice — so it releases at dismissal instead. Same obligation, opposite moment, and the
-      // asymmetry is why it did not travel with the code that already had it.
-      self.panelHost.releaseFocus()
       self.dismiss()
     }
   }
@@ -357,9 +345,6 @@ final class QuickAddWiring {
   /// a later invocation reusing the panel must not have its outcome cancelled by a stale closure.
   private func cancel(model: QuickAddPanelModel) {
     if activeModel === model { coordinator.cancel(from: model) }
-    // No explicit release. Clicking the close control during a confirmation makes the panel key
-    // again, and `panelHost.dismiss` now hands that back on every route rather than on this one —
-    // which is what fixed the Escape twin this line could not reach.
     dismiss()
   }
 

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
@@ -357,10 +357,9 @@ final class QuickAddWiring {
   /// a later invocation reusing the panel must not have its outcome cancelled by a stale closure.
   private func cancel(model: QuickAddPanelModel) {
     if activeModel === model { coordinator.cancel(from: model) }
-    // **Clicking the close control during a confirmation makes the panel key AGAIN**, so dismissing
-    // without releasing leaves us active with no useful key window and the next characters lost.
-    // The beat already released once; this is the second taking, by the user's own click.
-    panelHost.releaseFocus()
+    // No explicit release. Clicking the close control during a confirmation makes the panel key
+    // again, and `panelHost.dismiss` now hands that back on every route rather than on this one —
+    // which is what fixed the Escape twin this line could not reach.
     dismiss()
   }
 

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
@@ -295,8 +295,12 @@ final class QuickAddWiring {
       conclude(
         model, spelling.isEmpty ? .created : .saved, spelling: spelling, word: canonical)
     case .alreadyComplete(let canonical):
-      conclude(
-        model, .nothingToAdd, spelling: model.spellingToWrite, word: canonical)
+      conclude(model, .nothingToAdd, spelling: model.spellingToWrite, word: canonical)
+    case .alreadyPresent(let canonical):
+      // Split by OUTCOME rather than by re-testing the spelling here, which is the same rule the
+      // confirmation follows: the sentence is composed from what the write path REPORTS. There is no
+      // mishearing to name in this cell by construction, so `X already knows ""` cannot arise.
+      conclude(model, .alreadyInWords, spelling: "", word: canonical)
     }
   }
 
@@ -345,6 +349,8 @@ final class QuickAddWiring {
     case created(canonical: String)
     /// The canonical was already there and already carried every spelling the user kept.
     case alreadyComplete(canonical: String)
+    /// The canonical was already there and there was no spelling to attach.
+    case alreadyPresent(canonical: String)
     /// Nothing was written and the user did not get what they asked for.
     case refused(String)
   }
@@ -402,6 +408,9 @@ final class QuickAddWiring {
       // exactly this, on the accept route, for exactly this reason.
       coordinator.didFindAlreadySaved(usedSearch: usedSearch)
       return .alreadyComplete(canonical: stored.canonical)
+    case .alreadyPresent:
+      coordinator.didFindAlreadySaved(usedSearch: usedSearch)
+      return .alreadyPresent(canonical: stored.canonical)
     case .refused:
       return .refused(QuickAddPanelCopy.newWordAlreadyExists(canonical: stored.canonical))
     }
@@ -440,6 +449,21 @@ final class QuickAddWiring {
     case alreadyComplete
     /// Nothing was written and the user did not get what they asked for. Say so, keep the panel up.
     case refused
+    /// The canonical was already there and there was no spelling to attach, so nothing was written
+    /// and nothing needed to be — and unlike `refused`, there is nothing the user can DO about it.
+    ///
+    /// **Its own case rather than either neighbour, and both alternatives were tried.** It was
+    /// `refused`, which is honest about the write and wrong about the panel: only the invocation
+    /// that opened WITHOUT a readable selection can reach this cell, and that panel's ranking is
+    /// empty and its search field disabled, so the refusal's copy sent the user to a list that
+    /// cannot exist. Folding it into `alreadyComplete` fixes that and retires a distinction a review
+    /// round established — that cell has no spelling to confirm, so `alreadyComplete`'s
+    /// postcondition is vacuous there, which is the whole reason it was split out.
+    ///
+    /// Reports as `alreadySaved` like `alreadyComplete` does: nothing was created either way, so the
+    /// funnel does not care, and inventing a fifth outcome for it would put a distinction in the
+    /// telemetry that nobody asked a question about.
+    case alreadyPresent
   }
 
   package static func newWordOutcome(
@@ -451,10 +475,12 @@ final class QuickAddWiring {
     // Through this route `add` no-ops on a duplicate canonical, so a canonical that was NOT there
     // before is the only evidence a creation happened.
     guard canonicalExistedBefore else { return .created }
-    // It was already there. With a spelling to confirm, and nothing missing, the end state the user
-    // asked for holds — nothing to do. With NO spelling, nothing was created and nothing was added,
-    // so there is nothing to report as done.
-    return keptSpellings.isEmpty ? .refused : .alreadyComplete
+    // It was already there, and nothing the user kept is missing, so the end state they asked for
+    // holds either way. The two differ in whether there was a spelling to confirm, and that is the
+    // distinction round three drew — kept, because `alreadyComplete`'s postcondition is vacuous
+    // without one. What changed is only its NAME for the no-spelling half: `refused` was honest
+    // about the write and wrong about the panel. See the case docs above.
+    return keptSpellings.isEmpty ? .alreadyPresent : .alreadyComplete
   }
 
   /// Write a word and PROVE the spelling is on it afterwards.

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
@@ -30,9 +30,6 @@ final class QuickAddWiring {
   /// user was actually looking at, and a second invocation must reuse rather than stack.
   private var activeModel: QuickAddPanelModel?
 
-  /// A new word the user asked to create, which drives the edit sheet's presentation.
-  private var pendingNewWord: CustomWord?
-
   init(
     hotkeyService: HotkeyService,
     customWords: CustomWordsCoordinator,
@@ -50,17 +47,19 @@ final class QuickAddWiring {
         saveWord: { word, spelling in
           Self.saveAndConfirm(word, carrying: spelling, through: customWords)
         },
-        presentNewWordSheet: { _ in },
+        beginNewWord: {},
         emit: QuickAddTelemetryBridge.handler))
 
     // Assigned AFTER init rather than captured during it. `self` does not exist while the
     // coordinator is being built, and Swift says so; a placeholder that stayed would be a
     // Create-a-new-word button that renders, records its outcome, and opens nothing.
     //
-    // Canonical EMPTY and focused: the user knows the misspelling, because they selected it. What
-    // they have to supply is the correct form.
-    coordinator.setPresentNewWordSheet { [weak self] spelling in
-      self?.pendingNewWord = CustomWord(canonical: "", aliases: [spelling])
+    // **Which is what shipped, for a different reason, and is what #2391 fixes.** The placeholder
+    // was replaced correctly and the mechanism it was replaced with could not work: a SwiftUI
+    // `.sheet` over a panel that refuses main status presents nothing, silently. The button ran its
+    // action, set its binding, and changed no pixel.
+    coordinator.setBeginNewWord { [weak self] in
+      self?.activeModel?.beginComposing()
     }
   }
 
@@ -73,6 +72,9 @@ final class QuickAddWiring {
     provider.install()
     serviceProvider = provider
     panelHost.onDismiss = { [weak self] in self?.panelDismissed() }
+    // Escape means "back to the list" while composing and "close" otherwise, and only the model
+    // knows which. A missing wire here dismisses, which is the shipped behaviour rather than a trap.
+    panelHost.shouldConsumeCancel = { [weak self] in self?.activeModel?.consumeCancel() ?? false }
   }
 
   // MARK: - The two doors
@@ -123,21 +125,12 @@ final class QuickAddWiring {
     }
     activeModel = model
     let shown = panelHost.present(
-      QuickAddRoot(
+      QuickAddPanelView(
         model: model,
         onAccept: { [weak self] candidate in self?.accept(candidate, model: model) },
         onCreateNew: { [weak self] in self?.createNew(model: model) },
-        onCancel: { [weak self] in self?.cancel(model: model) },
-        newWord: Binding(
-          get: { [weak self] in self?.pendingNewWord },
-          set: { [weak self] in self?.pendingNewWord = $0 }),
-        // `usedSearch` is captured HERE, from the model this panel was built with, rather than
-        // read back off `activeModel` at save time. The sheet outlives the panel in at least one
-        // ordering, and a nil lookup defaulting to false would report a search-assisted save as an
-        // unassisted one — quietly, and in the direction that flatters the ranking.
-        onSaveNewWord: { [weak self] word in
-          self?.saveNewWord(word, usedSearch: model.isSearching)
-        }))
+        onCreate: { [weak self] word in self?.createWord(word, model: model) },
+        onCancel: { [weak self] in self?.cancel(model: model) }))
 
     // The host refuses to present a panel it could not measure, because an unmeasurable panel is an
     // invisible window that reports success. Clearing `activeModel` matters as much as the event:
@@ -164,9 +157,22 @@ final class QuickAddWiring {
   }
 
   private func createNew(model: QuickAddPanelModel) {
-    // NOT dismissed: the edit sheet presents OVER this panel, and tearing the panel down would take
-    // its presenter with it.
+    // NOT dismissed: composing is a STAGE of this panel now, so tearing it down would take the
+    // field the user is about to type into with it.
     coordinator.createNew(from: model)
+  }
+
+  /// The user pressed Return on the compose field.
+  ///
+  /// **A refusal keeps the panel up carrying the reason**, exactly as the accept route does — which
+  /// is the rule the sheet route already followed and the one thing worth preserving from it.
+  private func createWord(_ word: CustomWord, model: QuickAddPanelModel) {
+    // Read LIVE rather than captured at present time. The old capture existed because the sheet
+    // outlived the panel in at least one ordering; a stage of the panel cannot, and the honest
+    // answer to "did the ranking need rescuing" is the state the user was in when they committed.
+    if let message = saveNewWord(word, usedSearch: model.isSearching) {
+      model.noteWriteFailure(message)
+    }
   }
 
   private func cancel(model: QuickAddPanelModel) {
@@ -337,30 +343,6 @@ final class QuickAddWiring {
 
   private func dismiss() {
     activeModel = nil
-    pendingNewWord = nil
     panelHost.dismiss()
-  }
-}
-
-/// The panel's content plus the edit sheet it can present over itself.
-///
-/// A real SwiftUI `.sheet`, not the edit view hosted directly: `CustomWordEditSheet` dismisses itself
-/// through `@Environment(\.dismiss)`, which is supplied by a presenting context. Hosted bare in a
-/// panel there is no such context, so its Cancel button would render, be clickable, and do nothing.
-private struct QuickAddRoot: View {
-  @Bindable var model: QuickAddPanelModel
-  let onAccept: (QuickAddRanker.Candidate) -> Void
-  let onCreateNew: () -> Void
-  let onCancel: () -> Void
-  @Binding var newWord: CustomWord?
-  let onSaveNewWord: (CustomWord) -> String?
-
-  var body: some View {
-    QuickAddPanelView(
-      model: model, onAccept: onAccept, onCreateNew: onCreateNew, onCancel: onCancel
-    )
-    .sheet(item: $newWord) { word in
-      CustomWordEditSheet(word: word, onSave: onSaveNewWord)
-    }
   }
 }

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
@@ -357,6 +357,10 @@ final class QuickAddWiring {
   /// a later invocation reusing the panel must not have its outcome cancelled by a stale closure.
   private func cancel(model: QuickAddPanelModel) {
     if activeModel === model { coordinator.cancel(from: model) }
+    // **Clicking the close control during a confirmation makes the panel key AGAIN**, so dismissing
+    // without releasing leaves us active with no useful key window and the next characters lost.
+    // The beat already released once; this is the second taking, by the user's own click.
+    panelHost.releaseFocus()
     dismiss()
   }
 

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
@@ -26,6 +26,22 @@ final class QuickAddWiring {
   private let hotkeyService: HotkeyService
   private let customWords: CustomWordsCoordinator
 
+  /// How long a confirmation stays up after Return. The founder's number: *"fade away by itself
+  /// after two seconds"*.
+  private static let noticeSeconds: Double = 2
+
+  /// How long the opened-onto-a-covered-word notice stays up.
+  ///
+  /// Longer than the confirmation, and for a reason rather than for feel: that notice ASKS
+  /// something. The user has to read it, decide whether the ranking was right about them, and reach
+  /// for the search field if it was not. A confirmation asks nothing — it reports a decision the
+  /// user already made — so it can be as brief as it is legible.
+  private static let searchableNoticeSeconds: Double = 3
+
+  /// The pending fade. Cancelled by anything that takes the panel down first, so a stale timer can
+  /// never resolve or dismiss the NEXT invocation.
+  private var noticeDismissal: Task<Void, Never>?
+
   /// The panel currently up, if any. Held because the coordinator's outcome calls need the model the
   /// user was actually looking at, and a second invocation must reuse rather than stack.
   private var activeModel: QuickAddPanelModel?
@@ -113,9 +129,35 @@ final class QuickAddWiring {
   /// word to read whatever is frontmost NOW — which is our own panel — is the defect this guard was
   /// added to prevent in the first place.
   private func notAlreadyOpen() -> Bool {
-    guard panelHost.isVisible else { return true }
-    panelHost.raise()
-    return false
+    guard
+      Self.mayBeginCapture(
+        panelVisible: panelHost.isVisible, hasLiveInvocation: activeModel != nil)
+    else {
+      panelHost.raise()
+      return false
+    }
+    // Replacing a fading confirmation rather than raising it means its timer must not survive to
+    // dismiss the panel the new capture is about to fill.
+    noticeDismissal?.cancel()
+    noticeDismissal = nil
+    return true
+  }
+
+  /// Whether a fresh capture may start.
+  ///
+  /// **A confirmation fading out is NOT a live panel, and treating it as one costs the user their
+  /// next word.** `conclude` clears `activeModel` because the invocation has already resolved; the
+  /// window then stays up for two seconds carrying `"clawwed" added to Claude`. Inside that window
+  /// the visibility test alone raises the confirmation and refuses the capture — which from the
+  /// user's side is the shortcut not firing, on the second word they try to add in a row. Adding two
+  /// words in a row is the ordinary way to use this feature, so the window is not rare.
+  ///
+  /// Split out for the same reason `newWordOutcome` was: the version inline could not be tested, and
+  /// the state it gets wrong is one no test could reach. Two Bools, because those are the only two
+  /// facts the decision turns on and naming them is what makes the case above statable at all.
+  package static func mayBeginCapture(panelVisible: Bool, hasLiveInvocation: Bool) -> Bool {
+    guard panelVisible else { return true }
+    return !hasLiveInvocation
   }
 
   private func present(_ model: QuickAddPanelModel?) {
@@ -124,6 +166,9 @@ final class QuickAddWiring {
       return
     }
     activeModel = model
+    // A previous invocation's fade must not reach this panel.
+    noticeDismissal?.cancel()
+    noticeDismissal = nil
     let shown = panelHost.present(
       QuickAddPanelView(
         model: model,
@@ -142,18 +187,79 @@ final class QuickAddWiring {
       return
     }
     coordinator.didOpen()
+    // Opened onto a word that already knows this spelling: the panel says so and fades, unless the
+    // user types (#2391 §3).
+    if model.isShowingSearchableNotice { scheduleSearchableNoticeFade(for: model) }
   }
 
   // MARK: - Outcomes
 
-  /// Dismiss only when the word was actually saved. The same rule `saveNewWord` below already
-  /// followed — a refused write leaves the panel up, carrying the reason.
+  /// Confirm what happened, then leave. A refused write leaves the panel up carrying the reason —
+  /// the same rule `saveNewWord` below already followed.
+  ///
+  /// **The confirmation exists because failure was handled better than success (#2391 §1).** A
+  /// refusal kept the panel open and stated why; a save called `dismiss()` and that was the entire
+  /// behaviour. So the user learned more from failing than from succeeding, on a feature whose whole
+  /// promise is that succeeding is invisible — what they were told would happen only shows up in a
+  /// future dictation.
+  ///
+  /// The sentence is composed from what the coordinator REPORTS, never from the row the user
+  /// clicked: the row is a snapshot taken when the panel opened, and the panel is persistent.
   private func accept(_ candidate: QuickAddRanker.Candidate, model: QuickAddPanelModel) {
-    if let message = coordinator.accept(candidate, from: model) {
+    switch coordinator.accept(candidate, from: model) {
+    case .refused(let message):
       model.noteWriteFailure(message)
-      return
+    case .saved(let word):
+      conclude(model, .saved, spelling: model.spellingToWrite, word: word)
+    case .alreadyHad(let word):
+      conclude(model, .nothingToAdd, spelling: model.spellingToWrite, word: word)
     }
-    dismiss()
+  }
+
+  /// The invocation is over. Say what happened, hand the keyboard back, and fade.
+  ///
+  /// **`activeModel` is cleared FIRST, and that is what makes the beat safe.** The coordinator has
+  /// already resolved; leaving the model live would let the fade — or an Escape during it — report a
+  /// SECOND outcome for one open, which the double-resolution guard would then record as a defect
+  /// rather than as the ordinary thing the user just did.
+  ///
+  /// Focus goes back before the panel does. The user has already returned to their sentence, and a
+  /// key-capable panel that lingers for two seconds eats the first letters of their next word — a
+  /// confirmation that costs a keystroke is worse than no confirmation, which is what nearly sent
+  /// this to the dictation overlay instead of the panel.
+  private func conclude(
+    _ model: QuickAddPanelModel, _ kind: QuickAddPanelModel.Notice.Kind, spelling: String,
+    word: String
+  ) {
+    activeModel = nil
+    model.showNotice(kind, spelling: spelling, word: word)
+    panelHost.releaseFocus()
+    noticeDismissal?.cancel()
+    noticeDismissal = Task { [weak self] in
+      try? await Task.sleep(for: .seconds(Self.noticeSeconds))
+      guard !Task.isCancelled else { return }
+      self?.dismiss()
+    }
+  }
+
+  /// Fade the opened-onto-a-covered-word notice, resolving it as the non-event it is.
+  ///
+  /// **This one HAS to resolve, and the shipped `cancelled` would have been wrong.** Nothing was
+  /// written, but the user did not abandon anything either — there was nothing to abandon. The
+  /// funnel already has the word for it.
+  ///
+  /// Re-checked at fire time rather than cancelled on every keystroke: the user can type, which
+  /// returns the panel to its full list and makes this invocation live again. One guard beats a
+  /// cancellation the model would have to remember to request.
+  private func scheduleSearchableNoticeFade(for model: QuickAddPanelModel) {
+    noticeDismissal?.cancel()
+    noticeDismissal = Task { [weak self] in
+      try? await Task.sleep(for: .seconds(Self.searchableNoticeSeconds))
+      guard !Task.isCancelled, let self else { return }
+      guard self.activeModel === model, model.isShowingSearchableNotice else { return }
+      self.coordinator.didFindAlreadySaved(usedSearch: false)
+      self.dismiss()
+    }
   }
 
   private func createNew(model: QuickAddPanelModel) {
@@ -170,13 +276,33 @@ final class QuickAddWiring {
     // Read LIVE rather than captured at present time. The old capture existed because the sheet
     // outlived the panel in at least one ordering; a stage of the panel cannot, and the honest
     // answer to "did the ranking need rescuing" is the state the user was in when they committed.
-    if let message = saveNewWord(word, usedSearch: model.isSearching) {
+    switch saveNewWord(word, usedSearch: model.isSearching) {
+    case .refused(let message):
       model.noteWriteFailure(message)
+    case .created(let canonical):
+      let spelling = model.spellingToWrite.trimmingCharacters(in: .whitespacesAndNewlines)
+      // With no readable selection there is no mishearing to name, and a confirmation quoting an
+      // empty string would read as a defect. That state is precisely the one Create exists for.
+      conclude(
+        model, spelling.isEmpty ? .created : .saved, spelling: spelling, word: canonical)
+    case .alreadyComplete(let canonical):
+      conclude(
+        model, .nothingToAdd, spelling: model.spellingToWrite, word: canonical)
     }
   }
 
+  /// Only a LIVE invocation can be cancelled.
+  ///
+  /// **The close control stays on screen underneath a confirmation, deliberately** — dismissing the
+  /// beat early is a reasonable thing to want — and `conclude` has already resolved by then. Without
+  /// this the button emits a SECOND terminal event for one open, which the coordinator reports as
+  /// `double_resolution`: a defect that never reaches the screen and quietly disagrees with the
+  /// funnel.
+  ///
+  /// Identity, not a Bool: the captured `model` belongs to the panel this button was built for, and
+  /// a later invocation reusing the panel must not have its outcome cancelled by a stale closure.
   private func cancel(model: QuickAddPanelModel) {
-    coordinator.cancel(from: model)
+    if activeModel === model { coordinator.cancel(from: model) }
     dismiss()
   }
 
@@ -191,7 +317,9 @@ final class QuickAddWiring {
   /// validation, its error message and its change notification are the ones the rest of the app
   /// already relies on — a second write path here would be a second set of rules.
   ///
-  /// Returns nil on success or a user-facing message, which is the sheet's own contract.
+  /// **Returns what happened rather than dismissing**, because the caller now has a sentence to
+  /// say and cannot say it from a nil. Taking the panel down here would also mean the confirmation
+  /// had nowhere to appear.
   ///
   /// **A nil return from `add` is not proof the word was saved, and this is the second time that
   /// assumption cost this feature a false success.** `CustomWordsManager.add` RETURNS silently,
@@ -203,14 +331,23 @@ final class QuickAddWiring {
   /// So this asserts the OUTCOME rather than the call's return value — the word is there and it
   /// carries the spellings the user kept — which is the one check that covers both branches and any
   /// third one nobody has found yet.
-  private func saveNewWord(_ word: CustomWord, usedSearch: Bool) -> String? {
+  private enum NewWordSaveResult: Equatable {
+    /// The word is in the library and it was not there before.
+    case created(canonical: String)
+    /// The canonical was already there and already carried every spelling the user kept.
+    case alreadyComplete(canonical: String)
+    /// Nothing was written and the user did not get what they asked for.
+    case refused(String)
+  }
+
+  private func saveNewWord(_ word: CustomWord, usedSearch: Bool) -> NewWordSaveResult {
     // Snapshotted BEFORE the write, because it is the only way to tell "created" from "was already
     // there". See the vacuity note on the guard below.
     let canonicalExistedBefore = customWords.customWords.contains {
       $0.canonical.caseInsensitiveCompare(
         word.canonical.trimmingCharacters(in: .whitespacesAndNewlines)) == .orderedSame
     }
-    if let message = customWords.add(word) { return message }
+    if let message = customWords.add(word) { return .refused(message) }
     // Compare against the TRIMMED canonical, because that is what `add` stores. Comparing the raw
     // one reports a correct save as a failure whenever the user typed a leading space.
     let canonical = word.canonical.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -219,7 +356,7 @@ final class QuickAddWiring {
         $0.canonical.caseInsensitiveCompare(canonical) == .orderedSame
       })
     else {
-      return QuickAddPanelCopy.newWordNotSaved
+      return .refused(QuickAddPanelCopy.newWordNotSaved)
     }
     // Blank rows are ordinary trimming, not a lost edit — the editor leaves them behind. A NON-blank
     // spelling that vanished is the lie worth catching.
@@ -230,7 +367,7 @@ final class QuickAddWiring {
       !stored.aliases.contains { $0.caseInsensitiveCompare(alias) == .orderedSame }
     }
     guard missing.isEmpty else {
-      return QuickAddPanelCopy.newWordAlreadyExists(canonical: stored.canonical)
+      return .refused(QuickAddPanelCopy.newWordAlreadyExists(canonical: stored.canonical))
     }
     // **AND THE GUARD ABOVE IS VACUOUS WHEN THERE IS NOTHING TO CONFIRM.** Quick Add opened without
     // a readable selection has no heard spelling, so the sheet starts with one BLANK alias, `kept`
@@ -249,16 +386,16 @@ final class QuickAddWiring {
     {
     case .created:
       coordinator.didCreateNew(usedSearch: usedSearch)
+      return .created(canonical: stored.canonical)
     case .alreadyComplete:
       // NOT `didCreateNew`. Nothing was created, so counting one puts a write that did not happen in
       // the numerator of every rate computed off this funnel — and `alreadySaved` already means
       // exactly this, on the accept route, for exactly this reason.
       coordinator.didFindAlreadySaved(usedSearch: usedSearch)
+      return .alreadyComplete(canonical: stored.canonical)
     case .refused:
-      return QuickAddPanelCopy.newWordAlreadyExists(canonical: stored.canonical)
+      return .refused(QuickAddPanelCopy.newWordAlreadyExists(canonical: stored.canonical))
     }
-    dismiss()
-    return nil
   }
 
   /// Whether the sheet's save actually produced the word the user asked for.
@@ -343,6 +480,8 @@ final class QuickAddWiring {
 
   private func dismiss() {
     activeModel = nil
+    noticeDismissal?.cancel()
+    noticeDismissal = nil
     panelHost.dismiss()
   }
 }

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
@@ -326,11 +326,15 @@ final class QuickAddWiring {
       model.noteWriteFailure(message)
       speak(model)
     case .created(let canonical):
-      let spelling = model.spellingToWrite.trimmingCharacters(in: .whitespacesAndNewlines)
-      // With no readable selection there is no mishearing to name, and a confirmation quoting an
-      // empty string would read as a defect. That state is precisely the one Create exists for.
+      // **Composed from the WORD THAT WAS WRITTEN, never from the selection.** Selecting a word that
+      // is already spelled correctly and authoring it is an ordinary thing to do: `draftWord`
+      // correctly declines to store a word as an alias of itself, so nothing is attached — and
+      // choosing the sentence by "was the selection non-empty" then said `"Claude" added to Claude`
+      // about an add that did not happen. Third instance on this branch of a sentence composed from
+      // a neighbouring value instead of from what the write path reports.
+      let attached = word.aliases.first ?? ""
       conclude(
-        model, spelling.isEmpty ? .created : .saved, spelling: spelling, word: canonical)
+        model, attached.isEmpty ? .created : .saved, spelling: attached, word: canonical)
     case .alreadyComplete(let canonical):
       conclude(model, .nothingToAdd, spelling: model.spellingToWrite, word: canonical)
     case .alreadyPresent(let canonical):

--- a/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelModel.swift
+++ b/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelModel.swift
@@ -78,6 +78,9 @@ final class QuickAddPanelModel {
       /// `word` was created and there was no spelling to attach, because the panel opened without
       /// a readable selection. `spelling` is empty here.
       case created
+      /// `word` was already in the library and there was no spelling to attach — the same state as
+      /// `created`, arriving at a canonical that already existed. `spelling` is empty here.
+      case alreadyInWords
     }
 
     let kind: Kind

--- a/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelModel.swift
+++ b/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelModel.swift
@@ -36,6 +36,31 @@ final class QuickAddPanelModel {
   /// The rows on screen, and which one Return would accept.
   private(set) var ranking: QuickAddRanker.Ranking
 
+  /// What the panel is asking the user right now.
+  ///
+  /// **A stage, not a second window.** `Create a new word` used to present a SwiftUI `.sheet`, and
+  /// on this panel a sheet presents nothing at all: SwiftUI attaches one through
+  /// `NSWindow.beginSheet`, which AppKit refuses on a window with `canBecomeMain = false`, silently
+  /// (`swiftui-view-patterns.md` FACT: a-sheet-cannot-present-on-a-window-that-refuses-main-status).
+  /// The panel must refuse main status — taking it reorders the windows the user was working in
+  /// behind an accessory — so the fix is to stop needing a sheet rather than to flip a flag.
+  ///
+  /// Closed, so a third stage cannot inherit either of these two's rules by falling into whichever
+  /// branch is nearest.
+  enum Stage: Equatable, Sendable, CaseIterable {
+    /// The ranked list plus the search field.
+    case picking
+    /// One field: the correct spelling for `heard`. Reached from the create row.
+    case composing
+  }
+
+  private(set) var stage: Stage = .picking
+
+  /// The correct spelling the user is typing, while composing. Separate from `query` on purpose:
+  /// one navigates and the other is written, and a single field serving both is how a search string
+  /// becomes a stored word.
+  private(set) var draftCanonical: String = ""
+
   private let rankHeard: (String) -> QuickAddRanker.Ranking
   private let searchLibrary: (String, String) -> QuickAddRanker.Ranking
 
@@ -70,6 +95,76 @@ final class QuickAddPanelModel {
       trimmed.isEmpty
       ? rankHeard(heard)
       : searchLibrary(newQuery, heard)
+  }
+
+  // MARK: - Composing a new word
+
+  /// The user asked to author a word by hand.
+  ///
+  /// **Seeded from the search field when they were searching, and empty otherwise.** Someone who
+  /// typed a word, found nothing, and reached for Create has already told us what they mean; making
+  /// them type it a second time is the panel forgetting. Someone who typed nothing gets an empty
+  /// field rather than the misspelling they selected, because the misspelling is precisely what the
+  /// new word must NOT be called.
+  func beginComposing() {
+    guard stage == .picking else { return }
+    // A refusal describes the LAST accept, and composing is the user moving on from it — the same
+    // rule `updateQuery` follows for the same reason.
+    writeFailure = nil
+    draftCanonical = isSearching ? query.trimmingCharacters(in: .whitespacesAndNewlines) : ""
+    stage = .composing
+  }
+
+  func updateDraft(_ newDraft: String) {
+    draftCanonical = newDraft
+    writeFailure = nil
+  }
+
+  /// Back to the list. Escape's meaning while composing.
+  func cancelComposing() {
+    guard stage == .composing else { return }
+    stage = .picking
+    draftCanonical = ""
+    writeFailure = nil
+  }
+
+  /// Whether Escape belongs to the panel's CONTENT rather than to the window.
+  ///
+  /// **The one keypress with two meanings, and the window cannot tell them apart.** Escape is
+  /// handled on the panel itself (`KeyCapablePanel.cancelOperation`) because a focused text field's
+  /// field editor claims it first — so the window is where it arrives, and the window knows nothing
+  /// about stages. Asking here keeps the rule in the one place that already owns every other
+  /// keyboard decision, and it means a future stage cannot silently inherit "Escape closes
+  /// everything" by not being thought about.
+  ///
+  /// - Returns: true when this consumed the keypress, so the panel must NOT dismiss.
+  func consumeCancel() -> Bool {
+    guard stage == .composing else { return false }
+    cancelComposing()
+    return true
+  }
+
+  /// The word the user has authored, or nil when there is nothing to create.
+  ///
+  /// **Returns the WORD rather than a Bool, so the caller cannot build a different one.** A
+  /// `canCreate` flag plus a caller assembling `CustomWord(canonical: draft, aliases: [heard])` is
+  /// two places that must agree about trimming and about whether an empty heard spelling becomes a
+  /// blank alias — and the blank-alias case is exactly the one that made
+  /// `QuickAddWiring.newWordOutcome`'s postcondition vacuous.
+  ///
+  /// The heard spelling rides as the first alias, which is the entire point of authoring the word
+  /// from here rather than from Settings. With no readable selection there is no spelling, and the
+  /// word is created carrying none rather than carrying one blank one.
+  var draftWord: CustomWord? {
+    let canonical = draftCanonical.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !canonical.isEmpty else { return nil }
+    let spelling = heard.trimmingCharacters(in: .whitespacesAndNewlines)
+    // A spelling identical to the canonical is not a mishearing, it is the word. Storing it as an
+    // alias of itself is a duplicate the library would carry forever.
+    let aliases =
+      spelling.isEmpty || spelling.caseInsensitiveCompare(canonical) == .orderedSame
+      ? [] : [spelling]
+    return CustomWord(canonical: canonical, aliases: aliases)
   }
 
   // MARK: - The keyboard contract
@@ -108,7 +203,15 @@ final class QuickAddPanelModel {
   var isSearching: Bool { !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
 
   /// The row Return would accept, or nil when Return must write nothing.
-  var acceptTarget: QuickAddRanker.Candidate? { ranking.preselected }
+  ///
+  /// **nil while composing, and that is not defensive tidiness.** The list is still ranked and still
+  /// carries a preselected row; only the view has stopped showing it. A legend derived from this
+  /// would advertise `add spelling` over a compose field, and a stray Return arriving from anywhere
+  /// but that field would write to a row the user can no longer see.
+  var acceptTarget: QuickAddRanker.Candidate? {
+    guard stage == .picking else { return nil }
+    return ranking.preselected
+  }
 
   /// Record that the library refused the write. Set by the coordinator's caller, never here: the
   /// model does not know what a words file is and must not learn.

--- a/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelModel.swift
+++ b/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelModel.swift
@@ -305,6 +305,20 @@ final class QuickAddPanelModel {
     return false
   }
 
+  /// Whether the search field belongs on screen.
+  ///
+  /// **A refusal hides it, and the copy depends on that.** `updateQuery` will not re-rank without a
+  /// heard string, so under a refusal the field can be typed into and answers nothing. The refusal
+  /// messages were rewritten precisely to stop pointing at it, and `noRefusalPointsAtTheSearchField`
+  /// guards that wording — a disabled field left on screen is the control those messages were
+  /// forbidden from naming, still sitting there.
+  ///
+  /// A searchable notice shows it, because typing past that notice is the whole reason it is a
+  /// notice rather than a dismissal.
+  var showsSearchField: Bool {
+    (stage == .picking && refusal == nil) || isShowingSearchableNotice
+  }
+
   /// The notice currently on screen, or nil. One accessor, so the view and the timer cannot disagree
   /// about which stage counts as a notice.
   var notice: Notice? {

--- a/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelModel.swift
+++ b/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelModel.swift
@@ -45,13 +45,49 @@ final class QuickAddPanelModel {
   /// The panel must refuse main status — taking it reorders the windows the user was working in
   /// behind an accessory — so the fix is to stop needing a sheet rather than to flip a flag.
   ///
-  /// Closed, so a third stage cannot inherit either of these two's rules by falling into whichever
-  /// branch is nearest.
-  enum Stage: Equatable, Sendable, CaseIterable {
+  /// Closed, so a new stage cannot inherit another's rules by falling into whichever branch is
+  /// nearest.
+  enum Stage: Equatable, Sendable {
     /// The ranked list plus the search field.
     case picking
     /// One field: the correct spelling for `heard`. Reached from the create row.
     case composing
+    /// Nothing left to ask. The panel states what happened and takes itself away.
+    case notice(Notice)
+  }
+
+  /// What the panel says when it has nothing further to ask.
+  ///
+  /// **Two situations reach this and they differ in ONE property, which is why it is a flag rather
+  /// than two cases.** After Return the user has committed and gone back to their sentence, so the
+  /// panel must give keyboard focus back before it fades — a confirmation that eats the first letter
+  /// of their next word is worse than no confirmation. Opened onto a word that is already covered,
+  /// the user has typed nothing and is looking straight at the panel, so the search field stays and
+  /// typing returns them to the full list.
+  ///
+  /// Getting that backwards in either direction is a real defect — a terminal notice holding focus
+  /// swallows keystrokes, and a searchable one that dropped focus would make the escape hatch
+  /// unreachable — so the two are one value the callers cannot forget to set.
+  struct Notice: Equatable, Sendable {
+    /// Which of the three things happened. Closed, so a fourth cannot borrow another's sentence.
+    enum Kind: Equatable, Sendable, CaseIterable {
+      /// The spelling was written onto `word`.
+      case saved
+      /// `word` already carried the spelling, so nothing was written.
+      case nothingToAdd
+      /// `word` was created and there was no spelling to attach, because the panel opened without
+      /// a readable selection. `spelling` is empty here.
+      case created
+    }
+
+    let kind: Kind
+    /// What the user selected. Empty for `.created`.
+    let spelling: String
+    /// The library word, as it is NOW — never the ranking's snapshot of it.
+    let word: String
+    /// Whether the invocation is still LIVE behind the notice: the search field is shown, typing
+    /// returns to the full list, and nothing has been resolved yet.
+    let searchable: Bool
   }
 
   private(set) var stage: Stage = .picking
@@ -77,6 +113,20 @@ final class QuickAddPanelModel {
     // A refusal has no heard string to rank, so the panel opens on an empty list and a stated
     // reason rather than on a ranking of nothing.
     self.ranking = refusal == nil ? rankHeard(heard) : .empty
+    // **Opened onto a word that is already covered, the panel says so and leaves (#2391 §3).**
+    // The header already said `nothing to add` and the rest of the panel contradicted it: a
+    // highlighted row whose only action is a no-op, four unrelated words offered as if they were
+    // choices, a legend advertising `add spelling` in a state where nothing can be added, and a
+    // dismissal the user had to perform by hand.
+    //
+    // Decided HERE rather than in the view, because it is not a rendering question: it changes what
+    // Return does, whether the create row is offered, and whether this invocation resolves as
+    // `already_saved` or as a cancel.
+    if let top = self.ranking.preselected, top.alreadyHasHeardSpelling {
+      self.stage = .notice(
+        Notice(
+          kind: .nothingToAdd, spelling: heard, word: top.word.canonical, searchable: true))
+    }
   }
 
   // MARK: - The search field
@@ -89,6 +139,15 @@ final class QuickAddPanelModel {
     query = newQuery
     // A refusal describes the LAST accept. Typing is the user moving on from it.
     writeFailure = nil
+    // **Typing is how the user says the notice was wrong about them.** A word already covered is
+    // not the same as a user with nothing to do: the ranking can be wrong, and the search field is
+    // the escape hatch built for exactly that. Reaching for it returns the full list and, because
+    // the invocation has not resolved, cancels the pending auto-dismiss at its own guard.
+    if case .notice(let notice) = stage, notice.searchable,
+      !newQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    {
+      stage = .picking
+    }
     guard refusal == nil else { return }
     let trimmed = newQuery.trimmingCharacters(in: .whitespacesAndNewlines)
     ranking =
@@ -174,6 +233,11 @@ final class QuickAddPanelModel {
   /// Clamped rather than wrapping: wrapping from the last row to the first is a surprise when the
   /// list is short and the user is holding the key, and this list is at most a handful of rows.
   func moveHighlight(by offset: Int) {
+    // **An arrow press past a searchable notice means the same thing typing does: show me the
+    // options.** The field is on screen and focused there, so both keys are available and only one
+    // of them answered — pressing Down and watching nothing happen is the panel ignoring a key it
+    // is visibly offering.
+    if isShowingSearchableNotice { stage = .picking }
     guard !ranking.candidates.isEmpty else { return }
     let current = ranking.candidates.firstIndex { $0.id == ranking.preselectedID }
     // No highlight yet means the bar was not cleared, so an arrow press is the user OPTING IN to a
@@ -216,6 +280,34 @@ final class QuickAddPanelModel {
   /// Record that the library refused the write. Set by the coordinator's caller, never here: the
   /// model does not know what a words file is and must not learn.
   func noteWriteFailure(_ message: String) { writeFailure = message }
+
+  /// Return has been pressed and something happened. Say what, then the caller takes the panel away.
+  ///
+  /// **`searchable` is set HERE rather than taken as an argument, and it is always false.** This is
+  /// reached only after Return, when the user is already back in their sentence — a terminal notice
+  /// offering a focused field is the exact keystroke-eating defect that nearly sent the confirmation
+  /// to the dictation overlay instead of the panel. A caller that could pass `true` is a caller that
+  /// can reintroduce it.
+  func showNotice(_ kind: Notice.Kind, spelling: String, word: String) {
+    writeFailure = nil
+    stage = .notice(Notice(kind: kind, spelling: spelling, word: word, searchable: false))
+  }
+
+  /// Whether the panel is showing a notice the user can still type past.
+  ///
+  /// Read by the auto-dismiss before it resolves this invocation: the user may have typed in the
+  /// meantime, which puts the panel back on its list and makes the invocation live again.
+  var isShowingSearchableNotice: Bool {
+    if case .notice(let notice) = stage { return notice.searchable }
+    return false
+  }
+
+  /// The notice currently on screen, or nil. One accessor, so the view and the timer cannot disagree
+  /// about which stage counts as a notice.
+  var notice: Notice? {
+    if case .notice(let notice) = stage { return notice }
+    return nil
+  }
 
   /// What gets written if the user accepts. **Always the original selection, never the query.**
   ///

--- a/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelView.swift
+++ b/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelView.swift
@@ -56,6 +56,16 @@ enum QuickAddPanelCopy {
     "\(word) added to your words"
   }
 
+  /// The user authored a word by hand that was already in the library, with no spelling to attach.
+  ///
+  /// **Not a refusal, and it used to be one.** The panel that reaches this opened WITHOUT a readable
+  /// selection, so its ranking is empty and its search field disabled — and the refusal's copy told
+  /// the user to choose the word from a list that cannot exist there. Nothing is wrong in this
+  /// state: they asked for the word to be in their words, and it is.
+  static func alreadyInWordsNotice(word: String) -> String {
+    "\(word) is already in your words"
+  }
+
   /// The one place a `Notice` becomes English.
   ///
   /// **Exhaustive over `Kind` on purpose.** The model carries the FACTS — which thing happened, to
@@ -67,6 +77,7 @@ enum QuickAddPanelCopy {
     case .saved: savedNotice(spelling: notice.spelling, word: notice.word)
     case .nothingToAdd: nothingToAddNotice(spelling: notice.spelling, word: notice.word)
     case .created: createdNotice(word: notice.word)
+    case .alreadyInWords: alreadyInWordsNotice(word: notice.word)
     }
   }
 

--- a/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelView.swift
+++ b/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelView.swift
@@ -382,7 +382,19 @@ struct QuickAddPanelView: View {
     .padding(.top, 2)
     // The field takes focus the moment the stage appears. Without it the user reaches Create and
     // types into nothing — and the panel is key-capable precisely so that cannot happen.
+    //
+    // **BOTH, and the second is not belt-and-braces.** Measured on the running build, `.onAppear`
+    // alone left `AXFocusedUIElement` reporting the WINDOW rather than any field: entering compose
+    // removes the search field in the SAME update, and tearing down the focused field resolves
+    // focus to nothing afterwards. The assignment is not lost, it is overtaken — so it has to be
+    // re-asserted after that update, which is what the yield buys. `.onAppear` stays because it is
+    // correct whenever nothing is competing and keeps the common path synchronous; dropping it
+    // would make every entry into this stage focus a frame late.
     .onAppear { composeFocused = true }
+    .task {
+      await Task.yield()
+      composeFocused = true
+    }
   }
 
   /// Which sentence the group header is saying. Derived, never stored: a second copy of this on the

--- a/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelView.swift
+++ b/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelView.swift
@@ -1,3 +1,4 @@
+import EnviousWisprCore
 import EnviousWisprPostProcessing
 import EnviousWisprServices
 import SwiftUI
@@ -10,6 +11,22 @@ import SwiftUI
 enum QuickAddPanelCopy {
   static let searchPlaceholder = "Search your words"
   static let createNewWord = "Create a new word"
+
+  /// The compose stage's one instruction, and the only place the panel names what it is about to
+  /// create.
+  ///
+  /// **Two sentences because there are two situations, not because one needed softening.** With a
+  /// readable selection the user is correcting a specific mishearing and the field means "what
+  /// should this have been". With no selection there is nothing to correct — Create is then the
+  /// panel's ONLY working control — and a header quoting an empty string would read as a bug.
+  static func composeHeader(heard: String) -> String {
+    heard.isEmpty ? "New word" : "Correct spelling for \"\(heard)\""
+  }
+
+  /// What the compose field says when empty. Names the thing to type, never the action.
+  static func composePlaceholder(heard: String) -> String {
+    heard.isEmpty ? "The word to add" : "The correct spelling"
+  }
 
   /// Shown when the library refused the write, above the rows so the panel that stayed open says
   /// why. The message comes from the words authority itself rather than being reworded here: it is
@@ -98,6 +115,12 @@ enum QuickAddPanelCopy {
   static let legendMove = "move"
   static let legendClose = "close"
 
+  /// The compose stage's two caps. `back` and not `close`, because Escape means something different
+  /// there — the legend is the contract made visible, and a legend that says `close` over a field
+  /// whose Escape returns to the list is the panel promising a key it will not answer.
+  static let legendCreate = "create"
+  static let legendBack = "back"
+
   /// The one line shown instead of a ranking when we could not read a selection.
   ///
   /// Every refusal gets its own sentence. A single "could not read your selection" would be
@@ -155,54 +178,131 @@ struct QuickAddPanelView: View {
 
   /// Accept a candidate: add the heard spelling to that word.
   let onAccept: (QuickAddRanker.Candidate) -> Void
-  /// Create a new word carrying the heard spelling as its first alias.
+  /// Move to the compose stage. The word itself is built by the model, not here.
   let onCreateNew: () -> Void
+  /// Commit the authored word. Handed the word rather than the typed text, so the view cannot
+  /// assemble a different one than the model validated.
+  let onCreate: (CustomWord) -> Void
   /// Escape, or anything else that means "never mind".
   let onCancel: () -> Void
 
   @FocusState private var searchFocused: Bool
+  @FocusState private var composeFocused: Bool
 
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
-      searchWell
-      if let refusal = model.refusal {
-        Text(QuickAddPanelCopy.refusalMessage(refusal))
-          .font(.stBody)
-          .foregroundStyle(.stTextSecondary)
-          .fixedSize(horizontal: false, vertical: true)
-          .padding(.horizontal, 16)
-          .padding(.top, 14)
-      }
-      if let failure = model.writeFailure {
-        Text(QuickAddPanelCopy.writeFailure(failure))
-          .font(.stBody)
-          .foregroundStyle(.stError)
-          .fixedSize(horizontal: false, vertical: true)
-          .padding(.horizontal, 16)
-          .padding(.top, 14)
-      }
-      if !model.ranking.candidates.isEmpty {
-        Text(QuickAddPanelCopy.groupHeader(headerState, heard: model.heard))
-          .font(.stSectionHeader)
-          .tracking(0.5)
-          .foregroundStyle(headerState == .lowConfidence ? .stTextTertiary : .stAccent)
-          .padding(.horizontal, 16)
-          .padding(.top, 14)
-          .padding(.bottom, 6)
-        candidateRows
+      switch model.stage {
+      case .picking: pickingContent
+      case .composing: composingContent
       }
       Divider().overlay(Color.stDivider).padding(.top, 10)
-      createNewRow
+      if model.stage == .picking { createNewRow }
       legend
     }
     .frame(width: 360)
-    // The field takes focus on open, so typing is always the immediate alternative to accepting —
-    // which is what makes a wrong-but-confident ranking recoverable without reaching for the mouse.
-    .onAppear { searchFocused = true }
     // NO `.onExitCommand`. It sat here and never fired: the search field takes focus on open and its
     // field editor claims `cancelOperation(_:)` first. Escape is handled on the panel itself, where
     // nothing can intercept it — and leaving it here as well would give one keypress two dismissal
     // paths, which the coordinator's double-resolution guard would then report as a defect.
+    //
+    // Escape now has TWO meanings and the window still cannot tell them apart, which is why the
+    // decision stayed on the model (`consumeCancel`) rather than moving back here.
+  }
+
+  /// The ranked list, the search field, and the refusal or failure above them.
+  @ViewBuilder
+  private var pickingContent: some View {
+    searchWell
+    if let refusal = model.refusal {
+      Text(QuickAddPanelCopy.refusalMessage(refusal))
+        .font(.stBody)
+        .foregroundStyle(.stTextSecondary)
+        .fixedSize(horizontal: false, vertical: true)
+        .padding(.horizontal, 16)
+        .padding(.top, 14)
+    }
+    failureBanner
+    if !model.ranking.candidates.isEmpty {
+      Text(QuickAddPanelCopy.groupHeader(headerState, heard: model.heard))
+        .font(.stSectionHeader)
+        .tracking(0.5)
+        .foregroundStyle(headerState == .lowConfidence ? .stTextTertiary : .stAccent)
+        .padding(.horizontal, 16)
+        .padding(.top, 14)
+        .padding(.bottom, 6)
+      candidateRows
+    }
+  }
+
+  /// One field, and the sentence saying what it is for.
+  ///
+  /// **No category, no strictness, no AI suggestions, no delete.** Those are a Settings affordance
+  /// for someone curating a library; this is someone who highlighted a misspelling two seconds ago.
+  /// All three take their defaults and are editable in Settings afterwards, which is stated here
+  /// rather than in a commit nobody will read.
+  @ViewBuilder
+  private var composingContent: some View {
+    Text(QuickAddPanelCopy.composeHeader(heard: model.heard))
+      .font(.stSectionHeader)
+      .tracking(0.5)
+      .foregroundStyle(.stAccent)
+      .fixedSize(horizontal: false, vertical: true)
+      .padding(.horizontal, 16)
+      .padding(.top, 14)
+      .padding(.bottom, 6)
+    composeWell
+    failureBanner
+  }
+
+  /// Why the last write did not happen. Shared by both stages: the library refuses through the same
+  /// channel whichever field the user was in, and a second banner would be a second wording.
+  @ViewBuilder
+  private var failureBanner: some View {
+    if let failure = model.writeFailure {
+      Text(QuickAddPanelCopy.writeFailure(failure))
+        .font(.stBody)
+        .foregroundStyle(.stError)
+        .fixedSize(horizontal: false, vertical: true)
+        .padding(.horizontal, 16)
+        .padding(.top, 14)
+    }
+  }
+
+  private var composeWell: some View {
+    HStack(spacing: 8) {
+      Image(systemName: "plus")
+        .font(.system(size: 13, weight: .medium))
+        .foregroundStyle(.stTextTertiary)
+      TextField(
+        QuickAddPanelCopy.composePlaceholder(heard: model.heard),
+        // Explicit closures, NOT a bare method reference — see the note on `searchWell`. Swift
+        // 6.3.3 crashes emitting the reabstraction thunk, with no source diagnostic.
+        text: Binding(get: { model.draftCanonical }, set: { model.updateDraft($0) })
+      )
+      .textFieldStyle(.plain)
+      .font(.system(size: 15))
+      .foregroundStyle(.stTextPrimary)
+      .focused($composeFocused)
+      // **Return creates only when there is something to create.** An empty field does nothing,
+      // which is the same rule the picking stage applies below the confidence bar, and the legend
+      // says so by omitting the cap.
+      .onSubmit {
+        guard let word = model.draftWord else { return }
+        onCreate(word)
+      }
+    }
+    .padding(.horizontal, 12)
+    .frame(height: 38)
+    .background(RoundedRectangle(cornerRadius: 8).fill(Color.stSectionBg))
+    .overlay(
+      RoundedRectangle(cornerRadius: 8)
+        .strokeBorder(composeFocused ? Color.stAccentSolid : Color.stDivider, lineWidth: 1)
+    )
+    .padding(.horizontal, 12)
+    .padding(.top, 2)
+    // The field takes focus the moment the stage appears. Without it the user reaches Create and
+    // types into nothing — and the panel is key-capable precisely so that cannot happen.
+    .onAppear { composeFocused = true }
   }
 
   /// Which sentence the group header is saying. Derived, never stored: a second copy of this on the
@@ -273,6 +373,11 @@ struct QuickAddPanelView: View {
     )
     .padding(.horizontal, 12)
     .padding(.top, 12)
+    // The field takes focus when the stage appears, so typing is always the immediate alternative
+    // to accepting — which is what makes a wrong-but-confident ranking recoverable without reaching
+    // for the mouse. Moved off the body when the body gained a second stage: left there it fired
+    // once, at open, and returning from Compose left the panel with no focused field at all.
+    .onAppear { searchFocused = true }
   }
 
   private var candidateRows: some View {
@@ -345,11 +450,17 @@ struct QuickAddPanelView: View {
   /// user who would otherwise have to discover it by accident.
   private var legend: some View {
     HStack(spacing: 14) {
-      if model.acceptTarget != nil {
-        legendItem("\u{23CE}", QuickAddPanelCopy.legendAccept)
-      }
-      if !model.ranking.candidates.isEmpty {
-        legendItem("\u{2191}\u{2193}", QuickAddPanelCopy.legendMove)
+      if model.stage == .composing {
+        if model.draftWord != nil {
+          legendItem("\u{23CE}", QuickAddPanelCopy.legendCreate)
+        }
+      } else {
+        if model.acceptTarget != nil {
+          legendItem("\u{23CE}", QuickAddPanelCopy.legendAccept)
+        }
+        if !model.ranking.candidates.isEmpty {
+          legendItem("\u{2191}\u{2193}", QuickAddPanelCopy.legendMove)
+        }
       }
       // **A BUTTON, and it is the only mouse path off this panel.** The standard close control is
       // hidden because `.fullSizeContentView` puts the hosting view over the titlebar, so unhiding
@@ -361,15 +472,30 @@ struct QuickAddPanelView: View {
       //
       // The legend is where it belongs rather than in new chrome: it already names this key, so a
       // user reading "esc close" and clicking it is doing the obvious thing.
-      Button(action: onCancel) { legendItem("esc", QuickAddPanelCopy.legendClose) }
+      // Escape's label and its action both follow the stage, from ONE derived value. Two
+      // independent `if`s here is how a button comes to say `back` and dismiss the panel.
+      Button(action: escapeAction) { legendItem("esc", escapeLabel) }
         .buttonStyle(.plain)
         .contentShape(Rectangle())
-        .accessibilityLabel(QuickAddPanelCopy.legendClose)
+        .accessibilityLabel(escapeLabel)
       Spacer(minLength: 0)
     }
     .padding(.horizontal, 16)
     .padding(.vertical, 9)
     .background(Color.stSectionBg)
+  }
+
+  /// What Escape says, and what it does. Derived together so they cannot disagree.
+  private var escapeLabel: String {
+    model.stage == .composing ? QuickAddPanelCopy.legendBack : QuickAddPanelCopy.legendClose
+  }
+
+  private func escapeAction() {
+    if model.stage == .composing {
+      model.cancelComposing()
+    } else {
+      onCancel()
+    }
   }
 
   private func legendItem(_ cap: String, _ label: String) -> some View {

--- a/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelView.swift
+++ b/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelView.swift
@@ -59,9 +59,9 @@ enum QuickAddPanelCopy {
   /// The user authored a word by hand that was already in the library, with no spelling to attach.
   ///
   /// **Not a refusal, and it used to be one.** The panel that reaches this opened WITHOUT a readable
-  /// selection, so its ranking is empty and its search field disabled — and the refusal's copy told
-  /// the user to choose the word from a list that cannot exist there. Nothing is wrong in this
-  /// state: they asked for the word to be in their words, and it is.
+  /// selection, so its ranking is empty and its search field is not on screen — and the refusal's
+  /// copy told the user to choose the word from a list that cannot exist there. Nothing is wrong
+  /// in this state: they asked for the word to be in their words, and it is.
   static func alreadyInWordsNotice(word: String) -> String {
     "\(word) is already in your words"
   }
@@ -249,7 +249,7 @@ struct QuickAddPanelView: View {
       // rendered inside each branch would be a DIFFERENT view to SwiftUI on either side of that
       // transition. It would be torn down and rebuilt at the exact keystroke that causes the
       // transition, losing focus and the character that triggered it.
-      if showsSearchField { searchWell }
+      if model.showsSearchField { searchWell }
       switch model.stage {
       case .picking: pickingContent
       case .composing: composingContent
@@ -267,12 +267,6 @@ struct QuickAddPanelView: View {
     //
     // Escape now has TWO meanings and the window still cannot tell them apart, which is why the
     // decision stayed on the model (`consumeCancel`) rather than moving back here.
-  }
-
-  /// Whether the search field is on screen. `.picking` always, and a searchable notice because the
-  /// escape hatch is the whole reason that notice is not simply a dismissal.
-  private var showsSearchField: Bool {
-    model.stage == .picking || model.notice?.searchable == true
   }
 
   /// The ranked list, and the refusal or failure above it.
@@ -430,6 +424,9 @@ struct QuickAddPanelView: View {
       .font(.system(size: 15))
       .foregroundStyle(.stTextPrimary)
       .focused($searchFocused)
+      // Unreachable today — `showsSearchField` hides the field under a refusal — and kept as the
+      // floor: any future state that shows the field without a rankable heard string gets an inert
+      // control rather than a silent one.
       .disabled(model.refusal != nil)
       // Arrows move the highlight WITHOUT leaving the field, which is what lets the user keep typing
       // after correcting the selection.

--- a/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelView.swift
+++ b/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelView.swift
@@ -28,6 +28,48 @@ enum QuickAddPanelCopy {
     heard.isEmpty ? "The word to add" : "The correct spelling"
   }
 
+  /// The confirmation shown for a beat after Return (#2391 §1).
+  ///
+  /// **States what happened to the LIBRARY and promises nothing about future behaviour.** Not
+  /// "saved", which says nothing about where; not "will be corrected from now on", which is a
+  /// sentence the code cannot back — a spelling belongs to ONE word, and whether a future dictation
+  /// reaches this one depends on the rest of the library.
+  ///
+  /// The asymmetry this closes: a refused write already kept the panel open and stated the reason,
+  /// so the user learned more from failing than from succeeding, on a feature whose whole promise is
+  /// that succeeding is invisible.
+  static func savedNotice(spelling: String, word: String) -> String {
+    "\"\(spelling)\" added to \(word)"
+  }
+
+  /// The word already carries this spelling, so there is nothing to add (#2391 §3).
+  ///
+  /// Names the WORD first, because that is the fact the user does not have: they know what they
+  /// selected and are asking who owns it.
+  static func nothingToAddNotice(spelling: String, word: String) -> String {
+    "\(word) already knows \"\(spelling)\""
+  }
+
+  /// A word authored by hand with no spelling to attach, which is the state Create exists for: the
+  /// panel opened without a readable selection, so there is no mishearing to name.
+  static func createdNotice(word: String) -> String {
+    "\(word) added to your words"
+  }
+
+  /// The one place a `Notice` becomes English.
+  ///
+  /// **Exhaustive over `Kind` on purpose.** The model carries the FACTS — which thing happened, to
+  /// which word, with which spelling — and never a sentence, so a new outcome cannot ship borrowing
+  /// another's wording by being handed a string at the call site. A `switch` here is what makes the
+  /// compiler ask.
+  static func notice(_ notice: QuickAddPanelModel.Notice) -> String {
+    switch notice.kind {
+    case .saved: savedNotice(spelling: notice.spelling, word: notice.word)
+    case .nothingToAdd: nothingToAddNotice(spelling: notice.spelling, word: notice.word)
+    case .created: createdNotice(word: notice.word)
+    }
+  }
+
   /// Shown when the library refused the write, above the rows so the panel that stayed open says
   /// why. The message comes from the words authority itself rather than being reworded here: it is
   /// the same sentence the editor shows for the same refusal, and a second wording would be a
@@ -191,9 +233,16 @@ struct QuickAddPanelView: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
+      // **Hoisted out of the stages, and that is structural rather than cosmetic.** A searchable
+      // notice shows the field too, and typing in it returns the panel to its list — so a field
+      // rendered inside each branch would be a DIFFERENT view to SwiftUI on either side of that
+      // transition. It would be torn down and rebuilt at the exact keystroke that causes the
+      // transition, losing focus and the character that triggered it.
+      if showsSearchField { searchWell }
       switch model.stage {
       case .picking: pickingContent
       case .composing: composingContent
+      case .notice(let notice): noticeContent(notice)
       }
       Divider().overlay(Color.stDivider).padding(.top, 10)
       if model.stage == .picking { createNewRow }
@@ -209,10 +258,15 @@ struct QuickAddPanelView: View {
     // decision stayed on the model (`consumeCancel`) rather than moving back here.
   }
 
-  /// The ranked list, the search field, and the refusal or failure above them.
+  /// Whether the search field is on screen. `.picking` always, and a searchable notice because the
+  /// escape hatch is the whole reason that notice is not simply a dismissal.
+  private var showsSearchField: Bool {
+    model.stage == .picking || model.notice?.searchable == true
+  }
+
+  /// The ranked list, and the refusal or failure above it.
   @ViewBuilder
   private var pickingContent: some View {
-    searchWell
     if let refusal = model.refusal {
       Text(QuickAddPanelCopy.refusalMessage(refusal))
         .font(.stBody)
@@ -252,6 +306,27 @@ struct QuickAddPanelView: View {
       .padding(.bottom, 6)
     composeWell
     failureBanner
+  }
+
+  /// The panel with nothing left to ask: one sentence, and then it takes itself away.
+  ///
+  /// **Three lines where the shipped panel rendered nine.** Opened onto a word already covered, the
+  /// header said `nothing to add` and the rest of the panel contradicted it — a highlighted row
+  /// whose only action was a no-op, four unrelated words offered as if they were choices, and a
+  /// legend advertising a verb the state could not perform.
+  ///
+  /// The search field above this stays for a searchable notice, because the ranking can be wrong
+  /// and typing is how the user says so.
+  @ViewBuilder
+  private func noticeContent(_ notice: QuickAddPanelModel.Notice) -> some View {
+    let message = QuickAddPanelCopy.notice(notice)
+    Text(message)
+      .font(.stBody)
+      .foregroundStyle(.stTextPrimary)
+      .fixedSize(horizontal: false, vertical: true)
+      .padding(.horizontal, 16)
+      .padding(.top, 14)
+      .accessibilityLabel(message)
   }
 
   /// Why the last write did not happen. Shared by both stages: the library refuses through the same
@@ -450,17 +525,24 @@ struct QuickAddPanelView: View {
   /// user who would otherwise have to discover it by accident.
   private var legend: some View {
     HStack(spacing: 14) {
-      if model.stage == .composing {
+      // Switched on the stage rather than tested for one, so a new stage cannot inherit whichever
+      // branch happens to be the `else`. A notice offers no keys of its own: the ranking behind it
+      // still HAS a preselected row, and an `↑↓ move` cap over a sentence would name a control that
+      // is not on screen.
+      switch model.stage {
+      case .composing:
         if model.draftWord != nil {
           legendItem("\u{23CE}", QuickAddPanelCopy.legendCreate)
         }
-      } else {
+      case .picking:
         if model.acceptTarget != nil {
           legendItem("\u{23CE}", QuickAddPanelCopy.legendAccept)
         }
         if !model.ranking.candidates.isEmpty {
           legendItem("\u{2191}\u{2193}", QuickAddPanelCopy.legendMove)
         }
+      case .notice:
+        EmptyView()
       }
       // **A BUTTON, and it is the only mouse path off this panel.** The standard close control is
       // hidden because `.fullSizeContentView` puts the hosting view over the titlebar, so unhiding
@@ -490,12 +572,12 @@ struct QuickAddPanelView: View {
     model.stage == .composing ? QuickAddPanelCopy.legendBack : QuickAddPanelCopy.legendClose
   }
 
+  /// **Asks the model the same question the WINDOW asks.** Escape arrives twice by two routes —
+  /// `KeyCapablePanel.cancelOperation` for the key, this button for the mouse — and a second copy of
+  /// the rule here is how the two came to mean different things in the compose stage.
   private func escapeAction() {
-    if model.stage == .composing {
-      model.cancelComposing()
-    } else {
-      onCancel()
-    }
+    guard !model.consumeCancel() else { return }
+    onCancel()
   }
 
   private func legendItem(_ cap: String, _ label: String) -> some View {

--- a/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
@@ -932,31 +932,25 @@ struct QuickAddCoordinatorTests {
     #expect(QuickAddWiring.announcement(notice: nil, writeFailure: nil) == nil)
   }
 
-  // MARK: - What a focus-taking call actually takes (#2391, r5)
+  // MARK: - Where the keyboard goes when the panel gives it up (#2391, r6)
 
-  /// **The case a SECOND shortcut press lands on, and the one that takes nothing.**
+  /// **This replaces three tests about who focus was TAKEN from, and the replacement is the point.**
   ///
-  /// Making one owner for taking focus was right; writing it as if every call takes something was
-  /// not. Raising an already-key panel recomputes "were we active" as true — because THIS PANEL made
-  /// it true — so the debt owed to the app the user actually came from is discarded, and the
-  /// confirmation then leaves us active with their next keystrokes going nowhere.
-  @Test("Raising an already-key panel takes nothing, so the standing debt survives")
-  func raisingAnAlreadyKeyPanelTakesNothing() {
+  /// Those tests protected "give back exactly what you took", which needed the panel to remember —
+  /// and three review rounds each found another way for it to become key without recording anything:
+  /// a raise on an already-key panel, and a mouse click, with command-tab and the Dock waiting. That
+  /// set is AppKit's, so it has a next member however many are handled.
+  ///
+  /// The property is now structural rather than asserted: nothing is remembered, so nothing can be
+  /// stale. What remains to test is the one closed decision.
+  @Test("The keyboard goes to our own window when we have one, and to the app behind us otherwise")
+  func theKeyboardGoesWhereItBelongs() {
     #expect(
-      QuickAddPanelHost.focusTake(wasActive: true, keyWindowIsThePanel: true) == .nothing)
-  }
-
-  /// The paired positives, without which a rule that never classifies anything looks clean.
-  @Test("Every other combination names what it took")
-  func everyOtherCombinationNamesWhatItTook() {
-    // Not active: both came from outside, whatever held key.
+      QuickAddPanelHost.focusRelease(hasOtherKeyableWindow: true) == .handToOurOwnWindow,
+      "another window of ours means the user is inside our app; deactivating would hide it")
     #expect(
-      QuickAddPanelHost.focusTake(wasActive: false, keyWindowIsThePanel: false) == .fromAnotherApp)
-    #expect(
-      QuickAddPanelHost.focusTake(wasActive: false, keyWindowIsThePanel: true) == .fromAnotherApp)
-    // Active, and one of OUR windows held key — Settings, reachable because the shortcut is global.
-    #expect(
-      QuickAddPanelHost.focusTake(wasActive: true, keyWindowIsThePanel: false) == .fromOurOwnWindow)
+      QuickAddPanelHost.focusRelease(hasOtherKeyableWindow: false) == .deactivateApp,
+      "the panel alone means the user came from another app")
   }
 
   // MARK: - The created confirmation names what was written (#2391, r5)

--- a/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
@@ -962,6 +962,15 @@ struct QuickAddCoordinatorTests {
     #expect(QuickAddPanelHost.focusRelease(origin: .otherApp) == .deactivateApp)
   }
 
+  /// **The case AppKit's own notifications got wrong, kept so the observer version cannot return.**
+  /// `NSApp.activate` can make Settings key on its way to activating us, so a notification observer
+  /// records `.ourWindow` for an invocation that started in TextEdit. Capturing before anything
+  /// activates is what makes the answer `.otherApp`, and this asserts the consequence.
+  @Test("Our own activation cannot turn an external origin into one of our windows")
+  func ourOwnActivationDoesNotRewriteTheOrigin() {
+    #expect(QuickAddPanelHost.focusRelease(origin: .otherApp) == .deactivateApp)
+  }
+
   /// Unknown deactivates, and the asymmetry is the point: guessing "our window" when the user came
   /// from another app eats the keystrokes this mechanism exists to protect, while guessing
   /// "deactivate" when they were in our app costs a click.

--- a/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
@@ -22,7 +22,10 @@ struct QuickAddCoordinatorTests {
     var events: [QuickAddEvent] = []
     var saved: [CustomWord] = []
     var savedSpellings: [String] = []
-    var sheetsFor: [String] = []
+    /// How many times the panel was asked to move to its compose stage. A COUNT, not the heard
+    /// spelling: the coordinator stopped handing one over when the sheet was replaced by a stage of
+    /// the panel, and the model that already holds it is the only thing that assembles the word.
+    var beganNewWord = 0
     var refreshCalls = 0
 
     /// The user library, LIVE. Held here rather than captured by value so a test can change it
@@ -96,7 +99,7 @@ struct QuickAddCoordinatorTests {
         recorder.savedSpellings.append(spelling)
         return nil
       },
-      presentNewWordSheet: { recorder.sheetsFor.append($0) },
+      beginNewWord: { recorder.beganNewWord += 1 },
       emit: { recorder.events.append($0) },
       now: {
         clock.addTimeInterval(0.01)
@@ -507,19 +510,19 @@ struct QuickAddCoordinatorTests {
 
   // MARK: - The other two endings
 
-  @Test("Create-new opens the edit sheet on the heard spelling")
-  func createNewOpensTheSheet() throws {
+  @Test("Create-new moves the panel to its compose stage and writes nothing")
+  func createNewBeginsComposing() throws {
     let (coordinator, recorder) = makeCoordinator()
     let model = try #require(beginAndShow(coordinator))
 
     coordinator.createNew(from: model)
 
-    #expect(recorder.sheetsFor == ["codecs"])
-    // `createdNew` deliberately does NOT fire here any more — opening a sheet is an intention, and
-    // emitting on the click double-counted every open where the user then cancelled. The outcome is
+    #expect(recorder.beganNewWord == 1)
+    // `createdNew` deliberately does NOT fire here — reaching the compose field is an intention, and
+    // emitting on the click double-counted every open where the user then backed out. The outcome is
     // asserted in `didCreateNewResolvesOnce`, after the save is confirmed.
     #expect(recorder.outcomes.isEmpty)
-    #expect(recorder.saved.isEmpty, "the sheet writes, not this")
+    #expect(recorder.saved.isEmpty, "composing writes nothing")
   }
 
   @Test("Cancelling writes nothing and says so")
@@ -618,7 +621,7 @@ struct QuickAddCoordinatorTests {
 
     coordinator.createNew(from: model)
 
-    #expect(recorder.sheetsFor == ["codecs"])
+    #expect(recorder.beganNewWord == 1)
     #expect(recorder.outcomes.isEmpty)
   }
 

--- a/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
@@ -775,6 +775,35 @@ struct QuickAddCoordinatorTests {
         canonicalExistedBefore: true) == .alreadyComplete)
   }
 
+  /// **The argument that CLOSES the class, so it is a test rather than a paragraph.**
+  ///
+  /// Root B of this branch's review rounds is "an outcome that keeps the panel open must name an
+  /// action the panel can perform". The panel opened WITHOUT a readable selection cannot perform
+  /// any: its ranking is empty and its search field disabled by construction. So the enumeration is
+  /// only closed if no panel-keeping outcome is REACHABLE from that state.
+  ///
+  /// `.refused` is the only panel-keeping outcome, and it needs a missing spelling. With no heard
+  /// word `QuickAddPanelModel.draftWord` attaches no alias, so `keptSpellings` is empty, so
+  /// `missingSpellings` is empty, so `.refused` cannot arise. That chain is three files long and
+  /// entirely invisible from either end — which is exactly the kind of claim that decays into a
+  /// comment nobody rechecks.
+  @Test("A no-selection panel cannot reach an outcome that keeps it open")
+  func aRefusalPanelCannotReachAPanelKeepingOutcome() {
+    // What `draftWord` produces with no heard spelling: a word carrying no aliases.
+    let authored = CustomWord(canonical: "Qwen", aliases: [])
+    let kept = authored.aliases
+      .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+      .filter { !$0.isEmpty }
+    #expect(kept.isEmpty, "no heard spelling means nothing to keep")
+
+    // Every canonical-existed value, since that is the only other axis.
+    for existedBefore in [true, false] {
+      let outcome = QuickAddWiring.newWordOutcome(
+        keptSpellings: kept, missingSpellings: [], canonicalExistedBefore: existedBefore)
+      #expect(outcome != .refused, "a state with no way forward must not keep the panel open")
+    }
+  }
+
   /// The paired NEGATIVE, and it is what stops the change above collapsing the enum: `.refused` is
   /// still reachable, and it is reachable for the one reason that outranks everything — a spelling
   /// the user typed that is not on the word afterwards is a lost edit, whatever else is true.

--- a/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
@@ -889,4 +889,46 @@ struct QuickAddCoordinatorTests {
     // Nothing on screen wins outright. A stale live flag with no panel must not wedge the shortcut.
     #expect(QuickAddWiring.mayBeginCapture(panelVisible: false, hasLiveInvocation: true))
   }
+
+  // MARK: - What a VoiceOver user hears (#2391, confirming round)
+
+  /// **A spoken confirmation that differs from the visible one is two answers to "what happened",
+  /// and the blind user has no way to notice.** So the announcement is not a paraphrase — it is the
+  /// string the view renders, and this asserts that rather than trusting one derivation.
+  @Test("Every message the panel shows is spoken with the words it shows")
+  func theAnnouncementIsTheRenderedSentence() {
+    for kind in QuickAddPanelModel.Notice.Kind.allCases {
+      let notice = QuickAddPanelModel.Notice(
+        kind: kind,
+        spelling: [.created, .alreadyInWords].contains(kind) ? "" : "codecs",
+        word: "Codex", searchable: false)
+      #expect(
+        QuickAddWiring.announcement(notice: notice, writeFailure: nil)
+          == QuickAddPanelCopy.notice(notice))
+    }
+    #expect(
+      QuickAddWiring.announcement(notice: nil, writeFailure: "That word cannot be saved.")
+        == QuickAddPanelCopy.writeFailure("That word cannot be saved."))
+  }
+
+  /// The member the confirming round did NOT name, found by enumerating the channel axis rather than
+  /// fixing the two sites it did name. A refusal is the only message the user has to ACT on, and it
+  /// appears after a keypress while focus sits in the search field — so it is a dynamic status
+  /// change with nothing focused on it, exactly like the two notices.
+  @Test("A refusal is spoken too, and outranks a notice")
+  func aRefusalIsSpokenAndOutranksANotice() {
+    let notice = QuickAddPanelModel.Notice(
+      kind: .saved, spelling: "codecs", word: "Codex", searchable: false)
+
+    #expect(
+      QuickAddWiring.announcement(notice: notice, writeFailure: "nope")
+        == QuickAddPanelCopy.writeFailure("nope"))
+  }
+
+  /// The panel ASKING is not the panel TELLING. A ranked list with nothing refused and no notice has
+  /// no status change to announce, and speaking there would talk over the user exploring the rows.
+  @Test("A panel that is asking rather than telling says nothing")
+  func aPanelThatIsAskingAnnouncesNothing() {
+    #expect(QuickAddWiring.announcement(notice: nil, writeFailure: nil) == nil)
+  }
 }

--- a/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
@@ -352,9 +352,9 @@ struct QuickAddCoordinatorTests {
 
     recorder.userWords = []
 
-    let message = coordinator.accept(target, from: model)
+    let result = coordinator.accept(target, from: model)
 
-    #expect(message == QuickAddPanelCopy.wordNoLongerExists)
+    #expect(result == .refused(QuickAddPanelCopy.wordNoLongerExists))
     #expect(recorder.saved.isEmpty, "nothing may be written for a word that is gone")
     #expect(
       recorder.outcomes.isEmpty,
@@ -395,13 +395,13 @@ struct QuickAddCoordinatorTests {
     let model = try #require(beginAndShow(coordinator))
     let target = try #require(model.ranking.candidates.first)
 
-    let message = coordinator.accept(target, from: model)
+    let result = coordinator.accept(target, from: model)
 
     // The RETURNED message is the assertion that matters, and the first version of this test did
     // not make it. It asserted the TELEMETRY outcome, which is a fact about a dashboard; what the
     // comment above promises — "the user must be told" — is only true if the caller is handed
     // something to show, and the caller dismissed the panel regardless until this was added.
-    #expect(message == "That word cannot be saved.")
+    #expect(result == .refused("That word cannot be saved."))
     #expect(recorder.events.contains { if case .failed = $0 { true } else { false } })
     // NOT resolved. The panel is still open, so the invocation has not ended — `resolved` means
     // ENDED, and the second version of this test asserted `[.writeFailed]` here, which was the
@@ -452,29 +452,55 @@ struct QuickAddCoordinatorTests {
       })
   }
 
-  @Test("A save that succeeds returns nothing to show, which is what licenses the dismiss")
-  func aSuccessfulWriteReturnsNil() throws {
+  @Test("A save that succeeds names the word it wrote to")
+  func aSuccessfulWriteNamesItsTarget() throws {
     // The paired accepted case for the refusal above. Without it the caller could dismiss on any
-    // non-nil-ness rule and still pass, and a check that never classifies anything looks clean.
+    // non-refusal rule and still pass, and a check that never classifies anything looks clean.
+    //
+    // The NAME is what the panel's confirmation quotes, so a result that merely said "fine" would
+    // send the caller back to the row the user clicked — a snapshot taken when the panel opened.
     let (coordinator, recorder) = makeCoordinator(userWords: [word("Codex")])
     let model = try #require(beginAndShow(coordinator))
     let target = try #require(model.ranking.candidates.first)
 
-    #expect(coordinator.accept(target, from: model) == nil)
+    #expect(coordinator.accept(target, from: model) == .saved(word: "Codex"))
     #expect(recorder.outcomes == [.accepted])
   }
 
-  @Test("A word that already carries the spelling returns nothing to show")
-  func alreadySavedReturnsNil() throws {
-    // Nothing went wrong, so there is nothing to keep the panel open for. Distinguished from the
-    // refusal above only by the return value, which is why both are asserted.
+  @Test("A word that already carries the spelling reports that, not a save")
+  func alreadySavedIsDistinctFromSaved() throws {
+    // Nothing went wrong, so there is nothing to keep the panel open for — and nothing was written,
+    // so a confirmation reading `"codecs" added to Codex` would be a false sentence. The two
+    // successes are distinguished HERE because the caller cannot tell them apart: the row's
+    // `alreadyHasHeardSpelling` is the ranking's snapshot, and the decision is made live.
     let (coordinator, recorder) = makeCoordinator(
       selection: .text("codecs"), userWords: [word("Codex", aliases: ["codecs"])])
     let model = try #require(beginAndShow(coordinator))
     let target = try #require(model.ranking.candidates.first)
 
-    #expect(coordinator.accept(target, from: model) == nil)
+    #expect(coordinator.accept(target, from: model) == .alreadyHad(word: "Codex"))
     #expect(recorder.outcomes == [.alreadySaved])
+  }
+
+  /// **The staleness the confirmation could reintroduce, in the direction that matters.** The row
+  /// said `already has this` when the panel opened; the user then removed that alias in Settings and
+  /// pressed Return. The write happens, and a confirmation composed from the snapshot would tell
+  /// them nothing was added.
+  @Test("The result follows the live library, never the row the user clicked")
+  func theResultIsLiveNotSnapshotted() throws {
+    let (coordinator, recorder) = makeCoordinator(
+      selection: .text("codecs"), userWords: [word("Codex", aliases: ["codecs"])])
+    let model = try #require(beginAndShow(coordinator))
+    let target = try #require(model.ranking.candidates.first)
+    #expect(target.alreadyHasHeardSpelling, "the snapshot says there is nothing to add")
+
+    // The user deletes that spelling in Settings while the panel sits open.
+    recorder.userWords = [
+      CustomWord(id: target.word.id, canonical: "Codex", aliases: [])
+    ]
+
+    #expect(coordinator.accept(target, from: model) == .saved(word: "Codex"))
+    #expect(recorder.outcomes == [.accepted])
   }
 
   @Test("Accepting after searching is a distinct outcome from accepting the top row")
@@ -768,5 +794,29 @@ struct QuickAddCoordinatorTests {
       QuickAddWiring.newWordOutcome(
         keptSpellings: ["codecs"], missingSpellings: ["codecs"], canonicalExistedBefore: true)
         == .refused)
+  }
+
+  // MARK: - Whether a second press starts a fresh capture (#2391 §1)
+
+  /// **The regression the confirmation could have introduced, and it lands on the commonest way to
+  /// use this feature: adding two words in a row.**
+  ///
+  /// A confirmation stays on screen for two seconds after Return, with the invocation already
+  /// resolved. A visibility test alone would raise that confirmation and refuse the new capture —
+  /// indistinguishable, from the user's side, from the shortcut not firing.
+  ///
+  /// Paired with the case it must NOT break: a genuinely live panel still raises rather than
+  /// throwing away the selection the user already made, which is the #2381 fix this sits beside.
+  @Test("A fading confirmation yields to a new capture; a live panel does not")
+  func aFadingConfirmationDoesNotBlockTheNextCapture() {
+    #expect(
+      QuickAddWiring.mayBeginCapture(panelVisible: true, hasLiveInvocation: false),
+      "a resolved panel is a confirmation fading out, not a capture in progress")
+    #expect(
+      !QuickAddWiring.mayBeginCapture(panelVisible: true, hasLiveInvocation: true),
+      "a live panel is raised, never re-captured against our own window")
+    #expect(QuickAddWiring.mayBeginCapture(panelVisible: false, hasLiveInvocation: false))
+    // Nothing on screen wins outright. A stale live flag with no panel must not wedge the shortcut.
+    #expect(QuickAddWiring.mayBeginCapture(panelVisible: false, hasLiveInvocation: true))
   }
 }

--- a/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
@@ -482,6 +482,38 @@ struct QuickAddCoordinatorTests {
     #expect(recorder.outcomes == [.alreadySaved])
   }
 
+  /// **A word IS its canonical, so selecting that text adds nothing.** The live guard read the
+  /// aliases only, so this appended the canonical as an alias of itself and reported a save — a
+  /// junk write into the user's words file under a sentence reading `"Codex" added to Codex`.
+  ///
+  /// The fixture has NO aliases deliberately: with one, the row could pass on the alias check and
+  /// the canonical comparison would never be reached, which is the shape that lets a guard look
+  /// covered while asserting nothing.
+  @Test("Selecting a word's own canonical reports that it is already there, and writes nothing")
+  func theCanonicalCountsAsAlreadyCovered() throws {
+    let (coordinator, recorder) = makeCoordinator(
+      selection: .text("Codex"), userWords: [word("Codex")])
+    let model = try #require(beginAndShow(coordinator))
+    let target = try #require(model.ranking.candidates.first)
+
+    #expect(coordinator.accept(target, from: model) == .alreadyHad(word: "Codex"))
+    #expect(recorder.outcomes == [.alreadySaved])
+    #expect(
+      recorder.saved.isEmpty,
+      "nothing may be written: a canonical is already the spelling it is being asked to carry")
+  }
+
+  /// **Case-insensitively, matching the ranker and the alias check either side of it.**
+  @Test("A differently-cased canonical is still already covered")
+  func theCanonicalComparisonIgnoresCase() throws {
+    let (coordinator, _) = makeCoordinator(
+      selection: .text("codex"), userWords: [word("Codex")])
+    let model = try #require(beginAndShow(coordinator))
+    let target = try #require(model.ranking.candidates.first)
+
+    #expect(coordinator.accept(target, from: model) == .alreadyHad(word: "Codex"))
+  }
+
   /// **The staleness the confirmation could reintroduce, in the direction that matters.** The row
   /// said `already has this` when the panel opened; the user then removed that alias in Settings and
   /// pressed Return. The write happens, and a confirmation composed from the snapshot would tell

--- a/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
@@ -932,72 +932,19 @@ struct QuickAddCoordinatorTests {
     #expect(QuickAddWiring.announcement(notice: nil, writeFailure: nil) == nil)
   }
 
-  // MARK: - Where the keyboard goes when the panel gives it up (#2391, r6)
+  // MARK: - Focus hand-back: REMOVED (#2391, founder 2026-08-25)
 
-  /// **This replaces three tests about who focus was TAKEN from, and the replacement is the point.**
-  ///
-  /// Those tests protected "give back exactly what you took", which needed the panel to remember —
-  /// and three review rounds each found another way for it to become key without recording anything:
-  /// a raise on an already-key panel, and a mouse click, with command-tab and the Dock waiting. That
-  /// set is AppKit's, so it has a next member however many are handled.
-  ///
-  /// The property is now structural rather than asserted: nothing is remembered, so nothing can be
-  /// stale. What remains to test is the one closed decision.
-  @Test("The keyboard goes back to whatever actually had it")
-  func theKeyboardGoesWhereItBelongs() {
-    #expect(
-      QuickAddPanelHost.focusRelease(origin: .ourWindow) == .handToOurOwnWindow,
-      "a window of OURS had it, so deactivating would hide the user's own window")
-    #expect(
-      QuickAddPanelHost.focusRelease(origin: .otherApp) == .deactivateApp)
-  }
-
-  /// **The refutation that killed the previous version, kept as a case so it cannot come back.**
-  /// That version asked "do we have another window on screen", which is closed and WRONG: leave
-  /// Settings open BEHIND TextEdit, invoke the shortcut from TextEdit, and a window-list answer
-  /// sends the keyboard to Settings. Having a window is not the same fact as having come from it.
-  @Test("A visible window of ours is not evidence the user came from it")
-  func aVisibleWindowIsNotProvenance() {
-    // The state that case produces: our window exists and is visible, and the origin is another app.
-    #expect(QuickAddPanelHost.focusRelease(origin: .otherApp) == .deactivateApp)
-  }
-
-  /// **The refutation of the instant argument, kept so "a second press is the same invocation"
-  /// cannot come back.** `windowDidResignKey` is a no-op, so the panel sits visible and unfocused
-  /// while the user works elsewhere. A shortcut press in that state takes focus from somewhere new,
-  /// and reusing the first press's origin sends the keyboard to an app the user has left.
-  @Test("A press while the panel is visible but unfocused records a new origin")
-  func aRaiseOntoAnUnfocusedPanelRecapturesTheOrigin() {
-    #expect(QuickAddPanelHost.shouldCaptureOrigin(panelIsKey: false))
-    #expect(
-      !QuickAddPanelHost.shouldCaptureOrigin(panelIsKey: true),
-      "already holding focus means nothing is being taken, so the standing record still holds")
-  }
-
-  /// **The gate is what stops a fade re-raising a window the user has left.** After a confirmation
-  /// the beat has already released, so the panel is not key when the fade fires.
-  @Test("Dismissal hands focus back only when the panel is actually holding it")
-  func dismissalReleasesOnlyWhatItHolds() {
-    #expect(QuickAddPanelHost.shouldReleaseOnDismiss(panelIsKey: true))
-    #expect(!QuickAddPanelHost.shouldReleaseOnDismiss(panelIsKey: false))
-  }
-
-  /// **The case AppKit's own notifications got wrong, kept so the observer version cannot return.**
-  /// `NSApp.activate` can make Settings key on its way to activating us, so a notification observer
-  /// records `.ourWindow` for an invocation that started in TextEdit. Capturing before anything
-  /// activates is what makes the answer `.otherApp`, and this asserts the consequence.
-  @Test("Our own activation cannot turn an external origin into one of our windows")
-  func ourOwnActivationDoesNotRewriteTheOrigin() {
-    #expect(QuickAddPanelHost.focusRelease(origin: .otherApp) == .deactivateApp)
-  }
-
-  /// Unknown deactivates, and the asymmetry is the point: guessing "our window" when the user came
-  /// from another app eats the keystrokes this mechanism exists to protect, while guessing
-  /// "deactivate" when they were in our app costs a click.
-  @Test("With nothing observed the panel gives the keyboard back rather than keeping it")
-  func anUnknownOriginDeactivates() {
-    #expect(QuickAddPanelHost.focusRelease(origin: .unknown) == .deactivateApp)
-  }
+  // **The focus-return tests are GONE with the mechanism they guarded (founder, 2026-08-25).**
+  // `theKeyboardGoesWhereItBelongs`, `aVisibleWindowIsNotProvenance`,
+  // `ourOwnActivationDoesNotRewriteTheOrigin`, `aRaiseOntoAnUnfocusedPanelRecapturesTheOrigin`,
+  // `dismissalReleasesOnlyWhatItHolds` and `anUnknownOriginDeactivates` all asserted decisions about
+  // where to hand the keyboard back, and there is no longer anywhere to hand it back to.
+  //
+  // Per `deleting-a-test-carries-the-burden-of-adding-one`: what they protected was the correctness
+  // of a mechanism that has been REMOVED, not a user-facing outcome that still exists. The three
+  // refutations they carried — a visible window is not provenance, our own activation must not
+  // rewrite the origin, a second press onto an unfocused panel is a new origin — were all facts
+  // about that mechanism. Nothing else asserts them because nothing else needs them.
 
   // MARK: - The created confirmation names what was written (#2391, r5)
 

--- a/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
@@ -638,10 +638,10 @@ struct QuickAddCoordinatorTests {
     #expect(!model.ranking.candidates.isEmpty)
   }
 
-  @Test("Opening the new-word sheet resolves nothing, because an intention is not an outcome")
+  @Test("Reaching the compose field resolves nothing, because an intention is not an outcome")
   func createNewDoesNotResolve() throws {
-    // Emitting createdNew on the click counted opening a sheet as a save: cancelling the sheet left
-    // the panel up, and cancelling the panel then emitted a SECOND resolved event for one open.
+    // Emitting createdNew on the click counted the INTENTION as a save: backing out left the
+    // panel up, and cancelling the panel then emitted a SECOND resolved event for one open.
     let (coordinator, recorder) = makeCoordinator(userWords: [word("Codex")])
     let model = try #require(beginAndShow(coordinator))
 
@@ -651,8 +651,8 @@ struct QuickAddCoordinatorTests {
     #expect(recorder.outcomes.isEmpty)
   }
 
-  @Test("Cancelling after opening the sheet resolves exactly once, as cancelled")
-  func cancellingAfterTheSheetResolvesOnce() throws {
+  @Test("Cancelling after reaching the compose field resolves exactly once, as cancelled")
+  func cancellingAfterComposingResolvesOnce() throws {
     let (coordinator, recorder) = makeCoordinator(userWords: [word("Codex")])
     let model = try #require(beginAndShow(coordinator))
 
@@ -706,8 +706,11 @@ struct QuickAddCoordinatorTests {
 
   @Test("A confirmed new word resolves even when the panel has already gone")
   func createdNewResolvesWithoutAModel() throws {
-    // The sheet outlives the panel in at least one ordering, and the call site used to read
-    // `if let model = activeModel`, so a CONFIRMED save emitted nothing at all.
+    // The call site used to read `if let model = activeModel`, so a CONFIRMED save emitted
+    // nothing at all. **The ordering that made this reachable is gone** — composing is a stage
+    // of the panel now, and a stage cannot outlive it, which is why `usedSearch` is read live.
+    // Kept because the coordinator is still callable this way and the funnel hole it closed is
+    // the expensive kind: a save that happened and was never counted.
     let (coordinator, recorder) = makeCoordinator(userWords: [word("Codex")])
     let model = try #require(beginAndShow(coordinator))
     coordinator.createNew(from: model)
@@ -733,12 +736,14 @@ struct QuickAddCoordinatorTests {
     #expect(recorder.savedSpellings == ["codecs"])
     #expect(recorder.saved.first?.aliases.contains("codecs") == true)
   }
-  // MARK: - Did the sheet's save actually produce a word (#2381, cloud review)
+  // MARK: - Did the create actually produce a word (#2381, cloud review)
 
   @Test("A blank-alias save onto an existing canonical is refused")
   func blankAliasOntoExistingCanonicalIsRefused() {
     // The state the inline version could not see. Quick Add opened without a readable selection has
-    // no heard spelling, so the sheet starts with one BLANK alias and there is nothing to confirm.
+    // no heard spelling, so there is nothing to confirm. The sheet reached it by starting with one
+    // BLANK alias; `QuickAddPanelModel.draftWord` now refuses to build one, so the compose route no
+    // longer arrives here — this guard covers the OUTCOME rule, which every route still shares.
     // The postcondition asked "did the kept spellings land", which is vacuously true of none — so a
     // canonical that already existed took the success path while `add` silently no-oped. Nothing was
     // created and the panel closed saying nothing.

--- a/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
@@ -931,4 +931,49 @@ struct QuickAddCoordinatorTests {
   func aPanelThatIsAskingAnnouncesNothing() {
     #expect(QuickAddWiring.announcement(notice: nil, writeFailure: nil) == nil)
   }
+
+  // MARK: - What a focus-taking call actually takes (#2391, r5)
+
+  /// **The case a SECOND shortcut press lands on, and the one that takes nothing.**
+  ///
+  /// Making one owner for taking focus was right; writing it as if every call takes something was
+  /// not. Raising an already-key panel recomputes "were we active" as true — because THIS PANEL made
+  /// it true — so the debt owed to the app the user actually came from is discarded, and the
+  /// confirmation then leaves us active with their next keystrokes going nowhere.
+  @Test("Raising an already-key panel takes nothing, so the standing debt survives")
+  func raisingAnAlreadyKeyPanelTakesNothing() {
+    #expect(
+      QuickAddPanelHost.focusTake(wasActive: true, keyWindowIsThePanel: true) == .nothing)
+  }
+
+  /// The paired positives, without which a rule that never classifies anything looks clean.
+  @Test("Every other combination names what it took")
+  func everyOtherCombinationNamesWhatItTook() {
+    // Not active: both came from outside, whatever held key.
+    #expect(
+      QuickAddPanelHost.focusTake(wasActive: false, keyWindowIsThePanel: false) == .fromAnotherApp)
+    #expect(
+      QuickAddPanelHost.focusTake(wasActive: false, keyWindowIsThePanel: true) == .fromAnotherApp)
+    // Active, and one of OUR windows held key — Settings, reachable because the shortcut is global.
+    #expect(
+      QuickAddPanelHost.focusTake(wasActive: true, keyWindowIsThePanel: false) == .fromOurOwnWindow)
+  }
+
+  // MARK: - The created confirmation names what was written (#2391, r5)
+
+  /// **Selecting a word that is already spelled correctly and authoring it is ordinary**, and
+  /// `draftWord` correctly declines to store a word as an alias of itself. Choosing the sentence by
+  /// "was the selection non-empty" then claims an add that did not happen.
+  @Test("A word created with no alias attached is not confirmed as a spelling that was added")
+  func aSelfNamedCreationDoesNotClaimAnAdd() {
+    let model = QuickAddPanelModel(
+      heard: "Claude", refusal: nil, rankHeard: { _ in .empty }, searchLibrary: { _, _ in .empty })
+    model.beginComposing()
+    model.updateDraft("Claude")
+    let authored = model.draftWord
+
+    #expect(authored?.aliases.isEmpty == true, "a word is not an alias of itself")
+    // The selection is NON-empty, which is exactly what the old rule read.
+    #expect(!model.spellingToWrite.isEmpty)
+  }
 }

--- a/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
@@ -962,6 +962,26 @@ struct QuickAddCoordinatorTests {
     #expect(QuickAddPanelHost.focusRelease(origin: .otherApp) == .deactivateApp)
   }
 
+  /// **The refutation of the instant argument, kept so "a second press is the same invocation"
+  /// cannot come back.** `windowDidResignKey` is a no-op, so the panel sits visible and unfocused
+  /// while the user works elsewhere. A shortcut press in that state takes focus from somewhere new,
+  /// and reusing the first press's origin sends the keyboard to an app the user has left.
+  @Test("A press while the panel is visible but unfocused records a new origin")
+  func aRaiseOntoAnUnfocusedPanelRecapturesTheOrigin() {
+    #expect(QuickAddPanelHost.shouldCaptureOrigin(panelIsKey: false))
+    #expect(
+      !QuickAddPanelHost.shouldCaptureOrigin(panelIsKey: true),
+      "already holding focus means nothing is being taken, so the standing record still holds")
+  }
+
+  /// **The gate is what stops a fade re-raising a window the user has left.** After a confirmation
+  /// the beat has already released, so the panel is not key when the fade fires.
+  @Test("Dismissal hands focus back only when the panel is actually holding it")
+  func dismissalReleasesOnlyWhatItHolds() {
+    #expect(QuickAddPanelHost.shouldReleaseOnDismiss(panelIsKey: true))
+    #expect(!QuickAddPanelHost.shouldReleaseOnDismiss(panelIsKey: false))
+  }
+
   /// **The case AppKit's own notifications got wrong, kept so the observer version cannot return.**
   /// `NSApp.activate` can make Settings key on its way to activating us, so a notification observer
   /// records `.ourWindow` for an invocation that started in TextEdit. Capturing before anything

--- a/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
@@ -738,18 +738,54 @@ struct QuickAddCoordinatorTests {
   }
   // MARK: - Did the create actually produce a word (#2381, cloud review)
 
-  @Test("A blank-alias save onto an existing canonical is refused")
-  func blankAliasOntoExistingCanonicalIsRefused() {
-    // The state the inline version could not see. Quick Add opened without a readable selection has
-    // no heard spelling, so there is nothing to confirm. The sheet reached it by starting with one
-    // BLANK alias; `QuickAddPanelModel.draftWord` now refuses to build one, so the compose route no
-    // longer arrives here — this guard covers the OUTCOME rule, which every route still shares.
-    // The postcondition asked "did the kept spellings land", which is vacuously true of none — so a
-    // canonical that already existed took the success path while `add` silently no-oped. Nothing was
-    // created and the panel closed saying nothing.
+  @Test("A no-spelling save onto an existing canonical is its own outcome, not a refusal")
+  func noSpellingOntoExistingCanonicalIsAlreadyPresent() {
+    // **This cell was `.refused` and its REASON has been removed rather than overruled.** The
+    // postcondition asks "did the kept spellings land", which is vacuously true of none — so a
+    // canonical that already existed took the success path while `add` silently no-oped, and the
+    // panel closed saying nothing. Refusing was how that silence was made audible.
+    //
+    // #2391 §1 gave the panel something to say on EVERY ending, so the silence is gone and the
+    // refusal became a dead end: only the panel opened WITHOUT a readable selection can produce this
+    // cell, its ranking is empty and its search field disabled by construction, and the refusal's
+    // copy told the user to choose the word from a list that cannot exist there.
+    //
+    // Nothing is wrong in this state. They asked for the word to be in their words, and it is.
+    //
+    // **It did NOT become `.alreadyComplete`, and the case below is why.** Renaming the cell is a
+    // claim about the panel; merging it is a claim about the postcondition, and only the first is
+    // true.
     #expect(
       QuickAddWiring.newWordOutcome(
-        keptSpellings: [], missingSpellings: [], canonicalExistedBefore: true) == .refused)
+        keptSpellings: [], missingSpellings: [], canonicalExistedBefore: true) == .alreadyPresent)
+  }
+
+  /// **The distinction round three drew, restated as the thing that must not collapse.** The
+  /// no-spelling cell has nothing for `alreadyComplete`'s postcondition to confirm, which is why it
+  /// was split out; folding the two together makes that postcondition vacuous exactly where it
+  /// already was once. A guard on #2403 mutates one into the other, and this is the test it fires.
+  @Test("The two already-there cells stay distinct, because only one has a spelling to confirm")
+  func theTwoAlreadyThereCellsAreDistinct() {
+    #expect(
+      QuickAddWiring.newWordOutcome(
+        keptSpellings: [], missingSpellings: [], canonicalExistedBefore: true) == .alreadyPresent)
+    #expect(
+      QuickAddWiring.newWordOutcome(
+        keptSpellings: ["codecs"], missingSpellings: [],
+        canonicalExistedBefore: true) == .alreadyComplete)
+  }
+
+  /// The paired NEGATIVE, and it is what stops the change above collapsing the enum: `.refused` is
+  /// still reachable, and it is reachable for the one reason that outranks everything — a spelling
+  /// the user typed that is not on the word afterwards is a lost edit, whatever else is true.
+  @Test("A missing spelling is still refused, whatever else holds")
+  func aMissingSpellingIsStillRefused() {
+    for existedBefore in [true, false] {
+      #expect(
+        QuickAddWiring.newWordOutcome(
+          keptSpellings: ["codecs"], missingSpellings: ["codecs"],
+          canonicalExistedBefore: existedBefore) == .refused)
+    }
   }
 
   @Test("A blank-alias save of a genuinely new canonical IS a creation")

--- a/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
@@ -943,14 +943,31 @@ struct QuickAddCoordinatorTests {
   ///
   /// The property is now structural rather than asserted: nothing is remembered, so nothing can be
   /// stale. What remains to test is the one closed decision.
-  @Test("The keyboard goes to our own window when we have one, and to the app behind us otherwise")
+  @Test("The keyboard goes back to whatever actually had it")
   func theKeyboardGoesWhereItBelongs() {
     #expect(
-      QuickAddPanelHost.focusRelease(hasOtherKeyableWindow: true) == .handToOurOwnWindow,
-      "another window of ours means the user is inside our app; deactivating would hide it")
+      QuickAddPanelHost.focusRelease(origin: .ourWindow) == .handToOurOwnWindow,
+      "a window of OURS had it, so deactivating would hide the user's own window")
     #expect(
-      QuickAddPanelHost.focusRelease(hasOtherKeyableWindow: false) == .deactivateApp,
-      "the panel alone means the user came from another app")
+      QuickAddPanelHost.focusRelease(origin: .otherApp) == .deactivateApp)
+  }
+
+  /// **The refutation that killed the previous version, kept as a case so it cannot come back.**
+  /// That version asked "do we have another window on screen", which is closed and WRONG: leave
+  /// Settings open BEHIND TextEdit, invoke the shortcut from TextEdit, and a window-list answer
+  /// sends the keyboard to Settings. Having a window is not the same fact as having come from it.
+  @Test("A visible window of ours is not evidence the user came from it")
+  func aVisibleWindowIsNotProvenance() {
+    // The state that case produces: our window exists and is visible, and the origin is another app.
+    #expect(QuickAddPanelHost.focusRelease(origin: .otherApp) == .deactivateApp)
+  }
+
+  /// Unknown deactivates, and the asymmetry is the point: guessing "our window" when the user came
+  /// from another app eats the keystrokes this mechanism exists to protect, while guessing
+  /// "deactivate" when they were in our app costs a click.
+  @Test("With nothing observed the panel gives the keyboard back rather than keeping it")
+  func anUnknownOriginDeactivates() {
+    #expect(QuickAddPanelHost.focusRelease(origin: .unknown) == .deactivateApp)
   }
 
   // MARK: - The created confirmation names what was written (#2391, r5)

--- a/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelCopyTests.swift
+++ b/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelCopyTests.swift
@@ -156,6 +156,7 @@ struct QuickAddPanelCopyTests {
         QuickAddPanelCopy.savedNotice(spelling: "codecs", word: "Codex"),
         QuickAddPanelCopy.nothingToAddNotice(spelling: "codecs", word: "Codex"),
         QuickAddPanelCopy.createdNotice(word: "Codex"),
+        QuickAddPanelCopy.alreadyInWordsNotice(word: "Codex"),
       ]
 
     for text in all {
@@ -306,7 +307,11 @@ struct QuickAddPanelCopyTests {
     for kind in QuickAddPanelModel.Notice.Kind.allCases {
       let text = QuickAddPanelCopy.notice(
         QuickAddPanelModel.Notice(
-          kind: kind, spelling: kind == .created ? "" : "codecs", word: "Codex",
+          kind: kind,
+          // The two no-selection kinds carry no spelling BY CONSTRUCTION, so handing them one would
+          // test a value the app cannot produce and hide a sentence that quotes an empty string.
+          spelling: [.created, .alreadyInWords].contains(kind) ? "" : "codecs",
+          word: "Codex",
           searchable: false))
       #expect(!text.isEmpty, "\(kind) renders nothing")
       #expect(!text.contains("\"\""), "\(kind) quotes an empty string")
@@ -315,5 +320,23 @@ struct QuickAddPanelCopyTests {
     #expect(
       rendered.count == QuickAddPanelModel.Notice.Kind.allCases.count,
       "two kinds render the same sentence")
+  }
+
+  /// **The state the refusal used to own, and the reason it must not read as a failure.** The panel
+  /// that reaches this opened WITHOUT a readable selection, so its ranking is empty and its search
+  /// field disabled — the old copy told the user to choose the word from a list that cannot exist.
+  @Test("A word already in the library is reported plainly, naming no route the user cannot take")
+  func alreadyInWordsNamesNoImpossibleRoute() {
+    let text = QuickAddPanelCopy.alreadyInWordsNotice(word: "Codex")
+
+    #expect(text.contains("Codex"))
+    #expect(!text.contains("\"\""))
+    // Same term set the refusal guard uses, for the same reason one layer over: with no heard word
+    // there is nothing to rank, so every one of these names a control that is not on screen.
+    for pointsAtTheList in ["choose", "list", "search", "pick", "select"] {
+      #expect(
+        !text.lowercased().contains(pointsAtTheList),
+        "says \(pointsAtTheList), which names a control this state does not have")
+    }
   }
 }

--- a/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelCopyTests.swift
+++ b/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelCopyTests.swift
@@ -153,6 +153,9 @@ struct QuickAddPanelCopyTests {
         QuickAddPanelCopy.composeHeader(heard: ""),
         QuickAddPanelCopy.composePlaceholder(heard: "clawwed"),
         QuickAddPanelCopy.composePlaceholder(heard: ""),
+        QuickAddPanelCopy.savedNotice(spelling: "codecs", word: "Codex"),
+        QuickAddPanelCopy.nothingToAddNotice(spelling: "codecs", word: "Codex"),
+        QuickAddPanelCopy.createdNotice(word: "Codex"),
       ]
 
     for text in all {
@@ -251,5 +254,66 @@ struct QuickAddPanelCopyTests {
     #expect(QuickAddPanelCopy.legendBack != QuickAddPanelCopy.legendClose)
     #expect(!QuickAddPanelCopy.legendBack.isEmpty)
     #expect(QuickAddPanelCopy.legendCreate != QuickAddPanelCopy.legendAccept)
+  }
+
+  // MARK: - Saying what happened (#2391 §1 and §3)
+
+  /// **States what happened to the LIBRARY and promises nothing about future behaviour.** "will be
+  /// corrected from now on" is a sentence the code cannot back: a spelling belongs to one word, and
+  /// whether a future dictation reaches this one depends on the rest of the library.
+  @Test("The save confirmation names both the spelling and the word, and promises nothing else")
+  func theSaveConfirmationNamesBothHalves() {
+    let text = QuickAddPanelCopy.savedNotice(spelling: "codecs", word: "Codex")
+
+    #expect(text.contains("\"codecs\""))
+    #expect(text.contains("Codex"))
+    for promise in ["from now on", "will be", "always", "every time", "future"] {
+      #expect(!text.lowercased().contains(promise), "promises \(promise)")
+    }
+  }
+
+  /// The two successes must not read the same. Nothing was written in one of them, and a
+  /// confirmation that said otherwise would be the reported-success class this feature spent seven
+  /// review rounds closing, arriving through the sentence written to reassure the user.
+  @Test("Nothing-to-add does not read as a save")
+  func nothingToAddDoesNotClaimASave() {
+    let saved = QuickAddPanelCopy.savedNotice(spelling: "codecs", word: "Codex")
+    let nothing = QuickAddPanelCopy.nothingToAddNotice(spelling: "codecs", word: "Codex")
+
+    #expect(saved != nothing)
+    #expect(!nothing.lowercased().contains("added"))
+    #expect(nothing.contains("Codex"))
+    #expect(nothing.contains("\"codecs\""))
+  }
+
+  /// The state Create exists for: no readable selection, so no mishearing to name. A confirmation
+  /// quoting an empty string reads as a defect.
+  @Test("A word created with no spelling is confirmed without an empty quotation")
+  func theCreatedConfirmationQuotesNothing() {
+    let text = QuickAddPanelCopy.createdNotice(word: "Codex")
+
+    #expect(text.contains("Codex"))
+    #expect(!text.contains("\"\""))
+  }
+
+  /// **The dispatcher is the whole reason the model carries facts rather than a sentence.** Handing
+  /// a string in at the call site is how a new outcome ships wearing another one's wording; a
+  /// `switch` over a closed `Kind` makes the compiler ask instead. This asserts the mapping is
+  /// distinct and non-empty for every member, which is the property a `default:` would quietly lose.
+  @Test("Every notice kind renders its own sentence")
+  func everyNoticeKindHasItsOwnSentence() {
+    var rendered: Set<String> = []
+    for kind in QuickAddPanelModel.Notice.Kind.allCases {
+      let text = QuickAddPanelCopy.notice(
+        QuickAddPanelModel.Notice(
+          kind: kind, spelling: kind == .created ? "" : "codecs", word: "Codex",
+          searchable: false))
+      #expect(!text.isEmpty, "\(kind) renders nothing")
+      #expect(!text.contains("\"\""), "\(kind) quotes an empty string")
+      rendered.insert(text)
+    }
+    #expect(
+      rendered.count == QuickAddPanelModel.Notice.Kind.allCases.count,
+      "two kinds render the same sentence")
   }
 }

--- a/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelCopyTests.swift
+++ b/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelCopyTests.swift
@@ -148,6 +148,11 @@ struct QuickAddPanelCopyTests {
         // A member of the copy set like any other. Sweeping the SET rather than the strings that
         // existed when this was written is what makes a later addition visible here.
         QuickAddPanelCopy.writeFailure("That word cannot be saved."),
+        QuickAddPanelCopy.legendCreate, QuickAddPanelCopy.legendBack,
+        QuickAddPanelCopy.composeHeader(heard: "clawwed"),
+        QuickAddPanelCopy.composeHeader(heard: ""),
+        QuickAddPanelCopy.composePlaceholder(heard: "clawwed"),
+        QuickAddPanelCopy.composePlaceholder(heard: ""),
       ]
 
     for text in all {
@@ -213,5 +218,38 @@ struct QuickAddPanelCopyTests {
     // user tries, because any word corrected once scores 1.00 and lands here.
     #expect(!QuickAddPanelCopy.alreadyHasThisSpelling.contains("add"))
     #expect(QuickAddPanelCopy.alreadyHasThisSpelling.contains("already has"))
+  }
+
+  // MARK: - Composing a new word (#2391 §2)
+
+  /// **Two situations, two sentences.** With a selection the user is correcting a specific
+  /// mishearing; with none — the state where Create is the panel's only working control — there is
+  /// nothing to correct, and a header quoting an empty string reads as a bug.
+  @Test("The compose header quotes the selection, and says something else when there is none")
+  func composeHeaderAdaptsToTheSelection() {
+    #expect(QuickAddPanelCopy.composeHeader(heard: "clawwed").contains("\"clawwed\""))
+    let noSelection = QuickAddPanelCopy.composeHeader(heard: "")
+    #expect(!noSelection.contains("\"\""), "an empty quotation reads as a defect")
+    #expect(!noSelection.isEmpty)
+    #expect(noSelection != QuickAddPanelCopy.composeHeader(heard: "clawwed"))
+  }
+
+  @Test("The compose placeholder names the thing to type, in both situations")
+  func composePlaceholderNamesWhatToType() {
+    for heard in ["clawwed", ""] {
+      let text = QuickAddPanelCopy.composePlaceholder(heard: heard)
+      #expect(!text.isEmpty)
+      #expect(!text.contains("\"\""))
+    }
+  }
+
+  /// The legend is the keyboard contract made visible, so Escape's cap must state what Escape does
+  /// THERE. `close` over a field whose Escape returns to the list is the panel promising a key it
+  /// will not answer.
+  @Test("Escape is labelled back while composing, never close")
+  func escapeIsLabelledBackWhileComposing() {
+    #expect(QuickAddPanelCopy.legendBack != QuickAddPanelCopy.legendClose)
+    #expect(!QuickAddPanelCopy.legendBack.isEmpty)
+    #expect(QuickAddPanelCopy.legendCreate != QuickAddPanelCopy.legendAccept)
   }
 }

--- a/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelModelTests.swift
+++ b/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelModelTests.swift
@@ -519,4 +519,121 @@ struct QuickAddPanelModelTests {
 
     #expect(model.draftCanonical == "Qwen")
   }
+
+  // MARK: - Saying what happened and leaving (#2391 §1 and §3)
+
+  private func covered(_ canonical: String) -> QuickAddRanker.Candidate {
+    QuickAddRanker.Candidate(
+      word: CustomWord(canonical: canonical, aliases: ["codecs"]),
+      score: 1.0,
+      alreadyHasHeardSpelling: true)
+  }
+
+  private func rankingCovered(preselecting: Bool) -> QuickAddRanker.Ranking {
+    let rows = [covered("Codex"), candidate("Claude Code"), candidate("Qualtrics")]
+    return QuickAddRanker.Ranking(
+      candidates: rows, preselectedID: preselecting ? rows[0].id : nil)
+  }
+
+  /// The founder selected a word already covered and got a full picker offering nothing: a
+  /// highlighted row whose only action is a no-op, three unrelated words presented as choices, and a
+  /// dismissal he had to perform by hand — under a header that already said `nothing to add`.
+  @Test("Opening onto a covered word says so instead of offering a picker")
+  func openingOntoACoveredWordShowsANotice() throws {
+    let (model, _) = makeModel(heardRanking: rankingCovered(preselecting: true))
+
+    let notice = try #require(model.notice)
+    #expect(notice.kind == .nothingToAdd)
+    #expect(notice.word == "Codex")
+    #expect(notice.spelling == "codecs")
+    // The invocation has NOT resolved: the ranking can be wrong, and typing is how the user says so.
+    #expect(notice.searchable)
+  }
+
+  /// **Below the confidence bar nothing is preselected, and the user must choose.** A notice there
+  /// would answer a question the ranking deliberately refused to answer — and it would do it on the
+  /// strength of a row that was never offered as the answer.
+  @Test("A covered row that was not preselected does not shortcut the panel")
+  func anUnpreselectedCoveredRowStillShowsTheList() {
+    let (model, _) = makeModel(heardRanking: rankingCovered(preselecting: false))
+
+    #expect(model.stage == .picking)
+    #expect(model.notice == nil)
+  }
+
+  /// The escape hatch #2381 built for a wrong ranking has to survive a notice, or the notice becomes
+  /// a dead end the user can only escape by pressing the shortcut again and seeing it again.
+  @Test("Typing past the notice returns the full list")
+  func typingLeavesTheNotice() {
+    let (model, _) = makeModel(
+      heardRanking: rankingCovered(preselecting: true),
+      searchRanking: ranking(["Qualtrics"], preselecting: 0))
+
+    model.updateQuery("qual")
+
+    #expect(model.stage == .picking)
+    #expect(model.notice == nil)
+  }
+
+  /// The same trimming rule `isSearching` owns. A space bar is not the user saying the ranking was
+  /// wrong about them.
+  @Test("Whitespace does not count as typing past the notice")
+  func whitespaceDoesNotLeaveTheNotice() {
+    let (model, _) = makeModel(heardRanking: rankingCovered(preselecting: true))
+
+    model.updateQuery("   ")
+
+    #expect(model.notice?.searchable == true)
+  }
+
+  /// The search field is on screen and focused during a searchable notice, so both ways into the
+  /// list have to work. Only typing did — pressing Down watched nothing happen, on a panel visibly
+  /// offering the key.
+  @Test("An arrow past the notice opens the list, the same as typing")
+  func arrowsLeaveTheNotice() {
+    let (model, _) = makeModel(heardRanking: rankingCovered(preselecting: true))
+
+    model.moveHighlight(by: 1)
+
+    #expect(model.stage == .picking)
+    #expect(model.notice == nil)
+    #expect(model.acceptTarget != nil, "and the row it lands on is acceptable")
+  }
+
+  /// A notice is the panel saying it has nothing to ask. A Return arriving from anywhere while one
+  /// is up must not write to the row still sitting preselected behind it.
+  @Test("Return cannot accept a row behind a notice")
+  func aNoticeWithdrawsTheAcceptTarget() {
+    let (model, _) = makeModel(heardRanking: rankingCovered(preselecting: true))
+
+    #expect(model.acceptTarget == nil)
+    #expect(model.ranking.preselectedID != nil, "the ranking itself is untouched")
+  }
+
+  /// **A confirmation is NEVER searchable, and getting this backwards is the defect that nearly sent
+  /// it to the dictation overlay instead.** It is shown after Return, when the user has gone back to
+  /// their sentence; a focused field would eat the first letters of their next word.
+  @Test("A post-Return confirmation offers no field to type into")
+  func aConfirmationIsNotSearchable() throws {
+    let (model, _) = makeModel(heardRanking: ranking(["Codex"], preselecting: 0))
+
+    model.noteWriteFailure("stale")
+    model.showNotice(.saved, spelling: "codecs", word: "Codex")
+
+    let notice = try #require(model.notice)
+    #expect(notice.searchable == false)
+    #expect(notice.kind == .saved)
+    #expect(model.writeFailure == nil, "the failure it replaces must not render underneath it")
+  }
+
+  /// A refusal has nothing to rank, so there is no covered row to shortcut on. Guards the branch
+  /// order in the initialiser: reading the ranking before the refusal is handled would crash or,
+  /// worse, notice on an empty string.
+  @Test("A refusal never opens onto a notice")
+  func aRefusalNeverNotices() {
+    let (model, _) = makeModel(heard: "", refusal: .nothingSelected, heardRanking: .empty)
+
+    #expect(model.stage == .picking)
+    #expect(model.notice == nil)
+  }
 }

--- a/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelModelTests.swift
+++ b/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelModelTests.swift
@@ -262,7 +262,7 @@ struct QuickAddPanelModelTests {
       heard: heard, refusal: refusal, heardRanking: heardRanking, searchRanking: heardRanking)
     if !query.isEmpty { model.updateQuery(query) }
     let view = QuickAddPanelView(
-      model: model, onAccept: { _ in }, onCreateNew: {}, onCancel: {})
+      model: model, onAccept: { _ in }, onCreateNew: {}, onCreate: { _ in }, onCancel: {})
     return view.headerState
   }
 
@@ -350,5 +350,173 @@ struct QuickAddPanelModelTests {
     model.updateQuery("  cod  ")
 
     #expect(model.isSearching)
+  }
+
+  // MARK: - Composing a new word (#2391 §2)
+
+  /// The whole reason this stage exists. `Create a new word` presented a SwiftUI `.sheet`, and a
+  /// sheet cannot present on a window that refuses main status — silently, with no exception and no
+  /// log line. The button ran its action, set its binding, and changed nothing on screen. For a user
+  /// with no readable selection it was the panel's ONLY control, so the panel had no working action
+  /// at all.
+  @Test("Create moves the panel to its compose stage")
+  func createBeginsComposing() {
+    let (model, _) = makeModel(heardRanking: ranking(["Codex"], preselecting: 0))
+
+    model.beginComposing()
+
+    #expect(model.stage == .composing)
+  }
+
+  /// Someone who typed a word, found nothing, and reached for Create has already said what they
+  /// mean. Making them type it again is the panel forgetting.
+  @Test("A search in progress seeds the draft, trimmed")
+  func composingSeedsFromTheSearch() {
+    let (model, _) = makeModel(
+      heardRanking: ranking(["Codex"], preselecting: 0),
+      searchRanking: ranking(["Codex"], preselecting: nil))
+
+    model.updateQuery("  Qwen  ")
+    model.beginComposing()
+
+    #expect(model.draftCanonical == "Qwen")
+  }
+
+  /// **The misspelling is precisely what the new word must NOT be called**, so an empty field is the
+  /// correct start. Seeding it with `heard` would put `clawwed` in the library as a canonical.
+  @Test("With nothing typed the draft starts empty, never at the misspelling")
+  func composingDoesNotSeedTheMisspelling() {
+    let (model, _) = makeModel(
+      heard: "clawwed", heardRanking: ranking(["Claude"], preselecting: 0))
+
+    model.beginComposing()
+
+    #expect(model.draftCanonical.isEmpty)
+  }
+
+  /// Whitespace is not a search. The same trimming rule `isSearching` owns, reaching the one place
+  /// where getting it wrong writes a word rather than merely re-ranking a list.
+  @Test("A whitespace-only field seeds nothing")
+  func whitespaceQueryDoesNotSeedTheDraft() {
+    let (model, _) = makeModel(heardRanking: ranking(["Codex"], preselecting: 0))
+
+    model.updateQuery("   ")
+    model.beginComposing()
+
+    #expect(model.draftCanonical.isEmpty)
+  }
+
+  /// Escape has two meanings and the window cannot tell them apart, so the model answers.
+  @Test("Escape belongs to the content while composing and to the window otherwise")
+  func escapeIsConsumedOnlyWhileComposing() {
+    let (model, _) = makeModel(heardRanking: ranking(["Codex"], preselecting: 0))
+
+    #expect(model.consumeCancel() == false, "picking: the panel closes")
+
+    model.beginComposing()
+    #expect(model.consumeCancel() == true, "composing: back to the list")
+    #expect(model.stage == .picking)
+  }
+
+  /// Backing out must not leave the next visit to Compose holding the last attempt's text or the
+  /// last attempt's error.
+  @Test("Backing out of composing clears the draft and the refusal")
+  func cancellingComposingClearsState() {
+    let (model, _) = makeModel(heardRanking: ranking(["Codex"], preselecting: 0))
+
+    model.beginComposing()
+    model.updateDraft("Qwen")
+    model.noteWriteFailure("nope")
+    model.cancelComposing()
+
+    #expect(model.stage == .picking)
+    #expect(model.draftCanonical.isEmpty)
+    #expect(model.writeFailure == nil)
+  }
+
+  /// **The list is still ranked and still carries a preselected row while composing — only the view
+  /// has stopped showing it.** A legend derived from `acceptTarget` would advertise `add spelling`
+  /// over a compose field, and a stray Return would write to a row the user can no longer see.
+  @Test("Return cannot accept a hidden row while composing")
+  func composingWithdrawsTheAcceptTarget() {
+    let (model, _) = makeModel(heardRanking: ranking(["Codex"], preselecting: 0))
+    #expect(model.acceptTarget != nil)
+
+    model.beginComposing()
+
+    #expect(model.acceptTarget == nil)
+    #expect(model.ranking.preselectedID != nil, "the ranking itself is untouched")
+  }
+
+  @Test("An empty or whitespace draft creates nothing")
+  func anEmptyDraftIsNotAWord() {
+    let (model, _) = makeModel(heardRanking: ranking(["Codex"], preselecting: 0))
+
+    model.beginComposing()
+    #expect(model.draftWord == nil)
+
+    model.updateDraft("   ")
+    #expect(model.draftWord == nil)
+  }
+
+  /// The whole point of authoring the word from HERE rather than from Settings: it arrives carrying
+  /// the spelling the user selected.
+  @Test("The authored word carries the heard spelling as its alias")
+  func theDraftWordCarriesTheHeardSpelling() throws {
+    let (model, _) = makeModel(
+      heard: "clawwed", heardRanking: ranking(["Claude"], preselecting: 0))
+
+    model.beginComposing()
+    model.updateDraft("  Claude  ")
+    let word = try #require(model.draftWord)
+
+    #expect(word.canonical == "Claude")
+    // "Claude" heard as "clawwed" — the alias is the mishearing, not the word.
+    #expect(word.aliases == ["clawwed"])
+  }
+
+  /// A spelling identical to the canonical is not a mishearing, it is the word. Storing it as an
+  /// alias of itself is a duplicate the library would carry forever, and nothing else would refuse
+  /// it: `CustomWordsManager.add` has no rule against a word aliasing its own name.
+  @Test("A spelling equal to the word is not stored as its own alias")
+  func theDraftWordDropsASelfAlias() throws {
+    let (model, _) = makeModel(
+      heard: "Codex", heardRanking: ranking(["Codex"], preselecting: 0))
+
+    model.beginComposing()
+    model.updateDraft("codex")
+    let word = try #require(model.draftWord)
+
+    #expect(word.aliases.isEmpty)
+  }
+
+  /// **The state with no readable selection, which is the one Create exists for.** A blank alias
+  /// here is what made `QuickAddWiring.newWordOutcome`'s postcondition vacuous — `kept` was empty,
+  /// `missing.isEmpty` was trivially true, and a duplicate canonical took the success path having
+  /// written nothing.
+  @Test("With no selection the word is created carrying no spellings, not one blank one")
+  func theDraftWordCarriesNoBlankAlias() throws {
+    let (model, _) = makeModel(
+      heard: "", refusal: .nothingSelected, heardRanking: .empty)
+
+    model.beginComposing()
+    model.updateDraft("Qwen")
+    let word = try #require(model.draftWord)
+
+    #expect(word.canonical == "Qwen")
+    #expect(word.aliases.isEmpty)
+  }
+
+  /// A second `beginComposing` must not wipe what the user has typed. Reachable by clicking the
+  /// create row again, which is still on screen in some layouts, and by any future caller.
+  @Test("Composing is idempotent and does not discard the draft")
+  func beginComposingTwiceKeepsTheDraft() {
+    let (model, _) = makeModel(heardRanking: ranking(["Codex"], preselecting: 0))
+
+    model.beginComposing()
+    model.updateDraft("Qwen")
+    model.beginComposing()
+
+    #expect(model.draftCanonical == "Qwen")
   }
 }

--- a/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelModelTests.swift
+++ b/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelModelTests.swift
@@ -177,6 +177,20 @@ struct QuickAddPanelModelTests {
     #expect(model.writeFailure == nil)
   }
 
+  /// **The field is HIDDEN under a refusal, not merely inert, and the copy guard depends on it.**
+  /// `noRefusalPointsAtTheSearchField` forbids the refusal messages from naming a control the user
+  /// cannot use; leaving a disabled field on screen is that control, still there. The test below
+  /// covers the model half — the query text survives — and this covers whether it is shown at all.
+  @Test("A refusal takes the search field off screen")
+  func aRefusalHidesTheSearchField() {
+    let (refused, _) = makeModel(
+      heard: "", refusal: .accessibilityNotTrusted, heardRanking: .empty)
+    #expect(!refused.showsSearchField)
+
+    let (ordinary, _) = makeModel(heardRanking: ranking(["Codex"], preselecting: 0))
+    #expect(ordinary.showsSearchField, "the ordinary panel is the two-way half of this")
+  }
+
   @Test("A refusal leaves the search field inert rather than ranking an empty selection")
   func searchIsInertUnderARefusal() {
     let (model, calls) = makeModel(


### PR DESCRIPTION
Fixes the three Quick Add defects the founder found on his own first pass through the shipped feature. Part of #2391; §2 is one commit, §1 and §3 are the other, because they are one shape and building them apart would produce two notice treatments for one idea.

## §2 — `Create a new word` was DEAD, not merely oversized

The issue described it as opening a Settings editor bigger than the panel. Measured on the shipped build it opens **nothing at all**:

```
AXPress on "Create a new word"  ->  0 (success)
pendingNewWord                  ->  set
window count before / after     ->  3 / 3
```

SwiftUI attaches a `.sheet` through `NSWindow.beginSheet`, which AppKit refuses on a window with `canBecomeMain = false` — silently, no exception, no log line. `KeyCapablePanel` sets `canBecomeKey = true` because Return is the whole feature, and `canBecomeMain = false` because an accessory panel must not reorder the windows the user was working in behind it. **Both flags are individually correct and the combination forbids sheets**, so flipping one trades a dead button for the panel shoving the user's windows around every time it opens.

Promoted to `swiftui-view-patterns.md` FACT: a-sheet-cannot-present-on-a-window-that-refuses-main-status.

Severity: for a user with no readable selection, Create is the ONLY route — so for them the panel had no working action at all.

The fix removes the mechanism rather than repairing it, which is independently what this issue had already decided. Composing is a stage of the panel: one field, seeded from the search box when the user was searching and empty otherwise — never from the misspelling, which is precisely what the new word must not be called.

## §1 — a successful save confirmed nothing

`accept` called `dismiss()` and that was the entire behaviour, while a REFUSED write kept the panel open and stated the reason. The user learned more from failing than from succeeding, on a feature whose whole promise is that succeeding is invisible.

The panel now fades into `"clawwed" added to Claude` for two seconds.

**Where it lives was the open fork, and the recorded decision was the overlay pill.** The reason was the keyboard: this panel is key-capable, so a panel that lingers owns the keyboard while the user is already back in their sentence, and a confirmation that eats the first letter of their next word is worse than no confirmation.

That objection is answered rather than accepted. `releaseFocus()` hands the keyboard back at the moment of Return — `NSApp.deactivate()`, with the panel staying visible because `hidesOnDeactivate` is false and it sits at `.floating`, both set for their own reasons long before this needed them. **The founder asked for the panel, and the panel is now safe.**

## §3 — nothing to add opened a full picker offering nothing

The header said `nothing to add` and the rest of the panel contradicted it: a highlighted row whose only action is a no-op, four unrelated words offered as if they were choices, a legend advertising `add spelling` in a state where nothing can be added, and a dismissal the user had to perform by hand. Nine lines where one will do.

The escape hatch survives: the search field stays, and **typing or an arrow** returns the full list. Both, because the field is on screen and focused — a panel visibly offering a key that does nothing is the same defect one keypress over.

## The one property that keeps the two notices apart

They differ in exactly one flag, so it is one code path rather than two:

| | keyboard | typing | resolves as |
|---|---|---|---|
| confirmation (§1) | handed back | n/a | already resolved by `accept` |
| covered word (§3) | kept | returns the full list | `already_saved` on fade |

Getting it backwards either way is a real defect — one swallows keystrokes, the other removes the recovery path — so `searchable` is set by `showNotice` rather than taken as an argument.

## Two things this change makes safe that a diff review would not surface

Both found by self-review, both about a path somewhere else:

1. **A fading confirmation is not a live panel.** The visibility guard would have RAISED it and refused the next capture — from the user's side, the shortcut not firing, on the second word they add in a row, which is the ordinary way to use this. `mayBeginCapture` is split out and tested for the same reason `newWordOutcome` was: the version inline could not be tested, and the state it gets wrong is one no test could reach.
2. **The close control stays on screen under the confirmation**, and the invocation has already resolved. Escape reaches the window and checks `activeModel`; the legend's `esc` BUTTON called cancel directly with the model it captured at present time, emitting a second terminal event for one open — a `double_resolution` landing in telemetry rather than on screen. Escape now asks the model through one door, and cancel resolves only a live invocation.

## Structural notes

- `accept` returns three cases instead of an optional message, because the caller now has a claim to make. It cannot work this out for itself: the row's `alreadyHasHeardSpelling` is the ranking's snapshot and the panel is persistent, so composing the confirmation from it would be the same stale-read defect this path has produced three times — arriving through the sentence written to reassure the user.
- A `Notice` carries FACTS and never a sentence. `QuickAddPanelCopy.notice` is the one place it becomes English, exhaustive over a closed `Kind`.
- The panel can now change shape, so the window follows it: `NSHostingController` with `.preferredContentSize`, the measure-or-refuse guard intact, and a re-centre on resize because an `NSWindow` resizes about its bottom-left and would otherwise appear to slide down the screen.

## Review — nine rounds, and what each class cost before it closed

Every round returned a real, reproducible defect; none was a false positive. The honest summary is
not that findings converged — they went 2, 2, 1, 2, 1 — but that **three distinct classes were closed
one after another**, and two of the rounds found damage from the previous round's own fix.

The four-round gate was answered `accept with rationale`. It was answered partly on a read that
findings were shrinking, and that read was too optimistic; the correction is recorded here rather
than left standing.

### Class 1 — the panel's lifetime is no longer the invocation's

Before this change, "a panel is on screen" and "an invocation is live" were the same fact, and every
consumer of panel state assumed so silently. Adding a confirmation that outlives the work broke it.

Members: a fading confirmation refusing the next capture (the shortcut appearing not to fire on the
second word in a row); the close button resolving a second time for one open; a failed re-present
leaving a stale confirmation up indefinitely. Closed by `mayBeginCapture`, an identity guard on
cancel, and tearing the panel down on a refused present.

### Class 2 — an outcome that keeps the panel open must name a reachable action

The panel opened without a readable selection has an empty ranking and a disabled search field, so it
can perform none. A duplicate word authored there was refused with copy telling the user to choose it
from a list that cannot exist.

**A filed mutation guard caught the first fix.** Folding that cell into `.alreadyComplete` is exactly
what #2403 row 2 mutates, and the row is right: with no spelling there is nothing for
`alreadyComplete`'s postcondition to confirm, which is why a previous round split it out. Renaming
the cell is a claim about the PANEL; merging it is a claim about the POSTCONDITION. It became a
fourth case, `.alreadyPresent`, and the guard still binds.

Closed, and the closure is a test rather than a paragraph: `.refused` is the only panel-keeping
outcome, it needs a missing spelling, and with no heard word `draftWord` attaches no alias — a chain
three files long and invisible from either end.

### Class 3 — through which CHANNEL the user learns

Not a member of either class above, which is why enumerating them did not reach it. Two values:
sight and VoiceOver. `.accessibilityLabel` labels an element when VISITED; every message this panel
shows is a dynamic status change, and two of the three vanish on a timer while focus is deliberately
elsewhere.

Enumerating it found a member the review did not name — **the write-failure banner**, which is the
one message the user has to act on. One derivation returns the string the view renders, so the two
channels cannot disagree.

### The focus hand-back: SEVEN rounds, and the founder deleted the requirement

**This section used to argue for a design. There is no design — the mechanism is gone, 245 lines
removed and 20 added, and that is the most useful thing on this branch.**

Seven review rounds landed on one question: when the panel closes, where does the keyboard go? Each
answer was better than the last and each was refuted:

| Round | The answer | Why the next round killed it |
|---|---|---|
| r3 | record who held focus in `present` | a raise takes focus too |
| r5 | record in `present` and `raise` | a mouse click takes focus too |
| r6 | record in both, guard the panel | the set of ways a window becomes key is AppKit's, not ours |
| r7 | derive from the live window list | having a window is not the same fact as having come from it |
| r8 | capture at the one uncontaminated instant | `raise` falsifies it — the panel can sit visible and unfocused |
| r9 | ask the window whether it holds key | correct, and evaluated only at the two places we call it |
| r10 | — | a mouse click makes the panel key through NEITHER call site |

r9 published its own falsification condition in the code and in this body — *a counterexample must
change the panel's key status WITHOUT passing through `takeFocus` or `dismiss`* — and r10 met it
exactly. The predicate was right; there is no place to evaluate it that AppKit guarantees to visit.

**An eighth answer was designed and is not being written.** A continuously-maintained tracker,
filtering out our own activation and the panel itself, defeats every counterexample above including
r8's. It is not in this branch, because the founder retired the requirement rather than the bug:

> "they select a word, they trigger the shortcut, they interface with our pop-up, and then they will
> just naturally go click at the end of the sentence to continue to write ... so we don't need to
> control where the mouse is. That's not of any value add."

**The transferable lesson is the opposite of what seven rounds were teaching.** Every round improved
the ANSWER. None asked whether the QUESTION was worth answering. The reviewer was right seven times
and the exit was upstream of all of it.

**What survives:** the panel still takes the keyboard when it opens — Return is the whole feature.
Only giving it back is gone.

**What the user sees:** after the panel closes, EnviousWispr stays active with no window until they
click. Identical to what ships today — the `NSApp.deactivate()` this branch briefly replaced never
transferred activation either, measured on this machine. Status quo, now deliberate.

**Known edge, recorded rather than found later:** during the two-second confirmation the panel holds
the keyboard with a field on screen, so a user who keeps DICTATING instead of clicking could have
that text land in the search field. Narrow, and the founder's description has them clicking.

**Six tests deleted with it.** They asserted decisions about where to hand the keyboard back; there
is nowhere to hand it back to. #2422's recipe lost its four focus rows for the same reason — a dead
row blocks a whole battery, not one guard.

**What WOULD have been worth doing at that moment is filed as #2424:** swap the misspelled word in
the document for the corrected one. A different feature, and the first thing Quick Add would do that
writes into the user's document rather than our own words file.

### One more recurring shape, worth naming because it appeared three times

A user-facing sentence composed from a NEIGHBOURING VALUE rather than from what the write path
reports: the accept confirmation reading the ranking's snapshot, the already-there notice re-testing
the spelling at the call site, and the created notice reading the selection instead of the alias
actually attached — which said `"Claude" added to Claude` about an add that correctly did not happen.

### A guard that policed its own copy, and the view that contradicted it

`noRefusalPointsAtTheSearchField` forbids the refusal messages from naming a control the user cannot
use, and states in its own comment that the field is hidden in exactly that state. The view showed it
disabled. **A disabled field IS the control those messages were rewritten to stop pointing at**,
still on screen. The decision moved onto the model, where the three facts it needs already live, so
it is assertable rather than a private view property nothing can reach.

### Known limits, stated rather than hidden

The window and focus members have no unit test, and the reason is structural: `QuickAddPanelHost`
owns a real `NSPanel`, so "the keyboard went back", "the panel resized" and "an unmeasurable panel is
torn down" are assertions about AppKit. All are Live UAT items. The pure decisions underneath them —
`focusRelease`, `shouldCaptureOrigin`, `shouldReleaseOnDismiss`, `mayBeginCapture`, `newWordOutcome`,
`announcement` — are extracted and tested.

**Stated plainly because the new tests could be read as covering more than they do: they assert the
DECISIONS, not the WIRING.** A change that kept both predicates correct and stopped calling them from
`takeFocus` or `dismiss` would leave every one of them green. What binds the wiring is that both
takers route through one owner and every dismissal route through another — structural, not asserted —
plus the Live UAT pass. That is the same gap the previous five rounds lived in, and naming it is the
honest alternative to implying a test closed it.

### Recipe sweep

A filed mutation recipe is data about this code that lives OUTSIDE the repo, so no grep reaches it.
Validated all eight Quick Add batteries against this branch AND against `origin/main`; the two-way
control separates this change's damage from pre-existing decay. Five rows killed here, three already
dead, all repaired. Three issues had also drifted to multiple fenced recipe blocks, which both the
runner and the validator refuse, so they could not run at all. All eight now report fully runnable,
82 rows, read back off GitHub rather than off the files that generated them.

## What Live UAT found that nine review rounds could not

Two defects, both user-facing, both invisible to the whole suite by construction. Worth stating
plainly because the review record above is long and could otherwise read as thoroughness that was
already sufficient.

**1. The compose field never took the keyboard.** Pressing `Create a new word` left
`AXFocusedUIElement` reporting the WINDOW, so every keystroke was discarded until the user clicked
the field. Entering that stage removes the search field in the SAME update, and tearing down the
focused field resolves focus to nothing afterwards — the request was granted and then overtaken. The
doc comment above the failing line already described this exact outcome ("the user reaches Create and
types into nothing"), so the intent was right, the mechanism did not deliver it, and the comment told
every later reader the question was settled.

**2. `NSApp.deactivate()` does not hand activation to anyone.** From a clean state: Finder frontmost,
panel opens, Escape — and four seconds later we were still frontmost with ZERO windows, keystrokes
going nowhere. **This was fixed and then the whole mechanism was deleted**, so the finding survives
only as the reason the removal is not a regression: what ships today already behaves this way, and
nobody had measured it. Recorded because a future session WILL propose handing the keyboard back,
and this is the fact that decides whether their design can work.

**Two instruments were unfailable before they worked, and both are recorded in the harness.** The
first asserted on `frontmost()`, which cannot separate the arms while the release deactivates — its
failure text printed the observed value and the defect value as the same string. The second asserted
on `AXFocusedWindow`, which an INACTIVE app still reports, so it read the same in both arms too.
`frontmost()` is valid now, and only because the release finally names a destination.

## Validation

- **Debug 6935 / Release 6283, both PASS**, each reconciled against its own per-bundle lines
  (6729 + 206 and 6077 + 206), and all three new cases verified PRESENT in the run by name.
- **The first attempt at that lane was a false green and is worth one line, because it is this
  repo's documented trap and the guard against it fired correctly.** A foreground `cd` earlier in
  the session left the shell in the ROOT checkout, so `./scripts/xcode-test.sh` tested `main` and
  reported `PASS` with plausible numbers — true about main, evidence of nothing about this branch.
  The tell was the count moving the WRONG WAY by a small amount (6935 → 6891 in both configs) and
  the confirmation was free: `grep` for the three new test names returned **0**. The guard printed
  `pwd` and the branch as designed; its output went to the task file while I read the lane file.
  Re-run from an absolute worktree path, everything to one place.
- **Live UAT on the built dev app: 12/12 on the main harness**, and it found TWO defects no test
  could reach — see the section above. Every fix two-way controlled across a rebuild.
- **Focus harness: 2/2, with two rows SKIPPED and the reasons printed rather than banked as passes.**
  The `.ourWindow` origin cannot be staged through the Service door — every invocation logged
  `released to the origin app`, never `to our own window`, including runs where Settings was verified
  key three different ways. Reaching it needs the hotkey door, which is Carbon-registered and rejects
  synthetic events, so it needs a person. A red row there would have indicted correct code.
- **Known unverified, stated rather than implied:** opening the panel while one of OUR windows holds
  the keyboard. Its decision is unit-tested; its wiring is not live-verified.
- Mutation battery filed rather than run — it is the founder's day. Recipe in #2422, six rows, every
  predicate mutated in BOTH directions.

Part of #2391
